### PR TITLE
Agents Manager: keep chat docked on short viewports

### DIFF
--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -50,7 +50,6 @@
 		"@automattic/oauth-token": "workspace:^",
 		"@automattic/support-articles": "workspace:^",
 		"@automattic/urls": "workspace:^",
-		"@automattic/viewport": "workspace:^",
 		"@automattic/zendesk-client": "workspace:^",
 		"@tanstack/react-query": "^5.83.0",
 		"@wordpress/api-fetch": "^7.48.0",

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -110,15 +110,18 @@ $admin-menu-scrollable-class: 'agents-manager-admin-menu-scrollable';
 	}
 
 	// The current item's submenu renders inline and must stay in the scroll flow.
+	// `:focus-within` (not just the anchor's `:focus`) keeps the flyout fixed for
+	// the whole keyboard pass: if it fell back to core's absolute positioning
+	// while a submenu link is focused, the browser would scroll the wrap
+	// horizontally to reveal it, pushing the menu out of view.
 	&.#{$admin-menu-scrollable-class}
 		#adminmenu
 		li.opensub:not( .wp-has-current-submenu )
 		> .wp-submenu,
 	&.#{$admin-menu-scrollable-class}
 		#adminmenu
-		li:not( .wp-has-current-submenu )
-		> a.menu-top:focus
-		+ .wp-submenu {
+		li:not( .wp-has-current-submenu ):focus-within
+		> .wp-submenu {
 		@include admin-menu-flyout( $admin-menu-width );
 	}
 }
@@ -220,9 +223,8 @@ body.wp-admin.agents-manager-sidebar-container--sidebar-open:not( .modal-open ) 
 		&.#{$admin-menu-scrollable-class} #adminmenu li.opensub.wp-has-current-submenu > .wp-submenu,
 		&.#{$admin-menu-scrollable-class}
 			#adminmenu
-			li.wp-has-current-submenu
-			> a.menu-top:focus
-			+ .wp-submenu {
+			li.wp-has-current-submenu:focus-within
+			> .wp-submenu {
 			@include admin-menu-flyout( $admin-menu-width-folded );
 		}
 	}

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -76,15 +76,7 @@
 	}
 }
 
-// Docked mode removes document scroll, so `#adminmenuwrap` scrolls its own
-// overflow — which would clip the flyout submenus rendered inside it. Open
-// flyouts switch to `position: fixed` (viewport-positioned boxes escape
-// ancestor overflow); `--am-flyout-top` is set per menu item by
-// `observe-admin-menu-flyouts`. Core's bottom-edge correction
-// (`adjustSubmenu()` inline margin-top) assumes document scroll, so it's
-// neutralized. The whole treatment is gated on `$admin-menu-scrollable-class`
-// (added to <body> by the util) so core behavior stays untouched until the
-// script is ready to position the flyouts.
+// While docked, wp-admin’s menu becomes its own scroll container; flyout submenus are positioned with CSS vars set by `observe-admin-menu-flyouts`.
 $admin-menu-scrollable-class: 'agents-manager-admin-menu-scrollable';
 
 @mixin admin-menu-flyout( $admin-menu-width ) {

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -91,6 +91,10 @@ $admin-menu-scrollable-class: 'agents-manager-admin-menu-scrollable';
 	position: fixed;
 	top: var( --am-flyout-top, auto );
 	left: calc( $layout-spacing + $admin-menu-width );
+	// Set by the util when the flyout can't fit the viewport; it scrolls
+	// internally instead of running off-screen.
+	max-height: var( --am-flyout-max-height, none );
+	overflow-y: auto;
 	margin-top: 0 !important;
 }
 

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -76,6 +76,24 @@
 	}
 }
 
+// Docked mode removes document scroll, so `#adminmenuwrap` scrolls its own
+// overflow — which would clip the flyout submenus rendered inside it. Open
+// flyouts switch to `position: fixed` (viewport-positioned boxes escape
+// ancestor overflow); `--am-flyout-top` is set per menu item by
+// `observe-admin-menu-flyouts`. Core's bottom-edge correction
+// (`adjustSubmenu()` inline margin-top) assumes document scroll, so it's
+// neutralized. The whole treatment is gated on `$admin-menu-scrollable-class`
+// (added to <body> by the util) so core behavior stays untouched until the
+// script is ready to position the flyouts.
+$admin-menu-scrollable-class: 'agents-manager-admin-menu-scrollable';
+
+@mixin admin-menu-flyout( $admin-menu-width ) {
+	position: fixed;
+	top: var( --am-flyout-top, auto );
+	left: calc( $layout-spacing + $admin-menu-width );
+	margin-top: 0 !important;
+}
+
 // Mixin for wp-admin sidebar open styles
 @mixin wp-admin-sidebar-open-specific( $admin-menu-width ) {
 	#wpcontent {
@@ -85,6 +103,19 @@
 	#wpbody {
 		left: calc( $admin-menu-width + $layout-spacing );
 		width: calc( 100% - $admin-menu-width - $layout-spacing - $sidebar-width ) !important;
+	}
+
+	// The current item's submenu renders inline and must stay in the scroll flow.
+	&.#{$admin-menu-scrollable-class}
+		#adminmenu
+		li.opensub:not( .wp-has-current-submenu )
+		> .wp-submenu,
+	&.#{$admin-menu-scrollable-class}
+		#adminmenu
+		li:not( .wp-has-current-submenu )
+		> a.menu-top:focus
+		+ .wp-submenu {
+		@include admin-menu-flyout( $admin-menu-width );
 	}
 }
 
@@ -125,6 +156,14 @@ body.wp-admin.agents-manager-sidebar-container--sidebar-open:not( .modal-open ) 
 		border-left: 1px solid $admin-border-color;
 		border-bottom: 1px solid $admin-border-color;
 		border-bottom-left-radius: $main-border-radius;
+	}
+
+	// `hidden` on the x-axis: the closed flyouts sit at `left: <menu width>`
+	// inside the wrap and would otherwise create horizontal scroll distance.
+	// Open flyouts are `position: fixed`, so they escape the clip entirely.
+	&.#{$admin-menu-scrollable-class} #adminmenuwrap {
+		overflow: hidden auto;
+		scrollbar-width: thin;
 	}
 
 	#wpcontent {
@@ -171,6 +210,17 @@ body.wp-admin.agents-manager-sidebar-container--sidebar-open:not( .modal-open ) 
 
 	&.folded {
 		@include wp-admin-sidebar-open-specific( $admin-menu-width-folded );
+
+		// When folded, the current item's submenu is a flyout too (core reverts
+		// it from inline to `position: absolute`).
+		&.#{$admin-menu-scrollable-class} #adminmenu li.opensub.wp-has-current-submenu > .wp-submenu,
+		&.#{$admin-menu-scrollable-class}
+			#adminmenu
+			li.wp-has-current-submenu
+			> a.menu-top:focus
+			+ .wp-submenu {
+			@include admin-menu-flyout( $admin-menu-width-folded );
+		}
 	}
 }
 

--- a/packages/agents-manager/src/hooks/__tests__/use-agent-layout-manager.test.tsx
+++ b/packages/agents-manager/src/hooks/__tests__/use-agent-layout-manager.test.tsx
@@ -5,10 +5,7 @@ import { renderHook, act } from '@testing-library/react';
 import useAgentLayoutManager from '../use-agent-layout-manager/index';
 
 // Stub out viewport/responsive deps so `canDock` depends only on the hook's
-// own logic (viewport is always desktop, window is always tall enough).
-jest.mock( '@automattic/viewport', () => ( {
-	useWindowDimensions: () => ( { width: 1920, height: 1080 } ),
-} ) );
+// own logic (viewport is always desktop).
 jest.mock( '@wordpress/compose', () => ( {
 	useMediaQuery: () => true,
 } ) );

--- a/packages/agents-manager/src/hooks/__tests__/use-agent-layout-manager.test.tsx
+++ b/packages/agents-manager/src/hooks/__tests__/use-agent-layout-manager.test.tsx
@@ -267,3 +267,35 @@ describe( 'useAgentLayoutManager — split-screen class', () => {
 		expect( container.classList.contains( SPLIT_SCREEN_CLASS ) ).toBe( false );
 	} );
 } );
+
+describe( 'useAgentLayoutManager — scrollable admin menu', () => {
+	const SCROLLABLE_CLASS = 'agents-manager-admin-menu-scrollable';
+	let adminMenuWrap: HTMLElement;
+
+	beforeEach( () => {
+		adminMenuWrap = document.createElement( 'div' );
+		adminMenuWrap.id = 'adminmenuwrap';
+		const adminMenu = document.createElement( 'ul' );
+		adminMenu.id = 'adminmenu';
+		adminMenuWrap.appendChild( adminMenu );
+		document.body.appendChild( adminMenuWrap );
+	} );
+
+	afterEach( () => {
+		adminMenuWrap.remove();
+	} );
+
+	it( 'applies the scrollable-menu treatment only while the sidebar renders docked', () => {
+		const { result, unmount } = render();
+		expect( document.body.classList.contains( SCROLLABLE_CLASS ) ).toBe( true );
+
+		act( () => result.current.undock() );
+		expect( document.body.classList.contains( SCROLLABLE_CLASS ) ).toBe( false );
+
+		act( () => result.current.dock() );
+		expect( document.body.classList.contains( SCROLLABLE_CLASS ) ).toBe( true );
+
+		act( () => unmount() );
+		expect( document.body.classList.contains( SCROLLABLE_CLASS ) ).toBe( false );
+	} );
+} );

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/README.md
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/README.md
@@ -4,7 +4,7 @@
 
 **Key behavior**: On desktop (≥1200px), the chat can be docked as a sidebar or floating. On mobile/tablet, the chat is always floating.
 
-In order to prevent issues with the WP admin sidebar the hook will also use floating mode if the page height is less than that of the sidebar.
+While docked in wp-admin, the hook makes the admin menu scroll its own overflow (the docked frame removes document scroll) and keeps its flyout submenus positioned in viewport coordinates so they aren't clipped — see `src/utils/observe-admin-menu-flyouts.ts`.
 
 On Gutenberg editor screens (`post-php`, `post-new-php`, `site-editor-php`), docking also requires fullscreen mode (`body.is-fullscreen-mode`) — without it, wp-admin's chrome leaves too little room for the editor alongside the chat. The gate is re-evaluated whenever the `body` class list changes, so toggling fullscreen at runtime switches the chat between docked and floating.
 
@@ -148,7 +148,7 @@ The hook returns an object with the following properties:
 
 - **`isDocked`** (`boolean`) - `true` when the chat is in docked (sidebar) mode. Requires `canDock` to be `true` AND docked mode to be enabled (via `defaultDocked` or `dock()`).
 
-- **`canDock`** (`boolean`) - `true` when docking is possible. Requires a desktop viewport (matches `desktopMediaQuery`), enough vertical space for the docked sidebar, and — on Gutenberg editor screens (`post-php`, `post-new-php`, `site-editor-php`) — fullscreen mode (`body.is-fullscreen-mode`). Updates dynamically as these conditions change. Use this to show or hide dock/undock UI controls.
+- **`canDock`** (`boolean`) - `true` when docking is possible. Requires a desktop viewport (matches `desktopMediaQuery`) and — on Gutenberg editor screens (`post-php`, `post-new-php`, `site-editor-php`) — fullscreen mode (`body.is-fullscreen-mode`). Updates dynamically as these conditions change. Use this to show or hide dock/undock UI controls.
 
 - **`dock`** (`() => void`) - Switches to sidebar mode. When on desktop, this enables the docked layout and automatically opens the sidebar. No-op when `isReady` is `false` or `sidebarContainer` is not found.
 

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
@@ -236,7 +236,9 @@ export default function useAgentLayoutManager( {
 
 	// While docked, the wp-admin menu scrolls its own overflow and its flyout
 	// submenus need viewport coordinates — see `observe-admin-menu-flyouts`.
-	useEffect( () => {
+	// `useLayoutEffect` so the treatment lands in the same frame as the docked
+	// classes applied above.
+	useLayoutEffect( () => {
 		if ( ! shouldRenderSidebar ) {
 			return;
 		}

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
@@ -1,4 +1,3 @@
-import { useWindowDimensions } from '@automattic/viewport';
 import { Button } from '@wordpress/components';
 import { useMediaQuery } from '@wordpress/compose';
 import {
@@ -13,6 +12,7 @@ import {
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { AI } from '../../components/icons';
+import observeAdminMenuFlyouts from '../../utils/observe-admin-menu-flyouts';
 import observeEditorCanvasPointerDown from '../../utils/observe-editor-canvas-pointerdown';
 
 const SIDEBAR_TRANSITION_DURATION_MS = 200;
@@ -54,27 +54,12 @@ function subscribeToBodyClasses( notify: () => void ): () => void {
  */
 const useCanDock = ( { desktopMediaQuery }: { desktopMediaQuery: string } ) => {
 	const isDesktop = useMediaQuery( desktopMediaQuery );
-	const { height } = useWindowDimensions();
-	const [ adminMenuHeight, setAdminMenuHeight ] = useState( 0 );
-	const hasEnoughHeight = height >= adminMenuHeight;
 	const isFullscreenGateOpen = useSyncExternalStore(
 		subscribeToBodyClasses,
 		getIsFullscreenGateOpen
 	);
 
-	const calculateAdminMenuHeight = useCallback( () => {
-		const adminMenu = document.getElementById( 'adminmenu' );
-		if ( adminMenu ) {
-			const adminBar = document.getElementById( 'wpadminbar' );
-			const adminBarHeight = adminBar ? adminBar.offsetHeight : 32;
-			setAdminMenuHeight( adminMenu.offsetHeight + adminBarHeight + 20 );
-		}
-	}, [] );
-
-	return {
-		canDock: isDesktop && hasEnoughHeight && isFullscreenGateOpen,
-		calculateAdminMenuHeight,
-	};
+	return isDesktop && isFullscreenGateOpen;
 };
 
 interface Options {
@@ -116,7 +101,7 @@ export default function useAgentLayoutManager( {
 	const portalRef = useRef< HTMLDivElement | undefined >( undefined );
 	const [ isPortalReady, setIsPortalReady ] = useState( false );
 	const [ isDocked, setIsDocked ] = useState< boolean | null >( null );
-	const { canDock, calculateAdminMenuHeight } = useCanDock( { desktopMediaQuery } );
+	const canDock = useCanDock( { desktopMediaQuery } );
 	const shouldRenderSidebar = canDock && isDocked;
 	const openSidebarTimeoutRef = useRef< ReturnType< typeof setTimeout > | undefined >( undefined );
 	const closeSidebarTimeoutRef = useRef< ReturnType< typeof setTimeout > | undefined >( undefined );
@@ -151,8 +136,6 @@ export default function useAgentLayoutManager( {
 		if ( ! isReady || ! container ) {
 			return;
 		}
-
-		calculateAdminMenuHeight();
 
 		// Set initial docked state
 		if ( isDocked === null ) {
@@ -250,6 +233,16 @@ export default function useAgentLayoutManager( {
 			stopCanvasObserver();
 		};
 	}, [ isPortalReady, shouldRenderSidebar ] );
+
+	// While docked, the wp-admin menu scrolls its own overflow and its flyout
+	// submenus need viewport coordinates — see `observe-admin-menu-flyouts`.
+	useEffect( () => {
+		if ( ! shouldRenderSidebar ) {
+			return;
+		}
+
+		return observeAdminMenuFlyouts();
+	}, [ shouldRenderSidebar ] );
 
 	// Reflect split-screen state on the container as `is-split-screen`.
 	useLayoutEffect( () => {

--- a/packages/agents-manager/src/utils/__tests__/observe-admin-menu-flyouts.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/observe-admin-menu-flyouts.test.ts
@@ -162,6 +162,18 @@ describe( 'observeAdminMenuFlyouts', () => {
 		cleanup();
 	} );
 
+	it( 'resets horizontal scroll on the wrap (focus-driven scrolling can nudge it)', () => {
+		const { wrap, menu } = buildMenu();
+		addItem( menu, { top: 200, submenuHeight: 200 } );
+		const cleanup = attach();
+
+		wrap.scrollLeft = 80;
+		wrap.dispatchEvent( new Event( 'scroll' ) );
+		expect( wrap.scrollLeft ).toBe( 0 );
+
+		cleanup();
+	} );
+
 	it( 'positions a flyout already open on attach (hover during app load)', () => {
 		const { menu } = buildMenu();
 		const { item } = addItem( menu, { top: 250, submenuHeight: 200 } );

--- a/packages/agents-manager/src/utils/__tests__/observe-admin-menu-flyouts.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/observe-admin-menu-flyouts.test.ts
@@ -138,6 +138,18 @@ describe( 'observeAdminMenuFlyouts', () => {
 		cleanup();
 	} );
 
+	it( 'never emits a negative max-height on an extremely short viewport', () => {
+		window.innerHeight = 40; // Shorter than the frame top itself.
+		const { menu } = buildMenu();
+		const { item, link } = addItem( menu, { top: 100, submenuHeight: 200 } );
+		const cleanup = attach();
+
+		hover( link );
+		expect( item.style.getPropertyValue( MAX_HEIGHT_VAR ) ).toBe( '0px' );
+
+		cleanup();
+	} );
+
 	it( 'skips repositioning on pointer moves within the same item', () => {
 		const { menu } = buildMenu();
 		const { item, link } = addItem( menu, { top: 100, submenuHeight: 200 } );

--- a/packages/agents-manager/src/utils/__tests__/observe-admin-menu-flyouts.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/observe-admin-menu-flyouts.test.ts
@@ -72,9 +72,16 @@ function attach(): () => void {
 const hover = ( el: HTMLElement ) =>
 	el.dispatchEvent( new Event( 'pointerover', { bubbles: true } ) );
 
+const setViewportHeight = ( height: number ) =>
+	Object.defineProperty( window, 'innerHeight', {
+		value: height,
+		configurable: true,
+		writable: true,
+	} );
+
 describe( 'observeAdminMenuFlyouts', () => {
 	beforeEach( () => {
-		window.innerHeight = VIEWPORT_HEIGHT;
+		setViewportHeight( VIEWPORT_HEIGHT );
 	} );
 
 	afterEach( () => {
@@ -139,7 +146,7 @@ describe( 'observeAdminMenuFlyouts', () => {
 	} );
 
 	it( 'never emits a negative max-height on an extremely short viewport', () => {
-		window.innerHeight = 40; // Shorter than the frame top itself.
+		setViewportHeight( 40 ); // Shorter than the frame top itself.
 		const { menu } = buildMenu();
 		const { item, link } = addItem( menu, { top: 100, submenuHeight: 200 } );
 		const cleanup = attach();
@@ -203,12 +210,12 @@ describe( 'observeAdminMenuFlyouts', () => {
 		const cleanup = attach();
 
 		// The window shrinks while the flyout is open: 500 − 16 − 200 = 284.
-		window.innerHeight = 500;
+		setViewportHeight( 500 );
 		window.dispatchEvent( new Event( 'resize' ) );
 		expect( item.style.getPropertyValue( TOP_VAR ) ).toBe( '284px' );
 
 		cleanup();
-		window.innerHeight = 500 + 1;
+		setViewportHeight( 500 + 1 );
 		window.dispatchEvent( new Event( 'resize' ) );
 		expect( item.style.getPropertyValue( TOP_VAR ) ).toBe( '' );
 	} );

--- a/packages/agents-manager/src/utils/__tests__/observe-admin-menu-flyouts.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/observe-admin-menu-flyouts.test.ts
@@ -1,0 +1,203 @@
+/**
+ * @jest-environment jsdom
+ */
+import observeAdminMenuFlyouts from '../observe-admin-menu-flyouts';
+
+const SCROLLABLE_CLASS = 'agents-manager-admin-menu-scrollable';
+const TOP_VAR = '--am-flyout-top';
+const MAX_HEIGHT_VAR = '--am-flyout-max-height';
+
+// Geometry used across tests: 800px viewport, frame top at 50px, 16px gutter.
+const VIEWPORT_HEIGHT = 800;
+const WRAP_TOP = 50;
+const GAP = 16;
+
+// jsdom has no `DOMRect` constructor; build the shape by hand.
+const rect = ( top: number ) => (): DOMRect =>
+	( {
+		top,
+		bottom: top + 34,
+		left: 0,
+		right: 160,
+		width: 160,
+		height: 34,
+		x: 0,
+		y: top,
+		toJSON: () => ( {} ),
+	} ) as DOMRect;
+
+function buildMenu() {
+	const wrap = document.createElement( 'div' );
+	wrap.id = 'adminmenuwrap';
+	wrap.getBoundingClientRect = rect( WRAP_TOP );
+
+	const menu = document.createElement( 'ul' );
+	menu.id = 'adminmenu';
+	wrap.appendChild( menu );
+	document.body.appendChild( wrap );
+
+	return { wrap, menu };
+}
+
+function addItem(
+	menu: HTMLElement,
+	{ top, submenuHeight }: { top: number; submenuHeight: number }
+) {
+	const item = document.createElement( 'li' );
+	item.className = 'menu-top';
+	item.getBoundingClientRect = rect( top );
+
+	const link = document.createElement( 'a' );
+	link.className = 'menu-top';
+	link.href = '#';
+	item.appendChild( link );
+
+	const submenu = document.createElement( 'ul' );
+	submenu.className = 'wp-submenu';
+	Object.defineProperty( submenu, 'scrollHeight', { value: submenuHeight, configurable: true } );
+	item.appendChild( submenu );
+
+	menu.appendChild( item );
+	return { item, link };
+}
+
+function attach(): () => void {
+	const cleanup = observeAdminMenuFlyouts();
+	if ( ! cleanup ) {
+		throw new Error( 'expected the observer to attach' );
+	}
+	return cleanup;
+}
+
+const hover = ( el: HTMLElement ) =>
+	el.dispatchEvent( new Event( 'pointerover', { bubbles: true } ) );
+
+describe( 'observeAdminMenuFlyouts', () => {
+	beforeEach( () => {
+		window.innerHeight = VIEWPORT_HEIGHT;
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+		document.body.className = '';
+	} );
+
+	it( 'is a no-op outside wp-admin (no admin menu in the DOM)', () => {
+		expect( observeAdminMenuFlyouts() ).toBeUndefined();
+		expect( document.body.classList.contains( SCROLLABLE_CLASS ) ).toBe( false );
+	} );
+
+	it( 'gates the scrollable-menu CSS on a body class between attach and cleanup', () => {
+		buildMenu();
+		const cleanup = attach();
+		expect( document.body.classList.contains( SCROLLABLE_CLASS ) ).toBe( true );
+
+		cleanup();
+		expect( document.body.classList.contains( SCROLLABLE_CLASS ) ).toBe( false );
+	} );
+
+	it( 'aligns the hovered flyout with its item when it fits the viewport', () => {
+		const { menu } = buildMenu();
+		const { item, link } = addItem( menu, { top: 100, submenuHeight: 200 } );
+		const cleanup = attach();
+
+		hover( link );
+		expect( item.style.getPropertyValue( TOP_VAR ) ).toBe( '100px' );
+		// Cap is set unconditionally; here it exceeds the flyout height (no-op).
+		expect( item.style.getPropertyValue( MAX_HEIGHT_VAR ) ).toBe(
+			`${ VIEWPORT_HEIGHT - GAP - 100 }px`
+		);
+
+		cleanup();
+	} );
+
+	it( 'shifts the flyout up so its bottom stays inside the viewport', () => {
+		const { menu } = buildMenu();
+		const { item, link } = addItem( menu, { top: 700, submenuHeight: 200 } );
+		const cleanup = attach();
+
+		hover( link );
+		// 800 − 16 − 200 = 584: bottom lands exactly on the gutter.
+		expect( item.style.getPropertyValue( TOP_VAR ) ).toBe( '584px' );
+
+		cleanup();
+	} );
+
+	it( 'pins a taller-than-viewport flyout to the frame top and caps its height', () => {
+		const { menu } = buildMenu();
+		const { item, link } = addItem( menu, { top: 300, submenuHeight: 900 } );
+		const cleanup = attach();
+
+		hover( link );
+		expect( item.style.getPropertyValue( TOP_VAR ) ).toBe( `${ WRAP_TOP }px` );
+		// Capped below its 900px content height, so it scrolls internally.
+		expect( item.style.getPropertyValue( MAX_HEIGHT_VAR ) ).toBe(
+			`${ VIEWPORT_HEIGHT - GAP - WRAP_TOP }px`
+		);
+
+		cleanup();
+	} );
+
+	it( 'positions on keyboard focus', () => {
+		const { menu } = buildMenu();
+		const { item, link } = addItem( menu, { top: 150, submenuHeight: 200 } );
+		const cleanup = attach();
+
+		link.dispatchEvent( new Event( 'focusin', { bubbles: true } ) );
+		expect( item.style.getPropertyValue( TOP_VAR ) ).toBe( '150px' );
+
+		cleanup();
+	} );
+
+	it( 'keeps an open flyout glued to its item while the menu scrolls', () => {
+		const { wrap, menu } = buildMenu();
+		const { item } = addItem( menu, { top: 200, submenuHeight: 200 } );
+		item.classList.add( 'opensub' );
+		const cleanup = attach();
+
+		item.getBoundingClientRect = rect( 120 );
+		wrap.dispatchEvent( new Event( 'scroll' ) );
+		expect( item.style.getPropertyValue( TOP_VAR ) ).toBe( '120px' );
+
+		cleanup();
+	} );
+
+	it( 'positions a flyout already open on attach (hover during app load)', () => {
+		const { menu } = buildMenu();
+		const { item } = addItem( menu, { top: 250, submenuHeight: 200 } );
+		item.classList.add( 'opensub' );
+
+		const cleanup = attach();
+		expect( item.style.getPropertyValue( TOP_VAR ) ).toBe( '250px' );
+
+		cleanup();
+	} );
+
+	it( 'positions the focused item on attach when no flyout is hover-open', () => {
+		const { menu } = buildMenu();
+		const { item, link } = addItem( menu, { top: 350, submenuHeight: 200 } );
+		link.focus();
+
+		const cleanup = attach();
+		expect( item.style.getPropertyValue( TOP_VAR ) ).toBe( '350px' );
+
+		cleanup();
+	} );
+
+	it( 'detaches listeners and clears inline positioning on cleanup', () => {
+		const { wrap, menu } = buildMenu();
+		const { item, link } = addItem( menu, { top: 100, submenuHeight: 200 } );
+		const cleanup = attach();
+
+		hover( link );
+		expect( item.style.getPropertyValue( TOP_VAR ) ).not.toBe( '' );
+
+		cleanup();
+		expect( item.style.getPropertyValue( TOP_VAR ) ).toBe( '' );
+		expect( item.style.getPropertyValue( MAX_HEIGHT_VAR ) ).toBe( '' );
+
+		hover( link );
+		wrap.dispatchEvent( new Event( 'scroll' ) );
+		expect( item.style.getPropertyValue( TOP_VAR ) ).toBe( '' );
+	} );
+} );

--- a/packages/agents-manager/src/utils/__tests__/observe-admin-menu-flyouts.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/observe-admin-menu-flyouts.test.ts
@@ -196,6 +196,23 @@ describe( 'observeAdminMenuFlyouts', () => {
 		cleanup();
 	} );
 
+	it( 'reclamps an open flyout when the viewport resizes', () => {
+		const { menu } = buildMenu();
+		const { item } = addItem( menu, { top: 700, submenuHeight: 200 } );
+		item.classList.add( 'opensub' );
+		const cleanup = attach();
+
+		// The window shrinks while the flyout is open: 500 − 16 − 200 = 284.
+		window.innerHeight = 500;
+		window.dispatchEvent( new Event( 'resize' ) );
+		expect( item.style.getPropertyValue( TOP_VAR ) ).toBe( '284px' );
+
+		cleanup();
+		window.innerHeight = 500 + 1;
+		window.dispatchEvent( new Event( 'resize' ) );
+		expect( item.style.getPropertyValue( TOP_VAR ) ).toBe( '' );
+	} );
+
 	it( 'resets horizontal scroll on the wrap (focus-driven scrolling can nudge it)', () => {
 		const { wrap, menu } = buildMenu();
 		addItem( menu, { top: 200, submenuHeight: 200 } );

--- a/packages/agents-manager/src/utils/__tests__/observe-admin-menu-flyouts.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/observe-admin-menu-flyouts.test.ts
@@ -138,6 +138,28 @@ describe( 'observeAdminMenuFlyouts', () => {
 		cleanup();
 	} );
 
+	it( 'skips repositioning on pointer moves within the same item', () => {
+		const { menu } = buildMenu();
+		const { item, link } = addItem( menu, { top: 100, submenuHeight: 200 } );
+		const cleanup = attach();
+
+		hover( link );
+		expect( item.style.getPropertyValue( TOP_VAR ) ).toBe( '100px' );
+
+		// Pointer moves from the link to the submenu of the same item: no re-read.
+		item.getBoundingClientRect = rect( 130 );
+		link.dispatchEvent( new MouseEvent( 'pointerover', { bubbles: true, relatedTarget: item } ) );
+		expect( item.style.getPropertyValue( TOP_VAR ) ).toBe( '100px' );
+
+		// Coming from outside the item repositions again.
+		link.dispatchEvent(
+			new MouseEvent( 'pointerover', { bubbles: true, relatedTarget: document.body } )
+		);
+		expect( item.style.getPropertyValue( TOP_VAR ) ).toBe( '130px' );
+
+		cleanup();
+	} );
+
 	it( 'positions on keyboard focus', () => {
 		const { menu } = buildMenu();
 		const { item, link } = addItem( menu, { top: 150, submenuHeight: 200 } );

--- a/packages/agents-manager/src/utils/observe-admin-menu-flyouts.ts
+++ b/packages/agents-manager/src/utils/observe-admin-menu-flyouts.ts
@@ -60,6 +60,12 @@ export default function observeAdminMenuFlyouts(): ( () => void ) | undefined {
 
 	// Keep an open flyout glued to its item while the menu scrolls under it.
 	const handleScroll = () => {
+		// The wrap must never rest horizontally scrolled (it hides the menu with
+		// no scrollbar to recover); focus-driven scrolling can still nudge it.
+		if ( wrap.scrollLeft !== 0 ) {
+			wrap.scrollLeft = 0;
+		}
+
 		const openItem = menu.querySelector< HTMLElement >( 'li.opensub' );
 
 		if ( openItem ) {

--- a/packages/agents-manager/src/utils/observe-admin-menu-flyouts.ts
+++ b/packages/agents-manager/src/utils/observe-admin-menu-flyouts.ts
@@ -51,11 +51,25 @@ export default function observeAdminMenuFlyouts(): ( () => void ) | undefined {
 	};
 
 	const handlePointerOrFocus = ( event: Event ) => {
-		const item = ( event.target as Element ).closest< HTMLElement >( 'li.menu-top' );
-
-		if ( item ) {
-			positionFlyout( item );
+		if ( ! ( event.target instanceof Element ) ) {
+			return;
 		}
+
+		const item = event.target.closest< HTMLElement >( 'li.menu-top' );
+
+		if ( ! item ) {
+			return;
+		}
+
+		// pointerover/focusin re-fire for every move between descendants of the
+		// same item; the flyout is already positioned, so skip the layout reads.
+		const from = ( event as MouseEvent | FocusEvent ).relatedTarget;
+
+		if ( from instanceof Element && item.contains( from ) ) {
+			return;
+		}
+
+		positionFlyout( item );
 	};
 
 	// Keep an open flyout glued to its item while the menu scrolls under it.

--- a/packages/agents-manager/src/utils/observe-admin-menu-flyouts.ts
+++ b/packages/agents-manager/src/utils/observe-admin-menu-flyouts.ts
@@ -1,0 +1,87 @@
+const FLYOUT_TOP_VAR = '--am-flyout-top';
+// Gates the docked scrollable-menu CSS in `agent-dock/style.scss`; keep in sync
+// with `$admin-menu-scrollable-class` there.
+const SCROLLABLE_CLASS = 'agents-manager-admin-menu-scrollable';
+// Matches the docked frame's `$layout-spacing` gutter.
+const VIEWPORT_GAP = 16;
+
+/**
+ * The docked layout removes document scroll, so `#adminmenuwrap` must scroll its
+ * own overflow — which would clip the admin menu's flyout submenus. The docked CSS
+ * switches open flyouts to `position: fixed` so they escape the scroll container,
+ * reading their top coordinate from `--am-flyout-top`. This sets that property on
+ * the hovered/focused menu item, clamped so the flyout stays inside the viewport
+ * (replacing core's `adjustSubmenu()` margin-top correction, which assumes
+ * document scroll and is neutralized by the docked CSS). All of that CSS is gated
+ * on a body class added here, so the menu keeps core behavior until the script is
+ * ready to position the flyouts.
+ * Assumes a single active invocation at a time (one layout manager per page):
+ * attach/cleanup toggle page-global state (the body class, per-item inline
+ * styles) without reference counting.
+ * @returns Cleanup function that detaches all listeners, or undefined outside wp-admin.
+ */
+export default function observeAdminMenuFlyouts(): ( () => void ) | undefined {
+	const menu = document.getElementById( 'adminmenu' );
+	const wrap = document.getElementById( 'adminmenuwrap' );
+
+	if ( ! menu || ! wrap ) {
+		return;
+	}
+
+	const positionFlyout = ( item: HTMLElement ) => {
+		const submenu = item.querySelector< HTMLElement >( '.wp-submenu' );
+
+		if ( ! submenu ) {
+			return;
+		}
+
+		const itemTop = item.getBoundingClientRect().top;
+		const maxTop = window.innerHeight - VIEWPORT_GAP - submenu.offsetHeight;
+		const minTop = wrap.getBoundingClientRect().top;
+		const top = Math.max( minTop, Math.min( itemTop, maxTop ) );
+		item.style.setProperty( FLYOUT_TOP_VAR, `${ top }px` );
+	};
+
+	const handlePointerOrFocus = ( event: Event ) => {
+		const item = ( event.target as Element ).closest< HTMLElement >( 'li.menu-top' );
+
+		if ( item ) {
+			positionFlyout( item );
+		}
+	};
+
+	// Keep an open flyout glued to its item while the menu scrolls under it.
+	const handleScroll = () => {
+		const openItem = menu.querySelector< HTMLElement >( 'li.opensub' );
+
+		if ( openItem ) {
+			positionFlyout( openItem );
+		}
+	};
+
+	// A flyout may already be open (hover/focus during app load); give it a
+	// position before the gated CSS switches it to `position: fixed`, where it
+	// would otherwise sit on the static-position fallback until re-hovered.
+	const focusedItem = document.activeElement?.closest< HTMLElement >( 'li.menu-top' );
+	const openItem = menu.querySelector< HTMLElement >( 'li.opensub' ) ?? focusedItem;
+
+	if ( openItem && menu.contains( openItem ) ) {
+		positionFlyout( openItem );
+	}
+
+	document.body.classList.add( SCROLLABLE_CLASS );
+
+	menu.addEventListener( 'pointerover', handlePointerOrFocus );
+	menu.addEventListener( 'focusin', handlePointerOrFocus );
+	wrap.addEventListener( 'scroll', handleScroll, { passive: true } );
+
+	return () => {
+		document.body.classList.remove( SCROLLABLE_CLASS );
+		menu.removeEventListener( 'pointerover', handlePointerOrFocus );
+		menu.removeEventListener( 'focusin', handlePointerOrFocus );
+		wrap.removeEventListener( 'scroll', handleScroll );
+		menu.querySelectorAll< HTMLElement >( 'li.menu-top' ).forEach( ( item ) => {
+			item.style.removeProperty( FLYOUT_TOP_VAR );
+		} );
+	};
+}

--- a/packages/agents-manager/src/utils/observe-admin-menu-flyouts.ts
+++ b/packages/agents-manager/src/utils/observe-admin-menu-flyouts.ts
@@ -44,9 +44,10 @@ export default function observeAdminMenuFlyouts(): ( () => void ) | undefined {
 		item.style.setProperty( FLYOUT_TOP_VAR, `${ top }px` );
 		// Cap a flyout taller than the remaining viewport so it scrolls internally —
 		// nothing else can bring the tail of a fixed box into view.
+		// Floored at 0: a negative length is invalid CSS and would drop the cap.
 		item.style.setProperty(
 			FLYOUT_MAX_HEIGHT_VAR,
-			`${ window.innerHeight - VIEWPORT_GAP - top }px`
+			`${ Math.max( 0, window.innerHeight - VIEWPORT_GAP - top ) }px`
 		);
 	};
 

--- a/packages/agents-manager/src/utils/observe-admin-menu-flyouts.ts
+++ b/packages/agents-manager/src/utils/observe-admin-menu-flyouts.ts
@@ -73,8 +73,9 @@ export default function observeAdminMenuFlyouts(): ( () => void ) | undefined {
 		positionFlyout( item );
 	};
 
-	// Keep an open flyout glued to its item while the menu scrolls under it.
-	const handleScroll = () => {
+	// Keep an open flyout glued to its item while the menu scrolls under it or
+	// the viewport resizes.
+	const handleScrollOrResize = () => {
 		// The wrap must never rest horizontally scrolled (it hides the menu with
 		// no scrollbar to recover); focus-driven scrolling can still nudge it.
 		if ( wrap.scrollLeft !== 0 ) {
@@ -102,13 +103,15 @@ export default function observeAdminMenuFlyouts(): ( () => void ) | undefined {
 
 	menu.addEventListener( 'pointerover', handlePointerOrFocus );
 	menu.addEventListener( 'focusin', handlePointerOrFocus );
-	wrap.addEventListener( 'scroll', handleScroll, { passive: true } );
+	wrap.addEventListener( 'scroll', handleScrollOrResize, { passive: true } );
+	window.addEventListener( 'resize', handleScrollOrResize );
 
 	return () => {
 		document.body.classList.remove( SCROLLABLE_CLASS );
 		menu.removeEventListener( 'pointerover', handlePointerOrFocus );
 		menu.removeEventListener( 'focusin', handlePointerOrFocus );
-		wrap.removeEventListener( 'scroll', handleScroll );
+		wrap.removeEventListener( 'scroll', handleScrollOrResize );
+		window.removeEventListener( 'resize', handleScrollOrResize );
 		menu.querySelectorAll< HTMLElement >( 'li.menu-top' ).forEach( ( item ) => {
 			item.style.removeProperty( FLYOUT_TOP_VAR );
 			item.style.removeProperty( FLYOUT_MAX_HEIGHT_VAR );

--- a/packages/agents-manager/src/utils/observe-admin-menu-flyouts.ts
+++ b/packages/agents-manager/src/utils/observe-admin-menu-flyouts.ts
@@ -1,4 +1,5 @@
 const FLYOUT_TOP_VAR = '--am-flyout-top';
+const FLYOUT_MAX_HEIGHT_VAR = '--am-flyout-max-height';
 // Gates the docked scrollable-menu CSS in `agent-dock/style.scss`; keep in sync
 // with `$admin-menu-scrollable-class` there.
 const SCROLLABLE_CLASS = 'agents-manager-admin-menu-scrollable';
@@ -36,10 +37,17 @@ export default function observeAdminMenuFlyouts(): ( () => void ) | undefined {
 		}
 
 		const itemTop = item.getBoundingClientRect().top;
-		const maxTop = window.innerHeight - VIEWPORT_GAP - submenu.offsetHeight;
+		// `scrollHeight` so an earlier max-height cap doesn't skew the measurement.
+		const maxTop = window.innerHeight - VIEWPORT_GAP - submenu.scrollHeight;
 		const minTop = wrap.getBoundingClientRect().top;
 		const top = Math.max( minTop, Math.min( itemTop, maxTop ) );
 		item.style.setProperty( FLYOUT_TOP_VAR, `${ top }px` );
+		// Cap a flyout taller than the remaining viewport so it scrolls internally —
+		// nothing else can bring the tail of a fixed box into view.
+		item.style.setProperty(
+			FLYOUT_MAX_HEIGHT_VAR,
+			`${ window.innerHeight - VIEWPORT_GAP - top }px`
+		);
 	};
 
 	const handlePointerOrFocus = ( event: Event ) => {
@@ -82,6 +90,7 @@ export default function observeAdminMenuFlyouts(): ( () => void ) | undefined {
 		wrap.removeEventListener( 'scroll', handleScroll );
 		menu.querySelectorAll< HTMLElement >( 'li.menu-top' ).forEach( ( item ) => {
 			item.style.removeProperty( FLYOUT_TOP_VAR );
+			item.style.removeProperty( FLYOUT_MAX_HEIGHT_VAR );
 		} );
 	};
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,7 +143,6 @@ __metadata:
     "@automattic/oauth-token": "workspace:^"
     "@automattic/support-articles": "workspace:^"
     "@automattic/urls": "workspace:^"
-    "@automattic/viewport": "workspace:^"
     "@automattic/zendesk-client": "workspace:^"
     "@tanstack/react-query": "npm:^5.83.0"
     "@testing-library/dom": "npm:^10.4.1"


### PR DESCRIPTION
Fixes AI-1059

## Proposed Changes

* Remove the viewport-height docking gate from `useCanDock` — the docked chat now works at any viewport height instead of forcing itself undocked when the screen is shorter than the wp-admin menu.
* Make `#adminmenuwrap` scroll its own overflow while the chat is docked (the docked frame removes document scroll, which previously left a too-tall admin menu unreachable).
* Switch open flyout submenus to `position: fixed` so they escape the menu's scroll container instead of being clipped by it. A new `observe-admin-menu-flyouts` util positions them per item (`--am-flyout-top`), clamped to stay inside the viewport — replacing core's `adjustSubmenu()` margin correction, which assumes document scroll.
* Cap flyouts taller than the viewport with a `max-height` (`--am-flyout-max-height`) so they scroll internally instead of running off-screen.
* Gate the whole treatment on a body class the util adds when it attaches, so the admin menu keeps stock core behavior until the script is ready to position flyouts (no mispositioned flyouts while the app is still loading — including a flyout already open at the moment it mounts).
* Cover the classic, nav-unification, and folded menu widths. The current page's inline submenu keeps scrolling with the menu (except in folded mode, where core turns it into a flyout too).
* Add unit tests for the new util and for the body-class wiring in `useAgentLayoutManager`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is an alternative exploration for DOTCOM-15493, which was described as a subpar experience.

## Testing Instructions

Pair it with https://github.com/Automattic/jetpack/pull/50628

* `cd apps/agents-manager && yarn dev --sync`
* Sandbox `widgets.wp.com`
* On a Simple site with the unified agent experience enabled, open a wp-admin page and make sure the chat is docked and open
* Shrink the browser height below the WP admin menu height: the chat stays docked and the admin menu becomes vertically scrollable (no horizontal scrollbar)
* Hover sidebar items ("Posts", "Jetpack", …): flyouts appear aligned with their item; for items near the bottom of the screen the flyout shifts up to stay fully visible; a flyout taller than the window scrolls internally
* Scroll the admin menu while a flyout is open: it stays glued to its item
* Keyboard: Tab through the menu — flyouts open and are positioned correctly
* Collapse the menu ("Collapse menu"): flyouts, including the current page's, still work
* Regression check on a tall viewport: docked layout unchanged; undocked/floating mode unchanged

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
