### PR TITLE
Stats: page the video details chart through the full history

### DIFF
--- a/client/my-sites/stats/stats-summary/index.jsx
+++ b/client/my-sites/stats/stats-summary/index.jsx
@@ -72,7 +72,7 @@ class StatsSummaryChart extends Component {
 				{
 					label: tabLabel,
 					className: sectionClass,
-					value: formatNumber( record.value ),
+					value: record.formattedValue ?? formatNumber( record.value ),
 					icon: this.iconByChartType( chartType ),
 				},
 			];

--- a/client/my-sites/stats/stats-summary/index.jsx
+++ b/client/my-sites/stats/stats-summary/index.jsx
@@ -16,6 +16,8 @@ import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatsTabs from '../stats-tabs';
 import StatsTab from '../stats-tabs/tab';
 
+import './style.scss';
+
 class StatsSummaryChart extends Component {
 	static propTypes = {
 		data: PropTypes.array,
@@ -23,14 +25,11 @@ class StatsSummaryChart extends Component {
 		isLoading: PropTypes.bool,
 		chartType: PropTypes.string.isRequired,
 		labelKey: PropTypes.string.isRequired,
+		onClick: PropTypes.func,
 		sectionClass: PropTypes.string.isRequired,
 		selected: PropTypes.object,
 		tabLabel: PropTypes.string.isRequired,
 		type: PropTypes.string,
-	};
-
-	static defaultProps = {
-		onClick: () => {},
 	};
 
 	barClick = ( bar ) => {
@@ -89,7 +88,15 @@ class StatsSummaryChart extends Component {
 	}
 
 	render() {
-		const { dataKey, isLoading, chartType, labelKey, selected, tabLabel, type } = this.props;
+		const { dataKey, isLoading, chartType, labelKey, onClick, selected, tabLabel, type } =
+			this.props;
+		// Without an onClick handler the bars are hover-tooltip only: no click
+		// handling (which would also log a Google event) and no pointer cursor
+		// suggesting the bars do something.
+		const chartProps = {
+			data: this.buildChartData(),
+			...( onClick ? { barClick: this.barClick } : {} ),
+		};
 		const label = selected ? ': ' + selected[ labelKey ] : '';
 		const tabOptions = {
 			attr: labelKey,
@@ -103,16 +110,26 @@ class StatsSummaryChart extends Component {
 		const isModernized = 'post' === type || 'video' === type;
 
 		return isModernized ? (
-			<div className={ clsx( 'is-summary-chart', { 'is-loading': isLoading } ) }>
+			<div
+				className={ clsx( 'is-summary-chart', {
+					'is-loading': isLoading,
+					'is-hover-only': ! onClick,
+				} ) }
+			>
 				<StatsModulePlaceholder className="is-chart" isLoading={ isLoading } />
-				<ElementChart data={ this.buildChartData() } barClick={ this.barClick }>
+				<ElementChart { ...chartProps }>
 					<StatsEmptyState />
 				</ElementChart>
 			</div>
 		) : (
-			<Card className={ clsx( 'stats-module', 'is-summary-chart', { 'is-loading': isLoading } ) }>
+			<Card
+				className={ clsx( 'stats-module', 'is-summary-chart', {
+					'is-loading': isLoading,
+					'is-hover-only': ! onClick,
+				} ) }
+			>
 				<StatsModulePlaceholder className="is-chart" isLoading={ isLoading } />
-				<ElementChart data={ this.buildChartData() } barClick={ this.barClick }>
+				<ElementChart { ...chartProps }>
 					<StatsEmptyState />
 				</ElementChart>
 				<StatsTabs>

--- a/client/my-sites/stats/stats-summary/style.scss
+++ b/client/my-sites/stats/stats-summary/style.scss
@@ -1,0 +1,6 @@
+// Hover-tooltip-only charts (no onClick handler): bars still highlight on
+// hover so the tooltip has an anchor, but a pointer cursor would promise a
+// click action that doesn't exist.
+.is-summary-chart.is-hover-only .chart__bar:hover {
+	cursor: default;
+}

--- a/client/my-sites/stats/stats-video-detail/index.tsx
+++ b/client/my-sites/stats/stats-video-detail/index.tsx
@@ -40,9 +40,10 @@ export default function StatsVideoDetail( { postId, period, context }: StatsVide
 	// The video title and upload date come from the attachment post included in
 	// the statsVideo response — available in both Calypso and Odyssey (the
 	// stats-app proxy forwards stats routes). Mirrors VideoSummary's default
-	// Days/Weeks query, which is always fetched first.
+	// Days query, which is always fetched first, so this reuses that cached
+	// response instead of issuing its own request.
 	const videoInfoQuery = useMemo(
-		() => ( { postId, statType: 'views', period: 'month' } ),
+		() => ( { postId, statType: 'all', period: 'day', num: -1 } ),
 		[ postId ]
 	);
 	const videoStatsData = useSelector(

--- a/client/my-sites/stats/stats-video-detail/retention.ts
+++ b/client/my-sites/stats/stats-video-detail/retention.ts
@@ -1,0 +1,26 @@
+export interface RetentionBucket {
+	plays: number;
+	retentionRate: number;
+}
+
+/**
+ * Aggregate per-bucket retention rates into a single rate for the window.
+ *
+ * Retention can't be summed across buckets: the canonical formula is
+ * rate = (watch_time / plays) / duration. Since every bucket satisfies
+ * rate_i = (watch_i / plays_i) / duration, weighting each bucket's rate by its
+ * plays gives Σ(rate_i · plays_i) / Σplays_i = (Σwatch / Σplays) / duration —
+ * the endpoint's own `total` computation. Unlike back-deriving the duration
+ * from a single reference bucket, the rounding error the API bakes into a
+ * low-traffic bucket's rate only contributes in proportion to that bucket's
+ * plays instead of polluting the whole window.
+ */
+export function calculatePlayWeightedRetention( buckets: RetentionBucket[] ): number {
+	let plays = 0;
+	let weightedRate = 0;
+	for ( const bucket of buckets ) {
+		plays += bucket.plays;
+		weightedRate += bucket.retentionRate * bucket.plays;
+	}
+	return plays > 0 ? weightedRate / plays : 0;
+}

--- a/client/my-sites/stats/stats-video-detail/style.scss
+++ b/client/my-sites/stats/stats-video-detail/style.scss
@@ -171,7 +171,7 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 
 .stats-video-metric-tabs {
 	display: grid;
-	grid-template-columns: repeat(3, 1fr);
+	grid-template-columns: repeat(4, 1fr);
 	gap: 16px;
 	list-style: none;
 	// The chart's 42px-wide x-axis labels wrap onto a second line for

--- a/client/my-sites/stats/stats-video-detail/test/retention.ts
+++ b/client/my-sites/stats/stats-video-detail/test/retention.ts
@@ -1,0 +1,52 @@
+import { calculatePlayWeightedRetention } from '../retention';
+
+describe( 'calculatePlayWeightedRetention', () => {
+	test( 'weights each bucket by its plays', () => {
+		const rate = calculatePlayWeightedRetention( [
+			{ plays: 10, retentionRate: 80 },
+			{ plays: 30, retentionRate: 40 },
+		] );
+
+		expect( rate ).toBeCloseTo( ( 10 * 80 + 30 * 40 ) / 40, 10 );
+	} );
+
+	test( 'keeps a low-traffic first bucket from skewing the window', () => {
+		// One play whose rate the API rounded heavily (true rate ~50%) must not
+		// pollute the aggregate the way back-deriving the video duration from
+		// that single bucket would.
+		const rate = calculatePlayWeightedRetention( [
+			{ plays: 1, retentionRate: 33 },
+			{ plays: 999, retentionRate: 50 },
+		] );
+
+		expect( rate ).toBeCloseTo( 49.983, 3 );
+	} );
+
+	test( 'returns the common rate when every bucket matches', () => {
+		const rate = calculatePlayWeightedRetention( [
+			{ plays: 5, retentionRate: 42.5 },
+			{ plays: 500, retentionRate: 42.5 },
+		] );
+
+		expect( rate ).toBeCloseTo( 42.5, 10 );
+	} );
+
+	test( 'includes zero-retention buckets in the weighting', () => {
+		const rate = calculatePlayWeightedRetention( [
+			{ plays: 50, retentionRate: 0 },
+			{ plays: 50, retentionRate: 60 },
+		] );
+
+		expect( rate ).toBe( 30 );
+	} );
+
+	test( 'returns 0 when there are no plays', () => {
+		expect( calculatePlayWeightedRetention( [] ) ).toBe( 0 );
+		expect(
+			calculatePlayWeightedRetention( [
+				{ plays: 0, retentionRate: 25 },
+				{ plays: 0, retentionRate: 75 },
+			] )
+		).toBe( 0 );
+	} );
+} );

--- a/client/my-sites/stats/stats-video-detail/video-metric-tabs.tsx
+++ b/client/my-sites/stats/stats-video-detail/video-metric-tabs.tsx
@@ -1,10 +1,10 @@
 import { Gridicon } from '@automattic/components';
 import { formatNumber, formatNumberCompact } from '@automattic/number-formatters';
-import { Icon, seen, video } from '@wordpress/icons';
+import { chartBar, Icon, seen, video } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 
-export type VideoStatType = 'views' | 'impressions' | 'watch_time';
+export type VideoStatType = 'views' | 'impressions' | 'watch_time' | 'retention_rate';
 
 // `null` renders a loading placeholder.
 export type VideoMetricValues = Record< VideoStatType, number | null >;
@@ -20,6 +20,8 @@ function formatValue( statType: VideoStatType, value: number | null ) {
 				return formatNumber( value, { decimals: 1 } );
 			}
 			return `< ${ formatNumber( 1, { decimals: 1 } ) }`;
+		case 'retention_rate':
+			return `${ formatNumber( value, { decimals: 1 } ) }%`;
 		default:
 			return formatNumberCompact( value );
 	}
@@ -51,6 +53,11 @@ export default function VideoMetricTabs( {
 			key: 'watch_time',
 			label: translate( 'Hours watched', { textOnly: true } ),
 			icon: <Gridicon icon="time" size={ 24 } />,
+		},
+		{
+			key: 'retention_rate',
+			label: translate( 'Retention rate', { textOnly: true } ),
+			icon: <Icon icon={ chartBar } />,
 		},
 	];
 

--- a/client/my-sites/stats/stats-video-detail/video-metric-tabs.tsx
+++ b/client/my-sites/stats/stats-video-detail/video-metric-tabs.tsx
@@ -9,7 +9,7 @@ export type VideoStatType = 'views' | 'impressions' | 'watch_time' | 'retention_
 // `null` renders a loading placeholder.
 export type VideoMetricValues = Record< VideoStatType, number | null >;
 
-function formatValue( statType: VideoStatType, value: number | null ) {
+export function formatValue( statType: VideoStatType, value: number | null ) {
 	if ( value === null ) {
 		return '-';
 	}

--- a/client/my-sites/stats/stats-video-detail/video-summary.tsx
+++ b/client/my-sites/stats/stats-video-detail/video-summary.tsx
@@ -17,7 +17,11 @@ import StatsPeriodHeader from '../stats-period-header';
 import StatsPeriodNavigation from '../stats-period-navigation';
 import SummaryChart from '../stats-summary';
 import { calculatePlayWeightedRetention } from './retention';
-import VideoMetricTabs, { VideoStatType, VideoMetricValues } from './video-metric-tabs';
+import VideoMetricTabs, {
+	formatValue,
+	VideoStatType,
+	VideoMetricValues,
+} from './video-metric-tabs';
 
 type UiPeriod = 'day' | 'week' | 'month' | 'year';
 
@@ -26,6 +30,7 @@ interface ChartRecord {
 	periodLabel: string;
 	startDate: string;
 	value: number;
+	formattedValue?: string;
 }
 
 // A range-mode series row from the statsVideo normalizer: the period start
@@ -125,36 +130,43 @@ export default function VideoSummary( {
 			visibleRows.map( ( row ) => {
 				const start = moment( row.period );
 				const value = metricValue( row, statType );
+				// Views and impressions tooltips show the exact count; hours
+				// watched and retention rate reuse the metric-tab formatting
+				// (one decimal, % suffix) so the tooltip matches the card.
+				const record = {
+					startDate: row.period,
+					value,
+					formattedValue:
+						statType === 'watch_time' || statType === 'retention_rate'
+							? formatValue( statType, value )
+							: undefined,
+				};
 				switch ( uiPeriod ) {
 					case 'week':
 						return {
+							...record,
 							period: start.format( 'MMM D' ),
 							periodLabel: `${ start.format( 'L' ) } - ${ moment( row.period )
 								.add( 6, 'days' )
 								.format( 'L' ) }`,
-							startDate: row.period,
-							value,
 						};
 					case 'month':
 						return {
+							...record,
 							period: start.format( 'MMM YYYY' ),
 							periodLabel: start.format( 'MMMM YYYY' ),
-							startDate: row.period,
-							value,
 						};
 					case 'year':
 						return {
+							...record,
 							period: start.format( 'YYYY' ),
 							periodLabel: start.format( 'YYYY' ),
-							startDate: row.period,
-							value,
 						};
 					default:
 						return {
+							...record,
 							period: start.format( 'MMM D' ),
 							periodLabel: start.format( 'LL' ),
-							startDate: row.period,
-							value,
 						};
 				}
 			} ),

--- a/client/my-sites/stats/stats-video-detail/video-summary.tsx
+++ b/client/my-sites/stats/stats-video-detail/video-summary.tsx
@@ -1,7 +1,7 @@
 import { SegmentedControl } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useSelector } from 'calypso/state';
@@ -20,19 +20,6 @@ import VideoMetricTabs, { VideoStatType, VideoMetricValues } from './video-metri
 
 type UiPeriod = 'day' | 'week' | 'month' | 'year';
 
-// The stats/video/:id endpoint treats `period` as a fixed trailing-window
-// selector, not a bucket granularity: `month` returns ~31 daily buckets and
-// `year` returns ~13 monthly buckets (there are no weekly or yearly buckets,
-// and `day`/`week` windows are too small to chart). So we fetch the daily
-// window for the Days/Weeks views and the monthly window for Months/Years,
-// then aggregate client-side.
-type ApiPeriod = 'month' | 'year';
-
-// The endpoint only recognizes statType=watch_time|impressions; `views` falls
-// back to the plays column, which is the same metric the Videos module and the
-// All videos page label "Views".
-const FETCHED_STAT_TYPES = [ 'views', 'impressions', 'watch_time' ] as const;
-
 interface ChartRecord {
 	period: string;
 	periodLabel: string;
@@ -40,33 +27,37 @@ interface ChartRecord {
 	value: number;
 }
 
-interface BucketRecord {
-	key: string;
-	plays: number;
-	impressions: number;
-	watchTime: number;
+// A range-mode series row from the statsVideo normalizer: the period start
+// date plus one value per metric named in the response's `fields`.
+interface SeriesRow {
+	period: string;
+	[ metric: string ]: string | number;
 }
 
 interface VideoSummaryData {
-	data?: Array< { period: string; value: number } >;
+	rows?: SeriesRow[] | null;
+	metrics?: string[] | null;
 	post?: { post_date?: string } | null;
 }
 
-const STAT_TYPES: VideoStatType[] = [ 'views', 'impressions', 'watch_time' ];
+const STAT_TYPES: VideoStatType[] = [ 'views', 'impressions', 'watch_time', 'retention_rate' ];
+
+// The endpoint names the views column `plays` (the same metric the Videos
+// module and the All videos page label "Views"); the other tabs match their
+// column names directly.
+const METRIC_COLUMNS: Record< VideoStatType, string > = {
+	views: 'plays',
+	impressions: 'impressions',
+	watch_time: 'watch_time',
+	retention_rate: 'retention_rate',
+};
 
 function isVideoStatType( value: string | null ): value is VideoStatType {
 	return !! value && ( STAT_TYPES as string[] ).includes( value );
 }
 
-function metricOfBucket( bucket: BucketRecord, type: VideoStatType ): number {
-	switch ( type ) {
-		case 'impressions':
-			return bucket.impressions;
-		case 'watch_time':
-			return bucket.watchTime;
-		default:
-			return bucket.plays;
-	}
+function metricValue( row: SeriesRow, type: VideoStatType ): number {
+	return Number( row[ METRIC_COLUMNS[ type ] ] ) || 0;
 }
 
 export default function VideoSummary( {
@@ -80,210 +71,93 @@ export default function VideoSummary( {
 	const moment = useLocalizedMoment();
 	const siteId = useSelector( getSelectedSiteId );
 	const [ uiPeriod, setUiPeriod ] = useState< UiPeriod >( 'day' );
+	const [ page, setPage ] = useState( 1 );
 	const [ statType, setStatType ] = useState< VideoStatType >(
 		isVideoStatType( initialStatType ) ? initialStatType : 'views'
 	);
 	const [ selectedRecord, setSelectedRecord ] = useState< ChartRecord | null >( null );
 
-	const apiPeriod: ApiPeriod = uiPeriod === 'day' || uiPeriod === 'week' ? 'month' : 'year';
-
-	// The video's publish date, so the chart never shows periods before the
-	// video existed. Always queried with period=month (rather than reusing
-	// `apiPeriod`, which can be 'year') to mirror the parent StatsVideoDetail
-	// component's videoInfoQuery, so this reuses the same cached response.
-	const videoInfoQuery = useMemo(
-		() => ( { postId, statType: 'views', period: 'month' as const } ),
-		[ postId ]
-	);
-	const videoPublishDate = useSelector(
-		( state ) =>
-			(
-				getSiteStatsNormalizedData(
-					state,
-					siteId,
-					'statsVideo',
-					videoInfoQuery
-				) as VideoSummaryData | null
-			 )?.post?.post_date ?? null
+	// One request per granularity: statType=all returns every metric series in
+	// a single response, and num=-1 windows it from the video's publish date,
+	// so the chart can page back through the full history — mirroring how the
+	// Post Details chart fetches the post's entire view history up front and
+	// pages client-side.
+	const query = useMemo(
+		() => ( { postId, statType: 'all', period: uiPeriod, num: -1 } ),
+		[ postId, uiPeriod ]
 	);
 
-	// The endpoint's `month` window spans 31 days inclusive; trim to the
-	// trailing 30 so totals line up with the 30-day window the Videos module
-	// and the All videos page show by default, and drop any raw entry before
-	// the video's publish date. Shared by the bucketing below and by the
-	// header's date-range label, so both agree on the window.
-	const trimToTrailingWindow = useCallback(
-		(
-			data?: Array< { period: string; value: number } >
-		): Array< { period: string; value: number } > | undefined => {
-			const trimmed = apiPeriod === 'month' && data && data.length > 30 ? data.slice( -30 ) : data;
-			if ( ! trimmed || ! videoPublishDate ) {
-				return trimmed;
-			}
-			// apiPeriod === 'year' raw entries are whole months (e.g.
-			// '2026-07'); comparing those at day granularity would drop the
-			// publish month entirely for a video published mid-month.
-			const unit = apiPeriod === 'year' ? 'month' : 'day';
-			return trimmed.filter(
-				( { period } ) => ! moment( period ).isBefore( videoPublishDate, unit )
-			);
-		},
-		[ apiPeriod, videoPublishDate, moment ]
-	);
-
-	const queries = useMemo(
-		() =>
-			Object.fromEntries(
-				FETCHED_STAT_TYPES.map( ( type ) => [
-					type,
-					{ postId, statType: type, period: apiPeriod },
-				] )
-			) as Record<
-				( typeof FETCHED_STAT_TYPES )[ number ],
-				{ postId: number; statType: string; period: ApiPeriod }
-			>,
-		[ postId, apiPeriod ]
-	);
-
-	const playsData = useSelector(
+	const summaryData = useSelector(
 		( state ) =>
-			getSiteStatsNormalizedData(
-				state,
-				siteId,
-				'statsVideo',
-				queries.views
-			) as VideoSummaryData | null
-	);
-	const impressionsData = useSelector(
-		( state ) =>
-			getSiteStatsNormalizedData(
-				state,
-				siteId,
-				'statsVideo',
-				queries.impressions
-			) as VideoSummaryData | null
-	);
-	const watchTimeData = useSelector(
-		( state ) =>
-			getSiteStatsNormalizedData(
-				state,
-				siteId,
-				'statsVideo',
-				queries.watch_time
-			) as VideoSummaryData | null
+			getSiteStatsNormalizedData( state, siteId, 'statsVideo', query ) as VideoSummaryData | null
 	);
 	const isRequesting = useSelector( ( state ) =>
-		siteId
-			? FETCHED_STAT_TYPES.some( ( type ) =>
-					isRequestingSiteStatsForQuery( state, siteId, 'statsVideo', queries[ type ] )
-			  )
-			: false
+		siteId ? isRequestingSiteStatsForQuery( state, siteId, 'statsVideo', query ) : false
 	);
-
-	const hasSelectedSeriesFailed = useSelector( ( state ) =>
-		siteId ? hasSiteStatsQueryFailed( state, siteId, 'statsVideo', queries[ statType ] ) : false
+	const hasFailed = useSelector( ( state ) =>
+		siteId ? hasSiteStatsQueryFailed( state, siteId, 'statsVideo', query ) : false
 	);
 
 	// QuerySiteStats defers its initial request, so the requesting flag is
-	// still false on the first render after switching windows; treat missing
-	// data as loading too, or the empty state flashes before the fetch starts.
-	// A failed request also ends the loading state (empty chart instead of an
-	// infinite placeholder).
-	const isSelectedSeriesLoaded =
-		!! {
-			views: playsData,
-			impressions: impressionsData,
-			watch_time: watchTimeData,
-		}[ statType ] || hasSelectedSeriesFailed;
+	// still false on the first render after switching granularity; treat
+	// missing data as loading too, or the empty state flashes before the fetch
+	// starts. A failed request also ends the loading state (empty chart
+	// instead of an infinite placeholder).
+	const isLoaded = !! summaryData || hasFailed;
 
-	// Group the fetched buckets (daily or monthly) into the buckets the UI
-	// period wants, summing values. Bucket keys are normalized ISO dates.
-	const buckets: BucketRecord[] = useMemo( () => {
-		const unit = uiPeriod;
-		const toBucketMap = ( data?: Array< { period: string; value: number } > ) => {
-			const map = new Map< string, number >();
-			for ( const { period: date, value } of trimToTrailingWindow( data ) ?? [] ) {
-				const parsed = moment( date );
-				if ( ! parsed.isValid() ) {
-					continue;
-				}
-				// Stats weeks run Monday-Sunday (see stats-date-label); isoWeek
-				// matches that regardless of the user's locale.
-				const key = parsed.startOf( unit === 'week' ? 'isoWeek' : unit ).format( 'YYYY-MM-DD' );
-				map.set( key, ( map.get( key ) ?? 0 ) + value );
-			}
-			return map;
-		};
+	const rows = useMemo( () => summaryData?.rows ?? [], [ summaryData ] );
+	const availableMetrics = summaryData?.metrics ?? null;
 
-		const playsByBucket = toBucketMap( playsData?.data );
-		const impressionsByBucket = toBucketMap( impressionsData?.data );
-		const watchTimeByBucket = toBucketMap( watchTimeData?.data );
-
-		const keys = Array.from(
-			new Set( [
-				...playsByBucket.keys(),
-				...impressionsByBucket.keys(),
-				...watchTimeByBucket.keys(),
-			] )
-		).sort();
-
-		// Cap Weeks/Months/Years to the most recent STATS_SUMMARY_MAX_BARS
-		// buckets so they show the same amount of history per view as the
-		// Post Details chart, which pages in chunks of the same size. Weeks/
-		// Years will still fall short of that cap: the endpoint's `month`/
-		// `year` windows only cover ~30 days / ~13 months of raw data, which
-		// bucket into fewer than 10 weeks/years regardless of this cap —
-		// there's no more granular data to draw from without a backend
-		// change. Days aren't capped; there's no pagination for this chart,
-		// so it shows the full ~30-day window it always has.
-		const cappedKeys = uiPeriod === 'day' ? keys : keys.slice( -STATS_SUMMARY_MAX_BARS );
-		return cappedKeys.map( ( key ) => ( {
-			key,
-			plays: playsByBucket.get( key ) ?? 0,
-			impressions: impressionsByBucket.get( key ) ?? 0,
-			watchTime: watchTimeByBucket.get( key ) ?? 0,
-		} ) );
-	}, [ playsData, impressionsData, watchTimeData, uiPeriod, trimToTrailingWindow, moment ] );
+	// Page the full series in most-recent-last chunks, exactly like the Post
+	// Details chart ([start, end) bounds per page, page 1 = newest).
+	const totalCount = rows.length;
+	const maxPages = Math.max( Math.ceil( totalCount / STATS_SUMMARY_MAX_BARS ), 1 );
+	const dataStart = Math.max( totalCount - STATS_SUMMARY_MAX_BARS * page, 0 );
+	const dataEnd = Math.max( totalCount - STATS_SUMMARY_MAX_BARS * ( page - 1 ), 0 );
+	const visibleRows = useMemo(
+		() => rows.slice( dataStart, dataEnd ),
+		[ rows, dataStart, dataEnd ]
+	);
 
 	const chartData: ChartRecord[] = useMemo(
 		() =>
-			buckets.map( ( bucket ) => {
-				const start = moment( bucket.key );
-				const value = metricOfBucket( bucket, statType );
+			visibleRows.map( ( row ) => {
+				const start = moment( row.period );
+				const value = metricValue( row, statType );
 				switch ( uiPeriod ) {
 					case 'week':
 						return {
 							period: start.format( 'MMM D' ),
-							periodLabel: `${ start.format( 'L' ) } - ${ moment( bucket.key )
+							periodLabel: `${ start.format( 'L' ) } - ${ moment( row.period )
 								.add( 6, 'days' )
 								.format( 'L' ) }`,
-							startDate: bucket.key,
+							startDate: row.period,
 							value,
 						};
 					case 'month':
 						return {
 							period: start.format( 'MMM YYYY' ),
 							periodLabel: start.format( 'MMMM YYYY' ),
-							startDate: bucket.key,
+							startDate: row.period,
 							value,
 						};
 					case 'year':
 						return {
 							period: start.format( 'YYYY' ),
 							periodLabel: start.format( 'YYYY' ),
-							startDate: bucket.key,
+							startDate: row.period,
 							value,
 						};
 					default:
 						return {
 							period: start.format( 'MMM D' ),
 							periodLabel: start.format( 'LL' ),
-							startDate: bucket.key,
+							startDate: row.period,
 							value,
 						};
 				}
 			} ),
-		[ buckets, statType, uiPeriod, moment ]
+		[ visibleRows, statType, uiPeriod, moment ]
 	);
 
 	// No bar is highlighted by default; the header shows the range instead of
@@ -296,12 +170,12 @@ export default function VideoSummary( {
 	// single bar is selected, so it reads the same across every
 	// Day/Week/Month/Year tab and matches Post Details' behavior.
 	const chartDateRange = useMemo( () => {
-		if ( ! buckets.length ) {
+		if ( ! visibleRows.length ) {
 			return undefined;
 		}
 
-		const start = moment( buckets[ 0 ].key );
-		let end = moment( buckets[ buckets.length - 1 ].key );
+		const start = moment( visibleRows[ 0 ].period );
+		let end = moment( visibleRows[ visibleRows.length - 1 ].period );
 		switch ( uiPeriod ) {
 			case 'week':
 				end = end.add( 6, 'days' );
@@ -327,22 +201,53 @@ export default function VideoSummary( {
 			chartStart: start.format( 'YYYY-MM-DD' ),
 			chartEnd: end.format( 'YYYY-MM-DD' ),
 		};
-	}, [ buckets, uiPeriod, moment ] );
+	}, [ visibleRows, uiPeriod, moment ] );
 
-	// Card totals cover the whole window shown in the chart.
+	// Card totals cover the window shown in the chart (the current page).
+	// Retention can't be summed across buckets: the canonical formula is
+	// play-weighted — rate = (watch_time / plays) / duration — and the video
+	// duration isn't in the response. But every bucket satisfies
+	// rate_i = (watch_i / plays_i) / duration, so the constant is recovered
+	// from any bucket with plays and a non-zero rate, and the window rate is
+	// (Σwatch / Σplays) scaled by it — matching the endpoint's own `total`
+	// computation rather than a naive average of the daily rates.
 	const metricValues: VideoMetricValues = useMemo( () => {
-		const sum = ( data: VideoSummaryData | null, pick: ( bucket: BucketRecord ) => number ) =>
-			data ? buckets.reduce( ( total, bucket ) => total + pick( bucket ), 0 ) : null;
+		const sumOf = ( type: VideoStatType ) =>
+			visibleRows.reduce( ( total, row ) => total + metricValue( row, type ), 0 );
+		const has = ( type: VideoStatType ) =>
+			!! availableMetrics && availableMetrics.includes( METRIC_COLUMNS[ type ] );
+
+		let retention: number | null = null;
+		if ( has( 'retention_rate' ) && has( 'views' ) && has( 'watch_time' ) ) {
+			const plays = sumOf( 'views' );
+			const reference = visibleRows.find(
+				( row ) =>
+					metricValue( row, 'views' ) > 0 &&
+					metricValue( row, 'watch_time' ) > 0 &&
+					metricValue( row, 'retention_rate' ) > 0
+			);
+			if ( plays > 0 && reference ) {
+				const referencePerPlay =
+					metricValue( reference, 'watch_time' ) / metricValue( reference, 'views' );
+				retention =
+					( sumOf( 'watch_time' ) / plays ) *
+					( metricValue( reference, 'retention_rate' ) / referencePerPlay );
+			} else {
+				retention = 0;
+			}
+		}
 
 		return {
-			views: sum( playsData, ( bucket ) => bucket.plays ),
-			impressions: sum( impressionsData, ( bucket ) => bucket.impressions ),
-			watch_time: sum( watchTimeData, ( bucket ) => bucket.watchTime ),
+			views: has( 'views' ) ? sumOf( 'views' ) : null,
+			impressions: has( 'impressions' ) ? sumOf( 'impressions' ) : null,
+			watch_time: has( 'watch_time' ) ? sumOf( 'watch_time' ) : null,
+			retention_rate: retention,
 		};
-	}, [ buckets, playsData, impressionsData, watchTimeData ] );
+	}, [ visibleRows, availableMetrics ] );
 
 	const selectPeriod = ( newPeriod: UiPeriod ) => () => {
 		setUiPeriod( newPeriod );
+		setPage( 1 );
 		setSelectedRecord( null );
 	};
 
@@ -351,10 +256,23 @@ export default function VideoSummary( {
 		setSelectedRecord( null );
 	};
 
+	// Arrows page the whole visible window of bars, like the Post Details
+	// chart — they never step through individual bars.
+	const onPeriodChange = ( { direction }: { direction: string } ) => {
+		if ( 'previous' === direction && page < maxPages ) {
+			setPage( page + 1 );
+			setSelectedRecord( null );
+		} else if ( 'next' === direction && page > 1 ) {
+			setPage( page - 1 );
+			setSelectedRecord( null );
+		}
+	};
+
 	const tabLabels: Record< VideoStatType, string > = {
 		views: translate( 'Views', { textOnly: true } ),
 		impressions: translate( 'Impressions', { textOnly: true } ),
 		watch_time: translate( 'Hours watched', { textOnly: true } ),
+		retention_rate: translate( 'Retention rate', { textOnly: true } ),
 	};
 
 	const periods: Array< { id: UiPeriod; label: string } > = [
@@ -371,33 +289,18 @@ export default function VideoSummary( {
 				'has-less-than-three-bars': chartData.length > 0 && chartData.length < 3,
 			} ) }
 		>
-			{ siteId &&
-				FETCHED_STAT_TYPES.map( ( type ) => (
-					<QuerySiteStats
-						key={ `${ type }-${ apiPeriod }` }
-						siteId={ siteId }
-						statType="statsVideo"
-						query={ queries[ type ] }
-					/>
-				) ) }
-			{ /* apiPeriod is already 'month' on the Days/Weeks tabs, so
-			queries.views above is this exact query already; only fetch it
-			separately when viewing Months/Years. */ }
-			{ siteId && apiPeriod !== 'month' && (
-				<QuerySiteStats
-					key="video-info"
-					siteId={ siteId }
-					statType="statsVideo"
-					query={ videoInfoQuery }
-				/>
+			{ siteId && (
+				<QuerySiteStats key={ uiPeriod } siteId={ siteId } statType="statsVideo" query={ query } />
 			) }
 
 			<StatsPeriodHeader>
-				{ /* The video stats endpoint only returns a fixed trailing window
-				ending "now" (no backend support yet for an older window), so
-				there's no previous/next period to navigate to; the arrows are
-				hidden rather than shown disabled. */ }
-				<StatsPeriodNavigation showArrows={ false } date={ null }>
+				<StatsPeriodNavigation
+					showArrows
+					onPeriodChange={ onPeriodChange }
+					disablePreviousArrow={ page >= maxPages }
+					disableNextArrow={ page <= 1 }
+					date={ null }
+				>
 					<DatePicker
 						period={ uiPeriod }
 						date={ selected?.startDate }
@@ -419,7 +322,7 @@ export default function VideoSummary( {
 			</StatsPeriodHeader>
 
 			<SummaryChart
-				isLoading={ ( isRequesting || ! isSelectedSeriesLoaded ) && ! chartData.length }
+				isLoading={ ( isRequesting || ! isLoaded ) && ! chartData.length }
 				data={ chartData }
 				activeKey="period"
 				dataKey="value"

--- a/client/my-sites/stats/stats-video-detail/video-summary.tsx
+++ b/client/my-sites/stats/stats-video-detail/video-summary.tsx
@@ -16,6 +16,7 @@ import DatePicker from '../stats-date-label';
 import StatsPeriodHeader from '../stats-period-header';
 import StatsPeriodNavigation from '../stats-period-navigation';
 import SummaryChart from '../stats-summary';
+import { calculatePlayWeightedRetention } from './retention';
 import VideoMetricTabs, { VideoStatType, VideoMetricValues } from './video-metric-tabs';
 
 type UiPeriod = 'day' | 'week' | 'month' | 'year';
@@ -204,13 +205,7 @@ export default function VideoSummary( {
 	}, [ visibleRows, uiPeriod, moment ] );
 
 	// Card totals cover the window shown in the chart (the current page).
-	// Retention can't be summed across buckets: the canonical formula is
-	// play-weighted — rate = (watch_time / plays) / duration — and the video
-	// duration isn't in the response. But every bucket satisfies
-	// rate_i = (watch_i / plays_i) / duration, so the constant is recovered
-	// from any bucket with plays and a non-zero rate, and the window rate is
-	// (Σwatch / Σplays) scaled by it — matching the endpoint's own `total`
-	// computation rather than a naive average of the daily rates.
+	// Retention is play-weighted rather than summed — see retention.ts.
 	const metricValues: VideoMetricValues = useMemo( () => {
 		const sumOf = ( type: VideoStatType ) =>
 			visibleRows.reduce( ( total, row ) => total + metricValue( row, type ), 0 );
@@ -218,23 +213,13 @@ export default function VideoSummary( {
 			!! availableMetrics && availableMetrics.includes( METRIC_COLUMNS[ type ] );
 
 		let retention: number | null = null;
-		if ( has( 'retention_rate' ) && has( 'views' ) && has( 'watch_time' ) ) {
-			const plays = sumOf( 'views' );
-			const reference = visibleRows.find(
-				( row ) =>
-					metricValue( row, 'views' ) > 0 &&
-					metricValue( row, 'watch_time' ) > 0 &&
-					metricValue( row, 'retention_rate' ) > 0
+		if ( has( 'retention_rate' ) && has( 'views' ) ) {
+			retention = calculatePlayWeightedRetention(
+				visibleRows.map( ( row ) => ( {
+					plays: metricValue( row, 'views' ),
+					retentionRate: metricValue( row, 'retention_rate' ),
+				} ) )
 			);
-			if ( plays > 0 && reference ) {
-				const referencePerPlay =
-					metricValue( reference, 'watch_time' ) / metricValue( reference, 'views' );
-				retention =
-					( sumOf( 'watch_time' ) / plays ) *
-					( metricValue( reference, 'retention_rate' ) / referencePerPlay );
-			} else {
-				retention = 0;
-			}
 		}
 
 		return {

--- a/client/my-sites/stats/stats-video-detail/video-summary.tsx
+++ b/client/my-sites/stats/stats-video-detail/video-summary.tsx
@@ -81,7 +81,6 @@ export default function VideoSummary( {
 	const [ statType, setStatType ] = useState< VideoStatType >(
 		isVideoStatType( initialStatType ) ? initialStatType : 'views'
 	);
-	const [ selectedRecord, setSelectedRecord ] = useState< ChartRecord | null >( null );
 
 	// One request per granularity: statType=all returns every metric series in
 	// a single response, and num=-1 windows it from the video's publish date,
@@ -173,14 +172,8 @@ export default function VideoSummary( {
 		[ visibleRows, statType, uiPeriod, moment ]
 	);
 
-	// No bar is highlighted by default; the header shows the range instead of
-	// a single bar's date, so defaulting to the most recent bar would highlight
-	// it for no reason until the user actually clicks one.
-	const selected = selectedRecord;
-
 	// The header shows the date range the visible bars cover (like the Post
-	// Details chart's page-range header), rather than the period of whichever
-	// single bar is selected, so it reads the same across every
+	// Details chart's page-range header), so it reads the same across every
 	// Day/Week/Month/Year tab and matches Post Details' behavior.
 	const chartDateRange = useMemo( () => {
 		if ( ! visibleRows.length ) {
@@ -245,12 +238,6 @@ export default function VideoSummary( {
 	const selectPeriod = ( newPeriod: UiPeriod ) => () => {
 		setUiPeriod( newPeriod );
 		setPage( 1 );
-		setSelectedRecord( null );
-	};
-
-	const selectStatType = ( newStatType: VideoStatType ) => {
-		setStatType( newStatType );
-		setSelectedRecord( null );
 	};
 
 	// Arrows page the whole visible window of bars, like the Post Details
@@ -258,10 +245,8 @@ export default function VideoSummary( {
 	const onPeriodChange = ( { direction }: { direction: string } ) => {
 		if ( 'previous' === direction && page < maxPages ) {
 			setPage( page + 1 );
-			setSelectedRecord( null );
 		} else if ( 'next' === direction && page > 1 ) {
 			setPage( page - 1 );
-			setSelectedRecord( null );
 		}
 	};
 
@@ -283,7 +268,6 @@ export default function VideoSummary( {
 		<div
 			className={ clsx( 'stats-video-summary', 'is-chart-tabs', {
 				'is-period-year': uiPeriod === 'year',
-				'has-less-than-three-bars': chartData.length > 0 && chartData.length < 3,
 			} ) }
 		>
 			{ siteId && (
@@ -298,12 +282,7 @@ export default function VideoSummary( {
 					disableNextArrow={ page <= 1 }
 					date={ null }
 				>
-					<DatePicker
-						period={ uiPeriod }
-						date={ selected?.startDate }
-						dateRange={ chartDateRange }
-						isShort
-					/>
+					<DatePicker period={ uiPeriod } dateRange={ chartDateRange } isShort />
 				</StatsPeriodNavigation>
 				<SegmentedControl primary>
 					{ periods.map( ( { id, label } ) => (
@@ -326,13 +305,11 @@ export default function VideoSummary( {
 				labelKey="periodLabel"
 				chartType="video"
 				sectionClass="is-video"
-				selected={ selected }
-				onClick={ setSelectedRecord }
 				tabLabel={ tabLabels[ statType ] }
 				type="video"
 			/>
 
-			<VideoMetricTabs values={ metricValues } selected={ statType } onSelect={ selectStatType } />
+			<VideoMetricTabs values={ metricValues } selected={ statType } onSelect={ setStatType } />
 		</div>
 	);
 }

--- a/client/state/stats/lists/actions.js
+++ b/client/state/stats/lists/actions.js
@@ -109,12 +109,19 @@ export function requestSiteStats( siteId, statType, query ) {
 					},
 					options
 			  )
-			: wpcom
-					.site( siteId )
-					[ statType ](
-						options,
-						'statsVideo' === statType ? { statType: query.statType, period: query.period } : {}
-					);
+			: wpcom.site( siteId )[ statType ](
+					options,
+					// stats/video/:id takes its window and series selection from
+					// these params; only forward the ones the query actually sets
+					// so legacy queries keep their historical request shape.
+					'statsVideo' === statType
+						? Object.fromEntries(
+								[ 'statType', 'period', 'num', 'date', 'start_date' ]
+									.filter( ( param ) => query[ param ] !== undefined )
+									.map( ( param ) => [ param, query[ param ] ] )
+						  )
+						: {}
+			  );
 
 		return requestStats
 			.then( ( data ) => dispatch( receiveSiteStats( siteId, statType, query, data, Date.now() ) ) )

--- a/client/state/stats/lists/test/actions.js
+++ b/client/state/stats/lists/test/actions.js
@@ -111,7 +111,11 @@ describe( 'actions', () => {
 		test( 'should forward video stats range query parameters', () => {
 			const query = { postId: 31533, statType: 'all', period: 'day', num: -1 };
 
-			return requestSiteStats( SITE_ID, STAT_TYPE_VIDEO, query )( spy ).then( () => {
+			return requestSiteStats(
+				SITE_ID,
+				STAT_TYPE_VIDEO,
+				query
+			)( spy ).then( () => {
 				expect( spy ).toHaveBeenCalledWith(
 					expect.objectContaining( {
 						type: SITE_STATS_RECEIVE,

--- a/client/state/stats/lists/test/actions.js
+++ b/client/state/stats/lists/test/actions.js
@@ -59,6 +59,9 @@ describe( 'actions', () => {
 					error: 'not_found',
 				} )
 				.get( `/rest/v1.1/sites/${ SITE_ID }/stats/video/31533` )
+				.reply( 200, VIDEO_RESPONSE )
+				.get( `/rest/v1.1/sites/${ SITE_ID }/stats/video/31533` )
+				.query( { statType: 'all', period: 'day', num: '-1' } )
 				.reply( 200, VIDEO_RESPONSE );
 		} );
 
@@ -100,6 +103,22 @@ describe( 'actions', () => {
 						statType: STAT_TYPE_VIDEO,
 						data: VIDEO_RESPONSE,
 						query: { postId: 31533 },
+					} )
+				);
+			} );
+		} );
+
+		test( 'should forward video stats range query parameters', () => {
+			const query = { postId: 31533, statType: 'all', period: 'day', num: -1 };
+
+			return requestSiteStats( SITE_ID, STAT_TYPE_VIDEO, query )( spy ).then( () => {
+				expect( spy ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						type: SITE_STATS_RECEIVE,
+						siteId: SITE_ID,
+						statType: STAT_TYPE_VIDEO,
+						data: VIDEO_RESPONSE,
+						query,
 					} )
 				);
 			} );

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1644,7 +1644,7 @@ describe( 'utils', () => {
 						data: { date: '7-10', p: '0' },
 						pages: [],
 					} )
-				).toEqual( { pages: [], data: [], post: null } );
+				).toEqual( { pages: [], data: [], post: null, metrics: null, rows: null, total: null } );
 			} );
 
 			test( 'should skip non-tuple entries in the data array', () => {
@@ -1657,6 +1657,9 @@ describe( 'utils', () => {
 					pages: [],
 					data: [ { period: '2016-11-12', value: 1 } ],
 					post: null,
+					metrics: null,
+					rows: null,
+					total: null,
 				} );
 			} );
 
@@ -1700,6 +1703,9 @@ describe( 'utils', () => {
 						},
 					],
 					post: null,
+					metrics: null,
+					rows: null,
+					total: null,
 				} );
 			} );
 
@@ -1713,6 +1719,59 @@ describe( 'utils', () => {
 					pages: [],
 					data: [],
 					post,
+					metrics: null,
+					rows: null,
+					total: null,
+				} );
+			} );
+
+			test( 'should key range-mode rows by the metric names in fields', () => {
+				expect(
+					normalizers.statsVideo( {
+						fields: [ 'period', 'plays', 'impressions', 'watch_time', 'retention_rate' ],
+						data: [
+							[ '2026-07-01', 3, 10, 0.5, 25.5 ],
+							[ '2026-07-02', '0', 4, 0, 0 ],
+						],
+						pages: [],
+						total: { plays: 3, impressions: 14, watch_time: 0.5, retention_rate: 25.5 },
+					} )
+				).toEqual( {
+					pages: [],
+					data: [
+						{ period: '2026-07-01', value: 3 },
+						{ period: '2026-07-02', value: '0' },
+					],
+					post: null,
+					metrics: [ 'plays', 'impressions', 'watch_time', 'retention_rate' ],
+					rows: [
+						{
+							period: '2026-07-01',
+							plays: 3,
+							impressions: 10,
+							watch_time: 0.5,
+							retention_rate: 25.5,
+						},
+						{ period: '2026-07-02', plays: 0, impressions: 4, watch_time: 0, retention_rate: 0 },
+					],
+					total: { plays: 3, impressions: 14, watch_time: 0.5, retention_rate: 25.5 },
+				} );
+			} );
+
+			test( 'should build single-metric rows from a two-column fields list', () => {
+				expect(
+					normalizers.statsVideo( {
+						fields: [ 'period', 'impressions' ],
+						data: [ [ '2026-07-01', 7 ] ],
+						pages: [],
+					} )
+				).toEqual( {
+					pages: [],
+					data: [ { period: '2026-07-01', value: 7 } ],
+					post: null,
+					metrics: [ 'impressions' ],
+					rows: [ { period: '2026-07-01', impressions: 7 } ],
+					total: null,
 				} );
 			} );
 		} );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -844,6 +844,28 @@ export const normalizers = {
 				} );
 		}
 
+		// `fields` names the tuple columns after the leading period (one metric
+		// for a single statType, four for statType=all). Rows keyed by metric
+		// name let consumers pick series without caring about column order.
+		let metrics = null;
+		let rows = null;
+		if (
+			Array.isArray( payload.fields ) &&
+			payload.fields.length >= 2 &&
+			Array.isArray( payload.data )
+		) {
+			metrics = payload.fields.slice( 1 );
+			rows = payload.data
+				.filter( ( item ) => Array.isArray( item ) )
+				.map( ( item ) => {
+					const row = { period: item[ 0 ] };
+					metrics.forEach( ( metric, index ) => {
+						row[ metric ] = Number( item[ index + 1 ] ) || 0;
+					} );
+					return row;
+				} );
+		}
+
 		let pages = [];
 		if ( payload.pages ) {
 			pages = payload.pages.map( ( item ) => {
@@ -856,7 +878,16 @@ export const normalizers = {
 
 		// The endpoint also returns the video's attachment post, which carries
 		// the title and upload date.
-		return { pages, data, post: payload.post ?? null };
+		return {
+			pages,
+			data,
+			post: payload.post ?? null,
+			metrics,
+			rows,
+			// Range queries also return canonical totals over the window, keyed
+			// by metric name.
+			total: payload.total ?? null,
+		};
 	},
 
 	/**


### PR DESCRIPTION
Part of STATS-312 — the frontend half of the `stats/video/:video_id` range upgrade. The internal wpcom half (PR 229903) has **merged and is live in production** (verified: the `statType=all` response, including the retention series, serves this page against production).

## Proposed Changes

* **One request instead of three, covering the full history.** `VideoSummary` now fetches `{ statType: 'all', period: <granularity>, num: -1 }` — a single response carrying all four metric series (plays, impressions, watch_time, retention_rate) windowed from the video's publish date — replacing the three parallel trailing-window queries per metric.
* **Real pagination, like Post Details.** The chart pages the series client-side in `STATS_SUMMARY_MAX_BARS` chunks with the period-navigation arrows enabled (they were hidden before because the legacy endpoint could only return a fixed trailing window). Paging, slice bounds, and arrow-disable behavior mirror `StatsPostSummary`.
* **True bucket granularity.** Days/Weeks/Months/Years now request `period=day|week|month|year` directly; the client-side re-bucketing (`buckets`) and window-trimming (`trimToTrailingWindow`) hacks are gone.
* **New Retention rate tab.** The fourth metric tab charts the API's per-bucket retention series; the tab total is play-weighted over the visible window (matching the endpoint's own `total` math), not a naive average of daily rates. The metric tabs grid splits four ways so the new tab fits the row.
* **Tooltips match the metric cards.** Bar tooltips reuse the metric-tab formatter for Hours watched and Retention rate (`< 1.0`, `63.0%` instead of a bare `0` / `63`); Views and Impressions keep exact counts.
* **Hover-tooltip-only charts are truly inert.** Bars follow the Post Details chart's behavior: no click-to-select. Shared `StatsSummaryChart` now only wires up `barClick` when the caller passes `onClick`, and drops the pointer cursor otherwise — which also stops the Post Details chart from logging a `Clicked Summary Chart Bar` event for clicks that do nothing.
* `statsVideo` normalizer: adds `metrics` / `rows` (series keyed by the metric names in `fields`) and passes `total` through; the legacy `{ pages, data, post }` shape is unchanged. The request action now forwards `statType`/`period`/`num`/`date`/`start_date` when set.
* The parent page and the embeds card keep their existing behavior; the parent's metadata query now mirrors the summary's default Days query so it reuses the cached response.

## Why are these changes being made?

The video details chart could only show a fixed trailing window (~30 days daily / ~13 months monthly) anchored at "now": the legacy endpoint ignored all date parameters, so the page needed three requests per view, re-bucketed client-side, and had to hide the period-navigation arrows. With the endpoint's new range support the chart can finally walk back to the video's publish date — the same interaction the Post Details chart has always had — and gains the retention series the old API couldn't produce.

## Testing Instructions

Requires a site with VideoPress videos (the wpcom API change is live in production).

1. Open Stats → Videos → click a video to reach `/stats/day/videodetails/:site?post=<id>`.
2. Days/Weeks/Months/Years each render bars at that true granularity, max 10 bars per page.
3. The ‹ › arrows page back through history to the video's publish date; ‹ disables on the oldest page, › on the newest.
4. The header date range reflects the visible page. Bars are hover-tooltip only (like the Post Details chart): hovering shows the period and formatted value (`63.0%`, `< 1.0`), clicking does nothing, and the cursor stays a default arrow.
5. Metric tabs: Views / Impressions / Hours watched / Retention rate switch the charted series without refetching; totals match the visible window (retention shows a play-weighted %).
6. Video title/date card and Embedded pages card still render as before.
7. Regression check on the Post Details chart (Stats → Posts & pages → a post), which shares `StatsSummaryChart`: it renders and pages as before, and its bars likewise show no pointer cursor.
8. `yarn test-client client/state/stats/lists/test/utils.js client/state/stats/lists/test/actions.js client/my-sites/stats/stats-video-detail/test/retention.ts` — 129 tests green.

### Screenshots

#### Before — a fixed trailing window (at most the last 30 days), no paging
<img width="1232" height="754" alt="截圖 2026-07-27 下午4 05 42" src="https://github.com/user-attachments/assets/a5ad78c8-9945-4851-9350-c582f67b4cdf" />

#### After — 10 bars per page, paging back to the video's publish date
<img width="1232" height="757" alt="截圖 2026-07-27 下午4 06 27" src="https://github.com/user-attachments/assets/63c5bcd2-1672-47a0-bd4c-a05ad868fa92" />

#### Second screenshot: the oldest page, where `‹-` is disabled at the publish date
<img width="1223" height="757" alt="截圖 2026-07-27 下午4 06 37" src="https://github.com/user-attachments/assets/ef5f25df-4ef0-467e-9080-c42eb6d4f4f6" />

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?


