### PR TITLE
Record security key login failures as Tracks events

### DIFF
--- a/client/landing/login/common.js
+++ b/client/landing/login/common.js
@@ -3,7 +3,6 @@ import { getUrlParts } from '@automattic/calypso-url';
 import debugFactory from 'debug';
 import { initializeAnalytics } from 'calypso/lib/analytics/init';
 import getSuperProps from 'calypso/lib/analytics/super-props';
-import { setupErrorLogger } from 'calypso/lib/error-logger/setup-error-logger';
 import loadDevHelpers from 'calypso/lib/load-dev-helpers';
 import { setCurrentUser } from 'calypso/state/current-user/actions';
 import { setRoute } from 'calypso/state/route/actions';
@@ -80,6 +79,5 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 	setupContextMiddleware();
 	setRouteMiddleware( reduxStore );
 	setAnalyticsMiddleware( currentUser, reduxStore );
-	setupErrorLogger( reduxStore );
 	loadDevHelpers( reduxStore );
 }

--- a/client/landing/login/common.js
+++ b/client/landing/login/common.js
@@ -3,6 +3,7 @@ import { getUrlParts } from '@automattic/calypso-url';
 import debugFactory from 'debug';
 import { initializeAnalytics } from 'calypso/lib/analytics/init';
 import getSuperProps from 'calypso/lib/analytics/super-props';
+import { setupErrorLogger } from 'calypso/lib/error-logger/setup-error-logger';
 import loadDevHelpers from 'calypso/lib/load-dev-helpers';
 import { setCurrentUser } from 'calypso/state/current-user/actions';
 import { setRoute } from 'calypso/state/route/actions';
@@ -79,5 +80,6 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 	setupContextMiddleware();
 	setRouteMiddleware( reduxStore );
 	setAnalyticsMiddleware( currentUser, reduxStore );
+	setupErrorLogger( reduxStore );
 	loadDevHelpers( reduxStore );
 }

--- a/client/state/login/actions/login-user-with-security-key.js
+++ b/client/state/login/actions/login-user-with-security-key.js
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { captureException } from '@automattic/calypso-sentry';
 import { get as webauthn_auth } from '@github/webauthn-json';
 import { translate } from 'i18n-calypso';
 import {
@@ -83,6 +84,11 @@ export const loginUserWithSecurityKey = () => ( dispatch, getState ) => {
 					: httpError.name;
 				const message = errorMessages[ errorKey ] ?? errorMessages.default;
 				error = { code: httpError.name, message, field: 'global' };
+
+				captureException( httpError, {
+					tags: { flow: 'security-key-login', error_key: errorKey },
+					user: { id: loginParams.user_id?.toString() },
+				} );
 			} else {
 				error = getErrorFromHTTPError( httpError );
 			}

--- a/client/state/login/actions/login-user-with-security-key.js
+++ b/client/state/login/actions/login-user-with-security-key.js
@@ -86,7 +86,6 @@ export const loginUserWithSecurityKey = () => ( dispatch, getState ) => {
 				error = { code: httpError.name, message, field: 'global' };
 
 				captureException( httpError, {
-					tags: { calypso_section: 'login' },
 					user: { id: loginParams.user_id?.toString() },
 				} );
 			} else {

--- a/client/state/login/actions/login-user-with-security-key.js
+++ b/client/state/login/actions/login-user-with-security-key.js
@@ -86,7 +86,7 @@ export const loginUserWithSecurityKey = () => ( dispatch, getState ) => {
 				error = { code: httpError.name, message, field: 'global' };
 
 				captureException( httpError, {
-					tags: { flow: 'security-key-login', error_key: errorKey },
+					tags: { calypso_section: 'login' },
 					user: { id: loginParams.user_id?.toString() },
 				} );
 			} else {

--- a/client/state/login/actions/login-user-with-security-key.js
+++ b/client/state/login/actions/login-user-with-security-key.js
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import { captureException } from '@automattic/calypso-sentry';
 import { get as webauthn_auth } from '@github/webauthn-json';
 import { translate } from 'i18n-calypso';
 import {
@@ -7,6 +6,7 @@ import {
 	TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_FAILURE,
 	TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { remoteLoginUser } from 'calypso/state/login/actions/remote-login-user';
 import { updateNonce } from 'calypso/state/login/actions/update-nonce';
 import { getTwoFactorAuthNonce, getTwoFactorUserId } from 'calypso/state/login/selectors';
@@ -85,9 +85,11 @@ export const loginUserWithSecurityKey = () => ( dispatch, getState ) => {
 				const message = errorMessages[ errorKey ] ?? errorMessages.default;
 				error = { code: httpError.name, message, field: 'global' };
 
-				captureException( httpError, {
-					user: { id: loginParams.user_id?.toString() },
-				} );
+				dispatch(
+					recordTracksEvent( 'calypso_login_security_key_failure', {
+						error: errorKey,
+					} )
+				);
 			} else {
 				error = getErrorFromHTTPError( httpError );
 			}


### PR DESCRIPTION
Part of DOTMSD-1417

## Proposed Changes

* When a security key (WebAuthn) login fails, record a `calypso_login_security_key_failure` Tracks event with an `error` property set to the resolved error type (`NotAllowedError`, `AbortError`, `SecurityError`, `TypeError`, `NotFocusedError`, or the raw error name).
* Only the client-side WebAuthn failure path is reported. Normal HTTP responses from the challenge/authentication endpoints (e.g. expired nonce) are left alone to avoid noise.

## Why are these changes being made?

* Today a failed security key login only produces a translated, user-facing message. We have no visibility into which failures actually happen in the wild, which makes it hard to tell whether users are hitting real bugs or expected cancellations.
* Recording the error type as a Tracks event gives us that signal broken down by type, so we can discern real errors from cancellations (`NotAllowedError` / `AbortError`) — a user with no key registered on the device must cancel the prompt, which is expected, not a bug.

## Considerations

* The first pass logged the browser error to Sentry via `captureException`. We moved to Tracks instead: Sentry only samples ~10% of requests here (so counts would be undercounts), and expected cancellations would show up as errors that trigger alerts and triage noise. Tracks gives unsampled counts without framing expected user behavior as an error. Once we see the distribution, we can decide whether any specific error type warrants a real Sentry exception.

## Testing Instructions

* Trigger a two-factor login with a security key and cause the WebAuthn interaction to fail (e.g. cancel the browser prompt).
* Confirm the same user-facing error message still appears.
* In the browser's network/Tracks debugging, confirm a `calypso_login_security_key_failure` event fires with an `error` property matching the failure type.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
