### PR TITLE
Make PHP 8.4 the recommended PHP version

### DIFF
--- a/client/dashboard/sites/settings-php/test/index.test.tsx
+++ b/client/dashboard/sites/settings-php/test/index.test.tsx
@@ -86,7 +86,10 @@ describe( '<PHPVersionSettings>', () => {
 		render( <PHPVersionSettings siteSlug={ site.slug } />, { queryClient } );
 
 		const versionSelect = await screen.findByRole( 'combobox', { name: 'PHP version' } );
-		expect( versionSelect ).toHaveDisplayValue( '8.3 (Recommended)' );
+		expect( versionSelect ).toHaveDisplayValue( '8.3' );
+		expect(
+			within( versionSelect ).getByRole( 'option', { name: '8.4 (Recommended)' } )
+		).toBeVisible();
 		expect(
 			within( versionSelect ).queryByRole( 'option', { name: '8.2' } )
 		).not.toBeInTheDocument();

--- a/client/data/php-versions/index.jsx
+++ b/client/data/php-versions/index.jsx
@@ -1,13 +1,8 @@
 import { __, sprintf } from '@wordpress/i18n';
 
 export const getPHPVersions = ( siteId ) => {
-	// 25% of sites will have a recommended PHP version of 8.4. These sites are transferring to 8.4 by default.
-	// 251762970 is the first site of the list.
-	const isPhp84Default = siteId && siteId >= 251762970 && siteId % 4 === 0;
-
-	// PHP 8.3 is the default recommended version, 8.4 is the new recommended version for some sites.
-	const recommendedValue = isPhp84Default ? '8.4' : '8.3';
-	// translators: %s: PHP version number, e.g. "8.3", for a version switcher
+	const recommendedValue = '8.4';
+	// translators: %s: PHP version number, e.g. "8.4", for a version switcher
 	const recommendedLabel = sprintf( __( '%s (Recommended)' ), recommendedValue );
 	const PHP82AllowedSites = [ 255633016 ];
 
@@ -18,12 +13,12 @@ export const getPHPVersions = ( siteId ) => {
 			disabled: ! PHP82AllowedSites.includes( siteId ?? 0 ), // EOL 31 December 2026
 		},
 		{
-			label: isPhp84Default ? '8.3' : recommendedLabel,
+			label: '8.3',
 			value: '8.3',
 			disabled: false, // EOL 31 December 2027
 		},
 		{
-			label: isPhp84Default ? recommendedLabel : '8.4',
+			label: recommendedLabel,
 			value: '8.4',
 			disabled: false, // EOL 31 December 2028
 		},


### PR DESCRIPTION
Part of DOTCOM-17393. Follow-up to #112863.

## Proposed Changes

* Make PHP 8.4 the recommended version for all sites in `getPHPVersions()`, replacing the previous 25% ramp (`siteId % 4` on sites newer than 251762970) where PHP 8.3 was the recommended version for everyone else. Effects across the consumers:
  * The "(Recommended)" label moves from 8.3 to 8.4 in the Multi-site Dashboard and classic Calypso PHP version dropdowns.
  * The **A4A site-creation modal** now pre-selects PHP 8.4 for new sites.
  * In the **MSD settings summary**, sites on PHP 8.3 now show a "warning" badge instead of "success", nudging them toward 8.4.

## Why are these changes being made?

* With PHP 8.2 retired from the selectors (#112863), PHP 8.4 is the version we want new and upgrading sites to land on, so the ramp logic is no longer needed.

## Testing Instructions

* Run the unit tests: `yarn test-client client/dashboard/sites/settings-php`
* On the live branch (https://calypso.live?branch=dotcom-17393-make-php-84-the-recommended-version), open **Hosting → Server Settings** for an Atomic site and verify the dropdown labels PHP 8.4 as "(Recommended)" and PHP 8.3 has no suffix.
* For the Multi-site Dashboard, run `yarn start-dashboard` and open `http://my.localhost:3000/sites/<site-slug>/settings/php` — same expectation. On the settings overview, a site on 8.3 shows a warning badge for PHP.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)