### PR TITLE
A4A WooPayments setup: MSD-clean data layer for the site setup flow

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-site-setup/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-site-setup/index.tsx
@@ -15,6 +15,7 @@ import LayoutHeader, {
 	LayoutHeaderBreadcrumb as Breadcrumb,
 	LayoutHeaderActions as Actions,
 } from 'calypso/layout/hosting-dashboard/header';
+import { withoutHttp } from 'calypso/lib/url';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
@@ -100,7 +101,7 @@ const WooPaymentsSiteSetup = ( { siteId }: { siteId: string } ) => {
 					<>
 						<h2 className="woopayments-site-setup__page-title">
 							{ translate( 'WooPayments is now ready to be configured on %s', {
-								args: site?.slug,
+								args: withoutHttp( site.URL ),
 							} ) }
 						</h2>
 						<div className="woopayments-site-setup__page-description">

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-site-setup/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-site-setup/index.tsx
@@ -1,11 +1,4 @@
-import {
-	siteCorePluginActivateMutation,
-	siteCorePluginInstallMutation,
-	siteCorePluginsQuery,
-} from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
-import { SiteDetails } from '@automattic/data-stores';
-import { useMutation, useQuery } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
@@ -16,55 +9,27 @@ import { A4A_WOOPAYMENTS_DASHBOARD_LINK } from 'calypso/a8c-for-agencies/compone
 import StepSection from 'calypso/a8c-for-agencies/components/step-section';
 import StepSectionItem from 'calypso/a8c-for-agencies/components/step-section-item';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
+import { useWooPaymentsSiteSetup } from 'calypso/dashboard/agency/earn/woopayments/hooks/use-woopayments-site-setup';
 import LayoutBody from 'calypso/layout/hosting-dashboard/body';
 import LayoutHeader, {
 	LayoutHeaderBreadcrumb as Breadcrumb,
 	LayoutHeaderActions as Actions,
 } from 'calypso/layout/hosting-dashboard/header';
-import { useDispatch, useSelector } from 'calypso/state';
+import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import getSites from 'calypso/state/selectors/get-sites';
 
 import './style.scss';
-
-const WOOCOMMERCE_PLUGIN_SLUG = 'woocommerce/woocommerce';
-const WOOCOMMERCE_PAYMENTS_PLUGIN_SLUG = 'woocommerce-payments/woocommerce-payments';
 
 const WooPaymentsSiteSetup = ( { siteId }: { siteId: string } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const sites = useSelector( getSites );
 
-	const { mutateAsync: installPluginToSite, isPending: isPendingInstall } = useMutation(
-		siteCorePluginInstallMutation()
-	);
-	const { mutateAsync: activatePluginToSite, isPending: isPendingActivate } = useMutation(
-		siteCorePluginActivateMutation()
-	);
+	const { site, isLoading, status, setupUrl, installAndActivate, isInstalling } =
+		useWooPaymentsSiteSetup( parseInt( siteId ) );
+	const { woocommerceStatus, woocommercePaymentsStatus, isWooPaymentsActive } = status;
+
 	const [ error, setError ] = useState( false );
 	const [ isInstalled, setIsInstalled ] = useState( false );
-
-	const [ selectedSite, setSelectedSite ] = useState< SiteDetails | null | undefined >( null );
-
-	const { data: plugins, isLoading: isLoadingPlugins } = useQuery( {
-		...siteCorePluginsQuery( parseInt( siteId ) ),
-		enabled: !! siteId,
-	} );
-
-	const woocommercePlugin = plugins?.find(
-		( { plugin }: { plugin: string } ) => plugin === 'woocommerce/woocommerce'
-	);
-
-	const woocommerceStatus = woocommercePlugin?.status;
-	const isWooCommerceInactive = woocommerceStatus === 'inactive';
-
-	const woocommercePaymentsPlugin = plugins?.find(
-		( { plugin }: { plugin: string } ) => plugin === 'woocommerce-payments/woocommerce-payments'
-	);
-
-	const woocommercePaymentsStatus = woocommercePaymentsPlugin?.status;
-	const isWooPaymentsActive = woocommercePaymentsStatus === 'active';
-	const isWooPaymentsInactive = woocommercePaymentsStatus === 'inactive';
 
 	const title = translate( 'WooPayments site setup' );
 
@@ -77,47 +42,18 @@ const WooPaymentsSiteSetup = ( { siteId }: { siteId: string } ) => {
 			} )
 		);
 
-		const wooSetupUrl = `${ selectedSite?.URL }/wp-admin/admin.php?page=wc-admin&path=/payments/connect`;
-
 		if ( isInstalled || isWooPaymentsActive ) {
-			window.open( wooSetupUrl, '_blank' );
+			if ( setupUrl ) {
+				window.open( setupUrl, '_blank' );
+			}
 			return;
 		}
 
 		try {
-			// Install WooCommerce if not installed
-			if ( ! woocommercePlugin ) {
-				await installPluginToSite( {
-					siteId: parseInt( siteId ),
-					slug: 'woocommerce',
-				} );
+			await installAndActivate();
+			if ( setupUrl ) {
+				window.open( setupUrl, '_blank' );
 			}
-
-			// Activate WooCommerce if it is installed but inactive
-			if ( isWooCommerceInactive ) {
-				await activatePluginToSite( {
-					siteId: parseInt( siteId ),
-					plugin: WOOCOMMERCE_PLUGIN_SLUG,
-				} );
-			}
-
-			// Install WooPayments if not installed
-			if ( ! woocommercePaymentsPlugin ) {
-				await installPluginToSite( {
-					siteId: parseInt( siteId ),
-					slug: 'woocommerce-payments',
-				} );
-			}
-
-			// Activate WooPayments if it is installed but inactive
-			if ( isWooPaymentsInactive ) {
-				await activatePluginToSite( {
-					siteId: parseInt( siteId ),
-					plugin: WOOCOMMERCE_PAYMENTS_PLUGIN_SLUG,
-				} );
-			}
-			// Open WooPayments setup page
-			window.open( wooSetupUrl, '_blank' );
 			setIsInstalled( true );
 		} catch {
 			setError( true );
@@ -128,20 +64,8 @@ const WooPaymentsSiteSetup = ( { siteId }: { siteId: string } ) => {
 		// Redirect to dashboard if no siteId
 		if ( ! siteId ) {
 			page.redirect( A4A_WOOPAYMENTS_DASHBOARD_LINK );
-			return;
 		}
-
-		// Find matching site
-		const site = sites.find( ( site ) => site?.ID === parseInt( siteId ) );
-
-		if ( site ) {
-			// Set selected site and remove site_id param
-			setSelectedSite( site );
-			return;
-		}
-	}, [ siteId, sites ] );
-
-	const isPending = isPendingInstall || isPendingActivate;
+	}, [ siteId ] );
 
 	return (
 		<Layout className="woopayments-site-setup" title={ title } wide>
@@ -166,7 +90,7 @@ const WooPaymentsSiteSetup = ( { siteId }: { siteId: string } ) => {
 			</LayoutTop>
 
 			<LayoutBody>
-				{ ! selectedSite || isLoadingPlugins ? (
+				{ ! site || isLoading ? (
 					<>
 						<TextPlaceholder />
 						<TextPlaceholder />
@@ -176,7 +100,7 @@ const WooPaymentsSiteSetup = ( { siteId }: { siteId: string } ) => {
 					<>
 						<h2 className="woopayments-site-setup__page-title">
 							{ translate( 'WooPayments is now ready to be configured on %s', {
-								args: selectedSite?.domain,
+								args: site?.slug,
 							} ) }
 						</h2>
 						<div className="woopayments-site-setup__page-description">
@@ -204,7 +128,7 @@ const WooPaymentsSiteSetup = ( { siteId }: { siteId: string } ) => {
 												</div>
 												<Button
 													variant="primary"
-													href={ `${ selectedSite.URL }/wp-admin/plugin-install.php?s=woopayments&tab=search&type=term` }
+													href={ `${ site.URL }/wp-admin/plugin-install.php?s=woopayments&tab=search&type=term` }
 													target="_blank"
 													rel="noopener noreferrer"
 													onClick={ () => {
@@ -220,8 +144,8 @@ const WooPaymentsSiteSetup = ( { siteId }: { siteId: string } ) => {
 											</>
 										) : (
 											<Button
-												disabled={ isPending }
-												isBusy={ isPending }
+												disabled={ isInstalling }
+												isBusy={ isInstalling }
 												variant="primary"
 												onClick={ onInstallPluginClick }
 											>

--- a/client/dashboard/agency/earn/woopayments/hooks/use-woopayments-site-setup.ts
+++ b/client/dashboard/agency/earn/woopayments/hooks/use-woopayments-site-setup.ts
@@ -1,0 +1,78 @@
+import {
+	siteByIdQuery,
+	siteCorePluginsQuery,
+	siteCorePluginInstallMutation,
+	siteCorePluginActivateMutation,
+} from '@automattic/api-queries';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import {
+	WOOCOMMERCE_PLUGIN,
+	WOOCOMMERCE_PAYMENTS_PLUGIN,
+	WOOCOMMERCE_PLUGIN_SLUG,
+	WOOCOMMERCE_PAYMENTS_PLUGIN_SLUG,
+} from '../lib/constants';
+import { derivePluginStatus } from '../lib/derive-plugin-status';
+import { getSiteSetupUrl } from '../lib/get-site-setup-url';
+import type { WooPaymentsSiteSetup } from '../types';
+
+/**
+ * Data layer for the WooPayments site setup flow: resolves the target site, derives the
+ * WooCommerce / WooPayments plugin status, and orchestrates installing + activating both plugins.
+ *
+ * Side effects that belong to presentation (opening WP-Admin, analytics, error surfacing) stay
+ * with the caller — `installAndActivate` simply resolves once the plugins are ready or throws.
+ */
+export function useWooPaymentsSiteSetup( siteId: number ): WooPaymentsSiteSetup {
+	const { data: site, isLoading: isLoadingSite } = useQuery( {
+		...siteByIdQuery( siteId ),
+		enabled: !! siteId,
+	} );
+
+	const { data: plugins, isLoading: isLoadingPlugins } = useQuery( {
+		...siteCorePluginsQuery( siteId ),
+		enabled: !! siteId,
+	} );
+
+	const { mutateAsync: installPlugin, isPending: isInstallingPlugin } = useMutation(
+		siteCorePluginInstallMutation()
+	);
+	const { mutateAsync: activatePlugin, isPending: isActivatingPlugin } = useMutation(
+		siteCorePluginActivateMutation()
+	);
+
+	const status = derivePluginStatus( plugins );
+	const { hasWooCommerce, hasWooPayments, isWooCommerceInactive, isWooPaymentsInactive } = status;
+
+	const installAndActivate = useCallback( async () => {
+		if ( ! hasWooCommerce ) {
+			await installPlugin( { siteId, slug: WOOCOMMERCE_PLUGIN_SLUG } );
+		}
+		if ( isWooCommerceInactive ) {
+			await activatePlugin( { siteId, plugin: WOOCOMMERCE_PLUGIN } );
+		}
+		if ( ! hasWooPayments ) {
+			await installPlugin( { siteId, slug: WOOCOMMERCE_PAYMENTS_PLUGIN_SLUG } );
+		}
+		if ( isWooPaymentsInactive ) {
+			await activatePlugin( { siteId, plugin: WOOCOMMERCE_PAYMENTS_PLUGIN } );
+		}
+	}, [
+		activatePlugin,
+		installPlugin,
+		siteId,
+		hasWooCommerce,
+		hasWooPayments,
+		isWooCommerceInactive,
+		isWooPaymentsInactive,
+	] );
+
+	return {
+		site,
+		isLoading: isLoadingSite || isLoadingPlugins,
+		status,
+		setupUrl: site?.URL ? getSiteSetupUrl( site.URL ) : undefined,
+		installAndActivate,
+		isInstalling: isInstallingPlugin || isActivatingPlugin,
+	};
+}

--- a/client/dashboard/agency/earn/woopayments/hooks/use-woopayments-site-setup.ts
+++ b/client/dashboard/agency/earn/woopayments/hooks/use-woopayments-site-setup.ts
@@ -5,7 +5,7 @@ import {
 	siteCorePluginActivateMutation,
 } from '@automattic/api-queries';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import {
 	WOOCOMMERCE_PLUGIN,
 	WOOCOMMERCE_PAYMENTS_PLUGIN,
@@ -14,9 +14,9 @@ import {
 } from '../lib/constants';
 import { derivePluginStatus } from '../lib/derive-plugin-status';
 import { getSiteSetupUrl } from '../lib/get-site-setup-url';
-import type { WooPaymentsSiteSetup } from '../types';
+import type { WooPaymentsSiteSetupData } from '../types';
 
-export function useWooPaymentsSiteSetup( siteId: number ): WooPaymentsSiteSetup {
+export function useWooPaymentsSiteSetup( siteId: number ): WooPaymentsSiteSetupData {
 	const { data: site, isLoading: isLoadingSite } = useQuery( {
 		...siteByIdQuery( siteId ),
 		enabled: !! siteId,
@@ -34,7 +34,7 @@ export function useWooPaymentsSiteSetup( siteId: number ): WooPaymentsSiteSetup 
 		siteCorePluginActivateMutation()
 	);
 
-	const status = derivePluginStatus( plugins );
+	const status = useMemo( () => derivePluginStatus( plugins ), [ plugins ] );
 	const { hasWooCommerce, hasWooPayments, isWooCommerceInactive, isWooPaymentsInactive } = status;
 
 	const installAndActivate = useCallback( async () => {

--- a/client/dashboard/agency/earn/woopayments/hooks/use-woopayments-site-setup.ts
+++ b/client/dashboard/agency/earn/woopayments/hooks/use-woopayments-site-setup.ts
@@ -16,13 +16,6 @@ import { derivePluginStatus } from '../lib/derive-plugin-status';
 import { getSiteSetupUrl } from '../lib/get-site-setup-url';
 import type { WooPaymentsSiteSetup } from '../types';
 
-/**
- * Data layer for the WooPayments site setup flow: resolves the target site, derives the
- * WooCommerce / WooPayments plugin status, and orchestrates installing + activating both plugins.
- *
- * Side effects that belong to presentation (opening WP-Admin, analytics, error surfacing) stay
- * with the caller — `installAndActivate` simply resolves once the plugins are ready or throws.
- */
 export function useWooPaymentsSiteSetup( siteId: number ): WooPaymentsSiteSetup {
 	const { data: site, isLoading: isLoadingSite } = useQuery( {
 		...siteByIdQuery( siteId ),

--- a/client/dashboard/agency/earn/woopayments/lib/constants.ts
+++ b/client/dashboard/agency/earn/woopayments/lib/constants.ts
@@ -1,0 +1,7 @@
+// Canonical plugin identifiers (the plugin file path used by the Core plugins REST resource).
+export const WOOCOMMERCE_PLUGIN = 'woocommerce/woocommerce';
+export const WOOCOMMERCE_PAYMENTS_PLUGIN = 'woocommerce-payments/woocommerce-payments';
+
+// Install slugs (the WordPress.org directory slug used when installing a plugin).
+export const WOOCOMMERCE_PLUGIN_SLUG = 'woocommerce';
+export const WOOCOMMERCE_PAYMENTS_PLUGIN_SLUG = 'woocommerce-payments';

--- a/client/dashboard/agency/earn/woopayments/lib/derive-plugin-status.ts
+++ b/client/dashboard/agency/earn/woopayments/lib/derive-plugin-status.ts
@@ -1,0 +1,26 @@
+import { WOOCOMMERCE_PLUGIN, WOOCOMMERCE_PAYMENTS_PLUGIN } from './constants';
+import type { WooPaymentsPluginStatus } from '../types';
+import type { CorePlugin } from '@automattic/api-core';
+
+/**
+ * Reduce the site's Core plugins list to the WooCommerce / WooPayments flags the setup flow needs.
+ */
+export function derivePluginStatus( plugins: CorePlugin[] = [] ): WooPaymentsPluginStatus {
+	const woocommercePlugin = plugins.find( ( { plugin } ) => plugin === WOOCOMMERCE_PLUGIN );
+	const woocommercePaymentsPlugin = plugins.find(
+		( { plugin } ) => plugin === WOOCOMMERCE_PAYMENTS_PLUGIN
+	);
+
+	const woocommerceStatus = woocommercePlugin?.status;
+	const woocommercePaymentsStatus = woocommercePaymentsPlugin?.status;
+
+	return {
+		hasWooCommerce: !! woocommercePlugin,
+		hasWooPayments: !! woocommercePaymentsPlugin,
+		woocommerceStatus,
+		woocommercePaymentsStatus,
+		isWooCommerceInactive: woocommerceStatus === 'inactive',
+		isWooPaymentsActive: woocommercePaymentsStatus === 'active',
+		isWooPaymentsInactive: woocommercePaymentsStatus === 'inactive',
+	};
+}

--- a/client/dashboard/agency/earn/woopayments/lib/derive-plugin-status.ts
+++ b/client/dashboard/agency/earn/woopayments/lib/derive-plugin-status.ts
@@ -2,9 +2,6 @@ import { WOOCOMMERCE_PLUGIN, WOOCOMMERCE_PAYMENTS_PLUGIN } from './constants';
 import type { WooPaymentsPluginStatus } from '../types';
 import type { CorePlugin } from '@automattic/api-core';
 
-/**
- * Reduce the site's Core plugins list to the WooCommerce / WooPayments flags the setup flow needs.
- */
 export function derivePluginStatus( plugins: CorePlugin[] = [] ): WooPaymentsPluginStatus {
 	const woocommercePlugin = plugins.find( ( { plugin } ) => plugin === WOOCOMMERCE_PLUGIN );
 	const woocommercePaymentsPlugin = plugins.find(

--- a/client/dashboard/agency/earn/woopayments/lib/get-site-setup-url.ts
+++ b/client/dashboard/agency/earn/woopayments/lib/get-site-setup-url.ts
@@ -1,6 +1,3 @@
-/**
- * Build the WooPayments connect URL on a site's WP-Admin, where the agency finishes setup.
- */
 export function getSiteSetupUrl( siteUrl: string ): string {
 	return `${ siteUrl }/wp-admin/admin.php?page=wc-admin&path=/payments/connect`;
 }

--- a/client/dashboard/agency/earn/woopayments/lib/get-site-setup-url.ts
+++ b/client/dashboard/agency/earn/woopayments/lib/get-site-setup-url.ts
@@ -1,0 +1,6 @@
+/**
+ * Build the WooPayments connect URL on a site's WP-Admin, where the agency finishes setup.
+ */
+export function getSiteSetupUrl( siteUrl: string ): string {
+	return `${ siteUrl }/wp-admin/admin.php?page=wc-admin&path=/payments/connect`;
+}

--- a/client/dashboard/agency/earn/woopayments/lib/test/derive-plugin-status.test.ts
+++ b/client/dashboard/agency/earn/woopayments/lib/test/derive-plugin-status.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment node
+ */
+import { WOOCOMMERCE_PLUGIN, WOOCOMMERCE_PAYMENTS_PLUGIN } from '../constants';
+import { derivePluginStatus } from '../derive-plugin-status';
+import type { CorePlugin } from '@automattic/api-core';
+
+const plugin = ( overrides: Partial< CorePlugin > ): CorePlugin =>
+	( {
+		plugin: '',
+		status: 'active',
+		name: '',
+		...overrides,
+	} ) as CorePlugin;
+
+describe( 'derivePluginStatus', () => {
+	it( 'reports both plugins missing when the list is empty', () => {
+		expect( derivePluginStatus( [] ) ).toEqual( {
+			hasWooCommerce: false,
+			hasWooPayments: false,
+			woocommerceStatus: undefined,
+			woocommercePaymentsStatus: undefined,
+			isWooCommerceInactive: false,
+			isWooPaymentsActive: false,
+			isWooPaymentsInactive: false,
+		} );
+	} );
+
+	it( 'defaults to an empty list when called with no argument', () => {
+		expect( derivePluginStatus().hasWooCommerce ).toBe( false );
+	} );
+
+	it( 'flags an inactive WooCommerce install', () => {
+		const status = derivePluginStatus( [
+			plugin( { plugin: WOOCOMMERCE_PLUGIN, status: 'inactive' } ),
+		] );
+
+		expect( status.hasWooCommerce ).toBe( true );
+		expect( status.woocommerceStatus ).toBe( 'inactive' );
+		expect( status.isWooCommerceInactive ).toBe( true );
+	} );
+
+	it( 'flags an active WooPayments install', () => {
+		const status = derivePluginStatus( [
+			plugin( { plugin: WOOCOMMERCE_PAYMENTS_PLUGIN, status: 'active' } ),
+		] );
+
+		expect( status.hasWooPayments ).toBe( true );
+		expect( status.isWooPaymentsActive ).toBe( true );
+		expect( status.isWooPaymentsInactive ).toBe( false );
+	} );
+
+	it( 'flags an inactive WooPayments install', () => {
+		const status = derivePluginStatus( [
+			plugin( { plugin: WOOCOMMERCE_PAYMENTS_PLUGIN, status: 'inactive' } ),
+		] );
+
+		expect( status.isWooPaymentsActive ).toBe( false );
+		expect( status.isWooPaymentsInactive ).toBe( true );
+	} );
+
+	it( 'resolves both plugins when both are present', () => {
+		const status = derivePluginStatus( [
+			plugin( { plugin: WOOCOMMERCE_PLUGIN, status: 'active' } ),
+			plugin( { plugin: WOOCOMMERCE_PAYMENTS_PLUGIN, status: 'active' } ),
+		] );
+
+		expect( status.hasWooCommerce ).toBe( true );
+		expect( status.hasWooPayments ).toBe( true );
+		expect( status.isWooCommerceInactive ).toBe( false );
+		expect( status.isWooPaymentsActive ).toBe( true );
+	} );
+} );

--- a/client/dashboard/agency/earn/woopayments/lib/test/get-site-setup-url.test.ts
+++ b/client/dashboard/agency/earn/woopayments/lib/test/get-site-setup-url.test.ts
@@ -1,0 +1,12 @@
+/**
+ * @jest-environment node
+ */
+import { getSiteSetupUrl } from '../get-site-setup-url';
+
+describe( 'getSiteSetupUrl', () => {
+	it( 'builds the WooPayments connect URL on the site WP-Admin', () => {
+		expect( getSiteSetupUrl( 'https://example.com' ) ).toBe(
+			'https://example.com/wp-admin/admin.php?page=wc-admin&path=/payments/connect'
+		);
+	} );
+} );

--- a/client/dashboard/agency/earn/woopayments/types.ts
+++ b/client/dashboard/agency/earn/woopayments/types.ts
@@ -1,3 +1,5 @@
+import type { CorePlugin, Site } from '@automattic/api-core';
+
 export interface SitesWithWooPaymentsState {
 	blogId: number;
 	siteUrl: string;
@@ -13,3 +15,22 @@ export type RecordTracksEvent = (
 	eventName: string,
 	properties?: Record< string, unknown >
 ) => void;
+
+export type WooPaymentsPluginStatus = {
+	hasWooCommerce: boolean;
+	hasWooPayments: boolean;
+	woocommerceStatus?: CorePlugin[ 'status' ];
+	woocommercePaymentsStatus?: CorePlugin[ 'status' ];
+	isWooCommerceInactive: boolean;
+	isWooPaymentsActive: boolean;
+	isWooPaymentsInactive: boolean;
+};
+
+export type WooPaymentsSiteSetup = {
+	site: Site | undefined;
+	isLoading: boolean;
+	status: WooPaymentsPluginStatus;
+	setupUrl: string | undefined;
+	installAndActivate: () => Promise< void >;
+	isInstalling: boolean;
+};

--- a/client/dashboard/agency/earn/woopayments/types.ts
+++ b/client/dashboard/agency/earn/woopayments/types.ts
@@ -26,7 +26,7 @@ export type WooPaymentsPluginStatus = {
 	isWooPaymentsInactive: boolean;
 };
 
-export type WooPaymentsSiteSetup = {
+export type WooPaymentsSiteSetupData = {
 	site: Site | undefined;
 	isLoading: boolean;
 	status: WooPaymentsPluginStatus;


### PR DESCRIPTION
Part of the WooPayments site setup MSD compliance effort.


Related to https://linear.app/a8c/issue/A4A-2857/implement-woopayments-dashboard-screen

## Proposed Changes

* Extract the WooPayments site setup data/logic into a design-system-clean, Redux-free **data layer** under `client/dashboard/agency/earn/woopayments/`:
  * `lib/constants`, `lib/get-site-setup-url`, `lib/derive-plugin-status` (pure helpers)
  * `types.ts` for the derived plugin status and the hook return
  * `hooks/use-woopayments-site-setup` — resolves the site via `siteByIdQuery`, derives WooCommerce/WooPayments status, and orchestrates install/activate.
* Wire the classic A4A setup page (`sections/woopayments/primary/woopayments-site-setup`) to consume the hook, removing its inlined plugin queries/mutations and the Redux `getSites` lookup. The page keeps its `StepSection` presentation and owns only presentation-level side effects (opening WP-Admin, analytics, error state, redirect).

## Why are these changes being made?

* First step toward making the WooPayments site setup page MSD compliant, mirroring the Migrations: commissions port — shared/logic pieces move to the dashboard tree (design-system-clean, no Redux), while the classic host keeps its presentation. Site resolution moves off Redux `getSites` onto `siteByIdQuery` so the flow no longer depends on Calypso state, unblocking a future native MSD route with no duplicated logic.

## Testing Instructions

* In A4A, open **WooPayments commissions → Site setup** for a managed site. Verify:
  * Loading placeholders show briefly, then the “ready to be configured on <site>” content.
  * **Install and activate the plugin** installs/activates WooCommerce + WooPayments and opens the WP-Admin connect page; the button shows a busy state while running.
  * For a site that already has WooPayments active, the primary button reads **Finish setup** and opens WP-Admin directly (no install).
  * If install fails, the error copy and the **Visit WP-Admin** fallback button render.
  * Opening the page without a `site_id` redirects to the WooPayments dashboard.
* `yarn test-client client/dashboard/agency/earn/woopayments/lib/test` passes.
* `yarn typecheck-client` shows no new errors.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
