### PR TITLE
Revert "Dashboard: re-enable percentage-based rollout in all environments"

### DIFF
--- a/client/dashboard/utils/hosting-dashboard-enrollment.ts
+++ b/client/dashboard/utils/hosting-dashboard-enrollment.ts
@@ -5,7 +5,7 @@ import type { HostingDashboardOptIn } from '@automattic/api-core';
 const ROLLOUT_PERCENTAGE = 50;
 
 // When rollout begins, users registered after this ID (i.e. new users) are enrolled.
-const NEW_USER_ID_THRESHOLD = 282742932;
+const NEW_USER_ID_THRESHOLD = 282953237;
 
 /**
  * Whether the user belongs to the percentage-rollout cohort. Membership is

--- a/client/dashboard/utils/hosting-dashboard-enrollment.ts
+++ b/client/dashboard/utils/hosting-dashboard-enrollment.ts
@@ -5,7 +5,7 @@ import type { HostingDashboardOptIn } from '@automattic/api-core';
 const ROLLOUT_PERCENTAGE = 50;
 
 // When rollout begins, users registered after this ID (i.e. new users) are enrolled.
-const NEW_USER_ID_THRESHOLD = 282953237;
+const NEW_USER_ID_THRESHOLD = 282742932;
 
 /**
  * Whether the user belongs to the percentage-rollout cohort. Membership is

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -31,7 +31,7 @@
 		"dark-mode": true,
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
-		"dashboard/enable-percentage-rollout": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/omnibar-radical": false,
 		"dashboard/opt-in-welcome-modal": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -27,7 +27,7 @@
 		"dark-mode": true,
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
-		"dashboard/enable-percentage-rollout": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,
 		"dashboard/simulate-full-rollout": true,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -34,7 +34,7 @@
 		"dark-mode": true,
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": false,
-		"dashboard/enable-percentage-rollout": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/simulate-full-rollout": false,
 		"dashboard/wp-beta-program": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -32,7 +32,7 @@
 		"dark-mode": true,
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
-		"dashboard/enable-percentage-rollout": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/simulate-full-rollout": true,
 		"dashboard/wp-beta-program": true,

--- a/config/development.json
+++ b/config/development.json
@@ -71,7 +71,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/enable-percentage-rollout": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/force-opt-in-visibility": true,
 		"dashboard/omnibar-radical": false,
 		"dashboard/opt-in-welcome-modal": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -31,7 +31,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/enable-percentage-rollout": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/force-opt-in-visibility": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,

--- a/config/production.json
+++ b/config/production.json
@@ -44,7 +44,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/enable-percentage-rollout": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/rollout-advance-notice": true,
 		"dashboard/simulate-full-rollout": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -41,7 +41,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/enable-percentage-rollout": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/force-opt-in-visibility": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/rollout-advance-notice": true,

--- a/config/test.json
+++ b/config/test.json
@@ -36,7 +36,7 @@
 		"cookie-banner": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
-		"dashboard/enable-percentage-rollout": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/force-opt-in-visibility": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/rollout-advance-notice": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -40,7 +40,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/enable-percentage-rollout": true,
+		"dashboard/enable-percentage-rollout": false,
 		"dashboard/force-opt-in-visibility": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#112778

This is a just-in-case quick revert PR