### PR TITLE
Marketplace: don't show a direct-access error for a slow handoff

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -167,15 +167,14 @@ const MarketplaceProductInstall = ( {
 		// 2. This is a marketplace plugin installation but the installation process hasn't started
 		( ! isPluginUploadFlow && ! marketplaceInstallationInProgress );
 
-	// Check that the site URL and the plugin slug are the same which were selected on the plugin page
+	// The state authorizing the install is handed off asynchronously, so only treat it as missing
+	// once it has stayed missing for 2s. Any change to the condition restarts the timer.
 	useEffect( () => {
-		if ( shouldShowNoDirectAccessError ) {
-			waitFor( 2 ).then( () => {
-				if ( shouldShowNoDirectAccessError ) {
-					setNoDirectAccessError( true );
-				}
-			} );
+		if ( ! shouldShowNoDirectAccessError ) {
+			return;
 		}
+		const id = setTimeout( () => setNoDirectAccessError( true ), 2000 );
+		return () => clearTimeout( id );
 	}, [ shouldShowNoDirectAccessError ] );
 
 	// Upload flow startup

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -61,13 +61,12 @@ import {
 } from 'calypso/state/ui/selectors';
 import './style.scss';
 import ThemeDirectInstall from './theme-direct-install';
+import { useDelayedCondition } from './use-delayed-condition';
 import useMarketplaceAdditionalSteps from './use-marketplace-additional-steps';
 import type { TranslateResult } from 'i18n-calypso';
 
-// Both the install authorization and the plan's feature list are handed off asynchronously; each
-// gets a grace period before the page concludes it is missing.
+// The state authorizing an install is handed off asynchronously, so allow for it arriving late.
 const INSTALL_HANDOFF_GRACE_PERIOD_MS = 2000;
-const PLAN_FEATURES_GRACE_PERIOD_MS = 2000;
 
 const MarketplaceProductInstall = ( {
 	pluginSlug = '',
@@ -85,7 +84,6 @@ const MarketplaceProductInstall = ( {
 	const installFlowInitiatedRef = useRef( false );
 	const [ atomicFlow, setAtomicFlow ] = useState( false );
 	const [ nonInstallablePlanError, setNonInstallablePlanError ] = useState( false );
-	const [ noDirectAccessError, setNoDirectAccessError ] = useState( false );
 	const [ userDirectInstallationAllowed, setUserDirectInstallationAllowed ] = useState( false );
 	// The signup "Get started" flow reaches this page via a full-page redirect, which drops the
 	// in-memory purchase-flow state that normally authorizes the install. When that redirect marks
@@ -162,10 +160,7 @@ const MarketplaceProductInstall = ( {
 		if ( hasAtomicFeature || isJetpackSelfHosted || nonInstallablePlanError ) {
 			return;
 		}
-		const id = setTimeout(
-			() => setNonInstallablePlanError( true ),
-			PLAN_FEATURES_GRACE_PERIOD_MS
-		);
+		const id = setTimeout( () => setNonInstallablePlanError( true ), 2000 );
 		return () => clearTimeout( id );
 	}, [ hasAtomicFeature, isJetpackSelfHosted, nonInstallablePlanError ] );
 
@@ -175,16 +170,11 @@ const MarketplaceProductInstall = ( {
 		// 2. This is a marketplace plugin installation but the installation process hasn't started
 		( ! isPluginUploadFlow && ! marketplaceInstallationInProgress );
 
-	// Only report the authorization missing once it has stayed missing for the whole grace period,
-	// and clear the error if it turns up afterwards so a later failure gets a fresh grace period.
-	useEffect( () => {
-		if ( ! isInstallAuthorizationMissing ) {
-			setNoDirectAccessError( false );
-			return;
-		}
-		const id = setTimeout( () => setNoDirectAccessError( true ), INSTALL_HANDOFF_GRACE_PERIOD_MS );
-		return () => clearTimeout( id );
-	}, [ isInstallAuthorizationMissing ] );
+	// Flows that carry their own authorization never render this error, so don't arm the timer.
+	const noDirectAccessError = useDelayedCondition(
+		isInstallAuthorizationMissing && ! directInstallationAllowed,
+		INSTALL_HANDOFF_GRACE_PERIOD_MS
+	);
 
 	// Upload flow startup
 	useEffect( () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -64,6 +64,11 @@ import ThemeDirectInstall from './theme-direct-install';
 import useMarketplaceAdditionalSteps from './use-marketplace-additional-steps';
 import type { TranslateResult } from 'i18n-calypso';
 
+// Both the install authorization and the plan's feature list are handed off asynchronously; each
+// gets a grace period before the page concludes it is missing.
+const INSTALL_HANDOFF_GRACE_PERIOD_MS = 2000;
+const PLAN_FEATURES_GRACE_PERIOD_MS = 2000;
+
 const MarketplaceProductInstall = ( {
 	pluginSlug = '',
 	themeSlug = '',
@@ -157,25 +162,29 @@ const MarketplaceProductInstall = ( {
 		if ( hasAtomicFeature || isJetpackSelfHosted || nonInstallablePlanError ) {
 			return;
 		}
-		const id = setTimeout( () => setNonInstallablePlanError( true ), 2000 );
+		const id = setTimeout(
+			() => setNonInstallablePlanError( true ),
+			PLAN_FEATURES_GRACE_PERIOD_MS
+		);
 		return () => clearTimeout( id );
 	}, [ hasAtomicFeature, isJetpackSelfHosted, nonInstallablePlanError ] );
 
-	const shouldShowNoDirectAccessError =
+	const isInstallAuthorizationMissing =
 		// 1. This is a plugin upload flow (via zip file) and we don't have a primary domain set
 		( isPluginUploadFlow && ! primaryDomain ) ||
 		// 2. This is a marketplace plugin installation but the installation process hasn't started
 		( ! isPluginUploadFlow && ! marketplaceInstallationInProgress );
 
-	// The state authorizing the install is handed off asynchronously, so only treat it as missing
-	// once it has stayed missing for 2s. Any change to the condition restarts the timer.
+	// Only report the authorization missing once it has stayed missing for the whole grace period,
+	// and clear the error if it turns up afterwards so a later failure gets a fresh grace period.
 	useEffect( () => {
-		if ( ! shouldShowNoDirectAccessError ) {
+		if ( ! isInstallAuthorizationMissing ) {
+			setNoDirectAccessError( false );
 			return;
 		}
-		const id = setTimeout( () => setNoDirectAccessError( true ), 2000 );
+		const id = setTimeout( () => setNoDirectAccessError( true ), INSTALL_HANDOFF_GRACE_PERIOD_MS );
 		return () => clearTimeout( id );
-	}, [ shouldShowNoDirectAccessError ] );
+	}, [ isInstallAuthorizationMissing ] );
 
 	// Upload flow startup
 	useEffect( () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-delayed-condition.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-delayed-condition.tsx
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook } from '@testing-library/react';
+import { useDelayedCondition } from '../use-delayed-condition';
+
+const DELAY = 2000;
+
+const renderDelayed = ( condition: boolean ) =>
+	renderHook( ( held: boolean ) => useDelayedCondition( held, DELAY ), {
+		initialProps: condition,
+	} );
+
+const advance = ( ms: number ) =>
+	act( () => {
+		jest.advanceTimersByTime( ms );
+	} );
+
+describe( 'useDelayedCondition', () => {
+	beforeEach( () => jest.useFakeTimers() );
+	afterEach( () => jest.useRealTimers() );
+
+	it( 'reports only once the condition has held for the whole delay', () => {
+		const { result } = renderDelayed( true );
+		expect( result.current ).toBe( false );
+
+		advance( DELAY - 1 );
+		expect( result.current ).toBe( false );
+
+		advance( 1 );
+		expect( result.current ).toBe( true );
+	} );
+
+	it( 'cancels the pending report when the condition clears first', () => {
+		const { result, rerender } = renderDelayed( true );
+		advance( DELAY - 1 );
+
+		rerender( false );
+		advance( DELAY );
+
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'stops reporting when the condition recovers after the delay has passed', () => {
+		const { result, rerender } = renderDelayed( true );
+		advance( DELAY );
+		expect( result.current ).toBe( true );
+
+		rerender( false );
+
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'gives a recurrence a fresh delay rather than reporting it at once', () => {
+		const { result, rerender } = renderDelayed( true );
+		advance( DELAY );
+		rerender( false );
+
+		rerender( true );
+		expect( result.current ).toBe( false );
+
+		advance( DELAY - 1 );
+		expect( result.current ).toBe( false );
+
+		advance( 1 );
+		expect( result.current ).toBe( true );
+	} );
+
+	it( 'leaves no pending timer behind on unmount', () => {
+		const { unmount } = renderDelayed( true );
+		expect( jest.getTimerCount() ).toBe( 1 );
+
+		unmount();
+
+		expect( jest.getTimerCount() ).toBe( 0 );
+	} );
+} );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-delayed-condition.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-delayed-condition.tsx
@@ -22,56 +22,40 @@ describe( 'useDelayedCondition', () => {
 
 	it( 'reports only once the condition has held for the whole delay', () => {
 		const { result } = renderDelayed( true );
-		expect( result.current ).toBe( false );
-
 		advance( DELAY - 1 );
 		expect( result.current ).toBe( false );
-
 		advance( 1 );
 		expect( result.current ).toBe( true );
 	} );
 
-	it( 'cancels the pending report when the condition clears first', () => {
+	it( 'cancels the pending report if the condition clears first', () => {
 		const { result, rerender } = renderDelayed( true );
 		advance( DELAY - 1 );
-
 		rerender( false );
 		advance( DELAY );
-
 		expect( result.current ).toBe( false );
 	} );
 
-	it( 'stops reporting when the condition recovers after the delay has passed', () => {
+	it( 'stops reporting when the condition clears after the delay', () => {
 		const { result, rerender } = renderDelayed( true );
 		advance( DELAY );
-		expect( result.current ).toBe( true );
-
 		rerender( false );
-
 		expect( result.current ).toBe( false );
 	} );
 
-	it( 'gives a recurrence a fresh delay rather than reporting it at once', () => {
+	it( 'makes a recurrence wait out a fresh delay', () => {
 		const { result, rerender } = renderDelayed( true );
 		advance( DELAY );
 		rerender( false );
-
 		rerender( true );
 		expect( result.current ).toBe( false );
-
-		advance( DELAY - 1 );
-		expect( result.current ).toBe( false );
-
-		advance( 1 );
+		advance( DELAY );
 		expect( result.current ).toBe( true );
 	} );
 
 	it( 'leaves no pending timer behind on unmount', () => {
 		const { unmount } = renderDelayed( true );
-		expect( jest.getTimerCount() ).toBe( 1 );
-
 		unmount();
-
 		expect( jest.getTimerCount() ).toBe( 0 );
 	} );
 } );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-delayed-condition.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-delayed-condition.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Reports a condition only once it has held continuously for `delayMs`, and goes back to false as
+ * soon as it stops holding — so a condition that recovers late is not latched, and a recurrence
+ * waits out a fresh delay rather than being reported at once.
+ */
+export function useDelayedCondition( condition: boolean, delayMs: number ): boolean {
+	const [ hasHeld, setHasHeld ] = useState( false );
+
+	useEffect( () => {
+		if ( ! condition ) {
+			setHasHeld( false );
+			return;
+		}
+		const id = setTimeout( () => setHasHeld( true ), delayMs );
+		return () => clearTimeout( id );
+	}, [ condition, delayMs ] );
+
+	return hasHeld;
+}


### PR DESCRIPTION
## Proposed Changes

* Wait out a grace period before showing the direct-access error, and clear it if authorization turns up late. The previous delay never re-evaluated anything, so the error appeared anyway and then latched.
* Move the delay into a small local hook, with unit coverage for cancellation, late recovery, re-arming, and unmount.
* Skip the timer entirely for flows that carry their own authorization, which never show this error.

## Why are these changes being made?

The state authorizing an install is handed off asynchronously. When it arrived slightly late, a perfectly normal install was told the page should not be accessed directly — and the error stayed even once authorization arrived.

## Testing Instructions

```
yarn test-client client/my-sites/marketplace/pages/marketplace-product-install/test/use-delayed-condition.tsx
```

The page itself has no coverage and I have not exercised it in a browser. To confirm manually: run a plugin install and a theme install through to the redirect, checking no error screen appears on the way; then visit an install URL directly with nothing in progress and confirm the error still appears after a short delay.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
