### PR TITLE
Update the AI site builder onboarding path

### DIFF
--- a/client/components/sites-add-new-site/index.tsx
+++ b/client/components/sites-add-new-site/index.tsx
@@ -32,7 +32,10 @@ export const SitesAddNewSitePopover = ( { showCompact, context }: Props ) => {
 				) }
 				renderContent={ () => (
 					<div className="sites-add-new-site__popover-content">
-						<AsyncContent context={ context } aiSiteBuilderPath="/setup/ai-site-builder" />
+						<AsyncContent
+							context={ context }
+							aiSiteBuilderPath="/setup/ai-site-builder-onboarding"
+						/>
 					</div>
 				) }
 				onToggle={ ( isOpen ) => {

--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -23,7 +23,7 @@ import './style.scss';
 
 function AddNewSite( {
 	context = 'unknown',
-	aiSiteBuilderPath = '/setup/ai-site-builder',
+	aiSiteBuilderPath = '/setup/ai-site-builder-onboarding',
 }: AddNewSiteProps ) {
 	const { recordTracksEvent } = useAnalytics();
 	const auth = useContext( AuthContext );

--- a/client/dashboard/sites/empty-sites-state/index.tsx
+++ b/client/dashboard/sites/empty-sites-state/index.tsx
@@ -56,7 +56,7 @@ function CreateAndBuildActions() {
 				actions={
 					<Button
 						variant="secondary"
-						href={ addQueryArgs( wpcomLink( '/setup/ai-site-builder' ), {
+						href={ addQueryArgs( wpcomLink( '/setup/ai-site-builder-onboarding' ), {
 							source: CONTEXT,
 							ref: EMPTY_STATE_REF,
 						} ) }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -215,7 +215,10 @@ export default function Sites() {
 			<InviteAcceptedFlashMessage />
 			{ isModalOpen && (
 				<Modal title={ __( 'Add new site' ) } onRequestClose={ () => setIsModalOpen( false ) }>
-					<AddNewSite context="sites-dashboard" aiSiteBuilderPath="/setup/ai-site-builder" />
+					<AddNewSite
+						context="sites-dashboard"
+						aiSiteBuilderPath="/setup/ai-site-builder-onboarding"
+					/>
 				</Modal>
 			) }
 			<PageLayout

--- a/client/dashboard/sites/site-switcher/index.tsx
+++ b/client/dashboard/sites/site-switcher/index.tsx
@@ -41,7 +41,10 @@ const SiteSwitcher = ( props: SiteSwitcherProps ) => {
 					title={ __( 'Add new site' ) }
 					onRequestClose={ () => setIsAddSiteModalOpen( false ) }
 				>
-					<AddNewSite context="sites-dashboard" aiSiteBuilderPath="/setup/ai-site-builder" />
+					<AddNewSite
+						context="sites-dashboard"
+						aiSiteBuilderPath="/setup/ai-site-builder-onboarding"
+					/>
 				</Modal>
 			) }
 		</>


### PR DESCRIPTION
Fixes MARTECH-2541
Fixes MARTECH-2542

## Proposed Changes

* Update the `Create with AI` actions in the multisite dashboard and original dashboard to `/setup/ai-site-builder-onboarding`.
* Update the `Build with AI` empty and search-result actions to `/setup/ai-site-builder-onboarding`.

## Why are these changes being made?

* We're updating paths to use the new `/setup/ai-site-builder-onboarding` flow.

## Testing Instructions

* Using Calypso live or running locally, visit both http://calypso.localhost:3000/sites and http://my.localhost:3000/sites
* Click `Add new site` and confirm `Create with AI` opens `/setup/ai-site-builder-onboarding` while retaining the existing query parameters.
<img width="1547" height="929" alt="Screenshot 2026-07-15 at 10 08 29 PM" src="https://github.com/user-attachments/assets/dd29cfed-f157-4849-8bc8-bb80f37e1ead" />
<img width="1551" height="928" alt="Screenshot 2026-07-15 at 10 24 13 PM" src="https://github.com/user-attachments/assets/748ec210-90d7-4d9c-8add-d89dc20b8025" />

* Search for a site that does not exist and confirm `Build with AI` opens `/setup/ai-site-builder-onboarding` while retaining the existing query parameters.
<img width="1552" height="928" alt="Screenshot 2026-07-15 at 10 25 18 PM" src="https://github.com/user-attachments/assets/db2bf8de-9add-4f25-9639-1f6294011cd2" />
<img width="1555" height="927" alt="Screenshot 2026-07-15 at 10 24 55 PM" src="https://github.com/user-attachments/assets/62fb596b-b1c4-4647-823a-f8982bcc19f6" />

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
