### PR TITLE
A4A: Add client purchase confirmation

### DIFF
--- a/client/a8c-for-agencies/sections/client/lib/get-client-checkout-redirect-url.ts
+++ b/client/a8c-for-agencies/sections/client/lib/get-client-checkout-redirect-url.ts
@@ -1,0 +1,16 @@
+import { addQueryArgs } from '@wordpress/url';
+
+export const CLIENT_PURCHASE_COMPLETED_QUERY_ARG = 'client_purchase_completed';
+export const WPCOM_PLAN_PURCHASED_QUERY_ARG = 'wpcom_plan_purchased';
+
+export default function getClientCheckoutRedirectUrl(
+	subscriptionsUrl: string,
+	wpcomHostingProductSlug?: string
+) {
+	return addQueryArgs( subscriptionsUrl, {
+		[ CLIENT_PURCHASE_COMPLETED_QUERY_ARG ]: 'true',
+		...( wpcomHostingProductSlug && {
+			[ WPCOM_PLAN_PURCHASED_QUERY_ARG ]: wpcomHostingProductSlug,
+		} ),
+	} );
+}

--- a/client/a8c-for-agencies/sections/client/lib/test/get-client-checkout-redirect-url.test.ts
+++ b/client/a8c-for-agencies/sections/client/lib/test/get-client-checkout-redirect-url.test.ts
@@ -1,0 +1,20 @@
+import getClientCheckoutRedirectUrl from '../get-client-checkout-redirect-url';
+
+describe( 'getClientCheckoutRedirectUrl', () => {
+	it( 'marks a completed client purchase', () => {
+		expect( getClientCheckoutRedirectUrl( '/client/subscriptions' ) ).toBe(
+			'/client/subscriptions?client_purchase_completed=true'
+		);
+	} );
+
+	it( 'preserves the WordPress.com hosting product context', () => {
+		expect(
+			getClientCheckoutRedirectUrl(
+				'https://agencies.automattic.com/client/subscriptions',
+				'wpcom-business'
+			)
+		).toBe(
+			'https://agencies.automattic.com/client/subscriptions?client_purchase_completed=true&wpcom_plan_purchased=wpcom-business'
+		);
+	} );
+} );

--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
@@ -1,6 +1,5 @@
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
-import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
 import { getStripeConfiguration } from 'calypso/lib/store-transactions';
@@ -11,6 +10,7 @@ import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import ClientCheckoutV2Error from '../../checkout-v2-error';
 import ClientCheckoutV2Placeholder from '../../checkout-v2-placeholder';
 import useClientCheckout from '../../hooks/use-client-checkout';
+import getClientCheckoutRedirectUrl from '../../lib/get-client-checkout-redirect-url';
 
 import './style.scss';
 
@@ -26,9 +26,7 @@ function ClientCheckoutContent() {
 		} );
 
 	const subscriptionsUrl = window.location.origin + '/client/subscriptions';
-	const redirectTo = wpcomHostingProductSlug
-		? addQueryArgs( subscriptionsUrl, { wpcom_plan_purchased: wpcomHostingProductSlug } )
-		: subscriptionsUrl;
+	const redirectTo = getClientCheckoutRedirectUrl( subscriptionsUrl, wpcomHostingProductSlug );
 
 	if ( ! isReady ) {
 		return <ClientCheckoutV2Placeholder />;

--- a/client/a8c-for-agencies/sections/client/primary/express-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/express-checkout/index.tsx
@@ -1,6 +1,5 @@
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
-import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
@@ -10,6 +9,7 @@ import { getCurrentUserLocale, isUserLoggedIn } from 'calypso/state/current-user
 import ClientCheckoutV2Error from '../../checkout-v2-error';
 import ClientCheckoutV2Placeholder from '../../checkout-v2-placeholder';
 import useClientCheckout from '../../hooks/use-client-checkout';
+import getClientCheckoutRedirectUrl from '../../lib/get-client-checkout-redirect-url';
 
 const EXPRESS_CHECKOUT_REDIRECT_URL = 'https://agencies.automattic.com/client/subscriptions';
 
@@ -29,11 +29,10 @@ function ClientExpressCheckoutContent() {
 		return <ClientCheckoutV2Error title={ translate( 'Error' ) } message={ error } />;
 	}
 
-	const redirectTo = wpcomHostingProductSlug
-		? addQueryArgs( EXPRESS_CHECKOUT_REDIRECT_URL, {
-				wpcom_plan_purchased: wpcomHostingProductSlug,
-		  } )
-		: EXPRESS_CHECKOUT_REDIRECT_URL;
+	const redirectTo = getClientCheckoutRedirectUrl(
+		EXPRESS_CHECKOUT_REDIRECT_URL,
+		wpcomHostingProductSlug
+	);
 
 	return (
 		<CheckoutMain

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/index.tsx
@@ -145,9 +145,9 @@ export default function SubscriptionsList() {
 			sidebarNavigation={ <MobileSidebarNavigation /> }
 			withBorder
 		>
-			<LayoutTop>
-				<PurchaseConfirmationMessage />
+			<PurchaseConfirmationMessage />
 
+			<LayoutTop>
 				<LayoutHeader>
 					<Title>{ title } </Title>
 				</LayoutHeader>

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/purchase-confirmation-message.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/purchase-confirmation-message.tsx
@@ -5,37 +5,71 @@ import { useEffect, useState } from 'react';
 import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import {
+	CLIENT_PURCHASE_COMPLETED_QUERY_ARG,
+	WPCOM_PLAN_PURCHASED_QUERY_ARG,
+} from '../../lib/get-client-checkout-redirect-url';
 
 export default function PurchaseConfirmationMessage() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const rawArg = getQueryArg( window.location.href, 'wpcom_plan_purchased' );
+	const clientPurchaseCompleted =
+		getQueryArg( window.location.href, CLIENT_PURCHASE_COMPLETED_QUERY_ARG ) === 'true';
+	const rawArg = getQueryArg( window.location.href, WPCOM_PLAN_PURCHASED_QUERY_ARG );
 	const wpcomHostingPurchased = typeof rawArg === 'string' ? rawArg : '';
 
-	const [ successNotification, setSuccessNotification ] = useState< boolean >( false );
+	const [ confirmationType, setConfirmationType ] = useState< 'generic' | 'wpcom' | null >( null );
 
-	// Set the success notification when a WordPress.com site is purchased and remove the query arg from the URL
 	useEffect( () => {
-		if ( wpcomHostingPurchased ) {
-			setSuccessNotification( true );
-			dispatch(
-				recordTracksEvent( 'calypso_a4a_client_wpcom_hosting_purchased', {
-					hosting_plan: wpcomHostingPurchased,
-				} )
-			);
+		if ( clientPurchaseCompleted || wpcomHostingPurchased ) {
+			setConfirmationType( wpcomHostingPurchased ? 'wpcom' : 'generic' );
+			if ( wpcomHostingPurchased ) {
+				dispatch(
+					recordTracksEvent( 'calypso_a4a_client_wpcom_hosting_purchased', {
+						hosting_plan: wpcomHostingPurchased,
+					} )
+				);
+			} else {
+				dispatch( recordTracksEvent( 'calypso_a4a_client_purchase_confirmation_view' ) );
+			}
 			page(
-				removeQueryArgs( window.location.pathname + window.location.search, 'wpcom_plan_purchased' )
+				removeQueryArgs(
+					window.location.pathname + window.location.search,
+					CLIENT_PURCHASE_COMPLETED_QUERY_ARG,
+					WPCOM_PLAN_PURCHASED_QUERY_ARG
+				)
 			);
 		}
-	}, [ dispatch, wpcomHostingPurchased ] );
+	}, [ clientPurchaseCompleted, dispatch, wpcomHostingPurchased ] );
 
-	return successNotification ? (
+	if ( ! confirmationType ) {
+		return null;
+	}
+
+	if ( confirmationType === 'generic' ) {
+		return (
+			<LayoutBanner
+				className="subscriptions-list__purchase-confirmation"
+				isFullWidth
+				level="success"
+				title={ translate( 'Congratulations on your purchase!' ) }
+				onClose={ () => setConfirmationType( null ) }
+			>
+				{ translate(
+					'We’ve let your agency know, and they’ll begin setting things up for you. There’s nothing else you need to do right now.'
+				) }
+			</LayoutBanner>
+		);
+	}
+
+	return (
 		<LayoutBanner
+			className="subscriptions-list__purchase-confirmation"
 			isFullWidth
 			level="success"
 			title={ translate( 'You’ve successfully purchased a WordPress.com site!' ) }
-			onClose={ () => setSuccessNotification( false ) }
+			onClose={ () => setConfirmationType( null ) }
 		>
 			{ translate(
 				'Once your agency creates the site, you’ll be added as an admin, and it will appear in your {{a}}site list{{/a}}.',
@@ -46,5 +80,5 @@ export default function PurchaseConfirmationMessage() {
 				}
 			) }
 		</LayoutBanner>
-	) : null;
+	);
 }

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/style.scss
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/style.scss
@@ -1,7 +1,8 @@
-@import "calypso/assets/stylesheets/shared/mixins/breakpoints";
+@import 'calypso/assets/stylesheets/shared/mixins/breakpoints';
 
 .subscriptions-list__layout {
-	&.main.hosting-dashboard-layout.is-with-border .hosting-dashboard-layout__top-wrapper:not(.has-navigation) {
+	&.main.hosting-dashboard-layout.is-with-border
+		.hosting-dashboard-layout__top-wrapper:not( .has-navigation ) {
 		padding-block-start: 24px;
 		padding-block-end: 0;
 	}
@@ -15,10 +16,18 @@
 			padding-inline: 16px;
 			padding-block-end: 48px;
 
-			@include breakpoint-deprecated( ">660px" ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				padding-inline: 64px;
 			}
 		}
+	}
+}
+
+.subscriptions-list__purchase-confirmation {
+	padding-inline: 16px;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		padding-inline: 64px;
 	}
 }
 

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/test/purchase-confirmation-message.test.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/test/purchase-confirmation-message.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import page from '@automattic/calypso-router';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import PurchaseConfirmationMessage from '../purchase-confirmation-message';
+import type { ReactNode } from 'react';
+
+const mockDispatch = jest.fn();
+
+jest.mock( '@automattic/calypso-router', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: () => ( text: string ) => text,
+} ) );
+
+jest.mock( 'calypso/a8c-for-agencies/components/layout/banner', () => ( {
+	__esModule: true,
+	default: ( {
+		children,
+		level,
+		onClose,
+		title,
+	}: {
+		children: ReactNode;
+		level: string;
+		onClose: () => void;
+		title: string;
+	} ) => (
+		<section data-level={ level }>
+			<h2>{ title }</h2>
+			{ children }
+			<button onClick={ onClose }>Close</button>
+		</section>
+	),
+} ) );
+
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => mockDispatch,
+} ) );
+
+jest.mock( 'calypso/state/analytics/actions', () => ( {
+	recordTracksEvent: jest.fn( ( name, properties ) => ( {
+		type: 'RECORD_TRACKS_EVENT',
+		name,
+		properties,
+	} ) ),
+} ) );
+
+const mockedPage = page as jest.MockedFunction< typeof page >;
+const mockedRecordTracksEvent = recordTracksEvent as jest.MockedFunction<
+	typeof recordTracksEvent
+>;
+
+describe( 'PurchaseConfirmationMessage', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		window.history.replaceState( {}, '', '/client/subscriptions' );
+	} );
+
+	it( 'does not render on a direct subscriptions visit', () => {
+		const { container } = render( <PurchaseConfirmationMessage /> );
+
+		expect( container ).toBeEmptyDOMElement();
+		expect( mockedPage ).not.toHaveBeenCalled();
+	} );
+
+	it( 'shows and consumes the generic client purchase confirmation', async () => {
+		window.history.replaceState(
+			{},
+			'',
+			'/client/subscriptions?client_purchase_completed=true&source=checkout'
+		);
+
+		render( <PurchaseConfirmationMessage /> );
+
+		expect(
+			await screen.findByRole( 'heading', { name: 'Congratulations on your purchase!' } )
+		).toBeVisible();
+		expect(
+			screen.getByText(
+				'We’ve let your agency know, and they’ll begin setting things up for you. There’s nothing else you need to do right now.'
+			)
+		).toBeVisible();
+		expect( mockedPage ).toHaveBeenCalledWith( '/client/subscriptions?source=checkout' );
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_a4a_client_purchase_confirmation_view'
+		);
+	} );
+
+	it( 'keeps the WordPress.com hosting-specific confirmation', async () => {
+		window.history.replaceState(
+			{},
+			'',
+			'/client/subscriptions?client_purchase_completed=true&wpcom_plan_purchased=wpcom-business'
+		);
+
+		const { rerender } = render( <PurchaseConfirmationMessage /> );
+
+		expect(
+			await screen.findByRole( 'heading', {
+				name: 'You’ve successfully purchased a WordPress.com site!',
+			} )
+		).toBeVisible();
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_a4a_client_wpcom_hosting_purchased',
+			{ hosting_plan: 'wpcom-business' }
+		);
+		expect( mockedPage ).toHaveBeenCalledWith( '/client/subscriptions' );
+
+		window.history.replaceState( {}, '', '/client/subscriptions' );
+		rerender( <PurchaseConfirmationMessage /> );
+
+		expect(
+			screen.getByRole( 'heading', {
+				name: 'You’ve successfully purchased a WordPress.com site!',
+			} )
+		).toBeVisible();
+	} );
+
+	it( 'can be dismissed', async () => {
+		const user = userEvent.setup();
+		window.history.replaceState( {}, '', '/client/subscriptions?client_purchase_completed=true' );
+
+		render( <PurchaseConfirmationMessage /> );
+
+		await user.click(
+			await screen.findByRole( 'button', {
+				name: 'Close',
+			} )
+		);
+
+		await waitFor( () => {
+			expect(
+				screen.queryByRole( 'heading', { name: 'Congratulations on your purchase!' } )
+			).not.toBeInTheDocument();
+		} );
+	} );
+} );

--- a/client/a8c-for-agencies/sections/marketplace/checkout/submit-payment-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/submit-payment-info.tsx
@@ -7,6 +7,7 @@ import {
 	A4A_CLIENT_PAYMENT_METHODS_ADD_LINK,
 	A4A_CLIENT_SUBSCRIPTIONS_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import getClientCheckoutRedirectUrl from 'calypso/a8c-for-agencies/sections/client/lib/get-client-checkout-redirect-url';
 import usePaymentMethod from 'calypso/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-payment-method';
 import A4AFullLogo from 'calypso/assets/images/a8c-for-agencies/a4a-full-logo.svg';
 import { useDispatch } from 'calypso/state';
@@ -66,15 +67,7 @@ export default function SubmitPaymentInfo( { disableButton }: { disableButton?: 
 	useEffect( () => {
 		if ( status === 'success' ) {
 			dispatch( recordTracksEvent( 'calypso_a4a_client_checkout_submit_payment_info_success' ) );
-			dispatch(
-				successNotice(
-					translate( 'Thank you for your purchase! Your agency can now set up your product.' ),
-					{
-						displayOnNextPage: true,
-					}
-				)
-			);
-			page.redirect( A4A_CLIENT_SUBSCRIPTIONS_LINK );
+			page.redirect( getClientCheckoutRedirectUrl( A4A_CLIENT_SUBSCRIPTIONS_LINK ) );
 		}
 		if ( status === 'error' ) {
 			const alreadySubmittedError = error?.code === 'referral_is_not_pending';


### PR DESCRIPTION
Resolves A4A-3054

## Proposed Changes

* Mark successful A4A client checkout redirects.
* Show a one-time confirmation banner on **Your subscriptions**.
* Keep regular, express, and legacy client checkout confirmation behavior consistent.

<img width="1390" height="261" alt="image" src="https://github.com/user-attachments/assets/ee37aa3c-16cf-4306-8953-caee3a4fdb88" />

<img width="1387" height="262" alt="image" src="https://github.com/user-attachments/assets/e7acd928-3209-4329-902f-81e8a470e401" />


## Why are these changes being made?

* Clients currently land on their subscriptions without confirmation after completing a purchase.
* The banner confirms the agency was notified and that the client has no immediate follow-up action.

## Testing Instructions

* Complete an A4A client purchase.
* Verify **Your subscriptions** shows the success banner at the top.
* Dismiss the banner and verify it stays hidden.
* Refresh the page and verify the banner does not appear again.
* Open **Your subscriptions** directly and verify the banner is absent.

_— ClemenAgent (Powered by Codex)_

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g. browsers), interfaces (e.g. keyboard navigation), and assistive technologies (e.g. screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have you tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
