### PR TITLE
Launchpad: keep checklist item chevron inline on mobile

### DIFF
--- a/packages/launchpad/src/checklist-item/style.scss
+++ b/packages/launchpad/src/checklist-item/style.scss
@@ -123,7 +123,8 @@
 // general styles
 .checklist-item__text {
 	font-weight: 600;
-	flex-grow: 1;
+	flex: 1 1 0%;
+	min-width: 0;
 	text-align: left;
 }
 
@@ -236,6 +237,7 @@
 	display: flex;
 	line-height: 20px;
 	width: 30px;
+	flex-shrink: 0;
 }
 
 .gridicon.checklist-item__chevron {


### PR DESCRIPTION
Fixes DSGCOM-560

## Proposed Changes

* On mobile, the trailing chevron on a Launchpad checklist item could wrap onto its own line under a long label instead of staying right-aligned on the same row. This was visible on the Earn page, where "Connect a Stripe account to collect payments" dropped its arrow to a second line while the shorter "Set up an offer for your supporters" row kept it inline, making the two rows look broken and inconsistent.
* The label now wraps within its own column so the chevron stays inline and right-aligned. The same trailing-element wrapping affected badge, counter, and completed-checkmark rows that share this component, and those are fixed too.

## Why are these changes being made?

The checklist item row is a wrapping flexbox. The label used `flex-grow` with an auto flex-basis, so its hypothetical width for line-breaking was its full one-line width. On narrow screens a long label consumed the whole row, leaving no room for the trailing chevron, which then wrapped to its own line. Giving the label a zero flex-basis with `min-width: 0` makes it wrap inside its own column instead of pushing siblings off the line.

## Testing Instructions

* Visit the Earn page (`/earn/{site}`) on a site whose Stripe account is not yet connected, so the Launchpad checklist shows.
* Narrow the viewport to a mobile width (or use device emulation) until the "Connect a Stripe account…" label wraps to two lines.
* Confirm the chevron stays on the first line, right-aligned, matching the other rows — before this change it dropped to its own line.
* Sanity-check other Launchpad checklists (onboarding, etc.) to confirm labels, badges, counters, and completed checkmarks still render correctly.

Before / After (reproduction at a narrow width; top = before, bottom = after):

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
