### PR TITLE
Update Site Spec to v1.13.3

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -225,7 +225,7 @@
 	"blackbox_url": "https://blackbox-api.wp.com/v1/dist/v.js",
 	"blackbox_api_key": "e16ecd5d7848b169d97088e4c69065d8",
 	"site_spec": {
-		"script_url": "https://widgets.wp.com/site-spec/v1.13.1/index.js",
-		"css_url": "https://widgets.wp.com/site-spec/v1.13.1/style.css"
+		"script_url": "https://widgets.wp.com/site-spec/v1.13.3/index.js",
+		"css_url": "https://widgets.wp.com/site-spec/v1.13.3/style.css"
 	}
 }


### PR DESCRIPTION
Bumping Site Spec to 1.13.3 for the setup site builder flow.

See Site Spec repo for the Site Spec change.

## Testing

- Sandbox widgets.wp.com
- `yarn start`
- Visit http://calypso.localhost:3000/setup/ai-site-builder-spec/site-spec and confirm it loads Site Spec 1.13.3
- Confirm Site Spec functions as expected