### PR TITLE
Image Studio: Track quota exhaustion separately

### DIFF
--- a/packages/image-studio/src/components/index.tsx
+++ b/packages/image-studio/src/components/index.tsx
@@ -36,7 +36,11 @@ import {
 import { store as videoStudioStore } from '../stores/video-studio';
 import { ImageStudioMode, type ImageStudioProps, ToolbarOption } from '../types';
 import { defaultAgentConfigFactory } from '../utils/agent-config';
-import { trackImageStudioError, trackImageStudioPromptSent } from '../utils/tracking';
+import {
+	getImageStudioRequestErrorType,
+	trackImageStudioError,
+	trackImageStudioPromptSent,
+} from '../utils/tracking';
 import AnnotationCanvas from './annotation-canvas';
 import { AspectRatioPicker } from './aspect-ratio-picker';
 import { CanvasControls } from './canvas-controls';
@@ -172,7 +176,7 @@ function ImageStudioAgentChat( {
 				// Track the error
 				trackImageStudioError( {
 					mode,
-					errorType: mode === ImageStudioMode.Edit ? 'edit_failed' : 'generation_failed',
+					errorType: getImageStudioRequestErrorType( error, mode ),
 					attachmentId,
 				} );
 				// Re-throw to allow error to be handled by the UI

--- a/packages/image-studio/src/components/index.tsx
+++ b/packages/image-studio/src/components/index.tsx
@@ -17,6 +17,7 @@ import { useDraftCleanup } from '../hooks/use-draft-cleanup';
 import { useErrorNotice } from '../hooks/use-error-notice';
 import { useImageLoaded } from '../hooks/use-image-loaded';
 import { useImageStudioAgentSync } from '../hooks/use-image-studio-agent-sync';
+import { useImageStudioErrorTracking } from '../hooks/use-image-studio-error-tracking';
 import { useImageStudioFeedback } from '../hooks/use-image-studio-feedback';
 import { useImageStudioMessageDisplay } from '../hooks/use-image-studio-message-display';
 import { useImageStudioSuggestions } from '../hooks/use-image-studio-suggestions';
@@ -36,11 +37,7 @@ import {
 import { store as videoStudioStore } from '../stores/video-studio';
 import { ImageStudioMode, type ImageStudioProps, ToolbarOption } from '../types';
 import { defaultAgentConfigFactory } from '../utils/agent-config';
-import {
-	getImageStudioRequestErrorType,
-	trackImageStudioError,
-	trackImageStudioPromptSent,
-} from '../utils/tracking';
+import { trackImageStudioError, trackImageStudioPromptSent } from '../utils/tracking';
 import AnnotationCanvas from './annotation-canvas';
 import { AspectRatioPicker } from './aspect-ratio-picker';
 import { CanvasControls } from './canvas-controls';
@@ -170,18 +167,7 @@ function ImageStudioAgentChat( {
 				messageLength: message?.length || 0,
 			} );
 
-			try {
-				await agentChatProps.onSubmit?.( message );
-			} catch ( error ) {
-				// Track the error
-				trackImageStudioError( {
-					mode,
-					errorType: getImageStudioRequestErrorType( error, mode ),
-					attachmentId,
-				} );
-				// Re-throw to allow error to be handled by the UI
-				throw error;
-			}
+			await agentChatProps.onSubmit?.( message );
 		},
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[ agentChatProps, onChatSubmit, mode ]
@@ -189,6 +175,7 @@ function ImageStudioAgentChat( {
 
 	const { error: agentError, ...agentUiProps } = agentChatProps;
 
+	useImageStudioErrorTracking( agentError, mode, attachmentId );
 	useErrorNotice( agentError, addNotice, mode );
 
 	const isProcessing = agentChatProps.isProcessing || isAnnotationSaving;

--- a/packages/image-studio/src/hooks/use-image-studio-error-tracking.test.ts
+++ b/packages/image-studio/src/hooks/use-image-studio-error-tracking.test.ts
@@ -1,0 +1,67 @@
+import { renderHook } from '@testing-library/react';
+import { ImageStudioMode } from '../types';
+import { trackImageStudioError } from '../utils/tracking';
+import { useImageStudioErrorTracking } from './use-image-studio-error-tracking';
+
+jest.mock( '../utils/tracking', () => ( {
+	...jest.requireActual( '../utils/tracking' ),
+	trackImageStudioError: jest.fn(),
+} ) );
+
+describe( 'useImageStudioErrorTracking', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'tracks a quota error from the agent error state', () => {
+		renderHook( () =>
+			useImageStudioErrorTracking(
+				'Streaming error: You have reached your free usage limit. Please upgrade to a paid plan to continue. https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge',
+				ImageStudioMode.Generate
+			)
+		);
+
+		expect( trackImageStudioError ).toHaveBeenCalledWith( {
+			mode: ImageStudioMode.Generate,
+			errorType: 'quota_exceeded',
+			attachmentId: undefined,
+		} );
+	} );
+
+	it( 'does not track the same rendered error more than once', () => {
+		const { rerender } = renderHook(
+			( { error } ) => useImageStudioErrorTracking( error, ImageStudioMode.Generate ),
+			{
+				initialProps: { error: 'Provider failed' },
+			}
+		);
+
+		rerender( { error: 'Provider failed' } );
+
+		expect( trackImageStudioError ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'tracks edit errors with the attachment ID', () => {
+		renderHook( () => useImageStudioErrorTracking( 'Provider failed', ImageStudioMode.Edit, 42 ) );
+
+		expect( trackImageStudioError ).toHaveBeenCalledWith( {
+			mode: ImageStudioMode.Edit,
+			errorType: 'edit_failed',
+			attachmentId: 42,
+		} );
+	} );
+
+	it( 'tracks the same error again after a new request clears it', () => {
+		const { rerender } = renderHook(
+			( { error } ) => useImageStudioErrorTracking( error, ImageStudioMode.Generate ),
+			{
+				initialProps: { error: 'Provider failed' as string | null },
+			}
+		);
+
+		rerender( { error: null } );
+		rerender( { error: 'Provider failed' } );
+
+		expect( trackImageStudioError ).toHaveBeenCalledTimes( 2 );
+	} );
+} );

--- a/packages/image-studio/src/hooks/use-image-studio-error-tracking.ts
+++ b/packages/image-studio/src/hooks/use-image-studio-error-tracking.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from '@wordpress/element';
+import { ImageStudioMode } from '../types';
+import { getImageStudioRequestErrorType, trackImageStudioError } from '../utils/tracking';
+
+export function useImageStudioErrorTracking(
+	error: string | null,
+	mode: ImageStudioMode,
+	attachmentId?: number
+): void {
+	const lastTrackedError = useRef< string | null >( null );
+
+	useEffect( () => {
+		if ( ! error ) {
+			// useAgentChat clears errors when a new request starts, including retries of the same request.
+			lastTrackedError.current = null;
+			return;
+		}
+
+		if ( lastTrackedError.current === error ) {
+			return;
+		}
+
+		lastTrackedError.current = error;
+		trackImageStudioError( {
+			mode,
+			errorType: getImageStudioRequestErrorType( error, mode ),
+			attachmentId,
+		} );
+	}, [ error, mode, attachmentId ] );
+}

--- a/packages/image-studio/src/utils/tracking.test.ts
+++ b/packages/image-studio/src/utils/tracking.test.ts
@@ -6,7 +6,9 @@
 import { recordTracksEvent as recordTracksEventBase } from '@automattic/calypso-analytics';
 import { select } from '@wordpress/data';
 import { ImageStudioEntryPoint } from '../store';
+import { ImageStudioMode } from '../types';
 import {
+	getImageStudioRequestErrorType,
 	trackImageStudioClosed,
 	trackImageStudioOpened,
 	trackImageStudioReelShareClicked,
@@ -31,6 +33,27 @@ jest.mock( '../utils/session', () => ( {
 
 const recordTracksEventMock = recordTracksEventBase as jest.Mock;
 const selectMock = select as jest.Mock;
+
+describe( 'getImageStudioRequestErrorType', () => {
+	it( 'identifies the streamed free-credit exhaustion error as quota exceeded', () => {
+		const error = new Error(
+			'Streaming error: Congratulations on exploring Image Studio and reaching the free requests limit! Upgrade now to keep using it. https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge'
+		);
+
+		expect( getImageStudioRequestErrorType( error, ImageStudioMode.Generate ) ).toBe(
+			'quota_exceeded'
+		);
+	} );
+
+	it.each( [
+		[ ImageStudioMode.Generate, 'generation_failed' ],
+		[ ImageStudioMode.Edit, 'edit_failed' ],
+	] as const )( 'preserves the generic %s failure type for other errors', ( mode, errorType ) => {
+		expect( getImageStudioRequestErrorType( new Error( 'Provider failed' ), mode ) ).toBe(
+			errorType
+		);
+	} );
+} );
 
 describe( 'trackImageStudioOpened', () => {
 	beforeEach( () => {

--- a/packages/image-studio/src/utils/tracking.ts
+++ b/packages/image-studio/src/utils/tracking.ts
@@ -8,8 +8,9 @@
 import { recordTracksEvent as recordTracksEventBase } from '@automattic/calypso-analytics';
 import { select } from '@wordpress/data';
 import { store as imageStudioStore, type ImageStudioEntryPoint } from '../store';
+import { ImageStudioMode, type MetadataField } from '../types';
 import { getSessionId } from '../utils/session';
-import type { ImageStudioMode, MetadataField } from '../types';
+import { parseErrorUrl } from './parse-error-url';
 
 const TRACKS_PREFIX = 'jetpack_big_sky';
 const SITE_TYPES = [ 'simple', 'atomic', 'jetpack' ] as const;
@@ -195,18 +196,21 @@ interface TrackImageStudioImageGeneratedOptions {
 	isAnnotated: boolean;
 }
 
+type ImageStudioErrorType =
+	| 'generation_failed'
+	| 'edit_failed'
+	| 'quota_exceeded'
+	| 'ability_failed'
+	| 'preparation_failed'
+	| 'draft_cleanup_failed'
+	| 'draft_cleanup_permission_denied'
+	| 'delete_permanently_failed'
+	| 'save_metadata_failed'
+	| 'other';
+
 interface TrackImageStudioErrorOptions {
 	mode: ImageStudioMode;
-	errorType:
-		| 'generation_failed'
-		| 'edit_failed'
-		| 'ability_failed'
-		| 'preparation_failed'
-		| 'draft_cleanup_failed'
-		| 'draft_cleanup_permission_denied'
-		| 'delete_permanently_failed'
-		| 'save_metadata_failed'
-		| 'other';
+	errorType: ImageStudioErrorType;
 	attachmentId?: number;
 }
 
@@ -219,6 +223,29 @@ interface TrackImageStudioImageFeedbackOptions {
 interface TrackImageStudioFileNavigatedOptions {
 	attachmentId: number;
 	direction: 'previous' | 'next';
+}
+
+/**
+ * Classifies request errors for Image Studio error tracking.
+ * @param error - The request error
+ * @param mode  - The active Image Studio mode
+ * @returns The corresponding tracking error type
+ */
+export function getImageStudioRequestErrorType(
+	error: unknown,
+	mode: ImageStudioMode
+): ImageStudioErrorType {
+	const message =
+		error && typeof error === 'object' && 'message' in error
+			? String( error.message )
+			: String( error ?? '' );
+
+	// The agent endpoint exposes usage-quota errors to the client through an appended upgrade URL.
+	if ( parseErrorUrl( message ).isUpgradeUrl ) {
+		return 'quota_exceeded';
+	}
+
+	return mode === ImageStudioMode.Edit ? 'edit_failed' : 'generation_failed';
 }
 
 /**


### PR DESCRIPTION
## Proposed Changes

* Add a distinct `quota_exceeded` value to Image Studio error tracking.
* Classify request failures from the agent error state—the same error value that drives the existing upgrade notice—instead of the generic submit rejection.
* Preserve `generation_failed` and `edit_failed` for non-quota request failures.
* Track each rendered request error once, resetting between requests so retries are counted.
* Add regression coverage for the production quota-error shape, repeated requests, generic mode fallbacks, and edit attachment IDs.

## Why are these changes being made?

FORNO-430: Free-credit exhaustion currently emits the same error types as genuine generation and editing failures. That inflates apparent reliability failures and makes quota blocks impossible to distinguish in analytics.

The client contract exposes quota exhaustion through the upgrade URL appended to the agent error message. Live testing showed that this full error reaches the agent error state and upgrade-notice hook, while the submit promise rejects with a generic failure. Tracking now uses the same state as the notice so the quota signal is preserved.

After deployment, quota-blocked requests will move out of `generation_failed` and `edit_failed` into `quota_exceeded`. Dashboards using the former values should expect that step-change while total error volume remains stable.

## Testing Instructions

Automated checks:

* `yarn test-packages packages/image-studio/src/hooks/use-image-studio-error-tracking.test.ts packages/image-studio/src/utils/tracking.test.ts --runInBand` — 38 tests passed.
* `yarn typecheck-packages` — passed.
* `yarn eslint packages/image-studio/src/components/index.tsx packages/image-studio/src/hooks/use-image-studio-error-tracking.ts packages/image-studio/src/hooks/use-image-studio-error-tracking.test.ts` — no new errors; the component retains its existing warnings.
* `git diff --check` — passed.
* Claude review completed with no blockers after verifying `useAgentChat` clears `error` at request start and publishes every non-abort rejection to its error state.

Manual verification:

1. Create a new JN site
2. Connect Jetpack
3. Make sure you are not proxied
4. Generate a few images to exhaust free credits until you see this message `You have reached your free usage limit. Please upgrade to a paid plan to continue.` 
5. Check Live Track Events event_name=`jetpack_big_sky_image_studio_error` and filter by your username
6. Ensure you see error_type=`quota_exceeded`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the String Freeze label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have you tested the change in various languages?
- [x] For changes affecting Jetpack: Have we added the Needs Privacy Updates label if this pull request changes what data or activity we track or use?
