### PR TITLE
Domain bundles: render inline offers for featured triggers, with placement analytics

### DIFF
--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-events.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-events.ts
@@ -224,16 +224,18 @@ export const useWPCOMDomainSearchEvents = ( {
 					)
 				);
 			},
-			onBundleShown: ( bundle ) => {
+			onBundleShown: ( bundle, placement ) => {
 				recordTracksEvent( 'calypso_domain_bundle_shown', {
 					domain_bundle_group_id: bundle.bundle_group_id,
 					domain_count: bundle.domains.length,
+					placement,
 				} );
 			},
-			onBundleAddToCart: ( bundle ) => {
+			onBundleAddToCart: ( bundle, placement ) => {
 				recordTracksEvent( 'calypso_domain_bundle_accepted', {
 					domain_bundle_group_id: bundle.bundle_group_id,
 					domain_count: bundle.domains.length,
+					placement,
 				} );
 			},
 		};

--- a/packages/domain-search/src/components/inline-bundle-row/index.tsx
+++ b/packages/domain-search/src/components/inline-bundle-row/index.tsx
@@ -9,6 +9,8 @@ import {
 import { sprintf } from '@wordpress/i18n';
 import { arrowRight, Icon, lockOutline, plus } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import { useEffect } from 'react';
+import { getBundlePrimaryDomain } from '../../helpers/get-bundle-primary-domain';
 import { getTld } from '../../helpers/get-tld';
 import { useIsCurrentMutation } from '../../hooks/use-is-current-mutation';
 import { useDomainSearch } from '../../page/context';
@@ -57,11 +59,34 @@ export const InlineBundleRow = ( { bundle, isLoading }: InlineBundleRowProps ) =
 			await cart.onAddBundle( bundleToAdd );
 		},
 		onSuccess: ( _result, bundleToAdd ) => {
-			events.onBundleAddToCart( bundleToAdd );
+			events.onBundleAddToCart( bundleToAdd, 'inline' );
 		},
 		networkMode: 'always',
 		retry: false,
 	} );
+
+	// Fire `onBundleShown` once per distinct inline bundle that actually renders.
+	// Keyed on the group id so a new bundle (different trigger) re-fires while
+	// re-renders of the same bundle do not. The guard mirrors the render
+	// conditions below (loaded, has members, and offers at least one companion),
+	// so a loading or empty row never counts as shown. Mirrors the top-card
+	// `shownBundleGroupId` pattern in results.tsx.
+	const shownBundleGroupId =
+		! isLoading &&
+		bundle &&
+		bundle.domains.length > 0 &&
+		bundle.domains.some( ( domain ) => domain.domain !== getBundlePrimaryDomain( bundle ).domain )
+			? bundle.bundle_group_id
+			: undefined;
+
+	useEffect( () => {
+		if ( shownBundleGroupId && bundle ) {
+			events.onBundleShown( bundle, 'inline' );
+		}
+		// Intentionally keyed only on the group id: exactly one event per bundle that
+		// appears, not one per render or per `events`/object identity change.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ shownBundleGroupId ] );
 
 	if ( isLoading ) {
 		return (
@@ -82,8 +107,7 @@ export const InlineBundleRow = ( { bundle, isLoading }: InlineBundleRowProps ) =
 
 	// The line leads with the added (primary) domain in full, then the companion
 	// extensions the bundle adds: `thalasso.world + .info + .vip`.
-	const primary =
-		bundle.domains.find( ( domain ) => domain.role === 'primary' ) ?? bundle.domains[ 0 ];
+	const primary = getBundlePrimaryDomain( bundle );
 	const companions = bundle.domains.filter( ( domain ) => domain.domain !== primary.domain );
 
 	if ( companions.length === 0 ) {

--- a/packages/domain-search/src/components/search-results/index.tsx
+++ b/packages/domain-search/src/components/search-results/index.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useState } from 'react';
-import { useInlineBundles } from '../../hooks/use-inline-bundles';
 import { useDomainSearch } from '../../page/context';
 import {
 	DomainSuggestionsList,
@@ -9,16 +8,18 @@ import {
 import { InlineBundleRow } from '../inline-bundle-row';
 import { SearchResultsItem } from './item';
 import { SearchResultsPlaceholder } from './placeholder';
+import type { InlineBundleEntry } from '../../hooks/use-inline-bundles';
 
 const SearchResults = ( {
 	suggestions,
 	numberOfInitialVisibleSuggestions,
+	getInlineBundle,
 }: {
 	suggestions: string[];
 	numberOfInitialVisibleSuggestions?: number;
+	getInlineBundle: ( fqdn: string ) => InlineBundleEntry | undefined;
 } ) => {
 	const { filter, resetFilter, events, config } = useDomainSearch();
-	const { getInlineBundle } = useInlineBundles();
 	const [ numberOfVisibleSuggestions, setnumberOfVisibleSuggestions ] = useState(
 		numberOfInitialVisibleSuggestions ?? config.numberOfDomainsResultsPerPage
 	);

--- a/packages/domain-search/src/components/search-results/test/index.tsx
+++ b/packages/domain-search/src/components/search-results/test/index.tsx
@@ -19,7 +19,10 @@ describe( 'SearchResults', () => {
 
 		render(
 			<TestDomainSearchWithSuggestions query="test">
-				<SearchResults suggestions={ [ 'test-regular.com', 'test-regular.net' ] } />
+				<SearchResults
+					suggestions={ [ 'test-regular.com', 'test-regular.net' ] }
+					getInlineBundle={ () => undefined }
+				/>
 			</TestDomainSearchWithSuggestions>
 		);
 
@@ -35,7 +38,7 @@ describe( 'SearchResults', () => {
 
 		const { container } = render(
 			<TestDomainSearchWithSuggestions query="test-no-suggestions">
-				<SearchResults suggestions={ [] } />
+				<SearchResults suggestions={ [] } getInlineBundle={ () => undefined } />
 			</TestDomainSearchWithSuggestions>
 		);
 
@@ -61,7 +64,7 @@ describe( 'SearchResults', () => {
 		render(
 			<TestDomainSearchWithSuggestions query="test-no-suggestions" events={ { onFilterReset } }>
 				<Filter />
-				<SearchResults suggestions={ [] } />
+				<SearchResults suggestions={ [] } getInlineBundle={ () => undefined } />
 			</TestDomainSearchWithSuggestions>
 		);
 
@@ -102,7 +105,7 @@ describe( 'SearchResults', () => {
 		render(
 			<TestDomainSearchWithSuggestions query="test-no-suggestions" events={ { onFilterReset } }>
 				<Filter />
-				<SearchResults suggestions={ [] } />
+				<SearchResults suggestions={ [] } getInlineBundle={ () => undefined } />
 			</TestDomainSearchWithSuggestions>
 		);
 

--- a/packages/domain-search/src/helpers/get-bundle-primary-domain.ts
+++ b/packages/domain-search/src/helpers/get-bundle-primary-domain.ts
@@ -1,0 +1,12 @@
+import type { BundleSuggestion, BundleSuggestionDomain } from '@automattic/api-core';
+
+/**
+ * Resolve a bundle's primary (anchor) member. Prefers the domain explicitly
+ * tagged `role: 'primary'` and falls back to the first member, since `role` is
+ * optional on `BundleSuggestionDomain` and older bundles omit it. Callers that
+ * reach this with a non-empty `domains` array always get a member back; an
+ * empty bundle yields `undefined` (mirroring `domains[ 0 ]`).
+ */
+export function getBundlePrimaryDomain( bundle: BundleSuggestion ): BundleSuggestionDomain {
+	return bundle.domains.find( ( domain ) => domain.role === 'primary' ) ?? bundle.domains[ 0 ];
+}

--- a/packages/domain-search/src/helpers/index.ts
+++ b/packages/domain-search/src/helpers/index.ts
@@ -1,3 +1,4 @@
+export { getBundlePrimaryDomain } from './get-bundle-primary-domain';
 export { getRootDomain } from './get-root-domain';
 export { getTld } from './get-tld';
 export { isFqdnQuery } from './is-fqdn-query';

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -184,11 +184,23 @@ export const ResultsPage = () => {
 			// only when a currently-visible top BundleCard already resolves to that
 			// same primary — never merely because it matches the typed query, so a
 			// withheld/absent top card still leaves the inline offer visible.
-			const primaryFqdn = inlineBundle.bundle
-				? getBundlePrimaryDomain( inlineBundle.bundle ).domain.toLowerCase()
-				: suggestion.toLowerCase();
+			const primaryFqdn =
+				inlineBundle.bundle && inlineBundle.bundle.domains.length > 0
+					? getBundlePrimaryDomain( inlineBundle.bundle ).domain.toLowerCase()
+					: suggestion.toLowerCase();
 
 			if ( visibleBundlePrimaryFqdn && primaryFqdn === visibleBundlePrimaryFqdn ) {
+				return null;
+			}
+
+			// InlineBundleRow renders nothing for a resolved bundle without at least
+			// one companion beyond the primary, so drop the entry here too — otherwise
+			// the role="list" wrapper below would render with no listitem children.
+			if (
+				! inlineBundle.isLoading &&
+				inlineBundle.bundle &&
+				! inlineBundle.bundle.domains.some( ( { domain } ) => domain.toLowerCase() !== primaryFqdn )
+			) {
 				return null;
 			}
 

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -6,17 +6,20 @@ import { useEffect, useState } from 'react';
 import { BundleCard } from '../components/bundle-card';
 import { Cart } from '../components/cart';
 import { FeaturedSearchResults } from '../components/featured-search-results';
+import { InlineBundleRow } from '../components/inline-bundle-row';
 import { SearchBar } from '../components/search-bar';
 import { SearchNotice } from '../components/search-notice';
 import { SearchResults } from '../components/search-results';
 import { SkipSuggestion } from '../components/skip-suggestion';
 import { UnavailableSearchResult } from '../components/unavailable-search-result';
-import { isFqdnQuery } from '../helpers';
+import { getBundlePrimaryDomain, isFqdnQuery } from '../helpers';
+import { useInlineBundles } from '../hooks/use-inline-bundles';
 import { useIsCurrentMutation } from '../hooks/use-is-current-mutation';
 import { useRequestTracking } from '../hooks/use-request-tracking';
 import { useSuggestionsList } from '../hooks/use-suggestions-list';
 import { DOMAIN_BUNDLE_UNAVAILABLE_ERROR_CODE } from './constants';
 import { useDomainSearch } from './context';
+import type { InlineBundleEntry } from '../hooks/use-inline-bundles';
 import type { BundleSuggestion } from '@automattic/api-core';
 
 const hasErrorCode = ( error: unknown, code: string ) =>
@@ -98,7 +101,7 @@ export const ResultsPage = () => {
 		},
 		onSuccess: ( { wasAdded }, { bundle } ) => {
 			if ( wasAdded ) {
-				events.onBundleAddToCart( bundle );
+				events.onBundleAddToCart( bundle, 'card' );
 			}
 		},
 		networkMode: 'always',
@@ -144,6 +147,10 @@ export const ResultsPage = () => {
 		regularSuggestions,
 		bundleSuggestion,
 	} = useSuggestionsList();
+	// Hoisted here (rather than called inside SearchResults) so the featured-trigger
+	// inline rows and the regular-list inline rows share a single hook instance,
+	// and thus one set of bundle requests.
+	const { getInlineBundle } = useInlineBundles();
 	// The top BundleCard is the FQDN path only; a bare-term search shows inline
 	// bundle rows beneath trigger suggestions instead (see useInlineBundles).
 	const isFqdn = isFqdnQuery( query );
@@ -153,6 +160,41 @@ export const ResultsPage = () => {
 	const visibleBundleSuggestion = isFqdn ? bundleSuggestion : undefined;
 	const numberOfInitialVisibleSuggestions =
 		config.numberOfDomainsResultsPerPage - featuredSuggestions.length;
+
+	// A trigger domain promoted into the featured section (e.g. the bare-term
+	// search `example` surfaces `example.com` as a featured card) still needs its
+	// inline bundle offer, which the regular list would otherwise own. Derive one
+	// row per featured trigger that has (or is fetching) a bundle, rendered below
+	// the featured section.
+	const visibleBundlePrimaryFqdn =
+		visibleBundleSuggestion && visibleBundleSuggestion.domains.length > 0
+			? getBundlePrimaryDomain( visibleBundleSuggestion ).domain.toLowerCase()
+			: undefined;
+
+	const featuredInlineBundles = featuredSuggestions
+		.map( ( { suggestion } ) => {
+			const inlineBundle = getInlineBundle( suggestion );
+
+			if ( ! inlineBundle || ( ! inlineBundle.isLoading && ! inlineBundle.bundle ) ) {
+				return null;
+			}
+
+			// A per-FQDN bundle's primary is the trigger itself, so the featured
+			// suggestion string is the inline offer's primary FQDN. Suppress the row
+			// only when a currently-visible top BundleCard already resolves to that
+			// same primary — never merely because it matches the typed query, so a
+			// withheld/absent top card still leaves the inline offer visible.
+			const primaryFqdn = inlineBundle.bundle
+				? getBundlePrimaryDomain( inlineBundle.bundle ).domain.toLowerCase()
+				: suggestion.toLowerCase();
+
+			if ( visibleBundlePrimaryFqdn && primaryFqdn === visibleBundlePrimaryFqdn ) {
+				return null;
+			}
+
+			return { key: primaryFqdn, entry: inlineBundle };
+		} )
+		.filter( ( item ): item is { key: string; entry: InlineBundleEntry } => item !== null );
 
 	useRequestTracking();
 
@@ -166,7 +208,7 @@ export const ResultsPage = () => {
 
 	useEffect( () => {
 		if ( shownBundleGroupId && visibleBundleSuggestion ) {
-			events.onBundleShown( visibleBundleSuggestion );
+			events.onBundleShown( visibleBundleSuggestion, 'card' );
 		}
 		// Intentionally keyed only on the group id: we want exactly one event per
 		// bundle that appears, not one per render or per `events`/object identity change.
@@ -229,12 +271,24 @@ export const ResultsPage = () => {
 						) }
 					</FeaturedSearchResults>
 				) }
+				{ /* Inline bundle offers for triggers promoted into the featured section.
+				     Rendered full-width below the section (not inside FeaturedDomainSuggestionsList,
+				     which is a row-direction Flex) in a minimal role="list" wrapper so each
+				     row's role="listitem" has a valid parent. */ }
+				{ ! isLoadingSuggestions && featuredInlineBundles.length > 0 && (
+					<div role="list" className="domain-search--results__featured-inline-bundles">
+						{ featuredInlineBundles.map( ( { key, entry } ) => (
+							<InlineBundleRow key={ key } bundle={ entry.bundle } isLoading={ entry.isLoading } />
+						) ) }
+					</div>
+				) }
 				{ isLoadingSuggestions ? (
 					<SearchResults.Placeholder />
 				) : (
 					<SearchResults
 						suggestions={ regularSuggestions }
 						numberOfInitialVisibleSuggestions={ numberOfInitialVisibleSuggestions }
+						getInlineBundle={ getInlineBundle }
 					/>
 				) }
 			</VStack>

--- a/packages/domain-search/src/page/style.scss
+++ b/packages/domain-search/src/page/style.scss
@@ -84,6 +84,15 @@
 	}
 }
 
+// Inline bundle offers for featured triggers, stacked full-width below the
+// featured section. The row chrome (border/radius/padding) is self-contained in
+// .inline-bundle-row; this wrapper only supplies the gap between multiple rows.
+.domain-search--results__featured-inline-bundles {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
 // The in-flow SearchBar and in-flow promo card are the desktop affordances. On
 // mobile, the persistent fixed overlay below replaces both, so we hide these
 // in-flow nodes via CSS rather than unmounting them — keeping desktop markup

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -1483,6 +1483,97 @@ describe( 'ResultsPage', () => {
 			expect( await screen.findByTitle( 'flowers.com' ) ).toBeInTheDocument();
 			expect( screen.queryByRole( 'button', { name: 'Get bundle' } ) ).not.toBeInTheDocument();
 		} );
+
+		it( 'renders an inline bundle row below the featured section for a featured trigger in the cart', async () => {
+			// flowers.com is the first suggestion, so it is promoted to the featured
+			// section (Recommended) rather than the regular list. Its inline offer must
+			// still render — full-width in the featured-inline wrapper below the cards.
+			mockGetSuggestionsQuery( {
+				params: { query: 'flowers' },
+				suggestions: [
+					buildSuggestion( { domain_name: 'flowers.com' } ),
+					buildSuggestion( { domain_name: 'flowers.io' } ),
+					buildSuggestion( { domain_name: 'flowers.co' } ),
+				],
+			} );
+			mockGetBundleTriggersQuery( { params: { query: 'flowers' }, bundleTriggers: [ 'com' ] } );
+			mockGetBundleForDomainQuery( { fqdn: 'flowers.com', bundleSuggestion: flowersBundle } );
+
+			const { container } = render(
+				<TestDomainSearch
+					cart={ buildCart( {
+						items: [ buildCartItem( { domain: 'flowers', tld: 'com' } ) ],
+					} ) }
+					config={ { showBundleSuggestions: true } }
+					query="flowers"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			// flowers.com leads the suggestions, so it is promoted into the featured
+			// section rather than the regular list.
+			expect( await screen.findByTitle( 'flowers.com' ) ).toBeInTheDocument();
+
+			// The offer renders once, inside the featured-inline wrapper below the
+			// featured cards — never duplicated into the regular suggestions list.
+			expect( await screen.findByRole( 'button', { name: 'Get bundle' } ) ).toBeInTheDocument();
+			const featuredInlineWrapper = container.querySelector(
+				'.domain-search--results__featured-inline-bundles'
+			);
+			expect( featuredInlineWrapper ).not.toBeNull();
+			expect( featuredInlineWrapper?.querySelector( '.inline-bundle-row' ) ).not.toBeNull();
+			expect( screen.getByText( '.net' ) ).toBeInTheDocument();
+			expect( container.querySelectorAll( '.inline-bundle-row' ) ).toHaveLength( 1 );
+			expect( container.querySelector( '.domain-suggestions-list .inline-bundle-row' ) ).toBeNull();
+		} );
+
+		it( 'shows only the top BundleCard and no duplicate inline row for a FQDN trigger', async () => {
+			// NOTE: on this trunk-based branch the inline path is still FQDN-gated, so
+			// no inline row renders for an FQDN query at all. Once PR 1 relaxes that
+			// gate beneath this branch, the inline path also runs for FQDN queries and
+			// this test then exercises the featured de-dup: the top card and the inline
+			// offer share the flowers.com primary, so the inline row is suppressed. The
+			// assertion (no `.inline-bundle-row`, top card present) holds in both worlds.
+			mockGetAvailabilityQuery( {
+				params: { domainName: 'flowers.com' },
+				availability: buildAvailability( {
+					domain_name: 'flowers.com',
+					status: DomainAvailabilityStatus.AVAILABLE,
+				} ),
+			} );
+			mockGetSuggestionsQuery( {
+				params: { query: 'flowers.com' },
+				suggestions: [ buildSuggestion( { domain_name: 'flowers.com' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'flowers.com' },
+				bundleSuggestion: flowersBundle,
+			} );
+			// Mocked for the post-rebase (gate-relaxed) world; unconsumed on this branch.
+			mockGetBundleTriggersQuery( { params: { query: 'flowers.com' }, bundleTriggers: [ 'com' ] } );
+			mockGetBundleForDomainQuery( { fqdn: 'flowers.com', bundleSuggestion: flowersBundle } );
+
+			const { container } = render(
+				<TestDomainSearch
+					cart={ buildCart( {
+						items: [ buildCartItem( { domain: 'flowers', tld: 'com' } ) ],
+					} ) }
+					config={ { showBundleSuggestions: true } }
+					query="flowers.com"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			// The top BundleCard is the single offer...
+			expect( await findBundleMember( 'flowers.net' ) ).toBeInTheDocument();
+			// ...with no inline row duplicating the flowers.com primary.
+			expect( container.querySelector( '.inline-bundle-row' ) ).toBeNull();
+			expect(
+				container.querySelector( '.domain-search--results__featured-inline-bundles' )
+			).toBeNull();
+		} );
 	} );
 
 	describe( 'tracking', () => {
@@ -1579,7 +1670,8 @@ describe( 'ResultsPage', () => {
 					domains: expect.arrayContaining( [
 						expect.objectContaining( { domain: 'bundle-shown.com' } ),
 					] ),
-				} )
+				} ),
+				'card'
 			);
 		} );
 
@@ -1599,6 +1691,79 @@ describe( 'ResultsPage', () => {
 
 			expect( await screen.findByTitle( 'bundle-off.com' ) ).toBeInTheDocument();
 			expect( onBundleShown ).not.toHaveBeenCalled();
+		} );
+
+		it( 'fires the onBundleShown event with placement "card" for the top bundle card', async () => {
+			const onBundleShown = jest.fn();
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'bundle-card-shown.com' },
+				suggestions: [ buildSuggestion( { domain_name: 'bundle-card-shown.com' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'bundle-card-shown.com' },
+				bundleSuggestion: buildBundleSuggestion( 'bundle-card-shown' ),
+			} );
+
+			render(
+				<TestDomainSearch
+					events={ { onBundleShown } }
+					config={ { showBundleSuggestions: true } }
+					query="bundle-card-shown.com"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			await waitFor( () => {
+				expect( onBundleShown ).toHaveBeenCalledTimes( 1 );
+			} );
+			expect( onBundleShown ).toHaveBeenCalledWith(
+				expect.objectContaining( { bundle_group_id: 'mock-bundle-card-shown-group' } ),
+				'card'
+			);
+		} );
+
+		it( 'fires the onBundleShown event with placement "inline" once per rendered inline bundle', async () => {
+			const onBundleShown = jest.fn();
+
+			// petals.com leads the list, so it is promoted to the featured section and
+			// its inline offer is the featured-inline row (the Phase 3 path). A domain
+			// distinct from the other inline tests avoids sharing their cached bundle.
+			mockGetSuggestionsQuery( {
+				params: { query: 'petals' },
+				suggestions: [
+					buildSuggestion( { domain_name: 'petals.com' } ),
+					buildSuggestion( { domain_name: 'petals.io' } ),
+					buildSuggestion( { domain_name: 'petals.co' } ),
+				],
+			} );
+			mockGetBundleTriggersQuery( { params: { query: 'petals' }, bundleTriggers: [ 'com' ] } );
+			mockGetBundleForDomainQuery( {
+				fqdn: 'petals.com',
+				bundleSuggestion: buildBundleSuggestion( 'petals' ),
+			} );
+
+			render(
+				<TestDomainSearch
+					cart={ buildCart( {
+						items: [ buildCartItem( { domain: 'petals', tld: 'com' } ) ],
+					} ) }
+					events={ { onBundleShown } }
+					config={ { showBundleSuggestions: true } }
+					query="petals"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			await waitFor( () => {
+				expect( onBundleShown ).toHaveBeenCalledTimes( 1 );
+			} );
+			expect( onBundleShown ).toHaveBeenCalledWith(
+				expect.objectContaining( { bundle_group_id: 'mock-petals-group' } ),
+				'inline'
+			);
 		} );
 
 		it( 'fires the onBundleAddToCart event after the bundle add succeeds', async () => {
@@ -1645,7 +1810,8 @@ describe( 'ResultsPage', () => {
 				expect( onBundleAddToCart ).toHaveBeenCalledTimes( 1 );
 			} );
 			expect( onBundleAddToCart ).toHaveBeenCalledWith(
-				expect.objectContaining( { bundle_group_id: 'mock-bundle-accept-group' } )
+				expect.objectContaining( { bundle_group_id: 'mock-bundle-accept-group' } ),
+				'card'
 			);
 		} );
 

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -1529,12 +1529,10 @@ describe( 'ResultsPage', () => {
 		} );
 
 		it( 'shows only the top BundleCard and no duplicate inline row for a FQDN trigger', async () => {
-			// NOTE: on this trunk-based branch the inline path is still FQDN-gated, so
-			// no inline row renders for an FQDN query at all. Once PR 1 relaxes that
-			// gate beneath this branch, the inline path also runs for FQDN queries and
-			// this test then exercises the featured de-dup: the top card and the inline
-			// offer share the flowers.com primary, so the inline row is suppressed. The
-			// assertion (no `.inline-bundle-row`, top card present) holds in both worlds.
+			// The inline path runs for FQDN queries too (the base branch relaxed the
+			// FQDN gate), so this test exercises the featured de-dup: the top card and
+			// the inline offer share the flowers.com primary, so the inline row is
+			// suppressed in favor of the card.
 			mockGetAvailabilityQuery( {
 				params: { domainName: 'flowers.com' },
 				availability: buildAvailability( {
@@ -1550,7 +1548,6 @@ describe( 'ResultsPage', () => {
 				params: { query: 'flowers.com' },
 				bundleSuggestion: flowersBundle,
 			} );
-			// Mocked for the post-rebase (gate-relaxed) world; unconsumed on this branch.
 			mockGetBundleTriggersQuery( { params: { query: 'flowers.com' }, bundleTriggers: [ 'com' ] } );
 			mockGetBundleForDomainQuery( { fqdn: 'flowers.com', bundleSuggestion: flowersBundle } );
 

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -108,9 +108,19 @@ export interface DomainSearchEvents {
 	onTrademarkClaimsNoticeAccepted: ( suggestion: ReturnType< typeof useSuggestion > ) => void;
 	onTrademarkClaimsNoticeClosed: ( suggestion: ReturnType< typeof useSuggestion > ) => void;
 	onPageView: () => void;
-	onBundleShown: ( bundle: BundleSuggestion ) => void;
-	onBundleAddToCart: ( bundle: BundleSuggestion ) => void;
+	/**
+	 * A bundle offer became visible. `placement` distinguishes the top featured
+	 * `BundleCard` (`'card'`) from an inline row beneath a trigger suggestion
+	 * (`'inline'`) so the shown → accepted funnel can segment by surface.
+	 */
+	onBundleShown: ( bundle: BundleSuggestion, placement: BundlePlacement ) => void;
+	onBundleAddToCart: ( bundle: BundleSuggestion, placement: BundlePlacement ) => void;
 }
+
+/**
+ * Where a bundle offer is surfaced: the top featured card or an inline row.
+ */
+export type BundlePlacement = 'card' | 'inline';
 
 export interface DomainSearchConfig {
 	vendor: DomainSuggestionQueryVendor;


### PR DESCRIPTION
Related to #DOMAINS-2225

Part two of two, stacked on #112880 (the base branch of this PR). Together they close the gap where a bundle was only offered when the user typed the trigger domain as a full FQDN.

## Proposed Changes

When entering a `.com` FQDN search, the normal bundle top-card is displayed. When entering a bare search term, then adding `.com` to the cart, the user will see the inline bundle card. Make sure that the in-line bundle card doesn't duplicate the top card. Updated analytics to show which bundle card was displayed.

## Testing Instructions

Note that testing this PR also tests https://github.com/Automattic/wp-calypso/pull/112880. See #112880 for a screenshot of the inline-bundle.

* Search a bare term (e.g. `flowers`) with bundling enabled; `flowers.com` appears as a featured card. Add it to the cart: the inline bundle offer renders below the featured section (previously nothing appeared).
* Type the trigger FQDN (`flowers.com`) directly: the top bundle card remains the only offer — no duplicate inline row for the same primary domain.
* Verify `calypso_domain_bundle_shown` fires with `placement: 'inline'` for the inline row and `placement: 'card'` for the top card; same for `calypso_domain_bundle_accepted` on add.

<details>
<summary>Verification run (on this stacked branch)</summary>

```
yarn tsc --build packages/tsconfig.json   # clean
yarn test-packages packages/domain-search packages/api-core/src/domain-suggestions packages/api-queries
# Test Suites: 54 passed, 54 total
# Tests:       981 passed, 981 total
```

New tests: featured trigger renders the inline offer below the featured section; FQDN trigger query keeps the top card as the only offer (exercises the de-dup against the relaxed gate from the base PR); shown event fires once per rendered inline bundle with the correct placement.
</details>

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?

Co-Authored-By: Claude <noreply@anthropic.com>
