### PR TITLE
Dashboard: detect auth redirect loops with a bumpStat counter

### DIFF
--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -22,6 +22,29 @@ export const AUTH_QUERY_KEY = [ 'auth', 'user' ];
 
 const BOOTSTRAP_ERROR_MESSAGE = 'Failed to bootstrap user object';
 
+const AUTH_BOUNCE_COUNT_KEY = 'wpcom_auth_bounce_count';
+
+function trackAuthBounce() {
+	try {
+		const count = Number( window.sessionStorage.getItem( AUTH_BOUNCE_COUNT_KEY ) ) + 1;
+		window.sessionStorage.setItem( AUTH_BOUNCE_COUNT_KEY, String( count ) );
+
+		if ( count >= 2 ) {
+			bumpStat( 'dashboard-auth', 'loop' );
+		}
+	} catch {
+		// sessionStorage can be unavailable in private contexts.
+	}
+}
+
+function clearAuthBounceCount() {
+	try {
+		window.sessionStorage.removeItem( AUTH_BOUNCE_COUNT_KEY );
+	} catch {
+		// sessionStorage can be unavailable in private contexts.
+	}
+}
+
 function getOAuthAuthorizeUrl( {
 	state,
 	next = '',
@@ -138,6 +161,7 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 			authErrorHandled.current = true;
 
 			bumpStat( 'dashboard-auth', `bounce:${ reason }` );
+			trackAuthBounce();
 
 			if ( config.isEnabled( 'oauth' ) ) {
 				const state = crypto.randomUUID();
@@ -203,6 +227,7 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 			if ( ! successStatBumped.current ) {
 				successStatBumped.current = true;
 				bumpStat( 'dashboard-auth', shouldUseBootstrap() ? 'success:bootstrap' : 'success:fetch' );
+				clearAuthBounceCount();
 			}
 		}
 	}, [ user ] );

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -65,8 +65,6 @@ function trackAuthBounceLoop() {
 	}
 }
 
-// Checks that what is stored in sessionStorage matches the AuthBounceRecord
-// shape we expect.
 function isAuthBounceRecord( value: unknown ): value is AuthBounceRecord {
 	return (
 		typeof value === 'object' &&

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -26,6 +26,10 @@ const AUTH_BOUNCE_COUNT_KEY = 'wpcom_auth_bounce_count';
 
 const AUTH_LOOP_WINDOW_MS = 10 * 1000;
 
+// Cap the reported loop count (reported as "10+") so a runaway loop can't
+// inflate stat cardinality.
+const AUTH_LOOP_MAX_COUNT = 10;
+
 interface AuthBounceRecord {
 	count: number;
 	at: number;
@@ -53,7 +57,8 @@ function trackAuthBounceLoop() {
 		);
 
 		if ( count >= 2 ) {
-			bumpStat( 'dashboard-auth-loop', String( count ) );
+			const value = count >= AUTH_LOOP_MAX_COUNT ? `${ AUTH_LOOP_MAX_COUNT }+` : String( count );
+			bumpStat( 'dashboard-auth-loop', value );
 		}
 	} catch {
 		// sessionStorage can be unavailable in private contexts or JSON.parse may fail.

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -24,25 +24,53 @@ const BOOTSTRAP_ERROR_MESSAGE = 'Failed to bootstrap user object';
 
 const AUTH_BOUNCE_COUNT_KEY = 'wpcom_auth_bounce_count';
 
-function trackAuthBounce() {
+const AUTH_LOOP_WINDOW_MS = 10 * 1000;
+
+interface AuthBounceRecord {
+	count: number;
+	at: number;
+}
+
+// bumpStat when we have a login redirect loop.
+// We track the time of the last bounce, and if it was within a window we count
+// it towards our loop count. This is more reliable than clearing the counter on
+// successful auth, because how do we know when it is safe to clear the count?
+// It could be that immediately after successful auth, the very next API returns
+// 401 and causes a bounce, yet we would have already cleared the count.
+function trackAuthBounceLoop() {
 	try {
-		const count = Number( window.sessionStorage.getItem( AUTH_BOUNCE_COUNT_KEY ) ) + 1;
-		window.sessionStorage.setItem( AUTH_BOUNCE_COUNT_KEY, String( count ) );
+		const now = Date.now();
+		const storedRecord: unknown = JSON.parse(
+			window.sessionStorage.getItem( AUTH_BOUNCE_COUNT_KEY ) ?? 'null'
+		);
+		const previousRecord = isAuthBounceRecord( storedRecord ) ? storedRecord : null;
+		const withinWindow = previousRecord !== null && now - previousRecord.at < AUTH_LOOP_WINDOW_MS;
+		const count = withinWindow ? previousRecord.count + 1 : 1;
+
+		window.sessionStorage.setItem(
+			AUTH_BOUNCE_COUNT_KEY,
+			JSON.stringify( { count, at: now } satisfies AuthBounceRecord )
+		);
 
 		if ( count >= 2 ) {
-			bumpStat( 'dashboard-auth', 'loop' );
+			bumpStat( 'dashboard-auth-loop', String( count ) );
 		}
 	} catch {
-		// sessionStorage can be unavailable in private contexts.
+		// sessionStorage can be unavailable in private contexts or JSON.parse may fail.
 	}
 }
 
-function clearAuthBounceCount() {
-	try {
-		window.sessionStorage.removeItem( AUTH_BOUNCE_COUNT_KEY );
-	} catch {
-		// sessionStorage can be unavailable in private contexts.
-	}
+// Checks that what is stored in sessionStorage matches the AuthBounceRecord
+// shape we expect.
+function isAuthBounceRecord( value: unknown ): value is AuthBounceRecord {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		'count' in value &&
+		typeof value.count === 'number' &&
+		'at' in value &&
+		typeof value.at === 'number'
+	);
 }
 
 function getOAuthAuthorizeUrl( {
@@ -161,7 +189,7 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 			authErrorHandled.current = true;
 
 			bumpStat( 'dashboard-auth', `bounce:${ reason }` );
-			trackAuthBounce();
+			trackAuthBounceLoop();
 
 			if ( config.isEnabled( 'oauth' ) ) {
 				const state = crypto.randomUUID();
@@ -227,7 +255,6 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 			if ( ! successStatBumped.current ) {
 				successStatBumped.current = true;
 				bumpStat( 'dashboard-auth', shouldUseBootstrap() ? 'success:bootstrap' : 'success:fetch' );
-				clearAuthBounceCount();
 			}
 		}
 	}, [ user ] );

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -24,7 +24,7 @@ const BOOTSTRAP_ERROR_MESSAGE = 'Failed to bootstrap user object';
 
 const AUTH_BOUNCE_COUNT_KEY = 'wpcom_auth_bounce_count';
 
-const AUTH_LOOP_WINDOW_MS = 10 * 1000;
+const AUTH_LOOP_WINDOW_MS = 30 * 1000;
 
 // Cap the reported loop count (reported as "10+") so a runaway loop can't
 // inflate stat cardinality.

--- a/client/dashboard/app/auth/test/index.test.tsx
+++ b/client/dashboard/app/auth/test/index.test.tsx
@@ -50,6 +50,7 @@ describe( '<AuthProvider> stats', () => {
 	afterEach( () => {
 		config.disable( 'wpcom-user-bootstrap' );
 		delete window.currentUser;
+		window.sessionStorage.clear();
 	} );
 
 	test( 'bumps a success stat when the bootstrapped user is available', async () => {
@@ -98,6 +99,39 @@ describe( '<AuthProvider> stats', () => {
 			expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'bounce:unauthorized' )
 		);
 		expect( window.location.href ).toContain( '/log-in?redirect_to=' );
+	} );
+
+	test( 'does not bump a loop stat on the first bounce', async () => {
+		config.enable( 'wpcom-user-bootstrap' );
+
+		renderAuth();
+
+		await waitFor( () =>
+			expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'bounce:bootstrap' )
+		);
+		expect( mockedBumpStat ).not.toHaveBeenCalledWith( 'dashboard-auth', 'loop' );
+	} );
+
+	test( 'bumps a loop stat when a bounce repeats without a successful auth in between', async () => {
+		config.enable( 'wpcom-user-bootstrap' );
+		window.sessionStorage.setItem( 'wpcom_auth_bounce_count', '1' );
+
+		renderAuth();
+
+		await waitFor( () => expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'loop' ) );
+	} );
+
+	test( 'resets the bounce count when auth succeeds', async () => {
+		config.enable( 'wpcom-user-bootstrap' );
+		window.currentUser = testUser;
+		window.sessionStorage.setItem( 'wpcom_auth_bounce_count', '1' );
+
+		renderAuth();
+
+		expect( await screen.findByText( 'signed in' ) ).toBeVisible();
+		await waitFor( () =>
+			expect( window.sessionStorage.getItem( 'wpcom_auth_bounce_count' ) ).toBeNull()
+		);
 	} );
 
 	test( 'bumps a bounce stat when the session expires mid-app', async () => {

--- a/client/dashboard/app/auth/test/index.test.tsx
+++ b/client/dashboard/app/auth/test/index.test.tsx
@@ -109,29 +109,36 @@ describe( '<AuthProvider> stats', () => {
 		await waitFor( () =>
 			expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'bounce:bootstrap' )
 		);
-		expect( mockedBumpStat ).not.toHaveBeenCalledWith( 'dashboard-auth', 'loop' );
+		expect( mockedBumpStat ).not.toHaveBeenCalledWith( 'dashboard-auth-loop', expect.anything() );
 	} );
 
-	test( 'bumps a loop stat when a bounce repeats without a successful auth in between', async () => {
+	test( 'bumps a loop stat with the bounce count when a bounce repeats within the loop window', async () => {
 		config.enable( 'wpcom-user-bootstrap' );
-		window.sessionStorage.setItem( 'wpcom_auth_bounce_count', '1' );
-
-		renderAuth();
-
-		await waitFor( () => expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'loop' ) );
-	} );
-
-	test( 'resets the bounce count when auth succeeds', async () => {
-		config.enable( 'wpcom-user-bootstrap' );
-		window.currentUser = testUser;
-		window.sessionStorage.setItem( 'wpcom_auth_bounce_count', '1' );
-
-		renderAuth();
-
-		expect( await screen.findByText( 'signed in' ) ).toBeVisible();
-		await waitFor( () =>
-			expect( window.sessionStorage.getItem( 'wpcom_auth_bounce_count' ) ).toBeNull()
+		window.sessionStorage.setItem(
+			'wpcom_auth_bounce_count',
+			JSON.stringify( { count: 1, at: Date.now() } )
 		);
+
+		renderAuth();
+
+		await waitFor( () =>
+			expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth-loop', '2' )
+		);
+	} );
+
+	test( 'does not bump a loop stat when the previous bounce is outside the loop window', async () => {
+		config.enable( 'wpcom-user-bootstrap' );
+		window.sessionStorage.setItem(
+			'wpcom_auth_bounce_count',
+			JSON.stringify( { count: 5, at: Date.now() - 60 * 1000 } )
+		);
+
+		renderAuth();
+
+		await waitFor( () =>
+			expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'bounce:bootstrap' )
+		);
+		expect( mockedBumpStat ).not.toHaveBeenCalledWith( 'dashboard-auth-loop', expect.anything() );
 	} );
 
 	test( 'bumps a bounce stat when the session expires mid-app', async () => {

--- a/client/dashboard/app/auth/test/index.test.tsx
+++ b/client/dashboard/app/auth/test/index.test.tsx
@@ -126,6 +126,20 @@ describe( '<AuthProvider> stats', () => {
 		);
 	} );
 
+	test( 'caps the loop stat count', async () => {
+		config.enable( 'wpcom-user-bootstrap' );
+		window.sessionStorage.setItem(
+			'wpcom_auth_bounce_count',
+			JSON.stringify( { count: 20, at: Date.now() } )
+		);
+
+		renderAuth();
+
+		await waitFor( () =>
+			expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth-loop', '10+' )
+		);
+	} );
+
 	test( 'does not bump a loop stat when the previous bounce is outside the loop window', async () => {
 		config.enable( 'wpcom-user-bootstrap' );
 		window.sessionStorage.setItem(


### PR DESCRIPTION
Part of DOTMSD-1418. Stacked on #112682 — review that first.

## Proposed Changes

* Track consecutive auth bounces in `sessionStorage` as a `{ count, at }` record — the count plus the timestamp of the last bounce.
* A bounce counts toward the loop only if it lands within a 10s window of the previous one; otherwise the count restarts at 1. No reset-on-success needed.
* From the second consecutive in-window bounce onward, bump `dashboard-auth-loop` with the current count (e.g. `2`, `3`, …).

## Why are these changes being made?

The dashboard lives on `my.wordpress.com` while login lives on `wordpress.com`. If the session ever stops working across that host boundary (cookie scope, bootstrap breakage), users bounce between login and the dashboard indefinitely. The in-memory guard only survives a single page load, and a normal logged-out bounce is indistinguishable from that loop in the `bounce:*` stats added by #112682.

A consecutive-bounce counter that survives navigations separates "logged-out visitor, expected" from "authenticated users can't get in" — the actual incident signal worth alerting on. Any non-zero `dashboard-auth-loop` rate is a real failure.

Storing a timestamp alongside the count lets us use a short time window to decide whether bounces are consecutive, rather than clearing the counter on successful auth. Clearing on success is unreliable: a successful auth immediately followed by a 401 on the next API call would clear the count we still need, hiding the loop.

## Testing Instructions

* Run the unit tests: `yarn test-client client/dashboard/app/auth`
* Or in a browser: set `sessionStorage.wpcom_auth_bounce_count = JSON.stringify( { count: 1, at: Date.now() } )` on the dashboard origin, trigger an auth failure (e.g. clear cookies), and confirm a `pixel.wp.com/g.gif?...x_dashboard-auth-loop=2` request fires before the login redirect.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
