### PR TITLE
AI Launchpad: integrate ExPlat launchpad-personalization variations (Calypso)

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
 							'calypso/data/*',
 							'!calypso/data/data-center',
 							'!calypso/data/php-versions',
+							// Allowed: calypso/lib/ai-launchpad
 							// Allowed: calypso/lib/explat
 							// Allowed: calypso/lib/color-scheme
 							// Allowed: calypso/lib/interval/use-interval (temporary)
@@ -21,6 +22,7 @@ module.exports = {
 							// Allowed: calypso/lib/wp
 							'!calypso/lib',
 							'calypso/lib/*',
+							'!calypso/lib/ai-launchpad',
 							'!calypso/lib/color-scheme',
 							'!calypso/lib/explat',
 							'!calypso/lib/interval',

--- a/client/dashboard/sites/overview-visibility-card/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card/index.tsx
@@ -2,6 +2,8 @@ import { siteLaunchpadQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { lockOutline, published } from '@wordpress/icons';
+import { LAUNCHPAD_PERSONALIZATION_EXPERIMENT, normalizeVariation } from 'calypso/lib/ai-launchpad';
+import { useExperiment } from 'calypso/lib/explat';
 import { launch } from '../../components/icons';
 import OverviewCard from '../../components/overview-card';
 import { wpcomLink } from '../../utils/link';
@@ -41,6 +43,10 @@ function VisibilityCardUnlaunched( { site }: { site: Site } ) {
 		withTasks: true,
 	} );
 
+	const [ , personalizationAssignment ] = useExperiment( LAUNCHPAD_PERSONALIZATION_EXPERIMENT );
+	const isNoGuidance =
+		normalizeVariation( personalizationAssignment?.variationName ) === 'no_guidance';
+
 	const { data: launchpad } = useQuery( {
 		...siteLaunchpadQuery( site.ID, getLaunchpadChecklistSlug( site ) ),
 		enabled: ! isAiLaunchpad,
@@ -67,12 +73,17 @@ function VisibilityCardUnlaunched( { site }: { site: Site } ) {
 						description: __( 'Finish setting up your site.' ),
 						externalLink: setupLink,
 				  } ) }
-			progress={ {
-				value: completedTasks,
-				max: numberOfTasks,
-				label: `${ completedTasks }/${ numberOfTasks }`,
-				...( isLaunchpadCompleted && { variant: 'success' } ),
-			} }
+			{ ...( isNoGuidance
+				? {}
+				: {
+						// The no_guidance launchpad-personalization variation gets no progress guidance.
+						progress: {
+							value: completedTasks,
+							max: numberOfTasks,
+							label: `${ completedTasks }/${ numberOfTasks }`,
+							...( isLaunchpadCompleted && { variant: 'success' as const } ),
+						},
+				  } ) }
 		/>
 	);
 }

--- a/client/dashboard/sites/overview-visibility-card/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card/index.tsx
@@ -59,6 +59,18 @@ function VisibilityCardUnlaunched( { site }: { site: Site } ) {
 
 	const setupLink = setupUrl ?? wpcomLink( `/home/${ site.slug }` );
 
+	// The no_guidance launchpad-personalization variation omits the progress circle entirely.
+	const progressProps = isNoGuidance
+		? {}
+		: {
+				progress: {
+					value: completedTasks,
+					max: numberOfTasks,
+					label: `${ completedTasks }/${ numberOfTasks }`,
+					...( isLaunchpadCompleted && { variant: 'success' as const } ),
+				},
+		  };
+
 	return (
 		<OverviewCard
 			{ ...CARD_PROPS }
@@ -73,17 +85,7 @@ function VisibilityCardUnlaunched( { site }: { site: Site } ) {
 						description: __( 'Finish setting up your site.' ),
 						externalLink: setupLink,
 				  } ) }
-			{ ...( isNoGuidance
-				? {}
-				: {
-						// The no_guidance launchpad-personalization variation gets no progress guidance.
-						progress: {
-							value: completedTasks,
-							max: numberOfTasks,
-							label: `${ completedTasks }/${ numberOfTasks }`,
-							...( isLaunchpadCompleted && { variant: 'success' as const } ),
-						},
-				  } ) }
+			{ ...progressProps }
 		/>
 	);
 }

--- a/client/dashboard/sites/overview/test/index.test.tsx
+++ b/client/dashboard/sites/overview/test/index.test.tsx
@@ -4,11 +4,10 @@
 
 import { screen, waitFor, within } from '@testing-library/react';
 import nock from 'nock';
+import { LAUNCHPAD_PERSONALIZATION_EXPERIMENT } from 'calypso/lib/ai-launchpad';
 import { render } from '../../../test-utils';
 import SiteOverview from '../index';
 import type { Site } from '@automattic/api-core';
-
-const LAUNCHPAD_PERSONALIZATION_EXPERIMENT = 'wpcom_launchpad_personalization_202607_v1';
 
 // Seed a live ExPlat assignment into the storage the real useExperiment hook reads from, so it
 // resolves to the given variation through its normal code path — no module or network mocking.

--- a/client/dashboard/sites/overview/test/index.test.tsx
+++ b/client/dashboard/sites/overview/test/index.test.tsx
@@ -2,11 +2,27 @@
  * @jest-environment jsdom
  */
 
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import nock from 'nock';
 import { render } from '../../../test-utils';
 import SiteOverview from '../index';
 import type { Site } from '@automattic/api-core';
+
+const LAUNCHPAD_PERSONALIZATION_EXPERIMENT = 'wpcom_launchpad_personalization_202607_v1';
+
+// Seed a live ExPlat assignment into the storage the real useExperiment hook reads from, so it
+// resolves to the given variation through its normal code path — no module or network mocking.
+function assignPersonalizationVariation( variationName: string | null ) {
+	window.localStorage.setItem(
+		`explat-experiment--${ LAUNCHPAD_PERSONALIZATION_EXPERIMENT }`,
+		JSON.stringify( {
+			experimentName: LAUNCHPAD_PERSONALIZATION_EXPERIMENT,
+			variationName,
+			retrievedTimestamp: Date.now(),
+			ttl: 3600,
+		} )
+	);
+}
 
 const site = {
 	ID: 1,
@@ -146,6 +162,10 @@ describe( '<SiteOverview>', () => {
 			.reply( 200, {} );
 	} );
 
+	afterEach( () => {
+		window.localStorage.clear();
+	} );
+
 	test( 'renders the overview of a site with free plan', async () => {
 		mockSite( {
 			...site,
@@ -222,6 +242,20 @@ describe( '<SiteOverview>', () => {
 		expect( await getCard( 'Finish setting up your site' ) ).toBeVisible();
 		expect( await getCard( 'We’ll bring your vision to life' ) ).toBeVisible();
 		expect( await getCard( 'The perfect domain awaits' ) ).toBeVisible();
+	} );
+
+	test( 'hides the visibility progress bar for the no_guidance launchpad-personalization variation', async () => {
+		assignPersonalizationVariation( 'no_guidance' );
+		mockSite( { ...site, launch_status: 'unlaunched' } as Site );
+		render( <SiteOverview siteSlug={ site.slug } /> );
+
+		await screen.findByRole( 'heading', { name: 'Test Site' } );
+		await waitForFeatureGatedCards( 'Business' );
+
+		const card = await getCard( 'Finish setting up your site' );
+		await waitFor( () =>
+			expect( within( card ).queryByRole( 'progressbar' ) ).not.toBeInTheDocument()
+		);
 	} );
 
 	test( 'renders the overview of a commerce garden site', async () => {

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -17,6 +17,8 @@ import {
 import { useResizeObserver } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 import { useInView } from 'react-intersection-observer';
+import { LAUNCHPAD_PERSONALIZATION_EXPERIMENT, normalizeVariation } from 'calypso/lib/ai-launchpad';
+import { useExperiment } from 'calypso/lib/explat';
 import { useAnalytics } from '../../app/analytics';
 import ComponentViewTracker from '../../components/component-view-tracker';
 import SiteIcon from '../../components/site-icon';
@@ -335,8 +337,14 @@ export function MediaStorage( { site }: { site?: Site } ) {
 function SiteLaunchNag( { siteSlug }: { siteSlug: string } ) {
 	const { recordTracksEvent } = useAnalytics();
 	const { isCompleted, setupUrl } = useAiLaunchpad( siteSlug );
+	const [ , personalizationAssignment ] = useExperiment( LAUNCHPAD_PERSONALIZATION_EXPERIMENT );
 
 	if ( isCompleted ) {
+		return null;
+	}
+
+	// The no_guidance launchpad-personalization variation shows no launchpad mention at all.
+	if ( normalizeVariation( personalizationAssignment?.variationName ) === 'no_guidance' ) {
 		return null;
 	}
 

--- a/client/dashboard/sites/site-fields/test/visibility.tsx
+++ b/client/dashboard/sites/site-fields/test/visibility.tsx
@@ -4,12 +4,11 @@
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { QueryClient } from '@tanstack/react-query';
 import { waitFor } from '@testing-library/react';
+import { LAUNCHPAD_PERSONALIZATION_EXPERIMENT } from 'calypso/lib/ai-launchpad';
 import { render } from '../../../test-utils';
 import { wpcomLink } from '../../../utils/link';
 import { Visibility } from '../index';
 import type { Site } from '@automattic/api-core';
-
-const LAUNCHPAD_PERSONALIZATION_EXPERIMENT = 'wpcom_launchpad_personalization_202607_v1';
 
 function createQueryClientWithSite( site: Site ) {
 	const queryClient = new QueryClient( {

--- a/client/dashboard/sites/site-fields/test/visibility.tsx
+++ b/client/dashboard/sites/site-fields/test/visibility.tsx
@@ -3,10 +3,13 @@
  */
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { QueryClient } from '@tanstack/react-query';
+import { waitFor } from '@testing-library/react';
 import { render } from '../../../test-utils';
 import { wpcomLink } from '../../../utils/link';
 import { Visibility } from '../index';
 import type { Site } from '@automattic/api-core';
+
+const LAUNCHPAD_PERSONALIZATION_EXPERIMENT = 'wpcom_launchpad_personalization_202607_v1';
 
 function createQueryClientWithSite( site: Site ) {
 	const queryClient = new QueryClient( {
@@ -16,6 +19,20 @@ function createQueryClientWithSite( site: Site ) {
 	} );
 	queryClient.setQueryData( siteBySlugQuery( site.slug ).queryKey, site );
 	return queryClient;
+}
+
+// Seed a live ExPlat assignment into the storage the real useExperiment hook reads from, so it
+// resolves to the given variation through its normal code path — no module or network mocking.
+function assignPersonalizationVariation( variationName: string | null ) {
+	window.localStorage.setItem(
+		`explat-experiment--${ LAUNCHPAD_PERSONALIZATION_EXPERIMENT }`,
+		JSON.stringify( {
+			experimentName: LAUNCHPAD_PERSONALIZATION_EXPERIMENT,
+			variationName,
+			retrievedTimestamp: Date.now(),
+			ttl: 3600,
+		} )
+	);
 }
 
 const aiLaunchpadSite = {
@@ -29,6 +46,10 @@ const aiLaunchpadSite = {
 } as Site;
 
 describe( '<Visibility>', () => {
+	afterEach( () => {
+		window.localStorage.clear();
+	} );
+
 	test( 'for unlaunched sites, it renders "Coming soon" with a "Finish setup" link', () => {
 		const { container, getByRole } = render(
 			<Visibility
@@ -76,6 +97,21 @@ describe( '<Visibility>', () => {
 			{ queryClient: createQueryClientWithSite( completedSite ) }
 		);
 		expect( queryByRole( 'link', { name: /Finish setup/ } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'for the no_guidance personalization variation, it hides the "Finish setup" link', async () => {
+		assignPersonalizationVariation( 'no_guidance' );
+		const { queryByRole } = render(
+			<Visibility
+				siteSlug="test.wordpress.com"
+				visibility="private"
+				status={ null }
+				isLaunched={ false }
+			/>
+		);
+		await waitFor( () =>
+			expect( queryByRole( 'link', { name: /Finish setup/ } ) ).not.toBeInTheDocument()
+		);
 	} );
 
 	test( 'for coming soon sites, it renders "Coming soon"', () => {

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -121,12 +121,11 @@ const onboarding: FlowV2< typeof initialize > = {
 		 */
 		const getPostCheckoutDestination = async (
 			providedDependencies: ProvidedDependencies,
-			planCartItem: MinimalRequestCartProduct | null
+			planCartItem: MinimalRequestCartProduct | null,
+			launchpadPersonalizationVariation: LaunchpadPersonalizationVariation
 		): Promise< [ string, string | null, string | null ] > => {
 			// Launchpad-personalization treatments land straight in wp-admin instead of My Home:
 			// ai_launchpad in Site Setup (enabling the AI launchpad), no_guidance on the dashboard.
-			const launchpadPersonalizationVariation =
-				await resolveLaunchpadPersonalizationVariation( diyLaunchpad );
 			if ( launchpadPersonalizationVariation !== 'control' && providedDependencies.siteSlug ) {
 				const siteSlug = providedDependencies.siteSlug as string;
 				const site = await resolveSelect( SITE_STORE ).getSite( siteSlug );
@@ -359,8 +358,14 @@ const onboarding: FlowV2< typeof initialize > = {
 						return;
 					}
 
+					const launchpadPersonalizationVariation =
+						await resolveLaunchpadPersonalizationVariation( diyLaunchpad );
 					const [ destination, backDestination, backDestinationDomains ] =
-						await getPostCheckoutDestination( providedDependencies, planCartItem );
+						await getPostCheckoutDestination(
+							providedDependencies,
+							planCartItem,
+							launchpadPersonalizationVariation
+						);
 					if ( providedDependencies.processingResult === ProcessingResult.SUCCESS ) {
 						persistSignupDestination( destination );
 						setSignupCompleteFlowName( flowName );
@@ -408,9 +413,7 @@ const onboarding: FlowV2< typeof initialize > = {
 									steps_total: checkoutStepperPosition.total,
 								} )
 							);
-						} else if (
-							( await resolveLaunchpadPersonalizationVariation( diyLaunchpad ) ) !== 'control'
-						) {
+						} else if ( launchpadPersonalizationVariation !== 'control' ) {
 							// Launchpad personalization treatments skip the AI/manual chooser and land straight in wp-admin.
 							window.location.replace( destination );
 						} else if (

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -55,7 +55,7 @@ import type { DomainSuggestion } from '@automattic/api-core';
  * dev/QA override that forces the `ai_launchpad` variation without consulting ExPlat;
  * otherwise the variation comes from the sticky ExPlat assignment.
  */
-export async function resolvePersonalizationVariation(
+export async function resolveLaunchpadPersonalizationVariation(
 	diyLaunchpad: string | null
 ): Promise< LaunchpadPersonalizationVariation > {
 	if ( diyLaunchpad ) {
@@ -125,13 +125,14 @@ const onboarding: FlowV2< typeof initialize > = {
 		): Promise< [ string, string | null, string | null ] > => {
 			// Launchpad-personalization treatments land straight in wp-admin instead of My Home:
 			// ai_launchpad in Site Setup (enabling the AI launchpad), no_guidance on the dashboard.
-			const personalizationVariation = await resolvePersonalizationVariation( diyLaunchpad );
-			if ( personalizationVariation !== 'control' && providedDependencies.siteSlug ) {
+			const launchpadPersonalizationVariation =
+				await resolveLaunchpadPersonalizationVariation( diyLaunchpad );
+			if ( launchpadPersonalizationVariation !== 'control' && providedDependencies.siteSlug ) {
 				const siteSlug = providedDependencies.siteSlug as string;
 				const site = await resolveSelect( SITE_STORE ).getSite( siteSlug );
 				const adminUrl = site?.options?.admin_url ?? `https://${ siteSlug }/wp-admin/`;
 				const destination = getLaunchpadPersonalizationDestination( {
-					variation: personalizationVariation,
+					variation: launchpadPersonalizationVariation,
 					adminUrl,
 					enableAiLaunchpad: true,
 				} );
@@ -407,8 +408,10 @@ const onboarding: FlowV2< typeof initialize > = {
 									steps_total: checkoutStepperPosition.total,
 								} )
 							);
-						} else if ( ( await resolvePersonalizationVariation( diyLaunchpad ) ) !== 'control' ) {
-							// Personalization treatments skip the AI/manual chooser and land straight in wp-admin.
+						} else if (
+							( await resolveLaunchpadPersonalizationVariation( diyLaunchpad ) ) !== 'control'
+						) {
+							// Launchpad personalization treatments skip the AI/manual chooser and land straight in wp-admin.
 							window.location.replace( destination );
 						} else if (
 							refParameter === WOO_HOSTING_SOLUTIONS_REF &&

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -7,6 +7,12 @@ import { addQueryArgs, getQueryArg, getQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
 import { clearSessionStorageQuery } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
 import { WOO_HOSTING_SOLUTIONS_REF } from 'calypso/landing/stepper/constants';
+import {
+	LAUNCHPAD_PERSONALIZATION_EXPERIMENT,
+	normalizeVariation,
+	getLaunchpadPersonalizationDestination,
+	type LaunchpadPersonalizationVariation,
+} from 'calypso/lib/ai-launchpad';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { addSurvicate } from 'calypso/lib/analytics/survicate';
 import { loadExperimentAssignment } from 'calypso/lib/explat';
@@ -43,6 +49,21 @@ import { ProcessingResult } from '../../internals/steps-repository/processing-st
 import { type FlowV2, type ProvidedDependencies, type SubmitHandler } from '../../internals/types';
 import { getOnboardingStepperPosition } from './step-counter-config';
 import type { DomainSuggestion } from '@automattic/api-core';
+
+/**
+ * Resolve the launchpad-personalization variation. The `?diy-launchpad` query param is a
+ * dev/QA override that forces the `ai_launchpad` variation without consulting ExPlat;
+ * otherwise the variation comes from the sticky ExPlat assignment.
+ */
+export async function resolvePersonalizationVariation(
+	diyLaunchpad: string | null
+): Promise< LaunchpadPersonalizationVariation > {
+	if ( diyLaunchpad ) {
+		return 'ai_launchpad';
+	}
+	const assignment = await loadExperimentAssignment( LAUNCHPAD_PERSONALIZATION_EXPERIMENT );
+	return normalizeVariation( assignment?.variationName );
+}
 
 function initialize() {
 	const steps = [
@@ -102,17 +123,21 @@ const onboarding: FlowV2< typeof initialize > = {
 			providedDependencies: ProvidedDependencies,
 			planCartItem: MinimalRequestCartProduct | null
 		): Promise< [ string, string | null, string | null ] > => {
-			// Site Setup replaces My Home, so the diy-launchpad cohort must land there directly:
-			// any other destination (e.g. /home) would be the orphaned screen we just removed.
-			if ( diyLaunchpad && providedDependencies.siteSlug ) {
+			// Launchpad-personalization treatments land straight in wp-admin instead of My Home:
+			// ai_launchpad in Site Setup (enabling the AI launchpad), no_guidance on the dashboard.
+			const personalizationVariation = await resolvePersonalizationVariation( diyLaunchpad );
+			if ( personalizationVariation !== 'control' && providedDependencies.siteSlug ) {
 				const siteSlug = providedDependencies.siteSlug as string;
 				const site = await resolveSelect( SITE_STORE ).getSite( siteSlug );
 				const adminUrl = site?.options?.admin_url ?? `https://${ siteSlug }/wp-admin/`;
-				return [
-					`${ adminUrl }admin.php?page=site-setup-wp-admin&enable-ai-launchpad=1`,
-					null,
-					null,
-				];
+				const destination = getLaunchpadPersonalizationDestination( {
+					variation: personalizationVariation,
+					adminUrl,
+					enableAiLaunchpad: true,
+				} );
+				if ( destination ) {
+					return [ destination, null, null ];
+				}
 			}
 
 			if ( ! providedDependencies.hasExternalTheme && providedDependencies.hasPluginByGoal ) {
@@ -382,8 +407,8 @@ const onboarding: FlowV2< typeof initialize > = {
 									steps_total: checkoutStepperPosition.total,
 								} )
 							);
-						} else if ( diyLaunchpad ) {
-							// The diy-launchpad cohort skips the AI/manual chooser and lands straight in Site Setup.
+						} else if ( ( await resolvePersonalizationVariation( diyLaunchpad ) ) !== 'control' ) {
+							// Personalization treatments skip the AI/manual chooser and land straight in wp-admin.
 							window.location.replace( destination );
 						} else if (
 							refParameter === WOO_HOSTING_SOLUTIONS_REF &&

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -8,9 +8,8 @@ import { useEffect } from 'react';
 import { clearSessionStorageQuery } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
 import { WOO_HOSTING_SOLUTIONS_REF } from 'calypso/landing/stepper/constants';
 import {
-	LAUNCHPAD_PERSONALIZATION_EXPERIMENT,
-	normalizeVariation,
 	getLaunchpadPersonalizationDestination,
+	resolveLaunchpadPersonalizationVariation,
 	type LaunchpadPersonalizationVariation,
 } from 'calypso/lib/ai-launchpad';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
@@ -49,21 +48,6 @@ import { ProcessingResult } from '../../internals/steps-repository/processing-st
 import { type FlowV2, type ProvidedDependencies, type SubmitHandler } from '../../internals/types';
 import { getOnboardingStepperPosition } from './step-counter-config';
 import type { DomainSuggestion } from '@automattic/api-core';
-
-/**
- * Resolve the launchpad-personalization variation. The `?diy-launchpad` query param is a
- * dev/QA override that forces the `ai_launchpad` variation without consulting ExPlat;
- * otherwise the variation comes from the sticky ExPlat assignment.
- */
-export async function resolveLaunchpadPersonalizationVariation(
-	diyLaunchpad: string | null
-): Promise< LaunchpadPersonalizationVariation > {
-	if ( diyLaunchpad ) {
-		return 'ai_launchpad';
-	}
-	const assignment = await loadExperimentAssignment( LAUNCHPAD_PERSONALIZATION_EXPERIMENT );
-	return normalizeVariation( assignment?.variationName );
-}
 
 function initialize() {
 	const steps = [
@@ -124,22 +108,6 @@ const onboarding: FlowV2< typeof initialize > = {
 			planCartItem: MinimalRequestCartProduct | null,
 			launchpadPersonalizationVariation: LaunchpadPersonalizationVariation
 		): Promise< [ string, string | null, string | null ] > => {
-			// Launchpad-personalization treatments land straight in wp-admin instead of My Home:
-			// ai_launchpad in Site Setup (enabling the AI launchpad), no_guidance on the dashboard.
-			if ( launchpadPersonalizationVariation !== 'control' && providedDependencies.siteSlug ) {
-				const siteSlug = providedDependencies.siteSlug as string;
-				const site = await resolveSelect( SITE_STORE ).getSite( siteSlug );
-				const adminUrl = site?.options?.admin_url ?? `https://${ siteSlug }/wp-admin/`;
-				const destination = getLaunchpadPersonalizationDestination( {
-					variation: launchpadPersonalizationVariation,
-					adminUrl,
-					enableAiLaunchpad: true,
-				} );
-				if ( destination ) {
-					return [ destination, null, null ];
-				}
-			}
-
 			if ( ! providedDependencies.hasExternalTheme && providedDependencies.hasPluginByGoal ) {
 				return [ `/home/${ providedDependencies.siteSlug }`, null, null ];
 			}
@@ -177,6 +145,24 @@ const onboarding: FlowV2< typeof initialize > = {
 				const site = await resolveSelect( SITE_STORE ).getSite( siteSlug );
 				const adminUrl = site?.options?.admin_url ?? `https://${ siteSlug }/wp-admin/`;
 				return [ `${ adminUrl }admin.php?page=wc-admin`, null, null ];
+			}
+
+			// Launchpad-personalization treatments replace only the default My Home landing:
+			// ai_launchpad lands in Site Setup, no_guidance on the wp-admin dashboard. The
+			// functional handoffs above (plugin install, playground/blueprint import, Woo)
+			// keep their destinations regardless of the assigned variation.
+			if ( launchpadPersonalizationVariation !== 'control' && providedDependencies.siteSlug ) {
+				const siteSlug = providedDependencies.siteSlug as string;
+				const site = await resolveSelect( SITE_STORE ).getSite( siteSlug );
+				const adminUrl = site?.options?.admin_url ?? `https://${ siteSlug }/wp-admin/`;
+				const destination = getLaunchpadPersonalizationDestination( {
+					variation: launchpadPersonalizationVariation,
+					adminUrl,
+					enableAiLaunchpad: true,
+				} );
+				if ( destination ) {
+					return [ destination, null, null ];
+				}
 			}
 
 			return getOnboardingPostCheckoutDestination( {
@@ -326,15 +312,34 @@ const onboarding: FlowV2< typeof initialize > = {
 							);
 							return;
 						}
-						case 'blank-site':
+						case 'blank-site': {
 							if ( refParameter === WOO_HOSTING_SOLUTIONS_REF ) {
 								const site = await resolveSelect( SITE_STORE ).getSite( siteSlug );
 								const adminUrl = site?.options?.admin_url ?? `https://${ siteSlug }/wp-admin/`;
 								window.location.assign( `${ adminUrl }admin.php?page=wc-admin` );
-							} else {
-								window.location.assign( `/home/${ siteSlug }` );
+								return;
 							}
+
+							// Launchpad-personalization treatments land in wp-admin instead of My Home
+							// (which would bounce them there anyway, one redirect later).
+							const variation = await resolveLaunchpadPersonalizationVariation( diyLaunchpad );
+							if ( variation !== 'control' ) {
+								const site = await resolveSelect( SITE_STORE ).getSite( siteSlug );
+								const adminUrl = site?.options?.admin_url ?? `https://${ siteSlug }/wp-admin/`;
+								const destination = getLaunchpadPersonalizationDestination( {
+									variation,
+									adminUrl,
+									enableAiLaunchpad: true,
+								} );
+								if ( destination ) {
+									window.location.assign( destination );
+									return;
+								}
+							}
+
+							window.location.assign( `/home/${ siteSlug }` );
 							return;
+						}
 						default:
 							return;
 					}
@@ -413,9 +418,6 @@ const onboarding: FlowV2< typeof initialize > = {
 									steps_total: checkoutStepperPosition.total,
 								} )
 							);
-						} else if ( launchpadPersonalizationVariation !== 'control' ) {
-							// Launchpad personalization treatments skip the AI/manual chooser and land straight in wp-admin.
-							window.location.replace( destination );
 						} else if (
 							refParameter === WOO_HOSTING_SOLUTIONS_REF &&
 							isEnabled( 'onboarding/woo-hosting-post-purchase-setup-choice' )

--- a/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding.ts
@@ -3,7 +3,8 @@
  */
 import { renderHook } from '@testing-library/react';
 import { clearSessionStorageQuery } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
-import onboarding from '../onboarding';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
+import onboarding, { resolvePersonalizationVariation } from '../onboarding';
 
 jest.mock( 'calypso/components/domains/wpcom-domain-search/use-query-handler', () => ( {
 	clearSessionStorageQuery: jest.fn(),
@@ -90,5 +91,29 @@ describe( 'onboarding flow side effects', () => {
 		renderSideEffect( 'domains' );
 
 		expect( clearSessionStorageQuery ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'resolvePersonalizationVariation', () => {
+	beforeEach( () => jest.clearAllMocks() );
+
+	it( 'forces ai_launchpad when the diy-launchpad override is present', async () => {
+		await expect( resolvePersonalizationVariation( '1' ) ).resolves.toBe( 'ai_launchpad' );
+		expect( loadExperimentAssignment ).not.toHaveBeenCalled();
+	} );
+
+	it( 'reads the variation from ExPlat when no override is present', async () => {
+		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
+			variationName: 'no_guidance',
+		} );
+		await expect( resolvePersonalizationVariation( null ) ).resolves.toBe( 'no_guidance' );
+		expect( loadExperimentAssignment ).toHaveBeenCalledWith(
+			'wpcom_launchpad_personalization_202607_v1'
+		);
+	} );
+
+	it( 'falls back to control on an unrecognized assignment', async () => {
+		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( { variationName: null } );
+		await expect( resolvePersonalizationVariation( null ) ).resolves.toBe( 'control' );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding.ts
@@ -3,8 +3,7 @@
  */
 import { renderHook } from '@testing-library/react';
 import { clearSessionStorageQuery } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
-import onboarding, { resolveLaunchpadPersonalizationVariation } from '../onboarding';
+import onboarding from '../onboarding';
 
 jest.mock( 'calypso/components/domains/wpcom-domain-search/use-query-handler', () => ( {
 	clearSessionStorageQuery: jest.fn(),
@@ -91,29 +90,5 @@ describe( 'onboarding flow side effects', () => {
 		renderSideEffect( 'domains' );
 
 		expect( clearSessionStorageQuery ).not.toHaveBeenCalled();
-	} );
-} );
-
-describe( 'resolveLaunchpadPersonalizationVariation', () => {
-	beforeEach( () => jest.clearAllMocks() );
-
-	it( 'forces ai_launchpad when the diy-launchpad override is present', async () => {
-		await expect( resolveLaunchpadPersonalizationVariation( '1' ) ).resolves.toBe( 'ai_launchpad' );
-		expect( loadExperimentAssignment ).not.toHaveBeenCalled();
-	} );
-
-	it( 'reads the variation from ExPlat when no override is present', async () => {
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
-			variationName: 'no_guidance',
-		} );
-		await expect( resolveLaunchpadPersonalizationVariation( null ) ).resolves.toBe( 'no_guidance' );
-		expect( loadExperimentAssignment ).toHaveBeenCalledWith(
-			'wpcom_launchpad_personalization_202607_v1'
-		);
-	} );
-
-	it( 'falls back to control on an unrecognized assignment', async () => {
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( { variationName: null } );
-		await expect( resolveLaunchpadPersonalizationVariation( null ) ).resolves.toBe( 'control' );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding.ts
@@ -4,7 +4,7 @@
 import { renderHook } from '@testing-library/react';
 import { clearSessionStorageQuery } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
 import { loadExperimentAssignment } from 'calypso/lib/explat';
-import onboarding, { resolvePersonalizationVariation } from '../onboarding';
+import onboarding, { resolveLaunchpadPersonalizationVariation } from '../onboarding';
 
 jest.mock( 'calypso/components/domains/wpcom-domain-search/use-query-handler', () => ( {
 	clearSessionStorageQuery: jest.fn(),
@@ -94,11 +94,11 @@ describe( 'onboarding flow side effects', () => {
 	} );
 } );
 
-describe( 'resolvePersonalizationVariation', () => {
+describe( 'resolveLaunchpadPersonalizationVariation', () => {
 	beforeEach( () => jest.clearAllMocks() );
 
 	it( 'forces ai_launchpad when the diy-launchpad override is present', async () => {
-		await expect( resolvePersonalizationVariation( '1' ) ).resolves.toBe( 'ai_launchpad' );
+		await expect( resolveLaunchpadPersonalizationVariation( '1' ) ).resolves.toBe( 'ai_launchpad' );
 		expect( loadExperimentAssignment ).not.toHaveBeenCalled();
 	} );
 
@@ -106,7 +106,7 @@ describe( 'resolvePersonalizationVariation', () => {
 		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
 			variationName: 'no_guidance',
 		} );
-		await expect( resolvePersonalizationVariation( null ) ).resolves.toBe( 'no_guidance' );
+		await expect( resolveLaunchpadPersonalizationVariation( null ) ).resolves.toBe( 'no_guidance' );
 		expect( loadExperimentAssignment ).toHaveBeenCalledWith(
 			'wpcom_launchpad_personalization_202607_v1'
 		);
@@ -114,6 +114,6 @@ describe( 'resolvePersonalizationVariation', () => {
 
 	it( 'falls back to control on an unrecognized assignment', async () => {
 		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( { variationName: null } );
-		await expect( resolvePersonalizationVariation( null ) ).resolves.toBe( 'control' );
+		await expect( resolveLaunchpadPersonalizationVariation( null ) ).resolves.toBe( 'control' );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -27,6 +27,7 @@ import Loading from 'calypso/components/loading';
 import useAddEcommerceTrialMutation from 'calypso/data/ecommerce/use-add-ecommerce-trial-mutation';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { resolveLaunchpadPersonalizationVariation } from 'calypso/lib/ai-launchpad';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import wpcom from 'calypso/lib/wp';
 import {
@@ -261,6 +262,14 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 		const isPlaygroundPublish =
 			sessionStorage.getItem( SESSION_KEY_FROM_PLAYGROUND_PUBLISH ) === '1';
 
+		// Assignment point for the launchpad-personalization experiment. Resolving the
+		// variation before creation lets ai_launchpad sites start with the AI Launchpad
+		// enabled, so every post-checkout path (direct, chooser, Big Sky return)
+		// converges on it regardless of which URLs the user actually visits.
+		const launchpadPersonalizationVariation = isOnboardingFlow( flow )
+			? await resolveLaunchpadPersonalizationVariation( urlQueryParams.get( 'diy-launchpad' ) )
+			: 'control';
+
 		const site = await createSite(
 			flow,
 			theme,
@@ -281,7 +290,9 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			gardenName,
 			gardenPartnerName,
 			urlQueryParams.get( 'spec_id' ),
-			isPlaygroundPublish ? 'playground-publish' : undefined
+			isPlaygroundPublish ? 'playground-publish' : undefined,
+			undefined, // provisionTarget
+			launchpadPersonalizationVariation === 'ai_launchpad'
 		);
 
 		if ( ! site ) {

--- a/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
@@ -5,6 +5,7 @@
 import { ONBOARDING_FLOW } from '@automattic/onboarding';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
+import { addSurvicate } from 'calypso/lib/analytics/survicate';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import onboarding from '../flows/onboarding/onboarding';
 import { STEPS } from '../internals/steps';
@@ -110,7 +111,6 @@ describe( 'Onboarding Flow', () => {
 
 		describe( 'Survicate side effect', () => {
 			it( 'calls addSurvicate with user data when logged in on step changes', () => {
-				const { addSurvicate } = require( 'calypso/lib/analytics/survicate' );
 				const loggedInState = {
 					currentUser: {
 						id: 123,

--- a/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
@@ -32,6 +32,13 @@ jest.mock( 'calypso/lib/analytics/survicate', () => ( {
 	addSurvicate: jest.fn(),
 } ) );
 
+// The processing step awaits the launchpad-personalization ExPlat assignment before redirecting.
+// Resolve it synchronously to control (variationName: null) so the redirect fires within the test's
+// tick instead of waiting on a real network fetch.
+jest.mock( 'calypso/lib/explat', () => ( {
+	loadExperimentAssignment: jest.fn( () => Promise.resolve( { variationName: null } ) ),
+} ) );
+
 describe( 'Onboarding Flow', () => {
 	beforeAll( () => {
 		Object.defineProperty( window, 'location', {

--- a/client/landing/stepper/declarative-flow/test/onboarding-setup-your-site-ai.ts
+++ b/client/landing/stepper/declarative-flow/test/onboarding-setup-your-site-ai.ts
@@ -4,6 +4,13 @@
 import onboarding from '../flows/onboarding/onboarding';
 import { renderFlow } from './helpers';
 
+// The blank-site exit awaits the launchpad-personalization ExPlat assignment before
+// redirecting. Resolve it synchronously to control (variationName: null) so the
+// redirect fires within the test's tick instead of waiting on a real network fetch.
+jest.mock( 'calypso/lib/explat', () => ( {
+	loadExperimentAssignment: jest.fn( () => Promise.resolve( { variationName: null } ) ),
+} ) );
+
 const originalLocation = window.location;
 const tick = () => new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
 

--- a/client/lib/ai-launchpad/index.ts
+++ b/client/lib/ai-launchpad/index.ts
@@ -1,6 +1,23 @@
+import { loadExperimentAssignment } from 'calypso/lib/explat';
+
 export const LAUNCHPAD_PERSONALIZATION_EXPERIMENT = 'wpcom_launchpad_personalization_202607_v1';
 
 export type LaunchpadPersonalizationVariation = 'control' | 'ai_launchpad' | 'no_guidance';
+
+/**
+ * Resolve the launchpad-personalization variation. The `?diy-launchpad` query param is a
+ * dev/QA override that forces the `ai_launchpad` variation without consulting ExPlat;
+ * otherwise the variation comes from the sticky ExPlat assignment.
+ */
+export async function resolveLaunchpadPersonalizationVariation(
+	diyLaunchpad: string | null
+): Promise< LaunchpadPersonalizationVariation > {
+	if ( diyLaunchpad ) {
+		return 'ai_launchpad';
+	}
+	const assignment = await loadExperimentAssignment( LAUNCHPAD_PERSONALIZATION_EXPERIMENT );
+	return normalizeVariation( assignment?.variationName );
+}
 
 /**
  * Map an ExPlat variation name onto a known variation. Anything unrecognized (including

--- a/client/lib/ai-launchpad/index.ts
+++ b/client/lib/ai-launchpad/index.ts
@@ -1,0 +1,51 @@
+export const LAUNCHPAD_PERSONALIZATION_EXPERIMENT = 'wpcom_launchpad_personalization_202607_v1';
+
+export type LaunchpadPersonalizationVariation = 'control' | 'ai_launchpad' | 'no_guidance';
+
+/**
+ * Map an ExPlat variation name onto a known variation. Anything unrecognized (including
+ * null/undefined for an unassigned or not-yet-loaded user) is treated as `control`,
+ * so an absent or misconfigured experiment degrades to today's default behavior.
+ */
+export function normalizeVariation(
+	variationName: string | null | undefined
+): LaunchpadPersonalizationVariation {
+	switch ( variationName ) {
+		case 'ai_launchpad':
+			return 'ai_launchpad';
+		case 'no_guidance':
+			return 'no_guidance';
+		default:
+			return 'control';
+	}
+}
+
+interface DestinationArgs {
+	variation: LaunchpadPersonalizationVariation;
+	/** Site admin URL, guaranteed to end in a trailing slash (e.g. `https://x/wp-admin/`). */
+	adminUrl: string;
+	/** Append `&enable-ai-launchpad=1` for the post-checkout hand-off. Defaults to false. */
+	enableAiLaunchpad?: boolean;
+}
+
+/**
+ * The wp-admin destination for a treatment variation, or null for control (the caller keeps
+ * its existing destination logic). `ai_launchpad` lands in Site Setup; `no_guidance`
+ * lands on the plain wp-admin dashboard.
+ */
+export function getLaunchpadPersonalizationDestination( {
+	variation,
+	adminUrl,
+	enableAiLaunchpad = false,
+}: DestinationArgs ): string | null {
+	switch ( variation ) {
+		case 'ai_launchpad':
+			return `${ adminUrl }admin.php?page=site-setup-wp-admin${
+				enableAiLaunchpad ? '&enable-ai-launchpad=1' : ''
+			}`;
+		case 'no_guidance':
+			return adminUrl;
+		default:
+			return null;
+	}
+}

--- a/client/lib/ai-launchpad/test/index.ts
+++ b/client/lib/ai-launchpad/test/index.ts
@@ -1,0 +1,58 @@
+import {
+	LAUNCHPAD_PERSONALIZATION_EXPERIMENT,
+	normalizeVariation,
+	getLaunchpadPersonalizationDestination,
+} from '../index';
+
+describe( 'launchpad personalization experiment', () => {
+	it( 'exposes the agreed experiment name', () => {
+		expect( LAUNCHPAD_PERSONALIZATION_EXPERIMENT ).toBe(
+			'wpcom_launchpad_personalization_202607_v1'
+		);
+	} );
+
+	describe( 'normalizeVariation', () => {
+		it( 'maps the two treatment variation names', () => {
+			expect( normalizeVariation( 'ai_launchpad' ) ).toBe( 'ai_launchpad' );
+			expect( normalizeVariation( 'no_guidance' ) ).toBe( 'no_guidance' );
+		} );
+
+		it( 'treats control, unknown, null and undefined as control', () => {
+			expect( normalizeVariation( 'control' ) ).toBe( 'control' );
+			expect( normalizeVariation( 'something-else' ) ).toBe( 'control' );
+			expect( normalizeVariation( null ) ).toBe( 'control' );
+			expect( normalizeVariation( undefined ) ).toBe( 'control' );
+		} );
+	} );
+
+	describe( 'getLaunchpadPersonalizationDestination', () => {
+		const adminUrl = 'https://example.com/wp-admin/';
+
+		it( 'returns null for control (caller falls through)', () => {
+			expect(
+				getLaunchpadPersonalizationDestination( { variation: 'control', adminUrl } )
+			).toBeNull();
+		} );
+
+		it( 'sends ai_launchpad to Site Setup, enabling the AI launchpad when asked', () => {
+			expect(
+				getLaunchpadPersonalizationDestination( {
+					variation: 'ai_launchpad',
+					adminUrl,
+					enableAiLaunchpad: true,
+				} )
+			).toBe(
+				'https://example.com/wp-admin/admin.php?page=site-setup-wp-admin&enable-ai-launchpad=1'
+			);
+			expect(
+				getLaunchpadPersonalizationDestination( { variation: 'ai_launchpad', adminUrl } )
+			).toBe( 'https://example.com/wp-admin/admin.php?page=site-setup-wp-admin' );
+		} );
+
+		it( 'sends no_guidance to the wp-admin dashboard', () => {
+			expect(
+				getLaunchpadPersonalizationDestination( { variation: 'no_guidance', adminUrl } )
+			).toBe( 'https://example.com/wp-admin/' );
+		} );
+	} );
+} );

--- a/client/lib/ai-launchpad/test/index.ts
+++ b/client/lib/ai-launchpad/test/index.ts
@@ -1,8 +1,14 @@
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import {
 	LAUNCHPAD_PERSONALIZATION_EXPERIMENT,
 	normalizeVariation,
 	getLaunchpadPersonalizationDestination,
+	resolveLaunchpadPersonalizationVariation,
 } from '../index';
+
+jest.mock( 'calypso/lib/explat', () => ( {
+	loadExperimentAssignment: jest.fn(),
+} ) );
 
 describe( 'launchpad personalization experiment', () => {
 	it( 'exposes the agreed experiment name', () => {
@@ -22,6 +28,34 @@ describe( 'launchpad personalization experiment', () => {
 			expect( normalizeVariation( 'something-else' ) ).toBe( 'control' );
 			expect( normalizeVariation( null ) ).toBe( 'control' );
 			expect( normalizeVariation( undefined ) ).toBe( 'control' );
+		} );
+	} );
+
+	describe( 'resolveLaunchpadPersonalizationVariation', () => {
+		beforeEach( () => jest.clearAllMocks() );
+
+		it( 'forces ai_launchpad when the diy-launchpad override is present', async () => {
+			await expect( resolveLaunchpadPersonalizationVariation( '1' ) ).resolves.toBe(
+				'ai_launchpad'
+			);
+			expect( loadExperimentAssignment ).not.toHaveBeenCalled();
+		} );
+
+		it( 'reads the variation from ExPlat when no override is present', async () => {
+			( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
+				variationName: 'no_guidance',
+			} );
+			await expect( resolveLaunchpadPersonalizationVariation( null ) ).resolves.toBe(
+				'no_guidance'
+			);
+			expect( loadExperimentAssignment ).toHaveBeenCalledWith(
+				'wpcom_launchpad_personalization_202607_v1'
+			);
+		} );
+
+		it( 'falls back to control on an unrecognized assignment', async () => {
+			( loadExperimentAssignment as jest.Mock ).mockResolvedValue( { variationName: null } );
+			await expect( resolveLaunchpadPersonalizationVariation( null ) ).resolves.toBe( 'control' );
 		} );
 	} );
 

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -4,6 +4,8 @@ import { captureException } from '@automattic/calypso-sentry';
 import { fetchLaunchpad } from '@automattic/data-stores';
 import { areLaunchpadTasksCompleted } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper';
 import { isRemovedFlow } from 'calypso/landing/stepper/utils/flow-redirect-handler';
+import { LAUNCHPAD_PERSONALIZATION_EXPERIMENT, normalizeVariation } from 'calypso/lib/ai-launchpad';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { getQueryArgs } from 'calypso/lib/query-args';
 import { getSiteFragment } from 'calypso/lib/route';
 import { bumpStat } from 'calypso/state/analytics/actions';
@@ -85,6 +87,19 @@ export async function maybeRedirect( context, next ) {
 			siteId,
 			aiLaunchpadStatus === 'active' ? 'admin.php?page=site-setup-wp-admin' : 'index.php'
 		);
+		if ( redirectUrl ) {
+			window.location.replace( redirectUrl );
+			return;
+		}
+	}
+
+	// The no_guidance launchpad-personalization variation gets no guidance surface at all:
+	// keep these sites off My Home, landing them on the plain wp-admin dashboard.
+	const personalizationAssignment = await loadExperimentAssignment(
+		LAUNCHPAD_PERSONALIZATION_EXPERIMENT
+	);
+	if ( normalizeVariation( personalizationAssignment?.variationName ) === 'no_guidance' ) {
+		const redirectUrl = getSiteAdminUrl( state, siteId, 'index.php' );
 		if ( redirectUrl ) {
 			window.location.replace( redirectUrl );
 			return;

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -158,7 +158,8 @@ export const createSite = async (
 	gardenPartnerName?: string | null,
 	specId?: string | null,
 	ref?: string,
-	provisionTarget?: string | null
+	provisionTarget?: string | null,
+	aiLaunchpadEnabled?: boolean
 ) => {
 	const siteUrl = storedSiteUrl || domainItem?.domain_name;
 
@@ -217,6 +218,10 @@ export const createSite = async (
 					: {} ),
 				...( siteGoals && { site_goals: siteGoals } ),
 				...( ( ref ?? refParam ) && { ref: ref ?? refParam } ),
+				// Enables the wp-admin AI Launchpad from the moment the site exists, so every
+				// post-checkout path (direct, chooser, Big Sky return) converges on it. The
+				// option is in the WoA transfer allowlist, so it survives the Atomic transfer.
+				...( aiLaunchpadEnabled && { wpcom_ai_launchpad_enabled: true } ),
 				// Trigger backend build for ai-site-builder flow with commerce garden and spec_id
 				...( flowName === AI_SITE_BUILDER_FLOW &&
 					gardenName === 'commerce' &&


### PR DESCRIPTION
Part of DOTOBRD-567

## Proposed Changes

Integrate the `wpcom_launchpad_personalization_202607_v1` ExPlat experiment into onboarding and layer the new `no_guidance` variation onto the existing AI-launchpad surfaces. Three variations: `control` (today's experience), `ai_launchpad` (AI Launchpad in wp-admin, no old Launchpad, no My Home), and `no_guidance` (no launchpads at all).

Built on top of #112569, which already replaces My Home + the legacy launchpad for AI-launchpad sites based on the site's real launchpad status (`getAiLaunchpadStatus` / `useAiLaunchpad`). That covers `ai_launchpad`, so this PR only adds what the experiment uniquely needs:

* Add a self-contained `client/lib/ai-launchpad` module: experiment name, variation type, `normalizeVariation`, `resolveLaunchpadPersonalizationVariation`, and the wp-admin destination helper. (Added to the Dashboard import allowlist, same pattern as `calypso/lib/explat`.)
* **Assignment at site creation**: the variation resolves in the create-site step (onboarding flow only; `?diy-launchpad` kept as a dev/QA override forcing `ai_launchpad`), and `ai_launchpad` sites are created with `wpcom_ai_launchpad_enabled` via a new `/sites/new` option (230563-ghe-Automattic/wpcom). Enabling at creation — instead of via the `?enable-ai-launchpad=1` hand-off URL — makes every post-checkout path (direct, Big Sky chooser, Big Sky return) converge on the enabled launchpad, and the option survives the Atomic transfer.
* **Chooser shows in all arms**: the post-checkout AI/manual chooser (Big Sky) is no longer skipped for treatment users, so the Big Sky pick rate is a measurable outcome rather than a confounder. Treatments only replace the *default* My Home landing — `ai_launchpad` → wp-admin Site Setup, `no_guidance` → the wp-admin dashboard — while the functional handoffs (plugin-by-goal install, playground/blueprint import, Woo hosting-solutions → wc-admin) keep their destinations in every arm. The blank-site chooser exit goes straight to the variation destination instead of bouncing through `/home`. A companion Jetpack PR (Automattic/jetpack#50830, follow-up to Automattic/jetpack#50803) keeps explicitly enabled sites eligible for the AI Launchpad after a Big Sky build.
* **My Home** (`/home`): add a `no_guidance` branch that redirects these sites to the wp-admin dashboard (reusing #112569's `getSiteAdminUrl`). `ai_launchpad` is already handled by #112569. The assignment read is deliberately awaited (blocking): cold-cache latency once per device is preferred over flashing the wrong screen.
* **Dashboard site list**: hide the "Finish setup" nag for `no_guidance`. The `ai_launchpad` / completed cases are already handled by #112569's `useAiLaunchpad`.

Known accepted trade-offs: assignment happens at site creation (pre-checkout), so checkout abandoners are enrolled — equally across arms, so noise rather than bias. The `no_guidance` per-user suppression can override a manually enabled site's launchpad UX in the Dashboard (edge case, deliberately ignored).

## Why are these changes being made?

Replaces the temporary `?diy-launchpad` hand-off with a real, measurable experiment. Site creation is the single assignment point; other surfaces read the sticky ExPlat assignment. The `ai_launchpad` variation flows through the site-state machinery #112569 added, so this PR deliberately does not duplicate it — it assigns the variation, creates the site in the right state, and adds the `no_guidance` suppression that has no site-state signal.

## Testing Instructions

* Force `ai_launchpad` locally by appending `?diy-launchpad=1` in onboarding; seed the ExPlat assignment for `no_guidance` / `control`.
* Onboarding: complete a paid onboarding checkout. All arms see the Big Sky chooser (when plan-eligible). Landing after the chooser's blank-site pick (or without a chooser): `ai_launchpad` → wp-admin Site Setup; `no_guidance` → wp-admin dashboard; `control` → existing behavior. `ai_launchpad` sites have `wpcom_ai_launchpad_enabled` set from creation.
* My Home: as a `no_guidance` user, load `/home/:site` and confirm the redirect to the wp-admin dashboard; `control` stays on My Home. (`ai_launchpad` redirect is #112569's behavior.)
* Dashboard site list: confirm the "Finish setup" nag disappears for `no_guidance`.
* `yarn test-client` for the touched suites (57 passing) and `yarn typecheck-client`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation? (no new strings)
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
