### PR TITLE
useSitePurchases: switch to raw purchase objects

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-non-owner-handler.ts
+++ b/client/my-sites/plans-features-main/hooks/use-non-owner-handler.ts
@@ -32,12 +32,14 @@ export function useNonOwnerHandler( {
 			const currentSitePurchase = currentPlan?.purchaseId
 				? sitePurchases[ currentPlan?.purchaseId ]
 				: undefined;
+			const ownerUserId =
+				currentSitePurchase?.user_id != null ? Number( currentSitePurchase.user_id ) : undefined;
 
 			const siteOwner = await queryClient.ensureQueryData(
 				getUseSiteUserQueryOptions(
 					siteId,
-					currentSitePurchase?.userId,
-					siteQueryKeys.siteUser( siteId, currentSitePurchase?.userId )
+					ownerUserId,
+					siteQueryKeys.siteUser( siteId, ownerUserId )
 				)
 			);
 

--- a/packages/api-core/src/upgrades/index.ts
+++ b/packages/api-core/src/upgrades/index.ts
@@ -1,3 +1,4 @@
 export * from './fetchers';
 export * from './mutators';
+export * from './purchase-transforms';
 export * from './types';

--- a/packages/api-core/src/upgrades/purchase-transforms.ts
+++ b/packages/api-core/src/upgrades/purchase-transforms.ts
@@ -1,0 +1,153 @@
+import type { Purchase, PriceTierEntry, PurchasePriceTier } from './types';
+
+/**
+ * Derived, non-trivial shapes and predicates for a raw `Purchase`.
+ *
+ * The rest of a `Purchase` is a flat, directly-accessible object. The handful
+ * of properties here are the ones that the legacy `createPurchaseObject`
+ * assembler used to reshape (nested objects, value-mapped enums, coercions),
+ * so they cannot be replaced by a plain field rename. Consumers migrating off
+ * the assembler should read those properties through these helpers.
+ */
+
+export interface PurchasePaymentCreditCard {
+	id: number;
+	type: string;
+	displayBrand: string | null;
+	processor: string;
+	number: string;
+	/**
+	 * The expiry date in MM/YY if the payment method has one.
+	 *
+	 * Use `payment_expiry_date` on the Purchase if possible as it will be more
+	 * accurate.
+	 */
+	expiryDate: string;
+}
+
+export interface PurchasePayment {
+	name: string | undefined;
+	type: string | undefined;
+	countryCode: string | undefined | null;
+	countryName: string | undefined;
+	storedDetailsId: string | number | undefined | null;
+	/**
+	 * The expiry date in MM/YY if the payment method has one.
+	 *
+	 * Use `payment_expiry_date` on the Purchase if possible as it will be more
+	 * accurate.
+	 */
+	expiryDate?: string;
+	creditCard?: PurchasePaymentCreditCard;
+	paymentPartner?: string;
+}
+
+export interface PurchaseIntroductoryOffer {
+	costPerInterval: number;
+	costPerIntervalInteger: number;
+	endDate: string;
+	intervalCount: number;
+	intervalUnit: string;
+	isWithinPeriod: boolean;
+	transitionAfterRenewalCount: number;
+	isNextRenewalUsingOffer: boolean;
+	remainingRenewalsUsingOffer: number;
+	shouldProrateWhenOfferEnds: boolean;
+	isNextRenewalProrated: boolean;
+}
+
+/**
+ * Build the nested payment object for a purchase.
+ *
+ * The raw purchase exposes payment details as flat `payment_*` fields; this
+ * groups them into the shape the app expects, adding the `creditCard` sub-object
+ * only for card payments and the paypal_direct expiry date.
+ */
+export function getPurchasePayment( purchase: Purchase ): PurchasePayment {
+	const payment: PurchasePayment = {
+		name: purchase.payment_name,
+		type: purchase.payment_type,
+		countryCode: purchase.payment_country_code,
+		countryName: purchase.payment_country_name,
+		storedDetailsId: purchase.stored_details_id,
+	};
+
+	if ( purchase.payment_type === 'credit_card' ) {
+		payment.creditCard = {
+			id: Number( purchase.payment_card_id ),
+			type: purchase.payment_card_type ?? '',
+			displayBrand: purchase.payment_card_display_brand,
+			processor: purchase.payment_card_processor ?? '',
+			number: purchase.payment_details ?? '',
+			expiryDate: purchase.payment_expiry ?? '',
+		};
+	}
+
+	if ( purchase.payment_type === 'paypal_direct' ) {
+		payment.expiryDate = purchase.payment_expiry;
+	}
+
+	return payment;
+}
+
+/**
+ * Map the raw introductory offer (snake_case, string/number-loose) to the
+ * camelCase, coerced shape used across the app. Returns null when the purchase
+ * has no introductory offer.
+ */
+export function getPurchaseIntroductoryOffer(
+	purchase: Purchase
+): PurchaseIntroductoryOffer | null {
+	const offer = purchase.introductory_offer;
+	if ( ! offer ) {
+		return null;
+	}
+	return {
+		costPerInterval: Number( offer.cost_per_interval ),
+		costPerIntervalInteger: Number( offer.cost_per_interval_integer ),
+		endDate: String( offer.end_date ),
+		intervalCount: Number( offer.interval_count ),
+		intervalUnit: String( offer.interval_unit ),
+		isWithinPeriod: Boolean( offer.is_within_period ),
+		transitionAfterRenewalCount: Number( offer.transition_after_renewal_count ),
+		isNextRenewalUsingOffer: Boolean( offer.is_next_renewal_using_offer ),
+		remainingRenewalsUsingOffer: Number( offer.remaining_renewals_using_offer ),
+		shouldProrateWhenOfferEnds: Boolean( offer.should_prorate_when_offer_ends ),
+		isNextRenewalProrated: Boolean( offer.is_next_renewal_prorated ),
+	};
+}
+
+/**
+ * Map the raw price tier list to the trimmed camelCase shape used by the app.
+ * Returns undefined when the purchase has no price tier list.
+ */
+export function getPurchasePriceTierList( purchase: Purchase ): PurchasePriceTier[] | undefined {
+	return purchase.price_tier_list?.map(
+		( rawTier: PriceTierEntry ): PurchasePriceTier => ( {
+			minimumUnits: rawTier.minimum_units,
+			maximumUnits: rawTier.maximum_units,
+			minimumPrice: rawTier.minimum_price,
+			maximumPrice: rawTier.maximum_price,
+			minimumPriceDisplay: rawTier.minimum_price_display,
+			maximumPriceDisplay: rawTier.maximum_price_display,
+		} )
+	);
+}
+
+/**
+ * The raw `expiry_status` uses hyphenated values (e.g. 'auto-renewing',
+ * 'manual-renew', 'one-time-purchase'). The legacy assembler camelCased these,
+ * so the predicates below read the raw hyphenated values directly and give both
+ * Calypso and the Dashboard a single shared definition.
+ */
+export function isPurchaseAutoRenewing( purchase: Purchase ): boolean {
+	return purchase.expiry_status === 'auto-renewing';
+}
+
+export function isPurchaseOneTimePurchase( purchase: Purchase ): boolean {
+	return purchase.expiry_status === 'one-time-purchase';
+}
+
+export function isPurchaseExpiring( purchase: Purchase ): boolean {
+	return [ 'manual-renew', 'expiring' ].includes( purchase.expiry_status );
+}

--- a/packages/data-stores/src/add-ons/hooks/use-add-on-purchase-status.ts
+++ b/packages/data-stores/src/add-ons/hooks/use-add-on-purchase-status.ts
@@ -35,8 +35,8 @@ const useAddOnPurchaseStatus = ( { addOnMeta, selectedSiteId }: Props ): AddOnPu
 	 */
 	if ( matchingPurchases ) {
 		if ( addOnMeta.quantity ) {
-			const purchase: Purchases.Purchase = Object.values( matchingPurchases )[ 0 ];
-			if ( purchase.purchaseRenewalQuantity === addOnMeta.quantity ) {
+			const purchase: Purchases.RawPurchase = Object.values( matchingPurchases )[ 0 ];
+			if ( purchase.renewal_price_tier_usage_quantity === addOnMeta.quantity ) {
 				return { available: false, text: translate( 'Purchased' ) };
 			}
 		} else {

--- a/packages/data-stores/src/add-ons/hooks/use-get-purchased-storage-add-on.ts
+++ b/packages/data-stores/src/add-ons/hooks/use-get-purchased-storage-add-on.ts
@@ -18,7 +18,7 @@ export default function useGetPurchasedStorageAddOn( {
 		return null;
 	}
 
-	const purchase: Purchases.Purchase = Object.values( matchingPurchases )[ 0 ];
-	const storageAddOnQuantity = purchase.purchaseRenewalQuantity;
+	const purchase: Purchases.RawPurchase = Object.values( matchingPurchases )[ 0 ];
+	const storageAddOnQuantity = purchase.renewal_price_tier_usage_quantity;
 	return storageAddOns.find( ( addOn ) => addOn?.quantity === storageAddOnQuantity ) ?? null;
 }

--- a/packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
@@ -156,12 +156,12 @@ describe( 'usePricingMetaForGridPlans', () => {
 			} ) );
 			// Yearly purchase: renewal 600/yr, active intro 120/yr.
 			Purchases.useSitePurchaseById.mockImplementation( () => ( {
-				priceInteger: 600,
-				currencyCode: 'USD',
-				billPeriodDays: 365,
-				introductoryOffer: {
-					isWithinPeriod: true,
-					costPerIntervalInteger: 120,
+				price_integer: 600,
+				currency_code: 'USD',
+				bill_period_days: 365,
+				introductory_offer: {
+					is_within_period: true,
+					cost_per_interval_integer: 120,
 				},
 			} ) );
 		} );

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -1,3 +1,4 @@
+import { getPurchaseIntroductoryOffer } from '@automattic/api-core';
 import {
 	PLAN_MONTHLY_PERIOD,
 	type PlanSlug,
@@ -200,30 +201,31 @@ const usePricingMetaForGridPlans = ( {
 					let renewalPrice: Plans.PlanPricing[ 'originalPrice' ] | undefined;
 
 					if ( purchasedPlan ) {
+						const introductoryOffer = getPurchaseIntroductoryOffer( purchasedPlan );
 						const showIntroOfferHeadline =
 							!! showBillingDescriptionForIncreasedRenewalPrice &&
-							purchasedPlan.introductoryOffer?.isWithinPeriod;
+							introductoryOffer?.isWithinPeriod;
 						const currentTermPrice = showIntroOfferHeadline
-							? purchasedPlan.introductoryOffer!.costPerIntervalInteger
-							: purchasedPlan.priceInteger;
-						const isMonthly = purchasedPlan.billPeriodDays === PLAN_MONTHLY_PERIOD;
+							? introductoryOffer!.costPerIntervalInteger
+							: purchasedPlan.price_integer;
+						const isMonthly = purchasedPlan.bill_period_days === PLAN_MONTHLY_PERIOD;
 
 						if ( isMonthly && monthlyPrice !== currentTermPrice ) {
 							monthlyPrice = currentTermPrice;
 							fullPrice = parseFloat( ( currentTermPrice * 12 ).toFixed( 2 ) );
 						} else if ( fullPrice !== currentTermPrice ) {
-							const term = getTermFromDuration( purchasedPlan.billPeriodDays ) || '';
+							const term = getTermFromDuration( purchasedPlan.bill_period_days ) || '';
 							monthlyPrice = calculateMonthlyPrice( term, currentTermPrice );
 							fullPrice = currentTermPrice;
 						}
 
 						if ( showIntroOfferHeadline ) {
-							const renewalTerm = getTermFromDuration( purchasedPlan.billPeriodDays ) || '';
+							const renewalTerm = getTermFromDuration( purchasedPlan.bill_period_days ) || '';
 							renewalPrice = {
 								monthly: isMonthly
-									? purchasedPlan.priceInteger
-									: calculateMonthlyPrice( renewalTerm, purchasedPlan.priceInteger ),
-								full: purchasedPlan.priceInteger,
+									? purchasedPlan.price_integer
+									: calculateMonthlyPrice( renewalTerm, purchasedPlan.price_integer ),
+								full: purchasedPlan.price_integer,
 							};
 						}
 					}
@@ -240,7 +242,7 @@ const usePricingMetaForGridPlans = ( {
 								full: null,
 							},
 							currencyCode: purchasedPlan
-								? purchasedPlan?.currencyCode
+								? purchasedPlan?.currency_code
 								: plan?.pricing?.currencyCode,
 							...( renewalPrice && { renewalPrice } ),
 						},

--- a/packages/data-stores/src/purchases/hooks/test/use-site-purchases-by-product-slug.ts
+++ b/packages/data-stores/src/purchases/hooks/test/use-site-purchases-by-product-slug.ts
@@ -10,9 +10,9 @@ jest.mock( '../../queries/use-site-purchases' );
 
 describe( 'useSitePurchasesByProductSlug', () => {
 	const mockData = {
-		1: { id: 1, productSlug: 'foo' },
-		2: { id: 2, productSlug: 'bar' },
-		3: { id: 3, productSlug: 'foo' },
+		1: { ID: 1, product_slug: 'foo' },
+		2: { ID: 2, product_slug: 'bar' },
+		3: { ID: 3, product_slug: 'foo' },
 	};
 
 	beforeEach( () => {
@@ -37,8 +37,8 @@ describe( 'useSitePurchasesByProductSlug', () => {
 		);
 
 		expect( result.current ).toEqual( {
-			1: { id: 1, productSlug: 'foo' },
-			3: { id: 3, productSlug: 'foo' },
+			1: { ID: 1, product_slug: 'foo' },
+			3: { ID: 3, product_slug: 'foo' },
 		} );
 	} );
 

--- a/packages/data-stores/src/purchases/hooks/use-site-purchase-by-id.ts
+++ b/packages/data-stores/src/purchases/hooks/use-site-purchase-by-id.ts
@@ -1,12 +1,12 @@
 import useSitePurchases from '../queries/use-site-purchases';
-import type { Purchase } from '../types';
+import type { RawPurchase } from '../types';
 
 interface Props {
 	purchaseId?: number | null;
 	siteId?: string | number | null;
 }
 
-const useSitePurchaseById = ( { siteId, purchaseId }: Props ): Purchase | undefined => {
+const useSitePurchaseById = ( { siteId, purchaseId }: Props ): RawPurchase | undefined => {
 	const sitePurchases = useSitePurchases( { siteId } );
 
 	return sitePurchases?.data && typeof purchaseId === 'number'

--- a/packages/data-stores/src/purchases/hooks/use-site-purchases-by-product-slug.ts
+++ b/packages/data-stores/src/purchases/hooks/use-site-purchases-by-product-slug.ts
@@ -23,7 +23,7 @@ const useSitePurchasesByProductSlug = ( {
 
 		const found = Object.fromEntries(
 			Object.entries( sitePurchases.data ).filter(
-				( [ , purchase ] ) => purchase.productSlug === productSlug
+				( [ , purchase ] ) => purchase.product_slug === productSlug
 			)
 		);
 

--- a/packages/data-stores/src/purchases/queries/use-site-purchases.ts
+++ b/packages/data-stores/src/purchases/queries/use-site-purchases.ts
@@ -1,11 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcomRequest from '../../wpcom-request';
-import { createPurchaseObject } from '../lib/assembler';
 import useQueryKeysFactory from './lib/use-query-keys-factory';
-import type { RawPurchase, Purchase } from '../types';
+import type { RawPurchase } from '../types';
 
 export interface PurchasesIndex {
-	[ purchaseId: number ]: Purchase;
+	[ purchaseId: number ]: RawPurchase;
 }
 
 interface Props {
@@ -25,10 +24,7 @@ export function getUseSitePurchasesOptions(
 			} );
 
 			return Object.fromEntries(
-				purchases.map( ( rawPurchase ) => {
-					const purchase = createPurchaseObject( rawPurchase );
-					return [ purchase.id, purchase ];
-				} )
+				purchases.map( ( rawPurchase ) => [ Number( rawPurchase.ID ), rawPurchase ] )
 			);
 		},
 		enabled: !! siteId,

--- a/packages/plans-grid-next/src/components/shared/storage/hooks/use-purchased-storage-add-on.ts
+++ b/packages/plans-grid-next/src/components/shared/storage/hooks/use-purchased-storage-add-on.ts
@@ -43,7 +43,7 @@ export default function usePurchasedStorageAddOn(): AddOns.AddOnMeta | null {
 
 		// storage add-on is a tiered product, so we can assume it contains only one product entry here.
 		const purchasedAddOnSlug = quantityToAddOnSlug(
-			Object.values( spaceUpgradesPurchased )[ 0 ].purchaseRenewalQuantity
+			Object.values( spaceUpgradesPurchased )[ 0 ].renewal_price_tier_usage_quantity
 		);
 		const purchasedAddOn = storageAddOns
 			.filter( ( addOn ): addOn is AddOns.AddOnMeta => addOn !== null ) // TODO: fix the related hooks so this won't be needed


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-2256/

## Proposed changes

First step toward removing the purchases assembler: this adds shared, raw-object helpers to `api-core` and moves the `useSitePurchases` useQuery hook path to read the raw `Purchase` object directly instead of the assembled camelCase shape.

* Add `packages/api-core/src/upgrades/purchase-transforms.ts` with pure helpers on the raw purchase: `getPurchasePayment`, `getPurchaseIntroductoryOffer`, `getPurchasePriceTierList`, and `isPurchaseAutoRenewing` / `isPurchaseOneTimePurchase` / `isPurchaseExpiring` (which read the raw hyphenated `expiry_status`).
* `useSitePurchases` query now returns raw purchases keyed by `Number(rawPurchase.ID)` instead of running `createPurchaseObject`.
* `useSitePurchaseById` and `useSitePurchasesByProductSlug` return/filter raw purchases.
* Migrate the hook consumers to raw fields: `use-pricing-meta-for-grid-plans` (introductory offer via `getPurchaseIntroductoryOffer`; `price_integer` / `bill_period_days` / `currency_code`), both add-ons storage hooks, and the plans-grid-next storage hook (`renewal_price_tier_usage_quantity`).

## Why are these changes being made?

The assembler (`createPurchaseObject`) converts a raw purchase into a separate camelCase `Purchase` type. Keeping that type and the assembler in sync with the backend is error-prone, and the assembled type is a strict subset that drops raw fields consumers increasingly need. The end goal is to read the raw object directly everywhere and delete the assembler.

This PR establishes the pattern on the most isolated island — the useQuery hook path, which has no client-side consumers and aligns with the ongoing Redux→useQuery migration. The `api-core` helpers absorb the handful of genuinely non-trivial transforms (nested payment, introductory offer, price tiers, and the value-mapped `expiry_status`), so downstream consumers can migrate incrementally with tiny diffs while the Redux path continues to use the assembler untouched.

## Testing instructions

* On a site with a paid plan that has an active introductory offer, open the plans grid.
* Confirm the current plan's headline pricing and any "renews at" line render correctly (this path reads the purchase's intro offer and renewal price).

