### PR TITLE
Login: prevent duplicate login-endpoint POSTs on double submit

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -323,7 +323,11 @@ export class LoginForm extends Component {
 		this.props.recordTracksEvent( 'calypso_login_block_login_form_submit' );
 		this.props
 			.loginUser( usernameOrEmail, password, redirectTo, domain, this.props.blackbox )
-			.then( () => {
+			.then( ( result ) => {
+				if ( result === false ) {
+					return;
+				}
+
 				this.props.recordTracksEvent( 'calypso_login_block_login_form_success' );
 				onSuccess( redirectTo );
 			} )

--- a/client/blocks/login/test/login-form.jsx
+++ b/client/blocks/login/test/login-form.jsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import config from '@automattic/calypso-config';
-import { screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import cookie from 'cookie';
 import LoginForm from 'calypso/blocks/login/login-form';
@@ -306,6 +306,25 @@ describe( 'LoginForm', () => {
 			await userEvent.click( screen.getByRole( 'button', { name: /Log In/i } ) );
 
 			await waitFor( () => expect( window.Blackbox.reset ).toHaveBeenCalledTimes( 1 ) );
+		} );
+
+		test( 'sends only one login request when the form is submitted twice', async () => {
+			getBlackboxSessionId.mockResolvedValue( 'ABCDEFGHIJKLMNOPQRSTuv' );
+			mockFetch.mockResolvedValue( {
+				ok: false,
+				status: 400,
+				text: jest.fn().mockResolvedValue( '' ),
+			} );
+
+			renderRegularLoginForm();
+
+			const form = document.querySelector( 'form[method="post"]' );
+			act( () => {
+				form.requestSubmit();
+				form.requestSubmit();
+			} );
+
+			await waitFor( () => expect( mockFetch ).toHaveBeenCalledTimes( 1 ) );
 		} );
 	} );
 } );

--- a/client/state/login/actions/login-user.js
+++ b/client/state/login/actions/login-user.js
@@ -8,6 +8,7 @@ import {
 	TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
 import { remoteLoginUser } from 'calypso/state/login/actions/remote-login-user';
+import { isFormDisabled } from 'calypso/state/login/selectors';
 import {
 	getErrorFromHTTPError,
 	getSMSMessageFromResponse,
@@ -22,10 +23,14 @@ import 'calypso/state/login/init';
  * @param  {string}   redirectTo      		Url to redirect the user to upon successful login
  * @param  {string}   domain          		A domain to reverse login to
  * @param  {Object}   blackbox        		Blackbox protection helpers from `useBlackboxProtection`.
- * @returns {Function}                 		A thunk that can be dispatched
+ * @returns {Function}                 		A thunk that resolves to `false` when no login request is started
  */
 export const loginUser =
-	( usernameOrEmail, password, redirectTo, domain, blackbox ) => async ( dispatch ) => {
+	( usernameOrEmail, password, redirectTo, domain, blackbox ) => async ( dispatch, getState ) => {
+		if ( isFormDisabled( getState() ) ) {
+			return false;
+		}
+
 		dispatch( {
 			type: LOGIN_REQUEST,
 		} );


### PR DESCRIPTION
We've seen cases in the wild where users manage to submit the form twice. This doesn't play well with Blackbox, since each session must only be used once. I am not able to reproduce the issue, but the nginx logs don't lie.

I believe we can fix this by using a guard based on `isFormDisabled` (used for UI state). If isFormDisabled is already set, loginUser returns false before a second LOGIN_REQUEST. Read getState() so we see it before re-render; form skips success when result === false.

Also considered: instance ref, local isBusy, props.isFormDisabled:
- Props may observe same value (when multiple submits occur before React re-render),
- ref/local isBusy add more state (that may be out-of-sync with the UI state),
- this instead reuses the state the button already uses.

It's a real possibility that this small change doesn't fix it: if users were able to double submit the form, because the `isFormDisabled` state is incorrectly set to false due to some unknown reason, then this PR won't fix the issue. I'll keep an eye on the logs and see whether we see another occurence.