### PR TITLE
Stats: fix infotip icon size on plan usage heading

### DIFF
--- a/client/my-sites/stats/stats-plan-usage/index.tsx
+++ b/client/my-sites/stats/stats-plan-usage/index.tsx
@@ -86,7 +86,7 @@ const PlanUsage: React.FC< PlanUsageProps > = ( {
 				} ) }
 				<StatsInfotip
 					className="plan-usage-heading-info"
-					iconSize={ 18 }
+					iconSize={ 24 }
 					label={ translate( 'Learn more about billable views' ) }
 					side="bottom"
 				>

--- a/client/my-sites/stats/stats-plan-usage/style.scss
+++ b/client/my-sites/stats/stats-plan-usage/style.scss
@@ -41,6 +41,10 @@
 .plan-usage-heading-info {
 	display: inline-flex;
 	color: var(--studio-gray-60);
+
+	svg {
+		fill: currentColor;
+	}
 }
 
 .plan-usage-progress {

--- a/client/my-sites/stats/stats-plan-usage/style.scss
+++ b/client/my-sites/stats/stats-plan-usage/style.scss
@@ -40,7 +40,7 @@
 
 .plan-usage-heading-info {
 	display: inline-flex;
-	color: var(--studio-gray-60);
+	color: var(--color-neutral-20);
 
 	svg {
 		fill: currentColor;


### PR DESCRIPTION
## Proposed Changes

* Fixes the infotip next to "Your Stats plan usage" so it matches the styling of every other infotip in Stats: icon size and icon color were both off.

## Why are these changes being made?

* **Icon size**: the infotip used `iconSize={18}`, a leftover from before this component was migrated from `InfoPopover` to `StatsInfotip`. Every other heading-context infotip in Stats (e.g. the VideoPress module header, which shares the same heading font size) uses `iconSize={24}`.
* **Icon color**: `.plan-usage-heading-info` set `color: var(--studio-gray-60)` but never set `fill: currentColor` on the SVG, so the icon rendered with the SVG's default black fill instead of inheriting gray. Fixing just the `fill` still left the icon visibly darker than other infotips, because `--studio-gray-60` (`#50575e`) itself is a much darker shade than `--color-neutral-20`, which the equivalent heading-adjacent infotip elsewhere in Stats (`stats-info-area__popover`, same heading font size) actually uses. Switched the color variable to `--color-neutral-20` to match.

## Before / After

![before-after](https://github.com/user-attachments/assets/f96dabc1-7196-46a7-8ae6-0a114c6d5e40)

## Testing Instructions

* Go to Stats > any site with a Stats plan, and view the "Your Stats plan usage" section.
* Confirm the info icon next to the heading is now the same size and light gray color as info icons elsewhere in Stats (e.g. the module headers), instead of the smaller black icon shown in "before" above.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
