### PR TITLE
Omnibar: add a command palette entry point to the interim masterbar

### DIFF
--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -42,7 +42,7 @@ boot( {
 			apps: true,
 		},
 		plugins: true,
-		commandPalette: false,
+		commandPalette: true,
 		domainOnlySites: true,
 		siteOverview: {
 			preview: false,

--- a/client/dashboard/app/boot.tsx
+++ b/client/dashboard/app/boot.tsx
@@ -45,7 +45,7 @@ function boot( config: AppConfig ) {
 		import( './omnibar' ).then( ( m ) => m.default() ).catch( captureException );
 	} else {
 		import( './interim-omnibar' )
-			.then( ( m ) => m.default( omnibarEvents ) )
+			.then( ( m ) => m.default( omnibarEvents, config.supports.commandPalette ) )
 			.catch( captureException );
 	}
 

--- a/client/dashboard/app/boot.tsx
+++ b/client/dashboard/app/boot.tsx
@@ -45,7 +45,7 @@ function boot( config: AppConfig ) {
 		import( './omnibar' ).then( ( m ) => m.default() ).catch( captureException );
 	} else {
 		import( './interim-omnibar' )
-			.then( ( m ) => m.default( omnibarEvents, config.supports.commandPalette ) )
+			.then( ( m ) => m.default( omnibarEvents, config ) )
 			.catch( captureException );
 	}
 

--- a/client/dashboard/app/command-palette/commands.tsx
+++ b/client/dashboard/app/command-palette/commands.tsx
@@ -1,8 +1,21 @@
 import { useRouter } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
-import { globe, commentAuthorAvatar, envelope, bell, wordpress } from '@wordpress/icons';
+import {
+	globe,
+	commentAuthorAvatar,
+	envelope,
+	bell,
+	wordpress,
+	plugins,
+	cog,
+	payment,
+	receipt,
+	lock,
+} from '@wordpress/icons';
 import { useAppContext } from '../context';
 import type { AppConfig } from '../context';
+
+type Supports = AppConfig[ 'supports' ];
 
 export interface Command {
 	name: string;
@@ -10,8 +23,9 @@ export interface Command {
 	searchLabel: string;
 	path: string;
 	icon: React.ReactNode;
-	// Optional feature flag that controls when command is available
-	feature?: keyof AppConfig[ 'supports' ];
+	// Optional predicate that controls when the command is available, based on
+	// the app's supported features. Omit to always show the command.
+	isEnabled?: ( supports: Supports ) => boolean;
 }
 
 export const navigationCommands: Command[] = [
@@ -21,15 +35,7 @@ export const navigationCommands: Command[] = [
 		searchLabel: __( 'Navigate to Sites dashboard Sites page' ),
 		path: '/sites',
 		icon: wordpress,
-		feature: 'sites',
-	},
-	{
-		name: 'dashboard-go-to-emails',
-		label: __( 'Go to Emails' ),
-		searchLabel: __( 'Navigate to Email management Email inbox' ),
-		path: '/emails',
-		icon: envelope,
-		feature: 'emails',
+		isEnabled: ( supports ) => supports.sites,
 	},
 	{
 		name: 'dashboard-go-to-domains',
@@ -37,7 +43,23 @@ export const navigationCommands: Command[] = [
 		searchLabel: __( 'Navigate to Domain management Domains list' ),
 		path: '/domains',
 		icon: globe,
-		feature: 'domains',
+		isEnabled: ( supports ) => supports.domains,
+	},
+	{
+		name: 'dashboard-go-to-emails',
+		label: __( 'Go to Emails' ),
+		searchLabel: __( 'Navigate to Email management Email inbox' ),
+		path: '/emails',
+		icon: envelope,
+		isEnabled: ( supports ) => supports.emails,
+	},
+	{
+		name: 'dashboard-go-to-plugins',
+		label: __( 'Go to Plugins' ),
+		searchLabel: __( 'Navigate to Plugins management install plugins' ),
+		path: '/plugins',
+		icon: plugins,
+		isEnabled: ( supports ) => supports.plugins,
 	},
 	{
 		name: 'dashboard-go-to-account',
@@ -45,7 +67,39 @@ export const navigationCommands: Command[] = [
 		searchLabel: __( 'Navigate to User account profile settings' ),
 		path: '/me/account',
 		icon: commentAuthorAvatar,
-		feature: 'me',
+		isEnabled: ( supports ) => !! supports.me,
+	},
+	{
+		name: 'dashboard-go-to-preferences',
+		label: __( 'Go to Preferences' ),
+		searchLabel: __( 'Navigate to account preferences settings appearance language' ),
+		path: '/me/preferences',
+		icon: cog,
+		isEnabled: ( supports ) => !! supports.me,
+	},
+	{
+		name: 'dashboard-go-to-billing',
+		label: __( 'Go to Billing' ),
+		searchLabel: __( 'Navigate to billing payment methods active subscriptions' ),
+		path: '/me/billing',
+		icon: payment,
+		isEnabled: ( supports ) => !! ( supports.me && supports.me.billing ),
+	},
+	{
+		name: 'dashboard-go-to-purchases',
+		label: __( 'Go to Purchases' ),
+		searchLabel: __( 'Navigate to purchases receipts billing history' ),
+		path: '/me/billing/purchases',
+		icon: receipt,
+		isEnabled: ( supports ) => !! ( supports.me && supports.me.billing ),
+	},
+	{
+		name: 'dashboard-go-to-security',
+		label: __( 'Go to Security' ),
+		searchLabel: __( 'Navigate to account security password two-step authentication' ),
+		path: '/me/security',
+		icon: lock,
+		isEnabled: ( supports ) => !! ( supports.me && supports.me.security ),
 	},
 	{
 		name: 'dashboard-go-to-notifications',
@@ -53,7 +107,7 @@ export const navigationCommands: Command[] = [
 		searchLabel: __( 'Check your WordPress notifications alerts' ),
 		path: '/me/notifications',
 		icon: bell,
-		feature: 'notifications',
+		isEnabled: ( supports ) => supports.notifications,
 	},
 ];
 
@@ -64,13 +118,10 @@ export function useNavigationCommandLoader() {
 	const router = useRouter();
 	const { supports } = useAppContext();
 
-	// Filter commands based on feature flags from app context
-	const enabledCommands = navigationCommands.filter( ( cmd ) => {
-		if ( ! cmd.feature ) {
-			return true;
-		}
-		return supports[ cmd.feature ];
-	} );
+	// Filter commands based on the app's supported features.
+	const enabledCommands = navigationCommands.filter(
+		( cmd ) => ! cmd.isEnabled || cmd.isEnabled( supports )
+	);
 
 	return {
 		commands: enabledCommands.map( ( cmd ) => ( {

--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -51,10 +51,10 @@ export default async function loadOmnibar( events: OmnibarEvents, config: AppCon
 
 	hydrateRoot(
 		container,
-		<I18NContext.Provider value={ i18n }>
-			<AppProvider config={ config }>
+		<AppProvider config={ config }>
+			<I18NContext.Provider value={ i18n }>
 				<InterimOmnibarContainer initialUser={ window.currentUser ?? null } events={ events } />
-			</AppProvider>
-		</I18NContext.Provider>
+			</I18NContext.Provider>
+		</AppProvider>
 	);
 }

--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -2,10 +2,12 @@ import { isSupportSession } from '@automattic/calypso-support-session';
 // eslint-disable-next-line no-restricted-imports
 import { I18N, I18NContext } from 'i18n-calypso';
 import { hydrateRoot } from 'react-dom/client';
+import { AppProvider } from '../context';
 import { getUserLanguage, loadUserLocaleData } from '../shared-locale-loader';
+import type { AppConfig } from '../context';
 import type { OmnibarEvents } from '../omnibar/events';
 
-export default async function loadOmnibar( events: OmnibarEvents, showCommandPalette = false ) {
+export default async function loadOmnibar( events: OmnibarEvents, config: AppConfig ) {
 	const container = document.getElementById( 'wpcom-omnibar' );
 	if ( ! container ) {
 		return;
@@ -50,11 +52,9 @@ export default async function loadOmnibar( events: OmnibarEvents, showCommandPal
 	hydrateRoot(
 		container,
 		<I18NContext.Provider value={ i18n }>
-			<InterimOmnibarContainer
-				initialUser={ window.currentUser ?? null }
-				events={ events }
-				showCommandPalette={ showCommandPalette }
-			/>
+			<AppProvider config={ config }>
+				<InterimOmnibarContainer initialUser={ window.currentUser ?? null } events={ events } />
+			</AppProvider>
 		</I18NContext.Provider>
 	);
 }

--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -5,7 +5,7 @@ import { hydrateRoot } from 'react-dom/client';
 import { getUserLanguage, loadUserLocaleData } from '../shared-locale-loader';
 import type { OmnibarEvents } from '../omnibar/events';
 
-export default async function loadOmnibar( events: OmnibarEvents ) {
+export default async function loadOmnibar( events: OmnibarEvents, showCommandPalette = false ) {
 	const container = document.getElementById( 'wpcom-omnibar' );
 	if ( ! container ) {
 		return;
@@ -50,7 +50,11 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 	hydrateRoot(
 		container,
 		<I18NContext.Provider value={ i18n }>
-			<InterimOmnibarContainer initialUser={ window.currentUser ?? null } events={ events } />
+			<InterimOmnibarContainer
+				initialUser={ window.currentUser ?? null }
+				events={ events }
+				showCommandPalette={ showCommandPalette }
+			/>
 		</I18NContext.Provider>
 	);
 }

--- a/client/dashboard/app/interim-omnibar/interim-omnibar-container.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar-container.tsx
@@ -2,6 +2,7 @@ import { omnibarSiteIdQuery, queryClient, siteByIdQuery } from '@automattic/api-
 import { useQuery } from '@tanstack/react-query';
 import { useCallback, useEffect, useState } from 'react';
 import { AUTH_QUERY_KEY, initializeCurrentUser } from '../auth';
+import { useAppContext } from '../context';
 import { InterimOmnibar } from './interim-omnibar';
 import type { OmnibarEvents } from '../omnibar/events';
 import type { Site, User } from '@automattic/api-core';
@@ -9,7 +10,6 @@ import type { Site, User } from '@automattic/api-core';
 interface InterimOmnibarContainerProps {
 	initialUser: User | null;
 	events: OmnibarEvents;
-	showCommandPalette?: boolean;
 }
 
 interface InterimOmnibarData {
@@ -18,6 +18,7 @@ interface InterimOmnibarData {
 	currentRoute: string;
 	onToggleMenu?: () => void;
 	onToggleNotifications?: () => void;
+	showCommandPalette: boolean;
 }
 
 /**
@@ -30,6 +31,7 @@ function useInterimOmnibarData( {
 	initialUser,
 	events,
 }: InterimOmnibarContainerProps ): InterimOmnibarData {
+	const { supports } = useAppContext();
 	const [ hydrated, setHydrated ] = useState( false );
 	useEffect( () => {
 		setHydrated( true );
@@ -71,6 +73,9 @@ function useInterimOmnibarData( {
 			currentRoute: window.location.pathname,
 			onToggleMenu,
 			onToggleNotifications,
+			// Kept out of the SSR-mirroring render so the first client render matches
+			// the server (which doesn't render the button); it appears post-hydration.
+			showCommandPalette: false,
 		};
 	}
 
@@ -80,10 +85,11 @@ function useInterimOmnibarData( {
 		currentRoute: window.location.pathname,
 		onToggleMenu,
 		onToggleNotifications,
+		showCommandPalette: supports.commandPalette,
 	};
 }
 
 export function InterimOmnibarContainer( props: InterimOmnibarContainerProps ) {
 	const data = useInterimOmnibarData( props );
-	return <InterimOmnibar { ...data } showCommandPalette={ props.showCommandPalette } />;
+	return <InterimOmnibar { ...data } />;
 }

--- a/client/dashboard/app/interim-omnibar/interim-omnibar-container.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar-container.tsx
@@ -9,6 +9,7 @@ import type { Site, User } from '@automattic/api-core';
 interface InterimOmnibarContainerProps {
 	initialUser: User | null;
 	events: OmnibarEvents;
+	showCommandPalette?: boolean;
 }
 
 interface InterimOmnibarData {
@@ -84,5 +85,5 @@ function useInterimOmnibarData( {
 
 export function InterimOmnibarContainer( props: InterimOmnibarContainerProps ) {
 	const data = useInterimOmnibarData( props );
-	return <InterimOmnibar { ...data } />;
+	return <InterimOmnibar { ...data } showCommandPalette={ props.showCommandPalette } />;
 }

--- a/client/dashboard/app/interim-omnibar/interim-omnibar-container.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar-container.tsx
@@ -18,7 +18,7 @@ interface InterimOmnibarData {
 	currentRoute: string;
 	onToggleMenu?: () => void;
 	onToggleNotifications?: () => void;
-	showCommandPalette: boolean;
+	commandPalette: boolean;
 }
 
 /**
@@ -75,7 +75,7 @@ function useInterimOmnibarData( {
 			onToggleNotifications,
 			// Kept out of the SSR-mirroring render so the first client render matches
 			// the server (which doesn't render the button); it appears post-hydration.
-			showCommandPalette: false,
+			commandPalette: false,
 		};
 	}
 
@@ -85,7 +85,7 @@ function useInterimOmnibarData( {
 		currentRoute: window.location.pathname,
 		onToggleMenu,
 		onToggleNotifications,
-		showCommandPalette: supports.commandPalette,
+		commandPalette: supports.commandPalette,
 	};
 }
 

--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -47,6 +47,7 @@ interface Props {
 	currentRoute: string;
 	onToggleMenu?: () => void;
 	onToggleNotifications?: () => void;
+	showCommandPalette?: boolean;
 }
 
 export function InterimOmnibar( {
@@ -55,6 +56,7 @@ export function InterimOmnibar( {
 	currentRoute,
 	onToggleMenu,
 	onToggleNotifications,
+	showCommandPalette,
 }: Props ) {
 	const user = userProp ?? emptyUser;
 	const siteId = site?.ID ?? null;
@@ -192,6 +194,7 @@ export function InterimOmnibar( {
 					isCheckoutFailed={ false }
 					loadHelpCenterIcon
 					loadAgentsManager
+					showCommandPalette={ showCommandPalette }
 					isGlobalSidebarVisible={ false }
 					isGravatarDomain={ false }
 					dashboardOptIn

--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -47,7 +47,7 @@ interface Props {
 	currentRoute: string;
 	onToggleMenu?: () => void;
 	onToggleNotifications?: () => void;
-	showCommandPalette?: boolean;
+	commandPalette?: boolean;
 }
 
 export function InterimOmnibar( {
@@ -56,7 +56,7 @@ export function InterimOmnibar( {
 	currentRoute,
 	onToggleMenu,
 	onToggleNotifications,
-	showCommandPalette,
+	commandPalette,
 }: Props ) {
 	const user = userProp ?? emptyUser;
 	const siteId = site?.ID ?? null;
@@ -194,7 +194,7 @@ export function InterimOmnibar( {
 					isCheckoutFailed={ false }
 					loadHelpCenterIcon
 					loadAgentsManager
-					showCommandPalette={ showCommandPalette }
+					commandPalette={ commandPalette }
 					isGlobalSidebarVisible={ false }
 					isGravatarDomain={ false }
 					dashboardOptIn

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -191,7 +191,6 @@ class Document extends Component {
 									user={ user || null }
 									site={ null }
 									currentRoute={ this.props.path ?? '/' }
-									showCommandPalette={ sectionName === DOTCOM_DASHBOARD_SECTION_DEFINITION.name }
 								/>
 							</I18NContext.Provider>
 						</div>

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -191,6 +191,7 @@ class Document extends Component {
 									user={ user || null }
 									site={ null }
 									currentRoute={ this.props.path ?? '/' }
+									showCommandPalette={ sectionName === DOTCOM_DASHBOARD_SECTION_DEFINITION.name }
 								/>
 							</I18NContext.Provider>
 						</div>

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -3,11 +3,11 @@ import config from '@automattic/calypso-config';
 import { isEcommercePlan } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { Badge } from '@automattic/ui';
-import clsx from 'clsx';
 // @ts-expect-error The commands package is not yet typed.
 import { store as commandsStore } from '@wordpress/commands';
 import { dispatch } from '@wordpress/data';
 import { displayShortcut } from '@wordpress/keycodes';
+import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { parse } from 'qs';
@@ -122,7 +122,7 @@ class MasterbarLoggedIn extends Component {
 		useUnifiedAgent: PropTypes.bool,
 		launchButton: PropTypes.node,
 		sitePlanUrl: PropTypes.string,
-		showCommandPalette: PropTypes.bool,
+		commandPalette: PropTypes.bool,
 	};
 
 	state = { mounted: false };
@@ -1058,7 +1058,7 @@ class MasterbarLoggedIn extends Component {
 					{ this.renderSidebarMobileMenu() }
 					{ this.renderMySites() }
 					{ this.renderSiteMenu() }
-					{ this.props.showCommandPalette && this.renderCommandPalette() }
+					{ this.props.commandPalette && this.renderCommandPalette() }
 					{ this.renderUpdatesMenu() }
 					{ this.renderCommentsMenu() }
 					{ this.renderSiteActionMenu() }

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -7,7 +7,7 @@ import clsx from 'clsx';
 // @ts-expect-error The commands package is not yet typed.
 import { store as commandsStore } from '@wordpress/commands';
 import { dispatch } from '@wordpress/data';
-import { Icon, search } from '@wordpress/icons';
+import { displayShortcut } from '@wordpress/keycodes';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { parse } from 'qs';
@@ -1000,11 +1000,12 @@ class MasterbarLoggedIn extends Component {
 		return (
 			<Item
 				className="masterbar__item-command-palette"
-				icon={ <Icon icon={ search } /> }
 				onClick={ this.openCommandPalette }
 				tooltip={ translate( 'Search' ) }
 				ariaLabel={ translate( 'Search' ) }
-			/>
+			>
+				<span aria-hidden="true">{ displayShortcut.primary( 'k' ) }</span>
+			</Item>
 		);
 	}
 

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -1001,8 +1001,9 @@ class MasterbarLoggedIn extends Component {
 			<Item
 				className="masterbar__item-command-palette"
 				onClick={ this.openCommandPalette }
-				tooltip={ translate( 'Search' ) }
-				ariaLabel={ translate( 'Search' ) }
+				icon={ <span className="dashicons-before dashicons-search" /> }
+				tooltip={ translate( 'Open command palette' ) }
+				ariaLabel={ translate( 'Open command palette' ) }
 			>
 				<span aria-hidden="true">{ displayShortcut.primary( 'k' ) }</span>
 			</Item>

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -4,6 +4,10 @@ import { isEcommercePlan } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { Badge } from '@automattic/ui';
 import clsx from 'clsx';
+// @ts-expect-error The commands package is not yet typed.
+import { store as commandsStore } from '@wordpress/commands';
+import { dispatch } from '@wordpress/data';
+import { Icon, search } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { parse } from 'qs';
@@ -118,6 +122,7 @@ class MasterbarLoggedIn extends Component {
 		useUnifiedAgent: PropTypes.bool,
 		launchButton: PropTypes.node,
 		sitePlanUrl: PropTypes.string,
+		showCommandPalette: PropTypes.bool,
 	};
 
 	state = { mounted: false };
@@ -986,6 +991,23 @@ class MasterbarLoggedIn extends Component {
 		);
 	}
 
+	openCommandPalette = () => {
+		dispatch( commandsStore ).open();
+	};
+
+	renderCommandPalette() {
+		const { translate } = this.props;
+		return (
+			<Item
+				className="masterbar__item-command-palette"
+				icon={ <Icon icon={ search } /> }
+				onClick={ this.openCommandPalette }
+				tooltip={ translate( 'Search' ) }
+				ariaLabel={ translate( 'Search' ) }
+			/>
+		);
+	}
+
 	clickAgentsManagerAiChat = () => {
 		// Toggle: close the chat if it's already showing, otherwise resume the active
 		// conversation and open it.
@@ -1043,6 +1065,7 @@ class MasterbarLoggedIn extends Component {
 					{ this.renderLaunchButton() }
 				</div>
 				<div className="masterbar__section masterbar__section--right">
+					{ this.props.showCommandPalette && this.renderCommandPalette() }
 					{ this.renderCart() }
 					{ this.renderReader() }
 					{ loadHelpCenterIcon && this.renderHelpCenter() }

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -1057,6 +1057,7 @@ class MasterbarLoggedIn extends Component {
 					{ this.renderSidebarMobileMenu() }
 					{ this.renderMySites() }
 					{ this.renderSiteMenu() }
+					{ this.props.showCommandPalette && this.renderCommandPalette() }
 					{ this.renderUpdatesMenu() }
 					{ this.renderCommentsMenu() }
 					{ this.renderSiteActionMenu() }
@@ -1065,7 +1066,6 @@ class MasterbarLoggedIn extends Component {
 					{ this.renderLaunchButton() }
 				</div>
 				<div className="masterbar__section masterbar__section--right">
-					{ this.props.showCommandPalette && this.renderCommandPalette() }
 					{ this.renderCart() }
 					{ this.renderReader() }
 					{ loadHelpCenterIcon && this.renderHelpCenter() }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -398,10 +398,14 @@ body.is-mobile-app-view {
 		padding: 0 0 0 6px;
 	}
 
-	&.masterbar__item-command-palette .masterbar__item-content {
-		display: flex;
-		align-items: center;
-		line-height: 1;
+	&.masterbar__item-command-palette {
+		gap: 6px;
+
+		.masterbar__item-content {
+			display: flex;
+			align-items: center;
+			line-height: 1;
+		}
 	}
 
 	.dashicons-before {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -398,6 +398,12 @@ body.is-mobile-app-view {
 		padding: 0 0 0 6px;
 	}
 
+	&.masterbar__item-command-palette .masterbar__item-content {
+		display: flex;
+		align-items: center;
+		line-height: 1;
+	}
+
 	.dashicons-before {
 		height: 20px;
 		color: var(--color-masterbar-icon);


### PR DESCRIPTION
Fixes DOTCOM-16581

## Proposed Changes

* Enable the command palette for the WordPress.com dashboard.
* Add a `⌘K` entry point to the interim omnibar (the masterbar), in the left cluster next to the site menu, that opens the palette on click. `⌘K` / `Ctrl+K` opens it too (the shortcut is registered globally by the palette).
* The omnibar reads command-palette support from the app config via context, so variants that don't mount the palette (A4A, CIAB) don't show a dead button. The button renders post-hydration, consistent with the rest of the omnibar.

<img width="318" height="32" alt="image" src="https://github.com/user-attachments/assets/c98e1146-d85b-4923-badc-5ab69ffac1b0" />

## Why are these changes being made?

The dashboard bundles a command palette, but no app variant mounted it, so it was unreachable — there was no listener and no way to open it. This turns it on for dotcom and gives it a discoverable, clickable entry point in the omnibar (in addition to the keyboard shortcut), matching how Help and Notifications already surface there.

## Testing Instructions

* Run the dashboard (`yarn start-dashboard`) and open a WordPress.com site.
* Confirm a `⌘K` label appears in the masterbar, next to the site menu. Click it — the command palette should open.
* Confirm `⌘K` / `Ctrl+K` also opens it, and navigation commands (e.g. "Go to Sites") work.
* Confirm no console errors.

## Considerations

The palette is hard-enabled for dotcom rather than placed behind a feature flag. If a gradual rollout is preferred, it can move behind a config flag.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
