### PR TITLE
Dashboard: enable mc_analytics_enabled in dashboard-production env

### DIFF
--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -16,7 +16,6 @@
 	"i18n_default_locale_slug": "en",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
-	"mc_analytics_enabled": true,
 	"wpcom_url": "https://wpcalypso.wordpress.com",
 	"wpcom_login_url": "https://wordpress.com/log-in",
 	"features": {

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -16,6 +16,7 @@
 	"i18n_default_locale_slug": "en",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
+	"mc_analytics_enabled": true,
 	"wpcom_url": "https://wpcalypso.wordpress.com",
 	"wpcom_login_url": "https://wordpress.com/log-in",
 	"features": {

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -19,9 +19,9 @@
 		}
 	},
 	"i18n_default_locale_slug": "en",
+	"mc_analytics_enabled": true,
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
-	"mc_analytics_enabled": true,
 	"wpcom_url": "https://wordpress.com",
 	"wpcom_login_url": "https://wordpress.com/log-in",
 	"features": {

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -21,6 +21,7 @@
 	"i18n_default_locale_slug": "en",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
+	"mc_analytics_enabled": true,
 	"wpcom_url": "https://wordpress.com",
 	"wpcom_login_url": "https://wordpress.com/log-in",
 	"features": {


### PR DESCRIPTION
Related to DOTMSD-1418.

## Proposed Changes

* Set `mc_analytics_enabled: true` in the `dashboard-production` ~~and `dashboard-horizon`~~ configs.

## Why are these changes being made?

`bumpStat` no-ops unless `mc_analytics_enabled` is set, and only `production.json` and `horizon.json` enable it. The standalone dashboard envs inherit `false` from `_shared.json`, so every `bumpStat` there is silently dropped in production, including `hd-mutation-error` (#112540) and `hd-very-slow-nav`. 

## Testing Instructions

* On this branch, `yarn start-dashboard` serves `dashboard-development` where the flag is still off — expected.
* To verify the mechanism: set `window.configData.mc_analytics_enabled = true` in the console, trigger a failing mutation (e.g. save `ssh-ed25519 notarealkey` under Me → Security → SSH Key), and confirm a `pixel.wp.com/g.gif?...x_hd-mutation-error=unknown:400` request fires.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)