### PR TITLE
Stats: prevent post card headings from overlapping titles

### DIFF
--- a/client/components/post-stats-card/stories/index.stories.jsx
+++ b/client/components/post-stats-card/stories/index.stories.jsx
@@ -40,3 +40,17 @@ export const WithoutAThumbnail = () => (
 		/>
 	</div>
 );
+
+export const WrappedHeading = () => (
+	<div className="post-stats-card-story" style={ { margin: 'auto', maxWidth: '500px' } }>
+		<PostStatsCardVariations
+			heading="Most popular post in the past year"
+			uploadHref="#"
+			post={ {
+				date: '2025-09-08T14:24:48+00:00',
+				post_thumbnail: null,
+				title: 'Gradle modularization delivers 3x faster Android builds',
+			} }
+		/>
+	</div>
+);

--- a/client/components/post-stats-card/style.scss
+++ b/client/components/post-stats-card/style.scss
@@ -21,8 +21,7 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 	font-family: $font-sf-pro-text;
 	font-size: $font-body-small;
 	grid-template-columns: minmax(10px, 1.5fr) minmax(0, auto);
-	// 26px is the height of the heading, the remaining should be auto.
-	grid-template-rows: 26px auto auto;
+	grid-template-rows: auto auto auto;
 	grid-template-areas:
 		"heading thumbnail"
 		"post thumbnail"

--- a/client/components/post-stats-card/style.scss
+++ b/client/components/post-stats-card/style.scss
@@ -28,7 +28,6 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 		"counts thumbnail";
 	margin-bottom: 0;
 	max-width: 100%;
-	max-height: 255px;
 	padding: $card-padding;
 	gap: $card-padding;
 

--- a/client/components/post-stats-card/style.scss
+++ b/client/components/post-stats-card/style.scss
@@ -21,7 +21,6 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 	font-family: $font-sf-pro-text;
 	font-size: $font-body-small;
 	grid-template-columns: minmax(10px, 1.5fr) minmax(0, auto);
-	grid-template-rows: auto auto auto;
 	grid-template-areas:
 		"heading thumbnail"
 		"post thumbnail"
@@ -171,7 +170,6 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 			"heading heading"
 			"post thumbnail"
 			"counts counts";
-		max-height: initial;
 		padding: $card-padding 0;
 	}
 	.post-stats-card__thumbnail {

--- a/client/components/post-stats-card/style.scss
+++ b/client/components/post-stats-card/style.scss
@@ -66,6 +66,9 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 	font-weight: 500;
 	grid-area: heading;
 	line-height: 1.3;
+	// In Odyssey the wp-admin host styles bare `h4` with `margin: 1.33em 0`;
+	// the fixed 26px grid row used to absorb it, but an auto row grows with it.
+	margin: 0;
 }
 
 .post-stats-card__post-info {

--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -60,7 +60,6 @@
 
 	.post-stats-card {
 		margin: 0;
-		max-height: unset;
 
 		@media (max-width: $break-small) {
 			gap: 24px 12px;

--- a/client/my-sites/stats/sections/all-time-highlights-section/style.scss
+++ b/client/my-sites/stats/sections/all-time-highlights-section/style.scss
@@ -34,7 +34,6 @@
 
 	.post-stats-card {
 		flex: 1;
-		max-height: unset;
 		grid-template-columns: minmax(150px, 550px) minmax(0, auto);
 		// Enough space for .post-stats-card__upload
 		min-width: 480px;


### PR DESCRIPTION
Fixes STATS-370

## Proposed Changes

* Let `PostStatsCard` heading rows grow with wrapped heading content instead of fixing them at 26px.
* Zero the heading's margin: Odyssey's wp-admin host styles bare `h4` with `margin: 1.33em 0` — the old fixed 26px row absorbed it, but an auto row would grow with the host margin.

<img width="490" height="477" alt="截圖 2026-07-27 晚上11 15 07" src="https://github.com/user-attachments/assets/bb5de72a-9089-4477-b447-5f6e394ecc5d" />

* Drop the card's `max-height: 255px` — and the `max-height: unset` overrides both product consumers already carried to neutralize it. The cap only ever bit bare usages (e.g. Storybook, where the card body stopped at 255px while the grid content kept going); with it gone the component default matches how every surface actually renders, and the overrides become dead code. Nothing sizes off the cap (the thumbnail/upload panel follows the grid rows via `height: 100% + padding`).
* Add a Storybook case with the affected long heading and a long post title.

## Why are these changes being made?

* The fixed 26px heading row only allowed one line. When “Most popular post in the past year” wrapped at narrower card widths, the extra line overflowed into the post-title row.

## Testing Instructions

* Run `yarn storybook:start`.
* Open **client/components/Post Stats Card → Wrapped Heading**.
* Confirm the heading wraps above the post title without overlapping it.
* Confirm the card still shows its date, counts, and featured-image action.
* In Odyssey (Jetpack → Stats → Insights), confirm the heading carries no stray vertical margin — wp-admin styles bare `h4` with `margin: 1.33em 0`, which the Storybook environment can't reproduce.
* Automated checks:
  * `yarn eslint client/components/post-stats-card/stories/index.stories.jsx`
  * `yarn stylelint client/components/post-stats-card/style.scss`
  * Storybook compiled successfully, and browser geometry verification at a 500px card width measured a 52px heading row with a 24px gap before the title.
  * `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client` currently reaches unrelated existing errors in `use-wpcom-domain-search-events.ts`, `use-wpcom-domain-search-props.ts`, and missing `@automattic/date-range-picker` / `@automattic/omnibar` declarations.

|Before|After|
|-|-|
|<img width="443" height="418" alt="截圖 2026-07-27 晚上11 14 20" src="https://github.com/user-attachments/assets/16b50bc3-2d3b-48aa-8e1d-f8aa1825c269" />|<img width="452" height="437" alt="截圖 2026-07-27 晚上11 15 00" src="https://github.com/user-attachments/assets/f5811b96-1e00-4480-870b-559d6b6a656c" />|

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?




