### PR TITLE
A4A: use the primary color for secondary-button borders

### DIFF
--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -90,12 +90,6 @@
 	--a4a-brand-blue-80: #12304a;
 }
 
-/* 37.0.0 draws the secondary border with `border-color`; A4A buttons are borderless by
- * design, so turn it off. Buttons that want an outline still draw their own box-shadow. */
-:where(.components-button.is-secondary:not(.is-destructive)) {
-	border-color: transparent !important;
-}
-
 .theme-a8c-for-agencies {
 
 	.components-button:not( .dataviews-view-table-header-button ):not( .components-navigator-back-button ),

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -86,6 +86,17 @@
 
 /* A4A */
 .theme-a8c-for-agencies {
+	// 37.0.0's design tokens hardcode the stock blue for the wpds brand and focus colors,
+	// bypassing their --wp-admin-theme-color fallbacks; point them at the A4A primary.
+	--wpds-color-stroke-focus: var(--color-primary);
+	--wpds-color-foreground-interactive-brand: var(--color-primary);
+	--wpds-color-foreground-interactive-brand-active: var(--color-primary-70);
+	--wpds-color-stroke-interactive-brand: var(--color-primary);
+	--wpds-color-stroke-interactive-brand-active: var(--color-primary-70);
+	--wpds-color-background-interactive-brand-weak-active: var(--color-primary-0);
+	--wpds-color-background-interactive-brand-strong: var(--color-primary);
+	--wpds-color-background-interactive-brand-strong-active: var(--color-primary-70);
+
 	.components-button:not(.is-destructive) {
 		--wp-components-color-accent: var(--color-primary);
 		--wp-components-color-accent-darker-10: var(--color-primary-60);

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -92,11 +92,11 @@
 		--wp-components-color-accent-darker-20: var(--color-primary-60);
 	}
 
-	// A4A secondary buttons keep a subtle neutral border. 37.0.0's border-color is forced off
-	// by the Calypso override and reinstated as a box-shadow; restore the neutral border here
+	// A4A secondary buttons keep a primary border. 37.0.0's border-color is forced off
+	// by the Calypso override and reinstated as a box-shadow; restore the border here
 	// and drop the box-shadow. Buttons with their own outline keep it (higher specificity).
-	:where(.components-button.is-secondary:not(.is-destructive)) {
-		border-color: var(--color-accent-5) !important;
+	:where(.components-button.is-secondary:not(.is-destructive):not(:disabled)) {
+		border-color: var(--color-primary) !important;
 		box-shadow: none;
 	}
 }
@@ -243,7 +243,7 @@
 /* 37.0.0 draws the secondary border with `border-color` instead of the inset box-shadow
  * Calypso and several packages still use, so it leaks as a stray accent outline. Turn it
  * off and keep the box-shadow as the border. Destructive buttons keep their red border. */
-:where(.components-button.is-secondary:not(.is-destructive)) {
+:where(.components-button.is-secondary:not(.is-destructive):not(:disabled)) {
 	border-color: transparent !important;
 	box-shadow: inset 0 0 0 1px var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
 }


### PR DESCRIPTION
Follow-up to #113009 and #113014.

## Proposed Changes

* Secondary buttons in Automattic for Agencies now show a primary-colored (blue) border instead of the light gray one introduced in #113014.
* Disabled secondary buttons no longer get the active border treatment — they fall back to the component library’s own disabled styling. This applies both in Automattic for Agencies and across Calypso.
* Removed a leftover button rule in the Automattic for Agencies stylesheet that a later, more specific rule from #113014 had already fully superseded.

## Why are these changes being made?

* Before the `@wordpress/components` 37 bump, secondary buttons in Automattic for Agencies had a primary-colored border. The fallout fix in #113014 restored a border but picked a neutral gray, which changed how these buttons look. This brings back the original appearance.
* Disabled buttons should look disabled — keeping the regular border on them made them look actionable.

| Before | After |
|--------|--------|
| <img width="859" height="54" alt="Screenshot 2026-07-28 at 11 53 45 AM" src="https://github.com/user-attachments/assets/5b8f659c-2025-4679-8687-7c55873b6e5b" /> | <img width="855" height="55" alt="Screenshot 2026-07-28 at 11 53 50 AM" src="https://github.com/user-attachments/assets/2945e879-ff20-4f05-a3c6-bec4980c08f1" /> | 

Focus colors on A4A should be primary color on A4A:

<img width="355" height="236" alt="Screenshot 2026-07-28 at 11 55 58 AM" src="https://github.com/user-attachments/assets/3c9b7bcf-60eb-4e1f-99a9-1f142e6674cc" />

<img width="891" height="212" alt="Screenshot 2026-07-28 at 11 56 06 AM" src="https://github.com/user-attachments/assets/5c5df7d9-5f5f-4e96-82e4-37c365eb3b2f" />

Dataviews:

<img width="339" height="434" alt="Screenshot 2026-07-28 at 12 04 34 PM" src="https://github.com/user-attachments/assets/c0daf41f-d9f9-4611-9cdc-5dfd31a2b2d2" />

<img width="281" height="149" alt="Screenshot 2026-07-28 at 12 05 07 PM" src="https://github.com/user-attachments/assets/d33532ab-cff4-461d-8361-dfc201a770e6" />


## Testing Instructions

* Open the “Automattic for Agencies Live” link from this PR.
* Browse pages with secondary buttons (for example, Overview or Marketplace) and confirm they show a blue border.
* Confirm disabled secondary buttons use the default muted disabled styling, without the blue border.
* Open the “Calypso Live” link and confirm secondary buttons elsewhere are unchanged, and disabled ones use the default disabled styling.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)