### PR TITLE
Write On: enable calypso/write-on-flow in all environments

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/write-on/README.md
+++ b/client/landing/stepper/declarative-flow/flows/write-on/README.md
@@ -6,9 +6,9 @@ writing in the anonymous Write editor at `/write-editor` and clicked Publish.
 
 ## Feature flag
 
-Gated by `calypso/write-on-flow`. Enabled on `development`, `stage`, and
-`wpcalypso`; disabled on `production` and `horizon`. When the flag is off,
-`initialize()` redirects to `/setup/onboarding` before any steps mount.
+Gated by `calypso/write-on-flow`, enabled in all environments. The flag is
+kept as a kill switch: when it is off, `initialize()` redirects to
+`/setup/onboarding` before any steps mount.
 
 ## Flow
 

--- a/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
@@ -59,9 +59,8 @@ function clearAnonDraft() {
 }
 
 function initialize() {
-	// Phase 1 is staging-only; the companion endpoint is proxy-gated so the
-	// flow has nothing to land users on in production. Redirect to the
-	// standard onboarding flow when the feature flag is off.
+	// The flag is a kill switch for the flow. When it is off, redirect to the
+	// standard onboarding flow so there is nothing to land users on.
 	if ( ! config.isEnabled( 'calypso/write-on-flow' ) ) {
 		recordTracksEvent( 'calypso_write_on_flow_blocked', { reason: 'flag_off' } );
 		window.location.replace( '/setup/onboarding' );

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -20,7 +20,7 @@
 		"calypso/all-domain-management": false,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
-		"calypso/write-on-flow": false,
+		"calypso/write-on-flow": true,
 		"catch-js-errors": true,
 		"checkout/checkout-version": false,
 		"checkout/google-pay": true,

--- a/config/production.json
+++ b/config/production.json
@@ -33,7 +33,7 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
-		"calypso/write-on-flow": false,
+		"calypso/write-on-flow": true,
 		"catch-js-errors": true,
 		"checkout/checkout-version": false,
 		"checkout/google-pay": true,


### PR DESCRIPTION
Part of READ-559

## Proposed Changes

* Set `calypso/write-on-flow` to `true` in `production` and `horizon` (it was already on in `development`, `stage`, and `wpcalypso`), enabling the Write On flow in all environments.
* Refresh the now-stale phase-1 comment in `write-on.ts` and the flag section of the flow README to describe the flag as a kill switch rather than a staging-only gate.

## Why are these changes being made?

The Write On flow funnels a logged-out visitor from the anonymous Write editor through signup, site creation, and draft transfer, landing them in the editor on their new site. The flow's editor destination was previously gated server-side; that gate has since been removed in the editor's plugin, so the destination is live and the flow can be turned on for everyone. The flag is retained as a kill switch.

Sequencing note: the flow (the downstream consumer of the anonymous editor's draft hand-off) is enabled here so it is ready to catch traffic before the upstream anonymous editor entry point is opened. Enabling in the reverse order would strand users' drafts.

## Testing Instructions

Follow the flow README's testing steps:

1. In devtools on a `calypso.localhost:3000` page, seed a draft:
   ```js
   localStorage.setItem('wpcom-write-anon-draft', JSON.stringify({title:'Test',content:'<!-- wp:paragraph --><p>Test</p><!-- /wp:paragraph -->',ts:Date.now()}));
   ```
2. While logged out, visit `/setup/write-on`, complete signup, and verify a new site is created, the draft transfers as a post, and you land in the editor with the content loaded.
3. Verify `localStorage['wpcom-write-anon-draft']` is cleared.
4. Visit `/setup/write-on` with no draft, and again while logged in, and confirm each redirects to `/setup/onboarding`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
