### PR TITLE
Stats: fix broken empty states on email opens/clicks pages

### DIFF
--- a/apps/odyssey-stats/src/styles/typography.scss
+++ b/apps/odyssey-stats/src/styles/typography.scss
@@ -37,6 +37,8 @@ $highlight-card-tooltip-font: Inter, $display-type-font;
 // Replace fonts in client/my-sites/stats/all-time-highlights-section/style.scss.
 .stats__all-time-highlights-section .highlight-card-detail-item-content,
 // Replace fonts in packages/components/src/mobile-promo-card/style.scss.
-.promo-card__title {
+.promo-card__title,
+// Replace fonts in client/my-sites/stats/stats-email-detail/style.scss (the "Email opens" / "Email clicks" heading).
+.stats__email-detail > div > h1 {
 	font-family: $display-type-font;
 }

--- a/apps/odyssey-stats/src/styles/typography.scss
+++ b/apps/odyssey-stats/src/styles/typography.scss
@@ -32,7 +32,13 @@ $highlight-card-tooltip-font: Inter, $display-type-font;
 .highlight-card-heading {
 	font-family: $highlight-card-heading-font;
 }
-.highlight-card-count-value {
+// Doubled up for the same reason as ".highlight-cards-heading" above: this class is also rendered
+// from the stats-email-top-row component (client/my-sites/stats/stats-email-top-row/top-card.jsx),
+// which is a different lazily-loaded route chunk than the rest of HighlightCards, so an un-doubled
+// rule here can lose a specificity tie against the original (un-patched) rule depending on load
+// order. Confirmed live: rendered in Recoleta on the Email opens/clicks pages while every other
+// page using the same class rendered correctly.
+.highlight-card-count-value.highlight-card-count-value {
 	font-family: $highlight-card-count-font;
 }
 .highlight-card-tooltip-content {

--- a/apps/odyssey-stats/src/styles/typography.scss
+++ b/apps/odyssey-stats/src/styles/typography.scss
@@ -1,7 +1,14 @@
 @import "./variables";
 
 // Find all instances of stats-section-header mixin usage and override with stats-section-header-for-jetpack.
-.highlight-cards-heading,
+//
+// ".highlight-cards-heading" is doubled up (".highlight-cards-heading.highlight-cards-heading")
+// to outrank the un-doubled original rule (client/my-sites/stats/components/highlight-cards/style.scss)
+// on specificity alone. HighlightCards is used from several lazily-loaded route chunks, so which of
+// the two equally-specific rules loads last — and therefore wins a plain specificity tie — depends on
+// route/chunk load order rather than source order in this file. Confirmed live: the "Email opens" /
+// "Email clicks" page heading was still rendering in Recoleta despite already being listed here.
+.highlight-cards-heading.highlight-cards-heading,
 .post-stats-card__count-value,
 .post-stats-card__post-title,
 .post-trends__title,
@@ -42,9 +49,10 @@ $highlight-card-tooltip-font: Inter, $display-type-font;
 .stats__all-time-highlights-section .highlight-card-detail-item-content,
 // Replace fonts in packages/components/src/mobile-promo-card/style.scss.
 .promo-card__title,
-// Replace fonts in client/my-sites/stats/stats-email-detail/style.scss (the "Email opens" / "Email clicks" heading).
-.stats__email-detail > div > h1,
 // Replace fonts in client/my-sites/stats/wordads/earnings.scss (the "Earnings history" heading).
-.ads__table-header-title {
+// Doubled up for the same reason as ".highlight-cards-heading" above — the WordAds section is
+// also a lazily-loaded route chunk, so an un-doubled rule here can lose a specificity tie against
+// the original (un-patched) rule depending on load order. Confirmed live.
+.ads__table-header-title.ads__table-header-title {
 	font-family: $display-type-font;
 }

--- a/apps/odyssey-stats/src/styles/typography.scss
+++ b/apps/odyssey-stats/src/styles/typography.scss
@@ -34,11 +34,17 @@ $highlight-card-tooltip-font: Inter, $display-type-font;
 
 // Replace fonts in client/my-sites/stats/stats-period-header/style.scss.
 .stats__period-header .period,
+// The "Stats for" prefix next to the date above, e.g. on the Email opens/clicks pages.
+// Same source file as the ".period" rule above — missing here left it as the only
+// unpatched half of that heading, so it rendered in a different font than its own sibling.
+.stats__period-header .prefix,
 // Replace fonts in client/my-sites/stats/all-time-highlights-section/style.scss.
 .stats__all-time-highlights-section .highlight-card-detail-item-content,
 // Replace fonts in packages/components/src/mobile-promo-card/style.scss.
 .promo-card__title,
 // Replace fonts in client/my-sites/stats/stats-email-detail/style.scss (the "Email opens" / "Email clicks" heading).
-.stats__email-detail > div > h1 {
+.stats__email-detail > div > h1,
+// Replace fonts in client/my-sites/stats/wordads/earnings.scss (the "Earnings history" heading).
+.ads__table-header-title {
 	font-family: $display-type-font;
 }

--- a/client/my-sites/stats/stats-email-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-email-chart-tabs/index.jsx
@@ -10,6 +10,7 @@ import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { isLoadingTabs, getCountRecords } from 'calypso/state/stats/email-chart-tabs/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import StatsEmptyState from '../stats-empty-state';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import { buildChartData, getQueryDate } from './utility';
 
@@ -97,7 +98,9 @@ class StatModuleChartTabs extends Component {
 					minBarWidth={ 35 }
 					sliceFromBeginning={ false }
 					onChangeMaxBars={ onChangeMaxBars }
-				/>
+				>
+					<StatsEmptyState />
+				</Chart>
 			</div>
 		);
 	}

--- a/client/my-sites/stats/stats-email-detail/style.scss
+++ b/client/my-sites/stats/stats-email-detail/style.scss
@@ -80,15 +80,20 @@ $break-large-stats-countries: 1280px;
 			width: 100%;
 			display: grid;
 			gap: 0 24px;
-			grid-template-columns: 7fr 5fr;
-			grid-template-areas: "map list" "more more";
-	
-			@media (max-width: $break-large-stats-countries) {
-				grid-template-columns: 100%;
-				grid-template-areas:
-					"map"
-					"list"
-					"more";
+			grid-template-columns: 1fr;
+			grid-template-areas: "list" "more";
+
+			&:has(.stats-card--hero) {
+				grid-template-columns: 7fr 5fr;
+				grid-template-areas: "map list" "more more";
+
+				@media (max-width: $break-large-stats-countries) {
+					grid-template-columns: 100%;
+					grid-template-areas:
+						"map"
+						"list"
+						"more";
+				}
 			}
 	
 			.stats-card--hero {

--- a/client/my-sites/stats/stats-email-module/index.tsx
+++ b/client/my-sites/stats/stats-email-module/index.tsx
@@ -1,3 +1,4 @@
+import { mapMarker } from '@wordpress/icons';
 import { localize, translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import useStatsStrings from 'calypso/my-sites/stats/hooks/use-stats-strings';
@@ -8,6 +9,7 @@ import {
 } from 'calypso/state/stats/emails/selectors';
 import { IAppState } from 'calypso/state/types';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import EmptyModuleCard from '../components/empty-module-card';
 import Geochart from '../geochart';
 import ErrorPanel from '../stats-error';
 import StatsListCard from '../stats-list/stats-list-card';
@@ -43,6 +45,14 @@ const StatsEmailModule: React.FC< StatsEmailModuleProps & StatsEmailMapStateProp
 
 	const hasError = false; // TODO: Support error state in redux store
 	const metricLabel = statType === 'clicks' ? translate( 'Clicks' ) : translate( 'Opens' );
+	const hasData = Array.isArray( data ) && data.length > 0;
+
+	const emptyMessage =
+		path === 'countries' ? (
+			<EmptyModuleCard icon={ mapMarker } description={ moduleStrings.empty } />
+		) : (
+			moduleStrings.empty
+		);
 
 	return (
 		// @ts-ignore: Suppress missing props error
@@ -50,12 +60,13 @@ const StatsEmailModule: React.FC< StatsEmailModuleProps & StatsEmailMapStateProp
 			title={ moduleStrings.title }
 			moduleType={ path }
 			data={ data }
-			emptyMessage={ moduleStrings.empty }
+			emptyMessage={ emptyMessage }
 			error={ hasError && <ErrorPanel /> }
 			loader={ isLoading && <StatsModulePlaceholder isLoading={ isLoading } /> }
 			metricLabel={ metricLabel }
 			heroElement={
-				path === 'countries' && (
+				path === 'countries' &&
+				( isLoading || hasData ) && (
 					<Geochart
 						kind="email"
 						statType={ statType }

--- a/client/my-sites/stats/stats-email-module/index.tsx
+++ b/client/my-sites/stats/stats-email-module/index.tsx
@@ -1,6 +1,7 @@
 import { mapMarker } from '@wordpress/icons';
 import { localize, translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import useStatsStrings from 'calypso/my-sites/stats/hooks/use-stats-strings';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import {
@@ -47,9 +48,36 @@ const StatsEmailModule: React.FC< StatsEmailModuleProps & StatsEmailMapStateProp
 	const metricLabel = statType === 'clicks' ? translate( 'Clicks' ) : translate( 'Opens' );
 	const hasData = Array.isArray( data ) && data.length > 0;
 
+	const countriesEmptyDescription =
+		statType === 'clicks'
+			? translate( 'Clicks by {{link}}location{{/link}} will appear here.', {
+					comment: '{{link}} links to support documentation.',
+					components: {
+						link: (
+							<InlineSupportLink
+								supportContext={ isJetpack ? 'stats-countries-jetpack' : 'stats-countries' }
+								showIcon={ false }
+							/>
+						),
+					},
+					context: 'Stats: Info box label when the email Countries module is empty',
+			  } )
+			: translate( 'Opens by {{link}}location{{/link}} will appear here.', {
+					comment: '{{link}} links to support documentation.',
+					components: {
+						link: (
+							<InlineSupportLink
+								supportContext={ isJetpack ? 'stats-countries-jetpack' : 'stats-countries' }
+								showIcon={ false }
+							/>
+						),
+					},
+					context: 'Stats: Info box label when the email Countries module is empty',
+			  } );
+
 	const emptyMessage =
 		path === 'countries' ? (
-			<EmptyModuleCard icon={ mapMarker } description={ moduleStrings.empty } />
+			<EmptyModuleCard icon={ mapMarker } description={ countriesEmptyDescription } />
 		) : (
 			moduleStrings.empty
 		);

--- a/client/my-sites/stats/stats-email-module/index.tsx
+++ b/client/my-sites/stats/stats-email-module/index.tsx
@@ -50,7 +50,7 @@ const StatsEmailModule: React.FC< StatsEmailModuleProps & StatsEmailMapStateProp
 
 	const countriesEmptyDescription =
 		statType === 'clicks'
-			? translate( 'Clicks by {{link}}location{{/link}} will appear here.', {
+			? translate( 'Clicks by {{link}}countries{{/link}} will appear here.', {
 					comment: '{{link}} links to support documentation.',
 					components: {
 						link: (
@@ -62,7 +62,7 @@ const StatsEmailModule: React.FC< StatsEmailModuleProps & StatsEmailMapStateProp
 					},
 					context: 'Stats: Info box label when the email Countries module is empty',
 			  } )
-			: translate( 'Opens by {{link}}location{{/link}} will appear here.', {
+			: translate( 'Opens by {{link}}countries{{/link}} will appear here.', {
 					comment: '{{link}} links to support documentation.',
 					components: {
 						link: (

--- a/client/my-sites/stats/stats-email-module/index.tsx
+++ b/client/my-sites/stats/stats-email-module/index.tsx
@@ -1,7 +1,6 @@
 import { mapMarker } from '@wordpress/icons';
 import { localize, translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import useStatsStrings from 'calypso/my-sites/stats/hooks/use-stats-strings';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import {
@@ -50,28 +49,10 @@ const StatsEmailModule: React.FC< StatsEmailModuleProps & StatsEmailMapStateProp
 
 	const countriesEmptyDescription =
 		statType === 'clicks'
-			? translate( 'Clicks by {{link}}countries{{/link}} will appear here.', {
-					comment: '{{link}} links to support documentation.',
-					components: {
-						link: (
-							<InlineSupportLink
-								supportContext={ isJetpack ? 'stats-countries-jetpack' : 'stats-countries' }
-								showIcon={ false }
-							/>
-						),
-					},
+			? translate( 'Clicks by countries will appear here.', {
 					context: 'Stats: Info box label when the email Countries module is empty',
 			  } )
-			: translate( 'Opens by {{link}}countries{{/link}} will appear here.', {
-					comment: '{{link}} links to support documentation.',
-					components: {
-						link: (
-							<InlineSupportLink
-								supportContext={ isJetpack ? 'stats-countries-jetpack' : 'stats-countries' }
-								showIcon={ false }
-							/>
-						),
-					},
+			: translate( 'Opens by countries will appear here.', {
 					context: 'Stats: Info box label when the email Countries module is empty',
 			  } );
 

--- a/client/my-sites/stats/stats-empty-state/style.scss
+++ b/client/my-sites/stats/stats-empty-state/style.scss
@@ -1,7 +1,5 @@
 @import "@automattic/typography/styles/variables";
 
-$font-sf-pro-display: "SF Pro Display", $sans;
-$font-sf-pro-text: "SF Pro Text", $sans;
 $empty-text-color-derker: var(--color-neutral-80);
 $empty-text-color-lighter: var(--color-neutral-40);
 
@@ -27,14 +25,12 @@ $empty-text-color-lighter: var(--color-neutral-40);
 		}
 
 		.empty-state-card-heading {
-			font-family: $font-sf-pro-display;
 			font-weight: 600;
 			color: $empty-text-color-derker;
 			margin-bottom: 8px;
 		}
 
 		.empty-state-card-info {
-			font-family: $font-sf-pro-text;
 			font-size: $font-body-small;
 			color: $empty-text-color-lighter;
 		}


### PR DESCRIPTION
Fixes STATS-371

## Proposed Changes

* Give the Email opens / Email clicks charts a proper empty state (reusing the existing `StatsEmptyState` component) instead of falling back to the chart's generic "No activity this period" notice.
* Drop the hardcoded `SF Pro Display` / `SF Pro Text` font overrides in `stats-empty-state`, which don't exist in Calypso's font stack and caused the empty state to render in a different, mismatched typeface than the rest of the page.
* Fix the Countries card on the email stats pages: it always rendered the map `heroElement`, leaving a blank area where the map should be when there was no data, and its empty message was an unstyled raw string. It now follows the same pattern as the Locations module on the Traffic tab — the map only renders when there's data, and the empty state uses the shared `EmptyModuleCard` (icon + description).
* Fixed a page-specific grid layout that reserved a "map" column for the Countries card even when no map rendered, which squeezed the empty state into roughly 40% of the card width instead of spanning it.
* Reworded the Countries empty state copy on the email pages from the generic "visitors" wording to "Opens/Clicks by countries", matching the metric the page is actually showing (no doc link, since there isn't one for this context).
* Fixed the "Stats for [date]" heading in Odyssey Stats (the wp-admin embed) rendering in two different fonts: the "Stats for" prefix span used `font-family: Recoleta` while its sibling ".period" span (the date itself) was already patched to the app's sans stack — same source rule, only half of it was in the Odyssey override list.
* Fixed two more font overrides in `apps/odyssey-stats/src/styles/typography.scss` that were already in the list but still rendering Recoleta live: `.highlight-cards-heading` (the "Email opens" / "Email clicks" page title) and `.ads__table-header-title` ("Earnings history" on the WordAds page). Root cause: both components are lazily loaded per-route, so the browser duplicates their original (un-patched) CSS into whichever chunk loads them, at the same specificity as the override in the main bundle — whichever `<link>` lands in the DOM last wins that tie, which depends on chunk load order rather than source order in the stylesheet. Doubled up the class in each selector (e.g. `.highlight-cards-heading.highlight-cards-heading`) to win unconditionally, the same technique already used a few lines up for the UTM builder modal heading.

## Why are these changes being made?

The Stats empty states on the email opens/clicks pages looked broken: mismatched fonts, a plain unstyled notice instead of a proper empty state, and a blank area where the Countries map should be. This reuses the existing, already-correct empty state patterns from the Traffic tab instead of introducing anything new.

## Testing Instructions

* Visit a post's `Email opens` or `Email clicks` stats page for a period/post with no email data (e.g. `/stats/email/opens/day/<postId>/<site>`).
* Confirm the chart shows a proper "No data in this period" card (icon + heading + description) using the app's normal font, instead of the small dark "No activity this period" notice.
* Confirm the Countries card shows a centered icon + description spanning the full card width (no blank map area, no raw unstyled text) — matching the Locations module's empty state on the Traffic tab.
* Confirm the Countries empty description reads "Opens by countries will appear here." on the Email opens tab and "Clicks by countries will appear here." on the Email clicks tab.
* Confirm a post with real email opens/clicks data still renders the Countries map alongside the country list as before (unaffected by this change).
* In Odyssey Stats (Jetpack wp-admin embed), confirm the "Stats for [date]" heading, the "Email opens" / "Email clicks" page title, and "Earnings history" (WordAds page) all use the app's normal sans font, not a serif fallback. Verified live on a real Jetpack site, not just in a local build — see screenshots below.

![before/after comparison](https://raw.githubusercontent.com/Automattic/wp-calypso/screenshots/stats-email-empty-state/comparison.png)

![Odyssey Stats font fixes](https://raw.githubusercontent.com/Automattic/wp-calypso/screenshots/stats-email-empty-state/odyssey-font-fixes.png)

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?



