### PR TITLE
Update the name server connection flow

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table-style.scss
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table-style.scss
@@ -1,16 +1,20 @@
 /* Prevent horizontal overflow and allow text wrapping */
 .dns-records-table {
-		.dataviews-view-table__cell-content-wrapper {
-			min-width: initial;
-			white-space: normal;
+	.dataviews-view-table__cell-content-wrapper {
+		min-width: initial;
+		white-space: normal;
+		word-break: break-word;
+		overflow-wrap: break-word;
+		max-width: 100%;
+
+		> * {
 			word-break: break-word;
 			overflow-wrap: break-word;
-			max-width: 100%;
+		}
+	}
 
-			// Ensure Text components wrap properly
-			> * {
-				word-break: break-word;
-				overflow-wrap: break-word;
-			}
+	.dns-records-table__copy-button.components-button {
+		min-width: 24px;
+		padding: 0;
 	}
 }

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -27,14 +27,14 @@ const getSuggestedView = ( includeName: boolean ): ViewTable => {
 	return {
 		...baseSuggestedView,
 		fields: includeName
-			? [ 'name', 'currentValue', 'expectedValue', 'status' ]
-			: [ 'currentValue', 'expectedValue', 'status' ],
+			? [ 'name', 'expectedValue', 'currentValue', 'status' ]
+			: [ 'expectedValue', 'currentValue', 'status' ],
 	};
 };
 
 const viewAdvanced: ViewTable = {
 	...baseSuggestedView,
-	fields: [ 'type', 'name', 'currentValue', 'expectedValue', 'status' ],
+	fields: [ 'type', 'name', 'expectedValue', 'currentValue', 'status' ],
 };
 
 interface DnsRecordVerification {

--- a/client/dashboard/domains/domain-connection-setup/components/domain-propagation-status.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/domain-propagation-status.tsx
@@ -6,9 +6,10 @@ import {
 	__experimentalGrid as Grid,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { Card, CardBody } from '../../../components/card';
+import { __, sprintf } from '@wordpress/i18n';
+import { Card, CardBody, CardDivider } from '../../../components/card';
 import { useTimeSince } from '../../../components/time-since';
+import type { DomainConnectionStatus } from '../utils';
 
 function PropagationStatusIndicator( { propagated }: { propagated: boolean } ) {
 	return (
@@ -25,7 +26,13 @@ function PropagationStatusIndicator( { propagated }: { propagated: boolean } ) {
 	);
 }
 
-export default function DomainPropagationStatus( { domainName }: { domainName: string } ) {
+export default function DomainPropagationStatus( {
+	domainName,
+	status = 'connecting',
+}: {
+	domainName: string;
+	status?: DomainConnectionStatus;
+} ) {
 	const { data, isLoading, isError } = useQuery( domainPropagationStatusQuery( domainName ) );
 	const lastChecked = useTimeSince( data?.last_updated ?? '' );
 
@@ -40,20 +47,36 @@ export default function DomainPropagationStatus( { domainName }: { domainName: s
 			</Text>
 			<Card>
 				<CardBody>
-					<Grid columns={ 4 } gap={ 4 }>
+					<Grid gap={ 4 } style={ { gridTemplateColumns: 'repeat(auto-fit, minmax(110px, 1fr))' } }>
 						{ data.propagation_status.map( ( area ) => (
 							<HStack key={ area.area_code } spacing={ 2 } justify="flex-start">
-								<PropagationStatusIndicator propagated={ area.propagated } />
+								<PropagationStatusIndicator
+									propagated={
+										status === 'active' || ( status === 'connecting' && area.propagated )
+									}
+								/>
 								<Text>{ area.area_name }</Text>
 							</HStack>
 						) ) }
 					</Grid>
 				</CardBody>
+				{ status !== 'active' && (
+					<>
+						<CardDivider />
+						<CardBody>
+							<Text variant="muted" size={ 12 }>
+								{ status === 'verifying'
+									? __( 'Propagation begins once verification is complete.' )
+									: sprintf(
+											// translators: %s is the time the status was last checked
+											__( 'Last checked %s' ),
+											lastChecked
+									  ) }
+							</Text>
+						</CardBody>
+					</>
+				) }
 			</Card>
-			<Text variant="muted" size={ 12 }>
-				{ /* translators: %s is the time the status was last checked */ }
-				{ __( 'Last checked' ) } { lastChecked }
-			</Text>
 		</VStack>
 	);
 }

--- a/client/dashboard/domains/domain-connection-setup/connection-mode-card.scss
+++ b/client/dashboard/domains/domain-connection-setup/connection-mode-card.scss
@@ -1,4 +1,5 @@
 @import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .connection-mode-card__body {
 	padding-top: 16px;
@@ -8,6 +9,11 @@
 		padding-top: 24px;
 		padding-bottom: 24px;
 	}
+}
+
+.connection-mode-card .components-radio-control__input[type='radio']:focus:not(:focus-visible) {
+	box-shadow: none;
+	outline: none;
 }
 
 .setup-step__number {

--- a/client/dashboard/domains/domain-connection-setup/connection-mode-card.scss
+++ b/client/dashboard/domains/domain-connection-setup/connection-mode-card.scss
@@ -1,10 +1,44 @@
-@import "@wordpress/base-styles/breakpoints";
+@import '@wordpress/base-styles/breakpoints';
 
 .connection-mode-card__body {
 	padding-top: 16px;
 	padding-bottom: 16px;
+
 	@include break-medium {
 		padding-top: 24px;
 		padding-bottom: 24px;
 	}
+}
+
+.setup-step__number {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	box-sizing: border-box;
+	width: 20px;
+	height: 20px;
+	flex: 0 0 20px;
+	border: 1px solid var( --dashboard-overview__divider-color );
+	border-radius: 50%;
+	color: var( --dashboard-menu-item__color );
+	font-size: 12px;
+	line-height: 1;
+
+	&.is-current {
+		border-color: var( --dashboard-menu-item__color );
+		background: var( --dashboard-menu-item__color );
+		color: var( --dashboard-surface__background-color );
+	}
+}
+
+.setup-step__completed-icon {
+	flex: 0 0 20px;
+	color: var( --dashboard__background-color-success );
+	fill: var( --dashboard__background-color-success );
+}
+
+.setup-step__pending-icon {
+	flex: 0 0 20px;
+	color: var( --dashboard-menu-item__color );
+	fill: var( --dashboard-menu-item__color );
 }

--- a/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
+++ b/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
@@ -65,6 +65,11 @@ export default function ConnectionModeCard( {
 
 	const handleStepChange = ( index: number, checked: boolean ) => {
 		onStepChange( index, checked );
+
+		if ( checked ) {
+			const nextStepIndex = Math.min( index + 1, steps.length - 1 );
+			setStepsExpanded( steps.map( ( _, stepIndex ) => stepIndex === nextStepIndex ) );
+		}
 	};
 
 	const handleStepToggle = ( index: number, expanded: boolean ) => {

--- a/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
+++ b/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
@@ -26,6 +26,7 @@ interface ConnectionModeCardProps {
 	mode: DomainConnectionSetupModeValue;
 	title: string;
 	description: string;
+	heading?: string;
 	infoText: string;
 	steps: ConnectionModeStep[];
 	stepsCompleted: boolean[];
@@ -42,6 +43,7 @@ export default function ConnectionModeCard( {
 	mode,
 	title,
 	description,
+	heading,
 	infoText,
 	steps,
 	stepsCompleted,
@@ -55,34 +57,22 @@ export default function ConnectionModeCard( {
 }: ConnectionModeCardProps ) {
 	const isSelected = selectedMode === mode;
 
-	// Track which steps are expanded (first step expanded by default)
 	const [ stepsExpanded, setStepsExpanded ] = useState< boolean[] >(
 		steps.map( ( _, index ) => index === 0 )
 	);
 
 	const handleStepChange = ( index: number, checked: boolean ) => {
 		onStepChange( index, checked );
-
-		// When a step is checked, collapse all steps and expand the next one
-		if ( checked ) {
-			const newStepsExpanded = steps.map( () => false );
-
-			// If not the last step, expand the next one
-			if ( index < steps.length - 1 ) {
-				newStepsExpanded[ index + 1 ] = true;
-			} else {
-				// If it's the last step, keep it expanded
-				newStepsExpanded[ index ] = true;
-			}
-
-			setStepsExpanded( newStepsExpanded );
-		}
 	};
 
 	const handleStepToggle = ( index: number, expanded: boolean ) => {
 		setStepsExpanded( ( prev ) => {
+			if ( expanded ) {
+				return steps.map( ( _, stepIndex ) => stepIndex === index );
+			}
+
 			const newState = [ ...prev ];
-			newState[ index ] = expanded;
+			newState[ index ] = false;
 			return newState;
 		} );
 	};
@@ -130,17 +120,22 @@ export default function ConnectionModeCard( {
 						<>
 							<CardDivider />
 							<VStack spacing={ 6 }>
+								{ heading && (
+									<Text size="medium" weight={ 500 }>
+										{ heading }
+									</Text>
+								) }
 								{ mode === DomainConnectionSetupMode.SUGGESTED && ! hasEmailOrOtherServices && (
-									<Notice variant="info" title="No email or other services detected">
+									<Notice variant="info" title={ __( 'No email or other services detected' ) }>
 										<Text>
 											{ __(
-												'You can safely connect your domain without affecting anything else.'
+												'You can safely connect your domain without affecting other services.'
 											) }
 										</Text>
 									</Notice>
 								) }
 								{ mode === DomainConnectionSetupMode.SUGGESTED && hasEmailOrOtherServices && (
-									<Notice variant="info" title="Email or other services detected">
+									<Notice variant="info" title={ __( 'Email or other services detected' ) }>
 										<Text>
 											{ __(
 												'We detected email services attached to your domain. If you want to continue with this setup, we recommend copying over your DNS records before proceeding to avoid any disruptions.'
@@ -149,7 +144,7 @@ export default function ConnectionModeCard( {
 									</Notice>
 								) }
 								{ mode === DomainConnectionSetupMode.ADVANCED && hasEmailOrOtherServices && (
-									<Notice variant="info" title="Email or other services detected">
+									<Notice variant="info" title={ __( 'Email or other services detected' ) }>
 										<Text>
 											{ __(
 												'To avoid disruption, this is the safest way to connect your domain name.'
@@ -165,6 +160,7 @@ export default function ConnectionModeCard( {
 										<SetupStep
 											expanded={ stepsExpanded[ index ] }
 											completed={ stepsCompleted[ index ] }
+											stepNumber={ index + 1 }
 											onCheckboxChange={ ( checked ) => handleStepChange( index, checked ) }
 											onToggle={ ( expanded ) => handleStepToggle( index, expanded ) }
 											title={ step.title }
@@ -187,7 +183,7 @@ export default function ConnectionModeCard( {
 									isBusy={ isUpdatingConnectionMode }
 									disabled={ verificationDisabled }
 								>
-									{ __( 'Verify Connection' ) }
+									{ __( 'Verify connection' ) }
 								</Button>
 							</ButtonStack>
 						</>

--- a/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
+++ b/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
@@ -16,6 +16,8 @@ import { Card, CardBody, CardDivider } from '../../components/card';
 import Notice from '../../components/notice';
 import SetupStep from './setup-step';
 
+import './connection-mode-card.scss';
+
 interface ConnectionModeStep {
 	title: string;
 	label: string;

--- a/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
+++ b/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
@@ -67,8 +67,15 @@ export default function ConnectionModeCard( {
 		onStepChange( index, checked );
 
 		if ( checked ) {
-			const nextStepIndex = Math.min( index + 1, steps.length - 1 );
-			setStepsExpanded( steps.map( ( _, stepIndex ) => stepIndex === nextStepIndex ) );
+			const newStepsExpanded = steps.map( () => false );
+
+			if ( index < steps.length - 1 ) {
+				newStepsExpanded[ index + 1 ] = true;
+			} else {
+				newStepsExpanded[ index ] = true;
+			}
+
+			setStepsExpanded( newStepsExpanded );
 		}
 	};
 

--- a/client/dashboard/domains/domain-connection-setup/dns-records-dataview.tsx
+++ b/client/dashboard/domains/domain-connection-setup/dns-records-dataview.tsx
@@ -14,10 +14,16 @@ import { matchCurrentToTargetValues } from './utils/match-records';
 
 import './components/dns-records-table-style.scss';
 
-const baseSuggestedView: Pick< ViewTable, 'type' | 'page' | 'perPage' > = {
+const baseSuggestedView: Pick< ViewTable, 'type' | 'page' | 'perPage' | 'layout' > = {
 	type: 'table',
 	page: 1,
 	perPage: 10,
+	layout: {
+		styles: {
+			updateTo: { width: '100%' },
+			copy: { width: '1%' },
+		},
+	},
 };
 
 const getSuggestedView = ( includeName: boolean ): ViewTable => {

--- a/client/dashboard/domains/domain-connection-setup/dns-records-dataview.tsx
+++ b/client/dashboard/domains/domain-connection-setup/dns-records-dataview.tsx
@@ -3,10 +3,10 @@ import {
 	DomainMappingSetupInfo,
 	DomainMappingStatus,
 } from '@automattic/api-core';
-import { __experimentalText as Text } from '@wordpress/components';
+import { Button, __experimentalText as Text } from '@wordpress/components';
 import { DataViews, type Field, type ViewTable } from '@wordpress/dataviews';
-import { __ } from '@wordpress/i18n';
-import { Icon, arrowRight } from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
+import { Icon, arrowRight, copySmall } from '@wordpress/icons';
 import { useMemo } from 'react';
 import { DataViewsCard } from '../../components/dataviews';
 import { useDnsRecordNames } from './hooks/use-dns-record-names';
@@ -24,14 +24,14 @@ const getSuggestedView = ( includeName: boolean ): ViewTable => {
 	return {
 		...baseSuggestedView,
 		fields: includeName
-			? [ 'name', 'currentValue', 'arrow', 'updateTo' ]
-			: [ 'currentValue', 'arrow', 'updateTo' ],
+			? [ 'name', 'currentValue', 'arrow', 'updateTo', 'copy' ]
+			: [ 'currentValue', 'arrow', 'updateTo', 'copy' ],
 	};
 };
 
 const viewAdvanced: ViewTable = {
 	...baseSuggestedView,
-	fields: [ 'type', 'name', 'currentValue', 'arrow', 'updateTo' ],
+	fields: [ 'type', 'name', 'currentValue', 'arrow', 'updateTo', 'copy' ],
 };
 
 interface DNSRecord {
@@ -142,7 +142,7 @@ export default function DNSRecordsDataView( {
 			},
 			{
 				id: 'currentValue',
-				label: __( 'Current values' ),
+				label: __( 'Current value' ),
 				enableHiding: false,
 				enableSorting: false,
 				render: ( { item } ) => {
@@ -161,12 +161,32 @@ export default function DNSRecordsDataView( {
 			},
 			{
 				id: 'updateTo',
-				label: __( 'Update to' ),
+				label: __( 'Change to' ),
 				enableHiding: false,
 				enableSorting: false,
 				render: ( { item } ) => {
 					return <Text>{ item.updateTo }</Text>;
 				},
+			},
+			{
+				id: 'copy',
+				label: '',
+				enableHiding: false,
+				enableSorting: false,
+				header: <></>,
+				render: ( { item } ) => (
+					<Button
+						className="dns-records-table__copy-button"
+						icon={ copySmall }
+						size="compact"
+						aria-label={ sprintf(
+							// translators: %s is a DNS record value
+							__( 'Copy %s' ),
+							item.updateTo
+						) }
+						onClick={ () => void navigator.clipboard?.writeText( item.updateTo ) }
+					/>
+				),
 			},
 		],
 		[]

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
@@ -17,6 +17,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { globe } from '@wordpress/icons';
 import { useState } from 'react';
 import { Card, CardBody } from '../../components/card';
+import InlineSupportLink from '../../components/inline-support-link';
 import ConnectionModeCard from './connection-mode-card';
 import DNSRecordsDataView from './dns-records-dataview';
 import DomainConnectCard from './domain-connect-card';
@@ -66,56 +67,54 @@ export default function DomainConnectionSetup( {
 	const registrar = domainConnectionSetupInfo.reseller || domainConnectionSetupInfo.registrar;
 	const registrar_url = domainConnectionSetupInfo.registrar_url;
 
-	const commonSteps = [
-		{
-			title: registrar
-				? sprintf(
-						// translators: %s is the registrar name
-						__( '1. Login to %s' ),
-						registrar
-				  )
-				: __( '1. Login to your domain name provider' ),
-			label: __( 'I have opened the DNS settings' ),
-			content: (
-				<Text>
-					{ createInterpolateElement(
-						// translators: <registrar/> is the domain name provider, <domain/> is the domain name
-						__( 'Log in to <registrar/> and open DNS management for <domain/>.' ),
+	const loginStepTitle = registrar
+		? sprintf(
+				// translators: %s is the registrar name
+				__( 'Log in to %s' ),
+				registrar
+		  )
+		: __( 'Log in to your domain provider' );
 
-						{
-							registrar:
-								! isReseller && registrar_url ? (
-									<ExternalLink href={ registrar_url }> { registrar } </ExternalLink>
-								) : (
-									<>{ registrar || __( 'your domain name provider' ) }</>
-								),
-							domain: <>{ domainName }</>,
-						}
-					) }
-				</Text>
-			),
-		},
+	const suggestedLoginStep = {
+		title: loginStepTitle,
+		label: __( 'I have opened the name server settings' ),
+		content: (
+			<Text>
+				{ createInterpolateElement(
+					// translators: <domain/> is the domain name and <guide/> is a support link
+					__(
+						'Open the name server settings for <domain/>. Some registrars call this DNS settings. Need help? <guide>Follow our guide.</guide>'
+					),
+					{
+						domain: <>{ domainName }</>,
+						guide: <InlineSupportLink supportContext="map-domain-setup-instructions" />,
+					}
+				) }
+			</Text>
+		),
+	};
+
+	const suggestedModeSteps = [
+		suggestedLoginStep,
 		{
-			title: __( '2. Back up DNS records' ),
-			label: __( 'I have downloaded the DNS records' ),
+			title: __( 'Save your current name servers' ),
+			label: __( 'I have saved a copy of my name servers' ),
 			content: (
 				<Text>
 					{ __(
-						'It’s rare, but things can go sideways. Download your DNS records as a fallback, just in case.'
+						'Before making changes, save a copy of your current name servers. You can take a screenshot, copy them into a document, or write them down.'
 					) }
 				</Text>
 			),
 		},
-	];
-
-	const suggestedModeSteps = [
-		...commonSteps,
 		{
-			title: __( '3. Update name servers' ),
+			title: __( 'Update name servers' ),
 			label: __( 'I have updated the name servers' ),
 			content: (
 				<VStack spacing={ 6 }>
-					<Text>{ __( 'Replace all name server records with the values below.' ) }</Text>
+					<Text>
+						{ __( 'Replace your current name servers with the WordPress.com name servers below.' ) }
+					</Text>
 					<DNSRecordsDataView
 						domainName={ domainName }
 						domainMappingStatus={ domainMappingStatus }
@@ -127,10 +126,43 @@ export default function DomainConnectionSetup( {
 		},
 	];
 
+	const advancedLoginStep = {
+		title: loginStepTitle,
+		label: __( 'I have opened the DNS settings' ),
+		content: (
+			<Text>
+				{ createInterpolateElement(
+					// translators: <registrar/> is the domain provider and <domain/> is the domain name
+					__( 'Log in to <registrar/> and open DNS management for <domain/>.' ),
+					{
+						registrar:
+							! isReseller && registrar_url ? (
+								<ExternalLink href={ registrar_url }>{ registrar }</ExternalLink>
+							) : (
+								<>{ registrar || __( 'your domain provider' ) }</>
+							),
+						domain: <>{ domainName }</>,
+					}
+				) }
+			</Text>
+		),
+	};
+
 	const advancedModeSteps = [
-		...commonSteps,
+		advancedLoginStep,
 		{
-			title: __( '3. Update DNS records' ),
+			title: __( 'Back up DNS records' ),
+			label: __( 'I have downloaded the DNS records' ),
+			content: (
+				<Text>
+					{ __(
+						'It’s rare, but things can go sideways. Download your DNS records as a fallback, just in case.'
+					) }
+				</Text>
+			),
+		},
+		{
+			title: __( 'Update DNS records' ),
 			label: __( 'I have updated the DNS settings' ),
 			content: (
 				<VStack spacing={ 6 }>
@@ -221,12 +253,13 @@ export default function DomainConnectionSetup( {
 					) }
 					<ConnectionModeCard
 						mode={ DomainConnectionSetupMode.SUGGESTED }
-						title={ __( 'I only use this domain name for my website' ) }
-						description={ __( 'You’ll update your name servers to point to WordPress.com' ) }
+						title={ __( 'I only use this domain for my website' ) }
+						description={ __( 'You’ll update name servers' ) }
+						heading={ __( 'Connect with name servers' ) }
 						infoText={ sprintf(
 							// translators: %s is the domain name
 							__(
-								'Name servers connect your domain name to your site. It may take up to 72 hours for %s to become visible across the internet. We’ll email you when it’s done.'
+								'Name servers connect your domain to your website. After verification starts, %s can take up to 72 hours to appear across the internet.'
 							),
 							domainName
 						) }
@@ -243,8 +276,8 @@ export default function DomainConnectionSetup( {
 
 					<ConnectionModeCard
 						mode={ DomainConnectionSetupMode.ADVANCED }
-						title={ __( 'I use this domain name for email or other services' ) }
-						description={ __( 'You’ll update DNS records (CNAME and A)' ) }
+						title={ __( 'I use this domain for my website, email, or other services' ) }
+						description={ __( 'You’ll update DNS records' ) }
 						infoText={ sprintf(
 							// translators: %s is the domain name
 							__(

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -1,30 +1,26 @@
-import { Domain, DomainConnectionSetupMode } from '@automattic/api-core';
-import { Badge } from '@automattic/ui';
+import {
+	DomainConnectionSetupMode,
+	type Domain,
+	type DomainMappingSetupInfo,
+	type DomainMappingStatus,
+} from '@automattic/api-core';
+import { Link } from '@tanstack/react-router';
 import {
 	ExternalLink,
-	Icon,
 	Button,
 	__experimentalText as Text,
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { layout, swatch, atSymbol, published } from '@wordpress/icons';
 import { useAppContext } from '../../app/context';
 import { siteDomainsRoute, siteOverviewRoute } from '../../app/router/sites';
 import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
-import RouterLinkSummaryButton from '../../components/router-link-summary-button';
-import DnsPropagationProgressBar from './components/dns-propagation-progress-bar';
 import DnsRecordsTable from './components/dns-records-table';
 import DomainPropagationStatus from './components/domain-propagation-status';
-import { isMappingVerificationSuccess } from './utils';
-import VerificationInProgressNextSteps from './verification-in-progress-next-steps';
-import type { DomainMappingSetupInfo, DomainMappingStatus } from '@automattic/api-core';
-
-type DomainConnectionStatus = 'connected' | 'verifying';
+import { getDomainConnectionStatus } from './utils';
 
 interface DomainConnectionVerificationProps {
 	domainData: Domain;
@@ -46,85 +42,135 @@ export default function DomainConnectionVerification( {
 	isRestartingConnection,
 }: DomainConnectionVerificationProps ) {
 	const { name: appName } = useAppContext();
-	const status: DomainConnectionStatus = isMappingVerificationSuccess(
-		domainMappingStatus.mode,
-		domainMappingStatus
-	)
-		? 'connected'
-		: 'verifying';
-
+	const status = getDomainConnectionStatus( domainMappingStatus.mode, domainMappingStatus );
 	const hasCloudflareIpAddresses = domainMappingStatus.has_cloudflare_ip_addresses;
-
 	const connectedAndCanBeSetAsPrimary =
-		status === 'connected' && ! domainData.primary_domain && domainData.can_set_as_primary;
+		status === 'active' && ! domainData.primary_domain && domainData.can_set_as_primary;
+
+	const workingOnSiteLink = <Link to={ siteOverviewRoute.fullPath } params={ { siteSlug } } />;
+
+	const renderStatusMessage = () => {
+		if ( status === 'active' ) {
+			if ( connectedAndCanBeSetAsPrimary ) {
+				return createInterpolateElement(
+					__(
+						'<domain/> is connected. To send visitors there, <primaryAddress>set it as your primary site address</primaryAddress>.'
+					),
+					{
+						domain: <>{ domainName }</>,
+						primaryAddress: <Link to={ siteDomainsRoute.fullPath } params={ { siteSlug } } />,
+					}
+				);
+			}
+
+			return sprintf(
+				// translators: %s is the connected domain name
+				__( '%s is connected and ready to use.' ),
+				domainName
+			);
+		}
+
+		if ( status === 'connecting' ) {
+			return (
+				<VStack spacing={ 2 }>
+					<Text>
+						{ createInterpolateElement(
+							__(
+								'<domain/> is being connected in the background. We’ll email you when it’s active so you can continue <site>working on your site</site>.'
+							),
+							{ domain: <>{ domainName }</>, site: workingOnSiteLink }
+						) }
+					</Text>
+					<Text>
+						{ __(
+							'This usually takes a few hours, though in some cases it can take up to 72 hours.'
+						) }
+					</Text>
+				</VStack>
+			);
+		}
+
+		return (
+			<VStack spacing={ 2 }>
+				<Text>
+					{ __(
+						'This usually takes a few hours, though in some cases it can take up to 72 hours.'
+					) }
+				</Text>
+				<Text>
+					{ createInterpolateElement(
+						__(
+							'You can continue <site>working on your site</site> while we verify the connection.'
+						),
+						{ site: workingOnSiteLink }
+					) }
+				</Text>
+			</VStack>
+		);
+	};
 
 	return (
-		<Card
+		<VStack
+			spacing={ 6 }
 			className={ `dashboard-domain-connection-verification dashboard-domain-connection-verification--${ status }` }
 		>
-			<CardBody>
-				<VStack spacing={ 7 }>
-					<HStack justify="flex-start">
-						<Icon
-							className="dashboard-domain-connection-verification__icon"
-							icon={ status === 'verifying' ? swatch : published }
-						/>
-						<Text className="dashboard-domain-connection-verification__title" size={ 10 }>
-							{ domainName }
-						</Text>
-						<Badge intent={ status === 'connected' ? 'success' : 'warning' }>
-							{ status === 'connected' ? __( 'Active' ) : __( 'Verifying' ) }
-						</Badge>
-					</HStack>
+			<Card className="dashboard-domain-connection-verification__status-card">
+				<CardBody>
+					<VStack spacing={ 1 }>
+						<Text size="medium">{ domainName }</Text>
+						<Text size="small">{ status === 'active' ? __( 'Active' ) : __( 'Verifying' ) }</Text>
+					</VStack>
+				</CardBody>
+			</Card>
 
-					<DnsPropagationProgressBar
-						domainMappingStatus={ domainMappingStatus }
-						domainConnectionSetupInfo={ domainConnectionSetupInfo }
-					/>
-
-					{ status === 'verifying' && (
-						<Notice variant="info">
-							{ hasCloudflareIpAddresses
-								? createInterpolateElement(
-										__(
-											'<domainName/> is using Cloudflare, which hides DNS records, so we can’t verify them the usual way. We’ll still confirm that your domain name points to <appName/>.com. Please check that your <cloudflare/> DNS settings include the required records.'
-										),
-										{
-											domainName: <>{ domainName }</>,
-											appName: <>{ appName }</>,
-											cloudflare: (
-												<ExternalLink href="https://www.cloudflare.com/">Cloudflare</ExternalLink>
-											),
-										}
-								  )
-								: __(
-										'We’re checking your DNS records. Most updates happen quickly, but some providers cache old settings for up to 72 hours.'
-								  ) }
-						</Notice>
-					) }
-
-					<VStack spacing={ 4 }>
-						{ ! hasCloudflareIpAddresses && (
+			<Card className="dashboard-domain-connection-verification__content-card">
+				<CardBody>
+					<VStack spacing={ 6 }>
+						<VStack spacing={ 3 }>
 							<Text size="medium" weight={ 500 }>
-								{ domainMappingStatus.mode === DomainConnectionSetupMode.SUGGESTED
-									? __( 'Name server verification' )
-									: __( 'DNS record verification' ) }
+								{ status === 'active'
+									? __( 'Your domain is connected' )
+									: __( 'Your part is done. We’ll take it from here.' ) }
 							</Text>
-						) }
+							{ renderStatusMessage() }
+						</VStack>
 
-						{ ! hasCloudflareIpAddresses && (
-							<DnsRecordsTable
-								domainName={ domainName }
-								domainConnectionStatus={ domainMappingStatus }
-								domainConnectionSetupInfo={ domainConnectionSetupInfo }
-							/>
-						) }
-						{ hasCloudflareIpAddresses && domainMappingStatus.resolves_to_wpcom && (
+						{ hasCloudflareIpAddresses && status !== 'active' && (
 							<Notice variant="info">
 								{ createInterpolateElement(
 									__(
-										'<domainName/> appears to be set up with Cloudflare and it resolves to <appName/>.'
+										'<domainName/> is using Cloudflare, which hides DNS records, so we can’t verify them the usual way. We’ll still confirm that your domain points to <appName/>.com. Please check that your <cloudflare/> DNS settings include the required records.'
 									),
+									{
+										domainName: <>{ domainName }</>,
+										appName: <>{ appName }</>,
+										cloudflare: (
+											<ExternalLink href="https://www.cloudflare.com/">Cloudflare</ExternalLink>
+										),
+									}
+								) }
+							</Notice>
+						) }
+
+						{ ! hasCloudflareIpAddresses && (
+							<VStack spacing={ 4 }>
+								<Text size="medium" weight={ 500 }>
+									{ domainMappingStatus.mode === DomainConnectionSetupMode.SUGGESTED
+										? __( 'Name server verification' )
+										: __( 'DNS record verification' ) }
+								</Text>
+								<DnsRecordsTable
+									domainName={ domainName }
+									domainConnectionStatus={ domainMappingStatus }
+									domainConnectionSetupInfo={ domainConnectionSetupInfo }
+								/>
+							</VStack>
+						) }
+
+						{ hasCloudflareIpAddresses && status === 'active' && (
+							<Notice variant="info">
+								{ createInterpolateElement(
+									__( '<domainName/> is set up with Cloudflare and resolves to <appName/>.' ),
 									{
 										domainName: <>{ domainName }</>,
 										appName: <>{ appName }</>,
@@ -132,73 +178,36 @@ export default function DomainConnectionVerification( {
 								) }
 							</Notice>
 						) }
-					</VStack>
 
-					<DomainPropagationStatus domainName={ domainName } />
+						<DomainPropagationStatus domainName={ domainName } status={ status } />
 
-					<VStack spacing={ 4 }>
-						{ status === 'verifying' && (
+						<VStack spacing={ 4 }>
 							<Text size="medium" weight={ 500 }>
-								{ __( 'While you wait' ) }
+								{ __( 'Need help?' ) }
 							</Text>
-						) }
-
-						{ connectedAndCanBeSetAsPrimary && (
-							<>
-								<Text size="medium" weight={ 500 }>
-									{ __( 'Recommended' ) }
-								</Text>
-								<RouterLinkSummaryButton
-									to={ siteDomainsRoute.fullPath }
-									params={ { siteSlug } }
-									/* Translators: %s is the domain name. */
-									title={ sprintf( __( 'Set %s as your primary site address' ), domainName ) }
-									description={ __( 'It’s the URL visitors see in their browser’s address bar.' ) }
-									decoration={ <Icon icon={ atSymbol } /> }
-								/>
-							</>
-						) }
-						<RouterLinkSummaryButton
-							to={ siteOverviewRoute.fullPath }
-							params={ { siteSlug } }
-							title={ __( 'Customize your site' ) }
-							description={ __(
-								'While your domain name is connecting, you can still work on your site.'
-							) }
-							decoration={ <Icon icon={ layout } /> }
-						/>
-					</VStack>
-					{ status === 'verifying' && <VerificationInProgressNextSteps /> }
-
-					<VStack spacing={ 4 }>
-						<Text size="medium" weight={ 500 }>
-							{ __( 'Need help?' ) }
-						</Text>
-						<VStack spacing={ 2 }>
-							<HStack>
+							<VStack spacing={ 2 }>
+								<InlineSupportLink supportContext="map-domain-setup-instructions">
+									{ __( 'Domain connection guide' ) }
+								</InlineSupportLink>
+								<InlineSupportLink supportContext="transfer-domain-registrar-login">
+									{ __( 'Registrar instructions' ) }
+								</InlineSupportLink>
+								<InlineSupportLink supportContext="general-support-options">
+									{ __( 'Contact support' ) }
+								</InlineSupportLink>
 								<Button
 									variant="link"
 									onClick={ onRestartConnection }
 									isBusy={ isRestartingConnection }
 									disabled={ isRestartingConnection }
-									style={ { lineHeight: '20px' } }
 								>
-									{ __( 'Restart connection' ) }
+									{ __( 'Restart setup' ) }
 								</Button>
-							</HStack>
-							<InlineSupportLink supportContext="map-domain-setup-instructions">
-								{ __( 'Domain connection guide' ) }
-							</InlineSupportLink>
-							<InlineSupportLink supportContext="general-support-options">
-								{ __( 'Contact support' ) }
-							</InlineSupportLink>
-							<InlineSupportLink supportContext="transfer-domain-registrar-login">
-								{ __( 'Registrar instructions' ) }
-							</InlineSupportLink>
+							</VStack>
 						</VStack>
 					</VStack>
-				</VStack>
-			</CardBody>
-		</Card>
+				</CardBody>
+			</Card>
+		</VStack>
 	);
 }

--- a/client/dashboard/domains/domain-connection-setup/domain-registrar-banner.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-registrar-banner.tsx
@@ -29,7 +29,7 @@ export default function DomainRegistrarBanner( {
 					{ registrar && (
 						<HStack spacing={ 1 } justify="flex-end">
 							<Text variant="muted" size="small">
-								{ __( 'Registered by' ) }
+								{ __( 'Registered with' ) }
 							</Text>
 							{ ! isReseller && registrar_url ? (
 								<ExternalLink href={ registrar_url }>{ registrar }</ExternalLink>

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -22,6 +22,7 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import DomainConnectionSetup from './domain-connection-setup';
 import DomainConnectionVerification from './domain-connection-verification';
+import { getDomainConnectionStatus } from './utils';
 
 import './style.scss';
 
@@ -176,20 +177,25 @@ export default function DomainConnection() {
 
 	// If the connection mode is not null, it means we are on the verification step
 	const isVerificationStep = !! connectionMode;
+	const connectionStatus = getDomainConnectionStatus( connectionMode, domainMappingStatus );
+	let pageHeaderDescription: string = __(
+		'We’ll tailor the next steps based on how your domain is used.'
+	);
+
+	if ( isVerificationStep ) {
+		pageHeaderDescription =
+			connectionStatus === 'active'
+				? __( 'Your domain is connected and ready to use.' )
+				: __( 'Your domain is connecting in the background. We’ll email you when it’s active.' );
+	}
 
 	return (
 		<PageLayout
 			size="small"
 			header={
 				<PageHeader
-					title={
-						isVerificationStep ? __( 'Connection verification' ) : __( 'Connect your domain name' )
-					}
-					description={
-						isVerificationStep
-							? null
-							: __( 'We’ll tailor the next steps based on how your domain name is currently used.' )
-					}
+					title={ isVerificationStep ? __( 'Connection status' ) : __( 'Connect your domain' ) }
+					description={ pageHeaderDescription }
 				/>
 			}
 		>

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -188,15 +188,22 @@ export default function DomainConnection() {
 				? __( 'Your domain is connected and ready to use.' )
 				: __( 'Your domain is connecting in the background. We’ll email you when it’s active.' );
 	}
+	const pageHeader = (
+		<PageHeader
+			title={ isVerificationStep ? __( 'Connection status' ) : __( 'Connect your domain' ) }
+			description={ pageHeaderDescription }
+		/>
+	);
 
 	return (
 		<PageLayout
 			size="small"
 			header={
-				<PageHeader
-					title={ isVerificationStep ? __( 'Connection status' ) : __( 'Connect your domain' ) }
-					description={ pageHeaderDescription }
-				/>
+				isVerificationStep ? (
+					pageHeader
+				) : (
+					<div className="domain-connection-setup__page-header">{ pageHeader }</div>
+				)
 			}
 		>
 			{ isVerificationStep && ! queryError ? (

--- a/client/dashboard/domains/domain-connection-setup/setup-step.tsx
+++ b/client/dashboard/domains/domain-connection-setup/setup-step.tsx
@@ -6,11 +6,13 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { published, swatch } from '@wordpress/icons';
+import clsx from 'clsx';
 import { CollapsibleCard } from '../../components/collapsible-card';
 
 interface SetupStepProps {
 	expanded: boolean;
 	completed: boolean;
+	stepNumber?: number;
 	title: string;
 	label?: string;
 	children: React.ReactNode;
@@ -22,6 +24,7 @@ interface SetupStepProps {
 export default function SetupStep( {
 	expanded,
 	completed,
+	stepNumber,
 	title,
 	label,
 	children,
@@ -29,20 +32,31 @@ export default function SetupStep( {
 	onToggle,
 	className,
 }: SetupStepProps ) {
+	let stepIndicator: React.ReactNode = (
+		<Icon className="setup-step__pending-icon" size={ 20 } icon={ swatch } />
+	);
+
+	if ( stepNumber ) {
+		stepIndicator = (
+			<span
+				className={ clsx( 'setup-step__number', { 'is-current': expanded } ) }
+				aria-hidden="true"
+			>
+				{ stepNumber }
+			</span>
+		);
+	}
+
+	if ( completed ) {
+		stepIndicator = <Icon className="setup-step__completed-icon" size={ 20 } icon={ published } />;
+	}
+
 	return (
 		<CollapsibleCard
-			className={ className }
+			className={ clsx( 'setup-step', className ) }
 			header={
-				<HStack spacing={ 4 } justify="flex-start" alignment="left" expanded={ false }>
-					<Icon
-						size={ 24 }
-						icon={ completed ? published : swatch }
-						fill={
-							completed
-								? 'var(--dashboard__background-color-success)'
-								: 'var(--dashboard-menu-item__color)'
-						}
-					/>
+				<HStack spacing={ 3 } justify="flex-start" alignment="left">
+					{ stepIndicator }
 					<Text size={ 15 } weight={ 500 }>
 						{ title }
 					</Text>
@@ -53,7 +67,7 @@ export default function SetupStep( {
 			size={ { blockStart: 'medium', blockEnd: 'medium', inlineStart: 'none', inlineEnd: 'none' } }
 			isBorderless
 		>
-			<VStack spacing={ 6 } style={ { paddingInlineStart: '40px', paddingTop: '16px' } }>
+			<VStack spacing={ 4 } style={ { paddingInlineStart: '32px', paddingTop: '16px' } }>
 				{ children }
 				{ label && (
 					<CheckboxControl

--- a/client/dashboard/domains/domain-connection-setup/style.scss
+++ b/client/dashboard/domains/domain-connection-setup/style.scss
@@ -1,16 +1,42 @@
-@import "@wordpress/base-styles/colors";
-@import "@wordpress/base-styles/variables";
+@import '@wordpress/base-styles/colors';
+@import '@wordpress/base-styles/variables';
 
 .dashboard-domain-connection-verification {
-	&--connected {
-		.dashboard-domain-connection-verification__icon {
-			color: var(--dashboard__background-color-success);
-			fill: var(--dashboard__background-color-success);
+	&--verifying,
+	&--connecting {
+		.dashboard-domain-connection-verification__status-card {
+			border-color: color-mix(
+				in srgb,
+				var( --dashboard__background-color-warning ) 55%,
+				transparent
+			);
+			background: color-mix(
+				in srgb,
+				var( --dashboard__background-color-warning ) 4%,
+				var( --dashboard-surface__background-color )
+			);
 		}
 	}
 
-	.summary-button.components-button .summary-button-title {
-		font-weight: 500;
+	&--active .dashboard-domain-connection-verification__status-card {
+		border-color: color-mix(
+			in srgb,
+			var( --dashboard__background-color-success ) 65%,
+			transparent
+		);
+		background: color-mix(
+			in srgb,
+			var( --dashboard__background-color-success ) 4%,
+			var( --dashboard-surface__background-color )
+		);
+	}
+
+	.components-button.is-link {
+		width: fit-content;
+		height: auto;
+		min-height: 0;
+		justify-content: flex-start;
+		padding: 0;
 	}
 }
 
@@ -18,7 +44,7 @@
 	.icon-list-item {
 		padding: $grid-unit-10;
 	}
-	.icon-list-item__decoration + span > span > span:last-child{
+	.icon-list-item__decoration + span > span > span:last-child {
 		font-size: $font-size-small;
 	}
 }

--- a/client/dashboard/domains/domain-connection-setup/style.scss
+++ b/client/dashboard/domains/domain-connection-setup/style.scss
@@ -1,6 +1,11 @@
 @import '@wordpress/base-styles/colors';
 @import '@wordpress/base-styles/variables';
 
+.domain-connection-setup__page-header {
+	padding-block-end: $grid-unit-15;
+	text-align: center;
+}
+
 .dashboard-domain-connection-verification {
 	&--verifying,
 	&--connecting {

--- a/client/dashboard/domains/domain-connection-setup/test/dns-records-dataview.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/dns-records-dataview.test.tsx
@@ -192,7 +192,10 @@ describe( 'DNSRecordsDataView - Suggested Mode (Nameservers)', () => {
 
 		// Check for column headers
 		expect( await screen.findByText( 'Current value' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Change to' ) ).toBeInTheDocument();
+		const changeToHeader = screen.getByRole( 'columnheader', { name: 'Change to' } );
+		const columnHeaders = screen.getAllByRole( 'columnheader' );
+		expect( changeToHeader ).toHaveStyle( { width: '100%' } );
+		expect( columnHeaders[ 3 ] ).toHaveStyle( { width: '1%' } );
 		expect( screen.queryByText( 'Name' ) ).not.toBeInTheDocument();
 	} );
 

--- a/client/dashboard/domains/domain-connection-setup/test/dns-records-dataview.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/dns-records-dataview.test.tsx
@@ -191,8 +191,8 @@ describe( 'DNSRecordsDataView - Suggested Mode (Nameservers)', () => {
 		);
 
 		// Check for column headers
-		expect( await screen.findByText( 'Current values' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Update to' ) ).toBeInTheDocument();
+		expect( await screen.findByText( 'Current value' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Change to' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Name' ) ).not.toBeInTheDocument();
 	} );
 
@@ -301,14 +301,14 @@ describe( 'DNSRecordsDataView - Suggested Mode (Nameservers)', () => {
 		expect( screen.getByText( 'Name' ) ).toBeInTheDocument();
 
 		// Should have the basic columns
-		expect( screen.getByText( 'Current values' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Update to' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Current value' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Change to' ) ).toBeInTheDocument();
 
 		// Verify column count in header row
 		const rows = within( table ).getAllByRole( 'row' );
 		const headerCells = within( rows[ 0 ] ).getAllByRole( 'columnheader' );
-		// Should have 4 columns: Name, Current values, arrow (empty header), Update to
-		expect( headerCells ).toHaveLength( 4 );
+		// Name, current value, arrow, change to, and copy action
+		expect( headerCells ).toHaveLength( 5 );
 	} );
 
 	test( 'shows subdomain name in name column when connecting a subdomain', async () => {
@@ -645,8 +645,8 @@ describe( 'DNSRecordsDataView - Advanced Mode (A and CNAME Records)', () => {
 		// Check for column headers
 		expect( await screen.findByText( 'Type' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Name' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Current values' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Update to' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Current value' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Change to' ) ).toBeInTheDocument();
 	} );
 
 	test( 'handles empty current IP addresses array', async () => {
@@ -765,7 +765,7 @@ describe( 'DNSRecordsDataView - Advanced Mode (A and CNAME Records)', () => {
 		expect( within( row3Cells[ 4 ] ).getByText( 'example.com' ) ).toBeInTheDocument();
 	} );
 
-	test( 'renders all 5 columns in advanced mode (including type/name)', async () => {
+	test( 'renders all 6 columns in advanced mode (including type/name)', async () => {
 		const domainMappingStatus = createMockDomainMappingStatus( [ '192.0.78.24' ] );
 		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo();
 
@@ -784,13 +784,13 @@ describe( 'DNSRecordsDataView - Advanced Mode (A and CNAME Records)', () => {
 		// Should have ALL columns in advanced mode
 		expect( await screen.findByText( 'Type' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Name' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Current values' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Update to' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Current value' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Change to' ) ).toBeInTheDocument();
 
 		// Verify column count in header row
 		const rows = within( table ).getAllByRole( 'row' );
 		const headerCells = within( rows[ 0 ] ).getAllByRole( 'columnheader' );
-		// Should have 5 columns: Type, Name, Current values, arrow (empty header), Update to
-		expect( headerCells ).toHaveLength( 5 );
+		// Type, name, current value, arrow, change to, and copy action
+		expect( headerCells ).toHaveLength( 6 );
 	} );
 } );

--- a/client/dashboard/domains/domain-connection-setup/test/domain-connection-setup.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-connection-setup.test.tsx
@@ -259,53 +259,6 @@ describe( 'DomainConnectionSetup', () => {
 		} );
 	} );
 
-	describe( 'Step Progression', () => {
-		test( 'expands the next name server step when the current step is completed', async () => {
-			const user = userEvent.setup();
-			const domainMappingStatus = createMockDomainMappingStatus( {
-				mode: null,
-				has_mx_records: false,
-			} );
-			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
-				domain_connect_apply_wpcom_hosting: null,
-			} );
-
-			render(
-				<DomainConnectionSetup
-					{ ...defaultProps }
-					domainMappingStatus={ domainMappingStatus }
-					domainConnectionSetupInfo={ domainConnectionSetupInfo }
-				/>
-			);
-
-			await user.click(
-				screen.getByRole( 'checkbox', { name: 'I have opened the name server settings' } )
-			);
-
-			expect(
-				screen.queryByRole( 'checkbox', { name: 'I have opened the name server settings' } )
-			).not.toBeInTheDocument();
-			expect(
-				screen.getByRole( 'checkbox', { name: 'I have saved a copy of my name servers' } )
-			).toBeVisible();
-
-			await user.click(
-				screen.getByRole( 'checkbox', {
-					name: 'I have saved a copy of my name servers',
-				} )
-			);
-
-			expect(
-				screen.queryByRole( 'checkbox', {
-					name: 'I have saved a copy of my name servers',
-				} )
-			).not.toBeInTheDocument();
-			expect(
-				screen.getByRole( 'checkbox', { name: 'I have updated the name servers' } )
-			).toBeVisible();
-		} );
-	} );
-
 	describe( 'Mode Switching', () => {
 		test( 'switches from manual to Domain Connect when "Use Domain Connect" is clicked', async () => {
 			const user = userEvent.setup();

--- a/client/dashboard/domains/domain-connection-setup/test/domain-connection-setup.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-connection-setup.test.tsx
@@ -259,6 +259,53 @@ describe( 'DomainConnectionSetup', () => {
 		} );
 	} );
 
+	describe( 'Step Progression', () => {
+		test( 'expands the next name server step when the current step is completed', async () => {
+			const user = userEvent.setup();
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				mode: null,
+				has_mx_records: false,
+			} );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				domain_connect_apply_wpcom_hosting: null,
+			} );
+
+			render(
+				<DomainConnectionSetup
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			await user.click(
+				screen.getByRole( 'checkbox', { name: 'I have opened the name server settings' } )
+			);
+
+			expect(
+				screen.queryByRole( 'checkbox', { name: 'I have opened the name server settings' } )
+			).not.toBeInTheDocument();
+			expect(
+				screen.getByRole( 'checkbox', { name: 'I have saved a copy of my name servers' } )
+			).toBeVisible();
+
+			await user.click(
+				screen.getByRole( 'checkbox', {
+					name: 'I have saved a copy of my name servers',
+				} )
+			);
+
+			expect(
+				screen.queryByRole( 'checkbox', {
+					name: 'I have saved a copy of my name servers',
+				} )
+			).not.toBeInTheDocument();
+			expect(
+				screen.getByRole( 'checkbox', { name: 'I have updated the name servers' } )
+			).toBeVisible();
+		} );
+	} );
+
 	describe( 'Mode Switching', () => {
 		test( 'switches from manual to Domain Connect when "Use Domain Connect" is clicked', async () => {
 			const user = userEvent.setup();

--- a/client/dashboard/domains/domain-connection-setup/test/domain-connection-setup.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-connection-setup.test.tsx
@@ -148,9 +148,9 @@ describe( 'DomainConnectionSetup', () => {
 			await user.click( manualSetupButton );
 
 			// Should now show manual setup cards
-			expect( screen.getByText( 'I only use this domain name for my website' ) ).toBeVisible();
+			expect( screen.getByText( 'I only use this domain for my website' ) ).toBeVisible();
 			expect(
-				screen.getByText( 'I use this domain name for email or other services' )
+				screen.getByText( 'I use this domain for my website, email, or other services' )
 			).toBeVisible();
 
 			// Should show banner to switch back to DC
@@ -200,9 +200,9 @@ describe( 'DomainConnectionSetup', () => {
 			);
 
 			// Should show manual setup cards
-			expect( screen.getByText( 'I only use this domain name for my website' ) ).toBeVisible();
+			expect( screen.getByText( 'I only use this domain for my website' ) ).toBeVisible();
 			expect(
-				screen.getByText( 'I use this domain name for email or other services' )
+				screen.getByText( 'I use this domain for my website, email, or other services' )
 			).toBeVisible();
 
 			// Should NOT show Domain Connect card or banner
@@ -230,9 +230,9 @@ describe( 'DomainConnectionSetup', () => {
 			);
 
 			// Suggested mode card should be expanded (shows steps)
-			expect( screen.getByText( '1. Login to your domain name provider' ) ).toBeVisible();
-			expect( screen.getByText( '2. Back up DNS records' ) ).toBeVisible();
-			expect( screen.getByText( '3. Update name servers' ) ).toBeVisible();
+			expect( screen.getByText( 'Log in to your domain provider' ) ).toBeVisible();
+			expect( screen.getByText( 'Save your current name servers' ) ).toBeVisible();
+			expect( screen.getByText( 'Update name servers' ) ).toBeVisible();
 		} );
 
 		test( 'defaults to advanced mode when MX records detected', () => {
@@ -253,9 +253,9 @@ describe( 'DomainConnectionSetup', () => {
 			);
 
 			// Advanced mode card should be expanded (shows steps)
-			expect( screen.getByText( '1. Login to your domain name provider' ) ).toBeVisible();
-			expect( screen.getByText( '2. Back up DNS records' ) ).toBeVisible();
-			expect( screen.getByText( '3. Update DNS records' ) ).toBeVisible();
+			expect( screen.getByText( 'Log in to your domain provider' ) ).toBeVisible();
+			expect( screen.getByText( 'Back up DNS records' ) ).toBeVisible();
+			expect( screen.getByText( 'Update DNS records' ) ).toBeVisible();
 		} );
 	} );
 
@@ -283,7 +283,7 @@ describe( 'DomainConnectionSetup', () => {
 			await user.click( manualSetupButton );
 
 			// Verify we're at manual setup
-			expect( screen.getByText( 'I only use this domain name for my website' ) ).toBeVisible();
+			expect( screen.getByText( 'I only use this domain for my website' ) ).toBeVisible();
 
 			// Switch back to DC
 			const useDomainConnectButton = screen.getByRole( 'button', {
@@ -378,8 +378,8 @@ describe( 'DomainConnectionSetup', () => {
 				/>
 			);
 
-			// Check that "Registered by" text is displayed (unique to banner)
-			expect( screen.getByText( 'Registered by' ) ).toBeVisible();
+			// Check that "Registered with" text is displayed (unique to banner)
+			expect( screen.getByText( 'Registered with' ) ).toBeVisible();
 
 			// Check that registrar links are present with correct href
 			const registrarLinks = screen.getAllByRole( 'link', { name: /GoDaddy/i } );
@@ -406,7 +406,7 @@ describe( 'DomainConnectionSetup', () => {
 
 			// Check that reseller name is displayed
 			expect( screen.getByText( 'Reseller Name' ) ).toBeVisible();
-			expect( screen.getByText( 'Registered by' ) ).toBeVisible();
+			expect( screen.getByText( 'Registered with' ) ).toBeVisible();
 
 			// Check that there's no clickable link for reseller
 			const registrarLink = screen.queryByRole( 'link', { name: 'Reseller Name' } );
@@ -429,8 +429,8 @@ describe( 'DomainConnectionSetup', () => {
 				/>
 			);
 
-			// Check that "Registered by" text is not displayed
-			expect( screen.queryByText( 'Registered by' ) ).not.toBeInTheDocument();
+			// Check that "Registered with" text is not displayed
+			expect( screen.queryByText( 'Registered with' ) ).not.toBeInTheDocument();
 		} );
 
 		test( 'displays registrar name in setup instructions when available', () => {
@@ -453,7 +453,7 @@ describe( 'DomainConnectionSetup', () => {
 			);
 
 			// Check that step 1 includes registrar name
-			expect( screen.getByText( '1. Login to Namecheap' ) ).toBeVisible();
+			expect( screen.getByText( 'Log in to Namecheap' ) ).toBeVisible();
 
 			// Check that registrar links exist (they appear in multiple places)
 			const registrarLinks = screen.getAllByRole( 'link', { name: /Namecheap/i } );
@@ -481,7 +481,7 @@ describe( 'DomainConnectionSetup', () => {
 			);
 
 			// Check that step 1 uses fallback text
-			expect( screen.getByText( '1. Login to your domain name provider' ) ).toBeVisible();
+			expect( screen.getByText( 'Log in to your domain provider' ) ).toBeVisible();
 		} );
 
 		test( 'does not display clickable registrar link for resellers in setup instructions', () => {
@@ -505,7 +505,7 @@ describe( 'DomainConnectionSetup', () => {
 			);
 
 			// When reseller is present, it takes precedence over registrar
-			expect( screen.getByText( '1. Login to Reseller Company' ) ).toBeVisible();
+			expect( screen.getByText( 'Log in to Reseller Company' ) ).toBeVisible();
 
 			// Reseller name should not be a clickable link in instructions
 			const resellerLinks = screen.queryAllByRole( 'link', { name: 'Reseller Company' } );
@@ -529,7 +529,7 @@ describe( 'DomainConnectionSetup', () => {
 			);
 
 			// Check that registrar banner is displayed in DC mode
-			expect( screen.getByText( 'Registered by' ) ).toBeVisible();
+			expect( screen.getByText( 'Registered with' ) ).toBeVisible();
 
 			// Check that registrar links are present (appears in banner and DC card)
 			const registrarLinks = screen.getAllByRole( 'link', { name: /GoDaddy/i } );
@@ -558,19 +558,21 @@ describe( 'DomainConnectionSetup', () => {
 			);
 
 			// Check in Suggested mode (default)
-			expect( screen.getByText( '1. Login to Bluehost' ) ).toBeVisible();
+			expect( screen.getByText( 'Log in to Bluehost' ) ).toBeVisible();
+			expect( screen.getByText( 'I have opened the name server settings' ) ).toBeVisible();
 			let registrarLinks = screen.getAllByRole( 'link', { name: /Bluehost/i } );
 			expect( registrarLinks.length ).toBeGreaterThan( 0 );
 			expect( registrarLinks[ 0 ] ).toHaveAttribute( 'href', 'https://www.bluehost.com' );
 
 			// Switch to Advanced mode
 			const advancedModeTitle = screen.getByText(
-				'I use this domain name for email or other services'
+				'I use this domain for my website, email, or other services'
 			);
 			await user.click( advancedModeTitle );
 
 			// Check in Advanced mode
-			expect( screen.getByText( '1. Login to Bluehost' ) ).toBeVisible();
+			expect( screen.getByText( 'Log in to Bluehost' ) ).toBeVisible();
+			expect( screen.getByText( 'I have opened the DNS settings' ) ).toBeVisible();
 			registrarLinks = screen.getAllByRole( 'link', { name: /Bluehost/i } );
 			expect( registrarLinks.length ).toBeGreaterThan( 0 );
 			expect( registrarLinks[ 0 ] ).toHaveAttribute( 'href', 'https://www.bluehost.com' );

--- a/client/dashboard/domains/domain-connection-setup/test/domain-connection-verification.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-connection-verification.test.tsx
@@ -168,10 +168,10 @@ describe( 'DomainConnectionVerification', () => {
 		test( 'renders the verification component with domain name', () => {
 			const { container } = render( <DomainConnectionVerification { ...defaultProps } /> );
 
-			const titleElement = container.querySelector(
-				'.dashboard-domain-connection-verification__title'
+			const statusCard = container.querySelector(
+				'.dashboard-domain-connection-verification__status-card'
 			);
-			expect( titleElement ).toHaveTextContent( 'example.com' );
+			expect( statusCard ).toHaveTextContent( 'example.com' );
 		} );
 
 		test( 'shows Active badge when domain is connected', () => {
@@ -258,25 +258,28 @@ describe( 'DomainConnectionVerification', () => {
 	} );
 
 	describe( 'Verification Status', () => {
-		test( 'displays info notice when domain is verifying', () => {
+		test( 'displays the verification handoff message', () => {
 			const domainMappingStatus = createMockDomainMappingStatus( {
 				has_wpcom_ip_addresses: false,
 				resolves_to_wpcom: false,
 			} );
 
-			const { container } = render(
+			render(
 				<DomainConnectionVerification
 					{ ...defaultProps }
 					domainMappingStatus={ domainMappingStatus }
 				/>
 			);
 
-			const noticeElement = container.querySelector( '.dashboard-notice.is-info' );
-			expect( noticeElement ).toBeInTheDocument();
-			expect( noticeElement?.textContent ).toContain( 'checking your DNS records' );
+			expect( screen.getByText( 'Your part is done. We’ll take it from here.' ) ).toBeVisible();
+			expect(
+				screen.getByText(
+					'This usually takes a few hours, though in some cases it can take up to 72 hours.'
+				)
+			).toBeVisible();
 		} );
 
-		test( 'does not display info notice when domain is connected', () => {
+		test( 'displays the connected message when the domain is active', () => {
 			const domainMappingStatus = createMockDomainMappingStatus( {
 				has_wpcom_ip_addresses: true,
 				resolves_to_wpcom: true,
@@ -289,11 +292,7 @@ describe( 'DomainConnectionVerification', () => {
 				/>
 			);
 
-			expect(
-				screen.queryByText(
-					/We're checking your DNS records. Most updates happen quickly, but some providers cache old settings for up to 72 hours./
-				)
-			).not.toBeInTheDocument();
+			expect( screen.getByText( 'Your domain is connected' ) ).toBeVisible();
 		} );
 
 		test( 'displays correct verification section title for Advanced mode', () => {
@@ -326,7 +325,7 @@ describe( 'DomainConnectionVerification', () => {
 			expect( screen.getByText( 'Name server verification' ) ).toBeVisible();
 		} );
 
-		test( 'displays "Recommended" section when domain is not primary but can be set as primary', () => {
+		test( 'links to the primary site address setting when available', () => {
 			render(
 				<DomainConnectionVerification
 					{ ...defaultProps }
@@ -337,12 +336,10 @@ describe( 'DomainConnectionVerification', () => {
 				/>
 			);
 
-			expect( screen.getByText( 'Recommended' ) ).toBeVisible();
-
-			expect( screen.getByText( 'Set example.com as your primary site address' ) ).toBeVisible();
+			expect( screen.getByText( 'set it as your primary site address' ) ).toBeVisible();
 		} );
 
-		test( 'does not display "Recommended" section when domain is not primary and cannot be set as primary', () => {
+		test( 'does not link to the primary site address setting when unavailable', () => {
 			render(
 				<DomainConnectionVerification
 					{ ...defaultProps }
@@ -353,10 +350,10 @@ describe( 'DomainConnectionVerification', () => {
 				/>
 			);
 
-			expect( screen.queryByText( 'Recommended' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'set it as your primary site address' ) ).not.toBeInTheDocument();
 		} );
 
-		test( 'does not display "Recommended" section when domain is primary', () => {
+		test( 'does not link to the primary site address setting when already primary', () => {
 			render(
 				<DomainConnectionVerification
 					{ ...defaultProps }
@@ -367,14 +364,14 @@ describe( 'DomainConnectionVerification', () => {
 				/>
 			);
 
-			expect( screen.queryByText( 'Recommended' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'set it as your primary site address' ) ).not.toBeInTheDocument();
 		} );
 	} );
 
-	describe( 'While You Wait Section', () => {
-		test( 'displays "While you wait" section when domain is verifying', () => {
+	describe( 'Connecting Status', () => {
+		test( 'displays the background connection message after records are verified', () => {
 			const domainMappingStatus = createMockDomainMappingStatus( {
-				has_wpcom_ip_addresses: false,
+				has_wpcom_ip_addresses: true,
 				resolves_to_wpcom: false,
 			} );
 
@@ -385,11 +382,13 @@ describe( 'DomainConnectionVerification', () => {
 				/>
 			);
 
-			expect( screen.getByText( 'While you wait' ) ).toBeVisible();
-			expect( screen.getByText( 'Customize your site' ) ).toBeVisible();
+			expect(
+				screen.getByText( /example.com is being connected in the background/ )
+			).toBeVisible();
+			expect( screen.getAllByText( 'Verifying' )[ 0 ] ).toBeVisible();
 		} );
 
-		test( 'does not display "While you wait" heading when domain is connected', () => {
+		test( 'does not display the background connection message when active', () => {
 			const domainMappingStatus = createMockDomainMappingStatus( {
 				has_wpcom_ip_addresses: true,
 				resolves_to_wpcom: true,
@@ -402,28 +401,9 @@ describe( 'DomainConnectionVerification', () => {
 				/>
 			);
 
-			expect( screen.queryByText( 'While you wait' ) ).not.toBeInTheDocument();
-		} );
-
-		test( '"What happens next" card is expanded by default when domain is verifying', () => {
-			const domainMappingStatus = createMockDomainMappingStatus( {
-				has_wpcom_ip_addresses: false,
-				resolves_to_wpcom: false,
-			} );
-
-			render(
-				<DomainConnectionVerification
-					{ ...defaultProps }
-					domainMappingStatus={ domainMappingStatus }
-				/>
-			);
-
-			// Verify the "What happens next" section is visible and expanded
-			const whatHappensNextSection = screen.getByText( 'What happens next' );
-			expect( whatHappensNextSection ).toBeVisible();
-
-			// Verify content is visible (indicates expansion)
-			expect( screen.getByText( 'Automatic verification' ) ).toBeVisible();
+			expect(
+				screen.queryByText( /example.com is being connected in the background/ )
+			).not.toBeInTheDocument();
 		} );
 	} );
 } );

--- a/client/dashboard/domains/domain-connection-setup/utils.ts
+++ b/client/dashboard/domains/domain-connection-setup/utils.ts
@@ -72,6 +72,19 @@ export function isMappingVerificationSuccess(
 	return !! ( hasCloudflareIpAddresses && resolvesToWpcom );
 }
 
+export type DomainConnectionStatus = 'verifying' | 'connecting' | 'active';
+
+export function getDomainConnectionStatus(
+	mode: DomainConnectionSetupModeValue | null,
+	verificationStatus: DomainMappingStatus | undefined
+): DomainConnectionStatus {
+	if ( ! isMappingVerificationSuccess( mode, verificationStatus ) ) {
+		return 'verifying';
+	}
+
+	return verificationStatus?.resolves_to_wpcom ? 'active' : 'connecting';
+}
+
 export const resolveStepName = (
 	connectionMode: DomainConnectionSetupModeValue | null,
 	supportsDomainConnect: boolean,


### PR DESCRIPTION
Related to MARTECH-2554

## Proposed Changes

* Match the Domains / Connect / Name Servers setup and connection-status states to the Figma design.
* Reuse existing WPDS icons for step, copy, and status visuals.

## Why are these changes being made?

* Keep the domain connection flow consistent with the current design and guidance.

## Testing Instructions

* 

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
