### PR TITLE
Polyfills: exclude unused web.immediate (setImmediate) polyfill

### DIFF
--- a/packages/calypso-babel-config/presets/default.js
+++ b/packages/calypso-babel-config/presets/default.js
@@ -22,7 +22,8 @@ module.exports = ( api, opts ) => ( {
 				modules: modulesOption( opts ),
 				useBuiltIns: opts.useBuiltIns ? opts.useBuiltIns : 'entry',
 				// Exclude transforms that make all code slower, see https://github.com/facebook/create-react-app/pull/5278
-				exclude: [ 'transform-typeof-symbol' ],
+				// Exclude `web.immediate`: the non-standard setImmediate is unused and needed by no target browser.
+				exclude: [ 'transform-typeof-symbol', 'web.immediate' ],
 			},
 		],
 		[

--- a/packages/calypso-babel-config/presets/dependencies.js
+++ b/packages/calypso-babel-config/presets/dependencies.js
@@ -9,7 +9,8 @@ module.exports = () => ( {
 				useBuiltIns: 'entry',
 				corejs: 3.6,
 				// Exclude transforms that make all code slower, see https://github.com/facebook/create-react-app/pull/5278
-				exclude: [ 'transform-typeof-symbol' ],
+				// Exclude `web.immediate`: the non-standard setImmediate is unused and needed by no target browser.
+				exclude: [ 'transform-typeof-symbol', 'web.immediate' ],
 			},
 		],
 	],


### PR DESCRIPTION
## Proposed Changes

* Add `web.immediate` to the `@babel/preset-env` `exclude` list in both `packages/calypso-babel-config/presets/default.js` and `presets/dependencies.js`.

`packages/calypso-polyfills` does `import 'core-js/stable'`, which `@babel/preset-env` expands (with `useBuiltIns: 'entry'`) into the set of core-js polyfills our browserslist targets need. I verified — by running the repo's own `default.js` preset against `import 'core-js/stable'` for the `evergreen`, `wpcom`, and `defaults` browserslist envs — that the **only** core-js module it injects is `web.immediate` (the non-standard `setImmediate`/`clearImmediate`). Excluding it makes `import 'core-js/stable'` inject nothing in every env, while leaving the polyfill mechanism in place for any future need.

Measured payload of the removed module (bundled + minified + gzipped with esbuild): **~16.9 KB min / ~6.9 KB gzipped**. It ships in a shared vendors chunk pulled into the entry of every client (Calypso, Jetpack Cloud, A8C for Agencies, Dashboard) and the standalone apps that import `@automattic/calypso-polyfills`.

## Why are these changes being made?

* `setImmediate` is non-standard and implemented by **no** target browser (only legacy IE/Edge ever had it), so the polyfill is pure shipped weight for evergreen users.
* No first-party code uses `setImmediate` (`grep` across `client/`, `packages/`, `apps/` returns 0 hits).
* The only `setImmediate` references in the current production bundle are the core-js polyfill definition itself (removed here) and a `try/catch`-guarded `require('timers').setImmediate` in React's scheduler, which falls back safely. Known transitive users (e.g. `browser-filesaver`) already guard with `setImmediate || setTimeout`.

## Testing Instructions

* Build the client and confirm the app boots and behaves normally.
* Optional: verify no core-js modules are injected — run `@babel/preset-env` (`useBuiltIns: 'entry'`, `corejs: 3.6`) over `import 'core-js/stable';` with `debug: true` for `BROWSERSLIST_ENV=evergreen|wpcom|defaults`; the output should list only the two `transform-*regex*` syntax transforms and no `web.immediate`.
* Optional: `grep -r "setImmediate(" public/evergreen` after a build — the only definition should be the guarded React scheduler path.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
