### PR TITLE
A4A Marketplace: Keep the active hosting plan tab blue while hovered

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/style.scss
@@ -10,7 +10,7 @@
 	}
 }
 
-.pressable-overview-plan-selection__plan-category-tabpanel {
+.theme-a8c-for-agencies .pressable-overview-plan-selection__plan-category-tabpanel {
 	.components-tab-panel__tabs {
 		justify-content: center;
 		flex-wrap: wrap;
@@ -44,10 +44,14 @@
 			}
 
 			&.pressable-overview-plan-selection__plan-category-tab-is-active {
-				background-color: var( --color-primary-50 );
-				border-color: var( --color-primary-50 );
-				fill: var( --color-text-inverted );
-				color: var( --color-text-inverted );
+				&,
+				&:hover,
+				&:focus-visible {
+					background-color: var( --color-primary-50 );
+					border-color: var( --color-primary-50 );
+					fill: var( --color-text-inverted );
+					color: var( --color-text-inverted );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/A4A-3092/marketplace-hosting-active-plan-tab-turns-white-on-hover

## What & why

On **Marketplace → Hosting** (`/marketplace/hosting/pressable`), the plan-group segmented control ("Signature plans 1-10" / "Signature plans 11-17" / "Premium plans") rendered the **active** tab as a solid blue button — but hovering it turned the background white/light, so the active tab looked washed-out while the pointer was over it. The generic `:hover` rule was overriding the active/selected styling.

This applies the active-state styling to the selected tab's `&`, `&:hover`, and `&:focus-visible` together, so hovering (or focusing) the active tab keeps the blue background and inverted text. Inactive tabs keep their light hover background. The rule is also scoped under `.theme-a8c-for-agencies` (set on `<body>` in all four A4A configs) to give it the specificity to win cleanly.

## Testing Instructions

1. Open `agencies.automattic.com/marketplace/hosting/pressable` (or `yarn start-a8c-for-agencies`).
2. Scroll to "Choose from a variety of high performance hosting plans" and the plan-group toggle.
3. Hover the **active** tab (the blue one). Verify it stays blue with legible text — no white flash.
4. Hover an **inactive** tab and verify it still shows the light hover background.

## Notes

- **CSS-only**, one file (`.../premier-agency-hosting/style.scss`). Blast radius: `pressable-overview-plan-selection__plan-category-tabpanel` is used by exactly one component (`pressable-overview/plan-selection/filter.tsx`), rendered only from premier-agency-hosting — no selection/click behavior touched.
- No tests — no logic to assert; the cascade was verified by compiling the SCSS and comparing computed colors (active tab hover: `rgb(6,117,196)` before→after, vs the buggy `rgb(246,247,247)`). `stylelint` clean.
