### PR TITLE
Checkout: skip the sticky-summary auto-complete scroll on mobile load

### DIFF
--- a/client/my-sites/checkout/src/components/wp-contact-form.tsx
+++ b/client/my-sites/checkout/src/components/wp-contact-form.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
+import { useMobileCheckoutStickySummaryExperiment } from '../hooks/use-mobile-checkout-sticky-summary-experiment';
 import { usePrefillCheckoutContactForm } from '../hooks/use-prefill-checkout-contact-form';
 import { CHECKOUT_STORE } from '../lib/wpcom-store';
 import ContactDetailsContainer from './contact-details-container';
@@ -92,10 +93,12 @@ export default function WPContactForm( {
 	const { formStatus } = useFormStatus();
 	const isStepActive = useIsStepActive();
 	const isDisabled = ! isStepActive || formStatus !== FormStatus.READY;
+	const { isMobileCheckoutStickySummary } = useMobileCheckoutStickySummaryExperiment();
 
 	const hasCompleted = usePrefillCheckoutContactForm( {
 		setShouldShowContactDetailsValidationErrors,
 		isLoggedOut: isLoggedOutCart,
+		suppressScrollOnAutoComplete: isMobileCheckoutStickySummary,
 	} );
 
 	return (

--- a/client/my-sites/checkout/src/hooks/use-prefill-checkout-contact-form.ts
+++ b/client/my-sites/checkout/src/hooks/use-prefill-checkout-contact-form.ts
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { useCompleteAllSteps } from '@automattic/composite-checkout';
+import { useCompleteAllSteps, useSuppressNextForwardScroll } from '@automattic/composite-checkout';
 import { getCountryPostalCodeSupport } from '@automattic/wpcom-checkout';
 import { useDispatch as useWordPressDataDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
@@ -17,11 +17,13 @@ const debug = debugFactory( 'calypso:use-prefill-checkout-contact-form' );
 
 function useCachedContactDetailsForCheckoutForm(
 	cachedContactDetails: PossiblyCompleteDomainContactDetails | null,
-	setShouldShowContactDetailsValidationErrors?: ( allowed: boolean ) => void
+	setShouldShowContactDetailsValidationErrors?: ( allowed: boolean ) => void,
+	suppressScrollOnAutoComplete?: boolean
 ): boolean {
 	const countriesList = useCountryList();
 	const reduxDispatch = useReduxDispatch();
 	const completeAllSteps = useCompleteAllSteps();
+	const suppressNextForwardScroll = useSuppressNextForwardScroll();
 	const [ isComplete, setComplete ] = useState( false );
 	const didFillForm = useRef( false );
 
@@ -84,6 +86,11 @@ function useCachedContactDetailsForCheckoutForm(
 				}
 				if ( cachedContactDetails.countryCode ) {
 					setShouldShowContactDetailsValidationErrors?.( false );
+					// Auto-completing on load shouldn't jump the viewport the way a
+					// shopper pressing "Continue" would.
+					if ( suppressScrollOnAutoComplete ) {
+						suppressNextForwardScroll( true );
+					}
 					debug( 'Contact details are populated; attempting to auto-complete all steps' );
 					return completeAllSteps();
 				}
@@ -124,6 +131,8 @@ function useCachedContactDetailsForCheckoutForm(
 		setShouldShowContactDetailsValidationErrors,
 		reduxDispatch,
 		completeAllSteps,
+		suppressNextForwardScroll,
+		suppressScrollOnAutoComplete,
 		cachedContactDetails,
 		arePostalCodesSupported,
 		loadDomainContactDetailsFromCache,
@@ -140,15 +149,18 @@ function useCachedContactDetailsForCheckoutForm(
 export function usePrefillCheckoutContactForm( {
 	setShouldShowContactDetailsValidationErrors,
 	isLoggedOut,
+	suppressScrollOnAutoComplete,
 }: {
 	setShouldShowContactDetailsValidationErrors?: ( allowed: boolean ) => void;
 	isLoggedOut?: boolean;
+	suppressScrollOnAutoComplete?: boolean;
 } ): boolean {
 	const { contactDetails, isError } = useCachedContactDetails( { isLoggedOut } );
 
 	const hasCompleted = useCachedContactDetailsForCheckoutForm(
 		contactDetails,
-		setShouldShowContactDetailsValidationErrors
+		setShouldShowContactDetailsValidationErrors,
+		suppressScrollOnAutoComplete
 	);
 
 	// If there is an error, we return it as true and let the form handle it.

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -217,7 +217,7 @@ function isCreditCardFormValid(
 		case 'stripe': {
 			const fields = selectors.getFields( store.getState() );
 			const cardholderName = fields.cardholderName;
-			if ( ! cardholderName?.value.length ) {
+			if ( ! cardholderName?.value?.length ) {
 				// Touch the field so it displays a validation error
 				store.dispatch( actions.setFieldValue( 'cardholderName', '' ) );
 				store.dispatch( actions.setFieldError( 'cardholderName', __( 'This field is required' ) ) );
@@ -234,7 +234,7 @@ function isCreditCardFormValid(
 				);
 				setFieldsError();
 			}
-			if ( areThereErrors || ! cardholderName?.value.length || incompleteFieldKeys.length > 0 ) {
+			if ( areThereErrors || ! cardholderName?.value?.length || incompleteFieldKeys.length > 0 ) {
 				debug( 'card info is not valid', { errors, incompleteFieldKeys, cardholderName } );
 
 				return false;

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -1,5 +1,10 @@
 import { useStripe } from '@automattic/calypso-stripe';
-import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkout';
+import {
+	Button,
+	FormStatus,
+	useFormStatus,
+	PAYMENT_METHOD_STEP_ID,
+} from '@automattic/composite-checkout';
 import { useElements, CardNumberElement } from '@stripe/react-stripe-js';
 import { useSelect } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
@@ -62,7 +67,13 @@ export default function CreditCardPayButton( {
 	const reduxDispatch = useDispatch();
 	useEffect( () => {
 		if ( displayFieldsError ) {
-			document.body.scrollTop = document.documentElement.scrollTop = 0;
+			// The invalid fields live in the payment step, which may be scrolled
+			// out of view (e.g. behind a sticky submit button), making the click
+			// look like a no-op. Bring the step's fields back into view instead
+			// of jumping to the top of the page.
+			document
+				.getElementById( PAYMENT_METHOD_STEP_ID )
+				?.scrollIntoView?.( { behavior: 'smooth', block: 'start' } );
 			reduxDispatch( errorNotice( displayFieldsError, { ariaLive: 'assertive', role: 'alert' } ) );
 			setDisplayFieldsError( '' );
 		}

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -271,6 +271,13 @@ function isCreditCardFormValid(
 				}
 			} );
 
+			if ( ! isValid ) {
+				// Unlike the stripe branch above, nothing here previously
+				// surfaced an error notice or scrolled the invalid fields
+				// into view, so the button appeared to do nothing.
+				setFieldsError();
+			}
+
 			debug( 'ebanx validation - cardholder name and contact details', {
 				isValid,
 			} );

--- a/client/my-sites/checkout/src/payment-methods/wechat/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/wechat/index.tsx
@@ -1,4 +1,9 @@
-import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkout';
+import {
+	Button,
+	FormStatus,
+	useFormStatus,
+	PAYMENT_METHOD_STEP_ID,
+} from '@automattic/composite-checkout';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { Field } from '@automattic/wpcom-checkout';
@@ -204,6 +209,11 @@ function isFormValid( state: WeChatPaymentMethodState ): boolean {
 	if ( ! state.data.customerName.length || state.data.customerName.length < 3 ) {
 		// Touch the field so it displays a validation error
 		state.change( '' );
+		// The field may be scrolled out of view (e.g. behind a sticky submit
+		// button), which would otherwise make the click look like a no-op.
+		document
+			.getElementById( PAYMENT_METHOD_STEP_ID )
+			?.scrollIntoView?.( { behavior: 'smooth', block: 'start' } );
 		return false;
 	}
 	return true;

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -66,6 +66,7 @@ const CheckoutStepGroupContext = createContext< CheckoutStepGroupStore >( {
 		stepIdMap: {},
 		stepCompleteCallbackMap: {},
 		stepSkipValidationOnSubmitMap: {},
+		suppressNextForwardScroll: false,
 	},
 	actions: {
 		makeStepActive: noop,
@@ -77,6 +78,7 @@ const CheckoutStepGroupContext = createContext< CheckoutStepGroupStore >( {
 		getStepCompleteCallback: noopPromise,
 		getStepNumberFromId: noop,
 		setTotalSteps: noop,
+		setSuppressNextForwardScroll: noop,
 	},
 	subscription: new SubscriptionManager(),
 } );
@@ -100,6 +102,7 @@ function createCheckoutStepGroupState(): CheckoutStepGroupState {
 		stepIdMap: {},
 		stepCompleteCallbackMap: {},
 		stepSkipValidationOnSubmitMap: {},
+		suppressNextForwardScroll: false,
 	};
 }
 
@@ -254,6 +257,14 @@ function createCheckoutStepGroupActions(
 		return true;
 	};
 
+	// Allows a consumer to opt the next forward step change out of the
+	// scroll-into-view behavior below (e.g. a step auto-completing on load
+	// rather than the shopper pressing "Continue"). Consumed once by the
+	// scroll effect the next time it runs.
+	const setSuppressNextForwardScroll = ( value: boolean ) => {
+		state.suppressNextForwardScroll = value;
+	};
+
 	return {
 		setActiveStepNumber,
 		setStepCompleteStatus,
@@ -264,6 +275,7 @@ function createCheckoutStepGroupActions(
 		setStepComplete,
 		completeAllSteps,
 		makeStepActive,
+		setSuppressNextForwardScroll,
 	};
 }
 
@@ -451,11 +463,15 @@ function CheckoutStepGroupWrapper( {
 			// view. This corrects the viewport position on mobile after the previous
 			// step's content collapses and causes the layout to shift.
 			if ( scrollToStepOnForwardNavigation && newStep > prevStep ) {
-				const newStepId = Object.entries( store.state.stepIdMap ).find(
-					( [ , num ] ) => num === newStep
-				)?.[ 0 ];
-				if ( newStepId ) {
-					document.getElementById( newStepId )?.scrollIntoView?.( { block: 'start' } );
+				if ( store.state.suppressNextForwardScroll ) {
+					store.state.suppressNextForwardScroll = false;
+				} else {
+					const newStepId = Object.entries( store.state.stepIdMap ).find(
+						( [ , num ] ) => num === newStep
+					)?.[ 0 ];
+					if ( newStepId ) {
+						document.getElementById( newStepId )?.scrollIntoView?.( { block: 'start' } );
+					}
 				}
 			}
 		}
@@ -1079,6 +1095,17 @@ export function useSetStepComplete(): SetStepComplete {
 export function useCompleteAllSteps(): CompleteAllSteps {
 	const store = useContext( CheckoutStepGroupContext );
 	return store.actions.completeAllSteps;
+}
+
+/**
+ * Opts the next forward step change out of the scroll-into-view behavior
+ * (see `scrollToStepOnForwardNavigation`). Intended for step changes caused
+ * by something other than the shopper pressing "Continue" (e.g. a step
+ * auto-completing on load), where jumping the viewport would be surprising.
+ */
+export function useSuppressNextForwardScroll(): ( value: boolean ) => void {
+	const store = useContext( CheckoutStepGroupContext );
+	return store.actions.setSuppressNextForwardScroll;
 }
 
 export function useMakeStepActive(): MakeStepActive {

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -733,6 +733,20 @@ export function CheckoutFormSubmit( {
 		customPropertyForSubmitButtonHeight
 	);
 
+	// If validation fails below, the active step may be scrolled out of view
+	// (e.g. behind a sticky submit button), which would otherwise make the
+	// button look like it did nothing when it in fact surfaced errors.
+	const scrollActiveStepIntoView = useCallback( () => {
+		const activeStepId = Object.entries( stepIdMap ).find(
+			( [ , num ] ) => num === activeStepNumber
+		)?.[ 0 ];
+		if ( activeStepId ) {
+			document
+				.getElementById( activeStepId )
+				?.scrollIntoView?.( { behavior: 'smooth', block: 'start' } );
+		}
+	}, [ activeStepNumber, stepIdMap ] );
+
 	// Wrap validateForm to first validate any active step before submission
 	const wrappedValidateForm = useCallback( async () => {
 		// Only validate if there's an actual active step (within the range of registered steps)
@@ -751,6 +765,7 @@ export function CheckoutFormSubmit( {
 
 				if ( ! isStepComplete ) {
 					// Step validation failed, don't proceed with submission
+					scrollActiveStepIntoView();
 					return false;
 				}
 
@@ -761,7 +776,11 @@ export function CheckoutFormSubmit( {
 
 		// Now run the payment method validation if provided
 		if ( validateForm ) {
-			return await validateForm();
+			const isFormValid = await validateForm();
+			if ( ! isFormValid ) {
+				scrollActiveStepIntoView();
+			}
+			return isFormValid;
 		}
 
 		return true;
@@ -773,6 +792,7 @@ export function CheckoutFormSubmit( {
 		getStepCompleteCallback,
 		setStepCompleteStatus,
 		validateForm,
+		scrollActiveStepIntoView,
 	] );
 
 	const isDisabled = ( () => {

--- a/packages/composite-checkout/src/components/default-steps.tsx
+++ b/packages/composite-checkout/src/components/default-steps.tsx
@@ -1,6 +1,10 @@
 import CheckoutPaymentMethods, { CheckoutPaymentMethodsTitle } from './checkout-payment-methods';
 import type { CheckoutPageErrorCallback, CheckoutStepProps } from '../types';
 
+// Exported so consumers (e.g. a payment method's own submit button) can
+// scroll this step into view without duplicating the id.
+export const PAYMENT_METHOD_STEP_ID = 'payment-method-step';
+
 export function getDefaultPaymentMethodStep( {
 	onPageLoadError,
 	waitForPaymentMethodIds = [],
@@ -9,7 +13,7 @@ export function getDefaultPaymentMethodStep( {
 	waitForPaymentMethodIds?: string[];
 } ): CheckoutStepProps {
 	return {
-		stepId: 'payment-method-step',
+		stepId: PAYMENT_METHOD_STEP_ID,
 		isCompleteCallback: () => true,
 		className: 'checkout__payment-method-step',
 		titleContent: <CheckoutPaymentMethodsTitle />,

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -15,6 +15,7 @@ import {
 	useCompleteAllSteps,
 	useMakeStepActive,
 	useNextIncompleteStepId,
+	useSuppressNextForwardScroll,
 	createCheckoutStepGroupStore,
 } from './components/checkout-steps';
 import RadioButton from './components/radio-button';
@@ -74,6 +75,7 @@ export {
 	useProcessPayment,
 	useSetStepComplete,
 	useCompleteAllSteps,
+	useSuppressNextForwardScroll,
 	useTogglePaymentMethod,
 	useTransactionStatus,
 	useMakeStepActive,

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -18,6 +18,7 @@ import {
 	useSuppressNextForwardScroll,
 	createCheckoutStepGroupStore,
 } from './components/checkout-steps';
+import { PAYMENT_METHOD_STEP_ID } from './components/default-steps';
 import RadioButton from './components/radio-button';
 import useProcessPayment from './components/use-process-payment';
 import { useFormStatus } from './lib/form-status';
@@ -57,6 +58,7 @@ export {
 	CheckoutStepBody,
 	CheckoutStepGroup,
 	PaymentMethodStep,
+	PAYMENT_METHOD_STEP_ID,
 	checkoutTheme,
 	createCheckoutStepGroupStore,
 	makeErrorResponse,

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -4,7 +4,7 @@ import type { Theme as ThemeType } from './lib/theme';
 import type { ReactElement } from 'react';
 
 declare module '@emotion/react' {
-	// eslint-disable-next-line @typescript-eslint/no-empty-interface
+	// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 	export interface Theme extends ThemeType {}
 }
 
@@ -294,6 +294,7 @@ export interface CheckoutStepGroupState {
 	stepIdMap: StepIdMap;
 	stepCompleteCallbackMap: StepCompleteCallbackMap;
 	stepSkipValidationOnSubmitMap: Record< number, boolean >;
+	suppressNextForwardScroll: boolean;
 }
 
 export interface CheckoutStepGroupActions {
@@ -311,6 +312,7 @@ export interface CheckoutStepGroupActions {
 	) => void;
 	getStepCompleteCallback: ( stepNumber: number ) => StepCompleteCallback;
 	setTotalSteps: ( totalSteps: number ) => void;
+	setSuppressNextForwardScroll: ( value: boolean ) => void;
 }
 
 export type TogglePaymentMethod = ( paymentMethodId: string, available: boolean ) => void;


### PR DESCRIPTION
Fixes [SHILL-2304](https://linear.app/a8c/issue/SHILL-2304/checkout-view-automatically-scrolls-to-bottom-on-mobile)

## Proposed Changes

This PR fixes two separate checkout scroll-position bugs found while working on the mobile sticky-summary experiment.

**1. Scroll jump on checkout load (SHILL-2304)**

* Adds `useSuppressNextForwardScroll` to `composite-checkout`, a one-shot way for a consumer to opt the next forward step change out of the existing scroll-into-view behavior.
* Calls it from `usePrefillCheckoutContactForm` right before the auto-complete (`completeAllSteps()`) call, gated behind a new `suppressScrollOnAutoComplete` param.
* Wires that param from `WPContactForm` to `isMobileCheckoutStickySummary`, so only the experiment's treatment cohort is affected; manual step navigation (pressing Continue/Edit) and the control arm are unchanged.

**2. "Pay now" appears to do nothing when the payment step is scrolled out of view**

* `composite-checkout`'s `CheckoutFormSubmit` now scrolls the active step into view whenever submit-time validation fails (either the step's own `isCompleteCallback` or the consumer's `validateForm`), instead of leaving the shopper looking at an unchanged screen.
* Exports a `PAYMENT_METHOD_STEP_ID` constant so a payment method's own submit button can scroll to the payment step without duplicating its DOM id.
* Credit card: replaces a `scrollTop = 0` (jump to the very top of the page) with scrolling the payment step into view on invalid Stripe/Ebanx fields.
* Credit card: fixes a crash (`cardholderName?.value.length` only optional-chained through `cardholderName`, not `value`) that could throw and abort the click handler entirely before any error or scroll happened.
* Credit card: the Ebanx billing-fields check (name, address, phone, etc.) marked fields invalid but never surfaced an error notice at all, unlike the Stripe branch — fixed to call the same `setFieldsError()`.
* WeChat Pay: its own `isFormValid` check showed no notice and no scroll on an invalid customer-name field, so the button appeared to do nothing — now scrolls the step into view.
* Audited every other payment method (PayPal classic, PayPal JS, existing card, existing PayPal PPCP, Pix, Pix Automático, free purchase) for the same local-pre-validation-bypasses-scroll pattern; none of the others have it; they rely on the generic `CheckoutFormSubmit` fix above.

## Why are these changes being made?

**(1)** `CheckoutStepGroupWrapper`'s step-change effect scrolls the newly active step into view whenever the step number moves forward on mobile (`scrollToStepOnForwardNavigation`), added in #109715 to fix the viewport position after a step collapses from a manual "Continue" click. It has no way to tell that transition apart from a step advancing because cached contact details silently auto-completed it on page load (`usePrefillCheckoutContactForm` → `completeAllSteps()`), so both cases scroll identically — jumping straight to the payment step out from under a shopper who hasn't looked at the order review yet. The fix is scoped to the mobile sticky-summary experiment treatment cohort only, since that's the surface this was reported against.

**(2)** Several payment methods validate their own fields locally, before composite-checkout's generic submit-validation flow ever runs. When that local validation fails, some paths (credit card) scrolled to the wrong place, and others (WeChat, Ebanx billing fields) showed no feedback whatsoever — both read as the submit button doing nothing, which is especially confusing on a long checkout page or behind a sticky submit button. The fix makes "scroll the active/payment step into view on validation failure" a consistent behavior at both the generic (`CheckoutFormSubmit`) and payment-method-specific layers, and separately fixes the credit-card crash and the missing Ebanx error surfacing that were uncovered along the way.

Before (on load, with contact step prefilled)             |  After (on load, with contact step prefilled) 
:-------------------------:|:-------------------------:
<img width="280" height="616" alt="Screenshot 2026-07-28 at 6 20 37 PM" src="https://github.com/user-attachments/assets/19d11f70-69e0-4d2a-915c-538466c8c271" /> | <img width="282" height="619" alt="Screenshot 2026-07-28 at 6 19 58 PM" src="https://github.com/user-attachments/assets/3899e229-44a6-4a3c-bc62-0cab954d6069" />

## Testing Instructions

* Note: you need to test this with Firefox. The scrolling does not seem to happen in Chrome's mobile emulation.
* Use a sandbox with cached contact/billing details on a logged-in account (e.g. an account that's checked out before).
* Use the browser's emulation to simulate a mobile device with a narrow viewport.
* Force-enroll into the `calypso_mobile_checkout_sticky_summary_v1` treatment:
```
localStorage.setItem( 'explat-experiment--calypso_mobile_checkout_sticky_summary_v1', JSON.stringify( {
  experimentName: 'calypso_mobile_checkout_sticky_summary_v1',
  variationName: 'treatment', // or 'control'
  retrievedTimestamp: Date.now(), ttl: 3600,
} ) );
```
* Confirm the page does not scroll away from the top of the checkout view as the contact step auto-completes.
* Manually click "Continue" from a step and confirm the viewport still scrolls to the next step as before.
