### PR TITLE
A4A feedback (MSD): port the milestone rate-experience survey

### DIFF
--- a/client/dashboard/agency/feedback/config.ts
+++ b/client/dashboard/agency/feedback/config.ts
@@ -1,0 +1,42 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { FeedbackType, type FeedbackConfig } from './types';
+
+export const FEEDBACK_CONFIG: Record< FeedbackType, FeedbackConfig > = {
+	[ FeedbackType.MemberInviteSent ]: {
+		title: __( 'Invite emailed!' ),
+		getDescription: ( { email } ) =>
+			sprintf(
+				/* translators: %s: the invited team member's email or username */
+				__(
+					"We sent %s an invite. After accepting, they'll become an active member in your Team section."
+				),
+				email ?? ''
+			),
+		defaultReturnTo: '/team',
+		suggestion: {
+			label: __( 'What could have been better during the team invitation process?' ),
+			options: [
+				{
+					label: __( 'Finding where to invite my team members' ),
+					value: 'finding-where-to-invite-my-team-members',
+				},
+				{
+					label: __( 'Sending an invitation to a team member' ),
+					value: 'sending-an-invitation-to-a-team-member',
+				},
+				{
+					label: __( 'Finding documentation on team member permissions' ),
+					value: 'finding-documentation-on-team-member-permissions',
+				},
+				{
+					label: __( 'Other' ),
+					value: 'other',
+				},
+			],
+		},
+	},
+};
+
+export function getFeedbackConfig( type: string ): FeedbackConfig | undefined {
+	return FEEDBACK_CONFIG[ type as FeedbackType ];
+}

--- a/client/dashboard/agency/feedback/feedback-survey.tsx
+++ b/client/dashboard/agency/feedback/feedback-survey.tsx
@@ -1,0 +1,97 @@
+import {
+	Button,
+	CheckboxControl,
+	TextareaControl,
+	__experimentalVStack as VStack,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import type { FeedbackConfig, FeedbackResponses } from './types';
+
+interface FeedbackSurveyProps {
+	config: FeedbackConfig;
+	description: string;
+	isSubmitting: boolean;
+	onSubmit: ( responses: FeedbackResponses ) => void;
+	onSkip: () => void;
+}
+
+export default function FeedbackSurvey( {
+	config,
+	description,
+	isSubmitting,
+	onSubmit,
+	onSkip,
+}: FeedbackSurveyProps ) {
+	const [ experience, setExperience ] = useState( 'good' );
+	const [ comment, setComment ] = useState( '' );
+	const [ suggestions, setSuggestions ] = useState< string[] >( [] );
+
+	const toggleSuggestion = ( value: string ) =>
+		setSuggestions( ( prev ) =>
+			prev.includes( value ) ? prev.filter( ( v ) => v !== value ) : [ ...prev, value ]
+		);
+
+	return (
+		<VStack spacing={ 6 } className="a4a-feedback-survey">
+			<p>{ description }</p>
+
+			<ToggleGroupControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ __( 'What was your experience like?' ) }
+				value={ experience }
+				onChange={ ( value ) => setExperience( String( value ) ) }
+				isBlock
+			>
+				<ToggleGroupControlOption value="good" label={ __( 'Good' ) } />
+				<ToggleGroupControlOption value="neutral" label={ __( 'Neutral' ) } />
+				<ToggleGroupControlOption value="bad" label={ __( 'Bad' ) } />
+			</ToggleGroupControl>
+
+			{ config.suggestion && (
+				<VStack spacing={ 2 }>
+					<span>{ config.suggestion.label }</span>
+					{ config.suggestion.options.map( ( option ) => (
+						<CheckboxControl
+							__nextHasNoMarginBottom
+							key={ option.value }
+							label={ option.label }
+							checked={ suggestions.includes( option.value ) }
+							onChange={ () => toggleSuggestion( option.value ) }
+						/>
+					) ) }
+				</VStack>
+			) }
+
+			<TextareaControl
+				__nextHasNoMarginBottom
+				label={ __( 'Share your suggestions' ) }
+				value={ comment }
+				onChange={ setComment }
+			/>
+
+			<VStack spacing={ 3 }>
+				<Button
+					variant="primary"
+					__next40pxDefaultSize
+					isBusy={ isSubmitting }
+					disabled={ ! experience || isSubmitting }
+					onClick={ () => onSubmit( { experience, comment, suggestions } ) }
+				>
+					{ __( 'Send your feedback' ) }
+				</Button>
+				<Button
+					variant="tertiary"
+					__next40pxDefaultSize
+					disabled={ isSubmitting }
+					onClick={ onSkip }
+				>
+					{ __( 'Skip' ) }
+				</Button>
+			</VStack>
+		</VStack>
+	);
+}

--- a/client/dashboard/agency/feedback/index.tsx
+++ b/client/dashboard/agency/feedback/index.tsx
@@ -1,0 +1,46 @@
+import { useNavigate } from '@tanstack/react-router';
+import { useEffect } from 'react';
+import { feedbackRoute } from '../../app/router/agency';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { getFeedbackConfig } from './config';
+import FeedbackSurvey from './feedback-survey';
+import useShowFeedback from './use-show-feedback';
+import type { FeedbackType } from './types';
+
+export default function EarnFeedback() {
+	const { type, returnTo, email } = feedbackRoute.useSearch();
+	const navigate = useNavigate();
+	const config = getFeedbackConfig( type ?? '' );
+	const fallback = returnTo || '/overview';
+
+	const feedback = useShowFeedback( ( type ?? '' ) as FeedbackType );
+
+	// Unknown/missing type, or the survey was already answered: leave.
+	useEffect( () => {
+		if ( ! config || feedback.isFeedbackShown ) {
+			navigate( { to: fallback } );
+		}
+	}, [ config, feedback.isFeedbackShown, fallback, navigate ] );
+
+	if ( ! config ) {
+		return null;
+	}
+
+	const goBack = () => navigate( { to: fallback } );
+
+	return (
+		<PageLayout header={ <PageHeader title={ config.title } /> }>
+			<FeedbackSurvey
+				config={ config }
+				description={ config.getDescription( { email } ) }
+				isSubmitting={ feedback.isSubmitting }
+				onSubmit={ ( responses ) => feedback.submit( responses, goBack ) }
+				onSkip={ () => {
+					feedback.skip();
+					goBack();
+				} }
+			/>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/agency/feedback/test/config.test.ts
+++ b/client/dashboard/agency/feedback/test/config.test.ts
@@ -1,0 +1,17 @@
+import { getFeedbackConfig } from '../config';
+import { FeedbackType } from '../types';
+
+describe( 'getFeedbackConfig', () => {
+	it( 'returns the MemberInviteSent config with an interpolated email', () => {
+		const config = getFeedbackConfig( FeedbackType.MemberInviteSent );
+		expect( config ).toBeDefined();
+		expect( config!.title ).toBe( 'Invite emailed!' );
+		expect( config!.getDescription( { email: 'a@b.com' } ) ).toContain( 'a@b.com' );
+		expect( config!.suggestion?.options ).toHaveLength( 4 );
+		expect( config!.defaultReturnTo ).toBe( '/team' );
+	} );
+
+	it( 'returns undefined for an unknown type', () => {
+		expect( getFeedbackConfig( 'nope' ) ).toBeUndefined();
+	} );
+} );

--- a/client/dashboard/agency/feedback/test/feedback-survey.test.tsx
+++ b/client/dashboard/agency/feedback/test/feedback-survey.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options { "url": "https://my.localhost/" }
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../test-utils';
+import FeedbackSurvey from '../feedback-survey';
+import type { FeedbackConfig } from '../types';
+
+const config: FeedbackConfig = {
+	title: 'Invite emailed!',
+	getDescription: () => 'desc',
+	defaultReturnTo: '/team',
+	suggestion: {
+		label: 'What could have been better?',
+		options: [ { label: 'Finding it', value: 'finding' } ],
+	},
+};
+
+it( 'submits the assembled responses', async () => {
+	const onSubmit = jest.fn();
+	render(
+		<FeedbackSurvey
+			config={ config }
+			description="desc"
+			isSubmitting={ false }
+			onSubmit={ onSubmit }
+			onSkip={ jest.fn() }
+		/>
+	);
+
+	await userEvent.click( screen.getByRole( 'checkbox', { name: 'Finding it' } ) );
+	await userEvent.type( screen.getByRole( 'textbox' ), 'great' );
+	await userEvent.click( screen.getByRole( 'button', { name: 'Send your feedback' } ) );
+
+	expect( onSubmit ).toHaveBeenCalledWith( {
+		experience: 'good',
+		comment: 'great',
+		suggestions: [ 'finding' ],
+	} );
+} );
+
+it( 'skips', async () => {
+	const onSkip = jest.fn();
+	render(
+		<FeedbackSurvey
+			config={ config }
+			description="desc"
+			isSubmitting={ false }
+			onSubmit={ jest.fn() }
+			onSkip={ onSkip }
+		/>
+	);
+	await userEvent.click( screen.getByRole( 'button', { name: 'Skip' } ) );
+	expect( onSkip ).toHaveBeenCalled();
+} );

--- a/client/dashboard/agency/feedback/test/index.test.tsx
+++ b/client/dashboard/agency/feedback/test/index.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import EarnFeedback from '../index';
+
+const mockNavigate = jest.fn();
+
+let mockSearch: { type?: string; returnTo?: string; email?: string } = {};
+
+jest.mock( '@tanstack/react-router', () => ( {
+	...jest.requireActual( '@tanstack/react-router' ),
+	useNavigate: () => mockNavigate,
+} ) );
+
+jest.mock( '../../../app/router/agency', () => ( {
+	...jest.requireActual( '../../../app/router/agency' ),
+	feedbackRoute: {
+		useSearch: () => mockSearch,
+	},
+} ) );
+
+function mockPreferences( feedbackByType: Record< string, unknown > = {} ) {
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.1/me/preferences' )
+		.reply( 200, { calypso_preferences: { 'a4a-feedback': feedbackByType } } );
+}
+
+function mockAgency() {
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/wpcom/v2/agency' )
+		.reply( 200, [ { id: 42 } ] );
+}
+
+describe( '<EarnFeedback>', () => {
+	beforeEach( () => {
+		mockNavigate.mockClear();
+		mockSearch = {};
+	} );
+
+	test( 'renders the survey title for a known, unshown type', async () => {
+		mockSearch = { type: 'team-member-invite-sent', returnTo: '/team', email: 'a@b.com' };
+		mockPreferences();
+		mockAgency();
+
+		render( <EarnFeedback /> );
+
+		await waitFor( () => expect( screen.getByText( 'Invite emailed!' ) ).toBeVisible() );
+	} );
+
+	test( 'redirects to returnTo for an unknown type', async () => {
+		mockSearch = { type: 'not-a-real-type', returnTo: '/team' };
+		mockPreferences();
+		mockAgency();
+
+		render( <EarnFeedback /> );
+
+		await waitFor( () => expect( mockNavigate ).toHaveBeenCalledWith( { to: '/team' } ) );
+		expect( screen.queryByText( 'Invite emailed!' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'redirects to /overview when returnTo is missing and type is missing', async () => {
+		mockSearch = {};
+		mockPreferences();
+		mockAgency();
+
+		render( <EarnFeedback /> );
+
+		await waitFor( () => expect( mockNavigate ).toHaveBeenCalledWith( { to: '/overview' } ) );
+		expect( screen.queryByText( 'Invite emailed!' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'redirects to returnTo when the survey was already shown', async () => {
+		mockSearch = { type: 'team-member-invite-sent', returnTo: '/team' };
+		mockPreferences( { 'team-member-invite-sent': { lastSubmittedAt: 123 } } );
+		mockAgency();
+
+		render( <EarnFeedback /> );
+
+		// The known config still renders while the preferences query loads (there's
+		// no synchronous way to know it was already shown), but once it resolves the
+		// effect fires and navigates away.
+		await waitFor( () => expect( mockNavigate ).toHaveBeenCalledWith( { to: '/team' } ) );
+	} );
+} );

--- a/client/dashboard/agency/feedback/test/use-show-feedback.test.tsx
+++ b/client/dashboard/agency/feedback/test/use-show-feedback.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { AnalyticsProvider } from '../../../app/analytics';
+import { FeedbackType } from '../types';
+import useShowFeedback from '../use-show-feedback';
+
+function createWrapper() {
+	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	const Wrapper = function Wrapper( { children }: { children: React.ReactNode } ) {
+		return (
+			<QueryClientProvider client={ queryClient }>
+				<AnalyticsProvider client={ { recordTracksEvent: jest.fn(), recordPageView: jest.fn() } }>
+					{ children }
+				</AnalyticsProvider>
+			</QueryClientProvider>
+		);
+	};
+	return { Wrapper, queryClient };
+}
+
+describe( 'useShowFeedback', () => {
+	test( 'reports not-shown when the type has no timestamps', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/preferences' )
+			.reply( 200, { calypso_preferences: {} } );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/agency' )
+			.reply( 200, [ { id: 42, name: 'A', url: 'x' } ] );
+
+		const { result } = renderHook( () => useShowFeedback( FeedbackType.MemberInviteSent ), {
+			wrapper: createWrapper().Wrapper,
+		} );
+
+		await waitFor( () => expect( result.current.isFeedbackShown ).toBe( false ) );
+	} );
+
+	test( 'reports shown when lastSkippedAt is set for the type', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/preferences' )
+			.reply( 200, {
+				calypso_preferences: {
+					'a4a-feedback': { 'team-member-invite-sent': { lastSkippedAt: 123 } },
+				},
+			} );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/agency' )
+			.reply( 200, [ { id: 42, name: 'A', url: 'x' } ] );
+
+		const { result } = renderHook( () => useShowFeedback( FeedbackType.MemberInviteSent ), {
+			wrapper: createWrapper().Wrapper,
+		} );
+
+		await waitFor( () => expect( result.current.isFeedbackShown ).toBe( true ) );
+	} );
+
+	test( 'reports shown when lastSubmittedAt is set for the type', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/preferences' )
+			.reply( 200, {
+				calypso_preferences: {
+					'a4a-feedback': { 'team-member-invite-sent': { lastSubmittedAt: 456 } },
+				},
+			} );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/agency' )
+			.reply( 200, [ { id: 42, name: 'A', url: 'x' } ] );
+
+		const { result } = renderHook( () => useShowFeedback( FeedbackType.MemberInviteSent ), {
+			wrapper: createWrapper().Wrapper,
+		} );
+
+		await waitFor( () => expect( result.current.isFeedbackShown ).toBe( true ) );
+	} );
+
+	test( 'submit posts the correct survey payload', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/preferences' )
+			.reply( 200, { calypso_preferences: {} } );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/agency' )
+			.reply( 200, [ { id: 42, name: 'A', url: 'x' } ] );
+
+		let capturedSurveyBody: Record< string, unknown > | undefined;
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/rest/v1.1/marketing/survey', ( body ) => {
+				capturedSurveyBody = body;
+				return true;
+			} )
+			.reply( 200, {} );
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/me/preferences' ).reply( 200, {
+			calypso_preferences: {},
+		} );
+
+		const { Wrapper, queryClient } = createWrapper();
+		const { result } = renderHook( () => useShowFeedback( FeedbackType.MemberInviteSent ), {
+			wrapper: Wrapper,
+		} );
+
+		await waitFor( () => expect( result.current.isFeedbackShown ).toBe( false ) );
+		await waitFor( () =>
+			expect( queryClient.getQueryData( [ 'agency', 'active' ] ) ).toEqual( {
+				id: 42,
+				name: 'A',
+				url: 'x',
+			} )
+		);
+
+		act( () => {
+			result.current.submit( {
+				experience: 'good',
+				comment: 'nice',
+				suggestions: [ 'finding-where-to-invite-my-team-members' ],
+			} );
+		} );
+
+		await waitFor( () => expect( capturedSurveyBody ).toBeDefined() );
+
+		expect( capturedSurveyBody ).toMatchObject( {
+			survey_id: 'a4a-feedback-team-member-invite-sent',
+			site_id: 42,
+			survey_responses: {
+				rating: 'good',
+				comment: { text: 'nice' },
+				suggestions: { text: 'finding-where-to-invite-my-team-members' },
+			},
+		} );
+	} );
+
+	test( 'submit preserves other feedback types when writing the dismissal preference', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/preferences' )
+			.reply( 200, {
+				calypso_preferences: {
+					'a4a-feedback': { 'some-other-type': { lastSubmittedAt: 111 } },
+				},
+			} );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/agency' )
+			.reply( 200, [ { id: 42, name: 'A', url: 'x' } ] );
+
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/rest/v1.1/marketing/survey' )
+			.reply( 200, {} );
+
+		let capturedPreferenceBody: Record< string, unknown > | undefined;
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/rest/v1.1/me/preferences', ( body ) => {
+				capturedPreferenceBody = body;
+				return true;
+			} )
+			.reply( 200, { calypso_preferences: {} } );
+
+		const { Wrapper, queryClient } = createWrapper();
+		const { result } = renderHook( () => useShowFeedback( FeedbackType.MemberInviteSent ), {
+			wrapper: Wrapper,
+		} );
+
+		await waitFor( () => expect( result.current.isFeedbackShown ).toBe( false ) );
+		await waitFor( () =>
+			expect( queryClient.getQueryData( [ 'agency', 'active' ] ) ).toEqual( {
+				id: 42,
+				name: 'A',
+				url: 'x',
+			} )
+		);
+
+		act( () => {
+			result.current.submit( {
+				experience: 'good',
+				comment: 'nice',
+				suggestions: [ 'finding-where-to-invite-my-team-members' ],
+			} );
+		} );
+
+		await waitFor( () => expect( capturedPreferenceBody ).toBeDefined() );
+
+		const calypsoPreferences = capturedPreferenceBody?.calypso_preferences as Record<
+			string,
+			unknown
+		>;
+		const feedbackPreferences = calypsoPreferences[ 'a4a-feedback' ] as Record<
+			string,
+			{ lastSubmittedAt?: number }
+		>;
+
+		expect( feedbackPreferences[ 'some-other-type' ] ).toEqual( { lastSubmittedAt: 111 } );
+		expect( feedbackPreferences[ 'team-member-invite-sent' ]?.lastSubmittedAt ).toEqual(
+			expect.any( Number )
+		);
+	} );
+} );

--- a/client/dashboard/agency/feedback/types.ts
+++ b/client/dashboard/agency/feedback/types.ts
@@ -1,0 +1,24 @@
+export enum FeedbackType {
+	MemberInviteSent = 'team-member-invite-sent',
+}
+
+export type FeedbackSuggestionOption = {
+	label: string;
+	value: string;
+};
+
+export type FeedbackResponses = {
+	experience: string;
+	comment: string;
+	suggestions: string[];
+};
+
+export interface FeedbackConfig {
+	title: string;
+	getDescription: ( args: Record< string, string | undefined > ) => string;
+	defaultReturnTo: string;
+	suggestion?: {
+		label: string;
+		options: FeedbackSuggestionOption[];
+	};
+}

--- a/client/dashboard/agency/feedback/use-show-feedback.ts
+++ b/client/dashboard/agency/feedback/use-show-feedback.ts
@@ -1,0 +1,95 @@
+import {
+	activeAgencyQuery,
+	marketingSurveyMutation,
+	rawUserPreferencesQuery,
+	userPreferenceMutation,
+} from '@automattic/api-queries';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+import { useCallback, useMemo } from 'react';
+import { useAnalytics } from '../../app/analytics';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
+import type { FeedbackResponses, FeedbackType } from './types';
+import type { A4AFeedbackPreferenceEntry } from '@automattic/api-core';
+
+const FEEDBACK_PREFERENCE = 'a4a-feedback';
+
+export default function useShowFeedback( type: FeedbackType ) {
+	const { recordTracksEvent } = useAnalytics();
+	const { data: agency } = useQuery( activeAgencyQuery() );
+	const { data: preferences } = useQuery( rawUserPreferencesQuery() );
+
+	const feedbackByType = useMemo(
+		() =>
+			( preferences?.[ FEEDBACK_PREFERENCE ] ?? {} ) as Record<
+				string,
+				A4AFeedbackPreferenceEntry
+			>,
+		[ preferences ]
+	);
+	const entry = feedbackByType[ type ];
+	const isFeedbackShown = !! ( entry?.lastSubmittedAt || entry?.lastSkippedAt );
+
+	const { mutate: mutateSurvey, isPending: isSubmitting } = useMutation(
+		withSnackbar( marketingSurveyMutation(), {
+			success: __(
+				'Thanks! Our team will use your feedback to help prioritize improvements to Automattic for Agencies.'
+			),
+			error: __( 'Something went wrong. Please try again later.' ),
+		} )
+	);
+	const { mutate: mutatePreference } = useMutation( userPreferenceMutation( FEEDBACK_PREFERENCE ) );
+
+	const writeTimestamp = useCallback(
+		( key: 'lastSubmittedAt' | 'lastSkippedAt' ) => {
+			const merged: Record< string, A4AFeedbackPreferenceEntry > = {
+				...feedbackByType,
+				[ type ]: { ...feedbackByType[ type ], [ key ]: Date.now() },
+			};
+			mutatePreference( merged );
+		},
+		[ feedbackByType, mutatePreference, type ]
+	);
+
+	const submit = useCallback(
+		( responses: FeedbackResponses, onSuccess?: () => void ) => {
+			const agencyId = agency?.id;
+			if ( ! agencyId ) {
+				return;
+			}
+			const surveyResponses = {
+				rating: responses.experience,
+				comment: { text: responses.comment },
+				suggestions: { text: responses.suggestions.join( ', ' ) },
+			};
+			recordTracksEvent( 'calypso_a4a_feedback_submit', {
+				agency_id: agencyId,
+				survey_id: `${ FEEDBACK_PREFERENCE }-${ type }`,
+				rating: responses.experience,
+				suggestions: surveyResponses.suggestions.text,
+				comment: surveyResponses.comment.text,
+			} );
+			mutateSurvey(
+				{
+					site_id: agencyId,
+					survey_id: `${ FEEDBACK_PREFERENCE }-${ type }`,
+					survey_responses: surveyResponses,
+				},
+				{
+					onSuccess: () => {
+						writeTimestamp( 'lastSubmittedAt' );
+						onSuccess?.();
+					},
+				}
+			);
+		},
+		[ agency?.id, recordTracksEvent, mutateSurvey, type, writeTimestamp ]
+	);
+
+	const skip = useCallback( () => {
+		recordTracksEvent( 'calypso_a4a_feedback_skip', { type } );
+		writeTimestamp( 'lastSkippedAt' );
+	}, [ recordTracksEvent, type, writeTimestamp ] );
+
+	return { isFeedbackShown, isSubmitting, submit, skip };
+}

--- a/client/dashboard/agency/team/invite-team-member-modal.tsx
+++ b/client/dashboard/agency/team/invite-team-member-modal.tsx
@@ -1,5 +1,6 @@
 import { agencyTeamInviteMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
 import {
 	Button,
 	Modal,
@@ -12,6 +13,8 @@ import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { ButtonStack } from '../../components/button-stack';
+import { FeedbackType } from '../feedback/types';
+import useShowFeedback from '../feedback/use-show-feedback';
 
 interface InviteTeamMemberModalProps {
 	agencyId: number;
@@ -24,6 +27,8 @@ export default function InviteTeamMemberModal( { agencyId, onClose }: InviteTeam
 	const [ error, setError ] = useState( '' );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const invite = useMutation( agencyTeamInviteMutation( agencyId ) );
+	const navigate = useNavigate();
+	const { isFeedbackShown } = useShowFeedback( FeedbackType.MemberInviteSent );
 
 	const onSubmit = ( event: React.FormEvent ) => {
 		event.preventDefault();
@@ -31,14 +36,25 @@ export default function InviteTeamMemberModal( { agencyId, onClose }: InviteTeam
 			setError( __( 'Please enter a valid email or WordPress.com username.' ) );
 			return;
 		}
+		const submittedLogin = login.trim();
 		invite.mutate(
-			{ login: login.trim(), message: message.trim() },
+			{ login: submittedLogin, message: message.trim() },
 			{
 				onSuccess: () => {
 					createSuccessNotice( __( 'The invitation has been successfully sent.' ), {
 						type: 'snackbar',
 					} );
 					onClose();
+					if ( ! isFeedbackShown ) {
+						navigate( {
+							to: '/feedback',
+							search: {
+								type: FeedbackType.MemberInviteSent,
+								returnTo: '/team',
+								email: submittedLogin,
+							},
+						} );
+					}
 				},
 				onError: () =>
 					createErrorNotice( __( 'Failed to send the invitation.' ), { type: 'snackbar' } ),

--- a/client/dashboard/agency/team/test/invite-team-member-modal.test.tsx
+++ b/client/dashboard/agency/team/test/invite-team-member-modal.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import InviteTeamMemberModal from '../invite-team-member-modal';
+
+const mockNavigate = jest.fn();
+
+jest.mock( '@tanstack/react-router', () => ( {
+	...jest.requireActual( '@tanstack/react-router' ),
+	useNavigate: () => mockNavigate,
+} ) );
+
+function mockAgency() {
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/wpcom/v2/agency' )
+		.reply( 200, [ { id: 42, name: 'A', url: 'x' } ] );
+}
+
+function mockPreferences( feedbackByType: Record< string, unknown > = {} ) {
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.1/me/preferences' )
+		.reply( 200, { calypso_preferences: { 'a4a-feedback': feedbackByType } } );
+}
+
+function mockInvite() {
+	return nock( 'https://public-api.wordpress.com' )
+		.post( '/wpcom/v2/agency/42/user-invites' )
+		.reply( 200, { success: true } );
+}
+
+describe( '<InviteTeamMemberModal>', () => {
+	beforeEach( () => {
+		mockNavigate.mockClear();
+		nock.cleanAll();
+	} );
+
+	test( 'navigates to the feedback survey after a successful invite when not yet shown', async () => {
+		mockAgency();
+		mockPreferences();
+		mockInvite();
+
+		render( <InviteTeamMemberModal agencyId={ 42 } onClose={ jest.fn() } /> );
+
+		await userEvent.type(
+			screen.getByRole( 'textbox', { name: /Email or WordPress\.com username/ } ),
+			'a@b.com'
+		);
+		await userEvent.click( screen.getByRole( 'button', { name: 'Send invite' } ) );
+
+		await waitFor( () =>
+			expect( mockNavigate ).toHaveBeenCalledWith( {
+				to: '/feedback',
+				search: { type: 'team-member-invite-sent', returnTo: '/team', email: 'a@b.com' },
+			} )
+		);
+	} );
+
+	test( 'closes the modal and shows a success notice after a successful invite', async () => {
+		mockAgency();
+		mockPreferences();
+		mockInvite();
+
+		const onClose = jest.fn();
+		render( <InviteTeamMemberModal agencyId={ 42 } onClose={ onClose } /> );
+
+		await userEvent.type(
+			screen.getByRole( 'textbox', { name: /Email or WordPress\.com username/ } ),
+			'a@b.com'
+		);
+		await userEvent.click( screen.getByRole( 'button', { name: 'Send invite' } ) );
+
+		await waitFor( () => expect( onClose ).toHaveBeenCalled() );
+	} );
+
+	test( 'does not navigate to the feedback survey when it has already been shown', async () => {
+		mockAgency();
+		mockPreferences( { 'team-member-invite-sent': { lastSubmittedAt: 123 } } );
+		mockInvite();
+
+		const onClose = jest.fn();
+		render( <InviteTeamMemberModal agencyId={ 42 } onClose={ onClose } /> );
+
+		await userEvent.type(
+			screen.getByRole( 'textbox', { name: /Email or WordPress\.com username/ } ),
+			'a@b.com'
+		);
+		await userEvent.click( screen.getByRole( 'button', { name: 'Send invite' } ) );
+
+		await waitFor( () => expect( onClose ).toHaveBeenCalled() );
+		expect( mockNavigate ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -204,6 +204,22 @@ export const agencyTeamRoute = createRoute( {
 	)
 );
 
+// `/feedback` – shared milestone "rate your experience" survey screen
+export const feedbackRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Share your feedback' ) } ] } ),
+	getParentRoute: () => agencyRoute,
+	path: 'feedback',
+	validateSearch: ( search: Record< string, unknown > ) => ( {
+		type: typeof search.type === 'string' ? search.type : undefined,
+		returnTo: typeof search.returnTo === 'string' ? search.returnTo : undefined,
+		email: typeof search.email === 'string' ? search.email : undefined,
+	} ),
+} ).lazy( () =>
+	import( '../../agency/feedback' ).then( ( d ) =>
+		createLazyRoute( 'agency-feedback' )( { component: d.default } )
+	)
+);
+
 // `/earn` – summary of the agency's earning programs (default Earn screen)
 const earnOverviewRoute = createRoute( {
 	head: () => ( { meta: [ { title: __( 'Overview' ) } ] } ),
@@ -521,6 +537,7 @@ export const createAgencyRoutes = () => [
 		mcpRoute.addChildren( [ mcpOverviewRoute, mcpAvailableToolsRoute, mcpConnectRoute ] ),
 		agencySitesRoute,
 		agencyTeamRoute,
+		feedbackRoute,
 		earnOverviewRoute,
 		earnReferralsRoute,
 		earnWooPaymentsRoute,

--- a/packages/api-core/src/marketing-survey/types.ts
+++ b/packages/api-core/src/marketing-survey/types.ts
@@ -4,9 +4,9 @@ export interface MarketingSurveyResponse {
 }
 
 export interface MarketingSurveyResponses {
-	purchaseId: number;
-	purchase: string;
-	[ key: string ]: string | number | MarketingSurveyResponse;
+	purchaseId?: number;
+	purchase?: string;
+	[ key: string ]: string | number | MarketingSurveyResponse | undefined;
 }
 
 export interface MarketingSurveyDetails {

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -22,6 +22,11 @@ export interface VisitCounter {
 	lastUpdated: number | null; // Result of Date.now(), or null before the first visit
 }
 
+export interface A4AFeedbackPreferenceEntry {
+	lastSubmittedAt?: number;
+	lastSkippedAt?: number;
+}
+
 export interface UserPreferences {
 	recentSites?: number[];
 	'hosting-dashboard-color-scheme'?: 'light' | 'dark' | 'system';
@@ -45,4 +50,5 @@ export interface UserPreferences {
 	'reader-profile-posts-visibility'?: 'public' | 'hidden';
 	'reader-profile-sites-visibility'?: 'public' | 'hidden';
 	'reader-profile-hidden-sites'?: number[];
+	'a4a-feedback'?: Record< string, A4AFeedbackPreferenceEntry >;
 }

--- a/packages/api-queries/src/me-preferences.ts
+++ b/packages/api-queries/src/me-preferences.ts
@@ -24,6 +24,7 @@ const defaultValues: Required< UserPreferences > = {
 	'reader-profile-posts-visibility': 'public',
 	'reader-profile-sites-visibility': 'public',
 	'reader-profile-hidden-sites': [],
+	'a4a-feedback': {},
 };
 
 const staticPreferenceStatIds: Record< string, string > = {
@@ -41,6 +42,7 @@ const staticPreferenceStatIds: Record< string, string > = {
 	'reader-profile-posts-visibility': 'postvis',
 	'reader-profile-sites-visibility': 'sitevis',
 	'reader-profile-hidden-sites': 'hidsit',
+	'a4a-feedback': 'a4afb',
 };
 
 const dynamicPreferenceStatPrefixes: Record< string, string > = {


### PR DESCRIPTION
## Proposed Changes

Ports the A4A "milestone / rate-your-experience" feedback mechanism from the classic A4A app (`client/a8c-for-agencies/`) into the Multi-site Dashboard (MSD, `client/dashboard/`). This builds the reusable core and wires the **team-invite** survey (`MemberInviteSent`) as the first type.

* **Shared `/feedback` route screen** (`client/dashboard/agency/feedback/index.tsx`, registered in `app/router/agency.tsx`) renders a `FeedbackSurvey` (experience picker + suggestion checkboxes + comment), driven by a per-type config registry (`config.ts`). Unknown/missing `type`, or an already-answered survey, redirects to `returnTo` (fallback `/overview`).
* **`useShowFeedback` hook** gates on the shared `a4a-feedback` user preference, submits via the existing `marketingSurveyMutation`, and records the dismissal **only on submit success** (a failed submit shows an error snackbar, stays on the screen, and does not suppress the survey). The preference merge preserves other feedback types' entries.
* **Trigger:** a successful team invite (`invite-team-member-modal.tsx`) navigates to `/feedback?type=…&returnTo=/team&email=…` when the survey hasn't been shown, keeping the existing success snackbar.
* **Cross-surface parity:** reuses the classic identifiers so classic and MSD share dismissal state and land in the same survey dataset — preference key `a4a-feedback`, submitted `survey_id` `a4a-feedback-<type>`, `site_id` = agency id, ratings `good|neutral|bad`, and the same Tracks events (`calypso_a4a_feedback_submit`/`_skip`).
* **api-core:** generalizes the shared `marketing-survey`/`me-preferences` types (`purchaseId`/`purchase` optional; new `a4a-feedback` preference key), backward-compatible with the existing cancel-purchase caller.

The experience picker is built from `@wordpress/components` (`ToggleGroupControl`), not the classic `@automattic/components` `ExperienceControl`.

## Why are these changes being made?

The Dashboard is becoming the source of truth for agency features and cannot import `calypso/*`. This brings the milestone feedback surface to MSD natively (starting with team invite) while preserving data continuity with the classic app. Building the reusable core means each additional milestone type (e.g. referral completed, purchase completed) becomes a small config entry plus a trigger at its call site.

## Testing Instructions

1. Open the A4A dashboard and go to **Team**.
2. Invite a team member. On success, you are redirected to `/feedback` showing the milestone title ("Invite emailed!") with the invited email interpolated.
3. Choose an experience, optionally tick a suggestion + add a comment, and **Send your feedback** → it posts to `/marketing/survey` (`survey_id: a4a-feedback-team-member-invite-sent`, `site_id` = agency id) and returns you to **Team**.
4. Invite another member → the survey does **not** reappear (dismissal persisted per type).
5. Repeat and use **Skip** instead → returns to Team; also not reshown afterwards.

Automated: `yarn test-client client/dashboard/agency/feedback client/dashboard/agency/team` (21 tests). `yarn typecheck-client` and `yarn typecheck-packages` are clean.

### Note for reviewers

MSD's reused `submitMarketingSurvey` posts to `rest/v1.1/marketing/survey`, whereas the classic app used the `wpcom/v2` namespace. The `survey_id`/`site_id` data parity is preserved (same mutator the cancel-purchase flow already uses); please confirm both namespaces land in the same backend survey store if a single unified dataset is the goal.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
