### PR TITLE
Prevent ad-blocked cookie-banner chunk from crashing onboarding/login

### DIFF
--- a/client/components/async-load/index.tsx
+++ b/client/components/async-load/index.tsx
@@ -1,4 +1,4 @@
-import { lazy, useMemo, Suspense, type ComponentType, type ReactNode } from 'react';
+import { Component, lazy, useMemo, Suspense, type ComponentType, type ReactNode } from 'react';
 
 import './style.scss';
 
@@ -6,22 +6,55 @@ const DEFAULT_PLACEHOLDER = <div className="async-load__placeholder" />;
 
 type RequireCallback = () => Promise< { default: ComponentType< any > } >;
 
+/**
+ * Contains errors thrown while loading or rendering the async component — most
+ * importantly a failed dynamic `import()`, which happens when an ad blocker
+ * blocks the chunk request. Without this, that rejection propagates to the React
+ * root and unmounts the whole app. Opt in via the `errorBoundary` prop.
+ */
+class AsyncLoadErrorBoundary extends Component< { children: ReactNode }, { hasError: boolean } > {
+	state = { hasError: false };
+
+	static getDerivedStateFromError() {
+		return { hasError: true };
+	}
+
+	componentDidCatch( error: Error ) {
+		// Keep the failure observable now that it no longer surfaces as a crash.
+		// eslint-disable-next-line no-console
+		console.error( 'AsyncLoad failed to load its component:', error );
+	}
+
+	render() {
+		return this.state.hasError ? null : this.props.children;
+	}
+}
+
 type AsyncLoadProps = {
 	placeholder?: ReactNode;
 	require: RequireCallback;
+	/**
+	 * Contain a failed load instead of letting it crash the app. Off by default
+	 * so existing callers are unaffected; turn it on where the async component is
+	 * optional and its chunk may be blocked (e.g. by an ad blocker).
+	 */
+	errorBoundary?: boolean;
 	[ key: string ]: unknown;
 };
 
 export default function AsyncLoad( {
 	placeholder = DEFAULT_PLACEHOLDER,
 	require,
+	errorBoundary = false,
 	...props
 }: AsyncLoadProps ) {
-	const Component = useMemo( () => lazy( require ), [ require ] );
+	const LazyComponent = useMemo( () => lazy( require ), [ require ] );
 
-	return (
+	const content = (
 		<Suspense fallback={ placeholder }>
-			<Component { ...props } />
+			<LazyComponent { ...props } />
 		</Suspense>
 	);
+
+	return errorBoundary ? <AsyncLoadErrorBoundary>{ content }</AsyncLoadErrorBoundary> : content;
 }

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -59,10 +59,12 @@ import type { CurrentUser, HelpCenterSelect, HelpCenterDispatch } from '@automat
 import type { AnyAction } from 'redux';
 import type { WpcomRequestParams } from 'wpcom-proxy-request';
 
+// Chunk name deliberately avoids "cookie"/"banner": ad blockers match those in
+// request URLs, and this chunk is a dependency of pages (onboarding, login) that
+// break outright if it fails to load. Keep it in sync with the other importer in
+// client/layout/index.jsx.
 const loadCookieBanner = () =>
-	import(
-		/* webpackChunkName: "async-load-calypso-blocks-cookie-banner" */ 'calypso/blocks/cookie-banner'
-	);
+	import( /* webpackChunkName: "async-load-calypso-blocks-cb" */ 'calypso/blocks/cookie-banner' );
 const loadGlobalNotices = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-components-global-notices" */ 'calypso/components/global-notices'
@@ -275,7 +277,7 @@ async function main() {
 					<BrowserRouter basename="setup">
 						<FlowRenderer flow={ flow } steps={ flowSteps } />
 						{ config.isEnabled( 'cookie-banner' ) && (
-							<AsyncLoad require={ loadCookieBanner } placeholder={ null } />
+							<AsyncLoad require={ loadCookieBanner } placeholder={ null } errorBoundary />
 						) }
 						<AsyncLoad require={ loadGlobalNotices } placeholder={ null } id="notices" />
 					</BrowserRouter>

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -120,10 +120,12 @@ const loadSupportArticleDialog = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-blocks-support-article-dialog" */ 'calypso/blocks/support-article-dialog'
 	);
+// Chunk name deliberately avoids "cookie"/"banner": ad blockers match those in
+// request URLs, and this chunk is a dependency of pages (onboarding, login) that
+// break outright if it fails to load. Keep it in sync with the other importer in
+// client/landing/stepper/index.tsx.
 const loadCookieBanner = () =>
-	import(
-		/* webpackChunkName: "async-load-calypso-blocks-cookie-banner" */ 'calypso/blocks/cookie-banner'
-	);
+	import( /* webpackChunkName: "async-load-calypso-blocks-cb" */ 'calypso/blocks/cookie-banner' );
 const loadAppBanner = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-blocks-app-banner" */ 'calypso/blocks/app-banner'
@@ -439,7 +441,7 @@ class Layout extends Component {
 					<AsyncLoad require={ loadSupportArticleDialog } placeholder={ null } />
 				) }
 				{ config.isEnabled( 'cookie-banner' ) && (
-					<AsyncLoad require={ loadCookieBanner } placeholder={ null } />
+					<AsyncLoad require={ loadCookieBanner } placeholder={ null } errorBoundary />
 				) }
 				{ config.isEnabled( 'layout/app-banner' ) && (
 					<AsyncLoad require={ loadAppBanner } placeholder={ null } />


### PR DESCRIPTION
<!-- Link a related GitHub/Linear issue to this PR. -->

## Proposed Changes

* Stop an ad blocker from taking down the onboarding flow (and login) when it blocks the cookie-banner chunk.
* Rename the chunk so ad blockers stop matching it.
* Add an opt-in error boundary to `AsyncLoad` (default off) and enable it for the cookie banner.

## Why are these changes being made?

Ad blockers (Brave, EasyList/EasyPrivacy) block any request whose URL contains "cookie-banner". Our consent banner ships as a chunk named exactly that (`async-load-calypso-blocks-cookie-banner…js`).

On the stepper (`/setup/onboarding/user`) and the logged-in layout, the banner is loaded through `AsyncLoad`, which is `React.lazy` inside `Suspense` with **no error boundary**. When the chunk request is blocked, the dynamic `import()` rejects; `Suspense` handles the *pending* state but rethrows the *rejection*; with no boundary above it, the error reaches the React root and unmounts the entire app. An optional cosmetic banner takes the whole page down — blank screen.

The same module is also a **static, initial** dependency of `/log-in` and the main app (via `layout/logged-out.jsx`), so there the blocked request fails before any React runs — an error boundary can't help those; only not-being-blocked can.

### Reproduced locally

Blocked the chunk with the flag on, everything else equal:

| | `#wpcom` children | page |
|---|---|---|
| Control (not blocked) | 1 | "Create your account" form renders |
| Blocked | **0** | blank — only the dev bar; console shows `ChunkLoadError` + React's "consider adding an error boundary" |

## Considerations

Two independent mitigations, because they cover different failure modes:

* **Rename** (`async-load-calypso-blocks-cb`) makes the chunk load in the first place — this is what protects `/log-in` and the main app, where the module is an initial script and no boundary could intervene. It's a filter-list dodge, so not permanent on its own.
* **Error boundary** makes a *failed* load degrade to "no banner" instead of crashing, covering the stepper and any future breakage regardless of chunk name. It's gated behind a new `errorBoundary` prop that defaults to **off**, so no existing `AsyncLoad` caller changes behaviour — only the two cookie-banner call sites opt in.

Belt and braces on purpose: the rename could be defeated by a future filter rule, and the boundary alone wouldn't save the initial-script path.

## Testing Instructions

1. Enable the banner locally: append `?flags=cookie-banner` to a stepper URL, e.g. `/setup/onboarding/user?flags=cookie-banner`.
2. In devtools, block the request matching `async-load-calypso-blocks-cb` (Network → block request URL), or use an ad blocker.
3. **Before this change** (rename aside), blocking `…cookie-banner…` unmounts the whole flow — blank page.
4. **After:** the flow renders normally; the banner is simply absent, and the console logs a single "failed to load" line.
5. Sanity-check an unblocked load still shows the banner.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
