### PR TITLE
Returning user modal: Add theme variation

### DIFF
--- a/client/components/resurrected-welcome-modal/index.tsx
+++ b/client/components/resurrected-welcome-modal/index.tsx
@@ -5,6 +5,11 @@ import { close } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useResurrectedFreeUserEligibility } from 'calypso/lib/resurrected-users';
+import {
+	WELCOME_BACK_VARIATIONS,
+	WELCOME_BACK_VARIATION_MANUAL,
+	type WelcomeBackVariation,
+} from 'calypso/lib/resurrected-users/constants';
 
 import './style.scss';
 
@@ -29,6 +34,7 @@ type VariationConfig = {
 };
 
 const ONBOARDING_URL = '/setup/onboarding';
+const THEMES_SHOWCASE_URL = '/themes';
 
 // Rolled-out variation: MANUAL only.
 const MANUAL_VARIATION_CONFIG: VariationConfig = {
@@ -51,6 +57,30 @@ const MANUAL_VARIATION_CONFIG: VariationConfig = {
 			variant: 'tertiary',
 		},
 	],
+};
+
+const VARIATION_CONTENT: Partial< Record< WelcomeBackVariation, VariationConfig > > = {
+	[ WELCOME_BACK_VARIATIONS.themes ]: {
+		getTitle: ( translate ) => translate( 'Welcome back!' ),
+		getDescription: ( translate ) =>
+			translate(
+				"We've added beautiful new themes since your last visit. Browse around and find what feels right for your site."
+			),
+		ctas: [
+			{
+				id: 'manual-new',
+				getLabel: ( translate ) => translate( 'Browse new themes' ),
+				href: THEMES_SHOWCASE_URL,
+				variant: 'primary',
+			},
+			{
+				id: 'manual-continue',
+				getLabel: ( translate ) => translate( 'Create a new site' ),
+				href: ONBOARDING_URL,
+				variant: 'tertiary',
+			},
+		],
+	},
 };
 
 const getInitialDismissState = () => {
@@ -79,11 +109,15 @@ export const ResurrectedWelcomeModalGate = ( {
 	const previousVisibilityRef = useRef( false );
 
 	const variationName = eligibility.variationName;
-	const variationConfig = variationName ? MANUAL_VARIATION_CONFIG : undefined;
+	let variationConfig = variationName ? MANUAL_VARIATION_CONFIG : undefined;
+	if ( variationName && variationName in VARIATION_CONTENT ) {
+		variationConfig = VARIATION_CONTENT[ variationName ];
+	}
+
 	const variationClassName = variationName
 		? `resurrected-welcome-modal--${ variationName.replace( /_/g, '-' ) }`
 		: null;
-	const hasDarkHero = true; // MANUAL variation uses dark hero
+	const hasDarkHero = variationName === WELCOME_BACK_VARIATION_MANUAL;
 
 	const shouldDisplay =
 		! eligibility.isLoading &&

--- a/client/lib/resurrected-users/constants.ts
+++ b/client/lib/resurrected-users/constants.ts
@@ -7,5 +7,12 @@ export const RESURRECTED_EVENT_6M = 'calypso_user_resurrected_6m';
 /** Rolled-out welcome-back modal variation (manual onboarding + continue). */
 export const WELCOME_BACK_VARIATION_MANUAL = 'treatment_manual_dual' as const;
 
+/* Variations for the new welcome-back modal experiment */
+export const WELCOME_BACK_VARIATIONS = {
+	themes: 'treatment_themes',
+};
+export type WelcomeBackVariation =
+	( typeof WELCOME_BACK_VARIATIONS )[ keyof typeof WELCOME_BACK_VARIATIONS ];
+
 /** Feature flag to force the welcome-back modal for local/testing. */
 export const WELCOME_BACK_MODAL_FORCE_FLAG = 'welcome-back-modal-manual';

--- a/client/lib/resurrected-users/constants.ts
+++ b/client/lib/resurrected-users/constants.ts
@@ -10,7 +10,7 @@ export const WELCOME_BACK_VARIATION_MANUAL = 'treatment_manual_dual' as const;
 /* Variations for the new welcome-back modal experiment */
 export const WELCOME_BACK_VARIATIONS = {
 	themes: 'treatment_themes',
-} as const;
+};
 export type WelcomeBackVariation =
 	( typeof WELCOME_BACK_VARIATIONS )[ keyof typeof WELCOME_BACK_VARIATIONS ];
 

--- a/client/lib/resurrected-users/constants.ts
+++ b/client/lib/resurrected-users/constants.ts
@@ -10,7 +10,7 @@ export const WELCOME_BACK_VARIATION_MANUAL = 'treatment_manual_dual' as const;
 /* Variations for the new welcome-back modal experiment */
 export const WELCOME_BACK_VARIATIONS = {
 	themes: 'treatment_themes',
-};
+} as const;
 export type WelcomeBackVariation =
 	( typeof WELCOME_BACK_VARIATIONS )[ keyof typeof WELCOME_BACK_VARIATIONS ];
 


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTCOM-17868

## Proposed Changes

* Implement a new "themes" variation for the returning user welcome modal: 
<img width="414" height="517" alt="image" src="https://github.com/user-attachments/assets/b9d8e42f-60fd-4177-ac55-609fdf401e68" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To support future experiments.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Update `use-resurrected-free-user-eligibility.ts` and update the variant name to: 
```
    variationName: WELCOME_BACK_VARIATIONS.themes,
```
- Start Calypso with: `ENABLE_FEATURES=welcome-back-modal-manual yarn start` 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
