### PR TITLE
A4A Amplify: revise FAQ scoring copy

### DIFF
--- a/client/a8c-for-agencies/sections/amplify/primary/overview/sections/faq.tsx
+++ b/client/a8c-for-agencies/sections/amplify/primary/overview/sections/faq.tsx
@@ -27,7 +27,14 @@ const FAQS = [
 		id: 'how-is-the-score-calculated',
 		question: __( 'How is the score calculated?' ),
 		answer: __(
-			'Every score is a combination of programmatic checks and AI analysis. Programmatic checks cover signals with one right answer: element presence, character counts, contrast ratios, HTTP status, and page speed measurements. AI analysis covers signals that require judgment, including visual polish, content clarity, trust signal quality, and audience resonance. Each criterion is weighted by its real-world impact on conversion or discoverability, and the total adds up to 100 points per mode.'
+			'Every score Amplify by Automattic for Agencies produces is grounded in established research, published standards, and established resources. Each score combines programmatic checks with AI analysis. Programmatic checks cover signals with one right answer, such as element presence, character counts, contrast ratios, HTTP status, and page speed measurements. AI analysis covers signals that require judgment, including visual polish, content clarity, trust signal quality, and audience resonance. Each criterion is weighted by its real-world impact on conversion or discoverability, and the total adds up to 100 points per mode.'
+		),
+	},
+	{
+		id: 'how-to-read-your-score',
+		question: __( 'How do I read my score?' ),
+		answer: __(
+			'Amplify scores are directional indicators grounded in established research and the expertise of Automattic. They are not definitive verdicts. A score reflects a point-in-time audit of your homepage and may not account for all site-specific context, audience nuances, or intentional design decisions.'
 		),
 	},
 	{


### PR DESCRIPTION
Revises the FAQ copy at the bottom of the Amplify Overview page (A4A-3018).

## Proposed Changes

* **"How is the score calculated?"** — updated the answer to lead with the "grounded in established research, published standards, and established resources" framing and the refreshed programmatic/AI-analysis wording.
* **"How do I read my score?"** — new FAQ item explaining that scores are directional, point-in-time indicators rather than definitive verdicts.

## Why are these changes being made?

Content revision requested by design to clarify how Amplify scores are produced and how agencies should interpret them.

## Testing Instructions

1. Run `yarn start-a8c-for-agencies` and open `agencies.localhost:3000/amplify` as an agency user with the amplify capabilities.
2. Scroll to the Frequently asked questions section.
3. Confirm the "How is the score calculated?" answer shows the revised copy, and a new "How do I read my score?" item appears and expands with its answer.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_01Dc9KywjtU7WnCFTEvBSnQj
