### PR TITLE
Dashboard: collect the .uk registrant type in domain contact details

### DIFF
--- a/client/dashboard/components/domain-contact-details-form/contact-form.tsx
+++ b/client/dashboard/components/domain-contact-details-form/contact-form.tsx
@@ -19,11 +19,22 @@ import Notice from '../notice';
 import { getContactFormFields } from './contact-form-fields';
 import { mapValidationMessagesToFieldErrors } from './contact-validation-utils';
 import { RegionAddressFieldsLayout } from './region-address-fieldsets';
+import {
+	getUkContactFormFields,
+	getUkContactFormLayout,
+	getUkExtra,
+	hasUkDomain,
+} from './uk-contact-fields';
 import type { UseMutateAsyncFunction } from '@tanstack/react-query';
 interface ContactFormProps {
 	initialData?: DomainContactDetails;
 	beforeFormCard?: React.ReactNode;
 	beforeForm?: React.ReactNode;
+	/**
+	 * The domains being edited. Drives the ccTLD sections, which the registrar
+	 * requires on the payload for TLDs such as `.uk`.
+	 */
+	domainNames: string[];
 	isSubmitting: boolean;
 	onSubmit: ( normalizedFormData: DomainContactDetails ) => void;
 	validate: UseMutateAsyncFunction< DomainContactValidationResponse, Error, DomainContactDetails >;
@@ -31,6 +42,7 @@ interface ContactFormProps {
 
 export default function ContactForm( {
 	initialData,
+	domainNames,
 	isSubmitting,
 	beforeFormCard,
 	beforeForm,
@@ -100,15 +112,27 @@ export default function ContactForm( {
 			} );
 	}, [ validate ] );
 
+	const needsUkFields = useMemo( () => hasUkDomain( domainNames ), [ domainNames ] );
+	const ukRegistrantType = getUkExtra( normalizedFormData ).registrantType;
+
 	const fields: Field< DomainContactDetails >[] = useMemo(
-		() =>
-			getContactFormFields(
+		() => [
+			...getContactFormFields(
 				countryList ?? [],
 				statesList ?? [],
 				selectedCountryCode,
 				asyncValidator
 			),
-		[ countryList, statesList, selectedCountryCode, asyncValidator ]
+			...( needsUkFields ? getUkContactFormFields( ukRegistrantType ) : [] ),
+		],
+		[
+			countryList,
+			statesList,
+			selectedCountryCode,
+			asyncValidator,
+			needsUkFields,
+			ukRegistrantType,
+		]
 	);
 
 	const form = {
@@ -131,6 +155,7 @@ export default function ContactForm( {
 				countryList,
 				countryCode: selectedCountryCode,
 			} ),
+			...( needsUkFields ? getUkContactFormLayout( ukRegistrantType ) : [] ),
 			'optOutTransferLock',
 		],
 	};

--- a/client/dashboard/components/domain-contact-details-form/contact-validation-utils.ts
+++ b/client/dashboard/components/domain-contact-details-form/contact-validation-utils.ts
@@ -1,7 +1,9 @@
+import { UK_FIELD_TO_API_KEY_MAP } from './uk-contact-fields';
 import type {
 	ContactValidationResponseMessages,
 	DomainContactDetails,
 	DomainContactValidationResponse,
+	RawContactValidationResponseMessages,
 	SMSCountryCode,
 } from '@automattic/api-core';
 import type { NormalizedField } from '@wordpress/dataviews';
@@ -114,6 +116,16 @@ export const mapValidationMessagesToFieldErrors = (
 			continue;
 		}
 		const messagesForField = messages[ apiKey ];
+		if ( Array.isArray( messagesForField ) && messagesForField.length > 0 ) {
+			fieldErrors[ fieldId ] = messagesForField[ 0 ];
+		}
+	}
+
+	// ccTLD errors are keyed by their dotted path (`extra.uk.registrant_type`)
+	// rather than nested under `extra`, so they need a separate lookup.
+	const rawMessages = messages as RawContactValidationResponseMessages;
+	for ( const [ fieldId, apiKey ] of Object.entries( UK_FIELD_TO_API_KEY_MAP ) ) {
+		const messagesForField = rawMessages[ apiKey ];
 		if ( Array.isArray( messagesForField ) && messagesForField.length > 0 ) {
 			fieldErrors[ fieldId ] = messagesForField[ 0 ];
 		}

--- a/client/dashboard/components/domain-contact-details-form/test/contact-validation-utils.test.ts
+++ b/client/dashboard/components/domain-contact-details-form/test/contact-validation-utils.test.ts
@@ -27,6 +27,20 @@ describe( 'mapValidationMessagesToFieldErrors', () => {
 
 		expect( mapValidationMessagesToFieldErrors( messages ) ).toEqual( {} );
 	} );
+
+	it( 'maps the dotted ccTLD keys the endpoint reports .uk errors under', () => {
+		const messages = {
+			'extra.uk.registrant_type': [ 'Please choose a registrant type.' ],
+			'extra.uk.registration_number': [ 'Please use a valid registration number.' ],
+			email: [ 'Invalid email.' ],
+		} as unknown as ContactValidationResponseMessages;
+
+		expect( mapValidationMessagesToFieldErrors( messages ) ).toEqual( {
+			email: 'Invalid email.',
+			ukRegistrantType: 'Please choose a registrant type.',
+			ukRegistrationNumber: 'Please use a valid registration number.',
+		} );
+	} );
 } );
 
 const SMS_COUNTRY_CODES: SMSCountryCode[] = [

--- a/client/dashboard/components/domain-contact-details-form/test/uk-contact-fields.test.ts
+++ b/client/dashboard/components/domain-contact-details-form/test/uk-contact-fields.test.ts
@@ -1,0 +1,177 @@
+import {
+	UK_FIELD_IDS,
+	getUkContactFormFields,
+	getUkContactFormLayout,
+	hasUkDomain,
+	isUkDomain,
+	mapWhoisExtraToUkContactExtra,
+} from '../uk-contact-fields';
+import type { DomainContactDetails } from '@automattic/api-core';
+import type { Field } from '@wordpress/dataviews';
+
+const fieldById = ( fields: Field< DomainContactDetails >[], id: string ) =>
+	fields.find( ( field ) => field.id === id );
+
+describe( 'isUkDomain', () => {
+	test.each( [
+		'philemon.co.uk',
+		'example.uk',
+		'example.me.uk',
+		'example.org.uk',
+		'EXAMPLE.CO.UK',
+	] )( 'treats %s as a .uk domain', ( domainName ) => {
+		expect( isUkDomain( domainName ) ).toBe( true );
+	} );
+
+	test.each( [ 'example.com', 'example.co.uk.com', 'exampleuk', 'example.ukx' ] )(
+		'treats %s as a non-.uk domain',
+		( domainName ) => {
+			expect( isUkDomain( domainName ) ).toBe( false );
+		}
+	);
+} );
+
+describe( 'hasUkDomain', () => {
+	it( 'is true when any selected domain is a .uk one', () => {
+		expect( hasUkDomain( [ 'example.com', 'philemon.co.uk' ] ) ).toBe( true );
+	} );
+
+	it( 'is false when none are', () => {
+		expect( hasUkDomain( [ 'example.com', 'example.fr' ] ) ).toBe( false );
+	} );
+
+	it( 'is false for an empty selection', () => {
+		expect( hasUkDomain( [] ) ).toBe( false );
+	} );
+} );
+
+describe( 'getUkContactFormFields', () => {
+	it( 'always requires a registrant type and offers no pre-selected value', () => {
+		const registrantType = fieldById(
+			getUkContactFormFields( undefined ),
+			UK_FIELD_IDS.registrantType
+		);
+
+		expect( registrantType?.isValid?.required ).toBe( true );
+		// An empty first option keeps the control unselected, so a registrant whose
+		// stored type is unknown has to choose rather than inheriting a default.
+		expect( registrantType?.elements?.[ 0 ] ).toEqual( {
+			label: expect.any( String ),
+			value: '',
+		} );
+		expect( registrantType?.getValue?.( { item: { optOutTransferLock: false } } ) ).toBe( '' );
+	} );
+
+	it( 'omits the conditional fields for a registrant type that needs neither', () => {
+		const fields = getUkContactFormFields( 'IND' );
+
+		expect( fieldById( fields, UK_FIELD_IDS.tradingName ) ).toBeUndefined();
+		expect( fieldById( fields, UK_FIELD_IDS.registrationNumber ) ).toBeUndefined();
+		expect( getUkContactFormLayout( 'IND' ) ).toEqual( [ UK_FIELD_IDS.registrantType ] );
+	} );
+
+	it( 'adds both conditional fields for a corporate registrant type', () => {
+		const fields = getUkContactFormFields( 'LTD' );
+
+		expect( fieldById( fields, UK_FIELD_IDS.tradingName )?.isValid?.required ).toBe( true );
+		expect( fieldById( fields, UK_FIELD_IDS.registrationNumber )?.isValid?.required ).toBe( true );
+		expect( getUkContactFormLayout( 'LTD' ) ).toEqual( [
+			UK_FIELD_IDS.registrantType,
+			UK_FIELD_IDS.tradingName,
+			UK_FIELD_IDS.registrationNumber,
+		] );
+	} );
+
+	it( 'adds only the trading name for a sole trader', () => {
+		expect( getUkContactFormLayout( 'STRA' ) ).toEqual( [
+			UK_FIELD_IDS.registrantType,
+			UK_FIELD_IDS.tradingName,
+		] );
+	} );
+
+	it( 'adds only the registration number for a school', () => {
+		expect( getUkContactFormLayout( 'SCH' ) ).toEqual( [
+			UK_FIELD_IDS.registrantType,
+			UK_FIELD_IDS.registrationNumber,
+		] );
+	} );
+
+	it( 'reads nested values out of extra.uk', () => {
+		const item: DomainContactDetails = {
+			optOutTransferLock: false,
+			extra: { uk: { registrantType: 'LTD', tradingName: 'Stuart Lee Therapy' } },
+		};
+
+		const fields = getUkContactFormFields( 'LTD' );
+
+		expect( fieldById( fields, UK_FIELD_IDS.registrantType )?.getValue?.( { item } ) ).toBe(
+			'LTD'
+		);
+		expect( fieldById( fields, UK_FIELD_IDS.tradingName )?.getValue?.( { item } ) ).toBe(
+			'Stuart Lee Therapy'
+		);
+	} );
+
+	it( 'returns the whole extra object on edit so sibling values survive the shallow merge', () => {
+		const item: DomainContactDetails = {
+			optOutTransferLock: false,
+			extra: {
+				ca: { legalType: 'CCT' },
+				uk: { registrantType: 'LTD', registrationNumber: '12345678' },
+			},
+		};
+
+		const tradingName = fieldById( getUkContactFormFields( 'LTD' ), UK_FIELD_IDS.tradingName );
+
+		expect( tradingName?.setValue?.( { item, value: 'Stuart Lee Therapy' } ) ).toEqual( {
+			extra: {
+				ca: { legalType: 'CCT' },
+				uk: {
+					registrantType: 'LTD',
+					registrationNumber: '12345678',
+					tradingName: 'Stuart Lee Therapy',
+				},
+			},
+		} );
+	} );
+
+	it( 'rejects a registration number that does not match the registrar format', () => {
+		const field = fieldById( getUkContactFormFields( 'LTD' ), UK_FIELD_IDS.registrationNumber );
+
+		const pattern = new RegExp( field?.isValid?.pattern ?? '' );
+
+		expect( pattern.test( '12345678' ) ).toBe( true );
+		expect( pattern.test( 'AB123456' ) ).toBe( true );
+		expect( pattern.test( 'A1234567' ) ).toBe( true );
+		expect( pattern.test( '12345' ) ).toBe( false );
+		expect( pattern.test( 'not-a-number' ) ).toBe( false );
+	} );
+} );
+
+describe( 'mapWhoisExtraToUkContactExtra', () => {
+	it( 'converts the registrar snake_case keys to the form shape', () => {
+		expect(
+			mapWhoisExtraToUkContactExtra( {
+				registrant_type: 'LTD',
+				trading_name: 'Stuart Lee Therapy',
+				registration_number: '12345678',
+			} )
+		).toEqual( {
+			registrantType: 'LTD',
+			tradingName: 'Stuart Lee Therapy',
+			registrationNumber: '12345678',
+		} );
+	} );
+
+	it( 'omits conditional values the registrar has not stored', () => {
+		expect( mapWhoisExtraToUkContactExtra( { registrant_type: 'IND' } ) ).toEqual( {
+			registrantType: 'IND',
+		} );
+	} );
+
+	it( 'returns undefined when there is no stored registrant type, rather than guessing one', () => {
+		expect( mapWhoisExtraToUkContactExtra( undefined ) ).toBeUndefined();
+		expect( mapWhoisExtraToUkContactExtra( {} ) ).toBeUndefined();
+		expect( mapWhoisExtraToUkContactExtra( { registrant_type: '' } ) ).toBeUndefined();
+	} );
+} );

--- a/client/dashboard/components/domain-contact-details-form/test/uk-contact-fields.test.ts
+++ b/client/dashboard/components/domain-contact-details-form/test/uk-contact-fields.test.ts
@@ -135,6 +135,54 @@ describe( 'getUkContactFormFields', () => {
 		} );
 	} );
 
+	it( 'drops the conditional values a newly picked registrant type does not ask for', () => {
+		const item: DomainContactDetails = {
+			optOutTransferLock: false,
+			extra: {
+				ca: { legalType: 'CCT' },
+				uk: {
+					registrantType: 'LTD',
+					tradingName: 'Stuart Lee Therapy',
+					registrationNumber: '12345678',
+				},
+			},
+		};
+
+		const registrantType = fieldById(
+			getUkContactFormFields( 'LTD' ),
+			UK_FIELD_IDS.registrantType
+		);
+
+		// Left behind, they stay on the payload with no control on screen to fix
+		// them — and the registrar checks a registration number's format whether
+		// or not the type requires one.
+		expect( registrantType?.setValue?.( { item, value: 'IND' } ) ).toEqual( {
+			extra: { ca: { legalType: 'CCT' }, uk: { registrantType: 'IND' } },
+		} );
+	} );
+
+	it( 'keeps a conditional value the new registrant type still asks for', () => {
+		const item: DomainContactDetails = {
+			optOutTransferLock: false,
+			extra: {
+				uk: {
+					registrantType: 'LTD',
+					tradingName: 'Stuart Lee Therapy',
+					registrationNumber: '12345678',
+				},
+			},
+		};
+
+		const registrantType = fieldById(
+			getUkContactFormFields( 'LTD' ),
+			UK_FIELD_IDS.registrantType
+		);
+
+		expect( registrantType?.setValue?.( { item, value: 'STRA' } ) ).toEqual( {
+			extra: { uk: { registrantType: 'STRA', tradingName: 'Stuart Lee Therapy' } },
+		} );
+	} );
+
 	it( 'rejects a registration number that does not match the registrar format', () => {
 		const field = fieldById( getUkContactFormFields( 'LTD' ), UK_FIELD_IDS.registrationNumber );
 

--- a/client/dashboard/components/domain-contact-details-form/uk-contact-fields.tsx
+++ b/client/dashboard/components/domain-contact-details-form/uk-contact-fields.tsx
@@ -1,0 +1,197 @@
+import { __ } from '@wordpress/i18n';
+import type {
+	DomainContactDetails,
+	UkDomainContactExtraDetails,
+	WhoisContactExtra,
+} from '@automattic/api-core';
+import type { Field } from '@wordpress/dataviews';
+
+/**
+ * `.uk` registrant types accepted by the registrar, as listed in the `.uk`
+ * validation schema. The labels match the ones used at checkout so a registrant
+ * sees the same wording when buying and when editing.
+ * @see http://domains.opensrs.guide/docs/tld#section-uk
+ */
+const REGISTRANT_TYPE_LABELS: Record< string, () => string > = {
+	IND: () => __( 'Individual' ),
+	FIND: () => __( 'Foreign Individual' ),
+	STRA: () =>
+		/* translators: refers to the UK legal concept of self-employment/sole proprietorship */
+		__( 'UK Sole Trader' ),
+	PTNR: () => __( 'UK Partnership' ),
+	LTD: () => __( 'UK Limited Company' ),
+	LLP: () => __( 'UK Limited Liability Partnership' ),
+	CRC: () => __( 'UK Corporation by Royal Charter' ),
+	FCORP: () => __( 'Non-UK Corporation' ),
+	IP: () => __( 'UK Industrial/Provident Registered Company' ),
+	PLC: () => __( 'UK Public Limited Company' ),
+	SCH: () => __( 'UK School' ),
+	GOV: () => __( 'UK Government Body' ),
+	RCHAR: () => __( 'UK Registered Charity' ),
+	STAT: () => __( 'UK Statutory Body' ),
+	OTHER: () => __( 'UK Entity that does not fit another category' ),
+	FOTHER: () => __( 'Non-UK Entity that does not fit another category' ),
+};
+
+const TRADING_NAME_REQUIRED_FOR = [
+	'LTD',
+	'PLC',
+	'LLP',
+	'IP',
+	'RCHAR',
+	'FCORP',
+	'OTHER',
+	'FOTHER',
+	'STRA',
+];
+
+const REGISTRATION_NUMBER_REQUIRED_FOR = [ 'LTD', 'PLC', 'LLP', 'IP', 'SCH', 'RCHAR' ];
+
+const REGISTRATION_NUMBER_PATTERN = '^([a-zA-Z]{2}[0-9]{6}|[a-zA-Z][0-9]{7}|[0-9]{6,8})$';
+
+const TRADING_NAME_MIN_LENGTH = 4;
+
+export const UK_FIELD_IDS = {
+	registrantType: 'ukRegistrantType',
+	tradingName: 'ukTradingName',
+	registrationNumber: 'ukRegistrationNumber',
+} as const;
+
+/**
+ * Maps each `.uk` form field to the dotted path the validation endpoint reports
+ * its errors under, so a server message can be attached to the right control.
+ */
+export const UK_FIELD_TO_API_KEY_MAP: Record< string, string > = {
+	[ UK_FIELD_IDS.registrantType ]: 'extra.uk.registrant_type',
+	[ UK_FIELD_IDS.tradingName ]: 'extra.uk.trading_name',
+	[ UK_FIELD_IDS.registrationNumber ]: 'extra.uk.registration_number',
+};
+
+/**
+ * Every `.uk` second-level domain (.uk, .co.uk, .me.uk, .org.uk) shares the same
+ * registrant-type contract, so the top-level suffix is the only check needed.
+ */
+export function isUkDomain( domainName: string ) {
+	return domainName.toLowerCase().endsWith( '.uk' );
+}
+
+export function hasUkDomain( domainNames: string[] ) {
+	return domainNames.some( isUkDomain );
+}
+
+export function getUkExtra( data: DomainContactDetails ): UkDomainContactExtraDetails {
+	return data.extra?.uk ?? {};
+}
+
+/**
+ * Converts the registrar's stored `.uk` registrant details into the shape the
+ * form holds them in. The WHOIS read returns the registrar's own flat snake_case
+ * keys, so nothing here is nested under `uk` yet.
+ *
+ * Returns undefined when the registrar has nothing stored, which leaves the
+ * registrant type unselected rather than guessing one.
+ */
+export function mapWhoisExtraToUkContactExtra(
+	extra: WhoisContactExtra | undefined
+): UkDomainContactExtraDetails | undefined {
+	if ( ! extra?.registrant_type ) {
+		return undefined;
+	}
+
+	return {
+		registrantType: extra.registrant_type,
+		...( extra.trading_name ? { tradingName: extra.trading_name } : {} ),
+		...( extra.registration_number ? { registrationNumber: extra.registration_number } : {} ),
+	};
+}
+
+function setUkExtra(
+	item: DomainContactDetails,
+	edits: UkDomainContactExtraDetails
+): Partial< DomainContactDetails > {
+	// Return the whole `extra` object: the form merges edits shallowly, so a
+	// partial one would drop the sibling `.uk` values and any other ccTLD data.
+	return { extra: { ...item.extra, uk: { ...getUkExtra( item ), ...edits } } };
+}
+
+export function requiresTradingName( registrantType?: string ) {
+	return !! registrantType && TRADING_NAME_REQUIRED_FOR.includes( registrantType );
+}
+
+export function requiresRegistrationNumber( registrantType?: string ) {
+	return !! registrantType && REGISTRATION_NUMBER_REQUIRED_FOR.includes( registrantType );
+}
+
+/**
+ * Builds the `.uk` registrant fields for the contact form.
+ *
+ * The trading name and registration number are only included when the selected
+ * registrant type calls for them: DataForm's `required` rule is static, so
+ * omitting the field entirely is what keeps Save correctly gated as the type
+ * changes.
+ */
+export const getUkContactFormFields = (
+	registrantType: string | undefined
+): Field< DomainContactDetails >[] => {
+	const fields: Field< DomainContactDetails >[] = [
+		{
+			id: UK_FIELD_IDS.registrantType,
+			label: __( 'Choose the option that best describes your presence in the United Kingdom' ),
+			Edit: 'select',
+			// No default: the registrar's stored type is prefilled when known, and
+			// otherwise the registrant picks one. Defaulting (to `IND`, say) would
+			// silently rewrite a business registrant's type on an unrelated edit.
+			elements: [
+				{ label: __( 'Select an option' ), value: '' },
+				...Object.entries( REGISTRANT_TYPE_LABELS ).map( ( [ value, getLabel ] ) => ( {
+					label: getLabel(),
+					value,
+				} ) ),
+			],
+			getValue: ( { item } ) => getUkExtra( item ).registrantType ?? '',
+			setValue: ( { item, value } ) => setUkExtra( item, { registrantType: value } ),
+			isValid: { required: true },
+		},
+	];
+
+	if ( requiresTradingName( registrantType ) ) {
+		fields.push( {
+			id: UK_FIELD_IDS.tradingName,
+			label: __( 'Trading name' ),
+			type: 'text',
+			getValue: ( { item } ) => getUkExtra( item ).tradingName ?? '',
+			setValue: ( { item, value } ) => setUkExtra( item, { tradingName: value } ),
+			isValid: { required: true, minLength: TRADING_NAME_MIN_LENGTH },
+		} );
+	}
+
+	if ( requiresRegistrationNumber( registrantType ) ) {
+		fields.push( {
+			id: UK_FIELD_IDS.registrationNumber,
+			label: __( 'Registration number' ),
+			type: 'text',
+			getValue: ( { item } ) => getUkExtra( item ).registrationNumber ?? '',
+			setValue: ( { item, value } ) => setUkExtra( item, { registrationNumber: value } ),
+			isValid: { required: true, pattern: REGISTRATION_NUMBER_PATTERN },
+		} );
+	}
+
+	return fields;
+};
+
+/**
+ * The `.uk` field IDs to lay out, in order, for the current registrant type.
+ */
+export const getUkContactFormLayout = ( registrantType: string | undefined ): string[] => {
+	const layout: string[] = [ UK_FIELD_IDS.registrantType ];
+
+	if ( requiresTradingName( registrantType ) ) {
+		layout.push( UK_FIELD_IDS.tradingName );
+	}
+
+	if ( requiresRegistrationNumber( registrantType ) ) {
+		layout.push( UK_FIELD_IDS.registrationNumber );
+	}
+
+	return layout;
+};

--- a/client/dashboard/components/domain-contact-details-form/uk-contact-fields.tsx
+++ b/client/dashboard/components/domain-contact-details-form/uk-contact-fields.tsx
@@ -114,6 +114,36 @@ function setUkExtra(
 	return { extra: { ...item.extra, uk: { ...getUkExtra( item ), ...edits } } };
 }
 
+/**
+ * Sets the registrant type, dropping the conditional values the new type does
+ * not ask for.
+ *
+ * Hiding those fields is not enough: their values stay on the payload, and the
+ * registrar validates a registration number's format whenever one is present,
+ * whatever the registrant type. A number left behind by an earlier selection
+ * would fail validation with no control on screen to correct it.
+ */
+function setUkRegistrantType(
+	item: DomainContactDetails,
+	registrantType: string
+): Partial< DomainContactDetails > {
+	const { tradingName, registrationNumber, ...rest } = getUkExtra( item );
+
+	return {
+		extra: {
+			...item.extra,
+			uk: {
+				...rest,
+				registrantType,
+				...( requiresTradingName( registrantType ) && tradingName ? { tradingName } : {} ),
+				...( requiresRegistrationNumber( registrantType ) && registrationNumber
+					? { registrationNumber }
+					: {} ),
+			},
+		},
+	};
+}
+
 export function requiresTradingName( registrantType?: string ) {
 	return !! registrantType && TRADING_NAME_REQUIRED_FOR.includes( registrantType );
 }
@@ -149,7 +179,7 @@ export const getUkContactFormFields = (
 				} ) ),
 			],
 			getValue: ( { item } ) => getUkExtra( item ).registrantType ?? '',
-			setValue: ( { item, value } ) => setUkExtra( item, { registrantType: value } ),
+			setValue: ( { item, value } ) => setUkRegistrantType( item, value ),
 			isValid: { required: true },
 		},
 	];

--- a/client/dashboard/domains/domain-contact-details/index.tsx
+++ b/client/dashboard/domains/domain-contact-details/index.tsx
@@ -17,6 +17,10 @@ import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { Card, CardBody } from '../../components/card';
 import ContactForm from '../../components/domain-contact-details-form/contact-form';
 import ContactFormPrivacy from '../../components/domain-contact-details-form/contact-form-privacy';
+import {
+	isUkDomain,
+	mapWhoisExtraToUkContactExtra,
+} from '../../components/domain-contact-details-form/uk-contact-fields';
 import { findRegistrantWhois } from '../../utils/domain';
 import { DomainContactDetailsLayout } from './layout';
 import type { DomainContactDetails } from '@automattic/api-core';
@@ -30,7 +34,11 @@ export default function DomainContactInfo() {
 	const registrantWhoisData = findRegistrantWhois( whoisData );
 
 	const { initialData, key } = useMemo( () => {
-		const initialData = {
+		const ukExtra = isUkDomain( domainName )
+			? mapWhoisExtraToUkContactExtra( registrantWhoisData?.extra )
+			: undefined;
+
+		const initialData: DomainContactDetails = {
 			firstName: registrantWhoisData?.fname ?? '',
 			lastName: registrantWhoisData?.lname ?? '',
 			organization: registrantWhoisData?.org ?? '',
@@ -44,10 +52,11 @@ export default function DomainContactInfo() {
 			postalCode: registrantWhoisData?.pc ?? '',
 			fax: registrantWhoisData?.fax ?? '',
 			optOutTransferLock: false,
+			...( ukExtra ? { extra: { uk: ukExtra } } : {} ),
 		};
 
 		return { initialData, key: JSON.stringify( initialData ) };
-	}, [ registrantWhoisData ] );
+	}, [ registrantWhoisData, domainName ] );
 
 	const validateMutation = useMutation(
 		withSnackbar( domainWhoisValidateMutation( [ domainName ] ), { error: { source: 'server' } } )
@@ -124,6 +133,7 @@ export default function DomainContactInfo() {
 	return (
 		<DomainContactDetailsLayout>
 			<ContactForm
+				domainNames={ [ domainName ] }
 				isSubmitting={ isSubmitting }
 				onSubmit={ handleSubmit }
 				beforeFormCard={

--- a/client/dashboard/domains/domains-contact-details/index.tsx
+++ b/client/dashboard/domains/domains-contact-details/index.tsx
@@ -14,6 +14,10 @@ import { useMemo } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { domainsContactInfoRoute, domainsIndexRoute } from '../../app/router/domains';
 import ContactForm from '../../components/domain-contact-details-form/contact-form';
+import {
+	hasUkDomain,
+	mapWhoisExtraToUkContactExtra,
+} from '../../components/domain-contact-details-form/uk-contact-fields';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -79,12 +83,34 @@ export default function DomainsContactInfo() {
 			return { initialData, key: JSON.stringify( initialData ) };
 		}
 
-		const initialData = aggregateWhoisDataWithMostCommonValues(
-			whoisData.flat().filter( ( whois ) => whois.type === WhoisType.REGISTRANT )
-		);
+		const registrantWhois = whoisData
+			.flat()
+			.filter( ( whois ) => whois.type === WhoisType.REGISTRANT );
+
+		const initialData = aggregateWhoisDataWithMostCommonValues( registrantWhois );
+
+		// Follow the same most-common-value rule as every other field: when the
+		// selected .uk domains disagree on registrant type there is no single right
+		// answer, so the majority one is offered and the registrant can correct it.
+		const mostCommonExtraValue = ( fieldName: string ) =>
+			mostCommonValueInArray(
+				registrantWhois.map( ( whois ) => whois.extra?.[ fieldName ] ?? '' )
+			) ?? '';
+
+		const ukExtra = hasUkDomain( selectedDomains )
+			? mapWhoisExtraToUkContactExtra( {
+					registrant_type: mostCommonExtraValue( 'registrant_type' ),
+					trading_name: mostCommonExtraValue( 'trading_name' ),
+					registration_number: mostCommonExtraValue( 'registration_number' ),
+			  } )
+			: undefined;
+
+		if ( ukExtra ) {
+			initialData.extra = { uk: ukExtra };
+		}
 
 		return { initialData, key: JSON.stringify( initialData ) };
-	}, [ whoisData ] );
+	}, [ whoisData, selectedDomains ] );
 
 	const domainsWithUnmodifiableContactInfo = useMemo( () => {
 		return domainDetails
@@ -164,6 +190,7 @@ export default function DomainsContactInfo() {
 		>
 			<ContactForm
 				key={ key }
+				domainNames={ selectedDomains }
 				initialData={ initialData }
 				beforeForm={
 					<Notice

--- a/client/dashboard/domains/domains-contact-details/index.tsx
+++ b/client/dashboard/domains/domains-contact-details/index.tsx
@@ -15,7 +15,7 @@ import Breadcrumbs from '../../app/breadcrumbs';
 import { domainsContactInfoRoute, domainsIndexRoute } from '../../app/router/domains';
 import ContactForm from '../../components/domain-contact-details-form/contact-form';
 import {
-	hasUkDomain,
+	isUkDomain,
 	mapWhoisExtraToUkContactExtra,
 } from '../../components/domain-contact-details-form/uk-contact-fields';
 import Notice from '../../components/notice';
@@ -89,15 +89,24 @@ export default function DomainsContactInfo() {
 
 		const initialData = aggregateWhoisDataWithMostCommonValues( registrantWhois );
 
+		// Only the .uk domains carry registrant details, so they vote alone. The
+		// loader keeps `whoisData` in `selectedDomains` order, which is what makes
+		// the index check work. Counting the rest in would let their empty values
+		// win the majority and drop a prefill the .uk domains agreed on.
+		const ukRegistrantWhois = whoisData
+			.filter( ( _, index ) => isUkDomain( selectedDomains[ index ] ) )
+			.flat()
+			.filter( ( whois ) => whois.type === WhoisType.REGISTRANT );
+
 		// Follow the same most-common-value rule as every other field: when the
 		// selected .uk domains disagree on registrant type there is no single right
 		// answer, so the majority one is offered and the registrant can correct it.
 		const mostCommonExtraValue = ( fieldName: string ) =>
 			mostCommonValueInArray(
-				registrantWhois.map( ( whois ) => whois.extra?.[ fieldName ] ?? '' )
+				ukRegistrantWhois.map( ( whois ) => whois.extra?.[ fieldName ] ?? '' )
 			) ?? '';
 
-		const ukExtra = hasUkDomain( selectedDomains )
+		const ukExtra = ukRegistrantWhois.length
 			? mapWhoisExtraToUkContactExtra( {
 					registrant_type: mostCommonExtraValue( 'registrant_type' ),
 					trading_name: mostCommonExtraValue( 'trading_name' ),

--- a/packages/api-core/src/domain-whois/types.ts
+++ b/packages/api-core/src/domain-whois/types.ts
@@ -129,6 +129,15 @@ export type FrDomainContactExtraDetails = {
 	trademarkNumber?: string;
 	sirenSiret?: string;
 };
+/**
+ * ccTLD registrant details the registrar stores alongside the WHOIS contact.
+ *
+ * Only present for TLDs that declare extra contact fields (for example `.uk`,
+ * which stores `registrant_type`). The keys are the registrar's own snake_case
+ * names and differ per TLD, so this stays deliberately loose.
+ */
+export type WhoisContactExtra = Record< string, string >;
+
 export interface WhoisDataEntry {
 	fname: string;
 	lname: string;
@@ -145,6 +154,7 @@ export interface WhoisDataEntry {
 	fax: string;
 	state: string;
 	type: WhoisType;
+	extra?: WhoisContactExtra;
 }
 
 export interface WhoisEmailRecord {


### PR DESCRIPTION
<!-- No linked issue yet. -->
Task-related: DOMENG-850


## Proposed Changes

- .UK domains will now have a new field on Contact Information edition called `Choose the option that best describes your presence in the United Kingdom`:

<img width="972" height="444" alt="image" src="https://github.com/user-attachments/assets/e9804069-e238-45ba-8f1d-fd9db4da0c07" />


- Also, if the user selects `UK Limited Company` it will open two extra fields:

<img width="744" height="613" alt="image" src="https://github.com/user-attachments/assets/2d4bcd26-c89b-4afe-919e-f56bc3177909" />



## Why are these changes being made?

`.uk` domains are validated against a TLD-specific JSON schema that unconditionally requires an `extra.uk` object carrying `registrant_type`, plus `registration_number` and/or `trading_name` for corporate registrant types. The dashboard contact form never sent one, so **every** contact update for a `.uk` domain failed validation — including edits that only touched the email or address. The failure surfaced as an unhelpful empty-field error:

```json
{ "success": false, "messages": { "": ["There was a problem with this field."] } }
```

Worth recording, since it was the working assumption going in: this is **not** a dashboard regression. The classic contact form has the identical gap — `edit-contact-info/form-card.jsx` builds the same 12 flat fields and posts them with no `extra`, and `ContactDetailsFormFields` has no ccTLD handling. The `registrant-extra-info` components exist but have only ever been wired into checkout. `.uk` contact edits have been broken in both clients; the dashboard inherited the gap rather than dropping something.

**The registrant type deliberately has no default.** Defaulting it (to `IND`, say) would silently rewrite a business registrant's type whenever they edited an unrelated field, and corporate types are exactly the ones that also carry a registration number and trading name. It stays unselected until either the registrar's stored value is known or the registrant picks one.

### Known limitation, worth a look before this ships

The registrant type still will not reach the registrar on save, for two independent backend reasons:

* `WPCOM_JSON_API_Domains_Update_Whois_V1_1_Endpoint::get_contacts()` builds its payload from a fixed 12-field whitelist, so `extra` is dropped before `update_whois` sees it.
* `OpenSRS_Uk_TLD::prepare_api_command()` only injects the extra info for `provSWregister`. The whois update path is `provModify`, which falls through unchanged — and it is called with a null payload addendum regardless.

So `registrant_extra_info` is currently only ever written at registration time. This PR is still the fix for the reported bug — the payload now satisfies the schema, so `.uk` owners can edit their email, address, and phone again — but editing the *registrant type itself* is a silent no-op at the registrar until that write path exists. With prefill in place most registrants will not touch the field. If we want it airtight first, the options are to make the select read-only when prefilled, or to land the backend write path as a follow-up. Happy to take either on.

Prefill also depends on a companion backend change (not in this repo) that passes `fetch_extra` when reading whois, gated on the TLD declaring `contact_extra_fields` so it costs one extra registrar round trip for `.uk`/`.fr`/`.ca` rather than on every whois read. **Without it the section still renders and unblocks contact edits — it simply starts unselected instead of prefilled.**

## Testing Instructions

1. Open the dashboard domain contact details screen for a `.co.uk` (or `.uk`, `.me.uk`, `.org.uk`) domain.
2. Confirm the "Choose the option that best describes your presence in the United Kingdom" select appears below the address fields. With the companion backend change deployed it is prefilled with the domain's stored registrant type; without it, it starts unselected.
3. Leave it unselected and confirm **Save** stays disabled.
4. Pick `UK Limited Company` and confirm both **Trading name** and **Registration number** appear and are required. Pick `UK Sole Trader` — only the trading name should appear. Pick `Individual` — neither should.
5. Enter an invalid registration number (for example `12345`) and confirm it is rejected; `12345678`, `AB123456`, and `A1234567` are accepted.
6. Edit only the email and save. This previously failed with `The field "" is not valid`; it should now succeed.
7. Confirm a non-`.uk` domain (for example a `.com`) shows no new fields and behaves exactly as before.
8. Repeat step 1 via the bulk contact-details flow with a `.uk` domain in the selection.

Automated coverage: `yarn test-client client/dashboard/components/domain-contact-details-form client/dashboard/domains` — 324 tests passing, including a new `uk-contact-fields.test.ts`. `yarn typecheck-client` and `yarn eslint` are clean on the changed files.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors? <!-- typecheck-client is clean; runtime console not yet exercised in a browser -->
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2). <!-- uses the standard labelled select/text controls, but not yet verified with a screen reader -->
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? **This PR introduces new strings (the registrant type labels and field labels) — the label still needs adding.**
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
