### PR TITLE
Stats: show the video thumbnail in the video details card

### DIFF
--- a/client/my-sites/stats/stats-video-detail/index.tsx
+++ b/client/my-sites/stats/stats-video-detail/index.tsx
@@ -32,6 +32,7 @@ interface StatsVideoDetailProps {
 interface VideoStatsPost {
 	post_title?: string;
 	post_date?: string;
+	poster?: string | null;
 }
 
 export default function StatsVideoDetail( { postId, period, context }: StatsVideoDetailProps ) {
@@ -75,6 +76,7 @@ export default function StatsVideoDetail( { postId, period, context }: StatsVide
 
 	const videoTitle = videoStatsPost?.post_title || null;
 	const videoDate = videoStatsPost?.post_date || null;
+	const videoPoster = videoStatsPost?.poster || null;
 	// Loading until statsVideo answers (success or failure); a response
 	// without a post means there is genuinely no title and the card hides.
 	const isVideoInfoLoading = ! videoStatsData && ! hasVideoInfoFailed;
@@ -102,6 +104,7 @@ export default function StatsVideoDetail( { postId, period, context }: StatsVide
 					<VideoDetailsCard
 						title={ videoTitle }
 						date={ videoDate }
+						poster={ videoPoster }
 						isLoading={ isVideoInfoLoading }
 					/>
 					<VideoSummary postId={ postId } initialStatType={ statType } />

--- a/client/my-sites/stats/stats-video-detail/index.tsx
+++ b/client/my-sites/stats/stats-video-detail/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useLayoutEffect, useMemo } from 'react';
 import titlecase from 'to-title-case';
@@ -7,6 +8,8 @@ import {
 	recordCurrentScreen,
 } from 'calypso/my-sites/stats/hooks/use-stats-navigation-history';
 import { useSelector } from 'calypso/state';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import {
 	getSiteStatsNormalizedData,
 	hasSiteStatsQueryFailed,
@@ -57,6 +60,17 @@ export default function StatsVideoDetail( { postId, period, context }: StatsVide
 		siteId ? hasSiteStatsQueryFailed( state, siteId, 'statsVideo', videoInfoQuery ) : false
 	);
 	const videoStatsPost = videoStatsData?.post ?? null;
+
+	// Per the STATS-296 spec the thumbnail links to the video in the media
+	// library: wp-admin's upload.php in Odyssey, the /media route in Calypso
+	// (which itself forwards default-interface sites to upload.php). The
+	// video's stats id is its attachment id.
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
+	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
+	const mediaLibraryUrl = isOdysseyStats
+		? siteAdminUrl && `${ siteAdminUrl }upload.php?item=${ postId }`
+		: siteSlug && `/media/${ siteSlug }/${ postId }`;
 	const breadcrumbTrail = useStatsBreadcrumbTrail();
 	const statType = context.query.statType ?? null;
 
@@ -105,6 +119,7 @@ export default function StatsVideoDetail( { postId, period, context }: StatsVide
 						title={ videoTitle }
 						date={ videoDate }
 						poster={ videoPoster }
+						mediaLibraryUrl={ mediaLibraryUrl || null }
 						isLoading={ isVideoInfoLoading }
 					/>
 					<VideoSummary postId={ postId } initialStatType={ statType } />

--- a/client/my-sites/stats/stats-video-detail/style.scss
+++ b/client/my-sites/stats/stats-video-detail/style.scss
@@ -142,6 +142,17 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 	}
 }
 
+// The link box doesn't participate in the card grid — the image inside keeps
+// its grid-area, so the layout is identical with or without the link.
+.stats-video-details-card__thumbnail-link {
+	display: contents;
+
+	&:focus-visible .stats-video-details-card__thumbnail {
+		outline: 2px solid var(--color-primary);
+		outline-offset: 2px;
+	}
+}
+
 .stats-video-details-card__thumbnail {
 	align-self: center;
 	aspect-ratio: 16 / 9;

--- a/client/my-sites/stats/stats-video-detail/style.scss
+++ b/client/my-sites/stats/stats-video-detail/style.scss
@@ -142,12 +142,18 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 	}
 }
 
-// The link box doesn't participate in the card grid — the image inside keeps
-// its grid-area, so the layout is identical with or without the link.
+// The anchor keeps its own box as the grid item — display: contents on an
+// interactive element is dropped from the accessibility tree or loses focus
+// in some browsers. The thumbnail column is auto-width, so the anchor
+// shrink-wraps the image inside and the layout matches the unlinked one.
 .stats-video-details-card__thumbnail-link {
-	display: contents;
+	align-self: center;
+	border-radius: $border-radius;
+	display: block;
+	grid-area: thumbnail;
+	line-height: 0;
 
-	&:focus-visible .stats-video-details-card__thumbnail {
+	&:focus-visible {
 		outline: 2px solid var(--color-primary);
 		outline-offset: 2px;
 	}

--- a/client/my-sites/stats/stats-video-detail/style.scss
+++ b/client/my-sites/stats/stats-video-detail/style.scss
@@ -126,6 +126,32 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 	}
 }
 
+.stats-video-details-card.has-thumbnail {
+	display: grid;
+	grid-template-areas:
+		"heading thumbnail"
+		"info thumbnail";
+	grid-template-columns: minmax(0, 1fr) auto;
+
+	.stats-video-details-card__heading {
+		grid-area: heading;
+	}
+
+	.stats-video-details-card__info {
+		grid-area: info;
+	}
+}
+
+.stats-video-details-card__thumbnail {
+	align-self: center;
+	aspect-ratio: 16 / 9;
+	border-radius: $border-radius;
+	display: block;
+	grid-area: thumbnail;
+	object-fit: cover;
+	width: 192px;
+}
+
 .stats-video-embeds-card {
 	border-color: var(--studio-gray-5);
 	border-radius: 5px; /* stylelint-disable-line scales/radii */
@@ -260,5 +286,16 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 
 	.stats-video-details-card {
 		gap: 12px;
+	}
+
+	.stats-video-details-card.has-thumbnail {
+		grid-template-areas:
+			"heading heading"
+			"info thumbnail";
+	}
+
+	.stats-video-details-card__thumbnail {
+		aspect-ratio: 1;
+		width: 84px;
 	}
 }

--- a/client/my-sites/stats/stats-video-detail/test/video-details-card.tsx
+++ b/client/my-sites/stats/stats-video-detail/test/video-details-card.tsx
@@ -5,6 +5,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import VideoDetailsCard from '../video-details-card';
 
 const POSTER = 'https://videos.files.wordpress.com/abc123/poster.jpg';
+const MEDIA_URL = '/media/example.com/123';
 
 function getCard( container: HTMLElement ) {
 	return container.querySelector( '.stats-video-details-card' );
@@ -19,18 +20,44 @@ describe( 'VideoDetailsCard', () => {
 		const img = container.querySelector( 'img.stats-video-details-card__thumbnail' );
 		expect( img ).toHaveAttribute( 'src', POSTER );
 		expect( img ).toHaveAttribute( 'alt', '' );
+		expect( container.querySelector( 'a' ) ).toBeNull();
 		expect( getCard( container ) ).toHaveClass( 'has-thumbnail' );
 		expect( screen.getByText( 'My video' ) ).toBeInTheDocument();
 	} );
 
+	test( 'links the thumbnail to the media library when a URL is provided', () => {
+		const { container } = render(
+			<VideoDetailsCard
+				title="My video"
+				date={ null }
+				poster={ POSTER }
+				mediaLibraryUrl={ MEDIA_URL }
+			/>
+		);
+
+		const link = screen.getByRole( 'link', { name: 'View the video in the media library' } );
+		expect( link ).toHaveAttribute( 'href', MEDIA_URL );
+		expect( link.querySelector( 'img.stats-video-details-card__thumbnail' ) ).toHaveAttribute(
+			'alt',
+			''
+		);
+		expect( getCard( container ) ).toHaveClass( 'has-thumbnail' );
+	} );
+
 	test( 'drops back to the text-only layout when the poster fails to load', () => {
 		const { container } = render(
-			<VideoDetailsCard title="My video" date={ null } poster={ POSTER } />
+			<VideoDetailsCard
+				title="My video"
+				date={ null }
+				poster={ POSTER }
+				mediaLibraryUrl={ MEDIA_URL }
+			/>
 		);
 
 		fireEvent.error( container.querySelector( 'img.stats-video-details-card__thumbnail' )! );
 
 		expect( container.querySelector( 'img' ) ).toBeNull();
+		expect( container.querySelector( 'a' ) ).toBeNull();
 		expect( getCard( container ) ).not.toHaveClass( 'has-thumbnail' );
 		expect( screen.getByText( 'My video' ) ).toBeInTheDocument();
 	} );

--- a/client/my-sites/stats/stats-video-detail/test/video-details-card.tsx
+++ b/client/my-sites/stats/stats-video-detail/test/video-details-card.tsx
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import VideoDetailsCard from '../video-details-card';
+
+const POSTER = 'https://videos.files.wordpress.com/abc123/poster.jpg';
+
+function getCard( container: HTMLElement ) {
+	return container.querySelector( '.stats-video-details-card' );
+}
+
+describe( 'VideoDetailsCard', () => {
+	test( 'renders the poster as a decorative image with the thumbnail layout', () => {
+		const { container } = render(
+			<VideoDetailsCard title="My video" date={ null } poster={ POSTER } />
+		);
+
+		const img = container.querySelector( 'img.stats-video-details-card__thumbnail' );
+		expect( img ).toHaveAttribute( 'src', POSTER );
+		expect( img ).toHaveAttribute( 'alt', '' );
+		expect( getCard( container ) ).toHaveClass( 'has-thumbnail' );
+		expect( screen.getByText( 'My video' ) ).toBeInTheDocument();
+	} );
+
+	test( 'drops back to the text-only layout when the poster fails to load', () => {
+		const { container } = render(
+			<VideoDetailsCard title="My video" date={ null } poster={ POSTER } />
+		);
+
+		fireEvent.error( container.querySelector( 'img.stats-video-details-card__thumbnail' )! );
+
+		expect( container.querySelector( 'img' ) ).toBeNull();
+		expect( getCard( container ) ).not.toHaveClass( 'has-thumbnail' );
+		expect( screen.getByText( 'My video' ) ).toBeInTheDocument();
+	} );
+
+	test( 'keeps the text-only layout when there is no poster', () => {
+		const { container } = render( <VideoDetailsCard title="My video" date={ null } /> );
+
+		expect( container.querySelector( 'img' ) ).toBeNull();
+		expect( getCard( container ) ).not.toHaveClass( 'has-thumbnail' );
+		expect( screen.getByText( 'My video' ) ).toBeInTheDocument();
+	} );
+} );

--- a/client/my-sites/stats/stats-video-detail/test/video-details-card.tsx
+++ b/client/my-sites/stats/stats-video-detail/test/video-details-card.tsx
@@ -35,8 +35,12 @@ describe( 'VideoDetailsCard', () => {
 			/>
 		);
 
-		const link = screen.getByRole( 'link', { name: 'View the video in the media library' } );
+		const link = screen.getByRole( 'link', {
+			name: 'View the video in the media library (opens in a new tab)',
+		} );
 		expect( link ).toHaveAttribute( 'href', MEDIA_URL );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+		expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
 		expect( link.querySelector( 'img.stats-video-details-card__thumbnail' ) ).toHaveAttribute(
 			'alt',
 			''

--- a/client/my-sites/stats/stats-video-detail/video-details-card.tsx
+++ b/client/my-sites/stats/stats-video-detail/video-details-card.tsx
@@ -65,11 +65,17 @@ export default function VideoDetailsCard( {
 			</div>
 			{ posterUrl &&
 				( mediaLibraryUrl ? (
-					// The link, not the decorative image, carries the accessible name.
+					// The link, not the decorative image, carries the accessible
+					// name. It opens in a new tab: the media library (wp-admin in
+					// Odyssey) has no way back to this stats page.
 					<a
 						className="stats-video-details-card__thumbnail-link"
 						href={ mediaLibraryUrl }
-						aria-label={ translate( 'View the video in the media library', { textOnly: true } ) }
+						target="_blank"
+						rel="noopener noreferrer"
+						aria-label={ translate( 'View the video in the media library (opens in a new tab)', {
+							textOnly: true,
+						} ) }
 					>
 						{ renderThumbnail( posterUrl ) }
 					</a>

--- a/client/my-sites/stats/stats-video-detail/video-details-card.tsx
+++ b/client/my-sites/stats/stats-video-detail/video-details-card.tsx
@@ -10,11 +10,13 @@ export default function VideoDetailsCard( {
 	title,
 	date,
 	poster,
+	mediaLibraryUrl,
 	isLoading = false,
 }: {
 	title: string | null;
 	date: string | null;
 	poster?: string | null;
+	mediaLibraryUrl?: string | null;
 	isLoading?: boolean;
 } ) {
 	const translate = useTranslate();
@@ -28,6 +30,18 @@ export default function VideoDetailsCard( {
 	}
 
 	const posterUrl = poster && poster !== failedPoster ? poster : null;
+
+	// The card already shows the video's title next to the image, so the
+	// thumbnail adds no information for screen readers — treat it as
+	// decorative.
+	const renderThumbnail = ( url: string ) => (
+		<img
+			className="stats-video-details-card__thumbnail"
+			src={ url }
+			alt=""
+			onError={ () => setFailedPoster( url ) }
+		/>
+	);
 
 	return (
 		<Card
@@ -49,17 +63,19 @@ export default function VideoDetailsCard( {
 					</div>
 				) }
 			</div>
-			{ posterUrl && (
-				// The card already shows the video's title next to the image, so
-				// the thumbnail adds no information for screen readers — treat it
-				// as decorative.
-				<img
-					className="stats-video-details-card__thumbnail"
-					src={ posterUrl }
-					alt=""
-					onError={ () => setFailedPoster( posterUrl ) }
-				/>
-			) }
+			{ posterUrl &&
+				( mediaLibraryUrl ? (
+					// The link, not the decorative image, carries the accessible name.
+					<a
+						className="stats-video-details-card__thumbnail-link"
+						href={ mediaLibraryUrl }
+						aria-label={ translate( 'View the video in the media library', { textOnly: true } ) }
+					>
+						{ renderThumbnail( posterUrl ) }
+					</a>
+				) : (
+					renderThumbnail( posterUrl )
+				) ) }
 		</Card>
 	);
 }

--- a/client/my-sites/stats/stats-video-detail/video-details-card.tsx
+++ b/client/my-sites/stats/stats-video-detail/video-details-card.tsx
@@ -1,6 +1,7 @@
 import { Card } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 
 import './style.scss';
@@ -8,21 +9,33 @@ import './style.scss';
 export default function VideoDetailsCard( {
 	title,
 	date,
+	poster,
 	isLoading = false,
 }: {
 	title: string | null;
 	date: string | null;
+	poster?: string | null;
 	isLoading?: boolean;
 } ) {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
+	// Posters of private videos come back as tokenless CDN URLs that the CDN
+	// rejects (STATS-374), so hide the image instead of showing a broken one.
+	const [ failedPoster, setFailedPoster ] = useState< string | null >( null );
 
 	if ( ! title && ! isLoading ) {
 		return null;
 	}
 
+	const posterUrl = poster && poster !== failedPoster ? poster : null;
+
 	return (
-		<Card className={ clsx( 'stats-video-details-card', { 'is-loading': isLoading } ) }>
+		<Card
+			className={ clsx( 'stats-video-details-card', {
+				'is-loading': isLoading,
+				'has-thumbnail': !! posterUrl,
+			} ) }
+		>
 			<h4 className="stats-video-details-card__heading">{ translate( 'Video details' ) }</h4>
 			<div className="stats-video-details-card__info">
 				<div className="stats-video-details-card__title">{ title }</div>
@@ -36,6 +49,18 @@ export default function VideoDetailsCard( {
 					</div>
 				) }
 			</div>
+			{ posterUrl && (
+				<img
+					className="stats-video-details-card__thumbnail"
+					src={ posterUrl }
+					alt={ translate( 'Thumbnail for a video titled "%(title)s"', {
+						args: { title: title ?? '' },
+						comment: 'Alt-text for a video thumbnail.',
+						textOnly: true,
+					} ) }
+					onError={ () => setFailedPoster( posterUrl ) }
+				/>
+			) }
 		</Card>
 	);
 }

--- a/client/my-sites/stats/stats-video-detail/video-details-card.tsx
+++ b/client/my-sites/stats/stats-video-detail/video-details-card.tsx
@@ -50,14 +50,13 @@ export default function VideoDetailsCard( {
 				) }
 			</div>
 			{ posterUrl && (
+				// The card already shows the video's title next to the image, so
+				// the thumbnail adds no information for screen readers — treat it
+				// as decorative.
 				<img
 					className="stats-video-details-card__thumbnail"
 					src={ posterUrl }
-					alt={ translate( 'Thumbnail for a video titled "%(title)s"', {
-						args: { title: title ?? '' },
-						comment: 'Alt-text for a video thumbnail.',
-						textOnly: true,
-					} ) }
+					alt=""
 					onError={ () => setFailedPoster( posterUrl ) }
 				/>
 			) }


### PR DESCRIPTION
Part of STATS-375.

## Proposed Changes

* Show the video thumbnail in the Video details card on the video details page (`/stats/day/videodetails/:site?post=:id`).
* The thumbnail comes from the new `post.poster` field on the `stats/video/:video_id` response (a Photon-wrapped VideoPress poster URL), so no extra media request is needed — this also works in Odyssey Stats, whose stats-app proxy has no media route.
* Desktop shows a fixed 16:9 thumbnail beside the title/date; below the small breakpoint it becomes an 84px square next to the info block. `object-fit: cover` crops arbitrary poster aspect ratios into the fixed frame, which is what made the earlier full-bleed thumbnail layout (removed in #112499) hard to keep tidy.
* If the poster URL fails to load (e.g. private videos currently return a tokenless CDN URL the CDN rejects — STATS-374), the image hides instead of rendering broken, and the card falls back to the text-only layout.
* The thumbnail is decorative (`alt=""`): the card already shows the video's title next to it, so alt text would only repeat what screen readers just announced.
* Per the STATS-296 spec, the thumbnail links to the video in the media library: wp-admin's `upload.php?item=<id>` in Odyssey, the `/media/:site/:id` route in Calypso (which itself forwards default-interface sites to `upload.php`). The link opens in a new tab (the media library has no way back to the stats page). The anchor carries the accessible name (the image inside stays decorative), with a visible keyboard-focus outline. The anchor is the grid item itself (no `display: contents`, which some browsers drop from the accessibility tree); the auto-width thumbnail column shrink-wraps the image, so the layout is identical with or without the link.

## Why are these changes being made?

* The original video details card design included a thumbnail, but it was dropped during STATS-299 because the only data source was the media endpoint (unavailable through the Odyssey proxy) and the poster's arbitrary aspect ratios broke the card layout. The backend now ships the poster URL directly on the stats response, removing both blockers.

## Testing Instructions

* On a site with VideoPress videos that have stats, go to Stats → scroll to the Videos module (or All videos) and click a video to open its details page.
* Verify the Video details card shows the video thumbnail to the right of the title and published date, cropped to 16:9.
* Click the thumbnail: it opens the video in the media library in a new tab (`/media/:site/:id` in Calypso, `upload.php?item=<id>` in Odyssey / wp-admin-default sites), leaving the video details page in place.
* Narrow the viewport below the small breakpoint and verify the thumbnail becomes a small square next to the info text.
* Verify a video without a poster (or a non-VideoPress video) still renders the text-only card exactly as before.
* Optional: block the poster URL in DevTools and verify the image disappears instead of showing a broken icon.
* `yarn test-client client/my-sites/stats/stats-video-detail/test/video-details-card.tsx` — 4 tests green (poster, media-library link, failed-poster, and no-poster layouts).

### Screenshots

#### Normal viewport
<img width="1287" height="223" alt="截圖 2026-07-29 凌晨2 23 42" src="https://github.com/user-attachments/assets/8aee69b0-7779-4483-9394-e708bc56d517" />

#### Narrower viewport
<img width="630" height="290" alt="截圖 2026-07-29 凌晨2 23 55" src="https://github.com/user-attachments/assets/be7ac60d-cab1-4637-9819-9b1caeac3c9d" />

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)




