### PR TITLE
Enable the account recovery interstitial in all environments

### DIFF
--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -29,7 +29,7 @@
 		"ciab/allow-domain-features": true,
 		"cookie-banner": false,
 		"dark-mode": true,
-		"dashboard/account-recovery-interstitial": false,
+		"dashboard/account-recovery-interstitial": true,
 		"dashboard/dark-mode-rollout": true,
 		"dashboard/enable-percentage-rollout": false,
 		"dashboard/force-opt-in-visibility": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -25,7 +25,7 @@
 		"ciab/custom-branding": true,
 		"cookie-banner": false,
 		"dark-mode": true,
-		"dashboard/account-recovery-interstitial": false,
+		"dashboard/account-recovery-interstitial": true,
 		"dashboard/dark-mode-rollout": true,
 		"dashboard/enable-percentage-rollout": false,
 		"dashboard/opt-in-welcome-modal": true,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -31,7 +31,7 @@
 		"ciab/custom-branding": true,
 		"cookie-banner": true,
 		"dark-mode": true,
-		"dashboard/account-recovery-interstitial": false,
+		"dashboard/account-recovery-interstitial": true,
 		"dashboard/dark-mode-rollout": false,
 		"dashboard/enable-percentage-rollout": false,
 		"dashboard/opt-in-welcome-modal": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -30,7 +30,7 @@
 		"ciab/custom-branding": true,
 		"cookie-banner": false,
 		"dark-mode": true,
-		"dashboard/account-recovery-interstitial": false,
+		"dashboard/account-recovery-interstitial": true,
 		"dashboard/dark-mode-rollout": true,
 		"dashboard/enable-percentage-rollout": false,
 		"dashboard/opt-in-welcome-modal": true,


### PR DESCRIPTION
## Proposed Changes

Enable the Account Recovery interstitial in all dashboard environments (`development`, `horizon`, `stage`, and `production`).

## Why are these changes being made?

The AR interstitial feature flag was turned off on July 13th, 2026 due to conflicts with the MSD welcome modal (see p1783466109965749-slack-C08JZTRS6NA). This PR enables it again.

## Testing Instructions

* Load the dashboard as an experiment-control user with incomplete account security - the interstitial should appear.
* `yarn test-client client/dashboard/app/account-recovery-interstitial`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)