### PR TITLE
Reader search - sites column -  fix infinite loading placeholders / broken pagination

### DIFF
--- a/client/reader/components/reader-infinite-stream/index.jsx
+++ b/client/reader/components/reader-infinite-stream/index.jsx
@@ -1,12 +1,30 @@
 import { pickBy } from '@automattic/js-utils';
-import { useWindowVirtualizer } from '@tanstack/react-virtual';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { debounce } from '@wordpress/compose';
 import PropTypes from 'prop-types';
 import { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import { useScrollMargin } from 'calypso/reader/hooks/use-infinite-list/use-scroll-margin';
 import { recordTracksRailcarRender } from 'calypso/reader/stats';
 import './style.scss';
 
 const noop = () => {};
+
+// Calypso's Reader scrolls inside an inner overflow container, not the window.
+// Resolve the list's nearest scrollable ancestor so the virtualizer observes the
+// right element; a window virtualizer never sees scroll here, so the stream would
+// render trailing placeholders that never page in (READ-601). Falls back to the
+// document scroller when no scrollable ancestor exists (e.g. a window-scrolled host).
+const getScrollParent = ( node ) => {
+	let current = node?.parentElement ?? null;
+	while ( current ) {
+		const { overflowY } = window.getComputedStyle( current );
+		if ( overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay' ) {
+			return current;
+		}
+		current = current.parentElement;
+	}
+	return ( typeof document !== 'undefined' && document.scrollingElement ) || null;
+};
 
 // Rows rendered above and below the visible range, mirroring the prefetch feel
 // of react-virtualized's default overscan.
@@ -64,11 +82,12 @@ MeasuredRow.propTypes = {
 };
 
 /**
- * A window-scrolled, dynamically-measured infinite stream built on TanStack
- * Virtual. The list lays out at its full content height within the page flow
- * and the window itself is the scroll container. Row heights are seeded from
- * `minHeight` and then measured from the DOM (via a ResizeObserver-backed
- * `measureElement`), so variable, content-driven heights reflow automatically.
+ * A dynamically-measured infinite stream built on TanStack Virtual. The list
+ * lays out at its full content height within the page flow and virtualizes
+ * against its nearest scrollable ancestor (Reader content scrolls in an inner
+ * container, not the window). Row heights are seeded from `minHeight` and then
+ * measured from the DOM (via a ResizeObserver-backed `measureElement`), so
+ * variable, content-driven heights reflow automatically.
  *
  * Public API (consumed by other Reader components — preserve this contract):
  * @param {Object} props
@@ -95,26 +114,19 @@ function ReaderInfiniteStream( {
 	extraRenderItemProps,
 	minHeight = 70,
 } ) {
-	// State (not a ref) so the scroll margin recomputes once the list attaches.
+	// State (not a ref) so the scroll container / margin recompute once the list attaches.
 	const [ listElement, setListElement ] = useState( null );
-	const [ scrollMargin, setScrollMargin ] = useState( 0 );
+	const [ scrollElement, setScrollElement ] = useState( null );
 
-	// Offset (px) from the document top to the top of the list, so window scroll
-	// maps to the right items even when a header sits above the stream.
+	// Resolve the scroll container from the mounted list. Reader content scrolls in
+	// an inner element, so the virtualizer must observe it rather than the window.
 	useEffect( () => {
-		if ( ! listElement ) {
-			return;
-		}
-		const measure = () => {
-			const next = listElement.getBoundingClientRect().top + window.scrollY;
-			setScrollMargin( ( current ) => ( current === next ? current : next ) );
-		};
-		measure();
-		const observer = new ResizeObserver( measure );
-		observer.observe( listElement );
-		observer.observe( document.body );
-		return () => observer.disconnect();
+		setScrollElement( listElement ? getScrollParent( listElement ) : null );
 	}, [ listElement ] );
+
+	// Offset (px) from the top of the scroll container to the top of the list, so
+	// the scroll position maps to the right items even when a header sits above it.
+	const scrollMargin = useScrollMargin( listElement, scrollElement );
 
 	const itemsLength = items.length;
 	const moreToLoad = hasNextPage( itemsLength );
@@ -122,8 +134,9 @@ function ReaderInfiniteStream( {
 
 	const estimateSize = useCallback( () => minHeight, [ minHeight ] );
 
-	const virtualizer = useWindowVirtualizer( {
+	const virtualizer = useVirtualizer( {
 		count: rowCount,
+		getScrollElement: () => scrollElement,
 		estimateSize,
 		overscan: OVERSCAN_ROW_COUNT,
 		scrollMargin,

--- a/client/reader/components/reader-infinite-stream/index.jsx
+++ b/client/reader/components/reader-infinite-stream/index.jsx
@@ -12,8 +12,11 @@ const noop = () => {};
 // Calypso's Reader scrolls inside an inner overflow container, not the window.
 // Resolve the list's nearest scrollable ancestor so the virtualizer observes the
 // right element; a window virtualizer never sees scroll here, so the stream would
-// render trailing placeholders that never page in (READ-601). Falls back to the
-// document scroller when no scrollable ancestor exists (e.g. a window-scrolled host).
+// render trailing placeholders that never page in (READ-601). If no scrollable
+// ancestor is found, fall back to the document scroller as a best-effort default
+// so the list still renders — note this element virtualizer won't observe true
+// window scroll (that needs a window virtualizer), but the only consumer (the
+// search sites column) always has an inner scroll container, so that's moot.
 const getScrollParent = ( node ) => {
 	let current = node?.parentElement ?? null;
 	while ( current ) {

--- a/client/reader/data/feed/test/index.test.tsx
+++ b/client/reader/data/feed/test/index.test.tsx
@@ -125,10 +125,11 @@ describe( 'feed data layer', () => {
 			.reply( 200, {
 				feeds: [ { feed_ID: '7', blog_ID: '8', name: 'First page' } ],
 				total: 2,
+				next_page: 'offset=10&algorithm=reader/manage/search:0',
 			} );
 		nock( BASE )
 			.get( '/rest/v1.1/read/feed' )
-			.query( { q: 'wordpress', offset: '1' } )
+			.query( { q: 'wordpress', offset: '10' } )
 			.reply( 200, {
 				feeds: [ { feed_ID: '9', blog_ID: '10', name: 'Second page' } ],
 				total: 2,

--- a/client/reader/search-stream/site-results-container.tsx
+++ b/client/reader/search-stream/site-results-container.tsx
@@ -27,7 +27,7 @@ export default function SiteResultsContainer( {
 	onReceiveSearchResults,
 }: SiteResultsContainerProps ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
-	const { data, fetchNextPage } = useFeedSearchInfiniteQuery( {
+	const { data, fetchNextPage, hasNextPage } = useFeedSearchInfiniteQuery( {
 		query,
 		excludeFollowed: false,
 		sort,
@@ -59,15 +59,12 @@ export default function SiteResultsContainer( {
 		}
 	}, [ dedupedFeeds, onReceiveSearchResults ] );
 
-	const total = data?.pages?.[ 0 ]?.total ?? 0;
-	const cappedTotal = Math.min( total, 200 );
-
 	return (
 		<SiteResults
 			query={ query }
 			sort={ sort }
 			searchResults={ dedupedFeeds }
-			searchResultsCount={ cappedTotal }
+			hasNextPage={ hasNextPage }
 			isLoggedIn={ isLoggedIn }
 			fetchNextPage={ () => fetchNextPage() }
 		/>

--- a/client/reader/search-stream/site-results.jsx
+++ b/client/reader/search-stream/site-results.jsx
@@ -12,7 +12,7 @@ class SiteResults extends Component {
 		query: PropTypes.string,
 		sort: PropTypes.string,
 		searchResults: PropTypes.array,
-		searchResultsCount: PropTypes.number,
+		hasNextPage: PropTypes.bool,
 		fetchNextPage: PropTypes.func,
 		isLoggedIn: PropTypes.bool,
 		width: PropTypes.number.isRequired,
@@ -30,7 +30,11 @@ class SiteResults extends Component {
 		if ( this.isLoginPromptVisible( offset ) ) {
 			return false;
 		}
-		return offset < ( this.props.searchResultsCount ?? 0 );
+		// Defer to the infinite query's own stop condition (driven by the
+		// endpoint's `next_page` handle) rather than comparing the deduped offset
+		// to the inflated ES `total`, which never resolves and leaves the stream
+		// rendering permanent loading placeholders (READ-601).
+		return Boolean( this.props.hasNextPage );
 	};
 
 	isLoginPromptVisible( offset ) {

--- a/packages/api-core/src/read-feeds/types.ts
+++ b/packages/api-core/src/read-feeds/types.ts
@@ -8,7 +8,9 @@ export enum ReadFeedSearchSort {
 export interface ReadFeedSearchResponse {
 	algorithm: string;
 	feeds: ReadFeedItem[];
-	next_page: string;
+	// Omitted by the endpoint once the result set is exhausted (or the 200-result
+	// ceiling is reached), so consumers must treat its absence as "no more pages".
+	next_page?: string;
 	total: number;
 }
 

--- a/packages/api-queries/src/__tests__/read-feed.test.tsx
+++ b/packages/api-queries/src/__tests__/read-feed.test.tsx
@@ -1,3 +1,4 @@
+import { ReadFeedSearchSort } from '@automattic/api-core';
 import {
 	QueryClient,
 	QueryClientProvider,
@@ -159,7 +160,10 @@ describe( 'read feed queries', () => {
 		const { result } = renderHook(
 			() =>
 				useInfiniteQuery(
-					readFeedSearchInfiniteQuery( { query: 'wordpress', sort: 'last_updated' as never } )
+					readFeedSearchInfiniteQuery( {
+						query: 'wordpress',
+						sort: ReadFeedSearchSort.LastUpdated,
+					} )
 				),
 			{ wrapper: makeWrapper( client ) }
 		);

--- a/packages/api-queries/src/__tests__/read-feed.test.tsx
+++ b/packages/api-queries/src/__tests__/read-feed.test.tsx
@@ -83,13 +83,19 @@ describe( 'read feed queries', () => {
 	} );
 
 	it( 'uses an infinite query only for paginated feed search', async () => {
+		// Relevance handle carries the next offset (`from + size`); the endpoint
+		// steps the ES window by 10, and omits `next_page` once exhausted.
 		nock( BASE )
 			.get( '/rest/v1.1/read/feed' )
 			.query( { q: 'wordpress', offset: '0' } )
-			.reply( 200, { feeds: [ { feed_ID: '1' }, { feed_ID: '2' } ], total: 3 } );
+			.reply( 200, {
+				feeds: [ { feed_ID: '1' }, { feed_ID: '2' } ],
+				total: 3,
+				next_page: 'offset=10&algorithm=reader/manage/search:0',
+			} );
 		nock( BASE )
 			.get( '/rest/v1.1/read/feed' )
-			.query( { q: 'wordpress', offset: '2' } )
+			.query( { q: 'wordpress', offset: '10' } )
 			.reply( 200, { feeds: [ { feed_ID: '3' } ], total: 3 } );
 		const client = newClient();
 		const { result } = renderHook(
@@ -113,5 +119,56 @@ describe( 'read feed queries', () => {
 			undefined,
 		] );
 		expect( result.current.data?.pages.flatMap( ( page ) => page.feeds ) ).toHaveLength( 3 );
+	} );
+
+	it( 'stops paginating when the endpoint drops `next_page`, even if the ES total is higher', async () => {
+		// The endpoint reports an inflated raw ES `total` (it counts hits it then
+		// filters out) but omits `next_page` because no further ES results remain.
+		// Pagination must stop on the missing handle, not chase the total (READ-601).
+		nock( BASE )
+			.get( '/rest/v1.1/read/feed' )
+			.query( { q: 'wordpress', offset: '0' } )
+			.reply( 200, { feeds: [ { feed_ID: '1' }, { feed_ID: '2' } ], total: 50 } );
+		const client = newClient();
+		const { result } = renderHook(
+			() => useInfiniteQuery( readFeedSearchInfiniteQuery( { query: 'wordpress' } ) ),
+			{ wrapper: makeWrapper( client ) }
+		);
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		expect( result.current.hasNextPage ).toBe( false );
+		expect( result.current.data?.pages.flatMap( ( page ) => page.feeds ) ).toHaveLength( 2 );
+	} );
+
+	it( 'steps the offset by the page size for the date sort (opaque `next_page` handle)', async () => {
+		// The date sort's handle is an opaque page handle with no `offset`, so the
+		// client falls back to advancing by the fixed ES page size (10).
+		nock( BASE )
+			.get( '/rest/v1.1/read/feed' )
+			.query( { q: 'wordpress', sort: 'last_updated', offset: '0' } )
+			.reply( 200, {
+				feeds: [ { feed_ID: '1' } ],
+				total: 30,
+				next_page: 'last=1700000000&algorithm=reader/manage/search:0&blog=5&feed=0',
+			} );
+		nock( BASE )
+			.get( '/rest/v1.1/read/feed' )
+			.query( { q: 'wordpress', sort: 'last_updated', offset: '10' } )
+			.reply( 200, { feeds: [ { feed_ID: '2' } ], total: 30 } );
+		const client = newClient();
+		const { result } = renderHook(
+			() =>
+				useInfiniteQuery(
+					readFeedSearchInfiniteQuery( { query: 'wordpress', sort: 'last_updated' as never } )
+				),
+			{ wrapper: makeWrapper( client ) }
+		);
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		expect( result.current.hasNextPage ).toBe( true );
+
+		await result.current.fetchNextPage();
+		await waitFor( () => expect( result.current.hasNextPage ).toBe( false ) );
+		expect( result.current.data?.pages.flatMap( ( page ) => page.feeds ) ).toHaveLength( 2 );
 	} );
 } );

--- a/packages/api-queries/src/read-feed.ts
+++ b/packages/api-queries/src/read-feed.ts
@@ -62,6 +62,29 @@ export const readFeedSearchQuery = ( options: Options ) => {
 // boundary the UI used to enforce.
 const FEED_SEARCH_MAX_RESULTS = 200;
 
+// The `/read/feed` find endpoint pages Elasticsearch by a fixed window and never
+// receives a `number` param from this client, so it always returns 10 hits per
+// page. Advancing the offset by this window size (rather than the post-filter
+// `feeds.length`) keeps consecutive ES windows from overlapping, which would
+// otherwise stall the deduped client list before it reaches the end.
+const FEED_SEARCH_PAGE_SIZE = 10;
+
+// The endpoint's `next_page` handle is a query string. For the relevance sort it
+// carries the next offset (`from + size`); for the date sort it is an opaque
+// page handle with no offset. Return the parsed offset when present, otherwise
+// undefined so callers can fall back to stepping by the page size.
+const parseNextPageOffset = ( nextPage?: string ): number | undefined => {
+	if ( ! nextPage ) {
+		return undefined;
+	}
+	const offset = new URLSearchParams( nextPage ).get( 'offset' );
+	if ( offset == null ) {
+		return undefined;
+	}
+	const parsed = Number( offset );
+	return Number.isInteger( parsed ) && parsed >= 0 ? parsed : undefined;
+};
+
 export const readFeedSearchInfiniteQueryKey = ( options: Options ) => {
 	const { excludeFollowed, sort } = options;
 	const query = truncateQuery( options.query );
@@ -82,9 +105,21 @@ export const readFeedSearchInfiniteQuery = ( options: Options ) => {
 			_allPages: ReadFeedSearchResponse[],
 			lastPageParam: number
 		) => {
-			const next = lastPageParam + ( lastPage.feeds?.length ?? 0 );
-			const max = Math.min( lastPage.total ?? 0, FEED_SEARCH_MAX_RESULTS );
-			return next < max ? next : undefined;
+			// `next_page` is the endpoint's authoritative "is there more?" signal:
+			// it is emitted only while more ES results remain and omitted once the
+			// result set is exhausted or the 200-result ceiling is reached. The ES
+			// `total` is the raw hit count and overcounts results the endpoint
+			// filters out (graylisted, non-public, hidden Jetpack, empty feeds, …),
+			// so it must not drive the stop condition — the deduped client list can
+			// never reach it, which deadlocks the infinite stream (READ-601).
+			if ( ! lastPage.next_page ) {
+				return undefined;
+			}
+			// Relevance encodes the next offset in the handle; date sort omits it,
+			// so fall back to advancing by the fixed ES page size.
+			const nextOffset =
+				parseNextPageOffset( lastPage.next_page ) ?? lastPageParam + FEED_SEARCH_PAGE_SIZE;
+			return nextOffset < FEED_SEARCH_MAX_RESULTS ? nextOffset : undefined;
 		},
 		enabled: Boolean( query ),
 		meta: { persist: false },


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes # https://linear.app/a8c/issue/READ-601/reader-search-site-column-shows-placeholders-that-never-resolve

## Proposed Changes

The Reader search "Sites" column showed loading placeholders that never
resolved and never paged in more results. Two root causes:
- **Scroll detection.** `ReaderInfiniteStream` used a *window* virtualizer, but
  the Reader scrolls inside an inner container, so it never observed scroll and
  never called `fetchNextPage`. It now virtualizes against its nearest
  scrollable ancestor (matching how the classic stream and the Spaces
  `useInfiniteList` engine already handle scrolling).
- **Pagination logic.** The stream's "load more" was gated on the ES `total`
  (a raw hit count, e.g. 682k) that the deduped list can never reach, so it
  looped/stalled forever. Pagination is now driven by the endpoint's `next_page`
  handle (capped at the 200-result max), and the UI defers to the query's
  `hasNextPage` instead of comparing against `total`.


BEFORE
<img width="480" height="680" alt="sites-pagin-before" src="https://github.com/user-attachments/assets/b1e903eb-7a10-477b-97db-bff7f65f43c8" />


AFTER
<img width="480" height="680" alt="sites-pagin-after" src="https://github.com/user-attachments/assets/62723d8f-6591-4dcb-a64f-cdacf5e05ab2" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Permanent placeholders at end of first page of results, next pages never fetched.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to `/reader/search?q=technology`.
2. Confirm the right-hand **Sites** column loads real site cards (no permanent
   loading placeholders).
3. Scroll down — confirm the Sites column pages in additional results
   (`read/feed?...&offset=10`, `offset=20`, …) and placeholders resolve as new
   pages arrive.
4. Confirm pagination stops cleanly when the endpoint runs out of results (no
   lingering placeholders, no repeated identical requests).
5. Try a narrow query with few results and confirm it terminates without stuck
   placeholders.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
