### PR TITLE
jest-circus-allure-reporter: declare missing dependencies

### DIFF
--- a/packages/jest-circus-allure-reporter/package.json
+++ b/packages/jest-circus-allure-reporter/package.json
@@ -22,7 +22,8 @@
 	"license": "GPL-2.0-or-later",
 	"dependencies": {
 		"@types/allure-js-commons": "^0.0.4",
-		"allure-js-commons": "2.0.0-beta.9"
+		"allure-js-commons": "2.0.0-beta.9",
+		"jest-docblock": "^29.7.0"
 	},
 	"devDependencies": {
 		"@automattic/calypso-eslint-overrides": "workspace:^",

--- a/packages/jest-circus-allure-reporter/package.json
+++ b/packages/jest-circus-allure-reporter/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@automattic/jest-circus-allure-reporter",
 	"author": "Automattic Inc.",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "Allure reporter for Jest-Circus test runner.",
 	"main": "dist/esm/src/index.js",
 	"module": "dist/esm/src/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1533,6 +1533,7 @@ __metadata:
     "@types/allure-js-commons": "npm:^0.0.4"
     "@types/node": "npm:^24.12.2"
     allure-js-commons: "npm:2.0.0-beta.9"
+    jest-docblock: "npm:^29.7.0"
     typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Proposed Changes

Declare dependencies that `@automattic/jest-circus-allure-reporter` uses but never listed in its `package.json`:

* `jest-docblock` — imported by `src/reporter.ts`

## Why are these changes being made?

These modules are imported by the package's shipped code (or, for `tslib`, injected into the compiled output by the TypeScript compiler) but were absent from `package.json`. Within the monorepo they resolve through Yarn workspace hoisting, so the omission is invisible here. A third party installing `@automattic/jest-circus-allure-reporter` on its own would not receive them and module resolution would fail at import time.

## Testing Instructions

Packed the package with `yarn pack` and inspected resolution from a clean, separate install (no monorepo hoisting).

* **Before:** dependencies reachable from the package entry point fail to resolve (e.g. `Cannot find module`).
* **After:** every external module reachable from the entry point resolves against the package's declared dependencies.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?