### PR TITLE
Reader Chat: Rename Reader Chat errors to Site Chat

### DIFF
--- a/packages/agents-manager/src/utils/__tests__/reader-chat-error-message.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/reader-chat-error-message.test.ts
@@ -9,23 +9,33 @@ describe( 'getReaderChatErrorMessage', () => {
 		expect( getReaderChatErrorMessage( null ) ).toBeNull();
 	} );
 
-	it( 'maps Search usage errors to stable Reader Chat copy', () => {
+	it( 'maps Search usage errors to stable Site Chat copy', () => {
 		expect( getReaderChatErrorMessage( { code: 'reader_chat_search_ai_over_limit' } ) ).toBe(
-			'Reader Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.'
+			'Site Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.'
 		);
 	} );
 
-	it( 'maps production Search usage message strings to stable Reader Chat copy', () => {
+	it( 'maps production Search usage message strings to stable Site Chat copy', () => {
 		expect(
 			getReaderChatErrorMessage(
 				'Reader Chat is temporarily unavailable because this site has reached its Jetpack Search AI usage limit.'
 			)
 		).toBe(
-			'Reader Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.'
+			'Site Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.'
 		);
 	} );
 
-	it( 'maps wrapped Search usage Error messages to stable Reader Chat copy', () => {
+	it( 'maps new production Search usage message strings to stable Site Chat copy', () => {
+		expect(
+			getReaderChatErrorMessage(
+				'Site Chat is temporarily unavailable because this site has reached its Jetpack Search AI usage limit.'
+			)
+		).toBe(
+			'Site Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.'
+		);
+	} );
+
+	it( 'maps wrapped Search usage Error messages to stable Site Chat copy', () => {
 		expect(
 			getReaderChatErrorMessage(
 				new Error(
@@ -33,36 +43,44 @@ describe( 'getReaderChatErrorMessage', () => {
 				)
 			)
 		).toBe(
-			'Reader Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.'
+			'Site Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.'
 		);
 	} );
 
-	it( 'maps JSON-encoded Search usage error codes to stable Reader Chat copy', () => {
+	it( 'maps JSON-encoded Search usage error codes to stable Site Chat copy', () => {
 		expect(
 			getReaderChatErrorMessage( new Error( '{"code":"reader_chat_search_over_limit"}' ) )
 		).toBe(
-			'Reader Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.'
+			'Site Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.'
 		);
 	} );
 
-	it( 'maps unavailable target errors to stable Reader Chat copy', () => {
+	it( 'maps unavailable target errors to stable Site Chat copy', () => {
 		expect(
 			getReaderChatErrorMessage( { data: { code: 'reader_chat_search_not_supported' } } )
-		).toBe( 'Reader Chat is not available for this site.' );
+		).toBe( 'Site Chat is not available for this site.' );
 	} );
 
-	it( 'maps JSON-encoded unavailable error codes to stable Reader Chat copy', () => {
+	it( 'maps JSON-encoded unavailable error codes to stable Site Chat copy', () => {
 		expect(
 			getReaderChatErrorMessage( new Error( '{"code":"reader_chat_search_not_supported"}' ) )
-		).toBe( 'Reader Chat is not available for this site.' );
+		).toBe( 'Site Chat is not available for this site.' );
 	} );
 
-	it( 'maps production unavailable message strings to stable Reader Chat copy', () => {
+	it( 'maps old production unavailable message strings to stable Site Chat copy', () => {
 		expect(
 			getReaderChatErrorMessage(
 				'Reader Chat is not available because Jetpack Search is not available for this site.'
 			)
-		).toBe( 'Reader Chat is not available for this site.' );
+		).toBe( 'Site Chat is not available for this site.' );
+	} );
+
+	it( 'maps new production unavailable message strings to stable Site Chat copy', () => {
+		expect(
+			getReaderChatErrorMessage(
+				'Site Chat is not available because Jetpack Search is not available for this site.'
+			)
+		).toBe( 'Site Chat is not available for this site.' );
 	} );
 
 	it( 'maps rate limit errors by status', () => {
@@ -111,13 +129,13 @@ describe( 'getReaderChatErrorMessage', () => {
 
 	it( 'uses generic copy for unknown string errors', () => {
 		expect( getReaderChatErrorMessage( 'Unexpected failure' ) ).toBe(
-			'Reader Chat is unavailable. Please try again later.'
+			'Site Chat is unavailable. Please try again later.'
 		);
 	} );
 
 	it( 'reads nested agentic error codes', () => {
 		expect( getReaderChatErrorMessage( { error: { code: 'jetpack_ai_usage' } } ) ).toBe(
-			'Reader Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.'
+			'Site Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.'
 		);
 	} );
 
@@ -130,7 +148,7 @@ describe( 'getReaderChatErrorMessage', () => {
 				},
 			} )
 		).toBe(
-			'Reader Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.'
+			'Site Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.'
 		);
 	} );
 } );

--- a/packages/agents-manager/src/utils/reader-chat-error-message.ts
+++ b/packages/agents-manager/src/utils/reader-chat-error-message.ts
@@ -124,7 +124,10 @@ function isUnavailableMessage( message: string | undefined ): boolean {
 	}
 
 	const normalizedMessage = message.toLowerCase();
-	return normalizedMessage.includes( 'reader chat is not available' );
+	return (
+		normalizedMessage.includes( 'reader chat is not available' ) ||
+		normalizedMessage.includes( 'site chat is not available' )
+	);
 }
 
 function isRateLimitMessage( message: string | undefined ): boolean {
@@ -169,7 +172,7 @@ export function getReaderChatErrorMessage( error: unknown ): string | null {
 	const hasSearchLimitMessage = isSearchLimitMessage( message );
 	if ( hasSearchLimitCode || hasSearchLimitMessage ) {
 		return __(
-			'Reader Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.',
+			'Site Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.',
 			__i18n_text_domain__
 		);
 	}
@@ -177,7 +180,7 @@ export function getReaderChatErrorMessage( error: unknown ): string | null {
 	const hasUnavailableCode = code && UNAVAILABLE_ERROR_CODES.has( code );
 	const hasUnavailableMessage = isUnavailableMessage( message );
 	if ( hasUnavailableCode || hasUnavailableMessage ) {
-		return __( 'Reader Chat is not available for this site.', __i18n_text_domain__ );
+		return __( 'Site Chat is not available for this site.', __i18n_text_domain__ );
 	}
 
 	if (
@@ -188,5 +191,5 @@ export function getReaderChatErrorMessage( error: unknown ): string | null {
 		return __( 'Too many requests. Please try again later.', __i18n_text_domain__ );
 	}
 
-	return __( 'Reader Chat is unavailable. Please try again later.', __i18n_text_domain__ );
+	return __( 'Site Chat is unavailable. Please try again later.', __i18n_text_domain__ );
 }


### PR DESCRIPTION
Part of the cross-repository Reader Chat to Site Chat naming update.

<img width="389" height="551" alt="Screenshot 2026-07-30 at 11 06 54" src="https://github.com/user-attachments/assets/c0216aef-317b-42f5-9e38-857ba9623bc3" />

Jetpack PR https://github.com/Automattic/jetpack/pull/50854

## Proposed Changes

* Rename the Agents Manager error messages shown to users from Reader Chat to Site Chat.
* Continue recognizing both old Reader Chat and new Site Chat backend error wording during a staggered deployment.
* Keep `reader_chat` error codes, routes, files, and function names unchanged for compatibility.

## Why are these changes being made?

* "Reader Chat" can be confused with the WordPress Reader product. "Site Chat" makes it clearer that the feature lets visitors ask questions about the current site.

## Testing Instructions

Automated checks run:

* `yarn jest -c test/packages/jest.config.js --testPathPattern=packages/agents-manager/src/utils/__tests__/reader-chat-error-message.test.ts --runInBand` — 20 tests passed.
* `yarn typecheck-packages` — passed.
* `yarn workspace @automattic/agents-manager build` — passed.
* `cd apps/agents-manager && yarn build` — the webpack build completed; the follow-up language fetch timed out against `widgets.wp.com`.

Manual review:

1. Run `yarn start`.
2. Load the Agents Manager Site Chat surface and trigger an unavailable-site, Search-limit, and generic error.
3. Confirm each visible error says Site Chat.
4. Repeat with a backend response that still says Reader Chat and confirm it maps to the new Site Chat copy.
5. Verify the branch bundle in Simple, Atomic, and self-hosted Jetpack sandbox environments before merge.

### Live sandbox UI verification

#### Jetpack Search usage limit

<img width="800" alt="Site Chat Jetpack Search usage-limit error rendered in the live sandbox test" src="https://gist.githubusercontent.com/kat3samsin/ea46b61c72218bda2abbd4abd001752f/raw/2ec00938145243ce38e6d9a309fbc4c6eabeabc7/site-chat-usage-limit-actual-test.png" />

#### Site Chat unavailable

<img width="800" alt="Site Chat unavailable error rendered in the live sandbox test" src="https://gist.githubusercontent.com/kat3samsin/ea46b61c72218bda2abbd4abd001752f/raw/2ec00938145243ce38e6d9a309fbc4c6eabeabc7/site-chat-not-available-actual-test.png" />

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
