### PR TITLE
plans-grid-next: declare missing dependencies

### DIFF
--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -46,6 +46,7 @@
 		"storybook:start": "yarn msw init && storybook dev"
 	},
 	"dependencies": {
+		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
@@ -54,6 +55,7 @@
 		"@automattic/typography": "workspace:^",
 		"@emotion/react": "11.11.1",
 		"@emotion/styled": "^11.11.0",
+		"@wordpress/components": "^35.0.0",
 		"@wordpress/data": "^10.48.0",
 		"@wordpress/element": "^8.0.0",
 		"@wordpress/icons": "^13.3.0",
@@ -63,7 +65,8 @@
 		"clsx": "^2.1.1",
 		"i18n-calypso": "workspace:^",
 		"react-intersection-observer": "^9.4.3",
-		"react-transition-group": "^4.4.5"
+		"react-transition-group": "^4.4.5",
+		"tslib": "^2.8.1"
 	},
 	"peerDependencies": {
 		"@wordpress/i18n": "^6.21.0",

--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/plans-grid-next",
-	"version": "1.0.3",
+	"version": "1.1.0",
 	"description": "WordPress.com plans UI grid components and helpers.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1986,6 +1986,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/plans-grid-next@workspace:packages/plans-grid-next"
   dependencies:
+    "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-color-schemes": "workspace:^"
     "@automattic/calypso-products": "workspace:^"
@@ -2003,6 +2004,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:^6.9.1"
     "@testing-library/react": "npm:^16.3.2"
     "@testing-library/user-event": "npm:^14.6.1"
+    "@wordpress/components": "npm:^35.0.0"
     "@wordpress/data": "npm:^10.48.0"
     "@wordpress/element": "npm:^8.0.0"
     "@wordpress/icons": "npm:^13.3.0"
@@ -2017,6 +2019,7 @@ __metadata:
     react-transition-group: "npm:^4.4.5"
     resize-observer-polyfill: "npm:^1.5.1"
     storybook: "npm:^9.1.20"
+    tslib: "npm:^2.8.1"
     typescript: "npm:^6.0.3"
     webpack: "npm:^5.99.8"
   peerDependencies:


### PR DESCRIPTION
## Proposed Changes

Declare dependencies that `@automattic/plans-grid-next` uses but never listed in its `package.json`:

* `@automattic/calypso-analytics` — imported by `src/components/plan-type-selector/components/interval-type-dropdown.tsx`
* `@wordpress/components` — imported by `src/components/plan-type-selector/components/interval-type-dropdown.tsx`
* `tslib` — required by the compiled output (emitted by TypeScript `importHelpers`)

## Why are these changes being made?

These modules are imported by the package's shipped code (or, for `tslib`, injected into the compiled output by the TypeScript compiler) but were absent from `package.json`. Within the monorepo they resolve through Yarn workspace hoisting, so the omission is invisible here. A third party installing `@automattic/plans-grid-next` on its own would not receive them and module resolution would fail at import time.

The `workspace:^` entries are packages that already live in this monorepo; declaring them makes the existing import explicit.

## Testing Instructions

Packed the package with `yarn pack` and inspected resolution from a clean, separate install (no monorepo hoisting).

* **Before:** dependencies reachable from the package entry point fail to resolve (e.g. `Cannot find module`).
* **After:** every external module reachable from the entry point resolves against the package's declared dependencies.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?