### PR TITLE
Returning user modal: Add the experiment assignment

### DIFF
--- a/client/lib/resurrected-users/README.md
+++ b/client/lib/resurrected-users/README.md
@@ -1,15 +1,44 @@
 # Resurrected Free Users – Welcome Back Modal
 
-This module powers the welcome-back modal for eligible resurrected free users (180-day inactivity, no active paid subscriptions).
+This module powers the welcome-back modal for eligible resurrected free users. A user is
+eligible after 180 days of inactivity when they have no active paid subscriptions.
 
 ## Components
 
-- **`useResurrectedFreeUserEligibility`** – Determines eligibility (dormancy threshold, purchase checks) and returns the variation name for analytics. All eligible users see the MANUAL experience.
-- **`ResurrectedWelcomeModalGate`** – Renders the modal when eligible, dedupes per session, and emits impression/CTA analytics.
+- **`useResurrectedFreeUserEligibility`** – Resolves the dormancy and purchase checks, then
+  requests an ExPlat assignment only for eligible users.
+- **`ResurrectedWelcomeModalGate`** – Renders the assigned experience, dedupes display per
+  session, and emits impression and CTA analytics.
+
+## Experiment assignment
+
+The ExPlat experiment is `calypso_resurrected_users_welcome_back_modal_202607`.
+
+| Variation           | Experience                                                                                  |
+| ------------------- | ------------------------------------------------------------------------------------------- |
+| `control`           | Existing manual welcome-back experience                                                     |
+| `treatment_themes`  | Encourages the user to browse themes                                                        |
+| `treatment_content` | Continues the most recently modified draft, or starts a new post when no draft is available |
+| `treatment_design`  | Sends the user to the Site Editor                                                           |
+
+The existing manual experience is also the default when no ExPlat assignment is available. The
+modal waits for an eligible user's assignment before deciding which experience to display.
 
 ## Feature flag
 
-- **`welcome-back-modal-manual`** – When enabled (e.g. `ENABLE_FEATURES=welcome-back-modal-manual yarn start`), forces the modal to show for the current user regardless of eligibility, for local/testing.
+- **`welcome-back-modal-manual`** – When enabled (for example,
+  `ENABLE_FEATURES=welcome-back-modal-manual yarn start`), forces the modal to display regardless
+  of eligibility for local testing. When no assignment is available, it uses the existing manual
+  experience.
+
+## Display behavior
+
+- The modal is dismissed for the remainder of the browser session after the user closes it or
+  selects a CTA.
+- The content variation fetches only the latest modified draft and keeps the modal visible while
+  that request resolves.
+- The classic Calypso `/sites` mount is separate from the Dashboard client served at
+  `my.wordpress.com`; Dashboard does not currently mount this modal.
 
 ## Analytics
 

--- a/client/lib/resurrected-users/constants.ts
+++ b/client/lib/resurrected-users/constants.ts
@@ -3,6 +3,8 @@ export const RESURRECTION_DAY_LIMIT_EXPERIMENT = 180;
 
 export const RESURRECTED_EVENT = 'calypso_user_resurrected';
 export const RESURRECTED_EVENT_6M = 'calypso_user_resurrected_6m';
+export const RESURRECTED_FREE_USERS_EXPERIMENT =
+	'calypso_resurrected_users_welcome_back_modal_202607';
 
 /** Rolled-out welcome-back modal variation (manual onboarding + continue). */
 export const WELCOME_BACK_VARIATION_MANUAL = 'treatment_manual_dual' as const;

--- a/client/lib/resurrected-users/test/use-resurrected-free-user-eligibility.test.tsx
+++ b/client/lib/resurrected-users/test/use-resurrected-free-user-eligibility.test.tsx
@@ -3,11 +3,17 @@
  */
 import config from '@automattic/calypso-config';
 import { waitFor } from '@testing-library/react';
+import { useExperiment } from 'calypso/lib/explat';
 import { fetchUserPurchases } from 'calypso/state/purchases/actions';
 import userSettingsReducer from 'calypso/state/user-settings/reducer';
 import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
-import { WELCOME_BACK_VARIATION_MANUAL } from '../constants';
+import {
+	RESURRECTED_FREE_USERS_EXPERIMENT,
+	WELCOME_BACK_VARIATION_MANUAL,
+	WELCOME_BACK_VARIATIONS,
+} from '../constants';
 import { useResurrectedFreeUserEligibility } from '../use-resurrected-free-user-eligibility';
+import type { ExperimentAssignment } from '@automattic/explat-client';
 
 const selectorsState = {
 	purchases: null as Array< { type: string; status: string } > | null,
@@ -25,6 +31,10 @@ jest.mock( '@automattic/calypso-config', () => {
 		default: mockConfig,
 	};
 } );
+
+jest.mock( 'calypso/lib/explat', () => ( {
+	useExperiment: jest.fn(),
+} ) );
 
 jest.mock( 'calypso/state/purchases/selectors', () => ( {
 	getUserPurchases: () => selectorsState.purchases,
@@ -45,8 +55,16 @@ const mockFetchUserPurchases = fetchUserPurchases as jest.MockedFunction<
 	typeof fetchUserPurchases
 >;
 const mockIsFeatureEnabled = config.isEnabled as jest.MockedFunction< typeof config.isEnabled >;
+const mockUseExperiment = useExperiment as jest.MockedFunction< typeof useExperiment >;
 
 const DAY_IN_SECONDS = 24 * 60 * 60;
+
+const createExperimentAssignment = ( variationName: string ): ExperimentAssignment => ( {
+	experimentName: RESURRECTED_FREE_USERS_EXPERIMENT,
+	variationName,
+	retrievedTimestamp: Date.now(),
+	ttl: 60,
+} );
 
 const reducers = {
 	userSettings: userSettingsReducer,
@@ -84,6 +102,8 @@ describe( 'useResurrectedFreeUserEligibility', () => {
 		mockIsFeatureEnabled.mockReturnValue( false );
 		mockFetchUserPurchases.mockImplementation( () => () => Promise.resolve( [] ) );
 		mockFetchUserPurchases.mockClear();
+		mockUseExperiment.mockReturnValue( [ false, null ] );
+		mockUseExperiment.mockClear();
 	} );
 
 	it( 'requests user purchases when they have not loaded yet', async () => {
@@ -113,6 +133,9 @@ describe( 'useResurrectedFreeUserEligibility', () => {
 		expect( result.current.hasActivePaidSubscription ).toBe( true );
 		expect( result.current.isEligible ).toBe( false );
 		expect( result.current.isForcedVariation ).toBe( false );
+		expect( mockUseExperiment ).toHaveBeenCalledWith( RESURRECTED_FREE_USERS_EXPERIMENT, {
+			isEligible: false,
+		} );
 	} );
 
 	it( 'returns MANUAL variation when resurrected and free of active subscriptions', () => {
@@ -132,6 +155,41 @@ describe( 'useResurrectedFreeUserEligibility', () => {
 		expect( result.current.variationName ).toBe( WELCOME_BACK_VARIATION_MANUAL );
 		expect( result.current.isLoading ).toBe( false );
 		expect( result.current.isForcedVariation ).toBe( false );
+		expect( mockUseExperiment ).toHaveBeenCalledWith( RESURRECTED_FREE_USERS_EXPERIMENT, {
+			isEligible: true,
+		} );
+	} );
+
+	it( 'returns the assigned experiment variation for an eligible user', () => {
+		selectorsState.purchases = [];
+		selectorsState.hasLoaded = true;
+		mockUseExperiment.mockReturnValue( [
+			false,
+			createExperimentAssignment( WELCOME_BACK_VARIATIONS.content ),
+		] );
+
+		const { result } = renderHookWithProvider( () => useResurrectedFreeUserEligibility(), {
+			initialState: createState( { lastSeenOffsetDays: 400 } ),
+			reducers,
+		} );
+
+		expect( result.current.isEligible ).toBe( true );
+		expect( result.current.variationName ).toBe( WELCOME_BACK_VARIATIONS.content );
+		expect( result.current.isLoading ).toBe( false );
+	} );
+
+	it( 'waits for the experiment assignment for an eligible user', () => {
+		selectorsState.purchases = [];
+		selectorsState.hasLoaded = true;
+		mockUseExperiment.mockReturnValue( [ true, null ] );
+
+		const { result } = renderHookWithProvider( () => useResurrectedFreeUserEligibility(), {
+			initialState: createState( { lastSeenOffsetDays: 400 } ),
+			reducers,
+		} );
+
+		expect( result.current.isEligible ).toBe( false );
+		expect( result.current.isLoading ).toBe( true );
 	} );
 
 	it( 'forces eligibility when welcome-back-modal-manual flag is enabled', () => {
@@ -152,5 +210,8 @@ describe( 'useResurrectedFreeUserEligibility', () => {
 		expect( result.current.isLoading ).toBe( false );
 		expect( result.current.variationName ).toBe( WELCOME_BACK_VARIATION_MANUAL );
 		expect( result.current.isForcedVariation ).toBe( true );
+		expect( mockUseExperiment ).toHaveBeenCalledWith( RESURRECTED_FREE_USERS_EXPERIMENT, {
+			isEligible: false,
+		} );
 	} );
 } );

--- a/client/lib/resurrected-users/use-resurrected-free-user-eligibility.ts
+++ b/client/lib/resurrected-users/use-resurrected-free-user-eligibility.ts
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { useEffect, useMemo } from '@wordpress/element';
+import { useExperiment } from 'calypso/lib/explat';
 import { isRenewingBeforeExpiration, isSubscription } from 'calypso/lib/purchases';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
@@ -15,6 +16,7 @@ import {
 	RESURRECTION_DAY_LIMIT_EXPERIMENT,
 	WELCOME_BACK_MODAL_FORCE_FLAG,
 	WELCOME_BACK_VARIATION_MANUAL,
+	RESURRECTED_FREE_USERS_EXPERIMENT,
 } from './constants';
 import { hasExceededDormancyThreshold } from './utils';
 import type { Purchase } from 'calypso/lib/purchases/types';
@@ -79,8 +81,16 @@ export function useResurrectedFreeUserEligibility(): EligibilityResult {
 	);
 
 	const baseEligibility = isResurrectedSixMonths && hasActiveSubscriptions === false;
+	const [ isExperimentLoading, experimentAssignment ] = useExperiment(
+		RESURRECTED_FREE_USERS_EXPERIMENT,
+		{
+			isEligible: baseEligibility,
+		}
+	);
 
+	const variationName = experimentAssignment?.variationName ?? WELCOME_BACK_VARIATION_MANUAL;
 	const isForcedByFlag = config.isEnabled( WELCOME_BACK_MODAL_FORCE_FLAG );
+	const experimentReady = ! isExperimentLoading && !! variationName;
 
 	if ( isForcedByFlag ) {
 		return {
@@ -88,20 +98,22 @@ export function useResurrectedFreeUserEligibility(): EligibilityResult {
 			isResurrectedSixMonths,
 			hasActivePaidSubscription: hasActiveSubscriptions,
 			isEligible: true,
-			variationName: WELCOME_BACK_VARIATION_MANUAL,
+			variationName,
 			isForcedVariation: true,
 		};
 	}
 
-	const isLoading = isUserSettingsFetching || ! purchasesLoaded || isUserPurchasesFetching;
-
-	const variationName = baseEligibility ? WELCOME_BACK_VARIATION_MANUAL : null;
+	const isLoading =
+		isUserSettingsFetching ||
+		! purchasesLoaded ||
+		isUserPurchasesFetching ||
+		( baseEligibility && isExperimentLoading );
 
 	return {
 		isLoading,
 		isResurrectedSixMonths,
 		hasActivePaidSubscription: hasActiveSubscriptions,
-		isEligible: baseEligibility,
+		isEligible: baseEligibility && experimentReady,
 		variationName,
 		isForcedVariation: false,
 	};


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTCOM-17870

## Proposed Changes

Add the returning user modal experiment assignment.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To support a future experiment

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Login with a returning user account ( last activity 6 months ago). 
* Confirm the control modal loads correctly. 
* Assign the user to each of the variants and confirm the modal loads correctly. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
