### PR TITLE
Marketplace: extract the thank-you redirect into its own hook

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -1,12 +1,7 @@
-import { siteByIdQuery } from '@automattic/api-queries';
-import { WPCOM_FEATURES_ATOMIC, WPCOM_FEATURES_MANAGE_PLUGINS } from '@automattic/calypso-products';
-import page from '@automattic/calypso-router';
-import { useQuery } from '@tanstack/react-query';
+import { WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useMemo, useRef } from 'react';
 import { useQueryTheme } from 'calypso/components/data/query-theme';
-import { isAtomicTransferredSite } from 'calypso/dashboard/utils/site-atomic-transfers';
-import { useInterval } from 'calypso/lib/interval';
 import { waitFor } from 'calypso/my-sites/marketplace/util';
 import { useSelector, useDispatch } from 'calypso/state';
 import { initiateAtomicTransfer } from 'calypso/state/atomic/transfers/actions';
@@ -14,11 +9,7 @@ import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
 import { getPurchaseFlowState } from 'calypso/state/marketplace/purchase-flow/selectors';
 import { MARKETPLACE_ASYNC_PROCESS_STATUS } from 'calypso/state/marketplace/types';
-import {
-	installPlugin,
-	activatePlugin,
-	fetchSitePlugins,
-} from 'calypso/state/plugins/installed/actions';
+import { installPlugin, activatePlugin } from 'calypso/state/plugins/installed/actions';
 import {
 	getPluginOnSite,
 	getStatusForPlugin,
@@ -33,11 +24,10 @@ import getUploadedPluginId from 'calypso/state/selectors/get-uploaded-plugin-id'
 import isPluginUploadComplete from 'calypso/state/selectors/is-plugin-upload-complete';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import { isJetpackSite, getSiteAdminUrl } from 'calypso/state/sites/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	initiateThemeTransfer as initiateTransfer,
 	installAndActivateTheme,
-	requestActiveTheme,
 } from 'calypso/state/themes/actions';
 import { getTheme, isThemeActive as getThemeActive } from 'calypso/state/themes/selectors';
 import {
@@ -47,6 +37,7 @@ import {
 } from 'calypso/state/ui/selectors';
 import { useDelayedCondition } from './use-delayed-condition';
 import useMarketplaceAdditionalSteps from './use-marketplace-additional-steps';
+import { useThankYouRedirect } from './use-thank-you-redirect';
 
 // The state authorizing an install is handed off asynchronously, so allow for it arriving late.
 const INSTALL_HANDOFF_GRACE_PERIOD_MS = 2000;
@@ -256,108 +247,24 @@ export function useProductInstall( {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ pluginUploadComplete, installedPlugin, setCurrentStep ] );
 
-	// Fetch fresh site data (including admin_url) post-transfer
-	const { data: freshSite } = useQuery( {
-		...siteByIdQuery( siteId ?? 0 ),
-		enabled: !! siteId && ( ! atomicFlow || automatedTransferStatus === transferStates.COMPLETE ),
-		refetchInterval: ( query ) =>
-			query.state.data && isAtomicTransferredSite( query.state.data ) ? false : 2000,
-		staleTime: 0,
-		refetchOnMount: 'always',
-	} );
-
-	const freshAdminUrl = freshSite?.options?.admin_url;
-	const isAtomicTransferReady = freshSite ? isAtomicTransferredSite( freshSite ) : false;
-	const pluginsUrlFresh = freshAdminUrl
-		? `${ freshAdminUrl }plugins.php?activate=true&plugin_status=active`
-		: null;
-
-	const pluginsUrlSelector = useSelector( ( state ) =>
-		getSiteAdminUrl( state, siteId, 'plugins.php?activate=true&plugin_status=active' )
-	);
-
-	// Prefer fresh URL when available; if in atomic flow, wait for fresh URL
-	const pluginsUrlFinal = atomicFlow ? pluginsUrlFresh : pluginsUrlFresh || pluginsUrlSelector;
-
-	// For marketplace plugins (e.g. sensei-pro), the atomic transfer + plugin install
-	// is initiated during checkout, not by this component. The wporg data is unavailable,
-	// so atomicFlow is never set. Once the site is atomic, poll for installed plugins
-	// so that the existing redirect (installedPlugin && pluginActive) fires.
-	const isMarketplacePluginFlow =
-		! atomicFlow &&
-		! isPluginUploadFlow &&
-		!! pluginSlug &&
-		!! freshSite?.is_wpcom_atomic &&
-		wporgPlugin?.wporg === false;
-
-	useInterval(
-		() => dispatch( fetchSitePlugins( siteId ) ),
-		isMarketplacePluginFlow && ! pluginActive ? 3000 : null
-	);
-
-	const canManagePlugins = useSelector( ( state ) => {
-		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );
-	} );
-	// Check completition of all flows and redirect to thank you page
-	useEffect( () => {
-		if (
-			// Happens in 3 cases:
-			// - Click on "Install and activate" button for any plugin on /plugins/<site_name>
-			// - Install with the help of uploading archive of a plugins
-			// - If it's simple site which doesn't support plugins, then installing and activation happens at the same time with upgrading to Business plan
-			( installedPlugin && pluginActive ) ||
-			// Transfer to atomic using a marketplace plugin
-			( atomicFlow &&
-				transferStates.COMPLETE === automatedTransferStatus &&
-				canManagePlugins &&
-				isAtomicTransferReady ) ||
-			// Transfer to atomic uploading a zip plugin
-			( uploadedPluginSlug &&
-				isPluginUploadFlow &&
-				! isAtomic &&
-				transferStates.COMPLETE === automatedTransferStatus &&
-				canManagePlugins &&
-				isAtomicTransferReady )
-		) {
-			// Require a resolved pluginsUrlFinal before redirecting
-			if ( ! pluginsUrlFinal ) {
-				return;
-			}
-			waitFor( 1 ).then( () => {
-				window.location.href = pluginsUrlFinal as string;
-			} );
-		}
-	}, [
-		pluginActive,
-		automatedTransferStatus,
-		atomicFlow,
+	useThankYouRedirect( {
+		siteId,
+		selectedSite,
+		selectedSiteSlug,
+		currentStep,
 		isPluginUploadFlow,
-		isAtomic,
-		canManagePlugins,
+		pluginSlug,
+		themeSlug,
+		wporgPlugin,
+		wpOrgTheme,
+		isThemeActive,
 		installedPlugin,
+		pluginActive,
 		uploadedPluginSlug,
-		pluginsUrlFinal,
-		isAtomicTransferReady,
-	] ); // We need to trigger this hook also when `automatedTransferStatus` changes cause the plugin install is done on the background in that case.
-
-	// Validate theme is already active
-	useEffect( () => {
-		if ( themeSlug && wpOrgTheme && isThemeActive ) {
-			waitFor( 1 ).then( () =>
-				page.redirect(
-					`/marketplace/thank-you/${ selectedSiteSlug }?themes=${ themeSlug }&hide-progress-bar`
-				)
-			);
-		}
-	}, [ themeSlug, wpOrgTheme, isThemeActive, selectedSiteSlug ] );
-
-	// Polling for theme activation status
-	useInterval(
-		() => {
-			dispatch( requestActiveTheme( siteId ) );
-		},
-		! themeSlug || currentStep === 0 || ( themeSlug && wpOrgTheme && isThemeActive ) ? null : 3000
-	);
+		atomicFlow,
+		isAtomic,
+		automatedTransferStatus,
+	} );
 
 	const steps = useMemo( () => {
 		if ( themeSlug ) {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
@@ -1,0 +1,158 @@
+import { siteByIdQuery } from '@automattic/api-queries';
+import { WPCOM_FEATURES_MANAGE_PLUGINS } from '@automattic/calypso-products';
+import page from '@automattic/calypso-router';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { isAtomicTransferredSite } from 'calypso/dashboard/utils/site-atomic-transfers';
+import { useInterval } from 'calypso/lib/interval';
+import { waitFor } from 'calypso/my-sites/marketplace/util';
+import { useSelector, useDispatch } from 'calypso/state';
+import { transferStates } from 'calypso/state/automated-transfer/constants';
+import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
+import { requestActiveTheme } from 'calypso/state/themes/actions';
+
+// The redirect machinery: once a flow completes it fetches the freshest site data, resolves the
+// destination URL, keeps polling where a flow finishes in the background, and navigates. Plugin and
+// upload flows land on wp-admin's plugins page; a theme flow goes to the marketplace thank-you page.
+export function useThankYouRedirect( {
+	siteId,
+	selectedSite,
+	selectedSiteSlug,
+	currentStep,
+	isPluginUploadFlow,
+	pluginSlug,
+	themeSlug,
+	wporgPlugin,
+	wpOrgTheme,
+	isThemeActive,
+	installedPlugin,
+	pluginActive,
+	uploadedPluginSlug,
+	atomicFlow,
+	isAtomic,
+	automatedTransferStatus,
+}: {
+	siteId: number;
+	selectedSite: { ID?: number } | null | undefined;
+	selectedSiteSlug: string | null;
+	currentStep: number;
+	isPluginUploadFlow: boolean;
+	pluginSlug: string;
+	themeSlug: string;
+	wporgPlugin: { wporg?: boolean } | null | undefined;
+	wpOrgTheme: { id?: string } | null | undefined;
+	isThemeActive: boolean;
+	installedPlugin: { slug?: string; id?: string } | null | undefined;
+	pluginActive: boolean;
+	uploadedPluginSlug: string;
+	atomicFlow: boolean;
+	isAtomic: boolean | null;
+	automatedTransferStatus: string | null;
+} ) {
+	const dispatch = useDispatch();
+
+	// Fetch fresh site data (including admin_url) post-transfer
+	const { data: freshSite } = useQuery( {
+		...siteByIdQuery( siteId ?? 0 ),
+		enabled: !! siteId && ( ! atomicFlow || automatedTransferStatus === transferStates.COMPLETE ),
+		refetchInterval: ( query ) =>
+			query.state.data && isAtomicTransferredSite( query.state.data ) ? false : 2000,
+		staleTime: 0,
+		refetchOnMount: 'always',
+	} );
+
+	const freshAdminUrl = freshSite?.options?.admin_url;
+	const isAtomicTransferReady = freshSite ? isAtomicTransferredSite( freshSite ) : false;
+	const pluginsUrlFresh = freshAdminUrl
+		? `${ freshAdminUrl }plugins.php?activate=true&plugin_status=active`
+		: null;
+
+	const pluginsUrlSelector = useSelector( ( state ) =>
+		getSiteAdminUrl( state, siteId, 'plugins.php?activate=true&plugin_status=active' )
+	);
+
+	// Prefer fresh URL when available; if in atomic flow, wait for fresh URL
+	const pluginsUrlFinal = atomicFlow ? pluginsUrlFresh : pluginsUrlFresh || pluginsUrlSelector;
+
+	// For marketplace plugins (e.g. sensei-pro), the atomic transfer + plugin install
+	// is initiated during checkout, not by this component. The wporg data is unavailable,
+	// so atomicFlow is never set. Once the site is atomic, poll for installed plugins
+	// so that the existing redirect (installedPlugin && pluginActive) fires.
+	const isMarketplacePluginFlow =
+		! atomicFlow &&
+		! isPluginUploadFlow &&
+		!! pluginSlug &&
+		!! freshSite?.is_wpcom_atomic &&
+		wporgPlugin?.wporg === false;
+
+	useInterval(
+		() => dispatch( fetchSitePlugins( siteId ) ),
+		isMarketplacePluginFlow && ! pluginActive ? 3000 : null
+	);
+
+	const canManagePlugins = useSelector( ( state ) => {
+		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );
+	} );
+	// Check completition of all flows and redirect to thank you page
+	useEffect( () => {
+		if (
+			// Happens in 3 cases:
+			// - Click on "Install and activate" button for any plugin on /plugins/<site_name>
+			// - Install with the help of uploading archive of a plugins
+			// - If it's simple site which doesn't support plugins, then installing and activation happens at the same time with upgrading to Business plan
+			( installedPlugin && pluginActive ) ||
+			// Transfer to atomic using a marketplace plugin
+			( atomicFlow &&
+				transferStates.COMPLETE === automatedTransferStatus &&
+				canManagePlugins &&
+				isAtomicTransferReady ) ||
+			// Transfer to atomic uploading a zip plugin
+			( uploadedPluginSlug &&
+				isPluginUploadFlow &&
+				! isAtomic &&
+				transferStates.COMPLETE === automatedTransferStatus &&
+				canManagePlugins &&
+				isAtomicTransferReady )
+		) {
+			// Require a resolved pluginsUrlFinal before redirecting
+			if ( ! pluginsUrlFinal ) {
+				return;
+			}
+			waitFor( 1 ).then( () => {
+				window.location.href = pluginsUrlFinal as string;
+			} );
+		}
+	}, [
+		pluginActive,
+		automatedTransferStatus,
+		atomicFlow,
+		isPluginUploadFlow,
+		isAtomic,
+		canManagePlugins,
+		installedPlugin,
+		uploadedPluginSlug,
+		pluginsUrlFinal,
+		isAtomicTransferReady,
+	] ); // We need to trigger this hook also when `automatedTransferStatus` changes cause the plugin install is done on the background in that case.
+
+	// Validate theme is already active
+	useEffect( () => {
+		if ( themeSlug && wpOrgTheme && isThemeActive ) {
+			waitFor( 1 ).then( () =>
+				page.redirect(
+					`/marketplace/thank-you/${ selectedSiteSlug }?themes=${ themeSlug }&hide-progress-bar`
+				)
+			);
+		}
+	}, [ themeSlug, wpOrgTheme, isThemeActive, selectedSiteSlug ] );
+
+	// Polling for theme activation status
+	useInterval(
+		() => {
+			dispatch( requestActiveTheme( siteId ) );
+		},
+		! themeSlug || currentStep === 0 || ( themeSlug && wpOrgTheme && isThemeActive ) ? null : 3000
+	);
+}


### PR DESCRIPTION
## Proposed Changes

Move the post-install redirect machinery out of `useProductInstall` into a `useThankYouRedirect` hook: the fresh-site query, the destination-URL resolution, the background polling for flows that finish server-side, and the two redirect effects (plugin/upload to wp-admin, theme to the marketplace thank-you page).

This is verbatim code motion — the query, conditions, and navigation are unchanged, only relocated with their inputs passed in. The orchestration hook drops from 416 to 323 lines, and the navigation logic (the part of this page most prone to timing bugs) is now isolated in one place.

## Why are these changes being made?

`useProductInstall` had grown into a wall of reads, a state machine, and this redirect machinery all at one level. Pulling the redirect concern out is the largest cleanly-separable block: it consumes state but only produces a side effect (navigation), so it lifts out without entangling the rest.

## Testing Instructions

```
yarn test-client client/my-sites/marketplace/pages/marketplace-product-install/test/
```

The moved logic is unchanged by construction; `typecheck-client` and `eslint` pass. Because the redirect paths are not yet covered by unit tests, smoke-test manually: install a plugin and a theme through to completion and confirm each still redirects (plugin to wp-admin's plugins page, theme to the thank-you page).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
