### PR TITLE
Enable domain-bundling flag everywhere (frontend gate test)

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -50,7 +50,7 @@
 		"dashboard/simulate-full-rollout": false,
 		"dashboard/wp-beta-program": true,
 		"dolly/telegram": true,
-		"domain-bundling": false,
+		"domain-bundling": true,
 		"domain-transfer-redesign": true,
 		"emails/titan-tiers": false,
 		"google-my-business": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -50,6 +50,7 @@
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,
 		"dolly/telegram": true,
+		"domain-bundling": true,
 		"domain-transfer-redesign": true,
 		"emails/titan-tiers": false,
 		"google-my-business": true,


### PR DESCRIPTION
Flips the Calypso `domain-bundling` feature flag to `true` in `production.json` and adds it (`true`) to `stage.json`, so the domain bundle frontend path is enabled for everyone in every environment.
### Safety note
This changes the **frontend** gate only. The backend `WPCOM_DOMAIN_BUNDLE_DISCOUNTS_ENABLED` constant is unchanged (still `false`). With that constant false, only a12s see bundles.

The backend will be turned on in 228253-ghe-Automattic/wpcom

Co-Authored-By: Claude <noreply@anthropic.com>