### PR TITLE
Odyssey Stats: scope widget CSS to its own .jp-stats-widget mount point

### DIFF
--- a/apps/odyssey-stats/AGENTS.md
+++ b/apps/odyssey-stats/AGENTS.md
@@ -53,9 +53,9 @@ Odyssey routes API calls through Jetpack REST API, not `public-api.wordpress.com
 
 ### CSS Scoping
 
-Odyssey only owns the `#wpcom` subtree of a wp-admin page (wp-admin chrome is a sibling under the same `<body>`), so `webpack.config.js` runs a `postcss-prefix-selector` step scoping first-party component styles to `.jp-stats-dashboard` and known portal roots (`.color-scheme`, `.ReactModalPortal`, `[data-base-ui-portal]`, `[data-wp-compat-overlay-slot]`, `.components-modal__screen-overlay` for `@wordpress/components` `Modal`). Two lists there need updating as the app evolves:
+Odyssey only owns the `#wpcom` subtree of a wp-admin page (wp-admin chrome is a sibling under the same `<body>`), so `webpack.config.js` runs a `postcss-prefix-selector` step scoping first-party component styles to `.jp-stats-dashboard`, the WP-Admin dashboard widget's own mount point (`.jp-stats-widget`), and known portal roots (`.color-scheme`, `.ReactModalPortal`, `[data-base-ui-portal]`, `[data-wp-compat-overlay-slot]`, `.components-modal__screen-overlay` for `@wordpress/components` `Modal`). Two lists there need updating as the app evolves:
 
-- **Prefix target list** — add a new portal root if a component renders through one not already listed (e.g. a new `Popover`/`Dialog`/`Tooltip` library).
+- **Prefix target list** — add a new mount point or portal root if a component renders under a wrapper not already listed (e.g. a new standalone entry point, or a component that renders through a new `Popover`/`Dialog`/`Tooltip` library).
 - **`exclude` list** — add a pattern if a selector legitimately targets the real `<html>`/`<body>`/`:root` (RTL flags, `:lang()`, scroll-lock, etc.); prefixing those makes them permanently dead instead of just scoped.
 
 After changing either list, do a production build and grep the compiled CSS for the affected class to confirm it's scoped (or intentionally left unscoped), not silently dead.

--- a/apps/odyssey-stats/src/lib/test/css-scope.test.js
+++ b/apps/odyssey-stats/src/lib/test/css-scope.test.js
@@ -1,0 +1,86 @@
+import postcss from 'postcss';
+import prefixSelectorPlugin from 'postcss-prefix-selector';
+import cssScope from '../../../webpack-css-scope';
+
+/**
+ * Runs representative CSS through the real webpack `postcss-prefix-selector` config (the same
+ * options object webpack.config.js hands the plugin) and returns the compiled CSS text, so tests
+ * assert on what actually ships rather than a hand-copied stand-in.
+ */
+function compile( css, { from } = {} ) {
+	return postcss( [ prefixSelectorPlugin( cssScope ) ] ).process( css, { from } ).css;
+}
+
+/**
+ * Builds a DOM fixture with a `.jp-stats-dashboard` mount, a `.jp-stats-widget` mount, and
+ * unrelated wp-admin chrome outside both, injects the compiled CSS, and returns the elements
+ * tests match selectors against.
+ */
+function buildFixture( compiledCss ) {
+	document.body.innerHTML = `
+		<div class="jp-stats-dashboard"><div class="card" id="dashboard-card"></div></div>
+		<div class="jp-stats-widget"><div class="card" id="widget-card"></div></div>
+		<div id="adminmenu"><div class="card" id="adminmenu-card"></div></div>
+	`;
+	const style = document.createElement( 'style' );
+	style.textContent = compiledCss;
+	document.head.appendChild( style );
+	return {
+		dashboardCard: document.getElementById( 'dashboard-card' ),
+		widgetCard: document.getElementById( 'widget-card' ),
+		adminmenuCard: document.getElementById( 'adminmenu-card' ),
+		widgetRoot: document.querySelector( '.jp-stats-widget' ),
+	};
+}
+
+describe( 'Odyssey Stats CSS scoping (webpack-css-scope.js)', () => {
+	it( 'scopes a shared component selector under both .jp-stats-dashboard and .jp-stats-widget, but not outside either', () => {
+		// A distinctive, non-default color, so a passing assertion actually proves the rule
+		// applied — unlike e.g. `border-width`, whose computed value collapses to 0 regardless of
+		// the declared width whenever `border-style` is left at its `none` default, which would
+		// make an unscoped/never-applied rule indistinguishable from a correctly scoped one.
+		const compiled = compile( '.card { color: rgb(1, 2, 3); }', {
+			from: 'odyssey-stats/src/widget/index.scss',
+		} );
+		const { dashboardCard, widgetCard, adminmenuCard } = buildFixture( compiled );
+
+		expect( dashboardCard.matches( ':where(.jp-stats-dashboard, .jp-stats-widget) .card' ) ).toBe(
+			true
+		);
+		expect( getComputedStyle( dashboardCard ).color ).toBe( 'rgb(1, 2, 3)' );
+		expect( getComputedStyle( widgetCard ).color ).toBe( 'rgb(1, 2, 3)' );
+		expect( getComputedStyle( adminmenuCard ).color ).not.toBe( 'rgb(1, 2, 3)' );
+	} );
+
+	it( 'leaves .jp-stats-widget matching the widget mount itself, not a descendant of it', () => {
+		const compiled = compile(
+			'.jp-stats-widget { color: green; }\n.jp-stats-widget.is-ready { color: red; }',
+			{ from: 'odyssey-stats/src/widget/index.scss' }
+		);
+		const { widgetRoot } = buildFixture( compiled );
+
+		// If these rules got nested under the prefix (`:where(...) .jp-stats-widget {...}`),
+		// they'd require an ancestor of `.jp-stats-widget` matching the prefix — which doesn't
+		// exist, since `.jp-stats-widget` IS one of the prefix roots. That's the exact bug this
+		// exclusion prevents: verify it by asserting the styles actually apply to the root itself.
+		expect( getComputedStyle( widgetRoot ).color ).toBe( 'green' );
+
+		widgetRoot.classList.add( 'is-ready' );
+		expect( getComputedStyle( widgetRoot ).color ).toBe( 'red' );
+	} );
+
+	it( 'does not prefix an unrelated selector that merely starts with the widget class name', () => {
+		const compiled = compile( '.jp-stats-widget-extra { color: blue; }' );
+
+		expect( compiled ).toContain( ':where(' );
+		expect( compiled ).not.toMatch( /^\.jp-stats-widget-extra/m );
+	} );
+
+	it( 'leaves app.scss (already hand-scoped to .jp-stats-dashboard) unprefixed', () => {
+		const compiled = compile( '.jp-stats-dashboard .card { border: 0; }', {
+			from: 'odyssey-stats/src/app.scss',
+		} );
+
+		expect( compiled.trim() ).toBe( '.jp-stats-dashboard .card { border: 0; }' );
+	} );
+} );

--- a/apps/odyssey-stats/src/widget/index.scss
+++ b/apps/odyssey-stats/src/widget/index.scss
@@ -10,6 +10,13 @@ $segmentedControlItemBorderRadius: 4px;
 	container-type: inline-size;
 	// Offset the margin and padding of the `.postbox .inside` container.
 	margin: -11px -12px -12px;
+	// `#dashboard-widgets .postbox` (dashboard.css) rounds its own corners with
+	// `border-radius: 8px` but doesn't clip its content, so pulling flush to the
+	// postbox edges above leaves this element's square bottom corners poking out
+	// past the rounded ones. Round and clip to match; the top isn't affected since
+	// it sits below the postbox header, not at the postbox's own rounded edge.
+	border-radius: 0 0 8px 8px;
+	overflow: hidden;
 }
 
 // Counters WP-admin core's own `.card` utility class, which collides with the `Card` component

--- a/apps/odyssey-stats/src/widget/index.scss
+++ b/apps/odyssey-stats/src/widget/index.scss
@@ -12,6 +12,15 @@ $segmentedControlItemBorderRadius: 4px;
 	margin: -11px -12px -12px;
 }
 
+// Counters WP-admin core's own `.card` utility class, which collides with the `Card` component
+// StatsEmptyState (rendered by MiniChart/Modules) uses for its empty-state placeholder. Mirrors
+// the equivalent `.jp-stats-dashboard .card` override in app.scss for the main app.
+.card {
+	border: 0;
+	max-width: initial;
+	min-width: initial;
+}
+
 .stats-widget-content {
 	font-family: $font-sf-pro-text;
 

--- a/apps/odyssey-stats/src/widget/index.scss
+++ b/apps/odyssey-stats/src/widget/index.scss
@@ -15,7 +15,7 @@ $segmentedControlItemBorderRadius: 4px;
 	// postbox edges above leaves this element's square bottom corners poking out
 	// past the rounded ones. Round and clip to match; the top isn't affected since
 	// it sits below the postbox header, not at the postbox's own rounded edge.
-	border-radius: 0 0 8px 8px;
+	border-radius: 0 0 var(--wpds-border-radius-lg, 8px) var(--wpds-border-radius-lg, 8px);
 	overflow: hidden;
 }
 

--- a/apps/odyssey-stats/webpack-css-scope.js
+++ b/apps/odyssey-stats/webpack-css-scope.js
@@ -1,0 +1,51 @@
+/**
+ * The `postcss-prefix-selector` options that scope Odyssey's first-party component styles to
+ * their mount points, so generic classes (`.card`, `.button`, etc.) can't collide with wp-admin's
+ * own chrome. See AGENTS.md > CSS Scoping.
+ *
+ * Pulled out of webpack.config.js so `css-scope.test.js` can run the real options through the
+ * real plugin instead of a hand-copied stand-in that can drift from what actually ships.
+ */
+
+// .jp-stats-dashboard for normal content, .jp-stats-widget for the WP-Admin dashboard widget's
+// own mount point. The rest are portal roots first-party components can render into:
+// .color-scheme/.ReactModalPortal (Popover/Dialog), [data-base-ui-portal]/[data-wp-compat-overlay-slot]
+// (@wordpress/ui Popover/Tooltip/Dialog, e.g. StatsInfotip), .components-modal__screen-overlay
+// (@wordpress/components Modal, e.g. the UTM builder, stats upsell modal, and feedback modal).
+const prefix =
+	':where(.jp-stats-dashboard, .color-scheme, .ReactModalPortal, [data-base-ui-portal], [data-wp-compat-overlay-slot], .components-modal__screen-overlay, .jp-stats-widget)';
+
+const ignoreFiles = [
+	// Already hand-scoped; re-prefixing would double-nest it.
+	'odyssey-stats/src/app.scss',
+	// Calypso's global stylesheet (html/body reset, @wordpress/components CSS) — left unscoped
+	// for now.
+	'client/assets/stylesheets/style.scss',
+	// @visx/tooltip's TooltipInPortal (used by the line chart tooltip) portals to an unmarked
+	// <body> div, always wrapped in a `.visx-tooltip` element. This file already self-scopes
+	// under `.visx-tooltip` (like app.scss does under `[id="wpcom"]`) — re-prefixing would
+	// double-nest it.
+	'client/my-sites/stats/components/line-chart/styles.scss',
+	// Third-party CSS is out of scope here.
+	/node_modules/,
+];
+
+// Selectors that target the real <html>/<body>/document root, or a mount point's own root rule.
+// Prefixing these would require the mount point to be its own ancestor, which is impossible —
+// the rule would just go dead. Leave them unscoped instead.
+const exclude = [
+	/^:root(?![\w-])/, // :root, :root[data-theme=dark] .foo
+	/(^|[\s,])(html|body)(?=$|[\s.[:#,])/, // html.rtl, body.lockscroll
+	/^\.rtl(?![\w-])/, // .rtl button
+	/^:lang\(/, // :lang(he) .rtl
+	/^\[lang/, // [lang*=fr] .wp-brand-font
+	/^\[dir[~|^$*]?=/, // [dir=rtl] .chevron
+	// .jp-stats-widget styling its own mount element (widget/index.scss), including compound
+	// forms like `.jp-stats-widget.is-ready` or `.jp-stats-widget :hover`. It's already one of
+	// the prefix roots above, so nesting it as a descendant of itself would go dead — same
+	// problem :root/html/body have. Lookahead (not `$`) avoids also matching unrelated classes
+	// like `.jp-stats-widget-extra`.
+	/^\.jp-stats-widget(?![\w-])/,
+];
+
+module.exports = { prefix, ignoreFiles, exclude };

--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -137,6 +137,10 @@ module.exports = {
 								/^:lang\(/, // :lang(he) .rtl
 								/^\[lang/, // [lang*=fr] .wp-brand-font
 								/^\[dir[~|^$*]?=/, // [dir=rtl] .chevron
+								// .jp-stats-widget styling its own mount element (widget/index.scss).
+								// It's already one of the prefix roots above, so nesting it as a
+								// descendant of itself would go dead — same problem :root/html/body have.
+								/^\.jp-stats-widget$/,
 							],
 						} ),
 						autoprefixerPlugin(),

--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -112,7 +112,7 @@ module.exports = {
 							// .components-modal__screen-overlay (@wordpress/components Modal, e.g. the
 							// UTM builder, stats upsell modal, and feedback modal).
 							prefix:
-								':where(.jp-stats-dashboard, .color-scheme, .ReactModalPortal, [data-base-ui-portal], [data-wp-compat-overlay-slot], .components-modal__screen-overlay)',
+								':where(.jp-stats-dashboard, .color-scheme, .ReactModalPortal, [data-base-ui-portal], [data-wp-compat-overlay-slot], .components-modal__screen-overlay, .jp-stats-widget)',
 							ignoreFiles: [
 								// Already hand-scoped; re-prefixing would double-nest it.
 								'odyssey-stats/src/app.scss',

--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -18,6 +18,7 @@ const webpack = require( 'webpack' );
 const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 const cacheIdentifier = require( '../../build-tools/babel/babel-loader-cache-identifier' );
 const GenerateChunksMapPlugin = require( '../../build-tools/webpack/generate-chunks-map-plugin' );
+const cssScope = require( './webpack-css-scope' );
 
 const shouldEmitStats = process.env.EMIT_STATS && process.env.EMIT_STATS !== 'false';
 const isDevelopment = process.env.NODE_ENV !== 'production';
@@ -101,48 +102,11 @@ module.exports = {
 					// own `postcss.config.js` that they use for their webpack bundling process.
 					config: false,
 					plugins: [
-						// Scopes this repo's own component styles to .jp-stats-dashboard (the class
-						// on Odyssey's mount point), so generic classes (`.card`, `.button`, etc.)
-						// can't collide with wp-admin's own chrome. See AGENTS.md > CSS Scoping.
-						prefixSelectorPlugin( {
-							// .jp-stats-dashboard for normal content. The rest are portal roots
-							// first-party components can render into: .color-scheme/.ReactModalPortal
-							// (Popover/Dialog), [data-base-ui-portal]/[data-wp-compat-overlay-slot]
-							// (@wordpress/ui Popover/Tooltip/Dialog, e.g. StatsInfotip),
-							// .components-modal__screen-overlay (@wordpress/components Modal, e.g. the
-							// UTM builder, stats upsell modal, and feedback modal).
-							prefix:
-								':where(.jp-stats-dashboard, .color-scheme, .ReactModalPortal, [data-base-ui-portal], [data-wp-compat-overlay-slot], .components-modal__screen-overlay, .jp-stats-widget)',
-							ignoreFiles: [
-								// Already hand-scoped; re-prefixing would double-nest it.
-								'odyssey-stats/src/app.scss',
-								// Calypso's global stylesheet (html/body reset, @wordpress/components
-								// CSS) — left unscoped for now.
-								'client/assets/stylesheets/style.scss',
-								// @visx/tooltip's TooltipInPortal (used by the line chart tooltip)
-								// portals to an unmarked <body> div, always wrapped in a `.visx-tooltip`
-								// element. This file already self-scopes under `.visx-tooltip` (like
-								// app.scss does under `[id="wpcom"]`) — re-prefixing would double-nest it.
-								'client/my-sites/stats/components/line-chart/styles.scss',
-								// Third-party CSS is out of scope here.
-								/node_modules/,
-							],
-							// Selectors that target the real <html>/<body>/document root. Prefixing
-							// these would require #wpcom to be its own ancestor, which is impossible —
-							// the rule would just go dead. Leave them unscoped instead.
-							exclude: [
-								/^:root(?![\w-])/, // :root, :root[data-theme=dark] .foo
-								/(^|[\s,])(html|body)(?=$|[\s.[:#,])/, // html.rtl, body.lockscroll
-								/^\.rtl(?![\w-])/, // .rtl button
-								/^:lang\(/, // :lang(he) .rtl
-								/^\[lang/, // [lang*=fr] .wp-brand-font
-								/^\[dir[~|^$*]?=/, // [dir=rtl] .chevron
-								// .jp-stats-widget styling its own mount element (widget/index.scss).
-								// It's already one of the prefix roots above, so nesting it as a
-								// descendant of itself would go dead — same problem :root/html/body have.
-								/^\.jp-stats-widget$/,
-							],
-						} ),
+						// Scopes this repo's own component styles to .jp-stats-dashboard and
+						// .jp-stats-widget (Odyssey's mount points), so generic classes (`.card`,
+						// `.button`, etc.) can't collide with wp-admin's own chrome. See
+						// AGENTS.md > CSS Scoping and webpack-css-scope.js.
+						prefixSelectorPlugin( cssScope ),
 						autoprefixerPlugin(),
 					],
 				},


### PR DESCRIPTION
Related to #112498

## Proposed Changes

* #112498 added a `postcss-prefix-selector` build step to `apps/odyssey-stats/webpack.config.js` scoping first-party Odyssey Stats component styles to `.jp-stats-dashboard` and a handful of known portal roots.
* That scoping missed the WP-Admin "Jetpack Stats" dashboard widget (`apps/odyssey-stats/src/widget`), a separate lightweight bundle whose React root mounts into `#dashboard_stats` rather than `.jp-stats-dashboard`. This PR fixes three resulting regressions:
  * Adds `.jp-stats-widget` — the class Jetpack's PHP already puts on the widget's mount element (`class-wp-dashboard-odyssey-widget.php`) — to the prefix-selector scope list, so the widget's compiled CSS is scoped at all instead of shipping unscoped.
  * `widget/index.scss`'s own `.jp-stats-widget { ... }` rule (offsetting the postbox's margin/padding, and enabling the container query the widget's responsive layout depends on) was being auto-prefixed into a descendant of itself — an unsatisfiable selector — so it silently never applied. Excludes it from prefixing the same way `:root`/`html`/`body` already are, since it styles the scope root rather than something nested under it.
  * The widget lost `app.scss`'s `.jp-stats-dashboard .card` override, which counters WP-admin core's own `.card` utility class. That override never reaches the widget bundle since `app.scss` isn't imported there. Adds the equivalent override directly to `widget/index.scss`, which `mini-chart.tsx`/`modules.tsx` need for their `StatsEmptyState` placeholder.
* Documents `.jp-stats-widget` as a scope root in `apps/odyssey-stats/AGENTS.md`, and generalizes the "Prefix target list" guidance there to cover new mount points, not just portal roots, since this is exactly the kind of gap that guidance is meant to catch.

## Why are these changes being made?

* The widget lost its styling after #112498 landed, since its markup never sits inside `.jp-stats-dashboard`. A follow-up audit of the rest of the scoping mechanism against the widget bundle turned up two further, more subtle breakages beyond the missing root class.
* p1784699819251729-slack-CDLH4C1UZ

## Testing Instructions

* `yarn workspace @automattic/odyssey-stats build:stats`, then grep the compiled CSS chunk for the widget (the async chunk pulled in by `widget-loader`) to confirm: its selectors carry the `.jp-stats-widget` scope; the `.jp-stats-widget { ... }` root rule itself is left unprefixed; the `.card` override resolves under the shared `:where(...)`. Checked in both LTR and RTL output.
* Load a WP-Admin dashboard page with the Jetpack Stats widget visible and confirm it renders correctly, including the empty-state placeholder (no data) and the container-query-driven responsive layout on a narrow postbox column.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?