### PR TITLE
jetpack-ai-calypso: declare missing dependencies

### DIFF
--- a/packages/jetpack-ai-calypso/package.json
+++ b/packages/jetpack-ai-calypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-ai-calypso",
-	"version": "2.0.1",
+	"version": "2.1.0",
 	"description": "Jetpack AI utilities available to Calypso.",
 	"calypso:src": "src/index.ts",
 	"main": "dist/cjs/index.js",

--- a/packages/jetpack-ai-calypso/package.json
+++ b/packages/jetpack-ai-calypso/package.json
@@ -50,6 +50,26 @@
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
+	"dependencies": {
+		"@automattic/calypso-analytics": "workspace:^",
+		"@automattic/data-stores": "workspace:^",
+		"@automattic/i18n-utils": "workspace:^",
+		"@automattic/languages": "workspace:^",
+		"@wordpress/components": "^35.0.0",
+		"@wordpress/i18n": "^6.21.0",
+		"@wordpress/icons": "^13.3.0",
+		"clsx": "^2.1.1",
+		"debug": "^4.4.1",
+		"tslib": "^2.8.1",
+		"wpcom-proxy-request": "workspace:^"
+	},
+	"peerDependencies": {
+		"@babel/runtime": "^7.27.1",
+		"@wordpress/data": "^10.48.0",
+		"@wordpress/element": "^8.0.0",
+		"react": "^18.3.1 || ^19.0.0",
+		"react-dom": "^18.3.1 || ^19.0.0"
+	},
 	"devDependencies": {
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
@@ -62,23 +82,9 @@
 		"typescript": "^6.0.3",
 		"webpack": "^5.99.8"
 	},
-	"peerDependencies": {
-		"@babel/runtime": "^7.27.1",
-		"@wordpress/data": "^10.48.0",
-		"react": "^18.3.1 || ^19.0.0",
-		"react-dom": "^18.3.1 || ^19.0.0"
-	},
 	"peerDependenciesMeta": {
 		"@babel/runtime": {
 			"optional": true
 		}
-	},
-	"dependencies": {
-		"@automattic/calypso-analytics": "workspace:^",
-		"@automattic/data-stores": "workspace:^",
-		"@automattic/i18n-utils": "workspace:^",
-		"@automattic/languages": "workspace:^",
-		"clsx": "^2.1.1",
-		"debug": "^4.4.1"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1550,16 +1550,22 @@ __metadata:
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:^6.9.1"
     "@testing-library/react": "npm:^16.3.2"
+    "@wordpress/components": "npm:^35.0.0"
+    "@wordpress/i18n": "npm:^6.21.0"
+    "@wordpress/icons": "npm:^13.3.0"
     clsx: "npm:^2.1.1"
     debug: "npm:^4.4.1"
     postcss: "npm:^8.5.15"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
+    tslib: "npm:^2.8.1"
     typescript: "npm:^6.0.3"
     webpack: "npm:^5.99.8"
+    wpcom-proxy-request: "workspace:^"
   peerDependencies:
     "@babel/runtime": ^7.27.1
     "@wordpress/data": ^10.48.0
+    "@wordpress/element": ^8.0.0
     react: ^18.3.1 || ^19.0.0
     react-dom: ^18.3.1 || ^19.0.0
   peerDependenciesMeta:


### PR DESCRIPTION
## Proposed Changes

Declare dependencies that `@automattic/jetpack-ai-calypso` uses but never listed in its `package.json`:

* `@wordpress/components` — imported by `src/logo-generator/components/feature-fetch-failure-screen.tsx`
* `@wordpress/i18n` — imported by `src/logo-generator/components/feature-fetch-failure-screen.tsx`
* `@wordpress/icons` — imported by `src/logo-generator/components/generator-modal.tsx`
* `wpcom-proxy-request` — imported by `src/logo-generator/lib/media-exists.ts`
* `tslib` — required by the compiled output (emitted by TypeScript `importHelpers`)
* `@wordpress/element` (peer) — imported by `src/logo-generator/components/upgrade-nudge.tsx`

## Why are these changes being made?

These modules are imported by the package's shipped code (or, for `tslib`, injected into the compiled output by the TypeScript compiler) but were absent from `package.json`. Within the monorepo they resolve through Yarn workspace hoisting, so the omission is invisible here. A third party installing `@automattic/jetpack-ai-calypso` on its own would not receive them and module resolution would fail at import time. React (and other host singletons) are added as `peerDependencies` to match the convention used by the other packages in this repo.

The `workspace:^` entries are packages that already live in this monorepo; declaring them makes the existing import explicit.

## Testing Instructions

Packed the package with `yarn pack` and inspected resolution from a clean, separate install (no monorepo hoisting).

* **Before:** dependencies reachable from the package entry point fail to resolve (e.g. `Cannot find module`).
* **After:** every external module reachable from the entry point resolves against the package's declared dependencies.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?