### PR TITLE
Don't lose the Calypso Live link domain when clicked by pointing to /home

### DIFF
--- a/.github/workflows/calypso-live.yml
+++ b/.github/workflows/calypso-live.yml
@@ -50,69 +50,57 @@ jobs:
             const link = `https://calypso.live?${{steps.build_link.outputs.QUERY}}`;
             const homeLink = `https://calypso.live/home?${{steps.build_link.outputs.QUERY}}`;
 
-            const body = trimIndent(`
-              <!--calypso-live-watermark:apr@v1-->
+            const groups = [
+              {
+                label: 'WordPress.com',
+                environments: [
+                  { label: 'Dashboard Live', url: `${link}&env=dashboard` },
+                  { label: 'Calypso Live (/home)', url: homeLink },
+                ],
+              },
+              {
+                label: 'Automattic for Agencies',
+                environments: [
+                  { label: 'Dashboard Live', url: `${link}&env=dashboard-a4a` },
+                  { label: 'Automattic for Agencies Live', url: `${link}&env=a8c-for-agencies` },
+                ],
+              },
+              {
+                label: 'Jetpack Cloud',
+                environments: [
+                  { label: 'Jetpack Cloud Live', url: `${link}&env=jetpack` },
+                ],
+              },
+            ];
+
+            const renderEnv = ( env ) => trimIndent(`
               <details>
-                <summary>
-                  Calypso Live (/home) <a href="${homeLink}">(direct link)</a>
-                </summary>
+                <summary>${env.label} <a href="${env.url}">(direct link)</a></summary>
                 <table>
                   <tr>
                     <td>
-                      <a href="${homeLink}">${homeLink}</a>
-                    </td>
-                  </tr>
-                </table>
-              </details>
-              <details>
-                <summary>
-                  Dashboard Live (dotcom) <a href="${link}&env=dashboard">(direct link)</a>
-                </summary>
-                <table>
-                  <tr>
-                    <td>
-                      <a href="${link}&env=dashboard">${link}&env=dashboard</a>
-                    </td>
-                  </tr>
-                </table>
-              </details>
-              <details>
-                <summary>
-                  Dashboard Live (A4A) <a href="${link}&env=dashboard-a4a">(direct link)</a>
-                </summary>
-                <table>
-                  <tr>
-                    <td>
-                      <a href="${link}&env=dashboard-a4a">${link}&env=dashboard-a4a</a>
-                    </td>
-                  </tr>
-                </table>
-              </details>
-              <details>
-                <summary>
-                  Jetpack Cloud Live <a href="${link}&env=jetpack">(direct link)</a>
-                </summary>
-                <table>
-                  <tr>
-                    <td>
-                      <a href="${link}&env=jetpack">${link}&env=jetpack</a>
-                    </td>
-                  </tr>
-                </table>
-              </details>
-              <details>
-                <summary>
-                  Automattic for Agencies Live <a href="${link}&env=a8c-for-agencies">(direct link)</a>
-                </summary>
-                <table>
-                  <tr>
-                    <td>
-                      <a href="${link}&env=a8c-for-agencies">${link}&env=a8c-for-agencies</a>
+                      <a href="${env.url}">${env.url}</a>
                     </td>
                   </tr>
                 </table>
               </details>`
             );
+
+            // A group holding a single environment renders as a bare item, without a heading.
+            const renderGroup = ( group ) =>
+              group.environments.length === 1
+                ? renderEnv( group.environments[ 0 ] )
+                : [
+                    `<p>${ group.label }</p>`,
+                    '<ul>',
+                    ...group.environments.map( env => `<li>\n${ renderEnv( env ) }\n</li>` ),
+                    '</ul>',
+                  ].join( '\n' );
+
+            const body = [
+              '<!--calypso-live-watermark:apr@v1-->',
+              groups.map( renderGroup ).join( '\n<hr>\n' ),
+            ].join( '\n' );
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/calypso-live.yml
+++ b/.github/workflows/calypso-live.yml
@@ -48,41 +48,18 @@ jobs:
             }
 
             const link = `https://calypso.live?${{steps.build_link.outputs.QUERY}}`;
+            const homeLink = `https://calypso.live/home?${{steps.build_link.outputs.QUERY}}`;
 
             const body = trimIndent(`
               <!--calypso-live-watermark:apr@v1-->
               <details>
                 <summary>
-                  Calypso Live <a href="${link}">(direct link)</a>
+                  Calypso Live (/home) <a href="${homeLink}">(direct link)</a>
                 </summary>
                 <table>
                   <tr>
                     <td>
-                      <a href="${link}">${link}</a>
-                    </td>
-                  </tr>
-                </table>
-              </details>
-              <details>
-                <summary>
-                  Jetpack Cloud Live <a href="${link}&env=jetpack">(direct link)</a>
-                </summary>
-                <table>
-                  <tr>
-                    <td>
-                      <a href="${link}&env=jetpack">${link}&env=jetpack</a>
-                    </td>
-                  </tr>
-                </table>
-              </details>
-              <details>
-                <summary>
-                  Automattic for Agencies Live <a href="${link}&env=a8c-for-agencies">(direct link)</a>
-                </summary>
-                <table>
-                  <tr>
-                    <td>
-                      <a href="${link}&env=a8c-for-agencies">${link}&env=a8c-for-agencies</a>
+                      <a href="${homeLink}">${homeLink}</a>
                     </td>
                   </tr>
                 </table>
@@ -107,6 +84,30 @@ jobs:
                   <tr>
                     <td>
                       <a href="${link}&env=dashboard-a4a">${link}&env=dashboard-a4a</a>
+                    </td>
+                  </tr>
+                </table>
+              </details>
+              <details>
+                <summary>
+                  Jetpack Cloud Live <a href="${link}&env=jetpack">(direct link)</a>
+                </summary>
+                <table>
+                  <tr>
+                    <td>
+                      <a href="${link}&env=jetpack">${link}&env=jetpack</a>
+                    </td>
+                  </tr>
+                </table>
+              </details>
+              <details>
+                <summary>
+                  Automattic for Agencies Live <a href="${link}&env=a8c-for-agencies">(direct link)</a>
+                </summary>
+                <table>
+                  <tr>
+                    <td>
+                      <a href="${link}&env=a8c-for-agencies">${link}&env=a8c-for-agencies</a>
                     </td>
                   </tr>
                 </table>

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -45,54 +45,92 @@ object BuildDockerImage : BuildType({
         val qrEnv: String,    // e.g. "flags=oauth" or "env=jetpack&flags=oauth"
     )
 
+    data class EnvGroup(
+        val label: String,
+        val environments: List<EnvConfig>,
+    )
+
     val imageBase = "registry.a8c.com/calypso/app"
 	val commitImageExistsParam = "dockerImage.commitImageExists"
 
-    val environments = listOf(
-        EnvConfig(
-            label = "Calypso Live (/home)",
-            baseUrl = "https://calypso.live/home",
-            envQuery = "",
-            qrEnv = "flags=oauth",
+    val environmentGroups = listOf(
+        EnvGroup(
+            label = "WordPress.com",
+            environments = listOf(
+                EnvConfig(
+                    label = "Dashboard Live",
+                    envQuery = "&env=dashboard",
+                    qrEnv = "env=dashboard&flags=oauth",
+                ),
+                EnvConfig(
+                    label = "Calypso Live (/home)",
+                    baseUrl = "https://calypso.live/home",
+                    envQuery = "",
+                    qrEnv = "flags=oauth",
+                ),
+            ),
         ),
-		EnvConfig(
-			label = "Dashboard Live (dotcom)",
-			envQuery = "&env=dashboard",
-			qrEnv = "env=dashboard&flags=oauth",
-		),
-		EnvConfig(
-			label = "Dashboard Live (A4A)",
-			envQuery = "&env=dashboard-a4a",
-			qrEnv = "env=dashboard-a4a&flags=oauth",
-		),
-		EnvConfig(
-            label = "Jetpack Cloud Live",
-            envQuery = "&env=jetpack",
-            qrEnv = "env=jetpack&flags=oauth",
-		),
-        EnvConfig(
-			label = "Automattic for Agencies Live",
-			envQuery = "&env=a8c-for-agencies",
-			qrEnv = "env=a8c-for-agencies&flags=oauth",
-		)
+        EnvGroup(
+            label = "Automattic for Agencies",
+            environments = listOf(
+                EnvConfig(
+                    label = "Dashboard Live",
+                    envQuery = "&env=dashboard-a4a",
+                    qrEnv = "env=dashboard-a4a&flags=oauth",
+                ),
+                EnvConfig(
+                    label = "Automattic for Agencies Live",
+                    envQuery = "&env=a8c-for-agencies",
+                    qrEnv = "env=a8c-for-agencies&flags=oauth",
+                ),
+            ),
+        ),
+        EnvGroup(
+            label = "Jetpack Cloud",
+            environments = listOf(
+                EnvConfig(
+                    label = "Jetpack Cloud Live",
+                    envQuery = "&env=jetpack",
+                    qrEnv = "env=jetpack&flags=oauth",
+                ),
+            ),
+        )
     )
 
+    fun renderEnv(env: EnvConfig): String {
+        val url = "${env.baseUrl}?image=$imageBase:build-%build.number%${env.envQuery}"
+        return """
+            <details>
+              <summary>${env.label} <a href="$url">(direct link)</a></summary>
+              <table>
+                <tr>
+                  <td>
+                    <a href="$url">$url</a>
+                  </td>
+                </tr>
+              </table>
+            </details>
+            """.trimIndent()
+    }
+
     val htmlBlock = buildString {
-        environments.forEach { env ->
-            appendLine(
-                """
-                <details>
-                  <summary>${env.label} <a href="${env.baseUrl}?image=$imageBase:build-%build.number%${env.envQuery}">(direct link)</a></summary>
-                  <table>
-                    <tr>
-                      <td>
-                        <a href="${env.baseUrl}?image=$imageBase:build-%build.number%${env.envQuery}">${env.baseUrl}?image=$imageBase:build-%build.number%${env.envQuery}</a>
-                      </td>
-                    </tr>
-                  </table>
-                </details>
-                """.trimIndent()
-            )
+        environmentGroups.forEachIndexed { index, group ->
+            if (index > 0) {
+                appendLine("<hr>")
+            }
+            // A group holding a single environment renders as a bare item, without a heading.
+            if (group.environments.size == 1) {
+                appendLine(renderEnv(group.environments.single()))
+            } else {
+                appendLine("<p>${group.label}</p>")
+                appendLine("<ul>")
+                group.environments.forEach { env ->
+                    appendLine("<li>")
+                    appendLine(renderEnv(env))
+                    appendLine("</li>")
+                }
+                appendLine("</ul>")
+            }
             appendLine()
         }
     }

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -40,29 +40,20 @@ object BuildDockerImage : BuildType({
 
     data class EnvConfig(
         val label: String,
+        val baseUrl: String = "https://calypso.live",
         val envQuery: String, // e.g. "" or "&env=jetpack"
         val qrEnv: String,    // e.g. "flags=oauth" or "env=jetpack&flags=oauth"
     )
 
     val imageBase = "registry.a8c.com/calypso/app"
 	val commitImageExistsParam = "dockerImage.commitImageExists"
-	val baseUrl = "https://calypso.live"
 
     val environments = listOf(
         EnvConfig(
-            label = "Calypso Live",
+            label = "Calypso Live (/home)",
+            baseUrl = "https://calypso.live/home",
             envQuery = "",
             qrEnv = "flags=oauth",
-        ),
-        EnvConfig(
-            label = "Jetpack Cloud Live",
-            envQuery = "&env=jetpack",
-            qrEnv = "env=jetpack&flags=oauth",
-        ),
-        EnvConfig(
-            label = "Automattic for Agencies Live",
-            envQuery = "&env=a8c-for-agencies",
-            qrEnv = "env=a8c-for-agencies&flags=oauth",
         ),
 		EnvConfig(
 			label = "Dashboard Live (dotcom)",
@@ -73,6 +64,16 @@ object BuildDockerImage : BuildType({
 			label = "Dashboard Live (A4A)",
 			envQuery = "&env=dashboard-a4a",
 			qrEnv = "env=dashboard-a4a&flags=oauth",
+		),
+		EnvConfig(
+            label = "Jetpack Cloud Live",
+            envQuery = "&env=jetpack",
+            qrEnv = "env=jetpack&flags=oauth",
+		),
+        EnvConfig(
+			label = "Automattic for Agencies Live",
+			envQuery = "&env=a8c-for-agencies",
+			qrEnv = "env=a8c-for-agencies&flags=oauth",
 		)
     )
 
@@ -81,11 +82,11 @@ object BuildDockerImage : BuildType({
             appendLine(
                 """
                 <details>
-                  <summary>${env.label} <a href="${baseUrl}?image=$imageBase:build-%build.number%${env.envQuery}">(direct link)</a></summary>
+                  <summary>${env.label} <a href="${env.baseUrl}?image=$imageBase:build-%build.number%${env.envQuery}">(direct link)</a></summary>
                   <table>
                     <tr>
                       <td>
-                        <a href="${baseUrl}?image=$imageBase:build-%build.number%${env.envQuery}">${baseUrl}?image=$imageBase:build-%build.number%${env.envQuery}</a>
+                        <a href="${env.baseUrl}?image=$imageBase:build-%build.number%${env.envQuery}">${env.baseUrl}?image=$imageBase:build-%build.number%${env.envQuery}</a>
                       </td>
                     </tr>
                   </table>

--- a/client/root.js
+++ b/client/root.js
@@ -90,12 +90,7 @@ const waitForPrefs = () => async ( dispatch, getState ) => {
 };
 
 const getSitesLink = ( isDashboardOptIn ) => {
-	// In development environments, don't redirect to the Dashboard subdomain as it might not be the intent.
-	// For instance, developers might use the Calypso Live link to test something not in the Dashboard,
-	// but they get redirected to the Dashboard subdomain, and lose the Calypso Live domain in the process.
-	// As a temporary workaround, we send them to the v1 /sites instead.
-	// TODO: The workaround will need to change once we deprecate v1 /sites.
-	if ( isDashboardOptIn && ! [ 'development', 'wpcalypso' ].includes( config( 'env_id' ) ) ) {
+	if ( isDashboardOptIn ) {
 		bumpStat( 'dashboard-redirect', 'landing-page' );
 		return dashboardLink( '/sites' );
 	}
@@ -137,12 +132,6 @@ async function getLoggedInLandingPage( { dispatch, getState } ) {
 
 	if ( isCustomerHomeEnabled ) {
 		if ( isAdminInterfaceWPAdmin( getState(), primarySiteId ) ) {
-			if ( [ 'development', 'wpcalypso' ].includes( config( 'env_id' ) ) ) {
-				// On Calypso Live and dev environments, don't redirect to wp-admin
-				// as it navigates the user away from the testing environment.
-				return getSitesLink( dashboardOptIn );
-			}
-			// This URL starts with 'https://' because it's the access to wp-admin.
 			return getSiteAdminUrl( getState(), primarySiteId );
 		}
 		return `/home/${ primarySiteSlug }`;


### PR DESCRIPTION
Fixes p1784023308542989/1782189543.361639-slack-C097SQTJV9S

## Proposed Changes

Currently Calypso Live links are problematic for Automatticians: if the default landing page is set to site list, it will try to go to `/sites` (relative link), but MSD is forced-rollout, so it will redirect to `my.wordpress.com`, which will lose the original Calypso Live domain. It will make it hard to test Calypso (non-dashboard) screens.

This PR makes it so that we never lose the Calypso Live domain:

- ~~If the default landing page is set to site list, redirect to `/home/<primary site>` (instead of MSD /sites).~~
- ~~If the default landing page is set to primary site, but its admin interface is set to Classic, still redirect to `/home/<primary site>`(instead of the primary site's wp-admin).~~

by making the Calypso Live links in the bot comments to point to `/home` by default, opening the old site selector.

## Testing Instructions

Open the Calypso Live URLs from the bot comments; verify it opens the `/home` home selector.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?