### PR TITLE
date-range-picker: move sass to devDependencies

### DIFF
--- a/packages/date-range-picker/package.json
+++ b/packages/date-range-picker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/date-range-picker",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"description": "A date-range picker built on top of @automattic/ui's DateRangeCalendar, with timezone-aware site-day handling, preset shortcuts, and accessible inputs.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
@@ -46,8 +46,7 @@
 	},
 	"dependencies": {
 		"@automattic/ui": "workspace:^",
-		"date-fns": "^4.1.0",
-		"sass": "1.77.8"
+		"date-fns": "^4.1.0"
 	},
 	"peerDependencies": {
 		"@wordpress/components": ">=35.0.0",
@@ -97,6 +96,7 @@
 		"jest": "^29.7.0",
 		"mockdate": "^2.0.5",
 		"postcss": "^8.5.15",
+		"sass": "1.77.8",
 		"typescript": "^6.0.3",
 		"webpack": "^5.99.8"
 	}


### PR DESCRIPTION
## Proposed Changes

* Move `sass` from `dependencies` to `devDependencies` in `@automattic/date-range-picker`.
* Bump the package version to `1.0.7`.

## Why are these changes being made?

`sass` is only used at build time by `bin/build-styles.js`, which precompiles `src/style.scss` into `dist/{esm,cjs}/style.css`. The published package ships that compiled CSS, and Calypso consumers using `calypso:src` bundle the SCSS through their own sass-loader. No consumer of the published package needs `sass` at runtime, so declaring it as a runtime dependency needlessly pulls it into consumers' dependency trees.

This mirrors how `@automattic/calypso-color-schemes` (which uses `sass` the same build-time-only way) declares it as a devDependency.

## Testing Instructions

* `yarn install`
* `cd packages/date-range-picker && yarn build`
* Confirm the build succeeds and `dist/esm/style.css` / `dist/cjs/style.css` are produced (sass still resolves from devDependencies).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
