### PR TITLE
Build-wow: stop the status poller mislabelling real failures as timeouts

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/build-status-poller.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/build-status-poller.ts
@@ -15,6 +15,7 @@ const BUILD_WOW_FAILED_STATUS_PREFIX = 'failed:';
 export const BUILD_WOW_DELIVERY_PHASES = [ 'delivering', 'activating', 'verifying' ] as const;
 
 const MAX_REPORTED_ERROR_REASONS = 3;
+const MAX_ERROR_REASON_LENGTH = 300;
 
 // Maps a delivery phase onto the tail of the designed step list, so a build that
 // is already `delivering` when this screen loads does not jump straight to the
@@ -42,16 +43,44 @@ function reportSafely( report: () => void ): void {
 }
 
 // An aborted proxy request rejects with a DOM Event rather than an Error
-// (wpcom-proxy-request passes the abort event straight to the callback), which
-// stringifies to a useless "[object Event]".
+// (wpcom-proxy-request hands the abort event straight to the callback), and an
+// Event has no `message`, so it would otherwise stringify to "[object Event]".
+function isAbortLike( error: unknown ): boolean {
+	if ( typeof Event !== 'undefined' && error instanceof Event ) {
+		return true;
+	}
+	if ( ! error || typeof error !== 'object' ) {
+		return false;
+	}
+	const { name, type } = error as { name?: unknown; type?: unknown };
+	return name === 'AbortError' || type === 'abort';
+}
+
+// Failures arrive as WPError, which extends Error and carries the HTTP status
+// separately from the message — and whose message the response body can
+// overwrite, so two different statuses can share one string. The status is kept
+// in the reason so those stay distinguishable, both in the log and in the
+// dedup set.
 function describeRequestError( error: unknown ): string {
+	if ( isAbortLike( error ) ) {
+		return 'request aborted';
+	}
+
+	let message: string;
 	if ( error instanceof Error ) {
-		return error.message;
+		message = error.message;
+	} else if ( error && typeof error === 'object' && 'message' in error ) {
+		message = String( ( error as { message: unknown } ).message );
+	} else {
+		message = String( error );
 	}
-	if ( error && typeof error === 'object' && 'message' in error ) {
-		return String( ( error as { message: unknown } ).message );
-	}
-	return String( error );
+
+	const status =
+		error && typeof error === 'object' && 'status' in error
+			? ( error as { status?: unknown } ).status
+			: undefined;
+
+	return ( status ? `${ status } ${ message }` : message ).slice( 0, MAX_ERROR_REASON_LENGTH );
 }
 
 type BuildWowStatusResponse = {
@@ -100,15 +129,18 @@ export function pollForBuildWowStatus( {
 
 	const poll = async () => {
 		const controller = new AbortController();
-		const timeout = setTimeout( () => controller.abort(), requestTimeoutMs );
+		let hasPassedDeadline = false;
+		const timeout = setTimeout( () => {
+			hasPassedDeadline = true;
+			controller.abort();
+		}, requestTimeoutMs );
 		requestController = controller;
 		requestTimeout = timeout;
 
-		let status: string | undefined;
+		let response: BuildWowStatusResponse | undefined;
 
 		try {
-			const response = await fetchStatus( siteIdentifier, controller.signal );
-			status = typeof response.build_status === 'string' ? response.build_status : undefined;
+			response = await fetchStatus( siteIdentifier, controller.signal );
 		} catch ( error ) {
 			// A failed status request does not mean the generation failed; keep polling.
 			// Nothing is reported once the poller has been stopped: tearing down aborts
@@ -117,9 +149,14 @@ export function pollForBuildWowStatus( {
 			// a 3s interval cannot emit hundreds of entries but a later, more
 			// informative error is not hidden behind the first one either.
 			if ( isActive ) {
-				const reason = controller.signal.aborted
-					? `request timed out after ${ requestTimeoutMs }ms`
-					: describeRequestError( error );
+				// The deadline having passed is not on its own proof that this rejection
+				// is the abort: transports that ignore the signal run the request to its
+				// real conclusion, and calling that a timeout would discard the actual
+				// error. Both have to hold.
+				const reason =
+					hasPassedDeadline && isAbortLike( error )
+						? `request timed out after ${ requestTimeoutMs }ms`
+						: describeRequestError( error );
 				if (
 					! reportedReasons.has( reason ) &&
 					reportedReasons.size < MAX_REPORTED_ERROR_REASONS
@@ -137,6 +174,10 @@ export function pollForBuildWowStatus( {
 		if ( ! isActive ) {
 			return;
 		}
+
+		// Parsed outside the try so a malformed response cannot be reported as a
+		// request failure.
+		const status = typeof response?.build_status === 'string' ? response.build_status : undefined;
 
 		// Terminal callbacks are dispatched outside the try so a throw from one of them
 		// cannot be mistaken for a request failure and silently reschedule the poll.
@@ -163,12 +204,15 @@ export function pollForBuildWowStatus( {
 
 	return () => {
 		isActive = false;
+		// Both timers are cleared before aborting: abort() runs the transport's own
+		// listeners synchronously, and teardown happens exactly when the page is
+		// going away, so a throw from one of them must not leak the request timer.
 		if ( pollTimeout !== undefined ) {
 			clearTimeout( pollTimeout );
 		}
-		requestController?.abort();
 		if ( requestTimeout !== undefined ) {
 			clearTimeout( requestTimeout );
 		}
+		requestController?.abort();
 	};
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/build-status-poller.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/build-status-poller.ts
@@ -221,6 +221,77 @@ describe( 'pollForBuildWowStatus', () => {
 		expect( onRequestError ).not.toHaveBeenCalled();
 	} );
 
+	it( 'reports the real error when the deadline passed but the request was never aborted', async () => {
+		// Transports that ignore the signal (wpcom-xhr-request) run the request to its
+		// real conclusion, so the deadline having passed must not overwrite the cause.
+		const fetchStatus = jest.fn(
+			() =>
+				new Promise< { build_status?: string } >( ( _resolve, reject ) => {
+					setTimeout(
+						() => reject( Object.assign( new Error( 'Bad gateway' ), { status: 502 } ) ),
+						900
+					);
+				} )
+		);
+		const onRequestError = jest.fn();
+
+		pollForBuildWowStatus( {
+			siteIdentifier: '123',
+			onReady: jest.fn(),
+			onFailed: jest.fn(),
+			onRequestError,
+			pollIntervalMs: 5000,
+			requestTimeoutMs: 500,
+			fetchStatus,
+		} );
+
+		await jest.advanceTimersByTimeAsync( 1000 );
+
+		expect( onRequestError ).toHaveBeenCalledWith( '502 Bad gateway' );
+	} );
+
+	it( 'keeps distinct HTTP statuses apart even when they share a message', async () => {
+		const fetchStatus = jest
+			.fn()
+			.mockRejectedValueOnce( Object.assign( new Error( 'Unauthorized.' ), { status: 401 } ) )
+			.mockRejectedValue( Object.assign( new Error( 'Unauthorized.' ), { status: 403 } ) );
+		const onRequestError = jest.fn();
+
+		pollForBuildWowStatus( {
+			siteIdentifier: '123',
+			onReady: jest.fn(),
+			onFailed: jest.fn(),
+			onRequestError,
+			pollIntervalMs: 1000,
+			fetchStatus,
+		} );
+
+		await jest.advanceTimersByTimeAsync( 2000 );
+
+		expect( onRequestError.mock.calls.map( ( call ) => call[ 0 ] ) ).toEqual( [
+			'401 Unauthorized.',
+			'403 Unauthorized.',
+		] );
+	} );
+
+	it( 'describes a rejection that is not an Error', async () => {
+		const fetchStatus = jest.fn().mockRejectedValue( { message: 'gateway exploded' } );
+		const onRequestError = jest.fn();
+
+		pollForBuildWowStatus( {
+			siteIdentifier: '123',
+			onReady: jest.fn(),
+			onFailed: jest.fn(),
+			onRequestError,
+			pollIntervalMs: 1000,
+			fetchStatus,
+		} );
+
+		await jest.advanceTimersByTimeAsync( 0 );
+
+		expect( onRequestError ).toHaveBeenCalledWith( 'gateway exploded' );
+	} );
+
 	it( 'reports a request timeout as a readable reason, not "[object Event]"', async () => {
 		const fetchStatus = jest.fn(
 			( _siteIdentifier: string, signal: AbortSignal ) =>
@@ -360,7 +431,7 @@ describe( 'pollForBuildWowStatus', () => {
 		expect( onReady ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'stops polling and aborts the current request when cancelled', async () => {
+	it( 'stops scheduling further polls when cancelled between requests', async () => {
 		const fetchStatus = jest.fn().mockResolvedValue( {} );
 		const stop = pollForBuildWowStatus( {
 			siteIdentifier: '123',
@@ -375,5 +446,28 @@ describe( 'pollForBuildWowStatus', () => {
 		await jest.advanceTimersByTimeAsync( 5000 );
 
 		expect( fetchStatus ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'aborts the request that is still in flight when cancelled', async () => {
+		let capturedSignal: AbortSignal | undefined;
+		const fetchStatus = jest.fn( ( _siteIdentifier: string, signal: AbortSignal ) => {
+			capturedSignal = signal;
+			return new Promise< { build_status?: string } >( () => {} );
+		} );
+
+		const stop = pollForBuildWowStatus( {
+			siteIdentifier: '123',
+			onReady: jest.fn(),
+			onFailed: jest.fn(),
+			pollIntervalMs: 1000,
+			fetchStatus,
+		} );
+
+		await jest.advanceTimersByTimeAsync( 0 );
+		expect( capturedSignal?.aborted ).toBe( false );
+
+		stop();
+
+		expect( capturedSignal?.aborted ).toBe( true );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/use-site-generation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/use-site-generation.tsx
@@ -144,6 +144,65 @@ describe( 'useSiteGeneration', () => {
 		] );
 	} );
 
+	it( 'stops polling when the hook unmounts', () => {
+		const stopPolling = jest.fn();
+		pollMock.mockReturnValue( stopPolling );
+
+		const { unmount } = renderHook( () =>
+			useSiteGeneration( {
+				siteIdentifier: '123',
+				editorUrl: 'https://example.wordpress.com/wp-admin/site-editor.php',
+				steps: STEPS,
+			} )
+		);
+
+		expect( stopPolling ).not.toHaveBeenCalled();
+		unmount();
+		expect( stopPolling ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'logs a status request failure with the site it belongs to', () => {
+		renderHook( () =>
+			useSiteGeneration( {
+				siteIdentifier: '123',
+				editorUrl: 'https://example.wordpress.com/wp-admin/site-editor.php',
+				steps: STEPS,
+			} )
+		);
+
+		const { onRequestError } = pollMock.mock.calls[ 0 ][ 0 ];
+		act( () => {
+			onRequestError( '502 Bad gateway' );
+		} );
+
+		expect( logMock ).toHaveBeenCalledWith( 'site_generation_status_request_failed', {
+			site_identifier: '123',
+			error: '502 Bad gateway',
+		} );
+	} );
+
+	it( 'keeps the active step in range for a list shorter than the timer sequence', () => {
+		const shortSteps = STEPS.slice( 0, 2 );
+		const { result } = renderHook( () =>
+			useSiteGeneration( {
+				siteIdentifier: '123',
+				editorUrl: 'https://example.wordpress.com/wp-admin/site-editor.php',
+				steps: shortSteps,
+			} )
+		);
+
+		// STEP_DELAYS drives the index past the end of a two-step list; without the
+		// clamp every step reads complete and none is active.
+		act( () => {
+			jest.advanceTimersByTime( 140000 );
+		} );
+
+		expect( result.current.steps.map( ( step ) => step.status ) ).toEqual( [
+			'complete',
+			'active',
+		] );
+	} );
+
 	it( 'never moves progress backwards when statuses arrive out of order', () => {
 		const { result } = renderHook( () =>
 			useSiteGeneration( {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/use-site-generation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/use-site-generation.ts
@@ -71,11 +71,14 @@ export function useSiteGeneration( {
 			// user only ever sees the calm "your brief is saved, check again" state
 			// instead of a dead end.
 			onFailed: ( status ) => {
+				// State first: the poller dispatches terminal callbacks unguarded, so a
+				// throw out of the logging call would otherwise strand the user on a
+				// spinner until the generation deadline.
+				setHasTimedOut( true );
 				logBuildWowEvent( 'site_generation_failed', {
 					status,
 					site_identifier: siteIdentifier,
 				} );
-				setHasTimedOut( true );
 			},
 			onProgress: ( status ) =>
 				setStatusStepIndex( ( previous ) =>
@@ -93,6 +96,10 @@ export function useSiteGeneration( {
 			window.clearTimeout( generationTimeout );
 			stopPolling();
 		};
+		// A change to stepCount restarts everything above it: the generation deadline,
+		// the step timers, and the poller's error deduplication. The shipping step list
+		// is a fixed length, so this never fires today — but make the list conditional
+		// and the 30-minute deadline becomes resettable.
 	}, [ editorUrl, siteIdentifier, hasTimedOut, stepCount ] );
 
 	let failureReason: SiteGenerationFailureReason | undefined;


### PR DESCRIPTION
Part of BIGR-724.

> **Stacked on #112984** — this targets that branch so the diff shows only the follow-up. GitHub will retarget it to `trunk` automatically once #112984 merges. It should land after both #112984 and the paired backend PR, so the telemetry can be confirmed against a real endpoint before it is relied on.

## Proposed Changes

Diagnostics and coverage follow-ups to the build-wow status poller. Nothing here changes what a user sees.

- **A timeout is only claimed when the request was actually aborted.** The poller inferred it from `controller.signal.aborted`, which latches the instant the deadline fires and stays set. It now requires both the deadline to have passed and the rejection to be abort-shaped.
- **The reported reason keeps the HTTP status** and is bounded before it reaches the logging pipeline.
- **`describeRequestError` recognises aborts.** It was documented as handling a rejection that arrives as a DOM `Event` and could not — an `Event` has no `message`, so it fell through and returned the exact `"[object Event]"` the comment said it prevented.
- **Smaller hardening:** response parsing moved below the request `try` so a malformed payload is not reported as a request failure; teardown clears both timers before calling `abort()`; `onFailed` sets state before logging.
- **Coverage:** non-`Error` rejections, distinct statuses sharing a message, the deadline-passed-but-not-aborted path, an assertion that cancellation actually aborts the in-flight signal, plus hook-level unmount, request-failure wiring, and step-clamp tests.

## Why are these changes being made?

`wpcom-xhr-request` has no `signal` support — only `wpcom-proxy-request` honours it, and `client/lib/wp/browser.js` selects the xhr transport for oauth and Jetpack-site builds. On those builds the abort is a no-op, so the request runs on to its real conclusion. Because `signal.aborted` was already latched, a genuine failure minutes later was recorded as `request timed out after 15000ms` and the actual cause was discarded. The fabricated reason also occupied one of the three deduplication slots, so the real error could be prevented from ever being reported. That is the opposite of what the failure telemetry was added for, and it degrades exactly when the endpoint is unhealthy.

The status was worth keeping for the same reason. Failures arrive as `WPError`, which carries the status separately from the message and whose message the response body can overwrite, so a 401 and a 403 sharing a body message collapsed into a single deduplication slot and one was silently dropped.

The coverage gaps are included because several of them would have kept the suite green with the behaviour removed — the test named for the `"[object Event]"` fix drove a hardcoded branch and never called the function it was named after, and the cancellation test asserted only a call count because the request had already settled by the time it ran.

## Testing Instructions

1. `yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test` — 37 tests pass.
2. On a build using the xhr transport, stall a status request past the request deadline and then let it fail for a real reason. Confirm the logged `build_wow_site_generation_status_request_failed` reason is the real error with its HTTP status, not a timeout.
3. Navigate away from the generation screen mid-build and confirm no request-failure event is emitted.

## Pre-merge Checklist

Items from the template that do not apply to this change have been removed: there is no UI change (dark mode, accessibility), no new user-facing strings (string freeze, translations), and no selectors or expensive computations (memoizing).

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes? — 37 tests pass in `site-generation/test`. New coverage for non-`Error` rejections, distinct HTTP statuses sharing a message, the deadline-passed-but-not-aborted path, cancellation actually aborting the in-flight signal, and hook-level unmount / request-failure wiring / step-clamp. The clamp and the callback-liveness guards were each verified by removing them and confirming the new tests fail.
- [x] Have you checked for TypeScript, React or other console errors? — `yarn typecheck-client` reports 19 errors, all pre-existing on `trunk` and none in `site-generation`; `yarn eslint` is clean on the changed directory. Browser verification is pending the paired backend endpoint, since the failure paths this touches cannot be exercised until status requests can actually fail.
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? — build-wow is Atomic-only and gated to Automatticians, so Simple and self-hosted Jetpack do not apply. Atomic testing is blocked until the paired backend endpoint ships; until then the poll 404s and the changed code paths are unreachable.
- [ ] Does this change what data we track or use (p4TIVU-aUh-p2)? — it changes the shape of an existing event rather than adding tracking, and does not affect Jetpack, so no privacy label. Worth a reviewer's eye regardless: `build_wow_site_generation_status_request_failed` now carries the HTTP status alongside a server-supplied error message, capped at 300 characters. The message originates from our own backend, not user input, and `wp-error` copies response-body fields onto the error object — so if that endpoint ever returns something sensitive in `message`, this would put it in Logstash.
