### PR TITLE
Jetpack AI: Keep review tools in the default sidebar layout

### DIFF
--- a/packages/jetpack-ai-sidebar/src/components/feedback-list.scss
+++ b/packages/jetpack-ai-sidebar/src/components/feedback-list.scss
@@ -447,3 +447,23 @@
 		}
 	}
 }
+
+body.agents-manager-sidebar-container:not( .is-split-screen )
+	.agents-manager-chat--docked
+	.jetpack-ai-feedback-list__actions:has( .jetpack-ai-feedback-list__action-button.is-copy ) {
+	flex-wrap: nowrap;
+	align-items: stretch;
+	gap: 0.25rem;
+
+	.jetpack-ai-feedback-list__action-button {
+		justify-content: center;
+		min-width: 0;
+		padding-inline: 0.5rem;
+		text-align: center;
+		white-space: normal;
+
+		&.is-copy {
+			padding-inline: 0.25rem;
+		}
+	}
+}

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -2248,7 +2248,7 @@ describe( 'useSuggestions', () => {
 		] );
 	} );
 
-	it( 'keeps Simple Review on the backend path when clicked', () => {
+	it( 'keeps Simple Review on the backend path without opening split-screen when clicked', () => {
 		installAiEditorialReviewData();
 		installPostTypeMock( 'post' );
 		const addMessage = jest.fn();
@@ -2274,12 +2274,12 @@ describe( 'useSuggestions', () => {
 			);
 		} );
 
-		expect( mockSetIsSplitScreen ).toHaveBeenCalledWith( true );
+		expect( mockSetIsSplitScreen ).not.toHaveBeenCalled();
 		expect( clearSuggestions ).toHaveBeenCalled();
 		expect( addMessage ).not.toHaveBeenCalled();
 	} );
 
-	it( 'opens split-screen when the Proofread suggestion is clicked', () => {
+	it( 'does not open split-screen when the Proofread suggestion is clicked', () => {
 		installAiEditorialReviewData( { proofreadContent: true } );
 		installPostTypeMock( 'post' );
 		const proofreadPrompt = getEmptyViewSuggestions().find(
@@ -2296,10 +2296,10 @@ describe( 'useSuggestions', () => {
 			);
 		} );
 
-		expect( mockSetIsSplitScreen ).toHaveBeenCalledWith( true );
+		expect( mockSetIsSplitScreen ).not.toHaveBeenCalled();
 	} );
 
-	it( 'opens split-screen when the Editorial Review suggestion is clicked', () => {
+	it( 'does not open split-screen when the Editorial Review suggestion is clicked', () => {
 		installAiEditorialReviewData();
 		installPostTypeMock( 'post' );
 		const mediationPrompt = getEmptyViewSuggestions().find(
@@ -2316,7 +2316,7 @@ describe( 'useSuggestions', () => {
 			);
 		} );
 
-		expect( mockSetIsSplitScreen ).toHaveBeenCalledWith( true );
+		expect( mockSetIsSplitScreen ).not.toHaveBeenCalled();
 		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
 			'jetpack_ai_editorial_review_suggestion_click',
 			{}

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -9,7 +9,7 @@
 /**
  * WordPress dependencies
  */
-import { dispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useState, useEffect, useMemo } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 /**
@@ -1238,22 +1238,11 @@ export function useSuggestions(
 				trackBlockTransformationSuggestionClickForValue( value );
 			}
 
-			// Auto-expand the review-style chip flows below to 50vw.
 			if ( typeof value === 'string' && value === POST_FEEDBACK_SUGGESTION.prompt ) {
 				suppressCurrentPageContentForNextContext = true;
-				try {
-					( dispatch as any )( 'automattic/agents-manager' ).setIsSplitScreen( true );
-				} catch {
-					// Store not registered yet (e.g. tests); split-screen is demo polish.
-				}
 			}
 			if ( typeof value === 'string' && value === PROOFREAD_SUGGESTION.prompt ) {
 				suppressCurrentPageContentForNextContext = true;
-				try {
-					( dispatch as any )( 'automattic/agents-manager' ).setIsSplitScreen( true );
-				} catch {
-					// Store not registered yet (e.g. tests); split-screen is demo polish.
-				}
 			}
 			if (
 				isAiEditorialReviewAvailable() &&
@@ -1261,12 +1250,6 @@ export function useSuggestions(
 				value === AI_EDITORIAL_REVIEW_SUGGESTION.prompt
 			) {
 				trackAiEditorialReviewSuggestionClick();
-				try {
-					( dispatch as any )( 'automattic/agents-manager' ).setIsSplitScreen( true );
-				} catch {
-					// Store not registered yet (e.g. tests); split-screen is a
-					// polish feature, so a silent no-op is the right fallback.
-				}
 			}
 		};
 		window.addEventListener( 'big-sky-inline-suggestion-click', handleSuggestionClick, true );


### PR DESCRIPTION
## Proposed Changes

* Stop Simple Review, Proofread, and Editorial Review from automatically expanding the Agents Manager sidebar into split-screen mode.
* Preserve the manual split-screen control and the existing review-tool context and tracking behavior.
* As a secondary bug fix, keep the "Go to section", "Copy", and "Dismiss" actions aligned in the default docked sidebar without changing the split-screen or popped-out layouts.
* Update the review-tool click tests to prevent automatic split-screen expansion from returning.

## Why are these changes being made?

* Review tools should respect the default sidebar layout instead of forcing a wider presentation.
* Removing the forced expansion exposed an existing alignment bug at the default docked width, where the three-action manual-edit row could wrap "Dismiss" onto a separate line. A narrowly scoped responsive rule fixes that side issue while leaving wider layouts unchanged.

CSS fix demo:
Before
<img width="353" height="414" alt="image" src="https://github.com/user-attachments/assets/2b10deff-c797-4608-9d90-91a6deff9a3d" />

After
<img width="270" height="417" alt="image" src="https://github.com/user-attachments/assets/ea030656-3599-4a0c-9b1b-6639d8cc98e2" />


## Testing Instructions

1. Sandbox `widgets.wp.com`.
2. Check out this branch and sync it to the sandbox:
   ```sh
   git switch remove-review-auto-split-screen
   cd apps/agents-manager
   yarn dev --sync
   ```
3. Go to a draft post and open the Agents Manager sidebar.
4. Select any review tool, such as Proofread, Simple Review, or Editorial Review.
5. Verify that the sidebar does not automatically expand into split-screen mode.
6. Request an Editorial Review.
7. View the results in the default, non-split sidebar.
8. In sections that require a manual edit, verify that the "Go to section", "Copy", and "Dismiss" buttons are correctly aligned.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md), [Memoizing Selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors), and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation? (p4TIVU-5Jq-p2)
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words varies significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use? (p4TIVU-aUh-p2)