### PR TITLE
Returning user modal: Track returning user at 3 months

### DIFF
--- a/client/lib/analytics/track-resurrections/index.jsx
+++ b/client/lib/analytics/track-resurrections/index.jsx
@@ -4,8 +4,10 @@ import { useSelector } from 'react-redux';
 import {
 	RESURRECTED_EVENT,
 	RESURRECTED_EVENT_6M,
+	RESURRECTED_EVENT_3M,
 	RESURRECTION_DAY_LIMIT_DEFAULT,
 	RESURRECTION_DAY_LIMIT_EXPERIMENT,
+	RESURRECTION_DAY_LIMIT_EXPERIMENT2,
 } from 'calypso/lib/resurrected-users/constants';
 import { hasExceededDormancyThreshold } from 'calypso/lib/resurrected-users/utils';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
@@ -24,6 +26,10 @@ const TrackResurrections = () => {
 		lastSeen,
 		RESURRECTION_DAY_LIMIT_EXPERIMENT
 	);
+	const isRessurectedThreeMonths = hasExceededDormancyThreshold(
+		lastSeen,
+		RESURRECTION_DAY_LIMIT_EXPERIMENT2
+	);
 
 	useEffect( () => {
 		if ( isFetching ) {
@@ -39,6 +45,12 @@ const TrackResurrections = () => {
 			recordTracksEvent( RESURRECTED_EVENT_6M, {
 				last_seen: lastSeen,
 				day_limit: RESURRECTION_DAY_LIMIT_EXPERIMENT,
+			} );
+		}
+		if ( isRessurectedThreeMonths ) {
+			recordTracksEvent( RESURRECTED_EVENT_3M, {
+				last_seen: lastSeen,
+				day_limit: RESURRECTION_DAY_LIMIT_EXPERIMENT2,
 			} );
 		}
 	}, [ isFetching, isResurrectedDefault, isResurrectedSixMonths, lastSeen ] ); // Only run this when LastSeen value changes.

--- a/client/lib/analytics/track-resurrections/test/index.jsx
+++ b/client/lib/analytics/track-resurrections/test/index.jsx
@@ -2,7 +2,11 @@
  * @jest-environment jsdom
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { RESURRECTED_EVENT, RESURRECTED_EVENT_6M } from 'calypso/lib/resurrected-users/constants';
+import {
+	RESURRECTED_EVENT,
+	RESURRECTED_EVENT_6M,
+	RESURRECTED_EVENT_3M,
+} from 'calypso/lib/resurrected-users/constants';
 import userSettings from 'calypso/state/user-settings/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import TrackResurrections from '../';
@@ -40,7 +44,7 @@ describe( 'TrackResurrections', () => {
 		expect( recordTracksEvent ).toHaveBeenCalledTimes( 0 );
 	} );
 
-	it( 'should not call recordTracksEvent if lastSeen is less than six months ago', () => {
+	it( 'should not call recordTracksEvent if lastSeen is less than three months ago', () => {
 		const dormantThreshold = Date.now() / 1000 - 2 * 30 * 24 * 60 * 60; // 2 months-ish.
 
 		render( <TrackResurrections />, {
@@ -57,7 +61,7 @@ describe( 'TrackResurrections', () => {
 		expect( recordTracksEvent ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should call both resurrection events if lastSeen is more than one year ago', () => {
+	it( 'should call all resurrection events if lastSeen is more than one year ago', () => {
 		const resurrectedDate = Date.now() / 1000 - 2 * 365 * 24 * 60 * 60; // 2 years in seconds.
 
 		render( <TrackResurrections />, {
@@ -85,10 +89,47 @@ describe( 'TrackResurrections', () => {
 				last_seen: resurrectedDate,
 			} )
 		);
+		expect( recordTracksEvent ).toHaveBeenNthCalledWith(
+			3,
+			RESURRECTED_EVENT_3M,
+			expect.objectContaining( {
+				last_seen: resurrectedDate,
+			} )
+		);
 	} );
 
-	it( 'should call only the six month resurrection event if lastSeen is between six and twelve months ago', () => {
+	it( 'should call both the six and three month resurrection events if lastSeen is between six and twelve months ago', () => {
 		const resurrectedDate = Date.now() / 1000 - 8 * 30 * 24 * 60 * 60; // ~8 months.
+
+		render( <TrackResurrections />, {
+			initialState: {
+				userSettings: {
+					settings: {
+						last_admin_activity_timestamp: resurrectedDate,
+					},
+					fetching: false,
+				},
+			},
+		} );
+
+		expect( recordTracksEvent ).toHaveBeenCalledTimes( 2 );
+		expect( recordTracksEvent ).toHaveBeenNthCalledWith(
+			1,
+			RESURRECTED_EVENT_6M,
+			expect.objectContaining( {
+				last_seen: resurrectedDate,
+			} )
+		);
+		expect( recordTracksEvent ).toHaveBeenNthCalledWith(
+			2,
+			RESURRECTED_EVENT_3M,
+			expect.objectContaining( {
+				last_seen: resurrectedDate,
+			} )
+		);
+	} );
+	it( 'should call the three month resurrection event if lastSeen is between three and six months ago', () => {
+		const resurrectedDate = Date.now() / 1000 - 4 * 30 * 24 * 60 * 60; // ~4 months.
 
 		render( <TrackResurrections />, {
 			initialState: {
@@ -103,7 +144,7 @@ describe( 'TrackResurrections', () => {
 
 		expect( recordTracksEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordTracksEvent ).toHaveBeenCalledWith(
-			RESURRECTED_EVENT_6M,
+			RESURRECTED_EVENT_3M,
 			expect.objectContaining( {
 				last_seen: resurrectedDate,
 			} )

--- a/client/lib/resurrected-users/constants.ts
+++ b/client/lib/resurrected-users/constants.ts
@@ -1,8 +1,10 @@
 export const RESURRECTION_DAY_LIMIT_DEFAULT = 373;
 export const RESURRECTION_DAY_LIMIT_EXPERIMENT = 180;
+export const RESURRECTION_DAY_LIMIT_EXPERIMENT2 = 90;
 
 export const RESURRECTED_EVENT = 'calypso_user_resurrected';
 export const RESURRECTED_EVENT_6M = 'calypso_user_resurrected_6m';
+export const RESURRECTED_EVENT_3M = 'calypso_user_resurrected_3m';
 
 /** Rolled-out welcome-back modal variation (manual onboarding + continue). */
 export const WELCOME_BACK_VARIATION_MANUAL = 'treatment_manual_dual' as const;


### PR DESCRIPTION
## Proposed Changes

* Track users that return after at least 3 months of inactivity. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To support a future experiment

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
