### PR TITLE
Jetpack AI: Align AI Editorial Review nomenclature

### DIFF
--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -296,7 +296,7 @@ describe( 'AgentChat', () => {
 			},
 			{
 				id: 'ai-editorial-review',
-				label: 'AI Editorial Review',
+				label: 'Editorial Review',
 				prompt: 'Run an AI Editorial Review',
 			},
 		];
@@ -328,7 +328,7 @@ describe( 'AgentChat', () => {
 		expect( screen.getByRole( 'button', { name: 'Generate excerpt' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Optimize SEO' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Simple review' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: 'AI Editorial Review' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Editorial review' } ) ).toBeInTheDocument();
 
 		await user.click( screen.getByRole( 'button', { name: 'Optimize title' } ) );
 		expect( onSuggestionClick ).toHaveBeenCalledWith( writingSuggestions[ 0 ], suggestions );

--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -295,9 +295,9 @@ describe( 'AgentChat', () => {
 				prompt: 'Proofread this saved content',
 			},
 			{
-				id: 'mediate-review-notes',
-				label: 'Editorial Review',
-				prompt: 'Run an editorial review',
+				id: 'ai-editorial-review',
+				label: 'AI Editorial Review',
+				prompt: 'Run an AI Editorial Review',
 			},
 		];
 		const suggestions = [ designSuggestion, whatElseSuggestion, ...writingSuggestions ];
@@ -328,7 +328,7 @@ describe( 'AgentChat', () => {
 		expect( screen.getByRole( 'button', { name: 'Generate excerpt' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Optimize SEO' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Simple review' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: 'Editorial review' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'AI Editorial Review' } ) ).toBeInTheDocument();
 
 		await user.click( screen.getByRole( 'button', { name: 'Optimize title' } ) );
 		expect( onSuggestionClick ).toHaveBeenCalledWith( writingSuggestions[ 0 ], suggestions );

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -364,14 +364,14 @@ describe( 'OrchestratorChat', () => {
 		window.addEventListener( 'big-sky-inline-suggestion-click', listener );
 		const suggestion = {
 			id: 'ai-editorial-review',
-			label: 'AI Editorial Review',
+			label: 'Editorial Review',
 			prompt: 'Run an AI Editorial Review',
 		};
 
 		render( chat( { emptyViewSuggestions: [ suggestion ] } ) );
 		jest.mocked( recordBigSkyTracksEvent ).mockClear();
 
-		fireEvent.click( screen.getByRole( 'button', { name: 'AI Editorial Review' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Editorial Review' } ) );
 
 		expect( listener ).toHaveBeenCalledTimes( 1 );
 		expect( ( listener.mock.calls[ 0 ][ 0 ] as CustomEvent ).detail ).toEqual( {

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -359,6 +359,36 @@ describe( 'OrchestratorChat', () => {
 		window.removeEventListener( 'big-sky-inline-suggestion-click', listener );
 	} );
 
+	it( 'dispatches and tracks the canonical AI Editorial Review suggestion ID once', () => {
+		const listener = jest.fn();
+		window.addEventListener( 'big-sky-inline-suggestion-click', listener );
+		const suggestion = {
+			id: 'ai-editorial-review',
+			label: 'AI Editorial Review',
+			prompt: 'Run an AI Editorial Review',
+		};
+
+		render( chat( { emptyViewSuggestions: [ suggestion ] } ) );
+		jest.mocked( recordBigSkyTracksEvent ).mockClear();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'AI Editorial Review' } ) );
+
+		expect( listener ).toHaveBeenCalledTimes( 1 );
+		expect( ( listener.mock.calls[ 0 ][ 0 ] as CustomEvent ).detail ).toEqual( {
+			value: 'Run an AI Editorial Review',
+			autoSubmit: false,
+			suggestionId: 'ai-editorial-review',
+		} );
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 1 );
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_suggestion_click', {
+			suggestion_text: 'Run an AI Editorial Review',
+			suggestion_id: 'ai-editorial-review',
+			available_suggestions: '|ai-editorial-review|',
+		} );
+
+		window.removeEventListener( 'big-sky-inline-suggestion-click', listener );
+	} );
+
 	it( 'dispatches the inline suggestion event when Agenttic passes a prompt string', () => {
 		const listener = jest.fn();
 		window.addEventListener( 'big-sky-inline-suggestion-click', listener );

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -34,7 +34,7 @@ const WRITING_SUGGESTION_LABELS: Record< string, () => string > = {
 	'seo-enhancer': () => __( 'Optimize SEO', __i18n_text_domain__ ),
 	'generate-feedback': () => __( 'Simple review', __i18n_text_domain__ ),
 	'proofread-content': () => __( 'Proofread', __i18n_text_domain__ ),
-	'ai-editorial-review': () => __( 'AI Editorial Review', __i18n_text_domain__ ),
+	'ai-editorial-review': () => __( 'Editorial review', __i18n_text_domain__ ),
 };
 
 export const WRITING_SUGGESTION_IDS = new Set( Object.keys( WRITING_SUGGESTION_LABELS ) );

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -34,7 +34,7 @@ const WRITING_SUGGESTION_LABELS: Record< string, () => string > = {
 	'seo-enhancer': () => __( 'Optimize SEO', __i18n_text_domain__ ),
 	'generate-feedback': () => __( 'Simple review', __i18n_text_domain__ ),
 	'proofread-content': () => __( 'Proofread', __i18n_text_domain__ ),
-	'mediate-review-notes': () => __( 'Editorial review', __i18n_text_domain__ ),
+	'ai-editorial-review': () => __( 'AI Editorial Review', __i18n_text_domain__ ),
 };
 
 export const WRITING_SUGGESTION_IDS = new Set( Object.keys( WRITING_SUGGESTION_LABELS ) );

--- a/packages/agents-manager/src/utils/__tests__/orchestrator-error-message.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/orchestrator-error-message.test.ts
@@ -9,7 +9,13 @@ describe( 'getOrchestratorErrorMessage', () => {
 		expect( getOrchestratorErrorMessage( null ) ).toBeNull();
 	} );
 
-	it( 'maps the over-limit error code to localized upgrade copy', () => {
+	it( 'maps the AI Editorial Review over-limit error code to localized upgrade copy', () => {
+		expect( getOrchestratorErrorMessage( 'ai_editorial_review_over_limit' ) ).toBe(
+			'You have reached your Jetpack AI usage limit. Upgrade your plan to continue.'
+		);
+	} );
+
+	it( 'keeps mapping the legacy over-limit error code for delayed responses', () => {
 		expect( getOrchestratorErrorMessage( 'review_mediator_over_limit' ) ).toBe(
 			'You have reached your Jetpack AI usage limit. Upgrade your plan to continue.'
 		);
@@ -20,6 +26,13 @@ describe( 'getOrchestratorErrorMessage', () => {
 			'You have reached your Jetpack AI usage limit. Upgrade your plan to continue.'
 		);
 	} );
+
+	it.each( [ 'ai_editorial_review_over_limit_retryable', 'prefix_review_mediator_over_limit' ] )(
+		'passes the near-miss error code %s through unchanged',
+		( error ) => {
+			expect( getOrchestratorErrorMessage( error ) ).toBe( error );
+		}
+	);
 
 	it( 'passes other errors through unchanged', () => {
 		expect( getOrchestratorErrorMessage( 'Some other error.' ) ).toBe( 'Some other error.' );

--- a/packages/agents-manager/src/utils/orchestrator-error-message.ts
+++ b/packages/agents-manager/src/utils/orchestrator-error-message.ts
@@ -8,7 +8,11 @@ export function getOrchestratorErrorMessage( error: string | null ): string | nu
 		return null;
 	}
 
-	if ( error.includes( 'review_mediator_over_limit' ) || /jetpack ai usage limit/i.test( error ) ) {
+	if (
+		error === 'ai_editorial_review_over_limit' ||
+		error === 'review_mediator_over_limit' ||
+		/jetpack ai usage limit/i.test( error )
+	) {
 		return __(
 			'You have reached your Jetpack AI usage limit. Upgrade your plan to continue.',
 			__i18n_text_domain__

--- a/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.scss
+++ b/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.scss
@@ -98,7 +98,7 @@
 	}
 }
 
-.jetpack-ai-review-mediation {
+.jetpack-ai-editorial-review {
 	--jetpack-ai-review-action-border: color-mix(in srgb, currentColor 25%, transparent);
 	--jetpack-ai-review-action-border-hover: color-mix(in srgb, currentColor 45%, transparent);
 	--jetpack-ai-review-action-bg-hover: color-mix(in srgb, currentColor 6%, transparent);
@@ -112,9 +112,9 @@
 	color: inherit;
 
 	&.is-post-stale {
-		.jetpack-ai-review-mediation__stats,
-		.jetpack-ai-review-mediation__panel,
-		.jetpack-ai-review-mediation__footer {
+		.jetpack-ai-editorial-review__stats,
+		.jetpack-ai-editorial-review__panel,
+		.jetpack-ai-editorial-review__footer {
 			opacity: 0.5;
 		}
 	}
@@ -177,8 +177,8 @@
 	// Content region bottom spacing. Keep cards out of this broad PanelBody
 	// rule so their own internal padding is not overwritten.
 	.components-panel__body.is-opened
-		> :not(.components-panel__body-title):not(.jetpack-ai-review-mediation__card):not(
-			.jetpack-ai-review-mediation__conflict-card
+		> :not(.components-panel__body-title):not(.jetpack-ai-editorial-review__card):not(
+			.jetpack-ai-editorial-review__conflict-card
 		) {
 		padding: 0 0 0.75rem;
 	}

--- a/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.test.tsx
@@ -8,7 +8,7 @@ import '@testing-library/jest-dom';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import React from 'react';
-import ReviewMediation from './review-mediation';
+import AiEditorialReview from './ai-editorial-review';
 
 jest.mock( '@automattic/calypso-analytics', () => ( {
 	recordTracksEvent: jest.fn(),
@@ -152,8 +152,8 @@ const blocks = [
 ];
 
 function basePayload(
-	overrides: Partial< React.ComponentProps< typeof ReviewMediation > > = {}
-): React.ComponentProps< typeof ReviewMediation > {
+	overrides: Partial< React.ComponentProps< typeof AiEditorialReview > > = {}
+): React.ComponentProps< typeof AiEditorialReview > {
 	return {
 		summary: 'Two reviewers disagree on the procedural framing.',
 		postId: 1,
@@ -192,9 +192,9 @@ afterEach( () => {
 	delete ( window as any ).wp;
 } );
 
-describe( 'ReviewMediation — smoke render', () => {
+describe( 'AiEditorialReview — smoke render', () => {
 	it( 'renders the summary and no stats chips when payload is empty', () => {
-		render( <ReviewMediation { ...basePayload() } /> );
+		render( <AiEditorialReview { ...basePayload() } /> );
 
 		expect(
 			screen.getByText( 'Two reviewers disagree on the procedural framing.' )
@@ -210,7 +210,7 @@ describe( 'ReviewMediation — smoke render', () => {
 
 	it( 'renders all five sections when the payload is fully populated', () => {
 		render(
-			<ReviewMediation
+			<AiEditorialReview
 				{ ...basePayload( {
 					conflicts: [
 						{
@@ -268,7 +268,7 @@ describe( 'ReviewMediation — smoke render', () => {
 
 	it( 'tracks the rendered result with aggregate counts', async () => {
 		render(
-			<ReviewMediation
+			<AiEditorialReview
 				{ ...basePayload( {
 					review_context: 'notes_and_guidelines',
 					conflicts: [
@@ -323,7 +323,7 @@ describe( 'ReviewMediation — smoke render', () => {
 	it( 'marks a review for another post as stale and non-actionable', () => {
 		// Review was generated for post 2 (postId prop); editor is currently on post 1 (mockCurrentPostId).
 		render(
-			<ReviewMediation
+			<AiEditorialReview
 				{ ...basePayload( {
 					postId: 2,
 					conflicts: [
@@ -388,7 +388,7 @@ describe( 'ReviewMediation — smoke render', () => {
 
 	it( 'marks a review without source post context as stale', () => {
 		render(
-			<ReviewMediation
+			<AiEditorialReview
 				{ ...basePayload( {
 					postId: undefined,
 					suggested_edits: [
@@ -422,7 +422,7 @@ describe( 'ReviewMediation — smoke render', () => {
 		// !isPostStale gate the card would wrongly show a "Manual edit" tag.
 		mockCurrentPostId = 999;
 		render(
-			<ReviewMediation
+			<AiEditorialReview
 				{ ...basePayload( {
 					suggested_edits: [
 						{
@@ -450,7 +450,7 @@ describe( 'ReviewMediation — smoke render', () => {
 		'filters guideline violations without a rendered guideline quote when the value is %s',
 		( _label, quote ) => {
 			render(
-				<ReviewMediation
+				<AiEditorialReview
 					{ ...basePayload( {
 						guideline_violations: [
 							{
@@ -476,10 +476,10 @@ describe( 'ReviewMediation — smoke render', () => {
 	);
 } );
 
-describe( 'ReviewMediation — stats strip', () => {
+describe( 'AiEditorialReview — stats strip', () => {
 	it( 'renders one button per non-empty section with the correct count', () => {
 		render(
-			<ReviewMediation
+			<AiEditorialReview
 				{ ...basePayload( {
 					conflicts: [
 						{
@@ -518,7 +518,7 @@ describe( 'ReviewMediation — stats strip', () => {
 
 	it( 'scrolls the matching section into view when a stat chip is clicked', () => {
 		render(
-			<ReviewMediation
+			<AiEditorialReview
 				{ ...basePayload( {
 					suggested_edits: [
 						{
@@ -543,7 +543,7 @@ describe( 'ReviewMediation — stats strip', () => {
 	} );
 } );
 
-describe( 'ReviewMediation — suggested-edit accept flow', () => {
+describe( 'AiEditorialReview — suggested-edit accept flow', () => {
 	const editsPayload = basePayload( {
 		suggested_edits: [
 			{
@@ -559,7 +559,7 @@ describe( 'ReviewMediation — suggested-edit accept flow', () => {
 	it( 'applies the edit and collapses the card on Accept', async () => {
 		mockApplyReviewEdit.mockResolvedValueOnce( { success: true } );
 
-		render( <ReviewMediation { ...editsPayload } /> );
+		render( <AiEditorialReview { ...editsPayload } /> );
 
 		// Pre-accept: full card visible with rationale.
 		expect( screen.getByText( 'Concise.' ) ).toBeInTheDocument();
@@ -598,7 +598,7 @@ describe( 'ReviewMediation — suggested-edit accept flow', () => {
 		// A never-resolving apply keeps the card in the in-flight "Applying…" state.
 		mockApplyReviewEdit.mockReturnValueOnce( new Promise( () => undefined ) );
 
-		const { rerender } = render( <ReviewMediation { ...editsPayload } /> );
+		const { rerender } = render( <AiEditorialReview { ...editsPayload } /> );
 		await act( async () => {
 			fireEvent.click( screen.getByRole( 'button', { name: 'Apply change' } ) );
 		} );
@@ -606,7 +606,7 @@ describe( 'ReviewMediation — suggested-edit accept flow', () => {
 
 		// The editor navigates to another post while the apply is still in flight.
 		mockCurrentPostId = 999;
-		rerender( <ReviewMediation { ...editsPayload } /> );
+		rerender( <AiEditorialReview { ...editsPayload } /> );
 
 		// No stuck Apply/Applying button — Go to section (disabled) stands in.
 		expect( screen.queryByRole( 'button', { name: 'Apply change' } ) ).not.toBeInTheDocument();
@@ -628,7 +628,7 @@ describe( 'ReviewMediation — suggested-edit accept flow', () => {
 		} );
 
 		render(
-			<ReviewMediation
+			<AiEditorialReview
 				{ ...basePayload( {
 					suggested_edits: [
 						{
@@ -661,7 +661,7 @@ describe( 'ReviewMediation — suggested-edit accept flow', () => {
 	it( 'restores the full card from the collapsed row on Undo', async () => {
 		mockApplyReviewEdit.mockResolvedValueOnce( { success: true } );
 
-		render( <ReviewMediation { ...editsPayload } /> );
+		render( <AiEditorialReview { ...editsPayload } /> );
 
 		await act( async () => {
 			fireEvent.click( screen.getByRole( 'button', { name: 'Apply change' } ) );
@@ -685,7 +685,7 @@ describe( 'ReviewMediation — suggested-edit accept flow', () => {
 			contentAfter: 'The council voted on Tuesday on the procedural matter.',
 		} );
 
-		render( <ReviewMediation { ...editsPayload } /> );
+		render( <AiEditorialReview { ...editsPayload } /> );
 
 		await act( async () => {
 			fireEvent.click( screen.getByRole( 'button', { name: 'Apply change' } ) );
@@ -713,7 +713,7 @@ describe( 'ReviewMediation — suggested-edit accept flow', () => {
 		} );
 		mockUndoBlockEdit.mockReturnValueOnce( false ).mockReturnValueOnce( true );
 
-		render( <ReviewMediation { ...editsPayload } /> );
+		render( <AiEditorialReview { ...editsPayload } /> );
 
 		await act( async () => {
 			fireEvent.click( screen.getByRole( 'button', { name: 'Apply change' } ) );
@@ -740,7 +740,7 @@ describe( 'ReviewMediation — suggested-edit accept flow', () => {
 	it( 'marks the row failed (and not collapsed) when applyReviewEdit rejects', async () => {
 		mockApplyReviewEdit.mockResolvedValueOnce( { success: false } );
 
-		render( <ReviewMediation { ...editsPayload } /> );
+		render( <AiEditorialReview { ...editsPayload } /> );
 
 		await act( async () => {
 			fireEvent.click( screen.getByRole( 'button', { name: 'Apply change' } ) );
@@ -761,7 +761,7 @@ describe( 'ReviewMediation — suggested-edit accept flow', () => {
 		mockBlocks = [ ...blocks, { clientId: 'b3', name: 'core/query', attributes: { queryId: 1 } } ];
 
 		render(
-			<ReviewMediation
+			<AiEditorialReview
 				{ ...basePayload( {
 					suggested_edits: [
 						{
@@ -787,7 +787,7 @@ describe( 'ReviewMediation — suggested-edit accept flow', () => {
 
 	it( 'renders manual suggested edits without making them auto-applicable', () => {
 		render(
-			<ReviewMediation
+			<AiEditorialReview
 				{ ...basePayload( {
 					suggested_edits: [
 						{
@@ -819,7 +819,7 @@ describe( 'ReviewMediation — suggested-edit accept flow', () => {
 
 	it( 'badges edits with feedback_category and keeps that category on a Manual edit', () => {
 		render(
-			<ReviewMediation
+			<AiEditorialReview
 				{ ...basePayload( {
 					suggested_edits: [
 						{
@@ -852,7 +852,7 @@ describe( 'ReviewMediation — suggested-edit accept flow', () => {
 	} );
 
 	it( 'keeps block focus on the explicit block reference button', () => {
-		render( <ReviewMediation { ...editsPayload } /> );
+		render( <AiEditorialReview { ...editsPayload } /> );
 
 		const card = screen.getByText( 'Concise.' ).closest( '.jetpack-ai-feedback-list__item' );
 		expect( card ).toBeInTheDocument();
@@ -897,7 +897,7 @@ describe( 'ReviewMediation — suggested-edit accept flow', () => {
 		mockApplyReviewEdit.mockResolvedValueOnce( { success: true } );
 
 		render(
-			<ReviewMediation
+			<AiEditorialReview
 				{ ...basePayload( {
 					suggested_edits: [
 						{
@@ -928,7 +928,7 @@ describe( 'ReviewMediation — suggested-edit accept flow', () => {
 
 	it( 'offers Go to section instead of Apply when the source text no longer matches', () => {
 		render(
-			<ReviewMediation
+			<AiEditorialReview
 				{ ...basePayload( {
 					suggested_edits: [
 						{
@@ -952,7 +952,7 @@ describe( 'ReviewMediation — suggested-edit accept flow', () => {
 	} );
 
 	it( 'collapses the card on Dismiss without calling applyReviewEdit', () => {
-		render( <ReviewMediation { ...editsPayload } /> );
+		render( <AiEditorialReview { ...editsPayload } /> );
 
 		fireEvent.click( screen.getByRole( 'button', { name: 'Dismiss' } ) );
 
@@ -962,7 +962,7 @@ describe( 'ReviewMediation — suggested-edit accept flow', () => {
 	} );
 } );
 
-describe( 'ReviewMediation — guideline violations', () => {
+describe( 'AiEditorialReview — guideline violations', () => {
 	const violationsPayload = basePayload( {
 		guideline_violations: [
 			{
@@ -977,7 +977,7 @@ describe( 'ReviewMediation — guideline violations', () => {
 	} );
 
 	it( 'renders a violation as an advisory card — badge, struck excerpt, why, guideline, no Apply', () => {
-		render( <ReviewMediation { ...violationsPayload } /> );
+		render( <AiEditorialReview { ...violationsPayload } /> );
 
 		// Section heading carries the count, like the other grouped sections.
 		expect( screen.getByText( /Guideline violations \(1\)/ ) ).toBeInTheDocument();
@@ -999,14 +999,14 @@ describe( 'ReviewMediation — guideline violations', () => {
 	} );
 
 	it( 'focuses the referenced block when Go to section is clicked', () => {
-		render( <ReviewMediation { ...violationsPayload } /> );
+		render( <AiEditorialReview { ...violationsPayload } /> );
 
 		fireEvent.click( screen.getByRole( 'button', { name: 'Go to section' } ) );
 		expect( mockToggleBlockReferenceFocus ).toHaveBeenCalledWith( 'b1' );
 	} );
 
 	it( 'collapses to a Dismissed row on Dismiss and restores the card on Undo', () => {
-		render( <ReviewMediation { ...violationsPayload } /> );
+		render( <AiEditorialReview { ...violationsPayload } /> );
 
 		fireEvent.click( screen.getByRole( 'button', { name: 'Dismiss' } ) );
 
@@ -1025,7 +1025,7 @@ describe( 'ReviewMediation — guideline violations', () => {
 
 	it( 'disables Go to section when the referenced block is gone and omits the excerpt row', () => {
 		render(
-			<ReviewMediation
+			<AiEditorialReview
 				{ ...basePayload( {
 					guideline_violations: [
 						{
@@ -1049,7 +1049,7 @@ describe( 'ReviewMediation — guideline violations', () => {
 	} );
 } );
 
-describe( 'ReviewMediation — conflict resolutions', () => {
+describe( 'AiEditorialReview — conflict resolutions', () => {
 	const conflictPayload = basePayload( {
 		conflicts: [
 			{
@@ -1087,7 +1087,7 @@ describe( 'ReviewMediation — conflict resolutions', () => {
 	it( 'applies the per-reviewer candidate when its button is clicked', async () => {
 		mockApplyReviewEdit.mockResolvedValueOnce( { success: true } );
 
-		render( <ReviewMediation { ...conflictPayload } /> );
+		render( <AiEditorialReview { ...conflictPayload } /> );
 
 		await act( async () => {
 			fireEvent.click( screen.getByRole( 'button', { name: "Accept Marcus's wording" } ) );
@@ -1109,7 +1109,7 @@ describe( 'ReviewMediation — conflict resolutions', () => {
 	it( 'applies the AI candidate when its button is clicked', async () => {
 		mockApplyReviewEdit.mockResolvedValueOnce( { success: true } );
 
-		render( <ReviewMediation { ...conflictPayload } /> );
+		render( <AiEditorialReview { ...conflictPayload } /> );
 
 		await act( async () => {
 			fireEvent.click( screen.getByRole( 'button', { name: 'Accept AI resolution' } ) );
@@ -1130,7 +1130,7 @@ describe( 'ReviewMediation — conflict resolutions', () => {
 		// must stay in their own group and the AI + Dismiss pair must stay fixed,
 		// so the pairing never depends on the reviewer count's parity.
 		render(
-			<ReviewMediation
+			<AiEditorialReview
 				{ ...basePayload( {
 					conflicts: [
 						{
@@ -1169,10 +1169,10 @@ describe( 'ReviewMediation — conflict resolutions', () => {
 		);
 
 		const candidates = document.querySelector(
-			'.jetpack-ai-review-mediation__conflict-candidates'
+			'.jetpack-ai-editorial-review__conflict-candidates'
 		);
 		const resolve = document.querySelector(
-			'.jetpack-ai-review-mediation__conflict-resolution .jetpack-ai-review-mediation__actions'
+			'.jetpack-ai-editorial-review__conflict-resolution .jetpack-ai-editorial-review__actions'
 		);
 		expect( candidates ).toBeInTheDocument();
 		expect( resolve ).toBeInTheDocument();
@@ -1200,7 +1200,7 @@ describe( 'ReviewMediation — conflict resolutions', () => {
 	it( 'resolves in place on accept — keeps the header, shows Applied + Undo, and Undo restores the options', async () => {
 		mockApplyReviewEdit.mockResolvedValueOnce( { success: true } );
 
-		render( <ReviewMediation { ...conflictPayload } /> );
+		render( <AiEditorialReview { ...conflictPayload } /> );
 
 		await act( async () => {
 			fireEvent.click( screen.getByRole( 'button', { name: 'Accept AI resolution' } ) );
@@ -1235,7 +1235,7 @@ describe( 'ReviewMediation — conflict resolutions', () => {
 		} );
 		mockUndoBlockEdit.mockReturnValueOnce( false ).mockReturnValueOnce( true );
 
-		render( <ReviewMediation { ...conflictPayload } /> );
+		render( <AiEditorialReview { ...conflictPayload } /> );
 
 		await act( async () => {
 			fireEvent.click( screen.getByRole( 'button', { name: 'Accept AI resolution' } ) );
@@ -1273,7 +1273,7 @@ describe( 'ReviewMediation — conflict resolutions', () => {
 		];
 
 		render(
-			<ReviewMediation
+			<AiEditorialReview
 				{ ...basePayload( {
 					conflicts: [
 						{
@@ -1309,7 +1309,7 @@ describe( 'ReviewMediation — conflict resolutions', () => {
 
 	it( 'renders post-wide conflict candidates as manual guidance without accept buttons', () => {
 		render(
-			<ReviewMediation
+			<AiEditorialReview
 				{ ...basePayload( {
 					conflicts: [
 						{
@@ -1346,7 +1346,7 @@ describe( 'ReviewMediation — conflict resolutions', () => {
 
 	it( 'renders conflict candidates without exact source text as manual guidance', () => {
 		render(
-			<ReviewMediation
+			<AiEditorialReview
 				{ ...basePayload( {
 					conflicts: [
 						{
@@ -1395,7 +1395,7 @@ describe( 'ReviewMediation — conflict resolutions', () => {
 			];
 
 			render(
-				<ReviewMediation
+				<AiEditorialReview
 					{ ...basePayload( {
 						conflicts: [
 							{
@@ -1434,7 +1434,7 @@ describe( 'ReviewMediation — conflict resolutions', () => {
 	);
 } );
 
-describe( 'ReviewMediation — bulk Apply all', () => {
+describe( 'AiEditorialReview — bulk Apply all', () => {
 	it( 'applies only supported pending edits sequentially', async () => {
 		mockApplyReviewEdit.mockResolvedValue( { success: true } );
 		mockBlocks = [
@@ -1444,7 +1444,7 @@ describe( 'ReviewMediation — bulk Apply all', () => {
 		];
 
 		render(
-			<ReviewMediation
+			<AiEditorialReview
 				{ ...basePayload( {
 					conflicts: [
 						{
@@ -1574,7 +1574,7 @@ describe( 'ReviewMediation — bulk Apply all', () => {
 				},
 			],
 		} );
-		const { rerender } = render( <ReviewMediation { ...payload } /> );
+		const { rerender } = render( <AiEditorialReview { ...payload } /> );
 
 		await act( async () => {
 			fireEvent.click( screen.getByRole( 'button', { name: /Apply all \(2\)/ } ) );
@@ -1585,7 +1585,7 @@ describe( 'ReviewMediation — bulk Apply all', () => {
 		} );
 
 		mockCurrentPostId = 2;
-		rerender( <ReviewMediation { ...payload } /> );
+		rerender( <AiEditorialReview { ...payload } /> );
 
 		await act( async () => {
 			resolveFirstApply( { success: true } );
@@ -1601,17 +1601,17 @@ describe( 'ReviewMediation — bulk Apply all', () => {
 	} );
 } );
 
-describe( 'ReviewMediation — cached-run hint', () => {
+describe( 'AiEditorialReview — cached-run hint', () => {
 	it( 'renders a relative-time note when cached_at is set', () => {
 		// 10 minutes ago.
 		const cached_at = Math.floor( Date.now() / 1000 ) - 600;
-		render( <ReviewMediation { ...basePayload( { cached_at } ) } /> );
+		render( <AiEditorialReview { ...basePayload( { cached_at } ) } /> );
 
 		expect( screen.getByText( /Reusing review from .* ago/ ) ).toBeInTheDocument();
 	} );
 
 	it( 'omits the note when cached_at is not provided', () => {
-		render( <ReviewMediation { ...basePayload() } /> );
+		render( <AiEditorialReview { ...basePayload() } /> );
 		expect( screen.queryByText( /Reusing review/ ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.tsx
@@ -1,6 +1,6 @@
 /**
- * ReviewMediation — renders the AI Editorial Review card. Mounted by
- * `getChatComponent('review-mediation')` from a show-component response.
+ * AiEditorialReview — renders the AI Editorial Review card. Mounted by
+ * `getChatComponent('ai-editorial-review')` from a show-component response.
  */
 
 /**
@@ -41,7 +41,7 @@ import ReviewCard, { type ReviewCardRow } from './review-card';
 import ReviewerChip, { type ReviewerMetadata } from './reviewer-chip';
 
 /**
- * Types mirroring the wpcom `Review_Mediator_Ability` structured output.
+ * Types mirroring the wpcom `AI_Editorial_Review_Ability` structured output.
  */
 interface ReviewerPosition {
 	reviewer: string;
@@ -96,7 +96,7 @@ interface GuidelineViolation {
 
 type EditorPostId = number | string;
 
-interface ReviewMediationProps {
+interface AiEditorialReviewProps {
 	summary: string;
 	conflicts: Conflict[];
 	implications: Implication[];
@@ -107,7 +107,7 @@ interface ReviewMediationProps {
 	postId?: EditorPostId;
 	/**
 	 * Server-built map keyed by reviewer display name. Optional — older
-	 * mediations or the empty-state payload may omit it; consumers degrade
+	 * reviews or the empty-state payload may omit it; consumers degrade
 	 * gracefully (fall back to the deterministic-colour pill).
 	 */
 	reviewers_metadata?: Record< string, ReviewerMetadata >;
@@ -291,10 +291,10 @@ function getConflictApplyUnavailableReason(
 
 /**
  * Main component.
- * @param {ReviewMediationProps} props - Structured mediation output.
+ * @param {AiEditorialReviewProps} props - Structured review output.
  * @returns {import('react').ReactElement} The rendered component.
  */
-export default function ReviewMediation( {
+export default function AiEditorialReview( {
 	summary,
 	conflicts,
 	implications,
@@ -304,7 +304,7 @@ export default function ReviewMediation( {
 	postId,
 	reviewers_metadata,
 	cached_at,
-}: ReviewMediationProps ) {
+}: AiEditorialReviewProps ) {
 	// Review actions are only safe when the result can be tied to the current editor entity.
 	const currentPostId = useSelect( ( select ) => {
 		const editor = select( 'core/editor' ) as WpCurrentPostStore;
@@ -387,7 +387,7 @@ export default function ReviewMediation( {
 	);
 
 	// Flat pre-order list of blocks; ability's `block_index` maps to this array.
-	// Matches wpcom's recursive Review_Mediator_Ability::extract_blocks() order.
+	// Matches wpcom's recursive AI_Editorial_Review_Ability::extract_blocks() order.
 	const blocks = useSelect( ( select ) => {
 		const contentBlocks = getEditorContentBlocks(
 			select( 'core/block-editor' ) as BlockEditorStore,
@@ -458,7 +458,7 @@ export default function ReviewMediation( {
 		clearActiveBlockFocusUnlessBlockReferenceClick( event.target );
 	}, [] );
 
-	// Clear sidebar-created block focus when the mediation session ends.
+	// Clear sidebar-created block focus when the review session ends.
 	useEffect( () => {
 		return () => {
 			clearActiveBlockFocus();
@@ -520,12 +520,12 @@ export default function ReviewMediation( {
 				}
 				if ( result?.error ) {
 					// eslint-disable-next-line no-console
-					console.warn( '[ReviewMediation] applyReviewEdit failed', result.error );
+					console.warn( '[AiEditorialReview] applyReviewEdit failed', result.error );
 				}
 				return { success: false };
 			} catch ( err ) {
 				// eslint-disable-next-line no-console
-				console.warn( '[ReviewMediation] applyReviewEdit threw', err );
+				console.warn( '[AiEditorialReview] applyReviewEdit threw', err );
 				return { success: false };
 			}
 		},
@@ -983,12 +983,12 @@ export default function ReviewMediation( {
 
 	return (
 		<div
-			className={ `jetpack-ai-review-mediation${ isPostStale ? ' is-post-stale' : '' }` }
+			className={ `jetpack-ai-editorial-review${ isPostStale ? ' is-post-stale' : '' }` }
 			aria-disabled={ isPostStale || undefined }
 			onMouseDownCapture={ handleRootMouseDown }
 		>
 			{ isPostStale && (
-				<p className="jetpack-ai-review-mediation__stale-warning" role="note">
+				<p className="jetpack-ai-editorial-review__stale-warning" role="note">
 					{ __(
 						'Review context changed. Start a new chat and re-run this review.',
 						__i18n_text_domain__
@@ -1003,19 +1003,19 @@ export default function ReviewMediation( {
 			 * so they stay informational `<li>`s.
 			 */ }
 			<ul
-				className="jetpack-ai-review-mediation__stats"
+				className="jetpack-ai-editorial-review__stats"
 				aria-label={ __( 'Review stats', __i18n_text_domain__ ) }
 			>
 				{ conflicts.length > 0 && (
 					<li>
 						<button
 							type="button"
-							className="jetpack-ai-review-mediation__stat is-conflicts is-clickable"
+							className="jetpack-ai-editorial-review__stat is-conflicts is-clickable"
 							disabled={ isPostStale }
 							onClick={ () => handleStatClick( 'conflicts' ) }
 							title={ __( 'Jump to conflicts', __i18n_text_domain__ ) }
 						>
-							<span className="jetpack-ai-review-mediation__stat-count">{ conflicts.length }</span>{ ' ' }
+							<span className="jetpack-ai-editorial-review__stat-count">{ conflicts.length }</span>{ ' ' }
 							{ _n( 'conflict', 'conflicts', conflicts.length, __i18n_text_domain__ ) }
 						</button>
 					</li>
@@ -1024,12 +1024,12 @@ export default function ReviewMediation( {
 					<li>
 						<button
 							type="button"
-							className="jetpack-ai-review-mediation__stat is-clickable"
+							className="jetpack-ai-editorial-review__stat is-clickable"
 							disabled={ isPostStale }
 							onClick={ () => handleStatClick( 'implications' ) }
 							title={ __( 'Jump to implications', __i18n_text_domain__ ) }
 						>
-							<span className="jetpack-ai-review-mediation__stat-count">
+							<span className="jetpack-ai-editorial-review__stat-count">
 								{ implications.length }
 							</span>{ ' ' }
 							{ _n( 'implication', 'implications', implications.length, __i18n_text_domain__ ) }
@@ -1040,12 +1040,12 @@ export default function ReviewMediation( {
 					<li>
 						<button
 							type="button"
-							className="jetpack-ai-review-mediation__stat is-clickable"
+							className="jetpack-ai-editorial-review__stat is-clickable"
 							disabled={ isPostStale }
 							onClick={ () => handleStatClick( 'edits' ) }
 							title={ __( 'Jump to suggested edits', __i18n_text_domain__ ) }
 						>
-							<span className="jetpack-ai-review-mediation__stat-count">
+							<span className="jetpack-ai-editorial-review__stat-count">
 								{ suggested_edits.length }
 							</span>{ ' ' }
 							{ _n( 'edit', 'edits', suggested_edits.length, __i18n_text_domain__ ) }
@@ -1056,12 +1056,12 @@ export default function ReviewMediation( {
 					<li>
 						<button
 							type="button"
-							className="jetpack-ai-review-mediation__stat is-clickable"
+							className="jetpack-ai-editorial-review__stat is-clickable"
 							disabled={ isPostStale }
 							onClick={ () => handleStatClick( 'violations' ) }
 							title={ __( 'Jump to guideline violations', __i18n_text_domain__ ) }
 						>
-							<span className="jetpack-ai-review-mediation__stat-count">
+							<span className="jetpack-ai-editorial-review__stat-count">
 								{ renderedGuidelineViolations.length }
 							</span>{ ' ' }
 							{ _n(
@@ -1074,20 +1074,20 @@ export default function ReviewMediation( {
 					</li>
 				) }
 				{ acceptedCount > 0 && (
-					<li className="jetpack-ai-review-mediation__stat is-accepted">
-						<span className="jetpack-ai-review-mediation__stat-count">{ acceptedCount }</span>{ ' ' }
+					<li className="jetpack-ai-editorial-review__stat is-accepted">
+						<span className="jetpack-ai-editorial-review__stat-count">{ acceptedCount }</span>{ ' ' }
 						{ __( 'accepted', __i18n_text_domain__ ) }
 					</li>
 				) }
 				{ dismissedCount > 0 && (
-					<li className="jetpack-ai-review-mediation__stat is-dismissed">
-						<span className="jetpack-ai-review-mediation__stat-count">{ dismissedCount }</span>{ ' ' }
+					<li className="jetpack-ai-editorial-review__stat is-dismissed">
+						<span className="jetpack-ai-editorial-review__stat-count">{ dismissedCount }</span>{ ' ' }
 						{ __( 'dismissed', __i18n_text_domain__ ) }
 					</li>
 				) }
 			</ul>
 
-			<Panel className="jetpack-ai-review-mediation__panel">
+			<Panel className="jetpack-ai-editorial-review__panel">
 				<div
 					ref={ ( el ) => {
 						sectionRefs.current.summary = el;
@@ -1095,14 +1095,14 @@ export default function ReviewMediation( {
 				>
 					<PanelBody
 						title={ __( 'Review summary', __i18n_text_domain__ ) }
-						className="jetpack-ai-review-mediation__summary"
+						className="jetpack-ai-editorial-review__summary"
 						opened={ openSections.summary }
 						onToggle={ ( next: boolean ) => setSectionOpen( 'summary', next ) }
 					>
 						<p>{ summary }</p>
 						{ cached_at && (
 							<p
-								className="jetpack-ai-review-mediation__cached-hint"
+								className="jetpack-ai-editorial-review__cached-hint"
 								title={ __(
 									'The inputs (post content, notes, comments, guidelines) have not changed since the previous run, so the saved result is being reused to avoid a duplicate LLM call.',
 									__i18n_text_domain__
@@ -1128,7 +1128,7 @@ export default function ReviewMediation( {
 							>
 								<PanelBody
 									title={ __( 'Conflicts', __i18n_text_domain__ ) }
-									className="jetpack-ai-review-mediation__conflicts"
+									className="jetpack-ai-editorial-review__conflicts"
 									opened={ openSections.conflicts }
 									onToggle={ ( next: boolean ) => setSectionOpen( 'conflicts', next ) }
 								>
@@ -1178,22 +1178,22 @@ export default function ReviewMediation( {
 											: getConflictApplyUnavailableReason(
 													candidateStates.map( ( state ) => state.disabledReason )
 											  ) || __( 'Needs manual edit.', __i18n_text_domain__ );
-										const applyUnavailableReasonId = `review-mediation-conflict-${ i }-apply-reason`;
+										const applyUnavailableReasonId = `ai-editorial-review-conflict-${ i }-apply-reason`;
 										const isResolved = status === 'accepted' || status === 'dismissed';
 										if ( isResolved ) {
 											return (
 												<article
-													className={ `jetpack-ai-review-mediation__conflict-card is-${ status } is-resolved` }
+													className={ `jetpack-ai-editorial-review__conflict-card is-${ status } is-resolved` }
 													key={ `conflict-${ i }` }
 												>
-													<header className="jetpack-ai-review-mediation__conflict-header">
+													<header className="jetpack-ai-editorial-review__conflict-header">
 														<span
-															className="jetpack-ai-review-mediation__conflict-icon"
+															className="jetpack-ai-editorial-review__conflict-icon"
 															aria-hidden="true"
 														>
 															⚠
 														</span>
-														<h4 className="jetpack-ai-review-mediation__conflict-title">
+														<h4 className="jetpack-ai-editorial-review__conflict-title">
 															{ conflict.subject }
 														</h4>
 														{ headerBlockIndex !== null && (
@@ -1201,17 +1201,17 @@ export default function ReviewMediation( {
 																index={ headerBlockIndex }
 																blocks={ blocks }
 																onFocus={ focusCurrentPostBlock }
-																className="jetpack-ai-review-mediation__conflict-block-ref"
+																className="jetpack-ai-editorial-review__conflict-block-ref"
 															/>
 														) }
 													</header>
-													<div className="jetpack-ai-review-mediation__actions">
+													<div className="jetpack-ai-editorial-review__actions">
 														<span
-															className={ `jetpack-ai-review-mediation__resolution is-${ status }` }
+															className={ `jetpack-ai-editorial-review__resolution is-${ status }` }
 														>
 															{ status === 'accepted' && (
 																<Icon
-																	className="jetpack-ai-review-mediation__resolution-check"
+																	className="jetpack-ai-editorial-review__resolution-check"
 																	icon={ check }
 																	size={ 20 }
 																/>
@@ -1222,7 +1222,7 @@ export default function ReviewMediation( {
 														</span>
 														<button
 															type="button"
-															className="jetpack-ai-review-mediation__resolution-undo"
+															className="jetpack-ai-editorial-review__resolution-undo"
 															disabled={ isPostStale || bulkRunning }
 															onClick={ () => handleUndoConflict( i ) }
 															title={
@@ -1235,7 +1235,7 @@ export default function ReviewMediation( {
 															}
 														>
 															<Icon
-																className="jetpack-ai-review-mediation__undo-icon"
+																className="jetpack-ai-editorial-review__undo-icon"
 																icon={ undo }
 																size={ 20 }
 															/>
@@ -1247,17 +1247,17 @@ export default function ReviewMediation( {
 										}
 										return (
 											<article
-												className={ `jetpack-ai-review-mediation__conflict-card is-${ status }` }
+												className={ `jetpack-ai-editorial-review__conflict-card is-${ status }` }
 												key={ `conflict-${ i }` }
 											>
-												<header className="jetpack-ai-review-mediation__conflict-header">
+												<header className="jetpack-ai-editorial-review__conflict-header">
 													<span
-														className="jetpack-ai-review-mediation__conflict-icon"
+														className="jetpack-ai-editorial-review__conflict-icon"
 														aria-hidden="true"
 													>
 														⚠
 													</span>
-													<h4 className="jetpack-ai-review-mediation__conflict-title">
+													<h4 className="jetpack-ai-editorial-review__conflict-title">
 														{ conflict.subject }
 													</h4>
 													{ headerBlockIndex !== null && (
@@ -1265,21 +1265,21 @@ export default function ReviewMediation( {
 															index={ headerBlockIndex }
 															blocks={ blocks }
 															onFocus={ focusCurrentPostBlock }
-															className="jetpack-ai-review-mediation__conflict-block-ref"
+															className="jetpack-ai-editorial-review__conflict-block-ref"
 														/>
 													) }
 												</header>
-												<ul className="jetpack-ai-review-mediation__positions">
+												<ul className="jetpack-ai-editorial-review__positions">
 													{ conflict.positions.map( ( pos, j ) => (
 														<li
-															className="jetpack-ai-review-mediation__position"
+															className="jetpack-ai-editorial-review__position"
 															key={ `pos-${ i }-${ j }` }
 														>
 															<ReviewerChip
 																name={ pos.reviewer }
 																metadata={ getReviewerMetadata( pos.reviewer ) }
 															/>
-															<span className="jetpack-ai-review-mediation__position-text">
+															<span className="jetpack-ai-editorial-review__position-text">
 																{ pos.position }
 															</span>
 														</li>
@@ -1287,18 +1287,18 @@ export default function ReviewMediation( {
 												</ul>
 
 												{ ( aiCandidate || conflict.recommended_resolution ) && (
-													<div className="jetpack-ai-review-mediation__ai-inset">
-														<p className="jetpack-ai-review-mediation__ai-label">
-															<span className="jetpack-ai-review-mediation__ai-badge">
+													<div className="jetpack-ai-editorial-review__ai-inset">
+														<p className="jetpack-ai-editorial-review__ai-label">
+															<span className="jetpack-ai-editorial-review__ai-badge">
 																{ __( 'AI', __i18n_text_domain__ ) }
 															</span>{ ' ' }
 															{ __( 'Recommended resolution', __i18n_text_domain__ ) }
 														</p>
-														<p className="jetpack-ai-review-mediation__ai-text">
+														<p className="jetpack-ai-editorial-review__ai-text">
 															{ aiCandidate?.text || conflict.recommended_resolution }
 														</p>
 														{ conflict.guideline_anchor && (
-															<blockquote className="jetpack-ai-review-mediation__guideline-anchor">
+															<blockquote className="jetpack-ai-editorial-review__guideline-anchor">
 																{ conflict.guideline_anchor }
 															</blockquote>
 														) }
@@ -1308,20 +1308,20 @@ export default function ReviewMediation( {
 												{ applyUnavailableReason && (
 													<p
 														id={ applyUnavailableReasonId }
-														className="jetpack-ai-review-mediation__status is-manual"
+														className="jetpack-ai-editorial-review__status is-manual"
 													>
 														{ applyUnavailableReason }
 													</p>
 												) }
 
-												<div className="jetpack-ai-review-mediation__conflict-resolution">
+												<div className="jetpack-ai-editorial-review__conflict-resolution">
 													{ reviewerCandidateStates.length > 0 && (
-														<div className="jetpack-ai-review-mediation__conflict-candidates">
+														<div className="jetpack-ai-editorial-review__conflict-candidates">
 															{ reviewerCandidateStates.map( ( { candidate }, k ) => {
 																return (
 																	<button
 																		type="button"
-																		className="jetpack-ai-review-mediation__action is-reviewer"
+																		className="jetpack-ai-editorial-review__action is-reviewer"
 																		key={ `candidate-${ i }-${ k }` }
 																		disabled={ actionsDisabled }
 																		onClick={ () => handleAcceptCandidate( i, candidate ) }
@@ -1336,11 +1336,11 @@ export default function ReviewMediation( {
 															} ) }
 														</div>
 													) }
-													<div className="jetpack-ai-review-mediation__actions">
+													<div className="jetpack-ai-editorial-review__actions">
 														{ aiCandidate && (
 															<button
 																type="button"
-																className="jetpack-ai-review-mediation__action is-accept"
+																className="jetpack-ai-editorial-review__action is-accept"
 																disabled={ actionsDisabled }
 																onClick={ () => handleAcceptCandidate( i, aiCandidate ) }
 															>
@@ -1349,7 +1349,7 @@ export default function ReviewMediation( {
 														) }
 														<button
 															type="button"
-															className="jetpack-ai-review-mediation__action is-dismiss"
+															className="jetpack-ai-editorial-review__action is-dismiss"
 															disabled={ actionsDisabled }
 															onClick={ () => handleDismissConflict( i ) }
 														>
@@ -1374,7 +1374,7 @@ export default function ReviewMediation( {
 							>
 								<PanelBody
 									title={ __( 'Implications', __i18n_text_domain__ ) }
-									className="jetpack-ai-review-mediation__implications"
+									className="jetpack-ai-editorial-review__implications"
 									opened={ openSections.implications }
 									onToggle={ ( next: boolean ) => setSectionOpen( 'implications', next ) }
 								>
@@ -1383,7 +1383,7 @@ export default function ReviewMediation( {
 											<li key={ `imp-${ i }` }>
 												<strong>{ imp.change }</strong> — { imp.implies }
 												{ imp.affected_blocks.length > 0 && (
-													<span className="jetpack-ai-review-mediation__affected-blocks">
+													<span className="jetpack-ai-editorial-review__affected-blocks">
 														{ ' ' }
 														{ __( 'Affects:', __i18n_text_domain__ ) }{ ' ' }
 														{ imp.affected_blocks.map( ( b, j ) => (
@@ -1413,7 +1413,7 @@ export default function ReviewMediation( {
 							>
 								<PanelBody
 									title={ __( 'Suggested edits', __i18n_text_domain__ ) }
-									className="jetpack-ai-review-mediation__edits"
+									className="jetpack-ai-editorial-review__edits"
 									opened={ openSections.edits }
 									onToggle={ ( next: boolean ) => setSectionOpen( 'edits', next ) }
 								>
@@ -1497,7 +1497,7 @@ export default function ReviewMediation( {
 										}
 										const footer =
 											edit.supported_by_reviewers.length > 0 ? (
-												<p className="jetpack-ai-review-mediation__reviewers">
+												<p className="jetpack-ai-editorial-review__reviewers">
 													{ __( 'Requested by:', __i18n_text_domain__ ) }{ ' ' }
 													{ edit.supported_by_reviewers.map( ( r, j ) => (
 														<span key={ `edit-${ i }-rev-${ j }` }>
@@ -1564,7 +1564,7 @@ export default function ReviewMediation( {
 										__( 'Guideline violations', __i18n_text_domain__ ),
 										renderedGuidelineViolations.length
 									) }
-									className="jetpack-ai-review-mediation__violations"
+									className="jetpack-ai-editorial-review__violations"
 									opened={ openSections.violations }
 									onToggle={ ( next: boolean ) => setSectionOpen( 'violations', next ) }
 								>
@@ -1642,10 +1642,10 @@ export default function ReviewMediation( {
 			</Panel>
 
 			{ totalPendingCount > 0 && (
-				<footer className="jetpack-ai-review-mediation__footer">
+				<footer className="jetpack-ai-editorial-review__footer">
 					<button
 						type="button"
-						className="jetpack-ai-review-mediation__footer-action is-accept"
+						className="jetpack-ai-editorial-review__footer-action is-accept"
 						disabled={ isPostStale || bulkRunning || totalPendingCount === 0 }
 						onClick={ handleAcceptAllAi }
 					>

--- a/packages/jetpack-ai-sidebar/src/components/block-ref.scss
+++ b/packages/jetpack-ai-sidebar/src/components/block-ref.scss
@@ -1,5 +1,5 @@
 // Base styles shared by every BlockRef consumer (Generate Feedback / Proofreader
-// via FeedbackList, and AER via review-mediation). The block-type icon is added
+// via FeedbackList, and AI Editorial Review). The block-type icon is added
 // by BlockRef itself, so give it a sensible default size + alignment here;
 // per-surface stylesheets can override (FeedbackList uses a larger pill icon).
 .jetpack-ai-block-ref__icon {

--- a/packages/jetpack-ai-sidebar/src/components/block-ref.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/block-ref.tsx
@@ -34,9 +34,9 @@ export interface BlockSnapshot {
 }
 
 interface BlockRefProps {
-	/** 0-based block index from the mediation payload. Null = post-wide. */
+	/** 0-based block index from the review payload. Null = post-wide. */
 	index: number | null;
-	/** Flat pre-order block list from the mediator/editor block tree. */
+	/** Flat pre-order block list from the review/editor block tree. */
 	blocks: BlockSnapshot[];
 	/** Called on click for in-bounds refs; a no-op when out of bounds. */
 	onFocus?: ( index: number ) => void;

--- a/packages/jetpack-ai-sidebar/src/components/reviewer-chip.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/reviewer-chip.tsx
@@ -13,7 +13,7 @@ export interface ReviewerMetadata {
 }
 
 interface ReviewerChipProps {
-	/** The display name exactly as it appears in the mediation payload. */
+	/** The display name exactly as it appears in the review payload. */
 	name: string;
 	/** Server-provided metadata keyed by name; may be missing for some reviewers. */
 	metadata?: ReviewerMetadata | null;

--- a/packages/jetpack-ai-sidebar/src/extensions/block-toolbar-extension.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/extensions/block-toolbar-extension.test.tsx
@@ -156,7 +156,7 @@ describe( 'withJetpackAiToolbarButton', () => {
 
 	it.each( [
 		[ 'preview is disabled', { blockTransformations: true, blockToolbarButton: true }, false ],
-		[ 'only editorial review is enabled', { aiEditorialReview: true }, true ],
+		[ 'only AI Editorial Review is enabled', { aiEditorialReview: true }, true ],
 		[ 'toolbar button is missing', { blockTransformations: true }, true ],
 		[
 			'toolbar button is disabled',

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -10,11 +10,11 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { act, fireEvent, render } from '@testing-library/react';
 import React from 'react';
+import AiEditorialReview from './components/ai-editorial-review';
 import ExcerptPicker from './components/excerpt-picker';
 import ImageAltTextPicker from './components/image-alt-text-picker';
 import PostFeedback from './components/post-feedback';
 import Proofread from './components/proofread';
-import ReviewMediation from './components/review-mediation';
 import SeoDescriptionPicker from './components/seo-description-picker';
 import SeoTitlePicker from './components/seo-title-picker';
 import TitlePicker from './components/title-picker';
@@ -59,6 +59,11 @@ let mockBlocksByClientId: Record< string, any > = {};
 let mockEditorBlocks: any[] = [];
 const SHOW_COMPONENT_TOOL_ID = 'jetpack_ai__show_component';
 const LEGACY_SHOW_COMPONENT_TOOL_ID = 'big_sky__show_component';
+const AI_EDITORIAL_REVIEW_CONTRACT_ENTRY = {
+	id: 'ai-editorial-review-contract',
+	type: 'ai-editorial-review-contract',
+	data: { version: 2 },
+};
 
 function appendRootBlockListLayout( doc: Document = document ): HTMLElement {
 	const layout = doc.createElement( 'div' );
@@ -321,6 +326,68 @@ function getTracksCalls( eventName: string ) {
 describe( 'contextProvider.getClientContext', () => {
 	afterEach( () => {
 		delete ( globalThis as any ).agentsManagerData;
+		delete ( window as any ).wp;
+		mockSelectedBlock = null;
+	} );
+
+	it( 'advertises AI Editorial Review contract version 2 alongside selected block context', () => {
+		installPostTypeMock( 'post' );
+
+		expect( contextProvider.getClientContext().contextEntries ).toEqual( [
+			{
+				id: 'selected-block-content',
+				type: 'selected-block-content',
+				data: null,
+			},
+			AI_EDITORIAL_REVIEW_CONTRACT_ENTRY,
+		] );
+	} );
+
+	it( 'advertises the contract independently of AI Editorial Review availability', () => {
+		installAiEditorialReviewData( { aiEditorialReview: false } );
+		expect( contextProvider.getClientContext().contextEntries ).toContainEqual(
+			AI_EDITORIAL_REVIEW_CONTRACT_ENTRY
+		);
+
+		delete ( globalThis as any ).agentsManagerData;
+		expect( contextProvider.getClientContext().contextEntries ).toContainEqual(
+			AI_EDITORIAL_REVIEW_CONTRACT_ENTRY
+		);
+	} );
+
+	it( 'returns one fresh contract entry with every client context', () => {
+		const firstEntries = contextProvider.getClientContext().contextEntries;
+		const secondEntries = contextProvider.getClientContext().contextEntries;
+
+		expect( firstEntries ).not.toBe( secondEntries );
+		expect(
+			firstEntries.filter(
+				( entry: { id: string } ) => entry.id === AI_EDITORIAL_REVIEW_CONTRACT_ENTRY.id
+			)
+		).toHaveLength( 1 );
+		expect(
+			secondEntries.filter(
+				( entry: { id: string } ) => entry.id === AI_EDITORIAL_REVIEW_CONTRACT_ENTRY.id
+			)
+		).toHaveLength( 1 );
+	} );
+
+	it( 'keeps selected block content beside the contract entry', () => {
+		mockSelectedBlock = {
+			clientId: 'selected-block',
+			name: 'core/paragraph',
+			attributes: { content: 'Selected paragraph' },
+		};
+		installPostTypeMock( 'post' );
+
+		expect( contextProvider.getClientContext().contextEntries ).toEqual( [
+			{
+				id: 'selected-block-content',
+				type: 'selected-block-content',
+				data: { content: 'Selected paragraph' },
+			},
+			AI_EDITORIAL_REVIEW_CONTRACT_ENTRY,
+		] );
 	} );
 
 	it( 'forwards jetpackSEOSuggestionsEnabled = true when the host enables SEO suggestions', () => {
@@ -343,8 +410,12 @@ describe( 'getChatComponent', () => {
 		expect( getChatComponent( 'title-picker' ) ).toBe( TitlePicker );
 	} );
 
-	it( 'returns ReviewMediation for type "review-mediation"', () => {
-		expect( getChatComponent( 'review-mediation' ) ).toBe( ReviewMediation );
+	it( 'returns AiEditorialReview for type "ai-editorial-review"', () => {
+		expect( getChatComponent( 'ai-editorial-review' ) ).toBe( AiEditorialReview );
+	} );
+
+	it( 'does not register the legacy AI Editorial Review component type', () => {
+		expect( getChatComponent( 'review-mediation' ) ).toBeNull();
 	} );
 
 	it( 'returns PostFeedback for type "post-feedback"', () => {
@@ -1630,26 +1701,40 @@ describe( 'getEmptyViewSuggestions', () => {
 	it( 'hides post suggestions without a sidebar config', () => {
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 		expect( labels ).not.toContain( 'Optimize Title' );
-		expect( labels ).not.toContain( 'Editorial Review' );
+		expect( labels ).not.toContain( 'AI Editorial Review' );
 	} );
 
-	it( 'shows Editorial Review when enabled by agentsManagerData', () => {
+	it( 'returns one canonical AI Editorial Review suggestion', () => {
+		installAiEditorialReviewData();
+		installPostTypeMock( 'post' );
+
+		const suggestions = getEmptyViewSuggestions();
+		const aiEditorialReviewSuggestions = suggestions.filter(
+			( suggestion ) => suggestion.id === 'ai-editorial-review'
+		);
+
+		expect( aiEditorialReviewSuggestions ).toEqual( [
+			expect.objectContaining( { label: 'AI Editorial Review' } ),
+		] );
+	} );
+
+	it( 'shows AI Editorial Review when enabled by agentsManagerData', () => {
 		installAiEditorialReviewData();
 		installPostTypeMock( 'post' );
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 		expect( labels ).not.toContain( 'Optimize Title' );
-		expect( labels ).toContain( 'Editorial Review' );
+		expect( labels ).toContain( 'AI Editorial Review' );
 		expect( labels ).toContain( 'Simple Review' );
 	} );
 
-	it( 'shows Editorial Review on page editors', () => {
+	it( 'shows AI Editorial Review on page editors', () => {
 		installAiEditorialReviewData();
 		installPostTypeMock( 'page' );
 
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
 		expect( labels ).not.toContain( 'Optimize Title' );
-		expect( labels ).toContain( 'Editorial Review' );
+		expect( labels ).toContain( 'AI Editorial Review' );
 		expect( labels ).toContain( 'Simple Review' );
 	} );
 
@@ -1668,7 +1753,7 @@ describe( 'getEmptyViewSuggestions', () => {
 			'Generate Excerpt',
 			'Simple Review',
 			'Proofread',
-			'Editorial Review',
+			'AI Editorial Review',
 		] );
 	} );
 
@@ -1689,14 +1774,14 @@ describe( 'getEmptyViewSuggestions', () => {
 		}
 	);
 
-	it( 'hides Editorial Review until the post type is known', () => {
+	it( 'hides AI Editorial Review until the post type is known', () => {
 		installAiEditorialReviewData();
 		installPostTypeMock();
 
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
 		expect( labels ).not.toContain( 'Optimize Title' );
-		expect( labels ).not.toContain( 'Editorial Review' );
+		expect( labels ).not.toContain( 'AI Editorial Review' );
 	} );
 
 	it( 'hides Simple Review until the editor entity has a saved ID', () => {
@@ -1706,7 +1791,7 @@ describe( 'getEmptyViewSuggestions', () => {
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
 		expect( labels ).not.toContain( 'Simple Review' );
-		expect( labels ).toContain( 'Editorial Review' );
+		expect( labels ).toContain( 'AI Editorial Review' );
 	} );
 
 	it( 'hides Simple Review when the preview feature disables it', () => {
@@ -1716,7 +1801,7 @@ describe( 'getEmptyViewSuggestions', () => {
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
 		expect( labels ).not.toContain( 'Simple Review' );
-		expect( labels ).toContain( 'Editorial Review' );
+		expect( labels ).toContain( 'AI Editorial Review' );
 	} );
 
 	it( 'hides Proofread by default and shows it when the preview feature enables it', () => {
@@ -1749,7 +1834,7 @@ describe( 'getEmptyViewSuggestions', () => {
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
 		expect( labels ).not.toContain( 'Optimize Title' );
-		expect( labels ).not.toContain( 'Editorial Review' );
+		expect( labels ).not.toContain( 'AI Editorial Review' );
 	} );
 
 	it( 'treats missing features as disabled', () => {
@@ -1764,7 +1849,7 @@ describe( 'getEmptyViewSuggestions', () => {
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
 		expect( labels ).not.toContain( 'Optimize Title' );
-		expect( labels ).toContain( 'Editorial Review' );
+		expect( labels ).toContain( 'AI Editorial Review' );
 		expect( labels ).not.toContain( 'Simple Review' );
 	} );
 
@@ -1785,7 +1870,7 @@ describe( 'getEmptyViewSuggestions', () => {
 			'Optimize Title',
 			'Proofread',
 			'Simple Review',
-			'Editorial Review',
+			'AI Editorial Review',
 			'SEO Enhancer',
 			'Generate Excerpt',
 		].forEach( ( label ) => {
@@ -2188,7 +2273,7 @@ describe( 'useSuggestions', () => {
 			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
 		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
 			'Simple Review',
-			'Editorial Review',
+			'AI Editorial Review',
 		] );
 	} );
 
@@ -2244,7 +2329,7 @@ describe( 'useSuggestions', () => {
 		const latestSuggestions =
 			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
 		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
-			'Editorial Review',
+			'AI Editorial Review',
 		] );
 	} );
 
@@ -2299,7 +2384,7 @@ describe( 'useSuggestions', () => {
 		expect( mockSetIsSplitScreen ).not.toHaveBeenCalled();
 	} );
 
-	it( 'does not open split-screen when the Editorial Review suggestion is clicked', () => {
+	it( 'does not open split-screen when the AI Editorial Review suggestion is clicked', () => {
 		installAiEditorialReviewData();
 		installPostTypeMock( 'post' );
 		render( React.createElement( SuggestionsProbe, { onSuggestions: jest.fn() } ) );
@@ -2307,7 +2392,7 @@ describe( 'useSuggestions', () => {
 		act( () => {
 			window.dispatchEvent(
 				new CustomEvent( 'big-sky-inline-suggestion-click', {
-					detail: { suggestionId: 'mediate-review-notes' },
+					detail: { suggestionId: 'ai-editorial-review' },
 				} )
 			);
 		} );
@@ -2375,7 +2460,7 @@ describe( 'useSuggestions', () => {
 		} );
 	} );
 
-	it( 'does not open split-screen when Editorial Review is unavailable', () => {
+	it( 'does not open split-screen when AI Editorial Review is unavailable', () => {
 		installAiEditorialReviewData();
 		mockCurrentPostType = 'product';
 		installPostTypeMock( 'product' );
@@ -2385,7 +2470,7 @@ describe( 'useSuggestions', () => {
 		act( () => {
 			window.dispatchEvent(
 				new CustomEvent( 'big-sky-inline-suggestion-click', {
-					detail: { suggestionId: 'mediate-review-notes' },
+					detail: { suggestionId: 'ai-editorial-review' },
 				} )
 			);
 		} );
@@ -2550,6 +2635,7 @@ describe( 'contextProvider', () => {
 		const feedbackContext = contextProvider.getClientContext();
 		expect( feedbackContext.currentPageContent ).toEqual( [] );
 		expect( feedbackContext.jetpackAi ).toBeUndefined();
+		expect( feedbackContext.contextEntries ).toContainEqual( AI_EDITORIAL_REVIEW_CONTRACT_ENTRY );
 		expect( contextProvider.getClientContext().currentPageContent ).toHaveLength( 1 );
 		expect( contextProvider.getClientContext().jetpackAi ).toBeUndefined();
 	} );
@@ -2585,8 +2671,8 @@ describe( 'contextProvider', () => {
 		const feedbackPrompt = suggestions.find(
 			( suggestion ) => suggestion.id === 'generate-feedback'
 		)?.prompt;
-		const mediationPrompt = suggestions.find(
-			( suggestion ) => suggestion.id === 'mediate-review-notes'
+		const aiEditorialReviewPrompt = suggestions.find(
+			( suggestion ) => suggestion.id === 'ai-editorial-review'
 		)?.prompt;
 
 		render( React.createElement( SuggestionsProbe, { onSuggestions: jest.fn() } ) );
@@ -2599,7 +2685,10 @@ describe( 'contextProvider', () => {
 			);
 			window.dispatchEvent(
 				new CustomEvent( 'big-sky-inline-suggestion-click', {
-					detail: { value: mediationPrompt, suggestionId: 'mediate-review-notes' },
+					detail: {
+						value: aiEditorialReviewPrompt,
+						suggestionId: 'ai-editorial-review',
+					},
 				} )
 			);
 		} );
@@ -2837,7 +2926,7 @@ describe( 'toolProvider', () => {
 
 		it( 'accepts the legacy Big Sky show-component tool during migration', async () => {
 			const { result } = ( await toolProvider.executeAbility( LEGACY_SHOW_COMPONENT_TOOL_ID, {
-				type: 'review-mediation',
+				type: 'ai-editorial-review',
 				props: {
 					summary: 'Summary.',
 					conflicts: [],
@@ -2849,8 +2938,28 @@ describe( 'toolProvider', () => {
 
 			const parsed = JSON.parse( result.agentMessage );
 			expect( parsed.tool_id ).toBe( SHOW_COMPONENT_TOOL_ID );
-			expect( parsed.data.type ).toBe( 'review-mediation' );
+			expect( parsed.data.type ).toBe( 'ai-editorial-review' );
 		} );
+
+		it.each( [
+			[ 'Jetpack AI', SHOW_COMPONENT_TOOL_ID ],
+			[ 'legacy Big Sky', LEGACY_SHOW_COMPONENT_TOOL_ID ],
+		] )(
+			'rejects the old AI Editorial Review type through the %s tool',
+			async ( _label, toolId ) => {
+				const { result } = ( await toolProvider.executeAbility( toolId, {
+					type: 'review-mediation',
+					props: {},
+				} ) ) as any;
+
+				expect( result ).toMatchObject( {
+					success: false,
+					error: 'show-component: no component registered for type "review-mediation"',
+					returnToAgent: false,
+				} );
+				expect( result.agentMessage ).toBeUndefined();
+			}
+		);
 
 		it( 'delegates non-Jetpack legacy show-component calls to Big Sky', async () => {
 			const args = {
@@ -2889,9 +2998,9 @@ describe( 'toolProvider', () => {
 			expect( result.error ).toMatch( /missing type/ );
 		} );
 
-		it( 'does not attach a title checkpoint to review-mediation components', async () => {
+		it( 'does not attach a title checkpoint to AI Editorial Review components', async () => {
 			const { result } = ( await toolProvider.executeAbility( SHOW_COMPONENT_TOOL_ID, {
-				type: 'review-mediation',
+				type: 'ai-editorial-review',
 				props: {
 					summary: 'Summary.',
 					conflicts: [],
@@ -2899,16 +3008,36 @@ describe( 'toolProvider', () => {
 					suggested_edits: [],
 					guideline_violations: [],
 				},
-				toolCallId: 'call_review_mediation_123',
+				toolCallId: 'call_ai_editorial_review_123',
 			} ) ) as any;
 
 			const parsed = JSON.parse( result.agentMessage );
-			expect( parsed.data.type ).toBe( 'review-mediation' );
+			expect( parsed.data.type ).toBe( 'ai-editorial-review' );
 			expect( parsed.data.calypsoCheckpointId ).toBeUndefined();
 			expect( parsed.data.isCurrent ).toBe( true );
 			expect( parsed.data.hideZoomAction ).toBe( true );
 			expect( parsed.data.postId ).toBe( 123 );
 			expect( parsed.data.props.postId ).toBe( 123 );
+		} );
+
+		it( 'preserves the reviewed post ID on AI Editorial Review components', async () => {
+			const { result } = ( await toolProvider.executeAbility( SHOW_COMPONENT_TOOL_ID, {
+				type: 'ai-editorial-review',
+				props: {
+					summary: 'Summary.',
+					conflicts: [],
+					implications: [],
+					suggested_edits: [],
+					guideline_violations: [],
+					postId: 77,
+				},
+				toolCallId: 'call_ai_editorial_review_456',
+			} ) ) as any;
+
+			const parsed = JSON.parse( result.agentMessage );
+			expect( parsed.data.type ).toBe( 'ai-editorial-review' );
+			expect( parsed.data.postId ).toBe( 77 );
+			expect( parsed.data.props.postId ).toBe( 77 );
 		} );
 
 		it( 'stamps post-feedback components with the current editor entity ID', async () => {
@@ -2965,11 +3094,11 @@ describe( 'toolProvider', () => {
 			expect( parsed.data.props.postId ).toBe( 77 );
 		} );
 
-		it( 'does not stamp review-mediation components without a saved editor post ID', async () => {
+		it( 'does not stamp AI Editorial Review components without a saved editor post ID', async () => {
 			installWpDataMock( 'Original Title', 0 );
 
 			const { result } = ( await toolProvider.executeAbility( SHOW_COMPONENT_TOOL_ID, {
-				type: 'review-mediation',
+				type: 'ai-editorial-review',
 				props: {
 					summary: 'Summary.',
 					conflicts: [],
@@ -2980,7 +3109,7 @@ describe( 'toolProvider', () => {
 			} ) ) as any;
 
 			const parsed = JSON.parse( result.agentMessage );
-			expect( parsed.data.type ).toBe( 'review-mediation' );
+			expect( parsed.data.type ).toBe( 'ai-editorial-review' );
 			expect( parsed.data.postId ).toBeUndefined();
 			expect( parsed.data.props.postId ).toBeUndefined();
 		} );
@@ -3561,7 +3690,7 @@ describe( 'applyReviewEdit', () => {
 		} );
 		expect( blockUpdates ).toEqual( [] );
 		expect( warn ).toHaveBeenCalledWith(
-			'[ReviewMediation] currentText not found in block content',
+			'[AiEditorialReview] currentText not found in block content',
 			{ clientId: '550e8400-e29b-41d4-a716-446655440000' }
 		);
 		warn.mockRestore();
@@ -3592,7 +3721,7 @@ describe( 'applyReviewEdit', () => {
 		} );
 		expect( blockUpdates ).toEqual( [] );
 		expect( warn ).toHaveBeenCalledWith(
-			'[ReviewMediation] currentText not found in block content',
+			'[AiEditorialReview] currentText not found in block content',
 			{ clientId: '550e8400-e29b-41d4-a716-446655440000' }
 		);
 		warn.mockRestore();
@@ -3631,7 +3760,7 @@ describe( 'applyReviewEdit', () => {
 			} );
 			expect( blockUpdates ).toEqual( [] );
 			expect( warn ).toHaveBeenCalledWith(
-				'[ReviewMediation] currentText matches multiple spans in block content',
+				'[AiEditorialReview] currentText matches multiple spans in block content',
 				{ clientId: '550e8400-e29b-41d4-a716-446655440000' }
 			);
 			warn.mockRestore();

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -3689,10 +3689,9 @@ describe( 'applyReviewEdit', () => {
 			error: 'currentText not found in block content',
 		} );
 		expect( blockUpdates ).toEqual( [] );
-		expect( warn ).toHaveBeenCalledWith(
-			'[AiEditorialReview] currentText not found in block content',
-			{ clientId: '550e8400-e29b-41d4-a716-446655440000' }
-		);
+		expect( warn ).toHaveBeenCalledWith( '[Jetpack AI] currentText not found in block content', {
+			clientId: '550e8400-e29b-41d4-a716-446655440000',
+		} );
 		warn.mockRestore();
 	} );
 
@@ -3720,10 +3719,9 @@ describe( 'applyReviewEdit', () => {
 			error: 'currentText not found in block content',
 		} );
 		expect( blockUpdates ).toEqual( [] );
-		expect( warn ).toHaveBeenCalledWith(
-			'[AiEditorialReview] currentText not found in block content',
-			{ clientId: '550e8400-e29b-41d4-a716-446655440000' }
-		);
+		expect( warn ).toHaveBeenCalledWith( '[Jetpack AI] currentText not found in block content', {
+			clientId: '550e8400-e29b-41d4-a716-446655440000',
+		} );
 		warn.mockRestore();
 	} );
 
@@ -3760,7 +3758,7 @@ describe( 'applyReviewEdit', () => {
 			} );
 			expect( blockUpdates ).toEqual( [] );
 			expect( warn ).toHaveBeenCalledWith(
-				'[AiEditorialReview] currentText matches multiple spans in block content',
+				'[Jetpack AI] currentText matches multiple spans in block content',
 				{ clientId: '550e8400-e29b-41d4-a716-446655440000' }
 			);
 			warn.mockRestore();

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -1701,10 +1701,10 @@ describe( 'getEmptyViewSuggestions', () => {
 	it( 'hides post suggestions without a sidebar config', () => {
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 		expect( labels ).not.toContain( 'Optimize Title' );
-		expect( labels ).not.toContain( 'AI Editorial Review' );
+		expect( labels ).not.toContain( 'Editorial Review' );
 	} );
 
-	it( 'returns one canonical AI Editorial Review suggestion', () => {
+	it( 'returns one canonical AI Editorial Review suggestion with the existing UX label', () => {
 		installAiEditorialReviewData();
 		installPostTypeMock( 'post' );
 
@@ -1714,7 +1714,7 @@ describe( 'getEmptyViewSuggestions', () => {
 		);
 
 		expect( aiEditorialReviewSuggestions ).toEqual( [
-			expect.objectContaining( { label: 'AI Editorial Review' } ),
+			expect.objectContaining( { label: 'Editorial Review' } ),
 		] );
 	} );
 
@@ -1723,7 +1723,7 @@ describe( 'getEmptyViewSuggestions', () => {
 		installPostTypeMock( 'post' );
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 		expect( labels ).not.toContain( 'Optimize Title' );
-		expect( labels ).toContain( 'AI Editorial Review' );
+		expect( labels ).toContain( 'Editorial Review' );
 		expect( labels ).toContain( 'Simple Review' );
 	} );
 
@@ -1734,7 +1734,7 @@ describe( 'getEmptyViewSuggestions', () => {
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
 		expect( labels ).not.toContain( 'Optimize Title' );
-		expect( labels ).toContain( 'AI Editorial Review' );
+		expect( labels ).toContain( 'Editorial Review' );
 		expect( labels ).toContain( 'Simple Review' );
 	} );
 
@@ -1753,7 +1753,7 @@ describe( 'getEmptyViewSuggestions', () => {
 			'Generate Excerpt',
 			'Simple Review',
 			'Proofread',
-			'AI Editorial Review',
+			'Editorial Review',
 		] );
 	} );
 
@@ -1781,7 +1781,7 @@ describe( 'getEmptyViewSuggestions', () => {
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
 		expect( labels ).not.toContain( 'Optimize Title' );
-		expect( labels ).not.toContain( 'AI Editorial Review' );
+		expect( labels ).not.toContain( 'Editorial Review' );
 	} );
 
 	it( 'hides Simple Review until the editor entity has a saved ID', () => {
@@ -1791,7 +1791,7 @@ describe( 'getEmptyViewSuggestions', () => {
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
 		expect( labels ).not.toContain( 'Simple Review' );
-		expect( labels ).toContain( 'AI Editorial Review' );
+		expect( labels ).toContain( 'Editorial Review' );
 	} );
 
 	it( 'hides Simple Review when the preview feature disables it', () => {
@@ -1801,7 +1801,7 @@ describe( 'getEmptyViewSuggestions', () => {
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
 		expect( labels ).not.toContain( 'Simple Review' );
-		expect( labels ).toContain( 'AI Editorial Review' );
+		expect( labels ).toContain( 'Editorial Review' );
 	} );
 
 	it( 'hides Proofread by default and shows it when the preview feature enables it', () => {
@@ -1834,7 +1834,7 @@ describe( 'getEmptyViewSuggestions', () => {
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
 		expect( labels ).not.toContain( 'Optimize Title' );
-		expect( labels ).not.toContain( 'AI Editorial Review' );
+		expect( labels ).not.toContain( 'Editorial Review' );
 	} );
 
 	it( 'treats missing features as disabled', () => {
@@ -1849,7 +1849,7 @@ describe( 'getEmptyViewSuggestions', () => {
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
 		expect( labels ).not.toContain( 'Optimize Title' );
-		expect( labels ).toContain( 'AI Editorial Review' );
+		expect( labels ).toContain( 'Editorial Review' );
 		expect( labels ).not.toContain( 'Simple Review' );
 	} );
 
@@ -1870,7 +1870,7 @@ describe( 'getEmptyViewSuggestions', () => {
 			'Optimize Title',
 			'Proofread',
 			'Simple Review',
-			'AI Editorial Review',
+			'Editorial Review',
 			'SEO Enhancer',
 			'Generate Excerpt',
 		].forEach( ( label ) => {
@@ -2273,7 +2273,7 @@ describe( 'useSuggestions', () => {
 			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
 		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
 			'Simple Review',
-			'AI Editorial Review',
+			'Editorial Review',
 		] );
 	} );
 
@@ -2329,7 +2329,7 @@ describe( 'useSuggestions', () => {
 		const latestSuggestions =
 			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
 		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
-			'AI Editorial Review',
+			'Editorial Review',
 		] );
 	} );
 

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -15,6 +15,8 @@ import { __, _x } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import AiEditorialReview from './components/ai-editorial-review';
+import './components/ai-editorial-review.scss';
 import './components/block-ref.scss';
 import ExcerptPicker from './components/excerpt-picker';
 import './components/feedback-list.scss';
@@ -22,8 +24,6 @@ import ImageAltTextPicker from './components/image-alt-text-picker';
 import './components/image-alt-text-picker.scss';
 import PostFeedback from './components/post-feedback';
 import Proofread from './components/proofread';
-import ReviewMediation from './components/review-mediation';
-import './components/review-mediation.scss';
 import SeoDescriptionPicker from './components/seo-description-picker';
 import SeoTitlePicker from './components/seo-title-picker';
 import './components/base-suggestion-picker.scss';
@@ -154,15 +154,10 @@ const SEO_ENHANCER_SUGGESTION = {
 	],
 };
 
-/**
- * Editor-level suggestion to run AI Editorial Review on saved content.
- *
- * The id remains stable because saved chats/tests may still refer to the
- * original review-mediation identifier.
- */
+/** Editor-level suggestion to run AI Editorial Review on saved content. */
 const AI_EDITORIAL_REVIEW_SUGGESTION = {
-	id: 'mediate-review-notes',
-	label: __( 'Editorial Review', __i18n_text_domain__ ),
+	id: 'ai-editorial-review',
+	label: __( 'AI Editorial Review', __i18n_text_domain__ ),
 	description: __( 'In-depth review against your content guidelines.', __i18n_text_domain__ ),
 	prompt: __(
 		'Run an AI Editorial Review for this post. Check the content, reviewer notes, and site guidelines, then surface conflicts, implications, guideline issues, and suggested edits.',
@@ -469,7 +464,7 @@ function handleShowComponent( input: any ): any {
 		isCurrent: true,
 		hideZoomAction: true,
 	};
-	if ( type === 'review-mediation' || type === 'post-feedback' || type === 'proofread' ) {
+	if ( type === 'ai-editorial-review' || type === 'post-feedback' || type === 'proofread' ) {
 		const reviewedPostId =
 			normalizeEditorPostId( componentProps.postId ) ?? getCurrentEditorPostId();
 		if ( reviewedPostId ) {
@@ -786,6 +781,11 @@ export const contextProvider = {
 					type: 'selected-block-content',
 					data: selectedBlockContent ? { content: selectedBlockContent } : null,
 				},
+				{
+					id: 'ai-editorial-review-contract',
+					type: 'ai-editorial-review-contract',
+					data: { version: 2 },
+				},
 			],
 		};
 	},
@@ -814,8 +814,8 @@ export function getChatComponent( type: string ): ComponentType | null {
 	if ( type === 'image-alt-text-picker' ) {
 		return ImageAltTextPicker as ComponentType;
 	}
-	if ( type === 'review-mediation' ) {
-		return ReviewMediation as ComponentType;
+	if ( type === 'ai-editorial-review' ) {
+		return AiEditorialReview as ComponentType;
 	}
 	if ( type === 'post-feedback' ) {
 		return PostFeedback as ComponentType;

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -157,7 +157,7 @@ const SEO_ENHANCER_SUGGESTION = {
 /** Editor-level suggestion to run AI Editorial Review on saved content. */
 const AI_EDITORIAL_REVIEW_SUGGESTION = {
 	id: 'ai-editorial-review',
-	label: __( 'AI Editorial Review', __i18n_text_domain__ ),
+	label: __( 'Editorial Review', __i18n_text_domain__ ),
 	description: __( 'In-depth review against your content guidelines.', __i18n_text_domain__ ),
 	prompt: __(
 		'Run an AI Editorial Review for this post. Check the content, reviewer notes, and site guidelines, then surface conflicts, implications, guideline issues, and suggested edits.',

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -1,6 +1,6 @@
 /**
  * Block-action helpers and module state shared by the AM provider entry
- * (`../index`) and components (e.g. ReviewMediation). Lives here to break
+ * (`../index`) and components (e.g. AiEditorialReview). Lives here to break
  * the index ↔ component import cycle.
  */
 
@@ -130,7 +130,7 @@ function getAccessibleFrameDocuments(): Document[] {
 
 /**
  * Find a block element by clientId in the main document or editor iframe.
- * Exported so peer components (e.g. ReviewMediation) can scroll a block into
+ * Exported so peer components (e.g. AiEditorialReview) can scroll a block into
  * view on interaction.
  * @param {string} clientId - The block's clientId.
  * @returns The block element, or null.
@@ -627,7 +627,7 @@ export function handleUpdateBlockContent( input: any ): any {
 			const fallback = findBlockSnapshotByCurrentText( currentText, editableAttribute );
 			if ( fallback.error ) {
 				// eslint-disable-next-line no-console
-				console.warn( '[ReviewMediation] currentText matches multiple spans in block content', {
+				console.warn( '[AiEditorialReview] currentText matches multiple spans in block content', {
 					clientId,
 				} );
 				return {
@@ -640,7 +640,7 @@ export function handleUpdateBlockContent( input: any ): any {
 				targetClientId = fallback.snapshot.clientId;
 				snapshot = fallback.snapshot;
 				// eslint-disable-next-line no-console
-				console.warn( '[ReviewMediation] stale clientId matched by currentText', {
+				console.warn( '[AiEditorialReview] stale clientId matched by currentText', {
 					clientId,
 					targetClientId,
 				} );
@@ -666,7 +666,7 @@ export function handleUpdateBlockContent( input: any ): any {
 		const matchCount = countOccurrences( snapshot.content, currentText );
 		if ( matchCount === 0 ) {
 			// eslint-disable-next-line no-console
-			console.warn( '[ReviewMediation] currentText not found in block content', { clientId } );
+			console.warn( '[AiEditorialReview] currentText not found in block content', { clientId } );
 			return {
 				success: false,
 				error: 'currentText not found in block content',
@@ -675,7 +675,7 @@ export function handleUpdateBlockContent( input: any ): any {
 		}
 		if ( matchCount > 1 ) {
 			// eslint-disable-next-line no-console
-			console.warn( '[ReviewMediation] currentText matches multiple spans in block content', {
+			console.warn( '[AiEditorialReview] currentText matches multiple spans in block content', {
 				clientId,
 			} );
 			return {
@@ -727,7 +727,7 @@ export function handleUpdateBlockContent( input: any ): any {
 				const matchCount = countOccurrences( latestSnapshot.content, currentText );
 				if ( matchCount === 0 ) {
 					// eslint-disable-next-line no-console
-					console.warn( '[ReviewMediation] currentText not found in block content', {
+					console.warn( '[AiEditorialReview] currentText not found in block content', {
 						clientId: targetClientId,
 					} );
 					resolveFailure( 'currentText not found in block content' );
@@ -735,7 +735,7 @@ export function handleUpdateBlockContent( input: any ): any {
 				}
 				if ( matchCount > 1 ) {
 					// eslint-disable-next-line no-console
-					console.warn( '[ReviewMediation] currentText matches multiple spans in block content', {
+					console.warn( '[AiEditorialReview] currentText matches multiple spans in block content', {
 						clientId: targetClientId,
 					} );
 					resolveFailure( 'currentText matches multiple spans in block content' );
@@ -744,7 +744,7 @@ export function handleUpdateBlockContent( input: any ): any {
 				nextContent = latestSnapshot.content.replace( currentText, content );
 			} else if ( latestSnapshot.content !== snapshot.content ) {
 				// eslint-disable-next-line no-console
-				console.warn( '[ReviewMediation] block content changed while applying edit', {
+				console.warn( '[AiEditorialReview] block content changed while applying edit', {
 					clientId: targetClientId,
 				} );
 				resolveFailure( 'block content changed while applying edit' );
@@ -782,7 +782,7 @@ export function handleUpdateBlockContent( input: any ): any {
 }
 
 /**
- * Apply a mediation-suggested edit. When `currentText` is provided and uniquely
+ * Apply a review-suggested edit. When `currentText` is provided and uniquely
  * matches a span in the block, only that span is replaced. When it is missing or
  * ambiguous, the edit fails safely rather than replacing the whole block. Returns
  * `success: false` for unsupported edit targets so the UI can show 'failed' rather
@@ -818,7 +818,7 @@ export async function applyReviewEdit(
 }
 
 /**
- * Revert a block's content to a pre-accept snapshot. Used by ReviewMediation's
+ * Revert a block's content to a pre-accept snapshot. Used by AiEditorialReview's
  * per-card Undo to actually undo the mutation, not just flip UI state.
  * When `expectedContent` is supplied, only restore if the block still contains
  * the content this row applied. This avoids clobbering later accepted edits on

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -627,7 +627,7 @@ export function handleUpdateBlockContent( input: any ): any {
 			const fallback = findBlockSnapshotByCurrentText( currentText, editableAttribute );
 			if ( fallback.error ) {
 				// eslint-disable-next-line no-console
-				console.warn( '[AiEditorialReview] currentText matches multiple spans in block content', {
+				console.warn( '[Jetpack AI] currentText matches multiple spans in block content', {
 					clientId,
 				} );
 				return {
@@ -640,7 +640,7 @@ export function handleUpdateBlockContent( input: any ): any {
 				targetClientId = fallback.snapshot.clientId;
 				snapshot = fallback.snapshot;
 				// eslint-disable-next-line no-console
-				console.warn( '[AiEditorialReview] stale clientId matched by currentText', {
+				console.warn( '[Jetpack AI] stale clientId matched by currentText', {
 					clientId,
 					targetClientId,
 				} );
@@ -666,7 +666,7 @@ export function handleUpdateBlockContent( input: any ): any {
 		const matchCount = countOccurrences( snapshot.content, currentText );
 		if ( matchCount === 0 ) {
 			// eslint-disable-next-line no-console
-			console.warn( '[AiEditorialReview] currentText not found in block content', { clientId } );
+			console.warn( '[Jetpack AI] currentText not found in block content', { clientId } );
 			return {
 				success: false,
 				error: 'currentText not found in block content',
@@ -675,7 +675,7 @@ export function handleUpdateBlockContent( input: any ): any {
 		}
 		if ( matchCount > 1 ) {
 			// eslint-disable-next-line no-console
-			console.warn( '[AiEditorialReview] currentText matches multiple spans in block content', {
+			console.warn( '[Jetpack AI] currentText matches multiple spans in block content', {
 				clientId,
 			} );
 			return {
@@ -727,7 +727,7 @@ export function handleUpdateBlockContent( input: any ): any {
 				const matchCount = countOccurrences( latestSnapshot.content, currentText );
 				if ( matchCount === 0 ) {
 					// eslint-disable-next-line no-console
-					console.warn( '[AiEditorialReview] currentText not found in block content', {
+					console.warn( '[Jetpack AI] currentText not found in block content', {
 						clientId: targetClientId,
 					} );
 					resolveFailure( 'currentText not found in block content' );
@@ -735,7 +735,7 @@ export function handleUpdateBlockContent( input: any ): any {
 				}
 				if ( matchCount > 1 ) {
 					// eslint-disable-next-line no-console
-					console.warn( '[AiEditorialReview] currentText matches multiple spans in block content', {
+					console.warn( '[Jetpack AI] currentText matches multiple spans in block content', {
 						clientId: targetClientId,
 					} );
 					resolveFailure( 'currentText matches multiple spans in block content' );
@@ -744,7 +744,7 @@ export function handleUpdateBlockContent( input: any ): any {
 				nextContent = latestSnapshot.content.replace( currentText, content );
 			} else if ( latestSnapshot.content !== snapshot.content ) {
 				// eslint-disable-next-line no-console
-				console.warn( '[AiEditorialReview] block content changed while applying edit', {
+				console.warn( '[Jetpack AI] block content changed while applying edit', {
 					clientId: targetClientId,
 				} );
 				resolveFailure( 'block content changed while applying edit' );

--- a/packages/jetpack-ai-sidebar/src/utils/tracking.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tracking.ts
@@ -64,7 +64,7 @@ interface TrackBlockTransformationSuggestionOptions {
 }
 
 /**
- * Tracks the empty-view "AI Editorial Review" suggestion appearing.
+ * Tracks the AI Editorial Review empty-view suggestion appearing.
  */
 export function trackAiEditorialReviewSuggestionRendered(): void {
 	recordTracksEvent( 'ai_editorial_review_suggestion_rendered' );

--- a/packages/jetpack-ai-sidebar/src/utils/use-copy-to-clipboard.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/use-copy-to-clipboard.ts
@@ -2,7 +2,7 @@
  * Shared clipboard-copy state for review cards. Exposes whether the clipboard
  * API is available, which card currently shows "Copied", and a copy() that
  * flips that card to "Copied" for a couple of seconds. Used by both FeedbackList
- * (Generate Feedback / Proofreader) and review-mediation (AI Editorial Review).
+ * (Generate Feedback / Proofreader) and AI Editorial Review.
  * @package
  */
 


### PR DESCRIPTION
Part of FORNO-376.

Companion WPCOM stages:

- 228473-ghe-Automattic/wpcom — additive rename foundation.
- 228590-ghe-Automattic/wpcom — canonical server implementation and compatibility seams.
- 228621-ghe-Automattic/wpcom — versioned contract negotiation and canonical cutover architecture.
- 228900-ghe-Automattic/wpcom — production activation of contract negotiation.

## Proposed Changes

* Rename the feature-owned `ReviewMediation` component, files, styles, CSS selectors, DOM IDs, diagnostics, and tests to the canonical AI Editorial Review terminology.
* Change the provider contract from the legacy `review-mediation` component type to `ai-editorial-review`, without adding a legacy component reader.
* Change the empty-view suggestion ID from `mediate-review-notes` to `ai-editorial-review` while preserving the existing `Editorial Review` provider label and `Editorial review` grouped writing label.
* Advertise the versioned `ai-editorial-review-contract` context entry with `{ version: 2 }` in the same provider build that contains the canonical component reader.
* Recognize the canonical `ai_editorial_review_over_limit` error exactly while retaining the exact legacy error reader for delayed responses.
* Preserve the existing feature gate, post/page eligibility, Jetpack AI show-component tool ID, legacy Big Sky tool-ID adapter, post-ID safety, checkpoint behavior, and feature-specific Tracks event names.
* Add regression coverage for the canonical capability, component routing, legacy-type rejection, unchanged UX labels, suggestion grouping and analytics, post-ID handling, and exact error-code matching.

## Why are these changes being made?

* AI Editorial Review currently uses legacy Review Mediator identifiers in the Calypso/Agents Manager client even though the logical product and server contract use AI Editorial Review terminology. The existing shorter `Editorial Review` UX wording is intentionally unchanged.
* The WPCOM stages above deployed and enabled versioned negotiation while keeping clients without a capability marker on the legacy contract. This PR atomically adds the canonical reader and version-2 marker, so the server cannot select the canonical response contract before this client can render it.
* Self-hosted availability and feature-specific analytics remain unchanged. Generic suggestion reporting changes its ID value at this cutover from `mediate-review-notes` to `ai-editorial-review`; queries spanning the rollout should union both values. Event names, schema, and cardinality do not change.
* A stored historical `review-mediation` card may be omitted when an old conversation is reopened in this canonical-only client. That is an accepted compatibility tradeoff; the rest of the conversation should continue loading normally.

## Testing Instructions

### Simple site

1. Sandbox `widgets.wp.com`.
2. From `apps/agents-manager`, run `yarn dev --sync` to sync this branch to the sandbox.
3. Sandbox a Simple site and `public-api.wordpress.com`.
4. Use production Calypso and Jetpack.
5. Open the Agents Manager sidebar on a draft post and request **Editorial Review**.
6. Confirm the review completes successfully and displays the expected review interface without errors, missing output, or a failed ability invocation.

### Atomic site

1. Sandbox `widgets.wp.com`.
2. From `apps/agents-manager`, run `yarn dev --sync` to sync this branch to the sandbox.
3. Sandbox `public-api.wordpress.com`.
4. Open a draft post and open the Agents Manager sidebar.
5. Request **Editorial Review**.
6. Confirm the review completes successfully and displays the expected review interface without errors, missing output, or a failed ability invocation.

### Automated checks run locally

* `yarn test-packages packages/jetpack-ai-sidebar --runInBand` — 14 suites, 314 tests passed.
* `yarn test-packages packages/agents-manager --runInBand` — 37 suites, 441 tests passed.
* Jetpack AI Sidebar typecheck, ESLint, changed SCSS Stylelint, and both affected package builds passed.
* `yarn workspace @automattic/agents-manager-app build` passed across all ten production entrypoints.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
