### PR TITLE
Fix stray accent border on secondary buttons after @wordpress/components 37

### DIFF
--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -90,6 +90,12 @@
 	--a4a-brand-blue-80: #12304a;
 }
 
+/* 37.0.0 draws the secondary border with `border-color`; A4A buttons are borderless by
+ * design, so turn it off. Buttons that want an outline still draw their own box-shadow. */
+:where(.components-button.is-secondary:not(.is-destructive)) {
+	border-color: transparent !important;
+}
+
 .theme-a8c-for-agencies {
 
 	.components-button:not( .dataviews-view-table-header-button ):not( .components-navigator-back-button ),
@@ -104,7 +110,6 @@
 		box-sizing: border-box;
 		border-radius: 4px;
 
-		border-color: var(--color-accent-5);
 		fill: var(--color-accent-100);
 
 		&:hover,
@@ -118,13 +123,6 @@
 		&.is-borderless.is-primary:hover {
 			color: var(--color-primary-60);
 		}
-	}
-
-	// The shared consolidated stat card (reused from the dashboard) renders its
-	// info popover trigger as a borderless icon button; the button-border rule
-	// above would otherwise box it.
-	.consolidated-stat-card .components-button.has-icon:not( .is-primary ) {
-		border-color: transparent;
 	}
 
 	.button.split-button__toggle {

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -232,6 +232,14 @@
 	outline-offset: 0;
 }
 
+/* 37.0.0 draws the secondary border with `border-color` instead of the inset box-shadow
+ * Calypso and several packages still use, so it leaks as a stray accent outline. Turn it
+ * off and keep the box-shadow as the border. Destructive buttons keep their red border. */
+:where(.components-button.is-secondary:not(.is-destructive)) {
+	border-color: transparent !important;
+	box-shadow: inset 0 0 0 1px var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+}
+
 /* @wordpress/components RadioControl overrides --------------------------------------- */
 .components-radio-control {
 	&__input[type="radio"] {


### PR DESCRIPTION
## Proposed Changes

@wordpress/components 37 (bumped in #112947) reworked the Button border and this fixes the fallout in two ways, matching each surface's design:

* **Calypso & packages** (`_wp-components-overrides.scss`): social login/signup buttons, domain search, plans grid, the Reader, etc. draw their secondary-button border with an inset `box-shadow`. Neutralize 37's new `border-color` and reinstate the default accent border as a zero-specificity `box-shadow`, so those custom box-shadows keep owning the border exactly as before.
* **A4A** (`client/a8c-for-agencies/style.scss`): A4A buttons are borderless by design (hover background tint, no outline). Drop a blanket `border-color: var(--color-accent-5)` that was inert until 37 activated it, and turn off 37's stray secondary `border-color`, so buttons stay borderless. Outlined buttons that draw their own `box-shadow` keep it.

## Why are these changes being made?

Components 37 changed how the secondary `Button` paints its border: earlier releases used an inset `box-shadow`; 37 uses a real `border-color: <accent>` on top of a new base `border: 1px solid transparent`.

* In Calypso, components that still draw the border with a `box-shadow` end up with 37's new `border-color` leaking through as a stray blue outline (visible on login, signup, and domain search).
* In A4A, the new base border activated a previously-dormant blanket `border-color` declaration, boxing every button — including icon-only and borderless ones.

Both are restored to their intended appearance without touching each affected component. Destructive secondary buttons are excluded — 37 legitimately uses `border-color` for their red edge.

## Testing Instructions

* Load pages with secondary/outline buttons: login (social buttons), signup, domain search — confirm the normal neutral/custom border returns with no stray blue outline.
* In A4A (marketplace product filter, plugins management, sites), confirm buttons — especially icon-only/borderless ones — are borderless again.
* Confirm destructive secondary buttons keep their red border.
* Check light and dark mode.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
