### PR TITLE
Fix selected block shimmer for unrelated AI requests

### DIFF
--- a/packages/jetpack-ai-sidebar/AGENTS.md
+++ b/packages/jetpack-ai-sidebar/AGENTS.md
@@ -15,7 +15,7 @@ This package exports the **AM provider contract** — a set of functions the Age
 
 | Export                    | Role                                                      |
 | ------------------------- | --------------------------------------------------------- |
-| `useAbilitiesSetup`       | Captures AM's `addMessage`/`clearSuggestions` callbacks   |
+| `useAbilitiesSetup`       | Captures AM state and gates contextual block shimmer      |
 | `toolProvider`            | Surfaces Jetpack AI's client-side abilities to AM         |
 | `contextProvider`         | Sends Gutenberg editor state to the orchestrator          |
 | `getChatComponent`        | Maps `type` strings → React components for show-component |
@@ -32,7 +32,7 @@ All exports live in `src/index.ts`. This is intentionally a single-file provider
 - **Tool ID normalization**: AM normalizes tool IDs (`wpcom/update-block-content` → `wpcom__update_block_content`). The `isUpdateBlockContentTool` / `isShowComponentTool` helpers handle both forms. Any new tool must follow this pattern.
 - **Show-component via `agentMessage` escape hatch**: `handleShowComponent` returns `{ agentMessage: JSON }` — it does NOT call `addMessageFn` directly. agenttic-client wraps the JSON in an `{ role: 'agent', parts: [text] }` message, AM's `convert-tool-messages-to-components` resolves the component via `getChatComponent`, and AgentChat's action bar (thumbs/Undo) attaches because the original message had a text content part. See "Show-component pattern" below.
 - **Role transformation**: AM's `useAbilitiesSetup` handler maps `role: 'assistant'` → `'agent'` and everything else → `'user'`. When injecting messages directly via `addMessageFn`, always use `'assistant'` — passing `'agent'` would make the message render as user content and get filtered out of the agent message list.
-- **Processing shimmer**: The block editing shimmer uses `Flow Block` font + CSS animations injected into the block's owning document (which may be an iframe). The `ensureProcessingStyles` function is idempotent — don't duplicate style injection.
+- **Processing shimmer**: Start request-time shimmer only for a contextual block-transformation suggestion with a known target block. Free-form requests fall back to the concrete `handleUpdateBlockContent` action after its target is resolved. Never use generic AM processing state by itself. The effect uses `Flow Block` font + CSS animations injected into the block's owning document (which may be an iframe).
 
 ## Tools
 

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -2545,10 +2545,13 @@ describe( 'useSuggestions', () => {
 		expect( latestSuggestions ).toEqual( [] );
 	} );
 
-	it( 'does not start the selected block shimmer when a suggestion is only selected', () => {
+	it( 'starts block suggestion shimmer without duplicating concrete completion', () => {
+		jest.useFakeTimers();
 		installAiEditorialReviewData();
 		installPostTypeMock( 'post' );
 		mockSelectedBlock = { clientId: 'b1', name: 'core/paragraph' };
+		const blockActionComplete = jest.fn();
+		window.addEventListener( 'jetpack-ai-sidebar-block-action-complete', blockActionComplete );
 		const blockEl = document.createElement( 'div' );
 		blockEl.setAttribute( 'data-block', 'b1' );
 		document.body.appendChild( blockEl );
@@ -2565,10 +2568,36 @@ describe( 'useSuggestions', () => {
 
 		expect( blockEl.classList.contains( 'jetpack-ai-is-processing' ) ).toBe( false );
 		expect( blockEl.classList.contains( 'jetpack-ai-is-processing-content' ) ).toBe( false );
+
+		act( () => {
+			useAbilitiesSetup( {
+				addMessage: () => undefined,
+				clearSuggestions: () => undefined,
+				isProcessing: true,
+			} as any );
+		} );
+
+		expect( blockEl.classList.contains( 'jetpack-ai-is-processing' ) ).toBe( true );
+		expect( blockEl.classList.contains( 'jetpack-ai-is-processing-content' ) ).toBe( true );
+
+		act( () => {
+			window.dispatchEvent( new Event( 'jetpack-ai-sidebar-block-action-complete' ) );
+			useAbilitiesSetup( {
+				addMessage: () => undefined,
+				clearSuggestions: () => undefined,
+				isProcessing: false,
+			} as any );
+		} );
+
+		expect( blockEl.classList.contains( 'jetpack-ai-is-processing' ) ).toBe( false );
+		expect( blockEl.classList.contains( 'jetpack-ai-is-processing-content' ) ).toBe( false );
+		expect( blockActionComplete ).toHaveBeenCalledTimes( 1 );
+		window.removeEventListener( 'jetpack-ai-sidebar-block-action-complete', blockActionComplete );
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
 	} );
 
-	it( 'starts the selected block shimmer when AM starts processing', () => {
-		jest.useFakeTimers();
+	it( 'does not start the selected block shimmer when AM starts processing', () => {
 		installPostTypeMock( 'post' );
 		mockSelectedBlock = { clientId: 'lQ0k', name: 'core/paragraph' };
 		const blockEl = document.createElement( 'div' );
@@ -2578,25 +2607,17 @@ describe( 'useSuggestions', () => {
 		useAbilitiesSetup( {
 			addMessage: () => undefined,
 			clearSuggestions: () => undefined,
-			isProcessing: false,
-		} as any );
-		useAbilitiesSetup( {
-			addMessage: () => undefined,
-			clearSuggestions: () => undefined,
 			isProcessing: true,
 		} as any );
 
-		expect( blockEl.classList.contains( 'jetpack-ai-is-processing' ) ).toBe( true );
-		expect( blockEl.classList.contains( 'jetpack-ai-is-processing-content' ) ).toBe( true );
+		expect( blockEl.classList.contains( 'jetpack-ai-is-processing' ) ).toBe( false );
+		expect( blockEl.classList.contains( 'jetpack-ai-is-processing-content' ) ).toBe( false );
+
 		useAbilitiesSetup( {
 			addMessage: () => undefined,
 			clearSuggestions: () => undefined,
 			isProcessing: false,
 		} as any );
-		expect( blockEl.classList.contains( 'jetpack-ai-is-processing' ) ).toBe( false );
-		expect( blockEl.classList.contains( 'jetpack-ai-is-processing-content' ) ).toBe( false );
-		jest.runOnlyPendingTimers();
-		jest.useRealTimers();
 	} );
 } );
 

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -43,6 +43,7 @@ import {
 	getSelectedOrRememberedBlock,
 	rememberSelectedBlock,
 	clearRememberedSelectedBlock,
+	notifyBlockActionComplete,
 	BLOCK_ACTION_COMPLETE_EVENT,
 	SELECTED_BLOCK_CLEAR_EVENT,
 } from './utils/block-actions';
@@ -76,6 +77,8 @@ export { registerBlockEditorFilters } from './extensions';
 
 let clearSuggestionsFn: ( () => void ) | null = null;
 let wasAgentProcessing = false;
+let pendingBlockShimmerClientId: string | null = null;
+let blockShimmerStartedForRequest = false;
 let suppressCurrentPageContentForNextContext = false;
 
 /** Whether `_suggestion_rendered` has fired this page life (once-per-session). */
@@ -559,8 +562,8 @@ function getAbilitiesExecuteAbility():
 // ---------- useAbilitiesSetup ----------
 
 /**
- * Captures AM's clearSuggestions callback and processing state so the provider
- * can hide chips and run block-edit shimmers at the right time.
+ * Captures AM's clearSuggestions callback and starts request-time shimmer only
+ * for a known contextual block transformation.
  */
 export function useAbilitiesSetup( actions: {
 	addMessage: ( message: any ) => void;
@@ -573,10 +576,16 @@ export function useAbilitiesSetup( actions: {
 	}
 
 	const isProcessing = actions.isProcessing === true;
-	if ( isProcessing && ! wasAgentProcessing ) {
-		startBlockShimmer();
+	if ( isProcessing && ! wasAgentProcessing && pendingBlockShimmerClientId ) {
+		startBlockShimmer( pendingBlockShimmerClientId );
+		blockShimmerStartedForRequest = true;
 	} else if ( ! isProcessing && wasAgentProcessing ) {
 		stopBlockShimmer();
+		if ( blockShimmerStartedForRequest ) {
+			notifyBlockActionComplete();
+		}
+		pendingBlockShimmerClientId = null;
+		blockShimmerStartedForRequest = false;
 	}
 	wasAgentProcessing = isProcessing;
 }
@@ -1147,6 +1156,9 @@ export function useSuggestions(
 			setHidden( true );
 			clearSuggestionsFn?.();
 			suppressCurrentPageContentForNextContext = false;
+			pendingBlockShimmerClientId = BLOCK_SUGGESTIONS.some( matchesSuggestion )
+				? getSelectedOrRememberedBlock()?.clientId ?? null
+				: null;
 
 			if ( matchesSuggestion( POST_FEEDBACK_SUGGESTION ) ) {
 				suppressCurrentPageContentForNextContext = true;
@@ -1163,6 +1175,7 @@ export function useSuggestions(
 
 	useEffect( () => {
 		const handleBlockActionComplete = () => {
+			blockShimmerStartedForRequest = false;
 			setHidden( false );
 		};
 		window.addEventListener( BLOCK_ACTION_COMPLETE_EVENT, handleBlockActionComplete );
@@ -1174,6 +1187,7 @@ export function useSuggestions(
 	useEffect( () => {
 		const handleSelectedBlockClear = () => {
 			clearRememberedSelectedBlock();
+			pendingBlockShimmerClientId = null;
 			setHidden( false );
 		};
 		window.addEventListener( SELECTED_BLOCK_CLEAR_EVENT, handleSelectedBlockClear );
@@ -1205,6 +1219,7 @@ export function useSuggestions(
 
 	// Re-show suggestions when block selection changes (unless conversation is active)
 	useEffect( () => {
+		pendingBlockShimmerClientId = null;
 		setHidden( false );
 	}, [ editorContext.selectedBlock?.clientId ] );
 

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -380,15 +380,13 @@ export function applyProcessingEffect( el: HTMLElement ): void {
 }
 
 /**
- * Remove processing effect and show a brief highlight.
- * @param el - The block element.
+ * Start shimmer on a known block-edit target.
  */
-function removeProcessingEffect( el: HTMLElement ): void {
-	clearProcessingEffect( el );
-	el.classList.add( 'jetpack-ai-has-processed' );
-	setTimeout( () => {
-		el.classList.remove( 'jetpack-ai-has-processed' );
-	}, 1000 );
+export function startBlockShimmer( clientId: string ): void {
+	const blockEl = findBlockElement( clientId );
+	if ( blockEl ) {
+		applyProcessingEffect( blockEl );
+	}
 }
 
 /**
@@ -399,20 +397,15 @@ export function stopBlockShimmer(): void {
 }
 
 /**
- * Start shimmer on the currently selected block (if any).
+ * Remove processing effect and show a brief highlight.
+ * @param el - The block element.
  */
-export function startBlockShimmer(): void {
-	const wpData = ( window as any ).wp?.data;
-	if ( ! wpData ) {
-		return;
-	}
-	const block = getSelectedOrRememberedBlock();
-	if ( block?.clientId ) {
-		const blockEl = findBlockElement( block.clientId );
-		if ( blockEl ) {
-			applyProcessingEffect( blockEl );
-		}
-	}
+function removeProcessingEffect( el: HTMLElement ): void {
+	clearProcessingEffect( el );
+	el.classList.add( 'jetpack-ai-has-processed' );
+	setTimeout( () => {
+		el.classList.remove( 'jetpack-ai-has-processed' );
+	}, 1000 );
 }
 
 // ---------- Ability callbacks ----------


### PR DESCRIPTION
Fixes FORNO-415

## Proposed Changes

* Gate request-time block shimmer to contextual block transformation suggestions with a known target block.
* Keep concrete update-tool shimmer for free-form block edits after the target is resolved.
* Prevent duplicate block-complete events when a contextual edit also runs the concrete update tool.
* Add regression coverage for contextual and unrelated requests.

## Why are these changes being made?

The sidebar used the Agents Manager's generic processing state to animate the selected block. That made unrelated requests look like they were editing the block. This keeps the visual feedback for real block edits without applying it to every AI request.

## Testing Instructions

Automated:

* `yarn test-packages packages/jetpack-ai-sidebar --runInBand --no-watchman`
* `yarn workspace @automattic/jetpack-ai-sidebar typecheck`
* `yarn typecheck-packages`
* `yarn workspace @automattic/jetpack-ai-sidebar build`
* `yarn eslint packages/jetpack-ai-sidebar/src/index.ts packages/jetpack-ai-sidebar/src/index.test.ts packages/jetpack-ai-sidebar/src/utils/block-actions.ts`

Manual:

1. Open the AI sidebar in a Post and Page editor and select a text block.
2. Ask an unrelated question "what are the plugins installed on this site?"
3. Confirm the selected block does not show the processing animation.
4. Run Translate, Change tone, Check grammar, or Simplify on the selected block.
5. Confirm only that block animates while the edit is processing and updates normally.
6. Type a free-form block-edit request and confirm the animation starts only once the update tool identifies the target block.

Verified on a Simple sandbox.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g. browsers), interfaces (e.g. keyboard navigation), and assistive technologies (e.g. screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?