### PR TITLE
A4A WooPayments: Number the site setup steps

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-site-setup/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-site-setup/index.tsx
@@ -186,6 +186,7 @@ const WooPaymentsSiteSetup = ( { siteId }: { siteId: string } ) => {
 						</div>
 						<StepSection heading={ translate( 'Next steps' ) }>
 							<StepSectionItem
+								stepNumber={ 1 }
 								heading={ translate( 'Install and activate the plugin on WP-Admin' ) }
 								description={
 									<>
@@ -233,6 +234,7 @@ const WooPaymentsSiteSetup = ( { siteId }: { siteId: string } ) => {
 								}
 							/>
 							<StepSectionItem
+								stepNumber={ 2 }
 								heading={ translate( 'Earn commissions' ) }
 								description={
 									<>


### PR DESCRIPTION
Fixes A4A-3058

## Proposed Changes

* Pass `stepNumber={ 1 }` and `stepNumber={ 2 }` to the two `StepSectionItem`s on the WooPayments site setup screen, so the two cards render with a circled step number next to their headings.

Nothing else on the screen changes: no copy, no layout, no new component and no new CSS.

## Why are these changes being made?

The WooPayments site setup screen (WooPayments commissions → Site setup) walks an agency through getting WooPayments running on one of their sites. It renders two cards — "Install and activate the plugin on WP-Admin" and "Earn commissions" — inside a `StepSection`, using the shared `StepSectionItem` component.

`StepSectionItem` already accepts an optional `stepNumber` prop that renders a circled number to the left of the card heading. The other A4A step lists pass it (the team get-started screen, the team accept-invite screen, and the Partner Directory application dashboard), but the WooPayments screen never has. Without the numbers the two cards read as loose, independent options rather than a sequence to work through in order, which is what a QA walkthrough flagged: the order isn't clear.

Reusing the existing prop gives the same circled-number treatment as the AI and MCP setup screen that A4A-3058 points at as the reference pattern, without adding a second implementation of it.

**No tests were added.** The change is two props on an existing shared component — no logic, no branching, no state, nothing to assert that wouldn't just be a snapshot of JSX.

Three caveats worth knowing before review:

* **No completed-checkmark state.** The AI and MCP screen swaps the number for a circled checkmark once a step is done. This screen doesn't track per-step completion — it only knows whether the WooPayments plugin is active, which isn't the same as "step 1 is finished", since the merchant still has to configure WooPayments in WP-Admin — and `StepSectionItem` has no completed state. Wiring that up is separate work, so this PR numbers the steps and leaves completion alone.
* **Numbers don't show on narrow widths.** `StepSectionItem` hides its step number below `$break-large` (960px). That is an existing decision in the shared component and it applies to all four screens that use it. Below that width these cards render exactly as they do today — nothing overflows — but the numbers aren't shown. Changing it would alter three unrelated screens, so it's left alone here.
* **That narrow-width behaviour was verified by reading the CSS, not from a resized screenshot.** Browser resize silently no-oped during testing (the resize call reported success but `window.innerWidth` stayed at 1512), so the sub-960px claim rests on the `@include break-large` rule in `step-section-item/style.scss` rather than on a captured narrow viewport.

## Testing Instructions

Prerequisites: an Automattic for Agencies account with at least one site that has not finished WooPayments setup.

1. Check out this branch and start A4A locally:
   ```
   yarn start-a8c-for-agencies
   ```
2. Go to `http://agencies.localhost:3000/woopayments/dashboard`.
3. Find a site whose WOOPAYMENTS STATUS column reads "Continue setup" and click it. (You can also go straight to `http://agencies.localhost:3000/woopayments/site-setup/?site_id=<SITE_ID>`.)
4. Under "Next steps", verify the first card ("Install and activate the plugin on WP-Admin") shows a circled `1` to the left of its heading, and the second card ("Earn commissions") shows a circled `2`.
5. Verify the headings, descriptions, and buttons are otherwise unchanged, and that the circles line up with the card headings.
6. Open `http://agencies.localhost:3000/resources-and-tools/ai-mcp` and compare — the numbered circles read as the same treatment.
7. Narrow the browser below 960px and verify the cards stack as they did before, with no overflowing or clipped content (the numbers are not shown at that width, as described above).

### Screenshots

**Before**

<img width="1568" height="698" alt="before-woopayments-site-setup" src="https://github.com/user-attachments/assets/5ea4ddb5-fdd9-4113-95b0-31489db75fe9" />

**After**

<img width="1568" height="698" alt="after-woopayments-site-setup-numbered" src="https://github.com/user-attachments/assets/3bd01a3e-69ec-4232-9cff-bd24820bd620" />

**Reference — the AI and MCP screen, unchanged by this PR**

<img width="1568" height="698" alt="reference-ai-mcp-numbered-steps" src="https://github.com/user-attachments/assets/bfe7d710-f253-4401-9fc4-61c8a24bc51f" />

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes? — no; two props on an existing shared component, no logic to assert.
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors? — `yarn typecheck-client` passes, no console errors on the screen.
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2). — not verified with a screen reader; `StepSectionItem` renders the number as plain text (the AI and MCP screen marks its number `aria-hidden`), so it will be announced before the heading, as it already is on the other A4A screens.
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? — no new or changed strings.
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)? — no data or tracking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
