### PR TITLE
i18n-calypso: declare missing dependencies

### DIFF
--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "i18n-calypso",
-	"version": "8.0.0",
+	"version": "8.1.0",
 	"description": "I18n JavaScript library on top of Tannin originally used in Calypso.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -41,7 +41,11 @@
 		"hash.js": "^1.1.7",
 		"lru": "^3.1.0",
 		"tannin": "^1.2.0",
+		"tslib": "^2.8.1",
 		"use-subscription": "1.11.0"
+	},
+	"peerDependencies": {
+		"react": "^18.3.1 || ^19.0.0"
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
@@ -53,8 +57,5 @@
 		"react-dom": "^18.3.1",
 		"react-test-renderer": "^18.3.1",
 		"typescript": "^6.0.3"
-	},
-	"peerDependencies": {
-		"react": "^18.3.1 || ^19.0.0"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -20699,6 +20699,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-test-renderer: "npm:^18.3.1"
     tannin: "npm:^1.2.0"
+    tslib: "npm:^2.8.1"
     typescript: "npm:^6.0.3"
     use-subscription: "npm:1.11.0"
   peerDependencies:


### PR DESCRIPTION
## Proposed Changes

Declare dependencies that `i18n-calypso` uses but never listed in its `package.json`:

* `tslib` — required by the compiled output (emitted by TypeScript `importHelpers`)

## Why are these changes being made?

These modules are imported by the package's shipped code (or, for `tslib`, injected into the compiled output by the TypeScript compiler) but were absent from `package.json`. Within the monorepo they resolve through Yarn workspace hoisting, so the omission is invisible here. A third party installing `i18n-calypso` on its own would not receive them and module resolution would fail at import time.

## Testing Instructions

Packed the package with `yarn pack` and inspected resolution from a clean, separate install (no monorepo hoisting).

* **Before:** dependencies reachable from the package entry point fail to resolve (e.g. `Cannot find module`).
* **After:** every external module reachable from the entry point resolves against the package's declared dependencies.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?