### PR TITLE
Marketplace: tidy up the product install page

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -23,7 +23,6 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useInterval } from 'calypso/lib/interval';
 import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
-import useMarketplaceAdditionalSteps from 'calypso/my-sites/marketplace/pages/marketplace-product-install/use-marketplace-additional-steps';
 import theme from 'calypso/my-sites/marketplace/theme';
 import { waitFor } from 'calypso/my-sites/marketplace/util';
 import { useSelector, useDispatch } from 'calypso/state';
@@ -68,13 +67,17 @@ import {
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
 import './style.scss';
-import { MarketplacePluginInstallProps } from './types';
+import useMarketplaceAdditionalSteps from './use-marketplace-additional-steps';
 import type { IAppState } from 'calypso/state/types';
+import type { TranslateResult } from 'i18n-calypso';
 
 const MarketplaceProductInstall = ( {
 	pluginSlug = '',
 	themeSlug = '',
-}: MarketplacePluginInstallProps ) => {
+}: {
+	pluginSlug?: string;
+	themeSlug?: string;
+} ) => {
 	const isPluginUploadFlow = ! pluginSlug && ! themeSlug;
 	const [ currentStep, setCurrentStep ] = useState( 0 );
 	// Ref instead of state so the install effect can be guarded synchronously —
@@ -163,10 +166,6 @@ const MarketplaceProductInstall = ( {
 	const hasAtomicFeature = useSelector( ( state ) =>
 		siteHasFeature( state, selectedSite?.ID ?? null, WPCOM_FEATURES_ATOMIC )
 	);
-	const supportsAtomicUpgrade = useRef< boolean >( undefined );
-	useEffect( () => {
-		supportsAtomicUpgrade.current = hasAtomicFeature;
-	}, [ hasAtomicFeature ] );
 
 	// retrieve plugin data if not available
 	useEffect( () => {
@@ -175,17 +174,13 @@ const MarketplaceProductInstall = ( {
 		}
 	}, [ isWporgPluginFetched, pluginSlug, dispatch ] );
 
-	// Check if the user plan is enough for installation or it is a self-hosted jetpack site
-	// if not, check again in 2s and show an error message
+	// The plan's feature list can arrive late, so give it 2s before concluding that the site
+	// can't install plugins. Any change to the conditions restarts the timer.
 	useEffect( () => {
 		if ( hasAtomicFeature || isJetpackSelfHosted || nonInstallablePlanError ) {
 			return;
 		}
-		const id = setTimeout( () => {
-			if ( ! supportsAtomicUpgrade.current && ! isJetpackSelfHosted ) {
-				setNonInstallablePlanError( true );
-			}
-		}, 2000 );
+		const id = setTimeout( () => setNonInstallablePlanError( true ), 2000 );
 		return () => clearTimeout( id );
 	}, [ hasAtomicFeature, isJetpackSelfHosted, nonInstallablePlanError ] );
 
@@ -488,37 +483,33 @@ const MarketplaceProductInstall = ( {
 				</>
 			);
 		}
-		if ( pluginExists ) {
+		const uploadPageURL = `/plugins/upload/${ selectedSiteSlug }`;
+		const wpAdminUploadURL = `https://${ selectedSiteSlug }/wp-admin/plugin-install.php?tab=upload`;
+
+		// Rejected uploads all offer the same way out: back to the upload page, or retry in WP Admin.
+		const rejectedUploadLine: TranslateResult | false =
+			( pluginExists &&
+				translate(
+					'This plugin already exists on your site. If you want to upgrade or downgrade the plugin, please continue by uploading the plugin again from WP Admin.'
+				) ) ||
+			( pluginMalicious &&
+				translate(
+					'This plugin is identified as malicious. If you still insist to install the plugin, please continue by uploading the plugin again from WP Admin.'
+				) ) ||
+			( pluginTooBig &&
+				translate(
+					'This plugin is too big to be installed via this page. If you still want to install the plugin, please continue by uploading the plugin again from WP Admin.'
+				) );
+
+		if ( rejectedUploadLine ) {
 			return (
 				<EmptyContent
 					title={ null }
-					line={ translate(
-						'This plugin already exists on your site. If you want to upgrade or downgrade the plugin, please continue by uploading the plugin again from WP Admin.'
-					) }
+					line={ rejectedUploadLine }
 					secondaryAction={ translate( 'Back' ) }
-					secondaryActionURL={ `/plugins/upload/${ selectedSiteSlug }` }
+					secondaryActionURL={ uploadPageURL }
 					action={ translate( 'Re-upload plugin' ) }
-					actionURL={ `https://${ selectedSiteSlug }/wp-admin/plugin-install.php?tab=upload` }
-				/>
-			);
-		}
-		if ( pluginMalicious || pluginTooBig ) {
-			return (
-				<EmptyContent
-					title={ null }
-					line={
-						pluginMalicious
-							? translate(
-									'This plugin is identified as malicious. If you still insist to install the plugin, please continue by uploading the plugin again from WP Admin.'
-							  )
-							: translate(
-									'This plugin is too big to be installed via this page. If you still want to install the plugin, please continue by uploading the plugin again from WP Admin.'
-							  )
-					}
-					secondaryAction={ translate( 'Back' ) }
-					secondaryActionURL={ `/plugins/upload/${ selectedSiteSlug }` }
-					action={ translate( 'Re-upload plugin' ) }
-					actionURL={ `https://${ selectedSiteSlug }/wp-admin/plugin-install.php?tab=upload` }
+					actionURL={ wpAdminUploadURL }
 				/>
 			);
 		}
@@ -536,12 +527,10 @@ const MarketplaceProductInstall = ( {
 					) }
 					secondaryAction={ translate( 'Back' ) }
 					secondaryActionURL={
-						isPluginUploadFlow
-							? `/plugins/upload/${ selectedSiteSlug }`
-							: `/plugins/${ pluginSlug }/${ selectedSiteSlug }`
+						isPluginUploadFlow ? uploadPageURL : `/plugins/${ pluginSlug }/${ selectedSiteSlug }`
 					}
 					action={ translate( 'Upload from WP Admin' ) }
-					actionURL={ `https://${ selectedSiteSlug }/wp-admin/plugin-install.php?tab=upload` }
+					actionURL={ wpAdminUploadURL }
 				/>
 			);
 		}

--- a/client/my-sites/marketplace/pages/marketplace-product-install/types.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/types.ts
@@ -1,4 +1,0 @@
-export type MarketplacePluginInstallProps = {
-	pluginSlug?: string;
-	themeSlug?: string;
-};


### PR DESCRIPTION
## Proposed Changes

Four small, self-contained cleanups to the marketplace product install page, with no intended behavior change:

* Collapse the three near-identical error screens for rejected plugin uploads into one. They differed only in the explanation string; the generic install-failure screen stays separate because its actions differ.
* Remove a ref that mirrored a selector value into a timeout. Both halves of the guard it fed were always true by the time the timeout could fire, so the check was dead.
* Inline a four-line file that declared a single props type (whose name no longer matched the component).
* Import a sibling module relatively instead of by full path.

## Why are these changes being made?

This page is 580 lines covering three distinct flows — plugin upload by zip, plugin install, and theme install — and it has attracted a steady stream of bug fixes. This is the low-risk slice of a longer cleanup list: the changes that can be verified by reading, with the render path and one timer as their only blast radius. The riskier items (consolidating the overlapping atomic-transfer checks, the uncancelable timers, and splitting the component per flow) are deliberately left for separate PRs.

Worth noting for review: the flags for "plugin already exists" and "plugin too big" are both derived from the upload error object, so whenever either is set the generic catch-all condition is also true. The branch ordering is therefore load-bearing — deriving the button label from a shared flag instead of per branch would silently change it. The ordering and per-branch labels are preserved as-is.

## Testing Instructions

Verified by reading, plus `yarn typecheck-client` (no new errors) and `yarn eslint` (clean). The page has no test coverage — `--findRelatedTests` returns nothing — and I have not exercised it in a browser, so the checklist items below reflect that.

To confirm manually:

1. Visit the plugin install page for a site on a plan without plugin support, and confirm the upgrade prompt still appears after a short delay rather than immediately or never.
2. Trigger a rejected upload (an already-installed plugin, or an archive over the size limit) via the plugin upload page, and confirm the error screen shows the right explanation with the "Back" and "Re-upload plugin" actions.
3. Trigger a generic install failure and confirm that screen still offers "Upload from WP Admin", and that its "Back" link points at the upload page in the zip flow and at the plugin page otherwise.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
