### PR TITLE
Notifications: keep the bell badge live while the panel is closed (alt 2)

### DIFF
--- a/apps/notifications/src/app/client.ts
+++ b/apps/notifications/src/app/client.ts
@@ -1,0 +1,40 @@
+import RestClient from '../panel/rest-client';
+import { init as initAPI } from '../panel/rest-client/wpcom';
+import { store } from '../panel/state';
+import { addListeners, removeListeners } from '../panel/state/create-listener-middleware';
+
+let client: any;
+
+export function initClient( wpcom: any ) {
+	initAPI( wpcom );
+
+	if ( ! client ) {
+		client = new RestClient();
+		client.setVisibility( { isShowing: false, isVisible: ! document.hidden } );
+		document.addEventListener( 'visibilitychange', () => {
+			client.setVisibility( { isShowing: client.isShowing, isVisible: ! document.hidden } );
+			if ( ! document.hidden ) {
+				client.refreshNotes();
+			}
+		} );
+	}
+}
+
+export function getClient() {
+	return client;
+}
+
+export function subscribeUnseenCount( wpcom: any, onCount: ( count: number ) => void ): () => void {
+	initClient( wpcom );
+
+	const handlers = {
+		APP_RENDER_NOTES: [
+			( _store: unknown, action: unknown ) =>
+				onCount( ( action as { newNoteCount: number } ).newNoteCount ),
+		],
+	};
+
+	store.dispatch( addListeners( handlers ) );
+
+	return () => store.dispatch( removeListeners( handlers ) );
+}

--- a/apps/notifications/src/app/index.tsx
+++ b/apps/notifications/src/app/index.tsx
@@ -5,14 +5,13 @@ import { Provider } from 'react-redux';
 import repliesCache from '../panel/comment-replies-cache';
 import { modifierKeyIsActive } from '../panel/helpers/input';
 import { logError } from '../panel/helpers/log-error';
-import RestClient from '../panel/rest-client';
-import { init as initAPI } from '../panel/rest-client/wpcom';
-import { init as initStore } from '../panel/state';
+import { init as initStore, store } from '../panel/state';
 import { SET_IS_SHOWING } from '../panel/state/action-types';
 import actions from '../panel/state/actions';
 import { addListeners, removeListeners } from '../panel/state/create-listener-middleware';
 import getIsPanelOpen from '../panel/state/selectors/get-is-panel-open';
 import getKeyboardShortcutsEnabled from '../panel/state/selectors/get-keyboard-shortcuts-enabled';
+import { getClient, initClient } from './client';
 import { AppProvider } from './context';
 import ErrorBoundary from './error-boundary';
 import Note from './note';
@@ -22,20 +21,17 @@ import type { FilterName } from './types';
 
 import './style.scss';
 
-let client: any;
-
-let store = initStore();
-
 repliesCache.cleanup();
 
 /**
  * Force a manual refresh of the notes data
  */
-export const refreshNotes = () => client && client.refreshNotes.call( client );
+export const refreshNotes = () => getClient()?.refreshNotes();
 
 const defaultHandlers = {
 	APP_REFRESH_NOTES: [
 		( _store: any, action: any ) => {
+			const client = getClient();
 			if ( ! client ) {
 				return;
 			}
@@ -133,40 +129,30 @@ const NotificationApp = ( {
 	actionHandlers?: any;
 	wpcom: any;
 } ) => {
-	const [ isReady, setIsReady ] = useState( !! client );
+	const [ isReady, setIsReady ] = useState( !! getClient() );
 
 	useEffect( () => {
+		initClient( wpcom );
+		setIsReady( true );
+
 		store.dispatch( { type: 'APP_IS_READY' } );
 		store.dispatch( { type: SET_IS_SHOWING, isShowing: true } );
-		client?.setVisibility( { isShowing: true, isVisible: true } );
+		getClient()?.setVisibility( { isShowing: true, isVisible: ! document.hidden } );
 
 		return () => {
 			store.dispatch( { type: SET_IS_SHOWING, isShowing: false } );
-			client?.setVisibility( { isShowing: false, isVisible: false } );
+			getClient()?.setVisibility( { isShowing: false, isVisible: ! document.hidden } );
 		};
-	}, [] );
-
-	useEffect( () => {
-		initAPI( wpcom );
-
-		if ( ! client ) {
-			client = new RestClient();
-			client.locale = locale;
-			client?.setVisibility( { isShowing: true, isVisible: true } );
-			setIsReady( true );
-		}
 	}, [ wpcom ] );
 
 	useEffect( () => {
 		if ( customEnhancer ) {
-			store = initStore( { customEnhancer } );
+			initStore( { customEnhancer } );
 		}
 	}, [ customEnhancer ] );
 
 	useEffect( () => {
-		if ( client ) {
-			client.locale = locale;
-		}
+		getClient()?.setLocale( locale );
 	}, [ locale ] );
 
 	useEffect( () => {
@@ -237,7 +223,7 @@ const NotificationApp = ( {
 	return (
 		<ErrorBoundary>
 			<Provider store={ store }>
-				<AppProvider client={ client } locale={ locale }>
+				<AppProvider client={ getClient() } locale={ locale }>
 					<NotificationContent isDismissible={ isDismissible } />
 				</AppProvider>
 			</Provider>

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -681,9 +681,6 @@ function updateLastSeenTime( proposedTime, fromStorage ) {
 }
 
 function refreshNotes() {
-	if ( this.subscribed ) {
-		return;
-	}
 	debug( 'Refreshing notes...' );
 
 	getNotesList.call( this );
@@ -790,6 +787,10 @@ function setVisibility( { isShowing, isVisible } ) {
 	}
 }
 
+function setLocale( locale ) {
+	this.locale = locale;
+}
+
 Client.prototype.main = main;
 Client.prototype.reschedule = reschedule;
 Client.prototype.getNote = getNote;
@@ -802,5 +803,6 @@ Client.prototype.loadMore = loadMore;
 Client.prototype.hasMoreNotes = hasMoreNotes;
 Client.prototype.refreshNotes = refreshNotes;
 Client.prototype.setVisibility = setVisibility;
+Client.prototype.setLocale = setLocale;
 
 export default Client;

--- a/apps/notifications/src/panel/state/create-listener-middleware.ts
+++ b/apps/notifications/src/panel/state/create-listener-middleware.ts
@@ -51,6 +51,7 @@ function createListenerMiddleware(): Middleware {
 					const listenersForType = listeners.get( type )!;
 					handlers.forEach( ( handler ) => listenersForType.delete( handler ) );
 				}
+				return;
 			}
 			case 'LISTENER-MIDDLEWARE/CLEAR_LISTENERS': {
 				listeners.clear();

--- a/apps/notifications/src/panel/state/index.js
+++ b/apps/notifications/src/panel/state/index.js
@@ -21,6 +21,7 @@ const withMiddleware = () =>
 		createStore
 	);
 
+/** @type {any} */
 let store = null;
 store = init();
 

--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -63,6 +63,25 @@ export default function Notifications( {
 		omnibarEvents.notificationsOpen.emit( isOpen );
 	}, [ isOpen ] );
 
+	useEffect( () => {
+		let unsubscribe: ( () => void ) | undefined;
+		let cancelled = false;
+
+		import( '@automattic/notifications/src/app/client' ).then( ( { subscribeUnseenCount } ) => {
+			if ( ! cancelled ) {
+				unsubscribe = subscribeUnseenCount( wpcom, ( count ) => {
+					setHasUnseenNotifications( count > 0 );
+					omnibarEvents.notificationsUnseenCount.emit( count );
+				} );
+			}
+		} );
+
+		return () => {
+			cancelled = true;
+			unsubscribe?.();
+		};
+	}, [] );
+
 	const handleClose = () => {
 		handleToggle( false );
 	};

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -17,7 +17,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import clsx from 'clsx';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
-import { Component, Suspense, lazy, useMemo } from 'react';
+import { Component, Suspense, lazy, useEffect, useMemo } from 'react';
 import { connect } from 'react-redux';
 import localStorageHelper from 'store';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -111,8 +111,25 @@ const RedesignedNotifications = ( {
 	locale,
 	actionHandlers,
 	closePanel,
+	updateUnseenCount,
 } ) => {
 	const isMobile = useViewportMatch( 'small', '<' );
+
+	useEffect( () => {
+		let unsubscribe;
+		let cancelled = false;
+
+		import( '@automattic/notifications/src/app/client' ).then( ( { subscribeUnseenCount } ) => {
+			if ( ! cancelled ) {
+				unsubscribe = subscribeUnseenCount( wpcom, updateUnseenCount );
+			}
+		} );
+
+		return () => {
+			cancelled = true;
+			unsubscribe?.();
+		};
+	}, [ updateUnseenCount ] );
 
 	// Resolve the bell at measurement time: the masterbar remounts it when
 	// the unseen count changes, so a captured node can go stale.
@@ -458,6 +475,7 @@ export class Notifications extends Component {
 					locale={ localeSlug }
 					actionHandlers={ this.actionHandlers }
 					closePanel={ this.closePanel }
+					updateUnseenCount={ this.props.setUnseenCount }
 				/>
 			);
 


### PR DESCRIPTION
Fixes DOTMSD-1208

## Proposed Changes

- Keep the unread notifications bell badge live while the panel is closed, on the surfaces that mount the panel only when open (redesigned masterbar, Dashboard, Reader header).
- Move the notifications client out of the panel component into a shared module (`apps/notifications/src/app/client.ts`) so a single client owns the note stream and unread count for the whole page, independent of the panel's mount lifecycle. The bell subscribes to the count the client already computes.

## Why are these changes being made?

The client that subscribes to the note stream and computes the unread count was created inside the panel component, which only mounts while the panel is open. Before the panel was ever opened no client existed, so the bell showed only its page-load value; and closing the panel tore down the listener driving the badge. Either way the count froze until a page reload. Hoisting the client out keeps the badge live by reusing the existing note-stream and count logic, decoupled from the panel UI.

## Testing Instructions

- On a surface with the new notifications app (Dashboard, Reader, or the masterbar with `notifications/redesign`), leave the panel **closed** and trigger a notification from another account (like/comment).
- Confirm the bell updates without opening the panel — near-instant via the websocket, or within ~30s if websockets are unavailable — and that the masterbar shows the exact count.
- Open the panel and confirm the count/seen state is correct, then close it and confirm the badge stays live.

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
