### PR TITLE
(fix) Image Studio: ensure placement field is sent on all Feature Clip events

### DIFF
--- a/packages/image-studio/src/utils/tracking.test.ts
+++ b/packages/image-studio/src/utils/tracking.test.ts
@@ -496,6 +496,26 @@ describe( 'feature clip tracking helpers', () => {
 		} );
 	} );
 
+	it( 'pins the Feature Clip placement even against a caller-supplied one', () => {
+		// The wrapper's guarantee is that these events are always attributable to
+		// the Feature Clip flow, so a placement passed by a call site must not be
+		// able to weaken it.
+		selectMock.mockReturnValue( {
+			getEntryPoint: jest.fn( () => null ),
+		} );
+
+		trackImageStudioGenericShareClicked( {
+			surface: 'sidebar',
+			method: 'web-share',
+			placement: ImageStudioEntryPoint.MediaLibrary,
+		} as Parameters< typeof trackImageStudioGenericShareClicked >[ 0 ] );
+
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_feature_clip_generic_share_clicked',
+			expect.objectContaining( { placement: 'post_editor_feature_clip' } )
+		);
+	} );
+
 	it( 'keeps surface distinct from placement on Feature Clip events', () => {
 		// `surface` says where inside the feature ('sidebar' / 'modal'); `placement`
 		// says which entry point the flow came from. They are different properties

--- a/packages/image-studio/src/utils/tracking.test.ts
+++ b/packages/image-studio/src/utils/tracking.test.ts
@@ -441,4 +441,35 @@ describe( 'feature clip tracking helpers', () => {
 			expect.objectContaining( { sessionid: 'test-session-id' } )
 		);
 	} );
+
+	it( 'sends placement on feature_clip_panel_viewed when the store has no entry point', () => {
+		// The panel mounts with the editor sidebar, before anything has opened
+		// Image Studio, so the store cannot supply the placement here.
+		selectMock.mockReturnValue( {
+			getEntryPoint: jest.fn( () => null ),
+		} );
+
+		trackImageStudioFeatureClipPanelViewed();
+
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_feature_clip_panel_viewed',
+			expect.objectContaining( { placement: 'post_editor_feature_clip' } )
+		);
+	} );
+
+	it( 'keeps its own placement on feature_clip_panel_viewed when the store holds another entry point', () => {
+		// Opening Image Studio elsewhere in the page load leaves that entry point
+		// in the store. The panel event still came from the panel, so its own
+		// placement has to win over the fallback.
+		selectMock.mockReturnValue( {
+			getEntryPoint: jest.fn( () => ImageStudioEntryPoint.EditorBlock ),
+		} );
+
+		trackImageStudioFeatureClipPanelViewed();
+
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_feature_clip_panel_viewed',
+			expect.objectContaining( { placement: 'post_editor_feature_clip' } )
+		);
+	} );
 } );

--- a/packages/image-studio/src/utils/tracking.test.ts
+++ b/packages/image-studio/src/utils/tracking.test.ts
@@ -472,4 +472,46 @@ describe( 'feature clip tracking helpers', () => {
 			expect.objectContaining( { placement: 'post_editor_feature_clip' } )
 		);
 	} );
+
+	it( 'sends the Feature Clip placement on sidebar share events, where the store is empty', () => {
+		// Sharing straight from the panel never opens Image Studio, so the store
+		// has no entry point — the case that left these events unfilterable.
+		selectMock.mockReturnValue( {
+			getEntryPoint: jest.fn( () => null ),
+		} );
+
+		trackImageStudioGenericShareClicked( { surface: 'sidebar', method: 'web-share' } );
+		trackImageStudioReelShareCancelled( { surface: 'sidebar' } );
+		trackImageStudioFeatureClipAddedToPost( { attachmentId: 12 } );
+
+		[
+			'jetpack_big_sky_image_studio_feature_clip_generic_share_clicked',
+			'jetpack_big_sky_image_studio_feature_clip_share_cancelled',
+			'jetpack_big_sky_image_studio_feature_clip_added_to_post',
+		].forEach( ( eventName ) => {
+			expect( recordTracksEventMock ).toHaveBeenCalledWith(
+				eventName,
+				expect.objectContaining( { placement: 'post_editor_feature_clip' } )
+			);
+		} );
+	} );
+
+	it( 'keeps surface distinct from placement on Feature Clip events', () => {
+		// `surface` says where inside the feature ('sidebar' / 'modal'); `placement`
+		// says which entry point the flow came from. They are different properties
+		// and both have to survive.
+		selectMock.mockReturnValue( {
+			getEntryPoint: jest.fn( () => null ),
+		} );
+
+		trackImageStudioGenericShareClicked( { surface: 'modal', method: 'web-share' } );
+
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_feature_clip_generic_share_clicked',
+			expect.objectContaining( {
+				surface: 'modal',
+				placement: 'post_editor_feature_clip',
+			} )
+		);
+	} );
 } );

--- a/packages/image-studio/src/utils/tracking.ts
+++ b/packages/image-studio/src/utils/tracking.ts
@@ -146,6 +146,28 @@ function recordImageStudioEvent(
 	recordTracksEvent( eventName, baseProps );
 }
 
+/**
+ * Records a Feature Clip event, always carrying the Feature Clip placement.
+ *
+ * Every event in this family belongs to the post-editor Feature Clip flow,
+ * whether it fires from the sidebar panel or from the modal opened out of it.
+ * The store can't be relied on for that: the panel and its share actions run
+ * before anything opens Image Studio, so the entry point is still null and the
+ * event would go out with no placement and no way to filter it.
+ *
+ * @param eventName  Event name, without the tracks prefix.
+ * @param properties Event-specific properties.
+ */
+function recordFeatureClipEvent(
+	eventName: string,
+	properties: Record< string, string | number | boolean > = {}
+): void {
+	recordImageStudioEvent( eventName, {
+		placement: ImageStudioEntryPoint.PostEditorFeatureClip,
+		...properties,
+	} );
+}
+
 interface TrackImageStudioOpenedOptions {
 	mode: ImageStudioMode;
 	attachmentId?: number;
@@ -651,7 +673,7 @@ export function trackImageStudioReelShareClicked( {
 	if ( durationSeconds != null ) {
 		properties.duration_seconds = durationSeconds;
 	}
-	recordImageStudioEvent( 'image_studio_feature_clip_share_clicked', properties );
+	recordFeatureClipEvent( 'image_studio_feature_clip_share_clicked', properties );
 }
 
 /**
@@ -664,7 +686,7 @@ export function trackImageStudioReelShareNotConnected( {
 }: {
 	surface: ShareSurface;
 } ): void {
-	recordImageStudioEvent( 'image_studio_feature_clip_share_not_connected', { surface } );
+	recordFeatureClipEvent( 'image_studio_feature_clip_share_not_connected', { surface } );
 }
 
 /**
@@ -678,7 +700,7 @@ export function trackImageStudioReelShareConnectionDisabled( {
 }: {
 	surface: ShareSurface;
 } ): void {
-	recordImageStudioEvent( 'image_studio_feature_clip_share_connection_disabled', { surface } );
+	recordFeatureClipEvent( 'image_studio_feature_clip_share_connection_disabled', { surface } );
 }
 
 /**
@@ -691,7 +713,7 @@ export function trackImageStudioReelShareNotPublished( {
 }: {
 	surface: ShareSurface;
 } ): void {
-	recordImageStudioEvent( 'image_studio_feature_clip_share_post_not_published', { surface } );
+	recordFeatureClipEvent( 'image_studio_feature_clip_share_post_not_published', { surface } );
 }
 
 /**
@@ -704,7 +726,7 @@ export function trackImageStudioReelShareInvalidState( {
 }: {
 	surface: ShareSurface;
 } ): void {
-	recordImageStudioEvent( 'image_studio_feature_clip_share_invalid_state', { surface } );
+	recordFeatureClipEvent( 'image_studio_feature_clip_share_invalid_state', { surface } );
 }
 
 /**
@@ -713,7 +735,7 @@ export function trackImageStudioReelShareInvalidState( {
  * @param options.surface - Where the share originated ('sidebar' | 'modal')
  */
 export function trackImageStudioReelShareCancelled( { surface }: { surface: ShareSurface } ): void {
-	recordImageStudioEvent( 'image_studio_feature_clip_share_cancelled', { surface } );
+	recordFeatureClipEvent( 'image_studio_feature_clip_share_cancelled', { surface } );
 }
 
 /**
@@ -726,7 +748,7 @@ export function trackImageStudioReelShareDispatched( {
 }: {
 	surface: ShareSurface;
 } ): void {
-	recordImageStudioEvent( 'image_studio_feature_clip_share_dispatched', { surface } );
+	recordFeatureClipEvent( 'image_studio_feature_clip_share_dispatched', { surface } );
 }
 
 /**
@@ -746,7 +768,7 @@ export function trackImageStudioReelShareFailed( {
 	if ( errorMessage ) {
 		properties.error_message = errorMessage;
 	}
-	recordImageStudioEvent( 'image_studio_feature_clip_share_failed', properties );
+	recordFeatureClipEvent( 'image_studio_feature_clip_share_failed', properties );
 }
 
 /**
@@ -764,7 +786,7 @@ export function trackImageStudioGenericShareClicked( {
 	surface: ShareSurface;
 	method: 'web-share' | 'web-share-unsupported';
 } ): void {
-	recordImageStudioEvent( 'image_studio_feature_clip_generic_share_clicked', { surface, method } );
+	recordFeatureClipEvent( 'image_studio_feature_clip_generic_share_clicked', { surface, method } );
 }
 
 /**
@@ -781,7 +803,7 @@ export function trackImageStudioGenericShareCompleted( {
 	surface: ShareSurface;
 	method: 'web-share';
 } ): void {
-	recordImageStudioEvent( 'image_studio_feature_clip_generic_share_completed', {
+	recordFeatureClipEvent( 'image_studio_feature_clip_generic_share_completed', {
 		surface,
 		method,
 	} );
@@ -813,7 +835,7 @@ export function trackImageStudioGenericShareFailed( {
 	if ( failureKind ) {
 		properties.failure_kind = failureKind;
 	}
-	recordImageStudioEvent( 'image_studio_feature_clip_generic_share_failed', properties );
+	recordFeatureClipEvent( 'image_studio_feature_clip_generic_share_failed', properties );
 }
 
 /**
@@ -827,7 +849,7 @@ export function trackImageStudioFeatureClipAddedToPost( {
 }: {
 	attachmentId: number;
 } ): void {
-	recordImageStudioEvent( 'image_studio_feature_clip_added_to_post', {
+	recordFeatureClipEvent( 'image_studio_feature_clip_added_to_post', {
 		attachment_id: attachmentId,
 		surface: 'sidebar',
 	} );
@@ -839,13 +861,7 @@ export function trackImageStudioFeatureClipAddedToPost( {
  * engagement rates.
  */
 export function trackImageStudioFeatureClipPanelViewed(): void {
-	// Sent explicitly rather than left to the store: the panel is rendered by the
-	// editor sidebar, so at mount nothing has opened Image Studio yet and the
-	// store's entry point is still null. Without this the event carries no
-	// placement and cannot be excluded from Image Studio metrics.
-	recordImageStudioEvent( 'image_studio_feature_clip_panel_viewed', {
-		placement: ImageStudioEntryPoint.PostEditorFeatureClip,
-	} );
+	recordFeatureClipEvent( 'image_studio_feature_clip_panel_viewed' );
 }
 
 /**
@@ -854,7 +870,7 @@ export function trackImageStudioFeatureClipPanelViewed(): void {
  * impression denominator for how often closing mid-generation happens.
  */
 export function trackImageStudioFeatureClipCloseWarningShown(): void {
-	recordImageStudioEvent( 'image_studio_feature_clip_close_warning_shown' );
+	recordFeatureClipEvent( 'image_studio_feature_clip_close_warning_shown' );
 }
 
 /**
@@ -862,7 +878,7 @@ export function trackImageStudioFeatureClipCloseWarningShown(): void {
  * generating ("Cancel").
  */
 export function trackImageStudioFeatureClipCloseWarningKeptGenerating(): void {
-	recordImageStudioEvent( 'image_studio_feature_clip_close_warning_kept_generating' );
+	recordFeatureClipEvent( 'image_studio_feature_clip_close_warning_kept_generating' );
 }
 
 /**
@@ -870,5 +886,5 @@ export function trackImageStudioFeatureClipCloseWarningKeptGenerating(): void {
  * generation and closing the modal ("Stop and close").
  */
 export function trackImageStudioFeatureClipCloseWarningStopped(): void {
-	recordImageStudioEvent( 'image_studio_feature_clip_close_warning_stopped' );
+	recordFeatureClipEvent( 'image_studio_feature_clip_close_warning_stopped' );
 }

--- a/packages/image-studio/src/utils/tracking.ts
+++ b/packages/image-studio/src/utils/tracking.ts
@@ -7,7 +7,7 @@
 
 import { recordTracksEvent as recordTracksEventBase } from '@automattic/calypso-analytics';
 import { select } from '@wordpress/data';
-import { store as imageStudioStore, type ImageStudioEntryPoint } from '../store';
+import { store as imageStudioStore, ImageStudioEntryPoint } from '../store';
 import { getSessionId } from '../utils/session';
 import type { ImageStudioMode, MetadataField } from '../types';
 
@@ -120,7 +120,12 @@ function recordImageStudioEvent(
 
 	baseProps.site_type = siteType;
 
-	if ( entryPoint ) {
+	// The store's entry point is only a fallback. An event that knows its own
+	// placement passes it explicitly, and must keep it: the store holds whichever
+	// entry point was used last in this page load, which for an event that fires
+	// on mount rather than on open would report where the user happened to have
+	// been rather than where the event came from.
+	if ( entryPoint && undefined === baseProps.placement ) {
 		baseProps.placement = entryPoint;
 	}
 
@@ -834,7 +839,13 @@ export function trackImageStudioFeatureClipAddedToPost( {
  * engagement rates.
  */
 export function trackImageStudioFeatureClipPanelViewed(): void {
-	recordImageStudioEvent( 'image_studio_feature_clip_panel_viewed' );
+	// Sent explicitly rather than left to the store: the panel is rendered by the
+	// editor sidebar, so at mount nothing has opened Image Studio yet and the
+	// store's entry point is still null. Without this the event carries no
+	// placement and cannot be excluded from Image Studio metrics.
+	recordImageStudioEvent( 'image_studio_feature_clip_panel_viewed', {
+		placement: ImageStudioEntryPoint.PostEditorFeatureClip,
+	} );
 }
 
 /**

--- a/packages/image-studio/src/utils/tracking.ts
+++ b/packages/image-studio/src/utils/tracking.ts
@@ -163,8 +163,11 @@ function recordFeatureClipEvent(
 	properties: Record< string, string | number | boolean > = {}
 ): void {
 	recordImageStudioEvent( eventName, {
-		placement: ImageStudioEntryPoint.PostEditorFeatureClip,
 		...properties,
+		// Last, so the placement is guaranteed rather than merely defaulted. An
+		// event that needs a different one doesn't belong in this family and
+		// should call recordImageStudioEvent directly.
+		placement: ImageStudioEntryPoint.PostEditorFeatureClip,
 	} );
 }
 


### PR DESCRIPTION
### What

Feature Clip tracking event `jetpack_big_sky_image_studio_feature_clip_panel_viewed` are being sent without a `placement` property. This adds it across the family.

### Why

`placement` records which entry point a flow started from, and is what these events are filtered on. Two paths were missing it:

- **The panel impression** fires when the editor sidebar mounts. At that point nothing has opened Image Studio, so the store held no entry point and the event went out with no placement at all. Since this panel renders for everyone who opens the block editor, those impressions could not be separated from actual Image Studio usage.
- **Sharing a clip from the sidebar** never opens Image Studio either, so the share events taking that path had the same gap. The same events fired from the modal did carry a placement, which made the coverage look partial rather than broken.

### Changes

1. The whole Feature Clip family now goes through a small wrapper that supplies the Feature Clip placement, instead of each call site adding it. Every event in the family belongs to that flow whether it fires from the panel or from the modal opened out of it, so a new event added later carries the placement by construction.
2. `recordImageStudioEvent` no longer overwrites a `placement` that was passed explicitly. It previously spread the caller's properties and then unconditionally reassigned `placement` from the store, so an explicit value could not have survived. The store's value is now a fallback for events that don't supply one.
