### PR TITLE
Run copy-assets via 'yarn run -T' in packages that invoked it bare

### DIFF
--- a/packages/block-renderer/package.json
+++ b/packages/block-renderer/package.json
@@ -32,7 +32,7 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && yarn run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/design-preview/package.json
+++ b/packages/design-preview/package.json
@@ -32,7 +32,7 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && yarn run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/global-styles/package.json
+++ b/packages/global-styles/package.json
@@ -35,7 +35,7 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && yarn run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -35,7 +35,7 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && yarn run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"test": "yarn jest",
 		"watch": "tsc --build ./tsconfig.json --watch"

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -51,7 +51,7 @@
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && yarn run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build"
 	}
 }

--- a/packages/support-articles/package.json
+++ b/packages/support-articles/package.json
@@ -32,7 +32,7 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && yarn run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},


### PR DESCRIPTION
## Proposed Changes

Change six packages to run `copy-assets` via `yarn run -T` instead of invoking it bare in their `build` script:

* `@automattic/block-renderer`
* `@automattic/design-preview`
* `@automattic/global-styles`
* `@automattic/odie-client`
* `@automattic/sites`
* `@automattic/support-articles`

`- ... && copy-assets` → `+ ... && yarn run -T copy-assets`

## Why are these changes being made?

`copy-assets` is a binary provided by `@automattic/calypso-build`. These six packages called it bare without declaring `@automattic/calypso-build`, so it only resolved via Yarn's hoisted `.bin` — a phantom dependency that breaks when the package is built outside the hoisted monorepo (e.g. `@automattic/sites` was reported broken).

`yarn run -T copy-assets` runs the tool from the top-level workspace, which is exactly how the other packages in the repo (agents-manager, data-stores, domain-search, onboarding, subscriber, …) already invoke it. This fixes resolution without pulling `@automattic/calypso-build` — and its `postcss`/`webpack` peer dependencies — into each package.

## Testing Instructions

* From any of the six packages, `yarn run -T copy-assets` resolves and runs (verified in `packages/sites`).
* `yarn build` in each package completes the asset-copy step.
* No dependency or lockfile changes.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
