### PR TITLE
Marketplace: characterize install progression and fix three install-flow bugs

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
@@ -8,6 +8,7 @@ import automatedTransferReducer from 'calypso/state/automated-transfer/reducer';
 import marketplaceReducer from 'calypso/state/marketplace/reducer';
 import pluginsReducer from 'calypso/state/plugins/reducer';
 import routeReducer from 'calypso/state/route/reducer';
+import { receiveSite } from 'calypso/state/sites/actions';
 import themesReducer from 'calypso/state/themes/reducer';
 import uiReducer from 'calypso/state/ui/reducer';
 import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
@@ -116,8 +117,8 @@ describe( 'useProductInstall progression', () => {
 	} );
 	afterEach( () => jest.useRealTimers() );
 
-	it( 'installs in place once and reaches the installing step on a Jetpack site', async () => {
-		const { result } = renderProgress(
+	it( 'installs in place once even when the site data changes underneath it', async () => {
+		const { result, store } = renderProgress(
 			{ pluginSlug: 'give' },
 			{
 				...marketplaceHandoff,
@@ -140,6 +141,20 @@ describe( 'useProductInstall progression', () => {
 
 		await advance( 1000 );
 		expect( result.current.currentStep ).toBe( 1 );
+
+		// A site update re-runs the initiation effect; the re-entry guard must keep it from
+		// installing a second time.
+		await act( async () => {
+			store.dispatch(
+				receiveSite( {
+					ID: SITE_ID,
+					URL: `https://${ SITE_SLUG }`,
+					jetpack: true,
+					options: { is_automated_transfer: true },
+				} )
+			);
+		} );
+		expect( installPlugin ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'transfers a Simple site to Atomic and advances to activating when the transfer completes', async () => {
@@ -169,12 +184,25 @@ describe( 'useProductInstall progression', () => {
 		await advance( 1000 );
 		expect( result.current.currentStep ).toBe( 1 );
 
+		// The site turns Atomic mid-transfer, which would make the strategy install in place on a
+		// re-run; the re-entry guard must prevent any second initiation.
+		await act( async () => {
+			store.dispatch(
+				receiveSite( {
+					ID: SITE_ID,
+					URL: `https://${ SITE_SLUG }`,
+					options: { is_automated_transfer: true },
+				} )
+			);
+		} );
+		expect( initiateThemeTransfer ).toHaveBeenCalledTimes( 1 );
+		expect( installPlugin ).not.toHaveBeenCalled();
+
 		// The transfer reports complete later; the hook must react to that update to advance.
 		await act( async () => {
 			store.dispatch( setAutomatedTransferStatus( SITE_ID, transferStates.COMPLETE ) );
 		} );
 		expect( result.current.currentStep ).toBe( 2 );
-		expect( initiateThemeTransfer ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'stays idle when revisited with a stale completed handoff', async () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
@@ -1,0 +1,196 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act } from '@testing-library/react';
+import automatedTransferReducer from 'calypso/state/automated-transfer/reducer';
+import marketplaceReducer from 'calypso/state/marketplace/reducer';
+import pluginsReducer from 'calypso/state/plugins/reducer';
+import routeReducer from 'calypso/state/route/reducer';
+import themesReducer from 'calypso/state/themes/reducer';
+import uiReducer from 'calypso/state/ui/reducer';
+import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
+import { useProductInstall } from '../use-product-install';
+
+// Keep the post-transfer site fetch off the network, leaving the rest of the package intact.
+jest.mock( '@automattic/api-queries', () => ( {
+	...jest.requireActual( '@automattic/api-queries' ),
+	siteByIdQuery: ( siteId: number ) => ( {
+		queryKey: [ 'site', siteId ],
+		queryFn: async () => null,
+	} ),
+} ) );
+
+// The install-initiation effect dispatches these; replace them with inert, assertable actions.
+jest.mock( 'calypso/state/plugins/installed/actions', () => ( {
+	installPlugin: jest.fn( ( siteId: number, plugin: unknown, active: boolean ) => ( {
+		type: 'MOCK_INSTALL_PLUGIN',
+		siteId,
+		plugin,
+		active,
+	} ) ),
+	activatePlugin: jest.fn( ( siteId: number, plugin: unknown ) => ( {
+		type: 'MOCK_ACTIVATE_PLUGIN',
+		siteId,
+		plugin,
+	} ) ),
+	fetchSitePlugins: jest.fn( ( siteId: number ) => ( {
+		type: 'MOCK_FETCH_SITE_PLUGINS',
+		siteId,
+	} ) ),
+} ) );
+jest.mock( 'calypso/state/themes/actions', () => ( {
+	initiateThemeTransfer: jest.fn( ( siteId: number, _x, pluginSlug: string ) => ( {
+		type: 'MOCK_INITIATE_THEME_TRANSFER',
+		siteId,
+		pluginSlug,
+	} ) ),
+	installAndActivateTheme: jest.fn( ( themeId: string, siteId: number ) => ( {
+		type: 'MOCK_INSTALL_ACTIVATE_THEME',
+		themeId,
+		siteId,
+	} ) ),
+	requestActiveTheme: jest.fn( ( siteId: number ) => ( {
+		type: 'MOCK_REQUEST_ACTIVE_THEME',
+		siteId,
+	} ) ),
+} ) );
+jest.mock( 'calypso/state/atomic/transfers/actions', () => ( {
+	initiateAtomicTransfer: jest.fn( ( siteId: number, options: unknown ) => ( {
+		type: 'MOCK_INITIATE_ATOMIC_TRANSFER',
+		siteId,
+		options,
+	} ) ),
+} ) );
+
+const { installPlugin, activatePlugin } = jest.requireMock(
+	'calypso/state/plugins/installed/actions'
+);
+const { initiateThemeTransfer } = jest.requireMock( 'calypso/state/themes/actions' );
+
+const reducers = {
+	plugins: pluginsReducer,
+	themes: themesReducer,
+	marketplace: marketplaceReducer,
+	ui: uiReducer,
+	route: routeReducer,
+	automatedTransfer: automatedTransferReducer,
+};
+
+const SITE_ID = 1;
+const SITE_SLUG = 'example.com';
+
+const renderProgress = (
+	props: { pluginSlug?: string; themeSlug?: string },
+	initialState: object
+) => renderHookWithProvider( () => useProductInstall( props ), { reducers, initialState } );
+
+// The step advances via waitFor(), a setTimeout wrapped in a Promise, so flushing the timer also
+// needs the microtask queue drained — hence async act.
+const advance = async ( ms: number ) =>
+	act( async () => {
+		jest.advanceTimersByTime( ms );
+	} );
+
+// Common seeds: a trusted direct install (bypasses the handoff), and a fetched wporg plugin.
+const directInstall = { route: { query: { current: { directInstall: '1' } } } };
+const wporgPlugin = {
+	plugins: { wporg: { items: { give: { slug: 'give', fetched: true, name: 'GiveWP' } } } },
+};
+
+describe( 'useProductInstall progression', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+		installPlugin.mockClear();
+		activatePlugin.mockClear();
+		initiateThemeTransfer.mockClear();
+	} );
+	afterEach( () => jest.useRealTimers() );
+
+	it( 'installs in place and reaches the installing step on a Jetpack site', async () => {
+		const { result } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...directInstall,
+				...wporgPlugin,
+				ui: { selectedSiteId: SITE_ID },
+				sites: {
+					items: { [ SITE_ID ]: { ID: SITE_ID, URL: `https://${ SITE_SLUG }`, jetpack: true } },
+				},
+			}
+		);
+
+		// In-place strategy: installs directly, no atomic transfer.
+		expect( installPlugin ).toHaveBeenCalledWith(
+			SITE_ID,
+			expect.objectContaining( { slug: 'give' } ),
+			false
+		);
+		expect( initiateThemeTransfer ).not.toHaveBeenCalled();
+
+		await advance( 1000 );
+		expect( result.current.currentStep ).toBe( 1 );
+	} );
+
+	it( 'transfers a Simple site to Atomic and advances to activating on completion', async () => {
+		const { result } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...directInstall,
+				ui: { selectedSiteId: SITE_ID },
+				sites: {
+					items: {
+						[ SITE_ID ]: {
+							ID: SITE_ID,
+							URL: `https://${ SITE_SLUG }`,
+							options: { is_wpcom_simple: true },
+						},
+					},
+					features: { [ SITE_ID ]: { data: { active: [ 'atomic' ] } } },
+				},
+				plugins: { wporg: wporgPlugin.plugins.wporg },
+				// The transfer already reports complete, so once the installing step is reached the
+				// completion effect advances to activating.
+				automatedTransfer: { [ SITE_ID ]: { status: 'complete' } },
+			}
+		);
+
+		// Atomic-transfer strategy: transfers first rather than installing in place.
+		expect( initiateThemeTransfer ).toHaveBeenCalledWith(
+			SITE_ID,
+			null,
+			'give',
+			expect.anything(),
+			'plugin_install'
+		);
+		expect( installPlugin ).not.toHaveBeenCalled();
+
+		await advance( 1000 );
+		expect( result.current.currentStep ).toBe( 2 );
+	} );
+
+	it( 'stays idle when revisited with a stale completed handoff', async () => {
+		const { result } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...wporgPlugin,
+				ui: { selectedSiteId: SITE_ID },
+				sites: {
+					items: { [ SITE_ID ]: { ID: SITE_ID, URL: `https://${ SITE_SLUG }`, jetpack: true } },
+				},
+				marketplace: {
+					purchaseFlow: {
+						primaryDomain: SITE_SLUG,
+						productSlugInstalled: 'give',
+						pluginInstallationStatus: 'COMPLETED',
+					},
+				},
+			}
+		);
+
+		await advance( 2000 );
+		// No install is initiated and the progress bar never leaves step 0. This documents the
+		// pre-existing dead-end for a completed handoff revisited in the same session.
+		expect( installPlugin ).not.toHaveBeenCalled();
+		expect( result.current.currentStep ).toBe( 0 );
+	} );
+} );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
@@ -400,6 +400,38 @@ describe( 'useProductInstall progression', () => {
 		expect( initiateThemeTransfer ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	it( 'clears the plan error when Atomic eligibility arrives after the timeout', async () => {
+		const { result, store } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...marketplaceHandoff,
+				ui: { selectedSiteId: SITE_ID },
+				sites: {
+					items: {
+						[ SITE_ID ]: {
+							ID: SITE_ID,
+							URL: `https://${ SITE_SLUG }`,
+							options: { is_wpcom_simple: true },
+						},
+					},
+				},
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+
+		// With no feature data, the plan error appears after the grace period.
+		await advance( 2000 );
+		expect( result.current.error ).toEqual( { type: 'non-installable-plan' } );
+		expect( initiateThemeTransfer ).not.toHaveBeenCalled();
+
+		// Eligibility arrives late: the error must clear and the transfer must start.
+		await act( async () => {
+			store.dispatch( fetchSiteFeaturesCompleted( SITE_ID, { active: [ 'atomic' ] } ) );
+		} );
+		expect( result.current.error ).toBeNull();
+		expect( initiateThemeTransfer ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	it( 'stays idle when revisited with a stale completed handoff', async () => {
 		const { result } = renderProgress(
 			{ pluginSlug: 'give' },

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
@@ -2,6 +2,8 @@
  * @jest-environment jsdom
  */
 import { act } from '@testing-library/react';
+import { setAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
+import { transferStates } from 'calypso/state/automated-transfer/constants';
 import automatedTransferReducer from 'calypso/state/automated-transfer/reducer';
 import marketplaceReducer from 'calypso/state/marketplace/reducer';
 import pluginsReducer from 'calypso/state/plugins/reducer';
@@ -91,10 +93,18 @@ const advance = async ( ms: number ) =>
 		jest.advanceTimersByTime( ms );
 	} );
 
-// Common seeds: a trusted direct install (bypasses the handoff), and a fetched wporg plugin.
-const directInstall = { route: { query: { current: { directInstall: '1' } } } };
-const wporgPlugin = {
-	plugins: { wporg: { items: { give: { slug: 'give', fetched: true, name: 'GiveWP' } } } },
+const wporgItems = { give: { slug: 'give', fetched: true, name: 'GiveWP' } };
+
+// The marketplace handoff from checkout / the plugin page that authorizes an install: a matching
+// primary domain and product, with the installation not yet reported complete.
+const marketplaceHandoff = {
+	marketplace: {
+		purchaseFlow: {
+			primaryDomain: SITE_SLUG,
+			productSlugInstalled: 'give',
+			pluginInstallationStatus: 'IN_PROGRESS',
+		},
+	},
 };
 
 describe( 'useProductInstall progression', () => {
@@ -106,20 +116,21 @@ describe( 'useProductInstall progression', () => {
 	} );
 	afterEach( () => jest.useRealTimers() );
 
-	it( 'installs in place and reaches the installing step on a Jetpack site', async () => {
+	it( 'installs in place once and reaches the installing step on a Jetpack site', async () => {
 		const { result } = renderProgress(
 			{ pluginSlug: 'give' },
 			{
-				...directInstall,
-				...wporgPlugin,
+				...marketplaceHandoff,
 				ui: { selectedSiteId: SITE_ID },
 				sites: {
 					items: { [ SITE_ID ]: { ID: SITE_ID, URL: `https://${ SITE_SLUG }`, jetpack: true } },
 				},
+				plugins: { wporg: { items: wporgItems } },
 			}
 		);
 
-		// In-place strategy: installs directly, no atomic transfer.
+		// In-place strategy: installs directly, exactly once, with no atomic transfer.
+		expect( installPlugin ).toHaveBeenCalledTimes( 1 );
 		expect( installPlugin ).toHaveBeenCalledWith(
 			SITE_ID,
 			expect.objectContaining( { slug: 'give' } ),
@@ -131,11 +142,11 @@ describe( 'useProductInstall progression', () => {
 		expect( result.current.currentStep ).toBe( 1 );
 	} );
 
-	it( 'transfers a Simple site to Atomic and advances to activating on completion', async () => {
-		const { result } = renderProgress(
+	it( 'transfers a Simple site to Atomic and advances to activating when the transfer completes', async () => {
+		const { result, store } = renderProgress(
 			{ pluginSlug: 'give' },
 			{
-				...directInstall,
+				...marketplaceHandoff,
 				ui: { selectedSiteId: SITE_ID },
 				sites: {
 					items: {
@@ -147,36 +158,34 @@ describe( 'useProductInstall progression', () => {
 					},
 					features: { [ SITE_ID ]: { data: { active: [ 'atomic' ] } } },
 				},
-				plugins: { wporg: wporgPlugin.plugins.wporg },
-				// The transfer already reports complete, so once the installing step is reached the
-				// completion effect advances to activating.
-				automatedTransfer: { [ SITE_ID ]: { status: 'complete' } },
+				plugins: { wporg: { items: wporgItems } },
 			}
 		);
 
-		// Atomic-transfer strategy: transfers first rather than installing in place.
-		expect( initiateThemeTransfer ).toHaveBeenCalledWith(
-			SITE_ID,
-			null,
-			'give',
-			expect.anything(),
-			'plugin_install'
-		);
+		// Atomic-transfer strategy: transfers first, exactly once, rather than installing in place.
+		expect( initiateThemeTransfer ).toHaveBeenCalledTimes( 1 );
 		expect( installPlugin ).not.toHaveBeenCalled();
 
 		await advance( 1000 );
+		expect( result.current.currentStep ).toBe( 1 );
+
+		// The transfer reports complete later; the hook must react to that update to advance.
+		await act( async () => {
+			store.dispatch( setAutomatedTransferStatus( SITE_ID, transferStates.COMPLETE ) );
+		} );
 		expect( result.current.currentStep ).toBe( 2 );
+		expect( initiateThemeTransfer ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'stays idle when revisited with a stale completed handoff', async () => {
 		const { result } = renderProgress(
 			{ pluginSlug: 'give' },
 			{
-				...wporgPlugin,
 				ui: { selectedSiteId: SITE_ID },
 				sites: {
 					items: { [ SITE_ID ]: { ID: SITE_ID, URL: `https://${ SITE_SLUG }`, jetpack: true } },
 				},
+				plugins: { wporg: { items: wporgItems } },
 				marketplace: {
 					purchaseFlow: {
 						primaryDomain: SITE_SLUG,

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
@@ -68,6 +68,10 @@ jest.mock( 'calypso/state/atomic/transfers/actions', () => ( {
 		options,
 	} ) ),
 } ) );
+jest.mock( 'calypso/state/plugins/wporg/actions', () => ( {
+	...jest.requireActual( 'calypso/state/plugins/wporg/actions' ),
+	fetchPluginData: jest.fn( () => ( { type: 'MOCK_FETCH_PLUGIN_DATA' } ) ),
+} ) );
 
 const { installPlugin, activatePlugin } = jest.requireMock(
 	'calypso/state/plugins/installed/actions'
@@ -133,7 +137,6 @@ describe( 'useProductInstall progression', () => {
 			{ ...marketplaceHandoff, ...jetpackSite }
 		);
 
-		// In-place strategy: installs directly, exactly once, with no atomic transfer.
 		expect( installPlugin ).toHaveBeenCalledTimes( 1 );
 		expect( installPlugin ).toHaveBeenCalledWith(
 			SITE_ID,
@@ -142,14 +145,12 @@ describe( 'useProductInstall progression', () => {
 		);
 		expect( initiateThemeTransfer ).not.toHaveBeenCalled();
 
-		// The setup step is held visible for one second before moving on.
 		expect( result.current.currentStep ).toBe( 0 );
 		await advance( 999 );
 		expect( result.current.currentStep ).toBe( 0 );
 		await advance( 1 );
 		expect( result.current.currentStep ).toBe( 1 );
 
-		// The plugin finishes installing; the hook activates it once and advances to activating.
 		await act( async () => {
 			store.dispatch(
 				receiveSitePlugins( SITE_ID, [ { slug: 'give', id: 'give/give', active: false } ] )
@@ -157,6 +158,23 @@ describe( 'useProductInstall progression', () => {
 		} );
 		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
 		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, { slug: 'give', id: 'give/give' } );
+		expect( result.current.currentStep ).toBe( 2 );
+	} );
+
+	it( 'activates a plugin that finishes installing during the setup delay', async () => {
+		const { result, store } = renderProgress(
+			{ pluginSlug: 'give' },
+			{ ...marketplaceHandoff, ...jetpackSite }
+		);
+
+		await act( async () => {
+			store.dispatch(
+				receiveSitePlugins( SITE_ID, [ { slug: 'give', id: 'give/give', active: false } ] )
+			);
+		} );
+		await advance( 1000 );
+
+		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
 		expect( result.current.currentStep ).toBe( 2 );
 	} );
 
@@ -205,7 +223,6 @@ describe( 'useProductInstall progression', () => {
 			}
 		);
 
-		// Atomic-transfer strategy: transfers first, exactly once, with the expected payload.
 		expect( initiateThemeTransfer ).toHaveBeenCalledTimes( 1 );
 		expect( initiateThemeTransfer ).toHaveBeenCalledWith(
 			SITE_ID,
@@ -240,6 +257,36 @@ describe( 'useProductInstall progression', () => {
 		} );
 		expect( initiateThemeTransfer ).toHaveBeenCalledTimes( 1 );
 		expect( installPlugin ).not.toHaveBeenCalled();
+	} );
+
+	it( 'uploads a plugin and activates it once the upload completes', async () => {
+		const { result, store } = renderProgress(
+			{},
+			{
+				ui: { selectedSiteId: SITE_ID },
+				sites: {
+					items: { [ SITE_ID ]: { ID: SITE_ID, URL: `https://${ SITE_SLUG }`, jetpack: true } },
+				},
+				plugins: {
+					upload: {
+						progressPercent: { [ SITE_ID ]: 100 },
+						uploadedPluginId: { [ SITE_ID ]: 'give' },
+						inProgress: { [ SITE_ID ]: false },
+					},
+				},
+			}
+		);
+
+		await advance( 1000 );
+		expect( result.current.currentStep ).toBe( 1 );
+
+		await act( async () => {
+			store.dispatch(
+				receiveSitePlugins( SITE_ID, [ { slug: 'give', id: 'give/give', active: false } ] )
+			);
+		} );
+		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
+		expect( result.current.currentStep ).toBe( 2 );
 	} );
 
 	it( 'stays idle when revisited with a stale completed handoff', async () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
@@ -79,7 +79,8 @@ jest.mock( 'calypso/state/plugins/wporg/actions', () => ( {
 const { installPlugin, activatePlugin } = jest.requireMock(
 	'calypso/state/plugins/installed/actions'
 );
-const { initiateThemeTransfer, installAndActivateTheme } = jest.requireMock(
+// initiateThemeTransfer is the (confusingly named) action that starts a plugin's Atomic transfer.
+const { initiateThemeTransfer: initiatePluginTransfer, installAndActivateTheme } = jest.requireMock(
 	'calypso/state/themes/actions'
 );
 const { initiateAtomicTransfer } = jest.requireMock( 'calypso/state/atomic/transfers/actions' );
@@ -128,6 +129,21 @@ const jetpackSite = {
 	plugins: { wporg: { items: wporgItems } },
 };
 
+// A Simple site that qualifies for an Atomic transfer (has the Atomic feature).
+const simpleAtomicEligibleSite = {
+	ui: { selectedSiteId: SITE_ID },
+	sites: {
+		items: {
+			[ SITE_ID ]: {
+				ID: SITE_ID,
+				URL: `https://${ SITE_SLUG }`,
+				options: { is_wpcom_simple: true },
+			},
+		},
+		features: { [ SITE_ID ]: { data: { active: [ 'atomic' ] } } },
+	},
+};
+
 const THEME_SLUG = 'twentytwentyfour';
 const themeHandoff = {
 	marketplace: {
@@ -144,7 +160,7 @@ describe( 'useProductInstall progression', () => {
 		jest.useFakeTimers();
 		installPlugin.mockClear();
 		activatePlugin.mockClear();
-		initiateThemeTransfer.mockClear();
+		initiatePluginTransfer.mockClear();
 		installAndActivateTheme.mockClear();
 		initiateAtomicTransfer.mockClear();
 	} );
@@ -162,7 +178,7 @@ describe( 'useProductInstall progression', () => {
 			expect.objectContaining( { slug: 'give' } ),
 			false
 		);
-		expect( initiateThemeTransfer ).not.toHaveBeenCalled();
+		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
 
 		expect( result.current.currentStep ).toBe( 0 );
 		await advance( 999 );
@@ -228,23 +244,13 @@ describe( 'useProductInstall progression', () => {
 			{ pluginSlug: 'give' },
 			{
 				...marketplaceHandoff,
-				ui: { selectedSiteId: SITE_ID },
-				sites: {
-					items: {
-						[ SITE_ID ]: {
-							ID: SITE_ID,
-							URL: `https://${ SITE_SLUG }`,
-							options: { is_wpcom_simple: true },
-						},
-					},
-					features: { [ SITE_ID ]: { data: { active: [ 'atomic' ] } } },
-				},
+				...simpleAtomicEligibleSite,
 				plugins: { wporg: { items: wporgItems } },
 			}
 		);
 
-		expect( initiateThemeTransfer ).toHaveBeenCalledTimes( 1 );
-		expect( initiateThemeTransfer ).toHaveBeenCalledWith(
+		expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 );
+		expect( initiatePluginTransfer ).toHaveBeenCalledWith(
 			SITE_ID,
 			null,
 			'give',
@@ -275,7 +281,7 @@ describe( 'useProductInstall progression', () => {
 				} )
 			);
 		} );
-		expect( initiateThemeTransfer ).toHaveBeenCalledTimes( 1 );
+		expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 );
 		expect( installPlugin ).not.toHaveBeenCalled();
 	} );
 
@@ -342,20 +348,7 @@ describe( 'useProductInstall progression', () => {
 	it( 'transfers a Simple site to Atomic for a theme install', async () => {
 		const { store } = renderProgress(
 			{ themeSlug: THEME_SLUG },
-			{
-				...themeHandoff,
-				ui: { selectedSiteId: SITE_ID },
-				sites: {
-					items: {
-						[ SITE_ID ]: {
-							ID: SITE_ID,
-							URL: `https://${ SITE_SLUG }`,
-							options: { is_wpcom_simple: true },
-						},
-					},
-					features: { [ SITE_ID ]: { data: { active: [ 'atomic' ] } } },
-				},
-			}
+			{ ...themeHandoff, ...simpleAtomicEligibleSite }
 		);
 
 		await act( async () => {
@@ -394,13 +387,13 @@ describe( 'useProductInstall progression', () => {
 			}
 		);
 
-		expect( initiateThemeTransfer ).not.toHaveBeenCalled();
+		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
 
 		// The Atomic feature data arrives late; the transfer must still start.
 		await act( async () => {
 			store.dispatch( fetchSiteFeaturesCompleted( SITE_ID, { active: [ 'atomic' ] } ) );
 		} );
-		expect( initiateThemeTransfer ).toHaveBeenCalledTimes( 1 );
+		expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'shows no plan error for an already-Atomic site even without feature data', async () => {
@@ -450,14 +443,14 @@ describe( 'useProductInstall progression', () => {
 		// With no feature data, the plan error appears after the grace period.
 		await advance( 2000 );
 		expect( result.current.error ).toEqual( { type: 'non-installable-plan' } );
-		expect( initiateThemeTransfer ).not.toHaveBeenCalled();
+		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
 
 		// Eligibility arrives late: the error must clear and the transfer must start.
 		await act( async () => {
 			store.dispatch( fetchSiteFeaturesCompleted( SITE_ID, { active: [ 'atomic' ] } ) );
 		} );
 		expect( result.current.error ).toBeNull();
-		expect( initiateThemeTransfer ).toHaveBeenCalledTimes( 1 );
+		expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'stays idle when revisited with a stale completed handoff', async () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
@@ -10,6 +10,8 @@ import { receiveSitePlugins } from 'calypso/state/plugins/installed/actions';
 import pluginsReducer from 'calypso/state/plugins/reducer';
 import routeReducer from 'calypso/state/route/reducer';
 import { receiveSite } from 'calypso/state/sites/actions';
+import { fetchSiteFeaturesCompleted } from 'calypso/state/sites/features/actions';
+import { THEMES_REQUEST_SUCCESS } from 'calypso/state/themes/action-types';
 import themesReducer from 'calypso/state/themes/reducer';
 import uiReducer from 'calypso/state/ui/reducer';
 import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
@@ -60,6 +62,7 @@ jest.mock( 'calypso/state/themes/actions', () => ( {
 		type: 'MOCK_REQUEST_ACTIVE_THEME',
 		siteId,
 	} ) ),
+	requestTheme: jest.fn( () => ( { type: 'MOCK_REQUEST_THEME' } ) ),
 } ) );
 jest.mock( 'calypso/state/atomic/transfers/actions', () => ( {
 	initiateAtomicTransfer: jest.fn( ( siteId: number, options: unknown ) => ( {
@@ -76,7 +79,10 @@ jest.mock( 'calypso/state/plugins/wporg/actions', () => ( {
 const { installPlugin, activatePlugin } = jest.requireMock(
 	'calypso/state/plugins/installed/actions'
 );
-const { initiateThemeTransfer } = jest.requireMock( 'calypso/state/themes/actions' );
+const { initiateThemeTransfer, installAndActivateTheme } = jest.requireMock(
+	'calypso/state/themes/actions'
+);
+const { initiateAtomicTransfer } = jest.requireMock( 'calypso/state/atomic/transfers/actions' );
 
 const reducers = {
 	plugins: pluginsReducer,
@@ -122,12 +128,25 @@ const jetpackSite = {
 	plugins: { wporg: { items: wporgItems } },
 };
 
+const THEME_SLUG = 'twentytwentyfour';
+const themeHandoff = {
+	marketplace: {
+		purchaseFlow: {
+			primaryDomain: SITE_SLUG,
+			productSlugInstalled: THEME_SLUG,
+			pluginInstallationStatus: 'IN_PROGRESS',
+		},
+	},
+};
+
 describe( 'useProductInstall progression', () => {
 	beforeEach( () => {
 		jest.useFakeTimers();
 		installPlugin.mockClear();
 		activatePlugin.mockClear();
 		initiateThemeTransfer.mockClear();
+		installAndActivateTheme.mockClear();
+		initiateAtomicTransfer.mockClear();
 	} );
 	afterEach( () => jest.useRealTimers() );
 
@@ -287,6 +306,98 @@ describe( 'useProductInstall progression', () => {
 		} );
 		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
 		expect( result.current.currentStep ).toBe( 2 );
+	} );
+
+	it( 'installs and activates a theme in place on a Jetpack site', async () => {
+		const { result, store } = renderProgress(
+			{ themeSlug: THEME_SLUG },
+			{
+				...themeHandoff,
+				ui: { selectedSiteId: SITE_ID },
+				sites: {
+					items: { [ SITE_ID ]: { ID: SITE_ID, URL: `https://${ SITE_SLUG }`, jetpack: true } },
+				},
+			}
+		);
+
+		await act( async () => {
+			store.dispatch( {
+				type: THEMES_REQUEST_SUCCESS,
+				siteId: 'wporg',
+				query: {},
+				themes: [ { id: THEME_SLUG, name: 'Twenty Twenty-Four' } ],
+				found: 1,
+			} );
+		} );
+		expect( installAndActivateTheme ).toHaveBeenCalledWith( THEME_SLUG, SITE_ID );
+		expect( initiateAtomicTransfer ).not.toHaveBeenCalled();
+
+		await advance( 1000 );
+		expect( result.current.currentStep ).toBe( 1 );
+	} );
+
+	it( 'transfers a Simple site to Atomic for a theme install', async () => {
+		const { store } = renderProgress(
+			{ themeSlug: THEME_SLUG },
+			{
+				...themeHandoff,
+				ui: { selectedSiteId: SITE_ID },
+				sites: {
+					items: {
+						[ SITE_ID ]: {
+							ID: SITE_ID,
+							URL: `https://${ SITE_SLUG }`,
+							options: { is_wpcom_simple: true },
+						},
+					},
+					features: { [ SITE_ID ]: { data: { active: [ 'atomic' ] } } },
+				},
+			}
+		);
+
+		await act( async () => {
+			store.dispatch( {
+				type: THEMES_REQUEST_SUCCESS,
+				siteId: 'wporg',
+				query: {},
+				themes: [ { id: THEME_SLUG, name: 'Twenty Twenty-Four' } ],
+				found: 1,
+			} );
+		} );
+		expect( initiateAtomicTransfer ).toHaveBeenCalledWith( SITE_ID, {
+			themeSlug: THEME_SLUG,
+			context: 'theme_install',
+		} );
+		expect( installAndActivateTheme ).not.toHaveBeenCalled();
+	} );
+
+	it( 'starts the transfer when Atomic eligibility arrives after mount', async () => {
+		const { store } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...marketplaceHandoff,
+				ui: { selectedSiteId: SITE_ID },
+				// A Simple site with no feature data yet: no install strategy is available at mount.
+				sites: {
+					items: {
+						[ SITE_ID ]: {
+							ID: SITE_ID,
+							URL: `https://${ SITE_SLUG }`,
+							options: { is_wpcom_simple: true },
+						},
+					},
+				},
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+
+		expect( initiateThemeTransfer ).not.toHaveBeenCalled();
+
+		// The Atomic feature data arrives late; the transfer must still start.
+		await act( async () => {
+			store.dispatch( fetchSiteFeaturesCompleted( SITE_ID, { active: [ 'atomic' ] } ) );
+		} );
+		expect( initiateThemeTransfer ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'stays idle when revisited with a stale completed handoff', async () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
@@ -6,6 +6,7 @@ import { setAutomatedTransferStatus } from 'calypso/state/automated-transfer/act
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import automatedTransferReducer from 'calypso/state/automated-transfer/reducer';
 import marketplaceReducer from 'calypso/state/marketplace/reducer';
+import { receiveSitePlugins } from 'calypso/state/plugins/installed/actions';
 import pluginsReducer from 'calypso/state/plugins/reducer';
 import routeReducer from 'calypso/state/route/reducer';
 import { receiveSite } from 'calypso/state/sites/actions';
@@ -23,8 +24,10 @@ jest.mock( '@automattic/api-queries', () => ( {
 	} ),
 } ) );
 
-// The install-initiation effect dispatches these; replace them with inert, assertable actions.
+// Replace the initiators with inert, assertable actions; keep the rest of each module (e.g.
+// receiveSitePlugins) real so tests can drive genuine state transitions.
 jest.mock( 'calypso/state/plugins/installed/actions', () => ( {
+	...jest.requireActual( 'calypso/state/plugins/installed/actions' ),
 	installPlugin: jest.fn( ( siteId: number, plugin: unknown, active: boolean ) => ( {
 		type: 'MOCK_INSTALL_PLUGIN',
 		siteId,
@@ -42,10 +45,11 @@ jest.mock( 'calypso/state/plugins/installed/actions', () => ( {
 	} ) ),
 } ) );
 jest.mock( 'calypso/state/themes/actions', () => ( {
-	initiateThemeTransfer: jest.fn( ( siteId: number, _x, pluginSlug: string ) => ( {
-		type: 'MOCK_INITIATE_THEME_TRANSFER',
+	// Emit the real initiation action so the transfer status genuinely moves to START, as it does
+	// in production, rather than staying at whatever the test seeded.
+	initiateThemeTransfer: jest.fn( ( siteId: number ) => ( {
+		type: 'THEME_TRANSFER_INITIATE_REQUEST',
 		siteId,
-		pluginSlug,
 	} ) ),
 	installAndActivateTheme: jest.fn( ( themeId: string, siteId: number ) => ( {
 		type: 'MOCK_INSTALL_ACTIVATE_THEME',
@@ -108,6 +112,12 @@ const marketplaceHandoff = {
 	},
 };
 
+const jetpackSite = {
+	ui: { selectedSiteId: SITE_ID },
+	sites: { items: { [ SITE_ID ]: { ID: SITE_ID, URL: `https://${ SITE_SLUG }`, jetpack: true } } },
+	plugins: { wporg: { items: wporgItems } },
+};
+
 describe( 'useProductInstall progression', () => {
 	beforeEach( () => {
 		jest.useFakeTimers();
@@ -117,17 +127,10 @@ describe( 'useProductInstall progression', () => {
 	} );
 	afterEach( () => jest.useRealTimers() );
 
-	it( 'installs in place once even when the site data changes underneath it', async () => {
+	it( 'installs in place, keeps the setup step visible, then activates on completion', async () => {
 		const { result, store } = renderProgress(
 			{ pluginSlug: 'give' },
-			{
-				...marketplaceHandoff,
-				ui: { selectedSiteId: SITE_ID },
-				sites: {
-					items: { [ SITE_ID ]: { ID: SITE_ID, URL: `https://${ SITE_SLUG }`, jetpack: true } },
-				},
-				plugins: { wporg: { items: wporgItems } },
-			}
+			{ ...marketplaceHandoff, ...jetpackSite }
 		);
 
 		// In-place strategy: installs directly, exactly once, with no atomic transfer.
@@ -139,6 +142,31 @@ describe( 'useProductInstall progression', () => {
 		);
 		expect( initiateThemeTransfer ).not.toHaveBeenCalled();
 
+		// The setup step is held visible for one second before moving on.
+		expect( result.current.currentStep ).toBe( 0 );
+		await advance( 999 );
+		expect( result.current.currentStep ).toBe( 0 );
+		await advance( 1 );
+		expect( result.current.currentStep ).toBe( 1 );
+
+		// The plugin finishes installing; the hook activates it once and advances to activating.
+		await act( async () => {
+			store.dispatch(
+				receiveSitePlugins( SITE_ID, [ { slug: 'give', id: 'give/give', active: false } ] )
+			);
+		} );
+		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
+		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, { slug: 'give', id: 'give/give' } );
+		expect( result.current.currentStep ).toBe( 2 );
+	} );
+
+	it( 'installs in place only once when the site data changes underneath it', async () => {
+		const { result, store } = renderProgress(
+			{ pluginSlug: 'give' },
+			{ ...marketplaceHandoff, ...jetpackSite }
+		);
+
+		expect( installPlugin ).toHaveBeenCalledTimes( 1 );
 		await advance( 1000 );
 		expect( result.current.currentStep ).toBe( 1 );
 
@@ -157,7 +185,7 @@ describe( 'useProductInstall progression', () => {
 		expect( installPlugin ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'transfers a Simple site to Atomic and advances to activating when the transfer completes', async () => {
+	it( 'transfers a Simple site to Atomic and activates when the transfer completes', async () => {
 		const { result, store } = renderProgress(
 			{ pluginSlug: 'give' },
 			{
@@ -177,15 +205,30 @@ describe( 'useProductInstall progression', () => {
 			}
 		);
 
-		// Atomic-transfer strategy: transfers first, exactly once, rather than installing in place.
+		// Atomic-transfer strategy: transfers first, exactly once, with the expected payload.
 		expect( initiateThemeTransfer ).toHaveBeenCalledTimes( 1 );
+		expect( initiateThemeTransfer ).toHaveBeenCalledWith(
+			SITE_ID,
+			null,
+			'give',
+			'',
+			'plugin_install'
+		);
 		expect( installPlugin ).not.toHaveBeenCalled();
 
+		expect( result.current.currentStep ).toBe( 0 );
 		await advance( 1000 );
 		expect( result.current.currentStep ).toBe( 1 );
 
-		// The site turns Atomic mid-transfer, which would make the strategy install in place on a
-		// re-run; the re-entry guard must prevent any second initiation.
+		// Production reports completion from polling first, and only then refreshes the site. The
+		// hook must consume the completed status to advance, before the site reads as Atomic.
+		await act( async () => {
+			store.dispatch( setAutomatedTransferStatus( SITE_ID, transferStates.COMPLETE, '' ) );
+		} );
+		expect( result.current.currentStep ).toBe( 2 );
+
+		// The later site refresh (now Atomic) re-runs the initiation effect; the guard prevents any
+		// second initiation.
 		await act( async () => {
 			store.dispatch(
 				receiveSite( {
@@ -197,23 +240,13 @@ describe( 'useProductInstall progression', () => {
 		} );
 		expect( initiateThemeTransfer ).toHaveBeenCalledTimes( 1 );
 		expect( installPlugin ).not.toHaveBeenCalled();
-
-		// The transfer reports complete later; the hook must react to that update to advance.
-		await act( async () => {
-			store.dispatch( setAutomatedTransferStatus( SITE_ID, transferStates.COMPLETE ) );
-		} );
-		expect( result.current.currentStep ).toBe( 2 );
 	} );
 
 	it( 'stays idle when revisited with a stale completed handoff', async () => {
 		const { result } = renderProgress(
 			{ pluginSlug: 'give' },
 			{
-				ui: { selectedSiteId: SITE_ID },
-				sites: {
-					items: { [ SITE_ID ]: { ID: SITE_ID, URL: `https://${ SITE_SLUG }`, jetpack: true } },
-				},
-				plugins: { wporg: { items: wporgItems } },
+				...jetpackSite,
 				marketplace: {
 					purchaseFlow: {
 						primaryDomain: SITE_SLUG,

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
@@ -26,8 +26,7 @@ jest.mock( '@automattic/api-queries', () => ( {
 	} ),
 } ) );
 
-// Replace the initiators with inert, assertable actions; keep the rest of each module (e.g.
-// receiveSitePlugins) real so tests can drive genuine state transitions.
+// Replace the initiators with inert, assertable actions; keep the rest of each module real.
 jest.mock( 'calypso/state/plugins/installed/actions', () => ( {
 	...jest.requireActual( 'calypso/state/plugins/installed/actions' ),
 	installPlugin: jest.fn( ( siteId: number, plugin: unknown, active: boolean ) => ( {
@@ -47,8 +46,7 @@ jest.mock( 'calypso/state/plugins/installed/actions', () => ( {
 	} ) ),
 } ) );
 jest.mock( 'calypso/state/themes/actions', () => ( {
-	// Emit the real initiation action so the transfer status genuinely moves to START, as it does
-	// in production, rather than staying at whatever the test seeded.
+	// Emit the real action so the transfer status moves to START, as in production.
 	initiateThemeTransfer: jest.fn( ( siteId: number ) => ( {
 		type: 'THEME_TRANSFER_INITIATE_REQUEST',
 		siteId,
@@ -111,8 +109,7 @@ const advance = async ( ms: number ) =>
 
 const wporgItems = { give: { slug: 'give', fetched: true, name: 'GiveWP' } };
 
-// The marketplace handoff from checkout / the plugin page that authorizes an install: a matching
-// primary domain and product, with the installation not yet reported complete.
+// The handoff that authorizes an install: matching domain and product, not yet complete.
 const marketplaceHandoff = {
 	marketplace: {
 		purchaseFlow: {
@@ -223,9 +220,8 @@ describe( 'useProductInstall progression', () => {
 		await advance( 1000 );
 		expect( result.current.currentStep ).toBe( 1 );
 
-		// The wporg plugin selector returns a fresh object each render, so the initiation effect
-		// re-runs on every render (a site update here forces another); the re-entry guard is what
-		// keeps it to a single install. Without the guard this reaches multiple installs.
+		// getPlugin returns a fresh object each render, so the initiation effect re-runs constantly;
+		// the re-entry guard is what holds it to one install (without it, this reaches several).
 		await act( async () => {
 			store.dispatch(
 				receiveSite( {
@@ -365,35 +361,6 @@ describe( 'useProductInstall progression', () => {
 			context: 'theme_install',
 		} );
 		expect( installAndActivateTheme ).not.toHaveBeenCalled();
-	} );
-
-	it( 'starts the transfer when Atomic eligibility arrives after mount', async () => {
-		const { store } = renderProgress(
-			{ pluginSlug: 'give' },
-			{
-				...marketplaceHandoff,
-				ui: { selectedSiteId: SITE_ID },
-				// A Simple site with no feature data yet: no install strategy is available at mount.
-				sites: {
-					items: {
-						[ SITE_ID ]: {
-							ID: SITE_ID,
-							URL: `https://${ SITE_SLUG }`,
-							options: { is_wpcom_simple: true },
-						},
-					},
-				},
-				plugins: { wporg: { items: wporgItems } },
-			}
-		);
-
-		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
-
-		// The Atomic feature data arrives late; the transfer must still start.
-		await act( async () => {
-			store.dispatch( fetchSiteFeaturesCompleted( SITE_ID, { active: [ 'atomic' ] } ) );
-		} );
-		expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'shows no plan error for an already-Atomic site even without feature data', async () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
@@ -207,8 +207,9 @@ describe( 'useProductInstall progression', () => {
 		await advance( 1000 );
 		expect( result.current.currentStep ).toBe( 1 );
 
-		// A site update re-runs the initiation effect; the re-entry guard must keep it from
-		// installing a second time.
+		// The wporg plugin selector returns a fresh object each render, so the initiation effect
+		// re-runs on every render (a site update here forces another); the re-entry guard is what
+		// keeps it to a single install. Without the guard this reaches multiple installs.
 		await act( async () => {
 			store.dispatch(
 				receiveSite( {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
@@ -222,7 +222,7 @@ describe( 'useProductInstall progression', () => {
 		expect( installPlugin ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'transfers a Simple site to Atomic and activates when the transfer completes', async () => {
+	it( 'transfers a Simple site to Atomic and advances to the activation step on completion', async () => {
 		const { result, store } = renderProgress(
 			{ pluginSlug: 'give' },
 			{
@@ -282,6 +282,8 @@ describe( 'useProductInstall progression', () => {
 		const { result, store } = renderProgress(
 			{},
 			{
+				// The upload page authorizes the flow by setting the primary domain.
+				marketplace: { purchaseFlow: { primaryDomain: SITE_SLUG } },
 				ui: { selectedSiteId: SITE_ID },
 				sites: {
 					items: { [ SITE_ID ]: { ID: SITE_ID, URL: `https://${ SITE_SLUG }`, jetpack: true } },
@@ -398,6 +400,31 @@ describe( 'useProductInstall progression', () => {
 			store.dispatch( fetchSiteFeaturesCompleted( SITE_ID, { active: [ 'atomic' ] } ) );
 		} );
 		expect( initiateThemeTransfer ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'shows no plan error for an already-Atomic site even without feature data', async () => {
+		const { result } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...marketplaceHandoff,
+				ui: { selectedSiteId: SITE_ID },
+				// Already Atomic (installs in place), but the feature list never loads.
+				sites: {
+					items: {
+						[ SITE_ID ]: {
+							ID: SITE_ID,
+							URL: `https://${ SITE_SLUG }`,
+							options: { is_automated_transfer: true },
+						},
+					},
+				},
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+
+		await advance( 2000 );
+		expect( result.current.error ).toBeNull();
+		expect( installPlugin ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'clears the plan error when Atomic eligibility arrives after the timeout', async () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -126,8 +126,6 @@ export function useProductInstall( {
 	const isAtomic = useSelector( ( state ) =>
 		isSiteAutomatedTransfer( state, selectedSite?.ID ?? null )
 	);
-	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
-
 	const hasAtomicFeature = useSelector( ( state ) =>
 		siteHasFeature( state, selectedSite?.ID ?? null, WPCOM_FEATURES_ATOMIC )
 	);
@@ -139,11 +137,18 @@ export function useProductInstall( {
 		}
 	}, [ isWporgPluginFetched, pluginSlug, dispatch ] );
 
+	// How this site can install the product (in place, via an Atomic transfer, or not at all).
+	const installStrategy = chooseInstallStrategy( {
+		siteInstallsInPlace: !! ( isJetpack || isAtomic ),
+		siteCanTransferToAtomic: !! hasAtomicFeature,
+	} );
+
 	// The plan's feature list can arrive late, so only conclude the site can't install plugins once
-	// it has stayed uninstallable for the grace period. Deriving it (rather than latching a timer)
-	// means the error clears if eligibility arrives afterwards.
+	// no strategy has been available for the grace period. Deriving it from the same strategy the
+	// install uses keeps the error from disagreeing with what actually happens, and it clears if
+	// eligibility arrives afterwards.
 	const nonInstallablePlanError = useDelayedCondition(
-		! hasAtomicFeature && ! isJetpackSelfHosted,
+		installStrategy === 'none',
 		PLAN_FEATURES_GRACE_PERIOD_MS
 	);
 
@@ -182,13 +187,9 @@ export function useProductInstall( {
 			return;
 		}
 
-		const strategy = chooseInstallStrategy( {
-			siteInstallsInPlace: !! ( isJetpack || isAtomic ),
-			siteCanTransferToAtomic: !! hasAtomicFeature,
-		} );
 		// The site may not be installable yet — e.g. its feature data hasn't loaded. Leave the
 		// guard unset so a later update (features arriving) can still start the install.
-		if ( strategy === 'none' ) {
+		if ( installStrategy === 'none' ) {
 			return;
 		}
 
@@ -200,7 +201,7 @@ export function useProductInstall( {
 			waitFor( 1 ).then( () => setCurrentStep( 1 ) );
 		};
 
-		if ( strategy === 'in-place' ) {
+		if ( installStrategy === 'in-place' ) {
 			if ( wpOrgTheme ) {
 				dispatch( installAndActivateTheme( wpOrgTheme.id, siteId ) );
 			} else {
@@ -223,9 +224,7 @@ export function useProductInstall( {
 		pluginSlug,
 		themeSlug,
 		dispatch,
-		hasAtomicFeature,
-		isAtomic,
-		isJetpack,
+		installStrategy,
 	] );
 
 	// Validate completion of atomic transfer flow

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -173,41 +173,45 @@ export function useProductInstall( {
 	// Installing plugin flow startup
 	useEffect( () => {
 		if (
-			( marketplaceInstallationInProgress || directInstallationAllowed ) &&
-			! isPluginUploadFlow &&
-			! installFlowInitiatedRef.current &&
-			( wporgPlugin || wpOrgTheme )
+			! ( marketplaceInstallationInProgress || directInstallationAllowed ) ||
+			isPluginUploadFlow ||
+			installFlowInitiatedRef.current ||
+			! ( wporgPlugin || wpOrgTheme )
 		) {
-			installFlowInitiatedRef.current = true;
-			// Intentionally uncancelable. The ref above blocks re-entry, so tying this to the
-			// effect's lifetime would let a dependency change drop the step advance for good
-			// rather than reschedule it — and the dispatches below change state this effect reads.
-			const triggerInstallFlow = () => {
-				waitFor( 1 ).then( () => setCurrentStep( 1 ) );
-			};
-
-			const strategy = chooseInstallStrategy( {
-				siteInstallsInPlace: !! ( isJetpack || isAtomic ),
-				siteCanTransferToAtomic: !! hasAtomicFeature,
-			} );
-
-			if ( strategy === 'in-place' ) {
-				if ( wpOrgTheme ) {
-					dispatch( installAndActivateTheme( wpOrgTheme.id, siteId ) );
-				} else {
-					dispatch( installPlugin( siteId, wporgPlugin, false ) );
-				}
-				triggerInstallFlow();
-			} else if ( strategy === 'atomic-transfer' ) {
-				if ( wpOrgTheme ) {
-					dispatch( initiateAtomicTransfer( siteId, { themeSlug, context: 'theme_install' } ) );
-				} else {
-					setAtomicFlow( true );
-					dispatch( initiateTransfer( siteId, null, pluginSlug, '', 'plugin_install' ) );
-				}
-				triggerInstallFlow();
-			}
+			return;
 		}
+
+		const strategy = chooseInstallStrategy( {
+			siteInstallsInPlace: !! ( isJetpack || isAtomic ),
+			siteCanTransferToAtomic: !! hasAtomicFeature,
+		} );
+		// The site may not be installable yet — e.g. its feature data hasn't loaded. Leave the
+		// guard unset so a later update (features arriving) can still start the install.
+		if ( strategy === 'none' ) {
+			return;
+		}
+
+		installFlowInitiatedRef.current = true;
+		// Intentionally uncancelable. The ref above blocks re-entry, so tying this to the
+		// effect's lifetime would let a dependency change drop the step advance for good
+		// rather than reschedule it — and the dispatches below change state this effect reads.
+		const triggerInstallFlow = () => {
+			waitFor( 1 ).then( () => setCurrentStep( 1 ) );
+		};
+
+		if ( strategy === 'in-place' ) {
+			if ( wpOrgTheme ) {
+				dispatch( installAndActivateTheme( wpOrgTheme.id, siteId ) );
+			} else {
+				dispatch( installPlugin( siteId, wporgPlugin, false ) );
+			}
+		} else if ( wpOrgTheme ) {
+			dispatch( initiateAtomicTransfer( siteId, { themeSlug, context: 'theme_install' } ) );
+		} else {
+			setAtomicFlow( true );
+			dispatch( initiateTransfer( siteId, null, pluginSlug, '', 'plugin_install' ) );
+		}
+		triggerInstallFlow();
 	}, [
 		marketplaceInstallationInProgress,
 		directInstallationAllowed,

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -234,12 +234,14 @@ export function useProductInstall( {
 		}
 	}, [ atomicFlow, automatedTransferStatus, currentStep ] );
 
-	// Validate plugin is already installed and activate
+	// Activate the plugin once it is installed and the installing step has been reached. currentStep
+	// is a dependency so a plugin that appears before that step (a fast or already-installed plugin)
+	// still gets activated when the step catches up.
 	useEffect( () => {
 		if (
 			installedPlugin &&
 			currentStep === 1 &&
-			( ! isPluginUploadFlow || ( isPluginUploadFlow && pluginUploadComplete ) )
+			( ! isPluginUploadFlow || pluginUploadComplete )
 		) {
 			dispatch(
 				activatePlugin( siteId, {
@@ -249,10 +251,7 @@ export function useProductInstall( {
 			);
 			setCurrentStep( 2 );
 		}
-		// currentStep is a dependency so a plugin that appears before the installing step is reached
-		// (a fast or already-installed plugin) still gets activated once the step catches up.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ pluginUploadComplete, installedPlugin, setCurrentStep, currentStep ] );
+	}, [ installedPlugin, currentStep, isPluginUploadFlow, pluginUploadComplete, dispatch, siteId ] );
 
 	useThankYouRedirect( {
 		siteId,

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -43,6 +43,10 @@ import { useThankYouRedirect } from './use-thank-you-redirect';
 // The state authorizing an install is handed off asynchronously, so allow for it arriving late.
 const INSTALL_HANDOFF_GRACE_PERIOD_MS = 2000;
 
+// The plan's feature list is fetched asynchronously, so allow for it arriving late before
+// concluding the site can't install plugins.
+const PLAN_FEATURES_GRACE_PERIOD_MS = 2000;
+
 export type ProductInstallError =
 	| { type: 'non-installable-plan' }
 	| { type: 'no-direct-access-upload' }
@@ -65,7 +69,6 @@ export function useProductInstall( {
 	// otherwise re-enter the effect and dispatch repeatedly.
 	const installFlowInitiatedRef = useRef( false );
 	const [ atomicFlow, setAtomicFlow ] = useState( false );
-	const [ nonInstallablePlanError, setNonInstallablePlanError ] = useState( false );
 	const [ userDirectInstallationAllowed, setUserDirectInstallationAllowed ] = useState( false );
 	// The signup "Get started" flow reaches this page via a full-page redirect, which drops the
 	// in-memory purchase-flow state that normally authorizes the install. When that redirect marks
@@ -136,15 +139,13 @@ export function useProductInstall( {
 		}
 	}, [ isWporgPluginFetched, pluginSlug, dispatch ] );
 
-	// The plan's feature list can arrive late, so give it 2s before concluding that the site
-	// can't install plugins. Any change to the conditions restarts the timer.
-	useEffect( () => {
-		if ( hasAtomicFeature || isJetpackSelfHosted || nonInstallablePlanError ) {
-			return;
-		}
-		const id = setTimeout( () => setNonInstallablePlanError( true ), 2000 );
-		return () => clearTimeout( id );
-	}, [ hasAtomicFeature, isJetpackSelfHosted, nonInstallablePlanError ] );
+	// The plan's feature list can arrive late, so only conclude the site can't install plugins once
+	// it has stayed uninstallable for the grace period. Deriving it (rather than latching a timer)
+	// means the error clears if eligibility arrives afterwards.
+	const nonInstallablePlanError = useDelayedCondition(
+		! hasAtomicFeature && ! isJetpackSelfHosted,
+		PLAN_FEATURES_GRACE_PERIOD_MS
+	);
 
 	const isInstallAuthorizationMissing =
 		// 1. This is a plugin upload flow (via zip file) and we don't have a primary domain set

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -245,8 +245,10 @@ export function useProductInstall( {
 			);
 			setCurrentStep( 2 );
 		}
+		// currentStep is a dependency so a plugin that appears before the installing step is reached
+		// (a fast or already-installed plugin) still gets activated once the step catches up.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ pluginUploadComplete, installedPlugin, setCurrentStep ] );
+	}, [ pluginUploadComplete, installedPlugin, setCurrentStep, currentStep ] );
 
 	useThankYouRedirect( {
 		siteId,

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -43,8 +43,7 @@ import { useThankYouRedirect } from './use-thank-you-redirect';
 // The state authorizing an install is handed off asynchronously, so allow for it arriving late.
 const INSTALL_HANDOFF_GRACE_PERIOD_MS = 2000;
 
-// The plan's feature list is fetched asynchronously, so allow for it arriving late before
-// concluding the site can't install plugins.
+// The plan's feature list is fetched asynchronously; allow for it arriving late.
 const PLAN_FEATURES_GRACE_PERIOD_MS = 2000;
 
 export type ProductInstallError =
@@ -63,17 +62,14 @@ export function useProductInstall( {
 } ) {
 	const isPluginUploadFlow = ! pluginSlug && ! themeSlug;
 	const [ currentStep, setCurrentStep ] = useState( 0 );
-	// Ref instead of state so the install effect can be guarded synchronously —
-	// the dispatch inside the effect notifies redux subscribers (via
-	// useSyncExternalStore) before a setState would commit, which would
-	// otherwise re-enter the effect and dispatch repeatedly.
+	// A ref, not state, so the guard commits synchronously: the dispatch inside the effect notifies
+	// subscribers before a setState would, which would otherwise re-enter and dispatch again.
 	const installFlowInitiatedRef = useRef( false );
 	const [ atomicFlow, setAtomicFlow ] = useState( false );
 	const [ userDirectInstallationAllowed, setUserDirectInstallationAllowed ] = useState( false );
-	// The signup "Get started" flow reaches this page via a full-page redirect, which drops the
-	// in-memory purchase-flow state that normally authorizes the install. When that redirect marks
-	// itself as trusted (directInstall), proceed with the install directly instead of waiting on
-	// handoff state that will never arrive (which otherwise leaves the page polling forever).
+	// The signup flow reaches this page via a full-page redirect that drops the in-memory handoff
+	// state. A trusted redirect (directInstall) authorizes the install directly, rather than
+	// waiting on handoff state that will never arrive.
 	const directInstallFromSignup = useSelector( getCurrentQueryArguments )?.directInstall != null;
 	const directInstallationAllowed = userDirectInstallationAllowed || directInstallFromSignup;
 	const translate = useTranslate();
@@ -143,10 +139,9 @@ export function useProductInstall( {
 		siteCanTransferToAtomic: !! hasAtomicFeature,
 	} );
 
-	// The plan's feature list can arrive late, so only conclude the site can't install plugins once
-	// no strategy has been available for the grace period. Deriving it from the same strategy the
-	// install uses keeps the error from disagreeing with what actually happens, and it clears if
-	// eligibility arrives afterwards.
+	// Only conclude the site can't install once no strategy has been available for the grace period.
+	// Deriving from the same strategy the install uses keeps the two in agreement, and it clears if
+	// eligibility arrives late.
 	const nonInstallablePlanError = useDelayedCondition(
 		installStrategy === 'none',
 		PLAN_FEATURES_GRACE_PERIOD_MS
@@ -169,9 +164,7 @@ export function useProductInstall( {
 		if ( 100 !== pluginUploadProgress ) {
 			return;
 		}
-		// For smaller uploads or fast networks give
-		// the chance to Upload Plugin step to be shown
-		// before moving to next step.
+		// Let the upload step show briefly before advancing.
 		const id = setTimeout( () => setCurrentStep( 1 ), 1000 );
 		return () => clearTimeout( id );
 	}, [ pluginUploadProgress ] );
@@ -194,9 +187,8 @@ export function useProductInstall( {
 		}
 
 		installFlowInitiatedRef.current = true;
-		// Intentionally uncancelable. The ref above blocks re-entry, so tying this to the
-		// effect's lifetime would let a dependency change drop the step advance for good
-		// rather than reschedule it — and the dispatches below change state this effect reads.
+		// Intentionally uncancelable: the ref blocks re-entry, so tying this to the effect's
+		// lifetime would let a dependency change drop the step advance rather than reschedule it.
 		const triggerInstallFlow = () => {
 			waitFor( 1 ).then( () => setCurrentStep( 1 ) );
 		};
@@ -234,9 +226,8 @@ export function useProductInstall( {
 		}
 	}, [ atomicFlow, automatedTransferStatus, currentStep ] );
 
-	// Activate the plugin once it is installed and the installing step has been reached. currentStep
-	// is a dependency so a plugin that appears before that step (a fast or already-installed plugin)
-	// still gets activated when the step catches up.
+	// Activate once the plugin is installed and the installing step is reached. currentStep is a
+	// dependency so a plugin that appears before that step still activates when the step catches up.
 	useEffect( () => {
 		if (
 			installedPlugin &&


### PR DESCRIPTION
## Proposed Changes

Add characterization tests for the install page's progress state machine, which had no coverage, and fix three install-flow bugs the tests surfaced.

The tests pin the in-place, atomic-transfer, plugin-upload, and theme flows through initiation and activation, along with the re-entry guard, the intentional setup-step delay, and the idle behavior of a completed handoff revisited in the same session.

The three fixes, each reproduced by a test that fails without the change:

- A plugin that finished installing during the one-second setup delay was never activated, because the activation effect did not re-run once the step advanced. It now reacts to the step catching up.
- A site whose feature data had not loaded yet resolved to no install strategy but still set the re-entry guard, so it could never start once eligibility arrived. The guard is now set only after a real strategy is chosen.
- The "your plan doesn't allow installation" error was computed from a predicate that disagreed with the install strategy (and latched once set), so an Atomic site with slow feature data could start installing while showing a false upgrade prompt. The error is now derived from the same strategy the install uses, so it can't disagree and it clears when the site becomes installable.

## Why are these changes being made?

The step progression is the part of this page that has caused the most trouble over time and the only significant untested logic left. Pinning it down first lets the transitions be consolidated later without guessing — and building the net surfaced the three bugs above, which it then let us fix safely.

The suite also captures, as a test, a pre-existing dead-end that is not fixed here: a completed handoff revisited in the same session initiates nothing and stays on the first step. The signup direct-install entry and a genuinely late marketplace handoff remain uncovered.

## Testing Instructions

```
yarn test-client client/my-sites/marketplace/pages/marketplace-product-install/test/
```

Each transition and each fix was checked to fail when the corresponding production behavior is broken.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
