### PR TITLE
Posts: Add last draft query

### DIFF
--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -64,6 +64,7 @@ export * from './me-memberships';
 export * from './me-notification-devices';
 export * from './me-notification-settings';
 export * from './me-payment-methods';
+export * from './me-posts';
 export * from './me-preferences';
 export * from './me-settings';
 export * from './me-shopping-cart';

--- a/packages/api-core/src/me-posts/fetchers.ts
+++ b/packages/api-core/src/me-posts/fetchers.ts
@@ -1,0 +1,26 @@
+import { decodeEntities } from '@wordpress/html-entities';
+import { wpcom } from '../wpcom-fetcher';
+import type { UserLastDraft, UserLastDraftResponse } from './types';
+
+export async function fetchUserLastDraft( userId: number ): Promise< UserLastDraft | null > {
+	const response = ( await wpcom.req.get( '/me/posts', {
+		author: userId,
+		status: 'draft',
+		type: 'post',
+		order_by: 'modified',
+		order: 'DESC',
+		number: 1,
+		fields: 'ID,site_ID,title',
+	} ) ) as UserLastDraftResponse;
+	const post = response.posts?.[ 0 ];
+
+	if ( ! post?.ID || ! post.site_ID ) {
+		return null;
+	}
+
+	return {
+		id: post.ID,
+		siteId: post.site_ID,
+		title: decodeEntities( ( post.title ?? '' ).replace( /<[^>]*>/g, '' ) ).trim(),
+	};
+}

--- a/packages/api-core/src/me-posts/index.ts
+++ b/packages/api-core/src/me-posts/index.ts
@@ -1,0 +1,2 @@
+export * from './fetchers';
+export * from './types';

--- a/packages/api-core/src/me-posts/types.ts
+++ b/packages/api-core/src/me-posts/types.ts
@@ -1,0 +1,13 @@
+export interface UserLastDraft {
+	id: number;
+	siteId: number;
+	title: string;
+}
+
+export interface UserLastDraftResponse {
+	posts?: Array< {
+		ID?: number;
+		site_ID?: number;
+		title?: string;
+	} >;
+}

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -57,6 +57,7 @@ export * from './me-monetize';
 export * from './me-notifications-devices';
 export * from './me-notifications-settings';
 export * from './me-payment-methods';
+export * from './me-posts';
 export * from './me-preferences';
 export * from './me-settings';
 export * from './me-social-logins';

--- a/packages/api-queries/src/me-posts.ts
+++ b/packages/api-queries/src/me-posts.ts
@@ -1,0 +1,13 @@
+import { fetchUserLastDraft } from '@automattic/api-core';
+import { queryOptions } from '@tanstack/react-query';
+
+export const userLastDraftQuery = ( userId: number, enabled = true ) =>
+	queryOptions( {
+		queryKey: [ 'me', 'posts', 'last-draft', userId ],
+		queryFn: () => fetchUserLastDraft( userId ),
+		enabled: enabled && !! userId,
+		staleTime: Infinity,
+		retry: false,
+		refetchOnWindowFocus: false,
+		meta: { persist: false },
+	} );


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTCOM-18009

## Proposed Changes

Add a query to fetch the last draft the user worked on across all websites.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To support future experiments.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
