### PR TITLE
Marketplace: fix the install screen hanging forever for marketplace-only plugins

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -316,16 +316,15 @@ const MarketplaceProductInstall = ( {
 	// Prefer fresh URL when available; if in atomic flow, wait for fresh URL
 	const pluginsUrlFinal = atomicFlow ? pluginsUrlFresh : pluginsUrlFresh || pluginsUrlSelector;
 
-	// For marketplace plugins (e.g. sensei-pro), the atomic transfer + plugin install
-	// is initiated during checkout, not by this component. The wporg data is unavailable,
-	// so atomicFlow is never set. Once the site is atomic, poll for installed plugins
-	// so that the existing redirect (installedPlugin && pluginActive) fires.
+	// For marketplace plugins (e.g. sensei-pro, js-composer), the atomic transfer +
+	// plugin install is initiated during checkout, not by this component, so atomicFlow
+	// is never set. Once the site is atomic, poll for installed plugins so that the
+	// existing redirect (installedPlugin && pluginActive) fires. Do not gate this on the
+	// wporg lookup: wordpress.org answers 200 with an empty body for marketplace-only
+	// slugs, which gets normalized into `wporg: true`, so `wporg === false` never holds
+	// for exactly the plugins this fallback targets (DOTCOM-17744).
 	const isMarketplacePluginFlow =
-		! atomicFlow &&
-		! isPluginUploadFlow &&
-		!! pluginSlug &&
-		!! freshSite?.is_wpcom_atomic &&
-		wporgPlugin?.wporg === false;
+		! atomicFlow && ! isPluginUploadFlow && !! pluginSlug && !! freshSite?.is_wpcom_atomic;
 
 	useInterval(
 		() => dispatch( fetchSitePlugins( siteId ) ),
@@ -522,7 +521,10 @@ const MarketplaceProductInstall = ( {
 				/>
 			);
 		}
-		// Catch the rest of the error cases.
+		// Catch the rest of the error cases. The FAILURE check stays gated on atomicFlow:
+		// the automated-transfer status slice is persisted and never refreshed by the
+		// checkout-initiated path, so reading it un-gated would surface stale failures
+		// from old transfers as false errors.
 		if (
 			pluginUploadError ||
 			pluginInstallStatus?.error ||


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-17744/marketplace-plugin-install-hangs-forever-on-a-fake-progress-bar-with

## Proposed Changes

**The marketplace install screen’s recovery poll now arms for marketplace-only plugins, so checkout-initiated installs can complete instead of hanging forever.**

- `isMarketplacePluginFlow` no longer requires `wporgPlugin?.wporg === false`. That condition never holds for marketplace-only plugins: wordpress.org answers 200 with an empty body for slugs not published there, and the store normalizes that into `wporg: true` (source-level lie tracked in [DOTCOM-17975](https://linear.app/a8c/issue/DOTCOM-17975)).
- Once the site is Atomic, the screen polls installed plugins until the purchased plugin is active, and the existing redirect to wp-admin fires.
- Adds a comment guarding the transfer-FAILURE error check: it must stay gated on `atomicFlow`, because the persisted automated-transfer status is never refreshed on the checkout path and would surface stale failures as false errors.

A proper time limit and reachable error screen for this path are designed separately in [DOTCOM-17960](https://linear.app/a8c/issue/DOTCOM-17960).

## Why are these changes being made?

Buying a paid marketplace plugin (e.g. WPBakery) on a free Simple site starts the move to Atomic hosting during checkout. The install screen then waits for a signal that can never arrive: its recovery mechanism was gated on “this plugin is not on wordpress.org”, but our store records marketplace-only plugins as if they were on wordpress.org. The result is a paying customer stuck forever on a frozen progress bar with no error and no way out ([DOTCOM-17744](https://linear.app/a8c/issue/DOTCOM-17744), reproduced twice on video). The transfer itself succeeds — the page just never notices.

## Testing Instructions

1. Start from a free Simple site.
2. Buy a paid, marketplace-only plugin (WPBakery Page Builder, slug `js-composer`); checkout bundles the required plan.
3. Complete checkout and stay on the install screen.
4. Before this change: the progress bar freezes partway and never recovers. After: once the site becomes Atomic, the screen detects the installed plugin, the bar completes, and you are redirected to the wp-admin Plugins page.
5. Regression checks: install a free plugin on a Business Simple site (direct install path), upload a plugin zip, and install a theme — all should behave as before.
