### PR TITLE
A4A: Add unit tests for the Referrals list

### DIFF
--- a/client/dashboard/agency/earn/referrals/hooks/test/use-consolidated-payout-data.ts
+++ b/client/dashboard/agency/earn/referrals/hooks/test/use-consolidated-payout-data.ts
@@ -3,16 +3,13 @@
  */
 
 import { renderHook } from '@testing-library/react';
-import * as getEstimatedCommission from '../../lib/get-estimated-commission';
+import { getEstimatedCommission } from '../../lib/get-estimated-commission';
 import useGetConsolidatedPayoutData from '../use-consolidated-payout-data';
 import type { Referral } from '@automattic/api-core';
 
 jest.mock( '../../lib/get-estimated-commission' );
 
-const mockGetEstimatedCommission =
-	getEstimatedCommission.getEstimatedCommission as jest.MockedFunction<
-		typeof getEstimatedCommission.getEstimatedCommission
-	>;
+const mockGetEstimatedCommission = getEstimatedCommission as jest.Mock;
 
 describe( 'useGetConsolidatedPayoutData', () => {
 	const mockReferrals: Referral[] = [

--- a/client/dashboard/agency/earn/referrals/hooks/test/use-consolidated-payout-data.ts
+++ b/client/dashboard/agency/earn/referrals/hooks/test/use-consolidated-payout-data.ts
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from '@testing-library/react';
+import * as getEstimatedCommission from '../../lib/get-estimated-commission';
+import useGetConsolidatedPayoutData from '../use-consolidated-payout-data';
+import type { Referral } from '@automattic/api-core';
+
+jest.mock( '../../lib/get-estimated-commission' );
+
+const mockGetEstimatedCommission =
+	getEstimatedCommission.getEstimatedCommission as jest.MockedFunction<
+		typeof getEstimatedCommission.getEstimatedCommission
+	>;
+
+describe( 'useGetConsolidatedPayoutData', () => {
+	const mockReferrals: Referral[] = [
+		{
+			referralStatuses: [ 'active', 'pending' ],
+			purchaseStatuses: [ 'active' ],
+			purchases: [
+				{
+					product_id: 1,
+					status: 'active',
+					quantity: 1,
+				},
+				{
+					product_id: 2,
+					status: 'active',
+					quantity: 1,
+				},
+			],
+		},
+	] as never;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		// Default mock — `getEstimatedCommission` is dispatched on
+		// `usePreviousQuarter` so individual tests can override per-flag.
+		mockGetEstimatedCommission.mockReturnValue( 50 );
+	} );
+
+	it( 'calls getEstimatedCommission once for each quarter flag', () => {
+		renderHook( () => useGetConsolidatedPayoutData( mockReferrals ) );
+
+		expect( mockGetEstimatedCommission ).toHaveBeenCalledTimes( 2 );
+		expect( mockGetEstimatedCommission ).toHaveBeenCalledWith( mockReferrals, true );
+		expect( mockGetEstimatedCommission ).toHaveBeenCalledWith( mockReferrals, false );
+	} );
+
+	it( 'returns the previous-quarter and current-quarter commissions from getEstimatedCommission', () => {
+		mockGetEstimatedCommission.mockImplementation( ( _referrals, usePreviousQuarter ) =>
+			usePreviousQuarter ? 75 : 50
+		);
+
+		const { result } = renderHook( () => useGetConsolidatedPayoutData( mockReferrals ) );
+
+		expect( result.current.previousQuarterExpectedCommission ).toBe( 75 );
+		expect( result.current.currentQuarterExpectedCommission ).toBe( 50 );
+	} );
+
+	it( 'counts pending referral statuses as pendingOrders', () => {
+		const { result } = renderHook( () => useGetConsolidatedPayoutData( mockReferrals ) );
+
+		expect( result.current.pendingOrders ).toBe( 1 );
+	} );
+
+	it( 'sums pendingOrders across multiple referrals', () => {
+		const multipleReferrals: Referral[] = [
+			{
+				referralStatuses: [ 'active', 'pending' ],
+				purchaseStatuses: [ 'active' ],
+				purchases: [],
+			},
+			{
+				referralStatuses: [ 'pending', 'pending' ],
+				purchaseStatuses: [ 'active' ],
+				purchases: [],
+			},
+			{
+				referralStatuses: [ 'active' ],
+				purchaseStatuses: [ 'active' ],
+				purchases: [],
+			},
+		] as never;
+
+		const { result } = renderHook( () => useGetConsolidatedPayoutData( multipleReferrals ) );
+
+		// 1 from the first referral + 2 from the second = 3.
+		expect( result.current.pendingOrders ).toBe( 3 );
+	} );
+} );

--- a/client/dashboard/agency/earn/referrals/lib/test/get-estimated-commission.ts
+++ b/client/dashboard/agency/earn/referrals/lib/test/get-estimated-commission.ts
@@ -1,0 +1,229 @@
+import { getEstimatedCommission } from '../get-estimated-commission';
+import type { Referral } from '@automattic/api-core';
+
+describe( 'getEstimatedCommission', () => {
+	it( 'returns 0 for empty referrals', () => {
+		expect( getEstimatedCommission( [] ) ).toBe( 0 );
+	} );
+
+	it( 'sums current-quarter commissions across purchases', () => {
+		const referrals: Referral[] = [
+			{
+				purchaseStatuses: [ 'active' ],
+				referralStatuses: [ 'active' ],
+				purchases: [
+					{
+						product_id: 1,
+						status: 'active',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 150,
+							estimated_commission_previous_quarter: 75,
+						},
+					},
+					{
+						product_id: 2,
+						status: 'active',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 200,
+							estimated_commission_previous_quarter: 100,
+						},
+					},
+				],
+			} as never,
+		];
+
+		expect( getEstimatedCommission( referrals ) ).toBe( 350 );
+	} );
+
+	it( 'sums previous-quarter commissions when usePreviousQuarter is true', () => {
+		const referrals: Referral[] = [
+			{
+				purchaseStatuses: [ 'active' ],
+				referralStatuses: [ 'active' ],
+				purchases: [
+					{
+						product_id: 1,
+						status: 'active',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 150,
+							estimated_commission_previous_quarter: 75,
+						},
+					},
+					{
+						product_id: 2,
+						status: 'active',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 200,
+							estimated_commission_previous_quarter: 100,
+						},
+					},
+				],
+			} as never,
+		];
+
+		expect( getEstimatedCommission( referrals, true ) ).toBe( 175 );
+	} );
+
+	it( 'sums commissions across multiple referrals', () => {
+		const referrals: Referral[] = [
+			{
+				purchaseStatuses: [ 'active' ],
+				referralStatuses: [ 'active' ],
+				purchases: [
+					{
+						product_id: 1,
+						status: 'active',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 150,
+							estimated_commission_previous_quarter: 75,
+						},
+					},
+				],
+			} as never,
+			{
+				purchaseStatuses: [ 'active' ],
+				referralStatuses: [ 'active' ],
+				purchases: [
+					{
+						product_id: 1,
+						status: 'active',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 200,
+							estimated_commission_previous_quarter: 100,
+						},
+					},
+				],
+			} as never,
+		];
+
+		expect( getEstimatedCommission( referrals ) ).toBe( 350 );
+	} );
+
+	it( 'includes cancelled purchases', () => {
+		// Cancelled purchases still contribute commissions for the days they
+		// were active (the server-side compute already accounts for the
+		// revoked window).
+		const referrals: Referral[] = [
+			{
+				purchaseStatuses: [ 'cancelled' ],
+				referralStatuses: [ 'cancelled' ],
+				purchases: [
+					{
+						product_id: 1,
+						status: 'cancelled',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 50,
+							estimated_commission_previous_quarter: 25,
+						},
+					},
+				],
+			} as never,
+		];
+
+		expect( getEstimatedCommission( referrals ) ).toBe( 50 );
+	} );
+
+	it( 'skips pending purchases', () => {
+		const referrals: Referral[] = [
+			{
+				purchaseStatuses: [ 'pending' ],
+				referralStatuses: [ 'pending' ],
+				purchases: [
+					{
+						product_id: 1,
+						status: 'pending',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 999,
+							estimated_commission_previous_quarter: 999,
+						},
+					},
+				],
+			} as never,
+		];
+
+		expect( getEstimatedCommission( referrals ) ).toBe( 0 );
+	} );
+
+	it( 'skips error purchases', () => {
+		const referrals: Referral[] = [
+			{
+				purchaseStatuses: [ 'error' ],
+				referralStatuses: [ 'active' ],
+				purchases: [
+					{
+						product_id: 1,
+						status: 'error',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 999,
+							estimated_commission_previous_quarter: 999,
+						},
+					},
+				],
+			} as never,
+		];
+
+		expect( getEstimatedCommission( referrals ) ).toBe( 0 );
+	} );
+
+	it( 'contributes 0 for purchases without a commissions block', () => {
+		// In production every purchase carries server-supplied commissions.
+		// Defensive coverage for the rare case where the field is missing —
+		// must contribute 0 rather than fall back to the (now-removed) JS
+		// compute that double-counted alongside the BD branch.
+		const referrals: Referral[] = [
+			{
+				purchaseStatuses: [ 'active' ],
+				referralStatuses: [ 'active' ],
+				purchases: [
+					{
+						product_id: 1,
+						status: 'active',
+						quantity: 1,
+					},
+				],
+			} as never,
+		];
+
+		expect( getEstimatedCommission( referrals ) ).toBe( 0 );
+	} );
+
+	it( 'rounds the total to 2 decimal places', () => {
+		const referrals: Referral[] = [
+			{
+				purchaseStatuses: [ 'active' ],
+				referralStatuses: [ 'active' ],
+				purchases: [
+					{
+						product_id: 1,
+						status: 'active',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 10.111,
+							estimated_commission_previous_quarter: 5,
+						},
+					},
+					{
+						product_id: 2,
+						status: 'active',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 20.222,
+							estimated_commission_previous_quarter: 5,
+						},
+					},
+				],
+			} as never,
+		];
+
+		expect( getEstimatedCommission( referrals ) ).toBe( 30.33 );
+	} );
+} );


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/112638.

Part of A4A-2845

## Proposed Changes

* Add unit tests for the estimated-commission calculation and the consolidated payout data used by the Referrals list, split out of the main PR to keep it focused on the feature code.

## Why are these changes being made?

The Referrals list PR grew large, so the tests were moved here to make both easier to review. These are the same tests the classic Automattic for Agencies app has for this logic, adapted to the new dashboard.

## Testing Instructions

1. Run `yarn test-client client/dashboard/agency/earn/referrals` and confirm all tests pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?