### PR TITLE
Marketplace: trim avoidable delay from the install flow

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-post-transfer-plugin-recovery.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-post-transfer-plugin-recovery.tsx
@@ -110,6 +110,16 @@ describe( 'usePostTransferPluginRecovery', () => {
 		expect( activatePlugin ).toHaveBeenCalledTimes( 3 );
 	} );
 
+	it( 'refreshes the plugin list right after activating, without waiting for the next poll', async () => {
+		render();
+		tick();
+		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
+		const pollFetches = fetchSitePlugins.mock.calls.length;
+		await settle();
+		expect( fetchSitePlugins.mock.calls.length ).toBeGreaterThan( pollFetches );
+		expect( fetchSitePlugins ).toHaveBeenLastCalledWith( 1 );
+	} );
+
 	it( 'does not activate when it does not own activation (the step-driven flow does)', () => {
 		render( { ownsActivation: false } );
 		tick();

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
@@ -163,7 +163,7 @@ describe( 'useProductInstall progression', () => {
 	} );
 	afterEach( () => jest.useRealTimers() );
 
-	it( 'installs in place, keeps the setup step visible, then activates on completion', async () => {
+	it( 'installs in place, advances to the install step, then activates on completion', async () => {
 		const { result, store } = renderProgress(
 			{ pluginSlug: 'give' },
 			{ ...marketplaceHandoff, ...jetpackSite }
@@ -177,10 +177,6 @@ describe( 'useProductInstall progression', () => {
 		);
 		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
 
-		expect( result.current.currentStep ).toBe( 0 );
-		await advance( 999 );
-		expect( result.current.currentStep ).toBe( 0 );
-		await advance( 1 );
 		expect( result.current.currentStep ).toBe( 1 );
 
 		await act( async () => {
@@ -193,7 +189,7 @@ describe( 'useProductInstall progression', () => {
 		expect( result.current.currentStep ).toBe( 2 );
 	} );
 
-	it( 'activates a plugin that finishes installing during the setup delay', async () => {
+	it( 'activates a plugin that is already present when the install step begins', async () => {
 		const { result, store } = renderProgress(
 			{ pluginSlug: 'give' },
 			{ ...marketplaceHandoff, ...jetpackSite }
@@ -204,7 +200,6 @@ describe( 'useProductInstall progression', () => {
 				receiveSitePlugins( SITE_ID, [ { slug: 'give', id: 'give/give', active: false } ] )
 			);
 		} );
-		await advance( 1000 );
 
 		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
 		expect( result.current.currentStep ).toBe( 2 );
@@ -255,8 +250,6 @@ describe( 'useProductInstall progression', () => {
 		);
 		expect( installPlugin ).not.toHaveBeenCalled();
 
-		expect( result.current.currentStep ).toBe( 0 );
-		await advance( 1000 );
 		expect( result.current.currentStep ).toBe( 1 );
 
 		// Production reports completion from polling first, and only then refreshes the site. The

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-thank-you-redirect.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-thank-you-redirect.tsx
@@ -29,11 +29,8 @@ jest.mock( '@automattic/api-queries', () => ( {
 // canManagePlugins — the plan feature gate on the redirect.
 jest.mock( 'calypso/state/selectors/site-has-feature', () => () => true );
 
-// Capture the pre-redirect delay call instead of navigating.
-jest.mock( 'calypso/my-sites/marketplace/util', () => ( {
-	waitFor: jest.fn( () => new Promise( () => {} ) ),
-} ) );
-const { waitFor: navDelay } = jest.requireMock( 'calypso/my-sites/marketplace/util' );
+const PLUGINS_URL =
+	'https://example.wpcomstaging.com/wp-admin/plugins.php?activate=true&plugin_status=active';
 
 const ATOMIC_READY = {
 	ID: 1,
@@ -64,10 +61,27 @@ const render = ( overrides?: Partial< Props > ) =>
 	renderHookWithProvider( () => useThankYouRedirect( { ...baseProps, ...overrides } ) );
 
 describe( 'useThankYouRedirect', () => {
+	// jsdom can't navigate, so stand in a plain location object and read back the href the hook sets.
+	let originalLocation: Location;
+
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockRecoveryProps = undefined;
 		mockFreshSite = null;
+		originalLocation = window.location;
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			writable: true,
+			value: { ...originalLocation, href: '' },
+		} );
+	} );
+
+	afterEach( () => {
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			writable: true,
+			value: originalLocation,
+		} );
 	} );
 
 	it( 'owns activation only in the two recovery windows', () => {
@@ -97,12 +111,12 @@ describe( 'useThankYouRedirect', () => {
 		render( { atomicFlow: true, pluginActive: false } );
 		// Wait for the fresh site to resolve (readiness satisfied), so a premature redirect would fire.
 		await waitFor( () => expect( mockRecoveryProps?.canActivate ).toBe( true ) );
-		expect( navDelay ).not.toHaveBeenCalled();
+		expect( window.location.href ).toBe( '' );
 	} );
 
 	it( 'redirects once the plugin is active', async () => {
 		mockFreshSite = ATOMIC_READY;
 		render( { atomicFlow: true, pluginActive: true } );
-		await waitFor( () => expect( navDelay ).toHaveBeenCalled() );
+		await waitFor( () => expect( window.location.href ).toBe( PLUGINS_URL ) );
 	} );
 } );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-post-transfer-plugin-recovery.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-post-transfer-plugin-recovery.ts
@@ -49,6 +49,9 @@ export function usePostTransferPluginRecovery( {
 				dispatch( activatePlugin( siteId, { slug: installedPlugin.slug, id: installedPlugin.id } ) )
 			).finally( () => {
 				inFlightRef.current = false;
+				// Refresh right away so the now-active plugin is observed immediately, rather than waiting
+				// for the next poll — the caller's redirect is gated on that active state.
+				dispatch( fetchSitePlugins( siteId ) );
 			} );
 		},
 		enabled ? POLL_INTERVAL_MS : null

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -4,7 +4,6 @@ import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useMemo, useRef } from 'react';
 import { useQueryTheme } from 'calypso/components/data/query-theme';
-import { waitFor } from 'calypso/my-sites/marketplace/util';
 import { useSelector, useDispatch } from 'calypso/state';
 import { initiateAtomicTransfer } from 'calypso/state/atomic/transfers/actions';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
@@ -201,11 +200,6 @@ export function useProductInstall( {
 		}
 
 		installFlowInitiatedRef.current = true;
-		// Intentionally uncancelable: the ref blocks re-entry, so tying this to the effect's
-		// lifetime would let a dependency change drop the step advance rather than reschedule it.
-		const triggerInstallFlow = () => {
-			waitFor( 1 ).then( () => setCurrentStep( 1 ) );
-		};
 
 		if ( installStrategy === 'in-place' ) {
 			if ( wpOrgTheme ) {
@@ -219,7 +213,7 @@ export function useProductInstall( {
 			setAtomicFlow( true );
 			dispatch( initiateTransfer( siteId, null, pluginSlug, '', 'plugin_install' ) );
 		}
-		triggerInstallFlow();
+		setCurrentStep( 1 );
 	}, [
 		marketplaceInstallationInProgress,
 		directInstallationAllowed,

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
@@ -5,7 +5,6 @@ import { useQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { isAtomicTransferredSite } from 'calypso/dashboard/utils/site-atomic-transfers';
 import { useInterval } from 'calypso/lib/interval';
-import { waitFor } from 'calypso/my-sites/marketplace/util';
 import { useSelector, useDispatch } from 'calypso/state';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -121,9 +120,7 @@ export function useThankYouRedirect( {
 			if ( ! pluginsUrlFinal ) {
 				return;
 			}
-			waitFor( 1 ).then( () => {
-				window.location.href = pluginsUrlFinal as string;
-			} );
+			window.location.href = pluginsUrlFinal as string;
 		}
 	}, [
 		pluginActive,
@@ -140,10 +137,8 @@ export function useThankYouRedirect( {
 	// Validate theme is already active
 	useEffect( () => {
 		if ( themeSlug && wpOrgTheme && isThemeActive ) {
-			waitFor( 1 ).then( () =>
-				page.redirect(
-					`/marketplace/thank-you/${ selectedSiteSlug }?themes=${ themeSlug }&hide-progress-bar`
-				)
+			page.redirect(
+				`/marketplace/thank-you/${ selectedSiteSlug }?themes=${ themeSlug }&hide-progress-bar`
 			);
 		}
 	}, [ themeSlug, wpOrgTheme, isThemeActive, selectedSiteSlug ] );


### PR DESCRIPTION
## Proposed Changes

* Remove two ~1s timed holds from the marketplace install screen — one before advancing into the install step, one before the final redirect — so the flow doesn't pad itself with waits after the work is already done.
* Refresh the plugin list immediately after the post-transfer recovery activates a plugin, instead of waiting for the next poll to notice it went active.

## Why are these changes being made?

The install screen spent user-visible time waiting on timers that weren't gating anything real. Two fixed 1s delays sat in front of a step advance and the destination redirect, and after the recovery hook activated a plugin the redirect could wait up to a full poll interval for the active state to be observed. Together that's several seconds of avoidable waiting at the end of the flow. The deliberate holds that exist to prevent false-error flashes, and the backend transfer-readiness wait, are intentionally left as-is.

## Testing Instructions

1. Install a plugin that triggers an Atomic transfer (a free plugin that needs a plan, e.g. GiveWP) on a Simple site, and a marketplace-only paid plugin.
2. Confirm the flow still installs, activates, and lands on the destination — just sooner, with no lingering pauses once each step is actually complete.
3. Watch the progress screen through the transition and confirm it still reads as "finishing" rather than jumping abruptly.
4. Regression: a direct plugin install on a Business site, a zip upload, and a theme install should all still complete and redirect correctly.

Unit tests cover the immediate post-activation refresh and the removal of the pre-redirect delay. The progress-screen feel across the final transition is worth an eyeball on a live transfer before this leaves draft.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
