### PR TITLE
Update Help Center support-handoff message copy (DOTCOM-17941)

### DIFF
--- a/packages/i18n-utils/src/index.ts
+++ b/packages/i18n-utils/src/index.ts
@@ -6,6 +6,7 @@ export {
 } from './localize-url';
 export {
 	LocaleProvider,
+	getWpI18nLocaleSlug,
 	useLocale,
 	withLocale,
 	useIsEnglishLocale,

--- a/packages/i18n-utils/src/index.ts
+++ b/packages/i18n-utils/src/index.ts
@@ -6,7 +6,6 @@ export {
 } from './localize-url';
 export {
 	LocaleProvider,
-	getWpI18nLocaleSlug,
 	useLocale,
 	withLocale,
 	useIsEnglishLocale,

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -121,7 +121,7 @@ export const getOdieTransferMessages = ( botSlug?: OdieAllBotSlugs ): Message[] 
 		baseMessage,
 		{
 			content: __(
-				"We're connecting you with our support team. A Happiness Engineer will join the chat as soon as they're available.",
+				'A Happiness Engineer will reply as soon as they are available, either here or by email.',
 				__i18n_text_domain__
 			),
 			role: 'bot' as const,
@@ -136,7 +136,7 @@ export const getOdieTransferMessages = ( botSlug?: OdieAllBotSlugs ): Message[] 
 		},
 		{
 			content: __(
-				'They can see your chat with our AI assistant but please share any extra details while you wait so we can assist you better.',
+				'They can see this conversation, so please add any other details that may help.',
 				__i18n_text_domain__
 			),
 			role: 'bot' as const,

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -1,12 +1,9 @@
-import { englishLocales, getWpI18nLocaleSlug } from '@automattic/i18n-utils';
 import { isTestModeEnvironment } from '@automattic/zendesk-client';
-import { __, hasTranslation, sprintf } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import type { Context, Message, OdieAllowedBots, OdieAllBotSlugs } from './types';
 declare const __i18n_text_domain__: string;
 
-const hasEnTranslation = ( single: string ): boolean =>
-	englishLocales.includes( getWpI18nLocaleSlug() || 'en' ) ||
-	hasTranslation( single, undefined, __i18n_text_domain__ );
+type HasEnTranslation = ( single: string, context?: string, domain?: string ) => boolean;
 
 export const getOdieErrorMessage = (): string =>
 	__(
@@ -59,7 +56,10 @@ export function getFlowFromBotSlug( botSlug?: OdieAllBotSlugs ): string {
 	return 'wpcom';
 }
 
-export const getOdieTransferMessages = ( botSlug?: OdieAllBotSlugs ): Message[] => {
+export const getOdieTransferMessages = (
+	botSlug?: OdieAllBotSlugs,
+	hasEnTranslation: HasEnTranslation = () => true
+): Message[] => {
 	const isTestMode = isTestModeEnvironment();
 	const flow = getFlowFromBotSlug( botSlug );
 
@@ -126,7 +126,9 @@ export const getOdieTransferMessages = ( botSlug?: OdieAllBotSlugs ): Message[] 
 		baseMessage,
 		{
 			content: hasEnTranslation(
-				'A Happiness Engineer will reply as soon as they are available, either here or by email.'
+				'A Happiness Engineer will reply as soon as they are available, either here or by email.',
+				undefined,
+				__i18n_text_domain__
 			)
 				? __(
 						'A Happiness Engineer will reply as soon as they are available, either here or by email.',
@@ -148,7 +150,9 @@ export const getOdieTransferMessages = ( botSlug?: OdieAllBotSlugs ): Message[] 
 		},
 		{
 			content: hasEnTranslation(
-				'They can see this conversation, so please add any other details that may help.'
+				'They can see this conversation, so please add any other details that may help.',
+				undefined,
+				__i18n_text_domain__
 			)
 				? __(
 						'They can see this conversation, so please add any other details that may help.',

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -1,7 +1,12 @@
+import { englishLocales, getWpI18nLocaleSlug } from '@automattic/i18n-utils';
 import { isTestModeEnvironment } from '@automattic/zendesk-client';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, hasTranslation, sprintf } from '@wordpress/i18n';
 import type { Context, Message, OdieAllowedBots, OdieAllBotSlugs } from './types';
 declare const __i18n_text_domain__: string;
+
+const hasEnTranslation = ( single: string ): boolean =>
+	englishLocales.includes( getWpI18nLocaleSlug() || 'en' ) ||
+	hasTranslation( single, undefined, __i18n_text_domain__ );
 
 export const getOdieErrorMessage = (): string =>
 	__(
@@ -120,10 +125,17 @@ export const getOdieTransferMessages = ( botSlug?: OdieAllBotSlugs ): Message[] 
 	return [
 		baseMessage,
 		{
-			content: __(
-				'A Happiness Engineer will reply as soon as they are available, either here or by email.',
-				__i18n_text_domain__
-			),
+			content: hasEnTranslation(
+				'A Happiness Engineer will reply as soon as they are available, either here or by email.'
+			)
+				? __(
+						'A Happiness Engineer will reply as soon as they are available, either here or by email.',
+						__i18n_text_domain__
+				  )
+				: __(
+						"We're connecting you with our support team. A Happiness Engineer will join the chat as soon as they're available.",
+						__i18n_text_domain__
+				  ),
 			role: 'bot' as const,
 			type: 'message' as const,
 			context: {
@@ -135,10 +147,17 @@ export const getOdieTransferMessages = ( botSlug?: OdieAllBotSlugs ): Message[] 
 			},
 		},
 		{
-			content: __(
-				'They can see this conversation, so please add any other details that may help.',
-				__i18n_text_domain__
-			),
+			content: hasEnTranslation(
+				'They can see this conversation, so please add any other details that may help.'
+			)
+				? __(
+						'They can see this conversation, so please add any other details that may help.',
+						__i18n_text_domain__
+				  )
+				: __(
+						'They can see your chat with our AI assistant but please share any extra details while you wait so we can assist you better.',
+						__i18n_text_domain__
+				  ),
 			role: 'bot' as const,
 			type: 'message' as const,
 			context: {

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -1,3 +1,4 @@
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import {
 	useUpdateZendeskUserFields,
 	ZENDESK_CUSTOM_FIELD_AI_CHAT_ID,
@@ -37,6 +38,7 @@ export const useCreateZendeskConversation = () => {
 	const navigate = useNavigate();
 	const location = useLocation();
 	const interactionStatusByUuid = useOpenInteractionStatusMap();
+	const hasEnTranslation = useHasEnTranslation();
 
 	const getErrorMessage = ( error: unknown ) =>
 		error instanceof Error ? error.message : error?.toString?.() ?? 'Unknown error';
@@ -260,7 +262,7 @@ export const useCreateZendeskConversation = () => {
 				conversationId: conversationId,
 				messages: [
 					...prevChat.messages,
-					...getOdieTransferMessages( currentSupportInteraction?.bot_slug ),
+					...getOdieTransferMessages( currentSupportInteraction?.bot_slug, hasEnTranslation ),
 					getZendeskChatStartedMetaMessage(),
 				],
 				provider: 'zendesk',

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { HelpCenterSelect } from '@automattic/data-stores';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useIsMutating } from '@tanstack/react-query';
 import { useSelect } from '@wordpress/data';
 import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
@@ -53,6 +54,7 @@ export const useGetCombinedChat = (
 		useCurrentSupportInteraction();
 
 	const { loggedOutOdieChatId, sessionId, botSlug } = useLoggedOutSession();
+	const hasEnTranslation = useHasEnTranslation();
 
 	const odieId = loggedOutOdieChatId || getOdieIdFromInteraction( currentSupportInteraction );
 	const { isChatLoaded, connectionStatus } = useSelect( ( select ) => {
@@ -199,7 +201,10 @@ export const useGetCombinedChat = (
 								conversationId: conversation.id,
 								messages: [
 									...( odieChat ? filteredOdieMessages : [] ),
-									...getOdieTransferMessages( currentSupportInteraction?.bot_slug ),
+									...getOdieTransferMessages(
+										currentSupportInteraction?.bot_slug,
+										hasEnTranslation
+									),
 									getZendeskChatStartedMetaMessage(),
 									...( deduplicateZDMessages( [
 										// During connection recovery, the user queued messages can be deleted. This ensure they remain. And `deduplicateZDMessages` takes of duplication.
@@ -249,6 +254,7 @@ export const useGetCombinedChat = (
 		sessionId,
 		botSlug,
 		isLoadingCurrentSupportInteraction,
+		hasEnTranslation,
 		mainChatState?.messages?.length,
 		mainChatState?.odieId,
 		odieChat,


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-17941/update-the-message-for-users-in-the-help-center

## Proposed Changes

**Updates the automated copy shown when a Help Center chat moves from the AI assistant (Odie) to human support.**

## Testing Instructions

1. Run `yarn start`.
2. Open the Help Center and start a chat with the AI assistant.
3. Escalate to human support.
4. Confirm the handoff messages read as the new wording above.
