### PR TITLE
Photon: remove dead crc32 / seed-random server-hashing branch

### DIFF
--- a/packages/photon/package.json
+++ b/packages/photon/package.json
@@ -43,10 +43,7 @@
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"dependencies": {
-		"@types/seed-random": "^2.2.4",
-		"crc32": "^0.2.2",
 		"debug": "^4.4.1",
-		"seed-random": "^2.2.0",
 		"tslib": "^2.8.1"
 	},
 	"devDependencies": {

--- a/packages/photon/src/decs.d.ts
+++ b/packages/photon/src/decs.d.ts
@@ -1,3 +1,0 @@
-declare module 'crc32' {
-	export default function crc32( s: string ): string;
-}

--- a/packages/photon/src/index.ts
+++ b/packages/photon/src/index.ts
@@ -1,6 +1,4 @@
-import crc32 from 'crc32';
 import debugFactory from 'debug';
-import seed from 'seed-random';
 
 const debug = debugFactory( 'photon' );
 
@@ -74,7 +72,9 @@ export default function photon( imageUrl: string, opts?: PhotonOpts ): string | 
 			formattedUrl = parsedUrl.pathname;
 		}
 		photonUrl.pathname = formattedUrl;
-		photonUrl.hostname = serverFromUrlParts( formattedUrl, photonUrl.protocol === 'https:' );
+		// The Photon URL is always constructed over https here, so requests go to
+		// i0, which benefits from HTTP/2 multiplexing.
+		photonUrl.hostname = 'i0.wp.com';
 		if ( wasSecure ) {
 			photonUrl.searchParams.set( 'ssl', '1' );
 		}
@@ -102,25 +102,4 @@ export default function photon( imageUrl: string, opts?: PhotonOpts ): string | 
 
 function isAlreadyPhotoned( host: string ) {
 	return /^i[0-2]\.wp\.com$/.test( host );
-}
-
-/**
- * Determine which Photon server to connect to: `i0`, `i1`, or `i2`.
- *
- * Statically hash the subdomain based on the URL, to optimize browser caches.
- * Only use i0 when using photon over https, based on the assumption that https
- * maps to http/2 (or later)
- * @param  {string} pathname The pathname to use
- * @param  {boolean} isSecure Whether we're constructing a HTTPS URL or a HTTP one
- * @returns {string}          The hostname for the pathname
- */
-function serverFromUrlParts( pathname: string, isSecure: boolean ) {
-	if ( isSecure ) {
-		return 'i0.wp.com';
-	}
-	const hash = crc32( pathname );
-	const rng = seed( hash );
-	const server = 'i' + Math.floor( rng() * 3 );
-	debug( 'determined server "%s" to use with "%s"', server, pathname );
-	return server + '.wp.com';
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9883,13 +9883,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/seed-random@npm:^2.2.4":
-  version: 2.2.4
-  resolution: "@types/seed-random@npm:2.2.4"
-  checksum: 99b32d9207b0ef81d349f425b32cbd3af840808596bb5ea04cb3a72d6fac3147ebd6216ceb3e734d3504e6c36a53a9dc9eb1d8d79d4995ccf3003c852eae4651
-  languageName: node
-  linkType: hard
-
 "@types/semver@npm:^7.3.4":
   version: 7.5.3
   resolution: "@types/semver@npm:7.5.3"
@@ -15911,15 +15904,6 @@ __metadata:
     crc-32: "npm:^1.2.0"
     readable-stream: "npm:^3.4.0"
   checksum: 215b515775296c9f152cbb8435c9e39552876042d52eec6569508f2bfc6d7c6cfa4bc8939002457c7f612e9b995a377f7abbaf473b961941b816361574913c9c
-  languageName: node
-  linkType: hard
-
-"crc32@npm:^0.2.2":
-  version: 0.2.2
-  resolution: "crc32@npm:0.2.2"
-  bin:
-    crc32: ./bin/runner.js
-  checksum: ed475a5618c948112010677751819a03ff2259c8e52d11f427c4a901d9c560d859a7c623c7885e84e811ebffc9e2c4d1aff4e685475647ab3bc2f423b86905fe
   languageName: node
   linkType: hard
 
@@ -26255,10 +26239,7 @@ __metadata:
   resolution: "photon@workspace:packages/photon"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    "@types/seed-random": "npm:^2.2.4"
-    crc32: "npm:^0.2.2"
     debug: "npm:^4.4.1"
-    seed-random: "npm:^2.2.0"
     tslib: "npm:^2.8.1"
     typescript: "npm:^6.0.3"
   languageName: unknown
@@ -29967,13 +29948,6 @@ __metadata:
     ajv-formats: "npm:^2.1.1"
     ajv-keywords: "npm:^5.1.0"
   checksum: 1c8d2c480a026d7c02ab2ecbe5919133a096d6a721a3f201fa50663e4f30f6d6ba020dfddd93cb828b66b922e76b342e103edd19a62c95c8f60e9079cc403202
-  languageName: node
-  linkType: hard
-
-"seed-random@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "seed-random@npm:2.2.0"
-  checksum: 5d48dedf312e8075faa899664ec5867e3b088a11d0e955d7c6bcfffcd7fc6de5dbb51c41c24ef48060ee6a9592cad607e5c44306b4fd4828667451afe16b09a5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed Changes

* In `packages/photon`, remove the dead server-hashing branch in `serverFromUrlParts` and inline the hostname as `i0.wp.com`.
* Drop the now-unused `crc32`, `seed-random`, and `@types/seed-random` dependencies, and delete the local `crc32` type shim (`src/decs.d.ts`).

## Why are these changes being made?

`serverFromUrlParts( pathname, isSecure )` was meant to statically hash the pathname across `i0`/`i1`/`i2` for HTTP requests. But the branch is **unreachable**: `photonUrl` is always constructed from `https://i0.wp.com`, and the `secure: false` option flips the protocol to `http:` only *after* the hostname is chosen. So `isSecure` was always `true` and the function always returned `i0.wp.com` — the `crc32`/`seed-random` path never ran.

Removing it deletes ~**1.5 KB gzipped** of dead code (crc32 + seed-random) from every chunk that bundles `photon` — and `photon` is imported broadly (e.g. `@automattic/calypso-url`'s `safe-image-url`, media utils, the design picker).

This is a faithful dead-code removal, not a behavior change: the http server-spreading was already not happening. (If per-host spreading is ever wanted for HTTP Photon URLs, that would be a separate, intentional change.)

## Testing Instructions

* `yarn test-packages packages/photon` — all 14 existing tests pass.
* `yarn workspace photon build` — type-checks cleanly.
* Photon URLs are unchanged: secure and insecure URLs resolve to `i0.wp.com` exactly as before.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes? (Existing photon tests cover the changed path.)
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
