### PR TITLE
A4A: Tighten referral checkout summary spacing

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
@@ -1,3 +1,4 @@
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import { getProductsList } from 'calypso/state/products-list/selectors';
@@ -48,6 +49,16 @@ export default function PricingSummary( {
 	const isAgencyCheckout = ! isAutomatedReferrals && ! isClient;
 
 	const showOriginalPrice = isAgencyCheckout && totalCost !== actualCost;
+	const summaryTotal = (
+		<div className="checkout__summary-total">
+			<span>
+				{ isAutomatedReferrals
+					? translate( 'Total your client will pay:' )
+					: translate( 'Total:' ) }
+			</span>
+			<span>{ totalCostFormattedText }</span>
+		</div>
+	);
 
 	return (
 		<div className="checkout__summary">
@@ -72,15 +83,14 @@ export default function PricingSummary( {
 				) ) }
 			</ul>
 			<hr />
-			<div className="checkout__summary-total">
-				<span>
-					{ isAutomatedReferrals
-						? translate( 'Total your client will pay:' )
-						: translate( 'Total:' ) }
-				</span>
-				<span>{ totalCostFormattedText }</span>
-			</div>
-			{ isAutomatedReferrals && <CommissionsInfo items={ items } termPricing={ termPricing } /> }
+			{ isAutomatedReferrals ? (
+				<VStack spacing={ 2 }>
+					{ summaryTotal }
+					<CommissionsInfo items={ items } termPricing={ termPricing } />
+				</VStack>
+			) : (
+				summaryTotal
+			) }
 		</div>
 	);
 }


### PR DESCRIPTION
Resolves A4A-3040

## Proposed Changes

* Tighten the spacing between the client total and estimated commission in referral checkout.
* Keep the surrounding checkout summary and Marketplace cart-menu spacing unchanged.

## Why are these changes being made?

* The two related referral totals currently appear too far apart.
* An 8px gap presents them as one compact summary group.

## Testing Instructions

* Open an A4A Marketplace referral checkout with an eligible commission product.
* Verify the client total and estimated commission have an 8px vertical gap.
* Verify the remaining checkout summary spacing is unchanged.
* Open the Marketplace referral cart menu and verify its spacing is unchanged.

_— ClemenAgent (Powered by Codex)_

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g. browsers), interfaces (e.g. keyboard navigation), and assistive technologies (e.g. screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.org/api/hooks/using-hooks) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have you tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
