### PR TITLE
Playground new flow

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -50,6 +50,34 @@ import { type FlowV2, type ProvidedDependencies, type SubmitHandler } from '../.
 import { getOnboardingStepperPosition } from './step-counter-config';
 import type { DomainSuggestion } from '@automattic/api-core';
 
+export function getPlaygroundPostCheckoutDestination( {
+	locale,
+	siteId,
+	siteSlug,
+	playgroundId,
+}: {
+	locale: string;
+	siteId: number;
+	siteSlug: string;
+	playgroundId: string;
+} ): string {
+	const importerDestination = addQueryArgs(
+		withLocale( '/setup/site-setup/importerPlayground', locale ),
+		{
+			siteSlug,
+			siteId,
+			playground: playgroundId,
+		}
+	);
+
+	return addQueryArgs( '/setup/transferring-hosted-site', {
+		siteSlug,
+		siteId,
+		initiate_transfer_context: 'onboarding',
+		redirect_to: importerDestination,
+	} );
+}
+
 function initialize() {
 	const steps = [
 		STEPS.DOMAIN_SEARCH,
@@ -146,8 +174,26 @@ const onboarding: FlowV2< typeof initialize > = {
 					playground: playgroundId as string,
 				};
 
+				if ( blueprint ) {
+					params.blueprint = blueprint;
+				} else if ( playgroundId ) {
+					params.playground = playgroundId;
+				}
+
+				const importerDestination = addQueryArgs(
+					withLocale( '/setup/site-setup/importerPlayground', locale ),
+					params
+				);
+
 				return [
-					addQueryArgs( withLocale( '/setup/site-setup/importerPlayground', locale ), params ),
+					playgroundId
+						? getPlaygroundPostCheckoutDestination( {
+								locale,
+								siteSlug: params.siteSlug as string,
+								siteId: params.siteId as number,
+								playgroundId,
+						  } )
+						: importerDestination,
 					null,
 					null,
 				];
@@ -393,18 +439,13 @@ const onboarding: FlowV2< typeof initialize > = {
 							const siteSlug = providedDependencies.siteSlug as string;
 
 							/**
-							 * If the user comes from the Playground onboarding flow,
-							 * redirect the user back to Playground to start the import.
+							 * Playground imports require the post-checkout Atomic transfer to finish first.
 							 */
 							const playgroundId = getQueryArg( window.location.href, 'playground' );
 							const redirectTo: string =
 								playgroundId &&
 								! isPlanProductFree( {} as unknown as State, planCartItem?.product_id )
-									? addQueryArgs( withLocale( '/setup/site-setup/importerPlayground', locale ), {
-											siteSlug,
-											siteId: providedDependencies.siteId,
-											playground: playgroundId,
-									  } )
+									? destination
 									: addQueryArgs(
 											withLocale( '/setup/onboarding/post-checkout-onboarding', locale ),
 											{

--- a/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding.ts
@@ -3,7 +3,7 @@
  */
 import { renderHook } from '@testing-library/react';
 import { clearSessionStorageQuery } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
-import onboarding from '../onboarding';
+import onboarding, { getPlaygroundPostCheckoutDestination } from '../onboarding';
 
 jest.mock( 'calypso/components/domains/wpcom-domain-search/use-query-handler', () => ( {
 	clearSessionStorageQuery: jest.fn(),
@@ -61,6 +61,32 @@ jest.mock( '@automattic/onboarding', () => ( {
 	SITE_SETUP_FLOW: 'site-setup',
 	clearStepPersistedState: jest.fn(),
 } ) );
+
+describe( 'getPlaygroundPostCheckoutDestination', () => {
+	it( 'initiates the Atomic transfer before continuing to the Playground importer', () => {
+		const destination = getPlaygroundPostCheckoutDestination( {
+			locale: 'it',
+			siteId: 256300535,
+			siteSlug: 'example.wordpress.com',
+			playgroundId: 'playground-id',
+		} );
+		const transferUrl = new URL( destination, 'https://wordpress.com' );
+
+		expect( transferUrl.pathname ).toBe( '/setup/transferring-hosted-site' );
+		expect( transferUrl.searchParams.get( 'siteId' ) ).toBe( '256300535' );
+		expect( transferUrl.searchParams.get( 'siteSlug' ) ).toBe( 'example.wordpress.com' );
+		expect( transferUrl.searchParams.get( 'initiate_transfer_context' ) ).toBe( 'onboarding' );
+
+		const importerUrl = new URL(
+			transferUrl.searchParams.get( 'redirect_to' ) as string,
+			'https://wordpress.com'
+		);
+		expect( importerUrl.pathname ).toBe( '/setup/site-setup/importerPlayground/it' );
+		expect( importerUrl.searchParams.get( 'siteId' ) ).toBe( '256300535' );
+		expect( importerUrl.searchParams.get( 'siteSlug' ) ).toBe( 'example.wordpress.com' );
+		expect( importerUrl.searchParams.get( 'playground' ) ).toBe( 'playground-id' );
+	} );
+} );
 
 describe( 'onboarding flow side effects', () => {
 	const navigate = jest.fn();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/early-provisioning.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/early-provisioning.ts
@@ -5,6 +5,14 @@ import wpcom from 'calypso/lib/wp';
 
 export const EARLY_PROVISION_TARGET_WPCOM_ATOMIC = 'wpcom-atomic';
 
+export function getSiteProvisionTarget( queryParams: URLSearchParams ): string | null {
+	if ( queryParams.has( 'playground' ) ) {
+		return EARLY_PROVISION_TARGET_WPCOM_ATOMIC;
+	}
+
+	return queryParams.get( 'provision_target' ) ?? queryParams.get( 'early_provision_target' );
+}
+
 type AtomicProvisioningSite = {
 	URL?: string;
 	slug?: string;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/early-provisioning.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/early-provisioning.ts
@@ -13,6 +13,21 @@ export function getSiteProvisionTarget( queryParams: URLSearchParams ): string |
 	return queryParams.get( 'provision_target' ) ?? queryParams.get( 'early_provision_target' );
 }
 
+export function shouldWaitForAtomicProvisioning(
+	provisionTarget: string | null,
+	{
+		isPlayground,
+		goToCheckout,
+	}: {
+		isPlayground: boolean;
+		goToCheckout: boolean;
+	}
+): boolean {
+	return (
+		provisionTarget === EARLY_PROVISION_TARGET_WPCOM_ATOMIC && ( ! isPlayground || ! goToCheckout )
+	);
+}
+
 type AtomicProvisioningSite = {
 	URL?: string;
 	slug?: string;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -47,6 +47,7 @@ import {
 	getEarlyCreatedSiteId,
 	getSiteProvisionTarget,
 	pollForAtomicProvisioning,
+	shouldWaitForAtomicProvisioning,
 } from './early-provisioning';
 import type { Step as StepType } from '../../types';
 import type { OnboardSelect } from '@automattic/data-stores';
@@ -299,7 +300,12 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			throw new Error( 'Failed to create site' );
 		}
 
-		if ( provisionTarget === EARLY_PROVISION_TARGET_WPCOM_ATOMIC ) {
+		if (
+			shouldWaitForAtomicProvisioning( provisionTarget, {
+				isPlayground: urlQueryParams.has( 'playground' ),
+				goToCheckout: shouldGoToCheckout,
+			} )
+		) {
 			const atomicSite = await pollForAtomicProvisioning( site.siteId );
 			site.siteSlug = atomicSite.siteSlug;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -45,6 +45,7 @@ import { SESSION_KEY_FROM_PLAYGROUND_PUBLISH } from '../playground/lib/constants
 import {
 	EARLY_PROVISION_TARGET_WPCOM_ATOMIC,
 	getEarlyCreatedSiteId,
+	getSiteProvisionTarget,
 	pollForAtomicProvisioning,
 } from './early-provisioning';
 import type { Step as StepType } from '../../types';
@@ -220,13 +221,12 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 		// Flow A: The site was early-created during the AI chat session.
 		// Flow B: If early_created_site is absent, the regular createSiteWithCart path below handles creation.
 		const earlyCreatedSite = urlQueryParams.get( 'early_created_site' );
-		const earlyProvisionTarget =
-			urlQueryParams.get( 'provision_target' ) ?? urlQueryParams.get( 'early_provision_target' );
+		const provisionTarget = getSiteProvisionTarget( urlQueryParams );
 		const earlyCreatedSiteId = getEarlyCreatedSiteId( flow, earlyCreatedSite );
 
 		if ( earlyCreatedSiteId ) {
 			let siteSlug = String( earlyCreatedSiteId );
-			if ( earlyProvisionTarget === EARLY_PROVISION_TARGET_WPCOM_ATOMIC ) {
+			if ( provisionTarget === EARLY_PROVISION_TARGET_WPCOM_ATOMIC ) {
 				const atomicSite = await pollForAtomicProvisioning( earlyCreatedSiteId );
 				siteSlug = atomicSite.siteSlug;
 			} else if ( gardenName ) {
@@ -291,7 +291,7 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			gardenPartnerName,
 			urlQueryParams.get( 'spec_id' ),
 			isPlaygroundPublish ? 'playground-publish' : undefined,
-			undefined, // provisionTarget
+			provisionTarget,
 			launchpadPersonalizationVariation === 'ai_launchpad'
 		);
 
@@ -299,7 +299,7 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			throw new Error( 'Failed to create site' );
 		}
 
-		if ( earlyProvisionTarget === EARLY_PROVISION_TARGET_WPCOM_ATOMIC ) {
+		if ( provisionTarget === EARLY_PROVISION_TARGET_WPCOM_ATOMIC ) {
 			const atomicSite = await pollForAtomicProvisioning( site.siteId );
 			site.siteSlug = atomicSite.siteSlug;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/test/early-provisioning.test.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/test/early-provisioning.test.ts
@@ -6,6 +6,7 @@ import {
 	getEarlyCreatedSiteId,
 	getSiteProvisionTarget,
 	pollForAtomicProvisioning,
+	shouldWaitForAtomicProvisioning,
 } from '../early-provisioning';
 
 jest.mock( 'calypso/lib/wp', () => ( {
@@ -50,6 +51,35 @@ describe( 'getSiteProvisionTarget', () => {
 		expect( getSiteProvisionTarget( new URLSearchParams( 'early_provision_target=custom' ) ) ).toBe(
 			'custom'
 		);
+	} );
+} );
+
+describe( 'shouldWaitForAtomicProvisioning', () => {
+	it( 'does not wait for Atomic provisioning before a paid plan checkout', () => {
+		expect(
+			shouldWaitForAtomicProvisioning( EARLY_PROVISION_TARGET_WPCOM_ATOMIC, {
+				isPlayground: true,
+				goToCheckout: true,
+			} )
+		).toBe( false );
+	} );
+
+	it( 'waits for Playground Atomic provisioning when checkout is not required', () => {
+		expect(
+			shouldWaitForAtomicProvisioning( EARLY_PROVISION_TARGET_WPCOM_ATOMIC, {
+				isPlayground: true,
+				goToCheckout: false,
+			} )
+		).toBe( true );
+	} );
+
+	it( 'preserves early Atomic provisioning for other paid flows', () => {
+		expect(
+			shouldWaitForAtomicProvisioning( EARLY_PROVISION_TARGET_WPCOM_ATOMIC, {
+				isPlayground: false,
+				goToCheckout: true,
+			} )
+		).toBe( true );
 	} );
 } );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/test/early-provisioning.test.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/test/early-provisioning.test.ts
@@ -1,8 +1,10 @@
 import { AI_SITE_BUILDER_FLOW } from '@automattic/onboarding';
 import wpcom from 'calypso/lib/wp';
 import {
+	EARLY_PROVISION_TARGET_WPCOM_ATOMIC,
 	getAtomicProvisionedSiteSlug,
 	getEarlyCreatedSiteId,
+	getSiteProvisionTarget,
 	pollForAtomicProvisioning,
 } from '../early-provisioning';
 
@@ -28,6 +30,26 @@ describe( 'getEarlyCreatedSiteId', () => {
 
 	it( 'allows regular AI Site Builder creation when WPCOM Atomic early provisioning is not requested', () => {
 		expect( getEarlyCreatedSiteId( AI_SITE_BUILDER_FLOW, null ) ).toBeNull();
+	} );
+} );
+
+describe( 'getSiteProvisionTarget', () => {
+	it( 'provisions Playground sites on WPCOM Atomic', () => {
+		expect( getSiteProvisionTarget( new URLSearchParams( 'playground=123' ) ) ).toBe(
+			EARLY_PROVISION_TARGET_WPCOM_ATOMIC
+		);
+	} );
+
+	it( 'keeps an explicitly requested provision target outside Playground flows', () => {
+		expect( getSiteProvisionTarget( new URLSearchParams( 'provision_target=custom' ) ) ).toBe(
+			'custom'
+		);
+	} );
+
+	it( 'supports the legacy early provision target parameter', () => {
+		expect( getSiteProvisionTarget( new URLSearchParams( 'early_provision_target=custom' ) ) ).toBe(
+			'custom'
+		);
 	} );
 } );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/import-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/import-playground.ts
@@ -2,6 +2,7 @@ import wpcomRequest from 'wpcom-proxy-request';
 import { uploadExportFile, updateImporter } from 'calypso/state/imports/actions';
 import { fromApi, toApi } from 'calypso/state/imports/api';
 import { appStates } from 'calypso/state/imports/constants';
+import { pollForAtomicProvisioning } from '../../create-site/early-provisioning';
 import { PLAYGROUND_HOST } from './constants';
 import type { PlaygroundClient } from './types';
 
@@ -58,6 +59,7 @@ export async function uploadSiteZip( siteId: number, siteZip: File ): Promise< n
 }
 
 export async function createPlaygroundImport( siteId: number, siteZip: File ) {
+	await pollForAtomicProvisioning( siteId );
 	const attachmentId = await uploadSiteZip( siteId, siteZip );
 
 	return uploadExportFile( siteId, {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/import-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/import-playground.ts
@@ -58,11 +58,11 @@ export async function uploadSiteZip( siteId: number, siteZip: File ): Promise< n
 }
 
 export async function createPlaygroundImport( siteId: number, siteZip: File ) {
-	const mediaId = await uploadSiteZip( siteId, siteZip );
+	const attachmentId = await uploadSiteZip( siteId, siteZip );
 
 	return uploadExportFile( siteId, {
 		importStatus: { importStatus: 'importer-ready-for-upload', siteId, type: 'wordpress' },
-		mediaID: mediaId,
+		attachmentId: attachmentId,
 	} );
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/import-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/import-playground.ts
@@ -35,6 +35,31 @@ export async function getSiteZip( playground: PlaygroundClient ) {
 	return new File( [ zipBytes ], 'site.zip', { type: 'application/zip' } );
 }
 
+export async function uploadSiteZip( siteId: number, siteZip: File ): Promise< number > {
+	const response = await wpcomRequest< { media?: Array< { ID?: number } > } >( {
+		path: `/sites/${ siteId }/media/new`,
+		apiVersion: '1.1',
+		method: 'POST',
+		formData: [ [ 'media[]', siteZip ] ],
+	} );
+	const mediaId = response.media?.[ 0 ]?.ID;
+
+	if ( ! mediaId ) {
+		throw new Error( 'No media ID returned after uploading the Playground export.' );
+	}
+
+	return mediaId;
+}
+
+export async function createPlaygroundImport( siteId: number, siteZip: File ) {
+	const mediaId = await uploadSiteZip( siteId, siteZip );
+
+	return uploadExportFile( siteId, {
+		importStatus: { importStatus: 'importer-ready-for-upload', siteId, type: 'wordpress' },
+		mediaID: mediaId,
+	} );
+}
+
 export async function removeSandboxPlugins( playground: PlaygroundClient ): Promise< void > {
 	// Haydi and wccom-ai-connector are sandbox-only tools — remove them from the
 	// in-memory filesystem before exporting so they don't land on the live site.
@@ -85,11 +110,7 @@ export async function importPlaygroundSite(
 	{ waitForCompletion = false }: { waitForCompletion?: boolean } = {}
 ): Promise< string | undefined > {
 	const siteZip = await getSiteZip( playground );
-
-	const importer = await uploadExportFile( siteId, {
-		importStatus: { importStatus: 'importer-ready-for-upload', siteId, type: 'wordpress' },
-		file: siteZip,
-	} );
+	const importer = await createPlaygroundImport( siteId, siteZip );
 
 	if ( ! waitForCompletion ) {
 		return importer.importId;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/import-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/import-playground.ts
@@ -36,7 +36,10 @@ export async function getSiteZip( playground: PlaygroundClient ) {
 }
 
 export async function uploadSiteZip( siteId: number, siteZip: File ): Promise< number > {
-	const response = await wpcomRequest< { media?: Array< { ID?: number } > } >( {
+	const response = await wpcomRequest< {
+		media?: Array< { ID?: number } >;
+		errors?: unknown;
+	} >( {
 		path: `/sites/${ siteId }/media/new`,
 		apiVersion: '1.1',
 		method: 'POST',
@@ -45,7 +48,10 @@ export async function uploadSiteZip( siteId: number, siteZip: File ): Promise< n
 	const mediaId = response.media?.[ 0 ]?.ID;
 
 	if ( ! mediaId ) {
-		throw new Error( 'No media ID returned after uploading the Playground export.' );
+		const detail = response.errors ? JSON.stringify( response.errors ) : JSON.stringify( response );
+		throw new Error(
+			`No media ID returned after uploading the Playground export. API response: ${ detail }`
+		);
 	}
 
 	return mediaId;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/import-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/import-playground.ts
@@ -1,5 +1,6 @@
 import wpcomRequest from 'wpcom-proxy-request';
 import { uploadExportFile } from 'calypso/state/imports/actions';
+import { pollForAtomicProvisioning } from '../../create-site/early-provisioning';
 import { createPlaygroundImport } from '../lib/import-playground';
 
 jest.mock( 'wpcom-proxy-request', () => ( {
@@ -12,7 +13,12 @@ jest.mock( 'calypso/state/imports/actions', () => ( {
 	updateImporter: jest.fn(),
 } ) );
 
+jest.mock( '../../create-site/early-provisioning', () => ( {
+	pollForAtomicProvisioning: jest.fn(),
+} ) );
+
 const wpcomRequestMock = wpcomRequest as jest.Mock;
+const pollForAtomicProvisioningMock = pollForAtomicProvisioning as jest.Mock;
 const uploadExportFileMock = uploadExportFile as jest.Mock;
 
 describe( 'createPlaygroundImport', () => {
@@ -21,13 +27,28 @@ describe( 'createPlaygroundImport', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
+		pollForAtomicProvisioningMock.mockResolvedValue( { siteSlug: 'example.wordpress.com' } );
 	} );
 
-	it( 'uploads the export to the Atomic site and passes its media ID to the importer', async () => {
+	it( 'waits for the site to become Atomic before uploading the export', async () => {
+		let resolveProvisioning!: ( value: { siteSlug: string } ) => void;
+		pollForAtomicProvisioningMock.mockReturnValueOnce(
+			new Promise( ( resolve ) => {
+				resolveProvisioning = resolve;
+			} )
+		);
 		wpcomRequestMock.mockResolvedValue( { media: [ { ID: 456 } ] } );
 		uploadExportFileMock.mockResolvedValue( { importId: 'import-id' } );
 
-		await expect( createPlaygroundImport( siteId, siteZip ) ).resolves.toEqual( {
+		const importPromise = createPlaygroundImport( siteId, siteZip );
+
+		expect( pollForAtomicProvisioningMock ).toHaveBeenCalledWith( siteId );
+		expect( wpcomRequestMock ).not.toHaveBeenCalled();
+		expect( uploadExportFileMock ).not.toHaveBeenCalled();
+
+		resolveProvisioning( { siteSlug: 'example.wordpress.com' } );
+
+		await expect( importPromise ).resolves.toEqual( {
 			importId: 'import-id',
 		} );
 
@@ -43,8 +64,18 @@ describe( 'createPlaygroundImport', () => {
 				siteId,
 				type: 'wordpress',
 			},
-			mediaID: 456,
+			attachmentId: 456,
 		} );
+	} );
+
+	it( 'does not upload the export when Atomic provisioning fails', async () => {
+		pollForAtomicProvisioningMock.mockRejectedValue( new Error( 'Provisioning failed' ) );
+
+		await expect( createPlaygroundImport( siteId, siteZip ) ).rejects.toThrow(
+			'Provisioning failed'
+		);
+		expect( wpcomRequestMock ).not.toHaveBeenCalled();
+		expect( uploadExportFileMock ).not.toHaveBeenCalled();
 	} );
 
 	it( 'does not start an import when the media upload has no attachment ID', async () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/import-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/import-playground.ts
@@ -1,0 +1,58 @@
+import wpcomRequest from 'wpcom-proxy-request';
+import { uploadExportFile } from 'calypso/state/imports/actions';
+import { createPlaygroundImport } from '../lib/import-playground';
+
+jest.mock( 'wpcom-proxy-request', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/imports/actions', () => ( {
+	uploadExportFile: jest.fn(),
+	updateImporter: jest.fn(),
+} ) );
+
+const wpcomRequestMock = wpcomRequest as jest.Mock;
+const uploadExportFileMock = uploadExportFile as jest.Mock;
+
+describe( 'createPlaygroundImport', () => {
+	const siteId = 123;
+	const siteZip = new File( [ 'zip contents' ], 'site.zip', { type: 'application/zip' } );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'uploads the export to the Atomic site and passes its media ID to the importer', async () => {
+		wpcomRequestMock.mockResolvedValue( { media: [ { ID: 456 } ] } );
+		uploadExportFileMock.mockResolvedValue( { importId: 'import-id' } );
+
+		await expect( createPlaygroundImport( siteId, siteZip ) ).resolves.toEqual( {
+			importId: 'import-id',
+		} );
+
+		expect( wpcomRequestMock ).toHaveBeenCalledWith( {
+			path: '/sites/123/media/new',
+			apiVersion: '1.1',
+			method: 'POST',
+			formData: [ [ 'media[]', siteZip ] ],
+		} );
+		expect( uploadExportFileMock ).toHaveBeenCalledWith( siteId, {
+			importStatus: {
+				importStatus: 'importer-ready-for-upload',
+				siteId,
+				type: 'wordpress',
+			},
+			mediaID: 456,
+		} );
+	} );
+
+	it( 'does not start an import when the media upload has no attachment ID', async () => {
+		wpcomRequestMock.mockResolvedValue( { media: [] } );
+
+		await expect( createPlaygroundImport( siteId, siteZip ) ).rejects.toThrow(
+			'No media ID returned after uploading the Playground export.'
+		);
+		expect( uploadExportFileMock ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/state/imports/actions.js
+++ b/client/state/imports/actions.js
@@ -65,7 +65,7 @@ export const uploadExportFile = ( siteId, params ) =>
 
 		const formData = [
 			[ 'importStatus', JSON.stringify( params.importStatus ) ],
-			params.mediaID ? [ 'mediaID', params.mediaID ] : [ 'import', params.file ],
+			params.attachmentId ? [ 'attachmentId', params.attachmentId ] : [ 'import', params.file ],
 		];
 
 		if ( params.url ) {

--- a/client/state/imports/actions.js
+++ b/client/state/imports/actions.js
@@ -65,7 +65,7 @@ export const uploadExportFile = ( siteId, params ) =>
 
 		const formData = [
 			[ 'importStatus', JSON.stringify( params.importStatus ) ],
-			[ 'import', params.file ],
+			params.mediaID ? [ 'mediaID', params.mediaID ] : [ 'import', params.file ],
 		];
 
 		if ( params.url ) {

--- a/client/state/imports/test/upload-export-file.js
+++ b/client/state/imports/test/upload-export-file.js
@@ -1,0 +1,54 @@
+import wp from 'calypso/lib/wp';
+import { uploadExportFile } from 'calypso/state/imports/actions';
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: {
+		post: jest.fn(),
+	},
+} ) );
+
+describe( 'uploadExportFile', () => {
+	const siteId = 123;
+	const importStatus = {
+		importStatus: 'importer-ready-for-upload',
+		siteId,
+		type: 'wordpress',
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		wp.req.post.mockReturnValue( { upload: {} } );
+	} );
+
+	it( 'keeps uploading files through the import field', () => {
+		const file = new File( [ 'contents' ], 'export.zip', { type: 'application/zip' } );
+
+		uploadExportFile( siteId, { importStatus, file } );
+
+		expect( wp.req.post ).toHaveBeenCalledWith(
+			{
+				path: '/sites/123/imports/new',
+				formData: [
+					[ 'importStatus', JSON.stringify( importStatus ) ],
+					[ 'import', file ],
+				],
+			},
+			expect.any( Function )
+		);
+	} );
+
+	it( 'supports starting an import with a media ID', () => {
+		uploadExportFile( siteId, { importStatus, mediaID: 456 } );
+
+		expect( wp.req.post ).toHaveBeenCalledWith(
+			{
+				path: '/sites/123/imports/new',
+				formData: [
+					[ 'importStatus', JSON.stringify( importStatus ) ],
+					[ 'mediaID', 456 ],
+				],
+			},
+			expect.any( Function )
+		);
+	} );
+} );

--- a/client/state/imports/test/upload-export-file.js
+++ b/client/state/imports/test/upload-export-file.js
@@ -37,15 +37,15 @@ describe( 'uploadExportFile', () => {
 		);
 	} );
 
-	it( 'supports starting an import with a media ID', () => {
-		uploadExportFile( siteId, { importStatus, mediaID: 456 } );
+	it( 'supports starting an import with an attachment ID', () => {
+		uploadExportFile( siteId, { importStatus, attachmentId: 456 } );
 
 		expect( wp.req.post ).toHaveBeenCalledWith(
 			{
 				path: '/sites/123/imports/new',
 				formData: [
 					[ 'importStatus', JSON.stringify( importStatus ) ],
-					[ 'mediaID', 456 ],
+					[ 'attachmentId', 456 ],
 				],
 			},
 			expect.any( Function )


### PR DESCRIPTION
Add the new Playground flow:

1. Playground page: http://calypso.localhost:3000/setup/onboarding/playground
2. Cart: buy the site
3. The WoA site is created automatically <- new
4. The backup zip is added to the WoA site media library <- new
5. The import is started by sending the media ID to `/sites/${ siteId }/imports/new`, and not the .zip <- modified
6. The import starts on the target machine
7. The user is redirected to the new site

Previous flow was:

1. Playground page: http://calypso.localhost:3000/setup/onboarding/playground
2. Cart: buy the site
3. The import is started by sending the .zip to `/sites/${ siteId }/imports/new`
4. The .zip is saved
5. The site is moved to WoA
6. The .zip is downloaded
7. The .zip is uploaded to the new site
8. The import starts on the target machine
9. The user is redirected to the new site

## Proposed Changes

See paragraph before.

The new flow can potentially be started:

1. Again on the same site, it will rewrite the target
2. Directly from the plugin once moved to `wpcomsh`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply 229138-ghe-Automattic/wpcom
* Enable PCYsg-IA-p2
* Visit http://calypso.localhost:3000/setup/onboarding/playground
* Buy a site, see PCYsg-IA-p2 on how to do it
* Wait for the process to finish
* Be sure the new site is ok

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?