### PR TITLE
A4A: Open product FAQ links without reloading

### DIFF
--- a/client/components/jetpack/jetpack-product-info/index.tsx
+++ b/client/components/jetpack/jetpack-product-info/index.tsx
@@ -3,6 +3,7 @@ import { TranslateResult, useTranslate } from 'i18n-calypso';
 import {
 	Children,
 	cloneElement,
+	Fragment,
 	FunctionComponent,
 	isValidElement,
 	ReactNode,
@@ -88,7 +89,11 @@ const JetpackProductInfo: FunctionComponent< JetpackProductInfoProps > = ( {
 		faqButton.scrollIntoView( { behavior: 'smooth', block: 'nearest' } );
 	}, [] );
 
-	const renderedDisclaimer = Children.map( disclaimer, ( child ) => {
+	const renderDisclaimerNode = ( child: ReactNode ): ReactNode => {
+		if ( isValidElement< { children?: ReactNode } >( child ) && child.type === Fragment ) {
+			return cloneElement( child, {}, Children.map( child.props.children, renderDisclaimerNode ) );
+		}
+
 		if (
 			! isValidElement< AnchorHTMLAttributes< HTMLAnchorElement > >( child ) ||
 			child.type !== 'a' ||
@@ -106,7 +111,9 @@ const JetpackProductInfo: FunctionComponent< JetpackProductInfoProps > = ( {
 				}
 			},
 		} );
-	} );
+	};
+
+	const renderedDisclaimer = Children.map( disclaimer, renderDisclaimerNode );
 
 	return (
 		<div

--- a/client/components/jetpack/jetpack-product-info/index.tsx
+++ b/client/components/jetpack/jetpack-product-info/index.tsx
@@ -1,6 +1,14 @@
 import clsx from 'clsx';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
-import { FunctionComponent, ReactNode } from 'react';
+import {
+	Children,
+	cloneElement,
+	FunctionComponent,
+	isValidElement,
+	ReactNode,
+	useCallback,
+	useRef,
+} from 'react';
 import { useIncludedProductDescriptionMap } from 'calypso/components/jetpack/jetpack-product-info/hooks/use-included-product-description-map';
 import isWooCommerceProduct from 'calypso/jetpack-cloud/sections/partner-portal/lib/is-woocommerce-product';
 import { PricingBreakdown } from 'calypso/my-sites/plans/jetpack-plans/product-store/pricing-breakdown';
@@ -15,6 +23,7 @@ import JetpackProductInfoRecommendationTags from './recommendation-tags';
 import JetpackProductInfoRegularList from './regular-list';
 import JetpackProductInfoSection from './section';
 import type { VendorInfo } from '../jetpack-lightbox/types';
+import type { AnchorHTMLAttributes, MouseEvent } from 'react';
 
 import './style.scss';
 
@@ -61,9 +70,49 @@ const JetpackProductInfo: FunctionComponent< JetpackProductInfoProps > = ( {
 	} );
 
 	const descriptionMap = useIncludedProductDescriptionMap( product.productSlug );
+	const productInfoRef = useRef< HTMLDivElement >( null );
+
+	const onDisclaimerClick = useCallback( ( event: MouseEvent< HTMLAnchorElement > ) => {
+		const faqButtonId = event.currentTarget.hash.slice( 1 );
+		const faqButton = Array.from(
+			productInfoRef.current?.querySelectorAll< HTMLButtonElement >( '.foldable-faq__question' ) ??
+				[]
+		).find( ( button ) => button.id === faqButtonId );
+
+		if ( ! faqButton ) {
+			return;
+		}
+
+		event.preventDefault();
+		faqButton.click();
+		faqButton.scrollIntoView( { behavior: 'smooth', block: 'nearest' } );
+	}, [] );
+
+	const renderedDisclaimer = Children.map( disclaimer, ( child ) => {
+		if (
+			! isValidElement< AnchorHTMLAttributes< HTMLAnchorElement > >( child ) ||
+			child.type !== 'a' ||
+			! child.props.href?.startsWith( '#' )
+		) {
+			return child;
+		}
+
+		return cloneElement( child, {
+			onClick: ( event: MouseEvent< HTMLAnchorElement > ) => {
+				child.props.onClick?.( event );
+
+				if ( ! event.defaultPrevented ) {
+					onDisclaimerClick( event );
+				}
+			},
+		} );
+	} );
 
 	return (
-		<div className={ clsx( 'jetpack-product-info', { 'is-woocommerce-product': isWooCommerce } ) }>
+		<div
+			className={ clsx( 'jetpack-product-info', { 'is-woocommerce-product': isWooCommerce } ) }
+			ref={ productInfoRef }
+		>
 			<div className="jetpack-product-info__header">
 				<div className={ iconStyles }>
 					<img alt="" src={ icon } />
@@ -151,7 +200,7 @@ const JetpackProductInfo: FunctionComponent< JetpackProductInfoProps > = ( {
 
 			{ disclaimer && (
 				<JetpackProductInfoSection alwaysExpanded>
-					<span className="jetpack-product-info__disclaimer-text">{ disclaimer }</span>
+					<span className="jetpack-product-info__disclaimer-text">{ renderedDisclaimer }</span>
 				</JetpackProductInfoSection>
 			) }
 		</div>

--- a/client/components/jetpack/jetpack-product-info/test/index.test.tsx
+++ b/client/components/jetpack/jetpack-product-info/test/index.test.tsx
@@ -71,36 +71,4 @@ describe( 'JetpackProductInfo', () => {
 		} );
 		expect( window.location.hash ).toBe( '' );
 	} );
-
-	it( 'leaves external disclaimer links unchanged', async () => {
-		const user = userEvent.setup();
-		const onExternalLinkClick = jest.fn();
-		const productWithExternalDisclaimer = {
-			...product,
-			disclaimer: (
-				<a
-					href="https://jetpack.com/support/"
-					onClick={ ( event ) => {
-						event.preventDefault();
-						onExternalLinkClick();
-					} }
-				>
-					External details
-				</a>
-			),
-		};
-
-		render(
-			<JetpackProductInfo title="Security 10GB" product={ productWithExternalDisclaimer } />
-		);
-
-		const faqButton = screen.getByRole( 'button', {
-			name: 'How do backup storage limits work?',
-		} );
-		await user.click( screen.getByRole( 'link', { name: 'External details' } ) );
-
-		expect( onExternalLinkClick ).toHaveBeenCalledTimes( 1 );
-		expect( faqButton ).toHaveAttribute( 'aria-expanded', 'false' );
-		expect( faqButton.scrollIntoView ).not.toHaveBeenCalled();
-	} );
 } );

--- a/client/components/jetpack/jetpack-product-info/test/index.test.tsx
+++ b/client/components/jetpack/jetpack-product-info/test/index.test.tsx
@@ -3,6 +3,7 @@
  */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { translate } from 'i18n-calypso';
 import JetpackProductInfo from '../index';
 import type { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
 
@@ -44,7 +45,11 @@ const product = {
 			answer: 'Backup storage limit details.',
 		},
 	],
-	disclaimer: <a href="#backup-storage-limits-lightbox-faq">Learn more</a>,
+	disclaimer: translate( 'Subject to your usage and storage limit. {{link}}Learn more{{/link}}.', {
+		components: {
+			link: <a href="#backup-storage-limits-lightbox-faq" />,
+		},
+	} ),
 } as SelectorProduct;
 
 describe( 'JetpackProductInfo', () => {

--- a/client/components/jetpack/jetpack-product-info/test/index.test.tsx
+++ b/client/components/jetpack/jetpack-product-info/test/index.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import JetpackProductInfo from '../index';
+import type { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
+
+jest.mock( 'i18n-calypso', () => ( {
+	...jest.requireActual( 'i18n-calypso' ),
+	useTranslate: () => ( text: string ) => text,
+} ) );
+
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => jest.fn(),
+} ) );
+
+jest.mock( 'react-redux', () => ( {
+	useDispatch: () => jest.fn(),
+} ) );
+
+jest.mock( '../hooks/use-included-product-description-map', () => ( {
+	useIncludedProductDescriptionMap: () => ( {} ),
+} ) );
+
+jest.mock( 'calypso/jetpack-cloud/sections/partner-portal/lib/is-woocommerce-product', () => ( {
+	__esModule: true,
+	default: () => false,
+} ) );
+
+jest.mock( 'calypso/my-sites/plans/jetpack-plans/product-store/utils/get-product-icon', () => ( {
+	__esModule: true,
+	default: () => '/test-icon.svg',
+} ) );
+
+const product = {
+	productSlug: 'jetpack-security-t1-monthly',
+	iconSlug: 'jetpack-security',
+	lightboxDescription: 'Security for your site.',
+	faqs: [
+		{
+			id: 'backup-storage-limits-lightbox',
+			question: 'How do backup storage limits work?',
+			answer: 'Backup storage limit details.',
+		},
+	],
+	disclaimer: <a href="#backup-storage-limits-lightbox-faq">Learn more</a>,
+} as SelectorProduct;
+
+describe( 'JetpackProductInfo', () => {
+	beforeEach( () => {
+		Element.prototype.scrollIntoView = jest.fn();
+	} );
+
+	it( 'opens an internal disclaimer FAQ without navigating', async () => {
+		const user = userEvent.setup();
+		render( <JetpackProductInfo title="Security 10GB" product={ product } /> );
+
+		const faqButton = screen.getByRole( 'button', {
+			name: 'How do backup storage limits work?',
+		} );
+
+		expect( faqButton ).toHaveAttribute( 'aria-expanded', 'false' );
+
+		await user.click( screen.getByRole( 'link', { name: 'Learn more' } ) );
+
+		expect( faqButton ).toHaveAttribute( 'aria-expanded', 'true' );
+		expect( faqButton.scrollIntoView ).toHaveBeenCalledWith( {
+			behavior: 'smooth',
+			block: 'nearest',
+		} );
+		expect( window.location.hash ).toBe( '' );
+	} );
+
+	it( 'leaves external disclaimer links unchanged', async () => {
+		const user = userEvent.setup();
+		const onExternalLinkClick = jest.fn();
+		const productWithExternalDisclaimer = {
+			...product,
+			disclaimer: (
+				<a
+					href="https://jetpack.com/support/"
+					onClick={ ( event ) => {
+						event.preventDefault();
+						onExternalLinkClick();
+					} }
+				>
+					External details
+				</a>
+			),
+		};
+
+		render(
+			<JetpackProductInfo title="Security 10GB" product={ productWithExternalDisclaimer } />
+		);
+
+		const faqButton = screen.getByRole( 'button', {
+			name: 'How do backup storage limits work?',
+		} );
+		await user.click( screen.getByRole( 'link', { name: 'External details' } ) );
+
+		expect( onExternalLinkClick ).toHaveBeenCalledTimes( 1 );
+		expect( faqButton ).toHaveAttribute( 'aria-expanded', 'false' );
+		expect( faqButton.scrollIntoView ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
Resolves A4A-3038

## Proposed Changes

* Prevent the Jetpack product lightbox’s internal FAQ link from navigating and reloading A4A.
* Expand and scroll to the matching FAQ within the existing lightbox.
* Preserve external disclaimer link behavior.

<img width="582" height="333" alt="image" src="https://github.com/user-attachments/assets/25515bda-1016-47f4-9f2c-0364ab9ead7c" />

## Why are these changes being made?

* The **Learn more** disclaimer below some Jetpack product FAQs reloads the full dashboard instead of only opening the related FAQ.

## Testing Instructions

* Open A4A Marketplace Products.
* Open the Security 10GB product details.
* Click **Learn more** below the FAQs.
* Verify **How do backup storage limits work?** expands.
* Verify the product details remain open and the dashboard URL does not change or reload.

_— ClemenAgent (Powered by Codex)_

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
