### PR TITLE
Reauth required: log 2fa and redirect failures to logstash

### DIFF
--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -12,6 +12,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormVerificationCodeInput from 'calypso/components/forms/form-verification-code-input';
 import Notice from 'calypso/components/notice';
 import WarningCard from 'calypso/components/warning-card';
+import { logToLogstash } from 'calypso/lib/logstash';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import SecurityKeyForm from './security-key-form';
@@ -107,6 +108,15 @@ class ReauthRequired extends Component {
 				this.setState( { validatingCode: false } );
 				if ( error ) {
 					debug( 'There was an error validating that code: ' + JSON.stringify( error ) );
+					logToLogstash( {
+						feature: 'calypso_client',
+						message: 'Reauth required: error validating 2fa code',
+						severity: 'error',
+						extra: {
+							type: 'reauth_code_validation_error',
+							error: error.error ?? error.message ?? String( error ),
+						},
+					} ).catch( () => undefined );
 				} else {
 					debug( 'The code validated!' + JSON.stringify( data ) );
 				}

--- a/client/me/reauth-required/security-key-form.jsx
+++ b/client/me/reauth-required/security-key-form.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
+import { logToLogstash } from 'calypso/lib/logstash';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 
 import './security-key-form.scss';
@@ -36,13 +37,32 @@ export class SecurityKeyForm extends Component {
 							this.initiateSecurityKeyAuthentication( false );
 						} else {
 							// We only retry once, so let's show the original error.
+							this.logAuthenticationFailure( error );
 							this.setState( { isAuthenticating: false, showError: true } );
 						}
 					} );
 					return;
 				}
+				this.logAuthenticationFailure( error );
 				this.setState( { isAuthenticating: false, showError: true } );
 			} );
+	};
+
+	logAuthenticationFailure = ( error ) => {
+		// User cancellations/timeouts (webauthn DOMExceptions) are expected, not faults.
+		const isUserAbort =
+			error instanceof Error && [ 'NotAllowedError', 'AbortError' ].includes( error.name );
+
+		logToLogstash( {
+			feature: 'calypso_client',
+			message: 'Reauth required: security key authentication failed',
+			severity: isUserAbort ? 'warning' : 'error',
+			extra: {
+				type: 'reauth_security_key_error',
+				error_name: error instanceof Error ? error.name : undefined,
+				error: error instanceof Error ? error.message : JSON.stringify( error ?? null ),
+			},
+		} ).catch( () => undefined );
 	};
 
 	render() {

--- a/client/me/reauth-required/test/security-key-form.test.tsx
+++ b/client/me/reauth-required/test/security-key-form.test.tsx
@@ -5,6 +5,10 @@ import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SecurityKeyForm } from '../security-key-form';
 
+jest.mock( 'calypso/lib/logstash', () => ( {
+	logToLogstash: () => Promise.resolve(),
+} ) );
+
 describe( 'SecurityKeyForm', () => {
 	const currentUserId = 123;
 	const translate = ( str: string ) => str;

--- a/client/reauth-required/component.jsx
+++ b/client/reauth-required/component.jsx
@@ -2,6 +2,7 @@ import { getQueryArg } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import React, { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
+import { logToLogstash } from 'calypso/lib/logstash';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import ReauthRequiredComponent from 'calypso/me/reauth-required';
 import './style.scss';
@@ -33,6 +34,16 @@ export default function ReauthRequired() {
 					} else {
 						// eslint-disable-next-line no-console
 						console.warn( `Skipping potentially unsafe redirect to: ${ redirectTo }` );
+						logToLogstash( {
+							feature: 'calypso_client',
+							message: 'Reauth required: blocked redirect to untrusted origin',
+							severity: 'warning',
+							tags: [ 'dashboard' ],
+							extra: {
+								type: 'reauth_required_redirect_blocked',
+								redirect_to: redirectTo,
+							},
+						} ).catch( () => undefined );
 						// Optionally redirect to a default safe page, e.g., '/'
 						// window.location.href = '/';
 					}
@@ -40,8 +51,28 @@ export default function ReauthRequired() {
 					// Handle invalid URL if necessary
 					// eslint-disable-next-line no-console
 					console.error( `Invalid redirect URL: ${ redirectTo }`, e );
+					logToLogstash( {
+						feature: 'calypso_client',
+						message: 'Reauth required: invalid redirect URL',
+						severity: 'warning',
+						tags: [ 'dashboard' ],
+						extra: {
+							type: 'reauth_required_redirect_invalid_url',
+							redirect_to: redirectTo,
+							error: e instanceof Error ? e.message : String( e ),
+						},
+					} ).catch( () => undefined );
 				}
 			} else {
+				logToLogstash( {
+					feature: 'calypso_client',
+					message: 'Reauth required: missing redirect_to query param',
+					severity: 'warning',
+					tags: [ 'dashboard' ],
+					extra: {
+						type: 'reauth_required_redirect_missing',
+					},
+				} ).catch( () => undefined );
 				// Optional: Redirect to a default location if redirect_to is not present or invalid
 				// window.location.href = '/';
 			}


### PR DESCRIPTION
Part of DOTMSD-1418

## Proposed Changes

* Log to logstash (feature `calypso_client`) when the standalone `/me/reauth-required` page can't complete its redirect:
  * `redirect_to` points at an untrusted origin and is blocked (possible open-redirect probing — not a bug, but worth visibility)
  * `redirect_to` is present but unparseable
  * `redirect_to` is missing entirely after a successful reauth
* These three logs are tagged `dashboard` so they can be told apart from the legacy dashboard, since this page serves the MSD reauth flow.
* Log 2fa failures in the shared reauth dialog:
  * API error while validating a code (severity `error`; invalid-code typos are not logged — already covered by existing stats)
  * Security key authentication failure — severity `warning` for user cancellations/timeouts (webauthn `NotAllowedError`/`AbortError`), `error` otherwise

## Why are these changes being made?

* This is a port of the logging added for DOTMSD-1418. Reauth/redirect failures on this page are currently invisible: blocked or malformed redirects only hit the browser console, and 2fa validation/security-key errors only reach `debug()`. We can't tell how often users get stranded here or whether bad `redirect_to` values are being probed.
* `logToLogstash` is used rather than Sentry because these are expected/hostile-input conditions, not code bugs.

## Testing Instructions

**Note:** you can force the reauth-required behaviour by deleting the `twostep_auth` cookie

* Log in to a WordPress.com account with 2fa enabled, in an environment where you can watch the `calypso_client` feature in Kibana (or sandbox the logstash endpoint).
* Visit `/me/reauth-required?redirect_to=https://evil.example.com` and complete 2fa → expect a `reauth_required_redirect_blocked` warning log, tagged `dashboard`, and no navigation.
* Visit `/me/reauth-required` with no `redirect_to` and complete 2fa → expect `reauth_required_redirect_missing`.
* Submit a wrong code → no logstash entry (only the existing inline validation message).
* With a security-key account, dismiss the browser webauthn prompt → expect `reauth_security_key_error` with severity `warning`.
* `yarn test-client client/me/reauth-required` passes; `yarn typecheck-client` passes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
