### PR TITLE
Add trace IDs to AI feedback

### DIFF
--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -11,6 +11,7 @@ import { useNavigate } from 'react-router-dom';
 import { LOCAL_TOOL_RUNNING_MESSAGE } from '../../constants';
 import { useAgentsManagerContext } from '../../contexts';
 import { useRegisterCustomActions } from '../../hooks/custom-actions';
+import useAgentTraceIds from '../../hooks/use-agent-trace-ids';
 import { useBroadcastConversationActivity } from '../../hooks/use-broadcast-conversation-activity';
 import useCheckpointAction from '../../hooks/use-checkpoint-action';
 import useConversation from '../../hooks/use-conversation';
@@ -254,6 +255,7 @@ export default function OrchestratorChat( {
 		progressMessage,
 	} = useAgentChat( agentConfig! );
 	const messagesRef = useRef( messages );
+	const getTraceIdForMessage = useAgentTraceIds( agentConfig );
 	const previousMessagesRef = useRef( messages );
 	const showComponentOrderRef = useRef< Map< string, number > >( new Map() );
 	const nextShowComponentOrderRef = useRef( 0 );
@@ -447,6 +449,7 @@ export default function OrchestratorChat( {
 		useFeedbackAction( {
 			registerMessageActions,
 			messages,
+			getTraceIdForMessage,
 		} );
 
 	// Add Agenttic's built-in regenerate action on agent messages for providers
@@ -867,8 +870,11 @@ export default function OrchestratorChat( {
 		const latestAgentMessageId = getLatestAgentMessageId( currentMessages );
 
 		currentMessages = currentMessages.map( ( message ) => {
+			const traceId = getTraceIdForMessage( message.id );
+			const messageWithTraceId = traceId ? { ...message, traceId } : message;
+
 			if ( message.id.endsWith( '-next-step' ) ) {
-				return message;
+				return messageWithTraceId;
 			}
 
 			const directActions = [
@@ -880,7 +886,7 @@ export default function OrchestratorChat( {
 				} ),
 			];
 			if ( directActions.length === 0 ) {
-				return message;
+				return messageWithTraceId;
 			}
 
 			const existingActions = message.actions?.filter(
@@ -891,7 +897,7 @@ export default function OrchestratorChat( {
 			);
 
 			return {
-				...message,
+				...messageWithTraceId,
 				actions: [ ...( existingActions ?? [] ), ...directActions ].sort(
 					( actionA, actionB ) => ( actionA.order ?? Infinity ) - ( actionB.order ?? Infinity )
 				),
@@ -906,6 +912,7 @@ export default function OrchestratorChat( {
 		getCopyActionsForMessage,
 		getShowComponentOrder,
 		getFeedbackActionsForMessage,
+		getTraceIdForMessage,
 		getRegenerateActionsForMessage,
 		isBuildingSite,
 		isProcessing,

--- a/packages/agents-manager/src/hooks/__tests__/use-agent-trace-ids.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-agent-trace-ids.test.ts
@@ -1,0 +1,145 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import useAgentTraceIds from '../use-agent-trace-ids';
+import type { UseAgentChatConfig } from '@automattic/agenttic-client';
+
+const agentConfig = {
+	agentUrl: 'https://public-api.wordpress.com/wpcom/v2/ai/agent',
+	agentId: 'wp-orchestrator',
+	sessionId: 'session-1',
+} as UseAgentChatConfig;
+
+const agentUrl = `${ agentConfig.agentUrl }/${ agentConfig.agentId }`;
+
+function createResponse( body: string, contentType: string | null ) {
+	return {
+		clone: jest.fn( () => ( {
+			text: jest.fn().mockResolvedValue( body ),
+		} ) ),
+		headers: {
+			get: jest.fn( ( header: string ) =>
+				header.toLowerCase() === 'content-type' ? contentType : null
+			),
+		},
+	} as unknown as Response;
+}
+
+function createTraceEvent( messageId: string, traceId: string ) {
+	return {
+		result: {
+			traceId,
+			status: {
+				message: {
+					messageId,
+				},
+			},
+		},
+	};
+}
+
+describe( 'useAgentTraceIds', () => {
+	let originalFetch: typeof window.fetch;
+
+	beforeEach( () => {
+		originalFetch = window.fetch;
+	} );
+
+	afterEach( () => {
+		window.fetch = originalFetch;
+		jest.clearAllMocks();
+	} );
+
+	async function fetchAndFlush( input: RequestInfo | URL ): Promise< Response > {
+		let response: Response | undefined;
+		await act( async () => {
+			response = await window.fetch( input );
+			await Promise.resolve();
+		} );
+		return response!;
+	}
+
+	it( 'captures a trace ID from an agent JSON response', async () => {
+		const response = createResponse(
+			JSON.stringify( createTraceEvent( 'message-json', 'trace-json' ) ),
+			'application/json'
+		);
+		const fetchSpy = jest.fn().mockResolvedValue( response );
+		window.fetch = fetchSpy as unknown as typeof window.fetch;
+
+		const { result } = renderHook( () => useAgentTraceIds( agentConfig ) );
+
+		await expect( fetchAndFlush( agentUrl ) ).resolves.toBe( response );
+
+		await waitFor( () => expect( result.current( 'message-json' ) ).toBe( 'trace-json' ) );
+		expect( fetchSpy ).toHaveBeenCalledWith( agentUrl, undefined );
+	} );
+
+	it( 'captures trace IDs from agent SSE responses', async () => {
+		const response = createResponse(
+			[
+				'event: message',
+				`data: ${ JSON.stringify( createTraceEvent( 'message-sse-1', 'trace-sse-1' ) ) }`,
+				'',
+				`data: ${ JSON.stringify( createTraceEvent( 'message-sse-2', 'trace-sse-2' ) ) }`,
+				'',
+			].join( '\n' ),
+			'text/event-stream; charset=utf-8'
+		);
+		window.fetch = jest.fn().mockResolvedValue( response ) as unknown as typeof window.fetch;
+
+		const { result } = renderHook( () => useAgentTraceIds( agentConfig ) );
+
+		await fetchAndFlush( agentUrl );
+
+		await waitFor( () => {
+			expect( result.current( 'message-sse-1' ) ).toBe( 'trace-sse-1' );
+			expect( result.current( 'message-sse-2' ) ).toBe( 'trace-sse-2' );
+		} );
+	} );
+
+	it( 'ignores responses for other URLs', async () => {
+		const response = createResponse(
+			JSON.stringify( createTraceEvent( 'message-other', 'trace-other' ) ),
+			'application/json'
+		);
+		window.fetch = jest.fn().mockResolvedValue( response ) as unknown as typeof window.fetch;
+
+		const { result } = renderHook( () => useAgentTraceIds( agentConfig ) );
+
+		await fetchAndFlush( `${ agentConfig.agentUrl }/other-agent` );
+
+		expect( response.clone ).not.toHaveBeenCalled();
+		expect( result.current( 'message-other' ) ).toBeUndefined();
+	} );
+
+	it( 'supports Request-like objects when matching agent URLs', async () => {
+		const response = createResponse(
+			JSON.stringify( createTraceEvent( 'message-request', 'trace-request' ) ),
+			'application/json'
+		);
+		window.fetch = jest.fn().mockResolvedValue( response ) as unknown as typeof window.fetch;
+
+		const { result } = renderHook( () => useAgentTraceIds( agentConfig ) );
+
+		await fetchAndFlush( { url: agentUrl } as Request );
+
+		await waitFor( () => expect( result.current( 'message-request' ) ).toBe( 'trace-request' ) );
+	} );
+
+	it( 'restores calls to the previous fetch implementation on unmount', async () => {
+		const response = createResponse( '{}', 'application/json' );
+		const fetchSpy = jest.fn().mockResolvedValue( response );
+		window.fetch = fetchSpy as unknown as typeof window.fetch;
+
+		const { unmount } = renderHook( () => useAgentTraceIds( agentConfig ) );
+		const wrappedFetch = window.fetch;
+
+		unmount();
+
+		expect( window.fetch ).not.toBe( wrappedFetch );
+		await window.fetch( 'https://example.com' );
+		expect( fetchSpy ).toHaveBeenCalledWith( 'https://example.com' );
+	} );
+} );

--- a/packages/agents-manager/src/hooks/__tests__/use-feedback-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-feedback-action.test.ts
@@ -182,6 +182,31 @@ describe( 'useFeedbackAction', () => {
 			);
 		} );
 
+		it( 'sends rating with `trace_id` when available', async () => {
+			const messages = [ createMessage( 'msg-1', 'agent', 'Here is the answer' ) ];
+			renderHook( () =>
+				useFeedbackAction( {
+					...defaultConfig,
+					messages,
+					getTraceIdForMessage: () => 'trace-123',
+				} )
+			);
+
+			await triggerFeedback( 'msg-1', 'up' );
+
+			expect( mockFetch ).toHaveBeenCalledWith(
+				'https://public-api.wordpress.com/wpcom/v2/ai/feedback/session-abc/rate',
+				expect.objectContaining( {
+					body: JSON.stringify( {
+						message_id: 'msg-1',
+						rating: 'up',
+						message_text: 'Here is the answer',
+						trace_id: 'trace-123',
+					} ),
+				} )
+			);
+		} );
+
 		it( 'records the verbatim Big Sky thumbs-up event', async () => {
 			renderHook( () => useFeedbackAction( defaultConfig ) );
 			await triggerFeedback( 'msg-1', 'up' );
@@ -270,6 +295,25 @@ describe( 'useFeedbackAction', () => {
 					],
 				} )
 			);
+		} );
+
+		it( 'submits feedback text with `trace_id` when available', async () => {
+			const messages = [ createMessage( 'msg-1', 'agent', 'Bad answer' ) ];
+			const { result } = renderHook( () =>
+				useFeedbackAction( {
+					...defaultConfig,
+					messages,
+					getTraceIdForMessage: () => 'trace-123',
+				} )
+			);
+			await triggerFeedback( 'msg-1', 'down' );
+
+			await act( async () => {
+				await result.current.submitFeedbackText( 'The answer was incorrect' );
+			} );
+
+			const body = JSON.parse( findFetchCall( '/text' )[ 1 ].body );
+			expect( body.trace_id ).toBe( 'trace-123' );
 		} );
 
 		it( 'limits conversation context to last 4 messages', async () => {

--- a/packages/agents-manager/src/hooks/use-agent-trace-ids.ts
+++ b/packages/agents-manager/src/hooks/use-agent-trace-ids.ts
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import type { UseAgentChatConfig } from '@automattic/agenttic-client';
+
+interface TraceCapture {
+	messageId: string;
+	traceId: string;
+}
+
+function isRecord( value: unknown ): value is Record< string, unknown > {
+	return typeof value === 'object' && value !== null;
+}
+
+function getString( value: unknown ): string | undefined {
+	return typeof value === 'string' && value ? value : undefined;
+}
+
+function getTraceCaptureFromEvent( event: unknown ): TraceCapture | undefined {
+	if ( ! isRecord( event ) || ! isRecord( event.result ) ) {
+		return undefined;
+	}
+
+	const traceId = getString( event.result.traceId );
+	if (
+		! traceId ||
+		! isRecord( event.result.status ) ||
+		! isRecord( event.result.status.message )
+	) {
+		return undefined;
+	}
+
+	const messageId = getString( event.result.status.message.messageId );
+	return messageId ? { messageId, traceId } : undefined;
+}
+
+function getTraceCapturesFromJson( json: unknown ): TraceCapture[] {
+	const capture = getTraceCaptureFromEvent( json );
+	return capture ? [ capture ] : [];
+}
+
+function parseSseEvents( text: string ): unknown[] {
+	const events: unknown[] = [];
+	let data = '';
+
+	for ( const line of text.split( /\r?\n/ ) ) {
+		if ( line.startsWith( 'data:' ) ) {
+			data += ( data ? '\n' : '' ) + line.slice( line.startsWith( 'data: ' ) ? 6 : 5 );
+			continue;
+		}
+
+		if ( line.trim() === '' && data ) {
+			try {
+				events.push( JSON.parse( data ) );
+			} catch {}
+			data = '';
+		}
+	}
+
+	if ( data ) {
+		try {
+			events.push( JSON.parse( data ) );
+		} catch {}
+	}
+
+	return events;
+}
+
+function getTraceCapturesFromResponseText(
+	text: string,
+	contentType: string | null
+): TraceCapture[] {
+	if ( contentType?.includes( 'text/event-stream' ) ) {
+		return parseSseEvents( text ).flatMap( getTraceCapturesFromJson );
+	}
+
+	try {
+		return getTraceCapturesFromJson( JSON.parse( text ) );
+	} catch {
+		return [];
+	}
+}
+
+function requestUrlMatchesAgent(
+	input: RequestInfo | URL,
+	agentUrl: string,
+	agentId: string
+): boolean {
+	const url = typeof input === 'string' || input instanceof URL ? input.toString() : input.url;
+	return url === `${ agentUrl }/${ agentId }`;
+}
+
+export default function useAgentTraceIds( agentConfig?: UseAgentChatConfig | null ) {
+	const traceIdsByMessageIdRef = useRef< Map< string, string > >( new Map() );
+	const [ , setTraceIdsByMessageId ] = useState< Map< string, string > >(
+		traceIdsByMessageIdRef.current
+	);
+
+	useEffect( () => {
+		if (
+			! agentConfig?.agentUrl ||
+			! agentConfig?.agentId ||
+			typeof window === 'undefined' ||
+			typeof window.fetch !== 'function'
+		) {
+			return;
+		}
+
+		const originalFetch = window.fetch.bind( window );
+		window.fetch = ( async ( input: RequestInfo | URL, init?: RequestInit ) => {
+			const response = await originalFetch( input, init );
+
+			if ( requestUrlMatchesAgent( input, agentConfig.agentUrl, agentConfig.agentId ) ) {
+				void response
+					.clone()
+					.text()
+					.then( ( text ) => {
+						const captures = getTraceCapturesFromResponseText(
+							text,
+							response.headers.get( 'content-type' )
+						);
+						if ( captures.length === 0 ) {
+							return;
+						}
+
+						setTraceIdsByMessageId( ( previous ) => {
+							const next = new Map( traceIdsByMessageIdRef.current );
+							let changed = false;
+							for ( const { messageId, traceId } of captures ) {
+								if ( next.get( messageId ) !== traceId ) {
+									next.set( messageId, traceId );
+									changed = true;
+								}
+							}
+							if ( ! changed ) {
+								return previous;
+							}
+							traceIdsByMessageIdRef.current = next;
+							return next;
+						} );
+					} )
+					.catch( () => {} );
+			}
+
+			return response;
+		} ) as typeof window.fetch;
+
+		return () => {
+			window.fetch = originalFetch;
+		};
+	}, [ agentConfig?.agentId, agentConfig?.agentUrl ] );
+
+	return useCallback(
+		( messageId: string ) => traceIdsByMessageIdRef.current.get( messageId ),
+		[]
+	);
+}

--- a/packages/agents-manager/src/hooks/use-feedback-action.ts
+++ b/packages/agents-manager/src/hooks/use-feedback-action.ts
@@ -18,6 +18,7 @@ const FEEDBACK_API_BASE = 'https://public-api.wordpress.com/wpcom/v2/ai/feedback
 export interface UseFeedbackActionConfig {
 	registerMessageActions: UseAgentChatReturn[ 'registerMessageActions' ];
 	messages: Message[];
+	getTraceIdForMessage?: ( messageId: string ) => string | undefined;
 }
 
 export interface UseFeedbackActionReturn {
@@ -33,7 +34,8 @@ export async function rateMessage(
 	messageId: string,
 	rating: 'up' | 'down',
 	messageText?: string,
-	metadata?: Record< string, string >
+	metadata?: Record< string, string >,
+	traceId?: string
 ): Promise< void > {
 	const headers = await authProvider();
 	const url = `${ FEEDBACK_API_BASE }/${ encodeURIComponent( sessionId ) }/rate`;
@@ -43,6 +45,7 @@ export async function rateMessage(
 		rating: 'up' | 'down';
 		message_text?: string;
 		metadata?: Record< string, string >;
+		trace_id?: string;
 	} = { message_id: messageId, rating };
 
 	if ( messageText ) {
@@ -51,6 +54,10 @@ export async function rateMessage(
 
 	if ( metadata ) {
 		body.metadata = metadata;
+	}
+
+	if ( traceId ) {
+		body.trace_id = traceId;
 	}
 
 	fetch( url, {
@@ -70,7 +77,8 @@ export async function submitFeedback(
 	sessionId: string,
 	messageId: string,
 	feedback: string,
-	previousMessages?: PreviousMessage[]
+	previousMessages?: PreviousMessage[],
+	traceId?: string
 ): Promise< void > {
 	const headers = await authProvider();
 	const url = `${ FEEDBACK_API_BASE }/${ encodeURIComponent( sessionId ) }/text`;
@@ -79,6 +87,9 @@ export async function submitFeedback(
 		message_id: messageId,
 		feedback,
 	};
+	if ( traceId ) {
+		data.trace_id = traceId;
+	}
 	if ( previousMessages && previousMessages.length > 0 ) {
 		data.previous_messages = previousMessages;
 	}
@@ -168,6 +179,7 @@ function getPreviousMessages( messages: Message[], targetMessageId: string ): Pr
 
 export default function useFeedbackAction( {
 	messages,
+	getTraceIdForMessage,
 }: UseFeedbackActionConfig ): UseFeedbackActionReturn {
 	const { agentConfig, isLoggedIn, getActiveSessionId } = useAgentsManagerContext();
 	const { sessionId, authProvider } = agentConfig!;
@@ -177,8 +189,10 @@ export default function useFeedbackAction( {
 	// Keep refs to avoid recreating the feedback manager on every render
 	const messagesRef = useRef( messages );
 	const authProviderRef = useRef( authProvider );
+	const getTraceIdForMessageRef = useRef( getTraceIdForMessage );
 	messagesRef.current = messages;
 	authProviderRef.current = authProvider;
+	getTraceIdForMessageRef.current = getTraceIdForMessage;
 
 	const handleFeedback = useCallback(
 		( messageId: string, feedback: 'up' | 'down' ) => {
@@ -196,13 +210,16 @@ export default function useFeedbackAction( {
 
 			const message = messagesRef.current.find( ( m ) => m.id === messageId );
 			const messageText = message ? getMessageText( message ) : undefined;
+			const traceId = getTraceIdForMessageRef.current?.( messageId );
 
 			rateMessage(
 				currentAuthProvider,
 				currentSessionId,
 				messageId,
 				feedback,
-				messageText ?? undefined
+				messageText ?? undefined,
+				undefined,
+				traceId
 			);
 
 			if ( feedback === 'down' ) {
@@ -289,13 +306,15 @@ export default function useFeedbackAction( {
 			}
 
 			const previousMessages = getPreviousMessages( messagesRef.current, currentMessageId );
+			const traceId = getTraceIdForMessageRef.current?.( currentMessageId );
 
 			await submitFeedback(
 				currentAuthProvider,
 				currentSessionId,
 				currentMessageId,
 				feedbackText.trim(),
-				previousMessages
+				previousMessages,
+				traceId
 			);
 
 			recordAgentsManagerTracksEvent( 'response_feedback_submitted', {

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -8,6 +8,7 @@ import type { UIMessage } from '@automattic/agenttic-client';
 
 export interface AgentsManagerUIMessage extends UIMessage {
 	disabled?: boolean;
+	traceId?: string;
 	/** Suppress Agenttic's transient thinking indicator while this message is the latest one. */
 	suppressThinking?: boolean;
 }


### PR DESCRIPTION
## Proposed Changes

 - Capture Langfuse traceId values from AI agent final responses and associate them with the corresponding assistant message.
 - Include trace_id when submitting thumbs up/down feedback for a message.
 - Include the same trace_id when submitting negative feedback text for a thumbs-down message.
 - Keep feedback submission backward-compatible when no traceId is available.

## Why are these changes being made?

 - The AI agent backend now tags final responses with the Langfuse trace ID that produced them.
 - Sending this trace ID with ratings and negative feedback text lets feedback be scored against the exact Langfuse trace for that agent turn, instead of only the broader session.
 - This improves feedback quality for AI evaluation/debugging while preserving existing session-scoped feedback behavior for older responses or missing trace IDs.

## Testing Instructions

Test with 228946-ghe-Automattic/wpcom

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
