### PR TITLE
Dashboard: fix cancel -> refund flow

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -117,7 +117,6 @@ type TopNoticeArgs = {
 	displayVariant: DisplayVariant;
 	purchase: Purchase;
 	intent: CancelIntent | null;
-	isSplitCancelRemoveEnabled: boolean;
 };
 
 /**
@@ -127,14 +126,7 @@ type TopNoticeArgs = {
 const CACHE_GUARD_DURATION_MS = 15_000;
 
 function renderTopNotice( args: TopNoticeArgs ) {
-	const {
-		surveyShown,
-		showDomainOptionsStep,
-		displayVariant,
-		purchase,
-		intent,
-		isSplitCancelRemoveEnabled,
-	} = args;
+	const { surveyShown, showDomainOptionsStep, displayVariant, purchase, intent } = args;
 
 	if ( surveyShown || showDomainOptionsStep ) {
 		return null;
@@ -142,11 +134,7 @@ function renderTopNotice( args: TopNoticeArgs ) {
 
 	// Intent-cancel with a refund (flag-on) → promo notice with inline link to
 	// switch the user into the remove flow.
-	if (
-		isSplitCancelRemoveEnabled &&
-		displayVariant === 'cancel' &&
-		hasAmountAvailableToRefund( purchase )
-	) {
+	if ( displayVariant === 'cancel' && hasAmountAvailableToRefund( purchase ) ) {
 		return <RefundEligibilityNotice mode="refund-eligibility" purchase={ purchase } />;
 	}
 
@@ -1802,7 +1790,6 @@ function CancelPurchaseInner() {
 				displayVariant,
 				purchase,
 				intent,
-				isSplitCancelRemoveEnabled,
 			} ) }
 		>
 			{ isSolutionsStep ? (

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -281,7 +281,6 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 	const { user } = useAuth();
 	const navigate = useNavigate();
 	const locale = useLocale();
-	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
 
 	if ( String( user.ID ) !== String( purchase.user_id ) ) {
 		return null;
@@ -304,152 +303,99 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 			...( intent ? { search: { intent } } : {} ),
 		} );
 
-	if ( isSplitEnabled ) {
-		const hasRefund = hasAmountAvailableToRefund( purchase );
-		const autoRenewOn = purchase.is_auto_renew_enabled;
-		// Domain transfer gate: non-refundable transfers can't be cancelled without
-		// support intervention (preserves legacy behavior on classic; adds it to
-		// dashboard). Remove button is unaffected — a completed transfer with
-		// auto-renew off can still be removed below.
-		const isTransferNonRefundable = isDomainTransfer( purchase ) && ! hasRefund;
-		// Visibility is driven mainly by what the user controls:
-		// - Cancel: auto-renew is on (stopping it halts any upcoming retry too).
-		// - Remove: auto-renew is already off (cancelled subscriptions awaiting
-		//   removal, etc.).
-		// During the post-expiration grace period, we force the "Remove"
-		// option, though; given how close the subscription is to being removed
-		// anyway, turning off auto-renew via a "cancel" option would be
-		// confusing. (If the subscription still has grace period renewal
-		// attempts scheduled, the user can still disable auto-renew via the
-		// dedicated toggle instead.)
-		// When a refund is available with auto-renew still on, the refund path is
-		// surfaced inside the cancel flow via RefundEligibilityNotice instead of
-		// a second CTA here.
-		// Verified against wpcom-billing backend — cancel / disable-auto-renew /
-		// delete endpoints all accept the call in pending-renewal state, so we
-		// don't need to special-case it.
-		const showCancel =
-			autoRenewOn && ! isTransferNonRefundable && ! isExpiredAndInGracePeriod( purchase );
-		const showRemove = ! autoRenewOn || isExpiredAndInGracePeriod( purchase );
+	const hasRefund = hasAmountAvailableToRefund( purchase );
+	const autoRenewOn = purchase.is_auto_renew_enabled;
+	// Domain transfer gate: non-refundable transfers can't be cancelled without
+	// support intervention (preserves legacy behavior on classic; adds it to
+	// dashboard). Remove button is unaffected — a completed transfer with
+	// auto-renew off can still be removed below.
+	const isTransferNonRefundable = isDomainTransfer( purchase ) && ! hasRefund;
+	// Visibility is driven mainly by what the user controls:
+	// - Cancel: auto-renew is on (stopping it halts any upcoming retry too).
+	// - Remove: auto-renew is already off (cancelled subscriptions awaiting
+	//   removal, etc.).
+	// During the post-expiration grace period, we force the "Remove"
+	// option, though; given how close the subscription is to being removed
+	// anyway, turning off auto-renew via a "cancel" option would be
+	// confusing. (If the subscription still has grace period renewal
+	// attempts scheduled, the user can still disable auto-renew via the
+	// dedicated toggle instead.)
+	// When a refund is available with auto-renew still on, the refund path is
+	// surfaced inside the cancel flow via RefundEligibilityNotice instead of
+	// a second CTA here.
+	// Verified against wpcom-billing backend — cancel / disable-auto-renew /
+	// delete endpoints all accept the call in pending-renewal state, so we
+	// don't need to special-case it.
+	const showCancel =
+		autoRenewOn && ! isTransferNonRefundable && ! isExpiredAndInGracePeriod( purchase );
+	const showRemove = ! autoRenewOn || isExpiredAndInGracePeriod( purchase );
 
-		if ( ! showCancel && ! showRemove ) {
-			return null;
-		}
-
-		// Use non-breaking spaces in the date so it doesn't wrap mid-date
-		// (e.g. "April\n16, 2027") in narrow viewports.
-		const expiryDateFormatted = purchase.expiry_date
-			? formatDate( new Date( purchase.expiry_date ), locale, {
-					dateStyle: 'long',
-			  } ).replace( / /g, '\u00A0' )
-			: '';
-
-		const category = classifyPurchaseForCopy( purchase );
-		const cancelCopy = showCancel
-			? getCancelButtonCopy( {
-					category,
-					productName: purchase.product_name,
-					expiryDateFormatted,
-			  } )
-			: null;
-		const removeCopy = showRemove
-			? getRemoveButtonCopy( { category, productName: purchase.product_name, hasRefund } )
-			: null;
-
-		return (
-			<>
-				{ cancelCopy && (
-					<ActionList.ActionItem
-						title={ cancelCopy.label }
-						description={ cancelCopy.description }
-						actions={
-							<Button
-								variant="secondary"
-								// When Remove is shown alongside Cancel, keep Cancel neutral so
-								// the destructive emphasis goes to Remove only. When Cancel is
-								// the lone destructive action, make it red.
-								isDestructive={ ! showRemove }
-								size="compact"
-								onClick={ () => goToCancel( 'cancel' ) }
-							>
-								{ _x( 'Cancel', 'Stop the subscription from automatically charging and renewing' ) }
-							</Button>
-						}
-					/>
-				) }
-				{ removeCopy && (
-					<ActionList.ActionItem
-						title={ removeCopy.label }
-						description={ removeCopy.description }
-						actions={
-							<Button
-								variant="secondary"
-								isDestructive
-								size="compact"
-								onClick={ () => goToCancel( 'remove' ) }
-							>
-								{ _x(
-									'Remove',
-									'Remove the cancelled or expired subscription from the list of active purchases.'
-								) }
-							</Button>
-						}
-					/>
-				) }
-			</>
-		);
+	if ( ! showCancel && ! showRemove ) {
+		return null;
 	}
 
-	if ( purchase.is_cancelable ) {
-		return (
-			<ActionList.ActionItem
-				title={ __( 'Cancel subscription' ) }
-				description={ __( 'We’ll be sorry to see you go!' ) }
-				actions={
-					<Button
-						variant="secondary"
-						isDestructive
-						size="compact"
-						onClick={ () =>
-							navigate( {
-								to: cancelPurchaseRoute.fullPath,
-								params: { purchaseId: purchase.ID },
-							} )
-						}
-					>
-						{ _x( 'Cancel', 'Stop the subscription from automatically charging and renewing' ) }
-					</Button>
-				}
-			/>
-		);
-	}
-	if ( purchase.is_removable ) {
-		return (
-			<ActionList.ActionItem
-				title={ __( 'Remove subscription' ) }
-				description={ __( 'We’ll be sorry to see you go!' ) }
-				actions={
-					<Button
-						variant="secondary"
-						isDestructive
-						size="compact"
-						onClick={ () =>
-							navigate( {
-								to: cancelPurchaseRoute.fullPath,
-								params: { purchaseId: purchase.ID },
-							} )
-						}
-					>
-						{ _x(
-							'Remove',
-							'Remove the cancelled or expired subscription from the list of active purchases.'
-						) }
-					</Button>
-				}
-			/>
-		);
-	}
-	return null;
+	// Use non-breaking spaces in the date so it doesn't wrap mid-date
+	// (e.g. "April\n16, 2027") in narrow viewports.
+	const expiryDateFormatted = purchase.expiry_date
+		? formatDate( new Date( purchase.expiry_date ), locale, {
+				dateStyle: 'long',
+		  } ).replace( / /g, '\u00A0' )
+		: '';
+
+	const category = classifyPurchaseForCopy( purchase );
+	const cancelCopy = showCancel
+		? getCancelButtonCopy( {
+				category,
+				productName: purchase.product_name,
+				expiryDateFormatted,
+		  } )
+		: null;
+	const removeCopy = showRemove
+		? getRemoveButtonCopy( { category, productName: purchase.product_name, hasRefund } )
+		: null;
+
+	return (
+		<>
+			{ cancelCopy && (
+				<ActionList.ActionItem
+					title={ cancelCopy.label }
+					description={ cancelCopy.description }
+					actions={
+						<Button
+							variant="secondary"
+							// When Remove is shown alongside Cancel, keep Cancel neutral so
+							// the destructive emphasis goes to Remove only. When Cancel is
+							// the lone destructive action, make it red.
+							isDestructive={ ! showRemove }
+							size="compact"
+							onClick={ () => goToCancel( 'cancel' ) }
+						>
+							{ _x( 'Cancel', 'Stop the subscription from automatically charging and renewing' ) }
+						</Button>
+					}
+				/>
+			) }
+			{ removeCopy && (
+				<ActionList.ActionItem
+					title={ removeCopy.label }
+					description={ removeCopy.description }
+					actions={
+						<Button
+							variant="secondary"
+							isDestructive
+							size="compact"
+							onClick={ () => goToCancel( 'remove' ) }
+						>
+							{ _x(
+								'Remove',
+								'Remove the cancelled or expired subscription from the list of active purchases.'
+							) }
+						</Button>
+					}
+				/>
+			) }
+		</>
+	);
 }
 
 /**

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -277,7 +277,7 @@ function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
-function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
+export function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 	const { user } = useAuth();
 	const navigate = useNavigate();
 	const locale = useLocale();

--- a/client/dashboard/me/billing-purchases/purchase-settings/test/cancel-or-remove-action-button.test.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/test/cancel-or-remove-action-button.test.tsx
@@ -35,7 +35,9 @@ describe( '<CancelOrRemoveActionButton />', () => {
 
 	test( 'renders nothing for a subscription that is no longer active', () => {
 		const { container } = render(
-			<CancelOrRemoveActionButton purchase={ makePurchase( { subscription_status: 'expired' } ) } />
+			<CancelOrRemoveActionButton
+				purchase={ makePurchase( { subscription_status: 'inactive' } ) }
+			/>
 		);
 		expect( container ).toBeEmptyDOMElement();
 	} );

--- a/client/dashboard/me/billing-purchases/purchase-settings/test/cancel-or-remove-action-button.test.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/test/cancel-or-remove-action-button.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import { render } from '../../../../test-utils';
+import { CancelOrRemoveActionButton } from '../index';
+import type { Purchase } from '@automattic/api-core';
+
+// The rendering wrapper's default user has ID 1, so a purchase owned by user 1
+// belongs to the current user.
+function makePurchase( overrides: Partial< Purchase > = {} ): Purchase {
+	return {
+		ID: 1,
+		user_id: 1,
+		product_name: 'WordPress.com Business',
+		product_slug: 'business-bundle',
+		is_plan: true,
+		subscription_status: 'active',
+		expiry_status: 'auto-renewing',
+		expiry_date: '2027-01-01',
+		is_auto_renew_enabled: true,
+		refund_amount: 0,
+		...overrides,
+	} as Purchase;
+}
+
+describe( '<CancelOrRemoveActionButton />', () => {
+	test( 'renders nothing when the current user does not own the purchase', () => {
+		const { container } = render(
+			<CancelOrRemoveActionButton purchase={ makePurchase( { user_id: 2 } ) } />
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'renders nothing for a subscription that is no longer active', () => {
+		const { container } = render(
+			<CancelOrRemoveActionButton purchase={ makePurchase( { subscription_status: 'expired' } ) } />
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'shows only Cancel when auto-renew is on and no refund is available', () => {
+		render( <CancelOrRemoveActionButton purchase={ makePurchase() } /> );
+
+		expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeVisible();
+		expect( screen.getByText( 'Cancel subscription' ) ).toBeVisible();
+		expect( screen.getByText( /Stop future payments\. Keep plan features until/ ) ).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: 'Remove' } ) ).toBeNull();
+	} );
+
+	test( 'shows only Remove when auto-renew is off', () => {
+		render(
+			<CancelOrRemoveActionButton purchase={ makePurchase( { is_auto_renew_enabled: false } ) } />
+		);
+
+		expect( screen.getByRole( 'button', { name: 'Remove' } ) ).toBeVisible();
+		expect( screen.getByText( 'Remove plan' ) ).toBeVisible();
+		expect( screen.getByText( 'Plan features will be removed immediately.' ) ).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: 'Cancel' } ) ).toBeNull();
+	} );
+
+	test( 'forces Remove during the post-expiration grace period even when auto-renew is on', () => {
+		render(
+			<CancelOrRemoveActionButton
+				purchase={ makePurchase( { expiry_status: 'expired', subscription_status: 'active' } ) }
+			/>
+		);
+
+		expect( screen.getByRole( 'button', { name: 'Remove' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: 'Cancel' } ) ).toBeNull();
+	} );
+
+	test( 'keeps a single Cancel action (no second Remove CTA) when a refund is available with auto-renew on', () => {
+		render( <CancelOrRemoveActionButton purchase={ makePurchase( { refund_amount: 96 } ) } /> );
+
+		expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: 'Remove' } ) ).toBeNull();
+	} );
+
+	test( 'renders nothing for a non-refundable domain transfer with auto-renew on', () => {
+		const { container } = render(
+			<CancelOrRemoveActionButton
+				purchase={ makePurchase( {
+					product_slug: 'domain_transfer',
+					is_plan: false,
+					refund_amount: 0,
+				} ) }
+			/>
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-514/

## Proposed Changes

This updates the MSD cancellation -> refund flow to more closely mirror Calypso's current production flow, where a user is first shown a "Cancel plan" action, with a confirmation step that either confirms the cancellation or offers a refund in a notice. For an already cancelled plan, the action will be "Remove plan" which will issue a refund if available.

## Why are these changes being made?

During RSM, we ran a test to split cancellations and refunds into two separate actions from the purchase management page. That test performed poorly and was reverted in Calypso, but only partially reverted in MSD. Now that MSD has launched to some users, the differences between the two flows has been noticed.

## Testing Instructions

- Make a new purchase
- Visit http://my.localhost:3000/me/billing/purchases/ and select the new purchase
- The action at the bottom of the page should be to cancel the plan
- Clicking the action should take you to the confirmation page, with a refund notice if available
- Finishing the flow as-is should cancel the plan but not refund, but now the original CTA should be a removal button
- Selecting the refund option from the original notice should take you to the removal flow