### PR TITLE
e2e: Fix Form block Name field for WP 7.1 change

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
@@ -1,3 +1,4 @@
+import { ElementHandle } from 'playwright';
 import { OpenInlineInserter } from '../../pages';
 import {
 	disableFormEmailNotifications,
@@ -53,9 +54,30 @@ export class AllFormFieldsFlow implements BlockFlow {
 		} );
 		let lastBlockName = 'Text input field';
 
+		// Name field is named differently in WP 7.0 vs 7.1. Sigh.
+		// @todo Merge back into `remainingBlocksToAdd` once WP 7.1 is the minimum version tested against.
+		const nameFieldHandle = await this.addFieldBlockToForm(
+			context,
+			'Name field',
+			lastBlockName,
+			isRefactor,
+			// prettier-ignore
+			`:is( ${ makeSelectorFromBlockName( 'Name' ) }, ${ makeSelectorFromBlockName( 'Name field' ) } )`
+		);
+		const nameFieldName = await nameFieldHandle.getAttribute( 'data-title' );
+		if ( nameFieldName === null ) {
+			throw new Error( 'Name field element has no data-title\n' + nameFieldHandle );
+		}
+		lastBlockName = nameFieldName;
+		await labelFormFieldBlock( context.addedBlockLocator, {
+			blockName: lastBlockName,
+			accessibleLabelName: 'Add label…',
+			labelText: this.addLabelPrefix( 'Name field' ),
+			isRefactor,
+		} );
+
 		// Add remaining field blocks, labeling as we go.
 		const remainingBlocksToAdd = [
-			[ 'Name', 'Add label…', 'Name field' ],
 			[ 'Email field', 'Add label…' ],
 			[ 'Website field', 'Add label…' ],
 			[ 'Date picker', 'Add label…' ],
@@ -67,18 +89,12 @@ export class AllFormFieldsFlow implements BlockFlow {
 			[ 'Dropdown field', 'Add label' ],
 			[ 'Terms consent', 'Add implicit consent message…' ],
 		];
-		for ( const [ blockName, accessibleLabelName, inserterBlockName ] of remainingBlocksToAdd ) {
-			await this.addFieldBlockToForm(
-				context,
-				inserterBlockName ?? blockName,
-				blockName,
-				lastBlockName,
-				isRefactor
-			);
+		for ( const [ blockName, accessibleLabelName ] of remainingBlocksToAdd ) {
+			await this.addFieldBlockToForm( context, blockName, lastBlockName, isRefactor );
 			await labelFormFieldBlock( context.addedBlockLocator, {
 				blockName,
 				accessibleLabelName,
-				labelText: this.addLabelPrefix( inserterBlockName ?? blockName ),
+				labelText: this.addLabelPrefix( blockName ),
 				isRefactor,
 			} );
 			lastBlockName = blockName;
@@ -157,18 +173,19 @@ export class AllFormFieldsFlow implements BlockFlow {
 	 * Adds a field block to the form using the inline inserter.
 	 *
 	 * @param {EditorContext} context The editor context object.
-	 * @param {string} inserterBlockName Name of the block in the inserter.
-	 * @param {string} selectorBlockName Name of the block for the selector.
+	 * @param {string} blockName Name of the block.
 	 * @param {string} lastBlockName The name of the previously inserted block.
 	 * @param {boolean} isRefactor Whether the block is part of the refactored form fields.
+	 * @param {string} [blockSelector] Selector for the block. Defaults to `makeSelectorFromBlockName( blockName )`.
+	 * @returns An element handle to the added block.
 	 */
 	private async addFieldBlockToForm(
 		context: EditorContext,
-		inserterBlockName: string,
-		selectorBlockName: string,
+		blockName: string,
 		lastBlockName: string,
-		isRefactor: boolean
-	) {
+		isRefactor: boolean,
+		blockSelector?: string
+	): Promise< ElementHandle > {
 		const openInlineInserter: OpenInlineInserter = async ( editorCanvas ) => {
 			if ( isRefactor ) {
 				await context.editorPage.selectParentBlock( lastBlockName );
@@ -179,9 +196,9 @@ export class AllFormFieldsFlow implements BlockFlow {
 
 			await editorCanvas.getByRole( 'button', { name: 'Add block' } ).first().click();
 		};
-		await context.editorPage.addBlockInline(
-			inserterBlockName,
-			makeSelectorFromBlockName( selectorBlockName ),
+		return await context.editorPage.addBlockInline(
+			blockName,
+			blockSelector || makeSelectorFromBlockName( blockName ),
 			openInlineInserter
 		);
 	}


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

It seems that WordPress 7.1 goes back to deriving the block name from the name rather than the variant. So for now we have to account for both ways.

This partially reverts #108914 to do it a different way.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Because the E2E is broken against jetpackedgewpbeta.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn workspace wp-e2e-tests build && CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test --workerIdleMemoryLimit=512 test/e2e/specs/blocks/blocks__jetpack-forms.ts`
* `yarn workspace wp-e2e-tests build && CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="desktop" ATOMIC_VARIATION="wp-beta" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test --workerIdleMemoryLimit=512 test/e2e/specs/blocks/blocks__jetpack-forms.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
