### PR TITLE
Revert "Revert "Domain-only flow: skip site-or-domain for logged-out users too""

### DIFF
--- a/client/signup/steps/domains/index.tsx
+++ b/client/signup/steps/domains/index.tsx
@@ -28,7 +28,7 @@ import {
 	domainManagementTransferToOtherSite,
 } from 'calypso/my-sites/domains/paths';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { getStepUrl } from 'calypso/signup/utils';
+import { getNextStepName, getStepUrl } from 'calypso/signup/utils';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
@@ -60,6 +60,7 @@ const DomainSearchUI = (
 		stepName,
 		submitSignupStep,
 		goToNextStep,
+		goToStep,
 		locale,
 		queryObject,
 		baseSubmitStepProps,
@@ -71,6 +72,7 @@ const DomainSearchUI = (
 	const isDomainOnlyFlow = flowName === 'domain';
 	const isOnboardingWithEmailFlow = flowName === 'onboarding-with-email';
 
+	const isLoggedIn = useSelector( isUserLoggedIn );
 	const site = useSelector( getSelectedSite );
 
 	const siteSlug = queryObject.siteSlug;
@@ -220,6 +222,19 @@ const DomainSearchUI = (
 						{ stepName: 'plans-site-selected', wasSkipped: true },
 						{ cartItems: null }
 					);
+
+					// For logged-out users the account step is still pending, so the flow isn't
+					// "every step submitted" and the default goToNextStep() advances by array index
+					// from 'domain-only' back onto the just-skipped 'site-or-domain' step. Advance
+					// from the last auto-submitted step instead: logged-out users go to the account
+					// step, logged-in users fall through to checkout.
+					const nextStep = getNextStepName( flowName, 'plans-site-selected', isLoggedIn );
+					if ( nextStep ) {
+						goToStep( nextStep );
+					} else {
+						goToNextStep();
+					}
+					return;
 				}
 
 				goToNextStep();
@@ -257,6 +272,8 @@ const DomainSearchUI = (
 		clearQuery,
 		submitSignupStep,
 		goToNextStep,
+		goToStep,
+		isLoggedIn,
 		locale,
 		isDomainOnlyFlow,
 		baseSubmitStepProps,

--- a/client/signup/steps/domains/test/index.tsx
+++ b/client/signup/steps/domains/test/index.tsx
@@ -34,11 +34,13 @@ const baseProps = {
 	previousStepName: null,
 };
 
-function renderStep( props = baseProps ) {
+function renderStep( props = baseProps, options = {} ) {
 	mockWPCOMDomainSearch.mockClear();
-	renderWithProvider( <DomainSearchStep { ...props } /> );
+	renderWithProvider( <DomainSearchStep { ...props } />, options );
 	return mockWPCOMDomainSearch.mock.calls[ 0 ][ 0 ].events;
 }
+
+const LOGGED_IN_STATE = { currentUser: { id: 12345 } };
 
 describe( 'DomainSearchStep — domain-only checkout simplification', () => {
 	beforeEach( () => {
@@ -46,10 +48,11 @@ describe( 'DomainSearchStep — domain-only checkout simplification', () => {
 		mockWPCOMDomainSearch.mockReturnValue( null );
 	} );
 
-	it( 'auto-submits site-or-domain, site-picker, and plans-site-selected in the domain flow', () => {
+	it( 'auto-submits the skipped steps and routes logged-out users to the account step', () => {
 		const submitSignupStep = jest.fn();
+		const goToStep = jest.fn();
 		const goToNextStep = jest.fn();
-		const events = renderStep( { ...baseProps, submitSignupStep, goToNextStep } );
+		const events = renderStep( { ...baseProps, submitSignupStep, goToStep, goToNextStep } );
 
 		events.onContinue( [ domainItem ] );
 
@@ -83,7 +86,27 @@ describe( 'DomainSearchStep — domain-only checkout simplification', () => {
 			expect.objectContaining( { stepName: 'plans-site-selected', wasSkipped: true } ),
 			expect.objectContaining( { cartItems: null } )
 		);
+		// Logged out: jump to the account step instead of the skipped site-or-domain step.
+		expect( goToStep ).toHaveBeenCalledTimes( 1 );
+		expect( goToStep ).toHaveBeenCalledWith( expect.stringMatching( /^user/ ) );
+		expect( goToNextStep ).not.toHaveBeenCalled();
+	} );
+
+	it( 'skips straight to checkout for logged-in users in the domain flow', () => {
+		const submitSignupStep = jest.fn();
+		const goToStep = jest.fn();
+		const goToNextStep = jest.fn();
+		const events = renderStep(
+			{ ...baseProps, submitSignupStep, goToStep, goToNextStep },
+			{ initialState: LOGGED_IN_STATE }
+		);
+
+		events.onContinue( [ domainItem ] );
+
+		// Same auto-submitted steps, but no account step remains, so proceed to checkout.
+		expect( submitSignupStep ).toHaveBeenCalledTimes( 4 );
 		expect( goToNextStep ).toHaveBeenCalledTimes( 1 );
+		expect( goToStep ).not.toHaveBeenCalled();
 	} );
 
 	it( 'submits the domain step and does not skip steps in a non-domain flow', () => {

--- a/client/signup/steps/domains/types.ts
+++ b/client/signup/steps/domains/types.ts
@@ -2,7 +2,7 @@ export type StepProps = {
 	stepSectionName: string | null;
 	stepName: string;
 	flowName: string;
-	goToStep: () => void;
+	goToStep: ( stepName?: string, stepSectionName?: string, flowName?: string ) => void;
 	goToNextStep: () => void;
 	submitSignupStep: ( step: unknown, dependencies: unknown ) => void;
 	queryObject: Record< string, string | undefined >;

--- a/test/e2e/specs/flows/start-domain__purchase-flows.spec.ts
+++ b/test/e2e/specs/flows/start-domain__purchase-flows.spec.ts
@@ -2,11 +2,10 @@ import {
 	BrowserManager,
 	NewTestUserDetails,
 	NewUserResponse,
-	NewSiteResponse,
 	RestAPIClient,
 } from '@automattic/calypso-e2e';
 import { skipIfNotTrunk, tags, test } from '../../lib/pw-base';
-import { apiCloseAccount, apiDeleteSite } from '../shared';
+import { apiCloseAccount } from '../shared';
 
 test.describe(
 	'Start Domain Only Flows',
@@ -19,65 +18,7 @@ test.describe(
 		const accountsToCleanup: {
 			testUser: NewTestUserDetails;
 			newUserDetails: NewUserResponse;
-			newSiteDetails?: NewSiteResponse;
 		}[] = [];
-
-		test( 'As a new user, I can complete the domain-only flow and purchase a domain with a plan', async ( {
-			page,
-			componentDomainSearch,
-			helperData,
-			pageCartCheckout,
-			pageSignupPickPlan,
-			pageUserSignUp,
-		} ) => {
-			const testUser = helperData.getNewTestUser();
-			const planName = 'Personal';
-			let selectedDomain: string;
-			let newUserDetails: NewUserResponse;
-			let newSiteDetails: NewSiteResponse;
-
-			await test.step( 'When I enter the domain-only flow', async function () {
-				BrowserManager.setStoreCookie( page, { currency: 'USD' } );
-				await page.goto( helperData.getCalypsoURL( '/start/domain' ) );
-			} );
-
-			await test.step( 'And I search for a domain', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
-			} );
-
-			await test.step( 'And I add the first suggestion to the cart', async function () {
-				selectedDomain = await componentDomainSearch.selectFirstSuggestion();
-			} );
-
-			await test.step( 'And I continue to the next step', async function () {
-				await componentDomainSearch.continue();
-			} );
-
-			await test.step( 'And I select "New site" option', async function () {
-				await componentDomainSearch.selectNewSite();
-			} );
-
-			await test.step( `And I select the ${ planName } plan`, async function () {
-				await pageSignupPickPlan.selectPlanWithoutSiteCreation(
-					planName,
-					new RegExp( '.*start/domain/user-social.*' )
-				);
-			} );
-
-			await test.step( 'And I sign up as a new user and wait for site creation', async function () {
-				[ newUserDetails, newSiteDetails ] =
-					await pageUserSignUp.signupWithEmailAndWaitForSiteCreation( testUser.email );
-				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
-			} );
-
-			await test.step( 'Then I see the plan at checkout', async function () {
-				await pageCartCheckout.validateCartItem( `WordPress.com ${ planName }` );
-			} );
-
-			await test.step( 'And I see the domain at checkout', async function () {
-				await pageCartCheckout.validateCartItem( selectedDomain );
-			} );
-		} );
 
 		test( 'As a new user, I can complete the domain-only flow and purchase just a domain (no site)', async ( {
 			page,
@@ -107,10 +48,6 @@ test.describe(
 				await componentDomainSearch.continue();
 			} );
 
-			await test.step( 'And I select "Just buy a domain" option', async function () {
-				await componentDomainSearch.selectJustBuyADomain();
-			} );
-
 			await test.step( 'And I sign up as a new user', async function () {
 				newUserDetails = await pageUserSignUp.signupWithEmail( testUser.email );
 				accountsToCleanup.push( { testUser, newUserDetails } );
@@ -130,14 +67,6 @@ test.describe(
 					},
 					account.newUserDetails.body.bearer_token
 				);
-
-				if ( account.newSiteDetails ) {
-					await apiDeleteSite( restAPIClient, {
-						url: account.newSiteDetails.blog_details.url,
-						id: account.newSiteDetails.blog_details.blogid,
-						name: account.newSiteDetails.blog_details.blogname,
-					} );
-				}
 
 				await apiCloseAccount( restAPIClient, {
 					userID: account.newUserDetails.body.user_id,


### PR DESCRIPTION
Part of DOTPROD-122

Re-lands #112890, which was reverted in #112956 because the `@calypso-release` E2E suite failed on pre-release. This PR brings the fix back **and** updates that E2E suite to match the simplified flow, so it no longer breaks pre-release.

## Proposed Changes

**Re-landed from #112890 (domain-only flow fix):**

* Makes the domain-only checkout simplification skip the "Choose how to use your domain" (`site-or-domain`) step for **logged-out** users too, not only logged-in users.
* In the `domain-only` step's `onContinue`, after auto-submitting `site-or-domain`, `site-picker`, and `plans-site-selected`, navigate from the last auto-submitted step in a login-aware way (via `getNextStepName`) instead of relying on `goToNextStep()`.
* Widens the `goToStep` prop type to accept a target step name.

**New in this PR (pre-release E2E fix):**

* Updates `test/e2e/specs/flows/start-domain__purchase-flows.spec.ts` to match the simplified flow:
  * Drops the obsolete "Just buy a domain" selection from the domain-only purchase test (a new/logged-out user now goes straight from domain search to sign-up and checkout).
  * Removes the "purchase a domain with a plan" test: the "New site + plan" journey no longer exists in `/start/domain`.

## Why are these changes being made?

The `calypso_signup_domain_only_checkout_simplification_v1` treatment (shipped as the default in #112218) only skipped `site-or-domain` for logged-in users. For logged-out users, the still-pending account step left the flow "not every step submitted", so the framework's `goToNextStep()` advanced by array index from `domain-only` straight back onto the just-skipped `site-or-domain` step.

When #112890 fixed that, the `@calypso-release` suite still exercised the old flow (it clicked "Just buy a domain" / "New site" on the now-skipped step), so it failed on pre-release and the fix was reverted in #112956. Those tests encoded the pre-simplification journey; this PR updates them so the fix can land cleanly.

## Testing Instructions

Use the **Calypso Live** link from the auto-generated comment on this PR.

**Logged out**

1. Make sure you are logged out.
2. Go to `/start/domain/domain-only`.
3. Add a domain to the cart and press continue.
4. Check that the next step is the sign-up (account creation) step, not "Choose how to use your domain".
5. After logging in / creating the account, check that the next step is checkout.

**Logged in**

1. While logged in, add a domain to the cart and press continue.
2. Check that the next step is checkout.

**Automated**

* Unit: `yarn test-client client/signup/steps/domains`
* E2E (pre-release): the `@calypso-release` `Start Domain Only Flows` suite. It is gated by `skipIfNotTrunk()`, so to run it against a branch/live build set `BRANCH_NAME=trunk` and point `CALYPSO_BASE_URL` at the Calypso Live link.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
