### PR TITLE
Jetpack AI sidebar: add Generate image and Edit image suggestions

### DIFF
--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -47,6 +47,7 @@ import {
 	BLOCK_ACTION_COMPLETE_EVENT,
 	SELECTED_BLOCK_CLEAR_EVENT,
 } from './utils/block-actions';
+import { isImageStudioAvailable, openImageStudioForBlock } from './utils/image-studio';
 import {
 	isAiEditorialReviewEnabled,
 	isBlockTransformationsEnabled,
@@ -936,6 +937,9 @@ type BlockSuggestion = {
 	type: BlockTransformationSuggestionType;
 	condition: ( block: any ) => boolean;
 	options?: SuggestionOption[];
+	// Runs on click instead of sending the prompt. AgentUI submits the prompt
+	// only when this resolves true, so returning false keeps the chat untouched.
+	action?: () => boolean | Promise< boolean >;
 };
 
 /** Change-tone dropdown options; `value` is the full localized prompt filled on selection. */
@@ -1096,6 +1100,24 @@ const BLOCK_SUGGESTIONS: BlockSuggestion[] = [
 		type: 'image',
 		condition: ( block: any ) => IMAGE_BLOCK_TYPES.includes( block?.name ),
 	},
+	{
+		id: 'generate-image',
+		label: __( 'Generate image', __i18n_text_domain__ ),
+		// Empty prompt — opening Image Studio replaces sending anything to the agent.
+		prompt: '',
+		type: 'image',
+		condition: ( block: any ) => block?.name === 'core/image' && isImageStudioAvailable(),
+		action: () => ! openImageStudioForBlock( getSelectedOrRememberedBlock(), 'generate' ),
+	},
+	{
+		id: 'edit-image',
+		label: __( 'Edit image', __i18n_text_domain__ ),
+		prompt: '',
+		type: 'image',
+		condition: ( block: any ) =>
+			block?.name === 'core/image' && !! block?.attributes?.id && isImageStudioAvailable(),
+		action: () => ! openImageStudioForBlock( getSelectedOrRememberedBlock(), 'edit' ),
+	},
 ];
 
 function trackRenderedBlockTransformationSuggestions(
@@ -1151,6 +1173,7 @@ export function useSuggestions(
 		description?: string;
 		prompt?: string;
 		options?: SuggestionOption[];
+		action?: () => boolean | Promise< boolean >;
 	} >;
 	replaceEmptyViewSuggestions: boolean;
 } {
@@ -1253,7 +1276,13 @@ export function useSuggestions(
 	);
 	const blockTransformationSuggestions = useMemo(
 		() =>
-			applicable.map( ( { id, label, prompt, options } ) => ( { id, label, prompt, options } ) ),
+			applicable.map( ( { id, label, prompt, options, action } ) => ( {
+				id,
+				label,
+				prompt,
+				options,
+				action,
+			} ) ),
 		[ applicable ]
 	);
 	// Editor-level reviews (Optimize Title, Generate Feedback, AI Editorial Review)
@@ -1269,6 +1298,7 @@ export function useSuggestions(
 			label: string;
 			prompt: string;
 			options?: SuggestionOption[];
+			action?: () => boolean | Promise< boolean >;
 		} > = selectedBlock ? blockTransformationSuggestions : postLevelSuggestions;
 		return applySuggestionLimit( activeSuggestions, maxSuggestions );
 	}, [

--- a/packages/jetpack-ai-sidebar/src/utils/image-studio.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/image-studio.test.ts
@@ -1,0 +1,126 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { dispatch } from '@wordpress/data';
+import { isImageStudioAvailable, openImageStudioForBlock } from './image-studio';
+
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	store: 'core/block-editor',
+} ) );
+
+const mockDispatch = dispatch as unknown as jest.Mock;
+
+const openImageStudio = jest.fn();
+const updateBlockAttributes = jest.fn();
+
+// Routes the two stores this module dispatches to. An Image Studio bundle that
+// is not loaded leaves the store registered but without openImageStudio.
+function stubStores( { imageStudioRegistered = true } = {} ) {
+	mockDispatch.mockImplementation( ( storeRef: string ) => {
+		if ( storeRef === 'image-studio' ) {
+			return imageStudioRegistered ? { openImageStudio } : {};
+		}
+		if ( storeRef === 'core/block-editor' ) {
+			return { updateBlockAttributes };
+		}
+		return undefined;
+	} );
+}
+
+const imageBlock = {
+	clientId: 'abc123',
+	name: 'core/image',
+	attributes: { id: 42 },
+};
+
+describe( 'isImageStudioAvailable', () => {
+	beforeEach( () => jest.clearAllMocks() );
+
+	it( 'is true when the store exposes openImageStudio', () => {
+		stubStores();
+		expect( isImageStudioAvailable() ).toBe( true );
+	} );
+
+	it( 'is false when the Image Studio bundle is not loaded', () => {
+		stubStores( { imageStudioRegistered: false } );
+		expect( isImageStudioAvailable() ).toBe( false );
+	} );
+} );
+
+describe( 'openImageStudioForBlock', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		stubStores();
+	} );
+
+	it( 'passes the attachment id in edit mode', () => {
+		expect( openImageStudioForBlock( imageBlock, 'edit' ) ).toBe( true );
+		expect( openImageStudio ).toHaveBeenCalledWith(
+			42,
+			expect.any( Function ),
+			'editor_sidebar',
+			'core/image'
+		);
+	} );
+
+	it( 'omits the attachment id in generate mode so a new image is created', () => {
+		openImageStudioForBlock( imageBlock, 'generate' );
+		expect( openImageStudio ).toHaveBeenCalledWith(
+			undefined,
+			expect.any( Function ),
+			'editor_sidebar',
+			'core/image'
+		);
+	} );
+
+	it( 'does not open when the Image Studio bundle is not loaded', () => {
+		stubStores( { imageStudioRegistered: false } );
+		expect( openImageStudioForBlock( imageBlock, 'edit' ) ).toBe( false );
+		expect( openImageStudio ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not open for a block without a clientId', () => {
+		expect( openImageStudioForBlock( { name: 'core/image' }, 'edit' ) ).toBe( false );
+		expect( openImageStudio ).not.toHaveBeenCalled();
+	} );
+
+	it( 'writes the returned image back to the block on close', () => {
+		openImageStudioForBlock( imageBlock, 'edit' );
+		const onClose = openImageStudio.mock.calls[ 0 ][ 1 ];
+
+		onClose( { id: 99, url: 'https://example.com/new.jpg', alt: 'A cat' } );
+
+		expect( updateBlockAttributes ).toHaveBeenCalledWith( 'abc123', {
+			url: 'https://example.com/new.jpg',
+			id: 99,
+			alt: 'A cat',
+		} );
+	} );
+
+	it( 'clears the block attributes when the image is removed', () => {
+		openImageStudioForBlock( imageBlock, 'edit' );
+		const onClose = openImageStudio.mock.calls[ 0 ][ 1 ];
+
+		onClose( null );
+
+		expect( updateBlockAttributes ).toHaveBeenCalledWith( 'abc123', {
+			url: undefined,
+			id: undefined,
+			alt: '',
+			title: '',
+			caption: '',
+		} );
+	} );
+
+	it( 'leaves the block untouched when closed without an image', () => {
+		openImageStudioForBlock( imageBlock, 'edit' );
+		const onClose = openImageStudio.mock.calls[ 0 ][ 1 ];
+
+		onClose( undefined );
+
+		expect( updateBlockAttributes ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/jetpack-ai-sidebar/src/utils/image-studio.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/image-studio.ts
@@ -1,0 +1,98 @@
+/**
+ * Opens Image Studio from sidebar suggestions.
+ *
+ * Image Studio ships as its own bundle and registers an `image-studio` store on
+ * wp.data. It is loaded independently of this sidebar via the
+ * `agents_manager_agent_providers` PHP filter, so it may or may not be present
+ * at runtime. Reaching it through a store lookup rather than importing
+ * `@automattic/image-studio` keeps its UI out of this bundle and avoids a second
+ * registration of its store.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { dispatch } from '@wordpress/data';
+
+const IMAGE_STUDIO_STORE = 'image-studio';
+
+/** Mirrors ImageStudioEntryPoint.EditorSidebar, duplicated to avoid a package dependency. */
+const EDITOR_SIDEBAR_ENTRY_POINT = 'editor_sidebar';
+
+export type ImageStudioMode = 'edit' | 'generate';
+
+/** The subset of the Image Studio image payload written back to the block. */
+interface ImageStudioImage {
+	id: number;
+	url: string;
+	alt: string;
+}
+
+interface ImageStudioActions {
+	openImageStudio: (
+		attachmentId: number | undefined,
+		onClose: ( image: ImageStudioImage | null ) => void,
+		entryPoint: string,
+		blockType?: string | null
+	) => void;
+}
+
+function getImageStudioActions(): ImageStudioActions | undefined {
+	const actions = dispatch( IMAGE_STUDIO_STORE ) as Partial< ImageStudioActions > | undefined;
+
+	return typeof actions?.openImageStudio === 'function'
+		? ( actions as ImageStudioActions )
+		: undefined;
+}
+
+export function isImageStudioAvailable(): boolean {
+	return !! getImageStudioActions();
+}
+
+/**
+ * Opens Image Studio for a block, writing the resulting image back on close.
+ * @param block - The selected block.
+ * @param mode  - Whether to edit the block's existing image or generate a new one.
+ * @returns Whether Image Studio was opened.
+ */
+export function openImageStudioForBlock( block: any, mode: ImageStudioMode ): boolean {
+	const imageStudioActions = getImageStudioActions();
+
+	if ( ! imageStudioActions || ! block?.clientId ) {
+		return false;
+	}
+
+	const { clientId } = block;
+	const attachmentId = block.attributes?.id;
+
+	const handleClose = ( image: ImageStudioImage | null ) => {
+		// A null image means the user removed it.
+		if ( image === null ) {
+			dispatch( blockEditorStore ).updateBlockAttributes( clientId, {
+				url: undefined,
+				id: undefined,
+				alt: '',
+				title: '',
+				caption: '',
+			} );
+			return;
+		}
+
+		if ( image?.id ) {
+			dispatch( blockEditorStore ).updateBlockAttributes( clientId, {
+				url: image.url,
+				id: image.id,
+				alt: image.alt,
+			} );
+		}
+	};
+
+	imageStudioActions.openImageStudio(
+		mode === 'edit' ? attachmentId : undefined,
+		handleClose,
+		EDITOR_SIDEBAR_ENTRY_POINT,
+		block.name
+	);
+
+	return true;
+}


### PR DESCRIPTION
Relates to FORNO-234

## Proposed Changes

* Add Generate image and Edit image suggestions to the Jetpack AI sidebar, shown when a `core/image` block is selected. Both open Image Studio instead of sending a prompt to the agent.
* Add `utils/image-studio.ts`, which reaches Image Studio through its `image-studio` wp.data store and writes the resulting image back to the block on close.

## Why are these changes being made?

* These suggestions used to live in the Big Sky plugin back when it bundled Image Studio. Image Studio now ships from `packages/image-studio` in this repo, so the suggestions that open it belong next to it. A matching Big Sky change hides its own image suggestions when this sidebar is enabled, the same way it already defers translate, change tone and check grammar.

## Testing Instructions

Needs an environment with both the Jetpack AI sidebar and Image Studio loaded.

- Checkout PR
- `cd apps/agents-manager && yarn dev --sync`
- Sandbox `widgets.wp.com`
- Open the post editor and select an image block that already has an image.
- Confirm Generate image and Edit image suggestions appear alongside Generate alt text
- Click Edit image. Image Studio should open on that attachment, and nothing should be sent to the chat.
- Change the image, save and close. The block should pick up the new url, id and alt text.
- Click Generate image. Image Studio should open with no attachment, ready to generate a new one.
- Select an image block with no image yet. Edit image should be hidden, Generate image should still show.
- Select a paragraph block. Neither suggestion should appear.


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
