### PR TITLE
A4A Amplify: support the pending report status

### DIFF
--- a/client/a8c-for-agencies/data/amplify/types.ts
+++ b/client/a8c-for-agencies/data/amplify/types.ts
@@ -1,6 +1,6 @@
 export type AmplifyMode = 'human' | 'ai' | 'full';
 
-export type AmplifyReportStatus = 'in_progress' | 'completed' | 'failed';
+export type AmplifyReportStatus = 'pending' | 'in_progress' | 'completed' | 'failed';
 
 // `full` fills both lenses; a single-lens run fills its own and leaves the
 // other `null`. Both are `null` until the analysis completes.
@@ -11,9 +11,9 @@ export interface AmplifyScore {
 
 // A report as surfaced by the unified `/reports` routes. Every run lives on
 // the one collection through its whole life, its `status` telling you where
-// it is: `in_progress` (analysis queued or running), `completed` (`score`
-// populated, `pdf_url` set) or `failed` (`failure_reason` carries a short
-// reason). `id` is the numeric post id as a string.
+// it is: `pending` (analysis queued, waiting to start), `in_progress`
+// (analysis running), `completed` (`score` populated, `pdf_url` set) or
+// `failed` (`failure_reason` carries a short reason). `id` is the numeric post id as a string.
 export interface AmplifyReport {
 	id: string;
 	status: AmplifyReportStatus;

--- a/client/a8c-for-agencies/data/amplify/use-fetch-amplify-reports.ts
+++ b/client/a8c-for-agencies/data/amplify/use-fetch-amplify-reports.ts
@@ -4,8 +4,9 @@ import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import type { AmplifyReport, AmplifyReportsResponse } from './types';
 
-// While any report is still `in_progress`, poll so a running analysis flips
-// to its terminal status (`completed` / `failed`) without a manual refresh.
+// While any report is still `pending` or `in_progress`, poll so a queued or
+// running analysis flips to its terminal status (`completed` / `failed`)
+// without a manual refresh.
 const POLL_INTERVAL = 15 * 1000;
 
 export const getAmplifyReportsQueryKey = ( agencyId?: number ) => [
@@ -13,8 +14,10 @@ export const getAmplifyReportsQueryKey = ( agencyId?: number ) => [
 	agencyId,
 ];
 
-export function hasInProgressReports( reports?: AmplifyReport[] ): boolean {
-	return !! reports?.some( ( report ) => report.status === 'in_progress' );
+export function hasActiveReports( reports?: AmplifyReport[] ): boolean {
+	return !! reports?.some(
+		( report ) => report.status === 'pending' || report.status === 'in_progress'
+	);
 }
 
 function fetchAmplifyReports( agencyId: number ): Promise< AmplifyReport[] > {
@@ -34,7 +37,6 @@ export default function useFetchAmplifyReports() {
 		queryFn: () => fetchAmplifyReports( agencyId as number ),
 		enabled: !! agencyId,
 		refetchOnWindowFocus: false,
-		refetchInterval: ( query ) =>
-			hasInProgressReports( query.state.data ) ? POLL_INTERVAL : false,
+		refetchInterval: ( query ) => ( hasActiveReports( query.state.data ) ? POLL_INTERVAL : false ),
 	} );
 }

--- a/client/a8c-for-agencies/data/amplify/use-start-amplify-analysis.ts
+++ b/client/a8c-for-agencies/data/amplify/use-start-amplify-analysis.ts
@@ -45,11 +45,12 @@ export default function useStartAmplifyAnalysis< TContext = unknown >(
 			return startAmplifyAnalysis( params, agencyId );
 		},
 		onSuccess: ( data, variables, context ) => {
-			// Seed the reports cache with the new `in_progress` report so its row
+			// Seed the reports cache with the newly created report so its row
 			// appears immediately and the reports query starts polling (its
-			// refetchInterval keys off the presence of an in-progress report) —
-			// without waiting for a manual page refresh. We seed rather than only
-			// invalidate so the row shows even if a refetch races the write.
+			// refetchInterval keys off the presence of a pending or in-progress
+			// report) — without waiting for a manual page refresh. We seed rather
+			// than only invalidate so the row shows even if a refetch races the
+			// write.
 			queryClient.setQueryData< AmplifyReport[] >(
 				getAmplifyReportsQueryKey( agencyId ),
 				( previous ) => {

--- a/client/a8c-for-agencies/sections/amplify/primary/reports/reports-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/primary/reports/reports-content.tsx
@@ -195,11 +195,15 @@ export default function AmplifyReportsContent() {
 							</Badge>
 						);
 					}
-					if ( item.rowStatus === 'in_progress' ) {
+					if ( item.rowStatus === 'pending' || item.rowStatus === 'in_progress' ) {
 						return (
 							<HStack spacing={ 2 } justify="flex-start" expanded={ false }>
 								<Spinner />
-								<Text variant="muted">{ __( 'Analysis in progress' ) }</Text>
+								<Text variant="muted">
+									{ item.rowStatus === 'pending'
+										? __( 'Waiting to start' )
+										: __( 'Analysis in progress' ) }
+								</Text>
 							</HStack>
 						);
 					}

--- a/client/a8c-for-agencies/sections/amplify/primary/reports/use-report-rows.ts
+++ b/client/a8c-for-agencies/sections/amplify/primary/reports/use-report-rows.ts
@@ -41,9 +41,9 @@ export default function useAmplifyReportRows(): {
 	isLoading: boolean;
 	error: unknown;
 } {
-	// Polls every 15s while any report is `in_progress` (see
-	// use-fetch-amplify-reports), so a running analysis flips to its terminal
-	// status without a refresh.
+	// Polls every 15s while any report is `pending` or `in_progress` (see
+	// use-fetch-amplify-reports), so a queued or running analysis flips to its
+	// terminal status without a refresh.
 	const reportsQuery = useFetchAmplifyReports();
 
 	const rows = useMemo( () => toAmplifyReportRows( reportsQuery.data ), [ reportsQuery.data ] );


### PR DESCRIPTION
Follow-up to #112623. The backend now creates reports as `pending` before the analysis worker picks them up (228759-ghe-Automattic/wpcom); this teaches the client the new status. Ships after the wpcom PR deploys.

## Proposed Changes

* **`types.ts`** — `pending` added to `AmplifyReportStatus`, ahead of `in_progress`.
* **`use-fetch-amplify-reports.ts`** — the 15s polling now runs while any report is `pending` or `in_progress`.
* **`reports-content.tsx`** — pending rows show a spinner with **Waiting to start**; once the analysis starts, the row flips to the existing **Analysis in progress**.

## Why are these changes being made?

Without the new status in the union, a `pending` report would render the disabled Download button and the reports query wouldn't poll, so the row would never update without a refresh.

## Testing Instructions

0. Apply 228759-ghe-Automattic/wpcom to your sandbox.
1. Run `yarn start-a8c-for-agencies` and open `agencies.localhost:3000/amplify/reports` as an agency user with the amplify capabilities.
2. Run an analysis from **Amplify a site** — the new row shows a spinner with **Waiting to start**.
3. When the worker picks it up, the row flips to **Analysis in progress**, then to its scores + **Download PDF** once done, and polling stops.
4. Confirm no TypeScript/React console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?