### PR TITLE
Stats: Re-anchor UTM modal styles off the Modal portal root

### DIFF
--- a/client/my-sites/stats/AGENTS.md
+++ b/client/my-sites/stats/AGENTS.md
@@ -144,6 +144,8 @@ This code is shared with Odyssey Stats (`apps/odyssey-stats/`). When making chan
 
 Odyssey's build scopes first-party CSS to `.jp-stats-dashboard` plus a fixed list of known portal-root classes/attributes (see `apps/odyssey-stats/AGENTS.md` > CSS Scoping). Any new modal/dialog/popover/tooltip mechanism added here (e.g. `@wordpress/components` `Modal`, a new `Popover`/`Tooltip` library) that renders via `createPortal` to an *unlisted* root will silently lose its styling in Odyssey even though it looks fine in Calypso — update that prefix list when introducing one.
 
+**Never nest styles under a class that is itself a portal root.** Prefixing prepends the portal root as an *ancestor*, so a rule nested under a class you passed as `overlayClassName` (or any other class landing on the portal root element) compiles to something asking for that element to be its own descendant — it can never match, and it fails silently in Odyssey while working fine in Calypso. Anchor on a real descendant instead: pass `className` to `Modal` to style `.components-modal__frame`, or lead with an inner wrapper class. When compounding with a `@wordpress/components` base class to hold specificity, remember the `:where()` prefix adds none.
+
 ## Key Hooks Reference
 
 | Hook                          | Purpose                             |

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
@@ -83,6 +83,7 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger, initialData }
 				<Modal
 					title={ translate( 'Generate URL' ) }
 					onRequestClose={ closeModal }
+					className="stats-utm-builder__frame"
 					overlayClassName={ utmBuilderClasses }
 					bodyOpenClassName="stats-utm-builder__body-modal-open"
 				>

--- a/client/my-sites/stats/stats-module-utm-builder/style.scss
+++ b/client/my-sites/stats/stats-module-utm-builder/style.scss
@@ -13,22 +13,26 @@ $modal-content-padding: 32px;
 	overflow: hidden;
 }
 
-.stats-utm-builder__overlay {
+// Anchored on the modal frame, never on `.stats-utm-builder__overlay`: that class is the
+// Modal's portal root, and Odyssey prefixes first-party CSS with the portal root as an
+// ancestor, so nesting under it asks for the overlay inside itself and never matches.
+// The frame is a real descendant, so the same rules survive prefixing.
+.stats-utm-builder__frame {
 	@media (min-width: $break-large) {
-		.components-modal__frame {
+		// Compound with the base class to keep specificity over @wordpress/components' own
+		// `.components-modal__frame` max-height, which the prefix's `:where()` doesn't add to.
+		&.components-modal__frame {
 			max-height: 85%;
 		}
 	}
 
-	.components-modal__header {
+	// Mirrors @wordpress/components' own `.components-modal__header .components-modal__header-heading`
+	// so this outranks it — the prefix's `:where()` adds no specificity of its own.
+	.components-modal__header .components-modal__header-heading {
 		font-family: $font-recoleta;
-	
-		// Overwrite the modal's class
-		h1.components-modal__header-heading {
-			font-size: 32px;
-			line-height: 39px;
-			font-weight: 400;
-		}
+		font-size: 32px;
+		line-height: 39px;
+		font-weight: 400;
 	}
 }
 
@@ -41,11 +45,7 @@ $modal-content-padding: 32px;
 	}
 }
 
-// Focused-field outline follows the admin accent. Deliberately not nested
-// under `.stats-utm-builder__overlay`: that class is the Modal's portal root,
-// and Odyssey prefixes CSS with the portal root as an ancestor — nesting would
-// ask for the overlay inside itself and never match. Leading with the fields
-// wrapper keeps a valid descendant chain; `input[type="text"]` outranks the
+// Focused-field outline follows the admin accent. `input[type="text"]` outranks the
 // base `.form-text-input:focus` rule.
 .stats-utm-builder__fields input[type="text"].form-text-input:focus {
 	border-color: var(--color-accent);


### PR DESCRIPTION
Fixes STATS-352

## Why

On self-hosted (Odyssey) Stats, the UTM "Generate URL" modal ignored its own height cap on large screens, so on tall viewports it stretched further down the page than intended instead of stopping at 85% of the window. Same modal on WordPress.com was unaffected. This restores the intended sizing everywhere, and removes a class of styling bug that fails silently — where a rule looks correct in the source, works on WordPress.com, and is quietly dead in self-hosted Stats.

No visual change on WordPress.com.

## Proposed Changes

* Pass a new `stats-utm-builder__frame` class as the `Modal`'s `className` (it lands on `.components-modal__frame`) and re-anchor the modal's `max-height` and heading typography rules on it, instead of nesting them under `.stats-utm-builder__overlay`.
* Compound the `max-height` rule with `.components-modal__frame` so it keeps specificity over `@wordpress/components`' own rule — Odyssey's `:where()` prefix contributes no specificity, unlike the old two-class descendant selector.
* Move `font-family: $font-recoleta` from `.components-modal__header` onto the heading itself. See below — leaving it on the header would have applied Recoleta in Odyssey for the first time, and Odyssey doesn't want it.
* Drop the now-redundant per-rule explanation on the focus-outline rule; the reasoning lives once above the frame block.
* Document the general rule in `client/my-sites/stats/AGENTS.md`: never nest styles under a class that is itself a portal root.

## Why are these changes being made?

`.stats-utm-builder__overlay` is passed to `Modal` as `overlayClassName`, so it lands **on** the `.components-modal__screen-overlay` element rather than inside it. #112498 added `postcss-prefix-selector` to the Odyssey build, prefixing first-party selectors with a `:where()` list that includes `.components-modal__screen-overlay` as a scope root. Every rule nested under `.stats-utm-builder__overlay` therefore compiled to:

```
:where(…, .components-modal__screen-overlay) .stats-utm-builder__overlay …
```

which asks the overlay to be a descendant of itself and can never match.

Three rules were affected. Only one had a visible effect:

| Rule | Impact in Odyssey |
| --- | --- |
| `.components-modal__frame { max-height: 85% }` above `$break-large` | **Dead.** Fell back to `@wordpress/components`' base `max-height: calc(100% - 40px)` |
| `h1.components-modal__header-heading` size/weight/line-height | Dead, but no visible effect — `apps/odyssey-stats/src/styles/typography.scss` deliberately overrides all four properties with the Jetpack header style, and that override escapes prefixing because it compiles into the ignored `app.scss` |
| `.components-modal__header { font-family: recoleta }` | Dead, negligible — the heading is overridden as above and the only other header content is an icon-only close button. **Moved onto the heading** rather than re-anchored on the header |

Anchoring on the frame gives a valid descendant chain (the frame is a direct child of the overlay), so all three rules match again.

Recoleta moves onto the heading rather than staying on the header because re-anchoring the header rule as-is would have made it live in Odyssey for the first time, applying a WordPress.com brand font on an element the Jetpack typography deliberately overrides. The heading was the only thing in the header the font ever reached, so WordPress.com renders identically either way. The selector mirrors `@wordpress/components`' own `.components-modal__header .components-modal__header-heading` so it outranks that rule's `font-size: 20px; font-weight: 600` on specificity rather than on bundle order; Odyssey's `(0,4,0)` override still wins over it.

## Testing Instructions

Verified by running the shipped scope options (`apps/odyssey-stats/webpack-css-scope.js`) through `postcss-prefix-selector` over the compiled stylesheet. Before, all three rules resolved to `:where(…) .stats-utm-builder__overlay …`; after, the remaining rules resolve to `:where(…, .components-modal__screen-overlay) .stats-utm-builder__frame …`, which matches.

To check in a browser:

**Self-hosted Jetpack (Odyssey)**
1. Build Odyssey Stats and load Jetpack → Stats in wp-admin on a viewport taller than ~960px wide.
2. Open a Traffic page, expand the UTM module, and click the URL Builder (link icon) to open **Generate URL**.
3. The modal should stop at 85% of the window height. Before this change it extended to `100% - 40px`.
4. Confirm the modal heading is unchanged — it uses the Jetpack header font, not Recoleta.

**WordPress.com**
1. Open the same modal from a site's Stats → Traffic page.
2. Confirm no visual change: heading is Recoleta 32px, modal caps at 85% height on large screens.

Note: not exercised in a live browser in either environment — verification was on the compiled CSS. Worth a visual pass on a self-hosted site before merge.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XfMY8FJwyDrUa1o7sPPvC
