### PR TITLE
Dashboard billing: source Titan cancellation features from the backend

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -14,7 +14,6 @@ import {
 	getRemoveLossIntro,
 	getSingleItemCancelCopy,
 	getSingleItemRemoveCopy,
-	getTitanCancellationLossItems,
 } from './get-confirmation-copy';
 import type { Purchase, CancellationFeature } from '@automattic/api-core';
 
@@ -34,15 +33,11 @@ const CancelPurchaseFeatureList = ( {
 	cancellationFeatures: CancellationFeature[];
 	cancellationChanges: FeatureObject[];
 } ) => {
-	// Titan's server-provided feature list is tier-unaware, so for Titan
-	// purchases we derive the loss list from the tier the user is on. Everything
-	// else uses the server list, falling back to a per-product-type item so every
-	// confirmation screen shows at least one concrete thing the user is giving up.
-	const titanLossItems = getTitanCancellationLossItems( purchase );
+	// Use the server-provided cancellation feature list, falling back to a
+	// per-product-type item so every confirmation screen shows at least one
+	// concrete thing the user is giving up.
 	let lossItems: Array< { key: string; title: string } >;
-	if ( titanLossItems ) {
-		lossItems = titanLossItems.map( ( title, idx ) => ( { key: `titan-${ idx }`, title } ) );
-	} else if ( cancellationFeatures.length ) {
+	if ( cancellationFeatures.length ) {
 		lossItems = cancellationFeatures
 			.filter( ( feature ): feature is CancellationFeature => Boolean( feature ) )
 			.map( ( feature ) => ( { key: String( feature.feature_id ), title: feature.title } ) );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
@@ -1,8 +1,6 @@
 import { AkismetPlans, TitanMailSlugs } from '@automattic/api-core';
 import { _n, __, sprintf } from '@wordpress/i18n';
 import { intervalToDuration } from 'date-fns';
-import { TitanPlanTier } from '../../../emails/types';
-import { getTitanTierFromSlug } from '../../../emails/utils/titan-tiers';
 import { isGSuiteOrGoogleWorkspaceProductSlug, DisplayVariant } from '../../../utils/purchase';
 
 /**
@@ -583,58 +581,6 @@ export function getButtonLabels( { purchase, intent }: ConfirmationCopyArgs ): {
 		primary: __( 'Cancel subscription' ),
 		secondary: __( 'Keep subscription' ),
 	};
-}
-
-/**
- * Curated "what you'll lose" list for a Titan (Professional Email) subscription,
- * keyed off the purchase's tier. Returns null when the purchase is not a Titan
- * tier product.
- *
- * The server-provided cancel-features list is tier-unaware for Titan (it returns
- * the Pro feature set regardless of tier), so the cancel flow prefers this list
- * for Titan purchases to show the storage and highlights that match the tier the
- * user is actually on.
- */
-export function getTitanCancellationLossItems( purchase: PurchaseForCopy ): string[] | null {
-	const tier = getTitanTierFromSlug( purchase.product_slug );
-	if ( ! tier ) {
-		return null;
-	}
-
-	const customEmail = __( 'Your custom email address' );
-	const emailCalendarContacts = __( 'Email, calendar, and contacts' );
-	const webAndMobile = __( 'Access on web and mobile' );
-	const support = __( '24/7 email support' );
-
-	switch ( tier ) {
-		case TitanPlanTier.Premium:
-			return [
-				customEmail,
-				__( '50 GB of mailbox storage' ),
-				emailCalendarContacts,
-				webAndMobile,
-				__( 'Two-factor authentication, priority inbox, and more' ),
-				support,
-			];
-		case TitanPlanTier.Ultra:
-			return [
-				customEmail,
-				__( '100 GB of mailbox storage' ),
-				emailCalendarContacts,
-				webAndMobile,
-				__( 'Titan AI, email campaigns, and more' ),
-				support,
-			];
-		case TitanPlanTier.Pro:
-		default:
-			return [
-				customEmail,
-				__( '30 GB of mailbox storage' ),
-				emailCalendarContacts,
-				webAndMobile,
-				support,
-			];
-	}
 }
 
 /**

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/get-confirmation-copy.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/get-confirmation-copy.ts
@@ -10,7 +10,6 @@ import {
 	getCheckboxLabel,
 	getButtonLabels,
 	getFallbackLossItems,
-	getTitanCancellationLossItems,
 	getRefundEligibilityPromoCopy,
 } from '../get-confirmation-copy';
 import type { Purchase } from '@automattic/api-core';
@@ -310,41 +309,6 @@ describe( 'getFallbackLossItems', () => {
 				makePurchaseForCategory( 'one-time', { product_name: 'Do it for me: Website Design' } )
 			)
 		).toEqual( [ 'Do it for me: Website Design' ] );
-	} );
-} );
-
-describe( 'getTitanCancellationLossItems', () => {
-	test( 'returns null for non-Titan products', () => {
-		expect( getTitanCancellationLossItems( makePurchaseForCategory( 'plan' ) ) ).toBeNull();
-		expect(
-			getTitanCancellationLossItems( makePurchase( { is_plan: false, product_slug: 'gapps' } ) )
-		).toBeNull();
-	} );
-	test( 'Pro tier lists 30 GB storage and no tier highlight', () => {
-		const items = getTitanCancellationLossItems(
-			makePurchase( { is_plan: false, product_slug: 'wp_titan_mail_yearly' } )
-		);
-		expect( items ).toEqual( [
-			'Your custom email address',
-			'30 GB of mailbox storage',
-			'Email, calendar, and contacts',
-			'Access on web and mobile',
-			'24/7 email support',
-		] );
-	} );
-	test( 'Premium tier lists 50 GB storage and a tier highlight', () => {
-		const items = getTitanCancellationLossItems(
-			makePurchase( { is_plan: false, product_slug: 'wp_titan_mail_premium_yearly' } )
-		);
-		expect( items ).toContain( '50 GB of mailbox storage' );
-		expect( items ).toContain( 'Two-factor authentication, priority inbox, and more' );
-	} );
-	test( 'Ultra tier lists 100 GB storage and a tier highlight', () => {
-		const items = getTitanCancellationLossItems(
-			makePurchase( { is_plan: false, product_slug: 'wp_titan_mail_ultra_yearly' } )
-		);
-		expect( items ).toContain( '100 GB of mailbox storage' );
-		expect( items ).toContain( 'Titan AI, email campaigns, and more' );
 	} );
 } );
 


### PR DESCRIPTION
## Proposed Changes

The Cancel subscription page (`/me/billing/purchases/:id/cancel`) derived the Titan (Professional Email) "what you'll lose" list on the front-end (`getTitanCancellationLossItems`). That was a stopgap: the `control` cancel-features variant was tier-unaware and always returned the Pro feature set, so an Ultra/Premium subscriber saw the wrong storage/highlights.

The `treatment` variant now returns the tier-aware Titan feature list, so this moves Titan to the backend as the single source of truth:

* Always request `variant=treatment` for Titan purchases in `cancel-purchase/index.tsx`. Other products keep following the `purchases/split-cancel-remove` experiment as before.
* Prefetch the `treatment` key for Titan in the cancel-route loader (`app/router/me.tsx`) to avoid a loading flicker.
* Drop the front-end `getTitanCancellationLossItems` override in `feature-list.tsx` (and remove the now-unused helper + its tests in `get-confirmation-copy.ts`). Titan now renders the server list like every other product, with the existing per-product-type fallback.

## Why are these changes being made?

Keeping the tier-aware feature copy hardcoded in Calypso meant it had to be kept in sync with the product forever and only ever matched the Pro tier for the server list. With the backend `treatment` variant now returning per-tier data, the front-end duplicate is redundant and drift-prone, so the list should come from a single backend source.

## Testing Instructions

1. Open `/me/billing/purchases/:id/cancel` for a Titan (Professional Email) purchase.
2. Confirm the "what you'll lose" list matches the purchase tier (Pro / Premium / Ultra) and comes from the `cancel-features?variant=treatment` response (check the network request).
3. Repeat for a non-Titan purchase and confirm behavior is unchanged (still follows the `purchases/split-cancel-remove` flag).
4. Confirm no loading flicker on the Titan cancel page.

> Note: depends on the backend `cancel-features` `treatment` variant returning per-tier Titan features. Verify that is live before merging.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
