### PR TITLE
Blueprints: blueprint-aware site-spec + apply confirmed spec

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import {
+	applyBlueprintSpec,
 	getBlueprintArchiveSiteIdentifier,
 	getSiteAdminUrl,
 	getSiteEditorUrl,
@@ -359,43 +360,73 @@ const SiteSpec: StepType = function SiteSpec() {
 	// the background (kicked off on mount below). On spec confirm we poll the
 	// canonical Atomic transfer endpoint, then the import status, and finally hand
 	// the user off to the Atomic Site Editor.
-	const handleBlueprintArchiveSpecConfirm = useCallback( async () => {
-		if ( isSubmittingRef.current ) {
-			return;
-		}
+	const handleBlueprintArchiveSpecConfirm = useCallback(
+		async ( specData: unknown ) => {
+			if ( isSubmittingRef.current ) {
+				return;
+			}
 
-		if ( ! blueprintArchiveSiteIdentifier ) {
-			// eslint-disable-next-line no-console
-			console.error( 'Failed to finish blueprint import: missing target site.' );
-			return;
-		}
+			if ( ! blueprintArchiveSiteIdentifier ) {
+				// eslint-disable-next-line no-console
+				console.error( 'Failed to finish blueprint import: missing target site.' );
+				return;
+			}
 
-		isSubmittingRef.current = true;
+			isSubmittingRef.current = true;
 
-		try {
-			logBlueprintArchiveEvent( 'spec_confirm_poll_start', {
-				site_identifier: blueprintArchiveSiteIdentifier,
-			} );
+			const specId =
+				specData && typeof specData === 'object' && 'session_id' in specData
+					? ( specData as { session_id?: string } ).session_id
+					: undefined;
 
-			await waitForAtomicTransferComplete( blueprintArchiveSiteIdentifier );
-			await waitForBlueprintImportComplete( blueprintArchiveSiteIdentifier );
-			const adminUrl = await getSiteAdminUrl( blueprintArchiveSiteIdentifier );
-			const siteEditorUrl = getSiteEditorUrl( adminUrl );
+			try {
+				logBlueprintArchiveEvent( 'spec_confirm_poll_start', {
+					site_identifier: blueprintArchiveSiteIdentifier,
+				} );
 
-			logBlueprintArchiveEvent( 'redirect_site_editor', {
-				site_identifier: blueprintArchiveSiteIdentifier,
-			} );
-			window.location.href = siteEditorUrl;
-		} catch ( error ) {
-			logBlueprintArchiveEvent( 'spec_confirm_error', {
-				site_identifier: blueprintArchiveSiteIdentifier,
-				error: error instanceof Error ? error.message : String( error ),
-			} );
-			// eslint-disable-next-line no-console
-			console.error( 'Failed to finish blueprint import:', error );
-			isSubmittingRef.current = false;
-		}
-	}, [ blueprintArchiveSiteIdentifier ] );
+				await waitForAtomicTransferComplete( blueprintArchiveSiteIdentifier );
+				await waitForBlueprintImportComplete( blueprintArchiveSiteIdentifier );
+
+				// Apply the confirmed spec on top of the imported blueprint site
+				// (site title/tagline + knowledge). Non-fatal: if it fails, still
+				// hand the user off to their site.
+				if ( specId ) {
+					try {
+						await applyBlueprintSpec(
+							blueprintArchiveSiteIdentifier,
+							specId,
+							blueprintArchiveSlug
+						);
+						logBlueprintArchiveEvent( 'apply_spec_done', {
+							site_identifier: blueprintArchiveSiteIdentifier,
+						} );
+					} catch ( applyError ) {
+						logBlueprintArchiveEvent( 'apply_spec_error', {
+							site_identifier: blueprintArchiveSiteIdentifier,
+							error: applyError instanceof Error ? applyError.message : String( applyError ),
+						} );
+					}
+				}
+
+				const adminUrl = await getSiteAdminUrl( blueprintArchiveSiteIdentifier );
+				const siteEditorUrl = getSiteEditorUrl( adminUrl );
+
+				logBlueprintArchiveEvent( 'redirect_site_editor', {
+					site_identifier: blueprintArchiveSiteIdentifier,
+				} );
+				window.location.href = siteEditorUrl;
+			} catch ( error ) {
+				logBlueprintArchiveEvent( 'spec_confirm_error', {
+					site_identifier: blueprintArchiveSiteIdentifier,
+					error: error instanceof Error ? error.message : String( error ),
+				} );
+				// eslint-disable-next-line no-console
+				console.error( 'Failed to finish blueprint import:', error );
+				isSubmittingRef.current = false;
+			}
+		},
+		[ blueprintArchiveSiteIdentifier, blueprintArchiveSlug ]
+	);
 
 	// Kick off the background transfer + blueprint-archive import as soon as the
 	// spec page mounts, so it runs while the user reviews the spec.

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -16,6 +16,7 @@ import {
 	startBlueprintArchiveImport,
 	waitForAtomicTransferComplete,
 	waitForBlueprintImportComplete,
+	waitForSiteEditorReady,
 } from 'calypso/landing/stepper/utils/blueprint-archive-import';
 import {
 	getBuildWowSiteIdentifier,
@@ -407,6 +408,13 @@ const SiteSpec: StepType = function SiteSpec() {
 						} );
 					}
 				}
+
+				// The import record can flip to FINISHED before the freshly
+				// transferred Atomic site can serve its template parts, which makes
+				// the editor's first load render the header block as an error until a
+				// manual reload. Wait until the header template part is queryable
+				// before redirecting (times out gracefully so we never strand).
+				await waitForSiteEditorReady( blueprintArchiveSiteIdentifier );
 
 				const adminUrl = await getSiteAdminUrl( blueprintArchiveSiteIdentifier );
 				const siteEditorUrl = getSiteEditorUrl( adminUrl );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -25,9 +25,9 @@ import {
 import { logToLogstash } from 'calypso/lib/logstash';
 import { useSiteSpec } from 'calypso/lib/site-spec';
 import {
+	getBlueprintSiteSpecConfig,
 	getBuildWowSiteSpecConfig,
 	getCiabSiteSpecConfig,
-	getDefaultSiteSpecConfig,
 	getEarlyProvisionSiteSpecConfig,
 	type SiteSpecConfig,
 } from 'calypso/lib/site-spec/utils';
@@ -456,7 +456,9 @@ const SiteSpec: StepType = function SiteSpec() {
 	} else if ( shouldImportBlueprint ) {
 		siteSpecStep = (
 			<SiteSpecContainer
-				siteSpecConfig={ getDefaultSiteSpecConfig() }
+				siteSpecConfig={ getBlueprintSiteSpecConfig( {
+					blueprintId: blueprintArchiveSlug,
+				} ) }
 				onSpecConfirm={ handleBlueprintArchiveSpecConfirm }
 			/>
 		);

--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -123,6 +123,26 @@ export async function startBlueprintArchiveImport(
 }
 
 /**
+ * Apply the confirmed site spec on top of the already-imported blueprint site:
+ * writes the user's site title/tagline synchronously, stamps blueprint
+ * provenance, and materializes the spec into the site knowledge store. Runs
+ * after the import completes and before the redirect. Non-destructive.
+ */
+export async function applyBlueprintSpec(
+	siteIdentifier: string,
+	specId: string,
+	blueprintSlug: string
+): Promise< unknown > {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ siteIdentifier }/big-sky/apply-blueprint-spec`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{ spec_id: specId, blueprint_id: blueprintSlug }
+	);
+}
+
+/**
  * Poll the site's import status until the backup import finishes.
  * Resolves on success; throws on a terminal failure or timeout.
  */

--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -186,6 +186,45 @@ export async function waitForBlueprintImportComplete(
 }
 
 /**
+ * Poll the site's template-parts REST endpoint until the theme's `header`
+ * template part is served, so we only redirect into the Site Editor once the
+ * freshly-transferred Atomic site can actually render it. Without this, the
+ * editor's first load can race the import (theme/template parts not yet
+ * queryable) and the header block renders as an error until a manual reload.
+ *
+ * Resolves on ready OR on timeout — a timeout must not block handing the user
+ * off to their site (a manual reload still recovers).
+ */
+export async function waitForSiteEditorReady(
+	siteIdentifier: string,
+	{ totalTimeoutSeconds = 60, pollIntervalMs = 3000 } = {}
+): Promise< void > {
+	const deadline = Date.now() + totalTimeoutSeconds * 1000;
+
+	while ( Date.now() < deadline ) {
+		try {
+			const parts = ( await wpcom.req.get( {
+				path: `/sites/${ siteIdentifier }/template-parts`,
+				apiNamespace: 'wp/v2',
+			} ) ) as Array< { slug?: string; area?: string } >;
+
+			if (
+				Array.isArray( parts ) &&
+				parts.some( ( part ) => part?.slug === 'header' || part?.area === 'header' )
+			) {
+				return;
+			}
+		} catch {
+			// Site not ready to serve template parts yet — keep polling.
+		}
+
+		await wait( pollIntervalMs );
+	}
+
+	// Timed out: redirect anyway rather than stranding the user.
+}
+
+/**
  * Poll the canonical Atomic transfer status endpoint until the site's transfer
  * to Atomic completes. Resolves on a complete state; throws on a terminal
  * failure or timeout. A missing transfer (404 before the backup_import job

--- a/client/lib/site-spec/utils.ts
+++ b/client/lib/site-spec/utils.ts
@@ -33,6 +33,9 @@ export interface SiteSpecConfig {
 	agentUrl?: string;
 	agentId?: string;
 	buildSiteUrl?: string;
+	// Blueprint identifier when building from a blueprint. Forwarded by the widget
+	// to the agent (metadata.blueprint_id) so it can run a blueprint-aware interview.
+	blueprintId?: string;
 	theme?: {
 		// Branding
 		brandIcon?: ReactElement | string | null; // ReactElement or image URL; null hides
@@ -187,6 +190,25 @@ export function getDefaultSiteSpecConfig(): SiteSpecConfig {
 				client: 'calypso',
 			} ),
 		},
+	};
+}
+
+/**
+ * SiteSpec configuration for a site being built from a blueprint. Extends the
+ * default config with the blueprint identifier so the widget forwards it to the
+ * agent (as metadata.blueprint_id), which then runs a blueprint-aware interview.
+ * @param {Object} params            Params.
+ * @param {string} params.blueprintId Blueprint identifier (numeric library id or slug).
+ * @returns {SiteSpecConfig} Configuration object for the blueprint flow.
+ */
+export function getBlueprintSiteSpecConfig( {
+	blueprintId,
+}: {
+	blueprintId?: string;
+} ): SiteSpecConfig {
+	return {
+		...getDefaultSiteSpecConfig(),
+		...( blueprintId ? { blueprintId } : {} ),
 	};
 }
 


### PR DESCRIPTION
Stacked on #112534 (the minimal theme → blueprint → stock site-spec → blueprint-site flow + the Automattician-only Theme Sheet CTA).

These are the **site-spec enhancements** on top of that minimal flow — optional, layered separately so the core flow can ship first:

1. **Pass the blueprint identifier into the widget config** — the site-spec step uses `getBlueprintSiteSpecConfig` instead of `getDefaultSiteSpecConfig`, forwarding `blueprint_id` so the agent runs a blueprint-aware interview.
2. **Apply the confirmed spec to the imported site** — on confirm, call `applyBlueprintSpec` (writes title/tagline to the Atomic site + materializes the spec into the knowledge store).
3. **Wait for Site Editor readiness before redirect** — poll template-parts so the editor's first load doesn't race the transfer.

Note: `config/_shared.json`'s `site_spec` dev-bundle pointer is intentionally **not** committed; it points at the sandbox dev widget and must move to the prod widget version before merge.