### PR TITLE
Emails: keep lower Titan tiers visible with disabled button when upgrading

### DIFF
--- a/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
+++ b/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
@@ -100,8 +100,8 @@ const getTierDetails = ( tier: TitanPlanTier ): { description: string; features:
 	}
 };
 
-// Tiers ordered from lowest to highest, used to hide tiers below the current one
-// when upgrading.
+// Tiers ordered from lowest to highest, used to tell upgrades from downgrades
+// relative to the current tier.
 const TIER_ORDER: TitanPlanTier[] = [
 	TitanPlanTier.Pro,
 	TitanPlanTier.Premium,
@@ -178,21 +178,18 @@ export function TitanPlanGrid( {
 		},
 	];
 
-	// When upgrading, only offer the current plan (labeled below) and higher tiers,
-	// since this flow cannot downgrade.
-	const visiblePlans = currentTier
-		? plans.filter(
-				( plan ) => TIER_ORDER.indexOf( plan.tier ) >= TIER_ORDER.indexOf( currentTier )
-		  )
-		: plans;
+	// All tiers stay visible when upgrading; lower tiers render with a disabled
+	// button since this flow cannot downgrade.
+	const isLowerTier = ( tier: TitanPlanTier ) =>
+		currentTier ? TIER_ORDER.indexOf( tier ) < TIER_ORDER.indexOf( currentTier ) : false;
 
 	// The tier that gets the emphasized (primary) button: the recommended plan when
-	// buying, or the recommended upgrade target when upgrading. The current plan is
-	// never emphasized because its button is disabled.
+	// buying, or the recommended upgrade target when upgrading. The current and lower
+	// tiers are never emphasized because their buttons are disabled.
 	const primaryTier = ( () => {
 		const candidates = currentTier
-			? visiblePlans.filter( ( plan ) => plan.tier !== currentTier )
-			: visiblePlans;
+			? plans.filter( ( plan ) => plan.tier !== currentTier && ! isLowerTier( plan.tier ) )
+			: plans;
 		return ( candidates.find( ( plan ) => plan.isPopular ) ?? candidates[ 0 ] )?.tier;
 	} )();
 
@@ -207,14 +204,17 @@ export function TitanPlanGrid( {
 
 	return (
 		<div className="email-providers">
-			{ visiblePlans.map( ( plan ) => {
+			{ plans.map( ( plan ) => {
 				const planName = getTierName( plan.tier );
 				const details = getTierDetails( plan.tier );
 				const isCurrentPlan = plan.tier === currentTier;
+				const isDowngrade = isLowerTier( plan.tier );
 
 				let actionLabel;
 				if ( isCurrentPlan ) {
 					actionLabel = __( 'Current plan' );
+				} else if ( isDowngrade ) {
+					actionLabel = __( 'Included in your plan' );
 				} else if ( currentTier ) {
 					actionLabel = __( 'Upgrade' );
 				} else if ( plan.hasFreeTrial ) {
@@ -288,7 +288,7 @@ export function TitanPlanGrid( {
 							__next40pxDefaultSize
 							className="email-provider-action"
 							variant={ plan.tier === primaryTier ? 'primary' : 'secondary' }
-							disabled={ ! available || isCurrentPlan }
+							disabled={ ! available || isCurrentPlan || isDowngrade }
 							onClick={ () => {
 								// Upgrade mode goes to checkout for the picked tier; otherwise the
 								// grid is buying a new plan, so collect mailboxes first.

--- a/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
+++ b/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
@@ -121,8 +121,8 @@ export function TitanPlanGrid( {
 	interval: IntervalLength;
 	available: boolean;
 	// The tier the user is currently subscribed to. When set, the grid is in
-	// upgrade mode: lower tiers are hidden, the current tier is labeled, and higher
-	// tiers offer an upgrade.
+	// upgrade mode: lower tiers are shown with a disabled button, the current
+	// tier is labeled, and higher tiers offer an upgrade.
 	currentTier?: TitanPlanTier;
 	// Called when a higher tier is selected in upgrade mode (currentTier set).
 	onUpgrade?: ( tier: TitanPlanTier ) => void;


### PR DESCRIPTION
## Proposed Changes

In the Titan (Professional Email) plan grid on `/emails/choose-email-solution/:domain?intent=upgrade`, tiers below the user's current subscription were being hidden entirely. So a Premium subscriber never saw the Pro plan.

This keeps the full tier lineup visible:

* Lower tiers stay on screen with a **disabled** button labeled **"Included in your plan"** (this flow cannot downgrade).
* The current tier still shows a disabled "Current plan" button.
* Higher tiers still show the "Upgrade" action.
* The emphasized (primary) button now only lands on a real upgrade target: it excludes both the current tier and any lower tiers.

## Why are these changes being made?

Hiding lower tiers removed useful context from the comparison. Users upgrading from Premium could no longer see what Pro offered relative to their plan. Showing the whole lineup, with lower tiers clearly disabled, keeps the comparison complete while still preventing downgrades through this flow.

## Testing Instructions

1. Have a site/domain with an active Titan **Premium** subscription.
2. Visit `/emails/choose-email-solution/<domain>?intent=upgrade`.
3. Confirm the **Pro** plan is now visible with a disabled "Included in your plan" button.
4. Confirm **Premium** shows a disabled "Current plan" button.
5. Confirm **Ultra** shows an enabled, emphasized "Upgrade" button.
6. Repeat with a **Pro** subscription: Pro = "Current plan" (disabled), Premium/Ultra enabled ("Upgrade"), Premium emphasized.
7. Repeat with an **Ultra** subscription: Pro/Premium disabled ("Included in your plan"), Ultra = "Current plan".

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
