### PR TITLE
Replace deprecated @github/webauthn-json with native WebAuthn JSON methods

### DIFF
--- a/client/dashboard/me/security-two-step-auth/utils.ts
+++ b/client/dashboard/me/security-two-step-auth/utils.ts
@@ -1,5 +1,3 @@
-import { supported } from '@github/webauthn-json';
-
 function isBrowser() {
 	try {
 		if ( ! window ) {
@@ -12,7 +10,12 @@ function isBrowser() {
 }
 
 export function isWebAuthnSupported() {
-	return isBrowser() && supported();
+	return (
+		isBrowser() &&
+		typeof window.PublicKeyCredential !== 'undefined' &&
+		typeof window.PublicKeyCredential.parseCreationOptionsFromJSON === 'function' &&
+		typeof window.PublicKeyCredential.parseRequestOptionsFromJSON === 'function'
+	);
 }
 
 // WebAuthn requires the relying party ID to be a registrable suffix of the current origin, so

--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -1,10 +1,10 @@
 import config from '@automattic/calypso-config';
-import { get as webauthn_auth } from '@github/webauthn-json';
 import debugFactory from 'debug';
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import emitter from 'calypso/lib/mixins/emitter';
 import { reduxDispatch } from 'calypso/lib/redux-bridge';
+import { webauthnGet } from 'calypso/lib/webauthn';
 import wp from 'calypso/lib/wp';
 import { accountRecoverySettingsFetch } from 'calypso/state/account-recovery/settings/actions';
 import { requestConnectedApplications } from 'calypso/state/connected-applications/actions';
@@ -108,7 +108,7 @@ TwoStepAuthorization.prototype.loginUserWithSecurityKey = function ( args ) {
 			if ( typeof this.data.two_step_webauthn_nonce === 'undefined' ) {
 				return Promise.reject( response );
 			}
-			return webauthn_auth( { publicKey: parameters } );
+			return webauthnGet( parameters );
 		} )
 		.then( ( assertion ) => {
 			return this.postLoginRequest( 'webauthn-authentication-endpoint', {

--- a/client/lib/webauthn/index.js
+++ b/client/lib/webauthn/index.js
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import { create, supported } from '@github/webauthn-json';
 import { translate } from 'i18n-calypso';
 import wpcom from 'calypso/lib/wp';
 
@@ -39,12 +38,29 @@ function isBrowser() {
 }
 
 export function isWebAuthnSupported() {
-	return isBrowser() && supported();
+	return (
+		isBrowser() &&
+		typeof window.PublicKeyCredential !== 'undefined' &&
+		typeof window.PublicKeyCredential.parseCreationOptionsFromJSON === 'function' &&
+		typeof window.PublicKeyCredential.parseRequestOptionsFromJSON === 'function'
+	);
+}
+
+async function webauthnCreate( options ) {
+	const publicKey = window.PublicKeyCredential.parseCreationOptionsFromJSON( options );
+	const credential = await navigator.credentials.create( { publicKey } );
+	return credential.toJSON();
+}
+
+export async function webauthnGet( options ) {
+	const publicKey = window.PublicKeyCredential.parseRequestOptionsFromJSON( options );
+	const assertion = await navigator.credentials.get( { publicKey } );
+	return assertion.toJSON();
 }
 
 export function registerSecurityKey( keyName = null ) {
 	return wpcomApiRequest( '/me/two-step/security-key/registration_challenge' )
-		.then( ( options ) => create( { publicKey: options } ) )
+		.then( ( options ) => webauthnCreate( options ) )
 		.then( ( response ) => {
 			return wpcomApiRequest(
 				'/me/two-step/security-key/registration_validate',

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -1,5 +1,4 @@
 import { Button, Card, Dialog, FormInputValidation, FormLabel } from '@automattic/components';
-import { supported } from '@github/webauthn-json';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -12,6 +11,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormVerificationCodeInput from 'calypso/components/forms/form-verification-code-input';
 import Notice from 'calypso/components/notice';
 import WarningCard from 'calypso/components/warning-card';
+import { isWebAuthnSupported } from 'calypso/lib/webauthn';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import SecurityKeyForm from './security-key-form';
@@ -260,7 +260,7 @@ class ReauthRequired extends Component {
 		const enhancedSecurity = this.props.twoStepAuthorization.data?.two_step_enhanced_security;
 		const method = this.props.twoStepAuthorization.isTwoStepSMSEnabled() ? 'sms' : 'authenticator';
 		const isSecurityKeySupported =
-			this.props.twoStepAuthorization.isSecurityKeyEnabled() && supported();
+			this.props.twoStepAuthorization.isSecurityKeyEnabled() && isWebAuthnSupported();
 		const twoFactorAuthType = enhancedSecurity ? 'webauthn' : this.state.twoFactorAuthType;
 		// This enables the SMS button on the security key form regardless if we can send SMS or not.
 		// Otherwise, there's no way to go back to the verification form if smsRequestsAllowed is false.

--- a/client/package.json
+++ b/client/package.json
@@ -89,7 +89,6 @@
 		"@emotion/react": "^11.11.1",
 		"@emotion/styled": "^11.11.0",
 		"@fingerprintjs/fingerprintjs": "3.4.2",
-		"@github/webauthn-json": "^2.1.1",
 		"@paypal/react-paypal-js": "^8.7.0",
 		"@stripe/react-stripe-js": "^6.6.0",
 		"@stripe/stripe-js": "^9.8.0",

--- a/client/state/login/actions/login-user-with-security-key.js
+++ b/client/state/login/actions/login-user-with-security-key.js
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
-import { get as webauthn_auth } from '@github/webauthn-json';
 import { translate } from 'i18n-calypso';
+import { webauthnGet } from 'calypso/lib/webauthn';
 import {
 	TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST,
 	TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_FAILURE,
@@ -33,7 +33,7 @@ export const loginUserWithSecurityKey = () => ( dispatch, getState ) => {
 			if ( twoStepNonce ) {
 				dispatch( updateNonce( twoFactorAuthType, twoStepNonce ) );
 			}
-			return webauthn_auth( { publicKey: parameters } );
+			return webauthnGet( parameters );
 		} )
 		.then( ( assertion ) => {
 			const response = assertion.response;

--- a/packages/api-queries/package.json
+++ b/packages/api-queries/package.json
@@ -41,7 +41,6 @@
 		"@automattic/api-core": "workspace:^",
 		"@automattic/calypso-config": "workspace:^",
 		"@automattic/calypso-support-session": "workspace:^",
-		"@github/webauthn-json": "^2.1.1",
 		"@tanstack/query-sync-storage-persister": "^5.83.0",
 		"@tanstack/react-query": "^5.83.0",
 		"@tanstack/react-query-persist-client": "^5.83.0",

--- a/packages/api-queries/src/me-two-step.ts
+++ b/packages/api-queries/src/me-two-step.ts
@@ -12,7 +12,6 @@ import {
 	updateUserSettings,
 	sendTwoStepAuthSMSCode,
 } from '@automattic/api-core';
-import { create } from '@github/webauthn-json';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { userSettingsQuery } from './me-settings';
 import { queryClient } from './query-client';
@@ -33,11 +32,14 @@ export const registerTwoStepAuthSecurityKeyMutation = ( hostname = 'wordpress.co
 			const options = await fetchTwoStepAuthSecurityKeyRegistrationChallenge( { hostname } );
 
 			// Create the WebAuthn credential
-			const credential = await create( { publicKey: options } );
+			const publicKey = PublicKeyCredential.parseCreationOptionsFromJSON( options );
+			const credential = ( await navigator.credentials.create( {
+				publicKey,
+			} ) ) as PublicKeyCredential;
 
 			// Validate the registration with the server
 			const validationData = {
-				data: JSON.stringify( credential ),
+				data: JSON.stringify( credential.toJSON() ),
 				name: keyName,
 				hostname,
 			};

--- a/packages/calypso-build/webpack/util.js
+++ b/packages/calypso-build/webpack/util.js
@@ -69,7 +69,6 @@ const nodeModulesToTranspile = [
 	// In some cases we do want prefix style matching (e.g. `foo.` to match `foo.bar`)
 	'@automattic/calypso-polyfills/',
 	'@automattic/lasagna/',
-	'@github/webauthn-json/',
 	'acorn-jsx/',
 	'chalk/',
 	'd3-array/',

--- a/yarn.lock
+++ b/yarn.lock
@@ -257,7 +257,6 @@ __metadata:
     "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-support-session": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
-    "@github/webauthn-json": "npm:^2.1.1"
     "@tanstack/query-sync-storage-persister": "npm:^5.83.0"
     "@tanstack/react-query": "npm:^5.83.0"
     "@tanstack/react-query-persist-client": "npm:^5.83.0"
@@ -5409,15 +5408,6 @@ __metadata:
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
   checksum: 0b3c9958d3cd17f4add3574975e3115ae05dc7f1298a60810414b16f6f558c137b5fb3cd3905df380bacfd955ec13f67c1e6710cbb5c246a7e8d65a8289b2bff
-  languageName: node
-  linkType: hard
-
-"@github/webauthn-json@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "@github/webauthn-json@npm:2.1.1"
-  bin:
-    webauthn-json: dist/bin/main.js
-  checksum: 4423ddd1e5b74d91ded02ea551923a73c45b1ee2ee4294943aaddfc12e1929405ea1e8b4380456db829fcdc3a4d8a89bf8ee29c6a35be3889dc00236b1c96968
   languageName: node
   linkType: hard
 
@@ -14536,7 +14526,6 @@ __metadata:
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
     "@fingerprintjs/fingerprintjs": "npm:3.4.2"
-    "@github/webauthn-json": "npm:^2.1.1"
     "@paypal/react-paypal-js": "npm:^8.7.0"
     "@sentry/webpack-plugin": "npm:^1.21.0"
     "@stripe/react-stripe-js": "npm:^6.6.0"


### PR DESCRIPTION
## Proposed Changes

Replace the deprecated [`@github/webauthn-json`](https://github.com/github/webauthn-json) package with the native browser WebAuthn JSON serialization methods, following the migration advice in the archived repo's README.

- Registration (`create`) now uses `PublicKeyCredential.parseCreationOptionsFromJSON()` → `navigator.credentials.create()` → `credential.toJSON()`.
- Authentication (`get`) now uses `PublicKeyCredential.parseRequestOptionsFromJSON()` → `navigator.credentials.get()` → `credential.toJSON()`.
- `supported()` checks are replaced with a native capability check (`window.PublicKeyCredential` plus the `parse*FromJSON` methods).
- The shared Calypso `create`/`get` logic is centralized in `client/lib/webauthn` (new `webauthnGet` export); `packages/api-queries` and the self-contained Dashboard client each use the native APIs directly.
- Removed the `@github/webauthn-json` dependency from `client/package.json` and `packages/api-queries/package.json`, its entry in the `calypso-build` transpile list, and the `yarn.lock` entries.

## Why are these changes being made?

`@github/webauthn-json` was deprecated and its repository archived in March 2025. All major browsers now natively support `PublicKeyCredential.parseCreationOptionsFromJSON()`, `parseRequestOptionsFromJSON()`, and `toJSON()`, which the deprecation notice confirms are compatible with the library's encoding. Migrating drops a dead third-party dependency, reduces auth-page bundle size, and keeps us on browser-maintained APIs (including future extensions like PRF).

## Testing Instructions

1. `yarn install`
2. On a WordPress.com account with a security key (WebAuthn) enrolled:
   - Register a new security key via `/me/security/two-step` (classic) and via the Dashboard two-step screen — confirm the key is added.
   - Log out and log back in using the security key (login 2FA flow) — confirm authentication succeeds.
   - Trigger a re-auth prompt and confirm the security-key form still appears when supported.
3. On a browser/context without WebAuthn support, confirm the security-key UI is gracefully hidden.

Automated checks run locally: `yarn typecheck-packages` (pass), affected client type-check (no new errors), `yarn eslint` on changed files (pass), and the related unit tests (`security-two-step-auth/utils`, `reauth-required`) — all pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
