### PR TITLE
Earn: fix inconsistent spacing in the Earnings table

### DIFF
--- a/client/my-sites/earn/components/stats/index.tsx
+++ b/client/my-sites/earn/components/stats/index.tsx
@@ -31,37 +31,35 @@ function StatsSection() {
 			<div>
 				<SectionHeader label={ translate( 'Earnings' ) } />
 				<QueryMembershipsEarnings siteId={ site.ID } />
-				<Card>
-					<div className="memberships__module-content module-content">
-						<ul className="memberships__earnings-breakdown-list">
-							<li className="memberships__earnings-breakdown-item">
-								<span className="memberships__earnings-breakdown-label">
-									{ translate( 'Total earnings', { context: 'Sum of earnings' } ) }
-								</span>
-								<span className="memberships__earnings-breakdown-value">
-									{ formatCurrency( total, currency ) }
-								</span>
-							</li>
-							<li className="memberships__earnings-breakdown-item">
-								<span className="memberships__earnings-breakdown-label">
-									{ translate( 'Last 30 days', { context: 'Sum of earnings over last 30 days' } ) }
-								</span>
-								<span className="memberships__earnings-breakdown-value">
-									{ formatCurrency( lastMonth, currency ) }
-								</span>
-							</li>
-							<li className="memberships__earnings-breakdown-item">
-								<span className="memberships__earnings-breakdown-label">
-									{ translate( 'Next month', {
-										context: 'Forecast for the subscriptions due in the next 30 days',
-									} ) }
-								</span>
-								<span className="memberships__earnings-breakdown-value">
-									{ formatCurrency( forecast, currency ) }
-								</span>
-							</li>
-						</ul>
-					</div>
+				<Card className="memberships__earnings-card">
+					<ul className="memberships__earnings-breakdown-list">
+						<li className="memberships__earnings-breakdown-item">
+							<span className="memberships__earnings-breakdown-label">
+								{ translate( 'Total earnings', { context: 'Sum of earnings' } ) }
+							</span>
+							<span className="memberships__earnings-breakdown-value">
+								{ formatCurrency( total, currency ) }
+							</span>
+						</li>
+						<li className="memberships__earnings-breakdown-item">
+							<span className="memberships__earnings-breakdown-label">
+								{ translate( 'Last 30 days', { context: 'Sum of earnings over last 30 days' } ) }
+							</span>
+							<span className="memberships__earnings-breakdown-value">
+								{ formatCurrency( lastMonth, currency ) }
+							</span>
+						</li>
+						<li className="memberships__earnings-breakdown-item">
+							<span className="memberships__earnings-breakdown-label">
+								{ translate( 'Next month', {
+									context: 'Forecast for the subscriptions due in the next 30 days',
+								} ) }
+							</span>
+							<span className="memberships__earnings-breakdown-value">
+								{ formatCurrency( forecast, currency ) }
+							</span>
+						</li>
+					</ul>
 					<CommissionFees
 						commission={ commission }
 						iconSize={ 12 }

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -32,7 +32,6 @@ body.is-section-earn.theme-default.color-scheme {
 .memberships__module-content {
 	max-height: 520px;
 	overflow-y: auto;
-	margin-top: -24px;
 	border-bottom: 1px solid var(--color-neutral-5);
 }
 
@@ -132,14 +131,14 @@ body.is-section-earn.theme-default.color-scheme {
 .memberships__earnings-breakdown-item {
 	width: 33%;
 	float: left;
-	padding: 5px 0 10px;
+	padding: 16px 0;
 	list-style-type: none;
 	text-align: center;
 
 	@include breakpoint-deprecated( "<480px" ) {
 		width: auto;
 		float: none;
-		padding: 10px 24px;
+		padding: 16px 24px;
 		text-align: left;
 	}
 }
@@ -448,8 +447,8 @@ body.is-section-earn.theme-default.color-scheme {
 	display: block;
 	clear: both;
 	color: var(--color-neutral-30);
-	padding-bottom: 12px;
-	padding-top: 24px;
+	padding-top: 16px;
+	padding-bottom: 16px;
 	font-size: $font-body-extra-small;
 	line-height: 1.6;
 	font-style: italic;

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -116,7 +116,7 @@ body.is-section-earn.theme-default.color-scheme {
 	margin: 0;
 	padding-inline: 0;
 	padding-block: 0 16px;
-	border-block-end: 1px solid var(--color-neutral-5);
+	border-block-end: 1px solid var(--color-border-subtle);
 
 	@include breakpoint-deprecated( "<480px" ) {
 		grid-template-columns: 1fr;

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -29,10 +29,8 @@ body.is-section-earn.theme-default.color-scheme {
 	width: auto;
 }
 
-.memberships__module-content {
-	max-height: 520px;
-	overflow-y: auto;
-	border-bottom: 1px solid var(--color-neutral-5);
+.card.memberships__earnings-card {
+	padding-block: 16px;
 }
 
 .memberships__onboarding-wrapper {
@@ -112,7 +110,17 @@ body.is-section-earn.theme-default.color-scheme {
 }
 
 .memberships__earnings-breakdown-list {
+	display: grid;
+	grid-template-columns: repeat( 3, 1fr );
+	gap: 16px;
 	margin: 0;
+	padding-inline: 0;
+	padding-block: 0 16px;
+	border-block-end: 1px solid var(--color-neutral-5);
+
+	@include breakpoint-deprecated( "<480px" ) {
+		grid-template-columns: 1fr;
+	}
 }
 
 .memberships__earnings-breakdown-label {
@@ -129,28 +137,22 @@ body.is-section-earn.theme-default.color-scheme {
 }
 
 .memberships__earnings-breakdown-item {
-	width: 33%;
-	float: left;
-	padding: 16px 0;
 	list-style-type: none;
 	text-align: center;
 
 	@include breakpoint-deprecated( "<480px" ) {
-		width: auto;
-		float: none;
-		padding: 16px 24px;
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
 		text-align: left;
 	}
 }
 
 .memberships__earnings-breakdown-value {
-	width: 100%;
 	display: block;
 	font-size: $font-title-medium;
 
 	@include breakpoint-deprecated( "<480px" ) {
-		width: auto;
-		float: right;
 		font-size: $font-body;
 	}
 }
@@ -445,10 +447,8 @@ body.is-section-earn.theme-default.color-scheme {
 }
 .memberships__earnings-breakdown-notes {
 	display: block;
-	clear: both;
 	color: var(--color-neutral-30);
-	padding-top: 16px;
-	padding-bottom: 16px;
+	padding-block-start: 16px;
 	font-size: $font-body-extra-small;
 	line-height: 1.6;
 	font-style: italic;


### PR DESCRIPTION
Fixes DSGCOM-586

## Proposed Changes

* Normalize the vertical spacing of the Earnings table on the Monetize → Monetization Options tab (`/earn`) so the gaps between the values row, the divider, and the transaction-fee note follow a consistent rhythm.

## Why are these changes being made?

The table's spacing was built from several mismatched values: a negative top margin that cancelled the Card's padding on desktop but overflowed it on mobile (where the Card padding is smaller), asymmetric padding on the earnings items, and a separate asymmetric padding on the transaction-fee note. The result was an uneven rhythm. Normalizing everything to a symmetric 16px gap makes the spacing even and consistent across breakpoints.

## Testing Instructions

* Go to **Monetize → Monetization Options** (`/earn/{site}`) on a Simple/Atomic site.
* Confirm the **Earnings** table shows even spacing above and below the values row, around the divider, and around the "transaction fee for payments" note.
* Resize to a narrow (mobile) width and confirm the top of the table is no longer clipped/overflowing and spacing stays even.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
