### PR TITLE
Adapt to admin color scheme changes from WP 7.1

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_blue.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_blue.scss
@@ -25,11 +25,11 @@ Used studio-blue for the primary+accent.
 .color-scheme.is-blue {
 	/* Variables used in Calypso blue */
 	--theme-text-color: #fff; /* $text-color */
-	--theme-base-color: #52accc; /* $base-color */
+	--theme-base-color: #245278; /* $base-color */
 	--theme-submenu-text-color: #e2ecf1; /* $menu-submenu-text */
-	--theme-submenu-background-color: #4796b3; /* From wp-admin*/
+	--theme-submenu-background-color: #1c3f5d; /* From wp-admin*/
 	--theme-icon-color: #e5f8ff; /* $icon-color */
-	--theme-highlight-color: #096484; /* $highlight-color */
+	--theme-highlight-color: #437aa8; /* $highlight-color */
 	--theme-notification-color: #e1a948; /* Direct from wp-admin */
 
 	/* Primary */
@@ -64,12 +64,12 @@ Used studio-blue for the primary+accent.
 	--color-accent-90: var(--color-deprecated-blue-90);
 	--color-accent-100: var(--color-deprecated-blue-100);
 	--color-masterbar-background: var(--theme-base-color);
-	--color-masterbar-border: #6eb9d4; /* $adminbar-avatar-frame */
+	--color-masterbar-border: #2c6593; /* $adminbar-avatar-frame */
 	--color-masterbar-text: var(--theme-text-color);
 	--color-masterbar-submenu-text: var(--theme-submenu-text-color);
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-text-color);
-	--color-masterbar-submenu-group-background: #74b6ce; /* wp-admin ul.ab-sub-secondary */
+	--color-masterbar-submenu-group-background: #33648d; /* wp-admin ul.ab-sub-secondary */
 	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_coffee.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_coffee.scss
@@ -23,11 +23,11 @@ The wp-admin highlight color hue is 27, while studio-orange ranges from 25 to 35
 .color-scheme.is-coffee {
 	/* Variables used in Calypso Coffee */
 	--theme-text-color: #fff; /* $text-color */
-	--theme-base-color: #59524c; /* $base-color */
-	--theme-submenu-text-color: #cdcbc9; /* $menu-submenu-text */
-	--theme-submenu-background-color: #46403c; /* $menu-submenu-background */
+	--theme-base-color: #5c4c40; /* $base-color */
+	--theme-submenu-text-color: #cec9c6; /* $menu-submenu-text */
+	--theme-submenu-background-color: #473b31; /* $menu-submenu-background */
 	--theme-icon-color: #ece6f6; /* $icon-color */
-	--theme-highlight-color: #c7a589; /* $highlight-color */
+	--theme-highlight-color: #916745; /* $highlight-color */
 	--theme-notification-color: #9ea476; /* Direct from wp-admin */
 
 	/* Primary */
@@ -62,12 +62,12 @@ The wp-admin highlight color hue is 27, while studio-orange ranges from 25 to 35
 	--color-accent-90: var(--studio-orange-90);
 	--color-accent-100: var(--studio-orange-100);
 	--color-masterbar-background: var(--theme-base-color);
-	--color-masterbar-border: #6c645c; /* $adminbar-avatar-frame */
+	--color-masterbar-border: #715d4f; /* $adminbar-avatar-frame */
 	--color-masterbar-text: var(--theme-text-color);
 	--color-masterbar-submenu-text: var(--theme-submenu-text-color);
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-highlight-color);
-	--color-masterbar-submenu-group-background: #656463; /* wp-admin ul.ab-sub-secondary */
+	--color-masterbar-submenu-group-background: #6a5e56; /* wp-admin ul.ab-sub-secondary */
 	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_ectoplasm.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_ectoplasm.scss
@@ -35,11 +35,11 @@ Created this definition in color-studio to generate 0-100 shades:
 .color-scheme.is-ectoplasm {
 	/* Variables used in Calypso Ectoplasm */
 	--theme-text-color: #fff; /* $text-color */
-	--theme-base-color: #523f6d; /* $base-color */
-	--theme-submenu-text-color: #cbc5d3; /* $menu-submenu-text */
-	--theme-submenu-background-color: #413256; /* $menu-submenu-background */
+	--theme-base-color: #4a3369; /* $base-color */
+	--theme-submenu-text-color: #c9c2d2; /* $menu-submenu-text */
+	--theme-submenu-background-color: #392751; /* $menu-submenu-background */
 	--theme-icon-color: #ece6f6; /* $icon-color */
-	--theme-highlight-color: #a3b745; /* $highlight-color */
+	--theme-highlight-color: #646c3e; /* $highlight-color */
 	--theme-notification-color: #d46f15; /* Direct from wp-admin */
 
 	--ectoplasm-green-0: #f2f5e1;
@@ -86,12 +86,12 @@ Created this definition in color-studio to generate 0-100 shades:
 	--color-accent-90: var(--ectoplasm-green-90);
 	--color-accent-100: var(--ectoplasm-green-100);
 	--color-masterbar-background: var(--theme-base-color);
-	--color-masterbar-border: #634c84; /* $adminbar-avatar-frame */
+	--color-masterbar-border: #5b3f81; /* $adminbar-avatar-frame */
 	--color-masterbar-text: var(--theme-text-color);
 	--color-masterbar-submenu-text: var(--theme-submenu-text-color);
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-highlight-color);
-	--color-masterbar-submenu-group-background: #64537c; /* wp-admin ul.ab-sub-secondary */
+	--color-masterbar-submenu-group-background: #5c467a; /* wp-admin ul.ab-sub-secondary */
 	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
@@ -43,9 +43,9 @@ Primary+Accent is studio blue.
 	--theme-base-color: #e5e5e5; /* $base-color */
 	--theme-submenu-text-color: #686868; /* $menu-submenu-text */
 	--theme-submenu-background-color: #fff; /* $menu-submenu-background */
-	--theme-icon-color: #999; /* $icon-color */
-	--theme-highlight-color: #04a4cc; /* $highlight-color */
-	--theme-notification-color: #d64e07; /* Direct from wp-admin */
+	--theme-icon-color: #6a6a6a; /* $icon-color */
+	--theme-highlight-color: #007cba; /* $highlight-color */
+	--theme-notification-color: #c64606; /* Direct from wp-admin */
 
 	/* Primary */
 	--color-primary: var(--theme-highlight-color);
@@ -107,8 +107,8 @@ Primary+Accent is studio blue.
 
 	/* Sidebar Selected */
 	--color-sidebar-menu-selected-text: #fff;
-	--color-sidebar-menu-selected-background: #888;
-	--color-sidebar-menu-hover-background: #888;
+	--color-sidebar-menu-selected-background: #6e6e6e;
+	--color-sidebar-menu-hover-background: #6e6e6e;
 	--color-sidebar-menu-hover-text: #fff;
 
 	/* Sidebar Hover - Nav unification */

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
@@ -16,11 +16,11 @@ $notification-color: #69a8bb;
 .color-scheme.is-midnight {
 	/* Variables used in Calypso Midnight */
 	--theme-text-color: #fff; /* $text-color */
-	--theme-base-color: #363b3f; /* $base-color */
-	--theme-submenu-text-color: #c3c4c5; /* $menu-submenu-text */
-	--theme-submenu-background-color: #26292c; /* $menu-submenu-background */
+	--theme-base-color: #333c42; /* $base-color */
+	--theme-submenu-text-color: #c2c4c6; /* $menu-submenu-text */
+	--theme-submenu-background-color: #232a2e; /* $menu-submenu-background */
 	--theme-icon-color: #ece6f6; /* $icon-color */
-	--theme-highlight-color: #e14d43; /* highlight-color */
+	--theme-highlight-color: #cf4339; /* highlight-color */
 	--theme-notification-color: #69a8bb; /* Direct from wp-admin */
 
 	/* Primary */
@@ -55,12 +55,12 @@ $notification-color: #69a8bb;
 	--color-accent-90: var(--studio-red-90);
 	--color-accent-100: var(--studio-red-100);
 	--color-masterbar-background: var(--theme-base-color);
-	--color-masterbar-border: #464d52; /* $adminbar-avatar-frame */
+	--color-masterbar-border: #434e56; /* $adminbar-avatar-frame */
 	--color-masterbar-text: var(--theme-text-color);
 	--color-masterbar-submenu-text: var(--theme-submenu-text-color);
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-highlight-color);
-	--color-masterbar-submenu-group-background: #4c4c4d; /* wp-admin ul.ab-sub-secondary */
+	--color-masterbar-submenu-group-background: #484d51; /* wp-admin ul.ab-sub-secondary */
 	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_ocean.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_ocean.scss
@@ -28,11 +28,11 @@ opinion.  Celadon seems to match the ocean colors better.
 .color-scheme.is-ocean {
 	/* Variables used in Calypso Ectoplasm */
 	--theme-text-color: #fff; /* $text-color */
-	--theme-base-color: #738e96; /* $base-color */
-	--theme-submenu-text-color: #d5dde0; /* $menu-submenu-text */
-	--theme-submenu-background-color: #627c83; /* $menu-submenu-background */
+	--theme-base-color: #39535a; /* $base-color */
+	--theme-submenu-text-color: #c4cbce; /* $menu-submenu-text */
+	--theme-submenu-background-color: #2b3f44; /* $menu-submenu-background */
 	--theme-icon-color: #f2fcff; /* $icon-color */
-	--theme-highlight-color: #9ebaa0; /* $highlight-color */
+	--theme-highlight-color: #567958; /* $highlight-color */
 	--theme-notification-color: #aa9d88; /* Direct from wp-admin */
 
 	/* Primary */
@@ -67,12 +67,12 @@ opinion.  Celadon seems to match the ocean colors better.
 	--color-accent-90: var(--studio-celadon-90);
 	--color-accent-100: var(--studio-celadon-100);
 	--color-masterbar-background: var(--theme-base-color);
-	--color-masterbar-border: #879ea5; /* $adminbar-avatar-frame */
+	--color-masterbar-border: #476770; /* $adminbar-avatar-frame */
 	--color-masterbar-text: var(--theme-text-color);
 	--color-masterbar-submenu-text: var(--theme-submenu-text-color);
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-highlight-color);
-	--color-masterbar-submenu-group-background: #8f9a9e; /* wp-admin ul.ab-sub-secondary */
+	--color-masterbar-submenu-group-background: #4d636a; /* wp-admin ul.ab-sub-secondary */
 	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_sunrise.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_sunrise.scss
@@ -26,12 +26,12 @@ Well use studio-orange for both the primary and accent colors
 .color-scheme.is-sunrise {
 	/* Variables used in Calypso Sunrise */
 	--theme-text-color: #fff; /* $text-color: */
-	--theme-base-color: #cf4944; /* $base-color */
-	--theme-submenu-text-color: #f1c8c7; /* $menu-submenu-text */
-	--theme-submenu-background-color: #be3631; /* $menu-submenu-background */
+	--theme-base-color: #8a312d; /* $base-color */
+	--theme-submenu-text-color: #dcc1c0; /* $menu-submenu-text */
+	--theme-submenu-background-color: #6f2724; /* $menu-submenu-background */
 	--theme-submenu-hover-text-color: #f7e3d3; /* Direct from wp-admin */
 	--theme-icon-color: #f3f1f1; /* $icon-color */
-	--theme-highlight-color: #dd823b; /* $highlight-color */
+	--theme-highlight-color: #ad631e; /* $highlight-color */
 	--theme-notification-color: #ccaf0b; /* Direct from wp-admin */
 
 	/* Primary */
@@ -66,12 +66,12 @@ Well use studio-orange for both the primary and accent colors
 	--color-accent-90: var(--studio-orange-90);
 	--color-accent-100: var(--studio-orange-100);
 	--color-masterbar-background: var(--theme-base-color);
-	--color-masterbar-border: #d66560; /* $adminbar-avatar-frame */
+	--color-masterbar-border: #a53b36; /* $adminbar-avatar-frame */
 	--color-masterbar-text: var(--theme-text-color);
 	--color-masterbar-submenu-text: var(--theme-submenu-text-color);
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-submenu-hover-text-color);
-	--color-masterbar-submenu-group-background: #cf6b67; /* wp-admin ul.ab-sub-secondary */
+	--color-masterbar-submenu-group-background: #9d423e; /* wp-admin ul.ab-sub-secondary */
 	--color-global-masterbar-site-info-background: var(--color-masterbar-submenu-group-background);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 


### PR DESCRIPTION

Fixes DOTCOM-17698

## Proposed Changes

Port the admin color scheme changes from https://github.com/WordPress/wordpress-develop/pull/12026, which will be released in the upcoming WP 7.1.

## Testing Instructions

1. Prepare an Atomic site.
2. Go to MSD -> site -> Settings -> WordPress, choose the beta version.
3. Go to site's wp-admin -> Users -> Profile.
4. Choose a core color scheme.
5. Open `<Calypso Live>/home/<site slug>`
6. Verify the color scheme matches.
7. Repeat for all 7 core color schemes (All 9 core schemes minus Fresh and Modern).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
