### PR TITLE
Jetpack AI: remove the selected-block request marker

### DIFF
--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -2838,19 +2838,18 @@ describe( 'contextProvider', () => {
 		const proofreadContext = contextProvider.getClientContext();
 		expect( proofreadContext.currentPageContent ).toEqual( [] );
 		expect( proofreadContext.jetpackAi ).toBeUndefined();
-		expect( proofreadContext.jetpackAIRequestScope ).toBeUndefined();
 		expect( contextProvider.getClientContext().currentPageContent ).toHaveLength( 1 );
 		expect( contextProvider.getClientContext().jetpackAi ).toBeUndefined();
 	} );
 
-	it( 'scopes only the next block suggestion request to the selected block', () => {
+	it( 'keeps the selected block context available after a block suggestion click', () => {
 		installAiEditorialReviewData();
-		installContextProviderMock();
 		mockSelectedBlock = {
 			clientId: 'selected-block',
 			name: 'core/paragraph',
 			attributes: { content: 'Selected paragraph' },
 		};
+		installPostTypeMock( 'post' );
 
 		render( React.createElement( SuggestionsProbe, { onSuggestions: jest.fn() } ) );
 
@@ -2862,8 +2861,13 @@ describe( 'contextProvider', () => {
 			);
 		} );
 
-		expect( contextProvider.getClientContext().jetpackAIRequestScope ).toBe( 'selected-block' );
-		expect( contextProvider.getClientContext().jetpackAIRequestScope ).toBeUndefined();
+		const context = contextProvider.getClientContext();
+		expect( context.selectedBlockClientId ).toBe( 'selected-block' );
+		expect( context.contextEntries ).toContainEqual( {
+			id: 'selected-block-content',
+			type: 'selected-block-content',
+			data: { content: 'Selected paragraph' },
+		} );
 	} );
 
 	it( 'clears pending Simple Review content suppression when another suggestion is clicked', () => {

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -80,7 +80,6 @@ let wasAgentProcessing = false;
 let pendingBlockShimmerClientId: string | null = null;
 let blockShimmerStartedForRequest = false;
 let suppressCurrentPageContentForNextContext = false;
-let jetpackAIRequestScopeForNextContext: 'selected-block' | null = null;
 
 /** Whether `_suggestion_rendered` has fired this page life (once-per-session). */
 let suggestionRenderedFiredOnce = false;
@@ -757,9 +756,7 @@ export const contextProvider = {
 		let selectedBlockContent = '';
 		let currentPostType: string | undefined;
 		const suppressCurrentPageContent = suppressCurrentPageContentForNextContext;
-		const jetpackAIRequestScope = jetpackAIRequestScopeForNextContext;
 		suppressCurrentPageContentForNextContext = false;
-		jetpackAIRequestScopeForNextContext = null;
 
 		if ( wpData ) {
 			const editor = wpData.select( 'core/editor' );
@@ -792,7 +789,6 @@ export const contextProvider = {
 			},
 			currentPageContent,
 			selectedBlockClientId,
-			...( jetpackAIRequestScope && { jetpackAIRequestScope } ),
 			// Forward the host's SEO Enhancer verdict (plan + Jetpack SEO Tools
 			// module + kill switches) so the orchestrator can drop the SEO
 			// suggestion abilities when they aren't usable on this site — e.g. a
@@ -1173,11 +1169,6 @@ export function useSuggestions(
 			pendingBlockShimmerClientId = BLOCK_SUGGESTIONS.some( matchesSuggestion )
 				? getSelectedOrRememberedBlock()?.clientId ?? null
 				: null;
-			jetpackAIRequestScopeForNextContext = null;
-
-			if ( BLOCK_SUGGESTIONS.some( matchesSuggestion ) ) {
-				jetpackAIRequestScopeForNextContext = 'selected-block';
-			}
 
 			if ( matchesSuggestion( POST_FEEDBACK_SUGGESTION ) ) {
 				suppressCurrentPageContentForNextContext = true;


### PR DESCRIPTION
Follow-up to #112853.

## Proposed Changes

* Stop sending the one-shot `jetpackAIRequestScope` field after a block suggestion click.
* Keep `selectedBlockClientId` and the selected block content as the routing context.
* Update the suggestion-click test to verify that the selected block context remains available.

## Why are these changes being made?

The selected block already gives the orchestrator the context it needs for both suggestion clicks and manually typed requests. Removing the extra marker gives both paths the same routing behavior and avoids keeping duplicate request-scope state in the sidebar.

## Testing Instructions

Requires WPCOM PR 231102
1. Open a post with at least two paragraph blocks and select one paragraph.
2. Click the **Check grammar** suggestion.
3. Confirm only the selected block is updated.
4. Undo the change and keep the same block selected.
5. Type **Check grammar** in the sidebar.
6. Confirm only the selected block is updated.
7. With the block still selected, explicitly ask to check the grammar of the whole post.
8. Confirm the whole-post request still uses the whole post.

Automated checks run:

* `yarn jest -c test/packages/jest.config.js --runTestsByPath packages/jetpack-ai-sidebar/src/index.test.ts --runInBand` — 192 tests passed.
* `yarn workspace @automattic/jetpack-ai-sidebar typecheck` — passed.
* ESLint on both changed files — passed.
* Prettier check on both changed files — passed.

The repository-wide `yarn typecheck-packages` command still reports existing errors in `packages/api-queries` and `packages/sites`; none are in this package or changed by this PR.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md), [Using memoizing selectors](https://react-redux.js.org/api/hooks), and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
