### PR TITLE
Remove PHP 8.2 from the available PHP version selectors

### DIFF
--- a/client/dashboard/sites/settings-php/test/index.test.tsx
+++ b/client/dashboard/sites/settings-php/test/index.test.tsx
@@ -2,7 +2,9 @@
  * @jest-environment jsdom
  */
 
-import { screen, waitFor } from '@testing-library/react';
+import { sitePHPVersionQuery } from '@automattic/api-queries';
+import { QueryClient } from '@tanstack/react-query';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { render } from '../../../test-utils';
@@ -30,11 +32,11 @@ function mockSite( mockedSite: Site ) {
 		.reply( 200, mockedSite );
 }
 
-function mockPHPVersion( version: string ) {
+function mockPHPVersion( version: string, siteId: number = site.ID ) {
 	nock( 'https://public-api.wordpress.com' )
-		.get( `/wpcom/v2/sites/${ site.ID }/hosting/php-version` )
+		.get( `/wpcom/v2/sites/${ siteId }/hosting/php-version` )
 		.query( true )
-		.reply( 200, version );
+		.reply( 200, JSON.stringify( version ), { 'Content-Type': 'application/json' } );
 }
 
 function mockPHPVersionSaved( expectedVersion: string ) {
@@ -53,7 +55,11 @@ describe( '<PHPVersionSettings>', () => {
 		mockSite( site );
 		mockPHPVersion( '8.2' );
 
-		render( <PHPVersionSettings siteSlug={ site.slug } /> );
+		// The route loader awaits the PHP version before the page renders.
+		const queryClient = new QueryClient();
+		await queryClient.ensureQueryData( sitePHPVersionQuery( site.ID ) );
+
+		render( <PHPVersionSettings siteSlug={ site.slug } />, { queryClient } );
 		await screen.findByRole( 'heading', { name: 'PHP' } );
 
 		const versionSelect = await screen.findByRole( 'combobox', { name: 'PHP version' } );
@@ -68,6 +74,36 @@ describe( '<PHPVersionSettings>', () => {
 		await waitFor( () => {
 			expect( scope.isDone() ).toBe( true );
 		} );
+	} );
+
+	test( 'does not offer PHP 8.2 to sites that are not using it', async () => {
+		mockSite( site );
+		mockPHPVersion( '8.3' );
+
+		const queryClient = new QueryClient();
+		await queryClient.ensureQueryData( sitePHPVersionQuery( site.ID ) );
+
+		render( <PHPVersionSettings siteSlug={ site.slug } />, { queryClient } );
+
+		const versionSelect = await screen.findByRole( 'combobox', { name: 'PHP version' } );
+		expect( versionSelect ).toHaveDisplayValue( '8.3 (Recommended)' );
+		expect(
+			within( versionSelect ).queryByRole( 'option', { name: '8.2' } )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'offers PHP 8.2 to allowlisted sites', async () => {
+		const allowlistedSite = { ...site, ID: 255633016 } as Site;
+		mockSite( allowlistedSite );
+		mockPHPVersion( '8.3', allowlistedSite.ID );
+
+		const queryClient = new QueryClient();
+		await queryClient.ensureQueryData( sitePHPVersionQuery( allowlistedSite.ID ) );
+
+		render( <PHPVersionSettings siteSlug={ allowlistedSite.slug } />, { queryClient } );
+
+		const versionSelect = await screen.findByRole( 'combobox', { name: 'PHP version' } );
+		expect( within( versionSelect ).getByRole( 'option', { name: '8.2' } ) ).toBeVisible();
 	} );
 
 	test( 'renders upsell when the site does not have the plan feature', async () => {

--- a/client/data/php-versions/index.jsx
+++ b/client/data/php-versions/index.jsx
@@ -7,14 +7,15 @@ export const getPHPVersions = ( siteId ) => {
 
 	// PHP 8.3 is the default recommended version, 8.4 is the new recommended version for some sites.
 	const recommendedValue = isPhp84Default ? '8.4' : '8.3';
-	// translators: PHP Version for a version switcher
+	// translators: %s: PHP version number, e.g. "8.3", for a version switcher
 	const recommendedLabel = sprintf( __( '%s (Recommended)' ), recommendedValue );
+	const PHP82AllowedSites = [ 255633016 ];
 
 	const phpVersions = [
 		{
 			label: '8.2',
 			value: '8.2',
-			disabled: false, // EOL 31 December 2026
+			disabled: ! PHP82AllowedSites.includes( siteId ?? 0 ), // EOL 31 December 2026
 		},
 		{
 			label: isPhp84Default ? '8.3' : recommendedLabel,


### PR DESCRIPTION
Part of DOTCOM-17393

## Proposed Changes

* Disable PHP 8.2 as a selectable version in `getPHPVersions()`, the single source for the PHP version dropdowns, using a per-site allowlist (`PHP82AllowedSites`) — the same approach used when PHP 8.1 was retired (#104362). Effects across the consumers:
  * **Multi-site Dashboard** (`/sites/:site/settings/php`) and **classic Calypso server settings**: PHP 8.2 no longer appears in the dropdown, unless the site is currently running it — in that case it remains visible as the current version, but once the site moves off there is no way back.
  * **A4A site-creation modal**: PHP 8.2 is no longer offered for new sites.
  * The allowlisted site (255633016) can still select PHP 8.2.
* Fix the MSD PHP settings test, which was passing by accident:
  * The `nock` mock for the PHP version endpoint replied without a `Content-Type` header, so the client parsed the response as `{}` — the test never actually exercised a loaded current version. It only passed because React's controlled `<select>` falls back to the first non-disabled option, which happened to be 8.2.
  * The test now prefetches `sitePHPVersionQuery` before rendering, matching what the route loader guarantees in the real app, and the mock returns proper JSON.
* Add tests covering the new behavior (8.2 hidden for regular sites, offered to allowlisted sites).
* Fix a pre-existing `@wordpress/i18n-translator-comments` lint error in `client/data/php-versions/index.jsx` (comment change only; the translatable string is unchanged).

## Why are these changes being made?

* PHP 8.2 is being decommissioned (EOL 31 December 2026). After the migration effort completes, no site should be able to intentionally move back to PHP 8.2. One site needs a temporary exception while its remediation is ongoing.
* This covers the Calypso surfaces; MC surfaces (BRC, PHP migration debugger) are handled separately as part of the same issue.

## Testing Instructions

* Run the unit tests: `yarn test-client client/dashboard/sites/settings-php`
* On the live branch (https://calypso.live?branch=dotcom-17393-remove-php-82-from-the-available-php-version-selectors), open **Hosting → Server Settings** for an Atomic site that is **not** on PHP 8.2 and verify 8.2 is not in the PHP version dropdown, while 8.3 and 8.4 remain available.
* For a site currently **on** PHP 8.2, verify the dropdown still shows 8.2 as the current version.
* For the Multi-site Dashboard, run `yarn start-dashboard` and open `http://my.localhost:3000/sites/<site-slug>/settings/php` — same expectations as above.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
