### PR TITLE
A4A Overview: Pad the "Next steps" checklist items

### DIFF
--- a/client/a8c-for-agencies/sections/overview/body/next-steps/style.scss
+++ b/client/a8c-for-agencies/sections/overview/body/next-steps/style.scss
@@ -44,6 +44,10 @@
 
 	.checklist-item__task {
 
+		.checklist-item__task-content {
+			padding-inline: 16px;
+		}
+
 		.checklist-item__text {
 			@include body-medium;
 			color: var(--color-neutral-80);


### PR DESCRIPTION
Fixes A4A-3074

## Proposed Changes

Inset the Agency Overview "Next steps" checklist rows by 16px inline, scoped under `.next-steps`:

```scss
.checklist-item__task {
    .checklist-item__task-content {
        padding-inline: 16px;
    }
}
```

One file, four lines.

## Why are these changes being made?

The "Next steps" checklist on the Agency Overview renders Launchpad's `ChecklistItem` component, whose task content ships with `padding: 16px 0` — vertical padding only, since Launchpad's own layout supplies the horizontal inset.

Inside the Overview card there is no such inset, so the row label sat flush against the card's inner left edge and the chevron flush against the right. The list read as cramped next to the neighbouring Overview cards, which is unfortunate placement for the first thing a new agency sees on the dashboard.

Adding the inline padding restores the breathing room. It is scoped under `.next-steps` so no other Launchpad consumer is affected.

## Testing instructions

Prerequisites: a local A4A dev instance (`yarn start-a8c-for-agencies`), signed in to an agency account that still has incomplete onboarding steps (so the checklist renders).

1. Go to `/overview`.
2. Find the **Next steps** card — the checklist with "Add a site", "Explore our best-in-class hosting and plugins", "Start earning commission on referrals", "Invite your team".
3. Verify each row's label is inset from the left edge of the card and the chevron from the right, rather than sitting flush against them.
4. Verify the rows still align with the other content in the card, and that spacing looks consistent with the neighbouring Overview cards.
5. Narrow the browser to a mobile width and confirm the padding holds and nothing wraps awkwardly.
6. Check any other Launchpad checklist in the product (e.g. onboarding flows outside A4A) is unchanged — the rule is scoped to `.next-steps`.

## Notes

- The selector targets `ChecklistItem`'s own class names, which is how this stylesheet already customises the component (`.checklist-item__task`, `.checklist-item__text` are styled a few lines below). Scoping under `.next-steps` keeps the blast radius to this one card.
- No tests: this is a CSS-only change, and jsdom does not compute layout.
- The same card is also reported as missing its border-radius in A4A-3049, which is filed separately and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
