### PR TITLE
Calypso Purchase Management: fix cancellation -> refund flow actions

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
@@ -511,6 +511,29 @@ export function getRefundNoticeCopy( {
 }
 
 /**
+ * Promo notice shown on the Cancel screen when a refund is still available:
+ * a prompt sentence plus the label for the link that switches to the Remove
+ * flow. Plan-worded (not product-aware) to match the current copy.
+ */
+export function getRefundEligibilityPromoCopy( {
+	refundAmount,
+}: {
+	purchase: PurchaseForCopy;
+	refundAmount: string;
+} ): { prompt: string; linkLabel: string } {
+	return {
+		prompt: sprintf(
+			/* translators: %(refundAmount)s is a monetary amount, e.g. "$96.00" */
+			__(
+				'You’re eligible for a %(refundAmount)s refund if you remove your plan now. Your features will be unavailable right away.'
+			),
+			{ refundAmount }
+		),
+		linkLabel: __( 'Remove plan and claim refund.' ),
+	};
+}
+
+/**
  * Universal confirm checkbox — same on Cancel and Remove, any product type.
  * Expiry date lives in the feature-list intro and the top notice; the
  * checkbox is a final "I read the above" ack.

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
@@ -515,12 +515,10 @@ export function getRefundNoticeCopy( {
  * a prompt sentence plus the label for the link that switches to the Remove
  * flow. Plan-worded (not product-aware) to match the current copy.
  */
-export function getRefundEligibilityPromoCopy( {
-	refundAmount,
-}: {
-	purchase: PurchaseForCopy;
-	refundAmount: string;
-} ): { prompt: string; linkLabel: string } {
+export function getRefundEligibilityPromoCopy( { refundAmount }: { refundAmount: string } ): {
+	prompt: string;
+	linkLabel: string;
+} {
 	return {
 		prompt: sprintf(
 			/* translators: %(refundAmount)s is a monetary amount, e.g. "$96.00" */

--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -1,9 +1,8 @@
 import { Link } from '@tanstack/react-router';
-import { __, sprintf } from '@wordpress/i18n';
 import { cancelPurchaseRoute } from '../../../app/router/me';
 import Notice from '../../../components/notice';
 import { hasAmountAvailableToRefund } from '../../../utils/purchase';
-import { getRefundNoticeCopy } from './get-confirmation-copy';
+import { getRefundEligibilityPromoCopy, getRefundNoticeCopy } from './get-confirmation-copy';
 import RefundAmountString from './refund-amount-string';
 import type { Purchase } from '@automattic/api-core';
 
@@ -24,6 +23,7 @@ export default function RefundEligibilityNotice( props: RefundEligibilityNoticeP
 	}
 
 	if ( props.mode === 'refund-eligibility' ) {
+		const { prompt, linkLabel } = getRefundEligibilityPromoCopy( { purchase, refundAmount } );
 		return (
 			<Notice
 				variant="info"
@@ -33,17 +33,11 @@ export default function RefundEligibilityNotice( props: RefundEligibilityNoticeP
 						params={ { purchaseId: String( purchase.ID ) } }
 						search={ { intent: 'remove' as const } }
 					>
-						{ __( 'Remove plan and claim refund.' ) }
+						{ linkLabel }
 					</Link>
 				}
 			>
-				{ sprintf(
-					/* translators: %(refundAmount)s is a monetary amount, e.g. "$96.00" */
-					__(
-						'You’re eligible for a %(refundAmount)s refund if you remove your plan now. Your features will be unavailable right away.'
-					),
-					{ refundAmount }
-				) }
+				{ prompt }
 			</Notice>
 		);
 	}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -23,7 +23,7 @@ export default function RefundEligibilityNotice( props: RefundEligibilityNoticeP
 	}
 
 	if ( props.mode === 'refund-eligibility' ) {
-		const { prompt, linkLabel } = getRefundEligibilityPromoCopy( { purchase, refundAmount } );
+		const { prompt, linkLabel } = getRefundEligibilityPromoCopy( { refundAmount } );
 		return (
 			<Notice
 				variant="info"

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/get-confirmation-copy.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/get-confirmation-copy.ts
@@ -11,6 +11,7 @@ import {
 	getButtonLabels,
 	getFallbackLossItems,
 	getTitanCancellationLossItems,
+	getRefundEligibilityPromoCopy,
 } from '../get-confirmation-copy';
 import type { Purchase } from '@automattic/api-core';
 
@@ -344,6 +345,29 @@ describe( 'getTitanCancellationLossItems', () => {
 		);
 		expect( items ).toContain( '100 GB of mailbox storage' );
 		expect( items ).toContain( 'Titan AI, email campaigns, and more' );
+	} );
+} );
+
+describe( 'getRefundEligibilityPromoCopy', () => {
+	test( 'returns the plan-worded prompt and link label', () => {
+		const { prompt, linkLabel } = getRefundEligibilityPromoCopy( {
+			purchase: makePurchaseForCategory( 'plan' ),
+			refundAmount: '$96.00',
+		} );
+		expect( prompt ).toBe(
+			'You’re eligible for a $96.00 refund if you remove your plan now. Your features will be unavailable right away.'
+		);
+		expect( linkLabel ).toBe( 'Remove plan and claim refund.' );
+	} );
+	test( 'is not product-aware — non-plan products still get the plan wording', () => {
+		const { prompt, linkLabel } = getRefundEligibilityPromoCopy( {
+			purchase: makePurchaseForCategory( 'domain' ),
+			refundAmount: '$12.00',
+		} );
+		expect( prompt ).toBe(
+			'You’re eligible for a $12.00 refund if you remove your plan now. Your features will be unavailable right away.'
+		);
+		expect( linkLabel ).toBe( 'Remove plan and claim refund.' );
 	} );
 } );
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/get-confirmation-copy.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/get-confirmation-copy.ts
@@ -350,20 +350,14 @@ describe( 'getTitanCancellationLossItems', () => {
 
 describe( 'getRefundEligibilityPromoCopy', () => {
 	test( 'returns the plan-worded prompt and link label', () => {
-		const { prompt, linkLabel } = getRefundEligibilityPromoCopy( {
-			purchase: makePurchaseForCategory( 'plan' ),
-			refundAmount: '$96.00',
-		} );
+		const { prompt, linkLabel } = getRefundEligibilityPromoCopy( { refundAmount: '$96.00' } );
 		expect( prompt ).toBe(
 			'You’re eligible for a $96.00 refund if you remove your plan now. Your features will be unavailable right away.'
 		);
 		expect( linkLabel ).toBe( 'Remove plan and claim refund.' );
 	} );
-	test( 'is not product-aware — non-plan products still get the plan wording', () => {
-		const { prompt, linkLabel } = getRefundEligibilityPromoCopy( {
-			purchase: makePurchaseForCategory( 'domain' ),
-			refundAmount: '$12.00',
-		} );
+	test( 'interpolates the refund amount into the prompt', () => {
+		const { prompt, linkLabel } = getRefundEligibilityPromoCopy( { refundAmount: '$12.00' } );
 		expect( prompt ).toBe(
 			'You’re eligible for a $12.00 refund if you remove your plan now. Your features will be unavailable right away.'
 		);

--- a/client/me/purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/me/purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -44,7 +44,6 @@ const RefundEligibilityNotice = ( props: RefundEligibilityNoticeProps ) => {
 	};
 
 	const { prompt, linkLabel } = getRefundEligibilityPromoCopy( {
-		purchase: toPurchaseForCopy( props.purchase ),
 		refundAmount: props.refundAmount,
 	} );
 

--- a/client/me/purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/me/purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -1,8 +1,10 @@
 import page from '@automattic/calypso-router';
 import { Button } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
 import Notice from 'calypso/components/notice';
-import { getRefundNoticeCopy } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy';
+import {
+	getRefundEligibilityPromoCopy,
+	getRefundNoticeCopy,
+} from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy';
 import { toPurchaseForCopy } from './to-purchase-for-copy';
 import type { Purchases } from '@automattic/data-stores';
 
@@ -24,8 +26,6 @@ type RefundEligibilityNoticeProps =
 	| RefundEligibilityNoticeConfirmedProps;
 
 const RefundEligibilityNotice = ( props: RefundEligibilityNoticeProps ) => {
-	const translate = useTranslate();
-
 	if ( props.mode === 'confirmed' ) {
 		return (
 			<Notice className="cancel-purchase__refund-eligibility-notice" showDismiss={ false }>
@@ -43,22 +43,21 @@ const RefundEligibilityNotice = ( props: RefundEligibilityNoticeProps ) => {
 		page( `${ window.location.pathname }?intent=remove` );
 	};
 
+	const { prompt, linkLabel } = getRefundEligibilityPromoCopy( {
+		purchase: toPurchaseForCopy( props.purchase ),
+		refundAmount: props.refundAmount,
+	} );
+
 	return (
 		<Notice className="cancel-purchase__refund-eligibility-notice" showDismiss={ false }>
 			<p className="cancel-purchase__refund-eligibility-text">
-				{ translate(
-					"You're eligible for a %(refundText)s refund if you remove it now. Your access will end right away.",
-					{
-						args: { refundText: props.refundAmount },
-						context: 'refundText is a monetary amount in the form "[currency-symbol][amount]"',
-					}
-				) }{ ' ' }
+				{ prompt }{ ' ' }
 				<Button
 					variant="link"
 					className="cancel-purchase__refund-eligibility-link"
 					onClick={ onRemoveClick }
 				>
-					{ translate( 'Remove and claim refund.' ) }
+					{ linkLabel }
 				</Button>
 			</p>
 		</Notice>

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -61,7 +61,6 @@ import { Plans, type SiteDetails } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { DOMAIN_CANCEL, SUPPORT_ROOT } from '@automattic/urls';
 import { useQuery } from '@tanstack/react-query';
-import { hasTranslation } from '@wordpress/i18n';
 import { check, column, Icon, payment, reusableBlock, tool, trash, upload } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize, LocalizeProps, useTranslate } from 'i18n-calypso';
@@ -110,7 +109,6 @@ import {
 	isOneTimePurchase,
 	isPartnerPurchase,
 	isRenewable,
-	isSubscription,
 	isCloseToExpiration,
 	purchaseType,
 	getName,
@@ -121,11 +119,9 @@ import {
 import { getPurchaseCancellationFlowType } from 'calypso/lib/purchases/utils';
 import { hasCustomDomain } from 'calypso/lib/site/utils';
 import { addQueryArgs } from 'calypso/lib/url';
-import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
 import ProductLink from 'calypso/me/purchases/product-link';
 import titles from 'calypso/me/purchases/titles';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
-import WordAdsEligibilityWarningDialog from 'calypso/me/purchases/wordads-eligibility-warning-dialog';
 import PlanRenewalMessage from 'calypso/my-sites/plans/jetpack-plans/plan-renewal-message';
 import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import {
@@ -167,7 +163,6 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { isRequestingWordAdsApprovalForSite } from 'calypso/state/wordads/approve/selectors';
 import { cancelPurchase, managePurchase, purchasesRoot } from '../paths';
 import PurchaseSiteHeader from '../purchases-site/header';
-import RemovePurchase from '../remove-purchase';
 import {
 	canEditPaymentDetails,
 	getAddNewPaymentMethodPath,
@@ -269,9 +264,6 @@ export interface ManagePurchaseConnectedProps {
 }
 
 interface ManagePurchaseState {
-	showNonPrimaryDomainWarningDialog: boolean;
-	showWordAdsEligibilityWarningDialog: boolean;
-	cancelLink: string | null;
 	isRemoving: boolean;
 	isCancelSurveyVisible: boolean;
 	isReinstalling: boolean;
@@ -300,9 +292,6 @@ class ManagePurchase extends Component<
 	ManagePurchaseState
 > {
 	state = {
-		showNonPrimaryDomainWarningDialog: false,
-		showWordAdsEligibilityWarningDialog: false,
-		cancelLink: null,
 		isRemoving: false,
 		isCancelSurveyVisible: false,
 		isReinstalling: false,
@@ -377,16 +366,6 @@ class ManagePurchase extends Component<
 		const options = redirectTo ? { redirectTo } : undefined;
 		this.props.handleRenewMultiplePurchasesClick( purchases, siteSlug, options );
 	};
-
-	shouldShowNonPrimaryDomainWarning() {
-		const { hasNonPrimaryDomainsFlag, hasCustomPrimaryDomain, purchase } = this.props;
-		return hasNonPrimaryDomainsFlag && purchase && isPlan( purchase ) && hasCustomPrimaryDomain;
-	}
-
-	shouldShowWordAdsEligibilityWarning() {
-		const { hasSetupAds, purchase } = this.props;
-		return hasSetupAds && purchase && isPlan( purchase );
-	}
 
 	isPendingDomainRegistration( purchase: Purchase ): boolean {
 		if ( ! isDomainRegistration( purchase ) ) {
@@ -806,28 +785,6 @@ class ManagePurchase extends Component<
 		);
 	}
 
-	renderActionDetails( nonRefundableTranslatedActionDetails?: string ) {
-		const { purchase, translate } = this.props;
-
-		if ( ! purchase ) {
-			return null;
-		}
-
-		// Hide if refund window has lapsed.
-		if ( ! hasAmountAvailableToRefund( purchase ) || ! purchase?.mostRecentRenewDate ) {
-			if ( ! nonRefundableTranslatedActionDetails ) {
-				return null;
-			}
-			return this.renderActionDetailsText( nonRefundableTranslatedActionDetails, {
-				className: 'manage-purchase__refund-text',
-			} );
-		}
-
-		return this.renderActionDetailsText( translate( 'Refund available' ), {
-			className: 'manage-purchase__refund-text',
-		} );
-	}
-
 	renderActionDetailsText(
 		translatedActionDetails: string,
 		props?: ComponentProps< 'span' >
@@ -836,40 +793,22 @@ class ManagePurchase extends Component<
 	}
 
 	renderRemovePurchaseNavItem() {
-		const {
-			hasLoadedSites,
-			hasNonPrimaryDomainsFlag,
-			hasCustomPrimaryDomain,
-			hasCompletedCancelPurchaseSurvey,
-			site,
-			purchase,
-			purchaseListUrl,
-			translate,
-		} = this.props;
+		const { purchase } = this.props;
 		if ( ! purchase ) {
 			return null;
 		}
 
-		const isSplitEnabled = this.props.isSplitCancelRemoveEnabled;
 		const canRefund = hasAmountAvailableToRefund( purchase );
 		const autoRenewOn = !! purchase.isAutoRenewEnabled;
 
-		// Visibility:
-		//   Off flag → mutually exclusive with Cancel (preserves today's behavior).
-		//   On flag  → Remove when auto-renew is off, OR when the purchase is in its
-		//              post-expiry grace period (Cancel is not offered there, so Remove
-		//              is the only way to act on it — matching the Dashboard). The
-		//              refund-eligible case is surfaced inside the cancel flow via
-		//              RefundEligibilityNotice instead of a parallel Remove CTA.
-		if ( isSplitEnabled ) {
-			if ( autoRenewOn && ! isExpiredAndInGracePeriod( purchase ) ) {
-				return null;
-			}
-		} else if ( canAutoRenewBeTurnedOff( purchase ) ) {
+		// Show Remove when auto-renew is off, OR when the purchase is in its
+		// post-expiry grace period (Cancel is not offered there, so Remove is the
+		// only way to act on it — matching the Dashboard). The refund-eligible case
+		// is surfaced inside the cancel flow via RefundEligibilityNotice instead of
+		// a parallel Remove CTA.
+		if ( autoRenewOn && ! isExpiredAndInGracePeriod( purchase ) ) {
 			return null;
 		}
-
-		const isPlanPurchase = isPlan( purchase );
 
 		// 100-year plans and domains can't be removed via self-serve.
 		if ( is100Year( purchase ) ) {
@@ -879,149 +818,45 @@ class ManagePurchase extends Component<
 			return null;
 		}
 
-		if ( isSplitEnabled ) {
-			const removeCopy = getRemoveButtonCopy( {
-				category: classifyPurchaseForCopy( purchase ),
-				productName: purchase.productName,
-				hasRefund: canRefund,
-			} );
+		const removeCopy = getRemoveButtonCopy( {
+			category: classifyPurchaseForCopy( purchase ),
+			productName: purchase.productName,
+			hasRefund: canRefund,
+		} );
 
-			// All removes route through the unified confirmation screen via
-			// ?intent=remove. isDataValid on the cancel page now accepts any
-			// intent=remove purchase under the flag, so non-refundable and
-			// domain removes both land on the confirmation screen correctly.
-			const baseLink = ( this.props.getCancelPurchaseUrlFor ?? cancelPurchase )(
-				this.props.siteSlug,
-				purchase.id
-			);
-			const link = `${ baseLink }?intent=remove`;
-			return (
-				<CompactCard href={ link } className="remove-purchase__card">
-					<Icon icon={ trash } className="card__icon" />
-					{ removeCopy.label }
-					{ this.renderActionDetailsText( removeCopy.description, {
-						className: 'manage-purchase__refund-text',
-					} ) }
-				</CompactCard>
-			);
-		}
-
-		let text = translate( 'Cancel subscription' );
-
-		if ( isPlanPurchase ) {
-			text = translate( 'Cancel plan' );
-		} else if ( isDomainRegistration( purchase ) ) {
-			text = translate( 'Cancel domain subscription' );
-		}
-
-		return (
-			<RemovePurchase
-				hasLoadedSites={ hasLoadedSites }
-				hasLoadedUserPurchasesFromServer={ this.props.hasLoadedPurchasesFromServer }
-				hasNonPrimaryDomainsFlag={ hasNonPrimaryDomainsFlag }
-				hasSetupAds={ this.props.hasSetupAds }
-				hasCustomPrimaryDomain={ hasCustomPrimaryDomain }
-				activeSubscriptions={ this.getActiveMarketplaceSubscriptions() }
-				site={ site }
-				purchase={ purchase }
-				purchaseListUrl={ purchaseListUrl ?? purchasesRoot }
-				linkIcon="chevron-right"
-				skipRemovePlanSurvey={ isPlanPurchase && hasCompletedCancelPurchaseSurvey }
-			>
-				<Icon icon={ trash } className="card__icon" />
-				{ text }
-				{ this.renderActionDetails(
-					String(
-						isExpiredOrRemoved( purchase )
-							? translate( 'Expired purchase will be removed.' )
-							: translate( 'Will expire immediately and be removed' )
-					)
-				) }
-			</RemovePurchase>
+		// All removes route through the unified confirmation screen via
+		// ?intent=remove. isDataValid on the cancel page accepts any intent=remove
+		// purchase, so non-refundable and domain removes both land on the
+		// confirmation screen correctly.
+		const baseLink = ( this.props.getCancelPurchaseUrlFor ?? cancelPurchase )(
+			this.props.siteSlug,
+			purchase.id
 		);
-	}
-
-	showNonPrimaryDomainWarningDialog( cancelLink: string ) {
-		this.setState( {
-			showNonPrimaryDomainWarningDialog: true,
-			showWordAdsEligibilityWarningDialog: false,
-			isRemoving: false,
-			isCancelSurveyVisible: false,
-			cancelLink,
-		} );
-	}
-
-	showWordAdsEligibilityWarningDialog( cancelLink: string ) {
-		this.setState( {
-			showNonPrimaryDomainWarningDialog: false,
-			showWordAdsEligibilityWarningDialog: true,
-			isRemoving: false,
-			isCancelSurveyVisible: false,
-			cancelLink,
-		} );
+		const link = `${ baseLink }?intent=remove`;
+		return (
+			<CompactCard href={ link } className="remove-purchase__card">
+				<Icon icon={ trash } className="card__icon" />
+				{ removeCopy.label }
+				{ this.renderActionDetailsText( removeCopy.description, {
+					className: 'manage-purchase__refund-text',
+				} ) }
+			</CompactCard>
+		);
 	}
 
 	showPreCancellationModalDialog = () => {
 		this.setState( {
-			showNonPrimaryDomainWarningDialog: false,
-			showWordAdsEligibilityWarningDialog: false,
 			isRemoving: false,
 			isCancelSurveyVisible: true,
-			cancelLink: null,
 		} );
 	};
 
 	closeDialog = () => {
 		this.setState( {
-			showNonPrimaryDomainWarningDialog: false,
-			showWordAdsEligibilityWarningDialog: false,
 			isRemoving: false,
 			isCancelSurveyVisible: false,
-			cancelLink: null,
 		} );
 	};
-
-	goToCancelLink = () => {
-		const cancelLink = this.state.cancelLink;
-		if ( ! cancelLink ) {
-			return;
-		}
-		this.closeDialog();
-		page( cancelLink );
-	};
-
-	renderNonPrimaryDomainWarningDialog( site: SiteDetails, purchase: Purchase ) {
-		if ( this.state.showNonPrimaryDomainWarningDialog ) {
-			return (
-				<NonPrimaryDomainDialog
-					isDialogVisible={ this.state.showNonPrimaryDomainWarningDialog }
-					closeDialog={ this.closeDialog }
-					removePlan={ this.goToCancelLink }
-					planName={ getName( purchase ) }
-					oldDomainName={ site.domain }
-					newDomainName={ site.wpcom_url }
-					hasSetupAds={ this.props.hasSetupAds }
-				/>
-			);
-		}
-
-		return null;
-	}
-
-	renderWordAdsEligibilityWarningDialog( purchase: Purchase ) {
-		if ( this.state.showWordAdsEligibilityWarningDialog ) {
-			return (
-				<WordAdsEligibilityWarningDialog
-					isDialogVisible={ this.state.showWordAdsEligibilityWarningDialog }
-					closeDialog={ this.closeDialog }
-					removePlan={ this.goToCancelLink }
-					planName={ getName( purchase ) }
-				/>
-			);
-		}
-
-		return null;
-	}
 
 	renderCancelSurvey() {
 		const { purchase } = this.props;
@@ -1098,23 +933,22 @@ class ManagePurchase extends Component<
 	};
 
 	renderCancelPurchaseNavItem() {
-		const { isAtomicSite, purchase, translate } = this.props;
+		const { isAtomicSite, purchase } = this.props;
 		if ( ! purchase ) {
 			return null;
 		}
 		const { id } = purchase;
-		const isSplitEnabled = this.props.isSplitCancelRemoveEnabled;
 
 		if ( ! canAutoRenewBeTurnedOff( purchase ) ) {
 			return null;
 		}
 
-		// Under flag: only show the Cancel button when auto-renew is still on
-		// (i.e. the user hasn't already cancelled the subscription). The Remove
-		// button owns the auto-renew-off state. `canAutoRenewBeTurnedOff` returns
-		// true for refundable purchases even when auto-renew is already off, so
-		// the explicit `isAutoRenewEnabled` check is needed.
-		if ( isSplitEnabled && ! purchase.isAutoRenewEnabled ) {
+		// Only show the Cancel button when auto-renew is still on (i.e. the user
+		// hasn't already cancelled the subscription). The Remove button owns the
+		// auto-renew-off state. `canAutoRenewBeTurnedOff` returns true for
+		// refundable purchases even when auto-renew is already off, so the explicit
+		// `isAutoRenewEnabled` check is needed.
+		if ( ! purchase.isAutoRenewEnabled ) {
 			return null;
 		}
 
@@ -1142,49 +976,29 @@ class ManagePurchase extends Component<
 		}
 
 		const expiryDateDisplay = moment( purchase.expiryDate ).format( 'LL' );
-		// Under flag: use non-breaking spaces so the formatted date stays on one
-		// line in narrow viewports. Off flag we preserve trunk's exact output.
-		const cancelCopy = isSplitEnabled
-			? getCancelButtonCopy( {
-					category: classifyPurchaseForCopy( purchase ),
-					productName: purchase.productName,
-					expiryDateFormatted: expiryDateDisplay.replace( / /g, '\u00A0' ),
-			  } )
-			: null;
+		// Use non-breaking spaces so the formatted date stays on one line in narrow
+		// viewports.
+		const cancelCopy = getCancelButtonCopy( {
+			category: classifyPurchaseForCopy( purchase ),
+			productName: purchase.productName,
+			expiryDateFormatted: expiryDateDisplay.replace( / /g, '\u00A0' ),
+		} );
 
-		const onClick = ( event: { preventDefault: () => void } ) => {
+		const onClick = () => {
 			recordTracksEvent( 'calypso_purchases_manage_purchase_cancel_click', {
 				product_slug: purchase.productSlug,
 				is_atomic: isAtomicSite,
-				link_text: cancelCopy ? cancelCopy.label : getCancelPurchaseNavText( purchase, translate ),
+				link_text: cancelCopy.label,
 			} );
-
-			if ( ! isSplitEnabled && this.shouldShowWordAdsEligibilityWarning() ) {
-				event.preventDefault();
-				this.showWordAdsEligibilityWarningDialog( link );
-			}
-
-			if ( ! isSplitEnabled && this.shouldShowNonPrimaryDomainWarning() ) {
-				event.preventDefault();
-				this.showNonPrimaryDomainWarningDialog( link );
-			}
 		};
 
 		return (
 			<CompactCard href={ link } className="remove-purchase__card" onClick={ onClick }>
 				<Icon icon={ trash } className="card__icon" />
-				{ cancelCopy ? cancelCopy.label : getCancelPurchaseNavText( purchase, translate ) }
-				{ cancelCopy
-					? this.renderActionDetailsText( cancelCopy.description, {
-							className: 'manage-purchase__refund-text',
-					  } )
-					: this.renderActionDetails(
-							String(
-								translate( 'Will remain active until %(expiryDate)s', {
-									args: { expiryDate: expiryDateDisplay },
-								} )
-							)
-					  ) }
+				{ cancelCopy.label }
+				{ this.renderActionDetailsText( cancelCopy.description, {
+					className: 'manage-purchase__refund-text',
+				} ) }
 			</CompactCard>
 		);
 	}
@@ -1751,8 +1565,6 @@ class ManagePurchase extends Component<
 					purchase={ purchase }
 				/>
 				{ this.renderPurchaseDetail( preventRenewal ) }
-				{ this.renderWordAdsEligibilityWarningDialog( purchase ) }
-				{ site && this.renderNonPrimaryDomainWarningDialog( site, purchase ) }
 			</Fragment>
 		);
 	}
@@ -2046,22 +1858,3 @@ function ManagePurchaseWithExperiment( props: ManagePurchaseProps ) {
 }
 
 export default ManagePurchaseWithExperiment;
-
-function getCancelPurchaseNavText(
-	purchase: Purchase,
-	translate: LocalizeProps[ 'translate' ]
-): string {
-	if ( isDomainRegistration( purchase ) ) {
-		if ( hasTranslation( 'Cancel domain subscription' ) ) {
-			return translate( 'Cancel domain subscription' );
-		}
-		return translate( 'Cancel domain' );
-	} else if ( isPlan( purchase ) ) {
-		return translate( 'Cancel plan' );
-	} else if ( isSubscription( purchase ) ) {
-		return translate( 'Cancel subscription' );
-	} else if ( isOneTimePurchase( purchase ) ) {
-		return translate( 'Cancel' );
-	}
-	return '';
-}

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -146,33 +146,9 @@ describe( 'Purchase Management Buttons', () => {
 	const queryClient = new QueryClient();
 
 	beforeEach( () => {
-		// Default to the split-cancel-remove flow being enabled (matches config/test.json);
-		// individual tests opt out to exercise the flag-off path.
+		// The cancellation-features query is still gated on the split-cancel-remove
+		// flag, so keep it enabled (matches config/test.json).
 		useIsSplitCancelRemoveEnabled.mockReturnValue( true );
-	} );
-
-	it( 'cancel button links to the cancel flow with intent=cancel even when the split flag is off', async () => {
-		useIsSplitCancelRemoveEnabled.mockReturnValue( false );
-		nock( 'https://public-api.wordpress.com' )
-			.get( '/rest/v1.2/me/payment-methods?expired=include' )
-			.reply( 200 );
-
-		const store = createMockReduxStoreForPurchase( { ...purchase, is_auto_renew_enabled: true } );
-
-		render(
-			<QueryClientProvider client={ queryClient }>
-				<ReduxProvider store={ store }>
-					<ManagePurchase
-						purchaseId={ Number( purchase.ID ) }
-						isSiteLevel
-						siteSlug="onecooltestsite.com"
-					/>
-				</ReduxProvider>
-			</QueryClientProvider>
-		);
-
-		const cancelLink = await screen.findByRole( 'link', { name: /Cancel plan/i } );
-		expect( cancelLink ).toHaveAttribute( 'href', expect.stringContaining( 'intent=cancel' ) );
 	} );
 
 	it( 'renders a cancel button when auto-renew is ON', async () => {


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/CHE-508/

## Proposed Changes

This fixes a couple of issues with the cancellation -> refund flow for Calypso purchase management screens and puts it in alignment with the action and messaging of the multi-site dashboard.

- It fixes a bug where plans with auto-renew off (cancelled) are shown the removal button and flow, instead of the cancellation button and flow
- It updates the text of each button to match the MSD equivalent flows

| Before | After |
| ----------- | ----------- |
| <img width="3494" height="2504" alt="CleanShot 2026-07-21 at 17 13 14@2x" src="https://github.com/user-attachments/assets/067d400e-1a53-4ebb-80d3-55a9c832a05a" /> Auto-renew on, refund available | <img width="3494" height="2504" alt="CleanShot 2026-07-21 at 17 13 04@2x" src="https://github.com/user-attachments/assets/432dfef8-2f98-418a-b5b7-7589e89e24f3" /> Auto-renew on, refund available |
| <img width="3494" height="2504" alt="CleanShot 2026-07-21 at 17 12 49@2x" src="https://github.com/user-attachments/assets/04998cf6-6e88-4a28-8fe3-4f6906bd8b72" /> Auto-renew off, refund available (wrong "cancel plan") | <img width="3494" height="2504" alt="CleanShot 2026-07-21 at 17 12 42@2x" src="https://github.com/user-attachments/assets/7253e186-ab4c-4f40-9c07-24ae2ef88797" /> Auto-renew off, refund available |

## Why are these changes being made?

During RSM, a test was run to split cancellations and refunds into separate actions from the purchase management page, but was ultimately reverted. This leaves users in a somewhat confusing state, where after cancelling their plan, they should be shown a "Remove Plan" action with a direct link to remove the plan and refund if available.

This was cleaned up for the MSD in https://github.com/Automattic/wp-calypso/pull/112847, so these changes force Calypso to use the same messaging and actions.

## Testing Instructions

- Make a new purchase
- Visit the site-specific purchase management page for the purchase
- The action at the bottom of the page should be to cancel the plan
- Clicking the action should take you to the confirmation page, with a refund notice if available
- Finishing the flow as-is should cancel the plan but not refund, but now the original CTA should be a removal button
- Selecting the refund option from the original notice should take you to the removal flow
