### PR TITLE
Emails: show free-trial label per Titan tier in plan grid

### DIFF
--- a/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
+++ b/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
@@ -11,12 +11,15 @@ import { Text } from '../../../components/text';
 import { useEmailProduct } from '../../hooks/use-email-product';
 import poweredByTitanLogo from '../../resources/powered-by-titan-caps.svg';
 import { IntervalLength, MailboxProvider, TitanPlanTier } from '../../types';
-import type { Domain, Product } from '@automattic/api-core';
+import { getTrialMonths } from '../../utils/get-trial-months';
+import { isEligibleForIntroductoryOffer } from '../../utils/is-eligible-for-introductory-offer';
+import type { Domain, EmailSubscription, Product } from '@automattic/api-core';
 
 interface TitanPlan {
 	tier: TitanPlanTier;
 	product?: Product;
 	hasFreeTrial: boolean;
+	trialMonths: number;
 	isPopular: boolean;
 	everythingInName?: string;
 }
@@ -110,8 +113,6 @@ export function TitanPlanGrid( {
 	domainName,
 	interval,
 	available,
-	hasProFreeTrial,
-	proTrialMonths,
 	currentTier,
 	onUpgrade,
 }: {
@@ -119,8 +120,6 @@ export function TitanPlanGrid( {
 	domainName: string;
 	interval: IntervalLength;
 	available: boolean;
-	hasProFreeTrial: boolean;
-	proTrialMonths: number;
 	// The tier the user is currently subscribed to. When set, the grid is in
 	// upgrade mode: lower tiers are hidden, the current tier is labeled, and higher
 	// tiers offer an upgrade.
@@ -149,24 +148,31 @@ export function TitanPlanGrid( {
 		TitanPlanTier.Ultra
 	);
 
+	const emailSubscription = domain?.titan_mail_subscription as EmailSubscription | undefined;
+	const hasFreeTrial = ( product?: Product ) =>
+		isEligibleForIntroductoryOffer( { emailSubscription, product } );
+
 	const plans: TitanPlan[] = [
 		{
 			tier: TitanPlanTier.Pro,
 			product: proProduct,
-			hasFreeTrial: hasProFreeTrial,
+			hasFreeTrial: hasFreeTrial( proProduct ),
+			trialMonths: getTrialMonths( proProduct ),
 			isPopular: false,
 		},
 		{
 			tier: TitanPlanTier.Premium,
 			product: premiumProduct,
-			hasFreeTrial: false,
+			hasFreeTrial: hasFreeTrial( premiumProduct ),
+			trialMonths: getTrialMonths( premiumProduct ),
 			isPopular: true,
 			everythingInName: getTierName( TitanPlanTier.Pro ),
 		},
 		{
 			tier: TitanPlanTier.Ultra,
 			product: ultraProduct,
-			hasFreeTrial: false,
+			hasFreeTrial: hasFreeTrial( ultraProduct ),
+			trialMonths: getTrialMonths( ultraProduct ),
 			isPopular: false,
 			everythingInName: getTierName( TitanPlanTier.Premium ),
 		},
@@ -270,7 +276,7 @@ export function TitanPlanGrid( {
 									{ sprintf(
 										/* translators: %d is the number of free trial months. */
 										__( '%d month free trial' ),
-										proTrialMonths
+										plan.trialMonths
 									) }
 								</div>
 							) }

--- a/client/dashboard/emails/choose-email-solution/index.tsx
+++ b/client/dashboard/emails/choose-email-solution/index.tsx
@@ -1,4 +1,4 @@
-import { EmailSubscription, Product } from '@automattic/api-core';
+import { EmailSubscription } from '@automattic/api-core';
 import config from '@automattic/calypso-config';
 import { useNavigate } from '@tanstack/react-router';
 import {
@@ -34,6 +34,7 @@ import { useEmailProduct } from '../hooks/use-email-product';
 import poweredByTitanLogo from '../resources/powered-by-titan-caps.svg';
 import { IntervalLength, MailboxProvider, TitanPlanTier } from '../types';
 import { getTitanTierUpgradeUrl } from '../utils/get-tier-upgrade-url';
+import { getTrialMonths } from '../utils/get-trial-months';
 import { isEligibleForIntroductoryOffer } from '../utils/is-eligible-for-introductory-offer';
 import { isMonthlyEmailProduct } from '../utils/is-monthly-email-product';
 import { getTitanTierFromSlug } from '../utils/titan-tiers';
@@ -42,9 +43,6 @@ import { GoogleWorkspaceCard } from './components/google-workspace-card';
 import { TitanPlanGrid } from './components/titan-plan-grid';
 
 import './style.scss';
-
-const getTrialMonths = ( product?: Product ) =>
-	product?.introductory_offer?.interval_unit === 'year' ? 12 : 3;
 
 export default function ChooseEmailSolution() {
 	const { domain, domainName, site } = useDomainFromUrlParam();
@@ -284,8 +282,6 @@ export default function ChooseEmailSolution() {
 						domainName={ domainName }
 						interval={ billingInterval }
 						available={ isTitanAvailable }
-						hasProFreeTrial={ hasTitanFreeTrial }
-						proTrialMonths={ getTrialMonths( titanProduct ) }
 						currentTier={
 							isUpgradeIntent
 								? getTitanTierFromSlug( titanEmailSubscription?.product_slug )

--- a/client/dashboard/emails/utils/get-trial-months.ts
+++ b/client/dashboard/emails/utils/get-trial-months.ts
@@ -1,0 +1,4 @@
+import type { Product } from '@automattic/api-core';
+
+export const getTrialMonths = ( product?: Product ) =>
+	product?.introductory_offer?.interval_unit === 'year' ? 12 : 3;


### PR DESCRIPTION
## Proposed Changes

* In the `choose-email-solution` Titan plan grid, compute the free-trial badge and trial length **per tier** from each tier's own product, instead of hardcoding `hasFreeTrial: false` for Premium and Ultra.
* The parent (`index.tsx`) no longer passes Pro-only `hasProFreeTrial` / `proTrialMonths` props into the grid; the grid derives eligibility itself via `isEligibleForIntroductoryOffer` using the products it already fetches for all three tiers.
* Extracted the shared `getTrialMonths` helper into `client/dashboard/emails/utils/get-trial-months.ts` so both the page and the grid use the same logic.

## Why are these changes being made?

On the new-tiers email chooser, only the Pro plan ever showed the "N month free trial" label. The label is gated on `plan.hasFreeTrial`, but Premium and Ultra were hardcoded to `false`, and only the Pro tier's eligibility (and trial month count) was plumbed down from the parent. The grid already fetches the Premium/Ultra products, so their `introductory_offer` data was available but never checked. This wires each tier to its own product so any tier with a valid introductory offer displays the correct trial badge and duration.

## Testing Instructions

* Enable the `emails/titan-tiers` feature flag.
* Go to `/emails/choose-email-solution/<domain>` for a domain eligible for a Professional Email introductory offer.
* Confirm each tier (Pro / Premium / Ultra) whose product has a valid free-trial `introductory_offer` shows the "N month free trial" badge with the correct duration (12 for yearly, 3 for monthly), and the price shows the discounted/original pair.
* Toggle the billing interval and confirm the badge/duration update per tier.
* Confirm tiers without an introductory offer show no badge, and existing subscribers (upgrade mode / auto-redirect) behave unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
