### PR TITLE
Domain Search: drop "Start Free" skip label when the flow requires a paid plan

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/get-skip-suggestion-copy.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/get-skip-suggestion-copy.ts
@@ -1,0 +1,23 @@
+import { isAIBuilderOnboardingFlow } from '@automattic/onboarding';
+
+/**
+ * Copy override for the free-subdomain skip card, per flow.
+ *
+ * The AI Website Builder onboarding flow requires a paid plan, so skipping the
+ * domain doesn't start a free site — drop the "start free" framing. Every other
+ * flow keeps the default copy (returns `undefined`).
+ */
+export const getSkipSuggestionCopy = (
+	flow: string | null,
+	__: ( text: string ) => string
+): { title: string; buttonText: string } | undefined => {
+	if ( ! isAIBuilderOnboardingFlow( flow ) ) {
+		return undefined;
+	}
+
+	return {
+		// translators: %(domain)s is the free WordPress.com subdomain
+		title: __( 'Start with %(domain)s' ),
+		buttonText: __( 'Choose a domain later' ),
+	};
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -53,6 +53,7 @@ import { OnboardingProgress } from '../components/onboarding-progress';
 import { useShowOnboardingProgress } from '../components/onboarding-progress/use-show-onboarding-progress';
 import { useOnboardingHelpExperiment } from '../components/use-onboarding-help-experiment';
 import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
+import { getSkipSuggestionCopy } from './get-skip-suggestion-copy';
 import type { Step as StepType } from '../../types';
 import type { FreeDomainSuggestion } from '@automattic/api-core';
 import type { HelpCenterSelect, OnboardSelect } from '@automattic/data-stores';
@@ -199,13 +200,7 @@ const DomainSearchStep: StepType< {
 				! isDomainAndPlanFlow( flow ),
 			// AI Website Builder onboarding requires a paid plan, so skipping the
 			// domain doesn't start a free site — drop the "start free" framing.
-			skipSuggestionCopy: isAIBuilderOnboardingFlow( flow )
-				? {
-						// translators: %(domain)s is the free WordPress.com subdomain
-						title: __( 'Start with %(domain)s' ),
-						buttonText: __( 'Choose a domain later' ),
-				  }
-				: undefined,
+			skipSuggestionCopy: getSkipSuggestionCopy( flow, __ ),
 			includeDotBlogSubdomain:
 				! isHundredYearPlanFlow( flow ) &&
 				! isHundredYearDomainFlow( flow ) &&

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -197,6 +197,9 @@ const DomainSearchStep: StepType< {
 				! isHundredYearDomainFlow( flow ) &&
 				! isDomainFlow( flow ) &&
 				! isDomainAndPlanFlow( flow ),
+			// AI Website Builder onboarding requires a paid plan, so skipping the
+			// domain doesn't start a free site — drop the "start free" framing.
+			canStartFree: ! isAIBuilderOnboardingFlow( flow ),
 			includeDotBlogSubdomain:
 				! isHundredYearPlanFlow( flow ) &&
 				! isHundredYearDomainFlow( flow ) &&

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -199,7 +199,13 @@ const DomainSearchStep: StepType< {
 				! isDomainAndPlanFlow( flow ),
 			// AI Website Builder onboarding requires a paid plan, so skipping the
 			// domain doesn't start a free site — drop the "start free" framing.
-			canStartFree: ! isAIBuilderOnboardingFlow( flow ),
+			skipSuggestionCopy: isAIBuilderOnboardingFlow( flow )
+				? {
+						// translators: %(domain)s is the free WordPress.com subdomain
+						title: __( 'Start with %(domain)s' ),
+						buttonText: __( 'Choose a domain later' ),
+				  }
+				: undefined,
 			includeDotBlogSubdomain:
 				! isHundredYearPlanFlow( flow ) &&
 				! isHundredYearDomainFlow( flow ) &&
@@ -214,7 +220,7 @@ const DomainSearchStep: StepType< {
 				! isHundredYearPlanFlow( flow ) &&
 				( isHundredYearDomainFlow( flow ) ? !! query : true ),
 		};
-	}, [ flow, isCiab, isWooHostingSolutions, tldQuery, query, allowedTldsProp ] );
+	}, [ __, flow, isCiab, isWooHostingSolutions, tldQuery, query, allowedTldsProp ] );
 
 	const { submit } = navigation;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/test/get-skip-suggestion-copy.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/test/get-skip-suggestion-copy.ts
@@ -1,0 +1,17 @@
+import { getSkipSuggestionCopy } from '../get-skip-suggestion-copy';
+
+const identity = ( text: string ) => text;
+
+describe( 'getSkipSuggestionCopy', () => {
+	it( 'drops the "start free" framing for the AI Website Builder onboarding flow', () => {
+		expect( getSkipSuggestionCopy( 'ai-site-builder-onboarding', identity ) ).toEqual( {
+			title: 'Start with %(domain)s',
+			buttonText: 'Choose a domain later',
+		} );
+	} );
+
+	it( 'keeps the default copy for flows that can start free', () => {
+		expect( getSkipSuggestionCopy( 'onboarding', identity ) ).toBeUndefined();
+		expect( getSkipSuggestionCopy( null, identity ) ).toBeUndefined();
+	} );
+} );

--- a/packages/domain-search/src/components/skip-suggestion/index.tsx
+++ b/packages/domain-search/src/components/skip-suggestion/index.tsx
@@ -8,7 +8,7 @@ import { useDomainSearch } from '../../page/context';
 import { DomainSearchSkipSuggestion } from '../../ui';
 
 const SkipSuggestion = () => {
-	const { queries, query, currentSiteUrl, events, setQuery } = useDomainSearch();
+	const { queries, query, currentSiteUrl, events, setQuery, config } = useDomainSearch();
 
 	const isMutating = useIsMutating();
 
@@ -36,6 +36,7 @@ const SkipSuggestion = () => {
 			<DomainSearchSkipSuggestion
 				freeSuggestion={ suggestion.domain_name }
 				unavailableDomain={ isUnavailable ? query : undefined }
+				canStartFree={ config.canStartFree }
 				onSkip={ () => events.onSkip( suggestion ) }
 				onSuggestionClick={ () => setQuery( suggestion.domain_name ) }
 				disabled={ !! isMutating }

--- a/packages/domain-search/src/components/skip-suggestion/index.tsx
+++ b/packages/domain-search/src/components/skip-suggestion/index.tsx
@@ -36,7 +36,8 @@ const SkipSuggestion = () => {
 			<DomainSearchSkipSuggestion
 				freeSuggestion={ suggestion.domain_name }
 				unavailableDomain={ isUnavailable ? query : undefined }
-				canStartFree={ config.canStartFree }
+				title={ config.skipSuggestionCopy?.title }
+				buttonText={ config.skipSuggestionCopy?.buttonText }
 				onSkip={ () => events.onSkip( suggestion ) }
 				onSuggestionClick={ () => setQuery( suggestion.domain_name ) }
 				disabled={ !! isMutating }

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -69,7 +69,6 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 	config: {
 		vendor: 'variation2_front',
 		skippable: false,
-		canStartFree: true,
 		deemphasizedTlds: [],
 		includeDotBlogSubdomain: false,
 		allowsUsingOwnDomain: false,

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -69,6 +69,7 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 	config: {
 		vendor: 'variation2_front',
 		skippable: false,
+		canStartFree: true,
 		deemphasizedTlds: [],
 		includeDotBlogSubdomain: false,
 		allowsUsingOwnDomain: false,

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -116,11 +116,16 @@ export interface DomainSearchConfig {
 	vendor: DomainSuggestionQueryVendor;
 	skippable: boolean;
 	/**
-	 * Whether skipping the domain leads to a genuinely free site. When false,
-	 * the free-subdomain skip card drops the "free" framing and its CTA becomes
-	 * a neutral "choose later" action (e.g. flows that require a paid plan).
+	 * Optional copy overrides for the free-subdomain skip card. When omitted, the
+	 * card keeps its default "Start free with %(domain)s" title and "Start Free"
+	 * CTA. `title` may include the `%(domain)s` placeholder, interpolated with the
+	 * free subdomain (e.g. flows that require a paid plan can drop the "free"
+	 * framing).
 	 */
-	canStartFree: boolean;
+	skipSuggestionCopy?: {
+		title?: string;
+		buttonText?: string;
+	};
 	deemphasizedTlds: string[];
 	priceRules: PriceRulesConfig;
 	includeDotBlogSubdomain: boolean;

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -115,6 +115,12 @@ export interface DomainSearchEvents {
 export interface DomainSearchConfig {
 	vendor: DomainSuggestionQueryVendor;
 	skippable: boolean;
+	/**
+	 * Whether skipping the domain leads to a genuinely free site. When false,
+	 * the free-subdomain skip card drops the "free" framing and its CTA becomes
+	 * a neutral "choose later" action (e.g. flows that require a paid plan).
+	 */
+	canStartFree: boolean;
 	deemphasizedTlds: string[];
 	priceRules: PriceRulesConfig;
 	includeDotBlogSubdomain: boolean;

--- a/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
+++ b/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
@@ -16,6 +16,7 @@ interface Props {
 	freeSuggestion?: string;
 	unavailableDomain?: string;
 	existingSiteUrl?: string;
+	canStartFree?: boolean;
 	onSkip: () => void;
 	onSuggestionClick?: () => void;
 	disabled?: boolean;
@@ -26,6 +27,7 @@ const DomainSearchSkipSuggestion = ( {
 	freeSuggestion,
 	unavailableDomain,
 	existingSiteUrl,
+	canStartFree = true,
 	onSkip,
 	onSuggestionClick,
 	disabled,
@@ -76,13 +78,19 @@ const DomainSearchSkipSuggestion = ( {
 		);
 		showButton = false;
 	} else if ( freeSuggestion ) {
-		title = sprintf(
-			// translators: %(domain)s is the free WordPress.com subdomain
-			__( 'Start free with %(domain)s' ),
-			{ domain: freeSuggestion }
-		);
+		title = canStartFree
+			? sprintf(
+					// translators: %(domain)s is the free WordPress.com subdomain
+					__( 'Start free with %(domain)s' ),
+					{ domain: freeSuggestion }
+			  )
+			: sprintf(
+					// translators: %(domain)s is the free WordPress.com subdomain
+					__( 'Start with %(domain)s' ),
+					{ domain: freeSuggestion }
+			  );
 		subtitle = __( 'Upgrade to a custom domain name anytime.' );
-		buttonText = __( 'Start Free' );
+		buttonText = canStartFree ? __( 'Start Free' ) : __( 'Choose a domain later' );
 		chevronOnMobile = true;
 	}
 

--- a/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
+++ b/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
@@ -85,12 +85,13 @@ const DomainSearchSkipSuggestion = ( {
 		);
 		showButton = false;
 	} else if ( freeSuggestion ) {
-		title = sprintf(
-			titleOverride ??
-				// translators: %(domain)s is the free WordPress.com subdomain
-				__( 'Start free with %(domain)s' ),
-			{ domain: freeSuggestion }
-		);
+		title = titleOverride
+			? titleOverride.replace( '%(domain)s', freeSuggestion )
+			: sprintf(
+					// translators: %(domain)s is the free WordPress.com subdomain
+					__( 'Start free with %(domain)s' ),
+					{ domain: freeSuggestion }
+			  );
 		subtitle = __( 'Upgrade to a custom domain name anytime.' );
 		buttonText = buttonTextOverride ?? __( 'Start Free' );
 		chevronOnMobile = true;

--- a/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
+++ b/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
@@ -16,7 +16,13 @@ interface Props {
 	freeSuggestion?: string;
 	unavailableDomain?: string;
 	existingSiteUrl?: string;
-	canStartFree?: boolean;
+	/**
+	 * Overrides the default "Start free with %(domain)s" title of the
+	 * free-subdomain card. May include the `%(domain)s` placeholder.
+	 */
+	title?: string;
+	/** Overrides the default "Start Free" CTA of the free-subdomain card. */
+	buttonText?: string;
 	onSkip: () => void;
 	onSuggestionClick?: () => void;
 	disabled?: boolean;
@@ -27,7 +33,8 @@ const DomainSearchSkipSuggestion = ( {
 	freeSuggestion,
 	unavailableDomain,
 	existingSiteUrl,
-	canStartFree = true,
+	title: titleOverride,
+	buttonText: buttonTextOverride,
 	onSkip,
 	onSuggestionClick,
 	disabled,
@@ -78,19 +85,14 @@ const DomainSearchSkipSuggestion = ( {
 		);
 		showButton = false;
 	} else if ( freeSuggestion ) {
-		title = canStartFree
-			? sprintf(
-					// translators: %(domain)s is the free WordPress.com subdomain
-					__( 'Start free with %(domain)s' ),
-					{ domain: freeSuggestion }
-			  )
-			: sprintf(
-					// translators: %(domain)s is the free WordPress.com subdomain
-					__( 'Start with %(domain)s' ),
-					{ domain: freeSuggestion }
-			  );
+		title = sprintf(
+			titleOverride ??
+				// translators: %(domain)s is the free WordPress.com subdomain
+				__( 'Start free with %(domain)s' ),
+			{ domain: freeSuggestion }
+		);
 		subtitle = __( 'Upgrade to a custom domain name anytime.' );
-		buttonText = canStartFree ? __( 'Start Free' ) : __( 'Choose a domain later' );
+		buttonText = buttonTextOverride ?? __( 'Start Free' );
 		chevronOnMobile = true;
 	}
 

--- a/packages/domain-search/src/ui/domain-search-skip-suggestion/test/index.tsx
+++ b/packages/domain-search/src/ui/domain-search-skip-suggestion/test/index.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { DomainSearchSkipSuggestion } from '../index';
+
+// Force the "large" container query so the text CTA renders (the mobile layout
+// swaps it for an icon-only chevron button, which has no visible label).
+jest.mock( '../../../hooks/use-domain-suggestion-container', () => ( {
+	...jest.requireActual( '../../../hooks/use-domain-suggestion-container' ),
+	useDomainSuggestionContainer: () => ( {
+		containerRef: jest.fn(),
+		activeQuery: 'large',
+		currentWidth: 600,
+	} ),
+} ) );
+
+describe( 'DomainSearchSkipSuggestion', () => {
+	it( 'renders the default "start free" copy for a free suggestion', () => {
+		render(
+			<DomainSearchSkipSuggestion freeSuggestion="mysite.wordpress.com" onSkip={ jest.fn() } />
+		);
+
+		expect( screen.getByText( 'Start free with mysite.wordpress.com' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button' ) ).toHaveTextContent( 'Start Free' );
+	} );
+
+	it( 'renders the custom title and CTA when overrides are provided', () => {
+		render(
+			<DomainSearchSkipSuggestion
+				freeSuggestion="mysite.wordpress.com"
+				title="Start with %(domain)s"
+				buttonText="Choose a domain later"
+				onSkip={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByText( 'Start with mysite.wordpress.com' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Start free with mysite.wordpress.com' ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'button' ) ).toHaveTextContent( 'Choose a domain later' );
+	} );
+} );


### PR DESCRIPTION
## Proposed Changes

* Add a reusable `skipSuggestionCopy` config override to the domain search (`DomainSearchConfig`). It lets a flow customize the free-subdomain skip card's copy:
  * `title` — overrides the default **"Start free with X"** (supports the `%(domain)s` placeholder).
  * `buttonText` — overrides the default **"Start Free"** CTA.
* The skip-suggestion component (`DomainSearchSkipSuggestion`) now accepts optional `title` / `buttonText` props and falls back to the current defaults when they're not set — no behavior change for existing flows.
* Set the override **only** for the AI Website Builder onboarding flow (`ai-site-builder-onboarding`):
  * Title: **"Start free with X"** → **"Start with X"**
  * CTA: **"Start Free"** → **"Choose a domain later"** (reuses the existing string already used by the full-cart skip button).

## Why are these changes being made?

On the AI Website Builder onboarding domains step, the skip card offered a **"Start Free"** button. That's misleading: this flow now requires selecting a paid plan, so skipping the domain does **not** let you start a free site — you immediately hit the plan-selection step. The free-subdomain itself is genuinely free, so the "free domain" value prop is kept, but the "Start **Free**" call to action (which implies a free start) is replaced with a neutral "choose later" action.

Rather than encode a flow-specific rule inside the presentational component, the copy is exposed as a generic `skipSuggestionCopy` override: the component stays copy-agnostic, and any flow can tailor the skip card's title/CTA with a few lines while every other flow is unchanged (the override is optional and defaults to the current copy).

## Testing Instructions

* Go to `/setup/ai-site-builder-onboarding/domains`, search for a term, and look at the free-subdomain skip card at the bottom.
  * **Before:** title "Start free with X", button "Start Free".
  * **After:** title "Start with X", button "Choose a domain later".
* Verify other flows that show the skip card (e.g. `/setup/onboarding/domains`) are **unchanged** — still "Start free with X" / "Start Free".

Make sure the basic onboarding flow doesn't change:

<img width="1677" height="920" alt="image" src="https://github.com/user-attachments/assets/bea8f928-3231-433e-ab30-f3940fefa6b1" />

And the new /setup/ai-site-builder-onboarding/domains does:

<img width="1677" height="823" alt="image" src="https://github.com/user-attachments/assets/b0b66b36-45c0-4e8c-af35-e82481af0dd0" />

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if applicable?

---

Notes:
- New translatable string introduced: **"Start with %(domain)s"**. "Choose a domain later" already exists.
- Tests added: a `domain-search` component test for the skip-card title/CTA overrides, and a `getSkipSuggestionCopy` helper test asserting the AI Website Builder onboarding flow drops the "start free" framing.
- Ran locally: `typecheck-packages` (clean), `typecheck-client` (clean for changed files), the full `domain-search` package suite (384 passing), and the two new tests. Prettier-formatted and lint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






















