### PR TITLE
calypso-e2e: declare missing dependencies

### DIFF
--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-e2e",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"description": "Tools for e2e tests.",
 	"main": "dist/cjs/src/index.js",
 	"module": "dist/esm/src/index.js",

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -19,15 +19,21 @@
 	],
 	"license": "GPL-2.0-or-later",
 	"dependencies": {
+		"@automattic/jest-circus-allure-reporter": "workspace:^",
 		"@jest/types": "^29.6.3",
 		"@playwright/browser-chromium": "1.57.0",
 		"@playwright/browser-firefox": "1.57.0",
 		"@types/totp-generator": "^0.0.8",
+		"@wordpress/i18n": "^6.21.0",
+		"asana-phrase": "^0.0.8",
+		"chalk": "^4.1.2",
 		"form-data": "^4.0.6",
 		"jest-docblock": "^29.7.0",
+		"jest-environment-node": "^29.7.0",
 		"mailosaur": "^8.4.0",
 		"playwright": "1.57.0",
-		"totp-generator": "^0.0.14"
+		"totp-generator": "^0.0.14",
+		"tslib": "^2.8.1"
 	},
 	"devDependencies": {
 		"@automattic/calypso-eslint-overrides": "workspace:^",
@@ -36,8 +42,6 @@
 		"@automattic/zendesk-client": "workspace:^",
 		"@jest/globals": "^29.7.0",
 		"@types/node": "^24.12.2",
-		"@wordpress/i18n": "^6.21.0",
-		"asana-phrase": "^0.0.8",
 		"nock": "^14.0.15",
 		"typescript": "^6.0.3"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -549,6 +549,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-eslint-overrides": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@automattic/jest-circus-allure-reporter": "workspace:^"
     "@automattic/languages": "workspace:^"
     "@automattic/zendesk-client": "workspace:^"
     "@jest/globals": "npm:^29.7.0"
@@ -559,12 +560,15 @@ __metadata:
     "@types/totp-generator": "npm:^0.0.8"
     "@wordpress/i18n": "npm:^6.21.0"
     asana-phrase: "npm:^0.0.8"
+    chalk: "npm:^4.1.2"
     form-data: "npm:^4.0.6"
     jest-docblock: "npm:^29.7.0"
+    jest-environment-node: "npm:^29.7.0"
     mailosaur: "npm:^8.4.0"
     nock: "npm:^14.0.15"
     playwright: "npm:1.57.0"
     totp-generator: "npm:^0.0.14"
+    tslib: "npm:^2.8.1"
     typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Proposed Changes

Declare dependencies that `@automattic/calypso-e2e` uses but never listed in its `package.json`:

* `@automattic/jest-circus-allure-reporter` — imported by `src/jest-playwright-config/environment.ts`
* `@wordpress/i18n` — imported by `src/lib/utils/validate-translations.ts`
* `asana-phrase` — imported by `src/data-helper.ts`
* `chalk` — imported by `src/lib/test-account.ts`
* `jest-environment-node` — imported by `src/jest-playwright-config/environment.ts`
* `tslib` — required by the compiled output (emitted by TypeScript `importHelpers`)

## Why are these changes being made?

These modules are imported by the package's shipped code (or, for `tslib`, injected into the compiled output by the TypeScript compiler) but were absent from `package.json`. Within the monorepo they resolve through Yarn workspace hoisting, so the omission is invisible here. A third party installing `@automattic/calypso-e2e` on its own would not receive them and module resolution would fail at import time.

The `workspace:^` entries are packages that already live in this monorepo; declaring them makes the existing import explicit. `asana-phrase` and `@wordpress/i18n` were previously listed as `devDependencies` but are imported by shipped library modules, so they are moved to `dependencies`.

`@jest/globals` and `nock` are intentionally left as `devDependencies`: they appear only in this package's own compiled test files, which a consumer of the library does not import.

## Testing Instructions

Packed the package with `yarn pack` and inspected resolution from a clean, separate install (no monorepo hoisting).

* **Before:** dependencies reachable from the package entry point fail to resolve (e.g. `Cannot find module`).
* **After:** every external module reachable from the entry point resolves against the package's declared dependencies.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?