### PR TITLE
Dashboard MCP: add ChatGPT/Codex as an AI agent connect option

### DIFF
--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -42,7 +42,7 @@ function McpSetupComponent() {
 	const mcpClientOptions: Array< { label: string; value: McpClient } > = [
 		{ label: 'Claude', value: 'claude' },
 		{ label: 'Claude Code', value: 'claude-code' },
-		{ label: 'ChatGPT', value: 'chatgpt' },
+		{ label: 'ChatGPT/Codex', value: 'chatgpt' },
 		{ label: 'Cursor', value: 'cursor' },
 		{ label: 'VS Code', value: 'vscode' },
 		{ label: 'Continue', value: 'continue' },

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -49,20 +49,18 @@ function McpSetupComponent() {
 		{ label: __( 'Other MCP client' ), value: 'default' },
 	];
 
-	const clientDocumentation: Record< McpClient, string > = {
+	const clientDocumentation: Record< Exclude< McpClient, 'chatgpt' >, string > = {
 		claude: 'https://docs.claude.com/en/docs/mcp',
 		'claude-code': 'https://code.claude.com/docs/en/mcp',
-		chatgpt: 'https://chatgpt.com/plugins',
 		vscode: 'https://code.visualstudio.com/docs/copilot/customization/mcp-servers',
 		cursor: 'https://docs.cursor.com/en/context/mcp',
 		continue: 'https://docs.continue.dev/customize/deep-dives/mcp',
 		default: 'https://modelcontextprotocol.io/docs/develop/connect-local-servers',
 	};
 
-	const clientDocumentationLabels: Record< McpClient, string > = {
+	const clientDocumentationLabels: Record< Exclude< McpClient, 'chatgpt' >, string > = {
 		claude: __( 'Claude documentation' ),
 		'claude-code': __( 'Claude Code documentation' ),
-		chatgpt: __( 'ChatGPT documentation' ),
 		vscode: __( 'VS Code documentation' ),
 		cursor: __( 'Cursor documentation' ),
 		continue: __( 'Continue documentation' ),
@@ -203,7 +201,7 @@ function McpSetupComponent() {
 										</li>
 										<li>
 											<Text as="p" variant="muted">
-												{ __( 'Click "Browse connectors" and search for WordPress.com.' ) }
+												{ __( 'Click “Browse connectors” and search for WordPress.com.' ) }
 											</Text>
 										</li>
 										<li>
@@ -308,7 +306,7 @@ function McpSetupComponent() {
 										</li>
 										<li>
 											<Text as="p" variant="muted">
-												{ __( 'Click "Install plugin".' ) }
+												{ __( 'Click “Install plugin”.' ) }
 											</Text>
 										</li>
 									</ol>

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -27,7 +27,14 @@ import './style.scss';
 function McpSetupComponent() {
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 
-	type McpClient = 'claude' | 'claude-code' | 'cursor' | 'vscode' | 'continue' | 'default';
+	type McpClient =
+		| 'claude'
+		| 'claude-code'
+		| 'chatgpt'
+		| 'cursor'
+		| 'vscode'
+		| 'continue'
+		| 'default';
 
 	const [ selectedMcpClient, setSelectedMcpClient ] = useState< McpClient >( 'claude' );
 	const [ copyStatus, setCopyStatus ] = useState( 'idle' );
@@ -35,6 +42,7 @@ function McpSetupComponent() {
 	const mcpClientOptions: Array< { label: string; value: McpClient } > = [
 		{ label: 'Claude', value: 'claude' },
 		{ label: 'Claude Code', value: 'claude-code' },
+		{ label: 'ChatGPT', value: 'chatgpt' },
 		{ label: 'Cursor', value: 'cursor' },
 		{ label: 'VS Code', value: 'vscode' },
 		{ label: 'Continue', value: 'continue' },
@@ -44,6 +52,7 @@ function McpSetupComponent() {
 	const clientDocumentation: Record< McpClient, string > = {
 		claude: 'https://docs.claude.com/en/docs/mcp',
 		'claude-code': 'https://code.claude.com/docs/en/mcp',
+		chatgpt: 'https://chatgpt.com/plugins',
 		vscode: 'https://code.visualstudio.com/docs/copilot/customization/mcp-servers',
 		cursor: 'https://docs.cursor.com/en/context/mcp',
 		continue: 'https://docs.continue.dev/customize/deep-dives/mcp',
@@ -53,6 +62,7 @@ function McpSetupComponent() {
 	const clientDocumentationLabels: Record< McpClient, string > = {
 		claude: __( 'Claude documentation' ),
 		'claude-code': __( 'Claude Code documentation' ),
+		chatgpt: __( 'ChatGPT documentation' ),
 		vscode: __( 'VS Code documentation' ),
 		cursor: __( 'Cursor documentation' ),
 		continue: __( 'Continue documentation' ),
@@ -167,6 +177,7 @@ function McpSetupComponent() {
 
 				{ ( selectedMcpClient === 'claude' ||
 					selectedMcpClient === 'claude-code' ||
+					selectedMcpClient === 'chatgpt' ||
 					selectedMcpClient === 'cursor' ) && (
 					<Card>
 						<CardBody>
@@ -272,6 +283,37 @@ function McpSetupComponent() {
 									</VStack>
 								) }
 
+								{ /* Quick Setup for ChatGPT */ }
+								{ selectedMcpClient === 'chatgpt' && (
+									<ol className="mcp-setup__steps">
+										<li>
+											<Text as="p" variant="muted">
+												{ createInterpolateElement(
+													/* translators: <ChatGptSettings/> is a link to the ChatGPT plugins settings page */
+													__( 'Open <ChatGptSettings/>.' ),
+													{
+														ChatGptSettings: (
+															<ExternalLink href="https://chatgpt.com/plugins">
+																{ __( 'ChatGPT plugins settings' ) }
+															</ExternalLink>
+														),
+													}
+												) }
+											</Text>
+										</li>
+										<li>
+											<Text as="p" variant="muted">
+												{ __( 'Search for WordPress.com.' ) }
+											</Text>
+										</li>
+										<li>
+											<Text as="p" variant="muted">
+												{ __( 'Click "Install plugin".' ) }
+											</Text>
+										</li>
+									</ol>
+								) }
+
 								{ /* Quick Setup for Cursor */ }
 								{ selectedMcpClient === 'cursor' && (
 									<VStack spacing={ 4 }>
@@ -295,37 +337,39 @@ function McpSetupComponent() {
 					</Card>
 				) }
 
-				<Card>
-					<CardBody>
-						<VStack spacing={ 2 }>
-							<HStack justify="space-between" alignment="center">
-								<SectionHeader level={ 3 } title={ __( 'Manual setup' ) } />
-								<Button
-									icon={ copyStatus === 'success' ? check : copy }
-									variant="tertiary"
-									iconSize={ 20 }
-									onClick={ copyToClipboard }
-									aria-label={ __( 'Copy configuration to clipboard' ) }
+				{ selectedMcpClient !== 'chatgpt' && (
+					<Card>
+						<CardBody>
+							<VStack spacing={ 2 }>
+								<HStack justify="space-between" alignment="center">
+									<SectionHeader level={ 3 } title={ __( 'Manual setup' ) } />
+									<Button
+										icon={ copyStatus === 'success' ? check : copy }
+										variant="tertiary"
+										iconSize={ 20 }
+										onClick={ copyToClipboard }
+										aria-label={ __( 'Copy configuration to clipboard' ) }
+									/>
+								</HStack>
+								<Text as="p" variant="muted">
+									{ __( 'Copy this configuration into your client\u2019s MCP settings.' ) }
+								</Text>
+								<TextareaControl
+									className="mcp-setup__config-textarea"
+									__nextHasNoMarginBottom
+									value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
+									onChange={ () => {} }
+									readOnly
 								/>
-							</HStack>
-							<Text as="p" variant="muted">
-								{ __( 'Copy this configuration into your client\u2019s MCP settings.' ) }
-							</Text>
-							<TextareaControl
-								className="mcp-setup__config-textarea"
-								__nextHasNoMarginBottom
-								value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
-								onChange={ () => {} }
-								readOnly
-							/>
-							{ clientDocumentation[ selectedMcpClient ] && (
-								<ExternalLink href={ clientDocumentation[ selectedMcpClient ] }>
-									{ clientDocumentationLabels[ selectedMcpClient ] }
-								</ExternalLink>
-							) }
-						</VStack>
-					</CardBody>
-				</Card>
+								{ clientDocumentation[ selectedMcpClient ] && (
+									<ExternalLink href={ clientDocumentation[ selectedMcpClient ] }>
+										{ clientDocumentationLabels[ selectedMcpClient ] }
+									</ExternalLink>
+								) }
+							</VStack>
+						</CardBody>
+					</Card>
+				) }
 			</>
 		</PageLayout>
 	);

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -61,7 +61,6 @@ function McpSetupComponent( { path } ) {
 	const clientDocumentation = {
 		claude: 'https://docs.claude.com/en/docs/mcp',
 		'claude-code': 'https://code.claude.com/docs/en/mcp',
-		chatgpt: 'https://chatgpt.com/plugins',
 		vscode: 'https://code.visualstudio.com/docs/copilot/customization/mcp-servers',
 		cursor: 'https://docs.cursor.com/en/context/mcp',
 		continue: 'https://docs.continue.dev/customize/deep-dives/mcp',
@@ -71,7 +70,6 @@ function McpSetupComponent( { path } ) {
 	const clientDocumentationLabels = {
 		claude: translate( 'Claude documentation' ),
 		'claude-code': translate( 'Claude Code documentation' ),
-		chatgpt: translate( 'ChatGPT documentation' ),
 		vscode: translate( 'VS Code documentation' ),
 		cursor: translate( 'Cursor documentation' ),
 		continue: translate( 'Continue documentation' ),
@@ -203,7 +201,7 @@ function McpSetupComponent( { path } ) {
 									</li>
 									<li>
 										<Text as="p" size="medium">
-											{ translate( 'Click "Browse connectors" and search for WordPress.com.' ) }
+											{ translate( 'Click “Browse connectors” and search for WordPress.com.' ) }
 										</Text>
 									</li>
 									<li>
@@ -305,7 +303,7 @@ function McpSetupComponent( { path } ) {
 									</li>
 									<li>
 										<Text as="p" size="medium">
-											{ translate( 'Click "Install plugin".' ) }
+											{ translate( 'Click “Install plugin”.' ) }
 										</Text>
 									</li>
 								</ol>

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -51,7 +51,7 @@ function McpSetupComponent( { path } ) {
 	const mcpClientOptions = [
 		{ label: 'Claude', value: 'claude' },
 		{ label: 'Claude Code', value: 'claude-code' },
-		{ label: 'ChatGPT', value: 'chatgpt' },
+		{ label: 'ChatGPT/Codex', value: 'chatgpt' },
 		{ label: 'Cursor', value: 'cursor' },
 		{ label: 'VS Code', value: 'vscode' },
 		{ label: 'Continue', value: 'continue' },

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -51,6 +51,7 @@ function McpSetupComponent( { path } ) {
 	const mcpClientOptions = [
 		{ label: 'Claude', value: 'claude' },
 		{ label: 'Claude Code', value: 'claude-code' },
+		{ label: 'ChatGPT', value: 'chatgpt' },
 		{ label: 'Cursor', value: 'cursor' },
 		{ label: 'VS Code', value: 'vscode' },
 		{ label: 'Continue', value: 'continue' },
@@ -60,6 +61,7 @@ function McpSetupComponent( { path } ) {
 	const clientDocumentation = {
 		claude: 'https://docs.claude.com/en/docs/mcp',
 		'claude-code': 'https://code.claude.com/docs/en/mcp',
+		chatgpt: 'https://chatgpt.com/plugins',
 		vscode: 'https://code.visualstudio.com/docs/copilot/customization/mcp-servers',
 		cursor: 'https://docs.cursor.com/en/context/mcp',
 		continue: 'https://docs.continue.dev/customize/deep-dives/mcp',
@@ -69,6 +71,7 @@ function McpSetupComponent( { path } ) {
 	const clientDocumentationLabels = {
 		claude: translate( 'Claude documentation' ),
 		'claude-code': translate( 'Claude Code documentation' ),
+		chatgpt: translate( 'ChatGPT documentation' ),
 		vscode: translate( 'VS Code documentation' ),
 		cursor: translate( 'Cursor documentation' ),
 		continue: translate( 'Continue documentation' ),
@@ -174,6 +177,7 @@ function McpSetupComponent( { path } ) {
 
 			{ ( selectedMcpClient === 'claude' ||
 				selectedMcpClient === 'claude-code' ||
+				selectedMcpClient === 'chatgpt' ||
 				selectedMcpClient === 'cursor' ) && (
 				<Card>
 					<CardBody>
@@ -277,6 +281,36 @@ function McpSetupComponent( { path } ) {
 								</VStack>
 							) }
 
+							{ selectedMcpClient === 'chatgpt' && (
+								<ol className="mcp-setup__steps">
+									<li>
+										<Text as="p" size="medium">
+											{ createInterpolateElement(
+												/* translators: <ChatGptSettings/> is a link to the ChatGPT plugins settings page */
+												translate( 'Open <ChatGptSettings/>.' ),
+												{
+													ChatGptSettings: (
+														<ExternalLink href="https://chatgpt.com/plugins">
+															{ translate( 'ChatGPT plugins settings' ) }
+														</ExternalLink>
+													),
+												}
+											) }
+										</Text>
+									</li>
+									<li>
+										<Text as="p" size="medium">
+											{ translate( 'Search for WordPress.com.' ) }
+										</Text>
+									</li>
+									<li>
+										<Text as="p" size="medium">
+											{ translate( 'Click "Install plugin".' ) }
+										</Text>
+									</li>
+								</ol>
+							) }
+
 							{ selectedMcpClient === 'cursor' && (
 								<VStack spacing={ 4 }>
 									<Text as="p" size="medium">
@@ -299,36 +333,38 @@ function McpSetupComponent( { path } ) {
 				</Card>
 			) }
 
-			<Card>
-				<CardBody>
-					<VStack spacing={ 2 }>
-						<HStack justify="space-between" alignment="center">
-							<SectionHeader level={ 3 } title={ translate( 'Manual setup' ) } />
-							<Button
-								icon={ copyStatus === 'success' ? check : copy }
-								variant="tertiary"
-								iconSize={ 20 }
-								onClick={ copyToClipboard }
-								aria-label={ translate( 'Copy configuration to clipboard' ) }
+			{ selectedMcpClient !== 'chatgpt' && (
+				<Card>
+					<CardBody>
+						<VStack spacing={ 2 }>
+							<HStack justify="space-between" alignment="center">
+								<SectionHeader level={ 3 } title={ translate( 'Manual setup' ) } />
+								<Button
+									icon={ copyStatus === 'success' ? check : copy }
+									variant="tertiary"
+									iconSize={ 20 }
+									onClick={ copyToClipboard }
+									aria-label={ translate( 'Copy configuration to clipboard' ) }
+								/>
+							</HStack>
+							<Text as="p" size="medium">
+								{ translate( 'Copy this configuration into your client\u2019s MCP settings.' ) }
+							</Text>
+							<TextareaControl
+								__nextHasNoMarginBottom
+								value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
+								onChange={ () => {} }
+								readOnly
 							/>
-						</HStack>
-						<Text as="p" size="medium">
-							{ translate( 'Copy this configuration into your client\u2019s MCP settings.' ) }
-						</Text>
-						<TextareaControl
-							__nextHasNoMarginBottom
-							value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
-							onChange={ () => {} }
-							readOnly
-						/>
-						{ clientDocumentation[ selectedMcpClient ] && (
-							<ExternalLink href={ clientDocumentation[ selectedMcpClient ] }>
-								{ clientDocumentationLabels[ selectedMcpClient ] }
-							</ExternalLink>
-						) }
-					</VStack>
-				</CardBody>
-			</Card>
+							{ clientDocumentation[ selectedMcpClient ] && (
+								<ExternalLink href={ clientDocumentation[ selectedMcpClient ] }>
+									{ clientDocumentationLabels[ selectedMcpClient ] }
+								</ExternalLink>
+							) }
+						</VStack>
+					</CardBody>
+				</Card>
+			) }
 		</>
 	);
 }


### PR DESCRIPTION
## Proposed Changes

* Add **ChatGPT** as a selectable AI agent on the Connect AI agent screen. Applied to **both** surfaces that render this screen:
  * The new Multi-site Dashboard (`client/dashboard/me/mcp/setup/index.tsx`) — Preferences → AI and MCP → Connect AI agent.
  * The classic Calypso screen (`client/me/mcp/setup.jsx`) at `/me/mcp/setup`.
* ChatGPT gets a **Quick setup** flow only, with three steps:
  1. Open **ChatGPT plugins settings** (external link to `https://chatgpt.com/plugins`).
  2. Search for WordPress.com.
  3. Click "Install plugin".
* The **Manual setup** card is hidden when ChatGPT is selected, since ChatGPT does not use a manual MCP JSON config.

<img width="1107" height="488" alt="Screenshot 2026-07-22 at 3 38 19 PM" src="https://github.com/user-attachments/assets/fd5a20b6-7159-4a9e-a884-85a9552586b3" />

## Why are these changes being made?

<!-- -->

* ChatGPT connects to WordPress.com via its plugin store rather than a copy-paste MCP config, so it needs its own guided setup path distinct from the config-based clients (Claude, Cursor, VS Code, etc.).

## Testing Instructions

* Navigate to the Connect AI agent screen on either surface:
  * Classic: [/me/mcp/setup](http://calypso.localhost:3000/me/mcp/setup)
  * Dashboard: Preferences → AI and MCP → Connect AI agent ([/me/preferences/mcp/setup](http://my.localhost:3000/me/preferences/mcp/setup), behind the `mcp-settings` feature flag)
* In the **AI agent** dropdown, select **ChatGPT**.
* Confirm the **Quick setup** card shows the three ChatGPT steps and that "ChatGPT plugins settings" links to `https://chatgpt.com/plugins`.
* Confirm the **Manual setup** card is **not** shown for ChatGPT, but still appears for the other agents.
* Confirm that the **Manual setup** card is shown for the other connector options

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
