### PR TITLE
E2E: restore createSuiteTitle in migrated Playwright specs

### DIFF
--- a/test/e2e/specs/authentication/authentication__github.spec.ts
+++ b/test/e2e/specs/authentication/authentication__github.spec.ts
@@ -1,103 +1,107 @@
 import { DataHelper } from '@automattic/calypso-e2e';
 import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
 
-test.describe( 'Authentication: GitHub', { tag: [ tags.AUTHENTICATION ] }, () => {
-	skipIfMailosaurLimitReached();
-	test.skip(
-		DataHelper.isCalypsoProduction() === false,
-		'Skipping unless running on WordPress.com as GitHub authentication requires prod callbacks'
-	);
-
-	test( 'As a WordPress.com user, I can use my GitHub account to authenticate ', async ( {
-		clientEmail,
-		page,
-		pageGitHubLogin,
-		pageLogin,
-		secrets,
-	}, workerInfo ) => {
-		test.skip( true, 'Skipping the tests because of captcha issues on GitHub login page' );
+test.describe(
+	DataHelper.createSuiteTitle( 'Authentication: GitHub' ),
+	{ tag: [ tags.AUTHENTICATION ] },
+	() => {
+		skipIfMailosaurLimitReached();
 		test.skip(
-			workerInfo.project.name !== 'authentication',
-			'The authentication project is the only one that has the right browser settings for authentication tests'
+			DataHelper.isCalypsoProduction() === false,
+			'Skipping unless running on WordPress.com as GitHub authentication requires prod callbacks'
 		);
 
-		let timestamp: Date;
-		let code: string;
+		test( 'As a WordPress.com user, I can use my GitHub account to authenticate ', async ( {
+			clientEmail,
+			page,
+			pageGitHubLogin,
+			pageLogin,
+			secrets,
+		}, workerInfo ) => {
+			test.skip( true, 'Skipping the tests because of captcha issues on GitHub login page' );
+			test.skip(
+				workerInfo.project.name !== 'authentication',
+				'The authentication project is the only one that has the right browser settings for authentication tests'
+			);
 
-		await test.step( 'Given I am on the login page', async function () {
-			await pageLogin.visit();
-		} );
+			let timestamp: Date;
+			let code: string;
 
-		await test.step( 'When I click on Login with GitHub button', async function () {
-			await pageLogin.clickLoginWithGitHub();
-			await page.waitForURL( /.*github\.com\/login.*/ );
-		} );
-
-		await test.step( ' And I enter my GitHub username', async function () {
-			await pageGitHubLogin.enterEmail( secrets.testAccounts.gitHubLoginUser.username as string );
-			await pageGitHubLogin.pressEnter();
-		} );
-
-		await test.step( 'And I enter my GitHub password', async function () {
-			await pageGitHubLogin.enterPassword( secrets.testAccounts.gitHubLoginUser.password );
-			await pageGitHubLogin.pressEnter();
-		} );
-
-		await test.step( 'And I press Send SMS', async function () {
-			timestamp = new Date( Date.now() );
-			await pageGitHubLogin.clickButtonContainingText( 'Send SMS' );
-		} );
-
-		await test.step( 'And I handle SMS two-factor authentication', async function () {
-			const message = await clientEmail.getLastMatchingMessage( {
-				inboxId: secrets.mailosaur.totpUserInboxId,
-				receivedAfter: timestamp,
-				subject: 'SMS',
-				body: 'GitHub authentication code',
+			await test.step( 'Given I am on the login page', async function () {
+				await pageLogin.visit();
 			} );
 
-			code = clientEmail.get2FACodeFromMessage( message );
+			await test.step( 'When I click on Login with GitHub button', async function () {
+				await pageLogin.clickLoginWithGitHub();
+				await page.waitForURL( /.*github\.com\/login.*/ );
+			} );
 
-			await pageGitHubLogin.enter2FACode( code );
+			await test.step( ' And I enter my GitHub username', async function () {
+				await pageGitHubLogin.enterEmail( secrets.testAccounts.gitHubLoginUser.username as string );
+				await pageGitHubLogin.pressEnter();
+			} );
+
+			await test.step( 'And I enter my GitHub password', async function () {
+				await pageGitHubLogin.enterPassword( secrets.testAccounts.gitHubLoginUser.password );
+				await pageGitHubLogin.pressEnter();
+			} );
+
+			await test.step( 'And I press Send SMS', async function () {
+				timestamp = new Date( Date.now() );
+				await pageGitHubLogin.clickButtonContainingText( 'Send SMS' );
+			} );
+
+			await test.step( 'And I handle SMS two-factor authentication', async function () {
+				const message = await clientEmail.getLastMatchingMessage( {
+					inboxId: secrets.mailosaur.totpUserInboxId,
+					receivedAfter: timestamp,
+					subject: 'SMS',
+					body: 'GitHub authentication code',
+				} );
+
+				code = clientEmail.get2FACodeFromMessage( message );
+
+				await pageGitHubLogin.enter2FACode( code );
+			} );
+
+			await test.step( 'And I handle GitHub device verification if needed', async function () {
+				// GitHub may show a device verification screen in CI
+				const verificationUrl = 'https://github.com/sessions/verified-device';
+				// eslint-disable-next-line playwright/no-wait-for-navigation -- branches on the post-navigation URL to detect an optional GitHub verification screen; waitForURL can't express that. Rewrite in a follow-up pass.
+				const response = await page.waitForNavigation();
+
+				if ( ! response ) {
+					throw new Error( 'Navigation failed - no response received' );
+				}
+
+				if ( response.url() === verificationUrl ) {
+					// If we're on the verification screen, click the verify button
+					await pageGitHubLogin.clickButtonWithExactText( 'Verify' );
+				}
+			} );
+
+			await test.step( 'And I skip GitHub trust device if needed', async function () {
+				// GitHub may show a device verification screen in CI
+				const verificationUrl = 'https://github.com/sessions/trusted-device';
+				// eslint-disable-next-line playwright/no-wait-for-navigation -- branches on the post-navigation URL to detect an optional GitHub verification screen; waitForURL can't express that. Rewrite in a follow-up pass.
+				const response = await page.waitForNavigation();
+
+				if ( ! response ) {
+					throw new Error( 'Navigation failed - no response received' );
+				}
+
+				if ( response.url() === verificationUrl ) {
+					// If we're on the trusted device screen, skip it
+					await pageGitHubLogin.clickButtonWithExactText( "Don't ask again for this browser" );
+				}
+			} );
+
+			await test.step( 'And I verify successful login to WordPress.com', async function () {
+				await page.waitForURL( /.*wordpress\.com\/log-in\/github\/callback.*/ );
+				await page.waitForURL( /.*wordpress\.com\/sites.*/ );
+
+				expect( page.url() ).toMatch( /.*wordpress\.com\/sites.*/ );
+			} );
 		} );
-
-		await test.step( 'And I handle GitHub device verification if needed', async function () {
-			// GitHub may show a device verification screen in CI
-			const verificationUrl = 'https://github.com/sessions/verified-device';
-			// eslint-disable-next-line playwright/no-wait-for-navigation -- branches on the post-navigation URL to detect an optional GitHub verification screen; waitForURL can't express that. Rewrite in a follow-up pass.
-			const response = await page.waitForNavigation();
-
-			if ( ! response ) {
-				throw new Error( 'Navigation failed - no response received' );
-			}
-
-			if ( response.url() === verificationUrl ) {
-				// If we're on the verification screen, click the verify button
-				await pageGitHubLogin.clickButtonWithExactText( 'Verify' );
-			}
-		} );
-
-		await test.step( 'And I skip GitHub trust device if needed', async function () {
-			// GitHub may show a device verification screen in CI
-			const verificationUrl = 'https://github.com/sessions/trusted-device';
-			// eslint-disable-next-line playwright/no-wait-for-navigation -- branches on the post-navigation URL to detect an optional GitHub verification screen; waitForURL can't express that. Rewrite in a follow-up pass.
-			const response = await page.waitForNavigation();
-
-			if ( ! response ) {
-				throw new Error( 'Navigation failed - no response received' );
-			}
-
-			if ( response.url() === verificationUrl ) {
-				// If we're on the trusted device screen, skip it
-				await pageGitHubLogin.clickButtonWithExactText( "Don't ask again for this browser" );
-			}
-		} );
-
-		await test.step( 'And I verify successful login to WordPress.com', async function () {
-			await page.waitForURL( /.*wordpress\.com\/log-in\/github\/callback.*/ );
-			await page.waitForURL( /.*wordpress\.com\/sites.*/ );
-
-			expect( page.url() ).toMatch( /.*wordpress\.com\/sites.*/ );
-		} );
-	} );
-} );
+	}
+);

--- a/test/e2e/specs/authentication/authentication__magic-link.spec.ts
+++ b/test/e2e/specs/authentication/authentication__magic-link.spec.ts
@@ -2,64 +2,68 @@ import { DataHelper } from '@automattic/calypso-e2e';
 import { Message } from 'mailosaur/lib/models';
 import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
 
-test.describe( 'Authentication: Magic Link', { tag: [ tags.AUTHENTICATION ] }, () => {
-	skipIfMailosaurLimitReached();
-	test.skip(
-		DataHelper.isCalypsoProduction() === false,
-		'Skipping unless running on WordPress.com'
-	);
-
-	test( 'As a WordPress.com user, I can use a magic link to login to WordPress.com', async ( {
-		clientEmail,
-		page,
-		pageLogin,
-		secrets,
-	}, workerInfo ) => {
+test.describe(
+	DataHelper.createSuiteTitle( 'Authentication: Magic Link' ),
+	{ tag: [ tags.AUTHENTICATION ] },
+	() => {
+		skipIfMailosaurLimitReached();
 		test.skip(
-			workerInfo.project.name !== 'authentication',
-			'The authentication project is the only one that has the right browser settings for authentication tests'
+			DataHelper.isCalypsoProduction() === false,
+			'Skipping unless running on WordPress.com'
 		);
-		let magicLinkURL: URL;
-		let magicLinkEmail: Message;
 
-		await test.step( 'Given I am on the login page', async function () {
-			await pageLogin.visit();
-		} );
+		test( 'As a WordPress.com user, I can use a magic link to login to WordPress.com', async ( {
+			clientEmail,
+			page,
+			pageLogin,
+			secrets,
+		}, workerInfo ) => {
+			test.skip(
+				workerInfo.project.name !== 'authentication',
+				'The authentication project is the only one that has the right browser settings for authentication tests'
+			);
+			let magicLinkURL: URL;
+			let magicLinkEmail: Message;
 
-		await test.step( 'When I click on magic link', async function () {
-			await pageLogin.clickSendMagicLink();
-		} );
-
-		await test.step( 'And I request a magic link', async function () {
-			await pageLogin.fillUsername( secrets.testAccounts.defaultUser.email as string );
-			await pageLogin.clickSubmit();
-
-			magicLinkEmail = await clientEmail.getLastMatchingMessage( {
-				inboxId: secrets.mailosaur.defaultUserInboxId,
-				sentTo: secrets.testAccounts.defaultUser.email as string,
-				subject: 'Log in to WordPress.com',
+			await test.step( 'Given I am on the login page', async function () {
+				await pageLogin.visit();
 			} );
-			magicLinkURL = clientEmail.getMagicLink( magicLinkEmail );
 
-			expect( magicLinkURL.href ).toBeDefined();
-		} );
+			await test.step( 'When I click on magic link', async function () {
+				await pageLogin.clickSendMagicLink();
+			} );
 
-		await test.step( 'And I visit the magic link', async function () {
-			await page.goto( magicLinkURL.href );
-		} );
+			await test.step( 'And I request a magic link', async function () {
+				await pageLogin.fillUsername( secrets.testAccounts.defaultUser.email as string );
+				await pageLogin.clickSubmit();
 
-		await test.step( 'Then I am redirected to the WordPress.com homepage', async function () {
-			await page.waitForURL( /home/, { timeout: 15 * 1000 } );
-		} );
+				magicLinkEmail = await clientEmail.getLastMatchingMessage( {
+					inboxId: secrets.mailosaur.defaultUserInboxId,
+					sentTo: secrets.testAccounts.defaultUser.email as string,
+					subject: 'Log in to WordPress.com',
+				} );
+				magicLinkURL = clientEmail.getMagicLink( magicLinkEmail );
 
-		await test.step( 'And I can see My Home on WordPress.com', async function () {
-			await expect( page.getByRole( 'heading', { name: 'My Home' } ) ).toBeVisible();
-		} );
+				expect( magicLinkURL.href ).toBeDefined();
+			} );
 
-		await test.step( 'And I can delete the magic link email', async function () {
-			if ( magicLinkEmail ) {
-				await clientEmail.deleteMessage( magicLinkEmail );
-			}
+			await test.step( 'And I visit the magic link', async function () {
+				await page.goto( magicLinkURL.href );
+			} );
+
+			await test.step( 'Then I am redirected to the WordPress.com homepage', async function () {
+				await page.waitForURL( /home/, { timeout: 15 * 1000 } );
+			} );
+
+			await test.step( 'And I can see My Home on WordPress.com', async function () {
+				await expect( page.getByRole( 'heading', { name: 'My Home' } ) ).toBeVisible();
+			} );
+
+			await test.step( 'And I can delete the magic link email', async function () {
+				if ( magicLinkEmail ) {
+					await clientEmail.deleteMessage( magicLinkEmail );
+				}
+			} );
 		} );
-	} );
-} );
+	}
+);

--- a/test/e2e/specs/authentication/authentication__sms.spec.ts
+++ b/test/e2e/specs/authentication/authentication__sms.spec.ts
@@ -6,28 +6,32 @@ import { expect, tags, test } from '../../lib/pw-base';
  * There is a backend limit of one SMS per 5 minutes, so not sure we should even do this
  */
 
-test.describe( 'Authentication: SMS', { tag: [ tags.AUTHENTICATION ] }, () => {
-	test.skip(
-		DataHelper.isCalypsoProduction() === false,
-		'Skipping unless running on WordPress.com'
-	);
-
-	test( 'As a WordPress.com user, I can require 2fa via SMS', async ( { page }, workerInfo ) => {
+test.describe(
+	DataHelper.createSuiteTitle( 'Authentication: SMS' ),
+	{ tag: [ tags.AUTHENTICATION ] },
+	() => {
 		test.skip(
-			workerInfo.project.name !== 'authentication',
-			'The authentication project is the only one that has the right browser settings for authentication tests'
+			DataHelper.isCalypsoProduction() === false,
+			'Skipping unless running on WordPress.com'
 		);
-		// This should not be smaller than the timeout in the email client: {@link EmailClient.getLastMatchingMessage}
-		test.setTimeout( 130_000 );
 
-		await test.step( 'When I log in as a user with 2fa', async function () {
-			const testAccount = new TestAccount( 'smsUser' );
-			await testAccount.logInViaLoginPage( page );
-		} );
+		test( 'As a WordPress.com user, I can require 2fa via SMS', async ( { page }, workerInfo ) => {
+			test.skip(
+				workerInfo.project.name !== 'authentication',
+				'The authentication project is the only one that has the right browser settings for authentication tests'
+			);
+			// This should not be smaller than the timeout in the email client: {@link EmailClient.getLastMatchingMessage}
+			test.setTimeout( 130_000 );
 
-		await test.step( 'Then I am on the home page', async function () {
-			await page.waitForURL( /home/ );
-			await expect( page.getByRole( 'heading', { name: 'My Home' } ) ).toBeVisible();
+			await test.step( 'When I log in as a user with 2fa', async function () {
+				const testAccount = new TestAccount( 'smsUser' );
+				await testAccount.logInViaLoginPage( page );
+			} );
+
+			await test.step( 'Then I am on the home page', async function () {
+				await page.waitForURL( /home/ );
+				await expect( page.getByRole( 'heading', { name: 'My Home' } ) ).toBeVisible();
+			} );
 		} );
-	} );
-} );
+	}
+);

--- a/test/e2e/specs/authentication/authentication__totp.spec.ts
+++ b/test/e2e/specs/authentication/authentication__totp.spec.ts
@@ -4,7 +4,7 @@ import { expect, tags, test } from '../../lib/pw-base';
 const WOO_LOGIN_TIMEOUT = 30_000;
 
 test.describe(
-	'Authentication: Time-based One Time Passcode (TOTP)',
+	DataHelper.createSuiteTitle( 'Authentication: Time-based One Time Passcode (TOTP)' ),
 	{ tag: [ tags.AUTHENTICATION ] },
 	() => {
 		test.describe.configure( { mode: 'serial' } ); // Since both tests use the same TOTP, they should not be run at the same time

--- a/test/e2e/specs/blocks/blocks__media.spec.ts
+++ b/test/e2e/specs/blocks/blocks__media.spec.ts
@@ -20,7 +20,7 @@ import { TEST_IMAGE_PATH, TEST_AUDIO_PATH } from '../constants';
  * Keywords: Media, Video, VideoPress, Image, Audio, File
  */
 test.describe(
-	'Blocks: Media (Upload)',
+	DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ),
 	{ tag: [ tags.CALYPSO_PR, tags.GUTENBERG, tags.JETPACK_WPCOM_INTEGRATION ] },
 	() => {
 		skipIfNotTrunk();

--- a/test/e2e/specs/domain-upsell/domain-upsell__sidebar.spec.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__sidebar.spec.ts
@@ -1,53 +1,60 @@
+import { DataHelper } from '@automattic/calypso-e2e';
 import { expect, skipIfMailosaurLimitReached, skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 
-test.describe( 'Domain: Upsell (Sidebar)', { tag: [ tags.CALYPSO_RELEASE ] }, () => {
-	skipIfNotTrunk();
-	skipIfMailosaurLimitReached();
+test.describe(
+	DataHelper.createSuiteTitle( 'Domain: Upsell (Sidebar)' ),
+	{ tag: [ tags.CALYPSO_RELEASE ] },
+	() => {
+		skipIfNotTrunk();
+		skipIfMailosaurLimitReached();
 
-	const planName = 'Premium';
+		const planName = 'Premium';
 
-	test( `As a user, I can use the sidebar domain upsell to add a domain and a ${ planName } plan to cart`, async ( {
-		componentDomainSearch,
-		componentSidebar,
-		helperData,
-		page,
-		pageCartCheckout,
-		pagePlans,
-		sitePublic,
-	} ) => {
-		let selectedDomain: string;
+		test( `As a user, I can use the sidebar domain upsell to add a domain and a ${ planName } plan to cart`, async ( {
+			componentDomainSearch,
+			componentSidebar,
+			helperData,
+			page,
+			pageCartCheckout,
+			pagePlans,
+			sitePublic,
+		} ) => {
+			let selectedDomain: string;
 
-		await test.step( 'When I navigate to the Home dashboard on a new Free public site', async function () {
-			await page.goto( helperData.getCalypsoURL( `/home/${ sitePublic.blog_details.site_slug }` ) );
+			await test.step( 'When I navigate to the Home dashboard on a new Free public site', async function () {
+				await page.goto(
+					helperData.getCalypsoURL( `/home/${ sitePublic.blog_details.site_slug }` )
+				);
+			} );
+
+			await test.step( 'And I open the sidebar Domain Upsell notice', async function () {
+				await componentSidebar.openNotice(
+					'Upgrade',
+					`**/setup/domain-and-plan?siteSlug=${ sitePublic.blog_details.site_slug }`
+				);
+			} );
+
+			await test.step( 'And I search for a domain name', async function () {
+				await componentDomainSearch.search( `${ sitePublic.blog_details.site_slug }.com` );
+			} );
+
+			await test.step( 'And I choose the first suggestion and continue', async function () {
+				selectedDomain = await componentDomainSearch.selectFirstSuggestion();
+				expect( selectedDomain ).not.toBe( '' );
+				await componentDomainSearch.continue();
+			} );
+
+			await test.step( `And I choose the WordPress.com ${ planName } plan`, async function () {
+				await pagePlans.selectPlan( planName );
+			} );
+
+			await test.step( `Then WordPress.com ${ planName } is added to cart`, async function () {
+				await pageCartCheckout.validateCartItem( `WordPress.com ${ planName }` );
+			} );
+
+			await test.step( 'And I see the selected domain in checkout', async function () {
+				await pageCartCheckout.validateCartItem( selectedDomain );
+			} );
 		} );
-
-		await test.step( 'And I open the sidebar Domain Upsell notice', async function () {
-			await componentSidebar.openNotice(
-				'Upgrade',
-				`**/setup/domain-and-plan?siteSlug=${ sitePublic.blog_details.site_slug }`
-			);
-		} );
-
-		await test.step( 'And I search for a domain name', async function () {
-			await componentDomainSearch.search( `${ sitePublic.blog_details.site_slug }.com` );
-		} );
-
-		await test.step( 'And I choose the first suggestion and continue', async function () {
-			selectedDomain = await componentDomainSearch.selectFirstSuggestion();
-			expect( selectedDomain ).not.toBe( '' );
-			await componentDomainSearch.continue();
-		} );
-
-		await test.step( `And I choose the WordPress.com ${ planName } plan`, async function () {
-			await pagePlans.selectPlan( planName );
-		} );
-
-		await test.step( `Then WordPress.com ${ planName } is added to cart`, async function () {
-			await pageCartCheckout.validateCartItem( `WordPress.com ${ planName }` );
-		} );
-
-		await test.step( 'And I see the selected domain in checkout', async function () {
-			await pageCartCheckout.validateCartItem( selectedDomain );
-		} );
-	} );
-} );
+	}
+);

--- a/test/e2e/specs/domains/domains__add.spec.ts
+++ b/test/e2e/specs/domains/domains__add.spec.ts
@@ -1,8 +1,8 @@
-import { DomainsPage } from '@automattic/calypso-e2e';
+import { DataHelper, DomainsPage } from '@automattic/calypso-e2e';
 import { expect, skipIfMailosaurLimitReached, skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 
 test.describe(
-	'Domains: Add to current site',
+	DataHelper.createSuiteTitle( 'Domains: Add to current site' ),
 	{
 		tag: [ tags.CALYPSO_RELEASE ],
 	},

--- a/test/e2e/specs/editor/editor__navbar.spec.ts
+++ b/test/e2e/specs/editor/editor__navbar.spec.ts
@@ -1,4 +1,5 @@
 import {
+	DataHelper,
 	EditorPage,
 	TestAccount,
 	envVariables,
@@ -7,47 +8,51 @@ import {
 } from '@automattic/calypso-e2e';
 import { tags, test } from '../../lib/pw-base';
 
-test.describe( 'Editor: Navbar', { tag: [ tags.GUTENBERG, tags.CALYPSO_PR ] }, () => {
-	const features = envToFeatureKey( envVariables );
-	// @todo Does it make sense to create a `simpleSitePersonalPlanUserEdge` with GB edge?
-	// for now, it will pick up the default `gutenbergAtomicSiteEdgeUser` if edge is set.
-	const accountName = getTestAccountByFeature( features, [
-		{
-			gutenberg: 'stable',
-			siteType: 'simple',
-			accountName: 'simpleSitePersonalPlanUser',
-		},
-	] );
+test.describe(
+	DataHelper.createSuiteTitle( 'Editor: Navbar' ),
+	{ tag: [ tags.GUTENBERG, tags.CALYPSO_PR ] },
+	() => {
+		const features = envToFeatureKey( envVariables );
+		// @todo Does it make sense to create a `simpleSitePersonalPlanUserEdge` with GB edge?
+		// for now, it will pick up the default `gutenbergAtomicSiteEdgeUser` if edge is set.
+		const accountName = getTestAccountByFeature( features, [
+			{
+				gutenberg: 'stable',
+				siteType: 'simple',
+				accountName: 'simpleSitePersonalPlanUser',
+			},
+		] );
 
-	test( 'As a user, I can open the editor and return to the Calypso dashboard', async ( {
-		page,
-	} ) => {
-		let editorPage: EditorPage;
-		let siteSlug: string;
+		test( 'As a user, I can open the editor and return to the Calypso dashboard', async ( {
+			page,
+		} ) => {
+			let editorPage: EditorPage;
+			let siteSlug: string;
 
-		await test.step( 'Authenticate and setup the test', async () => {
-			editorPage = new EditorPage( page );
+			await test.step( 'Authenticate and setup the test', async () => {
+				editorPage = new EditorPage( page );
 
-			const testAccount = new TestAccount( accountName );
-			await testAccount.authenticate( page );
-			siteSlug = testAccount.getSiteURL( { protocol: false } );
+				const testAccount = new TestAccount( accountName );
+				await testAccount.authenticate( page );
+				siteSlug = testAccount.getSiteURL( { protocol: false } );
+			} );
+
+			await test.step( 'Go to the new post page', async () => {
+				await editorPage.visit( 'post', { siteSlug } );
+			} );
+
+			await test.step( 'Return to Calypso dashboard', async () => {
+				const WPAdminBarLocator = page.locator( '#wpadminbar' );
+				const isMobileClassicView =
+					envVariables.VIEWPORT_NAME === 'mobile' && ( await WPAdminBarLocator.isVisible() );
+
+				// The classic WP Admin Bar on mobile viewport doesn't have the
+				// "return" button, so let's not fail this test if it's the case.
+				// See https://github.com/Automattic/wp-calypso/pull/70982
+				if ( ! isMobileClassicView ) {
+					await editorPage.exitEditor();
+				}
+			} );
 		} );
-
-		await test.step( 'Go to the new post page', async () => {
-			await editorPage.visit( 'post', { siteSlug } );
-		} );
-
-		await test.step( 'Return to Calypso dashboard', async () => {
-			const WPAdminBarLocator = page.locator( '#wpadminbar' );
-			const isMobileClassicView =
-				envVariables.VIEWPORT_NAME === 'mobile' && ( await WPAdminBarLocator.isVisible() );
-
-			// The classic WP Admin Bar on mobile viewport doesn't have the
-			// "return" button, so let's not fail this test if it's the case.
-			// See https://github.com/Automattic/wp-calypso/pull/70982
-			if ( ! isMobileClassicView ) {
-				await editorPage.exitEditor();
-			}
-		} );
-	} );
-} );
+	}
+);

--- a/test/e2e/specs/editor/editor__post-advanced-flow.spec.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.spec.ts
@@ -12,198 +12,202 @@ import {
 } from '@automattic/calypso-e2e';
 import { skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 
-test.describe( 'Editor: Advanced Post Flow', { tag: [ tags.GUTENBERG, tags.CALYPSO_PR ] }, () => {
-	skipIfNotTrunk();
+test.describe(
+	DataHelper.createSuiteTitle( 'Editor: Advanced Post Flow' ),
+	{ tag: [ tags.GUTENBERG, tags.CALYPSO_PR ] },
+	() => {
+		skipIfNotTrunk();
 
-	// Authentication setup.
-	const features = envToFeatureKey( envVariables );
-	const accountName = getTestAccountByFeature( features, [
-		{ gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
-	] );
+		// Authentication setup.
+		const features = envToFeatureKey( envVariables );
+		const accountName = getTestAccountByFeature( features, [
+			{ gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
+		] );
 
-	test( 'As a user, I can publish, edit, revert, trash and permanently delete a post', async ( {
-		page,
-		browser,
-	} ) => {
-		// The full post life cycle (publish, edit, revert, trash, delete) does
-		// not fit the default 2-minute budget.
-		test.setTimeout( 300 * 1000 );
+		test( 'As a user, I can publish, edit, revert, trash and permanently delete a post', async ( {
+			page,
+			browser,
+		} ) => {
+			// The full post life cycle (publish, edit, revert, trash, delete) does
+			// not fit the default 2-minute budget.
+			test.setTimeout( 300 * 1000 );
 
-		// Post content setup. The title must be unique across the parallel
-		// projects (chrome, pixel) sharing the same site, and across retries:
-		// the post is located by title on the Posts page list.
-		const postTitle = `Post Life Cycle: ${ DataHelper.getTimestamp() } ${ DataHelper.getRandomPhrase() }`;
-		const originalContent = DataHelper.getRandomPhrase();
-		const additionalContent = 'Updated post content';
+			// Post content setup. The title must be unique across the parallel
+			// projects (chrome, pixel) sharing the same site, and across retries:
+			// the post is located by title on the Posts page list.
+			const postTitle = `Post Life Cycle: ${ DataHelper.getTimestamp() } ${ DataHelper.getRandomPhrase() }`;
+			const originalContent = DataHelper.getRandomPhrase();
+			const additionalContent = 'Updated post content';
 
-		let testAccount: TestAccount;
-		let siteSlug: string;
-		let editorPage: EditorPage;
-		let postsPage: PostsPage;
-		let paragraphBlock: ParagraphBlock;
-		let postURL: URL;
+			let testAccount: TestAccount;
+			let siteSlug: string;
+			let editorPage: EditorPage;
+			let postsPage: PostsPage;
+			let paragraphBlock: ParagraphBlock;
+			let postURL: URL;
 
-		await test.step( 'Authenticate and setup the test', async () => {
-			testAccount = new TestAccount( accountName );
-			await testAccount.authenticate( page );
-			siteSlug = testAccount.getSiteURL( { protocol: false } );
-		} );
+			await test.step( 'Authenticate and setup the test', async () => {
+				testAccount = new TestAccount( accountName );
+				await testAccount.authenticate( page );
+				siteSlug = testAccount.getSiteURL( { protocol: false } );
+			} );
 
-		// Publish post
+			// Publish post
 
-		await test.step( 'Start a new post from the Posts page', async () => {
-			postsPage = new PostsPage( page );
-			await postsPage.visit( { siteSlug } );
-			await postsPage.newPost( { siteSlug } );
-		} );
+			await test.step( 'Start a new post from the Posts page', async () => {
+				postsPage = new PostsPage( page );
+				await postsPage.visit( { siteSlug } );
+				await postsPage.newPost( { siteSlug } );
+			} );
 
-		await test.step( 'Enter post title', async () => {
-			editorPage = new EditorPage( page );
-			await editorPage.enterTitle( postTitle );
-		} );
+			await test.step( 'Enter post title', async () => {
+				editorPage = new EditorPage( page );
+				await editorPage.enterTitle( postTitle );
+			} );
 
-		await test.step( 'Enter post content', async () => {
-			const blockHandle = await editorPage.addBlockFromSidebar(
-				ParagraphBlock.blockName,
-				ParagraphBlock.blockEditorSelector,
-				{ noSearch: true }
-			);
-			paragraphBlock = new ParagraphBlock( blockHandle );
-			await paragraphBlock.enterParagraph( originalContent );
-		} );
+			await test.step( 'Enter post content', async () => {
+				const blockHandle = await editorPage.addBlockFromSidebar(
+					ParagraphBlock.blockName,
+					ParagraphBlock.blockEditorSelector,
+					{ noSearch: true }
+				);
+				paragraphBlock = new ParagraphBlock( blockHandle );
+				await paragraphBlock.enterParagraph( originalContent );
+			} );
 
-		await test.step( 'Publish post', async () => {
-			postURL = await editorPage.publish();
-		} );
+			await test.step( 'Publish post', async () => {
+				postURL = await editorPage.publish();
+			} );
 
-		/**
-		 * Validates post in the same tab to work around an issue with AT caching.
-		 *
-		 * @see https://github.com/Automattic/wp-calypso/pull/67964
-		 *
-		 * Retries due to possible cache issue.
-		 * @see https://github.com/Automattic/wp-calypso/issues/57503
-		 */
-		await test.step( 'Validate post', async () => {
-			await page.goto( postURL.href );
+			/**
+			 * Validates post in the same tab to work around an issue with AT caching.
+			 *
+			 * @see https://github.com/Automattic/wp-calypso/pull/67964
+			 *
+			 * Retries due to possible cache issue.
+			 * @see https://github.com/Automattic/wp-calypso/issues/57503
+			 */
+			await test.step( 'Validate post', async () => {
+				await page.goto( postURL.href );
 
-			await ElementHelper.reloadAndRetry( page, async () => {
-				await ParagraphBlock.validatePublishedContent( page, [ originalContent ] );
+				await ElementHelper.reloadAndRetry( page, async () => {
+					await ParagraphBlock.validatePublishedContent( page, [ originalContent ] );
+				} );
+			} );
+
+			// Edit published post
+
+			await test.step( 'Re-open the published post from the Posts page', async () => {
+				// Redefine the `EditorPage` without the `target`
+				// optional parameter.
+				// This is critical because even AT sites load with
+				// an iframe when the post is opened from the
+				// PostsPage.
+				// See: https://github.com/Automattic/wp-calypso/issues/74925
+				await postsPage.visit( { siteSlug } );
+				await postsPage.clickPost( postTitle );
+				editorPage = new EditorPage( page );
+			} );
+
+			await test.step( 'Editor is shown', async () => {
+				await editorPage.waitUntilLoaded();
+			} );
+
+			await test.step( 'Append additional content', async () => {
+				const blockHandle = await editorPage.addBlockFromSidebar(
+					ParagraphBlock.blockName,
+					ParagraphBlock.blockEditorSelector,
+					{ noSearch: true }
+				);
+				paragraphBlock = new ParagraphBlock( blockHandle );
+				await paragraphBlock.enterParagraph( additionalContent );
+			} );
+
+			await test.step( 'Publish updated post', async () => {
+				postURL = await editorPage.publish();
+			} );
+
+			/**
+			 * Validates post in the same tab to work around an issue with AT caching.
+			 *
+			 * @see https://github.com/Automattic/wp-calypso/pull/67964
+			 *
+			 * Retries due to possible cache issue.
+			 * @see https://github.com/Automattic/wp-calypso/issues/57503
+			 */
+			await test.step( 'Ensure published post contains additional content', async () => {
+				await page.goto( postURL.href );
+
+				await ElementHelper.reloadAndRetry( page, async () => {
+					await ParagraphBlock.validatePublishedContent( page, [
+						originalContent,
+						additionalContent,
+					] );
+				} );
+			} );
+
+			// Revert post to draft
+
+			await test.step( 'Re-open the updated post from the Posts page', async () => {
+				// See: https://github.com/Automattic/wp-calypso/issues/74925
+				await postsPage.visit( { siteSlug } );
+				await postsPage.clickPost( postTitle );
+				editorPage = new EditorPage( page );
+			} );
+
+			await test.step( 'Switch to draft', async () => {
+				await editorPage.unpublish();
+			} );
+
+			await test.step( 'Ensure post is no longer visible', async () => {
+				// It's important that we use another context to confirm that the
+				// page was reverted to draft. It's also important that we DON'T use
+				// a separate context to preview this page when it was previously
+				// published, because it would get cached and wouldn't 404 until the
+				// cache self-invalidates (300s period). This workaround is specific
+				// for Atomic sites. See pMz3w-fZ0 for more info.
+				const tmpContext = await browser.newContext();
+				const tmpPage = await tmpContext.newPage();
+				await tmpPage.goto( postURL.href );
+
+				await tmpPage.waitForSelector( 'body.error404' );
+				await tmpContext.close();
+			} );
+
+			// Trash post
+
+			await test.step( 'Trash post', async () => {
+				await postsPage.visit( { siteSlug } );
+				await postsPage.clickTab( 'Drafts' );
+				await postsPage.clickActionItemForPost( { title: postTitle, action: 'Trash' } );
+			} );
+
+			await test.step( 'Confirmation notice is shown', async () => {
+				const noticeComponent = new WpAdminNoticeComponent( page );
+				await noticeComponent.noticeShown( '1 post moved to the Trash.', {
+					type: 'Updated',
+				} );
+			} );
+
+			// Permanently delete post
+
+			await test.step( 'View trashed posts', async () => {
+				await postsPage.clickTab( 'Trash' );
+			} );
+
+			await test.step( 'Hard trash post', async () => {
+				await postsPage.clickActionItemForPost( {
+					title: postTitle,
+					action: 'Delete Permanently',
+				} );
+			} );
+
+			await test.step( 'Deletion confirmation notice is shown', async () => {
+				const noticeComponent = new WpAdminNoticeComponent( page );
+				await noticeComponent.noticeShown( '1 post permanently deleted', {
+					type: 'Updated',
+				} );
 			} );
 		} );
-
-		// Edit published post
-
-		await test.step( 'Re-open the published post from the Posts page', async () => {
-			// Redefine the `EditorPage` without the `target`
-			// optional parameter.
-			// This is critical because even AT sites load with
-			// an iframe when the post is opened from the
-			// PostsPage.
-			// See: https://github.com/Automattic/wp-calypso/issues/74925
-			await postsPage.visit( { siteSlug } );
-			await postsPage.clickPost( postTitle );
-			editorPage = new EditorPage( page );
-		} );
-
-		await test.step( 'Editor is shown', async () => {
-			await editorPage.waitUntilLoaded();
-		} );
-
-		await test.step( 'Append additional content', async () => {
-			const blockHandle = await editorPage.addBlockFromSidebar(
-				ParagraphBlock.blockName,
-				ParagraphBlock.blockEditorSelector,
-				{ noSearch: true }
-			);
-			paragraphBlock = new ParagraphBlock( blockHandle );
-			await paragraphBlock.enterParagraph( additionalContent );
-		} );
-
-		await test.step( 'Publish updated post', async () => {
-			postURL = await editorPage.publish();
-		} );
-
-		/**
-		 * Validates post in the same tab to work around an issue with AT caching.
-		 *
-		 * @see https://github.com/Automattic/wp-calypso/pull/67964
-		 *
-		 * Retries due to possible cache issue.
-		 * @see https://github.com/Automattic/wp-calypso/issues/57503
-		 */
-		await test.step( 'Ensure published post contains additional content', async () => {
-			await page.goto( postURL.href );
-
-			await ElementHelper.reloadAndRetry( page, async () => {
-				await ParagraphBlock.validatePublishedContent( page, [
-					originalContent,
-					additionalContent,
-				] );
-			} );
-		} );
-
-		// Revert post to draft
-
-		await test.step( 'Re-open the updated post from the Posts page', async () => {
-			// See: https://github.com/Automattic/wp-calypso/issues/74925
-			await postsPage.visit( { siteSlug } );
-			await postsPage.clickPost( postTitle );
-			editorPage = new EditorPage( page );
-		} );
-
-		await test.step( 'Switch to draft', async () => {
-			await editorPage.unpublish();
-		} );
-
-		await test.step( 'Ensure post is no longer visible', async () => {
-			// It's important that we use another context to confirm that the
-			// page was reverted to draft. It's also important that we DON'T use
-			// a separate context to preview this page when it was previously
-			// published, because it would get cached and wouldn't 404 until the
-			// cache self-invalidates (300s period). This workaround is specific
-			// for Atomic sites. See pMz3w-fZ0 for more info.
-			const tmpContext = await browser.newContext();
-			const tmpPage = await tmpContext.newPage();
-			await tmpPage.goto( postURL.href );
-
-			await tmpPage.waitForSelector( 'body.error404' );
-			await tmpContext.close();
-		} );
-
-		// Trash post
-
-		await test.step( 'Trash post', async () => {
-			await postsPage.visit( { siteSlug } );
-			await postsPage.clickTab( 'Drafts' );
-			await postsPage.clickActionItemForPost( { title: postTitle, action: 'Trash' } );
-		} );
-
-		await test.step( 'Confirmation notice is shown', async () => {
-			const noticeComponent = new WpAdminNoticeComponent( page );
-			await noticeComponent.noticeShown( '1 post moved to the Trash.', {
-				type: 'Updated',
-			} );
-		} );
-
-		// Permanently delete post
-
-		await test.step( 'View trashed posts', async () => {
-			await postsPage.clickTab( 'Trash' );
-		} );
-
-		await test.step( 'Hard trash post', async () => {
-			await postsPage.clickActionItemForPost( {
-				title: postTitle,
-				action: 'Delete Permanently',
-			} );
-		} );
-
-		await test.step( 'Deletion confirmation notice is shown', async () => {
-			const noticeComponent = new WpAdminNoticeComponent( page );
-			await noticeComponent.noticeShown( '1 post permanently deleted', {
-				type: 'Updated',
-			} );
-		} );
-	} );
-} );
+	}
+);

--- a/test/e2e/specs/fse/fse__temp-smoke-test.spec.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.spec.ts
@@ -1,4 +1,5 @@
 import {
+	DataHelper,
 	envVariables,
 	SidebarComponent,
 	TestAccount,
@@ -19,7 +20,7 @@ import { tags, test } from '../../lib/pw-base';
  * Keywords: FSE, Full Site Editor, Gutenberg
  */
 test.describe(
-	'Site Editor Smoke Test',
+	DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ),
 	{ tag: [ tags.CALYPSO_PR, tags.GUTENBERG, tags.JETPACK_WPCOM_INTEGRATION ] },
 	() => {
 		const features = envToFeatureKey( envVariables );

--- a/test/e2e/specs/jetpack/social__editor-features.spec.ts
+++ b/test/e2e/specs/jetpack/social__editor-features.spec.ts
@@ -87,7 +87,7 @@ if ( envVariables.JETPACK_TARGET === 'wpcom-deployment' ) {
  * Keywords: Social, Jetpack, Publicize, Editor
  */
 test.describe(
-	'Social: Editor features',
+	DataHelper.createSuiteTitle( 'Social: Editor features' ),
 	{ tag: [ tags.CALYPSO_PR, tags.JETPACK_WPCOM_INTEGRATION ] },
 	() => {
 		for ( const { plan, platform, testAccountName, features, isPrivate } of testCases ) {

--- a/test/e2e/specs/jetpack/social__editor-smoke.spec.ts
+++ b/test/e2e/specs/jetpack/social__editor-smoke.spec.ts
@@ -1,4 +1,5 @@
 import {
+	DataHelper,
 	EditorPage,
 	envToFeatureKey,
 	envVariables,
@@ -13,7 +14,7 @@ import { expect, tags, test } from '../../lib/pw-base';
  * Keywords: Social, Jetpack, Publicize
  */
 test.describe(
-	'Social: Editor Smoke test',
+	DataHelper.createSuiteTitle( 'Social: Editor Smoke test' ),
 	{ tag: [ tags.CALYPSO_PR, tags.JETPACK_WPCOM_INTEGRATION ] },
 	() => {
 		test( 'As a user, I can see the Social UI in the editor', async ( { page } ) => {

--- a/test/e2e/specs/p2/p2__post.spec.ts
+++ b/test/e2e/specs/p2/p2__post.spec.ts
@@ -9,7 +9,7 @@ import { ElementHandle } from 'playwright';
 import { tags, test } from '../../lib/pw-base';
 import type { TestAccount } from '@automattic/calypso-e2e';
 
-test.describe( 'P2: Post', { tag: [ tags.P2 ] }, () => {
+test.describe( DataHelper.createSuiteTitle( 'P2: Post' ), { tag: [ tags.P2 ] }, () => {
 	const postContent = DataHelper.getTimestamp();
 
 	let publishedPostURL: string | undefined;

--- a/test/e2e/specs/plans/plans__signup-business.spec.ts
+++ b/test/e2e/specs/plans/plans__signup-business.spec.ts
@@ -1,10 +1,10 @@
-import { BrowserManager, RestAPIClient } from '@automattic/calypso-e2e';
+import { BrowserManager, DataHelper, RestAPIClient } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
 import { apiCancelAtomicPlan, apiDeleteSite } from '../shared';
 import type { NewSiteResponse, TestAccount } from '@automattic/calypso-e2e';
 
 test.describe(
-	'Plans: Create a WordPress.com/Business site as existing user',
+	DataHelper.createSuiteTitle( 'Plans: Create a WordPress.com/Business site as existing user' ),
 	{
 		tag: [ tags.CALYPSO_RELEASE ],
 	},

--- a/test/e2e/specs/settings/settings__database-phpmyadmin.spec.ts
+++ b/test/e2e/specs/settings/settings__database-phpmyadmin.spec.ts
@@ -1,4 +1,5 @@
 import {
+	DataHelper,
 	TestAccount,
 	envVariables,
 	getTestAccountByFeature,
@@ -16,7 +17,7 @@ import { expect, tags, test } from '../../lib/pw-base';
  * Keywords: Settings, Jetpack, Hosting Configuration, phpMyAdmin
  */
 test.describe(
-	'Settings: Access phpMyAdmin',
+	DataHelper.createSuiteTitle( 'Settings: Access phpMyAdmin' ),
 	{ tag: [ tags.JETPACK_WPCOM_INTEGRATION, tags.CALYPSO_PR ] },
 	() => {
 		const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );

--- a/test/e2e/specs/stats/stats.spec.ts
+++ b/test/e2e/specs/stats/stats.spec.ts
@@ -14,88 +14,92 @@ import { skipIfNotTrunk, tags, test } from '../../lib/pw-base';
  *
  * Keywords: Stats, Jetpack, Odyssey Stats
  */
-test.describe( 'Stats', { tag: [ tags.CALYPSO_PR, tags.JETPACK_WPCOM_INTEGRATION ] }, () => {
-	skipIfNotTrunk();
+test.describe(
+	DataHelper.createSuiteTitle( 'Stats' ),
+	{ tag: [ tags.CALYPSO_PR, tags.JETPACK_WPCOM_INTEGRATION ] },
+	() => {
+		skipIfNotTrunk();
 
-	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
-		{ gutenberg: 'stable', siteType: 'simple', accountName: 'defaultUser' },
-	] );
+		const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
+			{ gutenberg: 'stable', siteType: 'simple', accountName: 'defaultUser' },
+		] );
 
-	test( 'As a user, I can browse the Traffic, Insights and Subscribers stats', async ( {
-		page,
-	} ) => {
-		let statsPage: StatsPage;
+		test( 'As a user, I can browse the Traffic, Insights and Subscribers stats', async ( {
+			page,
+		} ) => {
+			let statsPage: StatsPage;
 
-		await test.step( 'Authenticate and setup the test', async () => {
-			const testAccount = new TestAccount( accountName );
-			await testAccount.authenticate( page );
-		} );
+			await test.step( 'Authenticate and setup the test', async () => {
+				const testAccount = new TestAccount( accountName );
+				await testAccount.authenticate( page );
+			} );
 
-		await test.step( 'Navigate to Stats', async () => {
-			statsPage = new StatsPage( page );
+			await test.step( 'Navigate to Stats', async () => {
+				statsPage = new StatsPage( page );
 
-			if ( envVariables.ATOMIC_VARIATION === 'ecomm-plan' ) {
-				return await statsPage.visit(
-					DataHelper.getAccountSiteURL( accountName, { protocol: false } )
-				);
+				if ( envVariables.ATOMIC_VARIATION === 'ecomm-plan' ) {
+					return await statsPage.visit(
+						DataHelper.getAccountSiteURL( accountName, { protocol: false } )
+					);
+				}
+				const sidebarComponent = new SidebarComponent( page );
+				await sidebarComponent.navigate( 'Stats' );
+			} );
+
+			// Traffic
+
+			await test.step( 'Click on the Traffic tab', async () => {
+				await statsPage.clickTab( 'Traffic' );
+			} );
+
+			// TODO: Check if this step should be skipped.
+			// await test.step( 'Select "Months" stats period', async () => {
+			// 	await statsPage.selectStatsPeriodFromDropdown( 'Months' );
+			// } );
+
+			await test.step( 'Filter traffic activity to Likes', async () => {
+				await statsPage.showStatsOfType( { tab: 'Traffic', type: 'Likes' } );
+			} );
+
+			// Insights
+
+			await test.step( 'Click on Insights tab', async () => {
+				await statsPage.clickTab( 'Insights' );
+			} );
+
+			await test.step( 'Click link to see all annual insights', async () => {
+				await statsPage.clickViewAllAnnualInsights();
+				// Right now, we can't actually verify stats data because if run right after a test site purge,
+				// there may be nothing in there. We just verify that we can get to the page.
+
+				// TODO: find a reliable way to extend this to check data too.
+			} );
+
+			await test.step( 'Go back', async () => {
+				await page.goBack();
+			} );
+
+			// Subscribers
+
+			await test.step( 'Click on Subscribers tab', async () => {
+				await statsPage.clickTab( 'Subscribers' );
+			} );
+
+			// The Store tab is not present unless Business or higher plan is on the site and the
+			// site has gone AT.
+			if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
+				await test.step( 'Click on the Store tab', async () => {
+					await statsPage.clickTab( 'Store' );
+				} );
+
+				await test.step( 'Select "Years" stats period', async () => {
+					await statsPage.selectStatsPeriod( 'Years' );
+				} );
+
+				await test.step( 'Select "Gross sales" stats type', async () => {
+					await statsPage.showStatsOfType( { tab: 'Store', type: 'Gross Sales' } );
+				} );
 			}
-			const sidebarComponent = new SidebarComponent( page );
-			await sidebarComponent.navigate( 'Stats' );
 		} );
-
-		// Traffic
-
-		await test.step( 'Click on the Traffic tab', async () => {
-			await statsPage.clickTab( 'Traffic' );
-		} );
-
-		// TODO: Check if this step should be skipped.
-		// await test.step( 'Select "Months" stats period', async () => {
-		// 	await statsPage.selectStatsPeriodFromDropdown( 'Months' );
-		// } );
-
-		await test.step( 'Filter traffic activity to Likes', async () => {
-			await statsPage.showStatsOfType( { tab: 'Traffic', type: 'Likes' } );
-		} );
-
-		// Insights
-
-		await test.step( 'Click on Insights tab', async () => {
-			await statsPage.clickTab( 'Insights' );
-		} );
-
-		await test.step( 'Click link to see all annual insights', async () => {
-			await statsPage.clickViewAllAnnualInsights();
-			// Right now, we can't actually verify stats data because if run right after a test site purge,
-			// there may be nothing in there. We just verify that we can get to the page.
-
-			// TODO: find a reliable way to extend this to check data too.
-		} );
-
-		await test.step( 'Go back', async () => {
-			await page.goBack();
-		} );
-
-		// Subscribers
-
-		await test.step( 'Click on Subscribers tab', async () => {
-			await statsPage.clickTab( 'Subscribers' );
-		} );
-
-		// The Store tab is not present unless Business or higher plan is on the site and the
-		// site has gone AT.
-		if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
-			await test.step( 'Click on the Store tab', async () => {
-				await statsPage.clickTab( 'Store' );
-			} );
-
-			await test.step( 'Select "Years" stats period', async () => {
-				await statsPage.selectStatsPeriod( 'Years' );
-			} );
-
-			await test.step( 'Select "Gross sales" stats type', async () => {
-				await statsPage.showStatsOfType( { tab: 'Store', type: 'Gross Sales' } );
-			} );
-		}
-	} );
-} );
+	}
+);

--- a/test/e2e/specs/tools/advertising__promote.spec.ts
+++ b/test/e2e/specs/tools/advertising__promote.spec.ts
@@ -1,8 +1,9 @@
+import { DataHelper } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
 import { TEST_IMAGE_PATH } from '../constants';
 
 test.describe(
-	'Blaze Ads: Promote',
+	DataHelper.createSuiteTitle( 'Blaze Ads: Promote' ),
 	{ tag: [ tags.CALYPSO_PR, tags.JETPACK_WPCOM_INTEGRATION ] },
 	() => {
 		test( 'As a WordPress.com free plan user with a simple site, I can promote my content using Jetpack Blaze', async ( {

--- a/test/e2e/specs/tools/marketing__seo.spec.ts
+++ b/test/e2e/specs/tools/marketing__seo.spec.ts
@@ -1,64 +1,71 @@
+import { DataHelper } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
 
-test.describe( 'Marketing: SEO', { tag: [ tags.CALYPSO_PR ] }, () => {
-	test( 'As a WordPress.com business plan user with an atomic site, I can see the SEO settings page', async ( {
-		accountAtomic,
-		helperData,
-		page,
-		pageMarketing,
-	} ) => {
-		const frontPageText = helperData.getRandomPhrase();
-		const externalPreviewText = helperData.getRandomPhrase();
+test.describe(
+	DataHelper.createSuiteTitle( 'Marketing: SEO' ),
+	{ tag: [ tags.CALYPSO_PR ] },
+	() => {
+		test( 'As a WordPress.com business plan user with an atomic site, I can see the SEO settings page', async ( {
+			accountAtomic,
+			helperData,
+			page,
+			pageMarketing,
+		} ) => {
+			const frontPageText = helperData.getRandomPhrase();
+			const externalPreviewText = helperData.getRandomPhrase();
 
-		await test.step( `Given I am authenticated as '${ accountAtomic.accountName }'`, async function () {
-			await accountAtomic.authenticate( page );
+			await test.step( `Given I am authenticated as '${ accountAtomic.accountName }'`, async function () {
+				await accountAtomic.authenticate( page );
+			} );
+
+			await test.step( 'When I visit the Tools > Marketing > Traffic page', async function () {
+				await pageMarketing.visitTab( accountAtomic.getSiteURL( { protocol: false } ), 'traffic' );
+			} );
+
+			await test.step( 'And I enter and verify SEO page title front page structure ', async function () {
+				await pageMarketing.enterPageTitleStructure( 'Front Page', frontPageText );
+			} );
+
+			await test.step( 'Then I can validate and preview the text ', async function () {
+				await pageMarketing.validatePreviewTextForPageStructureCategory( frontPageText );
+			} );
+
+			await test.step( 'When I enter SEO external preview description', async function () {
+				await pageMarketing.enterExternalPreviewText( externalPreviewText );
+			} );
+
+			await test.step( 'And I open SEO preview', async function () {
+				await pageMarketing.clickButton( 'Show Previews' );
+			} );
+
+			await test.step( 'Then I can verify the preview for Facebook', async function () {
+				await pageMarketing.validateExternalPreview( 'Facebook', externalPreviewText );
+			} );
 		} );
 
-		await test.step( 'When I visit the Tools > Marketing > Traffic page', async function () {
-			await pageMarketing.visitTab( accountAtomic.getSiteURL( { protocol: false } ), 'traffic' );
-		} );
+		test( 'As a WordPress.com free plan user with a simple site, I can see the SEO Settings upsell under Jetpack', async ( {
+			accountSimpleSiteFreePlan,
+			page,
+			pageJetpackTraffic,
+		} ) => {
+			await test.step( `Given I am authenticated as '${ accountSimpleSiteFreePlan.accountName }'`, async function () {
+				await accountSimpleSiteFreePlan.authenticate( page );
+			} );
 
-		await test.step( 'And I enter and verify SEO page title front page structure ', async function () {
-			await pageMarketing.enterPageTitleStructure( 'Front Page', frontPageText );
-		} );
+			await test.step( 'When I visit the Jetpack > Traffic page', async function () {
+				await pageJetpackTraffic.visit(
+					accountSimpleSiteFreePlan.getSiteURL( { protocol: false } )
+				);
+			} );
 
-		await test.step( 'Then I can validate and preview the text ', async function () {
-			await pageMarketing.validatePreviewTextForPageStructureCategory( frontPageText );
-		} );
+			await test.step( 'Then I see the Jetpack Traffic page', async function () {
+				await expect( pageJetpackTraffic.trafficHeading ).toBeVisible();
+			} );
 
-		await test.step( 'When I enter SEO external preview description', async function () {
-			await pageMarketing.enterExternalPreviewText( externalPreviewText );
+			await test.step( 'And I see the SEO upsell', async function () {
+				await expect( pageJetpackTraffic.seoHeading ).toBeVisible();
+				await expect( pageJetpackTraffic.seoUpsellLink ).toBeVisible();
+			} );
 		} );
-
-		await test.step( 'And I open SEO preview', async function () {
-			await pageMarketing.clickButton( 'Show Previews' );
-		} );
-
-		await test.step( 'Then I can verify the preview for Facebook', async function () {
-			await pageMarketing.validateExternalPreview( 'Facebook', externalPreviewText );
-		} );
-	} );
-
-	test( 'As a WordPress.com free plan user with a simple site, I can see the SEO Settings upsell under Jetpack', async ( {
-		accountSimpleSiteFreePlan,
-		page,
-		pageJetpackTraffic,
-	} ) => {
-		await test.step( `Given I am authenticated as '${ accountSimpleSiteFreePlan.accountName }'`, async function () {
-			await accountSimpleSiteFreePlan.authenticate( page );
-		} );
-
-		await test.step( 'When I visit the Jetpack > Traffic page', async function () {
-			await pageJetpackTraffic.visit( accountSimpleSiteFreePlan.getSiteURL( { protocol: false } ) );
-		} );
-
-		await test.step( 'Then I see the Jetpack Traffic page', async function () {
-			await expect( pageJetpackTraffic.trafficHeading ).toBeVisible();
-		} );
-
-		await test.step( 'And I see the SEO upsell', async function () {
-			await expect( pageJetpackTraffic.seoHeading ).toBeVisible();
-			await expect( pageJetpackTraffic.seoUpsellLink ).toBeVisible();
-		} );
-	} );
-} );
+	}
+);

--- a/test/e2e/specs/users/invite__new-user.spec.ts
+++ b/test/e2e/specs/users/invite__new-user.spec.ts
@@ -10,178 +10,182 @@ import { expect, skipIfMailosaurLimitReached, skipIfNotTrunk, tags, test } from 
 import { apiCloseAccount, recordAccountLeakMarker } from '../shared';
 import type { NewUserResponse } from '@automattic/calypso-e2e';
 
-test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
-	skipIfNotTrunk();
-	skipIfMailosaurLimitReached();
-	const role = 'Editor';
-	const testUser = DataHelper.getNewTestUser( {
-		useMailosaur: true,
-		usernamePrefix: 'invited',
-	} );
-
-	let userManagementRevampFeature = false;
-	let acceptInviteLink: string;
-
-	// Accounts created during the run, closed via API in afterAll as a guaranteed
-	// teardown. The in-body UI close below stays as product coverage; the API close
-	// is the safety net for any run where the UI close did not happen. If the UI
-	// close did run, this account's token is dead and apiCloseAccount is a safe
-	// no-op (its existence probe writes no leak marker).
-	const accountsToCleanup: {
-		user: NewUserResponse[ 'body' ];
-		password: string;
-		email: string;
-	}[] = [];
-
-	test( 'As a WordPress.com user, I can invite a new user to my site, they can accept the invite and sign up, then I can remove them', async ( {
-		page,
-		componentSidebar,
-		clientEmail,
-		pageIncognito,
-		pagePeople,
-		pageAddPeople,
-		pageInvitePeople,
-		accountPreRelease,
-	} ) => {
-		await test.step( 'Given I am logged in as a site owner', async function () {
-			await accountPreRelease.authenticate( page );
-
-			userManagementRevampFeature = await page.evaluate(
-				"configData.features['user-management-revamp']"
-			);
+test.describe(
+	DataHelper.createSuiteTitle( 'Invite: New User' ),
+	{ tag: [ tags.CALYPSO_PR ] },
+	() => {
+		skipIfNotTrunk();
+		skipIfMailosaurLimitReached();
+		const role = 'Editor';
+		const testUser = DataHelper.getNewTestUser( {
+			useMailosaur: true,
+			usernamePrefix: 'invited',
 		} );
 
-		await test.step( 'When I navigate to Users > All Users', async function () {
-			await componentSidebar.navigate( 'Users', 'All Users' );
-		} );
+		let userManagementRevampFeature = false;
+		let acceptInviteLink: string;
 
-		await test.step( `And I invite a new user with role ${ role }`, async function () {
-			if ( userManagementRevampFeature ) {
-				await pagePeople.clickAddTeamMember();
-				await pageAddPeople.addTeamMember( {
-					email: testUser.email,
-					role: role.toLowerCase() as RoleValue,
-					message: `Test invite for role of ${ role }`,
-				} );
-			} else {
-				await pagePeople.clickInviteUser();
-				await pageInvitePeople.invite( {
-					email: testUser.email,
-					role: role as Roles,
-					message: `Test invite for role of ${ role }`,
-				} );
-			}
-		} );
+		// Accounts created during the run, closed via API in afterAll as a guaranteed
+		// teardown. The in-body UI close below stays as product coverage; the API close
+		// is the safety net for any run where the UI close did not happen. If the UI
+		// close did run, this account's token is dead and apiCloseAccount is a safe
+		// no-op (its existence probe writes no leak marker).
+		const accountsToCleanup: {
+			user: NewUserResponse[ 'body' ];
+			password: string;
+			email: string;
+		}[] = [];
 
-		await test.step( 'When I navigate to Users > All Users', async function () {
-			await componentSidebar.navigate( 'Users', 'All Users' );
-			if ( ! userManagementRevampFeature ) {
-				await pagePeople.clickTab( 'Invites' );
-			}
-			await pagePeople.clickViewAllIfAvailable();
-		} );
+		test( 'As a WordPress.com user, I can invite a new user to my site, they can accept the invite and sign up, then I can remove them', async ( {
+			page,
+			componentSidebar,
+			clientEmail,
+			pageIncognito,
+			pagePeople,
+			pageAddPeople,
+			pageInvitePeople,
+			accountPreRelease,
+		} ) => {
+			await test.step( 'Given I am logged in as a site owner', async function () {
+				await accountPreRelease.authenticate( page );
 
-		await test.step( 'Then I can see the invite is pending', async function () {
-			await pagePeople.waitForInvitation( testUser.email );
-		} );
-
-		await test.step( 'When the invited user checks their email', async function () {
-			const message = await clientEmail.getLastMatchingMessage( {
-				inboxId: testUser.inboxId,
-				sentTo: testUser.email,
-			} );
-			const links = await clientEmail.getLinksFromMessage( message );
-			acceptInviteLink = links.find( ( link: string ) =>
-				link.includes( 'accept-invite' )
-			) as string;
-			expect( acceptInviteLink ).toBeDefined();
-		} );
-
-		let signedUpUsername: string;
-
-		await test.step( 'And they sign up from the invite link', async function () {
-			await pageIncognito.goto( acceptInviteLink );
-
-			const userSignupPage = new UserSignupPage( pageIncognito.getPage() );
-			const signUpResponse = await userSignupPage.signupThroughInvite( testUser.email );
-
-			const created = signUpResponse.body;
-			// Queue teardown before asserting the rest of the identity: a created
-			// account must be scheduled for cleanup even if the response is partial.
-			// Otherwise a failed assertion below aborts the test before the in-body
-			// UI close, and the account leaks with no teardown and no leak marker.
-			accountsToCleanup.push( {
-				user: created,
-				password: testUser.password,
-				email: testUser.email,
+				userManagementRevampFeature = await page.evaluate(
+					"configData.features['user-management-revamp']"
+				);
 			} );
 
-			// Runtime guards: the signup response is untyped JSON, so the declared
-			// type is not a wire guarantee. Require the identity the afterAll teardown
-			// consumes to be truthy, not merely defined: an empty/null token passes
-			// `toBeDefined` but RestAPIClient treats it as absent and would fetch a
-			// fresh token from credentials, which fails on an already-closed account
-			// and records a false leak marker. Failing here aborts before the in-body
-			// UI close, so the queued account stays open and the fallback is correct.
-			expect( created?.user_id ).toBeTruthy();
-			expect( created?.bearer_token ).toBeTruthy();
+			await test.step( 'When I navigate to Users > All Users', async function () {
+				await componentSidebar.navigate( 'Users', 'All Users' );
+			} );
 
-			signedUpUsername = created.username;
-			expect( signedUpUsername ).toBeDefined();
+			await test.step( `And I invite a new user with role ${ role }`, async function () {
+				if ( userManagementRevampFeature ) {
+					await pagePeople.clickAddTeamMember();
+					await pageAddPeople.addTeamMember( {
+						email: testUser.email,
+						role: role.toLowerCase() as RoleValue,
+						message: `Test invite for role of ${ role }`,
+					} );
+				} else {
+					await pagePeople.clickInviteUser();
+					await pageInvitePeople.invite( {
+						email: testUser.email,
+						role: role as Roles,
+						message: `Test invite for role of ${ role }`,
+					} );
+				}
+			} );
+
+			await test.step( 'When I navigate to Users > All Users', async function () {
+				await componentSidebar.navigate( 'Users', 'All Users' );
+				if ( ! userManagementRevampFeature ) {
+					await pagePeople.clickTab( 'Invites' );
+				}
+				await pagePeople.clickViewAllIfAvailable();
+			} );
+
+			await test.step( 'Then I can see the invite is pending', async function () {
+				await pagePeople.waitForInvitation( testUser.email );
+			} );
+
+			await test.step( 'When the invited user checks their email', async function () {
+				const message = await clientEmail.getLastMatchingMessage( {
+					inboxId: testUser.inboxId,
+					sentTo: testUser.email,
+				} );
+				const links = await clientEmail.getLinksFromMessage( message );
+				acceptInviteLink = links.find( ( link: string ) =>
+					link.includes( 'accept-invite' )
+				) as string;
+				expect( acceptInviteLink ).toBeDefined();
+			} );
+
+			let signedUpUsername: string;
+
+			await test.step( 'And they sign up from the invite link', async function () {
+				await pageIncognito.goto( acceptInviteLink );
+
+				const userSignupPage = new UserSignupPage( pageIncognito.getPage() );
+				const signUpResponse = await userSignupPage.signupThroughInvite( testUser.email );
+
+				const created = signUpResponse.body;
+				// Queue teardown before asserting the rest of the identity: a created
+				// account must be scheduled for cleanup even if the response is partial.
+				// Otherwise a failed assertion below aborts the test before the in-body
+				// UI close, and the account leaks with no teardown and no leak marker.
+				accountsToCleanup.push( {
+					user: created,
+					password: testUser.password,
+					email: testUser.email,
+				} );
+
+				// Runtime guards: the signup response is untyped JSON, so the declared
+				// type is not a wire guarantee. Require the identity the afterAll teardown
+				// consumes to be truthy, not merely defined: an empty/null token passes
+				// `toBeDefined` but RestAPIClient treats it as absent and would fetch a
+				// fresh token from credentials, which fails on an already-closed account
+				// and records a false leak marker. Failing here aborts before the in-body
+				// UI close, so the queued account stays open and the fallback is correct.
+				expect( created?.user_id ).toBeTruthy();
+				expect( created?.bearer_token ).toBeTruthy();
+
+				signedUpUsername = created.username;
+				expect( signedUpUsername ).toBeDefined();
+			} );
+
+			await test.step( 'Then they see a welcome banner after signup', async function () {
+				await expect(
+					pageIncognito.getPage().getByText( `You're now an ${ role } of: ` )
+				).toBeVisible();
+			} );
+
+			await test.step( 'When I navigate back to Users > All Users', async function () {
+				await componentSidebar.navigate( 'Users', 'All Users' );
+			} );
+
+			await test.step( 'Then I can see the invited user part of the team', async function () {
+				await pagePeople.visitTeamMemberUserDetails( signedUpUsername );
+			} );
+
+			await test.step( 'Then I can remove the team member from the site', async function () {
+				await pagePeople.removeUserFromSite( signedUpUsername );
+			} );
+
+			await test.step( 'And the invited user closes their account', async function () {
+				const closeAccountFlow = new CloseAccountFlow( pageIncognito.getPage() );
+				await closeAccountFlow.closeAccount();
+			} );
 		} );
 
-		await test.step( 'Then they see a welcome banner after signup', async function () {
-			await expect(
-				pageIncognito.getPage().getByText( `You're now an ${ role } of: ` )
-			).toBeVisible();
-		} );
-
-		await test.step( 'When I navigate back to Users > All Users', async function () {
-			await componentSidebar.navigate( 'Users', 'All Users' );
-		} );
-
-		await test.step( 'Then I can see the invited user part of the team', async function () {
-			await pagePeople.visitTeamMemberUserDetails( signedUpUsername );
-		} );
-
-		await test.step( 'Then I can remove the team member from the site', async function () {
-			await pagePeople.removeUserFromSite( signedUpUsername );
-		} );
-
-		await test.step( 'And the invited user closes their account', async function () {
-			const closeAccountFlow = new CloseAccountFlow( pageIncognito.getPage() );
-			await closeAccountFlow.closeAccount();
-		} );
-	} );
-
-	test.afterAll( async function () {
-		for ( const acct of accountsToCleanup ) {
-			if ( ! acct.user?.user_id ) {
-				// The account was queued (created) but the signup response carried no
-				// user ID, so it cannot be closed by ID. Record a leak marker keyed by
-				// email so CI still surfaces it rather than dropping it silently.
-				recordAccountLeakMarker( {
-					username: acct.user?.username ?? '',
+		test.afterAll( async function () {
+			for ( const acct of accountsToCleanup ) {
+				if ( ! acct.user?.user_id ) {
+					// The account was queued (created) but the signup response carried no
+					// user ID, so it cannot be closed by ID. Record a leak marker keyed by
+					// email so CI still surfaces it rather than dropping it silently.
+					recordAccountLeakMarker( {
+						username: acct.user?.username ?? '',
+						email: acct.email,
+						error: 'Signup response missing user_id; account created but not closeable by ID.',
+					} );
+					continue;
+				}
+				// Prefer the bearer token captured at signup; fall back to the signup
+				// credentials so an account whose response omitted a token is still torn
+				// down. RestAPIClient fetches a fresh token from the credentials, which
+				// works because such an account never reached the in-body UI close and is
+				// therefore still open. apiCloseAccount records a leak marker when it
+				// cannot confirm closure, so a leak is never silently dropped.
+				const restAPIClient = new RestAPIClient(
+					{ username: acct.user.username ?? acct.email, password: acct.password },
+					acct.user.bearer_token
+				);
+				await apiCloseAccount( restAPIClient, {
+					userID: acct.user.user_id,
+					username: acct.user.username,
 					email: acct.email,
-					error: 'Signup response missing user_id; account created but not closeable by ID.',
 				} );
-				continue;
 			}
-			// Prefer the bearer token captured at signup; fall back to the signup
-			// credentials so an account whose response omitted a token is still torn
-			// down. RestAPIClient fetches a fresh token from the credentials, which
-			// works because such an account never reached the in-body UI close and is
-			// therefore still open. apiCloseAccount records a leak marker when it
-			// cannot confirm closure, so a leak is never silently dropped.
-			const restAPIClient = new RestAPIClient(
-				{ username: acct.user.username ?? acct.email, password: acct.password },
-				acct.user.bearer_token
-			);
-			await apiCloseAccount( restAPIClient, {
-				userID: acct.user.user_id,
-				username: acct.user.username,
-				email: acct.email,
-			} );
-		}
-	} );
-} );
+		} );
+	}
+);

--- a/test/e2e/specs/users/invite__revoke.spec.ts
+++ b/test/e2e/specs/users/invite__revoke.spec.ts
@@ -2,7 +2,7 @@ import { DataHelper, RestAPIClient, SecretsManager } from '@automattic/calypso-e
 import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
 
 test.describe(
-	'Invite: Revoke',
+	DataHelper.createSuiteTitle( 'Invite: Revoke' ),
 	{ tag: [ tags.CALYPSO_PR, tags.CALYPSO_RELEASE, tags.DESKTOP_ONLY ] },
 	() => {
 		skipIfMailosaurLimitReached();


### PR DESCRIPTION
## Proposed Changes

Wrap the top-level `test.describe()` title in `DataHelper.createSuiteTitle( … )` in 20 migrated Playwright specs, restoring the `(ENV: <variation>)` suffix (e.g. `(Atomic: wp-beta)`) that these suites carried before the Jest → Playwright migration.

## Why are these changes being made?

The suffix allows distinguishins runs of the same suite across at a glance. It was erroneously dropped during the migration.

## Testing Instructions

- `yarn eslint` and `test/e2e` `tsc --noEmit` pass on the changed files.
- No behavioral change to the tests themselves; only the reported suite title changes. In a Jetpack Atomic run (`JETPACK_TARGET=wpcom-deployment`, `TEST_ON_ATOMIC=true`, no explicit `RUN_ID`), the affected suites report as `… (Atomic: <variation>)`.
