### PR TITLE
Marketplace: extract the theme direct-install prompt

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -6,22 +6,19 @@ import {
 	WPCOM_FEATURES_MANAGE_PLUGINS,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { Button, WordPressLogo } from '@automattic/components';
+import { WordPressLogo } from '@automattic/components';
 import { css, Global, ThemeProvider } from '@emotion/react';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useMemo, useRef } from 'react';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
-import QueryProductsList from 'calypso/components/data/query-products-list';
 import { useQueryTheme } from 'calypso/components/data/query-theme';
 import EmptyContent from 'calypso/components/empty-content';
 import { isAtomicTransferredSite } from 'calypso/dashboard/utils/site-atomic-transfers';
-import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useInterval } from 'calypso/lib/interval';
-import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
 import theme from 'calypso/my-sites/marketplace/theme';
 import { waitFor } from 'calypso/my-sites/marketplace/util';
@@ -43,10 +40,6 @@ import {
 } from 'calypso/state/plugins/installed/selectors-ts';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getPlugin, isFetched } from 'calypso/state/plugins/wporg/selectors';
-import {
-	isMarketplaceProduct as isMarketplaceProductSelector,
-	getProductsList,
-} from 'calypso/state/products-list/selectors';
 import { getCurrentQueryArguments } from 'calypso/state/selectors/get-current-query-arguments';
 import getPluginUploadError from 'calypso/state/selectors/get-plugin-upload-error';
 import getPluginUploadProgress from 'calypso/state/selectors/get-plugin-upload-progress';
@@ -67,8 +60,8 @@ import {
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
 import './style.scss';
+import ThemeDirectInstall from './theme-direct-install';
 import useMarketplaceAdditionalSteps from './use-marketplace-additional-steps';
-import type { IAppState } from 'calypso/state/types';
 import type { TranslateResult } from 'i18n-calypso';
 
 const MarketplaceProductInstall = ( {
@@ -125,37 +118,21 @@ const MarketplaceProductInstall = ( {
 		getStatusForPlugin( state, siteId, pluginSlug )
 	);
 
-	const productsList = useSelector( getProductsList );
-	const isProductListFetched = Object.values( productsList ).length > 0;
-	const isMarketplaceProduct = useSelector( ( state ) =>
-		isMarketplaceProductSelector( state, pluginSlug )
-	);
-
 	const wpOrgTheme = useSelector( ( state ) => getTheme( state, 'wporg', themeSlug ) );
 	const isThemeActive = useSelector( ( state ) => getThemeActive( state, themeSlug, siteId ) );
 	useQueryTheme( 'wporg', themeSlug );
 
-	const { data: wpComPluginData } = useWPCOMPlugin( pluginSlug, {
-		enabled: isProductListFetched && isMarketplaceProduct,
-	} );
+	const { pluginInstallationStatus, productSlugInstalled, primaryDomain } =
+		useSelector( getPurchaseFlowState );
 
-	const marketplaceInstallationInProgress = useSelector( ( state ) => {
-		const { pluginInstallationStatus, productSlugInstalled, primaryDomain } = getPurchaseFlowState(
-			state as IAppState
-		);
-		if ( isPluginUploadFlow ) {
-			return (
-				pluginInstallationStatus !== MARKETPLACE_ASYNC_PROCESS_STATUS.COMPLETED &&
-				primaryDomain === selectedSiteSlug
-			);
-		}
-		return (
-			pluginInstallationStatus !== MARKETPLACE_ASYNC_PROCESS_STATUS.COMPLETED &&
-			productSlugInstalled &&
-			[ pluginSlug, themeSlug ].includes( productSlugInstalled ) &&
-			primaryDomain === selectedSiteSlug
-		);
-	} );
+	const isInstallationPending =
+		pluginInstallationStatus !== MARKETPLACE_ASYNC_PROCESS_STATUS.COMPLETED &&
+		primaryDomain === selectedSiteSlug;
+	const marketplaceInstallationInProgress = isPluginUploadFlow
+		? isInstallationPending
+		: isInstallationPending &&
+		  !! productSlugInstalled &&
+		  [ pluginSlug, themeSlug ].includes( productSlugInstalled );
 
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ?? null ) );
 	const isAtomic = useSelector( ( state ) =>
@@ -184,8 +161,6 @@ const MarketplaceProductInstall = ( {
 		return () => clearTimeout( id );
 	}, [ hasAtomicFeature, isJetpackSelfHosted, nonInstallablePlanError ] );
 
-	const { primaryDomain } = useSelector( getPurchaseFlowState );
-
 	const shouldShowNoDirectAccessError =
 		// 1. This is a plugin upload flow (via zip file) and we don't have a primary domain set
 		( isPluginUploadFlow && ! primaryDomain ) ||
@@ -205,13 +180,15 @@ const MarketplaceProductInstall = ( {
 
 	// Upload flow startup
 	useEffect( () => {
-		if ( 100 === pluginUploadProgress ) {
-			// For smaller uploads or fast networks give
-			// the chance to Upload Plugin step to be shown
-			// before moving to next step.
-			waitFor( 1 ).then( () => setCurrentStep( 1 ) );
+		if ( 100 !== pluginUploadProgress ) {
+			return;
 		}
-	}, [ pluginUploadProgress, setCurrentStep ] );
+		// For smaller uploads or fast networks give
+		// the chance to Upload Plugin step to be shown
+		// before moving to next step.
+		const id = setTimeout( () => setCurrentStep( 1 ), 1000 );
+		return () => clearTimeout( id );
+	}, [ pluginUploadProgress ] );
 
 	// Installing plugin flow startup
 	useEffect( () => {
@@ -222,6 +199,9 @@ const MarketplaceProductInstall = ( {
 			( wporgPlugin || wpOrgTheme )
 		) {
 			installFlowInitiatedRef.current = true;
+			// Intentionally uncancelable. The ref above blocks re-entry, so tying this to the
+			// effect's lifetime would let a dependency change drop the step advance for good
+			// rather than reschedule it — and the dispatches below change state this effect reads.
 			const triggerInstallFlow = () => {
 				waitFor( 1 ).then( () => setCurrentStep( 1 ) );
 			};
@@ -439,48 +419,14 @@ const MarketplaceProductInstall = ( {
 		}
 
 		if ( themeSlug && noDirectAccessError && ! directInstallationAllowed ) {
-			const variationPeriod = 'monthly';
-			const variation = wpComPluginData?.variations?.[ variationPeriod ];
-			const marketplaceProductSlug = getProductSlugByPeriodVariation( variation, productsList );
-			const productPage = `/themes/${ themeSlug }/${ selectedSite?.slug }`;
-			const productName = wpOrgTheme?.name || themeSlug;
-
 			return (
-				<>
-					<QueryProductsList />
-					<EmptyContent
-						className="marketplace-plugin-install__direct-install-container"
-						illustration={ wpOrgTheme?.screenshot || null }
-						illustrationWidth={ wpOrgTheme?.screenshot && 720 }
-						title={ productName }
-						line={ translate( 'Do you want to activate the theme %(theme)s?', {
-							args: { theme: wpOrgTheme?.name },
-						} ) }
-					>
-						{ isProductListFetched && (
-							<div className="marketplace-plugin-install__direct-install-actions">
-								<Button href={ productPage }>{ translate( 'Go to the theme page' ) }</Button>
-
-								{ ! isMarketplaceProduct ? (
-									<Button primary onClick={ () => setUserDirectInstallationAllowed( true ) }>
-										{ translate( 'Activate theme' ) }
-									</Button>
-								) : (
-									<Button
-										primary
-										onClick={ () =>
-											page(
-												`/checkout/${ selectedSite?.slug || '' }/${ marketplaceProductSlug }?#step2`
-											)
-										}
-									>
-										{ translate( 'Purchase and activate plugin' ) }
-									</Button>
-								) }
-							</div>
-						) }
-					</EmptyContent>
-				</>
+				<ThemeDirectInstall
+					themeSlug={ themeSlug }
+					pluginSlug={ pluginSlug }
+					siteSlug={ selectedSite?.slug }
+					theme={ wpOrgTheme }
+					onActivate={ () => setUserDirectInstallationAllowed( true ) }
+				/>
 			);
 		}
 		const uploadPageURL = `/plugins/upload/${ selectedSiteSlug }`;

--- a/client/my-sites/marketplace/pages/marketplace-product-install/theme-direct-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/theme-direct-install.tsx
@@ -1,0 +1,83 @@
+import page from '@automattic/calypso-router';
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import QueryProductsList from 'calypso/components/data/query-products-list';
+import EmptyContent from 'calypso/components/empty-content';
+import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query';
+import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
+import { useSelector } from 'calypso/state';
+import {
+	isMarketplaceProduct as isMarketplaceProductSelector,
+	getProductsList,
+} from 'calypso/state/products-list/selectors';
+
+/**
+ * Offers the user a way forward when the theme install page is reached without the handoff state
+ * that normally authorizes the install: either back to the theme page, or activate it from here.
+ */
+export default function ThemeDirectInstall( {
+	themeSlug,
+	pluginSlug,
+	siteSlug,
+	theme,
+	onActivate,
+}: {
+	themeSlug: string;
+	pluginSlug: string;
+	siteSlug?: string | null;
+	theme?: { name?: string; screenshot?: string };
+	onActivate: () => void;
+} ) {
+	const translate = useTranslate();
+	const productsList = useSelector( getProductsList );
+	const isProductListFetched = Object.values( productsList ).length > 0;
+	const isMarketplaceProduct = useSelector( ( state ) =>
+		isMarketplaceProductSelector( state, pluginSlug )
+	);
+	const { data: wpComPluginData } = useWPCOMPlugin( pluginSlug, {
+		enabled: isProductListFetched && isMarketplaceProduct,
+	} );
+
+	const marketplaceProductSlug = getProductSlugByPeriodVariation(
+		wpComPluginData?.variations?.monthly,
+		productsList
+	);
+
+	return (
+		<>
+			<QueryProductsList />
+			<EmptyContent
+				className="marketplace-plugin-install__direct-install-container"
+				illustration={ theme?.screenshot || null }
+				illustrationWidth={ theme?.screenshot ? 720 : undefined }
+				title={ theme?.name || themeSlug }
+				line={ translate( 'Do you want to activate the theme %(theme)s?', {
+					args: { theme: theme?.name || themeSlug },
+				} ) }
+			>
+				{ isProductListFetched && (
+					<div className="marketplace-plugin-install__direct-install-actions">
+						<Button href={ `/themes/${ themeSlug }/${ siteSlug }` }>
+							{ translate( 'Go to the theme page' ) }
+						</Button>
+
+						{ ! isMarketplaceProduct ? (
+							<Button primary onClick={ onActivate }>
+								{ translate( 'Activate theme' ) }
+							</Button>
+						) : (
+							<Button
+								primary
+								onClick={ () =>
+									page( `/checkout/${ siteSlug || '' }/${ marketplaceProductSlug }?#step2` )
+								}
+							>
+								{ translate( 'Purchase and activate plugin' ) }
+							</Button>
+						) }
+					</div>
+				) }
+			</EmptyContent>
+		</>
+	);
+}


### PR DESCRIPTION
## Proposed Changes

Second batch of cleanups to the marketplace product install page, following the earlier tidy-up:

* Move the theme direct-install screen into its own component. The products-list state and marketplace product lookup it exclusively owns move with it, so they are no longer fetched on every visit to the page regardless of flow.
* Subscribe to the purchase flow state once rather than twice, deriving the installation-in-progress check in plain code. This also removes a type cast that only existed because one selector was being called inside another.
* Give the upload-step timer a cleanup so it can't fire after its condition stops holding.

One further timer cleanup was planned for this batch and dropped during implementation — tying it to the effect's lifetime would have let it be cancelled without ever being rescheduled. A comment now records why it stays as it is.

## Why are these changes being made?

Continuing to peel low-risk work off a 580-line component that covers three distinct flows and has attracted a steady stream of bug fixes. The remaining backlog is the riskier half: consolidating the overlapping atomic-transfer checks, the remaining uncancelable timers, and eventually splitting the component per flow.

Two things surfaced while doing this that reviewers may want to weigh in on:

The extracted screen previously type-checked only because the theme object was untyped. Giving it a real prop type exposed a width value that could be an empty string and a translation argument that could be undefined. The width is now a plain conditional, and the translation argument falls back to the theme slug the way the title already did — so a theme whose data hasn't arrived shows its slug rather than an unresolved placeholder. That is the one intended behavior change here.

The extracted screen also contains a purchase action that appears unreachable: the theme route supplies no plugin slug, and the marketplace product lookup can only match a product with an empty slug. It is preserved verbatim in this PR rather than removed, since deleting it should be a deliberate decision.

## Testing Instructions

Verified by reading, plus `yarn typecheck-client` (no new errors) and `yarn eslint` (clean). The page has no test coverage, and I have not exercised it in a browser, so the checklist below reflects that.

To confirm manually:

1. Reach the theme install page without the state that normally authorizes the install, and confirm the prompt renders with its screenshot, title, and both actions, and that activating from there still works.
2. Do the same before the theme data has loaded and confirm the copy reads sensibly.
3. Run a plugin install and a zip upload through to completion, confirming the progress steps still advance and the redirect still fires.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
