### PR TITLE
A4A: Add Monitoring detailed view to the agency site page

### DIFF
--- a/client/dashboard/agency/sites/site-sidebar/index.tsx
+++ b/client/dashboard/agency/sites/site-sidebar/index.tsx
@@ -3,7 +3,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { backup, category, chartBar, formatListBullets, shield } from '@wordpress/icons';
+import { backup, category, chartBar, formatListBullets, pending, shield } from '@wordpress/icons';
 import { agencySiteRoute } from '../../../app/router/agency';
 import {
 	SidebarBackButton,
@@ -19,6 +19,7 @@ export default function AgencySiteSidebar() {
 	const { data: site } = useQuery( agencySiteQuery( siteSlug ) );
 	const { data: fullSite } = useQuery( siteBySlugQuery( siteSlug ) );
 	const supportsPerformance = fullSite ? siteTypeSupportsFeature( fullSite, 'performance' ) : false;
+	const supportsMonitoring = fullSite ? siteTypeSupportsFeature( fullSite, 'monitoring' ) : false;
 	const isApmEnabled = isEnabled( 'performance/apm' );
 
 	return (
@@ -74,6 +75,11 @@ export default function AgencySiteSidebar() {
 									{ __( 'History' ) }
 								</SidebarMenuItem>
 							</SidebarExpandableMenuItem>
+						) }
+						{ supportsMonitoring && (
+							<SidebarMenuItem icon={ pending } to={ `/sites/${ siteSlug }/monitoring` }>
+								{ __( 'Monitoring' ) }
+							</SidebarMenuItem>
 						) }
 						<SidebarExpandableMenuItem
 							label={ __( 'Logs' ) }

--- a/client/dashboard/agency/sites/site/monitoring.tsx
+++ b/client/dashboard/agency/sites/site/monitoring.tsx
@@ -1,0 +1,7 @@
+import { agencySiteRoute } from '../../../app/router/agency';
+import { SiteMonitoringContent } from '../../../sites/monitoring';
+
+export default function AgencySiteMonitoring() {
+	const { siteSlug } = agencySiteRoute.useParams();
+	return <SiteMonitoringContent siteSlug={ siteSlug } />;
+}

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -805,6 +805,20 @@ export const agencySitePerformanceBackendRequestDetailRoute = createRoute( {
 	)
 );
 
+// `/sites/$siteSlug/monitoring` – server stats detailed view (WP.com sites only)
+export const agencySiteMonitoringRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'monitoring' },
+	head: () => ( { meta: [ { title: __( 'Monitoring' ) } ] } ),
+	getParentRoute: () => agencySiteRoute,
+	path: 'monitoring',
+} ).lazy( () =>
+	import( '../../agency/sites/site/monitoring' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-monitoring' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const createAgencyRoutes = () => [
 	agencyRoute.addChildren( [
 		agencyOverviewRoute,
@@ -851,6 +865,7 @@ export const createAgencyRoutes = () => [
 					agencySitePerformanceBackendRequestDetailRoute,
 				] ),
 			] ),
+			agencySiteMonitoringRoute,
 			agencySiteLogsRoute.addChildren( [ agencySiteLogsIndexRoute, agencySiteActivityRoute ] ),
 		] ),
 	] ),

--- a/client/dashboard/sites/monitoring/index.tsx
+++ b/client/dashboard/sites/monitoring/index.tsx
@@ -98,8 +98,7 @@ function SiteMonitoringBody( {
 	);
 }
 
-function SiteMonitoring() {
-	const { siteSlug } = siteRoute.useParams();
+export function SiteMonitoringContent( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useQuery( siteBySlugQuery( siteSlug ) );
 	const locale = useLocale();
 
@@ -147,6 +146,11 @@ function SiteMonitoring() {
 			</PageLayout>
 		</HostingFeatureGatedWithCallout>
 	);
+}
+
+function SiteMonitoring() {
+	const { siteSlug } = siteRoute.useParams();
+	return <SiteMonitoringContent siteSlug={ siteSlug } />;
 }
 
 export default SiteMonitoring;


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/112509

Resolves A4A-2937

## Proposed Changes

Adds Monitoring to a site's page in the Automattic for Agencies dashboard:

* A **Monitoring** item in the site sidebar, shown only for WP.com sites.
* A full **Monitoring page** with server stats — response time, requests per minute, request methods, response types, and successful/unsuccessful HTTP responses — with a time-period switcher (6 hours to 7 days).
* Sites that support Monitoring but don't have it available yet (e.g. Simple sites on lower plans) see the standard "Monitor server stats" activation prompt.
* Self-hosted Jetpack sites never see the section, and opening the URL directly redirects back to the site overview.

This reuses the same Monitoring experience the main dashboard already has, so agency-managed sites get the exact same view.

## Why are these changes being made?

Agencies could open a site's overview but had no way to check its server stats from the new site page. This brings Monitoring to agency-managed sites, matching the recent additions of Scan and Performance. Monitoring is a WordPress.com hosting feature, so it's only offered for WP.com sites — the separate A4A monitor feature is unrelated and untouched.

## Testing Instructions

1. Open the Dashboard Live (A4A) link > Replace the `/sites` in the URL with `/overview` to see the A4A dashboard and go to a WP.com site's page.
2. In the sidebar, confirm **Monitoring** appears and open it.
3. Confirm the server stats load, and switch the time period (6 hours / 24 hours / 3 days / 7 days).
4. Open a self-hosted Jetpack site and confirm there is no **Monitoring** item; changing the URL to `/sites/{site}/monitoring` manually redirects back to the site's overview.
5. Open a Simple site without the feature and confirm the "Monitor server stats" activation prompt shows.
6. Since the shared Monitoring page was touched, open the Dashboard Live (dotcom) link, go to a site's **Monitoring** page, and confirm it still works unchanged.

<img width="1920" height="963" alt="Screenshot 2026-07-17 at 3 24 40 PM" src="https://github.com/user-attachments/assets/c8694512-16f4-4729-9e07-dac90965613a" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
