### PR TITLE
Marketplace: activate the plugin on the component-driven Atomic transfer flow

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-thank-you-redirect.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-thank-you-redirect.tsx
@@ -67,15 +67,22 @@ describe( 'useThankYouRedirect', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockRecoveryProps = undefined;
-		mockFreshSite = undefined;
+		mockFreshSite = null;
 	} );
 
-	it( 'owns activation at every step except the step-driven effect window (currentStep 1)', () => {
-		render( { currentStep: 0 } );
+	it( 'owns activation only in the two recovery windows', () => {
+		// Checkout-initiated flow observes a background transfer from step 0.
+		render( { atomicFlow: false, currentStep: 0 } );
 		expect( mockRecoveryProps?.ownsActivation ).toBe( true );
-		render( { currentStep: 1 } );
+		render( { atomicFlow: false, currentStep: 2 } );
 		expect( mockRecoveryProps?.ownsActivation ).toBe( false );
-		render( { currentStep: 2 } );
+
+		// Component-driven transfer lands the plugin at step 2.
+		render( { atomicFlow: true, currentStep: 0 } );
+		expect( mockRecoveryProps?.ownsActivation ).toBe( false );
+		render( { atomicFlow: true, currentStep: 1 } );
+		expect( mockRecoveryProps?.ownsActivation ).toBe( false );
+		render( { atomicFlow: true, currentStep: 2 } );
 		expect( mockRecoveryProps?.ownsActivation ).toBe( true );
 	} );
 

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-thank-you-redirect.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-thank-you-redirect.tsx
@@ -1,0 +1,101 @@
+/**
+ * @jest-environment jsdom
+ */
+import { waitFor } from '@testing-library/react';
+import { transferStates } from 'calypso/state/automated-transfer/constants';
+import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
+import { useThankYouRedirect } from '../use-thank-you-redirect';
+
+// Capture what the recovery hook is wired with.
+let mockRecoveryProps:
+	| { enabled: boolean; canActivate: boolean; ownsActivation: boolean }
+	| undefined;
+jest.mock( '../use-post-transfer-plugin-recovery', () => ( {
+	usePostTransferPluginRecovery: ( props: typeof mockRecoveryProps ) => {
+		mockRecoveryProps = props;
+	},
+} ) );
+
+// Control the post-transfer site fetch.
+let mockFreshSite: unknown;
+jest.mock( '@automattic/api-queries', () => ( {
+	...jest.requireActual( '@automattic/api-queries' ),
+	siteByIdQuery: () => ( {
+		queryKey: [ 'tyr-site' ],
+		queryFn: () => Promise.resolve( mockFreshSite ),
+	} ),
+} ) );
+
+// canManagePlugins — the plan feature gate on the redirect.
+jest.mock( 'calypso/state/selectors/site-has-feature', () => () => true );
+
+// Capture the pre-redirect delay call instead of navigating.
+jest.mock( 'calypso/my-sites/marketplace/util', () => ( {
+	waitFor: jest.fn( () => new Promise( () => {} ) ),
+} ) );
+const { waitFor: navDelay } = jest.requireMock( 'calypso/my-sites/marketplace/util' );
+
+const ATOMIC_READY = {
+	ID: 1,
+	is_wpcom_atomic: true,
+	capabilities: { manage_options: true },
+	options: { admin_url: 'https://example.wpcomstaging.com/wp-admin/' },
+};
+
+type Props = Parameters< typeof useThankYouRedirect >[ 0 ];
+const baseProps: Props = {
+	siteId: 1,
+	selectedSite: { ID: 1 },
+	selectedSiteSlug: 'example.wordpress.com',
+	currentStep: 2,
+	isPluginUploadFlow: false,
+	pluginSlug: 'give',
+	themeSlug: '',
+	wpOrgTheme: null,
+	isThemeActive: false,
+	installedPlugin: { slug: 'give', id: 'give/give' },
+	pluginActive: false,
+	uploadedPluginSlug: '',
+	atomicFlow: true,
+	isAtomic: true,
+	automatedTransferStatus: transferStates.COMPLETE,
+};
+const render = ( overrides?: Partial< Props > ) =>
+	renderHookWithProvider( () => useThankYouRedirect( { ...baseProps, ...overrides } ) );
+
+describe( 'useThankYouRedirect', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockRecoveryProps = undefined;
+		mockFreshSite = undefined;
+	} );
+
+	it( 'owns activation at every step except the step-driven effect window (currentStep 1)', () => {
+		render( { currentStep: 0 } );
+		expect( mockRecoveryProps?.ownsActivation ).toBe( true );
+		render( { currentStep: 1 } );
+		expect( mockRecoveryProps?.ownsActivation ).toBe( false );
+		render( { currentStep: 2 } );
+		expect( mockRecoveryProps?.ownsActivation ).toBe( true );
+	} );
+
+	it( 'enables recovery for the component-driven atomic-transfer flow once the site is Atomic', async () => {
+		mockFreshSite = ATOMIC_READY;
+		render( { atomicFlow: true, pluginActive: false } );
+		await waitFor( () => expect( mockRecoveryProps?.enabled ).toBe( true ) );
+	} );
+
+	it( 'does not redirect after an atomic transfer while the plugin is still inactive', async () => {
+		mockFreshSite = ATOMIC_READY;
+		render( { atomicFlow: true, pluginActive: false } );
+		// Wait for the fresh site to resolve (readiness satisfied), so a premature redirect would fire.
+		await waitFor( () => expect( mockRecoveryProps?.canActivate ).toBe( true ) );
+		expect( navDelay ).not.toHaveBeenCalled();
+	} );
+
+	it( 'redirects once the plugin is active', async () => {
+		mockFreshSite = ATOMIC_READY;
+		render( { atomicFlow: true, pluginActive: true } );
+		await waitFor( () => expect( navDelay ).toHaveBeenCalled() );
+	} );
+} );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
@@ -78,12 +78,12 @@ export function useThankYouRedirect( {
 		siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS )
 	);
 
-	// A checkout-initiated plugin install (transfer + install happen during checkout, not here, so
-	// atomicFlow is never set) that has landed on an Atomic site — the case this recovers. It does NOT
-	// gate on wporgPlugin.wporg: wordpress.org answers 200 with an empty body for a marketplace-only
-	// slug, which the store normalizes to wporg: true, so that never holds for the plugins we recover.
-	const isRecoveryFlow =
-		! atomicFlow && ! isPluginUploadFlow && !! pluginSlug && !! freshSite?.is_wpcom_atomic;
+	// A plugin install that has landed on an Atomic site with the plugin possibly still inactive.
+	// Covers both the checkout-initiated flow (atomicFlow never set) and the flow where this component
+	// drives the transfer (atomicFlow set) — in both, the transfer can complete before the plugin is
+	// activated. It does NOT gate on wporgPlugin.wporg: wordpress.org answers 200 with an empty body
+	// for a marketplace-only slug, which the store normalizes to wporg: true, so that never holds.
+	const isRecoveryFlow = ! isPluginUploadFlow && !! pluginSlug && !! freshSite?.is_wpcom_atomic;
 
 	usePostTransferPluginRecovery( {
 		siteId,
@@ -91,8 +91,10 @@ export function useThankYouRedirect( {
 		// isAtomicTransferReady already requires manage_options, which the transfer propagates after
 		// is_wpcom_atomic flips; activating during that gap would fail and burn the retry budget.
 		canActivate: !! isAtomicTransferReady,
-		// The step-driven flow activates at currentStep 1, so this hook owns activation only at step 0.
-		ownsActivation: currentStep === 0,
+		// The step-driven effect only activates at currentStep 1, so this hook owns activation at every
+		// other step — including step 2 of the atomic-transfer flow, where the plugin lands after that
+		// effect's window and would otherwise never be activated.
+		ownsActivation: currentStep !== 1,
 		installedPlugin,
 	} );
 	// Check completition of all flows and redirect to thank you page
@@ -103,8 +105,10 @@ export function useThankYouRedirect( {
 			// - Install with the help of uploading archive of a plugins
 			// - If it's simple site which doesn't support plugins, then installing and activation happens at the same time with upgrading to Business plan
 			( installedPlugin && pluginActive ) ||
-			// Transfer to atomic using a marketplace plugin
+			// Transfer to atomic using a marketplace plugin — wait for the plugin to actually be active,
+			// not just for the transfer to complete, or we redirect with the plugin still inactive.
 			( atomicFlow &&
+				pluginActive &&
 				transferStates.COMPLETE === automatedTransferStatus &&
 				canManagePlugins &&
 				isAtomicTransferReady ) ||

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
@@ -91,10 +91,11 @@ export function useThankYouRedirect( {
 		// isAtomicTransferReady already requires manage_options, which the transfer propagates after
 		// is_wpcom_atomic flips; activating during that gap would fail and burn the retry budget.
 		canActivate: !! isAtomicTransferReady,
-		// The step-driven effect only activates at currentStep 1, so this hook owns activation at every
-		// other step — including step 2 of the atomic-transfer flow, where the plugin lands after that
-		// effect's window and would otherwise never be activated.
-		ownsActivation: currentStep !== 1,
+		// Two recovery windows: the checkout-initiated flow, which sits at step 0 while it observes a
+		// background transfer, and the component-driven transfer, whose plugin lands at step 2 after the
+		// step-driven effect's activation window (step 1). Leaving ordinary in-place installs to that
+		// effect avoids a redundant activation racing it at step 2.
+		ownsActivation: ( ! atomicFlow && currentStep === 0 ) || ( atomicFlow && currentStep === 2 ),
 		installedPlugin,
 	} );
 	// Check completition of all flows and redirect to thank you page
@@ -104,14 +105,10 @@ export function useThankYouRedirect( {
 			// - Click on "Install and activate" button for any plugin on /plugins/<site_name>
 			// - Install with the help of uploading archive of a plugins
 			// - If it's simple site which doesn't support plugins, then installing and activation happens at the same time with upgrading to Business plan
+			// This also covers the atomic-transfer flows (checkout-initiated and component-driven): the
+			// plugin only reads active once the transfer is far enough along, and for an atomicFlow the
+			// redirect URL below resolves only after the transfer completes, so no separate arm is needed.
 			( installedPlugin && pluginActive ) ||
-			// Transfer to atomic using a marketplace plugin — wait for the plugin to actually be active,
-			// not just for the transfer to complete, or we redirect with the plugin still inactive.
-			( atomicFlow &&
-				pluginActive &&
-				transferStates.COMPLETE === automatedTransferStatus &&
-				canManagePlugins &&
-				isAtomicTransferReady ) ||
 			// Transfer to atomic uploading a zip plugin
 			( uploadedPluginSlug &&
 				isPluginUploadFlow &&
@@ -131,7 +128,6 @@ export function useThankYouRedirect( {
 	}, [
 		pluginActive,
 		automatedTransferStatus,
-		atomicFlow,
 		isPluginUploadFlow,
 		isAtomic,
 		canManagePlugins,


### PR DESCRIPTION
Part of DOTCOM-17744

## Proposed Changes

* Activate a marketplace plugin that an Atomic transfer leaves installed-but-inactive on the flow where **this page itself initiates the transfer** (a free plugin that requires a plan, e.g. GiveWP).
* Hold the post-transfer redirect until the plugin is actually active, instead of redirecting the moment the transfer completes.

## Why are these changes being made?

An earlier fix (the checkout-initiated marketplace-only case) handled the path where the transfer is kicked off during checkout. But a free plugin that needs a plan takes the other path — this page drives the transfer itself — and that path was never covered: nothing activated the plugin, and the page redirected to wp-admin as soon as the transfer finished, so the user landed with the plugin installed but off (the original GiveWP report). This makes the post-transfer recovery run on that path too, and stops the redirect from firing before the plugin is active.

## Testing Instructions

1. On a free Simple site, open `/plugins/give/<site>` and click "Upgrade and activate".
2. Buy a plan (test card); the site transfers to Atomic.
3. Stay on the install screen. Once the transfer completes, the plugin should be **activated** and you should land on the wp-admin Plugins page with it active (not inactive/hidden).
4. Regression: the checkout-initiated marketplace flow (a paid marketplace-only plugin), a direct plugin install on an existing Business site, a zip upload, and a theme install should all behave as before.

Verified end-to-end on a live Simple → Atomic transfer: the plugin activates and the redirect lands on wp-admin with it active.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
