### PR TITLE
Make @automattic/launchpad installable: un-private + declare deps for its tree

### DIFF
--- a/packages/api-queries/package.json
+++ b/packages/api-queries/package.json
@@ -39,21 +39,26 @@
 	},
 	"dependencies": {
 		"@automattic/api-core": "workspace:^",
+		"@automattic/calypso-config": "workspace:^",
 		"@automattic/calypso-support-session": "workspace:^",
+		"@github/webauthn-json": "^2.1.1",
 		"@tanstack/query-sync-storage-persister": "^5.83.0",
 		"@tanstack/react-query": "^5.83.0",
 		"@tanstack/react-query-persist-client": "^5.83.0",
+		"@tanstack/react-router": "^1.114.34",
 		"@wordpress/html-entities": "^4.48.0",
+		"deepmerge": "^4.3.1",
 		"fast-deep-equal": "^3.1.3",
 		"tslib": "^2.8.1"
+	},
+	"peerDependencies": {
+		"react": "^18.3.1 || ^19.0.0",
+		"react-dom": "^18.3.1 || ^19.0.0"
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"react": "^18.3.1",
+		"react-dom": "^18.3.1",
 		"typescript": "^6.0.3"
-	},
-	"private": true,
-	"peerDependencies": {
-		"react": "^18.3.1 || ^19.0.0"
 	}
 }

--- a/packages/calypso-support-session/package.json
+++ b/packages/calypso-support-session/package.json
@@ -38,11 +38,11 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
+		"debug": "^4.4.1",
 		"tslib": "^2.8.1"
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"typescript": "^6.0.3"
-	},
-	"private": true
+	}
 }

--- a/packages/js-utils/package.json
+++ b/packages/js-utils/package.json
@@ -17,7 +17,6 @@
 			"require": "./dist/cjs/index.js"
 		}
 	},
-	"private": true,
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Automattic/wp-calypso.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -254,18 +254,24 @@ __metadata:
   resolution: "@automattic/api-queries@workspace:packages/api-queries"
   dependencies:
     "@automattic/api-core": "workspace:^"
+    "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-support-session": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@github/webauthn-json": "npm:^2.1.1"
     "@tanstack/query-sync-storage-persister": "npm:^5.83.0"
     "@tanstack/react-query": "npm:^5.83.0"
     "@tanstack/react-query-persist-client": "npm:^5.83.0"
+    "@tanstack/react-router": "npm:^1.114.34"
     "@wordpress/html-entities": "npm:^4.48.0"
+    deepmerge: "npm:^4.3.1"
     fast-deep-equal: "npm:^3.1.3"
     react: "npm:^18.3.1"
+    react-dom: "npm:^18.3.1"
     tslib: "npm:^2.8.1"
     typescript: "npm:^6.0.3"
   peerDependencies:
     react: ^18.3.1 || ^19.0.0
+    react-dom: ^18.3.1 || ^19.0.0
   languageName: unknown
   linkType: soft
 
@@ -742,6 +748,7 @@ __metadata:
   resolution: "@automattic/calypso-support-session@workspace:packages/calypso-support-session"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
+    debug: "npm:^4.4.1"
     tslib: "npm:^2.8.1"
     typescript: "npm:^6.0.3"
   languageName: unknown


### PR DESCRIPTION
## Proposed Changes

Make `@automattic/launchpad` installable by a third party by closing the gaps in its dependency tree. This PR contains **all the code changes** required; the remaining step is publishing (see below).

Code changes here:
* Remove `private: true` from `@automattic/api-queries`, `@automattic/calypso-support-session`, `@automattic/js-utils` so they can be published.
* `api-queries`: declare deps it imported but didn't list — `@automattic/calypso-config`, `@github/webauthn-json` (^2.1.1), `@tanstack/react-router` (^1.114.34), `deepmerge` (^4.3.1), and `react-dom` (peer, required by `@tanstack/react-router`).
* `calypso-support-session`: declare `debug` (^4.4.1).

## Why

A 3rd-party `npm install @automattic/launchpad` currently fails: its tree (launchpad → data-stores → …) references `@automattic` packages that aren't on npm at the required versions. Full analysis of launchpad's transitive tree found exactly six packages that must be published:

| Package | on npm | needs | reason |
| --- | --- | --- | --- |
| `@automattic/api-queries` | — | 1.0.0 | private → un-privated here |
| `@automattic/calypso-support-session` | — | 1.0.0 | private → un-privated here (dep of api-queries) |
| `@automattic/design-types` | — | 1.0.0 | public, never published (no code change) |
| `@automattic/i18n-utils` | 1.2.4 | 1.3.0 | components/api-core/calypso-products require ^1.3.0 |
| `@automattic/ui` | 1.0.3 | 2.0.0 | components requires ^2.0.0 |
| `@automattic/viewport-react` | 1.0.2 | 1.0.3 | components requires ^1.0.3 |

`design-types`, `i18n-utils`, `ui`, and `viewport-react` are already public and phantom-dep-clean — they only need to be **published** at their current repo versions; no code change. `@automattic/js-utils` is already on npm at 0.1.0 (satisfies the tree) and needs no republish.

After merging this PR, publish the six:

```bash
yarn workspaces foreach -A --no-private --topological-dev \
  --include '@automattic/calypso-support-session' \
  --include '@automattic/api-queries' \
  --include '@automattic/design-types' \
  --include '@automattic/i18n-utils' \
  --include '@automattic/ui' \
  --include '@automattic/viewport-react' \
  npm publish --tolerate-republish
```

launchpad@1.2.3 / data-stores@3.2.1 don't need republishing — their declared ranges are satisfied once the six are on npm.

## Testing Instructions

* Full transitive resolution of published `@automattic/launchpad` against npm (with the six treated as published at their repo versions) reports no unresolved deps.
* `yarn install` completes with no peer (`YN0002`) errors.
* Each un-privated package's reachable deps all resolve against its declared dependencies.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?