### PR TITLE
Checkout: add is_step_container_v2 and stepper_flow to page view event

### DIFF
--- a/client/layout/test/utils.test.ts
+++ b/client/layout/test/utils.test.ts
@@ -1,5 +1,5 @@
 import { SITE_SETUP_FLOW, ONBOARDING_FLOW, SITE_MIGRATION_FLOW } from '@automattic/onboarding';
-import { isInStepContainerV2FlowContext } from '../utils';
+import { isInStepContainerV2FlowContext, getStepperFlowFromContext } from '../utils';
 
 describe( 'layout/utils', () => {
 	describe( 'isInStepContainerV2FlowContext', () => {
@@ -62,6 +62,53 @@ describe( 'layout/utils', () => {
 
 				expect( result ).toBe( false );
 			} );
+		} );
+	} );
+
+	describe( 'getStepperFlowFromContext', () => {
+		it( 'should return the flow from the URL when path starts with /setup', () => {
+			const pathname = '/setup/' + SITE_MIGRATION_FLOW;
+			const query = 'step=step1';
+
+			const result = getStepperFlowFromContext( pathname, query );
+
+			expect( result ).toBe( SITE_MIGRATION_FLOW );
+		} );
+
+		it( 'should return the flow inferred from redirect_to when path starts with /checkout', () => {
+			const pathname = '/checkout/site.com';
+			const query = 'redirect_to=%2Fsetup%2F' + SITE_SETUP_FLOW;
+
+			const result = getStepperFlowFromContext( pathname, query );
+
+			expect( result ).toBe( SITE_SETUP_FLOW );
+		} );
+
+		it( 'should return the flow inferred from cancel_to when path starts with /checkout and redirect_to has no flow', () => {
+			const pathname = '/checkout/site.com';
+			const query = 'redirect_to=%2Fsome-path&cancel_to=%2Fsetup%2F' + ONBOARDING_FLOW;
+
+			const result = getStepperFlowFromContext( pathname, query );
+
+			expect( result ).toBe( ONBOARDING_FLOW );
+		} );
+
+		it( 'should return an empty string when path starts with /checkout but neither redirect_to nor cancel_to has a flow', () => {
+			const pathname = '/checkout/site.com';
+			const query = 'redirect_to=%2Fsome-path&cancel_to=%2Fother-path';
+
+			const result = getStepperFlowFromContext( pathname, query );
+
+			expect( result ).toBe( '' );
+		} );
+
+		it( 'should return an empty string for paths that do not start with /setup or /checkout', () => {
+			const pathname = '/some-other-path';
+			const query = '';
+
+			const result = getStepperFlowFromContext( pathname, query );
+
+			expect( result ).toBe( '' );
 		} );
 	} );
 } );

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -169,10 +169,18 @@ export const handleScroll = ( event: React.UIEvent< HTMLElement > ): void => {
 	}
 };
 
-const isRedirectingToStepContainerV2Flow = ( redirectTo: string ) => {
+const getFlowFromRedirectURL = ( redirectTo: string ) => {
+	if ( ! redirectTo ) {
+		return '';
+	}
+
 	const { pathname, search } = new URL( redirectTo, 'http://example.com' );
 
-	return shouldUseStepContainerV2( getFlowFromURL( pathname, search ) );
+	return getFlowFromURL( pathname, search );
+};
+
+const isRedirectingToStepContainerV2Flow = ( redirectTo: string ) => {
+	return shouldUseStepContainerV2( getFlowFromRedirectURL( redirectTo ) );
 };
 
 const isMarketplaceThankYouRedirect = ( redirectTo: string ) => {
@@ -230,6 +238,36 @@ export const isInStepContainerV2FlowContext = ( pathname: string, query: string 
 export const useInitialIsInStepContainerV2FlowContext = () => {
 	const ref = useRef(
 		isInStepContainerV2FlowContext( window.location.pathname, window.location.search )
+	);
+
+	return ref.current;
+};
+
+/**
+ * Returns the stepper flow name associated with the current page, if any.
+ * On `/setup` this is the flow in the URL. On `/checkout` the flow (if any) is
+ * inferred from the `redirect_to`/`cancel_to` query params, since checkout
+ * itself isn't part of a stepper flow.
+ */
+export const getStepperFlowFromContext = ( pathname: string, query: string ): string => {
+	if ( pathname.startsWith( '/setup' ) ) {
+		return getFlowFromURL( pathname, query );
+	}
+
+	if ( pathname.startsWith( '/checkout' ) ) {
+		const params = new URLSearchParams( query );
+		const redirectTo = params.get( 'redirect_to' ) ?? '';
+		const cancelTo = params.get( 'cancel_to' ) ?? '';
+
+		return getFlowFromRedirectURL( redirectTo ) || getFlowFromRedirectURL( cancelTo );
+	}
+
+	return '';
+};
+
+export const useInitialStepperFlowFromContext = () => {
+	const ref = useRef(
+		getStepperFlowFromContext( window.location.pathname, window.location.search )
 	);
 
 	return ref.current;

--- a/client/my-sites/checkout/src/hooks/use-record-checkout-loaded.ts
+++ b/client/my-sites/checkout/src/hooks/use-record-checkout-loaded.ts
@@ -1,5 +1,9 @@
 import debugFactory from 'debug';
 import { useRef } from 'react';
+import {
+	useInitialIsInStepContainerV2FlowContext,
+	useInitialStepperFlowFromContext,
+} from 'calypso/layout/utils';
 import { hasRenewalItem } from 'calypso/lib/cart-values/cart-items';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -24,6 +28,8 @@ export default function useRecordCheckoutLoaded( {
 	const reduxDispatch = useDispatch();
 	const hasRecordedCheckoutLoad = useRef( false );
 	const { currency } = responseCart;
+	const isStepContainerV2 = useInitialIsInStepContainerV2FlowContext();
+	const stepperFlow = useInitialStepperFlowFromContext();
 	if ( ! isLoading && ! hasRecordedCheckoutLoad.current ) {
 		debug( 'composite checkout has loaded' );
 		reduxDispatch(
@@ -35,6 +41,8 @@ export default function useRecordCheckoutLoaded( {
 				is_composite: true,
 				checkout_flow: checkoutFlow,
 				currency,
+				is_step_container_v2: isStepContainerV2,
+				...( stepperFlow ? { stepper_flow: stepperFlow } : {} ),
 			} )
 		);
 		reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_loaded', {} ) );


### PR DESCRIPTION
Fixes [SHILL-2307](https://linear.app/a8c/issue/SHILL-2307/add-is-step-container-v2-and-stepper-flow-to-calypso-checkout-page)

## Proposed Changes

This adds two new properties to the `calypso_checkout_page_view` Tracks event so we can segment checkout funnel analysis by the StepContainerV2 rollout and by the stepper flow that led into checkout.

* Add `is_step_container_v2` (boolean) to the event, using the existing `useInitialIsInStepContainerV2FlowContext` hook.
* Add `stepper_flow` to the event when it can be determined, via a new `getStepperFlowFromContext` / `useInitialStepperFlowFromContext` helper in `client/layout/utils.ts`.
* `getStepperFlowFromContext` infers the flow name from `/setup/:flow`, or for `/checkout` pages from the `redirect_to`/`cancel_to` query params, reusing the pattern already established by `isInStepContainerV2FlowContext`.

## Why are these changes being made?

The checkout page view event currently has no way to tell whether a session used the StepContainerV2 layout, or which stepper flow (e.g. onboarding, site migration) the user came from before landing on checkout. Since checkout itself isn't part of a stepper flow, the flow name has to be inferred from the `redirect_to`/`cancel_to` query params rather than read directly — this mirrors the existing `isInStepContainerV2FlowContext` logic used elsewhere in the layout. `stepper_flow` is only included on the event when a flow can actually be determined, since most checkout sessions aren't reached via a stepper flow.

## Testing Instructions

* Load checkout directly (e.g. from My Sites > Plans) and confirm `calypso_checkout_page_view` includes `is_step_container_v2: false` and no `stepper_flow` property.
* Start the onboarding or site-migration stepper flow and proceed through to checkout, then confirm `calypso_checkout_page_view` includes `is_step_container_v2: true` and `stepper_flow` set to the originating flow name.
