### PR TITLE
Signup flow unusable if user has previously managed subscriptions via email

### DIFF
--- a/client/lib/user/shared-utils/initialize-current-user.ts
+++ b/client/lib/user/shared-utils/initialize-current-user.ts
@@ -28,7 +28,7 @@ export async function initializeCurrentUser(): Promise< UserData | false > {
 
 	if ( ! skipBootstrap && config.isEnabled( 'wpcom-user-bootstrap' ) ) {
 		if ( window.currentUser ) {
-			return window.currentUser;
+			return window.currentUser.ID ? window.currentUser : false;
 		}
 		return false;
 	}

--- a/client/state/current-user/reducer.js
+++ b/client/state/current-user/reducer.js
@@ -24,7 +24,7 @@ import { capabilitiesSchema, flagsSchema, idSchema, lasagnaSchema } from './sche
 export const id = withSchemaValidation( idSchema, ( state = null, action ) => {
 	switch ( action.type ) {
 		case CURRENT_USER_RECEIVE:
-			return action.user.ID;
+			return action.user?.ID ?? state;
 	}
 
 	return state;
@@ -33,7 +33,7 @@ export const id = withSchemaValidation( idSchema, ( state = null, action ) => {
 export const user = ( state = null, action ) => {
 	switch ( action.type ) {
 		case CURRENT_USER_RECEIVE:
-			return action.user;
+			return action.user?.ID ? action.user : state;
 		case CURRENT_USER_SET_EMAIL_VERIFIED:
 			return {
 				...state,

--- a/client/state/current-user/test/reducer.js
+++ b/client/state/current-user/test/reducer.js
@@ -1,7 +1,7 @@
 import deepFreeze from 'deep-freeze';
 import { CURRENT_USER_RECEIVE, SITE_RECEIVE, SITES_RECEIVE } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import reducer, { id, capabilities } from '../reducer';
+import reducer, { id, user, capabilities } from '../reducer';
 
 describe( 'reducer', () => {
 	jest.spyOn( console, 'warn' ).mockImplementation();
@@ -35,6 +35,24 @@ describe( 'reducer', () => {
 			expect( state ).toEqual( 73705554 );
 		} );
 
+		test( 'should keep previous state when received user has no ID', () => {
+			const state = id( 73705554, {
+				type: CURRENT_USER_RECEIVE,
+				user: { subscriptionManagementSubkey: 'abc' },
+			} );
+
+			expect( state ).toEqual( 73705554 );
+		} );
+
+		test( 'should stay null when received user has no ID', () => {
+			const state = id( null, {
+				type: CURRENT_USER_RECEIVE,
+				user: { subscriptionManagementSubkey: 'abc' },
+			} );
+
+			expect( state ).toBeNull();
+		} );
+
 		test( 'should validate ID is positive', () => {
 			const state = deserialize( id, -1 );
 			expect( state ).toBeNull();
@@ -53,6 +71,33 @@ describe( 'reducer', () => {
 		test( 'will SERIALIZE current user', () => {
 			const state = serialize( id, 73705554 );
 			expect( state ).toEqual( 73705554 );
+		} );
+	} );
+
+	describe( '#user()', () => {
+		test( 'should default to null', () => {
+			const state = user( undefined, {} );
+
+			expect( state ).toBeNull();
+		} );
+
+		test( 'should set the current user', () => {
+			const currentUser = { ID: 73705554, username: 'foo' };
+			const state = user( null, {
+				type: CURRENT_USER_RECEIVE,
+				user: currentUser,
+			} );
+
+			expect( state ).toEqual( currentUser );
+		} );
+
+		test( 'should keep previous state when received user has no ID', () => {
+			const state = user( null, {
+				type: CURRENT_USER_RECEIVE,
+				user: { subscriptionManagementSubkey: 'abc' },
+			} );
+
+			expect( state ).toBeNull();
 		} );
 	} );
 

--- a/packages/data-stores/src/user/resolvers.ts
+++ b/packages/data-stores/src/user/resolvers.ts
@@ -15,7 +15,7 @@ export function createResolvers() {
 		// In environments where `wpcom-user-bootstrap` is set to true, the currentUser
 		// object will be server-side rendered to window.currentUser. In these cases,
 		// return that object instead of performing another API request to `/me`.
-		if ( window.currentUser ) {
+		if ( window.currentUser?.ID ) {
 			return receiveCurrentUser( window.currentUser );
 		}
 		try {


### PR DESCRIPTION
Fixes DOTCOM-18020

## Why are these changes being made?

If you happen to have a `subkey` cookie, this is the experience when you land on `/setup/onboarding`. It just spins forever.

<img width="3008" height="1860" alt="CleanShot 2026-07-24 at 17 05 01@2x" src="https://github.com/user-attachments/assets/8e7bacec-511e-40cf-930c-97705f29e51b" />

A logged-out visitor with a leftover `subkey` cookie (used by the logged-out newsletter/subscription-management flow) causes an invalid `window.currentUser` global to be created. When the main Calypso dashboard boots it handles this situation fine, but the  stepper boot didn't.

This makes the client side resilient to invalid `window.currentUser` objects. But I question whether the way `subscriptionManagementSubkey` gets merged into `window.currentUser` is appropriate. Follow up #112949


## Proposed Changes

Harden the currentUser bootstrap against a partial/ID-less `window.currentUser` global.

- `initializeCurrentUser` (feeds both classic and stepper boots): return `false` when the bootstrapped `window.currentUser` has no `ID`, instead of returning it raw.
- data-stores `getCurrentUser` resolver: only seed `USER_STORE` from `window.currentUser` when it has an `ID`; otherwise fall through to `/me` / `receiveCurrentUserFailed()`.
- `id` and `user` reducers: make `CURRENT_USER_RECEIVE` null-safe so an ID-less user can never crash or half-populate the store (`id` keeps prior state, `user` ignores the receive).

No change to the stepper boot: with the `initializeCurrentUser` guard, `user` is already `false` for the ID-less case, so the existing `user ? user.ID : 0` handles it (and is the type-safe form).



## How does someone get a `subkey` cookie?

This cookie is used to 

- Go to `/wp-admin/admin.php?page=jetpack-newsletter` and add an email-subscriber
- Post something and make sure the email gets set
- Make sure you're logged out of wordpress.com
- Go to you email inbox and click the "manage subscriptions" link
- Inspect the cookies
  - You have a `subkey` cookie
  - You have no `wordpress_logged_in` cookie

## Testing Instructions

1. Log out (clear the `wordpress_logged_in` session).
2. Get a `subkey` cookie
  - Either follow the instructions above, or
  - On a Calypso page, set a `subkey` cookie: `document.cookie = "subkey=test"`.
4. Load `/setup/onboarding`.
   - Before: crash / infinite load (`Minified Redux error #14` in the console).
   - After: clean load, the user/auth step renders.
5. Confirm the logged-out subscription portal still works: `/reader/subscriptions` still loads and authenticates (this PR does not touch the `window.currentUser?.subscriptionManagementSubkey` reads).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
