### PR TITLE
A4A Licenses: Hide the search field on tabs with no licenses

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
@@ -63,6 +63,9 @@ export default function LicensesOverview( {
 
 	const showEmptyStateContent = isFetched && data?.all === 0;
 
+	// Counts aren't search-scoped: a zero means the tab is empty, not that an active query missed.
+	const showSearch = !! search || data?.[ filter ] !== 0;
+
 	return (
 		<Layout className="licenses-overview" title={ title } wide withBorder>
 			<LicensesOverviewContext.Provider value={ context }>
@@ -91,7 +94,7 @@ export default function LicensesOverview( {
 						<EmptyState />
 					) : (
 						<>
-							<LicenseSearch />
+							{ showSearch && <LicenseSearch /> }
 							<LicenseList />
 						</>
 					) }


### PR DESCRIPTION
Fixes A4A-3080

## Proposed Changes

Hide the licence search field on a tab that has no licences:

```tsx
// Counts aren't search-scoped: a zero means the tab is empty, not that an active query missed.
const showSearch = !! search || data?.[ filter ] !== 0;
```

One file, one render condition in `licenses-overview/index.tsx`.

## Why are these changes being made?

On Purchases → **Licenses**, a tab with a count of `0` (e.g. **Revoked 0**) still rendered the full-width *"Search by product name or license code"* field above the empty state. There is nothing to search, so the control pushed the actual message — *"No revoked licenses."* — and the **Issue new license** button roughly 52px down the page, and made an empty screen look busier than it is.

**The subtlety worth reviewing:** the field must still appear when a search is active and simply matches nothing. Hiding it there would strand the user with no way to see, edit or clear the query that emptied the list — a worse bug than the original.

Those two states render identically, so the condition cannot be "the list is empty". It leans on the fact that the counts from `useFetchLicenseCounts` are **not** search-scoped: `data[ filter ] === 0` means the tab itself is empty, regardless of any query. The `!! search` guard keeps the field whenever a term is present.

## Before / after

An empty tab (**Revoked 0**). The search field is gone and the empty state moves up under the tabs:

| Before | After |
| --- | --- |
| <img width="780" alt="before-revoked-empty-tab" src="https://github.com/user-attachments/assets/eb717d5f-4a6d-433e-917b-7a488642bb0c" /> | <img width="780" alt="after-revoked-empty-tab" src="https://github.com/user-attachments/assets/751bcd8b-70eb-4f43-b875-0aacc658ce74" /> |

The two states that must **not** change. A tab with licences where the query matches nothing keeps the field, the term and the clear button; a tab with licences and no query is untouched:

| Search with no results | Tab with licences |
| --- | --- |
| <img width="780" alt="after-search-no-results" src="https://github.com/user-attachments/assets/06daecee-6538-4f9d-bcee-caf4f4030b0f" /> | <img width="780" alt="after-tab-with-licenses" src="https://github.com/user-attachments/assets/dbb7697c-7259-487f-8d64-3065ccb80710" /> |

## Testing Instructions

Prerequisites: a local A4A dev instance (`yarn start-a8c-for-agencies`), signed in to an agency account.

1. Open Purchases → **Licenses** and select a tab whose count is `0`. Verify the search field is **not** rendered, and the empty state with **Issue new license** sits directly under the tabs.
2. Select a tab **with** licences and search for something that cannot match, e.g. `zzzz-no-such-license`. Verify the search field is **still** there, still contains your term, and still offers the clear (×) button.
3. On a tab with licences and no search, verify nothing has changed.

## Notes for reviewers

- **No tests were added.** The change is a single render condition and the three manual cases above cover it.
- **Case 1 was simulated, not real.** No tab on the test account is empty (Revoked 1.5K, Standard 1) and revoking a licence to create one is destructive, so an empty tab was faked with a temporary uncommitted stub of `useFetchLicenseCounts` / `useFetchLicenses`, screenshotted, then reverted. That is why the two case-1 screenshots read **Revoked 0** while the other two read **Revoked 1.5K**. Cases 2 and 3 are real, unmodified data, and only the one intended file is committed.
- **Narrow widths were not observed.** The automated viewport resize reported success but `window.innerWidth` stayed at 1512 and the media queries never flipped. Verified structurally instead: the only rule touching this element is a self-scoped `box-shadow` in `licenses-overview/style.scss:11`, nothing in A4A or `layout/hosting-dashboard` uses a `+`/`~` selector depending on `.search` as a sibling, and the page's two mobile rules target the header actions and nav wrapper. Removing a block-level element with no sibling coupling can't orphan a margin — but that is reasoning, not a screenshot. Worth an eyeball at mobile width.
- **No other A4A screen has this defect.** `selectedCount` appears exactly once in all of `client/a8c-for-agencies/` — in the licences filter — and only three A4A files use `LayoutNavigationTabs`. The near-miss is the Sites dashboard, which has an unconditional DataViews search but a single hardcoded tab with no count, so there is no counted-zero state to trigger it.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
