### PR TITLE
Dashboard: serve /.well-known/webauthn for WebAuthn Related Origin Requests

### DIFF
--- a/client/server/api/index.ts
+++ b/client/server/api/index.ts
@@ -1,12 +1,17 @@
 import config from '@automattic/calypso-config';
 import express from 'express';
 import signInWithApple from './sign-in-with-apple';
+import webauthnRelatedOrigins from './webauthn-related-origins';
 
 export default function api() {
 	const app = express();
 
 	if ( config.isEnabled( 'sign-in-with-apple/redirect' ) ) {
 		signInWithApple( app );
+	}
+
+	if ( config.isEnabled( 'webauthn/related-origin-requests' ) ) {
+		webauthnRelatedOrigins( app );
 	}
 
 	return app;

--- a/client/server/api/webauthn-related-origins.ts
+++ b/client/server/api/webauthn-related-origins.ts
@@ -1,0 +1,12 @@
+import type { Express, Request, Response } from 'express';
+
+// Lets the listed origins assert WebAuthn credentials scoped to this host's RP ID
+// (e.g. keys mistakenly registered against my.wordpress.com, usable at wordpress.com login).
+// https://passkeys.dev/docs/advanced/related-origins/
+const RELATED_ORIGINS = [ 'https://wordpress.com' ];
+
+export default function ( app: Express ) {
+	return app.get( '/.well-known/webauthn', ( request: Request, response: Response ) => {
+		response.json( { origins: RELATED_ORIGINS } );
+	} );
+}

--- a/client/server/api/webauthn-related-origins.ts
+++ b/client/server/api/webauthn-related-origins.ts
@@ -7,6 +7,9 @@ const RELATED_ORIGINS = [ 'https://wordpress.com' ];
 
 export default function ( app: Express ) {
 	return app.get( '/.well-known/webauthn', ( request: Request, response: Response ) => {
+		// The browser fetches this document cross-origin from the related origin
+		// performing the ceremony, so it must be readable from that origin.
+		response.set( 'Access-Control-Allow-Origin', 'https://wordpress.com' );
 		response.json( { origins: RELATED_ORIGINS } );
 	} );
 }

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -58,6 +58,7 @@
 		"rum-tracking/logstash": true,
 		"site-spec": true,
 		"two-factor/enhanced-security": true,
+		"webauthn/related-origin-requests": true,
 		"wordpress-ai-tools": true,
 		"wpcom-user-bootstrap": false
 	},

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -52,6 +52,7 @@
 		"rum-tracking/logstash": true,
 		"site-spec": true,
 		"two-factor/enhanced-security": true,
+		"webauthn/related-origin-requests": true,
 		"wordpress-ai-tools": true,
 		"wpcom-user-bootstrap": true
 	},

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -56,6 +56,7 @@
 		"rum-tracking/logstash": true,
 		"site-spec": true,
 		"two-factor/enhanced-security": true,
+		"webauthn/related-origin-requests": true,
 		"wordpress-ai-tools": true,
 		"wpcom-user-bootstrap": true
 	},

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -56,7 +56,7 @@
 		"rum-tracking/logstash": true,
 		"site-spec": true,
 		"two-factor/enhanced-security": true,
-		"webauthn/related-origin-requests": true,
+		"webauthn/related-origin-requests": false,
 		"wordpress-ai-tools": true,
 		"wpcom-user-bootstrap": true
 	},

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -56,7 +56,7 @@
 		"rum-tracking/logstash": true,
 		"site-spec": true,
 		"two-factor/enhanced-security": true,
-		"webauthn/related-origin-requests": false,
+		"webauthn/related-origin-requests": true,
 		"wordpress-ai-tools": true,
 		"wpcom-user-bootstrap": true
 	},

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -55,6 +55,7 @@
 		"rum-tracking/logstash": true,
 		"site-spec": true,
 		"two-factor/enhanced-security": true,
+		"webauthn/related-origin-requests": true,
 		"wordpress-ai-tools": true,
 		"wpcom-user-bootstrap": true
 	},


### PR DESCRIPTION
## Proposed Changes

* Serve `GET /.well-known/webauthn` from the Calypso node server, returning `{ "origins": [ "https://wordpress.com" ] }`.
* Gate it behind a new `webauthn/related-origin-requests` feature flag, enabled only in the dashboard variant configs (the builds served at `my.wordpress.com`).

## Why are these changes being made?

* Security keys registered through the dashboard before #112611 were created with RP ID `my.wordpress.com` instead of `wordpress.com`, so they fail at login: the login origin can't assert a credential scoped to a subdomain.
* A credential's RP ID can't be changed after creation. [WebAuthn Related Origin Requests](https://passkeys.dev/docs/advanced/related-origins/) is the standard bridge: this well-known document, served from the RP ID host (`my.wordpress.com`), authorizes the login origin to assert those credentials in ROR-capable browsers (Chrome/Edge 128+, Safari 18+).
* This is the client half. It has no effect until the backend issues login challenges with the per-credential RP ID and verifies assertions against it (tracked separately).

## Testing Instructions

### Quick check (HTTP)

* `yarn start-dashboard`, then `curl -i http://my.localhost:3000/.well-known/webauthn` — expect `200`, `Content-Type: application/json`, and `{"origins":["https://wordpress.com"]}`.

### Exercising it under the real `my.wordpress.com` / `wordpress.com` origins (trusted HTTPS)

A browser performs the ROR fetch against `https://<rp-id>/.well-known/webauthn` on port **443**, so a faithful test needs the real hostnames served over trusted HTTPS. All steps below are local-only.

1. **Map the hosts to loopback** in `/etc/hosts`:

   ```
   127.0.0.1  my.wordpress.com
   127.0.0.1  wordpress.com
   ```

2. **Install a locally-trusted CA and generate a cert** into the path the node server reads first (`config/server/certificate.pem` + `key.pem` are gitignored):

   ```bash
   brew install mkcert && mkcert -install   # trusts the CA in the system keychain
   cd wp-calypso
   mkcert -cert-file config/server/certificate.pem -key-file config/server/key.pem \
     wordpress.com "*.wordpress.com" my.wordpress.com
   ```

   `mkcert -install` requires your password (adds the CA to the system trust store). Undo later with `mkcert -uninstall`.

3. **Serve the dashboard build at `https://my.wordpress.com`.** In `config/development.json`, temporarily set (⚠️ **do not commit** — `git checkout config/development.json` afterwards):

   ```json
   "protocol": "https",
   "port": 443,
   "hostname_allowlist": [ "calypso.localhost", "my.localhost", "my.woo.localhost", "wordpress.com", "my.wordpress.com" ],
   "features": {
        "webauthn/related-origin-requests": true,
    }
   ```

   then `sudo yarn start` (443 is a privileged port).

4. **Verify** the endpoint is served from the real host over a trusted cert:

   ```bash
   curl -i https://my.wordpress.com/.well-known/webauthn
   # → 200, application/json, {"origins":["https://wordpress.com"]}
   ```

5. `wordpress.com` is the login origin side. To bring up a mock wordpress.com over the same trusted cert,
    * Create a security key scoped to `my.wordpress.com`
      * You need to revert https://github.com/Automattic/wp-calypso/pull/112611 and 228227-ghe-Automattic/wpcom
      * You need to sandbox `public-api.wordpress.com`
    * Apply 228530-ghe-Automattic/wpcom to your sandbox
    * Sandbox `<locale>.wordpress.com`, e.g.: `zh-tw.wordpress.com`
    * Run `MOCK_WORDPRESSDOTCOM=1 yarn start`
    * Go to https://wordpress.com
    * Switch to locale, e.g.: `wordpress.com/log-in/zh-tw`
    * Log in with your account
    * Ensure you can log in by the key scoped to `my.wordpress.com`

> A full browser ROR assertion (a `wordpress.com` login asserting a `my.wordpress.com`-scoped credential) also requires the backend to issue login challenges with the per-credential RP ID and verify assertions against it — tracked separately. Until that lands, this PR's observable behavior is the well-known payload above.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpizyM1w3ukuXRV4rH2Cs6
