### PR TITLE
Checkout: fix redirect payment QR dialog under React 19

### DIFF
--- a/client/my-sites/checkout/src/lib/pix-automatico-processor.ts
+++ b/client/my-sites/checkout/src/lib/pix-automatico-processor.ts
@@ -1,6 +1,7 @@
 import { makeErrorResponse, makeSuccessResponse } from '@automattic/composite-checkout';
 import { isValidBrazilianTaxId } from '@automattic/wpcom-checkout';
 import { createElement } from 'react';
+import { flushSync } from 'react-dom';
 import { Root, createRoot } from 'react-dom/client';
 import { PurchaseOrderStatus, fetchPurchaseOrder } from '../hooks/use-purchase-order';
 import { recordTransactionBeginAnalytics } from '../lib/analytics';
@@ -107,12 +108,14 @@ export async function pixAutomaticoProcessor(
 		'Payment failed. Please check your account and try again.'
 	);
 
-	const root = getRenderRoot( genericErrorMessage );
+	const container = createModalContainer();
+	let root: Root | null = null;
 	let rootUnmounted = false;
 	const safeDismissModal = () => {
 		if ( ! rootUnmounted ) {
 			rootUnmounted = true;
-			hideModal( root );
+			root?.unmount();
+			container.remove();
 		}
 	};
 
@@ -138,8 +141,8 @@ export async function pixAutomaticoProcessor(
 
 			let isModalActive = true;
 			let explicitClosureMessage: string | undefined;
-			displayModal( {
-				root,
+			root = displayModal( {
+				container,
 				qrCode: response.qr_code,
 				priceInteger: responseCart.total_cost_integer,
 				priceCurrency: responseCart.currency,
@@ -198,22 +201,17 @@ async function pollForOrderStatus(
 	return orderData.processing_status;
 }
 
-function getRenderRoot( genericErrorMessage: string ) {
-	const dialogTarget = document.querySelector( '.pix-automatico-modal-target' );
-	if ( ! dialogTarget ) {
-		// eslint-disable-next-line no-console
-		console.error( 'Dialog target was not found.' );
-		throw new Error( genericErrorMessage );
-	}
-	return createRoot( dialogTarget );
-}
-
-function hideModal( root: Root ): void {
-	root.unmount();
+function createModalContainer(): HTMLElement {
+	// Render into a fresh container appended to the body rather than a node
+	// owned by the outer checkout React tree.
+	const container = document.createElement( 'div' );
+	container.className = 'pix-automatico-modal-target';
+	document.body.appendChild( container );
+	return container;
 }
 
 function displayModal( {
-	root,
+	container,
 	qrCode,
 	priceInteger,
 	priceCurrency,
@@ -223,7 +221,7 @@ function displayModal( {
 	isJetpackNotAtomic,
 	isPixAutomatico,
 }: {
-	root: Root;
+	container: HTMLElement;
 	qrCode: string;
 	priceInteger: number;
 	priceCurrency: string;
@@ -232,36 +230,39 @@ function displayModal( {
 	isAkismet: boolean;
 	isJetpackNotAtomic: boolean;
 	isPixAutomatico: boolean;
-} ) {
-	root.render(
-		createElement( PixConfirmation, {
-			qrCode,
-			priceInteger,
-			priceCurrency,
-			cancel,
-			isAkismet,
-			isJetpackNotAtomic,
-			isPixAutomatico,
-		} )
-	);
-
-	// We have to activate the `<dialog>` element after a moment because we
-	// need to give React a chance to render it.
-	setTimeout( () => {
-		const dialogElement = document.querySelector( 'dialog.pix-confirmation' );
-		if ( ! dialogElement || ! ( 'showModal' in dialogElement ) ) {
-			// eslint-disable-next-line no-console
-			console.error( 'Dialog was not found or browser does not support dialogs.' );
-			error();
-			return;
-		}
-
-		// dialog elements are a new addition to HTML but should be
-		// supported by all the browsers that calypso supports.
-		// Nevertheless, TypeScript does not know about it.
-		( dialogElement.showModal as () => void )();
-		dialogElement.addEventListener( 'close', () => cancel() );
+} ): Root {
+	// Create the root and render into it in the same tick: under React 19 a
+	// root created earlier (before the async transaction) never commits its
+	// later render. flushSync forces the render to commit synchronously so the
+	// dialog element exists in the DOM before we call showModal().
+	const root = createRoot( container );
+	flushSync( () => {
+		root.render(
+			createElement( PixConfirmation, {
+				qrCode,
+				priceInteger,
+				priceCurrency,
+				cancel,
+				isAkismet,
+				isJetpackNotAtomic,
+				isPixAutomatico,
+			} )
+		);
 	} );
+
+	const dialogElement = container.querySelector( 'dialog.pix-confirmation' );
+	if ( ! dialogElement || ! ( 'showModal' in dialogElement ) ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Dialog was not found or browser does not support dialogs.' );
+		error();
+		return root;
+	}
+
+	// dialog elements are a new addition to HTML but should be
+	// supported by all the browsers that calypso supports.
+	// Nevertheless, TypeScript does not know about it.
+	( dialogElement.showModal as () => void )();
+	dialogElement.addEventListener( 'close', () => cancel() );
 	return root;
 }
 

--- a/client/my-sites/checkout/src/lib/pix-processor.ts
+++ b/client/my-sites/checkout/src/lib/pix-processor.ts
@@ -1,6 +1,7 @@
 import { makeErrorResponse, makeSuccessResponse } from '@automattic/composite-checkout';
 import { isValidBrazilianTaxId } from '@automattic/wpcom-checkout';
 import { createElement } from 'react';
+import { flushSync } from 'react-dom';
 import { Root, createRoot } from 'react-dom/client';
 import { PurchaseOrderStatus, fetchPurchaseOrder } from '../hooks/use-purchase-order';
 import { recordTransactionBeginAnalytics } from '../lib/analytics';
@@ -107,12 +108,14 @@ export async function pixProcessor(
 		'Payment failed. Please check your account and try again.'
 	);
 
-	const root = getRenderRoot( genericErrorMessage );
+	const container = createModalContainer();
+	let root: Root | null = null;
 	let rootUnmounted = false;
 	const safeDismissModal = () => {
 		if ( ! rootUnmounted ) {
 			rootUnmounted = true;
-			hideModal( root );
+			root?.unmount();
+			container.remove();
 		}
 	};
 
@@ -138,8 +141,8 @@ export async function pixProcessor(
 
 			let isModalActive = true;
 			let explicitClosureMessage: string | undefined;
-			displayModal( {
-				root,
+			root = displayModal( {
+				container,
 				qrCode: response.qr_code,
 				priceInteger: responseCart.total_cost_integer,
 				priceCurrency: responseCart.currency,
@@ -198,22 +201,17 @@ async function pollForOrderStatus(
 	return orderData.processing_status;
 }
 
-function getRenderRoot( genericErrorMessage: string ) {
-	const dialogTarget = document.querySelector( '.pix-modal-target' );
-	if ( ! dialogTarget ) {
-		// eslint-disable-next-line no-console
-		console.error( 'Dialog target was not found.' );
-		throw new Error( genericErrorMessage );
-	}
-	return createRoot( dialogTarget );
-}
-
-function hideModal( root: Root ): void {
-	root.unmount();
+function createModalContainer(): HTMLElement {
+	// Render into a fresh container appended to the body rather than a node
+	// owned by the outer checkout React tree.
+	const container = document.createElement( 'div' );
+	container.className = 'pix-modal-target';
+	document.body.appendChild( container );
+	return container;
 }
 
 function displayModal( {
-	root,
+	container,
 	qrCode,
 	priceInteger,
 	priceCurrency,
@@ -223,7 +221,7 @@ function displayModal( {
 	isJetpackNotAtomic,
 	isPixAutomatico,
 }: {
-	root: Root;
+	container: HTMLElement;
 	qrCode: string;
 	priceInteger: number;
 	priceCurrency: string;
@@ -232,36 +230,39 @@ function displayModal( {
 	isAkismet: boolean;
 	isJetpackNotAtomic: boolean;
 	isPixAutomatico: boolean;
-} ) {
-	root.render(
-		createElement( PixConfirmation, {
-			qrCode,
-			priceInteger,
-			priceCurrency,
-			cancel,
-			isAkismet,
-			isJetpackNotAtomic,
-			isPixAutomatico,
-		} )
-	);
-
-	// We have to activate the `<dialog>` element after a moment because we
-	// need to give React a chance to render it.
-	setTimeout( () => {
-		const dialogElement = document.querySelector( 'dialog.pix-confirmation' );
-		if ( ! dialogElement || ! ( 'showModal' in dialogElement ) ) {
-			// eslint-disable-next-line no-console
-			console.error( 'Dialog was not found or browser does not support dialogs.' );
-			error();
-			return;
-		}
-
-		// dialog elements are a new addition to HTML but should be
-		// supported by all the browsers that calypso supports.
-		// Nevertheless, TypeScript does not know about it.
-		( dialogElement.showModal as () => void )();
-		dialogElement.addEventListener( 'close', () => cancel() );
+} ): Root {
+	// Create the root and render into it in the same tick: under React 19 a
+	// root created earlier (before the async transaction) never commits its
+	// later render. flushSync forces the render to commit synchronously so the
+	// dialog element exists in the DOM before we call showModal().
+	const root = createRoot( container );
+	flushSync( () => {
+		root.render(
+			createElement( PixConfirmation, {
+				qrCode,
+				priceInteger,
+				priceCurrency,
+				cancel,
+				isAkismet,
+				isJetpackNotAtomic,
+				isPixAutomatico,
+			} )
+		);
 	} );
+
+	const dialogElement = container.querySelector( 'dialog.pix-confirmation' );
+	if ( ! dialogElement || ! ( 'showModal' in dialogElement ) ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Dialog was not found or browser does not support dialogs.' );
+		error();
+		return root;
+	}
+
+	// dialog elements are a new addition to HTML but should be
+	// supported by all the browsers that calypso supports.
+	// Nevertheless, TypeScript does not know about it.
+	( dialogElement.showModal as () => void )();
+	dialogElement.addEventListener( 'close', () => cancel() );
 	return root;
 }
 

--- a/client/my-sites/checkout/src/lib/upi-processor.ts
+++ b/client/my-sites/checkout/src/lib/upi-processor.ts
@@ -1,5 +1,6 @@
 import { makeErrorResponse, makeSuccessResponse } from '@automattic/composite-checkout';
 import { createElement } from 'react';
+import { flushSync } from 'react-dom';
 import { Root, createRoot } from 'react-dom/client';
 import { PurchaseOrderStatus, fetchPurchaseOrder } from '../hooks/use-purchase-order';
 import { recordTransactionBeginAnalytics } from '../lib/analytics';
@@ -121,12 +122,14 @@ export default async function upiProcessor(
 		'Payment failed. Please check your account and try again.'
 	);
 
-	const root = getRenderRoot( genericErrorMessage );
+	const container = createModalContainer();
+	let root: Root | null = null;
 	let rootUnmounted = false;
 	const safeDismissModal = () => {
 		if ( ! rootUnmounted ) {
 			rootUnmounted = true;
-			hideModal( root );
+			root?.unmount();
+			container.remove();
 		}
 	};
 
@@ -147,8 +150,8 @@ export default async function upiProcessor(
 
 			let isModalActive = true;
 			let explicitClosureMessage: string | undefined;
-			displayModal( {
-				root,
+			root = displayModal( {
+				container,
 				redirectUrl,
 				cancel: () => {
 					safeDismissModal();
@@ -278,55 +281,48 @@ async function pollForOrderStatus(
 	return orderData.processing_status;
 }
 
-function getRenderRoot( genericErrorMessage: string ) {
-	const dialogTarget = document.querySelector( '.upi-modal-target' );
-	if ( ! dialogTarget ) {
-		// eslint-disable-next-line no-console
-		console.error( 'Dialog target was not found.' );
-		throw new Error( genericErrorMessage );
-	}
-	return createRoot( dialogTarget );
-}
-
-function hideModal( root: Root ): void {
-	root.unmount();
+function createModalContainer(): HTMLElement {
+	// Render into a fresh container appended to the body rather than a node
+	// owned by the outer checkout React tree.
+	const container = document.createElement( 'div' );
+	container.className = 'upi-modal-target';
+	document.body.appendChild( container );
+	return container;
 }
 
 function displayModal( {
-	root,
+	container,
 	redirectUrl,
 	cancel,
 	error,
 }: {
-	root: Root;
+	container: HTMLElement;
 	redirectUrl: string;
 	cancel: () => void;
 	error: () => void;
-} ) {
-	root.render(
-		createElement( UpiConfirmation, {
-			redirectUrl,
-			cancel,
-		} )
-	);
-
-	// We have to activate the `<dialog>` element after a moment because we
-	// need to give React a chance to render it.
-	setTimeout( () => {
-		const dialogElement = document.querySelector( 'dialog.upi-confirmation' );
-		if ( ! dialogElement || ! ( 'showModal' in dialogElement ) ) {
-			// eslint-disable-next-line no-console
-			console.error( 'Dialog was not found or browser does not support dialogs.' );
-			error();
-			return;
-		}
-
-		// dialog elements are a new addition to HTML but should be
-		// supported by all the browsers that calypso supports.
-		// Nevertheless, TypeScript does not know about it.
-		( dialogElement.showModal as () => void )();
-		dialogElement.addEventListener( 'close', () => cancel() );
+} ): Root {
+	// Create the root and render into it in the same tick: under React 19 a
+	// root created earlier (before the async transaction) never commits its
+	// later render. flushSync forces the render to commit synchronously so the
+	// dialog element exists in the DOM before we call showModal().
+	const root = createRoot( container );
+	flushSync( () => {
+		root.render( createElement( UpiConfirmation, { redirectUrl, cancel } ) );
 	} );
+
+	const dialogElement = container.querySelector( 'dialog.upi-confirmation' );
+	if ( ! dialogElement || ! ( 'showModal' in dialogElement ) ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Dialog was not found or browser does not support dialogs.' );
+		error();
+		return root;
+	}
+
+	// dialog elements are a new addition to HTML but should be
+	// supported by all the browsers that calypso supports.
+	// Nevertheless, TypeScript does not know about it.
+	( dialogElement.showModal as () => void )();
+	dialogElement.addEventListener( 'close', () => cancel() );
 	return root;
 }
 

--- a/client/my-sites/checkout/src/lib/we-chat-processor.ts
+++ b/client/my-sites/checkout/src/lib/we-chat-processor.ts
@@ -4,6 +4,7 @@ import {
 	makeSuccessResponse,
 } from '@automattic/composite-checkout';
 import { createElement } from 'react';
+import { flushSync } from 'react-dom';
 import { Root, createRoot } from 'react-dom/client';
 import userAgent from 'calypso/lib/user-agent';
 import { PurchaseOrderStatus, fetchPurchaseOrder } from '../hooks/use-purchase-order';
@@ -91,7 +92,8 @@ export default async function weChatProcessor(
 		'Payment failed. Please check your account and try again.'
 	);
 
-	const root = getRenderRoot( genericErrorMessage );
+	const container = createModalContainer();
+	let root: Root | null = null;
 
 	return submitWpcomTransaction( formattedTransactionData, options )
 		.then( async ( response?: WPCOMTransactionEndpointResponse ) => {
@@ -115,18 +117,18 @@ export default async function weChatProcessor(
 
 			let isModalActive = true;
 			let explicitClosureMessage: string | undefined;
-			displayWeChatModal(
-				root,
+			root = displayWeChatModal(
+				container,
 				response.redirect_url,
 				responseCart.total_cost_integer,
 				responseCart.currency,
 				() => {
-					hideWeChatModal( root );
+					hideWeChatModal( root, container );
 					isModalActive = false;
 					explicitClosureMessage = translate( 'Payment cancelled.' );
 				},
 				() => {
-					hideWeChatModal( root );
+					hideWeChatModal( root, container );
 					isModalActive = false;
 					explicitClosureMessage = genericErrorMessage;
 				}
@@ -147,7 +149,7 @@ export default async function weChatProcessor(
 			return makeSuccessResponse( responseData );
 		} )
 		.catch( ( error ) => {
-			hideWeChatModal( root );
+			hideWeChatModal( root, container );
 			return makeErrorResponse( error.message );
 		} );
 }
@@ -170,58 +172,61 @@ async function pollForOrderStatus(
 	return orderData.processing_status;
 }
 
-function getRenderRoot( genericErrorMessage: string ) {
-	const weChatTarget = document.querySelector( '.we-chat-modal-target' );
-	if ( ! weChatTarget ) {
-		// eslint-disable-next-line no-console
-		console.error( 'Dialog target was not found.' );
-		throw new Error( genericErrorMessage );
-	}
-	return createRoot( weChatTarget );
+function createModalContainer(): HTMLElement {
+	// Render into a fresh container appended to the body rather than a node
+	// owned by the outer checkout React tree.
+	const container = document.createElement( 'div' );
+	container.className = 'we-chat-modal-target';
+	document.body.appendChild( container );
+	return container;
 }
 
-function hideWeChatModal( root: Root ): void {
-	root.unmount();
+function hideWeChatModal( root: Root | null, container: HTMLElement ): void {
+	root?.unmount();
+	container.remove();
 }
 
 function displayWeChatModal(
-	root: Root,
+	container: HTMLElement,
 	redirectUrl: string,
 	priceInteger: number,
 	priceCurrency: string,
 	cancel: () => void,
 	error: () => void
-) {
-	root.render(
-		createElement( WeChatConfirmation, {
-			redirectUrl,
-			priceInteger,
-			priceCurrency,
-		} )
-	);
+): Root {
+	// Create the root and render into it in the same tick: under React 19 a
+	// root created earlier (before the async transaction) never commits its
+	// later render. flushSync forces the render to commit synchronously so the
+	// dialog element exists in the DOM before we call showModal().
+	const root = createRoot( container );
+	flushSync( () => {
+		root.render(
+			createElement( WeChatConfirmation, {
+				redirectUrl,
+				priceInteger,
+				priceCurrency,
+			} )
+		);
+	} );
 
-	// We have to activate the `<dialog>` element after a moment because we
-	// need to give React a chance to render it.
-	setTimeout( () => {
-		const dialogElement = document.querySelector( 'dialog.we-chat-confirmation' );
-		if ( ! dialogElement || ! ( 'showModal' in dialogElement ) ) {
-			// eslint-disable-next-line no-console
-			console.error( 'Dialog was not found or browser does not support dialogs.' );
-			error();
-			return;
+	const dialogElement = container.querySelector( 'dialog.we-chat-confirmation' );
+	if ( ! dialogElement || ! ( 'showModal' in dialogElement ) ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Dialog was not found or browser does not support dialogs.' );
+		error();
+		return root;
+	}
+
+	// dialog elements are a new addition to HTML but should be
+	// supported by all the browsers that calypso supports.
+	// Nevertheless, TypeScript does not know about it.
+	( dialogElement.showModal as () => void )();
+	dialogElement.addEventListener( 'close', () => cancel() );
+	// Hide the dialog if you click outside it.
+	dialogElement.addEventListener( 'click', ( event ) => {
+		if ( event.target === event.currentTarget ) {
+			cancel();
 		}
-
-		// dialog elements are a new addition to HTML but should be
-		// supported by all the browsers that calypso supports.
-		// Nevertheless, TypeScript does not know about it.
-		( dialogElement.showModal as () => void )();
-		dialogElement.addEventListener( 'close', () => cancel() );
-		// Hide the dialog if you click outside it.
-		dialogElement.addEventListener( 'click', ( event ) => {
-			if ( event.target === event.currentTarget ) {
-				cancel();
-			}
-		} );
 	} );
 	return root;
 }

--- a/client/my-sites/checkout/src/payment-methods/pix.tsx
+++ b/client/my-sites/checkout/src/payment-methods/pix.tsx
@@ -311,7 +311,6 @@ function PixPayButton( {
 			fullWidth
 		>
 			{ submitButtonContent }
-			<div className="pix-modal-target" />
 		</Button>
 	);
 }
@@ -356,7 +355,6 @@ function PixAutomaticoPayButton( {
 			fullWidth
 		>
 			{ submitButtonContent }
-			<div className="pix-automatico-modal-target" />
 		</Button>
 	);
 }

--- a/client/my-sites/checkout/src/payment-methods/wechat/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/wechat/index.tsx
@@ -168,7 +168,6 @@ function WeChatPayButton( {
 					stripZeros: true,
 				} ) }
 			/>
-			<div className="we-chat-modal-target" />
 		</Button>
 	);
 }

--- a/client/my-sites/checkout/src/test/upi-processor.ts
+++ b/client/my-sites/checkout/src/test/upi-processor.ts
@@ -20,6 +20,22 @@ import {
 } from './util';
 
 describe( 'upiProcessor', () => {
+	// jsdom does not implement the native <dialog> showModal/close API, so
+	// polyfill them to mirror a browser that supports dialogs.
+	beforeAll( () => {
+		if ( ! HTMLDialogElement.prototype.showModal ) {
+			HTMLDialogElement.prototype.showModal = function showModal() {
+				this.open = true;
+			};
+		}
+		if ( ! HTMLDialogElement.prototype.close ) {
+			HTMLDialogElement.prototype.close = function close() {
+				this.open = false;
+				this.dispatchEvent( new Event( 'close' ) );
+			};
+		}
+	} );
+
 	const product = getEmptyResponseCartProduct();
 	const domainProduct = {
 		...getEmptyResponseCartProduct(),
@@ -97,7 +113,7 @@ describe( 'upiProcessor', () => {
 			mockTransactionsRedirectResponse( orderId )
 		);
 		const expected = {
-			payload: "Sorry, we couldn't process your payment. Please try again later.",
+			payload: 'Payment failed. Please check your account and try again.',
 			type: 'ERROR',
 		};
 
@@ -155,6 +171,38 @@ describe( 'upiProcessor', () => {
 		} );
 	} );
 
+	it( 'does not require a pre-existing modal target to be rendered', async () => {
+		// Intentionally do NOT render a `.upi-modal-target` element. In
+		// production that element is rendered by the outer checkout React tree,
+		// and mounting the dialog root into it breaks under React 19 (the outer
+		// re-render wipes the nested root). The processor must create its own
+		// modal container so it never depends on an outer-owned node.
+		mockTransactionsEndpoint( () => [
+			400,
+			{
+				error: 'test_error',
+				message: 'test error',
+			},
+		] );
+		const expected = { payload: 'test error', type: 'ERROR' };
+
+		await act( async () => {
+			await expect(
+				upiProcessor(
+					submitData,
+					{
+						...options,
+						contactDetails: {
+							countryCode,
+							postalCode,
+						},
+					},
+					translate
+				)
+			).resolves.toStrictEqual( expected );
+		} );
+	} );
+
 	it( 'sends the correct data to the endpoint with a site and one product', async () => {
 		// The processor renders the dialog into a div so that div must be
 		// present to avoid errors.
@@ -172,7 +220,7 @@ describe( 'upiProcessor', () => {
 			mockTransactionsRedirectResponse( orderId )
 		);
 		const expected = {
-			payload: "Sorry, we couldn't process your payment. Please try again later.",
+			payload: 'Payment failed. Please check your account and try again.',
 			type: 'ERROR',
 		};
 
@@ -229,7 +277,7 @@ describe( 'upiProcessor', () => {
 			mockTransactionsRedirectResponse( orderId )
 		);
 		const expected = {
-			payload: "Sorry, we couldn't process your payment. Please try again later.",
+			payload: 'Payment failed. Please check your account and try again.',
 			type: 'ERROR',
 		};
 
@@ -297,7 +345,7 @@ describe( 'upiProcessor', () => {
 			mockTransactionsRedirectResponse( orderId )
 		);
 		const expected = {
-			payload: "Sorry, we couldn't process your payment. Please try again later.",
+			payload: 'Payment failed. Please check your account and try again.',
 			type: 'ERROR',
 		};
 

--- a/client/my-sites/checkout/src/test/we-chat-processor.ts
+++ b/client/my-sites/checkout/src/test/we-chat-processor.ts
@@ -20,6 +20,22 @@ import {
 } from './util';
 
 describe( 'weChatProcessor', () => {
+	// jsdom does not implement the native <dialog> showModal/close API, so
+	// polyfill them to mirror a browser that supports dialogs.
+	beforeAll( () => {
+		if ( ! HTMLDialogElement.prototype.showModal ) {
+			HTMLDialogElement.prototype.showModal = function showModal() {
+				this.open = true;
+			};
+		}
+		if ( ! HTMLDialogElement.prototype.close ) {
+			HTMLDialogElement.prototype.close = function close() {
+				this.open = false;
+				this.dispatchEvent( new Event( 'close' ) );
+			};
+		}
+	} );
+
 	const product = getEmptyResponseCartProduct();
 	const domainProduct = {
 		...getEmptyResponseCartProduct(),
@@ -86,7 +102,7 @@ describe( 'weChatProcessor', () => {
 			name: 'test name',
 		};
 		const expected = {
-			payload: "Sorry, we couldn't process your payment. Please try again later.",
+			payload: 'Payment failed. Please check your account and try again.',
 			type: 'ERROR',
 		};
 
@@ -168,7 +184,7 @@ describe( 'weChatProcessor', () => {
 			name: 'test name',
 		};
 		const expected = {
-			payload: "Sorry, we couldn't process your payment. Please try again later.",
+			payload: 'Payment failed. Please check your account and try again.',
 			type: 'ERROR',
 		};
 
@@ -228,7 +244,7 @@ describe( 'weChatProcessor', () => {
 			name: 'test name',
 		};
 		const expected = {
-			payload: "Sorry, we couldn't process your payment. Please try again later.",
+			payload: 'Payment failed. Please check your account and try again.',
 			type: 'ERROR',
 		};
 
@@ -299,7 +315,7 @@ describe( 'weChatProcessor', () => {
 			name: 'test name',
 		};
 		const expected = {
-			payload: "Sorry, we couldn't process your payment. Please try again later.",
+			payload: 'Payment failed. Please check your account and try again.',
 			type: 'ERROR',
 		};
 

--- a/packages/wpcom-checkout/src/payment-methods/stripe-upi.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/stripe-upi.tsx
@@ -344,32 +344,29 @@ export function StripeUpiSubmitButton( {
 	}
 
 	return (
-		<>
-			<Button
-				disabled={ disabled }
-				onClick={ ( ev ) => {
-					ev.preventDefault();
-					if ( state.isValid() ) {
-						debug( 'Initiate Stripe UPI payment' );
-						onClick( {
-							name: state.data.customerName,
-							address: state.data.address,
-							streetNumber: state.data.streetNumber,
-							city: state.data.city,
-							state: state.data.state,
-							postalCode: state.data.postalCode,
-							country: state.data.country,
-						} );
-					}
-				} }
-				buttonType="primary"
-				isBusy={ FormStatus.SUBMITTING === formStatus }
-				fullWidth
-			>
-				{ submitButtonContent }
-			</Button>
-			<div className="upi-modal-target" />
-		</>
+		<Button
+			disabled={ disabled }
+			onClick={ ( ev ) => {
+				ev.preventDefault();
+				if ( state.isValid() ) {
+					debug( 'Initiate Stripe UPI payment' );
+					onClick( {
+						name: state.data.customerName,
+						address: state.data.address,
+						streetNumber: state.data.streetNumber,
+						city: state.data.city,
+						state: state.data.state,
+						postalCode: state.data.postalCode,
+						country: state.data.country,
+					} );
+				}
+			} }
+			buttonType="primary"
+			isBusy={ FormStatus.SUBMITTING === formStatus }
+			fullWidth
+		>
+			{ submitButtonContent }
+		</Button>
 	);
 }
 


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/SHILL-2254/upi-transactions-fail-after-react-19-checkout-change

## Proposed Changes

Stripe/redirect payment methods (UPI, WeChat, PIX, PIX Automático) show their confirmation dialog in a second React root. This restores that dialog under React 19 by creating the root at render time and committing it synchronously.

* Create the modal React root at render time (inside `displayModal`) instead of early in `getRenderRoot`, and `flushSync` the render so the dialog is in the DOM before `showModal()` runs.
* Query the dialog and call `showModal()` synchronously, removing the fragile `setTimeout` that raced React 19's async commit.
* Mount into a fresh `document.body`-appended container rather than a node owned by the outer checkout React tree.
* Remove the now-unused `.upi-modal-target` / `.pix-modal-target` / `.pix-automatico-modal-target` / `.we-chat-modal-target` mount points from the payment method components.
* Add a regression test asserting the processor no longer depends on a pre-existing modal target; polyfill jsdom's missing `HTMLDialogElement.showModal`/`close`; correct the `payment-failure` expectations to the real "Payment failed" message.

## Why are these changes being made?

After the React 19 runtime upgrade, submitting a Stripe/redirect payment method that shows a QR-code dialog (e.g. UPI) failed with "Sorry, we couldn't process your payment" and never displayed the dialog.

Root cause: each processor created its dialog React root early — in `getRenderRoot`, before the async `submitWpcomTransaction` — and only called `root.render()` later, in `displayModal`, after the network round-trip. Under React 19, a `.render()` into a root created that much earlier never commits, so the dialog element is never added to the DOM. The subsequent `setTimeout` check then hits the "Dialog was not found" branch, calls `error()`, and fails the transaction. A compounding issue: React 19 commits a fresh `createRoot().render()` only after a `setTimeout(0)` macrotask, so even a correctly-created root would not be found by the old `setTimeout`-based check.

The fix creates the root at render time and uses `flushSync` to force a synchronous commit, then queries the dialog and calls `showModal()` synchronously — removing the timing race entirely. Instrumentation confirmed the same component renders fine when its root is created at render time but stays empty when created early.

BLIK shares the same code pattern but is intentionally left unchanged: it renders a `@wordpress/components` Modal with no "dialog not found" error path, so it does not fail the transaction the same way, and its transaction volume showed no regression.

## Testing Instructions

TC:
```
yarn test-client client/my-sites/checkout/src/test/upi-processor.ts client/my-sites/checkout/src/test/we-chat-processor.ts
```

Manual testing:
* On a Simple site checkout with an INR cart, choose UPI and click Pay now.
* Confirm the QR-code dialog appears instead of the "couldn't process your payment" error, and the console shows no "Dialog was not found" error.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)