### PR TITLE
E2E: prove the billing API rejects dashboard-origin PayPal return URLs

### DIFF
--- a/test/e2e/specs/dashboard/billing__paypal-agreement-redirect-urls.spec.ts
+++ b/test/e2e/specs/dashboard/billing__paypal-agreement-redirect-urls.spec.ts
@@ -1,0 +1,75 @@
+import { RestAPIClient } from '@automattic/calypso-e2e';
+import { expect, tags, test } from '../../lib/pw-base';
+
+/**
+ * Requests a PayPal billing agreement for the given subscription, returning
+ * the parsed API response. A successful response contains the PayPal
+ * approval URL the user would be redirected to; nothing is charged and the
+ * agreement is inert unless approved on PayPal.
+ */
+async function createPayPalAgreement(
+	client: RestAPIClient,
+	subscriptionId: string,
+	returnUrlBase: string
+): Promise< unknown > {
+	return await client.sendRequest(
+		client.getRequestURL( '1', '/payment-methods/create-paypal-agreement' ),
+		{
+			method: 'post',
+			headers: {
+				Authorization: await client.getAuthorizationHeader( 'bearer' ),
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify( {
+				subscription_id: subscriptionId,
+				success_url: `${ returnUrlBase }/me/billing/payment-methods?success=true`,
+				cancel_url: `${ returnUrlBase }/me/billing/payment-methods`,
+				tax_country_code: 'US',
+				tax_postal_code: '90210',
+			} ),
+		}
+	);
+}
+
+test.describe( 'Dashboard: PayPal agreement redirect URLs', { tag: [ tags.DASHBOARD_PR ] }, () => {
+	test( 'The billing API accepts dashboard-origin return URLs when creating a PayPal agreement', async ( {
+		secrets,
+	} ) => {
+		const client = new RestAPIClient( {
+			username: secrets.testAccounts.atomicUser.username,
+			password: secrets.testAccounts.atomicUser.password,
+		} );
+		let subscriptionId: string;
+
+		await test.step( 'Given I own an active subscription', async function () {
+			const response = await client.sendRequest( client.getRequestURL( '1.2', '/upgrades' ), {
+				method: 'get',
+				headers: { Authorization: await client.getAuthorizationHeader( 'bearer' ) },
+			} );
+			expect( Array.isArray( response ), JSON.stringify( response ) ).toBe( true );
+			const subscription = response.find(
+				( purchase: { ID: number; expiry_status: string } ) => purchase.expiry_status !== 'expired'
+			);
+			expect( subscription, 'atomicUser has no active subscription' ).toBeDefined();
+			subscriptionId = String( subscription.ID );
+		} );
+
+		await test.step( 'When I request a PayPal agreement returning to wordpress.com, it is accepted', async function () {
+			const response = ( await createPayPalAgreement(
+				client,
+				subscriptionId,
+				'https://wordpress.com'
+			) ) as { error?: string };
+			expect( response?.error, JSON.stringify( response ) ).toBeUndefined();
+		} );
+
+		await test.step( 'Then a PayPal agreement returning to my.wordpress.com is also accepted', async function () {
+			const response = ( await createPayPalAgreement(
+				client,
+				subscriptionId,
+				'https://my.wordpress.com'
+			) ) as { error?: string };
+			expect( response?.error, JSON.stringify( response ) ).toBeUndefined();
+		} );
+	} );
+} );


### PR DESCRIPTION
## Proposed Changes

* New e2e spec asserting that `create-paypal-agreement` accepts `success_url`/`cancel_url` on `https://my.wordpress.com`, with a `https://wordpress.com` control step.

**This spec currently fails by design** — it exists to demonstrate a live production regression and should turn green (and only then merge) once the server-side fix lands:

```
{"error":"invalid_success_url","message":"The success_url parameter is set to
https://my.wordpress.com/me/billing/payment-methods?success=true which is not
a valid URL to redirect to."}
```

## Why are these changes being made?

* The dashboard's move from wordpress.com to my.wordpress.com missed the store API's redirect-URL allowlist. Changing a payment method to PayPal from the new dashboard fails with a 403, because the dashboard sends its own origin as the agreement's return URLs.
* The same allowlist gates checkout `success_url`/`cancel_url` and the post-purchase receipt redirect, so renewals launched from the dashboard lose their return-to-dashboard redirect too. This spec pins the smallest deterministic probe of that allowlist.
* The control step (wordpress.com return URLs) passes, isolating the failure to the origin rather than the request shape.

## Testing Instructions

* `cd test/e2e && yarn playwright test specs/dashboard/billing__paypal-agreement-redirect-urls.spec.ts --project=chrome --reporter=list`
* Expected today: the wordpress.com step passes, the my.wordpress.com step fails with `invalid_success_url`.
* The spec is API-level (no browser UI) and creates only inert PayPal agreement tokens; nothing is charged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KjdZiFUjApTv3pPu4KAra6