### PR TITLE
Agents Manager: preserve dropdown suggestion prompts

### DIFF
--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -23,15 +23,23 @@ jest.mock(
 			children,
 			emptyView,
 			floatingChatState,
+			suggestions = [],
+			onSuggestionClick,
 		}: {
 			children: ReactNode;
 			emptyView: ReactNode;
 			floatingChatState?: string;
+			suggestions?: Suggestion[];
+			onSuggestionClick?: (
+				selectedSuggestion: Suggestion,
+				availableSuggestions: Suggestion[]
+			) => void;
 		} ) {
 			mockContainerProps( { floatingChatState } );
 			return (
 				<div>
 					{ emptyView }
+					<MockSuggestionButtons suggestions={ suggestions } onSubmit={ onSuggestionClick } />
 					{ children }
 				</div>
 			);
@@ -48,6 +56,57 @@ jest.mock(
 			return <div>{ children }</div>;
 		}
 
+		function MockSuggestionButtons( {
+			suggestions = [],
+			onSubmit,
+		}: {
+			suggestions?: Suggestion[];
+			onSubmit?: ( selectedSuggestion: Suggestion, availableSuggestions: Suggestion[] ) => void;
+		} ) {
+			return (
+				<div>
+					{ suggestions.flatMap( ( suggestion ) => {
+						const { options, ...suggestionWithoutOptions } = suggestion;
+						if ( ! options?.length ) {
+							return (
+								<button
+									key={ suggestion.id }
+									onClick={ () => onSubmit?.( suggestion, suggestions ) }
+								>
+									{ suggestion.label }
+								</button>
+							);
+						}
+
+						return options.map( ( option ) => {
+							const parentPrompt = suggestion.prompt ?? suggestion.label;
+							const separator =
+								parentPrompt &&
+								option.value &&
+								! /\s$/.test( parentPrompt ) &&
+								! /^\s/.test( option.value )
+									? ' '
+									: '';
+							const selectedSuggestion = {
+								...suggestionWithoutOptions,
+								label: `${ suggestion.label } ${ option.label }`,
+								prompt: `${ parentPrompt }${ separator }${ option.value }`,
+							};
+
+							return (
+								<button
+									key={ `${ suggestion.id }-${ option.id }` }
+									onClick={ () => onSubmit?.( selectedSuggestion, suggestions ) }
+								>
+									{ suggestion.label }: { option.label }
+								</button>
+							);
+						} );
+					} ) }
+				</div>
+			);
+		}
+
 		function MockEmptyView( {
 			suggestions = [],
 			onSuggestionClick,
@@ -58,18 +117,7 @@ jest.mock(
 				availableSuggestions: Suggestion[]
 			) => void;
 		} ) {
-			return (
-				<div>
-					{ suggestions.map( ( suggestion ) => (
-						<button
-							key={ suggestion.id }
-							onClick={ () => onSuggestionClick?.( suggestion, suggestions ) }
-						>
-							{ suggestion.label }
-						</button>
-					) ) }
-				</div>
-			);
+			return <MockSuggestionButtons suggestions={ suggestions } onSubmit={ onSuggestionClick } />;
 		}
 
 		function MockSuggestions( {
@@ -79,15 +127,7 @@ jest.mock(
 			suggestions?: Suggestion[];
 			onSubmit?: ( selectedSuggestion: Suggestion, availableSuggestions: Suggestion[] ) => void;
 		} ) {
-			return (
-				<div>
-					{ suggestions.map( ( suggestion ) => (
-						<button key={ suggestion.id } onClick={ () => onSubmit?.( suggestion, suggestions ) }>
-							{ suggestion.label }
-						</button>
-					) ) }
-				</div>
-			);
+			return <MockSuggestionButtons suggestions={ suggestions } onSubmit={ onSubmit } />;
 		}
 
 		function MockMessageRenderer( { children }: { children: ReactNode } ) {
@@ -248,6 +288,59 @@ describe( 'AgentChat', () => {
 		await user.click( screen.getByRole( 'button', { name: 'Check grammar' } ) );
 
 		expect( onSuggestionClick ).toHaveBeenCalledWith( suggestion, [ suggestion ] );
+	} );
+
+	it( 'preserves the selected prompt from an inline dropdown suggestion', async () => {
+		const user = userEvent.setup();
+		const option = {
+			id: 'formal',
+			label: 'Formal',
+			value: 'Change the tone of this text to be more formal',
+		};
+		const suggestion = {
+			id: 'change-tone',
+			label: 'Change tone',
+			prompt: '',
+			options: [ option ],
+		};
+		const onSuggestionClick = jest.fn();
+
+		renderAgentChat( { isOpen: true, suggestions: [ suggestion ], onSuggestionClick } );
+
+		await user.click( screen.getByRole( 'button', { name: 'Change tone: Formal' } ) );
+
+		expect( onSuggestionClick ).toHaveBeenCalledWith( { ...suggestion, prompt: option.value }, [
+			suggestion,
+		] );
+	} );
+
+	it( 'preserves the selected prompt from an empty-view dropdown suggestion', async () => {
+		const user = userEvent.setup();
+		document.body.classList.add( 'post-php', 'post-type-post' );
+		const option = {
+			id: 'seo-description',
+			label: 'Description',
+			value: 'Generate an SEO meta description for this post',
+		};
+		const suggestion = {
+			id: 'seo-enhancer',
+			label: 'SEO Enhancer',
+			prompt: '',
+			options: [ option ],
+		};
+		const onSuggestionClick = jest.fn();
+
+		renderAgentChat( {
+			isOpen: true,
+			emptyViewSuggestions: [ suggestion ],
+			onSuggestionClick,
+		} );
+
+		await user.click( screen.getByRole( 'button', { name: 'Optimize SEO: Description' } ) );
+
+		expect( onSuggestionClick ).toHaveBeenCalledWith( { ...suggestion, prompt: option.value }, [
+			suggestion,
+		] );
 	} );
 
 	it( 'expands when open', () => {

--- a/packages/agents-manager/src/components/agent-chat/get-suggestion-click-payload.ts
+++ b/packages/agents-manager/src/components/agent-chat/get-suggestion-click-payload.ts
@@ -1,0 +1,23 @@
+import type { Suggestion } from '@automattic/agenttic-ui';
+
+export default function getSuggestionClickPayload(
+	selectedSuggestion: Suggestion | string,
+	availableSuggestions: Suggestion[]
+): Suggestion | string {
+	if ( typeof selectedSuggestion === 'string' ) {
+		return selectedSuggestion;
+	}
+
+	const originalSuggestion = availableSuggestions.find(
+		( suggestion ) => suggestion.id === selectedSuggestion.id
+	);
+	if ( ! originalSuggestion ) {
+		return selectedSuggestion;
+	}
+
+	return {
+		...selectedSuggestion,
+		...originalSuggestion,
+		...( selectedSuggestion.prompt !== undefined ? { prompt: selectedSuggestion.prompt } : {} ),
+	};
+}

--- a/packages/agents-manager/src/components/agent-chat/grouped-empty-view.tsx
+++ b/packages/agents-manager/src/components/agent-chat/grouped-empty-view.tsx
@@ -10,6 +10,7 @@ import {
 	WRITING_SUGGESTION_IDS,
 } from '../../hooks/use-empty-view-suggestions';
 import { isEditorPage } from '../../utils/is-editor-page';
+import getSuggestionClickPayload from './get-suggestion-click-payload';
 import type { ReactNode } from 'react';
 import './grouped-empty-view.scss';
 
@@ -54,12 +55,10 @@ export default function GroupedEmptyView( {
 		DESIGN_SUGGESTION_IDS.has( suggestion.id )
 	);
 	const handleSuggestionClick = ( selectedSuggestion: Suggestion | string ) => {
-		const originalSuggestion =
-			typeof selectedSuggestion === 'string'
-				? selectedSuggestion
-				: suggestions.find( ( suggestion ) => suggestion.id === selectedSuggestion.id ) ??
-				  selectedSuggestion;
-		onSuggestionClick?.( originalSuggestion, suggestions );
+		onSuggestionClick?.(
+			getSuggestionClickPayload( selectedSuggestion, suggestions ),
+			suggestions
+		);
 	};
 
 	if ( ! groupWritingSuggestions || writingSuggestions.length === 0 || ! hasDesignSuggestions ) {

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -27,6 +27,7 @@ import CustomALink from '../custom-a-link';
 import FeedbackInput from '../feedback-input';
 import { AI } from '../icons';
 import SelectedBlock from '../selected-block';
+import getSuggestionClickPayload from './get-suggestion-click-payload';
 import GroupedEmptyView from './grouped-empty-view';
 import type { UseImageUploadResult } from '../../hooks/use-image-upload';
 import type { ExternalContextCard, ExternalContextCardAction } from '../../utils/external-context';
@@ -203,12 +204,10 @@ export default function AgentChat( {
 	);
 	const handleDisplayedSuggestionClick = useCallback(
 		( selectedSuggestion: Suggestion | string ) => {
-			const originalSuggestion =
-				typeof selectedSuggestion === 'string'
-					? selectedSuggestion
-					: suggestions.find( ( suggestion ) => suggestion.id === selectedSuggestion.id ) ??
-					  selectedSuggestion;
-			onSuggestionClick?.( originalSuggestion, suggestions );
+			onSuggestionClick?.(
+				getSuggestionClickPayload( selectedSuggestion, suggestions ),
+				suggestions
+			);
 		},
 		[ onSuggestionClick, suggestions ]
 	);


### PR DESCRIPTION
## Proposed Changes

* Preserve the prompt Agenttic creates when someone selects an Agents Manager dropdown option.
* Apply the prompt preservation to starting-screen suggestions such as Optimize SEO and inline block suggestions such as Change tone and Translate.
* Add regression coverage for both dropdown paths.

## Why are these changes being made?

Selecting a dropdown option currently dismisses the suggestion view but fills the chat composer with a blank prompt. Calypso restores the original Jetpack AI Sidebar suggestion metadata after Agenttic creates the selected option prompt, but the original dropdown suggestion has an intentionally empty parent prompt.

This change keeps the original Jetpack AI Sidebar suggestion metadata while preserving the complete option prompt created by Agenttic, so the selected prompt appears in the composer.

## Testing Instructions

### Automated

* Run `yarn jest -c test/packages/jest.config.js packages/agents-manager/src/components/__tests__/agent-chat.test.tsx --runInBand`.

### Manual

1. Check out `fix/jetpack-ai-drop-down-prompt-fix`.
2. Sandbox `widgets.wp.com` and sync this branch by running `cd apps/agents-manager && yarn dev --sync`.
3. Navigate to a post or page editor and open the Agents Manager sidebar.
4. Open a dropdown suggestion such as Optimize SEO, or select a text block and open a block transformation dropdown such as Change tone or Translate.
5. Select an option from the dropdown.
6. Confirm that the full selected prompt is filled in the chat composer.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g. browsers), interfaces (e.g. keyboard navigation), and assistive technologies (e.g. screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
