### PR TITLE
desktop: Keep recordHar as commented-out option in E2E login test

### DIFF
--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -55,12 +55,13 @@ describe( 'User Can log in', () => {
 		await mkdir( path.dirname( CONSOLE_PATH ), { recursive: true } );
 		consoleStream = await createWriteStream( CONSOLE_PATH );
 
-		// Important! Do not enable `recordHar`: the login POST body and session cookies land in the
-		// artifact in cleartext.
 		electronApp = await electron.launch( {
 			executablePath: APP_PATH,
 			args: LAUNCH_ARGS,
 			timeout: 0,
+			// Important! Do not enable `recordHar`: the login POST body and session cookies land in the
+			// artifact in cleartext.
+			// recordHar: { path: HAR_PATH },
 			env: {
 				...process.env,
 				WP_DESKTOP_BASE_URL: BASE_URL,


### PR DESCRIPTION
Follow-up to #112942 (review feedback).


## Why are these changes being made?

Just a quick follow up to some PR feedback in #112942.

## Proposed Changes

* Make the comment—explaining which `recordHar` property exactly has to remain disabled—a bit clearer. By leaving it there and disabled it might be less likely for someone to come and re-add it.

## Testing Instructions

* Comment-only change; no behaviour change. `desktop/test/e2e/specs/login.js` still runs without HAR recording.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
