### PR TITLE
Rename cookie banner chunk to avoid content blocker filters

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -61,7 +61,7 @@ import type { WpcomRequestParams } from 'wpcom-proxy-request';
 
 const loadCookieBanner = () =>
 	import(
-		/* webpackChunkName: "async-load-calypso-blocks-cookie-banner" */ 'calypso/blocks/cookie-banner'
+		/* webpackChunkName: "async-load-calypso-blocks-privacy-prefs" */ 'calypso/blocks/cookie-banner'
 	);
 const loadGlobalNotices = () =>
 	import(

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -122,7 +122,7 @@ const loadSupportArticleDialog = () =>
 	);
 const loadCookieBanner = () =>
 	import(
-		/* webpackChunkName: "async-load-calypso-blocks-cookie-banner" */ 'calypso/blocks/cookie-banner'
+		/* webpackChunkName: "async-load-calypso-blocks-privacy-prefs" */ 'calypso/blocks/cookie-banner'
 	);
 const loadAppBanner = () =>
 	import(


### PR DESCRIPTION
Fixes p1784856717202709-slack-C025Q5RK2

## Proposed Changes

* Rename the async cookie banner chunk to `async-load-calypso-blocks-privacy-prefs`. Only the `webpackChunkName` comment changes; the module path stays `calypso/blocks/cookie-banner`.

## Why are these changes being made?

* Brave and other browsers running EasyList Cookie filters block URLs containing `cookie-banner`, so `async-load-calypso-blocks-cookie-banner.<hash>.min.css` never loads.
* `AsyncLoad` uses `React.lazy`, which throws during render when the import rejects. Stepper has no error boundary, so the throw unmounts the whole tree — `/setup/onboarding/user` renders blank with `ChunkLoadError`.

Follow-up: wrap `AsyncLoad`'s lazy component in an error boundary so any failed chunk degrades instead of blanking the app. This rename only dodges today's filter rules.

## Testing Instructions

The banner is off in development, and the flag is read server-side, so restart the dev server:

```bash
ENABLE_FEATURES=cookie-banner yarn start
```

In DevTools → Network → Network request blocking, add `*cookie-banner*` as the only pattern, then load `http://calypso.localhost:3000/setup/onboarding/user`.

* On trunk: blank page, `ChunkLoadError` in console.
* On this branch: page renders, banner appears.

Note: blocking `*privacy-prefs*` still blanks the page. That's expected — it blocks the renamed chunk itself, which is what the follow-up addresses.

EU users on Brave had the banner suppressed because its stylesheet was blocked; they will now see it.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?