### PR TITLE
Dashboard: bump dashboard-404 stat with missing path

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -56,6 +56,7 @@ import {
 	attachBuildTimestamp,
 	attachHead,
 	attachI18n,
+	bumpStat,
 } from 'calypso/server/render';
 import sanitize from 'calypso/server/sanitize';
 import stateCache from 'calypso/server/state-cache';
@@ -880,6 +881,8 @@ const setUpSectionContext = ( section, entrypoint ) => ( req, res, next ) => {
 
 const setNotFoundStatus = ( req, res, next ) => {
 	res.status( 404 );
+	// bumpStat only accepts 32 chars max for the value
+	bumpStat( 'dashboard-404', req.path.slice( 0, 32 ) );
 	next();
 };
 

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -60,6 +60,7 @@ jest.mock( 'calypso/server/render', () => ( {
 	attachBuildTimestamp: jest.fn(),
 	attachHead: jest.fn(),
 	attachI18n: jest.fn(),
+	bumpStat: jest.fn(),
 } ) );
 
 jest.mock( 'calypso/server/state-cache', () => new Map() );

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -67,7 +67,7 @@ export const markupCache = new Lru( {
 	maxAge: HOUR_IN_MS,
 } );
 
-function bumpStat( group, name ) {
+export function bumpStat( group, name ) {
 	const statUrl = `http://pixel.wp.com/g.gif?v=wpcom-no-pv&x_${ group }=${ name }&t=${ Math.random() }`;
 
 	if ( process.env.NODE_ENV === 'production' ) {


### PR DESCRIPTION
Part of DOTMSD-1418

## Proposed Changes

* Record a `dashboard-404` MC bump stat whenever the Dashboard server serves its not-found response, so we can see which missing paths are most common.
* The stat value is the requested path (`req.path`), truncated to the 32-char limit bump stats accept.
* Export the existing private `bumpStat` helper from `client/server/render/index.js` and reuse it in the Dashboard's `setNotFoundStatus` middleware (which is only used by the Dashboard catch-all route).

## Why are these changes being made?

We already track `dashboard-mutation-error` and `dashboard-redirect` stats. Adding `dashboard-404` gives visibility into the most popular 404 paths on the Dashboard, helping us find missing/broken routes worth fixing.

We can see the existing `calypso-ssr` stats in MC, so we know bump stats from the backend are working.

## Testing Instructions

* Build/run the Dashboard server in a production-like env (`bumpStat` only fires when `NODE_ENV === 'production'`).
* Request an unmatched Dashboard path.
* Confirm a request to `pixel.wp.com/g.gif?...x_dashboard-404=<path>` is fired with the (truncated) path, and the response is still a 404 serving the Dashboard shell.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
