### PR TITLE
Jetpack AI: Group Writing tools in Page Editor

### DIFF
--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -312,10 +312,13 @@ describe( 'AgentChat', () => {
 
 		const designButton = screen.getByRole( 'button', { name: 'Customize colors' } );
 		expect( designButton.closest( '.agents-manager-writing-suggestions' ) ).toBeNull();
-		expect( screen.queryByRole( 'button', { name: 'What else can you do?' } ) ).toBeNull();
 		expect( screen.getByText( 'Enhance and review your content.' ) ).toBeInTheDocument();
 
 		const writingToggle = screen.getByRole( 'button', { name: /Writing/ } );
+		const whatElseButton = screen.getByRole( 'button', { name: 'What else can you do?' } );
+		expect( writingToggle.compareDocumentPosition( whatElseButton ) ).toBe(
+			Node.DOCUMENT_POSITION_FOLLOWING
+		);
 		expect( writingToggle ).toHaveAttribute( 'aria-expanded', 'false' );
 		expect( screen.queryByRole( 'button', { name: 'Optimize title' } ) ).toBeNull();
 

--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -350,6 +350,31 @@ describe( 'AgentChat', () => {
 		expect( screen.queryByRole( 'button', { name: /Writing/ } ) ).toBeNull();
 	} );
 
+	it( 'keeps writing suggestions flat when there are no design suggestions', () => {
+		const suggestions = [
+			{
+				id: 'add-new-page',
+				label: 'Add new page',
+				prompt: 'Add a new page',
+			},
+			{
+				id: 'optimize-title',
+				label: 'Optimize Title',
+				prompt: 'Optimize the title of this post',
+			},
+		];
+
+		renderAgentChat( {
+			isOpen: true,
+			emptyViewSuggestions: suggestions,
+			groupWritingSuggestions: true,
+		} );
+
+		expect( screen.getByRole( 'button', { name: 'Add new page' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Optimize Title' } ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: /Writing/ } ) ).toBeNull();
+	} );
+
 	it( 'collapses to a button when closed without the AI chat entry button', () => {
 		renderAgentChat( { isOpen: false } );
 

--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -262,11 +262,26 @@ describe( 'AgentChat', () => {
 			label: 'Customize colors',
 			prompt: 'Customize colors',
 		};
+		const whatElseSuggestion = {
+			id: 'what-else-can-i-do',
+			label: 'What else can you do?',
+			prompt: 'What else can you do?',
+		};
 		const writingSuggestions = [
+			{
+				id: 'optimize-title',
+				label: 'Optimize Title',
+				prompt: 'Optimize the title of this post',
+			},
 			{
 				id: 'generate-excerpt',
 				label: 'Generate Excerpt',
 				prompt: 'Generate an excerpt',
+			},
+			{
+				id: 'seo-enhancer',
+				label: 'SEO Enhancer',
+				prompt: 'Optimize this content for search engines',
 			},
 			{
 				id: 'generate-feedback',
@@ -284,7 +299,7 @@ describe( 'AgentChat', () => {
 				prompt: 'Run an editorial review',
 			},
 		];
-		const suggestions = [ designSuggestion, ...writingSuggestions ];
+		const suggestions = [ designSuggestion, whatElseSuggestion, ...writingSuggestions ];
 		const onSuggestionClick = jest.fn();
 
 		renderAgentChat( {
@@ -296,15 +311,25 @@ describe( 'AgentChat', () => {
 
 		const designButton = screen.getByRole( 'button', { name: 'Customize colors' } );
 		expect( designButton.closest( '.agents-manager-writing-suggestions' ) ).toBeNull();
-		expect( screen.getByRole( 'button', { name: 'Writing 4' } ) ).toHaveAttribute(
-			'aria-expanded',
-			'true'
-		);
+		expect( screen.queryByRole( 'button', { name: 'What else can you do?' } ) ).toBeNull();
+		expect( screen.getByText( 'Improve and refine your content.' ) ).toBeInTheDocument();
 
-		await user.click( screen.getByRole( 'button', { name: 'Proofread' } ) );
-		expect( onSuggestionClick ).toHaveBeenCalledWith( writingSuggestions[ 2 ], suggestions );
+		const writingToggle = screen.getByRole( 'button', { name: /Writing/ } );
+		expect( writingToggle ).toHaveAttribute( 'aria-expanded', 'false' );
+		expect( screen.queryByRole( 'button', { name: 'Optimize title' } ) ).toBeNull();
 
-		await user.click( screen.getByRole( 'button', { name: 'Writing 4' } ) );
+		await user.click( writingToggle );
+		expect( writingToggle ).toHaveAttribute( 'aria-expanded', 'true' );
+		expect( screen.getByRole( 'button', { name: 'Optimize title' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Generate excerpt' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Optimize SEO' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Simple review' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Editorial review' } ) ).toBeInTheDocument();
+
+		await user.click( screen.getByRole( 'button', { name: 'Optimize title' } ) );
+		expect( onSuggestionClick ).toHaveBeenCalledWith( writingSuggestions[ 0 ], suggestions );
+
+		await user.click( writingToggle );
 		expect( screen.queryByRole( 'button', { name: 'Proofread' } ) ).toBeNull();
 	} );
 

--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -313,7 +313,7 @@ describe( 'AgentChat', () => {
 		const designButton = screen.getByRole( 'button', { name: 'Customize colors' } );
 		expect( designButton.closest( '.agents-manager-writing-suggestions' ) ).toBeNull();
 		expect( screen.queryByRole( 'button', { name: 'What else can you do?' } ) ).toBeNull();
-		expect( screen.getByText( 'Improve and refine your content.' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Enhance and review your content.' ) ).toBeInTheDocument();
 
 		const writingToggle = screen.getByRole( 'button', { name: /Writing/ } );
 		expect( writingToggle ).toHaveAttribute( 'aria-expanded', 'false' );

--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -72,6 +72,24 @@ jest.mock(
 			);
 		}
 
+		function MockSuggestions( {
+			suggestions = [],
+			onSubmit,
+		}: {
+			suggestions?: Suggestion[];
+			onSubmit?: ( selectedSuggestion: Suggestion, availableSuggestions: Suggestion[] ) => void;
+		} ) {
+			return (
+				<div>
+					{ suggestions.map( ( suggestion ) => (
+						<button key={ suggestion.id } onClick={ () => onSubmit?.( suggestion, suggestions ) }>
+							{ suggestion.label }
+						</button>
+					) ) }
+				</div>
+			);
+		}
+
 		function MockMessageRenderer( { children }: { children: ReactNode } ) {
 			return <>{ children }</>;
 		}
@@ -97,6 +115,7 @@ jest.mock(
 			},
 			createMessageRenderer: () => MockMessageRenderer,
 			EmptyView: MockEmptyView,
+			Suggestions: MockSuggestions,
 			ImageUploader: MockImageUploader,
 		};
 	},
@@ -113,7 +132,7 @@ jest.mock( '@wordpress/data', () => ( {
 		} ) ),
 } ) );
 
-jest.mock( '@wordpress/i18n', () => ( { __: ( text: string ) => text } ) );
+jest.mock( '@wordpress/i18n', () => ( { __: ( text: string ) => text, isRTL: () => false } ) );
 jest.mock( '../../utils/tracks', () => ( {
 	recordBigSkyTracksEvent: jest.fn(),
 	recordAgentsManagerTracksEvent: jest.fn(),
@@ -234,6 +253,76 @@ describe( 'AgentChat', () => {
 		renderAgentChat( { isOpen: true } );
 
 		expect( mockContainerProps ).toHaveBeenLastCalledWith( { floatingChatState: 'expanded' } );
+	} );
+
+	it( 'groups only writing suggestions while keeping design suggestions top level', async () => {
+		const user = userEvent.setup();
+		const designSuggestion = {
+			id: 'customize-colors',
+			label: 'Customize colors',
+			prompt: 'Customize colors',
+		};
+		const writingSuggestions = [
+			{
+				id: 'generate-excerpt',
+				label: 'Generate Excerpt',
+				prompt: 'Generate an excerpt',
+			},
+			{
+				id: 'generate-feedback',
+				label: 'Simple Review',
+				prompt: 'Review this saved content',
+			},
+			{
+				id: 'proofread-content',
+				label: 'Proofread',
+				prompt: 'Proofread this saved content',
+			},
+			{
+				id: 'mediate-review-notes',
+				label: 'Editorial Review',
+				prompt: 'Run an editorial review',
+			},
+		];
+		const suggestions = [ designSuggestion, ...writingSuggestions ];
+		const onSuggestionClick = jest.fn();
+
+		renderAgentChat( {
+			isOpen: true,
+			emptyViewSuggestions: suggestions,
+			groupWritingSuggestions: true,
+			onSuggestionClick,
+		} );
+
+		const designButton = screen.getByRole( 'button', { name: 'Customize colors' } );
+		expect( designButton.closest( '.agents-manager-writing-suggestions' ) ).toBeNull();
+		expect( screen.getByRole( 'button', { name: 'Writing 4' } ) ).toHaveAttribute(
+			'aria-expanded',
+			'true'
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Proofread' } ) );
+		expect( onSuggestionClick ).toHaveBeenCalledWith( writingSuggestions[ 2 ], suggestions );
+
+		await user.click( screen.getByRole( 'button', { name: 'Writing 4' } ) );
+		expect( screen.queryByRole( 'button', { name: 'Proofread' } ) ).toBeNull();
+	} );
+
+	it( 'keeps the flat empty view when there are no writing suggestions', () => {
+		const suggestion = {
+			id: 'customize-colors',
+			label: 'Customize colors',
+			prompt: 'Customize colors',
+		};
+
+		renderAgentChat( {
+			isOpen: true,
+			emptyViewSuggestions: [ suggestion ],
+			groupWritingSuggestions: true,
+		} );
+
+		expect( screen.getByRole( 'button', { name: 'Customize colors' } ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: /Writing/ } ) ).toBeNull();
 	} );
 
 	it( 'collapses to a button when closed without the AI chat entry button', () => {

--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -198,6 +198,7 @@ describe( 'AgentChat', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockHasAiChatEntry.mockReturnValue( false );
+		document.body.className = '';
 	} );
 
 	const imageUpload = ( isUploadingImages: boolean ) =>
@@ -371,8 +372,45 @@ describe( 'AgentChat', () => {
 		} );
 
 		expect( screen.getByRole( 'button', { name: 'Add new page' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: 'Optimize Title' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Optimize title' } ) ).toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: /Writing/ } ) ).toBeNull();
+	} );
+
+	it( 'uses sentence-case writing labels in ungrouped editor views', async () => {
+		const user = userEvent.setup();
+		document.body.classList.add( 'post-php', 'post-type-post' );
+		const suggestion = {
+			id: 'optimize-title',
+			label: 'Optimize Title',
+			prompt: 'Optimize the title of this post',
+		};
+		const onSuggestionClick = jest.fn();
+
+		renderAgentChat( {
+			isOpen: true,
+			emptyViewSuggestions: [ suggestion ],
+			groupWritingSuggestions: false,
+			onSuggestionClick,
+		} );
+
+		await user.click( screen.getByRole( 'button', { name: 'Optimize title' } ) );
+		expect( onSuggestionClick ).toHaveBeenCalledWith( suggestion, [ suggestion ] );
+	} );
+
+	it( 'keeps provider writing labels in ungrouped non-editor views', () => {
+		renderAgentChat( {
+			isOpen: true,
+			emptyViewSuggestions: [
+				{
+					id: 'optimize-title',
+					label: 'Optimize Title',
+					prompt: 'Optimize the title of this post',
+				},
+			],
+			groupWritingSuggestions: false,
+		} );
+
+		expect( screen.getByRole( 'button', { name: 'Optimize Title' } ) ).toBeInTheDocument();
 	} );
 
 	it( 'collapses to a button when closed without the AI chat entry button', () => {

--- a/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
@@ -64,6 +64,7 @@ jest.mock( '../../hooks/use-agent-layout-manager', () => ( options: unknown ) =>
 	mockUseAgentLayoutManager( options );
 	return {
 		isDocked: mockLayoutIsDocked,
+		isSidebarOpen: mockLayoutIsDocked && mockAgentsManagerState.isOpen !== false,
 		canDock: mockLayoutIsDocked,
 		dock: jest.fn(),
 		undock: jest.fn(),

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -151,6 +151,7 @@ const chat = ( props: Partial< ComponentProps< typeof OrchestratorChat > > = {} 
 		emptyViewSuggestions={ [] }
 		isDocked={ false }
 		isOpen
+		suggestionsVisible
 		onClose={ jest.fn() }
 		onExpand={ jest.fn() }
 		chatHeaderOptions={ [] }
@@ -378,6 +379,7 @@ describe( 'OrchestratorChat', () => {
 				emptyViewSuggestions={ emptySuggestions }
 				isDocked={ false }
 				isOpen
+				suggestionsVisible
 				onClose={ jest.fn() }
 				onExpand={ jest.fn() }
 				chatHeaderOptions={ [] }
@@ -428,6 +430,7 @@ describe( 'OrchestratorChat', () => {
 				emptyViewSuggestions={ emptySuggestions }
 				isDocked={ false }
 				isOpen
+				suggestionsVisible
 				onClose={ jest.fn() }
 				onExpand={ jest.fn() }
 				chatHeaderOptions={ [] }
@@ -488,7 +491,9 @@ describe( 'OrchestratorChat', () => {
 			{ id: 'getting-started', label: 'Getting started with WordPress', prompt: 'getting-started' },
 		];
 
-		render( chat( { emptyViewSuggestions: staticDefaults, isOpen: false } ) );
+		render(
+			chat( { emptyViewSuggestions: staticDefaults, isOpen: false, suggestionsVisible: false } )
+		);
 
 		expect( screen.queryByText( 'Getting started with WordPress' ) ).toBeNull();
 		expect( recordBigSkyTracksEvent ).not.toHaveBeenCalledWith(

--- a/packages/agents-manager/src/components/agent-chat/grouped-empty-view.scss
+++ b/packages/agents-manager/src/components/agent-chat/grouped-empty-view.scss
@@ -2,10 +2,19 @@
 	display: flex;
 	width: 100%;
 	flex-direction: column;
-	gap: var( --spacing-6 );
+	gap: 0;
+
+	// Agenttic UI does not expose stable hooks for joining its suggestion rows.
+	> [class*='EmptyView-module_container']
+		[class*='Suggestions-module_vertical']
+		> div:last-of-type
+		[class*='Suggestions-module_button'] {
+		border-end-start-radius: 0;
+		border-end-end-radius: 0;
+	}
 
 	&__help {
-		margin: 0;
+		margin: var( --spacing-6 ) 0 0;
 		padding: var( --spacing ) var( --spacing-4 );
 		color: var( --color-foreground );
 		font-size: var( --text-sm );
@@ -16,21 +25,26 @@
 
 .agents-manager-writing-suggestions {
 	width: 100%;
-	border-block: 1px solid var( --color-muted );
 
 	&__toggle {
 		display: grid;
 		width: 100%;
-		min-height: 52px;
 		grid-template-columns: minmax( 0, 1fr ) auto auto;
 		align-items: center;
 		gap: var( --spacing-2 );
-		padding: 0 var( --spacing-4 );
-		border: 0;
-		background: transparent;
+		margin-top: -1px;
+		padding: 14px 16px;
+		border: 1px solid var( --color-muted );
+		border-radius: 0 0 var( --radius-sm ) var( --radius-sm );
+		background: var( --color-background );
 		color: var( --color-foreground );
 		cursor: pointer;
 		text-align: left;
+
+		&[aria-expanded='true'] {
+			border-end-start-radius: 0;
+			border-end-end-radius: 0;
+		}
 
 		&:hover {
 			background-color: color-mix( in srgb, var( --color-background ) 50%, var( --color-muted ) );
@@ -43,21 +57,48 @@
 	}
 
 	&__title {
-		font-size: var( --text-sm );
-		font-weight: var( --font-weight-semibold );
+		font-size: var( --text-xs );
+		font-weight: var( --font-weight-medium );
 	}
 
-	&__count,
-	&__chevron {
+	&__content {
+		display: flex;
+		min-width: 0;
+		flex-direction: column;
+	}
+
+	&__description {
 		color: var( --color-muted-foreground );
+		font-size: var( --text-xs );
+		font-weight: 400;
+		line-height: 20px;
 	}
 
 	&__count {
+		color: var( --color-muted-foreground );
 		font-size: var( --text-xs );
 		font-variant-numeric: tabular-nums;
 	}
 
-	&__list {
-		padding: 0 var( --spacing-2 ) var( --spacing-2 );
+	&__chevron {
+		color: var( --color-foreground );
+		fill: currentColor;
+
+		path {
+			fill: currentColor;
+		}
 	}
+
+	&__list {
+		margin-top: -1px;
+		padding: 0;
+	}
+}
+
+// Match Agenttic UI's specificity so the nested list joins the disclosure row.
+.agents-manager-writing-suggestions__list.agents-manager-writing-suggestions__list
+	> div:first-of-type
+	[class*='Suggestions-module_button'] {
+	border-start-start-radius: 0;
+	border-start-end-radius: 0;
 }

--- a/packages/agents-manager/src/components/agent-chat/grouped-empty-view.scss
+++ b/packages/agents-manager/src/components/agent-chat/grouped-empty-view.scss
@@ -21,6 +21,25 @@
 		font-weight: 400;
 		line-height: var( --text-sm--line-height );
 	}
+
+	&__final-suggestion {
+		margin-top: -1px;
+		padding: 0;
+	}
+
+	&--has-final-suggestion {
+		.agents-manager-writing-suggestions__toggle {
+			border-end-start-radius: 0;
+			border-end-end-radius: 0;
+		}
+
+		.agents-manager-writing-suggestions__list
+			> div:last-of-type
+			[class*='Suggestions-module_button'] {
+			border-end-start-radius: 0;
+			border-end-end-radius: 0;
+		}
+	}
 }
 
 .agents-manager-writing-suggestions {
@@ -97,6 +116,13 @@
 
 // Match Agenttic UI's specificity so the nested list joins the disclosure row.
 .agents-manager-writing-suggestions__list.agents-manager-writing-suggestions__list
+	> div:first-of-type
+	[class*='Suggestions-module_button'] {
+	border-start-start-radius: 0;
+	border-start-end-radius: 0;
+}
+
+.agents-manager-grouped-empty-view__final-suggestion.agents-manager-grouped-empty-view__final-suggestion
 	> div:first-of-type
 	[class*='Suggestions-module_button'] {
 	border-start-start-radius: 0;

--- a/packages/agents-manager/src/components/agent-chat/grouped-empty-view.scss
+++ b/packages/agents-manager/src/components/agent-chat/grouped-empty-view.scss
@@ -1,0 +1,63 @@
+.agents-manager-grouped-empty-view {
+	display: flex;
+	width: 100%;
+	flex-direction: column;
+	gap: var( --spacing-6 );
+
+	&__help {
+		margin: 0;
+		padding: var( --spacing ) var( --spacing-4 );
+		color: var( --color-foreground );
+		font-size: var( --text-sm );
+		font-weight: 400;
+		line-height: var( --text-sm--line-height );
+	}
+}
+
+.agents-manager-writing-suggestions {
+	width: 100%;
+	border-block: 1px solid var( --color-muted );
+
+	&__toggle {
+		display: grid;
+		width: 100%;
+		min-height: 52px;
+		grid-template-columns: minmax( 0, 1fr ) auto auto;
+		align-items: center;
+		gap: var( --spacing-2 );
+		padding: 0 var( --spacing-4 );
+		border: 0;
+		background: transparent;
+		color: var( --color-foreground );
+		cursor: pointer;
+		text-align: left;
+
+		&:hover {
+			background-color: color-mix( in srgb, var( --color-background ) 50%, var( --color-muted ) );
+		}
+
+		&:focus-visible {
+			outline: 2px solid var( --color-ring );
+			outline-offset: -2px;
+		}
+	}
+
+	&__title {
+		font-size: var( --text-sm );
+		font-weight: var( --font-weight-semibold );
+	}
+
+	&__count,
+	&__chevron {
+		color: var( --color-muted-foreground );
+	}
+
+	&__count {
+		font-size: var( --text-xs );
+		font-variant-numeric: tabular-nums;
+	}
+
+	&__list {
+		padding: 0 var( --spacing-2 ) var( --spacing-2 );
+	}
+}

--- a/packages/agents-manager/src/components/agent-chat/grouped-empty-view.tsx
+++ b/packages/agents-manager/src/components/agent-chat/grouped-empty-view.tsx
@@ -9,6 +9,7 @@ import {
 	GROUPED_VIEW_HIDDEN_SUGGESTION_IDS,
 	WRITING_SUGGESTION_IDS,
 } from '../../hooks/use-empty-view-suggestions';
+import { isEditorPage } from '../../utils/is-editor-page';
 import type { ReactNode } from 'react';
 import './grouped-empty-view.scss';
 
@@ -37,35 +38,19 @@ export default function GroupedEmptyView( {
 		GroupedEmptyView,
 		'agents-manager-writing-suggestion-list'
 	);
-	const writingSuggestions = suggestions
-		.filter( ( suggestion ) => WRITING_SUGGESTION_IDS.has( suggestion.id ) )
-		.map( ( suggestion ) => ( {
-			...suggestion,
-			label: getWritingSuggestionLabel( suggestion ),
-		} ) );
+	const shouldFormatWritingSuggestions = groupWritingSuggestions || isEditorPage();
+	const displaySuggestions = suggestions.map( ( suggestion ) =>
+		shouldFormatWritingSuggestions && WRITING_SUGGESTION_IDS.has( suggestion.id )
+			? { ...suggestion, label: getWritingSuggestionLabel( suggestion ) }
+			: suggestion
+	);
+	const writingSuggestions = displaySuggestions.filter( ( suggestion ) =>
+		WRITING_SUGGESTION_IDS.has( suggestion.id )
+	);
 	// Grouping only helps when writing and design actions need separation.
 	const hasDesignSuggestions = suggestions.some( ( suggestion ) =>
 		DESIGN_SUGGESTION_IDS.has( suggestion.id )
 	);
-
-	if ( ! groupWritingSuggestions || writingSuggestions.length === 0 || ! hasDesignSuggestions ) {
-		return (
-			<EmptyView
-				heading={ heading }
-				help={ help }
-				suggestions={ suggestions }
-				onSuggestionClick={ onSuggestionClick }
-				icon={ icon }
-			/>
-		);
-	}
-
-	const topLevelSuggestions = suggestions.filter(
-		( suggestion ) =>
-			! WRITING_SUGGESTION_IDS.has( suggestion.id ) &&
-			! GROUPED_VIEW_HIDDEN_SUGGESTION_IDS.has( suggestion.id )
-	);
-	const collapsedIcon = isRTL() ? chevronLeft : chevronRight;
 	const handleSuggestionClick = ( selectedSuggestion: Suggestion | string ) => {
 		const originalSuggestion =
 			typeof selectedSuggestion === 'string'
@@ -74,6 +59,25 @@ export default function GroupedEmptyView( {
 				  selectedSuggestion;
 		onSuggestionClick?.( originalSuggestion, suggestions );
 	};
+
+	if ( ! groupWritingSuggestions || writingSuggestions.length === 0 || ! hasDesignSuggestions ) {
+		return (
+			<EmptyView
+				heading={ heading }
+				help={ help }
+				suggestions={ displaySuggestions }
+				onSuggestionClick={ handleSuggestionClick }
+				icon={ icon }
+			/>
+		);
+	}
+
+	const topLevelSuggestions = displaySuggestions.filter(
+		( suggestion ) =>
+			! WRITING_SUGGESTION_IDS.has( suggestion.id ) &&
+			! GROUPED_VIEW_HIDDEN_SUGGESTION_IDS.has( suggestion.id )
+	);
+	const collapsedIcon = isRTL() ? chevronLeft : chevronRight;
 
 	return (
 		<div className="agents-manager-grouped-empty-view">

--- a/packages/agents-manager/src/components/agent-chat/grouped-empty-view.tsx
+++ b/packages/agents-manager/src/components/agent-chat/grouped-empty-view.tsx
@@ -1,0 +1,100 @@
+import { EmptyView, Suggestions, type Suggestion } from '@automattic/agenttic-ui';
+import { useInstanceId } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
+import { __, isRTL } from '@wordpress/i18n';
+import { Icon, chevronDown, chevronLeft, chevronRight } from '@wordpress/icons';
+import { WRITING_SUGGESTION_IDS } from '../../hooks/use-empty-view-suggestions';
+import type { ReactNode } from 'react';
+import './grouped-empty-view.scss';
+
+interface Props {
+	heading: string;
+	help?: string;
+	icon: ReactNode;
+	suggestions: Suggestion[];
+	groupWritingSuggestions: boolean;
+	onSuggestionClick?: (
+		selectedSuggestion: Suggestion | string,
+		availableSuggestions?: Suggestion[]
+	) => void;
+}
+
+export default function GroupedEmptyView( {
+	heading,
+	help,
+	icon,
+	suggestions,
+	groupWritingSuggestions,
+	onSuggestionClick,
+}: Props ) {
+	const [ isWritingExpanded, setIsWritingExpanded ] = useState( true );
+	const writingSuggestionListId = useInstanceId(
+		GroupedEmptyView,
+		'agents-manager-writing-suggestion-list'
+	);
+	const writingSuggestions = suggestions.filter( ( suggestion ) =>
+		WRITING_SUGGESTION_IDS.has( suggestion.id )
+	);
+
+	if ( ! groupWritingSuggestions || writingSuggestions.length === 0 ) {
+		return (
+			<EmptyView
+				heading={ heading }
+				help={ help }
+				suggestions={ suggestions }
+				onSuggestionClick={ onSuggestionClick }
+				icon={ icon }
+			/>
+		);
+	}
+
+	const topLevelSuggestions = suggestions.filter(
+		( suggestion ) => ! WRITING_SUGGESTION_IDS.has( suggestion.id )
+	);
+	const collapsedIcon = isRTL() ? chevronLeft : chevronRight;
+	const handleSuggestionClick = ( selectedSuggestion: Suggestion | string ) => {
+		onSuggestionClick?.( selectedSuggestion, suggestions );
+	};
+
+	return (
+		<div className="agents-manager-grouped-empty-view">
+			<EmptyView
+				heading={ heading }
+				suggestions={ topLevelSuggestions }
+				onSuggestionClick={ handleSuggestionClick }
+				icon={ icon }
+			/>
+			<section className="agents-manager-writing-suggestions">
+				<button
+					type="button"
+					className="agents-manager-writing-suggestions__toggle"
+					aria-expanded={ isWritingExpanded }
+					aria-controls={ writingSuggestionListId }
+					onClick={ () => setIsWritingExpanded( ( isExpanded ) => ! isExpanded ) }
+				>
+					<span className="agents-manager-writing-suggestions__title">
+						{ __( 'Writing', __i18n_text_domain__ ) }
+					</span>
+					<span className="agents-manager-writing-suggestions__count">
+						{ writingSuggestions.length }
+					</span>
+					<Icon
+						className="agents-manager-writing-suggestions__chevron"
+						icon={ isWritingExpanded ? chevronDown : collapsedIcon }
+						size={ 20 }
+					/>
+				</button>
+				<div id={ writingSuggestionListId } hidden={ ! isWritingExpanded }>
+					<Suggestions
+						className="agents-manager-writing-suggestions__list"
+						layout="vertical"
+						translateY={ 0 }
+						suggestions={ writingSuggestions }
+						onSubmit={ handleSuggestionClick }
+					/>
+				</div>
+			</section>
+			{ help && <p className="agents-manager-grouped-empty-view__help">{ help }</p> }
+		</div>
+	);
+}

--- a/packages/agents-manager/src/components/agent-chat/grouped-empty-view.tsx
+++ b/packages/agents-manager/src/components/agent-chat/grouped-empty-view.tsx
@@ -3,7 +3,11 @@ import { useInstanceId } from '@wordpress/compose';
 import { useState } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
 import { Icon, chevronDown, chevronLeft, chevronRight } from '@wordpress/icons';
-import { WRITING_SUGGESTION_IDS } from '../../hooks/use-empty-view-suggestions';
+import {
+	getWritingSuggestionLabel,
+	GROUPED_VIEW_HIDDEN_SUGGESTION_IDS,
+	WRITING_SUGGESTION_IDS,
+} from '../../hooks/use-empty-view-suggestions';
 import type { ReactNode } from 'react';
 import './grouped-empty-view.scss';
 
@@ -27,14 +31,17 @@ export default function GroupedEmptyView( {
 	groupWritingSuggestions,
 	onSuggestionClick,
 }: Props ) {
-	const [ isWritingExpanded, setIsWritingExpanded ] = useState( true );
+	const [ isWritingExpanded, setIsWritingExpanded ] = useState( false );
 	const writingSuggestionListId = useInstanceId(
 		GroupedEmptyView,
 		'agents-manager-writing-suggestion-list'
 	);
-	const writingSuggestions = suggestions.filter( ( suggestion ) =>
-		WRITING_SUGGESTION_IDS.has( suggestion.id )
-	);
+	const writingSuggestions = suggestions
+		.filter( ( suggestion ) => WRITING_SUGGESTION_IDS.has( suggestion.id ) )
+		.map( ( suggestion ) => ( {
+			...suggestion,
+			label: getWritingSuggestionLabel( suggestion ),
+		} ) );
 
 	if ( ! groupWritingSuggestions || writingSuggestions.length === 0 ) {
 		return (
@@ -49,11 +56,18 @@ export default function GroupedEmptyView( {
 	}
 
 	const topLevelSuggestions = suggestions.filter(
-		( suggestion ) => ! WRITING_SUGGESTION_IDS.has( suggestion.id )
+		( suggestion ) =>
+			! WRITING_SUGGESTION_IDS.has( suggestion.id ) &&
+			! GROUPED_VIEW_HIDDEN_SUGGESTION_IDS.has( suggestion.id )
 	);
 	const collapsedIcon = isRTL() ? chevronLeft : chevronRight;
 	const handleSuggestionClick = ( selectedSuggestion: Suggestion | string ) => {
-		onSuggestionClick?.( selectedSuggestion, suggestions );
+		const originalSuggestion =
+			typeof selectedSuggestion === 'string'
+				? selectedSuggestion
+				: suggestions.find( ( suggestion ) => suggestion.id === selectedSuggestion.id ) ??
+				  selectedSuggestion;
+		onSuggestionClick?.( originalSuggestion, suggestions );
 	};
 
 	return (
@@ -72,8 +86,13 @@ export default function GroupedEmptyView( {
 					aria-controls={ writingSuggestionListId }
 					onClick={ () => setIsWritingExpanded( ( isExpanded ) => ! isExpanded ) }
 				>
-					<span className="agents-manager-writing-suggestions__title">
-						{ __( 'Writing', __i18n_text_domain__ ) }
+					<span className="agents-manager-writing-suggestions__content">
+						<span className="agents-manager-writing-suggestions__title">
+							{ __( 'Writing', __i18n_text_domain__ ) }
+						</span>
+						<span className="agents-manager-writing-suggestions__description">
+							{ __( 'Improve and refine your content.', __i18n_text_domain__ ) }
+						</span>
 					</span>
 					<span className="agents-manager-writing-suggestions__count">
 						{ writingSuggestions.length }

--- a/packages/agents-manager/src/components/agent-chat/grouped-empty-view.tsx
+++ b/packages/agents-manager/src/components/agent-chat/grouped-empty-view.tsx
@@ -6,7 +6,7 @@ import { Icon, chevronDown, chevronLeft, chevronRight } from '@wordpress/icons';
 import {
 	DESIGN_SUGGESTION_IDS,
 	formatWritingSuggestionLabels,
-	GROUPED_VIEW_HIDDEN_SUGGESTION_IDS,
+	WHAT_ELSE_CAN_I_DO_SUGGESTION_ID,
 	WRITING_SUGGESTION_IDS,
 } from '../../hooks/use-empty-view-suggestions';
 import { isEditorPage } from '../../utils/is-editor-page';
@@ -46,6 +46,9 @@ export default function GroupedEmptyView( {
 	const writingSuggestions = displaySuggestions.filter( ( suggestion ) =>
 		WRITING_SUGGESTION_IDS.has( suggestion.id )
 	);
+	const finalSuggestion = displaySuggestions.find(
+		( suggestion ) => suggestion.id === WHAT_ELSE_CAN_I_DO_SUGGESTION_ID
+	);
 	// Grouping only helps when writing and design actions need separation.
 	const hasDesignSuggestions = suggestions.some( ( suggestion ) =>
 		DESIGN_SUGGESTION_IDS.has( suggestion.id )
@@ -74,12 +77,16 @@ export default function GroupedEmptyView( {
 	const topLevelSuggestions = displaySuggestions.filter(
 		( suggestion ) =>
 			! WRITING_SUGGESTION_IDS.has( suggestion.id ) &&
-			! GROUPED_VIEW_HIDDEN_SUGGESTION_IDS.has( suggestion.id )
+			suggestion.id !== WHAT_ELSE_CAN_I_DO_SUGGESTION_ID
 	);
 	const collapsedIcon = isRTL() ? chevronLeft : chevronRight;
 
 	return (
-		<div className="agents-manager-grouped-empty-view">
+		<div
+			className={ `agents-manager-grouped-empty-view${
+				finalSuggestion ? ' agents-manager-grouped-empty-view--has-final-suggestion' : ''
+			}` }
+		>
 			<EmptyView
 				heading={ heading }
 				suggestions={ topLevelSuggestions }
@@ -121,6 +128,15 @@ export default function GroupedEmptyView( {
 					/>
 				</div>
 			</section>
+			{ finalSuggestion && (
+				<Suggestions
+					className="agents-manager-grouped-empty-view__final-suggestion"
+					layout="vertical"
+					translateY={ 0 }
+					suggestions={ [ finalSuggestion ] }
+					onSubmit={ handleSuggestionClick }
+				/>
+			) }
 			{ help && <p className="agents-manager-grouped-empty-view__help">{ help }</p> }
 		</div>
 	);

--- a/packages/agents-manager/src/components/agent-chat/grouped-empty-view.tsx
+++ b/packages/agents-manager/src/components/agent-chat/grouped-empty-view.tsx
@@ -97,7 +97,7 @@ export default function GroupedEmptyView( {
 				>
 					<span className="agents-manager-writing-suggestions__content">
 						<span className="agents-manager-writing-suggestions__title">
-							{ __( 'Writing', __i18n_text_domain__ ) }
+							{ __( 'Writing tools', __i18n_text_domain__ ) }
 						</span>
 						<span className="agents-manager-writing-suggestions__description">
 							{ __( 'Improve and refine your content.', __i18n_text_domain__ ) }

--- a/packages/agents-manager/src/components/agent-chat/grouped-empty-view.tsx
+++ b/packages/agents-manager/src/components/agent-chat/grouped-empty-view.tsx
@@ -4,6 +4,7 @@ import { useState } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
 import { Icon, chevronDown, chevronLeft, chevronRight } from '@wordpress/icons';
 import {
+	DESIGN_SUGGESTION_IDS,
 	getWritingSuggestionLabel,
 	GROUPED_VIEW_HIDDEN_SUGGESTION_IDS,
 	WRITING_SUGGESTION_IDS,
@@ -42,8 +43,12 @@ export default function GroupedEmptyView( {
 			...suggestion,
 			label: getWritingSuggestionLabel( suggestion ),
 		} ) );
+	// Grouping only helps when writing and design actions need separation.
+	const hasDesignSuggestions = suggestions.some( ( suggestion ) =>
+		DESIGN_SUGGESTION_IDS.has( suggestion.id )
+	);
 
-	if ( ! groupWritingSuggestions || writingSuggestions.length === 0 ) {
+	if ( ! groupWritingSuggestions || writingSuggestions.length === 0 || ! hasDesignSuggestions ) {
 		return (
 			<EmptyView
 				heading={ heading }

--- a/packages/agents-manager/src/components/agent-chat/grouped-empty-view.tsx
+++ b/packages/agents-manager/src/components/agent-chat/grouped-empty-view.tsx
@@ -5,7 +5,7 @@ import { __, isRTL } from '@wordpress/i18n';
 import { Icon, chevronDown, chevronLeft, chevronRight } from '@wordpress/icons';
 import {
 	DESIGN_SUGGESTION_IDS,
-	getWritingSuggestionLabel,
+	formatWritingSuggestionLabels,
 	GROUPED_VIEW_HIDDEN_SUGGESTION_IDS,
 	WRITING_SUGGESTION_IDS,
 } from '../../hooks/use-empty-view-suggestions';
@@ -39,10 +39,9 @@ export default function GroupedEmptyView( {
 		'agents-manager-writing-suggestion-list'
 	);
 	const shouldFormatWritingSuggestions = groupWritingSuggestions || isEditorPage();
-	const displaySuggestions = suggestions.map( ( suggestion ) =>
-		shouldFormatWritingSuggestions && WRITING_SUGGESTION_IDS.has( suggestion.id )
-			? { ...suggestion, label: getWritingSuggestionLabel( suggestion ) }
-			: suggestion
+	const displaySuggestions = formatWritingSuggestionLabels(
+		suggestions,
+		shouldFormatWritingSuggestions
 	);
 	const writingSuggestions = displaySuggestions.filter( ( suggestion ) =>
 		WRITING_SUGGESTION_IDS.has( suggestion.id )
@@ -97,10 +96,10 @@ export default function GroupedEmptyView( {
 				>
 					<span className="agents-manager-writing-suggestions__content">
 						<span className="agents-manager-writing-suggestions__title">
-							{ __( 'Writing tools', __i18n_text_domain__ ) }
+							{ __( 'Writing assistance', __i18n_text_domain__ ) }
 						</span>
 						<span className="agents-manager-writing-suggestions__description">
-							{ __( 'Improve and refine your content.', __i18n_text_domain__ ) }
+							{ __( 'Enhance and review your content.', __i18n_text_domain__ ) }
 						</span>
 					</span>
 					<span className="agents-manager-writing-suggestions__count">

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -13,9 +13,14 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
+import {
+	getWritingSuggestionLabel,
+	WRITING_SUGGESTION_IDS,
+} from '../../hooks/use-empty-view-suggestions';
 import useHasAiChatEntryButton from '../../hooks/use-has-ai-chat-entry-button';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import { getAgentsManagerInlineData } from '../../utils/get-agents-manager-inline-data';
+import { isEditorPage } from '../../utils/is-editor-page';
 import { isReaderChatHost } from '../../utils/is-reader-chat-agent';
 import { recordBigSkyTracksEvent } from '../../utils/tracks';
 import ChatHeader, { type Options as ChatHeaderOptions } from '../chat-header';
@@ -194,6 +199,27 @@ export default function AgentChat( {
 		() => ( { a: CustomALink, ...markdownComponents } ),
 		[ markdownComponents ]
 	);
+	const shouldFormatWritingSuggestions = groupWritingSuggestions || isEditorPage();
+	const displayedSuggestions = useMemo(
+		() =>
+			suggestions.map( ( suggestion ) =>
+				shouldFormatWritingSuggestions && WRITING_SUGGESTION_IDS.has( suggestion.id )
+					? { ...suggestion, label: getWritingSuggestionLabel( suggestion ) }
+					: suggestion
+			),
+		[ shouldFormatWritingSuggestions, suggestions ]
+	);
+	const handleDisplayedSuggestionClick = useCallback(
+		( selectedSuggestion: Suggestion | string ) => {
+			const originalSuggestion =
+				typeof selectedSuggestion === 'string'
+					? selectedSuggestion
+					: suggestions.find( ( suggestion ) => suggestion.id === selectedSuggestion.id ) ??
+					  selectedSuggestion;
+			onSuggestionClick?.( originalSuggestion, suggestions );
+		},
+		[ onSuggestionClick, suggestions ]
+	);
 
 	const messageRenderer = useMemo(
 		() =>
@@ -287,9 +313,9 @@ export default function AgentChat( {
 			variant={ isDocked ? 'embedded' : 'floating' }
 			freeDrag={ ! isDocked }
 			resizable={ ! isDocked }
-			suggestions={ suggestions }
+			suggestions={ displayedSuggestions }
 			clearSuggestions={ clearSuggestions }
-			onSuggestionClick={ onSuggestionClick }
+			onSuggestionClick={ onSuggestionClick ? handleDisplayedSuggestionClick : undefined }
 			floatingChatState={ floatingChatState }
 			onClose={ onClose }
 			onExpand={ onExpand }

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -1,7 +1,6 @@
 import {
 	AgentUI,
 	createMessageRenderer,
-	EmptyView,
 	ImageUploader,
 	type ImageUploaderHandle,
 	type MarkdownComponents,
@@ -26,6 +25,7 @@ import CustomALink from '../custom-a-link';
 import FeedbackInput from '../feedback-input';
 import { AI } from '../icons';
 import SelectedBlock from '../selected-block';
+import GroupedEmptyView from './grouped-empty-view';
 import type { UseImageUploadResult } from '../../hooks/use-image-upload';
 import type { ExternalContextCard, ExternalContextCardAction } from '../../utils/external-context';
 import type { Message, NoticeConfig } from '@automattic/agenttic-ui/dist/types';
@@ -43,6 +43,8 @@ interface Props {
 	chatHeaderOptions: ChatHeaderOptions;
 	/** Suggestions displayed when the chat is empty. */
 	emptyViewSuggestions?: Suggestion[];
+	/** Whether editor writing suggestions should render in a section. */
+	groupWritingSuggestions?: boolean;
 	/** Indicates if the chat is processing a request. */
 	isProcessing: boolean;
 	/** Custom thinking message to display while the agent is processing. */
@@ -149,6 +151,7 @@ export default function AgentChat( {
 	error = null,
 	chatHeaderOptions,
 	emptyViewSuggestions = [],
+	groupWritingSuggestions = false,
 	isProcessing,
 	thinkingMessage,
 	isLoadingConversation,
@@ -301,10 +304,11 @@ export default function AgentChat( {
 				isLoadingConversation ? (
 					<ChatMessageSkeleton count={ 3 } />
 				) : (
-					<EmptyView
+					<GroupedEmptyView
 						heading={ getEmptyViewHeading() }
 						help={ emptyViewSuggestions.length > 0 ? getEmptyViewHelp() : undefined }
 						suggestions={ emptyViewSuggestions }
+						groupWritingSuggestions={ groupWritingSuggestions }
 						onSuggestionClick={ onSuggestionClick }
 						icon={ <AI size={ 32 } /> }
 					/>

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -13,10 +13,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import {
-	getWritingSuggestionLabel,
-	WRITING_SUGGESTION_IDS,
-} from '../../hooks/use-empty-view-suggestions';
+import { formatWritingSuggestionLabels } from '../../hooks/use-empty-view-suggestions';
 import useHasAiChatEntryButton from '../../hooks/use-has-ai-chat-entry-button';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import { getAgentsManagerInlineData } from '../../utils/get-agents-manager-inline-data';
@@ -201,12 +198,7 @@ export default function AgentChat( {
 	);
 	const shouldFormatWritingSuggestions = groupWritingSuggestions || isEditorPage();
 	const displayedSuggestions = useMemo(
-		() =>
-			suggestions.map( ( suggestion ) =>
-				shouldFormatWritingSuggestions && WRITING_SUGGESTION_IDS.has( suggestion.id )
-					? { ...suggestion, label: getWritingSuggestionLabel( suggestion ) }
-					: suggestion
-			),
+		() => formatWritingSuggestionLabels( suggestions, shouldFormatWritingSuggestions ),
 		[ shouldFormatWritingSuggestions, suggestions ]
 	);
 	const handleDisplayedSuggestionClick = useCallback(

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -115,29 +115,37 @@ export default function AgentDock( {
 		[ isReaderChat, setIsOpen ]
 	);
 
-	const { isDocked, canDock, dock, undock, openSidebar, closeSidebar, createAgentPortal } =
-		useAgentLayoutManager( {
-			defaultDocked: isReaderChat ? false : isPersistedDocked,
-			defaultOpen: isPersistedOpen,
-			desktopMediaQuery,
-			// Only open the sidebar; keep the current route. Admin-bar items
-			// set their own route (e.g. history) before opening it.
-			onOpenSidebar: () => {
-				recordBigSkyTracksEvent( 'sidebar_open_click' );
-				setOpenState( true );
-			},
-			onCloseSidebar: () => {
-				recordBigSkyTracksEvent( 'sidebar_close_click' );
-				setOpenState( false );
-			},
-			onDock: () => {
-				recordBigSkyTracksEvent( 'ai_chat_docked' );
-			},
-			onUndock: () => {
-				recordBigSkyTracksEvent( 'ai_chat_undocked' );
-			},
-			isSplitScreen,
-		} );
+	const {
+		isDocked,
+		isSidebarOpen,
+		canDock,
+		dock,
+		undock,
+		openSidebar,
+		closeSidebar,
+		createAgentPortal,
+	} = useAgentLayoutManager( {
+		defaultDocked: isReaderChat ? false : isPersistedDocked,
+		defaultOpen: isPersistedOpen,
+		desktopMediaQuery,
+		// Only open the sidebar; keep the current route. Admin-bar items
+		// set their own route (e.g. history) before opening it.
+		onOpenSidebar: () => {
+			recordBigSkyTracksEvent( 'sidebar_open_click' );
+			setOpenState( true );
+		},
+		onCloseSidebar: () => {
+			recordBigSkyTracksEvent( 'sidebar_close_click' );
+			setOpenState( false );
+		},
+		onDock: () => {
+			recordBigSkyTracksEvent( 'ai_chat_docked' );
+		},
+		onUndock: () => {
+			recordBigSkyTracksEvent( 'ai_chat_undocked' );
+		},
+		isSplitScreen,
+	} );
 
 	// Docked close fires `sidebar_close_click` (via `onCloseSidebar`); undocked
 	// close fires `dock_back_button_click`. Matches Big Sky.
@@ -319,6 +327,7 @@ export default function AgentDock( {
 			emptyViewSuggestions={ emptyViewSuggestions }
 			isDocked={ isDocked }
 			isOpen={ chatIsOpen }
+			suggestionsVisible={ isDocked ? isSidebarOpen : chatIsOpen || isCompactMode }
 			onClose={ handleClose }
 			onExpand={ handleExpand }
 			chatHeaderOptions={ chatHeaderOptions }

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -15,6 +15,7 @@ import { useBroadcastConversationActivity } from '../../hooks/use-broadcast-conv
 import useCheckpointAction from '../../hooks/use-checkpoint-action';
 import useConversation from '../../hooks/use-conversation';
 import useCopyAction from '../../hooks/use-copy-action';
+import { usePageOrSiteEditorSurface } from '../../hooks/use-empty-view-suggestions';
 import useFeedbackAction from '../../hooks/use-feedback-action';
 import { useImageUpload } from '../../hooks/use-image-upload';
 import useRegenerateAction from '../../hooks/use-regenerate-action';
@@ -202,6 +203,7 @@ export default function OrchestratorChat( {
 		const editor = select( 'core/editor' ) as { getCurrentPostId?: () => number | string };
 		return editor?.getCurrentPostId?.();
 	}, [] );
+	const { isPageOrSiteEditorSurface: groupWritingSuggestions } = usePageOrSiteEditorSurface();
 
 	const {
 		addMessage,
@@ -948,6 +950,7 @@ export default function OrchestratorChat( {
 			inputValue={ inputValue }
 			onInputChange={ setInputValue }
 			isCompactMode={ isCompactMode }
+			groupWritingSuggestions={ groupWritingSuggestions }
 			imageUpload={ imageUpload }
 			showFeedbackInput={ showFeedbackInput }
 			onSubmitFeedbackText={ submitFeedbackText }

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -369,7 +369,7 @@ export default function OrchestratorChat( {
 		},
 	} );
 
-	const areSuggestionsVisible = isOpen || isCompactMode;
+	const areSuggestionsVisible = isOpen || isCompactMode || isDocked;
 
 	// Use dynamic suggestions from the external provider (e.g., Big Sky block-based suggestions)
 	const maxDynamicSuggestions = isDocked ? undefined : 3;

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -137,6 +137,8 @@ interface Props {
 	isDocked: boolean;
 	/** Indicates if the chat is expanded (floating mode). */
 	isOpen: boolean;
+	/** Indicates if suggestions are visible in the current layout. */
+	suggestionsVisible: boolean;
 	/** Called when the chat is closed. */
 	onClose: () => void;
 	/** Called when the chat is expanded (floating mode). */
@@ -171,6 +173,7 @@ export default function OrchestratorChat( {
 	emptyViewSuggestions,
 	isDocked,
 	isOpen,
+	suggestionsVisible,
 	onClose,
 	onExpand,
 	chatHeaderOptions,
@@ -369,12 +372,10 @@ export default function OrchestratorChat( {
 		},
 	} );
 
-	const areSuggestionsVisible = isOpen || isCompactMode || isDocked;
-
 	// Use dynamic suggestions from the external provider (e.g., Big Sky block-based suggestions)
 	const maxDynamicSuggestions = isDocked ? undefined : 3;
 	const dynamicSuggestions = useSuggestions?.( maxDynamicSuggestions, {
-		suggestionsVisible: areSuggestionsVisible,
+		suggestionsVisible,
 	} );
 	const dynamicSuggestionsList = dynamicSuggestions?.suggestions ?? [];
 	const replaceEmptyViewSuggestions = dynamicSuggestions?.replaceEmptyViewSuggestions === true;
@@ -879,7 +880,7 @@ export default function OrchestratorChat( {
 	// - Empty chat: show provider empty-view chips plus dynamic chips.
 	// - Active chat/input: show dynamic suggestions only.
 	let displayedEmptyViewSuggestions: Suggestion[] = [];
-	if ( ! areSuggestionsVisible ) {
+	if ( ! suggestionsVisible ) {
 		// Minimized/collapsed: the chat renders no suggestions, so leave the list
 		// empty to avoid firing chat_suggestions_rendered for hidden chips.
 		displayedEmptyViewSuggestions = [];

--- a/packages/agents-manager/src/hooks/__tests__/use-agent-layout-manager.test.tsx
+++ b/packages/agents-manager/src/hooks/__tests__/use-agent-layout-manager.test.tsx
@@ -107,12 +107,15 @@ describe( 'useAgentLayoutManager — open / close', () => {
 	it( 'toggles the sidebar-open class via open/close', () => {
 		const { result } = render();
 		expect( container.classList.contains( OPEN_CLASS ) ).toBe( true );
+		expect( result.current.isSidebarOpen ).toBe( true );
 
 		act( () => result.current.closeSidebar() );
 		expect( container.classList.contains( OPEN_CLASS ) ).toBe( false );
+		expect( result.current.isSidebarOpen ).toBe( false );
 
 		act( () => result.current.openSidebar() );
 		expect( container.classList.contains( OPEN_CLASS ) ).toBe( true );
+		expect( result.current.isSidebarOpen ).toBe( true );
 	} );
 
 	it( 'adds --closing when closing an open sidebar, and removes it after the transition', () => {
@@ -204,6 +207,7 @@ describe( 'useAgentLayoutManager — open-state sync on dock transition', () => 
 		await setBodyClass( FULLSCREEN_BODY_CLASS, true );
 		expect( result.current.isDocked ).toBe( true );
 		expect( container.classList.contains( OPEN_CLASS ) ).toBe( true );
+		expect( result.current.isSidebarOpen ).toBe( true );
 	} );
 
 	it( 'keeps the docked sidebar closed when the shared open state is false as it becomes dockable', async () => {
@@ -214,6 +218,7 @@ describe( 'useAgentLayoutManager — open-state sync on dock transition', () => 
 		await setBodyClass( FULLSCREEN_BODY_CLASS, true );
 		expect( result.current.isDocked ).toBe( true );
 		expect( container.classList.contains( OPEN_CLASS ) ).toBe( false );
+		expect( result.current.isSidebarOpen ).toBe( false );
 	} );
 } );
 

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
@@ -93,6 +93,7 @@ interface Options {
 
 interface ReturnValue {
 	isDocked: boolean;
+	isSidebarOpen: boolean;
 	canDock: boolean;
 	dock: () => void;
 	undock: () => void;
@@ -144,6 +145,9 @@ export default function useAgentLayoutManager( {
 				: sidebarContainer,
 		[ sidebarContainer ]
 	);
+	const [ isSidebarOpen, setIsSidebarOpen ] = useState(
+		() => defaultOpen || container?.classList.contains( SIDEBAR_OPEN_CLASS ) || false
+	);
 
 	// Initialize docked state, setup portal element, and handle dock/undock changes
 	// Use `useLayoutEffect` to prevent flickering
@@ -169,10 +173,6 @@ export default function useAgentLayoutManager( {
 			if ( shouldRenderSidebar ) {
 				container.classList.add( SIDEBAR_CONTAINER_CLASS );
 				portalRef.current.classList.add( 'agents-manager-chat--docked' );
-
-				if ( defaultOpenRef.current ) {
-					container.classList.add( SIDEBAR_OPEN_CLASS );
-				}
 			} else {
 				portalRef.current.classList.add( 'agents-manager-chat--undocked' );
 			}
@@ -189,7 +189,7 @@ export default function useAgentLayoutManager( {
 			portalRef.current.classList.remove( 'agents-manager-chat--undocked' );
 
 			if ( defaultOpenRef.current ) {
-				container.classList.add( SIDEBAR_OPEN_CLASS );
+				setIsSidebarOpen( true );
 			}
 
 			onDockRef.current();
@@ -205,10 +205,15 @@ export default function useAgentLayoutManager( {
 			);
 			portalRef.current.classList.add( 'agents-manager-chat--undocked' );
 			portalRef.current.classList.remove( 'agents-manager-chat--docked' );
+			setIsSidebarOpen( false );
 
 			onUndockRef.current();
 		}
 	}, [ container, isDocked, isReady, shouldRenderSidebar ] );
+
+	useLayoutEffect( () => {
+		container?.classList.toggle( SIDEBAR_OPEN_CLASS, !! shouldRenderSidebar && isSidebarOpen );
+	}, [ container, isSidebarOpen, shouldRenderSidebar ] );
 
 	// Track focus on the chat panel so the floating chat can raise its z-index. `pointerdown` also
 	// covers clicks on non-focusable regions (e.g. scroll areas) that skip `focusin`
@@ -293,7 +298,7 @@ export default function useAgentLayoutManager( {
 
 		clearTimeout( closeSidebarTimeoutRef.current );
 		container.classList.remove( SIDEBAR_CLOSING_CLASS );
-		container.classList.add( SIDEBAR_OPEN_CLASS );
+		setIsSidebarOpen( true );
 
 		onOpenSidebarRef.current();
 	}, [ canDock, container, isReady ] );
@@ -303,9 +308,8 @@ export default function useAgentLayoutManager( {
 			return;
 		}
 
-		const wasSidebarOpen = container.classList.contains( SIDEBAR_OPEN_CLASS );
-
-		container.classList.remove( SIDEBAR_OPEN_CLASS );
+		const wasSidebarOpen = isSidebarOpen;
+		setIsSidebarOpen( false );
 
 		// Only suppress admin bar pointer events during an actual sidebar-close transition.
 		if ( wasSidebarOpen ) {
@@ -317,7 +321,7 @@ export default function useAgentLayoutManager( {
 		}
 
 		onCloseSidebarRef.current();
-	}, [ canDock, container, isReady ] );
+	}, [ canDock, container, isReady, isSidebarOpen ] );
 
 	const dock = useCallback( () => {
 		if ( ! isReady || ! container ) {
@@ -370,6 +374,7 @@ export default function useAgentLayoutManager( {
 
 	return {
 		isDocked: !! shouldRenderSidebar,
+		isSidebarOpen: !! shouldRenderSidebar && isSidebarOpen,
 		canDock,
 		dock,
 		undock,

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -22,12 +22,23 @@ const SITE_EDITOR_ONLY_SUGGESTION_IDS = new Set( [
 
 const SITE_EDITOR_POST_TYPES = new Set( [ 'wp_template', 'wp_template_part' ] );
 
-export const WRITING_SUGGESTION_IDS = new Set( [
-	'generate-excerpt',
-	'generate-feedback',
-	'proofread-content',
-	'mediate-review-notes',
-] );
+const WRITING_SUGGESTION_LABELS: Record< string, () => string > = {
+	'optimize-title': () => __( 'Optimize title', __i18n_text_domain__ ),
+	'generate-excerpt': () => __( 'Generate excerpt', __i18n_text_domain__ ),
+	'seo-enhancer': () => __( 'Optimize SEO', __i18n_text_domain__ ),
+	'generate-feedback': () => __( 'Simple review', __i18n_text_domain__ ),
+	'proofread-content': () => __( 'Proofread', __i18n_text_domain__ ),
+	'mediate-review-notes': () => __( 'Editorial review', __i18n_text_domain__ ),
+};
+
+export const WRITING_SUGGESTION_IDS = new Set( Object.keys( WRITING_SUGGESTION_LABELS ) );
+
+export const GROUPED_VIEW_HIDDEN_SUGGESTION_IDS = new Set( [ 'what-else-can-i-do' ] );
+
+// Keep compact, sentence-case labels limited to the grouped editor view.
+export function getWritingSuggestionLabel( suggestion: Suggestion ): string {
+	return WRITING_SUGGESTION_LABELS[ suggestion.id ]?.() ?? suggestion.label;
+}
 
 export const DEFAULT_EMPTY_VIEW_SUGGESTION_IDS = {
 	gettingStarted: 'getting-started',

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -22,6 +22,13 @@ const SITE_EDITOR_ONLY_SUGGESTION_IDS = new Set( [
 
 const SITE_EDITOR_POST_TYPES = new Set( [ 'wp_template', 'wp_template_part' ] );
 
+export const WRITING_SUGGESTION_IDS = new Set( [
+	'generate-excerpt',
+	'generate-feedback',
+	'proofread-content',
+	'mediate-review-notes',
+] );
+
 export const DEFAULT_EMPTY_VIEW_SUGGESTION_IDS = {
 	gettingStarted: 'getting-started',
 	createPost: 'create-post',
@@ -120,7 +127,7 @@ function isSiteEditorRoute( currentRoute?: string ): boolean {
 	return !! currentRoute?.includes( 'site-editor.php' ) || pathname.includes( 'site-editor.php' );
 }
 
-function shouldShowSiteEditorSuggestionsForSurface(
+export function isPageOrSiteEditorSurface(
 	sectionName: string,
 	currentRoute?: string,
 	currentPostType?: string
@@ -140,6 +147,29 @@ function shouldShowSiteEditorSuggestionsForSurface(
 	return sectionName === 'site-editor';
 }
 
+export function usePageOrSiteEditorSurface() {
+	const { sectionName, currentRoute } = useAgentsManagerContext();
+	const currentPostType = useSelect( ( select ) => {
+		try {
+			const editorStore = select( 'core/editor' ) as {
+				getCurrentPostType?: () => string | undefined;
+			};
+			return editorStore?.getCurrentPostType?.();
+		} catch {
+			return undefined;
+		}
+	}, [] );
+
+	return {
+		currentPostType,
+		isPageOrSiteEditorSurface: isPageOrSiteEditorSurface(
+			sectionName,
+			currentRoute,
+			currentPostType
+		),
+	};
+}
+
 function filterEmptyViewSuggestions(
 	suggestions: Suggestion[],
 	shouldShowSiteEditorSuggestions: boolean
@@ -156,22 +186,8 @@ export function useEmptyViewSuggestions( {
 	loadedProviders,
 }: UseEmptyViewSuggestionsOptions ): Suggestion[] | null {
 	const isReaderChat = isReaderChatHost();
-	const { sectionName, currentRoute } = useAgentsManagerContext();
-	const currentPostType = useSelect( ( select ) => {
-		try {
-			const editorStore = select( 'core/editor' ) as {
-				getCurrentPostType?: () => string | undefined;
-			};
-			return editorStore?.getCurrentPostType?.();
-		} catch {
-			return undefined;
-		}
-	}, [] );
-	const shouldShowSiteEditorSuggestions = shouldShowSiteEditorSuggestionsForSurface(
-		sectionName,
-		currentRoute,
-		currentPostType
-	);
+	const { currentPostType, isPageOrSiteEditorSurface: shouldShowSiteEditorSuggestions } =
+		usePageOrSiteEditorSurface();
 
 	// Default suggestions - used when Big Sky doesn't provide custom ones
 	const defaultSuggestions = useMemo(

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -11,10 +11,14 @@ interface UseEmptyViewSuggestionsOptions {
 	loadedProviders: LoadedProviders | null;
 }
 
-const SITE_EDITOR_ONLY_SUGGESTION_IDS = new Set( [
+export const DESIGN_SUGGESTION_IDS = new Set( [
 	'customize-colors',
 	'choose-new-fonts',
 	'change-page-layout',
+] );
+
+const SITE_EDITOR_ONLY_SUGGESTION_IDS = new Set( [
+	...DESIGN_SUGGESTION_IDS,
 	'edit-pages',
 	'add-new-page',
 	'what-else-can-i-do',

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -17,11 +17,13 @@ export const DESIGN_SUGGESTION_IDS = new Set( [
 	'change-page-layout',
 ] );
 
+const WHAT_ELSE_CAN_I_DO_SUGGESTION_ID = 'what-else-can-i-do';
+
 const SITE_EDITOR_ONLY_SUGGESTION_IDS = new Set( [
 	...DESIGN_SUGGESTION_IDS,
 	'edit-pages',
 	'add-new-page',
-	'what-else-can-i-do',
+	WHAT_ELSE_CAN_I_DO_SUGGESTION_ID,
 ] );
 
 const SITE_EDITOR_POST_TYPES = new Set( [ 'wp_template', 'wp_template_part' ] );
@@ -37,11 +39,26 @@ const WRITING_SUGGESTION_LABELS: Record< string, () => string > = {
 
 export const WRITING_SUGGESTION_IDS = new Set( Object.keys( WRITING_SUGGESTION_LABELS ) );
 
-export const GROUPED_VIEW_HIDDEN_SUGGESTION_IDS = new Set( [ 'what-else-can-i-do' ] );
+export const GROUPED_VIEW_HIDDEN_SUGGESTION_IDS = new Set( [ WHAT_ELSE_CAN_I_DO_SUGGESTION_ID ] );
 
 // Keep writing action labels consistent across flat and grouped editor views.
 export function getWritingSuggestionLabel( suggestion: Suggestion ): string {
 	return WRITING_SUGGESTION_LABELS[ suggestion.id ]?.() ?? suggestion.label;
+}
+
+export function formatWritingSuggestionLabels(
+	suggestions: Suggestion[],
+	shouldFormat: boolean
+): Suggestion[] {
+	if ( ! shouldFormat ) {
+		return suggestions;
+	}
+
+	return suggestions.map( ( suggestion ) =>
+		WRITING_SUGGESTION_IDS.has( suggestion.id )
+			? { ...suggestion, label: getWritingSuggestionLabel( suggestion ) }
+			: suggestion
+	);
 }
 
 export const DEFAULT_EMPTY_VIEW_SUGGESTION_IDS = {

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -17,7 +17,7 @@ export const DESIGN_SUGGESTION_IDS = new Set( [
 	'change-page-layout',
 ] );
 
-const WHAT_ELSE_CAN_I_DO_SUGGESTION_ID = 'what-else-can-i-do';
+export const WHAT_ELSE_CAN_I_DO_SUGGESTION_ID = 'what-else-can-i-do';
 
 const SITE_EDITOR_ONLY_SUGGESTION_IDS = new Set( [
 	...DESIGN_SUGGESTION_IDS,
@@ -38,8 +38,6 @@ const WRITING_SUGGESTION_LABELS: Record< string, () => string > = {
 };
 
 export const WRITING_SUGGESTION_IDS = new Set( Object.keys( WRITING_SUGGESTION_LABELS ) );
-
-export const GROUPED_VIEW_HIDDEN_SUGGESTION_IDS = new Set( [ WHAT_ELSE_CAN_I_DO_SUGGESTION_ID ] );
 
 // Keep writing action labels consistent across flat and grouped editor views.
 export function getWritingSuggestionLabel( suggestion: Suggestion ): string {

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -39,7 +39,7 @@ export const WRITING_SUGGESTION_IDS = new Set( Object.keys( WRITING_SUGGESTION_L
 
 export const GROUPED_VIEW_HIDDEN_SUGGESTION_IDS = new Set( [ 'what-else-can-i-do' ] );
 
-// Keep compact, sentence-case labels limited to the grouped editor view.
+// Keep writing action labels consistent across flat and grouped editor views.
 export function getWritingSuggestionLabel( suggestion: Suggestion ): string {
 	return WRITING_SUGGESTION_LABELS[ suggestion.id ]?.() ?? suggestion.label;
 }


### PR DESCRIPTION
Part of FORNO-326
<img width="1475" height="1006" alt="Screenshot 2026-07-15 at 14 07 01" src="https://github.com/user-attachments/assets/636153d7-95fb-42a1-b91d-52dbb1935abc" />
<img width="392" height="552" alt="image" src="https://github.com/user-attachments/assets/0fba8ca8-e281-4043-80c7-8540ecf9703f" />
<img width="342" height="1305" alt="Screenshot 2026-07-15 at 14 08 59" src="https://github.com/user-attachments/assets/dcfe04ca-02dc-4731-b92c-4c936127532c" />

## Proposed Changes

* Group Optimize title, Generate excerpt, Optimize SEO, Simple review, Proofread, and Editorial review under Writing when the Page or Site Editor also offers a Design action.
* Place Writing after the top-level suggestions. Start it collapsed and show a short description, action count, and light chevron.
* Join the Writing row and expanded actions into one seamless, full-width list in light and dark modes.
* Hide "What else can you do?" in the grouped view while keeping Design and other suggestions at the top level.
* Keep writing suggestions flat when no Design actions are available. Use the same sentence-case writing labels in the flat Post Editor view while retaining provider labels outside editor surfaces.
* Pass the original provider suggestion through when the user selects an action.

## Why are these changes being made?

* The Writing disclosure separates writing actions from Design actions. A writing-only suggestion set needs no section, so it keeps the existing flat list.

## Testing Instructions

1. Run `yarn start` and open Agents Manager with an empty conversation in the Post Editor.
2. Confirm writing suggestions remain flat and use sentence-case labels such as "Optimize title", "Generate excerpt", and "Optimize SEO".
3. Select a writing action and confirm it starts the same action or prompt flow as before.
4. Open Agents Manager with an empty conversation in the Page Editor or Site Editor.
5. Confirm Design and page actions remain top-level, "What else can you do?" is absent, and Writing appears collapsed after the last top-level action.
6. Confirm Writing shows "Improve and refine your content.", a count of 6, and a visible chevron in dark mode.
7. Expand Writing and confirm all six actions form one seamless, full-width list with sentence-case labels.
8. Open Agents Manager with writing and page actions but no Design actions. Confirm all suggestions remain flat and no Writing disclosure appears.

Sandbox environments:

1. Run `cd apps/agents-manager && yarn dev --sync`.
2. Repeat the Page Editor and Site Editor checks on Simple, Atomic, and CIAB sites.
3. Check the collapsed and expanded states with a keyboard, in dark mode, and in an RTL locale.

## Pre-merge Checklist

* [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
* [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
* [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
* [x] Have you checked for TypeScript, React or other console errors?
* [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
* [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
* [ ] Have you used memoizing on expensive computations? Memoizing is not necessary for cheap computations. Removing useMemo might result in a better user experience. See this [React core team discussion](https://github.com/facebook/react/issues/14476#issuecomment-471199055) for more details.
* [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    * [ ] For UI changes, have you tested the change in various languages (for example, ES, PT, FR, or DE)? For language-dependent layout changes, have you tested in both left-to-right and right-to-left languages?
* [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
