### PR TITLE
Dashboard: unify sidebar menu item styling for external links

### DIFF
--- a/client/dashboard/app/responsive-sidebar/sidebar.tsx
+++ b/client/dashboard/app/responsive-sidebar/sidebar.tsx
@@ -1,4 +1,3 @@
-import { __experimentalHStack as HStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { brush, envelope, globe, layout, plugins } from '@wordpress/icons';
 import { useRef } from 'react';
@@ -90,29 +89,14 @@ function PrimaryMenuSidebar() {
 					<SidebarMenuItem to="/plugins/scheduled-updates">
 						{ __( 'Scheduled updates' ) }
 					</SidebarMenuItem>
-					<SidebarMenuItem
-						href={ wpcomLink( '/plugins' ) }
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						<HStack justify="flex-start" spacing={ 1 }>
-							<span>{ __( 'Browse plugins' ) }</span>
-							<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
-						</HStack>
+					<SidebarMenuItem href={ wpcomLink( '/plugins' ) }>
+						{ __( 'Browse plugins' ) }
 					</SidebarMenuItem>
 				</SidebarExpandableMenuItem>
 			) }
 			{ supports.themes && (
-				<SidebarMenuItem
-					icon={ brush }
-					href={ wpcomLink( '/themes' ) }
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					<HStack justify="flex-start" spacing={ 1 }>
-						<span>{ __( 'Themes' ) }</span>
-						<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
-					</HStack>
+				<SidebarMenuItem icon={ brush } href={ wpcomLink( '/themes' ) }>
+					{ __( 'Themes' ) }
 				</SidebarMenuItem>
 			) }
 		</SidebarMenu>

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
@@ -38,7 +38,7 @@ export function SidebarExpandableMenuItem( {
 	}, [ isActive ] );
 
 	return (
-		<VStack className="dashboard-sidebar__expandable" spacing={ 1 }>
+		<VStack className="dashboard-sidebar__expandable" spacing={ isOpen ? 1 : 0 }>
 			<Button
 				className="dashboard-sidebar__menu-item"
 				variant="tertiary"

--- a/client/dashboard/components/sidebar/sidebar-menu-item.tsx
+++ b/client/dashboard/components/sidebar/sidebar-menu-item.tsx
@@ -1,4 +1,5 @@
-import { __experimentalHStack as HStack, __experimentalItem as Item } from '@wordpress/components';
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
 import { useAnalytics } from '../../app/analytics';
 import RouterLinkButton from '../../components/router-link-button';
@@ -9,8 +10,6 @@ import './sidebar-menu-item.scss';
 interface SidebarMenuItemProps {
 	to?: string;
 	href?: string;
-	target?: string;
-	rel?: string;
 	icon?: React.JSX.Element;
 	children: React.ReactNode;
 	activeOptions?: ActiveOptions;
@@ -19,8 +18,6 @@ interface SidebarMenuItemProps {
 export function SidebarMenuItem( {
 	to,
 	href,
-	target,
-	rel,
 	icon,
 	children,
 	activeOptions,
@@ -31,27 +28,37 @@ export function SidebarMenuItem( {
 		recordTracksEvent( 'calypso_dashboard_menu_item_click', { to: to ?? href ?? '' } );
 	};
 
+	const label = href ? (
+		<HStack justify="flex-start" spacing={ 1 }>
+			<span>{ children }</span>
+			<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
+		</HStack>
+	) : (
+		<span>{ children }</span>
+	);
+
 	const content = icon ? (
 		<HStack justify="flex-start" spacing={ 2 }>
 			<Icon icon={ icon } size={ 20 } />
-			<span>{ children }</span>
+			{ label }
 		</HStack>
 	) : (
-		children
+		label
 	);
 
 	if ( href ) {
 		return (
-			<Item
-				as="a"
+			<Button
 				className="dashboard-sidebar__menu-item"
+				variant="tertiary"
 				href={ href }
-				target={ target }
-				rel={ rel }
+				target="_blank"
+				rel="noopener noreferrer"
+				__next40pxDefaultSize
 				onClick={ handleClick }
 			>
 				{ content }
-			</Item>
+			</Button>
 		);
 	}
 


### PR DESCRIPTION
Related to p1784199460263259-slack-C08JZTRS6NA

## Proposed Changes

* Render sidebar menu items with an external `href` ("Browse plugins", "Themes ↗") as a `Button`, like the router-link items, instead of an `Item` anchor.
* Move the "opens in a new tab" ↗ indicator into `SidebarMenuItem` itself — it's rendered automatically whenever `href` is passed, so callers no longer hand-roll it.
* Drop the `target`/`rel` props: every `href` use case opens externally, so `target="_blank" rel="noopener noreferrer"` is now applied by the component.
* Remove the stray 4px gap under collapsed expandable menu items: the wrapper `VStack` kept its `spacing` even when the panel was collapsed to zero height, making collapsed expandable items taller than regular ones.

## Why are these changes being made?

* It was reported that "Browse plugins" and "Themes ↗" have a slightly different font weight from the other sidebar items. The cause: external-link items rendered as a plain anchor (`__experimentalItem as="a"`, regular weight), while router items render as a `Button` (`.components-button` → medium weight). The anchor branch also missed the `.components-button.dashboard-sidebar__menu-item` styles (full width, menu item color).
* Rendering both branches as Buttons makes external items visually identical to the rest of the menu, and centralizing the new-tab arrow keeps future external items consistent by construction.

## Testing Instructions

1. Run `yarn start-dashboard` and open the dashboard.
2. In the sidebar, expand **Plugins** and compare "Browse plugins" with "Manage plugins" / "Scheduled updates" — the font weight should now match.
3. Compare **Themes ↗** with **Sites** / **Domains** — font weight, hover state, and spacing should match.
4. Verify both external items still open in a new tab and show the ↗ indicator.
5. Collapse **Plugins** and check the vertical spacing between it and its neighbors matches the spacing between the other menu items; expand it again and check the sub-items still have their usual spacing.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
