### PR TITLE
Skip domains__add e2e test during MSD rollout

### DIFF
--- a/test/e2e/specs/domains/domains__add.spec.ts
+++ b/test/e2e/specs/domains/domains__add.spec.ts
@@ -10,7 +10,10 @@ test.describe(
 		skipIfNotTrunk();
 		skipIfMailosaurLimitReached();
 
-		test( 'As a user, I can add a domain to my existing site', async ( {
+		// Skipped for now; can be updated once we're sure all onboarding tests will go
+		// through the MSD flow. See https://github.com/Automattic/wp-calypso/pull/112586
+		// and https://github.com/Automattic/wp-calypso/pull/112587.
+		test.skip( 'As a user, I can add a domain to my existing site', async ( {
 			componentDomainSearch,
 			componentSidebar,
 			helperData,


### PR DESCRIPTION
## Proposed Changes

* Skip the `domains__add` e2e test (`As a user, I can add a domain to my existing site`) while the Multi-Site Dashboard (MSD) onboarding flow is being rolled out.

## Why are these changes being made?

* The onboarding flow is in transition to the MSD flow, which makes this test unreliable. Skipping it avoids false failures during the rollout. The test can be re-enabled once all onboarding tests are confirmed to go through the MSD flow. See #112586 and #112587.

## Testing Instructions

* CI: confirm the `domains__add` spec is skipped rather than run.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
