### PR TITLE
Survicate: pass user_id as a visitor trait

### DIFF
--- a/client/dashboard/app/survicate/index.tsx
+++ b/client/dashboard/app/survicate/index.tsx
@@ -50,6 +50,7 @@ export function useSurvicate() {
 				}
 
 				const cleanupTraits = setSurvicateVisitorTraits( {
+					user_id: String( user.ID ),
 					email: user.email,
 					account_age_in_days: getAccountAgeInDays( user.date ),
 				} );

--- a/client/dashboard/app/survicate/test/index.test.tsx
+++ b/client/dashboard/app/survicate/test/index.test.tsx
@@ -97,6 +97,7 @@ describe( 'useSurvicate', () => {
 
 		expect( mockedLoadScript ).toHaveBeenCalledWith( SURVICATE_WORKSPACE_ID );
 		expect( mockedSetTraits ).toHaveBeenCalledWith( {
+			user_id: '1',
 			email: 'test@example.com',
 			account_age_in_days: 42,
 		} );

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -501,9 +501,9 @@ const onboarding: FlowV2< typeof initialize > = {
 		 */
 		useEffect( () => {
 			if ( isLoggedIn && user?.email && user?.date ) {
-				addSurvicate( { email: user.email, registrationDate: user.date } );
+				addSurvicate( { email: user.email, registrationDate: user.date, userId: user.ID } );
 			}
-		}, [ isLoggedIn, currentStepSlug, user?.email, user?.date ] );
+		}, [ isLoggedIn, currentStepSlug, user?.email, user?.date, user?.ID ] );
 
 		// Preload the visual split experiment
 		useEffect( () => {

--- a/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
@@ -138,6 +138,7 @@ describe( 'Onboarding Flow', () => {
 				expect( addSurvicate ).toHaveBeenCalledWith( {
 					email: 'test@example.com',
 					registrationDate: '2024-01-15T00:00:00+00:00',
+					userId: 123,
 				} );
 
 				rerender(

--- a/client/lib/analytics/survicate.js
+++ b/client/lib/analytics/survicate.js
@@ -14,7 +14,7 @@ export function mayWeLoadSurvicateScript() {
 	return config( 'survicate_enabled' );
 }
 
-export function addSurvicate( { email, registrationDate } ) {
+export function addSurvicate( { email, registrationDate, userId } ) {
 	if (
 		! shouldLoadSurvicate( {
 			locale: getLocaleSlug(),
@@ -30,6 +30,7 @@ export function addSurvicate( { email, registrationDate } ) {
 
 	const setTraits = () => {
 		setSurvicateVisitorTraits( {
+			...( userId ? { user_id: String( userId ) } : {} ),
 			email,
 			account_age_in_days: getAccountAgeInDays( registrationDate ),
 		} );

--- a/client/lib/analytics/test/survicate.js
+++ b/client/lib/analytics/test/survicate.js
@@ -50,6 +50,7 @@ const flushPromises = () => new Promise( ( resolve ) => setTimeout( resolve, 0 )
 const mockUserData = {
 	email: 'test@example.com',
 	registrationDate: '2024-01-15T00:00:00+00:00',
+	userId: 123,
 };
 
 describe( 'survicate', () => {
@@ -145,11 +146,25 @@ describe( 'survicate', () => {
 			expect( loadSurvicateScript ).toHaveBeenCalledWith( 'test-workspace-id' );
 		} );
 
-		test( 'should set visitor traits with email and account_age_in_days when script loads', async () => {
+		test( 'should set visitor traits with user_id, email and account_age_in_days when script loads', async () => {
 			addSurvicate( mockUserData );
 			await flushPromises();
 
 			expect( getAccountAgeInDays ).toHaveBeenCalledWith( mockUserData.registrationDate );
+			expect( setSurvicateVisitorTraits ).toHaveBeenCalledWith( {
+				user_id: '123',
+				email: 'test@example.com',
+				account_age_in_days: 42,
+			} );
+		} );
+
+		test( 'should omit user_id when no user ID is provided', async () => {
+			addSurvicate( {
+				email: mockUserData.email,
+				registrationDate: mockUserData.registrationDate,
+			} );
+			await flushPromises();
+
 			expect( setSurvicateVisitorTraits ).toHaveBeenCalledWith( {
 				email: 'test@example.com',
 				account_age_in_days: 42,
@@ -186,6 +201,7 @@ describe( 'survicate', () => {
 			// Should have called setSurvicateVisitorTraits without loading script again
 			expect( loadSurvicateScript ).not.toHaveBeenCalled();
 			expect( setSurvicateVisitorTraits ).toHaveBeenCalledWith( {
+				user_id: '123',
 				email: 'test@example.com',
 				account_age_in_days: 42,
 			} );

--- a/client/state/analytics/middleware.js
+++ b/client/state/analytics/middleware.js
@@ -37,7 +37,7 @@ const loadTrackingTool = ( trackingTool, store ) => {
 	if ( trackingTool === 'Survicate' ) {
 		const user = getCurrentUser( store.getState() );
 		if ( user?.email && user?.date ) {
-			addSurvicate( { email: user.email, registrationDate: user.date } );
+			addSurvicate( { email: user.email, registrationDate: user.date, userId: user.ID } );
 		}
 	}
 };

--- a/packages/survicate/AGENTS.md
+++ b/packages/survicate/AGENTS.md
@@ -22,7 +22,7 @@ visible package-wide. The methods we use:
 
 - `invokeEvent(name)` — trigger an event-based survey.
 - `closeSurvey()` — dismiss any currently displayed survey.
-- `setVisitorTraits(traits)` — attach traits (email, account age) used for targeting.
+- `setVisitorTraits(traits)` — attach traits (user ID, email, account age) used for targeting.
 - `addEventListener(event, handler)` / `removeEventListener` — subscribe to SDK events
   such as `survey_displayed`.
 - `destroyVisitor()` — reset the visitor.
@@ -76,8 +76,9 @@ deferred-until-`SurvicateReady` path.
 Visitor traits are published from **two** independent `setSurvicateVisitorTraits`
 call sites, and this is intentional — don't consolidate them into one:
 
-- `useSurvicate` pushes **identity** traits (`email`, `account_age_in_days`) once
-  from the authenticated user, right after the script loads, next to the
+- `useSurvicate` pushes **identity** traits (`user_id`, `email`,
+  `account_age_in_days`) once from the authenticated user, right after the script
+  loads, next to the
   `calypso_survicate_user_not_available_error` tracks event that fires when the
   email is missing at load time.
 - `useSurvicateVisitTraits` pushes **behavioral** traits (`msd_visits_<slug>`)


### PR DESCRIPTION
Fixes p1785266176528599/1785262921.571369-slack-C08JZTRS6NA

## Proposed Changes

* Send Survicate's reserved `user_id` visitor trait alongside `email` and `account_age_in_days`, at both identity call sites:
  * `useSurvicate()` in the Multi-site Dashboard — `user_id: String( user.ID )`.
  * `addSurvicate()` in classic Calypso — now takes a `userId` argument and includes `user_id` only when one is provided (so the trait is never set to `undefined`). Its two callers, the analytics middleware and the onboarding Stepper flow, pass the current user's ID.
* Updated the affected unit tests and added a case covering the omit-when-absent path.
* Refreshed the trait lists in `packages/survicate/AGENTS.md`.

The value is stringified because `user_id` is Survicate's reserved identity trait rather than an arbitrary numeric attribute.

## Why are these changes being made?

Survicate rejects targeting rules that reference the visitor's user ID with:

> This targeting requires user_id to be passed to Survicate. Without it, the survey won't appear.

We were only setting `email` and `account_age_in_days`, so any survey configured against `user_id` would silently never show. `_sva.setVisitorTraits` merges traits across calls, so the existing behavioral push (`msd_visits_*`) is unaffected and continues to upsert on top of the identity traits.

## Testing Instructions

1. Ensure the `survicate_enabled` config flag is on for your environment.
2. Load the Multi-site Dashboard while logged in and, in the browser console, confirm the trait is sent: `window._sva` is defined and the `setVisitorTraits` payload includes `user_id` (the `@automattic/survicate` debug logger prints `Visitor traits set: …` under `DEBUG=calypso:survicate`).
3. Repeat on a classic Calypso page (the analytics middleware path) and in `/setup/onboarding` while logged in.
4. In the Survicate dashboard, a survey targeted on `user_id` should now be eligible to appear.
5. Automated coverage:
   ```
   yarn test-client client/lib/analytics/test/survicate.js client/dashboard/app/survicate/test/index.test.tsx client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
   ```

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)