### PR TITLE
Checkout: add .in domain registrant nexus extra-info form

### DIFF
--- a/client/components/domains/registrant-extra-info/in-form.tsx
+++ b/client/components/domains/registrant-extra-info/in-form.tsx
@@ -1,0 +1,170 @@
+import { FormInputValidation, FormLabel } from '@automattic/components';
+import { camelCase, pick, isEmpty } from '@automattic/js-utils';
+import { LocalizeProps, localize } from 'i18n-calypso';
+import { PureComponent, ReactNode } from 'react';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormSelect from 'calypso/components/forms/form-select';
+import type { DomainContactDetails } from '@automattic/shopping-cart';
+import type { DomainContactDetailsErrors } from '@automattic/wpcom-checkout';
+
+import './style.scss';
+
+const defaultValues = {
+	nexusDeclaration: false,
+	nexusConnectionType: '',
+};
+
+export interface FormProps {
+	contactDetails: Record< string, unknown >;
+	ccTldDetails: Record< string, unknown >;
+	onContactDetailsChange?: ( payload: DomainContactDetails ) => void;
+	contactDetailsValidationErrors: DomainContactDetailsErrors;
+	isVisible?: boolean;
+	onSubmit?: () => void;
+}
+
+export class RegistrantExtraInfoInForm extends PureComponent< FormProps & LocalizeProps > {
+	nexusConnectionTypeOptions: ReactNode[];
+
+	constructor( props: FormProps & LocalizeProps ) {
+		super( props );
+		const { translate } = props;
+		const nexusConnectionTypes = {
+			ENTITY: translate( 'Indian Business Presence' ),
+			COMM: translate( 'Commercial Activity in India' ),
+			MKTG: translate( 'Marketing or Business Development Targeting India' ),
+			CONTENT: translate( 'Content or Digital Services Targeting Indian Users' ),
+			EDU: translate( 'Educational or Research Activities Involving India' ),
+			CULTURE: translate( 'Cultural or Community Activities Connected to India' ),
+			OTHER: translate( 'Other Business Purpose Connected to India' ),
+		};
+		this.nexusConnectionTypeOptions = [
+			<option value="" key="placeholder" disabled>
+				{ translate( 'Select an option' ) }
+			</option>,
+			...Object.entries( nexusConnectionTypes ).map( ( [ optionValue, text ] ) => (
+				<option value={ optionValue } key={ optionValue }>
+					{ text }
+				</option>
+			) ),
+		];
+	}
+
+	componentDidMount() {
+		if ( ! this.isForeignRegistrant() ) {
+			return;
+		}
+
+		// Add defaults to the store to make accepting default values work.
+		const providedDetails = Object.keys( this.props.ccTldDetails );
+		const neededRequiredDetails = [ 'nexusDeclaration', 'nexusConnectionType' ].filter(
+			( key ) => ! providedDetails.includes( key )
+		);
+
+		// Bail early as we already have the details from a previous purchase.
+		if ( isEmpty( neededRequiredDetails ) ) {
+			return;
+		}
+
+		const payload = {
+			extra: {
+				in: pick( defaultValues, neededRequiredDetails ),
+			},
+		};
+
+		this.props.onContactDetailsChange?.( payload );
+	}
+
+	isForeignRegistrant() {
+		const countryCode = this.props.contactDetails?.countryCode as string | undefined;
+		return Boolean( countryCode ) && countryCode !== 'IN';
+	}
+
+	handleChangeEvent = ( event: {
+		target: { id: string; value: string; checked: boolean; type: string };
+	} ) => {
+		const { value, checked, type, id } = event.target;
+		const payload = {
+			extra: {
+				in: { [ camelCase( id ) ]: type === 'checkbox' ? checked : value },
+			},
+		};
+
+		this.props.onContactDetailsChange?.( payload );
+	};
+
+	getNexusDeclarationErrorMessage() {
+		return (
+			this.props.contactDetailsValidationErrors?.extra?.in?.nexusDeclaration ??
+			this.props.translate( 'Required' )
+		);
+	}
+
+	renderNexusConnectionTypeErrors() {
+		const nexusConnectionTypeErrors =
+			this.props.contactDetailsValidationErrors?.extra?.in?.nexusConnectionType;
+		if ( ! nexusConnectionTypeErrors ) {
+			return null;
+		}
+		return <FormInputValidation text={ nexusConnectionTypeErrors } isError />;
+	}
+
+	render() {
+		const { translate } = this.props;
+
+		// The nexus declaration is only required when the registrant is not
+		// providing an Indian address.
+		if ( ! this.isForeignRegistrant() ) {
+			return null;
+		}
+
+		const { nexusDeclaration, nexusConnectionType } = {
+			...defaultValues,
+			...this.props.ccTldDetails,
+		};
+
+		return (
+			<form className="registrant-extra-info__form">
+				<p className="registrant-extra-info__form-desciption">
+					{ translate( 'Almost done! We need some extra details to register your %(tld)s domain.', {
+						args: { tld: '.in' },
+					} ) }
+				</p>
+				<FormFieldset>
+					<FormLabel htmlFor="nexus-connection-type">
+						{ translate( 'Choose the option that best describes your connection to India:' ) }
+					</FormLabel>
+					<FormSelect
+						id="nexus-connection-type"
+						value={ nexusConnectionType }
+						className="registrant-extra-info__form-nexus-connection-type"
+						onChange={ this.handleChangeEvent as any }
+					>
+						{ this.nexusConnectionTypeOptions }
+					</FormSelect>
+					{ this.renderNexusConnectionTypeErrors() }
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel>
+						<FormCheckbox
+							id="nexus-declaration"
+							checked={ Boolean( nexusDeclaration ) }
+							onChange={ this.handleChangeEvent }
+						/>
+						<span>
+							{ translate(
+								'I declare that I have a bona fide legitimate connection to India and that the information provided is accurate.'
+							) }
+						</span>
+						{ nexusDeclaration || (
+							<FormInputValidation text={ this.getNexusDeclarationErrorMessage() } isError />
+						) }
+					</FormLabel>
+				</FormFieldset>
+			</form>
+		);
+	}
+}
+
+export default localize( RegistrantExtraInfoInForm );

--- a/client/components/domains/registrant-extra-info/test/in-form.js
+++ b/client/components/domains/registrant-extra-info/test/in-form.js
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { RegistrantExtraInfoInForm } from '../in-form';
+
+const mockProps = {
+	translate: ( string ) => string,
+	updateContactDetailsCache: () => {},
+	onContactDetailsChange: () => {},
+	ccTldDetails: {},
+	contactDetailsValidationErrors: {},
+};
+
+describe( 'in-form', () => {
+	test( 'renders the nexus fields for a non-Indian registrant', () => {
+		const testProps = {
+			...mockProps,
+			contactDetails: { countryCode: 'US' },
+		};
+
+		render( <RegistrantExtraInfoInForm { ...testProps } /> );
+
+		expect(
+			screen.getByText( 'Choose the option that best describes your connection to India:' )
+		).toBeVisible();
+		expect( screen.getByRole( 'combobox' ) ).toBeVisible();
+		expect( screen.getByRole( 'checkbox' ) ).toBeVisible();
+	} );
+
+	test( 'renders nothing for an Indian registrant', () => {
+		const testProps = {
+			...mockProps,
+			contactDetails: { countryCode: 'IN' },
+		};
+
+		render( <RegistrantExtraInfoInForm { ...testProps } /> );
+
+		expect(
+			screen.queryByText( 'Choose the option that best describes your connection to India:' )
+		).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'combobox' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders nothing when no country has been selected yet', () => {
+		const testProps = {
+			...mockProps,
+			contactDetails: {},
+		};
+
+		render( <RegistrantExtraInfoInForm { ...testProps } /> );
+
+		expect( screen.queryByRole( 'combobox' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders the connection type validation error', () => {
+		const testProps = {
+			...mockProps,
+			contactDetails: { countryCode: 'US' },
+			ccTldDetails: { nexusDeclaration: true },
+			contactDetailsValidationErrors: {
+				extra: {
+					in: {
+						nexusConnectionType: 'Test connection type error.',
+					},
+				},
+			},
+		};
+
+		render( <RegistrantExtraInfoInForm { ...testProps } /> );
+
+		expect( screen.getByText( 'Test connection type error.' ) ).toBeVisible();
+	} );
+} );

--- a/client/my-sites/checkout/src/components/domain-contact-details.tsx
+++ b/client/my-sites/checkout/src/components/domain-contact-details.tsx
@@ -3,6 +3,7 @@ import { Fragment } from 'react';
 import ManagedContactDetailsFormFields from 'calypso/components/domains/contact-details-form-fields/managed-contact-details-form-fields';
 import RegistrantExtraInfoCaForm from 'calypso/components/domains/registrant-extra-info/ca-form';
 import RegistrantExtraInfoFrForm from 'calypso/components/domains/registrant-extra-info/fr-form';
+import RegistrantExtraInfoInForm from 'calypso/components/domains/registrant-extra-info/in-form';
 import RegistrantExtraInfoUkForm from 'calypso/components/domains/registrant-extra-info/uk-form';
 import {
 	hasGoogleApps,
@@ -82,6 +83,16 @@ export default function DomainContactDetails( {
 				<RegistrantExtraInfoFrForm
 					contactDetails={ contactDetails }
 					ccTldDetails={ contactDetails?.extra?.fr ?? {} }
+					onContactDetailsChange={ updateDomainContactFields }
+					contactDetailsValidationErrors={
+						shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
+					}
+				/>
+			) }
+			{ tlds.includes( 'in' ) && (
+				<RegistrantExtraInfoInForm
+					contactDetails={ contactDetails }
+					ccTldDetails={ contactDetails?.extra?.in ?? {} }
 					onContactDetailsChange={ updateDomainContactFields }
 					contactDetailsValidationErrors={
 						shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}

--- a/client/my-sites/checkout/src/hooks/use-cached-contact-details.ts
+++ b/client/my-sites/checkout/src/hooks/use-cached-contact-details.ts
@@ -71,6 +71,12 @@ function convertSnakeCaseContactDetailsExtraToCamelCase(
 			trademarkNumber: extra.fr?.trademark_number,
 			sirenSiret: extra.fr?.siren_siret,
 		},
+		in: {
+			nexusDeclaration: extra.in?.nexus_declaration
+				? String( extra.in.nexus_declaration )
+				: undefined,
+			nexusConnectionType: extra.in?.nexus_connection_type,
+		},
 	};
 }
 

--- a/client/my-sites/checkout/src/test/util/index.ts
+++ b/client/my-sites/checkout/src/test/util/index.ts
@@ -1425,6 +1425,7 @@ export const basicExpectedDomainDetails = {
 	extra: {
 		ca: null,
 		fr: null,
+		in: null,
 		uk: null,
 	},
 	fax: undefined,

--- a/client/my-sites/checkout/src/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/src/types/wpcom-store-state.ts
@@ -4,6 +4,7 @@ import type {
 	CaDomainContactExtraDetails,
 	UkDomainContactExtraDetails,
 	FrDomainContactExtraDetails,
+	InDomainContactExtraDetails,
 } from '@automattic/shopping-cart';
 import type {
 	PossiblyCompleteDomainContactDetails,
@@ -11,6 +12,7 @@ import type {
 	CaDomainContactExtraDetailsErrors,
 	UkDomainContactExtraDetailsErrors,
 	FrDomainContactExtraDetailsErrors,
+	InDomainContactExtraDetailsErrors,
 	ManagedContactDetailsShape,
 	ManagedContactDetailsTldExtraFieldsShape,
 	ManagedValue,
@@ -139,6 +141,28 @@ export function updateManagedContactDetailsShape< A, B >(
 		};
 	}
 
+	if ( data.tldExtraFields?.in ) {
+		if ( update.tldExtraFields?.in ) {
+			tldExtraFields.in = {
+				nexusDeclaration: combine(
+					update.tldExtraFields.in.nexusDeclaration,
+					data.tldExtraFields.in.nexusDeclaration
+				),
+				nexusConnectionType: combine(
+					update.tldExtraFields.in.nexusConnectionType,
+					data.tldExtraFields.in.nexusConnectionType
+				),
+			};
+		} else {
+			tldExtraFields.in = data.tldExtraFields.in;
+		}
+	} else if ( update.tldExtraFields?.in ) {
+		tldExtraFields.in = {
+			nexusDeclaration: construct( update.tldExtraFields.in.nexusDeclaration ),
+			nexusConnectionType: construct( update.tldExtraFields.in.nexusConnectionType ),
+		};
+	}
+
 	return {
 		firstName: combine( update.firstName, data.firstName ),
 		lastName: combine( update.lastName, data.lastName ),
@@ -230,7 +254,17 @@ export function flattenManagedContactDetailsShape< A, B >(
 			  ].filter( Boolean ) as B[] )
 			: [];
 
-	return values.concat( caValues, ukValues, frValues );
+	const inValues =
+		x.tldExtraFields && x.tldExtraFields.in
+			? ( [
+					x.tldExtraFields.in.nexusDeclaration ? f( x.tldExtraFields.in.nexusDeclaration ) : null,
+					x.tldExtraFields.in.nexusConnectionType
+						? f( x.tldExtraFields.in.nexusConnectionType )
+						: null,
+			  ].filter( Boolean ) as B[] )
+			: [];
+
+	return values.concat( caValues, ukValues, frValues, inValues );
 }
 
 export function isValid( arg: ManagedValue ): boolean {
@@ -461,11 +495,13 @@ function prepareTldExtraContactDetails( details: ManagedContactDetails ): {
 	ca: null | CaDomainContactExtraDetails;
 	uk: null | UkDomainContactExtraDetails;
 	fr: null | FrDomainContactExtraDetails;
+	in: null | InDomainContactExtraDetails;
 } {
 	return {
 		ca: prepareCaDomainContactExtraDetails( details ),
 		uk: prepareUkDomainContactExtraDetails( details ),
 		fr: prepareFrDomainContactExtraDetails( details ),
+		in: prepareInDomainContactExtraDetails( details ),
 	};
 }
 
@@ -473,11 +509,13 @@ function prepareTldExtraContactDetailsErrors( details: ManagedContactDetails ): 
 	ca: null | CaDomainContactExtraDetailsErrors;
 	uk: null | UkDomainContactExtraDetailsErrors;
 	fr: null | FrDomainContactExtraDetailsErrors;
+	in: null | InDomainContactExtraDetailsErrors;
 } {
 	return {
 		ca: prepareCaDomainContactExtraDetailsErrors( details ),
 		uk: prepareUkDomainContactExtraDetailsErrors( details ),
 		fr: prepareFrDomainContactExtraDetailsErrors( details ),
+		in: prepareInDomainContactExtraDetailsErrors( details ),
 	};
 }
 
@@ -567,6 +605,30 @@ function prepareFrDomainContactExtraDetailsErrors(
 	return null;
 }
 
+function prepareInDomainContactExtraDetails(
+	details: ManagedContactDetails
+): InDomainContactExtraDetails | null {
+	if ( details.tldExtraFields?.in ) {
+		return {
+			nexusDeclaration: details.tldExtraFields.in.nexusDeclaration?.value === 'true',
+			nexusConnectionType: details.tldExtraFields.in.nexusConnectionType?.value,
+		};
+	}
+	return null;
+}
+
+function prepareInDomainContactExtraDetailsErrors(
+	details: ManagedContactDetails
+): InDomainContactExtraDetailsErrors | null {
+	if ( details.tldExtraFields?.in ) {
+		return {
+			nexusDeclaration: details.tldExtraFields.in?.nexusDeclaration?.errors?.[ 0 ],
+			nexusConnectionType: details.tldExtraFields.in?.nexusConnectionType?.errors?.[ 0 ],
+		};
+	}
+	return null;
+}
+
 export function prepareDomainContactValidationRequest(
 	details: ManagedContactDetails
 ): DomainContactValidationRequest {
@@ -592,6 +654,12 @@ export function prepareDomainContactValidationRequest(
 			registrant_vat_id: details.vatId?.value,
 			trademark_number: details.tldExtraFields.fr.trademarkNumber?.value,
 			siren_siret: details.tldExtraFields.fr.sirenSiret?.value,
+		};
+	}
+	if ( details.tldExtraFields?.in ) {
+		extra.in = {
+			nexus_declaration: details.tldExtraFields.in.nexusDeclaration?.value === 'true',
+			nexus_connection_type: details.tldExtraFields.in.nexusConnectionType?.value,
 		};
 	}
 
@@ -688,6 +756,10 @@ export function formatDomainContactValidationResponse(
 				trademarkNumber: response.messages?.extra?.fr?.trademark_number,
 				sirenSiret: response.messages?.extra?.fr?.siren_siret,
 			},
+			in: {
+				nexusDeclaration: response.messages?.extra?.in?.nexus_declaration,
+				nexusConnectionType: response.messages?.extra?.in?.nexus_connection_type,
+			},
 		},
 	};
 }
@@ -725,6 +797,10 @@ function prepareManagedContactDetailsUpdate(
 				registrantType: rawFields?.extra?.fr?.registrantType,
 				trademarkNumber: rawFields?.extra?.fr?.trademarkNumber,
 				sirenSiret: rawFields?.extra?.fr?.sirenSiret,
+			},
+			in: {
+				nexusDeclaration: rawFields?.extra?.in?.nexusDeclaration?.toString(),
+				nexusConnectionType: rawFields?.extra?.in?.nexusConnectionType,
 			},
 		},
 	};

--- a/packages/api-core/src/domain-whois/types.ts
+++ b/packages/api-core/src/domain-whois/types.ts
@@ -33,6 +33,10 @@ export type DomainContactValidationRequestExtraFields = {
 		trademark_number?: string;
 		siren_siret?: string;
 	};
+	in?: {
+		nexus_declaration?: boolean;
+		nexus_connection_type?: string;
+	};
 	is_for_business?: boolean;
 };
 
@@ -74,6 +78,10 @@ export type ContactValidationResponseMessagesExtra = {
 		trademark_number?: string[];
 		siren_siret?: string[];
 	};
+	in?: {
+		nexus_declaration?: string[];
+		nexus_connection_type?: string[];
+	};
 	is_for_business?: boolean;
 };
 
@@ -109,6 +117,7 @@ export type DomainContactDetailsExtra = {
 	ca?: CaDomainContactExtraDetails | null;
 	uk?: UkDomainContactExtraDetails | null;
 	fr?: FrDomainContactExtraDetails | null;
+	in?: InDomainContactExtraDetails | null;
 };
 
 export type CaDomainContactExtraDetails = {
@@ -137,6 +146,11 @@ export type FrDomainContactExtraDetails = {
  * names and differ per TLD, so this stays deliberately loose.
  */
 export type WhoisContactExtra = Record< string, string >;
+
+export type InDomainContactExtraDetails = {
+	nexusDeclaration?: boolean;
+	nexusConnectionType?: string;
+};
 
 export interface WhoisDataEntry {
 	fname: string;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -1124,6 +1124,7 @@ export type DomainContactDetailsExtra = {
 	ca?: CaDomainContactExtraDetails | null;
 	uk?: UkDomainContactExtraDetails | null;
 	fr?: FrDomainContactExtraDetails | null;
+	in?: InDomainContactExtraDetails | null;
 };
 
 export type CaDomainContactExtraDetails = {
@@ -1143,6 +1144,11 @@ export type FrDomainContactExtraDetails = {
 	registrantVatId?: string;
 	trademarkNumber?: string;
 	sirenSiret?: string;
+};
+
+export type InDomainContactExtraDetails = {
+	nexusDeclaration?: boolean;
+	nexusConnectionType?: string;
 };
 
 export interface TermsOfServiceRecord {

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -268,6 +268,7 @@ type DomainContactDetailsErrorsExtra = {
 	ca?: CaDomainContactExtraDetailsErrors | null;
 	uk?: UkDomainContactExtraDetailsErrors | null;
 	fr?: FrDomainContactExtraDetailsErrors | null;
+	in?: InDomainContactExtraDetailsErrors | null;
 };
 
 export type CaDomainContactExtraDetailsErrors = {
@@ -287,6 +288,11 @@ export type FrDomainContactExtraDetailsErrors = {
 	registrantVatId?: string[] | TranslateResult[];
 	trademarkNumber?: string[] | TranslateResult[];
 	sirenSiret?: string[] | TranslateResult[];
+};
+
+export type InDomainContactExtraDetailsErrors = {
+	nexusDeclaration?: string | TranslateResult;
+	nexusConnectionType?: string | TranslateResult;
 };
 
 export type PayPalExpressEndpoint = (
@@ -414,6 +420,10 @@ export type ManagedContactDetailsTldExtraFieldsShape< T > = {
 		registrantVatId?: T;
 		trademarkNumber?: T;
 		sirenSiret?: T;
+	};
+	in?: {
+		nexusDeclaration?: T;
+		nexusConnectionType?: T;
 	};
 };
 
@@ -583,6 +593,10 @@ export type DomainContactValidationRequestExtraFields = {
 		trademark_number?: string;
 		siren_siret?: string;
 	};
+	in?: {
+		nexus_declaration?: boolean;
+		nexus_connection_type?: string;
+	};
 	is_for_business?: boolean;
 };
 
@@ -601,6 +615,10 @@ export type ContactValidationResponseMessagesExtra = {
 		registrant_type?: string[];
 		trademark_number?: string[];
 		siren_siret?: string[];
+	};
+	in?: {
+		nexus_declaration?: string[];
+		nexus_connection_type?: string[];
 	};
 	is_for_business?: boolean;
 };


### PR DESCRIPTION
Related to DOMENG-689

## Proposed Changes

Adds a per-TLD registrant extra-info form for `.in` (India) domains, shown in the checkout contact-details step. When the registrant provides a **non-Indian** address, the form collects the two pieces of information India's registry requires from foreign/non-resident registrants:

- **Connection type** (`nexusConnectionType`) — a dropdown: Indian Business Presence, Commercial Activity in India, Marketing/Business Development, Content/Digital Services, Educational/Research Activities, Cultural/Community Activities, or Other.
- **Nexus declaration** (`nexusDeclaration`) — a checkbox declaring a bona fide legitimate connection to India.

The fields render **only when a country is selected and it is not `IN`**; for Indian registrants the form renders nothing.

The change follows the existing `ca`/`uk`/`fr` extra-info pattern end to end:

- New `in-form.tsx` component (modelled on `uk-form.tsx`, checkbox handling from `ca-form.tsx`) + unit tests.
- Wired into `domain-contact-details.tsx` on `tlds.includes( 'in' )`.
- Added the `in` shape to every per-TLD type (`shopping-cart`, `api-core`, `wpcom-checkout`) — camelCase in Calypso state, snake_case (`nexus_declaration` / `nexus_connection_type`) in the validation request/response.
- Plumbed `in` through the checkout `wpcom-store-state.ts` mapping layers (merge, flatten, prepare helpers, validation request, response formatting) and the cached-contact-details hook, treating the checkbox as a `'true'`/`'false'` string like `ciraAgreementAccepted`.

This is the **front-end only**. A separate backend PR will add the `.in` validation schema and process the fields; the snake_case keys here must be confirmed against it before merge.

## Why are these changes being made?

`.in` registrations by registrants without an Indian address require a declaration of a legitimate connection ("nexus") to India plus a connection-type classification. Calypso checkout previously had no UI to collect these, so foreign `.in` registrations could not satisfy the registry's requirement.

## Testing Instructions

1. Check out this branch and run the dev server (`yarn start`).
2. Add a `.in` domain registration to the cart and proceed to checkout contact details.
3. Select a **non-Indian** country (e.g. United States): confirm the connection-type dropdown and the declaration checkbox appear, and that their values persist as you edit other fields.
4. Switch the country to **India**: confirm both fields disappear.
5. Automated: `yarn test-client client/components/domains/registrant-extra-info` (37 tests pass, incl. the new `in-form` suite).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
