### PR TITLE
Add calypso_domain_bundle_purchased Tracks event

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-create-payment-submitted-and-processing-callback.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-submitted-and-processing-callback.tsx
@@ -12,6 +12,7 @@ import {
 	clearSignupDestinationCookie,
 } from 'calypso/signup/storageUtils';
 import { useSelector, useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { clearPurchases } from 'calypso/state/purchases/actions';
 import { fetchReceiptCompleted } from 'calypso/state/receipts/actions';
 import hasGravatarDomainQueryParam from 'calypso/state/selectors/has-gravatar-domain-query-param';
@@ -196,6 +197,7 @@ export default function useCreatePaymentSubmittedAndProcessingCallback( {
 			) {
 				debug( 'fetching receipt' );
 				reduxDispatch( fetchReceiptCompleted( receiptId, transactionResult ) );
+				recordDomainBundlePurchasedEvents( responseCart, reduxDispatch );
 			}
 
 			if ( siteId ) {
@@ -339,6 +341,34 @@ async function recordPaymentCompleteAnalytics( {
 			recordCompositeCheckoutErrorDuringAnalytics( {
 				errorObject: err as Error,
 				failureDescription: 'useCreatePaymentSubmittedAndProcessingCallback',
+			} )
+		);
+	}
+}
+
+/**
+ * Completes the domain bundle funnel (shown -> accepted -> purchased) by firing one
+ * `calypso_domain_bundle_purchased` Tracks event per distinct bundle in the purchased cart.
+ * Matches the shape of the `shown`/`accepted` events emitted during domain search.
+ */
+function recordDomainBundlePurchasedEvents(
+	responseCart: ResponseCart,
+	reduxDispatch: CalypsoDispatch
+) {
+	const domainCountByBundle = new Map< string, number >();
+	for ( const product of responseCart.products ) {
+		const groupId = product.extra?.domain_bundle_group_id;
+		if ( ! groupId ) {
+			continue;
+		}
+		domainCountByBundle.set( groupId, ( domainCountByBundle.get( groupId ) ?? 0 ) + 1 );
+	}
+
+	for ( const [ groupId, domainCount ] of domainCountByBundle ) {
+		reduxDispatch(
+			recordTracksEvent( 'calypso_domain_bundle_purchased', {
+				domain_bundle_group_id: groupId,
+				domain_count: domainCount,
 			} )
 		);
 	}


### PR DESCRIPTION
Related to #DOMAINS-2221

## What

Adds a new `calypso_domain_bundle_purchased` Tracks event that fires on successful checkout completion, one event per distinct domain bundle in the purchased cart.

Props match the existing bundle events (`calypso_domain_bundle_shown`, `calypso_domain_bundle_accepted`):

- `domain_bundle_group_id`
- `domain_count` — number of products in the cart sharing that group id

## Why

The bundle funnel currently dead-ends at `accepted` (a click on "add to cart"). This completes the funnel **shown → accepted → purchased**, all joinable on `domain_bundle_group_id`, so we can measure conversion all the way through payment.

## How

In `use-create-payment-submitted-and-processing-callback.tsx`, on the confirmed-success path (same gate used for `fetchReceiptCompleted`: `receiptId` + `transactionResult.success` + `purchases`), we group `responseCart.products` by `product.extra?.domain_bundle_group_id`, skip products without a group id, and dispatch one `recordTracksEvent( 'calypso_domain_bundle_purchased', ... )` per distinct group id. Fires exactly once per successful purchase.

## Caveat

This is a **client-side** event: it fires when payment succeeds in the browser, so it will slightly over-count relative to cleared money (and, like all events in this callback, it does not capture redirect payment methods such as PayPal, which never invoke this callback). For hard revenue numbers prefer backend events; this event is for funnel analysis.

## Testing

- `eslint` (repo config) — clean
- `tsc --project client --noEmit` — no errors in the changed file
