### PR TITLE
Agents Manager: remove support session gate on persisted state

### DIFF
--- a/packages/data-stores/src/agents-manager/index.ts
+++ b/packages/data-stores/src/agents-manager/index.ts
@@ -8,6 +8,7 @@ import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
 import { getAgentsManagerState } from './resolvers';
 import * as selectors from './selectors';
+
 export type { State };
 export { persistAgentsManagerState } from './persist-state';
 

--- a/packages/data-stores/src/agents-manager/index.ts
+++ b/packages/data-stores/src/agents-manager/index.ts
@@ -1,7 +1,7 @@
 import { registerStore } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
 import { registerPlugins } from '../plugins';
-import { isE2ETest, isInSupportSession } from '../utils';
+import { isE2ETest } from '../utils';
 import { controls as wpcomRequestControls } from '../wpcom-request-controls';
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
@@ -18,8 +18,6 @@ export function register(): typeof STORE_KEY {
 		return STORE_KEY;
 	}
 
-	const enabledPersistedOpenState = ! isE2ETest() && ! isInSupportSession();
-
 	registerPlugins();
 
 	registerStore( STORE_KEY, {
@@ -29,7 +27,7 @@ export function register(): typeof STORE_KEY {
 		selectors,
 		persist: [],
 		// Don't persist the open state for e2e users, because parallel tests will start interfering with each other.
-		resolvers: enabledPersistedOpenState ? { getAgentsManagerState } : undefined,
+		resolvers: isE2ETest() ? undefined : { getAgentsManagerState },
 	} );
 
 	isRegistered = true;

--- a/packages/data-stores/src/agents-manager/index.ts
+++ b/packages/data-stores/src/agents-manager/index.ts
@@ -26,7 +26,7 @@ export function register(): typeof STORE_KEY {
 		controls: { ...controls, ...wpcomRequestControls },
 		selectors,
 		persist: [],
-		// Don't persist the open state for e2e users, because parallel tests will start interfering with each other.
+		// Don't restore persisted state for e2e users, because parallel tests will start interfering with each other.
 		resolvers: isE2ETest() ? undefined : { getAgentsManagerState },
 	} );
 


### PR DESCRIPTION
Part of AI-1076

## Proposed Changes

* Remove the `isInSupportSession()` gate from the Agents Manager store registration. The `isE2ETest()` check is kept and inlined.

## Why are these changes being made?

* To align the support experience with the user's environment: support sessions now restore the user's persisted Agents Manager state (open/docked/minimized, floating position, router history, last activity) instead of starting blank.
* The gate never guarded private data — a support session already acts as the user. It also caused a race that could leave `hasLoaded` unset and prevent the Agents Manager from rendering in support sessions; removing it fixes that too.

## Testing Instructions

* Code review only — I will review the code and then merge it.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
