### PR TITLE
Add shape and origin diagnostics to unknown bill_period_days log

### DIFF
--- a/packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
@@ -265,7 +265,9 @@ describe( 'usePricingMetaForGridPlans', () => {
 				site_id: siteId,
 				extra: expect.objectContaining( {
 					plan_slug: PLAN_BUSINESS,
-					bill_period_days: 999,
+					purchase_id: '1234',
+					bill_period_days_snake: '999',
+					object_keys: expect.stringContaining( 'bill_period_days' ),
 				} ),
 			} )
 		);

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -78,20 +78,36 @@ function logUnknownBillPeriodDays(
 	purchase: Purchases.RawPurchase,
 	siteId: number | null | undefined
 ): void {
-	const key = `${ siteId ?? '' }-${ purchase.ID }-${ purchase.bill_period_days }`;
+	const shape = purchase as unknown as Record< string, unknown >;
+	const purchaseId = shape.ID ?? shape.id;
+	const key = `${ siteId ?? '' }-${ String( purchaseId ) }-${ String(
+		shape.bill_period_days ?? shape.billPeriodDays
+	) }`;
 	if ( loggedUnknownBillPeriods.has( key ) ) {
 		return;
 	}
 	loggedUnknownBillPeriods.add( key );
+	const win =
+		typeof window !== 'undefined'
+			? ( window as unknown as { COMMIT_SHA?: string; location?: Location } )
+			: undefined;
 	logToLogstash( {
 		feature: 'calypso_client',
 		message: 'usePricingMetaForGridPlans: purchase has an unknown bill_period_days',
 		site_id: siteId ?? undefined,
 		extra: {
 			plan_slug: planSlug,
-			product_slug: purchase.product_slug,
-			bill_period_days: purchase.bill_period_days,
-			purchase_id: purchase.ID,
+			purchase_id: String( purchaseId ),
+			object_keys: Object.keys( shape ).sort().join( ',' ),
+			bill_period_days_snake: String( shape.bill_period_days ),
+			bill_period_days_camel: String( shape.billPeriodDays ),
+			product_slug_snake: String( shape.product_slug ),
+			product_slug_camel: String( shape.productSlug ),
+			expiry_status: String( shape.expiry_status ?? shape.expiryStatus ),
+			path: win?.location?.pathname ?? '',
+			commit_sha: String( win?.COMMIT_SHA ?? '' ),
+			caller_stack:
+				new Error( 'unknown-bill-period' ).stack?.split( '\n' ).slice( 0, 20 ).join( '\n' ) ?? '',
 		},
 		tags: [ 'unknown-term', 'bill-period-days' ],
 	} ).catch( () => {} );


### PR DESCRIPTION
Related to [SHILL-2261](https://linear.app/a8c/issue/SHILL-2261/investigate-unknown-term-errors-on-site-level-purchase-details-page)

## Proposed Changes

Enriches the `usePricingMetaForGridPlans: purchase has an unknown bill_period_days` logstash log (added in #112744) so we can determine, from production, why some current-plan purchases have no resolvable billing term and where they come from.

* Log `object_keys` (the purchase's full property list) — the decisive signal for snake_case (raw) vs camelCase (assembled) shape.
* Log both casings of the key fields: `bill_period_days_snake`/`bill_period_days_camel`, `product_slug_snake`/`product_slug_camel`, and `expiry_status` (either casing).
* Log the emitting `path` (route), the client `commit_sha` (`window.COMMIT_SHA`), and a trimmed `caller_stack` to pin the calling code and build.
* `String()`-coerce values so they always appear (previously `undefined` fields were silently dropped by `JSON.stringify`, which is what obscured the shape). Per-purchase dedupe is retained.
* Update the unit test to assert the new payload keys.

## Why are these changes being made?

Production is emitting many of these logs whose `extra` contains only `{ "plan_slug": "..." }`. Because `logToLogstash` runs the payload through `JSON.stringify` (which omits `undefined`), that means `product_slug`, `bill_period_days`, and `purchase_id` were all `undefined` — i.e. absent from the purchase object, not set to an exotic value. `Number(undefined)` is `NaN`, so `getTermFromDuration` returns `undefined` and the guard logs it.

All three snake_case fields being absent points to a shape mismatch: the object looks like the camelCase assembled `Purchase` (`billPeriodDays`/`productSlug`/`id`) rather than the raw `RawPurchase` the hook expects. At current HEAD the data path is uniformly raw, so this shouldn't originate from fresh code — which suggests version/bundle skew (a stale client pairing new pricing code with an old assembling purchases path). These diagnostics let us confirm the shape (`object_keys`, dual-casing fields), the build (`commit_sha`), and the origin (`path`, `caller_stack`) directly from the logs, and separate genuine exotic billing periods from this noise.

No PII is logged: only property names, slugs, ids, billing periods, expiry status, the route path, and code locations — never payment or personal fields.

## Testing Instructions

TC:
```
yarn test-packages packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
```

Manual testing:
* Point `usePricingMetaForGridPlans` at a current-plan purchase with an unmappable `bill_period_days` (or temporarily force `getTermFromDuration` to return `undefined`).
* Confirm a single `usePricingMetaForGridPlans: purchase has an unknown bill_period_days` logstash entry is emitted whose `extra` now includes `object_keys`, `bill_period_days_snake`/`_camel`, `path`, `commit_sha`, and `caller_stack`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
