### PR TITLE
zendesk-client: add publishConfig access:public

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,11 +4,6 @@ nodeLinker: node-modules
 enableGlobalCache: true
 yarnPath: .yarn/releases/yarn-4.0.2.cjs
 
-# Installs read through Yarn's mirror (npmRegistryServer, default
-# registry.yarnpkg.com), but publishing must target npm directly — the mirror is
-# read-only and rejects PUT. Publish-only; does not affect installs.
-npmPublishRegistry: "https://registry.npmjs.org"
-
 ### Log filters to discard irrelevant warnings. ###
 logFilters:
   # WordPress packages often have transitive dependencies with incorrect react-related peer dependencies.

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,6 +4,11 @@ nodeLinker: node-modules
 enableGlobalCache: true
 yarnPath: .yarn/releases/yarn-4.0.2.cjs
 
+# Installs read through Yarn's mirror (npmRegistryServer, default
+# registry.yarnpkg.com), but publishing must target npm directly — the mirror is
+# read-only and rejects PUT. Publish-only; does not affect installs.
+npmPublishRegistry: "https://registry.npmjs.org"
+
 ### Log filters to discard irrelevant warnings. ###
 logFilters:
   # WordPress packages often have transitive dependencies with incorrect react-related peer dependencies.

--- a/packages/zendesk-client/package.json
+++ b/packages/zendesk-client/package.json
@@ -6,6 +6,9 @@
 	"module": "dist/esm/index.js",
 	"calypso:src": "src/index.ts",
 	"types": "dist/types",
+	"publishConfig": {
+		"access": "public"
+	},
 	"exports": {
 		".": {
 			"calypso:src": "./src/index.ts",


### PR DESCRIPTION
## Proposed Changes

Add `publishConfig: { access: public }` to `@automattic/zendesk-client`.

## Why are these changes being made?

`@automattic/zendesk-client` is a published scoped package but was missing `publishConfig`, so `yarn npm publish` would try to publish it as restricted (private) and npm rejects with `402`. The other published scoped packages already declare `{ access: public }` — this is a companion to #112694, which fixed api-core / calypso-e2e / jest-circus-allure-reporter but overlooked this one.

## Testing Instructions

* `@automattic/zendesk-client` no longer 402s on access when published (requires npm auth).
* No runtime/source changes — `publishConfig` only affects publishing.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?