### PR TITLE
Plan grids redesign: fix dangling logos

### DIFF
--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -797,6 +797,10 @@ $redesign-table-cell-max-width: 280px;
 
 			&.has-4-cols .plans-grid-next-features-grid__bottom-plan-card {
 				max-width: $redesign-table-cell-max-width * 4;
+
+				&.is-enterprise-bottom-card {
+					--enterprise-bottom-card-logo-column-gap: 54px;
+				}
 			}
 
 			&.has-5-cols .plans-grid-next-features-grid__bottom-plan-card {
@@ -905,7 +909,7 @@ $redesign-table-cell-max-width: 280px;
 	.plans-grid-next-features-grid__bottom-plan-card-media .plans-grid-next-client-logo-list {
 		--bottom-plan-card-logo-height: 40px;
 		align-items: center;
-		column-gap: 64px;
+		column-gap: var( --enterprise-bottom-card-logo-column-gap, 64px );
 		justify-content: flex-end;
 		max-width: 1015px;
 		row-gap: 16px;
@@ -918,6 +922,39 @@ $redesign-table-cell-max-width: 280px;
 
 		.plans-grid-next-client-logo-list__item {
 			--adjustment-unit: calc( var( --bottom-plan-card-logo-height ) / 60 );
+		}
+	}
+
+	@media ( max-width: 1019px ) {
+		&:not(.is-small) {
+			.plan-features-2023-grid__content.has-4-cols.has-bottom-plan-card {
+				.plans-grid-next-features-grid__bottom-plan-card.is-enterprise-bottom-card {
+					--enterprise-bottom-card-logo-column-gap: 34px;
+				}
+			}
+		}
+	}
+
+	@media ( max-width: 930px ) {
+		&:not(.is-small) {
+			.plan-features-2023-grid__content.has-4-cols.has-bottom-plan-card {
+				.plans-grid-next-features-grid__bottom-plan-card.is-enterprise-bottom-card {
+					--enterprise-bottom-card-logo-column-gap: 14px;
+				}
+			}
+		}
+	}
+
+	@media ( max-width: 769px ) {
+		&:not(.is-small) {
+			.plan-features-2023-grid__content.has-4-cols.has-bottom-plan-card {
+				.plans-grid-next-features-grid__bottom-plan-card.is-enterprise-bottom-card {
+					.plans-grid-next-features-grid__bottom-plan-card-media
+						.plans-grid-next-client-logo-list {
+						--bottom-plan-card-logo-height: 24px;
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION

<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-17876

## Proposed Changes

* Implement CSS changes to avoid dangling logos in the Enterprise card.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the pricing grid redesign.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test with the 'five_plan_new_design' variant.
* Go to /setup/onboarding/domains, add a paid domain to the cart and proceed to the next step.
* Gradually resize the window width from maximum to mobile sizes and observe the behaviour of the logos in the Enterprise card at the bottom.
* Remove the domain from the cart and repeat step 3.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
