### PR TITLE
Components: remove form toggle and radio control cursor overrides

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -23,14 +23,6 @@
 	transition: opacity 1ms;
 }
 
-/* @wordpress/components FormToggle overrides ----------------------------------------- */
-.components-form-toggle {
-	input[type="checkbox"] {
-		cursor: pointer;
-
-	}
-}
-
 /* @wordpress/components Button overrides --------------------------------------------- */
 .components-button {
 	justify-content: center;

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -140,8 +140,8 @@
 			&:hover {
 				color: var(--color-passport-accent);
 			}
-		}	
-	
+		}
+
 		.components-button.is-link {
 			color: var(--color-passport-base);
 		}
@@ -219,7 +219,6 @@
 .components-radio-control {
 	&__input[type="radio"] {
 		padding: 6px;
-		cursor: pointer;
 
 		&:checked {
 			border-color: var(--color-accent);


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->



## Proposed Changes

Removes core component overrides for cursor; they're no longer needed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

`@wordpress/components` `FormToggle` already styles the cursor:

```168:170:node_modules/@wordpress/components/src/form-toggle/style.scss
	&:not(:disabled, [aria-disabled="true"]) {
		cursor: var(--wpds-cursor-control);
	}
```

That compiles to `cursor: var(--wpds-cursor-control, pointer)`.

The override was added in **2021** ([#49998](https://github.com/Automattic/wp-calypso/pull/49998)) when upstream did not set a pointer cursor on toggles. 

Same thing with `RadioControl`; it's now also covered upstream for both the input and the label.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Behavior for toggles and radio controls should be unchanged regarding cursor.


https://github.com/user-attachments/assets/9029ab84-8668-4282-b044-3a3d7d055450


https://github.com/user-attachments/assets/6b74cd90-594b-4566-9bc6-cdf32020d2a9



<details>
<summary> AI generated table of usage across Calypso</summary>
URL-oriented map of `@wordpress/components` **toggle** and **radio** usage in Calypso. `:site` = site slug, `:domain` = domain name.

**Legend**
- `ToggleControl` — most common
- `RadioControl` — choice lists
- `FormToggle` — lower-level toggle (used directly in a few places)

Dashboard URLs may also exist under classic Calypso with redirects (`maybeRedirectToMultiSiteDashboard`).

---

## Classic Calypso — `/settings/:section/:site`

Most site settings toggles live under `/settings/:section/:site`.

| URL | Component | Notes |
|---|---|---|
| `/settings/discussion/:site` | `ToggleControl` | Comments, pings, avatars, subscriptions |
| `/settings/security/:site` | `ToggleControl` | Firewall, allow list |
| `/settings/manage-connection/:site` | `ToggleControl` | API cache |
| `/settings/search/:site` | `ToggleControl` | Site search |
| `/settings/subscriptions/:site` | `ToggleControl` | Newsletter settings |
| `/settings/related-posts/:site` | `ToggleControl` | Related posts |
| `/settings/sso/:site` | `ToggleControl` | SSO |
| `/settings/monitor/:site` | `ToggleControl` | Jetpack monitor |
| `/settings/jetpack/:site` | `ToggleControl` | Jetpack modules (`jetpack-module-toggle`) |
| `/settings/performance/:site` | `ToggleControl` | Speed-up settings |
| `/settings/comment-display/:site` | `ToggleControl` | Comment display |
| `/settings/analytics/:site` | `ToggleControl` | Analytics (often redirects to traffic) |
| `/marketing/activitypub/:domain` | `ToggleControl` | Fediverse settings |

---

## Classic Calypso — `/me/*`

| URL | Component | Notes |
|---|---|---|
| `/me/privacy` | `ToggleControl` | Privacy settings |
| `/me/developer` | `ToggleControl` | Developer settings |
| `/me/account` | `RadioControl` | Landing page preference (`toggle-landing-page`) |
| `/me/account` | `ToggleControl` | Community translator toggle |
| `/me/notifications` | `ToggleControl` | WPCOM notification settings |
| `/me/notifications/comments` | `ToggleControl` | Comment notifications |
| `/me/notifications/updates` | `ToggleControl` | Achievements / on-this-day extras |
| `/me/notifications/subscriptions` | `ToggleControl` | Email subscription prefs |
| `/me/security/two-step` | `ToggleControl` | Enhanced security |
| `/me/mcp` | `ToggleControl` | MCP tools |
| `/me/mcp/setup` | `ToggleControl` | MCP setup |
| `/me/mcp/read`, `/me/mcp/write` | `ToggleControl` | MCP read/write tools |
| `/me/purchases/:site/:purchaseId` | `ToggleControl` | Auto-renew toggle |
| `/me/purchases/:site/:purchaseId/cancel` | `RadioControl` | Cancel auto-renewal survey |

---

## Classic Calypso — `/plugins/*`

| URL | Component | Notes |
|---|---|---|
| `/plugins/:plugin/:site` | `ToggleControl` | Plugin details CTA, autoupdate |
| `/plugins/manage/:site` | `ToggleControl` | Per-plugin activate toggle |
| `/plugins/scheduled-updates` | `FormToggle` | Multisite schedule list |
| `/plugins/scheduled-updates/:site` | `FormToggle`, `RadioControl` | Schedule form + frequency |
| `/plugins/scheduled-updates/:site/create` | `RadioControl` | Frequency selection |
| `/plugins/plans/:interval/:site` | `ToggleControl` | Plans filter bar |

---

## Classic Calypso — `/domains/*`

| URL | Component | Notes |
|---|---|---|
| `/domains/manage/:site/:domain/edit` | `ToggleControl` | Contact privacy, DNSSEC, name servers |
| `/domains/manage/all/overview/:domain/:site` | `ToggleControl` | Same domain settings (all-domains view) |
| `/domains/transfer/:domain/:site` | `ToggleControl` | Transfer options |

---

## Classic Calypso — `/earn/*` & `/sites/*`

| URL | Component | Notes |
|---|---|---|
| `/earn/:site` | `ToggleControl` | Plan/coupon modals |
| `/earn/payments/:site` | `ToggleControl` | Add/edit plan modal |
| `/earn/ads-settings/:site` | `RadioControl` | Ad settings |
| `/sites/settings/performance/:site` | `ToggleControl` | Performance |
| `/sites/settings/sftp-ssh/:site` | `ToggleControl` | SFTP |
| `/sites/settings/site/:site` | `ToggleControl` | Subscription gifting, agency, enhanced ownership |
| `/github-deployments/:site` | `FormToggle` | Auto activation, automated deployments |
| `/github-deployments/:site` (delete dialog) | `ToggleControl` | Delete deployment |
| `/site-logs/:site` | `ToggleControl` | Logs (classic hosting) |
| `/stats/:period/:site` | `FormToggle` | Module visibility toggles |

---

## Multi-site Dashboard

| URL | Component | Notes |
|---|---|---|
| `/sites/:site/logs` | `ToggleControl` | Auto-refresh in DataViews |
| `/sites/:site/logs/php` etc. | `ToggleControl` | Same logs UI |
| `/sites/:site/settings/ai-tools` | `ToggleControl` | AI tools read/write/setup |
| `/sites/:site/settings/ai-tools/read` | `ToggleControl` | |
| `/sites/:site/settings/ai-tools/write` | `ToggleControl` | |
| `/sites/:site/settings/ai-tools/setup` | `ToggleControl` | |
| `/sites/:site/settings/sftp-ssh` | `ToggleControl` | SSH card |
| `/sites/:site/settings/repositories` | `ToggleControl` | Connect/disconnect repo |
| `/sites/:site/settings/site-visibility` | `ToggleControl` | Preview links |
| `/sites/:site/deployments` | `ToggleControl` | Deployment toggles |
| `/domains/:domain/forwarding` | `RadioControl` | Forwarding form |
| `/domains/:domain/forwarding/add` | `RadioControl` | |
| `/domains/:domain/domain-connection-setup` | `RadioControl` | Connection mode |
| `/domains/:domain/name-servers` | `ToggleControl` | Name server form |
| `/domains/:domain/security` | `ToggleControl` | DNSSEC |
| `/domains/contact-info` | `ToggleControl` | Contact privacy |
| `/plugins/manage/:pluginId` | `ToggleControl` | Plugin field toggle |
| `/plugins/scheduled-updates` | `FormToggle` | Schedule list |
| `/plugins/scheduled-updates/new` | `RadioControl` | Frequency selection |
| `/plugins/scheduled-updates/edit/:scheduleId` | `RadioControl`, `FormToggle` | |
| `/me/preferences/privacy` | `ToggleControl` | Usage info, do-not-sell |
| `/me/preferences/mcp` | `ToggleControl` | MCP hub |
| `/me/preferences/mcp/setup` | `ToggleControl` | |
| `/me/preferences/mcp/read`, `/write` | `ToggleControl` | |
| `/me/notifications/sites` | `ToggleControl` | Per-site notifications |
| `/me/notifications/emails` | `ToggleControl` | |
| `/me/notifications/comments` | `ToggleControl` | |
| `/me/notifications/extras` | `ToggleControl` | On-this-day, achievements |
| `/me/security/two-step-auth` | `ToggleControl` | Enhanced security |
| `/me/billing/purchases/:purchaseId` | `ToggleControl` | Purchase settings |
| `/me/billing/purchases/:purchaseId/cancel` | `RadioControl` | Cancel flow steps |
| `/me/billing/purchases/:purchaseId/cancel` | `ToggleControl` | Atomic revert step |
| `/me/account` | `RadioControl` | Username update |
| `/me/billing/monetize-subscriptions/:subscriptionId` | `ToggleControl` | |

---

## Jetpack Cloud

| URL | Component | Notes |
|---|---|---|
| `/dashboard` | `ToggleControl` | Downtime monitoring activate toggle |
| `/dashboard` (site row) | `ToggleControl` | Notification settings (email/SMS/push) |
| `/plugins/:plugin` | `ToggleControl` | Plugin action (if routed through cloud) |

---

## A8C for Agencies

| URL | Component | Notes |
|---|---|---|
| `/marketplace/hosting/pressable` | `RadioControl` | Plan selection filter |
| `/marketplace/checkout` | `ToggleControl` | Referral toggle |
| `/marketplace/products` | `ToggleControl` | Term pricing toggle |
| `/woopayments/dashboard` | `RadioControl` | Add WooPayments to site table |
| `/woopayments/site-setup` | `ToggleControl` | |
| `/partner-directory/lead-matching` | `ToggleControl` | Lead matching prefs |

---

## Reader & subscriptions

| URL | Component | Notes |
|---|---|---|
| `/reader/users/me/achievements` | `ToggleControl` | Achievements settings popover |
| `/reader/users/me/settings` | `ToggleControl` | Profile/sites visibility cards |
| `/reader/atmosphere/:id/:tab` | `ToggleControl` | Interaction settings |
| `/reader/mastodon/:id/:tab` (composer) | `ToggleControl` | Sensitive media toggle |
| `/reader/social` composer | `ToggleControl` | CW visibility controls |
| `/reader/subscriptions` | `ToggleControl` | Newsletter category subscribe |
| `/reader/subscriptions` | `FormToggle` | Per-row delivery toggle |
| `/subscriptions/site/:blogId` | `ToggleControl`, `FormToggle` | Subscription manager |
| `/subscriptions/settings` | `ToggleControl` | Email/comment notification toggles |

---

## Modals / overlays (no fixed URL)

These use WP toggles/radios but appear inside flows on multiple pages:

- Cancel purchase / auto-renewal surveys (`RadioControl`, `ToggleControl`)
- Earn plan/coupon modals (`ToggleControl`)
- Plugin install/manage dialogs (`ToggleControl`)
- Site preview links modal (`ToggleControl`)
- Jetpack staging sites management (`ToggleControl`)
- Backup retention management (`RadioControl` — custom radio input class)
- Survey container steps (`RadioControl`)

---

## Quick test shortlist

These are high-signal pages:

1. `/settings/discussion/:site` — many `ToggleControl`s
2. `/plugins/scheduled-updates/:site` — `FormToggle` + `RadioControl`
3. `/me/notifications` — toggles across tabs
4. `/domains/manage/:site/:domain/edit` — toggles + radios
5. `/sites/:site/logs` (dashboard) — DataViews auto-refresh toggle
6. `/me/billing/purchases/:purchaseId/cancel` (dashboard) — cancel `RadioControl`
7. `/reader/subscriptions` — `FormToggle` in list rows

</details>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
