### PR TITLE
Me: use the native Clipboard API for 2FA backup codes copy button

### DIFF
--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -1,6 +1,5 @@
 import { Button, Gridicon, FormLabel, Tooltip } from '@automattic/components';
 import { saveAs } from 'browser-filesaver';
-import Clipboard from 'clipboard';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
@@ -40,22 +39,6 @@ class Security2faBackupCodesList extends Component {
 	printCodesButtonRef = createRef();
 	downloadCodesButtonRef = createRef();
 
-	componentDidMount() {
-		// Configure clipboard to be triggered on clipboard button press.
-		// `Button` forwards its ref to the underlying DOM element, so the ref's
-		// current value is already the node (no `findDOMNode`, removed in React 19).
-		const button = this.copyCodesButtonRef.current;
-		this.clipboard = new Clipboard( button, {
-			text: () => this.getBackupCodePlainText( this.props.backupCodes ),
-		} );
-		this.clipboard.on( 'success', this.onCopy );
-	}
-
-	componentWillUnmount() {
-		// Cleanup clipboard object
-		this.clipboard.destroy();
-	}
-
 	openPopup = () => {
 		this.popup = window.open();
 
@@ -75,6 +58,16 @@ class Security2faBackupCodesList extends Component {
 
 		if ( this.openPopup() ) {
 			this.doPopup( this.props.backupCodes );
+		}
+	};
+
+	copyCodes = () => {
+		const text = this.getBackupCodePlainText( this.props.backupCodes );
+		if ( text ) {
+			navigator.clipboard
+				.writeText( text )
+				.then( this.onCopy )
+				.catch( () => {} );
 		}
 	};
 
@@ -270,6 +263,7 @@ class Security2faBackupCodesList extends Component {
 							<Button
 								className="security-2fa-backup-codes-list__copy"
 								disabled={ ! this.props.backupCodes.length }
+								onClick={ this.copyCodes }
 								onMouseEnter={ this.enableCopyCodesTooltip }
 								onMouseLeave={ this.disableCopyCodesTooltip }
 								ref={ this.copyCodesButtonRef }

--- a/client/package.json
+++ b/client/package.json
@@ -132,7 +132,6 @@
 		"chalk": "^4.1.2",
 		"chrono-node": "^2.3.5",
 		"circular-dependency-plugin": "^5.2.2",
-		"clipboard": "^2.0.11",
 		"clsx": "^2.1.1",
 		"cmdk": "^0.2.1",
 		"component-closest": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14590,7 +14590,6 @@ __metadata:
     chalk: "npm:^4.1.2"
     chrono-node: "npm:^2.3.5"
     circular-dependency-plugin: "npm:^5.2.2"
-    clipboard: "npm:^2.0.11"
     clsx: "npm:^2.1.1"
     cmdk: "npm:^0.2.1"
     component-closest: "npm:^1.0.1"
@@ -15189,17 +15188,6 @@ __metadata:
   version: 2.4.5
   resolution: "client-zip@npm:2.4.5"
   checksum: b3ec15c8487575a992f86ced6f66a9905ef1955675e431bbe1a74e780448fff284904b2c9565678f97e31ae4f2b128fbc55f84af1b5a89f3d52c9225b8d7c14a
-  languageName: node
-  linkType: hard
-
-"clipboard@npm:^2.0.11":
-  version: 2.0.11
-  resolution: "clipboard@npm:2.0.11"
-  dependencies:
-    good-listener: "npm:^1.2.2"
-    select: "npm:^1.1.2"
-    tiny-emitter: "npm:^2.0.0"
-  checksum: 23bdf16b875bd2dd101eeefae3c25a2fbd990b613fad3d227ca6719d1b81a3c6f69701b494393fdecd07d98380024f82d045f464124dbbafbcf0557f2921978f
   languageName: node
   linkType: hard
 
@@ -16811,13 +16799,6 @@ __metadata:
   version: 1.0.0
   resolution: "delayed-stream@npm:1.0.0"
   checksum: d758899da03392e6712f042bec80aa293bbe9e9ff1b2634baae6a360113e708b91326594c8a486d475c69d6259afb7efacdc3537bfcda1c6c648e390ce601b19
-  languageName: node
-  linkType: hard
-
-"delegate@npm:^3.1.2":
-  version: 3.2.0
-  resolution: "delegate@npm:3.2.0"
-  checksum: f8512633514f375b8675018088fdd679d92b84246ad6ba1de9fbc4ea7630f7fb0ff8772ac86c37a68233885f58c6b8b70676d7366f38cb2dcbf7baa474e2362d
   languageName: node
   linkType: hard
 
@@ -20088,15 +20069,6 @@ __metadata:
   version: 0.1.4
   resolution: "globjoin@npm:0.1.4"
   checksum: 236e991b48f1a9869fe2aa7bb5141fb1f32973940567a3c012f8ccb58c3c85ab78ce594d374fa819410fff3b48cfd24584d7ef726939f8a3c3772890e62ea16b
-  languageName: node
-  linkType: hard
-
-"good-listener@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "good-listener@npm:1.2.2"
-  dependencies:
-    delegate: "npm:^3.1.2"
-  checksum: 5c532f2e223f1f3a12504077d6d960986979a7923fb428a26bde012b88ac57ffba1b28507f95bd16a73c1ae805fdb38d26d9442d538dd559fad159a7f58243fe
   languageName: node
   linkType: hard
 
@@ -29977,13 +29949,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"select@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "select@npm:1.1.2"
-  checksum: 5dbd871c03a52aa70ce29ab46e9115d26cb34404717e7e705e678b3b4d535bacfa0a4c4c2d32262acec7b6fdfb6827e8980ea4ef969a8681f8a0b752331a0a02
-  languageName: node
-  linkType: hard
-
 "semver-compare@npm:^1.0.0":
   version: 1.0.0
   resolution: "semver-compare@npm:1.0.0"
@@ -31629,13 +31594,6 @@ __metadata:
   version: 0.3.0
   resolution: "timsort@npm:0.3.0"
   checksum: 571b2054a0db3cf80eb255f8609a1f798cae9176f9ec6e3fbd03d64186c015cc9e1e75b88ba38e1d71aebcc03a931352522c7387dcb90caeb148375c7bc106f4
-  languageName: node
-  linkType: hard
-
-"tiny-emitter@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "tiny-emitter@npm:2.1.0"
-  checksum: 459c0bd6e636e80909898220eb390e1cba2b15c430b7b06cec6ac29d87acd29ef618b9b32532283af749f5d37af3534d0e3bde29fdf6bcefbf122784333c953d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed Changes

* Replace the `clipboard` (clipboard.js) dependency in `client/me/security-2fa-backup-codes-list/index.jsx` with the native `navigator.clipboard.writeText()` API.
* The copy button now copies in its own `onClick` handler (`copyCodes`) instead of clipboard.js binding to the DOM node. This removes the `componentDidMount`/`componentWillUnmount` lifecycle methods that only existed to construct and `destroy()` the `Clipboard` instance. The existing `onCopy` analytics handler still fires — now via `.then()`, i.e. only on a successful copy.
* Drop `clipboard` from `client/package.json` and `yarn.lock` (lockfile-only update; its `delegate`/`good-listener`/`select`/`tiny-emitter` tail goes too).

## Why are these changes being made?

* Removing the import removes clipboard.js (~**3.2 KB gzipped**, measured `dist/clipboard.min.js` = 3,233 B gz) from the async `me` section chunk.
* `navigator.clipboard.writeText()` is supported across the evergreen (and fallback) browser targets and is already the copy mechanism used throughout `client/dashboard`. `@wordpress/compose`'s `useCopyToClipboard` no longer depends on clipboard.js either, so this was the last direct consumer in the repo.

## Testing Instructions

* Go to **Me → Security → Two-Step Authentication** and reach the backup-codes step (or re-generate backup codes).
* Click the copy (clipboard icon) button and paste elsewhere — the ten codes should be copied, newline-separated, exactly as before.
* Confirm the `Clicked On 2fa Copy to clipboard Button` Google analytics event still records on a successful copy.
* Note: `navigator.clipboard` requires a secure context; production is HTTPS. There is no existing unit test for this component.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
