### PR TITLE
Dashboard: add unified Help dropdown and Ask AI to the omnibar

### DIFF
--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable no-restricted-imports */
+import { useShouldUseUnifiedAgent } from '@automattic/agents-manager';
 import {
 	purchaseQuery,
 	queryClient,
@@ -123,6 +124,10 @@ export function InterimOmnibar( {
 		store.dispatch( { type: 'NOTIFICATIONS_UNSEEN_COUNT_SET', unseenCount } );
 	} );
 
+	// The masterbar's own client, not the Dashboard one: that client is restored from
+	// storage, so a cached flag would resolve on the first render and mismatch the SSR.
+	const shouldUseUnifiedAgent = useShouldUseUnifiedAgent( omnibarQueryClient );
+
 	return (
 		<QueryClientProvider client={ omnibarQueryClient }>
 			<ReduxProvider store={ store }>
@@ -177,10 +182,11 @@ export function InterimOmnibar( {
 					isCheckoutPending={ false }
 					isCheckoutFailed={ false }
 					loadHelpCenterIcon
+					loadAgentsManager
 					isGlobalSidebarVisible={ false }
 					isGravatarDomain={ false }
 					dashboardOptIn
-					useUnifiedAgent={ false }
+					useUnifiedAgent={ !! shouldUseUnifiedAgent }
 					isSupportSession={ isSupportSession() }
 					isNotificationsShowing={ false }
 					isMigrationInProgress={ false }

--- a/client/layout/masterbar/masterbar-agents-manager/style.scss
+++ b/client/layout/masterbar/masterbar-agents-manager/style.scss
@@ -21,11 +21,17 @@
 		display: none;
 	}
 
-	.masterbar__help-menu-divider {
+	// Remove the alternating-group shading; this menu only needs a plain separator.
+	.masterbar__item-subitems .masterbar__item-subitems-item.masterbar__help-menu-divider {
+		background: none;
+
 		hr {
-			background: var( --color-masterbar-submenu-hover-text, var( --color-masterbar-highlight ) );
-			opacity: 0.2;
+			// Override the app-wide `hr` rule. Fixed neutral gray (not a text/theme
+			// token, which dark mode can remap to low contrast) so it stays visible.
 			margin: 0;
+			border: 0;
+			height: 1px;
+			background: var( --studio-gray-10 );
 		}
 	}
 

--- a/packages/agents-manager/README.md
+++ b/packages/agents-manager/README.md
@@ -99,7 +99,8 @@ See `src/hooks/custom-actions/README.md` for details.
 import { useShouldUseUnifiedAgent, getAgentsManagerInlineData } from '@automattic/agents-manager';
 
 function MyComponent() {
-	// Check if the unified agent experience is active
+	// Check if the unified agent experience is active. Outside a
+	// `QueryClientProvider`, pass a client: `useShouldUseUnifiedAgent( queryClient )`.
 	const shouldUseUnifiedAgent = useShouldUseUnifiedAgent();
 
 	// Read the unified experience flag from inline script data (non-hook)

--- a/packages/agents-manager/src/hooks/use-should-use-unified-agent.ts
+++ b/packages/agents-manager/src/hooks/use-should-use-unified-agent.ts
@@ -1,8 +1,11 @@
-/* eslint-disable no-restricted-imports */
 import { useUnifiedAiChat } from './use-unified-ai-chat';
+import type { QueryClient } from '@tanstack/react-query';
 
-export const useShouldUseUnifiedAgent = () => {
-	const { data: isEligibleViaAPI } = useUnifiedAiChat();
+/**
+ * Pass a `queryClient` when calling this outside a `QueryClientProvider`.
+ */
+export const useShouldUseUnifiedAgent = ( queryClient?: QueryClient ) => {
+	const { data: isEligibleViaAPI } = useUnifiedAiChat( true, queryClient );
 
 	return isEligibleViaAPI;
 };

--- a/packages/agents-manager/src/hooks/use-unified-ai-chat.ts
+++ b/packages/agents-manager/src/hooks/use-unified-ai-chat.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, type QueryClient } from '@tanstack/react-query';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { getAgentsManagerInlineData } from '../utils/get-agents-manager-inline-data';
 
@@ -21,31 +21,34 @@ interface AgentsManagerStateResponse {
  * The rollout logic lives in Agents Manager (Jetpack) via the
  * `agents_manager_use_unified_experience` filter.
  */
-export function useUnifiedAiChat( enabled = true ) {
-	return useQuery< boolean, Error >( {
-		queryKey: [ 'unified-ai-chat' ],
-		queryFn: async () => {
-			// 1. Check inline script first (available on wp-admin via Jetpack's Agents Manager)
-			const inlineValue = getAgentsManagerInlineData()?.useUnifiedExperience;
-			if ( inlineValue !== undefined ) {
-				return inlineValue;
-			}
+export function useUnifiedAiChat( enabled = true, queryClient?: QueryClient ) {
+	return useQuery< boolean, Error >(
+		{
+			queryKey: [ 'unified-ai-chat' ],
+			queryFn: async () => {
+				// 1. Check inline script first (available on wp-admin via Jetpack's Agents Manager)
+				const inlineValue = getAgentsManagerInlineData()?.useUnifiedExperience;
+				if ( inlineValue !== undefined ) {
+					return inlineValue;
+				}
 
-			// 2. Fall back to /agents-manager/state endpoint for Calypso app (wordpress.com)
-			if ( canAccessWpcomApis() ) {
-				const response: AgentsManagerStateResponse = await wpcomRequest( {
-					path: '/agents-manager/state?key=unified_ai_chat',
-					apiNamespace: 'wpcom/v2',
-				} );
+				// 2. Fall back to /agents-manager/state endpoint for Calypso app (wordpress.com)
+				if ( canAccessWpcomApis() ) {
+					const response: AgentsManagerStateResponse = await wpcomRequest( {
+						path: '/agents-manager/state?key=unified_ai_chat',
+						apiNamespace: 'wpcom/v2',
+					} );
 
-				return response.unified_ai_chat ?? false;
-			}
+					return response.unified_ai_chat ?? false;
+				}
 
-			// 3. No data available - default to false
-			return false;
+				// 3. No data available - default to false
+				return false;
+			},
+			enabled,
+			refetchOnWindowFocus: false,
+			staleTime: 300000, // 5 minutes
 		},
-		enabled,
-		refetchOnWindowFocus: false,
-		staleTime: 300000, // 5 minutes
-	} );
+		queryClient
+	);
 }


### PR DESCRIPTION
Part of `AI-1073` and `AI-1024`

## Proposed Changes

- Bring the combined **Help dropdown** and **"Ask AI"** button to the Multi-site Dashboard omnibar (the `my.wordpress.com` masterbar), matching the classic Calypso masterbar. Both are gated on the unified AI experience flag (`useShouldUseUnifiedAgent`) — the same source of truth Calypso uses — so they appear only when that experience is enabled.
- Give `useShouldUseUnifiedAgent()` an optional `queryClient` param so the omnibar (which renders outside a `QueryClientProvider`) can pass the masterbar's own client, then enable `loadAgentsManager` and `useUnifiedAgent`.
- Fix the help-menu divider in the agents-manager dropdown: drop the inherited alternating-group background band and render a single 1px separator with a fixed neutral gray, so it stays visible on both the dark omnibar panel and the light masterbar panel.

## Why are these changes being made?

The unified AI help experience (combined Help dropdown + "Ask AI") shipped on the classic Calypso masterbar but was not available on the new Multi-site Dashboard omnibar. This brings parity so Dashboard users get the same help/AI entry points, gated by the same rollout flag. The divider change corrects a rendering artifact (a shaded band / doubled line) in the dropdown.

## Testing Instructions

> **Note:** During testing, the wrong chat may load, or no chat may load at all, because older assets are still cached. Since the AM chat will replace the legacy HC chat, users should not encounter this issue. Therefore, I have kept the implementation as simple as possible and have not added logic to handle this temporary caching behavior.

1. Check out this PR.
2. Run `yarn start-dashboard`.
3. Go to `/wp-admin/profile.php` and enable the **Unified AI Experience** option.
4. Open an MSD page, such as `http://my.localhost:3000/sites`. The AI button and dropdown should appear in the admin bar and behave the same as they do on `http://calypso.localhost:3000/me`.

   * Verify that the broken divider styling has also been fixed.

https://github.com/user-attachments/assets/7a5331cd-0611-45e8-9745-18b7cd9ad325

5. Go back to `/wp-admin/profile.php` and disable the **Unified AI Experience** option.
6. **Wait for the cache to clear. This may take a few minutes.**
7. Verify that the legacy HC button is displayed:

<img width="384" height="149" alt="Screenshot showing the legacy HC button" src="https://github.com/user-attachments/assets/45cbb42e-705c-4b3c-8588-6dc590b601ff" />

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

