### PR TITLE
A4A Marketplace: Center the "Free" label in the product modal price box

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/style.scss
@@ -5,6 +5,13 @@
 	border-radius: 8px;
 	border: 1px solid var( --color-link );
 	padding: 1rem;
+
+	// The free label reserves 1.5rem beneath it so marketplace grid cards line up
+	// with priced ones. Alone in this box it reads as dead space, so split the same
+	// reservation evenly and center the label without resizing the box.
+	.product-price-with-discount__free {
+		margin-block: 0.75rem;
+	}
 }
 
 .license-lightbox__jetpack-manage-license-title {


### PR DESCRIPTION
Fixes A4A-3050

## Proposed Changes

Center the "Free" label vertically inside the price box of the Marketplace product modal, by splitting the spacing it already reserves evenly above and below it instead of placing it all underneath:

```scss
.product-price-with-discount__free {
    margin-block: 0.75rem;
}
```

Scoped to `client/jetpack-cloud/sections/partner-portal/license-lightbox/style.scss`, so only the modal is affected.

## Why are these changes being made?

In the Marketplace product modal, the bordered box above "Add to cart" holds the product's price. For a paid product it holds two lines — the price and its interval ("per license per month") — which fill the box, so it looks right. A free product renders only the word "Free", plus a `margin-block-end: 1.5rem` that exists so free and paid **cards in the store grid** reserve the same height and line up as a row.

Inside the modal there is no row to line up with, so that reservation becomes a band of dead space: the label sits 17px from the top of the box and 41px from the bottom, reading as though something failed to load.

Removing the margin would fix the modal and break the grid alignment it exists for. Splitting the same 1.5rem evenly (`margin-block: 0.75rem`) centers the label at 29px/29px without changing the box's height, the label's typography, or anything in the grid.

### Before / after

| Before | After |
|---|---|
| <img width="434" alt="Before: Free label sits at the top of the price box" src="https://github.com/user-attachments/assets/59f4ee23-256d-4c19-95a7-eb393bb8e6bd" /> | <img width="434" alt="After: Free label centered in the price box" src="https://github.com/user-attachments/assets/daf5caa3-2c82-49bd-a9d6-c9f0fc0a4696" /> |

## Testing instructions

Prerequisites: a local A4A dev instance (`yarn start-a8c-for-agencies`), signed in to an agency account.

1. Go to `/marketplace/products`.
2. Open a **free** product's modal — **WooPayments** is a good example. Verify the "Free" label is vertically centered in the bordered box above "Add to cart" (before this change it sat near the top with empty space below).
3. Open a **paid** product's modal, e.g. **Constellation**. Verify it is unchanged — price and interval line as before.
4. Back on `/marketplace/products`, verify the store grid is unchanged: free and paid cards still line up in a row, with matching card heights and "Add to cart" positions.

Measured before/after in the running app: modal box 82px in both cases, free label 17px/41px before and 29px/29px after; paid modal DOM identical; grid card geometry identical across the first 14 cards; label typography unchanged (20px / 24px / black).

## Notes for reviewers

- Not verified on a true mobile viewport — the browser window would not resize below screen width, so the lightbox aside was constrained to 260px live instead (still 29/29). No media query touches this label.
- Dark mode is unaffected by inspection rather than observation: the change adds no color or token, and the partner-portal/marketplace stylesheets contain no `prefers-color-scheme` rules.
- `yarn prettier --check` fails on this file both before and after this change (pre-existing `var( --studio-white )` spacing); reformatting was left out to keep the diff to one rule. `yarn stylelint` passes.
- No tests added: this is a pure CSS alignment change, jsdom does not compute layout, and the repo has no CSS snapshot harness. The measured geometry above is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
