### PR TITLE
A4A Amplify: show a specific message when a site is unreachable

### DIFF
--- a/client/a8c-for-agencies/sections/amplify/add-site/modal.tsx
+++ b/client/a8c-for-agencies/sections/amplify/add-site/modal.tsx
@@ -33,9 +33,15 @@ export default function AmplifyAddSiteModal( { onClose }: { onClose: () => void 
 		// closing this modal reveals the in-progress row. Here we just switch
 		// to the progress view instead of showing a notice.
 		onSuccess: () => setInProgress( true ),
-		onError: () => {
+		onError: ( error ) => {
+			const message =
+				error?.code === 'site_unreachable'
+					? __(
+							'We couldn’t reach this site to analyze it. Make sure it’s online and publicly accessible, then try again.'
+					  )
+					: __( 'Could not start the analysis. Please try again.' );
 			dispatch(
-				errorNotice( __( 'Could not start the analysis. Please try again.' ), {
+				errorNotice( message, {
 					id: 'amplify-analysis-error',
 					duration: 8000,
 				} )


### PR DESCRIPTION
Follow-up to the backend split of the `url` validation on `POST wpcom/v2/agency/{agencyId}/amplify/reports`, which now returns `site_unreachable` / 400 for a well-formed but unreachable URL (distinct from the malformed-input `a4a_amplify_bad_url` / 400). This teaches the client to surface that case. Ships after the wpcom PR deploys.

## Proposed Changes

* **`modal.tsx`** — the start-analysis `onError` now reads the error `code`: `site_unreachable` shows **We couldn’t reach this site to analyze it. Make sure it’s online and publicly accessible, then try again.**; every other failure keeps the existing generic **Could not start the analysis. Please try again.**

## Why are these changes being made?

Picking an offline site returned a 400 that the client collapsed into a generic "please try again" — misleading, since retrying an unreachable site won't help. Now the backend distinguishes the unreachable case, so the notice can tell the user what's actually wrong.

## Testing Instructions

1. Run `yarn start-a8c-for-agencies` and open `agencies.localhost:3000/amplify` as an agency user with the amplify capabilities.
2. Open **Amplify a site**, pick or enter a URL for a site that's offline / doesn't resolve, choose an analysis, and submit.
3. Confirm the error notice reads **We couldn’t reach this site to analyze it…** rather than the generic message.
4. Submit a normal, reachable site and confirm the analysis starts as before; confirm an unrelated failure still shows the generic notice.
5. Confirm no TypeScript/React console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_0161haWbyJiaySsAbjcMHMUC
