### PR TITLE
Marketplace: fix blank screen on the bare /marketplace path

### DIFF
--- a/client/my-sites/marketplace/controller.jsx
+++ b/client/my-sites/marketplace/controller.jsx
@@ -46,6 +46,10 @@ export function renderMarketplaceTestPage( context, next ) {
 	next();
 }
 
+export function redirectToPlugins() {
+	return page.redirect( '/plugins/browse/marketplace' );
+}
+
 export function redirectToHome( { path } ) {
 	const siteFragment = getSiteFragment( path );
 	if ( siteFragment ) {

--- a/client/my-sites/marketplace/index.js
+++ b/client/my-sites/marketplace/index.js
@@ -8,6 +8,7 @@ import {
 	renderPluginsInstallPage,
 	renderThemesInstallPage,
 	redirectToHome,
+	redirectToPlugins,
 	renderMarketplaceSignupSuccess,
 } from './controller';
 
@@ -53,6 +54,10 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
+
+	// The wildcard below requires a path segment after the slash, so the bare
+	// path needs its own route or it renders nothing at all.
+	page( '/marketplace', redirectToPlugins );
 
 	page( '/marketplace/*', redirectToHome );
 }


### PR DESCRIPTION
Fixes DOTCOM-18006

## Proposed Changes

* Register a route for the bare `/marketplace` path that redirects to `/plugins/browse/marketplace`, the marketplace category of the plugin browser.
* The section's existing catch-all, `page( '/marketplace/*', redirectToHome )`, compiles to a regexp that requires a path segment after the slash, so the bare path matched no route at all: Calypso loaded the section chunk, dispatched the path, found no handler, and left the boot placeholder (gray WordPress logo) on screen forever — no error, no redirect.

## Why are these changes being made?

* Anyone visiting the bare `/marketplace` URL gets a permanent blank screen. This has been the case since at least January 2025 — the bare path never had a handler; only subpaths did.
* `/plugins/browse/marketplace` is chosen over `/home` (what unknown subpaths get) because someone typing "marketplace" is looking for the browse surface, not their dashboard.

## Testing Instructions

* On the live branch (https://calypso.live?branch=dotcom-18006-fix-marketplace-bare-path-blank-screen), visit `/marketplace` while logged in → you should land on `/plugins/browse/marketplace` instead of a blank screen.
* Verify existing behavior is unchanged: `/marketplace/foo` still redirects to `/home` (site selector), and `/marketplace/thank-you/:site`, `/marketplace/plugin/:slug/install/:site` still work.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
