### PR TITLE
wpcom-proxy-request: handle cookie-auth-ok message

### DIFF
--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -424,6 +424,11 @@ function onmessage( e ) {
 		return;
 	}
 
+	// Another string non-JSON message, client can ignore it.
+	if ( data === 'cookie-auth-ok' ) {
+		return;
+	}
+
 	if ( postStrings && 'string' === typeof data ) {
 		data = JSON.parse( data );
 	}


### PR DESCRIPTION
The WP.com proxy iframe does a cookie check on load and sends a string messages `cookie-auth-ok` or `cookie-auth-missing` to the iframe listeners. But the client doesn't handle `cookie-auth-ok`. Either a `JSON.parse` is attempted (if legacy `postStrings` option is on) and fails with error, or the `cookie-auth-ok` string is treated as array, the last element is extracted (`"k"`) and treated as request ID. It will fail very nicely with a debug message:
```
bailing, no matching request with callback: k
```
but it still fails.

This PR fixes this.