### PR TITLE
A4A Amplify: match the site_unreachable code where the API returns it

### DIFF
--- a/client/a8c-for-agencies/data/amplify/types.ts
+++ b/client/a8c-for-agencies/data/amplify/types.ts
@@ -41,8 +41,20 @@ export interface ArchiveAmplifyReportParams {
 	reportId: string;
 }
 
+export interface AmplifyApiErrorDetail {
+	code: string;
+	message: string;
+}
+
 export interface AmplifyApiError {
 	status: number;
 	code: string | null;
 	message: string;
+	// A parameter validation failure surfaces as `rest_invalid_param` at the
+	// top level; the code that actually says what went wrong sits under
+	// `data.details`, keyed by parameter name.
+	data?: {
+		status?: number;
+		details?: Record< string, AmplifyApiErrorDetail >;
+	};
 }

--- a/client/a8c-for-agencies/sections/amplify/add-site/modal.tsx
+++ b/client/a8c-for-agencies/sections/amplify/add-site/modal.tsx
@@ -15,9 +15,18 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import AnalysisProgress from './analysis-progress';
 import AnalysisTypeCards from './analysis-type-cards';
 import AmplifySiteSelector from './site-selector';
-import type { AmplifyMode } from 'calypso/a8c-for-agencies/data/amplify/types';
+import type { AmplifyApiError, AmplifyMode } from 'calypso/a8c-for-agencies/data/amplify/types';
 
 import './style.scss';
+
+function isSiteUnreachableError( error: AmplifyApiError | null ) {
+	return (
+		error?.code === 'site_unreachable' ||
+		Object.values( error?.data?.details ?? {} ).some(
+			( detail ) => detail.code === 'site_unreachable'
+		)
+	);
+}
 
 export default function AmplifyAddSiteModal( { onClose }: { onClose: () => void } ) {
 	const dispatch = useDispatch();
@@ -34,12 +43,11 @@ export default function AmplifyAddSiteModal( { onClose }: { onClose: () => void 
 		// to the progress view instead of showing a notice.
 		onSuccess: () => setInProgress( true ),
 		onError: ( error ) => {
-			const message =
-				error?.code === 'site_unreachable'
-					? __(
-							'We couldn’t reach this site to analyze it. Make sure it’s online and publicly accessible, then try again.'
-					  )
-					: __( 'Could not start the analysis. Please try again.' );
+			const message = isSiteUnreachableError( error )
+				? __(
+						'We couldn’t reach this site to analyze it. Make sure it’s online and publicly accessible, then try again.'
+				  )
+				: __( 'Could not start the analysis. Please try again.' );
 			dispatch(
 				errorNotice( message, {
 					id: 'amplify-analysis-error',


### PR DESCRIPTION
## Proposed Changes

* Read the `site_unreachable` code from where the API actually returns it. The endpoint reports an unreachable site as a parameter validation failure, so the top-level code is `rest_invalid_param` and `site_unreachable` sits nested under `data.details`, keyed by parameter name:

```json
{
	"code": "rest_invalid_param",
	"message": "Invalid parameter(s): url",
	"data": {
		"status": 400,
		"details": {
			"url": { "code": "site_unreachable", "message": "…" }
		}
	}
}
```

* Add an `isSiteUnreachableError()` helper that scans `data.details` for the code, keeping the top-level check for the case where the endpoint returns it unwrapped.
* Model the nested `data.details` shape on `AmplifyApiError`.

## Why are these changes being made?

* Follow-up to #112987. The check ran against the top-level code only, so the targeted "we couldn’t reach this site" notice needs the nested lookup to fire. `wpcom.req` errors are built by `wp-error`, which copies the response body’s top-level props onto the error object — everything below `data` has to be read explicitly.
* Scanning `data.details` by value rather than hardcoding `details.url` keeps it working if the backend attaches the code to another parameter.

## Testing Instructions

* Go to A4A → Amplify and open the "Amplify a site" modal.
* Enter a well-formed URL for a site that can’t be reached (e.g. `https://this-domain-does-not-resolve-12345.com`), pick any analysis type, and click "Amplify it".
* The error notice should read "We couldn’t reach this site to analyze it. Make sure it’s online and publicly accessible, then try again."
* Trigger any other failure (e.g. block the request in devtools) and confirm the generic "Could not start the analysis. Please try again." notice still shows.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_019FYrW9P5FhmweCyohpKuKS
