### PR TITLE
Auto-retry the cache-seed build so a hung attempt self-heals

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -496,21 +496,29 @@ object BuildCacheSeedImages : BuildType({
 		script {
 			name = "Build cache-seed image (with retry)"
 			// The webpack build occasionally hangs at worker-pool shutdown and would
-			// otherwise sit until the job timeout, leaving cache-seed:latest stale and
-			// forcing slow, timing-out cold app builds. Retry once, with a per-attempt
-			// timeout, so a hung attempt self-heals in minutes instead of running the clock out.
+			// otherwise sit until the 65-min job timeout, leaving cache-seed:latest stale
+			// and forcing slow, timing-out cold app builds. Retry once on a timeout kill so
+			// the job self-heals without a human re-run. A hang burns the full ~28-min
+			// attempt first, so the self-heal is ~40-45 min, not instant.
 			scriptContent = """
 				#!/usr/bin/env bash
-				set -uo pipefail
+				set -euo pipefail
 
 				build_cache_seed() {
 					timeout --kill-after=1m 28m docker build --target cache-seed $commonArgs -t registry.a8c.com/calypso/cache-seed:%build.number% -f Dockerfile.cache-seed .
 				}
 
-				if build_cache_seed; then
+				rc=0
+				build_cache_seed || rc=${'$'}?
+				if [[ ${'$'}rc -eq 0 ]]; then
 					exit 0
 				fi
-				echo "cache-seed build failed or hung; retrying once."
+				# Only a timeout kill (124, or 137 from --kill-after's SIGKILL) is a hang
+				# worth retrying; surface a genuine build failure immediately.
+				if [[ ${'$'}rc -ne 124 && ${'$'}rc -ne 137 ]]; then
+					exit ${'$'}rc
+				fi
+				echo "cache-seed build timed out; retrying once."
 				build_cache_seed
 			""".trimIndent()
 		}

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -493,16 +493,26 @@ object BuildCacheSeedImages : BuildType({
 	steps {
 		val commonArgs = "--pull --build-arg workers=32 --build-arg node_memory=16384 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber} --build-arg profile=%PROFILE%"
 
-		dockerCommand {
-			name = "Build cache-seed image"
-			commandType = build {
-				source = file {
-					path = "Dockerfile.cache-seed"
+		script {
+			name = "Build cache-seed image (with retry)"
+			// The webpack build occasionally hangs at worker-pool shutdown and would
+			// otherwise sit until the job timeout, leaving cache-seed:latest stale and
+			// forcing slow, timing-out cold app builds. Retry once, with a per-attempt
+			// timeout, so a hung attempt self-heals in minutes instead of running the clock out.
+			scriptContent = """
+				#!/usr/bin/env bash
+				set -uo pipefail
+
+				build_cache_seed() {
+					timeout --kill-after=1m 28m docker build --target cache-seed $commonArgs -t registry.a8c.com/calypso/cache-seed:%build.number% -f Dockerfile.cache-seed .
 				}
-				namesAndTags = "registry.a8c.com/calypso/cache-seed:%build.number%"
-				commandArgs = "--target cache-seed $commonArgs"
-			}
-			param("dockerImage.platform", "linux")
+
+				if build_cache_seed; then
+					exit 0
+				fi
+				echo "cache-seed build failed or hung; retrying once."
+				build_cache_seed
+			""".trimIndent()
 		}
 		dockerCommand {
 			name = "Build cache-seed debug smoke image"


### PR DESCRIPTION
## What this does

Wraps the cache-seed image build in a retry. If an attempt is killed by a per-attempt `timeout` (i.e. a hang), it retries **once**. A genuine build failure — any exit that isn't a timeout kill (124/137) — is *not* retried; it surfaces immediately.

Timing: a hang burns the full ~28-min attempt before the retry starts, so a self-heal is ~40–45 min (28 + ~13-min rebuild + push) — well under the 65-min job limit. Not instant, but no human re-run.

## Why

`calypso_BuildCacheSeedImages` occasionally hangs (a webpack worker-pool shutdown deadlock) and does nothing until the job timeout kills it. That leaves `cache-seed:latest` stale, so app builds miss the warm cache, do a full cold build, and hit their own 20-minute timeout. Today a hang sits the full 65 minutes and needs someone to re-run it.

Safety net, independent of the root-cause fix (raising the worker thread pool, #112768).

## Notes for review

- **DSL validated locally** — `cd .teamcity && mvn teamcity-configs:generate` returns `BUILD SUCCESS` (needs Java ≤24; the toolchain's Byte Buddy rejects JDK 26). Note there's still no GitHub check that compiles `settings.kts`, which may deserve its own fix given how often the file is edited.
- **BuildKit cancellation — verified.** Tested locally on the same buildx: `timeout`'s SIGTERM makes `docker build` cancel the build (`context canceled`, rc 124) with no server-side build left running, and a retry immediately after got a clean slate and completed. The real hang is inside the container (not the docker client, which stays responsive to the signal), so the cancel path is the same.
- Same pattern applies to `calypso_BuildBaseImages` — **it's hanging right now**, so that follow-up is urgent, not eventual. (It's also covered by the thread-pool fix in #112768.)

Part of PERFOPS-292.

## Checklist

- [ ] General commit checklist followed (PCYsg-hS-p2)
- [ ] Other template items N/A (CI-config change; no app code, UI, strings, or tests)
