### PR TITLE
Purchases: restore cancel/remove behavior for bundled domain connections

### DIFF
--- a/client/dashboard/me/billing-purchases/AGENTS.md
+++ b/client/dashboard/me/billing-purchases/AGENTS.md
@@ -97,17 +97,23 @@ marketplace subscriptions on site.
    returns `REMOVE` for expired purchases, which maps to a DELETE call, not a cancel.
    Don't assume all paths through "cancel purchase" call the same mutation.
 
-4. **CRITICAL: `flowType` gets silently overridden** — Inside `onSurveyComplete()`,
+4. **Bundled purchases are Remove-only** — A purchase with `expiry_status === 'included'`
+   renews with its parent plan, so `is_auto_renew_enabled` says nothing useful about it and
+   disabling auto-renew is a no-op. Never offer Cancel for one. Only domain connections
+   (`domain_map`) can be removed on their own; the rest of a plan's bundle goes with the plan.
+   See `CancelOrRemoveActionButton` in `purchase-settings/index.tsx`.
+
+5. **CRITICAL: `flowType` gets silently overridden** — Inside `onSurveyComplete()`,
    `state.cancelIntent === 'refund'` switches `CANCEL_AUTORENEW` → `CANCEL_WITH_REFUND`.
    The `shouldShowRefundEligibilityNotice` feature flag also changes the default path.
 
-5. **Survey completion tracked per-purchase** — Stored in user preferences to avoid
+6. **Survey completion tracked per-purchase** — Stored in user preferences to avoid
    re-surveying. A new survey won't appear for a purchase that was already surveyed.
 
-6. **Siteless purchases** — Some products (Akismet, Jetpack, Marketplace) use temporary sites (`siteless.{jetpack|akismet|marketplace.wp|a4a}.com`). Guard with `purchase.is_attached_to_holding_site`. Never call `siteBySlugQuery()` for these — use `purchase.domain` or `purchase.blog_id` for display, skip site-dependent UI entirely.
+7. **Siteless purchases** — Some products (Akismet, Jetpack, Marketplace) use temporary sites (`siteless.{jetpack|akismet|marketplace.wp|a4a}.com`). Guard with `purchase.is_attached_to_holding_site`. Never call `siteBySlugQuery()` for these — use `purchase.domain` or `purchase.blog_id` for display, skip site-dependent UI entirely.
 
-7. **Transferred purchases** — Always check ownership before allowing purchase actions.
+8. **Transferred purchases** — Always check ownership before allowing purchase actions.
 
-8. **Route params are strings** — `purchaseId` from URL params must be `parseInt()`'d before passing to query functions.
+9. **Route params are strings** — `purchaseId` from URL params must be `parseInt()`'d before passing to query functions.
 
-9. **`site.options.unmapped_url` lies for `.home.blog` sites** — Returns the `.wordpress.com` URL even when the site's free domain is `.home.blog` (or another `.blog` subdomain). Don't use it to render the user's free hostname. Read the actual WPCOM domain from `siteDomainsQuery( siteId )` — find the entry flagged `wpcom_domain` or `is_wpcom_staging_domain` and use its `domain` field. This is the same root issue as Classic's `site.wpcom_url`, which is just `withoutHttp( unmapped_url )` — see `client/me/purchases/AGENTS.md` pitfall #6.
+10. **`site.options.unmapped_url` lies for `.home.blog` sites** — Returns the `.wordpress.com` URL even when the site's free domain is `.home.blog` (or another `.blog` subdomain). Don't use it to render the user's free hostname. Read the actual WPCOM domain from `siteDomainsQuery( siteId )` — find the entry flagged `wpcom_domain` or `is_wpcom_staging_domain` and use its `domain` field. This is the same root issue as Classic's `site.wpcom_url`, which is just `withoutHttp( unmapped_url )` — see `client/me/purchases/AGENTS.md` pitfall #6.

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -91,6 +91,7 @@ import {
 	isTitanMail,
 	isGoogleWorkspace,
 	isDomainTransfer,
+	isDomainMapping,
 	isDotcomPlan,
 	getRenewalUrlFromPurchase,
 	isStorageUpgradeEligible,
@@ -319,6 +320,11 @@ export function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase }
 
 	const hasRefund = hasAmountAvailableToRefund( purchase );
 	const autoRenewOn = purchase.is_auto_renew_enabled;
+	// A purchase bundled with a plan renews with that plan, so cancelling its
+	// auto-renew is meaningless — removal is the only action that does anything.
+	// Only domain connections can be removed on their own; the rest of a plan's
+	// bundle has to go with the plan.
+	const isBundledWithPlan = isIncludedWithPlan( purchase );
 	// Domain transfer gate: non-refundable transfers can't be cancelled without
 	// support intervention (preserves legacy behavior on classic; adds it to
 	// dashboard). Remove button is unaffected — a completed transfer with
@@ -341,8 +347,13 @@ export function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase }
 	// delete endpoints all accept the call in pending-renewal state, so we
 	// don't need to special-case it.
 	const showCancel =
-		autoRenewOn && ! isTransferNonRefundable && ! isExpiredAndInGracePeriod( purchase );
-	const showRemove = ! autoRenewOn || isExpiredAndInGracePeriod( purchase );
+		! isBundledWithPlan &&
+		autoRenewOn &&
+		! isTransferNonRefundable &&
+		! isExpiredAndInGracePeriod( purchase );
+	const showRemove = isBundledWithPlan
+		? isDomainMapping( purchase )
+		: ! autoRenewOn || isExpiredAndInGracePeriod( purchase );
 
 	if ( ! showCancel && ! showRemove ) {
 		return null;

--- a/client/dashboard/me/billing-purchases/purchase-settings/test/cancel-or-remove-action-button.test.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/test/cancel-or-remove-action-button.test.tsx
@@ -80,6 +80,37 @@ describe( '<CancelOrRemoveActionButton />', () => {
 		expect( screen.queryByRole( 'button', { name: 'Remove' } ) ).toBeNull();
 	} );
 
+	test( 'shows only Remove for a domain connection bundled with a plan', () => {
+		render(
+			<CancelOrRemoveActionButton
+				purchase={ makePurchase( {
+					product_name: 'Domain Connection',
+					product_slug: 'domain_map',
+					is_plan: false,
+					expiry_status: 'included',
+				} ) }
+			/>
+		);
+
+		expect( screen.getByRole( 'button', { name: 'Remove' } ) ).toBeVisible();
+		expect( screen.getByText( 'Remove Domain Connection' ) ).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: 'Cancel' } ) ).toBeNull();
+	} );
+
+	test( 'renders nothing for a non-domain-connection purchase bundled with a plan', () => {
+		const { container } = render(
+			<CancelOrRemoveActionButton
+				purchase={ makePurchase( {
+					product_name: 'Professional Email',
+					product_slug: 'wp_titan_mail_yearly',
+					is_plan: false,
+					expiry_status: 'included',
+				} ) }
+			/>
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
 	test( 'renders nothing for a non-refundable domain transfer with auto-renew on', () => {
 		const { container } = render(
 			<CancelOrRemoveActionButton

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -506,6 +506,14 @@ export function isDomainTransfer( purchase: Purchase | ObjectWithProductSlug ): 
 	return purchase.product_slug === DomainProductSlugs.TRANSFER_IN;
 }
 
+/**
+ * A domain connection (also known as a domain mapping): a domain registered
+ * elsewhere that points at a WordPress.com site.
+ */
+export function isDomainMapping( purchase: Purchase | ObjectWithProductSlug ): boolean {
+	return purchase.product_slug === DomainProductSlugs.DOMAIN_MAPPING;
+}
+
 export function isSiteRedirect( purchase: Purchase ): boolean {
 	return purchase.product_slug === OFFSITE_REDIRECT;
 }

--- a/client/me/purchases/AGENTS.md
+++ b/client/me/purchases/AGENTS.md
@@ -40,15 +40,20 @@ between the two without converting field names and values.
 
 ## Architectural Decisions
 
-1. **Two cancel paths (mutually exclusive)** — `manage-purchase/index.tsx` renders one
-   of two cancel entry points based on `canAutoRenewBeTurnedOff(purchase)`:
+1. **Two cancel entry points (mutually exclusive)** — `manage-purchase/index.tsx` renders
+   one of two CTAs, both linking to the same cancel page with a different `?intent=`:
 
-   - **True** → `renderCancelPurchaseNavItem()` → navigates to cancel page (full flow)
-   - **False** → `renderRemovePurchaseNavItem()` → renders `<RemovePurchase>` inline (delete)
+   - `renderCancelPurchaseNavItem()` → `?intent=cancel`, when auto-renew is on and
+     `canAutoRenewBeTurnedOff(purchase)` is true
+   - `renderRemovePurchaseNavItem()` → `?intent=remove`, when auto-renew is off, the
+     purchase is in its post-expiry grace period, or it's a domain connection bundled
+     with a plan
 
-   These map to different API calls (`cancelPurchase` for refund, `removePurchase`
-   DELETE for expired, `disableAutoRenew` for toggle). All say "Cancel" in the UI
-   but are NOT interchangeable.
+   The intent decides the API call on submit (`disableAutoRenew` for cancel,
+   `cancelAndRefund` for a refundable remove, `removePurchase` DELETE otherwise) — see
+   `getMutationFlowType` in `client/lib/purchases/utils.ts`. They are NOT interchangeable.
+   `<RemovePurchase>` in `remove-purchase/` is no longer part of this page; only
+   `client/my-sites/domains/domain-management` still uses it.
 
 2. **Three payment method paths** — `changePaymentMethod` (per-purchase, has card),
    `addPaymentMethod` (per-purchase, no card), `addNewPaymentMethod` (account-level).
@@ -65,40 +70,47 @@ between the two without converting field names and values.
    purchases even when auto-renew is already off. See `client/lib/purchases/index.ts`.
    Don't substitute `purchase.isAutoRenewEnabled`.
 
-2. **`isSiteLevel` prop changes data source silently** — In `manage-purchase`,
+2. **Bundled purchases are Remove-only** — A purchase with `expiry_status === 'included'`
+   renews with its parent plan, so `is_auto_renew_enabled` says nothing useful about it and
+   disabling auto-renew is a no-op (`canAutoRenewBeTurnedOff` already returns `false` for
+   them). Only domain connections (`domain_map`) can be removed on their own; the rest of a
+   plan's bundle goes with the plan. See `renderRemovePurchaseNavItem` in
+   `manage-purchase/index.tsx`.
+
+3. **`isSiteLevel` prop changes data source silently** — In `manage-purchase`,
    `isSiteLevel=true` checks `hasLoadedSitePurchasesFromServer` instead of
    `hasLoadedUserPurchasesFromServer`. Without the matching `QuerySitePurchases`
    component, you get a permanent loading state with no error.
 
-3. **Auto-renew toggle: deferred notice pattern** — Notices created while
+4. **Auto-renew toggle: deferred notice pattern** — Notices created while
    `showAutoRenewDisablingDialog` is visible get swallowed. The component uses
    `pendingNotice` state + `componentDidUpdate` to defer. Don't call `createNotice`
    directly in dialog callbacks.
 
-4. **`page()` vs `page.redirect()` after actions** — Use `page.redirect()` after
+5. **`page()` vs `page.redirect()` after actions** — Use `page.redirect()` after
    cancel/remove so users can't navigate back to an invalid state. `page()` is
    for normal navigation.
 
-5. **`purchase` is optional in PaymentMethodSelector** — The "add payment method"
+6. **`purchase` is optional in PaymentMethodSelector** — The "add payment method"
    flow passes `undefined`. Processors must handle this case. Success messages
    branch on whether `purchase` exists.
 
-6. **`site.wpcom_url` lies for `.home.blog` sites** — Always returns
+7. **`site.wpcom_url` lies for `.home.blog` sites** — Always returns
    `.wordpress.com` even when the site's free domain is `.home.blog` (or 27
    other `.blog` subdomains). Use `getWpComDomainBySiteId()` selector to get
    the actual free domain. Affects `NonPrimaryDomainDialog` in both
    `remove-purchase/` and `manage-purchase/`.
 
-7. **`isMonthly()` only checks plan slugs** — Returns `false` for Jetpack
+8. **`isMonthly()` only checks plan slugs** — Returns `false` for Jetpack
    product slugs like `jetpack_videopress_monthly` because it only checks
    `JETPACK_MONTHLY_PLANS`. Use `getJetpackItemTermVariants()` for products.
    Same issue with `getYearlyPlanByMonthly()` — only works for plans.
 
-8. **VAT API errors need field mapping** — `useMutation` error has
+9. **VAT API errors need field mapping** — `useMutation` error has
    `{ error: string, message: string }` but no field indicator. Map error
    codes to fields: `missing_country`/`invalid_country` → country field,
    `invalid_vat`/`missing_id`/`validation_failed` → id field.
 
-9. **Siteless purchases** — Some products (Akismet, Jetpack, Marketplace) use holding sites (`siteless.{jetpack|akismet|marketplace.wp|a4a}.com`). Guard with `purchase.isAttachedToHoldingSite`. Never query site data for these — use `purchase.domain` for display, skip site-dependent UI entirely.
+10. **Siteless purchases** — Some products (Akismet, Jetpack, Marketplace) use holding sites (`siteless.{jetpack|akismet|marketplace.wp|a4a}.com`). Guard with `purchase.isAttachedToHoldingSite`. Never query site data for these — use `purchase.domain` for display, skip site-dependent UI entirely.
 
-10. **Transferred purchases** — Always check ownership before allowing purchase actions.
+11. **Transferred purchases** — Always check ownership before allowing purchase actions.

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -310,14 +310,12 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			return false;
 		}
 
-		// Under the split flag, any purchase reached via ?intent=remove renders
-		// the unified confirmation screen. Allow through regardless of
-		// canAutoRenewBeTurnedOff so the page doesn't redirect away.
-		if (
-			! isValidForCancellation &&
-			props.isSplitCancelRemoveEnabled &&
-			props.intent === 'remove'
-		) {
+		// Any purchase reached via ?intent=remove renders the unified confirmation
+		// screen. Allow through regardless of canAutoRenewBeTurnedOff so the page
+		// doesn't redirect away: the Remove CTA on Purchase Settings is offered
+		// precisely for purchases that can't be cancelled (expired ones, and
+		// domain connections bundled with a plan).
+		if ( ! isValidForCancellation && props.intent === 'remove' ) {
 			return true;
 		}
 
@@ -601,20 +599,16 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 
 	/**
 	 * Returns true when the user clicked Remove on Purchase Settings AND the
-	 * purchase is non-refundable. In that case the legacy flow should call
-	 * DELETE rather than disable-auto-renew (the previous fallthrough). Gated
-	 * by the split cancel/remove experiment because it changes
-	 * user-visible post-action state (different endpoint, deleted row vs.
-	 * expiring row).
+	 * purchase is non-refundable. In that case the flow calls DELETE rather than
+	 * disable-auto-renew (the previous fallthrough), which for a purchase that
+	 * can't be cancelled — an expired one, or a domain connection bundled with a
+	 * plan — did nothing at all.
 	 *
 	 * Refundable purchases continue to flow through `cancelAndRefund` so the
 	 * user still receives their refund — `getMutationFlowType` returns
 	 * `CANCEL_WITH_REFUND` in that case.
 	 */
 	isLegacyRemoveDeleteFlow = ( purchase: Purchases.Purchase ) => {
-		if ( ! this.props.isSplitCancelRemoveEnabled ) {
-			return false;
-		}
 		if ( this.props.intent !== 'remove' ) {
 			return false;
 		}

--- a/client/me/purchases/cancel-purchase/test/remove-intent.jsx
+++ b/client/me/purchases/cancel-purchase/test/remove-intent.jsx
@@ -1,0 +1,151 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { purchaseCancelFeaturesQuery } from '@automattic/api-queries';
+import page from '@automattic/calypso-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { Provider as ReduxProvider } from 'react-redux';
+import { useIsSplitCancelRemoveEnabled } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled';
+import { createReduxStore } from 'calypso/state';
+import CancelPurchase from '../index';
+
+jest.mock( '@automattic/calypso-router', () => ( {
+	__esModule: true,
+	default: { redirect: jest.fn() },
+} ) );
+
+jest.mock(
+	'calypso/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled',
+	() => ( {
+		useIsSplitCancelRemoveEnabled: jest.fn( () => false ),
+	} )
+);
+
+// A domain connection bundled with a plan: `expiry_status: 'included'` means it
+// renews with the plan, so it is not "cancelable" — removal is the only action.
+const bundledDomainConnection = {
+	ID: '19823155',
+	user_id: '56924323',
+	blog_id: '212628935',
+	product_id: '5',
+	product_name: 'Domain Connection',
+	product_slug: 'domain_map',
+	product_type: 'domain_map',
+	meta: 'onecooltestsite.com',
+	domain: 'onecooltestsite.com',
+	blogname: 'One Cool Test Site',
+	subscribed_date: '2026-01-27T03:37:13+00:00',
+	subscription_status: 'active',
+	expiry_date: '2027-01-27T00:00:00+00:00',
+	expiry_status: 'included',
+	is_auto_renew_enabled: true,
+	is_cancelable: false,
+	is_refundable: false,
+	is_removable: true,
+	is_renewable: false,
+	can_disable_auto_renew: false,
+	amount: 13,
+	currency_code: 'USD',
+	currency_symbol: '$',
+	refund_amount: 0,
+	total_refund_amount: 0,
+	bill_period_days: 365,
+	included_domain: '',
+	included_domain_purchase_amount: 0,
+	attached_to_purchase_id: null,
+	is_locked: false,
+	price_tier_list: [],
+};
+
+function createStore( purchase ) {
+	return createReduxStore(
+		{
+			currentUser: { id: Number( purchase.user_id ) },
+			plans: { items: [] },
+			purchases: {
+				data: [ purchase ],
+				hasLoadedUserPurchasesFromServer: true,
+				hasLoadedSitePurchasesFromServer: true,
+			},
+			productsList: { items: {} },
+			sites: {
+				items: {
+					[ purchase.blog_id ]: {
+						ID: Number( purchase.blog_id ),
+						URL: 'https://onecooltestsite.com',
+						capabilities: {},
+						options: {},
+						slug: 'onecooltestsite.com',
+					},
+				},
+				plans: {},
+				requesting: {},
+				domains: { requesting: {}, items: {} },
+			},
+			plugins: { premium: { plugins: {} } },
+			ui: { selectSiteId: purchase.blog_id },
+		},
+		( state ) => state
+	);
+}
+
+function renderCancelPurchase( purchase, intent ) {
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { staleTime: Infinity, retry: false } },
+	} );
+	queryClient.setQueryData( purchaseCancelFeaturesQuery( Number( purchase.ID ) ).queryKey, {
+		features: [],
+	} );
+
+	return render(
+		<QueryClientProvider client={ queryClient }>
+			<ReduxProvider store={ createStore( purchase ) }>
+				<CancelPurchase
+					purchaseId={ Number( purchase.ID ) }
+					siteSlug="onecooltestsite.com"
+					intent={ intent }
+				/>
+			</ReduxProvider>
+		</QueryClientProvider>
+	);
+}
+
+describe( 'CancelPurchase with intent=remove', () => {
+	beforeEach( () => {
+		page.redirect.mockClear();
+		useIsSplitCancelRemoveEnabled.mockReturnValue( false );
+	} );
+
+	afterEach( () => {
+		nock.cleanAll();
+	} );
+
+	it( 'renders the removal confirmation for a purchase that cannot be cancelled', async () => {
+		renderCancelPurchase( bundledDomainConnection, 'remove' );
+
+		expect( await screen.findByText( 'Remove upgrade' ) ).toBeVisible();
+		expect( page.redirect ).not.toHaveBeenCalled();
+	} );
+
+	it( 'removes the purchase rather than disabling auto-renew', async () => {
+		const deleteRequest = nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/upgrades/19823155/delete' )
+			.reply( 200, {} );
+		const disableAutoRenewRequest = nock( 'https://public-api.wordpress.com' )
+			.post( '/rest/v1.1/upgrades/19823155/disable-auto-renew' )
+			.reply( 200, { success: true } );
+
+		renderCancelPurchase( bundledDomainConnection, 'remove' );
+
+		await userEvent.click( await screen.findByRole( 'button', { name: 'Continue removal' } ) );
+		await userEvent.click( await screen.findByRole( 'button', { name: 'Complete removal' } ) );
+
+		// The removal is fired after a short delay so the button stays busy.
+		await waitFor( () => expect( deleteRequest.isDone() ).toBe( true ), { timeout: 4000 } );
+		expect( disableAutoRenewRequest.isDone() ).toBe( false );
+	} );
+} );

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -158,6 +158,7 @@ import {
 	isExpiredAndInGracePeriod,
 	isExpiredOrRemoved,
 	isExpiredWithNoAutoRenewAttemptsLeft,
+	isIncludedWithPlan,
 	isPaidWithCredits,
 	isPartnerPurchase,
 	isRemoved,
@@ -869,13 +870,17 @@ class ManagePurchase extends Component<
 
 		const canRefund = hasAmountAvailableToRefund( purchase );
 		const autoRenewOn = !! purchase.is_auto_renew_enabled;
+		// A domain connection bundled with a plan renews with that plan, so Cancel
+		// is never offered for it (see `canAutoRenewBeTurnedOff`) and removal is the
+		// only action available — regardless of what auto-renew reports.
+		const isBundledDomainConnection = isIncludedWithPlan( purchase ) && isDomainMapping( purchase );
 
 		// Show Remove when auto-renew is off, OR when the purchase is in its
 		// post-expiry grace period (Cancel is not offered there, so Remove is the
 		// only way to act on it — matching the Dashboard). The refund-eligible case
 		// is surfaced inside the cancel flow via RefundEligibilityNotice instead of
 		// a parallel Remove CTA.
-		if ( autoRenewOn && ! isExpiredAndInGracePeriod( purchase ) ) {
+		if ( ! isBundledDomainConnection && autoRenewOn && ! isExpiredAndInGracePeriod( purchase ) ) {
 			return null;
 		}
 

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -208,6 +208,41 @@ describe( 'Purchase Management Buttons', () => {
 		expect( screen.queryByText( /Cancel subscription/ ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'renders a Remove button for a domain connection bundled with a plan, even though auto-renew is ON', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/me/payment-methods?expired=include' )
+			.reply( 200 );
+
+		const store = createMockReduxStoreForPurchase(
+			{
+				...purchase,
+				product_id: 5,
+				product_slug: 'domain_map',
+				product_name: 'Domain Connection',
+				product_type: 'domain_map',
+				meta: 'onecooltestsite.com',
+				expiry_status: 'included',
+				is_auto_renew_enabled: true,
+			},
+			{ 212628935: [ { name: 'onecooltestsite.com' } ] }
+		);
+
+		render(
+			<QueryClientProvider client={ queryClient }>
+				<ReduxProvider store={ store }>
+					<ManagePurchase
+						purchaseId={ Number( purchase.ID ) }
+						isSiteLevel
+						siteSlug="onecooltestsite.com"
+					/>
+				</ReduxProvider>
+			</QueryClientProvider>
+		);
+
+		expect( await screen.findByText( /Remove Domain Connection/ ) ).toBeVisible();
+		expect( screen.queryByText( /Cancel subscription/ ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'renders a Remove button with product-name language for an Akismet purchase attached to an akismet siteless holding site when auto-renew is OFF', async () => {
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.1/me/payment-methods?expired=include' )

--- a/packages/api-core/src/constants.ts
+++ b/packages/api-core/src/constants.ts
@@ -277,6 +277,7 @@ export const DomainProductSlugs = {
 	TRANSFER_IN: 'domain_transfer',
 	DOTCOM_DOMAIN_REGISTRATION: 'domain_reg',
 	DOMAIN_MOVE_INTERNAL: 'domain_move_internal',
+	DOMAIN_MAPPING: 'domain_map',
 } as const;
 
 export const TitanMailSlugs = {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2302/

## Proposed Changes

This fixes a regression introduced in #112847 and #112848 that showed no-op cancellation options for bundled domain connections. Now bundled domain connections are only shown an option to remove. All other domain connections are shown the standard cancellation -> removal options.

* Dashboard: never offer Cancel for a bundled purchase; offer Remove when it is a domain connection.
* Calypso: render the Remove CTA for a bundled domain connection even though it reports auto-renew on.
* Add `isDomainMapping()` to the Dashboard purchase utils, backed by a new `DomainProductSlugs.DOMAIN_MAPPING`.
* Let the Calypso cancel page act on `?intent=remove` regardless of `purchases/split-cancel-remove`, so removal reaches `DELETE /upgrades/:id/delete` rather than falling through to disable-auto-renew.
* Document the bundled-purchase rule in both `AGENTS.md` pitfall lists, and correct the Calypso "two cancel paths" section, which still described the pre-#112848 inline `<RemovePurchase>` flow.

## Why are these changes being made?

A Domain Connection on a site with a plan is a bundled purchase (`expiry_status: 'included'`) that renews with its parent plan. As such, they can only be removed - cancellation is a no-op. Both purchase management surfaces (Calypso and Dashboard) lost the logic that such a purchase can only be *removed*, so Calypso offered no cancel/remove action at all and the Dashboard offered a no-op cancellation option.

Two earlier PRs (#112847, #112848) replaced the sources of cancel/remove eligibility with a heuristic keyed only on auto-renew — `showCancel = autoRenewOn && …`, `showRemove = ! autoRenewOn || grace`. What they replaced was the only code carrying the domain-connection rule: Calypso's `isRemovable()` (reached through the `<RemovePurchase>` that #112848 removed) returned `true` for `isIncludedWithPlan && isDomainMapping`, and the Dashboard read the server's `is_cancelable` / `is_removable`. A bundled Domain Connection reports auto-renew on, so the new heuristic produced no usable action on either surface. Deriving the rule explicitly from `expiry_status` keeps both surfaces consistent and makes the intent legible at the call site.

The cancel page needed a second fix. The Remove CTA links to `?intent=remove`, but the page only honored that intent behind `purchases/split-cancel-remove`, which is `false` in every config since the ExPlat experiment was retired in #111441. Flag-off, the CTA redirected straight back to Purchase Settings, and a non-refundable removal that did get through called disable-auto-renew instead of DELETE. Only the two intent-routing guards are ungated here; everything gating new UI (confirmation screen, intervention offers, refund-email variant) stays behind the flag. The post-removal and post-cancel success notices are also still gated, which leaves removal without confirmation feedback — that is a follow-up PR.

## Testing Instructions

TC:
```
yarn test-client client/me/purchases client/dashboard/me/billing-purchases client/lib/purchases client/dashboard/utils
```

New coverage: bundled-domain-connection CTAs on both surfaces, and a Calypso cancel-page test that drives the flow and asserts `POST /wpcom/v2/upgrades/:id/delete` fires while disable-auto-renew does not.

Manual testing:
* Use an account with a Domain Connection on a site that has a plan (the purchase shows "Included with plan").
* Dashboard, `/me/billing/purchases` → open that purchase: expect a single **Remove Domain Connection** action and no Cancel action. Complete it and confirm the purchase disappears from Active Upgrades rather than reappearing unchanged.
* Calypso, `/me/purchases` → open the same purchase: expect the **Remove Domain Connection** card, which should open the removal confirmation screen instead of bouncing back to the purchase page.
* Regression check on a standalone Domain Connection (site without a plan): it should still get the normal Cancel flow, and Remove only once auto-renew is off.
* Regression check on an expired non-refundable purchase: Remove should now open the confirmation screen and delete the purchase.