### PR TITLE
Add preference mutation stat IDs

### DIFF
--- a/packages/api-queries/src/__tests__/me-preferences.test.ts
+++ b/packages/api-queries/src/__tests__/me-preferences.test.ts
@@ -1,0 +1,66 @@
+import { userPreferenceMutation, userPreferenceOptimisticMutation } from '../me-preferences';
+import type { UserPreferences } from '@automattic/api-core';
+
+function getPreferenceMutationStatId( preferenceKey: keyof UserPreferences ) {
+	return userPreferenceMutation( preferenceKey ).meta?.statId;
+}
+
+function getPreferenceOptimisticMutationStatId( preferenceKey: keyof UserPreferences ) {
+	return userPreferenceOptimisticMutation( preferenceKey ).meta?.statId;
+}
+
+describe( 'user preference mutation meta', () => {
+	it( 'uses short codes for static preferences', () => {
+		expect( getPreferenceOptimisticMutationStatId( 'recentSites' ) ).toBe(
+			'user-pref-opt-update.recent'
+		);
+	} );
+
+	it( 'buckets dynamic dashboard preferences by family', () => {
+		expect(
+			getPreferenceOptimisticMutationStatId( 'hosting-dashboard-visit-count-deployments' )
+		).toBe( 'user-pref-opt-update.visits' );
+
+		expect(
+			getPreferenceOptimisticMutationStatId( 'hosting-dashboard-dataviews-view-sites' )
+		).toBe( 'user-pref-opt-update.dvview' );
+	} );
+
+	it( 'buckets dynamic purchase preferences by family', () => {
+		expect( getPreferenceMutationStatId( 'cancel-purchase-survey-completed-123' ) ).toBe(
+			'user-pref-update.cncsvy'
+		);
+
+		expect(
+			getPreferenceMutationStatId( 'cancellation-offer-accepted-notice-dismissed-123' )
+		).toBe( 'user-pref-update.cncofr' );
+	} );
+
+	it( 'uses an other bucket for unknown preference keys', () => {
+		expect(
+			getPreferenceMutationStatId( 'experimental-preference' as keyof UserPreferences )
+		).toBe( 'user-pref-update.other' );
+	} );
+
+	it( 'keeps stat IDs within the length limit', () => {
+		const preferenceKeys: Array< keyof UserPreferences > = [
+			'recentSites',
+			'hosting-dashboard-dark-mode-announcement-dismissed',
+			'hosting-dashboard-opt-in-welcome-modal-dismissed',
+			'account-recovery-interstitial-snoozed-until',
+			'reader-profile-posts-visibility',
+			'reader-profile-sites-visibility',
+			'hosting-dashboard-overview-storage-notice-dismissed-123',
+			'hosting-dashboard-time-mismatch-warning-dismissed-123',
+			'cancellation-offer-accepted-notice-dismissed-123',
+			'experimental-preference' as keyof UserPreferences,
+		];
+
+		preferenceKeys.forEach( ( preferenceKey ) => {
+			expect( getPreferenceMutationStatId( preferenceKey )?.length ).toBeLessThanOrEqual( 28 );
+			expect( getPreferenceOptimisticMutationStatId( preferenceKey )?.length ).toBeLessThanOrEqual(
+				28
+			);
+		} );
+	} );
+} );

--- a/packages/api-queries/src/me-preferences.ts
+++ b/packages/api-queries/src/me-preferences.ts
@@ -26,6 +26,52 @@ const defaultValues: Required< UserPreferences > = {
 	'reader-profile-hidden-sites': [],
 };
 
+const staticPreferenceStatIds: Record< string, string > = {
+	recentSites: 'recent',
+	'hosting-dashboard-color-scheme': 'color',
+	'hosting-dashboard-dark-mode-announcement-dismissed': 'darkann',
+	'hosting-dashboard-opt-in': 'optin',
+	'hosting-dashboard-opt-in-welcome-modal-dismissed': 'optwelc',
+	'hosting-dashboard-welcome-notice-dismissed': 'welcome',
+	'account-recovery-interstitial-snoozed-until': 'acctrec',
+	'reader-landing-page': 'rdland',
+	'sites-landing-page': 'stland',
+	'achievements-visibility': 'achvis',
+	'achievements-global-notifications': 'achnot',
+	'reader-profile-posts-visibility': 'postvis',
+	'reader-profile-sites-visibility': 'sitevis',
+	'reader-profile-hidden-sites': 'hidsit',
+};
+
+const dynamicPreferenceStatPrefixes: Record< string, string > = {
+	'hosting-dashboard-dataviews-view': 'dvview',
+	'hosting-dashboard-visit-count': 'visits',
+	'hosting-dashboard-overview-storage-notice-dismissed': 'storage',
+	'hosting-dashboard-tours': 'tours',
+	'hosting-dashboard-time-mismatch-warning-dismissed': 'timewrn',
+	'hosting-dashboard-wp-beta-notice-dismissed': 'wpbeta',
+	'cancel-purchase-survey-completed': 'cncsvy',
+	'cancellation-offer-accepted-notice-dismissed': 'cncofr',
+};
+
+function getUserPreferenceMutationStatId(
+	statId: string,
+	preferenceName: keyof UserPreferences
+): string {
+	const preferenceKey = String( preferenceName );
+	const staticStatId = staticPreferenceStatIds[ preferenceKey ];
+
+	if ( staticStatId ) {
+		return `${ statId }.${ staticStatId }`;
+	}
+
+	const dynamicStatId = Object.entries( dynamicPreferenceStatPrefixes ).find( ( [ prefix ] ) =>
+		preferenceKey.startsWith( `${ prefix }-` )
+	)?.[ 1 ];
+
+	return `${ statId }.${ dynamicStatId ?? 'other' }`;
+}
+
 // Returns all user preferences, without applying any defaults.
 export const rawUserPreferencesQuery = () =>
 	queryOptions( {
@@ -50,7 +96,9 @@ export const userPreferenceQuery = < P extends keyof UserPreferences >( preferen
 
 export const userPreferenceMutation = < P extends keyof UserPreferences >( preferenceName: P ) =>
 	mutationOptions( {
-		meta: { statId: 'user-pref-update' },
+		meta: {
+			statId: getUserPreferenceMutationStatId( 'user-pref-update', preferenceName ),
+		},
 		mutationFn: ( data: UserPreferences[ P ] ) =>
 			updatePreferences( {
 				[ preferenceName ]: data ?? null, // null means deleting the preference
@@ -66,7 +114,9 @@ export const userPreferenceOptimisticMutation = < P extends keyof UserPreference
 	preferenceName: P
 ) =>
 	mutationOptions( {
-		meta: { statId: 'user-pref-opt-update' },
+		meta: {
+			statId: getUserPreferenceMutationStatId( 'user-pref-opt-update', preferenceName ),
+		},
 		mutationFn: userPreferenceMutation( preferenceName ).mutationFn,
 		onMutate: async ( value ) => {
 			await queryClient.cancelQueries( { queryKey: rawUserPreferencesQuery().queryKey } );


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Add `meta.statId` to single-preference mutation options so dashboard mutation error stats identify the preference key or dynamic preference family.
* Bucket dynamic preference keys such as `hosting-dashboard-visit-count-*`, `hosting-dashboard-dataviews-view-*`, and purchase-specific keys to avoid high-cardinality stats.
* Add unit coverage for static keys, dynamic dashboard keys, dynamic purchase keys, and the `other` fallback.

## Why are these changes being made?

* Production logs are showing many `userPreferenceOptimisticMutation.405` errors for `/rest/v1.1/me/preferences?http_envelope=1`, but that shared endpoint hides which dashboard or preference flow is responsible.
* Including the preference family in the existing mutation error stat should make the production signal actionable without changing request behavior.

## Testing Instructions

* Confirm dashboard mutation error stats for preference writes now include the preference family, for example `user-pref-update.recent.405` or `user-pref-opt-update.visits.405`.
* `git diff --check`
* Not run locally: focused Jest test could not start because this worktree is missing Yarn's node_modules state file.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
