### PR TITLE
A4A Migrations commissions: render the page natively on the dashboard Earn screen

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
@@ -1,4 +1,5 @@
-import { Button } from '@wordpress/components';
+import { useLocale } from '@automattic/i18n-utils';
+import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useCallback, useState } from 'react';
@@ -27,9 +28,14 @@ import type { ReactNode } from 'react';
 
 import './style.scss';
 
+const ClassicTableWrapper = ( { children }: { children: ReactNode } ) => (
+	<div className="redesigned-a8c-table full-width">{ children }</div>
+);
+
 export default function MigrationsCommissions() {
 	const dispatch = useDispatch();
 	const sites = useSelector( getSites );
+	const locale = useLocale();
 
 	const [ showAddSitesModal, setShowAddSitesModal ] = useState( false );
 	const {
@@ -47,13 +53,13 @@ export default function MigrationsCommissions() {
 	);
 
 	const onSuccess = useCallback(
-		( message: ReactNode, options?: { id?: string; duration?: number } ) =>
+		( message: string, options?: { id?: string; duration?: number } ) =>
 			dispatch( successNotice( message, options ) ),
 		[ dispatch ]
 	);
 
 	const onError = useCallback(
-		( message: ReactNode ) => dispatch( errorNotice( message ) ),
+		( message: string ) => dispatch( errorNotice( message ) ),
 		[ dispatch ]
 	);
 
@@ -120,7 +126,7 @@ export default function MigrationsCommissions() {
 					/>
 				) }
 				{ ! isLoading && ! showEmptyState && (
-					<div className="redesigned-a8c-table full-width">
+					<VStack spacing={ 6 }>
 						{ canTagSitesForCommission && (
 							<MigrationsConsolidatedCommissions items={ taggedSites } />
 						) }
@@ -130,8 +136,10 @@ export default function MigrationsCommissions() {
 							recordTracksEvent={ recordTracks }
 							onSuccess={ onSuccess }
 							onError={ onError }
+							locale={ locale }
+							TableWrapper={ ClassicTableWrapper }
 						/>
-					</div>
+					</VStack>
 				) }
 			</LayoutBody>
 
@@ -144,6 +152,7 @@ export default function MigrationsCommissions() {
 					onSuccess={ onSuccess }
 					onError={ onError }
 					getSiteCreatedAt={ getSiteCreatedAt }
+					locale={ locale }
 				/>
 			) }
 		</Layout>

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/style.scss
@@ -36,13 +36,15 @@
 		}
 	}
 
-	// Classic-only page inset; keep in sync with the shared `.consolidated-commissions`
-	// in dashboard/agency/earn/migrations/consolidated-commissions.
+	// Classic-only page inset; the list gap comes from the shared content's VStack, so
+	// this sets only the top and horizontal inset. Keep in sync with
+	// dashboard/agency/earn/migrations/consolidated-commissions.
 	.consolidated-commissions {
-		padding: 16px;
+		padding-block-start: 16px;
+		padding-inline: 16px;
 
 		@include break-large {
-			padding: 16px 64px 48px;
+			padding-inline: 64px;
 		}
 	}
 

--- a/client/dashboard/agency/earn/migrations/commissions-content.tsx
+++ b/client/dashboard/agency/earn/migrations/commissions-content.tsx
@@ -1,23 +1,26 @@
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { TextSkeleton } from '../../../components/text-skeleton';
 import MigrationsCommissionsList from './commissions-list';
 import MigrationsConsolidatedCommissions from './consolidated-commissions';
 import MigrationsCommissionsEmptyState from './empty-state';
 import MigrationsTagSitesModal from './tag-sites-modal';
 import type { RecordTracksEvent, ShowSuccessNotice, TaggedSite } from './types';
-import type { ReactNode } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 
 interface MigrationsCommissionsContentProps {
 	taggedSites: TaggedSite[];
 	isLoading: boolean;
 	recordTracksEvent: RecordTracksEvent;
 	onSuccess: ShowSuccessNotice;
-	onError: ( message: ReactNode ) => void;
+	onError: ( message: string ) => void;
 	getSiteCreatedAt: ( blogId: number ) => string | undefined;
+	locale: string;
 	canTagSitesForCommission: boolean;
 	migrationTags: string[];
 	isAddSitesModalOpen: boolean;
 	onCloseAddSitesModal: () => void;
 	onOpenAddSitesModal: () => void;
+	TableWrapper?: ComponentType< { children: ReactNode } >;
 }
 
 export default function MigrationsCommissionsContent( {
@@ -27,11 +30,13 @@ export default function MigrationsCommissionsContent( {
 	onSuccess,
 	onError,
 	getSiteCreatedAt,
+	locale,
 	canTagSitesForCommission,
 	migrationTags,
 	isAddSitesModalOpen,
 	onCloseAddSitesModal,
 	onOpenAddSitesModal,
+	TableWrapper,
 }: MigrationsCommissionsContentProps ) {
 	if ( isLoading ) {
 		return (
@@ -51,7 +56,7 @@ export default function MigrationsCommissionsContent( {
 					canTagSitesForCommission={ canTagSitesForCommission }
 				/>
 			) : (
-				<>
+				<VStack spacing={ 6 }>
 					{ canTagSitesForCommission && (
 						<MigrationsConsolidatedCommissions items={ taggedSites } />
 					) }
@@ -61,8 +66,10 @@ export default function MigrationsCommissionsContent( {
 						recordTracksEvent={ recordTracksEvent }
 						onSuccess={ onSuccess }
 						onError={ onError }
+						locale={ locale }
+						TableWrapper={ TableWrapper }
 					/>
-				</>
+				</VStack>
 			) }
 			{ isAddSitesModalOpen && (
 				<MigrationsTagSitesModal
@@ -73,6 +80,7 @@ export default function MigrationsCommissionsContent( {
 					onSuccess={ onSuccess }
 					onError={ onError }
 					getSiteCreatedAt={ getSiteCreatedAt }
+					locale={ locale }
 				/>
 			) }
 		</>

--- a/client/dashboard/agency/earn/migrations/commissions-list/commission-columns.tsx
+++ b/client/dashboard/agency/earn/migrations/commissions-list/commission-columns.tsx
@@ -18,10 +18,15 @@ export const SiteColumn = ( { site }: { site: string } ) => {
 	return urlToSlug( site );
 };
 
-export const MigratedOnColumn = ( { migratedOn }: { migratedOn: number } ) => {
+export const MigratedOnColumn = ( {
+	migratedOn,
+	locale,
+}: {
+	migratedOn: number;
+	locale: string;
+} ) => {
 	const date = new Date( migratedOn * 1000 );
-	// TODO: resolve the real locale once the dashboard port lands; hardcoded for now.
-	return <>{ formatDate( date, 'en', { day: '2-digit', month: 'short', year: 'numeric' } ) }</>;
+	return <>{ formatDate( date, locale, { day: '2-digit', month: 'short', year: 'numeric' } ) }</>;
 };
 
 export const ReviewStatusColumn = ( {

--- a/client/dashboard/agency/earn/migrations/commissions-list/index.tsx
+++ b/client/dashboard/agency/earn/migrations/commissions-list/index.tsx
@@ -2,7 +2,7 @@ import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { DataViews } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useCallback, useMemo, type ReactNode, useState } from 'react';
+import { useCallback, useMemo, type ComponentType, type ReactNode, useState } from 'react';
 import RequestReviewModal from '../request-review-modal';
 import { MigratedOnColumn, ReviewStatusColumn, SiteColumn } from './commission-columns';
 import UntagSiteDialog from './untag-site-dialog';
@@ -50,18 +50,24 @@ const INITIAL_VIEW: View = {
 	layout: {},
 };
 
+const DefaultTableWrapper = ( { children }: { children: ReactNode } ) => <>{ children }</>;
+
 export default function MigrationsCommissionsList( {
 	items,
 	migrationTags,
 	recordTracksEvent,
 	onSuccess,
 	onError,
+	locale,
+	TableWrapper = DefaultTableWrapper,
 }: {
 	items: TaggedSite[];
 	migrationTags: string[];
 	recordTracksEvent: RecordTracksEvent;
 	onSuccess: ShowSuccessNotice;
-	onError: ( message: ReactNode ) => void;
+	onError: ( message: string ) => void;
+	locale: string;
+	TableWrapper?: ComponentType< { children: ReactNode } >;
 } ) {
 	const isDesktop = useViewportMatch( 'large' );
 
@@ -108,7 +114,9 @@ export default function MigrationsCommissionsList( {
 				// We will change this when the MC tool is implemented and we have the migration date
 				label: __( 'Date added' ),
 				getValue: () => '-',
-				render: ( { item } ): ReactNode => <MigratedOnColumn migratedOn={ item.created_at } />,
+				render: ( { item } ): ReactNode => (
+					<MigratedOnColumn migratedOn={ item.created_at } locale={ locale } />
+				),
 				enableHiding: false,
 				enableSorting: false,
 			},
@@ -128,30 +136,35 @@ export default function MigrationsCommissionsList( {
 				enableSorting: false,
 			},
 		],
-		[]
+		[ locale ]
 	);
 
 	return (
 		<>
-			<DataViews
-				data={ items }
-				view={ responsiveView }
-				onChangeView={ setView }
-				fields={ fields }
-				search={ false }
-				actions={ actions }
-				getItemId={ ( item ) => `${ item.id }` }
-				paginationInfo={ pagination }
-				defaultLayouts={ { table: {}, list: {} } }
-			>
-				{ isDesktop && (
-					<HStack className="dataviews__view-actions commissions-list__view-actions" justify="end">
-						<DataViews.ViewConfig />
-					</HStack>
-				) }
-				<DataViews.Layout />
-				<DataViews.Footer />
-			</DataViews>
+			<TableWrapper>
+				<DataViews
+					data={ items }
+					view={ responsiveView }
+					onChangeView={ setView }
+					fields={ fields }
+					search={ false }
+					actions={ actions }
+					getItemId={ ( item ) => `${ item.id }` }
+					paginationInfo={ pagination }
+					defaultLayouts={ { table: {}, list: {} } }
+				>
+					{ isDesktop && (
+						<HStack
+							className="dataviews__view-actions commissions-list__view-actions"
+							justify="end"
+						>
+							<DataViews.ViewConfig />
+						</HStack>
+					) }
+					<DataViews.Layout />
+					<DataViews.Footer />
+				</DataViews>
+			</TableWrapper>
 
 			{ activeModal?.kind === 'untag' && (
 				<UntagSiteDialog

--- a/client/dashboard/agency/earn/migrations/commissions-list/untag-site-dialog.tsx
+++ b/client/dashboard/agency/earn/migrations/commissions-list/untag-site-dialog.tsx
@@ -54,13 +54,10 @@ export default function UntagSiteDialog( {
 					} );
 					onClose();
 					onSuccess(
-						createInterpolateElement(
-							sprintf(
-								/* translators: %s: the site URL */
-								__( 'Successfully untagged <strong>%s</strong>.' ),
-								site.url
-							),
-							{ strong: <strong /> }
+						sprintf(
+							/* translators: %s: the site URL */
+							__( 'Successfully untagged %s.' ),
+							site.url
 						),
 						{ id: 'a4a-commission-list-untag-success', duration: 5000 }
 					);

--- a/client/dashboard/agency/earn/migrations/index.tsx
+++ b/client/dashboard/agency/earn/migrations/index.tsx
@@ -10,6 +10,7 @@ import { useLocale } from '../../../app/locale';
 import { DataViewsCard } from '../../../components/dataviews';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
+import MissingPaymentSettingsNotice from '../missing-payment-settings-notice';
 import MigrationsCommissionsContent from './commissions-content';
 import useCanTagSitesForCommission from './hooks/use-can-tag-sites-for-commission';
 import useFetchTaggedSitesForMigration from './hooks/use-fetch-tagged-sites-for-migration';
@@ -61,6 +62,7 @@ export default function EarnMigrations() {
 					}
 				/>
 			}
+			notices={ <MissingPaymentSettingsNotice hasCommissionActivity={ taggedSites.length > 0 } /> }
 		>
 			<MigrationsCommissionsContent
 				taggedSites={ taggedSites }

--- a/client/dashboard/agency/earn/migrations/index.tsx
+++ b/client/dashboard/agency/earn/migrations/index.tsx
@@ -1,18 +1,82 @@
+import { allSitesQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { Button } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useCallback, useState } from 'react';
+import { useAnalytics } from '../../../app/analytics';
+import { useLocale } from '../../../app/locale';
+import { DataViewsCard } from '../../../components/dataviews';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
+import MigrationsCommissionsContent from './commissions-content';
+import useCanTagSitesForCommission from './hooks/use-can-tag-sites-for-commission';
+import useFetchTaggedSitesForMigration from './hooks/use-fetch-tagged-sites-for-migration';
 
 export default function EarnMigrations() {
+	const locale = useLocale();
+	const { recordTracksEvent } = useAnalytics();
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { canTagSitesForCommission, migrationTags } = useCanTagSitesForCommission();
+	const { data: sites = [] } = useQuery( allSitesQuery() );
+	const { data, isLoading } = useFetchTaggedSitesForMigration();
+	const taggedSites = data ?? [];
+
+	const [ isAddSitesModalOpen, setIsAddSitesModalOpen ] = useState( false );
+
+	const getSiteCreatedAt = useCallback(
+		( blogId: number ) => sites.find( ( site ) => site?.ID === blogId )?.options?.created_at,
+		[ sites ]
+	);
+
+	const onSuccess = useCallback(
+		( message: string, options?: { id?: string; duration?: number } ) =>
+			createSuccessNotice( message, { type: 'snackbar', id: options?.id } ),
+		[ createSuccessNotice ]
+	);
+
+	const onError = useCallback(
+		( message: string ) => createErrorNotice( message, { type: 'snackbar' } ),
+		[ createErrorNotice ]
+	);
+
+	const onOpenAddSitesModal = useCallback( () => {
+		recordTracksEvent( 'calypso_a8c_migrations_commissions_tag_sites_click' );
+		setIsAddSitesModalOpen( true );
+	}, [ recordTracksEvent ] );
+
 	return (
 		<PageLayout
 			header={
 				<PageHeader
 					title={ __( 'Migrations' ) }
 					description={ __( 'Earn commissions for migrating sites to Automattic hosting.' ) }
+					actions={
+						canTagSitesForCommission ? (
+							<Button variant="primary" onClick={ onOpenAddSitesModal }>
+								{ __( 'Tag sites for commission' ) }
+							</Button>
+						) : undefined
+					}
 				/>
 			}
 		>
-			{ /* TODO: Build the Earn migrations screen. */ }
+			<MigrationsCommissionsContent
+				taggedSites={ taggedSites }
+				isLoading={ isLoading }
+				recordTracksEvent={ recordTracksEvent }
+				onSuccess={ onSuccess }
+				onError={ onError }
+				getSiteCreatedAt={ getSiteCreatedAt }
+				locale={ locale }
+				canTagSitesForCommission={ canTagSitesForCommission }
+				migrationTags={ migrationTags }
+				isAddSitesModalOpen={ isAddSitesModalOpen }
+				onCloseAddSitesModal={ () => setIsAddSitesModalOpen( false ) }
+				onOpenAddSitesModal={ onOpenAddSitesModal }
+				TableWrapper={ DataViewsCard }
+			/>
 		</PageLayout>
 	);
 }

--- a/client/dashboard/agency/earn/migrations/request-review-modal/index.tsx
+++ b/client/dashboard/agency/earn/migrations/request-review-modal/index.tsx
@@ -16,7 +16,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
 import type { RecordTracksEvent, ShowSuccessNotice, TaggedSite } from '../types';
-import type { ReactNode } from 'react';
 
 export default function RequestReviewModal( {
 	onClose,
@@ -29,7 +28,7 @@ export default function RequestReviewModal( {
 	site: TaggedSite;
 	recordTracksEvent: RecordTracksEvent;
 	onSuccess: ShowSuccessNotice;
-	onError: ( message: ReactNode ) => void;
+	onError: ( message: string ) => void;
 } ) {
 	const queryClient = useQueryClient();
 	const { data: agency } = useQuery( activeAgencyQuery() );
@@ -58,13 +57,10 @@ export default function RequestReviewModal( {
 						site_id: site.id,
 					} );
 					onSuccess(
-						createInterpolateElement(
-							sprintf(
-								/* translators: %s: the site URL */
-								__( 'Your verification request for <strong>%s</strong> has been submitted.' ),
-								site.url
-							),
-							{ strong: <strong /> }
+						sprintf(
+							/* translators: %s: the site URL */
+							__( 'Your verification request for %s has been submitted.' ),
+							site.url
 						),
 						{ id: 'a4a-commission-request-review-success', duration: 5000 }
 					);

--- a/client/dashboard/agency/earn/migrations/tag-sites-modal/add-sites-table.tsx
+++ b/client/dashboard/agency/earn/migrations/tag-sites-modal/add-sites-table.tsx
@@ -23,6 +23,7 @@ export default function MigrationsAddSitesTable( {
 	migrationSourceHost,
 	recordTracksEvent,
 	getSiteCreatedAt,
+	locale,
 }: {
 	selectedSites: SiteItem[];
 	setSelectedSites: ( sites: SiteItem[] ) => void;
@@ -30,6 +31,7 @@ export default function MigrationsAddSitesTable( {
 	migrationSourceHost: string;
 	recordTracksEvent: RecordTracksEvent;
 	getSiteCreatedAt: ( blogId: number ) => string | undefined;
+	locale: string;
 } ) {
 	const isDesktop = useViewportMatch( 'large' );
 
@@ -123,8 +125,7 @@ export default function MigrationsAddSitesTable( {
 			getValue: () => '-',
 			render: ( { item }: { item: SiteItem } ) => {
 				const createdAt = getSiteCreatedAt( item.rawSite.blog_id );
-				// TODO: resolve the real locale once the dashboard port lands; hardcoded for now.
-				return createdAt ? formatDate( new Date( createdAt ), 'en' ) : '-';
+				return createdAt ? formatDate( new Date( createdAt ), locale ) : '-';
 			},
 			enableHiding: false,
 			enableSorting: false,
@@ -138,6 +139,7 @@ export default function MigrationsAddSitesTable( {
 		onSelectSite,
 		selectedSites,
 		getSiteCreatedAt,
+		locale,
 	] );
 
 	const { data: allSites, paginationInfo } = useMemo( () => {

--- a/client/dashboard/agency/earn/migrations/tag-sites-modal/index.tsx
+++ b/client/dashboard/agency/earn/migrations/tag-sites-modal/index.tsx
@@ -13,14 +13,12 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
 import { useState } from 'react';
 import MigrationsAddSitesTable from './add-sites-table';
 import type { SiteItem } from '../hooks/use-fetch-all-managed-sites-for-commission';
 import type { RecordTracksEvent, TaggedSite } from '../types';
-import type { ReactNode } from 'react';
 
 import './style.scss';
 
@@ -32,14 +30,16 @@ export default function MigrationsTagSitesModal( {
 	onSuccess,
 	onError,
 	getSiteCreatedAt,
+	locale,
 }: {
 	onClose: () => void;
 	taggedSites?: TaggedSite[];
 	migrationTags: string[];
 	recordTracksEvent: RecordTracksEvent;
-	onSuccess: ( message: ReactNode ) => void;
-	onError: ( message: ReactNode ) => void;
+	onSuccess: ( message: string ) => void;
+	onError: ( message: string ) => void;
 	getSiteCreatedAt: ( blogId: number ) => string | undefined;
+	locale: string;
 } ) {
 	const queryClient = useQueryClient();
 	const { data: agency } = useQuery( activeAgencyQuery() );
@@ -94,15 +94,10 @@ export default function MigrationsTagSitesModal( {
 					const siteUrl = hasSingleSite ? selectedSites[ 0 ].site : '';
 					onSuccess(
 						hasSingleSite
-							? createInterpolateElement(
-									sprintf(
-										/* translators: %s: the site URL */
-										__(
-											'The site <strong>%s</strong> has been successfully tagged for commission.'
-										),
-										siteUrl
-									),
-									{ strong: <strong /> }
+							? sprintf(
+									/* translators: %s: the site URL */
+									__( 'The site %s has been successfully tagged for commission.' ),
+									siteUrl
 							  )
 							: sprintf(
 									/* translators: %d: the number of sites tagged */
@@ -187,6 +182,7 @@ export default function MigrationsTagSitesModal( {
 						migrationSourceHost={ selectedMigrationSourceHost }
 						recordTracksEvent={ recordTracksEvent }
 						getSiteCreatedAt={ getSiteCreatedAt }
+						locale={ locale }
 					/>
 				) }
 			</VStack>

--- a/client/dashboard/agency/earn/migrations/test/commissions-content.test.tsx
+++ b/client/dashboard/agency/earn/migrations/test/commissions-content.test.tsx
@@ -13,6 +13,7 @@ const baseProps = {
 	onSuccess: () => {},
 	onError: () => {},
 	getSiteCreatedAt: () => undefined,
+	locale: 'en',
 	canTagSitesForCommission: true,
 	migrationTags: [ 'tag' ],
 	isAddSitesModalOpen: false,

--- a/client/dashboard/agency/earn/migrations/test/index.test.tsx
+++ b/client/dashboard/agency/earn/migrations/test/index.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Run: yarn test-client client/dashboard/agency/earn/migrations/test/index.test.tsx
+ */
+
+import { screen } from '@testing-library/react';
+import nock from 'nock';
+import { render } from '../../../../test-utils';
+import EarnMigrations from '../index';
+
+// Empty-state copy rendered by MigrationsCommissionsContent when there are no
+// tagged sites (regardless of eligibility).
+const EMPTY_STATE_HEADING = 'View your migrated websites and commissions right here.';
+const TAG_SITES_BUTTON = 'Tag sites for commission';
+
+// A `start_date` inside the incentive gap makes the agency ineligible to tag;
+// an absent `start_date` makes it eligible.
+function mockAgency( startDate?: string ) {
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( '/wpcom/v2/agency' )
+		.query( true )
+		.reply( 200, [
+			{
+				id: 1,
+				name: 'Test Agency',
+				third_party: startDate ? { pressable: { usage: { start_date: startDate } } } : {},
+			},
+		] );
+}
+
+function mockTaggedSites() {
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( '/wpcom/v2/agency/1/sites' )
+		.query( true )
+		.reply( 200, [] );
+}
+
+describe( '<EarnMigrations>', () => {
+	beforeEach( () => {
+		// Baseline endpoints the dashboard providers resolve on mount.
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( '/rest/v1.2/read/teams' )
+			.query( true )
+			.reply( 200, { teams: [] } );
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( '/rest/v1.1/me/preferences' )
+			.query( true )
+			.reply( 200, { calypso_preferences: {} } );
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( '/rest/v1.3/me/sites' )
+			.query( true )
+			.reply( 200, { sites: [], total: 0 } );
+	} );
+
+	test( 'shows the empty state and the tag-sites action when the agency is eligible', async () => {
+		mockAgency();
+		mockTaggedSites();
+
+		render( <EarnMigrations /> );
+
+		expect( await screen.findByText( EMPTY_STATE_HEADING ) ).toBeVisible();
+		expect( await screen.findByRole( 'button', { name: TAG_SITES_BUTTON } ) ).toBeVisible();
+	} );
+
+	test( 'hides the tag-sites action when the agency is not eligible', async () => {
+		mockAgency( '2025-08-11' );
+		mockTaggedSites();
+
+		render( <EarnMigrations /> );
+
+		expect( await screen.findByText( EMPTY_STATE_HEADING ) ).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: TAG_SITES_BUTTON } ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/agency/earn/migrations/types.ts
+++ b/client/dashboard/agency/earn/migrations/types.ts
@@ -1,5 +1,4 @@
 import type { MigrationCommissionSite } from '@automattic/api-core';
-import type { ReactNode } from 'react';
 
 /**
  * @deprecated Prefer importing `MigrationCommissionSite` from `@automattic/api-core`.
@@ -9,7 +8,9 @@ export type TaggedSite = MigrationCommissionSite;
 
 export type RecordTracksEvent = ( name: string, properties?: Record< string, unknown > ) => void;
 
+// Dashboard snackbars accept string content only, so notice callbacks are
+// narrowed to strings across both hosts.
 export type ShowSuccessNotice = (
-	message: ReactNode,
+	message: string,
 	options?: { id?: string; duration?: number }
 ) => void;

--- a/client/dashboard/agency/earn/missing-payment-settings-notice.tsx
+++ b/client/dashboard/agency/earn/missing-payment-settings-notice.tsx
@@ -1,25 +1,25 @@
 import { activeAgencyQuery, tipaltiPayeeQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
-import { Notice } from '../../../components/notice';
-import RouterLinkButton from '../../../components/router-link-button';
+import { Notice } from '../../components/notice';
+import RouterLinkButton from '../../components/router-link-button';
 
 interface MissingPaymentSettingsNoticeProps {
-	hasReferrals: boolean;
+	hasCommissionActivity: boolean;
 }
 
 export default function MissingPaymentSettingsNotice( {
-	hasReferrals,
+	hasCommissionActivity,
 }: MissingPaymentSettingsNoticeProps ) {
 	const { data: agency } = useQuery( activeAgencyQuery() );
 	const agencyId = agency?.id ?? 0;
 
 	const { data: tipaltiData, isSuccess } = useQuery( {
 		...tipaltiPayeeQuery( agencyId ),
-		enabled: !! agencyId && hasReferrals,
+		enabled: !! agencyId && hasCommissionActivity,
 	} );
 
-	if ( ! hasReferrals || ! isSuccess || tipaltiData?.IsPayable ) {
+	if ( ! hasCommissionActivity || ! isSuccess || tipaltiData?.IsPayable ) {
 		return null;
 	}
 

--- a/client/dashboard/agency/earn/referrals/index.tsx
+++ b/client/dashboard/agency/earn/referrals/index.tsx
@@ -14,10 +14,10 @@ import { DataViewsCard } from '../../../components/dataviews';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 import RouterLinkButton from '../../../components/router-link-button';
+import MissingPaymentSettingsNotice from '../missing-payment-settings-notice';
 import ConsolidatedViews from './consolidated-views';
 import { DEFAULT_VIEW } from './dataviews/views';
 import ReferralsEmptyState from './empty-state';
-import MissingPaymentSettingsNotice from './missing-payment-settings-notice';
 import ReferralsList from './referrals-list';
 import type { View } from '@wordpress/dataviews';
 
@@ -56,7 +56,7 @@ export default function EarnReferrals() {
 					}
 				/>
 			}
-			notices={ <MissingPaymentSettingsNotice hasReferrals={ hasReferrals } /> }
+			notices={ <MissingPaymentSettingsNotice hasCommissionActivity={ hasReferrals } /> }
 		>
 			{ ! isLoading && ! hasReferrals ? (
 				<ReferralsEmptyState agencyId={ agencyId } />


### PR DESCRIPTION
<!-- Stacked on `refactor/a4a/migrations-commissions-move-ui`; base is set accordingly. Re-target to trunk once the parent PRs merge. -->

Final step of the effort to port the A4A Migrations → Commissions feature into the Dashboard (MSD): render the page natively on the dashboard **Earn › Migrations** screen via the shared `MigrationsCommissionsContent`, and add the host seams (table container, locale) that both the dashboard and the classic A4A host need. The classic host keeps composing the shared leaf components directly so it can render its own empty state.

## Proposed Changes

* Flesh out the `EarnMigrations` screen (`client/dashboard/agency/earn/migrations/index.tsx`) to render `MigrationsCommissionsContent` with dashboard-native host concerns:
  * analytics via `useAnalytics().recordTracksEvent`
  * success / error snackbars via `@wordpress/notices`
  * site creation dates via `allSitesQuery()`
  * the tagging gate via `useCanTagSitesForCommission()`, plus a "Tag sites for commission" header action and the add-sites modal state
  * the tagged-sites query it passes into the presentational content (both hosts own the fetch and pass `taggedSites` / `isLoading` down)
* Re-introduce two host-specific seams as props (matching the WooPayments dashboard pattern) so both hosts render the shared component correctly:
  * **table container** — the dashboard passes `DataViewsCard`, the classic host passes its `redesigned-a8c-table` div
  * **locale** — the dashboard resolves it via `app/locale` `useLocale`, the classic host via `@automattic/i18n-utils` `useLocale`, restoring the real locale that was temporarily hardcoded to `en` in the "Date added" columns
* Narrow `onSuccess` / `onError` to `string` and convert the tag / untag / request-review success notices from `createInterpolateElement` (JSX) to plain `sprintf` strings, because dashboard snackbars only accept string content. Cosmetic effect on classic: the site name in those notices is no longer bold.
* Space the consolidated cards and the commissions list with a `VStack` in the shared content (rather than a page stylesheet), and drop the classic consolidated-cards bottom padding so the gap is not doubled. The classic card→list gap is now 24px, matching the dashboard.
* Add an `EarnMigrations` screen test.
* Render the missing-payment-settings notice on the dashboard screen, which was not showing the payout warning the classic page already shows. Promote the referrals dashboard notice to the shared `earn/` folder, rename its prop `hasReferrals` → `hasCommissionActivity`, and render it on both the migrations and referrals screens — gated on whether the agency has commission activity (tagged sites / referrals). It only appears once Tipalti reports the payee is not yet payable and links to the shared payout-settings screen.

## Why are these changes being made?

The Dashboard is the source of truth for agency features. The prior PRs in this stack moved the migrations-commission UI, data, and logic into `client/dashboard/agency/earn/migrations/` and cleaned it to MSD design-system standards, with the classic A4A app consuming it through injected host concerns. This PR wires that shared component into the dashboard's own Earn › Migrations screen, so MSD users get the page natively while the classic page keeps working unchanged.

## Testing Instructions

* On the dashboard, visit **Earn › Migrations**:
  * With tagged sites: the consolidated summary cards render above the commissions list; the "Tag sites for commission" action appears for eligible agencies and opens the tag-sites modal; tagging / untagging / requesting review show snackbar notices.
  * With no tagged sites: the empty state renders.
  * With tagged sites but no payout details: the “Add your payout information to get paid” notice shows at the top (and disappears once payout details are added); the same notice shows on the Referrals screen.
* Confirm the classic A4A Migrations → Commissions page still works (layout, notices, and the tag / untag / request-review flows). Note the two intended behaviour changes: the classic success notices no longer bold the site name, and the classic card→list gap is 24px.
* `yarn test-client client/dashboard/agency/earn` passes (43 tests).
* `yarn typecheck-client` shows no new errors under `agency/earn/migrations`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

