### PR TITLE
Dashboard: add Tracks events for clicks on the global Domains page

### DIFF
--- a/client/dashboard/domains/add-domain-button.tsx
+++ b/client/dashboard/domains/add-domain-button.tsx
@@ -5,6 +5,7 @@ import { Button, Dropdown, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { search, globe, chevronUp, chevronDown } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
+import { useAnalytics } from '../app/analytics';
 import { useAppContext } from '../app/context';
 import { siteRoute } from '../app/router/sites';
 import { getCurrentDashboard } from '../app/routing';
@@ -92,6 +93,8 @@ function AddDomainDropdown( {
 	onTransferOrConnectClick: () => void;
 	transferLabel: string;
 } ) {
+	const { recordTracksEvent } = useAnalytics();
+
 	return (
 		<Dropdown
 			renderToggle={ ( { isOpen, onToggle } ) => (
@@ -100,7 +103,12 @@ function AddDomainDropdown( {
 					iconPosition="right"
 					variant="primary"
 					__next40pxDefaultSize
-					onClick={ onToggle }
+					onClick={ () => {
+						if ( ! isOpen ) {
+							recordTracksEvent( 'calypso_dashboard_domains_add_domain_clicked' );
+						}
+						onToggle();
+					} }
 					aria-expanded={ isOpen }
 				>
 					{ __( 'Add domain name' ) }
@@ -108,10 +116,28 @@ function AddDomainDropdown( {
 			) }
 			renderContent={ () => (
 				<>
-					<MenuItem iconPosition="left" icon={ search } onClick={ onSearchClick }>
+					<MenuItem
+						iconPosition="left"
+						icon={ search }
+						onClick={ () => {
+							recordTracksEvent( 'calypso_dashboard_domains_add_domain_option_clicked', {
+								option: 'search',
+							} );
+							onSearchClick();
+						} }
+					>
 						{ __( 'Search domain names' ) }
 					</MenuItem>
-					<MenuItem iconPosition="left" icon={ globe } onClick={ onTransferOrConnectClick }>
+					<MenuItem
+						iconPosition="left"
+						icon={ globe }
+						onClick={ () => {
+							recordTracksEvent( 'calypso_dashboard_domains_add_domain_option_clicked', {
+								option: 'transfer_or_connect',
+							} );
+							onTransferOrConnectClick();
+						} }
+					>
 						{ transferLabel }
 					</MenuItem>
 				</>

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -19,6 +19,7 @@ import {
 	domainsContactInfoRoute,
 } from '../../app/router/domains';
 import { getCurrentDashboard } from '../../app/routing';
+import ComponentViewTracker from '../../components/component-view-tracker';
 import { isDomainRenewable, canSetAsPrimary, getDomainRenewalUrl } from '../../utils/domain';
 import { isTransferrableToWpcom } from '../../utils/domain-types';
 import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
@@ -70,6 +71,12 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 				label: __( 'Renew' ),
 				callback: ( items: DomainSummary[] ) => {
 					const domain = items[ 0 ];
+
+					recordTracksEvent( 'calypso_dashboard_domains_action_click', {
+						action: 'renew',
+						domain: domain.domain,
+					} );
+
 					const purchase = purchases?.find(
 						( p ) => p.ID === parseInt( domain.subscription_id ?? '0', 10 )
 					);
@@ -88,6 +95,11 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 				label: __( 'Set up' ),
 				callback: ( items: DomainSummary[] ) => {
 					const domain = items[ 0 ];
+
+					recordTracksEvent( 'calypso_dashboard_domains_action_click', {
+						action: 'setup',
+						domain: domain.domain,
+					} );
 
 					router.navigate( {
 						to: domainConnectionSetupRoute.fullPath,
@@ -113,6 +125,11 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 				callback: ( items: DomainSummary[] ) => {
 					const domain = items[ 0 ];
 
+					recordTracksEvent( 'calypso_dashboard_domains_action_click', {
+						action: 'manage-domain',
+						domain: domain.domain,
+					} );
+
 					const targetRoute =
 						domain.subtype.id === DomainSubtype.DOMAIN_TRANSFER &&
 						config.isEnabled( 'domain-transfer-redesign' )
@@ -137,6 +154,11 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 				callback: ( items: DomainSummary[] ) => {
 					const domain = items[ 0 ];
 
+					recordTracksEvent( 'calypso_dashboard_domains_action_click', {
+						action: 'manage-dns-settings',
+						domain: domain.domain,
+					} );
+
 					router.navigate( {
 						to: domainDnsRoute.fullPath,
 						params: {
@@ -158,6 +180,11 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 				callback: ( domains: DomainSummary[] ) => {
 					const domain = domains[ 0 ];
 					const site = sitesByBlogId[ domain.blog_id ];
+
+					recordTracksEvent( 'calypso_dashboard_domains_action_click', {
+						action: 'set-primary-site-address',
+						domain: domain.domain,
+					} );
 
 					if ( ! site ) {
 						return;
@@ -214,6 +241,12 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 				supportsBulk: false,
 				callback: ( items: DomainSummary[] ) => {
 					const domain = items[ 0 ];
+
+					recordTracksEvent( 'calypso_dashboard_domains_action_click', {
+						action: 'transfer-domain',
+						domain: domain.domain,
+					} );
+
 					const siteSlug = sitesByBlogId[ domain.blog_id ]?.slug ?? domain.site_slug;
 					const queryArgs: Record< string, string > = {
 						initialQuery: domain.domain,
@@ -242,6 +275,11 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 				callback: ( items: DomainSummary[] ) => {
 					const domain = items[ 0 ];
 
+					recordTracksEvent( 'calypso_dashboard_domains_action_click', {
+						action: 'connect-to-site',
+						domain: domain.domain,
+					} );
+
 					router.navigate( {
 						to: domainTransferToOtherSiteRoute.fullPath,
 						params: {
@@ -269,6 +307,10 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 					const site = sitesByBlogId[ items[ 0 ].blog_id ];
 					return site ? (
 						<Suspense fallback={ null }>
+							<ComponentViewTracker
+								eventName="calypso_dashboard_domains_action_click"
+								properties={ { action: 'change-site-address', domain: items[ 0 ].domain } }
+							/>
 							<SiteChangeAddressContent
 								site={ site }
 								domain={ items[ 0 ] }
@@ -286,6 +328,11 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 					if ( domains.length === 0 ) {
 						return;
 					}
+
+					recordTracksEvent( 'calypso_dashboard_domains_action_click', {
+						action: 'manage-contact-info',
+						domain: domains[ 0 ].domain,
+					} );
 
 					if ( domains.length === 1 ) {
 						return router.navigate( {
@@ -316,13 +363,19 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 				supportsBulk: true,
 				callback: () => {},
 				RenderModal: ( { items, closeModal = noop, onActionPerformed = noop } ) => (
-					<AutoRenewModal
-						items={ items }
-						onSuccess={ () => {
-							onActionPerformed( items );
-							closeModal();
-						} }
-					/>
+					<>
+						<ComponentViewTracker
+							eventName="calypso_dashboard_domains_action_click"
+							properties={ { action: 'manage-auto-renew', domain: items[ 0 ].domain } }
+						/>
+						<AutoRenewModal
+							items={ items }
+							onSuccess={ () => {
+								onActionPerformed( items );
+								closeModal();
+							} }
+						/>
+					</>
 				),
 				isEligible: ( item ) => isDomainRenewable( item ),
 			},

--- a/client/dashboard/domains/dataviews/field-expiry.tsx
+++ b/client/dashboard/domains/dataviews/field-expiry.tsx
@@ -2,6 +2,7 @@ import { DomainSubtype, DomainStatus } from '@automattic/api-core';
 import { Link } from '@tanstack/react-router';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useAnalytics } from '../../app/analytics';
 import { purchaseSettingsRoute } from '../../app/router/me';
 import { Text } from '../../components/text';
 import { canEnableAutoRenew } from '../../utils/domain';
@@ -16,6 +17,8 @@ export const DomainExpiryField = ( {
 	domain: DomainSummary;
 	value: string;
 } ) => {
+	const { recordTracksEvent } = useAnalytics();
+
 	// Site Overview does not show the Status column, so we use this column for error messages.
 	if (
 		inOverview &&
@@ -38,6 +41,11 @@ export const DomainExpiryField = ( {
 				<Link
 					to={ purchaseSettingsRoute.fullPath }
 					params={ { purchaseId: domain.subscription_id } }
+					onClick={ () =>
+						recordTracksEvent( 'calypso_dashboard_domains_turn_on_auto_renew_click', {
+							domain: domain.domain,
+						} )
+					}
 				>
 					{ __( 'Turn on auto-renew' ) }
 				</Link>

--- a/client/dashboard/domains/dataviews/views.ts
+++ b/client/dashboard/domains/dataviews/views.ts
@@ -41,6 +41,12 @@ export function recordDomainViewChanges(
 	newView: View,
 	recordTracksEvent: AnalyticsClient[ 'recordTracksEvent' ]
 ) {
+	// Fire once when the user starts searching (empty -> non-empty), rather than
+	// on every keystroke, and without logging the term itself.
+	if ( ! oldView.search && newView.search ) {
+		recordTracksEvent( 'calypso_dashboard_domains_search' );
+	}
+
 	if (
 		oldView.sort?.field !== newView.sort?.field ||
 		oldView.sort?.direction !== newView.sort?.direction

--- a/client/dashboard/domains/dataviews/views.ts
+++ b/client/dashboard/domains/dataviews/views.ts
@@ -41,8 +41,6 @@ export function recordDomainViewChanges(
 	newView: View,
 	recordTracksEvent: AnalyticsClient[ 'recordTracksEvent' ]
 ) {
-	// Fire once when the user starts searching (empty -> non-empty), rather than
-	// on every keystroke, and without logging the term itself.
 	if ( ! oldView.search && newView.search ) {
 		recordTracksEvent( 'calypso_dashboard_domains_search' );
 	}


### PR DESCRIPTION
Part of DOTMSD-1424

## Proposed Changes

Adds click tracking to the new Dashboard's global `/domains` page for parity with the Sites List, so MSD usage can be analyzed in the Superset navigation dashboard:

* `calypso_dashboard_domains_search` — fired once when the search goes from empty to non-empty (same empty→non-empty pattern as `calypso_dashboard_sites_search`; the search term itself is not logged).
* `calypso_dashboard_domains_add_domain_clicked` — fired when the "Add domain name" toggle button is clicked (opening only, parity with `calypso_dashboard_sites_add_new_site_clicked`).
* `calypso_dashboard_domains_add_domain_option_clicked` — fired when a dropdown option is chosen, with `option: 'search' | 'transfer_or_connect'`.
* `calypso_dashboard_domains_turn_on_auto_renew_click` — fired when the "Turn on auto-renew" link under the Paid Until date is clicked, with `domain`.
* `calypso_dashboard_domains_action_click` — unified event for all row actions (both the hover/primary actions like Renew and View settings, and the kebab menu items), with `action: '<action-id>'` and `domain` properties (parity with `calypso_dashboard_sites_action_click`). Covered actions: `renew`, `setup`, `manage-domain`, `manage-dns-settings`, `set-primary-site-address`, `transfer-domain`, `connect-to-site`, `manage-contact-info`, and the modal-based `change-site-address` and `manage-auto-renew` (tracked via `ComponentViewTracker`, same as the Sites List modal actions).

The existing `calypso_dashboard_domain_list_change_primary_link*` events are kept alongside the new unified event, matching the Sites List approach of keeping legacy per-action events.

## Why are these changes being made?

* The MSD Navigation Dashboard on Superset needs click-level Tracks data for the global Domains page. The first MSD iteration prioritized thorough tracking on the Sites List; this brings the Domains page to parity so the same usage questions can be answered for i2.

## Testing Instructions

1. Open the multi-site dashboard `/domains` page with the Tracks debugger enabled (or watch `window.console` with `localStorage.setItem( 'debug', 'calypso:analytics*' )`).
2. Type in the search bar → `calypso_dashboard_domains_search` fires once when the term goes from empty to non-empty (not per keystroke).
3. Click "Add domain name" → `calypso_dashboard_domains_add_domain_clicked` fires on open (not on close). Click each dropdown option → `calypso_dashboard_domains_add_domain_option_clicked` fires with `option: search` / `transfer_or_connect`.
4. For a domain with auto-renew off, click "Turn on auto-renew" under the Paid Until date → `calypso_dashboard_domains_turn_on_auto_renew_click` fires with the domain.
5. Trigger row actions from both the hover/primary buttons (Renew, View settings) and the kebab menu → `calypso_dashboard_domains_action_click` fires with the matching `action` and `domain`. For "Change site address" and "Manage auto-renew", the event fires when the modal opens.

Note: local `yarn typecheck-client` was skipped in this environment (no `node_modules` in the worktree); relying on the `type_check_client` CI check.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)