### PR TITLE
Preserve query params on siteSelection all-sites redirect

### DIFF
--- a/client/my-sites/controller.jsx
+++ b/client/my-sites/controller.jsx
@@ -707,7 +707,10 @@ export function siteSelection( context, next ) {
 				} else {
 					// If the site has loaded but siteId is still invalid then redirect to allSitesPath.
 					const siteFragmentOffset = context.path.indexOf( `/${ siteFragment }` );
-					const allSitesPath = context.path.substring( 0, siteFragmentOffset );
+					let allSitesPath = context.path.substring( 0, siteFragmentOffset );
+					if ( context.querystring ) {
+						allSitesPath += `?${ context.querystring }`;
+					}
 					page.redirect( allSitesPath );
 				}
 			} );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-511/

## Proposed changes

This preserves the query string when the `siteSelection` middleware falls back to redirecting to the all-sites path after it can't resolve a site fragment, so params like `cancel_to`/`redirect_to` survive.

* Re-append `context.querystring` to `allSitesPath` before `page.redirect()` in `siteSelection`, matching the existing behavior of `redirectToPrimary`.

## Why are these changes being made?

Landing on a checkout renewal URL that includes a site slug and query params — e.g. `/checkout/ecommerce-bundle/renew/1252758/somesite.wpcomstaging.com?cancel_to=…&redirect_to=…` — would intermittently redirect to a stripped `/checkout/ecommerce-bundle/renew/1252758`, dropping both the site-slug segment and the entire query string. Because `cancel_to`/`redirect_to` were lost, back/cancel navigation from checkout broke. It only reproduced sometimes; refreshing the page a few times triggered it.

Root cause: `siteSelection` runs before the checkout controller. On a fresh page load Redux is empty, so it always takes the async branch and dispatches `requestSite(siteFragment)`. When that fetch intermittently doesn't resolve to a usable site ID, it falls through to the "site invalid → all-sites" branch, which builds `allSitesPath` by truncating `context.path` right before the site fragment — discarding everything after it, including the query string. The sibling `redirectToPrimary` already preserves `context.querystring`; this branch did not. Re-appending it keeps the params intact so back/cancel navigation works even when the fallback redirect fires.

Note: this preserves the params but does not stop the redirect itself — on a bad load the URL still loses the `.wpcomstaging.com` slug segment. The deeper race (why `requestSite` for an Atomic `.wpcomstaging.com` fragment intermittently resolves without a usable site ID) is left as follow-up. https://linear.app/a8c/issue/CHE-512/checkout-renewal-intermittently-loses-the-site-slug-on-refresh

## Testing instructions

Manual testing:
* In a local Calypso instance, open a renewal checkout URL for an Atomic (`.wpcomstaging.com`) site that includes both `cancel_to` and `redirect_to` params, e.g. `/checkout/<product>/renew/<purchaseId>/<site>.wpcomstaging.com?cancel_to=…&redirect_to=…` (the Dashboard purchase settings "Renew" button generates one).
* Refresh the page several times to hit the intermittent redirect.
* Confirm that on loads where the site-slug segment is dropped, the `cancel_to`/`redirect_to` query params are still present in the address bar (before this change they were stripped).

