### PR TITLE
Odyssey Stats: keep the wp-submenu flyout margin override at .wp-admin scope

### DIFF
--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -112,8 +112,12 @@
 		margin: 0;
 		color: inherit;
 	}
+}
 
-	// Offset margin of menu items set in Calypso.
+// Counteracts the `ul ul { margin-left: 1.5em }` that Calypso's unscoped global stylesheet leaks
+// onto wp-admin's flyout submenus. `#adminmenu` lives outside `.jp-stats-dashboard`, so this one
+// override must stay at `.wp-admin` scope until the global styles are scoped.
+.wp-admin {
 	ul.wp-submenu,
 	ul.wp-submenu-wrap {
 		margin-left: 0;


### PR DESCRIPTION
Fixes the wp-admin flyout submenu gap introduced by #112498.

## Proposed Changes

* Move the `ul.wp-submenu, ul.wp-submenu-wrap { margin-left: 0 }` override out of the `.jp-stats-dashboard` block back to a `.wp-admin`-scoped block in `apps/odyssey-stats/src/styles/wp-admin.scss`.

## Why are these changes being made?

* #112498 scoped Odyssey's wp-admin overrides block to `.jp-stats-dashboard`, but this one rule exists to counteract the `ul ul { margin-left: 1.5em }` that Calypso's unscoped global stylesheet leaks onto wp-admin's admin-menu flyout submenus. `#adminmenu` lives outside `.jp-stats-dashboard`, so the override went dead and hover flyouts on the Stats page gained a ~24px horizontal gap between the menu and the flyout. The currently deployed production build predates #112498, so shipping this before the next Odyssey deploy prevents the regression from reaching users.
* The override remains a band-aid: the underlying unscoped global-stylesheet leak is tracked in STATS-334.

## Testing Instructions

* Build Odyssey Stats (`cd apps/odyssey-stats && yarn build`) and confirm `dist/build.min.css` contains `.wp-admin ul.wp-submenu,.wp-admin ul.wp-submenu-wrap{margin-left:0}` (unscoped), matching the currently deployed production build.
* On a self-hosted Jetpack site with this build, open Jetpack → Stats in wp-admin and hover a collapsed admin menu item that has a submenu (e.g. WooCommerce or Posts). The flyout should sit flush against the admin menu with no horizontal gap.

| Before (trunk) | After (this PR) |
| --- | --- |
| <img width="1222" height="1566" alt="Google Chrome -2026-07-17 at 18 14 33@2x" src="https://github.com/user-attachments/assets/7e1190d2-1953-4feb-919a-719f202877d4" /> | <img width="1022" height="1686" alt="Google Chrome -2026-07-17 at 18 21 41@2x" src="https://github.com/user-attachments/assets/5f2f2b85-bcd9-4e64-a23f-0005333bf121" /> |

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
