### PR TITLE
Checkout: Make sidebar Continue button always try to complete step

### DIFF
--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -814,15 +814,25 @@ export function CheckoutFormSubmit( {
 		if ( ! targetStepId ) {
 			return;
 		}
-		const didActivateTarget = await makeStepActive( targetStepId );
-		// If activation failed, makeStepActive stopped on an intervening step that
-		// did not validate and left it active. Scroll to whichever step actually
-		// ended up active (read from the live store) so the user lands on the step
-		// that needs attention rather than a step that stayed collapsed. Desktop
-		// does not auto-scroll on step changes, so we always scroll explicitly.
-		const stepIdToScrollTo = didActivateTarget
-			? targetStepId
-			: getStepIdFromNumber( state.activeStepNumber ) ?? targetStepId;
+		if ( stepIdMap[ targetStepId ] === activeStepNumber ) {
+			// The active step is itself the step that still needs completing.
+			// makeStepActive would be a no-op here because it only runs completion
+			// callbacks for the steps *before* its target, so it would never validate
+			// the active step. Run the active step's own completion callback instead so
+			// the button always tries to complete the step: surfacing inline validation
+			// errors when invalid and advancing when valid, exactly like the step's
+			// inline "Continue" button.
+			await getStepCompleteCallback( activeStepNumber )();
+		} else {
+			// makeStepActive walks forward from the active step, completing each step
+			// until it reaches the target or stops on an intervening step that fails to
+			// validate (leaving that step active).
+			await makeStepActive( targetStepId );
+		}
+		// Scroll to whichever step ended up active (read from the live store): the step
+		// we advanced to on success, or the step that still needs attention on failure.
+		// Desktop does not auto-scroll on step changes, so we always scroll explicitly.
+		const stepIdToScrollTo = getStepIdFromNumber( state.activeStepNumber ) ?? targetStepId;
 		document
 			.getElementById( stepIdToScrollTo )
 			?.scrollIntoView?.( { behavior: 'smooth', block: 'start' } );

--- a/packages/composite-checkout/test/checkout.tsx
+++ b/packages/composite-checkout/test/checkout.tsx
@@ -914,10 +914,38 @@ describe( 'Checkout', () => {
 			await waitFor( () => {
 				expect( scrollIntoView ).toHaveBeenCalledWith( { behavior: 'smooth', block: 'start' } );
 			} );
-			// The active step (step 1) is the first incomplete step, so it is the scroll target.
+			// The active step (step 1) validates successfully, so it completes and we
+			// advance to step 2, the next incomplete step, which becomes the scroll target.
 			expect( ( scrollIntoView.mock.instances[ 0 ] as HTMLElement ).id ).toBe(
-				'custom-contact-step'
+				'custom-incomplete-step'
 			);
+		} );
+
+		it( 'tries to complete the active step and stays on it when it fails to validate', async () => {
+			const scrollIntoView = jest.fn();
+			window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+			const isCompleteCallback = jest.fn( () => false );
+			// The active (first numbered) step is invalid; a later step follows it so the
+			// summary shows "Continue" rather than the Pay button.
+			const invalidActiveStep = { ...steps[ 3 ], isCompleteCallback };
+			const { container } = render(
+				<ContinueCheckout withProp steps={ [ steps[ 0 ], invalidActiveStep, steps[ 1 ] ] } />
+			);
+			const submitArea = getSubmitArea( container );
+			const user = userEvent.setup();
+			await user.click( getByTextInNode( submitArea, 'Continue' ) );
+
+			// The active step's own completion callback runs (the fix): previously
+			// makeStepActive would no-op on the active step and never validate it.
+			await waitFor( () => {
+				expect( isCompleteCallback ).toHaveBeenCalled();
+			} );
+			// Validation failed, so we stay on the active step and scroll to it.
+			await waitFor( () => {
+				expect( ( scrollIntoView.mock.instances[ 0 ] as HTMLElement ).id ).toBe(
+					'custom-incomplete-step'
+				);
+			} );
 		} );
 
 		it( 'renders the payment method submit button when the last step is active', () => {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2259/

## Proposed changes

Fixes the sidebar "Continue" button in checkout doing nothing when the active step is itself incomplete. It now always runs the active step's own completion callback so the button behaves consistently with the step's inline "Continue" button — surfacing validation errors on invalid input, advancing on valid input.

Before             |  After
:-------------------------:|:-------------------------:
<img width="1184" height="486" alt="Screenshot 2026-07-16 at 3 24 34 PM" src="https://github.com/user-attachments/assets/8887e7c4-cb3e-4a19-98a2-4dc796a754b4" /> | <img width="1306" height="470" alt="Screenshot 2026-07-16 at 3 25 51 PM" src="https://github.com/user-attachments/assets/2254b9f8-ca7c-4815-800b-c5f2b541d40f" />



## Why are these changes being made?

The sidebar "Continue" CTA (added in #111328, SHILL-2091) called `makeStepActive(targetStepId)` with the id of the next incomplete step. When the active step is itself incomplete — e.g. you edit the billing step and clear the postal code — `targetStepId` is the currently active step, and `makeStepActive` only runs completion callbacks for the steps *before* its target:

```js
for ( let step = activeStep; step < stepNumber; step++ ) { ... }
```

With `activeStep === stepNumber` that loop never executes, so the active step's validation never fires. The handler just re-set the same active step and scrolled, producing no visible effect and no error messaging — the reported "Continue button has no effect."

The fix routes that case through the active step's own completion callback (the same one the inline "Continue to payment" button uses), so the button always *tries to complete* the step: it validates, shows inline errors when invalid, and advances when valid. This makes the sidebar and inline buttons behave identically, which is the intended behavior.

## Testing instructions

* Open a WordPress.com checkout with two steps (billing info + payment method).
* On the billing step, clear the contents of the postal code field.
* Click the sidebar "Continue" button.
* Confirm the step now attempts to validate and shows the inline validation error, rather than silently doing nothing.
* Re-enter valid billing data, click "Continue" again, and confirm it advances to the payment step.

