### PR TITLE
AI Launchpad: drop the client-side AI-onboarded exclusion, no_guidance coming-soon card

### DIFF
--- a/client/dashboard/sites/overview-visibility-card/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card/index.tsx
@@ -49,8 +49,14 @@ function VisibilityCardUnlaunched( { site }: { site: Site } ) {
 
 	const { data: launchpad } = useQuery( {
 		...siteLaunchpadQuery( site.ID, getLaunchpadChecklistSlug( site ) ),
-		enabled: ! isAiLaunchpad,
+		enabled: ! isAiLaunchpad && ! isNoGuidance,
 	} );
+
+	// The no_guidance launchpad-personalization variation gets no setup guidance at all:
+	// the card behaves like a plain coming-soon site, pointing at the visibility settings.
+	if ( isNoGuidance ) {
+		return <VisibilityCardComingSoon site={ site } />;
+	}
 
 	const tasks = ( isAiLaunchpad ? aiTasks : launchpad?.checklist ) ?? [];
 	const numberOfTasks = tasks.length;
@@ -58,18 +64,6 @@ function VisibilityCardUnlaunched( { site }: { site: Site } ) {
 	const isLaunchpadCompleted = completedTasks && completedTasks === numberOfTasks;
 
 	const setupLink = setupUrl ?? wpcomLink( `/home/${ site.slug }` );
-
-	// The no_guidance launchpad-personalization variation omits the progress circle entirely.
-	const progressProps = isNoGuidance
-		? {}
-		: {
-				progress: {
-					value: completedTasks,
-					max: numberOfTasks,
-					label: `${ completedTasks }/${ numberOfTasks }`,
-					...( isLaunchpadCompleted && { variant: 'success' as const } ),
-				},
-		  };
 
 	return (
 		<OverviewCard
@@ -85,7 +79,12 @@ function VisibilityCardUnlaunched( { site }: { site: Site } ) {
 						description: __( 'Finish setting up your site.' ),
 						externalLink: setupLink,
 				  } ) }
-			{ ...progressProps }
+			progress={ {
+				value: completedTasks,
+				max: numberOfTasks,
+				label: `${ completedTasks }/${ numberOfTasks }`,
+				...( isLaunchpadCompleted && { variant: 'success' as const } ),
+			} }
 		/>
 	);
 }

--- a/client/dashboard/sites/overview/test/index.test.tsx
+++ b/client/dashboard/sites/overview/test/index.test.tsx
@@ -243,7 +243,7 @@ describe( '<SiteOverview>', () => {
 		expect( await getCard( 'The perfect domain awaits' ) ).toBeVisible();
 	} );
 
-	test( 'hides the visibility progress bar for the no_guidance launchpad-personalization variation', async () => {
+	test( 'shows a plain coming-soon visibility card for the no_guidance launchpad-personalization variation', async () => {
 		assignPersonalizationVariation( 'no_guidance' );
 		mockSite( { ...site, launch_status: 'unlaunched' } as Site );
 		render( <SiteOverview siteSlug={ site.slug } /> );
@@ -251,10 +251,11 @@ describe( '<SiteOverview>', () => {
 		await screen.findByRole( 'heading', { name: 'Test Site' } );
 		await waitForFeatureGatedCards( 'Business' );
 
-		const card = await getCard( 'Finish setting up your site' );
+		const card = await getCard( 'Ready to go public?' );
 		await waitFor( () =>
 			expect( within( card ).queryByRole( 'progressbar' ) ).not.toBeInTheDocument()
 		);
+		expect( screen.queryByText( 'Finish setting up your site.' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'renders the overview of a commerce garden site', async () => {

--- a/packages/api-core/src/site-ai-launchpad/types.ts
+++ b/packages/api-core/src/site-ai-launchpad/types.ts
@@ -17,6 +17,4 @@ export interface AiLaunchpadSiteOptions {
 	wpcom_ai_launchpad_enabled?: boolean;
 	wpcom_ai_launchpad_dismissed?: boolean;
 	wpcom_ai_launchpad_completed?: boolean;
-	site_intent?: string;
-	site_creation_flow?: string;
 }

--- a/packages/api-core/src/site-ai-launchpad/utils.ts
+++ b/packages/api-core/src/site-ai-launchpad/utils.ts
@@ -2,10 +2,11 @@ import type { AiLaunchpadSiteOptions, AiLaunchpadStatus } from './types';
 
 /**
  * Derives the AI Launchpad state from site options, mirroring the server-side
- * eligibility gate (`AI_Launchpad::is_eligible()` in jetpack-mu-wpcom): enabled,
- * not dismissed, and not already onboarded through an AI flow. Keep the two in
- * sync when the server gate changes. Only administrators get the AI Launchpad,
- * matching the wp-admin menu swap.
+ * eligibility gate (`AI_Launchpad::is_eligible()` in jetpack-mu-wpcom): enabled
+ * and not dismissed. AI-built (Big Sky) sites are eligible like any other — the
+ * tasklist tailors to what the build already covered. Keep the two in sync when
+ * the server gate changes. Only administrators get the AI Launchpad, matching
+ * the wp-admin menu swap.
  *
  * - `'active'`: the AI Launchpad replaces My Home and the legacy launchpad.
  * - `'completed'`: every task is done; setup surfaces should be hidden.
@@ -21,13 +22,6 @@ export function getAiLaunchpadStatus( site: {
 
 	const options = site.options;
 	if ( ! options?.wpcom_ai_launchpad_enabled || options.wpcom_ai_launchpad_dismissed ) {
-		return null;
-	}
-
-	if (
-		options.site_intent === 'ai-assembler' ||
-		options.site_creation_flow === 'ai-site-builder'
-	) {
 		return null;
 	}
 


### PR DESCRIPTION
Part of DOTOBRD-567. Follow-up to #112953 / #112569.

## Proposed Changes

Field testing the launchpad-personalization experiment surfaced two Calypso-side gaps:

* **Drop the client-side AI-onboarded exclusion** from `getAiLaunchpadStatus` (`packages/api-core`). When Automattic/jetpack#50830 dropped the `was_ai_onboarded()` exclusion server-side, this client mirror from #112569 survived — so a Big Sky-built site with `wpcom_ai_launchpad_enabled` set still returned `null`, bringing back My Home (the `/home` redirect stopped firing) and legacy MSD UX. The now-unused `site_intent` / `site_creation_flow` fields are removed from `AiLaunchpadSiteOptions`.
* **MSD visibility card for `no_guidance`**: #112953 only removed the progress circle, leaving the card a full "Finish setting up your site." affordance (and incidentally surfacing the external-link glyph). The card now renders the plain coming-soon variant (heading "Coming soon", "Ready to go public?", visibility-settings link) for `no_guidance`, and skips the legacy launchpad checklist fetch entirely.

Companion Jetpack PR for the remaining `no_guidance` gaps (wp-admin Dashboard widget, My Home menu / Calypso sidebar, which is server-driven via the admin-menu endpoint): Automattic/jetpack#50837

## Why are these changes being made?

The `no_guidance` variation promises no launchpad guidance at all, and `ai_launchpad` sites built with Big Sky must keep their AI Launchpad — both held server-side but broke on Calypso surfaces. See the field-test findings in DOTOBRD-567.

## Testing Instructions

* `ai_launchpad` + Big Sky: create a site through onboarding (variation assigned at creation), pick "Build with AI" at the post-checkout chooser, complete the Big Sky build. `/home/:site` should redirect to wp-admin Site Setup and MSD should show the AI launchpad UX (previously both reverted to legacy).
* `no_guidance`: on an unlaunched site, the MSD overview Visibility card shows "Coming soon / Ready to go public?" linking to visibility settings — no "Finish setting up your site." link, no progress circle, and no launchpad checklist request in the network tab.
* `control`: unchanged — setup card with progress circle.
* `yarn test-client` for the touched suites (217 passing) and `yarn typecheck-client`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation? (no new strings)
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
