### PR TITLE
Bump agenttic packages to 0.1.81

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"@automattic/accessible-focus": "workspace:^",
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-ui": "^0.1.80",
+		"@automattic/agenttic-ui": "^0.1.81",
 		"@automattic/api-core": "workspace:^",
 		"@automattic/api-queries": "workspace:^",
 		"@automattic/block-renderer": "workspace:^",

--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -41,8 +41,8 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.80",
-		"@automattic/agenttic-ui": "^0.1.80",
+		"@automattic/agenttic-client": "^0.1.81",
+		"@automattic/agenttic-ui": "^0.1.81",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/block-notes/package.json
+++ b/packages/block-notes/package.json
@@ -41,7 +41,7 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.80",
+		"@automattic/agenttic-client": "^0.1.81",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",
 		"@wordpress/api-fetch": "^7.48.0",

--- a/packages/image-studio/package.json
+++ b/packages/image-studio/package.json
@@ -51,8 +51,8 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.80",
-		"@automattic/agenttic-ui": "^0.1.80",
+		"@automattic/agenttic-client": "^0.1.81",
+		"@automattic/agenttic-ui": "^0.1.81",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",

--- a/packages/jetpack-ai-sidebar/package.json
+++ b/packages/jetpack-ai-sidebar/package.json
@@ -44,7 +44,7 @@
 		"typecheck": "tsc --build --dry"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.80",
+		"@automattic/agenttic-client": "^0.1.81",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
 		"@automattic/components": "workspace:^",

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -41,7 +41,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.80",
+		"@automattic/agenttic-ui": "^0.1.81",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/zendesk-client/package.json
+++ b/packages/zendesk-client/package.json
@@ -36,7 +36,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.80",
+		"@automattic/agenttic-ui": "^0.1.81",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-config": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -135,8 +135,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/agents-manager@workspace:packages/agents-manager"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.80"
-    "@automattic/agenttic-ui": "npm:^0.1.80"
+    "@automattic/agenttic-client": "npm:^0.1.81"
+    "@automattic/agenttic-ui": "npm:^0.1.81"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
@@ -182,9 +182,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/agenttic-client@npm:^0.1.80":
-  version: 0.1.80
-  resolution: "@automattic/agenttic-client@npm:0.1.80"
+"@automattic/agenttic-client@npm:^0.1.81":
+  version: 0.1.81
+  resolution: "@automattic/agenttic-client@npm:0.1.81"
   dependencies:
     "@types/react": "npm:^18.0.0 || ^19.0.0"
     marked: "npm:^16.2.1"
@@ -197,13 +197,13 @@ __metadata:
   peerDependenciesMeta:
     "@wordpress/api-fetch":
       optional: true
-  checksum: d4563b8c86a122c0e1a97fa7818facea3b101d5aaa6b8fcca8a41b6d0c874d2bf770151fd7ed4fddef24ffd3b2165aed0ca4e3938d48f0a135283f0e1c0934eb
+  checksum: 1ba4342ff5fd8e37d1a0186869bd5c2c6c1836ea05720ef4427e70a3a81de053473d42fe1773d09566e8870b00f15ed82beddcc8e599b7cbc00a2441f145a226
   languageName: node
   linkType: hard
 
-"@automattic/agenttic-ui@npm:^0.1.80":
-  version: 0.1.80
-  resolution: "@automattic/agenttic-ui@npm:0.1.80"
+"@automattic/agenttic-ui@npm:^0.1.81":
+  version: 0.1.81
+  resolution: "@automattic/agenttic-ui@npm:0.1.81"
   dependencies:
     "@automattic/charts": "npm:^1.10.0"
     "@radix-ui/react-popover": "npm:^1.1.15"
@@ -226,7 +226,7 @@ __metadata:
   dependenciesMeta:
     marked:
       optional: true
-  checksum: 79e7244f760c8ffee08f6817ef8a9e89af74626a951fa1ca76c2077012920ef692b09c33d2d1ac3fffb57f561d69f9ad6db01b88bcb30136c52798ff3ecf5e9b
+  checksum: 21fb5a329fc6cd73341c86c9503d7fb3968b3549d2f93919128ad5faf15daaeca490c6bc379c5964520756f596ee94e345dc9092e316b41d83c042e551056b73
   languageName: node
   linkType: hard
 
@@ -352,7 +352,7 @@ __metadata:
   resolution: "@automattic/block-notes@workspace:packages/block-notes"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.80"
+    "@automattic/agenttic-client": "npm:^0.1.81"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@testing-library/react": "npm:^15.0.7"
@@ -1506,8 +1506,8 @@ __metadata:
   resolution: "@automattic/image-studio@workspace:packages/image-studio"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.80"
-    "@automattic/agenttic-ui": "npm:^0.1.80"
+    "@automattic/agenttic-client": "npm:^0.1.81"
+    "@automattic/agenttic-ui": "npm:^0.1.81"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/oauth-token": "workspace:^"
@@ -1609,7 +1609,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/jetpack-ai-sidebar@workspace:packages/jetpack-ai-sidebar"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.80"
+    "@automattic/agenttic-client": "npm:^0.1.81"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
@@ -1876,7 +1876,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/odie-client@workspace:packages/odie-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.80"
+    "@automattic/agenttic-ui": "npm:^0.1.81"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
@@ -2714,7 +2714,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/zendesk-client@workspace:packages/zendesk-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.80"
+    "@automattic/agenttic-ui": "npm:^0.1.81"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
@@ -14243,7 +14243,7 @@ __metadata:
   dependencies:
     "@automattic/accessible-focus": "workspace:^"
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-ui": "npm:^0.1.80"
+    "@automattic/agenttic-ui": "npm:^0.1.81"
     "@automattic/api-core": "workspace:^"
     "@automattic/api-queries": "workspace:^"
     "@automattic/block-renderer": "workspace:^"


### PR DESCRIPTION
## Proposed Changes

* Bump `@automattic/agenttic-client` and `@automattic/agenttic-ui` from `^0.1.80` to `^0.1.81` across all consuming packages, and refresh `yarn.lock`.

## Why are these changes being made?

* Pick up the latest agenttic release and keep every consumer on a single, consistent version.

## Testing Instructions

* Run `yarn install` — resolution completes and both packages resolve to `0.1.81`.
* `yarn typecheck-packages` passes (no agenttic API type breaks).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
