### PR TITLE
Marketplace: extract the post-transfer plugin flow from the redirect hook

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/marketplace-plugin-flow.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/marketplace-plugin-flow.ts
@@ -1,0 +1,25 @@
+// For marketplace plugins (e.g. sensei-pro), the Atomic transfer + plugin install is initiated during
+// checkout, not by this component — so `atomicFlow` is never set and the .org-directory data is absent
+// (`wporg === false`). Detecting this flow lets the caller keep the site's plugins fresh after the
+// transfer so the redirect can fire once the plugin reports active.
+export function isMarketplacePluginActivationFlow( {
+	atomicFlow,
+	isPluginUploadFlow,
+	pluginSlug,
+	freshSite,
+	wporgPlugin,
+}: {
+	atomicFlow: boolean;
+	isPluginUploadFlow: boolean;
+	pluginSlug: string;
+	freshSite: { is_wpcom_atomic?: boolean } | null | undefined;
+	wporgPlugin: { wporg?: boolean } | null | undefined;
+} ): boolean {
+	return (
+		! atomicFlow &&
+		! isPluginUploadFlow &&
+		!! pluginSlug &&
+		!! freshSite?.is_wpcom_atomic &&
+		wporgPlugin?.wporg === false
+	);
+}

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/marketplace-plugin-flow.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/marketplace-plugin-flow.ts
@@ -1,0 +1,37 @@
+import { isMarketplacePluginActivationFlow } from '../marketplace-plugin-flow';
+
+type Args = Parameters< typeof isMarketplacePluginActivationFlow >[ 0 ];
+
+const defaults: Args = {
+	atomicFlow: false,
+	isPluginUploadFlow: false,
+	pluginSlug: 'sensei-pro',
+	freshSite: { is_wpcom_atomic: true },
+	wporgPlugin: { wporg: false },
+};
+
+const flow = ( overrides?: Partial< Args > ) =>
+	isMarketplacePluginActivationFlow( { ...defaults, ...overrides } );
+
+describe( 'isMarketplacePluginActivationFlow', () => {
+	it( 'detects a checkout-initiated marketplace plugin once the site is Atomic', () => {
+		expect( flow() ).toBe( true );
+	} );
+
+	it( 'is not the flow before the site is Atomic', () => {
+		expect( flow( { freshSite: { is_wpcom_atomic: false } } ) ).toBe( false );
+		expect( flow( { freshSite: null } ) ).toBe( false );
+		expect( flow( { freshSite: undefined } ) ).toBe( false );
+	} );
+
+	it( 'excludes the atomic-transfer and plugin-upload flows this component drives itself', () => {
+		expect( flow( { atomicFlow: true } ) ).toBe( false );
+		expect( flow( { isPluginUploadFlow: true } ) ).toBe( false );
+	} );
+
+	it( 'requires a plugin slug and a marketplace (not .org-directory) plugin', () => {
+		expect( flow( { pluginSlug: '' } ) ).toBe( false );
+		expect( flow( { wporgPlugin: { wporg: true } } ) ).toBe( false );
+		expect( flow( { wporgPlugin: null } ) ).toBe( false );
+	} );
+} );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-marketplace-plugin-polling.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-marketplace-plugin-polling.ts
@@ -1,0 +1,19 @@
+import { useInterval } from 'calypso/lib/interval';
+import { useDispatch } from 'calypso/state';
+import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
+
+const POLL_INTERVAL_MS = 3000;
+
+// A checkout-initiated marketplace plugin installs in the background after the Atomic transfer, so
+// while enabled keep the site's plugin list fresh. The redirect watches the refreshed `installedPlugin`
+// / `pluginActive` state and fires once the plugin reports active.
+export function useMarketplacePluginPolling( {
+	siteId,
+	enabled,
+}: {
+	siteId: number;
+	enabled: boolean;
+} ): void {
+	const dispatch = useDispatch();
+	useInterval( () => dispatch( fetchSitePlugins( siteId ) ), enabled ? POLL_INTERVAL_MS : null );
+}

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
@@ -8,10 +8,11 @@ import { useInterval } from 'calypso/lib/interval';
 import { waitFor } from 'calypso/my-sites/marketplace/util';
 import { useSelector, useDispatch } from 'calypso/state';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
-import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import { requestActiveTheme } from 'calypso/state/themes/actions';
+import { isMarketplacePluginActivationFlow } from './marketplace-plugin-flow';
+import { useMarketplacePluginPolling } from './use-marketplace-plugin-polling';
 
 // The redirect machinery: once a flow completes it fetches the freshest site data, resolves the
 // destination URL, keeps polling where a flow finishes in the background, and navigates. Plugin and
@@ -76,21 +77,15 @@ export function useThankYouRedirect( {
 	// Prefer fresh URL when available; if in atomic flow, wait for fresh URL
 	const pluginsUrlFinal = atomicFlow ? pluginsUrlFresh : pluginsUrlFresh || pluginsUrlSelector;
 
-	// For marketplace plugins (e.g. sensei-pro), the atomic transfer + plugin install
-	// is initiated during checkout, not by this component. The wporg data is unavailable,
-	// so atomicFlow is never set. Once the site is atomic, poll for installed plugins
-	// so that the existing redirect (installedPlugin && pluginActive) fires.
-	const isMarketplacePluginFlow =
-		! atomicFlow &&
-		! isPluginUploadFlow &&
-		!! pluginSlug &&
-		!! freshSite?.is_wpcom_atomic &&
-		wporgPlugin?.wporg === false;
+	const isMarketplacePluginFlow = isMarketplacePluginActivationFlow( {
+		atomicFlow,
+		isPluginUploadFlow,
+		pluginSlug,
+		freshSite,
+		wporgPlugin,
+	} );
 
-	useInterval(
-		() => dispatch( fetchSitePlugins( siteId ) ),
-		isMarketplacePluginFlow && ! pluginActive ? 3000 : null
-	);
+	useMarketplacePluginPolling( { siteId, enabled: isMarketplacePluginFlow && ! pluginActive } );
 
 	const canManagePlugins = useSelector( ( state ) => {
 		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );


### PR DESCRIPTION
## Proposed Changes

* Isolate the post-transfer marketplace-plugin flow — its detection and its plugin-list polling — out of the shared redirect hook into a dedicated predicate and a dedicated hook, each with its own unit tests.
* Pure refactor: no behavior change. The extracted pieces mirror the previous logic exactly.

## Why are these changes being made?

The redirect hook mixed several unrelated concerns, and the marketplace-plugin branch in particular was inline and untested. Giving that concern a single, isolated, tested home shrinks a multi-purpose hook and sets up a follow-up fix — activating a marketplace plugin that a checkout-initiated Atomic transfer leaves installed but inactive — to land as a small, self-contained, reviewable change rather than another edit buried in shared logic.

## Testing Instructions

* Run the marketplace product-install unit suite; a new suite covers the extracted flow predicate.
* No behavior change, so no manual testing is required beyond a smoke check that a marketplace plugin install still redirects as before.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
