### PR TITLE
A4A: Add spacing above purchase confirmation

### DIFF
--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/style.scss
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/style.scss
@@ -24,6 +24,7 @@
 }
 
 .subscriptions-list__purchase-confirmation {
+	margin-block-start: 24px;
 	padding-inline: 16px;
 
 	@include breakpoint-deprecated( '>660px' ) {


### PR DESCRIPTION
Part of A4A-3054

## Proposed Changes

* Add 24px of top spacing above the client purchase confirmation banner.

## Why are these changes being made?

* Follow up on #112884 so the banner has clear separation from the top edge of the page content.

## Testing Instructions

* Complete an A4A client purchase and land on **Your subscriptions**.
* Verify the confirmation banner has 24px of space above it.
* Verify the banner keeps its existing horizontal spacing on desktop and mobile.

_— ClemenAgent (Powered by Codex)_

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
