### PR TITLE
A4A: Fix collapsed list spacing on Referrals and Reports detail views

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -115,6 +115,7 @@ $data-view-border-color: #f1f1f1;
 		// The collapsed column is narrow, so the wide overview inset doesn't fit.
 		.referrals-list__view-actions {
 			padding-inline: 24px;
+			padding-block: 16px;
 		}
 
 		// Let the search toolbar's own padding set the spacing evenly above and below.
@@ -133,6 +134,16 @@ $data-view-border-color: #f1f1f1;
 
 		.dataviews-view-list__item .components-flex {
 			gap: 0;
+		}
+
+		.referrals-list__client {
+			display: flex;
+			align-items: center;
+			min-height: 48px;
+		}
+
+		.redesigned-a8c-table {
+			--wpds-dimension-padding-lg: 4px;
 		}
 
 		.hosting-dashboard-layout__top-wrapper > * {
@@ -246,9 +257,4 @@ $data-view-border-color: #f1f1f1;
 	ul {
 		margin: 16px;
 	}
-}
-
-.referrals-list__client {
-	@include body-medium;
-	color: var(--color-accent-80);
 }

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
@@ -9,7 +9,9 @@ import FormattedDate from 'calypso/components/formatted-date';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import type { ReportStatus } from '../../types';
 
-export const ReportSiteColumn = ( { site }: { site: string } ) => urlToSlug( site );
+export const ReportSiteColumn = ( { site }: { site: string } ) => (
+	<span className="reports-list__site">{ urlToSlug( site ) }</span>
+);
 
 export const ReportCountColumn = ( { count, onClick }: { count: number; onClick: () => void } ) => {
 	const translate = useTranslate();

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/reports-list.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/reports-list.tsx
@@ -131,6 +131,7 @@ export default function ReportsList( {
 						}
 					},
 					pagination: paginationInfo,
+					selection: dataViewsState.selectedItem ? [ dataViewsState.selectedItem.site ] : [],
 					enableSearch: false,
 					fields,
 					actions,
@@ -140,7 +141,7 @@ export default function ReportsList( {
 				} }
 			>
 				<HStack
-					className="dataviews__view-actions"
+					className="dataviews__view-actions reports-list__view-actions"
 					justify="end"
 					style={ {
 						paddingInline: isNarrowView || dataViewsState.selectedItem ? '16px' : '64px',

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/style.scss
@@ -35,6 +35,20 @@
 			gap: 0;
 		}
 
+		.reports-list__view-actions {
+			padding-block: 0 16px;
+		}
+
+		.reports-list__site {
+			display: flex;
+			align-items: center;
+			min-height: 48px;
+		}
+
+		.redesigned-a8c-table {
+			--wpds-dimension-padding-lg: 4px;
+		}
+
 		.hosting-dashboard-layout__top-wrapper > * {
 			padding-inline: 24px;
 		}


### PR DESCRIPTION
Resolves A4A-3047

## Proposed Changes

* On the Referrals and Reports dashboards, when a client or site is selected, the rows in the center column list are now compact and the text is vertically centered, instead of tall rows with empty space under the text.
* The selected site in the Reports list is now highlighted, the same way the selected client is highlighted on Referrals.
* The client email on Referrals and the site name on Reports now use the same default list styling as Teams and the multi-site dashboard.

## Why are these changes being made?

* The spacing in the center column list was inconsistent with the detail view next to it, and each row had noticeable dead space under its single line of text.
* The Reports list gave no indication of which site was currently open in the detail view.

## Testing Instructions

* Open the live link for this branch (A8C for Agencies) and log in as an agency that has referrals and reports.
* Go to Referrals and click a client in the list.
  * The list collapses into the left column. Rows should be compact, with the client email vertically centered and the selected client highlighted.
* Go to Reports and click a site in the list.
  * Same checks: compact rows, the site name vertically centered, and the selected site highlighted.
* Confirm the expanded full-width tables on both pages look unchanged.

<img width="1915" height="722" alt="Screenshot 2026-07-28 at 4 47 32 PM" src="https://github.com/user-attachments/assets/76a2d284-208c-4925-a1d8-18cfa80fa925" />
<img width="1915" height="722" alt="Screenshot 2026-07-28 at 4 49 23 PM" src="https://github.com/user-attachments/assets/d697e2af-5ed4-4342-8dfa-0469091ac4aa" />
<img width="1915" height="722" alt="Screenshot 2026-07-28 at 4 49 38 PM" src="https://github.com/user-attachments/assets/6d3aa914-6d8d-4057-aa84-422e41e5decf" />
<img width="1915" height="722" alt="Screenshot 2026-07-28 at 4 50 21 PM" src="https://github.com/user-attachments/assets/f5136982-d874-49ab-8f59-ab0647c1affc" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
