### PR TITLE
Purchases: assemble raw Purchase for 3 more manage-purchase children

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1240,7 +1240,14 @@ class ManagePurchase extends Component<
 
 				<span className="manage-purchase__settings-link">
 					{ ! isJetpackCloud() && site && (
-						<ProductLink purchase={ purchase } selectedSite={ site } />
+						// Temporary bridge (SHILL-2256): ProductLink still expects the
+						// camelCase Purchase. Remove once it reads the raw shape.
+						<ProductLink
+							purchase={ createPurchaseObject(
+								purchase as unknown as Parameters< typeof createPurchaseObject >[ 0 ]
+							) }
+							selectedSite={ site }
+						/>
 					) }
 				</span>
 
@@ -1367,7 +1374,15 @@ class ManagePurchase extends Component<
 		return (
 			<Fragment>
 				{ ( this.props.showHeader ?? true ) && (
-					<PurchaseSiteHeader siteId={ siteId } name={ siteName } purchase={ purchase } />
+					// Temporary bridge (SHILL-2256): PurchaseSiteHeader still expects the
+					// camelCase Purchase. Remove once it reads the raw shape.
+					<PurchaseSiteHeader
+						siteId={ siteId }
+						name={ siteName }
+						purchase={ createPurchaseObject(
+							purchase as unknown as Parameters< typeof createPurchaseObject >[ 0 ]
+						) }
+					/>
 				) }
 				<Card className={ classes }>
 					<header className="manage-purchase__header">
@@ -1676,6 +1691,11 @@ function PlanOverlapNotice( {
 	siteId: number;
 	purchase: Purchase;
 } ) {
+	// Temporary bridge (SHILL-2256): ProductPlanOverlapNotices still expects the
+	// camelCase Purchase. Remove once it reads the raw shape.
+	const currentPurchase = createPurchaseObject(
+		purchase as unknown as Parameters< typeof createPurchaseObject >[ 0 ]
+	);
 	if ( isSiteLevel ) {
 		if ( ! selectedSiteId ) {
 			// Probably still loading
@@ -1688,7 +1708,7 @@ function PlanOverlapNotice( {
 				plans={ JETPACK_PLANS }
 				products={ JETPACK_PRODUCTS_LIST }
 				siteId={ selectedSiteId }
-				currentPurchase={ purchase }
+				currentPurchase={ currentPurchase }
 			/>
 		);
 	}
@@ -1703,7 +1723,7 @@ function PlanOverlapNotice( {
 			plans={ JETPACK_PLANS }
 			products={ JETPACK_PRODUCTS_LIST }
 			siteId={ siteId }
-			currentPurchase={ purchase }
+			currentPurchase={ currentPurchase }
 		/>
 	);
 }


### PR DESCRIPTION
Related to [SHILL-2256](https://linear.app/a8c/issue/SHILL-2256/)

## Proposed Changes

Follow-up to the CancelPurchaseForm assembler bridge: three more children of `manage-purchase` still read camelCase `Purchase` fields but now receive the raw (snake_case) `Purchase` from `@automattic/api-core`. This runs the raw purchase through the legacy assembler (`createPurchaseObject`) at each call site so those components keep working.

* `ProductLink` — assemble the `purchase` prop at the call site (reads `productSlug` via calypso-products predicates and `siteId` in its `connect`).
* `PurchaseSiteHeader` — assemble the `purchase` prop at the call site (reads `isAttachedToHoldingSite`).
* `PlanOverlapNotice` — assemble once and pass the assembled object as `currentPurchase` in both branches (`ProductPlanOverlapNotices` reads `productSlug` and `isJetpackProduct`).

## Why are these changes being made?

`client/me/purchases/manage-purchase` was migrated to pass the raw `Purchase` object directly (part of removing the purchases assembler, SHILL-2256). These three children have not been converted yet and still expect camelCase props, so passing them the raw object silently breaks them: `ProductLink` would render no settings link, `PurchaseSiteHeader` would fail its holding-site guard, and `PlanOverlapNotice` would compare against `undefined` product slugs.

Rather than convert each component in this PR, this uses the same temporary "bridge" pattern already established elsewhere in the file — assembling the raw purchase at the call site — so the components continue to receive the shape they expect. Each bridge is marked with the SHILL-2256 comment so it can be removed once the component reads the raw shape directly.

## Testing Instructions

Manual testing:
* Visit a purchase detail page: `/purchases/subscriptions/:site/:purchaseId`.
* For a plan/domain/email/theme purchase, confirm the settings link ("Plan Features", "Domain Settings", "Email Settings", "Theme Details") renders and points to the correct place (`ProductLink`).
* Confirm the site header renders correctly, and that a purchase attached to a holding site (Akismet/Jetpack/Marketplace/A4A) hides the header (`PurchaseSiteHeader`).
* On a Jetpack site with overlapping plan/product coverage, confirm the plan-overlap notice still appears (`PlanOverlapNotice`).
* Confirm there are no console errors on any of these pages.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
