### PR TITLE
Validate the editorUrl parameter before redirecting from site-generation

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/editor-url.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/editor-url.ts
@@ -1,0 +1,26 @@
+const ALLOWED_HOST_SUFFIXES = [ '.wordpress.com', '.wpcomstaging.com' ];
+
+export function getSafeEditorUrl( rawUrl: string | null ): string | null {
+	if ( ! rawUrl ) {
+		return null;
+	}
+
+	let parsed: URL;
+	try {
+		parsed = new URL( rawUrl, window.location.origin );
+	} catch {
+		return null;
+	}
+
+	if ( parsed.protocol !== 'https:' && parsed.protocol !== 'http:' ) {
+		return null;
+	}
+
+	const { hostname } = parsed;
+	const isAllowedHost =
+		hostname === window.location.hostname ||
+		hostname === 'wordpress.com' ||
+		ALLOWED_HOST_SUFFIXES.some( ( suffix ) => hostname.endsWith( suffix ) );
+
+	return isAllowedHost ? parsed.href : null;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/index.tsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
+import { getSafeEditorUrl } from './editor-url';
 import { useSiteGeneration } from './use-site-generation';
 import { SiteGenerationView } from './view';
 import type { Step as StepType } from '../../types';
@@ -9,8 +10,8 @@ import './style.scss';
 const SiteGeneration: StepType = function SiteGeneration() {
 	const translate = useTranslate();
 	const query = useMemo( () => new URLSearchParams( window.location.search ), [] );
-	const siteIdentifier = query.get( 'siteId' ) ?? query.get( 'siteSlug' );
-	const editorUrl = query.get( 'editorUrl' );
+	const siteIdentifier = query.get( 'siteId' ) || query.get( 'siteSlug' );
+	const editorUrl = getSafeEditorUrl( query.get( 'editorUrl' ) );
 	const steps = useMemo(
 		() => [
 			{ id: 'preparing', label: translate( 'Preparing your site' ) },

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/editor-url.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/editor-url.ts
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { getSafeEditorUrl } from '../editor-url';
+
+describe( 'getSafeEditorUrl', () => {
+	it( 'returns null for a missing value', () => {
+		expect( getSafeEditorUrl( null ) ).toBeNull();
+		expect( getSafeEditorUrl( '' ) ).toBeNull();
+	} );
+
+	it( 'resolves relative paths against the current origin', () => {
+		expect( getSafeEditorUrl( '/wp-admin/site-editor.php?spec_id=spec-1' ) ).toBe(
+			'https://example.com/wp-admin/site-editor.php?spec_id=spec-1'
+		);
+	} );
+
+	it( 'allows wordpress.com and its subdomains', () => {
+		expect( getSafeEditorUrl( 'https://wordpress.com/setup' ) ).toBe(
+			'https://wordpress.com/setup'
+		);
+		expect( getSafeEditorUrl( 'https://example.wordpress.com/wp-admin/site-editor.php' ) ).toBe(
+			'https://example.wordpress.com/wp-admin/site-editor.php'
+		);
+	} );
+
+	it( 'allows wpcomstaging.com subdomains', () => {
+		expect( getSafeEditorUrl( 'https://example.wpcomstaging.com/wp-admin/' ) ).toBe(
+			'https://example.wpcomstaging.com/wp-admin/'
+		);
+	} );
+
+	it( 'rejects javascript: and data: schemes', () => {
+		// eslint-disable-next-line no-script-url
+		expect( getSafeEditorUrl( 'javascript:alert(1)' ) ).toBeNull();
+		// eslint-disable-next-line no-script-url
+		expect( getSafeEditorUrl( 'javascript://wordpress.com/%0aalert(1)' ) ).toBeNull();
+		expect( getSafeEditorUrl( 'data:text/html,<script>alert(1)</script>' ) ).toBeNull();
+	} );
+
+	it( 'rejects hosts outside the allowlist', () => {
+		expect( getSafeEditorUrl( 'https://evil.example/phishing' ) ).toBeNull();
+		expect( getSafeEditorUrl( 'https://evilwordpress.com/' ) ).toBeNull();
+		expect( getSafeEditorUrl( 'https://wordpress.com.evil.example/' ) ).toBeNull();
+	} );
+} );


### PR DESCRIPTION
Part of BIGR-653

## Proposed Changes

- Add `getSafeEditorUrl` and run the site-generation step's `editorUrl` query parameter through it before the blog-sticker poller navigates to it.
- Make an empty `siteId` query parameter fall back to `siteSlug` when resolving the site identifier.

## Why are these changes being made?

- The Site Editor destination is server-provided in Site Spec but round-trips through the query string, so a crafted link could redirect users to an arbitrary host — or execute a `javascript:` URL on the current origin — once the ready sticker appears.
- The validator only accepts http(s) URLs whose host is the current origin, wordpress.com, or a wordpress.com/wpcomstaging.com subdomain; anything else renders the step's existing failed state.

## Testing Instructions

* Run:

```sh
yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/site-generation --runInBand
```

* Open the `site-generation` step with a valid `editorUrl` (e.g. an `example.wordpress.com` Site Editor URL) and confirm the waiting screen renders and `blog-stickers` polling starts.
* Open it with `editorUrl=https://evil.example/` or a `javascript:` value and confirm the failed state renders, no navigation happens, and no polling requests are sent.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
