### PR TITLE
Add publishConfig access:public to api-core, calypso-e2e, jest-circus-allure-reporter

### DIFF
--- a/packages/api-core/package.json
+++ b/packages/api-core/package.json
@@ -8,6 +8,9 @@
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
 	"types": "dist/types/index.d.ts",
+	"publishConfig": {
+		"access": "public"
+	},
 	"calypso:src": "src/index.ts",
 	"exports": {
 		".": {

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -5,6 +5,9 @@
 	"main": "dist/cjs/src/index.js",
 	"module": "dist/esm/src/index.js",
 	"types": "dist/types/src/index.d.ts",
+	"publishConfig": {
+		"access": "public"
+	},
 	"author": "Automattic Inc.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",

--- a/packages/jest-circus-allure-reporter/package.json
+++ b/packages/jest-circus-allure-reporter/package.json
@@ -6,6 +6,9 @@
 	"main": "dist/esm/src/index.js",
 	"module": "dist/esm/src/index.js",
 	"types": "dist/types/src/index.d.ts",
+	"publishConfig": {
+		"access": "public"
+	},
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Proposed Changes

Add `"publishConfig": { "access": "public" }` to three published `@automattic`-scoped packages that were missing it:

* `@automattic/api-core`
* `@automattic/calypso-e2e`
* `@automattic/jest-circus-allure-reporter`

## Why are these changes being made?

Scoped npm packages default to **restricted** (private) on publish. Without `publishConfig.access: public`, `yarn npm publish` fails with `402 "You must sign up for private packages"` (surfaced while publishing the dependency-hygiene release). The other published packages in the monorepo already declare `{ access: public }`; this brings these three in line. (`i18n-calypso` is unscoped, so it is public by default and needs no change.)

## Testing Instructions

* `yarn npm publish` on each of the three packages no longer 402s on access (requires npm auth).
* No runtime/source changes — `publishConfig` only affects publishing.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
