### PR TITLE
Interim Omnibar: wire up admin menu so the Comments item renders

### DIFF
--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -3,6 +3,7 @@ import { useShouldUseUnifiedAgent } from '@automattic/agents-manager';
 import {
 	purchaseQuery,
 	queryClient,
+	siteAdminMenuQuery,
 	siteCurrentPlanQuery,
 	siteHourlyViewsQuery,
 } from '@automattic/api-queries';
@@ -81,6 +82,14 @@ export function InterimOmnibar( {
 	const { data: hourlyViews } = useQuery(
 		{
 			...siteHourlyViewsQuery( site?.ID ?? 0 ),
+			enabled: !! site,
+		},
+		queryClient
+	);
+
+	const { data: adminMenu } = useQuery(
+		{
+			...siteAdminMenuQuery( site?.ID ?? 0 ),
 			enabled: !! site,
 		},
 		queryClient
@@ -191,7 +200,7 @@ export function InterimOmnibar( {
 					isNotificationsShowing={ false }
 					isMigrationInProgress={ false }
 					migrationStatus={ null }
-					adminMenu={ null }
+					adminMenu={ adminMenu ?? null }
 					// Actions
 					setNextLayoutFocus={ noop }
 					activateNextLayoutFocus={ () => onToggleMenu?.() }

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -28,6 +28,7 @@ import {
 	sitePlansQuery,
 	siteBySlugQuery,
 	siteByIdQuery,
+	siteAdminMenuQuery,
 	siteCrontabsQuery,
 	sitePreviewLinksQuery,
 	sitePrimaryDataCenterQuery,
@@ -179,6 +180,10 @@ export const siteRoute = createRoute( {
 		const otherEnvironmentSiteId = site.is_wpcom_staging_site
 			? site.options?.wpcom_production_blog_id
 			: site.options?.wpcom_staging_blog_ids?.[ 0 ];
+
+		// Warm the omnibar admin menu without gating the route transition.
+		queryClient.prefetchQuery( siteAdminMenuQuery( site.ID ) );
+
 		await Promise.all( [
 			otherEnvironmentSiteId &&
 				queryClient.ensureQueryData( siteByIdQuery( otherEnvironmentSiteId ) ),

--- a/packages/api-core/src/admin-menu/index.ts
+++ b/packages/api-core/src/admin-menu/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/packages/api-core/src/admin-menu/types.ts
+++ b/packages/api-core/src/admin-menu/types.ts
@@ -1,0 +1,13 @@
+export interface AdminMenuItem {
+	slug: string;
+	title: string;
+	type: string;
+	url?: string;
+	icon?: string;
+	badge?: string;
+	count?: number;
+	parent?: string;
+	children?: AdminMenuItem[];
+}
+
+export type AdminMenuResponse = AdminMenuItem[] | { menu: AdminMenuItem[] };

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -3,6 +3,7 @@ export * from './constants';
 export * from './error';
 
 export * from './admin-bar';
+export * from './admin-menu';
 export * from './agency';
 export * from './agency-products';
 export * from './agency-referrals';
@@ -115,6 +116,7 @@ export * from './site-activity-log';
 export * from './site-activity-log-backup';
 export * from './site-address-change';
 export * from './site-admin-bar';
+export * from './site-admin-menu';
 export * from './site-ai-launchpad';
 export * from './site-atomic-transfers';
 export * from './site-automated-transfers-eligibility';

--- a/packages/api-core/src/site-admin-menu/fetchers.ts
+++ b/packages/api-core/src/site-admin-menu/fetchers.ts
@@ -1,0 +1,14 @@
+import { AdminMenuItem, AdminMenuResponse } from '../admin-menu/types';
+import { wpcom } from '../wpcom-fetcher';
+
+export async function fetchSiteAdminMenu( siteId: number ): Promise< AdminMenuItem[] > {
+	const response: AdminMenuResponse = await wpcom.req.get(
+		{
+			path: `/sites/${ siteId }/admin-menu/`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{ _locale: 'user' }
+	);
+
+	return Array.isArray( response ) ? response : response.menu ?? [];
+}

--- a/packages/api-core/src/site-admin-menu/index.ts
+++ b/packages/api-core/src/site-admin-menu/index.ts
@@ -1,0 +1,1 @@
+export * from './fetchers';

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -105,6 +105,7 @@ export * from './site-activity-log-backup';
 export * from './site-address-change';
 export * from './site-apm';
 export * from './site-admin-bar';
+export * from './site-admin-menu';
 export * from './site-agency';
 export * from './site-ai-launchpad';
 export * from './site-atomic-transfers';

--- a/packages/api-queries/src/site-admin-menu.ts
+++ b/packages/api-queries/src/site-admin-menu.ts
@@ -1,0 +1,9 @@
+import { fetchSiteAdminMenu } from '@automattic/api-core';
+import { queryOptions } from '@tanstack/react-query';
+
+export const siteAdminMenuQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'admin-menu' ],
+		queryFn: () => fetchSiteAdminMenu( siteId ),
+		staleTime: 5 * 60 * 1000,
+	} );


### PR DESCRIPTION
## Proposed Changes

* Add `siteAdminMenuQuery` (and the underlying `fetchSiteAdminMenu` fetcher in `@automattic/api-core`) that fetches `GET wpcom/v2/sites/{id}/admin-menu/`, normalizing both the legacy flat-array response and the newer `{ menu }` envelope to `AdminMenuItem[]`.
* In the Dashboard's interim omnibar (`client/dashboard/app/interim-omnibar/interim-omnibar.tsx`), fetch the admin menu and pass it to `MasterbarLoggedIn` as `adminMenu`, replacing the hardcoded `adminMenu={ null }`.

## Why are these changes being made?

The interim omnibar wraps the legacy `MasterbarLoggedIn`, whose `renderCommentsMenu()` (the comment-moderation item with a pending count) and `renderUpdatesMenu()` are driven entirely by the `adminMenu` prop. Because the interim omnibar passed `adminMenu={ null }`, those items never rendered in the Dashboard. Wiring up a real admin-menu fetch makes the Comments item (and the Updates item) appear with live counts and URLs, matching the classic masterbar.

## Testing Instructions

* Open the Dashboard with a site selected so the interim omnibar renders.
* Confirm the comment-moderation icon appears in the omnibar, and that its pending-comment count and link match wp-admin (`edit-comments.php`).
* On a site with pending core/plugin updates, confirm the Updates item also appears.
* Confirm no regressions on `domainOnlySite` (the Comments item is intentionally hidden there).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)