### PR TITLE
Checkout: preserve site slug on renewal URLs when site fetch fails (CHE-512)

### DIFF
--- a/client/my-sites/controller.jsx
+++ b/client/my-sites/controller.jsx
@@ -779,6 +779,13 @@ function requestAndSelectSite( context, next, { siteFragment, isUnlinkedCheckout
 				}
 			} else if ( shouldRedirectToJetpackAuthorize( context, site ) ) {
 				navigate( getJetpackAuthorizeURL( context, site ) );
+			} else if ( /^\/checkout\/[^/]+\/renew\//.test( context.pathname ) ) {
+				// On a checkout renewal URL that carries an explicit site slug, an
+				// intermittently failed/unresolvable site fetch must not strip the slug:
+				// the all-sites redirect below would drop the user onto the slug-less
+				// no-site renewal route. Let checkout render with the slug intact and
+				// handle its own missing-site state instead. See CHE-512.
+				next();
 			} else {
 				// If the site has loaded but siteId is still invalid then redirect to allSitesPath.
 				const siteFragmentOffset = context.path.indexOf( `/${ siteFragment }` );

--- a/client/my-sites/controller.jsx
+++ b/client/my-sites/controller.jsx
@@ -779,7 +779,10 @@ function requestAndSelectSite( context, next, { siteFragment, isUnlinkedCheckout
 				}
 			} else if ( shouldRedirectToJetpackAuthorize( context, site ) ) {
 				navigate( getJetpackAuthorizeURL( context, site ) );
-			} else if ( /^\/checkout\/[^/]+\/renew\//.test( context.pathname ) ) {
+			} else if (
+				context.pathname.includes( '/checkout/' ) &&
+				context.pathname.includes( '/renew/' )
+			) {
 				// On a checkout renewal URL that carries an explicit site slug, an
 				// intermittently failed/unresolvable site fetch must not strip the slug:
 				// the all-sites redirect below would drop the user onto the slug-less

--- a/client/my-sites/controller.jsx
+++ b/client/my-sites/controller.jsx
@@ -788,6 +788,12 @@ function requestAndSelectSite( context, next, { siteFragment, isUnlinkedCheckout
 				// the all-sites redirect below would drop the user onto the slug-less
 				// no-site renewal route. Let checkout render with the slug intact and
 				// handle its own missing-site state instead. See CHE-512.
+				//
+				// Clear any stale selection first: unlike the redirect branch below
+				// (which re-enters siteSelection with no fragment and clears it there),
+				// this path calls next() directly, so a selectedSiteId left over from a
+				// prior SPA navigation would otherwise leak into checkout.
+				dispatch( setAllSitesSelected() );
 				next();
 			} else {
 				// If the site has loaded but siteId is still invalid then redirect to allSitesPath.

--- a/client/my-sites/test/controller.js
+++ b/client/my-sites/test/controller.js
@@ -372,3 +372,94 @@ describe( 'redirectToPrimary', () => {
 		spy.mockRestore();
 	} );
 } );
+
+describe( 'siteSelection — site fetch failure fallback', () => {
+	// Flush only the microtask queue (the middleware's promise chain), never a macrotask.
+	// `page.redirect` schedules its real `page.replace` on a timer; pumping setTimeout here
+	// would let that leaked navigation fire and tear down the jsdom document mid-test.
+	const flushPromises = async () => {
+		for ( let i = 0; i < 10; i++ ) {
+			await Promise.resolve();
+		}
+	};
+
+	// Simulates a fresh page load where the site fetch fails: the store has no
+	// matching site (empty `sites.items`, so `getSiteId` returns null) and
+	// requestSite rejects, so `freshSiteId` ends up falsy and the middleware
+	// reaches its fallback branch.
+	const buildContext = ( { path, pathname, querystring, siteFragment } ) => {
+		const store = mockStore( {
+			currentUser: { id: 12345, user: { site_count: 3, visible_site_count: 2 } },
+			sites: { items: {} },
+			ui: {},
+		} );
+		const context = {
+			store,
+			params: { site: siteFragment },
+			path,
+			pathname,
+			querystring,
+			query: {},
+			section: { enableNoSites: false },
+		};
+		// The fetch callback bails out early if the user has navigated away, so
+		// pin the current route to this context's path.
+		page.current = context.path;
+		return context;
+	};
+
+	let redirect;
+
+	beforeEach( () => {
+		requestSite.mockReturnValue( () =>
+			Promise.reject( new Error( 'intermittent site fetch failure' ) )
+		);
+		redirect = jest.spyOn( page, 'redirect' ).mockImplementation( () => {} );
+		// `page.redirect` schedules a real `page.replace` on a timer; neutralize it so a
+		// leaked navigation cannot tear down the jsdom document while promises flush.
+		jest.spyOn( page, 'replace' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+		page.current = '';
+	} );
+
+	it( 'does not strip the site slug on a checkout renewal URL when the site fetch fails', async () => {
+		const siteFragment = 'ecommercesite.wpcomstaging.com';
+		const pathname = `/checkout/ecommerce-bundle/renew/1252758/${ siteFragment }`;
+		const querystring = 'cancel_to=%2Fplans&redirect_to=%2Fplans';
+		const context = buildContext( {
+			path: `${ pathname }?${ querystring }`,
+			pathname,
+			querystring,
+			siteFragment,
+		} );
+		const next = jest.fn();
+
+		siteSelection( context, next );
+		await flushPromises();
+
+		expect( redirect ).not.toHaveBeenCalled();
+		expect( next ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'redirects to the slug-less all-sites path on a non-checkout route when the site fetch fails', async () => {
+		const siteFragment = 'ecommercesite.wpcomstaging.com';
+		const pathname = `/stats/day/${ siteFragment }`;
+		const querystring = 'a=b';
+		const context = buildContext( {
+			path: `${ pathname }?${ querystring }`,
+			pathname,
+			querystring,
+			siteFragment,
+		} );
+		const next = jest.fn();
+
+		siteSelection( context, next );
+		await flushPromises();
+
+		expect( redirect ).toHaveBeenCalledWith( `/stats/day?${ querystring }` );
+		expect( next ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/my-sites/test/controller.js
+++ b/client/my-sites/test/controller.js
@@ -6,7 +6,7 @@ import page from '@automattic/calypso-router';
 import configureStore from 'redux-mock-store';
 import { thunk } from 'redux-thunk';
 import * as pageView from 'calypso/lib/analytics/page-view';
-import { PREFERENCES_SET } from 'calypso/state/action-types';
+import { PREFERENCES_SET, SELECTED_SITE_SET } from 'calypso/state/action-types';
 import { requestSite } from 'calypso/state/sites/actions';
 import {
 	updateRecentSitesPreferences,
@@ -387,11 +387,11 @@ describe( 'siteSelection — site fetch failure fallback', () => {
 	// matching site (empty `sites.items`, so `getSiteId` returns null) and
 	// requestSite rejects, so `freshSiteId` ends up falsy and the middleware
 	// reaches its fallback branch.
-	const buildContext = ( { path, pathname, querystring, siteFragment } ) => {
+	const buildContext = ( { path, pathname, querystring, siteFragment, selectedSiteId = null } ) => {
 		const store = mockStore( {
 			currentUser: { id: 12345, user: { site_count: 3, visible_site_count: 2 } },
 			sites: { items: {} },
-			ui: {},
+			ui: { selectedSiteId },
 		} );
 		const context = {
 			store,
@@ -440,6 +440,31 @@ describe( 'siteSelection — site fetch failure fallback', () => {
 		siteSelection( context, next );
 		await flushPromises();
 
+		expect( redirect ).not.toHaveBeenCalled();
+		expect( next ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'clears a stale selectedSiteId before rendering checkout when the site fetch fails', async () => {
+		const siteFragment = 'ecommercesite.wpcomstaging.com';
+		const pathname = `/checkout/ecommerce-bundle/renew/1252758/${ siteFragment }`;
+		const querystring = 'cancel_to=%2Fplans&redirect_to=%2Fplans';
+		const context = buildContext( {
+			path: `${ pathname }?${ querystring }`,
+			pathname,
+			querystring,
+			siteFragment,
+			// A prior SPA navigation left an unrelated site selected.
+			selectedSiteId: 999,
+		} );
+		const next = jest.fn();
+
+		siteSelection( context, next );
+		await flushPromises();
+
+		expect( context.store.getActions() ).toContainEqual( {
+			type: SELECTED_SITE_SET,
+			siteId: null,
+		} );
 		expect( redirect ).not.toHaveBeenCalled();
 		expect( next ).toHaveBeenCalledTimes( 1 );
 	} );


### PR DESCRIPTION
Part of CHE-512

## Proposed Changes

* Guard the `siteSelection` fallback redirect in `client/my-sites/controller.jsx` for checkout renewal routes. When a `/checkout/:product/renew/…` URL carries an explicit site slug and the site fetch fails to resolve a usable site ID, skip the slug-stripping all-sites redirect and continue to the checkout handler instead.
* Add unit tests for `siteSelection` covering the new renewal guard and a regression test confirming non-checkout routes still redirect to the slug-less all-sites path when the site fetch fails.

## Why are these changes being made?

On a fresh load of a site-scoped renewal checkout URL — e.g. `/checkout/ecommerce-bundle/renew/1252758/somesite.wpcomstaging.com` — `siteSelection` starts with an empty Redux store, so it always dispatches `requestSite( siteFragment )`. When that fetch intermittently rejects (transient failures that `requestSite` does not retry — it only retries two specific error shapes), `freshSiteId` ends up falsy and the middleware falls into its fallback branch, which redirects to the slug-less path. That drops the user onto the no-site renewal route rather than the site-scoped one.

The existing `site.ID` fallback already covers the "resolved but not in Redux" case, and the existing `.wpcomstaging.com` fallback is a no-op for fragments that are already staging slugs, so the one remaining failure mode is an outright rejection. For a renewal URL, redirecting to the slug-less path is never the correct recovery — it deterministically produces the wrong route. Letting checkout render with the slug intact lets it handle its own missing-site state gracefully.

This is a follow-up to CHE-511, which preserved the query params on this same redirect but intentionally left the deeper root cause (the redirect firing and stripping the slug) for this issue.

## Testing Instructions

* `yarn test-client client/my-sites/test/controller.js` — the new `siteSelection` tests pass (renewal guard skips the redirect and calls `next()`; non-checkout route still redirects to the slug-less all-sites path).
* Manual: load a site-scoped renewal URL such as `/checkout/<product>/renew/<id>/<site>.wpcomstaging.com?cancel_to=…&redirect_to=…`. On a load where the site fetch fails, the URL should retain the `.wpcomstaging.com` slug and remain on the site-scoped renewal route rather than redirecting to the no-site variant. Non-checkout routes with an unresolvable site fragment should still redirect to the all-sites path.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
