### PR TITLE
Emails: restore Titan control panel access in the Multi-Site Dashboard

### DIFF
--- a/client/dashboard/emails/components/test/titan-control-panel-modal.test.tsx
+++ b/client/dashboard/emails/components/test/titan-control-panel-modal.test.tsx
@@ -130,7 +130,9 @@ describe( '<TitanControlPanelModal>', () => {
 		await waitFor( () => expect( scope.isDone() ).toBe( true ) );
 	} );
 
-	test( 'closes the blank tab and warns when the auto-login URL cannot be fetched', async () => {
+	// The error snackbar itself comes from the mutation's withSnackbar meta, which the
+	// global Snackbars subscriber renders outside this component.
+	test( 'closes the blank tab when the auto-login URL cannot be fetched', async () => {
 		useLargeViewport();
 		mockDomain( ORDER_ID );
 		nock( 'https://public-api.wordpress.com' )

--- a/client/dashboard/emails/components/test/titan-control-panel-modal.test.tsx
+++ b/client/dashboard/emails/components/test/titan-control-panel-modal.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import TitanControlPanelModal from '../titan-control-panel-modal';
+
+const DOMAIN = 'example.com';
+const ORDER_ID = 4242;
+const AUTO_LOGIN_URL = 'https://manage.titan.email/auto-login?token=abc';
+
+function mockDomain( titanOrderId: number | null ) {
+	nock( 'https://public-api.wordpress.com' )
+		.get( `/rest/v1.2/domain-details/${ DOMAIN }` )
+		.query( true )
+		.reply( 200, {
+			domain: DOMAIN,
+			titan_mail_subscription: titanOrderId ? { order_id: titanOrderId } : null,
+		} );
+}
+
+function mockAutoLoginUrl( expectedContext?: string ) {
+	return nock( 'https://public-api.wordpress.com' )
+		.get( `/wpcom/v2/emails/titan/${ ORDER_ID }/control-panel-auto-login-url` )
+		.query( ( query ) => query.context === expectedContext )
+		.reply( 200, { auto_login_url: AUTO_LOGIN_URL } );
+}
+
+/**
+ * The shared dashboard test setup stubs matchMedia to never match, so every
+ * viewport query reports a small screen by default. `useMediaQuery` caches the
+ * MediaQueryList per window and query for the lifetime of the module, so the
+ * stubs have to be mutated in place rather than replaced between tests.
+ */
+const mediaQueryLists = new Map< string, MediaQueryList >();
+
+function mockViewport( matches: boolean ) {
+	( window.matchMedia as jest.Mock ).mockImplementation( ( query: string ) => {
+		let mediaQueryList = mediaQueryLists.get( query );
+		if ( ! mediaQueryList ) {
+			mediaQueryList = {
+				matches,
+				media: query,
+				onchange: null,
+				addListener: jest.fn(),
+				removeListener: jest.fn(),
+				addEventListener: jest.fn(),
+				removeEventListener: jest.fn(),
+				dispatchEvent: jest.fn(),
+			} as unknown as MediaQueryList;
+			mediaQueryLists.set( query, mediaQueryList );
+		}
+		return mediaQueryList;
+	} );
+
+	for ( const mediaQueryList of mediaQueryLists.values() ) {
+		( mediaQueryList as { matches: boolean } ).matches = matches;
+	}
+}
+
+const useLargeViewport = () => mockViewport( true );
+
+/**
+ * SummaryButton stays focusable while disabled, so it marks the state with
+ * aria-disabled rather than the disabled attribute.
+ */
+async function findEnabledButton( name: RegExp ) {
+	const button = await screen.findByRole( 'button', { name } );
+	await waitFor( () => expect( button ).not.toHaveAttribute( 'aria-disabled', 'true' ) );
+	return button;
+}
+
+describe( '<TitanControlPanelModal>', () => {
+	let openedWindow: { location: { href: string }; close: jest.Mock };
+
+	beforeEach( () => {
+		mockViewport( false );
+		openedWindow = { location: { href: '' }, close: jest.fn() };
+		jest.spyOn( window, 'open' ).mockReturnValue( openedWindow as unknown as Window );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	test( 'lists every control panel destination from the classic Manage all mailboxes page', async () => {
+		useLargeViewport();
+		mockDomain( ORDER_ID );
+		render( <TitanControlPanelModal domainName={ DOMAIN } /> );
+
+		await findEnabledButton( /Open control panel/ );
+
+		for ( const name of [
+			/Configure desktop app/,
+			/Get mobile app/,
+			/Import email data/,
+			/Configure catch-all email/,
+			/Set up internal forwarding/,
+		] ) {
+			expect( screen.getByRole( 'button', { name } ) ).toBeVisible();
+		}
+	} );
+
+	test( 'opens the control panel in a new tab using a single-use auto-login URL', async () => {
+		useLargeViewport();
+		mockDomain( ORDER_ID );
+		const scope = mockAutoLoginUrl();
+		const user = userEvent.setup();
+		render( <TitanControlPanelModal domainName={ DOMAIN } /> );
+
+		await user.click( await findEnabledButton( /Open control panel/ ) );
+
+		await waitFor( () => expect( scope.isDone() ).toBe( true ) );
+		// The tab is opened synchronously on click so pop-up blockers do not reject it.
+		expect( window.open ).toHaveBeenCalledWith( '', '_blank' );
+		await waitFor( () => expect( openedWindow.location.href ).toBe( AUTO_LOGIN_URL ) );
+	} );
+
+	test( 'deep-links to the requested control panel section', async () => {
+		useLargeViewport();
+		mockDomain( ORDER_ID );
+		const scope = mockAutoLoginUrl( 'configure_catch_all_email' );
+		const user = userEvent.setup();
+		render( <TitanControlPanelModal domainName={ DOMAIN } /> );
+
+		await user.click( await findEnabledButton( /Configure catch-all email/ ) );
+
+		await waitFor( () => expect( scope.isDone() ).toBe( true ) );
+	} );
+
+	test( 'closes the blank tab and warns when the auto-login URL cannot be fetched', async () => {
+		useLargeViewport();
+		mockDomain( ORDER_ID );
+		nock( 'https://public-api.wordpress.com' )
+			.get( `/wpcom/v2/emails/titan/${ ORDER_ID }/control-panel-auto-login-url` )
+			.query( true )
+			.reply( 500, { message: 'Something went wrong' } );
+		const user = userEvent.setup();
+		render( <TitanControlPanelModal domainName={ DOMAIN } /> );
+
+		await user.click( await findEnabledButton( /Open control panel/ ) );
+
+		await waitFor( () => expect( openedWindow.close ).toHaveBeenCalled() );
+		expect( openedWindow.location.href ).toBe( '' );
+	} );
+
+	test( 'disables every destination when the domain has no Titan subscription', async () => {
+		useLargeViewport();
+		mockDomain( null );
+		render( <TitanControlPanelModal domainName={ DOMAIN } /> );
+
+		expect(
+			await screen.findByText(
+				'We could not find an active Professional Email subscription for this domain.'
+			)
+		).toBeVisible();
+		expect( screen.getByRole( 'button', { name: /Open control panel/ } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+	} );
+
+	test( 'blocks the desktop-only sections on small screens', async () => {
+		mockDomain( ORDER_ID );
+		render( <TitanControlPanelModal domainName={ DOMAIN } /> );
+
+		expect(
+			await screen.findByText(
+				'Please switch to a device with a larger screen to access all email management features.'
+			)
+		).toBeVisible();
+
+		// Reachable anywhere: the control panel itself and the mobile app links.
+		await findEnabledButton( /Open control panel/ );
+		expect( screen.getByRole( 'button', { name: /Get mobile app/ } ) ).not.toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+
+		expect( screen.getByRole( 'button', { name: /Configure catch-all email/ } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+	} );
+} );

--- a/client/dashboard/emails/components/titan-control-panel-modal.tsx
+++ b/client/dashboard/emails/components/titan-control-panel-modal.tsx
@@ -3,12 +3,11 @@ import { domainQuery, titanControlPanelAutoLoginUrlMutation } from '@automattic/
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, Icon, Spinner } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { cloudUpload, desktop, login, mobile, settings, tool } from '@wordpress/icons';
-import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import Notice from '../../components/notice';
 import SummaryButton from '../../components/summary-button';
 import { SummaryButtonList } from '../../components/summary-button-list';
@@ -46,7 +45,7 @@ function getControlPanelLinks(): ControlPanelLink[] {
 			context: TitanControlPanelContext.GET_MOBILE_APP,
 			icon: mobile,
 			title: __( 'Get mobile app' ),
-			description: __( "Download Titan's Android and iOS apps to access your emails on the go" ),
+			description: __( 'Download Titan’s Android and iOS apps to access your emails on the go' ),
 		},
 		{
 			context: TitanControlPanelContext.IMPORT_EMAIL_DATA,
@@ -81,11 +80,14 @@ function getControlPanelLinks(): ControlPanelLink[] {
 export default function TitanControlPanelModal( { domainName }: { domainName: string } ) {
 	const isLargeViewport = useViewportMatch( 'large' );
 	const { recordTracksEvent } = useAnalytics();
-	const { createErrorNotice } = useDispatch( noticesStore );
 	const [ pendingContext, setPendingContext ] = useState< string | null >( null );
 
 	const { data: domain, isLoading: isLoadingDomain } = useQuery( domainQuery( domainName ) );
-	const { mutateAsync: fetchAutoLoginUrl } = useMutation( titanControlPanelAutoLoginUrlMutation() );
+	const { mutateAsync: fetchAutoLoginUrl } = useMutation(
+		withSnackbar( titanControlPanelAutoLoginUrlMutation(), {
+			error: __( 'Failed to open the control panel.' ),
+		} )
+	);
 
 	const orderId = domain?.titan_mail_subscription?.order_id;
 	const hasSubscription = ! isLoadingDomain && !! orderId;
@@ -115,10 +117,6 @@ export default function TitanControlPanelModal( { domainName }: { domainName: st
 			}
 		} catch {
 			controlPanelWindow?.close();
-			createErrorNotice(
-				__( 'We could not open the control panel. Please try again in a few minutes.' ),
-				{ type: 'snackbar' }
-			);
 		} finally {
 			setPendingContext( null );
 		}

--- a/client/dashboard/emails/components/titan-control-panel-modal.tsx
+++ b/client/dashboard/emails/components/titan-control-panel-modal.tsx
@@ -1,0 +1,175 @@
+import { TitanControlPanelContext } from '@automattic/api-core';
+import { domainQuery, titanControlPanelAutoLoginUrlMutation } from '@automattic/api-queries';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { __experimentalVStack as VStack, Icon, Spinner } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
+import { useDispatch } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { cloudUpload, desktop, login, mobile, settings, tool } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
+import { useAnalytics } from '../../app/analytics';
+import Notice from '../../components/notice';
+import SummaryButton from '../../components/summary-button';
+import { SummaryButtonList } from '../../components/summary-button-list';
+import { Text } from '../../components/text';
+
+const GENERIC_CONTEXT_KEY = 'control_panel';
+
+interface ControlPanelLink {
+	context?: TitanControlPanelContext;
+	icon: React.ComponentProps< typeof Icon >[ 'icon' ];
+	title: string;
+	description: string;
+	/**
+	 * Titan's control panel has no usable layout on small screens, so the sections
+	 * that require real interaction are only offered on larger viewports.
+	 */
+	requiresLargeViewport?: boolean;
+}
+
+function getControlPanelLinks(): ControlPanelLink[] {
+	return [
+		{
+			icon: tool,
+			title: __( 'Open control panel' ),
+			description: __( 'Reset passwords, configure DKIM, and access every Titan setting' ),
+		},
+		{
+			context: TitanControlPanelContext.CONFIGURE_DESKTOP_APP,
+			icon: desktop,
+			title: __( 'Configure desktop app' ),
+			description: __( 'View settings required to configure third-party email apps' ),
+			requiresLargeViewport: true,
+		},
+		{
+			context: TitanControlPanelContext.GET_MOBILE_APP,
+			icon: mobile,
+			title: __( 'Get mobile app' ),
+			description: __( "Download Titan's Android and iOS apps to access your emails on the go" ),
+		},
+		{
+			context: TitanControlPanelContext.IMPORT_EMAIL_DATA,
+			icon: cloudUpload,
+			title: __( 'Import email data' ),
+			description: __( 'Migrate existing emails from a remote server via IMAP' ),
+			requiresLargeViewport: true,
+		},
+		{
+			context: TitanControlPanelContext.CONFIGURE_CATCH_ALL_EMAIL,
+			icon: settings,
+			title: __( 'Configure catch-all email' ),
+			description: __( 'Route all undelivered emails to your domain to a specific mailbox' ),
+			requiresLargeViewport: true,
+		},
+		{
+			context: TitanControlPanelContext.CONFIGURE_INTERNAL_FORWARDING,
+			icon: login,
+			title: __( 'Set up internal forwarding' ),
+			description: __( 'Create email aliases that forward messages to one or several mailboxes' ),
+			requiresLargeViewport: true,
+		},
+	];
+}
+
+/**
+ * Replicates the classic Calypso "Manage all mailboxes" page
+ * (/email/:domain/titan/manage-mailboxes/:site) for the dashboard: a list of
+ * deep links into Titan's control panel, each resolved through a single-use
+ * auto-login URL so the user does not need an admin mailbox to sign in.
+ */
+export default function TitanControlPanelModal( { domainName }: { domainName: string } ) {
+	const isLargeViewport = useViewportMatch( 'large' );
+	const { recordTracksEvent } = useAnalytics();
+	const { createErrorNotice } = useDispatch( noticesStore );
+	const [ pendingContext, setPendingContext ] = useState< string | null >( null );
+
+	const { data: domain, isLoading: isLoadingDomain } = useQuery( domainQuery( domainName ) );
+	const { mutateAsync: fetchAutoLoginUrl } = useMutation( titanControlPanelAutoLoginUrlMutation() );
+
+	const orderId = domain?.titan_mail_subscription?.order_id;
+	const hasSubscription = ! isLoadingDomain && !! orderId;
+	const isPending = pendingContext !== null;
+
+	const handleClick = async ( link: ControlPanelLink ) => {
+		if ( ! orderId || isPending ) {
+			return;
+		}
+
+		const contextKey = link.context ?? GENERIC_CONTEXT_KEY;
+		recordTracksEvent( 'calypso_dashboard_emails_titan_control_panel_link_click', {
+			context: contextKey,
+		} );
+
+		// Opened up front so the tab stays attributable to this click; browsers
+		// block window.open() once the auto-login request has resolved.
+		const controlPanelWindow = window.open( '', '_blank' );
+		setPendingContext( contextKey );
+
+		try {
+			const url = await fetchAutoLoginUrl( { orderId, context: link.context } );
+			if ( controlPanelWindow ) {
+				controlPanelWindow.location.href = url;
+			} else {
+				window.location.href = url;
+			}
+		} catch {
+			controlPanelWindow?.close();
+			createErrorNotice(
+				__( 'We could not open the control panel. Please try again in a few minutes.' ),
+				{ type: 'snackbar' }
+			);
+		} finally {
+			setPendingContext( null );
+		}
+	};
+
+	return (
+		<VStack spacing={ 4 }>
+			<Text>
+				{ sprintf(
+					/* translators: %s is a domain name, e.g. example.com */
+					__(
+						'Manage every mailbox on %s from Titan’s control panel. Each option opens in a new tab.'
+					),
+					domainName
+				) }
+			</Text>
+
+			{ ! isLoadingDomain && ! orderId && (
+				<Notice variant="error">
+					{ __( 'We could not find an active Professional Email subscription for this domain.' ) }
+				</Notice>
+			) }
+
+			{ ! isLargeViewport && (
+				<Notice variant="warning">
+					{ __(
+						'Please switch to a device with a larger screen to access all email management features.'
+					) }
+				</Notice>
+			) }
+
+			<SummaryButtonList density="medium-low">
+				{ getControlPanelLinks().map( ( link ) => {
+					const contextKey = link.context ?? GENERIC_CONTEXT_KEY;
+					const isDisabled =
+						! hasSubscription || isPending || ( link.requiresLargeViewport && ! isLargeViewport );
+
+					return (
+						<SummaryButton
+							key={ contextKey }
+							title={ link.title }
+							description={ link.description }
+							decoration={
+								pendingContext === contextKey ? <Spinner /> : <Icon icon={ link.icon } />
+							}
+							disabled={ isDisabled }
+							onClick={ () => handleClick( link ) }
+						/>
+					);
+				} ) }
+			</SummaryButtonList>
+		</VStack>
+	);
+}

--- a/client/dashboard/emails/dataviews/actions/index.ts
+++ b/client/dashboard/emails/dataviews/actions/index.ts
@@ -3,6 +3,7 @@ import { useDeleteTitanMailboxAction } from './delete-titan-mailbox';
 import { useEditEmailForwardAction } from './edit-email-forward';
 import { useFinishSetupAction } from './finish-setup';
 import { useManageGoogleWorkspaceAction } from './manage-google-workspace';
+import { useManageTitanMailboxesAction } from './manage-titan-mailboxes';
 import { usePaymentDetailsAction } from './payment-details';
 import { useResendVerificationAction } from './resend-verification';
 import { useViewMailboxAction } from './view-mailbox';
@@ -14,6 +15,7 @@ export function useActions(): Action< Email >[] {
 		useViewMailboxAction(),
 		useFinishSetupAction(),
 		useManageGoogleWorkspaceAction(),
+		useManageTitanMailboxesAction(),
 		usePaymentDetailsAction(),
 		useResendVerificationAction(),
 		useEditEmailForwardAction(),

--- a/client/dashboard/emails/dataviews/actions/manage-titan-mailboxes.tsx
+++ b/client/dashboard/emails/dataviews/actions/manage-titan-mailboxes.tsx
@@ -1,0 +1,29 @@
+import { __ } from '@wordpress/i18n';
+import { useEffect } from 'react';
+import { useAnalytics } from '../../../app/analytics';
+import TitanControlPanelModal from '../../components/titan-control-panel-modal';
+import type { Email } from '../../types';
+import type { Action } from '@wordpress/dataviews';
+
+const ACTION_ID = 'manage-titan-mailboxes';
+
+export const useManageTitanMailboxesAction = (): Action< Email > => {
+	return {
+		id: ACTION_ID,
+		label: __( 'Manage all mailboxes' ),
+		modalHeader: __( 'Manage all mailboxes' ),
+		// The modal lists the individual control panel destinations.
+		callback: () => {},
+		RenderModal: ( { items } ) => {
+			const { recordTracksEvent } = useAnalytics();
+
+			useEffect( () => {
+				recordTracksEvent( 'calypso_dashboard_emails_action_click', { action_id: ACTION_ID } );
+			}, [ recordTracksEvent ] );
+
+			return <TitanControlPanelModal domainName={ items[ 0 ].domainName } />;
+		},
+		isEligible: ( item: Email ) =>
+			item.type === 'mailbox' && item.provider === 'titan' && item.status !== 'no_subscription',
+	};
+};

--- a/packages/api-core/src/emails/fetchers.ts
+++ b/packages/api-core/src/emails/fetchers.ts
@@ -1,5 +1,5 @@
 import { wpcom } from '../wpcom-fetcher';
-import type { EmailAccount, Mailbox } from './types';
+import type { EmailAccount, Mailbox, TitanControlPanelContext } from './types';
 
 export function fetchMailboxes( siteId: number ): Promise< Mailbox[] > {
 	return wpcom.req
@@ -20,4 +20,24 @@ export function fetchDomainMailboxAccounts(
 			apiNamespace: 'wpcom/v2',
 		} )
 		.then( ( data: { accounts: EmailAccount[] } ) => data.accounts );
+}
+
+/**
+ * Returns a single-use URL that logs the current user into Titan's control panel.
+ * `orderId` is the Titan subscription's order id (`domain.titan_mail_subscription.order_id`),
+ * and `context` deep-links to a specific section of the control panel.
+ */
+export function fetchTitanControlPanelAutoLoginUrl(
+	orderId: number,
+	context?: TitanControlPanelContext
+): Promise< string > {
+	return wpcom.req
+		.get(
+			{
+				path: `/emails/titan/${ encodeURIComponent( orderId ) }/control-panel-auto-login-url`,
+				apiNamespace: 'wpcom/v2',
+			},
+			context ? { context } : {}
+		)
+		.then( ( data: { auto_login_url: string } ) => data.auto_login_url );
 }

--- a/packages/api-core/src/emails/types.ts
+++ b/packages/api-core/src/emails/types.ts
@@ -4,6 +4,21 @@ export enum EmailProvider {
 	Titan = 'titan',
 }
 
+/**
+ * Sections of Titan's control panel that the auto-login URL can deep-link to.
+ */
+export const TitanControlPanelContext = {
+	CONFIGURE_CATCH_ALL_EMAIL: 'configure_catch_all_email',
+	CONFIGURE_DESKTOP_APP: 'configure_desktop_app',
+	CONFIGURE_INTERNAL_FORWARDING: 'configure_internal_forwarding',
+	CREATE_EMAIL: 'create_email_account',
+	GET_MOBILE_APP: 'get_mobile_app',
+	IMPORT_EMAIL_DATA: 'import_email_data',
+} as const;
+
+export type TitanControlPanelContext =
+	( typeof TitanControlPanelContext )[ keyof typeof TitanControlPanelContext ];
+
 export interface Mailbox {
 	account_type: EmailProvider;
 	domain: string;

--- a/packages/api-queries/src/emails.ts
+++ b/packages/api-queries/src/emails.ts
@@ -3,10 +3,12 @@ import {
 	deleteTitanMailbox,
 	fetchDomainMailboxAccounts,
 	fetchMailboxes,
+	fetchTitanControlPanelAutoLoginUrl,
 } from '@automattic/api-core';
 import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { userMailboxesQuery } from './me-mailboxes';
 import { queryClient } from './query-client';
+import type { TitanControlPanelContext } from '@automattic/api-core';
 
 export const mailboxesQuery = ( siteId: number ) =>
 	queryOptions( {
@@ -43,6 +45,18 @@ export const createTitanMailboxMutation = () => {
 		onSuccess: () => {
 			queryClient.resetQueries( userMailboxesQuery() );
 		},
+	} );
+};
+
+/**
+ * Modelled as a mutation rather than a query because the returned URL carries a
+ * short-lived, single-use login token that must never be served from cache.
+ */
+export const titanControlPanelAutoLoginUrlMutation = () => {
+	return mutationOptions( {
+		meta: { statId: 'titan-cpanel-url-fetch' },
+		mutationFn: ( vars: { orderId: number; context?: TitanControlPanelContext } ) =>
+			fetchTitanControlPanelAutoLoginUrl( vars.orderId, vars.context ),
 	} );
 };
 

--- a/packages/components/src/summary-button/style.scss
+++ b/packages/components/src/summary-button/style.scss
@@ -8,6 +8,9 @@
 	height: auto;
 	transition: none;
 	width: 100%;
+	// Buttons centre their text by default, which centres each wrapped line of a
+	// multi-line title or description even though the flex layout is start-aligned.
+	text-align: start;
 
 	&:hover:not(:disabled, [aria-disabled="true"]) {
 		background: color-mix(in srgb, #fff 98%, var(--wp-admin-theme-color, #3858e9));


### PR DESCRIPTION
## Proposed Changes

* Adds a **"Manage all mailboxes"** row action on Titan mailboxes in `/emails`, replicating the classic Calypso page at `/email/:domain/titan/manage-mailboxes/:site`. It opens a modal with the same five deep links into Titan's control panel, plus a generic **"Open control panel"** entry.
* Each link resolves through a single-use auto-login URL, so the user does not need an admin mailbox to sign in:
  * `fetchTitanControlPanelAutoLoginUrl()` in `packages/api-core/src/emails/fetchers.ts` -> `GET /wpcom/v2/emails/titan/:orderId/control-panel-auto-login-url?context=...`
  * `titanControlPanelAutoLoginUrlMutation()` in `packages/api-queries/src/emails.ts`. Modelled as a **mutation rather than a query** because the returned URL carries a short-lived, single-use login token that must never be served from cache.
  * `TitanControlPanelContext` in `packages/api-core/src/emails/types.ts`, mirroring the classic `client/lib/titan/constants.js`.
* Carries over the classic page's behaviour: the sections that need real interaction are gated to large viewports, with the same "switch to a device with a larger screen" notice below that.
* Drive-by fix in `packages/components/src/summary-button/style.scss`: `SummaryButton` renders a `<button>` with `display: block` and never resets the UA stylesheet's `text-align: center`. The inner flex column is `flex-start`-aligned, so a single-line title shrinks to fit and looks correct, but a description long enough to wrap centres each line. Adds `text-align: start` (not `left`, so RTL is unaffected). See screenshots below.

## Why are these changes being made?

For sites with Professional Email, the classic **"Manage all mailboxes"** section is now unreachable: with the MSD experiment enabled, Upgrades > Emails redirects to `/emails`, which had no equivalent.

That page was the only self-serve route into Titan's control panel. The dashboard links to `wp.titan.email` (the inbox) via "View mailbox", but never to `manage.titan.email`. Because we do not set mailboxes as "admins" on creation, logging into the control panel directly is also impossible by default.

The practical effect is that anyone who has not already promoted one of their mailboxes to admin has no self-serve way to reset mailbox passwords (outside Titan's own "forgot password" flow), configure DKIM manually, set up forwards or catch-alls, or delete a mailbox while keeping an active licence.

This is not caused by the Titan tier/SKU work; it is a gap that the MSD rollout exposes. Given the 100% rollout timeline, restoring the path is time-sensitive.

### Design notes

* **Row action rather than a page or a header button.** The action is domain-scoped, and the row already supplies the domain. A header button with a domain picker (like `chooseDomainRoute`) would add a step for the common single-domain case, and the header is shared by Titan, Google Workspace and forwarding rows, so a Titan-only button would need conditional rendering.
* **The generic "Open control panel" entry is new**, not in the classic page. The classic five links are all `context`-scoped deep links; password resets and DKIM live on the control panel home and are not reachable through any of them, so the five alone would not close the gap.
* **The Titan order id comes from `domainQuery(domain).titan_mail_subscription.order_id`**, matching classic's `getTitanMailOrderId()`. `EmailAccount.account_id` from `/me/mailboxes` is already loaded on the page and would save a request, but I could not confirm it is the same identifier this endpoint expects. Happy to switch if someone can confirm it against the backend.

## Testing Instructions

1. Have a site with a Professional Email (Titan) subscription, and enable the MSD experiment.
2. Go to `/emails` (`my.wordpress.com/emails`).
3. Open the row menu ("...") on a Titan mailbox. A **"Manage all mailboxes"** action should appear. It should not appear on Google Workspace mailboxes or email forwarders.
4. Click it. The modal should list six destinations. On a viewport narrower than 960px, the four desktop-only entries should be disabled and a warning notice should appear.
5. Click **"Open control panel"**. A new tab should open and land you in Titan's control panel at `manage.titan.email`, already signed in, without needing an admin mailbox.
6. Click **"Configure catch-all email"** and confirm the new tab deep-links to that section rather than the control panel home. Same for the other four contexts.
7. Confirm the tab is not blocked by the browser's pop-up blocker (it is opened synchronously on click, before the async request).

For the `SummaryButton` change, check any surface using `density="low"` or `"medium-low"` with a description long enough to wrap, and confirm the description is start-aligned rather than centred.

Automated coverage: `client/dashboard/emails/components/test/titan-control-panel-modal.test.tsx` covers the link list, the auto-login open, context deep-linking, the request-failure path, the no-subscription state, and small-screen gating.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
