### PR TITLE
Returning user modal: Update control copy

### DIFF
--- a/client/components/resurrected-welcome-modal/index.tsx
+++ b/client/components/resurrected-welcome-modal/index.tsx
@@ -54,7 +54,7 @@ const MANUAL_VARIATION_CONFIG: VariationConfig = {
 	getTitle: ( translate ) => translate( 'Welcome back!' ),
 	getDescription: ( translate ) =>
 		translate(
-			'Ready to explore our latest upgrades? All paid plans now include access to new themes and plugins.'
+			'Ready to explore our latest upgrades? All paid plans now include access to new themes and plugins. Pick up where you left off or start fresh with our latest tools.'
 		),
 	ctas: [
 		{
@@ -132,27 +132,6 @@ const VARIATION_CONTENT: Partial< Record< WelcomeBackVariation, VariationConfig 
 				id: 'design-new',
 				getLabel: ( translate ) => translate( 'Create a new site' ),
 				href: ONBOARDING_URL,
-				variant: 'tertiary',
-			},
-		],
-	},
-	[ WELCOME_BACK_VARIATIONS.control ]: {
-		getTitle: ( translate ) => translate( 'Welcome back!' ),
-		getDescription: ( translate ) =>
-			translate(
-				'Ready to explore our latest upgrades? All paid plans now include access to new themes and plugins. Pick up where you left off or start fresh with our latest tools.'
-			),
-		ctas: [
-			{
-				id: 'control-new',
-				getLabel: ( translate ) => translate( 'Create a new site' ),
-				href: ONBOARDING_URL,
-				variant: 'primary',
-			},
-			{
-				id: 'control-continue',
-				getLabel: ( translate ) => translate( 'Continue where I left off' ),
-				isDismissOnly: true,
 				variant: 'tertiary',
 			},
 		],


### PR DESCRIPTION
Related to DOTCOM-17870

## Proposed Changes

* Update the control copy and remove the `control` variation.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To prepare for future experiments.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
