### PR TITLE
Logs: fix infinite scroll in PHP error and web server logs

### DIFF
--- a/client/dashboard/sites/logs/dataviews/index.tsx
+++ b/client/dashboard/sites/logs/dataviews/index.tsx
@@ -2,8 +2,7 @@ import { LogType, PHPLog, ServerLog, SiteLogsParams } from '@automattic/api-core
 import { siteLogsInfiniteQuery } from '@automattic/api-queries';
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import { ToggleControl, Button } from '@wordpress/components';
-import { throttle } from '@wordpress/compose';
+import { ToggleControl, Button, Spinner } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { View, Filter, Field } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
@@ -68,14 +67,27 @@ function SiteLogsDataViews( {
 	const search = router.state.location.search;
 	const rafIdRef = useRef< number | null >( null );
 	const dataviewsRef = useRef< HTMLDivElement | null >( null );
-	const [ showScrollTop, setShowScrollTop ] = useState( false );
-
-	const { view, updateView, resetView } = usePersistentView( {
+	const {
+		view: persistedView,
+		updateView,
+		resetView,
+	} = usePersistentView( {
 		slug: `site-logs-${ logType }`,
 		defaultView: logType === LogType.PHP ? DEFAULT_PHP_LOGS_VIEW : DEFAULT_SERVER_LOGS_VIEW,
 		queryParams: search,
 		queryParamFilterFields: logType === LogType.PHP ? [ 'severity' ] : [],
 	} );
+
+	// Where DataViews' infinite scroll has advanced the window to. Deliberately
+	// not persisted, so it lives here rather than in the persisted view.
+	const [ startPosition, setStartPosition ] = useState( 1 );
+
+	// Infinite scroll is how this screen works, not a user preference, so force it
+	// on rather than inheriting it from a view persisted before it existed.
+	const view = useMemo(
+		() => ( { ...persistedView, infiniteScrollEnabled: true, startPosition } ),
+		[ persistedView, startPosition ]
+	);
 
 	// We want to parse 'from' and 'to' from the URL.
 	const parseUrlSeconds = useMemo( () => {
@@ -116,16 +128,31 @@ function SiteLogsDataViews( {
 		window.history.replaceState( null, '', url.toString() );
 	}, [ startSec, endSec, logType ] );
 
-	const filter = useMemo( () => toFilterParams( { view, logType } ), [ view, logType ] );
+	// Derived from the persisted view, not the merged one, so that advancing
+	// `startPosition` doesn't churn the query params.
+	const filter = useMemo(
+		() => toFilterParams( { view: persistedView, logType } ),
+		[ persistedView, logType ]
+	);
+	const sortOrder = persistedView.sort?.direction;
 
 	const params: SiteLogsParams = {
 		logType,
 		start: startSec,
 		end: endSec,
 		filter,
-		sortOrder: view.sort?.direction,
+		sortOrder,
 		pageSize: DEFAULT_PER_PAGE,
 	};
+
+	// The loaded pages restart whenever the query params change (a new date range,
+	// filter, or sort — including the range shifting under auto-refresh), so the
+	// window goes back to the beginning with them. Keyed by value: the view object
+	// identity changes on every render, so `filter` can't be a dependency.
+	const datasetKey = `${ startSec }|${ endSec }|${ sortOrder }|${ JSON.stringify( filter ) }`;
+	useEffect( () => {
+		setStartPosition( 1 );
+	}, [ datasetKey ] );
 
 	const {
 		data,
@@ -182,7 +209,9 @@ function SiteLogsDataViews( {
 				cancelAnimationFrame( rafIdRef.current );
 			}
 		};
-	}, [ logType, handleResize ] );
+		// Re-runs once the first page arrives: the wrapper doesn't exist while the
+		// loading placeholder shows, and bounding it is what makes the table scroll.
+	}, [ logType, handleResize, isLoadingLogQuery ] );
 
 	const phpLogs = useMemo< PhpLogWithId[] >( () => {
 		if ( logType !== LogType.PHP ) {
@@ -197,6 +226,21 @@ function SiteLogsDataViews( {
 		}
 		return buildServerLogsWithId( ( data?.pages as Array< { logs?: ServerLog[] } > ) ?? [] );
 	}, [ data?.pages, logType ] );
+
+	const logs = logType === LogType.PHP ? phpLogs : serverLogs;
+	const perPage = view.perPage ?? DEFAULT_PER_PAGE;
+
+	// With infinite scroll, DataViews expects the current window rather than
+	// everything loaded so far; it reassembles the full list itself.
+	const windowStart = startPosition - 1;
+	const visiblePhpLogs = useMemo(
+		() => phpLogs.slice( windowStart, windowStart + perPage ),
+		[ phpLogs, windowStart, perPage ]
+	);
+	const visibleServerLogs = useMemo(
+		() => serverLogs.slice( windowStart, windowStart + perPage ),
+		[ serverLogs, windowStart, perPage ]
+	);
 
 	const fields = useFields( { logType, timezoneString, gmtOffset } );
 
@@ -233,11 +277,13 @@ function SiteLogsDataViews( {
 			}
 		}
 
-		// Detect filters/sort/perPage changes
+		// Detect filters/sort/perPage changes. Normalize the filters, otherwise an
+		// unfiltered view compares `[]` against `undefined` and reports a change on
+		// every call — including each time infinite scroll advances the window.
 		const datasetChanged =
 			next.perPage !== view.perPage ||
 			next.sort?.direction !== view.sort?.direction ||
-			! fastDeepEqual( sourceFilters, view.filters );
+			! fastDeepEqual( sourceFilters, view.filters ?? [] );
 
 		const url = new URL( window.location.href );
 		// Always keep canonical time range params
@@ -251,10 +297,23 @@ function SiteLogsDataViews( {
 				queryKey: [ 'site', site.ID, 'logs', 'infinite' ],
 				exact: false,
 			} );
+			setStartPosition( 1 );
 			updateView( { ...next, page: 1 } );
-		} else {
-			updateView( next );
+			return;
 		}
+
+		// DataViews drives infinite scroll by advancing `startPosition`. Fetch the
+		// next page once the window nears the end of what has been loaded.
+		const nextStartPosition = next.startPosition ?? 1;
+		if ( nextStartPosition !== startPosition ) {
+			setStartPosition( nextStartPosition );
+
+			if ( nextStartPosition + perPage > logs.length && hasNextPage && ! isFetchingNextPage ) {
+				fetchNextPage();
+			}
+		}
+
+		updateView( next );
 	};
 
 	const handleAutoRefreshClick = ( isChecked: boolean ) => {
@@ -289,39 +348,10 @@ function SiteLogsDataViews( {
 		</>
 	);
 
-	const logs = logType === LogType.PHP ? phpLogs : serverLogs;
-
-	const infiniteScrollHandler = useCallback( () => {
-		if ( hasNextPage && ! isFetchingNextPage ) {
-			fetchNextPage();
-		}
-	}, [ hasNextPage, isFetchingNextPage, fetchNextPage ] );
-
-	useEffect( () => {
-		if ( ! dataviewsRef.current ) {
-			return;
-		}
-
-		const el = dataviewsRef.current;
-
-		const handleScroll = throttle( () => {
-			const scrollTop = el.scrollTop;
-			const scrollHeight = el.scrollHeight;
-			const clientHeight = el.clientHeight;
-
-			setShowScrollTop( scrollTop > clientHeight * 2 );
-
-			if ( scrollTop + clientHeight >= scrollHeight - 100 ) {
-				infiniteScrollHandler();
-			}
-		}, 100 );
-
-		el.addEventListener( 'scroll', handleScroll );
-		return () => el.removeEventListener( 'scroll', handleScroll );
-	}, [ infiniteScrollHandler ] );
-
+	// DataViews advances its window only while `totalItems` stays ahead of it, so
+	// report an optimistic total while more pages remain.
 	const paginationInfo = {
-		totalItems: logs.length,
+		totalItems: hasNextPage ? logs.length + perPage : logs.length,
 		totalPages: 1,
 	};
 
@@ -345,12 +375,24 @@ function SiteLogsDataViews( {
 		/>
 	);
 
+	// DataViews binds its infinite-scroll listener to the scroll container in an
+	// effect that gives up when the container isn't there yet, and never retries.
+	// The container only renders once DataViews has rows, so mounting it mid-fetch
+	// permanently loses the listener. Wait for the first page instead.
+	if ( isLoadingLogQuery ) {
+		return (
+			<div className="site-logs-loading">
+				<Spinner />
+			</div>
+		);
+	}
+
 	return (
 		<>
 			{ logType === LogType.PHP ? (
 				<DataViews< PHPLog >
-					data={ phpLogs }
-					isLoading={ isFetching }
+					data={ visiblePhpLogs }
+					isLoading={ isFetchingNextPage }
 					paginationInfo={ paginationInfo }
 					fields={ fields as Field< PHPLog >[] }
 					getItemId={ ( item ) => item.id }
@@ -365,8 +407,8 @@ function SiteLogsDataViews( {
 				/>
 			) : (
 				<DataViews< ServerLog >
-					data={ serverLogs }
-					isLoading={ isFetching }
+					data={ visibleServerLogs }
+					isLoading={ isFetchingNextPage }
 					paginationInfo={ paginationInfo }
 					fields={ fields as Field< ServerLog >[] }
 					getItemId={ ( item ) => item.id }
@@ -380,13 +422,18 @@ function SiteLogsDataViews( {
 					empty={ emptyState }
 				/>
 			) }
-			{ showScrollTop && (
+			{ startPosition > 1 && (
 				<Button
 					icon={ arrowUp }
 					iconSize={ 24 }
 					size="compact"
 					className="site-logs-scroll-to-top"
-					onClick={ () => dataviewsRef.current?.scrollTo( { top: 0, behavior: 'smooth' } ) }
+					onClick={ () => {
+						setStartPosition( 1 );
+						dataviewsRef.current
+							?.querySelector( '.dataviews-layout__container' )
+							?.scrollTo( { top: 0, behavior: 'smooth' } );
+					} }
 				/>
 			) }
 			{ ! isLoadingLogQuery && <PerformanceTrackerStop /> }

--- a/client/dashboard/sites/logs/dataviews/style.scss
+++ b/client/dashboard/sites/logs/dataviews/style.scss
@@ -83,6 +83,15 @@
 	margin: 0;
 }
 
+/* TEMPORARY: this screen scrolls instead of paginating, so the footer holds
+   nothing — but DataViews still mounts it partway through a fetch, which
+   resizes the scroll container under the reader. Hide it until the
+   @wordpress/dataviews 17.2.0 bump lands, which stops tying the footer's
+   visibility to the loading state, then remove this rule. */
+.site-logs-card .dataviews-footer {
+	display: none;
+}
+
 /* Center the Auto-refresh toggle with the sibling view-config and download icon buttons. */
 .site-logs-card .dataviews__view-actions .components-toggle-control {
 	display: flex;

--- a/client/dashboard/sites/logs/dataviews/style.scss
+++ b/client/dashboard/sites/logs/dataviews/style.scss
@@ -65,6 +65,24 @@
 	cursor: pointer;
 }
 
+/* DataViews appends its "loading more" spinner to the scrolled content, which
+   suits a fast request: it lands below the fold and the next batch arrives
+   before you reach it. A batch of logs can take a minute, so here it is scrolled
+   onto and sat with — pin it to the bottom so it doesn't shift rows or leave a
+   gap behind. */
+.site-logs-card .dataviews-loading:has( .dataviews-loading-more ) {
+	position: sticky;
+	bottom: 0;
+	flex-grow: 0;
+	padding: 6px 0;
+	background-color: var(--color-surface);
+	border-top: 1px solid var(--color-border-subtle);
+}
+
+.site-logs-card .dataviews-loading-more {
+	margin: 0;
+}
+
 /* Center the Auto-refresh toggle with the sibling view-config and download icon buttons. */
 .site-logs-card .dataviews__view-actions .components-toggle-control {
 	display: flex;

--- a/client/dashboard/sites/logs/dataviews/style.scss
+++ b/client/dashboard/sites/logs/dataviews/style.scss
@@ -65,12 +65,14 @@
 	cursor: pointer;
 }
 
-/* TEMPORARY: this screen scrolls instead of paginating, so the footer holds
-   nothing — but DataViews still mounts it partway through a fetch, which
-   resizes the scroll container under the reader. Hide it until the
-   @wordpress/dataviews 17.2.0 bump lands, which stops tying the footer's
+/* TEMPORARY: these two screens scroll instead of paginating, so the footer
+   holds nothing — but DataViews still mounts it partway through a fetch, which
+   resizes the scroll container under the reader. Scoped to php and server
+   because the activity log does paginate and needs its footer. Hide it until
+   the @wordpress/dataviews 17.2.0 bump lands, which stops tying the footer's
    visibility to the loading state, then remove this rule. */
-.site-logs-card .dataviews-footer {
+.site-logs-card--php .dataviews-footer,
+.site-logs-card--server .dataviews-footer {
 	display: none;
 }
 

--- a/client/dashboard/sites/logs/dataviews/style.scss
+++ b/client/dashboard/sites/logs/dataviews/style.scss
@@ -65,24 +65,6 @@
 	cursor: pointer;
 }
 
-/* DataViews appends its "loading more" spinner to the scrolled content, which
-   suits a fast request: it lands below the fold and the next batch arrives
-   before you reach it. A batch of logs can take a minute, so here it is scrolled
-   onto and sat with — pin it to the bottom so it doesn't shift rows or leave a
-   gap behind. */
-.site-logs-card .dataviews-loading:has( .dataviews-loading-more ) {
-	position: sticky;
-	bottom: 0;
-	flex-grow: 0;
-	padding: 6px 0;
-	background-color: var(--color-surface);
-	border-top: 1px solid var(--color-border-subtle);
-}
-
-.site-logs-card .dataviews-loading-more {
-	margin: 0;
-}
-
 /* TEMPORARY: this screen scrolls instead of paginating, so the footer holds
    nothing — but DataViews still mounts it partway through a fetch, which
    resizes the scroll container under the reader. Hide it until the

--- a/client/dashboard/sites/logs/dataviews/views.ts
+++ b/client/dashboard/sites/logs/dataviews/views.ts
@@ -3,14 +3,12 @@ import type { View } from '@wordpress/dataviews';
 
 export const DEFAULT_PER_PAGE = 50;
 
-// `infiniteScrollEnabled` is intentionally omitted: this view does its own
-// scroll-driven `fetchNextPage()` (see `index.tsx`). Enabling DataViews' own
-// infinite scroll on top of that makes `useData` window the rows and drop
-// off-screen ones, which fights the custom handler and looks janky.
 const DEFAULT_VIEW = {
 	type: 'table',
 	perPage: DEFAULT_PER_PAGE,
 	showLevels: false,
+	infiniteScrollEnabled: true,
+	startPosition: 1,
 } satisfies Partial< View >;
 
 export const DEFAULT_PHP_LOGS_VIEW: View = {

--- a/client/dashboard/sites/logs/style.scss
+++ b/client/dashboard/sites/logs/style.scss
@@ -8,6 +8,13 @@
 	}
 }
 
+.site-logs-loading {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 240px;
+}
+
 .dataviews-wrapper .screen-reader-text {
 	clip: rect(1px, 1px, 1px, 1px);
 	position: absolute !important;


### PR DESCRIPTION
Fixes DOTMSD-1461

## Proposed Changes

* Fix infinite scroll in the PHP error and web server logs, so more than the first 50 entries are reachable again.
* Replace the hand-rolled scroll handling with the infinite scroll DataViews provides.
* Show progress while the next batch loads, pinned to the bottom of the table.
* Hide the footer on these two screens, where it has nothing to show because they scroll instead of paginating.

## Why are these changes being made?

Customers report that the logs screens are stuck on the first page of results, with no way to reach the rest. Downloading the CSV shows there is much more data available.

These screens deliberately use infinite scroll rather than pagination, so no pagination controls are expected — but the infinite scroll itself silently stopped working, which leaves the remaining entries unreachable.

The screens drove their own scroll-based paging, listening for scroll events on the DataViews wrapper. That element stopped being the scrollable one in `@wordpress/dataviews` v13, when overflow moved to an inner container, so the handler never ran and no further page was ever requested. The upgrade landed a while before the MSD launch, which is why this surfaced as a launch regression rather than at upgrade time.

Rather than chase the new element, this drops the custom handling and uses the infinite scroll DataViews now provides, so nothing here is coupled to its internal DOM.

## Considerations

**Rendering the table before the first batch arrives.** DataViews binds its scroll listener in an effect that gives up when the scroll container isn't mounted yet, and never retries. The container only appears once it has rows. These screens rendered it immediately, while the first request was still out, so by the time the container existed the listener had already been abandoned — the view state was correct, the loaded count was correct, and no page was ever requested. Waiting for the first batch before rendering it is what makes the listener bind.

**Two things that only surface once paging works.** An unfiltered view compared `[]` against `undefined` and so reported a dataset change on every call; harmless when the only calls came from user actions, but with infinite scroll it fires on every window advance and discards the loaded pages. And the effect that bounds the table's height has to re-run once the table mounts, or the table never becomes scrollable and produces no scroll events at all.

**The one local style rule, and it is temporary.** While a batch loads, rows shift and a gap opens below them. The cause is the footer: there is nothing to put in it — these screens scroll rather than paginate — but DataViews mounts it partway through a fetch regardless, and because it takes space below the scroll container, the container resizes while the reader is in it. Hiding it settles the layout.

The rule is scoped to the php and server cards rather than to `.site-logs-card`, which the activity log also carries. The activity log paginates, and its footer is the only way to reach page 2 — hiding it there would have cost more than it saved.

An earlier revision instead pinned the progress spinner to the bottom of the table, on the theory that the spinner was what moved. It wasn't, and that rule has been dropped: the spinner now renders the way DataViews renders it everywhere else. Worth knowing if you saw the earlier diff.

`@wordpress/dataviews` 17.2.0 stops tying the footer's visibility to the loading state, so this rule should come out when that bump lands (#112947). It is a style rule rather than a component change so the revert is a deletion.

**What the windowing costs on 16.0.0.** Handing the paging to DataViews means `useData` keeps a window of rows and drops the ones outside it, which is why this view now passes a slice and lets DataViews reassemble the list. That is the mechanism working as intended, not a conflict — the custom handler it would have fought is gone.

There is one rough edge left, and it is worth knowing about before merging. 17.2.0 carries a second infinite-scroll fix beyond the footer: scroll-anchor restoration currently discards scrolling done while a page is in flight. DataViews records an anchor row when it asks for the next page, then restores that row's position once the page lands, regardless of where the reader has scrolled to in the meantime. Scrolling away mid-load therefore snaps you back. Measured on this branch, parking at three different offsets while a batch was outstanding:

| parked at | after the batch landed | moved by |
|---|---|---|
| 15370 | 37921 | 22551 |
| 15705 | 50343 | 34638 |
| 19283 | 62313 | 43030 |

Scrolling back up once loading has finished is unaffected — stepping from 24107 to 0 in nine moves held position exactly each time. It only bites while a request is outstanding, which on this endpoint can be tens of seconds.

This is not a regression: trunk cannot reach a second batch at all, so the situation never arises there, and the alternative is leaving the data unreachable. It is fixed upstream and lands with the same bump as the footer rule (#112947), so the two should go in close together.

## Testing Instructions

Requires a site with hosting features and more than 50 web server log entries in the selected range.

1. Go to a site → Logs → Web server.
2. Scroll to the bottom of the table.
3. The next batch loads and appends, and the scroll-to-top button appears. Keep scrolling to keep loading, until the data runs out.
4. While a batch is loading, a spinner sits pinned to the bottom of the table, the rows stay put, and no footer appears below the table.
5. Repeat on Logs → PHP errors for a site that has PHP errors.
6. On a site with no PHP errors, check the empty state and the toolbar still render.
7. Go to Logs → Activity and confirm its pagination is still there at the bottom of the table. That screen shares a class with the other two and keeps its footer.

On trunk, step 3 loads nothing and the button never appears.

Verified against the live API on an Atomic site with ~1,200 web server entries: before, the row count stayed at 50 no matter how far you scrolled; after, it goes 50 → 100 → 150, one batch per scroll. The PHP path was verified the same way against a stubbed endpoint, since no test site had PHP errors to page through — 50 → 100 → 130, stopping once the cursor is exhausted. The empty state and toolbar were checked on a site with no PHP errors.

Note when testing manually: the logs endpoint is slow and variable, and a single batch can take anywhere from ten seconds to over a minute to come back. Give it time before concluding nothing is loading.

The footer rule was checked against the live API afterwards. Sampled while a batch was in flight, the footer does mount and is held at zero height, with the scroll container staying at a steady 453px; on the activity log the same footer renders at 57px showing "PAGE 1 OF 3". Paging on the server log ran to 300 rows across six batches during that session.

Still unverified: dark mode and narrow widths where the table shows its horizontal scrollbar, and the PHP path, which has only ever been exercised against a stubbed endpoint because no test site has real PHP errors to page through.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? <!-- Atomic only; these screens require hosting features -->
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

