### PR TITLE
Make current-plan pricing tolerant of both purchase shapes

### DIFF
--- a/packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
@@ -273,6 +273,46 @@ describe( 'usePricingMetaForGridPlans', () => {
 		);
 	} );
 
+	it( 'should price from the purchase and log a shape mismatch when the current plan purchase is in the assembled camelCase shape', () => {
+		Plans.useCurrentPlan.mockImplementation( () => ( {
+			productSlug: PLAN_BUSINESS,
+			planSlug: PLAN_BUSINESS,
+			purchaseId: 1234,
+		} ) );
+		Purchases.useSitePurchaseById.mockImplementation( () => ( {
+			id: 1234,
+			productSlug: PLAN_BUSINESS,
+			priceInteger: 600,
+			currencyCode: 'USD',
+			billPeriodDays: 365,
+		} ) );
+
+		const pricingMeta = usePricingMetaForGridPlans( {
+			planSlugs: [ PLAN_BUSINESS ],
+			siteId,
+			coupon: undefined,
+			useCheckPlanAvailabilityForPurchase,
+		} );
+
+		// 600/yr resolves to 50/mo, i.e. it used the purchase price, not the untouched site plan price.
+		expect( pricingMeta?.[ PLAN_BUSINESS ]?.originalPrice ).toEqual( {
+			full: 600,
+			monthly: 50,
+		} );
+		expect( logToLogstash ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				message:
+					'usePricingMetaForGridPlans: current plan purchase has an unexpected assembled shape',
+				extra: expect.objectContaining( {
+					plan_slug: PLAN_BUSINESS,
+					bill_period_days_snake: 'undefined',
+					bill_period_days_camel: '365',
+				} ),
+				tags: expect.arrayContaining( [ 'shape-mismatch' ] ),
+			} )
+		);
+	} );
+
 	it( 'should return the original price as the site plan price and discounted price as Null for plans not available for purchase', () => {
 		Plans.useCurrentPlan.mockImplementation( () => ( {
 			productSlug: PLAN_BUSINESS,

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -71,29 +71,38 @@ function getTotalPrice( planPrice: number | null | undefined, addOnPrice = 0 ): 
 	return null !== planPrice && undefined !== planPrice ? planPrice + addOnPrice : null;
 }
 
-const loggedUnknownBillPeriods = new Set< string >();
+const loggedUnexpectedPurchases = new Set< string >();
 
-function logUnknownBillPeriodDays(
+/**
+ * `usePricingMetaForGridPlans` expects the raw (snake_case) purchase shape, but
+ * is sometimes handed the legacy camelCase-assembled `Purchase` instead (see the
+ * `normalizePurchaseForPricing` fallbacks). This logs the offending purchase —
+ * with enough detail to identify the shape and its origin — so the source can be
+ * tracked down. Deduped per message + purchase to keep the REST call rare.
+ */
+function logUnexpectedCurrentPlanPurchase(
+	message: string,
+	tags: string[],
 	planSlug: string,
 	purchase: Purchases.RawPurchase,
 	siteId: number | null | undefined
 ): void {
 	const shape = purchase as unknown as Record< string, unknown >;
 	const purchaseId = shape.ID ?? shape.id;
-	const key = `${ siteId ?? '' }-${ String( purchaseId ) }-${ String(
+	const key = `${ message }-${ siteId ?? '' }-${ String( purchaseId ) }-${ String(
 		shape.bill_period_days ?? shape.billPeriodDays
 	) }`;
-	if ( loggedUnknownBillPeriods.has( key ) ) {
+	if ( loggedUnexpectedPurchases.has( key ) ) {
 		return;
 	}
-	loggedUnknownBillPeriods.add( key );
+	loggedUnexpectedPurchases.add( key );
 	const win =
 		typeof window !== 'undefined'
 			? ( window as unknown as { COMMIT_SHA?: string; location?: Location } )
 			: undefined;
 	logToLogstash( {
 		feature: 'calypso_client',
-		message: 'usePricingMetaForGridPlans: purchase has an unknown bill_period_days',
+		message,
 		site_id: siteId ?? undefined,
 		extra: {
 			plan_slug: planSlug,
@@ -106,11 +115,43 @@ function logUnknownBillPeriodDays(
 			expiry_status: String( shape.expiry_status ?? shape.expiryStatus ),
 			path: win?.location?.pathname ?? '',
 			commit_sha: String( win?.COMMIT_SHA ?? '' ),
-			caller_stack:
-				new Error( 'unknown-bill-period' ).stack?.split( '\n' ).slice( 0, 20 ).join( '\n' ) ?? '',
+			caller_stack: new Error( message ).stack?.split( '\n' ).slice( 0, 20 ).join( '\n' ) ?? '',
 		},
-		tags: [ 'unknown-term', 'bill-period-days' ],
+		tags,
 	} ).catch( () => {} );
+}
+
+interface NormalizedPurchasePricing {
+	billPeriodDays: number;
+	priceInteger: number;
+	introductoryOffer: { isWithinPeriod: boolean; costPerIntervalInteger: number } | null;
+	/**
+	 * True when the purchase arrived in the legacy camelCase-assembled shape
+	 * rather than the raw (snake_case) shape this hook expects.
+	 */
+	isAssembledShape: boolean;
+}
+
+/**
+ * Reads the pricing-relevant fields off a purchase, tolerating both the raw
+ * (snake_case) shape and the legacy camelCase-assembled shape. The hook is
+ * supposed to only ever receive the raw shape, but some callers still supply the
+ * assembled one; normalizing here keeps current-plan pricing correct either way.
+ */
+function normalizePurchaseForPricing( purchase: Purchases.RawPurchase ): NormalizedPurchasePricing {
+	const shape = purchase as unknown as Record< string, unknown >;
+	const isAssembledShape =
+		shape.bill_period_days === undefined && shape.billPeriodDays !== undefined;
+	const assembledOffer = shape.introductoryOffer as
+		| { isWithinPeriod: boolean; costPerIntervalInteger: number }
+		| null
+		| undefined;
+	return {
+		billPeriodDays: Number( shape.bill_period_days ?? shape.billPeriodDays ),
+		priceInteger: Number( shape.price_integer ?? shape.priceInteger ),
+		introductoryOffer: getPurchaseIntroductoryOffer( purchase ) ?? assembledOffer ?? null,
+		isAssembledShape,
+	};
 }
 
 /**
@@ -243,19 +284,33 @@ const usePricingMetaForGridPlans = ( {
 					let renewalPrice: Plans.PlanPricing[ 'originalPrice' ] | undefined;
 
 					if ( purchasedPlan ) {
-						const introductoryOffer = getPurchaseIntroductoryOffer( purchasedPlan );
-						const billPeriodDays = Number( purchasedPlan.bill_period_days );
+						const { billPeriodDays, priceInteger, introductoryOffer, isAssembledShape } =
+							normalizePurchaseForPricing( purchasedPlan );
 						const term = getTermFromDuration( billPeriodDays );
 						const showIntroOfferHeadline =
 							!! showBillingDescriptionForIncreasedRenewalPrice &&
 							introductoryOffer?.isWithinPeriod;
 						const currentTermPrice = showIntroOfferHeadline
 							? introductoryOffer!.costPerIntervalInteger
-							: purchasedPlan.price_integer;
+							: priceInteger;
 						const isMonthly = billPeriodDays === PLAN_MONTHLY_PERIOD;
 
-						if ( ! term ) {
-							logUnknownBillPeriodDays( planSlug, purchasedPlan, siteId );
+						if ( isAssembledShape ) {
+							logUnexpectedCurrentPlanPurchase(
+								'usePricingMetaForGridPlans: current plan purchase has an unexpected assembled shape',
+								[ 'shape-mismatch', 'assembled-purchase' ],
+								planSlug,
+								purchasedPlan,
+								siteId
+							);
+						} else if ( ! term ) {
+							logUnexpectedCurrentPlanPurchase(
+								'usePricingMetaForGridPlans: purchase has an unknown bill_period_days',
+								[ 'unknown-term', 'bill-period-days' ],
+								planSlug,
+								purchasedPlan,
+								siteId
+							);
 						}
 
 						if ( isMonthly && monthlyPrice !== currentTermPrice ) {
@@ -269,10 +324,8 @@ const usePricingMetaForGridPlans = ( {
 						if ( showIntroOfferHeadline ) {
 							renewalPrice = {
 								monthly:
-									isMonthly || ! term
-										? purchasedPlan.price_integer
-										: calculateMonthlyPrice( term, purchasedPlan.price_integer ),
-								full: purchasedPlan.price_integer,
+									isMonthly || ! term ? priceInteger : calculateMonthlyPrice( term, priceInteger ),
+								full: priceInteger,
 							};
 						}
 					}


### PR DESCRIPTION
Related to [SHILL-2261](https://linear.app/a8c/issue/SHILL-2261/investigate-unknown-term-errors-on-site-level-purchase-details-page)

## Proposed Changes

Makes `usePricingMetaForGridPlans` tolerant of both purchase shapes so current-plan pricing is correct whether it receives the raw (snake_case) purchase or the legacy camelCase-assembled `Purchase`. This "stops the bleeding" on the false `unknown bill_period_days` logs and the associated mispricing while the root cause (an assembled purchase reaching this hook) is tracked down.

## Why are these changes being made?

The diagnostics from #112747 confirmed (from a production build, `commit_sha` matched trunk) that on `/domains/manage/…` the current-plan purchase reaches `usePricingMetaForGridPlans` in the camelCase-assembled shape (`object_keys` were entirely camelCase; `bill_period_days_camel` was a valid `365`). Because the hook read only snake_case fields, `bill_period_days`/`price_integer`/`introductory_offer` came back `undefined` — producing a false `unknown bill_period_days` log and silently falling back to the site-plan price instead of the purchase price.

At current trunk nothing should populate that cache with assembled data, so the exact source is still unknown. Rather than leave pricing wrong (and the logs noisy) while we chase it, this normalizes at the point of use so the hook is correct for either shape, and separates the "genuine unknown term" signal from the "unexpected shape" signal so the remaining investigation isn't drowned out.

## Testing Instructions

TC:
```
yarn test-packages packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
```
Covers three current-plan cases: raw shape (existing), raw-but-unmapped period (`unknown-term` log), and assembled camelCase shape (prices from the purchase + `shape-mismatch` log).

Manual testing:
* Open `/domains/manage/<domain>` (and a site-level purchase details page) for a site on a paid plan.
* Confirm the plan price renders correctly and no fatal error occurs.
* In logstash, confirm the false `unknown bill_period_days` entries for these purchases stop, and any assembled-shape occurrences now appear under the `shape-mismatch` message.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
