### PR TITLE
State: replace immutability-helper with object spread

### DIFF
--- a/client/components/domains/contact-details-form-fields/test/index.js
+++ b/client/components/domains/contact-details-form-fields/test/index.js
@@ -4,7 +4,6 @@
 
 import { omit } from '@automattic/js-utils';
 import { screen } from '@testing-library/react';
-import update from 'immutability-helper';
 import FormPhoneMediaInput from 'calypso/components/forms/form-phone-media-input';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { ContactDetailsFormFields } from '../';
@@ -124,7 +123,10 @@ describe( 'ContactDetailsFormFields', () => {
 		} );
 
 		test( 'should not render address fieldset when no country selected', () => {
-			const newProps = update( defaultProps, { contactDetails: { countryCode: { $set: '' } } } );
+			const newProps = {
+				...defaultProps,
+				contactDetails: { ...defaultProps.contactDetails, countryCode: '' },
+			};
 			render( <ContactDetailsFormFields { ...newProps } /> );
 
 			expect( screen.queryByTestId( 'region-address-fieldsets' ) ).not.toBeInTheDocument();
@@ -259,7 +261,8 @@ describe( 'ContactDetailsFormFields', () => {
 
 		test( 'should set phone country using geo location when country code not available in contact details', () => {
 			const newProps = {
-				...update( defaultProps, { contactDetails: { countryCode: { $set: '' } } } ),
+				...defaultProps,
+				contactDetails: { ...defaultProps.contactDetails, countryCode: '' },
 				userCountryCode: 'FR',
 			};
 
@@ -273,7 +276,10 @@ describe( 'ContactDetailsFormFields', () => {
 		} );
 
 		test( 'should use US as fallback', () => {
-			const newProps = update( defaultProps, { contactDetails: { countryCode: { $set: '' } } } );
+			const newProps = {
+				...defaultProps,
+				contactDetails: { ...defaultProps.contactDetails, countryCode: '' },
+			};
 
 			render( <ContactDetailsFormFields { ...newProps } /> );
 

--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -1,6 +1,5 @@
 import { camelCase, mapValues, pickBy, isEmpty } from '@automattic/js-utils';
 import { debounce } from '@wordpress/compose';
-import update from 'immutability-helper';
 
 function Controller( options ) {
 	if ( ! ( this instanceof Controller ) ) {
@@ -148,14 +147,15 @@ Controller.prototype.resetFields = function ( fieldValues ) {
 
 function changeFieldValue( formState, name, value, hideFieldErrorsOnChange ) {
 	const fieldState = getField( formState, name );
-	const command = {};
 
 	// We reset the errors if we weren't showing them already to avoid a flash of
 	// error messages when the user starts typing.
 	const errors = fieldState.isShowingErrors ? fieldState.errors : [];
 
-	command[ name ] = {
-		$merge: {
+	return {
+		...formState,
+		[ name ]: {
+			...formState[ name ],
 			value: value,
 			errors: errors,
 			isShowingErrors: ! hideFieldErrorsOnChange,
@@ -163,8 +163,6 @@ function changeFieldValue( formState, name, value, hideFieldErrorsOnChange ) {
 			isValidating: false,
 		},
 	};
-
-	return update( formState, command );
 }
 
 function changeFieldValues( formState, fieldValues ) {

--- a/client/package.json
+++ b/client/package.json
@@ -173,7 +173,6 @@
 		"he": "^1.2.0",
 		"hls.js": "^1.6.16",
 		"i18n-calypso": "workspace:^",
-		"immutability-helper": "^3.0.1",
 		"inherits": "^2.0.4",
 		"is-my-json-valid": "^2.20.6",
 		"jest": "^29.7.0",

--- a/client/state/domains/dns/reducer.js
+++ b/client/state/domains/dns/reducer.js
@@ -1,5 +1,4 @@
 import { pick } from '@automattic/js-utils';
-import update from 'immutability-helper';
 import {
 	DOMAINS_DNS_ADD,
 	DOMAINS_DNS_ADD_COMPLETED,
@@ -86,13 +85,10 @@ export const initialState = {
 };
 
 function updateDomainState( state, domainName, dns ) {
-	const command = {
-		[ domainName ]: {
-			$set: Object.assign( {}, state[ domainName ] || initialState, dns ),
-		},
+	return {
+		...state,
+		[ domainName ]: Object.assign( {}, state[ domainName ] || initialState, dns ),
 	};
-
-	return update( state, command );
 }
 
 function addDns( state, domainName, record ) {
@@ -100,60 +96,56 @@ function addDns( state, domainName, record ) {
 		isBeingAdded: true,
 	} );
 
-	return update( state, {
+	const domainState = state[ domainName ];
+	const added = domainState.records.concat( [ newRecord ] );
+
+	return {
+		...state,
 		[ domainName ]: {
-			isSubmittingForm: { $set: true },
-			records: {
-				$apply: ( records ) => {
-					const added = records.concat( [ newRecord ] );
-					return removeDuplicateWpcomRecords( domainName, added );
-				},
-			},
+			...domainState,
+			isSubmittingForm: true,
+			records: removeDuplicateWpcomRecords( domainName, added ),
 		},
-	} );
+	};
 }
 
 function deleteDns( state, domainName, record ) {
-	const index = findDnsIndex( state[ domainName ].records, record );
+	const domainState = state[ domainName ];
+	const index = findDnsIndex( domainState.records, record );
 
 	if ( index === -1 ) {
 		return state;
 	}
 
-	const command = {
-		[ domainName ]: {
-			records: {
-				$apply: ( records ) => {
-					const deleted = records.filter( ( _, current ) => index !== current );
+	const deleted = domainState.records.filter( ( _, current ) => index !== current );
 
-					return addMissingWpcomRecords( domainName, deleted );
-				},
-			},
+	return {
+		...state,
+		[ domainName ]: {
+			...domainState,
+			records: addMissingWpcomRecords( domainName, deleted ),
 		},
 	};
-
-	return update( state, command );
 }
 
 function updateDnsState( state, domainName, record, updatedFields ) {
-	const index = findDnsIndex( state[ domainName ].records, record );
+	const domainState = state[ domainName ];
+	const index = findDnsIndex( domainState.records, record );
 	const updatedRecord = Object.assign( {}, record, updatedFields );
 
 	if ( index === -1 ) {
 		return state;
 	}
 
-	const command = {
+	return {
+		...state,
 		[ domainName ]: {
-			records: {
-				[ index ]: {
-					$merge: updatedRecord,
-				},
-			},
+			...domainState,
+			records: domainState.records.map( ( currentRecord, currentIndex ) =>
+				currentIndex === index ? { ...currentRecord, ...updatedRecord } : currentRecord
+			),
 		},
 	};
-
-	return update( state, command );
 }
 
 function findDnsIndex( records, record ) {

--- a/client/state/domains/site-redirect/reducer.js
+++ b/client/state/domains/site-redirect/reducer.js
@@ -1,4 +1,3 @@
-import update from 'immutability-helper';
 import {
 	DOMAINS_SITE_REDIRECT_FETCH,
 	DOMAINS_SITE_REDIRECT_FETCH_COMPLETED,
@@ -10,13 +9,10 @@ import {
 } from 'calypso/state/action-types';
 
 function updateStateForSite( state, siteId, data ) {
-	const command = state[ siteId ] ? '$merge' : '$set';
-
-	return update( state, {
-		[ siteId ]: {
-			[ command ]: data,
-		},
-	} );
+	return {
+		...state,
+		[ siteId ]: state[ siteId ] ? { ...state[ siteId ], ...data } : data,
+	};
 }
 
 export const initialStateForSite = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14634,7 +14634,6 @@ __metadata:
     html-loader: "npm:^5.1.0"
     i18n-calypso: "workspace:^"
     ignore-loader: "npm:^0.1.2"
-    immutability-helper: "npm:^3.0.1"
     inherits: "npm:^2.0.4"
     is-my-json-valid: "npm:^2.20.6"
     jest: "npm:^29.7.0"
@@ -20874,15 +20873,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutability-helper@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "immutability-helper@npm:3.0.1"
-  dependencies:
-    invariant: "npm:^2.2.4"
-  checksum: bda92b76a232556f9de87c616bd28f90bdd27e80a584b4b229ef4c8f8e6001e87ab7e2f139588aee2f90d86b6fd2798a532e95cd2042f79ced197994103d4ab6
-  languageName: node
-  linkType: hard
-
 "immutable@npm:3.8.3":
   version: 3.8.3
   resolution: "immutable@npm:3.8.3"
@@ -21083,15 +21073,6 @@ __metadata:
   version: 2.2.0
   resolution: "interpret@npm:2.2.0"
   checksum: c0ef90daec6c4120bb7a226fa09a9511f6b5618aa9c94cf4641472f486948e643bb3b36efbd0136bbffdee876435af9fdf7bbb4622f5a16778eed5397f8a1946
-  languageName: node
-  linkType: hard
-
-"invariant@npm:^2.2.4":
-  version: 2.2.4
-  resolution: "invariant@npm:2.2.4"
-  dependencies:
-    loose-envify: "npm:^1.0.0"
-  checksum: 5af133a917c0bcf65e84e7f23e779e7abc1cd49cb7fdc62d00d1de74b0d8c1b5ee74ac7766099fb3be1b05b26dfc67bab76a17030d2fe7ea2eef867434362dfc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed Changes

* Replace the `immutability-helper` dependency with native object/array spread in its three remaining call sites:
  * `client/state/domains/dns/reducer.js` — `updateDomainState`, `addDns`, `deleteDns`, `updateDnsState`
  * `client/state/domains/site-redirect/reducer.js` — `updateStateForSite`
  * `client/lib/form-state/index.js` — `changeFieldValue`
* Drop `immutability-helper` from `client/package.json` and `yarn.lock` (lockfile-only update; its transitive `invariant` goes too).

Every call site used only shallow `$set` / `$merge` / `$apply` commands, which map directly onto `{ ...obj, ... }` spread (and `Array.prototype.map` for the single indexed-record `$merge`).

## Why are these changes being made?

* Removes ~**2.1 KB gzipped** from the domains/checkout async chunks that register these reducers and form-state.
* `immutability-helper`'s `update()` command DSL was a Redux-era convenience; React's own docs have recommended spread for these shallow patterns for years, and the rest of Calypso's reducers already use spread.

## Testing Instructions

* `yarn test-client client/state/domains/dns/test client/lib/form-state/test` — all existing tests pass (14 tests).
* Behavior is preserved: each helper still returns a new state object with new objects along the modified path and shares untouched branches by reference.
* Manual smoke test: edit DNS records for a domain (add / edit / delete) under **Domains → DNS records**, and set/clear a Site Redirect — state updates should behave exactly as before.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes? (Existing reducer/form-state tests cover the changed paths.)
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
