### PR TITLE
Purchase Management: Unify and fix the display of days relative to subscription expiry or renewal

### DIFF
--- a/client/dashboard/components/purchase-expiry-status/index.tsx
+++ b/client/dashboard/components/purchase-expiry-status/index.tsx
@@ -1,4 +1,5 @@
 import { SubscriptionBillPeriod, getPlanNames } from '@automattic/api-core';
+import { translationExists } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import { Button, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
@@ -6,12 +7,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useHelpCenter } from '../../app/help-center';
 import { useLocale } from '../../app/locale';
 import { Text } from '../../components/text';
-import {
-	formatDate,
-	isWithinLast,
-	isWithinNext,
-	getRelativeTimeString,
-} from '../../utils/datetime';
+import { formatDate, getCalendarDaysUntil, getRelativeDayString } from '../../utils/datetime';
 import {
 	isA4ABillingDragonPurchase,
 	isRecentMonthlyPurchase,
@@ -314,14 +310,29 @@ export function PurchaseExpiryStatus( {
 		}
 	}
 
+	const expiresOnText = createInterpolateElement(
+		// translators: date is a formatted expiry date
+		__( 'Expires on <date />' ),
+		{
+			date: <FormattedExpiryDate locale={ locale } purchase={ purchase } />,
+		}
+	);
+
 	if ( isExpiring( purchase ) && ! isAkismetFreeProduct( purchase ) ) {
-		if (
-			isWithinNext( new Date( purchase.expiry_date ), 30, 'days' ) &&
-			! isRecentMonthlyPurchase( purchase )
-		) {
-			const intent = isWithinNext( new Date( purchase.expiry_date ), 7, 'days' )
-				? ( 'error' as const )
-				: ( 'warning' as const );
+		const daysUntilExpiry = getCalendarDaysUntil( new Date( purchase.expiry_date ) );
+
+		// Covers both "later today" and a purchase whose expiry date has passed
+		// but which the backend still reports as expiring.
+		if ( daysUntilExpiry <= 0 ) {
+			return (
+				<Text intent="error">
+					{ translationExists( 'Expires today' ) ? __( 'Expires today' ) : expiresOnText }
+				</Text>
+			);
+		}
+
+		if ( daysUntilExpiry <= 30 && ! isRecentMonthlyPurchase( purchase ) ) {
+			const intent = daysUntilExpiry <= 7 ? ( 'error' as const ) : ( 'warning' as const );
 
 			return (
 				<Text intent={ intent }>
@@ -330,7 +341,12 @@ export function PurchaseExpiryStatus( {
 							// translators: timeUntilExpiry is a formatted expiration string like "in 30 days" and date is a formatted expiry date
 							__( 'Expires %(timeUntilExpiry)s on <date />' ),
 							{
-								timeUntilExpiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
+								// The branch above already excludes today and past dates, but
+								// the clamp keeps that guarantee local to this call.
+								timeUntilExpiry: getRelativeDayString(
+									new Date( purchase.expiry_date ),
+									'upcoming'
+								),
 							}
 						),
 						{
@@ -341,13 +357,7 @@ export function PurchaseExpiryStatus( {
 			);
 		}
 
-		return createInterpolateElement(
-			// translators: date is a formatted expiry date
-			__( 'Expires on <date />' ),
-			{
-				date: <FormattedExpiryDate locale={ locale } purchase={ purchase } />,
-			}
-		);
+		return expiresOnText;
 	}
 	if ( isExpiredOrRemoved( purchase ) && 'concierge-session' === purchase.product_slug ) {
 		// translators: %s is a formatted expiry date
@@ -357,14 +367,20 @@ export function PurchaseExpiryStatus( {
 	}
 
 	if ( isExpiredOrRemoved( purchase ) ) {
-		const isExpiredToday = isWithinLast( new Date( purchase.expiry_date ), 24, 'hours' );
+		// getCalendarDaysUntil counts forward, so this is negative once the expiry
+		// date has passed. Anything else means the expiry lands today or later —
+		// later being a purchase removed ahead of its expiry date — and both read
+		// as "Expired today" rather than "Expired in 3 days".
+		const expiredBeforeToday = getCalendarDaysUntil( new Date( purchase.expiry_date ) ) < 0;
 		const expiredTodayText = __( 'Expired today' );
 		// translators: timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"
 		const expiredFromNowText = sprintf( __( 'Expired %(timeSinceExpiry)s' ), {
-			timeSinceExpiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
+			timeSinceExpiry: getRelativeDayString( new Date( purchase.expiry_date ), 'past' ),
 		} );
 
-		return <Text intent="error">{ isExpiredToday ? expiredTodayText : expiredFromNowText }</Text>;
+		return (
+			<Text intent="error">{ expiredBeforeToday ? expiredFromNowText : expiredTodayText }</Text>
+		);
 	}
 
 	if ( isIncludedWithPlan( purchase ) ) {

--- a/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
@@ -6,7 +6,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
 import { purchaseSettingsRoute, changePaymentMethodRoute } from '../../../app/router/me';
 import Notice from '../../../components/notice';
-import { getRelativeTimeString, isWithinNext } from '../../../utils/datetime';
+import { getRelativeDayString, isWithinNext } from '../../../utils/datetime';
 import {
 	isExpiring,
 	isIncludedWithPlan,
@@ -224,12 +224,21 @@ export function OtherRenewablePurchasesNotice( {
 	const purchaseName = currentPurchase.is_domain
 		? currentPurchase.meta ?? ''
 		: currentPurchase.product_name;
-	const expiry = getRelativeTimeString( new Date( currentPurchase.expiry_date ) );
+	// These slots feed both past-tense ("expired %(expiry)s") and future-tense
+	// ("will expire %(expiry)s") sentences, so each is clamped to match the
+	// tense of the scenario it lands in.
+	const expiry = getRelativeDayString(
+		new Date( currentPurchase.expiry_date ),
+		isExpiredOrRemoved( currentPurchase ) ? 'past' : 'upcoming'
+	);
 	const includedPurchaseName = includedPurchase.is_domain
 		? includedPurchase.meta ?? ''
 		: includedPurchase.product_name;
 	const earliestOtherExpiry = earliestOtherExpiringPurchase
-		? getRelativeTimeString( new Date( earliestOtherExpiringPurchase.expiry_date ) )
+		? getRelativeDayString(
+				new Date( earliestOtherExpiringPurchase.expiry_date ),
+				isExpiredOrRemoved( earliestOtherExpiringPurchase ) ? 'past' : 'upcoming'
+		  )
 		: '';
 	const openUpcomingRenewalsDialog = () => setUpcomingRenewalsDialogVisible( true );
 	const link = <Button variant="link" onClick={ () => openUpcomingRenewalsDialog() } />;

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
@@ -3,10 +3,9 @@ import { Link } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { differenceInCalendarDays } from 'date-fns';
 import { purchaseSettingsRoute } from '../../../app/router/me';
 import Notice from '../../../components/notice';
-import { getRelativeTimeString } from '../../../utils/datetime';
+import { getCalendarDaysUntil, getRelativeDayString } from '../../../utils/datetime';
 import {
 	isIncludedWithPlan,
 	isExpiring,
@@ -105,7 +104,7 @@ export function PurchaseExpiringNotice( {
 							includedPurchaseName: includedPurchase.is_domain
 								? includedPurchase.meta ?? ''
 								: includedPurchase.product_name,
-							expiry: getRelativeTimeString( new Date( currentPurchase.expiry_date ) ),
+							expiry: getRelativeDayString( new Date( currentPurchase.expiry_date ), 'upcoming' ),
 						}
 					),
 					{
@@ -157,10 +156,15 @@ function ExpiringText( {
 	}
 
 	const purchaseName = purchase.is_domain ? purchase.meta ?? '' : purchase.product_name;
+	const daysToExpiry = getCalendarDaysUntil( new Date( purchase.expiry_date ) );
 
-	if ( purchase.bill_period_days === SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD ) {
-		const daysToExpiry = differenceInCalendarDays( new Date( purchase.expiry_date ), new Date() );
-
+	// A monthly purchase expiring today (or already past its expiry date, while
+	// still reported as expiring) falls through to the relative wording below,
+	// which renders "today" rather than "in 0 days".
+	if (
+		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD &&
+		daysToExpiry > 0
+	) {
 		if ( purchase.is_attached_to_holding_site ) {
 			return sprintf(
 				// translators: %(purchaseName)s: the name of the plan, %(daysToExpiry)d: a number of days
@@ -191,7 +195,7 @@ function ExpiringText( {
 		// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
 		return sprintf( __( '%(purchaseName)s will expire and be removed %(expiry)s.' ), {
 			purchaseName,
-			expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
+			expiry: getRelativeDayString( new Date( purchase.expiry_date ), 'upcoming' ),
 		} );
 	}
 
@@ -202,7 +206,7 @@ function ExpiringText( {
 		  __( '%(purchaseName)s will expire and be removed from your site %(expiry)s.' );
 	return sprintf( message, {
 		purchaseName,
-		expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
+		expiry: getRelativeDayString( new Date( purchase.expiry_date ), 'upcoming' ),
 	} );
 }
 
@@ -216,7 +220,7 @@ export function ExpiringLaterText( {
 	isDomainWithoutSite?: boolean;
 } ) {
 	const purchaseName = purchase.is_domain ? purchase.meta ?? '' : purchase.product_name;
-	const expiry = getRelativeTimeString( new Date( purchase.expiry_date ) );
+	const expiry = getRelativeDayString( new Date( purchase.expiry_date ), 'upcoming' );
 
 	if ( purchase.payment_type === 'credits' ) {
 		if ( autoRenewingUpgradesAction ) {

--- a/client/dashboard/utils/datetime.ts
+++ b/client/dashboard/utils/datetime.ts
@@ -1,6 +1,7 @@
+import { translationExists } from '@automattic/i18n-utils';
 import { dateI18n } from '@wordpress/date';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { parse, isValid, format } from 'date-fns';
+import { parse, isValid, format, differenceInCalendarDays } from 'date-fns';
 
 const HOUR_MS = 3_600_000;
 const YMD_REGEX = /^\d{4}-\d{2}-\d{2}$/;
@@ -51,10 +52,73 @@ export function isWithinNext( date: Date, count: number, unit: 'hours' | 'days' 
 }
 
 /**
+ * Whole days from today until `date` in the viewer's time zone: positive for
+ * future dates, negative for past ones, 0 for any time today.
+ *
+ * For example, if today is July 27 in the viewer's time zone (any time during
+ * that day) and a `date` is passed in corresponding to any time of day on July
+ * 29 in the viewer's time zone, this function will return 2.
+ *
+ * This is especially helpful to use when the viewer is being shown both the
+ * number of days and the date itself (since the date itself would typically be
+ * displayed in their time zone too); it guarantees they will stay consistent.
+ * For example, "Expires in X days on July 29"; if today is July 27, then the
+ * viewer would obviously expect X to be 2, and that is what this function
+ * provides.
+ *
+ * See also `getRelativeDayString` if you want to handle the relative date
+ * strings ("in X days" in the above example) automatically.
+ */
+export function getCalendarDaysUntil( date: Date ): number {
+	return differenceInCalendarDays( date, new Date() );
+}
+
+/**
+ * Like `getRelativeTimeString`, but it never gets more precise than a day, and
+ * never points the wrong way (where "wrong" is defined by the passed-in
+ * `direction`). Instead, anything that happens today reads "today", as does
+ * anything that has already moved past the expected `direction`.
+ *
+ * For example:
+ * - If your text is like "Expires %s", calling this function and passing in
+ *   "upcoming" for the `direction` means that a `date` 1 day from now will
+ *   render as "Expires in 1 day", but a `date` 1 day ago will render as
+ *   "Expires today" (rather than the nonsensical "Expires 1 day ago").
+ * - Similarly, if your text is like "Expired %s", passing in "past" for the
+ *   `direction` will ensure the text is either like "Expired 1 day ago" or
+ *   "Expired today", and never like "Expired in 1 day".
+ *
+ * This is helpful for cases where the timing of a server-determined status
+ * ("expires" vs. "expired" in the above example) may not line up exactly with
+ * calendar date transitions in the viewer's time zone; if we know the
+ * transition hasn't happened yet, then it is better to indicate it will happen
+ * imminently (i.e. "today") than to claim it will happen at a specific time
+ * that already passed.
+ */
+export function getRelativeDayString( date: Date, direction: 'upcoming' | 'past' ): string {
+	const days = getCalendarDaysUntil( date );
+	const isToday = direction === 'upcoming' ? days <= 0 : days >= 0;
+
+	if ( isToday && translationExists( 'today' ) ) {
+		return __( 'today' );
+	}
+
+	return getRelativeTimeString( date );
+}
+
+/**
  * Return a string like "in 2 days" or "1 month ago" for a given date.
  *
  * Note that given the imprecision of date math and time zones, this may not be
  * totally accurate. Use it only in places where precision is not required.
+ *
+ * It can drop to hours and minutes within a single day, and always says which
+ * direction the date actually points (for example, "in 2 minutes" for a date 2
+ * minutes in the future, or "2 minutes ago" for a date 2 minutes in the past).
+ *
+ * If your wording assumes a particular direction (for example, "Expires %s" or
+ * "Expired %s") and the smallest unit of precision you need is a day (rather
+ * than hours or minutes), use `getRelativeDayString` instead.
  */
 export function getRelativeTimeString( date: Date ): string {
 	const now = new Date();

--- a/client/dashboard/utils/test/datetime.ts
+++ b/client/dashboard/utils/test/datetime.ts
@@ -1,5 +1,13 @@
 import { dateI18n } from '@wordpress/date';
-import { parseYmdLocal, formatYmd, formatSiteYmd } from '../datetime';
+import MockDate from 'mockdate';
+import {
+	parseYmdLocal,
+	formatYmd,
+	formatSiteYmd,
+	getCalendarDaysUntil,
+	getRelativeTimeString,
+	getRelativeDayString,
+} from '../datetime';
 
 describe( 'datetime utils (site-time)', () => {
 	describe( 'parseYmdLocal', () => {
@@ -82,6 +90,108 @@ describe( 'datetime utils (site-time)', () => {
 		it( 'handles month/year boundaries correctly', () => {
 			expect( formatSiteYmd( new Date( 2025, 11, 31 ) ) ).toBe( '2025-12-31' ); // Dec 31
 			expect( formatSiteYmd( new Date( 2026, 0, 1 ) ) ).toBe( '2026-01-01' ); // Jan 1
+		} );
+	} );
+
+	describe( 'getCalendarDaysUntil', () => {
+		beforeEach( () => {
+			MockDate.set( '2026-02-24T12:00:00Z' );
+		} );
+
+		afterEach( () => {
+			MockDate.reset();
+		} );
+
+		it( 'counts calendar days, not elapsed 24-hour periods', () => {
+			// Less than 24 hours away, but on tomorrow's calendar day.
+			expect( getCalendarDaysUntil( new Date( '2026-02-25T01:00:00Z' ) ) ).toBe( 1 );
+			// More than 24 hours away, but only two calendar days out.
+			expect( getCalendarDaysUntil( new Date( '2026-02-26T01:00:00Z' ) ) ).toBe( 2 );
+		} );
+
+		it( 'returns 0 for any time on today’s calendar day', () => {
+			expect( getCalendarDaysUntil( new Date( '2026-02-24T00:00:00Z' ) ) ).toBe( 0 );
+			expect( getCalendarDaysUntil( new Date( '2026-02-24T23:59:59Z' ) ) ).toBe( 0 );
+		} );
+
+		it( 'returns negative values for past days', () => {
+			expect( getCalendarDaysUntil( new Date( '2026-02-23T23:00:00Z' ) ) ).toBe( -1 );
+			expect( getCalendarDaysUntil( new Date( '2026-02-14T12:00:00Z' ) ) ).toBe( -10 );
+		} );
+
+		it( 'crosses month boundaries', () => {
+			expect( getCalendarDaysUntil( new Date( '2026-03-01T12:00:00Z' ) ) ).toBe( 5 );
+		} );
+	} );
+
+	describe( 'getRelativeTimeString', () => {
+		beforeEach( () => {
+			MockDate.set( '2026-02-24T12:00:00Z' );
+		} );
+
+		afterEach( () => {
+			MockDate.reset();
+		} );
+
+		it( 'describes upcoming dates in days', () => {
+			expect( getRelativeTimeString( new Date( '2026-02-25T12:00:00Z' ) ) ).toBe( 'in 1 day' );
+			expect( getRelativeTimeString( new Date( '2026-02-27T12:00:00Z' ) ) ).toBe( 'in 3 days' );
+		} );
+
+		it( 'describes past dates in days', () => {
+			expect( getRelativeTimeString( new Date( '2026-02-21T12:00:00Z' ) ) ).toBe( '3 days ago' );
+		} );
+
+		it( 'counts whole calendar months rather than rounding to the nearest', () => {
+			// A day short of a full month still reads in days.
+			expect( getRelativeTimeString( new Date( '2026-03-23T12:00:00Z' ) ) ).toBe( 'in 27 days' );
+			expect( getRelativeTimeString( new Date( '2026-03-24T12:00:00Z' ) ) ).toBe( 'in 1 month' );
+			// Well past one month but short of two.
+			expect( getRelativeTimeString( new Date( '2026-04-10T12:00:00Z' ) ) ).toBe( 'in 1 month' );
+		} );
+
+		it( 'falls back to hours within the same calendar day', () => {
+			expect( getRelativeTimeString( new Date( '2026-02-24T19:00:00Z' ) ) ).toBe( 'in 7 hours' );
+		} );
+	} );
+
+	describe( 'getRelativeDayString', () => {
+		beforeEach( () => {
+			MockDate.set( '2026-02-24T12:00:00Z' );
+		} );
+
+		afterEach( () => {
+			MockDate.reset();
+		} );
+
+		it( 'never drops below day granularity', () => {
+			expect( getRelativeDayString( new Date( '2026-02-24T19:00:00Z' ), 'upcoming' ) ).toBe(
+				'today'
+			);
+			expect( getRelativeDayString( new Date( '2026-02-24T01:00:00Z' ), 'past' ) ).toBe( 'today' );
+		} );
+
+		it( 'clamps an upcoming date that has already slipped past', () => {
+			// An expiry date the backend has not yet flagged as expired must not
+			// read as "1 day ago" inside a future-tense sentence.
+			expect( getRelativeDayString( new Date( '2026-02-23T12:00:00Z' ), 'upcoming' ) ).toBe(
+				'today'
+			);
+		} );
+
+		it( 'clamps a past date that is still in the future', () => {
+			// A purchase removed before its expiry date must not read as "in 3 days"
+			// inside a past-tense sentence.
+			expect( getRelativeDayString( new Date( '2026-02-27T12:00:00Z' ), 'past' ) ).toBe( 'today' );
+		} );
+
+		it( 'passes through dates that point the expected way', () => {
+			expect( getRelativeDayString( new Date( '2026-02-27T12:00:00Z' ), 'upcoming' ) ).toBe(
+				'in 3 days'
+			);
+			expect( getRelativeDayString( new Date( '2026-02-21T12:00:00Z' ), 'past' ) ).toBe(
+				'3 days ago'
+			);
 		} );
 	} );
 } );

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -31,6 +31,7 @@ import Notice, { NoticeStatus } from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import { useIsSplitCancelRemoveEnabled } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled';
 import { getProductNounForCategory } from 'calypso/dashboard/me/billing-purchases/purchase-settings/classify-purchase-for-copy';
+import { getCalendarDaysUntil, getRelativeDayString } from 'calypso/dashboard/utils/datetime';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { createPurchasesArray } from 'calypso/lib/purchases/assembler';
 import { getTrialCheckoutUrl } from 'calypso/lib/trials/get-trial-checkout-url';
@@ -423,16 +424,18 @@ class PurchaseNotice extends Component<
 	}
 
 	getExpiringText( purchase: Purchase ) {
-		const { translate, moment, selectedSite } = this.props;
-		const expiry = moment( purchase.expiry_date );
+		const { translate, selectedSite } = this.props;
 
 		if ( selectedSite && purchase.expiry_status === 'manual-renew' && ! is100Year( purchase ) ) {
 			return this.getExpiringLaterText( purchase );
 		}
 
-		if ( isMonthlyPurchase( purchase ) ) {
-			const daysToExpiry = expiry.diff( moment(), 'days' );
+		const daysToExpiry = getCalendarDaysUntil( new Date( purchase.expiry_date ) );
 
+		// A monthly purchase expiring today (or already past its expiry date, while
+		// still reported as expiring) falls through to the relative wording below,
+		// which renders "today" rather than "in 0 days".
+		if ( isMonthlyPurchase( purchase ) && daysToExpiry > 0 ) {
 			if ( purchase.is_attached_to_holding_site ) {
 				return translate( '%(purchaseName)s will expire and be removed in %(daysToExpiry)d days.', {
 					args: {
@@ -457,7 +460,7 @@ class PurchaseNotice extends Component<
 			return translate( '%(purchaseName)s will expire and be removed %(expiry)s.', {
 				args: {
 					purchaseName: getName( purchase ),
-					expiry: expiry.fromNow(),
+					expiry: getRelativeDayString( new Date( purchase.expiry_date ), 'upcoming' ),
 				},
 			} );
 		}
@@ -465,7 +468,7 @@ class PurchaseNotice extends Component<
 		return translate( '%(purchaseName)s will expire and be removed from your site %(expiry)s.', {
 			args: {
 				purchaseName: getName( purchase ),
-				expiry: expiry.fromNow(),
+				expiry: getRelativeDayString( new Date( purchase.expiry_date ), 'upcoming' ),
 			},
 		} );
 	}
@@ -477,13 +480,12 @@ class PurchaseNotice extends Component<
 	 * @returns  {string}  Translated text for the warning message.
 	 */
 	getExpiringLaterText( purchase: Purchase, autoRenewingUpgradesLink?: ReactElement ): ReactNode {
-		const { translate, moment } = this.props;
-		const expiry = moment( purchase.expiry_date );
+		const { translate } = this.props;
 
 		const translateOptions: TranslateOptions = {
 			args: {
 				purchaseName: getName( purchase ),
-				expiry: expiry.fromNow(),
+				expiry: getRelativeDayString( new Date( purchase.expiry_date ), 'upcoming' ),
 			},
 		};
 
@@ -641,14 +643,8 @@ class PurchaseNotice extends Component<
 			PLAN_MIGRATION_TRIAL_MONTHLY,
 			PLAN_HOSTING_TRIAL_MONTHLY,
 		];
-		const {
-			moment,
-			purchase,
-			purchaseAttachedTo,
-			selectedSite,
-			translate,
-			getManagePurchaseUrlFor,
-		} = this.props;
+		const { purchase, purchaseAttachedTo, selectedSite, translate, getManagePurchaseUrlFor } =
+			this.props;
 
 		// For purchases included with a plan (for example, a domain mapping
 		// bundled with the plan), the plan purchase is used on this page when
@@ -698,7 +694,7 @@ class PurchaseNotice extends Component<
 					args: {
 						purchaseName: getName( currentPurchase ),
 						includedPurchaseName: getName( includedPurchase ),
-						expiry: moment( currentPurchase.expiry_date ).fromNow(),
+						expiry: getRelativeDayString( new Date( currentPurchase.expiry_date ), 'upcoming' ),
 					},
 					components: {
 						managePurchase: (
@@ -806,14 +802,22 @@ class PurchaseNotice extends Component<
 			( otherPurchase ) => Number( moment( otherPurchase.expiry_date ).format( 'X' ) )
 		);
 
-		const expiry = moment( currentPurchase.expiry_date );
+		// These slots feed both past-tense ("expired %(expiry)s") and future-tense
+		// ("will expire %(expiry)s") sentences, so each is clamped to match the
+		// tense of the scenario it lands in.
 		const translateOptions = {
 			args: {
 				purchaseName: getName( currentPurchase ),
 				includedPurchaseName: getName( includedPurchase ),
-				expiry: expiry.fromNow(),
+				expiry: getRelativeDayString(
+					new Date( currentPurchase.expiry_date ),
+					isExpiredOrRemoved( currentPurchase ) ? 'past' : 'upcoming'
+				),
 				earliestOtherExpiry: earliestOtherExpiringPurchase
-					? moment( earliestOtherExpiringPurchase.expiry_date ).fromNow()
+					? getRelativeDayString(
+							new Date( earliestOtherExpiringPurchase.expiry_date ),
+							isExpiredOrRemoved( earliestOtherExpiringPurchase ) ? 'past' : 'upcoming'
+					  )
 					: '',
 			},
 			components: {

--- a/client/me/purchases/manage-purchase/plan-details/billing-period.tsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.tsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { getRelativeDayString } from 'calypso/dashboard/utils/datetime';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
@@ -85,7 +86,7 @@ export class PlanBillingPeriod extends Component<
 		if ( isExpiredOrRemoved( purchase ) && purchase.expiry_date ) {
 			return translate( 'Billed yearly, expired %(timeSinceExpiry)s', {
 				args: {
-					timeSinceExpiry: moment( purchase.expiry_date ).fromNow(),
+					timeSinceExpiry: getRelativeDayString( new Date( purchase.expiry_date ), 'past' ),
 				},
 				comment: 'timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"',
 			} );
@@ -95,7 +96,7 @@ export class PlanBillingPeriod extends Component<
 	}
 
 	renderBillingPeriod() {
-		const { purchase, site, translate, moment, isProductOwner } = this.props;
+		const { purchase, site, translate, isProductOwner } = this.props;
 		if ( ! purchase ) {
 			return;
 		}
@@ -120,7 +121,7 @@ export class PlanBillingPeriod extends Component<
 						text: 'Billed monthly, expired %(timeSinceExpiry)s',
 						newCopy: translate( 'Billed monthly, expired %(timeSinceExpiry)s', {
 							args: {
-								timeSinceExpiry: moment( purchase.expiry_date ).fromNow(),
+								timeSinceExpiry: getRelativeDayString( new Date( purchase.expiry_date ), 'past' ),
 							},
 							comment:
 								'timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"',

--- a/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
@@ -132,7 +132,7 @@ describe( 'PlanBillingPeriod', () => {
 				};
 				render( <PlanBillingPeriod { ...annualPlanProps } purchase={ purchase } /> );
 				expect( screen.getByText( /billed yearly/i ) ).toHaveTextContent(
-					'Billed yearly, expired a month ago'
+					'Billed yearly, expired 1 month ago'
 				);
 			} );
 		} );

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -19,7 +19,7 @@ import { getPaymentMethodImageURL, razorpayImage as upiImage } from '@automattic
 import { ExternalLink, Button } from '@wordpress/components';
 import { Icon, cautionFilled as warningIcon } from '@wordpress/icons';
 import clsx from 'clsx';
-import { localize, useTranslate } from 'i18n-calypso';
+import { fixMe, localize, useTranslate } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import akismetIcon from 'calypso/assets/images/icons/akismet-icon.svg';
@@ -29,6 +29,7 @@ import payPalImage from 'calypso/assets/images/upgrades/paypal-full.svg';
 import SiteIcon from 'calypso/blocks/site-icon';
 import InfoPopover from 'calypso/components/info-popover';
 import { withLocalizedMoment, useLocalizedMoment } from 'calypso/components/localized-moment';
+import { getCalendarDaysUntil, getRelativeDayString } from 'calypso/dashboard/utils/datetime';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import {
@@ -589,17 +590,40 @@ export function PurchaseItemStatus( {
 	}
 
 	if ( isExpiring( purchase ) && ! isAkismetFreeProduct( purchase ) ) {
-		if ( expiry < moment().add( 30, 'days' ) && ! isRecentMonthlyPurchase( purchase ) ) {
+		const expiresOnText = translate( 'Expires on {{span}}%s{{/span}}', {
+			args: expiry.format( 'LL' ),
+			components: {
+				span: <span className="purchase-item__date" />,
+			},
+		} );
+		const daysUntilExpiry = getCalendarDaysUntil( expiry.toDate() );
+
+		// Covers both "later today" and a purchase whose expiry date has passed
+		// but which the backend still reports as expiring.
+		if ( daysUntilExpiry <= 0 ) {
+			return (
+				<span className="purchase-item__is-error">
+					{ fixMe( {
+						text: 'Expires today',
+						newCopy: translate( 'Expires today' ),
+						oldCopy: expiresOnText,
+					} ) }
+					<TrackImpression warning="purchase-expiring" />
+				</span>
+			);
+		}
+
+		if ( daysUntilExpiry <= 30 && ! isRecentMonthlyPurchase( purchase ) ) {
 			const expiryClass =
-				expiry < moment().add( 7, 'days' )
-					? 'purchase-item__is-error'
-					: 'purchase-item__is-warning';
+				daysUntilExpiry <= 7 ? 'purchase-item__is-error' : 'purchase-item__is-warning';
 
 			return (
 				<span className={ expiryClass }>
 					{ translate( 'Expires %(timeUntilExpiry)s on {{span}}%(date)s{{/span}}', {
 						args: {
-							timeUntilExpiry: expiry.fromNow(),
+							// The branch above already excludes today and past dates, but
+							// the clamp keeps that guarantee local to this call.
+							timeUntilExpiry: getRelativeDayString( expiry.toDate(), 'upcoming' ),
 							date: expiry.format( 'LL' ),
 						},
 						components: {
@@ -611,12 +635,7 @@ export function PurchaseItemStatus( {
 			);
 		}
 
-		return translate( 'Expires on {{span}}%s{{/span}}', {
-			args: expiry.format( 'LL' ),
-			components: {
-				span: <span className="purchase-item__date" />,
-			},
-		} );
+		return expiresOnText;
 	}
 
 	if ( isExpiredOrRemoved( purchase ) ) {
@@ -626,18 +645,22 @@ export function PurchaseItemStatus( {
 			} );
 		}
 
-		const isExpiredToday = moment().diff( expiry, 'hours' ) < 24;
+		// getCalendarDaysUntil counts forward, so this is negative once the expiry
+		// date has passed. Anything else means the expiry lands today or later —
+		// later being a purchase removed ahead of its expiry date — and both read
+		// as "Expired today" rather than "Expired in 3 days".
+		const expiredBeforeToday = getCalendarDaysUntil( expiry.toDate() ) < 0;
 		const expiredTodayText = translate( 'Expired today' );
 		const expiredFromNowText = translate( 'Expired %(timeSinceExpiry)s', {
 			args: {
-				timeSinceExpiry: expiry.fromNow(),
+				timeSinceExpiry: getRelativeDayString( expiry.toDate(), 'past' ),
 			},
 			context: 'timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"',
 		} );
 
 		return (
 			<span className="purchase-item__is-error">
-				{ isExpiredToday ? expiredTodayText : expiredFromNowText }
+				{ expiredBeforeToday ? expiredFromNowText : expiredTodayText }
 				<TrackImpression warning="purchase-expired" />
 			</span>
 		);

--- a/client/me/purchases/purchase-item/test/index.js
+++ b/client/me/purchases/purchase-item/test/index.js
@@ -3,17 +3,32 @@
  */
 import { screen } from '@testing-library/react';
 import i18n from 'i18n-calypso';
-import moment from 'moment';
+import MockDate from 'mockdate';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import PurchaseItem from '../';
 
+// Expiry copy is measured in whole calendar days in the viewer's time zone, so
+// these assertions only hold against a fixed clock.
+const NOW = '2026-02-24T18:00:00Z';
+
 describe( 'PurchaseItem', () => {
-	describe( 'a purchase that expired < 24 hours ago', () => {
+	beforeEach( () => {
+		MockDate.set( NOW );
+	} );
+
+	afterEach( () => {
+		MockDate.reset();
+		// i18n-calypso is a module-level singleton, so translations added by one
+		// test would otherwise change the copy every later test asserts on.
+		i18n.setLocale();
+	} );
+
+	describe( 'a purchase that expired earlier today', () => {
 		const purchase = {
 			productSlug: 'business-bundle',
 			expiryStatus: 'expired',
 			subscriptionStatus: 'active',
-			expiryDate: moment().subtract( 10, 'hours' ).format(),
+			expiryDate: '2026-02-24T08:00:00+00:00',
 		};
 
 		test( 'should be described as "Expired today"', () => {
@@ -29,6 +44,87 @@ describe( 'PurchaseItem', () => {
 			renderWithProvider( <PurchaseItem purchase={ purchase } /> );
 
 			expect( screen.getByText( translation ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'a purchase that expired on an earlier day', () => {
+		const purchase = {
+			productSlug: 'business-bundle',
+			expiryStatus: 'expired',
+			subscriptionStatus: 'active',
+			expiryDate: '2026-02-21T08:00:00+00:00',
+		};
+
+		test( 'should be described with how long ago it expired', () => {
+			renderWithProvider( <PurchaseItem purchase={ purchase } /> );
+
+			expect( screen.getByText( /expired 3 days ago/i ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'a purchase that expires later today', () => {
+		const purchase = {
+			productSlug: 'business-bundle',
+			expiryStatus: 'manualRenew',
+			subscriptionStatus: 'active',
+			expiryDate: '2026-02-24T23:00:00+00:00',
+		};
+
+		test( 'should be described as "Expires today" rather than a count of hours', () => {
+			renderWithProvider( <PurchaseItem purchase={ purchase } /> );
+
+			expect( screen.getByText( /expires today/i ) ).toBeInTheDocument();
+			expect( screen.queryByText( /hours/i ) ).toBeNull();
+		} );
+	} );
+
+	describe( 'a purchase past its expiry date that is still reported as expiring', () => {
+		// The backend does not flip expiry_status the moment the date passes, so
+		// this state is reachable for a while after expiry.
+		const purchase = {
+			productSlug: 'business-bundle',
+			expiryStatus: 'manualRenew',
+			subscriptionStatus: 'active',
+			expiryDate: '2026-02-23T23:00:00+00:00',
+		};
+
+		test( 'should say "Expires today", never a past interval in a future sentence', () => {
+			renderWithProvider( <PurchaseItem purchase={ purchase } /> );
+
+			expect( screen.getByText( /expires today/i ) ).toBeInTheDocument();
+			expect( screen.queryByText( /ago/i ) ).toBeNull();
+		} );
+	} );
+
+	describe( 'a purchase removed before its expiry date', () => {
+		const purchase = {
+			productSlug: 'business-bundle',
+			expiryStatus: 'expired',
+			subscriptionStatus: 'inactive',
+			expiryDate: '2026-02-27T23:00:00+00:00',
+		};
+
+		test( 'should not describe a future date as "Expired in N days"', () => {
+			renderWithProvider( <PurchaseItem purchase={ purchase } /> );
+
+			expect( screen.getByText( /expired today/i ) ).toBeInTheDocument();
+			expect( screen.queryByText( /expired in/i ) ).toBeNull();
+		} );
+	} );
+
+	describe( 'a purchase expiring within the next 30 days', () => {
+		const purchase = {
+			productSlug: 'business-bundle',
+			expiryStatus: 'manualRenew',
+			subscriptionStatus: 'active',
+			// Renders as February 27 in UTC, three calendar days out.
+			expiryDate: '2026-02-27T23:00:00+00:00',
+		};
+
+		test( 'should count the same calendar days as the date it displays', () => {
+			renderWithProvider( <PurchaseItem purchase={ purchase } /> );
+
+			expect( screen.getByText( /expires in 3 days on/i ) ).toBeInTheDocument();
 		} );
 	} );
 

--- a/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
@@ -4,7 +4,7 @@ import { formatCurrency } from '@automattic/number-formatters';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { FunctionComponent, Fragment, useState, useEffect, useCallback, useMemo } from 'react';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { getRelativeDayString } from 'calypso/dashboard/utils/datetime';
 import {
 	getName,
 	getRenewalPrice,
@@ -35,28 +35,27 @@ interface Props {
 
 function getExpiresText(
 	translate: ReturnType< typeof useTranslate >,
-	moment: ReturnType< typeof useLocalizedMoment >,
 	purchase: Purchase
 ): TranslateResult {
 	if ( isRenewingBeforeExpiration( purchase ) ) {
 		return translate( 'renews %(renewDate)s', {
 			comment:
-				'"renewDate" is relative to the present time and it is already localized, eg. "in a year", "in a month"',
-			args: { renewDate: moment( purchase.renewDate ).fromNow() },
+				'"renewDate" is relative to the present time and it is already localized, eg. "in a year", "in a month", "today"',
+			args: { renewDate: getRelativeDayString( new Date( purchase.renewDate ), 'upcoming' ) },
 		} );
 	}
 	if ( isExpiredOrRemoved( purchase ) ) {
 		return translate( 'expired %(expiry)s', {
 			comment:
-				'"expiry" is relative to the present time and it is already localized, eg. "in a year", "in a month", "a week ago"',
-			args: { expiry: moment( purchase.expiryDate ).fromNow() },
+				'"expiry" is relative to the present time and it is already localized, eg. "a week ago", "today"',
+			args: { expiry: getRelativeDayString( new Date( purchase.expiryDate ), 'past' ) },
 		} );
 	}
 	return translate( 'expires %(expiry)s', {
 		comment:
-			'"expiry" is relative to the present time and it is already localized, eg. "in a year", "in a month", "a week ago"',
+			'"expiry" is relative to the present time and it is already localized, eg. "in a year", "in a month", "today"',
 		args: {
-			expiry: moment( purchase.expiryDate ).fromNow(),
+			expiry: getRelativeDayString( new Date( purchase.expiryDate ), 'upcoming' ),
 		},
 	} );
 }
@@ -72,7 +71,6 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 	getManagePurchaseUrlFor = managePurchase,
 } ) => {
 	const translate = useTranslate();
-	const moment = useLocalizedMoment();
 	const [ selectedPurchases, setSelectedPurchases ] = useState< number[] >( [] );
 
 	const purchasesSortByRecentExpiryDate = useMemo(
@@ -109,7 +107,7 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 			</h3>
 			<hr />
 			{ purchasesSortByRecentExpiryDate.map( ( purchase ) => {
-				const expiresText = getExpiresText( translate, moment, purchase ) as string;
+				const expiresText = getExpiresText( translate, purchase ) as string;
 				const purchaseTypeText = purchaseType( purchase );
 				const onChange = () => {
 					if ( selectedPurchases.includes( purchase.id ) ) {

--- a/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
+++ b/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
@@ -6,8 +6,8 @@ import { FunctionComponent, useMemo, useCallback, useState, useEffect, useRef } 
 import { dismissCard } from 'calypso/blocks/dismissible-card/actions';
 import { isCardDismissed } from 'calypso/blocks/dismissible-card/selectors';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import SectionHeader from 'calypso/components/section-header';
+import { getRelativeDayString } from 'calypso/dashboard/utils/datetime';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { getRenewalItemFromProduct } from 'calypso/lib/cart-values/cart-items';
 import { getName, isRenewingBeforeExpiration, isExpiredOrRemoved } from 'calypso/lib/purchases';
@@ -60,7 +60,6 @@ interface Props {
 const UpcomingRenewalsReminder: FunctionComponent< Props > = ( { cart, addItemToCart } ) => {
 	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
-	const moment = useLocalizedMoment();
 	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) as SelectedSite );
 	const renewableSitePurchases: Purchase[] = useSelector( ( state ) =>
 		getRenewableSitePurchases( state, selectedSite?.ID )
@@ -207,7 +206,6 @@ const UpcomingRenewalsReminder: FunctionComponent< Props > = ( { cart, addItemTo
 
 	const { message, buttonLabel } = getMessages( {
 		translate,
-		moment,
 		selectedSite,
 		setUpcomingRenewalsDialogVisible: openAllPurchasesDialog,
 		renewablePurchasesNotAlreadyInCart,
@@ -247,13 +245,11 @@ const UpcomingRenewalsReminder: FunctionComponent< Props > = ( { cart, addItemTo
 
 function getMessages( {
 	translate,
-	moment,
 	selectedSite,
 	setUpcomingRenewalsDialogVisible,
 	renewablePurchasesNotAlreadyInCart,
 }: {
 	translate: ReturnType< typeof useTranslate >;
-	moment: ReturnType< typeof useLocalizedMoment >;
 	selectedSite: SelectedSite;
 	setUpcomingRenewalsDialogVisible: ( isVisible: boolean ) => void;
 	renewablePurchasesNotAlreadyInCart: Purchase[];
@@ -294,10 +290,15 @@ function getMessages( {
 	let message: TranslateResult = '';
 	const translateOptions = {
 		comment:
-			'"expiry" is relative to the present time and it is already localized, eg. "in a year", "in a month", "a week ago"',
+			'"expiry" is relative to the present time and it is already localized, eg. "in a year", "a week ago", "today"',
 		args: {
 			purchaseName: getName( purchase ),
-			expiry: moment( purchase.expiryDate ).fromNow(),
+			// This slot feeds both "expired %(expiry)s" and "is expiring %(expiry)s",
+			// so it is clamped to match the tense of the branch it lands in.
+			expiry: getRelativeDayString(
+				new Date( purchase.expiryDate ),
+				isExpiredOrRemoved( purchase ) ? 'past' : 'upcoming'
+			),
 		},
 	};
 
@@ -321,10 +322,10 @@ function getMessages( {
 	} else if ( isRenewingBeforeExpiration( purchase ) ) {
 		const renewingTranslateOptions = {
 			comment:
-				'"relativeRenewDate" is relative to the present time and it is already localized, eg. "in a year", "in a month"',
+				'"relativeRenewDate" is relative to the present time and it is already localized, eg. "in a year", "in a month", "today"',
 			args: {
 				purchaseName: getName( purchase ),
-				relativeRenewDate: moment( purchase.renewDate ).fromNow(),
+				relativeRenewDate: getRelativeDayString( new Date( purchase.renewDate ), 'upcoming' ),
 			},
 		};
 		if ( isDomainRegistration( purchase ) ) {

--- a/client/my-sites/customer-home/cards/tasks/renew/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/renew/index.jsx
@@ -2,14 +2,14 @@ import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import expiredIllustration from 'calypso/assets/images/customer-home/disconnected-dark.svg';
 import expiringIllustration from 'calypso/assets/images/customer-home/disconnected.svg';
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { getRelativeDayString } from 'calypso/dashboard/utils/datetime';
 import { TASK_RENEW_EXPIRED_PLAN } from 'calypso/my-sites/customer-home/cards/constants';
 import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 import { getSitePurchases } from 'calypso/state/purchases/selectors/get-site-purchases';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
-const Renew = ( { card, moment, purchases, site, siteSlug } ) => {
+const Renew = ( { card, purchases, site, siteSlug } ) => {
 	const translate = useTranslate();
 	const hasExpired = card === TASK_RENEW_EXPIRED_PLAN;
 
@@ -19,9 +19,9 @@ const Renew = ( { card, moment, purchases, site, siteSlug } ) => {
 
 	const planName = site?.plan.product_name_short;
 	const planSlug = planPurchase?.productSlug;
-	const expiry = moment( planPurchase?.expiryDate );
-	const expiryToday = Math.abs( moment().diff( expiry, 'hours' ) ) < 24;
-	const expiryText = expiryToday ? expiry.format( '[today]' ) : expiry.fromNow();
+	const expiryText = planPurchase?.expiryDate
+		? getRelativeDayString( new Date( planPurchase.expiryDate ), hasExpired ? 'past' : 'upcoming' )
+		: '';
 	const isOwner = site?.plan.user_is_owner;
 
 	const title = hasExpired
@@ -111,4 +111,4 @@ const mapStateToProps = ( state ) => {
 	};
 };
 
-export default connect( mapStateToProps )( withLocalizedMoment( Renew ) );
+export default connect( mapStateToProps )( Renew );

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -207,10 +207,26 @@ export interface Purchase {
 	is_past_expiry_date: boolean;
 
 	/**
-	 * Whole days until the subscription expires, rounded down. Uses a UTC midnight
-	 * basis, so it can go negative up to a day before `is_past_expiry_date`
-	 * (end-of-day basis) does, and can read up to a day off from the viewer's local
-	 * time zone. Null for purchases with no expiry time (one-time and perpetual).
+	 * Whole days from today until the subscription expires, counted in UTC.
+	 * Negative once the subscription has expired, and null for subscriptions
+	 * that never expire (for example, one-time purchases).
+	 *
+	 * Don't use this in text that counts down to a date the viewer can also
+	 * see; the fact that it is UTC-based means it can disagree by 1 day with
+	 * the viewer's own time zone. For example, a subscription expiration date
+	 * of July 30 (midnight UTC) will be shown as July 29 in any timezone west
+	 * of UTC (such as New York). As a result, the viewer will expect the
+	 * displayed days until expiration to equal 2 any time during the day on
+	 * July 27 in their time zone, and to equal 1 any time during the day on
+	 * July 28 in their time zone, etc. To get that behavior, see
+	 * `getCalendarDaysUntil` and `getRelativeDayString` in
+	 * `client/dashboard/utils/datetime.ts` instead.
+	 *
+	 * By contrast, do use this when the answer should match the server's time
+	 * rather than the viewer's time. If you want the count of days to change
+	 * at the same moment the subscription itself can change state (for
+	 * example, as soon as the subscription's `expiry_status` becomes
+	 * "expired"), then this property is a good choice.
 	 */
 	days_until_expiry: number | null;
 

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -51,9 +51,26 @@ export interface Purchase {
 	expiryStatus: string;
 
 	/**
-	 * Whole days until expiry, rounded down, negative once past expiry. Measured
-	 * against UTC midnight, so it can be up to a day off from the viewer's local
-	 * time zone. Null for purchases with no expiry time (one-time and perpetual).
+	 * Whole days from today until the subscription expires, counted in UTC.
+	 * Negative once the subscription has expired, and null for subscriptions
+	 * that never expire (for example, one-time purchases).
+	 *
+	 * Don't use this in text that counts down to a date the viewer can also
+	 * see; the fact that it is UTC-based means it can disagree by 1 day with
+	 * the viewer's own time zone. For example, a subscription expiration date
+	 * of July 30 (midnight UTC) will be shown as July 29 in any timezone west
+	 * of UTC (such as New York). As a result, the viewer will expect the
+	 * displayed days until expiration to equal 2 any time during the day on
+	 * July 27 in their time zone, and to equal 1 any time during the day on
+	 * July 28 in their time zone, etc. To get that behavior, see
+	 * `getCalendarDaysUntil` and `getRelativeDayString` in
+	 * `client/dashboard/utils/datetime.ts` instead.
+	 *
+	 * By contrast, do use this when the answer should match the server's time
+	 * rather than the viewer's time. If you want the count of days to change at
+	 * the same moment the subscription itself can change state (for example,
+	 * as soon as the subscription's `expiryStatus` becomes "expired"), then
+	 * this property is a good choice.
 	 */
 	daysUntilExpiry: number | null;
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2298/purchase-management-unify-and-fix-the-display-of-days-relative-to

## Proposed Changes

Currently, Calypso and the Multi-Site Dashboard use different methods for calculating the number of days to or since a subscription's expiry and renewal dates, for example in phrases such as "Expires in X days", "Renews in X days", "Expired X days ago", etc.  The Calypso method has buggy calculations everywhere; the Dashboard method has fewer bugs, although both Calypso and the Dashboard have problems around the day of expiration itself.

This pull request fixes the problem by introducing new helper methods `getCalendarDaysUntil()` and `getRelativeDayString()` and using them consistently throughout the codebase.  These methods use client-side, timezone-aware calculations; note that the server-side `days_until_expiry` property would actually give unexpected results in this scenario (since it is entirely UTC-based), and the pull request adds code comments explaining why.

This is being specifically fixed as part of the work on https://linear.app/a8c/project/milestone-1-purchase-management-page-shows-expirygrace-state-and-renew-b3e0cd708161/overview, because the main change there is expected to involve sharing some purchase management page messaging components between the Dashboard and Calypso.  Doing that without fixing this bug would make the bug especially stark, since users would then see conflicting information about the number of days remaining on their subscription as they scroll within the same Calypso interface.

## Testing Instructions

The testing instructions below assume that today is July 27, and that we are in a timezone west of UTC (there are different variations of the bug east of UTC).  Note also that some of the bugs only occur at certain times of day.
1. Buy a plan.
2. Turn off auto-renew, and (on the server) set its expiration date to something in the near future, e.g. July 31 UTC. This will be displayed as July 30 in the user interface, for your timezone.
3. Visit the various purchase listing pages in Calypso and the Dashboard, as well as the individual purchase mangagement page (in each location) for your specific subscription.
4. Before this pull request, the above pages might show inconsistencies in how the number of days until that date is communicated, "in 3 days" in some places and "in 4 days" in other places.  (Note this is hard to test, though; for example, in the UTC−4 timezone, the bug in Calypso is specifically only visible from midnight through 8am, due to the way the date rounding works.)  After this pull request, you should consistently see "in 3 days" everywhere, which makes sense because today is July 27 (three days prior to July 30).
5. Try the same with a subscription that expires tomorrow UTC (e.g. July 28), which means its expiration date is today in your current timezone. Without this pull request, you'll see messages like "Expires in X hours" in some parts of the interface -- which is too much granularity for something that is really just a rough marker of when the subscription is past due.  With this pull request, all such places should consistently say "Expires today".
6. Try the same with a subscription that expires today UTC (e.g. July 27), which means its expiration date is yesterday in your current timezone. Without this pull request, you'll see messages like "Expires X hours ago" or "Expires 1 day ago" in some parts of the interface, which obviously makes no sense.  With this pull request, all such places should consistently say "Expires today" (which is maybe not perfect either, but better).  Note the reason this scenario happens in the first place is that to avoid false alarms, subscriptions aren't treated as "expired" server-side until the end of the UTC day.

Here are example screenshots for the final case noted above (expiration date equal to today UTC), specifically on the purchase listing pages.

**Calypso**

| Before | After |
| :---: | :---: |
| <img width="704" height="86" alt="calypso-before" src="https://github.com/user-attachments/assets/e31c7592-b512-464c-9cb7-9ebb5e1459bc" /> | <img width="704" height="86" alt="calypso-after" src="https://github.com/user-attachments/assets/ef92fff1-88af-49ca-9f49-ecd377a8fdc8" /> |

**Dashboard**

| Before | After |
| :---: | :---: |
| <img width="883" height="86" alt="msd-before" src="https://github.com/user-attachments/assets/5f54c91e-d040-45ba-a24b-e6a648d1f93d" /> | <img width="883" height="86" alt="msd-after" src="https://github.com/user-attachments/assets/af5b528a-0413-4946-85ab-4453b4545bbd" /> |