### PR TITLE
Reader: Fix multiple /seen calls on posts that are already seen

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -541,7 +541,7 @@ export class FullPostView extends Component {
 		}
 
 		if ( ! this.hasLoaded && post && post._state !== 'pending' ) {
-			if ( this.isSeenEnabled() ) {
+			if ( this.isSeenEnabled() && ! post.is_seen ) {
 				this.markAsSeen();
 			}
 

--- a/client/blocks/reader-full-post/test/index.jsx
+++ b/client/blocks/reader-full-post/test/index.jsx
@@ -7,7 +7,7 @@ import { createStore } from 'redux';
 import { usePostCommentsApiDisabled } from 'calypso/reader/data/comments';
 import { usePost } from 'calypso/reader/data/post';
 import { useStreamPostKeySelection } from 'calypso/reader/stream/use-stream-post-key-selection';
-import { mapStateToFullPostProps, withFullPostNavigation } from '../index';
+import { FullPostView, mapStateToFullPostProps, withFullPostNavigation } from '../index';
 
 jest.mock( 'calypso/reader/data/comments', () => ( {
 	usePostCommentsApiDisabled: jest.fn(),
@@ -19,6 +19,12 @@ jest.mock( 'calypso/reader/data/post', () => ( {
 
 jest.mock( 'calypso/reader/stream/use-stream-post-key-selection', () => ( {
 	useStreamPostKeySelection: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/reader/stats', () => ( {
+	recordAction: jest.fn(),
+	recordGaEvent: jest.fn(),
+	recordTrackForPost: jest.fn(),
 } ) );
 
 // Mock the entire FullPostView component to focus on the specific logic we're testing
@@ -241,5 +247,63 @@ describe( 'FullPostView Comments API Disabled Logic', () => {
 
 			expect( queryByTestId( 'comment-button' ) ).toBeInTheDocument();
 		} );
+	} );
+} );
+
+describe( 'FullPostView automatic mark-as-seen on view', () => {
+	// `hasOrganization` makes `isSeenEnabled()` return true via
+	// `isEligibleForUnseen`, and the post carrying an `is_seen` field satisfies
+	// `canBeMarkedAsSeen`, so the only thing gating the request is `post.is_seen`.
+	const baseProps = {
+		hasOrganization: true,
+		teams: [],
+		referralStream: '',
+		setViewingFullPostKey: jest.fn(),
+	};
+
+	const feedPost = {
+		is_seen: false,
+		feed_ID: 1,
+		feed_URL: 'https://example.com/feed',
+		feed_item_ID: 10,
+		global_ID: 'global-1',
+	};
+
+	// Drive the automatic path directly: skip the pageview branch (needs a site)
+	// by pretending it already ran, and force the not-yet-loaded state.
+	const runAttemptToSendPageView = ( instance ) => {
+		instance.hasSentPageView = true;
+		instance.hasLoaded = false;
+		instance.attemptToSendPageView();
+	};
+
+	it( 'marks an unseen post as seen when the full post is viewed', () => {
+		const requestMarkAsSeen = jest.fn();
+		const instance = new FullPostView( {
+			...baseProps,
+			requestMarkAsSeen,
+			requestMarkAsSeenBlog: jest.fn(),
+			post: { ...feedPost, is_seen: false },
+		} );
+
+		runAttemptToSendPageView( instance );
+
+		expect( requestMarkAsSeen ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not hit the seen endpoint when the post is already seen', () => {
+		const requestMarkAsSeen = jest.fn();
+		const requestMarkAsSeenBlog = jest.fn();
+		const instance = new FullPostView( {
+			...baseProps,
+			requestMarkAsSeen,
+			requestMarkAsSeenBlog,
+			post: { ...feedPost, is_seen: true },
+		} );
+
+		runAttemptToSendPageView( instance );
+
+		expect( requestMarkAsSeen ).not.toHaveBeenCalled();
+		expect( requestMarkAsSeenBlog ).not.toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
## Proposed Changes

Add `post.is_seen` check to only call `/seen` endpoint if the post is not seen.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open same post multiple times and notice that unread count doesn't decrease with each view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
