### PR TITLE
A4A Licenses: Confirm which site a license was assigned to

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
@@ -34,10 +34,11 @@ import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selecto
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { resetSite, setPurchasedLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
-import { errorNotice } from 'calypso/state/notices/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { DEFAULT_SORT_DIRECTION, DEFAULT_SORT_FIELD } from '../../sites/constants';
 import { Site } from '../../sites/types';
 import AssignLicenseStepProgress from '../assign-license-step-progress';
+import getAssignLicenseSuccessMessage from '../lib/get-assign-license-success-message';
 import useAssignLicensesToSite from '../products-overview/hooks/use-assign-licenses-to-site';
 import { SITE_CARDS_PER_PAGE } from './constants';
 
@@ -193,6 +194,19 @@ export default function AssignLicense( { initialPage, initialSearch }: Props ) {
 		dispatch( resetSite() );
 		dispatch( setPurchasedLicense( assignLicensesResult ) );
 
+		const successMessage = getAssignLicenseSuccessMessage( translate, assignLicensesResult );
+
+		if ( successMessage ) {
+			// Persistent: must outlive the redirect and the optional feedback step in between.
+			dispatch(
+				successNotice( successMessage, {
+					id: 'assign_license_success',
+					isPersistent: true,
+					duration: 10000,
+				} )
+			);
+		}
+
 		const rejectedProduct = assignLicensesResult.selectedProducts.find(
 			( product ) => product.status === 'rejected'
 		);
@@ -232,7 +246,14 @@ export default function AssignLicense( { initialPage, initialSearch }: Props ) {
 						A4A_FEEDBACK_LINK
 					)
 			  );
-	}, [ assignLicensesToSite, dispatch, isFeedbackShown, licenseKeysArray, selectedSite?.ID ] );
+	}, [
+		assignLicensesToSite,
+		dispatch,
+		isFeedbackShown,
+		licenseKeysArray,
+		selectedSite?.ID,
+		translate,
+	] );
 
 	return (
 		<Layout

--- a/client/a8c-for-agencies/sections/marketplace/lib/get-assign-license-success-message.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/lib/get-assign-license-success-message.tsx
@@ -1,0 +1,29 @@
+import type { PurchasedProductsInfo } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+import type { LocalizeProps, TranslateResult } from 'i18n-calypso';
+
+export default function getAssignLicenseSuccessMessage(
+	translate: LocalizeProps[ 'translate' ],
+	{ selectedSite, selectedProducts }: PurchasedProductsInfo
+): TranslateResult | null {
+	const assignedProduct = selectedProducts.find( ( product ) => product.status === 'fulfilled' );
+
+	if ( ! selectedSite || ! assignedProduct ) {
+		return null;
+	}
+
+	return translate(
+		'{{strong}}%(licenseItem)s{{/strong}} was successfully assigned to ' +
+			'{{em}}%(selectedSite)s{{/em}}. Please allow a few minutes ' +
+			'for your features to activate.',
+		{
+			args: {
+				licenseItem: assignedProduct.name,
+				selectedSite,
+			},
+			components: {
+				strong: <strong />,
+				em: <em />,
+			},
+		}
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/lib/test/get-assign-license-success-message.test.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/lib/test/get-assign-license-success-message.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { translate } from 'i18n-calypso';
+import getAssignLicenseSuccessMessage from '../get-assign-license-success-message';
+import type { ProductInfo } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+
+const product = ( name: string, status: ProductInfo[ 'status' ] = 'fulfilled' ): ProductInfo => ( {
+	name,
+	key: `${ name.toLowerCase() }_key`,
+	status,
+} );
+
+const renderMessage = ( selectedSite: string, selectedProducts: ProductInfo[] ) => {
+	const message = getAssignLicenseSuccessMessage( translate, { selectedSite, selectedProducts } );
+	render( <div data-testid="message">{ message }</div> );
+	return screen.getByTestId( 'message' ).textContent;
+};
+
+describe( 'getAssignLicenseSuccessMessage', () => {
+	it( 'names the product and the site it was assigned to', () => {
+		expect( renderMessage( 'https://example.com', [ product( 'Jetpack Backup' ) ] ) ).toContain(
+			'Jetpack Backup was successfully assigned to https://example.com'
+		);
+	} );
+
+	it( 'only mentions the product that was actually assigned', () => {
+		const message = renderMessage( 'https://example.com', [
+			product( 'Jetpack Scan', 'rejected' ),
+			product( 'Jetpack Backup' ),
+		] );
+
+		expect( message ).toContain( 'Jetpack Backup was successfully assigned' );
+		expect( message ).not.toContain( 'Jetpack Scan' );
+	} );
+
+	it( 'returns null when nothing was assigned', () => {
+		expect(
+			getAssignLicenseSuccessMessage( translate, {
+				selectedSite: 'https://example.com',
+				selectedProducts: [ product( 'Jetpack Backup', 'rejected' ) ],
+			} )
+		).toBeNull();
+	} );
+
+	it( 'returns null when the site is unknown', () => {
+		expect(
+			getAssignLicenseSuccessMessage( translate, {
+				selectedSite: '',
+				selectedProducts: [ product( 'Jetpack Backup' ) ],
+			} )
+		).toBeNull();
+	} );
+} );


### PR DESCRIPTION
Fixes A4A-3056

## Proposed Changes

Dispatch A4A's standard success notice once a license assignment resolves, naming **both** the assigned product and the destination site:

> **Jetpack Backup** was successfully assigned to *example.com*. Please allow a few minutes for your features to activate.

Two files plus a test: the assign-license flow, and a `getAssignLicenseSuccessMessage()` helper that builds the string.

## Why are these changes being made?

Assigning a license from Purchases → Licenses → **Unassigned** → **Assign** redirected back to the licenses list without saying anything. The agency had no way to tell whether the assignment worked, or — more importantly — *which* site the product landed on. The flow was quiet.

Two details worth knowing:

- **The notice survives a redirect.** Assignment navigates back to the licenses list, with an optional purchase-feedback step in between, so a notice tied to the originating page would flash and vanish on an unmounting component. It's dispatched as a persistent notice with a 10s duration so it lands where the user actually ends up.
- **Only successful assignments are announced.** The helper returns `null` if nothing was fulfilled or no site is set, so a failed or empty assignment can't produce a false confirmation.

**One license per assignment.** The Assign flow only ever fulfills a single license/product — there is no flow for assigning multiple at once (the code documents this: *"there will always be one license as we don't have a flow for multiple licenses"*). So the message names the one product, and the notice uses a fixed id. (An earlier revision carried `Intl.ListFormat` multi-product listing and a per-assignment notice id for back-to-back assignments; both were removed as complexity for cases this flow can't produce — see the note below.)

## Testing instructions

Prerequisites: a local A4A dev instance (`yarn start-a8c-for-agencies`), signed in to an agency account with at least one **unassigned** license and a site to assign it to.

1. Go to Purchases → **Licenses** → the **Unassigned** tab.
2. Choose an unassigned license and start the **Assign** flow.
3. Pick a site and complete the assignment.
4. Verify a success notice appears on the page you land on, naming the **product** and the **site** — e.g. *"Jetpack Backup was successfully assigned to example.com."*
5. Verify the notice persists long enough to read after the redirect, including if the purchase-feedback step appears in between.
6. Check a narrow/mobile width.

## Notes for reviewers

- **On @tiagonoronha's note about the fixed notice id:** correct about the mechanism (a reused id within the duration doesn't restart the dismiss timer). It only bites on two *successful* assignments within 10s — but each assignment is a multi-step wizard ending in a redirect back to the list, so two completions can't realistically land that close together. The per-assignment-id fix that was briefly added has been reverted as complexity for an unreachable case; the notice is back to a fixed id.
- **The notice has not been observed rendering.** Verifying end to end requires a real, irreversible license assignment on a live agency account, so it was deliberately not done. Covered: unit tests for the message helper (single product, rejected-product filter, no site, nothing fulfilled).
