### PR TITLE
Reader: Update SeenPosts terminology

### DIFF
--- a/client/blocks/reader-feed-header/follow.tsx
+++ b/client/blocks/reader-feed-header/follow.tsx
@@ -2,7 +2,7 @@ import { isAutomatticianQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { Icon, seen } from '@wordpress/icons';
 import { filterURLForDisplay } from '@wordpress/url';
-import { useTranslate } from 'i18n-calypso';
+import { fixMe, useTranslate } from 'i18n-calypso';
 import { useState, type JSX } from 'react';
 import { shallowEqual } from 'react-redux';
 import SiteNotificationSettings from 'calypso/blocks/reader-site-notification-settings';
@@ -131,7 +131,11 @@ export default function ReaderFeedHeaderFollow( props: ReaderFeedHeaderFollowPro
 	const allSeen = resolvedFeed?.unseen_count === 0;
 	const isSeenEnabled =
 		isAutomattician || isEligibleForUnseen( { isWPForTeamsItem, hasOrganization } );
-	const seenBtnMsg = translate( 'Mark all as seen' );
+	const seenBtnMsg = fixMe( {
+		text: 'Mark all as read',
+		newCopy: translate( 'Mark all as read' ),
+		oldCopy: translate( 'Mark all as seen' ),
+	} );
 
 	return (
 		<div className="reader-feed-header__follow">

--- a/client/blocks/reader-feed-header/follow.tsx
+++ b/client/blocks/reader-feed-header/follow.tsx
@@ -135,7 +135,7 @@ export default function ReaderFeedHeaderFollow( props: ReaderFeedHeaderFollowPro
 		text: 'Mark all as read',
 		newCopy: translate( 'Mark all as read' ),
 		oldCopy: translate( 'Mark all as seen' ),
-	} );
+	} ) as string;
 
 	return (
 		<div className="reader-feed-header__follow">

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -5,7 +5,7 @@ import { Gridicon, EmbedContainer } from '@automattic/components';
 import { isDefaultLocale } from '@automattic/i18n-utils';
 import { pickBy } from '@automattic/js-utils';
 import clsx from 'clsx';
-import { translate } from 'i18n-calypso';
+import { fixMe, translate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { createRef, Component, useMemo } from 'react';
 import { connect } from 'react-redux';
@@ -662,8 +662,16 @@ export class FullPostView extends Component {
 	renderMarkAsSeenButton = () => {
 		const { post } = this.props;
 		const label = post.is_seen
-			? translate( 'Mark post as unseen' )
-			: translate( 'Mark post as seen' );
+			? fixMe( {
+					text: 'Mark post as unread',
+					newCopy: translate( 'Mark post as unread' ),
+					oldCopy: translate( 'Mark post as unseen' ),
+			  } )
+			: fixMe( {
+					text: 'Mark post as read',
+					newCopy: translate( 'Mark post as read' ),
+					oldCopy: translate( 'Mark post as seen' ),
+			  } );
 
 		return (
 			<button

--- a/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
+++ b/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
 import { pencil as edit, external, Icon, seen, published, unseen } from '@wordpress/icons';
-import { localize } from 'i18n-calypso';
+import { fixMe, localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -298,7 +298,17 @@ class ReaderPostEllipsisMenu extends Component {
 						useWordPressIcon
 						iconSize={ 24 }
 					>
-						{ isSeen ? translate( 'Mark as unseen' ) : translate( 'Mark as seen' ) }
+						{ isSeen
+							? fixMe( {
+									text: 'Mark as unread',
+									newCopy: translate( 'Mark as unread' ),
+									oldCopy: translate( 'Mark as unseen' ),
+							  } )
+							: fixMe( {
+									text: 'Mark as read',
+									newCopy: translate( 'Mark as read' ),
+									oldCopy: translate( 'Mark as seen' ),
+							  } ) }
 					</PopoverMenuItem>
 				) }
 

--- a/client/reader/a8c/main.jsx
+++ b/client/reader/a8c/main.jsx
@@ -1,5 +1,5 @@
 import { Button } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
+import { fixMe, useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import SectionHeader from 'calypso/components/section-header';
 import { useMarkAllAsSeenMutation } from 'calypso/reader/data/seen-posts';
@@ -26,7 +26,11 @@ export default function A8CFollowing( props ) {
 		<Stream { ...props }>
 			<SectionHeader label={ translate( 'Followed A8C Sites' ) }>
 				<Button compact onClick={ handleMarkAllAsSeen } disabled={ ! feedsInfo.unseenCount }>
-					{ translate( 'Mark all as seen' ) }
+					{ fixMe( {
+						text: 'Mark all as read',
+						newCopy: translate( 'Mark all as read' ),
+						oldCopy: translate( 'Mark all as seen' ),
+					} ) }
 				</Button>
 			</SectionHeader>
 		</Stream>

--- a/client/reader/p2/main.jsx
+++ b/client/reader/p2/main.jsx
@@ -1,5 +1,5 @@
 import { Button } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
+import { fixMe, useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import SectionHeader from 'calypso/components/section-header';
 import { useMarkAllAsSeenMutation } from 'calypso/reader/data/seen-posts';
@@ -26,7 +26,11 @@ export default function P2Following( props ) {
 		<Stream { ...props }>
 			<SectionHeader label={ translate( 'Followed P2 Sites' ) }>
 				<Button compact onClick={ handleMarkAllAsSeen } disabled={ ! feedsInfo.unseenCount }>
-					{ translate( 'Mark all as seen' ) }
+					{ fixMe( {
+						text: 'Mark all as read',
+						newCopy: translate( 'Mark all as read' ),
+						oldCopy: translate( 'Mark all as seen' ),
+					} ) }
 				</Button>
 			</SectionHeader>
 		</Stream>

--- a/client/reader/sidebar/more-menu-actions/index.tsx
+++ b/client/reader/sidebar/more-menu-actions/index.tsx
@@ -10,6 +10,7 @@ import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRe
 
 type MoreMenuActionsProps = {
 	identifier: string;
+	isSingleFeed?: boolean;
 	feedIds: number[];
 	feedUrls: string[];
 	unseenCount: number;
@@ -17,6 +18,7 @@ type MoreMenuActionsProps = {
 
 export function MoreMenuActions( {
 	identifier,
+	isSingleFeed = true,
 	feedIds,
 	feedUrls,
 	unseenCount,
@@ -54,18 +56,17 @@ export function MoreMenuActions( {
 		}
 	};
 
-	const title =
-		feedIds.length > 1
-			? ( fixMe( {
-					text: 'Mark all as read',
-					newCopy: translate( 'Mark all as read' ),
-					oldCopy: translate( 'Mark all as seen' ),
-			  } ) as string )
-			: ( fixMe( {
-					text: 'Mark as read',
-					newCopy: translate( 'Mark as read' ),
-					oldCopy: translate( 'Mark as seen' ),
-			  } ) as string );
+	const title = isSingleFeed
+		? ( fixMe( {
+				text: 'Mark as read',
+				newCopy: translate( 'Mark as read' ),
+				oldCopy: translate( 'Mark as seen' ),
+		  } ) as string )
+		: ( fixMe( {
+				text: 'Mark all as read',
+				newCopy: translate( 'Mark all as read' ),
+				oldCopy: translate( 'Mark all as seen' ),
+		  } ) as string );
 
 	return (
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions

--- a/client/reader/sidebar/more-menu-actions/index.tsx
+++ b/client/reader/sidebar/more-menu-actions/index.tsx
@@ -4,7 +4,7 @@ import { isAutomatticianQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { DropdownMenu } from '@wordpress/components';
 import { check, moreHorizontal } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
+import { fixMe, useTranslate } from 'i18n-calypso';
 import { useMarkAllAsSeenMutation } from 'calypso/reader/data/seen-posts';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
 
@@ -54,6 +54,19 @@ export function MoreMenuActions( {
 		}
 	};
 
+	const title =
+		feedIds.length > 1
+			? ( fixMe( {
+					text: 'Mark all as read',
+					newCopy: translate( 'Mark all as read' ),
+					oldCopy: translate( 'Mark all as seen' ),
+			  } ) as string )
+			: ( fixMe( {
+					text: 'Mark as read',
+					newCopy: translate( 'Mark as read' ),
+					oldCopy: translate( 'Mark as seen' ),
+			  } ) as string );
+
 	return (
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<span
@@ -72,7 +85,7 @@ export function MoreMenuActions( {
 				} }
 				controls={ [
 					{
-						title: translate( 'Mark all as seen' ) as string,
+						title,
 						icon: check,
 						onClick: handleMarkAllAsSeen,
 						isDisabled: unseenCount === 0,

--- a/client/reader/sidebar/more-menu-actions/test/index.test.tsx
+++ b/client/reader/sidebar/more-menu-actions/test/index.test.tsx
@@ -20,6 +20,7 @@ jest.mock( 'calypso/state/reader/analytics/useRecordReaderTracksEvent', () => ( 
 
 const defaultProps: ComponentProps< typeof MoreMenuActions > = {
 	identifier: 'following',
+	isSingleFeed: false,
 	feedIds: [ 1, 2 ],
 	feedUrls: [ 'https://example.com/feed', 'https://another.example.com/feed' ],
 	unseenCount: 3,
@@ -98,9 +99,9 @@ describe( 'MoreMenuActions', () => {
 	} );
 
 	describe( 'action title', () => {
-		test( 'uses the plural title when there is more than one feed', async () => {
+		test( 'uses the plural title when isSingleFeed is false', async () => {
 			const user = userEvent.setup();
-			renderMoreMenuActions( { feedIds: [ 1, 2 ] } );
+			renderMoreMenuActions( { isSingleFeed: false } );
 
 			await openMoreActionsMenu( user );
 
@@ -108,9 +109,9 @@ describe( 'MoreMenuActions', () => {
 			expect( screen.queryByRole( 'menuitem', { name: 'Mark as read' } ) ).not.toBeInTheDocument();
 		} );
 
-		test( 'uses the singular title when there is exactly one feed', async () => {
+		test( 'uses the singular title when isSingleFeed is true', async () => {
 			const user = userEvent.setup();
-			renderMoreMenuActions( { feedIds: [ 1 ] } );
+			renderMoreMenuActions( { isSingleFeed: true } );
 
 			await openMoreActionsMenu( user );
 
@@ -120,9 +121,9 @@ describe( 'MoreMenuActions', () => {
 			).not.toBeInTheDocument();
 		} );
 
-		test( 'uses the singular title when there are no feeds', async () => {
+		test( 'defaults to the singular title when isSingleFeed is not provided', async () => {
 			const user = userEvent.setup();
-			renderMoreMenuActions( { feedIds: [] } );
+			renderMoreMenuActions( { isSingleFeed: undefined } );
 
 			await openMoreActionsMenu( user );
 

--- a/client/reader/sidebar/more-menu-actions/test/index.test.tsx
+++ b/client/reader/sidebar/more-menu-actions/test/index.test.tsx
@@ -53,7 +53,7 @@ describe( 'MoreMenuActions', () => {
 		jest.clearAllMocks();
 	} );
 
-	test( 'renders the mark all as seen action', async () => {
+	test( 'renders the mark all as read action', async () => {
 		const user = userEvent.setup();
 		renderMoreMenuActions();
 
@@ -61,7 +61,7 @@ describe( 'MoreMenuActions', () => {
 
 		await openMoreActionsMenu( user );
 
-		expect( screen.getByRole( 'menuitem', { name: 'Mark all as seen' } ) ).toBeEnabled();
+		expect( screen.getByRole( 'menuitem', { name: 'Mark all as read' } ) ).toBeEnabled();
 	} );
 
 	test( 'marks all posts as seen and records the tracks event', async () => {
@@ -69,7 +69,7 @@ describe( 'MoreMenuActions', () => {
 		renderMoreMenuActions();
 
 		await openMoreActionsMenu( user );
-		await user.click( screen.getByRole( 'menuitem', { name: 'Mark all as seen' } ) );
+		await user.click( screen.getByRole( 'menuitem', { name: 'Mark all as read' } ) );
 
 		expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
 			'calypso_reader_mark_all_as_seen_clicked',
@@ -88,12 +88,48 @@ describe( 'MoreMenuActions', () => {
 
 		await openMoreActionsMenu( user );
 
-		const markAllAsSeenButton = screen.getByRole( 'menuitem', { name: 'Mark all as seen' } );
+		const markAllAsSeenButton = screen.getByRole( 'menuitem', { name: 'Mark all as read' } );
 		expect( markAllAsSeenButton ).toHaveAttribute( 'aria-disabled', 'true' );
 
 		await user.click( markAllAsSeenButton );
 
 		expect( mockRecordReaderTracksEvent ).not.toHaveBeenCalled();
 		expect( mockMarkAllAsSeen ).not.toHaveBeenCalled();
+	} );
+
+	describe( 'action title', () => {
+		test( 'uses the plural title when there is more than one feed', async () => {
+			const user = userEvent.setup();
+			renderMoreMenuActions( { feedIds: [ 1, 2 ] } );
+
+			await openMoreActionsMenu( user );
+
+			expect( screen.getByRole( 'menuitem', { name: 'Mark all as read' } ) ).toBeInTheDocument();
+			expect( screen.queryByRole( 'menuitem', { name: 'Mark as read' } ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'uses the singular title when there is exactly one feed', async () => {
+			const user = userEvent.setup();
+			renderMoreMenuActions( { feedIds: [ 1 ] } );
+
+			await openMoreActionsMenu( user );
+
+			expect( screen.getByRole( 'menuitem', { name: 'Mark as read' } ) ).toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'menuitem', { name: 'Mark all as read' } )
+			).not.toBeInTheDocument();
+		} );
+
+		test( 'uses the singular title when there are no feeds', async () => {
+			const user = userEvent.setup();
+			renderMoreMenuActions( { feedIds: [] } );
+
+			await openMoreActionsMenu( user );
+
+			expect( screen.getByRole( 'menuitem', { name: 'Mark as read' } ) ).toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'menuitem', { name: 'Mark all as read' } )
+			).not.toBeInTheDocument();
+		} );
 	} );
 } );

--- a/client/reader/sidebar/reader-sidebar-lists/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-lists/index.tsx
@@ -58,6 +58,7 @@ const ReaderSidebarLists = ( {
 				moreMenuActions={
 					<MoreMenuActions
 						identifier="sidebar-lists"
+						isSingleFeed={ false }
 						feedIds={ allFeedIds }
 						feedUrls={ [] }
 						unseenCount={ totalUnseenCount }

--- a/client/reader/sidebar/reader-sidebar-lists/list-item.tsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item.tsx
@@ -101,6 +101,7 @@ const ReaderSidebarListsListItem = ( {
 					<span className="sidebar__actions-and-count">
 						<MoreMenuActions
 							identifier="sidebar-list"
+							isSingleFeed={ false }
 							feedIds={ feedIds }
 							feedUrls={ [] }
 							unseenCount={ unseenCount }

--- a/client/reader/sidebar/reader-sidebar-lists/test/index.test.tsx
+++ b/client/reader/sidebar/reader-sidebar-lists/test/index.test.tsx
@@ -87,11 +87,11 @@ describe( 'ReaderSidebarLists', () => {
 		} );
 	} );
 
-	describe( 'mark all as seen', () => {
+	describe( 'mark all as read', () => {
 		beforeEach( () => {
 			jest.clearAllMocks();
 		} );
-		it( 'marks every feed across all lists as seen from the header action', async () => {
+		it( 'marks every feed across all lists as read from the header action', async () => {
 			const user = userEvent.setup();
 			const lists = [
 				makeList( 1, [
@@ -106,7 +106,7 @@ describe( 'ReaderSidebarLists', () => {
 			// The header's "More actions" button is the first one in the DOM,
 			// ahead of the per-list actions inside the expandable content.
 			await user.click( screen.getAllByRole( 'button', { name: 'More actions' } )[ 0 ] );
-			await user.click( screen.getByRole( 'menuitem', { name: 'Mark all as seen' } ) );
+			await user.click( screen.getByRole( 'menuitem', { name: 'Mark all as read' } ) );
 
 			expect( mockMarkAllAsSeen ).toHaveBeenCalledWith( {
 				identifier: 'sidebar-lists',
@@ -115,7 +115,7 @@ describe( 'ReaderSidebarLists', () => {
 			} );
 		} );
 
-		it( 'disables the header action when all lists are fully seen', async () => {
+		it( 'disables the header action when all lists are fully read', async () => {
 			const user = userEvent.setup();
 			const lists = [ makeList( 1, [ { feed_id: 10, unseen_count: 0 } ] ) ];
 
@@ -123,7 +123,7 @@ describe( 'ReaderSidebarLists', () => {
 
 			await user.click( screen.getAllByRole( 'button', { name: 'More actions' } )[ 0 ] );
 
-			expect( screen.getByRole( 'menuitem', { name: 'Mark all as seen' } ) ).toHaveAttribute(
+			expect( screen.getByRole( 'menuitem', { name: 'Mark all as read' } ) ).toHaveAttribute(
 				'aria-disabled',
 				'true'
 			);

--- a/client/reader/sidebar/reader-sidebar-lists/test/list-item.test.tsx
+++ b/client/reader/sidebar/reader-sidebar-lists/test/list-item.test.tsx
@@ -95,7 +95,7 @@ describe( 'ReaderSidebarListsListItem', () => {
 			expect( container.querySelector( '.a8c-count' ) ).toBeNull();
 		} );
 
-		it( 'does not show a count when every feed is fully seen', () => {
+		it( 'does not show a count when every feed is fully read', () => {
 			const listNoUnseen: ReadList = {
 				...list,
 				feeds: [
@@ -128,7 +128,7 @@ describe( 'ReaderSidebarListsListItem', () => {
 		} );
 	} );
 
-	describe( 'mark all as seen', () => {
+	describe( 'mark all as read', () => {
 		const listWithUnseen: ReadList = {
 			...list,
 			feeds: [
@@ -137,12 +137,12 @@ describe( 'ReaderSidebarListsListItem', () => {
 			],
 		};
 
-		it( 'marks the list feeds as seen', async () => {
+		it( 'marks the list feeds as read', async () => {
 			const user = userEvent.setup();
 			renderWithProvider( <ReaderSidebarListsListItem list={ listWithUnseen } path="/reader" /> );
 
 			await user.click( screen.getByRole( 'button', { name: 'More actions' } ) );
-			await user.click( screen.getByRole( 'menuitem', { name: 'Mark all as seen' } ) );
+			await user.click( screen.getByRole( 'menuitem', { name: 'Mark all as read' } ) );
 
 			expect( mockMarkAllAsSeen ).toHaveBeenCalledWith( {
 				identifier: 'sidebar-list',
@@ -151,18 +151,24 @@ describe( 'ReaderSidebarListsListItem', () => {
 			} );
 		} );
 
-		it( 'disables the action when the list is fully seen', async () => {
+		it( 'disables the action when the list is fully read', async () => {
 			const user = userEvent.setup();
 			renderWithProvider(
 				<ReaderSidebarListsListItem
-					list={ { ...list, feeds: [ { feed_id: 1, unseen_count: 0 } ] } }
+					list={ {
+						...list,
+						feeds: [
+							{ feed_id: 1, unseen_count: 0 },
+							{ feed_id: 2, unseen_count: 0 },
+						],
+					} }
 					path="/reader"
 				/>
 			);
 
 			await user.click( screen.getByRole( 'button', { name: 'More actions' } ) );
 
-			expect( screen.getByRole( 'menuitem', { name: 'Mark all as seen' } ) ).toHaveAttribute(
+			expect( screen.getByRole( 'menuitem', { name: 'Mark all as read' } ) ).toHaveAttribute(
 				'aria-disabled',
 				'true'
 			);

--- a/client/reader/sidebar/reader-sidebar-organizations/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list.jsx
@@ -84,6 +84,7 @@ export class ReaderSidebarOrganizationsList extends Component {
 				moreMenuActions={
 					<MoreMenuActions
 						identifier={ this.identifierForOrganizationId( organization.id ) }
+						isSingleFeed={ false }
 						feedIds={ feedsInfo.feedIds }
 						feedUrls={ feedsInfo.feedUrls }
 						unseenCount={ feedsInfo.unseenCount }

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -125,6 +125,7 @@ const ReaderSidebarRecent = ( { isOpen, onClick, path, className }: Props ): Rea
 			moreMenuActions={
 				<MoreMenuActions
 					identifier="following"
+					isSingleFeed={ false }
 					feedIds={ feedsInfo.feedIds }
 					feedUrls={ feedsInfo.feedUrls }
 					unseenCount={ feedsInfo.unseenCount }


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: https://linear.app/a8c/issue/READ-612 

## Proposed Changes

Updating text:

- Mark as seen -> Mark as read
- Mark all as seen -> Mark all as read

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Using "read" is close to the actual action while "seen" is confusing i.e. if a user have just seen the post in the feed then that should be marked as seen.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Verify action menu on sidebar.
- Verify ellipsis menu on post card.
- Verify P2 index page sidebar.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
