### PR TITLE
Update domain connection flow copy

### DIFF
--- a/client/components/domains/use-my-domain/utilities/option-info.jsx
+++ b/client/components/domains/use-my-domain/utilities/option-info.jsx
@@ -9,10 +9,10 @@ const transferIllustration = <Icon icon={ TransferIcon } />;
 
 const optionTitleText = {
 	get transfer() {
-		return __( 'Transfer your domain name' );
+		return __( 'Transfer your domain' );
 	},
 	get connect() {
-		return __( 'Connect your domain name' );
+		return __( 'Connect your site address' );
 	},
 };
 
@@ -22,7 +22,7 @@ const transferSupported = {
 		return optionTitleText.transfer;
 	},
 	get topText() {
-		return __( 'Manage everything in one place, including domain name renewals.' );
+		return __( 'Manage everything in one place.' );
 	},
 	get etaText() {
 		return __( 'May take 5–7 days' );
@@ -31,8 +31,8 @@ const transferSupported = {
 	get benefits() {
 		return [
 			__( 'Free domain name renewal for 1 year' ),
-			__( 'Manage everything in one place' ),
-			__( 'Private domain registration and SSL included' ),
+			__( 'Manage everything from WordPress.com' ),
+			__( 'Privacy protection and SSL included' ),
 		];
 	},
 };
@@ -54,7 +54,7 @@ const connectSupported = {
 		return optionTitleText.connect;
 	},
 	get topText() {
-		return __( 'Connect your existing domain name to WordPress.com.' );
+		return __( 'Use your existing domain with your site.' );
 	},
 	get etaText() {
 		return __( 'May take up to 72 hours' );
@@ -62,8 +62,8 @@ const connectSupported = {
 	learnMoreLink: MAP_EXISTING_DOMAIN,
 	get benefits() {
 		return [
-			__( 'Keep your current domain name provider' ),
-			__( "Your existing services won't be interrupted" ),
+			__( 'Keep your current domain provider' ),
+			__( 'Email and other services stay connected' ),
 			__( 'Privacy protection and SSL included' ),
 		];
 	},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -205,12 +205,12 @@ const UseMyDomain: StepType< {
 
 		if ( useMyDomainMode === 'domain-input' ) {
 			columnWidth = 4 as const;
-			headingText = __( 'Your domain name' );
-			subText = __( 'Enter the domain name your visitors already know.' );
+			headingText = __( 'Enter your domain' );
+			subText = __( 'Type the domain you already own, like yourdomain.com.' );
 		} else {
 			columnWidth = 6 as const;
-			headingText = __( 'Use a domain name I own' );
-			subText = __( 'Make your domain name part of something bigger.' );
+			headingText = __( 'Set up your domain' );
+			subText = __( 'Transfer your domain, or connect it from your current provider.' );
 		}
 
 		const getTopBarLeftElement = () => {

--- a/packages/calypso-e2e/src/lib/pages/use-a-domain-i-own-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/use-a-domain-i-own-page.ts
@@ -3,8 +3,8 @@ import { Locator, Page } from 'playwright';
 const selectors = {
 	ownedDomainInput: '.use-my-domain__domain-input-fieldset input',
 	continueButton: 'button:text("Continue")',
-	connectDomainButton: 'button span:text("Connect your domain name")',
-	transferDomainButton: 'button span:text("Transfer your domain name")',
+	connectDomainButton: 'button span:text("Connect your site address")',
+	transferDomainButton: 'button span:text("Transfer your domain")',
 };
 
 /**


### PR DESCRIPTION
Reintroduces #112758 after its revert in #112851.

## Proposed Changes

* Update copy on the Enter Domain and Path Selection steps.
* Update the domain-flow E2E selectors to match the new connection and transfer button text.

## Why are these changes being made?

* Updating the onboarding text with the latest copy.
* The original change was reverted because the pre-release E2E test still expected the previous button text. Keeping the selector update in this PR ensures the application and its E2E expectations change together.

## Testing Instructions

* From /setup/onboarding/use-my-domain, compare the text against the Figma mockups. Ensure that the text was updated accordingly.
* E2E test updates should reflect the copy changes for the button text.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
