### PR TITLE
Dashboard: stop retrying recent-sites write in an infinite loop

### DIFF
--- a/client/dashboard/app/omnibar/site.ts
+++ b/client/dashboard/app/omnibar/site.ts
@@ -35,13 +35,6 @@ async function ensureSite( siteId: number | undefined ) {
 /**
  * Keeps the omnibar's current site in sync with the URL, the most recent sites,
  * or the user's primary blog, in that priority.
- *
- * The work runs in response to route-resolution events rather than from a
- * reactive effect. Recording the current site into the `recentSites` preference
- * is an optimistic write that rolls back on failure; driving it off a `useEffect`
- * dependency on `recentSites` meant a persistently failing write kept re-triggering
- * itself. Reacting to navigation events instead means a rolled-back write emits no
- * event and is not retried.
  */
 export function useSyncOmnibarSite() {
 	const router = useRouter();
@@ -52,8 +45,11 @@ export function useSyncOmnibarSite() {
 
 	useEffect( () => {
 		let cancelled = false;
+		// Only the latest run may publish/record, so a slow run can't overwrite a newer one.
+		let latestRun = 0;
 
 		async function resolveOmnibarSite() {
+			const runId = ++latestRun;
 			const user = queryClient.getQueryData< User >( AUTH_QUERY_KEY );
 
 			const routeSite = router.state.matches.findLast(
@@ -66,12 +62,18 @@ export function useSyncOmnibarSite() {
 			);
 			const originSiteId = originSiteIdParam > 0 ? originSiteIdParam : undefined;
 
-			let recentSiteIds: number[] = [];
+			let recentSiteIds: number[];
 			try {
 				const preferences = await queryClient.ensureQueryData( rawUserPreferencesQuery() );
 				recentSiteIds = preferences.recentSites ?? [];
 			} catch {
-				recentSiteIds = [];
+				// If we can't read preferences, a write would likely fail too, so bail
+				// rather than attempt a doomed record.
+				return;
+			}
+
+			if ( cancelled || runId !== latestRun ) {
+				return;
 			}
 
 			const recentSiteId =
@@ -83,7 +85,7 @@ export function useSyncOmnibarSite() {
 				ensureSite( recentSiteId ),
 			] );
 
-			if ( cancelled ) {
+			if ( cancelled || runId !== latestRun ) {
 				return;
 			}
 

--- a/client/dashboard/app/omnibar/site.ts
+++ b/client/dashboard/app/omnibar/site.ts
@@ -2,15 +2,15 @@ import { isWpError, type Site, type User } from '@automattic/api-core';
 import {
 	omnibarSiteIdQuery,
 	queryClient,
+	rawUserPreferencesQuery,
 	siteByIdQuery,
-	userPreferenceQuery,
 	userPreferenceOptimisticMutation,
 } from '@automattic/api-queries';
 import calypsoConfig from '@automattic/calypso-config';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { useRouterState } from '@tanstack/react-router';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
 import { removeQueryArgs } from '@wordpress/url';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { AUTH_QUERY_KEY } from '../auth';
 
@@ -19,91 +19,96 @@ function isMemberOfSite( site: Site ) {
 	return !! site.capabilities;
 }
 
-/**
- * Initializes the current site for the omnibar, which is extracted from the URL,
- * or the most recent sites, or the user's primary blog, in that priority.
- */
-export function useInitializeOmnibarSite() {
-	const user = queryClient.getQueryData< User >( AUTH_QUERY_KEY );
+// Fetch a candidate site, tolerating failures so the omnibar can still fall
+// back to the next candidate (or the user's primary blog).
+async function ensureSite( siteId: number | undefined ) {
+	if ( ! siteId ) {
+		return undefined;
+	}
+	try {
+		return await queryClient.ensureQueryData( siteByIdQuery( siteId ) );
+	} catch {
+		return undefined;
+	}
+}
 
-	const { data: recentSiteIds, isLoading: isLoadingRecentSiteIds } = useQuery(
-		userPreferenceQuery( 'recentSites' ),
-		queryClient
-	);
+/**
+ * Keeps the omnibar's current site in sync with the URL, the most recent sites,
+ * or the user's primary blog, in that priority.
+ *
+ * The work runs in response to route-resolution events rather than from a
+ * reactive effect. Recording the current site into the `recentSites` preference
+ * is an optimistic write that rolls back on failure; driving it off a `useEffect`
+ * dependency on `recentSites` meant a persistently failing write kept re-triggering
+ * itself. Reacting to navigation events instead means a rolled-back write emits no
+ * event and is not retried.
+ */
+export function useSyncOmnibarSite() {
+	const router = useRouter();
 	const { mutate: updateRecentSites } = useMutation(
 		userPreferenceOptimisticMutation( 'recentSites' ),
 		queryClient
 	);
 
-	// Tracks the last site id we tried to record as most recent. On failure the
-	// optimistic mutation rolls `recentSites` back, which would otherwise re-trigger
-	// this effect and retry the same write forever. We only attempt each site once.
-	const lastRecordedSiteIdRef = useRef< number | undefined >( undefined );
-
-	const { location, routeSite, isRouteLoaded } = useRouterState( {
-		select: ( state ) => ( {
-			location: state.location,
-			routeSite: state.matches.findLast(
-				( match ) => !! ( match.loaderData as { site?: Site } )?.site
-			)?.loaderData?.site,
-			isRouteLoaded: state.status !== 'pending',
-		} ),
-	} );
-
-	// When coming from a site's wp-admin, the URL may contain an `origin_site_id` query param.
-	const originSiteIdParam = Number(
-		( location.search as Record< string, string | undefined > ).origin_site_id
-	);
-	const originSiteId = originSiteIdParam > 0 ? originSiteIdParam : undefined;
-	const recentSiteId =
-		queryClient.getQueryData< number | null >( omnibarSiteIdQuery().queryKey ) ||
-		recentSiteIds?.[ 0 ];
-
-	const { data: originSite, isLoading: isLoadingOriginSite } = useQuery( {
-		...siteByIdQuery( originSiteId ?? 0 ),
-		enabled: !! originSiteId,
-	} );
-
-	const { data: recentSite, isLoading: isLoadingRecentSite } = useQuery( {
-		...siteByIdQuery( recentSiteId ?? 0 ),
-		enabled: !! recentSiteId,
-	} );
-
 	useEffect( () => {
-		// Wait until the required data are fully loaded, to avoid flicker.
-		if ( ! isRouteLoaded || isLoadingRecentSiteIds || isLoadingOriginSite || isLoadingRecentSite ) {
-			return;
-		}
+		let cancelled = false;
 
-		// `omnibarSiteIdQuery` is used as cross-tree shared state — its placeholder
-		// queryFn resolves to `null`. If it's still in flight when we write here,
-		// the resolution will overwrite our value and the omnibar loses the site.
-		queryClient.cancelQueries( { queryKey: omnibarSiteIdQuery().queryKey } );
+		async function resolveOmnibarSite() {
+			const user = queryClient.getQueryData< User >( AUTH_QUERY_KEY );
 
-		const omnibarSite = [ routeSite, originSite, recentSite ].find(
-			( site ) => site && isMemberOfSite( site )
-		);
-		const omnibarSiteId = omnibarSite?.ID ?? user?.primary_blog;
-		queryClient.setQueryData( omnibarSiteIdQuery().queryKey, () => omnibarSiteId );
+			const routeSite = router.state.matches.findLast(
+				( match ) => !! ( match.loaderData as { site?: Site } )?.site
+			)?.loaderData?.site;
 
-		// Remove the `origin_site_id` query param from the URL.
-		if ( originSiteId ) {
-			window.history.replaceState(
-				null,
-				'',
-				removeQueryArgs( window.location.pathname + window.location.search, 'origin_site_id' )
+			// When coming from a site's wp-admin, the URL may contain an `origin_site_id` query param.
+			const originSiteIdParam = Number(
+				( router.state.location.search as Record< string, string | undefined > ).origin_site_id
 			);
-		}
+			const originSiteId = originSiteIdParam > 0 ? originSiteIdParam : undefined;
 
-		if (
-			omnibarSiteId &&
-			omnibarSiteId !== recentSiteIds?.[ 0 ] &&
-			omnibarSiteId !== lastRecordedSiteIdRef.current
-		) {
-			lastRecordedSiteIdRef.current = omnibarSiteId;
-			updateRecentSites(
-				[ ...new Set( [ omnibarSiteId, ...( recentSiteIds || [] ) ] ) ].slice( 0, 5 ),
-				{
+			let recentSiteIds: number[] = [];
+			try {
+				const preferences = await queryClient.ensureQueryData( rawUserPreferencesQuery() );
+				recentSiteIds = preferences.recentSites ?? [];
+			} catch {
+				recentSiteIds = [];
+			}
+
+			const recentSiteId =
+				queryClient.getQueryData< number | null >( omnibarSiteIdQuery().queryKey ) ||
+				recentSiteIds[ 0 ];
+
+			const [ originSite, recentSite ] = await Promise.all( [
+				ensureSite( originSiteId ),
+				ensureSite( recentSiteId ),
+			] );
+
+			if ( cancelled ) {
+				return;
+			}
+
+			// `omnibarSiteIdQuery` is used as cross-tree shared state — its placeholder
+			// queryFn resolves to `null`. If it's still in flight when we write here,
+			// the resolution will overwrite our value and the omnibar loses the site.
+			queryClient.cancelQueries( { queryKey: omnibarSiteIdQuery().queryKey } );
+
+			const omnibarSite = [ routeSite, originSite, recentSite ].find(
+				( site ) => site && isMemberOfSite( site )
+			);
+			const omnibarSiteId = omnibarSite?.ID ?? user?.primary_blog;
+			queryClient.setQueryData( omnibarSiteIdQuery().queryKey, () => omnibarSiteId );
+
+			// Remove the `origin_site_id` query param from the URL.
+			if ( originSiteId ) {
+				window.history.replaceState(
+					null,
+					'',
+					removeQueryArgs( window.location.pathname + window.location.search, 'origin_site_id' )
+				);
+			}
+
+			if ( omnibarSiteId && omnibarSiteId !== recentSiteIds[ 0 ] ) {
+				updateRecentSites( [ ...new Set( [ omnibarSiteId, ...recentSiteIds ] ) ].slice( 0, 5 ), {
 					onError: ( error ) => {
 						logToLogstash( {
 							feature: 'calypso_client',
@@ -120,20 +125,25 @@ export function useInitializeOmnibarSite() {
 							},
 						} );
 					},
-				}
-			);
+				} );
+			}
 		}
-	}, [
-		isRouteLoaded,
-		routeSite,
-		originSiteId,
-		originSite,
-		isLoadingOriginSite,
-		recentSite,
-		isLoadingRecentSite,
-		recentSiteIds,
-		isLoadingRecentSiteIds,
-		user,
-		updateRecentSites,
-	] );
+
+		// `onResolved` fires on each navigation once its matches have loaded. If the
+		// initial route already resolved before this effect ran, that event has been
+		// missed, so run once now; `resolvedLocation` is only set once the first
+		// resolution has happened, so this never double-fires with the event below.
+		if ( router.state.resolvedLocation ) {
+			resolveOmnibarSite();
+		}
+
+		const unsubscribe = router.subscribe( 'onResolved', () => {
+			resolveOmnibarSite();
+		} );
+
+		return () => {
+			cancelled = true;
+			unsubscribe();
+		};
+	}, [ router, updateRecentSites ] );
 }

--- a/client/dashboard/app/omnibar/site.ts
+++ b/client/dashboard/app/omnibar/site.ts
@@ -10,7 +10,7 @@ import calypsoConfig from '@automattic/calypso-config';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useRouterState } from '@tanstack/react-router';
 import { removeQueryArgs } from '@wordpress/url';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { AUTH_QUERY_KEY } from '../auth';
 
@@ -34,6 +34,11 @@ export function useInitializeOmnibarSite() {
 		userPreferenceOptimisticMutation( 'recentSites' ),
 		queryClient
 	);
+
+	// Tracks the last site id we tried to record as most recent. On failure the
+	// optimistic mutation rolls `recentSites` back, which would otherwise re-trigger
+	// this effect and retry the same write forever. We only attempt each site once.
+	const lastRecordedSiteIdRef = useRef< number | undefined >( undefined );
 
 	const { location, routeSite, isRouteLoaded } = useRouterState( {
 		select: ( state ) => ( {
@@ -90,7 +95,12 @@ export function useInitializeOmnibarSite() {
 			);
 		}
 
-		if ( omnibarSiteId && omnibarSiteId !== recentSiteIds?.[ 0 ] ) {
+		if (
+			omnibarSiteId &&
+			omnibarSiteId !== recentSiteIds?.[ 0 ] &&
+			omnibarSiteId !== lastRecordedSiteIdRef.current
+		) {
+			lastRecordedSiteIdRef.current = omnibarSiteId;
 			updateRecentSites(
 				[ ...new Set( [ omnibarSiteId, ...( recentSiteIds || [] ) ] ) ].slice( 0, 5 ),
 				{

--- a/client/dashboard/app/omnibar/test/site.test.tsx
+++ b/client/dashboard/app/omnibar/test/site.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+import { queryClient } from '@automattic/api-queries';
+import { waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import { AUTH_QUERY_KEY } from '../../auth';
+import { useInitializeOmnibarSite } from '../site';
+import type { User } from '@automattic/api-core';
+
+function OmnibarProbe() {
+	useInitializeOmnibarSite();
+	return null;
+}
+
+describe( 'useInitializeOmnibarSite', () => {
+	afterEach( () => {
+		nock.cleanAll();
+		queryClient.clear();
+	} );
+
+	test( 'records the recent site only once when the preference write keeps failing', async () => {
+		queryClient.setQueryData( AUTH_QUERY_KEY, { ID: 1, primary_blog: 123 } as User );
+
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( '/rest/v1.1/me/preferences' )
+			.reply( 200, { calypso_preferences: { recentSites: [ 999 ] } } );
+
+		// Sites are returned without `capabilities`, so they aren't treated as
+		// member sites and the omnibar falls back to the user's primary blog.
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( /\/rest\/v1\.1\/sites\/\d+/ )
+			.query( true )
+			.reply( 200, ( uri ) => ( { ID: Number( uri.match( /sites\/(\d+)/ )?.[ 1 ] ) } ) );
+
+		// The failure path logs to logstash.
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.post( '/rest/v1.1/logstash' )
+			.reply( 200, {} );
+
+		// The recent-sites write always fails. Before the fix, the optimistic
+		// mutation's rollback re-triggered the effect and it retried forever.
+		let postCount = 0;
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.post( '/rest/v1.1/me/preferences' )
+			.reply( () => {
+				postCount += 1;
+				return [ 405, { error: 'not_allowed' } ];
+			} );
+
+		render( <OmnibarProbe /> );
+
+		await waitFor( () => expect( postCount ).toBeGreaterThanOrEqual( 1 ) );
+		await new Promise( ( resolve ) => setTimeout( resolve, 200 ) );
+
+		expect( postCount ).toBe( 1 );
+	} );
+} );

--- a/client/dashboard/app/omnibar/test/site.test.tsx
+++ b/client/dashboard/app/omnibar/test/site.test.tsx
@@ -7,7 +7,7 @@ import nock from 'nock';
 import { render } from '../../../test-utils';
 import { AUTH_QUERY_KEY } from '../../auth';
 import { useSyncOmnibarSite } from '../site';
-import type { User } from '@automattic/api-core';
+import type { User, UserPreferences } from '@automattic/api-core';
 
 function OmnibarProbe() {
 	useSyncOmnibarSite();
@@ -65,9 +65,10 @@ describe( 'useSyncOmnibarSite', () => {
 		// …then fails and rolls `recentSites` back to `[ 999 ]`. That rollback is the
 		// exact event the old bug re-fired the write from; once it settles, no retry.
 		await waitFor( () =>
-			expect( queryClient.getQueryData( rawUserPreferencesQuery().queryKey )?.recentSites ).toEqual(
-				[ 999 ]
-			)
+			expect(
+				queryClient.getQueryData< UserPreferences >( rawUserPreferencesQuery().queryKey )
+					?.recentSites
+			).toEqual( [ 999 ] )
 		);
 		await flush();
 

--- a/client/dashboard/app/omnibar/test/site.test.tsx
+++ b/client/dashboard/app/omnibar/test/site.test.tsx
@@ -1,8 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-import { omnibarSiteIdQuery, queryClient } from '@automattic/api-queries';
-import { waitFor } from '@testing-library/react';
+import { omnibarSiteIdQuery, queryClient, rawUserPreferencesQuery } from '@automattic/api-queries';
+import { act, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { render } from '../../../test-utils';
 import { AUTH_QUERY_KEY } from '../../auth';
@@ -14,9 +14,13 @@ function OmnibarProbe() {
 	return null;
 }
 
+// Flush pending microtasks/effects so a hypothetical re-triggered write would fire.
+function flush() {
+	return act( async () => {} );
+}
+
 describe( 'useSyncOmnibarSite', () => {
 	afterEach( () => {
-		nock.cleanAll();
 		queryClient.clear();
 	} );
 
@@ -56,12 +60,51 @@ describe( 'useSyncOmnibarSite', () => {
 
 		render( <OmnibarProbe /> );
 
-		await waitFor( () => expect( postCount ).toBeGreaterThanOrEqual( 1 ) );
-		await new Promise( ( resolve ) => setTimeout( resolve, 200 ) );
+		// The write is attempted (optimistically setting `recentSites` to `[ 123, 999 ]`)…
+		await waitFor( () => expect( postCount ).toBe( 1 ) );
+		// …then fails and rolls `recentSites` back to `[ 999 ]`. That rollback is the
+		// exact event the old bug re-fired the write from; once it settles, no retry.
+		await waitFor( () =>
+			expect( queryClient.getQueryData( rawUserPreferencesQuery().queryKey )?.recentSites ).toEqual(
+				[ 999 ]
+			)
+		);
+		await flush();
 
 		expect( postCount ).toBe( 1 );
 
 		// The omnibar still resolves to the primary blog and publishes it as shared state.
 		expect( queryClient.getQueryData( omnibarSiteIdQuery().queryKey ) ).toBe( 123 );
+	} );
+
+	test( 'does not attempt a write when reading preferences fails', async () => {
+		queryClient.setQueryData( AUTH_QUERY_KEY, { ID: 1, primary_blog: 123 } as User );
+
+		// Reading preferences fails, so a write would likely fail too — we bail out.
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( '/rest/v1.1/me/preferences' )
+			.reply( 403, { error: 'unauthorized' } );
+
+		let postCount = 0;
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.post( '/rest/v1.1/me/preferences' )
+			.reply( () => {
+				postCount += 1;
+				return [ 200, {} ];
+			} );
+
+		render( <OmnibarProbe /> );
+
+		// Wait for the preferences read to fail, then confirm no write followed.
+		await waitFor( () =>
+			expect( queryClient.getQueryState( rawUserPreferencesQuery().queryKey )?.status ).toBe(
+				'error'
+			)
+		);
+		await flush();
+
+		expect( postCount ).toBe( 0 );
 	} );
 } );

--- a/client/dashboard/app/omnibar/test/site.test.tsx
+++ b/client/dashboard/app/omnibar/test/site.test.tsx
@@ -1,20 +1,20 @@
 /**
  * @jest-environment jsdom
  */
-import { queryClient } from '@automattic/api-queries';
+import { omnibarSiteIdQuery, queryClient } from '@automattic/api-queries';
 import { waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { render } from '../../../test-utils';
 import { AUTH_QUERY_KEY } from '../../auth';
-import { useInitializeOmnibarSite } from '../site';
+import { useSyncOmnibarSite } from '../site';
 import type { User } from '@automattic/api-core';
 
 function OmnibarProbe() {
-	useInitializeOmnibarSite();
+	useSyncOmnibarSite();
 	return null;
 }
 
-describe( 'useInitializeOmnibarSite', () => {
+describe( 'useSyncOmnibarSite', () => {
 	afterEach( () => {
 		nock.cleanAll();
 		queryClient.clear();
@@ -43,7 +43,8 @@ describe( 'useInitializeOmnibarSite', () => {
 			.reply( 200, {} );
 
 		// The recent-sites write always fails. Before the fix, the optimistic
-		// mutation's rollback re-triggered the effect and it retried forever.
+		// mutation's rollback changed `recentSites`, re-triggering the effect that
+		// fired the write, so it retried forever.
 		let postCount = 0;
 		nock( 'https://public-api.wordpress.com' )
 			.persist()
@@ -59,5 +60,8 @@ describe( 'useInitializeOmnibarSite', () => {
 		await new Promise( ( resolve ) => setTimeout( resolve, 200 ) );
 
 		expect( postCount ).toBe( 1 );
+
+		// The omnibar still resolves to the primary blog and publishes it as shared state.
+		expect( queryClient.getQueryData( omnibarSiteIdQuery().queryKey ) ).toBe( 123 );
 	} );
 } );

--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -28,7 +28,7 @@ import { NavigationBlockerRegistry } from '../navigation-blocker';
 import Notifications from '../notifications';
 import { useOmnibarEvent } from '../omnibar/events';
 import OmnibarSiteSwitcher from '../omnibar/omnibar-site-switcher';
-import { useInitializeOmnibarSite } from '../omnibar/site';
+import { useSyncOmnibarSite } from '../omnibar/site';
 import ResponsiveSidebar from '../responsive-sidebar';
 import Snackbars from '../snackbars';
 import { OptInWelcomeModal } from '../welcome-modal';
@@ -66,7 +66,7 @@ function Root() {
 	const [ isSidebarOpen, setIsSidebarOpen ] = useState( false );
 	const closeSidebar = useCallback( () => setIsSidebarOpen( false ), [ setIsSidebarOpen ] );
 
-	useInitializeOmnibarSite();
+	useSyncOmnibarSite();
 	useTrackVisitedAreas();
 	useOmnibarEvent( 'mobileMenu', () => setIsSidebarOpen( ( v ) => ! v ) );
 	useOmnibarEvent( 'linkClick', ( { href, event } ) => {


### PR DESCRIPTION
## Proposed Changes

* Fix an infinite loop where a persistently failing recent-sites preference write (e.g. HTTP 405) is retried forever, hammering `POST /me/preferences`.
* Drive the omnibar site sync from route-resolution events instead of a reactive effect, which removes the feedback loop at its source.
* Add regression tests covering the failing-write and failing-read paths.

## Why are these changes being made?

The omnibar records the current site into the `recentSites` user preference via an optimistic mutation: it writes the new value into the cache immediately and rolls it back on failure.

Previously the write was fired from a `useEffect` whose dependency array included the recent-sites value. On the happy path the optimistic value stuck and it settled. But on a persistent failure the rollback restored the old value — changing an effect dependency back to a state where the write fires again. That write failed, rolled back, re-triggered the effect, and so on indefinitely.

The root problem is using an effect to react to variable changes when the work is really a response to a navigation event. Recording the current site is an event ("the user navigated here"), not something that should re-run whenever the cache changes.

## The fix

* The sync now runs in response to route-resolution events rather than a reactive effect. A failed-and-rolled-back write emits no navigation event, so it is never retried.
* Preferences and site data are read imperatively at event time. If the preferences read fails, we bail rather than attempt a write that would likely fail too.
* A superseded run (a newer navigation started while an earlier one was still awaiting data) does not publish or record, so a slow earlier navigation cannot overwrite the current site.

## Considerations

An earlier iteration kept the effect but added a ref to record each site id only once. That suppresses the loop but leaves the underlying antipattern — an effect that re-runs on a value its own side effect mutates. Reacting to navigation events instead removes the feedback edge entirely, so there is no loop to guard against.

## Testing Instructions

Automated:

```
yarn test-client client/dashboard/app/omnibar/test/site.test.tsx
```

One test makes `POST /me/preferences` fail and asserts the write is attempted exactly once (no retry loop). Another makes the preferences read fail and asserts no write is attempted.

Manual:

1. Log into the dashboard.
2. Navigate so the resolved omnibar site differs from the first entry of the `recentSites` preference (e.g. open a specific site, or append `?origin_site_id=<id>` for a site not already at the front of recentSites).
3. In DevTools, force `POST **/me/preferences**` to fail (block/override with status 405).
4. Before: `POST /me/preferences` fires on an unbroken loop. After: it fires once and stops.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?
