### PR TITLE
Help Center: make mobile sheet fullscreen regardless of masterbar height

### DIFF
--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -145,10 +145,10 @@ a[href^='https://smooch.io/live-web-chat'] {
 		bottom: 0;
 		left: 0;
 		right: 0;
-		/* If the masterbar is there, don't cover it, if not, go to the top. */
-		top: var( --masterbar-height, 0 );
-		max-height: calc( 100% - 45px );
-		height: calc( 100% - var( --masterbar-height, 0 ) );
+		/* Go fullscreen, covering the masterbar. */
+		top: 0;
+		max-height: 100%;
+		height: 100%;
 		animation: none;
 		transition: none;
 


### PR DESCRIPTION
Fixes DOTMSD-1392

## Proposed Changes

* On mobile, the Help Center sheet now goes fullscreen: it starts at the top of the viewport (covering the masterbar) and uses the full viewport height.
* Previously the sheet was offset below the masterbar (`top: var(--masterbar-height)`) and its height/max-height were derived from the masterbar height, leaving a gap and a `100% - 45px` cap.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The mobile sheet was sized around the masterbar height, so its usable area varied with the host context and never truly filled the screen. Making it fullscreen gives a consistent, predictable mobile support experience regardless of whether a masterbar is present.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Calypso

1. Run `yarn start`.
2. Open the Help Center on a narrow viewport (mobile layout / `is-mobile`).
3. Verify the sheet fills the entire screen, covering the masterbar, with no gap at the top and no 45px cap.
4. Minimize the Help Center and confirm the minimized peek at the bottom still behaves correctly.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
4. Open the Help Center on a mobile viewport and verify it goes fullscreen as above.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
