### PR TITLE
Domain bundles: share one metadata request and offer inline bundles on FQDN queries

### DIFF
--- a/packages/api-core/src/domain-suggestions/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/domain-suggestions/__tests__/fetchers.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock';
-import { fetchBundleForDomain, fetchBundleSuggestion, fetchBundleTriggers } from '..';
+import { fetchBundleForDomain, fetchBundleMetadata } from '..';
 import type { BundleSuggestion } from '../types';
 
 const BASE = 'https://public-api.wordpress.com';
@@ -31,22 +31,26 @@ const bundleSuggestion: BundleSuggestion = {
 	catalogue_version: '1',
 };
 
-describe( 'fetchBundleSuggestion', () => {
+describe( 'fetchBundleMetadata', () => {
 	afterEach( () => nock.cleanAll() );
 
-	it( 'requests /domains/suggestions with with_bundles=1 and returns the bundle portion', async () => {
+	it( 'requests /domains/suggestions with with_bundles=1 and returns both bundle fields', async () => {
 		const scope = nock( BASE )
 			.get( '/rest/v1.1/domains/suggestions' )
 			.query( ( query ) => query.with_bundles === '1' && query.query === 'example' )
 			.reply( 200, {
 				domain_suggestions: [],
 				bundle_suggestion: bundleSuggestion,
+				bundle_triggers: [ 'com' ],
 			} );
 
-		const bundle = await fetchBundleSuggestion( 'example' );
+		const metadata = await fetchBundleMetadata( 'example' );
 
 		expect( scope.isDone() ).toBe( true );
-		expect( bundle ).toEqual( bundleSuggestion );
+		expect( metadata ).toEqual( {
+			bundle_suggestion: bundleSuggestion,
+			bundle_triggers: [ 'com' ],
+		} );
 	} );
 
 	it( 'lowercases the query before sending it', async () => {
@@ -56,49 +60,23 @@ describe( 'fetchBundleSuggestion', () => {
 			.reply( 200, {
 				domain_suggestions: [],
 				bundle_suggestion: bundleSuggestion,
-			} );
-
-		await fetchBundleSuggestion( 'MyBrand.com' );
-
-		expect( scope.isDone() ).toBe( true );
-	} );
-
-	it( 'returns null when the response carries no bundle suggestion', async () => {
-		nock( BASE ).get( '/rest/v1.1/domains/suggestions' ).query( true ).reply( 200, {
-			domain_suggestions: [],
-			bundle_suggestion: null,
-		} );
-
-		expect( await fetchBundleSuggestion( 'example' ) ).toBeNull();
-	} );
-} );
-
-describe( 'fetchBundleTriggers', () => {
-	afterEach( () => nock.cleanAll() );
-
-	it( 'requests with_bundles=1 and returns the bundle_triggers list', async () => {
-		const scope = nock( BASE )
-			.get( '/rest/v1.1/domains/suggestions' )
-			.query( ( query ) => query.with_bundles === '1' && query.query === 'example' )
-			.reply( 200, {
-				domain_suggestions: [],
-				bundle_suggestion: null,
 				bundle_triggers: [ 'com' ],
 			} );
 
-		const triggers = await fetchBundleTriggers( 'example' );
+		await fetchBundleMetadata( 'MyBrand.com' );
 
 		expect( scope.isDone() ).toBe( true );
-		expect( triggers ).toEqual( [ 'com' ] );
 	} );
 
-	it( 'returns an empty array when the response carries no triggers', async () => {
+	it( 'normalises a missing bundle suggestion to null and missing triggers to []', async () => {
 		nock( BASE ).get( '/rest/v1.1/domains/suggestions' ).query( true ).reply( 200, {
 			domain_suggestions: [],
-			bundle_suggestion: null,
 		} );
 
-		expect( await fetchBundleTriggers( 'example' ) ).toEqual( [] );
+		expect( await fetchBundleMetadata( 'example' ) ).toEqual( {
+			bundle_suggestion: null,
+			bundle_triggers: [],
+		} );
 	} );
 } );
 

--- a/packages/api-core/src/domain-suggestions/fetchers.ts
+++ b/packages/api-core/src/domain-suggestions/fetchers.ts
@@ -1,5 +1,6 @@
 import { wpcom } from '../wpcom-fetcher';
 import type {
+	BundleMetadata,
 	BundleSuggestion,
 	DomainSuggestion,
 	DomainSuggestionQuery,
@@ -76,19 +77,27 @@ export async function fetchAvailableTlds( search?: string, vendor?: string ): Pr
 }
 
 /**
- * Fetch a bundle suggestion for a search query.
+ * Fetch the bundle metadata for a search query.
  *
- * Calls the `with_bundles=1` opt-in on `/domains/suggestions` (DOMAINS-2166),
- * which wraps the response as `{ domain_suggestions, bundle_suggestion }`. We
- * only need the `bundle_suggestion` portion here. The backend gates the bundle
- * on its own feature flag and returns `null` when no bundle applies; the
- * frontend `domain-bundling` flag additionally gates whether this fetcher runs
- * at all (see the `bundleSuggestionQuery` consumer).
+ * Calls the `with_bundles=1` opt-in on `/domains/suggestions` (DOMAINS-2166 /
+ * DOMAINS-2207), which wraps the response as
+ * `{ domain_suggestions, bundle_suggestion, bundle_triggers }`. We return the
+ * two bundle fields together so a single request serves both consumers:
+ * `bundle_suggestion` powers the top `BundleCard` on an FQDN query, while
+ * `bundle_triggers` is the cheap catalogue of TLDs (currently just `com`) that
+ * offer an inline bundle when added to the cart. The backend gates each field
+ * on its own feature flag and omits it when nothing applies; this fetcher
+ * normalises a missing suggestion to `null` and missing triggers to `[]`. The
+ * frontend `domain-bundling` flag additionally gates whether the query runs at
+ * all (see the `bundleMetadataQuery` consumers).
  * @param search The domain search query (an SLD or FQDN).
- * @returns A bundle suggestion, or null when no bundle applies.
+ * @returns The bundle suggestion (or null) and the trigger TLDs (or []).
  */
-export async function fetchBundleSuggestion( search: string ): Promise< BundleSuggestion | null > {
-	const response: { bundle_suggestion?: BundleSuggestion | null } = await wpcom.req.get(
+export async function fetchBundleMetadata( search: string ): Promise< BundleMetadata > {
+	const response: {
+		bundle_suggestion?: BundleSuggestion | null;
+		bundle_triggers?: string[];
+	} = await wpcom.req.get(
 		{
 			apiVersion: '1.1',
 			path: '/domains/suggestions',
@@ -100,34 +109,10 @@ export async function fetchBundleSuggestion( search: string ): Promise< BundleSu
 		}
 	);
 
-	return response.bundle_suggestion ?? null;
-}
-
-/**
- * Fetch the inline-bundle trigger TLDs for a search query.
- *
- * Reads the `bundle_triggers` field off the same `with_bundles=1` opt-in on
- * `/domains/suggestions` (DOMAINS-2207). This is a cheap, catalogue-only list of
- * the TLDs (currently just `com`) that, when added to the cart from a bare-term
- * search, offer an inline bundle. The backend returns `[]` when the discounts
- * flag is off; this fetcher normalises a missing field to `[]` as well.
- * @param search The bare-term domain search query.
- * @returns The trigger TLDs, or an empty array when no triggers apply.
- */
-export async function fetchBundleTriggers( search: string ): Promise< string[] > {
-	const response: { bundle_triggers?: string[] } = await wpcom.req.get(
-		{
-			apiVersion: '1.1',
-			path: '/domains/suggestions',
-		},
-		{
-			query: search.trim().toLocaleLowerCase(),
-			vendor: 'variation2_front',
-			with_bundles: 1,
-		}
-	);
-
-	return response.bundle_triggers ?? [];
+	return {
+		bundle_suggestion: response.bundle_suggestion ?? null,
+		bundle_triggers: response.bundle_triggers ?? [],
+	};
 }
 
 /**

--- a/packages/api-core/src/domain-suggestions/types.ts
+++ b/packages/api-core/src/domain-suggestions/types.ts
@@ -323,3 +323,15 @@ export interface BundleSuggestion {
 	 */
 	catalogue_version: string;
 }
+
+/**
+ * The bundle-related portion of the `with_bundles=1` `/domains/suggestions`
+ * response, normalised for the frontend. Both fields come from the same
+ * request: `bundle_suggestion` powers the top `BundleCard` on an FQDN query,
+ * `bundle_triggers` is the catalogue of TLDs that offer an inline bundle on
+ * cart-add. Fetched together so a single query serves both consumers.
+ */
+export interface BundleMetadata {
+	bundle_suggestion: BundleSuggestion | null;
+	bundle_triggers: string[];
+}

--- a/packages/api-queries/src/domains.ts
+++ b/packages/api-queries/src/domains.ts
@@ -58,14 +58,19 @@ export const bundleMetadataQuery = ( query: string ) =>
 		meta: { persist: false },
 	} );
 
+// Module-level selectors so React Query sees a stable `select` reference across
+// renders instead of a fresh closure per call.
+const selectBundleSuggestion = ( data: BundleMetadata ) => data.bundle_suggestion;
+const selectBundleTriggers = ( data: BundleMetadata ) => data.bundle_triggers;
+
 export const bundleSuggestionQuery = ( query: string ) => ( {
 	...bundleMetadataQuery( query ),
-	select: ( data: BundleMetadata ) => data.bundle_suggestion,
+	select: selectBundleSuggestion,
 } );
 
 export const bundleTriggersQuery = ( query: string ) => ( {
 	...bundleMetadataQuery( query ),
-	select: ( data: BundleMetadata ) => data.bundle_triggers,
+	select: selectBundleTriggers,
 } );
 
 export const bundleForDomainQuery = ( fqdn: string ) =>

--- a/packages/api-queries/src/domains.ts
+++ b/packages/api-queries/src/domains.ts
@@ -7,11 +7,11 @@ import {
 	fetchAvailableTlds,
 	fetchBulkDomainUpdateStatus,
 	fetchBundleForDomain,
-	fetchBundleSuggestion,
-	fetchBundleTriggers,
+	fetchBundleMetadata,
 	fetchDomains,
 	fetchDomainSuggestions,
 	fetchFreeDomainSuggestion,
+	type BundleMetadata,
 	type FetchDomainsOptions,
 	type JobStatus,
 	type DomainSuggestionQuery,
@@ -45,19 +45,28 @@ export const freeSuggestionQuery = (
 		meta: { persist: false },
 	} );
 
-export const bundleSuggestionQuery = ( query: string ) =>
+// One request, two typed views. `bundle_suggestion` (top BundleCard) and
+// `bundle_triggers` (inline-bundle catalogue) both come from the same
+// `with_bundles=1` `/domains/suggestions` call, so they share a query key and
+// React Query dedupes them to a single network request even when both consumers
+// are enabled on the same query. The two exports below spread this query and add
+// a `select` picking their half of the response.
+export const bundleMetadataQuery = ( query: string ) =>
 	queryOptions( {
-		queryKey: [ 'bundle-suggestion', query ],
-		queryFn: () => fetchBundleSuggestion( query ),
+		queryKey: [ 'domain-bundle-metadata', query ],
+		queryFn: () => fetchBundleMetadata( query ),
 		meta: { persist: false },
 	} );
 
-export const bundleTriggersQuery = ( query: string ) =>
-	queryOptions( {
-		queryKey: [ 'bundle-triggers', query ],
-		queryFn: () => fetchBundleTriggers( query ),
-		meta: { persist: false },
-	} );
+export const bundleSuggestionQuery = ( query: string ) => ( {
+	...bundleMetadataQuery( query ),
+	select: ( data: BundleMetadata ) => data.bundle_suggestion,
+} );
+
+export const bundleTriggersQuery = ( query: string ) => ( {
+	...bundleMetadataQuery( query ),
+	select: ( data: BundleMetadata ) => data.bundle_triggers,
+} );
 
 export const bundleForDomainQuery = ( fqdn: string ) =>
 	queryOptions( {

--- a/packages/domain-search/src/hooks/test/bundle-metadata-shared-request.tsx
+++ b/packages/domain-search/src/hooks/test/bundle-metadata-shared-request.tsx
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { buildAvailability } from '../../test-helpers/factories/availability';
+import { mockGetAvailabilityQuery } from '../../test-helpers/queries/availability';
+import { mockGetSuggestionsQuery } from '../../test-helpers/queries/suggestions';
+import { queryClient, TestDomainSearch } from '../../test-helpers/renderer';
+import { useInlineBundles } from '../use-inline-bundles';
+import { useSuggestionsList } from '../use-suggestions-list';
+import type { BundleSuggestion } from '@automattic/api-core';
+
+const TEST_BUNDLE: BundleSuggestion = {
+	sld: 'flowers',
+	domains: [
+		{ domain: 'flowers.com', cost: '$22.00', raw_price: 22, product_slug: 'domain_reg' },
+		{ domain: 'flowers.net', cost: '$18.00', raw_price: 18, product_slug: 'domain_reg' },
+	],
+	bundle_price: 36,
+	original_price: 44,
+	discount_percent: 18,
+	category: 'business',
+	bundle_id: 'flowers-bundle',
+	bundle_group_id: 'v1.flowers.deadbeef',
+	catalogue_version: '1',
+};
+
+describe( 'bundle metadata shared request', () => {
+	afterEach( () => {
+		nock.cleanAll();
+		queryClient.clear();
+	} );
+
+	// Regression (DOMAINS-2225, case 5): after the FQDN gate was relaxed, both the
+	// top BundleCard (bundleSuggestion) and the inline-bundle catalogue
+	// (bundleTriggers) are enabled on an FQDN query. They share the
+	// `domain-bundle-metadata` query key, so React Query must dedupe the
+	// underlying `with_bundles=1` `/domains/suggestions` request to a single call.
+	it( 'issues the with_bundles request once for both bundleSuggestion and bundleTriggers', async () => {
+		mockGetSuggestionsQuery( { params: { query: 'flowers.com' }, suggestions: [] } );
+		mockGetAvailabilityQuery( {
+			params: { domainName: 'flowers.com' },
+			availability: buildAvailability( { domain_name: 'flowers.com' } ),
+		} );
+
+		let withBundlesCallCount = 0;
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/domains/suggestions' )
+			.query( { vendor: 'variation2_front', with_bundles: 1, query: 'flowers.com' } )
+			.reply( 200, () => {
+				withBundlesCallCount++;
+				return { bundle_suggestion: TEST_BUNDLE, bundle_triggers: [ 'com' ] };
+			} );
+
+		const { result } = renderHook(
+			() => ( {
+				suggestions: useSuggestionsList(),
+				inline: useInlineBundles(),
+			} ),
+			{
+				wrapper: ( { children } ) => (
+					<TestDomainSearch query="flowers.com" config={ { showBundleSuggestions: true } }>
+						{ children }
+					</TestDomainSearch>
+				),
+			}
+		);
+
+		await waitFor( () => {
+			expect( result.current.suggestions.bundleSuggestion ).toBeTruthy();
+			expect( result.current.inline.bundleTriggers ).toEqual( [ 'com' ] );
+		} );
+
+		expect( result.current.suggestions.bundleSuggestion?.sld ).toBe( 'flowers' );
+		expect( withBundlesCallCount ).toBe( 1 );
+	} );
+} );

--- a/packages/domain-search/src/hooks/test/use-inline-bundles.tsx
+++ b/packages/domain-search/src/hooks/test/use-inline-bundles.tsx
@@ -67,6 +67,8 @@ describe( 'useInlineBundles', () => {
 		queryClient.clear();
 	} );
 
+	// Regression (DOMAINS-2225, case 4): a bare-term search with a trigger in the
+	// cart keeps its existing inline behavior after the FQDN gate was relaxed.
 	it( 'fetches a bundle for a cart item whose TLD is a trigger', async () => {
 		mockGetBundleTriggersQuery( { params: { query: 'flowers' }, bundleTriggers: [ 'com' ] } );
 		mockGetBundleForDomainQuery( { fqdn: 'flowers.com', bundleSuggestion: BUNDLE_FOR_FLOWERS } );
@@ -95,14 +97,22 @@ describe( 'useInlineBundles', () => {
 		expect( result.current.getInlineBundle( 'flowers.net' ) ).toBeUndefined();
 	} );
 
-	it( 'is gated to bare-term searches: an FQDN query never fetches triggers or bundles', async () => {
+	// Regression (DOMAINS-2225, case 2): the FQDN gate was removed. Typing a
+	// non-trigger FQDN (flowers.net) and adding a trigger domain (flowers.com)
+	// to the cart must still offer that trigger's inline bundle.
+	it( 'offers an inline bundle for a trigger in the cart even on an FQDN query', async () => {
+		mockGetBundleTriggersQuery( { params: { query: 'flowers.net' }, bundleTriggers: [ 'com' ] } );
+		mockGetBundleForDomainQuery( { fqdn: 'flowers.com', bundleSuggestion: BUNDLE_FOR_FLOWERS } );
+
 		const { result } = renderUseInlineBundles( {
-			query: 'flowers.com',
+			query: 'flowers.net',
 			cart: { items: [ buildCartItem( { domain: 'flowers', tld: 'com' } ) ] },
 		} );
 
-		await waitFor( () => expect( result.current.bundleTriggers ).toEqual( [] ) );
-		expect( result.current.getInlineBundle( 'flowers.com' ) ).toBeUndefined();
+		await waitFor( () =>
+			expect( result.current.getInlineBundle( 'flowers.com' )?.bundle ).toBeTruthy()
+		);
+		expect( result.current.bundleTriggers ).toEqual( [ 'com' ] );
 	} );
 
 	it( 'is gated on the bundle flag: nothing is fetched when showBundleSuggestions is off', async () => {

--- a/packages/domain-search/src/hooks/use-inline-bundles.ts
+++ b/packages/domain-search/src/hooks/use-inline-bundles.ts
@@ -1,6 +1,5 @@
 import { useQueries, useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import { isFqdnQuery } from '../helpers';
 import { useDomainSearch } from '../page/context';
 import type { BundleSuggestion } from '@automattic/api-core';
 
@@ -19,19 +18,23 @@ export interface InlineBundleEntry {
 /**
  * Drives the inline bundle rows shown beneath trigger-domain suggestions.
  *
- * Inline bundles only apply to a bare-term search (no TLD in the query) and only
- * when the `domain-bundling` flag is on (surfaced as `config.showBundleSuggestions`).
- * When enabled it reads the cheap `bundle_triggers` catalogue list, then, for
- * every cart item whose TLD is a trigger, lazily fetches that FQDN's bundle from
- * the per-FQDN `/domains/bundle` (v2) endpoint. Each FQDN is fetched at most once
- * and cached. Consumers look up a domain's bundle via `getInlineBundle`.
+ * Inline bundles apply whenever the `domain-bundling` flag is on (surfaced as
+ * `config.showBundleSuggestions`), for both bare-term and FQDN queries:
+ * selecting a trigger domain (e.g. `flowers.com`) should offer its bundle even
+ * when the user typed a full domain. When enabled it reads the cheap
+ * `bundle_triggers` catalogue list, then, for every cart item whose TLD is a
+ * trigger, lazily fetches that FQDN's bundle from the per-FQDN `/domains/bundle`
+ * (v2) endpoint. Each FQDN is fetched at most once and cached. Consumers look up
+ * a domain's bundle via `getInlineBundle`.
  */
 export const useInlineBundles = () => {
 	const { query, queries, config, cart } = useDomainSearch();
 
-	// An FQDN search keeps the top BundleCard path, so inline bundles are gated
-	// to bare-term queries (see isFqdnQuery, shared with useSuggestionsList).
-	const inlineBundlesEnabled = config.showBundleSuggestions && ! isFqdnQuery( query );
+	// Gated on the domain-bundling flag only. An FQDN query is included: its
+	// bundleTriggers request shares a query key with useSuggestionsList's
+	// bundleSuggestion (see api-queries domains.ts), so the two dedupe to one
+	// network request rather than duplicating the same URL.
+	const inlineBundlesEnabled = config.showBundleSuggestions;
 
 	const { data: bundleTriggers = [] } = useQuery( {
 		...queries.bundleTriggers( query ),

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -43,10 +43,12 @@ export const useSuggestionsList = () => {
 		enabled: config.skippable && ! isFqdn,
 	} );
 
-	// The top bundle card is the FQDN path only: a bare-term search shows inline
+	// The top bundle card is the FQDN path: a bare-term search shows inline
 	// bundle rows instead (see useInlineBundles), and the backend returns no
-	// bundle_suggestion for a bare term anyway. Gating on isFqdnQuery keeps this
-	// request from duplicating the bare-term bundleTriggers request (same URL).
+	// bundle_suggestion for a bare term anyway, so this query stays gated to
+	// FQDN queries. It shares a query key with useInlineBundles' bundleTriggers
+	// (see api-queries domains.ts), so the two dedupe to a single request even
+	// when both are enabled on the same FQDN query.
 	// Still gated behind the frontend `domain-bundling` flag (config.showBundleSuggestions).
 	const { data: bundleSuggestion } = useQuery( {
 		...queries.bundleSuggestion( query ),

--- a/packages/domain-search/src/test-helpers/queries/suggestions.ts
+++ b/packages/domain-search/src/test-helpers/queries/suggestions.ts
@@ -36,12 +36,20 @@ export const mockGetSuggestionsQuery = ( {
 	return request.reply( 200, suggestions );
 };
 
-export const mockGetBundleSuggestionQuery = ( {
+// `bundle_suggestion` and `bundle_triggers` come back on ONE shared
+// `with_bundles=1` request (see bundleMetadataQuery), so composing
+// mockGetBundleSuggestionQuery + mockGetBundleTriggersQuery for the same query
+// does NOT work — only the first-registered nock interceptor is consumed and
+// the other half of the payload is silently absent. When a test needs both
+// fields on the same query, use this combined helper instead.
+export const mockGetBundleMetadataQuery = ( {
 	params,
-	bundleSuggestion,
+	bundleSuggestion = null,
+	bundleTriggers = [],
 }: {
 	params: Partial< DomainSuggestionQuery >;
-	bundleSuggestion: BundleSuggestion | null;
+	bundleSuggestion?: BundleSuggestion | null;
+	bundleTriggers?: string[];
 } ) => {
 	return nock( 'https://public-api.wordpress.com' )
 		.get( '/rest/v1.1/domains/suggestions' )
@@ -50,7 +58,17 @@ export const mockGetBundleSuggestionQuery = ( {
 			with_bundles: 1,
 			...params,
 		} )
-		.reply( 200, { bundle_suggestion: bundleSuggestion } );
+		.reply( 200, { bundle_suggestion: bundleSuggestion, bundle_triggers: bundleTriggers } );
+};
+
+export const mockGetBundleSuggestionQuery = ( {
+	params,
+	bundleSuggestion,
+}: {
+	params: Partial< DomainSuggestionQuery >;
+	bundleSuggestion: BundleSuggestion | null;
+} ) => {
+	return mockGetBundleMetadataQuery( { params, bundleSuggestion } );
 };
 
 export const mockGetBundleTriggersQuery = ( {
@@ -60,14 +78,7 @@ export const mockGetBundleTriggersQuery = ( {
 	params: Partial< DomainSuggestionQuery >;
 	bundleTriggers: string[];
 } ) => {
-	return nock( 'https://public-api.wordpress.com' )
-		.get( '/rest/v1.1/domains/suggestions' )
-		.query( {
-			vendor: 'variation2_front',
-			with_bundles: 1,
-			...params,
-		} )
-		.reply( 200, { bundle_triggers: bundleTriggers } );
+	return mockGetBundleMetadataQuery( { params, bundleTriggers } );
 };
 
 export const mockGetBundleForDomainQuery = ( {


### PR DESCRIPTION
Related to #DOMAINS-2225

Part one of two: this PR makes the inline-bundle data path selection-driven regardless of query shape; a follow-up PR (stacked on this one) renders inline offers for triggers promoted into the featured section.

## Proposed Changes

* Replace `fetchBundleSuggestion` and `fetchBundleTriggers` with a single `fetchBundleMetadata( search )` in `@automattic/api-core`, returning `{ bundle_suggestion, bundle_triggers }` from the same `with_bundles=1` request.
* Add `bundleMetadataQuery` in `@automattic/api-queries` on a single query key; `bundleSuggestionQuery` and `bundleTriggersQuery` become thin wrappers that spread it and `select` their half of the response. React Query dedupes on the shared key, so both consumers on the same query produce one network request. The `domain-search` context (`page/types.ts`, `page/context.ts`) is unchanged.
* Relax the inline-bundle gate in `useInlineBundles` from `config.showBundleSuggestions && ! isFqdnQuery( query )` to the flag alone. Previously, typing an FQDN (e.g. `flowers.net`) and then selecting a trigger domain (`flowers.com`) from the results list surfaced no bundle offer, because the inline path was disabled purely by the query's shape.

## Why are these changes being made?

A bundle should be offered when the user selects a trigger domain and adds it to their cart, whatever they typed. Today the inline path is gated to bare-term queries, so an FQDN search never offers a bundle for a selected trigger. That gate existed partly to avoid duplicating the `with_bundles=1` request the top bundle card already makes on FQDN queries; sharing one query key removes that duplication, which makes the gate safe to drop.

## Testing Instructions

This and #112881 can be tested simultaneously by testing #112881.

* With a sandbox serving `bundle_triggers: [ 'com' ]`, search an FQDN that is not a trigger (e.g. `flowers.net`), then add `flowers.com` from the results list to the cart. The inline bundle offer renders beneath it (previously nothing appeared).
* Bare-term searches behave as before (inline offer beneath a trigger in the regular list once it is in the cart).
* In the network panel, an FQDN search issues the `with_bundles=1` `/domains/suggestions` request once, not twice.

Inline bundle offer once a `com` trigger is added to the cart (searched `markbiekflowershop2026`, added the `.com`) — the `.com + .net + .blog` bundle renders inline via the shared-metadata path:

<img width="900" alt="Inline bundle offer rendered for a selected .com trigger" src="https://github.com/user-attachments/assets/085b7e80-6ebd-416c-9b27-0c55184bb052" />

<details>
<summary>Verification run</summary>

```
yarn tsc --build packages/tsconfig.json   # clean
yarn test-packages packages/domain-search packages/api-core/src/domain-suggestions packages/api-queries
# Test Suites: 54 passed, 54 total
# Tests:       977 passed, 977 total
```

New tests: FQDN non-trigger query still offers an inline bundle for a selected trigger; bare-term behavior preserved; shared-key dedup asserts the `with_bundles=1` request fires exactly once when both consumers are enabled.
</details>

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?

Co-Authored-By: Claude <noreply@anthropic.com>
