### PR TITLE
A4A: Add the referral detail view to the multi-site dashboard

### DIFF
--- a/client/dashboard/agency/earn/referrals/hooks/use-referral.ts
+++ b/client/dashboard/agency/earn/referrals/hooks/use-referral.ts
@@ -1,0 +1,19 @@
+import { activeAgencyQuery, referralsQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { earnReferralRoute } from '../../../../app/router/agency';
+import type { Referral } from '@automattic/api-core';
+
+export function useReferral(): {
+	referral?: Referral;
+	agencyId: number;
+} {
+	const { referralId } = earnReferralRoute.useParams();
+	const { data: agency } = useQuery( activeAgencyQuery() );
+	const agencyId = agency?.id ?? 0;
+	const { data: referrals = [] } = useQuery( referralsQuery( agencyId ) );
+
+	return {
+		referral: referrals.find( ( item ) => String( item.id ) === referralId ),
+		agencyId,
+	};
+}

--- a/client/dashboard/agency/earn/referrals/lib/get-order-summary.ts
+++ b/client/dashboard/agency/earn/referrals/lib/get-order-summary.ts
@@ -1,0 +1,29 @@
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { getProductName } from './get-product-name';
+import type { AgencyProduct, ReferralApiResponse } from '@automattic/api-core';
+
+export const MAX_SUMMARY_PRODUCT_NAMES = 3;
+
+export function getOrderProductNames(
+	order: ReferralApiResponse,
+	products?: AgencyProduct[]
+): string[] {
+	return order.products.map( ( product ) => getProductName( product, products ) );
+}
+
+export function getOrderSummary( order: ReferralApiResponse, products?: AgencyProduct[] ) {
+	if ( ! order.products.length ) {
+		return __( 'Referral' );
+	}
+	const names = getOrderProductNames( order, products );
+	if ( names.length <= MAX_SUMMARY_PRODUCT_NAMES ) {
+		return names.join( ', ' );
+	}
+	const remaining = names.length - MAX_SUMMARY_PRODUCT_NAMES;
+	return sprintf(
+		/* translators: %1$s is a list of product names, %2$d is the number of products not shown */
+		_n( '%1$s, and %2$d more', '%1$s, and %2$d more', remaining ),
+		names.slice( 0, MAX_SUMMARY_PRODUCT_NAMES ).join( ', ' ),
+		remaining
+	);
+}

--- a/client/dashboard/agency/earn/referrals/lib/get-product-name.ts
+++ b/client/dashboard/agency/earn/referrals/lib/get-product-name.ts
@@ -1,0 +1,33 @@
+import type { AgencyProduct, ReferralPurchase } from '@automattic/api-core';
+
+/**
+ * A referral stores the product the client was offered, which may be a monthly,
+ * yearly, or alternative variant, so every catalog id has to be considered.
+ */
+export function findAgencyProduct(
+	productId: number,
+	products?: AgencyProduct[]
+): AgencyProduct | undefined {
+	return products?.find( ( product ) =>
+		[
+			product.product_id,
+			product.monthly_product_id,
+			product.yearly_product_id,
+			product.alternative_product_id,
+			product.monthly_alternative_product_id,
+			product.yearly_alternative_product_id,
+		].includes( productId )
+	);
+}
+
+/**
+ * The purchase only carries a subscription once the client has paid, so unpaid
+ * referrals fall back to the product catalog for a display name.
+ */
+export function getProductName( purchase: ReferralPurchase, products?: AgencyProduct[] ): string {
+	return (
+		purchase.subscription?.product_name ??
+		findAgencyProduct( purchase.product_id, products )?.name ??
+		`#${ purchase.product_id }`
+	);
+}

--- a/client/dashboard/agency/earn/referrals/lib/get-purchase-status.ts
+++ b/client/dashboard/agency/earn/referrals/lib/get-purchase-status.ts
@@ -1,0 +1,26 @@
+import { __ } from '@wordpress/i18n';
+import type { ReferralPurchase } from '@automattic/api-core';
+
+export type PurchaseStatusBadgeIntent = 'default' | 'info' | 'success' | 'warning' | 'error';
+
+/**
+ * A purchase reports its own status rather than its referral order's, so an
+ * unpaid one reads as "Awaiting payment" instead of the order's "Pending".
+ */
+export function getPurchaseStatus( purchase: ReferralPurchase ): {
+	status: string;
+	type: PurchaseStatusBadgeIntent;
+} {
+	if ( purchase.status === 'active' ) {
+		return purchase.site_assigned
+			? { status: __( 'Assigned' ), type: 'success' }
+			: { status: __( 'Unassigned' ), type: 'warning' };
+	}
+	if ( purchase.status === 'canceled' ) {
+		return { status: __( 'Canceled' ), type: 'info' };
+	}
+	if ( purchase.status === 'error' ) {
+		return { status: __( 'Error' ), type: 'error' };
+	}
+	return { status: __( 'Awaiting payment' ), type: 'warning' };
+}

--- a/client/dashboard/agency/earn/referrals/lib/get-purchase-total.ts
+++ b/client/dashboard/agency/earn/referrals/lib/get-purchase-total.ts
@@ -1,0 +1,44 @@
+import { formatCurrency } from '@automattic/number-formatters';
+import { __, sprintf } from '@wordpress/i18n';
+import type { AgencyProduct, ReferralPurchase } from '@automattic/api-core';
+
+/**
+ * Falls back to the catalog price while a referral is unpaid and has no
+ * subscription. Unlike the name lookup, this matches on `product_id` alone: the
+ * monthly and yearly variants are separate catalog entries with different
+ * amounts, so matching a variant ID would report the wrong price.
+ */
+export function getPurchaseTotal(
+	purchase: ReferralPurchase,
+	products?: AgencyProduct[]
+): string | null {
+	const product = products?.find( ( item ) => item.product_id === purchase.product_id );
+
+	let amount = Number( product?.amount );
+	let currency = 'USD';
+	let interval = 'month';
+
+	if ( purchase.subscription?.purchase_price ) {
+		amount = Number( purchase.subscription.purchase_price );
+		currency = purchase.subscription.purchase_currency ?? '';
+		interval = purchase.subscription.billing_interval_unit ?? '';
+	}
+
+	if ( ! amount ) {
+		return null;
+	}
+
+	const formatted = formatCurrency( amount, currency );
+
+	return interval === 'year'
+		? sprintf(
+				/* translators: %s is the price of the subscription per year, e.g. "US$25.00" */
+				__( '%s/yr' ),
+				formatted
+		  )
+		: sprintf(
+				/* translators: %s is the price of the subscription per month, e.g. "US$25.00" */
+				__( '%s/mo' ),
+				formatted
+		  );
+}

--- a/client/dashboard/agency/earn/referrals/lib/get-purchase-total.ts
+++ b/client/dashboard/agency/earn/referrals/lib/get-purchase-total.ts
@@ -15,8 +15,8 @@ export function getPurchaseTotal(
 	const product = products?.find( ( item ) => item.product_id === purchase.product_id );
 
 	let amount = Number( product?.amount );
-	let currency = 'USD';
-	let interval = 'month';
+	let currency = product?.currency ?? 'USD';
+	let interval = product?.price_interval ?? 'month';
 
 	if ( purchase.subscription?.purchase_price ) {
 		amount = Number( purchase.subscription.purchase_price );

--- a/client/dashboard/agency/earn/referrals/lib/referral-orders.ts
+++ b/client/dashboard/agency/earn/referrals/lib/referral-orders.ts
@@ -1,0 +1,28 @@
+import type { Referral, ReferralApiResponse, ReferralPurchase } from '@automattic/api-core';
+
+const INACTIVE_STATUSES = [ 'archived', 'canceled' ];
+
+/**
+ * Sorts archived and canceled referrals to the bottom, since they are no longer
+ * actionable. The sort is stable, so the API's order holds within each group.
+ */
+export function sortReferralOrders( orders: ReferralApiResponse[] ): ReferralApiResponse[] {
+	const rank = ( order: ReferralApiResponse ) =>
+		INACTIVE_STATUSES.includes( order.status ) ? 1 : 0;
+	return orders.slice().sort( ( a, b ) => rank( a ) - rank( b ) );
+}
+
+/**
+ * Purchases belonging to an archived referral are hidden: the client can no
+ * longer complete them, so they are not real purchases.
+ */
+export function getActivePurchases( referral: Referral ): ReferralPurchase[] {
+	const archivedReferralIds = new Set(
+		referral.referrals
+			.filter( ( order ) => order.status === 'archived' )
+			.map( ( order ) => order.id )
+	);
+	return referral.purchases.filter(
+		( purchase ) => ! archivedReferralIds.has( purchase.referral_id )
+	);
+}

--- a/client/dashboard/agency/earn/referrals/referral-sidebar/index.tsx
+++ b/client/dashboard/agency/earn/referrals/referral-sidebar/index.tsx
@@ -1,0 +1,39 @@
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { category, people, receipt } from '@wordpress/icons';
+import { SidebarBackButton, SidebarMenu, SidebarMenuItem } from '../../../../components/sidebar';
+import { useReferral } from '../hooks/use-referral';
+import ReferralSwitcherItem from './referral-switcher-item';
+
+export default function ReferralSidebar() {
+	const { referral, agencyId } = useReferral();
+	const referralId = referral ? String( referral.id ) : '';
+
+	return (
+		<VStack spacing={ 2 }>
+			<SidebarBackButton to="/earn/referrals">{ __( 'Back to Referrals' ) }</SidebarBackButton>
+			{ referral && (
+				<VStack spacing={ 4 }>
+					<SidebarMenu>
+						<ReferralSwitcherItem referral={ referral } agencyId={ agencyId } />
+					</SidebarMenu>
+					<SidebarMenu>
+						<SidebarMenuItem
+							icon={ category }
+							to={ `/earn/referrals/${ referralId }` }
+							activeOptions={ { exact: true } }
+						>
+							{ __( 'Overview' ) }
+						</SidebarMenuItem>
+						<SidebarMenuItem icon={ people } to={ `/earn/referrals/${ referralId }/orders` }>
+							{ __( 'Referrals' ) }
+						</SidebarMenuItem>
+						<SidebarMenuItem icon={ receipt } to={ `/earn/referrals/${ referralId }/purchases` }>
+							{ __( 'Purchases' ) }
+						</SidebarMenuItem>
+					</SidebarMenu>
+				</VStack>
+			) }
+		</VStack>
+	);
+}

--- a/client/dashboard/agency/earn/referrals/referral-sidebar/referral-switcher-item.tsx
+++ b/client/dashboard/agency/earn/referrals/referral-sidebar/referral-switcher-item.tsx
@@ -1,0 +1,49 @@
+import { __experimentalHStack as HStack, Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { chevronUpDown } from '@wordpress/icons';
+import { SidebarMenuSwitcherItem } from '../../../../components/sidebar';
+import { Text } from '../../../../components/text';
+import ReferralSwitcher from '../referral-switcher';
+import type { Referral } from '@automattic/api-core';
+
+export default function ReferralSwitcherItem( {
+	referral,
+	agencyId,
+}: {
+	referral: Referral;
+	agencyId: number;
+} ) {
+	return (
+		<SidebarMenuSwitcherItem
+			switcher={
+				<ReferralSwitcher
+					referral={ referral }
+					agencyId={ agencyId }
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<Button
+							variant="tertiary"
+							onClick={ onToggle }
+							onKeyDown={ ( event: React.KeyboardEvent ) => {
+								if ( ! isOpen && event.code === 'ArrowDown' ) {
+									event.preventDefault();
+									onToggle();
+								}
+							} }
+							aria-haspopup="true"
+							aria-expanded={ isOpen }
+							label={ __( 'Switch referral' ) }
+							icon={ chevronUpDown }
+							size="small"
+						/>
+					) }
+				/>
+			}
+		>
+			<HStack justify="flex-start" alignment="center">
+				<Text weight={ 500 } truncate numberOfLines={ 1 }>
+					{ referral.client.email }
+				</Text>
+			</HStack>
+		</SidebarMenuSwitcherItem>
+	);
+}

--- a/client/dashboard/agency/earn/referrals/referral-switcher/index.tsx
+++ b/client/dashboard/agency/earn/referrals/referral-switcher/index.tsx
@@ -1,0 +1,56 @@
+import { referralsQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import useBuildCurrentRouteLink from '../../../../app/hooks/use-build-current-route-link';
+import Switcher from '../../../../components/switcher';
+import { Text } from '../../../../components/text';
+import type { SwitcherProps } from '../../../../components/switcher';
+import type { Referral } from '@automattic/api-core';
+
+const searchableFields = [
+	{
+		id: 'client',
+		getValue: ( { item }: { item: Referral } ) => item.client.email,
+		enableGlobalSearch: true,
+	},
+];
+
+export type ReferralSwitcherProps = Pick< SwitcherProps< Referral >, 'renderToggle' > & {
+	referral: Referral;
+	agencyId: number;
+};
+
+export default function ReferralSwitcher( {
+	referral,
+	agencyId,
+	renderToggle,
+}: ReferralSwitcherProps ) {
+	const [ isOpen, setIsOpen ] = useState( false );
+	const { data: referrals } = useQuery( { ...referralsQuery( agencyId ), enabled: isOpen } );
+	const buildCurrentRouteLink = useBuildCurrentRouteLink();
+
+	return (
+		<Switcher< Referral >
+			items={ referrals }
+			value={ referral }
+			searchableFields={ searchableFields }
+			headerTitle={ __( 'Switch referral' ) }
+			getItemUrl={ ( item ) =>
+				buildCurrentRouteLink( { params: { referralId: String( item.id ) } } )
+			}
+			renderToggle={ renderToggle }
+			renderItem={ ( { item } ) => (
+				<Switcher.Item
+					title={
+						<Text truncate numberOfLines={ 1 } style={ { color: 'inherit' } }>
+							{ item.client.email }
+						</Text>
+					}
+				/>
+			) }
+			open={ isOpen }
+			onToggle={ setIsOpen }
+		/>
+	);
+}

--- a/client/dashboard/agency/earn/referrals/referral/not-found.tsx
+++ b/client/dashboard/agency/earn/referrals/referral/not-found.tsx
@@ -1,0 +1,16 @@
+import { __ } from '@wordpress/i18n';
+import { PageHeader } from '../../../../components/page-header';
+import PageLayout from '../../../../components/page-layout';
+
+export default function ReferralNotFound() {
+	return (
+		<PageLayout
+			header={
+				<PageHeader
+					title={ __( 'Referral not found' ) }
+					description={ __( 'This referral could not be found.' ) }
+				/>
+			}
+		/>
+	);
+}

--- a/client/dashboard/agency/earn/referrals/referral/order-summary.scss
+++ b/client/dashboard/agency/earn/referrals/referral/order-summary.scss
@@ -1,0 +1,5 @@
+.referrals-order-summary__tooltip {
+	max-width: 320px;
+	white-space: pre-line;
+	text-align: start;
+}

--- a/client/dashboard/agency/earn/referrals/referral/order-summary.tsx
+++ b/client/dashboard/agency/earn/referrals/referral/order-summary.tsx
@@ -1,0 +1,30 @@
+import { Tooltip } from '@wordpress/components';
+import {
+	getOrderProductNames,
+	getOrderSummary,
+	MAX_SUMMARY_PRODUCT_NAMES,
+} from '../lib/get-order-summary';
+import type { AgencyProduct, ReferralApiResponse } from '@automattic/api-core';
+
+import './order-summary.scss';
+
+export default function OrderSummary( {
+	order,
+	products,
+}: {
+	order: ReferralApiResponse;
+	products?: AgencyProduct[];
+} ) {
+	const summary = getOrderSummary( order, products );
+	const names = getOrderProductNames( order, products );
+
+	if ( names.length <= MAX_SUMMARY_PRODUCT_NAMES ) {
+		return <>{ summary }</>;
+	}
+
+	return (
+		<Tooltip className="referrals-order-summary__tooltip" text={ names.join( '\n' ) }>
+			<span>{ summary }</span>
+		</Tooltip>
+	);
+}

--- a/client/dashboard/agency/earn/referrals/referral/overview.tsx
+++ b/client/dashboard/agency/earn/referrals/referral/overview.tsx
@@ -78,7 +78,9 @@ const getPurchaseFields = ( products?: AgencyProduct[] ): Field< PurchaseItem >[
 export default function ReferralOverview() {
 	const locale = useLocale();
 	const { referral, agencyId } = useReferral();
-	const { data: commissionPayout } = useQuery( referralCommissionPayoutQuery( agencyId ) );
+	const { data: commissionPayout, isLoading: isLoadingCommissionPayout } = useQuery(
+		referralCommissionPayoutQuery( agencyId )
+	);
 	const { data: products } = useQuery( agencyProductsQuery( agencyId ) );
 
 	const referralFields = useMemo( () => getReferralFields( products ), [ products ] );
@@ -115,6 +117,7 @@ export default function ReferralOverview() {
 				isSingleClient
 				referrals={ [ referral ] }
 				referralCommissionPayout={ commissionPayout }
+				isLoadingCommissionPayout={ isLoadingCommissionPayout }
 				locale={ locale }
 			/>
 			<Grid templateColumns="repeat(auto-fit, minmax(320px, 1fr))" gap={ 6 } align="start">

--- a/client/dashboard/agency/earn/referrals/referral/overview.tsx
+++ b/client/dashboard/agency/earn/referrals/referral/overview.tsx
@@ -1,0 +1,162 @@
+import { agencyProductsQuery, referralCommissionPayoutQuery } from '@automattic/api-queries';
+import { Badge } from '@automattic/ui';
+import { useQuery } from '@tanstack/react-query';
+import { __experimentalGrid as Grid, __experimentalHStack as HStack } from '@wordpress/components';
+import { DataViews } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { useMemo } from 'react';
+import { useLocale } from '../../../../app/locale';
+import { PageHeader } from '../../../../components/page-header';
+import PageLayout from '../../../../components/page-layout';
+import { Text } from '../../../../components/text';
+import ConsolidatedViews from '../consolidated-views';
+import { useReferral } from '../hooks/use-referral';
+import { getOrderSummary } from '../lib/get-order-summary';
+import { getProductName } from '../lib/get-product-name';
+import { getPurchaseStatus } from '../lib/get-purchase-status';
+import { getReferralStatus } from '../lib/get-referral-status';
+import { getActivePurchases, sortReferralOrders } from '../lib/referral-orders';
+import SubscriptionStatus from '../subscription-status';
+import ReferralNotFound from './not-found';
+import OrderSummary from './order-summary';
+import PreviewListCard from './preview-list-card';
+import type { AgencyProduct, ReferralApiResponse, ReferralPurchase } from '@automattic/api-core';
+import type { Field, View } from '@wordpress/dataviews';
+
+type PurchaseItem = ReferralPurchase & { _id: string };
+
+const REFERRAL_LIST_VIEW: View = { type: 'list', titleField: 'summary', fields: [ 'status' ] };
+const PURCHASE_LIST_VIEW: View = { type: 'list', titleField: 'product', fields: [ 'status' ] };
+
+function StatusBadge( { status }: { status: string } ) {
+	const { status: label, type } = getReferralStatus( status );
+	return <Badge intent={ type }>{ label }</Badge>;
+}
+
+function PurchaseStatusBadge( { purchase }: { purchase: ReferralPurchase } ) {
+	const { status, type } = getPurchaseStatus( purchase );
+	return <Badge intent={ type }>{ status }</Badge>;
+}
+
+const getReferralFields = ( products?: AgencyProduct[] ): Field< ReferralApiResponse >[] => [
+	{
+		id: 'summary',
+		label: __( 'Referral' ),
+		enableHiding: false,
+		enableSorting: false,
+		getValue: ( { item } ) => getOrderSummary( item, products ),
+		render: ( { item } ) => <OrderSummary order={ item } products={ products } />,
+	},
+	{
+		id: 'status',
+		label: __( 'Status' ),
+		enableHiding: false,
+		enableSorting: false,
+		getValue: ( { item } ) => item.status,
+		render: ( { item } ) => <StatusBadge status={ item.status } />,
+	},
+];
+
+const getPurchaseFields = ( products?: AgencyProduct[] ): Field< PurchaseItem >[] => [
+	{
+		id: 'product',
+		label: __( 'Product' ),
+		enableHiding: false,
+		enableSorting: false,
+		getValue: ( { item } ) => getProductName( item, products ),
+	},
+	{
+		id: 'status',
+		label: __( 'Status' ),
+		enableHiding: false,
+		enableSorting: false,
+		getValue: ( { item } ) => item.status,
+		render: ( { item } ) => <PurchaseStatusBadge purchase={ item } />,
+	},
+];
+
+export default function ReferralOverview() {
+	const locale = useLocale();
+	const { referral, agencyId } = useReferral();
+	const { data: commissionPayout } = useQuery( referralCommissionPayoutQuery( agencyId ) );
+	const { data: products } = useQuery( agencyProductsQuery( agencyId ) );
+
+	const referralFields = useMemo( () => getReferralFields( products ), [ products ] );
+	const purchaseFields = useMemo( () => getPurchaseFields( products ), [ products ] );
+
+	if ( ! referral ) {
+		return <ReferralNotFound />;
+	}
+
+	const referralId = String( referral.id );
+	const recentReferrals = sortReferralOrders( referral.referrals ).slice( 0, 5 );
+	const recentPurchases: PurchaseItem[] = getActivePurchases( referral )
+		.slice( 0, 5 )
+		.map( ( purchase, index ) => ( {
+			...purchase,
+			_id: `${ purchase.referral_id }-${ purchase.product_id }-${ index }`,
+		} ) );
+
+	return (
+		<PageLayout
+			header={
+				<PageHeader
+					title={ referral.client.email }
+					description={
+						<HStack spacing={ 2 } justify="flex-start" alignment="center" expanded={ false }>
+							<Text>{ __( 'Payment status' ) }</Text>
+							<SubscriptionStatus item={ referral } />
+						</HStack>
+					}
+				/>
+			}
+		>
+			<ConsolidatedViews
+				isSingleClient
+				referrals={ [ referral ] }
+				referralCommissionPayout={ commissionPayout }
+				locale={ locale }
+			/>
+			<Grid templateColumns="repeat(auto-fit, minmax(320px, 1fr))" gap={ 6 } align="start">
+				<PreviewListCard
+					title={ __( 'Recent referrals' ) }
+					isEmpty={ recentReferrals.length === 0 }
+					emptyText={ __( 'No referrals yet.' ) }
+					seeAllTitle={ __( 'See all referrals' ) }
+					seeAllHref={ `/earn/referrals/${ referralId }/orders` }
+				>
+					<DataViews< ReferralApiResponse >
+						data={ recentReferrals }
+						fields={ referralFields }
+						view={ REFERRAL_LIST_VIEW }
+						onChangeView={ () => {} }
+						getItemId={ ( item ) => String( item.id ) }
+						paginationInfo={ { totalItems: recentReferrals.length, totalPages: 1 } }
+						defaultLayouts={ { list: {} } }
+					>
+						<DataViews.Layout />
+					</DataViews>
+				</PreviewListCard>
+				<PreviewListCard
+					title={ __( 'Recent purchases' ) }
+					isEmpty={ recentPurchases.length === 0 }
+					emptyText={ __( 'No purchases yet.' ) }
+					seeAllTitle={ __( 'See all purchases' ) }
+					seeAllHref={ `/earn/referrals/${ referralId }/purchases` }
+				>
+					<DataViews< PurchaseItem >
+						data={ recentPurchases }
+						fields={ purchaseFields }
+						view={ PURCHASE_LIST_VIEW }
+						onChangeView={ () => {} }
+						getItemId={ ( item ) => item._id }
+						paginationInfo={ { totalItems: recentPurchases.length, totalPages: 1 } }
+						defaultLayouts={ { list: {} } }
+					>
+						<DataViews.Layout />
+					</DataViews>
+				</PreviewListCard>
+			</Grid>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/agency/earn/referrals/referral/preview-list-card.scss
+++ b/client/dashboard/agency/earn/referrals/referral/preview-list-card.scss
@@ -1,0 +1,22 @@
+// The preview lists are read-only, but the DataViews list layout renders a
+// clickable selection overlay and applies an accent-colored hover to each row.
+// Neutralize both so the rows look static (same intent as the Site overview's
+// Latest activity card).
+.referrals-preview-list-card {
+	.dataviews-view-list {
+		button.dataviews-view-list__item {
+			display: none;
+		}
+
+		div[role="row"]:not(.is-selected):hover {
+			color: inherit;
+			background-color: transparent;
+
+			.dataviews-view-list__title-field,
+			.dataviews-title-field,
+			.dataviews-view-list__fields {
+				color: inherit;
+			}
+		}
+	}
+}

--- a/client/dashboard/agency/earn/referrals/referral/preview-list-card.tsx
+++ b/client/dashboard/agency/earn/referrals/referral/preview-list-card.tsx
@@ -1,0 +1,37 @@
+import { Card, CardHeader, CardBody } from '../../../../components/card';
+import { SectionHeader } from '../../../../components/section-header';
+import { SummaryButtonCardFooter } from '../../../../components/summary-button-card-footer';
+import { Text } from '../../../../components/text';
+import type { ReactNode } from 'react';
+
+import './preview-list-card.scss';
+
+interface PreviewListCardProps {
+	title: string;
+	isEmpty: boolean;
+	emptyText: string;
+	seeAllTitle: string;
+	seeAllHref: string;
+	children: ReactNode;
+}
+
+export default function PreviewListCard( {
+	title,
+	isEmpty,
+	emptyText,
+	seeAllTitle,
+	seeAllHref,
+	children,
+}: PreviewListCardProps ) {
+	return (
+		<Card className="referrals-preview-list-card">
+			<CardHeader>
+				<SectionHeader title={ title } level={ 3 } />
+			</CardHeader>
+			<CardBody>{ isEmpty ? <Text variant="muted">{ emptyText }</Text> : children }</CardBody>
+			{ ! isEmpty && (
+				<SummaryButtonCardFooter title={ seeAllTitle } href={ seeAllHref } density="medium" />
+			) }
+		</Card>
+	);
+}

--- a/client/dashboard/agency/earn/referrals/referral/purchase-site-details.tsx
+++ b/client/dashboard/agency/earn/referrals/referral/purchase-site-details.tsx
@@ -1,0 +1,56 @@
+import { Badge } from '@automattic/ui';
+import { ExternalLink, Tooltip } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import RouterLinkButton from '../../../../components/router-link-button';
+import { urlToSlug } from '../../../../utils/url';
+import { findAgencyProduct } from '../lib/get-product-name';
+import { getPurchaseStatus } from '../lib/get-purchase-status';
+import type { AgencyProduct, ReferralPurchase } from '@automattic/api-core';
+
+const PRESSABLE_AUTH_URL = 'https://my.pressable.com/agency/auth';
+
+export default function PurchaseSiteDetails( {
+	purchase,
+	products,
+}: {
+	purchase: ReferralPurchase;
+	products?: AgencyProduct[];
+} ) {
+	const licenseKey = purchase.license?.license_key ?? '';
+
+	if ( licenseKey.startsWith( 'pressable-' ) ) {
+		return <ExternalLink href={ PRESSABLE_AUTH_URL }>{ __( 'Manage in Pressable' ) }</ExternalLink>;
+	}
+
+	if ( purchase.site_assigned ) {
+		const product = findAgencyProduct( purchase.product_id, products );
+		if ( product?.slug.startsWith( 'pressable' ) ) {
+			return <Badge intent="success">{ __( 'Pressable' ) }</Badge>;
+		}
+
+		const siteSlug = urlToSlug( purchase.site_assigned );
+		return (
+			<RouterLinkButton variant="link" to="/sites/$siteSlug" params={ { siteSlug } }>
+				{ siteSlug }
+			</RouterLinkButton>
+		);
+	}
+
+	const { status, type } = getPurchaseStatus( purchase );
+	const badge = <Badge intent={ type }>{ status }</Badge>;
+
+	if ( purchase.status !== 'pending' ) {
+		return badge;
+	}
+
+	const tooltip = licenseKey.startsWith( 'wpcom-hosting' )
+		? __( 'When your client pays, you can initiate this site.' )
+		: __( 'When your client pays, you can assign this product to a site.' );
+
+	// Badge does not forward refs, so Tooltip needs a DOM element to anchor to.
+	return (
+		<Tooltip text={ tooltip }>
+			<span style={ { display: 'inline-flex' } }>{ badge }</span>
+		</Tooltip>
+	);
+}

--- a/client/dashboard/agency/earn/referrals/referral/purchases.tsx
+++ b/client/dashboard/agency/earn/referrals/referral/purchases.tsx
@@ -1,0 +1,102 @@
+import { agencyProductsQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+import { useMemo, useState } from 'react';
+import { useLocale } from '../../../../app/locale';
+import { DataViews, DataViewsCard } from '../../../../components/dataviews';
+import { PageHeader } from '../../../../components/page-header';
+import PageLayout from '../../../../components/page-layout';
+import { formatDate } from '../../../../utils/datetime';
+import { useReferral } from '../hooks/use-referral';
+import { getProductName } from '../lib/get-product-name';
+import { getPurchaseTotal } from '../lib/get-purchase-total';
+import { getActivePurchases } from '../lib/referral-orders';
+import ReferralNotFound from './not-found';
+import PurchaseSiteDetails from './purchase-site-details';
+import type { ReferralPurchase } from '@automattic/api-core';
+import type { Field, View } from '@wordpress/dataviews';
+
+type PurchaseItem = ReferralPurchase & { _id: string };
+
+const DEFAULT_VIEW: View = {
+	type: 'table',
+	page: 1,
+	perPage: 20,
+	titleField: 'product',
+	fields: [ 'site', 'date', 'total' ],
+};
+
+export default function ReferralPurchases() {
+	const locale = useLocale();
+	const { referral, agencyId } = useReferral();
+	const { data: products } = useQuery( agencyProductsQuery( agencyId ) );
+	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+
+	const items = useMemo< PurchaseItem[] >(
+		() =>
+			( referral ? getActivePurchases( referral ) : [] ).map( ( purchase, index ) => ( {
+				...purchase,
+				_id: `${ purchase.referral_id }-${ purchase.product_id }-${ index }`,
+			} ) ),
+		[ referral ]
+	);
+
+	const fields = useMemo< Field< PurchaseItem >[] >(
+		() => [
+			{
+				id: 'product',
+				label: __( 'Product details' ),
+				enableHiding: false,
+				enableSorting: false,
+				getValue: ( { item } ) => getProductName( item, products ),
+			},
+			{
+				id: 'site',
+				label: __( 'Site details' ),
+				enableHiding: false,
+				enableSorting: false,
+				getValue: ( { item } ) => item.site_assigned || item.status,
+				render: ( { item } ) => <PurchaseSiteDetails purchase={ item } products={ products } />,
+			},
+			{
+				id: 'date',
+				label: __( 'Assigned on' ),
+				enableHiding: false,
+				enableSorting: false,
+				getValue: ( { item } ) =>
+					( item.license?.attached_at &&
+						formatDate( new Date( item.license.attached_at ), locale ) ) ||
+					'—',
+			},
+			{
+				id: 'total',
+				label: __( 'Total' ),
+				enableHiding: false,
+				enableSorting: false,
+				getValue: ( { item } ) => getPurchaseTotal( item, products ) ?? '—',
+			},
+		],
+		[ locale, products ]
+	);
+
+	if ( ! referral ) {
+		return <ReferralNotFound />;
+	}
+
+	return (
+		<PageLayout header={ <PageHeader title={ __( 'Purchases' ) } /> }>
+			<DataViewsCard>
+				<DataViews< PurchaseItem >
+					data={ items }
+					fields={ fields }
+					view={ view }
+					onChangeView={ setView }
+					search={ false }
+					getItemId={ ( item ) => item._id }
+					defaultLayouts={ { table: { titleField: 'product' } } }
+					paginationInfo={ { totalItems: items.length, totalPages: 1 } }
+				/>
+			</DataViewsCard>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/agency/earn/referrals/referral/purchases.tsx
+++ b/client/dashboard/agency/earn/referrals/referral/purchases.tsx
@@ -1,5 +1,6 @@
 import { agencyProductsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
 import { useLocale } from '../../../../app/locale';
@@ -79,6 +80,11 @@ export default function ReferralPurchases() {
 		[ locale, products ]
 	);
 
+	const { data: paginatedItems, paginationInfo } = useMemo(
+		() => filterSortAndPaginate( items, view, fields ),
+		[ items, view, fields ]
+	);
+
 	if ( ! referral ) {
 		return <ReferralNotFound />;
 	}
@@ -87,14 +93,14 @@ export default function ReferralPurchases() {
 		<PageLayout header={ <PageHeader title={ __( 'Purchases' ) } /> }>
 			<DataViewsCard>
 				<DataViews< PurchaseItem >
-					data={ items }
+					data={ paginatedItems }
 					fields={ fields }
 					view={ view }
 					onChangeView={ setView }
 					search={ false }
 					getItemId={ ( item ) => item._id }
 					defaultLayouts={ { table: { titleField: 'product' } } }
-					paginationInfo={ { totalItems: items.length, totalPages: 1 } }
+					paginationInfo={ paginationInfo }
 				/>
 			</DataViewsCard>
 		</PageLayout>

--- a/client/dashboard/agency/earn/referrals/referral/referrals-tab.tsx
+++ b/client/dashboard/agency/earn/referrals/referral/referrals-tab.tsx
@@ -6,9 +6,11 @@ import {
 import { Badge } from '@automattic/ui';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState } from 'react';
+import { useAnalytics } from '../../../../app/analytics';
 import ConfirmModal from '../../../../components/confirm-modal';
 import { DataViews, DataViewsCard } from '../../../../components/dataviews';
 import { PageHeader } from '../../../../components/page-header';
@@ -35,6 +37,7 @@ export default function ReferralReferralsTab() {
 	const { data: products } = useQuery( agencyProductsQuery( agencyId ) );
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 
+	const { recordTracksEvent } = useAnalytics();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { mutate: archiveReferral } = useMutation( archiveReferralMutation( agencyId ) );
 	const { mutate: resendReferralEmail } = useMutation( resendReferralEmailMutation( agencyId ) );
@@ -75,6 +78,7 @@ export default function ReferralReferralsTab() {
 					if ( ! order ) {
 						return;
 					}
+					recordTracksEvent( 'calypso_a4a_referrals_resend_email_button_click' );
 					resendReferralEmail( order.id, {
 						onSuccess: () =>
 							createSuccessNotice( __( 'The referral email has been resent.' ), {
@@ -96,13 +100,14 @@ export default function ReferralReferralsTab() {
 					if ( ! order?.checkout_url ) {
 						return;
 					}
+					recordTracksEvent( 'calypso_a4a_referrals_copy_link_button_click' );
 					navigator.clipboard
 						.writeText( order.checkout_url )
 						.then( () =>
 							createSuccessNotice( __( 'Link copied to clipboard.' ), { type: 'snackbar' } )
 						)
 						.catch( () =>
-							createErrorNotice( __( 'Could not copy the link to clipboard.' ), {
+							createErrorNotice( __( 'Failed to copy the link to clipboard.' ), {
 								type: 'snackbar',
 							} )
 						);
@@ -123,6 +128,7 @@ export default function ReferralReferralsTab() {
 							onCancel={ () => closeModal?.() }
 							onConfirm={ () => {
 								if ( order ) {
+									recordTracksEvent( 'calypso_a4a_referrals_archive_referral_button_click' );
 									archiveReferral( order.id, {
 										onSuccess: () =>
 											createSuccessNotice( __( 'The referral has been archived.' ), {
@@ -145,12 +151,23 @@ export default function ReferralReferralsTab() {
 				},
 			},
 		],
-		[ archiveReferral, resendReferralEmail, createSuccessNotice, createErrorNotice ]
+		[
+			archiveReferral,
+			resendReferralEmail,
+			createSuccessNotice,
+			createErrorNotice,
+			recordTracksEvent,
+		]
 	);
 
 	const orders = useMemo(
 		() => ( referral ? sortReferralOrders( referral.referrals ) : [] ),
 		[ referral ]
+	);
+
+	const { data: paginatedOrders, paginationInfo } = useMemo(
+		() => filterSortAndPaginate( orders, view, fields ),
+		[ orders, view, fields ]
 	);
 
 	if ( ! referral ) {
@@ -161,7 +178,7 @@ export default function ReferralReferralsTab() {
 		<PageLayout header={ <PageHeader title={ __( 'Referrals' ) } /> }>
 			<DataViewsCard>
 				<DataViews< ReferralApiResponse >
-					data={ orders }
+					data={ paginatedOrders }
 					fields={ fields }
 					actions={ actions }
 					view={ view }
@@ -169,7 +186,7 @@ export default function ReferralReferralsTab() {
 					search={ false }
 					getItemId={ ( item ) => String( item.id ) }
 					defaultLayouts={ { table: { titleField: 'summary' } } }
-					paginationInfo={ { totalItems: orders.length, totalPages: 1 } }
+					paginationInfo={ paginationInfo }
 				/>
 			</DataViewsCard>
 		</PageLayout>

--- a/client/dashboard/agency/earn/referrals/referral/referrals-tab.tsx
+++ b/client/dashboard/agency/earn/referrals/referral/referrals-tab.tsx
@@ -1,0 +1,177 @@
+import {
+	agencyProductsQuery,
+	archiveReferralMutation,
+	resendReferralEmailMutation,
+} from '@automattic/api-queries';
+import { Badge } from '@automattic/ui';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useMemo, useState } from 'react';
+import ConfirmModal from '../../../../components/confirm-modal';
+import { DataViews, DataViewsCard } from '../../../../components/dataviews';
+import { PageHeader } from '../../../../components/page-header';
+import PageLayout from '../../../../components/page-layout';
+import { useReferral } from '../hooks/use-referral';
+import { getOrderSummary } from '../lib/get-order-summary';
+import { getReferralStatus } from '../lib/get-referral-status';
+import { sortReferralOrders } from '../lib/referral-orders';
+import ReferralNotFound from './not-found';
+import OrderSummary from './order-summary';
+import type { ReferralApiResponse } from '@automattic/api-core';
+import type { Action, Field, View } from '@wordpress/dataviews';
+
+const DEFAULT_VIEW: View = {
+	type: 'table',
+	page: 1,
+	perPage: 20,
+	titleField: 'summary',
+	fields: [ 'status' ],
+};
+
+export default function ReferralReferralsTab() {
+	const { referral, agencyId } = useReferral();
+	const { data: products } = useQuery( agencyProductsQuery( agencyId ) );
+	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { mutate: archiveReferral } = useMutation( archiveReferralMutation( agencyId ) );
+	const { mutate: resendReferralEmail } = useMutation( resendReferralEmailMutation( agencyId ) );
+
+	const fields = useMemo< Field< ReferralApiResponse >[] >(
+		() => [
+			{
+				id: 'summary',
+				label: __( 'Referral' ),
+				enableHiding: false,
+				enableSorting: false,
+				getValue: ( { item } ) => getOrderSummary( item, products ),
+				render: ( { item } ) => <OrderSummary order={ item } products={ products } />,
+			},
+			{
+				id: 'status',
+				label: __( 'Status' ),
+				enableHiding: false,
+				enableSorting: false,
+				getValue: ( { item } ) => item.status,
+				render: ( { item } ) => {
+					const { status, type } = getReferralStatus( item.status );
+					return <Badge intent={ type }>{ status }</Badge>;
+				},
+			},
+		],
+		[ products ]
+	);
+
+	const actions = useMemo< Action< ReferralApiResponse >[] >(
+		() => [
+			{
+				id: 'resend-email',
+				label: __( 'Resend email' ),
+				isEligible: ( item ) => item.status === 'pending',
+				callback: ( items ) => {
+					const order = items[ 0 ];
+					if ( ! order ) {
+						return;
+					}
+					resendReferralEmail( order.id, {
+						onSuccess: () =>
+							createSuccessNotice( __( 'The referral email has been resent.' ), {
+								type: 'snackbar',
+							} ),
+						onError: () =>
+							createErrorNotice( __( 'Failed to resend the referral email.' ), {
+								type: 'snackbar',
+							} ),
+					} );
+				},
+			},
+			{
+				id: 'copy-link',
+				label: __( 'Copy link' ),
+				isEligible: ( item ) => item.status === 'pending' && !! item.checkout_url,
+				callback: ( items ) => {
+					const order = items[ 0 ];
+					if ( ! order?.checkout_url ) {
+						return;
+					}
+					navigator.clipboard
+						.writeText( order.checkout_url )
+						.then( () =>
+							createSuccessNotice( __( 'Link copied to clipboard.' ), { type: 'snackbar' } )
+						)
+						.catch( () =>
+							createErrorNotice( __( 'Could not copy the link to clipboard.' ), {
+								type: 'snackbar',
+							} )
+						);
+				},
+			},
+			{
+				id: 'archive',
+				label: __( 'Archive' ),
+				isDestructive: true,
+				isEligible: ( item ) => item.status !== 'archived' && item.status !== 'active',
+				RenderModal: ( { items, closeModal } ) => {
+					const order = items[ 0 ];
+					return (
+						<ConfirmModal
+							isOpen
+							title={ __( 'Archive referral' ) }
+							confirmButtonProps={ { children: __( 'Archive' ), isDestructive: true } }
+							onCancel={ () => closeModal?.() }
+							onConfirm={ () => {
+								if ( order ) {
+									archiveReferral( order.id, {
+										onSuccess: () =>
+											createSuccessNotice( __( 'The referral has been archived.' ), {
+												type: 'snackbar',
+											} ),
+										onError: () =>
+											createErrorNotice( __( 'Failed to archive the referral.' ), {
+												type: 'snackbar',
+											} ),
+									} );
+								}
+								closeModal?.();
+							} }
+						>
+							{ __(
+								"Your client won't be able to complete the purchases. If removed, you must create a new referral for any future purchases."
+							) }
+						</ConfirmModal>
+					);
+				},
+			},
+		],
+		[ archiveReferral, resendReferralEmail, createSuccessNotice, createErrorNotice ]
+	);
+
+	const orders = useMemo(
+		() => ( referral ? sortReferralOrders( referral.referrals ) : [] ),
+		[ referral ]
+	);
+
+	if ( ! referral ) {
+		return <ReferralNotFound />;
+	}
+
+	return (
+		<PageLayout header={ <PageHeader title={ __( 'Referrals' ) } /> }>
+			<DataViewsCard>
+				<DataViews< ReferralApiResponse >
+					data={ orders }
+					fields={ fields }
+					actions={ actions }
+					view={ view }
+					onChangeView={ setView }
+					search={ false }
+					getItemId={ ( item ) => String( item.id ) }
+					defaultLayouts={ { table: { titleField: 'summary' } } }
+					paginationInfo={ { totalItems: orders.length, totalPages: 1 } }
+				/>
+			</DataViewsCard>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/agency/earn/referrals/referral/referrals-tab.tsx
+++ b/client/dashboard/agency/earn/referrals/referral/referrals-tab.tsx
@@ -5,16 +5,21 @@ import {
 } from '@automattic/api-queries';
 import { Badge } from '@automattic/ui';
 import { useMutation, useQuery } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+} from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState } from 'react';
 import { useAnalytics } from '../../../../app/analytics';
-import ConfirmModal from '../../../../components/confirm-modal';
 import { DataViews, DataViewsCard } from '../../../../components/dataviews';
 import { PageHeader } from '../../../../components/page-header';
 import PageLayout from '../../../../components/page-layout';
+import { Text } from '../../../../components/text';
 import { useReferral } from '../hooks/use-referral';
 import { getOrderSummary } from '../lib/get-order-summary';
 import { getReferralStatus } from '../lib/get-referral-status';
@@ -39,7 +44,9 @@ export default function ReferralReferralsTab() {
 
 	const { recordTracksEvent } = useAnalytics();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const { mutate: archiveReferral } = useMutation( archiveReferralMutation( agencyId ) );
+	const { mutate: archiveReferral, isPending: isArchiving } = useMutation(
+		archiveReferralMutation( agencyId )
+	);
 	const { mutate: resendReferralEmail } = useMutation( resendReferralEmailMutation( agencyId ) );
 
 	const fields = useMemo< Field< ReferralApiResponse >[] >(
@@ -120,39 +127,60 @@ export default function ReferralReferralsTab() {
 				isEligible: ( item ) => item.status !== 'archived' && item.status !== 'active',
 				RenderModal: ( { items, closeModal } ) => {
 					const order = items[ 0 ];
+					const onConfirm = () => {
+						if ( ! order ) {
+							return;
+						}
+						recordTracksEvent( 'calypso_a4a_referrals_archive_referral_button_click' );
+						archiveReferral( order.id, {
+							onSuccess: () =>
+								createSuccessNotice( __( 'The referral has been archived.' ), {
+									type: 'snackbar',
+								} ),
+							onError: () =>
+								createErrorNotice( __( 'Failed to archive the referral.' ), {
+									type: 'snackbar',
+								} ),
+						} );
+						closeModal?.();
+					};
 					return (
-						<ConfirmModal
-							isOpen
-							title={ __( 'Archive referral' ) }
-							confirmButtonProps={ { children: __( 'Archive' ), isDestructive: true } }
-							onCancel={ () => closeModal?.() }
-							onConfirm={ () => {
-								if ( order ) {
-									recordTracksEvent( 'calypso_a4a_referrals_archive_referral_button_click' );
-									archiveReferral( order.id, {
-										onSuccess: () =>
-											createSuccessNotice( __( 'The referral has been archived.' ), {
-												type: 'snackbar',
-											} ),
-										onError: () =>
-											createErrorNotice( __( 'Failed to archive the referral.' ), {
-												type: 'snackbar',
-											} ),
-									} );
-								}
-								closeModal?.();
-							} }
-						>
-							{ __(
-								"Your client won't be able to complete the purchases. If removed, you must create a new referral for any future purchases."
-							) }
-						</ConfirmModal>
+						<VStack spacing={ 4 }>
+							<Text>
+								{ __(
+									"Your client won't be able to complete the purchases. If removed, you must create a new referral for any future purchases."
+								) }
+							</Text>
+							<HStack justify="right">
+								<Button
+									__next40pxDefaultSize
+									variant="tertiary"
+									onClick={ () => closeModal?.() }
+									disabled={ isArchiving }
+									accessibleWhenDisabled
+								>
+									{ __( 'Cancel' ) }
+								</Button>
+								<Button
+									__next40pxDefaultSize
+									variant="primary"
+									onClick={ onConfirm }
+									isBusy={ isArchiving }
+									disabled={ isArchiving }
+									accessibleWhenDisabled
+									isDestructive
+								>
+									{ __( 'Archive' ) }
+								</Button>
+							</HStack>
+						</VStack>
 					);
 				},
 			},
 		],
 		[
 			archiveReferral,
+			isArchiving,
 			resendReferralEmail,
 			createSuccessNotice,
 			createErrorNotice,

--- a/client/dashboard/app/responsive-sidebar/sidebar.tsx
+++ b/client/dashboard/app/responsive-sidebar/sidebar.tsx
@@ -1,6 +1,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { brush, envelope, globe, layout, plugins } from '@wordpress/icons';
 import { useRef } from 'react';
+import ReferralSidebar from '../../agency/earn/referrals/referral-sidebar';
 import AgencySiteSidebar from '../../agency/sites/site-sidebar';
 import RouterLinkButton from '../../components/router-link-button';
 import { SidebarExpandableMenuItem, SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
@@ -49,6 +50,9 @@ export default function Sidebar( { scrollSyncEnabled = false }: { scrollSyncEnab
 				</SidebarNavigator.Screen>
 				<SidebarNavigator.Screen path="/agency/sites/$siteSlug">
 					<AgencySiteSidebar />
+				</SidebarNavigator.Screen>
+				<SidebarNavigator.Screen path="/agency/earn/referrals/$referralId">
+					<ReferralSidebar />
 				</SidebarNavigator.Screen>
 				<SidebarNavigator.Screen path="/domains/$domainName">
 					<DomainSidebar />

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -1,5 +1,6 @@
 import {
 	activeAgencyQuery,
+	agencyProductsQuery,
 	agencyQuery,
 	agencyResourcesQuery,
 	agencySiteQuery,
@@ -10,8 +11,10 @@ import {
 	siteBySlugQuery,
 	siteScanQuery,
 	siteSettingsQuery,
+	referralsQuery,
+	referralCommissionPayoutQuery,
 } from '@automattic/api-queries';
-import { createRoute, createLazyRoute, notFound } from '@tanstack/react-router';
+import { createRoute, createLazyRoute, notFound, Outlet } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { dashboardRedirect, redirectAsNotAllowed } from './redirect';
 import { rootRoute } from './root';
@@ -256,6 +259,54 @@ const earnPayoutSettingsRoute = createRoute( {
 	)
 );
 
+// `/earn/referrals/$referralId` – referral (client) detail view; hosts the tab routes
+export const earnReferralRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Referral details' ) } ] } ),
+	getParentRoute: () => agencyRoute,
+	path: 'earn/referrals/$referralId',
+	loader: async () => {
+		const agency = await queryClient.ensureQueryData( activeAgencyQuery() );
+		const agencyId = agency?.id ?? 0;
+		if ( agencyId ) {
+			await Promise.all( [
+				queryClient.ensureQueryData( referralsQuery( agencyId ) ),
+				queryClient.ensureQueryData( agencyProductsQuery( agencyId ) ).catch( () => undefined ),
+			] );
+			queryClient.prefetchQuery( referralCommissionPayoutQuery( agencyId ) );
+		}
+	},
+	component: Outlet,
+} );
+
+const earnReferralOverviewRoute = createRoute( {
+	getParentRoute: () => earnReferralRoute,
+	path: '/',
+} ).lazy( () =>
+	import( '../../agency/earn/referrals/referral/overview' ).then( ( d ) =>
+		createLazyRoute( 'earn-referral-overview' )( { component: d.default } )
+	)
+);
+
+const earnReferralOrdersRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Referrals' ) } ] } ),
+	getParentRoute: () => earnReferralRoute,
+	path: 'orders',
+} ).lazy( () =>
+	import( '../../agency/earn/referrals/referral/referrals-tab' ).then( ( d ) =>
+		createLazyRoute( 'earn-referral-orders' )( { component: d.default } )
+	)
+);
+
+const earnReferralPurchasesRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Purchases' ) } ] } ),
+	getParentRoute: () => earnReferralRoute,
+	path: 'purchases',
+} ).lazy( () =>
+	import( '../../agency/earn/referrals/referral/purchases' ).then( ( d ) =>
+		createLazyRoute( 'earn-referral-purchases' )( { component: d.default } )
+	)
+);
+
 // `/sites/$siteSlug` – agency site detail (a layout that hosts the section routes)
 export const agencySiteRoute = createRoute( {
 	getParentRoute: () => agencyRoute,
@@ -475,6 +526,11 @@ export const createAgencyRoutes = () => [
 		earnWooPaymentsRoute,
 		earnMigrationsRoute,
 		earnPayoutSettingsRoute,
+		earnReferralRoute.addChildren( [
+			earnReferralOverviewRoute,
+			earnReferralOrdersRoute,
+			earnReferralPurchasesRoute,
+		] ),
 		agencySiteRoute.addChildren( [
 			agencySiteOverviewRoute,
 			agencySiteBackupsRoute.addChildren( [

--- a/packages/api-core/src/agency-products/fetchers.ts
+++ b/packages/api-core/src/agency-products/fetchers.ts
@@ -1,0 +1,12 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { AgencyProductFamily } from './types';
+
+export async function fetchAgencyProducts( agencyId: number ): Promise< AgencyProductFamily[] > {
+	return wpcom.req.get(
+		{
+			path: '/jetpack-licensing/partner/product-families',
+			apiNamespace: 'wpcom/v2',
+		},
+		{ agency_id: agencyId }
+	);
+}

--- a/packages/api-core/src/agency-products/index.ts
+++ b/packages/api-core/src/agency-products/index.ts
@@ -1,0 +1,2 @@
+export * from './fetchers';
+export * from './types';

--- a/packages/api-core/src/agency-products/types.ts
+++ b/packages/api-core/src/agency-products/types.ts
@@ -1,0 +1,21 @@
+export interface AgencyProduct {
+	name: string;
+	slug: string;
+	product_id: number;
+	monthly_product_id?: number;
+	yearly_product_id?: number;
+	alternative_product_id?: number;
+	monthly_alternative_product_id?: number;
+	yearly_alternative_product_id?: number;
+	currency: string;
+	amount: string;
+	price_interval: string;
+	/** Not in the API response — added client-side from the parent family. */
+	family_slug: string;
+}
+
+export interface AgencyProductFamily {
+	name: string;
+	slug: string;
+	products: Omit< AgencyProduct, 'family_slug' >[];
+}

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -4,6 +4,7 @@ export * from './error';
 
 export * from './admin-bar';
 export * from './agency';
+export * from './agency-products';
 export * from './agency-referrals';
 export * from './agency-team';
 export * from './agency-sites';

--- a/packages/api-queries/src/agency-products.ts
+++ b/packages/api-queries/src/agency-products.ts
@@ -1,0 +1,18 @@
+import { fetchAgencyProducts } from '@automattic/api-core';
+import { queryOptions } from '@tanstack/react-query';
+import type { AgencyProduct, AgencyProductFamily } from '@automattic/api-core';
+
+function flattenFamilies( families: AgencyProductFamily[] ): AgencyProduct[] {
+	return families.flatMap( ( family ) =>
+		family.products.map( ( product ) => ( { ...product, family_slug: family.slug } ) )
+	);
+}
+
+export const agencyProductsQuery = ( agencyId: number ) =>
+	queryOptions( {
+		queryKey: [ 'agency', agencyId, 'products' ] as const,
+		queryFn: () => fetchAgencyProducts( agencyId ),
+		select: flattenFamilies,
+		enabled: !! agencyId,
+		staleTime: 5 * 60 * 1000,
+	} );

--- a/packages/api-queries/src/agency-products.ts
+++ b/packages/api-queries/src/agency-products.ts
@@ -11,8 +11,7 @@ function flattenFamilies( families: AgencyProductFamily[] ): AgencyProduct[] {
 export const agencyProductsQuery = ( agencyId: number ) =>
 	queryOptions( {
 		queryKey: [ 'agency', agencyId, 'products' ] as const,
-		queryFn: () => fetchAgencyProducts( agencyId ),
-		select: flattenFamilies,
+		queryFn: async () => flattenFamilies( await fetchAgencyProducts( agencyId ) ),
 		enabled: !! agencyId,
 		staleTime: 5 * 60 * 1000,
 	} );

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -1,6 +1,7 @@
 export * from './query-client';
 
 export * from './agency';
+export * from './agency-products';
 export * from './agency-referrals';
 export * from './agency-team';
 export * from './agency-sites';


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/112638.

Part of A4A-2845

## Proposed Changes

* Add a detail view for a client, opened from the Referrals list, with three tabs:
  * **Overview** — the client's payment status, their commission cards, and the five most recent referrals and purchases side by side.
  * **Referrals** — every referral order for that client, with actions to resend the email, copy the checkout link, or archive.
  * **Purchases** — what the client has bought, with the site it is assigned to, the date, and the total.
* Add a client switcher to the sidebar so you can move between clients without going back to the list.
* Show product names and prices for referrals that have not been paid for yet. 
* Sort archived and cancelled referrals to the bottom of the list, and hide purchases belonging to an archived referral, matching the classic app.

## Why are these changes being made?

The Referrals list only tells you how a client is doing in aggregate. Agencies need to see the individual orders and purchases behind that, which is what the classic app offers today.

The classic app's detail view is not supported in the new dashboard, so this follows the same switcher pattern already used for site details.

## Testing Instructions

1. Open the Dashboard Live (A4A) link > Replace the `/sites` from the URL with `/overview` to see the A4A dashboard and go to **Earn → Referrals**.
2. Click a client to open their detail view.
3. On **Overview**, confirm the payment status, the commission cards, and the two recent lists. Use "See all" on each to jump to the matching tab.
4. On **Purchases**, confirm product names show for unpaid referrals, and that a price appears in Total. Compare against the same client at `/referrals/dashboard` in the classic app — they should match.
5. On **Referrals**, confirm archived and canceled orders appear at the bottom.
6. Confirm purchases belonging to an archived referral are not listed on the Purchases tab.
7. Use the sidebar switcher to move between clients and confirm the tabs update.

<img width="1920" height="814" alt="Screenshot 2026-07-16 at 1 20 10 PM" src="https://github.com/user-attachments/assets/0cd5e301-d078-414c-b7ff-33985b508c43" />
<img width="1920" height="422" alt="Screenshot 2026-07-16 at 1 21 49 PM" src="https://github.com/user-attachments/assets/92a17128-6f3c-4fe3-80a6-119dbaab19d2" />
<img width="1920" height="607" alt="Screenshot 2026-07-16 at 1 21 19 PM" src="https://github.com/user-attachments/assets/6bdefac4-5cbd-436e-94de-be7839ef4864" />
<img width="560" height="607" alt="Screenshot 2026-07-16 at 1 19 31 PM" src="https://github.com/user-attachments/assets/0083de16-00e1-486b-9144-4c003a58e20f" />



## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
