### PR TITLE
Agency Sites: Add flag-gated core update filter and WP version column

### DIFF
--- a/client/a8c-for-agencies/sections/sites/constants.ts
+++ b/client/a8c-for-agencies/sections/sites/constants.ts
@@ -15,4 +15,5 @@ export const filtersMap: AgencyDashboardFilterMap[] = [
 	{ filterType: 'site_disconnected', ref: 5 },
 	{ filterType: 'site_down', ref: 6 },
 	{ filterType: 'plugin_updates', ref: 7 },
+	{ filterType: 'core_updates', ref: 8 },
 ];

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { Badge } from '@automattic/components';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { Icon, starFilled } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -38,6 +39,7 @@ export const JetpackSitesDataViews = ( {
 	onRefetchSite,
 }: SitesDataViewsProps ) => {
 	const translate = useTranslate();
+	const isCoreUpdatesFilterEnabled = config.isEnabled( 'jetpack/agency-core-updates-filter' );
 
 	const { showOnlyFavorites, showOnlyDevelopmentSites } = useContext( SitesDashboardContext );
 	const totalSites = ( () => {
@@ -121,7 +123,7 @@ export const JetpackSitesDataViews = ( {
 	const [ scanRef, setScanRef ] = useState< HTMLElement | null >();
 	const [ pluginsRef, setPluginsRef ] = useState< HTMLElement | null >();
 
-	const fields = useMemo< Field< SiteData >[] >(
+	const baseFields = useMemo< Field< SiteData >[] >(
 		() => [
 			{
 				id: 'status',
@@ -137,6 +139,9 @@ export const JetpackSitesDataViews = ( {
 					{ value: 5, label: translate( 'Site disconnected' ) },
 					{ value: 6, label: translate( 'Site down' ) },
 					{ value: 7, label: translate( 'Plugins needing updates' ) },
+					...( isCoreUpdatesFilterEnabled
+						? [ { value: 8, label: translate( 'WordPress needing updates' ) } ]
+						: [] ),
 				],
 				filterBy: {
 					operators: [ 'is' ],
@@ -383,12 +388,60 @@ export const JetpackSitesDataViews = ( {
 			scanRef,
 			pluginsRef,
 			isLoading,
+			isCoreUpdatesFilterEnabled,
 			dataViewsState.selectedItem?.blog_id,
 			openSitePreviewPane,
 			getSiteErrors,
 			renderField,
 		]
 	);
+
+	const fields = useMemo< Field< SiteData >[] >( () => {
+		if ( ! isCoreUpdatesFilterEnabled ) {
+			return baseFields;
+		}
+
+		const wpVersionField: Field< SiteData > = {
+			id: 'wp_version',
+			label: translate( 'WP version' ),
+			getValue: ( { item } ) => item.site.value.wordpress_version,
+			render: ( { item } ) => {
+				if ( isLoading ) {
+					return <TextPlaceholder />;
+				}
+
+				const {
+					wordpress_version: wpVersion,
+					is_core_update_available: hasCoreUpdate,
+					latest_wordpress_version: latestVersion,
+				} = item.site.value;
+
+				if ( ! wpVersion ) {
+					return <span className="sites-dataview__wp-version">-</span>;
+				}
+
+				return (
+					<HStack spacing={ 2 } justify="flex-start">
+						<span className="sites-dataview__wp-version">{ wpVersion }</span>
+						{ hasCoreUpdate && (
+							<Badge type="warning">
+								{ latestVersion
+									? translate( 'Update to %(version)s', { args: { version: latestVersion } } )
+									: translate( 'Update available' ) }
+							</Badge>
+						) }
+					</HStack>
+				);
+			},
+			enableHiding: true,
+			enableSorting: false,
+		};
+
+		const favoriteIndex = baseFields.findIndex( ( field ) => field.id === 'favorite' );
+		const insertAt = favoriteIndex === -1 ? baseFields.length : favoriteIndex;
+
+		return [ ...baseFields.slice( 0, insertAt ), wpVersionField, ...baseFields.slice( insertAt ) ];
+	}, [ baseFields, isCoreUpdatesFilterEnabled, isLoading, translate ] );
 
 	const urlParams = new URLSearchParams( window.location.search );
 	const isOnboardingTourActive = urlParams.get( 'tour' ) !== null;

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { DESKTOP_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { ReactNode, useEffect, useState } from 'react';
@@ -30,8 +31,15 @@ interface Props {
 	featurePreview?: ReactNode | null;
 }
 
-const buildFilters = ( { issueTypes }: { issueTypes: string } ): Filter[] => {
-	const issueTypesArray = issueTypes?.split( ',' );
+export const buildFilters = ( { issueTypes }: { issueTypes: string } ): Filter[] => {
+	// The endpoint ignores unknown filters and would return every site, so a disabled
+	// filter must be dropped here rather than merely hidden from the filter menu.
+	const issueTypesArray = issueTypes
+		?.split( ',' )
+		.filter(
+			( issueType ) =>
+				issueType !== 'core_updates' || config.isEnabled( 'jetpack/agency-core-updates-filter' )
+		);
 
 	return (
 		issueTypesArray?.map( ( issueType ) => {
@@ -90,7 +98,16 @@ export const SitesDashboardProvider = ( {
 
 	// Limit fields on breakpoints smaller than 960px wide.
 	const isDesktop = useBreakpoint( DESKTOP_BREAKPOINT );
-	const desktopFields = [ 'stats', 'boost', 'backup', 'monitor', 'scan', 'plugins', 'favorite' ];
+	const desktopFields = [
+		'stats',
+		'boost',
+		'backup',
+		'monitor',
+		'scan',
+		'plugins',
+		...( config.isEnabled( 'jetpack/agency-core-updates-filter' ) ? [ 'wp_version' ] : [] ),
+		'favorite',
+	];
 	const getFieldsByBreakpoint = ( isDesktop: boolean ) =>
 		isDesktop ? desktopFields : EMPTY_ARRAY;
 

--- a/client/a8c-for-agencies/sections/sites/test/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/test/sites-dashboard-provider.tsx
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+import config from '@automattic/calypso-config';
+import { buildFilters } from '../sites-dashboard-provider';
+
+jest.mock( '@automattic/calypso-config', () => {
+	const actual = jest.requireActual( '@automattic/calypso-config' );
+	return {
+		...actual,
+		__esModule: true,
+		default: { ...actual.default, isEnabled: jest.fn() },
+		isEnabled: jest.fn(),
+	};
+} );
+
+const mockIsEnabled = config.isEnabled as jest.Mock;
+
+const setCoreUpdatesFilter = ( enabled: boolean ) =>
+	mockIsEnabled.mockImplementation( ( flag: string ) =>
+		flag === 'jetpack/agency-core-updates-filter' ? enabled : false
+	);
+
+describe( 'buildFilters', () => {
+	beforeEach( () => {
+		mockIsEnabled.mockReset();
+	} );
+
+	it( 'maps known issue types to their filter refs', () => {
+		setCoreUpdatesFilter( false );
+
+		expect( buildFilters( { issueTypes: 'backup_failed,site_down' } ) ).toEqual( [
+			{ field: 'status', operator: 'is', value: 2 },
+			{ field: 'status', operator: 'is', value: 6 },
+		] );
+	} );
+
+	it( 'includes core_updates when the flag is enabled', () => {
+		setCoreUpdatesFilter( true );
+
+		expect( buildFilters( { issueTypes: 'core_updates' } ) ).toEqual( [
+			{ field: 'status', operator: 'is', value: 8 },
+		] );
+	} );
+
+	// The endpoint ignores unknown filters and returns every site, so a disabled
+	// core_updates filter must be dropped rather than passed through as all_issues.
+	it( 'drops core_updates when the flag is disabled', () => {
+		setCoreUpdatesFilter( false );
+
+		expect( buildFilters( { issueTypes: 'core_updates' } ) ).toEqual( [] );
+	} );
+
+	it( 'keeps sibling filters when core_updates is dropped', () => {
+		setCoreUpdatesFilter( false );
+
+		expect( buildFilters( { issueTypes: 'core_updates,threats_found' } ) ).toEqual( [
+			{ field: 'status', operator: 'is', value: 4 },
+		] );
+	} );
+
+	it( 'falls back to all_issues for unrecognised issue types', () => {
+		setCoreUpdatesFilter( false );
+
+		expect( buildFilters( { issueTypes: 'not_a_real_filter' } ) ).toEqual( [
+			{ field: 'status', operator: 'is', value: 1 },
+		] );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -109,6 +109,9 @@ export interface Site {
 	php_version_num: number;
 	php_version: string;
 	wordpress_version: string;
+	// Populated by the sites endpoint only once core-update reporting ships; treat as unknown when absent.
+	latest_wordpress_version?: string;
+	is_core_update_available?: boolean;
 	hosting_provider_guess: string;
 	has_paid_agency_monitor: boolean;
 	is_atomic: boolean;
@@ -282,7 +285,8 @@ export type AgencyDashboardFilterOption =
 	| 'threats_found'
 	| 'site_disconnected'
 	| 'site_down'
-	| 'plugin_updates';
+	| 'plugin_updates'
+	| 'core_updates';
 
 export interface AgencyDashboardFilterMap {
 	filterType: AgencyDashboardFilterOption;

--- a/client/my-sites/activity/filterbar/type-selector/issue-type-selector.tsx
+++ b/client/my-sites/activity/filterbar/type-selector/issue-type-selector.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { localize, translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -38,6 +39,14 @@ const IssueTypeSelector: React.FunctionComponent< Props > = ( props ) => {
 			key: 'plugin_updates',
 			name: translate( 'Plugin needs updates' ),
 		},
+		...( config.isEnabled( 'jetpack/agency-core-updates-filter' )
+			? [
+					{
+						key: 'core_updates',
+						name: translate( 'WordPress needs updates' ),
+					},
+			  ]
+			: [] ),
 	];
 	return (
 		<TypeSelector

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -51,6 +51,7 @@
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,
+		"jetpack/agency-core-updates-filter": true,
 		"jetpack/crm-downloads": true,
 		"oauth": true,
 		"upgrades/redirect-payments": true

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -46,6 +46,7 @@
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,
+		"jetpack/agency-core-updates-filter": false,
 		"jetpack/crm-downloads": true,
 		"oauth": false,
 		"upgrades/redirect-payments": true

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -43,6 +43,7 @@
 		"ad-tracking": true,
 		"checkout/stripe-upi": true,
 		"cookie-banner": true,
+		"jetpack/agency-core-updates-filter": false,
 		"jetpack/crm-downloads": true,
 		"oauth": true,
 		"upgrades/redirect-payments": true

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -48,6 +48,7 @@
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,
+		"jetpack/agency-core-updates-filter": false,
 		"jetpack/crm-downloads": true,
 		"oauth": true,
 		"upgrades/redirect-payments": true

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -41,6 +41,7 @@
 		"individual-subscriber-stats": true,
 		"jetpack-cloud": true,
 		"jetpack/activity-log-sharing": true,
+		"jetpack/agency-core-updates-filter": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-restore-preflight-checks": true,
 		"jetpack/backup-retention-settings": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -35,6 +35,7 @@
 		"importers/newsletter": true,
 		"individual-subscriber-stats": true,
 		"jetpack-cloud": true,
+		"jetpack/agency-core-updates-filter": false,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-restore-preflight-checks": true,
 		"jetpack/backup-retention-settings": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -38,6 +38,7 @@
 		"importers/newsletter": true,
 		"individual-subscriber-stats": true,
 		"jetpack-cloud": true,
+		"jetpack/agency-core-updates-filter": false,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-restore-preflight-checks": true,
 		"jetpack/backup-retention-settings": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -38,6 +38,7 @@
 		"individual-subscriber-stats": true,
 		"jetpack-cloud": true,
 		"jetpack/activity-log-sharing": true,
+		"jetpack/agency-core-updates-filter": false,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-restore-preflight-checks": true,
 		"jetpack/backup-retention-settings": true,


### PR DESCRIPTION
## Proposed Changes

This change adds the client half of a `core_updates` issue type and a WP version column to the A4A sites table, both behind `jetpack/agency-core-updates-filter`. The flag is `true` in development and `false` in horizon, stage, and production.

The backend work is not in this repo and has not shipped. `/wpcom/v2/jetpack-agency/sites` must accept `core_updates=true` and filter server-side, and must return `is_core_update_available` (and ideally `latest_wordpress_version`) on the site payload. Both fields are declared optional on the `Site` type here so the column degrades to a plain version string until they arrive.

Because the endpoint ignores unrecognised query params and responds with the full site list, a `core_updates` filter reaching an unaware backend would render every site as if it needed updating. `buildFilters` therefore drops the type when the flag is off rather than only hiding it from the filter menu, so a hand-typed or bookmarked URL cannot produce that state. This is covered by unit tests.

Once the backend lands, enabling the flag makes `/sites?issue_types=core_updates` a shareable link for "sites not yet on the latest WordPress", reusing the existing deep-link machinery.

Note this surfaces which sites are behind; it does not update them. Remote core updates for self-hosted Jetpack sites do not exist in either dashboard today.

## Why are these changes being made?

The A4A and Jetpack Manage sites dashboards let you filter the site list down to sites that need attention. The filter is exposed in the URL as a comma-separated `issue_types` list — `/sites?issue_types=plugin_updates` — and the sidebar already ships deep links built this way, such as `/sites?issue_types=all_issues` for "Needs attention".

Despite the name, that filtering is not done in the browser. `useFetchDashboardSites` expands each issue type into its own boolean query param on `GET /wpcom/v2/jetpack-agency/sites`, and the endpoint returns a filtered, paginated page of sites. The client never filters the list itself.

There is no equivalent for WordPress core. During a security release there is nowhere in either dashboard to answer "which of my sites are not on the new version yet" — `wordpress_version` is already returned on the site payload but is not rendered in the sites table, and there is no issue type for it. Today the only way to see core versions across sites is the Multi-Site Dashboard at `/sites`, where the WP version column is off by default and cannot be pre-selected via URL.

## Testing Instructions

Prerequisites: a local checkout on this branch, and an agency account with at least one connected Jetpack site.

**A4A — filter and column hidden by default**

1. Run `yarn start-a8c-for-agencies`.
2. Open `http://agencies.localhost:3000/sites`.
3. Set `"jetpack/agency-core-updates-filter": false` in `config/a8c-for-agencies-development.json` and reload.
4. Confirm the status filter menu offers only the original seven options, ending at "Plugins needing updates", and that the table has no WP version column.
5. Visit `http://agencies.localhost:3000/sites?issue_types=core_updates` directly.
6. Confirm the list is unfiltered and no filter chip is applied. It must not show a "Needs attention" chip — that fallback is what the flag check prevents.

**A4A — filter and column visible when enabled**

7. Set `"jetpack/agency-core-updates-filter": true` in `config/a8c-for-agencies-development.json` and reload.
8. Confirm the status filter menu now offers "WordPress needing updates", and the table shows a "WP version" column between Plugins and the favourite star.
9. Confirm each row shows the site's WordPress version, or `-` when the payload has no version.
10. Select "WordPress needing updates" and confirm the URL becomes `?issue_types=core_updates`.
11. Because the endpoint does not support the param yet, the returned list will be unfiltered. This is expected until the backend ships.

**Badge rendering (needs stubbed data until the backend lands)**

12. In `client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx`, temporarily hardcode `hasCoreUpdate` to `true` in the `wp_version` field's `render`.
13. Confirm an orange "Update available" badge renders next to the version.
14. Also hardcode `latestVersion` to `'7.0.2'` and confirm the badge reads "Update to 7.0.2".
15. Revert both edits.

**Jetpack Manage**

16. Run `yarn start-jetpack-cloud` and open `http://jetpack.cloud.localhost:3000/dashboard`.
17. With `"jetpack/agency-core-updates-filter": false` in `config/jetpack-cloud-development.json`, open the "Issue Type" filter and confirm the list ends at "Plugin needs updates".
18. Set the flag to `true`, reload, and confirm "WordPress needs updates" now appears in the same menu.

**Automated checks**

19. `yarn test-client client/a8c-for-agencies/sections/sites client/jetpack-cloud/sections/agency-dashboard` — 49 suites, 240 tests pass.
20. `yarn typecheck-client` — no new errors introduced by this branch.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
