### PR TITLE
Domain-only flow: skip site-or-domain for logged-out users too

### DIFF
--- a/client/signup/steps/domains/index.tsx
+++ b/client/signup/steps/domains/index.tsx
@@ -28,7 +28,7 @@ import {
 	domainManagementTransferToOtherSite,
 } from 'calypso/my-sites/domains/paths';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { getStepUrl } from 'calypso/signup/utils';
+import { getNextStepName, getStepUrl } from 'calypso/signup/utils';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
@@ -60,6 +60,7 @@ const DomainSearchUI = (
 		stepName,
 		submitSignupStep,
 		goToNextStep,
+		goToStep,
 		locale,
 		queryObject,
 		baseSubmitStepProps,
@@ -71,6 +72,7 @@ const DomainSearchUI = (
 	const isDomainOnlyFlow = flowName === 'domain';
 	const isOnboardingWithEmailFlow = flowName === 'onboarding-with-email';
 
+	const isLoggedIn = useSelector( isUserLoggedIn );
 	const site = useSelector( getSelectedSite );
 
 	const siteSlug = queryObject.siteSlug;
@@ -220,6 +222,19 @@ const DomainSearchUI = (
 						{ stepName: 'plans-site-selected', wasSkipped: true },
 						{ cartItems: null }
 					);
+
+					// For logged-out users the account step is still pending, so the flow isn't
+					// "every step submitted" and the default goToNextStep() advances by array index
+					// from 'domain-only' back onto the just-skipped 'site-or-domain' step. Advance
+					// from the last auto-submitted step instead: logged-out users go to the account
+					// step, logged-in users fall through to checkout.
+					const nextStep = getNextStepName( flowName, 'plans-site-selected', isLoggedIn );
+					if ( nextStep ) {
+						goToStep( nextStep );
+					} else {
+						goToNextStep();
+					}
+					return;
 				}
 
 				goToNextStep();
@@ -257,6 +272,8 @@ const DomainSearchUI = (
 		clearQuery,
 		submitSignupStep,
 		goToNextStep,
+		goToStep,
+		isLoggedIn,
 		locale,
 		isDomainOnlyFlow,
 		baseSubmitStepProps,

--- a/client/signup/steps/domains/test/index.tsx
+++ b/client/signup/steps/domains/test/index.tsx
@@ -34,11 +34,13 @@ const baseProps = {
 	previousStepName: null,
 };
 
-function renderStep( props = baseProps ) {
+function renderStep( props = baseProps, options = {} ) {
 	mockWPCOMDomainSearch.mockClear();
-	renderWithProvider( <DomainSearchStep { ...props } /> );
+	renderWithProvider( <DomainSearchStep { ...props } />, options );
 	return mockWPCOMDomainSearch.mock.calls[ 0 ][ 0 ].events;
 }
+
+const LOGGED_IN_STATE = { currentUser: { id: 12345 } };
 
 describe( 'DomainSearchStep — domain-only checkout simplification', () => {
 	beforeEach( () => {
@@ -46,10 +48,11 @@ describe( 'DomainSearchStep — domain-only checkout simplification', () => {
 		mockWPCOMDomainSearch.mockReturnValue( null );
 	} );
 
-	it( 'auto-submits site-or-domain, site-picker, and plans-site-selected in the domain flow', () => {
+	it( 'auto-submits the skipped steps and routes logged-out users to the account step', () => {
 		const submitSignupStep = jest.fn();
+		const goToStep = jest.fn();
 		const goToNextStep = jest.fn();
-		const events = renderStep( { ...baseProps, submitSignupStep, goToNextStep } );
+		const events = renderStep( { ...baseProps, submitSignupStep, goToStep, goToNextStep } );
 
 		events.onContinue( [ domainItem ] );
 
@@ -83,7 +86,27 @@ describe( 'DomainSearchStep — domain-only checkout simplification', () => {
 			expect.objectContaining( { stepName: 'plans-site-selected', wasSkipped: true } ),
 			expect.objectContaining( { cartItems: null } )
 		);
+		// Logged out: jump to the account step instead of the skipped site-or-domain step.
+		expect( goToStep ).toHaveBeenCalledTimes( 1 );
+		expect( goToStep ).toHaveBeenCalledWith( expect.stringMatching( /^user/ ) );
+		expect( goToNextStep ).not.toHaveBeenCalled();
+	} );
+
+	it( 'skips straight to checkout for logged-in users in the domain flow', () => {
+		const submitSignupStep = jest.fn();
+		const goToStep = jest.fn();
+		const goToNextStep = jest.fn();
+		const events = renderStep(
+			{ ...baseProps, submitSignupStep, goToStep, goToNextStep },
+			{ initialState: LOGGED_IN_STATE }
+		);
+
+		events.onContinue( [ domainItem ] );
+
+		// Same auto-submitted steps, but no account step remains, so proceed to checkout.
+		expect( submitSignupStep ).toHaveBeenCalledTimes( 4 );
 		expect( goToNextStep ).toHaveBeenCalledTimes( 1 );
+		expect( goToStep ).not.toHaveBeenCalled();
 	} );
 
 	it( 'submits the domain step and does not skip steps in a non-domain flow', () => {

--- a/client/signup/steps/domains/types.ts
+++ b/client/signup/steps/domains/types.ts
@@ -2,7 +2,7 @@ export type StepProps = {
 	stepSectionName: string | null;
 	stepName: string;
 	flowName: string;
-	goToStep: () => void;
+	goToStep: ( stepName?: string, stepSectionName?: string, flowName?: string ) => void;
 	goToNextStep: () => void;
 	submitSignupStep: ( step: unknown, dependencies: unknown ) => void;
 	queryObject: Record< string, string | undefined >;


### PR DESCRIPTION
Part of DOTPROD-122

## Proposed Changes

* Makes the domain-only checkout simplification skip the "Choose how to use your domain" (`site-or-domain`) step for **logged-out** users too, not only logged-in users.
* In the `domain-only` step's `onContinue`, after auto-submitting `site-or-domain`, `site-picker`, and `plans-site-selected`, navigate from the last auto-submitted step in a login-aware way (via `getNextStepName`) instead of relying on `goToNextStep()`.
* Widens the `goToStep` prop type to accept a target step name.
* Tests: the logged-out case now asserts navigation to the account step; adds a logged-in case asserting it proceeds to checkout.

❌ User should not see the `site-or-domain` step (check the testing instructions)
<img width="1840" height="1140" alt="Screenshot 2026-07-22 at 20 26 11" src="https://github.com/user-attachments/assets/3b13b38f-c17c-4c5d-b810-48c045721e74" />

## Why are these changes being made?

The `calypso_signup_domain_only_checkout_simplification_v1` treatment (shipped as the default in #112218) only skipped `site-or-domain` for logged-in users. For logged-out users, the still-pending account step left the flow "not every step submitted", so the framework's `goToNextStep()` advanced by array index from `domain-only` straight back onto the just-skipped `site-or-domain` step. This makes the skip behave consistently across both auth states.

## Testing Instructions

Use the **Calypso Live** link from the auto-generated comment on this PR (the build tag changes as new commits are pushed). The direct link for the current build is:
[`https://calypso.live/start/domain/domain-only?image=registry.a8c.com/calypso/app:build-189712`](https://calypso.live/start/domain/domain-only?image=registry.a8c.com/calypso/app:build-189712)

**Logged out**

1. Make sure you are logged out.
2. Go to `/start/domain/domain-only`.
3. Add a domain to the cart and press continue.
4. Check that the next step is the sign-up (account creation) step, not "Choose how to use your domain".
5. After logging in / creating the account, check that the next step is checkout.

**Logged in**

1. While logged in, add a domain to the cart and press continue.
2. Check that the next step is checkout.

You can also run the unit tests: `yarn test-client client/signup/steps/domains`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
