### PR TITLE
Account recovery interstitial: cap the nudge at 3 shows per user

### DIFF
--- a/client/dashboard/app/account-recovery-interstitial/index.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/index.tsx
@@ -31,8 +31,8 @@ const DAY_IN_SECONDS = 86400;
 const EXPERIMENT_NAME = 'calypso_onboarding_account_recovery_modal_202606';
 const EXPERIMENT_TREATMENT_VARIATION = 'no_recovery_modal';
 
-/** Lifetime nudge cap — each dismissal (not impression) counts as one view. */
-const MAX_INTERSTITIAL_VIEWS = 3;
+/** Lifetime nudge cap — counts dismissals, not impressions. */
+const MAX_INTERSTITIAL_DISMISSALS = 3;
 
 /**
  * Snooze windows (in days) by security level
@@ -91,8 +91,8 @@ export default function AccountRecoveryInterstitial() {
 	const { data: snoozeUntilPersisted, isSuccess: isSnoozeLoaded } = useQuery(
 		userPreferenceQuery( 'account-recovery-interstitial-snoozed-until' )
 	);
-	const { data: viewCount, isSuccess: isViewCountLoaded } = useQuery(
-		userPreferenceQuery( 'account-recovery-interstitial-view-count' )
+	const { data: dismissCount, isSuccess: isDismissCountLoaded } = useQuery(
+		userPreferenceQuery( 'account-recovery-interstitial-dismiss-count' )
 	);
 	const { data: dashboardOptIn, isSuccess: isDashboardOptInLoaded } = useQuery(
 		userPreferenceQuery( 'hosting-dashboard-opt-in' )
@@ -121,7 +121,7 @@ export default function AccountRecoveryInterstitial() {
 	const snoozeDays = SNOOZE_DAYS[ securityLevel ];
 
 	const isSnoozed = !! snoozeUntilPersisted && now < snoozeUntilPersisted;
-	const hasReachedViewCap = ( viewCount ?? 0 ) >= MAX_INTERSTITIAL_VIEWS;
+	const hasReachedDismissCap = ( dismissCount ?? 0 ) >= MAX_INTERSTITIAL_DISMISSALS;
 
 	// Suppress the interstitial while the dashboard welcome modal is still pending, so the two
 	// full-page modals don't stack on the first dashboard load. The welcome-modal state is latched
@@ -143,11 +143,11 @@ export default function AccountRecoveryInterstitial() {
 		isAccountRecoveryLoaded &&
 		isUserSettingsLoaded &&
 		isSnoozeLoaded &&
-		isViewCountLoaded &&
+		isDismissCountLoaded &&
 		isWelcomeDataLoaded &&
 		! isWelcomeModalPending &&
 		! isSnoozed &&
-		! hasReachedViewCap &&
+		! hasReachedDismissCap &&
 		! isSupportSession() &&
 		securityLevel !== 'strong';
 
@@ -192,7 +192,7 @@ export default function AccountRecoveryInterstitial() {
 		// server's read-modify-write of the whole preferences blob, so one silently clobbers the other.
 		dismissMutation.mutate( {
 			'account-recovery-interstitial-snoozed-until': now + snoozeDays * DAY_IN_SECONDS,
-			'account-recovery-interstitial-view-count': ( viewCount ?? 0 ) + 1,
+			'account-recovery-interstitial-dismiss-count': ( dismissCount ?? 0 ) + 1,
 		} );
 		setIsDismissed( true );
 	};

--- a/client/dashboard/app/account-recovery-interstitial/index.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/index.tsx
@@ -31,11 +31,7 @@ const DAY_IN_SECONDS = 86400;
 const EXPERIMENT_NAME = 'calypso_onboarding_account_recovery_modal_202606';
 const EXPERIMENT_TREATMENT_VARIATION = 'no_recovery_modal';
 
-/**
- * Lifetime cap on how many times a user is nudged. Each dismissal counts as one nudge; once the cap
- * is reached the interstitial never shows again. Keeps the modal from becoming a recurring
- * annoyance for users who repeatedly snooze without setting up recovery.
- */
+/** Lifetime nudge cap — each dismissal (not impression) counts as one view. */
 const MAX_INTERSTITIAL_VIEWS = 3;
 
 /**

--- a/client/dashboard/app/account-recovery-interstitial/index.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/index.tsx
@@ -32,6 +32,13 @@ const EXPERIMENT_NAME = 'calypso_onboarding_account_recovery_modal_202606';
 const EXPERIMENT_TREATMENT_VARIATION = 'no_recovery_modal';
 
 /**
+ * Lifetime cap on how many times a user is nudged. Each dismissal counts as one nudge; once the cap
+ * is reached the interstitial never shows again. Keeps the modal from becoming a recurring
+ * annoyance for users who repeatedly snooze without setting up recovery.
+ */
+const MAX_INTERSTITIAL_VIEWS = 3;
+
+/**
  * Snooze windows (in days) by security level
  */
 const SNOOZE_DAYS: Record< SecurityLevel, number > = {
@@ -88,6 +95,9 @@ export default function AccountRecoveryInterstitial() {
 	const { data: snoozeUntilPersisted, isSuccess: isSnoozeLoaded } = useQuery(
 		userPreferenceQuery( 'account-recovery-interstitial-snoozed-until' )
 	);
+	const { data: viewCount, isSuccess: isViewCountLoaded } = useQuery(
+		userPreferenceQuery( 'account-recovery-interstitial-view-count' )
+	);
 	const { data: dashboardOptIn, isSuccess: isDashboardOptInLoaded } = useQuery(
 		userPreferenceQuery( 'hosting-dashboard-opt-in' )
 	);
@@ -97,6 +107,9 @@ export default function AccountRecoveryInterstitial() {
 
 	const snoozeMutation = useMutation(
 		userPreferenceMutation( 'account-recovery-interstitial-snoozed-until' )
+	);
+	const viewCountMutation = useMutation(
+		userPreferenceMutation( 'account-recovery-interstitial-view-count' )
 	);
 
 	const [ isDismissed, setIsDismissed ] = useState( false );
@@ -117,6 +130,7 @@ export default function AccountRecoveryInterstitial() {
 	const snoozeDays = SNOOZE_DAYS[ securityLevel ];
 
 	const isSnoozed = !! snoozeUntilPersisted && now < snoozeUntilPersisted;
+	const hasReachedViewCap = ( viewCount ?? 0 ) >= MAX_INTERSTITIAL_VIEWS;
 
 	// Suppress the interstitial while the dashboard welcome modal is still pending, so the two
 	// full-page modals don't stack on the first dashboard load. The welcome-modal state is latched
@@ -138,9 +152,11 @@ export default function AccountRecoveryInterstitial() {
 		isAccountRecoveryLoaded &&
 		isUserSettingsLoaded &&
 		isSnoozeLoaded &&
+		isViewCountLoaded &&
 		isWelcomeDataLoaded &&
 		! isWelcomeModalPending &&
 		! isSnoozed &&
+		! hasReachedViewCap &&
 		! isSupportSession() &&
 		securityLevel !== 'strong';
 
@@ -182,6 +198,7 @@ export default function AccountRecoveryInterstitial() {
 
 	const snooze = () => {
 		snoozeMutation.mutate( now + snoozeDays * DAY_IN_SECONDS );
+		viewCountMutation.mutate( ( viewCount ?? 0 ) + 1 );
 		setIsDismissed( true );
 	};
 

--- a/client/dashboard/app/account-recovery-interstitial/index.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/index.tsx
@@ -2,7 +2,7 @@ import {
 	accountRecoveryQuery,
 	userSettingsQuery,
 	userPreferenceQuery,
-	userPreferenceMutation,
+	userPreferencesMutation,
 } from '@automattic/api-queries';
 import { isSupportSession } from '@automattic/calypso-support-session';
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -105,12 +105,7 @@ export default function AccountRecoveryInterstitial() {
 		userPreferenceQuery( 'hosting-dashboard-opt-in-welcome-modal-dismissed' )
 	);
 
-	const snoozeMutation = useMutation(
-		userPreferenceMutation( 'account-recovery-interstitial-snoozed-until' )
-	);
-	const viewCountMutation = useMutation(
-		userPreferenceMutation( 'account-recovery-interstitial-view-count' )
-	);
+	const dismissMutation = useMutation( userPreferencesMutation() );
 
 	const [ isDismissed, setIsDismissed ] = useState( false );
 
@@ -197,8 +192,12 @@ export default function AccountRecoveryInterstitial() {
 	const { primaryCta, secondaryCta } = copy;
 
 	const snooze = () => {
-		snoozeMutation.mutate( now + snoozeDays * DAY_IN_SECONDS );
-		viewCountMutation.mutate( ( viewCount ?? 0 ) + 1 );
+		// Both writes go in a single request. Firing two separate preference mutations races on the
+		// server's read-modify-write of the whole preferences blob, so one silently clobbers the other.
+		dismissMutation.mutate( {
+			'account-recovery-interstitial-snoozed-until': now + snoozeDays * DAY_IN_SECONDS,
+			'account-recovery-interstitial-view-count': ( viewCount ?? 0 ) + 1,
+		} );
 		setIsDismissed( true );
 	};
 

--- a/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
@@ -217,6 +217,36 @@ describe( '<AccountRecoveryInterstitial>', () => {
 		} );
 	} );
 
+	test( 'does not show once the lifetime view cap has been reached', async () => {
+		// The user has already been nudged 3 times; the cap means they are never shown it again,
+		// even though they still have no recovery method and are not snoozed.
+		mockAccountRecovery( NONE_RECOVERY );
+		mockUserSettings( { two_step_enabled: false } );
+		mockPreferences( { 'account-recovery-interstitial-view-count': 3 } );
+
+		const { recordTracksEvent } = render( <AccountRecoveryInterstitial /> );
+
+		await waitFor( () => {
+			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+		} );
+		expect( recordTracksEvent ).not.toHaveBeenCalledWith(
+			'calypso_account_recovery_nudge_interstitial_impression',
+			expect.anything()
+		);
+	} );
+
+	test( 'still shows when the view count is below the cap', async () => {
+		mockAccountRecovery( NONE_RECOVERY );
+		mockUserSettings( { two_step_enabled: false } );
+		mockPreferences( { 'account-recovery-interstitial-view-count': 2 } );
+
+		render( <AccountRecoveryInterstitial /> );
+
+		expect(
+			await screen.findByRole( 'dialog', { name: 'Add a way back into your account' } )
+		).toBeVisible();
+	} );
+
 	test( 'snoozes (writes the preference and closes) when the reminder link is clicked', async () => {
 		const user = userEvent.setup();
 		mockAccountRecovery( NONE_RECOVERY );
@@ -228,6 +258,15 @@ describe( '<AccountRecoveryInterstitial>', () => {
 			.post( '/rest/v1.1/me/preferences', ( body ) => {
 				snoozedValue = body.calypso_preferences?.[ 'account-recovery-interstitial-snoozed-until' ];
 				return typeof snoozedValue === 'number';
+			} )
+			.query( true )
+			.reply( 200, {} );
+
+		let viewCountValue: number | undefined;
+		const viewCountPost = nock( 'https://public-api.wordpress.com' )
+			.post( '/rest/v1.1/me/preferences', ( body ) => {
+				viewCountValue = body.calypso_preferences?.[ 'account-recovery-interstitial-view-count' ];
+				return typeof viewCountValue === 'number';
 			} )
 			.query( true )
 			.reply( 200, {} );
@@ -244,6 +283,9 @@ describe( '<AccountRecoveryInterstitial>', () => {
 		expect( savePost.isDone() ).toBe( true );
 		// none-tier window is 14 days into the future.
 		expect( snoozedValue ).toBeGreaterThan( Math.floor( Date.now() / 1000 ) );
+		// First dismissal bumps the lifetime view count from 0 to 1.
+		expect( viewCountPost.isDone() ).toBe( true );
+		expect( viewCountValue ).toBe( 1 );
 		expect( recordTracksEvent ).toHaveBeenCalledWith(
 			'calypso_account_recovery_nudge_interstitial_dismiss',
 			{

--- a/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
@@ -55,16 +55,16 @@ function mockPreferences( calypso_preferences: Partial< UserPreferences > = {} )
 		.reply( 200, { calypso_preferences } );
 }
 
-// Dismissing writes the snooze and view-count preferences in a single request, so both values are
+// Dismissing writes the snooze and dismiss-count preferences in a single request, so both values are
 // captured from one POST body. (They must not be split into two concurrent writes — that races on
 // the server's read-modify-write of the whole preferences blob and one silently clobbers the other.)
 function mockDismissalWrites() {
-	const captured: { snoozedUntil?: number; viewCount?: number } = {};
+	const captured: { snoozedUntil?: number; dismissCount?: number } = {};
 	nock( 'https://public-api.wordpress.com' )
 		.post( '/rest/v1.1/me/preferences', ( body ) => {
 			const prefs = body.calypso_preferences ?? {};
 			captured.snoozedUntil = prefs[ 'account-recovery-interstitial-snoozed-until' ];
-			captured.viewCount = prefs[ 'account-recovery-interstitial-view-count' ];
+			captured.dismissCount = prefs[ 'account-recovery-interstitial-dismiss-count' ];
 			return true;
 		} )
 		.query( true )
@@ -234,12 +234,12 @@ describe( '<AccountRecoveryInterstitial>', () => {
 		} );
 	} );
 
-	test( 'does not show once the lifetime view cap has been reached', async () => {
-		// The user has already been nudged 3 times; the cap means they are never shown it again,
+	test( 'does not show once the lifetime dismiss cap has been reached', async () => {
+		// The user has already dismissed it 3 times; the cap means they are never shown it again,
 		// even though they still have no recovery method and are not snoozed.
 		mockAccountRecovery( NONE_RECOVERY );
 		mockUserSettings( { two_step_enabled: false } );
-		mockPreferences( { 'account-recovery-interstitial-view-count': 3 } );
+		mockPreferences( { 'account-recovery-interstitial-dismiss-count': 3 } );
 
 		const { recordTracksEvent } = render( <AccountRecoveryInterstitial /> );
 
@@ -252,10 +252,10 @@ describe( '<AccountRecoveryInterstitial>', () => {
 		);
 	} );
 
-	test( 'still shows when the view count is below the cap', async () => {
+	test( 'still shows when the dismiss count is below the cap', async () => {
 		mockAccountRecovery( NONE_RECOVERY );
 		mockUserSettings( { two_step_enabled: false } );
-		mockPreferences( { 'account-recovery-interstitial-view-count': 2 } );
+		mockPreferences( { 'account-recovery-interstitial-dismiss-count': 2 } );
 
 		render( <AccountRecoveryInterstitial /> );
 
@@ -297,7 +297,7 @@ describe( '<AccountRecoveryInterstitial>', () => {
 		);
 	} );
 
-	test( 'increments the lifetime view count on the first dismissal', async () => {
+	test( 'increments the lifetime dismiss count on the first dismissal', async () => {
 		const user = userEvent.setup();
 		mockAccountRecovery( NONE_RECOVERY );
 		mockUserSettings( { two_step_enabled: false } );
@@ -310,17 +310,17 @@ describe( '<AccountRecoveryInterstitial>', () => {
 		await user.click( screen.getByRole( 'button', { name: 'Remind me in 14 days' } ) );
 
 		await waitFor( () => {
-			expect( writes.viewCount ).toBe( 1 );
+			expect( writes.dismissCount ).toBe( 1 );
 		} );
 	} );
 
 	test( 'writes the capping value on the final allowed dismissal', async () => {
-		// With two prior views, a third dismissal writes exactly 3 — the value that trips the cap on
-		// the next load. Guards the `>= MAX_INTERSTITIAL_VIEWS` boundary against an off-by-one.
+		// With two prior dismissals, a third dismissal writes exactly 3 — the value that trips the cap
+		// on the next load. Guards the `>= MAX_INTERSTITIAL_DISMISSALS` boundary against an off-by-one.
 		const user = userEvent.setup();
 		mockAccountRecovery( NONE_RECOVERY );
 		mockUserSettings( { two_step_enabled: false } );
-		mockPreferences( { 'account-recovery-interstitial-view-count': 2 } );
+		mockPreferences( { 'account-recovery-interstitial-dismiss-count': 2 } );
 		const writes = mockDismissalWrites();
 
 		render( <AccountRecoveryInterstitial /> );
@@ -329,11 +329,11 @@ describe( '<AccountRecoveryInterstitial>', () => {
 		await user.click( screen.getByRole( 'button', { name: 'Remind me in 14 days' } ) );
 
 		await waitFor( () => {
-			expect( writes.viewCount ).toBe( 3 );
+			expect( writes.dismissCount ).toBe( 3 );
 		} );
 	} );
 
-	test( 'records the click, snoozes, and bumps the view count on a CTA click', async () => {
+	test( 'records the click, snoozes, and bumps the dismiss count on a CTA click', async () => {
 		const user = userEvent.setup();
 		mockAccountRecovery( NONE_RECOVERY );
 		mockUserSettings( { two_step_enabled: false } );
@@ -362,7 +362,7 @@ describe( '<AccountRecoveryInterstitial>', () => {
 		// Clicking a CTA both nudges the counter and snoozes, so the user isn't re-prompted while
 		// they head off to set up recovery.
 		await waitFor( () => {
-			expect( writes.viewCount ).toBe( 1 );
+			expect( writes.dismissCount ).toBe( 1 );
 		} );
 		expect( writes.snoozedUntil ).toBeGreaterThan( Math.floor( Date.now() / 1000 ) );
 	} );

--- a/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
@@ -55,6 +55,36 @@ function mockPreferences( calypso_preferences: Partial< UserPreferences > = {} )
 		.reply( 200, { calypso_preferences } );
 }
 
+// Dismissing fires two independent preference writes (snooze + view-count) to the same endpoint.
+// nock matches each request to the interceptor whose body predicate fits, so the two values are
+// captured independently regardless of which POST lands first.
+function mockDismissalWrites() {
+	const captured: { snoozedUntil?: number; viewCount?: number } = {};
+	nock( 'https://public-api.wordpress.com' )
+		.post( '/rest/v1.1/me/preferences', ( body ) => {
+			const value = body.calypso_preferences?.[ 'account-recovery-interstitial-snoozed-until' ];
+			if ( typeof value !== 'number' ) {
+				return false;
+			}
+			captured.snoozedUntil = value;
+			return true;
+		} )
+		.query( true )
+		.reply( 200, {} );
+	nock( 'https://public-api.wordpress.com' )
+		.post( '/rest/v1.1/me/preferences', ( body ) => {
+			const value = body.calypso_preferences?.[ 'account-recovery-interstitial-view-count' ];
+			if ( typeof value !== 'number' ) {
+				return false;
+			}
+			captured.viewCount = value;
+			return true;
+		} )
+		.query( true )
+		.reply( 200, {} );
+	return captured;
+}
+
 const EXPERIMENT_NAME = 'calypso_onboarding_account_recovery_modal_202606';
 const TREATMENT_VARIATION = 'no_recovery_modal';
 
@@ -252,24 +282,7 @@ describe( '<AccountRecoveryInterstitial>', () => {
 		mockAccountRecovery( NONE_RECOVERY );
 		mockUserSettings( { two_step_enabled: false } );
 		mockPreferences();
-
-		let snoozedValue: number | undefined;
-		const savePost = nock( 'https://public-api.wordpress.com' )
-			.post( '/rest/v1.1/me/preferences', ( body ) => {
-				snoozedValue = body.calypso_preferences?.[ 'account-recovery-interstitial-snoozed-until' ];
-				return typeof snoozedValue === 'number';
-			} )
-			.query( true )
-			.reply( 200, {} );
-
-		let viewCountValue: number | undefined;
-		const viewCountPost = nock( 'https://public-api.wordpress.com' )
-			.post( '/rest/v1.1/me/preferences', ( body ) => {
-				viewCountValue = body.calypso_preferences?.[ 'account-recovery-interstitial-view-count' ];
-				return typeof viewCountValue === 'number';
-			} )
-			.query( true )
-			.reply( 200, {} );
+		const writes = mockDismissalWrites();
 
 		const { recordTracksEvent } = render( <AccountRecoveryInterstitial /> );
 
@@ -280,12 +293,10 @@ describe( '<AccountRecoveryInterstitial>', () => {
 		await waitFor( () => {
 			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
 		} );
-		expect( savePost.isDone() ).toBe( true );
 		// none-tier window is 14 days into the future.
-		expect( snoozedValue ).toBeGreaterThan( Math.floor( Date.now() / 1000 ) );
-		// First dismissal bumps the lifetime view count from 0 to 1.
-		expect( viewCountPost.isDone() ).toBe( true );
-		expect( viewCountValue ).toBe( 1 );
+		await waitFor( () => {
+			expect( writes.snoozedUntil ).toBeGreaterThan( Math.floor( Date.now() / 1000 ) );
+		} );
 		expect( recordTracksEvent ).toHaveBeenCalledWith(
 			'calypso_account_recovery_nudge_interstitial_dismiss',
 			{
@@ -297,6 +308,76 @@ describe( '<AccountRecoveryInterstitial>', () => {
 				snooze_period: 14,
 			}
 		);
+	} );
+
+	test( 'increments the lifetime view count on the first dismissal', async () => {
+		const user = userEvent.setup();
+		mockAccountRecovery( NONE_RECOVERY );
+		mockUserSettings( { two_step_enabled: false } );
+		mockPreferences();
+		const writes = mockDismissalWrites();
+
+		render( <AccountRecoveryInterstitial /> );
+
+		await screen.findByRole( 'dialog' );
+		await user.click( screen.getByRole( 'button', { name: 'Remind me in 14 days' } ) );
+
+		await waitFor( () => {
+			expect( writes.viewCount ).toBe( 1 );
+		} );
+	} );
+
+	test( 'writes the capping value on the final allowed dismissal', async () => {
+		// With two prior views, a third dismissal writes exactly 3 — the value that trips the cap on
+		// the next load. Guards the `>= MAX_INTERSTITIAL_VIEWS` boundary against an off-by-one.
+		const user = userEvent.setup();
+		mockAccountRecovery( NONE_RECOVERY );
+		mockUserSettings( { two_step_enabled: false } );
+		mockPreferences( { 'account-recovery-interstitial-view-count': 2 } );
+		const writes = mockDismissalWrites();
+
+		render( <AccountRecoveryInterstitial /> );
+
+		await screen.findByRole( 'dialog' );
+		await user.click( screen.getByRole( 'button', { name: 'Remind me in 14 days' } ) );
+
+		await waitFor( () => {
+			expect( writes.viewCount ).toBe( 3 );
+		} );
+	} );
+
+	test( 'records the click, snoozes, and bumps the view count on a CTA click', async () => {
+		const user = userEvent.setup();
+		mockAccountRecovery( NONE_RECOVERY );
+		mockUserSettings( { two_step_enabled: false } );
+		mockPreferences();
+		const writes = mockDismissalWrites();
+
+		const { recordTracksEvent } = render( <AccountRecoveryInterstitial /> );
+
+		await screen.findByRole( 'dialog' );
+		await user.click( screen.getByRole( 'button', { name: 'Set up recovery email or phone' } ) );
+
+		await waitFor( () => {
+			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+		} );
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_account_recovery_nudge_interstitial_cta_click',
+			{
+				security_level: 'none',
+				has_recovery_email: false,
+				has_recovery_phone: false,
+				has_two_factor: false,
+				has_backup_codes: false,
+				cta_id: 'set_up_recovery',
+			}
+		);
+		// Clicking a CTA both nudges the counter and snoozes, so the user isn't re-prompted while
+		// they head off to set up recovery.
+		await waitFor( () => {
+			expect( writes.viewCount ).toBe( 1 );
+		} );
+		expect( writes.snoozedUntil ).toBeGreaterThan( Math.floor( Date.now() / 1000 ) );
 	} );
 
 	test( 'does not show (and records nothing) for a Happiness Engineer in a support session', async () => {

--- a/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
+++ b/client/dashboard/app/account-recovery-interstitial/test/index.test.tsx
@@ -55,29 +55,16 @@ function mockPreferences( calypso_preferences: Partial< UserPreferences > = {} )
 		.reply( 200, { calypso_preferences } );
 }
 
-// Dismissing fires two independent preference writes (snooze + view-count) to the same endpoint.
-// nock matches each request to the interceptor whose body predicate fits, so the two values are
-// captured independently regardless of which POST lands first.
+// Dismissing writes the snooze and view-count preferences in a single request, so both values are
+// captured from one POST body. (They must not be split into two concurrent writes — that races on
+// the server's read-modify-write of the whole preferences blob and one silently clobbers the other.)
 function mockDismissalWrites() {
 	const captured: { snoozedUntil?: number; viewCount?: number } = {};
 	nock( 'https://public-api.wordpress.com' )
 		.post( '/rest/v1.1/me/preferences', ( body ) => {
-			const value = body.calypso_preferences?.[ 'account-recovery-interstitial-snoozed-until' ];
-			if ( typeof value !== 'number' ) {
-				return false;
-			}
-			captured.snoozedUntil = value;
-			return true;
-		} )
-		.query( true )
-		.reply( 200, {} );
-	nock( 'https://public-api.wordpress.com' )
-		.post( '/rest/v1.1/me/preferences', ( body ) => {
-			const value = body.calypso_preferences?.[ 'account-recovery-interstitial-view-count' ];
-			if ( typeof value !== 'number' ) {
-				return false;
-			}
-			captured.viewCount = value;
+			const prefs = body.calypso_preferences ?? {};
+			captured.snoozedUntil = prefs[ 'account-recovery-interstitial-snoozed-until' ];
+			captured.viewCount = prefs[ 'account-recovery-interstitial-view-count' ];
 			return true;
 		} )
 		.query( true )

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -36,6 +36,7 @@ export interface UserPreferences {
 	[ key: `hosting-dashboard-wp-beta-notice-dismissed-${ number }` ]: string | undefined; // ISO timestamp when the user dismissed the beta notice for a site
 	'hosting-dashboard-welcome-notice-dismissed'?: string; // Timestamp when the user dismissed the notice
 	'account-recovery-interstitial-snoozed-until'?: number; // Unix timestamp (seconds) until which the account-recovery interstitial is snoozed; 0/unset means "never snoozed"
+	'account-recovery-interstitial-view-count'?: number; // How many times the user has been nudged by the account-recovery interstitial; capped so we stop after a few nudges
 	'reader-landing-page'?: ReaderLandingPage;
 	'sites-landing-page'?: SitesLandingPage;
 	[ key: `cancel-purchase-survey-completed-${ string | number }` ]: string | undefined;

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -36,7 +36,7 @@ export interface UserPreferences {
 	[ key: `hosting-dashboard-wp-beta-notice-dismissed-${ number }` ]: string | undefined; // ISO timestamp when the user dismissed the beta notice for a site
 	'hosting-dashboard-welcome-notice-dismissed'?: string; // Timestamp when the user dismissed the notice
 	'account-recovery-interstitial-snoozed-until'?: number; // Unix timestamp (seconds) until which the account-recovery interstitial is snoozed; 0/unset means "never snoozed"
-	'account-recovery-interstitial-view-count'?: number; // How many times the user has been nudged by the account-recovery interstitial; capped so we stop after a few nudges
+	'account-recovery-interstitial-dismiss-count'?: number; // How many times the user has dismissed the account-recovery interstitial; capped so we stop nudging after a few dismissals
 	'reader-landing-page'?: ReaderLandingPage;
 	'sites-landing-page'?: SitesLandingPage;
 	[ key: `cancel-purchase-survey-completed-${ string | number }` ]: string | undefined;

--- a/packages/api-queries/src/me-preferences.ts
+++ b/packages/api-queries/src/me-preferences.ts
@@ -11,7 +11,7 @@ const defaultValues: Required< UserPreferences > = {
 	'hosting-dashboard-opt-in-welcome-modal-dismissed': '',
 	'hosting-dashboard-welcome-notice-dismissed': '',
 	'account-recovery-interstitial-snoozed-until': 0,
-	'account-recovery-interstitial-view-count': 0,
+	'account-recovery-interstitial-dismiss-count': 0,
 	'reader-landing-page': {
 		useReaderAsLandingPage: false,
 		updatedAt: 0,
@@ -35,7 +35,7 @@ const staticPreferenceStatIds: Record< string, string > = {
 	'hosting-dashboard-opt-in-welcome-modal-dismissed': 'optwelc',
 	'hosting-dashboard-welcome-notice-dismissed': 'welcome',
 	'account-recovery-interstitial-snoozed-until': 'acctrec',
-	'account-recovery-interstitial-view-count': 'acrview',
+	'account-recovery-interstitial-dismiss-count': 'acrdis',
 	'reader-landing-page': 'rdland',
 	'sites-landing-page': 'stland',
 	'achievements-visibility': 'achvis',

--- a/packages/api-queries/src/me-preferences.ts
+++ b/packages/api-queries/src/me-preferences.ts
@@ -11,6 +11,7 @@ const defaultValues: Required< UserPreferences > = {
 	'hosting-dashboard-opt-in-welcome-modal-dismissed': '',
 	'hosting-dashboard-welcome-notice-dismissed': '',
 	'account-recovery-interstitial-snoozed-until': 0,
+	'account-recovery-interstitial-view-count': 0,
 	'reader-landing-page': {
 		useReaderAsLandingPage: false,
 		updatedAt: 0,
@@ -34,6 +35,7 @@ const staticPreferenceStatIds: Record< string, string > = {
 	'hosting-dashboard-opt-in-welcome-modal-dismissed': 'optwelc',
 	'hosting-dashboard-welcome-notice-dismissed': 'welcome',
 	'account-recovery-interstitial-snoozed-until': 'acctrec',
+	'account-recovery-interstitial-view-count': 'acrview',
 	'reader-landing-page': 'rdland',
 	'sites-landing-page': 'stland',
 	'achievements-visibility': 'achvis',


### PR DESCRIPTION
## Proposed Changes

* Add a persisted `account-recovery-interstitial-view-count` user preference (default `0`) with its mutation stat ID.
* Increment the count on each dismissal of the account-recovery interstitial and stop showing it once the user has been nudged `3` times.
* Write the snooze timestamp and the view count in a single `/me/preferences` request, so the two writes cannot race on the server-side read-modify-write of the whole preferences blob.
* Cover the cap with unit tests (hidden at the cap, still shown below it, and the count bump on dismissal).

## Why are these changes being made?

<!-- -->
The interstitial previously re-appeared every time a snooze window elapsed (14–365 days by security level) with no lifetime limit, which added up to roughly 11 nudges over the course of the experiment. Data Science flagged that as too aggressive and recommended capping it. This limits the modal to at most 3 nudges per user so it stops becoming a recurring annoyance for people who keep snoozing without setting up recovery. This is a prerequisite for relaunching the modal.

## Testing Instructions

* Run `yarn test-client client/dashboard/app/account-recovery-interstitial/test/index.test.tsx` — all pass. These cover the 3-view cap end to end: shown below the cap, suppressed once it is reached, and the correct value written on the final allowed dismissal.
* As an otherwise-eligible user (no recovery method, not snoozed), dismiss the modal once and confirm in the Network tab that a single `POST /me/preferences` carries both `account-recovery-interstitial-snoozed-until` and `account-recovery-interstitial-view-count`, and that the follow-up `GET /me/preferences` echoes the incremented count.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
