### PR TITLE
A4A MSD: open agencieshelp links in the Help Center

### DIFF
--- a/client/dashboard/agency/earn/referrals/consolidated-views.tsx
+++ b/client/dashboard/agency/earn/referrals/consolidated-views.tsx
@@ -1,7 +1,8 @@
 import { formatCurrency } from '@automattic/number-formatters';
-import { __experimentalGrid as Grid, Button } from '@wordpress/components';
+import { __experimentalGrid as Grid } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import InlineSupportLink from '../../../components/inline-support-link';
 import ConsolidatedStatCard from './consolidated-stat-card';
 import useConsolidatedPayoutData from './hooks/use-consolidated-payout-data';
 import { downloadCommissionsCsv } from './lib/download-commissions-csv';
@@ -99,7 +100,9 @@ export default function ConsolidatedViews( {
 					),
 					{
 						br: <br />,
-						a: <Button variant="link" href={ AGENCY_EARNINGS_LEARN_MORE_LINK } target="_blank" />,
+						a: (
+							<InlineSupportLink supportLink={ AGENCY_EARNINGS_LEARN_MORE_LINK } openInHelpCenter />
+						),
 					}
 				) }
 				isLoading={ isLoading || isLoadingCommissionPayout }
@@ -120,7 +123,9 @@ export default function ConsolidatedViews( {
 					),
 					{
 						br: <br />,
-						a: <Button variant="link" href={ AGENCY_EARNINGS_LEARN_MORE_LINK } target="_blank" />,
+						a: (
+							<InlineSupportLink supportLink={ AGENCY_EARNINGS_LEARN_MORE_LINK } openInHelpCenter />
+						),
 					}
 				) }
 				isLoading={ isLoading }

--- a/client/dashboard/agency/earn/referrals/consolidated-views.tsx
+++ b/client/dashboard/agency/earn/referrals/consolidated-views.tsx
@@ -1,5 +1,5 @@
 import { formatCurrency } from '@automattic/number-formatters';
-import { __experimentalGrid as Grid } from '@wordpress/components';
+import { Button, __experimentalGrid as Grid } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import InlineSupportLink from '../../../components/inline-support-link';

--- a/client/dashboard/agency/earn/referrals/consolidated-views.tsx
+++ b/client/dashboard/agency/earn/referrals/consolidated-views.tsx
@@ -101,7 +101,10 @@ export default function ConsolidatedViews( {
 					{
 						br: <br />,
 						a: (
-							<InlineSupportLink supportLink={ AGENCY_EARNINGS_LEARN_MORE_LINK } openInHelpCenter />
+							<InlineSupportLink
+								supportLink={ AGENCY_EARNINGS_LEARN_MORE_LINK }
+								forceOpenInHelpCenter
+							/>
 						),
 					}
 				) }
@@ -124,7 +127,10 @@ export default function ConsolidatedViews( {
 					{
 						br: <br />,
 						a: (
-							<InlineSupportLink supportLink={ AGENCY_EARNINGS_LEARN_MORE_LINK } openInHelpCenter />
+							<InlineSupportLink
+								supportLink={ AGENCY_EARNINGS_LEARN_MORE_LINK }
+								forceOpenInHelpCenter
+							/>
 						),
 					}
 				) }

--- a/client/dashboard/agency/earn/referrals/empty-state.tsx
+++ b/client/dashboard/agency/earn/referrals/empty-state.tsx
@@ -7,6 +7,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { reusableBlock } from '@wordpress/icons';
 import EmptyState from '../../../components/empty-state';
+import InlineSupportLink from '../../../components/inline-support-link';
 import RouterLinkButton from '../../../components/router-link-button';
 import { getAccountStatus } from '../payout-settings/get-account-status';
 import tipaltiLogo from './lib/tipalti-logo';
@@ -36,7 +37,12 @@ export default function ReferralsEmptyState( { agencyId }: { agencyId: number } 
 								'Make money when your clients buy Automattic products, hosting, or use WooPayments. No promo codes needed. <a>How much money will I make?</a>'
 							),
 							{
-								a: <ExternalLink href={ AGENCY_EARNINGS_LEARN_MORE_LINK } children={ null } />,
+								a: (
+									<InlineSupportLink
+										supportLink={ AGENCY_EARNINGS_LEARN_MORE_LINK }
+										openInHelpCenter
+									/>
+								),
 							}
 						) }
 					</EmptyState.Description>

--- a/client/dashboard/agency/earn/referrals/empty-state.tsx
+++ b/client/dashboard/agency/earn/referrals/empty-state.tsx
@@ -40,7 +40,7 @@ export default function ReferralsEmptyState( { agencyId }: { agencyId: number } 
 								a: (
 									<InlineSupportLink
 										supportLink={ AGENCY_EARNINGS_LEARN_MORE_LINK }
-										openInHelpCenter
+										forceOpenInHelpCenter
 									/>
 								),
 							}

--- a/client/dashboard/agency/earn/referrals/payout-cards.tsx
+++ b/client/dashboard/agency/earn/referrals/payout-cards.tsx
@@ -73,7 +73,10 @@ function PayoutAmount( {
 					</div>
 
 					<div>
-						<InlineSupportLink supportLink={ AGENCY_EARNINGS_LEARN_MORE_LINK } openInHelpCenter>
+						<InlineSupportLink
+							supportLink={ AGENCY_EARNINGS_LEARN_MORE_LINK }
+							forceOpenInHelpCenter
+						>
 							{ __( 'Learn more' ) }
 						</InlineSupportLink>
 					</div>

--- a/client/dashboard/agency/earn/referrals/payout-cards.tsx
+++ b/client/dashboard/agency/earn/referrals/payout-cards.tsx
@@ -1,6 +1,7 @@
 import { formatCurrency } from '@automattic/number-formatters';
-import { __experimentalVStack as VStack, Button } from '@wordpress/components';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import InlineSupportLink from '../../../components/inline-support-link';
 import { formatDate } from '../../../utils/datetime';
 import ConsolidatedStatCard from './consolidated-stat-card';
 import useGetPayoutData from './hooks/use-payout-data';
@@ -72,9 +73,9 @@ function PayoutAmount( {
 					</div>
 
 					<div>
-						<Button variant="link" href={ AGENCY_EARNINGS_LEARN_MORE_LINK } target="_blank">
+						<InlineSupportLink supportLink={ AGENCY_EARNINGS_LEARN_MORE_LINK } openInHelpCenter>
 							{ __( 'Learn more' ) }
-						</Button>
+						</InlineSupportLink>
 					</div>
 				</VStack>
 			}

--- a/client/dashboard/agency/tiers/influenced-revenue.tsx
+++ b/client/dashboard/agency/tiers/influenced-revenue.tsx
@@ -1,7 +1,6 @@
 import { formatCurrency } from '@automattic/number-formatters';
 import {
 	Button,
-	ExternalLink,
 	Popover,
 	ProgressBar,
 	__experimentalHStack as HStack,
@@ -10,6 +9,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { info } from '@wordpress/icons';
 import { useState } from 'react';
+import InlineSupportLink from '../../components/inline-support-link';
 import { Text } from '../../components/text';
 import getCurrentAgencyTier from './get-current-agency-tier';
 import type { AgencyTierType, RecordTracksEvent } from './types';
@@ -61,14 +61,15 @@ function InfluencedRevenueStrapline( {
 								'Earn commissions by referring Automattic products to your clients, receive revenue share from WooPayments transactions, and unlock savings through volume discounts on bulk purchases.'
 							) }
 						</Text>
-						<ExternalLink
-							href={ LEARN_MORE_URL }
+						<InlineSupportLink
+							supportLink={ LEARN_MORE_URL }
+							openInHelpCenter
 							onClick={ () =>
 								recordTracksEvent( 'calypso_a4a_agency_tier_influenced_revenue_learn_more_click' )
 							}
 						>
 							{ __( 'Learn more' ) }
-						</ExternalLink>
+						</InlineSupportLink>
 					</VStack>
 				</Popover>
 			) }

--- a/client/dashboard/agency/tiers/influenced-revenue.tsx
+++ b/client/dashboard/agency/tiers/influenced-revenue.tsx
@@ -63,7 +63,7 @@ function InfluencedRevenueStrapline( {
 						</Text>
 						<InlineSupportLink
 							supportLink={ LEARN_MORE_URL }
-							openInHelpCenter
+							forceOpenInHelpCenter
 							onClick={ () =>
 								recordTracksEvent( 'calypso_a4a_agency_tier_influenced_revenue_learn_more_click' )
 							}

--- a/client/dashboard/components/inline-support-link/index.tsx
+++ b/client/dashboard/components/inline-support-link/index.tsx
@@ -12,6 +12,7 @@ const InlineSupportLink = ( {
 	supportContext,
 	children = __( 'Learn more' ),
 	onClick,
+	openInHelpCenter = false,
 }: {
 	className?: string;
 	title?: string;
@@ -20,6 +21,8 @@ const InlineSupportLink = ( {
 	supportContext?: string;
 	children?: React.ReactNode;
 	onClick?: ( supportData: SupportDocData | null ) => void;
+	// Open the article in the Help Center panel even without a wpcom postId (e.g. an agencieshelp.automattic.com article, which is fetched by URL).
+	openInHelpCenter?: boolean;
 } ) => {
 	const { supportDocData, openSupportDoc } = useSupportDocData( {
 		supportPostId,
@@ -27,8 +30,10 @@ const InlineSupportLink = ( {
 		supportContext,
 	} );
 
+	const opensInPanel = !! supportDocData?.postId || openInHelpCenter;
+
 	const handleClick = ( event: React.SyntheticEvent< HTMLAnchorElement > ) => {
-		if ( supportDocData?.postId ) {
+		if ( opensInPanel ) {
 			event.preventDefault();
 			openSupportDoc();
 		}
@@ -53,6 +58,10 @@ const InlineSupportLink = ( {
 				{ children }
 			</a>
 		);
+	}
+
+	if ( openInHelpCenter ) {
+		return <a { ...linkProps }>{ children }</a>;
 	}
 
 	return <ExternalLink { ...linkProps }>{ children }</ExternalLink>;

--- a/client/dashboard/components/inline-support-link/index.tsx
+++ b/client/dashboard/components/inline-support-link/index.tsx
@@ -21,7 +21,6 @@ const InlineSupportLink = ( {
 	supportContext?: string;
 	children?: React.ReactNode;
 	onClick?: ( supportData: SupportDocData | null ) => void;
-	// Open the article in the Help Center panel even without a wpcom postId (e.g. an agencieshelp.automattic.com article, which is fetched by URL).
 	forceOpenInHelpCenter?: boolean;
 } ) => {
 	const { supportDocData, openSupportDoc } = useSupportDocData( {

--- a/client/dashboard/components/inline-support-link/index.tsx
+++ b/client/dashboard/components/inline-support-link/index.tsx
@@ -12,7 +12,7 @@ const InlineSupportLink = ( {
 	supportContext,
 	children = __( 'Learn more' ),
 	onClick,
-	openInHelpCenter = false,
+	forceOpenInHelpCenter = false,
 }: {
 	className?: string;
 	title?: string;
@@ -22,7 +22,7 @@ const InlineSupportLink = ( {
 	children?: React.ReactNode;
 	onClick?: ( supportData: SupportDocData | null ) => void;
 	// Open the article in the Help Center panel even without a wpcom postId (e.g. an agencieshelp.automattic.com article, which is fetched by URL).
-	openInHelpCenter?: boolean;
+	forceOpenInHelpCenter?: boolean;
 } ) => {
 	const { supportDocData, openSupportDoc } = useSupportDocData( {
 		supportPostId,
@@ -30,7 +30,7 @@ const InlineSupportLink = ( {
 		supportContext,
 	} );
 
-	const opensInPanel = !! supportDocData?.postId || openInHelpCenter;
+	const opensInPanel = !! supportDocData?.postId || forceOpenInHelpCenter;
 
 	const handleClick = ( event: React.SyntheticEvent< HTMLAnchorElement > ) => {
 		if ( opensInPanel ) {
@@ -60,7 +60,7 @@ const InlineSupportLink = ( {
 		);
 	}
 
-	if ( openInHelpCenter ) {
+	if ( forceOpenInHelpCenter ) {
 		return <a { ...linkProps }>{ children }</a>;
 	}
 

--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -571,6 +571,7 @@ const localDevHosts = [
 	'agencies.localhost',
 	'my.localhost',
 	'my.woo.localhost',
+	'my.a4a.localhost',
 ];
 
 function isLocalDevOrigin( urlOrigin ) {


### PR DESCRIPTION
## Proposed Changes

* Add a `forceOpenInHelpCenter` opt-in prop to the Dashboard's `InlineSupportLink`. When set, a bare support URL that has no wpcom `postId` (e.g. an `agencieshelp.automattic.com` knowledge-base article, which the Help Center fetches by URL) opens inside the Help Center panel instead of a new tab. The default is `false`, so all existing usages are unchanged.
* Convert the A4A agency "Learn more" links to use it: referrals consolidated views, payout cards, empty state, and tiers influenced revenue. Non-`agencieshelp` external links (e.g. Tipalti) are left as plain external links.
* Add `my.a4a.localhost` to the `wpcom-proxy-request` local dev-host allowlist.

## Why are these changes being made?

* In the A4A Multi-site Dashboard, `agencieshelp.automattic.com` "Learn more" links navigated the user out of the app. The Help Center panel is already mounted there, so these should open in-panel like they do in the classic A4A client.
* The article view fetches by URL (`/help/article?post_url=`), which is product-independent — so an opt-in on the existing `InlineSupportLink` is enough; no new component or duplicate helper is needed.
* The dev-host allowlist entry fixes the actual failure found while testing: on `my.a4a.localhost` (the A4A dashboard dev host, per `config/dashboard-development.json` and `app-a4a/routing.ts`), `canAccessWpcomApis()` returned `false` because the host was missing from `localDevHosts`. That made the article fetch fall back to `apiFetch('/help-center/fetch-post')`, which resolved against the local origin and returned 404. Adding the host makes the fetch use `wpcomRequest('/help/article')` through the proxy, matching how the rest of the app already works.

## Testing Instructions

1. Run the dashboard dev server and open the A4A dashboard at `my.a4a.localhost:3000`.
2. Go to **Earn → Referrals** (or **Tiers**) and open a card's info popover / description with a "Learn more" link.
3. Click the link. Expected: the Help Center panel opens and renders the knowledge-base article in-panel (it should not open a new tab).
4. In DevTools Network, confirm the request is `help/article?post_url=…` via the proxy (not the local `help-center/fetch-post`, which previously 404'd).
5. Regression check: on a dotcom surface, an existing `InlineSupportLink` (e.g. a domains "Learn more") still behaves as before.

### Follow-ups (not in this PR)

* `agencies-beta.automattic.com` is an A4A dashboard host but is not in the `wpcom-proxy-request` origin allowlist, so the same fallback would occur there. Left out because it is a production origin.
* Passing the A4A Help Center configuration (`product: 'a4a'` — search source, chat, contact-form variant) to the MSD panel is a separate change.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
