### PR TITLE
Redirect legacy AI Site Builder entries to paid onboarding

### DIFF
--- a/client/landing/stepper/utils/flow-redirect-handler.ts
+++ b/client/landing/stepper/utils/flow-redirect-handler.ts
@@ -16,9 +16,7 @@ const AI_SITE_BUILDER_REDIRECT: RedirectRule = {
 	flow: AI_SITE_BUILDER_FLOW,
 	to: `/setup/${ AI_SITE_BUILDER_ONBOARDING_FLOW }`,
 	shouldRedirect: ( searchParams ) =>
-		! searchParams.has( 'siteId' ) &&
-		! searchParams.has( 'siteSlug' ) &&
-		searchParams.get( 'build_wow' ) !== '1',
+		! searchParams.has( 'siteId' ) && ! searchParams.has( 'siteSlug' ),
 	replace: true,
 };
 

--- a/client/landing/stepper/utils/flow-redirect-handler.ts
+++ b/client/landing/stepper/utils/flow-redirect-handler.ts
@@ -1,8 +1,29 @@
-import { BLOG_FLOW } from '@automattic/onboarding';
+import {
+	AI_SITE_BUILDER_FLOW,
+	AI_SITE_BUILDER_ONBOARDING_FLOW,
+	BLOG_FLOW,
+} from '@automattic/onboarding';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
-// Flows to redirect
-const REMOVED_TAILORED_FLOWS = [
+type RedirectRule = {
+	flow: string;
+	to: string;
+	shouldRedirect?: ( searchParams: URLSearchParams ) => boolean;
+	replace?: boolean;
+};
+
+const AI_SITE_BUILDER_REDIRECT: RedirectRule = {
+	flow: AI_SITE_BUILDER_FLOW,
+	to: `/setup/${ AI_SITE_BUILDER_ONBOARDING_FLOW }`,
+	shouldRedirect: ( searchParams ) =>
+		! searchParams.has( 'siteId' ) &&
+		! searchParams.has( 'siteSlug' ) &&
+		searchParams.get( 'build_wow' ) !== '1',
+	replace: true,
+};
+
+// Flows to redirect and treat as removed throughout Calypso.
+const REMOVED_TAILORED_FLOWS: RedirectRule[] = [
 	{ flow: 'ai-assembler', to: '/start:lang?' },
 	{ flow: BLOG_FLOW, to: '/start:lang?' },
 	{ flow: 'free', to: '/start/free:lang?' },
@@ -19,6 +40,8 @@ const REMOVED_TAILORED_FLOWS = [
 	{ flow: 'domain-upsell', to: '/setup/domain-and-plan' },
 ];
 
+const FLOW_REDIRECTS = [ AI_SITE_BUILDER_REDIRECT, ...REMOVED_TAILORED_FLOWS ];
+
 export const isRemovedFlow = ( flowToCheck: string ) =>
 	!! REMOVED_TAILORED_FLOWS.find( ( { flow } ) => flow === flowToCheck );
 
@@ -28,11 +51,14 @@ const langPattern = '(?:/([a-z]{2}(?:-[a-z]{2})?))?/?$';
 // Test against a location pathname and build a redirect URL
 const redirectPathIfNecessary = ( pathname: string, search: string ) => {
 	// Add trailing slash to pathname if not present
-	pathname = pathname.endsWith( '/' ) ? pathname : pathname + '/';
+	const normalizedPathname = pathname.endsWith( '/' ) ? pathname : pathname + '/';
+	const searchParams = new URLSearchParams( search );
 
 	// Find the matching redirect route
-	const route = REMOVED_TAILORED_FLOWS.find( ( { flow } ) =>
-		pathname.startsWith( `/setup/${ flow }/` )
+	const route = FLOW_REDIRECTS.find(
+		( { flow, shouldRedirect } ) =>
+			normalizedPathname.startsWith( `/setup/${ flow }/` ) &&
+			( shouldRedirect?.( searchParams ) ?? true )
 	);
 
 	// If no route is found we don't redirect and return false
@@ -41,7 +67,7 @@ const redirectPathIfNecessary = ( pathname: string, search: string ) => {
 	}
 
 	// Find the language code in the pathname if present
-	const [ , lang ] = pathname.match( langPattern ) ?? [];
+	const [ , lang ] = normalizedPathname.match( langPattern ) ?? [];
 
 	// Replace the ":lang?" placeholder in the "to" field with the matched language or empty string if not present
 	const redirectUrl = route.to.replace( ':lang?', lang ? `/${ lang }` : '' );
@@ -49,15 +75,40 @@ const redirectPathIfNecessary = ( pathname: string, search: string ) => {
 	// Construct the final URL with search parameters if present
 	const finalUrl = `${ redirectUrl }${ search }`;
 
-	// Track the redirect event
-	recordTracksEvent( 'calypso_tailored_flows_redirect', {
-		redirect_from_url: location.pathname + location.search,
-		redirect_to_url: finalUrl,
-		referrer: document.referrer,
-	} );
+	if ( route.flow === AI_SITE_BUILDER_FLOW ) {
+		const legacyStep =
+			normalizedPathname.slice( `/setup/${ AI_SITE_BUILDER_FLOW }/`.length ).split( '/' )[ 0 ] ||
+			'initial';
+
+		recordTracksEvent( 'calypso_ai_site_builder_legacy_redirect', {
+			from_flow: AI_SITE_BUILDER_FLOW,
+			to_flow: AI_SITE_BUILDER_ONBOARDING_FLOW,
+			legacy_step: legacyStep,
+			...( searchParams.get( 'ref' ) && { ref: searchParams.get( 'ref' ) } ),
+			...( searchParams.get( 'source' ) && { source: searchParams.get( 'source' ) } ),
+			has_prompt: searchParams.has( 'prompt' ),
+			has_spec_id: searchParams.has( 'spec_id' ),
+			has_create_garden_site: searchParams.has( 'create_garden_site' ),
+			...( ( searchParams.get( 'provision_target' ) ||
+				searchParams.get( 'early_provision_target' ) ) && {
+				provision_target:
+					searchParams.get( 'provision_target' ) || searchParams.get( 'early_provision_target' ),
+			} ),
+		} );
+	} else {
+		recordTracksEvent( 'calypso_tailored_flows_redirect', {
+			redirect_from_url: location.pathname + location.search,
+			redirect_to_url: finalUrl,
+			referrer: document.referrer,
+		} );
+	}
 
 	// Perform the actual redirection
-	window.location.href = finalUrl;
+	if ( route.replace ) {
+		window.location.replace( finalUrl );
+	} else {
+		window.location.href = finalUrl;
+	}
 
 	return true;
 };

--- a/client/landing/stepper/utils/flow-redirect-handler.ts
+++ b/client/landing/stepper/utils/flow-redirect-handler.ts
@@ -15,6 +15,7 @@ type RedirectRule = {
 const AI_SITE_BUILDER_REDIRECT: RedirectRule = {
 	flow: AI_SITE_BUILDER_FLOW,
 	to: `/setup/${ AI_SITE_BUILDER_ONBOARDING_FLOW }`,
+	// Existing free-trial sites still use the legacy domains and plans steps to upgrade and launch.
 	shouldRedirect: ( searchParams ) =>
 		! searchParams.has( 'siteId' ) && ! searchParams.has( 'siteSlug' ),
 	replace: true,

--- a/client/landing/stepper/utils/test/flow-redirect-handler.ts
+++ b/client/landing/stepper/utils/test/flow-redirect-handler.ts
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment jsdom
+ */
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import redirectPathIfNecessary, { isRemovedFlow } from '../flow-redirect-handler';
+
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+describe( 'flow redirect handler', () => {
+	const replace = jest.fn();
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		Object.defineProperty( window, 'location', {
+			value: { href: '', replace },
+			writable: true,
+		} );
+	} );
+
+	it( 'redirects the retired AI Site Builder flow to paid onboarding', () => {
+		const didRedirect = redirectPathIfNecessary(
+			'/setup/ai-site-builder',
+			'?prompt=Build+a+bakery&source=landing-page&ref=hero'
+		);
+
+		expect( didRedirect ).toBe( true );
+		expect( replace ).toHaveBeenCalledWith(
+			'/setup/ai-site-builder-onboarding?prompt=Build+a+bakery&source=landing-page&ref=hero'
+		);
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_ai_site_builder_legacy_redirect', {
+			from_flow: 'ai-site-builder',
+			to_flow: 'ai-site-builder-onboarding',
+			legacy_step: 'initial',
+			ref: 'hero',
+			source: 'landing-page',
+			has_prompt: true,
+			has_spec_id: false,
+			has_create_garden_site: false,
+		} );
+	} );
+
+	it( 'redirects stale spec and garden entry points while classifying them for tracking', () => {
+		redirectPathIfNecessary(
+			'/setup/ai-site-builder/create-site',
+			'?spec_id=spec-123&create_garden_site=1&provision_target=wpcom-atomic'
+		);
+
+		expect( replace ).toHaveBeenCalledWith(
+			'/setup/ai-site-builder-onboarding?spec_id=spec-123&create_garden_site=1&provision_target=wpcom-atomic'
+		);
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_ai_site_builder_legacy_redirect', {
+			from_flow: 'ai-site-builder',
+			to_flow: 'ai-site-builder-onboarding',
+			legacy_step: 'create-site',
+			has_prompt: false,
+			has_spec_id: true,
+			has_create_garden_site: true,
+			provision_target: 'wpcom-atomic',
+		} );
+	} );
+
+	it.each( [
+		[ 'site id', '?siteId=123&redirect=site-launch' ],
+		[ 'site slug', '?siteSlug=example.wordpress.com&redirect=site-launch' ],
+	] )( 'preserves the existing-site upgrade path identified by %s', ( _label, search ) => {
+		const didRedirect = redirectPathIfNecessary( '/setup/ai-site-builder/domains', search );
+
+		expect( didRedirect ).toBe( false );
+		expect( replace ).not.toHaveBeenCalled();
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not redirect an explicit build-wow request', () => {
+		const didRedirect = redirectPathIfNecessary(
+			'/setup/ai-site-builder',
+			'?build_wow=1&spec_id=spec-123'
+		);
+
+		expect( didRedirect ).toBe( false );
+		expect( replace ).not.toHaveBeenCalled();
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not match the separate AI Site Builder Spec flow', () => {
+		const didRedirect = redirectPathIfNecessary(
+			'/setup/ai-site-builder-spec/site-spec',
+			'?build_wow=1&siteId=123'
+		);
+
+		expect( didRedirect ).toBe( false );
+		expect( replace ).not.toHaveBeenCalled();
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not classify existing AI Site Builder sites as removed', () => {
+		expect( isRemovedFlow( 'ai-site-builder' ) ).toBe( false );
+	} );
+} );

--- a/client/landing/stepper/utils/test/flow-redirect-handler.ts
+++ b/client/landing/stepper/utils/test/flow-redirect-handler.ts
@@ -62,10 +62,19 @@ describe( 'flow redirect handler', () => {
 	} );
 
 	it.each( [
-		[ 'site id', '?siteId=123&redirect=site-launch' ],
-		[ 'site slug', '?siteSlug=example.wordpress.com&redirect=site-launch' ],
-	] )( 'preserves the existing-site upgrade path identified by %s', ( _label, search ) => {
-		const didRedirect = redirectPathIfNecessary( '/setup/ai-site-builder/domains', search );
+		[
+			'domains with a site id',
+			'/setup/ai-site-builder/domains',
+			'?siteId=123&redirect=site-launch',
+		],
+		[ 'plans with a site id', '/setup/ai-site-builder/plans', '?siteId=123&redirect=site-launch' ],
+		[
+			'plans with a site slug',
+			'/setup/ai-site-builder/plans',
+			'?siteSlug=example.wordpress.com&redirect=site-launch',
+		],
+	] )( 'preserves the existing-site upgrade path through %s', ( _label, pathname, search ) => {
+		const didRedirect = redirectPathIfNecessary( pathname, search );
 
 		expect( didRedirect ).toBe( false );
 		expect( replace ).not.toHaveBeenCalled();

--- a/client/landing/stepper/utils/test/flow-redirect-handler.ts
+++ b/client/landing/stepper/utils/test/flow-redirect-handler.ts
@@ -72,17 +72,6 @@ describe( 'flow redirect handler', () => {
 		expect( recordTracksEvent ).not.toHaveBeenCalled();
 	} );
 
-	it( 'does not redirect an explicit build-wow request', () => {
-		const didRedirect = redirectPathIfNecessary(
-			'/setup/ai-site-builder',
-			'?build_wow=1&spec_id=spec-123'
-		);
-
-		expect( didRedirect ).toBe( false );
-		expect( replace ).not.toHaveBeenCalled();
-		expect( recordTracksEvent ).not.toHaveBeenCalled();
-	} );
-
 	it( 'does not match the separate AI Site Builder Spec flow', () => {
 		const didRedirect = redirectPathIfNecessary(
 			'/setup/ai-site-builder-spec/site-spec',


### PR DESCRIPTION
Related to DOTPROD-155

## Proposed Changes

* Redirect legacy `/setup/ai-site-builder` entries to the paid `ai-site-builder-onboarding` flow while preserving the query string.
* Keep existing-site domain and plan upgrade requests on the legacy flow when they include `siteId` or `siteSlug`.
* Keep the separate `ai-site-builder-spec` generative-theme flow unchanged.
* Record `calypso_ai_site_builder_legacy_redirect` with source and request classification properties without recording prompt contents.
* Add focused tests for redirects, upgrade exemptions, tracking, the separate Site Spec route, and the existing-site removed-flow classification.

## Why are these changes being made?

* The free AI Site Builder trial is no longer supported, so new and stale legacy entries should use the paid onboarding flow. 
* Previously created trial sites can still purchase a domain or plan and launch, so requests carrying their existing-site identifier remain on the legacy upgrade path. 
* The generative-theme flow uses the separate `ai-site-builder-spec` route and is unaffected by this redirect.

## Testing Instructions

* Confirm `/setup/ai-site-builder?prompt=example` redirects to `/setup/ai-site-builder-onboarding?prompt=example`.
* Confirm that `&source` and `&ref` params also carry over. 
* Confirm `/setup/ai-site-builder/domains?siteId=123&redirect=site-launch` remains in the legacy flow.
* Confirm `/setup/ai-site-builder/plans?siteId=123&redirect=site-launch` remains in the legacy flow.
* Confirm `/setup/ai-site-builder-spec/site-spec?build_wow=1` is not redirected.

## Follow-ups

* Monitor `calypso_stepper_flow_start` for `flow=ai-site-builder`, `step` values of `domains` or `plans`, and an existing `site_id`.
* If this existing-site cohort remains active, move it to a dedicated upgrade flow. Once the cohort reaches zero, remove the legacy-flow exemption and remaining flow code.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
