### PR TITLE
Server: redesign route registration in pages() around a route registry

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -1323,6 +1323,16 @@ export default function pages() {
 			}
 		} );
 
+	// The dashboard host has no login page; send /log-in to WordPress.com.
+	if ( isDashboardEnv() || calypsoEnv === 'development' ) {
+		app.get( pathToRegExp( '/log-in' ), ( req, res, next ) => {
+			if ( ! isAllowedDotcomDashboardHostname( req.hostname ) ) {
+				return next( 'route' );
+			}
+			res.redirect( config( 'wpcom_url' ) + req.originalUrl );
+		} );
+	}
+
 	// Set up login routing.
 	handleSectionPath( LOGIN_SECTION_DEFINITION, '/log-in', 'entry-login' );
 	loginRouter( serverRouter( app, setUpRoute, null ) );

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -893,30 +893,45 @@ const render404 =
 		res.status( 404 ).send( renderJsx( '404', ctx ) );
 	};
 
+// Each dashboard variant is an SPA served on its own hosts. A variant declares:
+//   definition/entrypoint — the section + webpack entry to render
+//   paths                 — section paths the variant renders itself
+//   devEnv                — the local dev env (besides the dashboard envs) that
+//                           also serves this variant, e.g. under `yarn start`
+//   isAllowedHostname     — hostnames the variant owns
+//   extraMiddleware       — middleware appended to the render chain
+//   redirects             — paths the variant does NOT serve and sends elsewhere
 const DASHBOARD_VARIANTS = [
 	{
+		name: 'dotcom',
 		definition: DOTCOM_DASHBOARD_SECTION_DEFINITION,
 		paths: DOTCOM_DASHBOARD_SECTION_PATHS,
 		entrypoint: 'entry-dashboard-dotcom',
 		devEnv: 'development',
 		isAllowedHostname: isAllowedDotcomDashboardHostname,
 		extraMiddleware: [ loadDashboardLocaleData ],
+		// my.wordpress.com has no login page of its own; send /log-in to WordPress.com.
+		redirects: [ { path: '/log-in', target: ( req ) => config( 'wpcom_url' ) + req.originalUrl } ],
 	},
 	{
+		name: 'ciab',
 		definition: CIAB_DASHBOARD_SECTION_DEFINITION,
 		paths: CIAB_DASHBOARD_SECTION_PATHS,
 		entrypoint: 'entry-dashboard-ciab',
 		devEnv: 'development',
 		isAllowedHostname: isAllowedCiabDashboardHostname,
 		extraMiddleware: [ loadDashboardLocaleData ],
+		redirects: [],
 	},
 	{
+		name: 'a4a',
 		definition: A4A_DASHBOARD_SECTION_DEFINITION,
 		paths: A4A_DASHBOARD_SECTION_PATHS,
 		entrypoint: 'entry-dashboard-a4a',
 		devEnv: 'a8c-for-agencies-development',
 		isAllowedHostname: isAllowedA4ADashboardHostname,
 		extraMiddleware: [],
+		redirects: [],
 	},
 ];
 
@@ -1209,6 +1224,90 @@ function wpcomPages( app ) {
 	} );
 }
 
+// Registers routes on the Express app: section renders, host-scoped redirects,
+// and the 404 shell, so the middleware chain and env/host gating live in one place.
+function createRouteRegistry( app ) {
+	const asRegExp = ( route ) => ( route instanceof RegExp ? route : pathToRegExp( route ) );
+
+	// Render `sectionDef` for each path. `isAllowedHost` scopes it to matching hosts
+	// (others fall through); `notFound` serves the shell with a 404 status.
+	const section = (
+		sectionDef,
+		paths,
+		{ entrypoint, isAllowedHost, middleware = [], notFound = false } = {}
+	) => {
+		const extra = notFound
+			? [ setNotFoundStatus, ...[].concat( middleware ) ]
+			: [].concat( middleware );
+		[].concat( paths ).forEach( ( route ) => {
+			const pathRegex = asRegExp( route );
+			app.get(
+				pathRegex,
+				( req, res, next ) =>
+					! isAllowedHost || isAllowedHost( req ) ? next() : next( 'route' ),
+				setupDefaultContext( entrypoint, sectionDef.name ),
+				setUpSectionContext( sectionDef, entrypoint ),
+				// Logged-out isomorphic sections are resolved by the serverRouter (SSR).
+				( req, res, next ) => {
+					if ( ! req.context.isLoggedIn && sectionDef.isomorphic ) {
+						return next( 'route' );
+					}
+					debug( `Using non-SSR pipeline for path ${ req.path } with handler ${ pathRegex }` );
+					next();
+				},
+				setUpRoute, // For SSR requests, this will happen in the serverRouter.
+				...extra,
+				serverRender
+			);
+		} );
+	};
+
+	// Redirect each path to `target(req)`. `isAllowedHost` scopes it; other hosts fall through.
+	const redirect = ( paths, target, { isAllowedHost, status } = {} ) => {
+		[].concat( paths ).forEach( ( route ) => {
+			app.get( asRegExp( route ), ( req, res, next ) => {
+				if ( isAllowedHost && ! isAllowedHost( req ) ) {
+					return next( 'route' );
+				}
+				return status ? res.redirect( status, target( req ) ) : res.redirect( target( req ) );
+			} );
+		} );
+	};
+
+	// Register rows in match order. Each row: `when` (env gate, skips the row),
+	// `isAllowedHost` (host gate), and either `render` a section or `redirect`.
+	const register = ( rows ) =>
+		rows.forEach( ( row ) => {
+			if ( row.when && ! row.when() ) {
+				return;
+			}
+			if ( row.redirect ) {
+				redirect( row.path, row.redirect, {
+					isAllowedHost: row.isAllowedHost,
+					status: row.status,
+				} );
+			} else {
+				section( row.render, row.path, {
+					entrypoint: row.entry,
+					isAllowedHost: row.isAllowedHost,
+					middleware: row.middleware,
+					notFound: row.notFound,
+				} );
+			}
+		} );
+
+	return { section, redirect, register };
+}
+
+// Environment predicates — does THIS server register the route at all?
+const inDashboardOrDevEnv = ( devEnv ) => isDashboardEnv() || calypsoEnv === devEnv;
+const dashboardVariantEnabled = ( variant ) => inDashboardOrDevEnv( variant.devEnv );
+
+// Host predicates — at request time, does this hostname belong to the route?
+const isA4ADashboardHost = ( req ) => isAllowedA4ADashboardHostname( req.hostname );
+const isAllowedDashboardRequest = ( req ) =>
+	isAllowedDashboardRoute( { hostname: req.hostname, path: req.path } );
+
 export default function pages() {
 	const app = express();
 
@@ -1225,93 +1324,69 @@ export default function pages() {
 		wpcomPages( app );
 	}
 
-	/**
-	 * Given information about a section, register the given path as an express
-	 * route and define a basic middleware chain. The chain sets up any request
-	 * context and renders the basic DOM structure, ultimately resolving the request.
-	 *
-	 * For SSR requests -- e.g. the section is compatible with SSR and the request
-	 * is logged out -- it skips the rendering portion of the chain, because that
-	 * is explicitly handled by the serverRouter. In SSR contexts, this chain is
-	 * still responsible for setting up some basic info like the context and the
-	 * bootstrapped user, but not for resolving the request.
-	 *
-	 * This approach allows requests to an SSR section to skip any section-specific
-	 * SSR middleware if the request wasn't going to be resolved with SSR anyways.
-	 */
-	function handleSectionPath( section, sectionPath, entrypoint, reqFilter, extraMiddleware ) {
-		const pathRegex = sectionPath instanceof RegExp ? sectionPath : pathToRegExp( sectionPath );
+	const routes = createRouteRegistry( app );
 
-		app.get(
-			pathRegex,
-			( req, res, next ) => ( ! reqFilter || reqFilter( req ) ? next() : next( 'route' ) ),
-			setupDefaultContext( entrypoint, section.name ),
-			setUpSectionContext( section, entrypoint ),
-			// Skip the rest of the middleware chain if SSR compatible. Further
-			// SSR checks aren't accounted for here, but happen in the SSR pipeline
-			// itself (see serverRouter). But if we know at a basic level that SSR
-			// won't be used, we can boost performance by rendering the page here.
-			( req, res, next ) => {
-				if ( ! req.context.isLoggedIn && section.isomorphic ) {
-					return next( 'route' );
-				}
-				debug( `Using non-SSR pipeline for path ${ req.path } with handler ${ pathRegex }` );
-				next();
-			},
-			setUpRoute, // For SSR requests, this will happen in the serverRouter.
-			...( extraMiddleware ? [].concat( extraMiddleware ) : [] ),
-			serverRender
-		);
-	}
+	// Render/redirect policy for the dashboard hosts (dotcom → my.wordpress.com,
+	// ciab, a4a). Registered before the shared Calypso and login routes below so a
+	// host-scoped row wins the match; the not-found catch-all comes after login.
+	const signupSection = sections.find( ( s ) => s.name === 'signup' );
+	const checkoutSection = sections.find( ( s ) => s.name === 'checkout' );
+	const a4aSignupSection = sections.find( ( s ) => s.name === 'a8c-for-agencies-signup' );
+	const inDotcomEnv = () => inDashboardOrDevEnv( 'development' );
+	const inA4AEnv = () => inDashboardOrDevEnv( 'a8c-for-agencies-development' );
 
-	// Special Calypso routes which also appear on `my.wordpress.com`
-	if ( isDashboardEnv() || calypsoEnv === 'development' ) {
-		const signupSectionDefinition = sections.find( ( s ) => s.name === 'signup' );
-		handleSectionPath( signupSectionDefinition, '/start', undefined, ( req ) =>
-			isAllowedDashboardRoute( { hostname: req.hostname, path: req.path } )
-		);
-		const checkoutSectionDefinition = sections.find( ( s ) => s.name === 'checkout' );
-		handleSectionPath( checkoutSectionDefinition, '/checkout', undefined, ( req ) =>
-			isAllowedDashboardRoute( { hostname: req.hostname, path: req.path } )
-		);
-		handleSectionPath( STEPPER_SECTION_DEFINITION, '/setup', 'entry-stepper', ( req ) =>
-			isAllowedDashboardRoute( { hostname: req.hostname, path: req.path } )
-		);
-	}
-
-	// Multi-site Dashboard (A4A) routing.
-	if ( isDashboardEnv() || calypsoEnv === 'a8c-for-agencies-development' ) {
-		const a4aSignupSectionDefinition = sections.find(
-			( s ) => s.name === 'a8c-for-agencies-signup'
-		);
-		A4A_SIGNUP_PATHS.forEach( ( a4aSignupPath ) => {
-			handleSectionPath( a4aSignupSectionDefinition, a4aSignupPath, undefined, ( req ) =>
-				isAllowedA4ADashboardHostname( req.hostname )
-			);
-		} );
-	}
-
-	// Register each dashboard variant's explicit section paths.
-	DASHBOARD_VARIANTS.forEach( ( variant ) => {
-		if ( ! ( isDashboardEnv() || calypsoEnv === variant.devEnv ) ) {
-			return;
-		}
-		variant.paths.forEach( ( route ) =>
-			handleSectionPath(
-				variant.definition,
-				route,
-				variant.entrypoint,
-				( req ) => variant.isAllowedHostname( req.hostname ),
-				variant.extraMiddleware
-			)
-		);
-	} );
+	routes.register( [
+		// Classic Calypso sections that are also exposed on dashboard hosts.
+		{
+			path: '/start',
+			when: inDotcomEnv,
+			isAllowedHost: isAllowedDashboardRequest,
+			render: signupSection,
+		},
+		{
+			path: '/checkout',
+			when: inDotcomEnv,
+			isAllowedHost: isAllowedDashboardRequest,
+			render: checkoutSection,
+		},
+		{
+			path: '/setup',
+			when: inDotcomEnv,
+			isAllowedHost: isAllowedDashboardRequest,
+			render: STEPPER_SECTION_DEFINITION,
+			entry: 'entry-stepper',
+		},
+		{
+			path: A4A_SIGNUP_PATHS,
+			when: inA4AEnv,
+			isAllowedHost: isA4ADashboardHost,
+			render: a4aSignupSection,
+		},
+		// Each dashboard variant renders its own SPA section paths...
+		...DASHBOARD_VARIANTS.map( ( variant ) => ( {
+			path: variant.paths,
+			when: () => dashboardVariantEnabled( variant ),
+			isAllowedHost: ( req ) => variant.isAllowedHostname( req.hostname ),
+			render: variant.definition,
+			entry: variant.entrypoint,
+			middleware: variant.extraMiddleware,
+		} ) ),
+		// ...and redirects any path it has no page for (e.g. dotcom has no /log-in).
+		...DASHBOARD_VARIANTS.flatMap( ( variant ) =>
+			variant.redirects.map( ( r ) => ( {
+				path: r.path,
+				when: () => dashboardVariantEnabled( variant ),
+				isAllowedHost: ( req ) => variant.isAllowedHostname( req.hostname ),
+				redirect: r.target,
+			} ) )
+		),
+	] );
 
 	sections
 		.filter( ( section ) => ! section.envId || section.envId.indexOf( config( 'env_id' ) ) > -1 )
 		.filter( isSectionEnabled )
 		.forEach( ( section ) => {
-			section.paths.forEach( ( sectionPath ) => handleSectionPath( section, sectionPath ) );
+			routes.section( section, section.paths );
 
 			if ( section.isomorphic ) {
 				// section.load() uses require on the server side so we also need to access the
@@ -1323,42 +1398,34 @@ export default function pages() {
 			}
 		} );
 
-	// The dashboard host has no login page; send /log-in to WordPress.com.
-	if ( isDashboardEnv() || calypsoEnv === 'development' ) {
-		app.get( pathToRegExp( '/log-in' ), ( req, res, next ) => {
-			if ( ! isAllowedDotcomDashboardHostname( req.hostname ) ) {
-				return next( 'route' );
-			}
-			res.redirect( config( 'wpcom_url' ) + req.originalUrl );
-		} );
-	}
-
-	// Set up login routing.
-	handleSectionPath( LOGIN_SECTION_DEFINITION, '/log-in', 'entry-login' );
+	// Login on every host; dotcom already redirected /log-in in the routes above.
+	routes.section( LOGIN_SECTION_DEFINITION, '/log-in', { entrypoint: 'entry-login' } );
 	loginRouter( serverRouter( app, setUpRoute, null ) );
 
 	// Register CSP report route
 	registerCspReportRoute( app );
 
-	// Multi-site Dashboard routing.
+	// Dashboard server is self-contained: unmatched paths serve the SPA shell as a
+	// 404 (client renders its own page), then we return before the Calypso routes.
 	if ( isDashboardEnv() ) {
-		// Serve the dashboard shell for any otherwise-unmatched path so the client
-		// router renders its own not-found page, instead of falling through to default.
-		DASHBOARD_VARIANTS.forEach( ( variant ) =>
-			handleSectionPath(
-				variant.definition,
-				/.*/,
-				variant.entrypoint,
-				( req ) => variant.isAllowedHostname( req.hostname ),
-				[ setNotFoundStatus, ...variant.extraMiddleware ]
-			)
+		routes.register(
+			DASHBOARD_VARIANTS.map( ( variant ) => ( {
+				path: /.*/,
+				isAllowedHost: ( req ) => variant.isAllowedHostname( req.hostname ),
+				render: variant.definition,
+				entry: variant.entrypoint,
+				middleware: variant.extraMiddleware,
+				notFound: true,
+			} ) )
 		);
 
 		return app;
 	}
 
-	handleSectionPath( STEPPER_SECTION_DEFINITION, '/setup', 'entry-stepper' );
-	handleSectionPath( SUBSCRIPTIONS_SECTION_DEFINITION, '/subscriptions', 'entry-subscriptions' );
+	routes.section( STEPPER_SECTION_DEFINITION, '/setup', { entrypoint: 'entry-stepper' } );
+	routes.section( SUBSCRIPTIONS_SECTION_DEFINITION, '/subscriptions', {
+		entrypoint: 'entry-subscriptions',
+	} );
 
 	// Redirect legacy `/new` routes to the corresponding `/start`
 	app.get( [ '/new', '/new/*' ], ( req, res ) => {

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -157,6 +157,7 @@ const buildApp = ( environment ) => {
 			( key ) =>
 				( {
 					hostname: 'valid.hostname',
+					wpcom_url: 'https://wordpress.com',
 					magnificent_non_en_locales: [ 'ar', 'es' ],
 					port: 3000,
 					env_id: environment,
@@ -209,6 +210,9 @@ const buildApp = ( environment ) => {
 					),
 					'entry-dashboard-dotcom': assetsList.map( ( asset ) =>
 						asset.replace( 'entry-main', 'entry-dashboard-dotcom' )
+					),
+					'entry-login': assetsList.map( ( asset ) =>
+						asset.replace( 'entry-main', 'entry-login' )
 					),
 					...Object.fromEntries(
 						sections.map( ( section ) => [
@@ -1104,6 +1108,18 @@ describe( 'main app', () => {
 		} );
 	} );
 
+	describe( 'Route /log-in', () => {
+		// Uses a dotcom dashboard hostname so the guard is the environment gate, not
+		// the host gate: in the classic env the redirect route must not be registered.
+		it( 'does not redirect to WordPress.com in the classic (non-dashboard) environment', async () => {
+			const { response } = await app.run( {
+				request: { url: '/log-in', hostname: 'my.wordpress.com' },
+			} );
+
+			expect( response.redirect ).not.toHaveBeenCalled();
+		} );
+	} );
+
 	describe( 'Route /menus', () => {
 		it( 'redirects to menus when there is a site', async () => {
 			const { response } = await app.run( { request: { url: '/menus/my-site' } } );
@@ -1607,5 +1623,27 @@ describe( 'dashboard app', () => {
 		expect( request.context.sectionName ).toBe( 'dashboard-dotcom' );
 		expect( response.statusCode ).not.toBe( 404 );
 		expect( app.getMocks().serverRender ).toHaveBeenCalled();
+	} );
+
+	it( 'redirects /log-in on the dotcom dashboard host to the WordPress.com login', async () => {
+		const { response } = await app.run( {
+			request: { url: '/log-in', hostname: 'my.wordpress.com' },
+		} );
+
+		expect( response.redirect ).toHaveBeenCalledWith( 'https://wordpress.com/log-in' );
+		expect( app.getMocks().serverRender ).not.toHaveBeenCalled();
+	} );
+
+	it( 'preserves the sub-path and query string when redirecting /log-in', async () => {
+		const { response } = await app.run( {
+			request: {
+				url: '/log-in/jetpack?redirect_to=%2Fhome',
+				hostname: 'my.wordpress.com',
+			},
+		} );
+
+		expect( response.redirect ).toHaveBeenCalledWith(
+			'https://wordpress.com/log-in/jetpack?redirect_to=%2Fhome'
+		);
 	} );
 } );


### PR DESCRIPTION
Follow-up to #112784 (stacked on it). Part of DOTMSD-1433.

## Proposed Changes

* Introduce a small **route registry** (`createRouteRegistry`) that every section render, host-scoped redirect, and 404-shell registration goes through — replacing the positional-arg `handleSectionPath` (no more bare `undefined` args) and the scattered per-environment `if` blocks.
* Express the dashboard hosts' render/redirect policy as **one declarative table**. Each row states, per path: which environment registers it (`when`), which hostname it serves (`isAllowedHost`), and what it does (`render` a section / `redirect`).
* Name the environment and host predicates (`inDashboardOrDevEnv`, `dashboardVariantEnabled`, `isAllowedDashboardRequest`, …) so the gating reads in plain language.
* `pages()` now reads top-to-bottom as the route table it builds: global middleware → wpcom redirects → dashboard host table → shared Calypso sections → login → dashboard not-found (self-contained return) → landing sections → legacy redirects → terminal 404/500.
* Add regression tests for the dashboard route policy (see Testing Instructions).

## Why are these changes being made?

Route registration in `pages()` was spread across several `if` blocks that each mixed three concerns — which environment a route applies to, which host it applies to, and what should happen (render, redirect, fall through, or 404). For a given request it was hard to tell who handles a path, who deliberately doesn't, and whether an unmatched path redirects or shows a not-found page. This makes the `(environment, host) → disposition` mapping explicit and gives every route one consistent registration path, so adding a host, variant, or env-gated route is a data change rather than a new bespoke block.

## Considerations

* **Section-definition contract left untouched.** `client/sections.js` and the `*_SECTION_DEFINITION` exports are consumed by the webpack `sections-loader` and the SSR pipeline; the registry sits on top of them rather than changing their shape.
* **Declarative table only where it earns its keep.** The render/redirect/not-found routes (dashboard hosts + host-gated Calypso sections) — the genuinely confusing part — become the table. Bespoke handlers (`/plans`, `/support-user`, `/subscriptions`, legacy redirects) stay as ordinary handlers; forcing their branchy logic into a uniform table would hide it, not clarify it.
* **Pure refactor.** Same paths, predicates, middleware, and match ordering. The one internal move — the dotcom `/log-in` redirect is now registered just before the shared login section instead of just after the Calypso sections loop — is match-order-equivalent because no Calypso section claims `/log-in`.

## Testing Instructions

* Automated: `yarn test-server client/server/pages/test/index.js` — **249 tests pass** (added 3 regression tests for the dashboard route policy: the dotcom `/log-in` redirect, sub-path/query preservation, and the env-gate that keeps the redirect from firing in the classic environment).
* `yarn typecheck-client` and `yarn eslint client/server/pages/index.js` — clean.
* Manual sanity (same as #112784): under `yarn start`, `http://my.localhost:3000/log-in` redirects to the Calypso login page; `http://calypso.localhost:3000/log-in` is unchanged; dashboard routes and unmatched dashboard-host paths behave as before.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)