### PR TITLE
Advertise canonical show-component ability names

### DIFF
--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -59,6 +59,8 @@ let mockBlocksByClientId: Record< string, any > = {};
 let mockEditorBlocks: any[] = [];
 const SHOW_COMPONENT_TOOL_ID = 'jetpack_ai__show_component';
 const LEGACY_SHOW_COMPONENT_TOOL_ID = 'big_sky__show_component';
+const SHOW_COMPONENT_ABILITY_NAME = 'jetpack-ai/show-component';
+const LEGACY_SHOW_COMPONENT_ABILITY_NAME = 'big-sky/show-component';
 const AI_EDITORIAL_REVIEW_CONTRACT_ENTRY = {
 	id: 'ai-editorial-review-contract',
 	type: 'ai-editorial-review-contract',
@@ -2873,15 +2875,17 @@ describe( 'toolProvider', () => {
 			const names = abilities.map( ( a: any ) => a.name );
 
 			expect( names ).toContain( 'wpcom/update-block-content' );
-			expect( names ).toContain( SHOW_COMPONENT_TOOL_ID );
-			expect( names ).toContain( LEGACY_SHOW_COMPONENT_TOOL_ID );
+			expect( names ).toContain( SHOW_COMPONENT_ABILITY_NAME );
+			expect( names ).toContain( LEGACY_SHOW_COMPONENT_ABILITY_NAME );
+			expect( names ).not.toContain( SHOW_COMPONENT_TOOL_ID );
+			expect( names ).not.toContain( LEGACY_SHOW_COMPONENT_TOOL_ID );
 		} );
 
 		it( 'wires a callback on each provided ability', async () => {
 			const abilities = await toolProvider.getAbilities();
-			const showComponent = abilities.find( ( a: any ) => a.name === SHOW_COMPONENT_TOOL_ID );
+			const showComponent = abilities.find( ( a: any ) => a.name === SHOW_COMPONENT_ABILITY_NAME );
 			const legacyShowComponent = abilities.find(
-				( a: any ) => a.name === LEGACY_SHOW_COMPONENT_TOOL_ID
+				( a: any ) => a.name === LEGACY_SHOW_COMPONENT_ABILITY_NAME
 			);
 			const updateBlock = abilities.find( ( a: any ) => a.name === 'wpcom/update-block-content' );
 
@@ -2906,7 +2910,7 @@ describe( 'toolProvider', () => {
 
 			const abilities = await toolProvider.getAbilities();
 			const legacyShowComponent = abilities.find(
-				( a: any ) => a.name === LEGACY_SHOW_COMPONENT_TOOL_ID
+				( a: any ) => a.name === LEGACY_SHOW_COMPONENT_ABILITY_NAME
 			);
 			const result = await legacyShowComponent.callback( args );
 
@@ -2929,7 +2933,7 @@ describe( 'toolProvider', () => {
 
 			const abilities = await toolProvider.getAbilities();
 			const legacyShowComponent = abilities.find(
-				( a: any ) => a.name === LEGACY_SHOW_COMPONENT_TOOL_ID
+				( a: any ) => a.name === LEGACY_SHOW_COMPONENT_ABILITY_NAME
 			);
 			const result = await legacyShowComponent.callback( {
 				type,
@@ -2948,8 +2952,8 @@ describe( 'toolProvider', () => {
 			const names = abilities.map( ( a: any ) => a.name );
 
 			expect( names ).not.toContain( 'wpcom/update-block-content' );
-			expect( names ).toContain( SHOW_COMPONENT_TOOL_ID );
-			expect( names ).toContain( LEGACY_SHOW_COMPONENT_TOOL_ID );
+			expect( names ).toContain( SHOW_COMPONENT_ABILITY_NAME );
+			expect( names ).toContain( LEGACY_SHOW_COMPONENT_ABILITY_NAME );
 		} );
 	} );
 
@@ -2972,6 +2976,18 @@ describe( 'toolProvider', () => {
 			expect( result ).toMatchObject( { success: false } );
 			expect( ( result as any ).error ).toMatch( /no component registered/ );
 		} );
+
+		it.each( [ SHOW_COMPONENT_ABILITY_NAME, SHOW_COMPONENT_TOOL_ID ] )(
+			'accepts Jetpack show-component as %s',
+			async ( name ) => {
+				const { result } = ( await toolProvider.executeAbility( name, {
+					type: 'title-picker',
+					props: { titles: [] },
+				} ) ) as any;
+
+				expect( JSON.parse( result.agentMessage ).tool_id ).toBe( SHOW_COMPONENT_TOOL_ID );
+			}
+		);
 
 		it( 'returns an agentMessage envelope for a valid title-picker call', async () => {
 			const titles = [
@@ -3080,22 +3096,25 @@ describe( 'toolProvider', () => {
 			expect( parsed.data.calypsoCheckpointId ).toBe( 'call_alt' );
 		} );
 
-		it( 'accepts the legacy Big Sky show-component tool during migration', async () => {
-			const { result } = ( await toolProvider.executeAbility( LEGACY_SHOW_COMPONENT_TOOL_ID, {
-				type: 'ai-editorial-review',
-				props: {
-					summary: 'Summary.',
-					conflicts: [],
-					implications: [],
-					suggested_edits: [],
-					guideline_violations: [],
-				},
-			} ) ) as any;
+		it.each( [ LEGACY_SHOW_COMPONENT_ABILITY_NAME, LEGACY_SHOW_COMPONENT_TOOL_ID ] )(
+			'accepts the legacy Big Sky show-component ability as %s during migration',
+			async ( name ) => {
+				const { result } = ( await toolProvider.executeAbility( name, {
+					type: 'ai-editorial-review',
+					props: {
+						summary: 'Summary.',
+						conflicts: [],
+						implications: [],
+						suggested_edits: [],
+						guideline_violations: [],
+					},
+				} ) ) as any;
 
-			const parsed = JSON.parse( result.agentMessage );
-			expect( parsed.tool_id ).toBe( SHOW_COMPONENT_TOOL_ID );
-			expect( parsed.data.type ).toBe( 'ai-editorial-review' );
-		} );
+				const parsed = JSON.parse( result.agentMessage );
+				expect( parsed.tool_id ).toBe( SHOW_COMPONENT_TOOL_ID );
+				expect( parsed.data.type ).toBe( 'ai-editorial-review' );
+			}
+		);
 
 		it.each( [
 			[ 'Jetpack AI', SHOW_COMPONENT_TOOL_ID ],

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -394,10 +394,12 @@ function applySuggestionLimit< T extends { id: string } >(
 
 const SHOW_COMPONENT_TOOL_ID = 'jetpack_ai__show_component';
 const LEGACY_SHOW_COMPONENT_TOOL_ID = 'big_sky__show_component';
+const SHOW_COMPONENT_ABILITY_NAME = 'jetpack-ai/show-component';
+const LEGACY_SHOW_COMPONENT_ABILITY_NAME = 'big-sky/show-component';
 const SHOW_COMPONENT_TOOL_IDS = [ SHOW_COMPONENT_TOOL_ID, LEGACY_SHOW_COMPONENT_TOOL_ID ];
 
 /**
- * Client-side ability definition for `jetpack_ai__show_component`.
+ * Client-side ability definition for `jetpack-ai/show-component`.
  *
  * Surfaced to AM via `toolProvider.getAbilities()` so the orchestrator
  * recognizes Jetpack-owned component tool calls. Same pattern as
@@ -405,7 +407,7 @@ const SHOW_COMPONENT_TOOL_IDS = [ SHOW_COMPONENT_TOOL_ID, LEGACY_SHOW_COMPONENT_
  */
 const SHOW_COMPONENT_ABILITY: any = {
 	id: SHOW_COMPONENT_TOOL_ID,
-	name: SHOW_COMPONENT_TOOL_ID,
+	name: SHOW_COMPONENT_ABILITY_NAME,
 	label: 'Show component',
 	category: 'jetpack-ai',
 	description: 'Render an interactive component in the chat.',
@@ -422,7 +424,7 @@ const SHOW_COMPONENT_ABILITY: any = {
 const LEGACY_SHOW_COMPONENT_ABILITY: any = {
 	...SHOW_COMPONENT_ABILITY,
 	id: LEGACY_SHOW_COMPONENT_TOOL_ID,
-	name: LEGACY_SHOW_COMPONENT_TOOL_ID,
+	name: LEGACY_SHOW_COMPONENT_ABILITY_NAME,
 };
 
 function hasShowComponentType( type: unknown ): type is string {
@@ -615,7 +617,15 @@ function filterAbility( abilities: any[], toolId: string ): any[] {
 }
 
 function isShowComponentTool( toolId: string ): boolean {
-	return SHOW_COMPONENT_TOOL_IDS.includes( toolId );
+	return (
+		SHOW_COMPONENT_TOOL_IDS.includes( toolId ) ||
+		toolId === SHOW_COMPONENT_ABILITY_NAME ||
+		toolId === LEGACY_SHOW_COMPONENT_ABILITY_NAME
+	);
+}
+
+function isLegacyShowComponentTool( toolId: string ): boolean {
+	return toolId === LEGACY_SHOW_COMPONENT_TOOL_ID || toolId === LEGACY_SHOW_COMPONENT_ABILITY_NAME;
 }
 
 export const toolProvider = {
@@ -679,7 +689,7 @@ export const toolProvider = {
 			return { result, returnToAgent: false };
 		}
 
-		if ( name === LEGACY_SHOW_COMPONENT_TOOL_ID && shouldDelegateLegacyShowComponent( args ) ) {
+		if ( isLegacyShowComponentTool( name ) && shouldDelegateLegacyShowComponent( args ) ) {
 			const executeAbility = getAbilitiesExecuteAbility();
 			if ( executeAbility ) {
 				return executeAbility( 'big-sky/show-component', args );


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes noisy warnings in wpcom due to legacy names: 

```
[22-Jul-2026 18:51:48 UTC] [A2A Abilities] Failed to create Frontend_Ability: jetpack_ai__show_component (error: Ability name must be a string containing a namespace prefix, i.e. "my-plugin/my-ability". It can only contain lowercase alphanumeric characters, dashes and the forward slash.)
[22-Jul-2026 18:51:48 UTC] [A2A Abilities] Failed to create Frontend_Ability: big_sky__show_component (error: Ability name must be a string containing a namespace prefix, i.e. "my-plugin/my-ability". It can only contain lowercase alphanumeric characters, dashes and the forward slash.)
```

## Proposed Changes

* Advertise the Jetpack AI and legacy Big Sky show-component abilities using canonical WordPress Abilities names.
* Keep the sanitized tool IDs used by inbound LLM calls and rendered component messages unchanged.
* Accept canonical and sanitized names in the provider fallback and cover both forms with tests.

## Why are these changes being made?

* The wpcom A2A endpoint validates frontend ability names using the canonical `namespace/ability-name` format. The client was advertising the already-sanitized tool IDs, so the backend rejected both abilities on every request.
* Agenttic derives and matches the sanitized LLM tool ID from the canonical ability name, so advertising the canonical name does not change the tool-call or component-rendering contract.

## Testing Instructions

On simple sites: 
- Sandbox a simple site
- Sandbox widgets.wp.com
- Run `cd apps/agents-manager && yarn dev --sync` to get the changes there
- In sandbox: `tail -f /tmp/php-errors` 
- Make some requests to the sidebar agent
- No warnings
- Things still work

* In Calypso (`yarn start`), send a request that returns a Jetpack AI picker and confirm the picker renders and remains interactive.
* In a Simple, Atomic, or CIAB sandbox (`cd apps/agents-manager && yarn dev --sync`), repeat the picker request and confirm the sanitized inbound tool call resolves locally.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
