### PR TITLE
Jetpack AI: keep block grammar checks scoped to the selected block

### DIFF
--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -2816,8 +2816,32 @@ describe( 'contextProvider', () => {
 		const proofreadContext = contextProvider.getClientContext();
 		expect( proofreadContext.currentPageContent ).toEqual( [] );
 		expect( proofreadContext.jetpackAi ).toBeUndefined();
+		expect( proofreadContext.jetpackAIRequestScope ).toBeUndefined();
 		expect( contextProvider.getClientContext().currentPageContent ).toHaveLength( 1 );
 		expect( contextProvider.getClientContext().jetpackAi ).toBeUndefined();
+	} );
+
+	it( 'scopes only the next block suggestion request to the selected block', () => {
+		installAiEditorialReviewData();
+		installContextProviderMock();
+		mockSelectedBlock = {
+			clientId: 'selected-block',
+			name: 'core/paragraph',
+			attributes: { content: 'Selected paragraph' },
+		};
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions: jest.fn() } ) );
+
+		act( () => {
+			window.dispatchEvent(
+				new CustomEvent( 'big-sky-inline-suggestion-click', {
+					detail: { suggestionId: 'check-grammar' },
+				} )
+			);
+		} );
+
+		expect( contextProvider.getClientContext().jetpackAIRequestScope ).toBe( 'selected-block' );
+		expect( contextProvider.getClientContext().jetpackAIRequestScope ).toBeUndefined();
 	} );
 
 	it( 'clears pending Simple Review content suppression when another suggestion is clicked', () => {
@@ -3387,7 +3411,8 @@ function installWpDataMockWithBlockEditor(
 			name: 'core/paragraph',
 			attributes: { content: 'original block content' },
 		},
-	}
+	},
+	options: { selectedBlockClientId?: string; rootClientIds?: string[] } = {}
 ) {
 	const editorState: { title: string } = { title: 'original' };
 	const blockUpdates: Array< { clientId: string; attrs: Record< string, unknown > } > = [];
@@ -3405,11 +3430,17 @@ function installWpDataMockWithBlockEditor(
 					return {
 						getBlock: ( clientId: string ) =>
 							blocks[ clientId ] ? { clientId, ...blocks[ clientId ] } : null,
+						getSelectedBlockClientId: () => options.selectedBlockClientId ?? null,
 						getBlocks: () =>
-							Object.entries( blocks ).map( ( [ clientId, block ] ) => ( {
-								clientId,
-								...block,
-							} ) ),
+							Object.entries( blocks )
+								.filter(
+									( [ clientId ] ) =>
+										! options.rootClientIds || options.rootClientIds.includes( clientId )
+								)
+								.map( ( [ clientId, block ] ) => ( {
+									clientId,
+									...block,
+								} ) ),
 					};
 				}
 				return undefined;
@@ -3752,6 +3783,63 @@ describe( 'applyReviewEdit', () => {
 		] );
 	} );
 
+	it( 'matches currentText when the model normalizes a curly apostrophe', async () => {
+		const { blockUpdates } = installWpDataMockWithBlockEditor( {
+			'550e8400-e29b-41d4-a716-446655440000': {
+				name: 'core/paragraph',
+				attributes: { content: 'With every bite, you’ll taste joyful memories. sss' },
+			},
+		} );
+		useAbilitiesSetup( { addMessage: () => undefined, clearSuggestions: () => undefined } as any );
+
+		const promise = applyReviewEdit(
+			'550e8400-e29b-41d4-a716-446655440000',
+			"With every bite, you'll taste joyful memories.",
+			undefined,
+			"With every bite, you'll taste joyful memories. sss"
+		);
+		jest.advanceTimersByTime( 1000 );
+		const result = await promise;
+
+		expect( result ).toMatchObject( {
+			success: true,
+			contentBefore: 'With every bite, you’ll taste joyful memories. sss',
+			contentAfter: "With every bite, you'll taste joyful memories.",
+		} );
+		expect( blockUpdates ).toEqual( [
+			{
+				clientId: '550e8400-e29b-41d4-a716-446655440000',
+				attrs: { content: "With every bite, you'll taste joyful memories." },
+			},
+		] );
+	} );
+
+	it( 'removes a matching span when the replacement content is empty', async () => {
+		const { blockUpdates } = installWpDataMockWithBlockEditor( {
+			WJZs: {
+				name: 'core/paragraph',
+				attributes: { content: '<strong>Paragraph text.</strong> sss' },
+			},
+		} );
+		useAbilitiesSetup( { addMessage: () => undefined, clearSuggestions: () => undefined } as any );
+
+		const promise = applyReviewEdit( 'WJZs', '', undefined, 'sss' );
+		jest.advanceTimersByTime( 1000 );
+		const result = await promise;
+
+		expect( result ).toMatchObject( {
+			success: true,
+			contentBefore: '<strong>Paragraph text.</strong> sss',
+			contentAfter: '<strong>Paragraph text.</strong> ',
+		} );
+		expect( blockUpdates ).toEqual( [
+			{
+				clientId: 'WJZs',
+				attrs: { content: '<strong>Paragraph text.</strong> ' },
+			},
+		] );
+	} );
+
 	it( 'falls back to a unique currentText match when the clientId is stale', async () => {
 		const { blockUpdates } = installWpDataMockWithBlockEditor( {
 			'live-client-id': {
@@ -3781,6 +3869,51 @@ describe( 'applyReviewEdit', () => {
 			{
 				clientId: 'live-client-id',
 				attrs: { content: 'Hello world, this is my first post.' },
+			},
+		] );
+		warn.mockRestore();
+	} );
+
+	it( 'uses the live selected block when stale page content is outside the root block tree', async () => {
+		const { blockUpdates } = installWpDataMockWithBlockEditor(
+			{
+				'page-content-client-id': {
+					name: 'core/paragraph',
+					attributes: {
+						content:
+							'I write this blog. If you\u2019re a soul-search like me, read on. aaaa bbbb cccc ddd',
+					},
+				},
+				'template-client-id': {
+					name: 'core/post-content',
+					attributes: {},
+				},
+			},
+			{
+				selectedBlockClientId: 'page-content-client-id',
+				rootClientIds: [ 'template-client-id' ],
+			}
+		);
+		useAbilitiesSetup( { addMessage: () => undefined, clearSuggestions: () => undefined } as any );
+		const warn = jest.spyOn( console, 'warn' ).mockImplementation( () => undefined );
+
+		const promise = applyReviewEdit(
+			'stale-page-client-id',
+			"I write this blog. If you're a soul-searcher like me, read on.",
+			undefined,
+			"I write this blog. If you're a soul-search like me, read on. aaaa bbbb cccc ddd"
+		);
+		jest.advanceTimersByTime( 1000 );
+		const result = await promise;
+
+		expect( result ).toMatchObject( {
+			success: true,
+			clientId: 'page-content-client-id',
+		} );
+		expect( blockUpdates ).toEqual( [
+			{
+				clientId: 'page-content-client-id',
+				attrs: { content: "I write this blog. If you're a soul-searcher like me, read on." },
 			},
 		] );
 		warn.mockRestore();
@@ -3884,6 +4017,7 @@ describe( 'applyReviewEdit', () => {
 	it.each( [
 		[ 'separate matches', 'vote now, then vote again after discussion.', 'vote' ],
 		[ 'overlapping matches', 'banana', 'ana' ],
+		[ 'quote-normalized matches', "don't and don’t", "don't" ],
 	] )(
 		'fails without replacing the block when currentText has %s',
 		async ( _label, content, currentText ) => {

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -3881,7 +3881,7 @@ describe( 'applyReviewEdit', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'I write this blog. If you\u2019re a soul-search like me, read on. aaaa bbbb cccc ddd',
+							'I write this blog. If you’re a soul-search like me, read on. aaaa bbbb cccc ddd',
 					},
 				},
 				'template-client-id': {

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -80,6 +80,7 @@ let wasAgentProcessing = false;
 let pendingBlockShimmerClientId: string | null = null;
 let blockShimmerStartedForRequest = false;
 let suppressCurrentPageContentForNextContext = false;
+let jetpackAIRequestScopeForNextContext: 'selected-block' | null = null;
 
 /** Whether `_suggestion_rendered` has fired this page life (once-per-session). */
 let suggestionRenderedFiredOnce = false;
@@ -746,7 +747,9 @@ export const contextProvider = {
 		let selectedBlockContent = '';
 		let currentPostType: string | undefined;
 		const suppressCurrentPageContent = suppressCurrentPageContentForNextContext;
+		const jetpackAIRequestScope = jetpackAIRequestScopeForNextContext;
 		suppressCurrentPageContentForNextContext = false;
+		jetpackAIRequestScopeForNextContext = null;
 
 		if ( wpData ) {
 			const editor = wpData.select( 'core/editor' );
@@ -779,6 +782,7 @@ export const contextProvider = {
 			},
 			currentPageContent,
 			selectedBlockClientId,
+			...( jetpackAIRequestScope && { jetpackAIRequestScope } ),
 			// Forward the host's SEO Enhancer verdict (plan + Jetpack SEO Tools
 			// module + kill switches) so the orchestrator can drop the SEO
 			// suggestion abilities when they aren't usable on this site — e.g. a
@@ -1159,6 +1163,11 @@ export function useSuggestions(
 			pendingBlockShimmerClientId = BLOCK_SUGGESTIONS.some( matchesSuggestion )
 				? getSelectedOrRememberedBlock()?.clientId ?? null
 				: null;
+			jetpackAIRequestScopeForNextContext = null;
+
+			if ( BLOCK_SUGGESTIONS.some( matchesSuggestion ) ) {
+				jetpackAIRequestScopeForNextContext = 'selected-block';
+			}
 
 			if ( matchesSuggestion( POST_FEEDBACK_SUGGESTION ) ) {
 				suppressCurrentPageContentForNextContext = true;

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -437,6 +437,31 @@ function getStringLikeAttributeNames( block: any ): string[] {
 	);
 }
 
+/**
+ * Treat typographic and straight quotation marks as equivalent when validating
+ * model-returned currentText. Each replacement is one UTF-16 code unit, so a
+ * match index in the normalized string still points to the same source span.
+ */
+function normaliseQuotationMarks( text: string ): string {
+	return text.replace( /[\u2018\u2019]/g, "'" ).replace( /[\u201c\u201d]/g, '"' );
+}
+
+function countCurrentTextOccurrences( source: string, currentText: string ): number {
+	return countOccurrences(
+		normaliseQuotationMarks( source ),
+		normaliseQuotationMarks( currentText )
+	);
+}
+
+function replaceCurrentText( source: string, currentText: string, replacement: string ): string {
+	const matchIndex = normaliseQuotationMarks( source ).indexOf(
+		normaliseQuotationMarks( currentText )
+	);
+	return (
+		source.slice( 0, matchIndex ) + replacement + source.slice( matchIndex + currentText.length )
+	);
+}
+
 function findAttributeByCurrentText( block: any, currentText?: string ): string | undefined {
 	if ( typeof currentText !== 'string' || currentText === '' ) {
 		return undefined;
@@ -444,7 +469,7 @@ function findAttributeByCurrentText( block: any, currentText?: string ): string 
 
 	const matches = getStringLikeAttributeNames( block ).filter( ( attributeName ) => {
 		const content = getAttributeContent( block, attributeName ) ?? '';
-		return countOccurrences( content, currentText ) === 1;
+		return countCurrentTextOccurrences( content, currentText ) === 1;
 	} );
 
 	return matches.length === 1 ? matches[ 0 ] : undefined;
@@ -565,7 +590,7 @@ function findBlockSnapshotByCurrentText(
 				attributeName: candidate,
 				content,
 			};
-			const matchCount = countOccurrences( content, currentText );
+			const matchCount = countCurrentTextOccurrences( content, currentText );
 			for ( let i = 0; i < matchCount; i++ ) {
 				matches.push( snapshot );
 			}
@@ -617,21 +642,54 @@ export function handleUpdateBlockContent( input: any ): any {
 	let snapshot = getBlockSnapshot( targetClientId, editableAttribute, currentText );
 	if ( ! snapshot ) {
 		if ( hasCurrentText ) {
-			const fallback = findBlockSnapshotByCurrentText( currentText, editableAttribute );
-			if ( fallback.error ) {
-				// eslint-disable-next-line no-console
-				console.warn( '[Jetpack AI] currentText matches multiple spans in block content', {
-					clientId,
-				} );
-				return {
-					success: false,
-					error: fallback.error,
-					returnToAgent: false,
-				};
+			const selectedClientId = getBlockEditorSelect()?.getSelectedBlockClientId?.();
+			if ( selectedClientId ) {
+				const selectedSnapshot = getBlockSnapshot(
+					selectedClientId,
+					editableAttribute,
+					currentText
+				);
+				if ( selectedSnapshot?.attributeName ) {
+					const selectedMatchCount = countCurrentTextOccurrences(
+						selectedSnapshot.content,
+						currentText
+					);
+					if ( selectedMatchCount === 1 ) {
+						targetClientId = selectedClientId;
+						snapshot = selectedSnapshot;
+					} else if ( selectedMatchCount > 1 ) {
+						// eslint-disable-next-line no-console
+						console.warn( '[Jetpack AI] currentText matches multiple spans in block content', {
+							clientId,
+						} );
+						return {
+							success: false,
+							error: 'currentText matches multiple spans in block content',
+							returnToAgent: false,
+						};
+					}
+				}
 			}
-			if ( fallback.snapshot ) {
-				targetClientId = fallback.snapshot.clientId;
-				snapshot = fallback.snapshot;
+
+			if ( ! snapshot ) {
+				const fallback = findBlockSnapshotByCurrentText( currentText, editableAttribute );
+				if ( fallback.error ) {
+					// eslint-disable-next-line no-console
+					console.warn( '[Jetpack AI] currentText matches multiple spans in block content', {
+						clientId,
+					} );
+					return {
+						success: false,
+						error: fallback.error,
+						returnToAgent: false,
+					};
+				}
+				if ( fallback.snapshot ) {
+					targetClientId = fallback.snapshot.clientId;
+					snapshot = fallback.snapshot;
+				}
+			}
+			if ( snapshot ) {
 				// eslint-disable-next-line no-console
 				console.warn( '[Jetpack AI] stale clientId matched by currentText', {
 					clientId,
@@ -656,7 +714,7 @@ export function handleUpdateBlockContent( input: any ): any {
 	// If that span no longer exists, fail rather than replacing the whole block
 	// with a partial suggested edit.
 	if ( hasCurrentText ) {
-		const matchCount = countOccurrences( snapshot.content, currentText );
+		const matchCount = countCurrentTextOccurrences( snapshot.content, currentText );
 		if ( matchCount === 0 ) {
 			// eslint-disable-next-line no-console
 			console.warn( '[Jetpack AI] currentText not found in block content', { clientId } );
@@ -717,7 +775,7 @@ export function handleUpdateBlockContent( input: any ): any {
 
 			let nextContent = content;
 			if ( hasCurrentText ) {
-				const matchCount = countOccurrences( latestSnapshot.content, currentText );
+				const matchCount = countCurrentTextOccurrences( latestSnapshot.content, currentText );
 				if ( matchCount === 0 ) {
 					// eslint-disable-next-line no-console
 					console.warn( '[Jetpack AI] currentText not found in block content', {
@@ -734,7 +792,7 @@ export function handleUpdateBlockContent( input: any ): any {
 					resolveFailure( 'currentText matches multiple spans in block content' );
 					return;
 				}
-				nextContent = latestSnapshot.content.replace( currentText, content );
+				nextContent = replaceCurrentText( latestSnapshot.content, currentText, content );
 			} else if ( latestSnapshot.content !== snapshot.content ) {
 				// eslint-disable-next-line no-console
 				console.warn( '[Jetpack AI] block content changed while applying edit', {


### PR DESCRIPTION
## Proposed Changes

* Mark block suggestions such as Check grammar as `selected-block` requests so the paired WordPress.com orchestrator route does not select the whole-post Proofreader.
* Apply returned edits to the live selected block when Page editor content has regenerated its client ID or is outside the root template block tree.
* Treat curly and straight quotation marks as equivalent while safely matching model-returned `currentText`.

## Why are these changes being made?

The Jetpack AI sidebar could route Check grammar to the whole-post Proofreader instead of the selected-block flow. Even when the block grammar ability returned a valid edit, Page editor content could have a stale client ID and sit outside `getBlocks()`, so the edit was not applied. Model-normalized quotes could also prevent an otherwise exact edit from matching the source block.

The paired WordPress.com orchestrator change consumes the exact `jetpackAIRequestScope: 'selected-block'` contract emitted here. Requests without that scope keep the existing Proofreader behavior.

## Testing Instructions

Follow steps in WPCOM PR 229442

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
