### PR TITLE
A4A-3100: Drop the holding-site slug from A4A renewal links

### DIFF
--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -627,8 +627,8 @@ function getCheckoutProductSlugFromPurchase( purchase: Purchase ): string {
 }
 
 function getCheckoutSiteSlugForPurchase( purchase: Purchase ): string {
-	if ( isAkismetProduct( purchase ) ) {
-		// Akismet checkout never uses a site slug.
+	// Neither Akismet nor A4A holding sites should use a site slug
+	if ( isAkismetProduct( purchase ) || isA4AHoldingSitePurchase( purchase ) ) {
 		return '';
 	}
 	return purchase.site_slug || '';

--- a/client/dashboard/utils/test/purchase.ts
+++ b/client/dashboard/utils/test/purchase.ts
@@ -15,6 +15,7 @@ import {
 	mightStillAutoRenew,
 	isExpiredWithNoAutoRenewAttemptsLeft,
 	creditCardExpiresBeforeSubscription,
+	getRenewalUrlFromPurchase,
 } from '../purchase';
 import type { Purchase } from '@automattic/api-core';
 
@@ -407,5 +408,35 @@ describe( 'creditCardExpiresBeforeSubscription', () => {
 				} )
 			)
 		).toBe( false );
+	} );
+} );
+
+describe( 'getRenewalUrlFromPurchase', () => {
+	test( 'omits the site slug for an A4A holding site purchase', () => {
+		const url = getRenewalUrlFromPurchase(
+			makePurchase( {
+				ID: 28259013,
+				product_slug: 'pressable_build_monthly',
+				meta: 'is-a4a',
+				is_attached_to_holding_site: true,
+				site_slug: 'siteless.agencies.automattic.com::yETR9VrPZIMpOMIL6CICWl36',
+			} )
+		);
+
+		expect( url ).toContain( '/checkout/pressable_build_monthly:is-a4a/renew/28259013/?' );
+		expect( url ).not.toContain( 'siteless.agencies.automattic.com' );
+	} );
+
+	test( 'keeps the site slug for a regular site purchase', () => {
+		const url = getRenewalUrlFromPurchase(
+			makePurchase( {
+				ID: 12345,
+				product_slug: 'business-bundle',
+				is_attached_to_holding_site: false,
+				site_slug: 'example.wordpress.com',
+			} )
+		);
+
+		expect( url ).toContain( '/checkout/business-bundle/renew/12345/example.wordpress.com?' );
 	} );
 } );


### PR DESCRIPTION
Linear: [A4A-3100](https://linear.app/a8c/issue/A4A-3100/agencies-cant-manually-renew-a-lapsed-plan-from-the-purchases-page)

## Proposed Changes

Stop appending the holding-site slug to A4A renewal links, so **Renew now** on the purchases page opens checkout.

Bug reported in Slack: p1785252492563499-slack-C091P0A65U5

## Why are these changes being made?

A4A subscriptions live on a siteless holding site. Appending its slug matched the `/checkout/:product/renew/:purchaseId/:domain` route, which runs `siteSelection`. Agencies have no sites of their own, so that renders "You don't have any sites yet". Without the slug the link matches the `noSite` route and works.

Same bug as SHILL-1726. The fix there redirected all renewal links to the generic renewal route (#109026) and was reverted (#109792) for breaking Jetpack renewals, so this regressed. This does it the narrow way instead — strip the slug, like the classic purchases page already does — leaving routing alone. Marketplace holding sites look the same but are out of scope here.

## Testing Instructions

1. ~~Apply the backend PR: 230955-ghe-Automattic/wpcom~~ (shipped)
2. For an agency with a subscription on a siteless site (unassigned license or Pressable), visit `/me/billing/purchases` on the Dashboard live link URL
3. From store admin, set the expiration date to a few days from now
4. Click to "Manage purchase"
5. Click "Renew"
6. The checkout should load with the renewal in the cart

<img width="1527" height="1033" alt="Screenshot 2026-07-28 at 12 26 44 PM" src="https://github.com/user-attachments/assets/4c1b5119-5be2-4e84-a80a-984378d01e14" />

Without this fix the checkout never loaded:
<img width="1493" height="607" alt="Screenshot 2026-07-28 at 12 27 28 PM" src="https://github.com/user-attachments/assets/0ad9fb09-9558-4f33-8565-3e55e1e4c934" />


---

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Crafted by Travbot (Claude-powered)