### PR TITLE
Purchases: assemble Purchase passed to CancelPurchaseForm

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -863,11 +863,17 @@ class ManagePurchase extends Component<
 			return null;
 		}
 
+		// Temporary bridge (SHILL-2256): CancelPurchaseForm still expects the
+		// camelCase Purchase. Remove once it reads the raw shape.
 		return (
 			<CancelPurchaseForm
 				disableButtons={ this.state.isRemoving }
-				purchase={ purchase }
-				linkedPurchases={ this.getActiveMarketplaceSubscriptions() }
+				purchase={ createPurchaseObject(
+					purchase as unknown as Parameters< typeof createPurchaseObject >[ 0 ]
+				) }
+				linkedPurchases={ this.getActiveMarketplaceSubscriptions().map( ( p ) =>
+					createPurchaseObject( p as unknown as Parameters< typeof createPurchaseObject >[ 0 ] )
+				) }
 				isVisible={ this.state.isCancelSurveyVisible }
 				onClose={ this.closeDialog }
 				onSurveyComplete={ this.cancelSubscription }


### PR DESCRIPTION
Related to [SHILL-2256](https://linear.app/a8c/issue/SHILL-2256/)

## Proposed Changes

The `manage-purchase` page was migrated to pass the raw (snake_case) `Purchase` object from `@automattic/api-core`, but `CancelPurchaseForm` still reads camelCase fields. This runs the raw purchase through the legacy assembler (`createPurchaseObject`) before handing it to the form, so the cancel survey keeps working while the rest of the page uses the raw shape.

* Assemble the `purchase` prop passed to `CancelPurchaseForm` via `createPurchaseObject`.
* Assemble each entry of `linkedPurchases` (from `getActiveMarketplaceSubscriptions()`) the same way.
* Leave `flowType` reading the raw purchase (`getPurchaseCancellationFlowType` operates on the snake_case shape).

## Why are these changes being made?

`client/me/purchases/manage-purchase` was recently converted to use the raw `Purchase` object directly instead of the assembled, camelCase object (part of removing the purchases assembler, SHILL-2256). `CancelPurchaseForm` has not been converted yet and still expects camelCase props (`purchase.productSlug`, `purchase.siteId`, `purchase.id`, etc.), so passing it the raw object would silently break the cancel survey.

Rather than convert `CancelPurchaseForm` in this PR, this uses the same temporary "bridge" pattern already established elsewhere in the file — assembling the raw purchase at the call site — so the form continues to receive the shape it expects. The bridge is marked with the SHILL-2256 comment so it can be removed once `CancelPurchaseForm` reads the raw shape directly.

## Testing Instructions

Manual testing:
* Visit a purchase detail page: `/purchases/subscriptions/:site/:purchaseId` for a cancellable plan.
* Click the cancel/remove entry point to open the cancellation survey.
* Confirm the survey renders correctly (product name, options, downgrade offers where applicable) and that submitting the survey completes without console errors.
* For a plan with active Marketplace subscriptions, confirm the linked purchases are still handled correctly in the flow.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
