### PR TITLE
Image Studio: Adopt unified AI Tracks property names

### DIFF
--- a/packages/image-studio/src/index.tsx
+++ b/packages/image-studio/src/index.tsx
@@ -31,6 +31,8 @@ interface ImageStudioData {
 	blogId?: number | string;
 	siteType?: 'simple' | 'atomic' | 'jetpack' | 'wpcom' | 'woa';
 	isA11n?: boolean;
+	// Reported as `agent_version` on Tracks events.
+	version?: string;
 }
 
 declare global {

--- a/packages/image-studio/src/utils/tracking.test.ts
+++ b/packages/image-studio/src/utils/tracking.test.ts
@@ -281,6 +281,68 @@ describe( 'recordImageStudioEvent — is_test property', () => {
 	} );
 } );
 
+describe( 'recordImageStudioEvent — unified AI property standards', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		selectMock.mockReturnValue( {
+			getEntryPoint: jest.fn( () => null ),
+		} );
+		delete ( window as any ).imageStudioData;
+	} );
+
+	afterEach( () => {
+		delete ( window as any ).imageStudioData;
+	} );
+
+	it( 'should identify the product with agent_name', () => {
+		trackImageStudioClosed( { mode: 'edit' } );
+
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_closed',
+			expect.objectContaining( { agent_name: 'image_studio' } )
+		);
+	} );
+
+	it( 'should send the session under both ai_session_id and sessionid', () => {
+		trackImageStudioClosed( { mode: 'edit' } );
+
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_closed',
+			expect.objectContaining( {
+				ai_session_id: 'test-session-id',
+				sessionid: 'test-session-id',
+			} )
+		);
+	} );
+
+	it( 'should include agent_version from imageStudioData', () => {
+		( window as any ).imageStudioData = { version: '15.9' };
+
+		trackImageStudioClosed( { mode: 'edit' } );
+
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_closed',
+			expect.objectContaining( { agent_version: '15.9' } )
+		);
+	} );
+
+	it( 'should send agent_version as none rather than omitting it when unavailable', () => {
+		trackImageStudioClosed( { mode: 'edit' } );
+
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_closed',
+			expect.objectContaining( { agent_version: 'none' } )
+		);
+	} );
+
+	it( 'should let a caller-supplied property win over the defaults', () => {
+		trackImageStudioClosed( { mode: 'edit' } );
+
+		const call = recordTracksEventMock.mock.calls[ 0 ];
+		expect( call[ 1 ] ).toMatchObject( { mode: 'edit' } );
+	} );
+} );
+
 describe( 'reel share tracking helpers', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();

--- a/packages/image-studio/src/utils/tracking.ts
+++ b/packages/image-studio/src/utils/tracking.ts
@@ -23,6 +23,7 @@ type ImageStudioTrackingData = {
 	siteType?: string;
 	isA11n?: boolean;
 	isDevMode?: boolean;
+	version?: string;
 };
 
 /**
@@ -112,9 +113,15 @@ function recordImageStudioEvent(
 	const blogId = getTrackingBlogId();
 	const siteType = getTrackingSiteType();
 	const imageStudioWindowData = getImageStudioWindowData();
+	const sessionId = getSessionId();
 	const baseProps: Record< string, string | number | boolean > = {
 		...properties,
-		sessionid: getSessionId(),
+		agent_name: 'image_studio',
+		// The standard prefers the string `none` over a missing value.
+		agent_version: imageStudioWindowData?.version || 'none',
+		ai_session_id: sessionId,
+		// The standard name is `ai_session_id`. Keep `sessionid` as well for backwards compatibility
+		sessionid: sessionId,
 	};
 
 	if ( blogId ) {


### PR DESCRIPTION
Part of FORNO-327

## Proposed Changes

* Add `agent_name` and `agent_version` to the Image Studio Tracks wrapper.
* Emit the session as `ai_session_id`, keeping `sessionid` for backwards compatibility.

## Why are these changes being made?

* Brings Image Studio in line with the Tracks standard for AI product events, so its data can be compared with the other AI products.

## Testing Instructions

* Checkout PR
* `cd apps/agents-manager && yarn dev --sync`
* Sandbox `widgets.wp.com`
* In your browser console run `localStorage.debug = 'calypso:analytics*'`
* Open Image Studio, and confirm every `jetpack_big_sky_image_studio_*` event carries `agent_name`, `agent_version`, `ai_session_id` and `sessionid`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?