### PR TITLE
Help Center: wire up the v1 contextual CTA on the home panel

### DIFF
--- a/packages/help-center/src/components/help-center-cta-variants.tsx
+++ b/packages/help-center/src/components/help-center-cta-variants.tsx
@@ -1,0 +1,86 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+import { calendar, external, Icon } from '@wordpress/icons';
+import type { ReactNode } from 'react';
+
+/**
+ * What every variant gets to render. Campaign copy and destination come from the
+ * payload; `onClick` is the tracking handler the dispatcher hands down.
+ */
+export interface HelpCenterCTAVariantProps {
+	url: string;
+	title: string;
+	description?: string;
+	actionLabel?: string;
+	onClick: () => void;
+}
+
+const CTALink = ( {
+	url,
+	onClick,
+	className,
+	children,
+}: {
+	url: string;
+	onClick: () => void;
+	className?: string;
+	children: ReactNode;
+} ) => (
+	<a className={ className } href={ url } target="_blank" rel="noreferrer" onClick={ onClick }>
+		{ children }
+	</a>
+);
+
+/** Title-only campaigns make the whole banner the click target. */
+const BannerLink = ( { url, title, description, onClick }: HelpCenterCTAVariantProps ) => (
+	<CTALink
+		className="help-center-cta__banner help-center-cta__banner--link"
+		url={ url }
+		onClick={ onClick }
+	>
+		<span className="help-center-cta__banner-content">
+			<span className="help-center-cta__title">
+				<strong>{ title }</strong>
+			</span>
+			{ description && <span className="help-center-cta__description">{ description }</span> }
+		</span>
+		<Icon icon={ external } size={ 20 } />
+	</CTALink>
+);
+
+const BannerWithAction = ( {
+	url,
+	title,
+	description,
+	actionLabel,
+	onClick,
+}: HelpCenterCTAVariantProps ) => (
+	<div className="help-center-cta__banner">
+		<p className="help-center-cta__title">
+			<strong>{ title }</strong>
+		</p>
+		{ description && <p className="help-center-cta__description">{ description }</p> }
+		<CTALink className="help-center-cta__action" url={ url } onClick={ onClick }>
+			{ actionLabel }
+		</CTALink>
+	</div>
+);
+
+export const Banner = ( props: HelpCenterCTAVariantProps ) =>
+	props.actionLabel ? <BannerWithAction { ...props } /> : <BannerLink { ...props } />;
+
+export const LinkListItem = ( { url, title, description, onClick }: HelpCenterCTAVariantProps ) => (
+	<li className="help-center-cta__resource-item help-center-link__item">
+		<div className="help-center-link__cell">
+			<CTALink url={ url } onClick={ onClick }>
+				<Icon icon={ calendar } size={ 24 } />
+				<span>
+					<span className="help-center-cta__resource-title">{ title }</span>
+					{ description && (
+						<span className="help-center-cta__resource-description">{ description }</span>
+					) }
+				</span>
+				<Icon icon={ external } size={ 20 } />
+			</CTALink>
+		</div>
+	</li>
+);

--- a/packages/help-center/src/components/help-center-cta.scss
+++ b/packages/help-center/src/components/help-center-cta.scss
@@ -34,6 +34,42 @@
 	}
 }
 
+.help-center-cta__banner--link {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	color: inherit;
+	text-decoration: none;
+
+	.help-center-cta__banner-content {
+		flex: 1;
+	}
+
+	.help-center-cta__title,
+	.help-center-cta__description {
+		display: block;
+		margin: 0;
+	}
+
+	.help-center-cta__title {
+		color: $help-center-blue;
+	}
+
+	svg {
+		fill: $help-center-blue;
+		flex-shrink: 0;
+	}
+
+	&:hover .help-center-cta__title {
+		text-decoration: underline;
+	}
+
+	&:focus-visible {
+		outline: $help-center-blue solid 2px;
+		outline-offset: 2px;
+	}
+}
+
 .help-center-cta__resource-item {
 	.help-center-link__cell a svg:first-child {
 		fill: $help-center-blue;

--- a/packages/help-center/src/components/help-center-cta.stories.tsx
+++ b/packages/help-center/src/components/help-center-cta.stories.tsx
@@ -116,6 +116,21 @@ export const BannerWithoutAction: Story = {
 	),
 };
 
+/** What the v1 campaign ships: title-only banner, the whole thing is the link. */
+export const BannerTitleOnly: Story = {
+	args: {
+		...sampleArgs,
+		variant: 'banner',
+		title: 'Book Your Free Onboarding Call',
+		description: undefined,
+	},
+	render: ( args ) => (
+		<PanelChrome>
+			<HelpCenterCTA { ...args } />
+		</PanelChrome>
+	),
+};
+
 export const LinkListItem: Story = {
 	args: {
 		...sampleArgs,

--- a/packages/help-center/src/components/help-center-cta.stories.tsx
+++ b/packages/help-center/src/components/help-center-cta.stories.tsx
@@ -21,7 +21,6 @@ type Story = StoryObj< typeof HelpCenterCTA >;
 
 const sampleArgs = {
 	ctaId: 'onboarding-call-v1',
-	placement: 'help-center-home',
 	url: 'https://calendly.example.com/onboarding',
 	title: 'Get set up with a free onboarding call',
 	description: 'Talk one-on-one with a Happiness Engineer and get your new site off the ground.',

--- a/packages/help-center/src/components/help-center-cta.tsx
+++ b/packages/help-center/src/components/help-center-cta.tsx
@@ -26,16 +26,21 @@ export interface HelpCenterCTAProps extends Omit< HelpCenterCTAVariantProps, 'on
 	ctaId: string;
 }
 
+// Module-level so it survives remounts (e.g. search filtering the More
+// resources list) and only resets on a full page load, per cta_id.
+const reportedCtaIds = new Set< string >();
+
 function useCTATracking(
 	eventProps: { cta_id: string; variant: string; placement: string } | null
 ) {
 	useEffect( () => {
-		if ( ! eventProps ) {
+		if ( ! eventProps || reportedCtaIds.has( eventProps.cta_id ) ) {
 			return;
 		}
+		reportedCtaIds.add( eventProps.cta_id );
 		recordTracksEvent( 'calypso_helpcenter_cta_impression', eventProps );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
+	}, [ eventProps?.cta_id ] );
 
 	return () => {
 		if ( eventProps ) {

--- a/packages/help-center/src/components/help-center-cta.tsx
+++ b/packages/help-center/src/components/help-center-cta.tsx
@@ -1,103 +1,43 @@
-/* eslint-disable wpcalypso/jsx-classname-namespace */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { calendar, external, Icon } from '@wordpress/icons';
 import { useEffect } from 'react';
+import { Banner, LinkListItem } from './help-center-cta-variants';
 import './help-center-cta.scss';
+import type { HelpCenterCTAVariantProps } from './help-center-cta-variants';
 
-export type HelpCenterCTAVariant = 'banner' | 'link-list-item';
-
-export interface HelpCenterCTAProps {
-	variant: HelpCenterCTAVariant;
-	ctaId: string;
+interface HelpCenterCTAVariantDefinition {
+	/** Where this variant renders. Reported with the Tracks events. */
 	placement: string;
-	url: string;
-	title: string;
-	description?: string;
-	actionLabel?: string;
+	Component: React.FC< HelpCenterCTAVariantProps >;
 }
 
-export const HelpCenterCTA: React.FC< HelpCenterCTAProps > = ( {
-	variant,
-	ctaId,
-	placement,
-	url,
-	title,
-	description,
-	actionLabel,
-} ) => {
+/**
+ * Every variant the backend can ask for. A new one is a new entry here plus a
+ * component in `help-center-cta-variants.tsx` — nothing else knows the list.
+ */
+export const HELP_CENTER_CTA_VARIANTS = {
+	banner: { placement: 'help-center-home', Component: Banner },
+	'link-list-item': { placement: 'help-center-more-resources', Component: LinkListItem },
+} as const satisfies Record< string, HelpCenterCTAVariantDefinition >;
+
+export type HelpCenterCTAVariant = keyof typeof HELP_CENTER_CTA_VARIANTS;
+
+export interface HelpCenterCTAProps extends Omit< HelpCenterCTAVariantProps, 'onClick' > {
+	variant: HelpCenterCTAVariant;
+	ctaId: string;
+}
+
+function useCTATracking( eventProps: { cta_id: string; variant: string; placement: string } ) {
 	useEffect( () => {
-		recordTracksEvent( 'calypso_helpcenter_cta_impression', {
-			cta_id: ctaId,
-			variant,
-			placement,
-		} );
+		recordTracksEvent( 'calypso_helpcenter_cta_impression', eventProps );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
-	const trackClick = () => {
-		recordTracksEvent( 'calypso_helpcenter_cta_click', {
-			cta_id: ctaId,
-			variant,
-			placement,
-		} );
-	};
+	return () => recordTracksEvent( 'calypso_helpcenter_cta_click', eventProps );
+}
 
-	if ( variant === 'banner' && ! actionLabel ) {
-		return (
-			<a
-				className="help-center-cta__banner help-center-cta__banner--link"
-				href={ url }
-				target="_blank"
-				rel="noreferrer"
-				onClick={ trackClick }
-			>
-				<span className="help-center-cta__banner-content">
-					<span className="help-center-cta__title">
-						<strong>{ title }</strong>
-					</span>
-					{ description && <span className="help-center-cta__description">{ description }</span> }
-				</span>
-				<Icon icon={ external } size={ 20 } />
-			</a>
-		);
-	}
+export const HelpCenterCTA: React.FC< HelpCenterCTAProps > = ( { variant, ctaId, ...content } ) => {
+	const { placement, Component } = HELP_CENTER_CTA_VARIANTS[ variant ];
+	const trackClick = useCTATracking( { cta_id: ctaId, variant, placement } );
 
-	if ( variant === 'link-list-item' ) {
-		return (
-			<li className="help-center-cta__resource-item help-center-link__item">
-				<div className="help-center-link__cell">
-					<a href={ url } target="_blank" rel="noreferrer" onClick={ trackClick }>
-						<Icon icon={ calendar } size={ 24 } />
-						<span>
-							<span className="help-center-cta__resource-title">{ title }</span>
-							{ description && (
-								<span className="help-center-cta__resource-description">{ description }</span>
-							) }
-						</span>
-						<Icon icon={ external } size={ 20 } />
-					</a>
-				</div>
-			</li>
-		);
-	}
-
-	return (
-		<div className="help-center-cta__banner">
-			<p className="help-center-cta__title">
-				<strong>{ title }</strong>
-			</p>
-			{ description && <p className="help-center-cta__description">{ description }</p> }
-			{ actionLabel && (
-				<a
-					className="help-center-cta__action"
-					href={ url }
-					target="_blank"
-					rel="noreferrer"
-					onClick={ trackClick }
-				>
-					{ actionLabel }
-				</a>
-			) }
-		</div>
-	);
+	return <Component { ...content } onClick={ trackClick } />;
 };

--- a/packages/help-center/src/components/help-center-cta.tsx
+++ b/packages/help-center/src/components/help-center-cta.tsx
@@ -42,6 +42,26 @@ export const HelpCenterCTA: React.FC< HelpCenterCTAProps > = ( {
 		} );
 	};
 
+	if ( variant === 'banner' && ! actionLabel ) {
+		return (
+			<a
+				className="help-center-cta__banner help-center-cta__banner--link"
+				href={ url }
+				target="_blank"
+				rel="noreferrer"
+				onClick={ trackClick }
+			>
+				<span className="help-center-cta__banner-content">
+					<span className="help-center-cta__title">
+						<strong>{ title }</strong>
+					</span>
+					{ description && <span className="help-center-cta__description">{ description }</span> }
+				</span>
+				<Icon icon={ external } size={ 20 } />
+			</a>
+		);
+	}
+
 	if ( variant === 'link-list-item' ) {
 		return (
 			<li className="help-center-cta__resource-item help-center-link__item">

--- a/packages/help-center/src/components/help-center-cta.tsx
+++ b/packages/help-center/src/components/help-center-cta.tsx
@@ -26,18 +26,34 @@ export interface HelpCenterCTAProps extends Omit< HelpCenterCTAVariantProps, 'on
 	ctaId: string;
 }
 
-function useCTATracking( eventProps: { cta_id: string; variant: string; placement: string } ) {
+function useCTATracking(
+	eventProps: { cta_id: string; variant: string; placement: string } | null
+) {
 	useEffect( () => {
+		if ( ! eventProps ) {
+			return;
+		}
 		recordTracksEvent( 'calypso_helpcenter_cta_impression', eventProps );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
-	return () => recordTracksEvent( 'calypso_helpcenter_cta_click', eventProps );
+	return () => {
+		if ( eventProps ) {
+			recordTracksEvent( 'calypso_helpcenter_cta_click', eventProps );
+		}
+	};
 }
 
 export const HelpCenterCTA: React.FC< HelpCenterCTAProps > = ( { variant, ctaId, ...content } ) => {
-	const { placement, Component } = HELP_CENTER_CTA_VARIANTS[ variant ];
-	const trackClick = useCTATracking( { cta_id: ctaId, variant, placement } );
+	const variantDefinition = HELP_CENTER_CTA_VARIANTS[ variant ];
+	const trackClick = useCTATracking(
+		variantDefinition ? { cta_id: ctaId, variant, placement: variantDefinition.placement } : null
+	);
 
+	if ( ! variantDefinition ) {
+		return null;
+	}
+
+	const { Component } = variantDefinition;
 	return <Component { ...content } onClick={ trackClick } />;
 };

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -5,6 +5,8 @@ import { backup, chevronRight, external, Icon, page, rss, video } from '@wordpre
 import { useI18n } from '@wordpress/react-i18n';
 import { useNavigate } from 'react-router-dom';
 import { useFeatureConfig, useHelpCenterContext } from '../contexts/HelpCenterContext';
+import { useHelpCenterCTA } from '../hooks';
+import { HelpCenterCTA } from './help-center-cta';
 
 import './help-center-more-resources.scss';
 
@@ -13,6 +15,7 @@ export const HelpCenterMoreResources = () => {
 	const { sectionName } = useHelpCenterContext();
 	const featureConfig = useFeatureConfig();
 	const navigate = useNavigate();
+	const cta = useHelpCenterCTA( 'help-center-more-resources' );
 
 	const trackMoreResourcesButtonClick = ( resource: string ) => {
 		recordTracksEvent( 'calypso_help_moreresources_click', {
@@ -38,6 +41,7 @@ export const HelpCenterMoreResources = () => {
 				{ __( 'More resources', __i18n_text_domain__ ) }
 			</h3>
 			<ul aria-labelledby="help-center-more-resources__resources">
+				{ cta && <HelpCenterCTA { ...cta } /> }
 				{ featureConfig.moreResources.supportHistory && (
 					<li className="help-center-more-resources__resource-item help-center-link__item">
 						<div className="help-center-more-resources__resource-cell help-center-link__cell">

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -15,7 +15,7 @@ export const HelpCenterMoreResources = () => {
 	const { sectionName } = useHelpCenterContext();
 	const featureConfig = useFeatureConfig();
 	const navigate = useNavigate();
-	const cta = useHelpCenterCTA( 'help-center-more-resources' );
+	const cta = useHelpCenterCTA( 'link-list-item' );
 
 	const trackMoreResourcesButtonClick = ( resource: string ) => {
 		recordTracksEvent( 'calypso_help_moreresources_click', {

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -4,12 +4,7 @@ import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import InlineHelpSearchCard from 'calypso/blocks/inline-help/inline-help-search-card';
 import { useFeatureConfig, useHelpCenterContext } from '../contexts/HelpCenterContext';
-import {
-	useHelpCenterSearch,
-	useGetHistoryChats,
-	useHelpCenterCTA,
-	HELP_CENTER_CTA_HOME_PLACEMENT,
-} from '../hooks';
+import { useHelpCenterSearch, useGetHistoryChats, useHelpCenterCTA } from '../hooks';
 import { useContextBasedSearchMapping } from '../hooks/use-context-based-search-mapping';
 import { useHelpSearchQuery } from '../hooks/use-help-search-query';
 import { HELP_CENTER_STORE } from '../stores';
@@ -46,7 +41,7 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 		[]
 	);
 	const { contextSearch } = useContextBasedSearchMapping( currentRoute );
-	const cta = useHelpCenterCTA( HELP_CENTER_CTA_HOME_PLACEMENT );
+	const cta = useHelpCenterCTA();
 	const { isLoading: isLoadingSearchResults } = useHelpSearchQuery(
 		searchQuery || contextTerm || contextSearch,
 		locale,

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -41,7 +41,7 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 		[]
 	);
 	const { contextSearch } = useContextBasedSearchMapping( currentRoute );
-	const cta = useHelpCenterCTA( 'help-center-home' );
+	const cta = useHelpCenterCTA( 'banner' );
 	const { isLoading: isLoadingSearchResults } = useHelpSearchQuery(
 		searchQuery || contextTerm || contextSearch,
 		locale,

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -4,10 +4,16 @@ import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import InlineHelpSearchCard from 'calypso/blocks/inline-help/inline-help-search-card';
 import { useFeatureConfig, useHelpCenterContext } from '../contexts/HelpCenterContext';
-import { useHelpCenterSearch, useGetHistoryChats } from '../hooks';
+import {
+	useHelpCenterSearch,
+	useGetHistoryChats,
+	useHelpCenterCTA,
+	HELP_CENTER_CTA_HOME_PLACEMENT,
+} from '../hooks';
 import { useContextBasedSearchMapping } from '../hooks/use-context-based-search-mapping';
 import { useHelpSearchQuery } from '../hooks/use-help-search-query';
 import { HELP_CENTER_STORE } from '../stores';
+import { HelpCenterCTA } from './help-center-cta';
 import { HelpCenterLaunchpad } from './help-center-launchpad';
 import { HelpCenterMoreResources } from './help-center-more-resources';
 import HelpCenterRecentConversations from './help-center-recent-conversations';
@@ -40,6 +46,7 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 		[]
 	);
 	const { contextSearch } = useContextBasedSearchMapping( currentRoute );
+	const cta = useHelpCenterCTA( HELP_CENTER_CTA_HOME_PLACEMENT );
 	const { isLoading: isLoadingSearchResults } = useHelpSearchQuery(
 		searchQuery || contextTerm || contextSearch,
 		locale,
@@ -61,6 +68,7 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 
 	return (
 		<div className="inline-help__search">
+			{ cta?.variant === 'banner' && <HelpCenterCTA { ...cta } /> }
 			{ featureConfig.home.recentConversations && (
 				<>
 					<HelpCenterRecentConversations />

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -41,7 +41,7 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 		[]
 	);
 	const { contextSearch } = useContextBasedSearchMapping( currentRoute );
-	const cta = useHelpCenterCTA();
+	const cta = useHelpCenterCTA( 'help-center-home' );
 	const { isLoading: isLoadingSearchResults } = useHelpSearchQuery(
 		searchQuery || contextTerm || contextSearch,
 		locale,
@@ -63,7 +63,7 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 
 	return (
 		<div className="inline-help__search">
-			{ cta?.variant === 'banner' && <HelpCenterCTA { ...cta } /> }
+			{ cta && <HelpCenterCTA { ...cta } /> }
 			{ featureConfig.home.recentConversations && (
 				<>
 					<HelpCenterRecentConversations />

--- a/packages/help-center/src/components/test/help-center-cta.tsx
+++ b/packages/help-center/src/components/test/help-center-cta.tsx
@@ -7,6 +7,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { HelpCenterCTA } from '../help-center-cta';
+import type { HelpCenterCTAVariant } from '../help-center-cta';
 
 const mockRecordTracksEvent = jest.fn();
 jest.mock( '@automattic/calypso-analytics', () => ( {
@@ -109,6 +110,20 @@ describe( 'HelpCenterCTA', () => {
 				variant: 'banner',
 				placement: 'help-center-home',
 			} );
+		} );
+	} );
+
+	describe( 'unregistered variant', () => {
+		it( 'renders nothing and fires no Tracks event', () => {
+			const { container } = render(
+				<HelpCenterCTA
+					{ ...baseProps }
+					variant={ 'not-a-real-variant' as unknown as HelpCenterCTAVariant }
+				/>
+			);
+
+			expect( container ).toBeEmptyDOMElement();
+			expect( mockRecordTracksEvent ).not.toHaveBeenCalled();
 		} );
 	} );
 

--- a/packages/help-center/src/components/test/help-center-cta.tsx
+++ b/packages/help-center/src/components/test/help-center-cta.tsx
@@ -76,12 +76,15 @@ describe( 'HelpCenterCTA', () => {
 			expect( link ).toHaveAttribute( 'rel', 'noreferrer' );
 		} );
 
-		it( 'renders no link when actionLabel is not provided', () => {
+		it( 'makes the whole banner a single link when actionLabel is not provided', () => {
 			render( <HelpCenterCTA { ...baseProps } variant="banner" /> );
 
-			expect( screen.getByText( baseProps.title ) ).toBeVisible();
-			expect( screen.getByText( baseProps.description ) ).toBeVisible();
-			expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+			const link = screen.getByRole( 'link' );
+			expect( link ).toHaveAttribute( 'href', baseProps.url );
+			expect( link ).toHaveAttribute( 'target', '_blank' );
+			expect( link ).toHaveAttribute( 'rel', 'noreferrer' );
+			expect( link ).toHaveTextContent( baseProps.title );
+			expect( link ).toHaveTextContent( baseProps.description );
 		} );
 
 		it( 'still fires the impression event when actionLabel is not provided', () => {
@@ -89,6 +92,20 @@ describe( 'HelpCenterCTA', () => {
 
 			expect( mockRecordTracksEvent ).toHaveBeenCalledTimes( 1 );
 			expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_helpcenter_cta_impression', {
+				cta_id: baseProps.ctaId,
+				variant: 'banner',
+				placement: baseProps.placement,
+			} );
+		} );
+
+		it( 'fires the click event when the whole-banner link is clicked', async () => {
+			const user = userEvent.setup();
+			render( <HelpCenterCTA { ...baseProps } variant="banner" /> );
+			mockRecordTracksEvent.mockClear();
+
+			await user.click( screen.getByRole( 'link' ) );
+
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_helpcenter_cta_click', {
 				cta_id: baseProps.ctaId,
 				variant: 'banner',
 				placement: baseProps.placement,

--- a/packages/help-center/src/components/test/help-center-cta.tsx
+++ b/packages/help-center/src/components/test/help-center-cta.tsx
@@ -15,7 +15,6 @@ jest.mock( '@automattic/calypso-analytics', () => ( {
 
 const baseProps = {
 	ctaId: 'onboarding-call-v1',
-	placement: 'help-center-home',
 	url: 'https://calendly.example.com/onboarding',
 	title: 'Get set up with a free onboarding call',
 	description: 'Talk one-on-one with a Happiness Engineer and get your new site off the ground.',
@@ -46,7 +45,7 @@ describe( 'HelpCenterCTA', () => {
 			expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_helpcenter_cta_impression', {
 				cta_id: baseProps.ctaId,
 				variant: 'banner',
-				placement: baseProps.placement,
+				placement: 'help-center-home',
 			} );
 		} );
 
@@ -62,7 +61,7 @@ describe( 'HelpCenterCTA', () => {
 			expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_helpcenter_cta_click', {
 				cta_id: baseProps.ctaId,
 				variant: 'banner',
-				placement: baseProps.placement,
+				placement: 'help-center-home',
 			} );
 		} );
 
@@ -94,7 +93,7 @@ describe( 'HelpCenterCTA', () => {
 			expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_helpcenter_cta_impression', {
 				cta_id: baseProps.ctaId,
 				variant: 'banner',
-				placement: baseProps.placement,
+				placement: 'help-center-home',
 			} );
 		} );
 
@@ -108,7 +107,7 @@ describe( 'HelpCenterCTA', () => {
 			expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_helpcenter_cta_click', {
 				cta_id: baseProps.ctaId,
 				variant: 'banner',
-				placement: baseProps.placement,
+				placement: 'help-center-home',
 			} );
 		} );
 	} );
@@ -136,7 +135,7 @@ describe( 'HelpCenterCTA', () => {
 			expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_helpcenter_cta_impression', {
 				cta_id: baseProps.ctaId,
 				variant: 'link-list-item',
-				placement: baseProps.placement,
+				placement: 'help-center-more-resources',
 			} );
 		} );
 
@@ -154,7 +153,7 @@ describe( 'HelpCenterCTA', () => {
 			expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_helpcenter_cta_click', {
 				cta_id: baseProps.ctaId,
 				variant: 'link-list-item',
-				placement: baseProps.placement,
+				placement: 'help-center-more-resources',
 			} );
 		} );
 

--- a/packages/help-center/src/components/test/help-center-cta.tsx
+++ b/packages/help-center/src/components/test/help-center-cta.tsx
@@ -14,12 +14,18 @@ jest.mock( '@automattic/calypso-analytics', () => ( {
 	recordTracksEvent: ( ...args: unknown[] ) => mockRecordTracksEvent( ...args ),
 } ) );
 
-const baseProps = {
-	ctaId: 'onboarding-call-v1',
-	url: 'https://calendly.example.com/onboarding',
-	title: 'Get set up with a free onboarding call',
-	description: 'Talk one-on-one with a Happiness Engineer and get your new site off the ground.',
-};
+// The impression dedupe set inside `help-center-cta.tsx` is module-level and
+// persists across tests in this file, so every test needs its own cta_id.
+let ctaIdCounter = 0;
+function makeBaseProps() {
+	ctaIdCounter += 1;
+	return {
+		ctaId: `onboarding-call-v1-${ ctaIdCounter }`,
+		url: 'https://calendly.example.com/onboarding',
+		title: 'Get set up with a free onboarding call',
+		description: 'Talk one-on-one with a Happiness Engineer and get your new site off the ground.',
+	};
+}
 
 describe( 'HelpCenterCTA', () => {
 	afterEach( () => {
@@ -28,6 +34,7 @@ describe( 'HelpCenterCTA', () => {
 
 	describe( 'banner variant', () => {
 		it( 'renders title, description, and actionLabel from props', () => {
+			const baseProps = makeBaseProps();
 			render(
 				<HelpCenterCTA { ...baseProps } variant="banner" actionLabel="Book your free call" />
 			);
@@ -38,6 +45,7 @@ describe( 'HelpCenterCTA', () => {
 		} );
 
 		it( 'fires the impression event exactly once on mount', () => {
+			const baseProps = makeBaseProps();
 			render(
 				<HelpCenterCTA { ...baseProps } variant="banner" actionLabel="Book your free call" />
 			);
@@ -51,6 +59,7 @@ describe( 'HelpCenterCTA', () => {
 		} );
 
 		it( 'fires the click event with the same payload when clicked', async () => {
+			const baseProps = makeBaseProps();
 			const user = userEvent.setup();
 			render(
 				<HelpCenterCTA { ...baseProps } variant="banner" actionLabel="Book your free call" />
@@ -67,6 +76,7 @@ describe( 'HelpCenterCTA', () => {
 		} );
 
 		it( 'opens the link in a new tab without a referrer', () => {
+			const baseProps = makeBaseProps();
 			render(
 				<HelpCenterCTA { ...baseProps } variant="banner" actionLabel="Book your free call" />
 			);
@@ -77,6 +87,7 @@ describe( 'HelpCenterCTA', () => {
 		} );
 
 		it( 'makes the whole banner a single link when actionLabel is not provided', () => {
+			const baseProps = makeBaseProps();
 			render( <HelpCenterCTA { ...baseProps } variant="banner" /> );
 
 			const link = screen.getByRole( 'link' );
@@ -88,6 +99,7 @@ describe( 'HelpCenterCTA', () => {
 		} );
 
 		it( 'still fires the impression event when actionLabel is not provided', () => {
+			const baseProps = makeBaseProps();
 			render( <HelpCenterCTA { ...baseProps } variant="banner" /> );
 
 			expect( mockRecordTracksEvent ).toHaveBeenCalledTimes( 1 );
@@ -99,6 +111,7 @@ describe( 'HelpCenterCTA', () => {
 		} );
 
 		it( 'fires the click event when the whole-banner link is clicked', async () => {
+			const baseProps = makeBaseProps();
 			const user = userEvent.setup();
 			render( <HelpCenterCTA { ...baseProps } variant="banner" /> );
 			mockRecordTracksEvent.mockClear();
@@ -115,6 +128,7 @@ describe( 'HelpCenterCTA', () => {
 
 	describe( 'unregistered variant', () => {
 		it( 'renders nothing and fires no Tracks event', () => {
+			const baseProps = makeBaseProps();
 			const { container } = render(
 				<HelpCenterCTA
 					{ ...baseProps }
@@ -129,6 +143,7 @@ describe( 'HelpCenterCTA', () => {
 
 	describe( 'link-list-item variant', () => {
 		it( 'renders title and description from props', () => {
+			const baseProps = makeBaseProps();
 			render(
 				<ul>
 					<HelpCenterCTA { ...baseProps } variant="link-list-item" />
@@ -140,6 +155,7 @@ describe( 'HelpCenterCTA', () => {
 		} );
 
 		it( 'fires the impression event exactly once on mount', () => {
+			const baseProps = makeBaseProps();
 			render(
 				<ul>
 					<HelpCenterCTA { ...baseProps } variant="link-list-item" />
@@ -155,6 +171,7 @@ describe( 'HelpCenterCTA', () => {
 		} );
 
 		it( 'fires the click event with the same payload when clicked', async () => {
+			const baseProps = makeBaseProps();
 			const user = userEvent.setup();
 			render(
 				<ul>
@@ -173,6 +190,7 @@ describe( 'HelpCenterCTA', () => {
 		} );
 
 		it( 'opens the link in a new tab without a referrer', () => {
+			const baseProps = makeBaseProps();
 			render(
 				<ul>
 					<HelpCenterCTA { ...baseProps } variant="link-list-item" />
@@ -182,6 +200,51 @@ describe( 'HelpCenterCTA', () => {
 			const link = screen.getByRole( 'link' );
 			expect( link ).toHaveAttribute( 'target', '_blank' );
 			expect( link ).toHaveAttribute( 'rel', 'noreferrer' );
+		} );
+	} );
+
+	describe( 'impression deduplication', () => {
+		it( 'fires exactly one impression when the same cta_id unmounts and remounts', () => {
+			const baseProps = makeBaseProps();
+			const { unmount } = render( <HelpCenterCTA { ...baseProps } variant="banner" /> );
+			unmount();
+
+			render( <HelpCenterCTA { ...baseProps } variant="banner" /> );
+
+			const impressionCalls = mockRecordTracksEvent.mock.calls.filter(
+				( [ eventName ] ) => eventName === 'calypso_helpcenter_cta_impression'
+			);
+			expect( impressionCalls ).toHaveLength( 1 );
+		} );
+
+		it( 'fires a second impression when a mounted component receives a new cta_id', () => {
+			const firstProps = makeBaseProps();
+			const secondProps = makeBaseProps();
+			const { rerender } = render( <HelpCenterCTA { ...firstProps } variant="banner" /> );
+
+			rerender( <HelpCenterCTA { ...secondProps } variant="banner" /> );
+
+			const impressionCalls = mockRecordTracksEvent.mock.calls.filter(
+				( [ eventName ] ) => eventName === 'calypso_helpcenter_cta_impression'
+			);
+			expect( impressionCalls ).toHaveLength( 2 );
+			expect( impressionCalls[ 1 ][ 1 ] ).toMatchObject( { cta_id: secondProps.ctaId } );
+		} );
+
+		it( 'never dedupes clicks: two clicks fire two click events', async () => {
+			const baseProps = makeBaseProps();
+			const user = userEvent.setup();
+			render( <HelpCenterCTA { ...baseProps } variant="banner" /> );
+			mockRecordTracksEvent.mockClear();
+
+			const link = screen.getByRole( 'link' );
+			await user.click( link );
+			await user.click( link );
+
+			const clickCalls = mockRecordTracksEvent.mock.calls.filter(
+				( [ eventName ] ) => eventName === 'calypso_helpcenter_cta_click'
+			);
+			expect( clickCalls ).toHaveLength( 2 );
 		} );
 	} );
 } );

--- a/packages/help-center/src/data/use-support-status.ts
+++ b/packages/help-center/src/data/use-support-status.ts
@@ -5,7 +5,7 @@ import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { SupportStatus } from '../types';
 
 // Bump me to invalidate the cache.
-const VERSION = 2;
+const VERSION = 3;
 
 interface APIFetchOptions {
 	global: boolean;

--- a/packages/help-center/src/feature-config/presets.ts
+++ b/packages/help-center/src/feature-config/presets.ts
@@ -14,6 +14,7 @@ const wpcomPreset: HelpCenterFeatureConfig = {
 	},
 	home: {
 		recentConversations: true,
+		contextualCta: true,
 	},
 	moreResources: {
 		visible: true,
@@ -41,6 +42,7 @@ const a4aPreset: HelpCenterFeatureConfig = {
 	},
 	home: {
 		recentConversations: false,
+		contextualCta: false,
 	},
 	moreResources: {
 		visible: false,
@@ -68,6 +70,7 @@ const commerceGardenPreset: HelpCenterFeatureConfig = {
 	},
 	home: {
 		recentConversations: true,
+		contextualCta: false,
 	},
 	moreResources: {
 		visible: true,

--- a/packages/help-center/src/feature-config/presets.ts
+++ b/packages/help-center/src/feature-config/presets.ts
@@ -14,7 +14,9 @@ const wpcomPreset: HelpCenterFeatureConfig = {
 	},
 	home: {
 		recentConversations: true,
-		contextualCta: true,
+	},
+	contextualCta: {
+		enabled: true,
 	},
 	moreResources: {
 		visible: true,
@@ -42,7 +44,9 @@ const a4aPreset: HelpCenterFeatureConfig = {
 	},
 	home: {
 		recentConversations: false,
-		contextualCta: false,
+	},
+	contextualCta: {
+		enabled: false,
 	},
 	moreResources: {
 		visible: false,
@@ -70,7 +74,9 @@ const commerceGardenPreset: HelpCenterFeatureConfig = {
 	},
 	home: {
 		recentConversations: true,
-		contextualCta: false,
+	},
+	contextualCta: {
+		enabled: false,
 	},
 	moreResources: {
 		visible: true,

--- a/packages/help-center/src/feature-config/types.ts
+++ b/packages/help-center/src/feature-config/types.ts
@@ -22,8 +22,10 @@ export type HelpCenterFeatureConfig = {
 	home: {
 		/** Show the recent conversations section on the home screen. */
 		recentConversations: boolean;
-		/** Show the contextual CTA served by the support-status endpoint. */
-		contextualCta: boolean;
+	};
+	contextualCta: {
+		/** Render the contextual CTAs served by the support-status endpoint. */
+		enabled: boolean;
 	};
 	moreResources: {
 		/** Show the entire More Resources section. */

--- a/packages/help-center/src/feature-config/types.ts
+++ b/packages/help-center/src/feature-config/types.ts
@@ -22,6 +22,8 @@ export type HelpCenterFeatureConfig = {
 	home: {
 		/** Show the recent conversations section on the home screen. */
 		recentConversations: boolean;
+		/** Show the contextual CTA served by the support-status endpoint. */
+		contextualCta: boolean;
 	};
 	moreResources: {
 		/** Show the entire More Resources section. */

--- a/packages/help-center/src/hooks/index.ts
+++ b/packages/help-center/src/hooks/index.ts
@@ -11,4 +11,4 @@ export { useFlowCustomOptions } from './use-flow-custom-options';
 export { useFlowZendeskUserFields } from './use-flow-zendesk-user-fields';
 export { useGetHistoryChats } from './use-get-history-chats';
 export { useHelpCenterSearch } from './use-help-center-search';
-export { useHelpCenterCTA, HELP_CENTER_CTA_HOME_PLACEMENT } from './use-help-center-cta';
+export { useHelpCenterCTA } from './use-help-center-cta';

--- a/packages/help-center/src/hooks/index.ts
+++ b/packages/help-center/src/hooks/index.ts
@@ -11,3 +11,4 @@ export { useFlowCustomOptions } from './use-flow-custom-options';
 export { useFlowZendeskUserFields } from './use-flow-zendesk-user-fields';
 export { useGetHistoryChats } from './use-get-history-chats';
 export { useHelpCenterSearch } from './use-help-center-search';
+export { useHelpCenterCTA, HELP_CENTER_CTA_HOME_PLACEMENT } from './use-help-center-cta';

--- a/packages/help-center/src/hooks/test/use-help-center-cta.tsx
+++ b/packages/help-center/src/hooks/test/use-help-center-cta.tsx
@@ -36,7 +36,7 @@ const setup = ( {
 	mockUseFeatureConfig.mockReturnValue( { home: { contextualCta } } );
 	mockUseSupportStatus.mockReturnValue( { data: cta ? { cta } : {}, isLoading } );
 
-	return renderHook( () => useHelpCenterCTA( 'help-center-home' ) );
+	return renderHook( () => useHelpCenterCTA() );
 };
 
 describe( 'useHelpCenterCTA', () => {

--- a/packages/help-center/src/hooks/test/use-help-center-cta.tsx
+++ b/packages/help-center/src/hooks/test/use-help-center-cta.tsx
@@ -21,6 +21,7 @@ const eligibleCta = {
 	id: 'onboarding-call-v1',
 	variant: 'banner',
 	url: 'https://savvycal.com/CustomerExperience/wordpresscom-onboarding-hc',
+	title: 'Book Your Free Onboarding Call',
 };
 
 const setup = ( {
@@ -43,7 +44,7 @@ describe( 'useHelpCenterCTA', () => {
 		jest.clearAllMocks();
 	} );
 
-	it( 'returns renderable props for an eligible user', () => {
+	it( 'maps the payload onto renderable props', () => {
 		const { result } = setup();
 
 		expect( result.current ).toEqual( {
@@ -51,8 +52,24 @@ describe( 'useHelpCenterCTA', () => {
 			ctaId: 'onboarding-call-v1',
 			placement: 'help-center-home',
 			url: eligibleCta.url,
-			title: 'Book Your Free Onboarding Call',
+			title: eligibleCta.title,
 			description: undefined,
+			actionLabel: undefined,
+		} );
+	} );
+
+	it( 'passes through the optional description and action label', () => {
+		const { result } = setup( {
+			cta: {
+				...eligibleCta,
+				description: 'Talk one-on-one with a Happiness Engineer.',
+				action_label: 'Book your free call',
+			},
+		} );
+
+		expect( result.current ).toMatchObject( {
+			description: 'Talk one-on-one with a Happiness Engineer.',
+			actionLabel: 'Book your free call',
 		} );
 	} );
 
@@ -68,16 +85,15 @@ describe( 'useHelpCenterCTA', () => {
 		expect( result.current ).toBeNull();
 	} );
 
-	it( 'returns null for a campaign id it has no copy for', () => {
-		const { result } = setup( { cta: { ...eligibleCta, id: 'unknown-campaign' } } );
-
-		expect( result.current ).toBeNull();
-	} );
-
 	it( 'returns null for an unsupported variant', () => {
 		const { result } = setup( { cta: { ...eligibleCta, variant: 'default' } } );
 
 		expect( result.current ).toBeNull();
+	} );
+
+	it( 'returns null when the payload is missing a title or a url', () => {
+		expect( setup( { cta: { ...eligibleCta, title: '' } } ).result.current ).toBeNull();
+		expect( setup( { cta: { ...eligibleCta, url: '' } } ).result.current ).toBeNull();
 	} );
 
 	it( 'skips the CTA and the support-status fetch when the product disables it', () => {

--- a/packages/help-center/src/hooks/test/use-help-center-cta.tsx
+++ b/packages/help-center/src/hooks/test/use-help-center-cta.tsx
@@ -116,6 +116,30 @@ describe( 'useHelpCenterCTA', () => {
 		expect( setup( { cta: { ...bannerCta, url: '' } } ).result.current ).toBeNull();
 	} );
 
+	it( 'returns null when the payload is missing an id', () => {
+		expect( setup( { cta: { ...bannerCta, id: '' } } ).result.current ).toBeNull();
+	} );
+
+	it( 'returns null when the title is not a string', () => {
+		const cta = {
+			...bannerCta,
+			title: [ 'Book Your Free Onboarding Call' ],
+		} as unknown as SupportStatus[ 'cta' ];
+
+		expect( setup( { cta } ).result.current ).toBeNull();
+	} );
+
+	it( 'renders the CTA without a description when it is not a string', () => {
+		const cta = {
+			...bannerCta,
+			description: { text: 'Talk one-on-one with a Happiness Engineer.' },
+		} as unknown as SupportStatus[ 'cta' ];
+
+		const { result } = setup( { cta } );
+
+		expect( result.current ).toMatchObject( { description: undefined } );
+	} );
+
 	it( 'refuses a destination that is not an http(s) url', () => {
 		expect(
 			setup( { cta: { ...bannerCta, url: 'javascript:alert(1)' } } ).result.current // eslint-disable-line no-script-url
@@ -130,7 +154,7 @@ describe( 'useHelpCenterCTA', () => {
 		expect( setup( { cta: { ...bannerCta, url: '/help/contact' } } ).result.current ).toBeNull();
 	} );
 
-	it( 'skips the CTA and the support-status fetch when the product disables it', () => {
+	it( 'returns null and asks the support-status query to stay disabled when the product disables it', () => {
 		const { result } = setup( { enabled: false } );
 
 		expect( result.current ).toBeNull();

--- a/packages/help-center/src/hooks/test/use-help-center-cta.tsx
+++ b/packages/help-center/src/hooks/test/use-help-center-cta.tsx
@@ -53,7 +53,6 @@ describe( 'useHelpCenterCTA', () => {
 		expect( result.current ).toEqual( {
 			variant: 'banner',
 			ctaId: 'onboarding-call-v1',
-			placement: 'help-center-home',
 			url: bannerCta.url,
 			title: bannerCta.title,
 			description: undefined,
@@ -76,16 +75,13 @@ describe( 'useHelpCenterCTA', () => {
 		} );
 	} );
 
-	it( 'reports the link-list item against the More resources placement', () => {
+	it( 'maps the link-list item variant', () => {
 		const { result } = setup( {
 			cta: { ...bannerCta, variant: 'link-list-item' },
 			variant: 'link-list-item',
 		} );
 
-		expect( result.current ).toMatchObject( {
-			variant: 'link-list-item',
-			placement: 'help-center-more-resources',
-		} );
+		expect( result.current ).toMatchObject( { variant: 'link-list-item' } );
 	} );
 
 	it( 'only answers the slot the backend built the CTA for', () => {

--- a/packages/help-center/src/hooks/test/use-help-center-cta.tsx
+++ b/packages/help-center/src/hooks/test/use-help-center-cta.tsx
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useHelpCenterCTA } from '../use-help-center-cta';
+import type { SupportStatus } from '../../types';
+
+const mockUseFeatureConfig = jest.fn();
+const mockUseSupportStatus = jest.fn();
+
+jest.mock( '../../contexts/HelpCenterContext', () => ( {
+	useFeatureConfig: () => mockUseFeatureConfig(),
+} ) );
+
+jest.mock( '../../data/use-support-status', () => ( {
+	useSupportStatus: ( enabled?: boolean ) => mockUseSupportStatus( enabled ),
+} ) );
+
+const eligibleCta = {
+	id: 'onboarding-call-v1',
+	variant: 'banner',
+	url: 'https://savvycal.com/CustomerExperience/wordpresscom-onboarding-hc',
+};
+
+const setup = ( {
+	contextualCta = true,
+	isLoading = false,
+	cta = eligibleCta,
+}: {
+	contextualCta?: boolean;
+	isLoading?: boolean;
+	cta?: SupportStatus[ 'cta' ] | null;
+} = {} ) => {
+	mockUseFeatureConfig.mockReturnValue( { home: { contextualCta } } );
+	mockUseSupportStatus.mockReturnValue( { data: cta ? { cta } : {}, isLoading } );
+
+	return renderHook( () => useHelpCenterCTA( 'help-center-home' ) );
+};
+
+describe( 'useHelpCenterCTA', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'returns renderable props for an eligible user', () => {
+		const { result } = setup();
+
+		expect( result.current ).toEqual( {
+			variant: 'banner',
+			ctaId: 'onboarding-call-v1',
+			placement: 'help-center-home',
+			url: eligibleCta.url,
+			title: 'Book Your Free Onboarding Call',
+			description: undefined,
+		} );
+	} );
+
+	it( 'returns null while support status is loading', () => {
+		const { result } = setup( { isLoading: true } );
+
+		expect( result.current ).toBeNull();
+	} );
+
+	it( 'returns null when the payload carries no cta', () => {
+		const { result } = setup( { cta: null } );
+
+		expect( result.current ).toBeNull();
+	} );
+
+	it( 'returns null for a campaign id it has no copy for', () => {
+		const { result } = setup( { cta: { ...eligibleCta, id: 'unknown-campaign' } } );
+
+		expect( result.current ).toBeNull();
+	} );
+
+	it( 'returns null for an unsupported variant', () => {
+		const { result } = setup( { cta: { ...eligibleCta, variant: 'default' } } );
+
+		expect( result.current ).toBeNull();
+	} );
+
+	it( 'skips the CTA and the support-status fetch when the product disables it', () => {
+		const { result } = setup( { contextualCta: false } );
+
+		expect( result.current ).toBeNull();
+		expect( mockUseSupportStatus ).toHaveBeenCalledWith( false );
+	} );
+} );

--- a/packages/help-center/src/hooks/test/use-help-center-cta.tsx
+++ b/packages/help-center/src/hooks/test/use-help-center-cta.tsx
@@ -4,8 +4,8 @@
 
 import { renderHook } from '@testing-library/react';
 import { useHelpCenterCTA } from '../use-help-center-cta';
+import type { HelpCenterCTAVariant } from '../../components/help-center-cta';
 import type { SupportStatus } from '../../types';
-import type { HelpCenterCTAPlacement } from '../use-help-center-cta';
 
 const mockUseFeatureConfig = jest.fn();
 const mockUseSupportStatus = jest.fn();
@@ -21,7 +21,6 @@ jest.mock( '../../data/use-support-status', () => ( {
 const bannerCta = {
 	id: 'onboarding-call-v1',
 	variant: 'banner',
-	placement: 'help-center-home',
 	url: 'https://savvycal.com/CustomerExperience/wordpresscom-onboarding-hc',
 	title: 'Book Your Free Onboarding Call',
 };
@@ -30,17 +29,17 @@ const setup = ( {
 	enabled = true,
 	isLoading = false,
 	cta = bannerCta,
-	placement = 'help-center-home',
+	variant = 'banner',
 }: {
 	enabled?: boolean;
 	isLoading?: boolean;
 	cta?: SupportStatus[ 'cta' ] | null;
-	placement?: HelpCenterCTAPlacement;
+	variant?: HelpCenterCTAVariant;
 } = {} ) => {
 	mockUseFeatureConfig.mockReturnValue( { contextualCta: { enabled } } );
 	mockUseSupportStatus.mockReturnValue( { data: cta ? { cta } : {}, isLoading } );
 
-	return renderHook( () => useHelpCenterCTA( placement ) );
+	return renderHook( () => useHelpCenterCTA( variant ) );
 };
 
 describe( 'useHelpCenterCTA', () => {
@@ -62,12 +61,12 @@ describe( 'useHelpCenterCTA', () => {
 		} );
 	} );
 
-	it( 'passes through the optional description and action label', () => {
+	it( 'passes through the optional description and link copy', () => {
 		const { result } = setup( {
 			cta: {
 				...bannerCta,
 				description: 'Talk one-on-one with a Happiness Engineer.',
-				action_label: 'Book your free call',
+				url_text: 'Book your free call',
 			},
 		} );
 
@@ -77,28 +76,31 @@ describe( 'useHelpCenterCTA', () => {
 		} );
 	} );
 
-	it( 'only answers the slot the backend placed the CTA in', () => {
-		expect( setup( { placement: 'help-center-more-resources' } ).result.current ).toBeNull();
-
-		const listCta = {
-			...bannerCta,
-			variant: 'link-list-item',
-			placement: 'help-center-more-resources',
-		};
-
-		expect( setup( { cta: listCta, placement: 'help-center-home' } ).result.current ).toBeNull();
-		expect(
-			setup( { cta: listCta, placement: 'help-center-more-resources' } ).result.current
-		).toMatchObject( { variant: 'link-list-item', placement: 'help-center-more-resources' } );
-	} );
-
-	it( 'returns null for a variant the slot cannot render', () => {
+	it( 'reports the link-list item against the More resources placement', () => {
 		const { result } = setup( {
-			cta: { ...bannerCta, placement: 'help-center-more-resources' },
-			placement: 'help-center-more-resources',
+			cta: { ...bannerCta, variant: 'link-list-item' },
+			variant: 'link-list-item',
 		} );
 
-		expect( result.current ).toBeNull();
+		expect( result.current ).toMatchObject( {
+			variant: 'link-list-item',
+			placement: 'help-center-more-resources',
+		} );
+	} );
+
+	it( 'only answers the slot the backend built the CTA for', () => {
+		expect( setup( { variant: 'link-list-item' } ).result.current ).toBeNull();
+		expect(
+			setup( { cta: { ...bannerCta, variant: 'link-list-item' }, variant: 'banner' } ).result
+				.current
+		).toBeNull();
+	} );
+
+	it( 'renders in no slot at all for an unknown variant', () => {
+		const unknown = { ...bannerCta, variant: 'default' };
+
+		expect( setup( { cta: unknown, variant: 'banner' } ).result.current ).toBeNull();
+		expect( setup( { cta: unknown, variant: 'link-list-item' } ).result.current ).toBeNull();
 	} );
 
 	it( 'returns null while support status is loading', () => {
@@ -109,12 +111,6 @@ describe( 'useHelpCenterCTA', () => {
 
 	it( 'returns null when the payload carries no cta', () => {
 		const { result } = setup( { cta: null } );
-
-		expect( result.current ).toBeNull();
-	} );
-
-	it( 'returns null for an unknown variant', () => {
-		const { result } = setup( { cta: { ...bannerCta, variant: 'default' } } );
 
 		expect( result.current ).toBeNull();
 	} );

--- a/packages/help-center/src/hooks/test/use-help-center-cta.tsx
+++ b/packages/help-center/src/hooks/test/use-help-center-cta.tsx
@@ -120,6 +120,20 @@ describe( 'useHelpCenterCTA', () => {
 		expect( setup( { cta: { ...bannerCta, url: '' } } ).result.current ).toBeNull();
 	} );
 
+	it( 'refuses a destination that is not an http(s) url', () => {
+		expect(
+			setup( { cta: { ...bannerCta, url: 'javascript:alert(1)' } } ).result.current // eslint-disable-line no-script-url
+		).toBeNull();
+		expect(
+			setup( { cta: { ...bannerCta, url: 'data:text/html,hi' } } ).result.current
+		).toBeNull();
+		expect( setup( { cta: { ...bannerCta, url: 'not a url' } } ).result.current ).toBeNull();
+	} );
+
+	it( 'refuses a relative destination', () => {
+		expect( setup( { cta: { ...bannerCta, url: '/help/contact' } } ).result.current ).toBeNull();
+	} );
+
 	it( 'skips the CTA and the support-status fetch when the product disables it', () => {
 		const { result } = setup( { enabled: false } );
 

--- a/packages/help-center/src/hooks/test/use-help-center-cta.tsx
+++ b/packages/help-center/src/hooks/test/use-help-center-cta.tsx
@@ -5,6 +5,7 @@
 import { renderHook } from '@testing-library/react';
 import { useHelpCenterCTA } from '../use-help-center-cta';
 import type { SupportStatus } from '../../types';
+import type { HelpCenterCTAPlacement } from '../use-help-center-cta';
 
 const mockUseFeatureConfig = jest.fn();
 const mockUseSupportStatus = jest.fn();
@@ -17,26 +18,29 @@ jest.mock( '../../data/use-support-status', () => ( {
 	useSupportStatus: ( enabled?: boolean ) => mockUseSupportStatus( enabled ),
 } ) );
 
-const eligibleCta = {
+const bannerCta = {
 	id: 'onboarding-call-v1',
 	variant: 'banner',
+	placement: 'help-center-home',
 	url: 'https://savvycal.com/CustomerExperience/wordpresscom-onboarding-hc',
 	title: 'Book Your Free Onboarding Call',
 };
 
 const setup = ( {
-	contextualCta = true,
+	enabled = true,
 	isLoading = false,
-	cta = eligibleCta,
+	cta = bannerCta,
+	placement = 'help-center-home',
 }: {
-	contextualCta?: boolean;
+	enabled?: boolean;
 	isLoading?: boolean;
 	cta?: SupportStatus[ 'cta' ] | null;
+	placement?: HelpCenterCTAPlacement;
 } = {} ) => {
-	mockUseFeatureConfig.mockReturnValue( { home: { contextualCta } } );
+	mockUseFeatureConfig.mockReturnValue( { contextualCta: { enabled } } );
 	mockUseSupportStatus.mockReturnValue( { data: cta ? { cta } : {}, isLoading } );
 
-	return renderHook( () => useHelpCenterCTA() );
+	return renderHook( () => useHelpCenterCTA( placement ) );
 };
 
 describe( 'useHelpCenterCTA', () => {
@@ -51,8 +55,8 @@ describe( 'useHelpCenterCTA', () => {
 			variant: 'banner',
 			ctaId: 'onboarding-call-v1',
 			placement: 'help-center-home',
-			url: eligibleCta.url,
-			title: eligibleCta.title,
+			url: bannerCta.url,
+			title: bannerCta.title,
 			description: undefined,
 			actionLabel: undefined,
 		} );
@@ -61,7 +65,7 @@ describe( 'useHelpCenterCTA', () => {
 	it( 'passes through the optional description and action label', () => {
 		const { result } = setup( {
 			cta: {
-				...eligibleCta,
+				...bannerCta,
 				description: 'Talk one-on-one with a Happiness Engineer.',
 				action_label: 'Book your free call',
 			},
@@ -71,6 +75,30 @@ describe( 'useHelpCenterCTA', () => {
 			description: 'Talk one-on-one with a Happiness Engineer.',
 			actionLabel: 'Book your free call',
 		} );
+	} );
+
+	it( 'only answers the slot the backend placed the CTA in', () => {
+		expect( setup( { placement: 'help-center-more-resources' } ).result.current ).toBeNull();
+
+		const listCta = {
+			...bannerCta,
+			variant: 'link-list-item',
+			placement: 'help-center-more-resources',
+		};
+
+		expect( setup( { cta: listCta, placement: 'help-center-home' } ).result.current ).toBeNull();
+		expect(
+			setup( { cta: listCta, placement: 'help-center-more-resources' } ).result.current
+		).toMatchObject( { variant: 'link-list-item', placement: 'help-center-more-resources' } );
+	} );
+
+	it( 'returns null for a variant the slot cannot render', () => {
+		const { result } = setup( {
+			cta: { ...bannerCta, placement: 'help-center-more-resources' },
+			placement: 'help-center-more-resources',
+		} );
+
+		expect( result.current ).toBeNull();
 	} );
 
 	it( 'returns null while support status is loading', () => {
@@ -85,19 +113,19 @@ describe( 'useHelpCenterCTA', () => {
 		expect( result.current ).toBeNull();
 	} );
 
-	it( 'returns null for an unsupported variant', () => {
-		const { result } = setup( { cta: { ...eligibleCta, variant: 'default' } } );
+	it( 'returns null for an unknown variant', () => {
+		const { result } = setup( { cta: { ...bannerCta, variant: 'default' } } );
 
 		expect( result.current ).toBeNull();
 	} );
 
 	it( 'returns null when the payload is missing a title or a url', () => {
-		expect( setup( { cta: { ...eligibleCta, title: '' } } ).result.current ).toBeNull();
-		expect( setup( { cta: { ...eligibleCta, url: '' } } ).result.current ).toBeNull();
+		expect( setup( { cta: { ...bannerCta, title: '' } } ).result.current ).toBeNull();
+		expect( setup( { cta: { ...bannerCta, url: '' } } ).result.current ).toBeNull();
 	} );
 
 	it( 'skips the CTA and the support-status fetch when the product disables it', () => {
-		const { result } = setup( { contextualCta: false } );
+		const { result } = setup( { enabled: false } );
 
 		expect( result.current ).toBeNull();
 		expect( mockUseSupportStatus ).toHaveBeenCalledWith( false );

--- a/packages/help-center/src/hooks/use-help-center-cta.ts
+++ b/packages/help-center/src/hooks/use-help-center-cta.ts
@@ -2,35 +2,47 @@ import { useFeatureConfig } from '../contexts/HelpCenterContext';
 import { useSupportStatus } from '../data/use-support-status';
 import type { HelpCenterCTAProps, HelpCenterCTAVariant } from '../components/help-center-cta';
 
-const VARIANTS: HelpCenterCTAVariant[] = [ 'banner', 'link-list-item' ];
+export type HelpCenterCTAPlacement = 'help-center-home' | 'help-center-more-resources';
 
-// Reported with the Tracks events. Moves to the payload once the backend can
-// place CTAs on more than the home panel.
-const PLACEMENT = 'help-center-home';
+/**
+ * Which variants each slot is able to render. A link-list item is an `<li>` and
+ * only belongs inside the More resources list; a banner only fits the standalone
+ * slot at the top of the home panel.
+ */
+const PLACEMENT_VARIANTS: Record< HelpCenterCTAPlacement, HelpCenterCTAVariant[] > = {
+	'help-center-home': [ 'banner' ],
+	'help-center-more-resources': [ 'link-list-item' ],
+};
 
 /**
  * Resolves the contextual CTA the backend picked for this user into renderable
- * props, or null when there is nothing to show. Campaign copy, destination, and
- * variant all come from the payload so they can change without a deploy.
+ * props, or null when this slot has nothing to show. Campaign copy, destination,
+ * variant, and placement all come from the payload so they can change without a
+ * deploy.
+ * @param placement The slot asking. Only the CTA the backend placed here renders.
  */
-export function useHelpCenterCTA(): HelpCenterCTAProps | null {
+export function useHelpCenterCTA( placement: HelpCenterCTAPlacement ): HelpCenterCTAProps | null {
 	const featureConfig = useFeatureConfig();
-	const { data, isLoading } = useSupportStatus( featureConfig.home.contextualCta );
+	const { data, isLoading } = useSupportStatus( featureConfig.contextualCta.enabled );
 
 	const cta = data?.cta;
 
-	if ( ! featureConfig.home.contextualCta || isLoading || ! cta ) {
+	if ( ! featureConfig.contextualCta.enabled || isLoading || ! cta ) {
 		return null;
 	}
 
-	if ( ! cta.title || ! cta.url || ! VARIANTS.includes( cta.variant as HelpCenterCTAVariant ) ) {
+	if ( cta.placement !== placement || ! cta.title || ! cta.url ) {
+		return null;
+	}
+
+	if ( ! PLACEMENT_VARIANTS[ placement ].includes( cta.variant as HelpCenterCTAVariant ) ) {
 		return null;
 	}
 
 	return {
 		variant: cta.variant as HelpCenterCTAVariant,
 		ctaId: cta.id,
-		placement: PLACEMENT,
+		placement,
 		url: cta.url,
 		title: cta.title,
 		description: cta.description,

--- a/packages/help-center/src/hooks/use-help-center-cta.ts
+++ b/packages/help-center/src/hooks/use-help-center-cta.ts
@@ -2,26 +2,19 @@ import { useFeatureConfig } from '../contexts/HelpCenterContext';
 import { useSupportStatus } from '../data/use-support-status';
 import type { HelpCenterCTAProps, HelpCenterCTAVariant } from '../components/help-center-cta';
 
-export type HelpCenterCTAPlacement = 'help-center-home' | 'help-center-more-resources';
-
-/**
- * Which variants each slot is able to render. A link-list item is an `<li>` and
- * only belongs inside the More resources list; a banner only fits the standalone
- * slot at the top of the home panel.
- */
-const PLACEMENT_VARIANTS: Record< HelpCenterCTAPlacement, HelpCenterCTAVariant[] > = {
-	'help-center-home': [ 'banner' ],
-	'help-center-more-resources': [ 'link-list-item' ],
+/** Where each variant renders. Reported with the Tracks events. */
+const VARIANT_PLACEMENTS: Record< HelpCenterCTAVariant, string > = {
+	banner: 'help-center-home',
+	'link-list-item': 'help-center-more-resources',
 };
 
 /**
  * Resolves the contextual CTA the backend picked for this user into renderable
  * props, or null when this slot has nothing to show. Campaign copy, destination,
- * variant, and placement all come from the payload so they can change without a
- * deploy.
- * @param placement The slot asking. Only the CTA the backend placed here renders.
+ * and variant all come from the payload so they can change without a deploy.
+ * @param variant The slot asking. Only the CTA the backend built for it renders.
  */
-export function useHelpCenterCTA( placement: HelpCenterCTAPlacement ): HelpCenterCTAProps | null {
+export function useHelpCenterCTA( variant: HelpCenterCTAVariant ): HelpCenterCTAProps | null {
 	const featureConfig = useFeatureConfig();
 	const { data, isLoading } = useSupportStatus( featureConfig.contextualCta.enabled );
 
@@ -31,21 +24,17 @@ export function useHelpCenterCTA( placement: HelpCenterCTAPlacement ): HelpCente
 		return null;
 	}
 
-	if ( cta.placement !== placement || ! cta.title || ! cta.url ) {
-		return null;
-	}
-
-	if ( ! PLACEMENT_VARIANTS[ placement ].includes( cta.variant as HelpCenterCTAVariant ) ) {
+	if ( cta.variant !== variant || ! cta.title || ! cta.url ) {
 		return null;
 	}
 
 	return {
-		variant: cta.variant as HelpCenterCTAVariant,
+		variant,
 		ctaId: cta.id,
-		placement,
+		placement: VARIANT_PLACEMENTS[ variant ],
 		url: cta.url,
 		title: cta.title,
 		description: cta.description,
-		actionLabel: cta.action_label,
+		actionLabel: cta.url_text,
 	};
 }

--- a/packages/help-center/src/hooks/use-help-center-cta.ts
+++ b/packages/help-center/src/hooks/use-help-center-cta.ts
@@ -1,0 +1,49 @@
+import { __ } from '@wordpress/i18n';
+import { useFeatureConfig } from '../contexts/HelpCenterContext';
+import { useSupportStatus } from '../data/use-support-status';
+import type { HelpCenterCTAProps, HelpCenterCTAVariant } from '../components/help-center-cta';
+
+export const HELP_CENTER_CTA_HOME_PLACEMENT = 'help-center-home';
+
+const VARIANTS: HelpCenterCTAVariant[] = [ 'banner', 'link-list-item' ];
+
+/**
+ * Copy stays client-side so it can be translated and A/B tested; the backend
+ * only decides who sees a campaign and where it points. Unknown campaign ids
+ * render nothing.
+ */
+const CAMPAIGN_COPY: Record< string, () => Pick< HelpCenterCTAProps, 'title' | 'description' > > = {
+	'onboarding-call-v1': () => ( {
+		title: __( 'Book Your Free Onboarding Call', __i18n_text_domain__ ),
+	} ),
+};
+
+/**
+ * Resolves the contextual CTA the backend picked for this user into renderable
+ * props, or null when there is nothing to show.
+ * @param placement Where the CTA renders; reported with the Tracks events.
+ */
+export function useHelpCenterCTA( placement: string ): HelpCenterCTAProps | null {
+	const featureConfig = useFeatureConfig();
+	const { data, isLoading } = useSupportStatus( featureConfig.home.contextualCta );
+
+	const cta = data?.cta;
+
+	if ( ! featureConfig.home.contextualCta || isLoading || ! cta ) {
+		return null;
+	}
+
+	const copy = CAMPAIGN_COPY[ cta.id ];
+
+	if ( ! copy || ! VARIANTS.includes( cta.variant as HelpCenterCTAVariant ) ) {
+		return null;
+	}
+
+	return {
+		...copy(),
+		variant: cta.variant as HelpCenterCTAVariant,
+		ctaId: cta.id,
+		placement,
+		url: cta.url,
+	};
+}

--- a/packages/help-center/src/hooks/use-help-center-cta.ts
+++ b/packages/help-center/src/hooks/use-help-center-cta.ts
@@ -2,12 +2,6 @@ import { useFeatureConfig } from '../contexts/HelpCenterContext';
 import { useSupportStatus } from '../data/use-support-status';
 import type { HelpCenterCTAProps, HelpCenterCTAVariant } from '../components/help-center-cta';
 
-/** Where each variant renders. Reported with the Tracks events. */
-const VARIANT_PLACEMENTS: Record< HelpCenterCTAVariant, string > = {
-	banner: 'help-center-home',
-	'link-list-item': 'help-center-more-resources',
-};
-
 /**
  * The destination is campaign data, so it can be edited without a deploy. Only
  * follow it when it is an absolute http(s) URL, never `javascript:` or `data:`.
@@ -45,7 +39,6 @@ export function useHelpCenterCTA( variant: HelpCenterCTAVariant ): HelpCenterCTA
 	return {
 		variant,
 		ctaId: cta.id,
-		placement: VARIANT_PLACEMENTS[ variant ],
 		url: cta.url,
 		title: cta.title,
 		description: cta.description,

--- a/packages/help-center/src/hooks/use-help-center-cta.ts
+++ b/packages/help-center/src/hooks/use-help-center-cta.ts
@@ -2,17 +2,18 @@ import { useFeatureConfig } from '../contexts/HelpCenterContext';
 import { useSupportStatus } from '../data/use-support-status';
 import type { HelpCenterCTAProps, HelpCenterCTAVariant } from '../components/help-center-cta';
 
-export const HELP_CENTER_CTA_HOME_PLACEMENT = 'help-center-home';
-
 const VARIANTS: HelpCenterCTAVariant[] = [ 'banner', 'link-list-item' ];
+
+// Reported with the Tracks events. Moves to the payload once the backend can
+// place CTAs on more than the home panel.
+const PLACEMENT = 'help-center-home';
 
 /**
  * Resolves the contextual CTA the backend picked for this user into renderable
  * props, or null when there is nothing to show. Campaign copy, destination, and
  * variant all come from the payload so they can change without a deploy.
- * @param placement Where the CTA renders; reported with the Tracks events.
  */
-export function useHelpCenterCTA( placement: string ): HelpCenterCTAProps | null {
+export function useHelpCenterCTA(): HelpCenterCTAProps | null {
 	const featureConfig = useFeatureConfig();
 	const { data, isLoading } = useSupportStatus( featureConfig.home.contextualCta );
 
@@ -29,7 +30,7 @@ export function useHelpCenterCTA( placement: string ): HelpCenterCTAProps | null
 	return {
 		variant: cta.variant as HelpCenterCTAVariant,
 		ctaId: cta.id,
-		placement,
+		placement: PLACEMENT,
 		url: cta.url,
 		title: cta.title,
 		description: cta.description,

--- a/packages/help-center/src/hooks/use-help-center-cta.ts
+++ b/packages/help-center/src/hooks/use-help-center-cta.ts
@@ -32,7 +32,14 @@ export function useHelpCenterCTA( variant: HelpCenterCTAVariant ): HelpCenterCTA
 		return null;
 	}
 
-	if ( cta.variant !== variant || ! cta.title || ! cta.url || ! isSafeUrl( cta.url ) ) {
+	if (
+		cta.variant !== variant ||
+		! cta.id ||
+		typeof cta.title !== 'string' ||
+		! cta.title ||
+		! cta.url ||
+		! isSafeUrl( cta.url )
+	) {
 		return null;
 	}
 
@@ -41,7 +48,7 @@ export function useHelpCenterCTA( variant: HelpCenterCTAVariant ): HelpCenterCTA
 		ctaId: cta.id,
 		url: cta.url,
 		title: cta.title,
-		description: cta.description,
-		actionLabel: cta.url_text,
+		description: typeof cta.description === 'string' ? cta.description : undefined,
+		actionLabel: typeof cta.url_text === 'string' ? cta.url_text : undefined,
 	};
 }

--- a/packages/help-center/src/hooks/use-help-center-cta.ts
+++ b/packages/help-center/src/hooks/use-help-center-cta.ts
@@ -1,4 +1,3 @@
-import { __ } from '@wordpress/i18n';
 import { useFeatureConfig } from '../contexts/HelpCenterContext';
 import { useSupportStatus } from '../data/use-support-status';
 import type { HelpCenterCTAProps, HelpCenterCTAVariant } from '../components/help-center-cta';
@@ -8,19 +7,9 @@ export const HELP_CENTER_CTA_HOME_PLACEMENT = 'help-center-home';
 const VARIANTS: HelpCenterCTAVariant[] = [ 'banner', 'link-list-item' ];
 
 /**
- * Copy stays client-side so it can be translated and A/B tested; the backend
- * only decides who sees a campaign and where it points. Unknown campaign ids
- * render nothing.
- */
-const CAMPAIGN_COPY: Record< string, () => Pick< HelpCenterCTAProps, 'title' | 'description' > > = {
-	'onboarding-call-v1': () => ( {
-		title: __( 'Book Your Free Onboarding Call', __i18n_text_domain__ ),
-	} ),
-};
-
-/**
  * Resolves the contextual CTA the backend picked for this user into renderable
- * props, or null when there is nothing to show.
+ * props, or null when there is nothing to show. Campaign copy, destination, and
+ * variant all come from the payload so they can change without a deploy.
  * @param placement Where the CTA renders; reported with the Tracks events.
  */
 export function useHelpCenterCTA( placement: string ): HelpCenterCTAProps | null {
@@ -33,17 +22,17 @@ export function useHelpCenterCTA( placement: string ): HelpCenterCTAProps | null
 		return null;
 	}
 
-	const copy = CAMPAIGN_COPY[ cta.id ];
-
-	if ( ! copy || ! VARIANTS.includes( cta.variant as HelpCenterCTAVariant ) ) {
+	if ( ! cta.title || ! cta.url || ! VARIANTS.includes( cta.variant as HelpCenterCTAVariant ) ) {
 		return null;
 	}
 
 	return {
-		...copy(),
 		variant: cta.variant as HelpCenterCTAVariant,
 		ctaId: cta.id,
 		placement,
 		url: cta.url,
+		title: cta.title,
+		description: cta.description,
+		actionLabel: cta.action_label,
 	};
 }

--- a/packages/help-center/src/hooks/use-help-center-cta.ts
+++ b/packages/help-center/src/hooks/use-help-center-cta.ts
@@ -9,6 +9,20 @@ const VARIANT_PLACEMENTS: Record< HelpCenterCTAVariant, string > = {
 };
 
 /**
+ * The destination is campaign data, so it can be edited without a deploy. Only
+ * follow it when it is an absolute http(s) URL, never `javascript:` or `data:`.
+ * @param url The destination from the payload.
+ */
+function isSafeUrl( url: string ): boolean {
+	try {
+		const { protocol } = new URL( url );
+		return protocol === 'https:' || protocol === 'http:';
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Resolves the contextual CTA the backend picked for this user into renderable
  * props, or null when this slot has nothing to show. Campaign copy, destination,
  * and variant all come from the payload so they can change without a deploy.
@@ -24,7 +38,7 @@ export function useHelpCenterCTA( variant: HelpCenterCTAVariant ): HelpCenterCTA
 		return null;
 	}
 
-	if ( cta.variant !== variant || ! cta.title || ! cta.url ) {
+	if ( cta.variant !== variant || ! cta.title || ! cta.url || ! isSafeUrl( cta.url ) ) {
 		return null;
 	}
 

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -86,6 +86,7 @@ interface Eligibility {
 interface SupportStatusCTA {
 	id: string;
 	variant: string;
+	placement: string;
 	url: string;
 	title: string;
 	description?: string;

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -87,6 +87,9 @@ interface SupportStatusCTA {
 	id: string;
 	variant: string;
 	url: string;
+	title: string;
+	description?: string;
+	action_label?: string;
 }
 
 export interface SupportStatus {

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -86,11 +86,10 @@ interface Eligibility {
 interface SupportStatusCTA {
 	id: string;
 	variant: string;
-	placement: string;
 	url: string;
 	title: string;
 	description?: string;
-	action_label?: string;
+	url_text?: string;
 }
 
 export interface SupportStatus {

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -83,9 +83,17 @@ interface Eligibility {
 	unified_agent_enabled?: boolean;
 }
 
+interface SupportStatusCTA {
+	id: string;
+	variant: string;
+	url: string;
+}
+
 export interface SupportStatus {
 	eligibility: Eligibility;
 	availability: Availability;
+	/** Absent when the user is not eligible for any contextual CTA. */
+	cta?: SupportStatusCTA;
 }
 
 export interface SupportActivity {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-489/wire-up-and-roll-out-the-v1-cta

## Proposed Changes

**The Help Center now renders the contextual CTA the backend picks for the user, in the slot the backend puts it in.**

- New `useHelpCenterCTA` hook turns the `cta` field of `GET /wpcom/v2/help/support-status` into renderable props — copy, destination, and placement all come from the payload.
- `placement` picks the slot: `banner` at the top of the home panel, `list` at the head of More resources. Anything else renders nothing.
- Gated behind a new `contextualCta.enabled` feature flag: on for WordPress.com, off for A8C for Agencies and Commerce Garden.

The backend still returns placeholder values, so nothing renders in production yet ([DOTSUP-488](https://linear.app/a8c/issue/DOTSUP-488)).

## Why are these changes being made?

New users get the most out of their first weeks when someone walks them through setup, and Happiness has free onboarding calls to offer — but nothing in the product tells people those calls exist. The Help Center is where a stuck new user already goes, so it’s the natural place to offer one.

Keeping the whole campaign server-side means the offer can be reworded, moved, or killed without shipping client code.

## Testing Instructions

Force the CTA locally by adding a `cta` object to the query result in `packages/help-center/src/data/use-support-status.ts`, e.g. `cta: { id: 'onboarding-call-v1', placement: 'banner', url: 'https://example.com', title: 'Book Your Free Onboarding Call' }`.

### Calypso

1. Run `yarn start` and open the Help Center home panel.
2. Verify the banner appears above recent conversations, is clickable end to end, and opens the URL in a new tab.
3. Switch to `placement: 'list'` and verify the CTA moves to the top of More resources and the banner slot is empty.
4. Remove the `cta` field, or set an unrecognised placement, and verify nothing renders in either slot.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`, run `cd apps/help-center && yarn dev --sync`, then repeat the steps above on any Simple, Atomic, or CIAB site.

### Other Help Center products

1. Open the Help Center in A8C for Agencies and Commerce Garden and verify no CTA renders.
