### PR TITLE
Banner: stop restyling the card edge on hover and focus

### DIFF
--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -50,10 +50,6 @@
 		background: none;
 		padding: 0;
 	}
-
-	&:hover {
-		box-shadow: none;
-	}
 }
 .upsell-nudge.is-dismissible.is-compact .banner__content {
 	flex-direction: column;
@@ -73,9 +69,5 @@
 
 	.card__link-indicator {
 		display: none;
-	}
-
-	&:hover {
-		box-shadow: none;
 	}
 }

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -44,18 +44,13 @@
 	&:hover {
 		transition: all 100ms ease-in-out;
 
-		&.is-card-link {
-			box-shadow: 0 0 0 1px var(--color-neutral), 0 2px 4px var(--color-neutral-10);
-		}
 		.card__link-indicator {
 			color: var(--color-neutral-dark);
 		}
 	}
 
-	&:focus {
-		&.is-card-link {
-			box-shadow: 0 0 0 2px var(--color-primary-light);
-		}
+	&:focus-visible {
+		box-shadow: 0 0 0 2px var(--color-primary-light);
 	}
 
 	@include breakpoint-deprecated( ">480px" ) {


### PR DESCRIPTION
Part of DSGCOM-576

## Proposed Changes

* Link banners no longer restyle the card edge on hover or on focus. Previously, hovering swapped the card's hairline border for a much darker ring plus a drop shadow, and focusing replaced that hairline with a thicker ring.
* Removed the compact upsell-nudge hover rules that existed only to cancel that outline. They are dead code now, and the computed style is unchanged.

The hover affordance is still there — the chevron darkens and the cursor changes. The focus ring is kept, but scoped to keyboard focus so clicking a banner with a mouse no longer leaves a ring behind.

## Why are these changes being made?

Reported as a broken hover state on the Payment Settings upsell banner. The banner draws its accent edge as a real border but gets its outer edge from a box shadow, and a box shadow paints outside the border box. When hover darkened that shadow, the two stacked into a doubled, near-black outline that no other card in the product has.

Aligning with the design system means removing the hover outline rather than restyling it. `Card` in `@automattic/components` only recolors its chevron on hover and never touches its edge, `Card` in `@wordpress/components` has no hover styling at all, and the Dashboard's upsell card has none either — its affordance is the call-to-action button inside it. The banner's hover was the outlier.

This is a shared style, so it affects every banner that renders as a link — roughly 18 across the product, with Site Settings the densest group. It is not scoped to the Payment Settings page.

## Testing Instructions

Note that most upsell banners pass a call-to-action button and render as a plain card, so they never had this hover state. You need one that renders as a whole-card link.

1. On a site without paid payment features, go to Monetize → Payment Settings.
2. Hover the "Upgrade to modify payment plans or add new plans" banner.
3. Before: the card gains a dark outline and a drop shadow. After: the border is unchanged, only the chevron darkens.
4. Tab to the banner and confirm the focus ring is visible and the card's border is unchanged. With the banner still focused, move the pointer over it and confirm the ring stays visible.
5. Spot-check a few other link banners, e.g. Settings → Performance, Settings → Security, and the plugin and theme upload screens.

Verified that the computed border is identical across the resting, hovered, and focused states, that the chevron color is the only thing hover changes, and that a keyboard-focused banner keeps a visible ring while simultaneously hovered.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
