### PR TITLE
A4A Plugins: Align the partial-selection dash with the checkmark in tri-state checkboxes

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -281,7 +281,10 @@
 		}
 	}
 
-	thead .dataviews-view-table__row th span {
+	// The Plugins dashboard reuses the `.sites-dashboard` root class, so this header-label
+	// typography reaches its select-all checkbox as soon as this chunk is in the document. The
+	// 20px line-height stretches that 16px container, pushing the centred indicator off-centre.
+	thead .dataviews-view-table__row th span:not( .components-checkbox-control__input-container ) {
 		@include heading-small;
 		line-height: 20px;
 		color: var( --color-accent-80 );

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -294,6 +294,25 @@
 		outline: none;
 	}
 
+	// The `check` and `reset` glyphs behind the checked and partially-selected states are not
+	// centred on the same axis inside their shared 24-unit viewBox: the checkmark's ink spans
+	// 7.5–16.1 (centre 11.8) while the dash spans 11.5–13 (centre 12.25). Centring the two SVGs
+	// therefore leaves the indicators 0.45 units apart. Nudge each glyph's ink onto the true
+	// centre of the box, in viewBox units so the correction scales with the rendered icon.
+	svg.components-checkbox-control__checked,
+	svg.components-checkbox-control__indeterminate {
+		// Falls back so the calc can never become invalid and drop the centring transform.
+		--checkbox-icon-viewbox-unit: calc(var(--checkmark-size, var(--checkbox-input-size, 16px)) / 24);
+	}
+
+	svg.components-checkbox-control__checked {
+		transform: translate(-50%, calc(-50% + 0.2 * var(--checkbox-icon-viewbox-unit)));
+	}
+
+	svg.components-checkbox-control__indeterminate {
+		transform: translate(-50%, calc(-50% - 0.25 * var(--checkbox-icon-viewbox-unit)));
+	}
+
 	.components-button.is-tertiary:not( .dataviews-view-table-header-button ) {
 		color: var(--color-primary-60);
 	}


### PR DESCRIPTION
Fixes A4A-3034

## Proposed Changes

* Nudge the checked and partially-selected checkbox indicators onto the true vertical centre of the checkbox, so the dash and the checkmark sit on the same axis as each other.
* Stop the Sites dashboard's header-label typography from reaching the Plugins select-all checkbox, which was dropping the indicator 2px once Sites had been visited.

## Why are these changes being made?

The multi-select header checkbox on **Plugins → Manage plugins** has three states. `CheckboxControl` from `@wordpress/components` renders the last two as absolutely-positioned SVGs stacked over the input: the `check` glyph when everything is selected, the `reset` glyph (a dash) when only some rows are. Both SVGs get the same box and the same `translate(-50%, -50%)`, so the *boxes* line up exactly.

The glyphs inside those boxes do not. Within their shared 24-unit viewBox, the checkmark's ink spans 7.5–16.1 (centre **11.8**) while the dash spans 11.5–13 (centre **12.25**). Centring the boxes therefore leaves the two indicators 0.45 viewBox units apart — 0.375px at the 16px checkbox size, with the dash sitting low and the checkmark sitting high. Toggling a row between "all selected" and "some selected" visibly shifts the indicator, which reads as sloppy in an otherwise tidy table.

This change adds a per-glyph vertical correction expressed in viewBox units, so each indicator's ink lands on the exact centre of the box. Because the offsets are a fraction of the rendered icon size rather than a fixed pixel value, they hold at both checkbox sizes the component uses (16px on desktop, 24px on small viewports).

Measured ink offset from the centre of the checkbox, on `/plugins/manage/sites`:

| State | Before | After |
|---|---|---|
| Checked | −0.167px (high) | 0px |
| Partially selected | +0.208px (low) | 0px |

The root cause is in `@wordpress/components`, so the same offset exists in stock Gutenberg. It is corrected here in the A4A stylesheet that already owns A4A's checkbox appearance, which fixes it for every A4A screen at once rather than patching the Plugins screen. It is worth reporting upstream separately.

`supportsBulk` only appears in the plugins list, so **Plugins → Manage plugins is currently the only A4A surface with a tri-state checkbox**. The checked-state half of the fix shifts every A4A checkmark down 0.167px, which is imperceptible and strictly more centred.

The declaration reads `var(--checkmark-size, var(--checkbox-input-size, 16px))` rather than `var(--checkmark-size)` on purpose. If that custom property is ever renamed upstream, the bare form would become invalid at computed-value time, `transform` would fall back to `none`, and the indicators would lose the `-50%, -50%` pullback entirely — visibly breaking every A4A checkbox. Most upstream changes to this area would merely make this rule redundant; that one would make it actively harmful, so the fallback chain guarantees the `calc()` always resolves.

### Before / after

The defect is 0.375px, which is invisible at 100%. Both shots are magnified 12× with a guideline through the exact centre of the box, showing all three states side by side.

**Before** — the dash sits clearly below the centre line:

<img width="1566" height="469" alt="before-magnified-12x" src="https://github.com/user-attachments/assets/0a5f988b-49c6-45d8-b043-d4a591f67563" />

**After** — the line bisects the dash, and the checkmark straddles it evenly:

<img width="1566" height="469" alt="after-magnified-12x" src="https://github.com/user-attachments/assets/fee508ee-a49d-4c64-8d1d-69134faf2758" />

## Also fixed: the header checkbox drops 2px after visiting Sites

Separately from the glyph centring above, the select-all checkbox in the Plugins header sat about 2px too low, but only after `/sites` had been visited earlier in the session.

The Sites dashboard styles every header-cell `span` with the column-label typography, including `line-height: 20px`, under a selector anchored on the `.sites-dashboard` root class. The Plugins dashboard renders under that same root class, so once the Sites CSS chunk is in the document it also matches the Plugins header. `CheckboxControl` wraps its input in a `span`, and the 20px line-height stretches that 16px span, centring the indicator 2px below the input. Opening `/plugins/manage/sites` directly never loads the Sites chunk, so the drop only appears after Sites is visited.

This excludes the checkbox container from the header-label rule (`th span:not(.components-checkbox-control__input-container)`), so the column labels keep their typography and the checkbox indicator stays on the input's centre. With the fix, the header indicator's `deltaY` is `0` in both navigation orders; it was `2px` after visiting Sites.

### Before / after (after visiting Sites, magnified 10×)

**Before** — the dash sits about 2px below the input's centre:

<img width="450" alt="Header checkbox dash sitting 2px low after visiting Sites" src="https://github.com/user-attachments/assets/e5411f28-3163-4a0b-b526-7dc72d7f8125" />

**After** — the dash sits on the input's centre:

<img width="450" alt="Header checkbox dash centred after visiting Sites" src="https://github.com/user-attachments/assets/360bb295-cb3c-42a9-95bd-ab79de37a7d2" />

## Testing Instructions

Prerequisites: an Automattic for Agencies account with at least two sites that have plugins installed.

1. Start the A4A dev server: `yarn start-a8c-for-agencies`
2. Go to `http://agencies.localhost:3000/plugins/manage/sites`
3. Click the select-all checkbox at the bottom left of the table, next to the item count. All rows are selected and the checkbox shows a **checkmark**.
4. Click any single row's checkbox to deselect it. The footer checkbox now shows a **dash** (partially selected).
5. Toggle that row's checkbox back and forth a few times and watch the footer checkbox. The dash and the checkmark should sit at the same height — no vertical jump as the indicator swaps.
6. To see it precisely, paste this in the browser console while the checkbox is in either state. Both `deltaX` and `deltaY` should be `0`; before this change they were `-0.167` and `+0.208`:

```js
const c = document.querySelector( '.components-checkbox-control__input-container' );
const input = c.querySelector( 'input' );
const svg = c.querySelector( 'svg.components-checkbox-control__checked, svg.components-checkbox-control__indeterminate' );
const path = svg.querySelector( 'path' );
const bb = path.getBBox();
const m = path.getScreenCTM();
const a = svg.createSVGPoint(); a.x = bb.x; a.y = bb.y;
const b = svg.createSVGPoint(); b.x = bb.x + bb.width; b.y = bb.y + bb.height;
const tl = a.matrixTransform( m ), br = b.matrixTransform( m );
const ir = input.getBoundingClientRect();
console.log( {
	state: svg.getAttribute( 'class' ),
	deltaY: ( tl.y + br.y ) / 2 - ( ir.top + ir.bottom ) / 2,
	deltaX: ( tl.x + br.x ) / 2 - ( ir.left + ir.right ) / 2,
} );
```

7. Narrow the browser below 600px so the checkbox switches to its 24px size, and repeat step 6. The offsets should still be `0`.
8. Spot-check an ordinary (non-tri-state) checkbox elsewhere in A4A — for example the consent checkbox in **Purchases → Payment methods → Add payment method**. The checkmark should still look centred.
9. Load `/sites` first, then navigate to `/plugins/manage/sites`, and repeat steps 5–6 on the header select-all checkbox. The indicator should stay centred; before this fix it dropped 2px in that navigation order only.

### How this was verified

Worth knowing before you re-test: the dev server available while writing this was serving a different worktree, so it never rebuilt with the patch. Rather than spend a full Calypso build on a sub-pixel CSS nudge, the SCSS was compiled with `sass` to get the exact build output, that CSS was injected into the running A4A page, and the measurements above were taken against the real component in the real DOM. The "after" numbers and screenshot therefore come from injected compiled CSS, not from a rebuilt bundle. The RTL output was checked separately by running `rtlcss` over the compiled rule — it flips the X translate exactly as it flips the upstream rule, and leaves the Y `calc()` untouched. A quick eyeball on a server actually running this branch is still worthwhile.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

### Notes on the unchecked items

* **No new tests.** This is a sub-pixel CSS alignment change with no behaviour to assert. jsdom does not compute layout, so a unit test could only assert the literal declaration text — it would restate the stylesheet rather than verify the alignment, and would break on any harmless refactor. Verified by measurement in the browser instead (step 6 above).
* **Dark mode** is unchecked because the change is a `transform` only and touches no colour; the A4A Plugins table does not have a dark variant.
* **Simple/Atomic/Jetpack sites** are unchecked because the change is presentational and site-type independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

