### PR TITLE
Packages: refresh launchpad, date-range-picker, and data-stores to fix duplicate dependencies

### DIFF
--- a/packages/data-stores/CHANGELOG.md
+++ b/packages/data-stores/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.2
+
+- Publish against `i18n-calypso@^8.0.0`, resolving a duplicate/mismatched `i18n-calypso` version in the installed dependency tree (previously published `3.2.1` pinned `i18n-calypso@^7.4.1`).
+
 ## 3.2.1
 
 - Declare React 19 compatibility for package consumers (#111721).

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/data-stores",
-	"version": "3.2.1",
+	"version": "3.2.2",
 	"description": "Calypso Data Stores.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/date-range-picker/CHANGELOG.md
+++ b/packages/date-range-picker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.6
+
+- Publish against `@automattic/ui@^2.0.0`, resolving a duplicate/mismatched `@automattic/ui` version in the installed dependency tree (previously published `1.0.4` pinned `@automattic/ui@^1.0.3`).
+
 ## 1.0.5
 
 - Packaging: declare `sass` as a runtime dependency for the package build script.

--- a/packages/date-range-picker/package.json
+++ b/packages/date-range-picker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/date-range-picker",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"description": "A date-range picker built on top of @automattic/ui's DateRangeCalendar, with timezone-aware site-day handling, preset shortcuts, and accessible inputs.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/launchpad/CHANGELOG.md
+++ b/packages/launchpad/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.4
+
+- Drop the direct `@automattic/components` dependency, resolving a duplicate/mismatched version in the installed dependency tree ([#111979](https://github.com/Automattic/wp-calypso/pull/111979)).
+- Drop unused and trivially-replaceable dependencies ([#111976](https://github.com/Automattic/wp-calypso/pull/111976)).
+
 ## 1.2.3
 
 - Declare React 19 compatibility for package consumers (#111721).

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/launchpad",
-	"version": "1.2.3",
+	"version": "1.2.4",
 	"description": "Launchpad components.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Proposed Changes

Package version bumps to publish already-merged dependency cleanups, each fixing a duplicated/mismatched dependency in consumers' installed trees:

* **`@automattic/launchpad` → `1.2.4`** — published `1.2.3` declares a direct `@automattic/components@^3.0.4` while the rest of the tree resolves `@automattic/components@4.1.0`. Trunk already dropped the direct dependency (#111979) plus other unused deps (#111976); this bump ships that fix.
* **`@automattic/date-range-picker` → `1.0.6`** — published `1.0.4` pins `@automattic/ui@^1.0.3`, but the workspace is now on `@automattic/ui@2.0.0`. The source already uses `workspace:^`, so a fresh publish resolves to `@automattic/ui@^2.0.0`.
* **`@automattic/data-stores` → `3.2.2`** — published `3.2.1` pins `i18n-calypso@^7.4.1`, but the workspace is now on `i18n-calypso@8.1.0`. The source already uses `workspace:^`, so a fresh publish resolves to `i18n-calypso@^8.0.0`.

## Why are these changes being made?

* Consumers installing these packages end up with two copies of a shared dependency (`@automattic/components`, `@automattic/ui`, `i18n-calypso` respectively). Publishing fresh versions that carry the corrected dependency ranges resolves the duplication.

## Testing Instructions

* Build each package: `yarn workspace @automattic/launchpad build`, `yarn workspace @automattic/date-range-picker build`, `yarn workspace @automattic/data-stores build`.
* After publish:
  * `npm view @automattic/launchpad@1.2.4 dependencies` — no longer lists `@automattic/components`.
  * `npm view @automattic/date-range-picker@1.0.6 dependencies` — lists `@automattic/ui@^2.0.0`.
  * `npm view @automattic/data-stores@3.2.2 dependencies` — lists `i18n-calypso@^8.0.0`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
