### PR TITLE
Reader: optimistically update the tag follow/unfollow button

### DIFF
--- a/client/reader/tag-stream/follow-tag-button.tsx
+++ b/client/reader/tag-stream/follow-tag-button.tsx
@@ -1,0 +1,41 @@
+import { Button } from '@wordpress/components';
+import { check, plus } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import type { JSX } from 'react';
+
+interface TagFollowButtonProps {
+	following?: boolean;
+	disabled?: boolean;
+	tagName?: string;
+	onToggle: () => void;
+}
+
+export function TagFollowButton( {
+	following,
+	disabled,
+	tagName,
+	onToggle,
+}: TagFollowButtonProps ): JSX.Element {
+	const translate = useTranslate();
+
+	const label = tagName
+		? ( ( following
+				? translate( 'Unfollow the “%(tagName)s” tag', { args: { tagName } } )
+				: translate( 'Follow the “%(tagName)s” tag', { args: { tagName } } ) ) as string )
+		: undefined;
+
+	return (
+		<Button
+			variant={ following ? 'secondary' : 'primary' }
+			icon={ following ? check : plus }
+			label={ label }
+			showTooltip={ !! label }
+			disabled={ disabled }
+			isBusy={ disabled }
+			onClick={ () => onToggle() }
+			__next40pxDefaultSize
+		>
+			{ following ? translate( 'Following' ) : translate( 'Follow' ) }
+		</Button>
+	);
+}

--- a/client/reader/tag-stream/header.tsx
+++ b/client/reader/tag-stream/header.tsx
@@ -5,12 +5,12 @@ import {
 } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import FollowButton from 'calypso/blocks/follow-button/button';
 import BloganuaryHeader from 'calypso/components/bloganuary-header';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordAction } from 'calypso/reader/stats';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
+import { TagFollowButton } from './follow-tag-button';
 import type { JSX } from 'react';
 
 interface TagStreamHeaderProps {
@@ -104,12 +104,11 @@ export default function TagStreamHeader( props: TagStreamHeaderProps ): JSX.Elem
 					</div>
 					<div className="tag-stream__header-follow">
 						{ showFollow && (
-							<FollowButton
-								followLabel={ translate( 'Follow tag' ) }
-								followingLabel={ translate( 'Following tag' ) }
+							<TagFollowButton
 								following={ following }
 								disabled={ followDisabled }
-								onFollowToggle={ onFollowToggle }
+								tagName={ title }
+								onToggle={ () => onFollowToggle?.() }
 							/>
 						) }
 					</div>

--- a/client/reader/tag-stream/header.tsx
+++ b/client/reader/tag-stream/header.tsx
@@ -17,6 +17,7 @@ interface TagStreamHeaderProps {
 	encodedTagSlug: string;
 	description?: string;
 	following?: boolean;
+	followDisabled?: boolean;
 	isPlaceholder?: boolean;
 	onFollowToggle?: () => void;
 	showFollow: boolean;
@@ -30,6 +31,7 @@ export default function TagStreamHeader( props: TagStreamHeaderProps ): JSX.Elem
 		description,
 		encodedTagSlug,
 		following,
+		followDisabled,
 		isPlaceholder,
 		onFollowToggle,
 		showFollow,
@@ -106,6 +108,7 @@ export default function TagStreamHeader( props: TagStreamHeaderProps ): JSX.Elem
 								followLabel={ translate( 'Follow tag' ) }
 								followingLabel={ translate( 'Following tag' ) }
 								following={ following }
+								disabled={ followDisabled }
 								onFollowToggle={ onFollowToggle }
 							/>
 						) }

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -124,6 +124,7 @@ class TagStream extends Component {
 				showFollow={ !! ( tag && tag.id ) }
 				following={ this.isSubscribed() }
 				onFollowToggle={ this.toggleFollowing }
+				followDisabled={ this.props.isTogglingFollow }
 				showSort={ showSort }
 				sort={ this.props.sort }
 			/>
@@ -190,8 +191,12 @@ function withTagFollowMutations( Inner ) {
 	return function WithTagFollowMutations( props ) {
 		const queryClient = useQueryClient();
 		const dispatch = useDispatch();
-		const { mutate: follow } = useMutation( followReadTagMutation( queryClient ) );
-		const { mutate: unfollow } = useMutation( unfollowReadTagMutation( queryClient ) );
+		const { mutate: follow, isPending: isFollowPending } = useMutation(
+			followReadTagMutation( queryClient )
+		);
+		const { mutate: unfollow, isPending: isUnfollowPending } = useMutation(
+			unfollowReadTagMutation( queryClient )
+		);
 
 		const followTag = ( tag ) =>
 			follow( tag, {
@@ -208,7 +213,14 @@ function withTagFollowMutations( Inner ) {
 					),
 			} );
 
-		return <Inner { ...props } followTag={ followTag } unfollowTag={ unfollowTag } />;
+		return (
+			<Inner
+				{ ...props }
+				followTag={ followTag }
+				unfollowTag={ unfollowTag }
+				isTogglingFollow={ isFollowPending || isUnfollowPending }
+			/>
+		);
 	};
 }
 

--- a/client/reader/tag-stream/test/follow-tag-button.tsx
+++ b/client/reader/tag-stream/test/follow-tag-button.tsx
@@ -1,0 +1,38 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TagFollowButton } from '../follow-tag-button';
+
+describe( 'TagFollowButton', () => {
+	it( 'shows the follow label and fires onToggle when not following', async () => {
+		const user = userEvent.setup();
+		const onToggle = jest.fn();
+		render( <TagFollowButton following={ false } onToggle={ onToggle } /> );
+
+		const button = screen.getByRole( 'button', { name: 'Follow' } );
+		expect( button ).toBeVisible();
+
+		await user.click( button );
+		expect( onToggle ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'shows the following label when following', () => {
+		render( <TagFollowButton following onToggle={ jest.fn() } /> );
+
+		expect( screen.getByRole( 'button', { name: 'Following' } ) ).toBeVisible();
+	} );
+
+	it( 'is disabled while a request is in flight', () => {
+		render( <TagFollowButton following={ false } disabled onToggle={ jest.fn() } /> );
+
+		expect( screen.getByRole( 'button', { name: 'Follow' } ) ).toBeDisabled();
+	} );
+
+	it( 'labels the button with the tag name for the tooltip', () => {
+		render( <TagFollowButton following={ false } tagName="Finance" onToggle={ jest.fn() } /> );
+
+		expect( screen.getByRole( 'button', { name: 'Follow the “Finance” tag' } ) ).toBeVisible();
+	} );
+} );

--- a/packages/api-queries/src/__tests__/read-tags.test.tsx
+++ b/packages/api-queries/src/__tests__/read-tags.test.tsx
@@ -278,6 +278,7 @@ describe( 'optimistic followed-tags cache updates', () => {
 
 		await waitFor( () => expect( cachedSlugs( client ) ).toEqual( [ 'health' ] ) );
 		expect( result.current.isPending ).toBe( true );
+		await waitFor( () => expect( result.current.isPending ).toBe( false ) );
 	} );
 
 	it( 'restores the followed cache when the unfollow request fails', async () => {

--- a/packages/api-queries/src/__tests__/read-tags.test.tsx
+++ b/packages/api-queries/src/__tests__/read-tags.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider, useMutation, useQuery } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import {
 	followReadTagMutation,
@@ -235,5 +235,100 @@ describe( 'unfollowReadTagMutation', () => {
 
 		await result.current.mutateAsync( 'Photography' );
 		expect( scope.isDone() ).toBe( true );
+	} );
+} );
+
+describe( 'optimistic followed-tags cache updates', () => {
+	afterEach( () => nock.cleanAll() );
+
+	const FOLLOWED_KEY = [ 'read', 'tags', 'followed', null ];
+
+	function seedFollowed( client: QueryClient, slugs: string[] ) {
+		client.setQueryData( FOLLOWED_KEY, {
+			tags: slugs.map( ( slug, i ) => ( {
+				ID: String( i + 1 ),
+				slug,
+				title: slug,
+				display_name: slug,
+				URL: `/tag/${ slug }`,
+			} ) ),
+		} );
+	}
+
+	function cachedSlugs( client: QueryClient ): string[] {
+		const data = client.getQueryData< { tags: Array< { slug: string } > } >( FOLLOWED_KEY );
+		return ( data?.tags ?? [] ).map( ( t ) => t.slug );
+	}
+
+	it( 'removes the tag from the followed cache on unfollow (before the request resolves)', async () => {
+		nock( BASE )
+			.post( '/rest/v1.1/read/tags/finance/mine/delete' )
+			.delay( 300 )
+			.reply( 200, { subscribed: false, removed_tag: '1' } );
+
+		const client = newClient();
+		seedFollowed( client, [ 'finance', 'health' ] );
+		const { result } = renderHook( () => useMutation( unfollowReadTagMutation( client ) ), {
+			wrapper: makeWrapper( client ),
+		} );
+
+		act( () => {
+			result.current.mutate( 'finance' );
+		} );
+
+		await waitFor( () => expect( cachedSlugs( client ) ).toEqual( [ 'health' ] ) );
+		expect( result.current.isPending ).toBe( true );
+	} );
+
+	it( 'restores the followed cache when the unfollow request fails', async () => {
+		nock( BASE ).post( '/rest/v1.1/read/tags/finance/mine/delete' ).reply( 500, {} );
+
+		const client = newClient();
+		seedFollowed( client, [ 'finance', 'health' ] );
+		const { result } = renderHook( () => useMutation( unfollowReadTagMutation( client ) ), {
+			wrapper: makeWrapper( client ),
+		} );
+
+		await act( async () => {
+			await result.current.mutateAsync( 'finance' ).catch( () => undefined );
+		} );
+
+		expect( cachedSlugs( client ) ).toEqual( [ 'finance', 'health' ] );
+	} );
+
+	it( 'adds the tag to the followed cache on follow', async () => {
+		nock( BASE )
+			.post( '/rest/v1.1/read/tags/gardening/mine/new' )
+			.reply( 200, { subscribed: true, added_tag: 'gardening', tags: [] } );
+
+		const client = newClient();
+		seedFollowed( client, [ 'health' ] );
+		const { result } = renderHook( () => useMutation( followReadTagMutation( client ) ), {
+			wrapper: makeWrapper( client ),
+		} );
+
+		await act( async () => {
+			await result.current.mutateAsync( 'gardening' );
+		} );
+
+		expect( cachedSlugs( client ) ).toEqual( expect.arrayContaining( [ 'health', 'gardening' ] ) );
+	} );
+
+	it( 'does not duplicate a tag that is already followed', async () => {
+		nock( BASE )
+			.post( '/rest/v1.1/read/tags/health/mine/new' )
+			.reply( 200, { subscribed: true, added_tag: 'health', tags: [] } );
+
+		const client = newClient();
+		seedFollowed( client, [ 'health' ] );
+		const { result } = renderHook( () => useMutation( followReadTagMutation( client ) ), {
+			wrapper: makeWrapper( client ),
+		} );
+
+		await act( async () => {
+			await result.current.mutateAsync( 'health' );
+		} );
+
+		expect( cachedSlugs( client ) ).toEqual( [ 'health' ] );
 	} );
 } );

--- a/packages/api-queries/src/__tests__/read-tags.test.tsx
+++ b/packages/api-queries/src/__tests__/read-tags.test.tsx
@@ -293,7 +293,47 @@ describe( 'optimistic followed-tags cache updates', () => {
 			await result.current.mutateAsync( 'finance' ).catch( () => undefined );
 		} );
 
-		expect( cachedSlugs( client ) ).toEqual( [ 'finance', 'health' ] );
+		expect( cachedSlugs( client ).sort() ).toEqual( [ 'finance', 'health' ] );
+	} );
+
+	it( 'removes only the optimistically-added tag when the follow request fails', async () => {
+		nock( BASE ).post( '/rest/v1.1/read/tags/gardening/mine/new' ).reply( 500, {} );
+
+		const client = newClient();
+		seedFollowed( client, [ 'health' ] );
+		const { result } = renderHook( () => useMutation( followReadTagMutation( client ) ), {
+			wrapper: makeWrapper( client ),
+		} );
+
+		await act( async () => {
+			await result.current.mutateAsync( 'gardening' ).catch( () => undefined );
+		} );
+
+		expect( cachedSlugs( client ) ).toEqual( [ 'health' ] );
+	} );
+
+	it( 'rolls back only its own tag when concurrent mutations run and one fails', async () => {
+		nock( BASE )
+			.post( '/rest/v1.1/read/tags/finance/mine/delete' )
+			.reply( 200, { subscribed: false, removed_tag: '1' } );
+		nock( BASE ).post( '/rest/v1.1/read/tags/health/mine/delete' ).reply( 500, {} );
+
+		const client = newClient();
+		seedFollowed( client, [ 'finance', 'health' ] );
+		const { result } = renderHook( () => useMutation( unfollowReadTagMutation( client ) ), {
+			wrapper: makeWrapper( client ),
+		} );
+
+		await act( async () => {
+			await Promise.all( [
+				result.current.mutateAsync( 'finance' ).catch( () => undefined ),
+				result.current.mutateAsync( 'health' ).catch( () => undefined ),
+			] );
+		} );
+
+		// finance's unfollow succeeded (stays removed); health's failed and was
+		// rolled back (re-added) without reverting finance's optimistic removal.
+		expect( cachedSlugs( client ) ).toEqual( [ 'health' ] );
 	} );
 
 	it( 'adds the tag to the followed cache on follow', async () => {

--- a/packages/api-queries/src/read-tags.ts
+++ b/packages/api-queries/src/read-tags.ts
@@ -7,12 +7,7 @@ import {
 	type ReadTag,
 	type ReadTagsResponse,
 } from '@automattic/api-core';
-import {
-	mutationOptions,
-	queryOptions,
-	type QueryClient,
-	type QueryKey,
-} from '@tanstack/react-query';
+import { mutationOptions, queryOptions, type QueryClient } from '@tanstack/react-query';
 import { decodeEntities } from '@wordpress/html-entities';
 
 export interface ReaderTag {
@@ -83,39 +78,24 @@ function slugify( tag: string ): string {
 // caller's QueryClient and uses it for cache invalidation. Pass
 // `useQueryClient()` from the consuming component.
 
-interface FollowedTagsMutationContext {
-	previous: Array< [ QueryKey, ReadTagsResponse | undefined ] >;
-}
-
 // Optimistically patch the followed-tags cache so the follow/unfollow button
 // flips on click instead of waiting for the POST + refetch round-trip. The cache
 // holds the raw response ({ tags: ReadTag[] }); `select` normalizes on read, so
 // we patch the raw shape here. `onSettled` invalidation reconciles with the
 // server afterwards.
-async function snapshotAndPatchFollowedTags(
-	queryClient: QueryClient,
-	updater: ( tags: ReadTag[] ) => ReadTag[]
-): Promise< FollowedTagsMutationContext > {
+async function cancelFollowedTags( queryClient: QueryClient ) {
 	try {
 		await queryClient.cancelQueries( { queryKey: [ 'read', 'tags', 'followed' ] } );
 	} catch {
 		// cancelQueries is best-effort; the optimistic patch below must still run.
 	}
-	const previous = queryClient.getQueriesData< ReadTagsResponse >( {
-		queryKey: [ 'read', 'tags', 'followed' ],
-	} );
+}
+
+function patchFollowedTags( queryClient: QueryClient, updater: ( tags: ReadTag[] ) => ReadTag[] ) {
 	queryClient.setQueriesData< ReadTagsResponse >(
 		{ queryKey: [ 'read', 'tags', 'followed' ] },
 		( old ) => ( old?.tags ? { ...old, tags: updater( old.tags ) } : old )
 	);
-	return { previous };
-}
-
-function rollbackFollowedTags(
-	queryClient: QueryClient,
-	context: FollowedTagsMutationContext | undefined
-) {
-	context?.previous.forEach( ( [ key, data ] ) => queryClient.setQueryData( key, data ) );
 }
 
 // Source a full ReadTag for the optimistic follow from the single-tag cache when
@@ -148,8 +128,9 @@ export const followReadTagMutation = ( queryClient: QueryClient ) =>
 				throw error;
 			}
 		},
-		onMutate: ( tag: string ) => {
+		onMutate: async ( tag: string ) => {
 			const slug = slugify( tag );
+			await cancelFollowedTags( queryClient );
 			const optimisticTag: ReadTag = findCachedReadTag( queryClient, slug ) ?? {
 				ID: slug,
 				slug,
@@ -157,11 +138,25 @@ export const followReadTagMutation = ( queryClient: QueryClient ) =>
 				display_name: tag,
 				URL: `/tag/${ slug }`,
 			};
-			return snapshotAndPatchFollowedTags( queryClient, ( tags ) =>
-				tags.some( ( t ) => t.slug.toLowerCase() === slug ) ? tags : [ ...tags, optimisticTag ]
-			);
+			let didAdd = false;
+			patchFollowedTags( queryClient, ( tags ) => {
+				if ( tags.some( ( t ) => t.slug.toLowerCase() === slug ) ) {
+					return tags;
+				}
+				didAdd = true;
+				return [ ...tags, optimisticTag ];
+			} );
+			// Roll back only this tag on error so a failure here doesn't clobber
+			// optimistic changes from other in-flight follow/unfollow mutations.
+			return { slug, didAdd };
 		},
-		onError: ( _error, _tag, context ) => rollbackFollowedTags( queryClient, context ),
+		onError: ( _error, _tag, context ) => {
+			if ( context?.didAdd ) {
+				patchFollowedTags( queryClient, ( tags ) =>
+					tags.filter( ( t ) => t.slug.toLowerCase() !== context.slug )
+				);
+			}
+		},
 		onSettled: () => invalidateFollowedTags( queryClient ),
 	} );
 
@@ -169,12 +164,30 @@ export const unfollowReadTagMutation = ( queryClient: QueryClient ) =>
 	mutationOptions( {
 		meta: { statId: 'read-tag-unfollow' },
 		mutationFn: ( tag: string ) => unfollowReadTag( slugify( tag ) ),
-		onMutate: ( tag: string ) => {
+		onMutate: async ( tag: string ) => {
 			const slug = slugify( tag );
-			return snapshotAndPatchFollowedTags( queryClient, ( tags ) =>
-				tags.filter( ( t ) => t.slug.toLowerCase() !== slug )
-			);
+			await cancelFollowedTags( queryClient );
+			let removedTag: ReadTag | undefined;
+			patchFollowedTags( queryClient, ( tags ) => {
+				const found = tags.find( ( t ) => t.slug.toLowerCase() === slug );
+				if ( found ) {
+					removedTag = found;
+				}
+				return tags.filter( ( t ) => t.slug.toLowerCase() !== slug );
+			} );
+			// Roll back only this tag on error so a failure here doesn't clobber
+			// optimistic changes from other in-flight follow/unfollow mutations.
+			return { slug, removedTag };
 		},
-		onError: ( _error, _tag, context ) => rollbackFollowedTags( queryClient, context ),
+		onError: ( _error, _tag, context ) => {
+			if ( context?.removedTag ) {
+				const removedTag = context.removedTag;
+				patchFollowedTags( queryClient, ( tags ) =>
+					tags.some( ( t ) => t.slug.toLowerCase() === context.slug )
+						? tags
+						: [ ...tags, removedTag ]
+				);
+			}
+		},
 		onSettled: () => invalidateFollowedTags( queryClient ),
 	} );

--- a/packages/api-queries/src/read-tags.ts
+++ b/packages/api-queries/src/read-tags.ts
@@ -7,7 +7,12 @@ import {
 	type ReadTag,
 	type ReadTagsResponse,
 } from '@automattic/api-core';
-import { mutationOptions, queryOptions, type QueryClient } from '@tanstack/react-query';
+import {
+	mutationOptions,
+	queryOptions,
+	type QueryClient,
+	type QueryKey,
+} from '@tanstack/react-query';
 import { decodeEntities } from '@wordpress/html-entities';
 
 export interface ReaderTag {
@@ -78,6 +83,55 @@ function slugify( tag: string ): string {
 // caller's QueryClient and uses it for cache invalidation. Pass
 // `useQueryClient()` from the consuming component.
 
+interface FollowedTagsMutationContext {
+	previous: Array< [ QueryKey, ReadTagsResponse | undefined ] >;
+}
+
+// Optimistically patch the followed-tags cache so the follow/unfollow button
+// flips on click instead of waiting for the POST + refetch round-trip. The cache
+// holds the raw response ({ tags: ReadTag[] }); `select` normalizes on read, so
+// we patch the raw shape here. `onSettled` invalidation reconciles with the
+// server afterwards.
+async function snapshotAndPatchFollowedTags(
+	queryClient: QueryClient,
+	updater: ( tags: ReadTag[] ) => ReadTag[]
+): Promise< FollowedTagsMutationContext > {
+	try {
+		await queryClient.cancelQueries( { queryKey: [ 'read', 'tags', 'followed' ] } );
+	} catch {
+		// cancelQueries is best-effort; the optimistic patch below must still run.
+	}
+	const previous = queryClient.getQueriesData< ReadTagsResponse >( {
+		queryKey: [ 'read', 'tags', 'followed' ],
+	} );
+	queryClient.setQueriesData< ReadTagsResponse >(
+		{ queryKey: [ 'read', 'tags', 'followed' ] },
+		( old ) => ( old?.tags ? { ...old, tags: updater( old.tags ) } : old )
+	);
+	return { previous };
+}
+
+function rollbackFollowedTags(
+	queryClient: QueryClient,
+	context: FollowedTagsMutationContext | undefined
+) {
+	context?.previous.forEach( ( [ key, data ] ) => queryClient.setQueryData( key, data ) );
+}
+
+// Source a full ReadTag for the optimistic follow from the single-tag cache when
+// available; the reconciling refetch replaces the minimal fallback with real data.
+function findCachedReadTag( queryClient: QueryClient, slug: string ): ReadTag | undefined {
+	const matches = queryClient.getQueriesData< ReadSingleTagResponse >( {
+		queryKey: [ 'read', 'tags', slug ],
+	} );
+	for ( const [ , data ] of matches ) {
+		if ( data?.tag ) {
+			return data.tag;
+		}
+	}
+	return undefined;
+}
+
 export const followReadTagMutation = ( queryClient: QueryClient ) =>
 	mutationOptions( {
 		meta: { statId: 'read-tag-follow' },
@@ -94,12 +148,33 @@ export const followReadTagMutation = ( queryClient: QueryClient ) =>
 				throw error;
 			}
 		},
-		onSuccess: () => invalidateFollowedTags( queryClient ),
+		onMutate: ( tag: string ) => {
+			const slug = slugify( tag );
+			const optimisticTag: ReadTag = findCachedReadTag( queryClient, slug ) ?? {
+				ID: slug,
+				slug,
+				title: tag,
+				display_name: tag,
+				URL: `/tag/${ slug }`,
+			};
+			return snapshotAndPatchFollowedTags( queryClient, ( tags ) =>
+				tags.some( ( t ) => t.slug.toLowerCase() === slug ) ? tags : [ ...tags, optimisticTag ]
+			);
+		},
+		onError: ( _error, _tag, context ) => rollbackFollowedTags( queryClient, context ),
+		onSettled: () => invalidateFollowedTags( queryClient ),
 	} );
 
 export const unfollowReadTagMutation = ( queryClient: QueryClient ) =>
 	mutationOptions( {
 		meta: { statId: 'read-tag-unfollow' },
 		mutationFn: ( tag: string ) => unfollowReadTag( slugify( tag ) ),
-		onSuccess: () => invalidateFollowedTags( queryClient ),
+		onMutate: ( tag: string ) => {
+			const slug = slugify( tag );
+			return snapshotAndPatchFollowedTags( queryClient, ( tags ) =>
+				tags.filter( ( t ) => t.slug.toLowerCase() !== slug )
+			);
+		},
+		onError: ( _error, _tag, context ) => rollbackFollowedTags( queryClient, context ),
+		onSettled: () => invalidateFollowedTags( queryClient ),
 	} );


### PR DESCRIPTION
Closes READ-614

## Proposed Changes

| Follow | Following |
|--------|--------|
| <img width="3334" height="1926" alt="CleanShot 2026-07-22 at 15 13 37@2x" src="https://github.com/user-attachments/assets/d043b81a-13c9-43f8-9618-89c848c8bed0" /> | <img width="3334" height="1928" alt="CleanShot 2026-07-22 at 15 13 50@2x" src="https://github.com/user-attachments/assets/4119a5d4-fa35-42be-acc0-b37cfeaec305" /> | 

* Add optimistic cache updates to `followReadTagMutation` / `unfollowReadTagMutation` in `packages/api-queries/src/read-tags.ts`: `onMutate` patches the followed-tags cache (adds/removes the tag) so the button flips on click, `onError` applies a **targeted per-tag inverse** (so a failed mutation doesn't clobber other in-flight optimistic updates), and `onSettled` invalidates to reconcile with the server.
* Extract the tag stream follow/unfollow button into a dedicated `TagFollowButton` component backed by the `@wordpress/components` `Button` (scoped to the tag stream — the shared `blocks/follow-button` is untouched):
  * **Follow** — `primary` variant with the `plus` icon when not following.
  * **Following** — `secondary` variant with the `check` icon when following.
  * Tooltip via the button `label`: “Follow the “%(tagName)s” tag” / “Unfollow the “%(tagName)s” tag”.
  * Disabled (with a busy state) while a request is in flight to prevent a double-fire.
* Add tests for the optimistic add/remove, dedupe, error rollback, concurrent-rollback isolation, and the new button component (labels, disabled state, tooltip label).

## Why are these changes being made?

The tag follow/unfollow button derives its state entirely from the followed-tags query, and the mutations previously only invalidated that query on success. So the label could not change until **both** the `POST .../mine/{new,delete}` and the followed-tags refetch had completed — the button felt unresponsive and was reported as "unfollow doesn't work". Patching the shared query optimistically flips the button on click and, because the state is shared, fixes every tag follow/unfollow surface (tag header, sidebar, interests modals, bloganuary header) at once.

## Testing Instructions

### Scenario 1 - Unfollow updates instantly:
- Go to `/tag/finance` while logged in and already following the tag
- Check that the button shows "Following" (secondary, check icon), and clicking it immediately flips to "Follow" (primary, plus icon) and stays there after the page settles

### Scenario 2 - Follow updates instantly:
- Go to `/tag/:tag` for a tag you do not follow
- Check that the button shows "Follow", and clicking it immediately flips to "Following" and stays there after the request completes

### Scenario 3 - Tooltip:
- Go to `/tag/finance` and hover/focus the button
- Check that the tooltip reads “Follow the “Finance” tag” (or “Unfollow the “Finance” tag” when already following)

### Scenario 4 - Failed request reverts:
- Go to `/tag/finance` with the network offline (or the request blocked)
- Check that the button briefly flips, then reverts to its previous state and a "Could not unfollow tag" notice appears

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
