### PR TITLE
Odie: track responses to the existing-conversation prompt

### DIFF
--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -12,7 +12,7 @@ import { useOpenLiveInteractions } from '../../hooks/use-open-interaction-status
 import './get-support.scss';
 
 interface GetSupportProps {
-	onClickAdditionalEvent?: ( destination: string ) => void;
+	onClickAdditionalEvent?: ( destination: string, props?: Record< string, unknown > ) => void;
 	isUserEligibleForPaidSupport?: boolean;
 	canConnectToZendesk?: boolean;
 	forceEmailSupport?: boolean;
@@ -130,7 +130,9 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 							? __( 'No, connect me with someone new', __i18n_text_domain__ )
 							: __( 'Get support', __i18n_text_domain__ ),
 						action: async () => {
-							onClickAdditionalEvent?.( 'chat' );
+							onClickAdditionalEvent?.( 'chat', {
+								has_open_conversation: !! supportInteraction,
+							} );
 							if ( isChatLoaded ) {
 								createZendeskConversation( {
 									createdFrom: 'chat_support_button',

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -127,10 +127,11 @@ export const UserMessage = ( {
 				<>
 					{ showGetSupport && (
 						<GetSupport
-							onClickAdditionalEvent={ ( destination ) => {
+							onClickAdditionalEvent={ ( destination, props ) => {
 								trackEvent( 'chat_get_support', {
 									location: 'user-message',
 									destination,
+									...props,
 								} );
 							} }
 						/>

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -216,6 +216,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 					! hasBeenWarnedAboutExistingConversation &&
 					! hasTriedToEscalateToSupport
 				) {
+					trackEvent( 'chat_existing_conversation_prompt' );
 					setChat( ( prevChat ) => ( {
 						...prevChat,
 						...props,


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/HAL-1199/handle-user-replies-to-the-help-center-ui-prompts-in-a-chat

## Proposed Changes

**Adds two Tracks events so we can measure how users respond to the "We noticed you have an ongoing conversation…" prompt.**

- Fires `calypso_odie_chat_existing_conversation_prompt` when the prompt is shown (it was a client-only message with no event, so we had no denominator).
- Adds a `has_open_conversation` prop to `calypso_odie_chat_get_support`, so clicks on **"No, connect me with someone new"** can be told apart from the identical-event **"Get support"** button.

## Why are these changes being made?

When a user already has an ongoing support chat and tries to start a new one, the Help Center shows a prompt with two buttons: go back to the existing conversation, or connect with someone new. Before we change that UX ([HAL-1199](https://linear.app/a8c/issue/HAL-1199/handle-user-replies-to-the-help-center-ui-prompts-in-a-chat)), we want to know how people actually behave — do they click a button, or ignore it and type a message?

Today we can't answer that cleanly. Nothing fires when the prompt appears, so there's no baseline to measure against. And the "No, connect me with someone new" button emits the exact same event as the plain "Get support" button shown in other cases, so the two are indistinguishable in the data. These two events close both gaps and let us build the real shown → clicked → typed funnel.

## Testing Instructions

1. Run `yarn start`.
2. Open the Help Center as a paid user with an existing open support conversation, and start escalating a new one until the "We noticed you have an ongoing conversation…" prompt appears.
3. Confirm `calypso_odie_chat_existing_conversation_prompt` fires when the prompt shows.
4. Click **"No, connect me with someone new"** and confirm `calypso_odie_chat_get_support` fires with `has_open_conversation: true`.
5. In a flow where the plain **"Get support"** button shows (no existing conversation), confirm the same event fires with `has_open_conversation: false`.
