### PR TITLE
Fix Unknown term error on site-level purchase details page

### DIFF
--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -202,25 +202,26 @@ const usePricingMetaForGridPlans = ( {
 
 					if ( purchasedPlan ) {
 						const introductoryOffer = getPurchaseIntroductoryOffer( purchasedPlan );
+						const billPeriodDays = Number( purchasedPlan.bill_period_days );
 						const showIntroOfferHeadline =
 							!! showBillingDescriptionForIncreasedRenewalPrice &&
 							introductoryOffer?.isWithinPeriod;
 						const currentTermPrice = showIntroOfferHeadline
 							? introductoryOffer!.costPerIntervalInteger
 							: purchasedPlan.price_integer;
-						const isMonthly = purchasedPlan.bill_period_days === PLAN_MONTHLY_PERIOD;
+						const isMonthly = billPeriodDays === PLAN_MONTHLY_PERIOD;
 
 						if ( isMonthly && monthlyPrice !== currentTermPrice ) {
 							monthlyPrice = currentTermPrice;
 							fullPrice = parseFloat( ( currentTermPrice * 12 ).toFixed( 2 ) );
 						} else if ( fullPrice !== currentTermPrice ) {
-							const term = getTermFromDuration( purchasedPlan.bill_period_days ) || '';
+							const term = getTermFromDuration( billPeriodDays ) || '';
 							monthlyPrice = calculateMonthlyPrice( term, currentTermPrice );
 							fullPrice = currentTermPrice;
 						}
 
 						if ( showIntroOfferHeadline ) {
-							const renewalTerm = getTermFromDuration( purchasedPlan.bill_period_days ) || '';
+							const renewalTerm = getTermFromDuration( billPeriodDays ) || '';
 							renewalPrice = {
 								monthly: isMonthly
 									? purchasedPlan.price_integer


### PR DESCRIPTION
Fixes [SHILL-2261](https://linear.app/a8c/issue/SHILL-2261/investigate-unknown-term-errors-on-site-level-purchase-details-page)

## Proposed Changes

Restores the numeric coercion of `bill_period_days` in `usePricingMetaForGridPlans`, fixing fatal `Unknown term:` errors on the site-level purchase details page.

## Why are these changes being made?

#112677 switched `useSitePurchases` off the `createPurchaseObject` assembler to raw purchase objects. The assembler used to coerce this field via `Number( purchase.bill_period_days )` because the API returns it as a string (e.g. `"365"`); the raw path dropped that coercion and read the field directly.

`getTermFromDuration` compares its argument with strict equality (`===`) against numeric period constants, so a string value never matches and it returns `undefined`. The `|| ''` fallback then handed an empty string to `calculateMonthlyPrice`, which throws `Unknown term:`. This surfaced as a fatal caught by the error boundary on the site-level purchase details page (logged as `site_level_purchases`). Separately, the `bill_period_days === PLAN_MONTHLY_PERIOD` check was silently always false against a string, pushing monthly plans down the throwing branch as well.

The error only reproduced on purchases where the current site-plan price differs from the purchase price (intro offers, discounts, proration), which is why it was intermittent rather than affecting every purchase. Restoring `Number()` matches the previous assembler behavior and fixes both problems.

## Testing Instructions

* On a sandbox, open a site-level purchase details page (`/purchases/subscriptions/:site/:purchaseId`) for a paid plan whose current site-plan price differs from the purchase price — e.g. one with an active introductory offer or a discounted/prorated renewal.
* Confirm the page renders the plan price without a fatal error and no `Unknown term:` / `site_level_purchases` error is logged.
* Verify monthly, annual, and biennial plans all display correct monthly and full prices.
