### PR TITLE
Fix missing AnalyticsProvider in the Add new site popover

### DIFF
--- a/client/components/sites-add-new-site/index.tsx
+++ b/client/components/sites-add-new-site/index.tsx
@@ -1,7 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Dropdown } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { AnalyticsProvider } from '../../dashboard/app/analytics';
 import { AuthProvider } from '../../dashboard/app/auth';
+import { useAnalyticsClient } from '../../sites/v2/hooks/use-analytics-client';
 import { AsyncContent } from './async';
 import AddNewSiteButton from './button';
 import type { AddNewSiteProps } from '../../dashboard/sites/add-new-site/types';
@@ -15,35 +17,38 @@ interface Props extends PropsWithChildren {
 
 export const SitesAddNewSitePopover = ( { showCompact, context }: Props ) => {
 	const translate = useTranslate();
+	const analyticsClient = useAnalyticsClient( undefined, window.location.pathname );
 
 	return (
 		<AuthProvider>
-			<Dropdown
-				popoverProps={ { placement: 'bottom-end', offset: 10, noArrow: false } }
-				focusOnMount
-				renderToggle={ ( { isOpen, onToggle } ) => (
-					<AddNewSiteButton
-						showMainButtonLabel={ ! showCompact }
-						mainButtonLabelText={ translate( 'Add new site' ) }
-						isMenuVisible={ isOpen }
-						isPrimary={ ! showCompact }
-						toggleMenu={ onToggle }
-					/>
-				) }
-				renderContent={ () => (
-					<div className="sites-add-new-site__popover-content">
-						<AsyncContent
-							context={ context }
-							aiSiteBuilderPath="/setup/ai-site-builder-onboarding"
+			<AnalyticsProvider client={ analyticsClient }>
+				<Dropdown
+					popoverProps={ { placement: 'bottom-end', offset: 10, noArrow: false } }
+					focusOnMount
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<AddNewSiteButton
+							showMainButtonLabel={ ! showCompact }
+							mainButtonLabelText={ translate( 'Add new site' ) }
+							isMenuVisible={ isOpen }
+							isPrimary={ ! showCompact }
+							toggleMenu={ onToggle }
 						/>
-					</div>
-				) }
-				onToggle={ ( isOpen ) => {
-					if ( isOpen ) {
-						recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_open' );
-					}
-				} }
-			/>
+					) }
+					renderContent={ () => (
+						<div className="sites-add-new-site__popover-content">
+							<AsyncContent
+								context={ context }
+								aiSiteBuilderPath="/setup/ai-site-builder-onboarding"
+							/>
+						</div>
+					) }
+					onToggle={ ( isOpen ) => {
+						if ( isOpen ) {
+							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_open' );
+						}
+					} }
+				/>
+			</AnalyticsProvider>
 		</AuthProvider>
 	);
 };

--- a/client/components/sites-add-new-site/test/index.tsx
+++ b/client/components/sites-add-new-site/test/index.tsx
@@ -23,6 +23,14 @@ jest.mock( '../async', () => ( {
 	AsyncContent: () => <div data-testid="async-content">Async Content</div>,
 } ) );
 
+// Mock the analytics client to avoid needing a Redux store
+jest.mock( 'calypso/sites/v2/hooks/use-analytics-client', () => ( {
+	useAnalyticsClient: () => ( {
+		recordTracksEvent: jest.fn(),
+		recordPageView: jest.fn(),
+	} ),
+} ) );
+
 // Mock fetchUser to provide auth data
 jest.mock( '@automattic/api-core', () => ( {
 	fetchUser: jest.fn( () =>


### PR DESCRIPTION
Fixes Sentry issue CALYPSO-3G10 ([useAnalytics() must be used with a \<AnalyticsProvider\>](https://a8c.sentry.io/issues/7616414636/))

## Proposed Changes

* Wrap the "Add new site" popover (classic `/sites` header) in `AnalyticsProvider`, reusing the same `useAnalyticsClient` hook the backported v2 site list uses.
* Mock the hook in the popover's tests, since the real one needs a Redux store.

## Why are these changes being made?

* The popover async-loads the new dashboard's `AddNewSite` component, which calls `useAnalytics()`. The popover only provided `AuthProvider`, so the hook fell back to the noop client. This has two effects:
  * In production it reports the error above to Sentry (once per pageload).
  * All Tracks events inside the popover (`calypso_dashboard_sites_new_site_action_click_*`) were silent no-ops on this surface.
* The rest of the page (the backported site list) already provides the client via its own React root; the header lives in the classic Calypso tree, which had no provider. The popover has no TanStack router, so the hook receives `window.location.pathname` to populate the `path` event prop, matching the site list's events.

## Testing Instructions

* Log in and go to `/sites` (the `sites/drive-migrations` flag is enabled in all environments, so the header shows the popover version of the button).
* Open DevTools, click **Add new site** in the header.
* Before: the console shows `useAnalytics() must be used with a <AnalyticsProvider>` when the popover opens.
* After: no console error, and with `localStorage.debug = 'calypso:analytics*'` you can see events such as `calypso_dashboard_sites_new_site_action_click_item { path: /sites, action: migrate }` recorded when clicking popover items.
* `yarn test-client client/components/sites-add-new-site`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
