### PR TITLE
Revert "Onboarding: ship winning mobile signup layout, remove experiment"

### DIFF
--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -52,6 +52,7 @@ interface SignupFormSocialFirst {
 	isEmailFirstVariant?: boolean;
 	isEmailAtBottom?: boolean;
 	isMobileCompactVariant?: boolean;
+	hideTosElement?: boolean;
 	allowedSocialServices?: SignupAllowedService[];
 	customTosElement?: JSX.Element;
 }
@@ -77,17 +78,26 @@ const options = {
 
 type Screen = 'initial' | 'email';
 
-// ToS copy for the mobile-compact signup layout. Rendered inside the form below
-// the sign-up options, kept as its own component so the legal links and the
+// ToS copy for the mobile-layout experiment. Same component is rendered in two
+// places depending on the variant — inside the form (`position='above'`) or in
+// the parent's heading slot (`position='below'`) — so the legal links and the
 // translation string live in one location.
-export const MobileCompactTosNotice = () => {
+export const MobileCompactTosNotice = ( { position }: { position: 'above' | 'below' } ) => {
 	const { __ } = useI18n();
-	const tosText = createInterpolateElement(
-		__(
-			'By continuing with any of the options above, you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
-		),
-		options
-	);
+	const tosText =
+		position === 'above'
+			? createInterpolateElement(
+					__(
+						'By continuing with any of the options above, you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+					),
+					options
+			  )
+			: createInterpolateElement(
+					__(
+						'By continuing with any of the options below, you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+					),
+					options
+			  );
 	return <p className="signup-form-social-first__tos-link">{ tosText }</p>;
 };
 
@@ -110,6 +120,7 @@ const SignupFormSocialFirst = ( {
 	isEmailFirstVariant,
 	isEmailAtBottom,
 	isMobileCompactVariant,
+	hideTosElement,
 	allowedSocialServices,
 	customTosElement,
 }: SignupFormSocialFirst ) => {
@@ -226,9 +237,18 @@ const SignupFormSocialFirst = ( {
 	);
 
 	if ( isMobileCompactVariant ) {
-		// In-form ToS: partner branding wins via customTosElement (rendered by
-		// renderTermsOfService); otherwise the compact "options above" notice.
-		const inFormTosElement = customTosElement ? renderTermsOfService() : <MobileCompactTosNotice />;
+		// In-form ToS:
+		//   - hideTosElement → parent renders the ToS elsewhere (top-position arm).
+		//   - customTosElement → partner branding wins (rendered by renderTermsOfService).
+		//   - otherwise → bottom-position "above" copy.
+		let inFormTosElement = null;
+		if ( ! hideTosElement ) {
+			inFormTosElement = customTosElement ? (
+				renderTermsOfService()
+			) : (
+				<MobileCompactTosNotice position="above" />
+			);
+		}
 		// Mobile compact: no "Have an account? Log in" link inside the form —
 		// the Log in link in the top bar covers that affordance per the Figma.
 		return (

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -149,7 +149,7 @@ describe( 'SignupFormSocialFirst', () => {
 			);
 		} );
 
-		test( 'renders the partner customTosElement instead of the default ToS', () => {
+		test( 'renders the partner customTosElement instead of the experiment ToS', () => {
 			const customTos = <span data-testid="partner-tos">Partner terms</span>;
 
 			render(
@@ -163,6 +163,19 @@ describe( 'SignupFormSocialFirst', () => {
 			expect( screen.getByTestId( 'partner-tos' ) ).toBeInTheDocument();
 			expect(
 				screen.queryByText( /By continuing with any of the options above/i )
+			).not.toBeInTheDocument();
+		} );
+
+		test( 'omits the in-form ToS when hideTosElement is true', () => {
+			const { container } = render(
+				<SignupFormSocialFirst { ...defaultProps } isMobileCompactVariant hideTosElement />
+			);
+
+			expect(
+				container.querySelector( '.signup-form-social-first__tos-link' )
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByText( /By continuing with any of the options/i )
 			).not.toBeInTheDocument();
 		} );
 
@@ -194,11 +207,19 @@ describe( 'SignupFormSocialFirst', () => {
 	} );
 
 	describe( 'MobileCompactTosNotice', () => {
-		test( 'renders the "options above" copy', () => {
-			render( <MobileCompactTosNotice /> );
+		test( 'renders the "options above" copy for position="above"', () => {
+			render( <MobileCompactTosNotice position="above" /> );
 
 			expect(
 				screen.getByText( /By continuing with any of the options above/i )
+			).toBeInTheDocument();
+		} );
+
+		test( 'renders the "options below" copy for position="below"', () => {
+			render( <MobileCompactTosNotice position="below" /> );
+
+			expect(
+				screen.getByText( /By continuing with any of the options below/i )
 			).toBeInTheDocument();
 		} );
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -9,7 +9,9 @@ import { useDispatch } from 'react-redux';
 import { AnyAction } from 'redux';
 import { reloadProxy, requestAllBlogsAccess } from 'wpcom-proxy-request';
 import OneTapAuthLoaderOverlay from 'calypso/blocks/login/one-tap-auth-loader-overlay';
-import SignupFormSocialFirst from 'calypso/blocks/signup-form/signup-form-social-first';
+import SignupFormSocialFirst, {
+	MobileCompactTosNotice,
+} from 'calypso/blocks/signup-form/signup-form-social-first';
 import FormattedHeader from 'calypso/components/formatted-header';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import { WOO_HOSTING_SOLUTIONS_REF } from 'calypso/landing/stepper/constants';
@@ -30,6 +32,7 @@ import { Step as StepType } from '../../types';
 import { useHandleSocialResponse } from './handle-social-response';
 import { SignupSlider } from './signup-slider';
 import useAccountCreationExperiment from './use-account-creation-experiment';
+import useMobileLayoutExperiment from './use-mobile-layout-experiment';
 import { useSocialService } from './use-social-service';
 import type { SignupAllowedService } from 'calypso/components/social-buttons/utils';
 
@@ -111,22 +114,27 @@ const UserStepComponent: StepType = function UserStep( {
 
 	const isStepContainerV2 = shouldUseStepContainerV2( flow );
 	const isLargeViewport = useViewportMatch( 'large' );
-	const isMobileViewport = useViewportMatch( 'small', '<' );
 
-	// Thumb-friendly compact layout for mobile signup. Woo referrers keep their
-	// permanent email-first treatment and partner-branded flows keep their own
-	// SSO providers, ToS, and heading copy — both are excluded so the compact
-	// layout never overrides them.
-	const isMobileCompactLayout =
-		isStepContainerV2 && isMobileViewport && ! isWooReferrer && ! partnerConfig;
+	// While the mobile-layout assignment is loading we defer both the heading and
+	// the form — otherwise the brief flash of control-shape UI before treatment
+	// paints would self-bias the social-conversion metric this experiment measures.
+	const {
+		isLoading: isMobileLayoutExperimentLoading,
+		isEligible: isMobileLayoutExperimentEligible,
+		isMobileTreatment,
+		isMobileTreatmentTosTop,
+	} = useMobileLayoutExperiment( { flow, isPartnerFlow: !! partnerConfig } );
+	const shouldDeferMobileReveal =
+		isMobileLayoutExperimentEligible && isMobileLayoutExperimentLoading;
 
 	const emailLabelText = isStepContainerV2 ? translate( 'Enter your email' ) : undefined;
-	// Partner branding always wins: isMobileCompactLayout is already false whenever
-	// partnerConfig is set, so the ! partnerConfig check here is belt-and-suspenders
-	// — it keeps the "partners never get the compact SSO set" invariant local to
-	// this line and safe if the eligibility above is ever refactored.
+	// Partner branding always wins over the experiment. useMobileLayoutExperiment
+	// already excludes partner flows from eligibility (so isMobileTreatment is
+	// false whenever partnerConfig is set), making the ! partnerConfig check
+	// belt-and-suspenders: it keeps the "partners never get the treatment SSO set"
+	// invariant local to this line and safe if eligibility is ever refactored.
 	const allowedSocialServices =
-		isMobileCompactLayout && ! partnerConfig ? MOBILE_SOCIAL_SERVICES : partnerConfig?.ssoProviders;
+		isMobileTreatment && ! partnerConfig ? MOBILE_SOCIAL_SERVICES : partnerConfig?.ssoProviders;
 	// customTosElement is reserved for partner branding (legal); the form's
 	// mobile-compact branch renders MobileCompactTosNotice as its own fallback
 	// when no customTosElement is provided. Routing the notice through
@@ -134,28 +142,31 @@ const UserStepComponent: StepType = function UserStep( {
 	const stepContent = (
 		<>
 			{ !! queryArgs.get( 'oneTapAuth' ) && ! notice && <OneTapAuthLoaderOverlay /> }
-			<SignupFormSocialFirst
-				stepName={ stepName }
-				flowName={ flow }
-				goToNextStep={ setWpAccountCreateResponse }
-				passDataToNextStep
-				logInUrl={ loginLink }
-				handleSocialResponse={ handleSocialResponse }
-				socialServiceResponse={ socialServiceResponse }
-				redirectToAfterLoginUrl={ window.location.href }
-				queryArgs={ {} }
-				userEmail={ queryArgs.get( 'user_email' ) || '' }
-				notice={ notice }
-				isSocialFirst
-				onCreateAccountSuccess={ handleCreateAccountSuccess }
-				backButtonInFooter={ ! isStepContainerV2 }
-				emailLabelText={ emailLabelText }
-				isEmailFirstVariant={ isEmailFirstVariant }
-				isEmailAtBottom={ isEmailAtBottom }
-				isMobileCompactVariant={ isMobileCompactLayout }
-				allowedSocialServices={ allowedSocialServices }
-				customTosElement={ signupTosElement }
-			/>
+			{ ! shouldDeferMobileReveal && (
+				<SignupFormSocialFirst
+					stepName={ stepName }
+					flowName={ flow }
+					goToNextStep={ setWpAccountCreateResponse }
+					passDataToNextStep
+					logInUrl={ loginLink }
+					handleSocialResponse={ handleSocialResponse }
+					socialServiceResponse={ socialServiceResponse }
+					redirectToAfterLoginUrl={ window.location.href }
+					queryArgs={ {} }
+					userEmail={ queryArgs.get( 'user_email' ) || '' }
+					notice={ notice }
+					isSocialFirst
+					onCreateAccountSuccess={ handleCreateAccountSuccess }
+					backButtonInFooter={ ! isStepContainerV2 }
+					emailLabelText={ emailLabelText }
+					isEmailFirstVariant={ isEmailFirstVariant }
+					isEmailAtBottom={ isEmailAtBottom }
+					isMobileCompactVariant={ isMobileTreatment }
+					hideTosElement={ isMobileTreatmentTosTop && ! signupTosElement }
+					allowedSocialServices={ allowedSocialServices }
+					customTosElement={ signupTosElement }
+				/>
+			) }
 			{ accountCreateResponse && 'bearer_token' in accountCreateResponse && (
 				<WpcomLoginForm
 					authorization={ 'Bearer ' + accountCreateResponse.bearer_token }
@@ -174,11 +185,16 @@ const UserStepComponent: StepType = function UserStep( {
 				args: { partner: partnerConfig.displayName },
 				textOnly: true,
 			} );
-		} else if ( isMobileCompactLayout ) {
+		} else if ( isMobileTreatment ) {
 			headingText = translate( 'Welcome to WordPress.com' );
 			headingSubText = translate( 'Sign up free to start creating your site.' );
 		}
-		const heading = (
+		// While the mobile experiment is resolving we render the layout without the
+		// heading so neither cohort sees the other variant's copy flash on cold visits.
+		// For the top-position arm, the ToS sits as a second <p> after Step.Heading
+		// (not inside subText, which Step.Heading wraps in a single <p>). Partner
+		// branding suppresses the experiment ToS — partners have their own copy.
+		const heading = shouldDeferMobileReveal ? null : (
 			// The locale suggestions are going to be reworked. Don't worry about it now.
 			<>
 				{ localeSuggestions }
@@ -187,6 +203,9 @@ const UserStepComponent: StepType = function UserStep( {
 					subText={ headingSubText }
 					align={ isEmailFirstVariant ? 'left' : undefined }
 				/>
+				{ isMobileTreatmentTosTop && ! signupTosElement && (
+					<MobileCompactTosNotice position="below" />
+				) }
 			</>
 		);
 
@@ -232,7 +251,7 @@ const UserStepComponent: StepType = function UserStep( {
 		return (
 			<Step.CenteredColumnLayout
 				className={ clsx( 'step-container-v2--user', {
-					'step-container-v2--user-mobile': isMobileCompactLayout,
+					'step-container-v2--user-mobile-treatment': isMobileTreatment,
 				} ) }
 				verticalAlign="center"
 				columnWidth={ 4 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
@@ -276,12 +276,12 @@ $breakpoint-mobile: 660px;
 	}
 }
 
-// Mobile signup layout: thumb-friendly per the Figma.
+// Mobile treatment experiment: thumb-friendly layout per the Figma.
 // Heading at the top of the content area, action cluster (social row → divider →
 // email field → Continue → ToS) anchored to the bottom of the viewport. Scoped to
-// the class added when isMobileCompactLayout is true so desktop users are never
-// affected.
-.step-container-v2:has(.step-container-v2--user-mobile) {
+// the class added when isMobileTreatment is true so desktop and control-group
+// mobile users are never affected.
+.step-container-v2:has(.step-container-v2--user-mobile-treatment) {
 	// Pin the top bar to the viewport. The header is the user's connection to
 	// the next onboarding step (Log in link, brand), so it must remain visible
 	// even when the form overflows and the document scrolls. The ToS is sticky
@@ -318,6 +318,23 @@ $breakpoint-mobile: 660px;
 	// Subtitle color: Gray 50 (#646970) per Figma.
 	.step-container-v2__heading p {
 		color: var(--studio-gray-50);
+	}
+
+	// Top-position ToS (treatment_tos_top): rendered as the direct sibling of
+	// .step-container-v2__heading inside the heading slot. The adjacent-sibling
+	// selector pins this rule to that exact position so the form-internal ToS
+	// (nested two levels deeper) and any future content-row children can't
+	// accidentally pick it up. Mirrors the subtitle's paragraph styling
+	// (Heading.scss `.step-container-v2__heading p`) so it reads as a
+	// continuation paragraph in the heading block. `text-wrap: pretty` (not
+	// `balance` like the subtitle) — `balance` equalizes line lengths, which
+	// produces unnatural breaks on body-length sentences.
+	.step-container-v2__heading + .signup-form-social-first__tos-link {
+		margin-block: 0.5rem 0;
+		color: var(--studio-gray-50);
+		font-size: 0.875rem;
+		line-height: 1.5;
+		text-wrap: pretty;
 	}
 
 	.signup-form-social-first--mobile-compact {
@@ -385,9 +402,10 @@ $breakpoint-mobile: 660px;
 			margin-block-end: 24px;
 		}
 
-		// ToS sits flush below the form's 24 px bottom margin. Larger, darker
-		// font-size / color (per legal) while keeping center alignment for the
-		// in-form placement. Sticky at the viewport bottom so it remains visible when
+		// ToS sits flush below the form's 24 px bottom margin. Matches the
+		// top-position arm's font-size / color (legal asked for the larger,
+		// darker treatment) while keeping center alignment for the in-form
+		// placement. Sticky at the viewport bottom so it remains visible when
 		// the form overflows (validation notices, longer locales, landscape
 		// orientation, the smallest portrait viewports). Solid background
 		// prevents the element behind it from showing through when sticky

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/index.tsx
@@ -2,33 +2,31 @@
  * @jest-environment jsdom
  */
 
+jest.mock( '../use-mobile-layout-experiment', () => jest.fn() );
+
 jest.mock( 'calypso/lib/partner-branding', () => ( {
 	usePartnerBranding: jest.fn(),
 } ) );
 
-jest.mock( '@wordpress/compose', () => ( {
-	...jest.requireActual( '@wordpress/compose' ),
-	useViewportMatch: jest.fn(),
-} ) );
-
 import { screen } from '@testing-library/dom';
-import { useViewportMatch } from '@wordpress/compose';
 import { MemoryRouter } from 'react-router-dom';
 import { usePartnerBranding } from 'calypso/lib/partner-branding';
 import loginReducer from 'calypso/state/login/reducer';
 import routeReducer from 'calypso/state/route/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import UserStep from '..';
+import useMobileLayoutExperiment from '../use-mobile-layout-experiment';
 
-const mockUseViewportMatch = useViewportMatch as unknown as jest.Mock;
+const mockUseMobileLayoutExperiment = useMobileLayoutExperiment as unknown as jest.Mock;
 const mockUsePartnerBranding = usePartnerBranding as unknown as jest.Mock;
 
-// Drives isMobileViewport = useViewportMatch( 'small', '<' ). Every other call
-// (e.g. useViewportMatch( 'large' )) resolves to false, i.e. not a wide viewport.
-const setViewport = ( { isMobile }: { isMobile: boolean } ) =>
-	mockUseViewportMatch.mockImplementation( ( breakpoint: string, operator?: string ) =>
-		breakpoint === 'small' && operator === '<' ? isMobile : false
-	);
+const defaultExperimentResult = {
+	isLoading: false,
+	isEligible: false,
+	variationName: 'control' as const,
+	isMobileTreatment: false,
+	isMobileTreatmentTosTop: false,
+};
 
 const noPartnerBranding = {
 	hasCustomBranding: false,
@@ -39,7 +37,7 @@ const noPartnerBranding = {
 
 describe( 'User email signup step', () => {
 	beforeEach( () => {
-		setViewport( { isMobile: false } );
+		mockUseMobileLayoutExperiment.mockReturnValue( defaultExperimentResult );
 		mockUsePartnerBranding.mockReturnValue( noPartnerBranding );
 	} );
 
@@ -62,42 +60,78 @@ describe( 'User email signup step', () => {
 		expect( screen.getByLabelText( 'Enter your email' ) ).toHaveValue( '' );
 	} );
 
-	describe( 'mobile compact layout', () => {
-		it( 'renders the default heading on desktop viewports', () => {
+	describe( 'mobile-layout experiment', () => {
+		it( 'renders the default heading on control', () => {
 			renderUserStep();
-			expect( screen.getByRole( 'heading', { name: 'Create your account' } ) ).toBeVisible();
+			expect( screen.getByRole( 'heading', { name: 'Create your account' } ) ).toBeInTheDocument();
 			expect(
 				screen.queryByRole( 'heading', { name: 'Welcome to WordPress.com' } )
 			).not.toBeInTheDocument();
 		} );
 
-		it( 'renders the compact layout with in-form ToS on mobile viewports', () => {
-			setViewport( { isMobile: true } );
+		it( 'swaps the heading copy on the bottom-position treatment', () => {
+			mockUseMobileLayoutExperiment.mockReturnValue( {
+				...defaultExperimentResult,
+				isEligible: true,
+				variationName: 'treatment_tos_bottom',
+				isMobileTreatment: true,
+			} );
 
 			renderUserStep();
 
-			expect( screen.getByRole( 'heading', { name: 'Welcome to WordPress.com' } ) ).toBeVisible();
-			expect( screen.getByText( 'Sign up free to start creating your site.' ) ).toBeVisible();
-			// "Above" copy: ToS lives inside the form, below the sign-up options.
-			expect( screen.getByText( /By continuing with any of the options above/i ) ).toBeVisible();
+			expect(
+				screen.getByRole( 'heading', { name: 'Welcome to WordPress.com' } )
+			).toBeInTheDocument();
+			expect( screen.getByText( 'Sign up free to start creating your site.' ) ).toBeInTheDocument();
+			// "Above" copy: ToS lives inside the form, rendered by SignupFormSocialFirst.
+			expect(
+				screen.getByText( /By continuing with any of the options above/i )
+			).toBeInTheDocument();
+			expect(
+				screen.queryByText( /By continuing with any of the options below/i )
+			).not.toBeInTheDocument();
 		} );
 
-		it( 'excludes Woo-referrer users from the compact layout on mobile', () => {
-			setViewport( { isMobile: true } );
+		it( 'renders the heading-slot ToS on the top-position treatment', () => {
+			mockUseMobileLayoutExperiment.mockReturnValue( {
+				...defaultExperimentResult,
+				isEligible: true,
+				variationName: 'treatment_tos_top',
+				isMobileTreatment: true,
+				isMobileTreatmentTosTop: true,
+			} );
 
-			renderUserStep( '/onboarding/user?ref=woo-hosting-solutions-flow' );
+			const { container } = renderUserStep();
 
-			expect( screen.getByRole( 'heading', { name: 'Create your account' } ) ).toBeVisible();
 			expect(
-				screen.queryByRole( 'heading', { name: 'Welcome to WordPress.com' } )
-			).not.toBeInTheDocument();
+				screen.getByRole( 'heading', { name: 'Welcome to WordPress.com' } )
+			).toBeInTheDocument();
+			// "Below" copy is in the heading slot, not the form.
+			expect(
+				screen.getByText( /By continuing with any of the options below/i )
+			).toBeInTheDocument();
 			expect(
 				screen.queryByText( /By continuing with any of the options above/i )
 			).not.toBeInTheDocument();
+			// The in-form ToS is suppressed by hideTosElement — exactly one tos-link
+			// element is rendered (the one in the heading slot).
+			expect( container.querySelectorAll( '.signup-form-social-first__tos-link' ) ).toHaveLength(
+				1
+			);
 		} );
 
-		it( 'preserves partner branding over the compact layout on mobile', () => {
-			setViewport( { isMobile: true } );
+		it( 'keeps the partner ToS and suppresses the heading-slot notice on the top-position treatment', () => {
+			// Partner branding wins over the experiment: even on the top-position
+			// arm, signupTosElement is truthy, so the experiment's heading-slot
+			// notice is suppressed (showTosInHeadingSlot is false) and the partner
+			// ToS renders inside the form via customTosElement.
+			mockUseMobileLayoutExperiment.mockReturnValue( {
+				...defaultExperimentResult,
+				isEligible: true,
+				variationName: 'treatment_tos_top',
+				isMobileTreatment: true,
+				isMobileTreatmentTosTop: true,
+			} );
 			mockUsePartnerBranding.mockReturnValue( {
 				hasCustomBranding: true,
 				partnerConfig: { id: 'woo', displayName: 'Woo', ssoProviders: [ 'google', 'apple' ] },
@@ -105,14 +139,32 @@ describe( 'User email signup step', () => {
 				signupTosElement: <>Partner reminder: agree to our partner Terms of Service.</>,
 			} );
 
+			const { container } = renderUserStep();
+
+			// Partner ToS renders (inside the form).
+			expect( screen.getByText( /Partner reminder: agree to our partner/i ) ).toBeInTheDocument();
+			// The experiment's heading-slot "options below" notice is not rendered.
+			expect(
+				screen.queryByText( /By continuing with any of the options below/i )
+			).not.toBeInTheDocument();
+			// Exactly one tos-link element — the partner one inside the form.
+			expect( container.querySelectorAll( '.signup-form-social-first__tos-link' ) ).toHaveLength(
+				1
+			);
+		} );
+
+		it( 'defers rendering the heading and form while the assignment is loading', () => {
+			mockUseMobileLayoutExperiment.mockReturnValue( {
+				...defaultExperimentResult,
+				isEligible: true,
+				isLoading: true,
+			} );
+
 			renderUserStep();
 
-			expect( screen.getByRole( 'heading', { name: 'Create an account for Woo' } ) ).toBeVisible();
-			expect( screen.getByText( /Partner reminder: agree to our partner/i ) ).toBeVisible();
-			// The compact "options above" notice is not rendered for partner flows.
-			expect(
-				screen.queryByText( /By continuing with any of the options above/i )
-			).not.toBeInTheDocument();
+			// Neither cohort sees the other variant's copy flash on cold visits.
+			expect( screen.queryByRole( 'heading' ) ).not.toBeInTheDocument();
+			expect( screen.queryByLabelText( 'Enter your email' ) ).not.toBeInTheDocument();
 		} );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/use-mobile-layout-experiment.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/use-mobile-layout-experiment.tsx
@@ -1,0 +1,137 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock( 'calypso/lib/explat', () => ( {
+	useExperiment: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/compose', () => ( {
+	...jest.requireActual( '@wordpress/compose' ),
+	useViewportMatch: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/landing/stepper/hooks/use-query', () => ( {
+	useQuery: jest.fn(),
+} ) );
+
+import { renderHook } from '@testing-library/react';
+import { useViewportMatch } from '@wordpress/compose';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useExperiment } from 'calypso/lib/explat';
+import useMobileLayoutExperiment from '../use-mobile-layout-experiment';
+
+const mockUseExperiment = useExperiment as jest.Mock;
+const mockUseViewportMatch = useViewportMatch as unknown as jest.Mock;
+const mockUseQuery = useQuery as jest.Mock;
+
+const renderHookForFlow = ( flow = 'onboarding', isPartnerFlow = false ) =>
+	renderHook( () => useMobileLayoutExperiment( { flow, isPartnerFlow } ) );
+
+describe( 'useMobileLayoutExperiment', () => {
+	beforeEach( () => {
+		jest.resetAllMocks();
+		mockUseQuery.mockReturnValue( new URLSearchParams() );
+		// Mobile viewport (< small breakpoint, i.e. < 600 px).
+		mockUseViewportMatch.mockReturnValue( true );
+	} );
+
+	it( 'returns control while the experiment assignment is loading', () => {
+		mockUseExperiment.mockReturnValue( [ true, { variationName: 'treatment_tos_top' } ] );
+
+		const { result } = renderHookForFlow();
+
+		expect( result.current.isLoading ).toBe( true );
+		expect( result.current.isEligible ).toBe( true );
+		expect( result.current.variationName ).toBe( 'control' );
+		expect( result.current.isMobileTreatment ).toBe( false );
+		expect( result.current.isMobileTreatmentTosTop ).toBe( false );
+	} );
+
+	it( 'returns control on non-mobile viewports regardless of assignment', () => {
+		mockUseViewportMatch.mockReturnValue( false );
+		mockUseExperiment.mockReturnValue( [ false, { variationName: 'treatment_tos_bottom' } ] );
+
+		const { result } = renderHookForFlow();
+
+		expect( result.current.isEligible ).toBe( false );
+		expect( result.current.variationName ).toBe( 'control' );
+		expect( result.current.isMobileTreatment ).toBe( false );
+		expect( result.current.isMobileTreatmentTosTop ).toBe( false );
+	} );
+
+	it( 'excludes Woo-referrer users from the experiment', () => {
+		mockUseQuery.mockReturnValue( new URLSearchParams( 'ref=woo-hosting-solutions-flow' ) );
+		mockUseExperiment.mockReturnValue( [ false, { variationName: 'treatment_tos_top' } ] );
+
+		const { result } = renderHookForFlow();
+
+		expect( result.current.isEligible ).toBe( false );
+		expect( result.current.variationName ).toBe( 'control' );
+		expect( result.current.isMobileTreatment ).toBe( false );
+		expect( result.current.isMobileTreatmentTosTop ).toBe( false );
+	} );
+
+	it( 'excludes partner-branded flows from the experiment', () => {
+		mockUseExperiment.mockReturnValue( [ false, { variationName: 'treatment_tos_top' } ] );
+
+		const { result } = renderHookForFlow( 'onboarding', true );
+
+		expect( result.current.isEligible ).toBe( false );
+		expect( result.current.variationName ).toBe( 'control' );
+		expect( result.current.isMobileTreatment ).toBe( false );
+		expect( result.current.isMobileTreatmentTosTop ).toBe( false );
+	} );
+
+	it( 'excludes flows that do not use step-container-v2', () => {
+		mockUseExperiment.mockReturnValue( [ false, { variationName: 'treatment_tos_top' } ] );
+
+		const { result } = renderHookForFlow( 'a-flow-that-does-not-use-step-container-v2' );
+
+		expect( result.current.isEligible ).toBe( false );
+		expect( result.current.variationName ).toBe( 'control' );
+		expect( result.current.isMobileTreatment ).toBe( false );
+	} );
+
+	it( 'exposes treatment_tos_bottom as isMobileTreatment without isMobileTreatmentTosTop', () => {
+		mockUseExperiment.mockReturnValue( [ false, { variationName: 'treatment_tos_bottom' } ] );
+
+		const { result } = renderHookForFlow();
+
+		expect( result.current.isLoading ).toBe( false );
+		expect( result.current.variationName ).toBe( 'treatment_tos_bottom' );
+		expect( result.current.isMobileTreatment ).toBe( true );
+		expect( result.current.isMobileTreatmentTosTop ).toBe( false );
+	} );
+
+	it( 'exposes treatment_tos_top as both isMobileTreatment and isMobileTreatmentTosTop', () => {
+		mockUseExperiment.mockReturnValue( [ false, { variationName: 'treatment_tos_top' } ] );
+
+		const { result } = renderHookForFlow();
+
+		expect( result.current.variationName ).toBe( 'treatment_tos_top' );
+		expect( result.current.isMobileTreatment ).toBe( true );
+		expect( result.current.isMobileTreatmentTosTop ).toBe( true );
+	} );
+
+	it( 'falls back to control when ExPlat returns an unknown variation name', () => {
+		mockUseExperiment.mockReturnValue( [
+			false,
+			{ variationName: 'treatment_unknown_future_arm' },
+		] );
+
+		const { result } = renderHookForFlow();
+
+		expect( result.current.isMobileTreatment ).toBe( false );
+		expect( result.current.isMobileTreatmentTosTop ).toBe( false );
+	} );
+
+	it( 'falls back to control when assignment is null', () => {
+		mockUseExperiment.mockReturnValue( [ false, null ] );
+
+		const { result } = renderHookForFlow();
+
+		expect( result.current.variationName ).toBe( 'control' );
+		expect( result.current.isMobileTreatment ).toBe( false );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-mobile-layout-experiment.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-mobile-layout-experiment.ts
@@ -1,0 +1,74 @@
+import { useViewportMatch } from '@wordpress/compose';
+import { WOO_HOSTING_SOLUTIONS_REF } from 'calypso/landing/stepper/constants';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useExperiment } from 'calypso/lib/explat';
+import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
+
+// Register the variation names below in ExPlat alongside the experiment slug.
+const MOBILE_LAYOUT_EXPERIMENT_NAME = 'calypso_signup_onboarding_user_mobile_layout_202606';
+
+type MobileLayoutExperimentVariant = 'control' | 'treatment_tos_bottom' | 'treatment_tos_top';
+
+type MobileLayoutExperimentResult = {
+	isLoading: boolean;
+	variationName: MobileLayoutExperimentVariant;
+	// True for both treatments — both apply the compact mobile layout. The two
+	// treatments differ only in ToS placement (see isMobileTreatmentTosTop).
+	isMobileTreatment: boolean;
+	// True for the top-position arm only — ToS rendered below the subtitle,
+	// with "options below" copy, and the form's internal ToS is suppressed.
+	isMobileTreatmentTosTop: boolean;
+	isEligible: boolean;
+};
+
+interface UseMobileLayoutExperimentParams {
+	flow: string;
+	// True when usePartnerBranding resolves a partnerConfig (Woo-branded OAuth2
+	// client, from=woo, redirect_to hostname match, etc.). Broader than the
+	// isWooReferrer ref-param check, so it must be passed in explicitly.
+	isPartnerFlow: boolean;
+}
+
+// The mobile-layout experiment is only eligible on mobile viewports so desktop
+// users never consume an ExPlat slot. Woo-referrer users keep their permanent
+// email-first treatment from PR #110118 and are excluded. Partner-branded flows
+// are also excluded so the treatment never overrides their SSO providers, ToS,
+// or heading copy — partner branding always wins (see index.tsx).
+function useMobileLayoutExperiment( {
+	flow,
+	isPartnerFlow,
+}: UseMobileLayoutExperimentParams ): MobileLayoutExperimentResult {
+	const queryArgs = useQuery();
+	const isWooReferrer = queryArgs.get( 'ref' ) === WOO_HOSTING_SOLUTIONS_REF;
+	const isStepContainerV2 = shouldUseStepContainerV2( flow );
+	const isMobileViewport = useViewportMatch( 'small', '<' );
+
+	const isEligible = isStepContainerV2 && isMobileViewport && ! isWooReferrer && ! isPartnerFlow;
+	const [ isLoading, assignment ] = useExperiment( MOBILE_LAYOUT_EXPERIMENT_NAME, {
+		isEligible,
+	} );
+
+	// Default to control while loading or for ineligible users — but consumers
+	// should also branch on isLoading to decide whether to defer the reveal,
+	// because allowing control-shape UI to paint before assignment resolves
+	// would self-bias the social-conversion metric this experiment measures.
+	const variationName: MobileLayoutExperimentVariant =
+		! isEligible || isLoading
+			? 'control'
+			: ( assignment?.variationName as MobileLayoutExperimentVariant | undefined ) ?? 'control';
+
+	const isMobileTreatment =
+		variationName === 'treatment_tos_bottom' || variationName === 'treatment_tos_top';
+	const isMobileTreatmentTosTop = variationName === 'treatment_tos_top';
+
+	return {
+		isLoading,
+		variationName,
+		isMobileTreatment,
+		isMobileTreatmentTosTop,
+		isEligible,
+	};
+}
+
+export default useMobileLayoutExperiment;
+export type { MobileLayoutExperimentVariant, MobileLayoutExperimentResult };


### PR DESCRIPTION
Reverts Automattic/wp-calypso#112789