### PR TITLE
Build: use sass-embedded with the modern-compiler API in sass-loader

### DIFF
--- a/packages/calypso-build/webpack/sass.js
+++ b/packages/calypso-build/webpack/sass.js
@@ -36,7 +36,8 @@ module.exports.loader = ( { includePaths, postCssOptions } ) => ( {
 		{
 			loader: require.resolve( 'sass-loader' ),
 			options: {
-				api: 'modern',
+				api: 'modern-compiler',
+				implementation: require.resolve( 'sass-embedded' ),
 				sassOptions: ( loaderContext ) => ( {
 					loadPaths: includePaths,
 					quietDeps: true,


### PR DESCRIPTION
## Proposed Changes

* Switch `sass-loader` from `api: 'modern'` to `api: 'modern-compiler'` and explicitly set `implementation` to `sass-embedded`.

`sass-loader`'s default implementation resolution prefers the pure-JS `sass` package over `sass-embedded`, even when the latter is installed (it already is in this repo). The pure-JS compiler runs in-process on webpack's main thread. With `api: 'modern-compiler'`, `sass-loader` keeps one persistent native `sass-embedded` compiler process and reuses it for every stylesheet, moving Sass compilation off the main thread and skipping per-compilation startup.

## Why are these changes being made?

* `yarn build-client` is bound by webpack's single main thread, and Sass compilation was part of that critical path. Measured on an M3 Max (16 cores, 48 GB), cold builds (no `.cache/evergreen`), back to back:
  * `trunk`: 40.0s
  * This branch: 34.9s (**12.7% faster**)
  * Reproduced in a second cold A/B pair: 40.2s → 34.2s.
* This also speeds up any build that compiles Sass, including production/Docker builds and webpack-cache misses.

### Output verification

* Dev client build emits 5,148 CSS files; file lists are identical between `trunk` and this branch.
* 7 of 5,148 files differ in content. All differences are the same class: dart-sass ≥ 1.79 preserves fractional color channels from color math, e.g. `background-color: #183ad6` becomes `rgb(23.6923076923, 58.1538461538, 214.3076923077)` (both round to the same displayed color), and `oklch(0.241 0 0)` becomes the equivalent `oklch(24.1% 0 0deg)`. This is version skew between `sass` 1.77.8 and `sass-embedded` 1.89.0, not a behavior of the embedded host. Both forms are valid CSS and render identically; the production CSS minimizer normalizes colors anyway.
* Two consecutive builds of this branch produce byte-identical output (no nondeterminism).

## Testing Instructions

* Run `time yarn build-client` on `trunk` and on this branch (delete `.cache/evergreen` before each run for a fair cold comparison) and compare times.
* Smoke test Calypso for CSS issues — styles should be visually identical.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
