### PR TITLE
A4A Monitor: Render the Upgrade badge tooltip above the notification modal

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/style.scss
@@ -1,7 +1,7 @@
 @import "@automattic/typography/styles/variables";
 
-.upgrade-popover {
-	z-index: 100000;
+.popover.upgrade-popover {
+	z-index: 100201;
 	border-radius: 4px;
 
 	.popover__inner {


### PR DESCRIPTION
Fixes A4A-3077

## Proposed Changes

Raise the popover above the modal overlay, in the component's own stylesheet:

```scss
.popover.upgrade-popover {
	z-index: 100201;
}
```

One file. The value is set directly rather than through the `z-index()` registry, since that registry is slated for removal; a comment records that it has to clear `@wordpress/components`' modal overlay at `100000`, so the number isn't mysterious later.

## Why are these changes being made?

In the Monitor notification settings, the **"Set custom notification"** modal has an **UPGRADE** badge beside the disabled *+ Add email address* control. Hovering it produced a tooltip that rendered *behind* the modal, so the text explaining why the control is disabled — and what upgrading unlocks — was unreadable at exactly the moment an agency is deciding whether to upgrade.

Two things were wrong:

1. **The value was too low.** `@wordpress/components`' modal overlay (`.components-modal__screen-overlay`) sits at `z-index: 100000`. The popover declared exactly `100000` too, so the modal — later in the DOM — won.
2. **The selector was too weak.** The base `.popover` rule is duplicated into several async CSS chunks, so a single-class `.upgrade-popover` override lost to whichever chunk loaded last. Qualifying it as `.popover.upgrade-popover` keeps it ahead on specificity.

## Scope: what is and isn't affected

This is confined to the jetpack-cloud downtime-monitoring components that A4A reuses. Checked and **not** affected:

- Calypso's own `Tooltip` (`.tooltip.popover`) sits at `100000`, and its source comment says it exists precisely to clear modals.
- A4A's `A4APopover` is built on `@wordpress/components` `Popover`, which sits at `1000000`.

So A4A's own popovers and tooltips over modals were already fine — this was not a systemic problem.

## Testing instructions

Prerequisites: a local A4A dev instance (`yarn start-a8c-for-agencies`), signed in to an agency account, and a site where multiple email recipients are **not** available (so the UPGRADE badge renders).

1. Go to `/sites` and open a site's Monitor notification settings.
2. Open the **"Set custom notification"** modal.
3. Hover the **UPGRADE** badge next to *+ Add email address*.
4. Verify the "Maximize uptime…" tooltip renders fully **above** the modal and is readable. Before this change it was painted behind the modal surface.
5. Confirm other popovers still behave: open an ellipsis menu in the sites list, and hover a tooltip elsewhere in the dashboard.

## Notes for reviewers

- **Narrow widths were not observed.** The automated viewport resize would not shrink Chrome's window below 1512px. Instead, the compiled `@wordpress/components` stylesheet was checked to confirm `.components-modal__screen-overlay`'s `z-index: 100000` is declared once with no media-query variant (only `.components-modal__frame` geometry changes at ≥600px), so the fix is viewport-independent. Still worth a quick manual check.
- The component stylesheet lives under `client/jetpack-cloud/`, not `client/a8c-for-agencies/` — that is where the buggy component lives, so it is the right place for the fix rather than an A4A-side override.
