### PR TITLE
MSD: add "Visit your site" action to critical error page

### DIFF
--- a/client/dashboard/sites/critical-error/index.tsx
+++ b/client/dashboard/sites/critical-error/index.tsx
@@ -98,16 +98,14 @@ const SiteCriticalError = ( { siteSlug }: { siteSlug: string } ) => {
 	const recoveryErrors = isAdmin ? getJetpackRecoverySessionErrors( site ) : [];
 
 	const items: Item[] = [];
-	if ( isAdmin ) {
+	if ( isAdmin && site.options?.admin_url ) {
 		items.push( {
 			icon: external,
 			text: createInterpolateElement(
 				// translators: <a/> is a link to the site's wp-admin with the text "Visit your site"
 				__( '<a>Visit your site</a> to check available recovery options.' ),
 				{
-					a: (
-						<a href={ site.options?.admin_url ?? '#' } target="_blank" rel="noopener noreferrer" />
-					),
+					a: <a href={ site.options.admin_url } target="_blank" rel="noopener noreferrer" />,
 				}
 			),
 		} );

--- a/client/dashboard/sites/critical-error/index.tsx
+++ b/client/dashboard/sites/critical-error/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Icon, envelope, formatListBullets, help } from '@wordpress/icons';
+import { Icon, envelope, external, formatListBullets, help } from '@wordpress/icons';
 import { Fragment, useEffect } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { useHelpCenter } from '../../app/help-center';
@@ -98,6 +98,20 @@ const SiteCriticalError = ( { siteSlug }: { siteSlug: string } ) => {
 	const recoveryErrors = isAdmin ? getJetpackRecoverySessionErrors( site ) : [];
 
 	const items: Item[] = [];
+	if ( isAdmin ) {
+		items.push( {
+			icon: external,
+			text: createInterpolateElement(
+				// translators: <a/> is a link to the site's wp-admin with the text "Visit your site"
+				__( '<a>Visit your site</a> to check available recovery options.' ),
+				{
+					a: (
+						<a href={ site.options?.admin_url ?? '#' } target="_blank" rel="noopener noreferrer" />
+					),
+				}
+			),
+		} );
+	}
 	if ( isAdmin ) {
 		items.push( {
 			icon: envelope,

--- a/client/dashboard/sites/critical-error/index.tsx
+++ b/client/dashboard/sites/critical-error/index.tsx
@@ -98,18 +98,6 @@ const SiteCriticalError = ( { siteSlug }: { siteSlug: string } ) => {
 	const recoveryErrors = isAdmin ? getJetpackRecoverySessionErrors( site ) : [];
 
 	const items: Item[] = [];
-	if ( isAdmin && site.options?.admin_url ) {
-		items.push( {
-			icon: external,
-			text: createInterpolateElement(
-				// translators: <a/> is a link to the site's wp-admin with the text "Visit your site"
-				__( '<a>Visit your site</a> to check available recovery options.' ),
-				{
-					a: <a href={ site.options.admin_url } target="_blank" rel="noopener noreferrer" />,
-				}
-			),
-		} );
-	}
 	if ( isAdmin ) {
 		items.push( {
 			icon: envelope,
@@ -119,6 +107,18 @@ const SiteCriticalError = ( { siteSlug }: { siteSlug: string } ) => {
 					'Search your admin email inbox for the keyword <q/> for troubleshooting instructions.'
 				),
 				{ q: <strong>{ __( 'critical error' ) }</strong> }
+			),
+		} );
+	}
+	if ( isAdmin && site.options?.admin_url ) {
+		items.push( {
+			icon: external,
+			text: createInterpolateElement(
+				// translators: <a/> is a link to the site's wp-admin with the text "Visit your site"
+				__( '<a>Visit your site</a> to check available recovery options.' ),
+				{
+					a: <a href={ site.options.admin_url } target="_blank" rel="noopener noreferrer" />,
+				}
 			),
 		} );
 	}

--- a/client/dashboard/sites/critical-error/index.tsx
+++ b/client/dashboard/sites/critical-error/index.tsx
@@ -4,12 +4,13 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { Link, useNavigate } from '@tanstack/react-router';
 import {
 	Button,
+	ExternalLink,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Icon, envelope, external, formatListBullets, help } from '@wordpress/icons';
+import { Icon, envelope, formatListBullets, help, wordpress } from '@wordpress/icons';
 import { Fragment, useEffect } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { useHelpCenter } from '../../app/help-center';
@@ -112,12 +113,12 @@ const SiteCriticalError = ( { siteSlug }: { siteSlug: string } ) => {
 	}
 	if ( isAdmin && site.options?.admin_url ) {
 		items.push( {
-			icon: external,
+			icon: wordpress,
 			text: createInterpolateElement(
 				// translators: <a/> is a link to the site's wp-admin with the text "Visit your site"
 				__( '<a>Visit your site</a> to check available recovery options.' ),
 				{
-					a: <a href={ site.options.admin_url } target="_blank" rel="noopener noreferrer" />,
+					a: <ExternalLink href={ site.options.admin_url } children={ null } />,
 				}
 			),
 		} );


### PR DESCRIPTION
## Proposed Changes

Add a "Visit your site" action item as the first entry in the "What you can try next" section on the critical error page
Links to the site's wp-admin so admins can access WordPress's built-in recovery mode directly
Shown to admin users only, consistent with the other admin-specific action items

<img width="1325" height="741" alt="Screenshot 2026-07-17 at 16 09 21" src="https://github.com/user-attachments/assets/0b2ea1ac-cbec-4e11-90b9-065e2d08d4b8" />



## Why are these changes being made?
Part of DOTMSD-1431

When a site hits a PHP fatal error, WordPress has a built-in recovery mode accessible via wp-admin that can help resolve the issue (e.g. by deactivating the offending plugin). Currently the critical error page doesn't surface this option, so admins may not know they can go directly to their site to recover.

## Testing Instructions
* Navigate to a site that has a critical PHP error at /sites/{slug}/critical-error
* Verify the first action item under "What you can try next" reads "Visit your site to check available recovery options."
* Verify the link points to the site's wp-admin URL and opens in a new tab
* Verify the item only appears for admin users