### PR TITLE
A4A Marketplace: Use the link color for links in product info modals

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/woopayments-revenue-share-notice/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/woopayments-revenue-share-notice/style.scss
@@ -16,6 +16,5 @@
 
 	a {
 		text-decoration: underline;
-		color: var(--color-text);
 	}
 }

--- a/client/components/jetpack/jetpack-product-info/style.scss
+++ b/client/components/jetpack/jetpack-product-info/style.scss
@@ -16,7 +16,6 @@
 
 	a {
 		text-decoration: underline;
-		color: var(--color-text);
 	}
 }
 
@@ -60,7 +59,6 @@
 	font-size: 1rem;
 
 	a {
-		color: var(--color-text);
 		text-decoration: underline;
 	}
 }
@@ -174,7 +172,6 @@
 
 	a {
 		text-decoration: underline;
-		color: var(--color-text);
 	}
 }
 


### PR DESCRIPTION
Product info modals in the A4A Marketplace render inline links such as "By Woo", "Learn more", and the "Automattic for Agencies" attribution. These links were given an explicit `color: var(--color-text)` (the near-black body color), so they rendered black instead of the link color. The sibling "View full terms" link in the same modal already used the link color, so the black links looked inconsistent.

This removes the `color: var(--color-text)` override from the `a` selectors in the two product-info stylesheets, so the links fall back to the theme's `--color-link`. Only the color override is removed; the underline stays. Headings, section titles, and the price are not links and keep their current color.

`client/components/jetpack/jetpack-product-info/style.scss` is shared with the Jetpack Cloud partner portal and the my-sites product-lightbox, so links in those modals also move to each app's `--color-link`. That is the intended result, since the override was the anomaly.

## Before / after (WooPayments product modal)

| Before | After |
| --- | --- |
| <img width="450" alt="Modal links rendered in near-black" src="https://github.com/user-attachments/assets/e28c0880-212e-4568-8f95-ef115ec41374" /> | <img width="450" alt="Modal links rendered in the link color" src="https://github.com/user-attachments/assets/e7f22246-76da-459c-897c-c96d2b1cc89c" /> |

## Testing instructions

Prerequisites: the A4A dashboard running locally (`yarn start-a8c-for-agencies`).

1. Go to `/marketplace/products` and open a product's info modal (append `?show_license_modal=woocommerce-woopayments`, and separately `?show_license_modal=jetpack-backup-t1`).
2. Confirm the inline links ("By Woo", "Learn more", "Automattic for Agencies") render in the link color, like the "View full terms" link.
3. Confirm non-link text (headings, section titles, description, price) is unchanged.

Fixes [A4A-3078](https://linear.app/a8c/issue/A4A-3078).
