### PR TITLE
Purchases: hide unavailable subscription actions for partner-managed (Jetpack Start) plans

### DIFF
--- a/client/dashboard/me/billing-purchases/AGENTS.md
+++ b/client/dashboard/me/billing-purchases/AGENTS.md
@@ -84,10 +84,25 @@ marketplace subscriptions on site.
 
 ## Common Pitfalls
 
-1. **`isPartnerPurchase` type guard narrows to wrong field** — Checks
-   `purchase?.partner_name` but narrows the type to `{ partnerType: string }` (camelCase).
-   The actual field on the `Purchase` interface is `partner_type` (snake_case). Downstream
-   code using the narrowed type will reference a field that doesn't exist.
+1. **Read `is_partner_managed` / `is_host_managed`; don't re-derive them** — A
+   partner-provisioned ("Jetpack Start") subscription is billed by the partner, so
+   WordPress.com self-serve management doesn't apply. The backend reports this directly:
+   `is_partner_managed` (a partner provisioned and bills it, excluding A4A store
+   purchases) and `is_host_managed` (that subset provisioned by a host rather than an
+   agency). Agencies buy through WordPress.com and *do* cancel here, so only
+   `is_host_managed` gates cancel/remove; the cancel flow separately skips their survey.
+
+   The flags replace a client-side derivation: a `partner_name` check paired with
+   `! isA4ABillingDragonPurchase()`, plus an `[ 'agency', 'a4a_agency' ]` list for the
+   host/agency split. Use the flags in new code. Several older call sites still derive it
+   by hand (`purchase-payment-method.tsx`, `components/purchase-expiry-status/`, and
+   classic's `manage-purchase/index.tsx`) and are yet to be swept.
+
+   `is_upgradable`, `is_cancelable`, `is_removable`, and `can_explicit_renew` are all
+   false server-side for the relevant cases, so the client only needs its own check where
+   visibility is driven by something else: `CancelOrRemoveActionButton` and classic's
+   `renderCancelPurchaseNavItem` key off auto-renew state rather than `is_cancelable`, and
+   the storage add-on has no server flag of its own.
 
 2. **Payment method list is empty while loading** — `allowedPaymentMethods === undefined`
    returns `[]` (no methods shown). Errors fail open (all methods shown). Don't add
@@ -110,7 +125,7 @@ marketplace subscriptions on site.
 6. **Survey completion tracked per-purchase** — Stored in user preferences to avoid
    re-surveying. A new survey won't appear for a purchase that was already surveyed.
 
-6. **Siteless purchases** — Some products (Akismet, Jetpack, Marketplace) use temporary sites (`siteless.{jetpack|akismet|marketplace.wp|a4a}.com`). Guard with `hasQueryableSite( purchase )` (`utils/purchase.ts`), which wraps `purchase.is_attached_to_holding_site`. Never fire **any** site-scoped query for these — not just `siteBySlugQuery()`, but anything hitting `/sites/{blog_id}/…` (`siteFeaturesQuery`, `sitePurchasesQuery`, `siteByIdQuery`, `siteDomainsQuery`, `cancellationOffersQuery`, backup queries, …). Use `purchase.domain` or `purchase.blog_id` for display, and skip site-dependent UI entirely.
+7. **Siteless purchases** — Some products (Akismet, Jetpack, Marketplace) use temporary sites (`siteless.{jetpack|akismet|marketplace.wp|a4a}.com`). Guard with `hasQueryableSite( purchase )` (`utils/purchase.ts`), which wraps `purchase.is_attached_to_holding_site`. Never fire **any** site-scoped query for these — not just `siteBySlugQuery()`, but anything hitting `/sites/{blog_id}/…` (`siteFeaturesQuery`, `sitePurchasesQuery`, `siteByIdQuery`, `siteDomainsQuery`, `cancellationOffersQuery`, backup queries, …). Use `purchase.domain` or `purchase.blog_id` for display, and skip site-dependent UI entirely.
 
    The user is not a member of the holding site, so those requests return `403 authorization_required`. `AuthProvider` (`app/auth/index.tsx`) subscribes to the whole query cache and treats that error as a signed-out session, redirecting to `/log-in` — which bounces straight back, looping forever (SHILL-2295). Note that `.catch()` on `ensureQueryData` does **not** protect you: the redirect is driven by the query *cache* entry going to `error`, not by the rejected promise. The query must not fire at all (`enabled: false`).
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1522,6 +1522,25 @@ function CancelPurchaseInner() {
 			return false;
 		}
 
+		// A host-managed plan is billed by the partner, so there is nothing to
+		// cancel here. The CTA is hidden on Purchase Settings; this also turns away
+		// anyone arriving from a stale link, with copy that names the partner rather
+		// than the generic "cannot be cancelled" message below.
+		if ( purchase.is_host_managed ) {
+			if ( ! createdErrorNoticeForRedirect.current ) {
+				createErrorNotice(
+					sprintf(
+						/* translators: %s is the name of the hosting partner, e.g. "Bluehost" */
+						__( 'This subscription is managed by %s. Please contact them to make changes.' ),
+						purchase.partner_name ?? ''
+					),
+					{ type: 'snackbar' }
+				);
+				createdErrorNoticeForRedirect.current = true;
+			}
+			return false;
+		}
+
 		// If intent=cancel/auto-renew but auto-renew is already off (e.g. page
 		// refresh after the mutation), redirect to Purchase Settings instead of
 		// re-showing the confirmation screen. Bypass when surveyShown is true —

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -103,7 +103,6 @@ import {
 	isExpiredOrRemoved,
 	mightStillAutoRenew,
 	isWithinRefundWindowDowngradeEligible,
-	isA4ABillingDragonPurchase,
 	isCentennialPurchase,
 	hasAmountAvailableToRefund,
 } from '../../../utils/purchase';
@@ -165,9 +164,19 @@ function getNonPlanUpgradeAction(
 		: undefined;
 }
 
-/** Whether the storage upgrade action is offered. */
+/**
+ * Whether the storage upgrade action is offered.
+ *
+ * Partner-managed subscriptions are excluded for the same reason `is_upgradable`
+ * is false for them server-side: the partner does the buying. There is no
+ * server-side flag for the storage add-on specifically, so it is checked here.
+ */
 function isStorageUpgradeShown( purchase: Purchase ): boolean {
-	return isStorageUpgradeEligible( purchase ) && ! isExpiredOrRemoved( purchase );
+	return (
+		isStorageUpgradeEligible( purchase ) &&
+		! isExpiredOrRemoved( purchase ) &&
+		! purchase.is_partner_managed
+	);
 }
 
 /**
@@ -331,6 +340,15 @@ export function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase }
 	// A fully removed subscription (no longer active) has nothing left to
 	// cancel or remove.
 	if ( isRemoved( purchase ) ) {
+		return null;
+	}
+
+	// The host owns the billing relationship for these, so cancelling has to
+	// happen there. `is_cancelable` and `is_removable` are both false server-side
+	// for them, but visibility below is driven by auto-renew state rather than by
+	// those flags, so the check has to be repeated here. Agency-provisioned
+	// purchases are bought through WordPress.com and stay cancellable.
+	if ( purchase.is_host_managed ) {
 		return null;
 	}
 
@@ -694,6 +712,14 @@ function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 		return null;
 	}
 
+	// Same for host-managed plans: upgrade and renew are false server-side and
+	// cancel/remove are gated above, so every action in the list resolves to
+	// nothing. Product links like CRM downloads still work, so the card stays
+	// when there is one of those to show.
+	if ( purchase.is_host_managed && ! hasProductAction ) {
+		return null;
+	}
+
 	// Users who don't own the purchase are only supposed to get a limited set
 	// of management links; if they aren't available, skip the card entirely so
 	// we don't render an empty shell.
@@ -911,7 +937,7 @@ const form = {
 	],
 };
 
-function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
+export function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 	const {
 		mutate: setAutoRenew,
 		error,
@@ -921,7 +947,14 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 	const navigate = useNavigate();
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
 
-	if ( String( user.ID ) !== String( purchase.user_id ) || isIncludedWithPlan( purchase ) ) {
+	// Auto-renew and the payment method are the partner's to manage rather than
+	// the customer's, so the whole card goes for a partner-managed subscription.
+	// The classic purchases page hides its equivalent block for the same reason.
+	if (
+		String( user.ID ) !== String( purchase.user_id ) ||
+		isIncludedWithPlan( purchase ) ||
+		purchase.is_partner_managed
+	) {
 		return null;
 	}
 
@@ -978,7 +1011,8 @@ function PurchasePriceCard( { purchase }: { purchase: Purchase } ) {
 			/>
 		);
 	}
-	if ( purchase.partner_name && ! isA4ABillingDragonPurchase( purchase ) ) {
+	// There is no WordPress.com price to show for a subscription the partner bills.
+	if ( purchase.is_partner_managed ) {
 		return null;
 	}
 	if ( purchase.is_trial_plan ) {
@@ -1412,18 +1446,10 @@ function PurchaseSubtitle( { purchase }: { purchase: Purchase } ) {
 		return null;
 	}
 
-	if ( purchase.partner_name && ! isA4ABillingDragonPurchase( purchase ) ) {
-		return (
-			<MetadataItem
-				title={ sprintf(
-					// translators: %(subtitle)s is the type of purchase (e.g. "Host Managed Plan"), %(partnerName)s is the name of the business partner
-					__( '%(subtitle)s. Please contact %(partnerName)s for details.' ),
-					{ subtitle, partnerName: purchase.partner_name }
-				) }
-			/>
-		);
-	}
-
+	// For a partner-managed purchase the subtitle is just the product type ("Host
+	// Managed Plan" / "Agency Managed Plan"); PartnerManagedNotice carries the
+	// "contact the partner" guidance that used to be appended here, where it read
+	// as a minor detail next to the action list.
 	return <MetadataItem title={ subtitle } />;
 }
 
@@ -1486,7 +1512,7 @@ export default function PurchaseSettings() {
 		...purchaseCancelFeaturesQuery( purchase.ID ),
 	} );
 	const features = cancelFeaturesResponse?.features ?? null;
-	const hasExpiryInfo = ! purchase.partner_name || isA4ABillingDragonPurchase( purchase );
+	const hasExpiryInfo = ! purchase.is_partner_managed;
 	// These two are deliberately separate: the header stands down whenever there
 	// is a notice at all, while the expiry card only takes a color when there is
 	// something the customer has to act on. While a renewal is still expected the

--- a/client/dashboard/me/billing-purchases/purchase-settings/partner-managed-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/partner-managed-notice.tsx
@@ -1,0 +1,29 @@
+import { __, sprintf } from '@wordpress/i18n';
+import Notice from '../../../components/notice';
+import { getSubtitleForDisplay } from '../../../utils/purchase';
+import type { Purchase } from '@automattic/api-core';
+
+/**
+ * Tells the customer that a partner provisioned and bills this subscription, so
+ * changes have to go through the partner. It carries the whole explanation for
+ * why the page has no management actions, which is why it's a notice rather than
+ * a line of sub-header metadata.
+ *
+ * The caller gates this on `purchase.is_partner_managed`.
+ */
+export function PartnerManagedNotice( { purchase }: { purchase: Purchase } ) {
+	const subtitle = getSubtitleForDisplay( purchase );
+	if ( ! subtitle || ! purchase.partner_name ) {
+		return null;
+	}
+
+	return (
+		<Notice variant="info">
+			{ sprintf(
+				/* translators: %(subtitle)s is the type of purchase (e.g. "Host Managed Plan"), %(partnerName)s is the name of the business partner */
+				__( '%(subtitle)s. Please contact %(partnerName)s for details.' ),
+				{ subtitle, partnerName: purchase.partner_name }
+			) }
+		</Notice>
+	);
+}

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -59,6 +59,7 @@ import {
 	OtherRenewablePurchasesNotice,
 	shouldShowOtherRenewablePurchasesNotice,
 } from './other-renewable-purchases-notice';
+import { PartnerManagedNotice } from './partner-managed-notice';
 import { PurchaseCancelledNotice } from './purchase-cancelled-notice';
 import { PurchaseExpiringNotice, shouldShowExpiringNotice } from './purchase-expiring-notice';
 import { RenewNoticeAction, shouldShowRenewNoticeAction } from './renew-notice-action';
@@ -330,6 +331,13 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 
 	if ( purchase.product_slug === 'concierge-session' && isExpiredOrRemoved( purchase ) ) {
 		return <ConciergeConsumedNotice />;
+	}
+
+	// Takes precedence over every notice below, including the expiry ones: those
+	// all push the customer toward a renewal or a payment method that the partner
+	// controls rather than WordPress.com.
+	if ( purchase.is_partner_managed ) {
+		return <PartnerManagedNotice purchase={ purchase } />;
 	}
 
 	// A plan that is expiring, expired, or otherwise at risk of not renewing

--- a/client/dashboard/me/billing-purchases/purchase-settings/test/cancel-or-remove-action-button.test.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/test/cancel-or-remove-action-button.test.tsx
@@ -123,4 +123,22 @@ describe( '<CancelOrRemoveActionButton />', () => {
 		);
 		expect( container ).toBeEmptyDOMElement();
 	} );
+
+	test( 'renders nothing for a host-managed plan', () => {
+		const { container } = render(
+			<CancelOrRemoveActionButton
+				purchase={ makePurchase( { is_partner_managed: true, is_host_managed: true } ) }
+			/>
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'still offers Cancel for an agency-managed plan', () => {
+		render(
+			<CancelOrRemoveActionButton
+				purchase={ makePurchase( { is_partner_managed: true, is_host_managed: false } ) }
+			/>
+		);
+		expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeVisible();
+	} );
 } );

--- a/client/dashboard/me/billing-purchases/purchase-settings/test/partner-managed-actions.test.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/test/partner-managed-actions.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import { render } from '../../../../test-utils';
+import { ManageSubscriptionCard, StorageUpgradeActionButton } from '../index';
+import type { Purchase } from '@automattic/api-core';
+
+// A partner-provisioned ("Jetpack Start") subscription. The eligibility flags
+// below deliberately say yes to every action that has no server-side flag of its
+// own, so only `is_partner_managed` can be what suppresses them.
+//
+// The upgrade, renew, cancel, and remove actions are not covered here: the
+// backend reports `is_upgradable`, `can_explicit_renew`, `is_cancelable`, and
+// `is_removable` as false for these subscriptions, so they need no client gate.
+// Cancel is the exception, since its visibility is driven by auto-renew state
+// instead — see cancel-or-remove-action-button.test.tsx.
+//
+// The rendering wrapper's default user has ID 1, so a purchase owned by user 1
+// belongs to the current user.
+function makePartnerPurchase( overrides: Partial< Purchase > = {} ): Purchase {
+	return {
+		ID: 1,
+		user_id: 1,
+		product_name: 'Jetpack Security Daily',
+		product_slug: 'jetpack_security_t1_yearly',
+		site_slug: 'example.com',
+		is_plan: true,
+		is_jetpack_plan_or_product: true,
+		is_jetpack_backup_t1: true,
+		is_auto_renew_enabled: true,
+		is_rechargeable: false,
+		subscription_status: 'active',
+		expiry_status: 'auto-renewing',
+		expiry_date: '2027-01-01',
+		is_partner_managed: true,
+		is_host_managed: true,
+		partner_name: 'Bluehost',
+		partner_type: 'hosting_provider',
+		...overrides,
+	} as Purchase;
+}
+
+describe( 'partner-managed purchase actions', () => {
+	test( 'the storage upgrade action is hidden for a storage-eligible product', () => {
+		const { container } = render(
+			<StorageUpgradeActionButton purchase={ makePartnerPurchase() } />
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'the manage subscription card is hidden, so no auto-renew or payment method controls', () => {
+		const { container } = render( <ManageSubscriptionCard purchase={ makePartnerPurchase() } /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'an agency-managed purchase also loses them, since the agency does the buying', () => {
+		const purchase = makePartnerPurchase( {
+			is_host_managed: false,
+			partner_name: 'Some Agency',
+			partner_type: 'a4a_agency',
+		} );
+
+		const { container } = render(
+			<>
+				<StorageUpgradeActionButton purchase={ purchase } />
+				<ManageSubscriptionCard purchase={ purchase } />
+			</>
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'a purchase WordPress.com bills keeps its actions', () => {
+		// Covers both an ordinary purchase and an A4A store purchase: the backend
+		// reports `is_partner_managed` as false for each.
+		const purchase = makePartnerPurchase( {
+			is_partner_managed: false,
+			is_host_managed: false,
+		} );
+
+		render(
+			<>
+				<StorageUpgradeActionButton purchase={ purchase } />
+				<ManageSubscriptionCard purchase={ purchase } />
+			</>
+		);
+
+		expect( screen.getByRole( 'button', { name: 'Upgrade storage' } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Add payment method' } ) ).toBeVisible();
+	} );
+} );

--- a/client/dashboard/me/billing-purchases/purchase-settings/test/partner-managed-notice.test.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/test/partner-managed-notice.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import { render } from '../../../../test-utils';
+import { PartnerManagedNotice } from '../partner-managed-notice';
+import type { Purchase } from '@automattic/api-core';
+
+function makePurchase( overrides: Partial< Purchase > = {} ): Purchase {
+	return {
+		ID: 1,
+		user_id: 1,
+		product_name: 'Jetpack Security Daily',
+		product_slug: 'jetpack_security_t1_yearly',
+		is_plan: true,
+		is_partner_managed: true,
+		is_host_managed: true,
+		partner_name: 'Bluehost',
+		partner_type: 'hosting_provider',
+		...overrides,
+	} as Purchase;
+}
+
+describe( '<PartnerManagedNotice />', () => {
+	test( 'names the host and tells the customer to contact them', () => {
+		render( <PartnerManagedNotice purchase={ makePurchase() } /> );
+		expect(
+			screen.getByText( 'Host Managed Plan. Please contact Bluehost for details.' )
+		).toBeVisible();
+	} );
+
+	test( 'says "Agency Managed Plan" for an agency partner', () => {
+		render(
+			<PartnerManagedNotice
+				purchase={ makePurchase( {
+					is_host_managed: false,
+					partner_name: 'Some Agency',
+					partner_type: 'a4a_agency',
+				} ) }
+			/>
+		);
+		expect(
+			screen.getByText( 'Agency Managed Plan. Please contact Some Agency for details.' )
+		).toBeVisible();
+	} );
+
+	test( 'renders nothing without a partner name to point the customer at', () => {
+		const { container } = render(
+			<PartnerManagedNotice purchase={ makePurchase( { partner_name: undefined } ) } />
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -294,6 +294,13 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			return false;
 		}
 
+		// A host-managed plan is billed by the partner, so there is nothing to
+		// cancel here. The CTA is hidden on the manage-purchase page; this also
+		// turns away anyone arriving from a stale link.
+		if ( purchase.is_host_managed ) {
+			return false;
+		}
+
 		const isDomainTransferCancelable = purchase.is_refundable || ! isDomainTransfer( purchase );
 		const isValidForCancellation =
 			canAutoRenewBeTurnedOff( purchase ) && isDomainTransferCancelable;

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1008,6 +1008,15 @@ class ManagePurchase extends Component<
 			return null;
 		}
 
+		// The host owns the billing relationship for a host-managed plan, so
+		// cancelling has to happen there. `is_cancelable` is false server-side for
+		// these, but visibility here is driven by auto-renew state instead, so the
+		// check has to be repeated. Agency-provisioned purchases are bought through
+		// WordPress.com and stay cancellable.
+		if ( purchase.is_host_managed ) {
+			return null;
+		}
+
 		// Only show the Cancel button when auto-renew is still on (i.e. the user
 		// hasn't already cancelled the subscription). The Remove button owns the
 		// auto-renew-off state. `canAutoRenewBeTurnedOff` returns true for
@@ -1440,25 +1449,15 @@ class ManagePurchase extends Component<
 									: purchaseType( purchase ) }
 							</div>
 							<div className="manage-purchase__price">
-								{ isPartnerPurchase( purchase ) && ! isA4ABillingDragonPurchase( purchase ) ? (
-									<div className="manage-purchase__contact-partner">
-										{ translate( 'Please contact %(partnerName)s for details', {
-											args: {
-												partnerName: purchase.partner_name ?? '',
-											},
-										} ) }
-									</div>
-								) : (
-									<>
-										{ isPurchaseOneTimePurchase( purchase ) && (
-											<PlanPrice
-												rawPrice={ purchase.regular_price_integer }
-												isSmallestUnit
-												currencyCode={ purchase.currency_code }
-												isOnSale={ !! purchase.sale_amount }
-											/>
-										) }
-									</>
+								{ /* A partner-managed purchase has no WordPress.com price to show, and
+								     the "contact the partner" guidance now lives in PurchaseNotice. */ }
+								{ ! purchase.is_partner_managed && isPurchaseOneTimePurchase( purchase ) && (
+									<PlanPrice
+										rawPrice={ purchase.regular_price_integer }
+										isSmallestUnit
+										currencyCode={ purchase.currency_code }
+										isOnSale={ !! purchase.sale_amount }
+									/>
 								) }
 							</div>
 						</div>

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -58,6 +58,7 @@ import {
 	isRechargeable,
 	isRenewingBeforeExpiration,
 	needsToRenewSoon,
+	purchaseType,
 	showCreditCardExpiringWarning,
 	isPaidWithCredits,
 	shouldAddPaymentSourceInsteadOfRenewingNow,
@@ -1470,6 +1471,30 @@ class PurchaseNotice extends Component<
 		);
 	}
 
+	/**
+	 * Tells the customer that a partner provisioned and bills this subscription,
+	 * so changes have to go through the partner. It carries the whole explanation
+	 * for why the page has no management actions, which is why it is a notice
+	 * rather than a line of metadata beside the price.
+	 *
+	 * The caller gates this on `purchase.is_partner_managed`.
+	 */
+	renderPartnerManagedNotice() {
+		const { purchase, translate } = this.props;
+		const subtitle = purchaseType( purchase );
+		if ( ! subtitle || ! purchase.partner_name ) {
+			return null;
+		}
+
+		return (
+			<Notice variant="info">
+				{ translate( '%(subtitle)s. Please contact %(partnerName)s for details.', {
+					args: { subtitle, partnerName: purchase.partner_name },
+				} ) }
+			</Notice>
+		);
+	}
+
 	renderNonProductOwnerNotice() {
 		const { translate } = this.props;
 
@@ -1658,6 +1683,13 @@ class PurchaseNotice extends Component<
 
 		if ( this.shouldRenderConciergeConsumedNotice() ) {
 			return this.renderConciergeConsumedNotice();
+		}
+
+		// Takes precedence over every notice below, including the expiry ones: those
+		// all push the customer toward a renewal or a payment method that the
+		// partner controls rather than WordPress.com.
+		if ( purchase.is_partner_managed ) {
+			return this.renderPartnerManagedNotice();
 		}
 
 		// A plan that is expiring, expired, or otherwise at risk of not renewing

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -213,11 +213,6 @@
 	clear: none;
 }
 
-.manage-purchase__contact-partner {
-	font-weight: 600;
-	display: block;
-}
-
 .manage-purchase__description {
 	color: var( --color-text-subtle );
 	display: block;

--- a/client/me/purchases/manage-purchase/test/notices.js
+++ b/client/me/purchases/manage-purchase/test/notices.js
@@ -370,4 +370,29 @@ describe( 'PurchaseNotice', () => {
 		renderNotice( { purchase, isProductOwner: true, selectedSite: { slug: 'testingsite' } } );
 		expect( screen.container ).toBeFalsy();
 	} );
+
+	it( 'renders a contact-the-partner notice for a host-managed plan instead of an expiring notice', () => {
+		const purchaseExpiry = new Date();
+		purchaseExpiry.setDate( purchaseExpiry.getDate() + 10 );
+		const purchase = {
+			ID: 'whatever1',
+			product_slug: 'jetpack_security_t1_yearly',
+			product_name: 'Jetpack Security',
+			is_plan: true,
+			is_renewable: true,
+			is_rechargeable: false,
+			expiry_status: 'manual-renew',
+			expiry_date: purchaseExpiry.toISOString(),
+			is_partner_managed: true,
+			is_host_managed: true,
+			partner_name: 'Bluehost',
+			partner_type: 'hosting_provider',
+		};
+		renderNotice( { purchase, isProductOwner: true, selectedSite: { slug: 'testingsite' } } );
+
+		expect(
+			screen.getByText( 'Host Managed Plan. Please contact Bluehost for details.' )
+		).toBeVisible();
+		expect( screen.queryByText( 'Renew Now' ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -657,4 +657,73 @@ describe( 'Purchase Management Buttons', () => {
 		await findPaymentMethodNavItem();
 		expect( screen.queryByText( /Upgrade/ ) ).not.toBeInTheDocument();
 	} );
+
+	it( 'does not render cancel or remove CTAs for a host-managed plan', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/me/payment-methods?expired=include' )
+			.reply( 200 );
+
+		// The server reports these as neither cancelable nor removable, but the CTA
+		// visibility here is driven by auto-renew state, so it needs the flag too.
+		const store = createMockReduxStoreForPurchase( {
+			...purchase,
+			is_auto_renew_enabled: true,
+			is_upgradable: false,
+			is_cancelable: false,
+			is_removable: false,
+			can_explicit_renew: false,
+			is_partner_managed: true,
+			is_host_managed: true,
+			partner_name: 'Bluehost',
+			partner_type: 'hosting_provider',
+		} );
+
+		render(
+			<QueryClientProvider client={ queryClient }>
+				<ReduxProvider store={ store }>
+					<ManagePurchase
+						purchaseId={ Number( purchase.ID ) }
+						isSiteLevel
+						siteSlug="onecooltestsite.com"
+					/>
+				</ReduxProvider>
+			</QueryClientProvider>
+		);
+
+		expect(
+			await screen.findByText( 'Host Managed Plan. Please contact Bluehost for details.' )
+		).toBeVisible();
+		expect( screen.queryByText( /Cancel subscription/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /Remove plan/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'still renders a cancel CTA for an agency-managed plan', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/me/payment-methods?expired=include' )
+			.reply( 200 );
+
+		const store = createMockReduxStoreForPurchase( {
+			...purchase,
+			is_auto_renew_enabled: true,
+			is_upgradable: false,
+			is_partner_managed: true,
+			is_host_managed: false,
+			partner_name: 'Some Agency',
+			partner_type: 'a4a_agency',
+		} );
+
+		render(
+			<QueryClientProvider client={ queryClient }>
+				<ReduxProvider store={ store }>
+					<ManagePurchase
+						purchaseId={ Number( purchase.ID ) }
+						isSiteLevel
+						siteSlug="onecooltestsite.com"
+					/>
+				</ReduxProvider>
+			</QueryClientProvider>
+		);
+
+		expect( await screen.findByText( /Cancel subscription/ ) ).toBeVisible();
+	} );
 } );

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -324,6 +324,25 @@ export interface Purchase {
 	 */
 	ownership_id: number;
 
+	/**
+	 * True when a Jetpack Start partner provisioned this subscription and bills
+	 * the customer for it, so WordPress.com is not the merchant and self-serve
+	 * subscription management does not apply. Shown as a "Host Managed Plan" or
+	 * an "Agency Managed Plan" depending on `partner_type`.
+	 *
+	 * A4A subscriptions bought through the store carry partner details (see
+	 * `partner_name`) but are billed here, so this is false for them.
+	 */
+	is_partner_managed: boolean;
+
+	/**
+	 * True for the `is_partner_managed` subscriptions a hosting partner rather
+	 * than an agency provisioned. `is_cancelable` and `is_removable` are false
+	 * for these, since cancelling has to happen at the host; agency-provisioned
+	 * plans are bought through WordPress.com and can still be cancelled here.
+	 */
+	is_host_managed: boolean;
+
 	partner_name: string | undefined;
 	partner_slug: string | undefined;
 	partner_type: string | undefined;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2289/

## Proposed Changes

This removes subscription management actions (auto-renew, upgrade, cancel, remove, etc.) for partner-provisioned (Jetpack Start) subscriptions. Instead, the subscriptions include a notice that asks the user to manage their purchase through the hosting partner. A4A subscriptions purchased and managed through Store are still able to be managed. 

| Before | After |
| ----------- | ----------- |
| <img width="1460" height="1778" alt="CleanShot 2026-07-31 at 13 39 25@2x" src="https://github.com/user-attachments/assets/0524d777-4d4f-4c2a-bb84-e6fd83c1ee23" />  | <img width="1444" height="1766" alt="CleanShot 2026-07-31 at 13 39 04@2x" src="https://github.com/user-attachments/assets/5c5bd4a2-0edc-42a7-aa3e-adcb7240324a" /> |

Three predicates now live in `client/dashboard/utils/purchase.ts`, imported into Calypso where the raw shape is already in use:

* `isPartnerPurchase` — any `partner_name`.
* `isPartnerManagedPurchase` — partner, excluding A4A Billing Dragon. Gates upgrade and payment.
* `isHostManagedPurchase` — also excludes agency partner types. Gates cancel/remove.

The renewal action was solved with a backend patch to `can_explicit_renew` in https://linear.app/a8c/issue/SHILL-2311/

## Why are these changes being made?

The Dashboard intentionally relies only on endpoint response values, whereas Calypso layers explicit `isPartnerPurchase` checks on top of the API flags, in roughly ten places, always shaped `isPartnerPurchase( purchase ) && ! isA4ABillingDragonPurchase( purchase )`. The Dashboard trusts `is_upgradable` / `is_rechargeable` alone. Since the backend reports those as true for host-managed plans, every action rendered. When purchase management was ported to the Dashboard, those overrides were missed.

## Testing Instructions

TC:

```
yarn test-client client/lib/purchases client/me/purchases client/dashboard/me/billing-purchases client/dashboard/utils
```

24 new tests: Dashboard action gating and notice rendering, the three predicates (including "partner name but no partner type", which the old narrowing lied about), and full-page classic renders in `purchase-management-buttons.js` / `notices.js`.

Manual testing — needs a user with a partner-provisioned Jetpack plan (see the ticket for a store-admin lookup):

* Open a Jetpack Start subscription management page.
* Confirm: an info notice reading "Host Managed Plan. Please contact <Partner> for details.", the sub-header reading just "Host Managed Plan", and **no** Upgrade / Renew / Add payment method / Cancel / Manage subscription card.
* Confirm no empty card shells are left behind where the action list used to be.
* Visit the cancel URL directly (`/me/purchases/<site>/<id>/cancel`) — it should redirect back with a snackbar naming the partner.