### PR TITLE
DO NOT MERGE: Dashboard prototype — workspace-aware Discover page and site overviews

### DIFF
--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -8,13 +8,73 @@ import {
 /* eslint-enable no-restricted-imports */
 import { isEnabled } from '@automattic/calypso-config';
 import boot from '../app/boot';
+import { setWorkspace } from '../app/workspace';
+import {
+	getMockSitesForPersona,
+	seedMockBloggerSiteCaches,
+} from '../sites/overview-blogger/mock-sites';
 import Logo from './logo';
 import type {
 	FetchSitesOptions,
 	FetchPaginatedSitesOptions,
 	FetchDashboardSiteFiltersParams,
+	FetchPaginatedSitesResponse,
+	Site,
 } from '@automattic/api-core';
 import './style.scss';
+
+seedMockBloggerSiteCaches();
+
+// Demo personas: `?persona=blogger` shows a single photography site in the
+// Essential workspace; `?persona=developer` restores the multi-site setup in
+// the Advanced workspace. The choice persists until the other link is opened.
+const PERSONA_STORAGE_KEY = 'dashboard-demo-persona';
+
+function resolvePersona(): 'developer' | 'blogger' {
+	if ( typeof window === 'undefined' ) {
+		return 'developer';
+	}
+	const requested = new URLSearchParams( window.location.search ).get( 'persona' );
+	if ( requested === 'blogger' || requested === 'developer' ) {
+		window.localStorage.setItem( PERSONA_STORAGE_KEY, requested );
+		setWorkspace( requested === 'blogger' ? 'essential' : 'advanced' );
+	}
+	return window.localStorage.getItem( PERSONA_STORAGE_KEY ) === 'blogger' ? 'blogger' : 'developer';
+}
+
+const persona = resolvePersona();
+const mockSites = getMockSitesForPersona( persona );
+
+const sitesQueryWithMocks = ( fetchSiteOptions?: FetchSitesOptions ) => {
+	const query = sitesQuery( 'all', fetchSiteOptions );
+	const baseQueryFn = query.queryFn as () => Promise< Site[] >;
+	return {
+		...query,
+		queryFn:
+			persona === 'blogger'
+				? async () => mockSites
+				: async () => [ ...mockSites, ...( await baseQueryFn() ) ],
+	};
+};
+
+const paginatedSitesQueryWithMocks = ( fetchSiteOptions?: FetchPaginatedSitesOptions ) => {
+	const query = paginatedSitesQuery( 'all', fetchSiteOptions );
+	const baseQueryFn = query.queryFn as () => Promise< FetchPaginatedSitesResponse >;
+	return {
+		...query,
+		queryFn: async () => {
+			const response = await baseQueryFn();
+			if ( persona === 'blogger' ) {
+				return { ...response, sites: mockSites, total: mockSites.length };
+			}
+			return {
+				...response,
+				sites: [ ...mockSites, ...response.sites ],
+				total: response.total + mockSites.length,
+			};
+		},
+	};
+};
 
 boot( {
 	name: 'WordPress.com',
@@ -55,9 +115,8 @@ boot( {
 		siteSwitcher: () => import( '../sites/site-switcher' ),
 	},
 	queries: {
-		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => sitesQuery( 'all', fetchSiteOptions ),
-		paginatedSitesQuery: ( fetchSiteOptions?: FetchPaginatedSitesOptions ) =>
-			paginatedSitesQuery( 'all', fetchSiteOptions ),
+		sitesQuery: sitesQueryWithMocks,
+		paginatedSitesQuery: paginatedSitesQueryWithMocks,
 		dashboardSiteFiltersQuery: ( fields: FetchDashboardSiteFiltersParams[ 'fields' ] ) =>
 			dashboardSiteFiltersQuery( 'all', fields ),
 		domainsQuery: () => domainsQuery(),

--- a/client/dashboard/app-dotcom/section.ts
+++ b/client/dashboard/app-dotcom/section.ts
@@ -22,6 +22,7 @@ export const DOTCOM_DASHBOARD_SECTION_DEFINITION = {
 
 export const DOTCOM_DASHBOARD_SECTION_PATHS = [
 	'/',
+	'/discover',
 	'/sites',
 	'/domains',
 	'/emails',

--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -22,6 +22,7 @@ import { omnibarEvents, useOmnibarEvent } from '../omnibar/events';
 import { getUserLanguage } from '../shared-locale-loader';
 import { OmnibarLaunchButton } from './omnibar-launch-button';
 import { createOmnibarStore } from './omnibar-store';
+import { OmnibarWorkspaceItem } from './omnibar-workspace-item';
 import type { User, Site } from '@automattic/api-core';
 
 const LocalizedMasterbarLoggedIn = localize( MasterbarLoggedIn );
@@ -186,6 +187,9 @@ export function InterimOmnibar( {
 					isMigrationInProgress={ false }
 					migrationStatus={ null }
 					adminMenu={ null }
+					additionalProfileMenuItems={ [
+						{ label: <OmnibarWorkspaceItem />, className: 'masterbar__workspace' },
+					] }
 					// Actions
 					setNextLayoutFocus={ noop }
 					activateNextLayoutFocus={ () => onToggleMenu?.() }

--- a/client/dashboard/app/interim-omnibar/omnibar-workspace-item.tsx
+++ b/client/dashboard/app/interim-omnibar/omnibar-workspace-item.tsx
@@ -1,0 +1,69 @@
+import { __ } from '@wordpress/i18n';
+import { check, chevronRightSmall, Icon } from '@wordpress/icons';
+import { setWorkspace, useWorkspace } from '../workspace';
+import type { Workspace } from '../workspace';
+
+interface WorkspaceOption {
+	value: Workspace;
+	label: string;
+	description: string;
+}
+
+/**
+ * "Workspace" entry for the Howdy menu, with a wp-admin style nested flyout
+ * to switch between the Essential and Advanced dashboard workspaces.
+ */
+export function OmnibarWorkspaceItem() {
+	const workspace = useWorkspace();
+	const options: WorkspaceOption[] = [
+		{
+			value: 'essential',
+			label: __( 'Essential' ),
+			description: __( 'For bloggers and creators' ),
+		},
+		{
+			value: 'advanced',
+			label: __( 'Advanced' ),
+			description: __( 'For developers and agencies' ),
+		},
+		{
+			value: 'commerce',
+			label: __( 'Commerce' ),
+			description: __( 'For e-commerce stores and Woo' ),
+		},
+	];
+	const current = options.find( ( option ) => option.value === workspace );
+
+	return (
+		<div className="omnibar-workspace">
+			<div className="omnibar-workspace__row">
+				<span>{ __( 'Workspace' ) }</span>
+				<span className="omnibar-workspace__current">
+					{ current?.label }
+					<Icon icon={ chevronRightSmall } size={ 18 } />
+				</span>
+			</div>
+			<ul className="omnibar-workspace__submenu">
+				{ options.map( ( option ) => (
+					<li key={ option.value }>
+						<button
+							type="button"
+							aria-current={ workspace === option.value ? 'true' : undefined }
+							onClick={ () => setWorkspace( option.value ) }
+						>
+							<span className="omnibar-workspace__option-check">
+								{ workspace === option.value && <Icon icon={ check } size={ 18 } /> }
+							</span>
+							<span className="omnibar-workspace__option-text">
+								<span className="omnibar-workspace__option-label">{ option.label }</span>
+								<span className="omnibar-workspace__option-description">
+									{ option.description }
+								</span>
+							</span>
+						</button>
+					</li>
+				) ) }
+			</ul>
+		</div>
+	);
+}

--- a/client/dashboard/app/interim-omnibar/style.scss
+++ b/client/dashboard/app/interim-omnibar/style.scss
@@ -85,3 +85,113 @@ body:has(#wpcom-omnibar) #wpcom {
 	--color-masterbar-submenu-group-background: #704000;
 	--color-global-masterbar-site-info-background: #704000;
 }
+
+// The masterbar indents the Howdy menu's Log Out row (left: 85px) to tuck it
+// under the account details beside the gravatar. With the Workspace row
+// inserted above it, that indent reads as misalignment — flush it to the start.
+#wpcom-omnibar .masterbar__item-subitems-item.logout-link {
+	top: 0;
+	// Physical on purpose: it overrides the masterbar's physical `left: 85px`,
+	// and both go through the same rtlcss flip for RTL builds.
+	// stylelint-disable-next-line property-disallowed-list
+	left: 0;
+	margin-bottom: 0;
+}
+
+// "Workspace" entry in the Howdy menu, with a wp-admin style nested flyout.
+// The flyout opens to the left because the Howdy menu hugs the screen edge.
+#wpcom-omnibar .masterbar__item-subitems-item.masterbar__workspace {
+	position: relative;
+
+	// Same hover treatment as the menu's links (e.g. Log Out): highlight the text.
+	&:hover .omnibar-workspace__row,
+	&:focus-within .omnibar-workspace__row {
+		color: var(--color-masterbar-submenu-hover-text, var(--color-masterbar-highlight));
+	}
+
+	.omnibar-workspace__row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 16px;
+		padding: 0 6px;
+		color: var(--color-masterbar-submenu-text, var(--color-masterbar-text));
+		cursor: default;
+	}
+
+	.omnibar-workspace__current {
+		display: inline-flex;
+		align-items: center;
+		opacity: 0.7;
+
+		svg {
+			fill: currentColor;
+		}
+	}
+
+	.omnibar-workspace__submenu {
+		display: none;
+		position: absolute;
+		inset-block-start: -6px;
+		inset-inline-end: 100%;
+		margin: 0;
+		padding: 6px 0;
+		min-width: 220px;
+		list-style: none;
+		background: var(--color-global-masterbar-submenu-background, var(--color-masterbar-item-hover-background));
+		box-shadow: 0 3px 5px rgba(0, 0, 0, 0.2);
+
+		li {
+			margin: 0;
+		}
+
+		button {
+			display: flex;
+			align-items: flex-start;
+			gap: 4px;
+			width: 100%;
+			padding: 6px 12px 6px 6px;
+			border: none;
+			background: none;
+			text-align: start;
+			cursor: pointer;
+			color: var(--color-masterbar-submenu-text, var(--color-masterbar-text));
+
+			&:hover,
+			&:focus-visible {
+				background: var(--color-global-masterbar-submenu-hover-background, var(--color-masterbar-item-hover-background));
+				color: var(--color-masterbar-submenu-hover-text, var(--color-masterbar-highlight));
+			}
+
+			&[aria-current='true'] .omnibar-workspace__option-label {
+				font-weight: 600;
+				color: var(--color-masterbar-highlight);
+			}
+		}
+	}
+
+	&:hover .omnibar-workspace__submenu,
+	&:focus-within .omnibar-workspace__submenu {
+		display: block;
+	}
+
+	.omnibar-workspace__option-check {
+		flex: 0 0 18px;
+		block-size: 18px;
+
+		svg {
+			fill: var(--color-masterbar-highlight);
+		}
+	}
+
+	.omnibar-workspace__option-text {
+		display: flex;
+		flex-direction: column;
+		line-height: 1.5;
+	}
+
+	.omnibar-workspace__option-description {
+		font-size: 11px;
+		opacity: 0.7;
+	}
+}

--- a/client/dashboard/app/responsive-sidebar/sidebar.tsx
+++ b/client/dashboard/app/responsive-sidebar/sidebar.tsx
@@ -1,6 +1,6 @@
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { brush, envelope, globe, layout, plugins } from '@wordpress/icons';
+import { brush, envelope, globe, layout, navigation, plugins } from '@wordpress/icons';
 import { useRef } from 'react';
 import AgencySiteSidebar from '../../agency/sites/site-sidebar';
 import RouterLinkButton from '../../components/router-link-button';
@@ -69,6 +69,9 @@ function PrimaryMenuSidebar() {
 		<SidebarMenu>
 			{ supports.agency && <AgencySidebar /> }
 			{ supports.agencyClient && <AgencyClientSidebar /> }
+			<SidebarMenuItem icon={ navigation } to="/discover">
+				{ __( 'Discover' ) }
+			</SidebarMenuItem>
 			{ supports.sites && (
 				<SidebarMenuItem icon={ layout } to="/sites">
 					{ __( 'Sites' ) }

--- a/client/dashboard/app/router/discover.ts
+++ b/client/dashboard/app/router/discover.ts
@@ -1,0 +1,25 @@
+import { createRoute, createLazyRoute } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
+import { rootRoute } from './root';
+
+export const discoverRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Discover' ),
+			},
+		],
+	} ),
+	getParentRoute: () => rootRoute,
+	path: 'discover',
+} ).lazy( () =>
+	import( '../../discover' ).then( ( d ) =>
+		createLazyRoute( 'discover' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const createDiscoverRoutes = () => {
+	return [ discoverRoute ];
+};

--- a/client/dashboard/app/router/index.tsx
+++ b/client/dashboard/app/router/index.tsx
@@ -6,6 +6,7 @@ import { handleOnCatch } from '../logger';
 import { startPerformanceTracking } from '../performance-tracking';
 import { createAgencyRoutes } from './agency';
 import { createAgencyClientRoutes } from './agency-client';
+import { createDiscoverRoutes } from './discover';
 import { createDomainsRoutes } from './domains';
 import { createEmailsRoutes } from './emails';
 import { createMeRoutes } from './me';
@@ -50,6 +51,8 @@ const createRouteTree = ( config: AppConfig ) => {
 	const children = [];
 
 	children.push( indexRoute );
+
+	children.push( ...createDiscoverRoutes() );
 
 	if ( config.supports.agency ) {
 		children.push( ...createAgencyRoutes() );

--- a/client/dashboard/app/workspace/index.ts
+++ b/client/dashboard/app/workspace/index.ts
@@ -1,0 +1,32 @@
+import { useSyncExternalStore } from 'react';
+
+export type Workspace = 'essential' | 'advanced' | 'commerce';
+
+const WORKSPACES: Workspace[] = [ 'essential', 'advanced', 'commerce' ];
+
+const STORAGE_KEY = 'dashboard-workspace';
+const listeners = new Set< () => void >();
+
+function subscribe( listener: () => void ) {
+	listeners.add( listener );
+	return () => {
+		listeners.delete( listener );
+	};
+}
+
+export function getWorkspace(): Workspace {
+	if ( typeof window === 'undefined' ) {
+		return 'essential';
+	}
+	const stored = window.localStorage.getItem( STORAGE_KEY ) as Workspace | null;
+	return stored && WORKSPACES.includes( stored ) ? stored : 'essential';
+}
+
+export function setWorkspace( workspace: Workspace ) {
+	window.localStorage.setItem( STORAGE_KEY, workspace );
+	listeners.forEach( ( listener ) => listener() );
+}
+
+export function useWorkspace(): Workspace {
+	return useSyncExternalStore( subscribe, getWorkspace, () => 'essential' );
+}

--- a/client/dashboard/components/overview-card/index.tsx
+++ b/client/dashboard/components/overview-card/index.tsx
@@ -50,7 +50,7 @@ export interface OverviewCardProps {
 	upsellFeatureId?: string;
 
 	bottom?: ReactNode;
-	onClick?: () => void;
+	onClick?: ( event?: React.MouseEvent ) => void;
 }
 
 export default function OverviewCard( {
@@ -184,8 +184,8 @@ export default function OverviewCard( {
 		</HStack>
 	);
 
-	const handleClick = () => {
-		onClick?.();
+	const handleClick = ( event?: React.MouseEvent ) => {
+		onClick?.( event );
 
 		if ( tracksId ) {
 			if ( intent === 'upsell' ) {

--- a/client/dashboard/discover/developer.tsx
+++ b/client/dashboard/discover/developer.tsx
@@ -1,0 +1,484 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { Badge } from '@automattic/ui';
+import {
+	Button,
+	__experimentalHeading as Heading,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import PageLayout from '../components/page-layout';
+import { Text } from '../components/text';
+import { wpcomLink } from '../utils/link';
+import { HelpStrip, SectionTitle, useDiscoverTracks, VideoTutorials } from './shared';
+import type { HelpLink, VideoTutorial } from './shared';
+
+interface DevAiPath {
+	slug: string;
+	name: string;
+	badge?: string;
+	hint: string;
+	description: string;
+	cta: { label: string; href: string };
+}
+
+interface DevPipelineStep {
+	title: string;
+	description: string;
+}
+
+type DevAiVersion = 'cards' | 'list';
+
+const DEV_AI_VERSIONS: DevAiVersion[] = [ 'cards', 'list' ];
+
+const DEV_AI_VERSION_STORAGE_KEY = 'discover-dev-ai-version';
+
+const getDevAiPaths = (): DevAiPath[] => [
+	{
+		slug: 'studio_code',
+		name: 'Studio Code',
+		badge: __( 'Beta' ),
+		hint: '$ studio code',
+		description: __(
+			'An AI agent that knows WordPress, not just code. Describe what you want in the terminal and it builds the block theme, content, and plugins — checking its own work with a screenshot loop.'
+		),
+		cta: {
+			label: __( 'Meet Studio Code' ),
+			href: 'https://developer.wordpress.com/docs/developer-tools/studio/studio-code/',
+		},
+	},
+	{
+		slug: 'mcp',
+		name: __( 'MCP Server' ),
+		badge: __( 'All paid plans' ),
+		hint: 'claude · cursor · vs code · codex',
+		description: __(
+			'Bring the agent you already use. Connect it to your live site with 80+ abilities — design-aware, scoped per site, and every write needs your explicit confirmation.'
+		),
+		cta: { label: __( 'Connect an agent' ), href: wpcomLink( '/me/mcp' ) },
+	},
+	{
+		slug: 'telex',
+		name: 'Telex',
+		badge: __( 'Experimental' ),
+		hint: 'prompt → installable .zip',
+		description: __(
+			'Turn plain-English descriptions into production-ready blocks and themes. No React, no PHP, no build tools — it runs entirely in your browser.'
+		),
+		cta: { label: __( 'Try Telex' ), href: 'https://telex.automattic.ai' },
+	},
+	{
+		slug: 'studio_assistant',
+		name: 'Studio Assistant',
+		badge: __( 'In Studio' ),
+		hint: 'chat · wp-cli · in the app',
+		description: __(
+			'AI chat built into the Studio desktop app. Ask questions and it runs WP-CLI for you — help without leaving your local site.'
+		),
+		cta: { label: __( 'Explore Studio' ), href: 'https://developer.wordpress.com/studio/' },
+	},
+];
+
+// Curated from the latest uploads on youtube.com/@wordpressdotcom, developer
+// and agency topics only. Titles are the actual YouTube video titles, so they
+// stay untranslated.
+const DEV_VIDEOS: VideoTutorial[] = [
+	{ id: '5B-5Z3A8YA8', title: 'My New Favourite Way to Vibe Code WordPress' },
+	{
+		id: '0NCfK6M33kY',
+		title:
+			'Media Editor Modal, React 19, Client-Side Media & PHP 8.5: WordPress for Developers — June 2026',
+	},
+	{ id: 'KDLqEd_QAD8', title: 'Connect Claude to your WordPress.com site' },
+	{ id: 'GRJYGLTpQLQ', title: 'WordPress Studio + MCP: A Better AI Workflow' },
+	{ id: 'Jywvzfo_w8c', title: 'You can now Vibe Code with WordPress.com' },
+];
+
+const getDevPipelineSteps = (): DevPipelineStep[] => [
+	{
+		title: __( 'Build locally' ),
+		description: __(
+			'Studio spins up WordPress in seconds — no Docker, no MySQL. Switch WordPress and PHP versions to catch compatibility issues early.'
+		),
+	},
+	{
+		title: __( 'Share a preview' ),
+		description: __(
+			'Cloud-hosted preview sites your clients can open anytime — even while your laptop sleeps.'
+		),
+	},
+	{
+		title: __( 'Push to deploy' ),
+		description: __(
+			'Connect a GitHub repo and every push ships automatically to staging or production. No FTP, no manual uploads.'
+		),
+	},
+	{
+		title: __( 'Test, then ship' ),
+		description: __(
+			'Clone production with one click, verify the risky changes on staging, and sync back when everything is green.'
+		),
+	},
+];
+
+const getDeveloperHelpLinks = (): HelpLink[] => [
+	{ label: __( 'Developer docs' ), href: 'https://developer.wordpress.com/docs/' },
+	{
+		label: __( 'MCP tools reference' ),
+		href: 'https://developer.wordpress.com/docs/mcp/tools-reference/',
+	},
+	{ label: __( 'Developer Blog' ), href: 'https://developer.wordpress.com/blog/' },
+	{ label: __( 'Contact us' ), href: wpcomLink( '/help' ) },
+];
+
+function DevHero() {
+	const trackClick = useDiscoverTracks( 'developers' );
+
+	return (
+		<section className="discover-dev-hero">
+			<div className="discover-dev-hero-inner">
+				<VStack spacing={ 5 } alignment="flex-start" className="discover-dev-hero-copy">
+					<Text className="discover-hero-eyebrow" as="p">
+						{ __( 'For developers & agencies' ) }
+					</Text>
+					<Heading level={ 1 } className="discover-hero-title">
+						{ __( 'Your workflow, your tools' ) }
+					</Heading>
+					<Text className="discover-hero-subtitle" as="p">
+						{ __(
+							'Real WordPress with developer control — SSH, WP-CLI, Git deployments, and staging. You build and ship; we handle speed, security, updates, and backups.'
+						) }
+					</Text>
+					<HStack spacing={ 3 } justify="flex-start" expanded={ false } wrap>
+						<Button
+							variant="primary"
+							href="https://developer.wordpress.com/studio/"
+							target="_blank"
+							rel="noopener noreferrer"
+							__next40pxDefaultSize
+							onClick={ () => trackClick( 'hero_primary' ) }
+						>
+							{ __( 'Download Studio — free' ) }
+						</Button>
+						<Button
+							variant="secondary"
+							className="discover-dev-hero-secondary"
+							href="https://developer.wordpress.com/docs/"
+							target="_blank"
+							rel="noopener noreferrer"
+							__next40pxDefaultSize
+							onClick={ () => trackClick( 'hero_secondary' ) }
+						>
+							{ __( 'Read the docs' ) }
+						</Button>
+					</HStack>
+					<Text className="discover-hero-footnote" as="p">
+						{ __(
+							'Studio is free and open source. WordPress powers over 40% of the web — you power WordPress.'
+						) }
+					</Text>
+				</VStack>
+				<div className="discover-dev-terminal" aria-hidden="true">
+					<div className="discover-dev-terminal-bar">
+						<span />
+						<span />
+						<span />
+						<code>studio — zsh</code>
+					</div>
+					<pre>
+						<span className="is-cmd">~/clients $ studio create acme-relaunch</span>
+						<span className="is-ok">✔ Local WordPress ready in 3s — no Docker, no MySQL</span>
+						<span className="is-cmd">~/clients/acme-relaunch $ studio code</span>
+						<span className="is-agent">agent · What are we building today?</span>
+						<span className="is-cmd">
+							&gt; Rebuild acme.com as a block theme, then push it to staging
+							<span className="discover-dev-caret" />
+						</span>
+					</pre>
+				</div>
+			</div>
+		</section>
+	);
+}
+
+// Decorative CSS-only product mocks for the AI cards; content is illustrative,
+// so it stays untranslated and hidden from assistive tech.
+function DevAiVisual( { slug }: { slug: string } ) {
+	switch ( slug ) {
+		case 'studio_code':
+			return (
+				<div className="discover-dev-visual-terminal">
+					<span className="is-cmd">$ studio code</span>
+					<span className="is-ok">✔ Block theme scaffolded</span>
+					<span className="is-ok">✔ Screenshot check passed</span>
+					<span className="is-cmd">
+						&gt; Add a pricing page
+						<span className="discover-dev-caret" />
+					</span>
+				</div>
+			);
+		case 'mcp':
+			return (
+				<div className="discover-dev-visual-abilities">
+					{ [ 'posts.create', 'media.upload', 'themes.design_tokens', 'stats.read' ].map(
+						( ability ) => (
+							<span key={ ability }>
+								<i />
+								{ ability }
+							</span>
+						)
+					) }
+				</div>
+			);
+		case 'telex':
+			return (
+				<div className="discover-dev-visual-telex">
+					<span className="discover-dev-visual-prompt">“A pricing table with three tiers”</span>
+					<span className="discover-dev-visual-arrow">↓</span>
+					<span className="discover-dev-visual-block">
+						<i />
+						<i />
+						<i />
+					</span>
+				</div>
+			);
+		case 'studio_assistant':
+			return (
+				<div className="discover-dev-visual-chat">
+					<span className="is-user">Why is my homepage slow?</span>
+					<span className="is-bot">Let me profile it for you…</span>
+					<span className="is-bot is-code">$ wp profile stage --fields=stage,time</span>
+				</div>
+			);
+		default:
+			return null;
+	}
+}
+
+function DevAiPaths() {
+	const trackClick = useDiscoverTracks( 'developers' );
+	const [ version, setVersion ] = useState< DevAiVersion >( () => {
+		if ( typeof window === 'undefined' ) {
+			return 'cards';
+		}
+		const stored = window.localStorage.getItem( DEV_AI_VERSION_STORAGE_KEY ) as DevAiVersion;
+		return DEV_AI_VERSIONS.includes( stored ) ? stored : 'cards';
+	} );
+
+	const switchVersion = ( next: DevAiVersion ) => {
+		setVersion( next );
+		window.localStorage.setItem( DEV_AI_VERSION_STORAGE_KEY, next );
+	};
+
+	return (
+		<VStack spacing={ 4 }>
+			<SectionTitle
+				title={ __( 'Build with AI, your way' ) }
+				action={
+					<div className="discover-mini-switch">
+						{ DEV_AI_VERSIONS.map( ( value, index ) => (
+							<button
+								key={ value }
+								type="button"
+								aria-pressed={ version === value }
+								onClick={ () => switchVersion( value ) }
+							>
+								{ `V${ index + 1 }` }
+							</button>
+						) ) }
+					</div>
+				}
+			/>
+			<Text as="p" className="discover-section-subheading">
+				{ __(
+					'General coding agents know code — these know WordPress. Pick the path that fits your workflow, or mix them.'
+				) }
+			</Text>
+			{ version === 'cards' ? (
+				<div className="discover-dev-ai-grid">
+					{ getDevAiPaths().map( ( path ) => (
+						<div key={ path.slug } className="discover-dev-ai-card">
+							<div className="discover-dev-ai-card-content">
+								<HStack spacing={ 2 } justify="flex-start" alignment="center" expanded={ false }>
+									<Heading level={ 3 } className="discover-dev-ai-card-title">
+										{ path.name }
+									</Heading>
+									{ path.badge && <Badge>{ path.badge }</Badge> }
+								</HStack>
+								<Text as="p" className="discover-dev-ai-card-description">
+									{ path.description }
+								</Text>
+								<code className="discover-dev-ledger-hint">{ path.hint }</code>
+								<div className="discover-dev-ai-card-action">
+									<Button
+										variant="secondary"
+										href={ path.cta.href }
+										target="_blank"
+										rel="noopener noreferrer"
+										__next40pxDefaultSize
+										onClick={ () => trackClick( `ai_${ path.slug }` ) }
+									>
+										{ path.cta.label }
+									</Button>
+								</div>
+							</div>
+							<div className="discover-dev-ai-card-visual" aria-hidden="true">
+								<DevAiVisual slug={ path.slug } />
+							</div>
+						</div>
+					) ) }
+				</div>
+			) : (
+				<div className="discover-dev-ledger">
+					{ getDevAiPaths().map( ( path ) => (
+						<div key={ path.slug } className="discover-dev-ledger-row">
+							<div className="discover-dev-ledger-body">
+								<HStack spacing={ 2 } justify="flex-start" alignment="center" expanded={ false }>
+									<Heading level={ 3 } className="discover-dev-ledger-title">
+										{ path.name }
+									</Heading>
+									{ path.badge && <Badge>{ path.badge }</Badge> }
+								</HStack>
+								<Text as="p" className="discover-dev-ledger-description">
+									{ path.description }
+								</Text>
+								<code className="discover-dev-ledger-hint">{ path.hint }</code>
+							</div>
+							<div className="discover-dev-ledger-aside">
+								<Button
+									variant="secondary"
+									href={ path.cta.href }
+									target="_blank"
+									rel="noopener noreferrer"
+									__next40pxDefaultSize
+									onClick={ () => trackClick( `ai_${ path.slug }` ) }
+								>
+									{ path.cta.label }
+								</Button>
+							</div>
+						</div>
+					) ) }
+				</div>
+			) }
+		</VStack>
+	);
+}
+
+function DevPipeline() {
+	const trackClick = useDiscoverTracks( 'developers' );
+
+	return (
+		<VStack spacing={ 4 }>
+			<SectionTitle
+				title={ __( 'From local to live' ) }
+				action={
+					<Button
+						variant="link"
+						href={ localizeUrl( 'https://wordpress.com/support/github-deployments/' ) }
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={ () => trackClick( 'pipeline_docs' ) }
+					>
+						{ __( 'How deployments work' ) }
+					</Button>
+				}
+			/>
+			<ol className="discover-dev-pipeline">
+				{ getDevPipelineSteps().map( ( step, index ) => (
+					<li key={ step.title }>
+						<span className="discover-dev-pipeline-marker">{ index + 1 }</span>
+						<Heading level={ 3 } className="discover-dev-pipeline-title">
+							{ step.title }
+						</Heading>
+						<Text as="p" className="discover-dev-pipeline-description">
+							{ step.description }
+						</Text>
+					</li>
+				) ) }
+			</ol>
+		</VStack>
+	);
+}
+
+function DevAgencyDuo() {
+	const trackClick = useDiscoverTracks( 'developers' );
+
+	return (
+		<VStack spacing={ 4 }>
+			<SectionTitle title={ __( 'Run client sites at scale' ) } />
+			<div className="discover-dev-duo">
+				<div className="discover-dev-duo-card is-dark">
+					<Text className="discover-dev-duo-eyebrow" as="p">
+						{ __( 'Automattic for Agencies · Free to join' ) }
+					</Text>
+					<Heading level={ 3 } className="discover-dev-duo-title">
+						{ __( 'Every client site, one command center' ) }
+					</Heading>
+					<Text as="p" className="discover-dev-duo-description">
+						{ __(
+							'Site management, updates, backups, and billing in one dashboard — with wholesale pricing, referral revenue, and five free development licenses to build on.'
+						) }
+					</Text>
+					<div className="discover-dev-duo-action">
+						<Button
+							variant="secondary"
+							className="discover-dev-duo-cta"
+							href="https://automattic.com/for-agencies/"
+							target="_blank"
+							rel="noopener noreferrer"
+							__next40pxDefaultSize
+							onClick={ () => trackClick( 'agency_a4a' ) }
+						>
+							{ __( 'Join for free' ) }
+						</Button>
+					</div>
+				</div>
+				<div className="discover-dev-duo-card">
+					<Text className="discover-dev-duo-eyebrow" as="p">
+						{ __( 'The new Hosting Dashboard' ) }
+					</Text>
+					<Heading level={ 3 } className="discover-dev-duo-title">
+						{ __( 'One dashboard. Every site. One click away.' ) }
+					</Heading>
+					<Text as="p" className="discover-dev-duo-description">
+						{ __(
+							'Persistent, wp-admin-aligned navigation whether you run 2 sites or 200. Check plugin updates across every site in one view, and switch without losing your place. You’re in it right now.'
+						) }
+					</Text>
+					<div className="discover-dev-duo-action">
+						<Button
+							variant="secondary"
+							href="/sites"
+							__next40pxDefaultSize
+							onClick={ () => trackClick( 'agency_dashboard' ) }
+						>
+							{ __( 'Explore your sites' ) }
+						</Button>
+					</div>
+				</div>
+			</div>
+		</VStack>
+	);
+}
+
+export default function DeveloperDiscover() {
+	return (
+		<>
+			<DevHero />
+			<PageLayout>
+				<VStack spacing={ 14 }>
+					<DevAiPaths />
+					<VideoTutorials
+						videos={ DEV_VIDEOS }
+						audience="developers"
+						title={ __( 'Watch what WordPress can do for developers' ) }
+					/>
+					<DevPipeline />
+					<DevAgencyDuo />
+					<HelpStrip links={ getDeveloperHelpLinks() } audience="developers" />
+				</VStack>
+			</PageLayout>
+		</>
+	);
+}

--- a/client/dashboard/discover/index.tsx
+++ b/client/dashboard/discover/index.tsx
@@ -1,0 +1,745 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import {
+	Button,
+	__experimentalHeading as Heading,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Icon,
+} from '@wordpress/components';
+import { useReducedMotion } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import {
+	arrowUp,
+	chartBar,
+	currencyDollar,
+	desktop,
+	envelope,
+	megaphone,
+	people,
+} from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useHelpCenter } from '../app/help-center';
+import { useWorkspace } from '../app/workspace';
+import PageLayout from '../components/page-layout';
+import { Text } from '../components/text';
+import { wpcomLink } from '../utils/link';
+import DeveloperDiscover from './developer';
+import {
+	HelpStrip,
+	NewsAndCommunity,
+	SectionTitle,
+	useDiscoverTracks,
+	VideoTutorials,
+} from './shared';
+import type {
+	CommunityContent,
+	DiscoverAudience,
+	HelpLink,
+	NewsItem,
+	VideoTutorial,
+} from './shared';
+
+import './style.scss';
+
+interface HeroContent {
+	eyebrow: string;
+	title: string;
+	subtitle: string;
+	primaryCta: { label: string; href: string };
+	secondaryCta: { label: string; href: string };
+	footnote: string;
+}
+
+interface ShowcaseTheme {
+	slug: string;
+	name: string;
+}
+
+interface Blueprint {
+	slug: string;
+	name: string;
+	// Pub theme whose screenshot illustrates the blueprint.
+	theme: string;
+}
+
+type ShowcaseVersion = 'themes' | 'blueprints';
+
+const SHOWCASE_VERSIONS: ShowcaseVersion[] = [ 'themes', 'blueprints' ];
+
+const SHOWCASE_VERSION_STORAGE_KEY = 'discover-showcase-version';
+
+interface Panel {
+	icon: React.JSX.Element;
+	title: string;
+	description: string;
+	cta: { label: string; href: string };
+	wide?: boolean;
+	terminal?: string[];
+}
+
+type CreatorHeroVersion = 'help' | 'ai' | 'original';
+
+const CREATOR_HERO_VERSIONS: CreatorHeroVersion[] = [ 'help', 'ai', 'original' ];
+
+const HERO_VERSION_STORAGE_KEY = 'discover-hero-version';
+
+const getCreatorHero = (): HeroContent => ( {
+	eyebrow: __( 'Made for creators' ),
+	title: __( 'Create something worth reading' ),
+	subtitle: __(
+		'Ideas, tools, and inspiration to take your site further — gathered in one place, updated all the time.'
+	),
+	primaryCta: { label: __( 'Write a post' ), href: wpcomLink( '/post' ) },
+	secondaryCta: { label: __( 'Build with AI' ), href: 'https://wordpress.com/ai-website-builder/' },
+	footnote: __(
+		'Millions of creators publish on WordPress.com every day. You’re in good company.'
+	),
+} );
+
+const getHelpHeroChips = (): string[] => [
+	__( 'Connect a domain' ),
+	__( 'Upgrade my plan' ),
+	__( 'Grow my traffic' ),
+	__( 'Reset my password' ),
+];
+
+// Rotating placeholder suggestions for the ask field. Creator-focused and
+// deliberately distinct from the chips rendered below it.
+const getHelpHeroPrompts = (): string[] => [
+	__( 'How do I get my first 100 subscribers?' ),
+	__( 'Help me write a better About page' ),
+	__( 'How can I earn money from my blog?' ),
+	__( 'How do I start a paid newsletter?' ),
+	__( 'Why isn’t my site showing on Google?' ),
+	__( 'What should I blog about this week?' ),
+];
+
+const getAiHeroChips = (): string[] => [
+	__( 'Start a travel blog' ),
+	__( 'Create a restaurant website' ),
+	__( 'Launch a coaching site' ),
+	__( 'Design a coffee shop site' ),
+];
+
+const CREATOR_THEMES: ShowcaseTheme[] = [
+	{ slug: 'bibliophile', name: 'Bibliophile' },
+	{ slug: 'lettre', name: 'Lettre' },
+	{ slug: 'dorna', name: 'Dorna' },
+	{ slug: 'stewart', name: 'Stewart' },
+	{ slug: 'course', name: 'Course' },
+	{ slug: 'skatepark', name: 'Skatepark' },
+];
+
+// Curated from youtube.com/@wordpressdotcom. Titles are the actual YouTube
+// video titles, so they stay untranslated.
+const CREATOR_VIDEOS: VideoTutorial[] = [
+	{ id: 'wm0jPV234zc', title: 'The New WordPress Editor Built for Writing' },
+	{ id: '9rCal5dxMiM', title: 'How to turn a rough draft into a finished blog post with AI' },
+	{ id: 'px-AH-ZoKmU', title: 'Turn Your Newsletter into a Paid Subscription on WordPress.com' },
+	{ id: '-rVv1bDHlRQ', title: 'How to Earn Ad Revenue with WordAds on WordPress.com' },
+	{ id: 'wHz4uiaBbOE', title: 'How to connect an existing domain to WordPress.com' },
+];
+
+const getCreatorBlueprints = (): Blueprint[] => [
+	{
+		slug: 'newsletter',
+		name: __( 'Newsletter' ),
+		theme: 'lettre',
+	},
+	{
+		slug: 'personal-blog',
+		name: __( 'Personal blog' ),
+		theme: 'stewart',
+	},
+	{
+		slug: 'portfolio',
+		name: __( 'Portfolio' ),
+		theme: 'dorna',
+	},
+	{
+		slug: 'author-site',
+		name: __( 'Author site' ),
+		theme: 'bibliophile',
+	},
+	{
+		slug: 'online-course',
+		name: __( 'Online course' ),
+		theme: 'course',
+	},
+	{
+		slug: 'community-hub',
+		name: __( 'Community hub' ),
+		theme: 'skatepark',
+	},
+];
+
+const getCreatorPanels = (): Panel[] => [
+	{
+		icon: megaphone,
+		title: __( 'Promote with Blaze' ),
+		description: __(
+			'Turn your best post into an ad that runs across millions of WordPress and Tumblr sites. No agency required.'
+		),
+		cta: { label: __( 'Start a campaign' ), href: wpcomLink( '/advertising' ) },
+	},
+	{
+		icon: envelope,
+		title: __( 'Send it as a newsletter' ),
+		description: __( 'Every post can land in your readers’ inboxes automatically.' ),
+		cta: { label: __( 'Set up newsletter' ), href: wpcomLink( '/setup/newsletter' ) },
+	},
+	{
+		icon: currencyDollar,
+		title: __( 'Get paid for your work' ),
+		description: __( 'Paid subscriptions, tips, and donations — built in, no plugins needed.' ),
+		cta: { label: __( 'Explore Earn' ), href: wpcomLink( '/earn' ) },
+	},
+	{
+		icon: desktop,
+		title: __( 'Meet your readers where they are' ),
+		description: __(
+			'Auto-share new posts to your social accounts and track what lands from your stats.'
+		),
+		cta: { label: __( 'Connect social accounts' ), href: wpcomLink( '/marketing/connections' ) },
+	},
+	{
+		icon: chartBar,
+		title: __( 'Know what’s working' ),
+		description: __(
+			'See which posts bring readers back, where they come from, and what to write next.'
+		),
+		cta: { label: __( 'Open Stats' ), href: wpcomLink( '/stats' ) },
+	},
+	{
+		icon: people,
+		title: __( 'Get discovered in the Reader' ),
+		description: __(
+			'Millions of people browse the WordPress.com Reader every day. Tag your posts and they can find you.'
+		),
+		cta: { label: __( 'Open the Reader' ), href: wpcomLink( '/reader' ) },
+	},
+];
+
+const getCreatorNews = (): NewsItem[] => [
+	{
+		title: __( 'The AI website builder now designs your whole site from one chat' ),
+		description: __( 'Describe what you want and watch pages, copy, and images come together.' ),
+		isNew: true,
+	},
+	{
+		title: __( 'New theme drop: six fresh looks for writers' ),
+		description: __( 'Editorial layouts with big type, built for long reads.' ),
+	},
+	{
+		title: __( 'Newsletter stats now show which subjects get opened' ),
+		description: __( 'Learn what makes your readers click, straight from your stats page.' ),
+	},
+];
+
+const getCreatorCommunity = (): CommunityContent => ( {
+	variant: 'blaze',
+	title: __( 'Share your site with the world' ),
+	description: __(
+		'Reach new readers and subscribers in minutes. Blaze puts your posts in front of millions across WordPress and Tumblr — set a budget, pick your audience, and watch it spread.'
+	),
+	cta: { label: __( 'Start advertising' ), href: wpcomLink( '/advertising' ) },
+} );
+
+const getCreatorHelpLinks = (): HelpLink[] => [
+	{ label: __( 'WordPress.com Learn' ), href: 'https://wordpress.com/learn/' },
+	{ label: __( 'Support guides' ), href: localizeUrl( 'https://wordpress.com/support/' ) },
+	{ label: __( 'Contact us' ), href: wpcomLink( '/help' ) },
+];
+
+function Hero( { content, audience }: { content: HeroContent; audience: DiscoverAudience } ) {
+	const trackClick = useDiscoverTracks( audience );
+
+	return (
+		<section className="discover-hero">
+			<VStack spacing={ 5 } alignment="center" className="discover-hero-inner">
+				<Text className="discover-hero-eyebrow" as="p">
+					{ content.eyebrow }
+				</Text>
+				<Heading level={ 1 } className="discover-hero-title">
+					{ content.title }
+				</Heading>
+				<Text className="discover-hero-subtitle" as="p">
+					{ content.subtitle }
+				</Text>
+				<HStack spacing={ 3 } justify="center" expanded={ false } wrap>
+					<Button
+						variant="primary"
+						href={ content.primaryCta.href }
+						__next40pxDefaultSize
+						onClick={ () => trackClick( 'hero_primary' ) }
+					>
+						{ content.primaryCta.label }
+					</Button>
+					<Button
+						variant="secondary"
+						className="discover-hero-secondary-cta"
+						href={ content.secondaryCta.href }
+						target="_blank"
+						rel="noopener noreferrer"
+						__next40pxDefaultSize
+						onClick={ () => trackClick( 'hero_secondary' ) }
+					>
+						{ content.secondaryCta.label }
+					</Button>
+				</HStack>
+				<Text className="discover-hero-footnote" as="p">
+					{ content.footnote }
+				</Text>
+			</VStack>
+		</section>
+	);
+}
+
+// Types each phrase into `display` character by character, holds it, erases
+// it, then moves on to the next — a "someone is typing" placeholder effect.
+function useTypingPlaceholder( phrases: string[], enabled: boolean ): string {
+	const [ display, setDisplay ] = useState( '' );
+
+	useEffect( () => {
+		if ( ! enabled || phrases.length === 0 ) {
+			return;
+		}
+
+		let phraseIndex = 0;
+		let length = 0;
+		// The caret stays solid while typing/erasing and blinks during pauses,
+		// mirroring how a real text caret behaves.
+		let phase: 'typing' | 'holding' | 'erasing' | 'resting' = 'typing';
+		let caretOn = true;
+		let blinksLeft = 0;
+		let timer: ReturnType< typeof setTimeout >;
+
+		const render = () => {
+			setDisplay( phrases[ phraseIndex ].slice( 0, length ) + ( caretOn ? '|' : '' ) );
+		};
+
+		const tick = () => {
+			const phrase = phrases[ phraseIndex ];
+			let delay;
+			if ( phase === 'typing' ) {
+				length++;
+				caretOn = true;
+				delay = 70;
+				if ( length === phrase.length ) {
+					phase = 'holding';
+					blinksLeft = 5;
+				}
+			} else if ( phase === 'holding' ) {
+				caretOn = ! caretOn;
+				blinksLeft--;
+				delay = 450;
+				if ( blinksLeft === 0 ) {
+					phase = 'erasing';
+					caretOn = true;
+				}
+			} else if ( phase === 'erasing' ) {
+				length--;
+				caretOn = true;
+				delay = 30;
+				if ( length === 0 ) {
+					phase = 'resting';
+					blinksLeft = 2;
+				}
+			} else {
+				caretOn = ! caretOn;
+				blinksLeft--;
+				delay = 400;
+				if ( blinksLeft === 0 ) {
+					phase = 'typing';
+					phraseIndex = ( phraseIndex + 1 ) % phrases.length;
+				}
+			}
+			render();
+			timer = setTimeout( tick, delay );
+		};
+
+		render();
+		timer = setTimeout( tick, 600 );
+		return () => clearTimeout( timer );
+	}, [ phrases, enabled ] );
+
+	return display;
+}
+
+function HelpHero( { audience }: { audience: DiscoverAudience } ) {
+	const trackClick = useDiscoverTracks( audience );
+	const { setOpenOdieWithContext } = useHelpCenter();
+	const [ question, setQuestion ] = useState( '' );
+	const [ isFocused, setIsFocused ] = useState( false );
+	const prefersReducedMotion = useReducedMotion();
+	const prompts = useMemo( getHelpHeroPrompts, [] );
+	const isAnimating = ! isFocused && question === '' && ! prefersReducedMotion;
+	const animatedPlaceholder = useTypingPlaceholder( prompts, isAnimating );
+
+	const ask = ( message: string, item: string ) => {
+		if ( ! message.trim() ) {
+			return;
+		}
+		trackClick( item );
+		setOpenOdieWithContext( { initialMessage: message.trim(), section: 'discover' } );
+	};
+
+	return (
+		<VStack spacing={ 5 } alignment="center" className="discover-hero-inner">
+			<Text className="discover-hero-eyebrow" as="p">
+				{ __( 'Made for creators' ) }
+			</Text>
+			<Heading level={ 1 } className="discover-hero-title">
+				{ __( 'Ask us anything' ) }
+			</Heading>
+			<form
+				className="discover-hero-ask"
+				onSubmit={ ( event ) => {
+					event.preventDefault();
+					ask( question, 'hero_help_ask' );
+				} }
+			>
+				<input
+					type="text"
+					value={ question }
+					aria-label={ __( 'How can we help you?' ) }
+					placeholder={ isAnimating ? animatedPlaceholder : __( 'How can we help you?' ) }
+					onChange={ ( event ) => setQuestion( event.target.value ) }
+					onFocus={ () => setIsFocused( true ) }
+					onBlur={ () => setIsFocused( false ) }
+				/>
+				<button type="submit" aria-label={ __( 'Ask' ) }>
+					<Icon icon={ arrowUp } size={ 20 } />
+				</button>
+			</form>
+			<HStack spacing={ 2 } justify="center" expanded={ false } wrap>
+				{ getHelpHeroChips().map( ( chip ) => (
+					<button
+						key={ chip }
+						type="button"
+						className="discover-hero-chip"
+						onClick={ () => ask( chip, 'hero_help_chip' ) }
+					>
+						{ chip }
+					</button>
+				) ) }
+			</HStack>
+		</VStack>
+	);
+}
+
+function AiHero( { audience }: { audience: DiscoverAudience } ) {
+	const trackClick = useDiscoverTracks( audience );
+	const [ prompt, setPrompt ] = useState( '' );
+	const textareaRef = useRef< HTMLTextAreaElement >( null );
+
+	const submit = () => {
+		if ( ! prompt.trim() ) {
+			return;
+		}
+		trackClick( 'hero_ai_submit' );
+		window.location.href = addQueryArgs( wpcomLink( '/setup/ai-site-builder' ), {
+			prompt: prompt.trim(),
+			source: 'discover-hero',
+		} );
+	};
+
+	return (
+		<VStack spacing={ 5 } alignment="center" className="discover-hero-inner">
+			<Text className="discover-hero-eyebrow" as="p">
+				{ __( 'AI Website Builder' ) }
+			</Text>
+			<Heading level={ 1 } className="discover-hero-title">
+				{ __( 'Make a website as unique as you.' ) }
+			</Heading>
+			<div className="discover-hero-prompt">
+				<textarea
+					ref={ textareaRef }
+					value={ prompt }
+					rows={ 3 }
+					placeholder={ __( 'Describe the site you want to create…' ) }
+					onChange={ ( event ) => setPrompt( event.target.value ) }
+					onKeyDown={ ( event ) => {
+						if ( event.key === 'Enter' && ! event.shiftKey ) {
+							event.preventDefault();
+							submit();
+						}
+					} }
+				/>
+				<button type="button" aria-label={ __( 'Create my site' ) } onClick={ submit }>
+					<Icon icon={ arrowUp } size={ 20 } />
+				</button>
+			</div>
+			<HStack spacing={ 2 } justify="center" expanded={ false } wrap>
+				{ getAiHeroChips().map( ( chip ) => (
+					<button
+						key={ chip }
+						type="button"
+						className="discover-hero-chip"
+						onClick={ () => {
+							setPrompt( chip );
+							textareaRef.current?.focus();
+						} }
+					>
+						{ chip }
+					</button>
+				) ) }
+			</HStack>
+			<Text className="discover-hero-footnote" as="p">
+				{ __( 'Start for free. No credit card required.' ) }
+			</Text>
+		</VStack>
+	);
+}
+
+function CreatorHero( { audience }: { audience: DiscoverAudience } ) {
+	const [ version, setVersion ] = useState< CreatorHeroVersion >( () => {
+		if ( typeof window === 'undefined' ) {
+			return 'help';
+		}
+		const stored = window.localStorage.getItem( HERO_VERSION_STORAGE_KEY ) as CreatorHeroVersion;
+		return CREATOR_HERO_VERSIONS.includes( stored ) ? stored : 'help';
+	} );
+
+	const switchVersion = ( next: CreatorHeroVersion ) => {
+		setVersion( next );
+		window.localStorage.setItem( HERO_VERSION_STORAGE_KEY, next );
+	};
+
+	return (
+		<div className="discover-hero-wrap">
+			{ version === 'original' ? (
+				<Hero content={ getCreatorHero() } audience={ audience } />
+			) : (
+				<section className="discover-hero">
+					{ version === 'help' ? (
+						<HelpHero audience={ audience } />
+					) : (
+						<AiHero audience={ audience } />
+					) }
+				</section>
+			) }
+			<div className="discover-hero-switcher">
+				{ CREATOR_HERO_VERSIONS.map( ( value, index ) => (
+					<button
+						key={ value }
+						type="button"
+						aria-pressed={ version === value }
+						onClick={ () => switchVersion( value ) }
+					>
+						{ `V${ index + 1 }` }
+					</button>
+				) ) }
+			</div>
+		</div>
+	);
+}
+
+function ThemeShowcase( { audience }: { audience: DiscoverAudience } ) {
+	const trackClick = useDiscoverTracks( audience );
+
+	return (
+		<VStack spacing={ 4 }>
+			<SectionTitle
+				title={ __( 'Set your site apart' ) }
+				action={
+					<Button
+						variant="link"
+						href={ wpcomLink( '/themes' ) }
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={ () => trackClick( 'themes_view_all' ) }
+					>
+						{ __( 'Explore all themes' ) }
+					</Button>
+				}
+			/>
+			<div className="discover-rail">
+				{ CREATOR_THEMES.map( ( theme ) => (
+					<a
+						key={ theme.slug }
+						className="discover-rail-card"
+						href={ wpcomLink( `/theme/${ theme.slug }` ) }
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={ () => trackClick( `theme_${ theme.slug }` ) }
+					>
+						<img
+							src={ `https://s0.wp.com/wp-content/themes/pub/${ theme.slug }/screenshot.png` }
+							alt={ theme.name }
+							loading="lazy"
+						/>
+						<span className="discover-rail-card-label">{ theme.name }</span>
+					</a>
+				) ) }
+			</div>
+		</VStack>
+	);
+}
+
+function BlueprintShowcase( { audience }: { audience: DiscoverAudience } ) {
+	const trackClick = useDiscoverTracks( audience );
+
+	return (
+		<VStack spacing={ 4 }>
+			<SectionTitle
+				title={ __( 'Start with a blueprint' ) }
+				action={
+					<Button
+						variant="link"
+						href="https://wordpress.com/blueprints/"
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={ () => trackClick( 'blueprints_view_all' ) }
+					>
+						{ __( 'Explore all blueprints' ) }
+					</Button>
+				}
+			/>
+			<Text as="p" className="discover-section-subheading">
+				{ __(
+					'A blueprint is a theme plus the plugins, pages, and settings for what you’re building. Start from a site that’s already set up, and WordPress.com AI helps you finish the rest.'
+				) }
+			</Text>
+			<div className="discover-rail">
+				{ getCreatorBlueprints().map( ( blueprint ) => (
+					<a
+						key={ blueprint.slug }
+						className="discover-rail-card"
+						href={ wpcomLink( `/setup/blueprint/${ blueprint.slug }` ) }
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={ () => trackClick( `blueprint_${ blueprint.slug }` ) }
+					>
+						<img
+							src={ `https://s0.wp.com/wp-content/themes/pub/${ blueprint.theme }/screenshot.png` }
+							alt={ blueprint.name }
+							loading="lazy"
+						/>
+						<span className="discover-rail-card-label">{ blueprint.name }</span>
+					</a>
+				) ) }
+			</div>
+		</VStack>
+	);
+}
+
+function PanelGrid( {
+	title,
+	panels,
+	audience,
+}: {
+	title: string;
+	panels: Panel[];
+	audience: DiscoverAudience;
+} ) {
+	const trackClick = useDiscoverTracks( audience );
+
+	return (
+		<VStack spacing={ 4 }>
+			<SectionTitle title={ title } />
+			<div className="discover-bento">
+				{ panels.map( ( panel ) => (
+					<div key={ panel.title } className={ `discover-panel ${ panel.wide ? 'is-wide' : '' }` }>
+						<span className="discover-panel-icon">
+							<Icon icon={ panel.icon } />
+						</span>
+						<Heading level={ 3 } className="discover-panel-title">
+							{ panel.title }
+						</Heading>
+						<Text as="p" className="discover-panel-description">
+							{ panel.description }
+						</Text>
+						{ panel.terminal && (
+							<code className="discover-terminal">
+								{ panel.terminal.map( ( line ) => (
+									<span key={ line }>{ line }</span>
+								) ) }
+							</code>
+						) }
+						<div className="discover-panel-action">
+							<Button
+								variant="link"
+								href={ panel.cta.href }
+								onClick={ () => trackClick( `panel_${ panel.title }` ) }
+							>
+								{ panel.cta.label }
+							</Button>
+						</div>
+					</div>
+				) ) }
+			</div>
+		</VStack>
+	);
+}
+
+export default function Discover() {
+	const workspace = useWorkspace();
+	const isCreators = workspace === 'essential';
+	const audience: DiscoverAudience = isCreators ? 'creators' : 'developers';
+	const trackClick = useDiscoverTracks( audience );
+	const [ showcaseVersion, setShowcaseVersion ] = useState< ShowcaseVersion >( () => {
+		if ( typeof window === 'undefined' ) {
+			return 'themes';
+		}
+		const stored = window.localStorage.getItem( SHOWCASE_VERSION_STORAGE_KEY ) as ShowcaseVersion;
+		return SHOWCASE_VERSIONS.includes( stored ) ? stored : 'themes';
+	} );
+
+	const switchShowcaseVersion = ( next: ShowcaseVersion ) => {
+		setShowcaseVersion( next );
+		window.localStorage.setItem( SHOWCASE_VERSION_STORAGE_KEY, next );
+		trackClick( `showcase_version_${ next }` );
+	};
+
+	return (
+		<div className="discover-page">
+			<div className="discover-sections" key={ audience }>
+				{ ! isCreators ? (
+					<DeveloperDiscover />
+				) : (
+					<>
+						<CreatorHero audience={ audience } />
+						<div className="discover-mini-switch-anchor">
+							<div className="discover-mini-switch">
+								{ SHOWCASE_VERSIONS.map( ( value, index ) => (
+									<button
+										key={ value }
+										type="button"
+										aria-pressed={ showcaseVersion === value }
+										onClick={ () => switchShowcaseVersion( value ) }
+									>
+										{ `V${ index + 1 }` }
+									</button>
+								) ) }
+							</div>
+						</div>
+						<PageLayout>
+							<VStack spacing={ 14 }>
+								{ showcaseVersion === 'themes' ? (
+									<ThemeShowcase audience={ audience } />
+								) : (
+									<BlueprintShowcase audience={ audience } />
+								) }
+								<VideoTutorials videos={ CREATOR_VIDEOS } audience={ audience } />
+								<PanelGrid
+									title={ __( 'Grow your audience' ) }
+									panels={ getCreatorPanels() }
+									audience={ audience }
+								/>
+								<NewsAndCommunity
+									news={ getCreatorNews() }
+									community={ getCreatorCommunity() }
+									viewAllHref={ localizeUrl( 'https://wordpress.com/blog/' ) }
+									audience={ audience }
+								/>
+								<HelpStrip links={ getCreatorHelpLinks() } audience={ audience } />
+							</VStack>
+						</PageLayout>
+					</>
+				) }
+			</div>
+		</div>
+	);
+}

--- a/client/dashboard/discover/shared.tsx
+++ b/client/dashboard/discover/shared.tsx
@@ -1,0 +1,286 @@
+import { Badge } from '@automattic/ui';
+import {
+	Button,
+	__experimentalHeading as Heading,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Icon,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { SVG, Path } from '@wordpress/primitives';
+import { useState } from 'react';
+import { useAnalytics } from '../app/analytics';
+import { Text } from '../components/text';
+
+export type DiscoverAudience = 'creators' | 'developers';
+
+export interface VideoTutorial {
+	id: string;
+	title: string;
+}
+
+export interface NewsItem {
+	title: string;
+	description: string;
+	isNew?: boolean;
+}
+
+export interface CommunityContent {
+	title: string;
+	description: string;
+	cta: { label: string; href: string };
+	variant?: 'blaze';
+}
+
+export interface HelpLink {
+	label: string;
+	href: string;
+}
+
+export function useDiscoverTracks( audience: DiscoverAudience ) {
+	const { recordTracksEvent } = useAnalytics();
+	return ( item: string ) =>
+		recordTracksEvent( 'calypso_dashboard_discover_click', { audience, item } );
+}
+
+export function SectionTitle( { title, action }: { title: string; action?: React.ReactNode } ) {
+	return (
+		<HStack justify="space-between" alignment="baseline">
+			<Heading level={ 2 } className="discover-section-title">
+				{ title }
+			</Heading>
+			{ action }
+		</HStack>
+	);
+}
+
+// Blaze flame from the shared BlazeLogo ( packages/components/src/icons/blaze.tsx ),
+// filled with the blaze-ads.com brand gradient.
+const blazeFlameIcon = (
+	<SVG viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+		<defs>
+			<linearGradient id="discover-blaze-flame-gradient" x1="0" y1="1" x2="1" y2="0">
+				<stop offset="0" stopColor="#f43e37" />
+				<stop offset="1" stopColor="#ff6c3d" />
+			</linearGradient>
+		</defs>
+		<Path
+			fill="url(#discover-blaze-flame-gradient)"
+			d="M112 71.186C112 77.0744 110.748 82.8791 108.302 88.3209C105.856 93.7628 102.3 98.7023 97.7771 102.86C93.2827 107.019 87.9349 110.312 82.0466 112.572C79.2589 113.633 76.3859 114.442 73.456 115L74.7645 114.302C74.7645 114.302 86.0859 107.828 88.3331 93.3163C89.3856 80.3674 78.6331 74.7023 78.6331 74.7023C78.6331 74.7023 73.1716 81.6184 65.4059 81.6184C53.2026 81.6184 55.4167 61.3158 55.4167 61.3158C55.4167 61.3158 36.9032 70.8512 36.9032 91.614C36.9032 104.591 49.9883 114.163 49.9883 114.163V114.191C48.2815 113.744 46.6032 113.186 44.9534 112.544C39.0651 110.284 33.7173 106.991 29.2229 102.833C24.7284 98.6744 21.1443 93.7349 18.6979 88.293C16.2516 82.8512 15 77.0465 15 71.1581C15 51.2326 38.2686 31.9209 38.2686 31.9209C38.2686 31.9209 40.4874 47.0744 51.8372 47.0744C73.1716 47.0744 65.4059 13 65.4059 13C65.4059 13 84.8059 24.3581 90.6372 54.6372C101.222 53.2632 100.337 39.4837 100.337 39.4837C100.337 39.4837 112 54.6372 112 71.3256"
+		/>
+	</SVG>
+);
+
+const playIcon = (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M8 5.5v13l11-6.5z" />
+	</SVG>
+);
+
+export function VideoTutorials( {
+	videos,
+	audience,
+	title,
+}: {
+	videos: VideoTutorial[];
+	audience: DiscoverAudience;
+	title?: string;
+} ) {
+	const trackClick = useDiscoverTracks( audience );
+	const [ selected, setSelected ] = useState( videos[ 0 ] );
+	const [ isPlaying, setIsPlaying ] = useState( false );
+
+	return (
+		<VStack spacing={ 4 }>
+			<SectionTitle
+				title={ title ?? __( 'Watch video tutorials' ) }
+				action={
+					<Button
+						variant="link"
+						href="https://www.youtube.com/@wordpressdotcom"
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={ () => trackClick( 'videos_view_all' ) }
+					>
+						{ __( 'View all tutorials' ) }
+					</Button>
+				}
+			/>
+			<div className="discover-videos">
+				<div className="discover-videos-player">
+					{ isPlaying ? (
+						<iframe
+							src={ `https://www.youtube-nocookie.com/embed/${ selected.id }?autoplay=1&rel=0` }
+							title={ selected.title }
+							allow="autoplay; encrypted-media; picture-in-picture"
+							allowFullScreen
+						/>
+					) : (
+						<button
+							type="button"
+							className="discover-videos-poster"
+							aria-label={ __( 'Play video' ) }
+							onClick={ () => {
+								setIsPlaying( true );
+								trackClick( `video_${ selected.id }` );
+							} }
+						>
+							<img
+								src={ `https://i.ytimg.com/vi/${ selected.id }/maxresdefault.jpg` }
+								alt={ selected.title }
+							/>
+							<span className="discover-videos-poster-play">
+								<Icon icon={ playIcon } size={ 32 } />
+							</span>
+						</button>
+					) }
+				</div>
+				<ul className="discover-videos-list">
+					{ videos.map( ( video ) => {
+						const isActive = video.id === selected.id;
+						return (
+							<li key={ video.id }>
+								<button
+									type="button"
+									className="discover-videos-item"
+									aria-current={ isActive ? 'true' : undefined }
+									onClick={ () => {
+										setSelected( video );
+										setIsPlaying( true );
+										trackClick( `video_${ video.id }` );
+									} }
+								>
+									<img
+										src={ `https://i.ytimg.com/vi/${ video.id }/mqdefault.jpg` }
+										alt=""
+										loading="lazy"
+									/>
+									<span className="discover-videos-item-text">
+										<span className="discover-videos-item-title">{ video.title }</span>
+										<span className="discover-videos-item-play">
+											<Icon icon={ playIcon } size={ 16 } />
+											{ isActive && isPlaying ? __( 'Now playing' ) : __( 'Play video' ) }
+										</span>
+									</span>
+								</button>
+							</li>
+						);
+					} ) }
+				</ul>
+			</div>
+		</VStack>
+	);
+}
+
+export function NewsAndCommunity( {
+	news,
+	community,
+	viewAllHref,
+	audience,
+}: {
+	news: NewsItem[];
+	community: CommunityContent;
+	viewAllHref: string;
+	audience: DiscoverAudience;
+} ) {
+	const trackClick = useDiscoverTracks( audience );
+
+	return (
+		<VStack spacing={ 4 }>
+			<SectionTitle
+				title={ __( 'Follow what’s new' ) }
+				action={
+					<Button
+						variant="link"
+						href={ viewAllHref }
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={ () => trackClick( 'news_view_all' ) }
+					>
+						{ __( 'View all updates' ) }
+					</Button>
+				}
+			/>
+			<div className="discover-news-layout">
+				<div className="discover-news">
+					{ news.map( ( item ) => (
+						<div
+							key={ item.title }
+							className={ `discover-news-item ${ item.isNew ? 'is-new' : '' }` }
+						>
+							<HStack justify="flex-start" spacing={ 2 } alignment="center" expanded={ false }>
+								<Text weight={ 500 }>{ item.title }</Text>
+								{ item.isNew && <Badge intent="success">{ __( 'New' ) }</Badge> }
+							</HStack>
+							<Text as="p" className="discover-news-item-description">
+								{ item.description }
+							</Text>
+						</div>
+					) ) }
+				</div>
+				<div
+					className={ `discover-community ${
+						community.variant ? `is-${ community.variant }` : ''
+					}` }
+				>
+					{ community.variant === 'blaze' && (
+						<span className="discover-community-icon">
+							<Icon icon={ blazeFlameIcon } size={ 44 } />
+						</span>
+					) }
+					<Heading level={ 3 } className="discover-community-title">
+						{ community.title }
+					</Heading>
+					<Text as="p" className="discover-community-description">
+						{ community.description }
+					</Text>
+					<div>
+						<Button
+							variant="secondary"
+							className="discover-community-cta"
+							href={ community.cta.href }
+							target="_blank"
+							rel="noopener noreferrer"
+							__next40pxDefaultSize
+							onClick={ () => trackClick( 'community_cta' ) }
+						>
+							{ community.cta.label }
+						</Button>
+					</div>
+				</div>
+			</div>
+		</VStack>
+	);
+}
+
+export function HelpStrip( {
+	links,
+	audience,
+}: {
+	links: HelpLink[];
+	audience: DiscoverAudience;
+} ) {
+	const trackClick = useDiscoverTracks( audience );
+
+	return (
+		<VStack spacing={ 3 } alignment="center" className="discover-help">
+			<Text weight={ 500 }>
+				{ __( 'We’re here to make your experience as smooth as possible' ) }
+			</Text>
+			<HStack spacing={ 4 } justify="center" expanded={ false } wrap>
+				{ links.map( ( link ) => (
+					<Button
+						key={ link.label }
+						variant="link"
+						href={ link.href }
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={ () => trackClick( `help_${ link.label }` ) }
+					>
+						{ link.label }
+					</Button>
+				) ) }
+			</HStack>
+		</VStack>
+	);
+}

--- a/client/dashboard/discover/style.scss
+++ b/client/dashboard/discover/style.scss
@@ -1,0 +1,1234 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.discover-page {
+	position: relative;
+}
+
+// Match the 56px section rhythm from the hero down to the page bottom.
+.discover-page .dashboard-page-layout {
+	padding-block: 56px;
+}
+
+// Audience switch entrance
+.discover-sections {
+	animation: discover-fade-in var( --wpds-motion-duration-lg ) var( --wpds-motion-easing-expressive ) both;
+}
+
+@keyframes discover-fade-in {
+	from {
+		opacity: 0;
+		transform: translateY( 12px );
+	}
+}
+
+// Hero — full-bleed across the content area
+.discover-hero {
+	position: relative;
+	overflow: hidden;
+	padding: clamp( 56px, 8vw, 96px ) clamp( 24px, 6vw, 72px );
+	text-align: center;
+	background:
+		radial-gradient(
+			80% 130% at 85% -10%,
+			color-mix( in srgb, var( --wp-admin-theme-color ) 20%, transparent ),
+			transparent 60%
+		),
+		radial-gradient(
+			70% 110% at 8% 110%,
+			color-mix( in srgb, var( --wp-admin-theme-color ) 12%, transparent ),
+			transparent 55%
+		),
+		var( --dashboard-surface__background-color );
+}
+
+.discover-hero-inner {
+	max-width: 760px;
+	margin-inline: auto;
+}
+
+.discover-hero-eyebrow {
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+	font-size: 12px;
+	font-weight: 600;
+	color: var( --wp-admin-theme-color );
+}
+
+.discover-hero-title {
+	font-family: Recoleta, serif;
+	font-size: clamp( 2.25rem, 4.5vw, 3.375rem );
+	font-weight: 400;
+	line-height: 1.1;
+	color: inherit;
+	text-wrap: balance;
+}
+
+.discover-hero-subtitle {
+	font-size: clamp( 1rem, 1.4vw, 1.25rem );
+	line-height: 1.6;
+	max-width: 560px;
+	margin-inline: auto;
+	color: inherit;
+	opacity: 0.8;
+	text-wrap: balance;
+}
+
+.discover-hero-footnote {
+	font-size: 12px;
+	color: inherit;
+	opacity: 0.65;
+}
+
+// Interactive hero — shared submit button for the ask pill and prompt card
+.discover-hero-ask button,
+.discover-hero-prompt button {
+	display: grid;
+	place-items: center;
+	inline-size: 36px;
+	block-size: 36px;
+	flex-shrink: 0;
+	padding: 0;
+	border: 0;
+	border-radius: 50%;
+	background: var( --wp-admin-theme-color );
+	color: var( --dashboard-surface__background-color );
+	cursor: pointer;
+	transition: background var( --wpds-motion-duration-md ) var( --wpds-motion-easing-balanced );
+
+	svg {
+		fill: currentColor;
+	}
+
+	&:hover {
+		background: color-mix( in srgb, var( --wp-admin-theme-color ) 85%, var( --dashboard__text-color ) );
+	}
+}
+
+// V1 — Help Center ask pill
+.discover-hero-ask {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	inline-size: 100%;
+	max-inline-size: 620px;
+	padding: 10px 10px 10px 20px;
+	border-radius: 24px;
+	background: var( --dashboard-surface__background-color );
+	border: 1px solid var( --dashboard-surface__border-color );
+	box-shadow: 0 8px 24px color-mix( in srgb, var( --dashboard__text-color ) 6%, transparent );
+	text-align: start;
+
+	input {
+		flex: 1;
+		min-inline-size: 0;
+		border: 0;
+		background: none;
+		font: inherit;
+		font-size: 16px;
+		color: inherit;
+
+		&:focus {
+			outline: none;
+		}
+	}
+
+	&:focus-within {
+		border-color: var( --wp-admin-theme-color );
+	}
+}
+
+// V2 — AI builder prompt card
+.discover-hero-prompt {
+	position: relative;
+	inline-size: 100%;
+	max-inline-size: 620px;
+	border-radius: var( --wpds-border-radius-lg );
+	background: var( --dashboard-surface__background-color );
+	border: 1px solid var( --dashboard-surface__border-color );
+	box-shadow: 0 8px 24px color-mix( in srgb, var( --dashboard__text-color ) 6%, transparent );
+	text-align: start;
+
+	textarea {
+		display: block;
+		inline-size: 100%;
+		padding: 16px 60px 16px 20px;
+		border: 0;
+		background: none;
+		font: inherit;
+		font-size: 16px;
+		line-height: 1.5;
+		color: inherit;
+		resize: none;
+
+		&:focus {
+			outline: none;
+		}
+	}
+
+	button {
+		position: absolute;
+		inset-block-end: 12px;
+		inset-inline-end: 12px;
+	}
+
+	&:focus-within {
+		border-color: var( --wp-admin-theme-color );
+	}
+}
+
+// Suggestion chips
+.discover-hero-chip {
+	padding: 6px 14px;
+	border: 0;
+	border-radius: 16px;
+	background: color-mix( in srgb, var( --wp-admin-theme-color ) 8%, transparent );
+	color: var( --wp-admin-theme-color );
+	font: inherit;
+	font-size: 13px;
+	cursor: pointer;
+	transition: background var( --wpds-motion-duration-md ) var( --wpds-motion-easing-balanced );
+
+	&:hover {
+		background: color-mix( in srgb, var( --wp-admin-theme-color ) 14%, transparent );
+	}
+}
+
+.discover-hero-wrap {
+	position: relative;
+}
+
+// Version switcher — intentionally quiet, bottom-right corner of the hero
+.discover-hero-switcher {
+	position: absolute;
+	inset-block-end: 10px;
+	inset-inline-end: 14px;
+	display: flex;
+	gap: 2px;
+	opacity: 0.4;
+	transition: opacity var( --wpds-motion-duration-md ) var( --wpds-motion-easing-balanced );
+
+	&:hover,
+	&:focus-within {
+		opacity: 1;
+	}
+
+	button {
+		padding: 2px 6px;
+		border: 0;
+		border-radius: var( --wpds-border-radius-sm, 2px );
+		background: none;
+		color: inherit;
+		font-size: 11px;
+		cursor: pointer;
+
+		&[aria-pressed='true'] {
+			font-weight: 700;
+			background: color-mix( in srgb, var( --dashboard__text-color ) 8%, transparent );
+		}
+	}
+}
+
+// Section titles
+.discover-section-title {
+	font-size: 20px;
+	font-weight: 600;
+}
+
+.discover-section-subheading {
+	max-inline-size: 640px;
+	margin-block-start: -8px;
+	line-height: 1.6;
+	opacity: 0.7;
+}
+
+// Compact V1/V2 switch — same quiet style as the hero switcher. The anchor
+// is a zero-height full-bleed row below the hero, so the switch overlays the
+// section's top padding at the same right inset as the hero switcher.
+.discover-mini-switch-anchor {
+	position: relative;
+}
+
+// The switch sits inside the section's 56px top padding, above the header
+// row, so it never overlaps the "Explore all…" link.
+.discover-mini-switch-anchor .discover-mini-switch {
+	position: absolute;
+	inset-block-start: 24px;
+	inset-inline-end: 14px;
+}
+
+.discover-mini-switch {
+	display: inline-flex;
+	gap: 2px;
+	opacity: 0.4;
+	transition: opacity var( --wpds-motion-duration-md ) var( --wpds-motion-easing-balanced );
+
+	&:hover,
+	&:focus-within {
+		opacity: 1;
+	}
+
+	button {
+		padding: 2px 6px;
+		border: 0;
+		border-radius: var( --wpds-border-radius-sm, 2px );
+		background: none;
+		color: inherit;
+		font-size: 11px;
+		cursor: pointer;
+
+		&[aria-pressed='true'] {
+			font-weight: 700;
+			background: color-mix( in srgb, var( --dashboard__text-color ) 8%, transparent );
+		}
+	}
+}
+
+// Theme showcase rail. The padding/negative-margin pair gives hover shadows
+// and the lift transform room to render inside the scrollport instead of
+// getting clipped by overflow-x.
+.discover-rail {
+	display: flex;
+	gap: 16px;
+	overflow-x: auto;
+	// Sized to the hover shadow (0 12px 24px) plus the -4px lift, so nothing
+	// clips against the scrollport edges. scroll-padding keeps the snap points
+	// on the content line rather than the bled scrollport edge.
+	padding: 16px 24px 40px;
+	margin: -16px -24px -40px;
+	scroll-padding-inline: 24px;
+	scroll-snap-type: x proximity;
+	// Fade partially visible cards at the scrollport edges instead of a hard
+	// crop. Eased stops so the falloff is smooth; cards resting on the content
+	// line (24px in) stay near full opacity.
+	mask-image: linear-gradient(
+		to right,
+		transparent,
+		rgb( 0 0 0 / 25% ) 8px,
+		rgb( 0 0 0 / 60% ) 16px,
+		rgb( 0 0 0 / 85% ) 24px,
+		#000 36px,
+		#000 calc( 100% - 36px ),
+		rgb( 0 0 0 / 85% ) calc( 100% - 24px ),
+		rgb( 0 0 0 / 60% ) calc( 100% - 16px ),
+		rgb( 0 0 0 / 25% ) calc( 100% - 8px ),
+		transparent
+	);
+}
+
+.discover-rail-card {
+	flex: 0 0 232px;
+	scroll-snap-align: start;
+	display: block;
+	overflow: hidden;
+	border-radius: var( --wpds-border-radius-lg );
+	border: 1px solid var( --dashboard-surface__border-color );
+	background: var( --dashboard-surface__background-color );
+	color: inherit;
+	text-decoration: none;
+	transition:
+		transform var( --wpds-motion-duration-md ) var( --wpds-motion-easing-balanced ),
+		box-shadow var( --wpds-motion-duration-md ) var( --wpds-motion-easing-balanced );
+}
+
+.discover-rail-card:hover,
+.discover-rail-card:focus-visible {
+	transform: translateY( -4px );
+	box-shadow: 0 12px 24px color-mix( in srgb, var( --dashboard__text-color ) 12%, transparent );
+}
+
+.discover-rail-card img {
+	display: block;
+	width: 100%;
+	aspect-ratio: 4 / 3;
+	object-fit: cover;
+	object-position: top;
+	border-block-end: 1px solid var( --dashboard-surface__border-color );
+}
+
+.discover-rail-card-label {
+	display: block;
+	padding: 12px 16px;
+	font-size: 13px;
+	font-weight: 500;
+}
+
+
+// Video tutorials — featured player with a playlist rail
+.discover-videos {
+	display: grid;
+	gap: 24px;
+	grid-template-columns: 1fr;
+	padding: 24px;
+	border-radius: var( --wpds-border-radius-lg );
+	border: 1px solid var( --dashboard-surface__border-color );
+	background: var( --dashboard-surface__background-color );
+
+	@include break-medium {
+		grid-template-columns: minmax( 0, 1.3fr ) minmax( 0, 1fr );
+	}
+}
+
+.discover-videos-player {
+	position: relative;
+	align-self: start;
+	aspect-ratio: 16 / 9;
+	overflow: hidden;
+	border-radius: var( --wpds-border-radius-md );
+	background: var( --dashboard__text-color );
+
+	iframe {
+		position: absolute;
+		inset: 0;
+		display: block;
+		inline-size: 100%;
+		block-size: 100%;
+		border: 0;
+	}
+}
+
+.discover-videos-poster {
+	position: absolute;
+	inset: 0;
+	display: block;
+	inline-size: 100%;
+	block-size: 100%;
+	padding: 0;
+	border: 0;
+	background: none;
+	cursor: pointer;
+
+	img {
+		display: block;
+		inline-size: 100%;
+		block-size: 100%;
+		object-fit: cover;
+	}
+}
+
+.discover-videos-poster-play {
+	position: absolute;
+	inset: 0;
+	margin: auto;
+	inline-size: 64px;
+	block-size: 64px;
+	display: grid;
+	place-items: center;
+	border-radius: 50%;
+	background: var( --dashboard-surface__background-color );
+	color: var( --dashboard__text-color );
+	box-shadow: 0 8px 24px color-mix( in srgb, var( --dashboard__text-color ) 25%, transparent );
+	transition: transform var( --wpds-motion-duration-md ) var( --wpds-motion-easing-balanced );
+
+	svg {
+		fill: currentColor;
+	}
+}
+
+.discover-videos-poster:hover .discover-videos-poster-play,
+.discover-videos-poster:focus-visible .discover-videos-poster-play {
+	transform: scale( 1.08 );
+}
+
+.discover-videos-list {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+
+	// The player's 16:9 box defines the row height; spreading the items
+	// pins the last one to the same bottom line as the player.
+	@include break-medium {
+		justify-content: space-between;
+	}
+}
+
+.discover-videos-item {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	inline-size: 100%;
+	padding: 8px;
+	border: 0;
+	border-radius: var( --wpds-border-radius-md );
+	background: none;
+	color: inherit;
+	font: inherit;
+	text-align: start;
+	cursor: pointer;
+
+	&:hover {
+		background: color-mix( in srgb, var( --dashboard__text-color ) 5%, transparent );
+	}
+
+	&[aria-current='true'] {
+		background: color-mix( in srgb, var( --wp-admin-theme-color ) 8%, transparent );
+	}
+
+	img {
+		flex: 0 0 96px;
+		inline-size: 96px;
+		aspect-ratio: 16 / 9;
+		object-fit: cover;
+		border-radius: var( --wpds-border-radius-md );
+	}
+}
+
+.discover-videos-item-text {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	min-inline-size: 0;
+}
+
+.discover-videos-item-title {
+	font-size: 13px;
+	font-weight: 500;
+	line-height: 1.4;
+}
+
+.discover-videos-item-play {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	font-size: 12px;
+	color: var( --wp-admin-theme-color );
+
+	svg {
+		fill: currentColor;
+	}
+}
+
+// Bento panel grid
+.discover-bento {
+	display: grid;
+	gap: 16px;
+	grid-template-columns: 1fr;
+
+	@include break-medium {
+		grid-template-columns: repeat( 3, 1fr );
+	}
+}
+
+.discover-panel {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 12px;
+	padding: 24px;
+	border-radius: var( --wpds-border-radius-lg );
+	border: 1px solid var( --dashboard-surface__border-color );
+	background: var( --dashboard-surface__background-color );
+	transition: box-shadow var( --wpds-motion-duration-md ) var( --wpds-motion-easing-balanced );
+}
+
+.discover-panel:hover {
+	box-shadow: 0 8px 20px color-mix( in srgb, var( --dashboard__text-color ) 8%, transparent );
+}
+
+.discover-panel.is-wide {
+	@include break-medium {
+		grid-column: span 2;
+	}
+}
+
+.discover-panel-icon {
+	display: grid;
+	place-items: center;
+	inline-size: 40px;
+	block-size: 40px;
+	border-radius: var( --wpds-border-radius-md );
+	background: color-mix( in srgb, var( --wp-admin-theme-color ) 12%, transparent );
+	color: var( --wp-admin-theme-color );
+
+	svg {
+		fill: currentColor;
+	}
+}
+
+.discover-panel-title {
+	font-size: 16px;
+	font-weight: 600;
+}
+
+.discover-panel-description {
+	line-height: 1.6;
+	opacity: 0.8;
+}
+
+.discover-panel-action {
+	margin-block-start: auto;
+}
+
+.discover-terminal {
+	display: flex;
+	flex-direction: column;
+	align-self: stretch;
+	gap: 4px;
+	padding: 16px;
+	border-radius: var( --wpds-border-radius-md );
+	background: var( --dashboard__text-color );
+	color: var( --dashboard__background-color );
+	font-family: var( --wpds-typography-font-family-mono );
+	font-size: 13px;
+	line-height: 1.6;
+	overflow-x: auto;
+	white-space: nowrap;
+}
+
+// News + community
+.discover-news-layout {
+	display: grid;
+	gap: 16px;
+	align-items: stretch;
+	grid-template-columns: 1fr;
+
+	@include break-medium {
+		grid-template-columns: minmax( 0, 1.5fr ) minmax( 0, 1fr );
+	}
+}
+
+.discover-news {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	border-radius: var( --wpds-border-radius-lg );
+	border: 1px solid var( --dashboard-surface__border-color );
+	background: var( --dashboard-surface__background-color );
+	padding-inline: 24px;
+}
+
+// Timeline dots, connected by the row dividers
+.discover-news-item {
+	position: relative;
+	padding-block: 20px;
+	padding-inline-start: 24px;
+}
+
+.discover-news-item::before {
+	content: '';
+	position: absolute;
+	inset-inline-start: 2px;
+	inset-block-start: 26px;
+	inline-size: 8px;
+	block-size: 8px;
+	border-radius: 50%;
+	background: color-mix( in srgb, var( --dashboard__text-color ) 30%, transparent );
+}
+
+.discover-news-item.is-new::before {
+	background: var( --wp-admin-theme-color );
+}
+
+.discover-news-item + .discover-news-item {
+	border-block-start: 1px solid var( --dashboard-surface__border-color );
+}
+
+.discover-news-item-description {
+	margin-block-start: 4px;
+	line-height: 1.6;
+	opacity: 0.7;
+}
+
+.discover-community {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: flex-start;
+	gap: 12px;
+	padding: 28px;
+	border-radius: var( --wpds-border-radius-lg );
+	background:
+		radial-gradient(
+			100% 140% at 100% 0%,
+			color-mix( in srgb, var( --wp-admin-theme-color ) 40%, transparent ),
+			transparent 65%
+		),
+		var( --dashboard__text-color );
+	color: var( --dashboard__background-color );
+}
+
+.discover-community-title {
+	font-family: Recoleta, serif;
+	font-size: 22px;
+	font-weight: 400;
+	color: inherit;
+}
+
+.discover-community-description {
+	line-height: 1.6;
+	color: inherit;
+	opacity: 0.8;
+}
+
+.discover-community .discover-community-cta {
+	color: inherit;
+	box-shadow: inset 0 0 0 1px currentColor;
+	background: transparent;
+}
+
+// Blaze promo variant — brand red/orange from blaze-ads.com.
+.discover-community.is-blaze {
+	background:
+		radial-gradient(
+			90% 130% at 100% 0%,
+			color-mix( in srgb, #f43e37 50%, transparent ),
+			transparent 62%
+		),
+		radial-gradient(
+			70% 110% at 0% 115%,
+			color-mix( in srgb, #ff6c3d 30%, transparent ),
+			transparent 55%
+		),
+		var( --dashboard__text-color );
+}
+
+.discover-community-icon svg {
+	display: block;
+}
+
+.discover-community.is-blaze .discover-community-cta {
+	background: #f43e37;
+	box-shadow: none;
+
+	&:hover:not( :disabled ),
+	&:active:not( :disabled ) {
+		background: #d93831;
+		color: inherit;
+		box-shadow: none;
+	}
+
+	&:focus-visible:not( :disabled ) {
+		background: #d93831;
+		color: inherit;
+		box-shadow: 0 0 0 var( --wp-admin-border-width-focus, 2px ) #ff6c3d;
+	}
+}
+
+// Help strip
+.discover-help {
+	padding-block: 16px;
+	text-align: center;
+}
+
+// Advanced workspace (developers & agencies)
+
+// Dark hero with a faint blueprint grid and the terminal mock alongside the copy.
+.discover-dev-hero {
+	position: relative;
+	overflow: hidden;
+	padding: clamp( 48px, 7vw, 88px ) clamp( 24px, 6vw, 72px );
+	background:
+		linear-gradient(
+			color-mix( in srgb, var( --dashboard__background-color ) 4%, transparent ) 1px,
+			transparent 1px
+		),
+		linear-gradient(
+			90deg,
+			color-mix( in srgb, var( --dashboard__background-color ) 4%, transparent ) 1px,
+			transparent 1px
+		),
+		radial-gradient(
+			90% 140% at 95% -20%,
+			color-mix( in srgb, var( --wp-admin-theme-color ) 40%, transparent ),
+			transparent 62%
+		),
+		var( --dashboard__text-color );
+	background-size: 48px 48px, 48px 48px, auto, auto;
+	color: var( --dashboard__background-color );
+}
+
+.discover-dev-hero-inner {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 40px;
+	align-items: center;
+	max-width: 1040px;
+	margin-inline: auto;
+
+	@include break-medium {
+		grid-template-columns: minmax( 0, 1.1fr ) minmax( 0, 1fr );
+	}
+}
+
+.discover-dev-hero .discover-hero-eyebrow {
+	color: inherit;
+	opacity: 0.75;
+}
+
+.discover-dev-hero .discover-hero-subtitle {
+	margin-inline: 0;
+}
+
+.discover-dev-hero .discover-dev-hero-secondary {
+	color: inherit;
+	box-shadow: inset 0 0 0 1px currentColor;
+	background: transparent;
+}
+
+.discover-dev-terminal {
+	overflow: hidden;
+	border-radius: var( --wpds-border-radius-lg );
+	border: 1px solid color-mix( in srgb, var( --dashboard__background-color ) 18%, transparent );
+	background: color-mix( in srgb, var( --dashboard__background-color ) 6%, transparent );
+	box-shadow: 0 24px 48px color-mix( in srgb, var( --dashboard__text-color ) 40%, transparent );
+}
+
+.discover-dev-terminal-bar {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 10px 14px;
+	border-block-end: 1px solid color-mix( in srgb, var( --dashboard__background-color ) 12%, transparent );
+
+	span {
+		inline-size: 10px;
+		block-size: 10px;
+		border-radius: 50%;
+		background: color-mix( in srgb, var( --dashboard__background-color ) 25%, transparent );
+	}
+
+	code {
+		margin-inline-start: auto;
+		font-family: var( --wpds-typography-font-family-mono );
+		font-size: 11px;
+		opacity: 0.5;
+	}
+}
+
+.discover-dev-terminal pre {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin: 0;
+	padding: 18px 20px;
+	font-family: var( --wpds-typography-font-family-mono );
+	font-size: 13px;
+	line-height: 1.5;
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+
+	.is-ok {
+		opacity: 0.7;
+	}
+
+	.is-agent {
+		color: color-mix( in srgb, var( --wp-admin-theme-color ) 45%, var( --dashboard__background-color ) );
+	}
+}
+
+.discover-dev-caret {
+	display: inline-block;
+	inline-size: 8px;
+	block-size: 15px;
+	margin-inline-start: 2px;
+	vertical-align: text-bottom;
+	background: currentColor;
+	animation: discover-dev-caret-blink 1.1s steps( 1 ) infinite;
+}
+
+@keyframes discover-dev-caret-blink {
+	50% {
+		opacity: 0;
+	}
+}
+
+// AI toolchain ledger — divided rows instead of cards
+.discover-dev-ledger {
+	border-block-start: 1px solid var( --dashboard-surface__border-color );
+}
+
+.discover-dev-ledger-row {
+	display: grid;
+	gap: 16px 32px;
+	grid-template-columns: 1fr;
+	align-items: center;
+	padding-block: 28px;
+	border-block-end: 1px solid var( --dashboard-surface__border-color );
+
+	@include break-medium {
+		grid-template-columns: minmax( 0, 1fr ) auto;
+	}
+}
+
+.discover-dev-ledger-body {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 8px;
+}
+
+.discover-dev-ledger-title {
+	font-size: 18px;
+	font-weight: 600;
+}
+
+.discover-dev-ledger-description {
+	max-inline-size: 640px;
+	line-height: 1.6;
+	opacity: 0.8;
+}
+
+.discover-dev-ledger-hint {
+	margin-block-start: 4px;
+	padding: 4px 10px;
+	border-radius: 16px;
+	border: 1px solid var( --dashboard-surface__border-color );
+	background: color-mix( in srgb, var( --dashboard__text-color ) 3%, transparent );
+	font-family: var( --wpds-typography-font-family-mono );
+	font-size: 12px;
+	opacity: 0.65;
+}
+
+// AI toolchain cards — V1 alternative to the ledger, 2×2 on desktop
+.discover-dev-ai-grid {
+	display: grid;
+	gap: 16px;
+	grid-template-columns: 1fr;
+
+	@include break-medium {
+		grid-template-columns: repeat( 2, 1fr );
+	}
+}
+
+.discover-dev-ai-card {
+	display: grid;
+	gap: 20px;
+	grid-template-columns: 1fr;
+	padding: 24px;
+	overflow: hidden;
+	border-radius: var( --wpds-border-radius-lg );
+	border: 1px solid var( --dashboard-surface__border-color );
+	background: var( --dashboard-surface__background-color );
+	transition: box-shadow var( --wpds-motion-duration-md ) var( --wpds-motion-easing-balanced );
+
+	@include break-small {
+		grid-template-columns: minmax( 0, 1.15fr ) minmax( 0, 0.85fr );
+	}
+}
+
+.discover-dev-ai-card:hover {
+	box-shadow: 0 8px 20px color-mix( in srgb, var( --dashboard__text-color ) 8%, transparent );
+}
+
+.discover-dev-ai-card-content {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 12px;
+}
+
+.discover-dev-ai-card-title {
+	font-size: 16px;
+	font-weight: 600;
+}
+
+.discover-dev-ai-card-description {
+	font-size: 13px;
+	line-height: 1.6;
+	opacity: 0.75;
+}
+
+.discover-dev-ai-card-action {
+	margin-block-start: auto;
+	padding-block-start: 12px;
+}
+
+// Flex (not percentage heights) so each mock fills the slot exactly, no
+// matter which column of the card ends up taller.
+.discover-dev-ai-card-visual {
+	display: flex;
+	min-block-size: 180px;
+	min-inline-size: 0;
+
+	> * {
+		flex: 1;
+		min-inline-size: 0;
+		box-sizing: border-box;
+	}
+}
+
+// Per-product mocks inside the card visual slot
+.discover-dev-visual-terminal {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	gap: 6px;
+	padding: 16px;
+	border-radius: var( --wpds-border-radius-md );
+	background: var( --dashboard__text-color );
+	color: var( --dashboard__background-color );
+	font-family: var( --wpds-typography-font-family-mono );
+	font-size: 12px;
+	line-height: 1.5;
+	overflow: hidden;
+
+	.is-ok {
+		opacity: 0.7;
+	}
+}
+
+.discover-dev-visual-abilities {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	gap: 8px;
+	padding: 16px;
+	border-radius: var( --wpds-border-radius-md );
+	background: color-mix( in srgb, var( --dashboard__text-color ) 3%, transparent );
+	font-family: var( --wpds-typography-font-family-mono );
+	font-size: 12px;
+	overflow: hidden;
+
+	span {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 6px 10px;
+		border-radius: var( --wpds-border-radius-sm, 2px );
+		border: 1px solid var( --dashboard-surface__border-color );
+		background: var( --dashboard-surface__background-color );
+	}
+
+	i {
+		flex-shrink: 0;
+		inline-size: 6px;
+		block-size: 6px;
+		border-radius: 50%;
+		background: var( --wp-admin-theme-color );
+	}
+}
+
+.discover-dev-visual-telex {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 10px;
+	padding: 16px;
+	border-radius: var( --wpds-border-radius-md );
+	background: color-mix( in srgb, var( --dashboard__text-color ) 3%, transparent );
+	overflow: hidden;
+}
+
+.discover-dev-visual-prompt {
+	padding: 6px 12px;
+	border-radius: 16px;
+	border: 1px solid var( --dashboard-surface__border-color );
+	background: var( --dashboard-surface__background-color );
+	font-size: 12px;
+	text-align: center;
+}
+
+.discover-dev-visual-arrow {
+	font-size: 14px;
+	opacity: 0.4;
+}
+
+.discover-dev-visual-block {
+	display: flex;
+	gap: 8px;
+	padding: 10px;
+	border-radius: var( --wpds-border-radius-sm, 2px );
+	border: 1px solid var( --dashboard-surface__border-color );
+	background: var( --dashboard-surface__background-color );
+
+	i {
+		display: block;
+		inline-size: 36px;
+		block-size: 44px;
+		border-radius: var( --wpds-border-radius-sm, 2px );
+		background: color-mix( in srgb, var( --wp-admin-theme-color ) 16%, transparent );
+	}
+
+	i:nth-child( 2 ) {
+		background: color-mix( in srgb, var( --wp-admin-theme-color ) 34%, transparent );
+	}
+}
+
+.discover-dev-visual-chat {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	gap: 8px;
+	padding: 16px;
+	border-radius: var( --wpds-border-radius-md );
+	background: color-mix( in srgb, var( --dashboard__text-color ) 3%, transparent );
+	font-size: 12px;
+	line-height: 1.5;
+	overflow: hidden;
+
+	span {
+		max-inline-size: 88%;
+		padding: 6px 10px;
+		border-radius: var( --wpds-border-radius-md );
+	}
+
+	.is-user {
+		align-self: flex-end;
+		background: var( --wp-admin-theme-color );
+		color: var( --dashboard-surface__background-color );
+	}
+
+	.is-bot {
+		align-self: flex-start;
+		border: 1px solid var( --dashboard-surface__border-color );
+		background: var( --dashboard-surface__background-color );
+	}
+
+	.is-code {
+		font-family: var( --wpds-typography-font-family-mono );
+	}
+}
+
+// Local-to-live pipeline — numbered steps joined by a connector line
+.discover-dev-pipeline {
+	display: grid;
+	gap: 32px 24px;
+	grid-template-columns: 1fr;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+
+	@include break-medium {
+		grid-template-columns: repeat( 4, 1fr );
+	}
+
+	li {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	@include break-medium {
+		li:not( :last-child )::after {
+			content: '';
+			position: absolute;
+			inset-block-start: 14px;
+			inset-inline-start: 40px;
+			inset-inline-end: -12px;
+			block-size: 1px;
+			background: var( --dashboard-surface__border-color );
+		}
+	}
+}
+
+.discover-dev-pipeline-marker {
+	display: grid;
+	place-items: center;
+	inline-size: 28px;
+	block-size: 28px;
+	border-radius: 50%;
+	background: color-mix( in srgb, var( --wp-admin-theme-color ) 12%, transparent );
+	color: var( --wp-admin-theme-color );
+	font-family: var( --wpds-typography-font-family-mono );
+	font-size: 12px;
+	font-weight: 600;
+}
+
+.discover-dev-pipeline-title {
+	font-size: 15px;
+	font-weight: 600;
+}
+
+.discover-dev-pipeline-description {
+	font-size: 13px;
+	line-height: 1.6;
+	opacity: 0.75;
+}
+
+// Agency duo — A4A (dark) next to the Hosting Dashboard card
+.discover-dev-duo {
+	display: grid;
+	gap: 16px;
+	grid-template-columns: 1fr;
+	align-items: stretch;
+
+	@include break-medium {
+		grid-template-columns: repeat( 2, 1fr );
+	}
+}
+
+.discover-dev-duo-card {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 12px;
+	padding: 28px;
+	border-radius: var( --wpds-border-radius-lg );
+	border: 1px solid var( --dashboard-surface__border-color );
+	background: var( --dashboard-surface__background-color );
+}
+
+.discover-dev-duo-card.is-dark {
+	border: 0;
+	background:
+		radial-gradient(
+			100% 140% at 100% 0%,
+			color-mix( in srgb, var( --wp-admin-theme-color ) 40%, transparent ),
+			transparent 65%
+		),
+		var( --dashboard__text-color );
+	color: var( --dashboard__background-color );
+}
+
+.discover-dev-duo-eyebrow {
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+	color: var( --wp-admin-theme-color );
+}
+
+.discover-dev-duo-card.is-dark .discover-dev-duo-eyebrow {
+	color: inherit;
+	opacity: 0.75;
+}
+
+.discover-dev-duo-title {
+	font-family: Recoleta, serif;
+	font-size: 22px;
+	font-weight: 400;
+	color: inherit;
+}
+
+.discover-dev-duo-description {
+	line-height: 1.6;
+	color: inherit;
+	opacity: 0.8;
+}
+
+.discover-dev-duo-action {
+	margin-block-start: auto;
+	padding-block-start: 8px;
+}
+
+.discover-dev-duo-card.is-dark .discover-dev-duo-cta {
+	color: inherit;
+	box-shadow: inset 0 0 0 1px currentColor;
+	background: transparent;
+}
+
+@media ( prefers-reduced-motion: reduce ) {
+	.discover-sections {
+		animation: none;
+	}
+
+	.discover-dev-caret {
+		animation: none;
+	}
+
+	.discover-rail-card,
+	.discover-panel,
+	.discover-videos-poster-play {
+		transition: none;
+	}
+
+	.discover-rail-card:hover,
+	.discover-rail-card:focus-visible {
+		transform: none;
+	}
+}

--- a/client/dashboard/sites/overview-blogger/index.tsx
+++ b/client/dashboard/sites/overview-blogger/index.tsx
@@ -1,0 +1,819 @@
+/**
+ * Prototype: site overview reimagined for bloggers & creators.
+ * Rendered for the three mock sites defined in ./mock-sites.ts, one per plan
+ * tier. All tiers share the same layout and card set (Visibility, Backup,
+ * Scan, Performance, Plan); content varies per site, and cards whose features
+ * require the Business plan become upsells on Free/Premium. Each tier keeps
+ * its own promo banner.
+ */
+import { localizeUrl } from '@automattic/i18n-utils';
+import {
+	__experimentalDivider as Divider,
+	__experimentalGrid as Grid,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+	Icon,
+} from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
+import {
+	backup,
+	chartBar,
+	check,
+	chevronRight,
+	comment,
+	envelope,
+	external,
+	help,
+	image,
+	lockOutline,
+	megaphone,
+	page,
+	pencil,
+	people,
+	plugins,
+	published,
+	rss,
+	shield,
+	starFilled,
+	video,
+	wordpress,
+} from '@wordpress/icons';
+import clsx from 'clsx';
+import { useHelpCenter } from '../../app/help-center';
+import { Card, CardBody, CardHeader } from '../../components/card';
+import OverviewCard from '../../components/overview-card';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { SectionHeader } from '../../components/section-header';
+import { Stat } from '../../components/stat';
+import { SummaryButtonCardFooter } from '../../components/summary-button-card-footer';
+import { Text } from '../../components/text';
+import { getMockBloggerSite, SOLO_BLOGGER_SITE_SLUG } from './mock-sites';
+import type { BloggerTier } from './mock-sites';
+import type { Site } from '@automattic/api-core';
+import type { ReactElement, ReactNode } from 'react';
+import './style.scss';
+
+const SPACING = {
+	DEFAULT: 6,
+	SMALL: 4,
+};
+
+interface ActivityItem {
+	icon: ReactElement;
+	text: string;
+	meta: string;
+}
+
+function getGridLayout( {
+	count,
+	isLargeViewport,
+	isSmallViewport,
+}: {
+	count: number;
+	isLargeViewport: boolean;
+	isSmallViewport: boolean;
+} ) {
+	if ( isLargeViewport ) {
+		return { columns: count, rows: 1 };
+	}
+	if ( isSmallViewport ) {
+		return { columns: 1, rows: count };
+	}
+	return { columns: 2, rows: Math.ceil( count / 2 ) };
+}
+
+const TIER_PREVIEW_THEME: Record< BloggerTier, string > = {
+	free: 'lettre',
+	premium: 'dorna',
+	business: 'stewart',
+};
+
+function SitePreviewColumn( { site, tier }: { site: Site; tier: BloggerTier } ) {
+	return (
+		<Card className="blogger-overview-preview">
+			<a href={ site.URL } target="_blank" rel="noreferrer">
+				<img
+					src={ `https://s0.wp.com/wp-content/themes/pub/${ TIER_PREVIEW_THEME[ tier ] }/screenshot.png` }
+					alt={ `Preview of ${ site.name }` }
+				/>
+				<span className="blogger-overview-preview__overlay">
+					<span className="blogger-overview-preview__label">Visit your site</span>
+				</span>
+			</a>
+		</Card>
+	);
+}
+
+interface SupportLink {
+	icon: ReactElement;
+	label: string;
+	href: string;
+	external?: boolean;
+}
+
+const SUPPORT_GUIDES: SupportLink[] = [
+	{
+		icon: page,
+		label: 'Write and schedule posts',
+		href: localizeUrl( 'https://wordpress.com/support/posts/' ),
+	},
+	{
+		icon: page,
+		label: 'Connect a custom domain',
+		href: localizeUrl( 'https://wordpress.com/support/domains/' ),
+	},
+	{
+		icon: page,
+		label: 'Change your site’s look',
+		href: localizeUrl( 'https://wordpress.com/support/themes/' ),
+	},
+	{
+		icon: page,
+		label: 'Grow your audience',
+		href: localizeUrl( 'https://wordpress.com/support/category/grow-your-audience/' ),
+	},
+];
+
+const SUPPORT_RESOURCES: SupportLink[] = [
+	{
+		icon: backup,
+		label: 'Support history',
+		href: 'https://wordpress.com/help',
+	},
+	{
+		icon: video,
+		label: 'Courses',
+		href: localizeUrl( 'https://wordpress.com/learn/' ),
+		external: true,
+	},
+	{
+		icon: rss,
+		label: 'Product updates',
+		href: localizeUrl( 'https://wordpress.com/blog/' ),
+		external: true,
+	},
+];
+
+function SupportLinkList( { links }: { links: SupportLink[] } ) {
+	return (
+		<div className="blogger-overview-support__list">
+			{ links.map( ( link ) => (
+				<a
+					key={ link.label }
+					className="blogger-overview-support__row"
+					href={ link.href }
+					{ ...( link.external ? { target: '_blank', rel: 'noreferrer' } : {} ) }
+				>
+					<Icon icon={ link.icon } size={ 20 } />
+					<span className="blogger-overview-support__row-label">{ link.label }</span>
+					<Icon
+						className="blogger-overview-support__row-indicator"
+						icon={ link.external ? external : chevronRight }
+						size={ 20 }
+					/>
+				</a>
+			) ) }
+		</div>
+	);
+}
+
+function VisibilityCard() {
+	return (
+		<OverviewCard
+			title="Visibility"
+			icon={ published }
+			heading="Public"
+			description="Anyone can view your site."
+			intent="success"
+		/>
+	);
+}
+
+function StorageStat( {
+	used,
+	max,
+	percent,
+	progressColor,
+}: {
+	used: string;
+	max: string;
+	percent: number;
+	progressColor?: 'alert-yellow' | 'alert-red' | 'alert-green';
+} ) {
+	return (
+		<Stat
+			density="high"
+			strapline="Storage"
+			metric={ used }
+			description={ max }
+			progressValue={ Math.max( 2.5, percent ) }
+			progressLabel={ `${ percent }%` }
+			progressColor={ progressColor }
+		/>
+	);
+}
+
+function BandwidthStat() {
+	return <Stat density="high" strapline="Bandwidth" metric="Unlimited" />;
+}
+
+function ActivityCard( {
+	site,
+	items,
+	emptyState,
+}: {
+	site: Site;
+	items: ActivityItem[];
+	emptyState?: ReactNode;
+} ) {
+	return (
+		<Card role="article" className="blogger-overview-activity">
+			<CardHeader>
+				<SectionHeader title="Latest activity" level={ 3 } />
+			</CardHeader>
+			<CardBody>
+				{ items.length === 0 ? (
+					emptyState
+				) : (
+					<VStack spacing={ 4 }>
+						{ items.map( ( item ) => (
+							<HStack key={ item.text } spacing={ 3 } justify="flex-start" alignment="center">
+								<span className="blogger-overview-activity__icon">
+									<Icon icon={ item.icon } size={ 24 } />
+								</span>
+								<VStack spacing={ 1 }>
+									<Text weight={ 500 }>{ item.text }</Text>
+									<Text variant="muted" size={ 12 } lineHeight="16px">
+										{ item.meta }
+									</Text>
+								</VStack>
+							</HStack>
+						) ) }
+					</VStack>
+				) }
+			</CardBody>
+			{ items.length > 0 && (
+				<SummaryButtonCardFooter
+					title="See all activity"
+					href={ `https://wordpress.com/activity-log/${ site.slug }` }
+					density="medium"
+				/>
+			) }
+		</Card>
+	);
+}
+
+function BackupCard( { site, tier }: { site: Site; tier: BloggerTier } ) {
+	if ( tier === 'business' ) {
+		return (
+			<OverviewCard
+				title="Last backup"
+				icon={ backup }
+				heading="1h ago"
+				description="Today at 3:43 PM."
+				intent="success"
+			/>
+		);
+	}
+	return (
+		<OverviewCard
+			title="Last backup"
+			icon={ backup }
+			heading="Your posts aren’t backed up"
+			description="Automatic daily backups and one-click restores come with the Business plan."
+			intent="upsell"
+			link={ `https://wordpress.com/plans/${ site.slug }` }
+		/>
+	);
+}
+
+function ScanCard( { site, tier }: { site: Site; tier: BloggerTier } ) {
+	if ( tier === 'business' ) {
+		return (
+			<OverviewCard
+				title="Last scan"
+				icon={ shield }
+				heading="No risks found"
+				description="We check your site every day."
+				intent="success"
+			/>
+		);
+	}
+	return (
+		<OverviewCard
+			title="Last scan"
+			icon={ shield }
+			heading="Add daily security scans"
+			description="We’ll check your site for malware and threats every day with the Business plan."
+			intent="upsell"
+			link={ `https://wordpress.com/plans/${ site.slug }` }
+		/>
+	);
+}
+
+const TIER_PERFORMANCE: Record<
+	BloggerTier,
+	{ heading: string; description: string; intent: 'success' | 'warning' }
+> = {
+	free: {
+		heading: 'Could be faster',
+		description: 'Your homepage takes 4.6 seconds to load on phones. See what to fix.',
+		intent: 'warning',
+	},
+	premium: {
+		heading: 'Looking good',
+		description: 'Your site loads quickly for most visitors.',
+		intent: 'success',
+	},
+	business: {
+		heading: 'Could be faster',
+		description: 'Large images are slowing your homepage. Fix them in one click.',
+		intent: 'warning',
+	},
+};
+
+function PerformanceCard( { site, tier }: { site: Site; tier: BloggerTier } ) {
+	const content =
+		site.slug === SOLO_BLOGGER_SITE_SLUG
+			? {
+					heading: 'Slow on photo pages',
+					description:
+						'Pages with many large images take 5.8 seconds to load. Compress them to speed things up.',
+					intent: 'warning' as const,
+			  }
+			: TIER_PERFORMANCE[ tier ];
+	return (
+		<OverviewCard
+			title="Performance"
+			icon={ chartBar }
+			heading={ content.heading }
+			description={ content.description }
+			intent={ content.intent }
+			link={ `/sites/${ site.slug }/performance` }
+		/>
+	);
+}
+
+function PlanCard( { site, tier }: { site: Site; tier: BloggerTier } ) {
+	switch ( tier ) {
+		case 'free':
+			return (
+				<OverviewCard
+					title="Plan"
+					icon={ wordpress }
+					heading="Free"
+					description="Upgrade for more space, a free domain, and no ads."
+					link={ `https://wordpress.com/plans/${ site.slug }` }
+					bottom={
+						<VStack spacing={ 4 }>
+							<StorageStat used="118 MB" max="1 GB" percent={ 12 } />
+							<Text variant="muted" lineHeight="16px" size={ 12 }>
+								Photos and videos fill this fast — paid plans start at 13 GB.
+							</Text>
+						</VStack>
+					}
+				/>
+			);
+		case 'premium':
+			if ( site.slug === SOLO_BLOGGER_SITE_SLUG ) {
+				return (
+					<OverviewCard
+						title="Plan"
+						icon={ wordpress }
+						heading="Premium"
+						description="Renews on March 3, 2027."
+						link={ `https://wordpress.com/plans/${ site.slug }` }
+						bottom={
+							<VStack spacing={ 4 }>
+								<StorageStat used="12.2 GB" max="13 GB" percent={ 94 } progressColor="alert-red" />
+								<Text variant="muted" lineHeight="16px" size={ 12 }>
+									Storage almost full — the Business plan includes 50 GB.
+								</Text>
+							</VStack>
+						}
+					/>
+				);
+			}
+			return (
+				<OverviewCard
+					title="Plan"
+					icon={ wordpress }
+					heading="Premium"
+					description="Renews on December 6, 2026."
+					link={ `https://wordpress.com/plans/my-plan/${ site.slug }` }
+					bottom={
+						<VStack spacing={ 4 }>
+							<StorageStat used="452 MB" max="13 GB" percent={ 3 } />
+							<BandwidthStat />
+						</VStack>
+					}
+				/>
+			);
+		case 'business':
+			return (
+				<OverviewCard
+					title="Plan"
+					icon={ wordpress }
+					heading="Business"
+					description="Renews on December 12, 2026."
+					link={ `https://wordpress.com/plans/my-plan/${ site.slug }` }
+					bottom={
+						<VStack spacing={ 4 }>
+							<StorageStat used="4.6 GB" max="50 GB" percent={ 9 } />
+							<BandwidthStat />
+						</VStack>
+					}
+				/>
+			);
+	}
+}
+
+function DomainPromoBanner( { site }: { site: Site } ) {
+	return (
+		<div className="blogger-overview-promo is-domain">
+			<HStack spacing={ 8 } justify="space-between" alignment="center" wrap>
+				<VStack spacing={ 4 } alignment="flex-start">
+					<h2 className="blogger-overview-promo__title">sunrisestories.blog is waiting for you</h2>
+					<p className="blogger-overview-promo__description">
+						Save up to 55% on annual plans and get your domain free for the first year — along with
+						more space for your photos and no ads between your stories.
+					</p>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						href={ `https://wordpress.com/domains/add/${ site.slug }` }
+					>
+						Claim your domain
+					</Button>
+				</VStack>
+				<div className="blogger-overview-promo__browser">
+					<span className="blogger-overview-promo__browser-dots">
+						<i />
+						<i />
+						<i />
+					</span>
+					<span className="blogger-overview-promo__browser-address">
+						<Icon icon={ lockOutline } size={ 16 } />
+						sunrisestories.blog
+					</span>
+				</div>
+			</HStack>
+		</div>
+	);
+}
+
+function GrowPromoBanner( { site }: { site: Site } ) {
+	const perks = [
+		{ icon: envelope, label: 'Email newsletters, built in' },
+		{ icon: megaphone, label: '$200 to promote your posts' },
+		{ icon: video, label: 'Stunning 4K video' },
+		{ icon: image, label: '4× the photo storage' },
+	];
+
+	return (
+		<div className="blogger-overview-promo is-grow">
+			<HStack spacing={ 8 } justify="space-between" alignment="center" wrap>
+				<VStack spacing={ 4 } alignment="flex-start">
+					<h2 className="blogger-overview-promo__title">
+						Your next thousand readers are out there
+					</h2>
+					<p className="blogger-overview-promo__description">
+						The Business plan is a growth kit for creators — reach new readers, keep them close with
+						newsletters, and give your photos and videos all the room they deserve.
+					</p>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						href={ `https://wordpress.com/plans/${ site.slug }` }
+					>
+						Grow with Business
+					</Button>
+				</VStack>
+				<div className="blogger-overview-promo__perks">
+					{ perks.map( ( perk ) => (
+						<span key={ perk.label } className="blogger-overview-promo__perk">
+							<Icon icon={ perk.icon } size={ 20 } />
+							{ perk.label }
+						</span>
+					) ) }
+				</div>
+			</HStack>
+		</div>
+	);
+}
+
+function MonetizePromoBanner( { site }: { site: Site } ) {
+	return (
+		<div className="blogger-overview-promo is-monetize">
+			<HStack spacing={ 8 } justify="space-between" alignment="center" wrap>
+				<VStack spacing={ 4 } alignment="flex-start">
+					<h2 className="blogger-overview-promo__title">Turn your readers into income</h2>
+					<p className="blogger-overview-promo__description">
+						You have 1,024 subscribers. Offer them a paid newsletter or exclusive posts — you set
+						the price, we handle the billing.
+					</p>
+					<Button
+						__next40pxDefaultSize
+						className="blogger-overview-promo__button-inverted"
+						href={ `https://wordpress.com/earn/${ site.slug }` }
+					>
+						Set up paid subscriptions
+					</Button>
+				</VStack>
+				<div className="blogger-overview-promo__earnings">
+					<span className="blogger-overview-promo__earnings-label">
+						If 5% of your subscribers pay $5/month
+					</span>
+					<span className="blogger-overview-promo__earnings-value">
+						$256<small>/month</small>
+					</span>
+				</div>
+			</HStack>
+		</div>
+	);
+}
+
+function PromoBanner( { site, tier }: { site: Site; tier: BloggerTier } ) {
+	switch ( tier ) {
+		case 'free':
+			return <DomainPromoBanner site={ site } />;
+		case 'premium':
+			return <GrowPromoBanner site={ site } />;
+		case 'business':
+			return <MonetizePromoBanner site={ site } />;
+	}
+}
+
+const TIER_ACTIVITY: Record< BloggerTier, ActivityItem[] > = {
+	free: [
+		{
+			icon: pencil,
+			text: 'Published “The first light of day”',
+			meta: 'Yesterday',
+		},
+		{
+			icon: people,
+			text: 'Your first reader subscribed',
+			meta: '2 days ago',
+		},
+		{
+			icon: image,
+			text: 'Uploaded 6 new photos',
+			meta: '3 days ago',
+		},
+		{
+			icon: page,
+			text: 'Created the About page',
+			meta: '4 days ago',
+		},
+		{
+			icon: published,
+			text: 'Your site went live',
+			meta: 'Last week',
+		},
+		{
+			icon: comment,
+			text: 'Received your first comment',
+			meta: 'Last week',
+		},
+		{
+			icon: chartBar,
+			text: 'Your busiest day yet — 12 visitors',
+			meta: '2 weeks ago',
+		},
+		{
+			icon: pencil,
+			text: 'Started a draft: “Places I want to go”',
+			meta: '2 weeks ago',
+		},
+		{
+			icon: check,
+			text: 'Completed your site setup checklist',
+			meta: '2 weeks ago',
+		},
+		{
+			icon: wordpress,
+			text: 'Created your site',
+			meta: '3 weeks ago',
+		},
+	],
+	premium: [
+		{
+			icon: pencil,
+			text: 'Published “Golden hour at the pier”',
+			meta: '2 days ago',
+		},
+		{
+			icon: image,
+			text: 'Uploaded 14 new photos',
+			meta: '4 days ago',
+		},
+		{
+			icon: people,
+			text: '4 people subscribed to your site',
+			meta: '5 days ago',
+		},
+		{
+			icon: page,
+			text: 'Updated the About page',
+			meta: 'Last week',
+		},
+		{
+			icon: pencil,
+			text: 'Published “Fog rolling over the marina”',
+			meta: 'Last week',
+		},
+		{
+			icon: starFilled,
+			text: '“Golden hour at the pier” got 12 likes',
+			meta: 'Last week',
+		},
+		{
+			icon: comment,
+			text: '6 new comments this week',
+			meta: 'Last week',
+		},
+		{
+			icon: envelope,
+			text: 'Newsletter sent to 48 subscribers',
+			meta: '2 weeks ago',
+		},
+		{
+			icon: chartBar,
+			text: 'Traffic spike — 320 views in one day',
+			meta: '2 weeks ago',
+		},
+		{
+			icon: video,
+			text: 'Uploaded “Harbor timelapse”',
+			meta: '3 weeks ago',
+		},
+	],
+	business: [
+		{
+			icon: plugins,
+			text: 'We updated 2 plugins for you',
+			meta: '1h ago · Handled by WordPress.com',
+		},
+		{
+			icon: backup,
+			text: 'Backup completed',
+			meta: '1h ago',
+		},
+		{
+			icon: people,
+			text: '3 people subscribed to your newsletter',
+			meta: 'Yesterday',
+		},
+		{
+			icon: pencil,
+			text: 'Published “Slow mornings in Lisbon”',
+			meta: '3 days ago',
+		},
+		{
+			icon: image,
+			text: 'Uploaded 22 new photos',
+			meta: '4 days ago',
+		},
+		{
+			icon: envelope,
+			text: 'Newsletter delivered to 210 subscribers',
+			meta: '5 days ago',
+		},
+		{
+			icon: comment,
+			text: '9 new comments this week',
+			meta: 'Last week',
+		},
+		{
+			icon: megaphone,
+			text: 'Blaze campaign reached 1,200 readers',
+			meta: 'Last week',
+		},
+		{
+			icon: shield,
+			text: 'Security scan completed — no threats found',
+			meta: 'Last week',
+		},
+		{
+			icon: chartBar,
+			text: 'Monthly traffic report is ready',
+			meta: '2 weeks ago',
+		},
+	],
+};
+
+function TierPrimaryCards( {
+	site,
+	tier,
+	spacing,
+}: {
+	site: Site;
+	tier: BloggerTier;
+	spacing: number;
+} ) {
+	return (
+		<>
+			<Grid columns={ 1 } rows={ 2 } gap={ spacing }>
+				<VisibilityCard />
+				<BackupCard site={ site } tier={ tier } />
+			</Grid>
+			<Grid columns={ 1 } rows={ 2 } gap={ spacing }>
+				<ScanCard site={ site } tier={ tier } />
+				<PerformanceCard site={ site } tier={ tier } />
+			</Grid>
+			<PlanCard site={ site } tier={ tier } />
+		</>
+	);
+}
+
+export default function BloggerSiteOverview( { siteSlug }: { siteSlug: string } ) {
+	const isLargeViewport = useViewportMatch( 'xlarge' );
+	const isSmallViewport = useViewportMatch( 'medium', '<' );
+	const { setShowHelpCenter } = useHelpCenter();
+	const spacing = isSmallViewport ? SPACING.SMALL : SPACING.DEFAULT;
+	const mock = getMockBloggerSite( siteSlug );
+
+	if ( ! mock ) {
+		return null;
+	}
+
+	const { site, tier } = mock;
+	const gridLayout = getGridLayout( { count: 4, isLargeViewport, isSmallViewport } );
+	const headerFields =
+		tier === 'business'
+			? 'WordPress 7.0.1 · PHP 8.3 · Hosted on WordPress.com'
+			: 'WordPress 7.0.1 · Hosted on WordPress.com';
+
+	return (
+		<PageLayout
+			size="large"
+			header={
+				<PageHeader
+					title={ site.name }
+					description={ <Text variant="muted">{ headerFields }</Text> }
+					actions={
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							href={ site.options?.admin_url }
+							icon={ wordpress }
+						>
+							WP Admin
+						</Button>
+					}
+				/>
+			}
+		>
+			<VStack alignment="stretch" spacing={ isSmallViewport ? 5 : 10 }>
+				<Grid { ...gridLayout } gap={ spacing }>
+					<SitePreviewColumn site={ site } tier={ tier } />
+					<TierPrimaryCards site={ site } tier={ tier } spacing={ spacing } />
+				</Grid>
+				<Divider
+					orientation="horizontal"
+					style={ { color: 'var(--dashboard-overview__divider-color)' } }
+				/>
+				<HStack
+					className={ clsx( 'site-overview-cards', 'site-overview-cards--secondary', {
+						'is-large': isLargeViewport,
+					} ) }
+					spacing={ spacing }
+					alignment="stretch"
+				>
+					<VStack spacing={ spacing } justify="start">
+						<ActivityCard site={ site } items={ TIER_ACTIVITY[ tier ] } />
+					</VStack>
+					<VStack className="blogger-overview-side" spacing={ spacing } justify="start">
+						<OverviewCard
+							title="Support"
+							icon={ help }
+							heading="Need a hand?"
+							description="Get instant answers from our AI assistant, or chat with a Happiness Engineer — any time."
+							link="https://wordpress.com/help"
+							onClick={ ( event ) => {
+								event?.preventDefault();
+								setShowHelpCenter( true );
+							} }
+							bottom={
+								<div className="blogger-overview-support__columns">
+									<VStack spacing={ 3 } justify="start">
+										<Text weight={ 500 }>Recommended guides</Text>
+										<SupportLinkList links={ SUPPORT_GUIDES } />
+									</VStack>
+									<VStack spacing={ 3 } justify="start" alignment="stretch">
+										<Text weight={ 500 }>More resources</Text>
+										<SupportLinkList links={ SUPPORT_RESOURCES } />
+									</VStack>
+								</div>
+							}
+						/>
+					</VStack>
+				</HStack>
+				<PromoBanner site={ site } tier={ tier } />
+			</VStack>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/sites/overview-blogger/mock-sites.ts
+++ b/client/dashboard/sites/overview-blogger/mock-sites.ts
@@ -1,0 +1,291 @@
+/**
+ * Local-only prototype data. Injects three fake blogger/creator sites (Free,
+ * Premium, Business) into the sites list so the blogger-focused overview
+ * redesign can be explored at /sites/<slug> without real API data.
+ */
+import {
+	persistQueryClientPromise,
+	queryClient,
+	siteByIdQuery,
+	siteBySlugQuery,
+	siteCurrentPlanQuery,
+	siteMediaStorageQuery,
+} from '@automattic/api-queries';
+import type { Site, SiteContextualPlan } from '@automattic/api-core';
+
+export type BloggerTier = 'free' | 'premium' | 'business';
+
+const MB = 1024 * 1024;
+const GB = 1024 * MB;
+
+interface MockSiteInput {
+	ID: number;
+	slug: string;
+	name: string;
+	URL: string;
+	tier: BloggerTier;
+	plan: NonNullable< Site[ 'plan' ] >;
+	isAtomic?: boolean;
+	storageUsedBytes: number;
+	maxStorageBytes: number;
+	/** Only shown in the solo-blogger persona (?persona=blogger). */
+	solo?: boolean;
+}
+
+function makeMockSite( input: MockSiteInput ): Site {
+	return {
+		ID: input.ID,
+		slug: input.slug,
+		name: input.name,
+		URL: input.URL,
+		plan: input.plan,
+		capabilities: {
+			manage_options: true,
+			update_plugins: true,
+		},
+		feed_ID: input.ID,
+		feed_URL: `${ input.URL }/feed/`,
+		subscribers_count: 0,
+		options: {
+			admin_url: `${ input.URL }/wp-admin/`,
+			created_at: '2025-09-14T10:00:00+00:00',
+			updated_at: '2026-07-14T15:43:00+00:00',
+			software_version: '7.0.1',
+			site_intent: 'write',
+			unmapped_url: input.URL,
+		},
+		is_a4a_dev_site: false,
+		is_a8c: false,
+		is_deleted: false,
+		is_coming_soon: false,
+		is_private: false,
+		is_wpcom_atomic: input.isAtomic ?? false,
+		is_wpcom_flex: false,
+		is_wpcom_staging_site: false,
+		is_vip: false,
+		lang: 'en',
+		launch_status: 'launched',
+		site_migration: {
+			in_progress: false,
+			is_complete: false,
+		},
+		site_owner: 0,
+		jetpack: false,
+		jetpack_connection: false,
+		jetpack_modules: null,
+		was_ecommerce_trial: false,
+		was_migration_trial: false,
+		was_hosting_trial: false,
+		was_upgraded_from_trial: false,
+		is_garden: false,
+		garden_name: null,
+		garden_partner: null,
+		garden_is_provisioned: null,
+	};
+}
+
+const MOCK_SITE_INPUTS: MockSiteInput[] = [
+	{
+		ID: 900000001,
+		slug: 'sunrise-stories.wordpress.com',
+		name: 'Sunrise Stories',
+		URL: 'https://sunrise-stories.wordpress.com',
+		tier: 'free',
+		plan: {
+			product_id: 1,
+			product_slug: 'free_plan',
+			product_name: 'WordPress.com Free',
+			product_name_short: 'Free',
+			product_name_en: 'Free',
+			expired: false,
+			is_free: true,
+			features: { active: [] },
+		},
+		storageUsedBytes: 118 * MB,
+		maxStorageBytes: 1 * GB,
+	},
+	{
+		ID: 900000002,
+		slug: 'coastalshots.gallery',
+		name: 'Coastal Shots',
+		URL: 'https://coastalshots.gallery',
+		tier: 'premium',
+		plan: {
+			product_id: 1003,
+			product_slug: 'value_bundle',
+			product_name: 'WordPress.com Premium',
+			product_name_short: 'Premium',
+			product_name_en: 'Premium',
+			expired: false,
+			is_free: false,
+			billing_period: 'Yearly',
+			features: { active: [] },
+		},
+		storageUsedBytes: 452 * MB,
+		maxStorageBytes: 13 * GB,
+	},
+	{
+		ID: 900000003,
+		slug: 'lucastravels.com',
+		name: 'Lucas Travels',
+		URL: 'https://lucastravels.com',
+		tier: 'business',
+		plan: {
+			product_id: 1008,
+			product_slug: 'business-bundle',
+			product_name: 'WordPress.com Business',
+			product_name_short: 'Business',
+			product_name_en: 'Business',
+			expired: false,
+			is_free: false,
+			billing_period: 'Yearly',
+			features: { active: [] },
+		},
+		isAtomic: true,
+		storageUsedBytes: 4.6 * GB,
+		maxStorageBytes: 50 * GB,
+	},
+	{
+		ID: 900000004,
+		slug: 'aperture-diaries.com',
+		name: 'Aperture Diaries',
+		URL: 'https://aperture-diaries.com',
+		tier: 'premium',
+		plan: {
+			product_id: 1003,
+			product_slug: 'value_bundle',
+			product_name: 'WordPress.com Premium',
+			product_name_short: 'Premium',
+			product_name_en: 'Premium',
+			expired: false,
+			is_free: false,
+			billing_period: 'Yearly',
+			features: { active: [] },
+		},
+		storageUsedBytes: 12.2 * GB,
+		maxStorageBytes: 13 * GB,
+		solo: true,
+	},
+];
+
+export const MOCK_BLOGGER_SITES: Site[] = MOCK_SITE_INPUTS.map( makeMockSite );
+
+export const SOLO_BLOGGER_SITE_SLUG = 'aperture-diaries.com';
+
+// Mock domains don't resolve, so the sites-list iframe preview renders
+// blank. These theme screenshots stand in for it.
+const MOCK_PREVIEW_THEME: Record< string, string > = {
+	'sunrise-stories.wordpress.com': 'lettre',
+	'coastalshots.gallery': 'dorna',
+	'lucastravels.com': 'stewart',
+	'aperture-diaries.com': 'dorna',
+};
+
+export function getMockSitePreviewImage( slug: string ): string | undefined {
+	const theme = MOCK_PREVIEW_THEME[ slug ];
+	return theme ? `https://s0.wp.com/wp-content/themes/pub/${ theme }/screenshot.png` : undefined;
+}
+
+export function getMockSitesForPersona( persona: 'developer' | 'blogger' ): Site[] {
+	const wantSolo = persona === 'blogger';
+	return MOCK_SITE_INPUTS.filter( ( input ) => Boolean( input.solo ) === wantSolo ).map(
+		( input ) => MOCK_BLOGGER_SITES.find( ( site ) => site.slug === input.slug ) as Site
+	);
+}
+
+const MOCK_INPUT_BY_SLUG = new Map( MOCK_SITE_INPUTS.map( ( input ) => [ input.slug, input ] ) );
+const MOCK_SITE_BY_SLUG = new Map(
+	MOCK_BLOGGER_SITES.map( ( site ) => [ site.slug, site ] as const )
+);
+
+export function isMockBloggerSiteSlug( slug: string ): boolean {
+	return MOCK_SITE_BY_SLUG.has( slug );
+}
+
+export function getMockBloggerSite( slug: string ): { site: Site; tier: BloggerTier } | undefined {
+	const site = MOCK_SITE_BY_SLUG.get( slug );
+	const input = MOCK_INPUT_BY_SLUG.get( slug );
+	if ( ! site || ! input ) {
+		return undefined;
+	}
+	return { site, tier: input.tier };
+}
+
+export function getMockBloggerStorage( slug: string ) {
+	const input = MOCK_INPUT_BY_SLUG.get( slug );
+	if ( ! input ) {
+		return undefined;
+	}
+	return { usedBytes: input.storageUsedBytes, maxBytes: input.maxStorageBytes };
+}
+
+const TIER_YEARLY_PRICE: Record< BloggerTier, number > = {
+	free: 0,
+	premium: 96,
+	business: 300,
+};
+
+function makeMockCurrentPlan( input: MockSiteInput ): SiteContextualPlan {
+	const price = TIER_YEARLY_PRICE[ input.tier ];
+	return {
+		formatted_original_price: `$${ price }`,
+		original_price: { amount: price, currency: 'USD' },
+		raw_price: price,
+		raw_price_integer: price * 100,
+		formatted_price: `$${ price }`,
+		raw_discount: 0,
+		raw_discount_integer: 0,
+		formatted_discount: '$0',
+		currency_code: 'USD',
+		product_id: input.plan.product_id,
+		product_slug: input.plan.product_slug,
+		product_name: input.plan.product_name ?? input.plan.product_name_short,
+		discount_reason: null,
+		cost_overrides: [],
+		is_domain_upgrade: false,
+		current_plan: true,
+		id: null,
+	};
+}
+
+function getMockQueryKeys( input: MockSiteInput ) {
+	return [
+		siteBySlugQuery( input.slug ).queryKey,
+		siteByIdQuery( input.ID ).queryKey,
+		siteMediaStorageQuery( input.ID ).queryKey,
+		siteCurrentPlanQuery( input.ID ).queryKey,
+	];
+}
+
+/**
+ * Seeds the query cache so route loaders (siteBySlugQuery, siteMediaStorageQuery,
+ * siteCurrentPlanQuery) resolve mock sites without hitting the API. The seeded
+ * entries have no observers, so they must be pinned (gcTime/staleTime Infinity)
+ * or TanStack garbage-collects them after ~5 minutes and the loaders fall
+ * through to real requests that 404. Data is written after the persisted cache
+ * is restored, or the restore would overwrite the seeds.
+ */
+export function seedMockBloggerSiteCaches() {
+	for ( const input of MOCK_SITE_INPUTS ) {
+		for ( const queryKey of getMockQueryKeys( input ) ) {
+			queryClient.setQueryDefaults( queryKey, { staleTime: Infinity, gcTime: Infinity } );
+		}
+	}
+
+	persistQueryClientPromise.then( () => {
+		for ( const input of MOCK_SITE_INPUTS ) {
+			const site = MOCK_SITE_BY_SLUG.get( input.slug ) as Site;
+			queryClient.setQueryData( siteBySlugQuery( input.slug ).queryKey, site );
+			queryClient.setQueryData( siteByIdQuery( input.ID ).queryKey, site );
+			queryClient.setQueryData( siteMediaStorageQuery( input.ID ).queryKey, {
+				max_storage_bytes_from_add_ons: 0,
+				max_storage_bytes: input.maxStorageBytes,
+				storage_used_bytes: input.storageUsedBytes,
+			} );
+			queryClient.setQueryData(
+				siteCurrentPlanQuery( input.ID ).queryKey,
+				makeMockCurrentPlan( input )
+			);
+		}
+	} );
+}

--- a/client/dashboard/sites/overview-blogger/style.scss
+++ b/client/dashboard/sites/overview-blogger/style.scss
@@ -1,0 +1,332 @@
+@import "@wordpress/base-styles/colors";
+
+.blogger-overview-preview {
+	position: relative;
+	overflow: hidden;
+
+	// The theme screenshots are tall portrait images; keep them out of the
+	// height calculation so the preview adapts to the sibling cards instead
+	// of inflating the row.
+	min-block-size: 240px;
+
+	a {
+		position: absolute;
+		inset: 0;
+		display: block;
+	}
+
+	img {
+		display: block;
+		inline-size: 100%;
+		block-size: 100%;
+		object-fit: cover;
+		object-position: top center;
+		background: $gray-100;
+		transition: transform 0.4s ease;
+	}
+
+	a:hover img,
+	a:focus-visible img {
+		transform: scale(1.04);
+	}
+
+	a:hover .blogger-overview-preview__overlay,
+	a:focus-visible .blogger-overview-preview__overlay {
+		opacity: 1;
+	}
+}
+
+.blogger-overview-preview__overlay {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: color-mix( in srgb, $gray-900 28%, transparent );
+	opacity: 0;
+	transition: opacity 0.2s ease;
+}
+
+// Visual stand-in for a DS primary button — a real <Button> can't be nested
+// inside the preview link.
+.blogger-overview-preview__label {
+	display: inline-flex;
+	align-items: center;
+	block-size: 40px;
+	padding: 0 16px;
+	background: var(--wp-components-color-accent, var(--wp-admin-theme-color));
+	color: var(--wp-components-color-accent-inverted, $white);
+	border-radius: 4px;
+	font-size: 13px;
+	font-weight: 400;
+	line-height: 1;
+}
+
+// Stretch the support card so the side column bottom-aligns with the
+// activity card next to it.
+.blogger-overview-side > .dashboard-overview-card:last-child {
+	flex-grow: 1;
+}
+
+// Stretch the activity card to the full column height so its bottom aligns
+// with the support card, keeping the "See all activity" footer pinned. The
+// wp Card wraps header/body/footer in an unclassed inner view, so the flex
+// column goes on that wrapper, not on the card itself.
+.blogger-overview-activity {
+	flex-grow: 1;
+
+	> div:first-child {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.components-card__body {
+		flex: 1 1 0;
+		// Keeps a useful list height when the row stacks and nothing constrains
+		// the card (e.g. mobile); past this, the list scrolls.
+		min-block-size: 280px;
+		overflow-y: auto;
+	}
+}
+
+.blogger-overview-support__columns {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 24px;
+	align-items: start;
+
+	@media ( max-width: 660px ) {
+		grid-template-columns: minmax(0, 1fr);
+	}
+}
+
+.blogger-overview-support__list {
+	border: 1px solid $gray-200;
+	border-radius: 8px;
+}
+
+a.blogger-overview-support__row {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 12px 16px;
+	text-decoration: none;
+	color: $gray-900;
+	fill: $gray-700;
+	font-size: 14px;
+	line-height: 20px;
+
+	+ .blogger-overview-support__row {
+		border-block-start: 1px solid $gray-100;
+	}
+
+	&:hover {
+		color: var(--wp-admin-theme-color);
+		fill: var(--wp-admin-theme-color);
+	}
+}
+
+.blogger-overview-support__row-label {
+	flex: 1;
+}
+
+.blogger-overview-support__row-indicator {
+	fill: $gray-600;
+}
+
+.blogger-overview-activity__icon {
+	box-sizing: border-box;
+	flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	inline-size: 40px;
+	block-size: 40px;
+	border-radius: 50%;
+	background: $gray-100;
+	fill: $gray-700;
+}
+
+.blogger-overview-promo {
+	box-sizing: border-box;
+
+	// The sibling secondary-cards row inherits `order: 2` from the shared
+	// overview styles; keep the banner after it.
+	order: 3;
+	border-radius: 8px;
+	padding: 48px;
+
+	@media ( max-width: 660px ) {
+		padding: 24px;
+	}
+}
+
+h2.blogger-overview-promo__title {
+	margin: 0;
+	font-family: Recoleta, serif;
+	font-size: 32px;
+	font-weight: 400;
+	line-height: 1.25;
+}
+
+p.blogger-overview-promo__description {
+	margin: 0;
+	font-size: 14px;
+	line-height: 20px;
+	max-inline-size: 480px;
+}
+
+// Free: warm sunrise, light — a domain is an aspiration, not a warning.
+.blogger-overview-promo.is-domain {
+	background: linear-gradient(
+		120deg,
+		color-mix( in srgb, $alert-yellow 30%, $white ) 0%,
+		color-mix( in srgb, $alert-red 12%, $white ) 100%
+	);
+
+	h2.blogger-overview-promo__title {
+		color: $gray-900;
+	}
+
+	p.blogger-overview-promo__description {
+		color: $gray-700;
+	}
+}
+
+.blogger-overview-promo__browser {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 12px 16px;
+	border-radius: 8px;
+	background: $white;
+	box-shadow: 0 8px 24px color-mix( in srgb, $gray-900 12%, transparent );
+}
+
+.blogger-overview-promo__browser-dots {
+	display: flex;
+	gap: 5px;
+
+	i {
+		inline-size: 8px;
+		block-size: 8px;
+		border-radius: 50%;
+		background: $gray-200;
+	}
+}
+
+.blogger-overview-promo__browser-address {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 6px 14px;
+	border-radius: 16px;
+	background: $gray-100;
+	color: $gray-900;
+	font-size: 14px;
+	font-weight: 500;
+
+	svg {
+		fill: $alert-green;
+	}
+}
+
+// Premium: cool dawn light — Business as a growth kit, not a warning.
+.blogger-overview-promo.is-grow {
+	background: linear-gradient(
+		120deg,
+		color-mix( in srgb, var( --wp-admin-theme-color ) 14%, $white ) 0%,
+		color-mix( in srgb, $alert-green 14%, $white ) 100%
+	);
+
+	h2.blogger-overview-promo__title {
+		color: $gray-900;
+	}
+
+	p.blogger-overview-promo__description {
+		color: $gray-700;
+	}
+}
+
+.blogger-overview-promo__perks {
+	display: grid;
+	grid-template-columns: repeat( 2, auto );
+	gap: 12px;
+}
+
+.blogger-overview-promo__perk {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	padding: 10px 16px;
+	border-radius: 8px;
+	background: $white;
+	box-shadow: 0 4px 16px color-mix( in srgb, $gray-900 10%, transparent );
+	color: $gray-900;
+	font-size: 13px;
+	font-weight: 500;
+
+	svg {
+		flex-shrink: 0;
+		fill: var( --wp-admin-theme-color );
+	}
+}
+
+// Business: deep green prosperity — money talks in money colors.
+.blogger-overview-promo.is-monetize {
+	background: linear-gradient(
+		120deg,
+		$gray-900 0%,
+		color-mix( in srgb, $alert-green 45%, $black ) 100%
+	);
+
+	h2.blogger-overview-promo__title {
+		color: $white;
+	}
+
+	p.blogger-overview-promo__description {
+		color: $gray-200;
+	}
+}
+
+.blogger-overview-promo__earnings {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding: 20px 24px;
+	border-radius: 8px;
+	background: $white;
+	box-shadow: 0 8px 24px color-mix( in srgb, $black 25%, transparent );
+}
+
+.blogger-overview-promo__earnings-label {
+	color: $gray-700;
+	font-size: 12px;
+	line-height: 16px;
+	max-inline-size: 200px;
+}
+
+.blogger-overview-promo__earnings-value {
+	color: $gray-900;
+	font-family: Recoleta, serif;
+	font-size: 32px;
+	line-height: 1.1;
+
+	small {
+		color: $gray-700;
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+		font-size: 13px;
+	}
+}
+
+.blogger-overview-promo .components-button.blogger-overview-promo__button-inverted {
+	color: $gray-900;
+	background: $white;
+	border-radius: 2px;
+
+	&:hover:not( :disabled ),
+	&:focus:not( :disabled ) {
+		color: $gray-900;
+		background: $gray-100;
+	}
+}

--- a/client/dashboard/sites/overview-developer/index.tsx
+++ b/client/dashboard/sites/overview-developer/index.tsx
@@ -1,0 +1,889 @@
+/**
+ * Prototype: site overview for developers & power users (Advanced workspace).
+ * Rendered for the three mock blogger sites. All tiers share the same layout
+ * and cards; content varies per site, and cards whose features require the
+ * Business plan (staging, deployments, SSH, logs, plugins) become upsells on
+ * Free/Premium. Color communicates urgency: healthy states are green or
+ * neutral, anything that deserves attention is amber.
+ */
+import { Badge } from '@automattic/ui';
+import {
+	__experimentalGrid as Grid,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+	privateApis,
+} from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
+import {
+	backup,
+	cloudUpload,
+	code,
+	copy,
+	key,
+	lockOutline,
+	moreVertical,
+	wordpress,
+} from '@wordpress/icons';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+import clsx from 'clsx';
+import { useState } from 'react';
+import { Card, CardBody, CardHeader } from '../../components/card';
+import OverviewCard from '../../components/overview-card';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { SectionHeader } from '../../components/section-header';
+import { Stat } from '../../components/stat';
+import { SummaryButtonCardFooter } from '../../components/summary-button-card-footer';
+import { Text } from '../../components/text';
+import { getMockBloggerSite, SOLO_BLOGGER_SITE_SLUG } from './../overview-blogger/mock-sites';
+import type { BloggerTier } from './../overview-blogger/mock-sites';
+import type { Site } from '@automattic/api-core';
+import type { ReactNode } from 'react';
+
+import './style.scss';
+
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/components'
+);
+
+const { Tabs } = unlock( privateApis );
+
+const SSH_COMMAND = 'ssh lucastravels.wordpress.com@sftp.wp.com';
+
+const planLink = ( site: Site ) => `https://wordpress.com/plans/${ site.slug }`;
+
+// Stretches the SectionHeader across the card so its actions right-align;
+// same idiom as overview-domains-card.
+const CARD_HEADER_STYLE: React.CSSProperties = {
+	flexDirection: 'column',
+	alignItems: 'stretch',
+};
+
+interface Vital {
+	strapline: string;
+	metric: string;
+	description: string;
+	tone?: 'warning';
+}
+
+const TIER_VITALS: Record< BloggerTier, Vital[] > = {
+	free: [
+		{ strapline: 'Uptime (30d)', metric: '99.98%', description: 'No incidents' },
+		{ strapline: 'Response time', metric: '412 ms', description: 'avg, 24h' },
+		{ strapline: 'Cache hit rate', metric: '88%', description: 'edge cache' },
+		{ strapline: 'Visitors (7d)', metric: '214', description: '+3% week over week' },
+		{ strapline: 'Requests (7d)', metric: '3.1k', description: '+2% week over week' },
+	],
+	premium: [
+		{ strapline: 'Uptime (30d)', metric: '99.99%', description: 'No incidents' },
+		{ strapline: 'Response time', metric: '268 ms', description: 'avg, 24h' },
+		{ strapline: 'Cache hit rate', metric: '93%', description: 'edge cache' },
+		{ strapline: 'Visitors (7d)', metric: '1.8k', description: '+12% week over week' },
+		{ strapline: 'Requests (7d)', metric: '12.4k', description: '+9% week over week' },
+	],
+	business: [
+		{ strapline: 'Uptime (30d)', metric: '99.99%', description: 'No incidents' },
+		{ strapline: 'Response time', metric: '187 ms', description: 'avg, 24h' },
+		{ strapline: 'Cache hit rate', metric: '96%', description: 'edge cache' },
+		{
+			strapline: 'PHP errors (24h)',
+			metric: '3',
+			description: '2 warnings, 1 deprecated',
+			tone: 'warning',
+		},
+		{ strapline: 'Requests (7d)', metric: '58.2k', description: '+6% week over week' },
+	],
+};
+
+interface EnvRow {
+	label: string;
+	value: ReactNode;
+}
+
+function EnvRows( { rows }: { rows: EnvRow[] } ) {
+	return (
+		<div className="dev-overview-env__rows">
+			{ rows.map( ( row ) => (
+				<HStack key={ row.label } justify="space-between" alignment="center" spacing={ 4 }>
+					<Text variant="muted" size={ 12 } lineHeight="20px">
+						{ row.label }
+					</Text>
+					{ typeof row.value === 'string' ? (
+						<Text size={ 12 } lineHeight="20px" style={ { textAlign: 'end' } }>
+							{ row.value }
+						</Text>
+					) : (
+						row.value
+					) }
+				</HStack>
+			) ) }
+		</div>
+	);
+}
+
+function EnvironmentCard( {
+	title,
+	badge,
+	badgeIntent,
+	rows,
+	footerTitle,
+	footerHref,
+}: {
+	title: string;
+	badge: string;
+	badgeIntent?: 'success' | 'warning';
+	rows: EnvRow[];
+	footerTitle?: string;
+	footerHref?: string;
+} ) {
+	return (
+		<Card role="article" className="dev-overview-env">
+			<CardHeader style={ CARD_HEADER_STYLE }>
+				<SectionHeader
+					title={ title }
+					level={ 3 }
+					actions={ <Badge intent={ badgeIntent }>{ badge }</Badge> }
+				/>
+			</CardHeader>
+			<CardBody>
+				<EnvRows rows={ rows } />
+			</CardBody>
+			{ footerTitle && footerHref && (
+				<SummaryButtonCardFooter title={ footerTitle } href={ footerHref } density="medium" />
+			) }
+		</Card>
+	);
+}
+
+const TIER_ACTIVE_THEME: Record< BloggerTier, string > = {
+	free: 'Stewart',
+	premium: 'Dorna',
+	business: 'Lente',
+};
+
+function SoftwareCard( { site, tier }: { site: Site; tier: BloggerTier } ) {
+	const isBusiness = tier === 'business';
+
+	return (
+		<Card role="article" className="dev-overview-fill">
+			<CardHeader style={ CARD_HEADER_STYLE }>
+				<SectionHeader title="Software" level={ 3 } />
+			</CardHeader>
+			<CardBody>
+				<EnvRows
+					rows={ [
+						{
+							label: 'WordPress',
+							value: (
+								<HStack spacing={ 2 } justify="flex-end" expanded={ false }>
+									<Text size={ 12 } lineHeight="20px">
+										7.0.1
+									</Text>
+									<Badge intent="success">Up to date</Badge>
+								</HStack>
+							),
+						},
+						{
+							label: 'PHP',
+							value: isBusiness ? (
+								<HStack spacing={ 2 } justify="flex-end" expanded={ false }>
+									<Text size={ 12 } lineHeight="20px">
+										8.3
+									</Text>
+									<Button
+										variant="link"
+										size="small"
+										href={ `https://wordpress.com/hosting-config/${ site.slug }` }
+									>
+										Change
+									</Button>
+								</HStack>
+							) : (
+								'8.3'
+							),
+						},
+						isBusiness
+							? {
+									label: 'Plugin updates',
+									value: <Badge intent="warning">2 available</Badge>,
+							  }
+							: {
+									label: 'Plugins',
+									value: (
+										<Button variant="link" size="small" href={ planLink( site ) }>
+											Available on Business
+										</Button>
+									),
+							  },
+						{
+							label: 'Vulnerabilities',
+							value: <Badge intent="success">None detected</Badge>,
+						},
+						{ label: 'Active theme', value: TIER_ACTIVE_THEME[ tier ] },
+						{
+							label: 'Malware scan',
+							value: isBusiness ? 'Clean · 2h ago' : 'Managed by WordPress.com',
+						},
+					] }
+				/>
+			</CardBody>
+			{ isBusiness ? (
+				<SummaryButtonCardFooter
+					title="Review plugin updates"
+					href={ `${ site.options?.admin_url }plugins.php` }
+					density="medium"
+				/>
+			) : (
+				<SummaryButtonCardFooter
+					title="Upgrade to install plugins"
+					href={ planLink( site ) }
+					density="medium"
+				/>
+			) }
+		</Card>
+	);
+}
+
+const TIER_SCORES: Record< BloggerTier, { desktop: number; mobile: number; lastRun: string } > = {
+	free: { desktop: 88, mobile: 71, lastRun: '1 day ago' },
+	premium: { desktop: 91, mobile: 78, lastRun: '3 days ago' },
+	business: { desktop: 82, mobile: 74, lastRun: '2 hours ago' },
+};
+
+function ScoreStat( { label, score }: { label: string; score: number } ) {
+	const isGood = score >= 90;
+	return (
+		<Stat
+			density="high"
+			strapline={ label }
+			metric={ String( score ) }
+			description={ isGood ? 'Excellent' : 'Needs Improvement' }
+			progressValue={ score }
+			progressLabel={ `${ score } out of 100` }
+			progressColor={ isGood ? 'alert-green' : 'alert-yellow' }
+		/>
+	);
+}
+
+function SpeedTestCard( { site, tier }: { site: Site; tier: BloggerTier } ) {
+	const scores =
+		site.slug === SOLO_BLOGGER_SITE_SLUG
+			? { desktop: 76, mobile: 58, lastRun: '5 hours ago' }
+			: TIER_SCORES[ tier ];
+
+	return (
+		<Card role="article" className="dev-overview-fill">
+			<CardHeader style={ CARD_HEADER_STYLE }>
+				<SectionHeader
+					title="Performance test"
+					level={ 3 }
+					actions={
+						<Button variant="secondary" size="compact">
+							Run test
+						</Button>
+					}
+				/>
+			</CardHeader>
+			<CardBody>
+				<VStack spacing={ 4 }>
+					<ScoreStat label="Desktop score" score={ scores.desktop } />
+					<ScoreStat label="Mobile score" score={ scores.mobile } />
+					<Text variant="muted" size={ 12 } lineHeight="20px">
+						Last test ran { scores.lastRun }.
+					</Text>
+				</VStack>
+			</CardBody>
+			<SummaryButtonCardFooter
+				title="Performance report"
+				href={ `/sites/${ site.slug }/performance` }
+				density="medium"
+			/>
+		</Card>
+	);
+}
+
+const TIER_PLAN_META: Record<
+	BloggerTier,
+	{ planName: string; storageUsed: string; storageMax: string; storagePercent: number }
+> = {
+	free: { planName: 'Free plan', storageUsed: '0.6 GB', storageMax: '1 GB', storagePercent: 60 },
+	premium: {
+		planName: 'Premium plan',
+		storageUsed: '3.2 GB',
+		storageMax: '13 GB',
+		storagePercent: 25,
+	},
+	business: {
+		planName: 'Business plan',
+		storageUsed: '4.6 GB',
+		storageMax: '50 GB',
+		storagePercent: 9,
+	},
+};
+
+function ResourcesCard( { site, tier }: { site: Site; tier: BloggerTier } ) {
+	const isBusiness = tier === 'business';
+	const meta =
+		site.slug === SOLO_BLOGGER_SITE_SLUG
+			? {
+					planName: 'Premium plan',
+					storageUsed: '12.2 GB',
+					storageMax: '13 GB',
+					storagePercent: 94,
+			  }
+			: TIER_PLAN_META[ tier ];
+
+	return (
+		<Card role="article" className="dev-overview-fill">
+			<CardHeader style={ CARD_HEADER_STYLE }>
+				<SectionHeader
+					title="Plan & resources"
+					level={ 3 }
+					actions={ <Badge>{ meta.planName }</Badge> }
+				/>
+			</CardHeader>
+			<CardBody>
+				<VStack spacing={ 4 }>
+					<Stat
+						density="high"
+						strapline="Storage"
+						metric={ meta.storageUsed }
+						description={ meta.storageMax }
+						progressValue={ meta.storagePercent }
+						progressLabel={ `${ meta.storagePercent }%` }
+						progressColor={ meta.storagePercent >= 90 ? 'alert-red' : undefined }
+					/>
+					{ isBusiness && (
+						<Stat
+							density="high"
+							strapline="CPU load"
+							metric="11%"
+							description="avg, 24h"
+							progressValue={ 11 }
+							progressLabel="11%"
+						/>
+					) }
+					<Stat density="high" strapline="Bandwidth" metric="Unlimited" />
+					{ ! isBusiness && (
+						<Text variant="muted" size={ 12 } lineHeight="20px">
+							CPU and server metrics come with the Business plan.
+						</Text>
+					) }
+				</VStack>
+			</CardBody>
+			<SummaryButtonCardFooter title="Manage plan" href={ planLink( site ) } density="medium" />
+		</Card>
+	);
+}
+
+function EnvironmentsSection( {
+	site,
+	tier,
+	columns,
+	gap,
+}: {
+	site: Site;
+	tier: BloggerTier;
+	columns: number;
+	gap: number;
+} ) {
+	const isBusiness = tier === 'business';
+
+	return (
+		<VStack spacing={ 4 }>
+			<SectionHeader title="Environments" level={ 2 } />
+			<Grid columns={ columns } gap={ gap }>
+				<EnvironmentCard
+					title="Production"
+					badge="Live"
+					badgeIntent="success"
+					rows={
+						isBusiness
+							? [
+									{ label: 'URL', value: 'lucastravels.com' },
+									{ label: 'WordPress', value: '7.0.1' },
+									{ label: 'PHP', value: '8.3' },
+									{ label: 'Object cache', value: 'Enabled' },
+									{ label: 'CDN', value: 'Active' },
+							  ]
+							: [
+									{ label: 'URL', value: site.slug },
+									{ label: 'WordPress', value: '7.0.1' },
+									{ label: 'PHP', value: '8.3' },
+									{ label: 'CDN', value: 'Active' },
+							  ]
+					}
+					footerTitle={ isBusiness ? 'Server settings' : 'Site settings' }
+					footerHref={
+						isBusiness
+							? `https://wordpress.com/hosting-config/${ site.slug }`
+							: `/sites/${ site.slug }/settings`
+					}
+				/>
+				{ isBusiness ? (
+					<EnvironmentCard
+						title="Staging"
+						badge="Synced"
+						badgeIntent="success"
+						rows={ [
+							{ label: 'URL', value: 'staging-4021.lucastravels.com' },
+							{ label: 'WordPress', value: '7.0.1' },
+							{ label: 'PHP', value: '8.3' },
+							{ label: 'Last synced', value: '2 days ago' },
+						] }
+						footerTitle="Manage staging"
+						footerHref={ `https://wordpress.com/staging-site/${ site.slug }` }
+					/>
+				) : (
+					<OverviewCard
+						title="Staging"
+						icon={ copy }
+						heading="Test before you ship"
+						description="A one-click copy of your site to try changes safely. Included in the Business plan."
+						intent="upsell"
+						link={ planLink( site ) }
+					/>
+				) }
+				{ isBusiness ? (
+					<EnvironmentCard
+						title="Deployments"
+						badge="Passing"
+						badgeIntent="success"
+						rows={ [
+							{ label: 'Repository', value: 'lucasmdo/lucastravels-theme' },
+							{ label: 'Branch', value: 'main' },
+							{ label: 'Last deploy', value: '2h ago · a1b2c3d' },
+							{ label: 'Mode', value: 'Automatic on push' },
+						] }
+						footerTitle="Deployment history"
+						footerHref={ `https://wordpress.com/github-deployments/${ site.slug }` }
+					/>
+				) : (
+					<OverviewCard
+						title="Deployments"
+						icon={ cloudUpload }
+						heading="Deploy from GitHub"
+						description="Connect a repository and ship on every push. Included in the Business plan."
+						intent="upsell"
+						link={ planLink( site ) }
+					/>
+				) }
+			</Grid>
+		</VStack>
+	);
+}
+
+function AccessSection( {
+	site,
+	tier,
+	columns,
+	gap,
+}: {
+	site: Site;
+	tier: BloggerTier;
+	columns: number;
+	gap: number;
+} ) {
+	const isBusiness = tier === 'business';
+
+	return (
+		<VStack spacing={ 4 }>
+			<SectionHeader title="Access & safety" level={ 2 } />
+			<Grid columns={ columns } gap={ gap }>
+				<OverviewCard
+					title="SSL certificate"
+					icon={ lockOutline }
+					heading="Valid"
+					description="Let’s Encrypt · renews automatically on September 12, 2026."
+					intent="success"
+				/>
+				{ isBusiness ? (
+					<OverviewCard
+						title="Developer access"
+						icon={ key }
+						heading="SSH enabled"
+						description="2 SSH keys · SFTP on · WP-CLI available."
+						link={ `https://wordpress.com/hosting-config/${ site.slug }` }
+					/>
+				) : (
+					<OverviewCard
+						title="Developer access"
+						icon={ key }
+						heading="SSH & WP-CLI"
+						description="Shell access, SFTP, and WP-CLI are included in the Business plan."
+						intent="upsell"
+						link={ planLink( site ) }
+					/>
+				) }
+				{ isBusiness ? (
+					<OverviewCard
+						title="Backups"
+						icon={ backup }
+						heading="1h ago"
+						description="30 restore points · daily and on-demand."
+						intent="success"
+						link={ `https://wordpress.com/backup/${ site.slug }` }
+					/>
+				) : (
+					<OverviewCard
+						title="Backups"
+						icon={ backup }
+						heading="Daily backups"
+						description="One-click restores and 30 restore points come with the Business plan."
+						intent="upsell"
+						link={ planLink( site ) }
+					/>
+				) }
+			</Grid>
+		</VStack>
+	);
+}
+
+type LogKind = 'php' | 'deploy' | 'crawler';
+
+const LOG_FILTERS: { value: LogKind | 'all'; label: string }[] = [
+	{ value: 'all', label: 'All' },
+	{ value: 'php', label: 'PHP' },
+	{ value: 'deploy', label: 'Deploys' },
+];
+
+// Severity badge classes reuse the color overrides from the Logs pages
+// (badge--warning, badge--deprecated, …) so both surfaces stay in sync.
+const LOG_LINES: {
+	severity: string;
+	severityClass: string;
+	date: string;
+	message: string;
+	kind: LogKind;
+}[] = [
+	{
+		severity: 'AI Crawler',
+		severityClass: 'crawler',
+		date: 'Jul 17, 2026, 6:12 AM',
+		message: 'GPTBot/2.1 fetched /sitemap.xml and 48 posts (200)',
+		kind: 'crawler',
+	},
+	{
+		severity: 'Warning',
+		severityClass: 'warning',
+		date: 'Jul 16, 2026, 2:02 PM',
+		message:
+			'PHP Warning: Undefined array key "lat" in wp-content/plugins/jetpack/modules/geo/geo.php on line 87',
+		kind: 'php',
+	},
+	{
+		severity: 'Deprecated',
+		severityClass: 'deprecated',
+		date: 'Jul 16, 2026, 9:47 AM',
+		message:
+			'PHP Deprecated: strpos(): Passing null to parameter #1 in wp-content/themes/lente/functions.php on line 142',
+		kind: 'php',
+	},
+	{
+		severity: 'Warning',
+		severityClass: 'warning',
+		date: 'Jul 15, 2026, 10:15 PM',
+		message:
+			'PHP Warning: Attempt to read property "ID" on null in wp-content/plugins/related-posts/render.php on line 51',
+		kind: 'php',
+	},
+	{
+		severity: 'AI Crawler',
+		severityClass: 'crawler',
+		date: 'Jul 15, 2026, 8:41 PM',
+		message: 'ClaudeBot/1.0 crawled 214 pages · robots.txt honored',
+		kind: 'crawler',
+	},
+	{
+		severity: 'Deploy',
+		severityClass: 'deploy',
+		date: 'Jul 14, 2026, 6:03 PM',
+		message: 'Deployment of lucasmdo/lucastravels-theme@main finished in 41s (a1b2c3d)',
+		kind: 'deploy',
+	},
+	{
+		severity: 'Deploy',
+		severityClass: 'deploy',
+		date: 'Jul 12, 2026, 9:15 AM',
+		message: 'Deployment of lucasmdo/lucastravels-theme@main finished in 38s (e4f5a6b)',
+		kind: 'deploy',
+	},
+];
+
+function LogsCard( { site, tier }: { site: Site; tier: BloggerTier } ) {
+	const [ filter, setFilter ] = useState< LogKind | 'all' >( 'all' );
+	const isBusiness = tier === 'business';
+	const visibleLines =
+		filter === 'all' ? LOG_LINES : LOG_LINES.filter( ( line ) => line.kind === filter );
+
+	if ( ! isBusiness ) {
+		return (
+			<Card role="article" className="dev-overview-logs">
+				<CardHeader style={ CARD_HEADER_STYLE }>
+					<SectionHeader title="Latest log entries" level={ 3 } />
+				</CardHeader>
+				<CardBody>
+					<VStack spacing={ 3 } alignment="left">
+						<Text variant="muted">
+							PHP error and web server logs are included in the Business plan. Watch errors,
+							deploys, and traffic as they happen.
+						</Text>
+						<Button variant="secondary" size="compact" href={ planLink( site ) }>
+							Upgrade to Business
+						</Button>
+					</VStack>
+				</CardBody>
+			</Card>
+		);
+	}
+
+	return (
+		<Card role="article" className="dev-overview-logs">
+			<CardHeader style={ CARD_HEADER_STYLE }>
+				<SectionHeader
+					title="Latest log entries"
+					level={ 3 }
+					actions={
+						<Button
+							variant="secondary"
+							size="compact"
+							href={ `https://wordpress.com/site-logs/${ site.slug }/php` }
+						>
+							Open logs
+						</Button>
+					}
+				/>
+			</CardHeader>
+			<CardBody>
+				<Tabs
+					selectedTabId={ filter }
+					onSelect={ ( tabId: string | null | undefined ) =>
+						setFilter( ( tabId ?? 'all' ) as LogKind | 'all' )
+					}
+				>
+					<VStack spacing={ 3 }>
+						<Tabs.TabList>
+							{ LOG_FILTERS.map( ( { value, label } ) => (
+								<Tabs.Tab key={ value } tabId={ value }>
+									{ label }
+								</Tabs.Tab>
+							) ) }
+						</Tabs.TabList>
+						<Tabs.TabPanel tabId={ filter }>
+							<table className="dev-overview-logs__table">
+								<thead>
+									<tr>
+										<th scope="col">Severity</th>
+										<th scope="col">Date & time (UTC)</th>
+										<th scope="col">Message</th>
+									</tr>
+								</thead>
+								<tbody>
+									{ visibleLines.map( ( line ) => (
+										<tr key={ line.date }>
+											<td>
+												<Badge intent="default" className={ `badge--${ line.severityClass }` }>
+													{ line.severity }
+												</Badge>
+											</td>
+											<td className="dev-overview-logs__date">{ line.date }</td>
+											<td>{ line.message }</td>
+										</tr>
+									) ) }
+								</tbody>
+							</table>
+						</Tabs.TabPanel>
+					</VStack>
+				</Tabs>
+			</CardBody>
+		</Card>
+	);
+}
+
+// Developer-flavored Business upsell: the pitch is the platform this page
+// keeps showing as locked — SSH/WP-CLI, plugins, staging, deployments, logs.
+// Business sites get no banner; there is nothing left to sell.
+const DEV_PROMO_CONTENT: Record<
+	'free' | 'premium',
+	{ title: string; body: string; terminal: { command: string; comment?: string }[] }
+> = {
+	free: {
+		title: 'Bring your own workflow',
+		body: 'Business unlocks the developer platform under this site — SSH and WP-CLI, custom plugins and themes, a staging site, and GitHub deployments.',
+		terminal: [
+			{ command: 'wp plugin install wp-graphql --activate' },
+			{ command: 'git push origin main', comment: '# deploys in ~40s' },
+		],
+	},
+	premium: {
+		title: 'One plan away from full control',
+		body: 'Everything locked on this page ships with Business — SSH and WP-CLI, staging, GitHub deployments, and live server logs.',
+		terminal: [
+			{ command: 'wp theme activate dorna' },
+			{ command: 'tail -f logs/php-errors.log' },
+		],
+	},
+};
+
+function DevPromoBanner( { site, tier }: { site: Site; tier: BloggerTier } ) {
+	if ( tier === 'business' ) {
+		return null;
+	}
+	const content = DEV_PROMO_CONTENT[ tier ];
+	const terminalLines = [ { command: `ssh ${ site.slug }@sftp.wp.com` }, ...content.terminal ];
+
+	return (
+		<div className="dev-overview-promo">
+			<VStack spacing={ 5 } alignment="left">
+				<h2 className="dev-overview-promo__title">{ content.title }</h2>
+				<p className="dev-overview-promo__body">{ content.body }</p>
+				<Button
+					__next40pxDefaultSize
+					variant="primary"
+					className="dev-overview-promo__button"
+					href={ planLink( site ) }
+				>
+					Upgrade to Business
+				</Button>
+			</VStack>
+			<div className="dev-overview-promo__terminal" aria-hidden="true">
+				<div className="dev-overview-promo__terminal-bar">
+					<i></i>
+					<i></i>
+					<i></i>
+				</div>
+				{ terminalLines.map( ( line ) => (
+					<p key={ line.command } className="dev-overview-promo__terminal-line">
+						<span className="dev-overview-promo__prompt">$</span> { line.command }
+						{ line.comment && (
+							<span className="dev-overview-promo__comment"> { line.comment }</span>
+						) }
+					</p>
+				) ) }
+			</div>
+		</div>
+	);
+}
+
+function QuickActionsMenu( { site }: { site: Site } ) {
+	return (
+		<DropdownMenu icon={ moreVertical } label="Quick actions">
+			{ ( { onClose }: { onClose: () => void } ) => (
+				<MenuGroup>
+					<MenuItem onClick={ onClose }>Purge edge cache</MenuItem>
+					<MenuItem onClick={ onClose }>Clear object cache</MenuItem>
+					<MenuItem
+						onClick={ () => {
+							window.open(
+								`https://wordpress.com/hosting-config/${ site.slug }`,
+								'_blank',
+								'noreferrer,noopener'
+							);
+							onClose();
+						} }
+					>
+						Open phpMyAdmin ↗
+					</MenuItem>
+					<MenuItem onClick={ onClose }>Download latest backup</MenuItem>
+				</MenuGroup>
+			) }
+		</DropdownMenu>
+	);
+}
+
+export default function DeveloperSiteOverview( { siteSlug }: { siteSlug: string } ) {
+	const isSmallViewport = useViewportMatch( 'medium', '<' );
+	const mock = getMockBloggerSite( siteSlug );
+
+	if ( ! mock ) {
+		return null;
+	}
+
+	const { site, tier } = mock;
+	const isBusiness = tier === 'business';
+	const spacing = isSmallViewport ? 4 : 6;
+	const envColumns = isSmallViewport ? 1 : 3;
+
+	return (
+		<PageLayout
+			size="large"
+			header={
+				<PageHeader
+					title={ site.name }
+					description={
+						<Text variant="muted">WordPress 7.0.1 · PHP 8.3 · Hosted on WordPress.com</Text>
+					}
+					actions={
+						<>
+							{ isBusiness && <QuickActionsMenu site={ site } /> }
+							{ isBusiness && (
+								<Button
+									__next40pxDefaultSize
+									variant="secondary"
+									icon={ code }
+									onClick={ () => window.navigator.clipboard?.writeText( SSH_COMMAND ) }
+								>
+									Copy SSH command
+								</Button>
+							) }
+							<Button
+								__next40pxDefaultSize
+								variant="primary"
+								href={ site.options?.admin_url }
+								icon={ wordpress }
+							>
+								WP Admin
+							</Button>
+						</>
+					}
+				/>
+			}
+		>
+			<VStack alignment="stretch" spacing={ isSmallViewport ? 5 : 10 }>
+				<Card role="article">
+					<CardBody>
+						<Grid columns={ isSmallViewport ? 2 : 5 } gap={ spacing }>
+							{ TIER_VITALS[ tier ].map( ( vital ) => (
+								<div
+									key={ vital.strapline }
+									className={ clsx( 'dev-overview-vital', {
+										'is-warning': vital.tone === 'warning',
+									} ) }
+								>
+									<Stat
+										density="high"
+										strapline={ vital.strapline }
+										metric={ vital.metric }
+										description={ vital.description }
+									/>
+								</div>
+							) ) }
+						</Grid>
+					</CardBody>
+				</Card>
+
+				<VStack spacing={ 4 }>
+					<SectionHeader title="Site health" level={ 2 } />
+					<Grid columns={ envColumns } gap={ spacing }>
+						<SoftwareCard site={ site } tier={ tier } />
+						<SpeedTestCard site={ site } tier={ tier } />
+						<ResourcesCard site={ site } tier={ tier } />
+					</Grid>
+				</VStack>
+
+				<EnvironmentsSection site={ site } tier={ tier } columns={ envColumns } gap={ spacing } />
+
+				<AccessSection site={ site } tier={ tier } columns={ envColumns } gap={ spacing } />
+
+				<LogsCard site={ site } tier={ tier } />
+
+				<DevPromoBanner site={ site } tier={ tier } />
+			</VStack>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/sites/overview-developer/style.scss
+++ b/client/dashboard/sites/overview-developer/style.scss
@@ -1,0 +1,186 @@
+@import "@wordpress/base-styles/colors";
+
+// Readable amber for warning text and scores; the raw $alert-yellow is too
+// light against a white surface.
+$dev-overview-warning-text: color-mix( in srgb, $alert-red 55%, $alert-yellow );
+
+.dev-overview-env__rows {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+// Cards that sit in a grid row with footers: the wp Card wraps its
+// header/body/footer in an unclassed inner view, so the flex column goes on
+// that wrapper. The body absorbs the stretch and the footers bottom-align
+// across the row.
+.dev-overview-fill,
+.dev-overview-env {
+	> div:first-child {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.components-card__body {
+		flex-grow: 1;
+	}
+}
+
+// Urgency color for vitals that deserve attention.
+.dev-overview-vital.is-warning .dashboard-stat__metric {
+	color: $dev-overview-warning-text;
+}
+
+// Business upsell banner for developers: dark surface, terminal mock instead
+// of the creator-flavored illustrations.
+.dev-overview-promo {
+	box-sizing: border-box;
+	display: grid;
+	grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+	gap: 48px;
+	align-items: center;
+	border-radius: 8px;
+	padding: 48px;
+	background: linear-gradient(
+		120deg,
+		$gray-900 0%,
+		color-mix( in srgb, var( --wp-admin-theme-color ) 35%, $black ) 100%
+	);
+
+	@media ( max-width: 782px ) {
+		grid-template-columns: minmax(0, 1fr);
+		gap: 24px;
+		padding: 24px;
+	}
+}
+
+h2.dev-overview-promo__title {
+	margin: 0;
+	color: $white;
+	font-size: 28px;
+	font-weight: 600;
+	line-height: 1.25;
+}
+
+p.dev-overview-promo__body {
+	margin: 0;
+	color: $gray-200;
+	font-size: 14px;
+	line-height: 20px;
+	max-inline-size: 480px;
+}
+
+.dev-overview-promo .components-button.dev-overview-promo__button {
+	align-self: flex-start;
+	background: $white;
+	color: $gray-900;
+
+	&:hover:not( :disabled ),
+	&:focus:not( :disabled ) {
+		background: $gray-100;
+		color: $gray-900;
+	}
+}
+
+.dev-overview-promo__terminal {
+	border-radius: 8px;
+	padding: 16px 20px 20px;
+	background: color-mix( in srgb, $black 50%, $gray-900 );
+	box-shadow: 0 8px 24px color-mix( in srgb, $black 35%, transparent );
+	overflow-x: auto;
+}
+
+.dev-overview-promo__terminal-bar {
+	display: flex;
+	gap: 5px;
+	margin-block-end: 12px;
+
+	i {
+		inline-size: 8px;
+		block-size: 8px;
+		border-radius: 50%;
+		background: $gray-700;
+	}
+}
+
+p.dev-overview-promo__terminal-line {
+	margin: 0 0 8px;
+	font-family: monospace;
+	font-size: 12px;
+	line-height: 18px;
+	color: $gray-100;
+	white-space: nowrap;
+
+	&:last-child {
+		margin-block-end: 0;
+	}
+}
+
+.dev-overview-promo__prompt {
+	color: $alert-green;
+}
+
+.dev-overview-promo__comment {
+	color: $gray-600;
+}
+
+// Same table treatment as the Logs pages: severity badge, date, message.
+table.dev-overview-logs__table {
+	inline-size: 100%;
+	border-collapse: collapse;
+
+	th {
+		padding: 8px 24px 8px 0;
+		text-align: start;
+		font-size: 11px;
+		font-weight: 500;
+		line-height: 16px;
+		text-transform: uppercase;
+		color: $gray-700;
+	}
+
+	td {
+		padding: 12px 24px 12px 0;
+		border-block-start: 1px solid $gray-100;
+		font-size: 13px;
+		line-height: 20px;
+		vertical-align: middle;
+	}
+
+	th:last-child,
+	td:last-child {
+		padding-inline-end: 0;
+	}
+}
+
+.dev-overview-logs__date {
+	color: $gray-700;
+	white-space: nowrap;
+}
+
+// Severity badge colors, matching the Logs pages' overrides.
+.dev-overview-logs {
+	.badge--warning {
+		--base-color: var(--studio-yellow-50);
+		background-color: var(--studio-yellow-5);
+		color: var(--studio-yellow-80);
+	}
+
+	.badge--deprecated {
+		--base-color: var(--color-deprecated-blue-50);
+		background-color: var(--color-deprecated-blue-5);
+		color: var(--color-deprecated-blue-80);
+	}
+
+	.badge--deploy {
+		--base-color: var(--studio-green-50);
+		background-color: var(--studio-green-5);
+		color: var(--studio-green-80);
+	}
+
+	.badge--crawler {
+		--base-color: var(--studio-gray-50);
+		background-color: var(--studio-gray-5);
+		color: var(--studio-gray-80);
+	}
+}

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -15,6 +15,7 @@ import { useRef } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { useAppContext } from '../../app/context';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
+import { useWorkspace } from '../../app/workspace';
 import { GuidedTourContextProvider, GuidedTourStep } from '../../components/guided-tour';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -23,6 +24,9 @@ import { isSelfHostedJetpackConnected, isCommerceGarden } from '../../utils/site
 import { SitesNoticeArbiter } from '../notice-arbiter';
 import AgencySiteShareCard from '../overview-agency-site-share-card';
 import BackupCard from '../overview-backup-card';
+import BloggerSiteOverview from '../overview-blogger';
+import { isMockBloggerSiteSlug } from '../overview-blogger/mock-sites';
+import DeveloperSiteOverview from '../overview-developer';
 import DIFMUpsellCard from '../overview-difm-upsell-card';
 import DomainsCard from '../overview-domains-card';
 import OverviewFlexUsageCard from '../overview-flex-usage-card';
@@ -301,4 +305,13 @@ function SiteOverview( {
 	);
 }
 
-export default SiteOverview;
+export default function SiteOverviewRoot( props: Parameters< typeof SiteOverview >[ 0 ] ) {
+	const workspace = useWorkspace();
+	if ( isMockBloggerSiteSlug( props.siteSlug ) ) {
+		if ( workspace !== 'essential' ) {
+			return <DeveloperSiteOverview siteSlug={ props.siteSlug } />;
+		}
+		return <BloggerSiteOverview siteSlug={ props.siteSlug } />;
+	}
+	return <SiteOverview { ...props } />;
+}

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -32,6 +32,7 @@ import { getSitePlanUpgradeUrl } from '../../utils/site-url';
 import { getVisibilityLabels } from '../../utils/site-visibility';
 import { canManageSite } from '../features';
 import { useAiLaunchpad } from '../hooks/use-ai-launchpad';
+import { getMockSitePreviewImage } from '../overview-blogger/mock-sites';
 import { isSitePlanTrial } from '../plans';
 import SitePreview from '../site-preview';
 import { JetpackLogo } from './jetpack-logo';
@@ -161,6 +162,26 @@ export function SiteIconLink( props: ComponentProps< typeof SiteIcon > ) {
 export function Preview( { site }: { site: Site } ) {
 	const [ resizeListener, { width } ] = useResizeObserver();
 	const { is_deleted, is_private, URL: url } = site;
+	const mockPreviewImage = getMockSitePreviewImage( site.slug );
+
+	if ( mockPreviewImage ) {
+		return (
+			<img
+				src={ mockPreviewImage }
+				alt={ site.name }
+				loading="lazy"
+				style={ {
+					display: 'block',
+					inlineSize: '100%',
+					blockSize: '100%',
+					objectFit: 'cover',
+					objectPosition: 'top center',
+					borderRadius: 'inherit',
+				} }
+			/>
+		);
+	}
+
 	// If the site is a private A8C site, X-Frame-Options is set to same
 	// origin.
 	const iframeDisabled = is_deleted || ( site.is_a8c && is_private );

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -295,6 +295,11 @@ class MasterbarLoggedIn extends Component {
 			: [
 					[
 						{
+							label: translate( 'Discover' ),
+							url: dashboardOptIn ? dashboardLink( '/discover' ) : '/discover',
+							onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_discover_clicked' ),
+						},
+						{
 							label: translate( 'Sites' ),
 							url: dashboardOptIn ? dashboardLink( '/sites' ) : '/sites',
 							onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_sites_clicked' ),
@@ -303,6 +308,11 @@ class MasterbarLoggedIn extends Component {
 							label: translate( 'Domains' ),
 							url: dashboardOptIn ? dashboardLink( '/domains' ) : '/domains/manage',
 							onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_domains_clicked' ),
+						},
+						{
+							label: translate( 'Emails' ),
+							url: dashboardOptIn ? dashboardLink( '/emails' ) : '/mailboxes',
+							onClick: () => this.props.recordTracksEvent( 'calypso_masterbar_emails_clicked' ),
 						},
 					],
 					...( this.props.isSimpleSite
@@ -795,6 +805,7 @@ class MasterbarLoggedIn extends Component {
 					? () => this.props.recordTracksEvent( 'calypso_masterbar_edit_profile_clicked' )
 					: undefined,
 			},
+			...( this.props.additionalProfileMenuItems ?? [] ),
 			{
 				label: translate( 'Log Out' ),
 				onClick: () => {


### PR DESCRIPTION
## Proposed Changes

**Prototype only — do not merge.** This branch exists to share a running preview via Calypso Live.

* Adds a Discover page to the Multi-site Dashboard (`/discover`) with two variants: one for creators and one for developers/power users.
* Adds a workspace switcher (Essential / Advanced / Commerce), surfaced in the Howdy menu and the omnibar, that selects which variant of the Discover page and site overviews is shown.
* Adds blogger-focused and developer-focused site overview redesigns, rendered for four injected mock sites (Free, Premium ×2, Business tiers). Cards whose features require a higher plan render as upsells.
* Adds demo personas for presenting the flows: `/sites?persona=blogger` shows a single photography site in the Essential workspace; `/sites?persona=developer` restores the multi-site view in the Advanced workspace.

## Why are these changes being made?

* To gather internal feedback on workspace-aware dashboard concepts with a clickable, data-realistic prototype instead of static mocks. The mock sites are injected client-side only; real sites are unaffected.

## Testing Instructions

* Open the Calypso Live link for this PR and log in.
* Go to `/sites` — your real sites appear alongside the mock sites (Sunrise Stories, Coastal Shots, Lucas Travels).
* Open a mock site's overview and switch workspaces from the Howdy menu to compare the blogger and developer variants.
* Visit `/discover` for the Discover page; it also changes with the workspace.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)