### PR TITLE
Profile: stop re-requesting the Gravatar avatar on every keystroke

### DIFF
--- a/client/dashboard/me/profile-gravatar/edit-gravatar.tsx
+++ b/client/dashboard/me/profile-gravatar/edit-gravatar.tsx
@@ -17,7 +17,7 @@ interface EditGravatarProps {
 }
 
 const EditGravatar = ( { isEmailVerified = true, avatarUrl, userEmail }: EditGravatarProps ) => {
-	const [ tempImage, setTempImage ] = useState< string | null >( null );
+	const [ avatarVersion, setAvatarVersion ] = useState< number | null >( null );
 	const [ showEmailVerificationNotice, setShowEmailVerificationNotice ] =
 		useState< boolean >( false );
 	const [ isOverlayVisible, setIsOverlayVisible ] = useState< boolean >( false );
@@ -28,12 +28,6 @@ const EditGravatar = ( { isEmailVerified = true, avatarUrl, userEmail }: EditGra
 
 	// Initialize the Gravatar Quick Editor to manage avatars in a dedicated Gravatar UI
 	const quickEditorRef = useRef< GravatarQuickEditorCore | null >( null );
-	const avatarUrlRef = useRef( avatarUrl );
-
-	// Update the avatar URL reference when the prop changes
-	useEffect( () => {
-		avatarUrlRef.current = avatarUrl;
-	}, [ avatarUrl ] );
 
 	useEffect( () => {
 		quickEditorRef.current = new GravatarQuickEditorCore( {
@@ -42,7 +36,7 @@ const EditGravatar = ( { isEmailVerified = true, avatarUrl, userEmail }: EditGra
 			utm: 'wpcomme',
 			onProfileUpdated: () => {
 				// Bust cache so the <img> reloads the latest avatar immediately
-				setTempImage( addQueryArgs( avatarUrlRef.current, { ver: Date.now() } ) as string );
+				setAvatarVersion( Date.now() );
 			},
 		} );
 
@@ -112,6 +106,10 @@ const EditGravatar = ( { isEmailVerified = true, avatarUrl, userEmail }: EditGra
 		transition: 'opacity 0.2s',
 	};
 
+	const displayUrl = avatarVersion
+		? ( addQueryArgs( avatarUrl, { ver: avatarVersion } ) as string )
+		: avatarUrl;
+
 	const openGravatarEditor = () => {
 		handleUnverifiedUserClick();
 		if ( isEmailVerified ) {
@@ -151,7 +149,7 @@ const EditGravatar = ( { isEmailVerified = true, avatarUrl, userEmail }: EditGra
 						aria-label={ uploadButtonLabel }
 					>
 						<img
-							src={ tempImage || avatarUrl }
+							src={ displayUrl }
 							alt={ __( 'Gravatar' ) }
 							width={ 48 }
 							height={ 48 }

--- a/client/dashboard/me/profile-gravatar/edit-gravatar.tsx
+++ b/client/dashboard/me/profile-gravatar/edit-gravatar.tsx
@@ -35,9 +35,6 @@ const EditGravatar = ( { isEmailVerified = true, avatarUrl, userEmail }: EditGra
 		avatarUrlRef.current = avatarUrl;
 	}, [ avatarUrl ] );
 
-	// Add a timestamp to the avatar URL to avoid cache since this component needs to show the latest avatar the user has uploaded
-	const displayUrl = addQueryArgs( avatarUrlRef.current, { ver: Date.now() } );
-
 	useEffect( () => {
 		quickEditorRef.current = new GravatarQuickEditorCore( {
 			email: userEmail,
@@ -154,7 +151,7 @@ const EditGravatar = ( { isEmailVerified = true, avatarUrl, userEmail }: EditGra
 						aria-label={ uploadButtonLabel }
 					>
 						<img
-							src={ tempImage || displayUrl }
+							src={ tempImage || avatarUrl }
 							alt={ __( 'Gravatar' ) }
 							width={ 48 }
 							height={ 48 }

--- a/client/dashboard/me/profile-gravatar/test/index.test.tsx
+++ b/client/dashboard/me/profile-gravatar/test/index.test.tsx
@@ -42,6 +42,20 @@ describe( '<GravatarProfileSection>', () => {
 		);
 	} );
 
+	test( 'keeps the avatar src stable while typing in other fields', async () => {
+		const user = userEvent.setup();
+		mockUserSettings( settings );
+
+		render( <GravatarProfileSection /> );
+		await screen.findByRole( 'heading', { name: 'Public Gravatar profile' } );
+
+		const srcBefore = screen.getByAltText( 'Gravatar' ).getAttribute( 'src' );
+
+		await user.type( screen.getByRole( 'textbox', { name: 'Display name' } ), 'abc' );
+
+		expect( screen.getByAltText( 'Gravatar' ) ).toHaveAttribute( 'src', srcBefore );
+	} );
+
 	test( 'renders the form and saves the form', async () => {
 		const user = userEvent.setup();
 		mockUserSettings( settings );


### PR DESCRIPTION
## Proposed Changes

* Stop firing a new Gravatar image request on every keystroke in the profile form; the avatar image URL is now stable and only changes after the user saves a new avatar

## Why are these changes being made?

* The avatar preview appended a fresh cache-busting timestamp on every render, so typing in any field of the form re-requested (and piled up failing) Gravatar image requests once per keystroke
* The timestamp only existed to refresh the preview after saving a new avatar, which the post-save refresh already handles

## Testing Instructions

1. Go to Me → Account in the dashboard
2. Open the browser Network panel and type in the "About me" field
   - Before: one Gravatar image request per keystroke; after: none
3. Click "Update avatar", save a new image in the Gravatar editor
   - The avatar preview still refreshes immediately after saving

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)