### PR TITLE
Site level purchases: Harden term lookup and log unknown bill_period_days

### DIFF
--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -674,7 +674,7 @@ export function getBillingMonthsForTerm( term: string ): number {
 	} else if ( term === TERM_CENTENNIALLY ) {
 		return 1200;
 	}
-	throw new Error( `Unknown term: ${ term }` );
+	throw new Error( `Unknown billing term in getBillingMonthsForTerm: ${ term }` );
 }
 
 export function getBillingTermForMonths( term: number ): string {
@@ -703,7 +703,7 @@ export function getBillingTermForMonths( term: number ): string {
 	} else if ( term === 1200 ) {
 		return TERM_CENTENNIALLY;
 	}
-	throw new Error( `Unknown term: ${ term }` );
+	throw new Error( `Unknown month count in getBillingTermForMonths: ${ term }` );
 }
 
 export function plansLink(

--- a/packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
@@ -28,7 +28,12 @@ jest.mock( '../../../purchases', () => ( {
 jest.mock( '../../../wpcom-plans-ui', () => ( {
 	store: 'wpcom-plans-ui',
 } ) );
+jest.mock( '@automattic/api-core', () => ( {
+	...jest.requireActual( '@automattic/api-core' ),
+	logToLogstash: jest.fn().mockResolvedValue( undefined ),
+} ) );
 
+import { logToLogstash } from '@automattic/api-core';
 import { PLAN_PERSONAL, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { useSelect } from '@wordpress/data';
 import * as Plans from '../../';
@@ -226,6 +231,44 @@ describe( 'usePricingMetaForGridPlans', () => {
 
 			expect( pricingMeta ).toEqual( expectedPricingMeta );
 		} );
+	} );
+
+	it( 'should fall back to the site plan price and log when the purchase has an unknown bill_period_days', () => {
+		Plans.useCurrentPlan.mockImplementation( () => ( {
+			productSlug: PLAN_BUSINESS,
+			planSlug: PLAN_BUSINESS,
+			purchaseId: 1234,
+		} ) );
+		Purchases.useSitePurchaseById.mockImplementation( () => ( {
+			ID: '1234',
+			product_slug: PLAN_BUSINESS,
+			price_integer: 600,
+			currency_code: 'USD',
+			bill_period_days: 999,
+		} ) );
+
+		const pricingMeta = usePricingMetaForGridPlans( {
+			planSlugs: [ PLAN_BUSINESS ],
+			siteId,
+			coupon: undefined,
+			useCheckPlanAvailabilityForPurchase,
+		} );
+
+		expect( pricingMeta?.[ PLAN_BUSINESS ]?.originalPrice ).toEqual( {
+			full: 500,
+			monthly: 500,
+		} );
+		expect( logToLogstash ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				feature: 'calypso_client',
+				message: 'usePricingMetaForGridPlans: purchase has an unknown bill_period_days',
+				site_id: siteId,
+				extra: expect.objectContaining( {
+					plan_slug: PLAN_BUSINESS,
+					bill_period_days: 999,
+				} ),
+			} )
+		);
 	} );
 
 	it( 'should return the original price as the site plan price and discounted price as Null for plans not available for purchase', () => {

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -1,4 +1,4 @@
-import { getPurchaseIntroductoryOffer } from '@automattic/api-core';
+import { getPurchaseIntroductoryOffer, logToLogstash } from '@automattic/api-core';
 import {
 	PLAN_MONTHLY_PERIOD,
 	type PlanSlug,
@@ -69,6 +69,32 @@ interface Props {
 
 function getTotalPrice( planPrice: number | null | undefined, addOnPrice = 0 ): number | null {
 	return null !== planPrice && undefined !== planPrice ? planPrice + addOnPrice : null;
+}
+
+const loggedUnknownBillPeriods = new Set< string >();
+
+function logUnknownBillPeriodDays(
+	planSlug: string,
+	purchase: Purchases.RawPurchase,
+	siteId: number | null | undefined
+): void {
+	const key = `${ siteId ?? '' }-${ purchase.ID }-${ purchase.bill_period_days }`;
+	if ( loggedUnknownBillPeriods.has( key ) ) {
+		return;
+	}
+	loggedUnknownBillPeriods.add( key );
+	logToLogstash( {
+		feature: 'calypso_client',
+		message: 'usePricingMetaForGridPlans: purchase has an unknown bill_period_days',
+		site_id: siteId ?? undefined,
+		extra: {
+			plan_slug: planSlug,
+			product_slug: purchase.product_slug,
+			bill_period_days: purchase.bill_period_days,
+			purchase_id: purchase.ID,
+		},
+		tags: [ 'unknown-term', 'bill-period-days' ],
+	} ).catch( () => {} );
 }
 
 /**
@@ -203,6 +229,7 @@ const usePricingMetaForGridPlans = ( {
 					if ( purchasedPlan ) {
 						const introductoryOffer = getPurchaseIntroductoryOffer( purchasedPlan );
 						const billPeriodDays = Number( purchasedPlan.bill_period_days );
+						const term = getTermFromDuration( billPeriodDays );
 						const showIntroOfferHeadline =
 							!! showBillingDescriptionForIncreasedRenewalPrice &&
 							introductoryOffer?.isWithinPeriod;
@@ -211,21 +238,24 @@ const usePricingMetaForGridPlans = ( {
 							: purchasedPlan.price_integer;
 						const isMonthly = billPeriodDays === PLAN_MONTHLY_PERIOD;
 
+						if ( ! term ) {
+							logUnknownBillPeriodDays( planSlug, purchasedPlan, siteId );
+						}
+
 						if ( isMonthly && monthlyPrice !== currentTermPrice ) {
 							monthlyPrice = currentTermPrice;
 							fullPrice = parseFloat( ( currentTermPrice * 12 ).toFixed( 2 ) );
-						} else if ( fullPrice !== currentTermPrice ) {
-							const term = getTermFromDuration( billPeriodDays ) || '';
+						} else if ( term && fullPrice !== currentTermPrice ) {
 							monthlyPrice = calculateMonthlyPrice( term, currentTermPrice );
 							fullPrice = currentTermPrice;
 						}
 
 						if ( showIntroOfferHeadline ) {
-							const renewalTerm = getTermFromDuration( billPeriodDays ) || '';
 							renewalPrice = {
-								monthly: isMonthly
-									? purchasedPlan.price_integer
-									: calculateMonthlyPrice( renewalTerm, purchasedPlan.price_integer ),
+								monthly:
+									isMonthly || ! term
+										? purchasedPlan.price_integer
+										: calculateMonthlyPrice( term, purchasedPlan.price_integer ),
 								full: purchasedPlan.price_integer,
 							};
 						}


### PR DESCRIPTION
Related to [SHILL-2261](https://linear.app/a8c/issue/SHILL-2261/investigate-unknown-term-errors-on-site-level-purchase-details-page)

## Proposed Changes

Follow-up to #112719. Hardens the plan-pricing path so an unmappable billing term can no longer fatal the site-level purchase details page, adds telemetry to find the offending purchases, and makes the two `Unknown term` errors self-identifying.

* Guard `usePricingMetaForGridPlans` so a purchase whose `bill_period_days` maps to no known term falls back to the site-plan price instead of calling `calculateMonthlyPrice('')` (which throws).
* Log such purchases to logstash via `logToLogstash` (`calypso_client`, tags `unknown-term` / `bill-period-days`), deduped per purchase so the REST call fires at most once per bad purchase per page load.
* Rename the two `getBilling*` `Unknown term` errors to name their function (`getBillingMonthsForTerm` / `getBillingTermForMonths`), so log entries are distinguishable and the new text proves the client is running new code.
* Add a unit test for the unknown `bill_period_days` case.

## Why are these changes being made?

The site level purchase settings page shows "%d%% cheaper than monthly" savings badge on the Renew annually nav item (only for annual-period purchases). To do that it calls the `usePricingMetaForGridPlans()` hook. So the page's only use of the hook is a monthly-vs-annual savings comparison. That has a special "current plan" branch and the term math runs on that plan's `bill_period_days`. That branch only executes when the slug being priced (`relatedMonthlyPlanSlug`) equals the site's current-plan slug — i.e. the site is currently on the monthly sibling of the plan you're viewing. When that current purchase's `bill_period_days` doesn't map to a known term, `calculateMonthlyPrice('')` throws and the whole `ManagePurchase` subtree unmounts into the error boundary. We are seeing a number of those errors in production.

#112719 restored the `Number()` coercion on `bill_period_days` and fixed the common cause of the `Unknown term:` fatals on the site-level purchase details page. But the underlying pattern is still fragile: `getTermFromDuration()` returns `undefined` for any value it doesn't map (e.g. one-time `-1`, or any unexpected period), the `|| ''` fallback turns that into `''`, and `calculateMonthlyPrice('')` throws — crashing the whole page through the error boundary. Coercion alone doesn't cover a value that is numeric but genuinely unmapped.

This change stops treating an unknown term as fatal: pricing degrades gracefully to the site-plan price, and the occurrence is logged with enough detail (`plan_slug`, `product_slug`, `bill_period_days`, `purchase_id`, `site_id`) to locate the specific purchases and decide whether the term table needs extending. As a side effect, affected purchases will stop emitting the `site_level_purchases` error-boundary event and start emitting the new, specific logstash message instead — a clean signal to track them down. The distinct error strings also make it possible to tell, from logs alone, which function threw and whether a client has picked up the new code.

## Testing Instructions

TC:
```
yarn test-packages packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
```
The new test ("should fall back to the site plan price and log when the purchase has an unknown `bill_period_days`") asserts the page no longer throws and that `logToLogstash` is called with the expected payload.

Manual testing:
* On a sandbox, open a site-level purchase details page (`/purchases/subscriptions/:site/:purchaseId`) for a paid plan.
* Confirm the page renders without a fatal error.
* To exercise the guard directly, temporarily force `getTermFromDuration` to return `undefined` (or point at a purchase with an unusual `bill_period_days`) and confirm: the page still renders using the site-plan price, and a `usePricingMetaForGridPlans: purchase has an unknown bill_period_days` entry appears in logstash (once per purchase), not the old `site_level_purchases` boundary error.
