### PR TITLE
Move subscription-management subkey to its own global

### DIFF
--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -71,6 +71,7 @@ class Document extends Component {
 			sectionGroup,
 			sectionName,
 			storeSandboxHelper,
+			subscriptionManagementSubkey,
 			target,
 			user,
 			useTranslationChunks,
@@ -93,6 +94,11 @@ class Document extends Component {
 			`var BUILD_TIMESTAMP = ${ jsonStringifyForHtml( buildTimestamp ) };\n` +
 			`var BUILD_TARGET = ${ jsonStringifyForHtml( target ) };\n` +
 			( user ? `var currentUser = ${ jsonStringifyForHtml( user ) };\n` : '' ) +
+			( subscriptionManagementSubkey
+				? `var subscriptionManagementSubkey = ${ jsonStringifyForHtml(
+						subscriptionManagementSubkey
+				  ) };\n`
+				: '' ) +
 			( isSupportSession ? 'var isSupportSession = true;\n' : '' ) +
 			( isSSP ? 'var isSSP = true;\n' : '' ) +
 			( app ? `var app = ${ jsonStringifyForHtml( app ) };\n` : '' ) +

--- a/client/lib/request-with-subkey-fallback/request-with-subkey-fallback.ts
+++ b/client/lib/request-with-subkey-fallback/request-with-subkey-fallback.ts
@@ -1,20 +1,13 @@
 import apiFetch from '@wordpress/api-fetch';
 import request from 'wpcom-proxy-request';
 
-// Overriding the global Window type in packages/data-stores/src/user/resolvers.ts caused the tests to fail.
-type SubkeyWindow = {
-	currentUser?: {
-		subscriptionManagementSubkey: string;
-	};
-};
-
 function requestWithSubkeyFallback< R, T = object >(
 	isLoggedIn: boolean,
 	path: string,
 	method = 'GET',
 	body: T = {} as T
 ): Promise< R > {
-	const subkey = ( window as SubkeyWindow ).currentUser?.subscriptionManagementSubkey;
+	const subkey = window.subscriptionManagementSubkey;
 	const apiVersion = '2';
 	const apiNamespace = 'wpcom/v2';
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -432,10 +432,7 @@ function setUpLoggedOutRoute( req, res, next ) {
 	}
 
 	if ( req.cookies?.subkey ) {
-		req.context.user = {
-			...( req.context.user ?? {} ),
-			subscriptionManagementSubkey: req.cookies.subkey,
-		};
+		req.context.subscriptionManagementSubkey = req.cookies.subkey;
 	}
 
 	Promise.all( setupRequests )

--- a/client/types.ts
+++ b/client/types.ts
@@ -138,6 +138,7 @@ declare global {
 			clientIp?: string;
 		};
 		currentUser?: User;
+		subscriptionManagementSubkey?: string; // Added by an inline script in <head> via SSR context for logged-out subscription management.
 		__REDUX_DEVTOOLS_EXTENSION__?: () => void;
 		Blackbox?: {
 			configure: ( config: {

--- a/packages/api-core/src/me/types.ts
+++ b/packages/api-core/src/me/types.ts
@@ -74,11 +74,6 @@ export interface User {
 	localeVariant?: string;
 
 	/**
-	 * The subkey for Subscription Management.
-	 */
-	subscriptionManagementSubkey?: string;
-
-	/**
 	 * Whether the user was bootstrapped (injected server-side).
 	 */
 	bootstrapped?: boolean;

--- a/packages/data-stores/src/reader/helpers/index.ts
+++ b/packages/data-stores/src/reader/helpers/index.ts
@@ -2,6 +2,12 @@ import apiFetch, { APIFetchOptions } from '@wordpress/api-fetch';
 import wpcomRequest from '../../wpcom-request';
 import isValidId from './validators';
 
+declare global {
+	interface Window {
+		subscriptionManagementSubkey?: string;
+	}
+}
+
 type callApiParams = {
 	apiNamespace?: string;
 	path: string;
@@ -11,9 +17,8 @@ type callApiParams = {
 	apiVersion?: string;
 };
 
-// Get cookie named subkey
 const getSubkey = () => {
-	return window.currentUser?.subscriptionManagementSubkey;
+	return window.subscriptionManagementSubkey;
 };
 
 // Helper function for fetching from subkey authenticated API. Subkey authentication process is only applied in case of logged-out users.


### PR DESCRIPTION
Related to DOTCOM-18020

> [!note]
> This PR is not well tested! I think this is a good idea, but I think @Automattic/loop should decide because I'm not familiar with all the ways subscriptions work and how else this global might get used that I'm not aware of.

## Why are these changes being made?

Back in https://github.com/Automattic/wp-calypso/pull/74892 this `subscriptionManagementSubkey` value was added to the `window.currentUser` global. This caused a signup flow issue (fixed by #112948) because the signup code interprets the presence of a `window.currentUser` as proof enough that the user is logged in and tries to use it to hydrate the redux store.

I think the underlying issue is that Calypso assumes that the shape of the `window.currentUser` global will match the response body of a call to the `/me` API endpoint. It's a performance optimisation that saves us from having to fetch this data. And by stashing another constant into this global it makes the behaviour diverge.

So I think it is better if `subscriptionManagementSubkey` is a whole other constant.
As mentioned in #74892 you could also argue that, since we're doing this to expose the `subkey` cookie to JavaScript, maybe the cookie should just be marked as `httpOnly=false`?
Maybe it should, but #74892 raises the idea that this may expose the cookie value to `.wordpress.com` subdomains which we don't want to do. I haven't verified that though.

See https://github.com/Automattic/wp-calypso/pull/112948 for instructions on what the `subkey` cookie is for how to get one.

## Proposed Changes

Stop overloading `window.currentUser` with the logged-out subscription-management subkey; give it its own global so the `window.currentUser` global will match the response body of the `/me` API call.

- `setUpLoggedOutRoute` (`client/server/pages/index.js`): stash the subkey on its own context field (`req.context.subscriptionManagementSubkey`) instead of mutating `req.context.user`. The logged-out `req.context.user` stays `false`. The `httpOnly` `subkey` cookie is still read server-side — no cookie-flag change.
- `client/document/index.jsx`: emit a dedicated `var subscriptionManagementSubkey = …` inline global alongside `currentUser`.
- Consumers read the new global instead of `window.currentUser?.subscriptionManagementSubkey`:
  - `request-with-subkey-fallback.ts` — uses `window.subscriptionManagementSubkey`; drops the local `SubkeyWindow` cast.
  - data-stores `getSubkey` (`reader/helpers/index.ts`) — uses `window.subscriptionManagementSubkey`.
- Types:
  - Remove `subscriptionManagementSubkey` from api-core `User` (the single source of truth; `data-stores` `CurrentUser = User` re-exports it).
  - Declare `subscriptionManagementSubkey?: string` on `Window` in `client/types.ts` and in data-stores.

## Testing Instructions

1. Log out (clear the `wordpress_logged_in` session).
2. On a Calypso page, set a `subkey` cookie: `document.cookie = "subkey=test"`.
3. Load `/setup/onboarding/user` — clean load; in the console `window.subscriptionManagementSubkey === 'test'` and `window.currentUser` is `undefined`.
4. Logged-out `/reader/subscriptions` still loads and authenticates (both subkey consumers migrated).

`yarn typecheck-client` and `yarn typecheck-packages` pass; data-stores reader tests pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
