### PR TITLE
Masterbar: add active state to the AI chat entry button

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -64,15 +64,10 @@ import isSimpleSite from 'calypso/state/sites/selectors/is-simple-site';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { activateNextLayoutFocus, setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
-import { getSectionGroup, getSectionName } from 'calypso/state/ui/selectors';
+import { getSectionGroup } from 'calypso/state/ui/selectors';
 import Item from './item';
 import Masterbar from './masterbar';
-import BigSkyIcon from './masterbar-agents-manager/big-sky-icon';
-import {
-	closeAgentsManagerChat,
-	isAgentsManagerChatVisible,
-	openAgentsManagerChat,
-} from './masterbar-agents-manager/chat-actions';
+import MasterbarAiChatButton from './masterbar-agents-manager/ai-chat-button';
 import HelpIcon from './masterbar-agents-manager/help-icon';
 import { HelpCenterIcon } from './masterbar-help-center/help-center-icon';
 import { MasterbarLaunchButton } from './masterbar-launch-button';
@@ -103,7 +98,6 @@ class MasterbarLoggedIn extends Component {
 		user: PropTypes.object.isRequired,
 		domainOnlySite: PropTypes.bool,
 		section: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
-		sectionName: PropTypes.string,
 		setNextLayoutFocus: PropTypes.func.isRequired,
 		currentLayoutFocus: PropTypes.string,
 		siteSlug: PropTypes.string,
@@ -1010,34 +1004,6 @@ class MasterbarLoggedIn extends Component {
 		);
 	}
 
-	clickAgentsManagerAiChat = () => {
-		// Toggle: close the chat if it's already showing, otherwise resume the active
-		// conversation and open it.
-		const isVisible = isAgentsManagerChatVisible();
-		this.props.recordTracksEvent( 'calypso_masterbar_agents_manager_ai_chat_clicked', {
-			section: this.props.sectionName,
-			action: isVisible ? 'close' : 'open',
-		} );
-		if ( isVisible ) {
-			closeAgentsManagerChat();
-		} else {
-			openAgentsManagerChat();
-		}
-	};
-
-	renderAgentsManagerAiChat() {
-		const { translate } = this.props;
-
-		return (
-			<Item
-				className="masterbar__item-agents-manager-ai-chat"
-				onClick={ this.clickAgentsManagerAiChat }
-				icon={ <BigSkyIcon /> }
-				tooltip={ translate( 'Ask AI' ) }
-			/>
-		);
-	}
-
 	render() {
 		const {
 			isCheckout,
@@ -1073,7 +1039,7 @@ class MasterbarLoggedIn extends Component {
 					{ loadHelpCenterIcon && this.renderHelpCenter() }
 					{ /* Show the AI button only where the chat dock is mounted (same two
 					     conditions the dock loads on), so clicking it always opens the chat. */ }
-					{ useUnifiedAgent && loadAgentsManager && this.renderAgentsManagerAiChat() }
+					{ useUnifiedAgent && loadAgentsManager && <MasterbarAiChatButton /> }
 					{ this.renderNotifications() }
 					{ this.renderProfileMenu() }
 				</div>
@@ -1119,7 +1085,6 @@ const ConnectedMasterbarLoggedIn = connect(
 			adminMenu: getAdminMenu( state, siteId ),
 			sectionGroup,
 			sidebarType,
-			sectionName: getSectionName( state ),
 			domainOnlySite: isDomainOnlySite( state, siteId ),
 			hasNoSites: siteCount === 0,
 			user: getCurrentUser( state ),

--- a/client/layout/masterbar/masterbar-agents-manager/ai-chat-button.tsx
+++ b/client/layout/masterbar/masterbar-agents-manager/ai-chat-button.tsx
@@ -1,0 +1,48 @@
+import { AGENTS_MANAGER_STORE } from '@automattic/agents-manager';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useSelect } from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { getSectionName } from 'calypso/state/ui/selectors';
+import Item from '../item';
+import BigSkyIcon from './big-sky-icon';
+import { closeAgentsManagerChat, openAgentsManagerChat } from './chat-actions';
+import type { AgentsManagerSelect } from '@automattic/data-stores';
+import './style.scss';
+
+const MasterbarAiChatButton = () => {
+	const translate = useTranslate();
+	const sectionName = useSelector( getSectionName );
+
+	const { isOpen, isMinimized } = useSelect(
+		( select ) => ( select( AGENTS_MANAGER_STORE ) as AgentsManagerSelect ).getAgentsManagerState(),
+		[]
+	);
+	const isChatVisible = isOpen && ! isMinimized;
+
+	// Toggle: close the chat if it's already showing, otherwise resume the active
+	// conversation and open it.
+	const handleClick = () => {
+		recordTracksEvent( 'calypso_masterbar_agents_manager_ai_chat_clicked', {
+			section: sectionName,
+			action: isChatVisible ? 'close' : 'open',
+		} );
+		if ( isChatVisible ) {
+			closeAgentsManagerChat();
+		} else {
+			openAgentsManagerChat();
+		}
+	};
+
+	return (
+		<Item
+			className="masterbar__item-agents-manager-ai-chat"
+			onClick={ handleClick }
+			icon={ <BigSkyIcon /> }
+			isActive={ isChatVisible }
+			tooltip={ translate( 'Ask AI' ) }
+		/>
+	);
+};
+
+export default MasterbarAiChatButton;

--- a/client/layout/masterbar/masterbar-agents-manager/index.jsx
+++ b/client/layout/masterbar/masterbar-agents-manager/index.jsx
@@ -5,7 +5,6 @@ import { usePrevious } from '@wordpress/compose';
 import { useSelect as useDateStoreSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { Icon, comment, backup, page, video, rss } from '@wordpress/icons';
-import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import getIsNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
@@ -150,10 +149,7 @@ const MasterbarAgentsManager = ( { tooltip } ) => {
 	return (
 		<Item
 			onClick={ trackIconInteraction }
-			className={ clsx( 'masterbar__item-agents-manager', {
-				'is-active': agentsManagerVisible,
-				'is-menu-panel': true,
-			} ) }
+			className="masterbar__item-agents-manager"
 			wrapperClassName="is-menu-panel"
 			tooltip={ tooltip }
 			icon={ <HelpIcon /> }

--- a/client/layout/masterbar/masterbar-agents-manager/test/ai-chat-button.tsx
+++ b/client/layout/masterbar/masterbar-agents-manager/test/ai-chat-button.tsx
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createReduxStore, dispatch, register } from '@wordpress/data';
+import React from 'react';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import MasterbarAiChatButton from '../ai-chat-button';
+import { closeAgentsManagerChat, openAgentsManagerChat } from '../chat-actions';
+
+type ChatState = { isOpen: boolean; isMinimized: boolean };
+
+const TEST_STORE = 'automattic/agents-manager-test';
+
+jest.mock( '@automattic/agents-manager', () => ( {
+	AGENTS_MANAGER_STORE: 'automattic/agents-manager-test',
+} ) );
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+jest.mock( '../chat-actions', () => ( {
+	closeAgentsManagerChat: jest.fn(),
+	openAgentsManagerChat: jest.fn(),
+} ) );
+
+const testStore = createReduxStore( TEST_STORE, {
+	reducer: (
+		state: ChatState = { isOpen: false, isMinimized: false },
+		action: { type: string; state?: ChatState }
+	) => ( action.type === 'SET_STATE' ? { ...state, ...action.state } : state ),
+	selectors: {
+		getAgentsManagerState: ( state: ChatState ) => state,
+	},
+	actions: {
+		setState: ( state: ChatState ) => ( { type: 'SET_STATE', state } ),
+	},
+} );
+register( testStore );
+
+const setChatState = ( state: ChatState ) => dispatch( testStore ).setState( state );
+
+const render = () =>
+	renderWithProvider( <MasterbarAiChatButton />, {
+		reducers: { ui: () => ( { section: { name: 'test-section' } } ) },
+	} );
+
+describe( 'MasterbarAiChatButton', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	const activeStateCases: Array< [ string, ChatState, boolean ] > = [
+		[ 'visible', { isOpen: true, isMinimized: false }, true ],
+		[ 'minimized', { isOpen: true, isMinimized: true }, false ],
+		[ 'closed', { isOpen: false, isMinimized: false }, false ],
+	];
+
+	it.each( activeStateCases )(
+		'marks the button active only while the chat is %s',
+		( _state, state, isActive ) => {
+			setChatState( state );
+
+			render();
+
+			expect( screen.getByRole( 'button' ).classList.contains( 'is-active' ) ).toBe( isActive );
+		}
+	);
+
+	it( 'closes the chat when clicked while the chat is showing', async () => {
+		setChatState( { isOpen: true, isMinimized: false } );
+
+		render();
+		await userEvent.click( screen.getByRole( 'button' ) );
+
+		expect( closeAgentsManagerChat ).toHaveBeenCalled();
+		expect( openAgentsManagerChat ).not.toHaveBeenCalled();
+	} );
+
+	it( 'opens the chat when clicked while the chat is hidden', async () => {
+		setChatState( { isOpen: false, isMinimized: false } );
+
+		render();
+		await userEvent.click( screen.getByRole( 'button' ) );
+
+		expect( openAgentsManagerChat ).toHaveBeenCalled();
+		expect( closeAgentsManagerChat ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
Related to AI-1077

## Proposed Changes

* The masterbar AI chat entry button now shows the masterbar active background (the same `--color-masterbar-item-active-background` treatment the notifications bell uses) while the chat is open and not minimized — whichever entry point opened it (the AI button itself or the Help menu's "Chat support" item).
* The Help menu button no longer shows the active background while the chat is open; the AI button is the chat's indicator.
* Extracted the AI button from the `MasterbarLoggedIn` class into `masterbar-agents-manager/ai-chat-button.tsx`, subscribing to the agents-manager store for the open/minimized state. The click handler now derives its toggle decision from the same store value that drives the active state, instead of a separate `window.__agentsManagerActions` read.
* Removed dead code along the way: the Help button's unused item-level `is-menu-panel` class and the now-unneeded `sectionName` wiring in `logged-in.jsx`.

The wp-admin admin bar is intentionally untouched: none of its buttons have an active state, so an unlit AI button already matches them.

## Why are these changes being made?

* The AI entry button gave no visual indication that the chat it toggles is open. Mirroring the notifications bell's active treatment makes the open state visible and makes a second click's behavior (close) predictable.
* Matching `EditorAiChatButton`'s `isOpen && ! isMinimized` semantics keeps the active state consistent across all AI chat entry points.

## Testing Instructions

1. Run `yarn start-dashboard`
2. Go to `http://my.localhost:3000/sites`
3. Now, you will see the AI entry button in the admin bar has an active state (the dark BG color, same as the "Bell" button) when the AI chat is visible / expanded:

<img width="402" height="117" alt="截圖 2026-07-28 晚上10 56 55" src="https://github.com/user-attachments/assets/b6fab930-a017-451b-9d6b-8aa2f11e0109" />

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

