### PR TITLE
A4A Migrations commissions: decouple side-effects for MSD port

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/commissions-content.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-content.tsx
@@ -1,15 +1,16 @@
 import { TextSkeleton } from 'calypso/dashboard/components/text-skeleton';
 import MigrationsCommissionsList from './commissions-list';
 import MigrationsConsolidatedCommissions from './consolidated-commissions';
-import useFetchTaggedSitesForMigration from './hooks/use-fetch-tagged-sites-for-migration';
 import MigrationsCommissionsEmptyState from './primary/migrations-commissions/empty-state';
 import MigrationsTagSitesModal from './tag-sites-modal';
-import type { RecordTracksEvent } from './types';
+import type { RecordTracksEvent, ShowSuccessNotice, TaggedSite } from './types';
 import type { ReactNode } from 'react';
 
 interface MigrationsCommissionsContentProps {
+	taggedSites: TaggedSite[];
+	isLoading: boolean;
 	recordTracksEvent: RecordTracksEvent;
-	onSuccess: ( message: ReactNode ) => void;
+	onSuccess: ShowSuccessNotice;
 	onError: ( message: ReactNode ) => void;
 	getSiteCreatedAt: ( blogId: number ) => string | undefined;
 	canTagSitesForCommission: boolean;
@@ -20,6 +21,8 @@ interface MigrationsCommissionsContentProps {
 }
 
 export default function MigrationsCommissionsContent( {
+	taggedSites,
+	isLoading,
 	recordTracksEvent,
 	onSuccess,
 	onError,
@@ -30,9 +33,6 @@ export default function MigrationsCommissionsContent( {
 	onCloseAddSitesModal,
 	onOpenAddSitesModal,
 }: MigrationsCommissionsContentProps ) {
-	const { data, isLoading } = useFetchTaggedSitesForMigration();
-	const taggedSites = data ?? [];
-
 	if ( isLoading ) {
 		return (
 			<>

--- a/client/a8c-for-agencies/sections/migrations/commissions-content.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-content.tsx
@@ -1,0 +1,80 @@
+import { TextSkeleton } from 'calypso/dashboard/components/text-skeleton';
+import MigrationsCommissionsList from './commissions-list';
+import MigrationsConsolidatedCommissions from './consolidated-commissions';
+import useFetchTaggedSitesForMigration from './hooks/use-fetch-tagged-sites-for-migration';
+import MigrationsCommissionsEmptyState from './primary/migrations-commissions/empty-state';
+import MigrationsTagSitesModal from './tag-sites-modal';
+import type { RecordTracksEvent } from './types';
+import type { ReactNode } from 'react';
+
+interface MigrationsCommissionsContentProps {
+	recordTracksEvent: RecordTracksEvent;
+	onSuccess: ( message: ReactNode ) => void;
+	onError: ( message: ReactNode ) => void;
+	getSiteCreatedAt: ( blogId: number ) => string | undefined;
+	canTagSitesForCommission: boolean;
+	migrationTags: string[];
+	isAddSitesModalOpen: boolean;
+	onCloseAddSitesModal: () => void;
+	onOpenAddSitesModal: () => void;
+}
+
+export default function MigrationsCommissionsContent( {
+	recordTracksEvent,
+	onSuccess,
+	onError,
+	getSiteCreatedAt,
+	canTagSitesForCommission,
+	migrationTags,
+	isAddSitesModalOpen,
+	onCloseAddSitesModal,
+	onOpenAddSitesModal,
+}: MigrationsCommissionsContentProps ) {
+	const { data, isLoading } = useFetchTaggedSitesForMigration();
+	const taggedSites = data ?? [];
+
+	if ( isLoading ) {
+		return (
+			<>
+				<TextSkeleton length={ 30 } />
+				<TextSkeleton length={ 30 } />
+			</>
+		);
+	}
+
+	return (
+		<>
+			{ taggedSites.length === 0 ? (
+				<MigrationsCommissionsEmptyState
+					recordTracksEvent={ recordTracksEvent }
+					onTagSitesClick={ onOpenAddSitesModal }
+					canTagSitesForCommission={ canTagSitesForCommission }
+				/>
+			) : (
+				<div className="migrations-commissions__content">
+					{ canTagSitesForCommission && (
+						<MigrationsConsolidatedCommissions items={ taggedSites } />
+					) }
+					<MigrationsCommissionsList
+						items={ taggedSites }
+						migrationTags={ migrationTags }
+						recordTracksEvent={ recordTracksEvent }
+						onSuccess={ onSuccess }
+						onError={ onError }
+					/>
+				</div>
+			) }
+			{ isAddSitesModalOpen && (
+				<MigrationsTagSitesModal
+					onClose={ onCloseAddSitesModal }
+					taggedSites={ taggedSites }
+					migrationTags={ migrationTags }
+					recordTracksEvent={ recordTracksEvent }
+					onSuccess={ onSuccess }
+					onError={ onError }
+					getSiteCreatedAt={ getSiteCreatedAt }
+				/>
+			) }
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
@@ -7,7 +7,7 @@ import RequestReviewModal from '../request-review-modal';
 import { MigratedOnColumn, ReviewStatusColumn, SiteColumn } from './commission-columns';
 import UntagSiteDialog from './untag-site-dialog';
 import useCommissionListActions from './use-commission-list-actions';
-import type { TaggedSite } from '../types';
+import type { RecordTracksEvent, TaggedSite } from '../types';
 import type { Field, View } from '@wordpress/dataviews';
 
 import '../commissions/components/dataviews/style.scss';
@@ -55,9 +55,15 @@ const INITIAL_VIEW: View = {
 export default function MigrationsCommissionsList( {
 	items,
 	migrationTags,
+	recordTracksEvent,
+	onSuccess,
+	onError,
 }: {
 	items: TaggedSite[];
 	migrationTags: string[];
+	recordTracksEvent: RecordTracksEvent;
+	onSuccess: ( message: ReactNode ) => void;
+	onError: ( message: ReactNode ) => void;
 } ) {
 	const isDesktop = useDesktopBreakpoint();
 
@@ -160,11 +166,18 @@ export default function MigrationsCommissionsList( {
 					site={ activeModal.site }
 					migrationTags={ migrationTags }
 					onClose={ closeModal }
+					onSuccess={ onSuccess }
 				/>
 			) }
 
 			{ activeModal?.kind === 'request-review' && (
-				<RequestReviewModal site={ activeModal.site } onClose={ closeModal } />
+				<RequestReviewModal
+					site={ activeModal.site }
+					onClose={ closeModal }
+					recordTracksEvent={ recordTracksEvent }
+					onSuccess={ onSuccess }
+					onError={ onError }
+				/>
 			) }
 		</>
 	);

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
@@ -7,7 +7,7 @@ import RequestReviewModal from '../request-review-modal';
 import { MigratedOnColumn, ReviewStatusColumn, SiteColumn } from './commission-columns';
 import UntagSiteDialog from './untag-site-dialog';
 import useCommissionListActions from './use-commission-list-actions';
-import type { RecordTracksEvent, TaggedSite } from '../types';
+import type { RecordTracksEvent, ShowSuccessNotice, TaggedSite } from '../types';
 import type { Field, View } from '@wordpress/dataviews';
 
 import '../commissions/components/dataviews/style.scss';
@@ -62,7 +62,7 @@ export default function MigrationsCommissionsList( {
 	items: TaggedSite[];
 	migrationTags: string[];
 	recordTracksEvent: RecordTracksEvent;
-	onSuccess: ( message: ReactNode ) => void;
+	onSuccess: ShowSuccessNotice;
 	onError: ( message: ReactNode ) => void;
 } ) {
 	const isDesktop = useDesktopBreakpoint();

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/untag-site-dialog.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/untag-site-dialog.tsx
@@ -25,7 +25,7 @@ export default function UntagSiteDialog( {
 	site: TaggedSite;
 	migrationTags: string[];
 	onClose: () => void;
-	onSuccess: ( message: ReactNode ) => void;
+	onSuccess: ( message: ReactNode, options?: { id?: string; duration?: number } ) => void;
 } ) {
 	const queryClient = useQueryClient();
 	const { data: agency } = useQuery( activeAgencyQuery() );
@@ -64,7 +64,8 @@ export default function UntagSiteDialog( {
 								site.url
 							),
 							{ strong: <strong /> }
-						)
+						),
+						{ id: 'a4a-commission-list-untag-success', duration: 5000 }
 					);
 				},
 			}

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/untag-site-dialog.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/untag-site-dialog.tsx
@@ -13,20 +13,20 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
-import { useDispatch } from 'calypso/state';
-import { successNotice } from 'calypso/state/notices/actions';
 import type { TaggedSite } from '../types';
+import type { ReactNode } from 'react';
 
 export default function UntagSiteDialog( {
 	site,
 	migrationTags,
 	onClose,
+	onSuccess,
 }: {
 	site: TaggedSite;
 	migrationTags: string[];
 	onClose: () => void;
+	onSuccess: ( message: ReactNode ) => void;
 } ) {
-	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
 	const { data: agency } = useQuery( activeAgencyQuery() );
 	const agencyId = agency?.id;
@@ -56,17 +56,14 @@ export default function UntagSiteDialog( {
 						queryKey: agencyMigrationCommissionSitesQuery( agencyId ).queryKey,
 					} );
 					onClose();
-					dispatch(
-						successNotice(
-							createInterpolateElement(
-								sprintf(
-									/* translators: %s: the site URL */
-									__( 'Successfully untagged <strong>%s</strong>.' ),
-									site.url
-								),
-								{ strong: <strong /> }
+					onSuccess(
+						createInterpolateElement(
+							sprintf(
+								/* translators: %s: the site URL */
+								__( 'Successfully untagged <strong>%s</strong>.' ),
+								site.url
 							),
-							{ id: 'a4a-commission-list-untag-success', duration: 5000 }
+							{ strong: <strong /> }
 						)
 					);
 				},

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/untag-site-dialog.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/untag-site-dialog.tsx
@@ -13,8 +13,7 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
-import type { TaggedSite } from '../types';
-import type { ReactNode } from 'react';
+import type { ShowSuccessNotice, TaggedSite } from '../types';
 
 export default function UntagSiteDialog( {
 	site,
@@ -25,7 +24,7 @@ export default function UntagSiteDialog( {
 	site: TaggedSite;
 	migrationTags: string[];
 	onClose: () => void;
-	onSuccess: ( message: ReactNode, options?: { id?: string; duration?: number } ) => void;
+	onSuccess: ShowSuccessNotice;
 } ) {
 	const queryClient = useQueryClient();
 	const { data: agency } = useQuery( activeAgencyQuery() );

--- a/client/a8c-for-agencies/sections/migrations/hooks/use-fetch-all-managed-sites-for-commission.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/use-fetch-all-managed-sites-for-commission.ts
@@ -1,14 +1,11 @@
 import { paginatedAgencySitesQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
-import { useSelector } from 'calypso/state';
-import getSites from 'calypso/state/selectors/get-sites';
 import type { AgencySite } from '@automattic/api-core';
 
 export type SiteItem = {
 	id: number;
 	site: string;
-	date: string;
 	rawSite: AgencySite;
 };
 
@@ -16,15 +13,13 @@ export type SiteItem = {
  * Hook to fetch all managed sites for commission tagging.
  *
  * This hook is specifically designed for the tag sites for commission modal,
- * where we need to show all sites fetched from the API regardless of whether
- * they exist in the Redux store. Sites not in Redux will show a dash for the date.
+ * where we need to show all sites fetched from the API. The site creation date
+ * shown in the modal is resolved by the host via `getSiteCreatedAt`.
  *
  * For other use cases that require full site data from Redux (like WooPayments or Reports),
  * use the `useFetchAllManagedSites` hook instead.
  */
 export const useFetchAllManagedSitesForCommission = () => {
-	const sites = useSelector( getSites );
-
 	// Fetch a single site first to learn the total, then request them all.
 	const firstFetch = useQuery( paginatedAgencySitesQuery( { page: 1, per_page: 1 } ) );
 
@@ -36,21 +31,15 @@ export const useFetchAllManagedSitesForCommission = () => {
 		enabled: isEnabled,
 	} );
 
-	// Unlike useFetchAllManagedSites, this hook does NOT filter out sites that
-	// are not in the Redux store - it includes all sites from the API. Sites
-	// without an `a4a_site_id` are dropped: the modal keys and selects rows by
-	// `id`, so an undefined id would collapse distinct sites together.
+	// Sites without an `a4a_site_id` are dropped: the modal keys and selects rows
+	// by `id`, so an undefined id would collapse distinct sites together.
 	const mappedSites: SiteItem[] = ( allSites.data?.sites ?? [] )
 		.filter( ( site ) => site.a4a_site_id != null )
-		.map( ( site ) => {
-			const foundSite = sites.find( ( s ) => s?.ID === site.blog_id );
-			return {
-				id: site.a4a_site_id as number,
-				site: urlToSlug( site.url ),
-				date: foundSite?.options?.created_at || '',
-				rawSite: site,
-			};
-		} );
+		.map( ( site ) => ( {
+			id: site.a4a_site_id as number,
+			site: urlToSlug( site.url ),
+			rawSite: site,
+		} ) );
 
 	const showLoading = ! mappedSites.length && ( firstFetch.isFetching || allSites.isFetching );
 

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/empty-state.tsx
@@ -2,26 +2,23 @@ import { Button, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
-import { useDispatch } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import StepSection from '../../commissions/components/step-section';
 import StepSectionItem from '../../commissions/components/step-section-item';
+import type { RecordTracksEvent } from '../../types';
 
 export default function MigrationsCommissionsEmptyState( {
-	setShowAddSitesModal,
+	recordTracksEvent,
+	onTagSitesClick,
 	canTagSitesForCommission,
 }: {
-	setShowAddSitesModal: ( show: boolean ) => void;
+	recordTracksEvent: RecordTracksEvent;
+	onTagSitesClick: () => void;
 	canTagSitesForCommission: boolean;
 } ) {
-	const dispatch = useDispatch();
-
 	const onTagMySelfMigratedSitesClick = useCallback( () => {
-		dispatch(
-			recordTracksEvent( 'calypso_a8c_migrations_commissions_tag_my_self_migrated_sites_click' )
-		);
-		setShowAddSitesModal( true );
-	}, [ dispatch, setShowAddSitesModal ] );
+		recordTracksEvent( 'calypso_a8c_migrations_commissions_tag_my_self_migrated_sites_click' );
+		onTagSitesClick();
+	}, [ recordTracksEvent, onTagSitesClick ] );
 
 	const a4aPluginUrl = 'https://wordpress.org/plugins/automattic-for-agencies-client';
 
@@ -54,10 +51,8 @@ export default function MigrationsCommissionsEmptyState( {
 													children={ null }
 													href={ a4aPluginUrl }
 													onClick={ () => {
-														dispatch(
-															recordTracksEvent(
-																'calypso_a8c_migrations_commissions_a4a_plugin_link_click'
-															)
+														recordTracksEvent(
+															'calypso_a8c_migrations_commissions_a4a_plugin_link_click'
 														);
 													} }
 												/>

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
@@ -1,31 +1,31 @@
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_MIGRATIONS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import MissingPaymentSettingsNotice from 'calypso/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice';
-import { TextSkeleton } from 'calypso/dashboard/components/text-skeleton';
 import LayoutBody from 'calypso/layout/hosting-dashboard/body';
 import LayoutHeader, {
 	LayoutHeaderBreadcrumb as Breadcrumb,
 	LayoutHeaderActions as Actions,
 } from 'calypso/layout/hosting-dashboard/header';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import MigrationsCommissionsList from '../../commissions-list';
-import MigrationsConsolidatedCommissions from '../../consolidated-commissions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import getSites from 'calypso/state/selectors/get-sites';
+import MigrationsCommissionsContent from '../../commissions-content';
 import useCanTagSitesForCommission from '../../hooks/use-can-tag-sites-for-commission';
 import useFetchTaggedSitesForMigration from '../../hooks/use-fetch-tagged-sites-for-migration';
-import MigrationsTagSitesModal from '../../tag-sites-modal';
-import MigrationsCommissionsEmptyState from './empty-state';
+import type { ReactNode } from 'react';
 
 import './style.scss';
 
 export default function MigrationsCommissions() {
 	const dispatch = useDispatch();
+	const sites = useSelector( getSites );
 
 	const [ showAddSitesModal, setShowAddSitesModal ] = useState( false );
 	const {
@@ -36,38 +36,34 @@ export default function MigrationsCommissions() {
 
 	const title = __( 'Migrations: commissions' );
 
+	const recordTracks = useCallback(
+		( name: string, properties?: Record< string, unknown > ) =>
+			dispatch( recordTracksEvent( name, properties ) ),
+		[ dispatch ]
+	);
+
+	const onSuccess = useCallback(
+		( message: ReactNode ) => dispatch( successNotice( message ) ),
+		[ dispatch ]
+	);
+
+	const onError = useCallback(
+		( message: ReactNode ) => dispatch( errorNotice( message ) ),
+		[ dispatch ]
+	);
+
+	const getSiteCreatedAt = useCallback(
+		( blogId: number ) => sites.find( ( s ) => s?.ID === blogId )?.options?.created_at,
+		[ sites ]
+	);
+
 	const onTagSitesClick = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_a8c_migrations_commissions_tag_sites_click' ) );
+		recordTracks( 'calypso_a8c_migrations_commissions_tag_sites_click' );
 		setShowAddSitesModal( true );
-	}, [ dispatch ] );
+	}, [ recordTracks ] );
 
-	const { data, isLoading } = useFetchTaggedSitesForMigration();
-	const taggedSites = data ?? [];
-
-	const showEmptyState = ! taggedSites.length;
-
-	const content = useMemo( () => {
-		if ( isLoading ) {
-			return (
-				<>
-					<TextSkeleton length={ 30 } />
-					<TextSkeleton length={ 30 } />
-				</>
-			);
-		}
-
-		return showEmptyState ? (
-			<MigrationsCommissionsEmptyState
-				setShowAddSitesModal={ setShowAddSitesModal }
-				canTagSitesForCommission={ canTagSitesForCommission }
-			/>
-		) : (
-			<div className="migrations-commissions__content">
-				{ canTagSitesForCommission && <MigrationsConsolidatedCommissions items={ taggedSites } /> }
-				<MigrationsCommissionsList items={ taggedSites } migrationTags={ migrationTags } />
-			</div>
-		);
-	}, [ isLoading, showEmptyState, canTagSitesForCommission, taggedSites, migrationTags ] );
+	const { data } = useFetchTaggedSitesForMigration();
+	const showEmptyState = ! ( data ?? [] ).length;
 
 	return (
 		<Layout
@@ -104,16 +100,17 @@ export default function MigrationsCommissions() {
 			</LayoutTop>
 
 			<LayoutBody>
-				<>
-					{ content }
-					{ showAddSitesModal && (
-						<MigrationsTagSitesModal
-							onClose={ () => setShowAddSitesModal( false ) }
-							taggedSites={ taggedSites }
-							migrationTags={ migrationTags }
-						/>
-					) }
-				</>
+				<MigrationsCommissionsContent
+					recordTracksEvent={ recordTracks }
+					onSuccess={ onSuccess }
+					onError={ onError }
+					getSiteCreatedAt={ getSiteCreatedAt }
+					canTagSitesForCommission={ canTagSitesForCommission }
+					migrationTags={ migrationTags }
+					isAddSitesModalOpen={ showAddSitesModal }
+					onCloseAddSitesModal={ () => setShowAddSitesModal( false ) }
+					onOpenAddSitesModal={ () => setShowAddSitesModal( true ) }
+				/>
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
@@ -43,7 +43,8 @@ export default function MigrationsCommissions() {
 	);
 
 	const onSuccess = useCallback(
-		( message: ReactNode ) => dispatch( successNotice( message ) ),
+		( message: ReactNode, options?: { id?: string; duration?: number } ) =>
+			dispatch( successNotice( message, options ) ),
 		[ dispatch ]
 	);
 

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
@@ -63,8 +63,9 @@ export default function MigrationsCommissions() {
 		setShowAddSitesModal( true );
 	}, [ recordTracks ] );
 
-	const { data } = useFetchTaggedSitesForMigration();
-	const showEmptyState = ! ( data ?? [] ).length;
+	const { data, isLoading } = useFetchTaggedSitesForMigration();
+	const taggedSites = data ?? [];
+	const showEmptyState = taggedSites.length === 0;
 
 	return (
 		<Layout
@@ -102,6 +103,8 @@ export default function MigrationsCommissions() {
 
 			<LayoutBody>
 				<MigrationsCommissionsContent
+					taggedSites={ taggedSites }
+					isLoading={ isLoading }
 					recordTracksEvent={ recordTracks }
 					onSuccess={ onSuccess }
 					onError={ onError }

--- a/client/a8c-for-agencies/sections/migrations/request-review-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/request-review-modal/index.tsx
@@ -16,19 +16,22 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
 import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
-import { useDispatch } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
-import type { TaggedSite } from '../types';
+import type { RecordTracksEvent, TaggedSite } from '../types';
+import type { ReactNode } from 'react';
 
 export default function RequestReviewModal( {
 	onClose,
 	site,
+	recordTracksEvent,
+	onSuccess,
+	onError,
 }: {
 	onClose: () => void;
 	site: TaggedSite;
+	recordTracksEvent: RecordTracksEvent;
+	onSuccess: ( message: ReactNode ) => void;
+	onError: ( message: ReactNode ) => void;
 } ) {
-	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
 	const { data: agency } = useQuery( activeAgencyQuery() );
 	const agencyId = agency?.id;
@@ -53,41 +56,34 @@ export default function RequestReviewModal( {
 					queryClient.invalidateQueries( {
 						queryKey: agencyMigrationCommissionSitesQuery( agencyId ).queryKey,
 					} );
-					dispatch(
-						recordTracksEvent( 'calypso_a4a_migrations_request_another_review_success', {
-							site_id: site.id,
-						} )
-					);
-					dispatch(
-						successNotice(
-							createInterpolateElement(
-								sprintf(
-									/* translators: %s: the site URL */
-									__( 'Your verification request for <strong>%s</strong> has been submitted.' ),
-									site.url
-								),
-								{ strong: <strong /> }
+					recordTracksEvent( 'calypso_a4a_migrations_request_another_review_success', {
+						site_id: site.id,
+					} );
+					onSuccess(
+						createInterpolateElement(
+							sprintf(
+								/* translators: %s: the site URL */
+								__( 'Your verification request for <strong>%s</strong> has been submitted.' ),
+								site.url
 							),
-							{ id: 'a4a-commission-request-review-success', duration: 5000 }
+							{ strong: <strong /> }
 						)
 					);
 					onClose();
 				},
 				onError: ( error ) => {
-					dispatch( errorNotice( error.message ) );
+					onError( error.message );
 				},
 			}
 		);
-		dispatch(
-			recordTracksEvent( 'calypso_a4a_migrations_request_another_review_submit', {
-				site_id: site.id,
-			} )
-		);
+		recordTracksEvent( 'calypso_a4a_migrations_request_another_review_submit', {
+			site_id: site.id,
+		} );
 	};
 
 	const handleOnClose = () => {
 		onClose();
-		dispatch( recordTracksEvent( 'calypso_a4a_migrations_request_another_review_close' ) );
+		recordTracksEvent( 'calypso_a4a_migrations_request_another_review_close' );
 	};
 
 	return (

--- a/client/a8c-for-agencies/sections/migrations/request-review-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/request-review-modal/index.tsx
@@ -29,7 +29,7 @@ export default function RequestReviewModal( {
 	onClose: () => void;
 	site: TaggedSite;
 	recordTracksEvent: RecordTracksEvent;
-	onSuccess: ( message: ReactNode ) => void;
+	onSuccess: ( message: ReactNode, options?: { id?: string; duration?: number } ) => void;
 	onError: ( message: ReactNode ) => void;
 } ) {
 	const queryClient = useQueryClient();
@@ -67,7 +67,8 @@ export default function RequestReviewModal( {
 								site.url
 							),
 							{ strong: <strong /> }
-						)
+						),
+						{ id: 'a4a-commission-request-review-success', duration: 5000 }
 					);
 					onClose();
 				},

--- a/client/a8c-for-agencies/sections/migrations/request-review-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/request-review-modal/index.tsx
@@ -16,7 +16,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
 import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
-import type { RecordTracksEvent, TaggedSite } from '../types';
+import type { RecordTracksEvent, ShowSuccessNotice, TaggedSite } from '../types';
 import type { ReactNode } from 'react';
 
 export default function RequestReviewModal( {
@@ -29,7 +29,7 @@ export default function RequestReviewModal( {
 	onClose: () => void;
 	site: TaggedSite;
 	recordTracksEvent: RecordTracksEvent;
-	onSuccess: ( message: ReactNode, options?: { id?: string; duration?: number } ) => void;
+	onSuccess: ShowSuccessNotice;
 	onError: ( message: ReactNode ) => void;
 } ) {
 	const queryClient = useQueryClient();

--- a/client/a8c-for-agencies/sections/migrations/tag-sites-modal/add-sites-table.tsx
+++ b/client/a8c-for-agencies/sections/migrations/tag-sites-modal/add-sites-table.tsx
@@ -7,13 +7,11 @@ import {
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useMemo, useState } from 'react';
-import { useDispatch } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	useFetchAllManagedSitesForCommission,
 	type SiteItem,
 } from '../hooks/use-fetch-all-managed-sites-for-commission';
-import { TaggedSite } from '../types';
+import type { RecordTracksEvent, TaggedSite } from '../types';
 import type { Field, View } from '@wordpress/dataviews';
 
 import '../commissions/components/dataviews/style.scss';
@@ -23,14 +21,17 @@ export default function MigrationsAddSitesTable( {
 	setSelectedSites,
 	taggedSites,
 	migrationSourceHost,
+	recordTracksEvent,
+	getSiteCreatedAt,
 }: {
 	selectedSites: SiteItem[];
 	setSelectedSites: ( sites: SiteItem[] ) => void;
 	taggedSites?: TaggedSite[];
 	migrationSourceHost: string;
+	recordTracksEvent: RecordTracksEvent;
+	getSiteCreatedAt: ( blogId: number ) => string | undefined;
 } ) {
 	const isDesktop = useDesktopBreakpoint();
-	const dispatch = useDispatch();
 
 	const { items, isLoading } = useFetchAllManagedSitesForCommission();
 
@@ -70,12 +71,10 @@ export default function MigrationsAddSitesTable( {
 	const onSelectAllSites = useCallback( () => {
 		const isAllSitesSelected = selectedSites.length === availableSites.length;
 		setSelectedSites( isAllSitesSelected ? [] : availableSites );
-		dispatch(
-			recordTracksEvent( 'calypso_a8c_migrations_tag_sites_modal_select_all_sites_click', {
-				type: isAllSitesSelected ? 'deselect' : 'select',
-			} )
-		);
-	}, [ dispatch, availableSites, selectedSites.length, setSelectedSites ] );
+		recordTracksEvent( 'calypso_a8c_migrations_tag_sites_modal_select_all_sites_click', {
+			type: isAllSitesSelected ? 'deselect' : 'select',
+		} );
+	}, [ recordTracksEvent, availableSites, selectedSites.length, setSelectedSites ] );
 
 	const onSelectSite = useCallback(
 		( checked: boolean, item: SiteItem ) => {
@@ -84,13 +83,11 @@ export default function MigrationsAddSitesTable( {
 			} else {
 				setSelectedSites( selectedSites.filter( ( site ) => site.id !== item.id ) );
 			}
-			dispatch(
-				recordTracksEvent( 'calypso_a8c_migrations_tag_sites_modal_select_site_click', {
-					type: checked ? 'select' : 'deselect',
-				} )
-			);
+			recordTracksEvent( 'calypso_a8c_migrations_tag_sites_modal_select_site_click', {
+				type: checked ? 'select' : 'deselect',
+			} );
 		},
-		[ dispatch, selectedSites, setSelectedSites ]
+		[ recordTracksEvent, selectedSites, setSelectedSites ]
 	);
 
 	const fields: Field< SiteItem >[] = useMemo( () => {
@@ -125,14 +122,23 @@ export default function MigrationsAddSitesTable( {
 			id: 'date',
 			label: __( 'Date added' ),
 			getValue: () => '-',
-			render: ( { item }: { item: SiteItem } ) =>
-				item.date ? new Date( item.date ).toLocaleDateString() : '-',
+			render: ( { item }: { item: SiteItem } ) => {
+				const createdAt = getSiteCreatedAt( item.rawSite.blog_id );
+				return createdAt ? new Date( createdAt ).toLocaleDateString() : '-';
+			},
 			enableHiding: false,
 			enableSorting: false,
 		};
 
 		return isDesktop ? [ siteColumn, dateColumn ] : [ siteColumn ];
-	}, [ isDesktop, availableSites.length, onSelectAllSites, onSelectSite, selectedSites ] );
+	}, [
+		isDesktop,
+		availableSites.length,
+		onSelectAllSites,
+		onSelectSite,
+		selectedSites,
+		getSiteCreatedAt,
+	] );
 
 	const { data: allSites, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( availableSites, view, fields );

--- a/client/a8c-for-agencies/sections/migrations/tag-sites-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/tag-sites-modal/index.tsx
@@ -19,12 +19,10 @@ import { Icon, info } from '@wordpress/icons';
 import { useState } from 'react';
 import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
 import { preventWidows } from 'calypso/lib/formatting';
-import { useDispatch } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import MigrationsAddSitesTable from './add-sites-table';
 import type { SiteItem } from '../hooks/use-fetch-all-managed-sites-for-commission';
-import type { TaggedSite } from '../types';
+import type { RecordTracksEvent, TaggedSite } from '../types';
+import type { ReactNode } from 'react';
 
 import './style.scss';
 
@@ -32,12 +30,19 @@ export default function MigrationsTagSitesModal( {
 	onClose,
 	taggedSites,
 	migrationTags,
+	recordTracksEvent,
+	onSuccess,
+	onError,
+	getSiteCreatedAt,
 }: {
 	onClose: () => void;
 	taggedSites?: TaggedSite[];
 	migrationTags: string[];
+	recordTracksEvent: RecordTracksEvent;
+	onSuccess: ( message: ReactNode ) => void;
+	onError: ( message: ReactNode ) => void;
+	getSiteCreatedAt: ( blogId: number ) => string | undefined;
 } ) {
-	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
 	const { data: agency } = useQuery( activeAgencyQuery() );
 	const agencyId = agency?.id;
@@ -84,54 +89,46 @@ export default function MigrationsTagSitesModal( {
 					queryClient.invalidateQueries( {
 						queryKey: agencyMigrationCommissionSitesQuery( agencyId ).queryKey,
 					} );
-					dispatch(
-						recordTracksEvent( 'calypso_a8c_migrations_tag_sites_modal_add_sites_success', {
-							count: selectedSites.length,
-							migration_source_host: finalMigrationSourceHost,
-						} )
-					);
+					recordTracksEvent( 'calypso_a8c_migrations_tag_sites_modal_add_sites_success', {
+						count: selectedSites.length,
+						migration_source_host: finalMigrationSourceHost,
+					} );
 					const hasSingleSite = selectedSites.length === 1;
 					const siteUrl = hasSingleSite ? selectedSites[ 0 ].site : '';
-					dispatch(
+					onSuccess(
 						hasSingleSite
-							? successNotice(
-									createInterpolateElement(
-										sprintf(
-											/* translators: %s: the site URL */
-											__(
-												'The site <strong>%s</strong> has been successfully tagged for commission.'
-											),
-											siteUrl
-										),
-										{ strong: <strong /> }
-									)
-							  )
-							: successNotice(
+							? createInterpolateElement(
 									sprintf(
-										/* translators: %d: the number of sites tagged */
-										__( '%d sites have been successfully tagged for commission.' ),
-										selectedSites.length
-									)
+										/* translators: %s: the site URL */
+										__(
+											'The site <strong>%s</strong> has been successfully tagged for commission.'
+										),
+										siteUrl
+									),
+									{ strong: <strong /> }
+							  )
+							: sprintf(
+									/* translators: %d: the number of sites tagged */
+									__( '%d sites have been successfully tagged for commission.' ),
+									selectedSites.length
 							  )
 					);
 					onClose();
 				},
 				onError: ( error ) => {
-					dispatch( errorNotice( error.message ) );
+					onError( error.message );
 				},
 			}
 		);
-		dispatch(
-			recordTracksEvent( 'calypso_a8c_migrations_tag_sites_modal_add_sites_click', {
-				count: selectedSites.length,
-				migration_source_host: finalMigrationSourceHost,
-			} )
-		);
+		recordTracksEvent( 'calypso_a8c_migrations_tag_sites_modal_add_sites_click', {
+			count: selectedSites.length,
+			migration_source_host: finalMigrationSourceHost,
+		} );
 	};
 
 	const handleOnClose = () => {
 		onClose();
-		dispatch( recordTracksEvent( 'calypso_a8c_migrations_tag_sites_modal_close' ) );
+		recordTracksEvent( 'calypso_a8c_migrations_tag_sites_modal_close' );
 	};
 
 	const handleMigrationSourceHostChange = ( value: string ) => {
@@ -185,6 +182,8 @@ export default function MigrationsTagSitesModal( {
 						selectedSites={ selectedSites }
 						setSelectedSites={ setSelectedSites }
 						migrationSourceHost={ selectedMigrationSourceHost }
+						recordTracksEvent={ recordTracksEvent }
+						getSiteCreatedAt={ getSiteCreatedAt }
 					/>
 				) }
 			</VStack>

--- a/client/a8c-for-agencies/sections/migrations/test/commissions-content.test.tsx
+++ b/client/a8c-for-agencies/sections/migrations/test/commissions-content.test.tsx
@@ -4,11 +4,11 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import MigrationsCommissionsContent from '../commissions-content';
-import useFetchTaggedSitesForMigration from '../hooks/use-fetch-tagged-sites-for-migration';
-
-jest.mock( '../hooks/use-fetch-tagged-sites-for-migration' );
+import type { ComponentProps } from 'react';
 
 const baseProps = {
+	taggedSites: [],
+	isLoading: false,
 	recordTracksEvent: () => {},
 	onSuccess: () => {},
 	onError: () => {},
@@ -20,25 +20,29 @@ const baseProps = {
 	onOpenAddSitesModal: () => {},
 };
 
-function renderContent() {
+const EMPTY_STATE_COPY = 'View your migrated websites and commissions right here.';
+
+function renderContent(
+	props: Partial< ComponentProps< typeof MigrationsCommissionsContent > > = {}
+) {
 	const client = new QueryClient();
 	return render(
 		<QueryClientProvider client={ client }>
-			<MigrationsCommissionsContent { ...baseProps } />
+			<MigrationsCommissionsContent { ...baseProps } { ...props } />
 		</QueryClientProvider>
 	);
 }
 
 describe( 'MigrationsCommissionsContent', () => {
 	it( 'shows the empty state when there are no tagged sites', () => {
-		jest
-			.mocked( useFetchTaggedSitesForMigration )
-			.mockReturnValue( { data: [], isLoading: false } as never );
+		renderContent( { taggedSites: [] } );
 
-		renderContent();
+		expect( screen.getByText( EMPTY_STATE_COPY ) ).toBeVisible();
+	} );
 
-		expect(
-			screen.getByText( 'View your migrated websites and commissions right here.' )
-		).toBeVisible();
+	it( 'shows the loading skeleton and not the empty state while loading', () => {
+		renderContent( { isLoading: true } );
+
+		expect( screen.queryByText( EMPTY_STATE_COPY ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/a8c-for-agencies/sections/migrations/test/commissions-content.test.tsx
+++ b/client/a8c-for-agencies/sections/migrations/test/commissions-content.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import MigrationsCommissionsContent from '../commissions-content';
+import useFetchTaggedSitesForMigration from '../hooks/use-fetch-tagged-sites-for-migration';
+
+jest.mock( '../hooks/use-fetch-tagged-sites-for-migration' );
+
+const baseProps = {
+	recordTracksEvent: () => {},
+	onSuccess: () => {},
+	onError: () => {},
+	getSiteCreatedAt: () => undefined,
+	canTagSitesForCommission: true,
+	migrationTags: [ 'tag' ],
+	isAddSitesModalOpen: false,
+	onCloseAddSitesModal: () => {},
+	onOpenAddSitesModal: () => {},
+};
+
+function renderContent() {
+	const client = new QueryClient();
+	return render(
+		<QueryClientProvider client={ client }>
+			<MigrationsCommissionsContent { ...baseProps } />
+		</QueryClientProvider>
+	);
+}
+
+describe( 'MigrationsCommissionsContent', () => {
+	it( 'shows the empty state when there are no tagged sites', () => {
+		jest
+			.mocked( useFetchTaggedSitesForMigration )
+			.mockReturnValue( { data: [], isLoading: false } as never );
+
+		renderContent();
+
+		expect(
+			screen.getByText( 'View your migrated websites and commissions right here.' )
+		).toBeVisible();
+	} );
+} );

--- a/client/a8c-for-agencies/sections/migrations/types.ts
+++ b/client/a8c-for-agencies/sections/migrations/types.ts
@@ -1,4 +1,5 @@
 import type { MigrationCommissionSite } from '@automattic/api-core';
+import type { ReactNode } from 'react';
 
 /**
  * @deprecated Prefer importing `MigrationCommissionSite` from `@automattic/api-core`.
@@ -7,3 +8,8 @@ import type { MigrationCommissionSite } from '@automattic/api-core';
 export type TaggedSite = MigrationCommissionSite;
 
 export type RecordTracksEvent = ( name: string, properties?: Record< string, unknown > ) => void;
+
+export type ShowSuccessNotice = (
+	message: ReactNode,
+	options?: { id?: string; duration?: number }
+) => void;

--- a/client/a8c-for-agencies/sections/migrations/types.ts
+++ b/client/a8c-for-agencies/sections/migrations/types.ts
@@ -5,3 +5,5 @@ import type { MigrationCommissionSite } from '@automattic/api-core';
  * Kept as an alias so existing imports across the migrations section keep working.
  */
 export type TaggedSite = MigrationCommissionSite;
+
+export type RecordTracksEvent = ( name: string, properties?: Record< string, unknown > ) => void;


### PR DESCRIPTION
<!-- Stacked on `refactor/a4a/migrations-commissions-agency-query`; base is set accordingly. Re-target to trunk once that PR merges. -->

Part of the effort to port the A4A Migrations → Commissions feature into the new Dashboard (MSD). This is PR 1 of that port: it makes the feature's components host-agnostic so they can later move into `client/dashboard/agency/earn/migrations/` and be consumed by both apps. No behavior change in A4A.

## Proposed Changes

* Introduce a shared `MigrationsCommissionsContent` component that owns the tagged-sites fetch, empty-state/list rendering, and the modals — receiving analytics, notices, and the site-created-at lookup as injected props.
* Refactor the list, modals, add-sites table, and empty state to stop calling Redux directly. They now accept:
  * `recordTracksEvent` (a `RecordTracksEvent` prop) instead of `dispatch( recordTracksEvent(...) )`.
  * `onSuccess` / `onError` callbacks instead of `dispatch( successNotice/errorNotice(...) )`.
  * `getSiteCreatedAt( blogId )` for the add-sites "Date added" column, replacing the Redux `getSites` backfill (the hook no longer reads Redux and drops its `date` field).
* Rewire the A4A page as the host: it keeps its layout shell + header button and wires the injected props from Redux (`recordTracksEvent`, `successNotice`/`errorNotice`, `getSites`), rendering `MigrationsCommissionsContent` in its body.
* Add a focused test for `MigrationsCommissionsContent` (empty-state path).

## Why are these changes being made?

The Dashboard is the source of truth for agency features, and A4A consumes dashboard components one-way. Before the feature can move into the Dashboard (which has no Redux), its components must stop depending on `calypso/state` for analytics and notices. Extracting a single presentational content component and injecting the two host-specific concerns (analytics, notices) plus the date lookup makes the components portable while keeping A4A behavior identical. Splitting this out keeps the port reviewable in small, behavior-preserving steps.

## Testing Instructions

* Load Migrations → Commissions in A4A as an agency user. The page, consolidated cards, list, empty state, and the tag-sites / untag / request-another-verification flows should all behave exactly as before, including the success/error notices and the add-sites "Date added" column.
* `yarn test-client client/a8c-for-agencies/sections/migrations` passes (18 tests).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
