### PR TITLE
A4A Migrations commissions: resolve active agency via api-queries

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/commissions-list/untag-site-dialog.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/untag-site-dialog.tsx
@@ -1,8 +1,9 @@
 import {
+	activeAgencyQuery,
 	agencyMigrationCommissionSitesQuery,
 	agencySiteTagsMutation,
 } from '@automattic/api-queries';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
 	__experimentalConfirmDialog as ConfirmDialog,
 	__experimentalHeading as Heading,
@@ -12,8 +13,7 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
-import { useDispatch, useSelector } from 'calypso/state';
-import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { useDispatch } from 'calypso/state';
 import { successNotice } from 'calypso/state/notices/actions';
 import type { TaggedSite } from '../types';
 
@@ -28,7 +28,8 @@ export default function UntagSiteDialog( {
 } ) {
 	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
-	const agencyId = useSelector( getActiveAgencyId );
+	const { data: agency } = useQuery( activeAgencyQuery() );
+	const agencyId = agency?.id;
 	useMinimizeHelpCenterOnMount();
 	const { mutate, isPending } = useMutation( agencySiteTagsMutation( agencyId ) );
 

--- a/client/a8c-for-agencies/sections/migrations/hooks/test/use-can-tag-sites-for-commission.test.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/test/use-can-tag-sites-for-commission.test.ts
@@ -4,42 +4,38 @@
  * Run: yarn test-client client/a8c-for-agencies/sections/migrations/hooks/test/use-can-tag-sites-for-commission.test.ts
  */
 
+import { useQuery } from '@tanstack/react-query';
 import { renderHook } from '@testing-library/react';
-import { useSelector } from 'react-redux';
 import {
 	A4A_MIGRATED_SITE_TAG,
 	A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026,
 } from '../../lib/constants';
 import useCanTagSitesForCommission from '../use-can-tag-sites-for-commission';
+import type { UseQueryResult } from '@tanstack/react-query';
 
-jest.mock( 'react-redux', () => ( {
-	useSelector: jest.fn(),
+jest.mock( '@tanstack/react-query', () => ( {
+	...jest.requireActual( '@tanstack/react-query' ),
+	useQuery: jest.fn(),
 } ) );
 
-function mockActiveAgency( overrides: Record< string, unknown > = {} ) {
+const mockUseQuery = useQuery as jest.MockedFunction< typeof useQuery >;
+
+function mockActiveAgency( startDate?: string | null ) {
 	return {
 		id: 1,
 		name: 'Test Agency',
 		third_party: {
 			pressable: {
 				usage: {
-					start_date: undefined,
-					end_date: undefined,
+					start_date: startDate ?? undefined,
 				},
 			},
 		},
-		...overrides,
 	};
 }
 
-function createState( activeAgency: ReturnType< typeof mockActiveAgency > | null ) {
-	return {
-		a8cForAgencies: {
-			agencies: {
-				activeAgency,
-			},
-		},
-	};
+function mockAgencyQuery( agency: ReturnType< typeof mockActiveAgency > | null ) {
+	mockUseQuery.mockReturnValue( { data: agency } as unknown as UseQueryResult );
 }
 
 describe( 'useCanTagSitesForCommission', () => {
@@ -48,12 +44,7 @@ describe( 'useCanTagSitesForCommission', () => {
 	} );
 
 	it( 'returns canTagSitesForCommission true and includes incentive tag when no start_date', () => {
-		const agency = mockActiveAgency();
-		jest
-			.mocked( useSelector )
-			.mockImplementation( ( selector: ( s: unknown ) => unknown ) =>
-				selector( createState( agency ) )
-			);
+		mockAgencyQuery( mockActiveAgency() );
 
 		const { result } = renderHook( () => useCanTagSitesForCommission() );
 
@@ -65,18 +56,7 @@ describe( 'useCanTagSitesForCommission', () => {
 	} );
 
 	it( 'returns true and includes incentive tag when start_date is empty string', () => {
-		const agency = mockActiveAgency( {
-			third_party: {
-				pressable: {
-					usage: { start_date: '', end_date: undefined },
-				},
-			},
-		} );
-		jest
-			.mocked( useSelector )
-			.mockImplementation( ( selector: ( s: unknown ) => unknown ) =>
-				selector( createState( agency ) )
-			);
+		mockAgencyQuery( mockActiveAgency( '' ) );
 
 		const { result } = renderHook( () => useCanTagSitesForCommission() );
 
@@ -88,18 +68,7 @@ describe( 'useCanTagSitesForCommission', () => {
 	} );
 
 	it( 'returns true when start_date is on or before cutoff (2025-08-10)', () => {
-		const agency = mockActiveAgency( {
-			third_party: {
-				pressable: {
-					usage: { start_date: '2025-08-10', end_date: null },
-				},
-			},
-		} );
-		jest
-			.mocked( useSelector )
-			.mockImplementation( ( selector: ( s: unknown ) => unknown ) =>
-				selector( createState( agency ) )
-			);
+		mockAgencyQuery( mockActiveAgency( '2025-08-10' ) );
 
 		const { result } = renderHook( () => useCanTagSitesForCommission() );
 
@@ -111,18 +80,7 @@ describe( 'useCanTagSitesForCommission', () => {
 	} );
 
 	it( 'returns false when start_date is in gap (2025-08-11 to 2026-02-10)', () => {
-		const agency = mockActiveAgency( {
-			third_party: {
-				pressable: {
-					usage: { start_date: '2025-08-11', end_date: null },
-				},
-			},
-		} );
-		jest
-			.mocked( useSelector )
-			.mockImplementation( ( selector: ( s: unknown ) => unknown ) =>
-				selector( createState( agency ) )
-			);
+		mockAgencyQuery( mockActiveAgency( '2025-08-11' ) );
 
 		const { result } = renderHook( () => useCanTagSitesForCommission() );
 
@@ -131,18 +89,7 @@ describe( 'useCanTagSitesForCommission', () => {
 	} );
 
 	it( 'returns true when start_date is on or after promo start (2026-02-11)', () => {
-		const agency = mockActiveAgency( {
-			third_party: {
-				pressable: {
-					usage: { start_date: '2026-02-11', end_date: null },
-				},
-			},
-		} );
-		jest
-			.mocked( useSelector )
-			.mockImplementation( ( selector: ( s: unknown ) => unknown ) =>
-				selector( createState( agency ) )
-			);
+		mockAgencyQuery( mockActiveAgency( '2026-02-11' ) );
 
 		const { result } = renderHook( () => useCanTagSitesForCommission() );
 

--- a/client/a8c-for-agencies/sections/migrations/hooks/test/use-can-tag-sites-for-commission.test.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/test/use-can-tag-sites-for-commission.test.ts
@@ -34,8 +34,11 @@ function mockActiveAgency( startDate?: string | null ) {
 	};
 }
 
-function mockAgencyQuery( agency: ReturnType< typeof mockActiveAgency > | null ) {
-	mockUseQuery.mockReturnValue( { data: agency } as unknown as UseQueryResult );
+function mockAgencyQuery(
+	agency: ReturnType< typeof mockActiveAgency > | null,
+	isLoading = false
+) {
+	mockUseQuery.mockReturnValue( { data: agency, isLoading } as unknown as UseQueryResult );
 }
 
 describe( 'useCanTagSitesForCommission', () => {
@@ -97,5 +100,13 @@ describe( 'useCanTagSitesForCommission', () => {
 		expect( result.current.migrationTags ).toContain(
 			A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026
 		);
+	} );
+
+	it( 'surfaces the agency query loading state', () => {
+		mockAgencyQuery( null, true );
+
+		const { result } = renderHook( () => useCanTagSitesForCommission() );
+
+		expect( result.current.isLoading ).toBe( true );
 	} );
 } );

--- a/client/a8c-for-agencies/sections/migrations/hooks/use-can-tag-sites-for-commission.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/use-can-tag-sites-for-commission.ts
@@ -1,6 +1,6 @@
+import { activeAgencyQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
-import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import {
 	A4A_MIGRATED_SITE_TAG,
 	A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026,
@@ -37,9 +37,9 @@ export default function useCanTagSitesForCommission(): {
 	canTagSitesForCommission: boolean;
 	migrationTags: string[];
 } {
-	const activeAgency = useSelector( getActiveAgency );
+	const { data: agency } = useQuery( activeAgencyQuery() );
 
-	const pressableUsageStartDate = activeAgency?.third_party?.pressable?.usage?.start_date;
+	const pressableUsageStartDate = agency?.third_party?.pressable?.usage?.start_date;
 	const withinPurchaseCutoff = isWithinPressablePurchaseCutoff( pressableUsageStartDate );
 
 	return useMemo( () => {

--- a/client/a8c-for-agencies/sections/migrations/hooks/use-can-tag-sites-for-commission.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/use-can-tag-sites-for-commission.ts
@@ -36,8 +36,9 @@ function isWithinPressablePurchaseCutoff( startDate: string | undefined | null )
 export default function useCanTagSitesForCommission(): {
 	canTagSitesForCommission: boolean;
 	migrationTags: string[];
+	isLoading: boolean;
 } {
-	const { data: agency } = useQuery( activeAgencyQuery() );
+	const { data: agency, isLoading } = useQuery( activeAgencyQuery() );
 
 	const pressableUsageStartDate = agency?.third_party?.pressable?.usage?.start_date;
 	const withinPurchaseCutoff = isWithinPressablePurchaseCutoff( pressableUsageStartDate );
@@ -51,6 +52,7 @@ export default function useCanTagSitesForCommission(): {
 		return {
 			canTagSitesForCommission,
 			migrationTags,
+			isLoading,
 		};
-	}, [ withinPurchaseCutoff ] );
+	}, [ withinPurchaseCutoff, isLoading ] );
 }

--- a/client/a8c-for-agencies/sections/migrations/hooks/use-fetch-tagged-sites-for-migration.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/use-fetch-tagged-sites-for-migration.ts
@@ -1,11 +1,10 @@
-import { agencyMigrationCommissionSitesQuery } from '@automattic/api-queries';
+import { activeAgencyQuery, agencyMigrationCommissionSitesQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import { useSelector } from 'calypso/state';
-import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { selectCommissionSites } from '../lib/select-commission-sites';
 
 export default function useFetchTaggedSitesForMigration() {
-	const agencyId = useSelector( getActiveAgencyId );
+	const { data: agency } = useQuery( activeAgencyQuery() );
+	const agencyId = agency?.id;
 
 	return useQuery( {
 		...agencyMigrationCommissionSitesQuery( agencyId ),

--- a/client/a8c-for-agencies/sections/migrations/hooks/use-fetch-tagged-sites-for-migration.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/use-fetch-tagged-sites-for-migration.ts
@@ -3,12 +3,14 @@ import { useQuery } from '@tanstack/react-query';
 import { selectCommissionSites } from '../lib/select-commission-sites';
 
 export default function useFetchTaggedSitesForMigration() {
-	const { data: agency } = useQuery( activeAgencyQuery() );
+	const { data: agency, isLoading: isAgencyLoading } = useQuery( activeAgencyQuery() );
 	const agencyId = agency?.id;
 
-	return useQuery( {
+	const query = useQuery( {
 		...agencyMigrationCommissionSitesQuery( agencyId ),
 		select: selectCommissionSites,
 		refetchOnWindowFocus: false,
 	} );
+
+	return { ...query, isLoading: isAgencyLoading || query.isLoading };
 }

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
@@ -28,7 +28,11 @@ export default function MigrationsCommissions() {
 	const dispatch = useDispatch();
 
 	const [ showAddSitesModal, setShowAddSitesModal ] = useState( false );
-	const { canTagSitesForCommission, migrationTags } = useCanTagSitesForCommission();
+	const {
+		canTagSitesForCommission,
+		migrationTags,
+		isLoading: isTagEligibilityLoading,
+	} = useCanTagSitesForCommission();
 
 	const title = __( 'Migrations: commissions' );
 
@@ -90,7 +94,7 @@ export default function MigrationsCommissions() {
 					/>
 					<Actions useColumnAlignment>
 						<MobileSidebarNavigation />
-						{ canTagSitesForCommission && (
+						{ ! isTagEligibilityLoading && canTagSitesForCommission && (
 							<Button variant="primary" onClick={ onTagSitesClick }>
 								{ __( 'Tag sites for commission' ) }
 							</Button>

--- a/client/a8c-for-agencies/sections/migrations/request-review-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/request-review-modal/index.tsx
@@ -1,8 +1,9 @@
 import {
+	activeAgencyQuery,
 	agencyMigrationCommissionSitesQuery,
 	requestMigrationReverificationMutation,
 } from '@automattic/api-queries';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
 	Button,
 	Modal,
@@ -15,8 +16,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
 import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
-import { useDispatch, useSelector } from 'calypso/state';
-import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import type { TaggedSite } from '../types';
@@ -30,7 +30,8 @@ export default function RequestReviewModal( {
 } ) {
 	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
-	const agencyId = useSelector( getActiveAgencyId );
+	const { data: agency } = useQuery( activeAgencyQuery() );
+	const agencyId = agency?.id;
 	useMinimizeHelpCenterOnMount();
 
 	const { mutate: requestReview, isPending } = useMutation(

--- a/client/a8c-for-agencies/sections/migrations/tag-sites-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/tag-sites-modal/index.tsx
@@ -1,8 +1,9 @@
 import {
+	activeAgencyQuery,
 	agencyMigrationCommissionSitesQuery,
 	tagAgencySitesForCommissionMutation,
 } from '@automattic/api-queries';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
 	Button,
 	Modal,
@@ -18,8 +19,7 @@ import { Icon, info } from '@wordpress/icons';
 import { useState } from 'react';
 import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
 import { preventWidows } from 'calypso/lib/formatting';
-import { useDispatch, useSelector } from 'calypso/state';
-import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import MigrationsAddSitesTable from './add-sites-table';
@@ -39,7 +39,8 @@ export default function MigrationsTagSitesModal( {
 } ) {
 	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
-	const agencyId = useSelector( getActiveAgencyId );
+	const { data: agency } = useQuery( activeAgencyQuery() );
+	const agencyId = agency?.id;
 	useMinimizeHelpCenterOnMount();
 
 	const { mutate: tagSitesForMigration, isPending } = useMutation(

--- a/packages/api-core/src/agency/types.ts
+++ b/packages/api-core/src/agency/types.ts
@@ -32,6 +32,14 @@ export interface Agency {
 	user?: {
 		capabilities: string[];
 	};
+	third_party?: null | {
+		pressable?: null | {
+			usage?: null | {
+				start_date?: string;
+				end_date?: string;
+			};
+		};
+	};
 }
 
 /**


### PR DESCRIPTION
<!-- Stacked on top of `refactor/a4a/migrations-commissions-dataviews`; the base branch is set accordingly. Re-target to trunk once that PR merges. -->

Part of the effort to make the A4A Migrations → Commissions page portable toward the new Dashboard (MSD).

## Proposed Changes

* Replace the Redux `getActiveAgencyId` / `getActiveAgency` selectors with `activeAgencyQuery()` (from `@automattic/api-queries`) across the migrations-commission hooks and modals, so the feature no longer reads the active agency from `calypso/state`.
* Add the `third_party.pressable.usage` subset (`start_date` / `end_date`) to the api-core `Agency` type. The `GET /wpcom/v2/agency` endpoint already returns it, so this is a purely additive type change that lets the eligibility hook read the Pressable usage start date off the query result.
* Update the `useCanTagSitesForCommission` unit test to mock `useQuery` instead of `react-redux`.

Analytics (`recordTracksEvent`) and notices intentionally stay on Redux — their MSD equivalents (`useAnalytics`, `@wordpress/notices`) are not wired into the A4A app, so they will move only when the page itself lands in the Dashboard.

## Why are these changes being made?

The active-agency selectors are the most pervasive Redux coupling in this feature. Sourcing the agency from the shared `activeAgencyQuery()` removes that coupling and lets the same hooks/modals move to the Dashboard (which has no Redux) without change, while behaving identically in the classic A4A app today. Splitting this out keeps each portability step reviewable and shippable on its own.

## Testing Instructions

* Open Migrations → Commissions in A4A as an agency user. The page, consolidated summary, and commissions list should load exactly as before.
* Tag sites for commission, untag a site, and request another verification — each modal should resolve the agency and complete its mutation as before.
* Confirm the "Tag sites for commission" action visibility still respects Pressable eligibility (the `useCanTagSitesForCommission` cutoff logic).
* `yarn test-client client/a8c-for-agencies/sections/migrations/hooks/test/use-can-tag-sites-for-commission.test.ts` passes.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
