### PR TITLE
Reader: replace twemoji with a native emoji regex in tag-stream

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -222,7 +222,6 @@
 		"to-title-case": "^1.0.0",
 		"tracekit": "^0.4.5",
 		"tus-js-client": "2.3.2",
-		"twemoji": "^12.1.6",
 		"ua-parser-js": "^0.7.22",
 		"uplot": "^1.6.32",
 		"uplot-react": "^1.1.4",

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -19,6 +19,11 @@ import EmptyContent from './empty';
 import TagStreamHeader from './header';
 import './style.scss';
 
+// Matches emoji, including keycap sequences (digit/# /* + U+FE0F + U+20E3), so that
+// emoji tag titles can be detected and converted to their text equivalent.
+const EMOJI_TITLE_PATTERN =
+	/\p{Emoji_Presentation}|\p{Extended_Pictographic}|[#*0-9]\uFE0F?\u20E3/u;
+
 class TagStream extends Component {
 	static propTypes = {
 		encodedTagSlug: PropTypes.string,
@@ -26,7 +31,7 @@ class TagStream extends Component {
 	};
 
 	state = {
-		isEmojiTitle: false,
+		emojiText: null,
 	};
 
 	_isMounted = false;
@@ -38,29 +43,10 @@ class TagStream extends Component {
 				this.setState( { emojiText: emojiText.default } );
 			}
 		} );
-		import( /* webpackChunkName: "async-load-twemoji" */ 'twemoji' ).then( ( twemoji ) => {
-			if ( this._isMounted ) {
-				const title = this.props.decodedTagSlug;
-				this.setState( {
-					twemoji: twemoji.default,
-					isEmojiTitle: title && twemoji.default.test( title ),
-				} );
-			}
-		} );
 	}
 
 	componentWillUnmount() {
 		this._isMounted = false;
-	}
-
-	static getDerivedStateFromProps( nextProps, prevState ) {
-		if ( ! prevState.twemoji || ! nextProps.decodedTagSlug ) {
-			return null;
-		}
-
-		return {
-			isEmojiTitle: prevState.twemoji.test( nextProps.decodedTagSlug ),
-		};
 	}
 
 	isSubscribed = () => {
@@ -105,7 +91,9 @@ class TagStream extends Component {
 		let encodedTagSlug = this.props.encodedTagSlug;
 
 		// If the tag contains emoji, convert to text equivalent
-		if ( this.state.emojiText && this.state.isEmojiTitle ) {
+		const isEmojiTitle =
+			!! this.props.decodedTagSlug && EMOJI_TITLE_PATTERN.test( this.props.decodedTagSlug );
+		if ( this.state.emojiText && isEmojiTitle ) {
 			encodedTagSlug = this.state.emojiText.convert( this.props.decodedTagSlug, {
 				delimiter: '',
 			} );

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -19,8 +19,7 @@ import EmptyContent from './empty';
 import TagStreamHeader from './header';
 import './style.scss';
 
-// Matches emoji, including keycap sequences (digit/# /* + U+FE0F + U+20E3), so that
-// emoji tag titles can be detected and converted to their text equivalent.
+// Matches emoji and keycap sequences (# / * / 0-9 + optional U+FE0F + U+20E3).
 const EMOJI_TITLE_PATTERN =
 	/\p{Emoji_Presentation}|\p{Extended_Pictographic}|[#*0-9]\uFE0F?\u20E3/u;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14689,7 +14689,6 @@ __metadata:
     to-title-case: "npm:^1.0.0"
     tracekit: "npm:^0.4.5"
     tus-js-client: "npm:2.3.2"
-    twemoji: "npm:^12.1.6"
     ua-parser-js: "npm:^0.7.22"
     uplot: "npm:^1.6.32"
     uplot-react: "npm:^1.1.4"
@@ -19472,7 +19471,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^8.0.1, fs-extra@npm:^8.1.0":
+"fs-extra@npm:^8.1.0":
   version: 8.1.0
   resolution: "fs-extra@npm:8.1.0"
   dependencies:
@@ -22679,19 +22678,6 @@ __metadata:
     graceful-fs:
       optional: true
   checksum: 7dc94b628d57a66b71fb1b79510d460d662eb975b5f876d723f81549c2e9cd316d58a2ddf742b2b93a4fa6b17b2accaf1a738a0e2ea114bdfb13a32e5377e480
-  languageName: node
-  linkType: hard
-
-"jsonfile@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "jsonfile@npm:5.0.0"
-  dependencies:
-    graceful-fs: "npm:^4.1.6"
-    universalify: "npm:^0.1.2"
-  dependenciesMeta:
-    graceful-fs:
-      optional: true
-  checksum: 281e32ca64e5731eb5cf6b53d759e20ed8ff94d4479336c174f5dfaf0d65b74317c3bb248386a57e2296bfd75fec9e3b5a4eb7f3fc03eb235ae1de598e3b7ae7
   languageName: node
   linkType: hard
 
@@ -32061,25 +32047,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"twemoji-parser@npm:12.1.3":
-  version: 12.1.3
-  resolution: "twemoji-parser@npm:12.1.3"
-  checksum: d24b4edb014e5f4dd5714820347b585064a1dc485626468c7ce9ab042d4cd553bacb322483c5f31877503b0800788214033703b5ac02a98c11aecbab304f7e5b
-  languageName: node
-  linkType: hard
-
-"twemoji@npm:^12.1.6":
-  version: 12.1.6
-  resolution: "twemoji@npm:12.1.6"
-  dependencies:
-    fs-extra: "npm:^8.0.1"
-    jsonfile: "npm:^5.0.0"
-    twemoji-parser: "npm:12.1.3"
-    universalify: "npm:^0.1.2"
-  checksum: a4d028897bf82890aa2796a0074bd1fa69b833844996e1fec1b7f07062b0a7272c480b7fd069f137b54a7d62ebcdaf48a98de530a3cfc07ac2054f74d8d00f30
-  languageName: node
-  linkType: hard
-
 "type-check@npm:^0.4.0, type-check@npm:~0.4.0":
   version: 0.4.0
   resolution: "type-check@npm:0.4.0"
@@ -32676,7 +32643,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"universalify@npm:^0.1.0, universalify@npm:^0.1.2":
+"universalify@npm:^0.1.0":
   version: 0.1.2
   resolution: "universalify@npm:0.1.2"
   checksum: e70e0339f6b36f34c9816f6bf9662372bd241714dc77508d231d08386d94f2c4aa1ba1318614f92015f40d45aae1b9075cd30bd490efbe39387b60a76ca3f045


### PR DESCRIPTION
## Proposed Changes

* Replace the `twemoji` dependency in `client/reader/tag-stream/main.jsx` with a native Unicode-property regex.
* The tag stream only ever used `twemoji.default.test( title )` to decide whether a tag title contains emoji — that boolean gates an emoji→text conversion (`emoji-text.convert`, kept as-is). With twemoji gone, `isEmojiTitle` becomes a synchronous derived value computed in `render()`, so the `componentDidMount` dynamic-import dance and the `getDerivedStateFromProps` derived-state block are removed.
* Drop `twemoji` from `client/package.json` and `yarn.lock` (lockfile-only update; `twemoji-parser` and its orphaned `jsonfile@5.0.0` go too).

The replacement regex is `/\p{Emoji_Presentation}|\p{Extended_Pictographic}|[#*0-9]️?⃣/u`. The last alternative preserves keycap-sequence detection (e.g. `#️⃣`, `1️⃣`, `*️⃣`) that `twemoji.test` matched.

## Why are these changes being made?

* Removing the import removes the `async-load-twemoji` chunk (~**3.7 KB gzipped**, measured `dist/twemoji.min.js` = 12,950 B min / 3,810 B gz) that loaded on the `/tag/:tag` route.
* `twemoji` is pinned at 12.1.6 (2019) and ships a whole library for one regex; the pinned version also **misses** all Unicode 13+ emoji (🥲🫠🩷…), which the native regex correctly detects — a small parity improvement.
* The old code deferred `isEmojiTitle` behind an async import and stored derived state (a React anti-pattern); computing it synchronously from props is simpler and correct.

Impact is contained: `isEmojiTitle` only controls whether `emoji-text.convert` runs on the decoded slug, whose sole downstream consumer is the `tag` property of the `calypso_reader_clicked_tag_sort` Tracks event — no URLs, follows, or API calls are affected.

## Testing Instructions

* Visit `/tag/<something>` in the Reader for both a plain tag and an emoji tag (e.g. a tag whose title contains 😀 or a keycap like `#️⃣`). Confirm the stream renders and behaves as before.
* There is no existing unit test for this component. The regex was validated against emoji, keycap sequences, Unicode 13+ emoji, and non-emoji slugs.
* `yarn eslint client/reader/tag-stream/main.jsx` and `yarn prettier --check` pass.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
