### PR TITLE
Help Center: add v1 contextual CTA components (banner + link-list item)

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -12,6 +12,7 @@ const storybookConfig = storybookDefaultConfig( {
 
 		'../packages/design-picker/src/**/*.stories.{ts,tsx}',
 		'../packages/domains-table/src/**/*.stories.{js,jsx,ts,tsx}',
+		'../packages/help-center/src/**/*.stories.{js,jsx,ts,tsx}',
 	],
 	webpackAliases: { calypso: path.join( __dirname, '../client' ) },
 	sassPrelude: `@use 'calypso/assets/stylesheets/shared/_utils.scss' as *;`,

--- a/packages/help-center/package.json
+++ b/packages/help-center/package.json
@@ -41,6 +41,7 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
+		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/odie-client": "workspace:^",

--- a/packages/help-center/src/components/_variables.scss
+++ b/packages/help-center/src/components/_variables.scss
@@ -21,3 +21,5 @@ $help-center-z-index-focused: $overlay-panel-z-index-focused;
 $help-center-blue: #3858e9;
 $help-center-notice-background: #FDF7E9;
 $help-center-notice-color: #644B1C;
+$help-center-cta-banner-background: color-mix(in srgb, var(--color-surface) 94%, $help-center-blue);
+$help-center-cta-banner-border: color-mix(in srgb, var(--color-surface) 76%, $help-center-blue);

--- a/packages/help-center/src/components/help-center-cta.scss
+++ b/packages/help-center/src/components/help-center-cta.scss
@@ -1,0 +1,56 @@
+@import "@wordpress/base-styles/colors";
+@import "variables";
+
+.help-center-cta__banner {
+	background-color: $help-center-cta-banner-background;
+	border: 1px solid $help-center-cta-banner-border;
+	border-radius: 4px;
+	padding: 8px 16px;
+
+	.help-center-cta__title {
+		margin: 0 0 4px;
+	}
+
+	.help-center-cta__description {
+		margin: 0 0 8px;
+		color: $gray-700;
+	}
+
+	.help-center-cta__action {
+		color: $help-center-blue;
+		font-weight: 500;
+		text-decoration: none;
+
+		&:hover {
+			text-decoration: underline;
+		}
+
+		&:focus-visible {
+			outline: $help-center-blue solid 2px;
+			outline-offset: 2px;
+		}
+	}
+}
+
+.help-center-cta__resource-item {
+	.help-center-link__cell a svg:first-child {
+		fill: $help-center-blue;
+	}
+
+	.help-center-cta__resource-title {
+		display: block;
+		font-weight: 600;
+	}
+
+	.help-center-cta__resource-description {
+		display: block;
+		color: $gray-700;
+		font-size: $font-body-extra-small;
+		font-weight: normal;
+	}
+
+	.help-center-link__cell a:focus {
+		outline: $help-center-blue solid 2px;
+		outline-offset: -2px;
+	}
+}

--- a/packages/help-center/src/components/help-center-cta.scss
+++ b/packages/help-center/src/components/help-center-cta.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 @import "@wordpress/base-styles/colors";
 @import "variables";
 
@@ -6,6 +7,7 @@
 	border: 1px solid $help-center-cta-banner-border;
 	border-radius: 4px;
 	padding: 8px 16px;
+	font-size: $font-body-small;
 
 	.help-center-cta__title {
 		margin: 0 0 4px;
@@ -45,7 +47,9 @@
 	.help-center-cta__resource-description {
 		display: block;
 		color: $gray-700;
-		font-size: $font-body-extra-small;
+		// Parent link text is $font-body-small; rescale so this computes to
+		// $font-body-extra-small of the panel root instead of compounding.
+		font-size: math.div($font-body-extra-small, $font-body-small) * 1em;
 		font-weight: normal;
 	}
 

--- a/packages/help-center/src/components/help-center-cta.stories.scss
+++ b/packages/help-center/src/components/help-center-cta.stories.scss
@@ -1,0 +1,48 @@
+@import "@wordpress/base-styles/colors";
+@import "variables";
+
+/**
+ * Storybook-only chrome for HelpCenterCTA: mocks the Help Center home panel
+ * so the CTA reads in context, without pulling in the real (store/router
+ * dependent) container, header, or search components.
+ */
+.help-center.help-center-cta-stories {
+	font-size: 16px;
+}
+
+.help-center-cta-stories__panel {
+	position: static;
+	width: 410px;
+	max-height: none;
+	height: auto;
+	margin: 24px auto;
+	border-radius: 16px;
+	box-shadow: 0 2px 12px rgba( 0, 0, 0, 0.15 );
+	overflow: hidden;
+
+	.help-center__container-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 9px 16px;
+		gap: 8px;
+	}
+}
+
+.help-center-cta-stories__header-actions {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	flex-shrink: 0;
+}
+
+.help-center-cta-stories__search {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	border: 1px solid var(--studio-gray-10);
+	border-radius: 4px;
+	padding: 8px 12px;
+	color: $gray-700;
+	font-size: $font-body-small;
+}

--- a/packages/help-center/src/components/help-center-cta.stories.tsx
+++ b/packages/help-center/src/components/help-center-cta.stories.tsx
@@ -1,0 +1,125 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+import { localizeUrl } from '@automattic/i18n-utils';
+import { Meta, StoryObj } from '@storybook/react';
+import { close, external, lineSolid, page, video, Icon } from '@wordpress/icons';
+import { HelpCenterCTA } from './help-center-cta';
+import type { ComponentProps, ReactNode } from 'react';
+import './help-center-header.scss';
+import './help-center-search.scss';
+import './help-center-more-resources.scss';
+import './help-center-cta.stories.scss';
+
+const meta: Meta< typeof HelpCenterCTA > = {
+	title: 'packages/help-center/HelpCenterCTA',
+	component: HelpCenterCTA,
+	tags: [ 'autodocs' ],
+};
+
+export default meta;
+
+type Story = StoryObj< typeof HelpCenterCTA >;
+
+const sampleArgs = {
+	ctaId: 'onboarding-call-v1',
+	placement: 'help-center-home',
+	url: 'https://calendly.example.com/onboarding',
+	title: 'Get set up with a free onboarding call',
+	description: 'Talk one-on-one with a Happiness Engineer and get your new site off the ground.',
+};
+
+const StaticResourceRow = ( {
+	icon,
+	label,
+	href,
+}: {
+	icon: ComponentProps< typeof Icon >[ 'icon' ];
+	label: string;
+	href: string;
+} ) => (
+	<li className="help-center-more-resources__resource-item help-center-link__item">
+		<div className="help-center-more-resources__resource-cell help-center-link__cell">
+			<a href={ href } target="_blank" rel="noreferrer">
+				<Icon icon={ icon } size={ 24 } />
+				<span>{ label }</span>
+				<Icon icon={ external } size={ 20 } />
+			</a>
+		</div>
+	</li>
+);
+
+const PanelChrome = ( {
+	children,
+	moreResourcesLeadItem,
+}: {
+	children?: ReactNode;
+	moreResourcesLeadItem?: ReactNode;
+} ) => (
+	<div className="help-center help-center-cta-stories">
+		<div className="help-center__container help-center-cta-stories__panel">
+			<div className="help-center__container-header">
+				<span className="help-center-header__text">Help Center</span>
+				<span className="help-center-cta-stories__header-actions">
+					<Icon icon={ lineSolid } size={ 20 } />
+					<Icon icon={ close } size={ 20 } />
+				</span>
+			</div>
+			<div className="help-center__container-content">
+				<div className="inline-help__search">
+					{ children }
+					<div className="help-center-cta-stories__search">
+						<span>Search guides…</span>
+					</div>
+					<div className="help-center-more-resources">
+						<h3 className="help-center__section-title">More resources</h3>
+						<ul>
+							{ moreResourcesLeadItem }
+							<StaticResourceRow
+								icon={ page }
+								label="Support guides"
+								href={ localizeUrl( 'https://wordpress.com/support/' ) }
+							/>
+							<StaticResourceRow
+								icon={ video }
+								label="Courses"
+								href={ localizeUrl( 'https://wordpress.com/support/courses' ) }
+							/>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+);
+
+export const Banner: Story = {
+	args: {
+		...sampleArgs,
+		variant: 'banner',
+		actionLabel: 'Book your free call',
+	},
+	render: ( args ) => (
+		<PanelChrome>
+			<HelpCenterCTA { ...args } />
+		</PanelChrome>
+	),
+};
+
+export const BannerWithoutAction: Story = {
+	args: {
+		...sampleArgs,
+		variant: 'banner',
+	},
+	render: ( args ) => (
+		<PanelChrome>
+			<HelpCenterCTA { ...args } />
+		</PanelChrome>
+	),
+};
+
+export const LinkListItem: Story = {
+	args: {
+		...sampleArgs,
+		variant: 'link-list-item',
+	},
+	render: ( args ) => <PanelChrome moreResourcesLeadItem={ <HelpCenterCTA { ...args } /> } />,
+};

--- a/packages/help-center/src/components/help-center-cta.tsx
+++ b/packages/help-center/src/components/help-center-cta.tsx
@@ -1,0 +1,82 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { calendar, external, Icon } from '@wordpress/icons';
+import { useEffect } from 'react';
+import './help-center-cta.scss';
+
+export type HelpCenterCTAVariant = 'banner' | 'link-list-item';
+
+export interface HelpCenterCTAProps {
+	variant: HelpCenterCTAVariant;
+	ctaId: string;
+	placement: string;
+	url: string;
+	title: string;
+	description?: string;
+	actionLabel?: string;
+}
+
+export const HelpCenterCTA: React.FC< HelpCenterCTAProps > = ( {
+	variant,
+	ctaId,
+	placement,
+	url,
+	title,
+	description,
+	actionLabel,
+} ) => {
+	useEffect( () => {
+		recordTracksEvent( 'calypso_helpcenter_cta_impression', {
+			cta_id: ctaId,
+			variant,
+			placement,
+		} );
+	}, [ ctaId, variant, placement ] );
+
+	const trackClick = () => {
+		recordTracksEvent( 'calypso_helpcenter_cta_click', {
+			cta_id: ctaId,
+			variant,
+			placement,
+		} );
+	};
+
+	if ( variant === 'link-list-item' ) {
+		return (
+			<li className="help-center-cta__resource-item help-center-link__item">
+				<div className="help-center-link__cell">
+					<a href={ url } target="_blank" rel="noreferrer" onClick={ trackClick }>
+						<Icon icon={ calendar } size={ 24 } />
+						<span>
+							<span className="help-center-cta__resource-title">{ title }</span>
+							{ description && (
+								<span className="help-center-cta__resource-description">{ description }</span>
+							) }
+						</span>
+						<Icon icon={ external } size={ 20 } />
+					</a>
+				</div>
+			</li>
+		);
+	}
+
+	return (
+		<div className="help-center-cta__banner">
+			<p className="help-center-cta__title">
+				<strong>{ title }</strong>
+			</p>
+			{ description && <p className="help-center-cta__description">{ description }</p> }
+			{ actionLabel && (
+				<a
+					className="help-center-cta__action"
+					href={ url }
+					target="_blank"
+					rel="noreferrer"
+					onClick={ trackClick }
+				>
+					{ actionLabel }
+				</a>
+			) }
+		</div>
+	);
+};

--- a/packages/help-center/src/components/help-center-cta.tsx
+++ b/packages/help-center/src/components/help-center-cta.tsx
@@ -31,7 +31,8 @@ export const HelpCenterCTA: React.FC< HelpCenterCTAProps > = ( {
 			variant,
 			placement,
 		} );
-	}, [ ctaId, variant, placement ] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 
 	const trackClick = () => {
 		recordTracksEvent( 'calypso_helpcenter_cta_click', {

--- a/packages/help-center/src/components/test/help-center-cta.tsx
+++ b/packages/help-center/src/components/test/help-center-cta.tsx
@@ -1,0 +1,156 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { HelpCenterCTA } from '../help-center-cta';
+
+const mockRecordTracksEvent = jest.fn();
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: ( ...args: unknown[] ) => mockRecordTracksEvent( ...args ),
+} ) );
+
+const baseProps = {
+	ctaId: 'onboarding-call-v1',
+	placement: 'help-center-home',
+	url: 'https://calendly.example.com/onboarding',
+	title: 'Get set up with a free onboarding call',
+	description: 'Talk one-on-one with a Happiness Engineer and get your new site off the ground.',
+};
+
+describe( 'HelpCenterCTA', () => {
+	afterEach( () => {
+		mockRecordTracksEvent.mockClear();
+	} );
+
+	describe( 'banner variant', () => {
+		it( 'renders title, description, and actionLabel from props', () => {
+			render(
+				<HelpCenterCTA { ...baseProps } variant="banner" actionLabel="Book your free call" />
+			);
+
+			expect( screen.getByText( baseProps.title ) ).toBeVisible();
+			expect( screen.getByText( baseProps.description ) ).toBeVisible();
+			expect( screen.getByRole( 'link', { name: 'Book your free call' } ) ).toBeVisible();
+		} );
+
+		it( 'fires the impression event exactly once on mount', () => {
+			render(
+				<HelpCenterCTA { ...baseProps } variant="banner" actionLabel="Book your free call" />
+			);
+
+			expect( mockRecordTracksEvent ).toHaveBeenCalledTimes( 1 );
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_helpcenter_cta_impression', {
+				cta_id: baseProps.ctaId,
+				variant: 'banner',
+				placement: baseProps.placement,
+			} );
+		} );
+
+		it( 'fires the click event with the same payload when clicked', async () => {
+			const user = userEvent.setup();
+			render(
+				<HelpCenterCTA { ...baseProps } variant="banner" actionLabel="Book your free call" />
+			);
+			mockRecordTracksEvent.mockClear();
+
+			await user.click( screen.getByRole( 'link', { name: 'Book your free call' } ) );
+
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_helpcenter_cta_click', {
+				cta_id: baseProps.ctaId,
+				variant: 'banner',
+				placement: baseProps.placement,
+			} );
+		} );
+
+		it( 'opens the link in a new tab without a referrer', () => {
+			render(
+				<HelpCenterCTA { ...baseProps } variant="banner" actionLabel="Book your free call" />
+			);
+
+			const link = screen.getByRole( 'link', { name: 'Book your free call' } );
+			expect( link ).toHaveAttribute( 'target', '_blank' );
+			expect( link ).toHaveAttribute( 'rel', 'noreferrer' );
+		} );
+
+		it( 'renders no link when actionLabel is not provided', () => {
+			render( <HelpCenterCTA { ...baseProps } variant="banner" /> );
+
+			expect( screen.getByText( baseProps.title ) ).toBeVisible();
+			expect( screen.getByText( baseProps.description ) ).toBeVisible();
+			expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'still fires the impression event when actionLabel is not provided', () => {
+			render( <HelpCenterCTA { ...baseProps } variant="banner" /> );
+
+			expect( mockRecordTracksEvent ).toHaveBeenCalledTimes( 1 );
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_helpcenter_cta_impression', {
+				cta_id: baseProps.ctaId,
+				variant: 'banner',
+				placement: baseProps.placement,
+			} );
+		} );
+	} );
+
+	describe( 'link-list-item variant', () => {
+		it( 'renders title and description from props', () => {
+			render(
+				<ul>
+					<HelpCenterCTA { ...baseProps } variant="link-list-item" />
+				</ul>
+			);
+
+			expect( screen.getByText( baseProps.title ) ).toBeVisible();
+			expect( screen.getByText( baseProps.description ) ).toBeVisible();
+		} );
+
+		it( 'fires the impression event exactly once on mount', () => {
+			render(
+				<ul>
+					<HelpCenterCTA { ...baseProps } variant="link-list-item" />
+				</ul>
+			);
+
+			expect( mockRecordTracksEvent ).toHaveBeenCalledTimes( 1 );
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_helpcenter_cta_impression', {
+				cta_id: baseProps.ctaId,
+				variant: 'link-list-item',
+				placement: baseProps.placement,
+			} );
+		} );
+
+		it( 'fires the click event with the same payload when clicked', async () => {
+			const user = userEvent.setup();
+			render(
+				<ul>
+					<HelpCenterCTA { ...baseProps } variant="link-list-item" />
+				</ul>
+			);
+			mockRecordTracksEvent.mockClear();
+
+			await user.click( screen.getByRole( 'link' ) );
+
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_helpcenter_cta_click', {
+				cta_id: baseProps.ctaId,
+				variant: 'link-list-item',
+				placement: baseProps.placement,
+			} );
+		} );
+
+		it( 'opens the link in a new tab without a referrer', () => {
+			render(
+				<ul>
+					<HelpCenterCTA { ...baseProps } variant="link-list-item" />
+				</ul>
+			);
+
+			const link = screen.getByRole( 'link' );
+			expect( link ).toHaveAttribute( 'target', '_blank' );
+			expect( link ).toHaveAttribute( 'rel', 'noreferrer' );
+		} );
+	} );
+} );

--- a/packages/help-center/src/index.ts
+++ b/packages/help-center/src/index.ts
@@ -8,3 +8,5 @@ export { default as HelpCenterInlineButton } from './components/help-center-inli
 export { default as Mail } from './icons/mail';
 export { useHelpSearchQuery } from './hooks/use-help-search-query';
 export { HelpCenterSupportGuides } from './components/help-center-support-guides';
+export { HelpCenterCTA } from './components/help-center-cta';
+export type { HelpCenterCTAProps, HelpCenterCTAVariant } from './components/help-center-cta';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1438,6 +1438,7 @@ __metadata:
   resolution: "@automattic/help-center@workspace:packages/help-center"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
+    "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-color-schemes": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-476/build-v1-cta-components-banner-link-list-item-in-the-client

## Proposed Changes

**Adds a `HelpCenterCTA` component to `packages/help-center` with two presentational variants — a banner and a “More Resources”-style link-list item — with built-in Tracks instrumentation.**

- Props: `variant`, `ctaId`, `placement`, `url`, `title`, `description`, `actionLabel` — no targeting logic or data fetching.
- Fires `calypso_helpcenter_cta_impression` on mount and `calypso_helpcenter_cta_click` on click, both with `cta_id`, `variant`, `placement`.
- Storybook stories render both variants inside a mocked Help Center panel, so both can be reviewed without wiring anything up.
- Unit tests cover rendering and both Tracks events for each variant.

The component is exported but not rendered anywhere yet — wiring into the Help Center home panel and eligibility targeting are handled in separate issues.

## Why are these changes being made?

We want to show contextual calls to action (e.g. “book a free onboarding call”) inside the Help Center, targeted at specific user segments. This PR builds the reusable UI pieces first, in isolation, so Happiness and design can review both visual variants and we can verify the analytics payloads before any user-facing rollout. Part of [DOTSUP-476](https://linear.app/a8c/issue/DOTSUP-476).

## Testing Instructions

Nothing user-facing changes in Calypso or Simple/Atomic/CIAB yet — the component isn’t rendered anywhere. Review happens in Storybook:

1. Run `yarn storybook:start`.
2. Open `packages/help-center/HelpCenterCTA` in the sidebar.
3. Check the **Banner**, **BannerWithoutAction**, and **LinkListItem** stories render correctly inside the mock panel.
4. With the browser console open, confirm a `calypso_helpcenter_cta_impression` Tracks event logs on story load and `calypso_helpcenter_cta_click` fires when clicking the CTA link.

