### PR TITLE
Email comparison: fix missing Google Workspace monthly price

### DIFF
--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -17,6 +17,8 @@ import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selector
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
+import { getSiteAvailableProduct } from 'calypso/state/sites/products/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
 import './style.scss';
@@ -56,7 +58,13 @@ const GoogleWorkspacePrice = ( {
 	const translate = useTranslate();
 
 	const productSlug = getGoogleWorkspaceProductSlug( intervalLength );
-	const product = useSelector( ( state ) => getProductBySlug( state, productSlug ) );
+	const selectedSite = useSelector( getSelectedSite );
+	const siteId = domain?.blogId ?? selectedSite?.ID;
+	const globalProduct = useSelector( ( state ) => getProductBySlug( state, productSlug ) );
+	const siteProduct = useSelector( ( state ) =>
+		getSiteAvailableProduct( state, siteId, productSlug )
+	);
+	const product = siteProduct ?? globalProduct;
 
 	const canPurchaseGSuite = useSelector( canUserPurchaseGSuite );
 


### PR DESCRIPTION
## Proposed Changes

* On `/emails/choose-email-solution/:site`, the Google Workspace card showed no monthly price (rendered `$0 /month /mailbox`) when the monthly billing cycle was selected. The annual price rendered correctly.
* `GoogleWorkspacePrice` now resolves its product from the site-available products list first (`getSiteAvailableProduct`), falling back to the global products list (`getProductBySlug`), mirroring how `ProfessionalEmailPrice` (the Professional Email / Titan card) already works.

## Why are these changes being made?

The monthly Google Workspace product cost is populated in the site-available products endpoint, not the global `type=all` products list. The comparison page already loads site products via `<QuerySiteProducts>`, and the Professional Email card consumes them, which is why Titan's monthly price renders correctly. The Google Workspace price component only read from the global products list, so the monthly product came back empty and the price fell back to `formatCurrency( 0 )`. Resolving the product the same way as the Professional Email card fixes the missing monthly price.

## Testing Instructions

1. Go to `/emails/choose-email-solution/<site>` for a site with a Google-Workspace-supported custom domain.
2. Expand the Google Workspace card.
3. Toggle the billing interval to **Pay monthly**.
4. Before: no real price is shown (displays `$0 /month /mailbox`). After: the correct monthly per-mailbox price is shown.
5. Toggle back to **Pay annually** and confirm the annual price still renders correctly.
6. Confirm the Professional Email card is unaffected in both intervals.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?