### PR TITLE
Checkout: mobile checkout redesign with sticky order experiment

### DIFF
--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.tsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.tsx
@@ -63,8 +63,8 @@ export class RegionAddressFieldsets extends Component<
 		const { getFieldProps, translate, shouldAutoFocusAddressField } = this.props;
 
 		return (
-			<div>
-				<div>
+			<div className="region-address-fieldsets">
+				<div className="region-address-fieldsets__street-address">
 					<Input
 						ref={ shouldAutoFocusAddressField ? this.inputRefCallback : noop }
 						label={ translate( 'Address' ) }

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -17,6 +17,7 @@ import {
 	useIsStepComplete,
 	CheckoutErrorBoundary,
 	CheckoutFormSubmit,
+	CheckoutPaymentMethods,
 	PaymentMethodStep,
 	FormStatus,
 	usePaymentMethod,
@@ -73,6 +74,7 @@ import { areVatDetailsSame } from 'calypso/me/purchases/vat-info/are-vat-details
 import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
 import { CheckoutOrderBanner } from 'calypso/my-sites/checkout/src/components/checkout-order-banner';
 import { useCheckoutUiRedesignExperiment } from 'calypso/my-sites/checkout/src/hooks/use-checkout-ui-redesign-experiment';
+import { useMobileCheckoutStickySummaryExperiment } from 'calypso/my-sites/checkout/src/hooks/use-mobile-checkout-sticky-summary-experiment';
 import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/src/hooks/use-valid-checkout-back-url';
 import { leaveCheckout } from 'calypso/my-sites/checkout/src/lib/leave-checkout';
 import {
@@ -111,8 +113,10 @@ import { EmptyCart, shouldShowEmptyCartPage } from './empty-cart';
 import { handleProgressStepSelect } from './handle-progress-step-select';
 import JetpackAkismetCheckoutSidebarPlanUpsell from './jetpack-akismet-checkout-sidebar-plan-upsell';
 import { LeaveCheckoutModal, useCheckoutLeaveModal } from './leave-checkout-modal';
+import { MobileCheckoutStickySummary } from './mobile-checkout-sticky-summary';
 import BeforeSubmitCheckoutHeader from './payment-method-step';
 import { PaymentMethodFilter } from './payment-methods-filter';
+import { getRefundWindowCopy } from './refund-policies';
 import SecondaryCartPromotions from './secondary-cart-promotions';
 import WPCheckoutOrderReview, { CouponFieldArea } from './wp-checkout-order-review';
 import {
@@ -194,13 +198,21 @@ function ConditionalContactDetailsMessage( {
 	contactDetailsType: ContactDetailsType;
 } ) {
 	const translate = useTranslate();
-	return contactDetailsType === 'domain' ? (
+	const { isMobileCheckoutStickySummary } = useMobileCheckoutStickySummaryExperiment();
+	if ( contactDetailsType !== 'domain' ) {
+		return null;
+	}
+	return (
 		<ContactDetailsFormDescription>
-			{ translate(
-				'Registering a domain name requires valid contact information. Privacy Protection is included for all eligible domains to protect your personal information.'
-			) }
+			{ isMobileCheckoutStickySummary
+				? translate(
+						'Required for domain registration. Your details are protected for eligible domains.'
+				  )
+				: translate(
+						'Registering a domain name requires valid contact information. Privacy Protection is included for all eligible domains to protect your personal information.'
+				  ) }
 		</ContactDetailsFormDescription>
-	) : null;
+	);
 }
 
 function LoadingSidebarContent() {
@@ -227,8 +239,12 @@ const ContactFormTitle = () => {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const contactDetailsType = getContactDetailsType( responseCart );
+	const { isMobileCheckoutStickySummary } = useMobileCheckoutStickySummaryExperiment();
 
 	if ( contactDetailsType === 'domain' ) {
+		if ( isMobileCheckoutStickySummary ) {
+			return <>{ String( translate( 'Contact information' ) ) }</>;
+		}
 		return (
 			<>
 				{ ! isActive && isComplete
@@ -273,7 +289,14 @@ const ContactFormTitle = () => {
 
 const OrderReviewTitle = () => {
 	const translate = useTranslate();
-	return <>{ String( translate( 'Your order' ) ) }</>;
+	const { isMobileCheckoutStickySummary } = useMobileCheckoutStickySummaryExperiment();
+	return (
+		<>
+			{ String(
+				isMobileCheckoutStickySummary ? translate( 'Order details' ) : translate( 'Your order' )
+			) }
+		</>
+	);
 };
 
 const getPresalesChatKey = ( responseCart: ObjectWithProducts ) => {
@@ -357,15 +380,21 @@ function CheckoutSidebarNudge( {
 // button — no hidden main-column button, no querySelector click proxy.
 function PortaledCheckoutFormSubmit( {
 	validateForm,
+	submitButtonHeader,
 }: {
 	validateForm?: () => Promise< boolean >;
+	submitButtonHeader?: ReactNode;
 } ) {
 	const { slotEl } = useSubmitButtonSlot();
 	if ( ! slotEl ) {
 		return null;
 	}
 	return createPortal(
-		<CheckoutFormSubmit validateForm={ validateForm } continueToNextIncompleteStep />,
+		<CheckoutFormSubmit
+			validateForm={ validateForm }
+			continueToNextIncompleteStep
+			submitButtonHeader={ submitButtonHeader }
+		/>,
 		slotEl
 	);
 }
@@ -599,6 +628,8 @@ export default function CheckoutMainContent( {
 	const isLargeViewport = useViewportMatch( 'large', '>=' );
 
 	const [ , isCheckoutUiRedesignV1 ] = useCheckoutUiRedesignExperiment();
+	const { isLoading: isMobileCheckoutStickySummaryLoading, isMobileCheckoutStickySummary } =
+		useMobileCheckoutStickySummaryExperiment();
 	const originalPriceForHeader = responseCart.products.reduce(
 		( sum, product ) => sum + product.item_original_subtotal_integer,
 		0
@@ -639,6 +670,18 @@ export default function CheckoutMainContent( {
 		);
 	}
 
+	// Wait for the assignment before painting, so treatment users aren't measured
+	// on control UI. Must stay after the completed-transaction check so a finished
+	// payment is never held behind ExPlat. Only eligible surfaces reach here.
+	if ( isMobileCheckoutStickySummaryLoading ) {
+		return (
+			<>
+				<PerformanceTrackerStop />
+				<Step.Loading />
+			</>
+		);
+	}
+
 	if (
 		shouldShowEmptyCartPage( {
 			responseCart,
@@ -652,7 +695,7 @@ export default function CheckoutMainContent( {
 		return (
 			<WPCheckoutWrapper>
 				<WPCheckoutSidebarContent></WPCheckoutSidebarContent>
-				<WPCheckoutMainContent>
+				<WPCheckoutMainContent isMobileCheckoutStickySummary={ isMobileCheckoutStickySummary }>
 					<PerformanceTrackerStop />
 					<WPCheckoutTitle className="checkout__main-title">
 						{ translate( 'Checkout' ) }
@@ -694,7 +737,7 @@ export default function CheckoutMainContent( {
 							errorMessage={ translate( 'Sorry, there was an error loading this information.' ) }
 							onError={ onSummaryError }
 						>
-							{ isCheckoutUiRedesignV1 ? (
+							{ ! isMobileCheckoutStickySummary && isCheckoutUiRedesignV1 && (
 								<CheckoutSummaryTitleLinkRedesign
 									className="checkout__summary-button"
 									onClick={ () => setIsSummaryVisible( ! isSummaryVisible ) }
@@ -725,7 +768,8 @@ export default function CheckoutMainContent( {
 										</CheckoutSummaryPricesWrapper>
 									</CheckoutSummaryTitleContentRedesign>
 								</CheckoutSummaryTitleLinkRedesign>
-							) : (
+							) }
+							{ ! isMobileCheckoutStickySummary && ! isCheckoutUiRedesignV1 && (
 								<CheckoutSummaryTitleLink
 									className="checkout__summary-button"
 									onClick={ () => setIsSummaryVisible( ! isSummaryVisible ) }
@@ -780,9 +824,34 @@ export default function CheckoutMainContent( {
 		</WPCheckoutSidebarContent>
 	);
 
+	// Control (and the non-portaled mobile fallback below) shows the money-back
+	// guarantee under the submit button.
+	const mobileSubmitButtonFooter = hasCartJetpackProductsOnly ? (
+		<JetpackCheckoutSeals />
+	) : (
+		<CheckoutMoneyBackGuarantee cart={ responseCart } />
+	);
+	// In the sticky bar the terms line rides above the CTA (header slot). The
+	// money-back guarantee is surfaced up in the payment step instead (see
+	// paymentStepRefundCopy) — reassurance at the moment of entering card
+	// details — so the footer slot below the CTA stays empty.
+	const portaledSubmitButtonHeader = isLargeViewport ? undefined : <SubmitButtonHeader />;
+	// Refund copy, no icon, that continues the secure-encryption notice at payment
+	// entry. getRefundWindowCopy is null when no refund window applies; mirror
+	// CheckoutMoneyBackGuarantee's all-domains guard.
+	const refundWindowCopy = getRefundWindowCopy( responseCart, translate );
+	const allCartItemsAreDomains = responseCart.products.every(
+		( product ) => product.is_domain_registration === true
+	);
+	const paymentStepRefundCopy =
+		refundWindowCopy && ! allCartItemsAreDomains ? refundWindowCopy : null;
+
 	const checkoutMainContent = (
 		<RestorableProductsProvider>
-			<WPCheckoutMainContent className="checkout-main-content">
+			<WPCheckoutMainContent
+				className="checkout-main-content"
+				isMobileCheckoutStickySummary={ isMobileCheckoutStickySummary }
+			>
 				<CheckoutOrderBanner />
 				{ isStepContainerV2 ? (
 					<Step.Heading
@@ -976,6 +1045,31 @@ export default function CheckoutMainContent( {
 						validatingButtonAriaLabel={ validatingButtonText }
 						onPageLoadError={ onPageLoadError }
 						waitForPaymentMethodIds={ [ 'apple-pay', 'google-pay' ] }
+						{ ...( isMobileCheckoutStickySummary && {
+							/* Figma 3971:13237 — the active heading reads "Payment method"
+							   under the experiment (vs. composite-checkout's default
+							   "Pick a payment method"). */
+							titleContent: <>{ translate( 'Payment method' ) }</>,
+							/* Figma 3971:13239 — secure-encryption notice sits as a
+							   13/regular/Gray 60 paragraph between the step heading
+							   and the methods card. We rebuild the default
+							   activeStepContent here so the notice ships alongside it. */
+							activeStepContent: (
+								<>
+									<p className="checkout-payment-method__secure-notice">
+										{ translate( 'All transactions are secure and encrypted.' ) }
+										{ /* getRefundWindowCopy is a badge label (no terminal stop), so it
+										     needs one to sit in prose here. */ }
+										{ paymentStepRefundCopy ? <> { paymentStepRefundCopy }.</> : null }
+									</p>
+									<CheckoutPaymentMethods
+										onPageLoadError={ onPageLoadError }
+										isComplete={ false }
+										waitForPaymentMethodIds={ [ 'apple-pay', 'google-pay' ] }
+									/>
+								</>
+							),
+						} ) }
 						isCompleteCallback={ () => {
 							// We want to consider this step complete only if there is a
 							// payment method selected and it does not have required fields.
@@ -1003,19 +1097,17 @@ export default function CheckoutMainContent( {
 						isSubmitted={ isSubmitted }
 						isLargeViewport={ isLargeViewport }
 					/>
-					{ isLargeViewport ? (
-						<PortaledCheckoutFormSubmit validateForm={ validateForm } />
+					{ isLargeViewport ||
+					( isStepContainerV2 && ! isLargeViewport && isMobileCheckoutStickySummary ) ? (
+						<PortaledCheckoutFormSubmit
+							validateForm={ validateForm }
+							submitButtonHeader={ portaledSubmitButtonHeader }
+						/>
 					) : (
 						<CheckoutFormSubmit
 							validateForm={ validateForm }
 							submitButtonHeader={ <SubmitButtonHeader /> }
-							submitButtonFooter={
-								hasCartJetpackProductsOnly ? (
-									<JetpackCheckoutSeals />
-								) : (
-									<CheckoutMoneyBackGuarantee cart={ responseCart } />
-								)
-							}
+							submitButtonFooter={ mobileSubmitButtonFooter }
 						/>
 					) }
 				</CheckoutStepGroup>
@@ -1054,6 +1146,7 @@ export default function CheckoutMainContent( {
 			<StepContainerV2CheckoutFixer
 				isLargeViewport={ isLargeViewport }
 				isCheckoutUiRedesignV1={ isCheckoutUiRedesignV1 }
+				isMobileCheckoutStickySummary={ isMobileCheckoutStickySummary }
 			>
 				<Step.TwoColumnLayout
 					firstColumnWidth={ 8 }
@@ -1110,7 +1203,7 @@ export default function CheckoutMainContent( {
 								{ isCheckoutUiRedesignV1 && (
 									<Step.Heading text={ translate( 'Checkout' ) } align="left" size="small" />
 								) }
-								{ checkoutSummary }
+								{ ! isMobileCheckoutStickySummary && checkoutSummary }
 							</>
 						);
 					} }
@@ -1129,7 +1222,12 @@ export default function CheckoutMainContent( {
 							);
 						}
 
-						return checkoutMainContent;
+						return (
+							<>
+								{ checkoutMainContent }
+								{ isMobileCheckoutStickySummary && <MobileCheckoutStickySummary /> }
+							</>
+						);
 					} }
 				</Step.TwoColumnLayout>
 				<LeaveCheckoutModal { ...leaveModalProps } />
@@ -1141,6 +1239,7 @@ export default function CheckoutMainContent( {
 const StepContainerV2CheckoutFixer = styled.div< {
 	isLargeViewport: boolean;
 	isCheckoutUiRedesignV1?: boolean;
+	isMobileCheckoutStickySummary?: boolean;
 } >`
 	background: ${ colorStudio.colors[ 'White' ] };
 
@@ -1218,6 +1317,18 @@ const StepContainerV2CheckoutFixer = styled.div< {
 				padding-block: 2rem;
 			}
 
+			.checkout-contact-form-step {
+				padding-block: 0 32px;
+			}
+
+			.checkout__payment-method-step {
+				padding-block-start: 0;
+			}
+
+			.checkout-step.is-active.checkout__payment-method-step {
+				padding-bottom: 16px;
+			}
+
 			.checkout-steps__submit-button-wrapper {
 				max-width: 100%;
 				padding-inline: var( --step-container-v2-content-inline-padding );
@@ -1225,6 +1336,131 @@ const StepContainerV2CheckoutFixer = styled.div< {
 				@media ( ${ props.theme.breakpoints.tabletUp } ) {
 					padding-inline: 0;
 				}
+			}
+		` }
+
+	${ ( props ) =>
+		! props.isLargeViewport &&
+		props.isMobileCheckoutStickySummary &&
+		css`
+			/* The submit button is portaled into the fixed sticky bar, so the native
+			   last-step reservation for it (--submit-button-height) is dead weight —
+			   zero it, or it stacks with the padding below into an odd trailing gap.
+			   The terms block already leaves most of the clearance; a small top-up
+			   lifts the last line clear of the bar. */
+			.checkout-main-content {
+				padding-block-end: 60px;
+			}
+			.checkout__step-wrapper.checkout__step-wrapper--last-step {
+				margin-bottom: 0;
+			}
+			/* Figma 2392:15311/15425/15448 — under the mobile sticky experiment
+			   every step renders as a plain heading; the stepper circle (number
+			   / green check) is dropped on all three steps. */
+			.checkout-step__stepper {
+				display: none;
+			}
+			.checkout-step__header h2 {
+				font-size: 20px;
+				line-height: 24px;
+				letter-spacing: -0.46px;
+			}
+			.checkout-step__header h2 > span {
+				font-weight: 500;
+				color: ${ colorStudio.colors[ 'Gray 100' ] };
+			}
+			/* Figma 2392:15428 — Contact step description. */
+			.checkout-contact-form-step .checkout-steps__step-content > p {
+				font-size: 13px;
+				line-height: 20px;
+				color: ${ colorStudio.colors[ 'Gray 60' ] };
+			}
+			.checkout-review-order__signed-in {
+				font-size: 14px;
+				line-height: 20px;
+				letter-spacing: -0.15px;
+				/* WPDS scales/grays — fallback hex matches @wordpress/base-styles
+				   defaults, since Calypso doesn't declare these vars globally. */
+				color: var( --wp-components-color-gray-700, #757575 );
+				margin: 0;
+			}
+			.checkout-review-order__signed-in strong {
+				font-weight: 400;
+				color: var( --wp-components-color-gray-800, #2f2f2f );
+			}
+			/* Figma 2392:15317 — 32px between the "signed in as …" line and the
+			   first cart row (vs. the default 24px from WPOrderReviewList), and
+			   drop the first row's top padding so the gap is exactly the list's
+			   margin, not stacked with the line item's own padding. Subsequent
+			   rows keep their 16px+16px rhythm; the last row drops its trailing
+			   padding so it sits flush against the section end. */
+			.wp-checkout__review-order-step .order-review-line-items {
+				margin-block-start: 32px;
+			}
+			.wp-checkout__review-order-step
+				.order-review-line-items
+				> li:first-child
+				.checkout-line-item {
+				padding-block-start: 0;
+			}
+			.wp-checkout__review-order-step .order-review-line-items > li:last-child .checkout-line-item {
+				padding-block-end: 0;
+			}
+			/* Figma 2392:15320 — product name typography. LineItemTitle is an
+			   unclassed styled.div; target it as the first child div of each
+			   line item. */
+			.wp-checkout__review-order-step .checkout-line-item > div:first-of-type {
+				font-size: 16px;
+				line-height: 24px;
+			}
+			/* Figma 2392:15321/15325/15326 — price typography:
+			   – Outer .checkout-line-item__price carries the "/mo" text node,
+			     so it gets the 13/regular/-0.08 cadence.
+			   – Inner LineItemPriceWrapper span (the actual amount + the
+			     <s> strikethrough) inherits up to 16/24/-0.32.
+			   – Strikethrough recolors to scales/grays/gray-700. */
+			.wp-checkout__review-order-step .checkout-line-item__price {
+				/* LineItemPriceWrapper is display:flex, so without making the
+				   outer span a flex container the sibling "/mo" text node ends
+				   up offset above the price baseline. */
+				display: flex;
+				align-items: baseline;
+				font-size: 13px;
+				line-height: 20px;
+				letter-spacing: -0.08px;
+				font-weight: 400;
+			}
+			.wp-checkout__review-order-step .checkout-line-item__price > span {
+				font-size: 16px;
+				line-height: 24px;
+				/* 8px between the strikethrough and the live price (Figma
+				   3838:3618 gap-[8px]); overrides LineItemPriceWrapper's
+				   default 4px gap. */
+				gap: 8px;
+			}
+			.wp-checkout__review-order-step .checkout-line-item__price > span > span {
+				font-weight: 500;
+			}
+			.wp-checkout__review-order-step .checkout-line-item__price > span > s {
+				color: var( --wp-components-color-gray-700, #757575 );
+			}
+			/* Figma 2392:15397 — "Remove plan/domain/email" link. */
+			.wp-checkout__review-order-step .checkout-line-item__remove-product {
+				font-size: 13px;
+				line-height: 20px;
+				font-weight: 400;
+				color: ${ colorStudio.colors[ 'Gray 100' ] };
+			}
+			/* "Have a coupon?" — match the secondary-link treatment above (Gray 100)
+			   instead of the lighter shared default, and drop the 24px area padding
+			   that leaves it stranded and inset from the rest of the column. */
+			.checkout__coupon-area {
+				padding-block: 8px;
+				padding-inline: 0;
+			}
+			.wp-checkout-order-review__show-coupon-field-button {
+				line-height: 20px;
+				color: ${ colorStudio.colors[ 'Gray 100' ] };
 			}
 		` }
 
@@ -1634,6 +1870,306 @@ const StepContainerV2CheckoutFixer = styled.div< {
 				padding-block-start: 24px;
 			}
 		` }
+	${ ( props ) =>
+		! props.isLargeViewport &&
+		props.isMobileCheckoutStickySummary &&
+		css`
+			/* Payment method card group — Figma 3971:13242. Container and
+			   divider borders track WPDS gray-200; the V1 baseline ships
+			   #e0e0e0 / #f0f0f0 — here both land on #e0e0e0 so the field
+			   reads as a single chrome instead of two tones. */
+			.checkout-payment-methods {
+				border-color: var( --wp-components-color-gray-200, #e0e0e0 );
+			}
+			.checkout-payment-methods .has-highlight {
+				border-bottom-color: var( --wp-components-color-gray-200, #e0e0e0 );
+			}
+			/* Selected row — Figma 3971:13243 — picks up a 4% Studio Blue
+			   tint on the background and an 8% Studio Blue inset border
+			   (drawn as a box-shadow so toggling selection doesn't shift
+			   the row by 1px). Drops V1's diagonal "selected" gradient. */
+			.checkout-payment-methods .has-highlight.is-checked {
+				background: rgba( 56, 88, 233, 0.04 );
+				box-shadow: inset 0 0 0 1px rgba( 56, 88, 233, 0.08 );
+			}
+			/* The composite-checkout primitive lays the Label out as a flex
+			   column with font-size 14px and min-height 72px below the
+			   400px smallPhoneUp breakpoint. The experiment runs on phones
+			   (small viewports) so lock to row + 13/52px (Figma 3971:13286
+			   row height) so each row matches Figma with logos sitting
+			   beside the title even on the narrowest devices. Font size
+			   lives here (not only in the V1 block) so mobile-sticky users
+			   on the non-V1 baseline still get 13px. */
+			.checkout-payment-methods .has-highlight > label {
+				min-height: 52px;
+				padding: 16px 16px 16px 48px;
+				flex-direction: row;
+				align-items: center;
+				justify-content: space-between;
+				gap: 16px;
+				font-size: 13px;
+				font-weight: 400;
+			}
+			.checkout-payment-methods .has-highlight > label::before {
+				left: 16px;
+			}
+			.checkout-payment-methods .has-highlight > label::after {
+				left: 20px;
+			}
+			.rtl .checkout-payment-methods .has-highlight > label {
+				padding: 16px 48px 16px 16px;
+			}
+			.rtl .checkout-payment-methods .has-highlight > label::before {
+				right: 16px;
+				left: auto;
+			}
+			.rtl .checkout-payment-methods .has-highlight > label::after {
+				right: 20px;
+				left: auto;
+			}
+			/* Brand logos render as 32x22 chips with a 4px radius and a
+			   1px gray-200 border (Figma 3971:13251 etc.). The brand SVG
+			   inside scales to fit the padded inner area while preserving
+			   its intrinsic aspect ratio (preserveAspectRatio defaults to
+			   xMidYMid meet, centering the path). PaymentMethodLogos spans
+			   render with either .credit-card__logos (credit card) or
+			   .payment-logos (PayPal, Bancontact, Apple Pay, etc.) — cover
+			   both. */
+			.checkout-payment-methods .credit-card__logos,
+			.checkout-payment-methods .payment-logos {
+				flex: 0 0 auto;
+				flex-wrap: nowrap;
+				gap: 4px;
+			}
+			.checkout-payment-methods .credit-card__logos svg,
+			.checkout-payment-methods .payment-logos svg {
+				background: ${ colorStudio.colors[ 'White' ] };
+				border: 1px solid var( --wp-components-color-gray-200, #e0e0e0 );
+				border-radius: 4px;
+				padding: 4px 6px;
+				box-sizing: border-box;
+				height: 22px;
+				width: 32px;
+			}
+			/* "+N" overflow pill — Figma 3971:13264. Same 32x22 chip
+			   silhouette as the brand logos, but the inner content is a
+			   centered 11px medium label instead of an SVG. */
+			.checkout-payment-methods .credit-card__logos-overflow {
+				display: inline-flex;
+				align-items: center;
+				justify-content: center;
+				min-width: 22px;
+				height: 22px;
+				padding: 0 6px;
+				background: ${ colorStudio.colors[ 'White' ] };
+				border: 1px solid var( --wp-components-color-gray-200, #e0e0e0 );
+				border-radius: 4px;
+				box-sizing: border-box;
+				font-size: 11px;
+				font-weight: 500;
+				line-height: 20px;
+				color: var( --wp-components-color-gray-900, #1e1e1e );
+				flex: 0 0 auto;
+			}
+			/* Lock icon at the end of the Card number input — Figma
+			   3971:13273. The StripeFieldWrapper.number is the chrome
+			   around Stripe's iframe; flatten it to a flex container,
+			   lift the visible border / padding / bg / height onto the
+			   wrapper itself, and zero out the inner StripeElement so
+			   only one chrome renders and the lock sits inside it. */
+			.credit-card-fields-inner-wrapper .number {
+				display: flex;
+				align-items: center;
+				gap: 8px;
+				height: 40px;
+				padding: 0 16px;
+				border: 1px solid ${ colorStudio.colors[ 'Gray 10' ] };
+				border-radius: 2px;
+				background: ${ colorStudio.colors[ 'White' ] };
+				box-sizing: border-box;
+			}
+			.credit-card-fields-inner-wrapper .number .StripeElement {
+				flex: 1 1 auto;
+				border: none;
+				padding: 0;
+				background: transparent;
+				height: auto;
+			}
+			.credit-card-fields-inner-wrapper .credit-card-number-field__lock-icon {
+				display: inline-flex;
+				align-items: center;
+				justify-content: center;
+				flex: 0 0 auto;
+				color: ${ colorStudio.colors[ 'Gray 100' ] };
+			}
+			.credit-card-fields-inner-wrapper .credit-card-number-field__brand-icon {
+				display: inline-flex;
+				align-items: center;
+				justify-content: center;
+				flex: 0 0 auto;
+				width: 25px;
+				height: 16px;
+			}
+			.credit-card-fields-inner-wrapper .credit-card-number-field__brand-icon img {
+				width: 100%;
+				height: 100%;
+				object-fit: contain;
+			}
+			/* Expiry + CVC + CVC card-back hint share one flex row under
+			   the experiment (Figma 3971:13274). Expiry and CVC each take
+			   1fr; the hint is a fixed 38px column with the card-back
+			   placeholder image rendered at 40px tall. */
+			.credit-card-fields-inner-wrapper .credit-card-fields__expiry-cvc-row {
+				display: flex;
+				gap: 8px;
+				align-items: flex-end;
+			}
+			.credit-card-fields-inner-wrapper .credit-card-fields__expiry-cvc-row > label {
+				flex: 1 1 0;
+				min-width: 0;
+			}
+			.credit-card-fields-inner-wrapper .credit-card-fields__cvc-hint {
+				display: flex;
+				flex: 0 0 38px;
+				width: 38px;
+				height: 40px;
+				align-items: center;
+				justify-content: center;
+			}
+			.credit-card-fields-inner-wrapper .credit-card-fields__cvc-hint svg,
+			.credit-card-fields-inner-wrapper .credit-card-fields__cvc-hint img {
+				width: 100%;
+				height: auto;
+				object-fit: contain;
+			}
+			/* "Use this payment method…" checkbox renders via WPDS
+			   CheckboxControl. The default --checkbox-input-size is 24px;
+			   Figma 3971:13283 specs it at 16×16. The token drives the
+			   input box, the check icon, and all hover/active outlines
+			   so a single override scales every part of the control
+			   without breaking states. */
+			.credit-card-fields-inner-wrapper
+				.assign-to-all-payment-methods-checkbox.components-checkbox-control {
+				--checkbox-input-size: 16px;
+			}
+			/* Expanded credit-card form sits 24px below the radio row
+			   (Figma 3971:13243 gap-[24px]). V1's wrapper rule already
+			   adds 16px padding on three sides; lift the top to 8px so
+			   the label's own 16px bottom padding sums to the 24px gap. */
+			div:has( > .credit-card-fields-inner-wrapper ) {
+				padding: 8px 16px 16px 16px;
+			}
+			/* Field rhythm matches the contact-information step — switch
+			   from CreditCardField / FieldRow's 16px margin-top to a flex
+			   column with a unified 16px gap so every field-to-field
+			   cadence lands on the same grid as the contact form. */
+			.credit-card-fields-inner-wrapper {
+				display: flex;
+				flex-direction: column;
+				gap: 16px;
+			}
+			.credit-card-fields-inner-wrapper > * {
+				margin-top: 0;
+			}
+			/* Field typography inside the credit-card form (Figma
+			   3971:13267–13276): labels 13/medium/Gray 100 with 6px below,
+			   inputs 40px tall with a 2px radius and Gray 10 border,
+			   descriptions 13/regular (not italic) with Gray 700 — Field
+			   from @automattic/wpcom-checkout renders its own emotion
+			   <label>/<input>/<p>, so we target by element rather than
+			   by class.
+
+			   Two label structures exist:
+			   - Field (Cardholder name): <label>text</label> as a sibling
+			     of the input.
+			   - Stripe (Card number / Expiry / CVC): <label><span>text</span>
+			     <wrapper>…</wrapper></label> — the span (LabelText) carries
+			     its own font + color from the styled-component, so we have
+			     to override on the span too. */
+			.credit-card-fields-inner-wrapper label,
+			.credit-card-fields-inner-wrapper label > span {
+				font-size: 13px;
+				line-height: 20px;
+				font-weight: 500;
+				color: ${ colorStudio.colors[ 'Gray 100' ] };
+			}
+			/* Gap between label text and its input — applies to both shapes
+			   (the span as the first child of a Stripe-label, the bare
+			   label as a sibling of the input for Field). */
+			.credit-card-fields-inner-wrapper label > span {
+				display: block;
+				margin-bottom: 6px;
+			}
+			.credit-card-fields-inner-wrapper > div > label[for] {
+				display: block;
+				margin-bottom: 6px;
+			}
+			/* Text-style inputs only — :not() excludes the "Use for all
+			   subscriptions" checkbox (and any stray radios), which would
+			   otherwise inherit the 40px height + 10/16 padding and render
+			   as a tall rectangle. White background re-establishes the
+			   field surface on top of the selected card's 4% blue tint. */
+			.credit-card-fields-inner-wrapper input:not( [type='checkbox'] ):not( [type='radio'] ) {
+				height: 40px;
+				font-size: 13px;
+				padding: 10px 16px;
+				border-radius: 2px;
+				border-color: ${ colorStudio.colors[ 'Gray 10' ] };
+				background: ${ colorStudio.colors[ 'White' ] };
+			}
+			/* Stripe Elements render in an iframe wrapped by a styled span;
+			   the wrapper's baseline is 12/14 padding + 16px font on a
+			   non-fixed height. Re-pin to match the Cardholder name input
+			   (40px tall, 10/16 padding, 2px radius, Gray 10 border, white
+			   bg) so card-number / expiry / CVC share the same rhythm. */
+			.credit-card-fields-inner-wrapper .StripeElement,
+			.credit-card-fields-inner-wrapper .stripe-element {
+				background: ${ colorStudio.colors[ 'White' ] };
+				height: 40px;
+				padding: 10px 16px;
+				border-radius: 2px;
+				border-color: ${ colorStudio.colors[ 'Gray 10' ] };
+				box-sizing: border-box;
+			}
+			/* Secure-encryption notice — Figma 3971:13239 — sits below the
+			   "Payment method" heading at 13/regular/Gray 60 with a 16px
+			   gap to the card group. The <p> is injected via
+			   activeStepContent above. */
+			.checkout__payment-method-step .checkout-payment-method__secure-notice {
+				font-size: 13px;
+				line-height: 20px;
+				font-weight: 400;
+				color: ${ colorStudio.colors[ 'Gray 60' ] };
+				margin: 0 0 16px;
+			}
+			.credit-card-fields-inner-wrapper p {
+				font-style: normal;
+				font-size: 13px;
+				line-height: 20px;
+				font-weight: 400;
+				color: ${ colorStudio.colors[ 'Gray 50' ] };
+				margin: 8px 0 0;
+			}
+			/* "Use this payment method for all subscriptions…" — the
+			   AssignToAllPaymentMethods checkbox uses WPDS' CheckboxControl
+			   whose label is informational text, not a field label. The
+			   broader label rule above paints field labels 13/medium/Gray
+			   100; restyle the checkbox label to 13/regular/Gray 50 so it
+			   reads as helper copy (Figma 3971:13285). Also reset the
+			   wrapper's margin-top to 0 — the inner-wrapper's flex+gap
+			   already supplies the 16px cadence. */
+			.credit-card-fields-inner-wrapper .components-checkbox-control label {
+				font-size: 13px;
+				line-height: 20px;
+				font-weight: 400;
+				color: ${ colorStudio.colors[ 'Gray 50' ] };
+				margin-bottom: 0;
+			}
+			.credit-card-fields-inner-wrapper .components-checkbox-control label a {
+				color: ${ colorStudio.colors[ 'Gray 100' ] };
+				text-decoration: underline;
+			}
+		` }
 `;
 
 const CheckoutSummary = styled.div`
@@ -1873,7 +2409,7 @@ function SubmitButtonHeader() {
 	const scrollToTOS = () => document?.getElementById( 'checkout-terms' )?.scrollIntoView();
 
 	return (
-		<SubmitButtonHeaderWrapper>
+		<SubmitButtonHeaderWrapper className="checkout-steps__submit-button-header">
 			{ translate( 'By continuing, you agree to our {{button}}Terms of Service{{/button}}.', {
 				components: {
 					button: <button onClick={ scrollToTOS } />,
@@ -2452,7 +2988,9 @@ const WPCheckoutCompletedWrapper = styled.div`
 	}
 `;
 
-const WPCheckoutMainContent = styled.div`
+const WPCheckoutMainContent = styled.div< {
+	isMobileCheckoutStickySummary?: boolean;
+} >`
 	grid-area: main-content;
 	margin-top: 50px;
 
@@ -2489,11 +3027,141 @@ const WPCheckoutMainContent = styled.div`
 		}
 		.form-fieldset.contact-details-form-fields .contact-details-form-fields__row,
 		.form-fieldset.contact-details-form-fields .custom-form-fieldsets__address-fields {
-			gap: 10px;
+			gap: ${ props.isMobileCheckoutStickySummary ? '16px' : '10px' };
 		}
 		.form-fieldset.contact-details-form-fields .contact-details-form-fields__field {
-			margin-bottom: 10px;
+			margin-bottom: ${ props.isMobileCheckoutStickySummary ? '0' : '10px' };
 		}
+		${ props.isMobileCheckoutStickySummary &&
+		css`
+			.form-fieldset.contact-details-form-fields .contact-details-form-fields__field,
+			.form-fieldset.contact-details-form-fields .contact-details-form-fields__country {
+				margin-top: 0;
+			}
+			/* "+ Add Address Line 2" / "+ Add organization name" toggles
+			   come from .form__hidden-input. Reset its 5px margin-top so
+			   the link sits at the parent's flex-gap rhythm, and match the
+			   "Remove plan" link typography (13/20/regular/Gray 100/underline)
+			   so all destructive/secondary links read as one family. */
+			.form-fieldset.contact-details-form-fields .form__hidden-input a {
+				margin-top: 0;
+				font-size: 13px;
+				line-height: 20px;
+				font-weight: 400;
+				color: ${ colorStudio.colors[ 'Gray 100' ] };
+				text-decoration: underline;
+			}
+			/* .vat-form__row carries its own 16px margin-top (plus a
+			   16px margin-block-start on stacked rows on mobile) — both
+			   redundant now that we drive spacing through column gaps. */
+			.checkout-contact-form-step .vat-form__row,
+			.checkout-contact-form-step .vat-form__row > div:not( :first-child ) {
+				margin-top: 0;
+				margin-block-start: 0;
+			}
+			/* The VAT form lives inside .__extra-fields (not flex by default)
+			   and each .vat-form__row stacks fields on mobile. Promote both
+			   plus the expanded-fields wrapper to flex columns with the
+			   unified 16px gap so the whole block matches the rest of the
+			   contact form's rhythm. */
+			.checkout-contact-form-step .contact-details-form-fields__extra-fields,
+			.checkout-contact-form-step .vat-form__expanded,
+			.checkout-contact-form-step .vat-form__row {
+				display: flex;
+				flex-direction: column;
+				gap: 16px;
+			}
+			/* Expanded VAT fields render as a quiet card to signal they
+			   form a distinct section toggled by the checkbox above. */
+			.checkout-contact-form-step .vat-form__expanded {
+				background: ${ colorStudio.colors[ 'Gray 0' ] };
+				border: 1px solid ${ colorStudio.colors[ 'Gray 5' ] };
+				border-radius: 4px;
+				padding: 16px;
+				margin-top: 8px;
+			}
+			/* Figma 2392:15444 — VAT details checkbox renders at 16x16.
+			   WPDS' .components-checkbox-control drives every dimension
+			   (input, checkmark icon, hover/active/disabled outlines)
+			   off --checkbox-input-size, so a single var override gives
+			   a properly-scaled checkbox with all states intact. */
+			.checkout-contact-form-step .vat-form__expand-button.components-checkbox-control {
+				--checkbox-input-size: 16px;
+			}
+			/* CheckboxControl's HStack ships with alignment="top" which makes
+			   the box sit at the line-box top while the text's cap-height
+			   sits a few pixels lower — visible misalignment. Center the
+			   pair instead. */
+			.checkout-contact-form-step
+				.vat-form__expand-button.components-checkbox-control
+				.components-h-stack {
+				align-items: center;
+			}
+			/* Figma 2392:15431 — all form labels render in Gray 100. */
+			.form-label {
+				color: ${ colorStudio.colors[ 'Gray 100' ] };
+			}
+			/* The VAT form (Field from @automattic/wpcom-checkout) renders
+			   a plain <label> via emotion, not .form-label, so it doesn't
+			   pick up the contact-form label styling. Match it here. */
+			.checkout-contact-form-step .vat-form__row label {
+				font-size: 13px;
+				line-height: 20px;
+				font-weight: 500;
+				color: ${ colorStudio.colors[ 'Gray 100' ] };
+				margin-bottom: 6px;
+			}
+			/* The "ES"/country-code prefix in front of the VAT ID input
+			   carries a 3.5rem min-width and 14px font that push the input
+			   over and leave a yawning gap. Match it to the input rhythm. */
+			.checkout-contact-form-step .vat-form__row .field__overlay-prefix {
+				font-size: 13px;
+				min-width: 0;
+				padding-inline: 12px;
+			}
+			/* Figma 2461:4947 — "Continue to payment" spans the full column. */
+			.checkout-next-step-button {
+				width: 100%;
+			}
+			/* Unified 16px vertical rhythm between every row. The outer
+			   FormFieldset is already flex-column but ships without a gap,
+			   and First/Last name is rendered as its sibling — not inside
+			   __contact-details. So the gap needs to live on all of:
+			   the outer FormFieldset, __contact-details itself, and the
+			   two un-classed wrapper divs from RegionAddressFieldsets. */
+			.form-fieldset.contact-details-form-fields,
+			.form-fieldset.contact-details-form-fields .contact-details-form-fields__contact-details,
+			.form-fieldset.contact-details-form-fields
+				.contact-details-form-fields__contact-details
+				> div:not( [class] ),
+			.form-fieldset.contact-details-form-fields
+				.contact-details-form-fields__contact-details
+				> div:not( [class] )
+				> div:not( [class] ) {
+				display: flex;
+				flex-direction: column;
+				gap: 16px;
+			}
+			/* …except the innermost RegionAddressFieldsets wrapper, which
+			   pairs an input with its toggle link ("+ Add Address Line 2")
+			   as a "Field + Action" group — Figma 2392:15432 puts those
+			   8px apart, not 16. */
+			.form-fieldset.contact-details-form-fields
+				.contact-details-form-fields__contact-details
+				> div:not( [class] )
+				> div:not( [class] ) {
+				gap: 8px;
+			}
+			/* Same rhythm for the "Add organization name" row — it sits in
+			   its own __row but is conceptually a Field+Action paired with
+			   the Last name field above. Negative margin compensates the
+			   parent's 16px column gap down to 8px. Only fires while the
+			   HiddenInput link is showing; once toggled to an input the
+			   row drops back to full 16px spacing. */
+			.contact-details-form-fields__row:has( .form__hidden-input ) {
+				margin-top: -8px;
+			}
+		` }
 		.checkout-terms-and-checkboxes a {
 			color: ${ props.theme.colors.textColorDark };
 		}

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1225,7 +1225,7 @@ export default function CheckoutMainContent( {
  * cascade. `isMobileCheckoutStickySummary` is already false above the `small`
  * breakpoint, so no additional viewport guard is needed here.
  */
-const mobileStickySummaryStyles = css`
+const mobileCheckoutStickySummaryStyles = css`
 	/* The submit button is portaled into the fixed sticky bar, so the native
 	   last-step reservation for it (--submit-button-height) is dead weight —
 	   zero it, or it stacks with the padding below into an odd trailing gap.
@@ -1375,7 +1375,7 @@ const mobileStickySummaryStyles = css`
 	   (small viewports) so lock to row + 13/52px (Figma 3971:13286
 	   row height) so each row matches Figma with logos sitting
 	   beside the title even on the narrowest devices. Font size
-	   lives here (not only in the V1 block) so mobile-sticky users
+	   lives here (not only in the V1 block) so mobile-checkout-sticky-summary users
 	   on the non-V1 baseline still get 13px. */
 	.checkout-payment-methods .has-highlight > label {
 		min-height: 52px;
@@ -2145,7 +2145,7 @@ const StepContainerV2CheckoutFixer = styled.div< {
 				padding-block-start: 24px;
 			}
 		` }
-	${ ( props ) => props.isMobileCheckoutStickySummary && mobileStickySummaryStyles }
+	${ ( props ) => props.isMobileCheckoutStickySummary && mobileCheckoutStickySummaryStyles }
 `;
 
 const CheckoutSummary = styled.div`

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1402,8 +1402,19 @@ const mobileCheckoutStickySummaryStyles = css`
 		flex-wrap: nowrap;
 		gap: 4px;
 	}
+	/* PaymentLogo lays its wrappers out for the legacy row: the brand
+	   wrapper nudges itself down 4px and the fallback lock icon is
+	   absolutely positioned (top 14px / right 10px), so it escapes the
+	   row and lands over the divider. Flatten both so every chip is an
+	   in-flow flex item the row can centre. */
+	.checkout-payment-methods .credit-card__logos > span,
+	.checkout-payment-methods .payment-logos > span {
+		position: static;
+		transform: none;
+	}
 	.checkout-payment-methods .credit-card__logos svg,
 	.checkout-payment-methods .payment-logos svg {
+		position: static;
 		background: ${ colorStudio.colors[ 'White' ] };
 		border: 1px solid var( --wp-components-color-gray-200, #e0e0e0 );
 		border-radius: 4px;

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -17,7 +17,6 @@ import {
 	useIsStepComplete,
 	CheckoutErrorBoundary,
 	CheckoutFormSubmit,
-	CheckoutPaymentMethods,
 	PaymentMethodStep,
 	FormStatus,
 	usePaymentMethod,
@@ -1039,22 +1038,16 @@ export default function CheckoutMainContent( {
 							titleContent: <>{ translate( 'Payment method' ) }</>,
 							/* Figma 3971:13239 — secure-encryption notice sits as a
 							   13/regular/Gray 60 paragraph between the step heading
-							   and the methods card. We rebuild the default
-							   activeStepContent here so the notice ships alongside it. */
-							activeStepContent: (
-								<>
-									<p className="checkout-payment-method__secure-notice">
-										{ translate( 'All transactions are secure and encrypted.' ) }
-										{ /* getRefundWindowCopy is a badge label (no terminal stop), so it
-										     needs one to sit in prose here. */ }
-										{ paymentStepRefundCopy ? <> { paymentStepRefundCopy }.</> : null }
-									</p>
-									<CheckoutPaymentMethods
-										onPageLoadError={ onPageLoadError }
-										isComplete={ false }
-										waitForPaymentMethodIds={ [ 'apple-pay', 'google-pay' ] }
-									/>
-								</>
+							   and the methods card. activeStepHeader renders directly
+							   above activeStepContent, so the default methods card is
+							   left untouched. */
+							activeStepHeader: (
+								<p className="checkout-payment-method__secure-notice">
+									{ translate( 'All transactions are secure and encrypted.' ) }
+									{ /* getRefundWindowCopy is a badge label (no terminal stop), so it
+									     needs one to sit in prose here. */ }
+									{ paymentStepRefundCopy ? <> { paymentStepRefundCopy }.</> : null }
+								</p>
 							),
 						} ) }
 						isCompleteCallback={ () => {
@@ -1618,7 +1611,7 @@ const mobileStickySummaryStyles = css`
 	/* Secure-encryption notice — Figma 3971:13239 — sits below the
 	   "Payment method" heading at 13/regular/Gray 60 with a 16px
 	   gap to the card group. The <p> is injected via
-	   activeStepContent above. */
+	   activeStepHeader above. */
 	.checkout__payment-method-step .checkout-payment-method__secure-notice {
 		font-size: 13px;
 		line-height: 20px;

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -628,8 +628,7 @@ export default function CheckoutMainContent( {
 	const isLargeViewport = useViewportMatch( 'large', '>=' );
 
 	const [ , isCheckoutUiRedesignV1 ] = useCheckoutUiRedesignExperiment();
-	const { isLoading: isMobileCheckoutStickySummaryLoading, isMobileCheckoutStickySummary } =
-		useMobileCheckoutStickySummaryExperiment();
+	const { isMobileCheckoutStickySummary } = useMobileCheckoutStickySummaryExperiment();
 	const originalPriceForHeader = responseCart.products.reduce(
 		( sum, product ) => sum + product.item_original_subtotal_integer,
 		0
@@ -667,18 +666,6 @@ export default function CheckoutMainContent( {
 					<Loading className="checkout__pending-content" title={ headingText } />
 				</WPCheckoutCompletedMainContent>
 			</WPCheckoutCompletedWrapper>
-		);
-	}
-
-	// Wait for the assignment before painting, so treatment users aren't measured
-	// on control UI. Must stay after the completed-transaction check so a finished
-	// payment is never held behind ExPlat. Only eligible surfaces reach here.
-	if ( isMobileCheckoutStickySummaryLoading ) {
-		return (
-			<>
-				<PerformanceTrackerStop />
-				<Step.Loading />
-			</>
 		);
 	}
 

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1223,6 +1223,438 @@ export default function CheckoutMainContent( {
 	);
 }
 
+/**
+ * Styles for the mobile sticky order summary experiment
+ * (`calypso_mobile_checkout_sticky_summary_v1`).
+ *
+ * Interpolated last in `StepContainerV2CheckoutFixer` so that for a user
+ * enrolled in both this and the checkout UI redesign, these rules win the
+ * cascade. `isMobileCheckoutStickySummary` is already false above the `small`
+ * breakpoint, so no additional viewport guard is needed here.
+ */
+const mobileStickySummaryStyles = css`
+	/* The submit button is portaled into the fixed sticky bar, so the native
+	   last-step reservation for it (--submit-button-height) is dead weight —
+	   zero it, or it stacks with the padding below into an odd trailing gap.
+	   The terms block already leaves most of the clearance; a small top-up
+	   lifts the last line clear of the bar. */
+	.checkout-main-content {
+		padding-block-end: 60px;
+	}
+	.checkout__step-wrapper.checkout__step-wrapper--last-step {
+		margin-bottom: 0;
+	}
+	.checkout-contact-form-step {
+		padding-block: 0 32px;
+	}
+	.checkout__payment-method-step {
+		padding-block-start: 0;
+	}
+	.checkout-step.is-active.checkout__payment-method-step {
+		padding-bottom: 16px;
+	}
+	/* Figma 2392:15311/15425/15448 — under the mobile sticky experiment
+	   every step renders as a plain heading; the stepper circle (number
+	   / green check) is dropped on all three steps. */
+	.checkout-step__stepper {
+		display: none;
+	}
+	.checkout-step__header h2 {
+		font-size: 20px;
+		line-height: 24px;
+		letter-spacing: -0.46px;
+	}
+	.checkout-step__header h2 > span {
+		font-weight: 500;
+		color: ${ colorStudio.colors[ 'Gray 100' ] };
+	}
+	/* Figma 2392:15428 — Contact step description. */
+	.checkout-contact-form-step .checkout-steps__step-content > p {
+		font-size: 13px;
+		line-height: 20px;
+		color: ${ colorStudio.colors[ 'Gray 60' ] };
+	}
+	.checkout-review-order__signed-in {
+		font-size: 14px;
+		line-height: 20px;
+		letter-spacing: -0.15px;
+		/* WPDS scales/grays — fallback hex matches @wordpress/base-styles
+		   defaults, since Calypso doesn't declare these vars globally. */
+		color: var( --wp-components-color-gray-700, #757575 );
+		margin: 0;
+	}
+	.checkout-review-order__signed-in strong {
+		font-weight: 400;
+		color: var( --wp-components-color-gray-800, #2f2f2f );
+	}
+	/* Figma 2392:15317 — 32px between the "signed in as …" line and the
+	   first cart row (vs. the default 24px from WPOrderReviewList), and
+	   drop the first row's top padding so the gap is exactly the list's
+	   margin, not stacked with the line item's own padding. Subsequent
+	   rows keep their 16px+16px rhythm; the last row drops its trailing
+	   padding so it sits flush against the section end. */
+	.wp-checkout__review-order-step .order-review-line-items {
+		margin-block-start: 32px;
+	}
+	.wp-checkout__review-order-step .order-review-line-items > li:first-child .checkout-line-item {
+		padding-block-start: 0;
+	}
+	.wp-checkout__review-order-step .order-review-line-items > li:last-child .checkout-line-item {
+		padding-block-end: 0;
+	}
+	/* Figma 2392:15320 — product name typography. LineItemTitle is an
+	   unclassed styled.div; target it as the first child div of each
+	   line item. */
+	.wp-checkout__review-order-step .checkout-line-item > div:first-of-type {
+		font-size: 16px;
+		line-height: 24px;
+	}
+	/* Figma 2392:15321/15325/15326 — price typography:
+	   – Outer .checkout-line-item__price carries the "/mo" text node,
+	     so it gets the 13/regular/-0.08 cadence.
+	   – Inner LineItemPriceWrapper span (the actual amount + the
+	     <s> strikethrough) inherits up to 16/24/-0.32.
+	   – Strikethrough recolors to scales/grays/gray-700. */
+	.wp-checkout__review-order-step .checkout-line-item__price {
+		/* LineItemPriceWrapper is display:flex, so without making the
+		   outer span a flex container the sibling "/mo" text node ends
+		   up offset above the price baseline. */
+		display: flex;
+		align-items: baseline;
+		font-size: 13px;
+		line-height: 20px;
+		letter-spacing: -0.08px;
+		font-weight: 400;
+	}
+	.wp-checkout__review-order-step .checkout-line-item__price > span {
+		font-size: 16px;
+		line-height: 24px;
+		/* 8px between the strikethrough and the live price (Figma
+		   3838:3618 gap-[8px]); overrides LineItemPriceWrapper's
+		   default 4px gap. */
+		gap: 8px;
+	}
+	.wp-checkout__review-order-step .checkout-line-item__price > span > span {
+		font-weight: 500;
+	}
+	.wp-checkout__review-order-step .checkout-line-item__price > span > s {
+		color: var( --wp-components-color-gray-700, #757575 );
+	}
+	/* Figma 2392:15397 — "Remove plan/domain/email" link. */
+	.wp-checkout__review-order-step .checkout-line-item__remove-product {
+		font-size: 13px;
+		line-height: 20px;
+		font-weight: 400;
+		color: ${ colorStudio.colors[ 'Gray 100' ] };
+	}
+	/* "Have a coupon?" — match the secondary-link treatment above (Gray 100)
+	   instead of the lighter shared default, and drop the 24px area padding
+	   that leaves it stranded and inset from the rest of the column. */
+	.checkout__coupon-area {
+		padding-block: 8px;
+		padding-inline: 0;
+	}
+	.wp-checkout-order-review__show-coupon-field-button {
+		line-height: 20px;
+		color: ${ colorStudio.colors[ 'Gray 100' ] };
+	}
+	/* Payment method card group — Figma 3971:13242. Container and
+	   divider borders track WPDS gray-200; the V1 baseline ships
+	   #e0e0e0 / #f0f0f0 — here both land on #e0e0e0 so the field
+	   reads as a single chrome instead of two tones. */
+	.checkout-payment-methods {
+		border-color: var( --wp-components-color-gray-200, #e0e0e0 );
+	}
+	.checkout-payment-methods .has-highlight {
+		border-bottom-color: var( --wp-components-color-gray-200, #e0e0e0 );
+	}
+	/* Selected row — Figma 3971:13243 — picks up a 4% Studio Blue
+	   tint on the background and an 8% Studio Blue inset border
+	   (drawn as a box-shadow so toggling selection doesn't shift
+	   the row by 1px). Drops V1's diagonal "selected" gradient. */
+	.checkout-payment-methods .has-highlight.is-checked {
+		background: rgba( 56, 88, 233, 0.04 );
+		box-shadow: inset 0 0 0 1px rgba( 56, 88, 233, 0.08 );
+	}
+	/* The composite-checkout primitive lays the Label out as a flex
+	   column with font-size 14px and min-height 72px below the
+	   400px smallPhoneUp breakpoint. The experiment runs on phones
+	   (small viewports) so lock to row + 13/52px (Figma 3971:13286
+	   row height) so each row matches Figma with logos sitting
+	   beside the title even on the narrowest devices. Font size
+	   lives here (not only in the V1 block) so mobile-sticky users
+	   on the non-V1 baseline still get 13px. */
+	.checkout-payment-methods .has-highlight > label {
+		min-height: 52px;
+		padding: 16px 16px 16px 48px;
+		flex-direction: row;
+		align-items: center;
+		justify-content: space-between;
+		gap: 16px;
+		font-size: 13px;
+		font-weight: 400;
+	}
+	.checkout-payment-methods .has-highlight > label::before {
+		left: 16px;
+	}
+	.checkout-payment-methods .has-highlight > label::after {
+		left: 20px;
+	}
+	.rtl .checkout-payment-methods .has-highlight > label {
+		padding: 16px 48px 16px 16px;
+	}
+	.rtl .checkout-payment-methods .has-highlight > label::before {
+		right: 16px;
+		left: auto;
+	}
+	.rtl .checkout-payment-methods .has-highlight > label::after {
+		right: 20px;
+		left: auto;
+	}
+	/* Brand logos render as 32x22 chips with a 4px radius and a
+	   1px gray-200 border (Figma 3971:13251 etc.). The brand SVG
+	   inside scales to fit the padded inner area while preserving
+	   its intrinsic aspect ratio (preserveAspectRatio defaults to
+	   xMidYMid meet, centering the path). PaymentMethodLogos spans
+	   render with either .credit-card__logos (credit card) or
+	   .payment-logos (PayPal, Bancontact, Apple Pay, etc.) — cover
+	   both. */
+	.checkout-payment-methods .credit-card__logos,
+	.checkout-payment-methods .payment-logos {
+		flex: 0 0 auto;
+		flex-wrap: nowrap;
+		gap: 4px;
+	}
+	.checkout-payment-methods .credit-card__logos svg,
+	.checkout-payment-methods .payment-logos svg {
+		background: ${ colorStudio.colors[ 'White' ] };
+		border: 1px solid var( --wp-components-color-gray-200, #e0e0e0 );
+		border-radius: 4px;
+		padding: 4px 6px;
+		box-sizing: border-box;
+		height: 22px;
+		width: 32px;
+	}
+	/* "+N" overflow pill — Figma 3971:13264. Same 32x22 chip
+	   silhouette as the brand logos, but the inner content is a
+	   centered 11px medium label instead of an SVG. */
+	.checkout-payment-methods .credit-card__logos-overflow {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 22px;
+		height: 22px;
+		padding: 0 6px;
+		background: ${ colorStudio.colors[ 'White' ] };
+		border: 1px solid var( --wp-components-color-gray-200, #e0e0e0 );
+		border-radius: 4px;
+		box-sizing: border-box;
+		font-size: 11px;
+		font-weight: 500;
+		line-height: 20px;
+		color: var( --wp-components-color-gray-900, #1e1e1e );
+		flex: 0 0 auto;
+	}
+	/* Lock icon at the end of the Card number input — Figma
+	   3971:13273. The StripeFieldWrapper.number is the chrome
+	   around Stripe's iframe; flatten it to a flex container,
+	   lift the visible border / padding / bg / height onto the
+	   wrapper itself, and zero out the inner StripeElement so
+	   only one chrome renders and the lock sits inside it. */
+	.credit-card-fields-inner-wrapper .number {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		height: 40px;
+		padding: 0 16px;
+		border: 1px solid ${ colorStudio.colors[ 'Gray 10' ] };
+		border-radius: 2px;
+		background: ${ colorStudio.colors[ 'White' ] };
+		box-sizing: border-box;
+	}
+	.credit-card-fields-inner-wrapper .number .StripeElement {
+		flex: 1 1 auto;
+		border: none;
+		padding: 0;
+		background: transparent;
+		height: auto;
+	}
+	.credit-card-fields-inner-wrapper .credit-card-number-field__lock-icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		flex: 0 0 auto;
+		color: ${ colorStudio.colors[ 'Gray 100' ] };
+	}
+	.credit-card-fields-inner-wrapper .credit-card-number-field__brand-icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		flex: 0 0 auto;
+		width: 25px;
+		height: 16px;
+	}
+	.credit-card-fields-inner-wrapper .credit-card-number-field__brand-icon img {
+		width: 100%;
+		height: 100%;
+		object-fit: contain;
+	}
+	/* Expiry + CVC + CVC card-back hint share one flex row under
+	   the experiment (Figma 3971:13274). Expiry and CVC each take
+	   1fr; the hint is a fixed 38px column with the card-back
+	   placeholder image rendered at 40px tall. */
+	.credit-card-fields-inner-wrapper .credit-card-fields__expiry-cvc-row {
+		display: flex;
+		gap: 8px;
+		align-items: flex-end;
+	}
+	.credit-card-fields-inner-wrapper .credit-card-fields__expiry-cvc-row > label {
+		flex: 1 1 0;
+		min-width: 0;
+	}
+	.credit-card-fields-inner-wrapper .credit-card-fields__cvc-hint {
+		display: flex;
+		flex: 0 0 38px;
+		width: 38px;
+		height: 40px;
+		align-items: center;
+		justify-content: center;
+	}
+	.credit-card-fields-inner-wrapper .credit-card-fields__cvc-hint svg,
+	.credit-card-fields-inner-wrapper .credit-card-fields__cvc-hint img {
+		width: 100%;
+		height: auto;
+		object-fit: contain;
+	}
+	/* "Use this payment method…" checkbox renders via WPDS
+	   CheckboxControl. The default --checkbox-input-size is 24px;
+	   Figma 3971:13283 specs it at 16×16. The token drives the
+	   input box, the check icon, and all hover/active outlines
+	   so a single override scales every part of the control
+	   without breaking states. */
+	.credit-card-fields-inner-wrapper
+		.assign-to-all-payment-methods-checkbox.components-checkbox-control {
+		--checkbox-input-size: 16px;
+	}
+	/* Expanded credit-card form sits 24px below the radio row
+	   (Figma 3971:13243 gap-[24px]). V1's wrapper rule already
+	   adds 16px padding on three sides; lift the top to 8px so
+	   the label's own 16px bottom padding sums to the 24px gap. */
+	div:has( > .credit-card-fields-inner-wrapper ) {
+		padding: 8px 16px 16px 16px;
+	}
+	/* Field rhythm matches the contact-information step — switch
+	   from CreditCardField / FieldRow's 16px margin-top to a flex
+	   column with a unified 16px gap so every field-to-field
+	   cadence lands on the same grid as the contact form. */
+	.credit-card-fields-inner-wrapper {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+	}
+	.credit-card-fields-inner-wrapper > * {
+		margin-top: 0;
+	}
+	/* Field typography inside the credit-card form (Figma
+	   3971:13267–13276): labels 13/medium/Gray 100 with 6px below,
+	   inputs 40px tall with a 2px radius and Gray 10 border,
+	   descriptions 13/regular (not italic) with Gray 700 — Field
+	   from @automattic/wpcom-checkout renders its own emotion
+	   <label>/<input>/<p>, so we target by element rather than
+	   by class.
+
+	   Two label structures exist:
+	   - Field (Cardholder name): <label>text</label> as a sibling
+	     of the input.
+	   - Stripe (Card number / Expiry / CVC): <label><span>text</span>
+	     <wrapper>…</wrapper></label> — the span (LabelText) carries
+	     its own font + color from the styled-component, so we have
+	     to override on the span too. */
+	.credit-card-fields-inner-wrapper label,
+	.credit-card-fields-inner-wrapper label > span {
+		font-size: 13px;
+		line-height: 20px;
+		font-weight: 500;
+		color: ${ colorStudio.colors[ 'Gray 100' ] };
+	}
+	/* Gap between label text and its input — applies to both shapes
+	   (the span as the first child of a Stripe-label, the bare
+	   label as a sibling of the input for Field). */
+	.credit-card-fields-inner-wrapper label > span {
+		display: block;
+		margin-bottom: 6px;
+	}
+	.credit-card-fields-inner-wrapper > div > label[for] {
+		display: block;
+		margin-bottom: 6px;
+	}
+	/* Text-style inputs only — :not() excludes the "Use for all
+	   subscriptions" checkbox (and any stray radios), which would
+	   otherwise inherit the 40px height + 10/16 padding and render
+	   as a tall rectangle. White background re-establishes the
+	   field surface on top of the selected card's 4% blue tint. */
+	.credit-card-fields-inner-wrapper input:not( [type='checkbox'] ):not( [type='radio'] ) {
+		height: 40px;
+		font-size: 13px;
+		padding: 10px 16px;
+		border-radius: 2px;
+		border-color: ${ colorStudio.colors[ 'Gray 10' ] };
+		background: ${ colorStudio.colors[ 'White' ] };
+	}
+	/* Stripe Elements render in an iframe wrapped by a styled span;
+	   the wrapper's baseline is 12/14 padding + 16px font on a
+	   non-fixed height. Re-pin to match the Cardholder name input
+	   (40px tall, 10/16 padding, 2px radius, Gray 10 border, white
+	   bg) so card-number / expiry / CVC share the same rhythm. */
+	.credit-card-fields-inner-wrapper .StripeElement,
+	.credit-card-fields-inner-wrapper .stripe-element {
+		background: ${ colorStudio.colors[ 'White' ] };
+		height: 40px;
+		padding: 10px 16px;
+		border-radius: 2px;
+		border-color: ${ colorStudio.colors[ 'Gray 10' ] };
+		box-sizing: border-box;
+	}
+	/* Secure-encryption notice — Figma 3971:13239 — sits below the
+	   "Payment method" heading at 13/regular/Gray 60 with a 16px
+	   gap to the card group. The <p> is injected via
+	   activeStepContent above. */
+	.checkout__payment-method-step .checkout-payment-method__secure-notice {
+		font-size: 13px;
+		line-height: 20px;
+		font-weight: 400;
+		color: ${ colorStudio.colors[ 'Gray 60' ] };
+		margin: 0 0 16px;
+	}
+	.credit-card-fields-inner-wrapper p {
+		font-style: normal;
+		font-size: 13px;
+		line-height: 20px;
+		font-weight: 400;
+		color: ${ colorStudio.colors[ 'Gray 50' ] };
+		margin: 8px 0 0;
+	}
+	/* "Use this payment method for all subscriptions…" — the
+	   AssignToAllPaymentMethods checkbox uses WPDS' CheckboxControl
+	   whose label is informational text, not a field label. The
+	   broader label rule above paints field labels 13/medium/Gray
+	   100; restyle the checkbox label to 13/regular/Gray 50 so it
+	   reads as helper copy (Figma 3971:13285). Also reset the
+	   wrapper's margin-top to 0 — the inner-wrapper's flex+gap
+	   already supplies the 16px cadence. */
+	.credit-card-fields-inner-wrapper .components-checkbox-control label {
+		font-size: 13px;
+		line-height: 20px;
+		font-weight: 400;
+		color: ${ colorStudio.colors[ 'Gray 50' ] };
+		margin-bottom: 0;
+	}
+	.credit-card-fields-inner-wrapper .components-checkbox-control label a {
+		color: ${ colorStudio.colors[ 'Gray 100' ] };
+		text-decoration: underline;
+	}
+`;
+
 const StepContainerV2CheckoutFixer = styled.div< {
 	isLargeViewport: boolean;
 	isCheckoutUiRedesignV1?: boolean;
@@ -1311,140 +1743,6 @@ const StepContainerV2CheckoutFixer = styled.div< {
 				@media ( ${ props.theme.breakpoints.tabletUp } ) {
 					padding-inline: 0;
 				}
-			}
-		` }
-
-	${ ( props ) =>
-		! props.isLargeViewport &&
-		props.isMobileCheckoutStickySummary &&
-		css`
-			/* The submit button is portaled into the fixed sticky bar, so the native
-			   last-step reservation for it (--submit-button-height) is dead weight —
-			   zero it, or it stacks with the padding below into an odd trailing gap.
-			   The terms block already leaves most of the clearance; a small top-up
-			   lifts the last line clear of the bar. */
-			.checkout-main-content {
-				padding-block-end: 60px;
-			}
-			.checkout__step-wrapper.checkout__step-wrapper--last-step {
-				margin-bottom: 0;
-			}
-			.checkout-contact-form-step {
-				padding-block: 0 32px;
-			}
-			.checkout__payment-method-step {
-				padding-block-start: 0;
-			}
-			.checkout-step.is-active.checkout__payment-method-step {
-				padding-bottom: 16px;
-			}
-			/* Figma 2392:15311/15425/15448 — under the mobile sticky experiment
-			   every step renders as a plain heading; the stepper circle (number
-			   / green check) is dropped on all three steps. */
-			.checkout-step__stepper {
-				display: none;
-			}
-			.checkout-step__header h2 {
-				font-size: 20px;
-				line-height: 24px;
-				letter-spacing: -0.46px;
-			}
-			.checkout-step__header h2 > span {
-				font-weight: 500;
-				color: ${ colorStudio.colors[ 'Gray 100' ] };
-			}
-			/* Figma 2392:15428 — Contact step description. */
-			.checkout-contact-form-step .checkout-steps__step-content > p {
-				font-size: 13px;
-				line-height: 20px;
-				color: ${ colorStudio.colors[ 'Gray 60' ] };
-			}
-			.checkout-review-order__signed-in {
-				font-size: 14px;
-				line-height: 20px;
-				letter-spacing: -0.15px;
-				/* WPDS scales/grays — fallback hex matches @wordpress/base-styles
-				   defaults, since Calypso doesn't declare these vars globally. */
-				color: var( --wp-components-color-gray-700, #757575 );
-				margin: 0;
-			}
-			.checkout-review-order__signed-in strong {
-				font-weight: 400;
-				color: var( --wp-components-color-gray-800, #2f2f2f );
-			}
-			/* Figma 2392:15317 — 32px between the "signed in as …" line and the
-			   first cart row (vs. the default 24px from WPOrderReviewList), and
-			   drop the first row's top padding so the gap is exactly the list's
-			   margin, not stacked with the line item's own padding. Subsequent
-			   rows keep their 16px+16px rhythm; the last row drops its trailing
-			   padding so it sits flush against the section end. */
-			.wp-checkout__review-order-step .order-review-line-items {
-				margin-block-start: 32px;
-			}
-			.wp-checkout__review-order-step
-				.order-review-line-items
-				> li:first-child
-				.checkout-line-item {
-				padding-block-start: 0;
-			}
-			.wp-checkout__review-order-step .order-review-line-items > li:last-child .checkout-line-item {
-				padding-block-end: 0;
-			}
-			/* Figma 2392:15320 — product name typography. LineItemTitle is an
-			   unclassed styled.div; target it as the first child div of each
-			   line item. */
-			.wp-checkout__review-order-step .checkout-line-item > div:first-of-type {
-				font-size: 16px;
-				line-height: 24px;
-			}
-			/* Figma 2392:15321/15325/15326 — price typography:
-			   – Outer .checkout-line-item__price carries the "/mo" text node,
-			     so it gets the 13/regular/-0.08 cadence.
-			   – Inner LineItemPriceWrapper span (the actual amount + the
-			     <s> strikethrough) inherits up to 16/24/-0.32.
-			   – Strikethrough recolors to scales/grays/gray-700. */
-			.wp-checkout__review-order-step .checkout-line-item__price {
-				/* LineItemPriceWrapper is display:flex, so without making the
-				   outer span a flex container the sibling "/mo" text node ends
-				   up offset above the price baseline. */
-				display: flex;
-				align-items: baseline;
-				font-size: 13px;
-				line-height: 20px;
-				letter-spacing: -0.08px;
-				font-weight: 400;
-			}
-			.wp-checkout__review-order-step .checkout-line-item__price > span {
-				font-size: 16px;
-				line-height: 24px;
-				/* 8px between the strikethrough and the live price (Figma
-				   3838:3618 gap-[8px]); overrides LineItemPriceWrapper's
-				   default 4px gap. */
-				gap: 8px;
-			}
-			.wp-checkout__review-order-step .checkout-line-item__price > span > span {
-				font-weight: 500;
-			}
-			.wp-checkout__review-order-step .checkout-line-item__price > span > s {
-				color: var( --wp-components-color-gray-700, #757575 );
-			}
-			/* Figma 2392:15397 — "Remove plan/domain/email" link. */
-			.wp-checkout__review-order-step .checkout-line-item__remove-product {
-				font-size: 13px;
-				line-height: 20px;
-				font-weight: 400;
-				color: ${ colorStudio.colors[ 'Gray 100' ] };
-			}
-			/* "Have a coupon?" — match the secondary-link treatment above (Gray 100)
-			   instead of the lighter shared default, and drop the 24px area padding
-			   that leaves it stranded and inset from the rest of the column. */
-			.checkout__coupon-area {
-				padding-block: 8px;
-				padding-inline: 0;
-			}
-			.wp-checkout-order-review__show-coupon-field-button {
-				line-height: 20px;
-				color: ${ colorStudio.colors[ 'Gray 100' ] };
 			}
 		` }
 
@@ -1854,306 +2152,7 @@ const StepContainerV2CheckoutFixer = styled.div< {
 				padding-block-start: 24px;
 			}
 		` }
-	${ ( props ) =>
-		! props.isLargeViewport &&
-		props.isMobileCheckoutStickySummary &&
-		css`
-			/* Payment method card group — Figma 3971:13242. Container and
-			   divider borders track WPDS gray-200; the V1 baseline ships
-			   #e0e0e0 / #f0f0f0 — here both land on #e0e0e0 so the field
-			   reads as a single chrome instead of two tones. */
-			.checkout-payment-methods {
-				border-color: var( --wp-components-color-gray-200, #e0e0e0 );
-			}
-			.checkout-payment-methods .has-highlight {
-				border-bottom-color: var( --wp-components-color-gray-200, #e0e0e0 );
-			}
-			/* Selected row — Figma 3971:13243 — picks up a 4% Studio Blue
-			   tint on the background and an 8% Studio Blue inset border
-			   (drawn as a box-shadow so toggling selection doesn't shift
-			   the row by 1px). Drops V1's diagonal "selected" gradient. */
-			.checkout-payment-methods .has-highlight.is-checked {
-				background: rgba( 56, 88, 233, 0.04 );
-				box-shadow: inset 0 0 0 1px rgba( 56, 88, 233, 0.08 );
-			}
-			/* The composite-checkout primitive lays the Label out as a flex
-			   column with font-size 14px and min-height 72px below the
-			   400px smallPhoneUp breakpoint. The experiment runs on phones
-			   (small viewports) so lock to row + 13/52px (Figma 3971:13286
-			   row height) so each row matches Figma with logos sitting
-			   beside the title even on the narrowest devices. Font size
-			   lives here (not only in the V1 block) so mobile-sticky users
-			   on the non-V1 baseline still get 13px. */
-			.checkout-payment-methods .has-highlight > label {
-				min-height: 52px;
-				padding: 16px 16px 16px 48px;
-				flex-direction: row;
-				align-items: center;
-				justify-content: space-between;
-				gap: 16px;
-				font-size: 13px;
-				font-weight: 400;
-			}
-			.checkout-payment-methods .has-highlight > label::before {
-				left: 16px;
-			}
-			.checkout-payment-methods .has-highlight > label::after {
-				left: 20px;
-			}
-			.rtl .checkout-payment-methods .has-highlight > label {
-				padding: 16px 48px 16px 16px;
-			}
-			.rtl .checkout-payment-methods .has-highlight > label::before {
-				right: 16px;
-				left: auto;
-			}
-			.rtl .checkout-payment-methods .has-highlight > label::after {
-				right: 20px;
-				left: auto;
-			}
-			/* Brand logos render as 32x22 chips with a 4px radius and a
-			   1px gray-200 border (Figma 3971:13251 etc.). The brand SVG
-			   inside scales to fit the padded inner area while preserving
-			   its intrinsic aspect ratio (preserveAspectRatio defaults to
-			   xMidYMid meet, centering the path). PaymentMethodLogos spans
-			   render with either .credit-card__logos (credit card) or
-			   .payment-logos (PayPal, Bancontact, Apple Pay, etc.) — cover
-			   both. */
-			.checkout-payment-methods .credit-card__logos,
-			.checkout-payment-methods .payment-logos {
-				flex: 0 0 auto;
-				flex-wrap: nowrap;
-				gap: 4px;
-			}
-			.checkout-payment-methods .credit-card__logos svg,
-			.checkout-payment-methods .payment-logos svg {
-				background: ${ colorStudio.colors[ 'White' ] };
-				border: 1px solid var( --wp-components-color-gray-200, #e0e0e0 );
-				border-radius: 4px;
-				padding: 4px 6px;
-				box-sizing: border-box;
-				height: 22px;
-				width: 32px;
-			}
-			/* "+N" overflow pill — Figma 3971:13264. Same 32x22 chip
-			   silhouette as the brand logos, but the inner content is a
-			   centered 11px medium label instead of an SVG. */
-			.checkout-payment-methods .credit-card__logos-overflow {
-				display: inline-flex;
-				align-items: center;
-				justify-content: center;
-				min-width: 22px;
-				height: 22px;
-				padding: 0 6px;
-				background: ${ colorStudio.colors[ 'White' ] };
-				border: 1px solid var( --wp-components-color-gray-200, #e0e0e0 );
-				border-radius: 4px;
-				box-sizing: border-box;
-				font-size: 11px;
-				font-weight: 500;
-				line-height: 20px;
-				color: var( --wp-components-color-gray-900, #1e1e1e );
-				flex: 0 0 auto;
-			}
-			/* Lock icon at the end of the Card number input — Figma
-			   3971:13273. The StripeFieldWrapper.number is the chrome
-			   around Stripe's iframe; flatten it to a flex container,
-			   lift the visible border / padding / bg / height onto the
-			   wrapper itself, and zero out the inner StripeElement so
-			   only one chrome renders and the lock sits inside it. */
-			.credit-card-fields-inner-wrapper .number {
-				display: flex;
-				align-items: center;
-				gap: 8px;
-				height: 40px;
-				padding: 0 16px;
-				border: 1px solid ${ colorStudio.colors[ 'Gray 10' ] };
-				border-radius: 2px;
-				background: ${ colorStudio.colors[ 'White' ] };
-				box-sizing: border-box;
-			}
-			.credit-card-fields-inner-wrapper .number .StripeElement {
-				flex: 1 1 auto;
-				border: none;
-				padding: 0;
-				background: transparent;
-				height: auto;
-			}
-			.credit-card-fields-inner-wrapper .credit-card-number-field__lock-icon {
-				display: inline-flex;
-				align-items: center;
-				justify-content: center;
-				flex: 0 0 auto;
-				color: ${ colorStudio.colors[ 'Gray 100' ] };
-			}
-			.credit-card-fields-inner-wrapper .credit-card-number-field__brand-icon {
-				display: inline-flex;
-				align-items: center;
-				justify-content: center;
-				flex: 0 0 auto;
-				width: 25px;
-				height: 16px;
-			}
-			.credit-card-fields-inner-wrapper .credit-card-number-field__brand-icon img {
-				width: 100%;
-				height: 100%;
-				object-fit: contain;
-			}
-			/* Expiry + CVC + CVC card-back hint share one flex row under
-			   the experiment (Figma 3971:13274). Expiry and CVC each take
-			   1fr; the hint is a fixed 38px column with the card-back
-			   placeholder image rendered at 40px tall. */
-			.credit-card-fields-inner-wrapper .credit-card-fields__expiry-cvc-row {
-				display: flex;
-				gap: 8px;
-				align-items: flex-end;
-			}
-			.credit-card-fields-inner-wrapper .credit-card-fields__expiry-cvc-row > label {
-				flex: 1 1 0;
-				min-width: 0;
-			}
-			.credit-card-fields-inner-wrapper .credit-card-fields__cvc-hint {
-				display: flex;
-				flex: 0 0 38px;
-				width: 38px;
-				height: 40px;
-				align-items: center;
-				justify-content: center;
-			}
-			.credit-card-fields-inner-wrapper .credit-card-fields__cvc-hint svg,
-			.credit-card-fields-inner-wrapper .credit-card-fields__cvc-hint img {
-				width: 100%;
-				height: auto;
-				object-fit: contain;
-			}
-			/* "Use this payment method…" checkbox renders via WPDS
-			   CheckboxControl. The default --checkbox-input-size is 24px;
-			   Figma 3971:13283 specs it at 16×16. The token drives the
-			   input box, the check icon, and all hover/active outlines
-			   so a single override scales every part of the control
-			   without breaking states. */
-			.credit-card-fields-inner-wrapper
-				.assign-to-all-payment-methods-checkbox.components-checkbox-control {
-				--checkbox-input-size: 16px;
-			}
-			/* Expanded credit-card form sits 24px below the radio row
-			   (Figma 3971:13243 gap-[24px]). V1's wrapper rule already
-			   adds 16px padding on three sides; lift the top to 8px so
-			   the label's own 16px bottom padding sums to the 24px gap. */
-			div:has( > .credit-card-fields-inner-wrapper ) {
-				padding: 8px 16px 16px 16px;
-			}
-			/* Field rhythm matches the contact-information step — switch
-			   from CreditCardField / FieldRow's 16px margin-top to a flex
-			   column with a unified 16px gap so every field-to-field
-			   cadence lands on the same grid as the contact form. */
-			.credit-card-fields-inner-wrapper {
-				display: flex;
-				flex-direction: column;
-				gap: 16px;
-			}
-			.credit-card-fields-inner-wrapper > * {
-				margin-top: 0;
-			}
-			/* Field typography inside the credit-card form (Figma
-			   3971:13267–13276): labels 13/medium/Gray 100 with 6px below,
-			   inputs 40px tall with a 2px radius and Gray 10 border,
-			   descriptions 13/regular (not italic) with Gray 700 — Field
-			   from @automattic/wpcom-checkout renders its own emotion
-			   <label>/<input>/<p>, so we target by element rather than
-			   by class.
-
-			   Two label structures exist:
-			   - Field (Cardholder name): <label>text</label> as a sibling
-			     of the input.
-			   - Stripe (Card number / Expiry / CVC): <label><span>text</span>
-			     <wrapper>…</wrapper></label> — the span (LabelText) carries
-			     its own font + color from the styled-component, so we have
-			     to override on the span too. */
-			.credit-card-fields-inner-wrapper label,
-			.credit-card-fields-inner-wrapper label > span {
-				font-size: 13px;
-				line-height: 20px;
-				font-weight: 500;
-				color: ${ colorStudio.colors[ 'Gray 100' ] };
-			}
-			/* Gap between label text and its input — applies to both shapes
-			   (the span as the first child of a Stripe-label, the bare
-			   label as a sibling of the input for Field). */
-			.credit-card-fields-inner-wrapper label > span {
-				display: block;
-				margin-bottom: 6px;
-			}
-			.credit-card-fields-inner-wrapper > div > label[for] {
-				display: block;
-				margin-bottom: 6px;
-			}
-			/* Text-style inputs only — :not() excludes the "Use for all
-			   subscriptions" checkbox (and any stray radios), which would
-			   otherwise inherit the 40px height + 10/16 padding and render
-			   as a tall rectangle. White background re-establishes the
-			   field surface on top of the selected card's 4% blue tint. */
-			.credit-card-fields-inner-wrapper input:not( [type='checkbox'] ):not( [type='radio'] ) {
-				height: 40px;
-				font-size: 13px;
-				padding: 10px 16px;
-				border-radius: 2px;
-				border-color: ${ colorStudio.colors[ 'Gray 10' ] };
-				background: ${ colorStudio.colors[ 'White' ] };
-			}
-			/* Stripe Elements render in an iframe wrapped by a styled span;
-			   the wrapper's baseline is 12/14 padding + 16px font on a
-			   non-fixed height. Re-pin to match the Cardholder name input
-			   (40px tall, 10/16 padding, 2px radius, Gray 10 border, white
-			   bg) so card-number / expiry / CVC share the same rhythm. */
-			.credit-card-fields-inner-wrapper .StripeElement,
-			.credit-card-fields-inner-wrapper .stripe-element {
-				background: ${ colorStudio.colors[ 'White' ] };
-				height: 40px;
-				padding: 10px 16px;
-				border-radius: 2px;
-				border-color: ${ colorStudio.colors[ 'Gray 10' ] };
-				box-sizing: border-box;
-			}
-			/* Secure-encryption notice — Figma 3971:13239 — sits below the
-			   "Payment method" heading at 13/regular/Gray 60 with a 16px
-			   gap to the card group. The <p> is injected via
-			   activeStepContent above. */
-			.checkout__payment-method-step .checkout-payment-method__secure-notice {
-				font-size: 13px;
-				line-height: 20px;
-				font-weight: 400;
-				color: ${ colorStudio.colors[ 'Gray 60' ] };
-				margin: 0 0 16px;
-			}
-			.credit-card-fields-inner-wrapper p {
-				font-style: normal;
-				font-size: 13px;
-				line-height: 20px;
-				font-weight: 400;
-				color: ${ colorStudio.colors[ 'Gray 50' ] };
-				margin: 8px 0 0;
-			}
-			/* "Use this payment method for all subscriptions…" — the
-			   AssignToAllPaymentMethods checkbox uses WPDS' CheckboxControl
-			   whose label is informational text, not a field label. The
-			   broader label rule above paints field labels 13/medium/Gray
-			   100; restyle the checkbox label to 13/regular/Gray 50 so it
-			   reads as helper copy (Figma 3971:13285). Also reset the
-			   wrapper's margin-top to 0 — the inner-wrapper's flex+gap
-			   already supplies the 16px cadence. */
-			.credit-card-fields-inner-wrapper .components-checkbox-control label {
-				font-size: 13px;
-				line-height: 20px;
-				font-weight: 400;
-				color: ${ colorStudio.colors[ 'Gray 50' ] };
-				margin-bottom: 0;
-			}
-			.credit-card-fields-inner-wrapper .components-checkbox-control label a {
-				color: ${ colorStudio.colors[ 'Gray 100' ] };
-				text-decoration: underline;
-			}
-		` }
+	${ ( props ) => props.isMobileCheckoutStickySummary && mobileStickySummaryStyles }
 `;
 
 const CheckoutSummary = styled.div`

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -3080,8 +3080,10 @@ const WPCheckoutMainContent = styled.div< {
 				.components-h-stack {
 				align-items: center;
 			}
-			/* Figma 2392:15431 — all form labels render in Gray 100. */
-			.form-label {
+			/* Figma 2392:15431 — contact form labels render in Gray 100. Scoped to
+			   the contact step: the payment step's own labels are handled by the
+			   .credit-card-fields-inner-wrapper rules. */
+			.checkout-contact-form-step .form-label {
 				color: ${ colorStudio.colors[ 'Gray 100' ] };
 			}
 			/* The VAT form (Field from @automattic/wpcom-checkout) renders

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -113,6 +113,7 @@ import { handleProgressStepSelect } from './handle-progress-step-select';
 import JetpackAkismetCheckoutSidebarPlanUpsell from './jetpack-akismet-checkout-sidebar-plan-upsell';
 import { LeaveCheckoutModal, useCheckoutLeaveModal } from './leave-checkout-modal';
 import { MobileCheckoutStickySummary } from './mobile-checkout-sticky-summary';
+import { mobileCheckoutStickySummaryRadioDotStyles } from './mobile-checkout-sticky-summary-styles';
 import BeforeSubmitCheckoutHeader from './payment-method-step';
 import { PaymentMethodFilter } from './payment-methods-filter';
 import { getRefundWindowCopy } from './refund-policies';
@@ -1378,31 +1379,16 @@ const mobileCheckoutStickySummaryStyles = css`
 	   lives here (not only in the V1 block) so mobile-checkout-sticky-summary users
 	   on the non-V1 baseline still get 13px. */
 	.checkout-payment-methods .has-highlight > label {
+		${ mobileCheckoutStickySummaryRadioDotStyles }
 		min-height: 52px;
-		padding: 16px 16px 16px 48px;
+		padding-block: 16px;
+		padding-inline: 48px 16px;
 		flex-direction: row;
 		align-items: center;
 		justify-content: space-between;
 		gap: 16px;
 		font-size: 13px;
 		font-weight: 400;
-	}
-	.checkout-payment-methods .has-highlight > label::before {
-		left: 16px;
-	}
-	.checkout-payment-methods .has-highlight > label::after {
-		left: 20px;
-	}
-	.rtl .checkout-payment-methods .has-highlight > label {
-		padding: 16px 48px 16px 16px;
-	}
-	.rtl .checkout-payment-methods .has-highlight > label::before {
-		right: 16px;
-		left: auto;
-	}
-	.rtl .checkout-payment-methods .has-highlight > label::after {
-		right: 20px;
-		left: auto;
 	}
 	/* Brand logos render as 32x22 chips with a 4px radius and a
 	   1px gray-200 border (Figma 3971:13251 etc.). The brand SVG

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1296,10 +1296,8 @@ const mobileCheckoutStickySummaryStyles = css`
 	.wp-checkout__review-order-step .order-review-line-items > li:last-child .checkout-line-item {
 		padding-block-end: 0;
 	}
-	/* Figma 2392:15320 — product name typography. LineItemTitle is an
-	   unclassed styled.div; target it as the first child div of each
-	   line item. */
-	.wp-checkout__review-order-step .checkout-line-item > div:first-of-type {
+	/* Figma 2392:15320 — product name typography. */
+	.wp-checkout__review-order-step .checkout-line-item .checkout-line-item__title {
 		font-size: 16px;
 		line-height: 24px;
 	}
@@ -3091,29 +3089,20 @@ const WPCheckoutMainContent = styled.div< {
 			   FormFieldset is already flex-column but ships without a gap,
 			   and First/Last name is rendered as its sibling — not inside
 			   __contact-details. So the gap needs to live on all of:
-			   the outer FormFieldset, __contact-details itself, and the
-			   two un-classed wrapper divs from RegionAddressFieldsets. */
+			   the outer FormFieldset, __contact-details itself, and both
+			   wrapper divs from RegionAddressFieldsets. */
 			.form-fieldset.contact-details-form-fields,
 			.form-fieldset.contact-details-form-fields .contact-details-form-fields__contact-details,
-			.form-fieldset.contact-details-form-fields
-				.contact-details-form-fields__contact-details
-				> div:not( [class] ),
-			.form-fieldset.contact-details-form-fields
-				.contact-details-form-fields__contact-details
-				> div:not( [class] )
-				> div:not( [class] ) {
+			.form-fieldset.contact-details-form-fields .region-address-fieldsets,
+			.form-fieldset.contact-details-form-fields .region-address-fieldsets__street-address {
 				display: flex;
 				flex-direction: column;
 				gap: 16px;
 			}
-			/* …except the innermost RegionAddressFieldsets wrapper, which
-			   pairs an input with its toggle link ("+ Add Address Line 2")
-			   as a "Field + Action" group — Figma 2392:15432 puts those
-			   8px apart, not 16. */
-			.form-fieldset.contact-details-form-fields
-				.contact-details-form-fields__contact-details
-				> div:not( [class] )
-				> div:not( [class] ) {
+			/* …except the street-address wrapper, which pairs an input with its
+			   toggle link ("+ Add Address Line 2") as a "Field + Action" group —
+			   Figma 2392:15432 puts those 8px apart, not 16. */
+			.form-fieldset.contact-details-form-fields .region-address-fieldsets__street-address {
 				gap: 8px;
 			}
 			/* Same rhythm for the "Add organization name" row — it sits in

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1304,18 +1304,6 @@ const StepContainerV2CheckoutFixer = styled.div< {
 				padding-block: 2rem;
 			}
 
-			.checkout-contact-form-step {
-				padding-block: 0 32px;
-			}
-
-			.checkout__payment-method-step {
-				padding-block-start: 0;
-			}
-
-			.checkout-step.is-active.checkout__payment-method-step {
-				padding-bottom: 16px;
-			}
-
 			.checkout-steps__submit-button-wrapper {
 				max-width: 100%;
 				padding-inline: var( --step-container-v2-content-inline-padding );
@@ -1340,6 +1328,15 @@ const StepContainerV2CheckoutFixer = styled.div< {
 			}
 			.checkout__step-wrapper.checkout__step-wrapper--last-step {
 				margin-bottom: 0;
+			}
+			.checkout-contact-form-step {
+				padding-block: 0 32px;
+			}
+			.checkout__payment-method-step {
+				padding-block-start: 0;
+			}
+			.checkout-step.is-active.checkout__payment-method-step {
+				padding-bottom: 16px;
 			}
 			/* Figma 2392:15311/15425/15448 — under the mobile sticky experiment
 			   every step renders as a plain heading; the stepper circle (number

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -41,6 +41,7 @@ import { existingPayPalPPCPPrefix } from '../hooks/use-create-payment-methods/us
 import useCreatePaymentSubmittedAndProcessingCallback from '../hooks/use-create-payment-submitted-and-processing-callback';
 import useDetectedCountryCode from '../hooks/use-detected-country-code';
 import useGetThankYouUrl from '../hooks/use-get-thank-you-url';
+import { useMobileCheckoutStickySummaryExperiment } from '../hooks/use-mobile-checkout-sticky-summary-experiment';
 import usePrepareProductsForCart from '../hooks/use-prepare-products-for-cart';
 import useRecordCartLoaded from '../hooks/use-record-cart-loaded';
 import useRecordCheckoutLoaded from '../hooks/use-record-checkout-loaded';
@@ -655,6 +656,8 @@ export default function CheckoutMain( {
 
 	const isCheckoutV2ExperimentLoading = false;
 	const [ isCheckoutUiRedesignLoading ] = useCheckoutUiRedesignExperiment();
+	const { isLoading: isMobileCheckoutStickySummaryLoading } =
+		useMobileCheckoutStickySummaryExperiment();
 
 	// This variable determines if we see the loading page or if checkout can
 	// render its steps.
@@ -680,7 +683,10 @@ export default function CheckoutMain( {
 		},
 		{ name: translate( 'Loading countries list' ), isLoading: countriesList.length < 1 },
 		{ name: translate( 'Loading Site' ), isLoading: isCheckoutV2ExperimentLoading },
-		{ name: translate( 'Loading checkout' ), isLoading: isCheckoutUiRedesignLoading },
+		{
+			name: translate( 'Loading checkout' ),
+			isLoading: isCheckoutUiRedesignLoading || isMobileCheckoutStickySummaryLoading,
+		},
 	];
 
 	if ( shouldSetMigrationSticker ) {

--- a/client/my-sites/checkout/src/components/checkout-submit-button-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-submit-button-content.tsx
@@ -3,8 +3,10 @@ import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled } from '@automattic/wpcom-checkout';
 import { sprintf } from '@wordpress/i18n';
+import { Icon, lock } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import useCartKey from '../../use-cart-key';
+import { useMobileCheckoutStickySummaryExperiment } from '../hooks/use-mobile-checkout-sticky-summary-experiment';
 
 const CreditCardPayButtonWrapper = styled.span`
 	display: inline-flex;
@@ -18,6 +20,22 @@ const StyledMaterialIcon = styled( MaterialIcon )`
 	.rtl & {
 		margin-right: 0;
 		margin-left: 0.7em;
+	}
+`;
+
+const StickyPayButtonWrapper = styled.span`
+	display: inline-flex;
+	align-items: center;
+`;
+
+const StyledLockIcon = styled( Icon )`
+	fill: ${ ( { theme } ) => theme.colors.surface };
+	margin-inline-end: 0.5em;
+
+	/* The composite-checkout button nudges every svg down 2px to baseline-align
+	   its MaterialIcon; neutralise that so the lock centres with the label. */
+	&& {
+		transform: none;
 	}
 `;
 
@@ -35,6 +53,7 @@ export function CheckoutSubmitButtonContent( { last4 }: { last4?: string } = {} 
 	const { responseCart } = useShoppingCart( cartKey );
 	const isPurchaseFree = responseCart.total_cost_integer === 0;
 	const { formStatus } = useFormStatus();
+	const { isMobileCheckoutStickySummary } = useMobileCheckoutStickySummaryExperiment();
 
 	if ( formStatus === FormStatus.SUBMITTING ) {
 		return <>{ __( 'Processing…' ) }</>;
@@ -44,6 +63,24 @@ export function CheckoutSubmitButtonContent( { last4 }: { last4?: string } = {} 
 		return <>{ __( 'Please wait…' ) }</>;
 	}
 
+	const payNowLabel = last4
+		? sprintf(
+				/* translators: %s is the masked saved card number, e.g. "**** 3220" */
+				__( 'Pay with %s' ),
+				/* translators: %s is the last 4 digits of the credit card number */
+				sprintf( _x( '**** %s', 'Masked credit card number' ), last4 )
+		  )
+		: __( 'Pay now' );
+
+	if ( isMobileCheckoutStickySummary ) {
+		return (
+			<StickyPayButtonWrapper>
+				<StyledLockIcon icon={ lock } size={ 20 } />
+				{ isPurchaseFree ? __( 'Complete Checkout' ) : payNowLabel }
+			</StickyPayButtonWrapper>
+		);
+	}
+
 	if ( isPurchaseFree ) {
 		return <CreditCardPayButtonWrapper>{ __( 'Complete Checkout' ) }</CreditCardPayButtonWrapper>;
 	}
@@ -51,14 +88,7 @@ export function CheckoutSubmitButtonContent( { last4 }: { last4?: string } = {} 
 	return (
 		<CreditCardPayButtonWrapper>
 			<StyledMaterialIcon icon="credit_card" />
-			{ last4
-				? sprintf(
-						/* translators: %s is the masked saved card number, e.g. "**** 3220" */
-						__( 'Pay with %s' ),
-						/* translators: %s is the last 4 digits of the credit card number */
-						sprintf( _x( '**** %s', 'Masked credit card number' ), last4 )
-				  )
-				: __( 'Pay now' ) }
+			{ payNowLabel }
 		</CreditCardPayButtonWrapper>
 	);
 }

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -441,7 +441,7 @@ function getItemSubtotalExcludingCoupon( product: ResponseCartProduct ): number 
  * it's just the result of comparing the prices of the annual to the monthly
  * product.
  */
-function getLineItemPriceDisplay(
+export function getLineItemPriceDisplay(
 	product: ResponseCartProduct,
 	responseCart: ResponseCart,
 	monthlyPrices: Record< string, number >

--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-radio-buttons.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-radio-buttons.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, type FunctionComponent } from 'react';
+import { mobileCheckoutStickySummaryRadioDotStyles } from 'calypso/my-sites/checkout/src/components/mobile-checkout-sticky-summary-styles';
 import { useMobileCheckoutStickySummaryExperiment } from 'calypso/my-sites/checkout/src/hooks/use-mobile-checkout-sticky-summary-experiment';
 import { ItemVariantRadioPrice } from './variant-radio-price';
 import type { ItemVariationPickerProps, WPCOMProductVariant, OnChangeItemVariant } from './types';
@@ -49,6 +50,7 @@ const TermOptionsItem = styled.li`
 
 	/* Tighten the label and reposition the radio dot to the Figma's 16px gutter. */
 	.is-mobile-checkout-sticky-summary & label {
+		${ mobileCheckoutStickySummaryRadioDotStyles }
 		padding-block: 16px;
 		padding-inline-start: 40px;
 		padding-inline-end: 16px;
@@ -57,19 +59,6 @@ const TermOptionsItem = styled.li`
 		font-size: 16px;
 		line-height: 24px;
 		color: var( --studio-gray-100 );
-	}
-
-	.is-mobile-checkout-sticky-summary & label::before {
-		inset-inline-start: 16px;
-		inset-block-start: 50%;
-		transform: translateY( -50% );
-	}
-
-	.is-mobile-checkout-sticky-summary & label::after {
-		inset-inline-start: 20px;
-		inset-block-start: 50%;
-		margin-block-start: 0;
-		transform: translateY( -50% );
 	}
 `;
 

--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-radio-buttons.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-radio-buttons.tsx
@@ -13,7 +13,7 @@ const TermOptions = styled.ul`
 	margin: 20px 0;
 	padding: 0;
 
-	&.is-mobile-sticky-summary {
+	&.is-mobile-checkout-sticky-summary {
 		background: var( --color-surface );
 		border: 1px solid var( --studio-gray-5 );
 		border-radius: 8px;
@@ -30,25 +30,25 @@ const TermOptionsItem = styled.li`
 		margin-top: 0;
 	}
 
-	.is-mobile-sticky-summary & {
+	.is-mobile-checkout-sticky-summary & {
 		margin: 0;
 	}
 
-	.is-mobile-sticky-summary &:not( :last-of-type ) {
+	.is-mobile-checkout-sticky-summary &:not( :last-of-type ) {
 		border-block-end: 1px solid var( --studio-gray-5 );
 	}
 
 	/* Flatten the per-row card border from RadioButton — the ul is the card now. */
-	.is-mobile-sticky-summary & .has-highlight {
+	.is-mobile-checkout-sticky-summary & .has-highlight {
 		border-radius: 0;
 	}
-	.is-mobile-sticky-summary & .has-highlight::before,
-	.is-mobile-sticky-summary & .has-highlight:hover::before {
+	.is-mobile-checkout-sticky-summary & .has-highlight::before,
+	.is-mobile-checkout-sticky-summary & .has-highlight:hover::before {
 		border: none;
 	}
 
 	/* Tighten the label and reposition the radio dot to the Figma's 16px gutter. */
-	.is-mobile-sticky-summary & label {
+	.is-mobile-checkout-sticky-summary & label {
 		padding-block: 16px;
 		padding-inline-start: 40px;
 		padding-inline-end: 16px;
@@ -59,13 +59,13 @@ const TermOptionsItem = styled.li`
 		color: var( --studio-gray-100 );
 	}
 
-	.is-mobile-sticky-summary & label::before {
+	.is-mobile-checkout-sticky-summary & label::before {
 		inset-inline-start: 16px;
 		inset-block-start: 50%;
 		transform: translateY( -50% );
 	}
 
-	.is-mobile-sticky-summary & label::after {
+	.is-mobile-checkout-sticky-summary & label::after {
 		inset-inline-start: 20px;
 		inset-block-start: 50%;
 		margin-block-start: 0;
@@ -124,8 +124,7 @@ export const ItemVariationRadioButtons: FunctionComponent< ItemVariationPickerPr
 	variants,
 } ) => {
 	const translate = useTranslate();
-	const { isMobileCheckoutStickySummary: isMobileStickySummary } =
-		useMobileCheckoutStickySummaryExperiment();
+	const { isMobileCheckoutStickySummary } = useMobileCheckoutStickySummaryExperiment();
 	const [ optimisticSelectedItem, setOptimisticSelectedItem ] = useState(
 		selectedItem.product_slug
 	);
@@ -150,7 +149,7 @@ export const ItemVariationRadioButtons: FunctionComponent< ItemVariationPickerPr
 			role="radiogroup"
 			aria-label={ translate( 'Pick a product term' ) }
 			className={ clsx( 'item-variation-picker', {
-				'is-mobile-sticky-summary': isMobileStickySummary,
+				'is-mobile-checkout-sticky-summary': isMobileCheckoutStickySummary,
 			} ) }
 		>
 			{ variants.map( ( productVariant: WPCOMProductVariant ) => (

--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-radio-buttons.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-radio-buttons.tsx
@@ -1,7 +1,9 @@
 import { RadioButton } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, type FunctionComponent } from 'react';
+import { useMobileCheckoutStickySummaryExperiment } from 'calypso/my-sites/checkout/src/hooks/use-mobile-checkout-sticky-summary-experiment';
 import { ItemVariantRadioPrice } from './variant-radio-price';
 import type { ItemVariationPickerProps, WPCOMProductVariant, OnChangeItemVariant } from './types';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
@@ -10,6 +12,13 @@ const TermOptions = styled.ul`
 	flex-basis: 100%;
 	margin: 20px 0;
 	padding: 0;
+
+	&.is-mobile-sticky-summary {
+		background: var( --color-surface );
+		border: 1px solid var( --studio-gray-5 );
+		border-radius: 8px;
+		overflow: hidden;
+	}
 `;
 
 const TermOptionsItem = styled.li`
@@ -19,6 +28,48 @@ const TermOptionsItem = styled.li`
 
 	:first-of-type {
 		margin-top: 0;
+	}
+
+	.is-mobile-sticky-summary & {
+		margin: 0;
+	}
+
+	.is-mobile-sticky-summary &:not( :last-of-type ) {
+		border-block-end: 1px solid var( --studio-gray-5 );
+	}
+
+	/* Flatten the per-row card border from RadioButton — the ul is the card now. */
+	.is-mobile-sticky-summary & .has-highlight {
+		border-radius: 0;
+	}
+	.is-mobile-sticky-summary & .has-highlight::before,
+	.is-mobile-sticky-summary & .has-highlight:hover::before {
+		border: none;
+	}
+
+	/* Tighten the label and reposition the radio dot to the Figma's 16px gutter. */
+	.is-mobile-sticky-summary & label {
+		padding-block: 16px;
+		padding-inline-start: 40px;
+		padding-inline-end: 16px;
+		min-height: 0;
+		gap: 8px;
+		font-size: 16px;
+		line-height: 24px;
+		color: var( --studio-gray-100 );
+	}
+
+	.is-mobile-sticky-summary & label::before {
+		inset-inline-start: 16px;
+		inset-block-start: 50%;
+		transform: translateY( -50% );
+	}
+
+	.is-mobile-sticky-summary & label::after {
+		inset-inline-start: 20px;
+		inset-block-start: 50%;
+		margin-block-start: 0;
+		transform: translateY( -50% );
 	}
 `;
 
@@ -54,7 +105,9 @@ const ProductVariant: FunctionComponent< ProductVariantProps > = ( {
 				checked={ isChecked }
 				disabled={ isDisabled }
 				onChange={ () => {
-					! isDisabled && onChangeItemVariant( selectedItem.uuid, productSlug, productId );
+					if ( ! isDisabled ) {
+						onChangeItemVariant( selectedItem.uuid, productSlug, productId );
+					}
 				} }
 				label={ <ItemVariantRadioPrice variant={ productVariant } compareTo={ compareTo } /> }
 				highlighted
@@ -71,6 +124,8 @@ export const ItemVariationRadioButtons: FunctionComponent< ItemVariationPickerPr
 	variants,
 } ) => {
 	const translate = useTranslate();
+	const { isMobileCheckoutStickySummary: isMobileStickySummary } =
+		useMobileCheckoutStickySummaryExperiment();
 	const [ optimisticSelectedItem, setOptimisticSelectedItem ] = useState(
 		selectedItem.product_slug
 	);
@@ -94,7 +149,9 @@ export const ItemVariationRadioButtons: FunctionComponent< ItemVariationPickerPr
 		<TermOptions
 			role="radiogroup"
 			aria-label={ translate( 'Pick a product term' ) }
-			className="item-variation-picker"
+			className={ clsx( 'item-variation-picker', {
+				'is-mobile-sticky-summary': isMobileStickySummary,
+			} ) }
 		>
 			{ variants.map( ( productVariant: WPCOMProductVariant ) => (
 				<ProductVariant

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
@@ -14,7 +14,7 @@ import { useMobileCheckoutStickySummaryExperiment } from 'calypso/my-sites/check
 import useCartKey from '../../../use-cart-key';
 import type { WPCOMProductVariant } from './types';
 
-const Discount = styled.span< { isMobileStickySummary?: boolean } >`
+const Discount = styled.span< { isMobileCheckoutStickySummary?: boolean } >`
 	text-align: center;
 	color: ${ colorStudio.colors[ 'Green 80' ] };
 
@@ -31,7 +31,7 @@ const Discount = styled.span< { isMobileStickySummary?: boolean } >`
 	}
 
 	${ ( props ) =>
-		props.isMobileStickySummary &&
+		props.isMobileCheckoutStickySummary &&
 		`
 		color: ${ colorStudio.colors[ 'Green 80' ] };
 		background-color: rgba( 184, 230, 191, 0.68 );
@@ -44,11 +44,14 @@ const Discount = styled.span< { isMobileStickySummary?: boolean } >`
 	` }
 `;
 
-const Price = styled.span< { isCheckoutUiRedesignV1?: boolean; isMobileStickySummary?: boolean } >`
+const Price = styled.span< {
+	isCheckoutUiRedesignV1?: boolean;
+	isMobileCheckoutStickySummary?: boolean;
+} >`
 	color: ${ colorStudio.colors[ 'Black' ] };
 	${ ( props ) => props.isCheckoutUiRedesignV1 && 'padding-right: 6px;' }
 	${ ( props ) =>
-		props.isMobileStickySummary &&
+		props.isMobileCheckoutStickySummary &&
 		`
 		color: var( --studio-gray-100 );
 		font-size: 13px;
@@ -61,7 +64,7 @@ const PriceSuffix = styled.span`
 	font-weight: 400;
 `;
 
-const Variant = styled.div< { isMobileStickySummary?: boolean } >`
+const Variant = styled.div< { isMobileCheckoutStickySummary?: boolean } >`
 	align-items: center;
 	display: flex;
 	font-size: 16px;
@@ -71,7 +74,7 @@ const Variant = styled.div< { isMobileStickySummary?: boolean } >`
 	width: 100%;
 
 	${ ( props ) =>
-		props.isMobileStickySummary &&
+		props.isMobileCheckoutStickySummary &&
 		`
 		color: var( --studio-gray-100 );
 		font-size: 13px;
@@ -104,11 +107,11 @@ const PriceArea = styled.span< { inlineDiscount?: boolean; isCheckoutUiRedesignV
 
 const DiscountPercentage: FunctionComponent< {
 	percent: number;
-	isMobileStickySummary?: boolean;
-} > = ( { percent, isMobileStickySummary } ) => {
+	isMobileCheckoutStickySummary?: boolean;
+} > = ( { percent, isMobileCheckoutStickySummary } ) => {
 	const translate = useTranslate();
 	return (
-		<Discount isMobileStickySummary={ isMobileStickySummary }>
+		<Discount isMobileCheckoutStickySummary={ isMobileCheckoutStickySummary }>
 			{ translate( 'Save %(percent)s%%', {
 				args: {
 					percent,
@@ -127,8 +130,7 @@ export const ItemVariantRadioPrice: FunctionComponent< {
 	const { couponStatus } = useShoppingCart( cartKey );
 	const isApplyingCoupon = couponStatus === 'pending';
 	const [ , isCheckoutUiRedesignV1 ] = useCheckoutUiRedesignExperiment();
-	const { isMobileCheckoutStickySummary: isMobileStickySummary } =
-		useMobileCheckoutStickySummaryExperiment();
+	const { isMobileCheckoutStickySummary } = useMobileCheckoutStickySummaryExperiment();
 	const compareToInfo = compareTo ? fromVariantPriceData( compareTo ) : null;
 	const variantInfo = fromVariantPriceData( variant );
 	const discountPercentage = compareToInfo
@@ -152,7 +154,7 @@ export const ItemVariantRadioPrice: FunctionComponent< {
 	} );
 
 	const priceDisplay = ( () => {
-		if ( isMobileStickySummary ) {
+		if ( isMobileCheckoutStickySummary ) {
 			// Render the suffix in its own span so the medium weight on
 			// <Price> doesn't bleed into "/mo" (Figma 2392:15326 wants
 			// regular).
@@ -179,9 +181,9 @@ export const ItemVariantRadioPrice: FunctionComponent< {
 	const label =
 		variant.termIntervalInMonths === 1 ? translate( 'Month' ) : variant.variantLabel.noun;
 	const showInlineDiscount =
-		( isCheckoutUiRedesignV1 || isMobileStickySummary ) && discountPercentage > 0;
+		( isCheckoutUiRedesignV1 || isMobileCheckoutStickySummary ) && discountPercentage > 0;
 	return (
-		<Variant isMobileStickySummary={ isMobileStickySummary }>
+		<Variant isMobileCheckoutStickySummary={ isMobileCheckoutStickySummary }>
 			<VariantTermLabel isCheckoutUiRedesignV1={ isCheckoutUiRedesignV1 }>
 				{ label }
 			</VariantTermLabel>
@@ -196,18 +198,18 @@ export const ItemVariantRadioPrice: FunctionComponent< {
 						{ showInlineDiscount && (
 							<DiscountPercentage
 								percent={ discountPercentage }
-								isMobileStickySummary={ isMobileStickySummary }
+								isMobileCheckoutStickySummary={ isMobileCheckoutStickySummary }
 							/>
 						) }
 						<Price
 							isCheckoutUiRedesignV1={ isCheckoutUiRedesignV1 }
-							isMobileStickySummary={ isMobileStickySummary }
+							isMobileCheckoutStickySummary={ isMobileCheckoutStickySummary }
 						>
 							{ priceDisplay }
 						</Price>
-						{ ! isCheckoutUiRedesignV1 && ! isMobileStickySummary && discountPercentage > 0 && (
-							<DiscountPercentage percent={ discountPercentage } />
-						) }
+						{ ! isCheckoutUiRedesignV1 &&
+							! isMobileCheckoutStickySummary &&
+							discountPercentage > 0 && <DiscountPercentage percent={ discountPercentage } /> }
 					</>
 				) }
 			</PriceArea>

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
@@ -10,10 +10,11 @@ import { LoadingCopy, styled } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { useCheckoutUiRedesignExperiment } from 'calypso/my-sites/checkout/src/hooks/use-checkout-ui-redesign-experiment';
+import { useMobileCheckoutStickySummaryExperiment } from 'calypso/my-sites/checkout/src/hooks/use-mobile-checkout-sticky-summary-experiment';
 import useCartKey from '../../../use-cart-key';
 import type { WPCOMProductVariant } from './types';
 
-const Discount = styled.span`
+const Discount = styled.span< { isMobileStickySummary?: boolean } >`
 	text-align: center;
 	color: ${ colorStudio.colors[ 'Green 80' ] };
 
@@ -28,14 +29,39 @@ const Discount = styled.span`
 		margin-right: 0;
 		margin-left: 8px;
 	}
+
+	${ ( props ) =>
+		props.isMobileStickySummary &&
+		`
+		color: ${ colorStudio.colors[ 'Green 80' ] };
+		background-color: rgba( 184, 230, 191, 0.68 );
+		border: 1px solid rgba( 0, 0, 0, 0.08 );
+		border-radius: 2px;
+		padding: 0 8px;
+		font-size: 11px;
+		font-weight: 500;
+		letter-spacing: -0.08px;
+	` }
 `;
 
-const Price = styled.span< { isCheckoutUiRedesignV1?: boolean } >`
+const Price = styled.span< { isCheckoutUiRedesignV1?: boolean; isMobileStickySummary?: boolean } >`
 	color: ${ colorStudio.colors[ 'Black' ] };
 	${ ( props ) => props.isCheckoutUiRedesignV1 && 'padding-right: 6px;' }
+	${ ( props ) =>
+		props.isMobileStickySummary &&
+		`
+		color: var( --studio-gray-100 );
+		font-size: 13px;
+		font-weight: 500;
+		line-height: 20px;
+	` }
 `;
 
-const Variant = styled.div`
+const PriceSuffix = styled.span`
+	font-weight: 400;
+`;
+
+const Variant = styled.div< { isMobileStickySummary?: boolean } >`
 	align-items: center;
 	display: flex;
 	font-size: 16px;
@@ -43,6 +69,14 @@ const Variant = styled.div`
 	justify-content: space-between;
 	line-height: 24px;
 	width: 100%;
+
+	${ ( props ) =>
+		props.isMobileStickySummary &&
+		`
+		color: var( --studio-gray-100 );
+		font-size: 13px;
+		line-height: 20px;
+	` }
 `;
 
 const VariantTermLabel = styled.span< { isCheckoutUiRedesignV1?: boolean } >`
@@ -68,10 +102,13 @@ const PriceArea = styled.span< { inlineDiscount?: boolean; isCheckoutUiRedesignV
 	` }
 `;
 
-const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent } ) => {
+const DiscountPercentage: FunctionComponent< {
+	percent: number;
+	isMobileStickySummary?: boolean;
+} > = ( { percent, isMobileStickySummary } ) => {
 	const translate = useTranslate();
 	return (
-		<Discount>
+		<Discount isMobileStickySummary={ isMobileStickySummary }>
 			{ translate( 'Save %(percent)s%%', {
 				args: {
 					percent,
@@ -90,6 +127,8 @@ export const ItemVariantRadioPrice: FunctionComponent< {
 	const { couponStatus } = useShoppingCart( cartKey );
 	const isApplyingCoupon = couponStatus === 'pending';
 	const [ , isCheckoutUiRedesignV1 ] = useCheckoutUiRedesignExperiment();
+	const { isMobileCheckoutStickySummary: isMobileStickySummary } =
+		useMobileCheckoutStickySummaryExperiment();
 	const compareToInfo = compareTo ? fromVariantPriceData( compareTo ) : null;
 	const variantInfo = fromVariantPriceData( variant );
 	const discountPercentage = compareToInfo
@@ -113,6 +152,17 @@ export const ItemVariantRadioPrice: FunctionComponent< {
 	} );
 
 	const priceDisplay = ( () => {
+		if ( isMobileStickySummary ) {
+			// Render the suffix in its own span so the medium weight on
+			// <Price> doesn't bleed into "/mo" (Figma 2392:15326 wants
+			// regular).
+			return (
+				<>
+					{ pricePerMonthFormatted }
+					<PriceSuffix>{ translate( '/mo' ) }</PriceSuffix>
+				</>
+			);
+		}
 		if ( isCheckoutUiRedesignV1 ) {
 			return translate( '%(pricePerMonth)s/mo', {
 				args: {
@@ -128,24 +178,34 @@ export const ItemVariantRadioPrice: FunctionComponent< {
 	} )();
 	const label =
 		variant.termIntervalInMonths === 1 ? translate( 'Month' ) : variant.variantLabel.noun;
+	const showInlineDiscount =
+		( isCheckoutUiRedesignV1 || isMobileStickySummary ) && discountPercentage > 0;
 	return (
-		<Variant>
+		<Variant isMobileStickySummary={ isMobileStickySummary }>
 			<VariantTermLabel isCheckoutUiRedesignV1={ isCheckoutUiRedesignV1 }>
 				{ label }
 			</VariantTermLabel>
 			<PriceArea
-				inlineDiscount={ isCheckoutUiRedesignV1 && discountPercentage > 0 }
+				inlineDiscount={ showInlineDiscount }
 				isCheckoutUiRedesignV1={ isCheckoutUiRedesignV1 }
 			>
 				{ isApplyingCoupon ? (
 					<LoadingCopy width="70px" height="16px" noMargin />
 				) : (
 					<>
-						{ isCheckoutUiRedesignV1 && discountPercentage > 0 && (
-							<DiscountPercentage percent={ discountPercentage } />
+						{ showInlineDiscount && (
+							<DiscountPercentage
+								percent={ discountPercentage }
+								isMobileStickySummary={ isMobileStickySummary }
+							/>
 						) }
-						<Price isCheckoutUiRedesignV1={ isCheckoutUiRedesignV1 }>{ priceDisplay }</Price>
-						{ ! isCheckoutUiRedesignV1 && discountPercentage > 0 && (
+						<Price
+							isCheckoutUiRedesignV1={ isCheckoutUiRedesignV1 }
+							isMobileStickySummary={ isMobileStickySummary }
+						>
+							{ priceDisplay }
+						</Price>
+						{ ! isCheckoutUiRedesignV1 && ! isMobileStickySummary && discountPercentage > 0 && (
 							<DiscountPercentage percent={ discountPercentage } />
 						) }
 					</>

--- a/client/my-sites/checkout/src/components/mobile-checkout-sticky-summary-styles.ts
+++ b/client/my-sites/checkout/src/components/mobile-checkout-sticky-summary-styles.ts
@@ -1,0 +1,34 @@
+import { css } from '@emotion/react';
+
+/**
+ * Repositions the radio dot drawn by composite-checkout's `RadioButton` into the
+ * 16px gutter the mobile sticky summary experiment uses, and centres it in the
+ * row.
+ *
+ * The primitive draws the outer circle as `label::before` and the inner dot as
+ * `label::after`, positioned with physical `left` plus a `.rtl &` block that
+ * swaps to `right`. Logical properties handle both directions on their own, so
+ * `inset-inline-end: auto` is all that is needed to clear whichever physical
+ * side the primitive set. Callers select the label; both of the experiment's
+ * selectors are one element more specific than the primitive's `.rtl &` rule, so
+ * this wins the cascade in RTL too.
+ *
+ * Row padding is deliberately not included — the payment-method rows and the
+ * term-variation rows use different inline padding.
+ */
+export const mobileCheckoutStickySummaryRadioDotStyles = css`
+	&::before {
+		inset-inline-start: 16px;
+		inset-inline-end: auto;
+		inset-block-start: 50%;
+		transform: translateY( -50% );
+	}
+
+	&::after {
+		inset-inline-start: 20px;
+		inset-inline-end: auto;
+		inset-block-start: 50%;
+		margin-block-start: 0;
+		transform: translateY( -50% );
+	}
+`;

--- a/client/my-sites/checkout/src/components/mobile-checkout-sticky-summary.tsx
+++ b/client/my-sites/checkout/src/components/mobile-checkout-sticky-summary.tsx
@@ -18,7 +18,7 @@ import { useTranslate } from 'i18n-calypso';
 import { Fragment, useId, useState } from 'react';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import useEquivalentMonthlyTotals, {
-	getSimulatedCostBeforeDiscounts,
+	getSubtotalBeforeDiscounts,
 } from 'calypso/my-sites/checkout/utils/use-equivalent-monthly-totals';
 import { useSubmitButtonSlot } from '../lib/submit-button-slot';
 import { getLineItemPriceDisplay } from './cost-overrides-list';
@@ -342,11 +342,7 @@ export function MobileCheckoutStickySummary() {
 	const monthlyPrices = useEquivalentMonthlyTotals( responseCart.products );
 	// The crossed-out total uses control's subtotal-before-discounts basis, so the
 	// bar and the panel quote the same numbers.
-	const subtotalBeforeDiscounts = responseCart.products.reduce( ( subtotal, product ) => {
-		const originalAmountInteger = getSimulatedCostBeforeDiscounts( product, monthlyPrices );
-		// In specific cases (e.g. premium domains) the original price (renewal) is lower than the due price.
-		return subtotal + Math.max( product.item_subtotal_integer, originalAmountInteger );
-	}, 0 );
+	const subtotalBeforeDiscounts = getSubtotalBeforeDiscounts( responseCart, monthlyPrices );
 	const crossedOutTotal =
 		subtotalBeforeDiscounts > responseCart.sub_total_integer
 			? formatCurrency( subtotalBeforeDiscounts, responseCart.currency, {

--- a/client/my-sites/checkout/src/components/mobile-checkout-sticky-summary.tsx
+++ b/client/my-sites/checkout/src/components/mobile-checkout-sticky-summary.tsx
@@ -1,0 +1,412 @@
+import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
+import { formatCurrency } from '@automattic/number-formatters';
+import { useShoppingCart, type ResponseCart } from '@automattic/shopping-cart';
+import {
+	filterCostOverridesForLineItem,
+	getCouponLineItemFromCart,
+	getCreditsLineItemFromCart,
+	getLabel,
+	getTaxBreakdownLineItemsFromCart,
+	getTotalLineItemFromCart,
+	isBillingInfoEmpty,
+	LineItemBillingInterval,
+	LineItemPrice,
+} from '@automattic/wpcom-checkout';
+import styled from '@emotion/styled';
+import { Icon, chevronUp } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { Fragment, useId, useState } from 'react';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import useEquivalentMonthlyTotals, {
+	getSimulatedCostBeforeDiscounts,
+} from 'calypso/my-sites/checkout/utils/use-equivalent-monthly-totals';
+import { useSubmitButtonSlot } from '../lib/submit-button-slot';
+import { getLineItemPriceDisplay } from './cost-overrides-list';
+import { PriceLoadingIndicator } from './wp-checkout-order-summary';
+
+const Wrapper = styled.div`
+	position: fixed;
+	inset-block-end: 0;
+	inset-inline-start: 0;
+	inset-inline-end: 0;
+	z-index: 100;
+	background: var( --color-surface );
+	border-block-start: 1px solid var( --color-border-subtle );
+	/* Lift the bar off the content it overlaps, same shadow as the native fixed
+	   submit bar. Kept in both states so the sheet reads as one raised surface. */
+	box-shadow: 0 -3px 10px 0 #0000001f;
+	padding: 16px;
+	display: flex;
+	flex-direction: column;
+`;
+
+const Panel = styled.div< { isOpen: boolean } >`
+	display: grid;
+	grid-template-rows: ${ ( props ) => ( props.isOpen ? '1fr' : '0fr' ) };
+	inline-size: 100%;
+	transition: grid-template-rows 300ms cubic-bezier( 0.16, 1, 0.3, 1 );
+
+	@media ( prefers-reduced-motion: reduce ) {
+		transition-duration: 1ms;
+	}
+`;
+
+const PanelInner = styled.div< { isOpen: boolean } >`
+	min-block-size: 0;
+	overflow: hidden;
+	opacity: ${ ( props ) => ( props.isOpen ? 1 : 0 ) };
+	transform: translateY( ${ ( props ) => ( props.isOpen ? '0' : '6px' ) } );
+	transition:
+		opacity 220ms ease,
+		transform 300ms cubic-bezier( 0.16, 1, 0.3, 1 );
+
+	@media ( prefers-reduced-motion: reduce ) {
+		transition-duration: 1ms;
+	}
+`;
+
+const ToggleRow = styled.button`
+	appearance: none;
+	background: none;
+	border: none;
+	padding: 0;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	inline-size: 100%;
+	color: var( --studio-gray-100 );
+	font-size: 20px;
+	font-weight: 500;
+	line-height: 26px;
+	letter-spacing: 0.38px;
+	text-align: start;
+
+	s {
+		font-weight: 400;
+		color: var( --studio-gray-50 );
+	}
+
+	&:focus-visible {
+		outline: 2px solid var( --color-primary );
+		outline-offset: 2px;
+		border-radius: 4px;
+	}
+`;
+
+const ChevronWrapper = styled.span< { isOpen: boolean } >`
+	flex-shrink: 0;
+	display: inline-flex;
+	color: var( --studio-gray-100 );
+	transition: transform 350ms cubic-bezier( 0.34, 1.56, 0.64, 1 );
+	transform: ${ ( props ) => ( props.isOpen ? 'rotate(180deg)' : 'rotate(0deg)' ) };
+
+	@media ( prefers-reduced-motion: reduce ) {
+		transition-duration: 1ms;
+	}
+`;
+
+const SubmitRow = styled.div`
+	inline-size: 100%;
+	margin-block-start: 16px;
+
+	.checkout-steps__submit-button-wrapper {
+		padding: 0;
+		inline-size: 100%;
+	}
+
+	/* The terms line rides the header slot, above the CTA, left-aligned. Its wrapper
+	   is display:none until a '.checkout__step-wrapper--last-step' ancestor reveals
+	   it; the portal moves it out of that ancestor, so reveal it here. (The
+	   money-back guarantee is surfaced up in the payment step, not below the CTA.) */
+	.checkout-steps__submit-button-header {
+		display: block;
+		margin-block: 0 12px;
+		text-align: start;
+	}
+
+	.checkout-steps__submit-button-wrapper > button,
+	.checkout-submit-button,
+	.checkout-submit-button button {
+		inline-size: 100%;
+	}
+`;
+
+const Summary = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	max-block-size: 70vh;
+	overflow-y: auto;
+	/* Separates the open sheet from the Total/CTA row below it. */
+	padding-block-end: 16px;
+	margin-block-end: 16px;
+	border-block-end: 1px solid var( --studio-gray-5 );
+`;
+
+const SummaryTitle = styled.p`
+	margin: 0;
+	font-size: 20px;
+	font-weight: 500;
+	line-height: 26px;
+	letter-spacing: 0.38px;
+	color: var( --studio-gray-100 );
+`;
+
+const ProductRow = styled.div`
+	display: flex;
+	gap: 8px;
+	align-items: flex-start;
+	font-size: 16px;
+	line-height: 24px;
+
+	s {
+		font-weight: 400;
+		color: var( --studio-gray-50 );
+	}
+
+	> :last-child span {
+		font-weight: 500;
+		color: var( --studio-gray-100 );
+	}
+`;
+
+const ProductInfo = styled.div`
+	flex: 1;
+	min-inline-size: 0;
+	display: flex;
+	flex-direction: column;
+`;
+
+const ProductName = styled.div`
+	/* Domains are long unbroken strings and would otherwise overflow into the
+	   price — same treatment as the shared LineItemTitle. */
+	overflow-wrap: anywhere;
+	font-weight: 500;
+	color: var( --studio-gray-100 );
+`;
+
+const ProductSublabel = styled.div`
+	font-size: 12px;
+	line-height: 20px;
+	color: var( --studio-gray-50 );
+`;
+
+const ProductDiscount = styled.div`
+	font-size: 12px;
+	line-height: 20px;
+	color: var( --studio-green-50 );
+`;
+
+const Divider = styled.div`
+	block-size: 1px;
+	inline-size: 100%;
+	background: var( --studio-gray-5 );
+`;
+
+const TotalPriceGroup = styled.span`
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+`;
+
+/**
+ * A cart-level row (coupon, tax, credits) below the products. Built from the same
+ * pieces as the product rows so its type treatment can't drift from them. Omit
+ * `formattedAmount` for a label-only row like "Tax: to be calculated".
+ */
+function SummaryLineItemRow( {
+	label,
+	formattedAmount,
+	isCartUpdating,
+}: {
+	label: string;
+	formattedAmount?: string;
+	isCartUpdating: boolean;
+} ) {
+	return (
+		<>
+			<Divider />
+			<ProductRow>
+				<ProductInfo>
+					<ProductName>{ label }</ProductName>
+				</ProductInfo>
+				{ formattedAmount !== undefined &&
+					( isCartUpdating ? (
+						<PriceLoadingIndicator width="50px" />
+					) : (
+						<LineItemPrice actualAmount={ formattedAmount } />
+					) ) }
+			</ProductRow>
+		</>
+	);
+}
+
+function StickyOrderSummary( {
+	responseCart,
+	isCartUpdating,
+	monthlyPrices,
+}: {
+	responseCart: ResponseCart;
+	isCartUpdating: boolean;
+	monthlyPrices: Record< string, number >;
+} ) {
+	const translate = useTranslate();
+	// Coupons/tax/credits, so the panel reconciles with the tax-inclusive,
+	// discount-net total in the bar. Same helpers and conditions control uses.
+	const couponLineItem = getCouponLineItemFromCart( responseCart );
+	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
+	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
+	// Per-product amounts come from control's own getLineItemPriceDisplay so the two
+	// arms can't disagree — it excludes the coupon (shown on its own row below),
+	// and handles introductory offers and monthly-equivalent crossed-out prices.
+
+	return (
+		<Summary>
+			<SummaryTitle>{ translate( 'Order summary' ) }</SummaryTitle>
+			{ responseCart.products.map( ( product, index ) => {
+				const { actualAmountDisplay, crossedOutAmountDisplay } = getLineItemPriceDisplay(
+					product,
+					responseCart,
+					monthlyPrices
+				);
+				const costOverrides = filterCostOverridesForLineItem( product, translate );
+				return (
+					<Fragment key={ product.uuid }>
+						{ index > 0 && <Divider /> }
+						<ProductRow>
+							<ProductInfo>
+								<ProductName>{ getLabel( product ) }</ProductName>
+								<ProductSublabel>
+									<LineItemBillingInterval product={ product } />
+								</ProductSublabel>
+								{ costOverrides.map( ( costOverride, overrideIndex ) => (
+									<ProductDiscount key={ overrideIndex }>
+										{ costOverride.humanReadableReason }
+									</ProductDiscount>
+								) ) }
+							</ProductInfo>
+							{ isCartUpdating ? (
+								<PriceLoadingIndicator width="60px" />
+							) : (
+								<LineItemPrice
+									actualAmount={ actualAmountDisplay }
+									crossedOutAmount={ crossedOutAmountDisplay }
+								/>
+							) }
+						</ProductRow>
+					</Fragment>
+				);
+			} ) }
+			{ /* Order mirrors control: coupon, tax, credits. */ }
+			{ couponLineItem && (
+				<SummaryLineItemRow
+					label={ couponLineItem.label }
+					formattedAmount={ couponLineItem.formattedAmount }
+					isCartUpdating={ isCartUpdating }
+				/>
+			) }
+			{ taxLineItems.map( ( taxLineItem ) => (
+				<SummaryLineItemRow
+					key={ taxLineItem.id }
+					label={ taxLineItem.label }
+					formattedAmount={ taxLineItem.formattedAmount }
+					isCartUpdating={ isCartUpdating }
+				/>
+			) ) }
+			{ isBillingInfoEmpty( responseCart ) && (
+				<SummaryLineItemRow
+					label={ String( translate( 'Tax: to be calculated', { textOnly: true } ) ) }
+					isCartUpdating={ isCartUpdating }
+				/>
+			) }
+			{ creditsLineItem && responseCart.sub_total_integer > 0 && (
+				<SummaryLineItemRow
+					label={ creditsLineItem.label }
+					formattedAmount={ creditsLineItem.formattedAmount }
+					isCartUpdating={ isCartUpdating }
+				/>
+			) }
+		</Summary>
+	);
+}
+
+export function MobileCheckoutStickySummary() {
+	const translate = useTranslate();
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
+	const totalLineItem = getTotalLineItemFromCart( responseCart );
+	// Call this once with the cart's own array: it memoizes on `products` by
+	// reference, so a fresh `[ product ]` per row would recompute every render.
+	const monthlyPrices = useEquivalentMonthlyTotals( responseCart.products );
+	// The crossed-out total uses control's subtotal-before-discounts basis, so the
+	// bar and the panel quote the same numbers.
+	const subtotalBeforeDiscounts = responseCart.products.reduce( ( subtotal, product ) => {
+		const originalAmountInteger = getSimulatedCostBeforeDiscounts( product, monthlyPrices );
+		// In specific cases (e.g. premium domains) the original price (renewal) is lower than the due price.
+		return subtotal + Math.max( product.item_subtotal_integer, originalAmountInteger );
+	}, 0 );
+	const crossedOutTotal =
+		subtotalBeforeDiscounts > responseCart.sub_total_integer
+			? formatCurrency( subtotalBeforeDiscounts, responseCart.currency, {
+					isSmallestUnit: true,
+					stripZeros: true,
+			  } )
+			: undefined;
+	const { setSlotEl } = useSubmitButtonSlot();
+	const [ isOpen, setIsOpen ] = useState( false );
+	const panelId = useId();
+	const { formStatus } = useFormStatus();
+	// The bar is fixed on screen for the whole checkout, so a stale price here is
+	// far more visible than in the sidebar. Mirror the summary's own handling.
+	const isCartUpdating = FormStatus.VALIDATING === formStatus;
+
+	return (
+		<Wrapper>
+			<Panel isOpen={ isOpen } id={ panelId } aria-hidden={ ! isOpen }>
+				<PanelInner isOpen={ isOpen }>
+					<StickyOrderSummary
+						responseCart={ responseCart }
+						isCartUpdating={ isCartUpdating }
+						monthlyPrices={ monthlyPrices }
+					/>
+				</PanelInner>
+			</Panel>
+
+			<ToggleRow
+				type="button"
+				onClick={ () => setIsOpen( ( value ) => ! value ) }
+				aria-expanded={ isOpen }
+				aria-controls={ panelId }
+				aria-label={
+					translate( 'Total: %(amount)s', {
+						args: { amount: totalLineItem.formattedAmount },
+						comment: 'Total price shown in the mobile checkout sticky bar',
+					} ) as string
+				}
+			>
+				<span>{ translate( 'Total:' ) }</span>
+				<TotalPriceGroup>
+					{ isCartUpdating ? (
+						<PriceLoadingIndicator width="80px" height="22px" />
+					) : (
+						<LineItemPrice
+							actualAmount={ totalLineItem.formattedAmount }
+							crossedOutAmount={ crossedOutTotal }
+						/>
+					) }
+					<ChevronWrapper isOpen={ isOpen } aria-hidden="true">
+						<Icon icon={ chevronUp } size={ 24 } />
+					</ChevronWrapper>
+				</TotalPriceGroup>
+			</ToggleRow>
+
+			{ /* The submit button portals in here with control's terms line and
+			     guarantee, so the bar renders no terms copy of its own. */ }
+			<SubmitRow>
+				<div ref={ setSlotEl } style={ { inlineSize: '100%' } } />
+			</SubmitRow>
+		</Wrapper>
+	);
+}

--- a/client/my-sites/checkout/src/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/src/components/vat-form/index.tsx
@@ -185,50 +185,52 @@ export function VatForm( {
 					/>
 				) }
 			</div>
-			<div className="vat-form__row">
-				<Field
-					id={ section + '-vat-organization' }
-					type="text"
-					label={ getVatFormString( 'organizationFieldLabel' ) }
-					value={ vatDetailsInForm.name ?? '' }
-					disabled={ isDisabled }
-					onChange={ ( newValue: string ) => {
-						setVatDetailsInForm( {
-							...vatDetailsInForm,
-							name: newValue,
-						} );
-					} }
-				/>
-				<Field
-					id={ section + '-vat-id' }
-					type="text"
-					label={ getVatFormString( 'vatIdFieldLabel' ) }
-					value={ vatDetailsInForm.id ?? '' }
-					disabled={ isDisabled || Boolean( vatDetailsFromServer.id ) }
-					onChange={ ( newValue: string ) => {
-						setVatDetailsInForm( {
-							...vatDetailsInForm,
-							id: newValue,
-						} );
-					} }
-					prefix={ vatDetailsInForm?.country ? vatDetailsInForm.country : '' }
-				/>
-			</div>
-			<div className="vat-form__row vat-form__row--full-width">
-				<Field
-					id={ section + '-vat-address' }
-					type="text"
-					label={ getVatFormString( 'vatAddressFieldLabel' ) }
-					value={ vatDetailsInForm.address ?? '' }
-					autoComplete={ `section-${ section } street-address` }
-					disabled={ isDisabled }
-					onChange={ ( newValue: string ) => {
-						setVatDetailsInForm( {
-							...vatDetailsInForm,
-							address: newValue,
-						} );
-					} }
-				/>
+			<div className="vat-form__expanded">
+				<div className="vat-form__row">
+					<Field
+						id={ section + '-vat-organization' }
+						type="text"
+						label={ getVatFormString( 'organizationFieldLabel' ) }
+						value={ vatDetailsInForm.name ?? '' }
+						disabled={ isDisabled }
+						onChange={ ( newValue: string ) => {
+							setVatDetailsInForm( {
+								...vatDetailsInForm,
+								name: newValue,
+							} );
+						} }
+					/>
+					<Field
+						id={ section + '-vat-id' }
+						type="text"
+						label={ getVatFormString( 'vatIdFieldLabel' ) }
+						value={ vatDetailsInForm.id ?? '' }
+						disabled={ isDisabled || Boolean( vatDetailsFromServer.id ) }
+						onChange={ ( newValue: string ) => {
+							setVatDetailsInForm( {
+								...vatDetailsInForm,
+								id: newValue,
+							} );
+						} }
+						prefix={ vatDetailsInForm?.country ? vatDetailsInForm.country : '' }
+					/>
+				</div>
+				<div className="vat-form__row vat-form__row--full-width">
+					<Field
+						id={ section + '-vat-address' }
+						type="text"
+						label={ getVatFormString( 'vatAddressFieldLabel' ) }
+						value={ vatDetailsInForm.address ?? '' }
+						autoComplete={ `section-${ section } street-address` }
+						disabled={ isDisabled }
+						onChange={ ( newValue: string ) => {
+							setVatDetailsInForm( {
+								...vatDetailsInForm,
+								address: newValue,
+							} );
+						} }
+					/>
+				</div>
 			</div>
 			{ vatDetailsFromServer.id && (
 				<div>

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -24,6 +24,7 @@ import {
 } from 'calypso/state/signup/flow/selectors';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import { useCheckoutUiRedesignExperiment } from '../hooks/use-checkout-ui-redesign-experiment';
+import { useMobileCheckoutStickySummaryExperiment } from '../hooks/use-mobile-checkout-sticky-summary-experiment';
 import Coupon from './coupon';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
 import type { OnChangeItemVariant } from './item-variation-picker';
@@ -146,6 +147,7 @@ export default function WPCheckoutOrderReview( {
 
 	const selectedSiteData = useSelector( getSelectedSite );
 	const [ , isCheckoutUiRedesignV1 ] = useCheckoutUiRedesignExperiment();
+	const { isMobileCheckoutStickySummary } = useMobileCheckoutStickySummaryExperiment();
 
 	// This is what will be displayed at the top of checkout prefixed by "Site: ".
 	const domainUrl = getDomainToDisplayInCheckoutHeader( responseCart, selectedSiteData, siteUrl );
@@ -168,17 +170,34 @@ export default function WPCheckoutOrderReview( {
 					isSummary && 'is-summary',
 				] ) }
 			>
-				{ domainUrl && (
-					<SiteSummary className="checkout-review-order__site">
-						{ isCheckoutUiRedesignV1 ? domainUrl : translate( 'Site: %s', { args: domainUrl } ) }
-					</SiteSummary>
-				) }
-				{ currentUserEmail && ! isGiftPurchase && (
-					<EmailSummary className="checkout-review-order__email">
-						{ isCheckoutUiRedesignV1
-							? currentUserEmail
-							: translate( 'Account: %s', { args: currentUserEmail } ) }
-					</EmailSummary>
+				{ isMobileCheckoutStickySummary ? (
+					currentUserEmail &&
+					! isGiftPurchase && (
+						<p className="checkout-review-order__signed-in">
+							{ translate( 'You’re signed in as {{em}}%(email)s{{/em}}.', {
+								args: { email: currentUserEmail },
+								components: { em: <strong /> },
+								comment: 'Shown at the top of mobile checkout under the order details heading.',
+							} ) }
+						</p>
+					)
+				) : (
+					<>
+						{ domainUrl && (
+							<SiteSummary className="checkout-review-order__site">
+								{ isCheckoutUiRedesignV1
+									? domainUrl
+									: translate( 'Site: %s', { args: domainUrl } ) }
+							</SiteSummary>
+						) }
+						{ currentUserEmail && ! isGiftPurchase && (
+							<EmailSummary className="checkout-review-order__email">
+								{ isCheckoutUiRedesignV1
+									? currentUserEmail
+									: translate( 'Account: %s', { args: currentUserEmail } ) }
+							</EmailSummary>
+						) }
+					</>
 				) }
 				{ planIsP2Plus && selectedSiteData?.name && (
 					<SiteSummary className="checkout-review-order__site">
@@ -249,7 +268,7 @@ export function CouponFieldArea( {
 
 	if ( isCouponFieldVisible ) {
 		return (
-			<CouponAreaWrapper>
+			<CouponAreaWrapper className="checkout__coupon-area">
 				<CouponField
 					id="order-review-coupon"
 					disabled={ formStatus !== FormStatus.READY }
@@ -261,7 +280,7 @@ export function CouponFieldArea( {
 	}
 
 	return (
-		<CouponAreaWrapper>
+		<CouponAreaWrapper className="checkout__coupon-area">
 			<CouponLinkWrapper>
 				<CouponEnableButton
 					className="wp-checkout-order-review__show-coupon-field-button"

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -883,7 +883,7 @@ const CheckoutSummaryLineItem = styled.div< { isDiscount?: boolean } >`
 	color: ${ ( props ) => ( props.isDiscount ? props.theme.colors.discount : 'inherit' ) };
 `;
 
-const PriceLoadingIndicator = styled.span< { width?: string; height?: string } >`
+export const PriceLoadingIndicator = styled.span< { width?: string; height?: string } >`
 	display: inline-block;
 	height: ${ ( props ) => props.height ?? '16px' };
 	width: ${ ( props ) => props.width ?? '60px' };

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -42,7 +42,7 @@ import { hasFreeCouponTransfersOnly } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import useEquivalentMonthlyTotals, {
-	getSimulatedCostBeforeDiscounts,
+	getSubtotalBeforeDiscounts,
 } from 'calypso/my-sites/checkout/utils/use-equivalent-monthly-totals';
 import { useSelector } from 'calypso/state';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
@@ -165,11 +165,7 @@ function CheckoutSummaryPriceList() {
 	const { formStatus } = useFormStatus();
 	const isCartUpdating = FormStatus.VALIDATING === formStatus;
 
-	const subtotalBeforeDiscounts = responseCart.products.reduce( ( subtotal, product ) => {
-		const originalAmountInteger = getSimulatedCostBeforeDiscounts( product, monthlyPrices );
-		// In specific cases (e.g. premium domains) the original price (renewal) is lower than the due price.
-		return subtotal + Math.max( product.item_subtotal_integer, originalAmountInteger );
-	}, 0 );
+	const subtotalBeforeDiscounts = getSubtotalBeforeDiscounts( responseCart, monthlyPrices );
 	const totalDiscount = subtotalBeforeDiscounts - responseCart.sub_total_integer;
 
 	return (

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -364,8 +364,7 @@ function LineItemWrapper( {
 	const [ restorableProducts, setRestorableProducts ] = useRestorableProducts();
 	const isRenewal = isWpComProductRenewal( product );
 	const isWooMobile = isWcMobileApp();
-	const { isMobileCheckoutStickySummary: isMobileStickySummary } =
-		useMobileCheckoutStickySummaryExperiment();
+	const { isMobileCheckoutStickySummary } = useMobileCheckoutStickySummaryExperiment();
 	let isDeletable = canItemBeRemovedFromCart( product, responseCart ) && ! isWooMobile;
 	const has100YearPlanProduct = has100YearPlan( responseCart );
 	const signupFlowName = getSignupCompleteFlowName();
@@ -494,7 +493,7 @@ function LineItemWrapper( {
 				shouldShowComparison={ shouldShowComparison }
 				compareToPrice={ compareToPrice }
 				isRenewalPricingExperiment={ isRenewalPricingExperiment }
-				isMobileStickySummary={ isMobileStickySummary }
+				isMobileCheckoutStickySummary={ isMobileCheckoutStickySummary }
 			>
 				<DropdownWrapper>
 					{ finalShouldShowVariantSelector && (

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -23,6 +23,7 @@ import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { has100YearPlan, getDomainRegistrations } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/src/hooks/product-variants';
+import { useMobileCheckoutStickySummaryExperiment } from 'calypso/my-sites/checkout/src/hooks/use-mobile-checkout-sticky-summary-experiment';
 import {
 	isRenewalPricingTreatment,
 	useRenewalPricingExperiment,
@@ -363,6 +364,8 @@ function LineItemWrapper( {
 	const [ restorableProducts, setRestorableProducts ] = useRestorableProducts();
 	const isRenewal = isWpComProductRenewal( product );
 	const isWooMobile = isWcMobileApp();
+	const { isMobileCheckoutStickySummary: isMobileStickySummary } =
+		useMobileCheckoutStickySummaryExperiment();
 	let isDeletable = canItemBeRemovedFromCart( product, responseCart ) && ! isWooMobile;
 	const has100YearPlanProduct = has100YearPlan( responseCart );
 	const signupFlowName = getSignupCompleteFlowName();
@@ -491,6 +494,7 @@ function LineItemWrapper( {
 				shouldShowComparison={ shouldShowComparison }
 				compareToPrice={ compareToPrice }
 				isRenewalPricingExperiment={ isRenewalPricingExperiment }
+				isMobileStickySummary={ isMobileStickySummary }
 			>
 				<DropdownWrapper>
 					{ finalShouldShowVariantSelector && (

--- a/client/my-sites/checkout/src/hooks/test/use-mobile-checkout-sticky-summary-experiment.ts
+++ b/client/my-sites/checkout/src/hooks/test/use-mobile-checkout-sticky-summary-experiment.ts
@@ -150,6 +150,37 @@ describe( 'useMobileCheckoutStickySummaryExperiment', () => {
 		} );
 	} );
 
+	// useViewportMatch is reactive. If eligibility could flip false -> true
+	// mid-session, ExPlat would start loading, isLoading would go back to true, and
+	// checkout would unmount its step group along with anything already typed.
+	describe( 'eligibility is frozen at mount', () => {
+		it( 'stays ineligible when the viewport later narrows past the breakpoint', () => {
+			mockUseViewportMatch.mockReturnValue( false );
+
+			const { rerender } = renderHook( () => useMobileCheckoutStickySummaryExperiment() );
+
+			mockUseViewportMatch.mockReturnValue( true );
+			rerender();
+
+			expect( mockUseExperiment ).toHaveBeenLastCalledWith(
+				'calypso_mobile_checkout_sticky_summary_v1',
+				{ isEligible: false }
+			);
+		} );
+
+		it( 'keeps a participant in the treatment when the viewport later widens', () => {
+			mockUseExperiment.mockReturnValue( [ false, treatmentAssignment ] );
+
+			const { result, rerender } = renderHook( () => useMobileCheckoutStickySummaryExperiment() );
+			expect( result.current.isMobileCheckoutStickySummary ).toBe( true );
+
+			mockUseViewportMatch.mockReturnValue( false );
+			rerender();
+
+			expect( result.current.isMobileCheckoutStickySummary ).toBe( true );
+		} );
+	} );
+
 	it( 'honors the QA query-param override on eligible surfaces', () => {
 		window.history.replaceState( {}, '', '/?mobile_checkout_sticky_summary=1' );
 

--- a/client/my-sites/checkout/src/hooks/test/use-mobile-checkout-sticky-summary-experiment.ts
+++ b/client/my-sites/checkout/src/hooks/test/use-mobile-checkout-sticky-summary-experiment.ts
@@ -1,0 +1,163 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { useViewportMatch } from '@wordpress/compose';
+import { useInitialIsInStepContainerV2FlowContext } from 'calypso/layout/utils';
+import { useExperiment } from 'calypso/lib/explat';
+import { useMobileCheckoutStickySummaryExperiment } from '../use-mobile-checkout-sticky-summary-experiment';
+
+jest.mock( '@wordpress/compose', () => ( {
+	...jest.requireActual( '@wordpress/compose' ),
+	useViewportMatch: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/layout/utils', () => ( {
+	...jest.requireActual( 'calypso/layout/utils' ),
+	useInitialIsInStepContainerV2FlowContext: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/explat', () => ( {
+	useExperiment: jest.fn(),
+} ) );
+
+const mockUseViewportMatch = useViewportMatch as jest.MockedFunction< typeof useViewportMatch >;
+const mockUseExperiment = useExperiment as jest.MockedFunction< typeof useExperiment >;
+const mockUseIsStepContainerV2 = useInitialIsInStepContainerV2FlowContext as jest.MockedFunction<
+	typeof useInitialIsInStepContainerV2FlowContext
+>;
+
+const treatmentAssignment = {
+	experimentName: 'calypso_mobile_checkout_sticky_summary_v1',
+	variationName: 'treatment',
+	retrievedTimestamp: 0,
+	ttl: 0,
+};
+
+describe( 'useMobileCheckoutStickySummaryExperiment', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockUseExperiment.mockReturnValue( [ false, null ] );
+		// Default to the only surface that can render the treatment: a mobile
+		// viewport inside a StepContainerV2 flow.
+		mockUseViewportMatch.mockReturnValue( true );
+		mockUseIsStepContainerV2.mockReturnValue( true );
+		window.history.replaceState( {}, '', '/' );
+	} );
+
+	it( 'only requests experiment assignment on mobile inside a StepContainerV2 flow', () => {
+		renderHook( () => useMobileCheckoutStickySummaryExperiment() );
+
+		expect( mockUseExperiment ).toHaveBeenCalledWith( 'calypso_mobile_checkout_sticky_summary_v1', {
+			isEligible: true,
+		} );
+	} );
+
+	it( 'opts out of experiment assignment on large viewports', () => {
+		mockUseViewportMatch.mockReturnValue( false );
+
+		renderHook( () => useMobileCheckoutStickySummaryExperiment() );
+
+		expect( mockUseExperiment ).toHaveBeenCalledWith( 'calypso_mobile_checkout_sticky_summary_v1', {
+			isEligible: false,
+		} );
+	} );
+
+	// The sticky summary only exists in the StepContainerV2 branch, and these
+	// components also render on /me/purchases via useCreateCreditCard. Enrolling
+	// there would fire an exposure for an experience the user can never see.
+	it( 'opts out of experiment assignment outside a StepContainerV2 flow', () => {
+		mockUseIsStepContainerV2.mockReturnValue( false );
+
+		renderHook( () => useMobileCheckoutStickySummaryExperiment() );
+
+		expect( mockUseExperiment ).toHaveBeenCalledWith( 'calypso_mobile_checkout_sticky_summary_v1', {
+			isEligible: false,
+		} );
+	} );
+
+	it( 'returns isLoading false and isMobileCheckoutStickySummary false on large viewports', () => {
+		mockUseViewportMatch.mockReturnValue( false );
+
+		const { result } = renderHook( () => useMobileCheckoutStickySummaryExperiment() );
+
+		expect( result.current ).toEqual( { isLoading: false, isMobileCheckoutStickySummary: false } );
+	} );
+
+	it( 'returns isMobileCheckoutStickySummary false outside a StepContainerV2 flow even if assigned to treatment', () => {
+		mockUseIsStepContainerV2.mockReturnValue( false );
+		mockUseExperiment.mockReturnValue( [ false, treatmentAssignment ] );
+
+		const { result } = renderHook( () => useMobileCheckoutStickySummaryExperiment() );
+
+		expect( result.current ).toEqual( { isLoading: false, isMobileCheckoutStickySummary: false } );
+	} );
+
+	it( 'returns isLoading true and isMobileCheckoutStickySummary false while ExPlat is loading on mobile', () => {
+		mockUseExperiment.mockReturnValue( [ true, null ] );
+
+		const { result } = renderHook( () => useMobileCheckoutStickySummaryExperiment() );
+
+		expect( result.current ).toEqual( { isLoading: true, isMobileCheckoutStickySummary: false } );
+	} );
+
+	it( 'returns isMobileCheckoutStickySummary false for control assignment on mobile', () => {
+		mockUseExperiment.mockReturnValue( [
+			false,
+			{ ...treatmentAssignment, variationName: 'control' },
+		] );
+
+		const { result } = renderHook( () => useMobileCheckoutStickySummaryExperiment() );
+
+		expect( result.current ).toEqual( {
+			isLoading: false,
+			isMobileCheckoutStickySummary: false,
+		} );
+	} );
+
+	it( 'returns isMobileCheckoutStickySummary true for treatment assignment on mobile', () => {
+		mockUseExperiment.mockReturnValue( [ false, treatmentAssignment ] );
+
+		const { result } = renderHook( () => useMobileCheckoutStickySummaryExperiment() );
+
+		expect( result.current ).toEqual( {
+			isLoading: false,
+			isMobileCheckoutStickySummary: true,
+		} );
+	} );
+
+	it( 'ignores the QA query-param override on large viewports', () => {
+		mockUseViewportMatch.mockReturnValue( false );
+		window.history.replaceState( {}, '', '/?mobile_checkout_sticky_summary=1' );
+
+		const { result } = renderHook( () => useMobileCheckoutStickySummaryExperiment() );
+
+		expect( result.current ).toEqual( {
+			isLoading: false,
+			isMobileCheckoutStickySummary: false,
+		} );
+	} );
+
+	it( 'ignores the QA query-param override outside a StepContainerV2 flow', () => {
+		mockUseIsStepContainerV2.mockReturnValue( false );
+		window.history.replaceState( {}, '', '/?mobile_checkout_sticky_summary=1' );
+
+		const { result } = renderHook( () => useMobileCheckoutStickySummaryExperiment() );
+
+		expect( result.current ).toEqual( {
+			isLoading: false,
+			isMobileCheckoutStickySummary: false,
+		} );
+	} );
+
+	it( 'honors the QA query-param override on eligible surfaces', () => {
+		window.history.replaceState( {}, '', '/?mobile_checkout_sticky_summary=1' );
+
+		const { result } = renderHook( () => useMobileCheckoutStickySummaryExperiment() );
+
+		expect( result.current ).toEqual( {
+			isLoading: false,
+			isMobileCheckoutStickySummary: true,
+		} );
+	} );
+} );

--- a/client/my-sites/checkout/src/hooks/use-mobile-checkout-sticky-summary-experiment.ts
+++ b/client/my-sites/checkout/src/hooks/use-mobile-checkout-sticky-summary-experiment.ts
@@ -33,6 +33,13 @@ export interface MobileCheckoutStickySummaryExperiment {
  * breakpoint can disagree with ones already mounted. Hoisting this to a context
  * provided once by `CheckoutMain` would remove that; not worth the churn while
  * this is a short-lived experiment.
+ *
+ * Teardown: everything belonging to this experiment is named after it, in one of
+ * three cases — `MobileCheckoutStickySummary` (identifiers),
+ * `mobile-checkout-sticky-summary` (CSS classes and file names) and
+ * `mobile_checkout_sticky_summary` (experiment name and query param). All three
+ * fall out of `grep -rEi 'mobile[-_]?checkout[-_]?sticky[-_]?summary'`; keep it
+ * that way when adding to the treatment.
  */
 export function useMobileCheckoutStickySummaryExperiment(): MobileCheckoutStickySummaryExperiment {
 	const isMobileViewport = useViewportMatch( 'small', '<' );

--- a/client/my-sites/checkout/src/hooks/use-mobile-checkout-sticky-summary-experiment.ts
+++ b/client/my-sites/checkout/src/hooks/use-mobile-checkout-sticky-summary-experiment.ts
@@ -11,8 +11,11 @@ export interface MobileCheckoutStickySummaryExperiment {
 }
 
 /**
- * `isLoading` is load-bearing: callers must suppress both treatment and control
- * UI until it resolves, or the treatment cohort is measured partly on control UI.
+ * `isLoading` is load-bearing: checkout must not paint its steps until the
+ * assignment resolves, or the treatment cohort is measured partly on control UI.
+ * That gating lives in `checkoutLoadingConditions` in `checkout-main.tsx`
+ * alongside checkout's other load blockers; consumers of
+ * `isMobileCheckoutStickySummary` don't need to check `isLoading` themselves.
  *
  * Eligibility is gated to where the treatment can actually show — mobile inside a
  * StepContainerV2 flow. These components also render on `/me/purchases` (via

--- a/client/my-sites/checkout/src/hooks/use-mobile-checkout-sticky-summary-experiment.ts
+++ b/client/my-sites/checkout/src/hooks/use-mobile-checkout-sticky-summary-experiment.ts
@@ -1,0 +1,48 @@
+import { useViewportMatch } from '@wordpress/compose';
+import { useInitialIsInStepContainerV2FlowContext } from 'calypso/layout/utils';
+import { useExperiment } from 'calypso/lib/explat';
+
+const EXPERIMENT_NAME = 'calypso_mobile_checkout_sticky_summary_v1';
+const QUERY_PARAM = 'mobile_checkout_sticky_summary';
+
+export interface MobileCheckoutStickySummaryExperiment {
+	isLoading: boolean;
+	isMobileCheckoutStickySummary: boolean;
+}
+
+/**
+ * `isLoading` is load-bearing: callers must suppress both treatment and control
+ * UI until it resolves, or the treatment cohort is measured partly on control UI.
+ *
+ * Eligibility is gated to where the treatment can actually show — mobile inside a
+ * StepContainerV2 flow. These components also render on `/me/purchases` (via
+ * `useCreateCreditCard`), where enrolling would fire an exposure nobody can see.
+ */
+export function useMobileCheckoutStickySummaryExperiment(): MobileCheckoutStickySummaryExperiment {
+	const isMobileViewport = useViewportMatch( 'small', '<' );
+	const isStepContainerV2 = useInitialIsInStepContainerV2FlowContext();
+	const isEligible = isMobileViewport && isStepContainerV2;
+	const [ isLoading, assignment ] = useExperiment( EXPERIMENT_NAME, {
+		isEligible,
+	} );
+
+	if ( ! isEligible ) {
+		return { isLoading: false, isMobileCheckoutStickySummary: false };
+	}
+
+	if ( isLoading ) {
+		return { isLoading: true, isMobileCheckoutStickySummary: false };
+	}
+
+	if ( typeof window !== 'undefined' ) {
+		const searchParams = new URLSearchParams( window.location.search );
+		if ( searchParams.get( QUERY_PARAM ) === '1' ) {
+			return { isLoading: false, isMobileCheckoutStickySummary: true };
+		}
+	}
+
+	return {
+		isLoading: false,
+		isMobileCheckoutStickySummary: assignment?.variationName === 'treatment',
+	};
+}

--- a/client/my-sites/checkout/src/hooks/use-mobile-checkout-sticky-summary-experiment.ts
+++ b/client/my-sites/checkout/src/hooks/use-mobile-checkout-sticky-summary-experiment.ts
@@ -1,4 +1,5 @@
 import { useViewportMatch } from '@wordpress/compose';
+import { useRef } from 'react';
 import { useInitialIsInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import { useExperiment } from 'calypso/lib/explat';
 
@@ -20,11 +21,23 @@ export interface MobileCheckoutStickySummaryExperiment {
  * Eligibility is gated to where the treatment can actually show — mobile inside a
  * StepContainerV2 flow. These components also render on `/me/purchases` (via
  * `useCreateCreditCard`), where enrolling would fire an exposure nobody can see.
+ *
+ * Eligibility is frozen at mount, mirroring
+ * `useInitialIsInStepContainerV2FlowContext`. `useViewportMatch` is reactive, and
+ * letting eligibility flip false -> true mid-session starts an ExPlat load, which
+ * puts `isLoading` back to true, drives checkout's form status to LOADING and
+ * unmounts the step group — taking anything the participant has typed with it.
+ * Freezing also keeps a participant in one arm for the whole session.
+ *
+ * The freeze is per call site, so components that mount after a resize across the
+ * breakpoint can disagree with ones already mounted. Hoisting this to a context
+ * provided once by `CheckoutMain` would remove that; not worth the churn while
+ * this is a short-lived experiment.
  */
 export function useMobileCheckoutStickySummaryExperiment(): MobileCheckoutStickySummaryExperiment {
 	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const isStepContainerV2 = useInitialIsInStepContainerV2FlowContext();
-	const isEligible = isMobileViewport && isStepContainerV2;
+	const isEligible = useRef( isMobileViewport && isStepContainerV2 ).current;
 	const [ isLoading, assignment ] = useExperiment( EXPERIMENT_NAME, {
 		isEligible,
 	} );

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-cvv-field.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-cvv-field.tsx
@@ -3,6 +3,7 @@ import { CardCvcElement } from '@stripe/react-stripe-js';
 import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { LeftColumn, RightColumn } from 'calypso/my-sites/checkout/src/components/ie-fallback';
+import { useMobileCheckoutStickySummaryExperiment } from 'calypso/my-sites/checkout/src/hooks/use-mobile-checkout-sticky-summary-experiment';
 import { Input } from 'calypso/my-sites/domains/components/form';
 import CVVImage from './cvv-image';
 import {
@@ -34,6 +35,7 @@ export default function CreditCardCvvField( {
 	const translate = useTranslate();
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
+	const { isMobileCheckoutStickySummary } = useMobileCheckoutStickySummaryExperiment();
 	const { cardCvc: cardCvcError } = useSelect(
 		( select ) => ( select( 'wpcom-credit-card' ) as WpcomCreditCardSelectors ).getCardDataErrors(),
 		[]
@@ -64,31 +66,37 @@ export default function CreditCardCvvField( {
 	}
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	const stripeField = (
+		<StripeFieldWrapper className="cvv" hasError={ !! cardCvcError } isDisabled={ isDisabled }>
+			<CardCvcElement
+				options={ {
+					style: stripeElementStyle,
+					disabled: isDisabled,
+				} }
+				onChange={ ( input ) => {
+					handleStripeFieldChange( input );
+				} }
+			/>
+		</StripeFieldWrapper>
+	);
+
 	return (
 		<Label>
 			<LabelText>{ translate( 'Security code' ) }</LabelText>
-			<GridRow gap="4%" columnWidths="67% 29%">
-				<LeftColumn>
-					<StripeFieldWrapper
-						className="cvv"
-						hasError={ !! cardCvcError }
-						isDisabled={ isDisabled }
-					>
-						<CardCvcElement
-							options={ {
-								style: stripeElementStyle,
-								disabled: isDisabled,
-							} }
-							onChange={ ( input ) => {
-								handleStripeFieldChange( input );
-							} }
-						/>
-					</StripeFieldWrapper>
-				</LeftColumn>
-				<RightColumn>
-					<CVVImage />
-				</RightColumn>
-			</GridRow>
+			{ isMobileCheckoutStickySummary ? (
+				/* Figma 3971:13276 — the CVC card-back hint moves out of the
+				   Security code field and into the expiry/CVC row as its own
+				   38px column (rendered by credit-card-fields.tsx). Drop the
+				   2-column GridRow so the input fills the field. */
+				stripeField
+			) : (
+				<GridRow gap="4%" columnWidths="67% 29%">
+					<LeftColumn>{ stripeField }</LeftColumn>
+					<RightColumn>
+						<CVVImage />
+					</RightColumn>
+				</GridRow>
+			) }
 			{ cardCvcError && <StripeErrorMessage>{ cardCvcError }</StripeErrorMessage> }
 		</Label>
 	);

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-fields.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-fields.tsx
@@ -6,6 +6,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { Fragment, useState, useEffect, useRef } from 'react';
 import { LeftColumn, RightColumn } from 'calypso/my-sites/checkout/src/components/ie-fallback';
 import Spinner from 'calypso/my-sites/checkout/src/components/spinner';
+import { useMobileCheckoutStickySummaryExperiment } from 'calypso/my-sites/checkout/src/hooks/use-mobile-checkout-sticky-summary-experiment';
 import { logStashEvent } from 'calypso/my-sites/checkout/src/lib/analytics';
 import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -15,6 +16,7 @@ import CreditCardCvvField from './credit-card-cvv-field';
 import CreditCardExpiryField from './credit-card-expiry-field';
 import CreditCardLoading from './credit-card-loading';
 import CreditCardNumberField from './credit-card-number-field';
+import CVVImage from './cvv-image';
 import { FieldRow, CreditCardFieldsWrapper, CreditCardField } from './form-layout-components';
 import { VgsCreditCardFields } from './vgs-credit-card-fields';
 import type { WpcomCreditCardSelectors } from './store';
@@ -121,10 +123,15 @@ export default function CreditCardFields( {
 	const shouldShowContactFields = shouldUseEbanx || shouldShowTaxFields;
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
+	const { isMobileCheckoutStickySummary } = useMobileCheckoutStickySummaryExperiment();
 
 	const stripeElementStyle = {
 		base: {
-			fontSize: '14px',
+			// Under the mobile sticky experiment the rest of the form sits
+			// on a 13px rhythm (Figma 3971:13272); match it inside the
+			// Stripe iframe so card-number / expiry / CVC value text reads
+			// the same height as the Cardholder name input.
+			fontSize: isMobileCheckoutStickySummary ? '13px' : '14px',
 			color: theme.colors.textColor,
 			fontFamily: theme.fonts.body,
 			fontWeight: theme.weights.normal,
@@ -258,19 +265,25 @@ export default function CreditCardFields( {
 						disabled={ isDisabled }
 					/>
 
-					<FieldRow>
-						<CreditCardNumberField
-							setIsStripeFullyLoaded={ setIsStripeFullyLoaded }
-							handleStripeFieldChange={ handleStripeFieldChange }
-							stripeElementStyle={ stripeElementStyle }
-							shouldUseEbanx={ shouldUseEbanx }
-							getErrorMessagesForField={ getErrorMessagesForField }
-							setFieldValue={ setFieldValue }
-							getFieldValue={ getFieldValue }
-						/>
-
-						<FieldRow gap="4%" columnWidths="48% 48%">
-							<LeftColumn>
+					{ isMobileCheckoutStickySummary ? (
+						/* Under the experiment, the credit-card-fields-inner-wrapper
+						   is a flex column with a 16px gap — hoist Card number and
+						   the Expiry/CVC row out of the default outer FieldRow so
+						   each row becomes a direct child of the inner wrapper and
+						   participates in the shared 16px rhythm (Figma 3971:13266). */
+						<>
+							<CreditCardNumberField
+								setIsStripeFullyLoaded={ setIsStripeFullyLoaded }
+								handleStripeFieldChange={ handleStripeFieldChange }
+								stripeElementStyle={ stripeElementStyle }
+								shouldUseEbanx={ shouldUseEbanx }
+								getErrorMessagesForField={ getErrorMessagesForField }
+								setFieldValue={ setFieldValue }
+								getFieldValue={ getFieldValue }
+							/>
+							{ /* Figma 3971:13274 lays Expiry + CVC + a 38px CVC card-back
+							     hint on one flex row. */ }
+							<div className="credit-card-fields__expiry-cvc-row">
 								<CreditCardExpiryField
 									handleStripeFieldChange={ handleStripeFieldChange }
 									stripeElementStyle={ stripeElementStyle }
@@ -279,8 +292,6 @@ export default function CreditCardFields( {
 									setFieldValue={ setFieldValue }
 									getFieldValue={ getFieldValue }
 								/>
-							</LeftColumn>
-							<RightColumn>
 								<CreditCardCvvField
 									handleStripeFieldChange={ handleStripeFieldChange }
 									stripeElementStyle={ stripeElementStyle }
@@ -289,9 +300,47 @@ export default function CreditCardFields( {
 									setFieldValue={ setFieldValue }
 									getFieldValue={ getFieldValue }
 								/>
-							</RightColumn>
+								<span className="credit-card-fields__cvc-hint" aria-hidden="true">
+									<CVVImage />
+								</span>
+							</div>
+						</>
+					) : (
+						<FieldRow>
+							<CreditCardNumberField
+								setIsStripeFullyLoaded={ setIsStripeFullyLoaded }
+								handleStripeFieldChange={ handleStripeFieldChange }
+								stripeElementStyle={ stripeElementStyle }
+								shouldUseEbanx={ shouldUseEbanx }
+								getErrorMessagesForField={ getErrorMessagesForField }
+								setFieldValue={ setFieldValue }
+								getFieldValue={ getFieldValue }
+							/>
+
+							<FieldRow gap="4%" columnWidths="48% 48%">
+								<LeftColumn>
+									<CreditCardExpiryField
+										handleStripeFieldChange={ handleStripeFieldChange }
+										stripeElementStyle={ stripeElementStyle }
+										shouldUseEbanx={ shouldUseEbanx }
+										getErrorMessagesForField={ getErrorMessagesForField }
+										setFieldValue={ setFieldValue }
+										getFieldValue={ getFieldValue }
+									/>
+								</LeftColumn>
+								<RightColumn>
+									<CreditCardCvvField
+										handleStripeFieldChange={ handleStripeFieldChange }
+										stripeElementStyle={ stripeElementStyle }
+										shouldUseEbanx={ shouldUseEbanx }
+										getErrorMessagesForField={ getErrorMessagesForField }
+										setFieldValue={ setFieldValue }
+										getFieldValue={ getFieldValue }
+									/>
+								</RightColumn>
+							</FieldRow>
 						</FieldRow>
-					</FieldRow>
+					) }
 
 					{ shouldShowContactFields && (
 						<ContactFields

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
@@ -1,8 +1,10 @@
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { CardNumberElement } from '@stripe/react-stripe-js';
 import { useSelect } from '@wordpress/data';
+import { Icon, lock } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import CreditCardNumberInput from 'calypso/components/upgrades/credit-card-number-input';
+import { useMobileCheckoutStickySummaryExperiment } from 'calypso/my-sites/checkout/src/hooks/use-mobile-checkout-sticky-summary-experiment';
 import { Label, LabelText, StripeFieldWrapper, StripeErrorMessage } from './form-layout-components';
 import type { WpcomCreditCardSelectors } from './store';
 import type { StripeFieldChangeInput } from './types';
@@ -28,6 +30,7 @@ export default function CreditCardNumberField( {
 	const { __ } = useI18n();
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
+	const { isMobileCheckoutStickySummary } = useMobileCheckoutStickySummaryExperiment();
 
 	const { cardNumber: cardNumberError } = useSelect(
 		( select ) => ( select( 'wpcom-credit-card' ) as WpcomCreditCardSelectors ).getCardDataErrors(),
@@ -81,6 +84,12 @@ export default function CreditCardNumberField( {
 						handleStripeFieldChange( input );
 					} }
 				/>
+
+				{ isMobileCheckoutStickySummary && (
+					<span className="credit-card-number-field__lock-icon" aria-hidden="true">
+						<Icon icon={ lock } size={ 20 } />
+					</span>
+				) }
 
 				{ cardNumberError && <StripeErrorMessage>{ cardNumberError }</StripeErrorMessage> }
 			</StripeFieldWrapper>

--- a/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
@@ -14,6 +14,7 @@ import {
 	SummaryLine,
 	SummaryDetails,
 } from 'calypso/my-sites/checkout/src/components/summary-details';
+import { useMobileCheckoutStickySummaryExperiment } from 'calypso/my-sites/checkout/src/hooks/use-mobile-checkout-sticky-summary-experiment';
 import CreditCardFields from './credit-card-fields';
 import CreditCardPayButton from './credit-card-pay-button';
 import type { WpcomCreditCardSelectors } from './store';
@@ -62,6 +63,25 @@ const CreditCardLabel: React.FC< {
 };
 
 function CreditCardLogos( { currency }: { currency: string | null } ) {
+	const { isMobileCheckoutStickySummary } = useMobileCheckoutStickySummaryExperiment();
+
+	// VISA / MasterCard / AMEX + a "+N" pill (Figma 3971:13250). N counts only what
+	// the control strip advertises for this currency (CB on EUR, JCB on JPY) — the
+	// pill is a claim about accepted cards, so it must not overcount.
+	if ( isMobileCheckoutStickySummary ) {
+		const overflowCount = currency === 'EUR' || currency === 'JPY' ? 1 : 0;
+		return (
+			<PaymentMethodLogos className="credit-card__logos">
+				<VisaLogo />
+				<MastercardLogo />
+				<AmexLogo />
+				{ overflowCount > 0 && (
+					<span className="credit-card__logos-overflow">{ `+${ overflowCount }` }</span>
+				) }
+			</PaymentMethodLogos>
+		);
+	}
+
 	return (
 		<PaymentMethodLogos className="credit-card__logos">
 			{ currency === 'EUR' && <CBLogo className="has-background" /> }

--- a/client/my-sites/checkout/utils/use-equivalent-monthly-totals.ts
+++ b/client/my-sites/checkout/utils/use-equivalent-monthly-totals.ts
@@ -5,7 +5,7 @@ import {
 	type PlanSlug,
 } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
-import { ResponseCartProduct } from '@automattic/shopping-cart';
+import { ResponseCartProduct, type ResponseCart } from '@automattic/shopping-cart';
 import { useMemo } from 'react';
 import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 
@@ -87,4 +87,23 @@ export function getSimulatedCostBeforeDiscounts(
 	return (
 		monthlyPrices[ product.product_slug as PlanSlug ] || product.item_original_subtotal_integer
 	);
+}
+
+/**
+ * Sums `getSimulatedCostBeforeDiscounts` across the cart to give the basis for
+ * the crossed-out subtotal shown in checkout.
+ *
+ * The returned value is in the smallest unit for the currency.
+ * @param responseCart - The cart.
+ * @param monthlyPrices - Map of plan slug to equivalent monthly total, from `useEquivalentMonthlyTotals`.
+ */
+export function getSubtotalBeforeDiscounts(
+	responseCart: ResponseCart,
+	monthlyPrices: Record< PlanSlug, number >
+): number {
+	return responseCart.products.reduce( ( subtotal, product ) => {
+		const originalAmountInteger = getSimulatedCostBeforeDiscounts( product, monthlyPrices );
+		// In specific cases (e.g. premium domains) the original price (renewal) is lower than the due price.
+		return subtotal + Math.max( product.item_subtotal_integer, originalAmountInteger );
+	}, 0 );
 }

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -313,7 +313,9 @@ function WPNonProductLineItem( {
 			data-e2e-product-slug={ lineItem.id }
 			data-product-type={ lineItem.type }
 		>
-			<LineItemTitle isSummary={ isSummary }>{ label }</LineItemTitle>
+			<LineItemTitle className="checkout-line-item__title" isSummary={ isSummary }>
+				{ label }
+			</LineItemTitle>
 
 			<span className="checkout-line-item__price">
 				{ isCartUpdating ? (
@@ -541,7 +543,9 @@ export function BundleLineItem( {
 			data-e2e-product-slug="domain-bundle"
 			data-product-type="domain-bundle"
 		>
-			<LineItemTitle isSummary={ isSummary }>{ bundleLabel }</LineItemTitle>
+			<LineItemTitle className="checkout-line-item__title" isSummary={ isSummary }>
+				{ bundleLabel }
+			</LineItemTitle>
 
 			<span className="checkout-line-item__price">
 				{ isCartUpdating ? (
@@ -1930,7 +1934,7 @@ function CheckoutLineItem( {
 					<GiftBadgeWithText />
 				</MobileGiftWrapper>
 			) }
-			<LineItemTitle isSummary={ isSummary }>
+			<LineItemTitle className="checkout-line-item__title" isSummary={ isSummary }>
 				{ label }
 				{ responseCart.is_gift_purchase && (
 					<DesktopGiftWrapper>

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -911,14 +911,14 @@ export function LineItemSublabelAndPrice( {
 	shouldShowComparison,
 	compareToPrice,
 	isRenewalPricingExperiment,
-	isMobileStickySummary,
+	isMobileCheckoutStickySummary,
 	isCartUpdating,
 }: {
 	product: ResponseCartProduct;
 	shouldShowComparison?: boolean;
 	compareToPrice?: number;
 	isRenewalPricingExperiment?: boolean;
-	isMobileStickySummary?: boolean;
+	isMobileCheckoutStickySummary?: boolean;
 	isCartUpdating?: boolean;
 } ) {
 	const translate = useTranslate();
@@ -1092,10 +1092,10 @@ export function LineItemSublabelAndPrice( {
 			stripZeros: true,
 		} );
 		// Gated off for the sticky summary: the strikethrough moves inline next to
-		// the price (see mobileStickyMonthlyCycleCrossedOutDisplay), so without this
+		// the price (see mobileCheckoutStickyMonthlyCycleCrossedOutDisplay), so without this
 		// it would render in both places.
 		const showCrossedOutPrice =
-			! isMobileStickySummary &&
+			! isMobileCheckoutStickySummary &&
 			product.item_original_subtotal_integer / ( product.months_per_bill_period ?? 1 ) !==
 				compareToPrice;
 
@@ -1137,20 +1137,20 @@ export function LineItemSublabelAndPrice( {
 								args: { price: actualMonthlyPrice },
 							} ) }
 						{ ! isRenewalPricingExperiment &&
-							isMobileStickySummary &&
+							isMobileCheckoutStickySummary &&
 							translate( '%(price)s billed annually', {
 								args: { price: actualSubtotal },
 								comment:
 									"Annual price formatted with the currency (e.g. '$99.99'); shown as the sublabel of a yearly plan line item in the mobile sticky checkout summary.",
 							} ) }
 						{ ! isRenewalPricingExperiment &&
-							! isMobileStickySummary &&
+							! isMobileCheckoutStickySummary &&
 							translate( 'Billed every year' ) }
 					</LineItemSublabelTitle>
 					{ showCrossedOutPrice && (
 						<s>
 							{ monthlyPrice }
-							{ ! isMobileStickySummary && <> { translate( '/month' ) }</> }
+							{ ! isMobileCheckoutStickySummary && <> { translate( '/month' ) }</> }
 						</s>
 					) }
 				</>
@@ -1166,14 +1166,14 @@ export function LineItemSublabelAndPrice( {
 								args: { price: actualMonthlyPrice },
 							} ) }
 						{ ! isRenewalPricingExperiment &&
-							isMobileStickySummary &&
+							isMobileCheckoutStickySummary &&
 							translate( '%(price)s billed every two years', {
 								args: { price: actualSubtotal },
 								comment:
 									"Total price formatted with the currency (e.g. '$99.99'); shown as the sublabel of a two-year plan line item in the mobile sticky checkout summary.",
 							} ) }
 						{ ! isRenewalPricingExperiment &&
-							! isMobileStickySummary &&
+							! isMobileCheckoutStickySummary &&
 							translate( 'Billed every 2 years' ) }
 					</LineItemSublabelTitle>
 					{ showCrossedOutPrice && (
@@ -1194,14 +1194,14 @@ export function LineItemSublabelAndPrice( {
 								args: { price: actualMonthlyPrice },
 							} ) }
 						{ ! isRenewalPricingExperiment &&
-							isMobileStickySummary &&
+							isMobileCheckoutStickySummary &&
 							translate( '%(price)s billed every three years', {
 								args: { price: actualSubtotal },
 								comment:
 									"Total price formatted with the currency (e.g. '$99.99'); shown as the sublabel of a three-year plan line item in the mobile sticky checkout summary.",
 							} ) }
 						{ ! isRenewalPricingExperiment &&
-							! isMobileStickySummary &&
+							! isMobileCheckoutStickySummary &&
 							translate( 'Billed every 3 years' ) }
 					</LineItemSublabelTitle>
 					{ showCrossedOutPrice && (
@@ -1633,8 +1633,8 @@ function LineItemPriceContent( {
 	actualAmountDisplay,
 	originalAmountDisplay,
 	stackedCrossedOutDisplay,
-	isMobileStickySummary,
-	mobileStickyMonthlyCycleCrossedOutDisplay,
+	isMobileCheckoutStickySummary,
+	mobileCheckoutStickyMonthlyCycleCrossedOutDisplay,
 }: {
 	isCartUpdating: boolean;
 	shouldShowComparison?: boolean;
@@ -1645,8 +1645,8 @@ function LineItemPriceContent( {
 	actualAmountDisplay: string;
 	originalAmountDisplay: string;
 	stackedCrossedOutDisplay?: string;
-	isMobileStickySummary?: boolean;
-	mobileStickyMonthlyCycleCrossedOutDisplay?: string;
+	isMobileCheckoutStickySummary?: boolean;
+	mobileCheckoutStickyMonthlyCycleCrossedOutDisplay?: string;
 } ) {
 	const translate = useTranslate();
 
@@ -1662,10 +1662,10 @@ function LineItemPriceContent( {
 					crossedOutAmount={
 						isDiscounted && ! isRenewalPricingExperiment
 							? originalMonthlyAmountDisplay
-							: mobileStickyMonthlyCycleCrossedOutDisplay
+							: mobileCheckoutStickyMonthlyCycleCrossedOutDisplay
 					}
 				/>
-				{ isMobileStickySummary ? translate( '/mo' ) : <> { translate( '/month' ) }</> }
+				{ isMobileCheckoutStickySummary ? translate( '/mo' ) : <> { translate( '/month' ) }</> }
 			</>
 		);
 	}
@@ -1700,7 +1700,7 @@ function CheckoutLineItem( {
 	shouldShowComparison,
 	compareToPrice,
 	isRenewalPricingExperiment,
-	isMobileStickySummary,
+	isMobileCheckoutStickySummary,
 }: PropsWithChildren< {
 	product: ResponseCartProduct;
 	className?: string;
@@ -1721,7 +1721,7 @@ function CheckoutLineItem( {
 	shouldShowComparison?: boolean;
 	compareToPrice?: number;
 	isRenewalPricingExperiment?: boolean;
-	isMobileStickySummary?: boolean;
+	isMobileCheckoutStickySummary?: boolean;
 } > ) {
 	const translate = useTranslate();
 	const hasBundledDomainsInCart = responseCart.products.some(
@@ -1804,8 +1804,8 @@ function CheckoutLineItem( {
 	// 3838:3619/3620). Only fills in where control shows none — the consumer keeps
 	// the pre-discount strikethrough ahead of this. Gated on isRenewalPricingExperiment
 	// so it doesn't leak a strikethrough into that experiment's arm.
-	const mobileStickyMonthlyCycleCrossedOutDisplay =
-		isMobileStickySummary &&
+	const mobileCheckoutStickyMonthlyCycleCrossedOutDisplay =
+		isMobileCheckoutStickySummary &&
 		! isRenewalPricingExperiment &&
 		shouldShowComparison &&
 		compareToPrice &&
@@ -1842,7 +1842,7 @@ function CheckoutLineItem( {
 	// add-on, Akismet has its own slug pattern distinct from Jetpack, so the
 	// specific checks come before the broader ones.
 	const removeLabel = ( () => {
-		if ( ! isMobileStickySummary ) {
+		if ( ! isMobileCheckoutStickySummary ) {
 			return translate( 'Remove from cart' );
 		}
 		if ( isPlan( product ) ) {
@@ -1950,8 +1950,10 @@ function CheckoutLineItem( {
 					actualAmountDisplay={ actualAmountDisplay }
 					originalAmountDisplay={ originalAmountDisplay }
 					stackedCrossedOutDisplay={ stackedCrossedOutDisplay }
-					isMobileStickySummary={ isMobileStickySummary }
-					mobileStickyMonthlyCycleCrossedOutDisplay={ mobileStickyMonthlyCycleCrossedOutDisplay }
+					isMobileCheckoutStickySummary={ isMobileCheckoutStickySummary }
+					mobileCheckoutStickyMonthlyCycleCrossedOutDisplay={
+						mobileCheckoutStickyMonthlyCycleCrossedOutDisplay
+					}
 				/>
 			</span>
 
@@ -1967,7 +1969,7 @@ function CheckoutLineItem( {
 								shouldShowComparison={ shouldShowComparison }
 								compareToPrice={ compareToPrice }
 								isRenewalPricingExperiment={ isRenewalPricingExperiment }
-								isMobileStickySummary={ isMobileStickySummary }
+								isMobileCheckoutStickySummary={ isMobileCheckoutStickySummary }
 								isCartUpdating={ isCartUpdating }
 							/>
 							<DomainDiscountCallout product={ product } />
@@ -1987,7 +1989,7 @@ function CheckoutLineItem( {
 					<LineItemSublabelAndPrice
 						product={ product }
 						isRenewalPricingExperiment={ isRenewalPricingExperiment }
-						isMobileStickySummary={ isMobileStickySummary }
+						isMobileCheckoutStickySummary={ isMobileCheckoutStickySummary }
 						isCartUpdating={ isCartUpdating }
 					/>
 				</LineItemMeta>

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -911,17 +911,23 @@ export function LineItemSublabelAndPrice( {
 	shouldShowComparison,
 	compareToPrice,
 	isRenewalPricingExperiment,
+	isMobileStickySummary,
 	isCartUpdating,
 }: {
 	product: ResponseCartProduct;
 	shouldShowComparison?: boolean;
 	compareToPrice?: number;
 	isRenewalPricingExperiment?: boolean;
+	isMobileStickySummary?: boolean;
 	isCartUpdating?: boolean;
 } ) {
 	const translate = useTranslate();
 	const productSlug = product.product_slug;
 	const price = formatCurrency( product.item_original_subtotal_integer, product.currency, {
+		isSmallestUnit: true,
+		stripZeros: true,
+	} );
+	const actualSubtotal = formatCurrency( product.item_subtotal_integer, product.currency, {
 		isSmallestUnit: true,
 		stripZeros: true,
 	} );
@@ -1085,9 +1091,13 @@ export function LineItemSublabelAndPrice( {
 			isSmallestUnit: true,
 			stripZeros: true,
 		} );
+		// Gated off for the sticky summary: the strikethrough moves inline next to
+		// the price (see mobileStickyMonthlyCycleCrossedOutDisplay), so without this
+		// it would render in both places.
 		const showCrossedOutPrice =
+			! isMobileStickySummary &&
 			product.item_original_subtotal_integer / ( product.months_per_bill_period ?? 1 ) !==
-			compareToPrice;
+				compareToPrice;
 
 		// Renewal Pricing: Calculate actual monthly renewal price
 		const actualMonthlyPrice = formatCurrency(
@@ -1122,15 +1132,25 @@ export function LineItemSublabelAndPrice( {
 			return (
 				<>
 					<LineItemSublabelTitle>
-						{ isRenewalPricingExperiment
-							? translate( 'Auto-renews at %(price)s/month. Billed every 12 months.', {
-									args: { price: actualMonthlyPrice },
-							  } )
-							: translate( 'Billed every year' ) }
+						{ isRenewalPricingExperiment &&
+							translate( 'Auto-renews at %(price)s/month. Billed every 12 months.', {
+								args: { price: actualMonthlyPrice },
+							} ) }
+						{ ! isRenewalPricingExperiment &&
+							isMobileStickySummary &&
+							translate( '%(price)s billed annually', {
+								args: { price: actualSubtotal },
+								comment:
+									"Annual price formatted with the currency (e.g. '$99.99'); shown as the sublabel of a yearly plan line item in the mobile sticky checkout summary.",
+							} ) }
+						{ ! isRenewalPricingExperiment &&
+							! isMobileStickySummary &&
+							translate( 'Billed every year' ) }
 					</LineItemSublabelTitle>
 					{ showCrossedOutPrice && (
 						<s>
-							{ monthlyPrice } { translate( '/month' ) }
+							{ monthlyPrice }
+							{ ! isMobileStickySummary && <> { translate( '/month' ) }</> }
 						</s>
 					) }
 				</>
@@ -1141,11 +1161,20 @@ export function LineItemSublabelAndPrice( {
 			return (
 				<>
 					<LineItemSublabelTitle>
-						{ isRenewalPricingExperiment
-							? translate( 'Auto-renews at %(price)s/month. Billed every 24 months.', {
-									args: { price: actualMonthlyPrice },
-							  } )
-							: translate( 'Billed every 2 years' ) }
+						{ isRenewalPricingExperiment &&
+							translate( 'Auto-renews at %(price)s/month. Billed every 24 months.', {
+								args: { price: actualMonthlyPrice },
+							} ) }
+						{ ! isRenewalPricingExperiment &&
+							isMobileStickySummary &&
+							translate( '%(price)s billed every two years', {
+								args: { price: actualSubtotal },
+								comment:
+									"Total price formatted with the currency (e.g. '$99.99'); shown as the sublabel of a two-year plan line item in the mobile sticky checkout summary.",
+							} ) }
+						{ ! isRenewalPricingExperiment &&
+							! isMobileStickySummary &&
+							translate( 'Billed every 2 years' ) }
 					</LineItemSublabelTitle>
 					{ showCrossedOutPrice && (
 						<s>
@@ -1160,11 +1189,20 @@ export function LineItemSublabelAndPrice( {
 			return (
 				<>
 					<LineItemSublabelTitle>
-						{ isRenewalPricingExperiment
-							? translate( 'Auto-renews at %(price)s/month. Billed every 36 months.', {
-									args: { price: actualMonthlyPrice },
-							  } )
-							: translate( 'Billed every 3 years' ) }
+						{ isRenewalPricingExperiment &&
+							translate( 'Auto-renews at %(price)s/month. Billed every 36 months.', {
+								args: { price: actualMonthlyPrice },
+							} ) }
+						{ ! isRenewalPricingExperiment &&
+							isMobileStickySummary &&
+							translate( '%(price)s billed every three years', {
+								args: { price: actualSubtotal },
+								comment:
+									"Total price formatted with the currency (e.g. '$99.99'); shown as the sublabel of a three-year plan line item in the mobile sticky checkout summary.",
+							} ) }
+						{ ! isRenewalPricingExperiment &&
+							! isMobileStickySummary &&
+							translate( 'Billed every 3 years' ) }
 					</LineItemSublabelTitle>
 					{ showCrossedOutPrice && (
 						<s>
@@ -1595,6 +1633,8 @@ function LineItemPriceContent( {
 	actualAmountDisplay,
 	originalAmountDisplay,
 	stackedCrossedOutDisplay,
+	isMobileStickySummary,
+	mobileStickyMonthlyCycleCrossedOutDisplay,
 }: {
 	isCartUpdating: boolean;
 	shouldShowComparison?: boolean;
@@ -1605,6 +1645,8 @@ function LineItemPriceContent( {
 	actualAmountDisplay: string;
 	originalAmountDisplay: string;
 	stackedCrossedOutDisplay?: string;
+	isMobileStickySummary?: boolean;
+	mobileStickyMonthlyCycleCrossedOutDisplay?: string;
 } ) {
 	const translate = useTranslate();
 
@@ -1618,10 +1660,12 @@ function LineItemPriceContent( {
 				<LineItemPrice
 					actualAmount={ monthlyAmountDisplay }
 					crossedOutAmount={
-						isDiscounted && ! isRenewalPricingExperiment ? originalMonthlyAmountDisplay : undefined
+						isDiscounted && ! isRenewalPricingExperiment
+							? originalMonthlyAmountDisplay
+							: mobileStickyMonthlyCycleCrossedOutDisplay
 					}
-				/>{ ' ' }
-				{ translate( '/month' ) }
+				/>
+				{ isMobileStickySummary ? translate( '/mo' ) : <> { translate( '/month' ) }</> }
 			</>
 		);
 	}
@@ -1656,6 +1700,7 @@ function CheckoutLineItem( {
 	shouldShowComparison,
 	compareToPrice,
 	isRenewalPricingExperiment,
+	isMobileStickySummary,
 }: PropsWithChildren< {
 	product: ResponseCartProduct;
 	className?: string;
@@ -1676,6 +1721,7 @@ function CheckoutLineItem( {
 	shouldShowComparison?: boolean;
 	compareToPrice?: number;
 	isRenewalPricingExperiment?: boolean;
+	isMobileStickySummary?: boolean;
 } > ) {
 	const translate = useTranslate();
 	const hasBundledDomainsInCart = responseCart.products.some(
@@ -1754,6 +1800,22 @@ function CheckoutLineItem( {
 		itemSubtotalInteger < originalAmountInteger && originalAmountDisplay
 	);
 
+	// Monthly-cycle strikethrough shown inline in the main price column (Figma
+	// 3838:3619/3620). Only fills in where control shows none — the consumer keeps
+	// the pre-discount strikethrough ahead of this. Gated on isRenewalPricingExperiment
+	// so it doesn't leak a strikethrough into that experiment's arm.
+	const mobileStickyMonthlyCycleCrossedOutDisplay =
+		isMobileStickySummary &&
+		! isRenewalPricingExperiment &&
+		shouldShowComparison &&
+		compareToPrice &&
+		pricePerMonth !== compareToPrice
+			? formatCurrency( compareToPrice, product.currency, {
+					isSmallestUnit: true,
+					stripZeros: true,
+			  } )
+			: undefined;
+
 	// For products with stacked cost overrides (e.g. premium domains with a
 	// price-increasing intro offer + sale coupon: $80 → $1,100 → $275), show
 	// the pre-discount price ($1,100) crossed out next to the final price.
@@ -1773,6 +1835,42 @@ function CheckoutLineItem( {
 		isGoogleWorkspaceProductSlug( productSlug ) ||
 		isGSuiteOrExtraLicenseProductSlug( productSlug ) ||
 		isTitanMail( product );
+
+	// Under the mobile sticky experiment the remove link uses a per-product
+	// label ("Remove plan/domain/email/…") instead of the generic "Remove
+	// from cart" — Figma 2392:15397. Order matters: storage is also an
+	// add-on, Akismet has its own slug pattern distinct from Jetpack, so the
+	// specific checks come before the broader ones.
+	const removeLabel = ( () => {
+		if ( ! isMobileStickySummary ) {
+			return translate( 'Remove from cart' );
+		}
+		if ( isPlan( product ) ) {
+			return translate( 'Remove plan' );
+		}
+		if ( isDomainRegistration( product ) ) {
+			return translate( 'Remove domain' );
+		}
+		if ( isEmail ) {
+			return translate( 'Remove email' );
+		}
+		if ( isTieredVolumeSpaceAddon( product ) ) {
+			return translate( 'Remove storage' );
+		}
+		if ( isDIFMProduct( product ) ) {
+			return translate( 'Remove service' );
+		}
+		if ( isAkismetProduct( product ) ) {
+			return translate( 'Remove Akismet' );
+		}
+		if ( isJetpackProductSlug( productSlug ) ) {
+			return translate( 'Remove Jetpack' );
+		}
+		if ( isAddOn( product ) ) {
+			return translate( 'Remove add-on' );
+		}
+		return translate( 'Remove from cart' );
+	} )();
 
 	const containsPartnerCoupon = getPartnerCoupon( {
 		coupon: responseCart.coupon,
@@ -1852,6 +1950,8 @@ function CheckoutLineItem( {
 					actualAmountDisplay={ actualAmountDisplay }
 					originalAmountDisplay={ originalAmountDisplay }
 					stackedCrossedOutDisplay={ stackedCrossedOutDisplay }
+					isMobileStickySummary={ isMobileStickySummary }
+					mobileStickyMonthlyCycleCrossedOutDisplay={ mobileStickyMonthlyCycleCrossedOutDisplay }
 				/>
 			</span>
 
@@ -1867,6 +1967,7 @@ function CheckoutLineItem( {
 								shouldShowComparison={ shouldShowComparison }
 								compareToPrice={ compareToPrice }
 								isRenewalPricingExperiment={ isRenewalPricingExperiment }
+								isMobileStickySummary={ isMobileStickySummary }
 								isCartUpdating={ isCartUpdating }
 							/>
 							<DomainDiscountCallout product={ product } />
@@ -1886,6 +1987,7 @@ function CheckoutLineItem( {
 					<LineItemSublabelAndPrice
 						product={ product }
 						isRenewalPricingExperiment={ isRenewalPricingExperiment }
+						isMobileStickySummary={ isMobileStickySummary }
 						isCartUpdating={ isCartUpdating }
 					/>
 				</LineItemMeta>
@@ -1938,7 +2040,7 @@ function CheckoutLineItem( {
 								onRemoveProductClick?.( label );
 							} }
 						>
-							{ translate( 'Remove from cart' ) }
+							{ removeLabel }
 						</DeleteButton>
 					</DeleteButtonWrapper>
 

--- a/packages/wpcom-checkout/test/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/test/checkout-line-items.tsx
@@ -156,7 +156,7 @@ describe( 'LineItemSublabelAndPrice', () => {
 					product={ yearlyPlan }
 					shouldShowComparison
 					compareToPrice={ compareToPrice }
-					isMobileStickySummary
+					isMobileCheckoutStickySummary
 				/>
 			);
 
@@ -184,7 +184,7 @@ describe( 'LineItemSublabelAndPrice', () => {
 					product={ yearlyPlan }
 					shouldShowComparison
 					compareToPrice={ compareToPrice }
-					isMobileStickySummary
+					isMobileCheckoutStickySummary
 				/>
 			);
 
@@ -197,7 +197,7 @@ describe( 'LineItemSublabelAndPrice', () => {
 					product={ yearlyPlan }
 					shouldShowComparison
 					compareToPrice={ compareToPrice }
-					isMobileStickySummary
+					isMobileCheckoutStickySummary
 					isRenewalPricingExperiment
 				/>
 			);

--- a/packages/wpcom-checkout/test/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/test/checkout-line-items.tsx
@@ -119,4 +119,91 @@ describe( 'LineItemSublabelAndPrice', () => {
 			);
 		} );
 	} );
+
+	// The mobile sticky-summary experiment restyles the yearly sublabel and moves
+	// the monthly-cycle strikethrough into the main price column. These cover the
+	// sublabel side of that split; the price-column side lives in the private
+	// LineItemPriceContent.
+	describe( 'mobile sticky summary — yearly plan sublabel', () => {
+		const yearlyPlan = {
+			...getEmptyResponseCartProduct(),
+			product_slug: 'value_bundle',
+			months_per_bill_period: 12,
+			currency: 'USD',
+			item_subtotal_integer: 9600,
+			item_original_subtotal_integer: 9600,
+		};
+		// compareToPrice is the monthly-cycle price used for the "vs monthly"
+		// comparison; differing from the item's own per-month price is what makes
+		// control render a strikethrough.
+		const compareToPrice = 1000;
+
+		test( 'control renders the plain "Billed every year" sublabel', () => {
+			render(
+				<LineItemSublabelAndPrice
+					product={ yearlyPlan }
+					shouldShowComparison
+					compareToPrice={ compareToPrice }
+				/>
+			);
+
+			expect( screen.getByText( 'Billed every year' ) ).toBeVisible();
+		} );
+
+		test( 'treatment renders the annual price in the sublabel instead', () => {
+			render(
+				<LineItemSublabelAndPrice
+					product={ yearlyPlan }
+					shouldShowComparison
+					compareToPrice={ compareToPrice }
+					isMobileStickySummary
+				/>
+			);
+
+			expect( screen.getByText( '$96 billed annually' ) ).toBeVisible();
+			expect( screen.queryByText( 'Billed every year' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'control keeps the monthly-cycle strikethrough in the sublabel', () => {
+			const { container } = render(
+				<LineItemSublabelAndPrice
+					product={ yearlyPlan }
+					shouldShowComparison
+					compareToPrice={ compareToPrice }
+				/>
+			);
+
+			expect( container.querySelector( 's' ) ).toBeVisible();
+		} );
+
+		// Without this gate the strikethrough renders twice under treatment: once
+		// here and once inline next to the live price.
+		test( 'treatment drops the sublabel strikethrough so it is not shown twice', () => {
+			const { container } = render(
+				<LineItemSublabelAndPrice
+					product={ yearlyPlan }
+					shouldShowComparison
+					compareToPrice={ compareToPrice }
+					isMobileStickySummary
+				/>
+			);
+
+			expect( container.querySelector( 's' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'the renewal-pricing experiment still wins over the treatment sublabel', () => {
+			render(
+				<LineItemSublabelAndPrice
+					product={ yearlyPlan }
+					shouldShowComparison
+					compareToPrice={ compareToPrice }
+					isMobileStickySummary
+					isRenewalPricingExperiment
+				/>
+			);
+
+			expect( screen.getByText( /Auto-renews at/ ) ).toBeVisible();
+			expect( screen.queryByText( '$96 billed annually' ) ).not.toBeInTheDocument();
+		} );
+	} );
 } );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2263/redesign-checkout-for-mobile-with-sticky-order-summary

A re-creation of https://github.com/Automattic/wp-calypso/pull/110909 with merge commits removed and architecture fixes applied.

## What & why

Experiment `calypso_mobile_checkout_sticky_summary_v1`: a redesigned **mobile checkout** — restyled payment-method card, contact step, VAT form, variant picker, and order-review rows — with the order summary moved into a fixed bottom bar (collapsed: total + Pay button; expanded: full line items). Tests conversion lift.

Renders only on a mobile viewport in a stepper (StepContainerV2) flow — onboarding, plan upgrades, domains, migrations, etc. The treatment reuses existing primitives (the real `CheckoutFormSubmit` is portaled into the bar; line items, amounts, and terms come from the same components control uses) and only renders in the eligible arm, so control is untouched.

## Experiment integrity

- Eligibility gated to mobile **and** a StepContainerV2 flow (no enrollment on `/me/purchases`).
- Waits for the ExPlat assignment before painting — no control→treatment flash, no metric self-bias.
- **Amounts match control**: per-product prices, discounts, tax, and the crossed-out total all come from control's own helpers, so the panel reconciles and the two arms quote identical numbers.
- **Content parity, relocated not removed**: coupon/tax/credits rows are shown; the money-back guarantee is surfaced at payment entry (continuing the "secure and encrypted" notice); Terms of Service sits above the CTA. Stripe's co-brand network picker (`showIcon`) stays on.

## Recordings (current vs. treatment)


https://github.com/user-attachments/assets/4f9347b7-8e2d-4a05-974d-d3ef61a28dcb

https://github.com/user-attachments/assets/8bf59289-feba-4b81-a4fa-69308e1b31bd


## Testing

Renders only <600px in a StepContainerV2 flow. Open a checkout URL with `redirect_to` at an onboarding flow (plain `/checkout/<site>` shows control), then force the variant:

```js
localStorage.setItem( 'explat-experiment--calypso_mobile_checkout_sticky_summary_v1', JSON.stringify( {
  experimentName: 'calypso_mobile_checkout_sticky_summary_v1',
  variationName: 'treatment', // or 'control'
  retrievedTimestamp: Date.now(), ttl: 3600,
} ) );
```
