### PR TITLE
Marketplace: Vertically align free product-store cards with paid cards

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/product-price-with-discount-info/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/product-price-with-discount-info/index.tsx
@@ -48,12 +48,13 @@ function ProductPriceWithDiscount( {
 
 	if ( isFree ) {
 		return (
-			<div className={ clsx( 'product-price-with-discount__price', { 'is-compact': compact } ) }>
-				{ isFetching ? (
-					<TextPlaceholder />
-				) : (
-					<p className="product-price-with-discount__free">{ translate( 'Free' ) }</p>
-				) }
+			<div>
+				<div className={ clsx( 'product-price-with-discount__price', { 'is-compact': compact } ) }>
+					{ isFetching ? <TextPlaceholder /> : translate( 'Free' ) }
+				</div>
+				<div className="product-price-with-discount__price-interval" aria-hidden="true">
+					&nbsp;
+				</div>
 			</div>
 		);
 	}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/product-price-with-discount-info/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/product-price-with-discount-info/style.scss
@@ -17,12 +17,6 @@
 		text-wrap: nowrap;
 	}
 
-	.product-price-with-discount__free {
-		margin-block-end: 1.5rem;
-		@include heading-x-large;
-		color: var(--studio-black);
-	}
-
 	.product-price-with-discount__price-discount {
 		margin-inline-start: 8px;
 		@include heading-large;


### PR DESCRIPTION
Fixes A4A-3050

## Proposed Changes

In the Marketplace product store, paid product cards render a two-line pricing block: the price (`product-price-with-discount__price`) plus an interval line below it (`product-price-with-discount__price-interval`, e.g. “per license per month”). Free cards took a different branch that rendered only the word “Free” in a `<p class="product-price-with-discount__free">`, and reserved space with a hard-coded `margin-block-end: 1.5rem` instead of a real second line.

Because the two branches produced blocks of different heights (and the “Free” text used a different line-height than a paid price), the free card's content sat a few pixels lower than a paid card's, and the description line below it no longer lined up across a row of cards.

This change makes the free branch structurally identical to the paid branch:

- Wrap the free content in the same outer `<div>` and render “Free” as direct text inside `product-price-with-discount__price`, so it inherits the exact same font size, line-height and color as a paid price.
- Add an empty, `aria-hidden` `product-price-with-discount__price-interval` line (a non-breaking space) that reserves the same height as the paid interval line, replacing the magic margin.
- Remove the now-unused `product-price-with-discount__free` style rule.

Alignment now derives from the same typography tokens as paid cards rather than a hand-tuned constant.

## Why are these changes being made?

The free-product cards' content was not vertically aligned with the paid-product cards on the store, so a row mixing free and paid cards looked visually off — the free cards' text was nudged down relative to their paid neighbors.

## Testing Instructions

Prerequisites: A local Automattic for Agencies dev instance (`yarn start-a8c-for-agencies`), signed in to an agency account.

1. Open the products store: `/marketplace/products`.
2. Scroll to the **WooCommerce extensions** section, which mixes paid and free cards in the same row — for example *Advanced Notifications* (paid, shows `US$3.25` / “per license per month”) next to *Affirm Payments for WooCommerce* and *Afterpay for WooCommerce* (both show “Free”).
3. Verify the free cards' price line (“Free”) and the description text below it line up with the paid card's price and description on the same row.
4. Before this change, the free card's description sat a few pixels lower than the paid card's; after this change they align.

Before / after (WooCommerce extensions row — paid *Advanced Notifications* beside free *Affirm* / *Afterpay*): screenshots captured during local verification are attached to the PR.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
