### PR TITLE
Convert ProductLink to use raw Purchase

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1306,14 +1306,7 @@ class ManagePurchase extends Component<
 
 				<span className="manage-purchase__settings-link">
 					{ ! isJetpackCloud() && site && (
-						// Temporary bridge (SHILL-2256): ProductLink still expects the
-						// camelCase Purchase. Remove once it reads the raw shape.
-						<ProductLink
-							purchase={ createPurchaseObject(
-								purchase as unknown as Parameters< typeof createPurchaseObject >[ 0 ]
-							) }
-							selectedSite={ site }
-						/>
+						<ProductLink purchase={ purchase } selectedSite={ site } />
 					) }
 				</span>
 

--- a/client/me/purchases/product-link/index.tsx
+++ b/client/me/purchases/product-link/index.tsx
@@ -3,7 +3,6 @@ import {
 	isGSuiteOrGoogleWorkspace,
 	isPlan,
 	isSiteRedirect,
-	isThemePurchase,
 	isTitanMail,
 } from '@automattic/calypso-products';
 import { type SiteDetails } from '@automattic/data-stores';
@@ -13,8 +12,10 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
 import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
 import { getThemeDetailsUrl } from 'calypso/state/themes/selectors';
-import type { Purchase } from 'calypso/lib/purchases/types';
+import type { Purchase } from '@automattic/api-core';
 import type { IAppState } from 'calypso/state/types';
+
+const isThemePurchase = ( purchase: Purchase ) => 'theme' === purchase.product_type;
 
 interface ProductLinkProps {
 	purchase: Purchase;
@@ -68,7 +69,7 @@ export default connect( ( state: IAppState, { purchase }: { purchase: Purchase }
 	if ( isThemePurchase( purchase ) ) {
 		return {
 			// No <QueryTheme /> component needed, since getThemeDetailsUrl() only needs the themeId which we pass here.
-			productUrl: getThemeDetailsUrl( state, purchase.meta as string, purchase.siteId ),
+			productUrl: getThemeDetailsUrl( state, purchase.meta as string, purchase.blog_id ),
 		};
 	}
 	return {};


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-2256/

## Proposed changes

Converts the `ProductLink` component — the "Plan Features" / "Domain Settings" / "Email Settings" / "Theme Details" link in the purchase detail header — to read the raw snake_case `Purchase` from `@automattic/api-core` instead of the assembled camelCase one. This removes the corresponding `createPurchaseObject` bridge from `ManagePurchase`.

* Switch the `purchase` prop and the `connect` mapping in `ProductLink` to the raw `Purchase` type.
* Replace `isThemePurchase` from `@automattic/calypso-products` with a one-line local predicate reading `product_type`, since the shared one only accepts camelCase `productType`.
* Read `purchase.blog_id` instead of `purchase.siteId` when building the theme details URL.
* Remove the temporary bridge in `manage-purchase/index.tsx`, which now passes its raw `purchase` straight through.

The other five predicates in the component (`isPlan`, `isDomainProduct`, `isSiteRedirect`, `isGSuiteOrGoogleWorkspace`, `isTitanMail`) already accept either shape and are untouched.

## Why are these changes being made?

SHILL-2256 is removing the purchases assembler (`createPurchaseObject`/`createPurchasesArray`) so consumers read the raw `Purchase` the API actually returns, rather than a duplicated camelCase type that has to be kept in sync by hand. The migration is incremental: `ManagePurchase` itself was converted earlier, but it still had to re-assemble a camelCase object for each child that had not yet moved. Each of those children that converts deletes one bridge, and the assembler can be removed once the last consumer is gone.

`ProductLink` is a good slice because it has exactly one caller and almost no coupling to the purchase shape — three field reads and a set of predicates that were already shape-agnostic.

The one wrinkle is `isThemePurchase`, which unlike its siblings in `@automattic/calypso-products` only accepts `{ productType: string }`. Widening it would touch every caller of a frozen, deprecated package, so this PR inlines the check instead — the same approach already taken for `hasIncludedDomain` in `PrecancellationChatButton`. The assembler defines `productType: purchase.product_type`, so the inlined predicate reads the identical field. Likewise `siteId: Number( purchase.blog_id )` in the assembler is a no-op given raw `blog_id` is already typed `number`, so the theme URL is unchanged.

## Testing instructions

TC:
```
yarn test-client --findRelatedTests client/me/purchases/product-link/index.tsx
```

No new tests — this is a type/shape conversion with no intended behavior change, covered by the existing `manage-purchase` suite above.

Manual testing:
* Log in as a user who owns a plan, a registered domain, an email subscription (Google Workspace or Titan), and a premium theme.
* Visit `/me/purchases` and open each of those purchases in turn.
* Confirm the settings link under the purchase title renders with the right label and destination for each: "Plan Features" → `/plans/:site`, "Domain Settings" → the domain management page, "Email Settings" → the email management page, "Theme Details" → the theme page.
* The theme case is the one most worth checking, since it is the field whose predicate changed — confirm the "Theme Details" link both appears and resolves to the correct theme for that site.
* Confirm no link renders when there is no selected site, and none renders in Jetpack Cloud.

