### PR TITLE
e2e: stop Likes test from gating Gutenberg rotations

### DIFF
--- a/test/e2e/specs/published-content/likes__post.spec.ts
+++ b/test/e2e/specs/published-content/likes__post.spec.ts
@@ -13,7 +13,10 @@ import { tags, test } from '../../lib/pw-base';
 
 test.describe(
 	'Likes: Post',
-	{ tag: [ tags.GUTENBERG, tags.CALYPSO_PR, tags.CALYPSO_RELEASE ] },
+	{
+		// This test exercises the published Like widget, not the editor.
+		tag: [ tags.CALYPSO_PR, tags.CALYPSO_RELEASE ],
+	},
 	() => {
 		const features = envToFeatureKey( envVariables );
 		const accountName = getTestAccountByFeature( features, [


### PR DESCRIPTION
Part of TESTOPS-200.

## Proposed Changes

* Remove the `@gutenberg` tag from the published post Likes test.
* Keep the test in the `@calypso-pr` and `@calypso-release` suites.

## Why are these changes being made?

* `likes__post` creates a post through the REST API and exercises the published Like widget. It never loads or interacts with Gutenberg.
* The Like widget's authenticated batch request is failing only on the Atomic Edge test site, causing an unrelated widget/authentication problem to block Gutenberg rotations. The current failure is visible in TeamCity build 18517018.
* The test remains part of the Calypso PR and release suites, where its behavior is relevant and will continue to be maintained.

## Testing Instructions

* Run `TEST_ON_ATOMIC=true GUTENBERG_EDGE=true PW_WORKERS=1 CI=1 yarn playwright test specs/published-content/likes__post.spec.ts --project=chrome --reporter=list --grep @calypso-pr` from `test/e2e`. The test should pass.
* Run the same Playwright command with `--list --grep @gutenberg`. The Likes test should not be selected.
* Run it with `--list --grep @calypso-pr`. The Likes test should be selected.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
