### PR TITLE
Reader Chat: isolate widget styles from host themes

### DIFF
--- a/apps/agents-manager/__tests__/postcss-config.test.js
+++ b/apps/agents-manager/__tests__/postcss-config.test.js
@@ -1,0 +1,84 @@
+// eslint-disable-next-line import/no-nodejs-modules
+const fs = require( 'fs' );
+const path = require( 'path' );
+const postcss = require( 'postcss' );
+const prefixSelector = require( 'postcss-prefix-selector' );
+const config = require( '../reader-chat-postcss.config' );
+const getWebpackConfig = require( '../webpack.config' );
+
+describe( 'Reader Chat PostCSS scoping', () => {
+	const { prefix, transform } = config.plugins[ 'postcss-prefix-selector' ];
+
+	it( 'is configured only for the Reader Chat webpack build', () => {
+		const configs = getWebpackConfig();
+		const readerPostCssConfig = path.join( __dirname, '..', 'reader-chat-postcss.config.js' );
+		const getPostCssConfig = ( webpackConfig ) =>
+			webpackConfig.module.rules
+				.flatMap( ( rule ) => rule.use || [] )
+				.find( ( loader ) => loader?.loader === require.resolve( 'postcss-loader' ) )?.options
+				.postcssOptions.config;
+		const readerConfig = configs.find( ( webpackConfig ) => webpackConfig.entry[ 'reader-chat' ] );
+		const otherConfigs = configs.filter( ( webpackConfig ) => webpackConfig !== readerConfig );
+
+		expect( getPostCssConfig( readerConfig ) ).toBe( readerPostCssConfig );
+		expect( otherConfigs.map( getPostCssConfig ) ).not.toContain( readerPostCssConfig );
+	} );
+
+	it( 'emits the Reader Chat manifest without externalizing dependencies', () => {
+		const readerConfig = getWebpackConfig().find(
+			( webpackConfig ) => webpackConfig.entry[ 'reader-chat' ]
+		);
+		const dependencyPlugin = readerConfig.plugins.find(
+			( plugin ) => plugin.constructor.name === 'DependencyExtractionWebpackPlugin'
+		);
+
+		expect( dependencyPlugin.options ).toMatchObject( {
+			outputFilename: '[name].asset.json',
+			outputFormat: 'json',
+			useDefaults: false,
+		} );
+	} );
+
+	it( 'prefixes Agenttic component styles with the chat wrapper', () => {
+		const filePath = require.resolve( '@automattic/agenttic-ui/index.css' );
+
+		expect(
+			transform(
+				prefix,
+				'.button-module_button',
+				'.agents-manager-chat .button-module_button',
+				filePath
+			)
+		).toBe( '.agents-manager-chat .button-module_button' );
+	} );
+
+	it( 'prefixes selectors in the real Agenttic stylesheet', async () => {
+		const filePath = require.resolve( '@automattic/agenttic-ui/index.css' );
+		const source = fs.readFileSync( filePath, 'utf8' );
+		const output = await postcss( [
+			prefixSelector( config.plugins[ 'postcss-prefix-selector' ] ),
+		] ).process( source, { from: filePath } );
+		const result = postcss.parse( output.css );
+		const buttonSelectors = [];
+
+		result.walkRules( ( rule ) => {
+			buttonSelectors.push(
+				...rule.selectors.filter( ( selector ) => selector.includes( '.button-module_button' ) )
+			);
+		} );
+
+		expect( buttonSelectors.length ).toBeGreaterThan( 0 );
+		expect( buttonSelectors.every( ( selector ) => selector.startsWith( prefix ) ) ).toBe( true );
+	} );
+
+	it( 'leaves other styles unchanged', () => {
+		expect(
+			transform(
+				prefix,
+				'.components-button',
+				'.agents-manager-chat .components-button',
+				'/repo/packages/components/style.scss'
+			)
+		).toBe( '.components-button' );
+	} );
+} );

--- a/apps/agents-manager/__tests__/reader-chat.test.js
+++ b/apps/agents-manager/__tests__/reader-chat.test.js
@@ -100,12 +100,18 @@ describe( 'injectScopedReset', () => {
 
 		expect( css ).toContain( 'font-size: 16px !important;' );
 		expect( css ).toContain( '--base-font-size: 16px !important;' );
-		expect( css ).toContain( '.agents-manager-chat .components-button.has-icon' );
+		expect( css ).toContain(
+			'.agents-manager-chat .components-button.has-icon:not(.components-dropdown-menu__menu-item)'
+		);
+		expect( css ).toContain(
+			'.agents-manager-chat .agents-manager-chat-header .components-button.has-icon:not(.components-dropdown-menu__menu-item)'
+		);
 		expect( css ).toContain(
 			'.agents-manager-chat .agents-manager-copy-action-button.components-button.has-icon'
 		);
 		expect( css ).toContain( 'text-transform: none !important;' );
 		expect( css ).toContain( 'letter-spacing: inherit !important;' );
+		expect( css ).toContain( '.agents-manager-chat textarea::placeholder' );
 		expect( css ).toContain( 'background: transparent !important;' );
 		expect( css ).toContain( 'color: var( --color-foreground, #1e1e1e ) !important;' );
 		expect( css ).toContain(
@@ -113,6 +119,10 @@ describe( 'injectScopedReset', () => {
 		);
 		expect( css ).toContain( ':not([aria-disabled="true"])' );
 		expect( css ).toContain( '.agents-manager-chat-header__menu-popover' );
+		expect( css ).toContain(
+			'.agents-manager-chat .agents-manager-chat-header .components-dropdown-menu__menu .components-dropdown-menu__menu-item'
+		);
+		expect( css ).toContain( 'white-space: nowrap !important;' );
 		expect( css ).toContain(
 			'.agents-manager-chat-header__menu-popover .components-dropdown-menu__menu-item[aria-disabled="true"]'
 		);

--- a/apps/agents-manager/package.json
+++ b/apps/agents-manager/package.json
@@ -49,6 +49,7 @@
 		"@wordpress/dependency-extraction-webpack-plugin": "^6.24.0",
 		"@wordpress/readable-js-assets-webpack-plugin": "^3.24.0",
 		"copy-webpack-plugin": "^10.2.4",
+		"postcss-prefix-selector": "^1.16.1",
 		"webpack": "^5.99.8"
 	},
 	"peerDependencies": {

--- a/apps/agents-manager/reader-chat-postcss.config.js
+++ b/apps/agents-manager/reader-chat-postcss.config.js
@@ -1,0 +1,20 @@
+const path = require( 'path' );
+const baseConfig = require( '../../packages/calypso-build/postcss.config.js' )();
+const agentticUiCssPath = require.resolve( '@automattic/agenttic-ui/index.css' );
+
+module.exports = {
+	...baseConfig,
+	plugins: {
+		...baseConfig.plugins,
+		'postcss-prefix-selector': {
+			prefix: '.agents-manager-chat',
+			transform( prefix, selector, prefixedSelector, filePath ) {
+				if ( path.normalize( filePath ) !== path.normalize( agentticUiCssPath ) ) {
+					return selector;
+				}
+
+				return selector.includes( prefix ) ? selector : prefixedSelector;
+			},
+		},
+	},
+};

--- a/apps/agents-manager/reader-chat.js
+++ b/apps/agents-manager/reader-chat.js
@@ -4,9 +4,10 @@
  * Loads the Agents Manager chat UI for blog readers (logged-out visitors).
  * Reads config from window.JetpackReaderChatConfig, mounts to #jetpack-reader-chat.
  *
- * IMPORTANT: This bundle is built without DependencyExtractionWebpackPlugin so
- * React, @wordpress/data, and all other WP packages are bundled inline. This
- * makes it safe to load on the frontend where WordPress's script loader is absent.
+ * IMPORTANT: Dependency extraction only emits the cache-busting asset manifest.
+ * Externalization is disabled, so React, WordPress data, and all other WP packages
+ * are bundled inline. This makes the bundle safe to load on the frontend where
+ * WordPress's script loader is absent.
  */
 
 import './config';
@@ -71,12 +72,22 @@ function injectScopedReset() {
 		 */
 		#jetpack-reader-chat input,
 		#jetpack-reader-chat textarea,
-		#jetpack-reader-chat button,
 		.agents-manager-chat input,
-		.agents-manager-chat textarea,
-		.agents-manager-chat button {
+		.agents-manager-chat textarea {
 			font-family: inherit !important;
 			font-size: inherit !important;
+			letter-spacing: inherit !important;
+			text-transform: none !important;
+		}
+		#jetpack-reader-chat button,
+		.agents-manager-chat button {
+			font-family: inherit !important;
+			text-transform: none !important;
+		}
+		#jetpack-reader-chat input::placeholder,
+		#jetpack-reader-chat textarea::placeholder,
+		.agents-manager-chat input::placeholder,
+		.agents-manager-chat textarea::placeholder {
 			letter-spacing: inherit !important;
 			text-transform: none !important;
 		}
@@ -120,7 +131,7 @@ function injectScopedReset() {
 			text-decoration: none !important;
 			text-transform: none !important;
 		}
-		.agents-manager-chat .components-button.has-icon {
+		.agents-manager-chat .components-button.has-icon:not(.components-dropdown-menu__menu-item) {
 			align-items: center !important;
 			background: transparent !important;
 			border: 0 !important;
@@ -131,14 +142,14 @@ function injectScopedReset() {
 			justify-content: center !important;
 			margin: 0 !important;
 		}
-		.agents-manager-chat .agents-manager-chat-header .components-button.has-icon,
+		.agents-manager-chat .agents-manager-chat-header .components-button.has-icon:not(.components-dropdown-menu__menu-item),
 		.agents-manager-chat .agents-manager-copy-action-button.components-button.has-icon,
 		.agents-manager-chat .agents-manager-zoom-action-button.components-button.has-icon {
 			height: 32px !important;
 			padding: 6px !important;
 			width: 32px !important;
 		}
-		.agents-manager-chat .agents-manager-chat-header .components-button.has-icon:hover:not(:disabled):not([aria-disabled="true"]),
+		.agents-manager-chat .agents-manager-chat-header .components-button.has-icon:not(.components-dropdown-menu__menu-item):hover:not(:disabled):not([aria-disabled="true"]),
 		.agents-manager-chat .agents-manager-copy-action-button.components-button.has-icon:hover:not(:disabled):not([aria-disabled="true"]),
 		.agents-manager-chat .agents-manager-zoom-action-button.components-button.has-icon:hover:not(:disabled):not([aria-disabled="true"]) {
 			background: var( --color-muted, rgba( 0, 0, 0, 0.06 ) ) !important;
@@ -167,8 +178,10 @@ function injectScopedReset() {
 			text-decoration: none !important;
 			text-transform: none !important;
 		}
-		.agents-manager-chat-header__menu-popover .components-dropdown-menu__menu-item {
+		.agents-manager-chat-header__menu-popover .components-dropdown-menu__menu-item,
+		.agents-manager-chat .agents-manager-chat-header .components-dropdown-menu__menu .components-dropdown-menu__menu-item {
 			align-items: center !important;
+			box-sizing: border-box !important;
 			display: flex !important;
 			gap: 8px !important;
 			height: auto !important;
@@ -176,7 +189,12 @@ function injectScopedReset() {
 			min-height: 32px !important;
 			padding: 6px 8px !important;
 			text-align: left !important;
+			white-space: nowrap !important;
 			width: 100% !important;
+		}
+		.agents-manager-chat .agents-manager-chat-header .components-dropdown-menu__menu .components-dropdown-menu__menu-item {
+			margin: 0 !important;
+			max-width: none !important;
 		}
 		.agents-manager-chat-header__menu-popover .components-dropdown-menu__menu-item:hover:not(:disabled):not([aria-disabled="true"]) {
 			background: var( --color-muted, rgba( 0, 0, 0, 0.06 ) ) !important;

--- a/apps/agents-manager/webpack.config.js
+++ b/apps/agents-manager/webpack.config.js
@@ -8,6 +8,26 @@ const GenerateChunksMapPlugin = require( '../../build-tools/webpack/generate-chu
 
 const isDevelopment = process.env.NODE_ENV !== 'production';
 
+function applyPostCssConfig( rules, config ) {
+	return rules.map( ( rule ) => ( {
+		...rule,
+		use: rule.use?.map( ( loader ) =>
+			loader?.loader === require.resolve( 'postcss-loader' )
+				? {
+						...loader,
+						options: {
+							...loader.options,
+							postcssOptions: {
+								...loader.options?.postcssOptions,
+								config,
+							},
+						},
+				  }
+				: loader
+		),
+	} ) );
+}
+
 function getIndividualConfig( options = {} ) {
 	const { name, env, argv, injectPolyfill = true } = options;
 
@@ -125,11 +145,11 @@ function getIndividualConfig( options = {} ) {
 }
 
 /**
- * Reader chat config — bundles all dependencies (no WP externals).
+ * Reader chat config — bundles all dependencies and emits an asset manifest.
  *
- * Omits DependencyExtractionWebpackPlugin entirely so React, @wordpress/data,
- * and other WP packages are inlined. The resulting reader-chat.min.js is
- * self-contained and safe to load on the frontend (no WP script loader needed).
+ * DependencyExtractionWebpackPlugin is configured with useDefaults: false so React,
+ * WordPress data, and other WP packages remain inlined. The resulting reader-chat.min.js
+ * is self-contained and safe to load on the frontend.
  * @param   {Object}  options                       options
  * @param   {Object}  options.env                   environment options
  * @param   {Object}  options.argv                  webpack CLI args
@@ -154,7 +174,10 @@ function getReaderConfig( options = {} ) {
 		module: {
 			...webpackConfig.module,
 			rules: [
-				...( webpackConfig.module?.rules || [] ),
+				...applyPostCssConfig(
+					webpackConfig.module?.rules || [],
+					path.join( __dirname, 'reader-chat-postcss.config.js' )
+				),
 				{
 					// P2/O2 expects window._ to remain Underscore.
 					resource: require.resolve( 'lodash/lodash.js' ),
@@ -191,7 +214,12 @@ function getReaderConfig( options = {} ) {
 				'process.env.NODE_DEBUG': JSON.stringify( process.env.NODE_DEBUG || false ),
 			} ),
 			new ReadableJsAssetsWebpackPlugin(),
-			// Intentionally NO DependencyExtractionWebpackPlugin — all WP deps are bundled.
+			// Emit the cache-busting manifest without externalizing any dependencies.
+			new DependencyExtractionWebpackPlugin( {
+				outputFilename: '[name].asset.json',
+				outputFormat: 'json',
+				useDefaults: false,
+			} ),
 		],
 	};
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -117,6 +117,7 @@ __metadata:
     "@wordpress/plugins": "npm:^7.48.0"
     "@wordpress/readable-js-assets-webpack-plugin": "npm:^3.24.0"
     copy-webpack-plugin: "npm:^10.2.4"
+    postcss-prefix-selector: "npm:^1.16.1"
     webpack: "npm:^5.99.8"
   peerDependencies:
     "@automattic/calypso-router": "workspace:^"


### PR DESCRIPTION
Fixes FORNO-410

## Proposed Changes

* Scope Agenttic UI selectors under `.agents-manager-chat` only in the Reader Chat webpack build, preventing host-theme styles from overriding the widget.
* Harden the Reader Chat boundary reset for inline dropdown items, composer placeholders, header controls, and suggestion typography.
* Emit `reader-chat.asset.json` without externalizing dependencies so the existing loader can version both the JavaScript and CSS assets.
* Add focused coverage for the scoped reset, real Agenttic stylesheet processing, Reader Chat-only webpack wiring, and the self-contained manifest configuration.

## Why are these changes being made?

Reader Chat is embedded in third-party themes whose global button and form-control styles can leak into the widget. On the affected self-hosted site, this changed the launcher, suggestion buttons, send button, input placeholder, and inline "New chat" menu.

The inline menu item was also being treated as a square icon-only header control. The selector exclusions and shared menu layout restore its intended full-width layout.

The Reader Chat loader already reads `reader-chat.asset.json` and uses its version for both the script and stylesheet, but the Reader Chat build did not emit that manifest. Emitting it prevents updated widget styles from remaining cached after deployment.

## Testing Instructions

### Automated

* `yarn test-apps apps/agents-manager/__tests__/reader-chat.test.js apps/agents-manager/__tests__/postcss-config.test.js --runInBand` — 51 tests passed.
* `yarn eslint apps/agents-manager/reader-chat.js apps/agents-manager/webpack.config.js apps/agents-manager/reader-chat-postcss.config.js apps/agents-manager/__tests__/reader-chat.test.js apps/agents-manager/__tests__/postcss-config.test.js` — zero errors; one pre-existing JSDoc warning outside this diff.
* `yarn install --immutable --mode=skip-build` — passed.
* `NODE_ENV=production yarn workspace @automattic/agents-manager-app run dev` — production webpack build passed. The local translation helper could not run because the compiled `@automattic/languages` package is unavailable in this worktree; no strings changed.
* Confirmed the emitted `reader-chat.asset.json` has an empty dependency list.
* Confirmed generated Agenttic selectors are prefixed in `reader-chat.css` and remain unprefixed in `agents-manager-gutenberg.css`.

### Manual
Prereq:
Open this [site](kat3samsinsandbox.wordpress.com) and observe Reader Chat style is not rendering styles correctly.

1. Sandbox `widgets.wp.com`; the test site itself does not need to be sandboxed.
2. From `apps/agents-manager`, run `yarn dev --sync`.
3. Open the [site](kat3samsinsandbox.wordpress.com) again and verify Reader Chat is rendering styles correctly
4. Open the collapsed Reader Chat launcher and verify it retains the intended shape and icon.
5. Open the header menu and verify "New chat" is full-width, single-line, left-aligned, and includes its icon.
6. Verify the suggestions, send button, input, and placeholder retain Reader Chat typography and layout.
7. Confirm there are no new browser-console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g. browsers), interfaces (e.g. keyboard navigation), and assistive technologies (e.g. screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

