### PR TITLE
Update WooCommerce proxy origins

### DIFF
--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -553,7 +553,6 @@ const wpcomAllowedOrigins = [
 	'https://agencies.automattic.com',
 	'https://my.wordpress.com',
 	'https://woocommerce.com',
-	'https://my.woocommerce.com',
 	'https://woocommercealshakero.jurassic.tube',
 	'http://wpcalypso.wordpress.com', // for running docker on dev instances
 	'http://widgets.wp.com',

--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -553,7 +553,6 @@ const wpcomAllowedOrigins = [
 	'https://agencies.automattic.com',
 	'https://my.wordpress.com',
 	'https://woocommerce.com',
-	'https://woocommercealshakero.jurassic.tube',
 	'http://wpcalypso.wordpress.com', // for running docker on dev instances
 	'http://widgets.wp.com',
 	'https://widgets.wp.com',
@@ -595,6 +594,7 @@ function isAllowedOrigin( urlOrigin ) {
 		wpcomAllowedOrigins.includes( urlOrigin ) ||
 		isLocalDevOrigin( urlOrigin ) ||
 		/^https:\/\/[a-z0-9-]+\.calypso\.live$/.test( urlOrigin ) ||
+		/^https:\/\/[a-z0-9-]+\.jurassic\.tube$/.test( urlOrigin ) ||
 		/^https:\/\/([a-z0-9-]+\.)+wordpress\.com$/.test( urlOrigin )
 	);
 }

--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -552,7 +552,9 @@ const wpcomAllowedOrigins = [
 	'https://jetpack.com',
 	'https://agencies.automattic.com',
 	'https://my.wordpress.com',
-	'https://my.woo.ai',
+	'https://woocommerce.com',
+	'https://my.woocommerce.com',
+	'https://woocommercealshakero.jurassic.tube',
 	'http://wpcalypso.wordpress.com', // for running docker on dev instances
 	'http://widgets.wp.com',
 	'https://widgets.wp.com',


### PR DESCRIPTION
## Proposed Changes

* Update the `wpcom-proxy-request` allowed origins for WooCommerce surfaces.
* Replace the old `https://my.woo.ai` origin with `https://woocommerce.com`, `https://my.woocommerce.com`, and `https://woocommercealshakero.jurassic.tube`.

## Why are these changes being made?

* WooCommerce-hosted surfaces need to be accepted as valid origins for proxied WordPress.com requests.

## Testing Instructions

* `yarn eslint packages/wpcom-proxy-request/src/index.js`
* `git diff --check origin/trunk...HEAD`
* For manual verification, load a WooCommerce-origin surface that uses proxied WordPress.com requests and confirm the proxy accepts the origin.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
