### PR TITLE
A4A: fix secondary-button border and filter focus ring after @wordpress/components 37

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/style.scss
@@ -33,6 +33,8 @@
 	&:hover:not(:disabled) {
 		border: none;
 		box-shadow: none;
+		// 37.0.0 moved the focus ring from box-shadow to outline; suppress it too.
+		outline: none;
 	}
 
 	&:hover:not(:disabled) {

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -91,6 +91,14 @@
 		--wp-components-color-accent-darker-10: var(--color-primary-60);
 		--wp-components-color-accent-darker-20: var(--color-primary-60);
 	}
+
+	// A4A secondary buttons keep a subtle neutral border. 37.0.0's border-color is forced off
+	// by the Calypso override and reinstated as a box-shadow; restore the neutral border here
+	// and drop the box-shadow. Buttons with their own outline keep it (higher specificity).
+	:where(.components-button.is-secondary:not(.is-destructive)) {
+		border-color: var(--color-accent-5) !important;
+		box-shadow: none;
+	}
 }
 
 /* Gravatar & WP Job Manager */


### PR DESCRIPTION
> [!NOTE]
> Follow-up to #113009 — the secondary-button border fix only takes effect once #113009's override is in trunk, so merge together or after it. The focus-ring fix is independent.

## Proposed Changes

Two A4A fallouts from @wordpress/components 37 (bumped in #112947):

* **Secondary button border** — restore the neutral (`--color-accent-5`, `#dcdcde`) outline on A4A secondary buttons and drop the leaked box-shadow.
* **Product filter focus ring** — suppress the stray blue outline on the marketplace filter's auto-focused first menu item.

## Why are these changes being made?

**Secondary buttons.** 37 draws the secondary `Button` border with `border-color`. #113009 forces that off and reinstates the border as a box-shadow for Calypso's outlined buttons; the shared overrides also remap A4A's accent to blue, so the box-shadow shows as a stray blue outline. Left unhandled the button ends up with *no* border at all — but A4A secondary buttons (e.g. "Create a development site") are outline buttons and should keep their subtle neutral border. Restore it via `border-color` and drop the box-shadow. Buttons that draw their own outline (e.g. the reports CTA) keep it, as their selector outranks this one.

**Filter focus ring.** 37 moved the button focus ring from `box-shadow` to `outline`. The product filter's menu items clear `border`/`box-shadow` on focus but not `outline`, so the auto-focused first item now shows a blue ring that wasn't there before. Suppress the outline too, matching the existing intent.

## Testing Instructions

* With #113009 also applied, load A4A marketplace (hosting, products), plugins, and sites.
* Confirm secondary/outline buttons show a subtle neutral border again — not blue, not borderless.
* Confirm icon-only / borderless buttons and menu items stay borderless.
* Open the marketplace product filter; confirm the first submenu item no longer shows a blue focus ring.
* Confirm the reports overview CTA keeps its outline, and destructive secondary buttons keep their red border.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
