### PR TITLE
domain-search: declare missing dependencies

### DIFF
--- a/packages/domain-search/package.json
+++ b/packages/domain-search/package.json
@@ -45,19 +45,28 @@
 	},
 	"dependencies": {
 		"@automattic/api-core": "workspace:^",
+		"@automattic/api-queries": "workspace:^",
 		"@automattic/calypso-products": "workspace:^",
+		"@automattic/components": "workspace:^",
 		"@automattic/explat-client": "workspace:^",
 		"@automattic/explat-client-react-helpers": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
+		"@automattic/number-formatters": "^1.2.0",
 		"@automattic/urls": "workspace:^",
 		"@tanstack/react-query": "^5.83.0",
 		"@wordpress/components": "^35.0.0",
 		"@wordpress/compose": "^8.2.0",
 		"@wordpress/icons": "^13.3.0",
+		"@wordpress/primitives": "^4.48.0",
 		"@wordpress/react-i18n": "^4.48.0",
 		"clsx": "^2.1.1",
 		"moment": "^2.30.1",
 		"qs": "^6.15.2"
+	},
+	"peerDependencies": {
+		"@wordpress/element": "^8.0.0",
+		"@wordpress/i18n": "^6.21.0",
+		"react": "^18.3.1 || ^19.0.0"
 	},
 	"devDependencies": {
 		"@automattic/calypso-eslint-overrides": "workspace:^",
@@ -74,9 +83,5 @@
 		"react-dom": "^18.3.1",
 		"storybook": "^9.1.20",
 		"typescript": "^6.0.3"
-	},
-	"peerDependencies": {
-		"@wordpress/i18n": "^6.21.0",
-		"react": "^18.3.1 || ^19.0.0"
 	}
 }

--- a/packages/domain-search/package.json
+++ b/packages/domain-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/domain-search",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"description": "Domain search components for WordPress.com.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/domain-search/package.json
+++ b/packages/domain-search/package.json
@@ -56,6 +56,8 @@
 		"@tanstack/react-query": "^5.83.0",
 		"@wordpress/components": "^35.0.0",
 		"@wordpress/compose": "^8.2.0",
+		"@wordpress/data": "^10.48.0",
+		"@wordpress/element": "^8.0.0",
 		"@wordpress/icons": "^13.3.0",
 		"@wordpress/primitives": "^4.48.0",
 		"@wordpress/react-i18n": "^4.48.0",
@@ -64,7 +66,6 @@
 		"qs": "^6.15.2"
 	},
 	"peerDependencies": {
-		"@wordpress/element": "^8.0.0",
 		"@wordpress/i18n": "^6.21.0",
 		"react": "^18.3.1 || ^19.0.0"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -1165,6 +1165,8 @@ __metadata:
     "@wordpress/base-styles": "npm:^9.1.0"
     "@wordpress/components": "npm:^35.0.0"
     "@wordpress/compose": "npm:^8.2.0"
+    "@wordpress/data": "npm:^10.48.0"
+    "@wordpress/element": "npm:^8.0.0"
     "@wordpress/icons": "npm:^13.3.0"
     "@wordpress/primitives": "npm:^4.48.0"
     "@wordpress/react-i18n": "npm:^4.48.0"
@@ -1178,7 +1180,6 @@ __metadata:
     storybook: "npm:^9.1.20"
     typescript: "npm:^6.0.3"
   peerDependencies:
-    "@wordpress/element": ^8.0.0
     "@wordpress/i18n": ^6.21.0
     react: ^18.3.1 || ^19.0.0
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -1146,13 +1146,16 @@ __metadata:
   resolution: "@automattic/domain-search@workspace:packages/domain-search"
   dependencies:
     "@automattic/api-core": "workspace:^"
+    "@automattic/api-queries": "workspace:^"
     "@automattic/calypso-eslint-overrides": "workspace:^"
     "@automattic/calypso-products": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@automattic/components": "workspace:^"
     "@automattic/explat-client": "workspace:^"
     "@automattic/explat-client-react-helpers": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
+    "@automattic/number-formatters": "npm:^1.2.0"
     "@automattic/urls": "workspace:^"
     "@storybook/addon-a11y": "npm:^9.1.20"
     "@tanstack/react-query": "npm:^5.83.0"
@@ -1163,6 +1166,7 @@ __metadata:
     "@wordpress/components": "npm:^35.0.0"
     "@wordpress/compose": "npm:^8.2.0"
     "@wordpress/icons": "npm:^13.3.0"
+    "@wordpress/primitives": "npm:^4.48.0"
     "@wordpress/react-i18n": "npm:^4.48.0"
     clsx: "npm:^2.1.1"
     copyfiles: "npm:^2.4.1"
@@ -1174,6 +1178,7 @@ __metadata:
     storybook: "npm:^9.1.20"
     typescript: "npm:^6.0.3"
   peerDependencies:
+    "@wordpress/element": ^8.0.0
     "@wordpress/i18n": ^6.21.0
     react: ^18.3.1 || ^19.0.0
   languageName: unknown


### PR DESCRIPTION
## Proposed Changes

Declare dependencies that `@automattic/domain-search` uses but never listed in its `package.json`:

* `@automattic/api-queries` — imported by `src/page/context.ts`
* `@automattic/components` — imported by `src/ui/domain-search-already-own-domain-cta/index.tsx`
* `@automattic/number-formatters` — imported by `src/components/suggestion-price/index.tsx`
* `@wordpress/primitives` — imported by `src/ui/domain-suggestion-cta/shopping-cart-icon.tsx`
* `@wordpress/element` (peer) — imported by `src/components/search-form/index.tsx`

## Why are these changes being made?

These modules are imported by the package's shipped code (or, for `tslib`, injected into the compiled output by the TypeScript compiler) but were absent from `package.json`. Within the monorepo they resolve through Yarn workspace hoisting, so the omission is invisible here. A third party installing `@automattic/domain-search` on its own would not receive them and module resolution would fail at import time. React (and other host singletons) are added as `peerDependencies` to match the convention used by the other packages in this repo.

The `workspace:^` entries are packages that already live in this monorepo; declaring them makes the existing import explicit.

## Testing Instructions

Packed the package with `yarn pack` and inspected resolution from a clean, separate install (no monorepo hoisting).

* **Before:** dependencies reachable from the package entry point fail to resolve (e.g. `Cannot find module`).
* **After:** every external module reachable from the entry point resolves against the package's declared dependencies.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?