### PR TITLE
Remove unused EmailFallbackNotice

### DIFF
--- a/packages/help-center/src/components/notices.scss
+++ b/packages/help-center/src/components/notices.scss
@@ -8,10 +8,6 @@
 	display: flex;
 	column-gap: 8px;
 	align-items: flex-start;
-	
-	&.email-fallback-notice {
-		padding: 8px;
-	}
 
 	&.cookie-warning {
 		margin-bottom: 30px;

--- a/packages/help-center/src/components/notices.tsx
+++ b/packages/help-center/src/components/notices.tsx
@@ -3,13 +3,9 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { useCanConnectToZendeskMessaging } from '@automattic/zendesk-client';
 import { Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Icon, info } from '@wordpress/icons';
 import { useEffect } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
 import { useFeatureConfig, useHelpCenterContext } from '../contexts/HelpCenterContext';
-import { useSupportStatus } from '../data/use-support-status';
 import useChatStatus from '../hooks/use-chat-status';
 import './notices.scss';
 import { HELP_CENTER_STORE } from '../stores';
@@ -58,43 +54,6 @@ export const BlockedZendeskNotice: React.FC = () => {
 				>
 					{ __( 'Learn more.', __i18n_text_domain__ ) }
 				</Button>
-			</p>
-		</div>
-	);
-};
-
-export const EmailFallbackNotice: React.FC = () => {
-	const navigate = useNavigate();
-	const { search } = useLocation();
-	const { data: supportStatus } = useSupportStatus();
-	const params = new URLSearchParams( search );
-	params.set( 'wapuuFlow', 'true' );
-	const url = '/contact-form?' + params.toString();
-
-	const title = supportStatus?.eligibility?.is_chat_restricted
-		? __( 'Live chat is currently unavailable.', __i18n_text_domain__ )
-		: __( 'Live chat is temporarily unavailable for scheduled maintenance.', __i18n_text_domain__ );
-
-	const message = __(
-		'Please reach out via <email>email</email> if you need assistance.',
-		__i18n_text_domain__
-	);
-
-	return (
-		<div className="help-center__notice email-fallback-notice">
-			<Icon icon={ info } className="help-center__notice-icon" />
-			<p>
-				<strong>{ title }</strong>
-				&nbsp;
-				{ createInterpolateElement( message, {
-					email: (
-						<Button
-							variant="link"
-							className="help-center__notice-link"
-							onClick={ () => navigate( url ) }
-						/>
-					),
-				} ) }
 			</p>
 		</div>
 	);

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -1,7 +1,6 @@
 import '@automattic/agenttic-ui/index.css';
 import { useInput } from '@automattic/agenttic-ui';
 import { HelpCenterSelect } from '@automattic/data-stores';
-import { EmailFallbackNotice } from '@automattic/help-center/src/components/notices';
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useConnectionStatusNotice } from '@automattic/zendesk-client';
 import { useSelect } from '@wordpress/data';
@@ -30,7 +29,7 @@ const getTextAreaPlaceholder = (
 
 export const OdieSendMessageButton = () => {
 	const divContainerRef = useRef< HTMLDivElement >( null );
-	const { trackEvent, chat, canConnectToZendesk, forceEmailSupport } = useOdieAssistantContext();
+	const { trackEvent, chat, canConnectToZendesk } = useOdieAssistantContext();
 	const cantTransferToZendesk =
 		( chat.messages?.[ chat.messages.length - 1 ]?.context?.flags?.forward_to_human_support &&
 			! canConnectToZendesk ) ??
@@ -133,8 +132,6 @@ export const OdieSendMessageButton = () => {
 
 	const customActions = showAttachmentButton ? [ attachmentAction ] : undefined;
 
-	const isEmailFallback = chat?.provider === 'zendesk' && forceEmailSupport;
-
 	// Handle key events including Enter submission and paste
 	const handleKeyDown = useCallback(
 		( e: React.KeyboardEvent< HTMLTextAreaElement > ) => {
@@ -176,25 +173,21 @@ export const OdieSendMessageButton = () => {
 	return (
 		<>
 			<div className="odie-chat-message-input-container agenttic" ref={ divContainerRef }>
-				{ isEmailFallback ? (
-					<EmailFallbackNotice />
-				) : (
-					<AgentUIFooter
-						value={ inputValue }
-						onChange={ setInputValue }
-						onSubmit={ sendMessageHandler }
-						attachmentPreviews={ attachmentPreviews }
-						onKeyDown={ handleKeyDown }
-						textareaRef={ textareaRef }
-						disabled={ isDisabled }
-						notice={ notice }
-						placeholder={ textAreaPlaceholder }
-						isProcessing={ isProcessing }
-						focusOnMount={ ! isInitialLoading }
-						customActions={ customActions }
-						actionOrder="before-submit"
-					/>
-				) }
+				<AgentUIFooter
+					value={ inputValue }
+					onChange={ setInputValue }
+					onSubmit={ sendMessageHandler }
+					attachmentPreviews={ attachmentPreviews }
+					onKeyDown={ handleKeyDown }
+					textareaRef={ textareaRef }
+					disabled={ isDisabled }
+					notice={ notice }
+					placeholder={ textAreaPlaceholder }
+					isProcessing={ isProcessing }
+					focusOnMount={ ! isInitialLoading }
+					customActions={ customActions }
+					actionOrder="before-submit"
+				/>
 			</div>
 			<AttachmentDropZone />
 		</>


### PR DESCRIPTION
## Proposed Changes

Remove the `EmailFallbackNotice` component, which is no longer used:

* Delete `EmailFallbackNotice` and its `.email-fallback-notice` styles from `@automattic/help-center` (`src/components/notices.tsx`, `notices.scss`), and the now-unused imports it required.
* Remove its only consumer — the `isEmailFallback` conditional in `@automattic/odie-client`'s send-message input (`send-message-input/index.tsx`) — so the input always renders the standard `AgentUIFooter`.

`BlockedZendeskNotice` (the other export in `notices.tsx`) is untouched.

## Why are these changes being made?

The email fallback notice was only shown when `chat.provider === 'zendesk' && forceEmailSupport`. The AI no longer escalates to a human when email support is forced, so that branch is never reached and the notice is dead code.

## Testing Instructions

### Calypso

1. Run `yarn start`.
2. Open the Help Center, start an AI chat, and confirm the message input renders normally (the `AgentUIFooter` text box) in all states.
3. Confirm there are no TypeScript/console errors.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
4. Open the Help Center, start an AI chat, and confirm the message input renders normally and no email-fallback notice appears.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
