### PR TITLE
Notifications: Fix checkboxes and radio buttons not rendering in Firefox

### DIFF
--- a/apps/notifications/src/app/note/reset.scss
+++ b/apps/notifications/src/app/note/reset.scss
@@ -122,6 +122,6 @@
 	}
 	input[type="radio"],
 	input[type="checkbox"] {
-		-webkit-appearance: none;
+		appearance: auto;
 	}
 }

--- a/apps/notifications/src/panel/boot/stylesheets/shared/reset.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/shared/reset.scss
@@ -123,6 +123,6 @@
 	}
 	input[type="radio"],
 	input[type="checkbox"] {
-		-webkit-appearance: none;
+		appearance: auto;
 	}
 }


### PR DESCRIPTION



Fixes #

Replace `-webkit-appearance: none` on `input[type="radio"]` and `input[type="checkbox"]` with `appearance: auto` to restore native browser rendering. The webkit-only property suppresses Firefox's built-in checkbox/radio UI, making them appear blank regardless of checked state (see #107972).



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
