### PR TITLE
Purchases: show both plan and storage upgrade CTAs for Jetpack storage products

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -69,7 +69,7 @@ import { Plans, type SiteDetails } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { DOMAIN_CANCEL, SUPPORT_ROOT } from '@automattic/urls';
 import { useQuery } from '@tanstack/react-query';
-import { check, column, Icon, payment, reusableBlock, tool, trash, upload } from '@wordpress/icons';
+import { check, column, Icon, payment, reusableBlock, tool, trash, cloud } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize, LocalizeProps, useTranslate } from 'i18n-calypso';
 import moment from 'moment';
@@ -453,7 +453,7 @@ class ManagePurchase extends Component<
 		// Show the upgrade button without the primary style if both buttons are present
 		return (
 			<Button primary={ !! preventRenewal } compact href={ upgradeUrl }>
-				{ translate( 'Upgrade' ) }
+				{ translate( 'Upgrade plan' ) }
 			</Button>
 		);
 	}
@@ -711,16 +711,13 @@ class ManagePurchase extends Component<
 			return null;
 		}
 
-		let icon;
 		let buttonText;
 
 		if ( isExpiredOrRemoved( purchase ) ) {
-			icon = column;
 			buttonText = isUpgradeablePlan
 				? translate( 'Pick another plan' )
 				: translate( 'Pick another product' );
 		} else {
-			icon = upload;
 			buttonText = isUpgradeablePlan ? translate( 'Upgrade plan' ) : translate( 'Upgrade product' );
 		}
 
@@ -733,7 +730,7 @@ class ManagePurchase extends Component<
 				href={ upgradeUrl }
 				onClick={ this.handleUpgradeClick }
 			>
-				<Icon icon={ icon } className="card__icon" />
+				<Icon icon={ column } className="card__icon" />
 				{ buttonText }
 			</CompactCard>
 		);
@@ -771,7 +768,7 @@ class ManagePurchase extends Component<
 				href={ `/plans/storage/${ siteSlug }` }
 				onClick={ this.handleUpgradeClick }
 			>
-				<Icon icon={ upload } className="card__icon" />
+				<Icon icon={ cloud } className="card__icon" />
 				{ translate( 'Upgrade storage' ) }
 			</CompactCard>
 		);

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -458,6 +458,40 @@ class ManagePurchase extends Component<
 		);
 	}
 
+	renderStorageUpgradeButton( preventRenewal: boolean ) {
+		const { purchase, translate, siteSlug } = this.props;
+		if ( ! purchase ) {
+			return null;
+		}
+
+		if ( isPartnerPurchase( purchase ) || isA4ABillingDragonPurchase( purchase ) ) {
+			return null;
+		}
+
+		const isUpgradeableBackupProduct = (
+			JETPACK_BACKUP_T1_PRODUCTS as ReadonlyArray< string >
+		 ).includes( purchase.product_slug );
+		const isUpgradeableSecurityPlan = (
+			JETPACK_SECURITY_T1_PLANS as ReadonlyArray< string >
+		 ).includes( purchase.product_slug );
+
+		if ( ! isUpgradeableSecurityPlan && ! isUpgradeableBackupProduct ) {
+			return null;
+		}
+
+		if ( isExpiredOrRemoved( purchase ) ) {
+			return null;
+		}
+
+		// If the "renew now" button is showing, it will be using primary styles
+		// Show the upgrade button without the primary style if both buttons are present
+		return (
+			<Button primary={ !! preventRenewal } compact href={ `/plans/storage/${ siteSlug }` }>
+				{ translate( 'Upgrade storage' ) }
+			</Button>
+		);
+	}
+
 	renderRenewalNavItem( content: JSX.Element | string, onClick: () => void ) {
 		const { purchase } = this.props;
 		if ( ! purchase ) {
@@ -549,13 +583,6 @@ class ManagePurchase extends Component<
 			return null;
 		}
 
-		const isUpgradeableBackupProduct = (
-			JETPACK_BACKUP_T1_PRODUCTS as ReadonlyArray< string >
-		 ).includes( purchase.product_slug );
-		const isUpgradeableSecurityPlan = (
-			JETPACK_SECURITY_T1_PLANS as ReadonlyArray< string >
-		 ).includes( purchase.product_slug );
-
 		if ( isAkismetProduct( purchase ) ) {
 			// For the first Iteration of Calypso Akismet checkout we are only suggesting
 			// for immediate upgrades to the next plan. We will change this in the future
@@ -583,10 +610,6 @@ class ManagePurchase extends Component<
 					purchase.product_slug as keyof typeof JETPACK_STARTER_UPGRADE_MAP
 				];
 			return `/checkout/${ siteSlug }/${ upgradePlan }`;
-		}
-
-		if ( isUpgradeableBackupProduct || isUpgradeableSecurityPlan ) {
-			return `/plans/storage/${ siteSlug }`;
 		}
 
 		return `/plans/${ siteSlug }`;
@@ -1399,6 +1422,7 @@ class ManagePurchase extends Component<
 						{ isProductOwner && ! purchase.is_locked && (
 							<div className="manage-purchase__renew-upgrade-buttons">
 								{ this.renderUpgradeButton( preventRenewal ) }
+								{ this.renderStorageUpgradeButton( preventRenewal ) }
 								{ ! preventRenewal && this.renderRenewButton() }
 							</div>
 						) }

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -766,7 +766,7 @@ class ManagePurchase extends Component<
 				tagName="button"
 				displayAsLink
 				href={ `/plans/storage/${ siteSlug }` }
-				onClick={ this.handleUpgradeClick }
+				onClick={ this.handleUpgradeStorageClick }
 			>
 				<Icon icon={ cloud } className="card__icon" />
 				{ translate( 'Upgrade storage' ) }

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -577,6 +577,18 @@ class ManagePurchase extends Component<
 		} );
 	};
 
+	handleUpgradeStorageClick = () => {
+		const { purchase } = this.props;
+		if ( ! purchase ) {
+			return null;
+		}
+
+		recordTracksEvent( 'calypso_purchases_upgrade_storage', {
+			status: isExpiredOrRemoved( purchase ) ? 'expired' : 'active',
+			plan: purchase.product_name,
+		} );
+	};
+
 	getUpgradeUrl() {
 		const { purchase, siteSlug } = this.props;
 		if ( ! purchase ) {
@@ -723,6 +735,44 @@ class ManagePurchase extends Component<
 			>
 				<Icon icon={ icon } className="card__icon" />
 				{ buttonText }
+			</CompactCard>
+		);
+	}
+
+	renderUpgradeStorageNavItem() {
+		const { purchase, translate, siteSlug } = this.props;
+		if ( ! purchase ) {
+			return null;
+		}
+
+		if ( isPartnerPurchase( purchase ) || isA4ABillingDragonPurchase( purchase ) ) {
+			return null;
+		}
+
+		const isUpgradeableBackupProduct = (
+			JETPACK_BACKUP_T1_PRODUCTS as ReadonlyArray< string >
+		 ).includes( purchase.product_slug );
+		const isUpgradeableSecurityPlan = (
+			JETPACK_SECURITY_T1_PLANS as ReadonlyArray< string >
+		 ).includes( purchase.product_slug );
+
+		if ( ! isUpgradeableSecurityPlan && ! isUpgradeableBackupProduct ) {
+			return null;
+		}
+
+		if ( isExpiredOrRemoved( purchase ) ) {
+			return null;
+		}
+
+		return (
+			<CompactCard
+				tagName="button"
+				displayAsLink
+				href={ `/plans/storage/${ siteSlug }` }
+				onClick={ this.handleUpgradeClick }
+			>
+				<Icon icon={ upload } className="card__icon" />
+				{ translate( 'Upgrade storage' ) }
 			</CompactCard>
 		);
 	}
@@ -1458,6 +1508,7 @@ class ManagePurchase extends Component<
 						{ ! preventRenewal && renderMonthlyRenewalOption && this.renderRenewMonthlyNavItem() }
 						{ /* TODO: Add ability to Renew Akismet subscription */ }
 						{ this.renderUpgradeNavItem() }
+						{ this.renderUpgradeStorageNavItem() }
 						{ this.renderEditPaymentMethodNavItem() }
 						{ config.isEnabled( 'jetpack/crm-downloads' ) && this.renderCrmDownloadsNavItem() }
 						{ this.renderReinstall() }

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -337,11 +337,12 @@ describe( 'Purchase Management Buttons', () => {
 		}
 	);
 
-	// Storage-eligible Jetpack products (Backup T1 / Security T1) show two CTAs:
-	// the generic plan upgrade (/plans) plus a dedicated "Upgrade storage"
-	// (/plans/storage). Backup T1 exercises the shared render path without
-	// pulling in the Jetpack-plan plugin-keys query.
-	it( 'renders both a plan upgrade and a storage upgrade button for a storage-eligible product', async () => {
+	// Storage-eligible Jetpack products (Backup T1 / Security T1) show a plan
+	// upgrade CTA (/plans) plus a dedicated "Upgrade storage" CTA
+	// (/plans/storage), each rendered both in the button row and in the
+	// options list at the bottom. Backup T1 exercises the shared render path
+	// without pulling in the Jetpack-plan plugin-keys query.
+	it( 'renders both a plan upgrade and a storage upgrade CTA for a storage-eligible product', async () => {
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.2/me/payment-methods?expired=include' )
 			.reply( 200 );
@@ -363,13 +364,15 @@ describe( 'Purchase Management Buttons', () => {
 			</QueryClientProvider>
 		);
 
-		expect( await screen.findByText( 'Upgrade' ) ).toHaveAttribute(
+		expect( await screen.findByText( 'Upgrade plan' ) ).toHaveAttribute(
 			'href',
 			'/plans/onecooltestsite.com'
 		);
-		expect( screen.getByText( 'Upgrade storage' ) ).toHaveAttribute(
-			'href',
-			'/plans/storage/onecooltestsite.com'
+
+		const storageCtas = screen.getAllByText( 'Upgrade storage' );
+		expect( storageCtas ).toHaveLength( 2 );
+		storageCtas.forEach( ( cta ) =>
+			expect( cta ).toHaveAttribute( 'href', '/plans/storage/onecooltestsite.com' )
 		);
 	} );
 

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -9,6 +9,7 @@ import {
 	PRODUCT_AKISMET_ENTERPRISE_GT2M_MONTHLY,
 	PRODUCT_AKISMET_ENTERPRISE_GT2M_YEARLY,
 	AKISMET_UPGRADES_PRODUCTS_MAP,
+	PRODUCT_JETPACK_BACKUP_T1_YEARLY,
 } from '@automattic/calypso-products';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
@@ -335,6 +336,42 @@ describe( 'Purchase Management Buttons', () => {
 			expect( screen.queryByText( /Upgrade/ ) ).not.toBeInTheDocument();
 		}
 	);
+
+	// Storage-eligible Jetpack products (Backup T1 / Security T1) show two CTAs:
+	// the generic plan upgrade (/plans) plus a dedicated "Upgrade storage"
+	// (/plans/storage). Backup T1 exercises the shared render path without
+	// pulling in the Jetpack-plan plugin-keys query.
+	it( 'renders both a plan upgrade and a storage upgrade button for a storage-eligible product', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/me/payment-methods?expired=include' )
+			.reply( 200 );
+
+		const store = createMockReduxStoreForPurchase( {
+			...purchase,
+			product_slug: PRODUCT_JETPACK_BACKUP_T1_YEARLY,
+		} );
+
+		render(
+			<QueryClientProvider client={ queryClient }>
+				<ReduxProvider store={ store }>
+					<ManagePurchase
+						purchaseId={ Number( purchase.ID ) }
+						isSiteLevel
+						siteSlug="onecooltestsite.com"
+					/>
+				</ReduxProvider>
+			</QueryClientProvider>
+		);
+
+		expect( await screen.findByText( 'Upgrade' ) ).toHaveAttribute(
+			'href',
+			'/plans/onecooltestsite.com'
+		);
+		expect( screen.getByText( 'Upgrade storage' ) ).toHaveAttribute(
+			'href',
+			'/plans/storage/onecooltestsite.com'
+		);
+	} );
 
 	it( 'renders payment method nav item for A4A billingdragon purchase on a real site', async () => {
 		nock( 'https://public-api.wordpress.com' )


### PR DESCRIPTION
Related to CHE-517

## Proposed Changes

For Jetpack Backup T1 products and Security T1 plans, the classic manage-purchase page showed a single "Upgrade" button that pointed at the storage upgrade page (`/plans/storage`), leaving no path to a full plan upgrade. This splits it into two CTAs in both the plan header and footer areas for Calypso purchase management. A follow-up will be created for the Dashboard.

| Before | After |
| ----------- | ----------- |
| <img width="2074" height="236" alt="CleanShot 2026-07-24 at 11 38 59@2x" src="https://github.com/user-attachments/assets/bb60e4bb-d5d5-47ac-aefa-cddce687fb11" /> | <img width="2150" height="260" alt="CleanShot 2026-07-24 at 11 34 06@2x" src="https://github.com/user-attachments/assets/ae503fd2-a793-4615-a571-c09401a9087c" /> |
| <img width="2070" height="386" alt="CleanShot 2026-07-24 at 11 39 07@2x" src="https://github.com/user-attachments/assets/f13fb3aa-8caf-47b4-90c0-5edd6baf286a" /> | <img width="2136" height="500" alt="CleanShot 2026-07-24 at 11 34 13@2x" src="https://github.com/user-attachments/assets/fafa79a2-e32d-4746-b39c-01dc5c8b024a" /> |

* Updates "Upgrade" buttons to "Upgrade plan"
* Adds an additional CTA for "Upgrade storage" for Jetpack Backup and Jetpack Security

## Why are these changes being made?

Storage-eligible Jetpack products (e.g. Jetpack Security with a 10GB storage tier) previously only surfaced a storage-upgrade CTA (introduced in https://github.com/Automattic/wp-calypso/pull/58300), which blocked customers from moving up to a higher plan such as Jetpack Complete directly from the purchase page. Showing both the plan-upgrade and storage-upgrade CTAs gives a path to either action.

While applying this I also found and fixed a latent bug in the original work: the storage-button eligibility guard used `||` (`! isSecurity || ! isBackup`), which — since a slug can only ever be in one of the two disjoint lists — always returned early, so the button never rendered. Corrected to `&&` (bail only when the slug is in neither list).

## Testing Instructions

TC:
```
yarn test-client client/me/purchases/manage-purchase/test/purchase-management-buttons.js
```

Manual testing:
* On the classic manage-purchase page (e.g. Jetpack Cloud `/purchases/subscriptions/<site>/<id>`) for a Jetpack Security T1 plan or a Backup T1 product owned by the current user.
* Confirm two buttons render: "Upgrade" → `/plans/<site>` and "Upgrade storage" → `/plans/storage/<site>`.
* Confirm non-storage products (e.g. a regular plan) still show only the single "Upgrade" button, unchanged.