### PR TITLE
Traffic: make the Blaze banner fit smaller screens

### DIFF
--- a/client/sites/marketing/traffic/style.scss
+++ b/client/sites/marketing/traffic/style.scss
@@ -302,6 +302,14 @@ body.is-section-marketing-traffic {
 .settings-traffic {
 	.promo-card-block {
 		margin-top: 0;
+
+		@media screen and (max-width: 910px) {
+			padding: 24px;
+		}
+
+		@media screen and (max-width: 480px) {
+			padding: 20px;
+		}
 	}
 
 	.promo-card-block .button {
@@ -310,6 +318,36 @@ body.is-section-marketing-traffic {
 
 	.promo-card-block img {
 		max-width: 170px;
+
+		@media screen and (max-width: 910px) {
+			max-width: 120px;
+			margin-bottom: 16px;
+		}
+
+		@media screen and (max-width: 480px) {
+			max-width: 96px;
+			margin-bottom: 12px;
+		}
+	}
+
+	.promo-card-block .formatted-header__title {
+		@media screen and (max-width: 910px) {
+			font-size: $font-title-medium;
+		}
+
+		@media screen and (max-width: 480px) {
+			font-size: $font-title-small;
+		}
+	}
+
+	.promo-card-block p {
+		@media screen and (max-width: 910px) {
+			font-size: $font-body-small;
+		}
+
+		@media screen and (max-width: 480px) {
+			margin-bottom: 16px;
+		}
 	}
 
 	.panel-card {


### PR DESCRIPTION
Part of ADS-1385

## Proposed Changes

On the Traffic page, the "Reach new readers and customers" Blaze banner was huge on phones and tablets — it filled almost the entire screen and pushed everything else out of view. This shrinks the banner's picture, heading, text, and spacing on smaller screens so it looks in proportion and the rest of the page is visible without a lot of scrolling. Nothing changes on desktop.

| Before | After |
|--------|-------|
| <img width="416" height="873" alt="Screenshot 2026-07-22 at 2 37 43 PM" src="https://github.com/user-attachments/assets/3d8d5e59-f5b3-495c-a60e-d97aeaa6050c" /> | <img width="410" height="864" alt="Screenshot 2026-07-22 at 2 37 49 PM" src="https://github.com/user-attachments/assets/7d001d2d-c36a-4b4b-8fa2-1e8880e817b3" /> |
| <img width="782" height="1042" alt="Screenshot 2026-07-22 at 2 50 19 PM" src="https://github.com/user-attachments/assets/60f8acde-a67f-4f0e-9a0c-d4cd89edf919" /> | <img width="785" height="1043" alt="Screenshot 2026-07-22 at 2 50 12 PM" src="https://github.com/user-attachments/assets/27851f03-1e7e-430d-9a05-b1ef55d53c2f" /> |

## Why are these changes being made?

On mobile the banner dominated the screen and buried the actual Traffic settings below the fold. Tablets had the same problem to a lesser degree. Making the banner scale down on smaller screens keeps it useful without letting it take over the page.

## Testing Instructions

* Go to **Marketing → Traffic** for a site that shows the Blaze banner (`/marketing/traffic/{site}`).
* Resize the browser (or use your browser's device toolbar) to a **phone width (~375px)** and a **tablet width (~768–834px)**.
* Confirm the banner's artwork, heading, and text are smaller and the banner no longer takes over the screen — the settings below it should be easy to reach.
* Check a normal **desktop width** and confirm the banner looks the same as before.
* Before / After screenshots at mobile and tablet widths are helpful here.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] For UI changes, have you tested the affected components in dark mode? (style-only, sizing changes; no color changes)
- [ ] Have you checked for TypeScript, React or other console errors?