### PR TITLE
Counted textarea: fix double border around the field

### DIFF
--- a/client/components/forms/counted-textarea/style.scss
+++ b/client/components/forms/counted-textarea/style.scss
@@ -5,6 +5,13 @@
 	border-radius: 2px;
 	background-color: var(--color-neutral-0);
 
+	// Highlight the whole control on focus so the textarea and its count panel
+	// read as one field, matching the sibling form inputs.
+	&:focus-within {
+		border-color: var(--color-primary);
+		box-shadow: 0 0 0 2px var(--color-primary-10);
+	}
+
 	&.is-exceeding-acceptable-length {
 		background: var(--color-error);
 
@@ -13,17 +20,25 @@
 			color: var(--color-text-inverted);
 		}
 	}
-}
 
-.counted-textarea__input {
-	display: block;
-	resize: vertical;
-	border: none;
-	padding: 8px;
+	// Keep the textarea borderless and drop its own focus ring; nesting outranks
+	// the `.form-textarea` border and box-shadow it would otherwise inherit.
+	// `:focus:hover` is listed explicitly to outrank `.form-textarea:focus:hover`.
+	.counted-textarea__input {
+		display: block;
+		resize: vertical;
+		border: none;
+
+		&:focus,
+		&:focus:hover {
+			box-shadow: none;
+		}
+	}
 }
 
 .counted-textarea__count-panel {
 	padding: 8px;
+	border-top: 1px solid var(--color-neutral-10);
 	font-size: $font-body-extra-small;
 	color: var(--color-neutral-50);
 }


### PR DESCRIPTION
Fixes DSGCOM-585

## Proposed Changes

- Fix the double border that `CountedTextarea` renders around its field. The component is meant to show a single border on the wrapper with a borderless textarea inside, but the textarea's `.form-textarea` border was winning over the intended `border: none`, so it drew its own border inside the wrapper's.
- The field's focus ring now lives on the wrapper instead of the inner textarea, keeping the control a single bordered box.

## Why are these changes being made?

The Welcome message field in the add-plan modal (Earn → Payments) showed a stacked double border where the "characters remaining" counter sits under the textarea, which looked like a glitch. The fix restores the component's intended single-border design, so every `CountedTextarea` usage (Earn plan/tier modals, SEO settings, invite people) is corrected consistently.

## Testing Instructions

1. Go to **Earn → Payments** and open **Add a new payment plan** (or edit an existing one).
2. Check the **Welcome message** field: it should have a single border enclosing both the textarea and the "characters remaining" counter.
3. Focus the field — the focus ring should highlight the whole box once, with no inner double outline.
4. Sanity-check other `CountedTextarea` usages (Site Settings → SEO meta description, People → Invite) look the same.

Before / After screenshots welcome for the visual change.
