### PR TITLE
Stepper: add accepts-props to the user (register) step

### DIFF
--- a/client/landing/stepper/README.md
+++ b/client/landing/stepper/README.md
@@ -394,7 +394,9 @@ flows keep working unchanged:
   default-safe. See
   [`steps-repository/unified-plans/index.tsx`](/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx).
 - The `__user` (`user`) step exposes `headerText`, `subHeaderText`, `hideLoginLink` (hides the
-  "Log in" link in both the V2 top bar and the V1 footer) and `allowedSocialServices` (restricts
+  top-level "Log in" link in the V2 top bar / V1 footer — note the email-first account-step
+  variant keeps its own in-form "Have an account? Log in" link, and existing users can still sign
+  in via the social / email buttons regardless) and `allowedSocialServices` (restricts
   which social sign-in providers are offered). This step is special: it is **auto-injected** by
   `injectUserStepInSteps()` when a flow marks a step `requiresLoggedInUser`, so it is not in the
   flow's `initialize()` array. Its props are therefore passed under the reserved `user` key of

--- a/client/landing/stepper/README.md
+++ b/client/landing/stepper/README.md
@@ -393,6 +393,15 @@ flows keep working unchanged:
   `PlansFeaturesMain` into the existing `plans-grid-next` override path). All optional and
   default-safe. See
   [`steps-repository/unified-plans/index.tsx`](/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx).
+- The `__user` (`user`) step exposes `headerText`, `subHeaderText`, `hideLoginLink` (hides the
+  "Log in" link in both the V2 top bar and the V1 footer) and `allowedSocialServices` (restricts
+  which social sign-in providers are offered). This step is special: it is **auto-injected** by
+  `injectUserStepInSteps()` when a flow marks a step `requiresLoggedInUser`, so it is not in the
+  flow's `initialize()` array. Its props are therefore passed under the reserved `user` key of
+  `useStepsProps()` — the return type is widened with
+  `MapStepsToTheirAcceptedProps<[ typeof PRIVATE_STEPS.USER ]>` so a flow can set them once. All
+  optional and default-safe. See
+  [`steps-repository/__user/index.tsx`](/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx).
 
 #### Renaming steps
 

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -192,6 +192,7 @@ export const FlowRenderer: React.FC< {
 					stepName="user"
 					redirectTo={ postAuthStepPath }
 					signupUrl={ signupUrl }
+					{ ...stepsProps?.[ PRIVATE_STEPS.USER.slug ] }
 				/>
 			);
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -40,12 +40,23 @@ import './style.scss';
 // flag enabled, but the local-dev one does).
 const MOBILE_SOCIAL_SERVICES: SignupAllowedService[] = [ 'google', 'apple', 'github' ];
 
-const UserStepComponent: StepType = function UserStep( {
+export type UserStepAccepts = {
+	headerText?: string;
+	subHeaderText?: string;
+	hideLoginLink?: boolean;
+	allowedSocialServices?: SignupAllowedService[];
+};
+
+const UserStepComponent: StepType< { accepts: UserStepAccepts } > = function UserStep( {
 	flow,
 	stepName,
 	navigation,
 	redirectTo = window.location.href,
 	signupUrl = window.location.href,
+	headerText,
+	subHeaderText,
+	hideLoginLink,
+	allowedSocialServices: allowedSocialServicesProp,
 } ) {
 	const translate = useTranslate();
 	const isLoggedIn = useSelector( isUserLoggedIn );
@@ -126,7 +137,10 @@ const UserStepComponent: StepType = function UserStep( {
 	// — it keeps the "partners never get the compact SSO set" invariant local to
 	// this line and safe if the eligibility above is ever refactored.
 	const allowedSocialServices =
-		isMobileCompactLayout && ! partnerConfig ? MOBILE_SOCIAL_SERVICES : partnerConfig?.ssoProviders;
+		allowedSocialServicesProp ??
+		( isMobileCompactLayout && ! partnerConfig
+			? MOBILE_SOCIAL_SERVICES
+			: partnerConfig?.ssoProviders );
 	// customTosElement is reserved for partner branding (legal); the form's
 	// mobile-compact branch renders MobileCompactTosNotice as its own fallback
 	// when no customTosElement is provided. Routing the notice through
@@ -167,8 +181,8 @@ const UserStepComponent: StepType = function UserStep( {
 	);
 
 	if ( isStepContainerV2 ) {
-		let headingText = translate( 'Create your account' );
-		let headingSubText;
+		let headingText = headerText ?? translate( 'Create your account' );
+		let headingSubText = subHeaderText;
 		if ( partnerConfig ) {
 			headingText = translate( 'Create an account for %(partner)s', {
 				args: { partner: partnerConfig.displayName },
@@ -197,7 +211,7 @@ const UserStepComponent: StepType = function UserStep( {
 					navigation.goBack ? <Step.BackButton onClick={ navigation.goBack } /> : undefined
 				}
 				rightElement={
-					isEmailFirstVariant ? null : (
+					hideLoginLink || isEmailFirstVariant ? null : (
 						<Step.LinkButton href={ loginLink }>{ translate( 'Log in' ) }</Step.LinkButton>
 					)
 				}
@@ -259,7 +273,8 @@ const UserStepComponent: StepType = function UserStep( {
 					<>
 						<FormattedHeader
 							align="center"
-							headerText={ translate( 'Create your account' ) }
+							headerText={ headerText ?? translate( 'Create your account' ) }
+							subHeaderText={ subHeaderText }
 							brandFont
 						/>
 						{ stepContent }
@@ -267,13 +282,15 @@ const UserStepComponent: StepType = function UserStep( {
 				}
 				recordTracksEvent={ recordTracksEvent }
 				customizedActionButtons={
-					<Button
-						className="step-wrapper__navigation-link forward"
-						href={ loginLink }
-						variant="link"
-					>
-						<span>{ translate( 'Log in' ) }</span>
-					</Button>
+					hideLoginLink ? undefined : (
+						<Button
+							className="step-wrapper__navigation-link forward"
+							href={ loginLink }
+							variant="link"
+						>
+							<span>{ translate( 'Log in' ) }</span>
+						</Button>
+					)
 				}
 			/>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -43,6 +43,11 @@ const MOBILE_SOCIAL_SERVICES: SignupAllowedService[] = [ 'google', 'apple', 'git
 export type UserStepAccepts = {
 	headerText?: string;
 	subHeaderText?: string;
+	/**
+	 * Hides the top-level "Log in" link (V2 top bar / V1 footer). The email-first
+	 * account-step variant keeps its own in-form "Have an account? Log in" link.
+	 * Existing users can still sign in via the social / email buttons either way.
+	 */
 	hideLoginLink?: boolean;
 	allowedSocialServices?: SignupAllowedService[];
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/index.tsx
@@ -18,7 +18,7 @@ import { usePartnerBranding } from 'calypso/lib/partner-branding';
 import loginReducer from 'calypso/state/login/reducer';
 import routeReducer from 'calypso/state/route/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
-import UserStep from '..';
+import UserStep, { type UserStepAccepts } from '..';
 
 const mockUseViewportMatch = useViewportMatch as unknown as jest.Mock;
 const mockUsePartnerBranding = usePartnerBranding as unknown as jest.Mock;
@@ -43,10 +43,18 @@ describe( 'User email signup step', () => {
 		mockUsePartnerBranding.mockReturnValue( noPartnerBranding );
 	} );
 
-	const renderUserStep = ( url = '/onboarding/user?user_email=test@example.com' ) => {
+	const renderUserStep = (
+		url = '/onboarding/user?user_email=test@example.com',
+		props: Partial< UserStepAccepts > = {}
+	) => {
 		return renderWithProvider(
 			<MemoryRouter initialEntries={ [ url ] }>
-				<UserStep flow="onboarding" stepName="user" navigation={ { submit: jest.fn() } } />
+				<UserStep
+					flow="onboarding"
+					stepName="user"
+					navigation={ { submit: jest.fn() } }
+					{ ...props }
+				/>
 			</MemoryRouter>,
 			{ reducers: { login: loginReducer, route: routeReducer } }
 		);
@@ -113,6 +121,29 @@ describe( 'User email signup step', () => {
 			expect(
 				screen.queryByText( /By continuing with any of the options above/i )
 			).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'accepts-props overrides', () => {
+		it( 'overrides the heading with headerText', () => {
+			renderUserStep( '/onboarding/user', { headerText: 'Join thousands of creators' } );
+			expect( screen.getByRole( 'heading', { name: 'Join thousands of creators' } ) ).toBeVisible();
+			expect(
+				screen.queryByRole( 'heading', { name: 'Create your account' } )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'renders subHeaderText beneath the title', () => {
+			renderUserStep( '/onboarding/user', { subHeaderText: 'Free forever, no card required' } );
+			expect( screen.getByText( 'Free forever, no card required' ) ).toBeVisible();
+		} );
+
+		it( 'renders with hideLoginLink and a restricted provider set without blowing up', () => {
+			renderUserStep( '/onboarding/user', {
+				hideLoginLink: true,
+				allowedSocialServices: [ 'google', 'apple' ],
+			} );
+			expect( screen.getByRole( 'heading', { name: 'Create your account' } ) ).toBeVisible();
 		} );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -270,7 +270,8 @@ export interface FlowV2< FlowStepsInitialize extends DefaultFlowStepsConfig > {
 	 */
 	useStepsProps?(): MapStepsToTheirAcceptedProps<
 		ExtractSteps< ReturnType< FlowStepsInitialize > >
-	>;
+	> &
+		MapStepsToTheirAcceptedProps< [ typeof PRIVATE_STEPS.USER ] >;
 
 	name: string;
 	/**


### PR DESCRIPTION
Part of DOTCOM-17641

## Proposed Changes

Lets a flow customize the auto-injected **user (register)** step via `useStepsProps()`, the same way goals / domain / plans already work — engineering reviews the change rather than hand-building each one.

**Framework (why this step was different):** the user step is auto-injected by `injectUserStepInSteps()` when a flow marks a step `requiresLoggedInUser`, so it is not in the flow's `initialize()` array and had no `useStepsProps()` slot. Two small pieces enable it:

* **Type** — widen the `useStepsProps()` return with `& MapStepsToTheirAcceptedProps<[ typeof PRIVATE_STEPS.USER ]>`, so a flow can type a reserved `user` key (reuses the existing helper; no new machinery).
* **Runtime** — the generic step render already spreads `stepsProps?.[ step.slug ]`, but the user step has its own render branch in `FlowRenderer` (the logged-out → auth-redirect case) that did not. Added `{ ...stepsProps?.[ PRIVATE_STEPS.USER.slug ] }` there so the props actually reach the step.

**Step (`__user`) — new optional, default-safe `accepts:` props:**

* `headerText` / `subHeaderText` — override the "Create your account" heading / add a sub-heading (both V1 `FormattedHeader` and V2 `Step.Heading` paths)
* `hideLoginLink` — hide the "Log in" link (V2 top bar + V1 footer action)
* `allowedSocialServices` — restrict which social sign-in providers are offered (whitelist; OR-ed over the form's existing computed value)

All props are optional and default to today's behavior — a flow that passes nothing renders exactly as before.

## Why are these changes being made?

Follow-up to the goals (#111083), domain-search (#111907) and plans (#112630) accepts-props work. The user step was the last main Signup step without a per-flow customization surface — blocked only on the small framework decision above.

## Testing Instructions

* `yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/index.tsx` — 9/9 pass (adds `headerText` heading-override, `subHeaderText`, and a `hideLoginLink` + `allowedSocialServices` smoke test).
* `yarn typecheck-client` — clean for the edited files.
* Manual, end-to-end in the browser via a scratch flow returning a `user` key from `useStepsProps()` (reverted before commit): confirmed `headerText` and `subHeaderText` change the heading, `hideLoginLink` removes the link, and `allowedSocialServices: ['google','apple']` drops the GitHub button. Screenshots below.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
