### PR TITLE
Dashboard: re-enable percentage-based rollout in all environments

### DIFF
--- a/client/dashboard/utils/hosting-dashboard-enrollment.ts
+++ b/client/dashboard/utils/hosting-dashboard-enrollment.ts
@@ -5,7 +5,7 @@ import type { HostingDashboardOptIn } from '@automattic/api-core';
 const ROLLOUT_PERCENTAGE = 50;
 
 // When rollout begins, users registered after this ID (i.e. new users) are enrolled.
-const NEW_USER_ID_THRESHOLD = 282742932;
+const NEW_USER_ID_THRESHOLD = 282953237;
 
 /**
  * Whether the user belongs to the percentage-rollout cohort. Membership is

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -31,7 +31,7 @@
 		"dark-mode": true,
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
-		"dashboard/enable-percentage-rollout": false,
+		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/omnibar-radical": false,
 		"dashboard/opt-in-welcome-modal": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -27,7 +27,7 @@
 		"dark-mode": true,
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
-		"dashboard/enable-percentage-rollout": false,
+		"dashboard/enable-percentage-rollout": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,
 		"dashboard/simulate-full-rollout": true,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -34,7 +34,7 @@
 		"dark-mode": true,
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": false,
-		"dashboard/enable-percentage-rollout": false,
+		"dashboard/enable-percentage-rollout": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/simulate-full-rollout": false,
 		"dashboard/wp-beta-program": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -32,7 +32,7 @@
 		"dark-mode": true,
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
-		"dashboard/enable-percentage-rollout": false,
+		"dashboard/enable-percentage-rollout": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/simulate-full-rollout": true,
 		"dashboard/wp-beta-program": true,

--- a/config/development.json
+++ b/config/development.json
@@ -71,7 +71,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/enable-percentage-rollout": false,
+		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/omnibar-radical": false,
 		"dashboard/opt-in-welcome-modal": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -31,7 +31,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/enable-percentage-rollout": false,
+		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,

--- a/config/production.json
+++ b/config/production.json
@@ -44,7 +44,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/enable-percentage-rollout": false,
+		"dashboard/enable-percentage-rollout": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/rollout-advance-notice": true,
 		"dashboard/simulate-full-rollout": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -41,7 +41,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/enable-percentage-rollout": false,
+		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/rollout-advance-notice": true,

--- a/config/test.json
+++ b/config/test.json
@@ -36,7 +36,7 @@
 		"cookie-banner": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
-		"dashboard/enable-percentage-rollout": false,
+		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/rollout-advance-notice": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -40,7 +40,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/enable-percentage-rollout": false,
+		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,


### PR DESCRIPTION
Fixes DOTMSD-1436
Fixes DOTMSD-1437

## Proposed Changes

* Flip `dashboard/enable-percentage-rollout` from `false` back to `true` in every environment config where it is defined.

## Why are these changes being made?

* The MSD percentage-based rollout was halted via the emergency revert #112593 during the security-keys incident. The underlying issue is resolved, so this restarts auto-enrollment at 50% (`userId % 100 < 50`).
* Exact reverse of #112593.

## Testing Instructions

* Confirm the flag is `true` in the relevant environment configs.
* For a user whose `userId % 100 < 50` (and no opt-out preference), verify they are auto-enrolled and redirected to the hosting dashboard.
* `yarn typecheck-client` and the flag-related unit tests (`client/dashboard/utils/test/hosting-dashboard-enrollment.ts`, `client/test/root-section.ts`) pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
