### PR TITLE
Dashboard: log visit-counter preference update failures to logstash

### DIFF
--- a/client/dashboard/app/hooks/use-visit-counter.ts
+++ b/client/dashboard/app/hooks/use-visit-counter.ts
@@ -1,8 +1,10 @@
+import { isWpError } from '@automattic/api-core';
 import { userPreferenceQuery, userPreferenceOptimisticMutation } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { useRouterState } from '@tanstack/react-router';
 import { useEffect, useRef } from 'react';
+import { logToLogstash } from 'calypso/lib/logstash';
 import { useAppContext } from '../context';
 import { resolveVisitAreaSlug } from '../survicate/visit-areas';
 
@@ -53,10 +55,29 @@ export function usePersistentVisitCounter( area: string | null ): void {
 			return;
 		}
 
-		mutate( {
-			count: ( counter?.count ?? 0 ) + 1,
-			lastUpdated: now,
-		} );
+		mutate(
+			{
+				count: ( counter?.count ?? 0 ) + 1,
+				lastUpdated: now,
+			},
+			{
+				onError: ( error ) => {
+					logToLogstash( {
+						feature: 'calypso_client',
+						message: error.message,
+						tags: [ 'dashboard', 'visit-counter-update-fail' ],
+						properties: {
+							status: isWpError( error ) ? error.status : undefined,
+							error_name: isWpError( error ) ? error.name : undefined,
+							env_id: config( 'env_id' ),
+							message: error.message,
+							path: window.location.href,
+							area,
+						},
+					} );
+				},
+			}
+		);
 	}, [ area, isSuccess, counter, mutate ] );
 }
 


### PR DESCRIPTION
## Proposed Changes

* Follow-up to #112818. Add the same logstash error logging to the automatic visit-counter preference update in `usePersistentVisitCounter` (`app/hooks/use-visit-counter.ts`), including the response status code, error name, URL path, and the visited area.

## Why are these changes being made?

* Like the omnibar `recentSites` update, the visit-counter preference update (`hosting-dashboard-visit-count-*`) fires automatically on navigation via an optimistic mutation that rolls back the cache on error, so a rejected session can re-fire the effect and retry. These updates contribute to the `POST /me/preferences` 405 volume surfaced by the `dashboard-mutation-error-status` stat, but the stat only records the status code — this logs the error details and path so we can tell which caller is failing and for whom.
* The `/logstash` endpoint accepts unauthenticated requests, so these logs get through even when the failure is an auth rejection.

## Testing Instructions

* Load the dashboard, then use browser devtools to block requests to `/me/preferences`.
* Navigate to a tracked dashboard area to trigger a visit-counter update.
* Confirm a `POST /logstash` request fires with the `visit-counter-update-fail` tag and the expected properties.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
