### PR TITLE
Site editor route: Add site picker default option

### DIFF
--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -9,7 +9,8 @@ import {
 } from './controller';
 
 export default function () {
-	page( '/site-editor/:site?', redirectLoggedOut, siteSelection, redirectSiteEditor );
+	page( '/site-editor/:site', redirectLoggedOut, siteSelection, redirectSiteEditor );
+	page( '/site-editor', redirectLoggedOut, siteSelection, sites, makeLayout, clientRender );
 	page( '/post', redirectLoggedOut, siteSelection, sites, makeLayout, clientRender );
 	page( '/post/new', '/post' ); // redirect from beep-beep-boop
 	page( '/post/:site/:post?', redirectToPermalinkIfLoggedOut, siteSelection, redirect );

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -159,6 +159,9 @@ class Sites extends Component {
 			case 'site-monitoring':
 				path = translate( 'Site Monitoring' );
 				break;
+			case 'site-editor':
+				path = translate( 'Site Editor' );
+				break;
 			case 'github-deployments':
 				path = translate( 'GitHub Deployments' );
 				break;


### PR DESCRIPTION
Part of DOTCOM-17865

## Proposed Changes

The site-editor route redirected to https://wordpress.com/nullsite-editor.php when no site was passed. This PR adds a `site-editor` route with no parameters that triggers the site picker. Once a site is selected, the site specific route is called, redirecting to the Site Editor for the selected website.

**Before**:
https://wordpress.com/site-editor => https://wordpress.com/nullsite-editor.php
<img width="529" height="409" alt="image" src="https://github.com/user-attachments/assets/03d2bf9b-c651-400e-ac5d-a92fedfdb49b" />
**After**:
<img width="650" height="232" alt="image" src="https://github.com/user-attachments/assets/3e6f2edc-98c7-4297-93ac-bfe40069ef44" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To support future experiments.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/site-editor`, confirm the site picker is shown correctly and selecting a site takes you to the Site Editor for that site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
