### PR TITLE
A4A Sites: Refresh the Monitor tab activity card

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-monitor.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-monitor.tsx
@@ -53,6 +53,7 @@ export function JetpackMonitorPreview( { site, trackEvent, hasError = false }: P
 						site={ site }
 						trackEvent={ trackEvent }
 						hasError={ hasError }
+						showSummary
 					/>
 				) }
 			</div>

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/a4a-style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/a4a-style.scss
@@ -125,11 +125,6 @@
 		right: 0;
 		text-align: unset;
 	}
-
-
-	.site-expanded-content__chart .chart .chart__bar.site-expanded-content__chart-bar-is-uptime .chart__bar-section {
-		border-radius: 2px;
-	}
 }
 
 .site-preview-pane__stats-content {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/expanded-card.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/expanded-card.tsx
@@ -13,6 +13,7 @@ interface Props {
 	href?: string;
 	isLoading?: boolean;
 	hasError?: boolean;
+	className?: string;
 }
 
 export default function ExpandedCard( {
@@ -24,6 +25,7 @@ export default function ExpandedCard( {
 	href,
 	isLoading,
 	hasError,
+	className,
 }: Props ) {
 	// Trigger click event when pressing Enter or Space
 	const handleOnKeyDown = ( event: React.KeyboardEvent< HTMLDivElement > ) => {
@@ -38,7 +40,7 @@ export default function ExpandedCard( {
 		href,
 		compact: true,
 		showLinkIcon: false,
-		className: clsx( 'expanded-card', {
+		className: clsx( 'expanded-card', className, {
 			'expanded-card__not-enabled': ! isEnabled,
 			'expanded-card__clickable': isClickable,
 			'expanded-card__loading': isLoading,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/hooks/use-get-monitor-downtime-text.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/hooks/use-get-monitor-downtime-text.ts
@@ -1,6 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
-import moment from 'moment';
 import { useCallback } from 'react';
+import { formatDowntimeDuration } from '../monitor-activity-summary';
 
 const useGetMonitorDowntimeText = () => {
 	const translate = useTranslate();
@@ -11,21 +11,9 @@ const useGetMonitorDowntimeText = () => {
 				return translate( 'Downtime' );
 			}
 
-			const duration = moment.duration( downtime, 'minutes' );
-
-			const days = duration.days();
-			const hours = duration.hours();
-			const minutes = duration.minutes();
-
-			const formattedDays = days > 0 ? `${ days }d ` : '';
-			const formattedHours = hours > 0 ? `${ hours }h ` : '';
-			const formattedMinutes = minutes > 0 ? `${ minutes }m` : '';
-
-			const time = `${ formattedDays }${ formattedHours }${ formattedMinutes }`;
-
 			return translate( 'Downtime for %(time)s', {
 				args: {
-					time: time.trim(),
+					time: formatDowntimeDuration( downtime ),
 				},
 				comment: '%(time) is the downtime, e.g. "2d 5h 30m", "5h 30m", "55m"',
 			} ) as string;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity-summary.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity-summary.ts
@@ -1,0 +1,69 @@
+import moment from 'moment';
+
+const MINUTES_IN_A_DAY = 24 * 60;
+
+export interface MonitorActivityDay {
+	date: string;
+	status: string;
+	downtime_in_minutes?: number;
+}
+
+export interface MonitorActivitySummary {
+	monitoredDays: number;
+	downtimeEvents: number;
+	// Null when the API did not report a duration for every day that had downtime.
+	downtimeInMinutes: number | null;
+	// Null when nothing has been monitored yet, or when the downtime durations are incomplete.
+	uptimeFraction: number | null;
+}
+
+/**
+ * The uptime endpoint reports one entry per day, so uptime and total downtime can only be
+ * stated truthfully when every day with downtime came back with a duration. When any of them
+ * is missing, both figures are reported as null so the caller can leave them out rather than
+ * understate the outage.
+ */
+export function getMonitorActivitySummary( days: MonitorActivityDay[] ): MonitorActivitySummary {
+	const monitoredDays = days.filter( ( { status } ) => status === 'up' || status === 'down' );
+	const downDays = monitoredDays.filter( ( { status } ) => status === 'down' );
+
+	const hasDowntimeDurations = downDays.every(
+		( { downtime_in_minutes } ) => typeof downtime_in_minutes === 'number'
+	);
+
+	if ( ! monitoredDays.length || ! hasDowntimeDurations ) {
+		return {
+			monitoredDays: monitoredDays.length,
+			downtimeEvents: downDays.length,
+			downtimeInMinutes: null,
+			uptimeFraction: null,
+		};
+	}
+
+	const downtimeInMinutes = downDays.reduce(
+		( total, { downtime_in_minutes } ) => total + ( downtime_in_minutes ?? 0 ),
+		0
+	);
+	const monitoredMinutes = monitoredDays.length * MINUTES_IN_A_DAY;
+
+	return {
+		monitoredDays: monitoredDays.length,
+		downtimeEvents: downDays.length,
+		downtimeInMinutes,
+		uptimeFraction: Math.max( monitoredMinutes - downtimeInMinutes, 0 ) / monitoredMinutes,
+	};
+}
+
+export function formatDowntimeDuration( downtimeInMinutes: number ): string {
+	const duration = moment.duration( downtimeInMinutes, 'minutes' );
+
+	const days = duration.days();
+	const hours = duration.hours();
+	const minutes = duration.minutes();
+
+	const formattedDays = days > 0 ? `${ days }d ` : '';
+	const formattedHours = hours > 0 ? `${ hours }h ` : '';
+	const formattedMinutes = minutes > 0 ? `${ minutes }m` : '';
+
+	return `${ formattedDays }${ formattedHours }${ formattedMinutes }`.trim() || '0m';
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
@@ -1,3 +1,5 @@
+import { formatNumber } from '@automattic/number-formatters';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import ElementChart from 'calypso/components/chart';
@@ -8,27 +10,138 @@ import { getSiteMonitorStatuses } from 'calypso/state/jetpack-agency-dashboard/s
 import useToggleActivateMonitor from '../../hooks/use-toggle-activate-monitor';
 import ExpandedCard from './expanded-card';
 import useGetMonitorDowntimeText from './hooks/use-get-monitor-downtime-text';
+import {
+	formatDowntimeDuration,
+	getMonitorActivitySummary,
+	type MonitorActivityDay,
+} from './monitor-activity-summary';
 import type { Site } from '../types';
+import type { ReactNode } from 'react';
 
 interface Props {
 	hasMonitor: boolean;
 	site: Site;
 	trackEvent: ( eventName: string ) => void;
 	hasError: boolean;
+	// Opt-in summary stats, status pill and legend around the activity bar.
+	showSummary?: boolean;
 }
 
 const START_INDEX = 10;
+const DAYS_SHOWN = 20;
 
-const MonitorDataContent = ( { siteId }: { siteId: number } ) => {
+// monitor_site_status is false by default, so a site that has never changed status is up.
+const INITIAL_UNIX_EPOCH = '1970-01-01 00:00:00';
+
+const isSiteUp = ( site: Site ) =>
+	site.monitor_settings.monitor_site_status ||
+	INITIAL_UNIX_EPOCH === site.monitor_last_status_change;
+
+const MonitorSummary = ( { days, site }: { days: MonitorActivityDay[]; site: Site } ) => {
+	const translate = useTranslate();
+
+	const { monitoredDays, downtimeEvents, downtimeInMinutes, uptimeFraction } =
+		getMonitorActivitySummary( days );
+
+	const stats: { key: string; value: string; label: ReactNode }[] = [];
+
+	if ( uptimeFraction !== null ) {
+		// Truncate rather than round so a site with recorded downtime never reads as 100%.
+		const truncatedUptime = Math.floor( uptimeFraction * 1000 ) / 1000;
+		const fractionDigits = truncatedUptime === 1 ? 0 : 1;
+
+		stats.push( {
+			key: 'uptime',
+			value: formatNumber( truncatedUptime, {
+				numberFormatOptions: {
+					style: 'percent',
+					minimumFractionDigits: fractionDigits,
+					maximumFractionDigits: fractionDigits,
+				},
+			} ),
+			label: translate( 'Uptime' ),
+		} );
+	}
+
+	if ( monitoredDays > 0 ) {
+		stats.push( {
+			key: 'downtime-events',
+			value: formatNumber( downtimeEvents ),
+			label: translate( 'Downtime event', 'Downtime events', { count: downtimeEvents } ),
+		} );
+	}
+
+	if ( downtimeInMinutes !== null ) {
+		stats.push( {
+			key: 'total-downtime',
+			value: formatDowntimeDuration( downtimeInMinutes ),
+			label: translate( 'Total downtime' ),
+		} );
+	}
+
+	const siteIsUp = isSiteUp( site );
+
+	return (
+		<div className="site-expanded-content__monitor-summary">
+			<div className="site-expanded-content__monitor-stats">
+				{ stats.map( ( { key, value, label } ) => (
+					<div className="site-expanded-content__monitor-stat" key={ key }>
+						<span className="site-expanded-content__monitor-stat-value">{ value }</span>
+						<span className="site-expanded-content__monitor-stat-label">{ label }</span>
+					</div>
+				) ) }
+			</div>
+			<div
+				className={ clsx(
+					'site-expanded-content__monitor-status',
+					siteIsUp
+						? 'site-expanded-content__monitor-status-is-up'
+						: 'site-expanded-content__monitor-status-is-down'
+				) }
+			>
+				<span className="site-expanded-content__monitor-status-dot" aria-hidden="true" />
+				{ siteIsUp ? translate( 'Site is up' ) : translate( 'Site is down' ) }
+			</div>
+		</div>
+	);
+};
+
+const MonitorLegend = () => {
+	const translate = useTranslate();
+
+	const items = [
+		{ key: 'up', modifier: 'is-uptime', label: translate( 'Up' ) },
+		{ key: 'down', modifier: 'is-downtime', label: translate( 'Downtime' ) },
+		{ key: 'no-data', modifier: 'is-not-monitored', label: translate( 'Not monitored' ) },
+	];
+
+	return (
+		<div className="site-expanded-content__monitor-legend">
+			{ items.map( ( { key, modifier, label } ) => (
+				<span className="site-expanded-content__monitor-legend-item" key={ key }>
+					<span
+						className={ clsx( 'site-expanded-content__monitor-legend-swatch', modifier ) }
+						aria-hidden="true"
+					/>
+					{ label }
+				</span>
+			) ) }
+		</div>
+	);
+};
+
+const MonitorDataContent = ( { site, showSummary }: { site: Site; showSummary: boolean } ) => {
 	const translate = useTranslate();
 	const getMonitorDowntimeText = useGetMonitorDowntimeText();
 
-	const { data } = useFetchMonitorData( siteId, '30 days' );
+	const { data } = useFetchMonitorData( site.blog_id, '30 days' );
 
 	const incidents = data ?? [];
 
 	// We need to slice the data because the API returns the latest 30 incidents
-	const monitorData = incidents.slice( START_INDEX ).map( ( data ) => {
+	const days: MonitorActivityDay[] = incidents.slice( START_INDEX );
+
+	const monitorData = days.map( ( data ) => {
 		const { date, status, downtime_in_minutes } = data;
 
 		let className = 'site-expanded-content__chart-bar-no-data';
@@ -60,13 +173,14 @@ const MonitorDataContent = ( { siteId }: { siteId: number } ) => {
 	return (
 		<div className="site-expanded-content__card-content">
 			<div className="site-expanded-content__card-content-column">
+				{ showSummary && <MonitorSummary days={ days } site={ site } /> }
 				<div className="site-expanded-content__chart">
 					{ monitorData.length > 0 ? (
 						<ElementChart
 							data={ monitorData }
 							minBarWidth={ 10 }
 							sliceFromBeginning={ false }
-							minBarsToBeShown={ 20 }
+							minBarsToBeShown={ DAYS_SHOWN }
 							hideYAxis
 							hideXAxis
 						/>
@@ -78,12 +192,19 @@ const MonitorDataContent = ( { siteId }: { siteId: number } ) => {
 					<span>{ translate( '20d ago' ) }</span>
 					<span>{ translate( 'Today' ) }</span>
 				</div>
+				{ showSummary && <MonitorLegend /> }
 			</div>
 		</div>
 	);
 };
 
-export default function MonitorActivity( { hasMonitor, site, trackEvent, hasError }: Props ) {
+export default function MonitorActivity( {
+	hasMonitor,
+	site,
+	trackEvent,
+	hasError,
+	showSummary = false,
+}: Props ) {
 	const translate = useTranslate();
 
 	const toggleActivateMonitor = useToggleActivateMonitor( [ site ] );
@@ -95,9 +216,23 @@ export default function MonitorActivity( { hasMonitor, site, trackEvent, hasErro
 		toggleActivateMonitor( true );
 	};
 
+	const title = translate( 'Monitor activity' );
+
 	return (
 		<ExpandedCard
-			header={ translate( 'Monitor activity' ) }
+			className={ clsx( { 'site-expanded-content__monitor-activity-detailed': showSummary } ) }
+			header={
+				showSummary ? (
+					<>
+						<span>{ title }</span>
+						<span className="site-expanded-content__monitor-range">
+							{ translate( 'Last %(days)d days', { args: { days: DAYS_SHOWN } } ) }
+						</span>
+					</>
+				) : (
+					title
+				)
+			}
 			isEnabled={ hasMonitor }
 			emptyContent={ translate(
 				'Activate {{strong}}Monitor{{/strong}} to see your uptime records',
@@ -112,7 +247,7 @@ export default function MonitorActivity( { hasMonitor, site, trackEvent, hasErro
 			// Allow to click on the card only if the monitor is not active & the site is not atomic
 			onClick={ ! hasMonitor ? handleOnClick : undefined }
 		>
-			{ hasMonitor && <MonitorDataContent siteId={ site.blog_id } /> }
+			{ hasMonitor && <MonitorDataContent site={ site } showSummary={ showSummary } /> }
 		</ExpandedCard>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
@@ -309,3 +309,156 @@ $color-yellow: var(--studio-yellow-50);
 	color: var(--studio-gray-40);
 	margin-block: 6px;
 }
+
+/**
+ * Detailed monitor activity: summary stats, status pill, full-height status bar and legend.
+ * Opted into via the `showSummary` prop, so the compact dashboard card is unaffected.
+ */
+.site-expanded-content__monitor-activity-detailed {
+	.expanded-card__header {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 8px;
+		overflow: visible;
+	}
+
+	.site-expanded-content__monitor-range {
+		@include body-medium;
+		color: var(--studio-gray-50);
+	}
+
+	.site-expanded-content__monitor-summary {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-between;
+		gap: 16px;
+		margin-block-end: 20px;
+	}
+
+	.site-expanded-content__monitor-stats {
+		display: flex;
+		flex-wrap: wrap;
+		row-gap: 8px;
+	}
+
+	// Trailing dividers keep every stat flush with the card edge when the row wraps.
+	.site-expanded-content__monitor-stat {
+		padding-inline-end: 24px;
+		margin-inline-end: 24px;
+		border-inline-end: 1px solid var(--studio-gray-5);
+
+		&:last-child {
+			padding-inline-end: 0;
+			margin-inline-end: 0;
+			border-inline-end: none;
+		}
+	}
+
+	.site-expanded-content__monitor-stat-value {
+		@include heading-2x-large;
+		display: block;
+		color: var(--studio-gray-100);
+	}
+
+	.site-expanded-content__monitor-stat-label {
+		@include body-medium;
+		display: block;
+		color: var(--studio-gray-50);
+	}
+
+	.site-expanded-content__monitor-status {
+		@include heading-medium;
+		display: inline-flex;
+		align-items: center;
+		gap: 8px;
+		padding: 6px 14px;
+		border-radius: 16px;
+		white-space: nowrap;
+	}
+
+	.site-expanded-content__monitor-status-dot {
+		flex-shrink: 0;
+		width: 8px;
+		height: 8px;
+		border-radius: 4px;
+		background-color: currentColor;
+	}
+
+	.site-expanded-content__monitor-status-is-up {
+		background-color: var(--studio-green-0);
+		color: var(--studio-green-60);
+	}
+
+	.site-expanded-content__monitor-status-is-down {
+		background-color: var(--studio-red-0);
+		color: var(--studio-red-60);
+	}
+
+	.site-expanded-content__chart {
+		.chart__bars {
+			gap: 4px;
+			overflow: hidden;
+		}
+
+		.chart .chart__bar {
+			height: 48px;
+			gap: 4px;
+
+			.chart__bar-section {
+				inset-inline: 0;
+				border-radius: 3px;
+				text-align: unset;
+			}
+
+			// The compact card renders downtime as a thin marker; here it is a full-height block.
+			&.site-expanded-content__chart-bar-is-downtime {
+				height: 48px !important;
+				position: static !important;
+			}
+		}
+	}
+
+	.site-expanded-content__x-axis-pointers {
+		@include body-small;
+		margin-block-start: 8px;
+		color: var(--studio-gray-50);
+	}
+
+	.site-expanded-content__monitor-legend {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px 20px;
+		margin-block-start: 16px;
+	}
+
+	.site-expanded-content__monitor-legend-item {
+		@include body-medium;
+		display: inline-flex;
+		align-items: center;
+		gap: 8px;
+		color: var(--studio-gray-60);
+	}
+
+	.site-expanded-content__monitor-legend-swatch {
+		flex-shrink: 0;
+		width: 12px;
+		height: 12px;
+		border-radius: 3px;
+
+		&.is-uptime {
+			background-color: $color-green;
+		}
+
+		&.is-downtime {
+			background-color: $color-red;
+		}
+
+		&.is-not-monitored {
+			background-color: var(--studio-gray-0);
+			border: 1px solid var(--studio-gray-5);
+		}
+	}
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
@@ -315,12 +315,14 @@ $color-yellow: var(--studio-yellow-50);
  * Opted into via the `showSummary` prop, so the compact dashboard card is unaffected.
  */
 .site-expanded-content__monitor-activity-detailed {
+	container-type: inline-size;
+
 	.expanded-card__header {
 		display: flex;
 		flex-wrap: wrap;
 		align-items: baseline;
 		justify-content: space-between;
-		gap: 8px;
+		gap: 4px 8px;
 		overflow: visible;
 	}
 
@@ -330,30 +332,31 @@ $color-yellow: var(--studio-yellow-50);
 	}
 
 	.site-expanded-content__monitor-summary {
+		--monitor-stat-gutter: 24px;
 		display: flex;
 		flex-wrap: wrap;
 		align-items: center;
 		justify-content: space-between;
 		gap: 16px;
 		margin-block-end: 20px;
+		overflow: hidden;
 	}
 
+	// Pulled back over one gutter so the divider opening each row — wrapped rows
+	// included — lands outside the summary and is clipped rather than left dangling.
 	.site-expanded-content__monitor-stats {
 		display: flex;
 		flex-wrap: wrap;
 		row-gap: 8px;
+		margin-inline-start: calc(-1px - var(--monitor-stat-gutter));
 	}
 
-	// Trailing dividers keep every stat flush with the card edge when the row wraps.
 	.site-expanded-content__monitor-stat {
-		padding-inline-end: 24px;
-		margin-inline-end: 24px;
-		border-inline-end: 1px solid var(--studio-gray-5);
+		padding-inline: var(--monitor-stat-gutter);
+		border-inline-start: 1px solid var(--studio-gray-5);
 
 		&:last-child {
 			padding-inline-end: 0;
-			margin-inline-end: 0;
-			border-inline-end: none;
 		}
 	}
 
@@ -398,14 +401,16 @@ $color-yellow: var(--studio-yellow-50);
 	}
 
 	.site-expanded-content__chart {
+		--monitor-bar-height: 48px;
+		--monitor-bar-gap: 4px;
+
 		.chart__bars {
-			gap: 4px;
+			gap: var(--monitor-bar-gap);
 			overflow: hidden;
 		}
 
 		.chart .chart__bar {
-			height: 48px;
-			gap: 4px;
+			height: var(--monitor-bar-height);
 
 			.chart__bar-section {
 				inset-inline: 0;
@@ -415,7 +420,7 @@ $color-yellow: var(--studio-yellow-50);
 
 			// The compact card renders downtime as a thin marker; here it is a full-height block.
 			&.site-expanded-content__chart-bar-is-downtime {
-				height: 48px !important;
+				height: var(--monitor-bar-height) !important;
 				position: static !important;
 			}
 		}
@@ -459,6 +464,25 @@ $color-yellow: var(--studio-yellow-50);
 		&.is-not-monitored {
 			background-color: var(--studio-gray-0);
 			border: 1px solid var(--studio-gray-5);
+		}
+	}
+
+	@container (max-width: 480px) {
+		.site-expanded-content__monitor-summary {
+			--monitor-stat-gutter: 16px;
+		}
+
+		.site-expanded-content__monitor-stat-value {
+			@include heading-x-large;
+		}
+
+		.site-expanded-content__chart {
+			--monitor-bar-height: 32px;
+			--monitor-bar-gap: 2px;
+		}
+
+		.site-expanded-content__monitor-legend {
+			gap: 8px 16px;
 		}
 	}
 }


### PR DESCRIPTION
## What & why

The Monitor tab of the A4A site preview pane (Sites → click a site → **Monitor**) renders a single `MonitorActivity` card. That component is **shared with the Jetpack Cloud agency dashboard**, where it's a compact card in a four-card grid, and its styling was written for that narrow context. In the much wider preview pane it reads badly: a row of near-empty boxes with `20d ago` / `Today` beneath and nothing else — no uptime figure, no downtime count, no current up/down status. The data to answer all of that is already in the response the card fetches; it was just never surfaced.

This PR adds an opt-in `showSummary` variant to the card and turns it on **for the A4A Monitor tab only**:

- A `Last 20 days` range label, a summary row (uptime % · downtime events · total downtime), a status pill for the site's current up/down state, and a colour legend.
- The activity bar becomes full-height solid blocks (green up, red downtime, gray not-monitored) instead of the thin outlined strip.
- The day-summary maths and downtime formatter move into `monitor-activity-summary.ts`, reused by `useGetMonitorDowntimeText` so the tooltip and the new stat can't drift apart.

The summary figures are computed from the uptime endpoint's per-day data (uptime = monitored minus downtime minutes; events = days with `status: down`; total = summed `downtime_in_minutes`). Uptime/total are shown only when every down day reported a duration, otherwise omitted rather than understated.

**For reviewers:** this is shared Jetpack Cloud code. The new presentation is behind a `showSummary` prop defaulting to `false`, with every new style scoped to a variant-only class, so the Jetpack Cloud dashboard card renders exactly as before (verified by construction and the existing test suite; not re-checked visually in a browser).

### Screenshots

**Before**

<img width="900" alt="Monitor tab before: a thin row of mostly-empty boxes" src="https://github.com/user-attachments/assets/2630a0c9-60a4-425f-9429-bc88963a1378"/>

**After** — 20 days of history with one 38-minute outage

<img width="900" alt="Monitor tab after, with summary stats, status pill, solid status bar and legend" src="https://github.com/user-attachments/assets/d4b520a8-f753-4324-bd35-9aa8641269ed"/>

**After** — a site with only one day of monitoring history

<img width="900" alt="Monitor tab after, for a site with a single day of monitoring history" src="https://github.com/user-attachments/assets/4b5ef446-80ca-4382-b7f6-9fde130c281f"/>

**After** — card constrained to 380px, stats row and legend wrapping

<img width="900" alt="Monitor tab after, card constrained to 380px, showing the stats row and legend wrapping" src="https://github.com/user-attachments/assets/683707cb-137c-4010-b88e-97056daa995c"/>

## Testing Instructions

Prerequisites: an A4A account with at least one Monitor-enabled site, and a local A4A dev server (`yarn start-a8c-for-agencies`, at `http://agencies.localhost:3000`).

1. Open `http://agencies.localhost:3000/sites`, click a site whose Monitor toggle is on (click the row rather than pasting the tab URL — a cold deep link bounces through `/landing`), and open the **Monitor** tab.
2. Verify the header shows `Monitor activity` with `Last 20 days` on the right, and a summary row of uptime % · downtime events · total downtime, with a `Site is up`/`Site is down` pill matching the sites-list status.
3. Verify the bar is full-height solid blocks (green up, red downtime, gray pre-monitoring), still labelled `20d ago` / `Today`, and hovering a block still shows the date + uptime/downtime tooltip.
4. Verify the legend reads `Up`, `Downtime`, `Not monitored` with matching swatches, and that narrowing the window wraps the stats row and legend rather than overflowing.
5. On a site with Monitor **off**, verify the empty state is unchanged and still clickable.
6. **Jetpack Cloud unaffected:** expand a site row in the Jetpack Cloud agency dashboard and confirm its `Monitor activity` card is unchanged (short strip, thin downtime marker, no summary/pill/legend).

Most test sites have no recorded downtime. To exercise the red block and singular label, temporarily stub the `days` assignment in `MonitorDataContent` (`client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx`) to mark a day `down` with `downtime_in_minutes: 38`; the card should then read `99.8%`, `1 Downtime event`, `38m`. Revert afterwards.

## Notes

- **No tests added** — presentational change to UI slated for replacement; the existing `monitor-activity` suite (22 tests) passes unchanged. `yarn typecheck-client`, `eslint`, `stylelint` clean on touched files.
- **New strings** (for String Freeze): `Last %(days)d days`, `Uptime`, `Downtime event`/`Downtime events`, `Total downtime`, `Site is up`, `Site is down`, `Up`, `Downtime`, `Not monitored`.
- Colours use `--studio-*` (matching the surrounding Jetpack Cloud stylesheet), so this variant is not dark-mode aware. Status dot and legend swatches are `aria-hidden`, so colour is never the sole carrier of meaning.
