### PR TITLE
Update theme banners to point to correct AI Site Buidler flow

### DIFF
--- a/client/my-sites/themes/banners-modern/ai-builder-banner.tsx
+++ b/client/my-sites/themes/banners-modern/ai-builder-banner.tsx
@@ -25,7 +25,7 @@ const AIBuilderBanner = () => {
 				<Button
 					className="banner-modern__button"
 					variant="primary"
-					href="/setup/ai-site-builder"
+					href="/setup/ai-site-builder-onboarding"
 					onClick={ trackClick }
 				>
 					{ translate( 'Start with AI' ) }

--- a/client/my-sites/themes/banners-modern/test/ai-builder-banner.test.tsx
+++ b/client/my-sites/themes/banners-modern/test/ai-builder-banner.test.tsx
@@ -31,7 +31,7 @@ describe( 'AIBuilderBanner', () => {
 		render( <AIBuilderBanner /> );
 		const button = screen.getByRole( 'link', { name: 'Start with AI' } );
 		expect( button ).toBeVisible();
-		expect( button ).toHaveAttribute( 'href', '/setup/ai-site-builder' );
+		expect( button ).toHaveAttribute( 'href', '/setup/ai-site-builder-onboarding' );
 	} );
 
 	test( 'tracks click event when CTA is clicked', async () => {

--- a/client/my-sites/themes/search-results-modern/search-more-options.tsx
+++ b/client/my-sites/themes/search-results-modern/search-more-options.tsx
@@ -57,7 +57,7 @@ const SearchMoreOptions = ( { title, subtitle, searchTerm }: SearchMoreOptionsPr
 					<Button
 						className="search-more-options__button"
 						variant="secondary"
-						href="/setup/ai-site-builder"
+						href="/setup/ai-site-builder-onboarding"
 						onClick={ trackAIClick }
 					>
 						{ translate( 'Build with AI' ) }

--- a/client/my-sites/themes/search-results-modern/test/search-more-options.test.tsx
+++ b/client/my-sites/themes/search-results-modern/test/search-more-options.test.tsx
@@ -53,7 +53,7 @@ describe( 'SearchMoreOptions', () => {
 		render( <SearchMoreOptions title="No themes found" /> );
 		expect( screen.getByRole( 'link', { name: 'Build with AI' } ) ).toHaveAttribute(
 			'href',
-			'/setup/ai-site-builder'
+			'/setup/ai-site-builder-onboarding'
 		);
 		expect( screen.getByRole( 'link', { name: 'Hire an expert' } ) ).toHaveAttribute(
 			'href',


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTPROD-155

## Proposed Changes

Updates the theme search and showcase banners to point to the correct AI Site builder flow

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

They were still pointing to the free trial

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I did not test this, as I don't know what conditions they're shown - I do not see them browsing or searching for themes on my sites. 

- Is the flow path correct? 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
