### PR TITLE
Jetpack Cloud: Use Dataviews for the activity log page

### DIFF
--- a/client/my-sites/activity/activity-log-dataviews/fields.tsx
+++ b/client/my-sites/activity/activity-log-dataviews/fields.tsx
@@ -1,0 +1,166 @@
+import { Icon, __experimentalHStack as HStack } from '@wordpress/components';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import clsx from 'clsx';
+import ActivityDescription from 'calypso/components/activity-card/activity-description';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+import { gridiconToWordPressIcon } from 'calypso/dashboard/utils/gridicons';
+import { applySiteOffset } from 'calypso/lib/site/timezone';
+import type { ActivityActorOption, ActivityLogEntry, ActivityTypeGroup } from './types';
+import type { Field, Operator } from '@wordpress/dataviews';
+import type { MomentInput, Moment } from 'moment';
+
+type MomentFactory = ( input?: MomentInput ) => Moment;
+
+export type FieldsOptions = {
+	moment: MomentFactory;
+	timezone: string | null;
+	gmtOffset: number | null;
+	groupTypes: ActivityTypeGroup[];
+	actorOptions: ActivityActorOption[];
+	showFilters: boolean;
+};
+
+export function getFields( {
+	moment,
+	timezone,
+	gmtOffset,
+	groupTypes,
+	actorOptions,
+	showFilters,
+}: FieldsOptions ): Field< ActivityLogEntry >[] {
+	const toLocal = ( ts: number ) => applySiteOffset( moment( ts ), { timezone, gmtOffset } );
+
+	const formatDate = ( ts: number ) => {
+		const local = toLocal( ts );
+		const now = applySiteOffset( moment(), { timezone, gmtOffset } );
+		const daysAgo = now.clone().startOf( 'day' ).diff( local.clone().startOf( 'day' ), 'days' );
+
+		// Within the last week moment's calendar() gives localized strings like
+		// "Today at 3:53 PM" or "Last Monday at 3:53 PM"; beyond that it falls
+		// back to plain dates, so switch to relative phrasing instead.
+		return daysAgo < 7 ? local.calendar( now ) : moment( ts ).fromNow();
+	};
+
+	const fields: Field< ActivityLogEntry >[] = [
+		{
+			id: 'date',
+			label: __( 'Date & time' ),
+			getValue: ( { item } ) => item.activityTs,
+			render: ( { item } ) => (
+				<time
+					className="activity-log-dataviews__date"
+					title={ toLocal( item.activityTs ).format( 'llll' ) }
+				>
+					{ formatDate( item.activityTs ) }
+				</time>
+			),
+		},
+		{
+			id: 'event',
+			label: __( 'Event' ),
+			getValue: ( { item } ) => item.activityTitle,
+			enableGlobalSearch: true,
+			render: ( { item } ) => {
+				const streamCount = item.streamCount ?? item.streams?.length ?? 0;
+
+				return (
+					<HStack alignment="left" spacing={ 3 }>
+						<span
+							className={ clsx( 'activity-log-dataviews__icon-box', {
+								'is-error': item.activityStatus === 'error',
+								'is-warning': item.activityStatus === 'warning',
+							} ) }
+						>
+							<Icon
+								icon={ gridiconToWordPressIcon( item.activityIcon ?? 'info-outline' ) }
+								size={ 20 }
+								className="activity-log-dataviews__icon"
+							/>
+						</span>
+						<span className="activity-log-dataviews__event-text">
+							<strong>{ item.activityTitle }</strong>
+							{ item.activityDescription && (
+								<span className="activity-log-dataviews__event-description">
+									{ ' ' }
+									<ActivityDescription activity={ item } />
+								</span>
+							) }
+							{ streamCount > 0 && (
+								<span className="activity-log-dataviews__stream-count">
+									{ ' ' }
+									{ sprintf(
+										/* translators: %d is the number of similar events grouped into this row */
+										_n( '· %d more event', '· %d more events', streamCount ),
+										streamCount
+									) }
+								</span>
+							) }
+						</span>
+					</HStack>
+				);
+			},
+		},
+		{
+			id: 'user',
+			label: __( 'User' ),
+			getValue: ( { item } ) => item.actorName ?? '',
+			enableGlobalSearch: true,
+			render: ( { item } ) => {
+				const isJetpackActor =
+					item.actorType === 'Application' && !! item.actorName?.startsWith( 'Jetpack' );
+				const isMultipleActors = item.actorType === 'Multiple';
+
+				return (
+					<span className="activity-log-dataviews__user">
+						{ isJetpackActor && (
+							<JetpackLogo
+								size={ 24 }
+								monochrome={ false }
+								className="activity-log-dataviews__user-logo"
+							/>
+						) }
+						{ ! isJetpackActor && ! isMultipleActors && item.actorAvatarUrl && (
+							<img
+								className="activity-log-dataviews__user-avatar"
+								src={ item.actorAvatarUrl }
+								alt=""
+								width={ 24 }
+								height={ 24 }
+							/>
+						) }
+						<span>{ isMultipleActors ? __( 'Multiple users' ) : item.actorName }</span>
+					</span>
+				);
+			},
+		},
+	];
+
+	if ( showFilters ) {
+		fields.push(
+			{
+				id: 'group',
+				label: __( 'Activity type' ),
+				getValue: ( { item } ) => item.activityGroup ?? '',
+				elements: groupTypes.map( ( type ) => ( {
+					value: type.key,
+					label: `${ type.name } (${ type.count })`,
+				} ) ),
+				filterBy: { operators: [ 'isAny' as Operator ] },
+				enableSorting: false,
+			},
+			{
+				id: 'actor',
+				label: __( 'Performed by' ),
+				getValue: ( { item } ) => item.actorName ?? '',
+				elements: actorOptions.map( ( actor ) => ( {
+					value: actor.key,
+					label: actor.name,
+				} ) ),
+				filterBy: { operators: [ 'isAny' as Operator ] },
+				enableSorting: false,
+			}
+		);
+	}
+
+	return fields;
+}

--- a/client/my-sites/activity/activity-log-dataviews/index.tsx
+++ b/client/my-sites/activity/activity-log-dataviews/index.tsx
@@ -1,0 +1,429 @@
+import { DateRangePicker } from '@automattic/date-range-picker';
+import { useQuery } from '@tanstack/react-query';
+import { Button, Notice } from '@wordpress/components';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import VisibleDaysLimitUpsell from 'calypso/components/activity-card-list/visible-days-limit-upsell';
+import { DataViews } from 'calypso/components/dataviews';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import useActivityLogActorsQuery from 'calypso/data/activity-log/use-activity-log-actors-query';
+import useActivityLogQuery from 'calypso/data/activity-log/use-activity-log-query';
+import { getActionableRewindId } from 'calypso/lib/jetpack/actionable-rewind-id';
+import {
+	isSuccessfulRealtimeBackup,
+	SUCCESSFUL_BACKUP_ACTIVITIES,
+} from 'calypso/lib/jetpack/backup-utils';
+import { settingsPath } from 'calypso/lib/jetpack/paths';
+import { navigate } from 'calypso/lib/navigate';
+import wpcom from 'calypso/lib/wp';
+import {
+	backupContentsPath,
+	backupDownloadPath,
+	backupRestorePath,
+} from 'calypso/my-sites/backup/paths';
+import { useDispatch, useSelector } from 'calypso/state';
+import { rewindRequestBackup, updateFilter } from 'calypso/state/activity-log/actions';
+import { filterStateToApiQuery } from 'calypso/state/activity-log/utils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import fromActivityTypeApi from 'calypso/state/data-layer/wpcom/sites/activity-types/from-api';
+import canRestoreSite from 'calypso/state/rewind/selectors/can-restore-site';
+import getActivityLogVisibleDays from 'calypso/state/rewind/selectors/get-activity-log-visible-days';
+import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
+import getActivityLogHiddenGroups from 'calypso/state/selectors/get-activity-log-hidden-groups';
+import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
+import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
+import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
+import isJetpackSiteMultiSite from 'calypso/state/sites/selectors/is-jetpack-site-multi-site';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getFields } from './fields';
+import type { ActivityActorOption, ActivityLogEntry } from './types';
+import type { Action, Filter, View } from '@wordpress/dataviews';
+
+import './style.scss';
+
+const DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
+
+const DEFAULT_VIEW: View = {
+	type: 'table',
+	fields: [ 'date', 'event', 'user' ],
+	perPage: 20,
+	page: 1,
+	sort: {
+		field: 'date',
+		direction: 'desc',
+	},
+	layout: {
+		styles: {
+			date: { width: '220px' },
+			event: { width: '100%' },
+			user: { width: '200px' },
+		},
+	},
+};
+
+const buildViewFilters = ( filter: { group?: string[] | null; actor?: string[] | null } ) => {
+	const filters: Filter[] = [];
+	if ( filter.group?.length ) {
+		filters.push( { field: 'group', operator: 'isAny', value: filter.group } );
+	}
+	if ( filter.actor?.length ) {
+		filters.push( { field: 'actor', operator: 'isAny', value: filter.actor } );
+	}
+	return filters;
+};
+
+const getFilterValues = ( filters: Filter[] | undefined, field: string ): string[] =>
+	filters?.find( ( f ) => f.field === field )?.value ?? [];
+
+const arraysDiffer = ( a: string[], b: string[] ) =>
+	a.length !== b.length || a.some( ( value ) => ! b.includes( value ) );
+
+export default function ActivityLogDataViews( { showFilters = true }: { showFilters?: boolean } ) {
+	const dispatch = useDispatch();
+	const moment = useLocalizedMoment();
+
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const siteSlug = useSelector( getSelectedSiteSlug ) as string;
+	const timezone = useSelector( ( state ) => getSiteTimezoneValue( state, siteId ) );
+	const gmtOffset = useSelector( ( state ) => getSiteGmtOffset( state, siteId ) );
+	const locale = useSelector( getCurrentUserLocale ) || 'en';
+	const filter = useSelector( ( state ) => getActivityLogFilter( state, siteId ) );
+	const notGroup = useSelector( ( state ) => getActivityLogHiddenGroups( state, siteId ) );
+	const visibleDays = useSelector( ( state ) => getActivityLogVisibleDays( state, siteId ) );
+	const isMultiSite = useSelector( ( state ) => isJetpackSiteMultiSite( state, siteId ) );
+	const isRestoreEnabled = useSelector( ( state ) => canRestoreSite( state, siteId ) );
+	const needsCredentials = useSelector( ( state ) =>
+		getDoesRewindNeedCredentials( state, siteId )
+	);
+
+	const queryFilter = useMemo(
+		() => ( notGroup ? { ...filter, notGroup } : filter ),
+		[ filter, notGroup ]
+	);
+
+	const { data, isLoading, isError, refetch } = useActivityLogQuery( siteId, queryFilter, {
+		enabled: !! siteId,
+		refetchOnWindowFocus: false,
+	} );
+
+	const { data: groupTypes = [] } = useQuery( {
+		queryKey: [
+			'activity-log-counts',
+			siteId,
+			filter.before ?? '',
+			filter.after ?? '',
+			filter.on ?? '',
+		],
+		queryFn: () =>
+			wpcom.req
+				.get(
+					{ path: `/sites/${ siteId }/activity/count/group`, apiNamespace: 'wpcom/v2' },
+					filterStateToApiQuery(
+						{ before: filter.before, after: filter.after, on: filter.on },
+						false
+					)
+				)
+				.then( fromActivityTypeApi ),
+		enabled: !! siteId && showFilters,
+		staleTime: 10 * 1000,
+	} );
+
+	const { data: actorsData } = useActivityLogActorsQuery( siteId, filter, {
+		enabled: !! siteId && showFilters,
+	} );
+	const actorOptions = useMemo(
+		() => ( actorsData ?? [] ) as ActivityActorOption[],
+		[ actorsData ]
+	);
+
+	const [ view, setView ] = useState< View >( () => ( {
+		...DEFAULT_VIEW,
+		page: filter.page ?? 1,
+		search: filter.textSearch ?? '',
+		filters: buildViewFilters( filter ),
+	} ) );
+
+	// Reflect external filter changes (deep links, back/forward navigation)
+	// into the view; values already in sync are left untouched to avoid loops.
+	useEffect( () => {
+		setView( ( previousView ) => {
+			const next = { ...previousView };
+			let changed = false;
+
+			if ( ( filter.page ?? 1 ) !== ( previousView.page ?? 1 ) ) {
+				next.page = filter.page ?? 1;
+				changed = true;
+			}
+			if ( ( filter.textSearch ?? '' ) !== ( previousView.search ?? '' ) ) {
+				next.search = filter.textSearch ?? '';
+				changed = true;
+			}
+			const viewGroup = getFilterValues( previousView.filters, 'group' );
+			const viewActor = getFilterValues( previousView.filters, 'actor' );
+			if (
+				arraysDiffer( filter.group ?? [], viewGroup ) ||
+				arraysDiffer( filter.actor ?? [], viewActor )
+			) {
+				next.filters = buildViewFilters( filter );
+				changed = true;
+			}
+
+			return changed ? next : previousView;
+		} );
+	}, [ filter ] );
+
+	// Debounce text search dispatches so we don't refetch on every keystroke.
+	const searchTimeoutRef = useRef< number | undefined >( undefined );
+	useEffect( () => () => window.clearTimeout( searchTimeoutRef.current ), [] );
+
+	const onChangeView = useCallback(
+		( nextView: View ) => {
+			setView( nextView );
+
+			const nextGroup = getFilterValues( nextView.filters, 'group' );
+			const nextActor = getFilterValues( nextView.filters, 'actor' );
+			const filterUpdates: Record< string, unknown > = {};
+
+			if ( arraysDiffer( nextGroup, filter.group ?? [] ) ) {
+				filterUpdates.group = nextGroup.length ? nextGroup : null;
+				filterUpdates.page = 1;
+				dispatch(
+					recordTracksEvent( 'calypso_activitylog_filterbar_select_type', {
+						num_groups_selected: nextGroup.length,
+					} )
+				);
+			}
+			if ( arraysDiffer( nextActor, filter.actor ?? [] ) ) {
+				filterUpdates.actor = nextActor.length ? nextActor : null;
+				filterUpdates.page = 1;
+				dispatch(
+					recordTracksEvent( 'calypso_activitylog_filterbar_select_actor', {
+						actor_count: nextActor.length,
+					} )
+				);
+			}
+			if ( ( nextView.page ?? 1 ) !== ( filter.page ?? 1 ) && ! filterUpdates.page ) {
+				filterUpdates.page = nextView.page ?? 1;
+			}
+			if ( Object.keys( filterUpdates ).length ) {
+				dispatch( updateFilter( siteId, filterUpdates ) );
+			}
+
+			const nextSearch = nextView.search ?? '';
+			if ( nextSearch !== ( filter.textSearch ?? '' ) ) {
+				window.clearTimeout( searchTimeoutRef.current );
+				searchTimeoutRef.current = window.setTimeout( () => {
+					dispatch( updateFilter( siteId, { textSearch: nextSearch || null, page: 1 } ) );
+					dispatch( recordTracksEvent( 'calypso_activitylog_filterbar_text_search' ) );
+				}, 500 );
+			}
+		},
+		[ dispatch, siteId, filter.group, filter.actor, filter.page, filter.textSearch ]
+	);
+
+	const onDateRangeChange = useCallback(
+		( next: { start: Date; end: Date } ) => {
+			dispatch(
+				updateFilter( siteId, {
+					after: moment( next.start ).startOf( 'day' ).utc().format( DATE_FORMAT ),
+					before: moment( next.end ).endOf( 'day' ).utc().format( DATE_FORMAT ),
+					on: null,
+					page: 1,
+				} )
+			);
+		},
+		[ dispatch, siteId, moment ]
+	);
+
+	const dateRange = useMemo( () => {
+		const start = filter.after ? moment.utc( filter.after ).local().toDate() : null;
+		const end = filter.before ? moment.utc( filter.before ).local().toDate() : null;
+		return {
+			start: start ?? moment().subtract( 29, 'days' ).toDate(),
+			end: end ?? moment().toDate(),
+		};
+	}, [ filter.after, filter.before, moment ] );
+
+	const logs = useMemo( () => ( data ?? [] ) as ActivityLogEntry[], [ data ] );
+
+	// Rewind policies can cap how far back the log is visible; trim anything
+	// older and offer the retention upsell when entries got cut off.
+	const visibleLimitCutoffDate = useMemo(
+		() =>
+			Number.isFinite( visibleDays )
+				? moment().subtract( visibleDays as number, 'days' )
+				: undefined,
+		[ visibleDays, moment ]
+	);
+	const visibleLogs = useMemo(
+		() =>
+			visibleLimitCutoffDate
+				? logs.filter( ( log ) =>
+						moment( log.activityTs ).isSameOrAfter( visibleLimitCutoffDate, 'day' )
+				  )
+				: logs,
+		[ logs, visibleLimitCutoffDate, moment ]
+	);
+	const hasHiddenOlderLogs = visibleLogs.length < logs.length;
+
+	const fields = useMemo(
+		() =>
+			getFields( {
+				moment,
+				timezone,
+				gmtOffset,
+				groupTypes,
+				actorOptions,
+				showFilters,
+			} ),
+		[ moment, timezone, gmtOffset, groupTypes, actorOptions, showFilters ]
+	);
+
+	// Group, actor, and text search are applied server-side through the
+	// activity endpoint, so strip them before the client-side pass.
+	const { data: visibleItems, paginationInfo } = useMemo( () => {
+		const clientView = { ...view, filters: [], search: '' };
+		return filterSortAndPaginate( visibleLogs, clientView, fields );
+	}, [ visibleLogs, view, fields ] );
+
+	const actions = useMemo( (): Action< ActivityLogEntry >[] => {
+		const actionableId = ( item: ActivityLogEntry ) => getActionableRewindId( item );
+		const isRewindableEvent = ( item: ActivityLogEntry ) =>
+			!! actionableId( item ) &&
+			( isSuccessfulRealtimeBackup( item ) ||
+				!! item.streams?.some( ( stream ) => isSuccessfulRealtimeBackup( stream ) ) );
+
+		return [
+			{
+				id: 'restore',
+				label: __( 'Restore to this point' ),
+				isEligible: ( item ) => ! isMultiSite && isRestoreEnabled && isRewindableEvent( item ),
+				callback: ( [ item ] ) => {
+					dispatch( recordTracksEvent( 'calypso_jetpack_backup_actions_restore_click' ) );
+					navigate( backupRestorePath( siteSlug, String( actionableId( item ) ) ) );
+				},
+			},
+			{
+				id: 'activate-restores',
+				label: __( 'Activate restores' ),
+				isEligible: ( item ) => ! isMultiSite && needsCredentials && isRewindableEvent( item ),
+				callback: () => {
+					dispatch( recordTracksEvent( 'calypso_jetpack_backup_actions_credentials_click' ) );
+					navigate( settingsPath( siteSlug ) );
+				},
+			},
+			{
+				id: 'view-files',
+				label: __( 'View files' ),
+				isEligible: ( item ) =>
+					! isMultiSite &&
+					isRewindableEvent( item ) &&
+					SUCCESSFUL_BACKUP_ACTIVITIES.includes( item.activityName ),
+				callback: ( [ item ] ) => {
+					dispatch( recordTracksEvent( 'calypso_jetpack_backup_actions_view_files_click' ) );
+					navigate( backupContentsPath( siteSlug, String( actionableId( item ) ) ) );
+				},
+			},
+			{
+				id: 'download',
+				label: __( 'Download backup' ),
+				isEligible: isRewindableEvent,
+				callback: ( [ item ] ) => {
+					const rewindId = actionableId( item );
+					if ( ! rewindId ) {
+						return;
+					}
+					dispatch(
+						recordTracksEvent( 'calypso_jetpack_backup_actions_download_click', {
+							rewind_id: rewindId,
+						} )
+					);
+					dispatch( rewindRequestBackup( siteId, rewindId ) );
+					navigate( backupDownloadPath( siteSlug, rewindId ) );
+				},
+			},
+		];
+	}, [ dispatch, siteId, siteSlug, isMultiSite, isRestoreEnabled, needsCredentials ] );
+
+	const onResetFilters = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_activitylog_filterbar_reset' ) );
+		dispatch(
+			updateFilter( siteId, {
+				group: null,
+				after: null,
+				before: null,
+				on: null,
+				actor: null,
+				textSearch: null,
+				page: 1,
+			} )
+		);
+	}, [ dispatch, siteId ] );
+
+	if ( isError ) {
+		return (
+			<Notice status="error" isDismissible={ false }>
+				{ __( 'We couldn’t load your activity log. Please try again.' ) }
+				<Button variant="link" onClick={ () => refetch() }>
+					{ __( 'Retry' ) }
+				</Button>
+			</Notice>
+		);
+	}
+
+	const isFiltered = !! (
+		filter.group?.length ||
+		filter.actor?.length ||
+		filter.textSearch ||
+		filter.after ||
+		filter.before
+	);
+
+	return (
+		<div className="activity-log-dataviews">
+			{ showFilters && (
+				<div className="activity-log-dataviews__controls">
+					<DateRangePicker
+						start={ dateRange.start }
+						end={ dateRange.end }
+						gmtOffset={ gmtOffset ?? undefined }
+						timezoneString={ timezone ?? undefined }
+						locale={ locale }
+						defaultFallbackPreset="last-30-days"
+						onChange={ onDateRangeChange }
+					/>
+				</div>
+			) }
+			<div className="activity-log-dataviews__list">
+				<DataViews< ActivityLogEntry >
+					data={ visibleItems }
+					fields={ fields }
+					view={ view }
+					onChangeView={ onChangeView }
+					actions={ actions }
+					getItemId={ ( item ) => String( item.activityId ) }
+					isLoading={ isLoading }
+					defaultLayouts={ { table: {} } }
+					paginationInfo={ paginationInfo }
+					search={ showFilters }
+					searchLabel={ __( 'Search posts by ID, title or author' ) }
+					empty={
+						<div className="activity-log-dataviews__empty">
+							<p>{ __( 'No matching events found.' ) }</p>
+							{ isFiltered && (
+								<Button variant="link" onClick={ onResetFilters }>
+									{ __( 'Remove all filters' ) }
+								</Button>
+							) }
+						</div>
+					}
+				/>
+			</div>
+			{ hasHiddenOlderLogs && ( view.page ?? 1 ) >= paginationInfo.totalPages && (
+				<VisibleDaysLimitUpsell />
+			) }
+		</div>
+	);
+}

--- a/client/my-sites/activity/activity-log-dataviews/style.scss
+++ b/client/my-sites/activity/activity-log-dataviews/style.scss
@@ -1,0 +1,110 @@
+.activity-log-dataviews {
+	margin-block-start: 16px;
+}
+
+.activity-log-dataviews__controls {
+	display: flex;
+	justify-content: flex-end;
+	margin-block-end: 16px;
+}
+
+.activity-log-dataviews .dataviews-view-table-header,
+.activity-log-dataviews .dataviews-view-table-header-button {
+	text-transform: uppercase;
+	font-size: 0.75rem;
+	font-weight: 500;
+	letter-spacing: 0.02em;
+	color: var( --color-text-subtle );
+}
+
+.activity-log-dataviews .dataviews-view-table-header-button,
+.activity-log-dataviews .dataviews__view-actions .components-button,
+.activity-log-dataviews .dataviews-pagination .components-button,
+.activity-log-dataviews .dataviews-item-actions .components-button {
+	border: none;
+	box-shadow: none;
+}
+
+.activity-log-dataviews .dataviews__view-actions .components-button,
+.activity-log-dataviews .dataviews-pagination .components-button,
+.activity-log-dataviews .dataviews-item-actions .components-button {
+	color: var( --studio-gray-70 );
+}
+
+.activity-log-dataviews .dataviews-wrapper tr.dataviews-view-table__row td {
+	padding-block: 14px;
+	border-block-end: 1px solid var( --color-border-subtle );
+	vertical-align: top;
+}
+
+.activity-log-dataviews__date {
+	color: var( --color-text-subtle );
+	white-space: nowrap;
+}
+
+.activity-log-dataviews__icon-box {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	inline-size: 32px;
+	block-size: 32px;
+	background: var( --studio-gray-0 );
+	border-radius: 4px;
+	flex-shrink: 0;
+}
+
+.activity-log-dataviews__icon {
+	fill: var( --color-text );
+}
+
+.activity-log-dataviews__icon-box.is-error {
+	background: var( --studio-red-0 );
+}
+
+.activity-log-dataviews__icon-box.is-error .activity-log-dataviews__icon {
+	fill: var( --studio-red-50 );
+}
+
+.activity-log-dataviews__icon-box.is-warning {
+	background: var( --studio-yellow-0 );
+}
+
+.activity-log-dataviews__icon-box.is-warning .activity-log-dataviews__icon {
+	fill: var( --studio-yellow-50 );
+}
+
+.activity-log-dataviews__event-text strong {
+	font-weight: 600;
+	color: var( --color-text );
+}
+
+.activity-log-dataviews__event-description,
+.activity-log-dataviews__stream-count {
+	color: var( --color-text-subtle );
+}
+
+.activity-log-dataviews__event-description div {
+	display: inline;
+}
+
+.activity-log-dataviews__user {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	color: var( --color-text-subtle );
+}
+
+.activity-log-dataviews__user-avatar {
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+
+.activity-log-dataviews__user-logo {
+	flex-shrink: 0;
+	display: block;
+}
+
+.activity-log-dataviews__empty {
+	text-align: center;
+	padding-block: 24px;
+}

--- a/client/my-sites/activity/activity-log-dataviews/types.ts
+++ b/client/my-sites/activity/activity-log-dataviews/types.ts
@@ -1,0 +1,22 @@
+import type { Activity } from 'calypso/state/activity-log/types';
+
+export type ActivityLogEntry = Activity & {
+	activityIsRewindable: boolean;
+	activityStatus?: string;
+	activityGroup?: string;
+	streams?: ActivityLogEntry[];
+	streamCount?: number;
+	isAggregate?: boolean;
+};
+
+export type ActivityTypeGroup = {
+	key: string;
+	name: string;
+	count: number;
+};
+
+export type ActivityActorOption = {
+	key: string;
+	name: string;
+	count?: number;
+};

--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -16,6 +16,7 @@ import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { preventWidows } from 'calypso/lib/formatting';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import ActivityLogDataViews from 'calypso/my-sites/activity/activity-log-dataviews';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { hasJetpackPartnerAccess as hasJetpackPartnerAccessSelector } from 'calypso/state/partner-portal/partner/selectors';
@@ -101,12 +102,16 @@ const ActivityLogV2: FunctionComponent = () => {
 				) }
 				{ settingsUrl && <TimeMismatchWarning siteId={ siteId } settingsUrl={ settingsUrl } /> }
 				<div className="activity-log-v2__content">
-					<ActivityCardList
-						logs={ logs }
-						pageSize={ 10 }
-						showFilter={ siteHasFullActivityLog }
-						siteId={ siteId }
-					/>
+					{ isJetpackCloud() ? (
+						<ActivityLogDataViews showFilters={ !! siteHasFullActivityLog } />
+					) : (
+						<ActivityCardList
+							logs={ logs }
+							pageSize={ 10 }
+							showFilter={ siteHasFullActivityLog }
+							siteId={ siteId }
+						/>
+					) }
 				</div>
 			</Page>
 		</Main>


### PR DESCRIPTION
## Proposed Changes

* Retrofits the Jetpack Cloud Activity Log page to use dataviews for design and experience consistency.

## Testing Instructions

* TBD - this is a WIP.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
