### PR TITLE
DOTMSD-1434: Do not warn users using a PHP version higher than the recommended

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
 							'!calypso/lib/use-site-launch-gating-variant',
 							'!calypso/lib/load-dev-helpers',
 							'!calypso/lib/logstash',
+							'!calypso/lib/version-compare',
 							'!calypso/lib/wp',
 							// Allowed: calypso/assets/icons
 							// Allowed: calypso/assets/images

--- a/client/dashboard/sites/settings-php/summary.tsx
+++ b/client/dashboard/sites/settings-php/summary.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { code } from '@wordpress/icons';
 import { getPHPVersions } from 'calypso/data/php-versions';
+import versionCompare from 'calypso/lib/version-compare';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 import { hasHostingFeature } from '../../utils/site-features';
 import type { Site } from '@automattic/api-core';
@@ -25,7 +26,9 @@ export default function PHPSettingsSummary( { site, density }: { site: Site; den
 		return [
 			{
 				text: version,
-				intent: version !== recommendedValue ? ( 'warning' as const ) : ( 'success' as const ),
+				intent: versionCompare( version, recommendedValue, '>=' )
+					? ( 'success' as const )
+					: ( 'warning' as const ),
 			},
 		];
 	};


### PR DESCRIPTION
Fixes DOTMSD-1434

## Proposed Changes

Any time we add a new PHP version but do not mark it as recommended, new sites will mark that version in a warning-yellow color (see DOTMSD-1434 for a screenshot).
This patch makes sure that versions higher than the recommended are still marked in green.

Note: This patch adds `'!calypso/lib/version-compare',` to the list of allowed imports in the MSD since the file is side-effect-free.

## Testing Instructions

* Since the currently recommended version is the highest available this is not testable without manually messing with the code:
```ts
diff --git i/client/dashboard/sites/settings-php/summary.tsx w/client/dashboard/sites/settings-php/summary.tsx
index 59737453d30..7671f72b8d4 100644
--- i/client/dashboard/sites/settings-php/summary.tsx
+++ w/client/dashboard/sites/settings-php/summary.tsx
@@ -16,7 +16,8 @@ export default function PHPSettingsSummary( { site, density }: { site: Site; den
                enabled: hasHostingFeature( site, HostingFeatures.PHP ),
        } );

-       const { recommendedValue } = getPHPVersions( site.ID );
+       // const { recommendedValue } = getPHPVersions( site.ID );
+       const recommendedValue = '8.3';

        const getBadge = () => {
                if ( ! version ) {
```

With this applied, the PHP version of your PHP 8.4 site will be marked in yellow, and after the patch it will be marked in green.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
