### PR TITLE
Dashboard: track auth outcomes with a bumpStat counter

### DIFF
--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -5,6 +5,7 @@ import { setUser } from '@automattic/calypso-sentry';
 import { isSupportUserSession } from '@automattic/calypso-support-session';
 import { magnificentNonEnLocales } from '@automattic/i18n-utils';
 import {
+	hashKey,
 	useQuery,
 	useQueryClient,
 	type QueryCacheNotifyEvent,
@@ -12,11 +13,14 @@ import {
 } from '@tanstack/react-query';
 import { createContext, useContext, useMemo, useEffect, useRef, useCallback } from 'react';
 import { wpcomLink } from '../../utils/link';
+import { bumpStat } from '../analytics';
 import { useAppContext } from '../context';
 import { OAUTH_CALLBACK_PATH } from './oauth-callback';
 import type { WPError } from '@automattic/api-core';
 
 export const AUTH_QUERY_KEY = [ 'auth', 'user' ];
+
+const BOOTSTRAP_ERROR_MESSAGE = 'Failed to bootstrap user object';
 
 function getOAuthAuthorizeUrl( {
 	state,
@@ -56,20 +60,35 @@ interface AuthContextType {
 }
 export const AuthContext = createContext< AuthContextType | undefined >( undefined );
 
-export async function initializeCurrentUser(): Promise< User > {
+function shouldUseBootstrap(): boolean {
 	// In support user session the `currentUser` refers to the wrong person so we should request
 	// the user object. Note we do not check `isSupportNextSession()` because in "next" support
 	// sessions the server does bootstrap the correct `currentUser`.
-	const useBootstrap = ! isSupportUserSession() && config.isEnabled( 'wpcom-user-bootstrap' );
+	return ! isSupportUserSession() && config.isEnabled( 'wpcom-user-bootstrap' );
+}
 
-	if ( useBootstrap ) {
+export async function initializeCurrentUser(): Promise< User > {
+	if ( shouldUseBootstrap() ) {
 		if ( window.currentUser ) {
 			return window.currentUser;
 		}
-		throw new Error( 'Failed to bootstrap user object' );
+		throw new Error( BOOTSTRAP_ERROR_MESSAGE );
 	}
 
 	return fetchUser();
+}
+
+function getAuthErrorReason( error: unknown ): string {
+	if ( error instanceof Error && error.message === BOOTSTRAP_ERROR_MESSAGE ) {
+		return 'bootstrap';
+	}
+	if (
+		isWpError( error ) &&
+		( error.error === 'authorization_required' || error.statusCode === 401 )
+	) {
+		return 'unauthorized';
+	}
+	return 'error';
 }
 
 /**
@@ -87,6 +106,7 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 		data: user,
 		isLoading: userIsLoading,
 		isError: userIsError,
+		error: userError,
 	} = useQuery( {
 		queryKey: AUTH_QUERY_KEY,
 		queryFn: initializeCurrentUser,
@@ -108,37 +128,42 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 		};
 	}, [ user ] );
 
-	const handleAuthError = useCallback( () => {
-		// Prevents repeated calls to redirect
-		if ( authErrorHandled.current ) {
-			return;
-		}
+	const handleAuthError = useCallback(
+		( reason: string ) => {
+			// Prevents repeated calls to redirect
+			if ( authErrorHandled.current ) {
+				return;
+			}
 
-		authErrorHandled.current = true;
+			authErrorHandled.current = true;
 
-		if ( config.isEnabled( 'oauth' ) ) {
-			const state = crypto.randomUUID();
-			sessionStorage.setItem( 'wpcom_oauth_state', state );
+			bumpStat( 'hd-auth', `bounce:${ reason }` );
 
-			// Default to the signup screen rather than the login screen for certain routes.
-			const isNewUser =
-				supports.startStoreRoute === true && window.location.pathname === '/start-store';
+			if ( config.isEnabled( 'oauth' ) ) {
+				const state = crypto.randomUUID();
+				sessionStorage.setItem( 'wpcom_oauth_state', state );
 
-			window.location.replace(
-				getOAuthAuthorizeUrl( {
-					state,
-					isNewUser,
-					next: window.location.pathname + window.location.search,
-				} )
-			);
-			return;
-		}
+				// Default to the signup screen rather than the login screen for certain routes.
+				const isNewUser =
+					supports.startStoreRoute === true && window.location.pathname === '/start-store';
 
-		const currentPath = window.location.href;
-		const path = config( 'wpcom_login_url' ) || wpcomLink( '/log-in' );
-		const loginUrl = `${ path }?redirect_to=${ encodeURIComponent( currentPath ) }`;
-		window.location.href = loginUrl;
-	}, [ supports.startStoreRoute ] );
+				window.location.replace(
+					getOAuthAuthorizeUrl( {
+						state,
+						isNewUser,
+						next: window.location.pathname + window.location.search,
+					} )
+				);
+				return;
+			}
+
+			const currentPath = window.location.href;
+			const path = config( 'wpcom_login_url' ) || wpcomLink( '/log-in' );
+			const loginUrl = `${ path }?redirect_to=${ encodeURIComponent( currentPath ) }`;
+			window.location.href = loginUrl;
+		},
+		[ supports.startStoreRoute ]
+	);
 
 	// Subscribe to network errors and when errors occur due to being logged
 	// out, redirect the user to the log in screen.
@@ -148,13 +173,18 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 		};
 
 		const handleEvent = ( event: MutationCacheNotifyEvent | QueryCacheNotifyEvent ) => {
+			// Errors fetching the user object itself are handled (and classified) below.
+			if ( 'query' in event && event.query.queryHash === hashKey( AUTH_QUERY_KEY ) ) {
+				return;
+			}
+
 			if (
 				event.type === 'updated' &&
 				event.action.type === 'error' &&
 				isWpError( event.action.error ) &&
 				isAuthError( event.action.error )
 			) {
-				handleAuthError();
+				handleAuthError( 'expired' );
 			}
 		};
 		const unsubMutationCache = queryClient.getMutationCache().subscribe( handleEvent );
@@ -165,9 +195,15 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 		};
 	}, [ queryClient, handleAuthError ] );
 
+	const successStatBumped = useRef( false );
 	useEffect( () => {
 		if ( user?.ID ) {
 			setUser( { id: user.ID.toString() } );
+
+			if ( ! successStatBumped.current ) {
+				successStatBumped.current = true;
+				bumpStat( 'hd-auth', shouldUseBootstrap() ? 'success:bootstrap' : 'success:fetch' );
+			}
 		}
 	}, [ user ] );
 
@@ -175,7 +211,7 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 	// `authorization_required` errors or not.
 	if ( userIsError ) {
 		if ( typeof window !== 'undefined' ) {
-			handleAuthError();
+			handleAuthError( getAuthErrorReason( userError ) );
 		}
 		return null;
 	}

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -137,7 +137,7 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 
 			authErrorHandled.current = true;
 
-			bumpStat( 'hd-auth', `bounce:${ reason }` );
+			bumpStat( 'dashboard-auth', `bounce:${ reason }` );
 
 			if ( config.isEnabled( 'oauth' ) ) {
 				const state = crypto.randomUUID();
@@ -202,7 +202,7 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 
 			if ( ! successStatBumped.current ) {
 				successStatBumped.current = true;
-				bumpStat( 'hd-auth', shouldUseBootstrap() ? 'success:bootstrap' : 'success:fetch' );
+				bumpStat( 'dashboard-auth', shouldUseBootstrap() ? 'success:bootstrap' : 'success:fetch' );
 			}
 		}
 	}, [ user ] );

--- a/client/dashboard/app/auth/test/index.test.tsx
+++ b/client/dashboard/app/auth/test/index.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * @jest-environment jsdom
+ */
+import config from '@automattic/calypso-config';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { bumpStat } from '../../analytics';
+import { AppProvider, APP_CONTEXT_DEFAULT_CONFIG } from '../../context';
+import { AuthProvider } from '../index';
+import type { User } from '@automattic/api-core';
+
+jest.mock( '../../analytics', () => ( {
+	...jest.requireActual( '../../analytics' ),
+	bumpStat: jest.fn(),
+} ) );
+
+const mockedBumpStat = jest.mocked( bumpStat );
+
+const testUser = { ID: 1, username: 'testuser', language: 'en' } as User;
+
+function wpError( fields: { status: number; statusCode: number; error?: string } ) {
+	return Object.assign( new Error( 'boom' ), fields );
+}
+
+function renderAuth() {
+	const queryClient = new QueryClient();
+	return {
+		queryClient,
+		...render(
+			<QueryClientProvider client={ queryClient }>
+				<AppProvider config={ APP_CONTEXT_DEFAULT_CONFIG }>
+					<AuthProvider>
+						<div>signed in</div>
+					</AuthProvider>
+				</AppProvider>
+			</QueryClientProvider>
+		),
+	};
+}
+
+describe( '<AuthProvider>', () => {
+	beforeEach( () => {
+		Object.defineProperty( window, 'location', {
+			writable: true,
+			value: { href: 'https://example.com/sites', pathname: '/sites', search: '' },
+		} );
+	} );
+
+	afterEach( () => {
+		config.disable( 'wpcom-user-bootstrap' );
+		delete window.currentUser;
+	} );
+
+	test( 'bumps a success stat when the bootstrapped user is available', async () => {
+		config.enable( 'wpcom-user-bootstrap' );
+		window.currentUser = testUser;
+
+		renderAuth();
+
+		expect( await screen.findByText( 'signed in' ) ).toBeVisible();
+		expect( mockedBumpStat ).toHaveBeenCalledWith( 'hd-auth', 'success:bootstrap' );
+	} );
+
+	test( 'bumps a bounce stat and redirects to login when the bootstrapped user is missing', async () => {
+		config.enable( 'wpcom-user-bootstrap' );
+
+		renderAuth();
+
+		await waitFor( () =>
+			expect( mockedBumpStat ).toHaveBeenCalledWith( 'hd-auth', 'bounce:bootstrap' )
+		);
+		expect( window.location.href ).toContain( '/log-in?redirect_to=' );
+		expect( screen.queryByText( 'signed in' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'bumps a success stat when the user is fetched from the API', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me' )
+			.query( true )
+			.reply( 200, testUser );
+
+		renderAuth();
+
+		expect( await screen.findByText( 'signed in' ) ).toBeVisible();
+		expect( mockedBumpStat ).toHaveBeenCalledWith( 'hd-auth', 'success:fetch' );
+	} );
+
+	test( 'bumps a bounce stat and redirects to login when fetching the user is unauthorized', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me' )
+			.query( true )
+			.reply( 403, { error: 'authorization_required', message: 'User cannot access this' } );
+
+		renderAuth();
+
+		await waitFor( () =>
+			expect( mockedBumpStat ).toHaveBeenCalledWith( 'hd-auth', 'bounce:unauthorized' )
+		);
+		expect( window.location.href ).toContain( '/log-in?redirect_to=' );
+	} );
+
+	test( 'bumps a bounce stat when the session expires mid-app', async () => {
+		config.enable( 'wpcom-user-bootstrap' );
+		window.currentUser = testUser;
+
+		const { queryClient } = renderAuth();
+		expect( await screen.findByText( 'signed in' ) ).toBeVisible();
+
+		const error = wpError( { status: 401, statusCode: 401, error: 'authorization_required' } );
+		await expect(
+			queryClient.fetchQuery( {
+				queryKey: [ 'some-data' ],
+				queryFn: () => Promise.reject( error ),
+				retry: false,
+			} )
+		).rejects.toBe( error );
+
+		await waitFor( () =>
+			expect( mockedBumpStat ).toHaveBeenCalledWith( 'hd-auth', 'bounce:expired' )
+		);
+	} );
+} );

--- a/client/dashboard/app/auth/test/index.test.tsx
+++ b/client/dashboard/app/auth/test/index.test.tsx
@@ -39,7 +39,7 @@ function renderAuth() {
 	};
 }
 
-describe( '<AuthProvider>', () => {
+describe( '<AuthProvider> stats', () => {
 	beforeEach( () => {
 		Object.defineProperty( window, 'location', {
 			writable: true,
@@ -59,7 +59,7 @@ describe( '<AuthProvider>', () => {
 		renderAuth();
 
 		expect( await screen.findByText( 'signed in' ) ).toBeVisible();
-		expect( mockedBumpStat ).toHaveBeenCalledWith( 'hd-auth', 'success:bootstrap' );
+		expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'success:bootstrap' );
 	} );
 
 	test( 'bumps a bounce stat and redirects to login when the bootstrapped user is missing', async () => {
@@ -68,7 +68,7 @@ describe( '<AuthProvider>', () => {
 		renderAuth();
 
 		await waitFor( () =>
-			expect( mockedBumpStat ).toHaveBeenCalledWith( 'hd-auth', 'bounce:bootstrap' )
+			expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'bounce:bootstrap' )
 		);
 		expect( window.location.href ).toContain( '/log-in?redirect_to=' );
 		expect( screen.queryByText( 'signed in' ) ).not.toBeInTheDocument();
@@ -83,7 +83,7 @@ describe( '<AuthProvider>', () => {
 		renderAuth();
 
 		expect( await screen.findByText( 'signed in' ) ).toBeVisible();
-		expect( mockedBumpStat ).toHaveBeenCalledWith( 'hd-auth', 'success:fetch' );
+		expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'success:fetch' );
 	} );
 
 	test( 'bumps a bounce stat and redirects to login when fetching the user is unauthorized', async () => {
@@ -95,7 +95,7 @@ describe( '<AuthProvider>', () => {
 		renderAuth();
 
 		await waitFor( () =>
-			expect( mockedBumpStat ).toHaveBeenCalledWith( 'hd-auth', 'bounce:unauthorized' )
+			expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'bounce:unauthorized' )
 		);
 		expect( window.location.href ).toContain( '/log-in?redirect_to=' );
 	} );
@@ -117,7 +117,7 @@ describe( '<AuthProvider>', () => {
 		).rejects.toBe( error );
 
 		await waitFor( () =>
-			expect( mockedBumpStat ).toHaveBeenCalledWith( 'hd-auth', 'bounce:expired' )
+			expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'bounce:expired' )
 		);
 	} );
 } );


### PR DESCRIPTION
Part of DOTMSD-1418.

## Proposed Changes

* Bump an `hd-auth` stat at every auth resolution in the dashboard's `AuthProvider`:
  * `success:bootstrap` / `success:fetch` when the user resolves (once per page load).
  * `bounce:unauthorized` / `bounce:bootstrap` / `bounce:error` when fetching the user fails and the visitor is redirected to login, with the failure reason in the name.
  * `bounce:expired` when a mid-session auth error (401/`authorization_required` on any query or mutation) triggers the redirect.
* Skip the auth query itself in the cache-error subscription so an initial user-fetch failure is classified by reason instead of being miscounted as a mid-session expiry.

## Why are these changes being made?

The auth path emits no telemetry today. Any failure fetching the user — a real logged-out 401, a missing bootstrap object, or a transient API error — silently redirects the visitor to the login page, and the error boundary deliberately drops auth errors as benign. If logins into the dashboard break, nothing surfaces it except user reports.

Counting every auth outcome gives a bounce rate per reason that can be trended and alerted on. `bumpStat` is used rather than a Tracks event because at bounce time there is no identified user and analytics may not be initialized; the anonymous stat pixel works in that state.

## Testing Instructions

* Run the unit tests: `yarn test-client client/dashboard/app/auth`
* Or load the dashboard while logged in and confirm a `pixel.wp.com/g.gif?...x_hd-auth=success:bootstrap` request; load it logged out (or with cookies cleared) and confirm an `x_hd-auth=bounce:...` request before the login redirect.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?