### PR TITLE
Reader: show 404 for unrecognized Reader paths instead of hanging

### DIFF
--- a/client/reader/atmosphere/index.tsx
+++ b/client/reader/atmosphere/index.tsx
@@ -1,8 +1,8 @@
 import './style.scss';
 
-import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sidebar } from 'calypso/reader/controller';
+import { readerPage } from 'calypso/reader/lib/reader-router';
 import {
 	atmosphereLanding,
 	atmosphereConnect,
@@ -16,43 +16,49 @@ import {
 } from './controller';
 
 export default function () {
-	page( '/reader/atmosphere', sidebar, atmosphereLanding, makeLayout, clientRender );
-	page( '/reader/atmosphere/connect', sidebar, atmosphereConnect, makeLayout, clientRender );
-	page( '/reader/atmosphere/:id(\\d+)', atmosphereIdRedirect );
-	page(
+	readerPage( '/reader/atmosphere', sidebar, atmosphereLanding, makeLayout, clientRender );
+	readerPage( '/reader/atmosphere/connect', sidebar, atmosphereConnect, makeLayout, clientRender );
+	readerPage( '/reader/atmosphere/:id(\\d+)', atmosphereIdRedirect );
+	readerPage(
 		'/reader/atmosphere/:id(\\d+)/thread/:did/:rkey',
 		sidebar,
 		atmosphereThread,
 		makeLayout,
 		clientRender
 	);
-	page(
+	readerPage(
 		'/reader/atmosphere/:id(\\d+)/profile/:actor',
 		sidebar,
 		atmosphereProfile,
 		makeLayout,
 		clientRender
 	);
-	page(
+	readerPage(
 		'/reader/atmosphere/:id(\\d+)/profile/:actor/followers',
 		sidebar,
 		atmosphereProfileFollowers,
 		makeLayout,
 		clientRender
 	);
-	page(
+	readerPage(
 		'/reader/atmosphere/:id(\\d+)/profile/:actor/following',
 		sidebar,
 		atmosphereProfileFollowing,
 		makeLayout,
 		clientRender
 	);
-	page(
+	readerPage(
 		'/reader/atmosphere/:id(\\d+)/tag/:hashtag',
 		sidebar,
 		atmosphereTagFeed,
 		makeLayout,
 		clientRender
 	);
-	page( '/reader/atmosphere/:id(\\d+)/:tab', sidebar, atmosphereAccount, makeLayout, clientRender );
+	readerPage(
+		'/reader/atmosphere/:id(\\d+)/:tab',
+		sidebar,
+		atmosphereAccount,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/reader/connections/index.tsx
+++ b/client/reader/connections/index.tsx
@@ -1,11 +1,11 @@
 import './style.scss';
 
-import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sidebar } from 'calypso/reader/controller';
+import { readerPage } from 'calypso/reader/lib/reader-router';
 import { connectionsLanding, connectionsNew } from './controller';
 
 export default function initConnections() {
-	page( '/reader/connections', sidebar, connectionsLanding, makeLayout, clientRender );
-	page( '/reader/connections/new', sidebar, connectionsNew, makeLayout, clientRender );
+	readerPage( '/reader/connections', sidebar, connectionsLanding, makeLayout, clientRender );
+	readerPage( '/reader/connections/new', sidebar, connectionsNew, makeLayout, clientRender );
 }

--- a/client/reader/conversations/index.js
+++ b/client/reader/conversations/index.js
@@ -1,10 +1,10 @@
-import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sidebar } from 'calypso/reader/controller';
+import { readerPage } from 'calypso/reader/lib/reader-router';
 import { conversations, conversationsA8c } from './controller';
 
 export default function () {
-	page( '/reader/conversations', sidebar, conversations, makeLayout, clientRender );
+	readerPage( '/reader/conversations', sidebar, conversations, makeLayout, clientRender );
 
-	page( '/reader/conversations/a8c', sidebar, conversationsA8c, makeLayout, clientRender );
+	readerPage( '/reader/conversations/a8c', sidebar, conversationsA8c, makeLayout, clientRender );
 }

--- a/client/reader/discover/index.web.jsx
+++ b/client/reader/discover/index.web.jsx
@@ -1,4 +1,3 @@
-import page from '@automattic/calypso-router';
 import { getAnyLanguageRouteParam } from '@automattic/i18n-utils';
 import AsyncLoad from 'calypso/components/async-load';
 import {
@@ -102,6 +101,5 @@ export default function ( router ) {
 	//
 	router( getDiscoverRoutes( anyLangParam ), ...commonMiddleware );
 
-	// Catch-all for unrecognized /discover/* paths.
-	page( '/discover/*', readerNotFound );
+	router( '/discover/*', readerNotFound );
 }

--- a/client/reader/discover/index.web.jsx
+++ b/client/reader/discover/index.web.jsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import { getAnyLanguageRouteParam } from '@automattic/i18n-utils';
 import AsyncLoad from 'calypso/components/async-load';
 import {
@@ -15,6 +16,7 @@ import {
 	trackUpdatesLoaded,
 	trackScrollPage,
 } from 'calypso/reader/controller-helper';
+import { readerNotFound } from 'calypso/reader/lib/reader-router';
 import { recordTrack } from 'calypso/reader/stats';
 import { getCurrentTabFromURL } from 'calypso/reader/utils';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -99,4 +101,7 @@ export default function ( router ) {
 
 	//
 	router( getDiscoverRoutes( anyLangParam ), ...commonMiddleware );
+
+	// Catch-all for unrecognized /discover/* paths.
+	page( '/discover/*', readerNotFound );
 }

--- a/client/reader/discover/test/index.web.jsx
+++ b/client/reader/discover/test/index.web.jsx
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment jsdom
+ */
+import page from '@automattic/calypso-router';
+import { readerNotFound } from 'calypso/reader/lib/reader-router';
+import initDiscover from '../index.web';
+
+jest.mock( '@automattic/calypso-router', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/i18n-utils', () => ( {
+	getAnyLanguageRouteParam: () => ':lang([a-z]{2,3}|[a-z]{2}-[a-z]{2})',
+} ) );
+
+jest.mock( 'calypso/components/async-load', () => () => null );
+
+jest.mock( 'calypso/controller', () => ( {
+	makeLayout: jest.fn(),
+	redirectInvalidLanguage: jest.fn(),
+	redirectLoggedOutToSignup: jest.fn(),
+	redirectWithoutLocaleParamInFrontIfLoggedIn: jest.fn(),
+	render: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/controller/shared', () => ( {
+	setLocaleMiddleware: jest.fn( () => jest.fn() ),
+} ) );
+
+jest.mock( 'calypso/lib/route', () => ( {
+	sectionify: jest.fn( ( path ) => path ),
+} ) );
+
+jest.mock( 'calypso/reader/controller', () => ( {
+	sidebar: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/reader/controller-helper', () => ( {
+	trackPageLoad: jest.fn(),
+	trackScrollPage: jest.fn(),
+	trackUpdatesLoaded: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/reader/lib/reader-router', () => ( {
+	readerNotFound: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/reader/stats', () => ( {
+	recordTrack: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/reader/utils', () => ( {
+	getCurrentTabFromURL: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/current-user/selectors', () => ( {
+	isUserLoggedIn: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/selectors/get-current-query-arguments', () => jest.fn() );
+jest.mock( 'calypso/state/selectors/get-current-route', () => jest.fn() );
+
+jest.mock( '../../lib/header-section', () => jest.fn() );
+
+jest.mock( '../discover-document-head', () => ( {
+	DiscoverDocumentHead: () => null,
+} ) );
+
+jest.mock( '../helper', () => ( {
+	FRESHLY_PRESSED_TAB: 'fresh',
+} ) );
+
+jest.mock( '../routes', () => ( {
+	DISCOVER_PREFIX: '/discover',
+	getDiscoverRoutes: jest.fn( () => [ '/discover' ] ),
+	getPrivateRoutes: jest.fn( () => [ '/discover/site' ] ),
+} ) );
+
+describe( 'reader discover routes', () => {
+	it( 'registers the discover catch-all through the injected router', () => {
+		const router = jest.fn();
+
+		initDiscover( router );
+
+		expect( router ).toHaveBeenCalledWith( '/discover/*', readerNotFound );
+		expect( page ).not.toHaveBeenCalledWith( '/discover/*', readerNotFound );
+	} );
+} );

--- a/client/reader/fediverse/index.tsx
+++ b/client/reader/fediverse/index.tsx
@@ -1,8 +1,8 @@
 import './style.scss';
 
-import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sidebar } from 'calypso/reader/controller';
+import { readerPage } from 'calypso/reader/lib/reader-router';
 import {
 	fediverseAccount,
 	fediverseAuthorProfile,
@@ -13,30 +13,36 @@ import {
 } from './controller';
 
 export default function () {
-	page( '/reader/fediverse', sidebar, fediverseLanding, makeLayout, clientRender );
-	page( '/reader/fediverse/:id(\\d+)', fediverseIdRedirect );
+	readerPage( '/reader/fediverse', sidebar, fediverseLanding, makeLayout, clientRender );
+	readerPage( '/reader/fediverse/:id(\\d+)', fediverseIdRedirect );
 	// More specific `:id/profile/:actor` route registered before the
 	// generic `:id/:tab` so the actor segment takes precedence.
-	page(
+	readerPage(
 		'/reader/fediverse/:id(\\d+)/profile/:actor',
 		sidebar,
 		fediverseAuthorProfile,
 		makeLayout,
 		clientRender
 	);
-	page(
+	readerPage(
 		'/reader/fediverse/:id(\\d+)/profile/:actor/followers',
 		sidebar,
 		fediverseProfileFollowers,
 		makeLayout,
 		clientRender
 	);
-	page(
+	readerPage(
 		'/reader/fediverse/:id(\\d+)/profile/:actor/following',
 		sidebar,
 		fediverseProfileFollowing,
 		makeLayout,
 		clientRender
 	);
-	page( '/reader/fediverse/:id(\\d+)/:tab', sidebar, fediverseAccount, makeLayout, clientRender );
+	readerPage(
+		'/reader/fediverse/:id(\\d+)/:tab',
+		sidebar,
+		fediverseAccount,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/reader/full-post/index.js
+++ b/client/reader/full-post/index.js
@@ -1,11 +1,11 @@
-import page from '@automattic/calypso-router';
 import { makeLayout, redirectLoggedOutToSignup, render as clientRender } from 'calypso/controller';
 import { blogDiscoveryByFeedId } from 'calypso/reader/controller';
+import { readerPage } from 'calypso/reader/lib/reader-router';
 import { blogPost, feedPost } from './controller';
 
 export default function () {
 	// Feed full post
-	page(
+	readerPage(
 		'/reader/feeds/:feed/posts/:post',
 		blogDiscoveryByFeedId,
 		redirectLoggedOutToSignup,
@@ -15,7 +15,7 @@ export default function () {
 	);
 
 	// Blog full post
-	page(
+	readerPage(
 		'/reader/blogs/:blog/posts/:post',
 		redirectLoggedOutToSignup,
 		blogPost,

--- a/client/reader/index.ts
+++ b/client/reader/index.ts
@@ -30,6 +30,7 @@ import {
 	loadNewSubscriptionPage,
 } from './controller';
 import postCacheMiddleware from './data/post/middleware';
+import { readerNotFound } from './lib/reader-router';
 import {
 	createList,
 	deleteList,
@@ -218,6 +219,12 @@ export default async function (): Promise< void > {
 	);
 
 	setupReaderRedirects();
+
+	// Catch-all: render a 404 for unrecognized /reader/* and /read/* paths instead of
+	// hanging. `readerNotFound` yields to sibling reader sections (search,
+	// conversations, …) that own the path, so only truly unknown paths render the 404.
+	page( '/reader/*', readerNotFound );
+	page( '/read/*', readerNotFound );
 }
 
 /**

--- a/client/reader/lib/reader-router.ts
+++ b/client/reader/lib/reader-router.ts
@@ -1,0 +1,38 @@
+import { createRouteRegistry, type Context } from '@automattic/calypso-router';
+import { makeLayout, notFound, render as clientRender } from 'calypso/controller';
+import { composeHandlers } from 'calypso/controller/shared';
+import { sidebar } from 'calypso/reader/controller';
+
+const readerRoutes = createRouteRegistry();
+
+/**
+ * Drop-in wrapper over `page` for Reader controllers: registers the route(s) and
+ * records them so `readerNotFound` can tell a real Reader path from a 404.
+ *
+ * Use it for Reader routes that live in a module OTHER than the one hosting the
+ * catch-all (i.e. the `/reader/*` siblings, whose routes are appended after the base
+ * `calypso/reader` catch-all). Routes that precede their own module's catch-all don't
+ * need it, and pass-through wildcards must stay on plain `page` so they aren't recorded.
+ */
+export const readerPage = readerRoutes.page;
+
+export function isKnownReaderRoute( path: string ): boolean {
+	return readerRoutes.has( path );
+}
+
+const renderReaderNotFound = composeHandlers( sidebar, notFound, makeLayout, clientRender );
+
+/**
+ * Catch-all for unrecognized Reader paths: yields when a real Reader route owns the
+ * path so dispatch reaches it; otherwise renders a 404 inside the Reader chrome.
+ *
+ * Register it with plain `page` (never `readerPage`) at each Reader top-level prefix,
+ * after that section's own routes.
+ */
+export function readerNotFound( context: Context, next: () => void ): void {
+	if ( isKnownReaderRoute( context.path ) ) {
+		next();
+		return;
+	}
+	renderReaderNotFound( context, next );
+}

--- a/client/reader/lib/reader-router.ts
+++ b/client/reader/lib/reader-router.ts
@@ -1,4 +1,4 @@
-import { createRouteRegistry, type Context } from '@automattic/calypso-router';
+import { createRouteRegistry, type Context, type RouteRegistry } from '@automattic/calypso-router';
 import { makeLayout, notFound, render as clientRender } from 'calypso/controller';
 import { composeHandlers } from 'calypso/controller/shared';
 import { sidebar } from 'calypso/reader/controller';
@@ -14,7 +14,7 @@ const readerRoutes = createRouteRegistry();
  * `calypso/reader` catch-all). Routes that precede their own module's catch-all don't
  * need it, and pass-through wildcards must stay on plain `page` so they aren't recorded.
  */
-export const readerPage = readerRoutes.page;
+export const readerPage: RouteRegistry[ 'page' ] = readerRoutes.page;
 
 export function isKnownReaderRoute( path: string ): boolean {
 	return readerRoutes.has( path );

--- a/client/reader/lib/test/reader-router.ts
+++ b/client/reader/lib/test/reader-router.ts
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import page, { createRouteRegistry } from '@automattic/calypso-router';
 import { readerPage, isKnownReaderRoute } from '../reader-router';
 
 describe( 'reader-router', () => {
@@ -31,10 +32,33 @@ describe( 'reader-router', () => {
 			const noop = () => {};
 			readerPage( '/reader/conversations', noop );
 			readerPage( '/reader/feeds/:feed/posts/:post', noop );
+			readerPage( '/reader/conversations', noop );
+			readerPage( '/reader/feeds/:feed/posts/:post', noop );
 
 			expect( isKnownReaderRoute( '/reader/conversations' ) ).toBe( true );
 			expect( isKnownReaderRoute( '/reader/feeds/123/posts/456' ) ).toBe( true );
 			expect( isKnownReaderRoute( '/reader/unknown' ) ).toBe( false );
+		} );
+
+		it( 'records regular expression routes', () => {
+			const route = /^\/reader\/regex$/;
+			const noop = () => {};
+			const registry = createRouteRegistry();
+
+			expect( () => registry.page( route, noop ) ).not.toThrow();
+			expect( registry.has( '/reader/regex' ) ).toBe( true );
+			expect( registry.has( '/reader/regex/extra' ) ).toBe( false );
+		} );
+
+		it( 'matches using the wrapped page instance strict setting', () => {
+			const router = page.create();
+			router.strict( true );
+			const registry = createRouteRegistry( router );
+
+			registry.page( '/reader/strict', () => {} );
+
+			expect( registry.has( '/reader/strict' ) ).toBe( true );
+			expect( registry.has( '/reader/strict/' ) ).toBe( false );
 		} );
 	} );
 } );

--- a/client/reader/lib/test/reader-router.ts
+++ b/client/reader/lib/test/reader-router.ts
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+import { readerPage, isKnownReaderRoute } from '../reader-router';
+
+describe( 'reader-router', () => {
+	describe( 'isKnownReaderRoute', () => {
+		it( 'matches recorded static and parameterized routes like page.js', () => {
+			const noop = () => {};
+			readerPage( '/reader/conversations', noop );
+			readerPage( '/reader/feeds/:feed/posts/:post', noop );
+			readerPage( '/reader/spaces/:slug/:tab', noop );
+
+			// Known: exact static route and parameterized routes with real segments.
+			expect( isKnownReaderRoute( '/reader/conversations' ) ).toBe( true );
+			expect( isKnownReaderRoute( '/reader/feeds/123/posts/456' ) ).toBe( true );
+			expect( isKnownReaderRoute( '/reader/spaces/design/discover' ) ).toBe( true );
+
+			// Query strings and a trailing slash are ignored when matching.
+			expect( isKnownReaderRoute( '/reader/conversations?ref=x' ) ).toBe( true );
+			expect( isKnownReaderRoute( '/reader/conversations/' ) ).toBe( true );
+			expect( isKnownReaderRoute( '/reader/feeds/123/posts/456/' ) ).toBe( true );
+
+			// Unknown: deeper unmatched paths and paths no recorded route owns.
+			expect( isKnownReaderRoute( '/reader/conversations/garbage' ) ).toBe( false );
+			expect( isKnownReaderRoute( '/reader/feeds/123/posts/456/garbage' ) ).toBe( false );
+			expect( isKnownReaderRoute( '/reader/totally-unknown' ) ).toBe( false );
+		} );
+
+		it( 'is idempotent when the same routes are re-registered (dev hot reload)', () => {
+			const noop = () => {};
+			readerPage( '/reader/conversations', noop );
+			readerPage( '/reader/feeds/:feed/posts/:post', noop );
+
+			expect( isKnownReaderRoute( '/reader/conversations' ) ).toBe( true );
+			expect( isKnownReaderRoute( '/reader/feeds/123/posts/456' ) ).toBe( true );
+			expect( isKnownReaderRoute( '/reader/unknown' ) ).toBe( false );
+		} );
+	} );
+} );

--- a/client/reader/liked-stream/index.js
+++ b/client/reader/liked-stream/index.js
@@ -1,8 +1,12 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sidebar } from 'calypso/reader/controller';
+import { readerNotFound } from 'calypso/reader/lib/reader-router';
 import { likes } from './controller';
 
 export default function () {
 	page( '/activities/likes', sidebar, likes, makeLayout, clientRender );
+
+	// Catch-all for unrecognized /activities/* paths.
+	page( '/activities/*', readerNotFound );
 }

--- a/client/reader/mastodon/index.tsx
+++ b/client/reader/mastodon/index.tsx
@@ -1,8 +1,8 @@
 import './style.scss';
 
-import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sidebar } from 'calypso/reader/controller';
+import { readerPage } from 'calypso/reader/lib/reader-router';
 import {
 	mastodonLanding,
 	mastodonConnect,
@@ -17,50 +17,56 @@ import {
 } from './controller';
 
 export default function () {
-	page( '/reader/mastodon', sidebar, mastodonLanding, makeLayout, clientRender );
-	page( '/reader/mastodon/connect', sidebar, mastodonConnect, makeLayout, clientRender );
-	page(
+	readerPage( '/reader/mastodon', sidebar, mastodonLanding, makeLayout, clientRender );
+	readerPage( '/reader/mastodon/connect', sidebar, mastodonConnect, makeLayout, clientRender );
+	readerPage(
 		'/reader/mastodon/oauth-callback',
 		sidebar,
 		mastodonOauthCallback,
 		makeLayout,
 		clientRender
 	);
-	page( '/reader/mastodon/:id(\\d+)', mastodonIdRedirect );
-	page(
+	readerPage( '/reader/mastodon/:id(\\d+)', mastodonIdRedirect );
+	readerPage(
 		'/reader/mastodon/:id(\\d+)/thread/:status_id',
 		sidebar,
 		mastodonThread,
 		makeLayout,
 		clientRender
 	);
-	page(
+	readerPage(
 		'/reader/mastodon/:id(\\d+)/profile/:actor',
 		sidebar,
 		mastodonProfile,
 		makeLayout,
 		clientRender
 	);
-	page(
+	readerPage(
 		'/reader/mastodon/:id(\\d+)/profile/:actor/followers',
 		sidebar,
 		mastodonProfileFollowers,
 		makeLayout,
 		clientRender
 	);
-	page(
+	readerPage(
 		'/reader/mastodon/:id(\\d+)/profile/:actor/following',
 		sidebar,
 		mastodonProfileFollowing,
 		makeLayout,
 		clientRender
 	);
-	page(
+	readerPage(
 		'/reader/mastodon/:id(\\d+)/tag/:hashtag',
 		sidebar,
 		mastodonTagFeed,
 		makeLayout,
 		clientRender
 	);
-	page( '/reader/mastodon/:id(\\d+)/:tab', sidebar, mastodonAccount, makeLayout, clientRender );
+	readerPage(
+		'/reader/mastodon/:id(\\d+)/:tab',
+		sidebar,
+		mastodonAccount,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/reader/notifications/index.jsx
+++ b/client/reader/notifications/index.jsx
@@ -1,11 +1,11 @@
-import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sidebar } from 'calypso/reader/controller';
+import { readerPage } from 'calypso/reader/lib/reader-router';
 import { notifications } from './controller';
 
 export default function () {
 	// While this page is no longer shown via sidebar navigation, it is still in use as users with
 	// 3PCs disabled are redirected to this when clicking the notification bell when outside
 	// Calypso.
-	page( '/reader/notifications', sidebar, notifications, makeLayout, clientRender );
+	readerPage( '/reader/notifications', sidebar, notifications, makeLayout, clientRender );
 }

--- a/client/reader/saved-stream/index.js
+++ b/client/reader/saved-stream/index.js
@@ -1,11 +1,11 @@
 import { isEnabled } from '@automattic/calypso-config';
-import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sidebar } from 'calypso/reader/controller';
+import { readerPage } from 'calypso/reader/lib/reader-router';
 import { saved } from './controller';
 
 export default function () {
 	if ( isEnabled( 'reader/saved-posts' ) ) {
-		page( '/read/saved', sidebar, saved, makeLayout, clientRender );
+		readerPage( '/read/saved', sidebar, saved, makeLayout, clientRender );
 	}
 }

--- a/client/reader/search/index.js
+++ b/client/reader/search/index.js
@@ -8,6 +8,7 @@ import {
 } from 'calypso/controller';
 import { setLocaleMiddleware } from 'calypso/controller/shared';
 import { sidebar } from 'calypso/reader/controller';
+import { readerPage } from 'calypso/reader/lib/reader-router';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { fetchTrendingTags } from '../tags/controller';
 import { search } from './controller';
@@ -27,7 +28,7 @@ export default function () {
 	// Invalid language
 	page( `/${ anyLangParam }/reader/search/`, redirectInvalidLanguage );
 
-	page(
+	readerPage(
 		[ '/reader/search', `/${ langParam }/reader/search` ],
 		redirectWithoutLocaleParamInFrontIfLoggedIn,
 		setLocaleMiddleware(),

--- a/client/reader/spaces/index.tsx
+++ b/client/reader/spaces/index.tsx
@@ -1,13 +1,13 @@
 import './style.scss';
 
-import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sidebar } from 'calypso/reader/controller';
+import { readerPage } from 'calypso/reader/lib/reader-router';
 import { spaces } from './controller';
 
 // Default export required: the section loader invokes `module.default`
 // (see `client/sections-middleware.js`).
 export default function initSpaces() {
-	page( '/reader/spaces/:slug', sidebar, spaces, makeLayout, clientRender );
-	page( '/reader/spaces/:slug/:tab', sidebar, spaces, makeLayout, clientRender );
+	readerPage( '/reader/spaces/:slug', sidebar, spaces, makeLayout, clientRender );
+	readerPage( '/reader/spaces/:slug/:tab', sidebar, spaces, makeLayout, clientRender );
 }

--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -9,6 +9,7 @@ import {
 import { setLocaleMiddleware } from 'calypso/controller/shared';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { sidebar } from 'calypso/reader/controller';
+import { readerNotFound } from 'calypso/reader/lib/reader-router';
 import { tagListing } from './controller';
 
 const redirectHashtaggedTags = ( context, next ) => {
@@ -46,4 +47,7 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
+
+	// Catch-all for unrecognized /tag/* paths (after the specific /tag/:tag route).
+	page( '/tag/*', readerNotFound );
 }

--- a/client/reader/tag-stream/test/index.js
+++ b/client/reader/tag-stream/test/index.js
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment jsdom
+ */
+import page from '@automattic/calypso-router';
+import { readerNotFound } from 'calypso/reader/lib/reader-router';
+import initTagStream from '../index';
+
+jest.mock( '@automattic/calypso-router', () => {
+	const pageMock = jest.fn();
+	pageMock.redirect = jest.fn();
+	return {
+		__esModule: true,
+		default: pageMock,
+	};
+} );
+
+jest.mock( '@automattic/i18n-utils', () => ( {
+	getAnyLanguageRouteParam: () => ':lang([a-z]{2,3}|[a-z]{2}-[a-z]{2})',
+	getLanguageRouteParam: () => ':lang(en|fr)?',
+} ) );
+
+jest.mock( 'calypso/controller', () => ( {
+	makeLayout: jest.fn(),
+	redirectInvalidLanguage: jest.fn(),
+	redirectWithoutLocaleParamInFrontIfLoggedIn: jest.fn(),
+	render: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/controller/shared', () => ( {
+	setLocaleMiddleware: jest.fn( () => jest.fn() ),
+} ) );
+
+jest.mock( 'calypso/lib/reader/is-reader-tag-embed-page', () => jest.fn( () => false ) );
+
+jest.mock( 'calypso/reader/controller', () => ( {
+	sidebar: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/reader/lib/reader-router', () => ( {
+	readerNotFound: jest.fn(),
+} ) );
+
+jest.mock( '../controller', () => ( {
+	tagListing: jest.fn(),
+} ) );
+
+describe( 'reader tag stream routes', () => {
+	beforeEach( () => {
+		page.mockClear();
+	} );
+
+	it( 'registers the tag catch-all', () => {
+		initTagStream();
+
+		expect( page ).toHaveBeenCalledWith( '/tag/*', readerNotFound );
+	} );
+} );

--- a/client/reader/tags/index.web.js
+++ b/client/reader/tags/index.web.js
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
 import {
 	makeLayout,
@@ -6,6 +7,7 @@ import {
 } from 'calypso/controller';
 import { setLocaleMiddleware } from 'calypso/controller/shared';
 import { sidebar } from 'calypso/reader/controller';
+import { readerNotFound } from 'calypso/reader/lib/reader-router';
 import { tagsListing, fetchTrendingTags, fetchAlphabeticTags } from './controller';
 
 export default function ( router ) {
@@ -22,4 +24,7 @@ export default function ( router ) {
 		makeLayout,
 		clientRender
 	);
+
+	// Catch-all for unrecognized /tags/* paths.
+	page( '/tags/*', readerNotFound );
 }

--- a/client/reader/tags/index.web.js
+++ b/client/reader/tags/index.web.js
@@ -1,4 +1,3 @@
-import page from '@automattic/calypso-router';
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
 import {
 	makeLayout,
@@ -25,6 +24,5 @@ export default function ( router ) {
 		clientRender
 	);
 
-	// Catch-all for unrecognized /tags/* paths.
-	page( '/tags/*', readerNotFound );
+	router( '/tags/*', readerNotFound );
 }

--- a/client/reader/tags/test/index.web.js
+++ b/client/reader/tags/test/index.web.js
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+import page from '@automattic/calypso-router';
+import { readerNotFound } from 'calypso/reader/lib/reader-router';
+import initTags from '../index.web';
+
+jest.mock( '@automattic/calypso-router', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/i18n-utils', () => ( {
+	getAnyLanguageRouteParam: () => ':lang([a-z]{2,3}|[a-z]{2}-[a-z]{2})',
+	getLanguageRouteParam: () => ':lang(en|fr)?',
+} ) );
+
+jest.mock( 'calypso/controller', () => ( {
+	makeLayout: jest.fn(),
+	redirectInvalidLanguage: jest.fn(),
+	redirectWithoutLocaleParamInFrontIfLoggedIn: jest.fn(),
+	render: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/controller/shared', () => ( {
+	setLocaleMiddleware: jest.fn( () => jest.fn() ),
+} ) );
+
+jest.mock( 'calypso/reader/controller', () => ( {
+	sidebar: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/reader/lib/reader-router', () => ( {
+	readerNotFound: jest.fn(),
+} ) );
+
+jest.mock( '../controller', () => ( {
+	fetchAlphabeticTags: jest.fn(),
+	fetchTrendingTags: jest.fn(),
+	tagsListing: jest.fn(),
+} ) );
+
+describe( 'reader tags routes', () => {
+	it( 'registers the tags catch-all through the injected router', () => {
+		const router = jest.fn();
+
+		initTags( router );
+
+		expect( router ).toHaveBeenCalledWith( '/tags/*', readerNotFound );
+		expect( page ).not.toHaveBeenCalledWith( '/tags/*', readerNotFound );
+	} );
+} );

--- a/client/reader/test/index.ts
+++ b/client/reader/test/index.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+import page from '@automattic/calypso-router';
+import initReader from '../index';
+import { readerNotFound } from '../lib/reader-router';
+
+jest.mock( '@automattic/calypso-router', () => {
+	const page = Object.assign( jest.fn(), { redirect: jest.fn() } );
+	return {
+		__esModule: true,
+		default: page,
+	};
+} );
+
+jest.mock( '@automattic/calypso-config', () => ( {
+	__esModule: true,
+	default: {
+		isEnabled: jest.fn( () => false ),
+	},
+} ) );
+
+jest.mock( '@automattic/i18n-utils', () => ( {
+	getAnyLanguageRouteParam: () => ':lang([a-z]{2,3}|[a-z]{2}-[a-z]{2})',
+	getLanguageRouteParam: () => ':lang(en|fr)?',
+} ) );
+
+jest.mock( 'redux-dynamic-middlewares', () => ( {
+	addMiddleware: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/controller', () => ( {
+	makeLayout: jest.fn(),
+	redirectLoggedOut: jest.fn(),
+	redirectLoggedOutToSignup: jest.fn(),
+	render: jest.fn(),
+	setSelectedSiteIdByOrigin: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/utils', () => ( {
+	setupRedirectRoutes: jest.fn(),
+} ) );
+
+jest.mock( '../controller', () => ( {
+	blogDiscoveryByFeedId: jest.fn(),
+	blogListing: jest.fn(),
+	commentSubscriptionsManager: jest.fn(),
+	feedDiscovery: jest.fn(),
+	feedListing: jest.fn(),
+	feedLookup: jest.fn(),
+	following: jest.fn(),
+	loadNewSubscriptionPage: jest.fn(),
+	pendingSubscriptionsManager: jest.fn(),
+	readA8C: jest.fn(),
+	readFollowingP2: jest.fn(),
+	redirectLoggedOutToDiscover: jest.fn(),
+	setupReadRoutes: jest.fn(),
+	sidebar: jest.fn(),
+	siteSubscription: jest.fn(),
+	siteSubscriptionsManager: jest.fn(),
+} ) );
+
+jest.mock( '../data/post/middleware', () => jest.fn() );
+
+jest.mock( '../lib/reader-router', () => ( {
+	readerNotFound: jest.fn(),
+} ) );
+
+jest.mock( '../list/controller', () => ( {
+	createList: jest.fn(),
+	deleteList: jest.fn(),
+	editList: jest.fn(),
+	editListItems: jest.fn(),
+	exportList: jest.fn(),
+	listListing: jest.fn(),
+} ) );
+
+jest.mock( '../on-this-day/controller', () => ( {
+	onThisDay: jest.fn(),
+} ) );
+
+jest.mock( '../user-profile/controller', () => ( {
+	redirectMeToCurrentUser: jest.fn(),
+	userProfile: jest.fn(),
+} ) );
+
+describe( 'reader routes', () => {
+	beforeEach( () => {
+		jest.mocked( page ).mockClear();
+	} );
+
+	it( 'registers catch-alls for reader and legacy read paths', async () => {
+		await initReader();
+
+		expect( page ).toHaveBeenCalledWith( '/reader/*', readerNotFound );
+		expect( page ).toHaveBeenCalledWith( '/read/*', readerNotFound );
+	} );
+} );

--- a/client/test/utils.test.ts
+++ b/client/test/utils.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+import page from '@automattic/calypso-router';
+import { setupRedirectRoutes } from '../utils';
+
+jest.mock( '@automattic/calypso-router', () => {
+	const page = Object.assign( jest.fn(), { redirect: jest.fn() } );
+	return {
+		__esModule: true,
+		default: page,
+	};
+} );
+
+describe( 'setupRedirectRoutes', () => {
+	beforeEach( () => {
+		jest.mocked( page ).mockClear();
+		jest.mocked( page.redirect ).mockClear();
+	} );
+
+	it( 'stops the middleware chain after a regex redirect matches', () => {
+		setupRedirectRoutes( [
+			{
+				path: '/reader/feeds/:feed_id/posts',
+				regex: /^\/reader\/feeds\/([0-9]+)\/posts$/i,
+				getRedirect: ( params ) => `/reader/feeds/${ params?.feed_id }`,
+			},
+		] );
+
+		const pageMock = page as unknown as jest.Mock;
+		const handler = pageMock.mock.calls[ 0 ][ 1 ] as (
+			context: { path: string; params: Record< string, string > },
+			next: () => void
+		) => void;
+		const next = jest.fn();
+
+		handler( { path: '/reader/feeds/123/posts', params: { feed_id: '123' } }, next );
+
+		expect( page.redirect ).toHaveBeenCalledWith( '/reader/feeds/123' );
+		expect( next ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/utils.ts
+++ b/client/utils.ts
@@ -70,6 +70,7 @@ export function setupRedirectRoutes( redirectRouteList: RedirectRouteList[] ): v
 		page( path, ( context, next ): void => {
 			if ( context.path.match( regex ) ) {
 				page.redirect( getRedirect( context.params ) + urlQueryParams );
+				return;
 			}
 
 			next();

--- a/packages/calypso-router/src/index.js
+++ b/packages/calypso-router/src/index.js
@@ -1179,3 +1179,41 @@ Route.prototype.match = function ( path, params ) {
  */
 const globalPage = createPage();
 export default globalPage;
+
+/**
+ * Create a registry that pairs route registration with a queryable record of the
+ * registered paths. `registry.page( path, ...callbacks )` behaves exactly like
+ * `page( path, ...callbacks )` but also records the path; `registry.has( path )`
+ * reports whether any recorded route matches `path`, using the same matching
+ * semantics as dispatch.
+ *
+ * Useful for section-scoped catch-alls that must distinguish real routes from
+ * unknown paths — e.g. lazily-loaded sibling sections registering under a shared
+ * prefix, where a plain catch-all would shadow routes appended later.
+ * @param {Function} pageInstance - Page instance to register routes on (defaults to the global instance)
+ * @returns {{ page: Function, has: Function }} The registry
+ */
+export function createRouteRegistry( pageInstance = globalPage ) {
+	const recordedPaths = new Set();
+	const matchers = [];
+
+	function record( path ) {
+		// Idempotent so re-registration (e.g. dev hot reload) doesn't grow the registry.
+		if ( recordedPaths.has( path ) ) {
+			return;
+		}
+		recordedPaths.add( path );
+		const route = new Route( path, null, pageInstance );
+		matchers.push( ( candidate ) => route.match( candidate, {} ) );
+	}
+
+	return {
+		page( path, ...callbacks ) {
+			( Array.isArray( path ) ? path : [ path ] ).forEach( record );
+			pageInstance( path, ...callbacks );
+		},
+		has( path ) {
+			return matchers.some( ( match ) => match( path ) );
+		},
+	};
+}

--- a/packages/calypso-router/src/index.js
+++ b/packages/calypso-router/src/index.js
@@ -1121,7 +1121,7 @@ Context.prototype.save = function () {
  * - `sensitive`    enable case-sensitive routes
  * - `strict`       enable strict matching for trailing slashes
  * @class
- * @param {string} path
+ * @param {string|RegExp} path
  * @param {Object=} options
  */
 function Route( path, options, pageInstance ) {
@@ -1183,9 +1183,9 @@ export default globalPage;
 /**
  * Create a registry that pairs route registration with a queryable record of the
  * registered paths. `registry.page( path, ...callbacks )` behaves exactly like
- * `page( path, ...callbacks )` but also records the path; `registry.has( path )`
- * reports whether any recorded route matches `path`, using the same matching
- * semantics as dispatch.
+ * `page( path, ...callbacks )` but also records string and RegExp paths;
+ * `registry.has( path )` reports whether any recorded route matches `path`,
+ * using the same matching semantics as dispatch.
  *
  * Useful for section-scoped catch-alls that must distinguish real routes from
  * unknown paths — e.g. lazily-loaded sibling sections registering under a shared
@@ -1195,7 +1195,29 @@ export default globalPage;
  */
 export function createRouteRegistry( pageInstance = globalPage ) {
 	const recordedPaths = new Set();
+	const staticPaths = new Set();
+	const strictStaticPaths = new Set();
 	const matchers = [];
+
+	function getStrict() {
+		return typeof pageInstance.strict === 'function' ? pageInstance.strict() : pageInstance._strict;
+	}
+
+	function isStaticPath( path ) {
+		return typeof path === 'string' && ! /[:*()]/.test( path );
+	}
+
+	function normalizeStaticPath( path, strict ) {
+		const qsIndex = path.indexOf( '?' );
+		let pathname = qsIndex !== -1 ? path.slice( 0, qsIndex ) : path;
+		pathname = decodeURIComponent( pathname ).toLowerCase();
+
+		if ( ! strict && pathname.length > 1 && pathname.endsWith( '/' ) ) {
+			return pathname.slice( 0, -1 );
+		}
+
+		return pathname;
+	}
 
 	function record( path ) {
 		// Idempotent so re-registration (e.g. dev hot reload) doesn't grow the registry.
@@ -1203,7 +1225,12 @@ export function createRouteRegistry( pageInstance = globalPage ) {
 			return;
 		}
 		recordedPaths.add( path );
-		const route = new Route( path, null, pageInstance );
+		const strict = getStrict();
+		if ( isStaticPath( path ) ) {
+			( strict ? strictStaticPaths : staticPaths ).add( normalizeStaticPath( path, strict ) );
+			return;
+		}
+		const route = new Route( path, { strict }, pageInstance );
 		matchers.push( ( candidate ) => route.match( candidate, {} ) );
 	}
 
@@ -1213,6 +1240,12 @@ export function createRouteRegistry( pageInstance = globalPage ) {
 			pageInstance( path, ...callbacks );
 		},
 		has( path ) {
+			if (
+				staticPaths.has( normalizeStaticPath( path, false ) ) ||
+				strictStaticPaths.has( normalizeStaticPath( path, true ) )
+			) {
+				return true;
+			}
 			return matchers.some( ( match ) => match( path ) );
 		},
 	};

--- a/packages/calypso-router/types/index.d.ts
+++ b/packages/calypso-router/types/index.d.ts
@@ -297,7 +297,7 @@ interface RouteRegistry {
 	 * Register route(s) like `page( path, ...callbacks )`, also recording the path
 	 * so `has()` can match against it.
 	 */
-	page( path: string | string[], ...callbacks: Callback[] ): void;
+	page( path: string | string[] | RegExp, ...callbacks: Callback[] ): void;
 	/**
 	 * Whether any recorded route matches `path` (same matching semantics as dispatch).
 	 */

--- a/packages/calypso-router/types/index.d.ts
+++ b/packages/calypso-router/types/index.d.ts
@@ -10,7 +10,7 @@ interface Page {
 	/**
 	 * Expose Route
 	 */
-	Route: Route;
+	Route: typeof Route;
 	/**
 	 * Expose Context
 	 */
@@ -186,9 +186,10 @@ interface Page {
 
 class Route {
 	/**
-	 * Initialize `Route` with the given HTTP `path` & `options`
+	 * Initialize `Route` with the given HTTP `path`, `options`, and owning `Page`
+	 * instance (this fork's constructor reads the instance's strict-matching mode).
 	 */
-	constructor( path: string, options?: RouteOptions ): Route;
+	constructor( path: string, options: RouteOptions | null | undefined, pageInstance: Page );
 	/**
 	 * Return route middleware with the given callback `fn()`.
 	 */
@@ -196,7 +197,7 @@ class Route {
 	/**
 	 * Check if this route matches `path`, if so populate `params`.
 	 */
-	match( path: string, params?: unknown ): boolean;
+	match( path: string, params?: Record< string, unknown > ): boolean;
 }
 
 interface RouteOptions {
@@ -291,6 +292,27 @@ class Context {
 
 const page: Page;
 
-export { Page, Callback, Context, Options, Route, RouteOptions };
+interface RouteRegistry {
+	/**
+	 * Register route(s) like `page( path, ...callbacks )`, also recording the path
+	 * so `has()` can match against it.
+	 */
+	page( path: string | string[], ...callbacks: Callback[] ): void;
+	/**
+	 * Whether any recorded route matches `path` (same matching semantics as dispatch).
+	 */
+	has( path: string ): boolean;
+}
+
+/**
+ * Create a registry that pairs route registration with a queryable record of the
+ * registered paths. Useful for section-scoped catch-alls that must distinguish
+ * real routes from unknown paths.
+ */
+function createRouteRegistry( pageInstance?: Page ): RouteRegistry;
+
+export { Page, Callback, Context, Options, Route, RouteOptions, RouteRegistry };
+
+export { createRouteRegistry };
 
 export default page;


### PR DESCRIPTION
Closes READ-130

## Proposed Changes

* Add `createRouteRegistry()` to `@automattic/calypso-router`: registers routes exactly like `page()` while also recording them, and answers `registry.has( path )` with the same matching semantics as dispatch.
* Add `client/reader/lib/reader-router.ts`, composing that registry into:
  * `readerPage` — a drop-in `page` wrapper used by the Reader's sibling section modules (search, conversations, notifications, connections, spaces, atmosphere, mastodon, fediverse, full-post, saved-stream) so their routes are recorded;
  * `readerNotFound` — a catch-all handler that yields (`next()`) when a recorded Reader route owns the path, and otherwise renders the standard "Page not found." view inside the Reader chrome (with the Reader sidebar when logged in).
* Register catch-alls at each Reader top-level prefix, after that section's own routes: `/reader/*` and `/read/*` (base reader module), `/discover/*`, `/tags/*`, `/tag/*`, and `/activities/*`.
* Fix the `calypso-router` type declarations: `Page.Route` is now the class (`typeof Route`), and `Route`'s constructor matches this fork's runtime signature (`path, options, pageInstance`).

## Why are these changes being made?

Visiting an unrecognized Reader URL (e.g. `/reader/asdfaljkaw34lkjbas`) hung forever with a console warning instead of showing a 404: a reader section matched the path and loaded its JS chunk, but no registered route rendered anything.

A bare `page( '/reader/*', notFound, … )` catch-all in the base reader module (the approach explored in #111264) is not enough — it introduces a shadowing bug. Reader routing is split across many lazily-loaded section modules, and the base `calypso/reader` section matches every `/reader/*` path, so it always loads first. Its catch-all is therefore appended to the router's dispatch list *before* the sibling modules' routes (`/reader/search`, `/reader/conversations`, full post, …), which only get appended later in the same dispatch. Since the render middleware is terminal, the catch-all would render a 404 and halt dispatch before the real route is ever reached.

The registry solves this: sibling modules register through `readerPage`, so the catch-all can distinguish a real Reader route (yield and let dispatch reach it) from a truly unknown path (render the 404). Recording is opt-in by design — pass-through wildcards and section loaders must not count as "known routes", and deliberate registration expresses exactly that intent. The mechanism lives in `@automattic/calypso-router` because it is pure routing logic, reusable by any other section group with the same lazy-loading layout; only the Reader-chrome 404 rendering stays in `client/reader`.

Added a regression test for the registry matching and idempotence.

## Testing Instructions

### Scenario 1 - Unknown Reader path shows a 404:
- Go to `/reader/asdfaljkaw34lkjbas`
- Check if you can see the "Page not found." view rendered inside the Reader layout (with the Reader sidebar when logged in), instead of a page that never loads

### Scenario 2 - Unknown sub-paths of other Reader surfaces show a 404:
- Go to `/reader/search/garbage`, `/reader/conversations/garbage`, `/read/garbage`, `/discover/garbage`, `/tags/garbage`, `/tag/foo/bar`, and `/activities/garbage`
- Check if you can see the "Page not found." view on each, with no hang and no console errors

### Scenario 3 - Valid Reader routes still render (fresh page loads):
- Go to each of `/reader`, `/reader/search`, `/reader/conversations`, `/reader/notifications`, `/reader/subscriptions`, `/discover`, `/tags`, `/tag/photography`, and `/activities/likes`, hard-reloading each URL
- Check if you can see each page render its real content, not a 404

### Scenario 4 - Full post and streams still render:
- Go to `/reader/feeds/:feed_id` for a feed you follow, then open one of its posts (`/reader/feeds/:feed_id/posts/:post_id`)
- Check if you can see the feed stream and the full post view render normally

### Scenario 5 - Redirects still win over the 404:
- Go to `/reader/following`, `/reader/blogs`, and `/reader/feeds`
- Check if you can see each redirect to `/reader` instead of showing a 404

### Scenario 6 - Client-side navigation mixes 404s and real routes:
- Go to `/reader`, then navigate to `/reader/search`, then to `/reader/garbage`, then to `/reader/conversations`
- Check if you can see the 404 only on `/reader/garbage`, with the surrounding routes rendering normally

### Scenario 7 - Logged out:
- In a private window, go to `/reader/garbage`
- Check if you can see the "Page not found." view (without the Reader sidebar), not a redirect to signup

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)