### PR TITLE
Dashboard: show both plan and storage upgrade CTAs for Jetpack storage products

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -93,7 +93,7 @@ import {
 	isDomainTransfer,
 	isDotcomPlan,
 	getRenewalUrlFromPurchase,
-	isJetpackT1SecurityPlan,
+	isStorageUpgradeEligible,
 	isWpcomFlexSubscription,
 	isAkismetFreeProduct,
 	isExpiredAndInGracePeriod,
@@ -109,6 +109,7 @@ import {
 import {
 	getChangedPlanRedirectUrl,
 	getSitePurchaseUpgradeUrl,
+	getSitePurchaseStorageUpgradeUrl,
 	getUpgradedPurchaseRedirectUrl,
 } from '../../../utils/site-url';
 import BillingFlexUsageCard from '../../billing-flex-usage';
@@ -140,10 +141,6 @@ function renewPurchase( purchase: Purchase ): void {
 }
 
 function getExpiredNewPlanUrl( purchase: Purchase ): string {
-	if ( purchase.is_jetpack_backup_t1 || isJetpackT1SecurityPlan( purchase ) ) {
-		return wpcomLink( `/plans/storage/${ purchase.site_slug }` );
-	}
-
 	if ( purchase.is_jetpack_plan_or_product ) {
 		return wpcomLink( `/plans/${ purchase.site_slug }` );
 	}
@@ -234,6 +231,7 @@ function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
 	const isOwner = String( user.ID ) === String( purchase.user_id );
 	const canBeRenewed = purchase.can_explicit_renew && isOwner;
 	const upgradeUrl = getSitePurchaseUpgradeUrl( purchase, getUpgradedPurchaseRedirectUrl() );
+	const storageUpgradeUrl = getSitePurchaseStorageUpgradeUrl( purchase );
 	const { recordTracksEvent } = useAnalytics();
 	const menuItems = [
 		canUpgradePurchase( purchase ) && upgradeUrl && isOwner && (
@@ -246,9 +244,25 @@ function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
 					upgradePurchase( upgradeUrl );
 				} }
 			>
-				{ _x( 'Upgrade', 'Change to a plan with more features.' ) }
+				{ _x( 'Upgrade plan', 'Change to a plan with more features.' ) }
 			</MenuItem>
 		),
+		isStorageUpgradeEligible( purchase ) &&
+			storageUpgradeUrl &&
+			isOwner &&
+			! isExpiredOrRemoved( purchase ) && (
+				<MenuItem
+					onClick={ () => {
+						recordTracksEvent( 'calypso_purchases_upgrade_storage', {
+							status: isExpiredOrRemoved( purchase ) ? 'expired' : 'active',
+							plan: purchase.product_name,
+						} );
+						upgradePurchase( storageUpgradeUrl );
+					} }
+				>
+					{ _x( 'Upgrade storage', 'Buy more storage space for the subscription.' ) }
+				</MenuItem>
+			),
 		canBeRenewed && (
 			<MenuItem
 				onClick={ () => {
@@ -462,7 +476,43 @@ function UpgradeActionButton( { purchase }: { purchase: Purchase } ) {
 						upgradePurchase( upgradeUrl );
 					} }
 				>
-					{ _x( 'Upgrade', 'Change to a plan with more features.' ) }
+					{ _x( 'Upgrade plan', 'Change to a plan with more features.' ) }
+				</Button>
+			}
+		/>
+	);
+}
+
+export function StorageUpgradeActionButton( { purchase }: { purchase: Purchase } ) {
+	const { user } = useAuth();
+	const { recordTracksEvent } = useAnalytics();
+	if ( String( user.ID ) !== String( purchase.user_id ) ) {
+		return null;
+	}
+	if ( ! isStorageUpgradeEligible( purchase ) || isExpiredOrRemoved( purchase ) ) {
+		return null;
+	}
+	const storageUpgradeUrl = getSitePurchaseStorageUpgradeUrl( purchase );
+	if ( ! storageUpgradeUrl ) {
+		return null;
+	}
+	return (
+		<ActionList.ActionItem
+			title={ __( 'Upgrade storage' ) }
+			description={ __( 'Get more storage space.' ) }
+			actions={
+				<Button
+					variant="secondary"
+					size="compact"
+					onClick={ () => {
+						recordTracksEvent( 'calypso_purchases_upgrade_storage', {
+							status: isExpiredOrRemoved( purchase ) ? 'expired' : 'active',
+							plan: purchase.product_name,
+						} );
+						upgradePurchase( storageUpgradeUrl );
+					} }
+				>
+					{ _x( 'Upgrade storage', 'Buy more storage space for the subscription.' ) }
 				</Button>
 			}
 		/>
@@ -677,6 +727,7 @@ function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 				<ReinstallButton purchase={ purchase } />
 				<JetpackCRMDownloadsButton purchase={ purchase } />
 				<UpgradeActionButton purchase={ purchase } />
+				<StorageUpgradeActionButton purchase={ purchase } />
 				{ ! isExpiredOrRemoved( purchase ) && isEmailPlanManagementEnabled( purchase ) && (
 					<AddMailboxesActionItem purchase={ purchase } />
 				) }
@@ -1516,7 +1567,7 @@ export default function PurchaseSettings() {
 								<HStack justify="space-between">
 									{ shouldShowHeaderUpgradeAction && upgradeUrl && (
 										<Button __next40pxDefaultSize variant="primary" href={ upgradeUrl }>
-											{ _x( 'Upgrade', 'Change to a plan with more features.' ) }
+											{ _x( 'Upgrade plan', 'Change to a plan with more features.' ) }
 										</Button>
 									) }
 									{ /* Email plans surface every action in the list below, so the

--- a/client/dashboard/me/billing-purchases/purchase-settings/test/storage-upgrade-action-button.test.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/test/storage-upgrade-action-button.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { JetpackPlans, type Purchase } from '@automattic/api-core';
+import { screen } from '@testing-library/react';
+import { render } from '../../../../test-utils';
+import { StorageUpgradeActionButton } from '../index';
+
+// The rendering wrapper's default user has ID 1, so a purchase owned by user 1
+// belongs to the current user.
+function makePurchase( overrides: Partial< Purchase > = {} ): Purchase {
+	return {
+		ID: 1,
+		user_id: 1,
+		product_name: 'Jetpack Backup',
+		product_slug: 'jetpack_backup_t1_yearly',
+		site_slug: 'example.com',
+		is_jetpack_backup_t1: true,
+		is_jetpack_plan_or_product: true,
+		subscription_status: 'active',
+		expiry_status: 'auto-renewing',
+		...overrides,
+	} as Purchase;
+}
+
+describe( '<StorageUpgradeActionButton />', () => {
+	test( 'renders the storage upgrade action for an owned Backup T1 product', () => {
+		render( <StorageUpgradeActionButton purchase={ makePurchase() } /> );
+		expect( screen.getByRole( 'button', { name: 'Upgrade storage' } ) ).toBeVisible();
+	} );
+
+	test( 'renders the storage upgrade action for a Security T1 plan', () => {
+		render(
+			<StorageUpgradeActionButton
+				purchase={ makePurchase( {
+					product_slug: JetpackPlans.PLAN_JETPACK_SECURITY_T1_YEARLY,
+					is_jetpack_backup_t1: false,
+				} ) }
+			/>
+		);
+		expect( screen.getByRole( 'button', { name: 'Upgrade storage' } ) ).toBeVisible();
+	} );
+
+	test( 'renders nothing when the current user does not own the purchase', () => {
+		const { container } = render(
+			<StorageUpgradeActionButton purchase={ makePurchase( { user_id: 2 } ) } />
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'renders nothing for a product that is not storage-eligible', () => {
+		const { container } = render(
+			<StorageUpgradeActionButton
+				purchase={ makePurchase( {
+					product_slug: 'business-bundle',
+					is_jetpack_backup_t1: false,
+				} ) }
+			/>
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'renders nothing for an expired purchase', () => {
+		const { container } = render(
+			<StorageUpgradeActionButton
+				purchase={ makePurchase( { expiry_status: 'expired', subscription_status: 'active' } ) }
+			/>
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -576,6 +576,10 @@ export function isJetpackT1SecurityPlan( purchase: Purchase ): boolean {
 	return securityT1Slugs.includes( purchase.product_slug as ( typeof securityT1Slugs )[ number ] );
 }
 
+export function isStorageUpgradeEligible( purchase: Purchase ): boolean {
+	return purchase.is_jetpack_backup_t1 || isJetpackT1SecurityPlan( purchase );
+}
+
 export function isDotcomPlan( purchase: Purchase ): boolean {
 	return purchase.is_plan && ! purchase.is_jetpack_plan_or_product;
 }

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -5,7 +5,7 @@ import { getCurrentDashboard } from '../app/routing';
 import { isSitePlanTrial, isSitePlanWooHosted } from '../sites/plans';
 import { isDashboardBackport } from './is-dashboard-backport';
 import { dashboardLink, redirectToDashboardLink, wpcomLink } from './link';
-import { isAkismetProduct, isJetpackT1SecurityPlan, isTitanMail } from './purchase';
+import { isAkismetProduct, isStorageUpgradeEligible, isTitanMail } from './purchase';
 import { isSelfHostedJetpackConnected } from './site-types';
 import type { Purchase, Site } from '@automattic/api-core';
 
@@ -144,10 +144,6 @@ export function getSitePurchaseUpgradeUrl( purchase: Purchase, redirectTo?: stri
 		} );
 	}
 
-	if ( purchase.is_jetpack_backup_t1 || isJetpackT1SecurityPlan( purchase ) ) {
-		return wpcomLink( `/plans/storage/${ purchase.site_slug }` );
-	}
-
 	if ( purchase.is_jetpack_plan_or_product ) {
 		return wpcomLink( `/plans/${ purchase.site_slug }` );
 	}
@@ -158,6 +154,13 @@ export function getSitePurchaseUpgradeUrl( purchase: Purchase, redirectTo?: stri
 		isWooHosted: purchase.is_woo_hosted_product,
 		redirectTo: redirectTo ?? redirectToDashboardLink(),
 	} );
+}
+
+export function getSitePurchaseStorageUpgradeUrl( purchase: Purchase ): string | undefined {
+	if ( ! isStorageUpgradeEligible( purchase ) ) {
+		return undefined;
+	}
+	return wpcomLink( `/plans/storage/${ purchase.site_slug }` );
 }
 
 function buildSitePlanUpgradeUrl( {

--- a/client/dashboard/utils/test/site-url.ts
+++ b/client/dashboard/utils/test/site-url.ts
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { JetpackPlans, type Purchase } from '@automattic/api-core';
+import { getSitePurchaseStorageUpgradeUrl, getSitePurchaseUpgradeUrl } from '../site-url';
+
+function makePurchase( overrides: Partial< Purchase > = {} ): Purchase {
+	return {
+		product_slug: 'jetpack_backup_t1_yearly',
+		site_slug: 'example.com',
+		is_jetpack_backup_t1: true,
+		is_jetpack_plan_or_product: true,
+		...overrides,
+	} as Purchase;
+}
+
+describe( 'getSitePurchaseStorageUpgradeUrl', () => {
+	test( 'links a Backup T1 product to the storage upgrade page', () => {
+		expect( getSitePurchaseStorageUpgradeUrl( makePurchase() ) ).toContain(
+			'/plans/storage/example.com'
+		);
+	} );
+
+	test( 'links a Security T1 plan to the storage upgrade page', () => {
+		expect(
+			getSitePurchaseStorageUpgradeUrl(
+				makePurchase( {
+					product_slug: JetpackPlans.PLAN_JETPACK_SECURITY_T1_YEARLY,
+					is_jetpack_backup_t1: false,
+				} )
+			)
+		).toContain( '/plans/storage/example.com' );
+	} );
+
+	test( 'returns undefined for a product that is not storage-eligible', () => {
+		expect(
+			getSitePurchaseStorageUpgradeUrl(
+				makePurchase( { product_slug: 'business-bundle', is_jetpack_backup_t1: false } )
+			)
+		).toBeUndefined();
+	} );
+} );
+
+describe( 'getSitePurchaseUpgradeUrl', () => {
+	test( 'routes a storage-eligible product to the plan upgrade page, not the storage page', () => {
+		const url = getSitePurchaseUpgradeUrl( makePurchase() );
+		expect( url ).not.toContain( '/plans/storage' );
+		expect( url ).toContain( '/plans/example.com' );
+	} );
+} );


### PR DESCRIPTION
Fixes CHE-517

## Proposed Changes

Mirrors the Calypso purchase management change (#112935) on the Dashboard purchase page. For Jetpack Backup T1 products and Security T1 plans, the single "Upgrade" action pointed at the storage upgrade page (`/plans/storage`), leaving no path to a full plan upgrade.

| Before | After |
| ----------- | ----------- |
| <img width="1758" height="508" alt="CleanShot 2026-07-24 at 12 00 39@2x" src="https://github.com/user-attachments/assets/2ac22021-2026-4ff0-9ffa-9a6523ddc6c2" /> | <img width="1732" height="506" alt="CleanShot 2026-07-24 at 12 00 51@2x" src="https://github.com/user-attachments/assets/636ba523-18c6-4e39-a213-5e3492aeeeb3" /> |
| <img width="1398" height="538" alt="CleanShot 2026-07-24 at 12 01 10@2x" src="https://github.com/user-attachments/assets/53f2f5b8-2503-46e8-95e0-55ed5d86039f" /> | <img width="1404" height="702" alt="CleanShot 2026-07-24 at 12 01 01@2x" src="https://github.com/user-attachments/assets/90504afd-f541-4d10-a5e3-51e43ab829eb" /> |

* Stop routing storage-eligible products to `/plans/storage` in `getSitePurchaseUpgradeUrl` and `getExpiredNewPlanUrl`; they now resolve to the plan upgrade page (`/plans/<site>`).
* Add `isStorageUpgradeEligible()` (utils/purchase) and `getSitePurchaseStorageUpgradeUrl()` (utils/site-url) helpers.
* Rename the plan-upgrade action label from "Upgrade" to "Upgrade plan" in the header button, the ⋮ quick-actions menu, and the options list.
* Add an "Upgrade storage" action for storage-eligible purchases in the ⋮ quick-actions menu (top) and the options list (bottom).
* Add tests for the storage-eligibility URL helpers and the `StorageUpgradeActionButton`.

## Why are these changes being made?

Storage-eligible Jetpack products (e.g. Jetpack Security with a 10GB storage tier) previously only surfaced a storage-upgrade CTA on the Dashboard, blocking customers from moving up to a higher plan such as Jetpack Complete (CHE-517). Showing both the plan-upgrade and storage-upgrade CTAs gives a path to either action, matching the classic purchases page.

Per the design decision, the header keeps a single primary "Upgrade plan" button; the "Upgrade storage" action lives in the ⋮ quick-actions menu at the top and as its own item in the options list at the bottom.

## Testing Instructions

TC:
```
yarn test-client client/dashboard/utils/test/site-url.ts client/dashboard/me/billing-purchases/purchase-settings/test/storage-upgrade-action-button.test.tsx
```

Manual testing:
* In the Dashboard, open a purchase for a Jetpack Security T1 plan or a Backup T1 product owned by the current user (`/me/billing/purchases/<id>`).
* Confirm the header shows a single "Upgrade plan" primary button, and the ⋮ Quick actions menu lists "Upgrade plan" and "Upgrade storage".
* Confirm the options list at the bottom shows both an "Upgrade plan" and an "Upgrade storage" action.
* Confirm "Upgrade plan" links to `/plans/<site>` and "Upgrade storage" links to `/plans/storage/<site>`.
* Confirm non-storage products still show only the plan upgrade action.