### PR TITLE
Dashboard Purchase Settings: Fix cardNumber in credit card notices

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
@@ -692,7 +692,7 @@ export function OtherRenewablePurchasesNotice( {
 		if ( currentPurchase.payment_card_id ) {
 			const cardDetails = {
 				cardType: purchase.payment_card_type ?? '',
-				cardNumber: Number( purchase.payment_card_id ) || 0,
+				cardNumber: Number( purchase.payment_details ) || 0,
 				cardExpiry: purchase.payment_expiry ?? '',
 			};
 
@@ -944,7 +944,7 @@ export function OtherRenewablePurchasesNotice( {
 		if ( currentPurchase.payment_card_id ) {
 			const cardDetails = {
 				cardType: purchase.payment_card_type ?? '',
-				cardNumber: Number( purchase.payment_card_id ) || 0,
+				cardNumber: Number( purchase.payment_details ) || 0,
 				cardExpiry: purchase.payment_expiry ?? '',
 			};
 

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -657,7 +657,7 @@ export function shouldShowCardExpiringWarning( purchase: Purchase ): boolean {
 function CreditCardExpiringNotice( { purchase }: { purchase: Purchase } ) {
 	const cardDetails = {
 		cardType: purchase.payment_card_type ?? '',
-		cardNumber: Number( purchase.payment_card_id ) || 0,
+		cardNumber: Number( purchase.payment_details ) || 0,
 		cardExpiry: purchase.payment_expiry ?? '',
 	};
 

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -447,10 +447,9 @@ export interface Purchase {
 	 * The billing processor class name for the stored card, or undefined for
 	 * the default (updatable) case.
 	 *
-	 * This is read in `cardProcessorSupportsUpdates` to decide whether the card
-	 * number can be updated. Cards processed via CC & Paygate can be updated (so
-	 * this stays undefined), but EBANX cards cannot, so this is set to
-	 * 'WPCOM_Billing_Ebanx' for them.
+	 * Used to determine whether the card number can be updated. Cards processed
+	 * via CC & Paygate can be updated, so this stays undefined; EBANX cards
+	 * cannot, so this is set to 'WPCOM_Billing_Ebanx' for them.
 	 */
 	payment_card_processor: string | undefined;
 

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -427,9 +427,39 @@ export interface Purchase {
 	 */
 	is_auto_renew_enabled: boolean;
 
+	/**
+	 * The ID of the stored payment method used for this subscription (the
+	 * `stored_details_id` of the underlying payment method).
+	 *
+	 * Only set when the payment method is a stored card; undefined otherwise.
+	 */
 	payment_card_id: number | string | undefined;
+
+	/**
+	 * The lowercased card type/brand of the stored card (eg: 'visa' or
+	 * 'mastercard').
+	 *
+	 * Only set when the payment method is a stored card; undefined otherwise.
+	 */
 	payment_card_type: string | undefined;
+
+	/**
+	 * The billing processor class name for the stored card, or undefined for
+	 * the default (updatable) case.
+	 *
+	 * This is read in `cardProcessorSupportsUpdates` to decide whether the card
+	 * number can be updated. Cards processed via CC & Paygate can be updated (so
+	 * this stays undefined), but EBANX cards cannot, so this is set to
+	 * 'WPCOM_Billing_Ebanx' for them.
+	 */
 	payment_card_processor: string | undefined;
+
+	/**
+	 * A human-readable display string for the stored card, currently its last 4
+	 * digits.
+	 *
+	 * Only set when the payment method is a stored card; undefined otherwise.
+	 */
 	payment_details: string | undefined;
 
 	/**


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2251/

## Proposed changes

This fixes the Dashboard billing purchase notices so the credit-card-expiring messages show the card's actual last 4 digits instead of the internal payment method ID, by sourcing `cardNumber` from `payment_details` rather than `payment_card_id`.

Before             |  After
:-------------------------:|:-------------------------:
<img width="687" height="214" alt="ending-in-before" src="https://github.com/user-attachments/assets/4e4c5992-77f0-445d-b562-58ff61af8941" /> | <img width="691" height="209" alt="ending-in-after" src="https://github.com/user-attachments/assets/317b9703-015b-4d72-9a36-092d05f837fc" />

## Why are these changes being made?

The credit-card-expiring notices build a `%(cardNumber)d` translation argument to render a message like "Your Visa ending in 1234 expires…". The Dashboard code was reading this value from `purchase.payment_card_id`, but that field holds the stored payment method's `stored_details_id` — an internal identifier, not the card number. The correct last-4 display string lives in `purchase.payment_details`. As a result, users saw an internal ID where their card's last 4 digits should appear.

The guard conditions (`if ( purchase.payment_card_id )`) are left unchanged because `payment_card_id` is the right field for testing whether a stored card exists; only the *displayed* value was wrong. The classic Calypso implementation (`client/me/purchases/manage-purchase/notices.tsx`) already uses the last-4 value, so this brings the Dashboard in line with existing behavior. The added doc comments on the `Purchase` interface make the distinction between these look-alike fields explicit to prevent the same mistake in the future.

This bug was introduced in https://github.com/Automattic/wp-calypso/pull/105490

## Testing instructions

Manual testing:
* In the Dashboard, view a purchase whose stored card expires before the subscription's next renewal (or is close to expiring) so the credit-card-expiring notice renders.
* Confirm the notice reads "Your {brand} ending in {last 4} expires/expired {date}…" and that the number shown matches the card's actual last 4 digits — not a long internal ID.
* If the site has other renewable purchases affected by the same card, confirm the "other upgrades" variant of the notice also shows the correct last 4 digits.

