### PR TITLE
Site launch celebration modal: stack and left-align the domain upsell on mobile

### DIFF
--- a/client/dashboard/sites/site-launch-celebration-modal/index.tsx
+++ b/client/dashboard/sites/site-launch-celebration-modal/index.tsx
@@ -88,7 +88,7 @@ export default function SiteLaunchCelebrationModal( {
 
 		if ( ! isPaidPlan && ! hasCustomDomain ) {
 			contentElement = (
-				<Text as="p" className="flex-shrink-safe">
+				<Text as="p">
 					{ createInterpolateElement(
 						__(
 							'Supercharge your website with a <strong>custom address</strong> that matches your blog, brand, or business.'
@@ -101,7 +101,7 @@ export default function SiteLaunchCelebrationModal( {
 			buttonHref = getAddSiteDomainUrl( site.slug );
 		} else if ( isPaidPlan && isBilledMonthly && ! hasCustomDomain ) {
 			contentElement = (
-				<Text as="p" className="flex-shrink-safe">
+				<Text as="p">
 					{ __(
 						'Interested in a custom domain? It’s free for the first year when you switch to annual billing.'
 					) }
@@ -111,7 +111,7 @@ export default function SiteLaunchCelebrationModal( {
 			buttonHref = getAddSiteDomainUrl( site.slug );
 		} else if ( isPaidPlan && ! hasCustomDomain ) {
 			contentElement = (
-				<Text as="p" className="flex-shrink-safe">
+				<Text as="p">
 					{ createInterpolateElement(
 						__(
 							'Your paid plan includes a domain name <strong>free for one year</strong>. Choose one that’s easy to remember and even easier to share.'
@@ -127,7 +127,7 @@ export default function SiteLaunchCelebrationModal( {
 		}
 
 		return (
-			<HStack spacing={ 3 } alignment="bottomRight">
+			<VStack spacing={ 4 } alignment="left">
 				{ contentElement }
 				<Button
 					variant="primary"
@@ -140,7 +140,7 @@ export default function SiteLaunchCelebrationModal( {
 				>
 					{ buttonText }
 				</Button>
-			</HStack>
+			</VStack>
 		);
 	};
 

--- a/client/dashboard/sites/site-launch-celebration-modal/index.tsx
+++ b/client/dashboard/sites/site-launch-celebration-modal/index.tsx
@@ -6,7 +6,7 @@ import {
 	Button,
 	Modal,
 } from '@wordpress/components';
-import { useEvent } from '@wordpress/compose';
+import { useEvent, useViewportMatch } from '@wordpress/compose';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { copy, globe } from '@wordpress/icons';
@@ -42,6 +42,7 @@ export default function SiteLaunchCelebrationModal( {
 		select: ( data ) => data.filter( ( domain ) => domain.blog_id === site.ID ),
 	} );
 	const copyButtonRef = useRef< HTMLButtonElement >( null );
+	const isMobileViewport = useViewportMatch( 'small', '<' );
 
 	const onOpen = useEvent( () => {
 		externalOnOpen?.();
@@ -88,7 +89,7 @@ export default function SiteLaunchCelebrationModal( {
 
 		if ( ! isPaidPlan && ! hasCustomDomain ) {
 			contentElement = (
-				<Text as="p">
+				<Text as="p" className="flex-shrink-safe">
 					{ createInterpolateElement(
 						__(
 							'Supercharge your website with a <strong>custom address</strong> that matches your blog, brand, or business.'
@@ -101,7 +102,7 @@ export default function SiteLaunchCelebrationModal( {
 			buttonHref = getAddSiteDomainUrl( site.slug );
 		} else if ( isPaidPlan && isBilledMonthly && ! hasCustomDomain ) {
 			contentElement = (
-				<Text as="p">
+				<Text as="p" className="flex-shrink-safe">
 					{ __(
 						'Interested in a custom domain? It’s free for the first year when you switch to annual billing.'
 					) }
@@ -111,7 +112,7 @@ export default function SiteLaunchCelebrationModal( {
 			buttonHref = getAddSiteDomainUrl( site.slug );
 		} else if ( isPaidPlan && ! hasCustomDomain ) {
 			contentElement = (
-				<Text as="p">
+				<Text as="p" className="flex-shrink-safe">
 					{ createInterpolateElement(
 						__(
 							'Your paid plan includes a domain name <strong>free for one year</strong>. Choose one that’s easy to remember and even easier to share.'
@@ -126,21 +127,30 @@ export default function SiteLaunchCelebrationModal( {
 			return null;
 		}
 
-		return (
+		const upsellButton = (
+			<Button
+				variant="primary"
+				href={ buttonHref }
+				onClick={ () =>
+					recordTracksEvent( 'calypso_launchpad_celebration_modal_upsell_clicked', {
+						product_slug: site?.plan?.product_slug,
+					} )
+				}
+			>
+				{ buttonText }
+			</Button>
+		);
+
+		return isMobileViewport ? (
 			<VStack spacing={ 4 } alignment="left">
 				{ contentElement }
-				<Button
-					variant="primary"
-					href={ buttonHref }
-					onClick={ () =>
-						recordTracksEvent( 'calypso_launchpad_celebration_modal_upsell_clicked', {
-							product_slug: site?.plan?.product_slug,
-						} )
-					}
-				>
-					{ buttonText }
-				</Button>
+				{ upsellButton }
 			</VStack>
+		) : (
+			<HStack spacing={ 3 } alignment="bottomRight">
+				{ contentElement }
+				{ upsellButton }
+			</HStack>
 		);
 	};
 


### PR DESCRIPTION
Part of [DSGCOM-635](https://linear.app/a8c/issue/DSGCOM-635)

## Proposed Changes

- Update the mobile layout of the MSD "Congrats, your site is live!" site launch modal by stacking and left-aligning the domain upsell button to the left

This is the MSD counterpart to this [Jetpack PR](https://github.com/Automattic/jetpack/pull/50544), which applies the same layout to the wp-admin site launch modal.

### Screenshots

| Before | After |
| --- | --- |
| <img width="612" height="882" alt="Screenshot 2026-07-15 at 12 52 34" src="https://github.com/user-attachments/assets/d91703ea-03c4-4fbe-b05d-20901002cd47" /> | <img width="612" height="882" alt="Screenshot 2026-07-15 at 12 52 13" src="https://github.com/user-attachments/assets/7fca2017-37c5-4801-9674-0e7b621fbfc7" /> |

## Why are these changes being made?

The previous layout felt cramped. Putting the text and button on their own lines lets the copy flow more freely. The issue DSGCOM-635 was verified on wp-admin, so this PR also keeps the layout consistent between surfaces.

## Testing Instructions

- In the MSD, on a site that's already launched, append `?celebrateLaunch=true` to the URL
- In mobile view, ensure the modal layout looks correct
- Check desktop view and ensure the layout is unchanged

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)