### PR TITLE
domain-search: remove failing copyfiles (no styles/ folder)

### DIFF
--- a/packages/domain-search/package.json
+++ b/packages/domain-search/package.json
@@ -38,7 +38,7 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig-build.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig-build.json ./tsconfig-cjs.json && yarn run -T copy-assets && npx copyfiles ./styles/** dist",
+		"build": "tsc --build ./tsconfig-build.json ./tsconfig-cjs.json && yarn run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch",
 		"storybook:start": "storybook dev"


### PR DESCRIPTION
## Proposed Changes

Remove `&& npx copyfiles ./styles/** dist` from `@automattic/domain-search`'s `build` script.

## Why are these changes being made?

The command copies a top-level `styles/` folder into `dist`, but **domain-search has no `styles/` folder** — and never has. It was boilerplate carried in from the package's initial commit (#104428). `./styles/**` matches nothing, so `copyfiles` exits non-zero and fails the build.

The component stylesheets live in `src/**/style.scss` and are already copied into `dist` by `copy-assets` (the previous step in the build). Verified: after removing this command, `yarn build` succeeds and 64 `.scss` files still land in `dist/cjs` and `dist/esm`.

## Testing Instructions

* `cd packages/domain-search && yarn build` — completes successfully (previously failed on `copyfiles`).
* `find packages/domain-search/dist -name '*.scss'` — stylesheets are present (copied by `copy-assets`).
* No dependency or lockfile changes.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
