### PR TITLE
A4A Overview: Square off the "Next steps" checklist item corners

### DIFF
--- a/client/a8c-for-agencies/sections/overview/body/next-steps/style.scss
+++ b/client/a8c-for-agencies/sections/overview/body/next-steps/style.scss
@@ -45,6 +45,7 @@
 	.checklist-item__task {
 
 		.checklist-item__task-content {
+			border-radius: 0;
 			padding-inline: 16px;
 		}
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/A4A-3049/next-steps-checklist-corners-not-rounded-border-radius

## What & why

On the A4A **Agency Overview → "Next steps"** checklist card, the individual checklist items had slightly rounded corners. The rounding was accidental — the item content inherited a `border-radius` it was never meant to have — and the items should read as square within the card.

This sets `border-radius: 0` on `.checklist-item__task-content` in the Next-steps stylesheet. The card's own intentional 4px radius is untouched; only the inner item corners are squared off.

## Testing Instructions

1. Run the A4A dashboard (`yarn start-a8c-for-agencies`) and open **Agency Overview**.
2. Look at the **"Next steps"** checklist card.
3. Verify the checklist items have square corners, and the card itself keeps its rounded corners.

## Notes

- CSS-only, single declaration — no tests added.
