### PR TITLE
privacy-toolset: declare missing runtime dependencies

### DIFF
--- a/packages/privacy-toolset/package.json
+++ b/packages/privacy-toolset/package.json
@@ -42,7 +42,10 @@
 		"storybook:start": "storybook dev"
 	},
 	"dependencies": {
-		"clsx": "^2.1.1"
+		"@wordpress/components": "^35.0.0",
+		"clsx": "^2.1.1",
+		"react-modal": "^3.16.3",
+		"tslib": "^2.8.1"
 	},
 	"peerDependencies": {
 		"react": "^18.3.1 || ^19.0.0",

--- a/packages/privacy-toolset/package.json
+++ b/packages/privacy-toolset/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/privacy-toolset",
-	"version": "2.1.1",
+	"version": "2.2.0",
 	"description": "Privacy tools and components for Automattic solutions.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2058,10 +2058,13 @@ __metadata:
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:^6.9.1"
     "@testing-library/react": "npm:^16.3.2"
+    "@wordpress/components": "npm:^35.0.0"
     clsx: "npm:^2.1.1"
     postcss: "npm:^8.5.15"
+    react-modal: "npm:^3.16.3"
     require-from-string: "npm:^2.0.2"
     storybook: "npm:^9.1.20"
+    tslib: "npm:^2.8.1"
     typescript: "npm:^6.0.3"
     webpack: "npm:^5.99.8"
   peerDependencies:


### PR DESCRIPTION
## Proposed Changes

Add three missing runtime dependencies to `@automattic/privacy-toolset`:

* `@wordpress/components` — imported by `do-not-sell-dialog` and `cookie-banner/granular-consent`
* `react-modal` — imported by `do-not-sell-dialog`
* `tslib` — required by the compiled output (emitted by TypeScript's `importHelpers`)

## Why are these changes being made?

These packages are imported by the shipped code but were never declared in `package.json`. Inside the monorepo they resolve through Yarn workspace hoisting, so the gap is invisible here. A third party running `npm install @automattic/privacy-toolset` gets none of them, and importing the package throws `Cannot find module '@wordpress/components'`.

## Testing Instructions

Packed the package with `yarn pack` and installed the tarball into a throwaway project with only `react`/`react-dom` present.

* **Before:** `require('@automattic/privacy-toolset')` → `Error: Cannot find module '@wordpress/components'`.
* **After:** the three dependencies install, and every dependency reachable from the package entry point resolves from the clean install.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
