### PR TITLE
Security: update Immutable to 4.3.9

### DIFF
--- a/.yarn/patches/draft-js-npm-0.11.7-ea66f83002.patch
+++ b/.yarn/patches/draft-js-npm-0.11.7-ea66f83002.patch
@@ -1,0 +1,108 @@
+diff --git a/lib/ContentState.js b/lib/ContentState.js
+index 2bb77556e46adde8accd5da672f0ef17b31b8369..fe45a8fdb759c82866f42d597360d41b835d37cc 100644
+--- a/lib/ContentState.js
++++ b/lib/ContentState.js
+@@ -112,7 +112,7 @@ var ContentState = /*#__PURE__*/function (_ContentStateRecord) {
+   };
+ 
+   _proto.getBlocksAsArray = function getBlocksAsArray() {
+-    return this.getBlockMap().toArray();
++    return this.getBlockMap().valueSeq().toArray();
+   };
+ 
+   _proto.getFirstBlock = function getFirstBlock() {
+diff --git a/lib/ContentState.js.flow b/lib/ContentState.js.flow
+index 987f5e34ce8e5203b01753d1cbfa1ed2680132a6..d3df4b1898e016b537de87f1a685628368f14841 100644
+--- a/lib/ContentState.js.flow
++++ b/lib/ContentState.js.flow
+@@ -108,7 +108,7 @@ class ContentState extends ContentStateRecord {
+   }
+ 
+   getBlocksAsArray(): Array<BlockNodeRecord> {
+-    return this.getBlockMap().toArray();
++    return this.getBlockMap().valueSeq().toArray();
+   }
+ 
+   getFirstBlock(): BlockNodeRecord {
+diff --git a/lib/DraftTreeInvariants.js b/lib/DraftTreeInvariants.js
+index 496d4a3abbce83f7c5838b649cd38dfa82c89784..e6ca538d678bfaa65a41b9e5e12e64e02b29d3ac 100644
+--- a/lib/DraftTreeInvariants.js
++++ b/lib/DraftTreeInvariants.js
+@@ -96,7 +96,7 @@ var DraftTreeInvariants = {
+    */
+   isConnectedTree: function isConnectedTree(blockMap) {
+     // exactly one node has no previous sibling + no parent
+-    var eligibleFirstNodes = blockMap.toArray().filter(function (block) {
++    var eligibleFirstNodes = blockMap.valueSeq().toArray().filter(function (block) {
+       return block.getParentKey() == null && block.getPrevSiblingKey() == null;
+     });
+ 
+@@ -159,7 +159,7 @@ var DraftTreeInvariants = {
+   isValidTree: function isValidTree(blockMap) {
+     var _this = this;
+ 
+-    var blocks = blockMap.toArray();
++    var blocks = blockMap.valueSeq().toArray();
+ 
+     if (!blocks.every(function (block) {
+       return _this.isValidBlock(block, blockMap);
+diff --git a/lib/DraftTreeInvariants.js.flow b/lib/DraftTreeInvariants.js.flow
+index e2b713c4fd15749a759e12dbf7fe51dd8d43e166..d9ac319db2d80028bbe6296da42705b35f383fc9 100644
+--- a/lib/DraftTreeInvariants.js.flow
++++ b/lib/DraftTreeInvariants.js.flow
+@@ -93,7 +93,7 @@ const DraftTreeInvariants = {
+    */
+   isConnectedTree(blockMap: BlockMap): boolean {
+     // exactly one node has no previous sibling + no parent
+-    const eligibleFirstNodes = blockMap.toArray().filter(block => block.getParentKey() == null && block.getPrevSiblingKey() == null);
++    const eligibleFirstNodes = blockMap.valueSeq().toArray().filter(block => block.getParentKey() == null && block.getPrevSiblingKey() == null);
+ 
+     if (eligibleFirstNodes.length !== 1) {
+       warning(true, 'Tree is not connected. More or less than one first node');
+@@ -147,7 +147,7 @@ const DraftTreeInvariants = {
+    * Checks that the block map is a connected tree with valid blocks
+    */
+   isValidTree(blockMap: BlockMap): boolean {
+-    const blocks = blockMap.toArray();
++    const blocks = blockMap.valueSeq().toArray();
+ 
+     if (!blocks.every(block => this.isValidBlock(block, blockMap))) {
+       return false;
+diff --git a/lib/randomizeBlockMapKeys.js b/lib/randomizeBlockMapKeys.js
+index 2da51d665ac373b60547a555e08f0a8484f15765..f44725e7e1f8b77a3f6189febb412243912ef423 100644
+--- a/lib/randomizeBlockMapKeys.js
++++ b/lib/randomizeBlockMapKeys.js
+@@ -84,13 +84,13 @@ var randomizeContentBlockNodeKeys = function randomizeContentBlockNodeKeys(block
+         }
+       });
+     });
+-  }).toArray().map(function (block) {
++  }).valueSeq().toArray().map(function (block) {
+     return [newKeysRef[block.getKey()], block.set('key', newKeysRef[block.getKey()])];
+   }));
+ };
+ 
+ var randomizeContentBlockKeys = function randomizeContentBlockKeys(blockMap) {
+-  return OrderedMap(blockMap.toArray().map(function (block) {
++  return OrderedMap(blockMap.valueSeq().toArray().map(function (block) {
+     var key = generateRandomKey();
+     return [key, block.set('key', key)];
+   }));
+diff --git a/lib/randomizeBlockMapKeys.js.flow b/lib/randomizeBlockMapKeys.js.flow
+index 9ef399472ffbcafe280d2f44f50c56c553808aa9..0e9d8898aa1f7c6016058dc5bc66f9f2ebe1a8b6 100644
+--- a/lib/randomizeBlockMapKeys.js.flow
++++ b/lib/randomizeBlockMapKeys.js.flow
+@@ -86,11 +86,11 @@ const randomizeContentBlockNodeKeys = (blockMap: BlockMap): BlockMap => {
+         }
+       });
+     });
+-  }).toArray().map(block => [newKeysRef[block.getKey()], block.set('key', newKeysRef[block.getKey()])]));
++  }).valueSeq().toArray().map(block => [newKeysRef[block.getKey()], block.set('key', newKeysRef[block.getKey()])]));
+ };
+ 
+ const randomizeContentBlockKeys = (blockMap: BlockMap): BlockMap => {
+-  return OrderedMap(blockMap.toArray().map(block => {
++  return OrderedMap(blockMap.valueSeq().toArray().map(block => {
+     const key = generateRandomKey();
+     return [key, block.set('key', key)];
+   }));

--- a/client/components/title-format-editor/test/index.jsx
+++ b/client/components/title-format-editor/test/index.jsx
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { TitleFormatEditor } from '..';
+
+describe( 'TitleFormatEditor', () => {
+	beforeAll( () => {
+		window.scrollTo = jest.fn();
+	} );
+
+	test( 'adds a token to the Draft.js editor state', () => {
+		const onChange = jest.fn();
+
+		render(
+			<TitleFormatEditor
+				onChange={ onChange }
+				shouldShowSeoArchiveTitleButton={ false }
+				titleData={ {
+					post: { title: 'Example title' },
+					site: { description: 'Example tagline', name: 'Example site' },
+				} }
+				titleFormats={ [] }
+				tokens={ { siteName: 'Site Name' } }
+				translate={ ( value ) => value }
+				type={ { label: 'Post title', value: 'posts' } }
+			/>
+		);
+
+		fireEvent.click( screen.getByText( 'Site Name' ) );
+
+		expect( onChange ).toHaveBeenCalledWith( 'posts', [ { type: 'siteName' } ] );
+	} );
+} );

--- a/client/components/title-format-editor/test/parser.js
+++ b/client/components/title-format-editor/test/parser.js
@@ -1,0 +1,43 @@
+import { Modifier, SelectionState } from 'draft-js';
+import { fromEditor, toEditor } from '../parser';
+
+describe( 'title format editor parser', () => {
+	test( 'round-trips text and token entities through Draft.js', () => {
+		const format = [
+			{ type: 'postTitle' },
+			{ type: 'string', value: ' | ' },
+			{ type: 'siteName' },
+		];
+		const tokens = {
+			postTitle: 'Post Title',
+			siteName: 'Site Name',
+		};
+
+		expect( fromEditor( toEditor( format, tokens ) ) ).toEqual( format );
+	} );
+
+	test( 'supports text, paste, and token removal operations', () => {
+		const tokens = { siteName: 'Site Name' };
+		const content = toEditor(
+			[ { type: 'string', value: 'Hello' }, { type: 'siteName' } ],
+			tokens
+		);
+		const block = content.getFirstBlock();
+		const textEnd = SelectionState.createEmpty( block.getKey() ).merge( {
+			anchorOffset: 5,
+			focusOffset: 5,
+		} );
+		const fragment = toEditor( [ { type: 'string', value: ' world' } ], {} ).getBlockMap();
+		const withPaste = Modifier.replaceWithFragment( content, textEnd, fragment );
+		const tokenStart = 11;
+		const tokenEnd = withPaste.getFirstBlock().getLength();
+		const tokenRange = SelectionState.createEmpty( block.getKey() ).merge( {
+			anchorOffset: tokenStart,
+			focusOffset: tokenEnd,
+		} );
+
+		expect( fromEditor( Modifier.removeRange( withPaste, tokenRange, 'forward' ) ) ).toEqual( [
+			{ type: 'string', value: 'Hello world' },
+		] );
+	} );
+} );

--- a/client/package.json
+++ b/client/package.json
@@ -150,7 +150,7 @@
 		"deepmerge": "^4.3.1",
 		"diff": "^4.0.2",
 		"dompurify": "3.4.12",
-		"draft-js": "^0.11.7",
+		"draft-js": "patch:draft-js@npm%3A0.11.7#~/.yarn/patches/draft-js-npm-0.11.7-ea66f83002.patch",
 		"duplicate-package-checker-webpack-plugin": "^3.0.0",
 		"email-validator": "^2.0.4",
 		"emoji-text": "^0.2.6",

--- a/package.json
+++ b/package.json
@@ -355,7 +355,7 @@
 		"dompurify@npm:^3.3.1": "3.4.11",
 		"dompurify@npm:^3.3.3": "3.4.11",
 		"flatted@npm:^2.0.0": "3.4.2",
-		"immutable@npm:~3.7.4": "3.8.3",
+		"immutable@npm:~3.7.4": "4.3.9",
 		"js-yaml@npm:^4.1.0": "4.3.0",
 		"js-yaml@npm:^4.1.1": "4.3.0",
 		"js-yaml@npm:^3.13.1": "4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14392,7 +14392,7 @@ __metadata:
     deepmerge: "npm:^4.3.1"
     diff: "npm:^4.0.2"
     dompurify: "npm:3.4.12"
-    draft-js: "npm:^0.11.7"
+    draft-js: "patch:draft-js@npm%3A0.11.7#~/.yarn/patches/draft-js-npm-0.11.7-ea66f83002.patch"
     duplicate-package-checker-webpack-plugin: "npm:^3.0.0"
     email-validator: "npm:^2.0.4"
     emoji-text: "npm:^0.2.6"
@@ -16954,7 +16954,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"draft-js@npm:^0.11.7":
+"draft-js@npm:0.11.7":
   version: 0.11.7
   resolution: "draft-js@npm:0.11.7"
   dependencies:
@@ -16965,6 +16965,20 @@ __metadata:
     react: ">=0.14.0"
     react-dom: ">=0.14.0"
   checksum: 25943c73cbacf7e00e3ee6bef3496feffe14f09c436cec9233a4fc1bb2b4302f2bcf5fc66f4a5f8e3a9135808d20783aff75e42659da3b21d50f63185bedf557
+  languageName: node
+  linkType: hard
+
+"draft-js@patch:draft-js@npm%3A0.11.7#~/.yarn/patches/draft-js-npm-0.11.7-ea66f83002.patch":
+  version: 0.11.7
+  resolution: "draft-js@patch:draft-js@npm%3A0.11.7#~/.yarn/patches/draft-js-npm-0.11.7-ea66f83002.patch::version=0.11.7&hash=4a6e84"
+  dependencies:
+    fbjs: "npm:^2.0.0"
+    immutable: "npm:~3.7.4"
+    object-assign: "npm:^4.1.1"
+  peerDependencies:
+    react: ">=0.14.0"
+    react-dom: ">=0.14.0"
+  checksum: 55003f185778ee9133c378a44aacfb875ef68f35f36eabe7effc048674ebcdf5044ab1d6dcf34069e7dca65d2df408f6b971cd5fa3ece4216b9810131d9fcf83
   languageName: node
   linkType: hard
 
@@ -20616,14 +20630,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:3.8.3":
-  version: 3.8.3
-  resolution: "immutable@npm:3.8.3"
-  checksum: bafa7b8371b7622bc3d128cd9e6bba3a654b968f09a237929629f43ac26f7e974a5879cd38baad0c26f6f0628753968611bf832add7bf0c44d647bf4306a2988
-  languageName: node
-  linkType: hard
-
-"immutable@npm:^4.0.0":
+"immutable@npm:4.3.9, immutable@npm:^4.0.0":
   version: 4.3.9
   resolution: "immutable@npm:4.3.9"
   checksum: 394faa90ac8f2f62824e6c639705efdb8313787d6bc7864e28a48ee36aa2ba4b724eaf54a701ad991c278967a412b09143dd24fd19e3e2b0204eb481a5afa6ef


### PR DESCRIPTION
Related security alerts:
- https://github.com/Automattic/wp-calypso/security/dependabot/519
- https://github.com/Automattic/wp-calypso/security/dependabot/521

## Proposed Changes

* Resolve Draft.js's transitive Immutable dependency to patched version 4.3.9.
* Patch Draft.js 0.11.7 so keyed block maps retain their expected value-only behavior under Immutable 4.
* Add focused coverage for title-format rendering, token insertion, serialization, paste, and token removal.

## Why are these changes being made?

* Immutable versions before 4.3.9 are affected by two high-severity denial-of-service advisories.
* Draft.js 0.11.7 pins Immutable 3 and has no newer release. A direct override breaks title-format rendering because Immutable 4 changed `KeyedCollection.toArray()` to return key-value tuples.
* The scoped Yarn patch restores Draft.js's expected block values while allowing the vulnerable Immutable 3.8.3 lock entry to be removed.

## Testing Instructions

* Run `yarn install --immutable`.
* Run `yarn test-client client/components/title-format-editor/test --runInBand`.
* Run `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client`.
* Confirm `yarn why immutable` resolves Draft.js to Immutable 4.3.9 and contains no Immutable 3.x install.
* Confirm the title format editor renders and supports adding and removing a token in SEO title settings.

## Pre-merge Checklist

<!-- Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
