### PR TITLE
E2E: fix failing dashboard two-step authentication spec

### DIFF
--- a/test/e2e/specs/authentication/authentication__dashboard-two-step.spec.ts
+++ b/test/e2e/specs/authentication/authentication__dashboard-two-step.spec.ts
@@ -118,7 +118,7 @@ async function satisfyReauthChallenge(
 	previousCode: string
 ): Promise< string > {
 	const logOut = page.getByText( 'Not you? Log out' );
-	if ( ! ( await logOut.isVisible().catch( () => false ) ) ) {
+	if ( ! ( await logOut.isVisible() ) ) {
 		return '';
 	}
 	const code = await getUnusedTOTPCode( page, new TOTPClient( totpSecret ), previousCode );
@@ -142,7 +142,10 @@ async function assertTwoStepEnabledAndLoggedIn( page: Page, totpSecret: string )
 	// answering it until the settings actually render.
 	let previousCode = '';
 	await expect( async () => {
-		previousCode = await satisfyReauthChallenge( page, totpSecret, previousCode );
+		const code = await satisfyReauthChallenge( page, totpSecret, previousCode );
+		if ( code ) {
+			previousCode = code;
+		}
 		await expect( registerKeyButton ).toBeVisible( { timeout: 3_000 } );
 	} ).toPass( { timeout: 90_000 } );
 }

--- a/test/e2e/specs/authentication/authentication__dashboard-two-step.spec.ts
+++ b/test/e2e/specs/authentication/authentication__dashboard-two-step.spec.ts
@@ -176,7 +176,12 @@ test.describe(
 				await page.goto( DataHelper.getDashboardURL( '/me/security/two-step-auth/app' ) );
 
 				const setupResponse = await setupResponsePromise;
-				totpSecret = ( await setupResponse.json() ).time_code;
+				// wpcom-proxy-request replies in http_envelope form, so the payload is
+				// under `body` and the transport is 200 regardless of the inner status.
+				const { code, body } = await setupResponse.json();
+				expect( code ).toBe( 200 );
+				// time_code is the secret space-grouped; strip it for TOTPClient's base32 decoder.
+				totpSecret = body.time_code.replace( /\s/g, '' );
 				expect( totpSecret ).toBeTruthy();
 
 				enableCode = new TOTPClient( totpSecret ).getToken();

--- a/test/e2e/specs/authentication/authentication__dashboard-two-step.spec.ts
+++ b/test/e2e/specs/authentication/authentication__dashboard-two-step.spec.ts
@@ -73,7 +73,9 @@ async function submitLoginTOTPCode(
 			return;
 		}
 	}
-	throw new Error( 'Login second-factor code was not accepted after retries.' );
+	throw new Error(
+		`Login second-factor code was not accepted after retries; still at ${ page.url() }.`
+	);
 }
 
 /**

--- a/test/e2e/specs/authentication/authentication__dashboard-two-step.spec.ts
+++ b/test/e2e/specs/authentication/authentication__dashboard-two-step.spec.ts
@@ -48,6 +48,35 @@ async function getUnusedTOTPCode(
 }
 
 /**
+ * Submits authenticator codes at the login second-factor screen until the login
+ * proceeds. A code an earlier step already consumed lands in the same 30s window
+ * and reads as invalid, so this rotates to the next code on rejection and fails
+ * fast rather than hanging on `submitVerificationCode`'s open-ended navigation wait.
+ */
+async function submitLoginTOTPCode(
+	page: Page,
+	pageLogin: LoginPage,
+	totpSecret: string,
+	previousCode: string
+): Promise< void > {
+	const totpClient = new TOTPClient( totpSecret );
+	for ( let attempt = 0; attempt < 3; attempt++ ) {
+		const code = await getUnusedTOTPCode( page, totpClient, previousCode );
+		previousCode = code;
+		await pageLogin.fillVerificationCode( code );
+		await pageLogin.clickSubmit();
+		const proceeded = await page
+			.waitForURL( ( url ) => ! url.pathname.includes( '/log-in' ), { timeout: 15_000 } )
+			.then( () => true )
+			.catch( () => false );
+		if ( proceeded ) {
+			return;
+		}
+	}
+	throw new Error( 'Login second-factor code was not accepted after retries.' );
+}
+
+/**
  * Completes the security-key second factor at login. With both a TOTP app and a
  * security key registered, the login flow may default to either method, so this
  * switches to the security-key form when needed. The form auto-initiates the
@@ -73,14 +102,47 @@ async function continueWithSecurityKey( page: Page ): Promise< void > {
 }
 
 /**
+ * Answers the two-step reauthentication challenge once, as a user would: a fresh
+ * authenticator code typed in and verified. Opening the security area with a
+ * freshly two-step-enabled session bounces to the classic Calypso
+ * `me/reauth-required` screen, keyed here on its "Not you? Log out" control. No-op
+ * (returns an empty string) when the challenge is absent. Returns the code it
+ * submitted so the caller can avoid replaying it on the next attempt (the endpoint
+ * rejects a code already consumed within its 30s window).
+ */
+async function satisfyReauthChallenge(
+	page: Page,
+	totpSecret: string,
+	previousCode: string
+): Promise< string > {
+	const logOut = page.getByText( 'Not you? Log out' );
+	if ( ! ( await logOut.isVisible().catch( () => false ) ) ) {
+		return '';
+	}
+	const code = await getUnusedTOTPCode( page, new TOTPClient( totpSecret ), previousCode );
+	await page.getByLabel( 'Verification code' ).fill( code );
+	await page.getByRole( 'button', { name: 'Verify' } ).click();
+	await logOut.waitFor( { state: 'hidden', timeout: 15_000 } ).catch( () => undefined );
+	return code;
+}
+
+/**
  * Asserts that the current session is authenticated and has two-step
  * authentication enabled: the dashboard's two-step-auth screen is a
  * behind-login route that only renders the "Register key" control once
  * `two_step_enabled` is true.
  */
-async function assertTwoStepEnabledAndLoggedIn( page: Page ): Promise< void > {
+async function assertTwoStepEnabledAndLoggedIn( page: Page, totpSecret: string ): Promise< void > {
 	await page.goto( DataHelper.getDashboardURL( '/me/security/two-step-auth' ) );
-	await expect( page.getByRole( 'button', { name: 'Register key' } ) ).toBeVisible();
+	const registerKeyButton = page.getByRole( 'button', { name: 'Register key' } );
+	// Opening the security area can bounce to the reauth challenge, sometimes only
+	// after briefly rendering the settings, and it can prompt again, so keep
+	// answering it until the settings actually render.
+	let previousCode = '';
+	await expect( async () => {
+		previousCode = await satisfyReauthChallenge( page, totpSecret, previousCode );
+		await expect( registerKeyButton ).toBeVisible( { timeout: 3_000 } );
+	} ).toPass( { timeout: 90_000 } );
 }
 
 test.describe(
@@ -190,10 +252,16 @@ test.describe(
 			} );
 
 			await test.step( 'Then two-step authentication is enabled', async function () {
-				await assertTwoStepEnabledAndLoggedIn( page );
+				await assertTwoStepEnabledAndLoggedIn( page, totpSecret );
 			} );
 
 			await test.step( 'When I log out and log in again using a TOTP code', async function () {
+				// signupSocialFirstWithEmail creates a passwordless account, so a
+				// password login has no field to fill. Set the generated password
+				// (which must be the only setting in the request) here, right before
+				// logging out: changing it invalidates the signup session that the
+				// enable and assert steps above rely on, so it cannot be done earlier.
+				await restAPIClient!.setMySettings( { password: testUser.password } );
 				await page.context().clearCookies();
 				await logInWithPassword(
 					page,
@@ -202,12 +270,11 @@ test.describe(
 					testUser.password
 				);
 
-				const code = await getUnusedTOTPCode( page, new TOTPClient( totpSecret ), enableCode );
-				await pageLogin.submitVerificationCode( code );
+				await submitLoginTOTPCode( page, pageLogin, totpSecret, enableCode );
 			} );
 
 			await test.step( 'Then I am logged in with the TOTP app', async function () {
-				await assertTwoStepEnabledAndLoggedIn( page );
+				await assertTwoStepEnabledAndLoggedIn( page, totpSecret );
 			} );
 
 			await test.step( 'When I register a security key in the dashboard', async function () {
@@ -249,7 +316,7 @@ test.describe(
 			} );
 
 			await test.step( 'Then I am logged in with the security key', async function () {
-				await assertTwoStepEnabledAndLoggedIn( page );
+				await assertTwoStepEnabledAndLoggedIn( page, totpSecret );
 			} );
 		} );
 	}


### PR DESCRIPTION
## Proposed Changes

Fix `authentication__dashboard-two-step.spec.ts`, which has failed on every scheduled run of the Calypso Authentication E2E job since it merged. The spec is gated to run only where the dashboard is served from `my.wordpress.com`, so it was skipped on its own PR and never actually executed until the scheduled job picked it up. It carried several stacked defects, all fixed here (no product code changes):

- **Read `time_code` from the `http_envelope` body.** The dashboard reaches the API through `wpcom-proxy-request`, whose rest-proxy appends `http_envelope=1` to every request, so the intercepted response body is `{ code, headers, body }` and `time_code` lives under `body`; the top-level read returned `undefined`, failing `expect( totpSecret ).toBeTruthy()`. Also assert the inner `code === 200` so an enveloped API error surfaces clearly instead of a bad-field read, and strip the spaces the API groups `time_code` with so the base32 decoder accepts the secret.
- **Give the passwordless account a password before the login steps.** `signupSocialFirstWithEmail` creates a passwordless account, so the log-out-and-back-in steps landed on the magic-link screen with no password field. Set the generated password via `setMySettings` right before the first log out (changing it invalidates the signup session, so it cannot be done earlier).
- **Answer the two-step reauthentication challenge.** Opening the security settings with a freshly two-step-enabled session bounces to the classic Calypso `me/reauth-required` screen. It is answered as a user would — a fresh authenticator code typed in and verified — and retried until the settings render.
- **Retry the login second-factor code.** A code already consumed by an earlier step lands in the same 30s window and reads as invalid; the login step now rotates to the next code instead of hanging on `submitVerificationCode`'s open-ended navigation wait.

## Why are these changes being made?

The Authentication E2E job (scheduled ~every 6h) had a single un-muted failing test on every run since the spec merged. The deterministic failure was the `time_code` read (`undefined`); the remaining defects surfaced once that was fixed and the spec ran end to end for the first time.

## Testing Instructions

The spec runs only where the dashboard is `my.wordpress.com`, so it cannot run against a per-PR calypso.live environment; verify on the scheduled Authentication job / a branch build.

- Reds before, all failing at `time_code` undefined: Authentication E2E builds `18539013` (first red) through `18570892` (10 consecutive).
- Verified locally against production (`CALYPSO_BASE_URL=https://wordpress.com`, `DASHBOARD_BASE_URL=https://my.wordpress.com`, `--project=authentication`): 5/5 green across repeated runs.
- Branch builds — the spec passed in 4 of 5 runs; the fixed logic never failed on CI. `18574174` and `18574584` fully green (all 10 passed); `18574128` and `18574210` the spec passed with the build red only from the unrelated `authentication__sms` 5-minute SMS throttle (self-induced by back-to-back reruns, cleared by spacing runs >5 min apart). `18574098` reddened on the orthogonal TESTOPS-229 email flake described below.

Note: the spec also calls `apiWaitForEmailVerification`, which intermittently fails with the `email_verified` replica-lag poison tracked in `TESTOPS-229` and fixed product-side by `228315-ghe-Automattic/wpcom` (open). That flake is orthogonal to the failures fixed here and resolves when that lands.
