### PR TITLE
A4A: Replace the stat info hover tooltip with a native title

### DIFF
--- a/client/a8c-for-agencies/components/consolidated-stats-card/index.tsx
+++ b/client/a8c-for-agencies/components/consolidated-stats-card/index.tsx
@@ -39,10 +39,10 @@ const CardInfo = ( { children, wrapperRef, footerText, title, footerAction }: Ca
 							title={ translate( 'Click to learn more' ) }
 							aria-label={
 								title
-									? ( translate( 'Click to learn more about %(statName)s', {
+									? ( translate( 'Learn more about %(statName)s', {
 											args: { statName: title },
 									  } ) as string )
-									: translate( 'Click to learn more' )
+									: translate( 'Learn more' )
 							}
 							onActivate={ () => setShowPopover( true ) }
 						>

--- a/client/a8c-for-agencies/components/consolidated-stats-card/index.tsx
+++ b/client/a8c-for-agencies/components/consolidated-stats-card/index.tsx
@@ -36,7 +36,14 @@ const CardInfo = ( { children, wrapperRef, footerText, title, footerAction }: Ca
 					{ ! isMobile && (
 						<A4APopoverTrigger
 							className="consolidated-stats-card__info-icon"
-							aria-label={ translate( 'More info' ) }
+							title={ translate( 'Click to learn more' ) }
+							aria-label={
+								title
+									? ( translate( 'Click to learn more about %(statName)s', {
+											args: { statName: title },
+									  } ) as string )
+									: translate( 'Click to learn more' )
+							}
 							onActivate={ () => setShowPopover( true ) }
 						>
 							<Gridicon icon="info-outline" size={ 16 } />

--- a/client/dashboard/components/consolidated-stat-card/index.tsx
+++ b/client/dashboard/components/consolidated-stat-card/index.tsx
@@ -56,10 +56,10 @@ export default function ConsolidatedStatCard( {
 										popoverTitle
 											? sprintf(
 													/* translators: %s is the name of the stat, e.g. "Total payouts" */
-													__( 'Click to learn more about %s' ),
+													__( 'Learn more about %s' ),
 													popoverTitle
 											  )
-											: __( 'Click to learn more' )
+											: __( 'Learn more' )
 									}
 									onClick={ () => setShowPopover( ( visible ) => ! visible ) }
 								/>

--- a/client/dashboard/components/consolidated-stat-card/index.tsx
+++ b/client/dashboard/components/consolidated-stat-card/index.tsx
@@ -6,6 +6,7 @@ import {
 	Button,
 	Popover,
 } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 import { info } from '@wordpress/icons';
 import { useState } from 'react';
 import { Card, CardBody } from '../card';
@@ -50,7 +51,16 @@ export default function ConsolidatedStatCard( {
 									icon={ info }
 									iconSize={ 18 }
 									ref={ setInfoAnchor }
-									label={ popoverTitle }
+									title={ __( 'Click to learn more' ) }
+									aria-label={
+										popoverTitle
+											? sprintf(
+													/* translators: %s is the name of the stat, e.g. "Total payouts" */
+													__( 'Click to learn more about %s' ),
+													popoverTitle
+											  )
+											: __( 'Click to learn more' )
+									}
 									onClick={ () => setShowPopover( ( visible ) => ! visible ) }
 								/>
 								{ showPopover && (


### PR DESCRIPTION
On the A4A dashboard stat cards (for example "All time referral payouts" on Referrals), the info (i) icon showed a custom hover tooltip with a short label. The icon is already a clickable button that opens the full detail popover on click, so the hover tooltip mostly repeated the stat name and competed with the click affordance.

This drops the custom hover tooltip on the stat info icons and gives the button a native `title="Click to learn more"` plus a descriptive `aria-label` ("Learn more about <stat name>"). The aria-label omits "Click to" because the control also opens on Enter/Space, so the label stays accurate for keyboard and screen-reader users. The pointer cursor and the click behavior are unchanged, so the detail popover still opens on click (and on Enter/Space). Two call sites are updated: the A4A `consolidated-stats-card` and the dashboard `consolidated-stat-card`.

The A4A card's `aria-label` uses `translate(…, { args })`, which returns a `TranslateResult`; it is cast to `string` for the `aria-label` prop, matching the existing pattern at `client/blocks/user-avatar/index.tsx:119`.

## Before / after (Referrals)

| Before | After |
| --- | --- |
| <img width="450" alt="Info icon showing a custom hover tooltip" src="https://github.com/user-attachments/assets/94b58270-8892-41ae-bbf1-9e7150185d43" /> | <img width="450" alt="Info icon with no custom hover tooltip" src="https://github.com/user-attachments/assets/2de73049-6fa3-45de-830f-0d8e041ab661" /> |

The WooPayments dashboard's detail popover is already click-triggered and is unchanged; its only change is the added `title` attribute, which has no visual hover state to capture.

## Testing instructions

Prerequisites: the A4A dashboard running locally (`yarn start-a8c-for-agencies`).

1. Open the Referrals dashboard. Hover the info (i) next to a payout stat. Confirm the custom tooltip no longer appears, the pointer cursor shows, and the native "Click to learn more" title appears on hover.
2. Click the icon (or focus it and press Enter/Space). Confirm the detail popover still opens with the full content.
3. Repeat on the WooPayments dashboard. The click popover is unchanged.

Fixes [A4A-3098](https://linear.app/a8c/issue/A4A-3098).
