### PR TITLE
Emails: redirect classic email management to MSD when titan-tiers flag is on

### DIFF
--- a/client/controller/index.node.jsx
+++ b/client/controller/index.node.jsx
@@ -96,4 +96,4 @@ export const setSelectedSiteIdByOrigin = () => {};
 // eslint-disable-next-line no-unused-vars
 export const redirectIfDuplicatedView = ( wpAdminPath ) => () => {};
 // eslint-disable-next-line no-unused-vars
-export const maybeRedirectToMultiSiteDashboard = ( path ) => () => {};
+export const maybeRedirectToMultiSiteDashboard = ( path, shouldForceRedirect ) => () => {};

--- a/client/controller/index.web.jsx
+++ b/client/controller/index.web.jsx
@@ -576,15 +576,20 @@ export const redirectIfDuplicatedView = ( wpAdminPath ) => async ( context, next
 
 /**
  * Middleware to redirect a user to the multi-site dashboard if the value of
- * `hosting-dashboard-opt-in` is configured to `forced-opt-in`.
+ * `hosting-dashboard-opt-in` is configured to `forced-opt-in`, or if the
+ * optional `shouldForceRedirect` predicate returns `true`. The predicate lets
+ * callers redirect users who are not in the dashboard rollout when a page can
+ * no longer be safely served by the classic UI (e.g. behind a feature flag).
  */
-export const maybeRedirectToMultiSiteDashboard = ( path ) => ( context, next ) => {
-	const state = context.store.getState();
-	if ( hasDashboardForcedOptIn( state ) ) {
-		const redirectUrl = typeof path === 'function' ? path( context.params, context.query ) : path;
-		bumpStat( 'dashboard-redirect', 'forced-opt-in' );
-		return navigate( dashboardLink( redirectUrl ?? context.path ) );
-	}
+export const maybeRedirectToMultiSiteDashboard =
+	( path, shouldForceRedirect ) => ( context, next ) => {
+		const state = context.store.getState();
+		const isForcedOptIn = hasDashboardForcedOptIn( state );
+		if ( isForcedOptIn || shouldForceRedirect?.( context ) ) {
+			const redirectUrl = typeof path === 'function' ? path( context.params, context.query ) : path;
+			bumpStat( 'dashboard-redirect', isForcedOptIn ? 'forced-opt-in' : 'feature-flag' );
+			return navigate( dashboardLink( redirectUrl ?? context.path ) );
+		}
 
-	next();
-};
+		next();
+	};

--- a/client/my-sites/email/index.jsx
+++ b/client/my-sites/email/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { translate } from 'i18n-calypso';
 import {
@@ -77,7 +78,10 @@ export default function () {
 		],
 		handlers: [
 			setupPreferences,
-			maybeRedirectToMultiSiteDashboard( ( params ) => `/emails?domainName=${ params.domain }` ),
+			maybeRedirectToMultiSiteDashboard(
+				( params ) => `/emails?domainName=${ params.domain }`,
+				() => isEnabled( 'emails/titan-tiers' )
+			),
 			...commonHandlers,
 			controller.emailManagement,
 			makeLayout,


### PR DESCRIPTION
## Proposed Changes

* Users in the multi-site dashboard (MSD) rollout are already redirected from the classic email management page (`/email/:domain/manage/:site`) to the MSD (`/emails?domainName=<domain>`). This adds the same redirect for users who are **not** in the rollout, gated behind the `emails/titan-tiers` feature flag.
* `maybeRedirectToMultiSiteDashboard` now accepts an optional `shouldForceRedirect` predicate. The redirect fires when the user is forced-opt-in **or** the predicate returns `true`. The analytics stat distinguishes the trigger (`forced-opt-in` vs `feature-flag`).
* The domain email management route passes `() => isEnabled( 'emails/titan-tiers' )` as the predicate.

## Why are these changes being made?

* The new Titan tier functionality (Pro/Premium/Ultra) is only being built in the MSD. It will not be applied to the deprecated classic email management pages. When `emails/titan-tiers` is enabled, non-rollout users must still reach the MSD so they get the tier-aware experience rather than a stale classic page.

## Testing Instructions

* Enable the `emails/titan-tiers` feature flag.
* As a user **not** in the MSD forced-opt-in rollout, navigate to `/email/<your-domain>/manage/<site>`.
* Confirm you are redirected to `/emails?domainName=<your-domain>` on the dashboard host.
* Disable the flag and confirm non-rollout users stay on the classic page (no redirect).
* Confirm users in the forced-opt-in rollout continue to be redirected regardless of the flag.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
