### PR TITLE
Bump agenttic packages to 0.1.79 and drop React 19 log filter

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -24,8 +24,6 @@ logFilters:
   # These packages are used by packages that support React 19, but their published peer ranges haven't
   # been widened yet. Keep this scoped to React 19 and the exact packages reported by Yarn.
   - level: discard
-    pattern: "+(react|react-dom) is listed by your project with version 19.*, which doesn't satisfy what @automattic/agenttic-ui *"
-  - level: discard
     pattern: "+(react|react-dom) is listed by your project with version 19.*, which doesn't satisfy what @paypal/react-paypal-js *"
 
   # i18n-calypso still declares a React 18 peer range.

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"@automattic/accessible-focus": "workspace:^",
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-ui": "^0.1.78",
+		"@automattic/agenttic-ui": "^0.1.79",
 		"@automattic/api-core": "workspace:^",
 		"@automattic/api-queries": "workspace:^",
 		"@automattic/block-renderer": "workspace:^",

--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -41,8 +41,8 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.78",
-		"@automattic/agenttic-ui": "^0.1.78",
+		"@automattic/agenttic-client": "^0.1.79",
+		"@automattic/agenttic-ui": "^0.1.79",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/block-notes/package.json
+++ b/packages/block-notes/package.json
@@ -41,7 +41,7 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.78",
+		"@automattic/agenttic-client": "^0.1.79",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",
 		"@wordpress/api-fetch": "^7.48.0",

--- a/packages/image-studio/package.json
+++ b/packages/image-studio/package.json
@@ -51,8 +51,8 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.78",
-		"@automattic/agenttic-ui": "^0.1.78",
+		"@automattic/agenttic-client": "^0.1.79",
+		"@automattic/agenttic-ui": "^0.1.79",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",

--- a/packages/jetpack-ai-sidebar/package.json
+++ b/packages/jetpack-ai-sidebar/package.json
@@ -44,7 +44,7 @@
 		"typecheck": "tsc --build --dry"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.78",
+		"@automattic/agenttic-client": "^0.1.79",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
 		"@automattic/components": "workspace:^",

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -41,7 +41,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.78",
+		"@automattic/agenttic-ui": "^0.1.79",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/zendesk-client": "workspace:^",

--- a/packages/odie-client/src/components/send-message-input/use-send-message-handler.ts
+++ b/packages/odie-client/src/components/send-message-input/use-send-message-handler.ts
@@ -10,7 +10,7 @@ interface UseSendMessageHandlerProps {
 	isChatBusy: boolean;
 	chat: Chat;
 	sendAttachments: () => void;
-	textareaRef: React.RefObject< HTMLTextAreaElement >;
+	textareaRef: React.RefObject< HTMLTextAreaElement | null >;
 	trackEvent: ( event: string, props?: Record< string, unknown > ) => void;
 	sendMessage: ( message: Message ) => Promise< unknown >;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,8 +133,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/agents-manager@workspace:packages/agents-manager"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.78"
-    "@automattic/agenttic-ui": "npm:^0.1.78"
+    "@automattic/agenttic-client": "npm:^0.1.79"
+    "@automattic/agenttic-ui": "npm:^0.1.79"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
@@ -180,55 +180,51 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/agenttic-client@npm:^0.1.78":
-  version: 0.1.78
-  resolution: "@automattic/agenttic-client@npm:0.1.78"
+"@automattic/agenttic-client@npm:^0.1.79":
+  version: 0.1.79
+  resolution: "@automattic/agenttic-client@npm:0.1.79"
   dependencies:
-    "@types/react": "npm:^18.0.0"
+    "@types/react": "npm:^18.0.0 || ^19.0.0"
     marked: "npm:^16.2.1"
-    react: "npm:^18.0.0"
   peerDependencies:
     "@wordpress/api-fetch": ^6.0.0 || ^7.0.0
-    react: ^18.0.0
+    react: ^18.0.0 || ^19.0.0
   dependenciesMeta:
     marked:
       optional: true
   peerDependenciesMeta:
     "@wordpress/api-fetch":
       optional: true
-  checksum: 084ab8ff11aa205fe57f4046f2ca4519d30261b12bb53459404caff2c58998cf2e70b1a7d1638a26714d4eef6665e4a5e6af9eb9279c3a75a356e0335c9c3d7f
+  checksum: 043a4ec8f0088fadff7023af4c012f5ae9ffb5655846143019d106faccd914dd5bad7ef490fe24317bed2ba65737e48b6523c8ab314d6ae3f3ff53ca43f1ace9
   languageName: node
   linkType: hard
 
-"@automattic/agenttic-ui@npm:^0.1.78":
-  version: 0.1.78
-  resolution: "@automattic/agenttic-ui@npm:0.1.78"
+"@automattic/agenttic-ui@npm:^0.1.79":
+  version: 0.1.79
+  resolution: "@automattic/agenttic-ui@npm:0.1.79"
   dependencies:
     "@automattic/charts": "npm:^1.10.0"
     "@radix-ui/react-popover": "npm:^1.1.15"
     "@radix-ui/react-scroll-area": "npm:^1.2.9"
     "@radix-ui/react-slot": "npm:^1.2.3"
-    "@visx/xychart": "npm:^4.0.0"
     "@wordpress/i18n": "npm:^6.1.0"
     class-variance-authority: "npm:^0.7.1"
     clsx: "npm:^2.1.1"
     framer-motion: "npm:^12.23.0"
     lucide-react: "npm:^0.525.0"
     marked: "npm:^16.2.1"
-    react: "npm:^18.0.0"
-    react-dom: "npm:^18.0.0"
     react-markdown: "npm:^10.1.0"
     react-textarea-autosize: "npm:^8.5.9"
     remark-gfm: "npm:^4.0.1"
     unified: "npm:^11.0.5"
     use-debounce: "npm:^10.0.6"
   peerDependencies:
-    react: ^18.0.0
-    react-dom: ^18.0.0
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
   dependenciesMeta:
     marked:
       optional: true
-  checksum: 94f115f1886a80b10f1864e48c35db4b69df5b2333fd1b4df69cff3b23ad659a4bc1ae5537ef72cff96bb975bf6db62387605da0a3c6d9f048d3cfdd5043f90e
+  checksum: 573ce9d379923e72b2d48b341e29aafe33de6ab653af4459d401f9d21b8580821c4710bc7aae6e4fe71f2d7ea504dcd4dbaea92c34b73b1c000425e587f3ef21
   languageName: node
   linkType: hard
 
@@ -344,7 +340,7 @@ __metadata:
   resolution: "@automattic/block-notes@workspace:packages/block-notes"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.78"
+    "@automattic/agenttic-client": "npm:^0.1.79"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@testing-library/react": "npm:^15.0.7"
@@ -1480,8 +1476,8 @@ __metadata:
   resolution: "@automattic/image-studio@workspace:packages/image-studio"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.78"
-    "@automattic/agenttic-ui": "npm:^0.1.78"
+    "@automattic/agenttic-client": "npm:^0.1.79"
+    "@automattic/agenttic-ui": "npm:^0.1.79"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/oauth-token": "workspace:^"
@@ -1576,7 +1572,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/jetpack-ai-sidebar@workspace:packages/jetpack-ai-sidebar"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.78"
+    "@automattic/agenttic-client": "npm:^0.1.79"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
@@ -1843,7 +1839,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/odie-client@workspace:packages/odie-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.78"
+    "@automattic/agenttic-ui": "npm:^0.1.79"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
@@ -14376,7 +14372,7 @@ __metadata:
   dependencies:
     "@automattic/accessible-focus": "workspace:^"
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-ui": "npm:^0.1.78"
+    "@automattic/agenttic-ui": "npm:^0.1.79"
     "@automattic/api-core": "workspace:^"
     "@automattic/api-queries": "workspace:^"
     "@automattic/block-renderer": "workspace:^"


### PR DESCRIPTION
Fixes DOTCOM-17695

## Proposed Changes

* Bump `@automattic/agenttic-ui` and `@automattic/agenttic-client` from `^0.1.78` to `^0.1.79`.
* Remove the `@automattic/agenttic-ui` React 19 peer-dependency log filter from `.yarnrc.yml` (added in #111721).
* Widen the `textareaRef` param in odie-client's `use-send-message-handler.ts` to `RefObject<HTMLTextAreaElement | null>` to match `useInput`'s updated React 19 ref typing in agenttic-ui `0.1.79`.

## Why are these changes being made?

`@automattic/agenttic-ui` / `@automattic/agenttic-client` `0.1.79` widen their React peer range to `^18 || ^19`. That was the reason the `.yarnrc.yml` log filter existed — to suppress the React 19 peer-dependency warning while agenttic still declared React 18 only. With the bump, that filter is obsolete and can be removed.

Note: the `@wordpress/*` and `@paypal/react-paypal-js` filters added in the same original PR are intentionally kept — those packages still resolve to React 18-only peer ranges (`@paypal/react-paypal-js@8.7.0` and the `@wordpress/*` monorepo), so their warnings would resurface if removed.

The agenttic bump surfaced a real type break: `useInput()` in `0.1.79` now returns `RefObject<HTMLTextAreaElement | null>` (React 19 ref typing), so the local handler's param type was widened to match.

## Testing Instructions

* Run `yarn install` — resolution completes and `agenttic-ui`/`agenttic-client` resolve to `0.1.79` with no React 19 peer-dependency warning for agenttic.
* `yarn build-packages` (runs as postinstall) type-checks the affected packages, including `odie-client`, and passes.
* Confirm the Odie/help-center send-message input still focuses and sends correctly.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?