### PR TITLE
Dashboard: log recent-sites preference update failures to logstash

### DIFF
--- a/client/dashboard/app/omnibar/site.ts
+++ b/client/dashboard/app/omnibar/site.ts
@@ -1,3 +1,4 @@
+import { isWpError, type Site, type User } from '@automattic/api-core';
 import {
 	omnibarSiteIdQuery,
 	queryClient,
@@ -5,12 +6,13 @@ import {
 	userPreferenceQuery,
 	userPreferenceOptimisticMutation,
 } from '@automattic/api-queries';
+import calypsoConfig from '@automattic/calypso-config';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useRouterState } from '@tanstack/react-router';
 import { removeQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
+import { logToLogstash } from 'calypso/lib/logstash';
 import { AUTH_QUERY_KEY } from '../auth';
-import type { Site, User } from '@automattic/api-core';
 
 function isMemberOfSite( site: Site ) {
 	// If the user is a member of the site, the capabilities property will exist
@@ -90,7 +92,25 @@ export function useInitializeOmnibarSite() {
 
 		if ( omnibarSiteId && omnibarSiteId !== recentSiteIds?.[ 0 ] ) {
 			updateRecentSites(
-				[ ...new Set( [ omnibarSiteId, ...( recentSiteIds || [] ) ] ) ].slice( 0, 5 )
+				[ ...new Set( [ omnibarSiteId, ...( recentSiteIds || [] ) ] ) ].slice( 0, 5 ),
+				{
+					onError: ( error ) => {
+						logToLogstash( {
+							feature: 'calypso_client',
+							message: error.message,
+							tags: [ 'dashboard', 'recent-sites-update-fail' ],
+							properties: {
+								status: isWpError( error ) ? error.status : undefined,
+								error_name: isWpError( error ) ? error.name : undefined,
+								env_id: calypsoConfig( 'env_id' ),
+								message: error.message,
+								path: window.location.href,
+								omnibar_site_id: omnibarSiteId,
+								recent_site_ids: recentSiteIds,
+							},
+						} );
+					},
+				}
 			);
 		}
 	}, [

--- a/packages/api-queries/src/agency-migrations.ts
+++ b/packages/api-queries/src/agency-migrations.ts
@@ -21,6 +21,7 @@ export const agencyMigrationCommissionSitesQuery = ( agencyId: number | undefine
 
 export const tagAgencySitesForCommissionMutation = ( agencyId: number | undefined ) =>
 	mutationOptions( {
+		meta: { statId: 'agcy-mig-commission-tag' },
 		mutationFn: ( input: TagSitesForCommissionInput ) => {
 			if ( ! agencyId ) {
 				throw new Error( 'No active agency found for the current user.' );
@@ -31,6 +32,7 @@ export const tagAgencySitesForCommissionMutation = ( agencyId: number | undefine
 
 export const requestMigrationReverificationMutation = ( agencyId: number | undefined ) =>
 	mutationOptions( {
+		meta: { statId: 'agcy-mig-reverify-request' },
 		mutationFn: ( input: RequestReverificationInput ) => {
 			if ( ! agencyId ) {
 				throw new Error( 'No active agency found for the current user.' );

--- a/packages/api-queries/src/agency-site-tags.ts
+++ b/packages/api-queries/src/agency-site-tags.ts
@@ -6,6 +6,7 @@ import { mutationOptions } from '@tanstack/react-query';
 // rather than the `@automattic/api-queries` singleton.
 export const agencySiteTagsMutation = ( agencyId: number | undefined ) =>
 	mutationOptions( {
+		meta: { statId: 'agcy-site-tags-update' },
 		mutationFn: ( { siteId, tags }: { siteId: number; tags: string[] } ) => {
 			if ( ! agencyId ) {
 				throw new Error( 'No active agency found for the current user.' );


### PR DESCRIPTION
## Proposed Changes

* Log failures of the automatic `recentSites` preference update (omnibar initialization) to logstash, including the response status code, error name, URL path, and the site IDs involved.
* Add missing `meta.statId` to three agency mutations (`agcy-site-tags-update`, `agcy-mig-commission-tag`, `agcy-mig-reverify-request`) — the `mutation-stat-ids` test was failing on trunk. Bundled here to land quickly.

## Why are these changes being made?

* Production stats show a large volume of 405 responses from `POST /me/preferences`, surfaced via the `dashboard-mutation-error-status` stat as `user-pref-opt-update.405`. The stat only records the status code, so we can't tell which caller is failing, for whom, or with what error body.
* The `recentSites` update in the omnibar is a prime suspect: it fires automatically on navigation, and because the optimistic mutation rolls back the cache on error, the effect that triggered it can re-fire and retry indefinitely — a single tab with a rejected session could emit 405s continuously.
* Logstash entries will show the error details and, via repetition from the same path/user, whether the retry-loop theory holds. The `/logstash` endpoint accepts unauthenticated requests, so these logs get through even when the failure is an auth rejection.

## Testing Instructions

* Load the dashboard, then use browser devtools to block requests to `/me/preferences`.
* Navigate so the omnibar site changes (e.g. open a different site) to trigger a `recentSites` update.
* Confirm a `POST /logstash` request fires with the `recent-sites-update-fail` tag and the expected properties.
* Run `yarn test-packages packages/api-queries/src/__tests__/mutation-stat-ids.test.ts` — passes (fails on trunk).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
