### PR TITLE
Agents Manager: Preserve JSON-looking agent responses

### DIFF
--- a/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
@@ -75,6 +75,21 @@ describe( 'convertToolMessagesToComponents', () => {
 		expect( result ).toEqual( [ message ] );
 	} );
 
+	it.each( [ '2', '0', '-1', '2.5', 'true', 'false', 'null', '"hello"', '[]', '{}' ] )(
+		'passes through JSON-looking agent text %s unchanged',
+		( text ) => {
+			const message = createMessage( {
+				content: [ { type: 'text', text } ],
+			} );
+
+			const result = convertToolMessagesToComponents( {
+				messages: [ message ],
+			} );
+
+			expect( result ).toEqual( [ message ] );
+		}
+	);
+
 	it.each( [
 		{
 			name: 'context flags',

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -171,6 +171,14 @@ export default function convertToolMessagesToComponents( {
 			return [ message ];
 		}
 
+		if (
+			typeof textData !== 'object' ||
+			textData === null ||
+			typeof textData.tool_id !== 'string'
+		) {
+			return [ message ];
+		}
+
 		// Handle `show-component` tool message
 		if ( isShowComponentTool( textData.tool_id ) ) {
 			// If not on an editor page, show an unavailable tool message instead of the component


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOAI-768/agent-cant-answer-with-plain-numbers

## Proposed Changes

* Preserve agent text that happens to be valid JSON unless it is an actual tool envelope with a string `tool_id`.
* Add regression coverage for numeric, boolean, null, string, array, and object-shaped JSON responses.
* Keep hiding unknown real tool envelopes instead of exposing raw tool JSON.

## Why are these changes being made?

* The Agents Manager adapter attempted to parse every agent text message as JSON. A plain response such as `2` parsed successfully, was treated as an unknown tool payload, and was removed from the conversation.
* `null` could throw while the converter tried to read `tool_id`.
* Tool handling should depend on the parsed payload having the shape of a tool envelope, not merely on `JSON.parse()` succeeding.

## Testing Instructions

### Automated

* `node_modules/.bin/jest -c test/packages/jest.config.js --runInBand --testPathPattern=packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts` — 46 tests passed.
* `node_modules/.bin/jest -c test/packages/jest.config.js --runInBand --testPathPattern=agents-manager` — 440 tests passed.
* `node_modules/.bin/tsc --build packages/tsconfig.json`
* `ESLINT_USE_FLAT_CONFIG=false node_modules/.bin/eslint packages/agents-manager/src/utils/convert-tool-messages-to-components.ts packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts`
* `node_modules/.bin/prettier --check packages/agents-manager/src/utils/convert-tool-messages-to-components.ts packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts`

### Calypso

1. Run `yarn start`.
2. Open Agents Manager and ask the agent to answer with only the number `2`.
3. Confirm `2` appears in the conversation and there is no warning about an undefined tool ID.
4. Repeat with `0`, `-1`, `2.5`, `true`, and `null`.

### Sandbox (Simple/Atomic/CIAB)

1. From `apps/agents-manager`, run `yarn dev --sync` against a sandbox.
2. Open Agents Manager on the sandbox site and ask the agent to answer with only the number `2`.
3. Confirm `2` appears in the conversation and there is no warning about an undefined tool ID.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
