### PR TITLE
A4A: Fix checkbox alignment in the "Add sites via WordPress.com" modal

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/table-content.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/table-content.tsx
@@ -15,6 +15,10 @@ export default function WPCOMSitesTableContent( { items, fields }: Props ) {
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,
 		fields: [ 'site', 'date', 'type' ],
+		// Column moving makes no sense here, and disabling it stops DataViews from
+		// wrapping each column header in a padded menu button — which indented the
+		// select-all checkbox out of line with the row checkboxes.
+		layout: { enableMoving: false },
 	} );
 
 	const { data, paginationInfo } = useMemo( () => {

--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/table-content.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/table-content.tsx
@@ -15,9 +15,7 @@ export default function WPCOMSitesTableContent( { items, fields }: Props ) {
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,
 		fields: [ 'site', 'date', 'type' ],
-		// Column moving makes no sense here, and disabling it stops DataViews from
-		// wrapping each column header in a padded menu button — which indented the
-		// select-all checkbox out of line with the row checkboxes.
+		// Prevents DataViews from wrapping headers in a padded menu button that misaligns the select-all checkbox.
 		layout: { enableMoving: false },
 	} );
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/A4A-3051/add-sites-modal-checkbox-alignment 

The "Add sites via WordPress.com connection" modal (A4A dashboard → Sites → Add sites) lists the sites available to connect in a DataViews table. The table's "Site" column header embeds the select-all checkbox inside the column label, and DataViews wraps every column header in a menu-trigger button whose job is to expose the column actions (sort, hide, move). That button carries its own padding.

The button padding indents the header's select-all checkbox a few pixels to the right of the row checkboxes below it, so the whole left column reads as misaligned. It also means clicking anywhere on the "SITE" header (including around the checkbox) can open a column-move menu, which is not useful in this modal. This was flagged as urgent in the A4A QA walkthrough.

This PR disables column moving for the table via DataViews' documented `layout: { enableMoving: false }` view option. Sorting and hiding are already disabled for these columns, and moving was the last remaining reason for the header menu button to exist. With all three off, DataViews renders the bare header label instead of the button, so the header and row cells share identical padding and the select-all checkbox lines up exactly with the row checkboxes. Clicking a column header no longer opens a menu.

### Before

<img width="734" height="111" alt="image" src="https://github.com/user-attachments/assets/fb06dd64-0208-485a-abef-ea7a407bf85a" />

### After

<img width="734" height="97" alt="image" src="https://github.com/user-attachments/assets/22f2c4b1-3661-4921-ade2-d62f49b97d22" />

## Testing Instructions

Prerequisites: an Automattic for Agencies account with at least one WordPress.com site available to connect (so the modal's site list is populated).

1. Run the A4A dashboard locally: `yarn start-a8c-for-agencies` or visit the A4A Live link below
2. Open the dashboard and go to **Sites**.
3. Click **Add sites** → **Via WordPress.com connection**.
4. Verify the select-all checkbox in the table header is aligned with the checkboxes in the rows below it (previously it sat a few pixels to the right).
5. Click the "SITE" column header text. Verify no column menu opens.
6. Narrow the browser window to a mobile width and verify the checkboxes stay aligned in the single-column layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
