### PR TITLE
Marketplace: name the install strategy behind a tested function

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/install-strategy.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/install-strategy.ts
@@ -1,0 +1,23 @@
+export type InstallStrategy = 'in-place' | 'atomic-transfer' | 'none';
+
+/**
+ * How the requested product should be installed on the current site:
+ * - `in-place`: the site already runs plugins/themes (Jetpack or Atomic), so install directly.
+ * - `atomic-transfer`: a Simple WPCOM site that qualifies for Atomic must transfer first.
+ * - `none`: the site can't install, so nothing is initiated.
+ */
+export function chooseInstallStrategy( {
+	siteInstallsInPlace,
+	siteCanTransferToAtomic,
+}: {
+	siteInstallsInPlace: boolean;
+	siteCanTransferToAtomic: boolean;
+} ): InstallStrategy {
+	if ( siteInstallsInPlace ) {
+		return 'in-place';
+	}
+	if ( siteCanTransferToAtomic ) {
+		return 'atomic-transfer';
+	}
+	return 'none';
+}

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/install-strategy.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/install-strategy.ts
@@ -1,0 +1,24 @@
+import { chooseInstallStrategy } from '../install-strategy';
+
+describe( 'chooseInstallStrategy', () => {
+	it.each( [
+		// siteInstallsInPlace, siteCanTransferToAtomic, expected
+		[ true, true, 'in-place' ],
+		[ true, false, 'in-place' ],
+		[ false, true, 'atomic-transfer' ],
+		[ false, false, 'none' ],
+	] as const )(
+		'installsInPlace=%s, canTransfer=%s -> %s',
+		( siteInstallsInPlace, siteCanTransferToAtomic, expected ) => {
+			expect( chooseInstallStrategy( { siteInstallsInPlace, siteCanTransferToAtomic } ) ).toBe(
+				expected
+			);
+		}
+	);
+
+	it( 'prefers installing in place over transferring to Atomic', () => {
+		expect(
+			chooseInstallStrategy( { siteInstallsInPlace: true, siteCanTransferToAtomic: true } )
+		).toBe( 'in-place' );
+	} );
+} );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -35,6 +35,7 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
+import { chooseInstallStrategy } from './install-strategy';
 import { useDelayedCondition } from './use-delayed-condition';
 import useMarketplaceAdditionalSteps from './use-marketplace-additional-steps';
 import { useThankYouRedirect } from './use-thank-you-redirect';
@@ -185,25 +186,25 @@ export function useProductInstall( {
 				waitFor( 1 ).then( () => setCurrentStep( 1 ) );
 			};
 
-			if ( isJetpack || isAtomic ) {
+			const strategy = chooseInstallStrategy( {
+				siteInstallsInPlace: !! ( isJetpack || isAtomic ),
+				siteCanTransferToAtomic: !! hasAtomicFeature,
+			} );
+
+			if ( strategy === 'in-place' ) {
 				if ( wpOrgTheme ) {
-					// initilize theme activating
 					dispatch( installAndActivateTheme( wpOrgTheme.id, siteId ) );
 				} else {
-					// initialize plugin installing
 					dispatch( installPlugin( siteId, wporgPlugin, false ) );
 				}
-
 				triggerInstallFlow();
-			} else if ( hasAtomicFeature ) {
-				// initialize atomic flow
+			} else if ( strategy === 'atomic-transfer' ) {
 				if ( wpOrgTheme ) {
 					dispatch( initiateAtomicTransfer( siteId, { themeSlug, context: 'theme_install' } ) );
 				} else {
 					setAtomicFlow( true );
 					dispatch( initiateTransfer( siteId, null, pluginSlug, '', 'plugin_install' ) );
 				}
-
 				triggerInstallFlow();
 			}
 		}


### PR DESCRIPTION
## Proposed Changes

Extract the "how should this product be installed" decision on the install page into a small pure function, `chooseInstallStrategy`, and switch the install-initiation effect on its result.

The choice between installing in place, transferring to Atomic first, or doing nothing was an unlabeled nested condition inside the effect. Pulling it out names the three outcomes and makes the decision testable on its own — the added tests cover its entire input space. Behaviour is unchanged: the same actions are dispatched under the same conditions.

This is a deliberately scoped first step. Consolidating the wider install-progress state machine (the `currentStep` transitions spread across several effects) is a larger change that needs its own test net first, and is left for a follow-up.

## Why are these changes being made?

The install-initiation logic was one of the harder parts of this page to read, because the site-capability decision was tangled into the effect that acts on it. Separating the decision from the action clarifies both and gives the branch real test coverage.

## Testing Instructions

```
yarn test-client client/my-sites/marketplace/pages/marketplace-product-install/test/
```

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
