### PR TITLE
mini-cart: declare missing dependencies

### DIFF
--- a/packages/mini-cart/package.json
+++ b/packages/mini-cart/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/mini-cart",
-	"version": "1.0.4",
+	"version": "1.1.0",
 	"description": "A simple wp.com shopping-cart interface.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/mini-cart/package.json
+++ b/packages/mini-cart/package.json
@@ -56,16 +56,16 @@
 		"debug": "^4.4.1",
 		"i18n-calypso": "workspace:^"
 	},
+	"peerDependencies": {
+		"@emotion/react": "^11.4.1",
+		"react": "^18.3.1 || ^19.0.0"
+	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
-		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"typescript": "^6.0.3"
-	},
-	"peerDependencies": {
-		"@emotion/react": "^11.4.1"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1730,11 +1730,11 @@ __metadata:
     "@wordpress/react-i18n": "npm:^4.48.0"
     debug: "npm:^4.4.1"
     i18n-calypso: "workspace:^"
-    react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     typescript: "npm:^6.0.3"
   peerDependencies:
     "@emotion/react": ^11.4.1
+    react: ^18.3.1 || ^19.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Proposed Changes

Declare dependencies that `@automattic/mini-cart` uses but never listed in its `package.json`:

* `react` (peer) — imported by the shipped code

## Why are these changes being made?

These modules are imported by the package's shipped code (or, for `tslib`, injected into the compiled output by the TypeScript compiler) but were absent from `package.json`. Within the monorepo they resolve through Yarn workspace hoisting, so the omission is invisible here. A third party installing `@automattic/mini-cart` on its own would not receive them and module resolution would fail at import time. React (and other host singletons) are added as `peerDependencies` to match the convention used by the other packages in this repo.

## Testing Instructions

Packed the package with `yarn pack` and inspected resolution from a clean, separate install (no monorepo hoisting).

* **Before:** dependencies reachable from the package entry point fail to resolve (e.g. `Cannot find module`).
* **After:** every external module reachable from the entry point resolves against the package's declared dependencies.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?