### PR TITLE
A4A Amplify: overview page style tweaks

### DIFF
--- a/client/a8c-for-agencies/sections/amplify/primary/overview/sections/ai-workflow.scss
+++ b/client/a8c-for-agencies/sections/amplify/primary/overview/sections/ai-workflow.scss
@@ -3,8 +3,12 @@
 // The only bespoke bits are the severity dot — a small status indicator with no
 // core equivalent — and keeping the mode toggle from shrinking in the header.
 
-.amplify-landing-workflow-mode-toggle {
+// `isBlock` is what makes core paint the enclosing border at rest rather than
+// only on hover/focus; it also stretches the control to the full header width,
+// which we undo here. Card-scoped so it outweighs the component's emotion class.
+.amplify-landing-workflow-card .amplify-landing-workflow-mode-toggle {
 	flex-shrink: 0;
+	inline-size: auto;
 }
 
 // Calypso's global `hr` reset (client/assets/stylesheets/_main.scss) paints

--- a/client/a8c-for-agencies/sections/amplify/primary/overview/sections/ai-workflow.tsx
+++ b/client/a8c-for-agencies/sections/amplify/primary/overview/sections/ai-workflow.tsx
@@ -182,6 +182,7 @@ export default function AmplifyAiWorkflow() {
 						</VStack>
 						<ToggleGroupControl
 							__next40pxDefaultSize
+							isBlock
 							hideLabelFromVision
 							label={ __( 'Analysis mode' ) }
 							value={ mode }

--- a/client/a8c-for-agencies/sections/amplify/primary/overview/sections/faq.scss
+++ b/client/a8c-for-agencies/sections/amplify/primary/overview/sections/faq.scss
@@ -1,9 +1,11 @@
-// PageSectionColumns styles every .components-button inside its content for hero
-// CTAs (`width: fit-content` at large, centered). The FAQ accordion toggles are
-// also .components-button and get caught. The toggle is a flex container (base
-// .components-button is inline-flex, justify-content: center), so restore full
-// width and left-align the title with `justify-content: flex-start`.
-.amplify-faq .components-panel__body-toggle.components-button {
+// The FAQ accordion toggles are .components-button, so two global rules catch
+// them: the A4A theme (client/a8c-for-agencies/style.scss) centers and un-wraps
+// every button, and PageSectionColumns sizes buttons for hero CTAs. The theme
+// rule matches at the same specificity as this one, so it needs the theme class
+// here to win reliably rather than by stylesheet order.
+.theme-a8c-for-agencies .amplify-faq .components-panel__body-toggle.components-button {
 	inline-size: 100%;
 	justify-content: flex-start;
+	text-align: start;
+	white-space: normal;
 }


### PR DESCRIPTION
Two style fixes on the Amplify Overview page (A4A-2926).

## Proposed Changes

* **`ai-workflow.tsx` / `ai-workflow.scss`** — the Human/AI toggle in the "Audit to agent in seconds" card now keeps its border at rest. Core's `ToggleGroupControl` only paints the enclosing border on hover/focus unless `isBlock` is set, so the toggle takes `isBlock` (matching the score-card toggle above it) and the CSS resets the full-width stretch that comes with it.
* **`faq.scss`** — FAQ accordion titles are left-aligned and wrap again. `.theme-a8c-for-agencies .components-button:not( .dataviews-view-table-header-button )` (#112374) matches at the same specificity as the existing FAQ override, so the theme's `justify-content: center` / `white-space: nowrap` was winning on stylesheet order. The override is now scoped under the theme class.

## Why are these changes being made?

Design flagged that the mode toggle reads as plain text until you hover it, so it isn't obvious there's anything to switch. The FAQ titles centering is a separate regression that surfaced while looking at the page.

## Testing Instructions

1. Run `yarn start-a8c-for-agencies` and open `agencies.localhost:3000/amplify` as an agency user with the amplify capabilities.
2. Scroll to **Audit to agent in seconds** — the Human/AI toggle shows its border without hovering, matching the toggle in the score card above. Switching between Human and AI still swaps the prompt list.
3. Scroll to **Frequently asked questions** — question titles are left-aligned, long ones wrap onto a second line, and the chevron stays on the right.
4. Narrow the window to mobile width and confirm both still look right.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_01PwekgQwSG9z5enHVBUS2gq
