### PR TITLE
Purchases: migrate PlanBillingPeriod to raw Purchase

### DIFF
--- a/client/me/purchases/lib/raw-purchase-helpers.ts
+++ b/client/me/purchases/lib/raw-purchase-helpers.ts
@@ -87,6 +87,10 @@ export function isRenewingBeforeExpiration( purchase: Purchase ): boolean {
 	return [ 'active', 'auto-renewing' ].includes( purchase.expiry_status );
 }
 
+export function isExpiring( purchase: Purchase ): boolean {
+	return [ 'manual-renew', 'expiring' ].includes( purchase.expiry_status );
+}
+
 export function isExpiredWithNoAutoRenewAttemptsLeft( purchase: Purchase ): boolean {
 	return isExpiredAndInGracePeriod( purchase ) && purchase.is_past_last_auto_renew_attempt_date;
 }

--- a/client/me/purchases/manage-purchase/plan-details/billing-period.tsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.tsx
@@ -11,21 +11,22 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	isExpiring,
 	isRenewingBeforeExpiration,
 	showCreditCardExpiringWarning,
 	isExpiredOrRemoved,
-} from 'calypso/lib/purchases';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import type { Purchases, SiteDetails } from '@automattic/data-stores';
+} from '../../lib/raw-purchase-helpers';
+import type { Purchase } from '@automattic/api-core';
+import type { SiteDetails } from '@automattic/data-stores';
 
 interface MomentProps {
 	moment: typeof moment;
 }
 
 export interface PlanBillingPeriodProps {
-	purchase: Purchases.Purchase;
+	purchase: Purchase;
 	site: SiteDetails | null | undefined;
 	isProductOwner: boolean;
 }
@@ -42,10 +43,10 @@ export class PlanBillingPeriod extends Component<
 > {
 	handleMonthlyToYearlyButtonClick = () => {
 		const { purchase } = this.props;
-		const yearlyPlanSlug = getYearlyPlanByMonthly( purchase.productSlug );
+		const yearlyPlanSlug = getYearlyPlanByMonthly( purchase.product_slug );
 
 		this.props.recordTracksEvent( 'calypso_purchase_details_plan_upgrade_click', {
-			current_plan: purchase.productSlug,
+			current_plan: purchase.product_slug,
 			upgrading_to: yearlyPlanSlug,
 		} );
 		page(
@@ -55,7 +56,7 @@ export class PlanBillingPeriod extends Component<
 				'/' +
 				yearlyPlanSlug +
 				'?upgrade_from=' +
-				purchase.productSlug
+				purchase.product_slug
 		);
 	};
 
@@ -66,25 +67,25 @@ export class PlanBillingPeriod extends Component<
 			return translate( 'Billed yearly, credit card expiring soon' );
 		}
 
-		if ( isRenewingBeforeExpiration( purchase ) && purchase.renewDate ) {
-			const renewDate = moment( purchase.renewDate );
+		if ( isRenewingBeforeExpiration( purchase ) && purchase.renew_date ) {
+			const renewDate = moment( purchase.renew_date );
 			return translate( 'Billed yearly, renews on %s', {
 				args: renewDate.format( 'LL' ),
 				comment: '%s is the renewal date in format M DD, Y, for example: June 10, 2019',
 			} );
 		}
 
-		if ( isExpiring( purchase ) && purchase.expiryDate ) {
+		if ( isExpiring( purchase ) && purchase.expiry_date ) {
 			return translate( 'Billed yearly, expires on %s', {
-				args: moment( purchase.expiryDate ).format( 'LL' ),
+				args: moment( purchase.expiry_date ).format( 'LL' ),
 				comment: '%s is the expiration date in format M DD, Y, for example: June 10, 2019',
 			} );
 		}
 
-		if ( isExpiredOrRemoved( purchase ) && purchase.expiryDate ) {
+		if ( isExpiredOrRemoved( purchase ) && purchase.expiry_date ) {
 			return translate( 'Billed yearly, expired %(timeSinceExpiry)s', {
 				args: {
-					timeSinceExpiry: moment( purchase.expiryDate ).fromNow(),
+					timeSinceExpiry: moment( purchase.expiry_date ).fromNow(),
 				},
 				comment: 'timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"',
 			} );
@@ -99,27 +100,27 @@ export class PlanBillingPeriod extends Component<
 			return;
 		}
 
-		if ( ! isMonthly( purchase.productSlug ) ) {
+		if ( ! isMonthly( purchase.product_slug ) ) {
 			return (
 				<FormSettingExplanation>{ this.renderYearlyBillingInformation() }</FormSettingExplanation>
 			);
 		}
 
-		const yearlyPlanSlug = getYearlyPlanByMonthly( purchase.productSlug );
+		const yearlyPlanSlug = getYearlyPlanByMonthly( purchase.product_slug );
 		if ( ! yearlyPlanSlug ) {
 			return;
 		}
 
-		const isTemporarySite = purchase.isAttachedToHoldingSite;
+		const isTemporarySite = purchase.is_attached_to_holding_site;
 		const isExpired = isExpiredOrRemoved( purchase );
 
 		const billedMonthlyText =
-			isExpired && purchase.expiryDate
+			isExpired && purchase.expiry_date
 				? fixMe( {
 						text: 'Billed monthly, expired %(timeSinceExpiry)s',
 						newCopy: translate( 'Billed monthly, expired %(timeSinceExpiry)s', {
 							args: {
-								timeSinceExpiry: moment( purchase.expiryDate ).fromNow(),
+								timeSinceExpiry: moment( purchase.expiry_date ).fromNow(),
 							},
 							comment:
 								'timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"',
@@ -132,13 +133,13 @@ export class PlanBillingPeriod extends Component<
 			<Fragment>
 				<FormSettingExplanation>
 					{ billedMonthlyText }
-					{ site && isProductOwner && ! purchase.isLocked && (
+					{ site && isProductOwner && ! purchase.is_locked && (
 						<Button onClick={ this.handleMonthlyToYearlyButtonClick } primary compact>
 							{ translate( 'Upgrade to yearly billing' ) }
 						</Button>
 					) }
 				</FormSettingExplanation>
-				{ ! site && ! isTemporarySite && ! purchase.isLocked && (
+				{ ! site && ! isTemporarySite && ! purchase.is_locked && (
 					<FormSettingExplanation>
 						{ translate(
 							'To manage your plan, please {{supportPageLink}}reconnect{{/supportPageLink}} your site.',

--- a/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
@@ -10,16 +10,14 @@ import { PlanBillingPeriod } from '../billing-period';
 const props = {
 	purchase: {
 		// Including the properties that are used by this component
-		id: 123,
-		siteId: 123,
-		productName: 'Jetpack Personal',
-		productSlug: 'jetpack_premium_monthly',
+		ID: 123,
+		blog_id: 123,
+		product_name: 'Jetpack Personal',
+		product_slug: 'jetpack_premium_monthly',
 		domain: 'site.com',
-		expiryStatus: 'active',
-		subscriptionStatus: 'active',
-		payment: {
-			type: 'paypal',
-		},
+		expiry_status: 'active',
+		subscription_status: 'active',
+		payment_type: 'paypal',
 	},
 	site: {
 		ID: 123,
@@ -70,7 +68,7 @@ describe( 'PlanBillingPeriod', () => {
 			...props,
 			purchase: {
 				...props.purchase,
-				productSlug: 'jetpack_personal',
+				product_slug: 'jetpack_personal',
 			},
 		};
 
@@ -85,13 +83,9 @@ describe( 'PlanBillingPeriod', () => {
 				const cardExpiryDate = moment().add( 1, 'months' ).format( 'MM/YY' );
 				const purchase = {
 					...annualPlanProps.purchase,
-					expiryDate: planExpiryDate,
-					payment: {
-						type: 'credit_card',
-						creditCard: {
-							expiryDate: cardExpiryDate,
-						},
-					},
+					expiry_date: planExpiryDate,
+					payment_type: 'credit_card',
+					payment_expiry: cardExpiryDate,
 				};
 				render( <PlanBillingPeriod { ...annualPlanProps } purchase={ purchase } /> );
 				expect( screen.getByText( /billed yearly/i ) ).toHaveTextContent(
@@ -104,7 +98,7 @@ describe( 'PlanBillingPeriod', () => {
 			it( 'should display a warning to the user', () => {
 				const purchase = {
 					...annualPlanProps.purchase,
-					renewDate: moment( '2020-01-01' ).format(),
+					renew_date: moment( '2020-01-01' ).format(),
 				};
 				render( <PlanBillingPeriod { ...annualPlanProps } purchase={ purchase } /> );
 				expect( screen.getByText( /billed yearly/i ) ).toHaveTextContent(
@@ -119,8 +113,8 @@ describe( 'PlanBillingPeriod', () => {
 				const futureDate = moment().add( 1, 'month' );
 				const purchase = {
 					...annualPlanProps.purchase,
-					expiryDate: futureDate.format(),
-					expiryStatus: 'expiring',
+					expiry_date: futureDate.format(),
+					expiry_status: 'expiring',
 				};
 				render( <PlanBillingPeriod { ...annualPlanProps } purchase={ purchase } /> );
 				expect( screen.getByText( /billed yearly/i ) ).toHaveTextContent(
@@ -133,8 +127,8 @@ describe( 'PlanBillingPeriod', () => {
 			it( 'should display a warning to the user', () => {
 				const purchase = {
 					...annualPlanProps.purchase,
-					expiryDate: moment().subtract( 1, 'month' ).format(),
-					expiryStatus: 'expired',
+					expiry_date: moment().subtract( 1, 'month' ).format(),
+					expiry_status: 'expired',
 				};
 				render( <PlanBillingPeriod { ...annualPlanProps } purchase={ purchase } /> );
 				expect( screen.getByText( /billed yearly/i ) ).toHaveTextContent(


### PR DESCRIPTION
Related to [SHILL-2256](https://linear.app/a8c/issue/SHILL-2256/remove-the-purchases-assembler-read-the-raw-purchase-object-directly)

## Proposed Changes

Fixes a crash on the classic manage-purchase detail page by finishing the raw-`Purchase` migration for `PlanBillingPeriod`, which the plan-details subtree had been left passing a raw purchase into.

* Migrate `PlanBillingPeriod` (`plan-details/billing-period.tsx`) off the camelCase data-stores `Purchase` onto the raw snake_case `Purchase` from `@automattic/api-core`.
* Read raw fields directly (`product_slug`, `renew_date`, `expiry_date`, `is_locked`, `is_attached_to_holding_site`) and source `isExpiring`/`isRenewingBeforeExpiration`/`isExpiredOrRemoved`/`showCreditCardExpiringWarning` from the local `raw-purchase-helpers` module instead of `calypso/lib/purchases`.
* Add an `isExpiring` port to `raw-purchase-helpers`, which the component needs.
* Update the `billing-period` unit-test fixtures to the raw snake_case shape.

## Why are these changes being made?

Commit #112808 migrated the manage-purchase subtree onto the raw snake_case `Purchase` from `@automattic/api-core`. `plan-details/index.tsx` was migrated and now hands its child `<PlanBillingPeriod>` the raw purchase, but the child was still typed against the camelCase data-stores shape and still called the `calypso/lib/purchases` helpers.

The raw purchase has no nested `payment` object (it uses flat `payment_type`, `payment_card_*` fields), so `isPaidWithCreditCard` read `purchase.payment.type` on an `undefined` value, throwing `TypeError: Cannot read properties of undefined (reading 'type')` and rendering the manage-purchase error boundary ("Sorry, there was an error loading this page"). Rather than re-wrap the purchase in a temporary `createPurchaseObject` bridge, this migrates the component to the raw shape — the end-state SHILL-2256 is driving toward.

## Testing Instructions

TC:
```
yarn test-client client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
```

Manual testing:
* On Jetpack Cloud staging, open a subscription's manage-purchase page (e.g. `/purchases/subscriptions/<site>/<id>`).
* Confirm the page loads with the "Billing period" section rendered instead of the error boundary, for both a monthly plan (shows "Billed monthly" + "Upgrade to yearly billing") and a yearly plan (shows "Billed yearly").
* Check the browser console — the `Cannot read properties of undefined (reading 'type')` TypeError should be gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)