### PR TITLE
api-queries: add missing statIds to agency mutations

### DIFF
--- a/packages/api-queries/src/agency-migrations.ts
+++ b/packages/api-queries/src/agency-migrations.ts
@@ -21,6 +21,7 @@ export const agencyMigrationCommissionSitesQuery = ( agencyId: number | undefine
 
 export const tagAgencySitesForCommissionMutation = ( agencyId: number | undefined ) =>
 	mutationOptions( {
+		meta: { statId: 'agcy-mig-commission-tag' },
 		mutationFn: ( input: TagSitesForCommissionInput ) => {
 			if ( ! agencyId ) {
 				throw new Error( 'No active agency found for the current user.' );
@@ -31,6 +32,7 @@ export const tagAgencySitesForCommissionMutation = ( agencyId: number | undefine
 
 export const requestMigrationReverificationMutation = ( agencyId: number | undefined ) =>
 	mutationOptions( {
+		meta: { statId: 'agcy-mig-reverify-request' },
 		mutationFn: ( input: RequestReverificationInput ) => {
 			if ( ! agencyId ) {
 				throw new Error( 'No active agency found for the current user.' );

--- a/packages/api-queries/src/agency-site-tags.ts
+++ b/packages/api-queries/src/agency-site-tags.ts
@@ -6,6 +6,7 @@ import { mutationOptions } from '@tanstack/react-query';
 // rather than the `@automattic/api-queries` singleton.
 export const agencySiteTagsMutation = ( agencyId: number | undefined ) =>
 	mutationOptions( {
+		meta: { statId: 'agcy-site-tags-update' },
 		mutationFn: ( { siteId, tags }: { siteId: number; tags: string[] } ) => {
 			if ( ! agencyId ) {
 				throw new Error( 'No active agency found for the current user.' );


### PR DESCRIPTION
## Proposed Changes

* Add the required `meta.statId` to three agency mutations that were missing it:
  * `agencySiteTagsMutation` → `agcy-site-tags-update`
  * `tagAgencySitesForCommissionMutation` → `agcy-mig-commission-tag`
  * `requestMigrationReverificationMutation` → `agcy-mig-reverify-request`

## Why are these changes being made?

* Every `@automattic/api-queries` mutation must carry a `meta.statId` so `MutationErrorTracker` can attribute failures. These three landed without one, so `yarn test-packages packages/api-queries/src/__tests__/mutation-stat-ids.test.ts` fails on trunk.
* IDs follow the package convention (noun-first, verb-final, `agcy-` family prefix, ≤28 chars).

## Testing Instructions

* Run `yarn test-packages packages/api-queries/src/__tests__/mutation-stat-ids.test.ts` — all 226 tests pass.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?