### PR TITLE
A4A: Consolidate site detail tabs

### DIFF
--- a/client/a8c-for-agencies/components/a4a-request-wp-admin-access/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-request-wp-admin-access/index.tsx
@@ -27,7 +27,7 @@ export function A4ARequestWPAdminAccess() {
 				</div>
 				<div className="a4a-request-wp-admin-access__description">
 					{ translate(
-						'Ask the Agency owner to provide you WP-Admin access to this site in order to manage its plugins and features.'
+						'Ask the Agency owner to provide you WP-Admin access to this site in order to access and manage this site’s features.'
 					) }
 				</div>
 				<Button

--- a/client/a8c-for-agencies/data/guided-tours/tours/use-sites-walkthrough-tour.tsx
+++ b/client/a8c-for-agencies/data/guided-tours/tours/use-sites-walkthrough-tour.tsx
@@ -82,7 +82,7 @@ export default function useSitesWalkthroughTour() {
 			popoverPosition: 'bottom right',
 			title: translate( '🔍 Detailed views' ),
 			description: translate(
-				'Click the arrow for detailed insights on stats, site speed performance, recent backups, and monitoring activity trends. Handy, right?'
+				'Click the site name for detailed insights on backups, security scans, Uptime Monitor, recent activity, and other available site details.'
 			),
 		},
 		{

--- a/client/a8c-for-agencies/data/guided-tours/tours/use-sites-walkthrough-tour.tsx
+++ b/client/a8c-for-agencies/data/guided-tours/tours/use-sites-walkthrough-tour.tsx
@@ -95,7 +95,7 @@ export default function useSitesWalkthroughTour() {
 					<br />
 					<br />
 					{ translate(
-						'Use the tabs to navigate between site speed, backups, Uptime Monitor, activity trends, and plugins.'
+						'Use the tabs to navigate between backups, security scans, Uptime Monitor, recent activity, and other available site details.'
 					) }
 				</>
 			),

--- a/client/a8c-for-agencies/sections/sites/constants.ts
+++ b/client/a8c-for-agencies/sections/sites/constants.ts
@@ -1,8 +1,8 @@
-import { JETPACK_BOOST_ID } from 'calypso/a8c-for-agencies/sections/sites/features/features';
+import { JETPACK_BACKUP_ID } from 'calypso/a8c-for-agencies/sections/sites/features/features';
 import { AgencyDashboardFilterMap } from './types';
 
 export const A4A_SITES_DASHBOARD_DEFAULT_CATEGORY = 'overview';
-export const A4A_SITES_DASHBOARD_DEFAULT_FEATURE = JETPACK_BOOST_ID;
+export const A4A_SITES_DASHBOARD_DEFAULT_FEATURE = JETPACK_BACKUP_ID;
 
 export const DEFAULT_SORT_FIELD = 'url';
 export const DEFAULT_SORT_DIRECTION = 'asc';

--- a/client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx
@@ -35,6 +35,7 @@ import SiteErrorPreview from './site-error-preview';
 import '../jetpack/style.scss';
 import '../../site-preview-pane/a4a-style.scss';
 
+// Keep removed IDs so old direct links fall back to the default tab.
 const REMOVED_FEATURE_IDS = [
 	JETPACK_BOOST_ID,
 	JETPACK_PLUGINS_ID,

--- a/client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx
@@ -26,18 +26,21 @@ import { ItemData } from 'calypso/layout/hosting-dashboard/item-view/types';
 import { A4A_SITES_DASHBOARD_DEFAULT_FEATURE } from '../../constants';
 import { useFetchTestConnections } from '../../hooks/use-fetch-test-connection';
 import useFormattedSites from '../../hooks/use-formatted-sites';
-import HostingOverviewPreview from '../hosting/overview';
 import { JetpackActivityPreview } from '../jetpack/activity';
 import { JetpackBackupPreview } from '../jetpack/backup';
-import { JetpackBoostPreview } from '../jetpack/jetpack-boost';
 import { JetpackMonitorPreview } from '../jetpack/jetpack-monitor';
-import { JetpackPluginsPreview } from '../jetpack/jetpack-plugins';
-import { JetpackStatsPreview } from '../jetpack/jetpack-stats';
 import { JetpackScanPreview } from '../jetpack/scan';
 import SiteErrorPreview from './site-error-preview';
 
 import '../jetpack/style.scss';
 import '../../site-preview-pane/a4a-style.scss';
+
+const REMOVED_FEATURE_IDS = [
+	JETPACK_BOOST_ID,
+	JETPACK_PLUGINS_ID,
+	JETPACK_STATS_ID,
+	HOSTING_OVERVIEW_ID,
+];
 
 export function OverviewPreviewPane( {
 	site,
@@ -69,13 +72,19 @@ export function OverviewPreviewPane( {
 	const showNoAccess = noWPAdminAccess;
 
 	useEffect( () => {
-		if ( selectedSiteFeature === undefined ) {
+		if (
+			selectedSiteFeature === undefined ||
+			REMOVED_FEATURE_IDS.includes( selectedSiteFeature )
+		) {
 			setSelectedSiteFeature( A4A_SITES_DASHBOARD_DEFAULT_FEATURE );
 		}
+	}, [ selectedSiteFeature, setSelectedSiteFeature ] );
+
+	useEffect( () => {
 		return () => {
 			setSelectedSiteFeature( undefined );
 		};
-	}, [] );
+	}, [ setSelectedSiteFeature ] );
 
 	const errorFeatures = useMemo(
 		() => [
@@ -103,21 +112,9 @@ export function OverviewPreviewPane( {
 		]
 	);
 
-	// Jetpack features: Boost, Backup, Monitor, Stats
+	// Site management features
 	const features = useMemo(
 		() => [
-			createFeaturePreview(
-				JETPACK_BOOST_ID,
-				'Boost',
-				true,
-				selectedSiteFeature,
-				setSelectedSiteFeature,
-				showNoAccess ? (
-					<A4ARequestWPAdminAccess />
-				) : (
-					<JetpackBoostPreview site={ site } trackEvent={ trackEvent } hasError={ hasError } />
-				)
-			),
 			createFeaturePreview(
 				JETPACK_BACKUP_ID,
 				'Backup',
@@ -161,53 +158,12 @@ export function OverviewPreviewPane( {
 				  ]
 				: [] ),
 			createFeaturePreview(
-				JETPACK_PLUGINS_ID,
-				translate( 'Plugins' ),
-				true,
-				selectedSiteFeature,
-				setSelectedSiteFeature,
-				showNoAccess ? (
-					<A4ARequestWPAdminAccess />
-				) : (
-					<JetpackPluginsPreview
-						link={ site.url_with_scheme + '/wp-admin/plugins.php' }
-						linkLabel={ translate( 'Manage Plugins in wp-admin' ) }
-						featureText={ translate( 'Manage all plugins installed on %(siteUrl)s', {
-							args: { siteUrl: site.url },
-						} ) }
-						captionText={ translate(
-							"Note: We are currently working to make this section function from the Automattic for Agencies dashboard. In the meantime, you'll be taken to WP-Admin."
-						) }
-					/>
-				)
-			),
-			createFeaturePreview(
-				JETPACK_STATS_ID,
-				'Stats',
-				true,
-				selectedSiteFeature,
-				setSelectedSiteFeature,
-				showNoAccess ? (
-					<A4ARequestWPAdminAccess />
-				) : (
-					<JetpackStatsPreview site={ site } trackEvent={ trackEvent } />
-				)
-			),
-			createFeaturePreview(
 				JETPACK_ACTIVITY_ID,
 				translate( 'Activity' ),
 				true,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
 				showNoAccess ? <A4ARequestWPAdminAccess /> : <JetpackActivityPreview site={ site } />
-			),
-			createFeaturePreview(
-				HOSTING_OVERVIEW_ID,
-				translate( 'Hosting' ),
-				true,
-				selectedSiteFeature,
-				setSelectedSiteFeature,
-				<HostingOverviewPreview site={ site } />
 			),
 			...( isEnabled( 'a4a/site-details-pane' )
 				? [

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -26,6 +26,21 @@ import useGetSiteErrors from '../../sites-dataviews/hooks/use-get-site-errors';
 import { AllowedTypes, Site, SiteData } from '../../types';
 import type { Action, Field } from '@wordpress/dataviews';
 
+const SitePreviewTourTarget = ( { children }: { children: ReactNode } ) => {
+	const [ context, setContext ] = useState< HTMLElement | null >();
+
+	return (
+		<>
+			<div ref={ setContext }>{ children }</div>
+			<GuidedTourStep
+				id="sites-walkthrough-site-preview"
+				tourId="sitesWalkthrough"
+				context={ context }
+			/>
+		</>
+	);
+};
+
 export const JetpackSitesDataViews = ( {
 	data,
 	isLoading,
@@ -121,6 +136,12 @@ export const JetpackSitesDataViews = ( {
 	const [ scanRef, setScanRef ] = useState< HTMLElement | null >();
 	const [ pluginsRef, setPluginsRef ] = useState< HTMLElement | null >();
 
+	const sitePreviewTourTargetId = sites.find(
+		( item ) =>
+			! item.site.value.is_simple &&
+			( isNotProduction || ! item.site.value.sticker?.includes( 'migration-in-progress' ) )
+	)?.site.value.blog_id;
+
 	const fields = useMemo< Field< SiteData >[] >(
 		() => [
 			{
@@ -172,7 +193,9 @@ export const JetpackSitesDataViews = ( {
 					}
 					const site = item.site.value;
 
-					return (
+					const isSitePreviewTourTarget = site.blog_id === sitePreviewTourTargetId;
+
+					const siteField = (
 						<div
 							className={ clsx( {
 								'is-site-selected': site.blog_id === dataViewsState.selectedItem?.blog_id,
@@ -186,6 +209,12 @@ export const JetpackSitesDataViews = ( {
 								errors={ getSiteErrors( item ) }
 							/>
 						</div>
+					);
+
+					return isSitePreviewTourTarget ? (
+						<SitePreviewTourTarget>{ siteField }</SitePreviewTourTarget>
+					) : (
+						siteField
 					);
 				},
 				enableHiding: false,
@@ -382,6 +411,7 @@ export const JetpackSitesDataViews = ( {
 			monitorRef,
 			scanRef,
 			pluginsRef,
+			sitePreviewTourTargetId,
 			isLoading,
 			dataViewsState.selectedItem?.blog_id,
 			openSitePreviewPane,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -1,6 +1,6 @@
-@import "@automattic/typography/styles/variables";
+@import '@automattic/typography/styles/variables';
 
-@import "calypso/assets/stylesheets/shared/mixins/breakpoints";
+@import 'calypso/assets/stylesheets/shared/mixins/breakpoints';
 
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
@@ -310,6 +310,12 @@
 	}
 
 	&.sites-dashboard__layout {
+		.backup__page > .admin-ui-navigable-region,
+		.scan > .admin-ui-navigable-region,
+		.scan-new > .admin-ui-navigable-region {
+			background-color: transparent;
+		}
+
 		.activity-card-list .activity-card .activity-card__time {
 			background: none;
 		}
@@ -319,18 +325,18 @@
 		.button.toolbar__button {
 			background: transparent;
 			border-color: transparent;
-			color: var(--color-neutral-70);
+			color: var( --color-neutral-70 );
 
 			&:hover {
 				background: transparent;
 				border-color: transparent;
-				color: var(--color-neutral-70);
+				color: var( --color-neutral-70 );
 			}
 
 			&:focus {
 				background: transparent;
 				border-color: transparent;
-				color: var(--color-neutral-70);
+				color: var( --color-neutral-70 );
 				box-shadow: none;
 			}
 		}

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/test/set-sites-dashboard-url.jsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/test/set-sites-dashboard-url.jsx
@@ -2,7 +2,10 @@
  * @jest-environment jsdom
  */
 import { mockedSites } from '../../../../data/sites.ts';
-import { A4A_SITES_DASHBOARD_DEFAULT_CATEGORY } from '../../constants';
+import {
+	A4A_SITES_DASHBOARD_DEFAULT_CATEGORY,
+	A4A_SITES_DASHBOARD_DEFAULT_FEATURE,
+} from '../../constants';
 import { updateSitesDashboardUrl } from '../update-sites-dashboard-url';
 
 describe( 'updateSitesDashboardUrl returns correct URL', () => {
@@ -11,7 +14,7 @@ describe( 'updateSitesDashboardUrl returns correct URL', () => {
 
 	const defaultSitesParams = {
 		setCategory: setCategoryMock,
-		selectedSiteFeature: 'jetpack-boost',
+		selectedSiteFeature: A4A_SITES_DASHBOARD_DEFAULT_FEATURE,
 		currentPage: 1,
 		sort: { field: 'url', direction: 'asc' },
 	};
@@ -65,7 +68,7 @@ describe( 'updateSitesDashboardUrl returns correct URL', () => {
 		} );
 
 		expect( setCategoryMock ).toHaveBeenCalledTimes( 1 );
-		expect( updatedUrl ).toBe( '/sites/overview/elegantsuperbly.wpcomstaging.com' );
+		expect( updatedUrl ).toBe( '/sites/overview/elegantsuperbly.wpcomstaging.com/jetpack-backup' );
 	} );
 
 	test( 'returns correct URL when a site is selected with filters and search', () => {
@@ -76,7 +79,7 @@ describe( 'updateSitesDashboardUrl returns correct URL', () => {
 			...defaultSitesParams,
 		} );
 
-		expect( updatedUrl ).toBe( '/sites/overview/elegantsuperbly.wpcomstaging.com' );
+		expect( updatedUrl ).toBe( '/sites/overview/elegantsuperbly.wpcomstaging.com/jetpack-backup' );
 	} );
 
 	test( 'returns correct URL with filters and search applied', () => {
@@ -120,6 +123,6 @@ describe( 'updateSitesDashboardUrl returns correct URL', () => {
 			...defaultSitesParams,
 		} );
 
-		expect( updatedUrl ).toBe( '/sites/overview/elegantsuperbly.wpcomstaging.com' );
+		expect( updatedUrl ).toBe( '/sites/overview/elegantsuperbly.wpcomstaging.com/jetpack-backup' );
 	} );
 } );

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
@@ -1,6 +1,5 @@
 import {
 	A4A_SITES_DASHBOARD_DEFAULT_CATEGORY,
-	A4A_SITES_DASHBOARD_DEFAULT_FEATURE,
 	DEFAULT_SORT_DIRECTION,
 	DEFAULT_SORT_FIELD,
 } from '../constants';
@@ -105,13 +104,7 @@ export const updateSitesDashboardUrl = ( {
 		showOnlyDevelopmentSites,
 	} );
 
-	if (
-		category &&
-		selectedSite &&
-		selectedSiteFeature &&
-		selectedSiteFeature !== A4A_SITES_DASHBOARD_DEFAULT_FEATURE
-	) {
-		// If the selected feature is the default one, we can leave the url a little cleaner, that's why we are comparing to the default feature in the condition above.
+	if ( category && selectedSite && selectedSiteFeature ) {
 		url = `${ baseUrl }/${ category }/${ selectedSite.url }/${ selectedSiteFeature }`;
 		shouldAddQueryArgs = false;
 	} else if ( category && selectedSite ) {

--- a/client/components/guided-tour/step/index.tsx
+++ b/client/components/guided-tour/step/index.tsx
@@ -71,7 +71,10 @@ export function GuidedTourStep( {
 
 	const completeStep = useCallback(
 		( event: MouseEvent | React.MouseEvent< HTMLElement > ) => {
-			event.stopPropagation();
+			// Let native target clicks reach their React handlers so the target action still runs.
+			if ( 'nativeEvent' in event ) {
+				event.stopPropagation();
+			}
 			nextStep( currentStep );
 			if ( isLastStep ) {
 				endTour();


### PR DESCRIPTION
Resolves A4A-3052

## Proposed Changes

<img width="901" height="583" alt="image" src="https://github.com/user-attachments/assets/7cc1ac3f-2428-4d21-a26b-61bba1a4054b" />

* Remove the low-value Boost, Plugins, Stats, and Hosting tabs from A4A site details.
* Make Backup the default site-detail tab.
* Keep old removed-tab links aligned with the new default.
* Update the related guided-tour copy:

<img width="917" height="449" alt="image" src="https://github.com/user-attachments/assets/0bf2858e-4bc8-4fb1-a3ee-ad608130c63a" />


<img width="1188" height="753" alt="image" src="https://github.com/user-attachments/assets/09946e5f-479a-4e81-ba83-705e659d543e" />

## Why are these changes being made?

* The removed tabs are redundant, empty, or provide little value in the A4A site-detail flow.
* Consolidating the tabs keeps the view focused on useful site-management information.

## Testing Instructions

* Open the A4A Sites page and select a connected site.
* Verify Backup opens by default.
* Verify Backup, Scan, Monitor, and Activity are available.
* On an Atomic site, verify Performance remains available.
* Verify Boost, Plugins, Stats, and Hosting are absent.
* Open an old URL for one of the removed tabs and verify it resolves to Backup.

_— ClemenAgent (Powered by Codex)_

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g. browsers), interfaces (e.g. keyboard navigation), and assistive technologies (e.g. screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have you tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
