### PR TITLE
Onboarding: ship progress bar as default for desktop

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -39,7 +39,6 @@ import { getOnboardingPostCheckoutDestination } from '../../helpers/get-onboardi
 import { withLocale } from '../../helpers/with-locale';
 import { usePurchasePlanNotification } from '../../internals/hooks/use-purchase-plan-notification';
 import { STEPS } from '../../internals/steps';
-import { ONBOARDING_PROGRESS_EXPERIMENT_NAME } from '../../internals/steps-repository/components/onboarding-progress/use-show-onboarding-progress';
 import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
 import { type FlowV2, type ProvidedDependencies, type SubmitHandler } from '../../internals/types';
 import { getOnboardingStepperPosition } from './step-counter-config';
@@ -477,13 +476,6 @@ const onboarding: FlowV2< typeof initialize > = {
 		useEffect( () => {
 			loadExperimentAssignment( 'calypso_plans_page_visual_separation_2025_09_v2' );
 		}, [] );
-
-		// Preload the onboarding progress bar experiment
-		useEffect( () => {
-			if ( isLoggedIn ) {
-				loadExperimentAssignment( ONBOARDING_PROGRESS_EXPERIMENT_NAME );
-			}
-		}, [ isLoggedIn ] );
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/test/use-show-onboarding-progress.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/test/use-show-onboarding-progress.test.tsx
@@ -5,75 +5,31 @@ jest.mock( '@wordpress/compose', () => ( {
 	useViewportMatch: jest.fn(),
 } ) );
 
-jest.mock( 'calypso/lib/explat', () => ( {
-	useExperiment: jest.fn(),
-} ) );
-
 import { renderHook } from '@testing-library/react';
 import { useViewportMatch } from '@wordpress/compose';
-import { useExperiment } from 'calypso/lib/explat';
 import { useShowOnboardingProgress } from '../use-show-onboarding-progress';
 
 const mockViewport = useViewportMatch as unknown as jest.Mock;
-const mockExperiment = useExperiment as unknown as jest.Mock;
 
 describe( 'useShowOnboardingProgress', () => {
 	beforeEach( () => {
 		mockViewport.mockReset();
-		mockExperiment.mockReset();
 	} );
 
-	it( 'shows on desktop onboarding for the progress_bar treatment', () => {
+	it( 'shows on desktop onboarding', () => {
 		mockViewport.mockReturnValue( true );
-		mockExperiment.mockReturnValue( [ false, { variationName: 'progress_bar' } ] );
 		const { result } = renderHook( () => useShowOnboardingProgress( true ) );
 		expect( result.current ).toBe( true );
 	} );
 
-	it( 'hides for the control assignment (null)', () => {
-		mockViewport.mockReturnValue( true );
-		mockExperiment.mockReturnValue( [ false, null ] );
-		const { result } = renderHook( () => useShowOnboardingProgress( true ) );
-		expect( result.current ).toBe( false );
-	} );
-
 	it( 'hides when not onboarding flow', () => {
 		mockViewport.mockReturnValue( true );
-		mockExperiment.mockReturnValue( [ false, { variationName: 'progress_bar' } ] );
 		const { result } = renderHook( () => useShowOnboardingProgress( false ) );
 		expect( result.current ).toBe( false );
 	} );
 
 	it( 'hides on mobile', () => {
 		mockViewport.mockReturnValue( false );
-		mockExperiment.mockReturnValue( [ false, { variationName: 'progress_bar' } ] );
-		const { result } = renderHook( () => useShowOnboardingProgress( true ) );
-		expect( result.current ).toBe( false );
-	} );
-
-	it( 'passes isEligible: true to useExperiment on desktop', () => {
-		mockViewport.mockReturnValue( true );
-		mockExperiment.mockReturnValue( [ false, { variationName: 'progress_bar' } ] );
-		renderHook( () => useShowOnboardingProgress( true ) );
-		expect( mockExperiment ).toHaveBeenCalledWith(
-			expect.any( String ),
-			expect.objectContaining( { isEligible: true } )
-		);
-	} );
-
-	it( 'passes isEligible: false to useExperiment on mobile', () => {
-		mockViewport.mockReturnValue( false );
-		mockExperiment.mockReturnValue( [ false, null ] );
-		renderHook( () => useShowOnboardingProgress( true ) );
-		expect( mockExperiment ).toHaveBeenCalledWith(
-			expect.any( String ),
-			expect.objectContaining( { isEligible: false } )
-		);
-	} );
-
-	it( 'hides while the experiment assignment is still loading', () => {
-		mockViewport.mockReturnValue( true );
-		mockExperiment.mockReturnValue( [ true, null ] );
 		const { result } = renderHook( () => useShowOnboardingProgress( true ) );
 		expect( result.current ).toBe( false );
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/use-show-onboarding-progress.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/use-show-onboarding-progress.ts
@@ -1,29 +1,12 @@
 import { useViewportMatch } from '@wordpress/compose';
-import { useExperiment } from 'calypso/lib/explat';
-
-export const ONBOARDING_PROGRESS_EXPERIMENT_NAME =
-	'calypso_signup_onboarding_progress_bar_202606_v1';
 
 /**
  * Single source of truth for whether the onboarding progress indicator shows.
  *
  * Desktop-only. Mobile keeps the existing top-bar step counter.
- *
- * While the experiment assignment is loading we return false, so the indicator
- * is never shown on a not-yet-resolved guess and then toggled once the
- * assignment lands. This keeps the header from flickering between the legacy
- * back link and the stepper.
  */
 export function useShowOnboardingProgress( isOnboardingFlow: boolean ): boolean {
 	const isDesktop = useViewportMatch( 'large' );
-	const [ isLoading, assignment ] = useExperiment( ONBOARDING_PROGRESS_EXPERIMENT_NAME, {
-		isEligible: isDesktop,
-	} );
-	const isTreatment = assignment?.variationName === 'progress_bar';
 
-	if ( isLoading ) {
-		return false;
-	}
-
-	return isOnboardingFlow && isDesktop && isTreatment;
+	return isOnboardingFlow && isDesktop;
 }


### PR DESCRIPTION
Fixes DOTPROD-144

## Proposed Changes

* Remove the ExPlat experiment gate (`calypso_signup_onboarding_progress_bar_202606_v1`) from the onboarding progress indicator.
* `useShowOnboardingProgress` now returns `isOnboardingFlow && isDesktop`, so the progress bar shows for all desktop onboarding users.
* Drop the experiment-assignment preload effect and unused import from the onboarding flow.
* Update the hook's tests to cover the experiment-free behavior.

## Why are these changes being made?

The onboarding progress bar experiment has concluded and the treatment (`progress_bar`) won: mid-funnel step-level conversions and site creation improved, revenue leans positive. Per the analysis, we're shipping the treatment as the permanent default. Mobile is unaffected (it keeps the existing top-bar step counter). Related: DATSCI experiment — "Optimizing a Step by Step Progress Bar In Onboarding Flow".

## Testing Instructions

* On a desktop viewport, start the onboarding flow (`/setup/onboarding`) and proceed through domain search → plans → checkout. The step-by-step progress indicator should appear on every step for all users (no longer experiment-gated).
* On a mobile viewport, confirm the progress bar does not appear and the existing top-bar step counter is shown.
* Run `yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/` — all tests pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?