### PR TITLE
Stats: clamp detail-page chart ranges to the site's today

### DIFF
--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -231,11 +231,16 @@ class StatsPostSummary extends Component {
 		// the current, in-progress period (e.g. this month before it ends).
 		// "Today" is the site's, not the viewer's — the bars are site-local
 		// days, so a viewer behind the site's timezone must not clamp the
-		// range a day short (or vice versa). Comparing date keys sidesteps
-		// mixed-zone moment math; callers only format() the result.
-		const siteToday = this.props.momentSiteZone();
-		if ( end.format( 'YYYY-MM-DD' ) > siteToday.format( 'YYYY-MM-DD' ) ) {
-			end = siteToday;
+		// range a day short (or vice versa). But never clamp below the newest
+		// bucket actually charted: after a timezone change the data can hold
+		// buckets past the site's current clock, and the header must still
+		// cover the bars it labels. Comparing date keys sidesteps mixed-zone
+		// moment math; callers only format() the result.
+		const siteTodayKey = this.props.momentSiteZone().format( 'YYYY-MM-DD' );
+		const newestBucketKey = chartData[ chartData.length - 1 ].startDate;
+		const clampKey = siteTodayKey > newestBucketKey ? siteTodayKey : newestBucketKey;
+		if ( end.format( 'YYYY-MM-DD' ) > clampKey ) {
+			end = moment( clampKey );
 		}
 
 		return { start, end };

--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -179,15 +179,17 @@ class StatsPostSummary extends Component {
 				// months before the post was published. Drop both rather than
 				// paginating into fake empty bars; post-publish months with
 				// zero views are kept, consistent with Days/Weeks paging.
-				const today = moment();
-				// The month buckets are site-local, so the publish boundary is
-				// resolved in the site's timezone too (see getPublishMonthKey);
-				// comparing YYYY-MM keys keeps the trim independent of the
-				// viewer's zone.
+				// The month buckets are site-local, so both boundaries resolve
+				// in the site's timezone: the current month from the site's
+				// "now" (a viewer a day behind the site must not hide the
+				// site's current month) and the publish boundary via
+				// getPublishMonthKey. Comparing YYYY-MM keys keeps the trim
+				// independent of the viewer's zone.
+				const currentMonth = this.props.momentSiteZone().format( 'YYYY-MM' );
 				const publishMonth = getPublishMonthKey( stats.post, this.props.momentSiteZone );
 				return [ ...statsByMonth( stats, moment ) ].filter(
 					( record ) =>
-						moment( record.startDate ).isSameOrBefore( today, 'month' ) &&
+						record.startDate.slice( 0, 7 ) <= currentMonth &&
 						( ! publishMonth || record.startDate.slice( 0, 7 ) >= publishMonth )
 				);
 			}
@@ -227,9 +229,13 @@ class StatsPostSummary extends Component {
 
 		// Don't extend the range into the future when the last bar is still
 		// the current, in-progress period (e.g. this month before it ends).
-		const today = moment();
-		if ( end.isAfter( today, 'day' ) ) {
-			end = today;
+		// "Today" is the site's, not the viewer's — the bars are site-local
+		// days, so a viewer behind the site's timezone must not clamp the
+		// range a day short (or vice versa). Comparing date keys sidesteps
+		// mixed-zone moment math; callers only format() the result.
+		const siteToday = this.props.momentSiteZone();
+		if ( end.format( 'YYYY-MM-DD' ) > siteToday.format( 'YYYY-MM-DD' ) ) {
+			end = siteToday;
 		}
 
 		return { start, end };

--- a/client/my-sites/stats/stats-video-detail/video-summary.tsx
+++ b/client/my-sites/stats/stats-video-detail/video-summary.tsx
@@ -12,6 +12,7 @@ import {
 } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { STATS_SUMMARY_MAX_BARS } from '../constants';
+import { useMomentInSite } from '../hooks/use-moment-site-zone';
 import DatePicker from '../stats-date-label';
 import StatsPeriodHeader from '../stats-period-header';
 import StatsPeriodNavigation from '../stats-period-navigation';
@@ -75,6 +76,7 @@ export default function VideoSummary( {
 } ) {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
+	const momentSiteZone = useMomentInSite();
 	const siteId = useSelector( getSelectedSiteId );
 	const [ uiPeriod, setUiPeriod ] = useState< UiPeriod >( 'day' );
 	const [ page, setPage ] = useState( 1 );
@@ -197,17 +199,18 @@ export default function VideoSummary( {
 		}
 
 		// Don't extend the range into the future when the last bucket is
-		// still the current, in-progress period.
-		const today = moment();
-		if ( end.isAfter( today, 'day' ) ) {
-			end = today;
-		}
+		// still the current, in-progress period. "Today" is the site's, not
+		// the viewer's: the buckets are site-local, so a viewer behind the
+		// site's timezone must not clamp the header a day short (or vice
+		// versa). Comparing date keys sidesteps mixed-zone moment math.
+		const siteToday = momentSiteZone().format( 'YYYY-MM-DD' );
+		const chartEnd = end.format( 'YYYY-MM-DD' );
 
 		return {
 			chartStart: start.format( 'YYYY-MM-DD' ),
-			chartEnd: end.format( 'YYYY-MM-DD' ),
+			chartEnd: chartEnd > siteToday ? siteToday : chartEnd,
 		};
-	}, [ visibleRows, uiPeriod, moment ] );
+	}, [ visibleRows, uiPeriod, moment, momentSiteZone ] );
 
 	// Card totals cover the window shown in the chart (the current page).
 	// Retention is play-weighted rather than summed — see retention.ts.

--- a/client/my-sites/stats/stats-video-detail/video-summary.tsx
+++ b/client/my-sites/stats/stats-video-detail/video-summary.tsx
@@ -202,13 +202,18 @@ export default function VideoSummary( {
 		// still the current, in-progress period. "Today" is the site's, not
 		// the viewer's: the buckets are site-local, so a viewer behind the
 		// site's timezone must not clamp the header a day short (or vice
-		// versa). Comparing date keys sidesteps mixed-zone moment math.
+		// versa). But never clamp below the newest bucket actually charted:
+		// after a timezone change the data can hold buckets past the site's
+		// current clock, and the header must still cover the bars it labels.
+		// Comparing date keys sidesteps mixed-zone moment math.
 		const siteToday = momentSiteZone().format( 'YYYY-MM-DD' );
+		const newestBucket = visibleRows[ visibleRows.length - 1 ].period;
+		const clampKey = siteToday > newestBucket ? siteToday : newestBucket;
 		const chartEnd = end.format( 'YYYY-MM-DD' );
 
 		return {
 			chartStart: start.format( 'YYYY-MM-DD' ),
-			chartEnd: chartEnd > siteToday ? siteToday : chartEnd,
+			chartEnd: chartEnd > clampKey ? clampKey : chartEnd,
 		};
 	}, [ visibleRows, uiPeriod, moment, momentSiteZone ] );
 


### PR DESCRIPTION
Fixes STATS-382 (follow-up flagged during #112969 review)

## Proposed Changes

* The Post Details and Video Details charts clamped their header date range ("don't extend into the future") — and the Post Details **Months** tab filtered out future months — against the **viewer's** `moment()`, while the stats buckets they label are **site-local**. When the viewer and the site sit on different sides of a date boundary, the header could clamp a day short of the site's newest bucket, and the Months tab could hide (or show) the site's current month incorrectly.
* Resolve "today" through the existing site-timezone moment factory (`useMomentInSite()` in `VideoSummary`, the `momentSiteZone` prop already injected into `StatsPostSummary` by #112574) and compare plain `YYYY-MM-DD` / `YYYY-MM` keys instead of mixed-zone moment comparisons.
* The clamp is **floored at the newest charted bucket**: after a site timezone change, the data can legitimately hold buckets past the site's current clock (views bucketed under the old offset). The header always covers the bars on screen — the clamp only trims period-end extension (end of week/month/year), never real bars.
* Bucket **label formatting** is untouched: bucket periods are naive site-local date strings, which render the same wall date in any zone. Only the "today" comparisons were viewer-dependent.
* The publish-date trims are already site-correct (#112574 for Post Details; Video Details windows server-side since #112969) — this PR covers the remaining viewer-local date logic those left behind.

## Why are these changes being made?

* Same class of bug as the publish-month timezone issue fixed in #112574, in the neighboring code paths: site-local data judged against viewer-local "now". Flagged as a non-blocking follow-up during the #112969 review; STATS-382 tracks it.

## Testing Instructions

1. Set your OS/browser timezone far from the site's (e.g. viewer UTC-10, site UTC+2 — or use a UTC+14 test site).
2. Open Stats → Posts & pages → a post's details around the site's midnight (when the site's date is ahead of yours):
   * The header range on the newest page ends on the **site's** today, not a day short.
   * The Months tab still shows the site's current month.
3. Open a video's details page (Stats → Videos → click a video): same header-range behavior on the newest page.
4. Timezone-change artifact: right after switching the site to a timezone behind the old one, the Days tab may chart a bucket dated past the site's new "today" — the header still ends on that bar (never before a charted bar), while Weeks/Months/Years headers end on the site's today.
5. With viewer and site in the same timezone, verify nothing changes on either page.
6. `yarn test-client client/my-sites/stats/stats-video-detail/test/ client/my-sites/stats/stats-post-summary/test/` — 14 tests green.

No new unit tests: the changed comparisons are now plain string-key comparisons against the site-zone factory, whose zone behavior is already covered by `publish-month.js` tests from #112574; the remaining logic has no branches beyond the clamp itself.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

