### PR TITLE
Marketplace: fix the zip-upload install screen hanging after an Atomic transfer

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-thank-you-redirect.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-thank-you-redirect.tsx
@@ -57,7 +57,6 @@ const baseProps: Props = {
 	pluginActive: false,
 	uploadedPluginSlug: '',
 	atomicFlow: true,
-	isAtomic: true,
 	automatedTransferStatus: transferStates.COMPLETE,
 };
 const render = ( overrides?: Partial< Props > ) =>
@@ -103,6 +102,21 @@ describe( 'useThankYouRedirect', () => {
 	it( 'redirects once the plugin is active', async () => {
 		mockFreshSite = ATOMIC_READY;
 		render( { atomicFlow: true, pluginActive: true } );
+		await waitFor( () => expect( navDelay ).toHaveBeenCalled() );
+	} );
+
+	it( 'redirects the zip-upload transfer flow once the Atomic transfer is ready', async () => {
+		mockFreshSite = ATOMIC_READY;
+		// The transfer has completed, so the site now reads as Atomic — the redirect must still fire.
+		render( {
+			isPluginUploadFlow: true,
+			pluginSlug: '',
+			uploadedPluginSlug: 'taipeiplugins',
+			installedPlugin: null,
+			pluginActive: false,
+			atomicFlow: false,
+			automatedTransferStatus: transferStates.COMPLETE,
+		} );
 		await waitFor( () => expect( navDelay ).toHaveBeenCalled() );
 	} );
 } );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -272,7 +272,6 @@ export function useProductInstall( {
 		pluginActive,
 		uploadedPluginSlug,
 		atomicFlow,
-		isAtomic,
 		automatedTransferStatus,
 	} );
 

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
@@ -30,7 +30,6 @@ export function useThankYouRedirect( {
 	pluginActive,
 	uploadedPluginSlug,
 	atomicFlow,
-	isAtomic,
 	automatedTransferStatus,
 }: {
 	siteId: number;
@@ -46,7 +45,6 @@ export function useThankYouRedirect( {
 	pluginActive: boolean;
 	uploadedPluginSlug: string;
 	atomicFlow: boolean;
-	isAtomic: boolean | null;
 	automatedTransferStatus: string | null;
 } ) {
 	const dispatch = useDispatch();
@@ -109,10 +107,10 @@ export function useThankYouRedirect( {
 			// plugin only reads active once the transfer is far enough along, and for an atomicFlow the
 			// redirect URL below resolves only after the transfer completes, so no separate arm is needed.
 			( installedPlugin && pluginActive ) ||
-			// Transfer to atomic uploading a zip plugin
+			// Zip-upload transfer to Atomic. The transfer makes the site Atomic, so this must not gate on
+			// the site being non-Atomic — isAtomicTransferReady already confirms the transfer landed.
 			( uploadedPluginSlug &&
 				isPluginUploadFlow &&
-				! isAtomic &&
 				transferStates.COMPLETE === automatedTransferStatus &&
 				canManagePlugins &&
 				isAtomicTransferReady )
@@ -129,7 +127,6 @@ export function useThankYouRedirect( {
 		pluginActive,
 		automatedTransferStatus,
 		isPluginUploadFlow,
-		isAtomic,
 		canManagePlugins,
 		installedPlugin,
 		uploadedPluginSlug,


### PR DESCRIPTION
## Proposed Changes

* Fix the plugin-zip upload screen hanging indefinitely after it transfers a Simple site to Atomic. The screen now redirects to wp-admin once the transfer completes, instead of getting stuck on the progress bar.

## Why are these changes being made?

Uploading a plugin `.zip` on a Simple site transfers the site to Atomic and then redirects to wp-admin. The fallback redirect condition required the site to *not* be an automated-transfer site while simultaneously requiring the freshly-fetched site to read as a transferred Atomic site — two conditions that can't both hold once the transfer lands, because the transfer is exactly what marks the site as an automated-transfer site. Since the flow refreshes the site as soon as the transfer completes, that state flips reliably, and the redirect could only fire by winning a timing race it normally lost — leaving the user stuck on the progress screen while the status and site endpoints polled forever.

The fix removes the contradictory condition. The redirect arm already positively confirms the transfer landed, so gating on the site being non-Atomic served no purpose beyond breaking the flow.

Note: this fixes the hang. A separate, backend-side issue (the Simple→Atomic transfer not always installing the uploaded plugin) is out of scope here; with this change the screen now redirects gracefully to wp-admin either way instead of trapping the user.

## Testing Instructions

1. On a Simple site (not yet Atomic), go to the plugin upload flow and upload a plugin `.zip`.
2. Let the site transfer to Atomic and the screen run to completion.
3. It should redirect to the wp-admin Plugins page instead of hanging on the progress bar.
4. Regression: uploading a `.zip` on an already-Atomic/Jetpack site, and installing a plugin from the marketplace, should both still complete and redirect as before.

Verified end-to-end on a live Simple → Atomic zip upload: the screen redirects where it previously hung.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
