### PR TITLE
Blocks: ETK: search inserter for Blog Posts block

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/blog-posts.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/blog-posts.ts
@@ -8,6 +8,7 @@ const blockParentSelector = '[aria-label="Block: Blog Posts"]';
 export class BlogPostsBlockFlow implements BlockFlow {
 	blockSidebarName = 'Blog Posts';
 	blockEditorSelector = blockParentSelector;
+	noSearch = false;
 
 	// We are very limited in what we can safely smoke test with the Blog Posts block because it is dependent on other posts.
 	// There's no guarantee (due to data clean up operations) that there will even be other posts!


### PR DESCRIPTION
## Proposed Changes

The `Blocks: ETK` E2E smoke test intermittently fails on the Gutenberg Atomic **edge** environment at `Blog Posts: Add the block from the sidebar`, with `locator.focus` timing out on the `getByRole( 'option', { name: 'Blog Posts', exact: true } )` inserter option.

Root cause: `BlogPostsBlockFlow` used `noSearch` browse mode, so the test relied on `.focus()` auto-scrolling the **full unfiltered** block list to reach the block. Blog Posts is the first inserter open on a fresh post, so it races the inserter's progressive rendering of below-fold third-party (Jetpack/Newspack) categories on slow edge CI, exhausting the 15s action timeout. The block is registered and present on edge (the same test passed in adjacent builds), so this is a rendering/timing flake, not a missing or renamed block.

Fix: set `noSearch = false` on `BlogPostsBlockFlow` (same pattern as `InstagramBlockFlow`). The test now types `Blog Posts` into the inserter search, filtering the list so the exact option renders deterministically at the top instead of depending on scroll-to-find.

Scope: only Blog Posts is touched. `PostCarouselBlockFlow` and `TimelineBlockFlow` still browse (they run when the inserter is warm and are not failing); the same one-liner applies if they ever flake.

Failing build: `calypso_WPComTests_gutenberg_atomic_edge_desktop/18621322`.

## Testing Instructions

Run the ETK block spec against staging:

```
CALYPSO_BASE_URL=<CALYPSO_STAGING_URL> yarn jest specs/blocks/blocks__etk.ts
```

Verified: 5/5 consecutive runs pass, `Blog Posts: Add the block from the sidebar` green each run (~1.5s). Edge itself is not reproducible locally (needs the edge Jetpack build and the edge account), so local verification ran on the stable Gutenberg account.

Edge coverage: the `calypso_WPComTests_gutenberg_atomic_edge_desktop` build was run against this branch (`calypso_WPComTests_gutenberg_atomic_edge_desktop/18625686`) and passed — 236 tests passed, 0 failures, with `Blog Posts: Add the block from the sidebar` green. This is on the exact environment where the test was failing.
