### PR TITLE
A4A: Add Settings and site info to the agency site page

### DIFF
--- a/client/dashboard/agency/sites/site-sidebar/index.tsx
+++ b/client/dashboard/agency/sites/site-sidebar/index.tsx
@@ -3,7 +3,15 @@ import { isEnabled } from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { backup, category, chartBar, formatListBullets, pending, shield } from '@wordpress/icons';
+import {
+	backup,
+	category,
+	chartBar,
+	formatListBullets,
+	pending,
+	settings,
+	shield,
+} from '@wordpress/icons';
 import { agencySiteRoute } from '../../../app/router/agency';
 import {
 	SidebarBackButton,
@@ -20,6 +28,9 @@ export default function AgencySiteSidebar() {
 	const { data: fullSite } = useQuery( siteBySlugQuery( siteSlug ) );
 	const supportsPerformance = fullSite ? siteTypeSupportsFeature( fullSite, 'performance' ) : false;
 	const supportsMonitoring = fullSite ? siteTypeSupportsFeature( fullSite, 'monitoring' ) : false;
+	const supportsSettings = fullSite
+		? siteTypeSupportsFeature( fullSite, 'settings' ) && !! fullSite.capabilities?.manage_options
+		: false;
 	const isApmEnabled = isEnabled( 'performance/apm' );
 
 	return (
@@ -90,6 +101,11 @@ export default function AgencySiteSidebar() {
 								{ __( 'Activity' ) }
 							</SidebarMenuItem>
 						</SidebarExpandableMenuItem>
+						{ supportsSettings && (
+							<SidebarMenuItem icon={ settings } to={ `/sites/${ siteSlug }/settings` }>
+								{ __( 'Settings' ) }
+							</SidebarMenuItem>
+						) }
 					</SidebarMenu>
 				</VStack>
 			) }

--- a/client/dashboard/agency/sites/site/overview.tsx
+++ b/client/dashboard/agency/sites/site/overview.tsx
@@ -6,7 +6,9 @@ import { agencySiteRoute } from '../../../app/router/agency';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 import PerformanceCard from '../../../sites/overview-performance-card';
-import { getDisplayUrl, getSiteName } from '../dataviews/site-data';
+import SiteOverviewFields from '../../../sites/overview-site-fields';
+import VisibilityCard from '../../../sites/overview-visibility-card';
+import { getSiteName } from '../dataviews/site-data';
 import ActivityCard from './activity-card';
 import BackupCard from './backup-card';
 import ScanCard from './scan-card';
@@ -19,9 +21,15 @@ export default function AgencySiteOverview() {
 
 	return (
 		<PageLayout
-			header={ <PageHeader title={ getSiteName( site ) } description={ getDisplayUrl( site ) } /> }
+			header={
+				<PageHeader
+					title={ getSiteName( site ) }
+					description={ <SiteOverviewFields site={ fullSite } /> }
+				/>
+			}
 		>
 			<Grid columns={ isSmallViewport ? 1 : 2 } gap={ isSmallViewport ? 4 : 6 }>
+				{ ! fullSite.is_wpcom_flex && <VisibilityCard site={ fullSite } /> }
 				<BackupCard site={ site } />
 				<ScanCard site={ site } siteSlug={ siteSlug } />
 				<PerformanceCard site={ fullSite } />

--- a/client/dashboard/agency/sites/site/overview.tsx
+++ b/client/dashboard/agency/sites/site/overview.tsx
@@ -24,9 +24,6 @@ export default function AgencySiteOverview() {
 			<Grid columns={ isSmallViewport ? 1 : 2 } gap={ isSmallViewport ? 4 : 6 }>
 				<BackupCard site={ site } />
 				<ScanCard site={ site } siteSlug={ siteSlug } />
-				{ /* TODO (A4A): for private/coming-soon/unlaunched sites this card links to
-				     `/sites/$slug/settings/site-visibility`, which has no route in the agency
-				     site view yet. Guard the link (or add settings) once A4A settings lands. */ }
 				<PerformanceCard site={ fullSite } />
 			</Grid>
 			<ActivityCard />

--- a/client/dashboard/agency/sites/site/overview.tsx
+++ b/client/dashboard/agency/sites/site/overview.tsx
@@ -29,7 +29,7 @@ export default function AgencySiteOverview() {
 			}
 		>
 			<Grid columns={ isSmallViewport ? 1 : 2 } gap={ isSmallViewport ? 4 : 6 }>
-				{ ! fullSite.is_wpcom_flex && <VisibilityCard site={ fullSite } /> }
+				<VisibilityCard site={ fullSite } />
 				<BackupCard site={ site } />
 				<ScanCard site={ site } siteSlug={ siteSlug } />
 				<PerformanceCard site={ fullSite } />

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -1,3 +1,4 @@
+import { DotcomFeatures, HostingFeatures, fetchTwoStep } from '@automattic/api-core';
 import {
 	activeAgencyQuery,
 	agencyProductsQuery,
@@ -6,29 +7,61 @@ import {
 	agencySiteQuery,
 	agencySitesWithPluginsQuery,
 	agencyWooPaymentsDataQuery,
+	bigSkyPluginQuery,
+	codeDeploymentQuery,
+	codeDeploymentsQuery,
+	githubInstallationsQuery,
 	mcpSettingsQuery,
+	productsQuery,
 	queryClient,
 	rawUserPreferencesQuery,
+	siteAgencyBlogQuery,
 	siteApmAggregateRollingQuery,
 	siteApmDetailQuery,
 	siteBackupsQuery,
 	siteBySlugQuery,
+	siteCrontabsQuery,
+	siteCurrentPlanQuery,
+	siteDefensiveModeSettingsQuery,
+	siteEdgeCacheStatusQuery,
+	siteJetpackModulesQuery,
+	siteJetpackSettingsQuery,
+	sitePHPVersionQuery,
 	sitePerformancePagesQuery,
+	sitePostByEmailSettingsQuery,
+	sitePreviewLinksQuery,
+	sitePrimaryDataCenterQuery,
+	siteRedirectQuery,
 	siteScanQuery,
 	siteSettingsQuery,
+	siteSftpUsersQuery,
+	siteSshAccessStatusQuery,
+	siteStaticFile404SettingQuery,
+	siteWordPressVersionQuery,
 	referralsQuery,
 	referralCommissionPayoutQuery,
 	tipaltiPayeeQuery,
+	userSettingsQuery,
 	wooPaymentsLicensesQuery,
+	wpOrgCoreVersionQuery,
 	WOOPAYMENTS_PLUGIN,
 } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { createRoute, createLazyRoute, notFound, Outlet } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
+import {
+	canOptOutOfWordPressBeta,
+	canSwitchWordPressVersion,
+	canTransferSite,
+	canViewHundredYearPlanSettings,
+} from '../../sites/features';
+import { reauthRequiredLink } from '../../utils/link';
+import { hasHostingFeature, hasPlanFeature } from '../../utils/site-features';
 import { getSiteTypeFeatureSupports } from '../../utils/site-type-feature-support';
+import { AUTH_QUERY_KEY } from '../auth';
 import { dashboardRedirect, redirectAsNotAllowed } from './redirect';
 import { rootRoute } from './root';
-import type { AgencyCapability } from '@automattic/api-core';
+import type { AgencyCapability, User } from '@automattic/api-core';
 import type { AnyRoute, StaticDataRouteOption } from '@tanstack/react-router';
 
 /**
@@ -808,6 +841,659 @@ export const agencySiteMonitoringRoute = createRoute( {
 	)
 );
 
+// `/sites/$siteSlug/settings` – settings hub, mirroring the dotcom dashboard's settings tree
+export const agencySiteSettingsRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settings' },
+	head: () => ( { meta: [ { title: __( 'Settings' ) } ] } ),
+	getParentRoute: () => agencySiteRoute,
+	path: 'settings',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+
+		queryClient.prefetchQuery( siteCurrentPlanQuery( site.ID ) );
+		await Promise.all( [
+			queryClient.ensureQueryData( siteSettingsQuery( site.ID ) ),
+			hasHostingFeature( site, HostingFeatures.PRIMARY_DATA_CENTER ) &&
+				queryClient.ensureQueryData( sitePrimaryDataCenterQuery( site.ID ) ),
+		] );
+	},
+} );
+
+const agencySiteSettingsIndexRoute = createRoute( {
+	getParentRoute: () => agencySiteSettingsRoute,
+	path: '/',
+} ).lazy( () =>
+	import( '../../sites/settings' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings' )( {
+			component: () => <d.default siteSlug={ agencySiteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const agencySiteSettingsSiteVisibilityRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsGeneralDotcomSiteVisibility' },
+	head: () => ( { meta: [ { title: __( 'Site visibility' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsRoute,
+	path: 'site-visibility',
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( site.is_wpcom_flex ) {
+			throw redirectAsNotAllowed( { to: agencySiteSettingsRoute.fullPath, params: { siteSlug } } );
+		}
+	},
+	loader: async ( { context, params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+
+		await Promise.all( [
+			queryClient.ensureQueryData( siteSettingsQuery( site.ID ) ),
+			queryClient.ensureQueryData( context.config.queries.domainsQuery() ),
+			site.is_coming_soon &&
+				hasPlanFeature( site, DotcomFeatures.SITE_PREVIEW_LINKS ) &&
+				queryClient.ensureQueryData( sitePreviewLinksQuery( site.ID ) ),
+		] );
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-site-visibility' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-site-visibility' )( {
+			component: () => <d.default siteSlug={ agencySiteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const agencySiteSettingsAIToolsRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsGeneralAITools' },
+	head: () => ( { meta: [ { title: __( 'AI tools' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsRoute,
+	path: 'ai-tools',
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
+		if ( ! isEnabled( 'wordpress-ai-tools' ) ) {
+			throw redirectAsNotAllowed( { to: agencySiteSettingsRoute.fullPath, params: { siteSlug } } );
+		}
+
+		if ( cause === 'enter' ) {
+			const twoStep = await fetchTwoStep();
+			if ( twoStep.two_step_reauthorization_required ) {
+				throw dashboardRedirect( { href: reauthRequiredLink(), reloadDocument: true } );
+			}
+		}
+	},
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		const pluginStatus = await queryClient.ensureQueryData( bigSkyPluginQuery( site.ID ) );
+
+		if ( pluginStatus?.available ) {
+			queryClient.prefetchQuery( sitePostByEmailSettingsQuery( site ) );
+		}
+
+		await queryClient.ensureQueryData( userSettingsQuery() );
+	},
+} );
+
+const agencySiteSettingsAIToolsIndexRoute = createRoute( {
+	getParentRoute: () => agencySiteSettingsAIToolsRoute,
+	path: '/',
+} ).lazy( () =>
+	import( '../../sites/settings-ai-tools' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-ai-tools' )( {
+			component: () => <d.default siteSlug={ agencySiteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+function redirectAgencySiteAiToolsSubpageToHub( {
+	cause,
+	params: { siteSlug },
+}: {
+	cause: string;
+	params: { siteSlug: string };
+} ) {
+	if ( cause === 'preload' ) {
+		return;
+	}
+	if ( ! isEnabled( 'mcp-settings' ) ) {
+		throw dashboardRedirect( {
+			to: agencySiteSettingsAIToolsIndexRoute.fullPath,
+			params: { siteSlug },
+		} );
+	}
+}
+
+const agencySiteSettingsAIToolsReadRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Read' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsAIToolsRoute,
+	path: 'read',
+	beforeLoad: redirectAgencySiteAiToolsSubpageToHub,
+	loader: async ( { params: { siteSlug } } ) => {
+		await Promise.all( [
+			queryClient.ensureQueryData( userSettingsQuery() ),
+			queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) ),
+		] );
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-ai-tools/read' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-ai-tools-read' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const agencySiteSettingsAIToolsWriteRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Write' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsAIToolsRoute,
+	path: 'write',
+	beforeLoad: redirectAgencySiteAiToolsSubpageToHub,
+	loader: async ( { params: { siteSlug } } ) => {
+		await Promise.all( [
+			queryClient.ensureQueryData( userSettingsQuery() ),
+			queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) ),
+		] );
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-ai-tools/write' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-ai-tools-write' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const agencySiteSettingsAIToolsSetupRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Connect AI agent' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsAIToolsRoute,
+	path: 'setup',
+	beforeLoad: redirectAgencySiteAiToolsSubpageToHub,
+	loader: async ( { params: { siteSlug } } ) => {
+		await Promise.all( [
+			queryClient.ensureQueryData( userSettingsQuery() ),
+			queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) ),
+		] );
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-ai-tools/setup' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-ai-tools-setup' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const agencySiteSettingsRedirectRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsGeneralRedirect' },
+	head: () => ( { meta: [ { title: __( 'Site Redirect' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsRoute,
+	path: 'site-redirect',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		return await Promise.all( [
+			queryClient.ensureQueryData( productsQuery() ),
+			queryClient.ensureQueryData( siteRedirectQuery( site.ID ) ),
+		] );
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-redirect' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-redirect' )( {
+			component: () => <d.default siteSlug={ agencySiteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const agencySiteSettingsSubscriptionGiftingRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsGeneral' },
+	head: () => ( { meta: [ { title: __( 'Accept a gift subscription' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsRoute,
+	path: 'subscription-gifting',
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( ! hasPlanFeature( site, DotcomFeatures.SUBSCRIPTION_GIFTING ) ) {
+			throw redirectAsNotAllowed( { to: agencySiteSettingsRoute.fullPath, params: { siteSlug } } );
+		}
+	},
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		await queryClient.ensureQueryData( siteSettingsQuery( site.ID ) );
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-subscription-gifting' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-subscription-gifting' )( {
+			component: () => <d.default siteSlug={ agencySiteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const agencySiteSettingsAgencyRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsGeneral' },
+	head: () => ( { meta: [ { title: __( 'Agency settings' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsRoute,
+	path: 'agency',
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( site.is_wpcom_atomic ) {
+			const agencyBlog = await queryClient.ensureQueryData( siteAgencyBlogQuery( site.ID ) );
+			if ( ! agencyBlog ) {
+				throw redirectAsNotAllowed( {
+					to: agencySiteSettingsRoute.fullPath,
+					params: { siteSlug },
+				} );
+			}
+		}
+	},
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( site.is_wpcom_atomic ) {
+			await queryClient.ensureQueryData( siteAgencyBlogQuery( site.ID ) );
+		}
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-agency' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-agency' )( {
+			component: () => <d.default siteSlug={ agencySiteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const agencySiteSettingsHundredYearPlanRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsGeneral' },
+	head: () => ( { meta: [ { title: __( 'Control your legacy' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsRoute,
+	path: 'hundred-year-plan',
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( ! canViewHundredYearPlanSettings( site ) ) {
+			throw redirectAsNotAllowed( { to: agencySiteSettingsRoute.fullPath, params: { siteSlug } } );
+		}
+	},
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		await queryClient.ensureQueryData( siteSettingsQuery( site.ID ) );
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-hundred-year-plan' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-hundred-year-plan' )( {
+			component: () => <d.default siteSlug={ agencySiteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const agencySiteSettingsWordPressRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsServer' },
+	head: () => ( { meta: [ { title: 'WordPress' } ] } ),
+	getParentRoute: () => agencySiteSettingsRoute,
+	path: 'wordpress',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( canSwitchWordPressVersion( site ) || canOptOutOfWordPressBeta( site, 'beta' ) ) {
+			// Fire-and-forget the external wp.org queries so a slow upstream
+			// doesn't hang navigation; the component suspends on them via
+			// useSuspenseQuery and falls back to the route's Suspense boundary.
+			queryClient.prefetchQuery( wpOrgCoreVersionQuery() );
+			queryClient.prefetchQuery( wpOrgCoreVersionQuery( 'beta' ) );
+			await queryClient.ensureQueryData( siteWordPressVersionQuery( site.ID ) );
+		}
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-wordpress' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-wordpress' )( {
+			component: () => <d.default siteSlug={ agencySiteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const agencySiteSettingsPHPRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsServer' },
+	head: () => ( { meta: [ { title: 'PHP' } ] } ),
+	getParentRoute: () => agencySiteSettingsRoute,
+	path: 'php',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( hasHostingFeature( site, HostingFeatures.PHP ) ) {
+			await queryClient.ensureQueryData( sitePHPVersionQuery( site.ID ) );
+		}
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-php' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-php' )( {
+			component: () => <d.default siteSlug={ agencySiteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const agencySiteSettingsSftpSshRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsServer' },
+	head: () => ( { meta: [ { title: __( 'SFTP/SSH' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsRoute,
+	path: 'sftp-ssh',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( hasHostingFeature( site, HostingFeatures.SFTP ) ) {
+			queryClient.prefetchQuery( siteSftpUsersQuery( site.ID ) );
+		}
+		if ( hasHostingFeature( site, HostingFeatures.SSH ) ) {
+			queryClient.prefetchQuery( siteSshAccessStatusQuery( site.ID ) );
+		}
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-sftp-ssh' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-sftp-ssh' )( {
+			component: () => <d.default siteSlug={ agencySiteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const agencySiteSettingsCrontabRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Cron' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsRoute,
+	path: 'crontab',
+} );
+
+const agencySiteSettingsCrontabIndexRoute = createRoute( {
+	getParentRoute: () => agencySiteSettingsCrontabRoute,
+	path: '/',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( hasHostingFeature( site, HostingFeatures.SSH ) ) {
+			queryClient.prefetchQuery( siteCrontabsQuery( site.ID ) );
+		}
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-crontab' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-crontab' )( {
+			component: () => <d.default siteSlug={ agencySiteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const agencySiteSettingsCrontabAddRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Add Scheduled Job' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsCrontabRoute,
+	path: 'add',
+} ).lazy( () =>
+	import( '../../sites/settings-crontab/add-crontab' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-crontab-add' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const agencySiteSettingsCrontabEditRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Edit scheduled job' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsCrontabRoute,
+	path: '$cronId/edit',
+	parseParams: ( params ) => ( {
+		cronId: Number( params.cronId ),
+	} ),
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		await queryClient.ensureQueryData( siteCrontabsQuery( site.ID ) );
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-crontab/edit-crontab' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-crontab-edit' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const agencySiteSettingsRepositoriesRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsServer' },
+	head: () => ( { meta: [ { title: __( 'Repositories' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsRoute,
+	path: 'repositories',
+} );
+
+const agencySiteSettingsRepositoriesIndexRoute = createRoute( {
+	getParentRoute: () => agencySiteSettingsRepositoriesRoute,
+	path: '/',
+	loader: async ( { params: { siteSlug } } ) => {
+		queryClient.prefetchQuery( githubInstallationsQuery() );
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		queryClient.prefetchQuery( codeDeploymentsQuery( site.ID ) );
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-repositories' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-repositories' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const agencySiteSettingsRepositoriesConnectRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Connect repository' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsRepositoriesRoute,
+	path: 'connect',
+	loader: () => {
+		queryClient.prefetchQuery( githubInstallationsQuery() );
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-repositories/connect-repository' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-repositories-connect' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const agencySiteSettingsRepositoriesManageRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Configure repository' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsRepositoriesRoute,
+	path: 'manage/$deploymentId',
+	parseParams: ( params ) => ( {
+		deploymentId: Number( params.deploymentId ),
+	} ),
+	loader: async ( { params: { siteSlug, deploymentId } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		await queryClient.ensureQueryData( codeDeploymentQuery( site.ID, deploymentId ) );
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-repositories/configure-repository' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-repositories-manage' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const agencySiteSettingsDatabaseRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsServer' },
+	head: () => ( { meta: [ { title: __( 'Database' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsRoute,
+	path: 'database',
+} ).lazy( () =>
+	import( '../../sites/settings-database' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-database' )( {
+			component: () => <d.default siteSlug={ agencySiteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const agencySiteSettingsPrimaryDataCenterRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsServer' },
+	head: () => ( { meta: [ { title: __( 'Primary data center' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsRoute,
+	path: 'primary-data-center',
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( hasHostingFeature( site, HostingFeatures.PRIMARY_DATA_CENTER ) ) {
+			const primaryDataCenter = await queryClient.ensureQueryData(
+				sitePrimaryDataCenterQuery( site.ID )
+			);
+			if ( primaryDataCenter ) {
+				return;
+			}
+		}
+
+		throw redirectAsNotAllowed( { to: agencySiteSettingsRoute.fullPath, params: { siteSlug } } );
+	},
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		await queryClient.ensureQueryData( sitePrimaryDataCenterQuery( site.ID ) );
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-primary-data-center' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-primary-data-center' )( {
+			component: () => <d.default siteSlug={ agencySiteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const agencySiteSettingsStaticFile404Route = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsServer' },
+	head: () => ( { meta: [ { title: __( 'Handling requests for nonexistent assets' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsRoute,
+	path: 'static-file-404',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( hasHostingFeature( site, HostingFeatures.STATIC_FILE_404 ) ) {
+			await queryClient.ensureQueryData( siteStaticFile404SettingQuery( site.ID ) );
+		}
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-static-file-404' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-static-file-404' )( {
+			component: () => <d.default siteSlug={ agencySiteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const agencySiteSettingsCachingRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsServer' },
+	head: () => ( { meta: [ { title: __( 'Caching' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsRoute,
+	path: 'caching',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( hasHostingFeature( site, HostingFeatures.CACHING ) ) {
+			await queryClient.ensureQueryData( siteEdgeCacheStatusQuery( site.ID ) );
+		}
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-caching' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-caching' )( {
+			component: () => <d.default siteSlug={ agencySiteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const agencySiteSettingsApmRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsServer' },
+	head: () => ( { meta: [ { title: __( 'Application Performance Monitoring' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsRoute,
+	path: 'apm',
+} ).lazy( () =>
+	import( '../../sites/settings-apm' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-apm' )( {
+			component: () => <d.default siteSlug={ agencySiteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const agencySiteSettingsWebApplicationFirewallRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsSecurity' },
+	head: () => ( { meta: [ { title: __( 'Web Application Firewall (WAF)' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsRoute,
+	path: 'web-application-firewall',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( hasHostingFeature( site, HostingFeatures.SECURITY_SETTINGS ) ) {
+			await Promise.all( [
+				queryClient.ensureQueryData( siteJetpackModulesQuery( site.ID ) ),
+				queryClient.ensureQueryData( siteJetpackSettingsQuery( site.ID ) ),
+			] );
+		}
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-web-application-firewall' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-web-application-firewall' )( {
+			component: () => <d.default siteSlug={ agencySiteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const agencySiteSettingsWpcomLoginRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsSecurity' },
+	head: () => ( { meta: [ { title: __( 'WordPress.com login' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsRoute,
+	path: 'wpcom-login',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( hasHostingFeature( site, HostingFeatures.SECURITY_SETTINGS ) ) {
+			await Promise.all( [
+				queryClient.ensureQueryData( siteJetpackModulesQuery( site.ID ) ),
+				queryClient.ensureQueryData( siteJetpackSettingsQuery( site.ID ) ),
+			] );
+		}
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-wpcom-login' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-wpcom-login' )( {
+			component: () => <d.default siteSlug={ agencySiteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const agencySiteSettingsDefensiveModeRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsSecurity' },
+	head: () => ( { meta: [ { title: __( 'Defensive mode' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsRoute,
+	path: 'defensive-mode',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( hasHostingFeature( site, HostingFeatures.DEFENSIVE_MODE ) ) {
+			await queryClient.ensureQueryData( siteDefensiveModeSettingsQuery( site.ID ) );
+		}
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-defensive-mode' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-defensive-mode' )( {
+			component: () => <d.default siteSlug={ agencySiteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const agencySiteSettingsTransferSiteRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Transfer site' ) } ] } ),
+	getParentRoute: () => agencySiteSettingsRoute,
+	path: 'transfer-site',
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
+		const user = queryClient.getQueryData< User >( AUTH_QUERY_KEY );
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( ! user || ! canTransferSite( site, user ) ) {
+			throw redirectAsNotAllowed( { to: agencySiteSettingsRoute.fullPath, params: { siteSlug } } );
+		}
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-transfer-site' ).then( ( d ) =>
+		createLazyRoute( 'agency-site-settings-transfer-site' )( {
+			component: () => (
+				<d.default siteSlug={ agencySiteRoute.useParams().siteSlug } context="dashboard_v2" />
+			),
+		} )
+	)
+);
+
 export const createAgencyRoutes = () => [
 	agencyRoute.addChildren( [
 		agencyOverviewRoute,
@@ -856,6 +1542,48 @@ export const createAgencyRoutes = () => [
 			] ),
 			agencySiteMonitoringRoute,
 			agencySiteLogsRoute.addChildren( [ agencySiteLogsIndexRoute, agencySiteActivityRoute ] ),
+			agencySiteSettingsRoute.addChildren( [
+				agencySiteSettingsIndexRoute,
+				agencySiteSettingsTransferSiteRoute,
+
+				// General
+				agencySiteSettingsSiteVisibilityRoute,
+				agencySiteSettingsAIToolsRoute.addChildren( [
+					agencySiteSettingsAIToolsIndexRoute,
+					agencySiteSettingsAIToolsReadRoute,
+					agencySiteSettingsAIToolsWriteRoute,
+					agencySiteSettingsAIToolsSetupRoute,
+				] ),
+				agencySiteSettingsSubscriptionGiftingRoute,
+				agencySiteSettingsAgencyRoute,
+				agencySiteSettingsHundredYearPlanRoute,
+				agencySiteSettingsRedirectRoute,
+
+				// Server
+				agencySiteSettingsWordPressRoute,
+				agencySiteSettingsPHPRoute,
+				agencySiteSettingsSftpSshRoute,
+				agencySiteSettingsCrontabRoute.addChildren( [
+					agencySiteSettingsCrontabIndexRoute,
+					agencySiteSettingsCrontabAddRoute,
+					agencySiteSettingsCrontabEditRoute,
+				] ),
+				agencySiteSettingsRepositoriesRoute.addChildren( [
+					agencySiteSettingsRepositoriesIndexRoute,
+					agencySiteSettingsRepositoriesConnectRoute,
+					agencySiteSettingsRepositoriesManageRoute,
+				] ),
+				agencySiteSettingsDatabaseRoute,
+				agencySiteSettingsPrimaryDataCenterRoute,
+				agencySiteSettingsStaticFile404Route,
+				agencySiteSettingsCachingRoute,
+				...( isEnabled( 'performance/apm' ) ? [ agencySiteSettingsApmRoute ] : [] ),
+
+				// Security
+				agencySiteSettingsWebApplicationFirewallRoute,
+				agencySiteSettingsWpcomLoginRoute,
+				agencySiteSettingsDefensiveModeRoute,
+			] ),
 		] ),
 	] ),
 ];

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -847,6 +847,18 @@ export const agencySiteSettingsRoute = createRoute( {
 	head: () => ( { meta: [ { title: __( 'Settings' ) } ] } ),
 	getParentRoute: () => agencySiteRoute,
 	path: 'settings',
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
+		// Keep the router in sync with the sidebar, which only offers Settings
+		// to users with manage_options on the site.
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( ! site.capabilities?.manage_options ) {
+			throw redirectAsNotAllowed( { to: `/sites/${ siteSlug }` } );
+		}
+	},
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -875,16 +875,6 @@ const agencySiteSettingsSiteVisibilityRoute = createRoute( {
 	head: () => ( { meta: [ { title: __( 'Site visibility' ) } ] } ),
 	getParentRoute: () => agencySiteSettingsRoute,
 	path: 'site-visibility',
-	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
-		if ( cause === 'preload' ) {
-			return;
-		}
-
-		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( site.is_wpcom_flex ) {
-			throw redirectAsNotAllowed( { to: agencySiteSettingsRoute.fullPath, params: { siteSlug } } );
-		}
-	},
 	loader: async ( { context, params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 

--- a/client/dashboard/domains/add-domain-button.tsx
+++ b/client/dashboard/domains/add-domain-button.tsx
@@ -17,7 +17,10 @@ function buildDomainQueryArgs( siteSlug?: string, adminUrl?: string ) {
 
 	if ( siteSlug ) {
 		queryArgs.siteSlug = siteSlug;
-		queryArgs.domainConnectionSetupUrl = getDomainConnectionSetupTemplateUrl();
+		const domainConnectionSetupUrl = getDomainConnectionSetupTemplateUrl();
+		if ( domainConnectionSetupUrl ) {
+			queryArgs.domainConnectionSetupUrl = domainConnectionSetupUrl;
+		}
 	}
 
 	const dashboard = getCurrentDashboard();

--- a/client/dashboard/sites/settings-ai-tools/read/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/read/index.tsx
@@ -2,6 +2,7 @@ import '../style.scss';
 
 import { userSettingsQuery, userSettingsMutation, siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
+import { useParams } from '@tanstack/react-router';
 import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
@@ -17,7 +18,6 @@ import {
 	mergeSiteMcpAbilities,
 } from '../../../../me/mcp/utils';
 import Breadcrumbs from '../../../app/breadcrumbs';
-import { siteRoute } from '../../../app/router/sites';
 import { withSnackbar } from '../../../app/snackbars/with-snackbar';
 import { Card, CardBody, CardDivider, CardHeader } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
@@ -45,7 +45,7 @@ interface McpAbility {
 }
 
 export default function SiteAIToolsRead() {
-	const { siteSlug } = siteRoute.useParams();
+	const { siteSlug } = useParams( { strict: false } ) as { siteSlug: string };
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 

--- a/client/dashboard/sites/settings-ai-tools/setup/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/setup/index.tsx
@@ -1,5 +1,6 @@
 import { userSettingsQuery, siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { useParams } from '@tanstack/react-router';
 import {
 	Button,
 	ExternalLink,
@@ -15,7 +16,6 @@ import { copy, check } from '@wordpress/icons';
 import { useState } from 'react';
 import { getSiteLevelEnabled } from '../../../../me/mcp/utils';
 import Breadcrumbs from '../../../app/breadcrumbs';
-import { siteRoute } from '../../../app/router/sites';
 import { Card, CardBody } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
 import { PageHeader } from '../../../components/page-header';
@@ -26,7 +26,7 @@ import { SectionHeader } from '../../../components/section-header';
 import '../../../me/mcp/setup/style.scss';
 
 function SiteAIToolsSetup() {
-	const { siteSlug } = siteRoute.useParams();
+	const { siteSlug } = useParams( { strict: false } ) as { siteSlug: string };
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 

--- a/client/dashboard/sites/settings-ai-tools/write/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/write/index.tsx
@@ -2,6 +2,7 @@ import '../style.scss';
 
 import { userSettingsQuery, userSettingsMutation, siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
+import { useParams } from '@tanstack/react-router';
 import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
@@ -17,7 +18,6 @@ import {
 	mergeSiteMcpAbilities,
 } from '../../../../me/mcp/utils';
 import Breadcrumbs from '../../../app/breadcrumbs';
-import { siteRoute } from '../../../app/router/sites';
 import { withSnackbar } from '../../../app/snackbars/with-snackbar';
 import { Card, CardBody, CardDivider, CardHeader } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
@@ -45,7 +45,7 @@ interface McpAbility {
 }
 
 export default function SiteAIToolsWrite() {
-	const { siteSlug } = siteRoute.useParams();
+	const { siteSlug } = useParams( { strict: false } ) as { siteSlug: string };
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 

--- a/client/dashboard/sites/settings-crontab/crontab-form.tsx
+++ b/client/dashboard/sites/settings-crontab/crontab-form.tsx
@@ -4,7 +4,7 @@ import {
 	siteCrontabUpdateMutation,
 } from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
+import { useNavigate, useParams } from '@tanstack/react-router';
 import { __experimentalVStack as VStack, Button, TextControl } from '@wordpress/components';
 import { DataForm, type Field } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
@@ -12,7 +12,6 @@ import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import {
-	siteRoute,
 	siteSettingsCrontabAddRoute,
 	siteSettingsCrontabEditRoute,
 	siteSettingsCrontabRoute,
@@ -33,7 +32,7 @@ interface CrontabFormProps {
 
 export default function CrontabForm( { crontab }: CrontabFormProps ) {
 	const isEditMode = !! crontab;
-	const { siteSlug } = siteRoute.useParams();
+	const { siteSlug } = useParams( { strict: false } ) as { siteSlug: string };
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const navigate = useNavigate( {
 		from: isEditMode ? siteSettingsCrontabEditRoute.fullPath : siteSettingsCrontabAddRoute.fullPath,

--- a/client/dashboard/sites/settings-crontab/crontab-form.tsx
+++ b/client/dashboard/sites/settings-crontab/crontab-form.tsx
@@ -11,17 +11,13 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
-import {
-	siteSettingsCrontabAddRoute,
-	siteSettingsCrontabEditRoute,
-	siteSettingsCrontabRoute,
-} from '../../app/router/sites';
 import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
+import { getSiteSettingsCrontabURL } from '../../utils/site-url';
 import { parseRequestedScheduleForBackwardCompatibility } from './parse-requested-schedule-for-backward-compatibility';
 import { ScheduleField } from './schedule-field';
 import type { Crontab, CrontabFormData } from '@automattic/api-core';
@@ -34,9 +30,7 @@ export default function CrontabForm( { crontab }: CrontabFormProps ) {
 	const isEditMode = !! crontab;
 	const { siteSlug } = useParams( { strict: false } ) as { siteSlug: string };
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const navigate = useNavigate( {
-		from: isEditMode ? siteSettingsCrontabEditRoute.fullPath : siteSettingsCrontabAddRoute.fullPath,
-	} );
+	const navigate = useNavigate();
 
 	// Initialize form data once from the loaded crontab (edit mode) or defaults (add mode)
 	const [ formData, setFormData ] = useState< CrontabFormData >( () => {
@@ -69,10 +63,7 @@ export default function CrontabForm( { crontab }: CrontabFormProps ) {
 	const isPending = isEditMode ? isUpdating : isCreating;
 
 	const handleCancel = () => {
-		navigate( {
-			to: siteSettingsCrontabRoute.fullPath,
-			params: { siteSlug },
-		} );
+		navigate( { to: getSiteSettingsCrontabURL( siteSlug ) } );
 	};
 
 	const handleSubmit = ( e: React.FormEvent ) => {
@@ -83,10 +74,7 @@ export default function CrontabForm( { crontab }: CrontabFormProps ) {
 		}
 
 		const onSuccess = () => {
-			navigate( {
-				to: siteSettingsCrontabRoute.fullPath,
-				params: { siteSlug },
-			} );
+			navigate( { to: getSiteSettingsCrontabURL( siteSlug ) } );
 		};
 
 		if ( isEditMode && crontab ) {

--- a/client/dashboard/sites/settings-crontab/edit-crontab.tsx
+++ b/client/dashboard/sites/settings-crontab/edit-crontab.tsx
@@ -1,16 +1,14 @@
 import { siteBySlugQuery, siteCrontabsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
-import {
-	siteRoute,
-	siteSettingsCrontabEditRoute,
-	siteSettingsCrontabRoute,
-} from '../../app/router/sites';
+import { useNavigate, useParams } from '@tanstack/react-router';
+import { siteSettingsCrontabEditRoute, siteSettingsCrontabRoute } from '../../app/router/sites';
 import CrontabForm from './crontab-form';
 
 export default function EditCrontab() {
-	const { siteSlug } = siteRoute.useParams();
-	const { cronId } = siteSettingsCrontabEditRoute.useParams();
+	const { siteSlug, cronId } = useParams( { strict: false } ) as {
+		siteSlug: string;
+		cronId: number;
+	};
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const navigate = useNavigate( { from: siteSettingsCrontabEditRoute.fullPath } );
 

--- a/client/dashboard/sites/settings-crontab/edit-crontab.tsx
+++ b/client/dashboard/sites/settings-crontab/edit-crontab.tsx
@@ -1,7 +1,7 @@
 import { siteBySlugQuery, siteCrontabsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate, useParams } from '@tanstack/react-router';
-import { siteSettingsCrontabEditRoute, siteSettingsCrontabRoute } from '../../app/router/sites';
+import { getSiteSettingsCrontabURL } from '../../utils/site-url';
 import CrontabForm from './crontab-form';
 
 export default function EditCrontab() {
@@ -10,7 +10,7 @@ export default function EditCrontab() {
 		cronId: number;
 	};
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const navigate = useNavigate( { from: siteSettingsCrontabEditRoute.fullPath } );
+	const navigate = useNavigate();
 
 	// Data is preloaded by the route loader
 	const { data: crontabs = [] } = useSuspenseQuery( siteCrontabsQuery( site.ID ) );
@@ -18,10 +18,7 @@ export default function EditCrontab() {
 
 	// If crontab not found, redirect back to list
 	if ( ! crontab ) {
-		navigate( {
-			to: siteSettingsCrontabRoute.fullPath,
-			params: { siteSlug },
-		} );
+		navigate( { to: getSiteSettingsCrontabURL( siteSlug ) } );
 		return null;
 	}
 

--- a/client/dashboard/sites/settings-crontab/index.tsx
+++ b/client/dashboard/sites/settings-crontab/index.tsx
@@ -21,7 +21,6 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { useLocale } from '../../app/locale';
-import { siteSettingsCrontabAddRoute, siteSettingsCrontabEditRoute } from '../../app/router/sites';
 import ConfirmModal from '../../components/confirm-modal';
 import { DataViewsCard } from '../../components/dataviews';
 import InlineSupportLink from '../../components/inline-support-link';
@@ -29,6 +28,7 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import TimeSince, { useTimeSince } from '../../components/time-since';
 import { hasHostingFeature } from '../../utils/site-features';
+import { getSiteSettingsCrontabAddURL, getSiteSettingsCrontabEditURL } from '../../utils/site-url';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import { parseRequestedScheduleForBackwardCompatibility } from './parse-requested-schedule-for-backward-compatibility';
 import { formatScheduleLabel, formatScheduleDescription } from './schedules';
@@ -221,8 +221,7 @@ export default function CrontabSettings( { siteSlug }: { siteSlug: string } ) {
 			label: __( 'Edit' ),
 			callback: ( items: Crontab[] ) => {
 				router.navigate( {
-					to: siteSettingsCrontabEditRoute.fullPath,
-					params: { siteSlug, cronId: items[ 0 ].cron_id },
+					to: getSiteSettingsCrontabEditURL( siteSlug, items[ 0 ].cron_id ),
 				} );
 			},
 		},
@@ -262,8 +261,7 @@ export default function CrontabSettings( { siteSlug }: { siteSlug: string } ) {
 								__next40pxDefaultSize
 								onClick={ () =>
 									router.navigate( {
-										to: siteSettingsCrontabAddRoute.fullPath,
-										params: { siteSlug },
+										to: getSiteSettingsCrontabAddURL( siteSlug ),
 									} )
 								}
 							>

--- a/client/dashboard/sites/settings-crontab/summary.tsx
+++ b/client/dashboard/sites/settings-crontab/summary.tsx
@@ -7,6 +7,7 @@ import { scheduled } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { hasHostingFeature } from '../../utils/site-features';
+import { getSiteSettingsCrontabURL } from '../../utils/site-url';
 import type { Site } from '@automattic/api-core';
 import type { Density } from '@automattic/components/src/summary-button/types';
 
@@ -48,7 +49,7 @@ export default function CrontabSettingsSummary( {
 
 	return (
 		<RouterLinkSummaryButton
-			to={ `/sites/${ site.slug }/settings/crontab` }
+			to={ getSiteSettingsCrontabURL( site.slug ) }
 			title={ __( 'Cron' ) }
 			density={ density }
 			decoration={ <Icon icon={ scheduled } /> }

--- a/client/dashboard/sites/settings-plan/summary.tsx
+++ b/client/dashboard/sites/settings-plan/summary.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { payment } from '@wordpress/icons';
+import { useAppContext } from '../../app/context';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 import { getSitePlanDisplayName } from '../../utils/site-plan';
 import { getSitePlanUrl } from '../../utils/site-url';
@@ -24,8 +25,16 @@ export default function SettingsPlanSummary( {
 		enabled: !! plan?.id,
 	} );
 
+	const { supports } = useAppContext();
+
 	const url = getSitePlanUrl( site, purchase );
 	if ( ! url || ! isRelativeUrl( url ) ) {
+		return null;
+	}
+
+	// The purchase-management URL only resolves in dashboards that register the
+	// `/me/billing` routes.
+	if ( url.startsWith( '/me/billing/' ) && ! ( supports.me && supports.me.billing ) ) {
 		return null;
 	}
 

--- a/client/dashboard/sites/settings-redirect/manage-site-redirect.tsx
+++ b/client/dashboard/sites/settings-redirect/manage-site-redirect.tsx
@@ -6,6 +6,7 @@ import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { useAppContext } from '../../app/context';
 import { purchaseSettingsRoute } from '../../app/router/me';
 import { Card, CardBody } from '../../components/card';
 import SiteRedirectForm, { SiteRedirectFormData } from './site-redirect-form';
@@ -16,6 +17,7 @@ interface ManageSiteRedirectProps {
 }
 
 export default function ManageSiteRedirect( { siteId, currentRedirect }: ManageSiteRedirectProps ) {
+	const { supports } = useAppContext();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { mutate: updateSiteRedirect, isPending } = useMutation(
 		updateSiteRedirectMutation( siteId )
@@ -50,7 +52,7 @@ export default function ManageSiteRedirect( { siteId, currentRedirect }: ManageS
 						isSubmitting={ isPending }
 						disableWhenUnchanged
 					/>
-					{ purchase && (
+					{ purchase && !! ( supports.me && supports.me.billing ) && (
 						<Text>
 							{ createInterpolateElement( __( '<link>Manage</link> your site redirect upgrade.' ), {
 								link: (

--- a/client/dashboard/sites/settings-repositories/configure-repository.tsx
+++ b/client/dashboard/sites/settings-repositories/configure-repository.tsx
@@ -4,11 +4,10 @@ import {
 	codeDeploymentQuery,
 } from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
+import { useNavigate, useParams } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
 import {
-	siteRoute,
 	siteSettingsRepositoriesRoute,
 	siteSettingsRepositoriesManageRoute,
 } from '../../app/router/sites';
@@ -18,7 +17,10 @@ import PageLayout from '../../components/page-layout';
 import { ConnectRepositoryForm } from './connect-repository-form';
 
 export default function ConfigureRepository() {
-	const { siteSlug, deploymentId } = siteRoute.useParams();
+	const { siteSlug, deploymentId } = useParams( { strict: false } ) as {
+		siteSlug: string;
+		deploymentId: number;
+	};
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: existingDeployment } = useSuspenseQuery(
 		codeDeploymentQuery( site.ID, deploymentId )

--- a/client/dashboard/sites/settings-repositories/configure-repository.tsx
+++ b/client/dashboard/sites/settings-repositories/configure-repository.tsx
@@ -7,13 +7,10 @@ import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { useNavigate, useParams } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
-import {
-	siteSettingsRepositoriesRoute,
-	siteSettingsRepositoriesManageRoute,
-} from '../../app/router/sites';
 import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { getSiteSettingsRepositoriesURL } from '../../utils/site-url';
 import { ConnectRepositoryForm } from './connect-repository-form';
 
 export default function ConfigureRepository() {
@@ -25,13 +22,10 @@ export default function ConfigureRepository() {
 	const { data: existingDeployment } = useSuspenseQuery(
 		codeDeploymentQuery( site.ID, deploymentId )
 	);
-	const navigateFrom = siteSettingsRepositoriesManageRoute.fullPath;
-	const navigate = useNavigate( {
-		from: navigateFrom,
-	} );
+	const navigate = useNavigate();
 
 	const handleCancel = () => {
-		navigate( { to: siteSettingsRepositoriesRoute.fullPath } );
+		navigate( { to: getSiteSettingsRepositoriesURL( siteSlug ) } );
 	};
 
 	const updateMutation = useMutation( updateCodeDeploymentMutation( site.ID, deploymentId ?? 0 ) );
@@ -80,7 +74,6 @@ export default function ConfigureRepository() {
 								{ reason }
 							)
 						}
-						navigateFrom={ navigateFrom }
 					/>
 				</CardBody>
 			</Card>

--- a/client/dashboard/sites/settings-repositories/connect-repository-form.tsx
+++ b/client/dashboard/sites/settings-repositories/connect-repository-form.tsx
@@ -8,7 +8,7 @@ import {
 	codeDeploymentsQuery,
 } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery, UseMutationResult } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
+import { useNavigate, useParams } from '@tanstack/react-router';
 import {
 	Button,
 	ComboboxControl,
@@ -28,7 +28,6 @@ import { __ } from '@wordpress/i18n';
 import { Icon, lock } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useEffect, useMemo, useState, useCallback, useRef } from 'react';
-import { siteRoute } from '../../app/router/sites';
 import { SectionHeader } from '../../components/section-header';
 import { AdvancedWorkflowStyle } from './advanced-workflow-style';
 import { useInstallGithub } from './use-install-github';
@@ -235,7 +234,7 @@ export const ConnectRepositoryForm = ( {
 }: ConnectRepositoryFormProps ) => {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const navigate = useNavigate( { from: navigateFrom } );
-	const { siteSlug } = siteRoute.useParams();
+	const { siteSlug } = useParams( { strict: false } ) as { siteSlug: string };
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const {
 		data: installations = [],

--- a/client/dashboard/sites/settings-repositories/connect-repository-form.tsx
+++ b/client/dashboard/sites/settings-repositories/connect-repository-form.tsx
@@ -29,6 +29,7 @@ import { Icon, lock } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useEffect, useMemo, useState, useCallback, useRef } from 'react';
 import { SectionHeader } from '../../components/section-header';
+import { getSiteSettingsRepositoriesURL } from '../../utils/site-url';
 import { AdvancedWorkflowStyle } from './advanced-workflow-style';
 import { useInstallGithub } from './use-install-github';
 import type {
@@ -37,7 +38,6 @@ import type {
 	CreateAndUpdateCodeDeploymentVariables,
 	CreateAndUpdateCodeDeploymentResponse,
 } from '@automattic/api-core';
-import type { NavigateOptions } from '@tanstack/react-router';
 
 interface ConnectRepositoryFormProps {
 	formTitle: string;
@@ -53,7 +53,6 @@ interface ConnectRepositoryFormProps {
 	submitText: string;
 	successMessage: string;
 	errorMessage: ( reason: string ) => string;
-	navigateFrom: NavigateOptions[ 'from' ];
 }
 
 export interface ConnectRepositoryFormData {
@@ -230,10 +229,9 @@ export const ConnectRepositoryForm = ( {
 	submitText,
 	successMessage,
 	errorMessage,
-	navigateFrom,
 }: ConnectRepositoryFormProps ) => {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const navigate = useNavigate( { from: navigateFrom } );
+	const navigate = useNavigate();
 	const { siteSlug } = useParams( { strict: false } ) as { siteSlug: string };
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const {
@@ -431,7 +429,7 @@ export const ConnectRepositoryForm = ( {
 				createSuccessNotice( successMessage, {
 					type: 'snackbar',
 				} );
-				navigate( { to: '/sites/$siteSlug/settings/repositories' } );
+				navigate( { to: getSiteSettingsRepositoriesURL( siteSlug ) } );
 			},
 			onError: ( error ) => {
 				createErrorNotice( errorMessage( error.message ), {

--- a/client/dashboard/sites/settings-repositories/connect-repository.tsx
+++ b/client/dashboard/sites/settings-repositories/connect-repository.tsx
@@ -4,11 +4,10 @@ import {
 	createCodeDeploymentMutation,
 } from '@automattic/api-queries';
 import { useSuspenseQuery, useQuery, useMutation } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
+import { useNavigate, useParams } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
 import {
-	siteRoute,
 	siteSettingsRepositoriesConnectRoute,
 	siteSettingsRepositoriesRoute,
 } from '../../app/router/sites';
@@ -19,7 +18,7 @@ import { ConnectRepositoryForm } from './connect-repository-form';
 import type { ConnectRepositoryFormData } from './connect-repository-form';
 
 export default function ConnectRepository() {
-	const { siteSlug } = siteRoute.useParams();
+	const { siteSlug } = useParams( { strict: false } ) as { siteSlug: string };
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: installations = [] } = useQuery( githubInstallationsQuery() );
 	const navigateFrom = siteSettingsRepositoriesConnectRoute.fullPath;

--- a/client/dashboard/sites/settings-repositories/connect-repository.tsx
+++ b/client/dashboard/sites/settings-repositories/connect-repository.tsx
@@ -7,13 +7,10 @@ import { useSuspenseQuery, useQuery, useMutation } from '@tanstack/react-query';
 import { useNavigate, useParams } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
-import {
-	siteSettingsRepositoriesConnectRoute,
-	siteSettingsRepositoriesRoute,
-} from '../../app/router/sites';
 import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { getSiteSettingsRepositoriesURL } from '../../utils/site-url';
 import { ConnectRepositoryForm } from './connect-repository-form';
 import type { ConnectRepositoryFormData } from './connect-repository-form';
 
@@ -21,11 +18,10 @@ export default function ConnectRepository() {
 	const { siteSlug } = useParams( { strict: false } ) as { siteSlug: string };
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: installations = [] } = useQuery( githubInstallationsQuery() );
-	const navigateFrom = siteSettingsRepositoriesConnectRoute.fullPath;
-	const navigate = useNavigate( { from: navigateFrom } );
+	const navigate = useNavigate();
 
 	const handleCancel = () => {
-		navigate( { to: siteSettingsRepositoriesRoute.fullPath } );
+		navigate( { to: getSiteSettingsRepositoriesURL( siteSlug ) } );
 	};
 
 	const createMutation = useMutation( createCodeDeploymentMutation( site.ID ) );
@@ -70,7 +66,6 @@ export default function ConnectRepository() {
 								{ reason }
 							)
 						}
-						navigateFrom={ navigateFrom }
 					/>
 				</CardBody>
 			</Card>

--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -5,7 +5,7 @@ import {
 	githubInstallationsQuery,
 } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { useNavigate, useRouter } from '@tanstack/react-router';
+import { useNavigate, useParams, useRouter, useSearch } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
@@ -14,7 +14,6 @@ import Breadcrumbs from '../../app/breadcrumbs';
 import { usePersistentView } from '../../app/hooks/use-persistent-view';
 import {
 	siteDeploymentsListRoute,
-	siteRoute,
 	siteSettingsRepositoriesConnectRoute,
 	siteSettingsRepositoriesManageRoute,
 	siteSettingsRepositoriesRoute,
@@ -34,13 +33,13 @@ import type { RenderModalProps, Action } from '@wordpress/dataviews';
 
 function RepositoriesList() {
 	const router = useRouter();
-	const { siteSlug } = siteRoute.useParams();
+	const { siteSlug } = useParams( { strict: false } ) as { siteSlug: string };
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { error: githubInstallationsError, isLoading: isLoadingInstallations } = useQuery(
 		githubInstallationsQuery()
 	);
 
-	const searchParams = siteSettingsRepositoriesRoute.useSearch();
+	const searchParams = useSearch( { strict: false } );
 	const { view, updateView, resetView } = usePersistentView( {
 		slug: 'site-settings-repositories',
 		defaultView: DEFAULT_VIEW,
@@ -162,7 +161,7 @@ function RepositoriesList() {
 }
 
 function SiteRepositories() {
-	const { siteSlug } = siteRoute.useParams();
+	const { siteSlug } = useParams( { strict: false } ) as { siteSlug: string };
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const navigate = useNavigate( { from: siteSettingsRepositoriesRoute.fullPath } );
 	const canConnect = hasHostingFeature( site, HostingFeatures.DEPLOYMENT );

--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -12,16 +12,15 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { usePersistentView } from '../../app/hooks/use-persistent-view';
-import {
-	siteDeploymentsListRoute,
-	siteSettingsRepositoriesConnectRoute,
-	siteSettingsRepositoriesManageRoute,
-	siteSettingsRepositoriesRoute,
-} from '../../app/router/sites';
 import { DataViews, DataViewsCard } from '../../components/dataviews';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { hasHostingFeature } from '../../utils/site-features';
+import {
+	getSiteDeploymentsURL,
+	getSiteSettingsRepositoriesConnectURL,
+	getSiteSettingsRepositoriesManageURL,
+} from '../../utils/site-url';
 import illustrationUrl from '../deployments/deployments-callout-illustration.svg';
 import GithubIcon from '../deployments/icons/github';
 import { TriggerDeploymentModalForm } from '../deployments-list/trigger-deployment-modal-form';
@@ -74,11 +73,7 @@ function RepositoriesList() {
 			label: __( 'Configure repository' ),
 			callback: ( items ) => {
 				router.navigate( {
-					to: siteSettingsRepositoriesManageRoute.fullPath,
-					params: {
-						siteSlug: siteSlug,
-						deploymentId: items[ 0 ].id,
-					},
+					to: getSiteSettingsRepositoriesManageURL( siteSlug, items[ 0 ].id ),
 				} );
 			},
 		},
@@ -88,10 +83,7 @@ function RepositoriesList() {
 			callback: ( items ) => {
 				const repositoryName = items[ 0 ]?.repository_name;
 				router.navigate( {
-					to: siteDeploymentsListRoute.fullPath,
-					params: {
-						siteSlug: siteSlug,
-					},
+					to: getSiteDeploymentsURL( siteSlug ),
 					search: repositoryName ? { repository: repositoryName } : undefined,
 				} );
 			},
@@ -118,7 +110,7 @@ function RepositoriesList() {
 					<Button
 						variant="link"
 						onClick={ () =>
-							router.navigate( { to: siteSettingsRepositoriesConnectRoute.fullPath } )
+							router.navigate( { to: getSiteSettingsRepositoriesConnectURL( siteSlug ) } )
 						}
 					/>
 				),
@@ -149,8 +141,7 @@ function RepositoriesList() {
 						const item = filteredData.find( ( d ) => d.id.toString() === selection[ 0 ] );
 						if ( item ) {
 							router.navigate( {
-								to: siteSettingsRepositoriesManageRoute.fullPath,
-								params: { siteSlug, deploymentId: item.id },
+								to: getSiteSettingsRepositoriesManageURL( siteSlug, item.id ),
 							} );
 						}
 					}
@@ -163,11 +154,11 @@ function RepositoriesList() {
 function SiteRepositories() {
 	const { siteSlug } = useParams( { strict: false } ) as { siteSlug: string };
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const navigate = useNavigate( { from: siteSettingsRepositoriesRoute.fullPath } );
+	const navigate = useNavigate();
 	const canConnect = hasHostingFeature( site, HostingFeatures.DEPLOYMENT );
 
 	const handleConnectRepository = () => {
-		navigate( { to: siteSettingsRepositoriesConnectRoute.fullPath } );
+		navigate( { to: getSiteSettingsRepositoriesConnectURL( siteSlug ) } );
 	};
 
 	return (

--- a/client/dashboard/sites/settings-repositories/summary.tsx
+++ b/client/dashboard/sites/settings-repositories/summary.tsx
@@ -2,6 +2,7 @@ import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
+import { getSiteSettingsRepositoriesURL } from '../../utils/site-url';
 import GithubIcon from '../deployments/icons/github';
 import type { Site } from '@automattic/api-core';
 import type { Density } from '@automattic/components/src/summary-button/types';
@@ -18,7 +19,7 @@ export default function RepositoriesSettingsSummary( {
 	}
 	return (
 		<RouterLinkSummaryButton
-			to={ `/sites/${ site.slug }/settings/repositories` }
+			to={ getSiteSettingsRepositoriesURL( site.slug ) }
 			title={ __( 'GitHub repositories' ) }
 			density={ density }
 			decoration={ <Icon icon={ <GithubIcon width={ 24 } height={ 24 } /> } /> }

--- a/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
@@ -27,6 +27,7 @@ import { trash } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState } from 'react';
 import { useAuth } from '../../app/auth';
+import { useAppContext } from '../../app/context';
 import { securitySshKeyRoute } from '../../app/router/me';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
@@ -89,12 +90,20 @@ const SshKeyCard = ( {
 };
 
 const AddSshKeyButton = () => {
+	const { supports } = useAppContext();
+
 	if ( isDashboardBackport() ) {
 		return (
 			<Button variant="secondary" target="_blank" href="/me/security/ssh-key" rel="noreferrer">
 				{ __( 'Add new SSH key ↗' ) }
 			</Button>
 		);
+	}
+
+	// The SSH key settings page only exists in dashboards that register the
+	// `/me/security` routes.
+	if ( ! ( supports.me && supports.me.security ) ) {
+		return null;
 	}
 
 	return (

--- a/client/dashboard/utils/domain-url.ts
+++ b/client/dashboard/utils/domain-url.ts
@@ -5,12 +5,15 @@ import { isDashboardBackport } from './is-dashboard-backport';
 import { dashboardLink, redirectToDashboardLink, wpcomLink } from './link';
 import type { Domain } from '@automattic/api-core';
 
-export function getDomainConnectionSetupTemplateUrl() {
-	const domainConnectionSetupTemplateUrl = domainConnectionSetupRoute.fullPath.replace(
-		'$domainName',
-		'%s'
-	);
-	return dashboardLink( domainConnectionSetupTemplateUrl );
+export function getDomainConnectionSetupTemplateUrl(): string | undefined {
+	// fullPath is only materialized once the domains route group is registered
+	// in the current dashboard's route tree; dashboards without the domains
+	// section (e.g. A4A) have no connection-setup page to link to.
+	const fullPath: string | undefined = domainConnectionSetupRoute.fullPath;
+	if ( ! fullPath ) {
+		return undefined;
+	}
+	return dashboardLink( fullPath.replace( '$domainName', '%s' ) );
 }
 
 export function getCreateSiteFromDomainOnlyUrl( domain: Domain ) {
@@ -27,9 +30,11 @@ export function getAddSiteDomainUrl( siteSlug: string ) {
 		return addQueryArgs( `/domains/add/${ siteSlug }`, { redirect_to: backUrl } );
 	}
 
+	const domainConnectionSetupUrl = getDomainConnectionSetupTemplateUrl();
+
 	return addQueryArgs( wpcomLink( '/setup/domain' ), {
 		siteSlug,
-		domainConnectionSetupUrl: getDomainConnectionSetupTemplateUrl(),
+		...( domainConnectionSetupUrl && { domainConnectionSetupUrl } ),
 		back_to: backUrl,
 		redirect_to: backUrl,
 		dashboard: getCurrentDashboard(),

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -70,6 +70,34 @@ export function getSiteVisibilityURL( site: Site ) {
  * - If the site is a wpcom site without a purchase, returns the URL to upgrade the site plan.
  * - Otherwise, returns the most appropriate URL to manage the site's current plan.
  */
+export function getSiteSettingsCrontabURL( siteSlug: string ) {
+	return `/sites/${ siteSlug }/settings/crontab`;
+}
+
+export function getSiteSettingsCrontabAddURL( siteSlug: string ) {
+	return `${ getSiteSettingsCrontabURL( siteSlug ) }/add`;
+}
+
+export function getSiteSettingsCrontabEditURL( siteSlug: string, cronId: number ) {
+	return `${ getSiteSettingsCrontabURL( siteSlug ) }/${ cronId }/edit`;
+}
+
+export function getSiteSettingsRepositoriesURL( siteSlug: string ) {
+	return `/sites/${ siteSlug }/settings/repositories`;
+}
+
+export function getSiteSettingsRepositoriesConnectURL( siteSlug: string ) {
+	return `${ getSiteSettingsRepositoriesURL( siteSlug ) }/connect`;
+}
+
+export function getSiteSettingsRepositoriesManageURL( siteSlug: string, deploymentId: number ) {
+	return `${ getSiteSettingsRepositoriesURL( siteSlug ) }/manage/${ deploymentId }`;
+}
+
+export function getSiteDeploymentsURL( siteSlug: string ) {
+	return `/sites/${ siteSlug }/deployments`;
+}
+
 export function getSitePlanUrl( site: Site, purchase?: Purchase ) {
 	if ( site.is_wpcom_staging_site ) {
 		return undefined;


### PR DESCRIPTION

Resolves A4A-3021 and A4A-3063

## Proposed Changes

Adds Settings and richer overview info to a site's page in the Automattic for Agencies dashboard:

* On the site **Overview**:
  * The header now shows the site's **WordPress version**, **PHP version**, and **hosting type** under the site name, with the versions linking to their settings pages.
  * A **Visibility card** at the top of the card grid showing whether the site is Public, Private, or Coming soon (with launch progress for unlaunched sites), linking to the visibility settings.
* A **Settings** item in the site sidebar, shown for WP.com sites when the user can manage the site.
* The full **Settings hub** with the same sections as the main dashboard:
  * **General** — site visibility, AI tools, site redirect, gift subscriptions, and plan.
  * **Server** — WordPress and PHP versions, SFTP/SSH, cron, GitHub repositories, database, handling of nonexistent assets, and caching.
  * **Security** — Web Application Firewall, WordPress.com login, and defensive mode.
  * Plus site **Actions** (re-install plugins & themes, duplicate) and the **Danger zone** (transfer, leave, reset, delete).
* Self-hosted Jetpack sites don't get a Settings section, and opening a settings URL directly redirects back to the site overview.
* A few settings pages that were tied to the main dashboard's routes were loosened so both dashboards can share them — the main dashboard behaves exactly as before.

This reuses the same Settings experience the main dashboard already has, so agency-managed sites get the exact same pages.

## Why are these changes being made?

Agencies could see a site's overview, backups, scan, performance, and logs, but had no way to manage the site's settings from the new site page. This brings Settings to agency-managed sites, matching the recent additions of Scan, Performance, and Monitoring.

## Known dependencies and limitations

* Some server pages — **Defensive mode, Caching, SFTP/SSH, Cron, and the "Open phpMyAdmin" action** — also need a backend change that lets this dashboard call the Atomic hosting endpoints. Until that ships they show an error or an empty state on the agency dashboard (they already work on the main dashboard). Backend PR: **[to be added]**
* Known dead-end links, same category as earlier reuse PRs: "Manage plan" on the hub and "View deployment runs" on the repositories page point to routes the agency dashboard doesn't register yet.

## Testing Instructions

1. Patch 229086-ghe-Automattic/wpcom
2. Open the Dashboard Live (A4A) link > replace `/sites` in the URL with `/overview` to see the A4A dashboard.
3. Open a WP.com site: the overview header shows the WordPress version, PHP version, and hosting type (the versions link to their settings pages), and a **Visibility** card appears in the card grid, reflecting the site's actual state and linking to the visibility settings.
4. Confirm **Settings** appears at the bottom of the sidebar.
5. On the Settings hub, confirm the **General**, **Server**, and **Security** sections show with the right badges, plus **Actions** and **Danger zone**.
6. Spot-check subpages — Site visibility, WordPress, PHP, Web Application Firewall, WordPress.com login — and confirm they load and save the same as on the main dashboard.
7. Defensive mode, Caching, SFTP/SSH, Cron, and "Open phpMyAdmin" require the backend change above; until it's deployed, expect an error page or empty state for those.
8. Open a self-hosted Jetpack site and confirm there is no Settings item, and that opening `/sites/<site>/settings` directly redirects to the site overview.
9. Confirm nothing changed on the main (dotcom) dashboard, especially the shared pages: GitHub repositories (list, connect, configure), Cron (add/edit), and the AI tools subpages.

<img width="1336" height="713" alt="Screenshot 2026-08-05 at 2 24 03 PM" src="https://github.com/user-attachments/assets/611fb5f9-0c0b-4bd4-8b83-4ce5f4f4f23e" />

<img width="2704" height="3858" alt="screencapture-container-vigorous-liskov-a4a-calypso-live-sites-darkdefendor3-wpcomstaging-com-settings-2026-08-05-14_24_47" src="https://github.com/user-attachments/assets/f0d6658f-6723-46c6-af0b-dcfbca32505a" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)