### PR TITLE
Bump Agenttic to 0.1.78

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"@automattic/accessible-focus": "workspace:^",
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-ui": "^0.1.77",
+		"@automattic/agenttic-ui": "^0.1.78",
 		"@automattic/api-core": "workspace:^",
 		"@automattic/api-queries": "workspace:^",
 		"@automattic/block-renderer": "workspace:^",

--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -41,8 +41,8 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.77",
-		"@automattic/agenttic-ui": "^0.1.77",
+		"@automattic/agenttic-client": "^0.1.78",
+		"@automattic/agenttic-ui": "^0.1.78",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/block-notes/package.json
+++ b/packages/block-notes/package.json
@@ -41,7 +41,7 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.77",
+		"@automattic/agenttic-client": "^0.1.78",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",
 		"@wordpress/api-fetch": "^7.48.0",

--- a/packages/image-studio/package.json
+++ b/packages/image-studio/package.json
@@ -51,8 +51,8 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.77",
-		"@automattic/agenttic-ui": "^0.1.77",
+		"@automattic/agenttic-client": "^0.1.78",
+		"@automattic/agenttic-ui": "^0.1.78",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",

--- a/packages/jetpack-ai-sidebar/package.json
+++ b/packages/jetpack-ai-sidebar/package.json
@@ -44,7 +44,7 @@
 		"typecheck": "tsc --build --dry"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.77",
+		"@automattic/agenttic-client": "^0.1.78",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
 		"@automattic/components": "workspace:^",

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -41,7 +41,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.77",
+		"@automattic/agenttic-ui": "^0.1.78",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/zendesk-client": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,8 +133,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/agents-manager@workspace:packages/agents-manager"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.77"
-    "@automattic/agenttic-ui": "npm:^0.1.77"
+    "@automattic/agenttic-client": "npm:^0.1.78"
+    "@automattic/agenttic-ui": "npm:^0.1.78"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
@@ -180,9 +180,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/agenttic-client@npm:^0.1.77":
-  version: 0.1.77
-  resolution: "@automattic/agenttic-client@npm:0.1.77"
+"@automattic/agenttic-client@npm:^0.1.78":
+  version: 0.1.78
+  resolution: "@automattic/agenttic-client@npm:0.1.78"
   dependencies:
     "@types/react": "npm:^18.0.0"
     marked: "npm:^16.2.1"
@@ -196,13 +196,13 @@ __metadata:
   peerDependenciesMeta:
     "@wordpress/api-fetch":
       optional: true
-  checksum: 927d4e2bc08d20ffd121f5d68cac65978371ade946ba675d880d6c3af3422b2997e4fb713c013e0b84e49f4acc0955b9f8158105c39464c7876045990dfb0ad5
+  checksum: 084ab8ff11aa205fe57f4046f2ca4519d30261b12bb53459404caff2c58998cf2e70b1a7d1638a26714d4eef6665e4a5e6af9eb9279c3a75a356e0335c9c3d7f
   languageName: node
   linkType: hard
 
-"@automattic/agenttic-ui@npm:^0.1.77":
-  version: 0.1.77
-  resolution: "@automattic/agenttic-ui@npm:0.1.77"
+"@automattic/agenttic-ui@npm:^0.1.78":
+  version: 0.1.78
+  resolution: "@automattic/agenttic-ui@npm:0.1.78"
   dependencies:
     "@automattic/charts": "npm:^1.10.0"
     "@radix-ui/react-popover": "npm:^1.1.15"
@@ -228,7 +228,7 @@ __metadata:
   dependenciesMeta:
     marked:
       optional: true
-  checksum: fedd09f2a133c9b733a775c2fc0b20a13517aba30c5d4f1a4bc32c609e6827ec7dacb1e76d85b2c8db758f007b15fbb93978674ccbc748ef12ccaf6c1423c1f3
+  checksum: 94f115f1886a80b10f1864e48c35db4b69df5b2333fd1b4df69cff3b23ad659a4bc1ae5537ef72cff96bb975bf6db62387605da0a3c6d9f048d3cfdd5043f90e
   languageName: node
   linkType: hard
 
@@ -344,7 +344,7 @@ __metadata:
   resolution: "@automattic/block-notes@workspace:packages/block-notes"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.77"
+    "@automattic/agenttic-client": "npm:^0.1.78"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@testing-library/react": "npm:^15.0.7"
@@ -1480,8 +1480,8 @@ __metadata:
   resolution: "@automattic/image-studio@workspace:packages/image-studio"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.77"
-    "@automattic/agenttic-ui": "npm:^0.1.77"
+    "@automattic/agenttic-client": "npm:^0.1.78"
+    "@automattic/agenttic-ui": "npm:^0.1.78"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/oauth-token": "workspace:^"
@@ -1576,7 +1576,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/jetpack-ai-sidebar@workspace:packages/jetpack-ai-sidebar"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.77"
+    "@automattic/agenttic-client": "npm:^0.1.78"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
@@ -1843,7 +1843,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/odie-client@workspace:packages/odie-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.77"
+    "@automattic/agenttic-ui": "npm:^0.1.78"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
@@ -14376,7 +14376,7 @@ __metadata:
   dependencies:
     "@automattic/accessible-focus": "workspace:^"
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-ui": "npm:^0.1.77"
+    "@automattic/agenttic-ui": "npm:^0.1.78"
     "@automattic/api-core": "workspace:^"
     "@automattic/api-queries": "workspace:^"
     "@automattic/block-renderer": "workspace:^"


### PR DESCRIPTION
## Proposed Changes

* Bump `@automattic/agenttic-client` and `@automattic/agenttic-ui` from `0.1.77` to `0.1.78` across all Calypso consumers.
* Refresh the Yarn lockfile so Reader Chat and the other Agents Manager surfaces receive the corrected Agenttic UI package.

## Why are these changes being made?

* Agenttic UI 0.1.78 keeps the chat composer CSS in the package entry stylesheet. This ensures the AI-interaction disclosure introduced by Agenttic is shipped with its intended styling in Reader Chat and other consumers.
* Keeping the client and UI packages aligned follows the existing dependency-update pattern in this repository.

## Testing Instructions

Automated checks:

```bash
yarn install --immutable
NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client
NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-packages
yarn workspace @automattic/agents-manager build
yarn workspace @automattic/agents-manager-app build
yarn jest -c test/packages/jest.config.js --runInBand --runTestsByPath packages/agents-manager/src/components/__tests__/agent-chat.test.tsx packages/agents-manager/src/components/__tests__/agents-manager.test.tsx
yarn jest -c test/apps/jest.config.js --runInBand --runTestsByPath apps/agents-manager/__tests__/reader-chat.test.js
```

Calypso:

1. Run `yarn start`.
2. Open an Agents Manager chat surface.
3. Confirm the chat renders without console errors and the disclosure appears below the composer.
4. Confirm the Guidelines link is styled and opens in a new tab.

Simple/Atomic/CIAB sandbox:

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/agents-manager && yarn dev --sync`.
3. Open Reader Chat on a supported site.
4. Confirm the disclosure reads “You’re chatting with AI. Guidelines.” below the input and remains visible in the floating panel.
5. Send a message and confirm the response renders without console errors.

The production build was also inspected to confirm `reader-chat.min.js` contains the disclosure copy and `reader-chat.css` contains the `chat-compliance-disclosure` styles.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have you tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
