### PR TITLE
odie-client: move EmailFallbackNotice in, decouple from useSupportStatus

### DIFF
--- a/packages/help-center/src/components/notices.tsx
+++ b/packages/help-center/src/components/notices.tsx
@@ -3,13 +3,9 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { useCanConnectToZendeskMessaging } from '@automattic/zendesk-client';
 import { Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Icon, info } from '@wordpress/icons';
 import { useEffect } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
 import { useFeatureConfig, useHelpCenterContext } from '../contexts/HelpCenterContext';
-import { useSupportStatus } from '../data/use-support-status';
 import useChatStatus from '../hooks/use-chat-status';
 import './notices.scss';
 import { HELP_CENTER_STORE } from '../stores';
@@ -58,43 +54,6 @@ export const BlockedZendeskNotice: React.FC = () => {
 				>
 					{ __( 'Learn more.', __i18n_text_domain__ ) }
 				</Button>
-			</p>
-		</div>
-	);
-};
-
-export const EmailFallbackNotice: React.FC = () => {
-	const navigate = useNavigate();
-	const { search } = useLocation();
-	const { data: supportStatus } = useSupportStatus();
-	const params = new URLSearchParams( search );
-	params.set( 'wapuuFlow', 'true' );
-	const url = '/contact-form?' + params.toString();
-
-	const title = supportStatus?.eligibility?.is_chat_restricted
-		? __( 'Live chat is currently unavailable.', __i18n_text_domain__ )
-		: __( 'Live chat is temporarily unavailable for scheduled maintenance.', __i18n_text_domain__ );
-
-	const message = __(
-		'Please reach out via <email>email</email> if you need assistance.',
-		__i18n_text_domain__
-	);
-
-	return (
-		<div className="help-center__notice email-fallback-notice">
-			<Icon icon={ info } className="help-center__notice-icon" />
-			<p>
-				<strong>{ title }</strong>
-				&nbsp;
-				{ createInterpolateElement( message, {
-					email: (
-						<Button
-							variant="link"
-							className="help-center__notice-link"
-							onClick={ () => navigate( url ) }
-						/>
-					),
-				} ) }
 			</p>
 		</div>
 	);

--- a/packages/odie-client/src/components/email-fallback-notice/index.tsx
+++ b/packages/odie-client/src/components/email-fallback-notice/index.tsx
@@ -1,0 +1,45 @@
+import { Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Icon, info } from '@wordpress/icons';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+interface EmailFallbackNoticeProps {
+	isChatRestricted?: boolean;
+}
+
+export const EmailFallbackNotice = ( { isChatRestricted }: EmailFallbackNoticeProps ) => {
+	const navigate = useNavigate();
+	const { search } = useLocation();
+	const params = new URLSearchParams( search );
+	params.set( 'wapuuFlow', 'true' );
+	const url = '/contact-form?' + params.toString();
+
+	const title = isChatRestricted
+		? __( 'Live chat is currently unavailable.', __i18n_text_domain__ )
+		: __( 'Live chat is temporarily unavailable for scheduled maintenance.', __i18n_text_domain__ );
+
+	const message = __(
+		'Please reach out via <email>email</email> if you need assistance.',
+		__i18n_text_domain__
+	);
+
+	return (
+		<div className="help-center__notice email-fallback-notice">
+			<Icon icon={ info } className="help-center__notice-icon" />
+			<p>
+				<strong>{ title }</strong>
+				&nbsp;
+				{ createInterpolateElement( message, {
+					email: (
+						<Button
+							variant="link"
+							className="help-center__notice-link"
+							onClick={ () => navigate( url ) }
+						/>
+					),
+				} ) }
+			</p>
+		</div>
+	);
+};

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -1,7 +1,6 @@
 import '@automattic/agenttic-ui/index.css';
 import { useInput } from '@automattic/agenttic-ui';
 import { HelpCenterSelect } from '@automattic/data-stores';
-import { EmailFallbackNotice } from '@automattic/help-center/src/components/notices';
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useConnectionStatusNotice } from '@automattic/zendesk-client';
 import { useSelect } from '@wordpress/data';
@@ -12,6 +11,7 @@ import Smooch from 'smooch';
 import { useOdieAssistantContext } from '../../context';
 import { useSendChatMessage } from '../../hooks';
 import { AgentUIFooter } from '../chat-footer';
+import { EmailFallbackNotice } from '../email-fallback-notice';
 import { useMessageSizeErrorNotice } from '../notices';
 import { useAttachmentHandler } from './use-attachment-handler';
 import { useSendMessageHandler } from './use-send-message-handler';
@@ -30,7 +30,8 @@ const getTextAreaPlaceholder = (
 
 export const OdieSendMessageButton = () => {
 	const divContainerRef = useRef< HTMLDivElement >( null );
-	const { trackEvent, chat, canConnectToZendesk, forceEmailSupport } = useOdieAssistantContext();
+	const { trackEvent, chat, canConnectToZendesk, forceEmailSupport, isChatRestricted } =
+		useOdieAssistantContext();
 	const cantTransferToZendesk =
 		( chat.messages?.[ chat.messages.length - 1 ]?.context?.flags?.forward_to_human_support &&
 			! canConnectToZendesk ) ??
@@ -177,7 +178,7 @@ export const OdieSendMessageButton = () => {
 		<>
 			<div className="odie-chat-message-input-container agenttic" ref={ divContainerRef }>
 				{ isEmailFallback ? (
-					<EmailFallbackNotice />
+					<EmailFallbackNotice isChatRestricted={ isChatRestricted } />
 				) : (
 					<AgentUIFooter
 						value={ inputValue }


### PR DESCRIPTION
## Proposed Changes

Move `EmailFallbackNotice` from `@automattic/help-center` into `@automattic/odie-client`, and decouple it from help-center's data layer:

* New component `packages/odie-client/src/components/email-fallback-notice/index.tsx`. It no longer calls help-center's `useSupportStatus`; instead it takes an `isChatRestricted?: boolean` prop (which only drove the notice title).
* `send-message-input` now renders the local component and passes `isChatRestricted` from `useOdieAssistantContext()`, which already exposes it.
* Removed `EmailFallbackNotice` (and its now-unused imports) from `@automattic/help-center`'s `notices.tsx`. `BlockedZendeskNotice` and the shared `help-center__notice` styles are unchanged.

## Why are these changes being made?

`EmailFallbackNotice` was only used by odie-client but lived in help-center and pulled in help-center's `useSupportStatus` hook. Moving it into odie and passing the one value it needs (`isChatRestricted`) as a prop removes odie's dependence on that help-center hook and keeps the component with its only consumer.

The component keeps the existing `help-center__notice` / `email-fallback-notice` class names, so its appearance is unchanged (odie always renders inside the Help Center, where those styles are loaded). No dependency or lockfile changes are needed — odie already uses `@wordpress/components` and `react-router-dom` elsewhere.

## Testing Instructions

### Calypso

1. Run `yarn start`.
2. Trigger the email-fallback state (Zendesk chat provider with email support forced) and confirm the "Live chat is …unavailable" notice renders in the message input as before, with the correct title for restricted vs. maintenance, and the email link opens the contact form.
3. Confirm no TypeScript/console errors.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
4. Trigger the same email-fallback state and confirm the notice renders and behaves as before.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
