### PR TITLE
site-admin: declare missing dependencies

### DIFF
--- a/packages/site-admin/package.json
+++ b/packages/site-admin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/site-admin",
-	"version": "0.1.5",
+	"version": "0.2.0",
 	"description": "A reusable UI package providing essential resources for building a modern administrative interface within the WordPress admin. It offers structured components, a routing system, and layout utilities.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/site-admin/package.json
+++ b/packages/site-admin/package.json
@@ -47,6 +47,24 @@
 	"license": "GPL-2.0-or-later",
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/site-admin#readme",
+	"dependencies": {
+		"@wordpress/base-styles": "^9.1.0",
+		"@wordpress/commands": "^1.48.0",
+		"@wordpress/components": "^35.0.0",
+		"@wordpress/compose": "^8.2.0",
+		"@wordpress/core-data": "^7.48.0",
+		"@wordpress/dom": "^4.48.0",
+		"@wordpress/element": "^8.0.0",
+		"@wordpress/html-entities": "^4.48.0",
+		"@wordpress/i18n": "^6.21.0",
+		"@wordpress/icons": "^13.3.0",
+		"@wordpress/keycodes": "^4.48.0",
+		"@wordpress/url": "^4.48.0",
+		"clsx": "^2.1.1",
+		"history": "^5.3.0",
+		"route-recognizer": "^0.3.4",
+		"tslib": "^2.8.1"
+	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.48.0",
 		"react": "^18.3.1 || ^19.0.0",
@@ -61,20 +79,5 @@
 		"storybook": "^9.1.20",
 		"typescript": "^6.0.3",
 		"webpack": "^5.99.8"
-	},
-	"dependencies": {
-		"@wordpress/base-styles": "^9.1.0",
-		"@wordpress/commands": "^1.48.0",
-		"@wordpress/components": "^35.0.0",
-		"@wordpress/compose": "^8.2.0",
-		"@wordpress/core-data": "^7.48.0",
-		"@wordpress/dom": "^4.48.0",
-		"@wordpress/element": "^8.0.0",
-		"@wordpress/i18n": "^6.21.0",
-		"@wordpress/icons": "^13.3.0",
-		"@wordpress/url": "^4.48.0",
-		"clsx": "^2.1.1",
-		"history": "^5.3.0",
-		"route-recognizer": "^0.3.4"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2148,8 +2148,10 @@ __metadata:
     "@wordpress/core-data": "npm:^7.48.0"
     "@wordpress/dom": "npm:^4.48.0"
     "@wordpress/element": "npm:^8.0.0"
+    "@wordpress/html-entities": "npm:^4.48.0"
     "@wordpress/i18n": "npm:^6.21.0"
     "@wordpress/icons": "npm:^13.3.0"
+    "@wordpress/keycodes": "npm:^4.48.0"
     "@wordpress/url": "npm:^4.48.0"
     clsx: "npm:^2.1.1"
     copyfiles: "npm:^2.4.1"
@@ -2157,6 +2159,7 @@ __metadata:
     postcss: "npm:^8.5.15"
     route-recognizer: "npm:^0.3.4"
     storybook: "npm:^9.1.20"
+    tslib: "npm:^2.8.1"
     typescript: "npm:^6.0.3"
     webpack: "npm:^5.99.8"
   peerDependencies:


### PR DESCRIPTION
## Proposed Changes

Declare dependencies that `@automattic/site-admin` uses but never listed in its `package.json`:

* `@wordpress/html-entities` — imported by `src/components/site-hub/index.tsx`
* `@wordpress/keycodes` — imported by `src/components/site-hub/index.tsx`
* `tslib` — required by the compiled output (emitted by TypeScript `importHelpers`)

## Why are these changes being made?

These modules are imported by the package's shipped code (or, for `tslib`, injected into the compiled output by the TypeScript compiler) but were absent from `package.json`. Within the monorepo they resolve through Yarn workspace hoisting, so the omission is invisible here. A third party installing `@automattic/site-admin` on its own would not receive them and module resolution would fail at import time.

## Testing Instructions

Packed the package with `yarn pack` and inspected resolution from a clean, separate install (no monorepo hoisting).

* **Before:** dependencies reachable from the package entry point fail to resolve (e.g. `Cannot find module`).
* **After:** every external module reachable from the entry point resolves against the package's declared dependencies.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?