### PR TITLE
Convert purchases product-link and purchases-site header to TS

### DIFF
--- a/client/me/purchases/product-link/index.tsx
+++ b/client/me/purchases/product-link/index.tsx
@@ -6,15 +6,23 @@ import {
 	isThemePurchase,
 	isTitanMail,
 } from '@automattic/calypso-products';
+import { type SiteDetails } from '@automattic/data-stores';
 import i18n from 'i18n-calypso';
-import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
 import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
 import { getThemeDetailsUrl } from 'calypso/state/themes/selectors';
+import type { Purchase } from 'calypso/lib/purchases/types';
+import type { IAppState } from 'calypso/state/types';
 
-const ProductLink = ( { productUrl, purchase, selectedSite } ) => {
+interface ProductLinkProps {
+	purchase: Purchase;
+	selectedSite?: SiteDetails | null | false;
+	productUrl?: string | null;
+}
+
+const ProductLink = ( { productUrl, purchase, selectedSite }: ProductLinkProps ) => {
 	let url;
 	let text;
 
@@ -31,7 +39,7 @@ const ProductLink = ( { productUrl, purchase, selectedSite } ) => {
 	}
 
 	if ( isDomainProduct( purchase ) || isSiteRedirect( purchase ) ) {
-		url = domainManagementEdit( selectedSite.slug, purchase.meta );
+		url = domainManagementEdit( selectedSite.slug, purchase.meta as string );
 		text = i18n.translate( 'Domain Settings' );
 	}
 
@@ -56,16 +64,11 @@ const ProductLink = ( { productUrl, purchase, selectedSite } ) => {
 	return <span />;
 };
 
-ProductLink.propTypes = {
-	purchase: PropTypes.object.isRequired,
-	selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
-};
-
-export default connect( ( state, { purchase } ) => {
+export default connect( ( state: IAppState, { purchase }: { purchase: Purchase } ) => {
 	if ( isThemePurchase( purchase ) ) {
 		return {
 			// No <QueryTheme /> component needed, since getThemeDetailsUrl() only needs the themeId which we pass here.
-			productUrl: getThemeDetailsUrl( state, purchase.meta, purchase.siteId ),
+			productUrl: getThemeDetailsUrl( state, purchase.meta as string, purchase.siteId ),
 		};
 	}
 	return {};

--- a/client/me/purchases/purchases-site/header.tsx
+++ b/client/me/purchases/purchases-site/header.tsx
@@ -1,22 +1,30 @@
 import { CompactCard, Gridicon } from '@automattic/components';
-import PropTypes from 'prop-types';
+import { type SiteDetails } from '@automattic/data-stores';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import Site from 'calypso/blocks/site';
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
 import QuerySites from 'calypso/components/data/query-sites';
 import { getSite } from 'calypso/state/sites/selectors';
+import type { Purchase } from 'calypso/lib/purchases/types';
+import type { IAppState } from 'calypso/state/types';
 
 import './header.scss';
 
-class PurchaseSiteHeader extends Component {
-	static propTypes = {
-		isPlaceholder: PropTypes.bool,
-		siteId: PropTypes.number,
-		name: PropTypes.string,
-		purchase: PropTypes.object,
-	};
+interface PurchaseSiteHeaderProps {
+	isPlaceholder?: boolean;
+	siteId?: number;
+	name?: string;
+	purchase?: Purchase;
+}
 
+interface PurchaseSiteHeaderConnectedProps {
+	site?: SiteDetails | null;
+}
+
+class PurchaseSiteHeader extends Component<
+	PurchaseSiteHeaderProps & PurchaseSiteHeaderConnectedProps
+> {
 	// Disconnected sites can't render the `Site` component, but there can be
 	// purchases from disconnected sites. Here we spoof the Site header.
 	renderFauxSite() {
@@ -66,6 +74,6 @@ class PurchaseSiteHeader extends Component {
 	}
 }
 
-export default connect( ( state, { siteId } ) => ( {
+export default connect( ( state: IAppState, { siteId }: PurchaseSiteHeaderProps ) => ( {
 	site: getSite( state, siteId ),
 } ) )( PurchaseSiteHeader );


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-2256/

## Proposed changes

Converts two classic purchases presentational components from JSX to TypeScript, typing their props and Redux `connect` selectors against the shared `Purchase` and `SiteDetails` types. No behavior changes.

* Convert `client/me/purchases/product-link/index.jsx` → `index.tsx`; replace `PropTypes` with a `ProductLinkProps` interface and type the `mapStateToProps` with `IAppState`.
* Convert `client/me/purchases/purchases-site/header.jsx` → `header.tsx`; convert the class component's `static propTypes` into typed props interfaces and type its `getSite` selector.

## Why are these changes being made?

Part of the ongoing effort to remove the purchases assembler and read the raw purchase object directly (SHILL-2256). Typing these consumers of the `Purchase` shape ahead of time makes the eventual field-shape migration safe and mechanical, since the compiler will flag any mismatched field access. These two components were still untyped JSX, so converting them closes a gap and matches the surrounding TypeScript in the purchases directory.

## Testing instructions

TC:
```
yarn typecheck-client
```

Manual testing:
* Go to Me → Purchases and open a purchase detail page.
* Confirm the settings link renders correctly per product type (Plan Features / Domain Settings / Email Settings / Theme Details).
* Confirm the site header renders normally, including the faux-site header for disconnected sites and no header for holding-site purchases.
