### PR TITLE
Masterbar: show site icon in the site menu

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -3,6 +3,7 @@ import config from '@automattic/calypso-config';
 import { isEcommercePlan } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { Badge } from '@automattic/ui';
+import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { parse } from 'qs';
@@ -13,6 +14,7 @@ import AsyncLoad from 'calypso/components/async-load';
 import Gravatar from 'calypso/components/gravatar';
 import { dashboardLink, wpcomLink } from 'calypso/dashboard/utils/link';
 import { navigate } from 'calypso/lib/navigate';
+import resizeImageUrl from 'calypso/lib/resize-image-url';
 import wpcom from 'calypso/lib/wp';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { preload } from 'calypso/sections-helper';
@@ -611,11 +613,25 @@ class MasterbarLoggedIn extends Component {
 			} );
 		}
 
+		const siteIconUrl = site?.icon?.img || site?.icon?.ico;
+		const hasSiteIcon = !! siteIconUrl;
+		const icon = hasSiteIcon ? (
+			<img
+				className="masterbar__item-site-icon"
+				src={ resizeImageUrl( siteIconUrl, 40 ) }
+				alt=""
+				width={ 20 }
+				height={ 20 }
+			/>
+		) : (
+			<span className="dashicons-before dashicons-admin-home" />
+		);
+
 		return (
 			<Item
-				className="masterbar__item-my-site"
+				className={ clsx( 'masterbar__item-my-site', { 'has-site-icon': hasSiteIcon } ) }
 				url={ siteUrl }
-				icon={ <span className="dashicons-before dashicons-admin-home" /> }
+				icon={ icon }
 				tipTarget="visit-site"
 				subItems={ [ menuItems ] }
 			>

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -231,6 +231,25 @@ body.is-mobile-app-view {
 		gap: 6px;
 	}
 
+	&.masterbar__item-my-site.has-site-icon {
+		gap: 6px;
+
+		.masterbar__item-site-icon {
+			width: 20px;
+			height: 20px;
+			border-radius: 2px;
+			background: var(--studio-white);
+		}
+
+		@media only screen and (max-width: 781px) {
+			.masterbar__item-site-icon {
+				width: 28px;
+				height: 28px;
+				border-radius: 4px;
+			}
+		}
+	}
+
 	@media only screen and (max-width: 781px) {
 		&.masterbar__item-my-site {
 			padding-left: inherit;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -238,7 +238,7 @@ body.is-mobile-app-view {
 			width: 20px;
 			height: 20px;
 			border-radius: 2px;
-			background: var(--studio-white);
+			background: #f0f0f1;
 		}
 
 		@media only screen and (max-width: 781px) {


### PR DESCRIPTION
Fixes DOTCOM-17788

## Proposed Changes

Gutenberg 23.6 shows the site icon in the admin bar if set (https://github.com/WordPress/gutenberg/pull/79807). This PR ports that logic to our masterbar component in Calypso.

## Testing Instructions

1. Upload a site icon to your site on Settings -> General.
1. Verify it shows up in both `my.localhost:3000/sites/:siteSlug` and `calypso.localhost:3000/home/:siteSlug`:

| Before | After |
| - | - |
|  <img width="327" height="83" alt="image" src="https://github.com/user-attachments/assets/5e816274-dd5f-43a6-82a9-b99e7302870d" /> | <img width="326" height="81" alt="image" src="https://github.com/user-attachments/assets/18d21b90-9c8c-4702-b90c-17064a180d71" /> |

3. Verify it looks the same as in wp-admin.
4. Verify it looks the same as in wp-admin in mobile viewport.
5. Remove the site icon; verify it shows the home dashicon back.

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
