### PR TITLE
[WIP] A4A Marketplace Titan Inbox add-on mock-up

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/lib/titan-inbox-mock.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/lib/titan-inbox-mock.ts
@@ -1,0 +1,31 @@
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
+
+export const TITAN_INBOX_MOCK_SLUG = 'pressable-addon-titan-inbox';
+
+export function isTitanInboxMockProduct( product: Pick< APIProductFamilyProduct, 'slug' > ) {
+	return product.slug === TITAN_INBOX_MOCK_SLUG;
+}
+
+export function getTitanInboxMockProduct(
+	priceSource?: APIProductFamilyProduct
+): APIProductFamilyProduct {
+	const amount = '3.50';
+
+	return {
+		...priceSource,
+		name: 'Pressable Titan Inbox Add-on: 1',
+		slug: TITAN_INBOX_MOCK_SLUG,
+		product_id: priceSource?.product_id ?? 999970,
+		monthly_product_id: priceSource?.monthly_product_id ?? priceSource?.product_id ?? 999970,
+		yearly_product_id: priceSource?.yearly_product_id ?? priceSource?.product_id ?? 999971,
+		currency: priceSource?.currency ?? 'USD',
+		amount,
+		price_interval: 'month',
+		price_per_unit: 350,
+		price_per_unit_display: amount,
+		family_slug: 'pressable-addon',
+		supported_bundles: [ { quantity: 1, amount, price_per_unit: 350 } ],
+		monthly_price: 3.5,
+		yearly_price: 42,
+	};
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/index.tsx
@@ -21,6 +21,7 @@ import withProductLightbox, {
 	ProductLightboxActivatorProps,
 	WithProductLightboxProps,
 } from '../hocs/with-product-lightbox';
+import { isTitanInboxMockProduct } from '../lib/titan-inbox-mock';
 import ProductBadges from '../product-badges';
 import useCustomProductCard from './hooks/use-custom-product-card';
 import ProductPriceWithDiscount from './product-price-with-discount-info';
@@ -58,6 +59,7 @@ function ProductCard( props: Props ) {
 
 	const pressableMemoryTarget = getPressableMemoryTarget( currentProduct );
 	const isPressableMemoryAddon = isPressablePhpMemoryAddon( currentProduct );
+	const isTitanInboxMockAddon = isTitanInboxMockProduct( currentProduct );
 	const { description: productDescription } = useProductDescription(
 		currentProduct.slug,
 		pressableMemoryTarget
@@ -228,14 +230,15 @@ function ProductCard( props: Props ) {
 					>
 						{ ctaLabel }
 					</Button>
-					{ ! /^jetpack-backup-addon-storage-/.test( currentProduct.slug ) && (
-						<LicenseLightboxLink
-							customText={ translate( 'View details' ) }
-							productName={ getProductShortTitle( currentProduct ) }
-							onClick={ onShowLightbox }
-							showIcon={ false }
-						/>
-					) }
+					{ ! /^jetpack-backup-addon-storage-/.test( currentProduct.slug ) &&
+						! isTitanInboxMockAddon && (
+							<LicenseLightboxLink
+								customText={ translate( 'View details' ) }
+								productName={ getProductShortTitle( currentProduct ) }
+								onClick={ onShowLightbox }
+								showIcon={ false }
+							/>
+						) }
 				</div>
 			</div>
 		</div>

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -1,7 +1,7 @@
 import { JetpackLogo } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import pressableIcon from 'calypso/assets/images/a8c-for-agencies/product-logos/pressable.svg';
 import WooLogoColor from 'calypso/assets/images/icons/Woo_logo_color.svg';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -12,18 +12,24 @@ import {
 } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/incompatible-products';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { PRODUCT_CATEGORY_PRESSABLE_ADDON, PRODUCT_FILTER_KEY_CATEGORIES } from '../../constants';
 import { MarketplaceTypeContext, ShoppingCartContext } from '../../context';
 import { useProductTermAvailabilityTooltip } from '../../hooks/use-marketplace';
 import usePressableAddonVisibility, {
 	canShowPressableAddonsInMarketplace,
 } from '../../hooks/use-pressable-addon-visibility';
-import { SelectedFilters } from '../../lib/product-filter';
+import { filterProductsAndPlans, type SelectedFilters } from '../../lib/product-filter';
 import useProductAndPlansWithPressableVisibility from '../hooks/use-product-and-plans-with-pressable-visibility';
 import { getSupportedBundleSizes } from '../hooks/use-product-bundle-size';
 import useSubmitForm from '../hooks/use-submit-form';
+import { getTitanInboxMockProduct, isTitanInboxMockProduct } from '../lib/titan-inbox-mock';
 import ProductCard from '../product-card';
 import ProductListingEmpty from './empty';
 import ProductListingSection from './section';
+import TitanInboxDomainSelectorModal, {
+	TITAN_INBOX_MOCK_DOMAINS,
+} from './titan-inbox-domain-selector-modal';
+import type { TitanInboxDomain } from './titan-inbox-domain-selector-modal';
 import type { ShoppingCartItem, TermPricingType } from '../../types';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
@@ -57,6 +63,8 @@ export default function ProductListing( {
 
 	const { selectedCartItems, setSelectedCartItems } = useContext( ShoppingCartContext );
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
+	const [ pendingTitanInboxProduct, setPendingTitanInboxProduct ] =
+		useState< APIProductFamilyProduct | null >( null );
 
 	const termAvailabilityTooltip = useProductTermAvailabilityTooltip( termPricing );
 
@@ -90,7 +98,51 @@ export default function ProductListing( {
 		canShowPressableAddonsByMode
 	);
 
-	const isEmptyList = ! filteredProductsAndBundles.length;
+	const titanInboxMockProduct = useMemo(
+		() => getTitanInboxMockProduct( pressableAddons[ 0 ] ),
+		[ pressableAddons ]
+	);
+	const shouldShowTitanInboxMockProduct = useMemo( () => {
+		const selectedCategoryFilters = selectedFilters[ PRODUCT_FILTER_KEY_CATEGORIES ];
+		const hasSelectedCategoryFilter = Object.values( selectedCategoryFilters ).some( Boolean );
+		const canShowForSelectedCategory =
+			! hasSelectedCategoryFilter || selectedCategoryFilters[ PRODUCT_CATEGORY_PRESSABLE_ADDON ];
+
+		if ( ! canShowForSelectedCategory ) {
+			return false;
+		}
+
+		if ( ! filterProductsAndPlans( [ titanInboxMockProduct ], selectedFilters ).length ) {
+			return false;
+		}
+
+		const normalizedSearch = productSearchQuery?.trim().toLowerCase();
+
+		if ( ! normalizedSearch ) {
+			return true;
+		}
+
+		return [
+			titanInboxMockProduct.name,
+			titanInboxMockProduct.slug,
+			'Titan email mailbox Pressable',
+		]
+			.join( ' ' )
+			.toLowerCase()
+			.includes( normalizedSearch );
+	}, [ productSearchQuery, selectedFilters, titanInboxMockProduct ] );
+	const pressableAddonsWithTitanMock = useMemo( () => {
+		if ( ! shouldShowTitanInboxMockProduct ) {
+			return pressableAddons;
+		}
+
+		if ( pressableAddons.some( isTitanInboxMockProduct ) ) {
+			return pressableAddons;
+		}
+
+		return [ ...pressableAddons, titanInboxMockProduct ];
+	}, [ pressableAddons, shouldShowTitanInboxMockProduct, titanInboxMockProduct ] );
+	const isEmptyList = ! filteredProductsAndBundles.length && ! shouldShowTitanInboxMockProduct;
 
 	// Create a ref for `filteredProductsAndBundles` to prevent unnecessary re-renders caused by the `useEffect` hook.
 	const filteredProductsAndBundlesRef = useRef( filteredProductsAndBundles );
@@ -181,6 +233,41 @@ export default function ProductListing( {
 
 	const onSelectOrReplaceProduct = useCallback(
 		( product: APIProductFamilyProduct, replace?: APIProductFamilyProduct ) => {
+			if ( isTitanInboxMockProduct( product ) ) {
+				const isSelectedTitanInbox = selectedCartItems.some(
+					( item ) => item.slug === product.slug
+				);
+
+				if ( isSelectedTitanInbox ) {
+					const selectedTitanInboxItem = selectedCartItems.find(
+						( item ) => item.slug === product.slug
+					);
+
+					setSelectedCartItems(
+						selectedCartItems.filter( ( item ) => item.slug !== product.slug )
+					);
+					dispatch(
+						recordTracksEvent( 'calypso_a4a_marketplace_products_overview_unselect_product', {
+							product: product.slug,
+							quantity: selectedTitanInboxItem?.quantity ?? quantity,
+							purchase_mode: marketplaceType,
+							term_pricing: termPricing,
+						} )
+					);
+					return;
+				}
+
+				setPendingTitanInboxProduct( product );
+				dispatch(
+					recordTracksEvent( 'calypso_a4a_marketplace_titan_inbox_domain_selector_open', {
+						product: product.slug,
+						purchase_mode: marketplaceType,
+						term_pricing: termPricing,
+					} )
+				);
+				return;
+			}
+
 			if ( replace ) {
 				setSelectedCartItems(
 					selectedCartItems.map( ( item ) => {
@@ -225,15 +312,58 @@ export default function ProductListing( {
 		]
 	);
 
+	const handleConfirmTitanInboxDomain = useCallback(
+		( domain: TitanInboxDomain, inboxQuantity: number ) => {
+			if ( ! pendingTitanInboxProduct ) {
+				return;
+			}
+
+			const titanInboxCartItem = {
+				...pendingTitanInboxProduct,
+				name: `${ pendingTitanInboxProduct.name } (${ domain.domain })`,
+				site_domain: domain.domain,
+				titan_inbox_quantity: inboxQuantity,
+				quantity: inboxQuantity,
+			};
+
+			setSelectedCartItems( [
+				...selectedCartItems.filter( ( item ) => item.slug !== pendingTitanInboxProduct.slug ),
+				titanInboxCartItem,
+			] );
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_marketplace_titan_inbox_domain_selected', {
+					product: pendingTitanInboxProduct.slug,
+					quantity: inboxQuantity,
+					purchase_mode: marketplaceType,
+					term_pricing: termPricing,
+					active_inboxes: domain.activeInboxes,
+					allowed_inboxes: domain.allowedInboxes,
+				} )
+			);
+			setPendingTitanInboxProduct( null );
+		},
+		[
+			dispatch,
+			marketplaceType,
+			pendingTitanInboxProduct,
+			selectedCartItems,
+			setSelectedCartItems,
+			termPricing,
+		]
+	);
+
 	const { isReady } = useSubmitForm( { selectedSite, suggestedProductSlugs } );
 
 	const isSelected = useCallback(
-		( slug: string | string[] ) =>
-			selectedCartItems.some(
+		( slug: string | string[] ) => {
+			const slugs = Array.isArray( slug ) ? slug : [ slug ];
+
+			return selectedCartItems.some(
 				( item ) =>
-					( Array.isArray( slug ) ? slug.includes( item.slug ) : item.slug === slug ) &&
-					item.quantity === quantity
-			),
+					slugs.includes( item.slug ) &&
+					( isTitanInboxMockProduct( item ) || item.quantity === quantity )
+			);
+		},
 		[ quantity, selectedCartItems ]
 	);
 
@@ -291,6 +421,11 @@ export default function ProductListing( {
 				( productDoNotHaveSupportedBundles
 					? translate( 'This product does not offer volume discounts.' )
 					: undefined );
+			const selectedTitanInboxQuantity = options.some( isTitanInboxMockProduct )
+				? selectedCartItems.find( ( item ) =>
+						options.some( ( option ) => option.slug === item.slug )
+				  )?.quantity
+				: undefined;
 
 			return (
 				<ProductCard
@@ -309,7 +444,7 @@ export default function ProductListing( {
 					}
 					hideDiscount={ isSingleLicenseView }
 					suggestedProduct={ suggestedProduct }
-					quantity={ productDoNotHaveSupportedBundles ? 1 : quantity }
+					quantity={ productDoNotHaveSupportedBundles ? 1 : selectedTitanInboxQuantity ?? quantity }
 					withCustomCard={ withCustomCard }
 					tooltip={ tooltip }
 					tooltipPosition="bottom"
@@ -393,15 +528,23 @@ export default function ProductListing( {
 				</ProductListingSection>
 			) }
 
-			{ pressableAddons.length > 0 && (
+			{ pressableAddonsWithTitanMock.length > 0 && (
 				<ProductListingSection
 					icon={ <img src={ pressableIcon } width={ 26 } height={ 26 } alt="Pressable" /> }
 					title={ translate( 'Pressable add-ons' ) }
 					description={ translate( 'Increase your plan limits and features with plan add-ons.' ) }
 					stickyHeadingTopOffset={ stickyHeadingTopOffset }
 				>
-					{ getProductCards( pressableAddons ) }
+					{ getProductCards( pressableAddonsWithTitanMock ) }
 				</ProductListingSection>
+			) }
+			{ pendingTitanInboxProduct && (
+				<TitanInboxDomainSelectorModal
+					product={ pendingTitanInboxProduct }
+					domains={ TITAN_INBOX_MOCK_DOMAINS }
+					onClose={ () => setPendingTitanInboxProduct( null ) }
+					onConfirm={ handleConfirmTitanInboxDomain }
+				/>
 			) }
 		</>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/style.scss
@@ -1,6 +1,6 @@
-@import "@wordpress/base-styles/breakpoints";
-@import "@wordpress/base-styles/mixins";
-@import "@wordpress/base-styles/variables";
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
 
 .product-listing-section__content,
 .product-listing-section__header {
@@ -36,7 +36,7 @@
 .product-listing-section__header-subtitle {
 	@include body-medium;
 
-	color: var(--color-neutral-60);
+	color: var( --color-neutral-60 );
 	display: none;
 
 	@include break-medium {
@@ -51,11 +51,11 @@
 	margin-block-end: 32px;
 
 	@include break-large {
-		grid-template-columns: repeat(2, 1fr);
+		grid-template-columns: repeat( 2, 1fr );
 	}
 
 	@include break-huge {
-		grid-template-columns: repeat(3, 1fr);
+		grid-template-columns: repeat( 3, 1fr );
 	}
 }
 
@@ -80,5 +80,188 @@
 .product-listing-empty__message-description {
 	@include body-medium;
 
-	color: var(--color-neutral-50);
+	color: var( --color-neutral-50 );
+}
+
+.titan-inbox-domain-selector-modal.components-modal__frame {
+	width: min( 1040px, calc( 100vw - 32px ) );
+	max-height: calc( 100vh - 48px );
+}
+
+.titan-inbox-domain-selector-modal .components-modal__content {
+	padding: 0 32px 32px;
+}
+
+.titan-inbox-domain-selector-modal__layout {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 40px;
+
+	@include break-large {
+		grid-template-columns: minmax( 0, 1fr ) 340px;
+	}
+}
+
+.titan-inbox-domain-selector-modal__main,
+.titan-inbox-domain-selector-modal__aside,
+.titan-inbox-domain-selector-modal__summary,
+.titan-inbox-domain-selector-modal__quantity-copy {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.titan-inbox-domain-selector-modal__intro {
+	display: flex;
+	align-items: flex-start;
+	gap: 12px;
+	color: var( --color-neutral-60 );
+}
+
+.titan-inbox-domain-selector-modal__intro img {
+	width: 28px;
+	height: 28px;
+}
+
+.titan-inbox-domain-selector-modal__intro p {
+	margin: 0;
+}
+
+.titan-inbox-domain-selector-modal__domains {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	max-height: 360px;
+	overflow-y: auto;
+}
+
+.titan-inbox-domain-selector-modal__domain-option {
+	display: flex;
+	justify-content: space-between;
+	gap: 16px;
+	width: 100%;
+	padding: 14px 16px;
+	border: 1px solid var( --color-neutral-10 );
+	border-radius: 4px;
+	background: var( --color-surface );
+	color: var( --color-text );
+	text-align: start;
+	cursor: pointer;
+}
+
+.titan-inbox-domain-selector-modal__domain-option:hover,
+.titan-inbox-domain-selector-modal__domain-option:focus-visible,
+.titan-inbox-domain-selector-modal__domain-option.is-selected {
+	border-color: var( --color-primary );
+	box-shadow: 0 0 0 1px var( --color-primary );
+}
+
+.titan-inbox-domain-selector-modal__domain-primary,
+.titan-inbox-domain-selector-modal__domain-meta {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.titan-inbox-domain-selector-modal__domain-name,
+.titan-inbox-domain-selector-modal__product-name,
+.titan-inbox-domain-selector-modal__summary-value,
+.titan-inbox-domain-selector-modal__quantity-label {
+	font-weight: 600;
+}
+
+.titan-inbox-domain-selector-modal__domain-site,
+.titan-inbox-domain-selector-modal__domain-meta,
+.titan-inbox-domain-selector-modal__interval,
+.titan-inbox-domain-selector-modal__summary-label,
+.titan-inbox-domain-selector-modal__summary-note,
+.titan-inbox-domain-selector-modal__quantity-description,
+.titan-inbox-domain-selector-modal__empty {
+	color: var( --color-neutral-60 );
+	font-size: 13px;
+}
+
+.titan-inbox-domain-selector-modal__domain-meta {
+	align-items: flex-end;
+	text-align: end;
+}
+
+.titan-inbox-domain-selector-modal__aside {
+	padding: 24px;
+	background: var( --color-neutral-0 );
+	border-radius: 4px;
+}
+
+.titan-inbox-domain-selector-modal__price-box {
+	padding: 18px;
+	border: 1px solid var( --color-primary );
+	border-radius: 4px;
+	background: var( --color-surface );
+}
+
+.titan-inbox-domain-selector-modal__price {
+	margin-block-start: 12px;
+	font-size: 24px;
+	font-weight: 600;
+	line-height: 1.2;
+}
+
+.titan-inbox-domain-selector-modal__summary {
+	padding-block: 8px;
+}
+
+.titan-inbox-domain-selector-modal__quantity {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 16px;
+	padding: 16px;
+	border: 1px solid var( --color-neutral-10 );
+	border-radius: 4px;
+	background: var( --color-surface );
+}
+
+.titan-inbox-domain-selector-modal__quantity-copy {
+	gap: 4px;
+}
+
+.titan-inbox-domain-selector-modal__quantity .a4a-number-input-v2 {
+	flex-shrink: 0;
+	width: 104px;
+}
+
+.titan-inbox-domain-selector-modal__aside .components-button {
+	justify-content: center;
+	width: 100%;
+}
+
+.titan-inbox-domain-selector-modal__empty {
+	padding: 24px;
+	border: 1px dashed var( --color-neutral-20 );
+	border-radius: 4px;
+	text-align: center;
+}
+
+@include break-mobile {
+	.titan-inbox-domain-selector-modal .components-modal__content {
+		padding: 0 20px 24px;
+	}
+
+	.titan-inbox-domain-selector-modal__domain-option {
+		flex-direction: column;
+	}
+
+	.titan-inbox-domain-selector-modal__domain-meta {
+		align-items: flex-start;
+		text-align: start;
+	}
+
+	.titan-inbox-domain-selector-modal__quantity {
+		align-items: stretch;
+		flex-direction: column;
+	}
+
+	.titan-inbox-domain-selector-modal__quantity .a4a-number-input-v2 {
+		width: 100%;
+	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/titan-inbox-domain-selector-modal.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/titan-inbox-domain-selector-modal.tsx
@@ -1,0 +1,234 @@
+import { formatCurrency } from '@automattic/number-formatters';
+import { Button, Modal, SearchControl } from '@wordpress/components';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo, useState } from 'react';
+import A4ANumberInputV2 from 'calypso/a8c-for-agencies/components/a4a-number-input-v2';
+import pressableIcon from 'calypso/assets/images/a8c-for-agencies/product-logos/pressable.svg';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
+
+export type TitanInboxDomain = {
+	domain: string;
+	siteName: string;
+	planName: string;
+	trialEndsAt: string;
+	activeInboxes: number;
+	allowedInboxes: number;
+};
+
+export const TITAN_INBOX_MOCK_DOMAINS: TitanInboxDomain[] = [
+	{
+		domain: 'client-alpha.com',
+		siteName: 'Client Alpha',
+		planName: 'Signature 50',
+		trialEndsAt: 'Oct 14, 2026',
+		activeInboxes: 1,
+		allowedInboxes: 3,
+	},
+	{
+		domain: 'northstar-studio.test',
+		siteName: 'Northstar Studio',
+		planName: 'Signature 100',
+		trialEndsAt: 'Oct 14, 2026',
+		activeInboxes: 0,
+		allowedInboxes: 1,
+	},
+	{
+		domain: 'shop.example-agency.com',
+		siteName: 'Example Shop',
+		planName: 'Signature 250',
+		trialEndsAt: 'Sep 30, 2026',
+		activeInboxes: 3,
+		allowedInboxes: 5,
+	},
+	{
+		domain: 'pressable-client.dev',
+		siteName: 'Pressable Client Dev',
+		planName: 'Signature 20',
+		trialEndsAt: 'Nov 2, 2026',
+		activeInboxes: 1,
+		allowedInboxes: 2,
+	},
+	{
+		domain: 'launch-campaign.co',
+		siteName: 'Launch Campaign',
+		planName: 'Signature 50',
+		trialEndsAt: 'Oct 28, 2026',
+		activeInboxes: 2,
+		allowedInboxes: 4,
+	},
+];
+
+type Props = {
+	product: APIProductFamilyProduct;
+	domains: TitanInboxDomain[];
+	onClose: () => void;
+	onConfirm: ( domain: TitanInboxDomain, inboxQuantity: number ) => void;
+};
+
+export default function TitanInboxDomainSelectorModal( {
+	product,
+	domains,
+	onClose,
+	onConfirm,
+}: Props ) {
+	const translate = useTranslate();
+	const [ search, setSearch ] = useState( '' );
+	const [ selectedDomainName, setSelectedDomainName ] = useState< string | null >( null );
+	const [ inboxQuantity, setInboxQuantity ] = useState( 1 );
+
+	const filteredDomains = useMemo( () => {
+		const normalizedSearch = search.trim().toLowerCase();
+
+		if ( ! normalizedSearch ) {
+			return domains;
+		}
+
+		return domains.filter( ( domain ) =>
+			[ domain.domain, domain.siteName, domain.planName ].some( ( value ) =>
+				value.toLowerCase().includes( normalizedSearch )
+			)
+		);
+	}, [ domains, search ] );
+
+	const selectedDomain = useMemo(
+		() => domains.find( ( domain ) => domain.domain === selectedDomainName ) ?? null,
+		[ domains, selectedDomainName ]
+	);
+
+	const productPrice = Number( product.monthly_price ?? product.amount );
+	const formattedPrice = Number.isFinite( productPrice )
+		? formatCurrency( productPrice * inboxQuantity, product.currency || 'USD' )
+		: product.amount;
+
+	const handleInboxQuantityChange = ( value: number ) => {
+		setInboxQuantity( Math.max( 1, Math.round( value ) ) );
+	};
+
+	return (
+		<Modal
+			className="titan-inbox-domain-selector-modal"
+			title={ translate( 'Select a domain for Titan Inbox' ) }
+			onRequestClose={ onClose }
+		>
+			<div className="titan-inbox-domain-selector-modal__layout">
+				<div className="titan-inbox-domain-selector-modal__main">
+					<div className="titan-inbox-domain-selector-modal__intro">
+						<img src={ pressableIcon } alt="" />
+						<p>
+							{ translate(
+								'Choose the Pressable domain where this inbox slot should be provisioned.'
+							) }
+						</p>
+					</div>
+					<SearchControl
+						label={ translate( 'Search domains' ) }
+						placeholder={ translate( 'Search domains' ) }
+						value={ search }
+						onChange={ ( value = '' ) => setSearch( value ) }
+					/>
+					<div
+						className="titan-inbox-domain-selector-modal__domains"
+						role="radiogroup"
+						aria-label={ translate( 'Pressable domains' ) }
+					>
+						{ filteredDomains.map( ( domain ) => {
+							const isSelected = selectedDomainName === domain.domain;
+
+							return (
+								<button
+									key={ domain.domain }
+									type="button"
+									className={ clsx( 'titan-inbox-domain-selector-modal__domain-option', {
+										'is-selected': isSelected,
+									} ) }
+									role="radio"
+									aria-checked={ isSelected }
+									onClick={ () => setSelectedDomainName( domain.domain ) }
+								>
+									<span className="titan-inbox-domain-selector-modal__domain-primary">
+										<span className="titan-inbox-domain-selector-modal__domain-name">
+											{ domain.domain }
+										</span>
+										<span className="titan-inbox-domain-selector-modal__domain-site">
+											{ domain.siteName }
+										</span>
+									</span>
+									<span className="titan-inbox-domain-selector-modal__domain-meta">
+										<span>{ domain.planName }</span>
+										<span>
+											{ translate( 'Trial ends %(trialEndsAt)s', {
+												args: { trialEndsAt: domain.trialEndsAt },
+											} ) }
+										</span>
+										<span>
+											{ translate( '%(activeInboxes)d/%(allowedInboxes)d inboxes active', {
+												args: {
+													activeInboxes: domain.activeInboxes,
+													allowedInboxes: domain.allowedInboxes,
+												},
+											} ) }
+										</span>
+									</span>
+								</button>
+							);
+						} ) }
+						{ filteredDomains.length === 0 && (
+							<div className="titan-inbox-domain-selector-modal__empty">
+								{ translate( 'No domains match this search.' ) }
+							</div>
+						) }
+					</div>
+				</div>
+				<aside className="titan-inbox-domain-selector-modal__aside">
+					<div className="titan-inbox-domain-selector-modal__price-box">
+						<div className="titan-inbox-domain-selector-modal__product-name">{ product.name }</div>
+						<div className="titan-inbox-domain-selector-modal__price">{ formattedPrice }</div>
+						<div className="titan-inbox-domain-selector-modal__interval">
+							{ translate( 'per month' ) }
+						</div>
+					</div>
+					<div className="titan-inbox-domain-selector-modal__summary">
+						<div className="titan-inbox-domain-selector-modal__summary-label">
+							{ translate( 'Selected domain' ) }
+						</div>
+						<div className="titan-inbox-domain-selector-modal__summary-value">
+							{ selectedDomain?.domain ?? translate( 'No domain selected' ) }
+						</div>
+						{ selectedDomain && (
+							<div className="titan-inbox-domain-selector-modal__summary-note">
+								{ translate( 'The inbox keeps the domain trial end date: %(trialEndsAt)s.', {
+									args: { trialEndsAt: selectedDomain.trialEndsAt },
+								} ) }
+							</div>
+						) }
+					</div>
+					{ selectedDomain && (
+						<div className="titan-inbox-domain-selector-modal__quantity">
+							<div className="titan-inbox-domain-selector-modal__quantity-copy">
+								<div className="titan-inbox-domain-selector-modal__quantity-label">
+									{ translate( 'Inbox quantity' ) }
+								</div>
+								<div className="titan-inbox-domain-selector-modal__quantity-description">
+									{ translate( 'Choose how many inbox slots to add for this domain.' ) }
+								</div>
+							</div>
+							<A4ANumberInputV2
+								value={ inboxQuantity }
+								onChange={ handleInboxQuantityChange }
+								minimum={ 1 }
+							/>
+						</div>
+					) }
+					<Button
+						variant="primary"
+						disabled={ ! selectedDomain }
+						onClick={ () => selectedDomain && onConfirm( selectedDomain, inboxQuantity ) }
+					>
+						{ translate( 'Add to cart' ) }
+					</Button>
+				</aside>
+			</div>
+		</Modal>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/hooks/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks/index.tsx
@@ -161,6 +161,10 @@ export function useProductDescription(
 				  );
 		}
 
+		if ( productSlug === 'pressable-addon-titan-inbox' ) {
+			description = translate( 'Add one Titan inbox to a selected Pressable domain.' );
+		}
+
 		switch ( productSlug ) {
 			case 'jetpack-complete':
 				description = translate(


### PR DESCRIPTION
[WIP - MOCK]
Part of Titan Inbox add-on marketplace exploration.

## Proposed Changes

* Mock a Titan Inbox add-on in the A4A Marketplace Pressable add-ons list.
* Add a simple domain-selection modal before the mocked Titan add-on can be added.
* Add mocked Pressable domains, domain search, trial-end context, and active/allowed inbox counts.
* Add an inbox quantity selector after a domain is selected.
* Set the mocked Titan Inbox price to 3.50 per inbox.

## Why are these changes being made?

* This draft PR is an exploratory mock-up so product managers can try the proposed A4A Marketplace flow before the backend Titan product, checkout metadata, and Pressable provisioning contracts are finalized.

## Testing Instructions

* Open A4A Marketplace Products in the A4A live preview.
* Filter to Pressable add-ons.
* Click “Add to cart” on the Titan Inbox add-on.
* Verify the domain selector opens.
* Verify search filters the mocked domains.
* Select a domain.
* Verify the inbox quantity selector appears in the right side of the modal above the button.
* Set the inbox quantity to 3.
* Verify the modal total updates to 10.50 in the current preview currency.
* Click “Add to cart”.
* Verify the Titan card shows “Added 3 to cart”.

_— ClemenAgent (Powered by Codex)_

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
