### PR TITLE
Dashboard: turn the custom-domain recovery warning into a notice with a clear CTA

### DIFF
--- a/client/dashboard/me/profile-personal-details/email-section.tsx
+++ b/client/dashboard/me/profile-personal-details/email-section.tsx
@@ -1,7 +1,10 @@
 import { accountRecoveryQuery, cancelPendingEmailChangeMutation } from '@automattic/api-queries';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { Link } from '@tanstack/react-router';
-import { __experimentalInputControl as InputControl, Button } from '@wordpress/components';
+import {
+	__experimentalInputControl as InputControl,
+	__experimentalVStack as VStack,
+	Button,
+} from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, info, check } from '@wordpress/icons';
@@ -9,6 +12,8 @@ import emailValidator from 'email-validator';
 import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../../app/auth';
 import { withSnackbar } from '../../app/snackbars/with-snackbar';
+import Notice from '../../components/notice';
+import RouterLinkButton from '../../components/router-link-button';
 import { recoveryEmailMatchesAccountEmail } from '../security-account-recovery/utils';
 import { isCustomDomainEmail } from './email-utils';
 import { useIsEmailWritePending } from './use-email-write-pending';
@@ -128,9 +133,6 @@ export default function EmailSection( {
 		if ( showBouncingEmailError ) {
 			return 'has-error';
 		}
-		if ( showCustomDomainWarning ) {
-			return 'has-warning';
-		}
 		if ( emailValidationState === 'valid' ) {
 			return 'has-success';
 		}
@@ -177,24 +179,6 @@ export default function EmailSection( {
 			);
 		}
 
-		if ( showCustomDomainWarning ) {
-			return (
-				<>
-					<Icon icon={ info } size={ 16 } />
-					<span>
-						{ createInterpolateElement(
-							__(
-								'This email uses a custom domain. If your domain expires, you’d lose access to account recovery. <a>Set up a recovery email or phone number</a> to keep access to your account.'
-							),
-							{
-								a: <Link to="/me/security/account-recovery" />,
-							}
-						) }
-					</span>
-				</>
-			);
-		}
-
 		// Input validation messages
 		if ( value && value !== currentEmail ) {
 			if ( emailValidationState === 'valid' ) {
@@ -226,7 +210,6 @@ export default function EmailSection( {
 		isEmailPending,
 		isEmailVerified,
 		showBouncingEmailError,
-		showCustomDomainWarning,
 		value,
 		currentEmail,
 		emailValidationState,
@@ -235,18 +218,35 @@ export default function EmailSection( {
 	] );
 
 	return (
-		<InputControl
-			__next40pxDefaultSize
-			id="email-input"
-			type="text"
-			label={ __( 'Email address' ) }
-			value={ value }
-			onChange={ ( newValue ) => onChange( newValue ?? '' ) }
-			autoComplete="email"
-			disabled={ disabled || isEmailPending }
-			className={ getValidationClass() }
-			help={ getHelpText() }
-			aria-describedby={ getHelpText() ? 'email-help' : undefined }
-		/>
+		<VStack spacing={ 4 }>
+			<InputControl
+				__next40pxDefaultSize
+				id="email-input"
+				type="text"
+				label={ __( 'Email address' ) }
+				value={ value }
+				onChange={ ( newValue ) => onChange( newValue ?? '' ) }
+				autoComplete="email"
+				disabled={ disabled || isEmailPending }
+				className={ getValidationClass() }
+				help={ getHelpText() }
+				aria-describedby={ getHelpText() ? 'email-help' : undefined }
+			/>
+			{ showCustomDomainWarning && (
+				<Notice
+					variant="warning"
+					title={ __( 'Protect access to your account' ) }
+					actions={
+						<RouterLinkButton variant="primary" to="/me/security/account-recovery">
+							{ __( 'Set up account recovery' ) }
+						</RouterLinkButton>
+					}
+				>
+					{ __(
+						'This email uses a custom domain. If your domain expires, you’d lose access to account recovery. Add a recovery email or phone number to keep access to your account.'
+					) }
+				</Notice>
+			) }
+		</VStack>
 	);
 }

--- a/client/dashboard/me/profile-personal-details/email-section.tsx
+++ b/client/dashboard/me/profile-personal-details/email-section.tsx
@@ -237,7 +237,7 @@ export default function EmailSection( {
 					variant="warning"
 					title={ __( 'Protect access to your account' ) }
 					actions={
-						<RouterLinkButton variant="primary" to="/me/security/account-recovery">
+						<RouterLinkButton variant="secondary" to="/me/security/account-recovery">
 							{ __( 'Set up account recovery' ) }
 						</RouterLinkButton>
 					}

--- a/client/dashboard/me/profile-personal-details/style.scss
+++ b/client/dashboard/me/profile-personal-details/style.scss
@@ -25,20 +25,6 @@
 	}
 }
 
-.components-input-control.has-warning {
-	.components-base-control__help {
-		color: var( --dashboard__foreground-color-warning );
-		display: flex;
-		align-items: flex-start;
-		gap: 4px;
-
-		svg {
-			fill: var( --dashboard__foreground-color-warning );
-			flex-shrink: 0;
-		}
-	}
-}
-
 .components-input-control.has-success {
 	.components-input-control__backdrop {
 		border-color: var( --dashboard__background-color-success );

--- a/client/dashboard/me/profile-personal-details/test/index.test.tsx
+++ b/client/dashboard/me/profile-personal-details/test/index.test.tsx
@@ -303,7 +303,7 @@ describe( '<PersonalDetailsSection>', () => {
 			expect( await screen.findByText( /lose access to account recovery/i ) ).toBeVisible();
 		} );
 
-		test( 'links to the account recovery settings page', async () => {
+		test( 'shows a CTA linking to the account recovery settings page', async () => {
 			mockUserSettings( {
 				...settings,
 				user_email: 'jane@mycustomdomain.com',
@@ -314,7 +314,7 @@ describe( '<PersonalDetailsSection>', () => {
 			render( <PersonalDetailsSection /> );
 
 			expect(
-				await screen.findByRole( 'link', { name: /set up a recovery email or phone number/i } )
+				await screen.findByRole( 'link', { name: /set up account recovery/i } )
 			).toHaveAttribute( 'href', '/me/security/account-recovery' );
 		} );
 


### PR DESCRIPTION
Part of DOTMSD-1368

## Proposed Changes

* Promote the Profile email custom-domain warning from inline help text under the input to a warning `Notice` with a clear CTA: a primary "Set up account recovery" button linking to `/me/security/account-recovery` (rendered with `RouterLinkButton`, so navigation stays client-side).
* The display conditions are unchanged: custom-domain email, account-recovery settings loaded, and no recovery email/phone set.
* Remove the now-unused `has-warning` input styles.

## Why are these changes being made?

* The account-recovery expiry warning rendered as small inline help text with a text link, which is easy to miss for something with account-recovery implications. A notice with an explicit button makes the risk and the next step obvious, matching how other action-required notices in the dashboard are presented (e.g. the email verification banner).

## Testing Instructions

* Log in with an account whose email is on a custom domain (not a well-known free provider) and which has **no** recovery email or phone number set.
* Go to `/me/account` in the dashboard.
* Under the **Email address** field, verify the warning notice "Protect access to your account" appears with a "Set up account recovery" button.
* Click the button and verify it navigates to Security → Account recovery without a full page reload.
* Add a recovery email or phone number, return to `/me/account`, and verify the notice no longer appears.
* Unit tests: `yarn test-client client/dashboard/me/profile-personal-details`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
