### PR TITLE
A4A: Add Download CSV to referral commissions

### DIFF
--- a/client/dashboard/agency/earn/referrals/consolidated-views.tsx
+++ b/client/dashboard/agency/earn/referrals/consolidated-views.tsx
@@ -4,8 +4,9 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import ConsolidatedStatCard from './consolidated-stat-card';
 import useConsolidatedPayoutData from './hooks/use-consolidated-payout-data';
+import { downloadCommissionsCsv } from './lib/download-commissions-csv';
 import PayoutCards from './payout-cards';
-import type { Referral, ReferralCommissionPayout } from '@automattic/api-core';
+import type { AgencyProduct, Referral, ReferralCommissionPayout } from '@automattic/api-core';
 
 const AGENCY_EARNINGS_LEARN_MORE_LINK =
 	'https://agencieshelp.automattic.com/knowledge-base/automattic-for-agencies-earnings/';
@@ -33,6 +34,13 @@ interface ConsolidatedViewsProps {
 	isLoadingCommissionPayout?: boolean;
 	/** Each app passes its own user locale for date formatting. */
 	locale?: string;
+	/**
+	 * The product catalog, needed to resolve each commission's rate. Without it
+	 * the CSV download is hidden, since the rows would be incomplete.
+	 */
+	products?: AgencyProduct[];
+	/** Each app passes its own analytics client. */
+	recordTracksEvent?: ( eventName: string, properties?: Record< string, unknown > ) => void;
 }
 
 export default function ConsolidatedViews( {
@@ -42,6 +50,8 @@ export default function ConsolidatedViews( {
 	isLoading,
 	isLoadingCommissionPayout,
 	locale,
+	products,
+	recordTracksEvent,
 }: ConsolidatedViewsProps ) {
 	const { previousQuarterExpectedCommission, currentQuarterExpectedCommission, pendingOrders } =
 		useConsolidatedPayoutData( referrals );
@@ -49,6 +59,23 @@ export default function ConsolidatedViews( {
 	const totalPayouts = isSingleClient
 		? findClientTotalCommission( referrals[ 0 ], referralCommissionPayout )
 		: referralCommissionPayout?.total_commission;
+
+	const handleDownloadCsv = () => {
+		recordTracksEvent?.( 'calypso_a4a_referrals_download_commissions_csv', {
+			detailed_view: isSingleClient,
+		} );
+		downloadCommissionsCsv( {
+			referrals,
+			products: products ?? [],
+			referralCommissionPayout,
+			isSingleClient,
+			clientEmail: isSingleClient ? referrals[ 0 ]?.client?.email : undefined,
+		} );
+	};
+
+	// Referrals supply each row's quantity and commission rate, so offering the
+	// download before they arrive would produce a CSV with rows missing.
+	const canDownloadCsv = ! isLoading && !! products && !! totalPayouts && totalPayouts > 0;
 
 	return (
 		<Grid
@@ -60,6 +87,13 @@ export default function ConsolidatedViews( {
 				value={ formatCurrency( totalPayouts ?? 0, 'USD' ) }
 				footerText={
 					isSingleClient ? __( 'All payouts for this client' ) : __( 'All time referral payouts' )
+				}
+				footerAction={
+					canDownloadCsv ? (
+						<Button variant="link" onClick={ handleDownloadCsv }>
+							{ __( 'Download CSV' ) }
+						</Button>
+					) : undefined
 				}
 				popoverTitle={ __( 'Total payouts' ) }
 				popoverContent={ createInterpolateElement(

--- a/client/dashboard/agency/earn/referrals/consolidated-views.tsx
+++ b/client/dashboard/agency/earn/referrals/consolidated-views.tsx
@@ -34,10 +34,7 @@ interface ConsolidatedViewsProps {
 	isLoadingCommissionPayout?: boolean;
 	/** Each app passes its own user locale for date formatting. */
 	locale?: string;
-	/**
-	 * The product catalog, needed to resolve each commission's rate. Without it
-	 * the CSV download is hidden, since the rows would be incomplete.
-	 */
+	/** Product catalog for resolving commission rates in the CSV export. */
 	products?: AgencyProduct[];
 	/** Each app passes its own analytics client. */
 	recordTracksEvent?: ( eventName: string, properties?: Record< string, unknown > ) => void;

--- a/client/dashboard/agency/earn/referrals/index.tsx
+++ b/client/dashboard/agency/earn/referrals/index.tsx
@@ -1,5 +1,6 @@
 import {
 	activeAgencyQuery,
+	agencyProductsQuery,
 	referralsQuery,
 	referralCommissionPayoutQuery,
 } from '@automattic/api-queries';
@@ -7,6 +8,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
+import { useAnalytics } from '../../../app/analytics';
 import { useLocale } from '../../../app/locale';
 import { DataViewsCard } from '../../../components/dataviews';
 import { PageHeader } from '../../../components/page-header';
@@ -30,6 +32,8 @@ export default function EarnReferrals() {
 	const { data: commissionPayout, isLoading: isLoadingCommissionPayout } = useQuery(
 		referralCommissionPayoutQuery( agencyId )
 	);
+	const { data: products } = useQuery( agencyProductsQuery( agencyId ) );
+	const { recordTracksEvent } = useAnalytics();
 
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 
@@ -64,6 +68,8 @@ export default function EarnReferrals() {
 						isLoading={ isLoading }
 						isLoadingCommissionPayout={ isLoadingCommissionPayout }
 						locale={ locale }
+						products={ products }
+						recordTracksEvent={ recordTracksEvent }
 					/>
 					<DataViewsCard>
 						<ReferralsList

--- a/client/dashboard/agency/earn/referrals/lib/commissions.ts
+++ b/client/dashboard/agency/earn/referrals/lib/commissions.ts
@@ -1,0 +1,38 @@
+// The commission rules are also implemented in the backend, which computes the
+// actual payouts. TODO: Expose them via an API endpoint so there is a single
+// source of truth; until then, keep this file in sync with the backend.
+export const isProductEligibleForCommission = ( slug: string ) => {
+	const thirdPartyProducts = [
+		'woocommerce-affirm',
+		'woocommerce-afterpay',
+		'woocommerce-constellation',
+		'woocommerce-dynamic-pricing',
+		'woocommerce-klarna',
+		'woocommerce-klaviyo',
+		'woocommerce-mollie',
+		'woocommerce-paypal',
+		'woocommerce-rental-products',
+		'woocommerce-smart-coupons',
+		'woocommerce-square',
+		'woocommerce-stripe',
+		'woocommerce-variation-swatches-and-photos',
+	];
+
+	if ( thirdPartyProducts.includes( slug ) ) {
+		return false;
+	}
+	return true;
+};
+
+export const getProductCommissionPercentage = ( slug?: string, familySlug?: string ) => {
+	if ( ! slug || ! familySlug || ! isProductEligibleForCommission( slug ) ) {
+		return 0;
+	}
+	if ( [ 'wpcom-hosting', 'pressable-hosting' ].includes( familySlug ) ) {
+		return 0.2;
+	}
+	if ( slug.startsWith( 'jetpack-' ) || slug.startsWith( 'woocommerce-' ) ) {
+		return 0.5;
+	}
+	return 0;
+};

--- a/client/dashboard/agency/earn/referrals/lib/download-commissions-csv.ts
+++ b/client/dashboard/agency/earn/referrals/lib/download-commissions-csv.ts
@@ -1,0 +1,42 @@
+import { generateCommissionsCsv } from './generate-commissions-csv';
+import type { AgencyProduct, Referral, ReferralCommissionPayout } from '@automattic/api-core';
+
+interface DownloadCommissionsCsvArgs {
+	referrals: Referral[];
+	products: AgencyProduct[];
+	referralCommissionPayout?: ReferralCommissionPayout;
+	isSingleClient?: boolean;
+	clientEmail?: string;
+}
+
+export function downloadCommissionsCsv( {
+	referrals,
+	products,
+	referralCommissionPayout,
+	isSingleClient,
+	clientEmail,
+}: DownloadCommissionsCsvArgs ): void {
+	const csvContent = generateCommissionsCsv(
+		referrals,
+		products,
+		referralCommissionPayout,
+		isSingleClient
+	);
+
+	const blob = new Blob( [ csvContent ], { type: 'text/csv;charset=utf-8;' } );
+
+	const date = new Date().toISOString().split( 'T' )[ 0 ];
+	const clientSuffix = clientEmail ? `-${ clientEmail.split( '@' )[ 0 ] }` : '';
+	const filename = `referral-commissions${ clientSuffix }-${ date }.csv`;
+
+	const url = window.URL.createObjectURL( blob );
+	const link = document.createElement( 'a' );
+	link.href = url;
+	link.download = filename;
+
+	document.body.appendChild( link );
+	link.click();
+	document.body.removeChild( link );
+
+	window.URL.revokeObjectURL( url );
+}

--- a/client/dashboard/agency/earn/referrals/lib/generate-commissions-csv.ts
+++ b/client/dashboard/agency/earn/referrals/lib/generate-commissions-csv.ts
@@ -1,0 +1,213 @@
+import { getProductCommissionPercentage } from './commissions';
+import type {
+	AgencyProduct,
+	Referral,
+	ReferralCommissionPayout,
+	ReferralCommissionPayoutClient,
+	ReferralPurchase,
+} from '@automattic/api-core';
+
+/** CSV line ending per RFC 4180; CRLF ensures Excel and Windows tools parse rows correctly. */
+const CSV_LINE_ENDING = '\r\n';
+
+/** UTF-8 BOM so Excel opens the file with correct encoding. */
+const UTF8_BOM = '\uFEFF';
+
+/**
+ * Characters that spreadsheet applications (Excel, Google Sheets, etc.) treat as the
+ * start of a formula. A field beginning with one of these can execute on open, so we
+ * neutralize it. Includes tab and carriage return, which some parsers strip before
+ * evaluating the remaining formula.
+ */
+const FORMULA_TRIGGERS = [ '=', '+', '-', '@', '\t', '\r' ];
+
+/**
+ * Escapes a value for CSV format.
+ * Neutralizes formula injection by prefixing a single quote to fields that begin with a
+ * formula trigger character (spreadsheets render the leading quote-prefixed value as a literal string).
+ * Wraps in quotes if the value contains commas, quotes, or newlines.
+ * Doubles any existing quotes.
+ */
+function csvEscape( value: unknown ): string {
+	let str = value == null ? '' : String( value );
+	// A lone trigger character (e.g. the '-' placeholder used for missing values) is not a
+	// formula, so only neutralize when there is content after the trigger.
+	if ( str.length > 1 && FORMULA_TRIGGERS.some( ( char ) => str.startsWith( char ) ) ) {
+		str = `'${ str }`;
+	}
+	const needsQuotes = /[",\n]/.test( str );
+	const escaped = str.replace( /"/g, '""' );
+	return needsQuotes ? `"${ escaped }"` : escaped;
+}
+
+function formatDate( dateString: string | null ): string {
+	if ( ! dateString ) {
+		return '-';
+	}
+	const date = new Date( dateString );
+	const iso = date.toISOString().split( 'T' )[ 0 ];
+	return iso || '-';
+}
+
+function formatCurrency( amount: number | string | null | undefined ): string {
+	const n = typeof amount === 'number' ? amount : Number( amount );
+	return Number.isFinite( n ) ? n.toFixed( 2 ) : '-';
+}
+
+function formatPercentage( percentage: number ): string {
+	return `${ ( percentage * 100 ).toFixed( 0 ) }%`;
+}
+
+interface CommissionRow {
+	clientEmail: string;
+	productName: string;
+	quantity: number | '-';
+	invoicedDate: string;
+	price: number;
+	commissionPercentage: string;
+	commissionAmount: number;
+}
+
+function findMatchingPurchase(
+	referrals: Referral[],
+	apiClient: ReferralCommissionPayoutClient,
+	productId: number,
+	products: AgencyProduct[]
+): { referral: Referral; purchase: ReferralPurchase; product: AgencyProduct } | null {
+	const referral = referrals.find(
+		( r ) =>
+			r.client.id === apiClient.client_user_id ||
+			r.client.email?.toLowerCase() === apiClient.email?.toLowerCase()
+	);
+	if ( ! referral?.purchases?.length ) {
+		return null;
+	}
+	const product = products.find( ( p ) =>
+		[
+			p.product_id,
+			p.monthly_product_id,
+			p.yearly_product_id,
+			p.alternative_product_id,
+			p.monthly_alternative_product_id,
+			p.yearly_alternative_product_id,
+		].includes( productId )
+	);
+	if ( ! product ) {
+		return null;
+	}
+	const purchase = referral.purchases.find( ( p ) =>
+		[
+			product.product_id,
+			product.monthly_product_id,
+			product.yearly_product_id,
+			product.alternative_product_id,
+			product.monthly_alternative_product_id,
+			product.yearly_alternative_product_id,
+		].includes( p.product_id )
+	);
+	if ( ! purchase || purchase.status === 'pending' || purchase.status === 'error' ) {
+		return null;
+	}
+	return { referral, purchase, product };
+}
+
+/** One row per invoice; supplemental fields come from the matching referral purchase. */
+function buildRowsFromApi(
+	referralCommissionPayout: ReferralCommissionPayout,
+	referrals: Referral[],
+	products: AgencyProduct[],
+	isSingleClient?: boolean
+): CommissionRow[] {
+	const rows: CommissionRow[] = [];
+
+	for ( const apiClient of referralCommissionPayout.client_data ) {
+		for ( const apiProduct of apiClient.products ) {
+			const match = findMatchingPurchase( referrals, apiClient, apiProduct.product_id, products );
+
+			if ( apiProduct.invoices && apiProduct.invoices.length > 0 ) {
+				const clientEmail = apiClient.client_user_id === 'N/A' ? 'N/A' : apiClient.email;
+				const productName = apiProduct.product_name;
+				for ( const invoice of apiProduct.invoices ) {
+					const invoicedDate = formatDate( invoice.payment_date );
+					const price = invoice.paid_amount;
+					const commissionAmount = invoice.commission_amount;
+					if ( match ) {
+						rows.push( {
+							clientEmail,
+							productName,
+							quantity: match.purchase.quantity ?? 1,
+							invoicedDate,
+							price,
+							commissionPercentage: formatPercentage(
+								getProductCommissionPercentage( match.product.slug, match.product.family_slug )
+							),
+							commissionAmount,
+						} );
+					} else if ( apiClient.client_user_id === 'N/A' && ! isSingleClient ) {
+						const priceNum = typeof price === 'number' ? price : Number( price );
+						const commissionNum =
+							typeof commissionAmount === 'number' ? commissionAmount : Number( commissionAmount );
+						const derivedPercentage =
+							Number.isFinite( priceNum ) && priceNum > 0 && Number.isFinite( commissionNum )
+								? commissionNum / priceNum
+								: null;
+						rows.push( {
+							clientEmail,
+							productName,
+							quantity: 1,
+							invoicedDate,
+							price,
+							commissionPercentage:
+								derivedPercentage != null ? formatPercentage( derivedPercentage ) : '-',
+							commissionAmount,
+						} );
+					}
+				}
+			}
+		}
+	}
+
+	return rows;
+}
+
+/** Returns a headers-only CSV when there is no payout data. */
+export function generateCommissionsCsv(
+	referrals: Referral[],
+	products: AgencyProduct[],
+	referralCommissionPayout?: ReferralCommissionPayout,
+	isSingleClient?: boolean
+): string {
+	const headers = [
+		...( isSingleClient ? [] : [ 'Client Email' ] ),
+		'Product Name',
+		'Quantity',
+		'Invoiced On',
+		'Price (USD)',
+		'Commission %',
+		'Commission Amount (USD)',
+	];
+
+	const rows = referralCommissionPayout?.client_data?.length
+		? buildRowsFromApi( referralCommissionPayout, referrals, products, isSingleClient )
+		: [];
+
+	const csvLines: string[] = [];
+	csvLines.push( headers.map( csvEscape ).join( ',' ) );
+
+	for ( const row of rows ) {
+		const line = [
+			...( isSingleClient ? [] : [ row.clientEmail ] ),
+			row.productName,
+			row.quantity,
+			row.invoicedDate,
+			formatCurrency( row.price ),
+			row.commissionPercentage,
+			formatCurrency( row.commissionAmount ),
+		]
+			.map( csvEscape )
+			.join( ',' );
+		csvLines.push( line );
+	}
+
+	return UTF8_BOM + csvLines.join( CSV_LINE_ENDING );
+}

--- a/client/dashboard/agency/earn/referrals/lib/generate-commissions-csv.ts
+++ b/client/dashboard/agency/earn/referrals/lib/generate-commissions-csv.ts
@@ -21,13 +21,7 @@ const UTF8_BOM = '\uFEFF';
  */
 const FORMULA_TRIGGERS = [ '=', '+', '-', '@', '\t', '\r' ];
 
-/**
- * Escapes a value for CSV format.
- * Neutralizes formula injection by prefixing a single quote to fields that begin with a
- * formula trigger character (spreadsheets render the leading quote-prefixed value as a literal string).
- * Wraps in quotes if the value contains commas, quotes, or newlines.
- * Doubles any existing quotes.
- */
+/** Neutralizes formula injection by prefixing fields that begin with a trigger character. */
 function csvEscape( value: unknown ): string {
 	let str = value == null ? '' : String( value );
 	// A lone trigger character (e.g. the '-' placeholder used for missing values) is not a
@@ -111,7 +105,6 @@ function findMatchingPurchase(
 	return { referral, purchase, product };
 }
 
-/** One row per invoice; supplemental fields come from the matching referral purchase. */
 function buildRowsFromApi(
 	referralCommissionPayout: ReferralCommissionPayout,
 	referrals: Referral[],
@@ -170,7 +163,6 @@ function buildRowsFromApi(
 	return rows;
 }
 
-/** Returns a headers-only CSV when there is no payout data. */
 export function generateCommissionsCsv(
 	referrals: Referral[],
 	products: AgencyProduct[],

--- a/client/dashboard/agency/earn/referrals/lib/test/generate-commissions-csv.ts
+++ b/client/dashboard/agency/earn/referrals/lib/test/generate-commissions-csv.ts
@@ -1,0 +1,135 @@
+import { generateCommissionsCsv } from '../generate-commissions-csv';
+import type { AgencyProduct, Referral, ReferralCommissionPayout } from '@automattic/api-core';
+
+function payoutWithProductName( productName: string ): ReferralCommissionPayout {
+	return {
+		total_amount: 100,
+		total_commission: 10,
+		start_date: '2024-01-01',
+		end_date: '2024-01-31',
+		next_payout_date: '2024-03-02',
+		client_data: [
+			{
+				client_user_id: 'N/A',
+				email: 'client@example.com',
+				total_amount: 100,
+				total_commission: 10,
+				products: [
+					{
+						product_id: 1,
+						product_name: productName,
+						total_amount: 100,
+						total_commission: 10,
+						invoices: [ { payment_date: '2024-01-15', paid_amount: 100, commission_amount: 10 } ],
+					},
+				],
+			},
+		],
+	};
+}
+
+describe( 'generateCommissionsCsv', () => {
+	it.each( [ '=HYPERLINK(evil)', '+1+1', '-1', '@SUM(A1)', '\tcmd', '\rcmd' ] )(
+		'neutralizes formula injection in fields starting with %j',
+		( payload ) => {
+			const csv = generateCommissionsCsv( [], [], payoutWithProductName( payload ) );
+			// The injected field is prefixed with a single quote so spreadsheets treat it as a literal string.
+			expect( csv ).toContain( `'${ payload }` );
+		}
+	);
+
+	it( 'does not alter values that do not start with a formula trigger', () => {
+		const csv = generateCommissionsCsv( [], [], payoutWithProductName( 'Pro Plan' ) );
+		expect( csv ).toContain( 'Pro Plan' );
+		expect( csv ).not.toContain( "'Pro Plan" );
+	} );
+
+	it( 'does not prefix a lone trigger character used as a placeholder', () => {
+		const csv = generateCommissionsCsv( [], [], payoutWithProductName( '-' ) );
+		expect( csv ).not.toContain( "'-" );
+	} );
+
+	it( 'still quotes and escapes fields containing commas and quotes', () => {
+		const csv = generateCommissionsCsv( [], [], payoutWithProductName( 'Plan "A", annual' ) );
+		expect( csv ).toContain( '"Plan ""A"", annual"' );
+	} );
+
+	// The payout endpoint can report an alternative product id while the referrals endpoint
+	// reports the canonical one, so matching must bridge every id variant.
+	const catalogProduct = {
+		name: 'WordPress.com Business',
+		slug: 'wpcom-hosting',
+		family_slug: 'wpcom-hosting',
+		product_id: 1018,
+		alternative_product_id: 9999,
+		monthly_alternative_product_id: 3301,
+		yearly_alternative_product_id: 3300,
+	} as unknown as AgencyProduct;
+
+	const referral = {
+		id: 12345,
+		client: { id: 12345, email: 'client@example.com' },
+		purchases: [ { product_id: 1018, status: 'active', quantity: 2 } ],
+		purchaseStatuses: [ 'active' ],
+		referralStatuses: [ 'active' ],
+		referrals: [],
+	} as unknown as Referral;
+
+	function payoutForProductId( productId: number ): ReferralCommissionPayout {
+		return {
+			total_amount: 100,
+			total_commission: 20,
+			start_date: '2024-01-01',
+			end_date: '2024-01-31',
+			next_payout_date: '2024-03-02',
+			client_data: [
+				{
+					client_user_id: 12345,
+					email: 'client@example.com',
+					total_amount: 100,
+					total_commission: 20,
+					products: [
+						{
+							product_id: productId,
+							product_name: 'WordPress.com Business',
+							total_amount: 100,
+							total_commission: 20,
+							invoices: [ { payment_date: '2024-01-15', paid_amount: 100, commission_amount: 20 } ],
+						},
+					],
+				},
+			],
+		};
+	}
+
+	it.each( [
+		[ 'monthly alternative', 3301 ],
+		[ 'yearly alternative', 3300 ],
+		[ 'legacy alternative', 9999 ],
+	] )(
+		'matches a purchase when the payout reports the %s product id',
+		( _label, payoutProductId ) => {
+			const csv = generateCommissionsCsv(
+				[ referral ],
+				[ catalogProduct ],
+				payoutForProductId( payoutProductId as number ),
+				true
+			);
+			expect( csv ).toContain( 'WordPress.com Business' );
+			// 20% (from the matched product's hosting slug) and quantity 2 (from the matched purchase)
+			// only appear when the row came from a successful match rather than being dropped.
+			expect( csv ).toContain( '20%' );
+			expect( csv ).toContain( 'WordPress.com Business,2,' );
+		}
+	);
+
+	it( 'drops the row in the single-client view when no product matches', () => {
+		const csv = generateCommissionsCsv(
+			[ referral ],
+			[ catalogProduct ],
+			payoutForProductId( 4242 ),
+			true
+		);
+		expect( csv ).not.toContain( 'WordPress.com Business' );
+	} );
+} );

--- a/client/dashboard/agency/earn/referrals/referral/overview.tsx
+++ b/client/dashboard/agency/earn/referrals/referral/overview.tsx
@@ -5,6 +5,7 @@ import { __experimentalGrid as Grid, __experimentalHStack as HStack } from '@wor
 import { DataViews } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
+import { useAnalytics } from '../../../../app/analytics';
 import { useLocale } from '../../../../app/locale';
 import { PageHeader } from '../../../../components/page-header';
 import PageLayout from '../../../../components/page-layout';
@@ -82,6 +83,7 @@ export default function ReferralOverview() {
 		referralCommissionPayoutQuery( agencyId )
 	);
 	const { data: products } = useQuery( agencyProductsQuery( agencyId ) );
+	const { recordTracksEvent } = useAnalytics();
 
 	const referralFields = useMemo( () => getReferralFields( products ), [ products ] );
 	const purchaseFields = useMemo( () => getPurchaseFields( products ), [ products ] );
@@ -119,6 +121,8 @@ export default function ReferralOverview() {
 				referralCommissionPayout={ commissionPayout }
 				isLoadingCommissionPayout={ isLoadingCommissionPayout }
 				locale={ locale }
+				products={ products }
+				recordTracksEvent={ recordTracksEvent }
 			/>
 			<Grid templateColumns="repeat(auto-fit, minmax(320px, 1fr))" gap={ 6 } align="start">
 				<PreviewListCard


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/112639.

Part of A4A-2845

## Proposed Changes

* Add a **Download CSV** link to the total payouts card, on both the Referrals list and a client's detail view.
* The file lists one row per commission, with the client's email, product, quantity, the date it was invoiced, the price, the commission rate and the amount. On a client's detail view the email column is dropped, since every row is that client.
* The link only appears once an agency actually has payouts, matching the classic app.

## Why are these changes being made?

Agencies use this export to reconcile their commissions against their own records, so it needs to exist in the new dashboard before the classic app can be retired.

Bringing the export across also means the file itself is generated in one place rather than once per app, so the two cannot drift apart.

## Testing Instructions

> Note: the link only shows for an agency with payouts above zero. On a test account with no payouts it is hidden by design.

1. Open the Dashboard Live (A4A) link > Replace the `/sites` from the URL with `/overview` to see the A4A dashboard and go to **Earn → Referrals** with an agency that has payouts.
2. Confirm **Download CSV** appears under the all-time payouts total.
3. Download the file and confirm it opens cleanly in a spreadsheet, with a row per commission and correct client emails, products, prices, and rates. Confirm this matches with the production one.

<img width="1382" height="143" alt="Screenshot 2026-07-16 at 3 17 27 PM" src="https://github.com/user-attachments/assets/661317c3-060f-4b01-a1ca-957c44e61a81" />


4. Open a client and confirm the same link appears on their Overview, and that the file covers only that client and has no email column. Confirm this matches with the production one.

<img width="1920" height="610" alt="Screenshot 2026-07-16 at 3 18 14 PM" src="https://github.com/user-attachments/assets/cd09e18a-c36e-42bb-873c-54835f64dbc6" />


5. On an agency with no payouts, confirm the link is not shown.



## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
