### PR TITLE
wpcom-checkout: declare missing dependencies

### DIFF
--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-checkout",
-	"version": "1.0.4",
+	"version": "1.1.0",
 	"description": "Functions and components used by WordPress.com checkout.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -48,6 +48,7 @@
 		"@automattic/calypso-stripe": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/composite-checkout": "workspace:^",
+		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/js-utils": "workspace:^",
 		"@automattic/number-formatters": "^1.2.0",
 		"@automattic/shopping-cart": "workspace:^",
@@ -55,6 +56,7 @@
 		"@fnando/cnpj": "2.0.0",
 		"@fnando/cpf": "1.0.2",
 		"@stripe/stripe-js": "^9.8.0",
+		"@wordpress/components": "^35.0.0",
 		"@wordpress/data": "^10.48.0",
 		"@wordpress/i18n": "^6.21.0",
 		"@wordpress/react-i18n": "^4.48.0",
@@ -63,18 +65,18 @@
 		"postcss": "^8.5.15",
 		"prop-types": "^15.8.1"
 	},
+	"peerDependencies": {
+		"@emotion/react": "^11.4.1",
+		"react": "^18.3.1 || ^19.0.0"
+	},
 	"devDependencies": {
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
-		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"typescript": "^6.0.3",
 		"webpack": "^5.99.8"
-	},
-	"peerDependencies": {
-		"@emotion/react": "^11.4.1"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2535,6 +2535,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/composite-checkout": "workspace:^"
+    "@automattic/i18n-utils": "workspace:^"
     "@automattic/js-utils": "workspace:^"
     "@automattic/number-formatters": "npm:^1.2.0"
     "@automattic/shopping-cart": "workspace:^"
@@ -2545,6 +2546,7 @@ __metadata:
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:^6.9.1"
     "@testing-library/react": "npm:^16.3.2"
+    "@wordpress/components": "npm:^35.0.0"
     "@wordpress/data": "npm:^10.48.0"
     "@wordpress/i18n": "npm:^6.21.0"
     "@wordpress/react-i18n": "npm:^4.48.0"
@@ -2552,12 +2554,12 @@ __metadata:
     i18n-calypso: "workspace:^"
     postcss: "npm:^8.5.15"
     prop-types: "npm:^15.8.1"
-    react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     typescript: "npm:^6.0.3"
     webpack: "npm:^5.99.8"
   peerDependencies:
     "@emotion/react": ^11.4.1
+    react: ^18.3.1 || ^19.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Proposed Changes

Declare dependencies that `@automattic/wpcom-checkout` uses but never listed in its `package.json`:

* `@automattic/i18n-utils` — imported by `src/checkout-line-items.tsx`
* `@wordpress/components` — imported by `src/removed-from-cart-item.tsx`
* `react` (peer) — imported by `src/checkout-line-items.tsx`

## Why are these changes being made?

These modules are imported by the package's shipped code (or, for `tslib`, injected into the compiled output by the TypeScript compiler) but were absent from `package.json`. Within the monorepo they resolve through Yarn workspace hoisting, so the omission is invisible here. A third party installing `@automattic/wpcom-checkout` on its own would not receive them and module resolution would fail at import time. React (and other host singletons) are added as `peerDependencies` to match the convention used by the other packages in this repo.

The `workspace:^` entries are packages that already live in this monorepo; declaring them makes the existing import explicit.

## Testing Instructions

Packed the package with `yarn pack` and inspected resolution from a clean, separate install (no monorepo hoisting).

* **Before:** dependencies reachable from the package entry point fail to resolve (e.g. `Cannot find module`).
* **After:** every external module reachable from the entry point resolves against the package's declared dependencies.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?