### PR TITLE
Revert #95140 - Remove patch that's no longer needed

### DIFF
--- a/client/root.js
+++ b/client/root.js
@@ -18,7 +18,6 @@ import {
 } from 'calypso/state/sites/selectors';
 import { hasReadersAsLandingPage } from 'calypso/state/sites/selectors/has-reader-as-landing-page';
 import { hasSitesAsLandingPage } from 'calypso/state/sites/selectors/has-sites-as-landing-page';
-import { getSelectedSiteId } from './state/ui/selectors';
 
 /**
  * @param clientRouter Unused. We can't use the isomorphic router because we want to do redirects.
@@ -121,9 +120,9 @@ async function getLoggedInLandingPage( { dispatch, getState } ) {
 
 	// determine the primary site ID (it's a property of "current user" object) and then
 	// ensure that the primary site info is loaded into Redux before proceeding.
-	const primaryOrSelectedSiteId = getSelectedSiteId( getState() ) || getPrimarySiteId( getState() );
-	await dispatch( waitForSite( primaryOrSelectedSiteId ) );
-	const primarySiteSlug = getSiteSlug( getState(), primaryOrSelectedSiteId );
+	const primarySiteId = getPrimarySiteId( getState() );
+	await dispatch( waitForSite( primarySiteId ) );
+	const primarySiteSlug = getSiteSlug( getState(), primarySiteId );
 
 	if ( ! primarySiteSlug ) {
 		if ( getIsSubscriptionOnly( getState() ) ) {
@@ -134,20 +133,17 @@ async function getLoggedInLandingPage( { dispatch, getState } ) {
 		return getSitesLink( dashboardOptIn );
 	}
 
-	const isCustomerHomeEnabled = canCurrentUserUseCustomerHome(
-		getState(),
-		primaryOrSelectedSiteId
-	);
+	const isCustomerHomeEnabled = canCurrentUserUseCustomerHome( getState(), primarySiteId );
 
 	if ( isCustomerHomeEnabled ) {
-		if ( isAdminInterfaceWPAdmin( getState(), primaryOrSelectedSiteId ) ) {
+		if ( isAdminInterfaceWPAdmin( getState(), primarySiteId ) ) {
 			if ( [ 'development', 'wpcalypso' ].includes( config( 'env_id' ) ) ) {
 				// On Calypso Live and dev environments, don't redirect to wp-admin
 				// as it navigates the user away from the testing environment.
 				return getSitesLink( dashboardOptIn );
 			}
 			// This URL starts with 'https://' because it's the access to wp-admin.
-			return getSiteAdminUrl( getState(), primaryOrSelectedSiteId );
+			return getSiteAdminUrl( getState(), primarySiteId );
 		}
 		return `/home/${ primarySiteSlug }`;
 	}

--- a/client/test/root-section.ts
+++ b/client/test/root-section.ts
@@ -229,43 +229,14 @@ describe( 'Logged In Landing Page', () => {
 		await waitFor( () => expect( page.current ).toBe( '/reader' ) );
 	} );
 
-	test( 'user with a selected site goes to My Home for Default Style interface', async () => {
-		const state = {
-			currentUser: {
-				id: 1,
-				capabilities: { 1: { edit_posts: true }, 2: { edit_posts: true } },
-				user: { primary_blog: 1 },
-			},
-			ui: { selectedSiteId: 2 },
-			sites: {
-				items: {
-					1: {
-						ID: 1,
-						URL: 'https://test.wordpress.com',
-					},
-					2: {
-						ID: 2,
-						URL: 'https://selected.wordpress.com',
-						options: { wpcom_admin_interface: 'calypso' },
-					},
-				},
-			},
-		};
-		const { page } = initRouter( { state } );
-
-		page( '/' );
-
-		await waitFor( () => expect( page.current ).toBe( '/home/selected.wordpress.com' ) );
-	} );
-
-	test( 'user with a selected site goes to WP Admin Dashboard for Classic Style interface', async () => {
+	test( 'user with a primary site using the Classic interface goes to WP Admin Dashboard', async () => {
 		const state = {
 			currentUser: {
 				id: 1,
 				capabilities: { 1: { edit_posts: true } },
 				user: { primary_blog: 1 },
 			},
-			ui: { selectedSiteId: 1 },
+			ui: {},
 			sites: {
 				items: {
 					1: {


### PR DESCRIPTION
## Proposed Changes

- Revert the landing-page change from #95140 so getLoggedInLandingPage (client/root.js) resolves the root /
redirect from the primary site again, instead of getSelectedSiteId() || getPrimarySiteId().
- Remove the now-unused getSelectedSiteId import.
- Update client/test/root-section.ts: drop the "selected site → My Home" case (asserted the reverted behavior) and
repurpose its companion into a primary-site "Classic interface → wp-admin" case so that coverage is retained.

## Why are these changes being made?

#95140 changed the shared root-landing logic to prefer the currently selected site over the primary site. That function also decides where a logged-in user lands when they hit the Calypso root (/). Because ui.selectedSiteId is persisted (client/state/ui/reducer.js wraps the reducer in withSchemaValidation → withPersistence) and is set whenever any site is viewed, a stale selected site gets rehydrated on a cold load and wins over the user's primary site. The result is that visiting the root no longer reliably lands users on their primary site / configured landing page.

#95140 was a [Pri] Normal groundskeeping tweak for the 404 "Return Home" button (#94938); reverting it re-opens that minor issue but restores the correct default-landing behavior for everyone. The 404 nicety can't be preserved cleanly here anyway — the button is a static, server-rendered <a href="/"> with no site context — so it's left for a separate follow-up.

## Testing Instructions

- View a specific non-primary site (e.g. open /home/<some-non-primary-site>) so a selected site gets persisted to
state.
- Navigate to the Calypso root (/).
- Confirm you land on your account default — your primary site's My Home (or your configured Sites/Reader landing
page), not the last site you were viewing.
- Sanity-check the other landing paths still work: a "Sites" landing-page preference → /sites, a "Reader"
preference → /reader, and a primary site on the Classic interface → wp-admin.
- yarn test-client client/test/root-section.ts passes (10 cases).