### PR TITLE
E2E: skip-plan cart oracle + P2 nav hardening (Jest→PW PR5)

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -1,3 +1,4 @@
+import { errors } from 'playwright';
 import { getCalypsoURL } from '../../data-helper';
 import { waitForElementEnabled } from '../../element-helper';
 import type { PaymentDetails, RegistrarDetails } from '../../types/data-helper.types';
@@ -153,6 +154,32 @@ export class CartCheckoutPage {
 		if ( itemsCount !== totalItems ) {
 			throw new Error( `Expected ${ totalItems } items in cart, but found ${ itemsCount }` );
 		}
+	}
+
+	/**
+	 * Validates that the cart contains no plan line item.
+	 *
+	 * Plan rows carry `data-product-type="plan"`, so this asserts the
+	 * "plan was skipped" contract directly; a strict item count would break on
+	 * unrelated rows such as auto-added free-domain entitlements.
+	 */
+	async validateNoPlanInCart(): Promise< void > {
+		const cartItemsLocator = this.page.locator( selectors.cartItems );
+		await cartItemsLocator.first().waitFor( { state: 'visible', timeout: 30 * 1000 } );
+		const planItem = this.page.locator( `${ selectors.cartItems }[data-product-type="plan"]` );
+		try {
+			// Inverted wait: give a late cart update a bounded window to add a plan
+			// row; timing out here is the success path. A plan row added later than
+			// this window is not caught.
+			await planItem.first().waitFor( { state: 'visible', timeout: 5 * 1000 } );
+		} catch ( error ) {
+			if ( error instanceof errors.TimeoutError ) {
+				return;
+			}
+			throw error;
+		}
+		const planLabel = ( await planItem.first().innerText() ).split( '\n' )[ 0 ];
+		throw new Error( `Expected no plan in cart, but found: ${ planLabel }` );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/p2-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/p2-page.ts
@@ -2,6 +2,7 @@ import { Page } from 'playwright';
 
 const selectors = {
 	newPostButton: 'button:has-text("New Post")',
+	editorInserterToggle: 'button[aria-label="Toggle block inserter"]',
 	publishedPost: ( postContent: string ) => `.entry-content:has-text("${ postContent }")`,
 };
 
@@ -24,7 +25,22 @@ export class P2Page {
 	 * Click 'New post' to show the editor.
 	 */
 	async clickNewPost(): Promise< void > {
-		await this.page.click( selectors.newPostButton );
+		// The button is server-rendered before its click handler hydrates; a
+		// too-early click is silently lost, so retry until the editor opens.
+		const inserterToggle = this.page.locator( selectors.editorInserterToggle );
+		for ( let attempt = 0; attempt < 3; attempt++ ) {
+			if ( await inserterToggle.isVisible() ) {
+				return;
+			}
+			await this.page.click( selectors.newPostButton );
+			try {
+				await inserterToggle.waitFor( { state: 'visible', timeout: 5000 } );
+				return;
+			} catch {
+				// Handler was not attached yet; click again.
+			}
+		}
+		throw new Error( 'Editor did not open after clicking "New Post".' );
 	}
 
 	/**

--- a/test/e2e/specs/flows/setup-domain-and-plan__skip-plan.spec.ts
+++ b/test/e2e/specs/flows/setup-domain-and-plan__skip-plan.spec.ts
@@ -45,8 +45,8 @@ test.describe( 'Domain: Upsell (Skip Plan)', { tag: [ tags.CALYPSO_RELEASE ] }, 
 			await pageCartCheckout.validateCartItem( selectedDomain );
 		} );
 
-		await test.step( 'And the cart contains only the domain (no plan)', async function () {
-			await pageCartCheckout.validateCartItemsCount( 1 );
+		await test.step( 'And no plan was added to the cart', async function () {
+			await pageCartCheckout.validateNoPlanInCart();
 		} );
 	} );
 } );

--- a/test/e2e/specs/p2/p2__post.spec.ts
+++ b/test/e2e/specs/p2/p2__post.spec.ts
@@ -25,8 +25,7 @@ test.describe( 'P2: Post', { tag: [ tags.P2 ] }, () => {
 		} );
 
 		await test.step( 'And I navigate to the P2 site', async function () {
-			// eslint-disable-next-line playwright/no-networkidle -- swapping the nav wait risks editor-hydration races on P2; revisit in a follow-up pass.
-			await page.goto( accountP2.getSiteURL(), { waitUntil: 'networkidle' } );
+			await page.goto( accountP2.getSiteURL(), { waitUntil: 'load' } );
 		} );
 
 		let blockHandle: ElementHandle;


### PR DESCRIPTION
Part of [TESTOPS-144](https://linear.app/a8c/issue/TESTOPS-144), under [TESTOPS-49](https://linear.app/a8c/issue/TESTOPS-49) (Jest→Playwright E2E migration, multi-PR).

PR5 of the series. Depends on PR1/PR2/PR3, already on trunk.

## Proposed Changes

Modify-only refinements to two already-migrated Playwright specs. No `.ts` → `.spec.ts` migration, no harness, CI, or env changes.

The `infrastructure` specs that once carried this issue already landed on trunk (PR1), and the `experimental-gutenberg` pair moved to PR9 (`@group gutenberg`), so what remains is the residual refinement set.

Two commits:

- **skip-plan** — replace the brittle `validateCartItemsCount( 1 )` with a new `CartCheckoutPage.validateNoPlanInCart()`. A count-of-1 breaks whenever the cart carries an unrelated row (e.g. an auto-added free-domain entitlement). The new method asserts the actual contract — no plan line item — via `data-product-type="plan"`. It is an inverted bounded wait: a late cart update that adds a plan row within the window still fails the test, and any non-timeout error rethrows.
- **p2** — drop the deprecated `networkidle` navigation wait (and its `eslint-disable`) for `load`, and make `P2Page.clickNewPost()` hydration-safe. The New Post button is server-rendered before its click handler attaches, so a too-early click was silently lost; the method now retries the click until the editor's block-inserter toggle appears rather than depending on network quiescence.

## Why are these changes being made?

Folded-in oracle and reliability fixes deferred during earlier migration PRs (the `networkidle` `eslint-disable` was left with an explicit "revisit in a follow-up pass" note). The source migration branch is treated as prior work, not as an authoritative reference; each change was re-derived against current trunk and current product markup.

## Testing Instructions

Run against staging (`CALYPSO_STAGING_URL`):

```
CALYPSO_BASE_URL=<staging> yarn workspace wp-e2e-tests playwright test \
  --project=pixel --project=chrome specs/flows/setup-domain-and-plan__skip-plan.spec.ts \
  --reporter=list
```

`skip-plan` is `@calypso-release` and self-skips off trunk (`skipIfNotTrunk`); pass `BRANCH_NAME=trunk` to force it locally. Verified with `--repeat-each=5`: every run that reached checkout passed the new assertion; the only failures were the unrelated domain-search flake, upstream of the change.

The `p2` spec is `@p2`, a schedule-only build not in the PR matrix — validate it via `calypso_WPComTests_p2` against this branch. It does not run reliably in a local browser: the trunk baseline fails identically at `IsolatedBlockEditorComponent.addBlock` (untouched by this PR) while `calypso_WPComTests_p2` is green on trunk, so the failure is a local-environment artifact, not a regression. The parts this PR touches work: in every local run the editor opened with the caret in the empty paragraph.

`yarn eslint`, `tsc` on `test/e2e/tsconfig.json`, and the `@automattic/calypso-e2e` build all pass.
