### PR TITLE
Blaze dashboard: disable webpack module concatenation

### DIFF
--- a/apps/blaze-dashboard/webpack.config.js
+++ b/apps/blaze-dashboard/webpack.config.js
@@ -58,7 +58,7 @@ module.exports = {
 	},
 	optimization: {
 		minimize: ! isDevelopment,
-		concatenateModules: ! shouldEmitStats,
+		concatenateModules: false,
 		minimizer: Minify(),
 		splitChunks: false,
 	},


### PR DESCRIPTION
## Proposed Changes

* Disable webpack module concatenation (scope hoisting) for the Blaze dashboard build.

## Why are these changes being made?

The dashboard runs inside wp-admin and bundles some compound-component packages that are not provided by the host. In production builds, scope hoisting left one of their hoisted namespace bindings `undefined`, so the dashboard threw `Cannot read properties of undefined` on boot and never rendered (permanent spinner). The failure only appeared in production, since concatenation is disabled in development.

Disabling module concatenation resolves it and mirrors the `help-center` app, which bundles the same kind of packages and already disables concatenation for a related reason.

## Testing Instructions

* Build the dashboard in production mode and load it in wp-admin.
* The dashboard should render normally, with no error in the console.
