### PR TITLE
Purchases: issue the refund when removing a refundable subscription

### DIFF
--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -847,7 +847,11 @@ export function getMutationFlowType(
 		return getPurchaseCancellationFlowType( purchase );
 	}
 
-	if ( purchase.is_auto_renew_enabled && hasAmountAvailableToRefund( purchase ) ) {
+	// intent === 'remove': refundability alone decides the endpoint. A purchase
+	// still inside its refund window goes through cancel-and-refund rather than
+	// the bare DELETE — auto-renew is typically already off by the time Remove is
+	// offered (the user cancelled first), so it must not gate the refund.
+	if ( hasAmountAvailableToRefund( purchase ) ) {
 		return CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND;
 	}
 	return CANCEL_FLOW_TYPE.REMOVE;

--- a/client/dashboard/utils/test/purchase.ts
+++ b/client/dashboard/utils/test/purchase.ts
@@ -108,11 +108,20 @@ describe( 'getMutationFlowType', () => {
 		).toBe( CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND );
 	} );
 
-	test( 'intent=remove + auto-renew off → REMOVE (DELETE)', () => {
+	test( 'intent=remove + auto-renew off + refund available → CANCEL_WITH_REFUND', () => {
 		expect(
 			getMutationFlowType(
 				'remove',
 				makePurchase( { is_auto_renew_enabled: false, is_refundable: true, refund_amount: 50 } )
+			)
+		).toBe( CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND );
+	} );
+
+	test( 'intent=remove + auto-renew off + no refund → REMOVE (DELETE)', () => {
+		expect(
+			getMutationFlowType(
+				'remove',
+				makePurchase( { is_auto_renew_enabled: false, is_refundable: false, refund_amount: 0 } )
 			)
 		).toBe( CANCEL_FLOW_TYPE.REMOVE );
 	} );

--- a/client/lib/purchases/test/utils.ts
+++ b/client/lib/purchases/test/utils.ts
@@ -96,11 +96,20 @@ describe( 'getMutationFlowType', () => {
 		).toBe( CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND );
 	} );
 
-	test( 'intent=remove + auto-renew off → REMOVE (DELETE)', () => {
+	test( 'intent=remove + auto-renew off + refund available → CANCEL_WITH_REFUND', () => {
 		expect(
 			getMutationFlowType(
 				'remove',
 				makePurchase( { isAutoRenewEnabled: false, isRefundable: true, refundAmount: 50 } )
+			)
+		).toBe( CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND );
+	} );
+
+	test( 'intent=remove + auto-renew off + no refund → REMOVE (DELETE)', () => {
+		expect(
+			getMutationFlowType(
+				'remove',
+				makePurchase( { isAutoRenewEnabled: false, isRefundable: false, refundAmount: 0 } )
 			)
 		).toBe( CANCEL_FLOW_TYPE.REMOVE );
 	} );

--- a/client/lib/purchases/utils.ts
+++ b/client/lib/purchases/utils.ts
@@ -57,7 +57,11 @@ export function getMutationFlowType( intent: CancelIntent | null, purchase: Purc
 		return getPurchaseCancellationFlowType( purchase );
 	}
 
-	if ( purchase?.isAutoRenewEnabled && hasAmountAvailableToRefund( purchase ) ) {
+	// intent === 'remove': refundability alone decides the endpoint. A purchase
+	// still inside its refund window goes through cancel-and-refund rather than
+	// the bare DELETE — auto-renew is typically already off by the time Remove is
+	// offered (the user cancelled first), so it must not gate the refund.
+	if ( purchase && hasAmountAvailableToRefund( purchase ) ) {
 		return CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND;
 	}
 	return CANCEL_FLOW_TYPE.REMOVE;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2306/

Reported in Slack: p1785253075378599-slack-C0117V2PCAE

## Proposed Changes

Removing a subscription that was still inside its refund period silently issued no refund in the Dashboard. `getMutationFlowType` gated the cancel-and-refund flow on auto-renew still being enabled, so a refundable purchase with auto-renew already off resolved to the plain DELETE endpoint. This makes refundability alone decide the endpoint for the remove intent.

* Drop the `isAutoRenewEnabled` conjunct from the `intent === 'remove'` branch of `getMutationFlowType` in `client/dashboard/utils/purchase.ts` and its Classic counterpart `client/lib/purchases/utils.ts`.
* Preserve the Classic copy's null-tolerance for `purchase` (`isRefundable()` dereferences directly, so the old optional chaining was load-bearing on that branch).
* Update the two unit tests that asserted the old behaviour, and add coverage for refundable-and-auto-renew-off vs. non-refundable-and-auto-renew-off.

## Why are these changes being made?

Two endpoints are reachable from the same Remove button: `POST /wpcom/v2/upgrades/{id}/delete`, which does not refund, and `POST /wpcom/v2/upgrades/{id}/cancel`, which does. `getMutationFlowType` chose between them with:

```js
if ( purchase.is_auto_renew_enabled && hasAmountAvailableToRefund( purchase ) ) {
	return CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND;
}
return CANCEL_FLOW_TYPE.REMOVE;
```

The Remove action is only offered once auto-renew is off (`showRemove = ! autoRenewOn || isExpiredAndInGracePeriod( purchase )`), which is exactly when that first conjunct is false. So on the documented path — cancel a plan, then take the Remove action it surfaces — a refundable purchase always fell through to the DELETE. The purchase was removed and no refund was issued.

The UI made this worse by promising the refund the mutation never requested: `getRemoveButtonCopy` renders "Get a refund and remove plan features immediately." whenever `refund_amount > 0`, and the remove flow shows a confirmed refund-amount notice above the confirmation.

Refundability is the only thing that should decide the endpoint here. That is already how the no-intent heuristic behaves — `getPurchaseCancellationFlowType` checks refundability first, before it looks at auto-renew — so the intent path was the outlier.

Classic never issued the wrong request, because `isLegacyRemoveDeleteFlow` re-checks `hasAmountAvailableToRefund` and bails out of the DELETE path before consulting `getMutationFlowType`. That local guard was quietly compensating for the shared helper; it is now redundant rather than load-bearing, and its doc comment ("`getMutationFlowType` returns `CANCEL_WITH_REFUND` in that case") becomes accurate. Both copies of the helper are fixed so the two surfaces agree at the source instead of at one call site.

## Testing Instructions

TC:

```
yarn test-client client/dashboard/utils/test/purchase.ts client/lib/purchases/test/utils.ts
```

The two renamed tests fail before this change and pass after. The full purchase-related suites also pass:

```
yarn test-client client/dashboard/me/billing-purchases client/me/purchases client/dashboard/utils client/lib/purchases
```

Manual testing (needs a payments sandbox):

* Buy a plan.
* In the Multi-site Dashboard purchase management page, go through the cancellation flow — this disables auto-renew.
* Back on the purchase page, take the new Remove action and complete the flow.
* Confirm the request goes to `/wpcom/v2/upgrades/{id}/cancel` (not `/delete`) and that a refund appears in Payments Admin for that ownership ID.
* Repeat the same steps in the Classic purchase management page and confirm it still refunds — behaviour there should be unchanged.
* Also confirm a non-refundable purchase (expired, or past its refund window) still uses `/delete` and is removed without a refund.