### PR TITLE
Reader: keep sidebar mounted across stream ⇄ full-post navigation

### DIFF
--- a/client/reader/full-post/controller.jsx
+++ b/client/reader/full-post/controller.jsx
@@ -1,13 +1,10 @@
 import AsyncLoad from 'calypso/components/async-load';
 import { trackPageLoad } from 'calypso/reader/controller-helper';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 const loadReaderFullPost = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-blocks-reader-full-post" */ 'calypso/blocks/reader-full-post'
 	);
-const loadSidebar = () =>
-	import( /* webpackChunkName: "async-load-calypso-reader-sidebar" */ 'calypso/reader/sidebar' );
 
 const analyticsPageTitle = 'Reader';
 
@@ -19,7 +16,6 @@ const scrollTopIfNoHash = () =>
 	}, 0 );
 
 export function blogPost( context, next ) {
-	const state = context.store.getState();
 	const blogId = context.params.blog;
 	const postId = context.params.post;
 	const basePath = '/reader/blogs/:blog_id/posts/:post_id';
@@ -40,17 +36,11 @@ export function blogPost( context, next ) {
 		/>
 	);
 
-	if ( isUserLoggedIn( state ) ) {
-		context.secondary = (
-			<AsyncLoad require={ loadSidebar } path={ context.path } placeholder={ null } />
-		);
-	}
 	scrollTopIfNoHash();
 	next();
 }
 
 export function feedPost( context, next ) {
-	const state = context.store.getState();
 	const feedId = context.params.feed;
 	const postId = context.params.post;
 	const basePath = '/reader/feeds/:feed_id/posts/:feed_item_id';
@@ -61,12 +51,6 @@ export function feedPost( context, next ) {
 	context.primary = (
 		<AsyncLoad require={ loadReaderFullPost } feedId={ feedId } postId={ postId } />
 	);
-
-	if ( isUserLoggedIn( state ) ) {
-		context.secondary = (
-			<AsyncLoad require={ loadSidebar } path={ context.path } placeholder={ null } />
-		);
-	}
 
 	scrollTopIfNoHash();
 	next();

--- a/client/reader/full-post/index.js
+++ b/client/reader/full-post/index.js
@@ -1,5 +1,5 @@
 import { makeLayout, redirectLoggedOutToSignup, render as clientRender } from 'calypso/controller';
-import { blogDiscoveryByFeedId } from 'calypso/reader/controller';
+import { blogDiscoveryByFeedId, sidebar } from 'calypso/reader/controller';
 import { readerPage } from 'calypso/reader/lib/reader-router';
 import { blogPost, feedPost } from './controller';
 
@@ -9,6 +9,7 @@ export default function () {
 		'/reader/feeds/:feed/posts/:post',
 		blogDiscoveryByFeedId,
 		redirectLoggedOutToSignup,
+		sidebar,
 		feedPost,
 		makeLayout,
 		clientRender
@@ -18,6 +19,7 @@ export default function () {
 	readerPage(
 		'/reader/blogs/:blog/posts/:post',
 		redirectLoggedOutToSignup,
+		sidebar,
 		blogPost,
 		makeLayout,
 		clientRender


### PR DESCRIPTION
Fixes READ-615

## Proposed Changes

* Route the Reader full-post views (`/reader/feeds/:feed/posts/:post`, `/reader/blogs/:blog/posts/:post`) through the shared `sidebar` middleware from `calypso/reader/controller` instead of their own duplicate `loadSidebar`/`context.secondary` setup.
* Remove the now-unused duplicate `loadSidebar` import chunk and the `isUserLoggedIn` gate from `full-post/controller.jsx` (the shared middleware already applies the same logged-in gate and `path`).

## Why are these changes being made?

The left Reader sidebar visibly flashed when navigating from a stream into a post's full view and back. `AsyncLoad` memoizes its lazy component on the `require` prop's identity, and the full-post route passed a *different* `loadSidebar` function reference than every other Reader route — so crossing stream ⇄ full-post changed the sidebar's component type and forced a remount (blank `Suspense` placeholder = the flash). Sharing the single `sidebar` middleware gives every Reader route the same `require` reference, so React reconciles the sidebar in place instead of remounting it.

## Testing Instructions

### Scenario 1 - Sidebar stays stable navigating into a post:
- Go to `/reader`
- Click a post to open its full view (`/reader/feeds/:feed_id/posts/:post_id`)
- Check that the left sidebar (followed feeds list, unseen counts, scroll position) stays in place with no flash, blank frame, or list reflow during the transition

### Scenario 2 - Sidebar stays stable navigating back:
- From the full post view, navigate back to `/reader`
- Check that the left sidebar again stays stable with no flash or remount

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
