### PR TITLE
Domains: surface an error when a bundle add fails instead of silently hiding the card (DOMAINS-2221)

### DIFF
--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -115,10 +115,12 @@ export const ResultsPage = () => {
 
 	// Turn an add failure into a notice on the card rather than silently doing
 	// nothing. The "unavailable" case (the backend stripped an incomplete bundle
-	// group, so fewer members came back than were sent) carries no server message,
-	// so give it its own copy; every other error surfaces the cart's own message
-	// (a CartActionError, already user-facing) with a generic fallback. Clicking
-	// "Get bundle" again re-fires the mutation, which clears the error state.
+	// group, so fewer members came back than were sent) only carries a generic
+	// internal message ("The domain bundle could not be added to the cart."), so
+	// override it with friendlier, more actionable copy; every other error
+	// surfaces the cart's own message (a CartActionError, already user-facing)
+	// with a generic fallback. Clicking "Get bundle" again re-fires the mutation,
+	// which clears the error state.
 	const bundleErrorMessage = ( () => {
 		if ( ! isCurrentMutation || ! addBundleError ) {
 			return undefined;

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -1,4 +1,4 @@
-import { useIsMutating, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useIsMutating, useMutation } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { chevronDown, chevronUp, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
@@ -37,11 +37,6 @@ type AddBundleToCartResult = {
 	wasAdded: boolean;
 };
 
-type UnavailableBundle = {
-	groupId: string;
-	query: string;
-};
-
 const StickyCompactBanner = () => {
 	const { __ } = useI18n();
 	const [ isExpanded, setIsExpanded ] = useState( false );
@@ -74,9 +69,7 @@ const StickyCompactBanner = () => {
 
 export const ResultsPage = () => {
 	const { __ } = useI18n();
-	const { slots, config, events, cart, query, queries } = useDomainSearch();
-	const queryClient = useQueryClient();
-	const [ unavailableBundle, setUnavailableBundle ] = useState< UnavailableBundle >();
+	const { slots, config, events, cart, query } = useDomainSearch();
 
 	const { mutationId, isCurrentMutation } = useIsCurrentMutation();
 
@@ -108,16 +101,6 @@ export const ResultsPage = () => {
 				events.onBundleAddToCart( bundle );
 			}
 		},
-		onError: async ( error, { bundle, query: failedQuery } ) => {
-			if ( ! isBundleUnavailableError( error ) ) {
-				return;
-			}
-
-			setUnavailableBundle( { groupId: bundle.bundle_group_id, query: failedQuery } );
-			await queryClient.invalidateQueries( {
-				queryKey: queries.bundleSuggestion( failedQuery ).queryKey,
-			} );
-		},
 		networkMode: 'always',
 		retry: false,
 	} );
@@ -128,17 +111,30 @@ export const ResultsPage = () => {
 	// query produces a new bundle suggestion, so drop the stale error.
 	useEffect( () => {
 		resetAddBundle();
-		setUnavailableBundle( undefined );
 	}, [ query, resetAddBundle ] );
 
-	// The cart rejects with the server's first cart message (a CartActionError),
-	// which is already user-facing copy. Fall back when it's missing. Clicking
+	// Turn an add failure into a notice on the card rather than silently doing
+	// nothing. The "unavailable" case (the backend stripped an incomplete bundle
+	// group, so fewer members came back than were sent) carries no server message,
+	// so give it its own copy; every other error surfaces the cart's own message
+	// (a CartActionError, already user-facing) with a generic fallback. Clicking
 	// "Get bundle" again re-fires the mutation, which clears the error state.
-	const bundleErrorMessage =
-		isCurrentMutation && addBundleError && ! isBundleUnavailableError( addBundleError )
-			? addBundleError.message ||
-			  __( 'Sorry, we couldn’t add the bundle to your cart. Please try again.' )
-			: undefined;
+	const bundleErrorMessage = ( () => {
+		if ( ! isCurrentMutation || ! addBundleError ) {
+			return undefined;
+		}
+
+		if ( isBundleUnavailableError( addBundleError ) ) {
+			return __(
+				'This bundle is no longer available — one or more of the domains may have just been registered.'
+			);
+		}
+
+		return (
+			addBundleError.message ||
+			__( 'Sorry, we couldn’t add the bundle to your cart. Please try again.' )
+		);
+	} )();
 
 	const {
 		isLoading: isLoadingSuggestions,
@@ -149,13 +145,10 @@ export const ResultsPage = () => {
 	// The top BundleCard is the FQDN path only; a bare-term search shows inline
 	// bundle rows beneath trigger suggestions instead (see useInlineBundles).
 	const isFqdn = isFqdnQuery( query );
-	const visibleBundleSuggestion =
-		! isFqdn ||
-		( unavailableBundle &&
-			bundleSuggestion?.bundle_group_id === unavailableBundle.groupId &&
-			query === unavailableBundle.query )
-			? undefined
-			: bundleSuggestion;
+	// A failed add keeps the card mounted (with an error notice) rather than
+	// hiding it, so the user sees the failure instead of the offer silently
+	// vanishing. See bundleErrorMessage above.
+	const visibleBundleSuggestion = isFqdn ? bundleSuggestion : undefined;
 	const numberOfInitialVisibleSuggestions =
 		config.numberOfDomainsResultsPerPage - featuredSuggestions.length;
 

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -1024,7 +1024,7 @@ describe( 'ResultsPage', () => {
 			} );
 		} );
 
-		it( 'clears the bundle card and refetches the bundle suggestion when the bundle is permanently unavailable', async () => {
+		it( 'keeps the bundle card and shows a notice when the bundle is no longer available', async () => {
 			const user = userEvent.setup();
 			const onAddBundle = jest.fn().mockRejectedValue(
 				Object.assign( new Error( 'The domain bundle could not be added to the cart.' ), {
@@ -1040,12 +1040,8 @@ describe( 'ResultsPage', () => {
 				params: { query: 'test-bundle-permanent.com' },
 				bundleSuggestion: buildBundleSuggestion( 'test-bundle-permanent' ),
 			} );
-			const refetchRequest = mockGetBundleSuggestionQuery( {
-				params: { query: 'test-bundle-permanent.com' },
-				bundleSuggestion: null,
-			} );
 
-			render(
+			const { container } = render(
 				<TestDomainSearch
 					cart={ buildCart( { onAddBundle } ) }
 					config={ { showBundleSuggestions: true } }
@@ -1059,60 +1055,18 @@ describe( 'ResultsPage', () => {
 
 			await user.click( screen.getByRole( 'button', { name: 'Get bundle' } ) );
 
+			// The card stays put and surfaces a tailored notice rather than silently
+			// disappearing, so the user sees the add failed. See DOMAINS-2221.
 			await waitFor( () => {
-				expect( refetchRequest.isDone() ).toBe( true );
+				expect(
+					getByText(
+						container,
+						'This bundle is no longer available — one or more of the domains may have just been registered.'
+					)
+				).toBeInTheDocument();
 			} );
-
-			await waitFor( () => {
-				expect( screen.queryByRole( 'button', { name: 'Get bundle' } ) ).not.toBeInTheDocument();
-			} );
-			expect( queryBundleMember( 'test-bundle-permanent.net' ) ).not.toBeInTheDocument();
-		} );
-
-		it( 'keeps the stale bundle hidden when the permanent-failure refetch returns the same bundle group', async () => {
-			const user = userEvent.setup();
-			const unavailableBundle = buildBundleSuggestion( 'test-bundle-same-group' );
-			const onAddBundle = jest.fn().mockRejectedValue(
-				Object.assign( new Error( 'The domain bundle could not be added to the cart.' ), {
-					code: 'domain_bundle_unavailable',
-				} )
-			);
-
-			mockGetSuggestionsQuery( {
-				params: { query: 'test-bundle-same-group.com' },
-				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-same-group.com' } ) ],
-			} );
-			mockGetBundleSuggestionQuery( {
-				params: { query: 'test-bundle-same-group.com' },
-				bundleSuggestion: unavailableBundle,
-			} );
-			const refetchRequest = mockGetBundleSuggestionQuery( {
-				params: { query: 'test-bundle-same-group.com' },
-				bundleSuggestion: unavailableBundle,
-			} );
-
-			render(
-				<TestDomainSearch
-					cart={ buildCart( { onAddBundle } ) }
-					config={ { showBundleSuggestions: true } }
-					query="test-bundle-same-group.com"
-				>
-					<ResultsPage />
-				</TestDomainSearch>
-			);
-
-			expect( await findBundleMember( 'test-bundle-same-group.net' ) ).toBeInTheDocument();
-
-			await user.click( screen.getByRole( 'button', { name: 'Get bundle' } ) );
-
-			await waitFor( () => {
-				expect( refetchRequest.isDone() ).toBe( true );
-			} );
-
-			await waitFor( () => {
-				expect( screen.queryByRole( 'button', { name: 'Get bundle' } ) ).not.toBeInTheDocument();
-			} );
-			expect( queryBundleMember( 'test-bundle-same-group.net' ) ).not.toBeInTheDocument();
+			expect( queryBundleMember( 'test-bundle-permanent.net' ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'button', { name: 'Get bundle' } ) ).toBeInTheDocument();
 		} );
 
 		it( 'does not hide or refetch the next query when an old bundle add fails permanently', async () => {
@@ -1188,7 +1142,11 @@ describe( 'ResultsPage', () => {
 
 			expect( freshRefetchRequest.isDone() ).toBe( false );
 			expect( getBundleMember( 'test-bundle-late-fresh.net' ) ).toBeInTheDocument();
-			expect( screen.getByRole( 'button', { name: 'Get bundle' } ) ).toBeEnabled();
+			// Once the stale mutation settles, no add is in flight, so the fresh
+			// card's CTA is enabled again.
+			await waitFor( () => {
+				expect( screen.getByRole( 'button', { name: 'Get bundle' } ) ).toBeEnabled();
+			} );
 		} );
 
 		it( 'clears the error when retrying succeeds', async () => {


### PR DESCRIPTION
Related to #DOMAINS-2221

Standalone trunk bugfix — not stacked on the inline-bundles feature (#112346). The silent-hide behavior is already live on trunk.

## Problem

When `onAddBundle` rejects with `domain_bundle_unavailable` — the backend cart validator stripped an incomplete bundle group, so fewer members came back than were sent — the results page hid the bundle card and showed no message, then refetched the suggestion. From the user's seat, clicking "Get bundle" did nothing: the offer just vanished. This is the CfT-reported symptom.

## Fix

Treat the unavailable case like every other cart error: keep the card mounted and render a tailored notice in its existing error slot — "This bundle is no longer available — one or more of the domains may have just been registered." Clicking "Get bundle" again re-fires the mutation and clears the error, matching the generic-error path.

<img width="2368" height="1534" alt="CleanShot 2026-07-14 at 13 41 58@2x" src="https://github.com/user-attachments/assets/d579a742-64c2-4ced-8da8-3a8daa0904cc" />


## Testing

To simulate the error condition, modify `wp-content/admin-plugins/wpcom-billing/default-shopping-cart-validator.php` on your sandbox:

- In the `enforce_bundle_integrity_rules()` function, change:
```php
if ( null !== $expected_size && count( $members ) < $expected_size ) {
```
to
```php
// TEMP DOMAINS-2221 sandbox test — force the strip for any bundle whose
// SLD contains "bundlefail", to exercise the frontend
// domain_bundle_unavailable notice (#112615). REMOVE before deploy.
$force_fail = null !== $expected_size && (bool) array_filter(
	$members,
	static function ( $m ) {
		return false !== strpos( (string) $m->meta, 'bundlefail' );
	}
);

if ( ( null !== $expected_size && count( $members ) < $expected_size ) || $force_fail ) {
```

- Make sure the public-api is sandboxed
- Then use the calypso.live url or run this branch locally
- Go to `/start?flags=domain-bundling`
- Search for `bundlefailtest.com`.
- Click "Get Bundle" once the bundle appears.
- You should see the error message shown above.

<details>
<summary>Unit tests</summary>

```
jest packages/domain-search/src/page/test/results.tsx

Tests: 54 passed, 54 total
```

`tsc --noEmit` and `eslint` on the changed files: clean.

Test changes: rewrote the two tests that asserted the old hide/refetch behavior into one asserting the card stays with the notice; the "same-group refetch" test was removed (that scenario no longer exists — there is no refetch).
</details>
