### PR TITLE
Add auto-port dev scripts to run multiple Calypso instances in parallel

### DIFF
--- a/bin/with-free-port.js
+++ b/bin/with-free-port.js
@@ -1,0 +1,61 @@
+const { spawn } = require( 'child_process' );
+const net = require( 'net' );
+
+function isPortFree( port ) {
+	return new Promise( ( resolve ) => {
+		const server = net.createServer();
+		server.once( 'error', () => resolve( false ) );
+		server.once( 'listening', () => server.close( () => resolve( true ) ) );
+		// No host = all interfaces, matching how the dev server binds.
+		server.listen( port );
+	} );
+}
+
+async function findFreePort( base, tries = 50 ) {
+	for ( let port = base; port < base + tries; port++ ) {
+		// eslint-disable-next-line no-await-in-loop
+		if ( await isPortFree( port ) ) {
+			return port;
+		}
+	}
+	throw new Error( `No free port found between ${ base } and ${ base + tries }` );
+}
+
+async function main() {
+	const command = process.argv.slice( 2 );
+	if ( ! command.length ) {
+		console.error( 'Usage: node bin/with-free-port.js <command…>' );
+		process.exit( 1 );
+	}
+
+	const base = parseInt( process.env.PORT, 10 ) || 3000;
+	const port = await findFreePort( base );
+
+	if ( port !== base ) {
+		console.log( `\n⚠  Port ${ base } is in use — starting on ${ port }` );
+	}
+	console.log( `→ http://calypso.localhost:${ port }\n` );
+
+	const child = spawn( command.join( ' ' ), {
+		shell: true,
+		stdio: 'inherit',
+		env: { ...process.env, PORT: String( port ) },
+	} );
+
+	const forward = ( signal ) => child.kill( signal );
+	process.on( 'SIGINT', forward );
+	process.on( 'SIGTERM', forward );
+
+	child.on( 'exit', ( code, signal ) => {
+		if ( signal ) {
+			process.kill( process.pid, signal );
+		} else {
+			process.exit( code ?? 0 );
+		}
+	} );
+}
+
+main().catch( ( error ) => {
+	console.error( error.message );
+	process.exit( 1 );
+} );

--- a/client/dashboard/docs/dev-server.md
+++ b/client/dashboard/docs/dev-server.md
@@ -23,3 +23,16 @@ Runs only the multi-site dashboard. This command is faster than the above comman
 - `my.localhost:3000`
 - `my.woo.localhost:3000`
 - `my.a4a.localhost:3000`
+
+## Running multiple instances in parallel
+
+To run more than one instance at once (e.g. one per worktree), use the auto-port
+variants instead of a hardcoded `PORT`. They pick the first free port starting at
+`3000` and print the URL to open:
+
+- `yarn start-auto-port` — same as `yarn start`, on the next free port.
+- `yarn start-dashboard-auto-port` — same as `yarn start-dashboard`, on the next free port.
+
+Keep the `*.localhost` hostnames (only the port changes) so authentication via your
+logged-in WordPress.com session keeps working. Pass a custom base with
+`PORT=3100 yarn start-auto-port` to search upward from `3100`.

--- a/package.json
+++ b/package.json
@@ -112,6 +112,8 @@
 		"site-admin:storybook:start": "yarn workspace @automattic/site-admin run storybook:start",
 		"start": "check-node-version --package && node bin/welcome.js && node packages/calypso-doctor/cli.js --once && yarn run build-start && yarn run start-build",
 		"start:debug": "NODE_OPTIONS='--max-old-space-size=8192' SOURCEMAP='eval-source-map' yarn start",
+		"start-auto-port": "node bin/with-free-port.js yarn run start",
+		"start-dashboard-auto-port": "node bin/with-free-port.js yarn run start-dashboard",
 		"start-mock-wordpress-com": "MOCK_WORDPRESSDOTCOM=1 yarn run start",
 		"start-build": "BROWSERSLIST_ENV=evergreen node build/server.js | bunyan -o short",
 		"start-jetpack-cloud": "CALYPSO_ENV=jetpack-cloud-development yarn run start",


### PR DESCRIPTION
_No linked issue._

## Proposed Changes

* Add `bin/with-free-port.js`: a small wrapper that finds the first free port starting at `PORT || 3000` and runs the given command with `PORT` set (forwarding stdio, exit code and signals).
* Add `yarn start-auto-port` and `yarn start-dashboard-auto-port` scripts that use the wrapper.
* Document running multiple instances in parallel in `client/dashboard/docs/dev-server.md`.

## Why are these changes being made?

Every `yarn start` variant defaults to port `3000`, so starting a second instance (e.g. one per git worktree when working on several branches at once) fails with a port conflict and forces the developer to pick and set `PORT` by hand. These scripts auto-select the next free port so multiple dev instances run in parallel with no manual juggling, while keeping the `*.localhost` hostnames that the logged-in WordPress.com session auth depends on (only the port changes).

## Testing Instructions

### Scenario 1 - Second instance picks a free port:
- With one instance already running on `:3000`, run `yarn start-auto-port` from another worktree.
- Check that the console prints `Port 3000 is in use — starting on 3001` and `→ http://calypso.localhost:3001`, and the server boots on `3001`.

### Scenario 2 - Both instances reachable at once:
- Go to `http://calypso.localhost:3001/reader`
- Check that the Reader loads while the other instance at `http://calypso.localhost:3000/reader` is still reachable.

### Scenario 3 - Custom base port:
- Run `PORT=3100 yarn start-auto-port`
- Check that it starts on `3100` (or the next free port above it) and prints that URL.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
