### PR TITLE
Domains: correct the contact validation response message type

### DIFF
--- a/client/dashboard/components/domain-contact-details-form/contact-validation-utils.ts
+++ b/client/dashboard/components/domain-contact-details-form/contact-validation-utils.ts
@@ -14,12 +14,12 @@ export type AsyncValidator = (
 ) => Promise< DomainContactValidationResponse >;
 
 /**
- * Maps DomainContactDetails field IDs (camelCase) to API response keys (snake_case)
+ * Maps DomainContactDetails field IDs (camelCase) to API response keys (snake_case).
+ *
+ * A `null` means the field has no counterpart in the validation response, so
+ * errors for it are never surfaced against a form field.
  */
-export const FIELD_TO_API_KEY_MAP: Record<
-	keyof DomainContactDetails,
-	keyof ContactValidationResponseMessages | null
-> = {
+export const FIELD_TO_API_KEY_MAP: Record< keyof DomainContactDetails, string | null > = {
 	firstName: 'first_name',
 	lastName: 'last_name',
 	organization: 'organization',
@@ -34,7 +34,10 @@ export const FIELD_TO_API_KEY_MAP: Record<
 	fax: 'fax',
 	vatId: 'vat_id',
 	optOutTransferLock: null, // Not validated by API
-	extra: null, // Has nested structure, handled separately if needed
+	// TLD extra fields have no single response key: each one is reported under its
+	// own dot-qualified key (`extra.uk.registrant_type`). The form has no controls
+	// for them yet, so their errors reach the user only via `messages_simple`.
+	extra: null,
 };
 
 /**
@@ -77,8 +80,7 @@ export const createFieldAsyncValidator = (
 
 			// Extract field-specific error from messages
 			const fieldErrors = result.messages[ apiKey ];
-			// Check if fieldErrors is a string array (not the 'extra' object type)
-			if ( Array.isArray( fieldErrors ) && fieldErrors.length > 0 ) {
+			if ( fieldErrors && fieldErrors.length > 0 ) {
 				return fieldErrors[ 0 ]; // Return first error message
 			}
 
@@ -108,7 +110,7 @@ export const mapValidationMessagesToFieldErrors = (
 
 	for ( const [ fieldId, apiKey ] of Object.entries( FIELD_TO_API_KEY_MAP ) as [
 		keyof DomainContactDetails,
-		keyof ContactValidationResponseMessages | null,
+		string | null,
 	][] ) {
 		if ( ! apiKey ) {
 			continue;

--- a/client/dashboard/components/domain-contact-details-form/test/contact-validation-utils.test.ts
+++ b/client/dashboard/components/domain-contact-details-form/test/contact-validation-utils.test.ts
@@ -20,10 +20,22 @@ describe( 'mapValidationMessagesToFieldErrors', () => {
 	} );
 
 	it( 'ignores fields with empty message arrays and non-field keys', () => {
-		const messages = {
+		const messages: ContactValidationResponseMessages = {
 			state: [],
-			extra: { ca: { cira_agreement_accepted: [ 'nope' ] } },
-		} as unknown as ContactValidationResponseMessages;
+			unrecognized_field: [ 'nope' ],
+		};
+
+		expect( mapValidationMessagesToFieldErrors( messages ) ).toEqual( {} );
+	} );
+
+	it( 'ignores TLD extra-field errors, which arrive under dot-qualified keys', () => {
+		// The endpoint reports nested properties as `extra.uk.registrant_type`, not
+		// as a nested object. The form has no controls for them, so they map to
+		// nothing rather than being mistaken for a top-level field error.
+		const messages: ContactValidationResponseMessages = {
+			'extra.uk.registrant_type': [ 'Please choose a registrant type.' ],
+			'extra.ca.cira_agreement_accepted': [ 'nope' ],
+		};
 
 		expect( mapValidationMessagesToFieldErrors( messages ) ).toEqual( {} );
 	} );

--- a/packages/api-core/src/domain-whois/types.ts
+++ b/packages/api-core/src/domain-whois/types.ts
@@ -58,44 +58,17 @@ export type ContactValidationRequestContactInformation = {
 	vat_id?: string;
 };
 
-export type ContactValidationResponseMessagesExtra = {
-	ca?: {
-		lang?: string[];
-		legal_type?: string[];
-		cira_agreement_accepted?: string[];
-	};
-	uk?: {
-		registrant_type?: string[];
-		registration_number?: string[];
-		trading_name?: string[];
-	};
-	fr?: {
-		registrant_type?: string[];
-		trademark_number?: string[];
-		siren_siret?: string[];
-	};
-	is_for_business?: boolean;
-};
-
-export type ContactValidationResponseMessages = {
-	first_name?: string[];
-	last_name?: string[];
-	organization?: string[];
-	email?: string[];
-	phone?: string[];
-	phone_number_country?: string[];
-	address_1?: string[];
-	address_2?: string[];
-	city?: string[];
-	state?: string[];
-	postal_code?: string[];
-	country_code?: string[];
-	fax?: string[];
-	vat_id?: string[];
-	extra?: ContactValidationResponseMessagesExtra;
-};
-
-export type RawContactValidationResponseMessages = Record< string, string[] >;
+/**
+ * Per-field validation messages, keyed by the name of the field that failed.
+ *
+ * The map is always flat. Errors on nested properties carry a dot-qualified key
+ * rather than a nested object — a failing `.uk` registrant type arrives as
+ * `{ 'extra.uk.registrant_type': [ … ] }`, never as
+ * `{ extra: { uk: { registrant_type: [ … ] } } }`. The per-TLD JSON schemas set
+ * those qualified names explicitly via `error_field`, so they are identical on
+ * v1.1 and v1.2 of the endpoint.
+ */
+export type ContactValidationResponseMessages = Record< string, string[] >;
 
 export type DomainContactValidationResponse =
 	| { success: true }


### PR DESCRIPTION
## Proposed Changes

Correct the type describing the `messages` object returned by `POST /me/domain-contact-information/validate`.

* Replace `ContactValidationResponseMessages` (a nested shape) and the unused `RawContactValidationResponseMessages` alias with a single accurate `Record<string, string[]>`, and delete the now-unreferenced `ContactValidationResponseMessagesExtra`.
* Retype `FIELD_TO_API_KEY_MAP` values as `string | null` and drop the `Array.isArray` guard that only existed to defend against a nested `extra` object the server never sends.
* Replace the test fixture that encoded the wrong shape with one covering the real dot-qualified keys.

No behavioural change — the runtime already handled the real payload correctly by accident. This is types and tests only.

## Why are these changes being made?

The endpoint keys `messages` by the name of the field that failed, always as a flat map:

```php
$messages[ $error_code ][] = html_entity_decode( $error_message );
```

with an explicit note in `Domain_Helper::validate_contact_information` that *"the error codes are the names of the fields that failed validation."*

Errors on nested properties carry a **dot-qualified key** rather than a nested object — a failing `.uk` registrant type arrives as `{ "extra.uk.registrant_type": [...] }`, never as `{ extra: { uk: { registrant_type: [...] } } }`. The per-TLD JSON schemas set those qualified names explicitly via `error_field`, and explicit names win over the endpoint's `qualify_properties` option, so the keys are identical on v1.1 and v1.2.

Our type declared the nested form, which is a shape the server does not produce at either version. It happened to be harmless because every key the dashboard form currently maps is top-level, where flat and nested look identical. Meanwhile `RawContactValidationResponseMessages` — declared right underneath and never imported — described the payload accurately.

Classic checkout doesn't hit this because it re-nests the dotted keys through `hydrateNestedObject` before anything reads them; the dashboard has no equivalent conversion step and reads the raw response directly.

Fixing this now so that follow-up work on TLD extra fields (registrant type for `.uk`/`.fr`) starts from a type that matches the wire, rather than one that quietly suggests a nested walk that would never match anything.

## Testing Instructions

Types and tests only; there is nothing to observe in the UI.

```
yarn test-client client/dashboard/components/domain-contact-details-form
yarn typecheck-client
yarn typecheck-packages
```

To confirm the premise against the live API, validate contact details for a `.fr` domain with no `extra` in the payload and inspect the response — `messages` comes back keyed `extra.fr.registrant_type`, flat.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
