### PR TITLE
Image Studio: Clarify MIME type synchronization guidance

### DIFF
--- a/packages/image-studio/src/types/index.ts
+++ b/packages/image-studio/src/types/index.ts
@@ -59,7 +59,7 @@ export enum MetadataField {
 
 /**
  * Supported image MIME types for Image Studio.
- * Keep in sync with the list in https://github.a8c.com/Automattic/wpcom/blob/14f1b110a11250b6a1834a31376c9a9f68ff1b0a/wp-content/lib/ai/tools/big-sky/images/class.image-utils.php#L783
+ * Keep in sync with the supported MIME types in the Big Sky backend image utilities.
  */
 export const IMAGE_STUDIO_SUPPORTED_MIME_TYPES = [
 	'image/jpeg',


### PR DESCRIPTION
## Proposed Changes

- Replace a repository-specific source link in the Image Studio MIME-type comment with contributor-friendly wording.
- Keep the guidance that the client list must stay synchronized with the Big Sky backend image utilities.

## Why are these changes being made?

The previous comment pointed to a source location that is not useful to contributors working in this public repository. The replacement keeps the relevant maintenance context in the code without relying on that location.

## Testing Instructions

No manual product testing is practical because this is a comment-only change with no runtime behavior.

Validated with:

- `yarn workspace @automattic/image-studio typecheck`
- ESLint against `packages/image-studio/src/types/index.ts`
- `git diff --check`
- A package search confirming no restricted source-location links remain
- Clean Claude review (`NO_FEEDBACK`)

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents, interfaces, and assistive technologies (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
