### PR TITLE
A4A Sites: Remove the resting underline on the Threats and Updates links

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -850,6 +850,18 @@
 		color: var( --color-scary-50 );
 	}
 
+	// Scoped here rather than on the shared status column, which Jetpack Cloud also renders.
+	// The hover underline sits on the value so it picks up the status color; on the anchor
+	// it would resolve to the link blue instead.
+	.sites-overview__row-status > a {
+		text-decoration: none;
+
+		&:hover > *,
+		&:focus-visible > * {
+			text-decoration: underline;
+		}
+	}
+
 	@mixin boost-score-style( $color, $background-color ) {
 		@extend .sites-overview__column-content;
 		color: $color;


### PR DESCRIPTION
The A4A Sites dashboard shows each site as a row of status values (Threats, Updates, Backup, Monitor) under the shared `.sites-overview__row-status` column. Each value is wrapped in a bare anchor so the cell is clickable.

Calypso's global `a` rule only sets a color, so the browser default underline applied to these values. That underline rendered in the anchor's link blue while the value text is red (threats) or amber (updates), so it looked like a mismatched, doubled treatment, and no other stat in the row is underlined.

This removes the resting underline on the Sites-row status anchors and shows an underline only on `:hover` and `:focus-visible`, drawn on the value so it takes the status color. The rule is scoped to the Sites-dashboard stylesheet, so the shared status column that Jetpack Cloud also renders keeps its current styling. All four status links share the element and the defect, so the fix covers all of them.

## Before / after

| Before | After |
| --- | --- |
| <img width="450" alt="Threats and Updates links with a resting underline" src="https://github.com/user-attachments/assets/b87be84e-df58-4e9b-9f7b-0b0ad42274f4" /> | <img width="450" alt="Threats and Updates links with no resting underline" src="https://github.com/user-attachments/assets/89b16ca4-cb48-4e57-9a53-ed637a0560da" /> |

## Testing instructions

Prerequisites: the A4A dashboard running locally (`yarn start-a8c-for-agencies`) with an agency that has a site showing a threat and pending updates.

1. Open `/sites`.
2. Find a site row with "N Threat(s)" (red) and "N Updates" (amber). Confirm neither has a resting underline and both keep their color.
3. Hover, then keyboard-focus (Tab) each link. An underline appears in the status color.
4. Click through and confirm navigation and the threats tooltip still work.

Fixes [A4A-3094](https://linear.app/a8c/issue/A4A-3094).
