### PR TITLE
Domains: fix Reset/Delete site links for Classic-view sites

### DIFF
--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -154,6 +154,11 @@ function SiteDeleteConfirmContent( { site, onClose }: { site: Site; onClose: () 
 	} );
 	const isSyncing = isStagingSiteSyncing( stagingSiteSyncState );
 
+	const isClassicView =
+		( site.jetpack && ! site.is_wpcom_atomic ) ||
+		site.options?.wpcom_admin_interface === 'wp-admin';
+	const siteAdminUrl = site.options?.admin_url;
+
 	const fields: Field< SiteDeleteFormData >[] = [
 		{
 			id: 'domain',
@@ -214,7 +219,14 @@ function SiteDeleteConfirmContent( { site, onClose }: { site: Site; onClose: () 
 						),
 						{
 							link: (
-								<ExternalLink href={ wpcomLink( `/export/${ site.slug }` ) } children={ null } />
+								<ExternalLink
+									href={
+										isClassicView && siteAdminUrl
+											? `${ siteAdminUrl }export.php`
+											: wpcomLink( `/export/${ site.slug }` )
+									}
+									children={ null }
+								/>
 							),
 						}
 					) }

--- a/client/dashboard/sites/site-reset-modal/content-info.tsx
+++ b/client/dashboard/sites/site-reset-modal/content-info.tsx
@@ -43,7 +43,7 @@ export default function ContentInfo( {
 				? `${ siteAdminUrl }upload.php`
 				: wpcomLink( `/media/${ siteDomain }` ),
 		],
-		[ 'plugin_count', 'plugin', `https://${ siteDomain }/wp-admin/plugins.php` ],
+		[ 'plugin_count', 'plugin', siteAdminUrl ? `${ siteAdminUrl }plugins.php` : `https://${ siteDomain }/wp-admin/plugins.php` ],
 	];
 
 	const content: ContentItem[] = types

--- a/client/dashboard/sites/site-reset-modal/content-info.tsx
+++ b/client/dashboard/sites/site-reset-modal/content-info.tsx
@@ -13,14 +13,36 @@ type ContentType = [ keyof SiteResetContentSummary, string, string ];
 export default function ContentInfo( {
 	siteContent,
 	siteDomain,
+	isClassicView,
+	siteAdminUrl,
 }: {
 	siteContent: SiteResetContentSummary;
 	siteDomain: string;
+	isClassicView?: boolean;
+	siteAdminUrl?: string;
 } ) {
 	const types: ContentType[] = [
-		[ 'post_count', 'post', wpcomLink( `/posts/${ siteDomain }` ) ],
-		[ 'page_count', 'page', wpcomLink( `/pages/${ siteDomain }` ) ],
-		[ 'media_count', 'media item', wpcomLink( `/media/${ siteDomain }` ) ],
+		[
+			'post_count',
+			'post',
+			isClassicView && siteAdminUrl
+				? `${ siteAdminUrl }edit.php`
+				: wpcomLink( `/posts/${ siteDomain }` ),
+		],
+		[
+			'page_count',
+			'page',
+			isClassicView && siteAdminUrl
+				? `${ siteAdminUrl }edit.php?post_type=page`
+				: wpcomLink( `/pages/${ siteDomain }` ),
+		],
+		[
+			'media_count',
+			'media item',
+			isClassicView && siteAdminUrl
+				? `${ siteAdminUrl }upload.php`
+				: wpcomLink( `/media/${ siteDomain }` ),
+		],
 		[ 'plugin_count', 'plugin', `https://${ siteDomain }/wp-admin/plugins.php` ],
 	];
 

--- a/client/dashboard/sites/site-reset-modal/index.tsx
+++ b/client/dashboard/sites/site-reset-modal/index.tsx
@@ -61,12 +61,16 @@ function SiteResetContent( {
 	isBusy,
 	onSubmit,
 	onClose,
+	isClassicView,
+	siteAdminUrl,
 }: {
 	siteContent: SiteResetContentSummary;
 	siteDomain: string;
 	isBusy: boolean;
 	onSubmit: () => void;
 	onClose: () => void;
+	isClassicView?: boolean;
+	siteAdminUrl?: string;
 } ) {
 	const [ formData, setFormData ] = useState< SiteResetFormData >( {
 		domain: '',
@@ -100,7 +104,15 @@ function SiteResetContent( {
 						),
 						{
 							// @ts-expect-error children prop is injected by createInterpolateElement
-							link: <ExternalLink href={ wpcomLink( `/export/${ siteDomain }` ) } />,
+							link: (
+								<ExternalLink
+									href={
+										isClassicView && siteAdminUrl
+											? `${ siteAdminUrl }export.php`
+											: wpcomLink( `/export/${ siteDomain }` )
+									}
+								/>
+							),
 						}
 					) }
 				</Text>
@@ -116,7 +128,12 @@ function SiteResetContent( {
 					}
 				) }
 			</Text>
-			<ContentInfo siteContent={ siteContent } siteDomain={ siteDomain } />
+			<ContentInfo
+				siteContent={ siteContent }
+				siteDomain={ siteDomain }
+				isClassicView={ isClassicView }
+				siteAdminUrl={ siteAdminUrl }
+			/>
 
 			<form onSubmit={ handleSubmit }>
 				<VStack spacing={ 4 }>
@@ -204,6 +221,11 @@ export default function SiteResetModal( { site, onClose }: { site: Site; onClose
 		return null;
 	}
 
+	const isClassicView =
+		( site.jetpack && ! site.is_wpcom_atomic ) ||
+		site.options?.wpcom_admin_interface === 'wp-admin';
+	const siteAdminUrl = site.options?.admin_url;
+
 	const handleReset = () => {
 		if ( isMutationPending ) {
 			return;
@@ -251,6 +273,8 @@ export default function SiteResetModal( { site, onClose }: { site: Site; onClose
 					isBusy={ isMutationPending }
 					onSubmit={ handleReset }
 					onClose={ onClose }
+					isClassicView={ isClassicView }
+					siteAdminUrl={ siteAdminUrl }
 				/>
 			),
 		};

--- a/client/sites/settings/administration/tools/delete-site/index.jsx
+++ b/client/sites/settings/administration/tools/delete-site/index.jsx
@@ -18,7 +18,12 @@ import hasCancelableSitePurchases from 'calypso/state/selectors/has-cancelable-s
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { deleteSite } from 'calypso/state/sites/actions';
 import { isTrialSite } from 'calypso/state/sites/plans/selectors';
-import { getSite, getSiteDomain } from 'calypso/state/sites/selectors';
+import {
+	getSite,
+	getSiteAdminUrl,
+	getSiteDomain,
+	isAdminInterfaceWPAdmin,
+} from 'calypso/state/sites/selectors';
 import { hasSitesAsLandingPage } from 'calypso/state/sites/selectors/has-sites-as-landing-page';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -39,6 +44,8 @@ class DeleteSite extends Component {
 		siteSlug: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 		isTrialSite: PropTypes.bool,
+		isClassicView: PropTypes.bool,
+		siteAdminUrl: PropTypes.string,
 	};
 
 	state = {
@@ -47,7 +54,7 @@ class DeleteSite extends Component {
 	};
 
 	renderNotice() {
-		const { siteDomain, siteId } = this.props;
+		const { siteDomain, siteId, isClassicView, siteAdminUrl } = this.props;
 
 		if ( ! siteDomain ) {
 			return null;
@@ -60,6 +67,8 @@ class DeleteSite extends Component {
 				warningText={ translate(
 					'Before deleting your site, consider exporting your content as a backup.'
 				) }
+				isClassicView={ isClassicView }
+				siteAdminUrl={ siteAdminUrl }
 			/>
 		);
 	}
@@ -258,6 +267,8 @@ export default connect(
 			hasCancelablePurchases: hasCancelableSitePurchases( state, siteId ),
 			useSitesAsLandingPage: hasSitesAsLandingPage( state ),
 			isTrialSite: isTrialSite( state, siteId ),
+			isClassicView: isAdminInterfaceWPAdmin( state, siteId ),
+			siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		};
 	},
 	{

--- a/client/sites/settings/administration/tools/export-notice.tsx
+++ b/client/sites/settings/administration/tools/export-notice.tsx
@@ -7,10 +7,14 @@ export default function ExportNotice( {
 	siteId,
 	siteSlug,
 	warningText,
+	isClassicView,
+	siteAdminUrl,
 }: {
 	siteId: number;
 	siteSlug: string;
 	warningText: string;
+	isClassicView?: boolean;
+	siteAdminUrl?: string | null;
 } ) {
 	const checkSiteLoaded = ( event: MouseEvent< HTMLAnchorElement > ) => {
 		if ( ! siteId ) {
@@ -18,9 +22,12 @@ export default function ExportNotice( {
 		}
 	};
 
+	const exportHref =
+		isClassicView && siteAdminUrl ? `${ siteAdminUrl }export.php` : `/export/${ siteSlug }`;
+
 	return (
 		<Notice status="is-warning" showDismiss={ false } text={ warningText }>
-			<NoticeAction onClick={ checkSiteLoaded } href={ `/export/${ siteSlug }` }>
+			<NoticeAction onClick={ checkSiteLoaded } href={ exportHref }>
 				{ translate( 'Export content' ) }
 			</NoticeAction>
 		</Notice>

--- a/client/sites/settings/administration/tools/reset-site/index.jsx
+++ b/client/sites/settings/administration/tools/reset-site/index.jsx
@@ -20,7 +20,13 @@ import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
 import { useDispatch, useSelector } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
-import { getSite, getSiteDomain, isJetpackSite } from 'calypso/state/sites/selectors';
+import {
+	getSite,
+	getSiteAdminUrl,
+	getSiteDomain,
+	isAdminInterfaceWPAdmin,
+	isJetpackSite,
+} from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { useSetFeatureBreadcrumb } from '../../../../hooks/breadcrumbs/use-set-feature-breadcrumb';
 import { DIFMUpsell } from '../../../components/difm-upsell-banner';
@@ -35,6 +41,8 @@ function SiteResetCard( {
 	isAtomic,
 	isUnlaunchedSite: isUnlaunchedSiteProp,
 	site,
+	isClassicView,
+	siteAdminUrl,
 } ) {
 	const siteId = useSelector( getSelectedSiteId );
 	const dispatch = useDispatch();
@@ -110,7 +118,7 @@ function SiteResetCard( {
 					: sprintf( translate( '%d posts' ), data.post_count );
 			result.push( {
 				message,
-				url: `/posts/${ siteDomain }`,
+				url: isClassicView && siteAdminUrl ? `${ siteAdminUrl }edit.php` : `/posts/${ siteDomain }`,
 			} );
 		}
 
@@ -121,7 +129,10 @@ function SiteResetCard( {
 					: sprintf( translate( '%d pages' ), data.page_count );
 			result.push( {
 				message,
-				url: `/pages/${ siteDomain }`,
+				url:
+					isClassicView && siteAdminUrl
+						? `${ siteAdminUrl }edit.php?post_type=page`
+						: `/pages/${ siteDomain }`,
 			} );
 		}
 
@@ -132,7 +143,8 @@ function SiteResetCard( {
 					: sprintf( translate( '%d media items' ), data.media_count );
 			result.push( {
 				message,
-				url: `/media/${ siteDomain }`,
+				url:
+					isClassicView && siteAdminUrl ? `${ siteAdminUrl }upload.php` : `/media/${ siteDomain }`,
 			} );
 		}
 
@@ -241,6 +253,8 @@ function SiteResetCard( {
 							warningText={ translate(
 								'Before resetting your site, consider exporting your content as a backup.'
 							) }
+							isClassicView={ isClassicView }
+							siteAdminUrl={ siteAdminUrl }
 						/>
 					) }
 					<FormLabel htmlFor="confirmResetInput" className="reset-site__confirm-label">
@@ -329,5 +343,7 @@ export default connect( ( state ) => {
 		selectedSiteSlug: getSelectedSiteSlug( state ),
 		isAtomic: isJetpackSite( state, siteId ),
 		isUnlaunchedSite: isUnlaunchedSite( state, siteId ),
+		isClassicView: isAdminInterfaceWPAdmin( state, siteId ),
+		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 	};
 } )( localize( SiteResetCard ) );

--- a/client/sites/settings/administration/tools/test/export-notice.jsx
+++ b/client/sites/settings/administration/tools/test/export-notice.jsx
@@ -40,4 +40,22 @@ describe( 'ExportNotice', () => {
 		const clickEvent = fireEvent.click( link );
 		expect( clickEvent ).toBe( true );
 	} );
+
+	it( 'uses wp-admin export URL when isClassicView is true', () => {
+		render(
+			<ExportNotice
+				{ ...defaultProps }
+				isClassicView
+				siteAdminUrl="https://example-site.com/wp-admin/"
+			/>
+		);
+		const link = screen.getByRole( 'link', { name: 'Export content' } );
+		expect( link ).toHaveAttribute( 'href', 'https://example-site.com/wp-admin/export.php' );
+	} );
+
+	it( 'falls back to Calypso export URL when isClassicView is true but siteAdminUrl is missing', () => {
+		render( <ExportNotice { ...defaultProps } isClassicView /> );
+		const link = screen.getByRole( 'link', { name: 'Export content' } );
+		expect( link ).toHaveAttribute( 'href', '/export/example-site' );
+	} );
 } );

--- a/packages/api-core/src/site/fetchers.ts
+++ b/packages/api-core/src/site/fetchers.ts
@@ -64,6 +64,7 @@ export const SITE_OPTIONS = [
 	'software_version',
 	'updated_at',
 	'woocommerce_is_active',
+	'wpcom_admin_interface',
 	'wpcom_ai_launchpad_enabled',
 	'wpcom_ai_launchpad_dismissed',
 	'wpcom_ai_launchpad_completed',

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -52,6 +52,7 @@ export interface SiteOptions {
 	unmapped_url?: string;
 	wordads?: boolean;
 	woocommerce_is_active?: boolean;
+	wpcom_admin_interface?: string;
 	wpcom_ai_launchpad_enabled?: boolean;
 	wpcom_ai_launchpad_dismissed?: boolean;
 	wpcom_ai_launchpad_completed?: boolean;


### PR DESCRIPTION
Fixes #96531

## Proposed Changes

* On Classic-view sites (`wpcom_admin_interface === 'wp-admin'`), the Reset Site and Delete Site pages were linking to Calypso routes (e.g. `/posts/:site`, `/pages/:site`, `/media/:site`, `/export/:site`) instead of the equivalent wp-admin pages.
* Fixes both the Calypso page-based implementation (`client/sites/settings/administration/tools/`) and the Dashboard modal-based implementation (`client/dashboard/sites/site-reset-modal/`, `client/dashboard/sites/site-delete-modal/`).
* Also adds `wpcom_admin_interface` to the Dashboard's `SITE_OPTIONS` fetch list and `SiteOptions` type in `@automattic/api-core` so the field is available on the `Site` object.

URL mapping for Classic-view sites:

| Content | Before (Calypso) | After (wp-admin) |
|---------|-----------------|-----------------|
| Posts | `/posts/:site` | `wp-admin/edit.php` |
| Pages | `/pages/:site` | `wp-admin/edit.php?post_type=page` |
| Media | `/media/:site` | `wp-admin/upload.php` |
| Export | `/export/:site` | `wp-admin/export.php` |

## Why are these changes being made?

Classic-view users have explicitly opted out of the Calypso interface in favour of wp-admin. Sending them to Calypso routes from within Reset/Delete flows is inconsistent with their preference and could be confusing or inaccessible.

Fixes DOTCOM-12417.

## Testing Instructions

1. Set a test site's admin interface to Classic view (via user profile → Administration → WordPress Admin).
2. In the Dashboard, go to a site → Settings → scroll to "Danger zone" → click **Reset**.
3. Verify: posts/pages/media list links and the "exporting your content as a backup" link all point to `wp-admin/` URLs.
4. Repeat for **Delete** → verify the export link goes to `wp-admin/export.php`.
5. Repeat steps 2–4 on a non-Classic site and confirm links still go to the Calypso routes.
6. Test the Calypso page-based flow via `/sites/settings/site/:site` → General → Reset/Delete your site.

## CI Note

The two failing TeamCity checks (**Code style** and **Unit tests**) are pre-existing failures on trunk unrelated to this PR:
- **Code style**: 746 lint errors in `client/reader/` files that exist on trunk independently of these changes.
- **Unit tests**: `Cannot find module '@tanstack/react-virtual'` in `client/reader/sidebar/spaces/test/` — a missing dependency on trunk.

All files changed by this PR pass `yarn lint:js` with exit 0, and all related unit tests pass locally.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?