### PR TITLE
Account recovery interstitial: bump experiment to 202607

### DIFF
--- a/client/dashboard/app/account-recovery-interstitial/index.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/index.tsx
@@ -28,7 +28,7 @@ const DAY_IN_SECONDS = 86400;
  * ExPlat A/B experiment gating the interstitial. Users in the `no_recovery_modal` variation will _not_ see the
  * modal; everyone else (control / unassigned) does.
  */
-const EXPERIMENT_NAME = 'calypso_onboarding_account_recovery_modal_202606';
+const EXPERIMENT_NAME = 'calypso_onboarding_account_recovery_modal_202607';
 const EXPERIMENT_TREATMENT_VARIATION = 'no_recovery_modal';
 
 /**

--- a/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
@@ -55,7 +55,7 @@ function mockPreferences( calypso_preferences: Partial< UserPreferences > = {} )
 		.reply( 200, { calypso_preferences } );
 }
 
-const EXPERIMENT_NAME = 'calypso_onboarding_account_recovery_modal_202606';
+const EXPERIMENT_NAME = 'calypso_onboarding_account_recovery_modal_202607';
 const TREATMENT_VARIATION = 'no_recovery_modal';
 
 // The interstitial is hidden only for users in the `no_recovery_modal` treatment; control and


### PR DESCRIPTION
## Proposed Changes

* Rename the ExPlat experiment gating the account-recovery interstitial from `calypso_onboarding_account_recovery_modal_202606` to `calypso_onboarding_account_recovery_modal_202607` (in both the component and its test).

## Why are these changes being made?

<!-- -->
The 202606 experiment went live on July 7 but had to be disabled on July 13 due to a conflict with the MSD welcome modal, so it never completed. A new experiment record has been created taking the welcome modal into account. This PR points the interstitial at the 202607 clone so the modal can be relaunched and its impact measured cleanly. The welcome-modal suppression logic that resolves the original conflict already lives in this component.

## Testing Instructions

* Run the unit tests: `yarn test-client client/dashboard/app/account-recovery-interstitial/test/index.test.tsx` — all 12 pass.
* With the 202607 experiment active, load the dashboard as a user with incomplete account-recovery setup and confirm the interstitial appears for the control group and is hidden for the `no_recovery_modal` treatment.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?