### PR TITLE
Dashboard: name mutation failure stats using meta.statId

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -177,5 +177,15 @@ module.exports = {
 			},
 		],
 		'@tanstack/query/exhaustive-deps': 'error',
+		'no-restricted-syntax': [
+			'error',
+			{
+				// Spreading an api-queries factory and then setting `meta` replaces the
+				// whole object, dropping the factory's `meta.statId`.
+				selector: "Property[key.name='meta'] > ObjectExpression > Property[key.name='snackbar']",
+				message:
+					'Setting `meta.snackbar` by hand drops the mutation’s `meta.statId`. Use `withSnackbar()` from app/snackbars/with-snackbar instead.',
+			},
+		],
 	},
 };

--- a/client/dashboard/AGENTS.md
+++ b/client/dashboard/AGENTS.md
@@ -15,6 +15,27 @@ This is the new hosting dashboard for WordPress.com.
   2. If the behavior genuinely differs per dashboard variant, add a property to `AppConfig` that each variant provides, and branch on that property instead of the name.
   3. Before doing either, ask: if this UX is better for one variant, wouldn't it be better for all users? Prefer a single code path when possible.
 
+### Mutation snackbars
+
+Use `withSnackbar()` from `app/snackbars/with-snackbar` to attach a snackbar to a mutation. Never write `meta: { snackbar }` by hand:
+
+```ts
+useMutation( withSnackbar( sitePhpVersionMutation( siteId ), { success: __( 'Saved.' ) } ) );
+```
+
+Every `@automattic/api-queries` mutation carries a `meta.statId` naming its failure stat. Spreading a factory and then setting `meta` replaces the whole object rather than merging, so the `statId` is lost and the failure is reported as `missing`. `withSnackbar()` merges instead. A `no-restricted-syntax` rule in `.eslintrc.js` enforces this.
+
+If the mutation needs other options too, wrap only the factory:
+
+```ts
+useMutation( {
+	...withSnackbar( sitePhpVersionMutation( siteId ), { success: __( 'Saved.' ) } ),
+	onSuccess: () => {
+		/* … */
+	},
+} );
+```
+
 ### Internationalization
 
 - When calling locale-aware formatting functions (`toLocaleDateString`, `toLocaleString`, `Intl.*`, etc.), prefer passing the user's locale from `useLocale()` (`app/locale`) rather than `undefined`. Passing `undefined` falls back to the browser/OS locale, so output silently drifts from the user's WordPress.com language setting.

--- a/client/dashboard/AGENTS.md
+++ b/client/dashboard/AGENTS.md
@@ -23,7 +23,7 @@ Use `withSnackbar()` from `app/snackbars/with-snackbar` to attach a snackbar to 
 useMutation( withSnackbar( sitePhpVersionMutation( siteId ), { success: __( 'Saved.' ) } ) );
 ```
 
-Every `@automattic/api-queries` mutation carries a `meta.statId` naming its failure stat. Spreading a factory and then setting `meta` replaces the whole object rather than merging, so the `statId` is lost and the failure is reported as `missing`. `withSnackbar()` merges instead. A `no-restricted-syntax` rule in `.eslintrc.js` enforces this.
+Every `@automattic/api-queries` mutation carries a `meta.statId` naming its failure stat. Spreading a factory and then setting `meta` replaces the whole object rather than merging, so the `statId` is lost. `withSnackbar()` merges instead. A `no-restricted-syntax` rule in `.eslintrc.js` enforces this.
 
 If the mutation needs other options too, wrap only the factory:
 

--- a/client/dashboard/agency/resources/mcp/use-mcp-settings.ts
+++ b/client/dashboard/agency/resources/mcp/use-mcp-settings.ts
@@ -6,21 +6,19 @@ import {
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
+import { withSnackbar } from '../../../app/snackbars/with-snackbar';
 import type { McpSettingsUpdate } from '@automattic/api-core';
 
 export function useMcpSettings() {
 	const { data: agency } = useQuery( activeAgencyQuery() );
 	const agencyId = agency?.id ?? 0;
 	const { data: settings, isLoading } = useQuery( mcpSettingsQuery( agencyId ) );
-	const { mutate, isPending } = useMutation( {
-		...agencyMcpSettingsMutation( agencyId ),
-		meta: {
-			snackbar: {
-				success: __( 'MCP settings saved.' ),
-				error: __( 'Could not save. Please try again.' ),
-			},
-		},
-	} );
+	const { mutate, isPending } = useMutation(
+		withSnackbar( agencyMcpSettingsMutation( agencyId ), {
+			success: __( 'MCP settings saved.' ),
+			error: __( 'Could not save. Please try again.' ),
+		} )
+	);
 
 	const save = useCallback( ( update: McpSettingsUpdate ) => mutate( update ), [ mutate ] );
 

--- a/client/dashboard/app/analytics/index.tsx
+++ b/client/dashboard/app/analytics/index.tsx
@@ -56,8 +56,9 @@ export function bumpStat( group: string, value: string ) {
  *
  * Example:
  * ```ts
- *   [ 'error', 'failed' ],
+ * bumpMultipleStats(
  *   [ 'my-stat', 'failed' ],
+ *   [ 'error', 'failed' ],
  *   [ 'interesting', 'true' ]
  * );
  * ```

--- a/client/dashboard/app/mutation-error-tracker/index.tsx
+++ b/client/dashboard/app/mutation-error-tracker/index.tsx
@@ -1,4 +1,5 @@
 import { isWpError } from '@automattic/api-core';
+import { captureException } from '@automattic/calypso-sentry';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { bumpMultipleStats } from '../analytics';
@@ -15,9 +16,24 @@ export default function MutationErrorTracker() {
 			const { mutation } = event;
 			const error = event.action.error;
 
-			// Most mutations are not annotated yet, so a missing ID is expected rather
-			// than a fault worth reporting.
-			const value = mutation.meta?.statId ?? 'missing';
+			const statId = mutation.meta?.statId;
+
+			// Every api-queries mutation is annotated, so a missing ID means an unannotated
+			// mutation defined elsewhere — a gap in the stats worth fixing at the source.
+			if ( statId === undefined ) {
+				captureException( new Error( 'Failed mutation is missing a meta.statId property' ), {
+					extra: {
+						mutation_key: mutation.options.mutationKey ?? null,
+						error_message: error instanceof Error ? error.message : String( error ),
+						error_status: isWpError( error ) ? error.status : null,
+
+						// Stack may help us track down which mutation this is.
+						error_stack: error instanceof Error ? error.stack : null,
+					},
+				} );
+			}
+
+			const value = statId ?? 'missing';
 			const stats = [] as [ string, string ][];
 
 			stats.push( [ 'dashboard-mutation-error', value ] );
@@ -28,7 +44,7 @@ export default function MutationErrorTracker() {
 				// prompt), so monitor the rate rather than reporting each one to Sentry.
 				stats.push( [ 'dashboard-mutation-error-other', value ] );
 			} else {
-				// Groups mutation failures with their error code e.g. `domain-dnssec-mut.401`
+				// Groups mutation failures with their error code e.g. `domain-dnssec-update.401`
 				stats.push( [ 'dashboard-mutation-error-status', `${ value }.${ error.status }` ] );
 
 				if ( error.status >= 400 && error.status < 500 ) {

--- a/client/dashboard/app/mutation-error-tracker/test/index.test.tsx
+++ b/client/dashboard/app/mutation-error-tracker/test/index.test.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { captureException } from '@automattic/calypso-sentry';
 import { render } from '../../../test-utils';
 import { bumpMultipleStats } from '../../analytics';
 import MutationErrorTracker from '../index';
@@ -10,7 +11,12 @@ jest.mock( '../../analytics', () => ( {
 	bumpMultipleStats: jest.fn(),
 } ) );
 
+jest.mock( '@automattic/calypso-sentry', () => ( {
+	captureException: jest.fn(),
+} ) );
+
 const mockedBumpMultipleStats = jest.mocked( bumpMultipleStats );
+const mockedCaptureException = jest.mocked( captureException );
 
 function wpError( fields: { status: number; statusCode: number; error?: string } ) {
 	return Object.assign( new Error( 'boom' ), fields );
@@ -68,13 +74,15 @@ describe( '<MutationErrorTracker>', () => {
 			[ 'dashboard-mutation-error', '2fa-security-key-register' ],
 			[ 'dashboard-mutation-error-other', '2fa-security-key-register' ]
 		);
+		expect( mockedCaptureException ).not.toHaveBeenCalled();
 	} );
 
-	test( 'falls back to `missing` for a mutation with no statId', async () => {
+	test( 'falls back to `missing` and reports a mutation with no statId', async () => {
 		const { queryClient } = render( <MutationErrorTracker /> );
 
 		const error = wpError( { status: 500, statusCode: 500 } );
 		const mutation = queryClient.getMutationCache().build( queryClient, {
+			mutationKey: [ 'PULL_FROM_STAGING', 12345 ],
 			mutationFn: () => Promise.reject( error ),
 		} );
 
@@ -85,6 +93,33 @@ describe( '<MutationErrorTracker>', () => {
 			[ 'dashboard-mutation-error-status', 'missing.500' ],
 			[ 'dashboard-mutation-error-5xx', 'missing' ]
 		);
+		expect( mockedCaptureException ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				message: 'Failed mutation is missing a meta.statId property',
+			} ),
+			expect.objectContaining( {
+				extra: expect.objectContaining( {
+					mutation_key: [ 'PULL_FROM_STAGING', 12345 ],
+					error_message: 'boom',
+					error_status: 500,
+					error_stack: error.stack,
+				} ),
+			} )
+		);
+	} );
+
+	test( 'does not report a failure that has a statId', async () => {
+		const { queryClient } = render( <MutationErrorTracker /> );
+
+		const error = wpError( { status: 404, statusCode: 404, error: 'not_found' } );
+		const mutation = queryClient.getMutationCache().build( queryClient, {
+			meta: { statId: '2fa-security-key-register' },
+			mutationFn: () => Promise.reject( error ),
+		} );
+
+		await expect( mutation.execute( undefined ) ).rejects.toBe( error );
+
+		expect( mockedCaptureException ).not.toHaveBeenCalled();
 	} );
 
 	test( 'does not bump anything when a mutation succeeds', async () => {
@@ -98,5 +133,6 @@ describe( '<MutationErrorTracker>', () => {
 		await mutation.execute( undefined );
 
 		expect( mockedBumpMultipleStats ).not.toHaveBeenCalled();
+		expect( mockedCaptureException ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/dashboard/app/snackbars/test/index.tsx
+++ b/client/dashboard/app/snackbars/test/index.tsx
@@ -2,6 +2,9 @@
  * @jest-environment jsdom
  */
 
+/* eslint-disable no-restricted-syntax -- these fixtures stand in for the merged
+   `meta` the mutation cache holds, not for a mutation call site. */
+
 import { useQueryClient } from '@tanstack/react-query';
 import { act, render } from '@testing-library/react';
 import { SnackbarList } from '@wordpress/components';

--- a/client/dashboard/app/snackbars/test/index.tsx
+++ b/client/dashboard/app/snackbars/test/index.tsx
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/* eslint-disable no-restricted-syntax -- these fixtures stand in for the merged
-   `meta` the mutation cache holds, not for a mutation call site. */
-
 import { useQueryClient } from '@tanstack/react-query';
 import { act, render } from '@testing-library/react';
 import { SnackbarList } from '@wordpress/components';
@@ -109,6 +106,8 @@ describe( 'Snackbars', () => {
 			action: { type: 'success' },
 			mutation: {
 				meta: {
+					// Testing the underlying snackbar behaviour, so don't use withSnackbar() here.
+					// eslint-disable-next-line no-restricted-syntax
 					snackbar: {
 						success: 'Operation completed.',
 					},
@@ -175,6 +174,7 @@ describe( 'Snackbars', () => {
 			},
 			mutation: {
 				meta: {
+					// eslint-disable-next-line no-restricted-syntax -- see above: we're testing the snackbar behaviour itself.
 					snackbar: {
 						error: { source: 'server' },
 					},
@@ -206,6 +206,7 @@ describe( 'Snackbars', () => {
 			},
 			mutation: {
 				meta: {
+					// eslint-disable-next-line no-restricted-syntax -- see above: we're testing the snackbar behaviour itself.
 					snackbar: {
 						error: 'Custom snackbar error.',
 					},

--- a/client/dashboard/app/snackbars/with-snackbar.ts
+++ b/client/dashboard/app/snackbars/with-snackbar.ts
@@ -19,5 +19,6 @@ export function withSnackbar< T extends { meta?: ApiQueriesMutationMeta } >(
 	options: T,
 	snackbar: Snackbar
 ): T {
+	// eslint-disable-next-line no-restricted-syntax -- this is the merge the rule points at.
 	return { ...options, meta: { ...options.meta, snackbar } };
 }

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -19,6 +19,7 @@ import {
 	domainsContactInfoRoute,
 } from '../../app/router/domains';
 import { getCurrentDashboard } from '../../app/routing';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import ComponentViewTracker from '../../components/component-view-tracker';
 import { isDomainRenewable, canSetAsPrimary, getDomainRenewalUrl } from '../../utils/domain';
 import { isTransferrableToWpcom } from '../../utils/domain-types';
@@ -42,14 +43,11 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const { data: purchases } = useQuery( userPurchasesQuery() );
 
-	const { mutate: setPrimaryDomain, isPending: isSettingPrimaryDomain } = useMutation( {
-		...siteSetPrimaryDomainMutation(),
-		meta: {
-			snackbar: {
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const { mutate: setPrimaryDomain, isPending: isSettingPrimaryDomain } = useMutation(
+		withSnackbar( siteSetPrimaryDomainMutation(), {
+			error: { source: 'server' },
+		} )
+	);
 
 	const sitesByBlogId: Record< number, Site > = useMemo( () => {
 		if ( ! sites ) {

--- a/client/dashboard/domains/dns/add.tsx
+++ b/client/dashboard/domains/dns/add.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute } from '../../app/router/domains';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import DnsDescription from '../domain-dns/dns-description';
@@ -17,16 +18,13 @@ export default function DomainAddDNS() {
 	const navigate = useNavigate();
 	const { domainName } = domainRoute.useParams();
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
-	const mutation = useMutation( {
-		...domainDnsMutation( domainName ),
-		meta: {
-			snackbar: {
-				/* translators: %s is the domain name */
-				success: sprintf( __( 'DNS record added successfully for %s.' ), domainName ),
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( domainDnsMutation( domainName ), {
+			/* translators: %s is the domain name */
+			success: sprintf( __( 'DNS record added successfully for %s.' ), domainName ),
+			error: { source: 'server' },
+		} )
+	);
 
 	const navigateToDNSOverviewPage = () => {
 		navigate( {

--- a/client/dashboard/domains/dns/edit.tsx
+++ b/client/dashboard/domains/dns/edit.tsx
@@ -5,6 +5,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useEffect } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute } from '../../app/router/domains';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import DnsDescription from '../domain-dns/dns-description';
@@ -20,16 +21,13 @@ export default function DomainEditDNS() {
 	const { domainName } = domainRoute.useParams();
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const { recordId } = domainRoute.useSearch();
-	const mutation = useMutation( {
-		...domainDnsMutation( domainName ),
-		meta: {
-			snackbar: {
-				/* translators: %s is the domain name */
-				success: sprintf( __( 'DNS record updated successfully for %s.' ), domainName ),
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( domainDnsMutation( domainName ), {
+			/* translators: %s is the domain name */
+			success: sprintf( __( 'DNS record updated successfully for %s.' ), domainName ),
+			error: { source: 'server' },
+		} )
+	);
 
 	const { data: dnsRecords } = useSuspenseQuery( domainDnsQuery( domainName ) );
 

--- a/client/dashboard/domains/domain-contact-details/index.tsx
+++ b/client/dashboard/domains/domain-contact-details/index.tsx
@@ -13,6 +13,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useMemo } from 'react';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
 import { domainRoute } from '../../app/router/domains';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { Card, CardBody } from '../../components/card';
 import ContactForm from '../../components/domain-contact-details-form/contact-form';
 import ContactFormPrivacy from '../../components/domain-contact-details-form/contact-form-privacy';
@@ -48,54 +49,41 @@ export default function DomainContactInfo() {
 		return { initialData, key: JSON.stringify( initialData ) };
 	}, [ registrantWhoisData ] );
 
-	const validateMutation = useMutation( {
-		...domainWhoisValidateMutation( [ domainName ] ),
-		meta: { snackbar: { error: { source: 'server' } } },
-	} );
-	const updateMutation = useMutation( {
-		...domainWhoisMutation( domainName ),
-		meta: {
-			snackbar: {
-				/* translators: %s is the domain name */
-				success: sprintf( __( 'Contact details for %s saved.' ), domainName ),
-				error: { source: 'server' },
-			},
-		},
-	} );
-	const savePrivacyMutation = useMutation( {
-		...domainPrivacySaveMutation( domainName ),
-		meta: {
-			snackbar: {
-				/* translators: %s is the domain name */
-				success: sprintf( __( 'Privacy has been successfully updated for %s!' ), domainName ),
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const validateMutation = useMutation(
+		withSnackbar( domainWhoisValidateMutation( [ domainName ] ), { error: { source: 'server' } } )
+	);
+	const updateMutation = useMutation(
+		withSnackbar( domainWhoisMutation( domainName ), {
+			/* translators: %s is the domain name */
+			success: sprintf( __( 'Contact details for %s saved.' ), domainName ),
+			error: { source: 'server' },
+		} )
+	);
+	const savePrivacyMutation = useMutation(
+		withSnackbar( domainPrivacySaveMutation( domainName ), {
+			/* translators: %s is the domain name */
+			success: sprintf( __( 'Privacy has been successfully updated for %s!' ), domainName ),
+			error: { source: 'server' },
+		} )
+	);
 
-	const disclosePrivacyMutation = useMutation( {
-		...domainPrivacyDiscloseSaveMutation( domainName ),
-		meta: {
-			snackbar: {
-				success: sprintf(
-					/* translators: %s is the domain name */
-					__( 'Your contact information for %s is now publicly visible!' ),
-					domainName
-				),
-				error: { source: 'server' },
-			},
-		},
-	} );
-	const redactPrivacyMutation = useMutation( {
-		...domainPrivacyDiscloseSaveMutation( domainName ),
-		meta: {
-			snackbar: {
+	const disclosePrivacyMutation = useMutation(
+		withSnackbar( domainPrivacyDiscloseSaveMutation( domainName ), {
+			success: sprintf(
 				/* translators: %s is the domain name */
-				success: sprintf( __( 'Your contact information for %s is now redacted!' ), domainName ),
-				error: { source: 'server' },
-			},
-		},
-	} );
+				__( 'Your contact information for %s is now publicly visible!' ),
+				domainName
+			),
+			error: { source: 'server' },
+		} )
+	);
+	const redactPrivacyMutation = useMutation(
+		withSnackbar( domainPrivacyDiscloseSaveMutation( domainName ), {
+			/* translators: %s is the domain name */
+			success: sprintf( __( 'Your contact information for %s is now redacted!' ), domainName ),
+			error: { source: 'server' },
+		} )
+	);
 
 	const isSubmitting =
 		validateMutation.isPending ||

--- a/client/dashboard/domains/domain-diagnostics/index.tsx
+++ b/client/dashboard/domains/domain-diagnostics/index.tsx
@@ -11,6 +11,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
 import { domainOverviewRoute, domainRoute } from '../../app/router/domains';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
@@ -24,25 +25,19 @@ export default function DomainDiagnostics() {
 
 	const { data: domainDiagnostics } = useSuspenseQuery( domainDiagnosticsQuery( domainName ) );
 
-	const { mutate: fixDnsIssues, isPending: isFixing } = useMutation( {
-		...domainDnsEmailMutation( domainName ),
-		meta: {
-			snackbar: {
-				success: __( 'Default email DNS records restored.' ),
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const { mutate: fixDnsIssues, isPending: isFixing } = useMutation(
+		withSnackbar( domainDnsEmailMutation( domainName ), {
+			success: __( 'Default email DNS records restored.' ),
+			error: { source: 'server' },
+		} )
+	);
 
-	const { mutate: dismissNotice, isPending: isDismissing } = useMutation( {
-		...domainNoticeMutation( domainName, 'email-dns-records-diagnostics' ),
-		meta: {
-			snackbar: {
-				success: __( 'Domain diagnostics notice dismissed.' ),
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const { mutate: dismissNotice, isPending: isDismissing } = useMutation(
+		withSnackbar( domainNoticeMutation( domainName, 'email-dns-records-diagnostics' ), {
+			success: __( 'Domain diagnostics notice dismissed.' ),
+			error: { source: 'server' },
+		} )
+	);
 
 	const emailDnsDiagnostics = domainDiagnostics?.email_dns_records;
 

--- a/client/dashboard/domains/domain-dns/actions.tsx
+++ b/client/dashboard/domains/domain-dns/actions.tsx
@@ -6,20 +6,18 @@ import { __ } from '@wordpress/i18n';
 import { pencil as edit, trash } from '@wordpress/icons';
 import { useMemo } from 'react';
 import { domainRoute, domainDnsEditRoute } from '../../app/router/domains';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import type { DnsRecord } from '@automattic/api-core';
 import type { Action } from '@wordpress/dataviews';
 
 export function useDnsActions(): Action< DnsRecord >[] {
 	const { domainName } = domainRoute.useParams();
-	const { mutate: deleteDnsRecord, isPending: isDeletingDnsRecord } = useMutation( {
-		...domainDnsMutation( domainName ),
-		meta: {
-			snackbar: {
-				success: __( 'DNS record deleted.' ),
-				error: __( 'Failed to delete DNS record.' ),
-			},
-		},
-	} );
+	const { mutate: deleteDnsRecord, isPending: isDeletingDnsRecord } = useMutation(
+		withSnackbar( domainDnsMutation( domainName ), {
+			success: __( 'DNS record deleted.' ),
+			error: __( 'Failed to delete DNS record.' ),
+		} )
+	);
 	const router = useRouter();
 
 	return useMemo( () => {

--- a/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
+++ b/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
@@ -10,6 +10,7 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect } from 'react';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import type { DnsRecord } from '@automattic/api-core';
 
@@ -30,16 +31,13 @@ export default function DnsImportDialog( {
 }: DnsImportDialogProps ) {
 	const [ selectedRecords, setSelectedRecords ] = useState< Set< string > >( new Set() );
 
-	const updateDnsMutation = useMutation( {
-		...domainDnsMutation( domainName ),
-		meta: {
-			snackbar: {
-				/* translators: %s is the domain name */
-				success: sprintf( __( 'DNS records saved for %s.' ), domainName ),
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const updateDnsMutation = useMutation(
+		withSnackbar( domainDnsMutation( domainName ), {
+			/* translators: %s is the domain name */
+			success: sprintf( __( 'DNS records saved for %s.' ), domainName ),
+			error: { source: 'server' },
+		} )
+	);
 
 	// Initialize all records as selected when records change
 	useEffect( () => {

--- a/client/dashboard/domains/domain-dns/email-setup-form.tsx
+++ b/client/dashboard/domains/domain-dns/email-setup-form.tsx
@@ -10,6 +10,7 @@ import { DataForm, Field, useFormValidity } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
 import { domainRoute } from '../../app/router/domains';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 
 export type EmailSetupFormData = {
@@ -47,23 +48,20 @@ export default function EmailSetupForm( {
 	const { domainName } = domainRoute.useParams();
 	const [ formData, setFormData ] = useState< EmailSetupFormData >( defaultFormData );
 
-	const mutation = useMutation( {
-		...domainDnsApplyTemplateMutation( domainName ),
-		meta: {
-			snackbar: {
-				// translators: %(providerName)s will be replaced with the name of the service provider that this template is used for, for example Google Workspace or Office 365; %(domainName)s will be replaced with the domain name
-				success: sprintf( __( '%(provider)s email set up for %(domainName)s.' ), {
-					provider: label,
-					domainName,
-				} ),
-				// translators: %(providerName)s will be replaced with the name of the service provider that this template is used for, for example Google Workspace or Office 365; %(domainName)s will be replaced with the domain name
-				error: sprintf( __( 'Failed to complete %(provider)s email setup for %(domainName)s.' ), {
-					provider: label,
-					domainName,
-				} ),
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( domainDnsApplyTemplateMutation( domainName ), {
+			// translators: %(providerName)s will be replaced with the name of the service provider that this template is used for, for example Google Workspace or Office 365; %(domainName)s will be replaced with the domain name
+			success: sprintf( __( '%(provider)s email set up for %(domainName)s.' ), {
+				provider: label,
+				domainName,
+			} ),
+			// translators: %(providerName)s will be replaced with the name of the service provider that this template is used for, for example Google Workspace or Office 365; %(domainName)s will be replaced with the domain name
+			error: sprintf( __( 'Failed to complete %(provider)s email setup for %(domainName)s.' ), {
+				provider: label,
+				domainName,
+			} ),
+		} )
+	);
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -19,6 +19,7 @@ import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
 import { domainDnsAddRoute, domainRoute } from '../../app/router/domains';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { DataViewsCard } from '../../components/dataviews';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
@@ -67,26 +68,20 @@ export default function DomainDns() {
 	const { domainName } = domainRoute.useParams();
 	const router = useRouter();
 	const { recordTracksEvent } = useAnalytics();
-	const updateDnsMutation = useMutation( {
-		...domainDnsMutation( domainName ),
-		meta: {
-			snackbar: {
-				/* translators: %s is the domain name */
-				success: sprintf( __( 'Default A records restored for %s.' ), domainName ),
-				error: { source: 'server' },
-			},
-		},
-	} );
-	const restoreDefaultEmailRecordsMutation = useMutation( {
-		...domainDnsEmailMutation( domainName ),
-		meta: {
-			snackbar: {
-				/* translators: %s is the domain name */
-				success: sprintf( __( 'Default email DNS records restored for %s.' ), domainName ),
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const updateDnsMutation = useMutation(
+		withSnackbar( domainDnsMutation( domainName ), {
+			/* translators: %s is the domain name */
+			success: sprintf( __( 'Default A records restored for %s.' ), domainName ),
+			error: { source: 'server' },
+		} )
+	);
+	const restoreDefaultEmailRecordsMutation = useMutation(
+		withSnackbar( domainDnsEmailMutation( domainName ), {
+			/* translators: %s is the domain name */
+			success: sprintf( __( 'Default email DNS records restored for %s.' ), domainName ),
+			error: { source: 'server' },
+		} )
+	);
 
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const { data: dnsData, isLoading, isFetching } = useQuery( domainDnsQuery( domainName ) );

--- a/client/dashboard/domains/domain-forwarding/add.tsx
+++ b/client/dashboard/domains/domain-forwarding/add.tsx
@@ -4,6 +4,7 @@ import { useRouter } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute, domainForwardingRoute } from '../../app/router/domains';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import DomainForwardingForm from './form';
@@ -15,16 +16,13 @@ import type { DomainForwardingSaveData } from '@automattic/api-core';
 export default function AddDomainForwarding() {
 	const router = useRouter();
 	const { domainName } = domainRoute.useParams();
-	const saveMutation = useMutation( {
-		...domainForwardingSaveMutation( domainName ),
-		meta: {
-			snackbar: {
-				/* translators: %s is the domain name */
-				success: sprintf( __( 'Domain forwarding rule for %s saved.' ), domainName ),
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const saveMutation = useMutation(
+		withSnackbar( domainForwardingSaveMutation( domainName ), {
+			/* translators: %s is the domain name */
+			success: sprintf( __( 'Domain forwarding rule for %s saved.' ), domainName ),
+			error: { source: 'server' },
+		} )
+	);
 	const { data: domainData } = useSuspenseQuery( domainQuery( domainName ) );
 	const forceSubdomainsOnly = domainData?.primary_domain && ! domainData?.is_domain_only_site;
 

--- a/client/dashboard/domains/domain-forwarding/delete-modal.tsx
+++ b/client/dashboard/domains/domain-forwarding/delete-modal.tsx
@@ -7,6 +7,7 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import type { DomainForwarding } from '@automattic/api-core';
 
@@ -21,16 +22,13 @@ const DomainForwardingDeleteModal = ( {
 	domainForwarding,
 	onClose,
 }: DomainForwardingDeleteModalProps ) => {
-	const deleteMutation = useMutation( {
-		...domainForwardingDeleteMutation( domainName ),
-		meta: {
-			snackbar: {
-				/* translators: %s is the domain name */
-				success: sprintf( __( 'Domain forwarding rule for %s deleted.' ), domainName ),
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const deleteMutation = useMutation(
+		withSnackbar( domainForwardingDeleteMutation( domainName ), {
+			/* translators: %s is the domain name */
+			success: sprintf( __( 'Domain forwarding rule for %s deleted.' ), domainName ),
+			error: { source: 'server' },
+		} )
+	);
 	const { recordTracksEvent } = useAnalytics();
 
 	const onConfirm = () => {

--- a/client/dashboard/domains/domain-forwarding/edit.tsx
+++ b/client/dashboard/domains/domain-forwarding/edit.tsx
@@ -9,6 +9,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute, domainForwardingRoute } from '../../app/router/domains';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import DomainForwardingForm from './form';
@@ -21,16 +22,13 @@ export default function EditDomainForwarding() {
 	const router = useRouter();
 	const { domainName, forwardingId } = domainRoute.useParams();
 	const { data: forwardingData } = useSuspenseQuery( domainForwardingQuery( domainName ) );
-	const saveMutation = useMutation( {
-		...domainForwardingSaveMutation( domainName ),
-		meta: {
-			snackbar: {
-				/* translators: %s is the domain name */
-				success: sprintf( __( 'Domain forwarding rule for %s saved.' ), domainName ),
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const saveMutation = useMutation(
+		withSnackbar( domainForwardingSaveMutation( domainName ), {
+			/* translators: %s is the domain name */
+			success: sprintf( __( 'Domain forwarding rule for %s saved.' ), domainName ),
+			error: { source: 'server' },
+		} )
+	);
 	const { data: domainData } = useSuspenseQuery( domainQuery( domainName ) );
 	const forceSubdomainsOnly = domainData?.primary_domain && ! domainData?.is_domain_only_site;
 

--- a/client/dashboard/domains/domain-glue-records/add.tsx
+++ b/client/dashboard/domains/domain-glue-records/add.tsx
@@ -6,6 +6,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute, domainGlueRecordsRoute } from '../../app/router/domains';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import DomainGlueRecordsForm from './form';
@@ -13,16 +14,13 @@ import DomainGlueRecordsForm from './form';
 export default function AddDomainGlueRecords() {
 	const navigate = useNavigate();
 	const { domainName } = domainRoute.useParams();
-	const createMutation = useMutation( {
-		...domainGlueRecordCreateMutation( domainName ),
-		meta: {
-			snackbar: {
-				/* translators: %s is the domain name */
-				success: sprintf( __( 'Glue record for %s saved.' ), domainName ),
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const createMutation = useMutation(
+		withSnackbar( domainGlueRecordCreateMutation( domainName ), {
+			/* translators: %s is the domain name */
+			success: sprintf( __( 'Glue record for %s saved.' ), domainName ),
+			error: { source: 'server' },
+		} )
+	);
 	const { recordTracksEvent } = useAnalytics();
 
 	const handleSubmit = ( glueRecord: DomainGlueRecord ) => {

--- a/client/dashboard/domains/domain-glue-records/delete-modal.tsx
+++ b/client/dashboard/domains/domain-glue-records/delete-modal.tsx
@@ -7,6 +7,7 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import type { DomainGlueRecord } from '@automattic/api-core';
 
@@ -21,16 +22,13 @@ const DomainGlueRecordDeleteModal = ( {
 	domainName,
 	onClose,
 }: DomainGlueRecordDeleteModalProps ) => {
-	const deleteMutation = useMutation( {
-		...domainGlueRecordDeleteMutation( domainName ),
-		meta: {
-			snackbar: {
-				/* translators: %s is the domain name */
-				success: sprintf( __( 'Glue record for %s deleted.' ), domainName ),
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const deleteMutation = useMutation(
+		withSnackbar( domainGlueRecordDeleteMutation( domainName ), {
+			/* translators: %s is the domain name */
+			success: sprintf( __( 'Glue record for %s deleted.' ), domainName ),
+			error: { source: 'server' },
+		} )
+	);
 	const { recordTracksEvent } = useAnalytics();
 
 	const onConfirm = () => {

--- a/client/dashboard/domains/domain-glue-records/edit.tsx
+++ b/client/dashboard/domains/domain-glue-records/edit.tsx
@@ -6,6 +6,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute, domainGlueRecordsRoute } from '../../app/router/domains';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import DomainGlueRecordsForm from './form';
@@ -14,16 +15,13 @@ export default function EditDomainGlueRecords() {
 	const navigate = useNavigate();
 	const { domainName, nameServer } = domainRoute.useParams();
 	const { data: glueRecordsData } = useSuspenseQuery( domainGlueRecordsQuery( domainName ) );
-	const updateMutation = useMutation( {
-		...domainGlueRecordUpdateMutation( domainName ),
-		meta: {
-			snackbar: {
-				/* translators: %s is the domain name */
-				success: sprintf( __( 'Glue record for %s saved.' ), domainName ),
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const updateMutation = useMutation(
+		withSnackbar( domainGlueRecordUpdateMutation( domainName ), {
+			/* translators: %s is the domain name */
+			success: sprintf( __( 'Glue record for %s saved.' ), domainName ),
+			error: { source: 'server' },
+		} )
+	);
 	const { recordTracksEvent } = useAnalytics();
 	const glueRecord = glueRecordsData.find(
 		( glueRecord: DomainGlueRecord ) => glueRecord.nameserver === nameServer

--- a/client/dashboard/domains/domain-overview/icann-suspension-notice.tsx
+++ b/client/dashboard/domains/domain-overview/icann-suspension-notice.tsx
@@ -7,20 +7,18 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import Notice from '../../components/notice';
 
 export default function IcannSuspensionNotice( { domainName }: { domainName: string } ) {
-	const resendIcannVerificationEmail = useMutation( {
-		...resendIcannVerificationEmailMutation( domainName ),
-		meta: {
-			snackbar: {
-				success: __(
-					'Verification email sent! It should arrive within a few minutes. Please check your inbox and follow the instructions to verify your domain name.'
-				),
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const resendIcannVerificationEmail = useMutation(
+		withSnackbar( resendIcannVerificationEmailMutation( domainName ), {
+			success: __(
+				'Verification email sent! It should arrive within a few minutes. Please check your inbox and follow the instructions to verify your domain name.'
+			),
+			error: { source: 'server' },
+		} )
+	);
 	const { recordTracksEvent } = useAnalytics();
 
 	const onClick = () => {

--- a/client/dashboard/domains/domain-security/dnssec.tsx
+++ b/client/dashboard/domains/domain-security/dnssec.tsx
@@ -9,6 +9,7 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
 import { SectionHeader } from '../../components/section-header';
@@ -22,16 +23,13 @@ interface DnsSecProps {
 
 export default function DnsSec( { domainName, domain }: DnsSecProps ) {
 	const { recordTracksEvent } = useAnalytics();
-	const mutation = useMutation( {
-		...domainDnssecMutation( domainName ),
-		meta: {
-			snackbar: {
-				/* translators: %s is the domain name */
-				success: sprintf( __( 'DNSSEC setting for %s saved.' ), domainName ),
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( domainDnssecMutation( domainName ), {
+			/* translators: %s is the domain name */
+			success: sprintf( __( 'DNSSEC setting for %s saved.' ), domainName ),
+			error: { source: 'server' },
+		} )
+	);
 
 	const { isPending } = mutation;
 

--- a/client/dashboard/domains/domain-security/ssl-certificate.tsx
+++ b/client/dashboard/domains/domain-security/ssl-certificate.tsx
@@ -14,6 +14,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { ReactElement } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { domainSecurityRoute } from '../../app/router/domains';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
@@ -28,16 +29,13 @@ interface SslCertificateProps {
 
 export default function SslCertificate( { domainName, domain, sslDetails }: SslCertificateProps ) {
 	const { recordTracksEvent } = useAnalytics();
-	const mutation = useMutation( {
-		...provisionSslCertificateMutation( domainName ),
-		meta: {
-			snackbar: {
-				/* translators: %s is the domain name */
-				success: sprintf( __( 'New SSL certificate requested for %s.' ), domainName ),
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( provisionSslCertificateMutation( domainName ), {
+			/* translators: %s is the domain name */
+			success: sprintf( __( 'New SSL certificate requested for %s.' ), domainName ),
+			error: { source: 'server' },
+		} )
+	);
 
 	const getSslStatusMessage = ( sslDetails: SslDetails ) => {
 		const hasFailureReasons =

--- a/client/dashboard/domains/domain-transfer/outbound-transfer.tsx
+++ b/client/dashboard/domains/domain-transfer/outbound-transfer.tsx
@@ -18,6 +18,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
 import { useLocale } from '../../app/locale';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
@@ -41,22 +42,16 @@ export default function OutboundTransfer( { domain }: { domain: Domain } ) {
 		enabled: ! isDomainConnection,
 	} );
 	const registrantEmail = findRegistrantWhois( whoisData )?.email;
-	const { mutate: updateDomainLock, isPending: isUpdatingDomainLock } = useMutation( {
-		...domainLockMutation( domainName ),
-		meta: {
-			snackbar: {
-				error: { source: 'server' },
-			},
-		},
-	} );
-	const { mutate: requestTransferCode, isPending: isRequestingTransferCode } = useMutation( {
-		...domainTransferCodeMutation( domainName ),
-		meta: {
-			snackbar: {
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const { mutate: updateDomainLock, isPending: isUpdatingDomainLock } = useMutation(
+		withSnackbar( domainLockMutation( domainName ), {
+			error: { source: 'server' },
+		} )
+	);
+	const { mutate: requestTransferCode, isPending: isRequestingTransferCode } = useMutation(
+		withSnackbar( domainTransferCodeMutation( domainName ), {
+			error: { source: 'server' },
+		} )
+	);
 	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	const handleToggleChange = ( enabled: boolean ) => {

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
@@ -19,6 +19,7 @@ import { useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { useLocale } from '../../app/locale';
 import { domainRoute } from '../../app/router/domains';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import Notice from '../../components/notice';
@@ -56,25 +57,19 @@ export default function TransferDomainToAnyUser() {
 		domainTransferRequestQuery( domainName, domain.site_slug )
 	);
 	const { mutate: deleteDomainTransferRequest, isPending: isDeletingDomainTransferRequest } =
-		useMutation( {
-			...deleteDomainTransferRequestMutation( domainName, domain.site_slug ),
-			meta: {
-				snackbar: {
-					success: __( 'Domain transfer cancelled.' ),
-					error: __( 'Failed to cancel domain transfer.' ),
-				},
-			},
-		} );
+		useMutation(
+			withSnackbar( deleteDomainTransferRequestMutation( domainName, domain.site_slug ), {
+				success: __( 'Domain transfer cancelled.' ),
+				error: __( 'Failed to cancel domain transfer.' ),
+			} )
+		);
 	const { mutate: updateDomainTransferRequest, isPending: isUpdatingDomainTransferRequest } =
-		useMutation( {
-			...updateDomainTransferRequestMutation( domainName, domain.site_slug ),
-			meta: {
-				snackbar: {
-					success: __( 'A domain transfer request has been emailed to the recipient’s address.' ),
-					error: __( 'Failed to initiate domain transfer.' ),
-				},
-			},
-		} );
+		useMutation(
+			withSnackbar( updateDomainTransferRequestMutation( domainName, domain.site_slug ), {
+				success: __( 'A domain transfer request has been emailed to the recipient’s address.' ),
+				error: __( 'Failed to initiate domain transfer.' ),
+			} )
+		);
 	const locale = useLocale();
 	const transferEmail = domainTransferRequest?.email;
 	const requestedAt = domainTransferRequest?.requested_at;

--- a/client/dashboard/domains/name-servers/index.tsx
+++ b/client/dashboard/domains/name-servers/index.tsx
@@ -13,6 +13,7 @@ import { useAuth } from '../../app/auth';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
 import { domainRoute } from '../../app/router/domains';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
@@ -30,16 +31,13 @@ export default function NameServers() {
 		data: { nameServers, isUsingDefaultNameServers, defaultNameServers },
 	} = useSuspenseQuery( domainNameServersQuery( domainName ) );
 
-	const { mutate: updateNameServers, isPending: isUpdatingNameServers } = useMutation( {
-		...domainNameServersMutation( domainName ),
-		meta: {
-			snackbar: {
-				/* translators: %s is the domain name */
-				success: sprintf( __( 'Name servers for %s updated successfully.' ), domainName ),
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const { mutate: updateNameServers, isPending: isUpdatingNameServers } = useMutation(
+		withSnackbar( domainNameServersMutation( domainName ), {
+			/* translators: %s is the domain name */
+			success: sprintf( __( 'Name servers for %s updated successfully.' ), domainName ),
+			error: { source: 'server' },
+		} )
+	);
 
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const { data: site } = useQuery( siteByIdQuery( domain.blog_id ) );

--- a/client/dashboard/me/billing-history/dataviews.tsx
+++ b/client/dashboard/me/billing-history/dataviews.tsx
@@ -5,6 +5,7 @@ import { __experimentalText as Text, __experimentalVStack as VStack } from '@wor
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, type JSX } from 'react';
 import { receiptRoute } from '../../app/router/me';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { isAkismetPro500Plan } from '../../utils/akismet';
 import { getTaxName } from '../../utils/tax';
 import {
@@ -54,17 +55,14 @@ export const DEFAULT_VIEW: View = {
 
 export function useActions() {
 	const navigate = useNavigate();
-	const { mutate: sendEmail } = useMutation( {
-		...sendReceiptEmailMutation(),
-		meta: {
-			snackbar: {
-				success: __( 'Your receipt was sent by email successfully.' ),
-				error: __(
-					'There was a problem sending your receipt. Please try again later or contact support.'
-				),
-			},
-		},
-	} );
+	const { mutate: sendEmail } = useMutation(
+		withSnackbar( sendReceiptEmailMutation(), {
+			success: __( 'Your receipt was sent by email successfully.' ),
+			error: __(
+				'There was a problem sending your receipt. Please try again later or contact support.'
+			),
+		} )
+	);
 
 	return useMemo(
 		() => [

--- a/client/dashboard/me/billing-history/receipt.tsx
+++ b/client/dashboard/me/billing-history/receipt.tsx
@@ -24,6 +24,7 @@ import { type ReactNode, useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { useLocale } from '../../app/locale';
 import { receiptRoute, taxDetailsRoute } from '../../app/router/me';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -268,17 +269,14 @@ type ReceiptTaxDetail = {
 
 function UserVatDetails( { receipt }: { receipt: Receipt } ) {
 	const { data: vatDetails } = useSuspenseQuery( userTaxDetailsQuery() );
-	const sendEmailMutation = useMutation( {
-		...sendReceiptEmailMutation(),
-		meta: {
-			snackbar: {
-				success: __( 'Your receipt was sent by email successfully.' ),
-				error: __(
-					'There was a problem sending your receipt. Please try again later or contact support.'
-				),
-			},
-		},
-	} );
+	const sendEmailMutation = useMutation(
+		withSnackbar( sendReceiptEmailMutation(), {
+			success: __( 'Your receipt was sent by email successfully.' ),
+			error: __(
+				'There was a problem sending your receipt. Please try again later or contact support.'
+			),
+		} )
+	);
 
 	const handleEmailReceipt = ( event: React.MouseEvent< HTMLButtonElement > ) => {
 		event.preventDefault();

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -62,6 +62,7 @@ import {
 	purchaseSettingsRoute,
 } from '../../../app/router/me';
 import { getCurrentDashboard } from '../../../app/routing';
+import { withSnackbar } from '../../../app/snackbars/with-snackbar';
 import { ActionList } from '../../../components/action-list';
 import { Card, CardBody } from '../../../components/card';
 import ClipboardInputControl from '../../../components/clipboard-input-control';
@@ -640,15 +641,12 @@ function JetpackCRMDownloadsButton( { purchase }: { purchase: Purchase } ) {
 }
 
 function ReinstallButton( { purchase }: { purchase: Purchase } ) {
-	const { mutate: reinstallPlugins, isPending: isMutationPending } = useMutation( {
-		...reinstallMarketplacePluginsQuery( purchase.blog_id ),
-		meta: {
-			snackbar: {
-				success: __( 'Plugins reinstalled.' ),
-				error: __( 'Failed to reinstall plugins.' ),
-			},
-		},
-	} );
+	const { mutate: reinstallPlugins, isPending: isMutationPending } = useMutation(
+		withSnackbar( reinstallMarketplacePluginsQuery( purchase.blog_id ), {
+			success: __( 'Plugins reinstalled.' ),
+			error: __( 'Failed to reinstall plugins.' ),
+		} )
+	);
 	if ( ! isMarketplacePlugin( purchase ) ) {
 		return null;
 	}

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../me/mcp/utils';
 import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { Card, CardBody, CardDivider } from '../../components/card';
 import ComponentViewTracker from '../../components/component-view-tracker';
 import { PageHeader } from '../../components/page-header';
@@ -100,15 +101,12 @@ function McpComponent() {
 	const readBadge = getReadBadge( readTools );
 	const writeBadge = getWriteBadge( writeTools );
 
-	const mutation = useMutation( {
-		...userSettingsMutation(),
-		meta: {
-			snackbar: {
-				success: __( 'Settings saved.' ),
-				error: __( 'Failed to save settings.' ),
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( userSettingsMutation(), {
+			success: __( 'Settings saved.' ),
+			error: __( 'Failed to save settings.' ),
+		} )
+	);
 
 	const handleMcpToggle = ( enabled: boolean ) => {
 		const overrides = getOverridesToMatch( Object.entries( mcpAbilities ), enabled ) as

--- a/client/dashboard/me/mcp/mcp-sites/index.tsx
+++ b/client/dashboard/me/mcp/mcp-sites/index.tsx
@@ -12,6 +12,7 @@ import { useAnalytics } from '../../../app/analytics';
 import Breadcrumbs from '../../../app/breadcrumbs';
 import { useAppContext } from '../../../app/context';
 import { siteSettingsAIToolsRoute } from '../../../app/router/sites';
+import { withSnackbar } from '../../../app/snackbars/with-snackbar';
 import { ActionList } from '../../../components/action-list';
 import { Card, CardBody } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
@@ -62,15 +63,12 @@ export default function McpMcpSites() {
 		( site: Site ) => ! managedSiteIds.includes( site.ID )
 	);
 
-	const mutation = useMutation( {
-		...userSettingsMutation(),
-		meta: {
-			snackbar: {
-				success: __( 'MCP settings saved.' ),
-				error: __( 'Failed to save MCP settings.' ),
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( userSettingsMutation(), {
+			success: __( 'MCP settings saved.' ),
+			error: __( 'Failed to save MCP settings.' ),
+		} )
+	);
 
 	const handleSiteAdd = ( siteId: number ) => {
 		const eventName = mcpEnabled

--- a/client/dashboard/me/mcp/read/index.tsx
+++ b/client/dashboard/me/mcp/read/index.tsx
@@ -16,6 +16,7 @@ import { groupToolsByGroup, groupToolsBySubCategory } from '../../../../me/mcp/g
 import { getGroupDescriptors, getAccountMcpAbilities } from '../../../../me/mcp/utils';
 import { useAnalytics } from '../../../app/analytics';
 import Breadcrumbs from '../../../app/breadcrumbs';
+import { withSnackbar } from '../../../app/snackbars/with-snackbar';
 import { Card, CardBody } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
 import { PageHeader } from '../../../components/page-header';
@@ -66,15 +67,12 @@ export default function McpRead() {
 	const groups = groupToolsByGroup( allTools, groupDescriptors ) as ToolGroup[];
 	const pageAllEnabled = allTools.length > 0 && allTools.every( ( [ , tool ] ) => tool.enabled );
 
-	const mutation = useMutation( {
-		...userSettingsMutation(),
-		meta: {
-			snackbar: {
-				success: __( 'MCP settings saved.' ),
-				error: __( 'Failed to save MCP settings.' ),
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( userSettingsMutation(), {
+			success: __( 'MCP settings saved.' ),
+			error: __( 'Failed to save MCP settings.' ),
+		} )
+	);
 
 	const handleToolChange = ( toolId: string, enabled: boolean, groupName: string | null ) => {
 		mutation.mutate(

--- a/client/dashboard/me/mcp/write/index.tsx
+++ b/client/dashboard/me/mcp/write/index.tsx
@@ -16,6 +16,7 @@ import { groupToolsByGroup, groupToolsBySubCategory } from '../../../../me/mcp/g
 import { getGroupDescriptors, getAccountMcpAbilities } from '../../../../me/mcp/utils';
 import { useAnalytics } from '../../../app/analytics';
 import Breadcrumbs from '../../../app/breadcrumbs';
+import { withSnackbar } from '../../../app/snackbars/with-snackbar';
 import { Card, CardBody } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
 import { PageHeader } from '../../../components/page-header';
@@ -66,15 +67,12 @@ export default function McpWrite() {
 	const groups = groupToolsByGroup( allTools, groupDescriptors ) as ToolGroup[];
 	const pageAllEnabled = allTools.length > 0 && allTools.every( ( [ , tool ] ) => tool.enabled );
 
-	const mutation = useMutation( {
-		...userSettingsMutation(),
-		meta: {
-			snackbar: {
-				success: __( 'MCP settings saved.' ),
-				error: __( 'Failed to save MCP settings.' ),
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( userSettingsMutation(), {
+			success: __( 'MCP settings saved.' ),
+			error: __( 'Failed to save MCP settings.' ),
+		} )
+	);
 
 	const handleToolChange = ( toolId: string, enabled: boolean, groupName: string | null ) => {
 		mutation.mutate(

--- a/client/dashboard/me/notifications-emails/pause-all-emails/index.tsx
+++ b/client/dashboard/me/notifications-emails/pause-all-emails/index.tsx
@@ -5,6 +5,7 @@ import { CheckboxControl, Button, __experimentalVStack as VStack } from '@wordpr
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useCallback } from 'react';
 import { useAnalytics } from '../../../app/analytics';
+import { withSnackbar } from '../../../app/snackbars/with-snackbar';
 import { Card, CardBody } from '../../../components/card';
 import { ConfirmationModal } from './confirmation-modal';
 
@@ -21,15 +22,12 @@ export const PauseAllEmails = () => {
 		mutate: updateSettings,
 		isPending: isSaving,
 		isSuccess: isSettingsUpdated,
-	} = useMutation( {
-		...userSettingsMutation(),
-		meta: {
-			snackbar: {
-				success: enabled ? __( 'All emails paused.' ) : __( 'All emails unpaused.' ),
-				error: __( 'Failed to pause all emails.' ),
-			},
-		},
-	} );
+	} = useMutation(
+		withSnackbar( userSettingsMutation(), {
+			success: enabled ? __( 'All emails paused.' ) : __( 'All emails unpaused.' ),
+			error: __( 'Failed to pause all emails.' ),
+		} )
+	);
 
 	const originalState = isAllWpcomEmailsDisabled( settings );
 	const [ isConfirmDialogOpen, setIsConfirmDialogOpen ] = useState( false );

--- a/client/dashboard/me/notifications-emails/subscription-settings/index.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/index.tsx
@@ -13,6 +13,7 @@ import { __ } from '@wordpress/i18n';
 import { useCallback, useMemo, useState } from 'react';
 import { useAnalytics } from '../../../app/analytics';
 import { NavigationBlocker } from '../../../app/navigation-blocker';
+import { withSnackbar } from '../../../app/snackbars/with-snackbar';
 import { Card, CardBody } from '../../../components/card';
 import { getSettings, getSettingsKeys, SubscriptionSettingsForm, type SettingsData } from './form';
 
@@ -43,15 +44,12 @@ export const SubscriptionSettings = () => {
 	const [ dataState, setDataState ] = useState< SettingsData >( originalSettings );
 	const { recordTracksEvent } = useAnalytics();
 
-	const { mutate: saveSettings, isPending: isSaving } = useMutation( {
-		...userSettingsMutation(),
-		meta: {
-			snackbar: {
-				success: __( 'Subscription settings saved.' ),
-				error: __( 'Failed to save subscription settings.' ),
-			},
-		},
-	} );
+	const { mutate: saveSettings, isPending: isSaving } = useMutation(
+		withSnackbar( userSettingsMutation(), {
+			success: __( 'Subscription settings saved.' ),
+			error: __( 'Failed to save subscription settings.' ),
+		} )
+	);
 
 	const isDataStateDirty = useMemo(
 		() => isDirty( dataState, originalSettings ),

--- a/client/dashboard/me/profile-deletion/index.tsx
+++ b/client/dashboard/me/profile-deletion/index.tsx
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { trash } from '@wordpress/icons';
 import { useState } from 'react';
 import { useAuth } from '../../app/auth';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ActionList } from '../../components/action-list';
 import AccountDeletionConfirmModal from './account-deletion-modal';
 
@@ -13,15 +14,12 @@ export default function AccountDeletionSection() {
 	const { user } = useAuth();
 	const navigate = useNavigate();
 	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
-	const mutation = useMutation( {
-		...closeAccountMutation(),
-		meta: {
-			snackbar: {
-				success: __( 'Account deletion initiated.' ),
-				error: __( 'Failed to delete account.' ),
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( closeAccountMutation(), {
+			success: __( 'Account deletion initiated.' ),
+			error: __( 'Failed to delete account.' ),
+		} )
+	);
 	const { data: purchases, isLoading: isFetchingPurchases } = useQuery( {
 		...userPurchasesQuery(),
 		enabled: showConfirmModal,

--- a/client/dashboard/me/profile-personal-details/email-section.tsx
+++ b/client/dashboard/me/profile-personal-details/email-section.tsx
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { Icon, info, check } from '@wordpress/icons';
 import emailValidator from 'email-validator';
 import { useState, useEffect, useCallback } from 'react';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { isCustomDomainEmail } from './email-utils';
 import type { UserSettings } from '@automattic/api-core';
 import './style.scss';
@@ -46,7 +47,10 @@ export default function EmailSection( {
 	const mutation = cancelPendingEmailChangeMutation();
 
 	const { mutate: cancelPendingEmail, isPending: isCancelPending } = useMutation( {
-		...mutation,
+		...withSnackbar( mutation, {
+			success: __( 'Pending email change canceled.' ),
+			error: __( 'Failed to cancel pending email change.' ),
+		} ),
 		onSuccess: ( data, variables, context ) => {
 			// Call the original onSuccess from the mutation if it exists
 			if ( mutation.onSuccess ) {
@@ -54,12 +58,6 @@ export default function EmailSection( {
 			}
 			// Use the fresh data from the mutation response
 			onChange( data.user_email || '' );
-		},
-		meta: {
-			snackbar: {
-				success: __( 'Pending email change canceled.' ),
-				error: __( 'Failed to cancel pending email change.' ),
-			},
 		},
 	} );
 

--- a/client/dashboard/me/profile-personal-details/index.tsx
+++ b/client/dashboard/me/profile-personal-details/index.tsx
@@ -15,6 +15,7 @@ import { DataForm, Field, Form } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo, useCallback } from 'react';
 import { NavigationBlocker } from '../../app/navigation-blocker';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { Card, CardBody } from '../../components/card';
 import FlashMessage from '../../components/flash-message';
 import { SectionHeader } from '../../components/section-header';
@@ -32,15 +33,12 @@ export default function PersonalDetailsSection() {
 	const [ edits, setEdits ] = useState< Partial< UserSettings > >( {} );
 	const [ isEmailValid, setIsEmailValid ] = useState< boolean >( true );
 
-	const mutation = useMutation( {
-		...userSettingsMutation(),
-		meta: {
-			snackbar: {
-				success: __( 'Settings saved.' ),
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( userSettingsMutation(), {
+			success: __( 'Settings saved.' ),
+			error: { source: 'server' },
+		} )
+	);
 
 	const data = useMemo( () => ( { ...userSettings, ...edits } ), [ userSettings, edits ] );
 

--- a/client/dashboard/me/profile-personal-details/update-email/email-verification-banner.tsx
+++ b/client/dashboard/me/profile-personal-details/update-email/email-verification-banner.tsx
@@ -7,6 +7,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState, useEffect } from 'react';
+import { withSnackbar } from '../../../app/snackbars/with-snackbar';
 import Notice from '../../../components/notice';
 import type { UserSettings } from '@automattic/api-core';
 
@@ -103,24 +104,21 @@ export default function EmailVerificationBanner( { userData }: EmailVerification
 
 	// Resend email
 	const { mutate: resendEmail, isPending: isResendPending } = useMutation( {
-		...resendEmailVerificationMutation( pendingEmail || '' ),
+		...withSnackbar( resendEmailVerificationMutation( pendingEmail || '' ), {
+			success: pendingEmail
+				? sprintf(
+						/* translators: %s is the user's new email address they're trying to change to */
+						__( 'We sent an email to %s. Please check your inbox to verify your email.' ),
+						pendingEmail
+				  )
+				: __( 'Verification email sent.' ),
+			error: __( 'Failed to resend verification email.' ),
+		} ),
 		onSuccess: () => {
 			setShowResendButton( false );
 		},
 		onError: () => {
 			setShowResendButton( true );
-		},
-		meta: {
-			snackbar: {
-				success: pendingEmail
-					? sprintf(
-							/* translators: %s is the user's new email address they're trying to change to */
-							__( 'We sent an email to %s. Please check your inbox to verify your email.' ),
-							pendingEmail
-					  )
-					: __( 'Verification email sent.' ),
-				error: __( 'Failed to resend verification email.' ),
-			},
 		},
 	} );
 

--- a/client/dashboard/me/profile-personal-details/username-section.tsx
+++ b/client/dashboard/me/profile-personal-details/username-section.tsx
@@ -7,6 +7,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { Icon, info, check } from '@wordpress/icons';
 import { useState, useCallback } from 'react';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { reloadWithFlashMessage } from '../../components/flash-message';
 import UsernameUpdateForm from './update-username';
 import UsernameUpdateConfirmationModal from './update-username/confirmation-modal';
@@ -47,14 +48,11 @@ export default function UsernameSection( {
 	const [ validationResult, setValidationResult ] = useState< ValidationResult | null >( null );
 
 	const { mutate: updateUsername, isPending } = useMutation( {
-		...updateUsernameMutation(),
+		...withSnackbar( updateUsernameMutation(), {
+			error: __( 'Failed to update username.' ),
+		} ),
 		onSuccess: () => {
 			reloadWithFlashMessage( 'username' );
-		},
-		meta: {
-			snackbar: {
-				error: __( 'Failed to update username.' ),
-			},
 		},
 	} );
 

--- a/client/dashboard/me/security-legacy-contact/remove-contact-dialog.tsx
+++ b/client/dashboard/me/security-legacy-contact/remove-contact-dialog.tsx
@@ -1,6 +1,7 @@
 import { deleteLegacyContactMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import ConfirmModal from '../../components/confirm-modal';
 import type { LegacyContact } from '@automattic/api-core';
 
@@ -15,15 +16,12 @@ export default function RemoveContactDialog( {
 	isOpen,
 	onClose,
 }: RemoveContactDialogProps ) {
-	const mutation = useMutation( {
-		...deleteLegacyContactMutation(),
-		meta: {
-			snackbar: {
-				success: __( 'Legacy contact removed.' ),
-				error: __( 'Failed to remove legacy contact.' ),
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( deleteLegacyContactMutation(), {
+			success: __( 'Legacy contact removed.' ),
+			error: __( 'Failed to remove legacy contact.' ),
+		} )
+	);
 
 	const handleRemove = () => {
 		mutation.mutate( contact.legacy_contact_id, {

--- a/client/dashboard/me/security-ssh-key/ssh-key-form.tsx
+++ b/client/dashboard/me/security-ssh-key/ssh-key-form.tsx
@@ -15,6 +15,7 @@ import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
@@ -46,24 +47,18 @@ export default function SshKeyForm( {
 		key: '',
 	} );
 
-	const { mutate: createSshKey, isPending: isCreatingSshKey } = useMutation( {
-		...createSshKeyMutation(),
-		meta: {
-			snackbar: {
-				success: __( 'SSH key saved.' ),
-				error: __( 'Failed to save SSH key.' ),
-			},
-		},
-	} );
-	const { mutate: updateSshKey, isPending: isUpdatingSshKey } = useMutation( {
-		...updateSshKeyMutation(),
-		meta: {
-			snackbar: {
-				success: __( 'SSH key saved.' ),
-				error: __( 'Failed to save SSH key.' ),
-			},
-		},
-	} );
+	const { mutate: createSshKey, isPending: isCreatingSshKey } = useMutation(
+		withSnackbar( createSshKeyMutation(), {
+			success: __( 'SSH key saved.' ),
+			error: __( 'Failed to save SSH key.' ),
+		} )
+	);
+	const { mutate: updateSshKey, isPending: isUpdatingSshKey } = useMutation(
+		withSnackbar( updateSshKeyMutation(), {
+			success: __( 'SSH key saved.' ),
+			error: __( 'Failed to save SSH key.' ),
+		} )
+	);
 
 	const handleUpdateSshKey = () => {
 		recordTracksEvent( 'calypso_dashboard_security_ssh_key_update_click' );

--- a/client/dashboard/me/security-ssh-key/ssh-key.tsx
+++ b/client/dashboard/me/security-ssh-key/ssh-key.tsx
@@ -13,6 +13,7 @@ import { pencil as edit, trash } from '@wordpress/icons';
 import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { useLocale } from '../../app/locale';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import ConfirmModal from '../../components/confirm-modal';
@@ -32,15 +33,12 @@ export default function SshKey( {
 
 	const [ isRemoveDialogOpen, setIsRemoveDialogOpen ] = useState( false );
 
-	const { mutate: deleteSshKey, isPending: isDeletingSshKey } = useMutation( {
-		...deleteSshKeyMutation(),
-		meta: {
-			snackbar: {
-				success: __( 'SSH key deleted.' ),
-				error: __( 'Failed to delete SSH key.' ),
-			},
-		},
-	} );
+	const { mutate: deleteSshKey, isPending: isDeletingSshKey } = useMutation(
+		withSnackbar( deleteSshKeyMutation(), {
+			success: __( 'SSH key deleted.' ),
+			error: __( 'Failed to delete SSH key.' ),
+		} )
+	);
 
 	const handleEdit = () => {
 		recordTracksEvent( 'calypso_dashboard_security_ssh_key_edit_click' );

--- a/client/dashboard/me/security-two-step-auth-sms/setup-phone-number.tsx
+++ b/client/dashboard/me/security-two-step-auth-sms/setup-phone-number.tsx
@@ -12,6 +12,7 @@ import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import PhoneNumberInput, { type SecuritySMSNumber } from '../../components/phone-number-input';
@@ -37,15 +38,12 @@ export default function SetupPhoneNumber( { userSettings }: { userSettings: User
 	const { mutate: setupTwoStepAuthSMS, isPending: isSetupSMSPending } = useMutation(
 		setupTwoStepAuthSMSMutation()
 	);
-	const { mutate: resendTwoStepAuthSMSCode, isPending: isResending } = useMutation( {
-		...resendTwoStepAuthSMSCodeMutation(),
-		meta: {
-			snackbar: {
-				success: __( 'Verification code sent to your phone.' ),
-				error: __( 'Failed to send verification code. Please try again.' ),
-			},
-		},
-	} );
+	const { mutate: resendTwoStepAuthSMSCode, isPending: isResending } = useMutation(
+		withSnackbar( resendTwoStepAuthSMSCodeMutation(), {
+			success: __( 'Verification code sent to your phone.' ),
+			error: __( 'Failed to send verification code. Please try again.' ),
+		} )
+	);
 
 	const initialCountryCode = userSettings.two_step_sms_country;
 	const initialPhoneNumber = userSettings.two_step_sms_phone_number || '';

--- a/client/dashboard/sites/domains/primary-domain-selector-notice.tsx
+++ b/client/dashboard/sites/domains/primary-domain-selector-notice.tsx
@@ -18,6 +18,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useMemo } from 'react';
 import { useAnalytics } from '../../app/analytics';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import InlineSupportLink from '../../components/inline-support-link';
 import { Notice } from '../../components/notice';
 import UpsellCTAButton from '../../components/upsell-cta-button';
@@ -48,19 +49,16 @@ const PrimaryDomainSelectorNotice = ( {
 		( ! ( primaryWithPlanOnly && isOnFreePlan ) &&
 			( site?.plan?.features?.active.includes( 'set-primary-custom-domain' ) ?? false ) ) ||
 		isFlexSite;
-	const setPrimaryDomainMutation = useMutation( {
-		...siteSetPrimaryDomainMutation(),
-		meta: {
-			snackbar: {
-				success: sprintf(
-					/* translators: %s is domain */
-					__( 'Primary site address changed: all domains will redirect to %s.' ),
-					formData.primaryDomain
-				),
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const setPrimaryDomainMutation = useMutation(
+		withSnackbar( siteSetPrimaryDomainMutation(), {
+			success: sprintf(
+				/* translators: %s is domain */
+				__( 'Primary site address changed: all domains will redirect to %s.' ),
+				formData.primaryDomain
+			),
+			error: { source: 'server' },
+		} )
+	);
 	const currentPrimaryDomain = domains.find( ( domain ) => domain.primary_domain )?.domain;
 	const domainsList = useMemo( () => {
 		if ( ! domains || ! site ) {

--- a/client/dashboard/sites/performance/backend/start-capturing-button.tsx
+++ b/client/dashboard/sites/performance/backend/start-capturing-button.tsx
@@ -5,6 +5,7 @@ import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEffect } from 'react';
 import { useAnalytics } from '../../../app/analytics';
+import { withSnackbar } from '../../../app/snackbars/with-snackbar';
 
 export default function StartCapturingButton( {
 	site,
@@ -21,15 +22,12 @@ export default function StartCapturingButton( {
 		recordTracksEvent( 'calypso_dashboard_site_apm_enable_impression', { context } );
 	}, [ recordTracksEvent, context ] );
 
-	const { mutate, isPending } = useMutation( {
-		...siteApmEnabledMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: __( 'APM enabled.' ),
-				error: __( 'Failed to enable APM.' ),
-			},
-		},
-	} );
+	const { mutate, isPending } = useMutation(
+		withSnackbar( siteApmEnabledMutation( site.ID ), {
+			success: __( 'APM enabled.' ),
+			error: __( 'Failed to enable APM.' ),
+		} )
+	);
 
 	const handleClick = () => {
 		recordTracksEvent( 'calypso_dashboard_site_apm_enable_click', { context } );

--- a/client/dashboard/sites/settings-agency/index.tsx
+++ b/client/dashboard/sites/settings-agency/index.tsx
@@ -12,6 +12,7 @@ import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { NavigationBlocker } from '../../app/navigation-blocker';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import Notice from '../../components/notice';
@@ -51,15 +52,12 @@ const form = {
 export default function SettingsAgency( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: siteSettings } = useQuery( siteSettingsQuery( site.ID ) );
-	const mutation = useMutation( {
-		...siteSettingsMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: __( 'Agency settings saved.' ),
-				error: __( 'Failed to save agency settings.' ),
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( siteSettingsMutation( site.ID ), {
+			success: __( 'Agency settings saved.' ),
+			error: __( 'Failed to save agency settings.' ),
+		} )
+	);
 
 	const [ formData, setFormData ] = useState( {
 		is_fully_managed_agency_site: siteSettings?.is_fully_managed_agency_site,

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -45,6 +45,7 @@ import {
 import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { useHelpCenter } from '../../app/help-center';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { Card, CardBody, CardDivider, CardFooter } from '../../components/card';
 import ClipboardInputControl from '../../components/clipboard-input-control';
 import ConfirmModal from '../../components/confirm-modal';
@@ -192,15 +193,12 @@ function EmailAssistantCard( {
 	const vCardHref = agentEmailAddress ? getVCardDataUrl( site.slug, agentEmailAddress ) : undefined;
 	const vCardFileName = getVCardFileName( site.slug );
 
-	const emailAddressMutation = useMutation( {
-		...sitePostByEmailSettingsMutation( site ),
-		meta: {
-			snackbar: {
-				success: __( 'AI agent email address settings saved.' ),
-				error: __( 'Failed to save AI agent email address settings.' ),
-			},
-		},
-	} );
+	const emailAddressMutation = useMutation(
+		withSnackbar( sitePostByEmailSettingsMutation( site ), {
+			success: __( 'AI agent email address settings saved.' ),
+			error: __( 'Failed to save AI agent email address settings.' ),
+		} )
+	);
 	const isEmailAddressActionDisabled =
 		isPostByEmailSettingsLoading || emailAddressMutation.isPending;
 
@@ -342,17 +340,14 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 		: { text: __( 'Disabled' ) };
 	const readBadge = hasSiteAbilityOverrides ? getReadBadge( readTools ) : defaultBadge;
 	const writeBadge = hasSiteAbilityOverrides ? getWriteBadge( writeTools ) : defaultBadge;
-	const mcpMutation = useMutation( {
-		...userSettingsMutation(),
-		meta: {
-			snackbar: {
-				success: isMcpEnabled
-					? __( 'MCP access disabled for this site.' )
-					: __( 'MCP access enabled for this site.' ),
-				error: __( 'Failed to save MCP settings.' ),
-			},
-		},
-	} );
+	const mcpMutation = useMutation(
+		withSnackbar( userSettingsMutation(), {
+			success: isMcpEnabled
+				? __( 'MCP access disabled for this site.' )
+				: __( 'MCP access enabled for this site.' ),
+			error: __( 'Failed to save MCP settings.' ),
+		} )
+	);
 
 	const handleMcpToggle = ( enabled: boolean ) => {
 		const abilities: Record< string, boolean > = {};
@@ -386,15 +381,12 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 		);
 	};
 
-	const mutation = useMutation( {
-		...bigSkyPluginMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: ! isEnabled ? __( 'AI assistant enabled.' ) : __( 'AI assistant disabled.' ),
-				error: __( 'Failed to save AI assistant settings.' ),
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( bigSkyPluginMutation( site.ID ), {
+			success: ! isEnabled ? __( 'AI assistant enabled.' ) : __( 'AI assistant disabled.' ),
+			error: __( 'Failed to save AI assistant settings.' ),
+		} )
+	);
 
 	const description = isAvailable
 		? createInterpolateElement(

--- a/client/dashboard/sites/settings-ai-tools/read/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/read/index.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../../../me/mcp/utils';
 import Breadcrumbs from '../../../app/breadcrumbs';
 import { siteRoute } from '../../../app/router/sites';
+import { withSnackbar } from '../../../app/snackbars/with-snackbar';
 import { Card, CardBody, CardDivider, CardHeader } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
 import { PageHeader } from '../../../components/page-header';
@@ -77,15 +78,12 @@ export default function SiteAIToolsRead() {
 	);
 	const readTools = allTools.filter( ( [ toolId, tool ] ) => ! isWriteTool( toolId, tool ) );
 
-	const mutation = useMutation( {
-		...userSettingsMutation(),
-		meta: {
-			snackbar: {
-				success: __( 'MCP settings saved.' ),
-				error: __( 'Failed to save MCP settings.' ),
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( userSettingsMutation(), {
+			success: __( 'MCP settings saved.' ),
+			error: __( 'Failed to save MCP settings.' ),
+		} )
+	);
 
 	// When there are no existing overrides, materialize the implicit default alongside the change
 	// so subsequent edits have a full baseline to work from.

--- a/client/dashboard/sites/settings-ai-tools/write/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/write/index.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../../../me/mcp/utils';
 import Breadcrumbs from '../../../app/breadcrumbs';
 import { siteRoute } from '../../../app/router/sites';
+import { withSnackbar } from '../../../app/snackbars/with-snackbar';
 import { Card, CardBody, CardDivider, CardHeader } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
 import { PageHeader } from '../../../components/page-header';
@@ -77,15 +78,12 @@ export default function SiteAIToolsWrite() {
 	);
 	const writeTools = allTools.filter( ( [ toolId, tool ] ) => isWriteTool( toolId, tool ) );
 
-	const mutation = useMutation( {
-		...userSettingsMutation(),
-		meta: {
-			snackbar: {
-				success: __( 'MCP settings saved.' ),
-				error: __( 'Failed to save MCP settings.' ),
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( userSettingsMutation(), {
+			success: __( 'MCP settings saved.' ),
+			error: __( 'Failed to save MCP settings.' ),
+		} )
+	);
 
 	// When there are no existing overrides, materialize the implicit default alongside the change
 	// so subsequent edits have a full baseline to work from.

--- a/client/dashboard/sites/settings-apm/index.tsx
+++ b/client/dashboard/sites/settings-apm/index.tsx
@@ -5,6 +5,7 @@ import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
@@ -15,15 +16,12 @@ import { getBackendCalloutProps } from '../performance/backend-callout';
 
 function ApmToggle( { site }: { site: Site } ) {
 	const enabled = !! site.options?.apm_enabled;
-	const { mutate, isPending } = useMutation( {
-		...siteApmEnabledMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: enabled ? __( 'APM disabled.' ) : __( 'APM enabled.' ),
-				error: enabled ? __( 'Failed to disable APM.' ) : __( 'Failed to enable APM.' ),
-			},
-		},
-	} );
+	const { mutate, isPending } = useMutation(
+		withSnackbar( siteApmEnabledMutation( site.ID ), {
+			success: enabled ? __( 'APM disabled.' ) : __( 'APM enabled.' ),
+			error: enabled ? __( 'Failed to disable APM.' ) : __( 'Failed to enable APM.' ),
+		} )
+	);
 
 	const handleClick = () => mutate( ! enabled );
 

--- a/client/dashboard/sites/settings-caching/index.tsx
+++ b/client/dashboard/sites/settings-caching/index.tsx
@@ -22,6 +22,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useEffect, useState, type JSX } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { NavigationBlocker } from '../../app/navigation-blocker';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ActionList } from '../../components/action-list';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
@@ -78,35 +79,26 @@ export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
 		active: isEdgeCacheEnabled ?? false,
 	} );
 
-	const edgeCacheStatusMutation = useMutation( {
-		...siteEdgeCacheStatusMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: formData.active
-					? __( 'Global edge cache enabled.' )
-					: __( 'Global edge cache disabled.' ),
-				error: __( 'Failed to save global edge cache settings.' ),
-			},
-		},
-	} );
-	const edgeCacheClearMutation = useMutation( {
-		...siteEdgeCacheClearMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: __( 'Global edge cache cleared.' ),
-				error: __( 'Failed to clear global edge cache.' ),
-			},
-		},
-	} );
-	const objectCacheClearMutation = useMutation( {
-		...siteObjectCacheClearMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: __( 'Object cache cleared.' ),
-				error: __( 'Failed to clear object cache.' ),
-			},
-		},
-	} );
+	const edgeCacheStatusMutation = useMutation(
+		withSnackbar( siteEdgeCacheStatusMutation( site.ID ), {
+			success: formData.active
+				? __( 'Global edge cache enabled.' )
+				: __( 'Global edge cache disabled.' ),
+			error: __( 'Failed to save global edge cache settings.' ),
+		} )
+	);
+	const edgeCacheClearMutation = useMutation(
+		withSnackbar( siteEdgeCacheClearMutation( site.ID ), {
+			success: __( 'Global edge cache cleared.' ),
+			error: __( 'Failed to clear global edge cache.' ),
+		} )
+	);
+	const objectCacheClearMutation = useMutation(
+		withSnackbar( siteObjectCacheClearMutation( site.ID ), {
+			success: __( 'Object cache cleared.' ),
+			error: __( 'Failed to clear object cache.' ),
+		} )
+	);
 
 	const isDirty = isEdgeCacheEnabled !== formData.active;
 	const { isPending } = edgeCacheStatusMutation;

--- a/client/dashboard/sites/settings-crontab/crontab-form.tsx
+++ b/client/dashboard/sites/settings-crontab/crontab-form.tsx
@@ -17,6 +17,7 @@ import {
 	siteSettingsCrontabEditRoute,
 	siteSettingsCrontabRoute,
 } from '../../app/router/sites';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
@@ -52,25 +53,19 @@ export default function CrontabForm( { crontab }: CrontabFormProps ) {
 		};
 	} );
 
-	const { mutate: createCrontab, isPending: isCreating } = useMutation( {
-		...siteCrontabCreateMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: __( 'Scheduled job created.' ),
-				error: __( 'Failed to create scheduled job.' ),
-			},
-		},
-	} );
+	const { mutate: createCrontab, isPending: isCreating } = useMutation(
+		withSnackbar( siteCrontabCreateMutation( site.ID ), {
+			success: __( 'Scheduled job created.' ),
+			error: __( 'Failed to create scheduled job.' ),
+		} )
+	);
 
-	const { mutate: updateCrontab, isPending: isUpdating } = useMutation( {
-		...siteCrontabUpdateMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: __( 'Scheduled job updated.' ),
-				error: __( 'Failed to update scheduled job.' ),
-			},
-		},
-	} );
+	const { mutate: updateCrontab, isPending: isUpdating } = useMutation(
+		withSnackbar( siteCrontabUpdateMutation( site.ID ), {
+			success: __( 'Scheduled job updated.' ),
+			error: __( 'Failed to update scheduled job.' ),
+		} )
+	);
 
 	const isPending = isEditMode ? isUpdating : isCreating;
 

--- a/client/dashboard/sites/settings-hundred-year-plan/contact-form.tsx
+++ b/client/dashboard/sites/settings-hundred-year-plan/contact-form.tsx
@@ -6,6 +6,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { NavigationBlocker } from '../../app/navigation-blocker';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import { SectionHeader } from '../../components/section-header';
@@ -27,15 +28,12 @@ const form = {
 };
 
 export default function ContactForm( { site, settings }: { site: Site; settings: SiteSettings } ) {
-	const mutation = useMutation( {
-		...siteSettingsMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: __( 'Legacy contact saved.' ),
-				error: __( 'Failed to save legacy contact.' ),
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( siteSettingsMutation( site.ID ), {
+			success: __( 'Legacy contact saved.' ),
+			error: __( 'Failed to save legacy contact.' ),
+		} )
+	);
 
 	const [ formData, setFormData ] = useState( {
 		wpcom_legacy_contact: settings?.wpcom_legacy_contact,

--- a/client/dashboard/sites/settings-hundred-year-plan/locked-mode-form.tsx
+++ b/client/dashboard/sites/settings-hundred-year-plan/locked-mode-form.tsx
@@ -5,6 +5,7 @@ import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { NavigationBlocker } from '../../app/navigation-blocker';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import { SectionHeader } from '../../components/section-header';
@@ -31,15 +32,12 @@ export default function LockedModeForm( {
 	site: Site;
 	settings: SiteSettings;
 } ) {
-	const mutation = useMutation( {
-		...siteSettingsMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: __( 'Locked mode saved.' ),
-				error: __( 'Failed to save locked mode.' ),
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( siteSettingsMutation( site.ID ), {
+			success: __( 'Locked mode saved.' ),
+			error: __( 'Failed to save locked mode.' ),
+		} )
+	);
 
 	const [ formData, setFormData ] = useState( {
 		wpcom_locked_mode: !! settings?.wpcom_locked_mode,

--- a/client/dashboard/sites/settings-php/index.tsx
+++ b/client/dashboard/sites/settings-php/index.tsx
@@ -12,6 +12,7 @@ import { useState } from 'react';
 import { getPHPVersions } from 'calypso/data/php-versions';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { NavigationBlocker } from '../../app/navigation-blocker';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
@@ -27,15 +28,12 @@ export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } )
 		...sitePHPVersionQuery( site.ID ),
 		enabled: hasHostingFeature( site, HostingFeatures.PHP ),
 	} );
-	const mutation = useMutation( {
-		...sitePHPVersionMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: __( 'PHP version saved.' ),
-				error: __( 'Failed to save PHP version.' ),
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( sitePHPVersionMutation( site.ID ), {
+			success: __( 'PHP version saved.' ),
+			error: __( 'Failed to save PHP version.' ),
+		} )
+	);
 
 	const [ formData, setFormData ] = useState< { version: string } >( {
 		version: currentVersion ?? '',

--- a/client/dashboard/sites/settings-repositories/disconnect-repository-modal-content.tsx
+++ b/client/dashboard/sites/settings-repositories/disconnect-repository-modal-content.tsx
@@ -12,6 +12,7 @@ import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import type { Field } from '@wordpress/dataviews';
 
@@ -33,15 +34,12 @@ export function DisconnectRepositoryModalContent( {
 		removeFiles: false,
 	} );
 
-	const { mutate: deleteDeployment, isPending: isDisconnecting } = useMutation( {
-		...codeDeploymentDeleteMutation( deployment?.blog_id, deployment?.id ),
-		meta: {
-			snackbar: {
-				success: __( 'Repository disconnected.' ),
-				error: __( 'Failed to disconnect repository.' ),
-			},
-		},
-	} );
+	const { mutate: deleteDeployment, isPending: isDisconnecting } = useMutation(
+		withSnackbar( codeDeploymentDeleteMutation( deployment?.blog_id, deployment?.id ), {
+			success: __( 'Repository disconnected.' ),
+			error: __( 'Failed to disconnect repository.' ),
+		} )
+	);
 
 	const handleDisconnect = () => {
 		deleteDeployment( !! formData.removeFiles, {

--- a/client/dashboard/sites/settings-sftp-ssh/enable-sftp-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/enable-sftp-card.tsx
@@ -10,6 +10,7 @@ import {
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
@@ -24,15 +25,12 @@ export default function EnableSftpCard( {
 	siteId: number;
 	canUseSsh: boolean;
 } ) {
-	const mutation = useMutation( {
-		...siteSftpUsersCreateMutation( siteId ),
-		meta: {
-			snackbar: {
-				success: __( 'SFTP/SSH credentials saved.' ),
-				error: __( 'Failed to save SFTP/SSH credentials. Please refresh the page and try again.' ),
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( siteSftpUsersCreateMutation( siteId ), {
+			success: __( 'SFTP/SSH credentials saved.' ),
+			error: __( 'Failed to save SFTP/SSH credentials. Please refresh the page and try again.' ),
+		} )
+	);
 
 	const handleCreateCredentials = () => {
 		mutation.mutate( undefined );

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -8,6 +8,7 @@ import { __ } from '@wordpress/i18n';
 import { useLayoutEffect, useMemo, useState } from 'react';
 import { useAppContext } from '../../app/context';
 import { NavigationBlocker } from '../../app/navigation-blocker';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
@@ -127,15 +128,12 @@ export function PrivacyForm( { site, settings }: { site: Site; settings: SiteSet
 		},
 	} );
 
-	const mutation = useMutation( {
-		...siteSettingsMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: __( 'Site visibility settings saved.' ),
-				error: __( 'Failed to save site visibility settings.' ),
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( siteSettingsMutation( site.ID ), {
+			success: __( 'Site visibility settings saved.' ),
+			error: __( 'Failed to save site visibility settings.' ),
+		} )
+	);
 
 	const primaryDomain = domains.find( ( domain ) => domain.primary_domain );
 	const isPrimaryDomainStaging = Boolean(

--- a/client/dashboard/sites/settings-static-file-404/index.tsx
+++ b/client/dashboard/sites/settings-static-file-404/index.tsx
@@ -11,6 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { NavigationBlocker } from '../../app/navigation-blocker';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
@@ -57,15 +58,12 @@ export default function SiteStaticFile404Settings( { siteSlug }: { siteSlug: str
 		...siteStaticFile404SettingQuery( site.ID ),
 		enabled: hasHostingFeature( site, HostingFeatures.STATIC_FILE_404 ),
 	} );
-	const mutation = useMutation( {
-		...siteStaticFile404SettingMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: __( 'Nonexistent assets settings saved.' ),
-				error: __( 'Failed to save nonexistent asset settings.' ),
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( siteStaticFile404SettingMutation( site.ID ), {
+			success: __( 'Nonexistent assets settings saved.' ),
+			error: __( 'Failed to save nonexistent asset settings.' ),
+		} )
+	);
 
 	const [ formData, setFormData ] = useState< { setting: string } >( {
 		setting: currentSetting ?? 'default',

--- a/client/dashboard/sites/settings-web-application-firewall/allow-list-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/allow-list-form.tsx
@@ -10,6 +10,7 @@ import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import { SectionHeader } from '../../components/section-header';
@@ -53,15 +54,12 @@ const form = {
 
 export default function AllowListForm( { site }: { site: Site } ) {
 	const { data: jetpackSettings } = useSuspenseQuery( siteJetpackSettingsQuery( site.ID ) );
-	const mutation = useMutation( {
-		...siteJetpackSettingsMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: __( 'Allowed IP addresses saved.' ),
-				error: __( 'Failed to save allowed IP addresses.' ),
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( siteJetpackSettingsMutation( site.ID ), {
+			success: __( 'Allowed IP addresses saved.' ),
+			error: __( 'Failed to save allowed IP addresses.' ),
+		} )
+	);
 
 	const currentEnabled = jetpackSettings?.jetpack_waf_ip_allow_list_enabled ?? false;
 	const currentList = jetpackSettings?.jetpack_waf_ip_allow_list ?? '';

--- a/client/dashboard/sites/settings-web-application-firewall/block-list-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/block-list-form.tsx
@@ -6,6 +6,7 @@ import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { NavigationBlocker } from '../../app/navigation-blocker';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import { SectionHeader } from '../../components/section-header';
@@ -51,15 +52,12 @@ const form = {
 
 export default function BlockListForm( { site }: { site: Site } ) {
 	const { data: jetpackSettings } = useSuspenseQuery( siteJetpackSettingsQuery( site.ID ) );
-	const mutation = useMutation( {
-		...siteJetpackSettingsMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: __( 'Blocked IP addresses saved.' ),
-				error: __( 'Failed to save blocked IP addresses.' ),
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( siteJetpackSettingsMutation( site.ID ), {
+			success: __( 'Blocked IP addresses saved.' ),
+			error: __( 'Failed to save blocked IP addresses.' ),
+		} )
+	);
 
 	// The WAF module is only supported on self-hosted Jetpack sites, and not supported on VIP
 	const isFirewallModuleSupported =

--- a/client/dashboard/sites/settings-wordpress/beta-opt-out-button.tsx
+++ b/client/dashboard/sites/settings-wordpress/beta-opt-out-button.tsx
@@ -10,6 +10,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import type { Site } from '@automattic/api-core';
 
 interface BetaOptOutButtonProps {
@@ -23,13 +24,10 @@ export function BetaOptOutButton( { site, onSuccess }: BetaOptOutButtonProps ) {
 	const { data: betaVersion } = useQuery( wpOrgCoreVersionQuery( 'beta' ) );
 
 	const mutation = useMutation( {
-		...siteWordPressVersionMutation( site.ID, { deferUntilBackupComplete: false } ),
-		meta: {
-			snackbar: {
-				success: __( 'You have opted out of the WordPress beta version.' ),
-				error: __( 'Failed to opt out of the WordPress beta version.' ),
-			},
-		},
+		...withSnackbar( siteWordPressVersionMutation( site.ID, { deferUntilBackupComplete: false } ), {
+			success: __( 'You have opted out of the WordPress beta version.' ),
+			error: __( 'Failed to opt out of the WordPress beta version.' ),
+		} ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteWordPressVersionQuery( site.ID ) );
 			queryClient.invalidateQueries( sitePendingWordPressVersionQuery( site.ID ) );

--- a/client/dashboard/sites/settings-wordpress/use-version-switch.ts
+++ b/client/dashboard/sites/settings-wordpress/use-version-switch.ts
@@ -12,6 +12,7 @@ import { useQuery, useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { usePrevious } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useReducer } from 'react';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { useBackupState } from '../backups/use-backup-state';
 import type { BackupState } from '../backups/use-backup-state';
 import type { Site } from '@automattic/api-core';
@@ -110,15 +111,12 @@ export function useVersionSwitch( site: Site ): VersionSwitchState {
 		refetchInterval: hasPendingVersion && backupState.hasRecentlyCompleted ? 5000 : false,
 	} );
 
-	const mutation = useMutation( {
-		...siteWordPressVersionMutation( site.ID, { deferUntilBackupComplete } ),
-		meta: {
-			snackbar: {
-				...( ! deferUntilBackupComplete && { success: __( 'WordPress version saved.' ) } ),
-				error: __( 'Failed to save WordPress version.' ),
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( siteWordPressVersionMutation( site.ID, { deferUntilBackupComplete } ), {
+			...( ! deferUntilBackupComplete && { success: __( 'WordPress version saved.' ) } ),
+			error: __( 'Failed to save WordPress version.' ),
+		} )
+	);
 
 	const switchVersion = ( version: string ) => {
 		if ( deferUntilBackupComplete ) {

--- a/client/dashboard/sites/settings/site-actions.tsx
+++ b/client/dashboard/sites/settings/site-actions.tsx
@@ -4,6 +4,7 @@ import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useAuth } from '../../app/auth';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ActionList } from '../../components/action-list';
 import { SectionHeader } from '../../components/section-header';
 import { wpcomLink } from '../../utils/link';
@@ -11,15 +12,12 @@ import { canViewSiteActions, canDuplicateSite } from '../features';
 import type { Site } from '@automattic/api-core';
 
 const RestorePlanSoftware = ( { site }: { site: Site } ) => {
-	const mutation = useMutation( {
-		...sitePlanSoftwareRestoreMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: __( 'Requested restoration of plugins and themes that come with your plan.' ),
-				error: __( 'Failed to request restoration of plan plugin and themes.' ),
-			},
-		},
-	} );
+	const mutation = useMutation(
+		withSnackbar( sitePlanSoftwareRestoreMutation( site.ID ), {
+			success: __( 'Requested restoration of plugins and themes that come with your plan.' ),
+			error: __( 'Failed to request restoration of plan plugin and themes.' ),
+		} )
+	);
 
 	const handleClick = () => {
 		mutation.mutate( undefined );

--- a/client/dashboard/sites/site-launch-button/use-site-launch.tsx
+++ b/client/dashboard/sites/site-launch-button/use-site-launch.tsx
@@ -6,6 +6,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { useMemo, useState, type ComponentType, type ReactElement } from 'react';
 import { useSiteLaunchGatingVariant } from 'calypso/lib/use-site-launch-gating-variant';
 import { getCurrentDashboard } from '../../app/routing';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { dashboardLinkWithBackport, redirectToDashboardLink, wpcomLink } from '../../utils/link';
 import {
 	isSitePlanLaunchable as getIsSitePlanLaunchable,
@@ -62,15 +63,12 @@ export function useSiteLaunch(
 		select: ( data ) => data.filter( ( d ) => d.blog_id === site.ID ),
 	} );
 
-	const launchMutation = useMutation( {
-		...siteLaunchMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: __( 'Your site has been launched; now you can share it with the world!' ),
-				error: __( 'Failed to launch site.' ),
-			},
-		},
-	} );
+	const launchMutation = useMutation(
+		withSnackbar( siteLaunchMutation( site.ID ), {
+			success: __( 'Your site has been launched; now you can share it with the world!' ),
+			error: __( 'Failed to launch site.' ),
+		} )
+	);
 
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ isExperimentLoading, variant ] = useSiteLaunchGatingVariant();

--- a/client/dashboard/sites/site-preview-links/index.tsx
+++ b/client/dashboard/sites/site-preview-links/index.tsx
@@ -10,6 +10,7 @@ import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { Card, CardBody } from '../../components/card';
 import { SectionHeader } from '../../components/section-header';
 import SitePreviewLink from '../../components/site-preview-link';
@@ -30,24 +31,18 @@ export default function SitePreviewLinks( { site, title, description }: SitePrev
 		...sitePreviewLinksQuery( site.ID ),
 		enabled: linksPermitted,
 	} );
-	const createMutation = useMutation( {
-		...sitePreviewLinkCreateMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: __( 'Preview link enabled.' ),
-				error: __( 'Failed to enable preview link.' ),
-			},
-		},
-	} );
-	const deleteMutation = useMutation( {
-		...sitePreviewLinkDeleteMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: __( 'Preview link disabled.' ),
-				error: __( 'Failed to disable preview link.' ),
-			},
-		},
-	} );
+	const createMutation = useMutation(
+		withSnackbar( sitePreviewLinkCreateMutation( site.ID ), {
+			success: __( 'Preview link enabled.' ),
+			error: __( 'Failed to enable preview link.' ),
+		} )
+	);
+	const deleteMutation = useMutation(
+		withSnackbar( sitePreviewLinkDeleteMutation( site.ID ), {
+			success: __( 'Preview link disabled.' ),
+			error: __( 'Failed to disable preview link.' ),
+		} )
+	);
 	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	if ( ! linksPermitted ) {

--- a/packages/api-queries/AGENTS.md
+++ b/packages/api-queries/AGENTS.md
@@ -1,0 +1,66 @@
+# API Queries
+
+See `README.md` for the package overview and the general guidelines on adding queries and mutations. This file covers one thing those don't: the `meta.statId` every mutation must carry.
+
+## Commands
+
+```bash
+# Run tests
+yarn test-packages packages/api-queries
+
+# Type check (also emits dist/types)
+yarn typecheck-packages
+
+# Lint
+yarn eslint packages/api-queries/src/<file>
+```
+
+## Adding a mutation: `meta.statId`
+
+Name the ID `<noun>-<verb>`: the thing acted on first, the action last.
+
+```ts
+export const sitePluginActivateMutation = ( siteId: number ) =>
+	mutationOptions( {
+		meta: { statId: 'site-plugin-activate' },
+		mutationFn: ( plugin: string ) => activatePlugin( siteId, plugin ),
+	} );
+```
+
+Noun first is what makes the stats display group usefully — every `site-plugin-*` mutation sorts together, where a verb-first `activate-site-plugin` would sort beside `activate-account`.
+
+### Describe the call, not the factory
+
+The ID is written by hand and is **deliberately not derived from the export name**. Nothing checks the two against each other, and they are expected to disagree:
+
+- The noun leads even when the export name reads the other way round: `installPluginMutation` → `plugin-install`.
+- Where the export name is vague, the ID names what the request actually does. `siteDatabaseMutation` calls `restoreDatabasePassword`, so its ID is `site-db-password-restore`, not `site-database`.
+
+Read the `mutationFn` before naming the ID.
+
+### Always end in a verb
+
+Every ID ends in a verb. That is what keeps stat IDs for queries addable later without `site-php-version` colliding with the mutation's.
+
+Some mutations save a thing and have no obvious verb. Invent one rather than leaving the ID verb-less — a settings write is `-update` (`site-settings-update`, `domain-dns-update`), and a boolean write that goes both ways is `-toggle` (`site-apm-toggle`, `site-jp-module-toggle`).
+
+### Fitting the length limit
+
+**An ID can't exceed 28 characters.** `bumpStat` itself stops at 32; the remaining 4 are reserved for the `.<status>` suffix `MutationErrorTracker` appends.
+
+When an ID overflows, in order of preference:
+
+1. **Drop a redundant word.** Usually the fastest fix and the most readable result — `site-jp-mon-settings-create` → `site-jp-mon-create`, `cancel-pending-email-change` → `email-change-cancel`.
+2. **Abbreviate a phrase the way its family already does.** Abbreviations are per-family conventions, not a global table: `two-step-auth` → `2fa`, `subscription` → `sub`, `download` → `dl`, `transfer` → `xfer`, `deployment` → `deploy`, `preference` → `pref`. Match the siblings in the same file rather than inventing a new short form.
+
+Keep a family internally consistent — if one ID abbreviates a word, its siblings should too. Don't abbreviate to buy headroom you don't need: spell the verb out (`-update`, not `-upd`) whenever it fits.
+
+### Always run the test
+
+`statId` is typed as optional — requiring it would force it on every `useMutation` call site repo-wide — so a missing one won't fail the type-check. `meta` also carries an index signature (required by TS#15300), so a typo like `statid` type-checks and silently leaves `statId` undefined.
+
+`src/__tests__/mutation-stat-ids.test.ts` is the only thing that catches either, along with a duplicate or over-length ID. It can't check the naming convention itself — noun-first and verb-final are a review concern, not a testable one. Run it after adding or renaming any mutation:
+
+```bash
+yarn test-packages packages/api-queries
+```

--- a/packages/api-queries/AGENTS.md
+++ b/packages/api-queries/AGENTS.md
@@ -29,6 +29,10 @@ export const sitePluginActivateMutation = ( siteId: number ) =>
 
 Noun first is what makes the stats display group usefully — every `site-plugin-*` mutation sorts together, where a verb-first `activate-site-plugin` would sort beside `activate-account`.
 
+### Lead with the scope
+
+When a mutation is scoped to one kind of thing, that scope is the start of the noun: `site-` for anything acting on a site, `domain-` for a domain, `purch-` for a purchase. Keep it even when the export name or file leaves it implicit — `deploy-create` in `site-deployments.ts` is `site-deploy-create`, `ssl-cert-provision` is `domain-ssl-provision`. It groups the family and tells a human reading the stat what surface failed. Drop the scope prefix only when the ID overflows the length limit and nothing else will give (see below).
+
 ### Describe the call, not the factory
 
 The ID is written by hand and is **deliberately not derived from the export name**. Nothing checks the two against each other, and they are expected to disagree:

--- a/packages/api-queries/CLAUDE.md
+++ b/packages/api-queries/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/api-queries/README.md
+++ b/packages/api-queries/README.md
@@ -61,6 +61,9 @@ These guidelines should be followed to ensure reusability of the queries and mut
 ### Adding mutations
 
 - Define mutations as functions that return the result of `mutationOptions()` from `@tanstack/react-query`. This is to improve TypeScript type inference.
+- Every mutation must set a `meta.statId`. It identifies the mutation in failure stats, where the mutation key can't be relied on because it is optional and most mutations here don't set one.
+  - Name it `<noun>-<verb>` — the thing acted on first, the action last (`site-plugin-activate`, not `activate-site-plugin`), so that the stats display groups a family together. It describes the request the `mutationFn` makes, and is deliberately not derived from the export name.
+  - An ID can't exceed 28 characters, so recurring phrases are abbreviated to fit (`two-step-auth` → `2fa`, `subscription` → `sub`). `src/__tests__/mutation-stat-ids.test.ts` asserts that every mutation has a `statId`, that none is duplicated, and that none is over the limit. See `AGENTS.md` for the naming rules in full.
 - Add `onSuccess` and `onError` handlers to invalidate queries and update the cache as needed.
   - You can do so by using the exported `queryClient` instance:
 

--- a/packages/api-queries/src/__tests__/mutation-stat-ids.test.ts
+++ b/packages/api-queries/src/__tests__/mutation-stat-ids.test.ts
@@ -1,0 +1,86 @@
+import * as apiQueries from '../index';
+
+/**
+ * `bumpMultipleStats()` enforces the 32-character limit `bumpStat` imposes. The budget here is
+ * lower: the remaining characters are reserved for the `.<status>` suffix `MutationErrorTracker`
+ * appends to the ID at bump time.
+ */
+const STAT_ID_MAX_LENGTH = 28;
+
+/**
+ * Mutation factories only close over their arguments — `mutationFn` is not called
+ * here — so invoking them with no arguments is enough to read back their options.
+ * A factory that destructures its arguments eagerly will throw; record it rather
+ * than skipping silently, so it can't disappear from the audit unnoticed.
+ */
+function collectMutations() {
+	const found: Array< { name: string; statId?: string } > = [];
+	const uncallable: string[] = [];
+
+	for ( const [ name, value ] of Object.entries( apiQueries ) ) {
+		if ( ! name.endsWith( 'Mutation' ) || typeof value !== 'function' ) {
+			continue;
+		}
+
+		try {
+			const options = ( value as ( ...args: unknown[] ) => unknown )();
+			if ( ! options || typeof options !== 'object' || ! ( 'mutationFn' in options ) ) {
+				continue;
+			}
+			const meta = ( options as { meta?: { statId?: unknown } } ).meta;
+			found.push( {
+				name,
+				statId: typeof meta?.statId === 'string' ? meta.statId : undefined,
+			} );
+		} catch {
+			uncallable.push( name );
+		}
+	}
+
+	return { found, uncallable };
+}
+
+describe( 'mutation statId', () => {
+	const { found, uncallable } = collectMutations();
+
+	// Without this the suite below would pass vacuously if the barrel stopped
+	// exporting, every factory threw, or the naming convention changed. There are
+	// ~219 readable factories today; the floor is loose enough not to need bumping.
+	it( 'discovers the mutation factories exported from the barrel', () => {
+		expect( found.length ).toBeGreaterThan( 150 );
+	} );
+
+	// The reader `use*Mutation` exports are hooks, not options factories, so they
+	// can't be read outside a render and are invisible to the checks below. Kept
+	// as an explicit list so the gap stays visible rather than silently growing.
+	it( 'has only the known reader hooks unreadable', () => {
+		expect( uncallable.every( ( name ) => name.startsWith( 'use' ) ) ).toBe( true );
+	} );
+
+	// `meta` carries an index signature (required by TS#15300), so a typo like
+	// `statid` type-checks and leaves `statId` undefined. These two tests are the
+	// only thing standing between that and a stat reported as 'missing'.
+	it( 'sets a statId on every mutation', () => {
+		const missing = found.filter( ( m ) => m.statId === undefined ).map( ( m ) => m.name );
+
+		expect( missing ).toEqual( [] );
+	} );
+
+	// IDs are hand-written rather than derived from the export name, so nothing but this
+	// stops two mutations reporting under one stat and silently pooling their failures.
+	it( 'has no duplicate statIds', () => {
+		const ids = found.map( ( m ) => m.statId ).filter( Boolean );
+		expect( ids ).toHaveLength( new Set( ids ).size );
+	} );
+
+	// `bumpMultipleStats()` doesn't truncate an over-long ID, it reports it to Sentry — so one
+	// of these costs a spurious exception on every failure of that mutation, forever. Fix by
+	// shortening the ID: drop a redundant word, or abbreviate a phrase the way its family does.
+	it( 'keeps every statId within the stat length limit', () => {
+		const tooLong = found
+			.filter( ( m ) => ( m.statId?.length ?? 0 ) > STAT_ID_MAX_LENGTH )
+			.map( ( m ) => `${ m.name }: '${ m.statId }' is ${ m.statId?.length } chars` );
+
+		expect( tooLong ).toEqual( [] );
+	} );
+} );

--- a/packages/api-queries/src/__tests__/mutation-stat-ids.test.ts
+++ b/packages/api-queries/src/__tests__/mutation-stat-ids.test.ts
@@ -1,9 +1,8 @@
 import * as apiQueries from '../index';
 
 /**
- * `bumpMultipleStats()` enforces the 32-character limit `bumpStat` imposes. The budget here is
- * lower: the remaining characters are reserved for the `.<status>` suffix `MutationErrorTracker`
- * appends to the ID at bump time.
+ * `bumpStats` have a 32-character limit. The budget here is lower. The remaining
+ * space is reserved for suffixes like `.401`.
  */
 const STAT_ID_MAX_LENGTH = 28;
 
@@ -13,7 +12,7 @@ const STAT_ID_MAX_LENGTH = 28;
  * A factory that destructures its arguments eagerly will throw; record it rather
  * than skipping silently, so it can't disappear from the audit unnoticed.
  */
-function collectMutations() {
+function collectMutationsInPackage() {
 	const found: Array< { name: string; statId?: string } > = [];
 	const uncallable: string[] = [];
 
@@ -40,12 +39,11 @@ function collectMutations() {
 	return { found, uncallable };
 }
 
-describe( 'mutation statId', () => {
-	const { found, uncallable } = collectMutations();
+describe( 'mutation statIds', () => {
+	const { found, uncallable } = collectMutationsInPackage();
 
-	// Without this the suite below would pass vacuously if the barrel stopped
-	// exporting, every factory threw, or the naming convention changed. There are
-	// ~219 readable factories today; the floor is loose enough not to need bumping.
+	// Confidence check to make sure we're actually finding the mutations.
+	// There are ~219 readable factories today; 150 should be enough to be sure we've found them.
 	it( 'discovers the mutation factories exported from the barrel', () => {
 		expect( found.length ).toBeGreaterThan( 150 );
 	} );
@@ -53,29 +51,24 @@ describe( 'mutation statId', () => {
 	// The reader `use*Mutation` exports are hooks, not options factories, so they
 	// can't be read outside a render and are invisible to the checks below. Kept
 	// as an explicit list so the gap stays visible rather than silently growing.
+	// TODO convert the hooks into regular mutation factories.
 	it( 'has only the known reader hooks unreadable', () => {
 		expect( uncallable.every( ( name ) => name.startsWith( 'use' ) ) ).toBe( true );
 	} );
 
-	// `meta` carries an index signature (required by TS#15300), so a typo like
-	// `statid` type-checks and leaves `statId` undefined. These two tests are the
-	// only thing standing between that and a stat reported as 'missing'.
-	it( 'sets a statId on every mutation', () => {
-		const missing = found.filter( ( m ) => m.statId === undefined ).map( ( m ) => m.name );
-
-		expect( missing ).toEqual( [] );
+	describe( 'sets a statId on every mutation', () => {
+		found.forEach( ( { name, statId } ) => {
+			it( `defines a statId for ${ name }`, () => {
+				expect( statId ).toBeDefined();
+			} );
+		} );
 	} );
 
-	// IDs are hand-written rather than derived from the export name, so nothing but this
-	// stops two mutations reporting under one stat and silently pooling their failures.
 	it( 'has no duplicate statIds', () => {
 		const ids = found.map( ( m ) => m.statId ).filter( Boolean );
 		expect( ids ).toHaveLength( new Set( ids ).size );
 	} );
 
-	// `bumpMultipleStats()` doesn't truncate an over-long ID, it reports it to Sentry — so one
-	// of these costs a spurious exception on every failure of that mutation, forever. Fix by
-	// shortening the ID: drop a redundant word, or abbreviate a phrase the way its family does.
 	it( 'keeps every statId within the stat length limit', () => {
 		const tooLong = found
 			.filter( ( m ) => ( m.statId?.length ?? 0 ) > STAT_ID_MAX_LENGTH )

--- a/packages/api-queries/src/agency-team.ts
+++ b/packages/api-queries/src/agency-team.ts
@@ -60,30 +60,35 @@ function invalidateActiveAgency() {
 
 export const agencyTeamInviteMutation = ( agencyId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'agcy-team-invite' },
 		mutationFn: ( input: AgencyTeamInviteInput ) => inviteAgencyTeamMember( agencyId, input ),
 		onSuccess: () => invalidateAgencyTeam( agencyId ),
 	} );
 
 export const agencyTeamResendInviteMutation = ( agencyId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'agcy-team-invite-resend' },
 		mutationFn: ( inviteId: number ) => resendAgencyTeamInvite( agencyId, inviteId ),
 		onSuccess: () => invalidateAgencyTeam( agencyId ),
 	} );
 
 export const agencyTeamCancelInviteMutation = ( agencyId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'agcy-team-invite-cancel' },
 		mutationFn: ( inviteId: number ) => cancelAgencyTeamInvite( agencyId, inviteId ),
 		onSuccess: () => invalidateAgencyTeam( agencyId ),
 	} );
 
 export const agencyTeamRemoveMemberMutation = ( agencyId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'agcy-team-member-remove' },
 		mutationFn: ( userId: number ) => removeAgencyTeamMember( agencyId, userId ),
 		onSuccess: () => invalidateAgencyTeam( agencyId ),
 	} );
 
 export const agencyTeamTransferOwnershipMutation = ( agencyId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'agcy-team-ownership-xfer' },
 		mutationFn: ( newOwnerId: number ) => transferAgencyOwnership( agencyId, newOwnerId ),
 		onSuccess: () => {
 			invalidateAgencyTeam( agencyId );

--- a/packages/api-queries/src/agency.ts
+++ b/packages/api-queries/src/agency.ts
@@ -116,6 +116,7 @@ export const mcpSettingsQuery = ( agencyId: number ) =>
 export const agencyMcpSettingsMutation = ( agencyId: number ) => {
 	const queryKey = mcpSettingsQuery( agencyId ).queryKey;
 	return mutationOptions( {
+		meta: { statId: 'agcy-mcp-settings-update' },
 		mutationFn: ( update: McpSettingsUpdate ) => updateAgencyMcpSettings( agencyId, update ),
 		onMutate: async ( update: McpSettingsUpdate ) => {
 			await queryClient.cancelQueries( { queryKey } );

--- a/packages/api-queries/src/big-sky-plugin.ts
+++ b/packages/api-queries/src/big-sky-plugin.ts
@@ -12,6 +12,7 @@ export const bigSkyPluginQuery = ( siteId: number ) =>
 
 export const bigSkyPluginMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'big-sky-plugin-update' },
 		mutationFn: ( data: BigSkyPluginUpdateRequest ) => updateBigSkyPlugin( siteId, data ),
 		onSuccess: () => {
 			// Invalidate the big-sky-plugin query to refresh the UI

--- a/packages/api-queries/src/big-sky-plugin.ts
+++ b/packages/api-queries/src/big-sky-plugin.ts
@@ -12,7 +12,7 @@ export const bigSkyPluginQuery = ( siteId: number ) =>
 
 export const bigSkyPluginMutation = ( siteId: number ) =>
 	mutationOptions( {
-		meta: { statId: 'big-sky-plugin-update' },
+		meta: { statId: 'site-big-sky-plugin-update' },
 		mutationFn: ( data: BigSkyPluginUpdateRequest ) => updateBigSkyPlugin( siteId, data ),
 		onSuccess: () => {
 			// Invalidate the big-sky-plugin query to refresh the UI

--- a/packages/api-queries/src/cancellation-offers.ts
+++ b/packages/api-queries/src/cancellation-offers.ts
@@ -10,6 +10,7 @@ export const cancellationOffersQuery = ( siteId: number, purchaseId: number ) =>
 
 export const applyCancellationOfferMutation = ( siteId: number, purchaseId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'cancellation-offer-apply' },
 		mutationFn: () => applyCancellationOffer( siteId, purchaseId ),
 		onSuccess: ( data ) => {
 			queryClient.invalidateQueries( cancellationOffersQuery( siteId, purchaseId ) );

--- a/packages/api-queries/src/domain-connection-setup.ts
+++ b/packages/api-queries/src/domain-connection-setup.ts
@@ -24,6 +24,7 @@ export const domainMappingStatusQuery = ( domainName: string ) =>
 
 export const updateConnectionModeMutation = ( domainName: string, siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'conn-mode-update' },
 		mutationFn: ( connectionMode: string | null ) =>
 			updateConnectionModeAndGetMappingStatus( domainName, connectionMode ),
 		onSuccess: () => {

--- a/packages/api-queries/src/domain-connection-setup.ts
+++ b/packages/api-queries/src/domain-connection-setup.ts
@@ -24,7 +24,7 @@ export const domainMappingStatusQuery = ( domainName: string ) =>
 
 export const updateConnectionModeMutation = ( domainName: string, siteId: number ) =>
 	mutationOptions( {
-		meta: { statId: 'conn-mode-update' },
+		meta: { statId: 'domain-conn-mode-update' },
 		mutationFn: ( connectionMode: string | null ) =>
 			updateConnectionModeAndGetMappingStatus( domainName, connectionMode ),
 		onSuccess: () => {

--- a/packages/api-queries/src/domain-contact-verification.ts
+++ b/packages/api-queries/src/domain-contact-verification.ts
@@ -3,6 +3,7 @@ import { mutationOptions } from '@tanstack/react-query';
 
 export const domainContactVerificationMutation = ( domainName: string ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-contact-verify' },
 		mutationFn: ( formData: [ string, File, string ][] ) =>
 			domainContactVerification( domainName, formData ),
 	} );

--- a/packages/api-queries/src/domain-dns-records.ts
+++ b/packages/api-queries/src/domain-dns-records.ts
@@ -18,6 +18,7 @@ export const domainDnsQuery = ( domainName: string ) =>
 
 export const domainDnsMutation = ( domainName: string ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-dns-update' },
 		mutationFn: ( {
 			recordsToAdd,
 			recordsToRemove,
@@ -34,6 +35,7 @@ export const domainDnsMutation = ( domainName: string ) =>
 
 export const domainDnsEmailMutation = ( domainName: string ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-dns-email-restore' },
 		mutationFn: () => restoreDefaultEmailRecords( domainName ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( {
@@ -44,6 +46,7 @@ export const domainDnsEmailMutation = ( domainName: string ) =>
 
 export const domainDnsApplyTemplateMutation = ( domainName: string ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-dns-tmpl-apply' },
 		mutationFn: ( {
 			provider,
 			service,
@@ -60,6 +63,7 @@ export const domainDnsApplyTemplateMutation = ( domainName: string ) =>
 
 export const domainDnsImportBindMutation = ( domainName: string ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-dns-bind-import' },
 		mutationFn: ( file: File ) => importDnsBind( domainName, file ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( domainDnsQuery( domainName ) );

--- a/packages/api-queries/src/domain-dnssec.ts
+++ b/packages/api-queries/src/domain-dnssec.ts
@@ -5,6 +5,7 @@ import { queryClient } from './query-client';
 
 export const domainDnssecMutation = ( domain: string ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-dnssec-update' },
 		mutationFn: ( enabled: boolean ) => updateDNSSEC( domain, enabled ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( domainQuery( domain ) );

--- a/packages/api-queries/src/domain-email.ts
+++ b/packages/api-queries/src/domain-email.ts
@@ -32,6 +32,7 @@ type Variables = {
 
 export const addEmailForwarderMutation = () =>
 	mutationOptions< unknown, ResponseError, Variables >( {
+		meta: { statId: 'email-fwd-add' },
 		mutationFn: ( {
 			domain,
 			mailbox,

--- a/packages/api-queries/src/domain-forwarding.ts
+++ b/packages/api-queries/src/domain-forwarding.ts
@@ -15,6 +15,7 @@ export const domainForwardingQuery = ( domainName: string ) =>
 
 export const domainForwardingDeleteMutation = ( domainName: string ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-forwarding-delete' },
 		mutationFn: ( forwardingId: number ) => deleteDomainForwarding( domainName, forwardingId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( domainForwardingQuery( domainName ) );
@@ -23,6 +24,7 @@ export const domainForwardingDeleteMutation = ( domainName: string ) =>
 
 export const domainForwardingSaveMutation = ( domainName: string ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-forwarding-save' },
 		mutationFn: ( data: DomainForwardingSaveData ) => saveDomainForwarding( domainName, data ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( domainForwardingQuery( domainName ) );

--- a/packages/api-queries/src/domain-glue-records.ts
+++ b/packages/api-queries/src/domain-glue-records.ts
@@ -16,6 +16,7 @@ export const domainGlueRecordsQuery = ( domainName: string ) =>
 
 export const domainGlueRecordCreateMutation = ( domainName: string ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-glue-create' },
 		mutationFn: ( glueRecord: DomainGlueRecord ) => createDomainGlueRecord( glueRecord ),
 		onSuccess: ( newData, createdGlueRecord ) => {
 			queryClient.setQueryData(
@@ -28,6 +29,7 @@ export const domainGlueRecordCreateMutation = ( domainName: string ) =>
 
 export const domainGlueRecordUpdateMutation = ( domainName: string ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-glue-update' },
 		mutationFn: ( glueRecord: DomainGlueRecord ) => updateDomainGlueRecord( glueRecord ),
 		onSuccess: ( newData, updatedGlueRecord ) => {
 			queryClient.setQueryData(
@@ -48,6 +50,7 @@ export const domainGlueRecordUpdateMutation = ( domainName: string ) =>
 
 export const domainGlueRecordDeleteMutation = ( domainName: string ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-glue-delete' },
 		mutationFn: ( glueRecord: DomainGlueRecord ) =>
 			deleteDomainGlueRecord( domainName, glueRecord ),
 		onSuccess: ( newData, deletedGlueRecord ): void => {

--- a/packages/api-queries/src/domain-name-servers.ts
+++ b/packages/api-queries/src/domain-name-servers.ts
@@ -15,6 +15,7 @@ export const domainNameServersQuery = ( domainName: string ) =>
 
 export const domainNameServersMutation = ( domainName: string ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-name-servers-update' },
 		mutationFn: ( nameServers: string[] ) => updateDomainNameServers( domainName, nameServers ),
 		onSuccess: ( _, data ) => {
 			const oldData = queryClient.getQueryData( domainNameServersQuery( domainName ).queryKey ) as

--- a/packages/api-queries/src/domain-notices.ts
+++ b/packages/api-queries/src/domain-notices.ts
@@ -5,6 +5,7 @@ import { queryClient } from './query-client';
 
 export const domainNoticeMutation = ( domainName: string, noticeType: string ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-notice-set' },
 		mutationFn: ( noticeMessage: string ) =>
 			setDomainNotice( domainName, noticeType, noticeMessage ),
 		onSuccess: () => {

--- a/packages/api-queries/src/domain-privacy.ts
+++ b/packages/api-queries/src/domain-privacy.ts
@@ -11,6 +11,7 @@ import { queryClient } from './query-client';
 
 export const domainPrivacySaveMutation = ( domainName: string ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-privacy-save' },
 		mutationFn: ( enable_privacy: boolean ) =>
 			enable_privacy ? enableDomainPrivacy( domainName ) : disableDomainPrivacy( domainName ),
 		onSuccess: ( _, enable_privacy: boolean ) => {
@@ -25,6 +26,7 @@ export const domainPrivacySaveMutation = ( domainName: string ) =>
 
 export const domainPrivacyDiscloseSaveMutation = ( domainName: string ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-privacy-disclose' },
 		mutationFn: ( disclose: boolean ) =>
 			disclose ? discloseDomainPrivacy( domainName ) : redactDomainPrivacy( domainName ),
 		onSuccess: ( _, disclose: boolean ) => {

--- a/packages/api-queries/src/domain-ssl.ts
+++ b/packages/api-queries/src/domain-ssl.ts
@@ -10,7 +10,7 @@ export const sslDetailsQuery = ( domainName: string ) =>
 
 export const provisionSslCertificateMutation = ( domainName: string ) =>
 	mutationOptions( {
-		meta: { statId: 'ssl-cert-provision' },
+		meta: { statId: 'domain-ssl-provision' },
 		mutationFn: () => provisionSslCertificate( domainName ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( sslDetailsQuery( domainName ) );

--- a/packages/api-queries/src/domain-ssl.ts
+++ b/packages/api-queries/src/domain-ssl.ts
@@ -10,6 +10,7 @@ export const sslDetailsQuery = ( domainName: string ) =>
 
 export const provisionSslCertificateMutation = ( domainName: string ) =>
 	mutationOptions( {
+		meta: { statId: 'ssl-cert-provision' },
 		mutationFn: () => provisionSslCertificate( domainName ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( sslDetailsQuery( domainName ) );

--- a/packages/api-queries/src/domain-transfer.ts
+++ b/packages/api-queries/src/domain-transfer.ts
@@ -18,6 +18,7 @@ import type { Domain } from '@automattic/api-core';
 
 export const domainLockMutation = ( domain: string ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-lock' },
 		mutationFn: ( enabled: boolean ) => updateDomainLock( domain, enabled ),
 		onSuccess: ( _, enabled ) => {
 			const oldDomain = queryClient.getQueryData( domainQuery( domain ).queryKey );
@@ -31,6 +32,7 @@ export const domainLockMutation = ( domain: string ) =>
 
 export const domainTransferCodeMutation = ( domain: string ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-xfer-code-request' },
 		mutationFn: () => requestTransferCode( domain ),
 	} );
 
@@ -42,6 +44,7 @@ export const ipsTagListQuery = () =>
 
 export const ipsTagMutation = ( domain: string ) =>
 	mutationOptions( {
+		meta: { statId: 'ips-tag-save' },
 		mutationFn: ( ipsTag: string ) => saveIpsTag( domain, ipsTag ),
 	} );
 
@@ -53,6 +56,7 @@ export const domainTransferRequestQuery = ( domain: string, siteSlug: string ) =
 
 export const updateDomainTransferRequestMutation = ( domain: string, siteSlug: string ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-xfer-req-update' },
 		mutationFn: ( email: string ) => updateDomainTransferRequest( domain, siteSlug, email ),
 		onSuccess: ( _, email ) => {
 			// Manually update the cache before invalidating the query
@@ -66,6 +70,7 @@ export const updateDomainTransferRequestMutation = ( domain: string, siteSlug: s
 
 export const deleteDomainTransferRequestMutation = ( domain: string, siteSlug: string ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-xfer-req-delete' },
 		mutationFn: () => deleteDomainTransferRequest( domain, siteSlug ),
 		onSuccess: () => {
 			// Manually update the cache before invalidating the query
@@ -76,6 +81,7 @@ export const deleteDomainTransferRequestMutation = ( domain: string, siteSlug: s
 
 export const domainTransferToUserMutation = ( domain: string, siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-owner-xfer' },
 		mutationFn: ( userId: string ) => domainTransferToUser( domain, siteId, userId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( { queryKey: [ 'domains' ] } );
@@ -84,6 +90,7 @@ export const domainTransferToUserMutation = ( domain: string, siteId: number ) =
 
 export const transferDomainToSiteMutation = ( domain: string, siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-site-xfer' },
 		mutationFn: ( targetSiteId: number ) => transferDomainToSite( domain, siteId, targetSiteId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( domainQuery( domain ) );
@@ -98,6 +105,7 @@ export const domainInboundTransferStatusQuery = ( domainName: string ) =>
 
 export const startDomainInboundTransferMutation = ( domain: string, siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-xfer-in-start' },
 		mutationFn: ( authCode: string ) => startDomainInboundTransfer( siteId, domain, authCode ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( domainQuery( domain ) );

--- a/packages/api-queries/src/domain-transfer.ts
+++ b/packages/api-queries/src/domain-transfer.ts
@@ -18,7 +18,7 @@ import type { Domain } from '@automattic/api-core';
 
 export const domainLockMutation = ( domain: string ) =>
 	mutationOptions( {
-		meta: { statId: 'domain-lock' },
+		meta: { statId: 'domain-xfer-lock-update' },
 		mutationFn: ( enabled: boolean ) => updateDomainLock( domain, enabled ),
 		onSuccess: ( _, enabled ) => {
 			const oldDomain = queryClient.getQueryData( domainQuery( domain ).queryKey );
@@ -44,7 +44,7 @@ export const ipsTagListQuery = () =>
 
 export const ipsTagMutation = ( domain: string ) =>
 	mutationOptions( {
-		meta: { statId: 'ips-tag-save' },
+		meta: { statId: 'domain-xfer-ips-tag-save' },
 		mutationFn: ( ipsTag: string ) => saveIpsTag( domain, ipsTag ),
 	} );
 

--- a/packages/api-queries/src/domain-whois.ts
+++ b/packages/api-queries/src/domain-whois.ts
@@ -16,6 +16,7 @@ export const domainWhoisQuery = ( domainName: string ) =>
 
 export const domainWhoisValidateMutation = ( domainNames: string[] ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-whois-validate' },
 		mutationFn: ( domainContactDetails: DomainContactDetails ) => {
 			const contactInformation = mapRecordKeysRecursively(
 				domainContactDetails,
@@ -27,6 +28,7 @@ export const domainWhoisValidateMutation = ( domainNames: string[] ) =>
 
 export const domainWhoisMutation = ( domainName: string ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-whois-update' },
 		mutationFn: ( {
 			domainContactDetails,
 			transferLock,

--- a/packages/api-queries/src/domain.ts
+++ b/packages/api-queries/src/domain.ts
@@ -27,7 +27,7 @@ export const disconnectDomainMutation = ( domainName: string ) =>
 
 export const resendIcannVerificationEmailMutation = ( domainName: string ) =>
 	mutationOptions( {
-		meta: { statId: 'icann-verify-resend' },
+		meta: { statId: 'domain-icann-verify-resend' },
 		mutationFn: () => resendIcannVerificationEmail( domainName ),
 	} );
 

--- a/packages/api-queries/src/domain.ts
+++ b/packages/api-queries/src/domain.ts
@@ -18,6 +18,7 @@ export const domainQuery = ( domainName: string ) =>
 
 export const disconnectDomainMutation = ( domainName: string ) =>
 	mutationOptions( {
+		meta: { statId: 'domain-disconnect' },
 		mutationFn: () => disconnectDomain( domainName ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( domainQuery( domainName ) );
@@ -26,11 +27,13 @@ export const disconnectDomainMutation = ( domainName: string ) =>
 
 export const resendIcannVerificationEmailMutation = ( domainName: string ) =>
 	mutationOptions( {
+		meta: { statId: 'icann-verify-resend' },
 		mutationFn: () => resendIcannVerificationEmail( domainName ),
 	} );
 
 export const resendVerifyEmailForwardMutation = () => {
 	return mutationOptions( {
+		meta: { statId: 'email-fwd-verify-resend' },
 		mutationFn: ( vars: { domainName: string; mailbox: string; destination: string } ) =>
 			resendVerifyEmailForward( vars.domainName, vars.mailbox, vars.destination ),
 	} );
@@ -38,6 +41,7 @@ export const resendVerifyEmailForwardMutation = () => {
 
 export const deleteEmailForwardMutation = () => {
 	return mutationOptions( {
+		meta: { statId: 'email-fwd-delete' },
 		mutationFn: ( vars: { domainName: string; mailbox: string; destination: string } ) =>
 			deleteEmailForward( vars.domainName, vars.mailbox, vars.destination ),
 		onSuccess: () => {
@@ -48,6 +52,7 @@ export const deleteEmailForwardMutation = () => {
 
 export const updateEmailForwardMutation = () => {
 	return mutationOptions( {
+		meta: { statId: 'email-fwd-update' },
 		mutationFn: ( vars: {
 			domainName: string;
 			mailbox: string;

--- a/packages/api-queries/src/domains.ts
+++ b/packages/api-queries/src/domains.ts
@@ -134,6 +134,7 @@ export const bulkDomainUpdateStatusQuery = () =>
 
 export const bulkDomainsActionMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'domains-bulk-apply' },
 		mutationFn: ( action: BulkDomainsAction ) => bulkDomainsAction( action ),
 		onSuccess: () => {
 			queryClient.refetchQueries( bulkDomainUpdateStatusQuery() );

--- a/packages/api-queries/src/emails.ts
+++ b/packages/api-queries/src/emails.ts
@@ -23,6 +23,7 @@ export const mailboxAccountsQuery = ( siteId: number, domain: string ) =>
 
 export const createTitanMailboxMutation = () => {
 	return mutationOptions( {
+		meta: { statId: 'titan-mailbox-create' },
 		mutationFn: ( vars: {
 			domainName: string;
 			isAdmin: boolean;
@@ -47,6 +48,7 @@ export const createTitanMailboxMutation = () => {
 
 export const deleteTitanMailboxMutation = () => {
 	return mutationOptions( {
+		meta: { statId: 'titan-mailbox-delete' },
 		mutationFn: ( vars: { domainName: string; mailbox: string } ) =>
 			deleteTitanMailbox( vars.domainName, vars.mailbox ),
 		onSuccess: () => {

--- a/packages/api-queries/src/github.ts
+++ b/packages/api-queries/src/github.ts
@@ -108,6 +108,7 @@ export const githubWorkflowChecksQuery = (
 
 export const saveGithubCredentialsMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'github-credentials-save' },
 		mutationFn: ( { accessToken }: { accessToken: string } ) =>
 			saveGithubCredentials( accessToken ),
 		onSuccess: () => {
@@ -139,6 +140,7 @@ export const githubWorkflowsQuery = (
 
 export const createGithubWorkflowMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'github-workflow-create' },
 		mutationFn: ( request: CreateWorkflowRequest ) => createGithubWorkflow( request ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( {

--- a/packages/api-queries/src/marketing-survey.ts
+++ b/packages/api-queries/src/marketing-survey.ts
@@ -5,12 +5,14 @@ import { queryClient } from './query-client';
 
 export const marketingSurveyMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'marketing-survey-submit' },
 		mutationFn: submitMarketingSurvey,
 	} );
 
 export const cancelPurchaseSurveyCompletedMutation = ( purchaseId: string | number ) => {
 	const preferenceName = `cancel-purchase-survey-completed-${ purchaseId }`;
 	return mutationOptions( {
+		meta: { statId: 'purch-cancel-survey-complete' },
 		mutationFn: () =>
 			updatePreferences( {
 				[ preferenceName ]: 'true',

--- a/packages/api-queries/src/me-account-recovery.ts
+++ b/packages/api-queries/src/me-account-recovery.ts
@@ -19,6 +19,7 @@ export const accountRecoveryQuery = () =>
 
 export const updateAccountRecoveryEmailMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'recovery-email-update' },
 		mutationFn: updateAccountRecoveryEmail,
 		onSuccess: ( _, email ) => {
 			queryClient.setQueryData(
@@ -30,6 +31,7 @@ export const updateAccountRecoveryEmailMutation = () =>
 
 export const removeAccountRecoveryEmailMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'recovery-email-remove' },
 		mutationFn: removeAccountRecoveryEmail,
 		onSuccess: () => {
 			queryClient.setQueryData(
@@ -41,6 +43,7 @@ export const removeAccountRecoveryEmailMutation = () =>
 
 export const resendAccountRecoveryEmailValidationMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'recovery-email-resend' },
 		mutationFn: resendAccountRecoveryEmailValidation,
 	} );
 
@@ -52,6 +55,7 @@ type UpdateAccountRecoverySMSMutationParams = {
 
 export const updateAccountRecoverySMSMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'recovery-sms-update' },
 		mutationFn: ( { countryCode, phoneNumber }: UpdateAccountRecoverySMSMutationParams ) =>
 			updateAccountRecoverySMS( countryCode, phoneNumber ),
 		onSuccess: ( _, sms ) => {
@@ -74,6 +78,7 @@ export const updateAccountRecoverySMSMutation = () =>
 
 export const removeAccountRecoverySMSMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'recovery-sms-remove' },
 		mutationFn: removeAccountRecoverySMS,
 		onSuccess: () => {
 			queryClient.setQueryData(
@@ -85,11 +90,13 @@ export const removeAccountRecoverySMSMutation = () =>
 
 export const resendAccountRecoverySMSValidationMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'recovery-sms-resend' },
 		mutationFn: resendAccountRecoverySMSValidation,
 	} );
 
 export const validateAccountRecoverySMSCodeMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'recovery-sms-code-validate' },
 		mutationFn: validateAccountRecoverySMSCode,
 		onSuccess: () => {
 			queryClient.setQueryData(

--- a/packages/api-queries/src/me-account.ts
+++ b/packages/api-queries/src/me-account.ts
@@ -4,6 +4,7 @@ import { queryClient } from './query-client';
 
 export const closeAccountMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'account-close' },
 		mutationFn: closeAccount,
 		onSuccess: () => {
 			// Clear all cached data when account is closed
@@ -13,6 +14,7 @@ export const closeAccountMutation = () =>
 
 export const restoreAccountMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'account-restore' },
 		mutationFn: ( token: string ) => restoreAccount( token ),
 		onSuccess: () => {
 			// Invalidate all queries to refresh data after account restoration

--- a/packages/api-queries/src/me-achieve.ts
+++ b/packages/api-queries/src/me-achieve.ts
@@ -4,6 +4,7 @@ import type { AchievementKey, UnlockAchievementResponse } from '@automattic/api-
 
 export const unlockAchievementMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< UnlockAchievementResponse, Error, AchievementKey >( {
+		meta: { statId: 'achievement-unlock' },
 		mutationFn: unlockAchievement,
 		onSuccess: ( result ) => {
 			if ( result.granted ) {

--- a/packages/api-queries/src/me-billing-history.ts
+++ b/packages/api-queries/src/me-billing-history.ts
@@ -20,5 +20,6 @@ export const receiptQuery = ( receiptId: number, options?: { includeFailedPurcha
 
 export const sendReceiptEmailMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'receipt-email-send' },
 		mutationFn: ( receiptId: string ) => sendBillingReceiptEmail( receiptId ),
 	} );

--- a/packages/api-queries/src/me-blocked-sites.ts
+++ b/packages/api-queries/src/me-blocked-sites.ts
@@ -18,6 +18,7 @@ export const blockedSitesInfiniteQuery = ( perPage: number ) =>
 
 export const unblockSiteMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'site-unblock' },
 		mutationFn: ( siteId: number ) => unblockSite( siteId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( { queryKey: [ 'me', 'blocked-sites' ] } );

--- a/packages/api-queries/src/me-connected-applications.ts
+++ b/packages/api-queries/src/me-connected-applications.ts
@@ -10,6 +10,7 @@ export const connectedApplicationsQuery = () =>
 
 export const deleteConnectedApplicationMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'connected-app-delete' },
 		mutationFn: deleteConnectedApplication,
 		onSuccess: () => queryClient.invalidateQueries( connectedApplicationsQuery() ),
 	} );

--- a/packages/api-queries/src/me-dpa.ts
+++ b/packages/api-queries/src/me-dpa.ts
@@ -3,5 +3,6 @@ import { mutationOptions } from '@tanstack/react-query';
 
 export const requestDpaMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'dpa-request' },
 		mutationFn: requestDpa,
 	} );

--- a/packages/api-queries/src/me-legacy-contacts.ts
+++ b/packages/api-queries/src/me-legacy-contacts.ts
@@ -28,6 +28,7 @@ export const legacyContactQuery = ( legacyContactId: number ) =>
 
 export const addLegacyContactMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'legacy-contact-add' },
 		mutationFn: ( { email, notes }: { email: string; notes?: string } ) =>
 			addLegacyContact( email, notes ),
 		onSuccess: () => {
@@ -37,6 +38,7 @@ export const addLegacyContactMutation = () =>
 
 export const deleteLegacyContactMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'legacy-contact-delete' },
 		mutationFn: ( legacyContactId: number ) => deleteLegacyContact( legacyContactId ),
 		onSuccess: ( _data, legacyContactId ) => {
 			// Drop the contact from the cached list right away so the UI returns to

--- a/packages/api-queries/src/me-notifications-settings/index.ts
+++ b/packages/api-queries/src/me-notifications-settings/index.ts
@@ -21,6 +21,7 @@ export interface Variables {
 
 export const userNotificationsSettingsMutation = () =>
 	mutationOptions< UserNotificationSettings, Error, Variables >( {
+		meta: { statId: 'user-notifs-settings-update' },
 		mutationFn: ( newData: Variables ) =>
 			updateUserNotificationSettings( newData.data, newData.applyToAll ),
 		mutationKey: [ 'me', 'notifications', 'settings' ],

--- a/packages/api-queries/src/me-payment-methods.ts
+++ b/packages/api-queries/src/me-payment-methods.ts
@@ -91,6 +91,7 @@ export const allowedPaymentMethodsQuery = () =>
 
 export const saveCreditCardMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'credit-card-save' },
 		mutationFn: ( params: SaveCreditCardParams ) => saveCreditCard( params ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( {
@@ -101,6 +102,7 @@ export const saveCreditCardMutation = () =>
 
 export const updateCreditCardMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'credit-card-update' },
 		mutationFn: ( params: UpdateCreditCardParams ) => updateCreditCard( params ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( {

--- a/packages/api-queries/src/me-preferences.ts
+++ b/packages/api-queries/src/me-preferences.ts
@@ -50,6 +50,7 @@ export const userPreferenceQuery = < P extends keyof UserPreferences >( preferen
 
 export const userPreferenceMutation = < P extends keyof UserPreferences >( preferenceName: P ) =>
 	mutationOptions( {
+		meta: { statId: 'user-pref-update' },
 		mutationFn: ( data: UserPreferences[ P ] ) =>
 			updatePreferences( {
 				[ preferenceName ]: data ?? null, // null means deleting the preference
@@ -65,6 +66,7 @@ export const userPreferenceOptimisticMutation = < P extends keyof UserPreference
 	preferenceName: P
 ) =>
 	mutationOptions( {
+		meta: { statId: 'user-pref-opt-update' },
 		mutationFn: userPreferenceMutation( preferenceName ).mutationFn,
 		onMutate: async ( value ) => {
 			await queryClient.cancelQueries( { queryKey: rawUserPreferencesQuery().queryKey } );
@@ -86,6 +88,7 @@ export const userPreferenceOptimisticMutation = < P extends keyof UserPreference
 
 export const userPreferencesMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'user-prefs-update' },
 		mutationFn: ( data: Partial< UserPreferences > ) => updatePreferences( data ),
 		onSuccess: ( newData ) => {
 			queryClient.setQueryData( rawUserPreferencesQuery().queryKey, ( oldData ) =>

--- a/packages/api-queries/src/me-settings.ts
+++ b/packages/api-queries/src/me-settings.ts
@@ -10,6 +10,7 @@ export const userSettingsQuery = () =>
 
 export const userSettingsMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'user-settings-update' },
 		mutationFn: updateUserSettings,
 		onSuccess: ( newData, variables ) => {
 			queryClient.setQueryData(
@@ -29,6 +30,7 @@ export const userSettingsMutation = () =>
 
 export const cancelPendingEmailChangeMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'email-change-cancel' },
 		mutationFn: () => updateUserSettings( { user_email_change_pending: false } ),
 		onSuccess: ( newData ) => {
 			queryClient.setQueryData(
@@ -44,6 +46,7 @@ export const cancelPendingEmailChangeMutation = () =>
 
 export const resendEmailVerificationMutation = ( email: string ) =>
 	mutationOptions( {
+		meta: { statId: 'email-verify-resend' },
 		mutationFn: () => updateUserSettings( { user_email: email } ),
 		onSuccess: ( newData ) => {
 			queryClient.setQueryData(

--- a/packages/api-queries/src/me-social-logins.ts
+++ b/packages/api-queries/src/me-social-logins.ts
@@ -6,6 +6,7 @@ import type { ConnectSocialUserArgs, PostLoginRequestArgs } from '@automattic/ap
 
 export const disconnectSocialUserMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'social-user-disconnect' },
 		mutationFn: ( service: string ) =>
 			disconnectSocialUser( {
 				service,
@@ -19,6 +20,7 @@ export const disconnectSocialUserMutation = () =>
 
 export const connectSocialUserMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'social-user-connect' },
 		mutationFn: ( data: ConnectSocialUserArgs ) =>
 			connectSocialUser( {
 				...data,
@@ -32,5 +34,6 @@ export const connectSocialUserMutation = () =>
 
 export const postLoginRequestMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'login-request-post' },
 		mutationFn: ( data: PostLoginRequestArgs ) => postLoginRequest( data ),
 	} );

--- a/packages/api-queries/src/me-ssh.ts
+++ b/packages/api-queries/src/me-ssh.ts
@@ -14,6 +14,7 @@ export const sshKeysQuery = () =>
 
 export const createSshKeyMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'ssh-key-create' },
 		mutationFn: createSshKey,
 		onSuccess: () => {
 			queryClient.invalidateQueries( sshKeysQuery() );
@@ -22,6 +23,7 @@ export const createSshKeyMutation = () =>
 
 export const updateSshKeyMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'ssh-key-update' },
 		mutationFn: updateSshKey,
 		onSuccess: () => {
 			queryClient.invalidateQueries( sshKeysQuery() );
@@ -30,6 +32,7 @@ export const updateSshKeyMutation = () =>
 
 export const deleteSshKeyMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'ssh-key-delete' },
 		mutationFn: deleteSshKey,
 		onSuccess: () => {
 			queryClient.invalidateQueries( sshKeysQuery() );

--- a/packages/api-queries/src/me-stripe-setup-intent.ts
+++ b/packages/api-queries/src/me-stripe-setup-intent.ts
@@ -4,5 +4,6 @@ import type { CreateSetupIntentParams } from '@automattic/api-core';
 
 export const createStripeSetupIntentMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'stripe-intent-create' },
 		mutationFn: ( params: CreateSetupIntentParams ) => createStripeSetupIntent( params ),
 	} );

--- a/packages/api-queries/src/me-tax-contact-information.ts
+++ b/packages/api-queries/src/me-tax-contact-information.ts
@@ -4,5 +4,6 @@ import type { ValidateTaxContactInfoParams } from '@automattic/api-core';
 
 export const validateTaxContactInformationMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'tax-contact-info-validate' },
 		mutationFn: ( params: ValidateTaxContactInfoParams ) => validateTaxContactInformation( params ),
 	} );

--- a/packages/api-queries/src/me-tax-details.ts
+++ b/packages/api-queries/src/me-tax-details.ts
@@ -10,6 +10,7 @@ export const userTaxDetailsQuery = () =>
 
 export const userTaxDetailsMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'user-tax-details-update' },
 		mutationFn: updateUserTaxDetails,
 		onSuccess: ( newData ) => {
 			queryClient.setQueryData(

--- a/packages/api-queries/src/me-two-step.ts
+++ b/packages/api-queries/src/me-two-step.ts
@@ -67,6 +67,7 @@ export const twoStepAuthApplicationPasswordsQuery = () =>
 
 export const createTwoStepAuthApplicationPasswordMutation = () =>
 	mutationOptions( {
+		meta: { statId: '2fa-app-pw-create' },
 		mutationFn: createTwoStepAuthApplicationPassword,
 		onSuccess: () => {
 			queryClient.invalidateQueries( twoStepAuthApplicationPasswordsQuery() );
@@ -75,6 +76,7 @@ export const createTwoStepAuthApplicationPasswordMutation = () =>
 
 export const deleteTwoStepAuthApplicationPasswordMutation = () =>
 	mutationOptions( {
+		meta: { statId: '2fa-app-pw-delete' },
 		mutationFn: deleteTwoStepAuthApplicationPassword,
 		onSuccess: () => {
 			queryClient.invalidateQueries( twoStepAuthApplicationPasswordsQuery() );
@@ -89,6 +91,7 @@ export const twoStepAuthAppSetupQuery = () =>
 
 export const validateTwoStepAuthCodeMutation = () =>
 	mutationOptions( {
+		meta: { statId: '2fa-code-validate' },
 		mutationFn: validateTwoStepAuthCode,
 		onSuccess: ( data ) => {
 			// This is a workaround to handle the error/success response
@@ -104,11 +107,13 @@ export const validateTwoStepAuthCodeMutation = () =>
 
 export const generateTwoStepAuthBackupCodesMutation = () =>
 	mutationOptions( {
+		meta: { statId: '2fa-backup-codes-generate' },
 		mutationFn: generateTwoStepAuthBackupCodes,
 	} );
 
 export const setupTwoStepAuthSMSMutation = () =>
 	mutationOptions( {
+		meta: { statId: '2fa-sms-setup' },
 		mutationFn: async ( data: Partial< UserSettings > ) => {
 			try {
 				await updateUserSettings( data );
@@ -121,5 +126,6 @@ export const setupTwoStepAuthSMSMutation = () =>
 
 export const resendTwoStepAuthSMSCodeMutation = () =>
 	mutationOptions( {
+		meta: { statId: '2fa-sms-code-resend' },
 		mutationFn: sendTwoStepAuthSMSCode,
 	} );

--- a/packages/api-queries/src/me-username.ts
+++ b/packages/api-queries/src/me-username.ts
@@ -5,6 +5,7 @@ import { queryClient } from './query-client';
 
 export const updateUsernameMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'username-update' },
 		mutationFn: ( { username, action }: { username: string; action: string } ) =>
 			updateUsername( username, action ),
 		onSuccess: () => {

--- a/packages/api-queries/src/notification-devices/index.ts
+++ b/packages/api-queries/src/notification-devices/index.ts
@@ -29,6 +29,7 @@ export const notificationDeviceQuery = () =>
  */
 export const notificationDeviceRemovalMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'notif-device-remove' },
 		mutationFn: ( deviceId: string ) => deleteNotificationsDevice( deviceId ),
 		onMutate: () => {
 			const previousData = queryClient.getQueryData( notificationDeviceQuery().queryKey );
@@ -63,6 +64,7 @@ export const notificationPushPermissionStateQuery = () => {
  */
 export const notificationDeviceRegistrationMutation = () =>
 	mutationOptions< NotificationsDeviceResponse, Error >( {
+		meta: { statId: 'notif-device-register' },
 		mutationFn: async () => {
 			const subscription = await startBrowserSubscription();
 

--- a/packages/api-queries/src/payment-methods.ts
+++ b/packages/api-queries/src/payment-methods.ts
@@ -4,5 +4,6 @@ import type { CreatePayPalAgreementParams } from '@automattic/api-core';
 
 export const createPayPalAgreementMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'paypal-agreement-create' },
 		mutationFn: ( params: CreatePayPalAgreementParams ) => createPayPalAgreement( params ),
 	} );

--- a/packages/api-queries/src/plugin.ts
+++ b/packages/api-queries/src/plugin.ts
@@ -27,6 +27,7 @@ export const wpOrgPluginQuery = ( slug: string, locale: string ) =>
 
 export const installPluginMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'plugin-install' },
 		mutationFn: ( vars: { siteId: number; slug: string } ) =>
 			installPlugin( vars.siteId, vars.slug ),
 		onSuccess: ( _data, vars ) => {

--- a/packages/api-queries/src/post-likes.ts
+++ b/packages/api-queries/src/post-likes.ts
@@ -139,6 +139,7 @@ export const likePostMutation = ( queryClient: QueryClient ) =>
 		PostLikeMutationParams,
 		PostLikeMutationContext
 	>( {
+		meta: { statId: 'post-like' },
 		mutationFn: likePost,
 		onMutate: ( variables ) => snapshotAndUpdate( queryClient, variables, true ),
 		onSuccess: ( data, { siteId, postId } ) => {
@@ -164,6 +165,7 @@ export const unlikePostMutation = ( queryClient: QueryClient ) =>
 		PostLikeMutationParams,
 		PostLikeMutationContext
 	>( {
+		meta: { statId: 'post-unlike' },
 		mutationFn: unlikePost,
 		onMutate: ( variables ) => snapshotAndUpdate( queryClient, variables, false ),
 		onSuccess: ( data, { siteId, postId } ) => {

--- a/packages/api-queries/src/read-follows.ts
+++ b/packages/api-queries/src/read-follows.ts
@@ -401,6 +401,7 @@ export const markSiteSubscriptionUnfollowed = ( queryClient: QueryClient, feedUr
 
 export const followSiteMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< SiteSubscriptionItem, Error, FollowSiteParams >( {
+		meta: { statId: 'site-follow' },
 		mutationFn: ( params ) => followSite( params ),
 		onSuccess: ( subscription, params ) => {
 			patchSiteSubscription( queryClient, {
@@ -413,6 +414,7 @@ export const followSiteMutation = ( queryClient: QueryClient ) =>
 
 export const unfollowSiteMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< unknown, Error, UnfollowSiteParams >( {
+		meta: { statId: 'site-unfollow' },
 		mutationFn: ( params ) => unfollowSite( params ),
 		onSuccess: async ( _response, params ) => {
 			if ( params.feedUrl ) {
@@ -568,6 +570,7 @@ const rollbackOptimisticDeliveryPatch = (
 export const updateSitePostEmailSubscriptionMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< unknown, Error, FollowDeliveryParams, SiteSubscriptionDeliveryMutationContext >(
 		{
+			meta: { statId: 'site-post-email-sub-update' },
 			mutationFn: ( params ) => updateSitePostEmailSubscription( params ),
 			onMutate: ( params ) => withOptimisticDeliveryPatch( queryClient, params, 'post-email' ),
 			onError: ( _error, _params, context ) =>
@@ -579,6 +582,7 @@ export const updateSitePostEmailSubscriptionMutation = ( queryClient: QueryClien
 export const updateSiteCommentEmailSubscriptionMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< unknown, Error, FollowDeliveryParams, SiteSubscriptionDeliveryMutationContext >(
 		{
+			meta: { statId: 'site-cmt-email-sub-update' },
 			mutationFn: ( params ) => updateSiteCommentEmailSubscription( params ),
 			onMutate: ( params ) => withOptimisticDeliveryPatch( queryClient, params, 'comment-email' ),
 			onError: ( _error, _params, context ) =>
@@ -590,6 +594,7 @@ export const updateSiteCommentEmailSubscriptionMutation = ( queryClient: QueryCl
 export const updateSitePostEmailDeliveryFrequencyMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< unknown, Error, FollowDeliveryParams, SiteSubscriptionDeliveryMutationContext >(
 		{
+			meta: { statId: 'site-post-email-freq-update' },
 			mutationFn: ( params ) => updateSitePostEmailDeliveryFrequency( params ),
 			onMutate: ( params ) => withOptimisticDeliveryPatch( queryClient, params, 'email-frequency' ),
 			onError: ( _error, _params, context ) =>
@@ -601,6 +606,7 @@ export const updateSitePostEmailDeliveryFrequencyMutation = ( queryClient: Query
 export const updateSitePostNotificationSubscriptionMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< unknown, Error, FollowDeliveryParams, SiteSubscriptionDeliveryMutationContext >(
 		{
+			meta: { statId: 'site-post-notif-sub-update' },
 			mutationFn: ( params ) => updateSitePostNotificationSubscription( params ),
 			onMutate: ( params ) => withOptimisticDeliveryPatch( queryClient, params, 'notification' ),
 			onError: ( _error, _params, context ) =>

--- a/packages/api-queries/src/read-follows.ts
+++ b/packages/api-queries/src/read-follows.ts
@@ -401,7 +401,7 @@ export const markSiteSubscriptionUnfollowed = ( queryClient: QueryClient, feedUr
 
 export const followSiteMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< SiteSubscriptionItem, Error, FollowSiteParams >( {
-		meta: { statId: 'site-follow' },
+		meta: { statId: 'read-site-follow' },
 		mutationFn: ( params ) => followSite( params ),
 		onSuccess: ( subscription, params ) => {
 			patchSiteSubscription( queryClient, {
@@ -414,7 +414,7 @@ export const followSiteMutation = ( queryClient: QueryClient ) =>
 
 export const unfollowSiteMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< unknown, Error, UnfollowSiteParams >( {
-		meta: { statId: 'site-unfollow' },
+		meta: { statId: 'read-site-unfollow' },
 		mutationFn: ( params ) => unfollowSite( params ),
 		onSuccess: async ( _response, params ) => {
 			if ( params.feedUrl ) {
@@ -570,7 +570,7 @@ const rollbackOptimisticDeliveryPatch = (
 export const updateSitePostEmailSubscriptionMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< unknown, Error, FollowDeliveryParams, SiteSubscriptionDeliveryMutationContext >(
 		{
-			meta: { statId: 'site-post-email-sub-update' },
+			meta: { statId: 'read-post-email-sub-update' },
 			mutationFn: ( params ) => updateSitePostEmailSubscription( params ),
 			onMutate: ( params ) => withOptimisticDeliveryPatch( queryClient, params, 'post-email' ),
 			onError: ( _error, _params, context ) =>
@@ -582,7 +582,7 @@ export const updateSitePostEmailSubscriptionMutation = ( queryClient: QueryClien
 export const updateSiteCommentEmailSubscriptionMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< unknown, Error, FollowDeliveryParams, SiteSubscriptionDeliveryMutationContext >(
 		{
-			meta: { statId: 'site-cmt-email-sub-update' },
+			meta: { statId: 'read-cmt-email-sub-update' },
 			mutationFn: ( params ) => updateSiteCommentEmailSubscription( params ),
 			onMutate: ( params ) => withOptimisticDeliveryPatch( queryClient, params, 'comment-email' ),
 			onError: ( _error, _params, context ) =>
@@ -594,7 +594,7 @@ export const updateSiteCommentEmailSubscriptionMutation = ( queryClient: QueryCl
 export const updateSitePostEmailDeliveryFrequencyMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< unknown, Error, FollowDeliveryParams, SiteSubscriptionDeliveryMutationContext >(
 		{
-			meta: { statId: 'site-post-email-freq-update' },
+			meta: { statId: 'read-post-email-freq-update' },
 			mutationFn: ( params ) => updateSitePostEmailDeliveryFrequency( params ),
 			onMutate: ( params ) => withOptimisticDeliveryPatch( queryClient, params, 'email-frequency' ),
 			onError: ( _error, _params, context ) =>
@@ -606,7 +606,7 @@ export const updateSitePostEmailDeliveryFrequencyMutation = ( queryClient: Query
 export const updateSitePostNotificationSubscriptionMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< unknown, Error, FollowDeliveryParams, SiteSubscriptionDeliveryMutationContext >(
 		{
-			meta: { statId: 'site-post-notif-sub-update' },
+			meta: { statId: 'read-post-notif-sub-update' },
 			mutationFn: ( params ) => updateSitePostNotificationSubscription( params ),
 			onMutate: ( params ) => withOptimisticDeliveryPatch( queryClient, params, 'notification' ),
 			onError: ( _error, _params, context ) =>

--- a/packages/api-queries/src/read-list-items.ts
+++ b/packages/api-queries/src/read-list-items.ts
@@ -129,6 +129,7 @@ export interface AddReadListFeedVariables {
 
 export const addReadListFeedMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< unknown, Error, AddReadListFeedVariables, ListItemMutationContext >( {
+		meta: { statId: 'read-list-feed-add' },
 		mutationFn: ( variables ) => addReadListFeed( variables ),
 		onMutate: ( { owner, slug, feedId } ) =>
 			snapshotAndOptimisticallyUpdate( queryClient, owner, slug, ( items ) => {
@@ -152,6 +153,7 @@ export interface DeleteReadListFeedVariables {
 
 export const deleteReadListFeedMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< unknown, Error, DeleteReadListFeedVariables, ListItemMutationContext >( {
+		meta: { statId: 'read-list-feed-delete' },
 		mutationFn: ( variables ) => deleteReadListFeed( variables ),
 		onMutate: ( { owner, slug, feedId } ) =>
 			snapshotAndOptimisticallyUpdate( queryClient, owner, slug, ( items ) =>
@@ -169,6 +171,7 @@ export interface DeleteReadListSiteVariables {
 
 export const deleteReadListSiteMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< unknown, Error, DeleteReadListSiteVariables, ListItemMutationContext >( {
+		meta: { statId: 'read-list-site-delete' },
 		mutationFn: ( variables ) => deleteReadListSite( variables ),
 		onMutate: ( { owner, slug, siteId } ) =>
 			snapshotAndOptimisticallyUpdate( queryClient, owner, slug, ( items ) =>
@@ -190,6 +193,7 @@ export interface AddReadListTagVariables {
 
 export const addReadListTagMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< unknown, Error, AddReadListTagVariables, ListItemMutationContext >( {
+		meta: { statId: 'read-list-tag-add' },
 		mutationFn: ( variables ) => addReadListTag( variables ),
 		onMutate: ( { owner, slug, tagId, tagSlug } ) =>
 			snapshotAndOptimisticallyUpdate( queryClient, owner, slug, ( items ) => {
@@ -220,6 +224,7 @@ export interface DeleteReadListTagVariables {
 
 export const deleteReadListTagMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< unknown, Error, DeleteReadListTagVariables, ListItemMutationContext >( {
+		meta: { statId: 'read-list-tag-delete' },
 		mutationFn: ( variables ) => deleteReadListTag( variables ),
 		onMutate: ( { owner, slug, tagId } ) =>
 			snapshotAndOptimisticallyUpdate( queryClient, owner, slug, ( items ) =>

--- a/packages/api-queries/src/read-lists.ts
+++ b/packages/api-queries/src/read-lists.ts
@@ -45,12 +45,14 @@ function invalidateSubscribedLists( queryClient: QueryClient ): Promise< void > 
 
 export const createReadListMutation = ( queryClient: QueryClient ) =>
 	mutationOptions( {
+		meta: { statId: 'read-list-create' },
 		mutationFn: createReadList,
 		onSuccess: () => invalidateSubscribedLists( queryClient ),
 	} );
 
 export const updateReadListMutation = ( queryClient: QueryClient ) =>
 	mutationOptions( {
+		meta: { statId: 'read-list-update' },
 		mutationFn: updateReadList,
 		onSuccess: ( data ) => {
 			queryClient.setQueryData( readListQuery( data.list.owner, data.list.slug ).queryKey, data );
@@ -60,6 +62,7 @@ export const updateReadListMutation = ( queryClient: QueryClient ) =>
 
 export const followReadListMutation = ( queryClient: QueryClient ) =>
 	mutationOptions( {
+		meta: { statId: 'read-list-follow' },
 		mutationFn: ( { owner, slug }: { owner: string; slug: string } ) =>
 			followReadList( owner, slug ),
 		onSuccess: () => invalidateSubscribedLists( queryClient ),
@@ -67,6 +70,7 @@ export const followReadListMutation = ( queryClient: QueryClient ) =>
 
 export const unfollowReadListMutation = ( queryClient: QueryClient ) =>
 	mutationOptions( {
+		meta: { statId: 'read-list-unfollow' },
 		mutationFn: ( { owner, slug }: { owner: string; slug: string } ) =>
 			unfollowReadList( owner, slug ),
 		onSuccess: () => invalidateSubscribedLists( queryClient ),
@@ -74,6 +78,7 @@ export const unfollowReadListMutation = ( queryClient: QueryClient ) =>
 
 export const deleteReadListMutation = ( queryClient: QueryClient ) =>
 	mutationOptions( {
+		meta: { statId: 'read-list-delete' },
 		mutationFn: ( { owner, slug }: { owner: string; slug: string } ) =>
 			deleteReadList( owner, slug ),
 		onSuccess: ( _data, { owner, slug } ) => {

--- a/packages/api-queries/src/read-seen-posts.ts
+++ b/packages/api-queries/src/read-seen-posts.ts
@@ -14,6 +14,7 @@ import { patchSubscriptionSeenCount } from './read-follows';
 
 export const markReaderPostsAsSeenMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< ReadSeenPostsResponse, Error, ReadSeenPostsFeedParams >( {
+		meta: { statId: 'read-posts-seen-mark' },
 		mutationFn: markReaderPostsAsSeen,
 		onSuccess: ( _response, params ) => {
 			patchSubscriptionSeenCount(
@@ -26,6 +27,7 @@ export const markReaderPostsAsSeenMutation = ( queryClient: QueryClient ) =>
 
 export const markReaderPostsAsUnseenMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< ReadSeenPostsResponse, Error, ReadSeenPostsFeedParams >( {
+		meta: { statId: 'read-posts-unseen-mark' },
 		mutationFn: markReaderPostsAsUnseen,
 		onSuccess: ( _response, params ) => {
 			patchSubscriptionSeenCount(
@@ -38,6 +40,7 @@ export const markReaderPostsAsUnseenMutation = ( queryClient: QueryClient ) =>
 
 export const markReaderWpcomPostsAsSeenMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< ReadSeenPostsResponse, Error, ReadSeenPostsBlogParams >( {
+		meta: { statId: 'read-wpcom-seen-mark' },
 		mutationFn: markReaderWpcomPostsAsSeen,
 		onSuccess: ( _response, params ) => {
 			patchSubscriptionSeenCount(
@@ -50,6 +53,7 @@ export const markReaderWpcomPostsAsSeenMutation = ( queryClient: QueryClient ) =
 
 export const markReaderWpcomPostsAsUnseenMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< ReadSeenPostsResponse, Error, ReadSeenPostsBlogParams >( {
+		meta: { statId: 'read-wpcom-unseen-mark' },
 		mutationFn: markReaderWpcomPostsAsUnseen,
 		onSuccess: ( _response, params ) => {
 			patchSubscriptionSeenCount(
@@ -62,6 +66,7 @@ export const markReaderWpcomPostsAsUnseenMutation = ( queryClient: QueryClient )
 
 export const markAllReaderPostsAsSeenMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< ReadSeenPostsResponse, Error, ReadSeenPostsAllParams >( {
+		meta: { statId: 'read-posts-all-seen-mark' },
 		mutationFn: markAllReaderPostsAsSeen,
 		onSuccess: ( _response, params ) => {
 			patchSubscriptionSeenCount( queryClient, { feedIds: params.feedIds }, () => 0 );

--- a/packages/api-queries/src/read-site-recommendations.ts
+++ b/packages/api-queries/src/read-site-recommendations.ts
@@ -97,5 +97,6 @@ export const dismissReadSiteRecommendationMutation = () =>
 		Error,
 		DismissReadSiteRecommendationParams
 	>( {
+		meta: { statId: 'read-site-rec-dismiss' },
 		mutationFn: dismissReadSiteRecommendation,
 	} );

--- a/packages/api-queries/src/read-spaces.ts
+++ b/packages/api-queries/src/read-spaces.ts
@@ -153,6 +153,7 @@ const setReadSpaceDetailCaches = ( queryClient: QueryClient, space: ReadSpaceDet
 
 export const createReadSpaceMutation = ( queryClient: QueryClient ) =>
 	mutationOptions( {
+		meta: { statId: 'read-space-create' },
 		mutationFn: createReadSpace,
 		onSuccess: ( space ) => {
 			// Append the summary to the list and seed the detail cache so the sidebar
@@ -180,6 +181,7 @@ export const updateReadSpaceMutation = ( queryClient: QueryClient ) =>
 		UpdateReadSpaceVariables,
 		{ previousList: ReadSpace[] | undefined; previousSlug: string | undefined }
 	>( {
+		meta: { statId: 'read-space-update' },
 		mutationFn: ( { spaceId, params } ) => updateReadSpace( spaceId, params ),
 		// Optimistically patch the cached list summary so the sidebar — which reads
 		// `useSpaces()` (this list) and renders each item's icon and colour from
@@ -252,6 +254,7 @@ export const updateReadSpaceMutation = ( queryClient: QueryClient ) =>
 // hard-deletes (no undo), so the caller should confirm before mutating.
 export const deleteReadSpaceMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< ReadSpaceDeletionResult, unknown, string >( {
+		meta: { statId: 'read-space-delete' },
 		mutationFn: deleteReadSpace,
 		onSuccess: ( _result, spaceId ) => {
 			// Resolve the deleted space's slug (from the list, falling back to the
@@ -288,12 +291,14 @@ const writeReadSpaceDetail = ( queryClient: QueryClient, space: ReadSpaceDetails
 
 export const addReadSpaceSourceMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< ReadSpaceDetails, unknown, ReadSpaceSourceMutationParams >( {
+		meta: { statId: 'read-space-source-add' },
 		mutationFn: addReadSpaceSource,
 		onSuccess: ( space ) => writeReadSpaceDetail( queryClient, space ),
 	} );
 
 export const deleteReadSpaceSourceMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< ReadSpaceDetails, unknown, ReadSpaceSourceMutationParams >( {
+		meta: { statId: 'read-space-source-delete' },
 		mutationFn: deleteReadSpaceSource,
 		onSuccess: ( space ) => writeReadSpaceDetail( queryClient, space ),
 	} );

--- a/packages/api-queries/src/read-tags.ts
+++ b/packages/api-queries/src/read-tags.ts
@@ -80,6 +80,7 @@ function slugify( tag: string ): string {
 
 export const followReadTagMutation = ( queryClient: QueryClient ) =>
 	mutationOptions( {
+		meta: { statId: 'read-tag-follow' },
 		mutationFn: async ( tag: string ) => {
 			const slug = slugify( tag );
 			try {
@@ -98,6 +99,7 @@ export const followReadTagMutation = ( queryClient: QueryClient ) =>
 
 export const unfollowReadTagMutation = ( queryClient: QueryClient ) =>
 	mutationOptions( {
+		meta: { statId: 'read-tag-unfollow' },
 		mutationFn: ( tag: string ) => unfollowReadTag( slugify( tag ) ),
 		onSuccess: () => invalidateFollowedTags( queryClient ),
 	} );

--- a/packages/api-queries/src/reader-atmosphere.ts
+++ b/packages/api-queries/src/reader-atmosphere.ts
@@ -115,7 +115,7 @@ export function useCreateConnectionMutation() {
 	const client = useQueryClient();
 	return useMutation< AtmosphereCreateConnectionResponse, AtmosphereError, CreateConnectionParams >(
 		{
-			meta: { statId: 'conn-create' },
+			meta: { statId: 'atmo-conn-create' },
 			mutationFn: createConnection,
 			onSuccess: () => {
 				client.invalidateQueries( { queryKey: readerAtmosphereKeys.connections() } );
@@ -1057,7 +1057,7 @@ export function useCreateLikeMutation( connectionId: number ) {
 		{ postUri: string; postCid: string },
 		OptimisticContext
 	>( {
-		meta: { statId: 'like-create' },
+		meta: { statId: 'atmo-like-create' },
 		mutationFn: ( { postUri, postCid } ) => createLike( { connectionId, postUri, postCid } ),
 		onMutate: async ( { postUri } ) => {
 			await queryClient.cancelQueries( {
@@ -1089,7 +1089,7 @@ export function useDeleteLikeMutation( connectionId: number ) {
 	const queryClient = useQueryClient();
 	return useMutation< void, AtmosphereError, { rkey: string; postUri: string }, OptimisticContext >(
 		{
-			meta: { statId: 'like-delete' },
+			meta: { statId: 'atmo-like-delete' },
 			mutationFn: ( { rkey } ) => deleteLike( { connectionId, rkey } ),
 			onMutate: async ( { postUri } ) => {
 				await queryClient.cancelQueries( {
@@ -1117,7 +1117,7 @@ export function useCreateRepostMutation( connectionId: number ) {
 		{ postUri: string; postCid: string },
 		OptimisticContext
 	>( {
-		meta: { statId: 'repost-create' },
+		meta: { statId: 'atmo-repost-create' },
 		mutationFn: ( { postUri, postCid } ) => createRepost( { connectionId, postUri, postCid } ),
 		onMutate: async ( { postUri } ) => {
 			await queryClient.cancelQueries( {
@@ -1149,7 +1149,7 @@ export function useDeleteRepostMutation( connectionId: number ) {
 	const queryClient = useQueryClient();
 	return useMutation< void, AtmosphereError, { rkey: string; postUri: string }, OptimisticContext >(
 		{
-			meta: { statId: 'repost-delete' },
+			meta: { statId: 'atmo-repost-delete' },
 			mutationFn: ( { rkey } ) => deleteRepost( { connectionId, rkey } ),
 			onMutate: async ( { postUri } ) => {
 				await queryClient.cancelQueries( {
@@ -1306,7 +1306,7 @@ export function useDeletePostMutation(
 ) {
 	const queryClient = useQueryClient();
 	return useMutation< void, AtmosphereError, DeletePostMutationVars, RemovalContext >( {
-		meta: { statId: 'post-delete' },
+		meta: { statId: 'atmo-post-delete' },
 		mutationFn: ( { rkey } ) => deletePost( { connectionId, rkey } ),
 		onMutate: async ( { postUri, replyParentUri } ) => {
 			await queryClient.cancelQueries( { queryKey: readerAtmosphereKeys.all } );
@@ -1733,7 +1733,7 @@ export function removePlaceholder< P extends { items: AtmosphereFeedItem[] } >(
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const uploadBlobMutation = ( _queryClient: QueryClient ) =>
 	mutationOptions< UploadBlobResult, AtmosphereError, UploadBlobParams >( {
-		meta: { statId: 'blob-upload' },
+		meta: { statId: 'atmo-blob-upload' },
 		mutationFn: uploadBlob,
 	} );
 
@@ -1763,7 +1763,7 @@ export const uploadBlobMutation = ( _queryClient: QueryClient ) =>
  */
 export const createPostMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< CreatePostResult, AtmosphereError, CreatePostParams, CreatePostContext >( {
-		meta: { statId: 'post-create' },
+		meta: { statId: 'atmo-post-create' },
 		mutationFn: createPost,
 		onMutate: async ( vars ) => {
 			await queryClient.cancelQueries( { queryKey: readerAtmosphereKeys.all } );

--- a/packages/api-queries/src/reader-atmosphere.ts
+++ b/packages/api-queries/src/reader-atmosphere.ts
@@ -115,6 +115,7 @@ export function useCreateConnectionMutation() {
 	const client = useQueryClient();
 	return useMutation< AtmosphereCreateConnectionResponse, AtmosphereError, CreateConnectionParams >(
 		{
+			meta: { statId: 'conn-create' },
 			mutationFn: createConnection,
 			onSuccess: () => {
 				client.invalidateQueries( { queryKey: readerAtmosphereKeys.connections() } );
@@ -649,6 +650,7 @@ export const followAtmosphereActorMutation = ( queryClient: QueryClient ) =>
 		FollowAtmosphereActorVars,
 		FollowAtmosphereMutationContext
 	>( {
+		meta: { statId: 'atmo-actor-follow' },
 		mutationFn: ( vars ) =>
 			createFollow( { connectionId: vars.connectionId, subject_did: vars.subjectDid } ),
 		onMutate: async ( vars ) => {
@@ -732,6 +734,7 @@ export const unfollowAtmosphereActorMutation = ( queryClient: QueryClient ) =>
 		UnfollowAtmosphereActorVars,
 		FollowAtmosphereMutationContext
 	>( {
+		meta: { statId: 'atmo-actor-unfollow' },
 		mutationFn: ( vars ) => deleteFollow( { connectionId: vars.connectionId, rkey: vars.rkey } ),
 		onMutate: async ( vars ) => {
 			const key = scopedProfileKey( vars );
@@ -1054,6 +1057,7 @@ export function useCreateLikeMutation( connectionId: number ) {
 		{ postUri: string; postCid: string },
 		OptimisticContext
 	>( {
+		meta: { statId: 'like-create' },
 		mutationFn: ( { postUri, postCid } ) => createLike( { connectionId, postUri, postCid } ),
 		onMutate: async ( { postUri } ) => {
 			await queryClient.cancelQueries( {
@@ -1085,6 +1089,7 @@ export function useDeleteLikeMutation( connectionId: number ) {
 	const queryClient = useQueryClient();
 	return useMutation< void, AtmosphereError, { rkey: string; postUri: string }, OptimisticContext >(
 		{
+			meta: { statId: 'like-delete' },
 			mutationFn: ( { rkey } ) => deleteLike( { connectionId, rkey } ),
 			onMutate: async ( { postUri } ) => {
 				await queryClient.cancelQueries( {
@@ -1112,6 +1117,7 @@ export function useCreateRepostMutation( connectionId: number ) {
 		{ postUri: string; postCid: string },
 		OptimisticContext
 	>( {
+		meta: { statId: 'repost-create' },
 		mutationFn: ( { postUri, postCid } ) => createRepost( { connectionId, postUri, postCid } ),
 		onMutate: async ( { postUri } ) => {
 			await queryClient.cancelQueries( {
@@ -1143,6 +1149,7 @@ export function useDeleteRepostMutation( connectionId: number ) {
 	const queryClient = useQueryClient();
 	return useMutation< void, AtmosphereError, { rkey: string; postUri: string }, OptimisticContext >(
 		{
+			meta: { statId: 'repost-delete' },
 			mutationFn: ( { rkey } ) => deleteRepost( { connectionId, rkey } ),
 			onMutate: async ( { postUri } ) => {
 				await queryClient.cancelQueries( {
@@ -1299,6 +1306,7 @@ export function useDeletePostMutation(
 ) {
 	const queryClient = useQueryClient();
 	return useMutation< void, AtmosphereError, DeletePostMutationVars, RemovalContext >( {
+		meta: { statId: 'post-delete' },
 		mutationFn: ( { rkey } ) => deletePost( { connectionId, rkey } ),
 		onMutate: async ( { postUri, replyParentUri } ) => {
 			await queryClient.cancelQueries( { queryKey: readerAtmosphereKeys.all } );
@@ -1725,6 +1733,7 @@ export function removePlaceholder< P extends { items: AtmosphereFeedItem[] } >(
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const uploadBlobMutation = ( _queryClient: QueryClient ) =>
 	mutationOptions< UploadBlobResult, AtmosphereError, UploadBlobParams >( {
+		meta: { statId: 'blob-upload' },
 		mutationFn: uploadBlob,
 	} );
 
@@ -1754,6 +1763,7 @@ export const uploadBlobMutation = ( _queryClient: QueryClient ) =>
  */
 export const createPostMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< CreatePostResult, AtmosphereError, CreatePostParams, CreatePostContext >( {
+		meta: { statId: 'post-create' },
 		mutationFn: createPost,
 		onMutate: async ( vars ) => {
 			await queryClient.cancelQueries( { queryKey: readerAtmosphereKeys.all } );

--- a/packages/api-queries/src/reader-fediverse.ts
+++ b/packages/api-queries/src/reader-fediverse.ts
@@ -402,6 +402,7 @@ export const followFediverseActorMutation = ( queryClient: QueryClient ) =>
 		FollowFediverseActorVars,
 		FollowFediverseMutationContext
 	>( {
+		meta: { statId: 'fediverse-actor-follow' },
 		mutationFn: ( vars ) =>
 			createFediverseFollow( { connectionId: vars.connectionId, actor: vars.actor } ),
 		onMutate: async ( vars ) => {
@@ -481,6 +482,7 @@ export const unfollowFediverseActorMutation = ( queryClient: QueryClient ) =>
 		FollowFediverseActorVars,
 		FollowFediverseMutationContext
 	>( {
+		meta: { statId: 'fediverse-actor-unfollow' },
 		mutationFn: ( vars ) =>
 			deleteFediverseFollow( { connectionId: vars.connectionId, actor: vars.actor } ),
 		onMutate: async ( vars ) => {
@@ -568,6 +570,7 @@ export const createFediversePostMutation = ( queryClient: QueryClient ) =>
 		FediverseCreatePostParams,
 		CreateFediversePostContext
 	>( {
+		meta: { statId: 'fediverse-post-create' },
 		mutationFn: createFediversePost,
 		onMutate: async ( vars ) => {
 			const timelineKey = readerFediverseKeys.timeline( vars.connectionId );

--- a/packages/api-queries/src/reader-mastodon.ts
+++ b/packages/api-queries/src/reader-mastodon.ts
@@ -82,6 +82,7 @@ export function useMastodonConnectionsQuery( { enabled }: { enabled?: boolean } 
 export function useAuthorizeMastodonConnectionMutation() {
 	return useMutation< MastodonAuthorizeResponse, MastodonError, AuthorizeMastodonConnectionParams >(
 		{
+			meta: { statId: 'mastodon-conn-authorize' },
 			mutationFn: authorizeMastodonConnection,
 		}
 	);
@@ -94,6 +95,7 @@ export function useCompleteMastodonConnectionMutation() {
 		MastodonError,
 		CompleteMastodonConnectionParams
 	>( {
+		meta: { statId: 'mastodon-conn-complete' },
 		mutationFn: completeMastodonConnection,
 		onSuccess: ( { connection } ) => {
 			// Seed the list cache synchronously so the route we `page.replace`
@@ -833,6 +835,7 @@ function restoreMastodonPostSnapshots(
 export function useCreateMastodonLikeMutation( connectionId: number ) {
 	const queryClient = useQueryClient();
 	return useMutation< void, MastodonError, { statusId: string }, OptimisticContext >( {
+		meta: { statId: 'mastodon-like-create' },
 		mutationFn: ( { statusId } ) => createMastodonLike( { connectionId, statusId } ),
 		onMutate: async ( { statusId } ) => {
 			// cancelQueries is best-effort — TanStack docs flag it as such.
@@ -862,6 +865,7 @@ export function useCreateMastodonLikeMutation( connectionId: number ) {
 export function useDeleteMastodonLikeMutation( connectionId: number ) {
 	const queryClient = useQueryClient();
 	return useMutation< void, MastodonError, { statusId: string }, OptimisticContext >( {
+		meta: { statId: 'mastodon-like-delete' },
 		mutationFn: ( { statusId } ) => deleteMastodonLike( { connectionId, statusId } ),
 		onMutate: async ( { statusId } ) => {
 			try {
@@ -888,6 +892,7 @@ export function useDeleteMastodonLikeMutation( connectionId: number ) {
 export function useCreateMastodonRepostMutation( connectionId: number ) {
 	const queryClient = useQueryClient();
 	return useMutation< void, MastodonError, { statusId: string }, OptimisticContext >( {
+		meta: { statId: 'mastodon-repost-create' },
 		mutationFn: ( { statusId } ) => createMastodonRepost( { connectionId, statusId } ),
 		onMutate: async ( { statusId } ) => {
 			try {
@@ -912,6 +917,7 @@ export function useCreateMastodonRepostMutation( connectionId: number ) {
 export function useDeleteMastodonRepostMutation( connectionId: number ) {
 	const queryClient = useQueryClient();
 	return useMutation< void, MastodonError, { statusId: string }, OptimisticContext >( {
+		meta: { statId: 'mastodon-repost-delete' },
 		mutationFn: ( { statusId } ) => deleteMastodonRepost( { connectionId, statusId } ),
 		onMutate: async ( { statusId } ) => {
 			try {
@@ -1073,6 +1079,7 @@ export const createMastodonPostMutation = (
 		MastodonCreatePostMutationParams,
 		CreatePostContext
 	>( {
+		meta: { statId: 'mastodon-post-create' },
 		mutationFn: ( vars ) => createMastodonPostWithQuoteFallback( vars, hooks ),
 		onMutate: async ( vars ) => {
 			// cancelQueries is best-effort — TanStack docs flag it as such.
@@ -1142,6 +1149,7 @@ export const createMastodonPostMutation = (
  */
 export const uploadMastodonMediaMutation = () =>
 	mutationOptions< MastodonMediaUploadResult, MastodonError, MastodonMediaUploadParams >( {
+		meta: { statId: 'mastodon-media-upload' },
 		mutationFn: uploadMastodonMedia,
 	} );
 
@@ -1197,6 +1205,7 @@ export const followMastodonActorMutation = ( queryClient: QueryClient ) =>
 		FollowMastodonActorVars,
 		FollowMastodonMutationContext
 	>( {
+		meta: { statId: 'mastodon-actor-follow' },
 		mutationFn: ( vars ) =>
 			createMastodonFollow( { connectionId: vars.connectionId, accountId: vars.accountId } ),
 		onMutate: async ( vars ) => {
@@ -1275,6 +1284,7 @@ export const unfollowMastodonActorMutation = ( queryClient: QueryClient ) =>
 		FollowMastodonActorVars,
 		FollowMastodonMutationContext
 	>( {
+		meta: { statId: 'mastodon-actor-unfollow' },
 		mutationFn: ( vars ) =>
 			deleteMastodonFollow( { connectionId: vars.connectionId, accountId: vars.accountId } ),
 		onMutate: async ( vars ) => {

--- a/packages/api-queries/src/site-address-change.ts
+++ b/packages/api-queries/src/site-address-change.ts
@@ -10,11 +10,13 @@ import { siteQueryFilter } from './site';
 
 export const validateSiteAddressChangeMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'site-address-validate' },
 		mutationFn: ( data: ValidateSiteAddressData ) => validateSiteAddress( data ),
 	} );
 
 export const changeSiteAddressChangeMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'site-address-change' },
 		mutationFn: ( data: ChangeSiteAddressData ) => changeSiteAddress( data ),
 		onSuccess: ( data, { siteId } ) => {
 			queryClient.invalidateQueries( siteQueryFilter( siteId ) );

--- a/packages/api-queries/src/site-apm.ts
+++ b/packages/api-queries/src/site-apm.ts
@@ -18,6 +18,7 @@ function snapToMinute( sec: number ): number {
 
 export const siteApmEnabledMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-apm-toggle' },
 		mutationFn: ( active: boolean ) => updateApmEnabled( siteId, active ),
 		onSuccess: ( _data, active ) => {
 			queryClient.setQueriesData< Site >( siteQueryFilter( siteId ), ( site ) =>

--- a/packages/api-queries/src/site-backup-download.ts
+++ b/packages/api-queries/src/site-backup-download.ts
@@ -29,6 +29,7 @@ export const siteBackupDownloadProgressQuery = ( siteId: number, downloadId: num
  */
 export const siteBackupDownloadInitiateMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-backup-dl-init' },
 		mutationFn: ( {
 			timestamp,
 			config: downloadConfig,
@@ -54,6 +55,7 @@ export const siteBackupFilteredDownloadStatusQuery = (
 
 export const siteBackupFilteredDownloadPrepareMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'site-backup-filt-dl-prep' },
 		mutationFn: ( {
 			siteId,
 			rewindId,
@@ -74,6 +76,7 @@ export const siteBackupFilteredDownloadPrepareMutation = () =>
  */
 export const siteGranularBackupDownloadInitiateMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-backup-gran-dl-init' },
 		mutationFn: ( {
 			rewindId,
 			includePaths,

--- a/packages/api-queries/src/site-backup-restore.ts
+++ b/packages/api-queries/src/site-backup-restore.ts
@@ -28,6 +28,7 @@ export const siteBackupRestoreProgressQuery = ( siteId: number, restoreId: numbe
  */
 export const siteBackupRestoreInitiateMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-backup-restore-init' },
 		mutationFn: ( {
 			timestamp,
 			config: restoreConfig,
@@ -48,6 +49,7 @@ export const siteBackupRestoreInitiateMutation = ( siteId: number ) =>
  */
 export const siteBackupGranularRestoreMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-backup-gran-restore' },
 		mutationFn: ( {
 			timestamp,
 			config: granularConfig,

--- a/packages/api-queries/src/site-backups.ts
+++ b/packages/api-queries/src/site-backups.ts
@@ -27,6 +27,7 @@ export const siteBackupsQuery = ( siteId: number ) =>
 
 export const siteBackupEnqueueMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-backup-enqueue' },
 		mutationFn: () => enqueueSiteBackup( siteId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteBackupsQuery( siteId ) );
@@ -78,5 +79,6 @@ export const siteBackupSizeQuery = ( siteId: number ) =>
 
 export const siteUpdateRetentionDaysMutation = ( siteId: number, retentionDays: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-retention-days-update' },
 		mutationFn: () => updateRetentionDays( siteId, retentionDays ),
 	} );

--- a/packages/api-queries/src/site-cache.ts
+++ b/packages/api-queries/src/site-cache.ts
@@ -16,6 +16,7 @@ export const siteObjectCacheLastClearedTimestampQuery = ( siteId: number ) =>
 
 export const siteObjectCacheClearMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-object-cache-clear' },
 		mutationFn: ( reason: string ) => clearObjectCache( siteId, reason ),
 		onSuccess: () => {
 			queryClient.setQueryData(
@@ -34,6 +35,7 @@ export const siteEdgeCacheLastClearedTimestampQuery = ( siteId: number ) =>
 
 export const siteEdgeCacheClearMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-edge-cache-clear' },
 		mutationFn: () => clearEdgeCache( siteId ),
 		onSuccess: () => {
 			queryClient.setQueryData(
@@ -51,6 +53,7 @@ export const siteEdgeCacheStatusQuery = ( siteId: number ) =>
 
 export const siteEdgeCacheStatusMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-edge-cache-toggle' },
 		mutationFn: ( active: boolean ) => updateEdgeCacheStatus( siteId, active ),
 		onSuccess: ( active ) => {
 			queryClient.setQueryData( siteEdgeCacheStatusQuery( siteId ).queryKey, active );

--- a/packages/api-queries/src/site-comments.ts
+++ b/packages/api-queries/src/site-comments.ts
@@ -182,6 +182,7 @@ export const siteCommentQuery = ( { siteId, commentId }: SiteCommentQueryParams 
  */
 export const createSitePostCommentMutation = () =>
 	mutationOptions< SiteComment, Error, CreateSitePostReplyParams >( {
+		meta: { statId: 'site-post-cmt-create' },
 		mutationFn: createSitePostReply,
 	} );
 
@@ -193,6 +194,7 @@ export const createSitePostCommentMutation = () =>
  */
 export const createSiteCommentReplyMutation = () =>
 	mutationOptions< SiteComment, Error, CreateSiteCommentReplyParams >( {
+		meta: { statId: 'site-cmt-reply-create' },
 		mutationFn: ( { siteId, parentCommentId, content } ) =>
 			createSiteCommentReply( { siteId, parentCommentId, content } ),
 	} );
@@ -204,6 +206,7 @@ export const createSiteCommentReplyMutation = () =>
  */
 export const likeSiteCommentMutation = () =>
 	mutationOptions< SiteCommentLikeMutationResponse, Error, SiteCommentLikeMutationParams >( {
+		meta: { statId: 'site-cmt-like' },
 		mutationFn: ( { siteId, commentId } ) => likeSiteComment( { siteId, commentId } ),
 	} );
 
@@ -214,5 +217,6 @@ export const likeSiteCommentMutation = () =>
  */
 export const unlikeSiteCommentMutation = () =>
 	mutationOptions< SiteCommentLikeMutationResponse, Error, SiteCommentLikeMutationParams >( {
+		meta: { statId: 'site-cmt-unlike' },
 		mutationFn: ( { siteId, commentId } ) => unlikeSiteComment( { siteId, commentId } ),
 	} );

--- a/packages/api-queries/src/site-crontab.ts
+++ b/packages/api-queries/src/site-crontab.ts
@@ -11,6 +11,7 @@ export const siteCrontabsQuery = ( siteId: number ) =>
 
 export const siteCrontabCreateMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-crontab-create' },
 		mutationFn: ( params: CrontabFormData ) => createCrontab( siteId, params ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteCrontabsQuery( siteId ) );
@@ -19,6 +20,7 @@ export const siteCrontabCreateMutation = ( siteId: number ) =>
 
 export const siteCrontabUpdateMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-crontab-update' },
 		mutationFn: ( { cronId, params }: { cronId: number; params: CrontabFormData } ) =>
 			updateCrontab( siteId, cronId, params ),
 		onSuccess: () => {
@@ -28,6 +30,7 @@ export const siteCrontabUpdateMutation = ( siteId: number ) =>
 
 export const siteCrontabDeleteMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-crontab-delete' },
 		mutationFn: ( cronId: number ) => deleteCrontab( siteId, cronId ),
 		onSuccess: ( _, cronId ) => {
 			queryClient.setQueryData( siteCrontabsQuery( siteId ).queryKey, ( currentCrontabs ) => {

--- a/packages/api-queries/src/site-database.ts
+++ b/packages/api-queries/src/site-database.ts
@@ -3,5 +3,6 @@ import { mutationOptions } from '@tanstack/react-query';
 
 export const siteDatabaseMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-db-password-restore' },
 		mutationFn: () => restoreDatabasePassword( siteId ),
 	} );

--- a/packages/api-queries/src/site-defensive-mode.ts
+++ b/packages/api-queries/src/site-defensive-mode.ts
@@ -14,6 +14,7 @@ export const siteDefensiveModeSettingsQuery = ( siteId: number ) =>
 
 export const siteDefensiveModeSettingsMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-def-mode-update' },
 		mutationFn: ( data: DefensiveModeSettingsUpdate ) =>
 			updateEdgeCacheDefensiveModeSettings( siteId, data ),
 		onSuccess: ( data ) => {

--- a/packages/api-queries/src/site-deployments.ts
+++ b/packages/api-queries/src/site-deployments.ts
@@ -33,6 +33,7 @@ export const codeDeploymentRunsQuery = ( siteId: number, deploymentId: number ) 
 
 export const createCodeDeploymentRunMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'code-deploy-run-create' },
 		mutationFn: async ( { siteId, deploymentId }: { siteId: number; deploymentId: number } ) =>
 			createCodeDeploymentRun( siteId, deploymentId ),
 		onSuccess: ( ...args ) => {
@@ -46,12 +47,14 @@ export const createCodeDeploymentRunMutation = () =>
 
 export const codeDeploymentDeleteMutation = ( siteId: number, deploymentId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'code-deploy-delete' },
 		mutationFn: ( removeFiles: boolean ) =>
 			deleteCodeDeployment( siteId, deploymentId, removeFiles ),
 	} );
 
 export const createCodeDeploymentMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'code-deploy-create' },
 		mutationFn: ( variables: CreateAndUpdateCodeDeploymentVariables ) =>
 			createCodeDeployment( siteId, variables ),
 		onSuccess: () => {
@@ -61,6 +64,7 @@ export const createCodeDeploymentMutation = ( siteId: number ) =>
 
 export const updateCodeDeploymentMutation = ( siteId: number, deploymentId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'code-deploy-update' },
 		mutationFn: ( variables: CreateAndUpdateCodeDeploymentVariables ) =>
 			updateCodeDeployment( siteId, deploymentId, variables ),
 		onSuccess: () => {

--- a/packages/api-queries/src/site-deployments.ts
+++ b/packages/api-queries/src/site-deployments.ts
@@ -33,7 +33,7 @@ export const codeDeploymentRunsQuery = ( siteId: number, deploymentId: number ) 
 
 export const createCodeDeploymentRunMutation = () =>
 	mutationOptions( {
-		meta: { statId: 'code-deploy-run-create' },
+		meta: { statId: 'deploy-run-create' },
 		mutationFn: async ( { siteId, deploymentId }: { siteId: number; deploymentId: number } ) =>
 			createCodeDeploymentRun( siteId, deploymentId ),
 		onSuccess: ( ...args ) => {
@@ -47,14 +47,14 @@ export const createCodeDeploymentRunMutation = () =>
 
 export const codeDeploymentDeleteMutation = ( siteId: number, deploymentId: number ) =>
 	mutationOptions( {
-		meta: { statId: 'code-deploy-delete' },
+		meta: { statId: 'deploy-delete' },
 		mutationFn: ( removeFiles: boolean ) =>
 			deleteCodeDeployment( siteId, deploymentId, removeFiles ),
 	} );
 
 export const createCodeDeploymentMutation = ( siteId: number ) =>
 	mutationOptions( {
-		meta: { statId: 'code-deploy-create' },
+		meta: { statId: 'deploy-create' },
 		mutationFn: ( variables: CreateAndUpdateCodeDeploymentVariables ) =>
 			createCodeDeployment( siteId, variables ),
 		onSuccess: () => {
@@ -64,7 +64,7 @@ export const createCodeDeploymentMutation = ( siteId: number ) =>
 
 export const updateCodeDeploymentMutation = ( siteId: number, deploymentId: number ) =>
 	mutationOptions( {
-		meta: { statId: 'code-deploy-update' },
+		meta: { statId: 'deploy-update' },
 		mutationFn: ( variables: CreateAndUpdateCodeDeploymentVariables ) =>
 			updateCodeDeployment( siteId, deploymentId, variables ),
 		onSuccess: () => {

--- a/packages/api-queries/src/site-deployments.ts
+++ b/packages/api-queries/src/site-deployments.ts
@@ -33,7 +33,7 @@ export const codeDeploymentRunsQuery = ( siteId: number, deploymentId: number ) 
 
 export const createCodeDeploymentRunMutation = () =>
 	mutationOptions( {
-		meta: { statId: 'deploy-run-create' },
+		meta: { statId: 'site-deploy-run-create' },
 		mutationFn: async ( { siteId, deploymentId }: { siteId: number; deploymentId: number } ) =>
 			createCodeDeploymentRun( siteId, deploymentId ),
 		onSuccess: ( ...args ) => {
@@ -47,14 +47,14 @@ export const createCodeDeploymentRunMutation = () =>
 
 export const codeDeploymentDeleteMutation = ( siteId: number, deploymentId: number ) =>
 	mutationOptions( {
-		meta: { statId: 'deploy-delete' },
+		meta: { statId: 'site-deploy-delete' },
 		mutationFn: ( removeFiles: boolean ) =>
 			deleteCodeDeployment( siteId, deploymentId, removeFiles ),
 	} );
 
 export const createCodeDeploymentMutation = ( siteId: number ) =>
 	mutationOptions( {
-		meta: { statId: 'deploy-create' },
+		meta: { statId: 'site-deploy-create' },
 		mutationFn: ( variables: CreateAndUpdateCodeDeploymentVariables ) =>
 			createCodeDeployment( siteId, variables ),
 		onSuccess: () => {
@@ -64,7 +64,7 @@ export const createCodeDeploymentMutation = ( siteId: number ) =>
 
 export const updateCodeDeploymentMutation = ( siteId: number, deploymentId: number ) =>
 	mutationOptions( {
-		meta: { statId: 'deploy-update' },
+		meta: { statId: 'site-deploy-update' },
 		mutationFn: ( variables: CreateAndUpdateCodeDeploymentVariables ) =>
 			updateCodeDeployment( siteId, deploymentId, variables ),
 		onSuccess: () => {

--- a/packages/api-queries/src/site-domains.ts
+++ b/packages/api-queries/src/site-domains.ts
@@ -14,6 +14,7 @@ export const siteDomainsQuery = ( siteId: number ) =>
 
 export const siteSetPrimaryDomainMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'site-primary-domain-set' },
 		mutationFn: ( { siteId, domain }: { siteId: number; domain: string } ) =>
 			setPrimaryDomain( siteId, domain ),
 		onSuccess: ( data, { siteId } ) => {

--- a/packages/api-queries/src/site-jetpack-connection.ts
+++ b/packages/api-queries/src/site-jetpack-connection.ts
@@ -28,6 +28,7 @@ export const jetpackTestConnectionQuery = ( siteId: number, isStaleConnectionHea
 
 export const siteJetpackDisconnectMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-jp-disconnect' },
 		mutationFn: () => disconnectJetpackSite( siteId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteQueryFilter( siteId ) );

--- a/packages/api-queries/src/site-jetpack-modules.ts
+++ b/packages/api-queries/src/site-jetpack-modules.ts
@@ -16,6 +16,7 @@ export const siteJetpackModulesQuery = ( siteId: number ) =>
 
 export const siteJetpackModulesMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-jp-module-toggle' },
 		mutationFn: ( variables: { module: string; value: boolean } ) => {
 			const { module, value } = variables;
 			return value

--- a/packages/api-queries/src/site-jetpack-monitor-settings.ts
+++ b/packages/api-queries/src/site-jetpack-monitor-settings.ts
@@ -9,6 +9,7 @@ type CreateVars = { siteId: number; body: Partial< JetpackMonitorSettings > };
 
 export const siteJetpackMonitorSettingsCreateMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'site-jp-mon-create' },
 		mutationFn: async ( vars: CreateVars ) => {
 			const { siteId, body } = vars;
 			// Activate monitor module before creating settings, mirroring legacy flow

--- a/packages/api-queries/src/site-jetpack-settings.ts
+++ b/packages/api-queries/src/site-jetpack-settings.ts
@@ -63,6 +63,7 @@ export const siteJetpackSettingsQuery = ( siteId: number ) =>
 
 export const siteJetpackSettingsMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-jp-settings-update' },
 		mutationFn: ( settings: Partial< JetpackSettings > ) =>
 			updateJetpackSettings( siteId, settings ),
 		onSuccess: ( newData: unknown, newSettings: Partial< JetpackSettings > ) => {

--- a/packages/api-queries/src/site-owner-transfer.ts
+++ b/packages/api-queries/src/site-owner-transfer.ts
@@ -10,18 +10,21 @@ import type { SiteOwnerTransferContext } from '@automattic/api-core';
 
 export const siteOwnerTransferMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-owner-xfer' },
 		mutationFn: ( data: { new_site_owner: string; context?: SiteOwnerTransferContext } ) =>
 			startSiteOwnerTransfer( siteId, data ),
 	} );
 
 export const siteOwnerTransferEligibilityCheckMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-owner-xfer-check' },
 		mutationFn: ( data: { new_site_owner: string } ) =>
 			checkSiteOwnerTransferEligibility( siteId, data ),
 	} );
 
 export const siteOwnerTransferConfirmMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-owner-xfer-confirm' },
 		mutationFn: ( data: { hash: string } ) => confirmSiteOwnerTransfer( siteId, data ),
 		onSuccess: ( { transfer } ) => {
 			if ( transfer ) {

--- a/packages/api-queries/src/site-php-version.ts
+++ b/packages/api-queries/src/site-php-version.ts
@@ -10,6 +10,7 @@ export const sitePHPVersionQuery = ( siteId: number ) =>
 
 export const sitePHPVersionMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-php-version-update' },
 		mutationFn: ( version: string ) => updatePHPVersion( siteId, version ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( sitePHPVersionQuery( siteId ) );

--- a/packages/api-queries/src/site-plans.ts
+++ b/packages/api-queries/src/site-plans.ts
@@ -36,5 +36,6 @@ export const sitePlanBySlugQuery = ( siteId: number, productSlug: string ) =>
 
 export const sitePlanSoftwareRestoreMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-plan-sw-restore' },
 		mutationFn: () => restoreSitePlanSoftware( siteId ),
 	} );

--- a/packages/api-queries/src/site-plugins.ts
+++ b/packages/api-queries/src/site-plugins.ts
@@ -122,7 +122,7 @@ export const sitePluginInstallMutation = () =>
 
 export const siteCorePluginInstallMutation = () =>
 	mutationOptions( {
-		meta: { statId: 'core-plugin-install' },
+		meta: { statId: 'site-core-plugin-install' },
 		mutationFn: ( vars: { siteId: number; slug: string } ) =>
 			installSiteCorePlugin( vars.siteId, vars.slug ),
 		onSuccess: ( _data, vars: { siteId: number } ) => invalidateSiteCorePlugins( vars.siteId ),
@@ -130,7 +130,7 @@ export const siteCorePluginInstallMutation = () =>
 
 export const siteCorePluginActivateMutation = () =>
 	mutationOptions( {
-		meta: { statId: 'core-plugin-activate' },
+		meta: { statId: 'site-core-plugin-activate' },
 		mutationFn: ( vars: { siteId: number; plugin: string } ) =>
 			activateSiteCorePlugin( vars.siteId, vars.plugin ),
 		onSuccess: ( _data, vars: { siteId: number } ) => invalidateSiteCorePlugins( vars.siteId ),

--- a/packages/api-queries/src/site-plugins.ts
+++ b/packages/api-queries/src/site-plugins.ts
@@ -66,6 +66,7 @@ const invalidatePluginsForSite = ( siteId: number ) => {
 
 export const sitePluginActivateMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'site-plugin-activate' },
 		mutationFn: ( vars: { siteId: number; pluginId: string } ) =>
 			activateSitePlugin( vars.siteId, vars.pluginId ),
 		onSuccess: ( _data, vars: { siteId: number } ) => invalidatePluginsForSite( vars.siteId ),
@@ -73,6 +74,7 @@ export const sitePluginActivateMutation = () =>
 
 export const sitePluginDeactivateMutation = ( invalidateQueriesOnSuccess = true ) =>
 	mutationOptions( {
+		meta: { statId: 'site-plugin-deactivate' },
 		mutationFn: ( vars: { siteId: number; pluginId: string } ) =>
 			deactivateSitePlugin( vars.siteId, vars.pluginId ),
 		onSuccess: ( _data, vars: { siteId: number } ) => {
@@ -84,6 +86,7 @@ export const sitePluginDeactivateMutation = ( invalidateQueriesOnSuccess = true 
 
 export const sitePluginUpdateMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'site-plugin-update' },
 		mutationFn: ( vars: { siteId: number; pluginId: string } ) =>
 			updateSitePlugin( vars.siteId, vars.pluginId ),
 		onSuccess: ( _data, vars: { siteId: number } ) => invalidatePluginsForSite( vars.siteId ),
@@ -91,6 +94,7 @@ export const sitePluginUpdateMutation = () =>
 
 export const sitePluginAutoupdateEnableMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'site-plugin-auto-enable' },
 		mutationFn: ( vars: { siteId: number; pluginId: string } ) =>
 			enableSitePluginAutoupdate( vars.siteId, vars.pluginId ),
 		onSuccess: ( _data, vars: { siteId: number } ) => invalidatePluginsForSite( vars.siteId ),
@@ -98,6 +102,7 @@ export const sitePluginAutoupdateEnableMutation = () =>
 
 export const sitePluginAutoupdateDisableMutation = ( invalidateQueriesOnSuccess = true ) =>
 	mutationOptions( {
+		meta: { statId: 'site-plugin-auto-disable' },
 		mutationFn: ( vars: { siteId: number; pluginId: string } ) =>
 			disableSitePluginAutoupdate( vars.siteId, vars.pluginId ),
 		onSuccess: ( _data, vars: { siteId: number } ) => {
@@ -109,6 +114,7 @@ export const sitePluginAutoupdateDisableMutation = ( invalidateQueriesOnSuccess 
 
 export const sitePluginInstallMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'site-plugin-install' },
 		mutationFn: ( vars: { siteId: number; pluginId: string } ) =>
 			installSitePlugin( vars.siteId, vars.pluginId ),
 		onSuccess: ( _data, vars: { siteId: number } ) => invalidatePluginsForSite( vars.siteId ),
@@ -116,6 +122,7 @@ export const sitePluginInstallMutation = () =>
 
 export const siteCorePluginInstallMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'core-plugin-install' },
 		mutationFn: ( vars: { siteId: number; slug: string } ) =>
 			installSiteCorePlugin( vars.siteId, vars.slug ),
 		onSuccess: ( _data, vars: { siteId: number } ) => invalidateSiteCorePlugins( vars.siteId ),
@@ -123,6 +130,7 @@ export const siteCorePluginInstallMutation = () =>
 
 export const siteCorePluginActivateMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'core-plugin-activate' },
 		mutationFn: ( vars: { siteId: number; plugin: string } ) =>
 			activateSiteCorePlugin( vars.siteId, vars.plugin ),
 		onSuccess: ( _data, vars: { siteId: number } ) => invalidateSiteCorePlugins( vars.siteId ),
@@ -130,6 +138,7 @@ export const siteCorePluginActivateMutation = () =>
 
 export const sitePluginRemoveMutation = ( invalidateQueriesOnSuccess = true ) =>
 	mutationOptions( {
+		meta: { statId: 'site-plugin-remove' },
 		mutationFn: ( vars: { siteId: number; pluginId: string } ) =>
 			removeSitePlugin( vars.siteId, vars.pluginId ),
 		onSuccess: ( _data, vars: { siteId: number } ) => {

--- a/packages/api-queries/src/site-post-by-email.ts
+++ b/packages/api-queries/src/site-post-by-email.ts
@@ -20,6 +20,7 @@ export const sitePostByEmailSettingsQuery = ( site: Site ) => {
 
 export const sitePostByEmailSettingsMutation = ( site: Site ) =>
 	mutationOptions( {
+		meta: { statId: 'site-post-by-email-update' },
 		mutationFn: ( settings: SitePostByEmailSettingsUpdate ) =>
 			updateSitePostByEmailSettings( site, settings.post_by_email_address ),
 		onSuccess: ( postByEmailSettings ) => {

--- a/packages/api-queries/src/site-preview-links.ts
+++ b/packages/api-queries/src/site-preview-links.ts
@@ -14,6 +14,7 @@ export const sitePreviewLinksQuery = ( siteId: number ) =>
 
 export const sitePreviewLinkCreateMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-preview-link-create' },
 		mutationFn: () => createSitePreviewLink( siteId ),
 		onSuccess: ( data ) => {
 			queryClient.setQueryData( sitePreviewLinksQuery( siteId ).queryKey, [ data ] );
@@ -22,6 +23,7 @@ export const sitePreviewLinkCreateMutation = ( siteId: number ) =>
 
 export const sitePreviewLinkDeleteMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-preview-link-delete' },
 		mutationFn: ( code: string ) => deleteSitePreviewLink( siteId, code ),
 		onSuccess: () => {
 			queryClient.removeQueries( sitePreviewLinksQuery( siteId ) );

--- a/packages/api-queries/src/site-redirect.ts
+++ b/packages/api-queries/src/site-redirect.ts
@@ -10,6 +10,7 @@ export const siteRedirectQuery = ( siteId: number ) =>
 
 export const updateSiteRedirectMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-redirect-update' },
 		mutationFn: ( location: string ) => updateSiteRedirect( siteId, location ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( {

--- a/packages/api-queries/src/site-reset.ts
+++ b/packages/api-queries/src/site-reset.ts
@@ -13,6 +13,7 @@ export const siteResetContentSummaryQuery = ( siteId: number ) =>
 
 export const siteResetMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-reset' },
 		mutationFn: () => resetSite( siteId ),
 	} );
 

--- a/packages/api-queries/src/site-scan.ts
+++ b/packages/api-queries/src/site-scan.ts
@@ -32,6 +32,7 @@ export const siteScanHistoryQuery = ( siteId: number ) =>
 
 export const siteScanEnqueueMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-scan-enqueue' },
 		mutationFn: () => enqueueSiteScan( siteId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteScanQuery( siteId ) );
@@ -40,6 +41,7 @@ export const siteScanEnqueueMutation = ( siteId: number ) =>
 
 export const ignoreThreatMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'threat-ignore' },
 		mutationFn: ( threatId: number ) => ignoreThreat( siteId, threatId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteScanQuery( siteId ) );
@@ -49,6 +51,7 @@ export const ignoreThreatMutation = ( siteId: number ) =>
 
 export const unignoreThreatMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'threat-unignore' },
 		mutationFn: ( threatId: number ) => unignoreThreat( siteId, threatId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteScanQuery( siteId ) );
@@ -58,6 +61,7 @@ export const unignoreThreatMutation = ( siteId: number ) =>
 
 export const fixThreatMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'threat-fix' },
 		mutationFn: ( threatId: number ) => fixThreat( siteId, threatId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteScanQuery( siteId ) );
@@ -67,6 +71,7 @@ export const fixThreatMutation = ( siteId: number ) =>
 
 export const fixThreatsMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'threats-fix' },
 		mutationFn: ( threatIds: number[] ) => fixThreats( siteId, threatIds ),
 	} );
 

--- a/packages/api-queries/src/site-scan.ts
+++ b/packages/api-queries/src/site-scan.ts
@@ -41,7 +41,7 @@ export const siteScanEnqueueMutation = ( siteId: number ) =>
 
 export const ignoreThreatMutation = ( siteId: number ) =>
 	mutationOptions( {
-		meta: { statId: 'threat-ignore' },
+		meta: { statId: 'site-threat-ignore' },
 		mutationFn: ( threatId: number ) => ignoreThreat( siteId, threatId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteScanQuery( siteId ) );
@@ -51,7 +51,7 @@ export const ignoreThreatMutation = ( siteId: number ) =>
 
 export const unignoreThreatMutation = ( siteId: number ) =>
 	mutationOptions( {
-		meta: { statId: 'threat-unignore' },
+		meta: { statId: 'site-threat-unignore' },
 		mutationFn: ( threatId: number ) => unignoreThreat( siteId, threatId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteScanQuery( siteId ) );
@@ -61,7 +61,7 @@ export const unignoreThreatMutation = ( siteId: number ) =>
 
 export const fixThreatMutation = ( siteId: number ) =>
 	mutationOptions( {
-		meta: { statId: 'threat-fix' },
+		meta: { statId: 'site-threat-fix' },
 		mutationFn: ( threatId: number ) => fixThreat( siteId, threatId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteScanQuery( siteId ) );
@@ -71,7 +71,7 @@ export const fixThreatMutation = ( siteId: number ) =>
 
 export const fixThreatsMutation = ( siteId: number ) =>
 	mutationOptions( {
-		meta: { statId: 'threats-fix' },
+		meta: { statId: 'site-threats-fix' },
 		mutationFn: ( threatIds: number[] ) => fixThreats( siteId, threatIds ),
 	} );
 

--- a/packages/api-queries/src/site-settings.ts
+++ b/packages/api-queries/src/site-settings.ts
@@ -12,6 +12,7 @@ export const siteSettingsQuery = ( siteId: number ) =>
 
 export const siteSettingsMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-settings-update' },
 		mutationFn: ( data: Partial< SiteSettings > ) => updateSiteSettings( siteId, data ),
 		onSuccess: ( newData ) => {
 			queryClient.setQueryData( siteSettingsQuery( siteId ).queryKey, ( oldData ) => {

--- a/packages/api-queries/src/site-sftp.ts
+++ b/packages/api-queries/src/site-sftp.ts
@@ -29,6 +29,7 @@ const updateCurrentSftpUsers = ( currentSftpUsers: SftpUser[] | undefined, sftpU
 
 export const siteSftpUsersCreateMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-sftp-users-create' },
 		mutationFn: () => createSftpUser( siteId ),
 		onSuccess: ( createdSftpUser ) => {
 			queryClient.setQueryData( siteSftpUsersQuery( siteId ).queryKey, ( currentSftpUsers ) =>
@@ -39,6 +40,7 @@ export const siteSftpUsersCreateMutation = ( siteId: number ) =>
 
 export const siteSftpUsersResetPasswordMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-sftp-users-pw-reset' },
 		mutationFn: ( sshUsername: string ) => resetSftpPassword( siteId, sshUsername ),
 		onSuccess: ( updatedSftpUser ) => {
 			queryClient.setQueryData( siteSftpUsersQuery( siteId ).queryKey, ( currentSftpUsers ) =>

--- a/packages/api-queries/src/site-ssh.ts
+++ b/packages/api-queries/src/site-ssh.ts
@@ -18,6 +18,7 @@ export const siteSshAccessStatusQuery = ( siteId: number ) =>
 
 export const siteSshAccessEnableMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-ssh-access-enable' },
 		mutationFn: () => enableSshAccess( siteId ),
 		onSuccess: ( data ) => {
 			queryClient.setQueryData( siteSshAccessStatusQuery( siteId ).queryKey, data );
@@ -26,6 +27,7 @@ export const siteSshAccessEnableMutation = ( siteId: number ) =>
 
 export const siteSshAccessDisableMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-ssh-access-disable' },
 		mutationFn: () => disableSshAccess( siteId ),
 		onSuccess: ( data ) => {
 			queryClient.setQueryData( siteSshAccessStatusQuery( siteId ).queryKey, data );
@@ -40,6 +42,7 @@ export const siteSshKeysQuery = ( siteId: number ) =>
 
 export const siteSshKeysAttachMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-ssh-keys-attach' },
 		mutationFn: ( name: string ) => attachSiteSshKey( siteId, name ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteSshKeysQuery( siteId ) );
@@ -48,6 +51,7 @@ export const siteSshKeysAttachMutation = ( siteId: number ) =>
 
 export const siteSshKeysDetachMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-ssh-keys-detach' },
 		mutationFn: ( siteSshKey: SiteSshKey ) =>
 			detachSiteSshKey( siteId, siteSshKey.user_login, siteSshKey.name ),
 		onSuccess: () => {

--- a/packages/api-queries/src/site-staging-sites.ts
+++ b/packages/api-queries/src/site-staging-sites.ts
@@ -24,6 +24,7 @@ export const isCreatingStagingSiteQuery = ( stagingSiteId: number ) =>
 
 export const stagingSiteCreateMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'staging-site-create' },
 		mutationFn: () => createStagingSite( siteId ),
 		onMutate: () => {
 			queryClient.setQueryData( isCreatingStagingSiteQuery( siteId ).queryKey, true );
@@ -39,6 +40,7 @@ export const isDeletingStagingSiteQuery = ( stagingSiteId: number ) =>
 
 export const stagingSiteDeleteMutation = ( stagingSiteId: number, productionSiteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'staging-site-delete' },
 		mutationFn: () => deleteStagingSite( stagingSiteId, productionSiteId ),
 		onSuccess: () => {
 			queryClient.setQueryData( isDeletingStagingSiteQuery( stagingSiteId ).queryKey, true );

--- a/packages/api-queries/src/site-staging-sync.ts
+++ b/packages/api-queries/src/site-staging-sync.ts
@@ -8,6 +8,7 @@ export const PULL_FROM_STAGING = 'pull-from-staging-site-mutation-key';
 
 export const pushToStagingMutation = ( productionSiteId: number, stagingSiteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'staging-push' },
 		mutationKey: [ PUSH_TO_STAGING, stagingSiteId ],
 		mutationFn: ( options: StagingSyncOptions ) =>
 			pushToStaging( productionSiteId, stagingSiteId, options ),
@@ -20,6 +21,7 @@ export const pushToStagingMutation = ( productionSiteId: number, stagingSiteId: 
 
 export const pullFromStagingMutation = ( productionSiteId: number, stagingSiteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'staging-pull' },
 		mutationKey: [ PULL_FROM_STAGING, stagingSiteId ],
 		mutationFn: ( options: StagingSyncOptions ) =>
 			pullFromStaging( productionSiteId, stagingSiteId, options ),

--- a/packages/api-queries/src/site-staging-sync.ts
+++ b/packages/api-queries/src/site-staging-sync.ts
@@ -8,7 +8,7 @@ export const PULL_FROM_STAGING = 'pull-from-staging-site-mutation-key';
 
 export const pushToStagingMutation = ( productionSiteId: number, stagingSiteId: number ) =>
 	mutationOptions( {
-		meta: { statId: 'staging-push' },
+		meta: { statId: 'staging-site-push' },
 		mutationKey: [ PUSH_TO_STAGING, stagingSiteId ],
 		mutationFn: ( options: StagingSyncOptions ) =>
 			pushToStaging( productionSiteId, stagingSiteId, options ),
@@ -21,7 +21,7 @@ export const pushToStagingMutation = ( productionSiteId: number, stagingSiteId: 
 
 export const pullFromStagingMutation = ( productionSiteId: number, stagingSiteId: number ) =>
 	mutationOptions( {
-		meta: { statId: 'staging-pull' },
+		meta: { statId: 'staging-site-pull' },
 		mutationKey: [ PULL_FROM_STAGING, stagingSiteId ],
 		mutationFn: ( options: StagingSyncOptions ) =>
 			pullFromStaging( productionSiteId, stagingSiteId, options ),

--- a/packages/api-queries/src/site-static-file-404.ts
+++ b/packages/api-queries/src/site-static-file-404.ts
@@ -10,6 +10,7 @@ export const siteStaticFile404SettingQuery = ( siteId: number ) =>
 
 export const siteStaticFile404SettingMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-static-file404-update' },
 		mutationFn: ( setting: string ) => updateStaticFile404Setting( siteId, setting ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteStaticFile404SettingQuery( siteId ) );

--- a/packages/api-queries/src/site-update-schedules.ts
+++ b/packages/api-queries/src/site-update-schedules.ts
@@ -36,6 +36,7 @@ const invalidateSiteUpdateSchedules = ( siteId: number ) => {
 // Mutation: create single-site schedule
 export const siteUpdateScheduleCreateMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-upd-sched-create' },
 		mutationFn: ( body: CreateSiteUpdateScheduleBody ) => createSiteUpdateSchedule( siteId, body ),
 		onSuccess: () => {
 			invalidateSiteUpdateSchedules( siteId );
@@ -45,6 +46,7 @@ export const siteUpdateScheduleCreateMutation = ( siteId: number ) =>
 // Mutation: edit single-site schedule
 export const siteUpdateScheduleEditMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-upd-sched-edit' },
 		mutationFn: ( variables: { scheduleId: string; body: EditSiteUpdateScheduleBody } ) =>
 			editSiteUpdateSchedule( siteId, variables.scheduleId, variables.body ),
 		onSuccess: () => {
@@ -55,6 +57,7 @@ export const siteUpdateScheduleEditMutation = ( siteId: number ) =>
 // Mutation: delete single-site schedule
 export const siteUpdateScheduleDeleteMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-upd-sched-delete' },
 		mutationFn: ( scheduleId: string ) => deleteSiteUpdateSchedule( siteId, scheduleId ),
 		onSuccess: () => {
 			invalidateSiteUpdateSchedules( siteId );
@@ -64,6 +67,7 @@ export const siteUpdateScheduleDeleteMutation = ( siteId: number ) =>
 // Mutation: toggle active for any site (siteId provided in variables)
 export const siteUpdateScheduleSetActiveMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'site-upd-sched-activate' },
 		mutationFn: ( variables: { siteId: number; scheduleId: string; active: boolean } ) =>
 			setSiteUpdateScheduleActive( variables.siteId, variables.scheduleId, variables.active ),
 		onSuccess: ( _data, variables ) => {
@@ -75,6 +79,7 @@ export const siteUpdateScheduleSetActiveMutation = () =>
 // Batch create across multiple sites
 export const updateSchedulesBatchCreateMutation = ( siteIds: number[] ) =>
 	mutationOptions( {
+		meta: { statId: 'upd-scheds-batch-create' },
 		mutationFn: async ( body: CreateSiteUpdateScheduleBody ) => {
 			const results = await Promise.all(
 				siteIds.map( async ( siteId ) => {

--- a/packages/api-queries/src/site-update-schedules.ts
+++ b/packages/api-queries/src/site-update-schedules.ts
@@ -79,7 +79,7 @@ export const siteUpdateScheduleSetActiveMutation = () =>
 // Batch create across multiple sites
 export const updateSchedulesBatchCreateMutation = ( siteIds: number[] ) =>
 	mutationOptions( {
-		meta: { statId: 'upd-scheds-batch-create' },
+		meta: { statId: 'site-upd-sched-batch-create' },
 		mutationFn: async ( body: CreateSiteUpdateScheduleBody ) => {
 			const results = await Promise.all(
 				siteIds.map( async ( siteId ) => {

--- a/packages/api-queries/src/site-users.ts
+++ b/packages/api-queries/src/site-users.ts
@@ -16,6 +16,7 @@ export const siteCurrentUserQuery = ( siteId: number ) =>
 
 export const siteUserDeleteMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-user-delete' },
 		mutationFn: ( userId: number ) => deleteSiteUser( siteId, userId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteQueryFilter( siteId ) );

--- a/packages/api-queries/src/site-wordpress-version.ts
+++ b/packages/api-queries/src/site-wordpress-version.ts
@@ -23,6 +23,7 @@ export const siteWordPressVersionMutation = (
 	options?: { deferUntilBackupComplete?: boolean }
 ) =>
 	mutationOptions( {
+		meta: { statId: 'site-wp-version-update' },
 		mutationFn: ( version: string ) =>
 			updateWordPressVersion( siteId, version, options?.deferUntilBackupComplete ),
 		onSuccess: () => {

--- a/packages/api-queries/src/site.ts
+++ b/packages/api-queries/src/site.ts
@@ -126,6 +126,7 @@ export const siteQueryFilter = ( siteId: number ) => ( {
 
 export const siteDeleteMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-delete' },
 		mutationFn: () => deleteSite( siteId ),
 		onSuccess: () => {
 			// Delay the invalidation for the redirection to complete first
@@ -139,6 +140,7 @@ export const siteDeleteMutation = ( siteId: number ) =>
 
 export const siteLaunchMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-launch' },
 		mutationFn: () => launchSite( siteId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteQueryFilter( siteId ) );
@@ -147,6 +149,7 @@ export const siteLaunchMutation = ( siteId: number ) =>
 
 export const siteRestoreMutation = ( siteId: number ) =>
 	mutationOptions( {
+		meta: { statId: 'site-restore' },
 		mutationFn: () => restoreSite( siteId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteQueryFilter( siteId ) );

--- a/packages/api-queries/src/upgrades.ts
+++ b/packages/api-queries/src/upgrades.ts
@@ -84,6 +84,7 @@ export const userPurchaseSetAutoRenewQuery = () =>
 
 export const assignPaymentMethodMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'payment-method-assign' },
 		mutationFn: ( params: AssignPaymentMethodParams ) => assignPaymentMethod( params ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( userPurchasesQuery() );
@@ -92,6 +93,7 @@ export const assignPaymentMethodMutation = () =>
 
 export const removePurchaseMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'purch-remove' },
 		mutationFn: removePurchase,
 		onSuccess: () => {
 			queryClient.invalidateQueries( userPurchasesQuery() );
@@ -100,6 +102,7 @@ export const removePurchaseMutation = () =>
 
 export const cancelAndRefundPurchaseMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'purch-cancel-refund' },
 		mutationFn: ( params: {
 			purchaseId: number;
 			options: PurchaseCancelOptions | PurchaseDowngradeOptions;
@@ -111,6 +114,7 @@ export const cancelAndRefundPurchaseMutation = () =>
 
 export const extendPurchaseWithFreeMonthMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'purch-free-month-extend' },
 		mutationFn: ( purchaseId: number ) => extendPurchaseWithFreeMonth( purchaseId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( userPurchasesQuery() );
@@ -119,6 +123,7 @@ export const extendPurchaseWithFreeMonthMutation = () =>
 
 export const setDelayedDowngradeMutation = () =>
 	mutationOptions( {
+		meta: { statId: 'downgrade-delayed-set' },
 		mutationFn: (
 			params: { purchaseId: number } & (
 				| { enabled: true; toProductId: number }

--- a/packages/api-queries/src/upgrades.ts
+++ b/packages/api-queries/src/upgrades.ts
@@ -123,7 +123,7 @@ export const extendPurchaseWithFreeMonthMutation = () =>
 
 export const setDelayedDowngradeMutation = () =>
 	mutationOptions( {
-		meta: { statId: 'downgrade-delayed-set' },
+		meta: { statId: 'purch-downgrade-delayed-set' },
 		mutationFn: (
 			params: { purchaseId: number } & (
 				| { enabled: true; toProductId: number }


### PR DESCRIPTION
Part of DOTMSD-1418

Builds on #112725, now merged. That PR landed the plumbing — `ApiQueriesMutationMeta`, `withSnackbar()`, `bumpMultipleStats`, and the `mutation-error-tracker` rename — and proved it end to end on the two security-key mutations. This is the full rollout, plus the enforcement to keep it from rotting.

## Proposed Changes

* Annotate every mutation in `@automattic/api-queries` with `meta: { statId: '<noun>-<verb>' }` — ~230 across 91 files, including the reader `use*Mutation` hooks by hand.
* Convert all 80 dashboard snackbar call sites to `withSnackbar()`, so none silently drops the factory's `statId`.
* Enforce both conventions:
  * `packages/api-queries/src/__tests__/mutation-stat-ids.test.ts` reads back every factory and asserts a present, unique, in-length `statId`.
  * A `no-restricted-syntax` rule in `client/dashboard/.eslintrc.js` fails any hand-written `meta: { snackbar }`, which is always a `statId` clobber now that the helper exists.
* Document the convention in `packages/api-queries/AGENTS.md` (naming, length limit, abbreviations) and `client/dashboard/AGENTS.md`.
* `mutation-error-tracker` now reports a *missing* `statId` to Sentry. With every api-queries mutation annotated, a missing ID means an unannotated mutation defined elsewhere — a gap worth fixing at the source, not the norm as it was in #112725.

## Why are these changes being made?

#112725 covers the why of the approach: why `statId` lives in `meta`, why the IDs are hand-written noun-first, why `withSnackbar()` is needed, and why the meta type extends `Record< string, unknown >`. This PR applies it everywhere and adds the guards, because the type system can't: `statId` has to stay optional (requiring it would land on every `useMutation` call site repo-wide), and the index signature TS#15300 forces means a typo like `statid` still compiles. The test and the lint rule catch what the compiler won't.

## Known gap

The reader `use*Mutation` exports are React hooks, not options factories, so they can't be called outside a render and the guard test can't read them; their IDs were checked by hand. The test does assert that the only unreadable exports are those hooks, so a new plain factory going unannotated still fails.

## Testing Instructions

* `yarn test-packages packages/api-queries` — includes the guard suite (statId present, unique, `<noun>-<verb>`, within the length limit).
* `yarn test-client client/dashboard/app/snackbars client/dashboard/app/mutation-error-tracker` — 10 tests.
* `yarn lint:js` — the new rule reports 0 violations across `client/dashboard`.
* To confirm the guards guard: delete a `meta` line from any mutation in `packages/api-queries/src`, or misspell `statId`, and re-run the first command; both fail with the offending export named. Then hand-write a `meta: { snackbar: {} }` at any dashboard call site and re-run lint.
* `yarn typecheck-packages && yarn typecheck-client` (in that order — the client reads `packages/*/dist/types`, which `typecheck-packages` emits).
* No user-facing change. Snackbar text and behaviour are untouched; this only affects the name recorded for the mutation failure stats.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
