### PR TITLE
Stats: fix mobile breadcrumb overlap on details pages

### DIFF
--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -157,13 +157,21 @@ $font-sf-pro-display: "SF Pro Display", $sans;
 		}
 
 		// Each crumb (separator + label) wraps in a span that is the actual
-		// flex item; without min-width: 0 on it, the label inside can never
-		// shrink and the ellipsis rules below have no effect.
+		// flex item. Intermediate crumbs must not shrink: their content
+		// (separator and link) is flex-shrink: 0, so a shrinking wrapper just
+		// overflows and the label paints over the next crumb. Only the last
+		// crumb — the current page — shrinks, so its min-width: 0 lets the
+		// label's ellipsis rules below take effect.
 		.stats-breadcrumbs__item {
 			display: inline-flex;
 			align-items: center;
 			gap: 8px;
-			min-width: 0;
+			flex-shrink: 0;
+
+			&:last-child {
+				flex-shrink: 1;
+				min-width: 0;
+			}
 		}
 
 		.stats-breadcrumbs__link {


### PR DESCRIPTION
Fixes STATS-381

## Proposed Changes

* On narrow viewports, the breadcrumb on Stats **details** pages (video details, post details, …) rendered overlapping text: the trailing letters of an intermediate crumb (e.g. *Videos*) painted over the next `/` separator, and the crumb ran into the page title with no spacing.
* Root cause: every `.stats-breadcrumbs__item` wrapper had `min-width: 0` with the default `flex-shrink: 1`, while its content (separator and link) is `flex-shrink: 0`. Under shrink pressure the wrapper compressed below its content width and, with no `overflow: hidden`, the label visually overflowed onto the following crumb.
* Fix: pin intermediate crumbs to their natural width (`flex-shrink: 0`) and let only the **last** crumb — the current page — shrink (`flex-shrink: 1; min-width: 0`), where the existing `text-overflow: ellipsis` rules on `.stats-breadcrumbs__current` take effect.
* One shared stylesheet rule, so the fix covers every details page rendered through `StatsMain` breadcrumbs.

## Why are these changes being made?

* The breadcrumb was unreadable on mobile: items collided instead of spacing, truncating, or wrapping cleanly (see STATS-381 for an iPhone 12 Pro screenshot). Expected behavior — stable separators and spacing, with the current page title ellipsizing gracefully — is exactly what the `min-width: 0` on the last crumb was meant to deliver; it was just applied to every crumb.

## Testing Instructions

1. Open Odyssey Stats (or Calypso stats) on a mobile viewport (e.g. iPhone 12 Pro in DevTools).
2. Navigate to a video details page (Stats → Videos → click a video) with a long video title.
3. Verify the breadcrumb reads `Stats / Videos / <title>` with consistent separators and spacing — no overlapping glyphs — and the title ellipsizes.
4. Repeat on a post details page (Stats → Posts & pages → click a post) — same behavior.
5. Verify wide viewports are unchanged.

No unit tests: the bug lives in CSS flex behavior, which Jest/jsdom doesn't apply — verification is visual (see screenshots).

### Screenshots
|Before|After|
|-|-|
|<img width="221" height="90" alt="截圖 2026-07-29 上午10 56 42" src="https://github.com/user-attachments/assets/9a3a9fcf-595f-4481-9b7d-447f2d2e3511" />|<img width="224" height="86" alt="截圖 2026-07-29 上午10 56 27" src="https://github.com/user-attachments/assets/7d14773d-759f-4260-8502-095988d3dd7b" />|

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

