### PR TITLE
Dashboard billing: derive Titan cancellation feature list from the tier

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -14,6 +14,7 @@ import {
 	getRemoveLossIntro,
 	getSingleItemCancelCopy,
 	getSingleItemRemoveCopy,
+	getTitanCancellationLossItems,
 } from './get-confirmation-copy';
 import type { Purchase, CancellationFeature } from '@automattic/api-core';
 
@@ -33,17 +34,24 @@ const CancelPurchaseFeatureList = ( {
 	cancellationFeatures: CancellationFeature[];
 	cancellationChanges: FeatureObject[];
 } ) => {
-	// When the server returns no feature list, fall back to a per-product-type
-	// item so every confirmation screen shows at least one concrete thing the
-	// user is giving up.
-	const lossItems: Array< { key: string; title: string } > = cancellationFeatures.length
-		? cancellationFeatures
-				.filter( ( feature ): feature is CancellationFeature => Boolean( feature ) )
-				.map( ( feature ) => ( { key: String( feature.feature_id ), title: feature.title } ) )
-		: getFallbackLossItems( purchase ).map( ( title, idx ) => ( {
-				key: `fallback-${ idx }`,
-				title,
-		  } ) );
+	// Titan's server-provided feature list is tier-unaware, so for Titan
+	// purchases we derive the loss list from the tier the user is on. Everything
+	// else uses the server list, falling back to a per-product-type item so every
+	// confirmation screen shows at least one concrete thing the user is giving up.
+	const titanLossItems = getTitanCancellationLossItems( purchase );
+	let lossItems: Array< { key: string; title: string } >;
+	if ( titanLossItems ) {
+		lossItems = titanLossItems.map( ( title, idx ) => ( { key: `titan-${ idx }`, title } ) );
+	} else if ( cancellationFeatures.length ) {
+		lossItems = cancellationFeatures
+			.filter( ( feature ): feature is CancellationFeature => Boolean( feature ) )
+			.map( ( feature ) => ( { key: String( feature.feature_id ), title: feature.title } ) );
+	} else {
+		lossItems = getFallbackLossItems( purchase ).map( ( title, idx ) => ( {
+			key: `fallback-${ idx }`,
+			title,
+		} ) );
+	}
 
 	if ( ! lossItems.length && ! cancellationChanges.length ) {
 		return null;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
@@ -1,6 +1,8 @@
 import { AkismetPlans, TitanMailSlugs } from '@automattic/api-core';
 import { _n, __, sprintf } from '@wordpress/i18n';
 import { intervalToDuration } from 'date-fns';
+import { TitanPlanTier } from '../../../emails/types';
+import { getTitanTierFromSlug } from '../../../emails/utils/titan-tiers';
 import { isGSuiteOrGoogleWorkspaceProductSlug, DisplayVariant } from '../../../utils/purchase';
 
 /**
@@ -511,6 +513,58 @@ export function getButtonLabels( { purchase, intent }: ConfirmationCopyArgs ): {
 		primary: __( 'Cancel subscription' ),
 		secondary: __( 'Keep subscription' ),
 	};
+}
+
+/**
+ * Curated "what you'll lose" list for a Titan (Professional Email) subscription,
+ * keyed off the purchase's tier. Returns null when the purchase is not a Titan
+ * tier product.
+ *
+ * The server-provided cancel-features list is tier-unaware for Titan (it returns
+ * the Pro feature set regardless of tier), so the cancel flow prefers this list
+ * for Titan purchases to show the storage and highlights that match the tier the
+ * user is actually on.
+ */
+export function getTitanCancellationLossItems( purchase: PurchaseForCopy ): string[] | null {
+	const tier = getTitanTierFromSlug( purchase.product_slug );
+	if ( ! tier ) {
+		return null;
+	}
+
+	const customEmail = __( 'Your custom email address' );
+	const emailCalendarContacts = __( 'Email, calendar, and contacts' );
+	const webAndMobile = __( 'Access on web and mobile' );
+	const support = __( '24/7 email support' );
+
+	switch ( tier ) {
+		case TitanPlanTier.Premium:
+			return [
+				customEmail,
+				__( '50 GB of mailbox storage' ),
+				emailCalendarContacts,
+				webAndMobile,
+				__( 'Two-factor authentication, priority inbox, and more' ),
+				support,
+			];
+		case TitanPlanTier.Ultra:
+			return [
+				customEmail,
+				__( '100 GB of mailbox storage' ),
+				emailCalendarContacts,
+				webAndMobile,
+				__( 'Titan AI, email campaigns, and more' ),
+				support,
+			];
+		case TitanPlanTier.Pro:
+		default:
+			return [
+				customEmail,
+				__( '30 GB of mailbox storage' ),
+				emailCalendarContacts,
+				webAndMobile,
+				support,
+			];
+	}
 }
 
 /**

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/get-confirmation-copy.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/get-confirmation-copy.ts
@@ -10,6 +10,7 @@ import {
 	getCheckboxLabel,
 	getButtonLabels,
 	getFallbackLossItems,
+	getTitanCancellationLossItems,
 } from '../get-confirmation-copy';
 import type { Purchase } from '@automattic/api-core';
 
@@ -308,6 +309,41 @@ describe( 'getFallbackLossItems', () => {
 				makePurchaseForCategory( 'one-time', { product_name: 'Do it for me: Website Design' } )
 			)
 		).toEqual( [ 'Do it for me: Website Design' ] );
+	} );
+} );
+
+describe( 'getTitanCancellationLossItems', () => {
+	test( 'returns null for non-Titan products', () => {
+		expect( getTitanCancellationLossItems( makePurchaseForCategory( 'plan' ) ) ).toBeNull();
+		expect(
+			getTitanCancellationLossItems( makePurchase( { is_plan: false, product_slug: 'gapps' } ) )
+		).toBeNull();
+	} );
+	test( 'Pro tier lists 30 GB storage and no tier highlight', () => {
+		const items = getTitanCancellationLossItems(
+			makePurchase( { is_plan: false, product_slug: 'wp_titan_mail_yearly' } )
+		);
+		expect( items ).toEqual( [
+			'Your custom email address',
+			'30 GB of mailbox storage',
+			'Email, calendar, and contacts',
+			'Access on web and mobile',
+			'24/7 email support',
+		] );
+	} );
+	test( 'Premium tier lists 50 GB storage and a tier highlight', () => {
+		const items = getTitanCancellationLossItems(
+			makePurchase( { is_plan: false, product_slug: 'wp_titan_mail_premium_yearly' } )
+		);
+		expect( items ).toContain( '50 GB of mailbox storage' );
+		expect( items ).toContain( 'Two-factor authentication, priority inbox, and more' );
+	} );
+	test( 'Ultra tier lists 100 GB storage and a tier highlight', () => {
+		const items = getTitanCancellationLossItems(
+			makePurchase( { is_plan: false, product_slug: 'wp_titan_mail_ultra_yearly' } )
+		);
+		expect( items ).toContain( '100 GB of mailbox storage' );
+		expect( items ).toContain( 'Titan AI, email campaigns, and more' );
 	} );
 } );
 


### PR DESCRIPTION
Fixes #

## Proposed Changes

* On the Dashboard Cancel subscription page, the "what you'll lose" list for Titan (Professional Email) is now derived from the tier the user is actually on (Pro / Premium / Ultra) instead of the server `cancel-features` list.
* Added `getTitanCancellationLossItems()` in `cancel-purchase/get-confirmation-copy.ts`, which resolves the tier via the existing `getTitanTierFromSlug()` and returns a curated per-tier loss list (correct mailbox storage + a tier highlight). Returns `null` for non-Titan products.
* Wired it into `cancel-purchase/feature-list.tsx`: Titan purchases use the tier list; everything else keeps the server list -> per-product fallback behavior unchanged.
* Added unit tests for the new helper.

## Why are these changes being made?

The server `GET /wpcom/v2/upgrades/{purchaseId}/cancel-features` endpoint is tier-unaware for Titan and returns the Pro feature set regardless of tier. As a result, an Ultra subscriber on the cancel screen saw "30 GB of mailbox storage" (Pro) instead of 100 GB. This surfaces tier-correct storage and highlights so the list matches what the user is paying for.

## Testing Instructions

* Open the Cancel subscription page for a Titan **Ultra** purchase (`/me/billing/purchases/:id/cancel?intent=cancel`).
* The loss list should now read "100 GB of mailbox storage" plus an Ultra highlight, instead of "30 GB".
* Repeat with a Premium purchase (50 GB) and a Pro purchase (30 GB, no extra highlight).
* Non-Titan products (plans, domains, Google Workspace, Jetpack, etc.) are unchanged.
* `yarn test-client client/dashboard/me/billing-purchases/cancel-purchase/test/get-confirmation-copy.ts`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?