### PR TITLE
Purchase Management: show purchase features on purchase management pages

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -474,7 +474,7 @@ export const cancelPurchaseRoute = createRoute( {
 			queryClient.ensureQueryData( plansQuery() ),
 			// Prefetch the default (control) variant; the component refetches
 			// under the 'treatment' key when the split-cancel-remove flag is on.
-			queryClient.ensureQueryData( purchaseCancelFeaturesQuery( purchase.ID ) ),
+			queryClient.ensureQueryData( purchaseCancelFeaturesQuery( purchase.ID, 'treatment' ) ),
 		] );
 		return { purchase, intent };
 	},

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -472,9 +472,7 @@ export const cancelPurchaseRoute = createRoute( {
 			queryClient.ensureQueryData( productsQuery() ),
 			queryClient.ensureQueryData( siteFeaturesQuery( purchase.blog_id ) ),
 			queryClient.ensureQueryData( plansQuery() ),
-			// Prefetch the default (control) variant; the component refetches
-			// under the 'treatment' key when the split-cancel-remove flag is on.
-			queryClient.ensureQueryData( purchaseCancelFeaturesQuery( purchase.ID, 'treatment' ) ),
+			queryClient.ensureQueryData( purchaseCancelFeaturesQuery( purchase.ID ) ),
 		] );
 		return { purchase, intent };
 	},

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -452,10 +452,7 @@ function CancelPurchaseInner() {
 	const { data: plans } = useSuspenseQuery( plansQuery() );
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
 	const { data: purchaseCancelFeatures } = useQuery(
-		purchaseCancelFeaturesQuery(
-			parseInt( purchaseId, 10 ),
-			isSplitCancelRemoveEnabled ? 'treatment' : 'control'
-		)
+		purchaseCancelFeaturesQuery( parseInt( purchaseId, 10 ), 'treatment' )
 	);
 
 	const lastSiteQueryIsError = useRef< boolean >( false );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -452,7 +452,7 @@ function CancelPurchaseInner() {
 	const { data: plans } = useSuspenseQuery( plansQuery() );
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
 	const { data: purchaseCancelFeatures } = useQuery(
-		purchaseCancelFeaturesQuery( parseInt( purchaseId, 10 ), 'treatment' )
+		purchaseCancelFeaturesQuery( parseInt( purchaseId, 10 ) )
 	);
 
 	const lastSiteQueryIsError = useRef< boolean >( false );

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1438,10 +1438,8 @@ export default function PurchaseSettings() {
 	} )();
 
 	const isCentennial = isCentennialPurchase( purchase );
-	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
 	const { data: cancelFeaturesResponse } = useQuery( {
 		...purchaseCancelFeaturesQuery( purchase.ID, 'treatment' ),
-		enabled: isSplitEnabled,
 	} );
 	const features = cancelFeaturesResponse?.features ?? null;
 	const hasExpiryInfo = ! purchase.partner_name || isA4ABillingDragonPurchase( purchase );

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1443,7 +1443,7 @@ export default function PurchaseSettings() {
 		...purchaseCancelFeaturesQuery( purchase.ID, 'treatment' ),
 		enabled: isSplitEnabled,
 	} );
-	const features = isSplitEnabled ? cancelFeaturesResponse?.features ?? null : null;
+	const features = cancelFeaturesResponse?.features ?? null;
 	const hasExpiryInfo = ! purchase.partner_name || isA4ABillingDragonPurchase( purchase );
 
 	const isSmallViewport = useViewportMatch( 'medium', '<' );

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -692,7 +692,7 @@ function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 function PurchaseFeatureItems( { features }: { features: CancellationFeature[] } ) {
 	return (
 		<VStack spacing={ 4 }>
-			<Text weight="bold">{ __( 'What you get' ) }</Text>
+			<Text weight="bold">{ __( 'Included with your purchase' ) }</Text>
 			<VStack as="ul" spacing={ 1 } className="purchase-settings__feature-list">
 				{ features.map( ( feature ) => (
 					<HStack key={ feature.feature_id } as="li" justify="flex-start" spacing={ 3 }>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1439,7 +1439,7 @@ export default function PurchaseSettings() {
 
 	const isCentennial = isCentennialPurchase( purchase );
 	const { data: cancelFeaturesResponse } = useQuery( {
-		...purchaseCancelFeaturesQuery( purchase.ID, 'treatment' ),
+		...purchaseCancelFeaturesQuery( purchase.ID ),
 	} );
 	const features = cancelFeaturesResponse?.features ?? null;
 	const hasExpiryInfo = ! purchase.partner_name || isA4ABillingDragonPurchase( purchase );

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -1579,7 +1579,7 @@ const ConnectedCancelPurchase = connect(
 function CancelPurchaseWithExperiment( props: CancelPurchaseProps ) {
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
 	const { data: purchaseCancelFeatures, isPending: isPurchaseCancelFeaturesLoading } = useQuery(
-		purchaseCancelFeaturesQuery( props.purchaseId, 'treatment' )
+		purchaseCancelFeaturesQuery( props.purchaseId )
 	);
 	return (
 		<ConnectedCancelPurchase

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -1579,10 +1579,7 @@ const ConnectedCancelPurchase = connect(
 function CancelPurchaseWithExperiment( props: CancelPurchaseProps ) {
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
 	const { data: purchaseCancelFeatures, isPending: isPurchaseCancelFeaturesLoading } = useQuery(
-		purchaseCancelFeaturesQuery(
-			props.purchaseId,
-			isSplitCancelRemoveEnabled ? 'treatment' : 'control'
-		)
+		purchaseCancelFeaturesQuery( props.purchaseId, 'treatment' )
 	);
 	return (
 		<ConnectedCancelPurchase

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -105,7 +105,7 @@ export function cancelPurchase( context, next ) {
 
 	// Start fetching cancel features immediately — the useQuery inside
 	// CancelPurchaseWrapper will reuse this in-flight promise.
-	queryClient.prefetchQuery( purchaseCancelFeaturesQuery( purchaseId ) );
+	queryClient.prefetchQuery( purchaseCancelFeaturesQuery( purchaseId, 'treatment' ) );
 
 	const CancelPurchaseWrapper = localize( () => {
 		// React Query owns the cancellation-features fetch: cancel-on-unmount,
@@ -113,7 +113,7 @@ export function cancelPurchase( context, next ) {
 		// dashboard side uses the same query at
 		// client/dashboard/me/billing-purchases/cancel-purchase/index.tsx.
 		const { data: purchaseCancelFeatures, isLoading: isPurchaseCancelFeaturesLoading } = useQuery(
-			purchaseCancelFeaturesQuery( purchaseId )
+			purchaseCancelFeaturesQuery( purchaseId, 'treatment' )
 		);
 		return (
 			<PurchasesWrapper title={ pageTitle }>

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -105,7 +105,7 @@ export function cancelPurchase( context, next ) {
 
 	// Start fetching cancel features immediately — the useQuery inside
 	// CancelPurchaseWrapper will reuse this in-flight promise.
-	queryClient.prefetchQuery( purchaseCancelFeaturesQuery( purchaseId, 'treatment' ) );
+	queryClient.prefetchQuery( purchaseCancelFeaturesQuery( purchaseId ) );
 
 	const CancelPurchaseWrapper = localize( () => {
 		// React Query owns the cancellation-features fetch: cancel-on-unmount,
@@ -113,7 +113,7 @@ export function cancelPurchase( context, next ) {
 		// dashboard side uses the same query at
 		// client/dashboard/me/billing-purchases/cancel-purchase/index.tsx.
 		const { data: purchaseCancelFeatures, isLoading: isPurchaseCancelFeaturesLoading } = useQuery(
-			purchaseCancelFeaturesQuery( purchaseId, 'treatment' )
+			purchaseCancelFeaturesQuery( purchaseId )
 		);
 		return (
 			<PurchasesWrapper title={ pageTitle }>

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1837,7 +1837,7 @@ function mapDispatchToProps( dispatch: CalypsoDispatch ) {
 function ManagePurchaseWithExperiment( props: ManagePurchaseProps ) {
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
 	const { data: cancelFeaturesResponse } = useQuery( {
-		...purchaseCancelFeaturesQuery( props.purchaseId, 'treatment' ),
+		...purchaseCancelFeaturesQuery( props.purchaseId ),
 	} );
 	const cancellationFeatures = cancelFeaturesResponse?.features ?? null;
 	return (

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1067,7 +1067,7 @@ class ManagePurchase extends Component<
 		}
 
 		if ( isPlan( purchase ) && plan ) {
-			return plan.getDescription();
+			return null;
 		}
 
 		if ( isThemePurchase( purchase ) && theme ) {
@@ -1160,8 +1160,7 @@ class ManagePurchase extends Component<
 	}
 
 	renderPurchaseDescription() {
-		const { purchase, site, translate, isSplitCancelRemoveEnabled, cancellationFeatures } =
-			this.props;
+		const { purchase, site, translate, cancellationFeatures } = this.props;
 
 		if ( ! purchase ) {
 			return null;
@@ -1169,23 +1168,6 @@ class ManagePurchase extends Component<
 
 		if ( isMarketplaceHoldingSitePurchase( purchase ) || isA4AHoldingSitePurchase( purchase ) ) {
 			return null;
-		}
-
-		// When the split flag is on and the API has returned features for this
-		// purchase, show the feature list instead of the description.
-		if ( isSplitCancelRemoveEnabled && cancellationFeatures && cancellationFeatures.length > 0 ) {
-			return (
-				<div className="manage-purchase__content">
-					<ul className="manage-purchase__feature-list-items">
-						{ cancellationFeatures.map( ( feature ) => (
-							<li key={ feature.feature_id } className="manage-purchase__feature-list-item">
-								<Icon icon={ check } size={ 24 } className="manage-purchase__feature-icon" />
-								<span>{ feature.title }</span>
-							</li>
-						) ) }
-					</ul>
-				</div>
-			);
 		}
 
 		const registrationAgreementUrl = getDomainRegistrationAgreementUrl( purchase );
@@ -1221,19 +1203,32 @@ class ManagePurchase extends Component<
 		return (
 			<div className="manage-purchase__content">
 				<span className="manage-purchase__description">
-					<div className="manage-purchase__content-domain-description">
-						{ this.getPurchaseDescription() }
-					</div>
-					<div className="manage-purchase__content-domain-description">
-						{ purchase.productType === 'domain_transfer' && (
-							<>
+					{ this.getPurchaseDescription() && (
+						<div className="manage-purchase__content-purchase-description">
+							{ this.getPurchaseDescription() }
+						</div>
+					) }
+					{ purchase.productType === 'domain_transfer' && (
+						<>
+							<div className="manage-purchase__content-domain-description">
 								{ cancelText } { domainTransferDuration }
-							</>
-						) }
-					</div>
-					<div className="manage-purchase__content-domain-description">
-						{ purchase.productType === 'domain_transfer' && supportText }
-					</div>
+							</div>
+							<div className="manage-purchase__content-domain-description">{ supportText }</div>
+						</>
+					) }
+					{ cancellationFeatures && cancellationFeatures.length > 0 && (
+						<div className="manage-purchase__content-purchase-features">
+							<strong>{ translate( 'Included with your purchase' ) }</strong>
+							<ul className="manage-purchase__feature-list-items">
+								{ cancellationFeatures.map( ( feature ) => (
+									<li key={ feature.feature_id } className="manage-purchase__feature-list-item">
+										<Icon icon={ check } size={ 24 } className="manage-purchase__feature-icon" />
+										<span>{ feature.title }</span>
+									</li>
+								) ) }
+							</ul>
+						</div>
+					) }
 				</span>
 
 				<span className="manage-purchase__settings-link">

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1843,11 +1843,8 @@ function ManagePurchaseWithExperiment( props: ManagePurchaseProps ) {
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
 	const { data: cancelFeaturesResponse } = useQuery( {
 		...purchaseCancelFeaturesQuery( props.purchaseId, 'treatment' ),
-		enabled: isSplitCancelRemoveEnabled,
 	} );
-	const cancellationFeatures = isSplitCancelRemoveEnabled
-		? cancelFeaturesResponse?.features ?? null
-		: null;
+	const cancellationFeatures = cancelFeaturesResponse?.features ?? null;
 	return (
 		<ConnectedManagePurchase
 			{ ...props }

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -80,7 +80,6 @@ import CancelPurchaseForm from 'calypso/components/marketing-survey/cancel-purch
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
-import { useIsSplitCancelRemoveEnabled } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled';
 import {
 	getCancelButtonCopy,
 	getRemoveButtonCopy,
@@ -216,7 +215,6 @@ export interface ManagePurchaseProps {
 }
 
 export interface ManagePurchaseConnectedProps {
-	isSplitCancelRemoveEnabled: boolean;
 	cancellationFeatures: CancellationFeature[] | null;
 	hasCustomPrimaryDomain?: boolean | null;
 	hasLoadedDomains?: boolean;
@@ -1200,12 +1198,14 @@ class ManagePurchase extends Component<
 			'Domain transfers can take anywhere from five to seven days to complete.'
 		);
 
+		const purchaseDescription = this.getPurchaseDescription() ?? null;
+
 		return (
 			<div className="manage-purchase__content">
 				<span className="manage-purchase__description">
-					{ this.getPurchaseDescription() && (
+					{ purchaseDescription && (
 						<div className="manage-purchase__content-purchase-description">
-							{ this.getPurchaseDescription() }
+							{ purchaseDescription }
 						</div>
 					) }
 					{ purchase.productType === 'domain_transfer' && (
@@ -1835,18 +1835,11 @@ function mapDispatchToProps( dispatch: CalypsoDispatch ) {
 }
 
 function ManagePurchaseWithExperiment( props: ManagePurchaseProps ) {
-	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
 	const { data: cancelFeaturesResponse } = useQuery( {
 		...purchaseCancelFeaturesQuery( props.purchaseId ),
 	} );
 	const cancellationFeatures = cancelFeaturesResponse?.features ?? null;
-	return (
-		<ConnectedManagePurchase
-			{ ...props }
-			isSplitCancelRemoveEnabled={ isSplitCancelRemoveEnabled }
-			cancellationFeatures={ cancellationFeatures }
-		/>
-	);
+	return <ConnectedManagePurchase { ...props } cancellationFeatures={ cancellationFeatures } />;
 }
 
 export default ManagePurchaseWithExperiment;

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -140,8 +140,9 @@
 	}
 }
 
+.manage-purchase__content-purchase-description,
 .manage-purchase__content-domain-description {
-	margin-bottom: 4px;
+	margin-bottom: 8px;
 }
 
 .manage-purchase__header {
@@ -236,7 +237,6 @@
 	list-style: none;
 	margin: 0;
 	padding: 0;
-	transform: translateX( -4px );
 }
 
 .manage-purchase__feature-list-item {

--- a/client/me/purchases/product-link/index.jsx
+++ b/client/me/purchases/product-link/index.jsx
@@ -23,7 +23,7 @@ const ProductLink = ( { productUrl, purchase, selectedSite } ) => {
 	}
 
 	if ( isPlan( purchase ) ) {
-		url = '/plans/my-plan/' + selectedSite.slug;
+		url = '/plans/' + selectedSite.slug;
 		if ( isJetpackCloud() ) {
 			url = 'https://wordpress.com' + url;
 		}

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
@@ -228,7 +228,7 @@ const DowngradeConfirmationModal = ( {
 	const translate = useTranslate();
 
 	const { data: cancelFeaturesData, isLoading } = useQuery( {
-		...purchaseCancelFeaturesQuery( purchaseId ?? 0, 'control', targetPlanSlug ?? undefined ),
+		...purchaseCancelFeaturesQuery( purchaseId ?? 0, 'treatment', targetPlanSlug ?? undefined ),
 		enabled: !! purchaseId && !! targetPlanSlug && isOpen,
 		// The feature delta is fixed for the dialog's lifetime. Don't refetch on
 		// window focus: in the instant-downgrade flow the dialog stays open (with its

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -706,7 +706,7 @@ const PlansFeaturesMain = ( {
 		if ( currentPlanPurchaseId ) {
 			try {
 				await queryClient.ensureQueryData(
-					purchaseCancelFeaturesQuery( currentPlanPurchaseId, 'control', planSlug )
+					purchaseCancelFeaturesQuery( currentPlanPurchaseId, 'treatment', planSlug )
 				);
 			} catch {
 				// Open the modal regardless; its own query will retry and show a spinner.

--- a/packages/api-queries/src/upgrades.ts
+++ b/packages/api-queries/src/upgrades.ts
@@ -59,7 +59,7 @@ export const purchaseQuery = ( purchaseId: number ) =>
  */
 export const purchaseCancelFeaturesQuery = (
 	purchaseId: number,
-	variant: 'control' | 'treatment' = 'control',
+	variant: 'control' | 'treatment' = 'treatment',
 	targetProductSlug?: string
 ) =>
 	queryOptions( {


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-2282/
Part of https://linear.app/a8c/issue/DSGCOM-701/

## Proposed Changes

This removes the feature flag gating to show the purchase features on the purchase management page in both MSD and Calypso. It also changes the default feature list to the updated "treatment" features from the RSM cancellation flow improvements, and in Calypso, update the "Plan Features" link to link to the plans grid.

| Before | After |
| ----------- | ----------- |
| <img width="1394" height="362" alt="CleanShot 2026-07-22 at 13 09 16@2x" src="https://github.com/user-attachments/assets/0eb4dd2b-7eaa-4b82-aa20-226078502941" /> MSD Purchase Management | <img width="1388" height="882" alt="CleanShot 2026-07-22 at 13 08 58@2x" src="https://github.com/user-attachments/assets/9a4ecd7f-32a2-49f9-ab10-ce50fe4bfcbb" /> MSD Purchase Management |
| <img width="2140" height="686" alt="CleanShot 2026-07-22 at 15 51 14@2x" src="https://github.com/user-attachments/assets/0b00aeef-e5a8-45d5-a6e0-2c138626259d" /> Calypso Purchase Management | <img width="2132" height="1074" alt="CleanShot 2026-07-22 at 15 51 21@2x" src="https://github.com/user-attachments/assets/0c67c4e5-baf9-457d-967d-185c423ee48f" /> Calypso Purchase Management |
| <img width="1434" height="1192" alt="CleanShot 2026-07-22 at 15 22 54@2x" src="https://github.com/user-attachments/assets/b7ca2894-5498-47e4-a808-ff2ece3d8fcf" /> Cancellation/Removal Flow | <img width="1416" height="1234" alt="CleanShot 2026-07-22 at 15 23 03@2x" src="https://github.com/user-attachments/assets/76fd23e1-1698-437e-944e-f2e9cc995d92" /> Cancellation/Removal Flow |

## Why are these changes being made?

Missing plan features from the purchase management pages were noted in previous design audits, and give the user a sense of what key features are included in their plan _before_ they enter the cancellation flow. The new feature list (the `treatment` value from the endpoint) fills out missing features for a number of products, is worded to remove internal terminology, and ordered with higher-value features at the top of the list. Anywhere the features list is used, we're updating to the treatment variant. The variant flag from the endpoint will be removed in a follow-up.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the purchase management page for a variety of product types.
* Verify that the product features are included on the purchase management page and match the same list in the first step of the cancellation and removal flows.
