### PR TITLE
Dashboard: track 2-step security key mutation failures

### DIFF
--- a/client/dashboard/app/mutation-error-tracker/index.tsx
+++ b/client/dashboard/app/mutation-error-tracker/index.tsx
@@ -3,20 +3,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { bumpStat } from '../analytics';
 
-function getMutationKeyLabel( key: unknown ): string {
-	if ( ! Array.isArray( key ) ) {
-		return 'unknown';
-	}
-	const leading: string[] = [];
-	for ( const part of key ) {
-		if ( typeof part !== 'string' ) {
-			break;
-		}
-		leading.push( part );
-	}
-	return leading.length ? leading.join( ':' ) : 'unknown';
-}
-
 export default function MutationErrorTracker() {
 	const queryClient = useQueryClient();
 
@@ -28,11 +14,18 @@ export default function MutationErrorTracker() {
 
 			const { mutation } = event;
 			const error = event.action.error;
+			const trackingId = mutation.meta?.trackingId;
 
-			const keyLabel = getMutationKeyLabel( mutation.options.mutationKey );
-			const name = isWpError( error ) ? `${ keyLabel }:${ error.status }` : keyLabel;
+			if ( ! trackingId ) {
+				return;
+			}
 
-			bumpStat( 'hd-mutation-error', name );
+			// Only track server-side errors now.
+			if ( ! isWpError( error ) || Math.floor( error.status / 100 ) !== 5 ) {
+				return;
+			}
+
+			bumpStat( 'dashboard-mutation-error', trackingId );
 		} );
 	}, [ queryClient ] );
 

--- a/client/dashboard/app/mutation-error-tracker/test/index.test.tsx
+++ b/client/dashboard/app/mutation-error-tracker/test/index.test.tsx
@@ -17,21 +17,52 @@ function wpError( fields: { status: number; statusCode: number; error?: string }
 }
 
 describe( '<MutationErrorTracker>', () => {
-	test( 'bumps a KEY:status stat when a keyed WPError mutation fails', async () => {
+	test( 'bumps the trackingId stat when a WPError mutation fails', async () => {
 		const { queryClient } = render( <MutationErrorTracker /> );
 
 		const error = wpError( { status: 500, statusCode: 500, error: 'internal_server_error' } );
 		const mutation = queryClient.getMutationCache().build( queryClient, {
-			mutationKey: [ 'PULL_FROM_STAGING', 12345 ],
+			meta: { trackingId: 'registerTwoStepAuthSecurityKey' },
 			mutationFn: () => Promise.reject( error ),
 		} );
 
 		await expect( mutation.execute( undefined ) ).rejects.toBe( error );
 
-		expect( mockedBumpStat ).toHaveBeenCalledWith( 'hd-mutation-error', 'PULL_FROM_STAGING:500' );
+		expect( mockedBumpStat ).toHaveBeenCalledWith(
+			'dashboard-mutation-error',
+			'registerTwoStepAuthSecurityKey'
+		);
 	} );
 
-	test( 'bumps the key label alone for an unkeyed, non-WPError failure', async () => {
+	test( 'does not bump anything for a 4xx WPError failure', async () => {
+		const { queryClient } = render( <MutationErrorTracker /> );
+
+		const error = wpError( { status: 403, statusCode: 403, error: 'forbidden' } );
+		const mutation = queryClient.getMutationCache().build( queryClient, {
+			meta: { trackingId: 'registerTwoStepAuthSecurityKey' },
+			mutationFn: () => Promise.reject( error ),
+		} );
+
+		await expect( mutation.execute( undefined ) ).rejects.toBe( error );
+
+		expect( mockedBumpStat ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does not bump anything for a non-WPError failure', async () => {
+		const { queryClient } = render( <MutationErrorTracker /> );
+
+		const error = new Error( 'NotAllowedError' );
+		const mutation = queryClient.getMutationCache().build( queryClient, {
+			meta: { trackingId: 'registerTwoStepAuthSecurityKey' },
+			mutationFn: () => Promise.reject( error ),
+		} );
+
+		await expect( mutation.execute( undefined ) ).rejects.toBe( error );
+
+		expect( mockedBumpStat ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does not bump anything for a failure without a trackingId', async () => {
 		const { queryClient } = render( <MutationErrorTracker /> );
 
 		const error = new Error( 'plain' );
@@ -41,7 +72,7 @@ describe( '<MutationErrorTracker>', () => {
 
 		await expect( mutation.execute( undefined ) ).rejects.toBe( error );
 
-		expect( mockedBumpStat ).toHaveBeenCalledWith( 'hd-mutation-error', 'unknown' );
+		expect( mockedBumpStat ).not.toHaveBeenCalled();
 	} );
 
 	test( 'does not bump anything when a mutation succeeds', async () => {

--- a/client/dashboard/app/snackbars/index.tsx
+++ b/client/dashboard/app/snackbars/index.tsx
@@ -1,4 +1,4 @@
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryClient, type MutationMeta } from '@tanstack/react-query';
 import { SnackbarList } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Icon, published, error } from '@wordpress/icons';
@@ -18,8 +18,19 @@ declare module '@tanstack/react-query' {
 				success?: string;
 				error?: string | { source: 'server' };
 			};
+			trackingId?: string;
 		};
 	}
+}
+
+export function withSnackbar< TOptions extends { meta?: MutationMeta } >(
+	options: TOptions,
+	snackbar: NonNullable< MutationMeta[ 'snackbar' ] >
+): TOptions {
+	return {
+		...options,
+		meta: { ...options.meta, snackbar },
+	};
 }
 
 export default function Snackbars() {

--- a/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
@@ -15,6 +15,7 @@ import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { useAnalytics } from '../../../../app/analytics';
+import { withSnackbar } from '../../../../app/snackbars';
 import { ActionList } from '../../../../components/action-list';
 import ConfirmModal from '../../../../components/confirm-modal';
 import InlineSupportLink from '../../../../components/inline-support-link';
@@ -117,14 +118,11 @@ export default function SecurityKeys() {
 
 	const registrations = securityKeys?.registrations ?? [];
 
-	const { mutate: deleteSecurityKey, isPending: isDeletingSecurityKey } = useMutation( {
-		...deleteTwoStepAuthSecurityKeyMutation(),
-		meta: {
-			snackbar: {
-				success: __( 'Security key deleted.' ),
-			},
-		},
-	} );
+	const { mutate: deleteSecurityKey, isPending: isDeletingSecurityKey } = useMutation(
+		withSnackbar( deleteTwoStepAuthSecurityKeyMutation(), {
+			success: __( 'Security key deleted.' ),
+		} )
+	);
 
 	const handleRemoveKey = ( item: SecurityKeyRegistration ) => {
 		setSelectedKeyToRemove( item );

--- a/packages/api-queries/src/me-two-step.ts
+++ b/packages/api-queries/src/me-two-step.ts
@@ -28,6 +28,7 @@ export const twoStepAuthSecurityKeysQuery = () =>
 // usable at login, not to whichever host the dashboard is served from.
 export const registerTwoStepAuthSecurityKeyMutation = ( hostname = 'wordpress.com' ) =>
 	mutationOptions( {
+		meta: { trackingId: 'registerTwoStepAuthSecurityKey' },
 		mutationFn: async ( keyName: string ) => {
 			// First, fetch the registration challenge
 			const options = await fetchTwoStepAuthSecurityKeyRegistrationChallenge( { hostname } );
@@ -51,6 +52,7 @@ export const registerTwoStepAuthSecurityKeyMutation = ( hostname = 'wordpress.co
 
 export const deleteTwoStepAuthSecurityKeyMutation = () =>
 	mutationOptions( {
+		meta: { trackingId: 'deleteTwoStepAuthSecurityKey' },
 		mutationFn: deleteTwoStepAuthSecurityKey,
 		onSuccess: () => {
 			queryClient.invalidateQueries( twoStepAuthSecurityKeysQuery() );


### PR DESCRIPTION
Part of DOTMSD-1417

## Proposed Changes

This PR updates the following:

- Mutations in `MutationErrorTracker` are now identified with an explicit `meta.trackingId`. Why? Because `mutationKey` can contain actual ids/slugs rather than stable `$id`/$slug` strings. So it's not suitable for tracking id.
- For now, we track explicit 5xx server error, and ignore user or 4xx errors.
- Collect all into the same tracking id bin/bucket. We can split by `.501` / `.503` later if we feel necessary.
- The id/bin/bucket is now literally the same function name in the source code. This is so that we can trace to the source code quickly.
- For now we apply to two-step security key mutations.
- Add a `withSnackbar` helper that merges snackbar config into `meta`. This is for developer ergonomics, otherwise we need to declare the mutation into a variable then spread its meta so that the snakcbar meta does not override the tracking id.
   - Opinions welcome.

## Why are these changes being made?

We want to track security key mutation failures.

## Testing Instructions

The quickest way is to checkout locally, then apply:

```diff
diff --git i/config/development.json w/config/development.json
index 448b5073649..cb92310c982 100644
--- i/config/development.json
+++ w/config/development.json
@@ -20,7 +20,7 @@
        "oauth_client_id": "39911",
        "wpcom_signup_id": "39911",
        "wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
-       "mc_analytics_enabled": false,
+       "mc_analytics_enabled": true,
        "boom_analytics_enabled": false,
        "server_side_boom_analytics_enabled": false,
        "boom_analytics_key": "development",
diff --git i/packages/api-queries/src/me-two-step.ts w/packages/api-queries/src/me-two-step.ts
index 0e3a24de73d..921e9861ef0 100644
--- i/packages/api-queries/src/me-two-step.ts
+++ w/packages/api-queries/src/me-two-step.ts
@@ -30,6 +30,11 @@ export const registerTwoStepAuthSecurityKeyMutation = ( hostname = 'wordpress.co
        mutationOptions( {
                meta: { trackingId: 'registerTwoStepAuthSecurityKey' },
                mutationFn: async ( keyName: string ) => {
+                       throw Object.assign( new Error( 'Simulated server error' ), {
+                               status: 500,
+                               statusCode: 500,
+                               error: 'internal_server_error',
+                       } );
                        // First, fetch the registration challenge
                        const options = await fetchTwoStepAuthSecurityKeyRegistrationChallenge( { hostname } );
```

then check in devtools for `pixel.wp.com/g.gif` request when registering a security key in /me -> Security,

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?
