### PR TITLE
A4A: use the brand primary color for the Stat progress bar

### DIFF
--- a/client/a8c-for-agencies/components/stat/index.tsx
+++ b/client/a8c-for-agencies/components/stat/index.tsx
@@ -64,7 +64,7 @@ export function Stat( {
 					value={ isLoading ? 0 : progressValue }
 					total={ 100 }
 					title={ progressLabel }
-					color={ progressColor ? progressColorMap[ progressColor ] : undefined }
+					color={ progressColor ? progressColorMap[ progressColor ] : 'var(--color-primary)' }
 				/>
 			) }
 		</div>


### PR DESCRIPTION
## Proposed Changes

* Progress bars rendered by the Stat component in Automattic for Agencies now fill with the brand primary color instead of the stock WordPress.com blue. This affects the “Influenced revenue” bar on the agency tier page and the eligibility progress bar on the Partner Directory lead matching page.

## Why are these changes being made?

* The Automattic for Agencies Stat component started as a copy of the Multi-site Dashboard one in #109568. The original colors its progress bar from the theme, so it always matched the surrounding brand. The copy swapped in an older progress bar whose default fill is a hardcoded stock blue, which is where the wrong color crept in. This restores the behavior the component had before the copy: a bar that follows the brand color by default.
* Status colors passed explicitly (green, red, yellow) are unaffected — they still take precedence.
* This is a temporary fix. The longer-term plan is to move away from this copied component and reuse the shared Multi-site Dashboard pieces instead (as the agency tier page already does for tier cards and benefits), at which point this component and this override go away.

## Testing Instructions

* Open the “Automattic for Agencies Live” link from this PR.
* Go to Overview → your agency tier (“Your agency tier and benefits”).
* Confirm the “Influenced revenue” progress bar fill is the brand blue, not the stock WordPress.com blue.
* Check a Stat progress bar that uses a status color (if available) and confirm it keeps its green/red/yellow fill.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

