### PR TITLE
Revert "Domain-only flow: skip site-or-domain for logged-out users too"

### DIFF
--- a/client/signup/steps/domains/index.tsx
+++ b/client/signup/steps/domains/index.tsx
@@ -28,7 +28,7 @@ import {
 	domainManagementTransferToOtherSite,
 } from 'calypso/my-sites/domains/paths';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { getNextStepName, getStepUrl } from 'calypso/signup/utils';
+import { getStepUrl } from 'calypso/signup/utils';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
@@ -60,7 +60,6 @@ const DomainSearchUI = (
 		stepName,
 		submitSignupStep,
 		goToNextStep,
-		goToStep,
 		locale,
 		queryObject,
 		baseSubmitStepProps,
@@ -72,7 +71,6 @@ const DomainSearchUI = (
 	const isDomainOnlyFlow = flowName === 'domain';
 	const isOnboardingWithEmailFlow = flowName === 'onboarding-with-email';
 
-	const isLoggedIn = useSelector( isUserLoggedIn );
 	const site = useSelector( getSelectedSite );
 
 	const siteSlug = queryObject.siteSlug;
@@ -222,19 +220,6 @@ const DomainSearchUI = (
 						{ stepName: 'plans-site-selected', wasSkipped: true },
 						{ cartItems: null }
 					);
-
-					// For logged-out users the account step is still pending, so the flow isn't
-					// "every step submitted" and the default goToNextStep() advances by array index
-					// from 'domain-only' back onto the just-skipped 'site-or-domain' step. Advance
-					// from the last auto-submitted step instead: logged-out users go to the account
-					// step, logged-in users fall through to checkout.
-					const nextStep = getNextStepName( flowName, 'plans-site-selected', isLoggedIn );
-					if ( nextStep ) {
-						goToStep( nextStep );
-					} else {
-						goToNextStep();
-					}
-					return;
 				}
 
 				goToNextStep();
@@ -272,8 +257,6 @@ const DomainSearchUI = (
 		clearQuery,
 		submitSignupStep,
 		goToNextStep,
-		goToStep,
-		isLoggedIn,
 		locale,
 		isDomainOnlyFlow,
 		baseSubmitStepProps,

--- a/client/signup/steps/domains/test/index.tsx
+++ b/client/signup/steps/domains/test/index.tsx
@@ -34,13 +34,11 @@ const baseProps = {
 	previousStepName: null,
 };
 
-function renderStep( props = baseProps, options = {} ) {
+function renderStep( props = baseProps ) {
 	mockWPCOMDomainSearch.mockClear();
-	renderWithProvider( <DomainSearchStep { ...props } />, options );
+	renderWithProvider( <DomainSearchStep { ...props } /> );
 	return mockWPCOMDomainSearch.mock.calls[ 0 ][ 0 ].events;
 }
-
-const LOGGED_IN_STATE = { currentUser: { id: 12345 } };
 
 describe( 'DomainSearchStep — domain-only checkout simplification', () => {
 	beforeEach( () => {
@@ -48,11 +46,10 @@ describe( 'DomainSearchStep — domain-only checkout simplification', () => {
 		mockWPCOMDomainSearch.mockReturnValue( null );
 	} );
 
-	it( 'auto-submits the skipped steps and routes logged-out users to the account step', () => {
+	it( 'auto-submits site-or-domain, site-picker, and plans-site-selected in the domain flow', () => {
 		const submitSignupStep = jest.fn();
-		const goToStep = jest.fn();
 		const goToNextStep = jest.fn();
-		const events = renderStep( { ...baseProps, submitSignupStep, goToStep, goToNextStep } );
+		const events = renderStep( { ...baseProps, submitSignupStep, goToNextStep } );
 
 		events.onContinue( [ domainItem ] );
 
@@ -86,27 +83,7 @@ describe( 'DomainSearchStep — domain-only checkout simplification', () => {
 			expect.objectContaining( { stepName: 'plans-site-selected', wasSkipped: true } ),
 			expect.objectContaining( { cartItems: null } )
 		);
-		// Logged out: jump to the account step instead of the skipped site-or-domain step.
-		expect( goToStep ).toHaveBeenCalledTimes( 1 );
-		expect( goToStep ).toHaveBeenCalledWith( expect.stringMatching( /^user/ ) );
-		expect( goToNextStep ).not.toHaveBeenCalled();
-	} );
-
-	it( 'skips straight to checkout for logged-in users in the domain flow', () => {
-		const submitSignupStep = jest.fn();
-		const goToStep = jest.fn();
-		const goToNextStep = jest.fn();
-		const events = renderStep(
-			{ ...baseProps, submitSignupStep, goToStep, goToNextStep },
-			{ initialState: LOGGED_IN_STATE }
-		);
-
-		events.onContinue( [ domainItem ] );
-
-		// Same auto-submitted steps, but no account step remains, so proceed to checkout.
-		expect( submitSignupStep ).toHaveBeenCalledTimes( 4 );
 		expect( goToNextStep ).toHaveBeenCalledTimes( 1 );
-		expect( goToStep ).not.toHaveBeenCalled();
 	} );
 
 	it( 'submits the domain step and does not skip steps in a non-domain flow', () => {

--- a/client/signup/steps/domains/types.ts
+++ b/client/signup/steps/domains/types.ts
@@ -2,7 +2,7 @@ export type StepProps = {
 	stepSectionName: string | null;
 	stepName: string;
 	flowName: string;
-	goToStep: ( stepName?: string, stepSectionName?: string, flowName?: string ) => void;
+	goToStep: () => void;
 	goToNextStep: () => void;
 	submitSignupStep: ( step: unknown, dependencies: unknown ) => void;
 	queryObject: Record< string, string | undefined >;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#112890