### PR TITLE
A4A Marketplace: Hide the yearly-billing tooltip for free products

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hooks/test/use-marketplace.test.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/test/use-marketplace.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useProductTermAvailabilityTooltip } from '../use-marketplace';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
+
+const buildProduct = ( overrides: Partial< APIProductFamilyProduct > = {} ) =>
+	( {
+		name: 'Test product',
+		slug: 'test-product',
+		product_id: 1,
+		yearly_product_id: 1,
+		currency: 'USD',
+		amount: '10',
+		price_interval: 'month',
+		family_slug: 'test-family',
+		supported_bundles: [],
+		yearly_price: 120,
+		...overrides,
+	} ) as APIProductFamilyProduct;
+
+describe( 'useProductTermAvailabilityTooltip', () => {
+	it( 'warns about yearly billing for a paid product without monthly pricing', () => {
+		const { result } = renderHook( () => useProductTermAvailabilityTooltip( 'monthly' ) );
+
+		expect( result.current( buildProduct() ) ).toBe(
+			'This product is not available for monthly billing. We will bill you yearly instead.'
+		);
+	} );
+
+	it( 'warns about monthly billing for a paid product without yearly pricing', () => {
+		const { result } = renderHook( () => useProductTermAvailabilityTooltip( 'yearly' ) );
+
+		const product = buildProduct( {
+			yearly_product_id: undefined,
+			monthly_product_id: 1,
+			yearly_price: undefined,
+			monthly_price: 10,
+		} );
+
+		expect( result.current( product ) ).toBe(
+			'This product is not available for yearly billing. We will bill you monthly instead.'
+		);
+	} );
+
+	it( 'stays silent for a free product', () => {
+		const { result } = renderHook( () => useProductTermAvailabilityTooltip( 'monthly' ) );
+
+		const freeProduct = buildProduct( {
+			amount: '0',
+			yearly_price: 0,
+			monthly_price: 0,
+		} );
+
+		expect( result.current( freeProduct ) ).toBeUndefined();
+	} );
+
+	it( 'stays silent for a free product with no term prices at all', () => {
+		const { result } = renderHook( () => useProductTermAvailabilityTooltip( 'monthly' ) );
+
+		const freeProduct = buildProduct( {
+			amount: '0',
+			yearly_price: undefined,
+			monthly_price: undefined,
+		} );
+
+		expect( result.current( freeProduct ) ).toBeUndefined();
+	} );
+
+	it( 'keeps the warning for a paid product whose amount is formatted with a separator', () => {
+		const { result } = renderHook( () => useProductTermAvailabilityTooltip( 'monthly' ) );
+
+		const product = buildProduct( { amount: '1,200', yearly_price: undefined } );
+
+		expect( result.current( product ) ).toBe(
+			'This product is not available for monthly billing. We will bill you yearly instead.'
+		);
+	} );
+} );

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-marketplace.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-marketplace.ts
@@ -88,11 +88,25 @@ export const checkProductTermAvailability = (
 	return { isMissingMonthlyId, isMissingYearlyId };
 };
 
+const getAmount = ( amount?: string ) => {
+	if ( ! amount ) {
+		return 0;
+	}
+	return parseFloat( amount.replace( ',', '' ) ) || 0;
+};
+
+const isFreeProduct = ( product: APIProductFamilyProduct ) =>
+	! product.monthly_price && ! product.yearly_price && ! getAmount( product.amount );
+
 export const useProductTermAvailabilityTooltip = ( termPricing: TermPricingType ) => {
 	const translate = useTranslate();
 
 	const termAvailabilityTooltip = useCallback(
 		( product: APIProductFamilyProduct ) => {
+			if ( isFreeProduct( product ) ) {
+				return undefined;
+			}
+
 			const { isMissingMonthlyId, isMissingYearlyId } = checkProductTermAvailability(
 				product,
 				termPricing
@@ -287,7 +301,7 @@ export const useGetProductPricingInfo = (
 
 		// If we don't have userProducts, we just pull the price from the product and not calculate the discount
 		if ( ! Object.keys( userProducts ).length ) {
-			const actualCost = Number( product?.price_per_unit_display?.replace( /,/g, '' ) ) ?? 0;
+			const actualCost = Number( product?.price_per_unit_display?.replace( /,/g, '' ) );
 			return {
 				actualCost,
 				discountedCost: actualCost,
@@ -298,13 +312,6 @@ export const useGetProductPricingInfo = (
 				isFree: actualCost === 0,
 			};
 		}
-
-		const getAmount = ( amount?: string ) => {
-			if ( ! amount ) {
-				return 0;
-			}
-			return parseFloat( amount.replace( ',', '' ) ) || 0;
-		};
 
 		const bundle = product?.supported_bundles?.find( ( bundle ) => bundle.quantity === quantity );
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/A4A-3093/hide-monthly-billing-tooltip-for-free-products

## What & why

In the A4A **Marketplace**, a product marked **Free** showed the tooltip:

> "This product is not available for monthly billing. We will bill you yearly instead."

That message is meant for *paid* products that only support yearly billing (shown when the billing toggle is on Monthly). For a **Free** product there's no billing at all, so the tooltip is nonsensical.

This suppresses the tooltip for free products while leaving it for paid yearly-only products.

## How

In `useProductTermAvailabilityTooltip` (`use-marketplace.ts`), a product is treated as **free** when it has no monthly price, no yearly price, and a zero `amount`:

```ts
const isFreeProduct = ( product ) =>
	! product.monthly_price && ! product.yearly_price && ! getAmount( product.amount );
```

When the product is free, the hook returns `undefined` (no tooltip). Paid products with no monthly term still return the yearly-billing message, unchanged.

## Testing Instructions

Prerequisites: `yarn start-a8c-for-agencies`, an agency account, and the Marketplace with a **Free** product visible (the billing toggle set to **Monthly**).

1. Set the billing toggle to **Monthly**.
2. Hover a **Free** product's price/term. Verify **no** "not available for monthly billing / billed yearly instead" tooltip appears.
3. Hover a **paid, yearly-only** product. Verify the tooltip **still** appears (unchanged).

## Notes

- **Display-only** — no pricing/billing behavior changes.
- **One incidental line:** removed a pre-existing dead `?? 0` on the `Number( … )` cost expression (line 299) — `Number()` never returns `null`/`undefined`, so the `??` never fired; this is behavior-preserving. It had to go because the pre-commit / changed-file lint flags it (`no-constant-binary-expression`). Deliberately *not* changed to `|| 0`, which would alter the `NaN` case.
- **Tests:** 5 cases, written test-first (the two free-product cases failed against the old code; the three paid cases passed) — paid-without-monthly, paid-without-yearly, free-with-zero-prices, free-with-prices-absent, and a comma-formatted amount (`'1,200'` must not parse to zero). 47/47 marketplace tests pass; lint clean.
- **Not verified in a running app** — reaching a free product with the Monthly toggle needs an authenticated A4A account plus the `a4a-bd-term-pricing` / `a4a-bd-checkout` flags; justified from code. Worth a human spot-check before merge.
