### PR TITLE
A4A dashboard: declarative capability-based route guard

### DIFF
--- a/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
@@ -45,6 +45,9 @@ export default function TeamList() {
 	const canRemove = useSelector( ( state: A4AStore ) =>
 		hasAgencyCapability( state, 'a4a_remove_users' )
 	);
+	const canInvite = useSelector( ( state: A4AStore ) =>
+		hasAgencyCapability( state, 'a4a_edit_user_invites' )
+	);
 	const currentUser = useSelector( getCurrentUser );
 
 	const handleMemberAction = useHandleMemberAction( { onRefetchList: refetch } );
@@ -61,6 +64,7 @@ export default function TeamList() {
 
 	const actions = useTeamActions( {
 		canRemove,
+		canInvite,
 		currentUserEmail: currentUser?.email,
 		onResendInvite,
 		onConfirmAction: setActiveRequest,

--- a/client/dashboard/agency/team/dataviews/actions.ts
+++ b/client/dashboard/agency/team/dataviews/actions.ts
@@ -11,11 +11,13 @@ export type TeamActionRequest =
 
 export function useTeamActions( {
 	canRemove,
+	canInvite,
 	currentUserEmail,
 	onResendInvite,
 	onConfirmAction,
 }: {
 	canRemove: boolean;
+	canInvite: boolean;
 	currentUserEmail?: string;
 	onResendInvite: ( member: TeamMember ) => void;
 	onConfirmAction: ( request: TeamActionRequest ) => void;
@@ -30,13 +32,13 @@ export function useTeamActions( {
 			{
 				id: 'resend-user-invite',
 				label: __( 'Resend invite' ),
-				isEligible: ( item: TeamMember ) => isNotOwner( item ) && isInvited( item ),
+				isEligible: ( item: TeamMember ) => canInvite && isNotOwner( item ) && isInvited( item ),
 				callback: ( items: TeamMember[] ) => onResendInvite( items[ 0 ] ),
 			},
 			{
 				id: 'cancel-user-invite',
 				label: __( 'Cancel invite' ),
-				isEligible: ( item: TeamMember ) => isNotOwner( item ) && isInvited( item ),
+				isEligible: ( item: TeamMember ) => canInvite && isNotOwner( item ) && isInvited( item ),
 				callback: ( items: TeamMember[] ) =>
 					onConfirmAction( { kind: 'cancel-invite', member: items[ 0 ] } ),
 			},
@@ -65,5 +67,5 @@ export function useTeamActions( {
 					onConfirmAction( { kind: 'remove-member', member: items[ 0 ], isSelf: false } ),
 			},
 		];
-	}, [ canRemove, currentUserEmail, onResendInvite, onConfirmAction ] );
+	}, [ canRemove, canInvite, currentUserEmail, onResendInvite, onConfirmAction ] );
 }

--- a/client/dashboard/agency/team/dataviews/test/actions.test.ts
+++ b/client/dashboard/agency/team/dataviews/test/actions.test.ts
@@ -30,10 +30,14 @@ const activeSelf: TeamMember = {
 const pendingInvite: TeamMember = { id: 4, email: 'pending@example.com', status: 'pending' };
 const expiredInvite: TeamMember = { id: 5, email: 'expired@example.com', status: 'expired' };
 
-function setup( { canRemove = true }: { canRemove?: boolean } = {} ) {
+function setup( {
+	canRemove = true,
+	canInvite = true,
+}: { canRemove?: boolean; canInvite?: boolean } = {} ) {
 	const { result } = renderHook( () =>
 		useTeamActions( {
 			canRemove,
+			canInvite,
 			currentUserEmail: CURRENT_USER_EMAIL,
 			onResendInvite: () => {},
 			onConfirmAction: () => {},
@@ -94,5 +98,11 @@ describe( 'useTeamActions eligibility', () => {
 		expect( isEligible( 'remove-team-member', activeOther ) ).toBe( false );
 		// Transfer stays available; it is not capability-gated.
 		expect( isEligible( 'transfer-ownership', activeOther ) ).toBe( true );
+	} );
+
+	it( 'gates resend/cancel invite behind the invite capability', () => {
+		const isEligible = setup( { canInvite: false } );
+		expect( isEligible( 'resend-user-invite', pendingInvite ) ).toBe( false );
+		expect( isEligible( 'cancel-user-invite', pendingInvite ) ).toBe( false );
 	} );
 } );

--- a/client/dashboard/agency/team/index.tsx
+++ b/client/dashboard/agency/team/index.tsx
@@ -24,6 +24,7 @@ import TeamMembersContent from './team-members-content';
 import type { TeamMember } from '@automattic/api-core';
 
 const REMOVE_USERS_CAPABILITY = 'a4a_remove_users';
+const INVITE_USERS_CAPABILITY = 'a4a_edit_user_invites';
 
 export default function AgencyTeam() {
 	const { recordTracksEvent } = useAnalytics();
@@ -52,10 +53,9 @@ export default function AgencyTeam() {
 		[ members, invites ]
 	);
 
-	const canRemove = hasAnyCapability(
-		activeAgency?.user?.capabilities ?? [],
-		REMOVE_USERS_CAPABILITY
-	);
+	const capabilities = activeAgency?.user?.capabilities ?? [];
+	const canRemove = hasAnyCapability( capabilities, REMOVE_USERS_CAPABILITY );
+	const canInvite = hasAnyCapability( capabilities, INVITE_USERS_CAPABILITY );
 
 	const [ activeRequest, setActiveRequest ] = useState< TeamActionRequest | null >( null );
 	const [ isInviteOpen, setIsInviteOpen ] = useState( false );
@@ -89,16 +89,18 @@ export default function AgencyTeam() {
 					title={ __( 'Team' ) }
 					description={ __( 'Manage team members and invitations for your agency.' ) }
 					actions={
-						<Button
-							variant="primary"
-							__next40pxDefaultSize
-							onClick={ () => {
-								recordTracksEvent( 'calypso_dashboard_team_invite_member_click' );
-								setIsInviteOpen( true );
-							} }
-						>
-							{ __( 'Invite a team member' ) }
-						</Button>
+						canInvite ? (
+							<Button
+								variant="primary"
+								__next40pxDefaultSize
+								onClick={ () => {
+									recordTracksEvent( 'calypso_dashboard_team_invite_member_click' );
+									setIsInviteOpen( true );
+								} }
+							>
+								{ __( 'Invite a team member' ) }
+							</Button>
+						) : undefined
 					}
 				/>
 			}

--- a/client/dashboard/agency/team/index.tsx
+++ b/client/dashboard/agency/team/index.tsx
@@ -77,6 +77,7 @@ export default function AgencyTeam() {
 
 	const actions = useTeamActions( {
 		canRemove,
+		canInvite,
 		currentUserEmail: user?.email,
 		onResendInvite,
 		onConfirmAction: setActiveRequest,

--- a/client/dashboard/agency/team/index.tsx
+++ b/client/dashboard/agency/team/index.tsx
@@ -13,7 +13,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { useAuth } from '../../app/auth';
 import { usePersistentView } from '../../app/hooks/use-persistent-view';
-import { agencyTeamRoute } from '../../app/router/agency';
+import { agencyTeamRoute, hasAnyCapability } from '../../app/router/agency';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { useTeamActions, type TeamActionRequest } from './dataviews/actions';
@@ -52,7 +52,10 @@ export default function AgencyTeam() {
 		[ members, invites ]
 	);
 
-	const canRemove = !! activeAgency?.user?.capabilities?.includes( REMOVE_USERS_CAPABILITY );
+	const canRemove = hasAnyCapability(
+		activeAgency?.user?.capabilities ?? [],
+		REMOVE_USERS_CAPABILITY
+	);
 
 	const [ activeRequest, setActiveRequest ] = useState< TeamActionRequest | null >( null );
 	const [ isInviteOpen, setIsInviteOpen ] = useState( false );

--- a/client/dashboard/app/responsive-sidebar/agency.tsx
+++ b/client/dashboard/app/responsive-sidebar/agency.tsx
@@ -4,6 +4,21 @@ import { __ } from '@wordpress/i18n';
 import { home, globe, layout, pages, tag, currencyDollar, people } from '@wordpress/icons';
 import { SidebarExpandableMenuItem, SidebarMenuItem } from '../../components/sidebar';
 import { useAppContext } from '../context';
+import {
+	agencySitesRoute,
+	agencyTeamRoute,
+	agencyTiersRoute,
+	earnMigrationsRoute,
+	earnOverviewRoute,
+	earnPayoutSettingsRoute,
+	earnReferralsRoute,
+	earnWooPaymentsRoute,
+	exclusiveOffersRoute,
+	isRouteAllowedByCapabilities,
+	learnRoute,
+	mcpRoute,
+} from '../router/agency';
+import type { AnyRoute } from '@tanstack/react-router';
 
 export default function AgencySidebar() {
 	const { supports } = useAppContext();
@@ -13,29 +28,45 @@ export default function AgencySidebar() {
 		return null;
 	}
 
-	const canAccessMcp = !! ( supports.agency.mcp && activeAgency?.mcp?.allowed );
+	// Menu items are hidden rather than left to bounce off the route guard in
+	// `agencyRoute.beforeLoad`, which would redirect to /overview with an error.
+	const capabilities = activeAgency?.user?.capabilities ?? [];
+	const canAccess = ( route: AnyRoute ) => isRouteAllowedByCapabilities( route, capabilities );
+
+	const canAccessLearn = !! supports.agency.learn && canAccess( learnRoute );
+	const canAccessMcp =
+		!! ( supports.agency.mcp && activeAgency?.mcp?.allowed ) && canAccess( mcpRoute );
+	const canAccessEarn =
+		!! supports.agency.earn &&
+		[
+			earnOverviewRoute,
+			earnReferralsRoute,
+			earnWooPaymentsRoute,
+			earnMigrationsRoute,
+			earnPayoutSettingsRoute,
+		].some( canAccess );
 
 	return (
 		<>
 			<SidebarMenuItem icon={ home } to="/overview">
 				{ __( 'Home' ) }
 			</SidebarMenuItem>
-			{ supports.agency.sites && (
+			{ supports.agency.sites && canAccess( agencySitesRoute ) && (
 				<SidebarMenuItem icon={ layout } to="/sites">
 					{ __( 'Sites' ) }
 				</SidebarMenuItem>
 			) }
-			{ supports.agency.team && (
+			{ supports.agency.team && canAccess( agencyTeamRoute ) && (
 				<SidebarMenuItem icon={ people } to="/team">
 					{ __( 'Team' ) }
 				</SidebarMenuItem>
 			) }
-			{ supports.agency.tiers && (
+			{ supports.agency.tiers && canAccess( agencyTiersRoute ) && (
 				<SidebarExpandableMenuItem label={ __( 'Agency' ) } icon={ globe } to="/agency/tiers">
 					<SidebarMenuItem to="/agency/tiers">{ __( 'Tiers' ) }</SidebarMenuItem>
 				</SidebarExpandableMenuItem>
 			) }
-			{ supports.agency.exclusiveOffers && (
+			{ supports.agency.exclusiveOffers && canAccess( exclusiveOffersRoute ) && (
 				<SidebarExpandableMenuItem
 					label={ __( 'Marketplace' ) }
 					icon={ tag }
@@ -46,9 +77,9 @@ export default function AgencySidebar() {
 					</SidebarMenuItem>
 				</SidebarExpandableMenuItem>
 			) }
-			{ ( supports.agency.learn || canAccessMcp ) && (
+			{ ( canAccessLearn || canAccessMcp ) && (
 				<SidebarExpandableMenuItem label={ __( 'Resources' ) } icon={ pages } to="/resources">
-					{ supports.agency.learn && (
+					{ canAccessLearn && (
 						<SidebarMenuItem to="/resources/learn">{ __( 'Learn' ) }</SidebarMenuItem>
 					) }
 					{ canAccessMcp && (
@@ -56,15 +87,27 @@ export default function AgencySidebar() {
 					) }
 				</SidebarExpandableMenuItem>
 			) }
-			{ supports.agency.earn && (
+			{ canAccessEarn && (
 				<SidebarExpandableMenuItem label={ __( 'Earn' ) } icon={ currencyDollar } to="/earn">
-					<SidebarMenuItem to="/earn" activeOptions={ { exact: true } }>
-						{ __( 'Overview' ) }
-					</SidebarMenuItem>
-					<SidebarMenuItem to="/earn/referrals">{ __( 'Referrals' ) }</SidebarMenuItem>
-					<SidebarMenuItem to="/earn/woopayments">{ __( 'WooPayments' ) }</SidebarMenuItem>
-					<SidebarMenuItem to="/earn/migrations">{ __( 'Migrations' ) }</SidebarMenuItem>
-					<SidebarMenuItem to="/earn/payout-settings">{ __( 'Payout settings' ) }</SidebarMenuItem>
+					{ canAccess( earnOverviewRoute ) && (
+						<SidebarMenuItem to="/earn" activeOptions={ { exact: true } }>
+							{ __( 'Overview' ) }
+						</SidebarMenuItem>
+					) }
+					{ canAccess( earnReferralsRoute ) && (
+						<SidebarMenuItem to="/earn/referrals">{ __( 'Referrals' ) }</SidebarMenuItem>
+					) }
+					{ canAccess( earnWooPaymentsRoute ) && (
+						<SidebarMenuItem to="/earn/woopayments">{ __( 'WooPayments' ) }</SidebarMenuItem>
+					) }
+					{ canAccess( earnMigrationsRoute ) && (
+						<SidebarMenuItem to="/earn/migrations">{ __( 'Migrations' ) }</SidebarMenuItem>
+					) }
+					{ canAccess( earnPayoutSettingsRoute ) && (
+						<SidebarMenuItem to="/earn/payout-settings">
+							{ __( 'Payout settings' ) }
+						</SidebarMenuItem>
+					) }
 				</SidebarExpandableMenuItem>
 			) }
 		</>

--- a/client/dashboard/app/responsive-sidebar/test/agency.test.tsx
+++ b/client/dashboard/app/responsive-sidebar/test/agency.test.tsx
@@ -29,8 +29,8 @@ const config = {
 
 function mockAgency( capabilities: string[] ) {
 	nock( 'https://public-api.wordpress.com' )
+		.persist()
 		.get( '/wpcom/v2/agency' )
-		.times( 2 )
 		.reply( 200, [ { id: 1, mcp: { allowed: true }, user: { capabilities } } ] );
 }
 
@@ -47,10 +47,6 @@ async function renderSidebar( capabilities: string[] ) {
 }
 
 describe( '<AgencySidebar>', () => {
-	afterEach( () => {
-		nock.cleanAll();
-	} );
-
 	test( 'shows every menu item when the user holds every capability', async () => {
 		await renderSidebar( [
 			'a4a_read_managed_sites',
@@ -97,5 +93,20 @@ describe( '<AgencySidebar>', () => {
 		expect( screen.getByRole( 'link', { name: 'Payout settings' } ) ).toBeVisible();
 		expect( screen.queryByRole( 'link', { name: 'Referrals' } ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'link', { name: 'WooPayments' } ) ).not.toBeInTheDocument();
+	} );
+
+	// MCP is the one item gated by both a tier flag (`mcp.allowed`) and a
+	// capability (`a4a_read_learn`). `mockAgency` always reports the tier flag
+	// on, so these cases isolate the capability gate.
+	test( 'shows MCP when the agency is MCP-enabled and the user holds the learn capability', async () => {
+		await renderSidebar( [ 'a4a_read_learn' ] );
+
+		expect( screen.getByRole( 'link', { name: 'MCP' } ) ).toBeVisible();
+	} );
+
+	test( 'hides MCP when the agency is MCP-enabled but the user lacks the learn capability', async () => {
+		await renderSidebar( [ 'a4a_read_managed_sites' ] );
+
+		expect( screen.queryByRole( 'link', { name: 'MCP' } ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/dashboard/app/responsive-sidebar/test/agency.test.tsx
+++ b/client/dashboard/app/responsive-sidebar/test/agency.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import { AppProvider, APP_CONTEXT_DEFAULT_CONFIG } from '../../context';
+import AgencySidebar from '../agency';
+import type { AgencySupports } from '../../context';
+
+const agencySupports: AgencySupports = {
+	overview: true,
+	tiers: true,
+	exclusiveOffers: true,
+	learn: true,
+	mcp: true,
+	sites: true,
+	team: true,
+	earn: true,
+};
+
+// The default test config has `supports.agency: false`, which short-circuits
+// the sidebar. Nesting a provider overrides it for this component only.
+const config = {
+	...APP_CONTEXT_DEFAULT_CONFIG,
+	supports: { ...APP_CONTEXT_DEFAULT_CONFIG.supports, agency: agencySupports },
+};
+
+function mockAgency( capabilities: string[] ) {
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/wpcom/v2/agency' )
+		.times( 2 )
+		.reply( 200, [ { id: 1, mcp: { allowed: true }, user: { capabilities } } ] );
+}
+
+async function renderSidebar( capabilities: string[] ) {
+	mockAgency( capabilities );
+	render(
+		<AppProvider config={ config }>
+			<AgencySidebar />
+		</AppProvider>
+	);
+	// `Home` is unrestricted, so it marks the point where the suspended
+	// agency queries have resolved and the menu has settled.
+	await screen.findByRole( 'link', { name: 'Home' } );
+}
+
+describe( '<AgencySidebar>', () => {
+	afterEach( () => {
+		nock.cleanAll();
+	} );
+
+	test( 'shows every menu item when the user holds every capability', async () => {
+		await renderSidebar( [
+			'a4a_read_managed_sites',
+			'a4a_read_users',
+			'a4a_read_agency_tier',
+			'a4a_read_exclusive_offers',
+			'a4a_read_learn',
+			'a4a_read_referrals',
+			'a4a_read_migrations',
+		] );
+
+		expect( screen.getByRole( 'link', { name: 'Sites' } ) ).toBeVisible();
+		expect( screen.getByRole( 'link', { name: 'Team' } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Agency' } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Marketplace' } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Resources' } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Earn' } ) ).toBeVisible();
+	} );
+
+	test( 'hides menu items the user lacks the capability for', async () => {
+		await renderSidebar( [ 'a4a_read_managed_sites' ] );
+
+		expect( screen.getByRole( 'link', { name: 'Sites' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'link', { name: 'Team' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Agency' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Marketplace' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Resources' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Earn' } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'leaves only Home when the user holds no capabilities', async () => {
+		await renderSidebar( [] );
+
+		expect( screen.getByRole( 'link', { name: 'Home' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'link', { name: 'Sites' } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'keeps the Earn menu but drops the sub-items the user cannot reach', async () => {
+		await renderSidebar( [ 'a4a_read_migrations' ] );
+
+		expect( screen.getByRole( 'button', { name: 'Earn' } ) ).toBeVisible();
+		expect( screen.getByRole( 'link', { name: 'Overview' } ) ).toBeVisible();
+		expect( screen.getByRole( 'link', { name: 'Migrations' } ) ).toBeVisible();
+		expect( screen.getByRole( 'link', { name: 'Payout settings' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'link', { name: 'Referrals' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: 'WooPayments' } ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -18,22 +18,59 @@ import { createRoute, createLazyRoute, notFound, Outlet } from '@tanstack/react-
 import { __ } from '@wordpress/i18n';
 import { dashboardRedirect, redirectAsNotAllowed } from './redirect';
 import { rootRoute } from './root';
+import type { AgencyCapability } from '@automattic/api-core';
+
+type CapabilityRouteMatch = {
+	staticData?: {
+		requiresAgencyCapability?: AgencyCapability | AgencyCapability[];
+	};
+};
+
+/**
+ * Any-of (OR): true when `capabilities` contains at least one required capability.
+ */
+export function hasAnyCapability(
+	capabilities: readonly string[],
+	required: AgencyCapability | AgencyCapability[]
+): boolean {
+	const list = Array.isArray( required ) ? required : [ required ];
+	return list.some( ( capability ) => capabilities.includes( capability ) );
+}
+
+/**
+ * True when every matched agency route's declared capability requirement is
+ * satisfied. Routes without `requiresAgencyCapability` are unrestricted.
+ */
+export function isAllowedByCapabilities(
+	matches: ReadonlyArray< CapabilityRouteMatch >,
+	capabilities: readonly string[]
+): boolean {
+	return matches.every( ( match ) => {
+		const required = match.staticData?.requiresAgencyCapability;
+		return ! required || hasAnyCapability( capabilities, required );
+	} );
+}
 
 // Pathless layout route that guards every agency route (blocks client users).
 const agencyRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	id: 'agency',
-	beforeLoad: async ( { cause } ) => {
+	beforeLoad: async ( { cause, matches } ) => {
 		if ( cause === 'preload' ) {
 			return; // Don't redirect on hover/intent preloads.
 		}
 
-		const [ agency ] = await Promise.all( [
+		const [ agency, activeAgency ] = await Promise.all( [
 			queryClient.ensureQueryData( agencyQuery() ),
 			queryClient.ensureQueryData( activeAgencyQuery() ),
 		] );
 		if ( agency.isClientUser ) {
 			throw redirectAsNotAllowed( { to: '/client/subscriptions' } );
+		}
+
+		const capabilities = activeAgency?.user?.capabilities ?? [];
+		if ( ! isAllowedByCapabilities( matches, capabilities ) ) {
+			throw redirectAsNotAllowed( { to: '/overview' } );
 		}
 	},
 } );
@@ -190,6 +227,7 @@ export const agencySitesRoute = createRoute( {
 
 // `/team` – manage agency team members and invitations
 export const agencyTeamRoute = createRoute( {
+	staticData: { requiresAgencyCapability: 'a4a_read_users' },
 	head: () => ( {
 		meta: [ { title: __( 'Team' ) } ],
 	} ),

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -19,12 +19,7 @@ import { __ } from '@wordpress/i18n';
 import { dashboardRedirect, redirectAsNotAllowed } from './redirect';
 import { rootRoute } from './root';
 import type { AgencyCapability } from '@automattic/api-core';
-
-type CapabilityRouteMatch = {
-	staticData?: {
-		requiresAgencyCapability?: AgencyCapability | AgencyCapability[];
-	};
-};
+import type { AnyRoute, StaticDataRouteOption } from '@tanstack/react-router';
 
 /**
  * Any-of (OR): true when `capabilities` contains at least one required capability.
@@ -37,18 +32,35 @@ export function hasAnyCapability(
 	return list.some( ( capability ) => capabilities.includes( capability ) );
 }
 
+function satisfiesStaticData(
+	staticData: StaticDataRouteOption | undefined,
+	capabilities: readonly string[]
+): boolean {
+	const required = staticData?.requiresAgencyCapability;
+	return ! required || hasAnyCapability( capabilities, required );
+}
+
 /**
  * True when every matched agency route's declared capability requirement is
  * satisfied. Routes without `requiresAgencyCapability` are unrestricted.
  */
 export function isAllowedByCapabilities(
-	matches: ReadonlyArray< CapabilityRouteMatch >,
+	matches: ReadonlyArray< { staticData?: StaticDataRouteOption } >,
 	capabilities: readonly string[]
 ): boolean {
-	return matches.every( ( match ) => {
-		const required = match.staticData?.requiresAgencyCapability;
-		return ! required || hasAnyCapability( capabilities, required );
-	} );
+	return matches.every( ( match ) => satisfiesStaticData( match.staticData, capabilities ) );
+}
+
+/**
+ * The same check against a route object, for surfaces that decide whether to
+ * link to a route at all (the sidebar) rather than guarding a navigation to it.
+ * Reading the requirement off the route keeps the menu and the guard in sync.
+ */
+export function isRouteAllowedByCapabilities(
+	route: AnyRoute,
+	capabilities: readonly string[]
+): boolean {
+	return satisfiesStaticData( route.options.staticData, capabilities );
 }
 
 // Pathless layout route that guards every agency route (blocks client users).
@@ -95,7 +107,7 @@ const agencyOverviewRoute = createRoute( {
 );
 
 // `/tiers` – agency tiers & benefits
-const agencyTiersRoute = createRoute( {
+export const agencyTiersRoute = createRoute( {
 	staticData: { requiresAgencyCapability: 'a4a_read_agency_tier' },
 	head: () => ( {
 		meta: [
@@ -116,7 +128,7 @@ const agencyTiersRoute = createRoute( {
 );
 
 // `/marketplace/exclusive-offers` – partner offers (Refer / Resell)
-const exclusiveOffersRoute = createRoute( {
+export const exclusiveOffersRoute = createRoute( {
 	staticData: { requiresAgencyCapability: 'a4a_read_exclusive_offers' },
 	head: () => ( {
 		meta: [
@@ -136,7 +148,7 @@ const exclusiveOffersRoute = createRoute( {
 );
 
 // `/resources/learn` – guides, articles, and training for agencies
-const learnRoute = createRoute( {
+export const learnRoute = createRoute( {
 	staticData: { requiresAgencyCapability: 'a4a_read_learn' },
 	head: () => ( {
 		meta: [
@@ -165,7 +177,7 @@ const ensureMcpSettings = async () => {
 	}
 };
 
-const mcpRoute = createRoute( {
+export const mcpRoute = createRoute( {
 	staticData: { requiresAgencyCapability: 'a4a_read_learn' },
 	head: () => ( { meta: [ { title: __( 'MCP' ) } ] } ),
 	getParentRoute: () => agencyRoute,
@@ -248,7 +260,7 @@ export const agencyTeamRoute = createRoute( {
 );
 
 // `/earn` – summary of the agency's earning programs (default Earn screen)
-const earnOverviewRoute = createRoute( {
+export const earnOverviewRoute = createRoute( {
 	staticData: { requiresAgencyCapability: [ 'a4a_read_referrals', 'a4a_read_migrations' ] },
 	head: () => ( { meta: [ { title: __( 'Overview' ) } ] } ),
 	getParentRoute: () => agencyRoute,
@@ -260,7 +272,7 @@ const earnOverviewRoute = createRoute( {
 );
 
 // `/earn/referrals` – referral commissions
-const earnReferralsRoute = createRoute( {
+export const earnReferralsRoute = createRoute( {
 	staticData: { requiresAgencyCapability: 'a4a_read_referrals' },
 	head: () => ( { meta: [ { title: __( 'Referrals' ) } ] } ),
 	getParentRoute: () => agencyRoute,
@@ -272,7 +284,7 @@ const earnReferralsRoute = createRoute( {
 );
 
 // `/earn/woopayments` – WooPayments revenue share
-const earnWooPaymentsRoute = createRoute( {
+export const earnWooPaymentsRoute = createRoute( {
 	// TODO: replace with a dedicated WooPayments capability when one exists.
 	staticData: { requiresAgencyCapability: 'a4a_read_referrals' },
 	head: () => ( { meta: [ { title: __( 'WooPayments' ) } ] } ),
@@ -285,7 +297,7 @@ const earnWooPaymentsRoute = createRoute( {
 );
 
 // `/earn/migrations` – migration commissions
-const earnMigrationsRoute = createRoute( {
+export const earnMigrationsRoute = createRoute( {
 	staticData: { requiresAgencyCapability: 'a4a_read_migrations' },
 	head: () => ( { meta: [ { title: __( 'Migrations' ) } ] } ),
 	getParentRoute: () => agencyRoute,
@@ -297,7 +309,7 @@ const earnMigrationsRoute = createRoute( {
 );
 
 // `/earn/payout-settings` – where and how the agency gets paid
-const earnPayoutSettingsRoute = createRoute( {
+export const earnPayoutSettingsRoute = createRoute( {
 	staticData: { requiresAgencyCapability: [ 'a4a_read_referrals', 'a4a_read_migrations' ] },
 	head: () => ( { meta: [ { title: __( 'Payout settings' ) } ] } ),
 	getParentRoute: () => agencyRoute,

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -96,6 +96,7 @@ const agencyOverviewRoute = createRoute( {
 
 // `/tiers` – agency tiers & benefits
 const agencyTiersRoute = createRoute( {
+	staticData: { requiresAgencyCapability: 'a4a_read_agency_tier' },
 	head: () => ( {
 		meta: [
 			{
@@ -116,6 +117,7 @@ const agencyTiersRoute = createRoute( {
 
 // `/marketplace/exclusive-offers` – partner offers (Refer / Resell)
 const exclusiveOffersRoute = createRoute( {
+	staticData: { requiresAgencyCapability: 'a4a_read_exclusive_offers' },
 	head: () => ( {
 		meta: [
 			{
@@ -135,6 +137,7 @@ const exclusiveOffersRoute = createRoute( {
 
 // `/resources/learn` – guides, articles, and training for agencies
 const learnRoute = createRoute( {
+	staticData: { requiresAgencyCapability: 'a4a_read_learn' },
 	head: () => ( {
 		meta: [
 			{
@@ -163,6 +166,7 @@ const ensureMcpSettings = async () => {
 };
 
 const mcpRoute = createRoute( {
+	staticData: { requiresAgencyCapability: 'a4a_read_learn' },
 	head: () => ( { meta: [ { title: __( 'MCP' ) } ] } ),
 	getParentRoute: () => agencyRoute,
 	path: 'resources/ai-mcp',
@@ -211,6 +215,7 @@ const mcpConnectRoute = createRoute( {
 
 // `/sites` – agency-managed sites
 export const agencySitesRoute = createRoute( {
+	staticData: { requiresAgencyCapability: 'a4a_read_managed_sites' },
 	head: () => ( {
 		meta: [ { title: __( 'Sites' ) } ],
 	} ),
@@ -244,6 +249,7 @@ export const agencyTeamRoute = createRoute( {
 
 // `/earn` – summary of the agency's earning programs (default Earn screen)
 const earnOverviewRoute = createRoute( {
+	staticData: { requiresAgencyCapability: [ 'a4a_read_referrals', 'a4a_read_migrations' ] },
 	head: () => ( { meta: [ { title: __( 'Overview' ) } ] } ),
 	getParentRoute: () => agencyRoute,
 	path: 'earn',
@@ -255,6 +261,7 @@ const earnOverviewRoute = createRoute( {
 
 // `/earn/referrals` – referral commissions
 const earnReferralsRoute = createRoute( {
+	staticData: { requiresAgencyCapability: 'a4a_read_referrals' },
 	head: () => ( { meta: [ { title: __( 'Referrals' ) } ] } ),
 	getParentRoute: () => agencyRoute,
 	path: 'earn/referrals',
@@ -266,6 +273,8 @@ const earnReferralsRoute = createRoute( {
 
 // `/earn/woopayments` – WooPayments revenue share
 const earnWooPaymentsRoute = createRoute( {
+	// TODO: replace with a dedicated WooPayments capability when one exists.
+	staticData: { requiresAgencyCapability: 'a4a_read_referrals' },
 	head: () => ( { meta: [ { title: __( 'WooPayments' ) } ] } ),
 	getParentRoute: () => agencyRoute,
 	path: 'earn/woopayments',
@@ -277,6 +286,7 @@ const earnWooPaymentsRoute = createRoute( {
 
 // `/earn/migrations` – migration commissions
 const earnMigrationsRoute = createRoute( {
+	staticData: { requiresAgencyCapability: 'a4a_read_migrations' },
 	head: () => ( { meta: [ { title: __( 'Migrations' ) } ] } ),
 	getParentRoute: () => agencyRoute,
 	path: 'earn/migrations',
@@ -288,6 +298,7 @@ const earnMigrationsRoute = createRoute( {
 
 // `/earn/payout-settings` – where and how the agency gets paid
 const earnPayoutSettingsRoute = createRoute( {
+	staticData: { requiresAgencyCapability: [ 'a4a_read_referrals', 'a4a_read_migrations' ] },
 	head: () => ( { meta: [ { title: __( 'Payout settings' ) } ] } ),
 	getParentRoute: () => agencyRoute,
 	path: 'earn/payout-settings',
@@ -347,6 +358,7 @@ const earnReferralPurchasesRoute = createRoute( {
 
 // `/sites/$siteSlug` – agency site detail (a layout that hosts the section routes)
 export const agencySiteRoute = createRoute( {
+	staticData: { requiresAgencyCapability: 'a4a_read_managed_sites' },
 	getParentRoute: () => agencyRoute,
 	path: 'sites/$siteSlug',
 	loader: async ( { params: { siteSlug } } ) => {

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -261,6 +261,7 @@ export const agencyTeamRoute = createRoute( {
 
 // `/earn` – summary of the agency's earning programs (default Earn screen)
 export const earnOverviewRoute = createRoute( {
+	// TODO: replace with a top-level `a4a_read_earnings` capability when one exists.
 	staticData: { requiresAgencyCapability: [ 'a4a_read_referrals', 'a4a_read_migrations' ] },
 	head: () => ( { meta: [ { title: __( 'Overview' ) } ] } ),
 	getParentRoute: () => agencyRoute,
@@ -310,6 +311,7 @@ export const earnMigrationsRoute = createRoute( {
 
 // `/earn/payout-settings` – where and how the agency gets paid
 export const earnPayoutSettingsRoute = createRoute( {
+	// TODO: replace with a top-level `a4a_read_earnings` capability when one exists.
 	staticData: { requiresAgencyCapability: [ 'a4a_read_referrals', 'a4a_read_migrations' ] },
 	head: () => ( { meta: [ { title: __( 'Payout settings' ) } ] } ),
 	getParentRoute: () => agencyRoute,
@@ -322,6 +324,7 @@ export const earnPayoutSettingsRoute = createRoute( {
 
 // `/earn/referrals/$referralId` – referral (client) detail view; hosts the tab routes
 export const earnReferralRoute = createRoute( {
+	staticData: { requiresAgencyCapability: 'a4a_read_referrals' },
 	head: () => ( { meta: [ { title: __( 'Referral details' ) } ] } ),
 	getParentRoute: () => agencyRoute,
 	path: 'earn/referrals/$referralId',

--- a/client/dashboard/app/router/index.tsx
+++ b/client/dashboard/app/router/index.tsx
@@ -16,6 +16,7 @@ import { createSitesRoutes } from './sites';
 import { startStoreRoute } from './start-store';
 import type { SiteTypeFeature } from '../../utils/site-type-feature-support';
 import type { AppConfig } from '../context';
+import type { AgencyCapability } from '@automattic/api-core';
 import type { ErrorInfo } from 'react';
 
 /**
@@ -29,6 +30,11 @@ declare module '@tanstack/react-router' {
 		 */
 		requiresSiteTypeSupport?: SiteTypeFeature;
 		availableToInaccessibleJetpackSites?: boolean;
+		/**
+		 * If set, the route is only accessible when the agency user holds at least one
+		 * of these capabilities. Enforced in agencyRoute.beforeLoad.
+		 */
+		requiresAgencyCapability?: AgencyCapability | AgencyCapability[];
 	}
 }
 

--- a/client/dashboard/app/router/test/agency-capabilities.test.ts
+++ b/client/dashboard/app/router/test/agency-capabilities.test.ts
@@ -23,7 +23,9 @@ function collectUnguardedRoutes(
 	ancestorGuarded: boolean,
 	parentPath: string
 ): string[] {
-	const path = route.options?.path;
+	// Index routes carry `path: '/'`; treat it as no segment so paths don't
+	// gain a trailing `//`.
+	const path = route.options?.path === '/' ? undefined : route.options?.path;
 	const fullPath = path ? [ parentPath, path ].filter( Boolean ).join( '/' ) : parentPath;
 	const guarded = ancestorGuarded || !! route.options?.staticData?.requiresAgencyCapability;
 	const children = Array.isArray( route.children ) ? route.children : [];

--- a/client/dashboard/app/router/test/agency-capabilities.test.ts
+++ b/client/dashboard/app/router/test/agency-capabilities.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { hasAnyCapability, isAllowedByCapabilities } from '../agency';
+
+describe( 'hasAnyCapability', () => {
+	test( 'returns true when the single required capability is present', () => {
+		expect( hasAnyCapability( [ 'a4a_read_reports' ], 'a4a_read_reports' ) ).toBe( true );
+	} );
+
+	test( 'returns false when the single required capability is absent', () => {
+		expect( hasAnyCapability( [ 'a4a_read_users' ], 'a4a_read_reports' ) ).toBe( false );
+	} );
+
+	test( 'returns true when at least one of an array is present (any-of)', () => {
+		expect(
+			hasAnyCapability( [ 'a4a_read_users' ], [ 'a4a_read_reports', 'a4a_read_users' ] )
+		).toBe( true );
+	} );
+
+	test( 'returns false when none of an array is present', () => {
+		expect(
+			hasAnyCapability( [ 'a4a_read_marketplace' ], [ 'a4a_read_reports', 'a4a_read_users' ] )
+		).toBe( false );
+	} );
+
+	test( 'returns false for an empty capabilities list', () => {
+		expect( hasAnyCapability( [], 'a4a_read_reports' ) ).toBe( false );
+	} );
+} );
+
+describe( 'isAllowedByCapabilities', () => {
+	test( 'allows a route with no capability requirement', () => {
+		expect( isAllowedByCapabilities( [ { staticData: {} }, {} ], [] ) ).toBe( true );
+	} );
+
+	test( 'allows when the required capability is present', () => {
+		expect(
+			isAllowedByCapabilities(
+				[ { staticData: { requiresAgencyCapability: 'a4a_read_reports' } } ],
+				[ 'a4a_read_reports' ]
+			)
+		).toBe( true );
+	} );
+
+	test( 'blocks when a matched route requires an absent capability', () => {
+		expect(
+			isAllowedByCapabilities(
+				[ { staticData: { requiresAgencyCapability: 'a4a_read_reports' } } ],
+				[ 'a4a_read_users' ]
+			)
+		).toBe( false );
+	} );
+
+	test( 'blocks when any matched route in the chain is unauthorized', () => {
+		expect(
+			isAllowedByCapabilities(
+				[
+					{ staticData: {} },
+					{
+						staticData: {
+							requiresAgencyCapability: [ 'a4a_read_reports', 'a4a_edit_reports' ],
+						},
+					},
+				],
+				[ 'a4a_read_users' ]
+			)
+		).toBe( false );
+	} );
+} );

--- a/client/dashboard/app/router/test/agency-capabilities.test.ts
+++ b/client/dashboard/app/router/test/agency-capabilities.test.ts
@@ -2,7 +2,39 @@
  * @jest-environment jsdom
  */
 
-import { hasAnyCapability, isAllowedByCapabilities } from '../agency';
+import { createAgencyRoutes, hasAnyCapability, isAllowedByCapabilities } from '../agency';
+import type { StaticDataRouteOption } from '@tanstack/react-router';
+
+type RouteNode = {
+	options?: { path?: string; staticData?: StaticDataRouteOption };
+	children?: RouteNode[];
+};
+
+// Routes that are intentionally reachable by any agency member, so they carry
+// no `requiresAgencyCapability`. Anything else must be guarded by itself or an
+// ancestor; a new unguarded route will fail the coverage test below.
+const OPEN_ROUTE_PATHS = new Set( [
+	'', // the pathless `agency` guard route itself
+	'overview', // the fallback the capability guard redirects to
+] );
+
+function collectUnguardedRoutes(
+	route: RouteNode,
+	ancestorGuarded: boolean,
+	parentPath: string
+): string[] {
+	const path = route.options?.path;
+	const fullPath = path ? [ parentPath, path ].filter( Boolean ).join( '/' ) : parentPath;
+	const guarded = ancestorGuarded || !! route.options?.staticData?.requiresAgencyCapability;
+	const children = Array.isArray( route.children ) ? route.children : [];
+
+	const unguarded = ! guarded && ! OPEN_ROUTE_PATHS.has( fullPath ) ? [ fullPath ] : [];
+
+	return children.reduce< string[] >(
+		( acc, child ) => acc.concat( collectUnguardedRoutes( child, guarded, fullPath ) ),
+		unguarded
+	);
+}
 
 describe( 'hasAnyCapability', () => {
 	test( 'returns true when the single required capability is present', () => {
@@ -67,5 +99,17 @@ describe( 'isAllowedByCapabilities', () => {
 				[ 'a4a_read_users' ]
 			)
 		).toBe( false );
+	} );
+} );
+
+describe( 'createAgencyRoutes capability coverage', () => {
+	test( 'every agency route is capability-guarded or explicitly open', () => {
+		const routes = createAgencyRoutes() as RouteNode[];
+		const unguarded = routes.reduce< string[] >(
+			( acc, route ) => acc.concat( collectUnguardedRoutes( route, false, '' ) ),
+			[]
+		);
+
+		expect( unguarded ).toEqual( [] );
 	} );
 } );

--- a/packages/api-core/src/agency/types.ts
+++ b/packages/api-core/src/agency/types.ts
@@ -15,6 +15,30 @@ export interface AgencyTier {
 }
 
 /**
+ * Agency user capabilities, following the `a4a_<action>_<resource>` convention.
+ * Used to declare per-route access requirements in the dashboard router.
+ */
+export type AgencyCapability =
+	| 'a4a_read_managed_sites'
+	| 'a4a_read_reports'
+	| 'a4a_edit_reports'
+	| 'a4a_read_marketplace'
+	| 'a4a_read_referrals'
+	| 'a4a_read_migrations'
+	| 'a4a_read_partner_directory'
+	| 'a4a_read_agency_tier'
+	| 'a4a_read_users'
+	| 'a4a_read_learn'
+	| 'a4a_read_amplify'
+	| 'a4a_read_exclusive_offers'
+	| 'a4a_jetpack_licensing'
+	| 'a4a_edit_user_invites'
+	| 'a4a_remove_users'
+	| 'a4a_revoke_licenses'
+	| 'a4a_remove_payment_methods'
+	| 'a4a_remove_managed_sites';
+
+/**
  * A single agency, as returned by GET /wpcom/v2/agency. Only the fields
  * consumed by the dashboard are modeled here.
  */


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-2939/implement-permission-check-on-msd-for-a4a

## Proposed Changes

* Add a declarative, capability-based route guard for the A4A area of the multi-site Dashboard. Routes declare a required agency capability via `staticData.requiresAgencyCapability`; the agency layout route's `beforeLoad` enforces it against the active agency's capabilities and redirects unauthorized users to `/overview` with a `route-not-allowed` flash (the same redirect-then-toast convention as the existing Agency/Client guard).
* Add an `AgencyCapability` union type in `@automattic/api-core`.
* Annotate the existing agency routes with their required capability, ported from Calypso's `MEMBER_ACCESSIBLE_PATHS`: tiers, exclusive offers, learn, MCP, sites (list + `$siteSlug` layout, whose children inherit), team, and the earn programs. The overview route stays open.
* Filter the agency sidebar by the same capabilities, so gated routes are hidden rather than left as dead links that bounce to `/overview`. Expandable parents (Agency, Marketplace, Resources, Earn) hide when they would be empty; Earn keeps the sub-items the user can reach and drops the rest. Calypso does the equivalent in `use-main-menu-items`.
* Reuse the shared `hasAnyCapability` helper for the team screen's remove-users check.

## Why are these changes being made?

The classic Calypso A4A dashboard gates routes on per-user agency capabilities (`isPathAllowed` / `MEMBER_ACCESSIBLE_PATHS`). The new Dashboard client had no route-level capability guard yet. This ports that access control so multi-user agencies only reach routes their capabilities permit. It intentionally mirrors the already-shipped `requiresSiteTypeSupport` `staticData` pattern (enforced centrally in a parent `beforeLoad`) for consistency and a single auditable enforcement point.

The sidebar reads each requirement off the route object via `isRouteAllowedByCapabilities( route, capabilities )` rather than keeping its own copy of the capability map — the same approach the site sidebar already uses for `availableToInaccessibleJetpackSites`. The menu and the guard therefore cannot drift apart: annotating a route gates it and hides its menu entry in one edit.

Scope is capabilities only. Tier/feature gating (e.g. the MCP `mcp.allowed` gate) and role checks are left as their existing separate mechanisms.

## Testing Instructions

* Unit tests: `yarn test-client client/dashboard/app/router/test/agency-capabilities.test.ts client/dashboard/app/responsive-sidebar/test/agency.test.tsx` (13 passing).
* As an agency user **without** a given capability, confirm the corresponding sidebar entry is absent (e.g. no Team entry without `a4a_read_users`), and that navigating directly to `/team` still redirects to `/overview` with the “route not allowed” snackbar.
* As an agency user **with** the capability, confirm the entry is present and the route loads normally.
* With only `a4a_read_migrations`, confirm the Earn menu still appears but shows only Overview, Migrations and Payout settings — not Referrals or WooPayments.
* Confirm the always-open `/overview` remains reachable regardless of capabilities, and that client users are still redirected to `/client/subscriptions`.

> Note: `yarn typecheck-client` currently reports pre-existing errors in `client/dashboard/me/notifications-*` caused by a stale `@automattic/api-queries` build on trunk. None are in files touched by this PR; they clear with a clean package build.

### Open questions for review

* **Earn overview and payout settings** are gated as any-of `['a4a_read_referrals', 'a4a_read_migrations']` — MSD groups earnings differently from Calypso, so there is no exact 1:1. Confirm this is the intended access rule.
* **WooPayments** reuses `a4a_read_referrals` (carried over from Calypso's placeholder); marked with a `TODO` for a dedicated capability.
* **Unannotated routes are open by default**, whereas Calypso's `isPathAllowed` denies unlisted paths. This matches the existing `requiresSiteTypeSupport` convention, but it means a new agency route is reachable by every member until someone annotates it. Worth deciding whether to add a test that asserts every agency route is either annotated or explicitly allowlisted.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
