### PR TITLE
Audit env/env_id uses in MSD

### DIFF
--- a/client/dashboard/app/analytics/index.tsx
+++ b/client/dashboard/app/analytics/index.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { captureException } from '@automattic/calypso-sentry';
 import { addQueryArgs } from '@wordpress/url';
 import { createContext, useContext } from 'react';
 
@@ -23,15 +24,21 @@ export function AnalyticsProvider( { children, client }: AnalyticsProviderProps 
 	return <AnalyticsContext.Provider value={ client }>{ children }</AnalyticsContext.Provider>;
 }
 
+const MISSING_PROVIDER_MESSAGE = 'useAnalytics() must be used with a <AnalyticsProvider>';
+
+let hasCapturedMissingProviderOnce = false;
+
 export function useAnalytics() {
 	const context = useContext( AnalyticsContext );
 
-	if (
-		! config< string >( 'env_id' ).includes( 'production' ) &&
-		context === defaultNoopAnalyticsClient
-	) {
-		// eslint-disable-next-line no-console
-		console.error( 'useAnalytics() must be used with a <AnalyticsProvider>' );
+	if ( context === defaultNoopAnalyticsClient ) {
+		if ( config( 'env' ) !== 'production' ) {
+			// eslint-disable-next-line no-console
+			console.error( MISSING_PROVIDER_MESSAGE );
+		} else if ( ! hasCapturedMissingProviderOnce ) {
+			hasCapturedMissingProviderOnce = true;
+			captureException( new Error( MISSING_PROVIDER_MESSAGE ) );
+		}
 	}
 
 	return context;

--- a/client/dashboard/app/logger/index.tsx
+++ b/client/dashboard/app/logger/index.tsx
@@ -61,7 +61,7 @@ export function handleOnCatch(
 		tags: [ 'dashboard' ],
 		properties: {
 			dashboard_backport: options.dashboard_backport,
-			env: calypsoConfig( 'env_id' ),
+			env_id: calypsoConfig( 'env_id' ),
 			message: error.message,
 			stack: errorInfo.componentStack,
 			path: window.location.href,

--- a/client/dashboard/app/logger/test/index.test.ts
+++ b/client/dashboard/app/logger/test/index.test.ts
@@ -77,7 +77,7 @@ describe( 'handleOnCatch', () => {
 			tags: [ 'dashboard' ],
 			properties: {
 				dashboard_backport: false,
-				env: 'development',
+				env_id: 'development',
 				message: 'Boom',
 				stack: 'at SitePage',
 				path: 'https://example.com/',

--- a/client/dashboard/sites/performance/frontend/index.tsx
+++ b/client/dashboard/sites/performance/frontend/index.tsx
@@ -48,7 +48,9 @@ export default function SitePerformanceFrontend( { siteSlug }: { siteSlug: strin
 		return pagesData?.[ 0 ];
 	}, [ page_id, pagesData ] );
 
-	const performanceUrl = [ 'development', 'wpcalypso' ].includes( config( 'env_id' ) )
+	const performanceUrl = [ 'development', 'dashboard-development', 'wpcalypso' ].includes(
+		config( 'env_id' )
+	)
 		? url ?? currentPage?.link
 		: currentPage?.link;
 


### PR DESCRIPTION
Fixes DOTMSD-1428

## Why are these changes being made?

A root cause of the recent key incident was `env_id` being used to gate production behaviour where `env` was meant. The two are easy to confuse:

* `env` is the flavour of environment. Several distinct deployments are all `production`.
* `env_id` is a unique ID for one specific deployment, so it can never answer "am I in production?".

This audits every remaining use of both in the dashboard.

Only the analytics warning repeated the incident's mistake. Its blast radius was small — a stray console error in production-flavour environments — but it is the same bug.

The other three changes are adjacent problems the audit surfaced:

* The logstash property named `env` holds an `env_id`. That is exactly the naming confusion the incident report called out, sitting in the logging code someone will read while debugging the next one.
* The performance allowlist was copied from Calypso, where its values are correct, and never gained the dashboard's own development ID. The `?url=` override is currently dead in dashboard dev.
* A missing analytics provider in production produced no signal at all.


## Proposed Changes

* Analytics: gate the missing-provider warning on `env` instead of a substring match on `env_id`.
* Analytics: report a missing provider to Sentry in production, rather than staying silent.
* Logger: rename the logstash property `env` to `env_id`, matching the value it has always carried.
* Performance: add `dashboard-development` to the allowlist for the `?url=` report override.

The other seven uses of `env`/`env_id` in the dashboard were already correct and are untouched.


## Considerations

**Severity gating was left alone.** The router asks whether it is *the* production dashboard deployment by ID. That looks like the incident's bug but is a genuine identity question, and the backport routers mirror it. Switching it to `env` would promote stage and horizon errors to error severity and into the alerts channel.

**The logstash rename diverges from the rest of Calypso.** 28 producers send an `env_id` value under a property named `env`; exactly one already uses `env_id`. Renaming only the dashboard's makes it the odd one out, and any saved logstash search filtering on `env` will stop matching dashboard errors. Emitting both was the alternative. Renaming was chosen because the dashboard is where the confusion caused an incident, and a compatibility alias would preserve the confusing name indefinitely. **This wants a check against the alerts channel and logstash dashboards before merge** — it is adjacent to the logging work in DOTMSD-1417.

**The Sentry report fires once per page load.** The check lives in a hook body used by ~170 call sites, so it runs on every render of every consumer, and this Sentry client does not dedupe and samples at 100%. Reporting unlatched would flood the quota. The error is constructed at the call site so the stack identifies which component lacked the provider. The development console warning is deliberately not latched, so that path is unchanged.

## Testing Instructions

The analytics and performance changes are only observable in specific environments:

* In dashboard development, confirm `?url=` on the site performance frontend report still targets the given URL.
* Confirm no console error about a missing analytics provider appears in normal use — the provider is present, so none of these paths should fire at all.
* After deploy, confirm dashboard errors still arrive in logstash under the renamed `env_id` property, and update any saved searches filtering on `env`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
