### PR TITLE
Marketplace: don't re-show the access error after an install completes

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
@@ -29,6 +29,19 @@ const withUploadError = ( uploadError: object ) => ( {
 	plugins: { upload: { uploadError: { [ SITE_ID ]: uploadError } } },
 } );
 
+const SITE_SLUG = 'example.com';
+
+// A site that can install plugins (so the plan-error timer never fires), optionally with a
+// marketplace purchase-flow handoff seeded.
+const withInstallableSite = ( purchaseFlow?: object ) => ( {
+	ui: { selectedSiteId: SITE_ID },
+	sites: {
+		items: { [ SITE_ID ]: { ID: SITE_ID, URL: `https://${ SITE_SLUG }` } },
+		features: { [ SITE_ID ]: { data: { active: [ 'atomic' ] } } },
+	},
+	...( purchaseFlow ? { marketplace: { purchaseFlow } } : {} ),
+} );
+
 describe( 'useProductInstall', () => {
 	describe( 'steps', () => {
 		it( 'lists set-up, install, and activate for a marketplace plugin', () => {
@@ -90,5 +103,41 @@ describe( 'useProductInstall', () => {
 				expect( result.current.error ).toEqual( { type: 'rejected-upload', reason } );
 			}
 		);
+
+		it( 'prompts to activate a theme reached without an install handoff', () => {
+			jest.useFakeTimers();
+			try {
+				const { result } = renderProductInstall(
+					{ themeSlug: 'twentytwentyfour' },
+					withInstallableSite()
+				);
+				act( () => {
+					jest.advanceTimersByTime( 2000 );
+				} );
+				expect( result.current.error ).toEqual( { type: 'theme-direct-install' } );
+			} finally {
+				jest.useRealTimers();
+			}
+		} );
+
+		it( 'does not re-show the access error after an authorized theme install completes', () => {
+			jest.useFakeTimers();
+			try {
+				const { result } = renderProductInstall(
+					{ themeSlug: 'twentytwentyfour' },
+					withInstallableSite( {
+						primaryDomain: SITE_SLUG,
+						productSlugInstalled: 'twentytwentyfour',
+						pluginInstallationStatus: 'COMPLETED',
+					} )
+				);
+				act( () => {
+					jest.advanceTimersByTime( 2000 );
+				} );
+				expect( result.current.error ).toBeNull();
+			} finally {
+				jest.useRealTimers();
+			}
+		} );
 	} );
 } );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -145,11 +145,19 @@ export function useProductInstall( {
 		return () => clearTimeout( id );
 	}, [ hasAtomicFeature, isJetpackSelfHosted, nonInstallablePlanError ] );
 
+	// Whether the marketplace handoff (from checkout or the plugin/theme page) authorized this
+	// install. Unlike marketplaceInstallationInProgress this stays true once the install completes,
+	// so a finished install isn't mistaken for a direct page visit and re-shown the access error.
+	const isMarketplaceInstallAuthorized =
+		primaryDomain === selectedSiteSlug &&
+		!! productSlugInstalled &&
+		[ pluginSlug, themeSlug ].includes( productSlugInstalled );
+
 	const isInstallAuthorizationMissing =
 		// 1. This is a plugin upload flow (via zip file) and we don't have a primary domain set
 		( isPluginUploadFlow && ! primaryDomain ) ||
-		// 2. This is a marketplace plugin installation but the installation process hasn't started
-		( ! isPluginUploadFlow && ! marketplaceInstallationInProgress );
+		// 2. This is a marketplace install that was never authorized (whether or not it has finished)
+		( ! isPluginUploadFlow && ! isMarketplaceInstallAuthorized );
 
 	// Flows that carry their own authorization never render this error, so don't arm the timer.
 	const noDirectAccessError = useDelayedCondition(


### PR DESCRIPTION
## Proposed Changes

Fix the install page re-showing its "should not be accessed directly" screen after a successful install.

The direct-access check inferred "the install was never authorized" from "the install is not currently in progress." But the in-progress signal also drops once an install finishes, so a completed and perfectly valid install looked like a direct page visit and re-armed the access error after the grace period. For a theme install this re-showed the activation prompt on a finished install; the redirect normally navigated away first, but not reliably.

The check now keys off the handoff signals from checkout / the plugin or theme page, which persist past completion, so a finished install is no longer mistaken for a direct visit. The install-trigger logic is untouched.

## Why are these changes being made?

The underlying flag carried two meanings — "hasn't started" and "is no longer running" — and only the first should surface the access error. Separating them removes the spurious screen on the completion path.

## Testing Instructions

```
yarn test-client client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
```

Two regression tests are added: a completed authorized theme install shows no error after the grace period, and a theme reached with no handoff still shows the activation prompt. The first fails on the previous condition and passes on this one.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
