### PR TITLE
Dashboard: offer creating a new site from a domain-only domain

### DIFF
--- a/client/dashboard/domains/domain-overview/featured-card-site.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-site.tsx
@@ -45,7 +45,7 @@ export default function FeaturedCardSite( { domain }: Props ) {
 			icon={ shouldShowAddAttachSite ? <Icon icon={ layout } /> : <SiteIcon site={ site } /> }
 			description={
 				shouldShowAddAttachSite ? (
-					__( 'Attach this domain name to an existing site.' )
+					__( 'Attach this domain name to a new or existing site.' )
 				) : (
 					<Truncate tooltip={ domain.site_slug } numberOfLines={ 1 }>
 						{ domain.site_slug }

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-other-site.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-other-site.tsx
@@ -17,6 +17,7 @@ import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { getCreateSiteFromDomainOnlyUrl } from '../../utils/domain-url';
 import { SelectSite } from './select-site';
 import type { Site } from '@automattic/api-core';
 
@@ -63,6 +64,17 @@ export default function DomainTransferToOtherSite() {
 						__( 'Attach %s to a site you’re an administrator of:' ),
 						domainName
 					) }
+					actions={
+						domain?.is_domain_only_site ? (
+							<Button
+								__next40pxDefaultSize
+								variant="primary"
+								href={ getCreateSiteFromDomainOnlyUrl( domain ) }
+							>
+								{ __( 'Add a new site' ) }
+							</Button>
+						) : undefined
+					}
 				/>
 			}
 		>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1558,7 +1558,7 @@ export default function PurchaseSettings() {
 				icon={ <Icon icon={ layout } /> }
 				title={ __( 'Attach to a site' ) }
 				heading={ __( 'No site attached' ) }
-				description={ __( 'Attach this domain name to an existing site.' ) }
+				description={ __( 'Attach this domain name to a new or existing site.' ) }
 				link={ `/domains/${ purchase.meta }/transfer/other-site` }
 				intent="upsell"
 			/>

--- a/client/dashboard/utils/domain-url.ts
+++ b/client/dashboard/utils/domain-url.ts
@@ -3,6 +3,7 @@ import { domainConnectionSetupRoute } from '../app/router/domains';
 import { getCurrentDashboard } from '../app/routing';
 import { isDashboardBackport } from './is-dashboard-backport';
 import { dashboardLink, redirectToDashboardLink, wpcomLink } from './link';
+import type { Domain } from '@automattic/api-core';
 
 export function getDomainConnectionSetupTemplateUrl() {
 	const domainConnectionSetupTemplateUrl = domainConnectionSetupRoute.fullPath.replace(
@@ -10,6 +11,13 @@ export function getDomainConnectionSetupTemplateUrl() {
 		'%s'
 	);
 	return dashboardLink( domainConnectionSetupTemplateUrl );
+}
+
+export function getCreateSiteFromDomainOnlyUrl( domain: Domain ) {
+	return addQueryArgs( wpcomLink( '/start/site-selected/' ), {
+		siteSlug: domain.site_slug,
+		siteId: domain.blog_id,
+	} );
 }
 
 export function getAddSiteDomainUrl( siteSlug: string ) {


### PR DESCRIPTION
Fixes DOTMSD-1423

## Proposed Changes

* Add an “Add a new site” action to the “Attach to another site” screen when the domain is a domain-only one. It links to the `site-selected` signup flow (the same destination Calypso uses for its “Add a new site” option), which lets the user pick a plan and turn the domain-only holding site into a real site.
* Update the “Attach to a site” card copy on the domain overview and purchase settings screens from “…to an existing site.” to “…to a new or existing site.”

## Why are these changes being made?

* A user who buys just a domain currently has no way to create a site (or purchase hosting) for it from the new dashboard: every entry point only offers attaching the domain to an *existing* site, which is a dead end for users whose domain-only domain is their only "site". Calypso offered an “Add site” button for this case; the new dashboard lost that path.
* All entry points (domain overview card, the “Attach site” link in the domains list, the purchase settings card, and the transfer options screen) funnel into the same “Attach to another site” screen, so surfacing the action there covers them all — including users with zero sites, who otherwise see an empty site picker.

## Testing Instructions

1. Use an account that owns a domain-only domain (a domain not attached to any site) and open the v2 dashboard.
2. Go to **Domains** and click **Attach site** on the domain-only domain (or open the domain, then click the **Attach to a site** card).
3. Verify the “Attach to another site” screen shows an **Add a new site** button in the header, and that it leads to the plan selection step of the `site-selected` flow for the domain’s holding site.
4. Verify the button does not appear when reaching the same screen for a domain that is already attached to a regular site (e.g. via **Transfer** → **To another WordPress.com site**).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)