### PR TITLE
Marketplace: separate install-error decision from rendering

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -7,6 +7,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
 import theme from 'calypso/my-sites/marketplace/theme';
 import './style.scss';
+import ProductInstallErrorView from './product-install-error';
 import { useProductInstall } from './use-product-install';
 
 const MarketplaceProductInstall = ( {
@@ -16,10 +17,12 @@ const MarketplaceProductInstall = ( {
 	pluginSlug?: string;
 	themeSlug?: string;
 } ) => {
-	const { siteId, currentStep, steps, additionalSteps, error } = useProductInstall( {
-		pluginSlug,
-		themeSlug,
-	} );
+	const { siteId, currentStep, steps, additionalSteps, error, onActivateTheme } = useProductInstall(
+		{
+			pluginSlug,
+			themeSlug,
+		}
+	);
 
 	return (
 		<ThemeProvider theme={ theme }>
@@ -40,7 +43,14 @@ const MarketplaceProductInstall = ( {
 				<WordPressLogo className="marketplace-plugin-install__logo" size={ 24 } />
 			</Masterbar>
 			<div className="marketplace-plugin-install__root">
-				{ error || (
+				{ error ? (
+					<ProductInstallErrorView
+						error={ error }
+						pluginSlug={ pluginSlug }
+						themeSlug={ themeSlug }
+						onActivateTheme={ onActivateTheme }
+					/>
+				) : (
 					<MarketplaceProgressBar
 						steps={ steps }
 						currentStep={ currentStep }

--- a/client/my-sites/marketplace/pages/marketplace-product-install/product-install-error.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/product-install-error.tsx
@@ -1,0 +1,118 @@
+import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
+import { useTranslate } from 'i18n-calypso';
+import EmptyContent from 'calypso/components/empty-content';
+import { useSelector } from 'calypso/state';
+import { getTheme } from 'calypso/state/themes/selectors';
+import { getSelectedSite, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import ThemeDirectInstall from './theme-direct-install';
+import type { ProductInstallError } from './use-product-install';
+
+export default function ProductInstallErrorView( {
+	error,
+	pluginSlug,
+	themeSlug,
+	onActivateTheme,
+}: {
+	error: ProductInstallError;
+	pluginSlug: string;
+	themeSlug: string;
+	onActivateTheme: () => void;
+} ) {
+	const translate = useTranslate();
+	const selectedSite = useSelector( getSelectedSite );
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const wpOrgTheme = useSelector( ( state ) => getTheme( state, 'wporg', themeSlug ) );
+
+	const uploadPageURL = `/plugins/upload/${ selectedSiteSlug }`;
+	const wpAdminUploadURL = `https://${ selectedSiteSlug }/wp-admin/plugin-install.php?tab=upload`;
+
+	switch ( error.type ) {
+		case 'non-installable-plan': {
+			const businessPlanName = getPlan( PLAN_BUSINESS )?.getTitle() ?? '';
+			return (
+				<EmptyContent
+					title={ null }
+					line={ translate(
+						"Your current plan doesn't allow plugin installation. Please upgrade to %(businessPlanName)s plan first.",
+						{
+							args: { businessPlanName },
+						}
+					) }
+					action={ translate( 'Upgrade to %(planName)s Plan', {
+						args: { planName: businessPlanName },
+					} ) }
+					actionURL={ `/checkout/${ selectedSite?.slug }/business?redirect_to=/marketplace/plugin/${ pluginSlug }/install/${ selectedSite?.slug }#step2` }
+				/>
+			);
+		}
+		case 'no-direct-access-upload':
+			return (
+				<EmptyContent
+					title={ null }
+					line={ translate(
+						'This URL should not be accessed directly. Please try to upload the plugin again.'
+					) }
+					action={ translate( 'Go to the upload page' ) }
+					actionURL={ `/plugins/upload/${ selectedSite?.slug }` }
+				/>
+			);
+		case 'theme-direct-install':
+			return (
+				<ThemeDirectInstall
+					themeSlug={ themeSlug }
+					pluginSlug={ pluginSlug }
+					siteSlug={ selectedSite?.slug }
+					theme={ wpOrgTheme }
+					onActivate={ onActivateTheme }
+				/>
+			);
+		case 'rejected-upload': {
+			// Separate translate() calls per reason so the strings stay extractable.
+			let line;
+			switch ( error.reason ) {
+				case 'exists':
+					line = translate(
+						'This plugin already exists on your site. If you want to upgrade or downgrade the plugin, please continue by uploading the plugin again from WP Admin.'
+					);
+					break;
+				case 'malicious':
+					line = translate(
+						'This plugin is identified as malicious. If you still insist to install the plugin, please continue by uploading the plugin again from WP Admin.'
+					);
+					break;
+				case 'too-big':
+					line = translate(
+						'This plugin is too big to be installed via this page. If you still want to install the plugin, please continue by uploading the plugin again from WP Admin.'
+					);
+					break;
+			}
+			return (
+				<EmptyContent
+					title={ null }
+					line={ line }
+					secondaryAction={ translate( 'Back' ) }
+					secondaryActionURL={ uploadPageURL }
+					action={ translate( 'Re-upload plugin' ) }
+					actionURL={ wpAdminUploadURL }
+				/>
+			);
+		}
+		case 'generic':
+			return (
+				<EmptyContent
+					title={ null }
+					line={ translate(
+						'An error occurred while installing the plugin. Please try uploading it again from WP Admin.'
+					) }
+					secondaryAction={ translate( 'Back' ) }
+					secondaryActionURL={
+						! pluginSlug && ! themeSlug
+							? uploadPageURL
+							: `/plugins/${ pluginSlug }/${ selectedSiteSlug }`
+					}
+					action={ translate( 'Upload from WP Admin' ) }
+					actionURL={ wpAdminUploadURL }
+				/>
+			);
+	}
+}

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ */
+import marketplaceReducer from 'calypso/state/marketplace/reducer';
+import pluginsReducer from 'calypso/state/plugins/reducer';
+import themesReducer from 'calypso/state/themes/reducer';
+import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
+import { useProductInstall } from '../use-product-install';
+
+// useProductInstall reads several section-lazy slices that the bare test store doesn't register.
+const reducers = {
+	plugins: pluginsReducer,
+	themes: themesReducer,
+	marketplace: marketplaceReducer,
+};
+
+const renderProductInstall = ( props: { pluginSlug?: string; themeSlug?: string } ) =>
+	renderHookWithProvider( () => useProductInstall( props ), { reducers } );
+
+describe( 'useProductInstall', () => {
+	describe( 'steps', () => {
+		it( 'lists set-up, install, and activate for a marketplace plugin', () => {
+			const { result } = renderProductInstall( { pluginSlug: 'give' } );
+			expect( result.current.steps ).toEqual( [
+				'Setting up plugin installation',
+				'Installing plugin',
+				'Activating plugin',
+			] );
+		} );
+
+		it( 'leads with the upload step when no product slug is given', () => {
+			const { result } = renderProductInstall( {} );
+			expect( result.current.steps ).toEqual( [
+				'Uploading plugin',
+				'Installing plugin',
+				'Activating plugin',
+			] );
+		} );
+
+		it( 'uses the two theme steps for a theme slug', () => {
+			const { result } = renderProductInstall( { themeSlug: 'twentytwentyfour' } );
+			expect( result.current.steps ).toEqual( [
+				'Setting up theme installation',
+				'Activating theme',
+			] );
+		} );
+	} );
+} );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
@@ -1,9 +1,11 @@
 /**
  * @jest-environment jsdom
  */
+import { act } from '@testing-library/react';
 import marketplaceReducer from 'calypso/state/marketplace/reducer';
 import pluginsReducer from 'calypso/state/plugins/reducer';
 import themesReducer from 'calypso/state/themes/reducer';
+import uiReducer from 'calypso/state/ui/reducer';
 import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
 import { useProductInstall } from '../use-product-install';
 
@@ -12,10 +14,20 @@ const reducers = {
 	plugins: pluginsReducer,
 	themes: themesReducer,
 	marketplace: marketplaceReducer,
+	ui: uiReducer,
 };
 
-const renderProductInstall = ( props: { pluginSlug?: string; themeSlug?: string } ) =>
-	renderHookWithProvider( () => useProductInstall( props ), { reducers } );
+const SITE_ID = 1;
+
+const renderProductInstall = (
+	props: { pluginSlug?: string; themeSlug?: string },
+	initialState?: object
+) => renderHookWithProvider( () => useProductInstall( props ), { reducers, initialState } );
+
+const withUploadError = ( uploadError: object ) => ( {
+	ui: { selectedSiteId: SITE_ID },
+	plugins: { upload: { uploadError: { [ SITE_ID ]: uploadError } } },
+} );
 
 describe( 'useProductInstall', () => {
 	describe( 'steps', () => {
@@ -44,5 +56,39 @@ describe( 'useProductInstall', () => {
 				'Activating theme',
 			] );
 		} );
+	} );
+
+	describe( 'error', () => {
+		it( 'has no error before any grace period elapses', () => {
+			const { result } = renderProductInstall( { pluginSlug: 'give' } );
+			expect( result.current.error ).toBeNull();
+		} );
+
+		it( 'reports the plan error once the grace period passes for a site that cannot install', () => {
+			jest.useFakeTimers();
+			try {
+				const { result } = renderProductInstall( { pluginSlug: 'give' } );
+				expect( result.current.error ).toBeNull();
+
+				act( () => {
+					jest.advanceTimersByTime( 2000 );
+				} );
+				expect( result.current.error ).toEqual( { type: 'non-installable-plan' } );
+			} finally {
+				jest.useRealTimers();
+			}
+		} );
+
+		it.each( [
+			[ 'exists', { error: 'folder_exists' } ],
+			[ 'malicious', { error: 'plugin_malicious' } ],
+			[ 'too-big', { statusCode: 413 } ],
+		] as const )(
+			'reports a rejected upload (%s) from the upload error state',
+			( reason, uploadError ) => {
+				const { result } = renderProductInstall( {}, withUploadError( uploadError ) );
+				expect( result.current.error ).toEqual( { type: 'rejected-upload', reason } );
+			}
+		);
 	} );
 } );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -1,16 +1,10 @@
 import { siteByIdQuery } from '@automattic/api-queries';
-import {
-	PLAN_BUSINESS,
-	WPCOM_FEATURES_ATOMIC,
-	getPlan,
-	WPCOM_FEATURES_MANAGE_PLUGINS,
-} from '@automattic/calypso-products';
+import { WPCOM_FEATURES_ATOMIC, WPCOM_FEATURES_MANAGE_PLUGINS } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useMemo, useRef } from 'react';
 import { useQueryTheme } from 'calypso/components/data/query-theme';
-import EmptyContent from 'calypso/components/empty-content';
 import { isAtomicTransferredSite } from 'calypso/dashboard/utils/site-atomic-transfers';
 import { useInterval } from 'calypso/lib/interval';
 import { waitFor } from 'calypso/my-sites/marketplace/util';
@@ -51,13 +45,18 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
-import ThemeDirectInstall from './theme-direct-install';
 import { useDelayedCondition } from './use-delayed-condition';
 import useMarketplaceAdditionalSteps from './use-marketplace-additional-steps';
-import type { TranslateResult } from 'i18n-calypso';
 
 // The state authorizing an install is handed off asynchronously, so allow for it arriving late.
 const INSTALL_HANDOFF_GRACE_PERIOD_MS = 2000;
+
+export type ProductInstallError =
+	| { type: 'non-installable-plan' }
+	| { type: 'no-direct-access-upload' }
+	| { type: 'theme-direct-install' }
+	| { type: 'rejected-upload'; reason: 'exists' | 'malicious' | 'too-big' }
+	| { type: 'generic' };
 
 export function useProductInstall( {
 	pluginSlug = '',
@@ -375,107 +374,43 @@ export function useProductInstall( {
 	}, [ themeSlug, isPluginUploadFlow, translate ] );
 	const additionalSteps = useMarketplaceAdditionalSteps();
 
-	const renderError = () => {
-		// Evaluate error causes in priority order
+	// Which error screen to show, in priority order, or null for none. The presentational mapping
+	// lives in ProductInstallErrorView; keeping this as data makes the branching testable.
+	const error: ProductInstallError | null = ( () => {
 		if ( nonInstallablePlanError ) {
-			return (
-				<EmptyContent
-					title={ null }
-					line={ translate(
-						"Your current plan doesn't allow plugin installation. Please upgrade to %(businessPlanName)s plan first.",
-						{
-							args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-						}
-					) }
-					action={ translate( 'Upgrade to %(planName)s Plan', {
-						args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-					} ) }
-					actionURL={ `/checkout/${ selectedSite?.slug }/business?redirect_to=/marketplace/plugin/${ pluginSlug }/install/${ selectedSite?.slug }#step2` }
-				/>
-			);
+			return { type: 'non-installable-plan' };
 		}
 		if ( isPluginUploadFlow && noDirectAccessError && ! directInstallationAllowed ) {
-			return (
-				<EmptyContent
-					title={ null }
-					line={ translate(
-						'This URL should not be accessed directly. Please try to upload the plugin again.'
-					) }
-					action={ translate( 'Go to the upload page' ) }
-					actionURL={ `/plugins/upload/${ selectedSite?.slug }` }
-				/>
-			);
+			return { type: 'no-direct-access-upload' };
 		}
-
 		if ( themeSlug && noDirectAccessError && ! directInstallationAllowed ) {
-			return (
-				<ThemeDirectInstall
-					themeSlug={ themeSlug }
-					pluginSlug={ pluginSlug }
-					siteSlug={ selectedSite?.slug }
-					theme={ wpOrgTheme }
-					onActivate={ () => setUserDirectInstallationAllowed( true ) }
-				/>
-			);
+			return { type: 'theme-direct-install' };
 		}
-		const uploadPageURL = `/plugins/upload/${ selectedSiteSlug }`;
-		const wpAdminUploadURL = `https://${ selectedSiteSlug }/wp-admin/plugin-install.php?tab=upload`;
-
-		// Rejected uploads all offer the same way out: back to the upload page, or retry in WP Admin.
-		const rejectedUploadLine: TranslateResult | false =
-			( pluginExists &&
-				translate(
-					'This plugin already exists on your site. If you want to upgrade or downgrade the plugin, please continue by uploading the plugin again from WP Admin.'
-				) ) ||
-			( pluginMalicious &&
-				translate(
-					'This plugin is identified as malicious. If you still insist to install the plugin, please continue by uploading the plugin again from WP Admin.'
-				) ) ||
-			( pluginTooBig &&
-				translate(
-					'This plugin is too big to be installed via this page. If you still want to install the plugin, please continue by uploading the plugin again from WP Admin.'
-				) );
-
-		if ( rejectedUploadLine ) {
-			return (
-				<EmptyContent
-					title={ null }
-					line={ rejectedUploadLine }
-					secondaryAction={ translate( 'Back' ) }
-					secondaryActionURL={ uploadPageURL }
-					action={ translate( 'Re-upload plugin' ) }
-					actionURL={ wpAdminUploadURL }
-				/>
-			);
+		if ( pluginExists ) {
+			return { type: 'rejected-upload', reason: 'exists' };
 		}
-		// Catch the rest of the error cases.
+		if ( pluginMalicious ) {
+			return { type: 'rejected-upload', reason: 'malicious' };
+		}
+		if ( pluginTooBig ) {
+			return { type: 'rejected-upload', reason: 'too-big' };
+		}
 		if (
 			pluginUploadError ||
 			pluginInstallStatus?.error ||
 			( atomicFlow && automatedTransferStatus === transferStates.FAILURE )
 		) {
-			return (
-				<EmptyContent
-					title={ null }
-					line={ translate(
-						'An error occurred while installing the plugin. Please try uploading it again from WP Admin.'
-					) }
-					secondaryAction={ translate( 'Back' ) }
-					secondaryActionURL={
-						isPluginUploadFlow ? uploadPageURL : `/plugins/${ pluginSlug }/${ selectedSiteSlug }`
-					}
-					action={ translate( 'Upload from WP Admin' ) }
-					actionURL={ wpAdminUploadURL }
-				/>
-			);
+			return { type: 'generic' };
 		}
-	};
+		return null;
+	} )();
 
 	return {
 		siteId,
 		currentStep,
 		steps,
 		additionalSteps,
-		error: renderError(),
+		error,
+		onActivateTheme: () => setUserDirectInstallationAllowed( true ),
 	};
 }


### PR DESCRIPTION
## Proposed Changes

Separate the install page's error *decision* from its *rendering*, and add tests.

The `useProductInstall` hook now returns a small typed error descriptor (which screen to show, in priority order) instead of a rendered element. A new presentational component maps that descriptor to the actual `EmptyContent` / theme-activation screen. Because the branching is now plain data, it can be asserted directly — the tests cover the per-flow step labels, the plan error, and the rejected-upload reasons.

This is a concern-split rather than a per-flow split. The three flows share too much mutable state (the current step, the atomic-transfer flag, the install-initiation effect, the redirect machinery) to separate cleanly, so pulling out cohesive concerns is the decomposition that actually reduces the tangle without duplicating a shared spine. Error rendering is the first such concern.

Behavior is unchanged: the descriptor branches mirror the previous priority order, and the moved user-facing strings are preserved verbatim.

## Why are these changes being made?

The page had no test coverage until now, which is part of why it has needed a steady stream of fixes. Turning the error branching into data makes the riskiest decision logic observable and testable, and shrinks the orchestration hook.

## Testing Instructions

```
yarn test-client client/my-sites/marketplace/pages/marketplace-product-install/test/
```

Behavior is unchanged by construction. Manual smoke: install a plugin and a theme through to their redirects, and confirm the error screens still appear for a plan without plugin support and for a rejected upload.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
