### PR TITLE
Build: upgrade sass-loader to 16.0.8 to fix intermittent Docker image build timeouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -313,7 +313,7 @@
 		"recursive-copy": "^2.0.14",
 		"resize-observer-polyfill": "^1.5.1",
 		"sass": "1.77.8",
-		"sass-loader": "^14.2.1",
+		"sass-loader": "^16.0.8",
 		"source-map": "^0.7.4",
 		"stackframe": "^1.1.1",
 		"stacktrace-gps": "^3.0.3",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -54,7 +54,7 @@
 		"postcss-loader": "^6.2.1",
 		"recursive-copy": "^2.0.14",
 		"sass": "1.77.8",
-		"sass-loader": "^14.2.1",
+		"sass-loader": "^16.0.8",
 		"semver": "^7.7.2",
 		"terser-webpack-plugin": "^5.3.14",
 		"thread-loader": "^3.0.4",

--- a/packages/calypso-storybook/package.json
+++ b/packages/calypso-storybook/package.json
@@ -33,7 +33,7 @@
 	"dependencies": {
 		"@automattic/calypso-babel-config": "workspace:^",
 		"css-loader": "^6.11.0",
-		"sass-loader": "^14.2.1",
+		"sass-loader": "^16.0.8",
 		"style-loader": "^1.3.0",
 		"webpack": "^5.99.8"
 	},

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -84,7 +84,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"redux": "^5.0.1",
-		"sass-loader": "^14.2.1",
+		"sass-loader": "^16.0.8",
 		"storybook": "^9.1.20",
 		"style-loader": "^1.3.0",
 		"typescript": "^6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -493,7 +493,7 @@ __metadata:
     postcss-loader: "npm:^6.2.1"
     recursive-copy: "npm:^2.0.14"
     sass: "npm:1.77.8"
-    sass-loader: "npm:^14.2.1"
+    sass-loader: "npm:^16.0.8"
     semver: "npm:^7.7.2"
     terser-webpack-plugin: "npm:^5.3.14"
     thread-loader: "npm:^3.0.4"
@@ -714,7 +714,7 @@ __metadata:
     css-loader: "npm:^6.11.0"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    sass-loader: "npm:^14.2.1"
+    sass-loader: "npm:^16.0.8"
     storybook: "npm:^9.1.20"
     style-loader: "npm:^1.3.0"
     webpack: "npm:^5.99.8"
@@ -2023,7 +2023,7 @@ __metadata:
     react-router: "npm:6.30.4"
     react-router-dom: "npm:6.30.4"
     redux: "npm:^5.0.1"
-    sass-loader: "npm:^14.2.1"
+    sass-loader: "npm:^16.0.8"
     storybook: "npm:^9.1.20"
     style-loader: "npm:^1.3.0"
     tslib: "npm:^2.8.1"
@@ -29536,13 +29536,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass-loader@npm:^14.2.1":
-  version: 14.2.1
-  resolution: "sass-loader@npm:14.2.1"
+"sass-loader@npm:^16.0.8":
+  version: 16.0.8
+  resolution: "sass-loader@npm:16.0.8"
   dependencies:
     neo-async: "npm:^2.6.2"
   peerDependencies:
-    "@rspack/core": 0.x || 1.x
+    "@rspack/core": 0.x || ^1.0.0 || ^2.0.0-0
     node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
     sass: ^1.3.0
     sass-embedded: "*"
@@ -29558,7 +29558,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 9a48d454584d96d6c562eb323bb9e3c6808e930eeaaa916975b97d45831e0b87936a8655cdb3a4512a25abc9587dea65a9616e42396be0d7e7c507a4795a8146
+  checksum: c05886e6f1373eec23b05ea4d2dfc4317385dc3431ec665b611703ea60b4f9337f6547889c7b7f1c8e36d156caf1294e3d28292f104d6499076cf237f3c723bc
   languageName: node
   linkType: hard
 
@@ -33520,7 +33520,7 @@ __metadata:
     redux: "npm:^5.0.1"
     resize-observer-polyfill: "npm:^1.5.1"
     sass: "npm:1.77.8"
-    sass-loader: "npm:^14.2.1"
+    sass-loader: "npm:^16.0.8"
     source-map: "npm:^0.7.4"
     stackframe: "npm:^1.1.1"
     stacktrace-gps: "npm:^3.0.3"


### PR DESCRIPTION
Fixes the intermittent 20-minute execution timeouts on the [Docker image](https://teamcity.a8c.com/buildConfiguration/calypso_BuildDockerImage) TeamCity job, introduced by #112616.

Upstream bug: [webpack-contrib/sass-loader#1244](https://github.com/webpack-contrib/sass-loader/issues/1244) · fix: [#1245](https://github.com/webpack-contrib/sass-loader/pull/1245) (released in sass-loader 16.0.3)

## Proposed Changes

* Upgrade `sass-loader` from `^14.2.1` to `^16.0.8` everywhere it's declared (root, `calypso-build`, `calypso-storybook`, `onboarding`).

## Why are these changes being made?

Since #112616 switched sass compilation to `api: 'modern-compiler'` + `sass-embedded`, 20–30% of Docker image builds hang after webpack finishes compiling and get killed by the 20-minute timeout. Retrying the same commit usually passes.

sass-loader 14.2.1 has a race in the modern-compiler path: loader invocations arriving before the first `initAsyncCompiler()` resolves each spawn their own compiler, but only one is kept and disposed on shutdown. The rest leave orphaned `dart-sass --embedded` child processes that keep the Node event loop alive, so webpack finishes its work but the process never exits — 0% CPU until TeamCity kills the build. Fixed upstream in 16.0.3; the timeouts can't be fixed from our side of the API.

<details>
<summary>Evidence: all 248 timeouts since the merge are this hang; none before it</summary>

The hang wave starts at 12:20 UTC July 15 — five minutes after #112616 merged — and the PR's own branch build hit it the day before merge. Classified the build logs of every Docker image failure 14 days back:

| Hang signature (last output → 15–19 min silence → killed) | Count |
|---|---|
| Silent right after client webpack finishes compiling | 225 |
| Right after the Sentry sourcemap report, before webpack exits (trunk builds) | 16 |
| `build-languages` done; the parallel `build-server` webpack never exits | 5 |
| Compile errors on the branch, then same hang at exit | 2 |

Pre-merge control: zero hang signatures. The only 2 earlier timeouts were cold-cache slow builds killed mid-work; all other failures were ordinary compile errors. Agent perfmon confirms the host sits at ~0–2% CPU for the entire hang.
</details>

<details>
<summary>Upgrade compatibility notes (14 → 16, and why not 17)</summary>

* v15 flipped the default `api` to `modern` — both call sites here (`calypso-build/webpack/sass.js`, `calypso-storybook`) already pass an explicit modern `api` with modern-style `sassOptions`; no behavior change.
* v16 dropped `node-sass` support — not used here.
* Node floor 18.12 (repo: 24.x); webpack peer `^5.27.0` (repo: `^5.99.8`).
* `yarn why sass-loader` shows a single `16.0.8` lockfile entry, and the hoisted `node_modules/sass-loader` (what `require.resolve()` loads) contains the dispose fix.
* Not jumping to 17.0.0: it converts the package to ESM and defaults `api` to `'auto'` — unrelated churn.
</details>

## Testing Instructions

* Re-trigger the **Docker image** build on this PR several times — the hang was intermittent (~20–30%), so one green run proves little. Each run should finish in ~4–7 minutes with no silent gap after webpack completes.
* Local smoke test (compiles scss through the new loader; should emit CSS and exit promptly, exit code 0):
  ```bash
  NODE_ENV=production CALYPSO_ENV=production BROWSERSLIST_ENV=evergreen \
  ENTRY_LIMIT=entry-login yarn webpack --config client/webpack.config.js --stats-preset errors-only
  ```
* After merge, watch the [job's build history](https://teamcity.a8c.com/buildConfiguration/calypso_BuildDockerImage): "Execution timeout" failures should stop.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
