### PR TITLE
Restore Unit Tests on trunk

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -570,7 +570,6 @@ object RunAllUnitTests : BuildType({
 			branchFilter = """
 				+:*
 				-:pull*
-				-:trunk
 			""".trimIndent()
 		}
 	}
@@ -611,6 +610,7 @@ object RunAllUnitTests : BuildType({
 				messageFormat = simpleMessageFormat()
 			}
 			branchFilter = """
+				+:trunk
 				+:gh-readonly-queue/*
 			""".trimIndent()
 			buildFailedToStart = true


### PR DESCRIPTION
Follow-up to #112165

## Proposed Changes

* Restore `RunAllUnitTests` trunk coverage by removing the `-:trunk` VCS trigger exclusion.
* Add `+:trunk` back to the Unit Tests Slack notification filter while keeping merge-queue notifications.

## Why are these changes being made?

* Unit Tests were previously changed to run on PR/feature branches and merge queue refs, but not on trunk.
* This brings back the post-merge trunk signal without dropping the merge-queue coverage added in the previous change.

## Testing Instructions

* Confirm `.teamcity/_self/projects/WebApp.kt` leaves the Unit Tests VCS trigger as `+:*` and `-:pull*`, with no trunk exclusion.
* Confirm the Unit Tests notification filter includes both `+:trunk` and `+:gh-readonly-queue/*`.
* Ran `git diff --check -- .teamcity/_self/projects/WebApp.kt`.
* Attempted `mvn org.jetbrains.teamcity:teamcity-configs-maven-plugin:generate` from `.teamcity`; it could not complete because `teamcity.a8c.com` timed out while resolving `org.jetbrains.teamcity:configs-dsl-kotlin-parent`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
