### PR TITLE
Fix 500 on domain routes for sites with a relative icon path

### DIFF
--- a/client/dashboard/components/site-icon/index.tsx
+++ b/client/dashboard/components/site-icon/index.tsx
@@ -19,13 +19,15 @@ export default function SiteIcon( { site, size = 48 }: { site: Site; size?: numb
 		if ( ! ico ) {
 			return;
 		}
-		const url = new URL( ico );
+		// Atomic `/sites/:slug` can return a relative upload path instead of a full URL;
+		// resolve it against the site URL so the icon still renders (and we don't crash).
+		const url = new URL( ico, site.URL );
 		// wordpress.com/wp-content works with w.
 		url.searchParams.set( 'w', '96' );
 		// "blavatar" works with s.
 		url.searchParams.set( 's', '96' );
 		return url.toString();
-	}, [ ico ] );
+	}, [ ico, site.URL ] );
 
 	const className = clsx( {
 		'is-small': size <= 16,

--- a/client/dashboard/components/site-icon/index.tsx
+++ b/client/dashboard/components/site-icon/index.tsx
@@ -19,8 +19,7 @@ export default function SiteIcon( { site, size = 48 }: { site: Site; size?: numb
 		if ( ! ico ) {
 			return;
 		}
-		// Atomic `/sites/:slug` can return a relative upload path instead of a full URL;
-		// resolve it against the site URL so the icon still renders (and we don't crash).
+		// Atomic `/sites/:slug` can return a relative upload path instead of a full URL.
 		const url = new URL( ico, site.URL );
 		// wordpress.com/wp-content works with w.
 		url.searchParams.set( 'w', '96' );


### PR DESCRIPTION
Part of DOTMSD-1464

## Proposed Changes

* Resolve the site icon in `SiteIcon` against `site.URL` (`new URL( ico, site.URL )`) instead of `new URL( ico )`.

## Why are these changes being made?

Some sites (observed on Atomic) return the site icon as a **relative upload path** (e.g. `/wp-content/uploads/2022/09/cropped-icon.png`) rather than a full URL. `/me/sites` returns a fully-formed icon URL, but `/sites/:slug` can return just the path, so the dashboard must be resilient to that response shape.

`new URL( ico )` with a bare relative path throws `TypeError: Failed to construct 'URL': Invalid URL` synchronously inside the `useMemo` during render, which crashes the entire route with a `500 / Something wrong happened` — affecting domain management pages in both Calypso and the multi-site dashboard.

Passing `site.URL` as the base:
* makes relative paths resolve to a valid absolute URL on the site's own origin, so the icon actually renders;
* leaves already-absolute icon URLs unchanged (the base is ignored when the input is absolute);
* guarantees `new URL()` no longer throws, eliminating the 500.

## Testing Instructions

* Check out this branch and load a domain management route (e.g. `/domains/manage/example.com`) for a site whose site-icon API response is a relative path (`/wp-content/uploads/.../icon.png`).
* Before: the page crashes with `500 / Something wrong happened` and a console `TypeError: Failed to construct 'URL': Invalid URL`.
* After: the route loads and the site icon renders (resolved against the site's own domain).
* Also verify a site with a normal absolute-URL icon still renders its icon unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
