### PR TITLE
Add tests for the plan downgrade flow (SHILL-2266)

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/test/get-plans-intent.test.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/test/get-plans-intent.test.ts
@@ -1,10 +1,31 @@
 /**
  * @jest-environment jsdom
  */
+import { PLAN_UPGRADE_FLOW } from '@automattic/onboarding';
 import { getPlansIntent } from '../util/get-plans-intent';
 
 describe( 'getPlansIntent', () => {
+	afterEach( () => {
+		window.history.replaceState( {}, '', '/' );
+	} );
+
 	it( 'maps the ai-site-builder-onboarding flow to the four paid plans intent', () => {
 		expect( getPlansIntent( 'ai-site-builder-onboarding' ) ).toBe( 'plans-ai-assembler-paid-only' );
+	} );
+
+	describe( 'plan-upgrade flow (dashboard "Change plan" downgrade entry point)', () => {
+		it( 'maps to the upgrade-or-downgrade intent when allow_downgrade=true', () => {
+			window.history.replaceState( {}, '', '/?allow_downgrade=true' );
+			expect( getPlansIntent( PLAN_UPGRADE_FLOW ) ).toBe( 'plans-upgrade-or-downgrade' );
+		} );
+
+		it( 'maps to the upgrade-only intent when allow_downgrade is absent', () => {
+			expect( getPlansIntent( PLAN_UPGRADE_FLOW ) ).toBe( 'plans-upgrade' );
+		} );
+
+		it( 'maps to the upgrade-only intent when allow_downgrade is not exactly "true"', () => {
+			window.history.replaceState( {}, '', '/?allow_downgrade=false' );
+			expect( getPlansIntent( PLAN_UPGRADE_FLOW ) ).toBe( 'plans-upgrade' );
+		} );
 	} );
 } );

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -50,6 +50,7 @@ jest.mock( '@automattic/data-stores', () => ( {
 		...jest.requireActual( '@automattic/data-stores' ).Plans,
 		usePlans: jest.fn(),
 		usePricingMetaForGridPlans: jest.fn(),
+		useCurrentPlan: jest.fn(),
 	},
 	AddOns: {
 		...jest.requireActual( '@automattic/data-stores' ).AddOns,
@@ -216,6 +217,40 @@ describe( 'PlansFeaturesMain', () => {
 					PLAN_ECOMMERCE_2_YEARS,
 					PLAN_ENTERPRISE_GRID_WPCOM,
 				] )
+			);
+		} );
+	} );
+
+	describe( 'PlansFeaturesMain. Downgrade flow (plans-upgrade-or-downgrade intent)', () => {
+		// The dashboard "Change plan" button sends owners to the plan-upgrade
+		// stepper flow with allow_downgrade=true, which resolves to the
+		// 'plans-upgrade-or-downgrade' intent. Unlike 'plans-upgrade', that intent
+		// must keep lower-tier plans visible so the user can downgrade. These tests
+		// guard that behavior against Plans page UX changes.
+		beforeEach( () => {
+			Plans.useCurrentPlan.mockImplementation( () => ( { planSlug: PLAN_BUSINESS } ) );
+		} );
+
+		test( 'shows lower-tier plans (below the current plan) for the downgrade intent', () => {
+			renderWithProvider( <PlansFeaturesMain { ...props } intent="plans-upgrade-or-downgrade" /> );
+
+			expect( screen.getByTestId( 'visible-plans' ) ).toHaveTextContent(
+				JSON.stringify( [
+					PLAN_FREE,
+					PLAN_PERSONAL,
+					PLAN_PREMIUM,
+					PLAN_BUSINESS,
+					PLAN_ECOMMERCE,
+					PLAN_ENTERPRISE_GRID_WPCOM,
+				] )
+			);
+		} );
+
+		test( 'hides lower-tier plans for the upgrade-only intent (contrast)', () => {
+			renderWithProvider( <PlansFeaturesMain { ...props } intent="plans-upgrade" /> );
+
+			expect( screen.getByTestId( 'visible-plans' ) ).toHaveTextContent(
+				JSON.stringify( [ PLAN_BUSINESS, PLAN_ECOMMERCE, PLAN_ENTERPRISE_GRID_WPCOM ] )
 			);
 		} );
 	} );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2266/

## Proposed Changes

Adds unit/integration test coverage for the dashboard "Change plan" → downgrade flow, which routes plan owners to the stepper `plan-upgrade` flow with `allow_downgrade=true` so the Plans page shows lower-tier plans and "Downgrade" CTAs. This guards the flow against accidental breakage while the Plans page is under heavy experimentation.

* `get-plans-intent`: assert the `plan-upgrade` flow with `allow_downgrade=true` resolves the `plans-upgrade-or-downgrade` intent, and resolves `plans-upgrade` when the param is absent or not exactly `"true"`.
* `plans-features-main`: assert the `plans-upgrade-or-downgrade` intent keeps lower-tier plans visible (all tiers, including plans below the current Business plan), paired with a contrast case showing the `plans-upgrade` intent slices to the current plan and up.

## Why are these changes being made?

The downgrade flow spans three components with no test coverage: the dashboard builds a `plan-upgrade` URL with `allow_downgrade=true`, `getPlansIntent` maps that param to the `plans-upgrade-or-downgrade` intent, and the plans grid widens to include lower-tier plans for that intent. The Plans page is actively being reworked, so it's easy to break a link in this chain while iterating on unrelated UX.

These two tests lock the two most fragile links: the intent mapping and the lower-tier plan visibility. The plan-visibility test pins a current Business plan and pairs the downgrade assertion with an upgrade-only assertion, so it fails loudly if someone makes the downgrade intent slice tiers like the upgrade intent — a vacuous "all tiers shown" assertion with no current plan would not catch that regression.

## Testing Instructions

TC:
```
yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/test/get-plans-intent.test.ts client/my-sites/plans-features-main/test/index.jsx
```

Both suites should pass (4 and 18 tests respectively).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
