### PR TITLE
Titan tiers: rename plan display names to Essential/Plus/Ultra

### DIFF
--- a/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
+++ b/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
@@ -27,9 +27,9 @@ interface TitanPlan {
 const getTierName = ( tier: TitanPlanTier ): string => {
 	switch ( tier ) {
 		case TitanPlanTier.Pro:
-			return __( 'Pro' );
+			return __( 'Essential' );
 		case TitanPlanTier.Premium:
-			return __( 'Premium' );
+			return __( 'Plus' );
 		case TitanPlanTier.Ultra:
 			return __( 'Ultra' );
 	}


### PR DESCRIPTION
## Proposed Changes

* Rename the user-facing Titan (Professional Email) tier names shown in the Dashboard email plan grid:
  * Pro -> **Essential**
  * Premium -> **Plus**
  * Ultra -> **Ultra**

This is a string-only change in `getTierName` (`client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx`). The names flow through the plan card heading, the "Get %s" button label, and the "Everything in %s" line. The page header already reads "Professional Email plans", so the card titles show only the tier name.

The internal `TitanPlanTier` enum identifiers (`pro`/`premium`/`ultra`), the `?tier=` URL params, the `TITAN_TIER_SLUGS` mapping, and the backend product slug constants (`wp_titan_mail_premium_*`, `wp_titan_mail_ultra_*`) are intentionally left unchanged, since they mirror the backend contract.

## Why are these changes being made?

* Marketing/product decision to present the tiers as Essential / Plus / Ultra. The internal identifiers stay aligned with the backend, so only the display strings change.

## Testing Instructions

* Enable the `emails/titan-tiers` feature flag.
* In the Dashboard, go through the email purchase flow to reach the Titan plan grid (`/emails/choose-email-solution/:domain`).
* Confirm the three plan cards read **Essential**, **Plus**, and **Ultra**, and that the "Get ..." button and "Everything in ..." lines use the new names.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?