### PR TITLE
A4A: Fix sidebar back button hover background color

### DIFF
--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -90,7 +90,7 @@
 
 .theme-a8c-for-agencies {
 
-	.components-button:not( .dataviews-view-table-header-button ),
+	.components-button:not( .dataviews-view-table-header-button ):not( .components-navigator-back-button ),
 	.button {
 		display: inline-flex;
 		align-items: center;


### PR DESCRIPTION
## Proposed Changes

* Fixes the A4A sidebar navigator **back button** rendering with a grey accent background (`--color-accent-0`) on hover/focus instead of the intended sidebar hover color.
* Adds the navigator back button to the exclusion list on the generic A4A button rule in `client/a8c-for-agencies/style.scss`, mirroring the existing `:not( .dataviews-view-table-header-button )` exclusion.

## Why are these changes being made?

The sidebar back button is a `@wordpress/components` `NavigatorBackButton`, which renders as `.components-button.components-navigator-back-button`. The shared navigator stylesheet (`client/layout/sidebar-v2/navigator/style.scss`) already gives it the correct sidebar hover background, but the generic A4A button rule was winning on specificity:

- A4A rule `.theme-a8c-for-agencies .components-button:not( … ):hover` → specificity `(0,4,0)`
- Navigator rule `.sidebar-v2__navigator-sub-menu .components-navigator-back-button:hover` → specificity `(0,3,0)`

The existing `:not( .dataviews-view-table-header-button )` exclusion adds a class' worth of specificity (a `:not()` inherits the specificity of its argument), which is exactly what tipped the generic rule above the sidebar's own hover style. Excluding the back button as well lets the shared sidebar styles apply as intended.

## Testing Instructions

1. Open the A4A dashboard and navigate into a sidebar sub-menu that shows the "Back" navigator button.
2. Hover / focus the back button.
3. **Before:** the button shows a grey accent background. **After:** it shows the normal sidebar hover background, consistent with the other sidebar menu items.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
