### PR TITLE
Fix E2E teardown user leak on invalid_token account close

### DIFF
--- a/packages/calypso-e2e/src/teardown-markers.ts
+++ b/packages/calypso-e2e/src/teardown-markers.ts
@@ -12,6 +12,10 @@ const MAX_ERROR_LENGTH = 300;
 const ATOMIC_DEPROVISION_TIMEOUT_MS = 180 * 1000;
 const ATOMIC_DEPROVISION_POLL_MS = 15 * 1000;
 
+// Fresh signup tokens can reach `/me` before the account-close endpoint.
+const TOKEN_PROPAGATION_TIMEOUT_MS = 30 * 1000;
+const TOKEN_PROPAGATION_POLL_MS = 5 * 1000;
+
 export interface AccountLeak {
 	/**
 	 * Numeric user ID; absent when a signup response created an account but did
@@ -91,6 +95,19 @@ function isActiveAtomicSiteError( error: unknown ): boolean {
 		return true;
 	}
 	return /atomic-site|active atomic sites/i.test( errorMessage( error ) );
+}
+
+/**
+ * Matches only raw close responses. A thrown `invalid_token` came from the
+ * preliminary `/me` request and is handled by the closed-account probe.
+ */
+function isTransientInvalidTokenCloseResponse( error: unknown ): boolean {
+	return (
+		!! error &&
+		typeof error === 'object' &&
+		! ( error instanceof Error ) &&
+		( error as { error?: unknown } ).error === 'invalid_token'
+	);
 }
 
 /**
@@ -208,7 +225,11 @@ export async function closeAccountAndRecordLeak(
 	// Track the wait so the terminal `[atomic-teardown]` breadcrumb reports how
 	// long the Atomic deprovision took, surfacing drift if that timing changes.
 	const startedAt = Date.now();
-	const deadline = startedAt + ATOMIC_DEPROVISION_TIMEOUT_MS;
+	const atomicDeadline = startedAt + ATOMIC_DEPROVISION_TIMEOUT_MS;
+	// Anchored to the first invalid_token response, not startedAt, so an Atomic
+	// deprovision wait can't consume the token-propagation window before the
+	// token race has even surfaced.
+	let tokenDeadline: number | undefined;
 	let closeError: unknown;
 	let attempts = 0;
 	let sawAtomicSite = false;
@@ -241,13 +262,22 @@ export async function closeAccountAndRecordLeak(
 			closeError = error;
 		}
 
-		// Only an active-Atomic-site rejection is worth waiting on; every other
-		// failure is terminal and falls through to the leak probe immediately.
-		if ( ! isActiveAtomicSiteError( closeError ) || Date.now() >= deadline ) {
+		let pollMs: number;
+		if ( isActiveAtomicSiteError( closeError ) && Date.now() < atomicDeadline ) {
+			sawAtomicSite = true;
+			pollMs = ATOMIC_DEPROVISION_POLL_MS;
+		} else if ( isTransientInvalidTokenCloseResponse( closeError ) ) {
+			if ( tokenDeadline === undefined ) {
+				tokenDeadline = Date.now() + TOKEN_PROPAGATION_TIMEOUT_MS;
+			}
+			if ( Date.now() >= tokenDeadline ) {
+				break;
+			}
+			pollMs = TOKEN_PROPAGATION_POLL_MS;
+		} else {
 			break;
 		}
-		sawAtomicSite = true;
-		await new Promise( ( resolve ) => setTimeout( resolve, ATOMIC_DEPROVISION_POLL_MS ) );
+		await new Promise( ( resolve ) => setTimeout( resolve, pollMs ) );
 	}
 
 	if ( sawAtomicSite ) {

--- a/packages/calypso-e2e/src/test/teardown-markers.test.ts
+++ b/packages/calypso-e2e/src/test/teardown-markers.test.ts
@@ -273,9 +273,15 @@ describe( 'closeAccountAndRecordLeak', () => {
 		expect( existsSync( markerFile( details.userID ) ) ).toBe( false );
 	} );
 
-	test( 'retries while the close is blocked by an active Atomic site, then clears once it succeeds', async () => {
-		jest.useFakeTimers();
-		try {
+	describe( 'retry loops (fake timers)', () => {
+		beforeEach( () => {
+			jest.useFakeTimers();
+		} );
+		afterEach( () => {
+			jest.useRealTimers();
+		} );
+
+		test( 'retries while the close is blocked by an active Atomic site, then clears once it succeeds', async () => {
 			let calls = 0;
 			const closeAccount = jest.fn( async () => {
 				calls += 1;
@@ -294,14 +300,9 @@ describe( 'closeAccountAndRecordLeak', () => {
 
 			expect( closeAccount ).toHaveBeenCalledTimes( 3 );
 			expect( existsSync( markerFile( details.userID ) ) ).toBe( false );
-		} finally {
-			jest.useRealTimers();
-		}
-	} );
+		} );
 
-	test( 'records a leak when the Atomic site never deprovisions within the retry window', async () => {
-		jest.useFakeTimers();
-		try {
+		test( 'records a leak when the Atomic site never deprovisions within the retry window', async () => {
 			const promise = closeAccountAndRecordLeak(
 				fakeClient( {
 					closeAccount: jest.fn( async () => ( {
@@ -318,9 +319,64 @@ describe( 'closeAccountAndRecordLeak', () => {
 			await promise;
 
 			expect( existsSync( markerFile( details.userID ) ) ).toBe( true );
-		} finally {
-			jest.useRealTimers();
-		}
+		} );
+
+		test( 'retries while the close POST rejects a fresh token, then clears once it succeeds', async () => {
+			let calls = 0;
+			const closeAccount = jest.fn( async () => {
+				calls += 1;
+				return calls < 3
+					? { error: 'invalid_token', message: 'The OAuth2 token is invalid.' }
+					: { success: true };
+			} );
+			const promise = closeAccountAndRecordLeak(
+				fakeClient( { closeAccount, getMyAccountInformation: jest.fn( async () => ( {} ) ) } ),
+				details,
+				leakDir
+			);
+			await jest.advanceTimersByTimeAsync( 30 * 1000 );
+			await promise;
+
+			expect( closeAccount ).toHaveBeenCalledTimes( 3 );
+			expect( existsSync( markerFile( details.userID ) ) ).toBe( false );
+		} );
+
+		test( 'records a leak when the close POST still rejects the token past the retry window', async () => {
+			const promise = closeAccountAndRecordLeak(
+				fakeClient( {
+					closeAccount: jest.fn( async () => ( {
+						error: 'invalid_token',
+						message: 'The OAuth2 token is invalid.',
+					} ) ),
+					getMyAccountInformation: jest.fn( async () => ( {} ) ),
+				} ),
+				details,
+				leakDir
+			);
+			await jest.advanceTimersByTimeAsync( 60 * 1000 );
+			await promise;
+
+			expect( existsSync( markerFile( details.userID ) ) ).toBe( true );
+		} );
+	} );
+
+	test( 'a thrown invalid_token error is not retried and resolves via the probe', async () => {
+		const closeAccount = jest.fn( async () => {
+			throw new Error( 'invalid_token: The OAuth2 token is invalid.' );
+		} );
+		await closeAccountAndRecordLeak(
+			fakeClient( {
+				closeAccount,
+				getMyAccountInformation: jest.fn( async () => {
+					throw new Error( 'invalid_token: The OAuth2 token is invalid.' );
+				} ),
+			} ),
+			details,
+			leakDir
+		);
+
+		expect( closeAccount ).toHaveBeenCalledTimes( 1 );
+		expect( existsSync( markerFile( details.userID ) ) ).toBe( false );
 	} );
 
 	test( 'never throws even when the client throws', async () => {


### PR DESCRIPTION
## Related

Originating alert: `p1784592090375969-slack-C0E1C5NCR`

## Proposed Changes

E2E teardown leaked test users when the account-close `POST` rejected a seconds-old signup bearer token with `invalid_token` (read-after-write propagation lag). The close-retry loop only retried `atomic-site` rejections, so `invalid_token` was terminal and the account leaked.

`packages/calypso-e2e/src/teardown-markers.ts`:

- Retry the close on a transient `invalid_token` **response object** within a 30s window (5s poll), alongside the existing `atomic-site` retry (180s / 15s), each on its own deadline.
- The token deadline is anchored to the first `invalid_token` response, not teardown start, so an Atomic-deprovision wait cannot consume the propagation window before the token race surfaces.
- Only the raw `{ error: 'invalid_token' }` close response is retried. A thrown `invalid_token` `Error` (dead / already-closed token) is not retried and still resolves instantly via the post-loop probe.

All spec teardowns route through `closeAccountAndRecordLeak`, so one guard covers every spec, desktop and mobile, with no per-spec changes.

## Why

Fresh signup tokens are accepted by `GET /me` before the account-close endpoint accepts them. Known behavior, already modeled for site creation in `test/e2e/specs/shared/api-wait-for-account-propagation.ts`. Observed lag was seconds, so the common recovery is one extra attempt (~5s). If the token stays rejected past 30s the run still records the leak: no leak can be silently dropped.

## Testing Instructions

- `yarn test-packages packages/calypso-e2e/src/test/teardown-markers.test.ts` — 28/28 pass.
- `yarn typecheck-client` — clean (CI runs it; the changed package is consumed by `test/e2e`).

Affected pre-release matrix builds: desktop `18583560`, mobile `18583561` (run #5104). The token-lag signature (`invalid_token` object in a leak marker) should no longer fail teardown; the genuine-leak path is unchanged, so real leaks still fail the build.
