### PR TITLE
Track admin-bar redirects to the hosting dashboard with a bumpStat counter

### DIFF
--- a/client/components/email-verification/index.js
+++ b/client/components/email-verification/index.js
@@ -1,6 +1,7 @@
 import { removeQueryArgs } from '@wordpress/url';
 import i18n from 'i18n-calypso';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
+import { bumpStat } from 'calypso/lib/analytics/mc';
 import { sendVerificationSignal } from 'calypso/lib/user/verification-checker';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
@@ -47,6 +48,7 @@ export default function emailVerification( context, next ) {
 
 // Helper function to build redirect URL
 function buildDashboardRedirectUrl( verified, newEmailResult ) {
+	bumpStat( 'dashboard-redirect', 'email-verification' );
 	let redirectUrl = dashboardLink( '/me/profile' );
 	if ( verified ) {
 		redirectUrl += `?verified=${ verified }`;

--- a/client/controller/index.web.jsx
+++ b/client/controller/index.web.jsx
@@ -19,6 +19,7 @@ import { RouteProvider } from 'calypso/components/route';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
 import Layout from 'calypso/layout';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
+import { bumpStat } from 'calypso/lib/analytics/mc';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { navigate } from 'calypso/lib/navigate';
 import { createAccountUrl, login } from 'calypso/lib/paths';
@@ -581,6 +582,7 @@ export const maybeRedirectToMultiSiteDashboard = ( path ) => ( context, next ) =
 	const state = context.store.getState();
 	if ( hasDashboardForcedOptIn( state ) ) {
 		const redirectUrl = typeof path === 'function' ? path( context.params, context.query ) : path;
+		bumpStat( 'dashboard-redirect', 'forced-opt-in' );
 		return navigate( dashboardLink( redirectUrl ?? context.path ) );
 	}
 

--- a/client/me/controller.jsx
+++ b/client/me/controller.jsx
@@ -5,6 +5,7 @@ import { createElement } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
+import { bumpStat } from 'calypso/lib/analytics/mc';
 import AppsComponent from 'calypso/me/get-apps';
 import McpComponent from 'calypso/me/mcp/main';
 import McpAddSiteComponent from 'calypso/me/mcp/mcp-add-site';
@@ -193,6 +194,7 @@ export const maybeRedirectToDashboard = ( context, next ) => {
 
 	dispatch( waitForPrefs() ).finally( () => {
 		if ( hasDashboardOptIn( getState() ) ) {
+			bumpStat( 'dashboard-redirect', 'me' );
 			window.location.replace( dashboardLink( '/me' ) );
 			return;
 		}

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -377,7 +377,7 @@ const maybeRedirectToDashboard = ( context, next ) => {
 
 	dispatch( waitForPrefs() ).finally( () => {
 		if ( hasDashboardOptIn( getState() ) ) {
-			bumpStat( 'hd-redirect', 'domains' );
+			bumpStat( 'dashboard-redirect', 'domain-list' );
 			window.location.replace( dashboardLink( '/domains' ) );
 			return;
 		}

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -10,6 +10,7 @@ import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
+import { bumpStat } from 'calypso/lib/analytics/mc';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { sectionify } from 'calypso/lib/route';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
@@ -376,6 +377,7 @@ const maybeRedirectToDashboard = ( context, next ) => {
 
 	dispatch( waitForPrefs() ).finally( () => {
 		if ( hasDashboardOptIn( getState() ) ) {
+			bumpStat( 'hd-redirect', 'domains' );
 			window.location.replace( dashboardLink( '/domains' ) );
 			return;
 		}

--- a/client/my-sites/invites/utils.tsx
+++ b/client/my-sites/invites/utils.tsx
@@ -2,6 +2,7 @@ import { determineUrlType, URL_TYPE } from '@automattic/calypso-url';
 import { addQueryArgs } from '@wordpress/url';
 import i18n from 'i18n-calypso';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
+import { bumpStat } from 'calypso/lib/analytics/mc';
 import { logmeinUrl } from 'calypso/lib/logmein';
 
 type InviteType = {
@@ -211,6 +212,9 @@ export function getRedirectAfterAccept( invite: InviteType, hasDashboardOptIn: b
 			return getDestinationUrl( readerPath );
 
 		default:
+			if ( hasDashboardOptIn ) {
+				bumpStat( 'dashboard-redirect', 'invite-accept' );
+			}
 			return getDestinationUrl( mySitesPath );
 	}
 }

--- a/client/root.js
+++ b/client/root.js
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import globalPageInstance from '@automattic/calypso-router';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
+import { bumpStat } from 'calypso/lib/analytics/mc';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
 import { fetchPreferences } from 'calypso/state/preferences/actions';
@@ -96,6 +97,7 @@ const getSitesLink = ( isDashboardOptIn ) => {
 	// As a temporary workaround, we send them to the v1 /sites instead.
 	// TODO: The workaround will need to change once we deprecate v1 /sites.
 	if ( isDashboardOptIn && ! [ 'development', 'wpcalypso' ].includes( config( 'env_id' ) ) ) {
+		bumpStat( 'dashboard-redirect', 'landing-page' );
 		return dashboardLink( '/sites' );
 	}
 

--- a/client/sites/controller.tsx
+++ b/client/sites/controller.tsx
@@ -6,6 +6,7 @@ import i18n from 'i18n-calypso';
 import AsyncLoad from 'calypso/components/async-load';
 import ResurrectedWelcomeModalGate from 'calypso/components/resurrected-welcome-modal';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
+import { bumpStat } from 'calypso/lib/analytics/mc';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
 import { removeNotice, successNotice } from 'calypso/state/notices/actions';
@@ -188,6 +189,7 @@ export const maybeRedirectToDashboard = ( context: PageJSContext, next: () => vo
 
 	dispatch( waitForPrefs() ).finally( () => {
 		if ( hasDashboardOptIn( getState() ) ) {
+			bumpStat( 'hd-redirect', 'sites' );
 			window.location.replace( dashboardLink( '/sites' ) );
 			return;
 		}

--- a/client/sites/controller.tsx
+++ b/client/sites/controller.tsx
@@ -189,7 +189,7 @@ export const maybeRedirectToDashboard = ( context: PageJSContext, next: () => vo
 
 	dispatch( waitForPrefs() ).finally( () => {
 		if ( hasDashboardOptIn( getState() ) ) {
-			bumpStat( 'hd-redirect', 'sites' );
+			bumpStat( 'dashboard-redirect', 'site-list' );
 			window.location.replace( dashboardLink( '/sites' ) );
 			return;
 		}

--- a/client/sites/overview/controller.tsx
+++ b/client/sites/overview/controller.tsx
@@ -1,6 +1,7 @@
 import page from '@automattic/calypso-router';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { isMigrationInProgress } from 'calypso/data/site-migration';
+import { bumpStat } from 'calypso/lib/analytics/mc';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
 import { fetchPreferences } from 'calypso/state/preferences/actions';
@@ -43,6 +44,7 @@ export function redirectToSiteOverview( context: PageJSContext ) {
 
 	dispatch( waitForPrefs() ).finally( () => {
 		if ( hasDashboardOptIn( getState() ) ) {
+			bumpStat( 'dashboard-redirect', 'site-overview' );
 			window.location.replace( dashboardLink( path ) );
 			return;
 		}


### PR DESCRIPTION
Part of DOTMSD-1418.

## Proposed Changes

* Bump an `dashboard-redirect` stat (`sites` / `domains`) when the admin-bar `origin_admin_bar=wpcom` redirect sends an opted-in user from old Calypso to the hosting dashboard.

## Why are these changes being made?

The enrollment redirect into the hosting dashboard is untracked: there is no count of how many users Calypso hands off. Counting departures gives the send side of the funnel — arrivals are already measured by dashboard page views and the `hd-auth` success stats (#112682) — so a redirect that starts losing users (broken link, auth failure on the other side) becomes visible as a divergence between the two instead of going unnoticed.

## Testing Instructions

* With the new hosting dashboard opt-in enabled, visit `/sites?origin_admin_bar=wpcom` on old Calypso and confirm a `pixel.wp.com/g.gif?...x_hd-redirect=sites` request fires before the redirect to `my.wordpress.com`; same for `/domains/manage?origin_admin_bar=wpcom` with `x_hd-redirect=domains`.
* Without the opt-in, confirm no stat is bumped and the old dashboard renders.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?