### PR TITLE
A4A Sites: Halve the preview pane tab gap and clear the Activity background

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -175,6 +175,11 @@
 
 	@media ( min-width: $break-large ) {
 		&.sites-dashboard__layout:not( .preview-hidden ) {
+			// The error preview sets its own content padding.
+			.hosting-dashboard-item-view:not( .site-error-preview ) .hosting-dashboard-item-view__content {
+				padding-block-start: 24px;
+			}
+
 			.sites-overview {
 				padding: 0;
 
@@ -310,16 +315,6 @@
 	}
 
 	&.sites-dashboard__layout {
-		// The shared item view leaves 48px between the tab strip and the content.
-		// Halve it here only — the rule is shared with the Dotcom sites and domain panes.
-		.hosting-dashboard-item-view:not( .site-error-preview ) {
-			@include break-large {
-				.hosting-dashboard-item-view__content {
-					padding-block-start: 24px;
-				}
-			}
-		}
-
 		.backup__page > .admin-ui-navigable-region,
 		.scan > .admin-ui-navigable-region,
 		.scan-new > .admin-ui-navigable-region,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -310,9 +310,20 @@
 	}
 
 	&.sites-dashboard__layout {
+		// The shared item view leaves 48px between the tab strip and the content.
+		// Halve it here only — the rule is shared with the Dotcom sites and domain panes.
+		.hosting-dashboard-item-view:not( .site-error-preview ) {
+			@include break-large {
+				.hosting-dashboard-item-view__content {
+					padding-block-start: 24px;
+				}
+			}
+		}
+
 		.backup__page > .admin-ui-navigable-region,
 		.scan > .admin-ui-navigable-region,
-		.scan-new > .admin-ui-navigable-region {
+		.scan-new > .admin-ui-navigable-region,
+		.activity-log-v2 > .admin-ui-navigable-region {
 			background-color: transparent;
 		}
 


### PR DESCRIPTION
## Proposed Changes

Two presentation-only fixes to the A4A Sites preview pane — the panel that opens when you click a site in Automattic for Agencies → Sites, with the Backup / Scan / Monitor / Activity tab strip. Both land in `client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss`.

**1. Halve the gap between the tab strip and the tab content (48px → 24px).**

**2. Remove the gray panel behind the Activity tab's content.**

## Why are these changes being made?

### The tab gap

The pane is the shared `ItemView` from `client/layout/hosting-dashboard/item-view/`; its body (`.hosting-dashboard-item-view__content`) sets `padding: 48px 24px`. That 48px is the entire gap between the nav and the first card — it reads as a hole and pushes content below the fold on shorter viewports.

The fix overrides only `padding-block-start` to 24px, folded into the A4A stylesheet's existing `@media (min-width: $break-large) { &.sites-dashboard__layout:not( .preview-hidden ) }` block rather than added as a new rule. `:not( .site-error-preview )` leaves the tab-less error variant on its own padding, and keeping it above `$break-large` leaves the narrow layout's existing `10px 10px 88px` untouched.

**On blast radius:** `.sites-dashboard__layout` is *not* A4A-only — the Dotcom Sites dashboard and the domain overview pane apply it too. What keeps this override off those screens is that this stylesheet is imported only by the A4A Sites section and CSS is extracted per chunk, so it ships in the A4A chunk and never loads on wordpress.com. The whole file already relies on this (it scopes `.sites-overview` width, item-view radius, etc. the same way). The shared `item-view/**` files are untouched. A4A Referrals and Reports use `ItemView` but never apply `.sites-dashboard__layout`, so they can't match regardless.

### The Activity background

Backup, Scan, and Activity wrap their content in `@wordpress/admin-ui`'s `Page`, which paints `--wpds-color-bg-surface-neutral` onto `.admin-ui-navigable-region`. Inside the white preview pane that shows as a stray off-white panel. #112861 already reset this for `.backup__page`, `.scan`, and `.scan-new`; Activity (`.activity-log-v2`) was simply missing from that list. This adds it as one more selector on the existing transparent-background rule.

## Testing Instructions

Prerequisites: a local A4A dev server (`yarn start-a8c-for-agencies`, `http://agencies.localhost:3000`) and an agency account with a connected site.

1. Open `http://agencies.localhost:3000/sites` and click a site row to open the preview pane.
2. On each tab (Backup, Scan, Monitor, Activity, and Details if the flag is on), verify the gap between the tab strip and the first card is 24px, not 48px.
3. On **Activity**, verify the content sits on the pane's white background with no off-white panel — `.activity-log-v2 > .admin-ui-navigable-region` should compute `background-color: rgba(0, 0, 0, 0)`.
4. Narrow below 960px and verify the pane keeps its `10px 10px 88px` content padding (this change must not touch the narrow layout).
5. Confirm nothing else moved: open Calypso's Sites dashboard and a domain from `/domains/manage` — both use the same `ItemView` and should still show 48px.
6. In A4A, open a site in a connection-error state (tab-less pane) and confirm its padding is unchanged.

## Before / after

**Backup**

<img width="1568" height="702" alt="before-backup" src="https://github.com/user-attachments/assets/e2997eb3-c2bb-4fcb-9887-c4f19eec26a7"/>
<img width="1568" height="702" alt="after-backup" src="https://github.com/user-attachments/assets/adef1f86-0c35-4206-ad22-e0e912174e6b"/>

**Scan**

<img width="1568" height="702" alt="before-scan" src="https://github.com/user-attachments/assets/4a218a0f-23b5-4ce5-994f-de840d633c34"/>
<img width="1568" height="702" alt="after-scan" src="https://github.com/user-attachments/assets/74ac4d21-2a43-4f69-b873-02b9242869f0"/>

**Monitor**

<img width="1568" height="702" alt="before-monitor" src="https://github.com/user-attachments/assets/83645bd0-07fd-4d24-99c7-9eec60af68aa"/>
<img width="1568" height="702" alt="after-monitor" src="https://github.com/user-attachments/assets/408db1bc-4b2d-4a0b-bdf6-d56be74c92d1"/>

**Activity**

<img width="1568" height="702" alt="before-activity" src="https://github.com/user-attachments/assets/f35ab421-3310-4da6-9e10-86d06ddd501b"/>
<img width="1568" height="702" alt="after-activity" src="https://github.com/user-attachments/assets/26dbb394-94ce-40c0-97cb-4ed47d34eef8"/>

**Activity background, zoomed on the panel's right edge** — the off-white band is the bug; gone in the second image.

<img width="346" height="500" alt="before-activity-background-zoom" src="https://github.com/user-attachments/assets/1a33e5f1-c0a4-4f0f-8d5a-7ea5d2e66bdf"/>
<img width="346" height="500" alt="after-activity-background-zoom" src="https://github.com/user-attachments/assets/1d224ab0-199a-4d56-ad8d-cd8ec636844c"/>

## Notes

- **No tests** — declarative SCSS with no branch or computed value; verified with measured computed styles in the browser.
- The `a4a/site-details-pane` flag adds a Details tab; the spacing applies to it too, as intended.
