### PR TITLE
Dashboard: nudge new users to set up account recovery after email verification

### DIFF
--- a/client/dashboard/me/security/index.tsx
+++ b/client/dashboard/me/security/index.tsx
@@ -12,6 +12,7 @@ import SecurityPasswordSummary from '../security-password/summary';
 import SecuritySocialLoginsSummary from '../security-social-logins/summary';
 import SecuritySshKeySummary from '../security-ssh-key/summary';
 import SecurityTwoStepAuthSummary from '../security-two-step-auth/summary';
+import RecoveryNudgeNotice from './recovery-nudge-notice';
 
 function Security() {
 	const { supports } = useAppContext();
@@ -30,6 +31,7 @@ function Security() {
 					description={ __( 'Manage your account security settings and authentication methods.' ) }
 				/>
 			}
+			notices={ <RecoveryNudgeNotice /> }
 		>
 			<SummaryButtonList>
 				<SecurityPasswordSummary />

--- a/client/dashboard/me/security/recovery-nudge-notice.tsx
+++ b/client/dashboard/me/security/recovery-nudge-notice.tsx
@@ -1,0 +1,61 @@
+import { Link } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect, useRef } from 'react';
+import { useAnalytics } from '../../app/analytics';
+import Notice from '../../components/notice';
+
+function isVerifiedRedirect() {
+	if ( typeof window === 'undefined' ) {
+		return false;
+	}
+	return new URLSearchParams( window.location.search ).get( 'verified' ) === '1';
+}
+
+function removeVerifiedParam() {
+	const params = new URLSearchParams( window.location.search );
+	params.delete( 'verified' );
+	const newUrl = window.location.pathname + ( params.toString() ? '?' + params.toString() : '' );
+	window.history.replaceState( {}, '', newUrl );
+}
+
+export default function RecoveryNudgeNotice() {
+	const { recordTracksEvent } = useAnalytics();
+	const [ isVisible, setIsVisible ] = useState( isVerifiedRedirect );
+	const hasRecordedImpression = useRef( false );
+
+	useEffect( () => {
+		if ( ! isVisible || hasRecordedImpression.current ) {
+			return;
+		}
+		hasRecordedImpression.current = true;
+		recordTracksEvent( 'calypso_dashboard_security_recovery_notice_impression' );
+		removeVerifiedParam();
+	}, [ isVisible, recordTracksEvent ] );
+
+	if ( ! isVisible ) {
+		return null;
+	}
+
+	return (
+		<Notice
+			variant="success"
+			title={ __( 'Email verified' ) }
+			onClose={ () => {
+				recordTracksEvent( 'calypso_dashboard_security_recovery_notice_dismiss' );
+				setIsVisible( false );
+			} }
+			actions={
+				<Link
+					to="/me/security/account-recovery"
+					onClick={ () => recordTracksEvent( 'calypso_dashboard_security_recovery_notice_click' ) }
+				>
+					{ __( 'Set up account recovery' ) }
+				</Link>
+			}
+		>
+			{ __(
+				'Help us help you recover your account if anything goes wrong. Set up at least one recovery option.'
+			) }
+		</Notice>
+	);
+}

--- a/client/dashboard/me/security/test/recovery-nudge-notice.test.tsx
+++ b/client/dashboard/me/security/test/recovery-nudge-notice.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../test-utils';
+import RecoveryNudgeNotice from '../recovery-nudge-notice';
+
+function setUrl( search: string ) {
+	window.history.replaceState( {}, '', `/me/security${ search }` );
+}
+
+describe( '<RecoveryNudgeNotice>', () => {
+	beforeEach( () => {
+		setUrl( '' );
+	} );
+
+	test( 'shows the notice, records an impression, and strips the verified param when verified=1', () => {
+		setUrl( '?verified=1' );
+
+		const { recordTracksEvent } = render( <RecoveryNudgeNotice /> );
+
+		expect( screen.getByText( /Set up at least one recovery option/ ) ).toBeVisible();
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_dashboard_security_recovery_notice_impression'
+		);
+		expect( window.location.search ).toBe( '' );
+	} );
+
+	test( 'renders nothing and records no impression without the verified param', () => {
+		const { recordTracksEvent } = render( <RecoveryNudgeNotice /> );
+
+		expect( screen.queryByText( /Set up at least one recovery option/ ) ).not.toBeInTheDocument();
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+	} );
+
+	test( 'records a dismiss event and hides the notice when closed', async () => {
+		setUrl( '?verified=1' );
+		const user = userEvent.setup();
+
+		const { recordTracksEvent } = render( <RecoveryNudgeNotice /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Dismiss' } ) );
+
+		expect( screen.queryByText( /Set up at least one recovery option/ ) ).not.toBeInTheDocument();
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_dashboard_security_recovery_notice_dismiss'
+		);
+	} );
+
+	test( 'records a click event when the recovery CTA is followed', async () => {
+		setUrl( '?verified=1' );
+		const user = userEvent.setup();
+
+		const { recordTracksEvent } = render( <RecoveryNudgeNotice /> );
+
+		await user.click( screen.getByRole( 'link', { name: 'Set up account recovery' } ) );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_dashboard_security_recovery_notice_click'
+		);
+	} );
+} );


### PR DESCRIPTION
Part of DOTOBRD-370

## Proposed Changes

- In the Hosting Dashboard's `/me/security` page, when the URL has a `?verified=1` parameter, show a dismissible success notice
- That notice shows email verification success and nudges the user to set up an account recovery method
- Add Tracks events for notice impression, CTA click, and dismiss
- Screenshot:

<img width="1095" height="1049" alt="Screenshot 2026-07-16 at 18 32 14" src="https://github.com/user-attachments/assets/105debe6-9294-42d4-800f-33a42b0072a3" />

## Why are these changes being made?

New users rarely set up account recovery, which generates account recovery support tickets later. Prompting right after email verification, when the user is engaged, aims to increase account recovery setup.

## Testing Instructions

Unit tests:
```
yarn test-client client/dashboard/me/security/test/recovery-nudge-notice.test.tsx
```

Manual tests:
- Build this PR locally or open the live Dashboard link
- Go to `/me/security?verified=1`
- Ensure the success notice appears like in the screenshot
- Ensure the CTA link goes to the account recovery page
- Ensure you can dismiss the modal

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
