### PR TITLE
E2E: cover security key registration and removal from the new dashboard

### DIFF
--- a/test/e2e/specs/dashboard/security__two-step-security-keys.spec.ts
+++ b/test/e2e/specs/dashboard/security__two-step-security-keys.spec.ts
@@ -1,3 +1,4 @@
+import { snoozeAccountRecoveryInterstitial } from '../../lib/dashboard-helpers';
 import { getAccount } from '../../lib/get-account';
 import { expect, tags, test } from '../../lib/pw-base';
 import type { Page } from 'playwright';
@@ -30,7 +31,7 @@ async function removeAllSecurityKeysViaCalypso(
 	page: Page,
 	calypsoBaseUrl: string
 ): Promise< void > {
-	await page.goto( `${ calypsoBaseUrl }/me/security` );
+	await page.goto( `${ calypsoBaseUrl }/me/security/two-step` );
 	// The section only renders once the keys have been fetched.
 	const section = page.locator( '.security-2fa-key' );
 	await section.waitFor();
@@ -48,16 +49,23 @@ test.describe(
 	{ tag: [ tags.DASHBOARD_PR, tags.CALYPSO_RELEASE ] },
 	() => {
 		test( 'As a WordPress.com user with two-step auth, I can register and remove a security key from the dashboard', async ( {
+			browserName,
 			environment,
 			page,
 			pageDashboard,
 		} ) => {
+			test.skip(
+				browserName !== 'chromium',
+				'CDP virtual authenticators are only available in Chromium'
+			);
+
 			const keyName = `e2e-key-${ Date.now() }`;
 			let keyMayExist = false;
 
 			try {
 				await test.step( 'Given I am authenticated with two-step authentication', async function () {
 					const testAccount = await getAccount( page, 'totpUser' );
+					await snoozeAccountRecoveryInterstitial( testAccount.restAPI );
 					await testAccount.authenticate( page, { waitUntilStable: false } );
 				} );
 

--- a/test/e2e/specs/dashboard/security__two-step-security-keys.spec.ts
+++ b/test/e2e/specs/dashboard/security__two-step-security-keys.spec.ts
@@ -1,0 +1,113 @@
+import { getAccount } from '../../lib/get-account';
+import { expect, tags, test } from '../../lib/pw-base';
+import type { Page } from 'playwright';
+
+/**
+ * Registers a CDP virtual authenticator so WebAuthn prompts complete
+ * automatically without a physical security key. Chromium-only.
+ */
+async function addVirtualAuthenticator( page: Page ): Promise< void > {
+	const cdpSession = await page.context().newCDPSession( page );
+	await cdpSession.send( 'WebAuthn.enable' );
+	await cdpSession.send( 'WebAuthn.addVirtualAuthenticator', {
+		options: {
+			protocol: 'ctap2',
+			transport: 'usb',
+			hasResidentKey: true,
+			hasUserVerification: true,
+			isUserVerified: true,
+			automaticPresenceSimulation: true,
+		},
+	} );
+}
+
+/**
+ * Removes every security key on the account via the classic Calypso security
+ * page. Runs as cleanup so an interrupted test never leaves a key behind,
+ * which would change the account's login challenge for other specs.
+ */
+async function removeAllSecurityKeysViaCalypso(
+	page: Page,
+	calypsoBaseUrl: string
+): Promise< void > {
+	await page.goto( `${ calypsoBaseUrl }/me/security` );
+	// The section only renders once the keys have been fetched.
+	const section = page.locator( '.security-2fa-key' );
+	await section.waitFor();
+	const deleteButtons = section.locator( '.security-2fa-key__delete-key' );
+	while ( ( await deleteButtons.count() ) > 0 ) {
+		const count = await deleteButtons.count();
+		await deleteButtons.first().click();
+		await page.getByRole( 'button', { name: 'Remove key' } ).click();
+		await expect( deleteButtons ).toHaveCount( count - 1 );
+	}
+}
+
+test.describe(
+	'Dashboard: Security Keys',
+	{ tag: [ tags.DASHBOARD_PR, tags.CALYPSO_RELEASE ] },
+	() => {
+		test( 'As a WordPress.com user with two-step auth, I can register and remove a security key from the dashboard', async ( {
+			environment,
+			page,
+			pageDashboard,
+		} ) => {
+			const keyName = `e2e-key-${ Date.now() }`;
+			let keyMayExist = false;
+
+			try {
+				await test.step( 'Given I am authenticated with two-step authentication', async function () {
+					const testAccount = await getAccount( page, 'totpUser' );
+					await testAccount.authenticate( page, { waitUntilStable: false } );
+				} );
+
+				await test.step( 'And my browser has a security key available', async function () {
+					await addVirtualAuthenticator( page );
+				} );
+
+				await test.step( 'When I visit the two-step authentication page', async function () {
+					await pageDashboard.visitPath( 'me/security/two-step-auth' );
+					await expect( page.getByRole( 'heading', { name: 'Security keys' } ) ).toBeVisible();
+				} );
+
+				await test.step( 'And I register a new security key', async function () {
+					await page.getByRole( 'button', { name: 'Register key' } ).click();
+					await page.getByLabel( 'Security key name' ).fill( keyName );
+					keyMayExist = true;
+					await page.getByRole( 'button', { name: 'Add key' } ).click();
+				} );
+
+				const keyItem = page.locator( '.action-item' ).filter( { hasText: keyName } );
+
+				await test.step( 'Then the security key is registered and listed', async function () {
+					await expect(
+						page.getByTestId( 'snackbar' ).getByText( `Security key "${ keyName }" added.` )
+					).toBeVisible();
+					await expect( keyItem ).toBeVisible();
+				} );
+
+				await test.step( 'When I remove the security key', async function () {
+					await keyItem.getByRole( 'button', { name: 'Remove' } ).click();
+					await page.getByRole( 'button', { name: 'Remove security key' } ).click();
+				} );
+
+				await test.step( 'Then the security key is no longer listed', async function () {
+					await expect(
+						page.getByTestId( 'snackbar' ).getByText( 'Security key deleted.' )
+					).toBeVisible();
+					await expect( keyItem ).toBeHidden();
+					keyMayExist = false;
+				} );
+			} finally {
+				if ( keyMayExist ) {
+					try {
+						await removeAllSecurityKeysViaCalypso( page, environment.CALYPSO_BASE_URL );
+					} catch ( error ) {
+						// Deliberately swallowed: a cleanup failure must not mask the test result.
+						console.warn( `Security key cleanup failed: ${ error }` );
+					}
+				}
+			}
+		} );
+	}
+);


### PR DESCRIPTION
Part of DOTMSD-1415

## Proposed Changes

* New e2e spec covering the full security-key lifecycle from the new dashboard origin: register a key on `/me/security/two-step-auth`, see it listed, remove it.
* Uses a CDP virtual authenticator (first WebAuthn usage in the e2e suite), the `totpUser` account (security keys require two-step auth), and a best-effort cleanup pass via classic Calypso so an interrupted run can never leave a key behind that would change the account's login challenge.
* Hardening from a live local run: the cleanup pass now targets `/me/security/two-step` (the keys list no longer renders on `/me/security`), non-Chromium projects skip instead of failing (CDP virtual authenticators are Chromium-only), and the account-recovery interstitial is snoozed before login.

## Why are these changes being made?

* The dashboard's move from wordpress.com to my.wordpress.com silently broke security-key creation: the server issued and validated the WebAuthn challenge against the wordpress.com origin. Nothing in the e2e suite exercised WebAuthn, so it slipped through.
* This spec locks the flow down so the next origin-sensitive change to WebAuthn is caught in CI.
* Note: against a local dev server this passes even while production was broken, because in non-production builds the client sends an explicit `hostname` to the challenge endpoint. Pointing the suite at production (`DASHBOARD_BASE_URL=https://my.wordpress.com`) exercises the real production path, which omits that parameter.

## Testing Instructions

* Start a local dev server, then `cd test/e2e && yarn playwright test specs/dashboard/security__two-step-security-keys.spec.ts --project=chrome --reporter=list`
* Passes in ~10s. To verify against production, set `DASHBOARD_BASE_URL=https://my.wordpress.com CALYPSO_BASE_URL=https://wordpress.com`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KjdZiFUjApTv3pPu4KAra6