### PR TITLE
Help Center: route Help button to admin bar when wpadminbar is visible

### DIFF
--- a/apps/help-center/help-center-gutenberg.jsx
+++ b/apps/help-center/help-center-gutenberg.jsx
@@ -31,13 +31,15 @@ function HelpCenterContent() {
 
 	const canvasMode = useCanvasMode();
 
-	// When a top admin bar is present in the editor — Gutenberg's "admin bar in editor" (omnibar)
-	// experiment, or any context that renders a visible #wpadminbar — the Help button moves out of
-	// the toolbar and into that admin bar.
-	const isAdminBarInEditor =
-		!! window.__experimentalAdminBarInEditor ||
-		document.body.classList.contains( 'has-admin-bar-in-editor' ) ||
-		( document.getElementById( 'wpadminbar' )?.offsetHeight ?? 0 ) > 0;
+	// Whether the Help button belongs in the admin bar rather than the editor toolbar. Snapshot it
+	// once at mount: the underlying signals change as the user toggles editor modes (fullscreen,
+	// distraction-free), and we don't want the button hopping between the toolbar and the admin bar.
+	const [ isAdminBarInEditor ] = useState(
+		() =>
+			!! window.__experimentalAdminBarInEditor ||
+			document.body.classList.contains( 'has-admin-bar-in-editor' ) ||
+			( document.getElementById( 'wpadminbar' )?.offsetHeight ?? 0 ) > 0
+	);
 
 	const trackIconInteraction = useCallback( () => {
 		recordTracksEvent( 'wpcom_help_center_icon_interaction', {

--- a/apps/help-center/help-center-gutenberg.jsx
+++ b/apps/help-center/help-center-gutenberg.jsx
@@ -35,7 +35,8 @@ function HelpCenterContent() {
 	// When it's active, the legacy Help button moves out of the toolbar and into that admin bar.
 	const isAdminBarInEditor =
 		!! window.__experimentalAdminBarInEditor ||
-		document.body.classList.contains( 'has-admin-bar-in-editor' );
+		document.body.classList.contains( 'has-admin-bar-in-editor' ) ||
+		( document.getElementById( 'wpadminbar' )?.offsetHeight ?? 0 ) > 0;
 
 	const trackIconInteraction = useCallback( () => {
 		recordTracksEvent( 'wpcom_help_center_icon_interaction', {

--- a/apps/help-center/help-center-gutenberg.jsx
+++ b/apps/help-center/help-center-gutenberg.jsx
@@ -31,8 +31,9 @@ function HelpCenterContent() {
 
 	const canvasMode = useCanvasMode();
 
-	// Gutenberg's "admin bar in editor" (omnibar) experiment puts a top admin bar in the editor.
-	// When it's active, the legacy Help button moves out of the toolbar and into that admin bar.
+	// When a top admin bar is present in the editor — Gutenberg's "admin bar in editor" (omnibar)
+	// experiment, or any context that renders a visible #wpadminbar — the Help button moves out of
+	// the toolbar and into that admin bar.
 	const isAdminBarInEditor =
 		!! window.__experimentalAdminBarInEditor ||
 		document.body.classList.contains( 'has-admin-bar-in-editor' ) ||

--- a/packages/agents-manager/src/utils/__tests__/editor-entry-points.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/editor-entry-points.test.ts
@@ -52,6 +52,29 @@ describe( 'isAdminBarInEditor', () => {
 		setOmnibarActive( false );
 		expect( isAdminBarInEditor() ).toBe( false );
 	} );
+
+	it( 'returns true when a visible #wpadminbar is present', () => {
+		const adminBar = document.createElement( 'div' );
+		adminBar.id = 'wpadminbar';
+		// jsdom reports offsetHeight as 0, so stub a visible height.
+		Object.defineProperty( adminBar, 'offsetHeight', { value: 32, configurable: true } );
+		document.body.appendChild( adminBar );
+
+		expect( isAdminBarInEditor() ).toBe( true );
+
+		adminBar.remove();
+	} );
+
+	it( 'returns false when #wpadminbar is present but hidden', () => {
+		const adminBar = document.createElement( 'div' );
+		adminBar.id = 'wpadminbar';
+		Object.defineProperty( adminBar, 'offsetHeight', { value: 0, configurable: true } );
+		document.body.appendChild( adminBar );
+
+		expect( isAdminBarInEditor() ).toBe( false );
+
+		adminBar.remove();
+	} );
 } );
 
 describe( 'isEditorAiEntryEnabled', () => {

--- a/packages/agents-manager/src/utils/__tests__/editor-entry-points.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/editor-entry-points.test.ts
@@ -1,14 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import {
-	isAdminBarInEditor,
-	isEditorAiEntryEnabled,
-	isEditorHelpMenuEnabled,
-} from '../editor-entry-points';
-import { getAgentsManagerInlineData } from '../get-agents-manager-inline-data';
-import { isEditorPage } from '../is-editor-page';
-
 jest.mock( '../get-agents-manager-inline-data', () => ( {
 	getAgentsManagerInlineData: jest.fn(),
 } ) );
@@ -16,8 +8,6 @@ jest.mock( '../is-editor-page', () => ( {
 	isEditorPage: jest.fn(),
 } ) );
 
-const mockInlineData = getAgentsManagerInlineData as jest.Mock;
-const mockIsEditorPage = isEditorPage as jest.Mock;
 const ADMIN_BAR_IN_EDITOR_CLASS = 'has-admin-bar-in-editor';
 // Saved so each suite can restore it — `setDesktop` overwrites `window.matchMedia`.
 const originalMatchMedia = window.matchMedia;
@@ -27,6 +17,24 @@ type TestWindow = Window & { __experimentalAdminBarInEditor?: boolean };
 function setOmnibarActive( active: boolean ) {
 	( window as TestWindow ).__experimentalAdminBarInEditor = active;
 }
+
+// `isAdminBarInEditor` snapshots its result on first read, so reset the module before each test to
+// re-run those tests against a fresh snapshot.
+let isAdminBarInEditor: () => boolean;
+let isEditorAiEntryEnabled: () => boolean;
+let isEditorHelpMenuEnabled: () => boolean;
+let mockInlineData: jest.Mock;
+let mockIsEditorPage: jest.Mock;
+
+beforeEach( async () => {
+	jest.resetModules();
+	( { isAdminBarInEditor, isEditorAiEntryEnabled, isEditorHelpMenuEnabled } = await import(
+		'../editor-entry-points'
+	) );
+	mockInlineData = ( await import( '../get-agents-manager-inline-data' ) )
+		.getAgentsManagerInlineData as unknown as jest.Mock;
+	mockIsEditorPage = ( await import( '../is-editor-page' ) ).isEditorPage as unknown as jest.Mock;
+} );
 
 describe( 'isAdminBarInEditor', () => {
 	afterEach( () => {

--- a/packages/agents-manager/src/utils/editor-entry-points.ts
+++ b/packages/agents-manager/src/utils/editor-entry-points.ts
@@ -8,15 +8,17 @@ import { isEditorPage } from './is-editor-page';
 const EDITOR_ENTRY_MEDIA_QUERY = '(min-width: 480px)';
 
 /**
- * Whether Gutenberg's "admin bar in editor" (omnibar) experiment is active — it renders a top
- * admin bar in the fullscreen editor. Both signals below are set server-side by Gutenberg core.
+ * Whether a top admin bar is present in the editor — Gutenberg's "admin bar in editor" (omnibar)
+ * experiment, or any context that renders a visible `#wpadminbar`. When it is, the editor toolbar
+ * entry points move into the admin bar instead.
  */
 export function isAdminBarInEditor(): boolean {
 	const hasExperimentFlag = !! ( window as Window & { __experimentalAdminBarInEditor?: boolean } )
 		.__experimentalAdminBarInEditor;
 	const hasBodyClass = document.body.classList.contains( 'has-admin-bar-in-editor' );
+	const hasVisibleAdminBar = ( document.getElementById( 'wpadminbar' )?.offsetHeight ?? 0 ) > 0;
 
-	return hasExperimentFlag || hasBodyClass;
+	return hasExperimentFlag || hasBodyClass || hasVisibleAdminBar;
 }
 
 /**

--- a/packages/agents-manager/src/utils/editor-entry-points.ts
+++ b/packages/agents-manager/src/utils/editor-entry-points.ts
@@ -14,10 +14,9 @@ let adminBarInEditorSnapshot: boolean | undefined;
  * experiment, or any context that renders a visible `#wpadminbar`. When it is, the editor toolbar
  * entry points move into the admin bar instead.
  *
- * Snapshotted on first read and kept for the page's lifetime, mirroring the Help Center button
- * (`apps/help-center/help-center-gutenberg.jsx`): the signals change as the user toggles editor
- * modes (fullscreen, distraction-free), and the entry points must not hop between the toolbar and
- * the admin bar.
+ * Snapshotted on first read and kept for the page's lifetime: the signals change as the user
+ * toggles editor modes (fullscreen, distraction-free), and the entry points must not hop between
+ * the toolbar and the admin bar.
  */
 export function isAdminBarInEditor(): boolean {
 	if ( adminBarInEditorSnapshot === undefined ) {

--- a/packages/agents-manager/src/utils/editor-entry-points.ts
+++ b/packages/agents-manager/src/utils/editor-entry-points.ts
@@ -7,18 +7,29 @@ import { isEditorPage } from './is-editor-page';
  */
 const EDITOR_ENTRY_MEDIA_QUERY = '(min-width: 480px)';
 
+let adminBarInEditorSnapshot: boolean | undefined;
+
 /**
  * Whether a top admin bar is present in the editor — Gutenberg's "admin bar in editor" (omnibar)
  * experiment, or any context that renders a visible `#wpadminbar`. When it is, the editor toolbar
  * entry points move into the admin bar instead.
+ *
+ * Snapshotted on first read and kept for the page's lifetime, mirroring the Help Center button
+ * (`apps/help-center/help-center-gutenberg.jsx`): the signals change as the user toggles editor
+ * modes (fullscreen, distraction-free), and the entry points must not hop between the toolbar and
+ * the admin bar.
  */
 export function isAdminBarInEditor(): boolean {
-	const hasExperimentFlag = !! ( window as Window & { __experimentalAdminBarInEditor?: boolean } )
-		.__experimentalAdminBarInEditor;
-	const hasBodyClass = document.body.classList.contains( 'has-admin-bar-in-editor' );
-	const hasVisibleAdminBar = ( document.getElementById( 'wpadminbar' )?.offsetHeight ?? 0 ) > 0;
+	if ( adminBarInEditorSnapshot === undefined ) {
+		const hasExperimentFlag = !! ( window as Window & { __experimentalAdminBarInEditor?: boolean } )
+			.__experimentalAdminBarInEditor;
+		const hasBodyClass = document.body.classList.contains( 'has-admin-bar-in-editor' );
+		const hasVisibleAdminBar = ( document.getElementById( 'wpadminbar' )?.offsetHeight ?? 0 ) > 0;
 
-	return hasExperimentFlag || hasBodyClass || hasVisibleAdminBar;
+		adminBarInEditorSnapshot = hasExperimentFlag || hasBodyClass || hasVisibleAdminBar;
+	}
+
+	return adminBarInEditorSnapshot;
 }
 
 /**


### PR DESCRIPTION
Fixes DOTCOM-17519

## Proposed Changes

Route the editor "Help"/AI entry buttons into the admin bar whenever a `#wpadminbar` is actually visible, in addition to the existing omnibar experiment checks (`window.__experimentalAdminBarInEditor` / the `has-admin-bar-in-editor` body class). The placement is decided **once, when the entry point first mounts**, and kept for the lifetime of the page.

* `apps/help-center/help-center-gutenberg.jsx` — broaden `isAdminBarInEditor` to also treat a visible `#wpadminbar` as a reason to route the Help button into the admin bar, and snapshot the decision at mount with a lazy `useState` initializer.
* `packages/agents-manager/src/utils/editor-entry-points.ts` — mirror the same check in the shared `isAdminBarInEditor()` that gates the editor toolbar AI/Help entry points, memoizing it at module scope so both surfaces make the same one-shot placement decision. The freeze only stabilizes the mode decision; the reactive element-presence checks in `hasAiChatEntryButton` (Site Editor navigation) still re-evaluate. Unit tests reset the module per case via `jest.resetModules()` + dynamic `import()`.

The visibility test uses `offsetHeight > 0`, which treats a missing or `display:none` admin bar as "not visible" (height `0`), so the default toolbar placement is unchanged when there is no visible admin bar at mount. When the bar is visible, the existing downstream logic wires up and reveals the admin-bar button and hides the toolbar `Fill`.

Why snapshot at mount: the underlying signals change as the user toggles editor modes (fullscreen, distraction-free), so recomputing on every render would make the button hop between the toolbar and the admin bar. Freezing the decision keeps the button in one place for the session.

## Why are these changes being made?

The placement decision previously relied only on the experimental omnibar flag/class. In contexts where the classic admin bar is genuinely rendered but that flag isn't set, the entry buttons stayed in the editor toolbar instead of the admin bar. Keying off the real visibility of `#wpadminbar` puts them back in the admin bar where they belong.

## Testing Instructions

1. Sandbox `widgets.wp.com` (the sites themselves do not need sandboxing).
2. Run `cd apps/help-center && yarn dev --sync` (and `cd apps/agents-manager && yarn dev --sync` if testing the AI entry point).
3. Visit a site with `gutenberg-edge` sticker
4. Go to Site Editor or Post Editor where the classic admin bar (`#wpadminbar`) is visible.
5. Confirm the Help/AI entry buttons appear in the admin bar (not the editor toolbar) and open/close correctly.
6. Load the editor in fullscreen mode (no visible admin bar) and confirm the buttons appear in the editor toolbar. Note that placement is decided at load: toggling fullscreen/distraction-free afterward does not move the buttons.
7. `yarn jest -c test/packages/jest.config.js --testPathPattern=editor-entry-points` passes.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
