### PR TITLE
Bump site-purchases query key after purchase shape change

### DIFF
--- a/packages/data-stores/src/purchases/queries/lib/use-query-keys-factory.ts
+++ b/packages/data-stores/src/purchases/queries/lib/use-query-keys-factory.ts
@@ -1,5 +1,9 @@
 const useQueryKeysFactory = () => ( {
-	sitePurchases: ( siteId?: string | number | null ) => [ 'site-purchases', siteId ],
+	// The `2` is a cache version. #112677 changed the stored shape from the assembled
+	// camelCase `Purchase` to the raw snake_case `RawPurchase` under this same key, so
+	// long-lived sessions spanning that deploy served stale assembled data to new readers.
+	// Bump this whenever the stored shape changes so old and new code never share an entry.
+	sitePurchases: ( siteId?: string | number | null ) => [ 'site-purchases', 2, siteId ],
 	transferredPurchases: ( userId?: string | number | null ) => [ 'transferred-purchases', userId ],
 } );
 


### PR DESCRIPTION
Related to [SHILL-2261](https://linear.app/a8c/issue/SHILL-2261/investigate-unknown-term-errors-on-site-level-purchase-details-page)

## Proposed Changes

Versions the `['site-purchases', siteId]` React Query key to `['site-purchases', 2, siteId]` so that code from before and after #112677 never shares the same cache entry.

## Why are these changes being made?

This appears to be the root-cause fix for the false `unknown bill_period_days` / `shape-mismatch` logs traced in SHILL-2261.

#112677 changed the shape stored under `['site-purchases', siteId]` from the assembled camelCase `Purchase` to the raw snake_case `RawPurchase`, but left the key unchanged. React Query dedupes by key, so in a long-lived SPA session that spans the deploy, an old chunk (whose `useSitePurchases` still assembles and stores under the same key) populates the shared cache with camelCase objects, and the new `usePricingMetaForGridPlans` then reads them expecting raw. The result is `bill_period_days` coming back `undefined`, which surfaced as false "unknown term" logs (and, before the hardening, a fatal on the purchase details page).

The production diagnostics confirmed this: the logged object was keyed by a real purchase id and had exactly `createPurchaseObject`'s camelCase output with a valid `billPeriodDays: 365` — the fingerprint of the pre-#112677 queryFn.

Bumping the key means new code reads/writes a fresh entry and simply refetches raw data, while stale old chunks keep using the old key in isolation. Every current reader/writer (`useSitePurchaseById`, `useSitePurchasesByProductSlug`, `use-non-owner-handler`) goes through this one factory, so they all move together. General rule captured in the comment: bump the key whenever the stored shape changes.

The shape-tolerance in the companion PR https://github.com/Automattic/wp-calypso/pull/112751 stays in place as defense-in-depth and covers the brief window until this propagates; once the logs confirm the problem is gone, the tolerance can be removed.

## Testing Instructions


* Load a site's plan/pricing surfaces (e.g. `/domains/manage/<domain>`, site-level purchase details) and confirm plan pricing renders correctly.
* In DevTools, confirm site purchases are cached under `['site-purchases', 2, <siteId>]`.
* Monitor logstash: the `unknown-term` / `shape-mismatch` (`usePricingMetaForGridPlans`) entries should taper off as sessions pick up the new key.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
