### PR TITLE
Dashboard: surface unverified email state on the profile screen

### DIFF
--- a/client/dashboard/me/profile-personal-details/email-section.tsx
+++ b/client/dashboard/me/profile-personal-details/email-section.tsx
@@ -16,7 +16,8 @@ interface EmailSectionProps {
 	value: string;
 	onChange: ( value: string ) => void;
 	disabled?: boolean;
-	userData: UserSettings;
+	userSettings: UserSettings;
+	isEmailVerified: boolean;
 	onValidationChange?: ( isValid: boolean ) => void;
 }
 
@@ -41,7 +42,8 @@ export default function EmailSection( {
 	value,
 	onChange,
 	disabled = false,
-	userData,
+	userSettings,
+	isEmailVerified,
 	onValidationChange,
 }: EmailSectionProps ) {
 	const mutation = cancelPendingEmailChangeMutation();
@@ -61,9 +63,9 @@ export default function EmailSection( {
 		},
 	} );
 
-	const isEmailPending = userData.user_email_change_pending;
-	const pendingEmail = userData.new_user_email;
-	const currentEmail = isEmailPending && pendingEmail ? pendingEmail : userData.user_email;
+	const isEmailPending = userSettings.user_email_change_pending;
+	const pendingEmail = userSettings.new_user_email;
+	const currentEmail = isEmailPending && pendingEmail ? pendingEmail : userSettings.user_email;
 
 	const [ emailValidationState, setEmailValidationState ] =
 		useEmailValidation( onValidationChange );
@@ -191,9 +193,15 @@ export default function EmailSection( {
 			}
 		}
 
+		// The saved email address has never been verified (and no change is pending).
+		if ( ! isEmailVerified ) {
+			return __( 'Your email has not been verified yet.' );
+		}
+
 		return null;
 	}, [
 		isEmailPending,
+		isEmailVerified,
 		showCustomDomainWarning,
 		value,
 		currentEmail,

--- a/client/dashboard/me/profile-personal-details/index.tsx
+++ b/client/dashboard/me/profile-personal-details/index.tsx
@@ -14,6 +14,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { DataForm, Field, Form } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo, useCallback } from 'react';
+import { useAuth } from '../../app/auth';
 import { NavigationBlocker } from '../../app/navigation-blocker';
 import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { Card, CardBody } from '../../components/card';
@@ -26,6 +27,7 @@ import type { UserSettings } from '@automattic/api-core';
 import './style.scss';
 
 export default function PersonalDetailsSection() {
+	const { user } = useAuth();
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 	const { data: isAutomattician } = useSuspenseQuery( isAutomatticianQuery() );
 	const isMobile = useViewportMatch( 'small', '<' );
@@ -43,7 +45,7 @@ export default function PersonalDetailsSection() {
 	const data = useMemo( () => ( { ...userSettings, ...edits } ), [ userSettings, edits ] );
 
 	const currentUsername = userSettings.user_login || '';
-	const isEmailVerified = userSettings.email_verified ?? true;
+	const isEmailVerified = user.email_verified;
 	const canChangeUsername = userSettings.user_login_can_be_changed ?? true;
 
 	// Form event handlers
@@ -146,7 +148,10 @@ export default function PersonalDetailsSection() {
 						/>
 
 						{ /* Email verification banner */ }
-						<EmailVerificationBanner userData={ userSettings } />
+						<EmailVerificationBanner
+							userSettings={ userSettings }
+							isEmailVerified={ isEmailVerified }
+						/>
 
 						<NavigationBlocker shouldBlock={ isDirty } />
 
@@ -174,7 +179,8 @@ export default function PersonalDetailsSection() {
 							value={ data.user_email || '' }
 							onChange={ ( value ) => handleFieldChange( { user_email: value } ) }
 							disabled={ isSaving }
-							userData={ userSettings }
+							userSettings={ userSettings }
+							isEmailVerified={ isEmailVerified }
 							onValidationChange={ setIsEmailValid }
 						/>
 

--- a/client/dashboard/me/profile-personal-details/test/index.test.tsx
+++ b/client/dashboard/me/profile-personal-details/test/index.test.tsx
@@ -8,7 +8,7 @@ import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { render } from '../../../test-utils';
 import PersonalDetailsSection from '../index';
-import type { UserSettings } from '@automattic/api-core';
+import type { User, UserSettings } from '@automattic/api-core';
 
 const settings = {
 	first_name: 'John',
@@ -19,6 +19,14 @@ const settings = {
 	user_login_can_be_changed: true,
 	is_dev_account: false,
 } as unknown as UserSettings;
+
+const unverifiedUser = {
+	ID: 1,
+	username: 'johndoe',
+	email: 'john@example.com',
+	email_verified: false,
+	language: 'en',
+} as User;
 
 function mockUserSettings( data: UserSettings ) {
 	return nock( 'https://public-api.wordpress.com' )
@@ -128,10 +136,10 @@ describe( '<PersonalDetailsSection>', () => {
 		} );
 
 		test( 'disables username field for unverified email users', async () => {
-			mockUserSettings( { ...settings, email_verified: false } as unknown as UserSettings );
+			mockUserSettings( settings );
 			mockIsAutomattician( false );
 
-			render( <PersonalDetailsSection /> );
+			render( <PersonalDetailsSection />, { user: unverifiedUser } );
 
 			await waitFor( () => {
 				expect( screen.getByRole( 'textbox', { name: 'Username' } ) ).toBeDisabled();
@@ -201,6 +209,18 @@ describe( '<PersonalDetailsSection>', () => {
 				expect( screen.getByRole( 'textbox', { name: 'Email address' } ) ).toBeDisabled();
 			} );
 			expect( screen.getByText( 'Your email has not been verified yet.' ) ).toBeVisible();
+		} );
+
+		test( 'shows the unverified notice when the account email is not verified', async () => {
+			mockUserSettings( settings );
+			mockIsAutomattician( false );
+
+			render( <PersonalDetailsSection />, { user: unverifiedUser } );
+
+			await screen.findByRole( 'textbox', { name: 'Email address' } );
+
+			expect( screen.getByText( 'Your email has not been verified yet.' ) ).toBeVisible();
+			expect( screen.getByText( 'Verify your email' ) ).toBeVisible();
 		} );
 
 		test( 'cancels pending email change', async () => {

--- a/client/dashboard/me/profile-personal-details/update-email/email-verification-banner.tsx
+++ b/client/dashboard/me/profile-personal-details/update-email/email-verification-banner.tsx
@@ -1,4 +1,8 @@
-import { resendEmailVerificationMutation } from '@automattic/api-queries';
+import {
+	cancelPendingEmailChangeMutation,
+	resendEmailVerificationMutation,
+	sendEmailVerificationMutation,
+} from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
@@ -43,12 +47,16 @@ function cleanUpEmailVerificationParams() {
 }
 
 interface EmailVerificationBannerProps {
-	userData: UserSettings;
+	userSettings: UserSettings;
+	isEmailVerified: boolean;
 }
 
-export default function EmailVerificationBanner( { userData }: EmailVerificationBannerProps ) {
+export default function EmailVerificationBanner( {
+	userSettings,
+	isEmailVerified,
+}: EmailVerificationBannerProps ) {
 	const { createErrorNotice } = useDispatch( noticesStore );
-	const [ showResendButton, setShowResendButton ] = useState( true );
+	const [ canResend, setCanResend ] = useState( true );
 
 	// Extract verification params to avoid multiple URL parsing calls
 	const {
@@ -73,8 +81,10 @@ export default function EmailVerificationBanner( { userData }: EmailVerification
 		return null;
 	} );
 
-	const isEmailPending = userData.user_email_change_pending;
-	const pendingEmail = userData.new_user_email;
+	const pendingEmail = userSettings.new_user_email;
+	const isEmailChangePending = !! userSettings.user_email_change_pending && !! pendingEmail;
+	const shouldShowVerifyNotice = isEmailChangePending || ! isEmailVerified;
+	const unverifiedEmail = isEmailChangePending ? pendingEmail : userSettings.user_email;
 
 	useEffect( () => {
 		// Handle error cases
@@ -102,32 +112,31 @@ export default function EmailVerificationBanner( { userData }: EmailVerification
 		emailVerificationFailed,
 	] );
 
-	// Resend email
+	const resendMutation = isEmailChangePending
+		? resendEmailVerificationMutation( pendingEmail || '' )
+		: sendEmailVerificationMutation();
+
 	const { mutate: resendEmail, isPending: isResendPending } = useMutation( {
-		...withSnackbar( resendEmailVerificationMutation( pendingEmail || '' ), {
-			success: pendingEmail
+		...withSnackbar( resendMutation, {
+			success: unverifiedEmail
 				? sprintf(
-						/* translators: %s is the user's new email address they're trying to change to */
+						/* translators: %s is the email address awaiting verification */
 						__( 'We sent an email to %s. Please check your inbox to verify your email.' ),
-						pendingEmail
+						unverifiedEmail
 				  )
 				: __( 'Verification email sent.' ),
 			error: __( 'Failed to resend verification email.' ),
 		} ),
-		onSuccess: () => {
-			setShowResendButton( false );
-		},
-		onError: () => {
-			setShowResendButton( true );
-		},
+		onSuccess: () => setCanResend( false ),
+		onError: () => setCanResend( true ),
 	} );
 
-	const handleResendEmail = () => {
-		if ( ! pendingEmail ) {
-			return;
-		}
-		resendEmail();
-	};
+	const { mutate: cancelPendingEmail, isPending: isCancelPending } = useMutation(
+		withSnackbar( cancelPendingEmailChangeMutation(), {
+			success: __( 'Pending email change canceled.' ),
+			error: __( 'Failed to cancel pending email change.' ),
+		} )
+	);
 
 	if ( showSuccessNotice ) {
 		const wasEmailChange = verificationType === 'email_change';
@@ -156,8 +165,8 @@ export default function EmailVerificationBanner( { userData }: EmailVerification
 		);
 	}
 
-	// Show pending email verification notice
-	if ( ! isEmailPending || ! pendingEmail ) {
+	// Show the verification notice for a pending change or an unverified account email.
+	if ( ! shouldShowVerifyNotice || ! unverifiedEmail ) {
 		return null;
 	}
 
@@ -167,20 +176,37 @@ export default function EmailVerificationBanner( { userData }: EmailVerification
 				variant="warning"
 				title={ __( 'Verify your email' ) }
 				actions={
-					showResendButton && (
-						<Button variant="link" onClick={ handleResendEmail } disabled={ isResendPending }>
+					<>
+						<Button
+							variant="primary"
+							__next40pxDefaultSize
+							onClick={ () => resendEmail() }
+							disabled={ isResendPending || ! canResend }
+							isBusy={ isResendPending }
+						>
 							{ __( 'Resend email' ) }
 						</Button>
-					)
+						{ isEmailChangePending && (
+							<Button
+								variant="secondary"
+								__next40pxDefaultSize
+								onClick={ () => cancelPendingEmail() }
+								disabled={ isCancelPending }
+								isBusy={ isCancelPending }
+							>
+								{ __( 'Cancel the pending email change' ) }
+							</Button>
+						) }
+					</>
 				}
 			>
 				{ createInterpolateElement(
 					sprintf(
-						/* translators: %s is the user's new email address they're trying to change to */
+						/* translators: %s is the email address awaiting verification */
 						__(
 							'Check your inbox at <strong>%s</strong> for the confirmation email, or click "Resend email" to get a new one.'
 						),
-						pendingEmail
+						unverifiedEmail
 					),
 					{
 						strong: <strong />,

--- a/client/dashboard/me/profile-personal-details/update-email/test/email-verification-banner.test.tsx
+++ b/client/dashboard/me/profile-personal-details/update-email/test/email-verification-banner.test.tsx
@@ -26,7 +26,7 @@ describe( '<EmailVerificationBanner>', () => {
 	test( 'shows verification banner and resends email', async () => {
 		const user = userEvent.setup();
 
-		render( <EmailVerificationBanner userData={ pendingSettings } /> );
+		render( <EmailVerificationBanner userSettings={ pendingSettings } isEmailVerified /> );
 
 		expect( await screen.findByText( 'Verify your email' ) ).toBeVisible();
 
@@ -44,6 +44,62 @@ describe( '<EmailVerificationBanner>', () => {
 		} );
 	} );
 
+	test( 'cancels the pending email change from the banner', async () => {
+		const user = userEvent.setup();
+
+		render( <EmailVerificationBanner userSettings={ pendingSettings } isEmailVerified /> );
+
+		expect( await screen.findByText( 'Verify your email' ) ).toBeVisible();
+
+		const scope = nock( 'https://public-api.wordpress.com' )
+			.post( '/rest/v1.1/me/settings', ( body ) => {
+				expect( body ).toEqual( expect.objectContaining( { user_email_change_pending: false } ) );
+				return true;
+			} )
+			.reply( 200, { ...pendingSettings, user_email_change_pending: false } );
+
+		await user.click( screen.getByRole( 'button', { name: 'Cancel the pending email change' } ) );
+
+		await waitFor( () => {
+			expect( scope.isDone() ).toBe( true );
+		} );
+	} );
+
+	test( 'does not offer to cancel when the email is unverified with no pending change', async () => {
+		render( <EmailVerificationBanner userSettings={ settings } isEmailVerified={ false } /> );
+
+		expect( await screen.findByText( 'Verify your email' ) ).toBeVisible();
+		expect(
+			screen.queryByRole( 'button', { name: 'Cancel the pending email change' } )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'shows verification banner for an unverified email and resends via the dedicated endpoint', async () => {
+		const user = userEvent.setup();
+
+		render( <EmailVerificationBanner userSettings={ settings } isEmailVerified={ false } /> );
+
+		expect( await screen.findByText( 'Verify your email' ) ).toBeVisible();
+
+		const scope = nock( 'https://public-api.wordpress.com' )
+			.post( '/rest/v1.1/me/send-verification-email' )
+			.reply( 200, {} );
+
+		await user.click( screen.getByRole( 'button', { name: 'Resend email' } ) );
+
+		await waitFor( () => {
+			expect( scope.isDone() ).toBe( true );
+		} );
+	} );
+
+	test( 'does not show the banner when the email is verified and no change is pending', async () => {
+		render( <EmailVerificationBanner userSettings={ settings } isEmailVerified /> );
+
+		await waitFor( () => {
+			expect( screen.queryByText( 'Verify your email' ) ).not.toBeInTheDocument();
+		} );
+	} );
+
 	test( 'shows success banner after email change verification', async () => {
 		const originalLocation = window.location;
 		Object.defineProperty( window, 'location', {
@@ -51,7 +107,7 @@ describe( '<EmailVerificationBanner>', () => {
 			writable: true,
 		} );
 
-		render( <EmailVerificationBanner userData={ settings } /> );
+		render( <EmailVerificationBanner userSettings={ settings } isEmailVerified /> );
 
 		expect( await screen.findByText( 'Email address updated' ) ).toBeVisible();
 		expect( screen.getByText( 'Update domain contacts' ) ).toBeVisible();
@@ -69,7 +125,7 @@ describe( '<EmailVerificationBanner>', () => {
 			writable: true,
 		} );
 
-		render( <EmailVerificationBanner userData={ settings } /> );
+		render( <EmailVerificationBanner userSettings={ settings } isEmailVerified /> );
 
 		expect( await screen.findByText( 'Email verified' ) ).toBeVisible();
 		expect( screen.queryByText( 'Update domain contacts' ) ).not.toBeInTheDocument();

--- a/client/dashboard/test-utils.tsx
+++ b/client/dashboard/test-utils.tsx
@@ -11,6 +11,7 @@ const defaultUser = {
 	ID: 1,
 	username: 'testuser',
 	email: 'test@example.com',
+	email_verified: true,
 	language: 'en',
 } as User;
 

--- a/packages/api-core/src/me-settings/mutators.ts
+++ b/packages/api-core/src/me-settings/mutators.ts
@@ -45,3 +45,10 @@ export async function updateUserSettings(
 export async function validatePassword( password: string ): Promise< PasswordValidationResponse > {
 	return await wpcom.req.post( '/me/settings/password/validate', { password } );
 }
+
+export async function sendVerificationEmail(): Promise< void > {
+	return await wpcom.req.post( {
+		path: '/me/send-verification-email',
+		apiVersion: '1.1',
+	} );
+}

--- a/packages/api-queries/src/me-settings.ts
+++ b/packages/api-queries/src/me-settings.ts
@@ -1,6 +1,7 @@
-import { fetchUserSettings, updateUserSettings } from '@automattic/api-core';
+import { fetchUserSettings, sendVerificationEmail, updateUserSettings } from '@automattic/api-core';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { queryClient, clearQueryClient } from './query-client';
+import type { UserSettings } from '@automattic/api-core';
 
 export const userSettingsQuery = () =>
 	queryOptions( {
@@ -57,5 +58,15 @@ export const resendEmailVerificationMutation = ( email: string ) =>
 						...newData,
 					}
 			);
+		},
+	} );
+
+export const sendEmailVerificationMutation = () =>
+	mutationOptions( {
+		meta: { statId: 'email-verify-send' },
+		// Return `{}` to match `resendEmailVerificationMutation`'s data type.
+		mutationFn: async (): Promise< Partial< UserSettings > > => {
+			await sendVerificationEmail();
+			return {};
 		},
 	} );


### PR DESCRIPTION
Part of DOTMSD-1468

## Proposed Changes

* On the Dashboard profile screen (`/me/profile`), show "Your email has not been verified yet." on the email field and a "Verify your email" banner when the account email is unverified and no email change is pending — not only when a change is pending.
* Read `email_verified` from the authenticated user object instead of the optional user-settings copy (which defaulted to `true` when absent). This is the same source the two-step summary already uses.
* The banner's "Resend email" now uses the dedicated `/me/send-verification-email` endpoint for an unverified original address, and the existing settings update for a pending change.
* When a change is pending, the banner also offers "Cancel the pending email change" alongside "Resend email".

| Pending | Unverified |
| - | - |
|<img width="642" height="179" alt="image" src="https://github.com/user-attachments/assets/a3aa020a-e88a-49b6-b7f5-c07a2396f7e0" />|<img width="638" height="180" alt="image" src="https://github.com/user-attachments/assets/c5500ba4-d438-412a-97a2-ba6d6f64c581" />|

## Why are these changes being made?

The classic `/me/account` screen surfaces "Your email has not been verified yet." on two conditions: a pending email change, or an unverified account email. The Dashboard only handled the pending case, so a user whose original email was never confirmed saw nothing prompting them to verify.

There were two root causes:
* The Dashboard branched solely on the pending-change flag, never on email verification status.
* It sourced `email_verified` from user settings, where the field is optional and fell back to "verified", rather than from the user object where it is authoritative — as the classic screen does.

## Testing Instructions

* Sign in as a user whose primary email is not verified (no pending email change).
* Go to `/me/profile`.
* Confirm the email field shows "Your email has not been verified yet." and a "Verify your email" banner appears.
* Click "Resend email" and confirm a verification email is requested (`POST /me/send-verification-email`).
* With a pending email change, confirm the banner shows both "Resend email" and "Cancel the pending email change", and that canceling clears the pending change.
* Confirm a user with a verified email and no pending change sees neither the message nor the banner.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

