### PR TITLE
Fix eslint errors in use-staging-site.ts

### DIFF
--- a/client/dashboard/sites/site/use-staging-site.ts
+++ b/client/dashboard/sites/site/use-staging-site.ts
@@ -228,7 +228,7 @@ export default function useStagingSite( site: Site ) {
 				recordTracksEvent( 'calypso_hosting_configuration_staging_site_add_failure' );
 				createErrorNotice(
 					sprintf(
-						// translators: %(reason)s: is why adding the staging site failed.
+						// translators: %(reason)s: the reason the staging site creation failed.
 						__( 'Failed to create staging site: %(reason)s' ),
 						{ reason: error.message }
 					),

--- a/client/dashboard/sites/site/use-staging-site.ts
+++ b/client/dashboard/sites/site/use-staging-site.ts
@@ -127,7 +127,9 @@ export default function useStagingSite( site: Site ) {
 				explicitDismiss: true,
 				id: 'staging-site-added',
 			} );
-			productionSite && queryClient.invalidateQueries( siteBySlugQuery( productionSite.slug ) );
+			if ( productionSite ) {
+				queryClient.invalidateQueries( siteBySlugQuery( productionSite.slug ) );
+			}
 			queryClient.setQueryData(
 				isCreatingStagingSiteQuery( productionSiteId ?? 0 ).queryKey,
 				false
@@ -226,7 +228,7 @@ export default function useStagingSite( site: Site ) {
 				recordTracksEvent( 'calypso_hosting_configuration_staging_site_add_failure' );
 				createErrorNotice(
 					sprintf(
-						// translators: "reason" is why adding the staging site failed.
+						// translators: %(reason)s: is why adding the staging site failed.
 						__( 'Failed to create staging site: %(reason)s' ),
 						{ reason: error.message }
 					),


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes #

## Proposed Changes

* Wrap the `productionSite &&` conditional in an `if` statement instead of using it as a standalone expression.
* Fix the translator comment above the `%(reason)s` placeholder so it references the correct placeholder name.

## Why are these changes being made?

The eslint `no-unused-expressions` rule was failing on the standalone `productionSite && ...` expression. Separately, the translator comment said `"reason"` instead of `%(reason)s`, which doesn't match the actual placeholder and wouldn't help translators.

## Testing Instructions

* Run `yarn lint:js client/dashboard/sites/site/use-staging-site.ts` — no errors.
* Confirm staging site creation/removal notices still work as before (no functional change).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
