### PR TITLE
Revert "Blocks: ETK: search inserter for Blog Posts block"

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/blog-posts.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/blog-posts.ts
@@ -8,7 +8,6 @@ const blockParentSelector = '[aria-label="Block: Blog Posts"]';
 export class BlogPostsBlockFlow implements BlockFlow {
 	blockSidebarName = 'Blog Posts';
 	blockEditorSelector = blockParentSelector;
-	noSearch = false;
 
 	// We are very limited in what we can safely smoke test with the Blog Posts block because it is dependent on other posts.
 	// There's no guarantee (due to data clean up operations) that there will even be other posts!


### PR DESCRIPTION
Reverts Automattic/wp-calypso#112915.
The fix was a site setup issue, see p1784787024274149-slack-CRWCHQGUB