### PR TITLE
E2E: re-enable domain setup + plan cancellation flows against the Multi-site Dashboard

### DIFF
--- a/packages/calypso-e2e/src/lib/components/dashboard-snackbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/dashboard-snackbar-component.ts
@@ -1,0 +1,54 @@
+import { Page } from 'playwright';
+
+const selectors = {
+	snackbar: '.components-snackbar',
+};
+
+/**
+ * Escapes regular expression metacharacters in the given text.
+ *
+ * @param text Text to escape.
+ */
+const escapeForRegExp = ( text: string ) => text.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
+
+/**
+ * Represents the snackbar notices of the Multi-site Dashboard.
+ *
+ * The dashboard surfaces transient feedback through `@wordpress/notices`
+ * snackbars (`client/dashboard/app/snackbars`) rather than the Calypso notices
+ * covered by `NoticeComponent`.
+ */
+export class DashboardSnackbarComponent {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param page Page on which the interactions take place.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Verifies a snackbar with the given text is shown.
+	 *
+	 * Snackbars can auto-dismiss, so callers should assert as soon as the action
+	 * that triggers the snackbar has settled.
+	 *
+	 * @param text Full or partial text to validate on page.
+	 * @param options Options.
+	 * @param options.timeout Custom timeout value.
+	 * @param options.exact Whether the snackbar text must match `text` exactly.
+	 */
+	async noticeShown(
+		text: string,
+		{ timeout, exact }: { timeout?: number; exact: boolean }
+	): Promise< void > {
+		await this.page
+			.locator( selectors.snackbar )
+			.filter( { hasText: exact ? new RegExp( `^\\s*${ escapeForRegExp( text ) }\\s*$` ) : text } )
+			.first()
+			.waitFor( { state: 'visible', timeout: timeout } );
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -14,6 +14,7 @@ export * from './domain-search-component';
 export * from './isolated-block-editor-component';
 export * from './block-widget-editor-component';
 export * from './notice-component';
+export * from './dashboard-snackbar-component';
 export * from './react-modal-component';
 export * from './editor-component';
 export * from './editor-inline-block-inserter-component';

--- a/packages/calypso-e2e/src/lib/components/me/dashboard-me-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/me/dashboard-me-sidebar-component.ts
@@ -1,0 +1,45 @@
+import { Page } from 'playwright';
+import envVariables from '../../../env-variables';
+
+/**
+ * Represents the `/me` sidebar in the Multi-site Dashboard.
+ */
+export class DashboardMeSidebarComponent {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Brings the sidebar into view on mobile viewports.
+	 *
+	 * Below the `medium` breakpoint the sidebar is rendered off screen behind
+	 * `ResponsiveSidebar` and only slides in once the omnibar's menu toggle is
+	 * clicked. No-op on wider viewports, where the sidebar is always visible.
+	 */
+	async openMobileMenu() {
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			await this.page.getByRole( 'button', { name: 'Menu' } ).click();
+		}
+	}
+
+	/**
+	 * Navigates to the given item of the sidebar menu.
+	 *
+	 * @param item Plaintext label of the menu item (eg. "Billing").
+	 */
+	async navigate(
+		item: 'Account' | 'Preferences' | 'Billing' | 'Security' | 'Notifications' | 'Apps'
+	) {
+		await this.page
+			.getByRole( 'navigation' )
+			.getByRole( 'link', { name: item, exact: true } )
+			.click();
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/me/index.ts
+++ b/packages/calypso-e2e/src/lib/components/me/index.ts
@@ -1,1 +1,2 @@
+export * from './dashboard-me-sidebar-component';
 export * from './me-sidebar-component';

--- a/packages/calypso-e2e/src/lib/flows/cancel-dashboard-purchase-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/cancel-dashboard-purchase-flow.ts
@@ -1,0 +1,82 @@
+import { Page } from 'playwright';
+
+type CancelReason = 'Another reason…';
+
+// The survey's step buttons render `@wordpress/components` buttons that are
+// `disabled`/`is-busy` while a request is in flight. Playwright's actionability
+// checks ride that out, but the default action timeout is too tight for a real
+// cancel-and-refund round-trip in the test environment.
+const STEP_BUTTON_TIMEOUT = 30 * 1000;
+
+/**
+ * Completes the Multi-site Dashboard cancellation confirmation and survey for a
+ * plan being removed with a refund.
+ *
+ * The survey copy is shared with the classic dashboard, but its markup is not:
+ * the questions render as `RadioControl` groups rather than dropdowns, and the
+ * step buttons are labelled by intent ("Continue removal" / "Complete removal"
+ * on the `intent=remove` path this flow drives). `cancelAtomicPurchaseFlow`
+ * covers the classic equivalent.
+ *
+ * @param {Page} page Page the survey is rendered on.
+ * @param feedback Answers to give to the survey.
+ * @param {CancelReason} feedback.reason Cancellation reason to select.
+ * @param {string} feedback.customReasonText Free-text elaboration on the reason.
+ */
+export async function cancelDashboardPurchaseFlow(
+	page: Page,
+	feedback: {
+		reason: CancelReason;
+		customReasonText: string;
+	}
+) {
+	// The feedback question is worded by intent: "Why would you like to cancel?"
+	// on the cancel path and "Why would you like to remove?" on the refund-and-
+	// remove (`intent=remove`) path this flow drives. Match either.
+	await page
+		.getByRole( 'radiogroup', { name: /Why would you like to (cancel|remove)\?/ } )
+		.getByRole( 'radio', { name: feedback.reason, exact: true } )
+		.check();
+
+	await page
+		.getByRole( 'textbox', { name: 'Can you please specify?' } )
+		.fill( feedback.customReasonText );
+
+	// Submit the feedback step. This is not the final step, so the button reads
+	// "Continue removal" rather than "Complete removal".
+	await page
+		.getByRole( 'button', { name: 'Continue removal', exact: true } )
+		.click( { timeout: STEP_BUTTON_TIMEOUT } );
+
+	// The next (and final) step asks where the user is headed next. Selecting an
+	// answer enables the final step button.
+	await page
+		.getByRole( 'radiogroup', { name: 'Where is your next adventure taking you?' } )
+		.getByRole( 'radio', { name: "I'm staying here and using the free plan.", exact: true } )
+		.check();
+
+	// Submitting the final step fires the cancel-and-refund request. Start
+	// listening for its response *before* clicking so the listener cannot miss
+	// a fast response. The request hits `wpcom/v2/purchases/<id>/cancel`; the
+	// API proxy URL contains `purchases/<id>/cancel`.
+	const cancelResponsePromise = page.waitForResponse(
+		( response ) =>
+			response.request().method() === 'POST' && /\/upgrades\/\d+\/cancel/.test( response.url() ),
+		// A refund is a real server round-trip and can be slow in the test
+		// environment, so allow a generous window.
+		{ timeout: 60 * 1000 }
+	);
+
+	// The final step button also offers a "Skip and remove" shortcut alongside
+	// "Complete removal"; take the one that submits the answers.
+	await page
+		.getByRole( 'button', { name: 'Complete removal', exact: true } )
+		.click( { timeout: STEP_BUTTON_TIMEOUT } );
+
+	// Completing the survey does not trigger a full-page navigation: the
+	// dashboard updates in place as a single-page-app state change. Block until
+	// the cancel request actually resolves so the caller's snackbar assertion
+	// only has to cover the notice render, not the full network round-trip —
+	// the success snackbar auto-dismisses shortly after it appears.
+	await cancelResponsePromise;
+}

--- a/packages/calypso-e2e/src/lib/flows/cancel-dashboard-purchase-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/cancel-dashboard-purchase-flow.ts
@@ -18,10 +18,10 @@ const STEP_BUTTON_TIMEOUT = 30 * 1000;
  * on the `intent=remove` path this flow drives). `cancelAtomicPurchaseFlow`
  * covers the classic equivalent.
  *
- * @param {Page} page Page the survey is rendered on.
+ * @param page Page the survey is rendered on.
  * @param feedback Answers to give to the survey.
- * @param {CancelReason} feedback.reason Cancellation reason to select.
- * @param {string} feedback.customReasonText Free-text elaboration on the reason.
+ * @param feedback.reason Cancellation reason to select.
+ * @param feedback.customReasonText Free-text elaboration on the reason.
  */
 export async function cancelDashboardPurchaseFlow(
 	page: Page,

--- a/packages/calypso-e2e/src/lib/flows/index.ts
+++ b/packages/calypso-e2e/src/lib/flows/index.ts
@@ -6,3 +6,4 @@ export * from './lohp-theme-signup-flow';
 
 // Newer style flows (without a class)
 export * from './cancel-purchase-flow';
+export * from './cancel-dashboard-purchase-flow';

--- a/packages/calypso-e2e/src/lib/pages/me/dashboard-purchases-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/dashboard-purchases-page.ts
@@ -11,7 +11,7 @@ export class DashboardPurchasesPage {
 	/**
 	 * Constructs an instance of the page.
 	 *
-	 * @param {Page} page The underlying page.
+	 * @param page The underlying page.
 	 */
 	constructor( page: Page ) {
 		this.page = page;

--- a/packages/calypso-e2e/src/lib/pages/me/dashboard-purchases-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/dashboard-purchases-page.ts
@@ -1,0 +1,105 @@
+import { Page } from 'playwright';
+import { getDashboardURL } from '../../../data-helper';
+
+/**
+ * Represents the Billing > Active upgrades screens (`/me/billing/purchases`)
+ * of the Multi-site Dashboard.
+ */
+export class DashboardPurchasesPage {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the page.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Waits until the browser is on the correct Billing page in the Multi-site Dashboard.
+	 *
+	 * Guards against acting on the wrong page (eg. after an unexpected redirect):
+	 * waiting for the domains URL first frames such a failure clearly instead of
+	 * surfacing a confusing missing-button locator error.
+	 */
+	private async waitForPageLoaded( purchasesPage: 'list' | 'details' ) {
+		const dashboardHost = new URL( getDashboardURL() ).host;
+		await this.page.waitForURL(
+			( url ) =>
+				url.host === dashboardHost &&
+				( purchasesPage === 'list'
+					? url.pathname === '/me/billing/purchases'
+					: /^\/me\/billing\/purchases\/\d+$/.test( url.pathname ) )
+		);
+	}
+
+	/* Purchases list view */
+
+	/**
+	 * Clicks on the matching purchase.
+	 *
+	 * @param name Name of the purchased subscription.
+	 * @param siteSlug Site slug.
+	 */
+	async clickOnPurchase( name: string, siteSlug: string ) {
+		await this.waitForPageLoaded( 'list' );
+		await this.page
+			.getByRole( 'row' )
+			.filter( { hasText: name } )
+			.filter( { hasText: siteSlug } )
+			.getByRole( 'link', { name: name } )
+			.click();
+	}
+
+	/* Purchase detail view */
+
+	/**
+	 * Cancels the purchase via the refund-and-remove path and advances to its
+	 * cancellation survey.
+	 *
+	 * The "Cancel" action on the purchase settings screen lands on a
+	 * cancellation confirmation screen (`intent=cancel`) whose primary action
+	 * only disables auto-renew — it no longer issues a refund. To drive the
+	 * immediate refund-and-remove path (the one the cancellation specs assert),
+	 * this follows the "Remove plan and claim refund." notice link, which
+	 * navigates to the same route under `intent=remove` where the primary
+	 * confirm button reads "Continue removal". Confirming there begins the
+	 * cancellation survey, which fires the refund on completion.
+	 */
+	async cancelPurchase() {
+		await this.waitForPageLoaded( 'details' );
+
+		await this.page
+			.locator( '.action-item' )
+			.filter( { hasText: 'Cancel subscription' } )
+			.getByRole( 'button', { name: 'Cancel', exact: true } )
+			.click();
+
+		// Follow the refund-eligibility notice link to switch from the
+		// auto-renew-only `intent=cancel` screen to the refund-and-remove
+		// `intent=remove` screen. Matched by a copy-resilient pattern so wording
+		// tweaks to the notice don't break the flow.
+		await this.page.getByRole( 'link', { name: /claim refund/i } ).click();
+
+		// The screen remounts under `intent=remove`. Wait for its primary confirm
+		// button before inspecting the rest of the screen.
+		const cancelSubscriptionButton = this.page.getByRole( 'button', {
+			name: 'Continue removal',
+			exact: true,
+		} );
+		await cancelSubscriptionButton.waitFor( { state: 'visible' } );
+
+		// The confirm button is gated behind an "I've reviewed what I'll lose…"
+		// checkbox. Tick it only when present so the flow still works if the
+		// confirmation screen drops it.
+		const confirmCheckbox = this.page.getByRole( 'checkbox', { name: /reviewed what/i } );
+		if ( ( await confirmCheckbox.count() ) > 0 ) {
+			await confirmCheckbox.check();
+		}
+
+		// Confirm. Clicking "Continue removal" begins the cancellation survey.
+		await cancelSubscriptionButton.click();
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/me/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/index.ts
@@ -1,3 +1,4 @@
 export * from './account-settings-page';
+export * from './dashboard-purchases-page';
 export * from './my-profile-page';
 export * from './purchases-page';

--- a/test/e2e/lib/pw-base.ts
+++ b/test/e2e/lib/pw-base.ts
@@ -35,8 +35,11 @@ import {
 	BlazeCampaignPage,
 	BlockWidgetEditorComponent,
 	CartCheckoutPage,
+	DashboardMeSidebarComponent,
 	DashboardPage,
+	DashboardPurchasesPage,
 	DashboardSiteDomainsPage,
+	DashboardSnackbarComponent,
 	DashboardVisibilitySettingsPage,
 	DataHelper,
 	DomainSearchComponent,
@@ -170,6 +173,14 @@ export const test = base.extend<
 		 * Component for searching/selecting domains during signup flows.
 		 */
 		componentDomainSearch: DomainSearchComponent;
+		/**
+		 * Component for the Multi-site Dashboard `/me` sidebar (profile/settings).
+		 */
+		componentDashboardMeSidebar: DashboardMeSidebarComponent;
+		/**
+		 * Component for the Multi-site Dashboard snackbar notices.
+		 */
+		componentDashboardSnackbar: DashboardSnackbarComponent;
 		/**
 		 * Component for the Me sidebar (profile/settings)
 		 */
@@ -327,6 +338,10 @@ export const test = base.extend<
 		 */
 		pagePurchases: PurchasesPage;
 		/**
+		 * Page object representing the Multi-site Dashboard Billing > Active upgrades screens.
+		 */
+		pageDashboardPurchases: DashboardPurchasesPage;
+		/**
 		 * Page object representing the WordPress.com themes detail page.
 		 */
 		pageThemeDetails: ThemesDetailPage;
@@ -424,6 +439,14 @@ export const test = base.extend<
 	componentBlockWidgetEditor: async ( { page }, use ) => {
 		const blockWidgetEditorComponent = new BlockWidgetEditorComponent( page );
 		await use( blockWidgetEditorComponent );
+	},
+	componentDashboardMeSidebar: async ( { page }, use ) => {
+		const dashboardMeSidebarComponent = new DashboardMeSidebarComponent( page );
+		await use( dashboardMeSidebarComponent );
+	},
+	componentDashboardSnackbar: async ( { page }, use ) => {
+		const dashboardSnackbarComponent = new DashboardSnackbarComponent( page );
+		await use( dashboardSnackbarComponent );
 	},
 	componentMeSidebar: async ( { page }, use ) => {
 		const meSidebarComponent = new MeSidebarComponent( page );
@@ -596,6 +619,10 @@ export const test = base.extend<
 	pagePurchases: async ( { page }, use ) => {
 		const purchasesPage = new PurchasesPage( page );
 		await use( purchasesPage );
+	},
+	pageDashboardPurchases: async ( { page }, use ) => {
+		const dashboardPurchasesPage = new DashboardPurchasesPage( page );
+		await use( dashboardPurchasesPage );
 	},
 	pageThemeDetails: async ( { page }, use ) => {
 		const themesDetailPage = new ThemesDetailPage( page );

--- a/test/e2e/specs/flows/setup-domain__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-domain__flows.spec.ts
@@ -1,12 +1,12 @@
 import {
 	BrowserManager,
-	cancelAtomicPurchaseFlow,
+	cancelDashboardPurchaseFlow,
 	NewSiteResponse,
 	NewTestUserDetails,
 	NewUserResponse,
 	RestAPIClient,
 } from '@automattic/calypso-e2e';
-import { skipIfNotTrunk, tags, test, expect } from '../../lib/pw-base';
+import { /* skipIfNotTrunk,*/ tags, test, expect } from '../../lib/pw-base';
 import { apiCloseAccount, apiCreateFreeSiteForUser, apiDeleteSite } from '../shared';
 
 test.describe(
@@ -15,7 +15,7 @@ test.describe(
 		tag: [ tags.CALYPSO_RELEASE ],
 	},
 	() => {
-		skipIfNotTrunk();
+		// skipIfNotTrunk();
 
 		const accountsToCleanup: {
 			testUser: NewTestUserDetails;
@@ -272,29 +272,26 @@ test.describe(
 			} );
 		} );
 
-		// Skipped for now; can be updated once we're sure all onboarding tests will go
-		// through the MSD flow. See https://github.com/Automattic/wp-calypso/pull/112586
-		// and https://github.com/Automattic/wp-calypso/pull/112587.
-		test.skip( 'As a new user, I can create a paid site, add a domain, then cancel the plan', async ( {
+		test( 'As a new user, I can create a paid site, add a domain, then cancel the plan', async ( {
 			page,
+			componentDashboardMeSidebar,
+			componentDashboardSnackbar,
 			componentDomainSearch,
 			componentSelectItems,
 			componentSiteSelect,
-			componentMeSidebar,
-			componentNotice,
 			helperData,
 			pageCartCheckout,
+			pageDashboardPurchases,
 			pagePostCheckoutSetupSite,
 			pageSignupPickPlan,
 			pageUserSignUp,
-			pageMyProfile,
-			pagePurchases,
 		} ) => {
 			// This test chains several genuinely slow flows end to end: creating a
 			// paid site, completing checkout, adding a domain, and finally
-			// cancelling the plan with a real refund round-trip. The default 120s
-			// per-test budget is too tight for all of that, so widen it for this
-			// test only.
+			// cancelling the plan in the Multi-site Dashboard with a real refund
+			// round-trip. The default 120s per-test budget is too tight for all of
+			// that, so widen it for this test only.
+			// test.setTimeout( 300 * 1000 );
 			test.setTimeout( 240 * 1000 );
 
 			const planName = 'Personal';
@@ -385,35 +382,35 @@ test.describe(
 				await pageCartCheckout.validateCartItem( selectedDomain );
 			} );
 
-			await test.step( 'And I navigate to Me > Purchases', async function () {
-				await pageMyProfile.visit();
-				await componentMeSidebar.openMobileMenu();
-				await componentMeSidebar.navigate( 'Purchases' );
+			await test.step( 'And I navigate to Billing > Active upgrades', async function () {
+				await page.goto( helperData.getDashboardURL( '/me' ) );
+				await componentDashboardMeSidebar.openMobileMenu();
+				await componentDashboardMeSidebar.navigate( 'Billing' );
+				await page.getByRole( 'link', { name: 'Active upgrades', exact: true } ).click();
 			} );
 
 			await test.step( 'And I view details of the purchased plan', async function () {
-				await pagePurchases.clickOnPurchase(
+				await pageDashboardPurchases.clickOnPurchase(
 					`WordPress.com ${ planName }`,
 					newSiteDetails.blog_details.site_slug as string
 				);
-				await pagePurchases.cancelPurchase( 'Cancel plan' );
 			} );
 
 			await test.step( 'And I cancel the plan renewal', async function () {
-				// cancelAtomicPurchaseFlow now blocks until the cancel-and-refund
-				// API request resolves, so by the time it returns the success
-				// notice is rendering. The notice still carries a 10s auto-dismiss
-				// duration, so keep a comfortable margin to observe it.
-				await cancelAtomicPurchaseFlow( page, {
+				await pageDashboardPurchases.cancelPurchase();
+
+				// cancelDashboardPurchaseFlow blocks until the cancel-and-refund API
+				// request resolves, so by the time it returns the success snackbar is
+				// rendering. The snackbar still auto-dismisses, so keep a comfortable
+				// margin to observe it.
+				await cancelDashboardPurchaseFlow( page, {
 					reason: 'Another reason…',
 					customReasonText: 'E2E TEST CANCELLATION',
 				} );
 
-				await componentNotice.noticeShown(
+				await componentDashboardSnackbar.noticeShown(
 					'Your refund has been processed and your purchase removed.',
-					{
-						timeout: 30 * 1000,
-					}
+					{ exact: true }
 				);
 			} );
 		} );
@@ -533,28 +530,24 @@ test.describe(
 			} );
 		} );
 
-		// Skipped for now; can be updated once we're sure all onboarding tests will go
-		// through the MSD flow. See https://github.com/Automattic/wp-calypso/pull/112586
-		// and https://github.com/Automattic/wp-calypso/pull/112587.
-		test.skip( 'As a new user, I can create a paid site, add a domain using pre-selected site flow, then cancel the plan', async ( {
+		test( 'As a new user, I can create a paid site, add a domain using pre-selected site flow, then cancel the plan', async ( {
 			page,
+			componentDashboardMeSidebar,
+			componentDashboardSnackbar,
 			componentDomainSearch,
-			componentMeSidebar,
-			componentNotice,
 			helperData,
 			pageCartCheckout,
+			pageDashboardPurchases,
 			pagePostCheckoutSetupSite,
 			pageSignupPickPlan,
 			pageUserSignUp,
-			pageMyProfile,
-			pagePurchases,
 		} ) => {
 			// This test chains several genuinely slow flows end to end: creating a
 			// paid site, completing checkout, adding a domain, and finally
-			// cancelling the plan with a real refund round-trip. The default 120s
-			// per-test budget is too tight for all of that, so widen it for this
-			// test only.
-			test.setTimeout( 240 * 1000 );
+			// cancelling the plan in the Multi-site Dashboard with a real refund
+			// round-trip. The default 120s per-test budget is too tight for all of
+			// that, so widen it for this test only.
+			test.setTimeout( 300 * 1000 );
 
 			const planName = 'Personal';
 			const testUser = helperData.getNewTestUser();
@@ -622,35 +615,34 @@ test.describe(
 				await pageCartCheckout.validateCartItem( selectedDomain );
 			} );
 
-			await test.step( 'And I navigate to Me > Purchases', async function () {
-				await pageMyProfile.visit();
-				await componentMeSidebar.openMobileMenu();
-				await componentMeSidebar.navigate( 'Purchases' );
+			await test.step( 'And I navigate to Billing > Active upgrades', async function () {
+				await page.goto( helperData.getDashboardURL( '/me' ) );
+				await componentDashboardMeSidebar.openMobileMenu();
+				await componentDashboardMeSidebar.navigate( 'Billing' );
+				await page.getByRole( 'link', { name: 'Active upgrades', exact: true } ).click();
 			} );
 
 			await test.step( 'And I view details of the purchased plan', async function () {
-				await pagePurchases.clickOnPurchase(
+				await pageDashboardPurchases.clickOnPurchase(
 					`WordPress.com ${ planName }`,
 					newSiteDetails.blog_details.site_slug as string
 				);
-				await pagePurchases.cancelPurchase( 'Cancel plan' );
+				await pageDashboardPurchases.cancelPurchase();
 			} );
 
 			await test.step( 'And I cancel the plan renewal', async function () {
-				// cancelAtomicPurchaseFlow now blocks until the cancel-and-refund
-				// API request resolves, so by the time it returns the success
-				// notice is rendering. The notice still carries a 10s auto-dismiss
-				// duration, so keep a comfortable margin to observe it.
-				await cancelAtomicPurchaseFlow( page, {
+				// cancelDashboardPurchaseFlow blocks until the cancel-and-refund API
+				// request resolves, so by the time it returns the success snackbar is
+				// rendering. The snackbar still auto-dismisses, so keep a comfortable
+				// margin to observe it.
+				await cancelDashboardPurchaseFlow( page, {
 					reason: 'Another reason…',
 					customReasonText: 'E2E TEST CANCELLATION',
 				} );
 
-				await componentNotice.noticeShown(
+				await componentDashboardSnackbar.noticeShown(
 					'Your refund has been processed and your purchase removed.',
-					{
-						timeout: 30 * 1000,
-					}
+					{ exact: true }
 				);
 			} );
 		} );

--- a/test/e2e/specs/flows/setup-domain__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-domain__flows.spec.ts
@@ -401,8 +401,7 @@ test.describe(
 
 				// cancelDashboardPurchaseFlow blocks until the cancel-and-refund API
 				// request resolves, so by the time it returns the success snackbar is
-				// rendering. The snackbar still auto-dismisses, so keep a comfortable
-				// margin to observe it.
+				// rendering.
 				await cancelDashboardPurchaseFlow( page, {
 					reason: 'Another reason…',
 					customReasonText: 'E2E TEST CANCELLATION',
@@ -633,8 +632,7 @@ test.describe(
 			await test.step( 'And I cancel the plan renewal', async function () {
 				// cancelDashboardPurchaseFlow blocks until the cancel-and-refund API
 				// request resolves, so by the time it returns the success snackbar is
-				// rendering. The snackbar still auto-dismisses, so keep a comfortable
-				// margin to observe it.
+				// rendering.
 				await cancelDashboardPurchaseFlow( page, {
 					reason: 'Another reason…',
 					customReasonText: 'E2E TEST CANCELLATION',

--- a/test/e2e/specs/flows/setup-domain__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-domain__flows.spec.ts
@@ -6,7 +6,7 @@ import {
 	NewUserResponse,
 	RestAPIClient,
 } from '@automattic/calypso-e2e';
-import { /* skipIfNotTrunk,*/ tags, test, expect } from '../../lib/pw-base';
+import { skipIfNotTrunk, tags, test, expect } from '../../lib/pw-base';
 import { apiCloseAccount, apiCreateFreeSiteForUser, apiDeleteSite } from '../shared';
 
 test.describe(
@@ -15,7 +15,7 @@ test.describe(
 		tag: [ tags.CALYPSO_RELEASE ],
 	},
 	() => {
-		// skipIfNotTrunk();
+		skipIfNotTrunk();
 
 		const accountsToCleanup: {
 			testUser: NewTestUserDetails;

--- a/test/e2e/specs/flows/setup-domain__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-domain__flows.spec.ts
@@ -288,10 +288,9 @@ test.describe(
 		} ) => {
 			// This test chains several genuinely slow flows end to end: creating a
 			// paid site, completing checkout, adding a domain, and finally
-			// cancelling the plan in the Multi-site Dashboard with a real refund
-			// round-trip. The default 120s per-test budget is too tight for all of
-			// that, so widen it for this test only.
-			// test.setTimeout( 300 * 1000 );
+			// cancelling the plan with a real refund round-trip. The default 120s
+			// per-test budget is too tight for all of that, so widen it for this
+			// test only.
 			test.setTimeout( 240 * 1000 );
 
 			const planName = 'Personal';
@@ -543,10 +542,10 @@ test.describe(
 		} ) => {
 			// This test chains several genuinely slow flows end to end: creating a
 			// paid site, completing checkout, adding a domain, and finally
-			// cancelling the plan in the Multi-site Dashboard with a real refund
-			// round-trip. The default 120s per-test budget is too tight for all of
-			// that, so widen it for this test only.
-			test.setTimeout( 300 * 1000 );
+			// cancelling the plan with a real refund round-trip. The default 120s
+			// per-test budget is too tight for all of that, so widen it for this
+			// test only.
+			test.setTimeout( 240 * 1000 );
 
 			const planName = 'Personal';
 			const testUser = helperData.getNewTestUser();


### PR DESCRIPTION
Fixes DOTMSD-1449
Fixes DOTMSD-1448

## Proposed Changes

* Un-skip the two `setup-domain__flows` specs that create a paid site, add a domain, then cancel the plan.
* Point their cancellation half at the Multi-site Dashboard's Billing screens instead of Calypso's Me > Purchases.
* Add the E2E page objects/components/flow the dashboard path needs: purchases list + detail, the `/me` sidebar, snackbar notices, and the cancellation survey.

## Why are these changes being made?

* The two specs were skipped when onboarding moved to the MSD flow, pending confidence that all onboarding tests would go through it. That's now the case, so the specs can come back.
* They can't simply be re-enabled as they were: cancellation now lives in the dashboard, whose markup differs from Calypso's even where the copy is shared. The survey renders radio groups rather than dropdowns, feedback arrives via snackbars rather than Calypso notices, and the buttons are labelled by intent.
* Reaching a refund on the dashboard also takes a different route. The "Cancel" action now lands on a confirmation screen that only disables auto-renew; the immediate refund-and-remove path these specs assert is behind the "claim refund" notice link.

## Testing Instructions

* Run against a Calypso instance:

```
yarn playwright test specs/flows/setup-domain__flows.spec.ts --reporter=list
```

* Both cancellation specs should pass. Each creates a throwaway user and site and cleans up after itself.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
