### PR TITLE
Checkout: confine thank-you header hover to the back link

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/style.scss
@@ -13,10 +13,12 @@
 	}
 
 	.checkout-thank-you__item-wrapper {
+		// Fills the bar so the contact link is pushed to the far edge, but the
+		// button inside must stay label-width — it is the hover and click target.
 		flex: 1;
+		display: flex;
 
 		.checkout-thank-you__item {
-			width: 100%;
 			justify-content: start;
 			cursor: pointer;
 			font-size: 14px;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/style.scss
@@ -1,6 +1,7 @@
 .checkout-thank-you__masterbar {
 	--color-masterbar-background: var(--color-main-background);
 	--color-masterbar-text: var(--studio-gray-60);
+	--color-masterbar-item-hover-background: transparent;
 	padding-right: 24px;
 	border-bottom: 0;
 
@@ -13,8 +14,6 @@
 	}
 
 	.checkout-thank-you__item-wrapper {
-		// Fills the bar so the contact link is pushed to the far edge, but the
-		// button inside must stay label-width — it is the hover and click target.
 		flex: 1;
 		display: flex;
 
@@ -25,8 +24,6 @@
 			font-weight: 500;
 
 			&:hover {
-				background: var(--studio-white);
-
 				.masterbar__item-content {
 					color: var(--color-masterbar-text);
 					text-decoration: underline;


### PR DESCRIPTION
Fixes DSGCOM-584

## Proposed Changes

* Confine the post-checkout thank-you header's back-link hover state and click target to the link itself, instead of letting them span the width of the bar.
* Stop the link painting a background on hover at all, leaving the underline as the affordance.

## Why are these changes being made?

The back link sits in a flex filler that pushes the contact link to the opposite edge of the masterbar, but the link's button was being stretched to fill that filler. It ended up covering roughly 85% of the header, which had two consequences: hovering anywhere along the bar repainted the entire header, and clicking apparently empty header space navigated away.

The reported symptom was the visual one. The stray click target is the same cause and is arguably the more disruptive of the two, since it fires an unintended navigation away from the page a customer has just landed on after paying.

Shrinking the button to its label fixes the extent but still leaves a pale block behind the link, because this bar is very slightly off-white rather than white. Since the header is light and the link is already underlined on hover, the background is dropped entirely.

Worth knowing for review: the hover background could not simply be deleted. The base masterbar paints a dark hover background above 480px, which reads correctly on the dark bar it was written for; removing the local declaration lets that dark colour through on this light one. It is therefore set through the hover background custom property, joining the two properties this bar already reassigns, rather than through a rule that has to outweigh the base.

## Testing Instructions

Reproducing needs a receipt with at least one purchase on it — the redesigned thank-you page (and therefore this header) only renders when the receipt has purchases, so a receipt-less URL falls through to the legacy layout, which has no header at all. Grab a receipt ID from billing history under `/me/purchases/billing`, then load:

```
/checkout/thank-you/<site-slug>/<receipt-id>
```

A single-plan receipt gives the layout from the report.

Before / after:

1. Hover slowly across the header from the logo toward the contact link. Before, the whole bar flips to a flat white; after, only the link's underline appears and no colour changes.
2. Click the empty space between the back link and the contact link. Before, this navigates to the site's dashboard; after, nothing happens.
3. Narrow the viewport below 480px and confirm the back link's icon and label still sit correctly next to the logo, and that hovering does not tint the link.

Step 3 is worth attention from a reviewer: the stretch being removed here was introduced alongside a set of mobile fixes to this header, so mobile is where a regression would surface if one exists. The dark-background behaviour described above is also breakpoint-dependent, so it is worth checking either side of 480px.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
