### PR TITLE
Agents Manager: Stop bundling libvips WASM in the reader chat build

### DIFF
--- a/apps/agents-manager/reader-chat-vips-stub.js
+++ b/apps/agents-manager/reader-chat-vips-stub.js
@@ -1,21 +1,12 @@
 /**
- * Stub for `@wordpress/vips/worker` in the reader-chat bundle.
+ * Stub for `@wordpress/vips/worker`, aliased in for the reader chat build only.
  *
- * `@wordpress/block-editor` depends on `@wordpress/upload-media`, which lazy-imports
- * `@wordpress/vips/worker` to do client-side image processing. That worker ships
- * libvips as base64-inlined WASM (`vips.wasm` + `vips-heif.wasm`), so webpack emits
- * it as a ~15MB chunk.
+ * Keeping it avoids re-inlining libvips as ~15MB of base64 WASM, which the frontend
+ * bundle would otherwise pull in via `@wordpress/upload-media` and never execute.
  *
- * Reader chat never reaches that code: it has no block editor canvas, and its own
- * image uploads go through `@wordpress/media-utils` (a plain REST upload), not
- * `@wordpress/upload-media`. Only the frontend bundle disables dependency
- * externalization, so it is also the only entry point that would inline the chunk.
- *
- * The processing helpers reject rather than silently return, so a future code path
- * that does depend on them fails loudly instead of corrupting an upload. The
- * cancel/terminate helpers are no-ops — upload-media guards both behind an
- * already-loaded module, so they are unreachable here, but a no-op keeps any
- * future cleanup path from throwing.
+ * Processing helpers reject so a real caller fails loudly rather than silently
+ * mishandling an upload. Cancel/terminate are no-ops: `@wordpress/upload-media` only
+ * calls them once the real module has loaded.
  */
 
 function unavailable() {

--- a/apps/agents-manager/reader-chat-vips-stub.js
+++ b/apps/agents-manager/reader-chat-vips-stub.js
@@ -1,0 +1,37 @@
+/**
+ * Stub for `@wordpress/vips/worker` in the reader-chat bundle.
+ *
+ * `@wordpress/block-editor` depends on `@wordpress/upload-media`, which lazy-imports
+ * `@wordpress/vips/worker` to do client-side image processing. That worker ships
+ * libvips as base64-inlined WASM (`vips.wasm` + `vips-heif.wasm`), so webpack emits
+ * it as a ~15MB chunk.
+ *
+ * Reader chat never reaches that code: it has no block editor canvas, and its own
+ * image uploads go through `@wordpress/media-utils` (a plain REST upload), not
+ * `@wordpress/upload-media`. Only the frontend bundle disables dependency
+ * externalization, so it is also the only entry point that would inline the chunk.
+ *
+ * The processing helpers reject rather than silently return, so a future code path
+ * that does depend on them fails loudly instead of corrupting an upload. The
+ * cancel/terminate helpers are no-ops — upload-media guards both behind an
+ * already-loaded module, so they are unreachable here, but a no-op keeps any
+ * future cleanup path from throwing.
+ */
+
+function unavailable() {
+	return Promise.reject(
+		new Error( 'vips image processing is not bundled in the reader chat build.' )
+	);
+}
+
+export const vipsCompressImage = unavailable;
+export const vipsConvertImageFormat = unavailable;
+export const vipsHasTransparency = unavailable;
+export const vipsResizeImage = unavailable;
+export const vipsRotateImage = unavailable;
+
+export function vipsCancelOperations() {
+	return Promise.resolve( false );
+}
+
+export function terminateVipsWorker() {}

--- a/apps/agents-manager/webpack.config.js
+++ b/apps/agents-manager/webpack.config.js
@@ -192,6 +192,9 @@ function getReaderConfig( options = {} ) {
 				// Share one Smooch instance across bundles (see smooch-shim.js).
 				// TODO: Remove once Agents Manager takes over the Help Center.
 				smooch$: path.join( __dirname, '../../build-tools/webpack/smooch-shim.js' ),
+				// Keep libvips' inlined WASM out of the frontend bundle. See
+				// reader-chat-vips-stub.js.
+				'@wordpress/vips/worker$': path.join( __dirname, 'reader-chat-vips-stub.js' ),
 				'../agent-history': path.join( __dirname, 'reader-chat-route-stub.js' ),
 				'../support-guide': path.join( __dirname, 'reader-chat-route-stub.js' ),
 				'../support-guides': path.join( __dirname, 'reader-chat-route-stub.js' ),


### PR DESCRIPTION
## Proposed Changes

* Alias `@wordpress/vips/worker` to a small stub in the reader chat webpack config, so libvips' inlined WebAssembly is no longer emitted as a bundle chunk.

## Why are these changes being made?

The reader chat entry point is the only Agents Manager bundle that disables dependency externalization, so `@wordpress/block-editor` gets bundled rather than loaded from WordPress's script registry. It depends on `@wordpress/upload-media`, which lazy-imports `@wordpress/vips/worker` for client-side image processing. That worker ships libvips as base64-inlined WebAssembly, so webpack emits it as a ~15MB chunk.

Reader chat never reaches that code path:

* It renders no `BlockEditorProvider` — the only `@wordpress/block-editor` module that imports `@wordpress/upload-media`.
* Its own image uploads go through `@wordpress/media-utils`, which has no vips dependency.
* The eagerly imported helpers (`detectClientSideMediaSupport`, `isHeicCanvasSupported`) are pure feature detection and never load the worker.

So the chunk is dead weight in the built output.

The stub rejects on the image-processing helpers, so a future code path that does need them fails loudly rather than silently mishandling an upload. `vipsCancelOperations` and `terminateVipsWorker` are no-ops — `@wordpress/upload-media` guards both behind an already-loaded module.

Only the reader chat config is aliased. The other entry points externalize `wp-block-editor`, so they never bundled vips to begin with.

## Testing Instructions

* `cd apps/agents-manager && yarn build`
* Confirm no ~15MB chunk is emitted into `dist/`. The vips chunk should now be ~500 bytes and export the same seven functions; `reader-chat.min.js` should be unchanged in size.
* Load reader chat on a blog and confirm it opens, sends and receives messages, and that image upload still works.