### PR TITLE
Dashboard: redirect /log-in on the dashboard host to WordPress.com

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -1323,6 +1323,16 @@ export default function pages() {
 			}
 		} );
 
+	// The dashboard host has no login page; send /log-in to WordPress.com.
+	if ( isDashboardEnv() || calypsoEnv === 'development' ) {
+		app.get( pathToRegExp( '/log-in' ), ( req, res, next ) => {
+			if ( ! isAllowedDotcomDashboardHostname( req.hostname ) ) {
+				return next( 'route' );
+			}
+			res.redirect( config( 'wpcom_url' ) + req.originalUrl );
+		} );
+	}
+
 	// Set up login routing.
 	handleSectionPath( LOGIN_SECTION_DEFINITION, '/log-in', 'entry-login' );
 	loginRouter( serverRouter( app, setUpRoute, null ) );


### PR DESCRIPTION
Fixes DOTMSD-1433

## Proposed Changes

* On dashboard hosts (`my.wordpress.com`, `my.localhost`, `*.calypso.live`), redirect `/log-in` and its sub-paths to the WordPress.com login page (a 302 to `wpcom_url` + the original URL, preserving query params like `redirect_to`).
* Requests to `/log-in` on any non-dashboard host are unaffected and continue to hit the classic login section.

## Why are these changes being made?

Visiting `my.wordpress.com/log-in` served a bare login page — the standalone `/log-in` variant, missing the social sign-ons and the rest of the normal login experience. The classic login section is registered for `/log-in` on **every** hostname with no host filter, and `/log-in` is not one of the dashboard's own routes, so the request was captured by the login section before the dashboard app ever booted. The dashboard's own client-side "redirect unauthenticated users to the login page" logic can't help, because it only runs after the dashboard bundle mounts on a dashboard route.

This change intercepts `/log-in` on the dashboard host with a server-side redirect, registered just before the login section so it wins the route-order match. Unauthenticated users now land on the real WordPress.com login page.

## Considerations

The redirect is a standalone route rather than an `extraMiddleware` on the login section or the dashboard section. The login section is isomorphic, and for logged-out requests the section pipeline short-circuits before any `extraMiddleware` runs — so a middleware there would be bypassed for exactly the unauthenticated users we need to redirect. Routing through the dashboard section instead would spin up full request context and a user-bootstrap round-trip only to throw it away with a 302. A plain redirect route avoids both and issues the 302 immediately.

## Testing Instructions

* Run `yarn start` and visit `http://my.localhost:3000/log-in` while logged out → you should be redirected to the Calypso login page (`http://calypso.localhost:3000/log-in`), not the bare dashboard-host login page.
* Confirm `http://calypso.localhost:3000/log-in` still serves the normal login page unchanged.
* Confirm a sub-path like `http://my.localhost:3000/log-in/link/use` also redirects, preserving path and query.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)