### PR TITLE
subscriber: declare missing dependencies

### DIFF
--- a/packages/subscriber/package.json
+++ b/packages/subscriber/package.json
@@ -37,7 +37,10 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
+		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/components": "workspace:^",
+		"@automattic/data-stores": "workspace:^",
+		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/onboarding": "workspace:^",
 		"@automattic/viewport": "workspace:^",
 		"@automattic/viewport-react": "workspace:^",
@@ -52,17 +55,18 @@
 		"@wordpress/react-i18n": "^4.48.0",
 		"clsx": "^2.1.1",
 		"debug": "^4.4.1",
+		"email-validator": "^2.0.4",
 		"react-popper": "^2.3.0"
-	},
-	"devDependencies": {
-		"@automattic/calypso-color-schemes": "workspace:^",
-		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^6.0.3"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.48.0",
 		"react": "^18.3.1 || ^19.0.0",
 		"react-dom": "^18.3.1 || ^19.0.0",
 		"redux": "^5.0.1"
+	},
+	"devDependencies": {
+		"@automattic/calypso-color-schemes": "workspace:^",
+		"@automattic/calypso-typescript-config": "workspace:^",
+		"typescript": "^6.0.3"
 	}
 }

--- a/packages/subscriber/package.json
+++ b/packages/subscriber/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/subscriber",
-	"version": "0.0.2",
+	"version": "0.1.0",
 	"description": "Subscriber importer.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2219,9 +2219,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/subscriber@workspace:packages/subscriber"
   dependencies:
+    "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-color-schemes": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
+    "@automattic/data-stores": "workspace:^"
+    "@automattic/i18n-utils": "workspace:^"
     "@automattic/onboarding": "workspace:^"
     "@automattic/viewport": "workspace:^"
     "@automattic/viewport-react": "workspace:^"
@@ -2236,6 +2239,7 @@ __metadata:
     "@wordpress/react-i18n": "npm:^4.48.0"
     clsx: "npm:^2.1.1"
     debug: "npm:^4.4.1"
+    email-validator: "npm:^2.0.4"
     react-popper: "npm:^2.3.0"
     typescript: "npm:^6.0.3"
   peerDependencies:


### PR DESCRIPTION
## Proposed Changes

Declare dependencies that `@automattic/subscriber` uses but never listed in its `package.json`:

* `@automattic/calypso-analytics` — imported by the shipped code
* `@automattic/data-stores` — imported by `src/components/add-form/index.tsx`
* `@automattic/i18n-utils` — imported by `src/components/add-form/index.tsx`
* `email-validator` — imported by `src/components/add-form/index.tsx`

## Why are these changes being made?

These modules are imported by the package's shipped code (or, for `tslib`, injected into the compiled output by the TypeScript compiler) but were absent from `package.json`. Within the monorepo they resolve through Yarn workspace hoisting, so the omission is invisible here. A third party installing `@automattic/subscriber` on its own would not receive them and module resolution would fail at import time.

The `workspace:^` entries are packages that already live in this monorepo; declaring them makes the existing import explicit.

## Testing Instructions

Packed the package with `yarn pack` and inspected resolution from a clean, separate install (no monorepo hoisting).

* **Before:** dependencies reachable from the package entry point fail to resolve (e.g. `Cannot find module`).
* **After:** every external module reachable from the entry point resolves against the package's declared dependencies.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?