### PR TITLE
A4A Referrals: Fix the washed-out hover on the is-dark payout CTA

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/index.tsx
@@ -52,8 +52,7 @@ export const MissingPaymentSettingsNotice = ( {
 			>
 				<div>{ getDescription() }</div>
 				<Button
-					className="missing-payment-settings-notice__button"
-					variant="primary"
+					className="missing-payment-settings-notice__button is-dark"
 					href={ commissionType ? 'payment-settings' : A4A_REFERRALS_PAYMENT_SETTINGS }
 				>
 					{ translate( 'Add payout information now' ) }

--- a/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/index.tsx
@@ -52,7 +52,8 @@ export const MissingPaymentSettingsNotice = ( {
 			>
 				<div>{ getDescription() }</div>
 				<Button
-					className="missing-payment-settings-notice__button is-dark"
+					className="missing-payment-settings-notice__button"
+					variant="primary"
 					href={ commissionType ? 'payment-settings' : A4A_REFERRALS_PAYMENT_SETTINGS }
 				>
 					{ translate( 'Add payout information now' ) }

--- a/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/style.scss
@@ -3,3 +3,15 @@
 		margin-block-start: 1rem;
 	}
 }
+
+// The A4A theme's catch-all `.components-button:not(…):not(…):hover` rule is one class more
+// specific than `.components-button.is-dark:hover`, so it repaints the background light while
+// the label stays white. Restated here on our own classes at a higher specificity so the shared
+// is-dark styles stay untouched.
+.theme-a8c-for-agencies .a4a-layout__banner.missing-payment-settings-notice {
+	.missing-payment-settings-notice__button.is-dark:hover,
+	.missing-payment-settings-notice__button.is-dark:focus-visible {
+		background-color: var( --color-accent-100 );
+		color: var( --color-surface );
+	}
+}


### PR DESCRIPTION
The "Add your payout information to get paid." notice on A4A Referrals renders its "Add payout information now" button with the `is-dark` variant, matching the other A4A notice buttons. On hover the label washed out to nearly invisible: white text on a light background.

The cause is a catch-all `.components-button:not(…):not(…):hover` rule in the A4A theme that is one class more specific than `.components-button.is-dark:hover`. On hover it repaints the background light while the label stays white, so contrast drops to about 1.07:1.

This restates the correct dark hover on the notice's own classes at a higher specificity, so the button keeps its dark background and white label on hover (about 18.4:1). The shared `is-dark` and Button styles are not touched, and there is no `.components-*` override or `!important`. The button stays `is-dark` rather than switching to a primary variant, which keeps it consistent with the sibling notice buttons. The hover matches the resting appearance, as those siblings do.

## Before / after (hover)

| Before | After |
| --- | --- |
| <img width="450" alt="On hover the label washes out to near-invisible" src="https://github.com/user-attachments/assets/1bd470b7-e8dd-4124-b045-90ba916154f2" /> | <img width="450" alt="On hover the label stays legible on the dark button" src="https://github.com/user-attachments/assets/3e212e04-9171-4cbe-b3d1-c441dc4c80a9" /> |

Resting `is-dark` state, unchanged:

<img width="450" alt="Resting dark is-dark button" src="https://github.com/user-attachments/assets/dd570389-5568-4062-8a02-a73b0369f640" />

## Testing instructions

Prerequisites: the A4A dashboard running locally (`yarn start-a8c-for-agencies`), on a Referrals surface that shows the "Add your payout information to get paid." notice.

1. Find the "Add payout information now" button.
2. Hover it. Confirm the label stays clearly legible on the dark button.
3. Confirm the resting button is the dark `is-dark` treatment and still links to the payout settings screen.

Fixes [A4A-3095](https://linear.app/a8c/issue/A4A-3095).
