### PR TITLE
Sites: Add the returning user modal and experiment

### DIFF
--- a/client/components/resurrected-welcome-modal/index.tsx
+++ b/client/components/resurrected-welcome-modal/index.tsx
@@ -97,9 +97,7 @@ export const ResurrectedWelcomeModalGate = ( {
 				cta_id: cta.id,
 			} );
 
-			if ( cta.isDismissOnly ) {
-				persistDismissal( 'cta' );
-			}
+			persistDismissal( 'cta' );
 		},
 		[ variationName, persistDismissal ]
 	);

--- a/client/components/resurrected-welcome-modal/test/index.test.tsx
+++ b/client/components/resurrected-welcome-modal/test/index.test.tsx
@@ -35,6 +35,7 @@ jest.mock( 'calypso/lib/resurrected-users', () => ( {
 const contentEligibility = {
 	isLoading: false,
 	isResurrectedSixMonths: true,
+	isResurrectedThreeMonths: true,
 	hasActivePaidSubscription: false,
 	isEligible: true,
 	variationName: WELCOME_BACK_VARIATIONS.content,

--- a/client/components/resurrected-welcome-modal/test/index.test.tsx
+++ b/client/components/resurrected-welcome-modal/test/index.test.tsx
@@ -178,7 +178,7 @@ describe( 'ResurrectedWelcomeModalGate content variation', () => {
 			'calypso_resurrected_welcome_modal_cta_click',
 			{
 				variation: WELCOME_BACK_VARIATIONS.content,
-				cta_id: 'content-new',
+				cta_id: 'write-post',
 			}
 		);
 		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();

--- a/client/components/resurrected-welcome-modal/test/index.test.tsx
+++ b/client/components/resurrected-welcome-modal/test/index.test.tsx
@@ -156,4 +156,31 @@ describe( 'ResurrectedWelcomeModalGate content variation', () => {
 			expect.anything()
 		);
 	} );
+
+	it( 'dismisses the modal when a navigation CTA is clicked', async () => {
+		mockUseResurrectedFreeUserEligibility.mockReturnValue( {
+			...contentEligibility,
+			isForcedVariation: false,
+		} );
+		mockUseLastDraftQuery.mockReturnValue( { data: null, isPending: false } );
+		const user = userEvent.setup();
+
+		renderWithProvider( <ResurrectedWelcomeModalGate /> );
+		const cta = screen.getByRole( 'link', { name: 'Write your next post' } );
+		cta.addEventListener( 'click', ( event ) => event.preventDefault() );
+
+		await user.click( cta );
+
+		expect( window.sessionStorage.getItem( 'wpcom_resurrected_welcome_modal_dismissed' ) ).toBe(
+			'true'
+		);
+		expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_resurrected_welcome_modal_cta_click',
+			{
+				variation: WELCOME_BACK_VARIATIONS.content,
+				cta_id: 'content-new',
+			}
+		);
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -62,6 +62,7 @@ module.exports = {
 							'!@automattic/components/src/breadcrumbs',
 							'!@automattic/components/src/breadcrumbs/types',
 							'!@automattic/components/src/logos',
+							'!@automattic/components/src/resurrected-welcome-modal',
 							'!@automattic/date-range-picker',
 							'!@automattic/domain-search',
 							'!@automattic/domains-table',

--- a/client/dashboard/app-a4a/index.tsx
+++ b/client/dashboard/app-a4a/index.tsx
@@ -39,6 +39,7 @@ boot( {
 		reader: false,
 		help: true,
 		notifications: false,
+		resurrectedWelcomeModal: false,
 		me: false,
 		plugins: false,
 		commandPalette: false,

--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -34,6 +34,7 @@ boot( {
 		reader: false,
 		help: true,
 		notifications: false,
+		resurrectedWelcomeModal: false,
 		me: {
 			billing: {
 				monetizeSubscriptions: false,

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -31,6 +31,7 @@ boot( {
 		reader: true,
 		help: true,
 		notifications: true,
+		resurrectedWelcomeModal: true,
 		me: {
 			billing: {
 				monetizeSubscriptions: true,

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -64,6 +64,7 @@ export type AppConfig = {
 		reader: boolean;
 		help: boolean;
 		notifications: boolean;
+		resurrectedWelcomeModal: boolean;
 		me: MeSupports | false;
 		commandPalette: boolean;
 		domainOnlySites: boolean;
@@ -111,6 +112,7 @@ export const APP_CONTEXT_DEFAULT_CONFIG: AppConfig = {
 		reader: false,
 		help: false,
 		notifications: false,
+		resurrectedWelcomeModal: false,
 		me: false,
 		commandPalette: false,
 		domainOnlySites: false,

--- a/client/dashboard/app/resurrected-welcome-modal/constants.ts
+++ b/client/dashboard/app/resurrected-welcome-modal/constants.ts
@@ -1,0 +1,13 @@
+export const RESURRECTION_DAY_LIMIT_EXPERIMENT = 180;
+export const RESURRECTION_DAY_LIMIT_3M = 90;
+
+export const RESURRECTED_EVENT_6M = 'calypso_user_resurrected_6m';
+export const RESURRECTED_EVENT_3M = 'calypso_user_resurrected_3m';
+export const RESURRECTED_FREE_USERS_EXPERIMENT =
+	'calypso_resurrected_users_welcome_back_modal_202607';
+
+export const WELCOME_BACK_VARIATION_MANUAL = 'treatment_manual_dual';
+
+export const WELCOME_BACK_MODAL_FORCE_FLAG = 'welcome-back-modal-manual';
+
+export const WELCOME_BACK_90_DAY_ELIGIBILITY_FLAG = 'resurrected-users/90-day-eligibility';

--- a/client/dashboard/app/resurrected-welcome-modal/index.tsx
+++ b/client/dashboard/app/resurrected-welcome-modal/index.tsx
@@ -1,0 +1,176 @@
+import { userLastDraftQuery } from '@automattic/api-queries';
+import ResurrectedWelcomeModal, {
+	WELCOME_BACK_VARIATIONS,
+	type ResurrectedWelcomeModalCta,
+} from '@automattic/components/src/resurrected-welcome-modal';
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { wpcomLink } from '../../utils/link';
+import { useAnalytics } from '../analytics';
+import { useAuth } from '../auth';
+import {
+	RESURRECTED_EVENT_3M,
+	RESURRECTED_EVENT_6M,
+	RESURRECTION_DAY_LIMIT_3M,
+	RESURRECTION_DAY_LIMIT_EXPERIMENT,
+} from './constants';
+import { useResurrectedFreeUserEligibility } from './use-resurrected-free-user-eligibility';
+
+const SESSION_STORAGE_KEY = 'wpcom_resurrected_welcome_modal_dismissed';
+
+function getInitialDismissState() {
+	if ( typeof window === 'undefined' ) {
+		return false;
+	}
+
+	return window.sessionStorage.getItem( SESSION_STORAGE_KEY ) === 'true';
+}
+
+interface Props {
+	isSuppressed?: boolean;
+	onEligibilityResolved?: ( willDisplay: boolean ) => void;
+	onVisibilityChange?: ( isVisible: boolean ) => void;
+}
+
+export function ResurrectedWelcomeModalGate( {
+	isSuppressed = false,
+	onEligibilityResolved,
+	onVisibilityChange,
+}: Props ) {
+	const { recordTracksEvent } = useAnalytics();
+	const { user } = useAuth();
+	const eligibility = useResurrectedFreeUserEligibility();
+	const [ hasDismissedForSession, setHasDismissedForSession ] = useState( () =>
+		eligibility.isForcedVariation ? false : getInitialDismissState()
+	);
+	const [ hasTrackedImpression, setHasTrackedImpression ] = useState( false );
+	const hasTrackedResurrectionRef = useRef( false );
+	const previousVisibilityRef = useRef( false );
+
+	const variationName = eligibility.variationName;
+	const isContentVariation =
+		eligibility.isEligible && variationName === WELCOME_BACK_VARIATIONS.content;
+	const lastDraftQuery = useQuery(
+		userLastDraftQuery( user.ID, isContentVariation && ! hasDismissedForSession && ! isSuppressed )
+	);
+	const willDisplay =
+		! eligibility.isLoading &&
+		eligibility.isEligible &&
+		! hasDismissedForSession &&
+		!! variationName;
+	const shouldDisplay = willDisplay && ! isSuppressed;
+
+	useEffect( () => {
+		if ( eligibility.isForcedVariation ) {
+			setHasDismissedForSession( false );
+		}
+	}, [ eligibility.isForcedVariation ] );
+
+	useEffect( () => {
+		if (
+			eligibility.isLoading ||
+			eligibility.lastSeen === null ||
+			hasTrackedResurrectionRef.current
+		) {
+			return;
+		}
+
+		hasTrackedResurrectionRef.current = true;
+
+		if ( eligibility.isResurrectedSixMonths ) {
+			recordTracksEvent( RESURRECTED_EVENT_6M, {
+				last_seen: eligibility.lastSeen,
+				day_limit: RESURRECTION_DAY_LIMIT_EXPERIMENT,
+			} );
+		}
+
+		if ( eligibility.isResurrectedThreeMonths ) {
+			recordTracksEvent( RESURRECTED_EVENT_3M, {
+				last_seen: eligibility.lastSeen,
+				day_limit: RESURRECTION_DAY_LIMIT_3M,
+			} );
+		}
+	}, [
+		eligibility.isLoading,
+		eligibility.isResurrectedSixMonths,
+		eligibility.isResurrectedThreeMonths,
+		eligibility.lastSeen,
+		recordTracksEvent,
+	] );
+
+	useEffect( () => {
+		if ( ! eligibility.isLoading ) {
+			onEligibilityResolved?.( willDisplay );
+		}
+	}, [ eligibility.isLoading, onEligibilityResolved, willDisplay ] );
+
+	useEffect( () => {
+		if ( previousVisibilityRef.current !== shouldDisplay ) {
+			previousVisibilityRef.current = shouldDisplay;
+			onVisibilityChange?.( shouldDisplay );
+		}
+	}, [ shouldDisplay, onVisibilityChange ] );
+
+	useEffect( () => {
+		if ( ! shouldDisplay || hasTrackedImpression || ! variationName ) {
+			return;
+		}
+
+		recordTracksEvent( 'calypso_resurrected_welcome_modal_impression', {
+			variation: variationName,
+		} );
+		setHasTrackedImpression( true );
+	}, [ shouldDisplay, variationName, hasTrackedImpression, recordTracksEvent ] );
+
+	const persistDismissal = useCallback(
+		( source: 'cta' | 'close' = 'cta' ) => {
+			setHasDismissedForSession( true );
+			if ( typeof window !== 'undefined' && ! eligibility.isForcedVariation ) {
+				window.sessionStorage.setItem( SESSION_STORAGE_KEY, 'true' );
+			}
+			if ( source === 'close' ) {
+				recordTracksEvent( 'calypso_resurrected_welcome_modal_dismiss', {
+					variation: variationName || 'unknown',
+					source,
+				} );
+			}
+		},
+		[ eligibility.isForcedVariation, recordTracksEvent, variationName ]
+	);
+
+	const handleCta = useCallback(
+		( cta: ResurrectedWelcomeModalCta ) => {
+			if ( ! variationName ) {
+				return;
+			}
+
+			recordTracksEvent( 'calypso_resurrected_welcome_modal_cta_click', {
+				variation: variationName,
+				cta_id: cta.id,
+			} );
+
+			if ( cta.isDismissOnly ) {
+				persistDismissal( 'cta' );
+			}
+		},
+		[ persistDismissal, recordTracksEvent, variationName ]
+	);
+
+	if ( ! shouldDisplay || ! variationName ) {
+		return null;
+	}
+
+	return (
+		<ResurrectedWelcomeModal
+			variationName={ variationName }
+			lastDraft={ lastDraftQuery.data }
+			isLastDraftLoading={ isContentVariation && lastDraftQuery.isPending }
+			resolveHref={ wpcomLink }
+			onClose={ () => persistDismissal( 'close' ) }
+			onCtaClick={ handleCta }
+		/>
+	);
+}
+
+export { useResurrectedFreeUserEligibility } from './use-resurrected-free-user-eligibility';
+export type { EligibilityResult } from './use-resurrected-free-user-eligibility';

--- a/client/dashboard/app/resurrected-welcome-modal/index.tsx
+++ b/client/dashboard/app/resurrected-welcome-modal/index.tsx
@@ -149,9 +149,7 @@ export function ResurrectedWelcomeModalGate( {
 				cta_id: cta.id,
 			} );
 
-			if ( cta.isDismissOnly ) {
-				persistDismissal( 'cta' );
-			}
+			persistDismissal( 'cta' );
 		},
 		[ persistDismissal, recordTracksEvent, variationName ]
 	);

--- a/client/dashboard/app/resurrected-welcome-modal/test/index.test.tsx
+++ b/client/dashboard/app/resurrected-welcome-modal/test/index.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options { "url": "https://my.localhost/" }
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { ResurrectedWelcomeModalGate } from '..';
+import { render } from '../../../test-utils';
+import {
+	RESURRECTED_EVENT_3M,
+	RESURRECTED_EVENT_6M,
+	RESURRECTION_DAY_LIMIT_3M,
+	RESURRECTION_DAY_LIMIT_EXPERIMENT,
+} from '../constants';
+import { useResurrectedFreeUserEligibility } from '../use-resurrected-free-user-eligibility';
+
+jest.mock( '../use-resurrected-free-user-eligibility' );
+
+const mockUseEligibility = jest.mocked( useResurrectedFreeUserEligibility );
+const eligibleUser = {
+	isLoading: false,
+	lastSeen: 1721600000,
+	isResurrectedSixMonths: true,
+	isResurrectedThreeMonths: true,
+	hasActivePaidSubscription: false,
+	isEligible: true,
+	variationName: 'treatment_content',
+	isForcedVariation: false,
+};
+
+describe( 'ResurrectedWelcomeModalGate', () => {
+	beforeEach( () => {
+		window.sessionStorage.clear();
+		mockUseEligibility.mockReturnValue( eligibleUser );
+	} );
+
+	test( 'shows the shared content modal with the latest draft', async () => {
+		const draftRequest = nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/posts' )
+			.query( true )
+			.reply( 200, {
+				posts: [
+					{
+						ID: 45,
+						site_ID: 67,
+						title: '<strong>My &amp; Draft</strong>',
+					},
+				],
+			} );
+		const onEligibilityResolved = jest.fn();
+		const { recordTracksEvent } = render(
+			<ResurrectedWelcomeModalGate onEligibilityResolved={ onEligibilityResolved } />
+		);
+
+		const draftCta = await screen.findByRole( 'link', {
+			name: 'Finish Draft: "My & Draft"',
+		} );
+
+		expect( draftCta.getAttribute( 'href' ) ).toContain( '/post/67/45' );
+		expect( draftRequest.isDone() ).toBe( true );
+		expect( onEligibilityResolved ).toHaveBeenCalledWith( true );
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_resurrected_welcome_modal_impression',
+			{ variation: 'treatment_content' }
+		);
+		expect( recordTracksEvent ).toHaveBeenCalledWith( RESURRECTED_EVENT_6M, {
+			last_seen: eligibleUser.lastSeen,
+			day_limit: RESURRECTION_DAY_LIMIT_EXPERIMENT,
+		} );
+		expect( recordTracksEvent ).toHaveBeenCalledWith( RESURRECTED_EVENT_3M, {
+			last_seen: eligibleUser.lastSeen,
+			day_limit: RESURRECTION_DAY_LIMIT_3M,
+		} );
+	} );
+
+	test( 'allows lower-priority modals when the user is ineligible', async () => {
+		mockUseEligibility.mockReturnValue( {
+			...eligibleUser,
+			isEligible: false,
+			variationName: 'treatment_manual_dual',
+		} );
+		const onEligibilityResolved = jest.fn();
+
+		render( <ResurrectedWelcomeModalGate onEligibilityResolved={ onEligibilityResolved } /> );
+
+		await waitFor( () => expect( onEligibilityResolved ).toHaveBeenCalledWith( false ) );
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'tracks a three-month resurrection independently of the six-month event', async () => {
+		mockUseEligibility.mockReturnValue( {
+			...eligibleUser,
+			isResurrectedSixMonths: false,
+			isEligible: false,
+		} );
+
+		const { recordTracksEvent } = render( <ResurrectedWelcomeModalGate /> );
+
+		await waitFor( () =>
+			expect( recordTracksEvent ).toHaveBeenCalledWith( RESURRECTED_EVENT_3M, {
+				last_seen: eligibleUser.lastSeen,
+				day_limit: RESURRECTION_DAY_LIMIT_3M,
+			} )
+		);
+		expect( recordTracksEvent ).not.toHaveBeenCalledWith( RESURRECTED_EVENT_6M, expect.anything() );
+	} );
+
+	test( 'allows lower-priority modals when dismissed earlier in the session', async () => {
+		window.sessionStorage.setItem( 'wpcom_resurrected_welcome_modal_dismissed', 'true' );
+		const onEligibilityResolved = jest.fn();
+
+		render( <ResurrectedWelcomeModalGate onEligibilityResolved={ onEligibilityResolved } /> );
+
+		await waitFor( () => expect( onEligibilityResolved ).toHaveBeenCalledWith( false ) );
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'persists and tracks a close', async () => {
+		mockUseEligibility.mockReturnValue( {
+			...eligibleUser,
+			variationName: 'treatment_manual_dual',
+		} );
+		const user = userEvent.setup();
+		const { recordTracksEvent } = render( <ResurrectedWelcomeModalGate /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Close welcome back modal' } ) );
+
+		expect( window.sessionStorage.getItem( 'wpcom_resurrected_welcome_modal_dismissed' ) ).toBe(
+			'true'
+		);
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_resurrected_welcome_modal_dismiss', {
+			variation: 'treatment_manual_dual',
+			source: 'close',
+		} );
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/app/resurrected-welcome-modal/test/index.test.tsx
+++ b/client/dashboard/app/resurrected-welcome-modal/test/index.test.tsx
@@ -136,4 +136,29 @@ describe( 'ResurrectedWelcomeModalGate', () => {
 		} );
 		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
 	} );
+
+	test( 'dismisses the modal when a navigation CTA is clicked', async () => {
+		mockUseEligibility.mockReturnValue( {
+			...eligibleUser,
+			variationName: 'treatment_manual_dual',
+		} );
+		const user = userEvent.setup();
+		const { recordTracksEvent } = render( <ResurrectedWelcomeModalGate /> );
+		const cta = screen.getByRole( 'link', { name: 'Create a new site' } );
+		cta.addEventListener( 'click', ( event ) => event.preventDefault() );
+
+		await user.click( cta );
+
+		expect( window.sessionStorage.getItem( 'wpcom_resurrected_welcome_modal_dismissed' ) ).toBe(
+			'true'
+		);
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_resurrected_welcome_modal_cta_click',
+			{
+				variation: 'treatment_manual_dual',
+				cta_id: 'manual-new',
+			}
+		);
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/client/dashboard/app/resurrected-welcome-modal/test/use-resurrected-free-user-eligibility.test.tsx
+++ b/client/dashboard/app/resurrected-welcome-modal/test/use-resurrected-free-user-eligibility.test.tsx
@@ -1,0 +1,282 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options { "url": "https://my.localhost/" }
+ */
+
+import { disable, enable } from '@automattic/calypso-config';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { useExperiment } from 'calypso/lib/explat';
+import {
+	RESURRECTED_FREE_USERS_EXPERIMENT,
+	WELCOME_BACK_90_DAY_ELIGIBILITY_FLAG,
+	WELCOME_BACK_MODAL_FORCE_FLAG,
+	WELCOME_BACK_VARIATION_MANUAL,
+} from '../constants';
+import { useResurrectedFreeUserEligibility } from '../use-resurrected-free-user-eligibility';
+import type { ReactNode } from 'react';
+
+jest.mock( 'calypso/lib/explat', () => ( {
+	useExperiment: jest.fn(),
+} ) );
+
+const mockUseExperiment = jest.mocked( useExperiment );
+const DAY_IN_SECONDS = 24 * 60 * 60;
+
+function timestampDaysAgo( days: number ): number {
+	return Math.floor( Date.now() / 1000 ) - days * DAY_IN_SECONDS;
+}
+
+function mockUserSettings( lastAdminActivityTimestamp: number | string ) {
+	return nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.1/me/settings' )
+		.query( true )
+		.reply( 200, {
+			last_admin_activity_timestamp: lastAdminActivityTimestamp,
+		} );
+}
+
+function mockPurchases( purchases: object[] = [] ) {
+	return nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.2/upgrades' )
+		.query( true )
+		.reply( 200, purchases );
+}
+
+function makePurchase( {
+	expiryStatus,
+	isDomainRegistration = false,
+}: {
+	expiryStatus: string;
+	isDomainRegistration?: boolean;
+} ) {
+	return {
+		ID: 1,
+		ownership_id: 1,
+		product_id: 1,
+		blog_id: 1,
+		user_id: 1,
+		is_domain: isDomainRegistration,
+		is_domain_registration: isDomainRegistration,
+		expiry_status: expiryStatus,
+	};
+}
+
+function createExperimentAssignment( variationName: string ) {
+	return {
+		experimentName: RESURRECTED_FREE_USERS_EXPERIMENT,
+		variationName,
+		retrievedTimestamp: Date.now(),
+		ttl: 60,
+	};
+}
+
+function renderEligibilityHook() {
+	const queryClient = new QueryClient( {
+		defaultOptions: {
+			queries: {
+				retry: false,
+			},
+		},
+	} );
+	const wrapper = ( { children }: { children: ReactNode } ) => (
+		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+	);
+
+	return renderHook( () => useResurrectedFreeUserEligibility(), { wrapper } );
+}
+
+describe( 'useResurrectedFreeUserEligibility', () => {
+	beforeEach( () => {
+		disable( WELCOME_BACK_90_DAY_ELIGIBILITY_FLAG );
+		disable( WELCOME_BACK_MODAL_FORCE_FLAG );
+		mockUseExperiment.mockReturnValue( [ false, null ] );
+	} );
+
+	afterEach( () => {
+		disable( WELCOME_BACK_90_DAY_ELIGIBILITY_FLAG );
+		disable( WELCOME_BACK_MODAL_FORCE_FLAG );
+		jest.clearAllMocks();
+	} );
+
+	test( 'returns an assigned variation for an eligible resurrected user', async () => {
+		const lastSeen = timestampDaysAgo( 200 );
+		mockUserSettings( lastSeen );
+		mockPurchases();
+		mockUseExperiment.mockReturnValue( [
+			false,
+			createExperimentAssignment( 'treatment_content' ),
+		] );
+
+		const { result } = renderEligibilityHook();
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+
+		expect( result.current ).toEqual( {
+			isLoading: false,
+			lastSeen,
+			isResurrectedSixMonths: true,
+			isResurrectedThreeMonths: true,
+			hasActivePaidSubscription: false,
+			isEligible: true,
+			variationName: 'treatment_content',
+			isForcedVariation: false,
+		} );
+		expect( mockUseExperiment ).toHaveBeenLastCalledWith( RESURRECTED_FREE_USERS_EXPERIMENT, {
+			isEligible: true,
+		} );
+	} );
+
+	test( 'accepts a numeric-string activity timestamp', async () => {
+		mockUserSettings( String( timestampDaysAgo( 200 ) ) );
+		mockPurchases();
+
+		const { result } = renderEligibilityHook();
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+
+		expect( result.current.isResurrectedSixMonths ).toBe( true );
+		expect( result.current.isResurrectedThreeMonths ).toBe( true );
+		expect( result.current.isEligible ).toBe( true );
+		expect( result.current.variationName ).toBe( WELCOME_BACK_VARIATION_MANUAL );
+	} );
+
+	test( 'does not assign a recent user to the experiment', async () => {
+		mockUserSettings( timestampDaysAgo( 30 ) );
+		mockPurchases();
+
+		const { result } = renderEligibilityHook();
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+
+		expect( result.current.isResurrectedSixMonths ).toBe( false );
+		expect( result.current.isResurrectedThreeMonths ).toBe( false );
+		expect( result.current.isEligible ).toBe( false );
+		expect( mockUseExperiment ).toHaveBeenLastCalledWith( RESURRECTED_FREE_USERS_EXPERIMENT, {
+			isEligible: false,
+		} );
+	} );
+
+	test( 'does not assign a user with an invalid activity timestamp', async () => {
+		mockUserSettings( 'invalid' );
+		mockPurchases();
+
+		const { result } = renderEligibilityHook();
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+
+		expect( result.current.isResurrectedSixMonths ).toBe( false );
+		expect( result.current.isResurrectedThreeMonths ).toBe( false );
+		expect( result.current.isEligible ).toBe( false );
+	} );
+
+	test.each( [ 'active', 'auto-renewing' ] )(
+		'does not assign a user with an %s subscription',
+		async ( expiryStatus ) => {
+			mockUserSettings( timestampDaysAgo( 200 ) );
+			mockPurchases( [ makePurchase( { expiryStatus } ) ] );
+
+			const { result } = renderEligibilityHook();
+
+			await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+
+			expect( result.current.hasActivePaidSubscription ).toBe( true );
+			expect( result.current.isEligible ).toBe( false );
+		}
+	);
+
+	test( 'ignores renewing domain registrations', async () => {
+		mockUserSettings( timestampDaysAgo( 200 ) );
+		mockPurchases( [
+			makePurchase( {
+				expiryStatus: 'active',
+				isDomainRegistration: true,
+			} ),
+		] );
+
+		const { result } = renderEligibilityHook();
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+
+		expect( result.current.hasActivePaidSubscription ).toBe( false );
+		expect( result.current.isEligible ).toBe( true );
+	} );
+
+	test( 'waits for the experiment assignment when base eligibility is met', async () => {
+		mockUserSettings( timestampDaysAgo( 200 ) );
+		mockPurchases();
+		mockUseExperiment.mockReturnValue( [ true, null ] );
+
+		const { result } = renderEligibilityHook();
+
+		await waitFor( () => {
+			expect( result.current.isResurrectedSixMonths ).toBe( true );
+			expect( result.current.isResurrectedThreeMonths ).toBe( true );
+			expect( result.current.hasActivePaidSubscription ).toBe( false );
+		} );
+
+		expect( result.current.isLoading ).toBe( true );
+		expect( result.current.isEligible ).toBe( false );
+	} );
+
+	test( 'fails closed when eligibility data cannot be loaded', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/settings' )
+			.query( true )
+			.reply( 500 );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/upgrades' )
+			.query( true )
+			.reply( 500 );
+
+		const { result } = renderEligibilityHook();
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+
+		expect( result.current.isEligible ).toBe( false );
+		expect( result.current.hasActivePaidSubscription ).toBeNull();
+	} );
+
+	test( 'forces eligibility with the local development flag', async () => {
+		enable( WELCOME_BACK_MODAL_FORCE_FLAG );
+		mockUserSettings( timestampDaysAgo( 30 ) );
+		mockPurchases( [ makePurchase( { expiryStatus: 'active' } ) ] );
+
+		const { result } = renderEligibilityHook();
+
+		await waitFor( () => expect( result.current.hasActivePaidSubscription ).toBe( true ) );
+
+		expect( result.current.isLoading ).toBe( false );
+		expect( result.current.isEligible ).toBe( true );
+		expect( result.current.variationName ).toBe( WELCOME_BACK_VARIATION_MANUAL );
+		expect( result.current.isForcedVariation ).toBe( true );
+	} );
+
+	test( 'uses the 180-day threshold when 90-day eligibility is disabled', async () => {
+		mockUserSettings( timestampDaysAgo( 100 ) );
+		mockPurchases();
+
+		const { result } = renderEligibilityHook();
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+
+		expect( result.current.isResurrectedSixMonths ).toBe( false );
+		expect( result.current.isResurrectedThreeMonths ).toBe( true );
+		expect( result.current.isEligible ).toBe( false );
+	} );
+
+	test( 'uses the 90-day threshold when 90-day eligibility is enabled', async () => {
+		enable( WELCOME_BACK_90_DAY_ELIGIBILITY_FLAG );
+		mockUserSettings( timestampDaysAgo( 100 ) );
+		mockPurchases();
+
+		const { result } = renderEligibilityHook();
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+
+		expect( result.current.isResurrectedSixMonths ).toBe( false );
+		expect( result.current.isResurrectedThreeMonths ).toBe( true );
+		expect( result.current.isEligible ).toBe( true );
+	} );
+} );

--- a/client/dashboard/app/resurrected-welcome-modal/use-resurrected-free-user-eligibility.ts
+++ b/client/dashboard/app/resurrected-welcome-modal/use-resurrected-free-user-eligibility.ts
@@ -1,0 +1,118 @@
+import { userPurchasesQuery, userSettingsQuery } from '@automattic/api-queries';
+import config from '@automattic/calypso-config';
+import { useQuery } from '@tanstack/react-query';
+import { useExperiment } from 'calypso/lib/explat';
+import {
+	RESURRECTED_FREE_USERS_EXPERIMENT,
+	RESURRECTION_DAY_LIMIT_3M,
+	RESURRECTION_DAY_LIMIT_EXPERIMENT,
+	WELCOME_BACK_90_DAY_ELIGIBILITY_FLAG,
+	WELCOME_BACK_MODAL_FORCE_FLAG,
+	WELCOME_BACK_VARIATION_MANUAL,
+} from './constants';
+import type { Purchase } from '@automattic/api-core';
+
+const SECONDS_PER_DAY = 24 * 60 * 60;
+
+export interface EligibilityResult {
+	isLoading: boolean;
+	lastSeen: number | null;
+	isResurrectedSixMonths: boolean;
+	isResurrectedThreeMonths: boolean;
+	hasActivePaidSubscription: boolean | null;
+	isEligible: boolean;
+	variationName: string;
+	isForcedVariation: boolean;
+}
+
+function normalizeLastSeen( lastSeen: number | string | undefined ): number | null {
+	const numericLastSeen = Number( lastSeen );
+
+	if ( ! Number.isFinite( numericLastSeen ) ) {
+		return null;
+	}
+
+	return numericLastSeen;
+}
+
+function hasExceededDormancyThreshold( lastSeen: number | null, dayLimit: number ): boolean {
+	if ( lastSeen === null ) {
+		return false;
+	}
+
+	const threshold = Math.floor( Date.now() / 1000 ) - dayLimit * SECONDS_PER_DAY;
+
+	return lastSeen < threshold;
+}
+
+function hasActivePaidSubscription( purchases: Purchase[] | undefined ): boolean | null {
+	if ( ! purchases ) {
+		return null;
+	}
+
+	return purchases.some(
+		( purchase ) =>
+			! purchase.is_domain_registration &&
+			purchase.expiry_status !== 'one-time-purchase' &&
+			[ 'active', 'auto-renewing' ].includes( purchase.expiry_status )
+	);
+}
+
+export function useResurrectedFreeUserEligibility(): EligibilityResult {
+	const userSettingsQueryResult = useQuery( userSettingsQuery() );
+	const userPurchasesQueryResult = useQuery( userPurchasesQuery() );
+
+	const lastSeen = normalizeLastSeen( userSettingsQueryResult.data?.last_admin_activity_timestamp );
+	const isResurrectedSixMonths = hasExceededDormancyThreshold(
+		lastSeen,
+		RESURRECTION_DAY_LIMIT_EXPERIMENT
+	);
+	const isResurrectedThreeMonths = hasExceededDormancyThreshold(
+		lastSeen,
+		RESURRECTION_DAY_LIMIT_3M
+	);
+	const isResurrected = config.isEnabled( WELCOME_BACK_90_DAY_ELIGIBILITY_FLAG )
+		? isResurrectedThreeMonths
+		: isResurrectedSixMonths;
+	const hasActiveSubscriptions = hasActivePaidSubscription( userPurchasesQueryResult.data );
+	const baseEligibility = isResurrected && hasActiveSubscriptions === false;
+
+	const [ isExperimentLoading, experimentAssignment ] = useExperiment(
+		RESURRECTED_FREE_USERS_EXPERIMENT,
+		{
+			isEligible: baseEligibility,
+		}
+	);
+
+	const variationName = experimentAssignment?.variationName ?? WELCOME_BACK_VARIATION_MANUAL;
+	const isForcedByFlag = config.isEnabled( WELCOME_BACK_MODAL_FORCE_FLAG );
+
+	if ( isForcedByFlag ) {
+		return {
+			isLoading: false,
+			lastSeen,
+			isResurrectedSixMonths,
+			isResurrectedThreeMonths,
+			hasActivePaidSubscription: hasActiveSubscriptions,
+			isEligible: true,
+			variationName,
+			isForcedVariation: true,
+		};
+	}
+
+	const isLoading =
+		userSettingsQueryResult.isPending ||
+		userPurchasesQueryResult.isPending ||
+		( baseEligibility && isExperimentLoading );
+
+	return {
+		isLoading,
+		lastSeen,
+		isResurrectedSixMonths,
+		isResurrectedThreeMonths,
+		hasActivePaidSubscription: hasActiveSubscriptions,
+		isEligible: baseEligibility && ! isExperimentLoading,
+		variationName,
+		isForcedVariation: false,
+	};
+}

--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -30,6 +30,7 @@ import { useOmnibarEvent } from '../omnibar/events';
 import OmnibarSiteSwitcher from '../omnibar/omnibar-site-switcher';
 import { useSyncOmnibarSite } from '../omnibar/site';
 import ResponsiveSidebar from '../responsive-sidebar';
+import { ResurrectedWelcomeModalGate } from '../resurrected-welcome-modal';
 import Snackbars from '../snackbars';
 import { OptInWelcomeModal } from '../welcome-modal';
 import './style.scss';
@@ -58,13 +59,27 @@ function Root() {
 	const isOptInWelcomeModalEnabled =
 		! isDashboardBackport() && ! isE2ETest() && isEnabled( 'dashboard/opt-in-welcome-modal' );
 	const { name, supports, LoadingLogo = WordPressLogo } = useAppContext();
+	const isResurrectedWelcomeModalEnabled =
+		supports.resurrectedWelcomeModal && ! isDashboardBackport() && ! isE2ETest();
 	const isFetching = useIsFetching();
 	const isMutating = useIsMutating();
 	const router = useRouter();
 	const queryClient = useQueryClient();
 	const queryCache = queryClient.getQueryCache();
 	const [ isSidebarOpen, setIsSidebarOpen ] = useState( false );
+	const [ resurrectedModalState, setResurrectedModalState ] = useState<
+		'pending' | 'eligible' | 'ineligible'
+	>( isResurrectedWelcomeModalEnabled ? 'pending' : 'ineligible' );
 	const closeSidebar = useCallback( () => setIsSidebarOpen( false ), [ setIsSidebarOpen ] );
+	const handleResurrectedModalEligibility = useCallback( ( willDisplay: boolean ) => {
+		setResurrectedModalState( ( state ) => {
+			if ( state !== 'pending' ) {
+				return state;
+			}
+
+			return willDisplay ? 'eligible' : 'ineligible';
+		} );
+	}, [] );
 
 	useSyncOmnibarSite();
 	useTrackVisitedAreas();
@@ -198,8 +213,15 @@ function Root() {
 			<OmnibarSiteSwitcher />
 			<Snackbars />
 			<CheckoutSuccessFlashMessage />
-			{ isAccountRecoveryInterstitialEnabled && <AccountRecoveryInterstitial /> }
-			{ isOptInWelcomeModalEnabled && <OptInWelcomeModal /> }
+			{ isResurrectedWelcomeModalEnabled && (
+				<ResurrectedWelcomeModalGate onEligibilityResolved={ handleResurrectedModalEligibility } />
+			) }
+			{ resurrectedModalState === 'ineligible' && isAccountRecoveryInterstitialEnabled && (
+				<AccountRecoveryInterstitial />
+			) }
+			{ resurrectedModalState === 'ineligible' && isOptInWelcomeModalEnabled && (
+				<OptInWelcomeModal />
+			) }
 			<PageViewTracker />
 			<MutationErrorTracker />
 			<NavigationBlockerRegistry />

--- a/client/lib/analytics/track-resurrections/index.jsx
+++ b/client/lib/analytics/track-resurrections/index.jsx
@@ -3,7 +3,9 @@ import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import {
 	RESURRECTED_EVENT,
+	RESURRECTED_EVENT_3M,
 	RESURRECTED_EVENT_6M,
+	RESURRECTION_DAY_LIMIT_3M,
 	RESURRECTION_DAY_LIMIT_DEFAULT,
 	RESURRECTION_DAY_LIMIT_EXPERIMENT,
 } from 'calypso/lib/resurrected-users/constants';
@@ -24,6 +26,10 @@ const TrackResurrections = () => {
 		lastSeen,
 		RESURRECTION_DAY_LIMIT_EXPERIMENT
 	);
+	const isResurrectedThreeMonths = hasExceededDormancyThreshold(
+		lastSeen,
+		RESURRECTION_DAY_LIMIT_3M
+	);
 
 	useEffect( () => {
 		if ( isFetching ) {
@@ -41,7 +47,19 @@ const TrackResurrections = () => {
 				day_limit: RESURRECTION_DAY_LIMIT_EXPERIMENT,
 			} );
 		}
-	}, [ isFetching, isResurrectedDefault, isResurrectedSixMonths, lastSeen ] ); // Only run this when LastSeen value changes.
+		if ( isResurrectedThreeMonths ) {
+			recordTracksEvent( RESURRECTED_EVENT_3M, {
+				last_seen: lastSeen,
+				day_limit: RESURRECTION_DAY_LIMIT_3M,
+			} );
+		}
+	}, [
+		isFetching,
+		isResurrectedDefault,
+		isResurrectedSixMonths,
+		isResurrectedThreeMonths,
+		lastSeen,
+	] ); // Only run this when LastSeen value changes.
 
 	return null;
 };

--- a/client/lib/analytics/track-resurrections/test/index.jsx
+++ b/client/lib/analytics/track-resurrections/test/index.jsx
@@ -2,7 +2,11 @@
  * @jest-environment jsdom
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { RESURRECTED_EVENT, RESURRECTED_EVENT_6M } from 'calypso/lib/resurrected-users/constants';
+import {
+	RESURRECTED_EVENT,
+	RESURRECTED_EVENT_3M,
+	RESURRECTED_EVENT_6M,
+} from 'calypso/lib/resurrected-users/constants';
 import userSettings from 'calypso/state/user-settings/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import TrackResurrections from '../';
@@ -40,7 +44,7 @@ describe( 'TrackResurrections', () => {
 		expect( recordTracksEvent ).toHaveBeenCalledTimes( 0 );
 	} );
 
-	it( 'should not call recordTracksEvent if lastSeen is less than six months ago', () => {
+	it( 'should not call recordTracksEvent if lastSeen is less than three months ago', () => {
 		const dormantThreshold = Date.now() / 1000 - 2 * 30 * 24 * 60 * 60; // 2 months-ish.
 
 		render( <TrackResurrections />, {
@@ -57,7 +61,7 @@ describe( 'TrackResurrections', () => {
 		expect( recordTracksEvent ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should call both resurrection events if lastSeen is more than one year ago', () => {
+	it( 'should call all resurrection events if lastSeen is more than one year ago', () => {
 		const resurrectedDate = Date.now() / 1000 - 2 * 365 * 24 * 60 * 60; // 2 years in seconds.
 
 		render( <TrackResurrections />, {
@@ -85,10 +89,46 @@ describe( 'TrackResurrections', () => {
 				last_seen: resurrectedDate,
 			} )
 		);
+		expect( recordTracksEvent ).toHaveBeenNthCalledWith(
+			3,
+			RESURRECTED_EVENT_3M,
+			expect.objectContaining( {
+				last_seen: resurrectedDate,
+			} )
+		);
 	} );
 
-	it( 'should call only the six month resurrection event if lastSeen is between six and twelve months ago', () => {
+	it( 'should call the six and three month events if lastSeen is between six and twelve months ago', () => {
 		const resurrectedDate = Date.now() / 1000 - 8 * 30 * 24 * 60 * 60; // ~8 months.
+
+		render( <TrackResurrections />, {
+			initialState: {
+				userSettings: {
+					settings: {
+						last_admin_activity_timestamp: resurrectedDate,
+					},
+					fetching: false,
+				},
+			},
+		} );
+
+		expect( recordTracksEvent ).toHaveBeenCalledTimes( 2 );
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			RESURRECTED_EVENT_6M,
+			expect.objectContaining( {
+				last_seen: resurrectedDate,
+			} )
+		);
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			RESURRECTED_EVENT_3M,
+			expect.objectContaining( {
+				last_seen: resurrectedDate,
+			} )
+		);
+	} );
+
+	it( 'should call only the three month event if lastSeen is between three and six months ago', () => {
+		const resurrectedDate = Date.now() / 1000 - 4 * 30 * 24 * 60 * 60; // ~4 months.
 
 		render( <TrackResurrections />, {
 			initialState: {
@@ -103,7 +143,7 @@ describe( 'TrackResurrections', () => {
 
 		expect( recordTracksEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordTracksEvent ).toHaveBeenCalledWith(
-			RESURRECTED_EVENT_6M,
+			RESURRECTED_EVENT_3M,
 			expect.objectContaining( {
 				last_seen: resurrectedDate,
 			} )

--- a/client/lib/resurrected-users/README.md
+++ b/client/lib/resurrected-users/README.md
@@ -1,7 +1,8 @@
 # Resurrected Free Users – Welcome Back Modal
 
 This module powers the welcome-back modal for eligible resurrected free users. A user is
-eligible after 180 days of inactivity when they have no active paid subscriptions.
+eligible after 180 days of inactivity when they have no active paid subscriptions. The inactivity
+threshold is 90 days while the experiment eligibility flag is enabled.
 
 ## Components
 
@@ -26,6 +27,8 @@ modal waits for an eligible user's assignment before deciding which experience t
 
 ## Feature flag
 
+- **`resurrected-users/90-day-eligibility`** – Uses the experiment's 90-day inactivity threshold
+  instead of the default 180-day threshold.
 - **`welcome-back-modal-manual`** – When enabled (for example,
   `ENABLE_FEATURES=welcome-back-modal-manual yarn start`), forces the modal to display regardless
   of eligibility for local testing. When no assignment is available, it uses the existing manual
@@ -37,8 +40,8 @@ modal waits for an eligible user's assignment before deciding which experience t
   selects a CTA.
 - The content variation fetches only the latest modified draft and keeps the modal visible while
   that request resolves.
-- The classic Calypso `/sites` mount is separate from the Dashboard client served at
-  `my.wordpress.com`; Dashboard does not currently mount this modal.
+- The classic Calypso `/sites` mount and the Dashboard client served at `my.wordpress.com` use
+  separate eligibility adapters for the shared modal.
 
 ## Analytics
 
@@ -49,4 +52,5 @@ modal waits for an eligible user's assignment before deciding which experience t
 ## Events
 
 - `calypso_user_resurrected` – Legacy 373-day resurrection.
-- `calypso_user_resurrected_6m` – 180-day resurrection (used for this modal).
+- `calypso_user_resurrected_6m` – 180-day resurrection.
+- `calypso_user_resurrected_3m` – 90-day resurrection.

--- a/client/lib/resurrected-users/constants.ts
+++ b/client/lib/resurrected-users/constants.ts
@@ -1,8 +1,10 @@
 export const RESURRECTION_DAY_LIMIT_DEFAULT = 373;
 export const RESURRECTION_DAY_LIMIT_EXPERIMENT = 180;
+export const RESURRECTION_DAY_LIMIT_3M = 90;
 
 export const RESURRECTED_EVENT = 'calypso_user_resurrected';
 export const RESURRECTED_EVENT_6M = 'calypso_user_resurrected_6m';
+export const RESURRECTED_EVENT_3M = 'calypso_user_resurrected_3m';
 export const RESURRECTED_FREE_USERS_EXPERIMENT =
 	'calypso_resurrected_users_welcome_back_modal_202607';
 
@@ -21,3 +23,5 @@ export type WelcomeBackVariation =
 
 /** Feature flag to force the welcome-back modal for local/testing. */
 export const WELCOME_BACK_MODAL_FORCE_FLAG = 'welcome-back-modal-manual';
+
+export const WELCOME_BACK_90_DAY_ELIGIBILITY_FLAG = 'resurrected-users/90-day-eligibility';

--- a/client/lib/resurrected-users/test/use-resurrected-free-user-eligibility.test.tsx
+++ b/client/lib/resurrected-users/test/use-resurrected-free-user-eligibility.test.tsx
@@ -9,6 +9,7 @@ import userSettingsReducer from 'calypso/state/user-settings/reducer';
 import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
 import {
 	RESURRECTED_FREE_USERS_EXPERIMENT,
+	WELCOME_BACK_90_DAY_ELIGIBILITY_FLAG,
 	WELCOME_BACK_VARIATION_MANUAL,
 	WELCOME_BACK_VARIATIONS,
 } from '../constants';
@@ -150,6 +151,7 @@ describe( 'useResurrectedFreeUserEligibility', () => {
 		} );
 
 		expect( result.current.isResurrectedSixMonths ).toBe( true );
+		expect( result.current.isResurrectedThreeMonths ).toBe( true );
 		expect( result.current.hasActivePaidSubscription ).toBe( false );
 		expect( result.current.isEligible ).toBe( true );
 		expect( result.current.variationName ).toBe( WELCOME_BACK_VARIATION_MANUAL );
@@ -158,6 +160,37 @@ describe( 'useResurrectedFreeUserEligibility', () => {
 		expect( mockUseExperiment ).toHaveBeenCalledWith( RESURRECTED_FREE_USERS_EXPERIMENT, {
 			isEligible: true,
 		} );
+	} );
+
+	it( 'uses the 180-day threshold when 90-day eligibility is disabled', () => {
+		selectorsState.purchases = [];
+		selectorsState.hasLoaded = true;
+
+		const { result } = renderHookWithProvider( () => useResurrectedFreeUserEligibility(), {
+			initialState: createState( { lastSeenOffsetDays: 100 } ),
+			reducers,
+		} );
+
+		expect( result.current.isResurrectedSixMonths ).toBe( false );
+		expect( result.current.isResurrectedThreeMonths ).toBe( true );
+		expect( result.current.isEligible ).toBe( false );
+	} );
+
+	it( 'uses the 90-day threshold when 90-day eligibility is enabled', () => {
+		mockIsFeatureEnabled.mockImplementation(
+			( flagName ) => flagName === WELCOME_BACK_90_DAY_ELIGIBILITY_FLAG
+		);
+		selectorsState.purchases = [];
+		selectorsState.hasLoaded = true;
+
+		const { result } = renderHookWithProvider( () => useResurrectedFreeUserEligibility(), {
+			initialState: createState( { lastSeenOffsetDays: 100 } ),
+			reducers,
+		} );
+
+		expect( result.current.isResurrectedSixMonths ).toBe( false );
+		expect( result.current.isResurrectedThreeMonths ).toBe( true );
+		expect( result.current.isEligible ).toBe( true );
 	} );
 
 	it( 'returns the assigned experiment variation for an eligible user', () => {

--- a/client/lib/resurrected-users/use-resurrected-free-user-eligibility.ts
+++ b/client/lib/resurrected-users/use-resurrected-free-user-eligibility.ts
@@ -13,10 +13,12 @@ import {
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
 import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
 import {
+	RESURRECTED_FREE_USERS_EXPERIMENT,
+	RESURRECTION_DAY_LIMIT_3M,
 	RESURRECTION_DAY_LIMIT_EXPERIMENT,
+	WELCOME_BACK_90_DAY_ELIGIBILITY_FLAG,
 	WELCOME_BACK_MODAL_FORCE_FLAG,
 	WELCOME_BACK_VARIATION_MANUAL,
-	RESURRECTED_FREE_USERS_EXPERIMENT,
 } from './constants';
 import { hasExceededDormancyThreshold } from './utils';
 import type { Purchase } from 'calypso/lib/purchases/types';
@@ -24,6 +26,7 @@ import type { Purchase } from 'calypso/lib/purchases/types';
 interface EligibilityResult {
 	isLoading: boolean;
 	isResurrectedSixMonths: boolean;
+	isResurrectedThreeMonths: boolean;
 	hasActivePaidSubscription: boolean | null;
 	isEligible: boolean;
 	variationName: string | null;
@@ -74,13 +77,20 @@ export function useResurrectedFreeUserEligibility(): EligibilityResult {
 		() => hasExceededDormancyThreshold( lastSeen, RESURRECTION_DAY_LIMIT_EXPERIMENT ),
 		[ lastSeen ]
 	);
+	const isResurrectedThreeMonths = useMemo(
+		() => hasExceededDormancyThreshold( lastSeen, RESURRECTION_DAY_LIMIT_3M ),
+		[ lastSeen ]
+	);
 
 	const hasActiveSubscriptions = useMemo(
 		() => hasActivePaidSubscription( purchases ),
 		[ purchases ]
 	);
 
-	const baseEligibility = isResurrectedSixMonths && hasActiveSubscriptions === false;
+	const isResurrected = config.isEnabled( WELCOME_BACK_90_DAY_ELIGIBILITY_FLAG )
+		? isResurrectedThreeMonths
+		: isResurrectedSixMonths;
+	const baseEligibility = isResurrected && hasActiveSubscriptions === false;
 	const [ isExperimentLoading, experimentAssignment ] = useExperiment(
 		RESURRECTED_FREE_USERS_EXPERIMENT,
 		{
@@ -96,6 +106,7 @@ export function useResurrectedFreeUserEligibility(): EligibilityResult {
 		return {
 			isLoading: false,
 			isResurrectedSixMonths,
+			isResurrectedThreeMonths,
 			hasActivePaidSubscription: hasActiveSubscriptions,
 			isEligible: true,
 			variationName,
@@ -112,6 +123,7 @@ export function useResurrectedFreeUserEligibility(): EligibilityResult {
 	return {
 		isLoading,
 		isResurrectedSixMonths,
+		isResurrectedThreeMonths,
 		hasActivePaidSubscription: hasActiveSubscriptions,
 		isEligible: baseEligibility && experimentReady,
 		variationName,

--- a/packages/components/src/resurrected-welcome-modal/index.tsx
+++ b/packages/components/src/resurrected-welcome-modal/index.tsx
@@ -69,13 +69,13 @@ function getVariationConfig( variationName: string ): VariationConfig {
 				),
 				ctas: [
 					{
-						id: 'manual-new',
+						id: 'browse-themes',
 						label: __( 'Browse new themes' ),
 						href: THEMES_SHOWCASE_URL,
 						variant: 'primary',
 					},
 					{
-						id: 'manual-continue',
+						id: 'manual-new',
 						label: __( 'Create a new site' ),
 						href: ONBOARDING_URL,
 						variant: 'tertiary',
@@ -90,13 +90,13 @@ function getVariationConfig( variationName: string ): VariationConfig {
 				),
 				ctas: [
 					{
-						id: 'content-new',
+						id: 'write-post',
 						label: __( 'Write your next post' ),
 						href: NEW_POST_URL,
 						variant: 'primary',
 					},
 					{
-						id: 'content-new-site',
+						id: 'manual-new',
 						label: __( 'Create a new site' ),
 						href: ONBOARDING_URL,
 						variant: 'tertiary',
@@ -117,7 +117,7 @@ function getVariationConfig( variationName: string ): VariationConfig {
 						variant: 'primary',
 					},
 					{
-						id: 'design-new',
+						id: 'manual-new',
 						label: __( 'Create a new site' ),
 						href: ONBOARDING_URL,
 						variant: 'tertiary',
@@ -166,9 +166,9 @@ export default function ResurrectedWelcomeModal( {
 			omission: '…',
 		} );
 		resolvedCtas = resolvedCtas.map( ( cta ) =>
-			cta.id === 'content-new'
+			cta.id === 'write-post'
 				? {
-						id: 'content-draft',
+						id: 'continue-draft',
 						label: getDraftCtaLabel( truncatedDraftTitle ),
 						href: `/post/${ lastDraft.siteId }/${ lastDraft.id }`,
 						variant: 'primary',
@@ -205,10 +205,9 @@ export default function ResurrectedWelcomeModal( {
 					<div className="resurrected-welcome-modal__actions">
 						{ resolvedCtas.map( ( cta ) => {
 							const variant = cta.variant ?? 'primary';
-							const isLoading =
-								isContentVariation && isLastDraftLoading && cta.id === 'content-new';
+							const isLoading = isContentVariation && isLastDraftLoading && cta.id === 'write-post';
 							const ctaTitle =
-								cta.id === 'content-draft' && lastDraft
+								cta.id === 'continue-draft' && lastDraft
 									? getDraftCtaLabel( lastDraft.title )
 									: undefined;
 

--- a/packages/components/src/resurrected-welcome-modal/style.scss
+++ b/packages/components/src/resurrected-welcome-modal/style.scss
@@ -8,6 +8,7 @@
 	height: auto;
 	max-height: calc( 100vh - 32px );
 	border-radius: 8px;
+	outline: 0;
 	overflow: hidden;
 }
 

--- a/packages/components/src/resurrected-welcome-modal/style.scss
+++ b/packages/components/src/resurrected-welcome-modal/style.scss
@@ -68,8 +68,8 @@
 
 .resurrected-welcome-modal__close {
 	position: absolute;
-	top: 16px;
-	right: 16px;
+	inset-block-start: 16px;
+	inset-inline-end: 16px;
 	width: 24px;
 	height: 24px;
 	border: 0;
@@ -94,7 +94,7 @@
 .resurrected-welcome-modal__content {
 	margin-top: 0;
 	padding: 26px;
-	text-align: left;
+	text-align: start;
 }
 
 .resurrected-welcome-modal__title {


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-18009

## Proposed Changes

Implement the returning user modal/experiment in the multi site dashboard.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To support a future experiment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow the instructions in DOTCOM-17870 and confirm the modal works correctly in both Calypso and MSD.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
