### PR TITLE
Emails: enable Titan plan downgrade and add "Manage your plan" action

### DIFF
--- a/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
+++ b/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
@@ -13,6 +13,7 @@ import poweredByTitanLogo from '../../resources/powered-by-titan-caps.svg';
 import { IntervalLength, MailboxProvider, TitanPlanTier } from '../../types';
 import { getTrialMonths } from '../../utils/get-trial-months';
 import { isEligibleForIntroductoryOffer } from '../../utils/is-eligible-for-introductory-offer';
+import { TITAN_TIER_ORDER } from '../../utils/titan-tiers';
 import type { Domain, EmailSubscription, Product } from '@automattic/api-core';
 
 interface TitanPlan {
@@ -100,14 +101,6 @@ const getTierDetails = ( tier: TitanPlanTier ): { description: string; features:
 	}
 };
 
-// Tiers ordered from lowest to highest, used to tell upgrades from downgrades
-// relative to the current tier.
-const TIER_ORDER: TitanPlanTier[] = [
-	TitanPlanTier.Pro,
-	TitanPlanTier.Premium,
-	TitanPlanTier.Ultra,
-];
-
 export function TitanPlanGrid( {
 	domain,
 	domainName,
@@ -121,10 +114,11 @@ export function TitanPlanGrid( {
 	interval: IntervalLength;
 	available: boolean;
 	// The tier the user is currently subscribed to. When set, the grid is in
-	// upgrade mode: lower tiers are shown with a disabled button, the current
-	// tier is labeled, and higher tiers offer an upgrade.
+	// upgrade mode: the current tier is labeled, higher tiers offer an upgrade,
+	// and lower tiers offer a downgrade.
 	currentTier?: TitanPlanTier;
-	// Called when a higher tier is selected in upgrade mode (currentTier set).
+	// Called when a different tier is selected in upgrade mode (currentTier set):
+	// a higher tier is an upgrade, a lower tier a downgrade.
 	onUpgrade?: ( tier: TitanPlanTier ) => void;
 } ) {
 	const navigate = useNavigate();
@@ -178,14 +172,15 @@ export function TitanPlanGrid( {
 		},
 	];
 
-	// All tiers stay visible when upgrading; lower tiers render with a disabled
-	// button since this flow cannot downgrade.
+	// All tiers stay visible when upgrading; lower tiers offer a downgrade.
 	const isLowerTier = ( tier: TitanPlanTier ) =>
-		currentTier ? TIER_ORDER.indexOf( tier ) < TIER_ORDER.indexOf( currentTier ) : false;
+		currentTier
+			? TITAN_TIER_ORDER.indexOf( tier ) < TITAN_TIER_ORDER.indexOf( currentTier )
+			: false;
 
 	// The tier that gets the emphasized (primary) button: the recommended plan when
 	// buying, or the recommended upgrade target when upgrading. The current and lower
-	// tiers are never emphasized because their buttons are disabled.
+	// tiers are never emphasized because upgrading is the encouraged action.
 	const primaryTier = ( () => {
 		const candidates = currentTier
 			? plans.filter( ( plan ) => plan.tier !== currentTier && ! isLowerTier( plan.tier ) )
@@ -214,7 +209,7 @@ export function TitanPlanGrid( {
 				if ( isCurrentPlan ) {
 					actionLabel = __( 'Current plan' );
 				} else if ( isDowngrade ) {
-					actionLabel = __( 'Included in your plan' );
+					actionLabel = __( 'Downgrade' );
 				} else if ( currentTier ) {
 					actionLabel = __( 'Upgrade' );
 				} else if ( plan.hasFreeTrial ) {
@@ -288,7 +283,7 @@ export function TitanPlanGrid( {
 							__next40pxDefaultSize
 							className="email-provider-action"
 							variant={ plan.tier === primaryTier ? 'primary' : 'secondary' }
-							disabled={ ! available || isCurrentPlan || isDowngrade }
+							disabled={ ! available || isCurrentPlan }
 							onClick={ () => {
 								// Upgrade mode goes to checkout for the picked tier; otherwise the
 								// grid is buying a new plan, so collect mailboxes first.

--- a/client/dashboard/emails/utils/titan-tiers.ts
+++ b/client/dashboard/emails/utils/titan-tiers.ts
@@ -16,8 +16,21 @@ export const TITAN_TIER_SLUGS: Record< TitanPlanTier, Record< IntervalLength, st
 	},
 };
 
+// Tiers ordered from lowest to highest, used to tell upgrades from downgrades
+// relative to the current tier.
+export const TITAN_TIER_ORDER: TitanPlanTier[] = [
+	TitanPlanTier.Pro,
+	TitanPlanTier.Premium,
+	TitanPlanTier.Ultra,
+];
+
 export function isTitanPlanTier( value: unknown ): value is TitanPlanTier {
 	return Object.values( TitanPlanTier ).includes( value as TitanPlanTier );
+}
+
+// The top tier has nothing higher to upgrade to.
+export function isHighestTitanTier( tier?: TitanPlanTier ): boolean {
+	return !! tier && tier === TITAN_TIER_ORDER[ TITAN_TIER_ORDER.length - 1 ];
 }
 
 export function getTitanTierFromSlug( productSlug?: string ): TitanPlanTier | undefined {

--- a/client/dashboard/me/billing-purchases/purchase-settings/email-plan.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/email-plan.tsx
@@ -8,12 +8,12 @@ import { Button } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { currencyDollar, envelope } from '@wordpress/icons';
 import { useAnalytics } from '../../../app/analytics';
-import { addMailboxRoute } from '../../../app/router/emails';
+import { addMailboxRoute, chooseEmailSolutionRoute } from '../../../app/router/emails';
 import { ActionList } from '../../../components/action-list';
 import OverviewCard from '../../../components/overview-card';
 import { IntervalLength, MailboxProvider, TitanPlanTier } from '../../../emails/types';
 import { isMonthlyEmailProduct } from '../../../emails/utils/is-monthly-email-product';
-import { getTitanTierFromSlug } from '../../../emails/utils/titan-tiers';
+import { getTitanTierFromSlug, isHighestTitanTier } from '../../../emails/utils/titan-tiers';
 import { isTitanMail } from '../../../utils/purchase';
 import type { Purchase } from '@automattic/api-core';
 
@@ -83,6 +83,50 @@ export function AddMailboxesActionItem( { purchase }: { purchase: Purchase } ) {
 			actions={
 				<Button variant="secondary" size="compact" onClick={ onAdd }>
 					{ __( 'Add' ) }
+				</Button>
+			}
+		/>
+	);
+}
+
+/**
+ * The highest email tier has nothing higher to upgrade to, so the generic
+ * upgrade action is hidden. In that case "Manage your plan" takes over as a
+ * neutral entry into the tier grid, where the user can still change their plan.
+ */
+export function isEmailPlanAtHighestTier( purchase: Purchase ): boolean {
+	return (
+		isEmailPlanManagementEnabled( purchase ) &&
+		isHighestTitanTier( getTitanTierFromSlug( purchase.product_slug ) )
+	);
+}
+
+function useManagePlanNavigation( purchase: Purchase ) {
+	const navigate = useNavigate();
+	const { recordTracksEvent } = useAnalytics();
+
+	return () => {
+		recordTracksEvent( 'calypso_purchases_email_manage_plan_click', {
+			product_slug: purchase.product_slug,
+		} );
+		navigate( {
+			to: chooseEmailSolutionRoute.to,
+			params: { domain: purchase.meta ?? '' },
+			search: { intent: 'upgrade' as const },
+		} );
+	};
+}
+
+export function ManageEmailPlanActionItem( { purchase }: { purchase: Purchase } ) {
+	const onManage = useManagePlanNavigation( purchase );
+
+	return (
+		<ActionList.ActionItem
+			title={ __( 'Manage your plan' ) }
+			description={ __( 'Review your plan and see other options.' ) }
+			actions={
+				<Button variant="secondary" size="compact" onClick={ onManage }>
+					{ __( 'Manage' ) }
 				</Button>
 			}
 		/>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -121,6 +121,8 @@ import {
 	AddMailboxesActionItem,
 	EmailPlanMailboxCard,
 	EmailPlanPriceCard,
+	ManageEmailPlanActionItem,
+	isEmailPlanAtHighestTier,
 	isEmailPlanManagementEnabled,
 } from './email-plan';
 import { getCancelButtonCopy, getRemoveButtonCopy } from './get-cancel-remove-copy';
@@ -439,6 +441,11 @@ function canUpgradePurchase( purchase: Purchase ): boolean {
 	if ( isTitanMail( purchase ) && ! config.isEnabled( 'emails/titan-tiers' ) ) {
 		return false;
 	}
+	// The highest email tier has nothing to upgrade to; "Manage your plan"
+	// takes over so the user can still reach the plan grid.
+	if ( isEmailPlanAtHighestTier( purchase ) ) {
+		return false;
+	}
 	return true;
 }
 
@@ -727,6 +734,9 @@ function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 				<ReinstallButton purchase={ purchase } />
 				<JetpackCRMDownloadsButton purchase={ purchase } />
 				<UpgradeActionButton purchase={ purchase } />
+				{ ! isExpiredOrRemoved( purchase ) && isEmailPlanAtHighestTier( purchase ) && (
+					<ManageEmailPlanActionItem purchase={ purchase } />
+				) }
 				<StorageUpgradeActionButton purchase={ purchase } />
 				{ ! isExpiredOrRemoved( purchase ) && isEmailPlanManagementEnabled( purchase ) && (
 					<AddMailboxesActionItem purchase={ purchase } />

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -123,6 +123,8 @@ import {
 	AddMailboxesActionItem,
 	EmailPlanMailboxCard,
 	EmailPlanPriceCard,
+	ManageEmailPlanActionItem,
+	isEmailPlanAtHighestTier,
 	isEmailPlanManagementEnabled,
 } from './email-plan';
 import { getCancelButtonCopy, getRemoveButtonCopy } from './get-cancel-remove-copy';
@@ -153,6 +155,11 @@ function getNonPlanUpgradeAction(
 	// Titan email upgrades route through the flag-gated tier grid; without the flag
 	// the upgrade URL would fall through to the wrong (site plan) page.
 	if ( isTitanMail( purchase ) && ! config.isEnabled( 'emails/titan-tiers' ) ) {
+		return undefined;
+	}
+	// The highest email tier has nothing to upgrade to; "Manage your plan"
+	// takes over so the user can still reach the plan grid.
+	if ( isEmailPlanAtHighestTier( purchase ) ) {
 		return undefined;
 	}
 	const href = getSitePurchaseUpgradeUrl( purchase, getUpgradedPurchaseRedirectUrl() );
@@ -744,6 +751,9 @@ function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 				<ReinstallButton purchase={ purchase } />
 				<JetpackCRMDownloadsButton purchase={ purchase } />
 				<ProductChangeActionItem purchase={ purchase } />
+				{ ! isExpiredOrRemoved( purchase ) && isEmailPlanAtHighestTier( purchase ) && (
+					<ManageEmailPlanActionItem purchase={ purchase } />
+				) }
 				<StorageUpgradeActionButton purchase={ purchase } />
 				{ ! isExpiredOrRemoved( purchase ) && isEmailPlanManagementEnabled( purchase ) && (
 					<AddMailboxesActionItem purchase={ purchase } />


### PR DESCRIPTION
## Proposed Changes

Behind the `emails/titan-tiers` flag (Dashboard):

* **Tier grid** (`titan-plan-grid.tsx`): lower tiers now render an actionable **"Downgrade"** button instead of a disabled **"Included in your plan"**. Selecting a lower tier routes through the existing tier-checkout path (`getTitanTierUpgradeUrl`), same as an upgrade, with the current mailbox count.
* **Purchase page** (`purchase-settings/`): when a Professional Email plan is already at the **highest tier** (nothing to upgrade to), the generic "Upgrade subscription" action is hidden and a neutral **"Manage your plan"** action takes its place, opening the tier grid so the user can still change their plan. The copy deliberately does not invite a downgrade explicitly.
* Moved the tier ordering into a shared `TITAN_TIER_ORDER` in `titan-tiers.ts` and added `isHighestTitanTier()`, so the grid and the purchase page share one source of truth.

## Why are these changes being made?

Previously the tier grid could only upgrade: lower tiers were shown as a dead, disabled button, and a top-tier subscriber had no entry point back into the plan grid at all. This lets an existing Professional Email subscriber move down a tier, and gives top-tier subscribers a way to reach the plan grid without implying a downgrade in the purchase-page copy.

## Testing Instructions

1. Enable the `emails/titan-tiers` flag (on by default in `development`).
2. On a domain with a **Premium or Ultra** Professional Email subscription, open `/emails/choose-email-solution/<domain>?intent=upgrade`. Lower tiers should show an enabled **Downgrade** button; clicking it goes to checkout for that lower tier with the existing mailbox count. The current tier shows "Current plan"; higher tiers (if any) show "Upgrade".
3. On the purchase page `/me/billing/purchases/<id>` for that subscription:
   * **Pro / Premium**: shows "Upgrade subscription".
   * **Ultra** (highest tier): shows **"Manage your plan"** instead, linking to the tier grid.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?