### PR TITLE
Convert CancelAutoRenewalForm to use raw Purchase object

### DIFF
--- a/client/components/marketing-survey/cancel-auto-renewal-form/index.tsx
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/index.tsx
@@ -9,12 +9,12 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import enrichedSurveyData from 'calypso/components/marketing-survey/cancel-purchase-form/enriched-survey-data';
 import PrecancellationChatButton from 'calypso/components/marketing-survey/cancel-purchase-form/precancellation-chat-button';
 import { submitSurvey } from 'calypso/lib/purchases/actions';
-import type { Purchases } from '@automattic/data-stores';
+import type { Purchase } from '@automattic/api-core';
 
 import './style.scss';
 
 interface CancelAutoRenewalFormProps {
-	purchase: Purchases.Purchase;
+	purchase: Purchase;
 	selectedSiteId: number;
 	isVisible?: boolean;
 	onClose: () => void;
@@ -102,7 +102,12 @@ class CancelAutoRenewalForm extends Component<
 		this.props.submitSurvey(
 			'calypso-cancel-auto-renewal',
 			selectedSiteId,
-			enrichedSurveyData( surveyData, purchase )
+			enrichedSurveyData( surveyData, {
+				subscribedDate: purchase.subscribed_date,
+				blogCreatedDate: purchase.blog_created_date,
+				id: purchase.ID,
+				productSlug: purchase.product_slug,
+			} )
 		);
 
 		this.props.onClose();
@@ -153,7 +158,7 @@ class CancelAutoRenewalForm extends Component<
 				</DialogContent>
 				<DialogFooter>
 					<PrecancellationChatButton
-						purchase={ purchase.rawPurchase }
+						purchase={ purchase }
 						onClick={ onClose }
 						className="cancel-auto-renewal-form__chat-button"
 					/>

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.tsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.tsx
@@ -13,7 +13,6 @@ import { ConfirmDialog, DialogContent, DialogFooter } from 'calypso/components/c
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import CancelAutoRenewalForm from 'calypso/components/marketing-survey/cancel-auto-renewal-form';
 import { isAkismetHoldingSitePurchase } from 'calypso/dashboard/utils/purchase';
-import { createPurchaseObject } from 'calypso/lib/purchases/assembler';
 import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
 import { isExpiredAndInGracePeriod } from '../../../lib/raw-purchase-helpers';
 import type { Purchase } from '@automattic/api-core';
@@ -480,9 +479,7 @@ class AutoRenewDisablingDialog extends Component<
 
 		return (
 			<CancelAutoRenewalForm
-				// Temporary bridge (SHILL-2256): CancelAutoRenewalForm still expects the
-				// camelCase Purchase. Remove once the cancel survey reads the raw shape.
-				purchase={ createPurchaseObject( purchase ) }
+				purchase={ purchase }
 				selectedSiteId={ purchase.blog_id }
 				isVisible={ isVisible }
 				onClose={ this.closeAndCleanup }


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-2256/

## Proposed changes

Converts `CancelAutoRenewalForm` — the "Help us improve" survey shown after a user turns off auto-renew — to read the raw snake_case `Purchase` from `@automattic/api-core` instead of the assembled camelCase one from `@automattic/data-stores`. This removes the temporary bridge in `AutoRenewDisablingDialog`, which was assembling a camelCase object purely to hand it to this child.

* Change the `purchase` prop type on `CancelAutoRenewalForm` from `Purchases.Purchase` to the raw `Purchase`.
* Adapt the four fields `enrichedSurveyData` needs (`subscribed_date`, `blog_created_date`, `ID`, `product_slug`) at the call site, since that helper is still shared by five camelCase callers.
* Drop the `purchase.rawPurchase` unwrap when rendering `PrecancellationChatButton`, which already takes the raw shape.
* Remove the `createPurchaseObject` bridge and its import from `AutoRenewDisablingDialog`, whose `purchase` prop was already raw.

`isDomainRegistration` and `isPlan` need no change — both `@automattic/calypso-products` predicates already accept either shape.

## Why are these changes being made?

SHILL-2256 is removing the purchases assembler (`createPurchaseObject`/`createPurchasesArray`) so that consumers read the raw `Purchase` the API actually returns, rather than a duplicated camelCase type that has to be kept in sync by hand. The migration is incremental: each component that converts drops one temporary bridge, and the assembler can be deleted once the last consumer is gone.

`AutoRenewDisablingDialog` was migrated to raw in the earlier `manage-purchase` slice, but it still had to call `createPurchaseObject` on the way into `CancelAutoRenewalForm`. Converting the survey form removes the last thing standing between that dialog and a fully raw path. The form is a good next slice because it is small and has exactly one caller, so there is no risk of pushing new bridges into unrelated code.

The one wrinkle is `enrichedSurveyData`, which is still camelCase and shared with five other callers. Rather than convert it (and force five unrelated call sites into this PR), the field mapping happens at the one call site — the same approach already used in `CancelPurchaseForm`. The values are identical to what the assembler produced, so the survey payload is unchanged.

## Testing instructions

* Log in as a user with an auto-renewing plan or domain subscription.
* Go to `/me/purchases`, open a purchase with auto-renew enabled, and toggle auto-renew off.
* Work through the confirmation dialog until the "Help us improve" survey appears.
* Confirm the survey copy names the right product type — "plan" for a plan, "domain" for a domain registration, "subscription" otherwise.
* Pick an option and click Submit. Confirm the request to `/marketing/survey` succeeds and carries the expected `purchase` (product slug), `purchaseId`, `daysSincePurchase`, and `daysSinceSiteCreation` values.
* Confirm the "Get help" chat button still renders in the survey footer and opens with the correct site and product context.

