### PR TITLE
Dashboard: warn when a security key must be re-registered

### DIFF
--- a/client/dashboard/app/security-key-reregister-notice/index.tsx
+++ b/client/dashboard/app/security-key-reregister-notice/index.tsx
@@ -1,0 +1,39 @@
+import { userPreferenceQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+import ComponentViewTracker from '../../components/component-view-tracker';
+import { Notice } from '../../components/notice';
+import RouterLinkButton from '../../components/router-link-button';
+
+/**
+ * Whether the security key re-register notice is eligible to show. Read at the
+ * call site so the notice never decides its own visibility inside the arbiter.
+ * See client/dashboard/sites/AGENTS.md.
+ */
+export function useShouldShowSecurityKeyReregisterNotice() {
+	const { data: isReregisterRequired } = useSuspenseQuery(
+		userPreferenceQuery( 'two_step_security_key_reregister_required' )
+	);
+	return isReregisterRequired;
+}
+
+export default function SecurityKeyReregisterNotice() {
+	return (
+		<>
+			<ComponentViewTracker eventName="calypso_dashboard_security_key_reregister_notice_impression" />
+			<Notice
+				variant="warning"
+				title={ __( 'Your security key needs to be replaced' ) }
+				actions={
+					<RouterLinkButton to="/me/security/two-step-auth" variant="primary">
+						{ __( 'Register a new key' ) }
+					</RouterLinkButton>
+				}
+			>
+				{ __(
+					'There was an issue during setup, and your security key can’t be used to sign in. But don’t fret — your account is still secure.'
+				) }
+			</Notice>
+		</>
+	);
+}

--- a/client/dashboard/app/security-key-reregister-notice/index.tsx
+++ b/client/dashboard/app/security-key-reregister-notice/index.tsx
@@ -31,7 +31,7 @@ export default function SecurityKeyReregisterNotice() {
 				}
 			>
 				{ __(
-					'There was an issue during setup, and your security key can’t be used to sign in. But don’t fret — your account is still secure.'
+					'There was an issue during setup, so your security key might not always work when you sign in. But don’t fret — your account is still secure.'
 				) }
 			</Notice>
 		</>

--- a/client/dashboard/me/security-two-step-auth/main-page/security-keys/register-key.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/security-keys/register-key.tsx
@@ -1,5 +1,9 @@
-import { registerTwoStepAuthSecurityKeyMutation } from '@automattic/api-queries';
-import { useMutation } from '@tanstack/react-query';
+import {
+	registerTwoStepAuthSecurityKeyMutation,
+	userPreferenceMutation,
+	userPreferenceQuery,
+} from '@automattic/api-queries';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import {
 	Modal,
 	Button,
@@ -34,6 +38,13 @@ export default function RegisterKey( { onClose }: { onClose: () => void } ) {
 		registerTwoStepAuthSecurityKeyMutation( getSecurityKeyHostname() )
 	);
 
+	const { data: isReregisterRequired } = useQuery(
+		userPreferenceQuery( 'two_step_security_key_reregister_required' )
+	);
+	const { mutate: setReregisterRequired } = useMutation(
+		userPreferenceMutation( 'two_step_security_key_reregister_required' )
+	);
+
 	const handleSubmit = async ( e: React.FormEvent< HTMLFormElement > ) => {
 		e.preventDefault();
 		recordTracksEvent(
@@ -41,6 +52,9 @@ export default function RegisterKey( { onClose }: { onClose: () => void } ) {
 		);
 		registerSecurityKey( formData.keyName.trim(), {
 			onSuccess: () => {
+				if ( isReregisterRequired ) {
+					setReregisterRequired( false );
+				}
 				createSuccessNotice(
 					/* translators: %s is the security key name */
 					sprintf( __( 'Security key "%s" added.' ), formData.keyName ),

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -18,6 +18,9 @@ import { useAuth } from '../app/auth';
 import { useAppContext } from '../app/context';
 import { usePersistentView } from '../app/hooks/use-persistent-view';
 import { sitesRoute } from '../app/router/sites';
+import SecurityKeyReregisterNotice, {
+	useShouldShowSecurityKeyReregisterNotice,
+} from '../app/security-key-reregister-notice';
 import { DataViewsEmptyStateLayout } from '../components/dataviews';
 import InlineSupportLink from '../components/inline-support-link';
 import { PageHeader } from '../components/page-header';
@@ -159,7 +162,11 @@ export default function Sites() {
 	const isRestoringAccount = !! currentSearchParams.restored;
 
 	const { user } = useAuth();
+	const { supports } = useAppContext();
 	const { data: isAutomattician } = useSuspenseQuery( isAutomatticianQuery() );
+
+	const isSecurityKeyReregisterRequired = useShouldShowSecurityKeyReregisterNotice();
+	const showSecurityKeyReregisterNotice = supports.me && isSecurityKeyReregisterRequired;
 
 	const defaultView = getDefaultView( {
 		siteCount: user.site_count,
@@ -243,6 +250,7 @@ export default function Sites() {
 				}
 				notices={
 					<SitesNoticeArbiter>
+						{ showSecurityKeyReregisterNotice && <SecurityKeyReregisterNotice /> }
 						{ ! isDashboardBackport() && isRestoringAccount && <RestoringSitesNotices /> }
 					</SitesNoticeArbiter>
 				}

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -45,4 +45,5 @@ export interface UserPreferences {
 	'reader-profile-posts-visibility'?: 'public' | 'hidden';
 	'reader-profile-sites-visibility'?: 'public' | 'hidden';
 	'reader-profile-hidden-sites'?: number[];
+	two_step_security_key_reregister_required?: boolean;
 }

--- a/packages/api-queries/src/me-preferences.ts
+++ b/packages/api-queries/src/me-preferences.ts
@@ -42,6 +42,7 @@ const staticPreferenceStatIds: Record< string, string > = {
 	'reader-profile-posts-visibility': 'postvis',
 	'reader-profile-sites-visibility': 'sitevis',
 	'reader-profile-hidden-sites': 'hidsit',
+	two_step_security_key_reregister_required: '2fakey',
 };
 
 const dynamicPreferenceStatPrefixes: Record< string, string > = {

--- a/packages/api-queries/src/me-preferences.ts
+++ b/packages/api-queries/src/me-preferences.ts
@@ -24,6 +24,7 @@ const defaultValues: Required< UserPreferences > = {
 	'reader-profile-posts-visibility': 'public',
 	'reader-profile-sites-visibility': 'public',
 	'reader-profile-hidden-sites': [],
+	two_step_security_key_reregister_required: false,
 };
 
 const staticPreferenceStatIds: Record< string, string > = {


### PR DESCRIPTION
Related to DOTMSD-1416

## Proposed Changes

* Show a warning notice on the Dashboard Sites page when the `two_step_security_key_reregister_required` user preference is set, with a primary **Register a new key** button that opens Two-step authentication.
* The notice is not dismissible — it stays until the flag is cleared.
* Clear the flag automatically once the user successfully registers a security key, so the notice goes away after the problem is fixed.

<img width="1217" height="163" alt="image" src="https://github.com/user-attachments/assets/c9dbf753-ad77-48cc-9ddc-6fc93ac56a8b" />


Copy:

> **Your security key needs to be replaced**
> There was an issue during setup, so your security key might not always work when you sign in. But don’t fret — your account is still secure.
>
> **[ Register a new key ]**

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Some users have a registered security key that was not set up correctly and can no longer be used to sign in. Today they only discover this at the login screen, when they are already locked out of the flow they wanted.
* Surfacing it inside the Dashboard means they find out — and can fix it — while they are still signed in, rather than at the worst possible moment.
* The Sites page is the Dashboard's home surface, so the affected user reliably lands on it and sees the notice.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the Dashboard Sites page. With no preference set, nothing changes.
* Set the preference for your user, e.g. from the browser console:
  ```js
  wpcom.req.post( '/me/preferences', { calypso_preferences: { two_step_security_key_reregister_required: true } } )
  ```
  Reload the Sites page. The notice should appear above the site list.
* Confirm the **Register a new key** button navigates to Two-step authentication.
* Confirm the notice cannot be dismissed.
* With the flag set, register a security key from Me → Security → Two-step authentication. After it registers, the flag should be reset and the notice should disappear.

## Considerations

* **Placement.** Scoping the notice to Me → Security would put it next to the fix, but the affected users have no reason to visit that screen — they would keep hitting the failure at login instead. The Sites page shows at most one top-of-page notice, arbitrated in priority order; the re-register warning is registered as the highest-priority candidate so it reliably reaches the user without stacking with other banners.
* **CTA.** The call to action is a primary button rather than an inline text link, so the next step is prominent.
* **Dismissal.** A persisted dismissal would let someone permanently hide a real sign-in problem, so the notice has no close button. Instead it clears itself once the user registers a replacement key.
* **Classic Calypso.** This only covers the Dashboard — both the notice and the flag reset. A user who views the notice-less classic `/me/security/two-step` page, or registers a key there, will neither see the notice nor have the flag cleared by this change. Worth a follow-up if that audience is still significant.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
