### PR TITLE
Jetpack Cloud: Use Dataviews for the backups page

### DIFF
--- a/client/my-sites/backup/backup-dataviews/fields.tsx
+++ b/client/my-sites/backup/backup-dataviews/fields.tsx
@@ -1,0 +1,111 @@
+import { Icon, __experimentalHStack as HStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import ActivityDescription from 'calypso/components/activity-card/activity-description';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+import { gridiconToWordPressIcon } from 'calypso/dashboard/utils/gridicons';
+import { applySiteOffset } from 'calypso/lib/site/timezone';
+import type { BackupActivity } from './types';
+import type { Field } from '@wordpress/dataviews';
+import type { MomentInput, Moment } from 'moment';
+
+type MomentFactory = ( input?: MomentInput ) => Moment;
+
+export type FieldsOptions = {
+	moment: MomentFactory;
+	timezone: string | null;
+	gmtOffset: number | null;
+};
+
+export function getFields( {
+	moment,
+	timezone,
+	gmtOffset,
+}: FieldsOptions ): Field< BackupActivity >[] {
+	const formatDate = ( ts: number ) => {
+		const local = applySiteOffset( moment( ts ), { timezone, gmtOffset } );
+		const now = applySiteOffset( moment(), { timezone, gmtOffset } );
+		const daysAgo = now.clone().startOf( 'day' ).diff( local.clone().startOf( 'day' ), 'days' );
+
+		// Within the last week moment's calendar() gives localized strings like
+		// "Today at 3:53 PM" or "Last Monday at 3:53 PM"; beyond that it falls
+		// back to plain dates, so switch to relative phrasing instead.
+		return daysAgo < 7 ? local.calendar( now ) : moment( ts ).fromNow();
+	};
+
+	return [
+		{
+			id: 'date',
+			label: __( 'Date & time' ),
+			getValue: ( { item } ) => item.activityTs,
+			render: ( { item } ) => (
+				<time
+					className="backup-dataviews__date"
+					title={ applySiteOffset( moment( item.activityTs ), { timezone, gmtOffset } ).format(
+						'llll'
+					) }
+				>
+					{ formatDate( item.activityTs ) }
+				</time>
+			),
+		},
+		{
+			id: 'event',
+			label: __( 'Event' ),
+			getValue: ( { item } ) => item.activityTitle,
+			enableGlobalSearch: true,
+			render: ( { item } ) => (
+				<HStack alignment="left" spacing={ 3 }>
+					<span className="backup-dataviews__icon-box">
+						<Icon
+							icon={ gridiconToWordPressIcon( item.activityIcon ?? 'cloud' ) }
+							size={ 20 }
+							className="backup-dataviews__icon"
+						/>
+					</span>
+					<span className="backup-dataviews__event-text">
+						<strong>{ item.activityTitle }</strong>
+						{ item.activityDescription && (
+							<span className="backup-dataviews__event-description">
+								{ ' ' }
+								<ActivityDescription activity={ item } />
+							</span>
+						) }
+					</span>
+				</HStack>
+			),
+		},
+		{
+			id: 'user',
+			label: __( 'User' ),
+			getValue: ( { item } ) => item.actorName ?? '',
+			enableGlobalSearch: true,
+			render: ( { item } ) => {
+				const isJetpackActor =
+					item.actorType === 'Application' && !! item.actorName?.startsWith( 'Jetpack' );
+
+				return (
+					<span className="backup-dataviews__user">
+						{ isJetpackActor ? (
+							<JetpackLogo
+								size={ 24 }
+								monochrome={ false }
+								className="backup-dataviews__user-logo"
+							/>
+						) : (
+							item.actorAvatarUrl && (
+								<img
+									className="backup-dataviews__user-avatar"
+									src={ item.actorAvatarUrl }
+									alt=""
+									width={ 24 }
+									height={ 24 }
+								/>
+							)
+						) }
+						<span>{ item.actorName }</span>
+					</span>
+				);
+			},
+		},
+	];
+}

--- a/client/my-sites/backup/backup-dataviews/index.tsx
+++ b/client/my-sites/backup/backup-dataviews/index.tsx
@@ -1,0 +1,210 @@
+import page from '@automattic/calypso-router';
+import { DateRangePicker } from '@automattic/date-range-picker';
+import { Button, Notice } from '@wordpress/components';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { useCallback, useMemo, useState } from 'react';
+import { DataViews } from 'calypso/components/dataviews';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { buildTimeRangeForActivityLog } from 'calypso/dashboard/utils/site-activity-log';
+import useRewindableActivityLogQuery from 'calypso/data/activity-log/use-rewindable-activity-log-query';
+import {
+	INDEX_FORMAT,
+	isActivityBackup,
+	isSuccessfulRealtimeBackup,
+} from 'calypso/lib/jetpack/backup-utils';
+import { useDispatch, useSelector } from 'calypso/state';
+import { rewindRequestBackup } from 'calypso/state/activity-log/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import canRestoreSite from 'calypso/state/rewind/selectors/can-restore-site';
+import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
+import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { backupContentsPath, backupDownloadPath, backupRestorePath } from '../paths';
+import { getFields } from './fields';
+import type { BackupActivity } from './types';
+import type { Action, View } from '@wordpress/dataviews';
+
+import './style.scss';
+
+const DEFAULT_VIEW: View = {
+	type: 'table',
+	fields: [ 'date', 'event', 'user' ],
+	perPage: 20,
+	page: 1,
+	sort: {
+		field: 'date',
+		direction: 'desc',
+	},
+	layout: {
+		styles: {
+			date: { width: '220px' },
+			event: { width: '100%' },
+			user: { width: '200px' },
+		},
+	},
+};
+
+const isBackupActivity = ( activity: BackupActivity ) =>
+	isActivityBackup( activity ) || isSuccessfulRealtimeBackup( activity );
+
+export default function BackupsDataViews( { queryDate }: { queryDate?: string } ) {
+	const dispatch = useDispatch();
+	const moment = useLocalizedMoment();
+
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const siteSlug = useSelector( getSelectedSiteSlug ) as string;
+	const timezone = useSelector( ( state ) => getSiteTimezoneValue( state, siteId ) );
+	const gmtOffset = useSelector( ( state ) => getSiteGmtOffset( state, siteId ) );
+	const locale = useSelector( getCurrentUserLocale ) || 'en';
+	const isRestoreEnabled = useSelector( ( state ) => canRestoreSite( state, siteId ) );
+
+	const [ dateRange, setDateRange ] = useState( () => {
+		if ( queryDate ) {
+			const day = moment( queryDate, INDEX_FORMAT );
+			if ( day.isValid() ) {
+				return { start: day.toDate(), end: day.toDate() };
+			}
+		}
+		return {
+			start: moment().subtract( 29, 'days' ).toDate(),
+			end: moment().toDate(),
+		};
+	} );
+
+	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+
+	const { after, before } = useMemo(
+		() =>
+			buildTimeRangeForActivityLog(
+				dateRange.start,
+				dateRange.end,
+				timezone ?? undefined,
+				gmtOffset ?? undefined
+			),
+		[ dateRange, timezone, gmtOffset ]
+	);
+
+	const { data, isLoading, isError, refetch } = useRewindableActivityLogQuery(
+		siteId,
+		{ after, before, aggregate: false, number: 1000 },
+		{
+			enabled: !! siteId,
+			select: ( activities: BackupActivity[] ) => activities.filter( isBackupActivity ),
+			refetchOnWindowFocus: false,
+		}
+	);
+	const backups = useMemo( () => ( data ?? [] ) as BackupActivity[], [ data ] );
+
+	const actions = useMemo( (): Action< BackupActivity >[] => {
+		const hasRewindId = ( item: BackupActivity ) => !! item.rewindId;
+		const isRestorable = ( item: BackupActivity ) =>
+			!! ( isRestoreEnabled && item.activityIsRewindable && item.rewindId );
+
+		return [
+			{
+				id: 'restore',
+				label: __( 'Restore to this point' ),
+				isEligible: isRestorable,
+				callback: ( [ item ] ) => {
+					dispatch(
+						recordTracksEvent( 'calypso_jetpack_backup_dataviews_restore_click', {
+							rewind_id: item.rewindId,
+						} )
+					);
+					page( backupRestorePath( siteSlug, String( item.rewindId ) ) );
+				},
+			},
+			{
+				id: 'download',
+				label: __( 'Download backup' ),
+				isEligible: hasRewindId,
+				callback: ( [ item ] ) => {
+					if ( ! item.rewindId ) {
+						return;
+					}
+					dispatch( rewindRequestBackup( siteId, item.rewindId ) );
+					dispatch(
+						recordTracksEvent( 'calypso_jetpack_backup_dataviews_download_click', {
+							rewind_id: item.rewindId,
+						} )
+					);
+					page( backupDownloadPath( siteSlug, String( item.rewindId ) ) );
+				},
+			},
+			{
+				id: 'browse-files',
+				label: __( 'Browse files' ),
+				isEligible: ( item ) => !! ( item.activityIsRewindable && item.rewindId ),
+				callback: ( [ item ] ) => {
+					dispatch( recordTracksEvent( 'calypso_jetpack_backup_dataviews_browse_click' ) );
+					page( backupContentsPath( siteSlug, String( item.rewindId ) ) );
+				},
+			},
+		];
+	}, [ dispatch, siteId, siteSlug, isRestoreEnabled ] );
+
+	const fields = useMemo(
+		() => getFields( { moment, timezone, gmtOffset } ),
+		[ moment, timezone, gmtOffset ]
+	);
+
+	const { data: visibleBackups, paginationInfo } = useMemo(
+		() => filterSortAndPaginate( backups, view, fields ),
+		[ backups, view, fields ]
+	);
+
+	const onDateRangeChange = useCallback( ( next: { start: Date; end: Date } ) => {
+		setDateRange( next );
+		setView( ( previousView ) => ( { ...previousView, page: 1 } ) );
+	}, [] );
+
+	if ( isError ) {
+		return (
+			<Notice status="error" isDismissible={ false }>
+				{ __( 'We couldn’t load your backups. Please try again.' ) }
+				<Button variant="link" onClick={ () => refetch() }>
+					{ __( 'Retry' ) }
+				</Button>
+			</Notice>
+		);
+	}
+
+	return (
+		<div className="backup-dataviews">
+			<div className="backup-dataviews__controls">
+				<DateRangePicker
+					start={ dateRange.start }
+					end={ dateRange.end }
+					gmtOffset={ gmtOffset ?? undefined }
+					timezoneString={ timezone ?? undefined }
+					locale={ locale }
+					defaultFallbackPreset="last-30-days"
+					onChange={ onDateRangeChange }
+				/>
+			</div>
+			<div className="backup-dataviews__list">
+				<DataViews< BackupActivity >
+					data={ visibleBackups }
+					fields={ fields }
+					view={ view }
+					onChangeView={ setView }
+					actions={ actions }
+					getItemId={ ( item ) => String( item.activityId ) }
+					isLoading={ isLoading }
+					defaultLayouts={ { table: {} } }
+					paginationInfo={ paginationInfo }
+					searchLabel={ __( 'Search backups' ) }
+					empty={
+						<p>
+							{ view.search
+								? __( 'No backups match your search.' )
+								: __( 'No backups found in this date range.' ) }
+						</p>
+					}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/client/my-sites/backup/backup-dataviews/style.scss
+++ b/client/my-sites/backup/backup-dataviews/style.scss
@@ -1,0 +1,88 @@
+.backup-dataviews {
+	margin-block-start: 16px;
+}
+
+.backup-dataviews__controls {
+	display: flex;
+	justify-content: flex-end;
+	margin-block-end: 16px;
+}
+
+.backup-dataviews .dataviews-view-table-header,
+.backup-dataviews .dataviews-view-table-header-button {
+	text-transform: uppercase;
+	font-size: 0.75rem;
+	font-weight: 500;
+	letter-spacing: 0.02em;
+	color: var( --color-text-subtle );
+}
+
+.backup-dataviews .dataviews-view-table-header-button {
+	border: none;
+	box-shadow: none;
+}
+
+.backup-dataviews .dataviews__view-actions .components-button,
+.backup-dataviews .dataviews-pagination .components-button,
+.backup-dataviews .dataviews-item-actions .components-button {
+	border: none;
+	box-shadow: none;
+	color: var( --studio-gray-70 );
+}
+
+.backup-dataviews .dataviews-wrapper tr.dataviews-view-table__row td {
+	padding-block: 14px;
+	border-block-end: 1px solid var( --color-border-subtle );
+	vertical-align: top;
+}
+
+.backup-dataviews__date {
+	color: var( --color-text-subtle );
+	white-space: nowrap;
+}
+
+.backup-dataviews__icon-box {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	inline-size: 32px;
+	block-size: 32px;
+	background: var( --studio-gray-0 );
+	border-radius: 4px;
+	flex-shrink: 0;
+}
+
+.backup-dataviews__icon {
+	fill: var( --color-text );
+}
+
+.backup-dataviews__event-text strong {
+	font-weight: 600;
+	color: var( --color-text );
+}
+
+.backup-dataviews__event-description {
+	color: var( --color-text-subtle );
+}
+
+.backup-dataviews__event-description div {
+	display: inline;
+}
+
+.backup-dataviews__user {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	color: var( --color-text-subtle );
+}
+
+.backup-dataviews__user-avatar {
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+
+.backup-dataviews__user-logo {
+	flex-shrink: 0;
+	display: block;
+}
+

--- a/client/my-sites/backup/backup-dataviews/types.ts
+++ b/client/my-sites/backup/backup-dataviews/types.ts
@@ -1,0 +1,6 @@
+import type { Activity } from 'calypso/state/activity-log/types';
+
+export type BackupActivity = Activity & {
+	activityIsRewindable?: boolean;
+	activityStatus?: string;
+};

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -17,6 +17,7 @@ import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import QuerySiteProducts from 'calypso/components/data/query-site-products';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import BackupActionsToolbar from 'calypso/components/jetpack/backup-actions-toolbar';
+import BackupGettingStarted from 'calypso/components/jetpack/backup-getting-started';
 import BackupPlaceholder from 'calypso/components/jetpack/backup-placeholder';
 import JetpackFooter from 'calypso/components/jetpack/jetpack-footer';
 import JetpackTitle from 'calypso/components/jetpack-title';
@@ -37,6 +38,7 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { useSelectedSiteSelector } from 'calypso/state/sites/hooks';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import BackupsDataViews from './backup-dataviews';
 import BackupDatePicker from './backup-date-picker';
 import BackupsMadeRealtimeBanner from './banners/backups-made-realtime-banner';
 import EnableRestoresBanner from './banners/enable-restores-banner';
@@ -89,7 +91,7 @@ const BackupPage = ( { queryDate } ) => {
 				actions={ showHeader ? <BackupActionsToolbar siteId={ siteId } /> : undefined }
 			>
 				<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
-				<AdminContent selectedDate={ selectedDate } />
+				<AdminContent selectedDate={ selectedDate } queryDate={ queryDate } />
 			</Page>
 			{ showHeader && <JetpackFooter /> }
 		</Main>
@@ -112,7 +114,7 @@ const isFilterEmpty = ( filter ) => {
 	return true;
 };
 
-function AdminContent( { selectedDate } ) {
+function AdminContent( { selectedDate, queryDate } ) {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
@@ -153,6 +155,7 @@ function AdminContent( { selectedDate } ) {
 						onDateChange={ onDateChange }
 						selectedDate={ selectedDate }
 						needCredentials={ needCredentials }
+						queryDate={ queryDate }
 					/>
 				</>
 			) }
@@ -160,7 +163,7 @@ function AdminContent( { selectedDate } ) {
 	);
 }
 
-function BackupStatus( { selectedDate, needCredentials, onDateChange } ) {
+function BackupStatus( { selectedDate, needCredentials, onDateChange, queryDate } ) {
 	const isFetchingSiteFeatures = useSelectedSiteSelector( isRequestingSiteFeatures );
 	const isPoliciesInitialized = useSelectedSiteSelector( isRewindPoliciesInitialized );
 	const siteId = useSelector( getSelectedSiteId );
@@ -175,9 +178,34 @@ function BackupStatus( { selectedDate, needCredentials, onDateChange } ) {
 		return <BackupPlaceholder showDatePicker />;
 	}
 
+	if ( isJetpackCloud() ) {
+		return (
+			<div className="backup__main-wrap">
+				<div className="backup__header">
+					<div className="backup__header-left">
+						<div className="backup__header-title">{ translate( 'Latest Backups' ) }</div>
+						<div className="backup__header-text">
+							{ translate( 'This is a list of your latest generated backups' ) }
+						</div>
+					</div>
+					<div className="backup__header-right">
+						<BackupActionsToolbar siteId={ siteId } />
+					</div>
+				</div>
+
+				{ needCredentials && <EnableRestoresBanner /> }
+				{ ! needCredentials && hasRealtimeBackups && <BackupsMadeRealtimeBanner /> }
+
+				<BackupStorageSpace />
+				<BackupsDataViews queryDate={ queryDate } />
+				{ hasRealtimeBackups && <BackupGettingStarted /> }
+			</div>
+		);
+	}
+
 	return (
 		<div className="backup__main-wrap">
-			{ ( isJetpackCloud() || isA8CForAgencies() ) && (
+			{ isA8CForAgencies() && (
 				<div className="backup__header">
 					<div className="backup__header-left">
 						<div className="backup__header-title">{ translate( 'Latest Backups' ) }</div>


### PR DESCRIPTION
## Proposed Changes

* Retrofits the Jetpack Cloud Backups page to use dataviews for design and experience consistency.

## Testing Instructions

* TBD - this is a WIP.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
