### PR TITLE
Reader: Keep the primary panel visible between lazy-loaded pages

### DIFF
--- a/client/reader/color-scheme/dark-mode.scss
+++ b/client/reader/color-scheme/dark-mode.scss
@@ -31,6 +31,7 @@
 		color: var( --dashboard__text-color );
 	}
 
+	.layout.is-global-sidebar-visible .layout__primary:not( :has( > * ) ),
 	.layout.is-global-sidebar-visible .layout__primary > div:not( :has( .recent-feed ) ) {
 		border-color: var( --color-border-subtle );
 	}

--- a/client/reader/controller.jsx
+++ b/client/reader/controller.jsx
@@ -127,7 +127,9 @@ export function following( context, next ) {
 
 export function loadNewSubscriptionPage( context, next ) {
 	const selectedTab = getCurrentTabFromURL( context.path, 'reader/new', 'add-new' );
-	context.primary = <AsyncLoad require={ loadNewSubscription } selectedTab={ selectedTab } />;
+	context.primary = (
+		<AsyncLoad require={ loadNewSubscription } selectedTab={ selectedTab } placeholder={ null } />
+	);
 
 	trackPageLoad( '/reader/new', 'Reader > New Subscription', 'reader-new-subscription' );
 	next();
@@ -349,7 +351,7 @@ export async function siteSubscriptionsManager( context, next ) {
 	const mcKey = 'subscription-sites';
 	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
-	context.primary = <AsyncLoad require={ loadSiteSubscriptionsManager } />;
+	context.primary = <AsyncLoad require={ loadSiteSubscriptionsManager } placeholder={ null } />;
 	next();
 }
 
@@ -376,6 +378,7 @@ export async function siteSubscription( context, next ) {
 			subscriptionId={ context.params.subscription_id }
 			blogId={ context.params.blog_id }
 			transition={ context.query.transition === 'true' }
+			placeholder={ null }
 		/>
 	);
 	next();
@@ -387,7 +390,7 @@ export async function commentSubscriptionsManager( context, next ) {
 	const mcKey = 'subscription-comments';
 	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
-	context.primary = <AsyncLoad require={ loadCommentSubscriptionsManager } />;
+	context.primary = <AsyncLoad require={ loadCommentSubscriptionsManager } placeholder={ null } />;
 	next();
 }
 
@@ -397,7 +400,7 @@ export async function pendingSubscriptionsManager( context, next ) {
 	const mcKey = 'subscription-pending';
 	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
-	context.primary = <AsyncLoad require={ loadPendingSubscriptionsManager } />;
+	context.primary = <AsyncLoad require={ loadPendingSubscriptionsManager } placeholder={ null } />;
 	next();
 }
 

--- a/client/reader/conversations/controller.jsx
+++ b/client/reader/conversations/controller.jsx
@@ -37,6 +37,7 @@ export function conversations( context, next ) {
 			key="conversations"
 			streamKey={ streamKey }
 			trackScrollPage={ scrollTracker }
+			placeholder={ null }
 		/>
 	);
 	next();
@@ -73,6 +74,7 @@ export function conversationsA8c( context, next ) {
 			streamKey={ streamKey }
 			store={ { id: streamKey } }
 			trackScrollPage={ scrollTracker }
+			placeholder={ null }
 		/>
 	);
 	next();

--- a/client/reader/discover/index.web.jsx
+++ b/client/reader/discover/index.web.jsx
@@ -76,6 +76,7 @@ const discover = ( context, next ) => {
 				className="is-discover-stream"
 				selectedTab={ selectedTab }
 				query={ context.query }
+				placeholder={ null }
 			/>
 		</>
 	);

--- a/client/reader/full-post/controller.jsx
+++ b/client/reader/full-post/controller.jsx
@@ -37,6 +37,7 @@ export function blogPost( context, next ) {
 			blogId={ blogId }
 			postId={ postId }
 			referral={ referral }
+			placeholder={ null }
 		/>
 	);
 
@@ -59,7 +60,12 @@ export function feedPost( context, next ) {
 	trackPageLoad( basePath, fullPageTitle, 'full_post' );
 
 	context.primary = (
-		<AsyncLoad require={ loadReaderFullPost } feedId={ feedId } postId={ postId } />
+		<AsyncLoad
+			require={ loadReaderFullPost }
+			feedId={ feedId }
+			postId={ postId }
+			placeholder={ null }
+		/>
 	);
 
 	if ( isUserLoggedIn( state ) ) {

--- a/client/reader/list/controller.jsx
+++ b/client/reader/list/controller.jsx
@@ -24,7 +24,9 @@ export const createList = ( context, next ) => {
 	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 	recordTrack( 'calypso_reader_list_create_loaded' );
 
-	context.primary = <AsyncLoad require={ loadListManage } key="list-manage" isCreateForm />;
+	context.primary = (
+		<AsyncLoad require={ loadListManage } key="list-manage" isCreateForm placeholder={ null } />
+	);
 	next();
 };
 
@@ -64,6 +66,7 @@ export const listListing = ( context, next ) => {
 				mcKey
 			) }
 			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
+			placeholder={ null }
 		/>
 	);
 	next();
@@ -87,6 +90,7 @@ export const editList = ( context, next ) => {
 			owner={ encodeURIComponent( context.params.user ) }
 			slug={ encodeURIComponent( context.params.list ) }
 			selectedSection="details"
+			placeholder={ null }
 		/>
 	);
 	next();
@@ -110,6 +114,7 @@ export const editListItems = ( context, next ) => {
 			owner={ encodeURIComponent( context.params.user ) }
 			slug={ encodeURIComponent( context.params.list ) }
 			selectedSection="items"
+			placeholder={ null }
 		/>
 	);
 	next();
@@ -133,6 +138,7 @@ export const exportList = ( context, next ) => {
 			owner={ encodeURIComponent( context.params.user ) }
 			slug={ encodeURIComponent( context.params.list ) }
 			selectedSection="export"
+			placeholder={ null }
 		/>
 	);
 	next();
@@ -156,6 +162,7 @@ export const deleteList = ( context, next ) => {
 			owner={ encodeURIComponent( context.params.user ) }
 			slug={ encodeURIComponent( context.params.list ) }
 			selectedSection="delete"
+			placeholder={ null }
 		/>
 	);
 	next();

--- a/client/reader/on-this-day/controller.jsx
+++ b/client/reader/on-this-day/controller.jsx
@@ -28,6 +28,6 @@ export function onThisDay( context, next ) {
 
 	setPageTitle( context, i18n.translate( 'On This Day' ) );
 
-	context.primary = <AsyncLoad require={ loadMain } />;
+	context.primary = <AsyncLoad require={ loadMain } placeholder={ null } />;
 	next();
 }

--- a/client/reader/on-this-day/index.tsx
+++ b/client/reader/on-this-day/index.tsx
@@ -334,6 +334,7 @@ export const OnThisDay = ( { viewToggle, streamKey }: OnThisDayProps ) => {
 						feedId={ selectedItem.feedId }
 						blogId={ selectedItem.blogId }
 						postId={ selectedItem.postId }
+						placeholder={ null }
 						onClose={ () => {
 							const focusItem = itemRefs.current[ selectedItem?.postId?.toString() ?? '' ];
 							if ( ! isWide ) {

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -325,6 +325,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 							require={ loadReaderFullPost }
 							feedId={ selectedItem.feedId }
 							postId={ selectedItem.postId }
+							placeholder={ null }
 							onClose={ () => {
 								const focusItem = itemRefs.current[ getStreamItemKey( selectedItem ) ];
 								if ( ! isWide ) {

--- a/client/reader/search/controller.jsx
+++ b/client/reader/search/controller.jsx
@@ -93,6 +93,7 @@ const exported = {
 							onSortChange={ reportSortChange }
 							searchType={ show }
 							trendingTags={ context.params.trendingTags }
+							placeholder={ null }
 						/>
 					</div>
 				</div>

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -125,6 +125,7 @@ body.is-section-reader {
 			}
 		}
 
+		.layout__primary:not( :has( > * ) ),
 		.layout__primary > div:not( :has( .recent-feed ) ) {
 			background: var( --color-surface );
 			border-radius: 8px;

--- a/client/reader/tag-stream/controller.jsx
+++ b/client/reader/tag-stream/controller.jsx
@@ -87,6 +87,7 @@ export const tagListing = ( context, next ) => {
 				) }
 				startDate={ startDate }
 				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) } // eslint-disable-line
+				placeholder={ null }
 			/>
 		</>
 	);

--- a/client/reader/user-profile/controller.tsx
+++ b/client/reader/user-profile/controller.tsx
@@ -64,6 +64,7 @@ export function userProfile( ctx: Context, next: () => void ): void {
 			) }
 			path={ context.path }
 			view={ view }
+			placeholder={ null }
 		/>
 	);
 	next();


### PR DESCRIPTION
Closes READ-617

Video reproducing the issue
https://github.com/user-attachments/assets/983956df-f83c-4ae5-ba0e-ec46b3639154



## Proposed Changes

- Disable the generic `AsyncLoad` placeholder across Reader lazy-loaded surfaces.
- Keep the Reader main panel visible while a page chunk is loading by applying its existing panel styling when `.layout__primary` is empty.

## Why are these changes being made?
Before this PR we were showing a squashed default loading component from the async component, it was causing layout shifts. 

- With a null Suspense fallback, the primary area temporarily has no child while the next Reader page loads.
- Reader panel styling previously depended on that child, which made the panel flash away during transitions such as Search to Discover.
- Styling the empty primary area preserves the Reader chrome without introducing another loading UI.

## Testing Instructions

### Scenario 1 - Search to Discover:
- Go to `/reader/search`
- Navigate to Discover while using uncached Reader chunks or a throttled network
- Check if the main Reader panel remains visible without a generic loading placeholder while Discover loads

### Scenario 2 - Discover to Search:
- Go to `/discover`
- Navigate to Search while using uncached Reader chunks or a throttled network
- Check if the main Reader panel remains visible without shifting or flashing away while Search loads

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
