### PR TITLE
A4A-3101: Don't crash the purchases page on a missing expiry date

### DIFF
--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -184,6 +184,10 @@ export function creditCardExpiresBeforeSubscription( purchase: Purchase ): boole
 	if ( 'credit_card' !== purchase.payment_type ) {
 		return false;
 	}
+	// Some purchases have no expiry date, so there is nothing to compare against.
+	if ( ! purchase.expiry_date ) {
+		return false;
+	}
 	// For 100 years plans, the credit card will probably always expire before
 	// the subscription so we should only consider this true if we are close to
 	// the expiration date.

--- a/client/dashboard/utils/test/purchase.ts
+++ b/client/dashboard/utils/test/purchase.ts
@@ -14,6 +14,7 @@ import {
 	isRemoved,
 	mightStillAutoRenew,
 	isExpiredWithNoAutoRenewAttemptsLeft,
+	creditCardExpiresBeforeSubscription,
 } from '../purchase';
 import type { Purchase } from '@automattic/api-core';
 
@@ -342,5 +343,69 @@ describe( 'hasQueryableSite', () => {
 
 	test( 'is false when there is no blog_id at all', () => {
 		expect( hasQueryableSite( makePurchase( { blog_id: 0 } ) ) ).toBe( false );
+	} );
+} );
+
+describe( 'creditCardExpiresBeforeSubscription', () => {
+	test( 'is true when the card expires before the subscription', () => {
+		expect(
+			creditCardExpiresBeforeSubscription(
+				makePurchase( {
+					payment_type: 'credit_card',
+					payment_expiry_date: '2027-01-31',
+					expiry_date: '2027-06-01',
+				} )
+			)
+		).toBe( true );
+	} );
+
+	test( 'is false when the card outlives the subscription', () => {
+		expect(
+			creditCardExpiresBeforeSubscription(
+				makePurchase( {
+					payment_type: 'credit_card',
+					payment_expiry_date: '2027-06-30',
+					expiry_date: '2027-01-01',
+				} )
+			)
+		).toBe( false );
+	} );
+
+	test( 'falls back to payment_expiry when payment_expiry_date is absent', () => {
+		expect(
+			creditCardExpiresBeforeSubscription(
+				makePurchase( {
+					payment_type: 'credit_card',
+					payment_expiry: '01/27',
+					expiry_date: '2027-06-01',
+				} )
+			)
+		).toBe( true );
+	} );
+
+	// The API returns no expiry date for some purchases even though the type
+	// says otherwise, and parsing it as a date throws.
+	test( 'is false when the purchase has no expiry date', () => {
+		expect(
+			creditCardExpiresBeforeSubscription(
+				makePurchase( {
+					payment_type: 'credit_card',
+					payment_expiry_date: '2027-01-31',
+					expiry_date: null as unknown as string,
+				} )
+			)
+		).toBe( false );
+	} );
+
+	test( 'is false when the purchase has no expiry date and only payment_expiry', () => {
+		expect(
+			creditCardExpiresBeforeSubscription(
+				makePurchase( {
+					payment_type: 'credit_card',
+					payment_expiry: '01/27',
+					expiry_date: null as unknown as string,
+				} )
+			)
+		).toBe( false );
 	} );
 } );


### PR DESCRIPTION
Linear: [A4A-3101](https://linear.app/a8c/issue/A4A-3101)

## Proposed Changes

`creditCardExpiresBeforeSubscription` now returns false when a purchase has no expiry date, instead of throwing.

Before it resulted in this error:
<img width="1551" height="544" alt="Screenshot 2026-07-28 at 12 37 18 PM" src="https://github.com/user-attachments/assets/cae3fcfb-a16d-4c86-b89f-a82cee799674" />

## Why are these changes being made?

The upgrades endpoint returns no expiry date for some purchases, and the function parses that field with `parseISO`, which throws on null. That happens while rendering the expiry column, so one bad row takes down the whole purchases page with a 500 and "Cannot read properties of null (reading 'split')".

There's a backend fix going in separately so A4A purchases report their real expiry date: 230955-ghe-Automattic/wpcom. 

Worth noting the type says `expiry_date: string` while the API can return null, which is why nothing flagged this. Correcting that would touch well over a hundred call sites, so it's left for its own PR -hence the cast in the new tests.

## Testing Instructions

1. TC tests

---

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Crafted by Travbot (Claude-powered)