### PR TITLE
E2E: Add email verification diagnostics

### DIFF
--- a/test/e2e/lib/pw-base.ts
+++ b/test/e2e/lib/pw-base.ts
@@ -90,6 +90,7 @@ import {
 	apiCloseAccount,
 	apiWaitForBearerTokenAcceptance,
 	apiWaitForEmailVerification,
+	visitEmailActivationLink,
 } from '../specs/shared';
 import { useBlackboxTestKeyForCollect } from './blackbox-test-key';
 import { snoozeAccountRecoveryInterstitial } from './dashboard-helpers';
@@ -637,7 +638,7 @@ export const test = base.extend<
 			const activationLink = links.find( ( link: string ) =>
 				link.includes( 'activate' )
 			) as string;
-			await page.goto( activationLink );
+			await visitEmailActivationLink( page, activationLink, testUser.email );
 			await apiWaitForEmailVerification( restAPIClient, testUser.email );
 			// Fresh accounts have no recovery method set up, so the dashboard's
 			// account-recovery interstitial would mount over every route and block

--- a/test/e2e/specs/authentication/authentication__dashboard-two-step.spec.ts
+++ b/test/e2e/specs/authentication/authentication__dashboard-two-step.spec.ts
@@ -5,6 +5,7 @@ import {
 	apiCloseAccount,
 	apiWaitForBearerTokenAcceptance,
 	apiWaitForEmailVerification,
+	visitEmailActivationLink,
 } from '../shared';
 import type { LoginPage } from '@automattic/calypso-e2e';
 import type { CDPSession, Page } from 'playwright';
@@ -157,7 +158,7 @@ test.describe(
 				} );
 				const links = await clientEmail.getLinksFromMessage( message );
 				const activationLink = links.find( ( link ) => link.includes( 'activate' ) ) as string;
-				await page.goto( activationLink );
+				await visitEmailActivationLink( page, activationLink, testUser.email );
 				await apiWaitForEmailVerification( restAPIClient!, testUser.email );
 
 				// A fresh account has no recovery method, so the dashboard's

--- a/test/e2e/specs/shared/api-wait-for-account-propagation.ts
+++ b/test/e2e/specs/shared/api-wait-for-account-propagation.ts
@@ -1,7 +1,9 @@
 import type { MyAccountInformationResponse, RestAPIClient } from '@automattic/calypso-e2e';
+import type { Page, Request } from 'playwright';
 
 const POLL_INTERVAL = 1000;
 const POLL_TIMEOUT = 30 * 1000;
+const LOG_PREFIX = '[email-verification]';
 
 // `RestAPIClient` surfaces API failures as `Error( '<code>: <message>' )`
 // without the HTTP status, so transient failures are recognized by known
@@ -25,6 +27,119 @@ function isTransientError( error: unknown ): boolean {
 	return TRANSIENT_ERROR_PATTERNS.some( ( pattern ) => pattern.test( message ) );
 }
 
+function sanitizeURL( url: string ): string {
+	try {
+		const parsedURL = new URL( url );
+		const pathname = parsedURL.pathname.replace( /(\/activate\/)[^/]+/gi, '$1[redacted]' );
+		return `${ parsedURL.origin }${ pathname }`;
+	} catch {
+		return '[invalid-url]';
+	}
+}
+
+function getURLSecrets( url: string ): string[] {
+	try {
+		const parsedURL = new URL( url );
+		const values = [ ...parsedURL.searchParams.values() ];
+		const activationKeys = [ parsedURL.pathname, ...values ].flatMap( ( value ) =>
+			[ ...value.matchAll( /\/activate\/([^/?#]+)/gi ) ].map( ( match ) => match[ 1 ] )
+		);
+		return [ ...values, parsedURL.hash.slice( 1 ), ...activationKeys ].filter( Boolean );
+	} catch {
+		return [];
+	}
+}
+
+function sanitizeText( text: string, redactions: string[] = [] ): string {
+	for ( const redaction of redactions ) {
+		text = text.replaceAll( redaction, '[redacted]' );
+	}
+	return text
+		.replace( /Bearer\s+\S+/gi, 'Bearer [redacted]' )
+		.replace( /https?:\/\/[^\s"'<>]+/g, sanitizeURL );
+}
+
+function getErrorDetails(
+	error: unknown,
+	redactions?: string[]
+): { class: string; message: string } {
+	return {
+		class: error instanceof Error ? error.name : typeof error,
+		message: sanitizeText( error instanceof Error ? error.message : String( error ), redactions ),
+	};
+}
+
+function logEmailVerification( record: Record< string, unknown > ): void {
+	console.log( `${ LOG_PREFIX } ${ JSON.stringify( record ) }` );
+}
+
+async function getRedirectChain( request: Request | null | undefined ) {
+	const requests: Request[] = [];
+	for ( let current = request; current; current = current.redirectedFrom() ) {
+		requests.unshift( current );
+	}
+
+	return Promise.all(
+		requests.map( async ( current ) => ( {
+			url: sanitizeURL( current.url() ),
+			status: ( await current.response().catch( () => null ) )?.status() ?? null,
+		} ) )
+	);
+}
+
+/**
+ * Visits an email activation link and logs sanitized navigation diagnostics.
+ */
+export async function visitEmailActivationLink(
+	page: Page,
+	activationLink: string,
+	expectedEmail: string
+): Promise< void > {
+	const startedAt = Date.now();
+	const activationSecrets = getURLSecrets( activationLink );
+	let lastNavigationRequest: Request | undefined;
+	let navigationError: unknown;
+	let navigationSucceeded = false;
+	const trackNavigationRequest = ( request: Request ) => {
+		if ( request.isNavigationRequest() && request.frame() === page.mainFrame() ) {
+			lastNavigationRequest = request;
+		}
+	};
+
+	page.on( 'request', trackNavigationRequest );
+	try {
+		const response = await page.goto( activationLink );
+		lastNavigationRequest = response?.request() ?? lastNavigationRequest;
+		navigationSucceeded = true;
+	} catch ( error ) {
+		navigationError = error;
+	} finally {
+		page.off( 'request', trackNavigationRequest );
+	}
+
+	const endedAt = Date.now();
+	const title = await page.title().catch( () => null );
+
+	logEmailVerification( {
+		event: 'activation',
+		expectedEmail,
+		startedAt: new Date( startedAt ).toISOString(),
+		endedAt: new Date( endedAt ).toISOString(),
+		durationMs: endedAt - startedAt,
+		result: navigationSucceeded ? 'response' : 'error',
+		redirectChain: await getRedirectChain( lastNavigationRequest ),
+		finalUrl: sanitizeURL( page.url() ),
+		title: title === null ? null : sanitizeText( title, activationSecrets ),
+		...( navigationSucceeded
+			? {}
+			: { error: getErrorDetails( navigationError, activationSecrets ) } ),
+	} );
+
+	if ( ! navigationSucceeded ) {
+		throw navigationError;
+	}
+}
+
 /**
  * Polls the read-only `/me` endpoint until `until` holds for its response,
  * absorbing transient errors along the way.
@@ -41,19 +156,66 @@ function isTransientError( error: unknown ): boolean {
 async function pollMyAccountInformation(
 	client: RestAPIClient,
 	until: ( me: MyAccountInformationResponse ) => boolean,
-	timeoutMessage: string
+	timeoutMessage: string,
+	diagnostics?: { expectedEmail: string }
 ): Promise< void > {
-	const deadline = Date.now() + POLL_TIMEOUT;
+	const startedAt = Date.now();
+	const deadline = startedAt + POLL_TIMEOUT;
+	let attempts = 0;
 	let lastError: unknown = null;
 	while ( true ) {
+		attempts++;
+		const attemptStartedAt = Date.now();
 		try {
-			if ( until( await client.getMyAccountInformation() ) ) {
+			const me = await client.getMyAccountInformation();
+			const complete = until( me );
+			if ( diagnostics ) {
+				logEmailVerification( {
+					event: 'poll-attempt',
+					expectedEmail: diagnostics.expectedEmail,
+					attempt: attempts,
+					timestamp: new Date( attemptStartedAt ).toISOString(),
+					durationMs: Date.now() - attemptStartedAt,
+					result: 'response',
+					me: {
+						ID: me.ID,
+						email: me.email,
+						email_verified: me.email_verified,
+						emailMatchesExpected: me.email === diagnostics.expectedEmail,
+					},
+				} );
+			}
+			if ( complete ) {
+				if ( diagnostics ) {
+					const endedAt = Date.now();
+					logEmailVerification( {
+						event: 'poll-complete',
+						expectedEmail: diagnostics.expectedEmail,
+						result: 'complete',
+						attempts,
+						startedAt: new Date( startedAt ).toISOString(),
+						endedAt: new Date( endedAt ).toISOString(),
+						durationMs: endedAt - startedAt,
+					} );
+				}
 				return;
 			}
 			// The call succeeded; the awaited flag has just not flipped yet.
 			lastError = null;
 		} catch ( error ) {
-			if ( ! isTransientError( error ) ) {
+			const transient = isTransientError( error );
+			if ( diagnostics ) {
+				logEmailVerification( {
+					event: 'poll-attempt',
+					expectedEmail: diagnostics.expectedEmail,
+					attempt: attempts,
+					timestamp: new Date( attemptStartedAt ).toISOString(),
+					durationMs: Date.now() - attemptStartedAt,
+					result: transient ? 'transient-error' : 'fatal-error',
+					error: getErrorDetails( error ),
+				} );
+			}
+			if ( ! transient ) {
 				throw error;
 			}
 			lastError = error;
@@ -62,6 +224,18 @@ async function pollMyAccountInformation(
 			break;
 		}
 		await new Promise( ( resolve ) => setTimeout( resolve, POLL_INTERVAL ) );
+	}
+	if ( diagnostics ) {
+		const endedAt = Date.now();
+		logEmailVerification( {
+			event: 'poll-timeout',
+			expectedEmail: diagnostics.expectedEmail,
+			result: 'timeout',
+			attempts,
+			startedAt: new Date( startedAt ).toISOString(),
+			endedAt: new Date( endedAt ).toISOString(),
+			durationMs: endedAt - startedAt,
+		} );
 	}
 	throw new Error( lastError ? `${ timeoutMessage } Last error: ${ lastError }` : timeoutMessage );
 }
@@ -109,6 +283,7 @@ export async function apiWaitForEmailVerification(
 	await pollMyAccountInformation(
 		client,
 		( me ) => me.email_verified === true,
-		`Email verification for ${ email } did not propagate after visiting the activation link.`
+		`Email verification for ${ email } did not propagate after visiting the activation link.`,
+		{ expectedEmail: email }
 	);
 }


### PR DESCRIPTION
Part of TESTOPS-229

## Proposed Changes

* Add a shared activation-link visitor that logs sanitized redirect statuses, timing and the final page state.
* Log correlated `/me` attempts and completion details only while waiting for email verification.
* Use the shared visitor in the `sitePublic` fixture and dashboard two-step authentication flow.

## Why are these changes being made?

* Email activation can complete before `email_verified` is readable through `/me`. When that flakes, the existing failure doesn't say whether navigation, account identity or propagation failed. These logs add that context without changing retries, timeouts or bearer-token polling.

## Testing Instructions

* Run the E2E TypeScript check:

```sh
NODE_OPTIONS="--max-old-space-size=16384" yarn tsc --project test/e2e/tsconfig.json --noEmit
```

* Run the dashboard two-step flow five times:

```sh
CALYPSO_BASE_URL="$CALYPSO_STAGING_URL" DASHBOARD_BASE_URL="$DASHBOARD_URL" NODE_OPTIONS="--max-old-space-size=16384" yarn workspace wp-e2e-tests playwright test specs/authentication/authentication__dashboard-two-step.spec.ts --project=authentication --repeat-each=5 --workers=1 --reporter=list
```

* Run a `sitePublic` fixture consumer five times:

```sh
CALYPSO_BASE_URL="$CALYPSO_STAGING_URL" NODE_OPTIONS="--max-old-space-size=16384" yarn workspace wp-e2e-tests playwright test specs/tools/import__sites-medium.spec.ts --project=chrome --grep "One:" --repeat-each=5 --workers=1 --reporter=list
```

* Search the output for `[email-verification]`. Activation URLs should contain no query parameters, fragments or activation keys. `/me` records should include sequential attempts, matching account identity and completion totals.
* Local result: the `sitePublic` consumer passed 5/5. The authentication flow verified email 5/5, then failed later because the TOTP setup response contained no `time_code`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
