### PR TITLE
Build: terminate thread-loader pool on done to fix cache-seed/base-image build hang

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -494,7 +494,7 @@ webpackConfig.plugins.push( {
 				// eslint-disable-next-line import/no-extraneous-dependencies
 				require( 'thread-loader/dist/workerPools' ).getPool( { workers: workerCount } ).terminate();
 			} catch ( e ) {
-				// Best-effort cleanup — never fail the build over it.
+				console.warn( 'TerminateThreadLoaderPool: pool cleanup skipped:', e && e.message );
 			}
 		} );
 	},

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -484,9 +484,6 @@ const webpackConfig = {
 	},
 };
 
-// thread-loader leaks its worker processes on one-shot builds, and their referenced
-// pipes pin the event loop so the build never exits (thread-loader#122). Terminate the
-// pool on `done` (skip watch mode). getPool options must match calypso-build's transpile.js.
 webpackConfig.plugins.push( {
 	apply( compiler ) {
 		compiler.hooks.done.tap( 'TerminateThreadLoaderPool', () => {

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -484,4 +484,23 @@ const webpackConfig = {
 	},
 };
 
+// thread-loader leaks its worker processes on one-shot builds, and their referenced
+// pipes pin the event loop so the build never exits (thread-loader#122). Terminate the
+// pool on `done` (skip watch mode). getPool options must match calypso-build's transpile.js.
+webpackConfig.plugins.push( {
+	apply( compiler ) {
+		compiler.hooks.done.tap( 'TerminateThreadLoaderPool', () => {
+			if ( compiler.watchMode ) {
+				return;
+			}
+			try {
+				// eslint-disable-next-line import/no-extraneous-dependencies
+				require( 'thread-loader/dist/workerPools' ).getPool( { workers: workerCount } ).terminate();
+			} catch ( e ) {
+				// Best-effort cleanup — never fail the build over it.
+			}
+		} );
+	},
+} );
+
 module.exports = webpackConfig;


### PR DESCRIPTION
Part of DEVPROD-1185.

## Proposed Changes

Terminate the thread-loader worker pool when the client webpack build finishes, so a one-shot production build exits cleanly instead of hanging until the CI timeout.

## Why are these changes being made?

The cache-seed and base-image Docker builds intermittently hang for their full 65-minute limit and get killed, leaving the shared webpack cache stale and stalling downstream app builds.

Root cause: the production build uses thread-loader to parallelize babel across worker child processes. thread-loader spawns those workers `detached` and `unref()`ed, but their stdio pipes stay referenced and keep the parent's event loop alive. Workers are disposed only by a 500ms idle `poolTimeout` timer (armed only when the internal job counter reaches 0) or by a `process.on('exit')` handler — which cannot run, because the lingering workers are exactly what prevent the process from exiting. Under threadpool/CPU starvation on shared CI agents a worker's job-completion is missed, the counter never returns to 0, the disposal timer is never armed, and the workers pin the process forever. This is the still-open upstream issue webpack-contrib/thread-loader#122 (webpack 5 persistent cache + thread-loader).

webpack's `done` hook fires after the build has compiled, while the event loop is still free, so terminating the pool there runs thread-loader's own `dispose()`/`writeEnd()` teardown reliably — from a hook that runs, instead of one that provably cannot. Watch/dev-server builds keep the pool warm for fast rebuilds, so they are skipped. Both the cache-seed and base-image builds run `build-client`, which shares this config, so one change covers both.

Maintainer note: the plugin's `getPool({ workers: workerCount })` must stay in sync with the thread-loader options in `packages/calypso-build/webpack/transpile.js`. `getPool` keys its pool cache by those options, so a mismatch would return a fresh empty pool and silently no-op.

This supersedes #112768 (`UV_THREADPOOL_SIZE=32`), which targeted the libuv threadpool — the wrong layer. A controlled A/B contention sweep found raising the threadpool from 4 to 32 had no effect on the hang: the stuck handles are worker child processes, orthogonal to the libuv threadpool. The auto-retry safety net (#112802) remains complementary and worth landing regardless.

## Testing Instructions

The teardown deadlock was reproduced deterministically by setting thread-loader's `poolTimeout: Infinity`, which disables the idle disposal timer entirely and guarantees the post-`done` hang, then running the cache-seed build both ways:

- Without this fix: the build compiles, `done` fires, all worker processes linger, the process never exits, and it is killed (event loop idle several minutes, dozens of stuck `thread-loader/dist/worker.js` processes with referenced pipes).
- With this fix: `done` fires, the pool is terminated, and the build exits cleanly and succeeds.

Also confirmed in the unmodified ship configuration that `getPool` returns the same populated worker pool the loader uses and a normal build completes with no regression. Node 24 rules out the unrelated libuv io_uring hang window (nodejs/node#49911).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
