### PR TITLE
Plans: Show term length selector in downgrade flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -1,3 +1,4 @@
+import { getIntervalTypeForTerm, getPlan, isFreePlan } from '@automattic/calypso-products';
 import { OnboardSelect } from '@automattic/data-stores';
 import { DOMAIN_FLOW, ONBOARDING_FLOW, Step, useStepPersistedState } from '@automattic/onboarding';
 import { useSelect, useDispatch as useWPDispatch } from '@wordpress/data';
@@ -143,10 +144,22 @@ const PlansStepAdaptor: StepType< {
 	const isUsingStepContainerV2 =
 		shouldUseStepContainerV2( props.flow ) || props.flow === DOMAIN_FLOW;
 
-	// The downgrade flow only lets users move between paid plans on the same billing
-	// term, so hide the free and enterprise plans (not valid downgrade targets) and
-	// the billing term selector.
+	// The downgrade flow only lets users move between paid plans, so hide the free
+	// and enterprise plans (not valid downgrade targets) and default the billing
+	// term selector to the currently active plan's term.
 	const isDowngradeFlow = defaultPlansIntent === 'plans-upgrade-or-downgrade';
+
+	const currentPlanSlug = site?.plan?.product_slug;
+	const currentPlanIntervalType =
+		currentPlanSlug && ! isFreePlan( currentPlanSlug )
+			? getIntervalTypeForTerm( getPlan( currentPlanSlug )?.term ?? '' )
+			: null;
+
+	useEffect( () => {
+		if ( isDowngradeFlow && planInterval === undefined && currentPlanIntervalType ) {
+			setPlanInterval( currentPlanIntervalType );
+		}
+	}, [ isDowngradeFlow, planInterval, currentPlanIntervalType ] );
 
 	if ( isLoadingSelectedTheme ) {
 		return isUsingStepContainerV2 ? <Step.Loading /> : <Loading />;
@@ -157,7 +170,6 @@ const PlansStepAdaptor: StepType< {
 			{ ...getHidePlanPropsBasedOnThemeType( selectedThemeType || '' ) }
 			hideFreePlan={ hideFreePlan || isDowngradeFlow }
 			hideEnterprisePlan={ isDowngradeFlow }
-			hidePlanTypeSelector={ isDowngradeFlow }
 			selectedSite={ site ?? undefined }
 			saveSignupStep={ ( step ) => {
 				setStepState( ( mostRecentState = { ...stepState, ...step } as ProvidedDependencies ) );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-513/

## Proposed changes

This restores the billing-term selector on the stepper plans page for the self-serve downgrade flow (`/setup/plan-upgrade?allow_downgrade=true`), which had been intentionally hidden, and makes it open pre-selected to the currently active plan's term instead of the generic default.

Before             |  After
:-------------------------:|:-------------------------:
<img width="1510" height="779" alt="Screenshot 2026-07-16 at 4 02 31 PM" src="https://github.com/user-attachments/assets/4c2b1acd-b72e-47f5-97a2-e7ff19792fea" /> | <img width="1512" height="802" alt="Screenshot 2026-07-16 at 4 02 39 PM" src="https://github.com/user-attachments/assets/9c24150f-e156-4855-b729-87e5f9ee930c" />


## Why are these changes being made?

When the self-serve downgrade feature launched on the stepper plans page, the billing-term selector was hidden to keep users on a single billing term. In practice that removed a useful affordance: downgrade-eligible users could no longer see or choose the term the plans are displayed on, which is confusing when their active plan is billed monthly, biennially, or triennially rather than annually.

Bringing the selector back — but defaulting it to the active plan's term — keeps the flow anchored to what the user is actually paying for today while letting them adjust the term if they want. The existing `PlansFeaturesMain` term-compatibility logic (`ensureCompatibleIntervalType` / `useFilteredDisplayedIntervals`, already active because the plan-upgrade flow sets `isStepperUpgradeFlow`) continues to clamp and filter out terms shorter than the current plan, so re-enabling the selector doesn't reopen shorter-term downgrades.

## Testing instructions

Manual testing:
* Use a WordPress.com site you admin that holds a paid plan (ideally one on a non-annual term, e.g. monthly or biennial, to make the default obvious).
* Visit `/setup/plan-upgrade?siteSlug=<your-site>&allow_downgrade=true`.
* Confirm the billing-term selector is now visible above the plans grid.
* Confirm it opens pre-selected to the same term as your active plan.
* Change the term and confirm the grid updates and your selection sticks.
* Confirm free and enterprise plans are still not shown.

