### PR TITLE
A4A Plugins: Show a loading indicator on the manage-plugins dashboard

### DIFF
--- a/client/a8c-for-agencies/sections/plugins/controller.tsx
+++ b/client/a8c-for-agencies/sections/plugins/controller.tsx
@@ -4,6 +4,7 @@ import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { A4A_PLUGINS_LINK } from '../../components/sidebar-menu/lib/constants';
 import MainSidebar from '../../components/sidebar-menu/main';
+import prefetchAllSitesPlugins from './lib/prefetch-all-sites-plugins';
 
 // Reset selected site id for multi-site view since it is never reset
 // and the plugins component behaves differently when there
@@ -27,6 +28,7 @@ export const pluginsContext: Callback = ( context ) => {
 
 export const pluginManagementContext: Callback = ( context, next ) => {
 	resetSite( context );
+	context.store.dispatch( prefetchAllSitesPlugins() );
 	context.secondary = <MainSidebar path={ context.path } />;
 	context.primary = (
 		<>
@@ -38,6 +40,7 @@ export const pluginManagementContext: Callback = ( context, next ) => {
 
 export const pluginDetailsContext: Callback = ( context, next ) => {
 	resetSite( context );
+	context.store.dispatch( prefetchAllSitesPlugins() );
 	context.secondary = <MainSidebar path={ context.path } />;
 	context.primary = (
 		<>

--- a/client/a8c-for-agencies/sections/plugins/lib/prefetch-all-sites-plugins.ts
+++ b/client/a8c-for-agencies/sections/plugins/lib/prefetch-all-sites-plugins.ts
@@ -1,0 +1,34 @@
+import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
+import { fetchAllPlugins } from 'calypso/state/plugins/installed/actions';
+import { getPlugins, isRequestingForAllSites } from 'calypso/state/plugins/installed/selectors';
+import getSelectedOrAllSitesWithJetpackPlugin from 'calypso/state/selectors/get-selected-or-all-sites-with-jetpack-plugin';
+import type { CalypsoDispatch } from 'calypso/state/types';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Starts the all-sites plugins fetch before the plugins dashboard first renders.
+ *
+ * The dashboard's loading flag is only raised once `<QueryPlugins>` dispatches from an
+ * effect, which is one render too late: DataViews latches whether it has ever loaded
+ * from the flag it sees on its first render, and a dashboard that starts out "not
+ * loading" shows the empty "No results" state for the whole fetch instead of a spinner.
+ * Dispatching from the route handler puts the request in flight beforehand.
+ */
+const prefetchAllSitesPlugins =
+	() =>
+	( dispatch: CalypsoDispatch, getState: () => AppState ): void => {
+		const state = getState();
+
+		if ( isRequestingForAllSites( state ) ) {
+			return;
+		}
+
+		const siteIds = siteObjectsToSiteIds( getSelectedOrAllSitesWithJetpackPlugin( state ) ) ?? [];
+		if ( getPlugins( state, siteIds, 'all' ).length ) {
+			return;
+		}
+
+		dispatch( fetchAllPlugins() );
+	};
+
+export default prefetchAllSitesPlugins;

--- a/client/a8c-for-agencies/sections/plugins/lib/test/prefetch-all-sites-plugins.ts
+++ b/client/a8c-for-agencies/sections/plugins/lib/test/prefetch-all-sites-plugins.ts
@@ -1,0 +1,75 @@
+import { fetchAllPlugins } from 'calypso/state/plugins/installed/actions';
+import prefetchAllSitesPlugins from '../prefetch-all-sites-plugins';
+import type { AppState } from 'calypso/types';
+
+jest.mock( 'calypso/state/plugins/installed/actions', () => ( {
+	fetchAllPlugins: jest.fn( () => ( { type: 'FETCH_ALL_PLUGINS' } ) ),
+} ) );
+
+const SITE_ID = 12345;
+
+const makeState = ( { isRequestingAll = false, plugins = {} } = {} ) => ( {
+	plugins: {
+		installed: {
+			isRequestingAll,
+			isRequesting: {},
+			plugins,
+			status: {},
+		},
+	},
+	sites: {
+		items: {
+			[ SITE_ID ]: {
+				ID: SITE_ID,
+				jetpack: true,
+				visible: true,
+				options: { jetpack_connection_active_plugins: [ 'jetpack' ] },
+			},
+		},
+	},
+	currentUser: {
+		capabilities: { [ SITE_ID ]: { manage_options: true } },
+	},
+	ui: { selectedSiteId: null },
+} );
+
+const run = ( state: object ) => {
+	const dispatch = jest.fn();
+	prefetchAllSitesPlugins()( dispatch, () => state as AppState );
+	return dispatch;
+};
+
+describe( 'prefetchAllSitesPlugins()', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'should fetch when no plugins have been loaded yet', () => {
+		const dispatch = run( makeState() );
+
+		expect( fetchAllPlugins ).toHaveBeenCalled();
+		expect( dispatch ).toHaveBeenCalledWith( { type: 'FETCH_ALL_PLUGINS' } );
+	} );
+
+	test( 'should not fetch while a request is already in flight', () => {
+		const dispatch = run( makeState( { isRequestingAll: true } ) );
+
+		expect( fetchAllPlugins ).not.toHaveBeenCalled();
+		expect( dispatch ).not.toHaveBeenCalled();
+	} );
+
+	test( 'should not fetch again once plugins are in state', () => {
+		const dispatch = run( {
+			...makeState( {
+				plugins: {
+					[ SITE_ID ]: [
+						{ id: 'akismet/akismet', slug: 'akismet', name: 'Akismet', active: true },
+					],
+				},
+			} ),
+		} );
+
+		expect( fetchAllPlugins ).not.toHaveBeenCalled();
+		expect( dispatch ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
## What & why

On the A4A dashboard **Plugins → Manage** (`/plugins/manage/sites`), there was **no loading indicator** while the data loaded — the screen sat blank (and could briefly flash an empty "No results") before content appeared.

**Root cause:** the plugins dashboard's DataViews shows a loading state driven by the shared "is loading plugins for all sites" state, but on the A4A route the all-sites plugins fetch wasn't dispatched until *after* the dashboard first rendered. So at first paint the state read "not loading, no items" → the empty state rendered instead of a spinner, and the loading indicator never appeared.

## The fix (A4A-scoped)

Kick off the all-sites plugins fetch **from the A4A plugins route handler**, so the request is already in flight when the dashboard first renders — at which point the existing DataViews loading state correctly shows the spinner. A small `prefetchAllSitesPlugins` thunk is dispatched from `sections/plugins/controller.tsx`, guarded so it does **not** re-request when a fetch is already in flight or the list is already loaded (keeps navigation between the list and a plugin's sites pane free of extra requests).

**No shared code is touched** — this is deliberately scoped to A4A. (An earlier revision fixed the shared loading selector/reducer, which also changed the my-sites plugins dashboard and Jetpack Cloud; that was reverted in favor of this A4A-only approach.)

## Testing Instructions

Prerequisites: `yarn start-a8c-for-agencies`, an agency account with connected sites that have plugins.

1. With the network throttled (or on a cold load), open **Plugins → Manage** (`/plugins/manage/sites`).
2. Verify a **loading indicator** shows while the plugins/sites data is pending — not a blank screen or a flash of "No results".
3. Once loaded, verify the list renders normally, and that navigating into a plugin's sites pane and back does **not** trigger a redundant refetch.

## Notes for reviewers

- **A4A-only by design.** The other clients' plugins dashboards are unchanged.
- **The fix is timing-based** — it works because the fetch is dispatched *before* the dashboard renders. That coupling is deliberate and documented in the thunk's doc comment, but it isn't self-evident from the dashboard's own code: if the prefetch is ever removed, the missing-indicator bug returns silently. (The shared-state approach would have made the flag correct by construction, but that's cross-client and out of scope here.)
- **Tests:** 3 cases on the guard's real branches — fetches on cold state, skips while in flight, skips once loaded. The "already loaded" case is self-verifying (a bad site/capability fixture would return `[]` and fail rather than pass vacuously). `eslint` clean; `typecheck` clean under the touched path.
- **Not verified in a running app** (needs an authenticated A4A session) — justified from code. Worth a human spot-check of the spinner before merge.
