### PR TITLE
E2E: fix Atomic collection abort and park four checks that lost their mutes

### DIFF
--- a/test/e2e/specs/blocks/blocks__coblocks__blocks.spec.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__blocks.spec.ts
@@ -26,14 +26,15 @@ if ( envVariables.TEST_ON_ATOMIC ) {
  * 	- theme: a non-block-based theme (eg. Twenty-Twenty One)
  */
 test.describe( 'CoBlocks: Blocks', { tag: [ tags.GUTENBERG ] }, () => {
-	const accountName = getTestAccountByFeature( features );
-
 	// Test data
 	const pricingTableBlockPrices = [ 4.99, 9.99 ];
 	const heroBlockHeading = 'Hero heading';
 	const clicktoTweetBlockTweet = 'Tweet text';
 
 	test( 'As a user, I can use CoBlocks in a post', async ( { page, pageEditor } ) => {
+		// Resolved here, not at describe scope: Playwright loads every spec during collection
+		// regardless of --grep, so a throw for an unmatched feature key aborts the whole run.
+		const accountName = getTestAccountByFeature( features );
 		let pricingTableBlock: PricingTableBlock;
 		let logoImage: TestFile;
 

--- a/test/e2e/specs/blocks/blocks__coblocks__blocks.spec.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__blocks.spec.ts
@@ -32,8 +32,7 @@ test.describe( 'CoBlocks: Blocks', { tag: [ tags.GUTENBERG ] }, () => {
 	const clicktoTweetBlockTweet = 'Tweet text';
 
 	test( 'As a user, I can use CoBlocks in a post', async ( { page, pageEditor } ) => {
-		// Resolved here, not at describe scope: Playwright loads every spec during collection
-		// regardless of --grep, so a throw for an unmatched feature key aborts the whole run.
+		// Resolved in-test: a describe-scope throw aborts collection for the whole run.
 		const accountName = getTestAccountByFeature( features );
 		let pricingTableBlock: PricingTableBlock;
 		let logoImage: TestFile;

--- a/test/e2e/specs/blocks/blocks__coblocks__blocks.spec.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__blocks.spec.ts
@@ -32,7 +32,7 @@ test.describe( 'CoBlocks: Blocks', { tag: [ tags.GUTENBERG ] }, () => {
 	const clicktoTweetBlockTweet = 'Tweet text';
 
 	test( 'As a user, I can use CoBlocks in a post', async ( { page, pageEditor } ) => {
-		// Resolved in-test: a describe-scope throw aborts collection for the whole run.
+		// Must resolve inside the test: a throw at describe scope aborts collection for the entire run.
 		const accountName = getTestAccountByFeature( features );
 		let pricingTableBlock: PricingTableBlock;
 		let logoImage: TestFile;

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.spec.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.spec.ts
@@ -23,7 +23,7 @@ if ( envVariables.TEST_ON_ATOMIC ) {
  */
 test.describe( 'CoBlocks: Extensions: Cover Styles', { tag: [ tags.GUTENBERG ] }, () => {
 	test( 'As a user, I can change CoBlocks cover styles', async ( { page, pageEditor } ) => {
-		// Resolved in-test: a describe-scope throw aborts collection for the whole run.
+		// Must resolve inside the test: a throw at describe scope aborts collection for the entire run.
 		const accountName = getTestAccountByFeature( features );
 		let imageFile: TestFile;
 		let coverBlock: CoverBlock;

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.spec.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.spec.ts
@@ -22,9 +22,10 @@ if ( envVariables.TEST_ON_ATOMIC ) {
  * 	- theme: a non-block-based theme (eg. Twenty-Twenty One)
  */
 test.describe( 'CoBlocks: Extensions: Cover Styles', { tag: [ tags.GUTENBERG ] }, () => {
-	const accountName = getTestAccountByFeature( features );
-
 	test( 'As a user, I can change CoBlocks cover styles', async ( { page, pageEditor } ) => {
+		// Resolved here, not at describe scope: Playwright loads every spec during collection
+		// regardless of --grep, so a throw for an unmatched feature key aborts the whole run.
+		const accountName = getTestAccountByFeature( features );
 		let imageFile: TestFile;
 		let coverBlock: CoverBlock;
 

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.spec.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.spec.ts
@@ -23,8 +23,7 @@ if ( envVariables.TEST_ON_ATOMIC ) {
  */
 test.describe( 'CoBlocks: Extensions: Cover Styles', { tag: [ tags.GUTENBERG ] }, () => {
 	test( 'As a user, I can change CoBlocks cover styles', async ( { page, pageEditor } ) => {
-		// Resolved here, not at describe scope: Playwright loads every spec during collection
-		// regardless of --grep, so a throw for an unmatched feature key aborts the whole run.
+		// Resolved in-test: a describe-scope throw aborts collection for the whole run.
 		const accountName = getTestAccountByFeature( features );
 		let imageFile: TestFile;
 		let coverBlock: CoverBlock;

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.spec.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.spec.ts
@@ -24,8 +24,7 @@ test.describe( 'CoBlocks: Extensions: Gutter Control', { tag: [ tags.GUTENBERG ]
 		page,
 		pageEditor,
 	} ) => {
-		// Resolved here, not at describe scope: Playwright loads every spec during collection
-		// regardless of --grep, so a throw for an unmatched feature key aborts the whole run.
+		// Resolved in-test: a describe-scope throw aborts collection for the whole run.
 		const accountName = getTestAccountByFeature( features );
 		let pricingTableBlock: PricingTableBlock;
 

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.spec.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.spec.ts
@@ -20,12 +20,13 @@ if ( isAtomic ) {
  * 	- theme: a non-block-based theme (eg. Twenty-Twenty One)
  */
 test.describe( 'CoBlocks: Extensions: Gutter Control', { tag: [ tags.GUTENBERG ] }, () => {
-	const accountName = getTestAccountByFeature( features );
-
 	test( 'As a user, I can change CoBlocks gutter control settings', async ( {
 		page,
 		pageEditor,
 	} ) => {
+		// Resolved here, not at describe scope: Playwright loads every spec during collection
+		// regardless of --grep, so a throw for an unmatched feature key aborts the whole run.
+		const accountName = getTestAccountByFeature( features );
 		let pricingTableBlock: PricingTableBlock;
 
 		await test.step( 'Given I am authenticated', async () => {

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.spec.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.spec.ts
@@ -24,7 +24,7 @@ test.describe( 'CoBlocks: Extensions: Gutter Control', { tag: [ tags.GUTENBERG ]
 		page,
 		pageEditor,
 	} ) => {
-		// Resolved in-test: a describe-scope throw aborts collection for the whole run.
+		// Must resolve inside the test: a throw at describe scope aborts collection for the entire run.
 		const accountName = getTestAccountByFeature( features );
 		let pricingTableBlock: PricingTableBlock;
 

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.spec.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.spec.ts
@@ -24,8 +24,7 @@ if ( envVariables.TEST_ON_ATOMIC ) {
  */
 test.describe( 'CoBlocks: Extensions: Replace Image', { tag: [ tags.GUTENBERG ] }, () => {
 	test( 'As a user, I can replace an image in the editor', async ( { page, pageEditor } ) => {
-		// Resolved here, not at describe scope: Playwright loads every spec during collection
-		// regardless of --grep, so a throw for an unmatched feature key aborts the whole run.
+		// Resolved in-test: a describe-scope throw aborts collection for the whole run.
 		const accountName = getTestAccountByFeature( features );
 		let imageFile: TestFile;
 		let imageBlock: ImageBlock;

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.spec.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.spec.ts
@@ -23,9 +23,10 @@ if ( envVariables.TEST_ON_ATOMIC ) {
  * 	- theme: a non-block-based theme (eg. Twenty-Twenty One)
  */
 test.describe( 'CoBlocks: Extensions: Replace Image', { tag: [ tags.GUTENBERG ] }, () => {
-	const accountName = getTestAccountByFeature( features );
-
 	test( 'As a user, I can replace an image in the editor', async ( { page, pageEditor } ) => {
+		// Resolved here, not at describe scope: Playwright loads every spec during collection
+		// regardless of --grep, so a throw for an unmatched feature key aborts the whole run.
+		const accountName = getTestAccountByFeature( features );
 		let imageFile: TestFile;
 		let imageBlock: ImageBlock;
 		let uploadedImageURL: string;

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.spec.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.spec.ts
@@ -24,7 +24,7 @@ if ( envVariables.TEST_ON_ATOMIC ) {
  */
 test.describe( 'CoBlocks: Extensions: Replace Image', { tag: [ tags.GUTENBERG ] }, () => {
 	test( 'As a user, I can replace an image in the editor', async ( { page, pageEditor } ) => {
-		// Resolved in-test: a describe-scope throw aborts collection for the whole run.
+		// Must resolve inside the test: a throw at describe scope aborts collection for the entire run.
 		const accountName = getTestAccountByFeature( features );
 		let imageFile: TestFile;
 		let imageBlock: ImageBlock;

--- a/test/e2e/specs/blocks/blocks__jetpack-other.spec.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-other.spec.ts
@@ -1,7 +1,6 @@
 import {
 	BlockFlow,
 	envVariables,
-	// GifFlow,
 	MapFlow,
 	RelatedPostsFlow,
 	StarRatingBlock,
@@ -9,13 +8,10 @@ import {
 import { tags } from '../../lib/pw-base';
 import { createBlockTests } from './shared/block-smoke-testing';
 
-const blockFlows: BlockFlow[] = [
-	new StarRatingBlock( { rating: 3.5 } ),
-	// Parked (TESTOPS-148): giphy changed the content of their embed, so the flow can no longer
-	// find the player. The mute this had under the Jest test ID died with the migration, and the
-	// migrated suite is one test, so a mute would now take every other block here down with it.
-	// new GifFlow( { query: 'https://giphy.com/embed/MDJ9IbxxvDUQM' } ),
-];
+// GifFlow dropped (TESTOPS-148): giphy changed the content of their embed, so the flow can no
+// longer find the player. Its Jest-era mute died with the migration, and the suite is now a
+// single test, so a mute would take every other block here down with it.
+const blockFlows: BlockFlow[] = [ new StarRatingBlock( { rating: 3.5 } ) ];
 
 // Private sites change behavior of the Map block.
 // @see: https://github.com/Automattic/jetpack/issues/32991

--- a/test/e2e/specs/blocks/blocks__jetpack-other.spec.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-other.spec.ts
@@ -11,9 +11,9 @@ import { createBlockTests } from './shared/block-smoke-testing';
 
 const blockFlows: BlockFlow[] = [
 	new StarRatingBlock( { rating: 3.5 } ),
-	// Parked: giphy changed the content of their embed, so the flow can no longer find the
-	// player. Was muted project-wide under the Jest test ID (TeamCity mute 1559); the migrated
-	// suite is one test, so a mute would now take every other block here down with it.
+	// Parked (TESTOPS-148): giphy changed the content of their embed, so the flow can no longer
+	// find the player. The mute this had under the Jest test ID died with the migration, and the
+	// migrated suite is one test, so a mute would now take every other block here down with it.
 	// new GifFlow( { query: 'https://giphy.com/embed/MDJ9IbxxvDUQM' } ),
 ];
 

--- a/test/e2e/specs/blocks/blocks__jetpack-other.spec.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-other.spec.ts
@@ -1,7 +1,7 @@
 import {
 	BlockFlow,
 	envVariables,
-	GifFlow,
+	// GifFlow,
 	MapFlow,
 	RelatedPostsFlow,
 	StarRatingBlock,
@@ -11,7 +11,10 @@ import { createBlockTests } from './shared/block-smoke-testing';
 
 const blockFlows: BlockFlow[] = [
 	new StarRatingBlock( { rating: 3.5 } ),
-	new GifFlow( { query: 'https://giphy.com/embed/MDJ9IbxxvDUQM' } ),
+	// Parked: giphy changed the content of their embed, so the flow can no longer find the
+	// player. Was muted project-wide under the Jest test ID (TeamCity mute 1559); the migrated
+	// suite is one test, so a mute would now take every other block here down with it.
+	// new GifFlow( { query: 'https://giphy.com/embed/MDJ9IbxxvDUQM' } ),
 ];
 
 // Private sites change behavior of the Map block.

--- a/test/e2e/specs/blocks/blocks__jetpack-writing.spec.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-writing.spec.ts
@@ -1,19 +1,11 @@
-import { /* AIAssistantFlow, */ BlockFlow, MarkdownFlow } from '@automattic/calypso-e2e';
+import { BlockFlow, MarkdownFlow } from '@automattic/calypso-e2e';
 import { tags } from '../../lib/pw-base';
 import { createBlockTests } from './shared/block-smoke-testing';
 
+// AIAssistantFlow dropped (TESTOPS-148): it has been failing to configure the block since April
+// 2026. Its Jest-era mute died with the migration, and the suite is now a single test, so a mute
+// would take every other block here down with it.
 const blockFlows: BlockFlow[] = [
-	// Parked (TESTOPS-148): has been failing to configure the block since April 2026. The mute
-	// this had under the Jest test ID died with the migration, and the migrated suite is one
-	// test, so a mute would now take every other block here down with it.
-	// new AIAssistantFlow(
-	// 	{
-	// 		query: 'In two short sentences, tell me about Vancouver, Canada.',
-	// 		tone: 'Passionate',
-	// 		improve: 'Make shorter',
-	// 	},
-	// 	{ keywords: [ 'Vancouver' ] }
-	// ),
 	new MarkdownFlow(
 		{
 			text: '### Markdown Header',

--- a/test/e2e/specs/blocks/blocks__jetpack-writing.spec.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-writing.spec.ts
@@ -3,9 +3,9 @@ import { tags } from '../../lib/pw-base';
 import { createBlockTests } from './shared/block-smoke-testing';
 
 const blockFlows: BlockFlow[] = [
-	// Parked: has been failing to configure the block since April 2026. Was muted project-wide
-	// under the Jest test ID (TeamCity mute 1501); the migrated suite is one test, so a mute
-	// would now take every other block here down with it.
+	// Parked (TESTOPS-148): has been failing to configure the block since April 2026. The mute
+	// this had under the Jest test ID died with the migration, and the migrated suite is one
+	// test, so a mute would now take every other block here down with it.
 	// new AIAssistantFlow(
 	// 	{
 	// 		query: 'In two short sentences, tell me about Vancouver, Canada.',

--- a/test/e2e/specs/blocks/blocks__jetpack-writing.spec.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-writing.spec.ts
@@ -1,16 +1,19 @@
-import { AIAssistantFlow, BlockFlow, MarkdownFlow } from '@automattic/calypso-e2e';
+import { /* AIAssistantFlow, */ BlockFlow, MarkdownFlow } from '@automattic/calypso-e2e';
 import { tags } from '../../lib/pw-base';
 import { createBlockTests } from './shared/block-smoke-testing';
 
 const blockFlows: BlockFlow[] = [
-	new AIAssistantFlow(
-		{
-			query: 'In two short sentences, tell me about Vancouver, Canada.',
-			tone: 'Passionate',
-			improve: 'Make shorter',
-		},
-		{ keywords: [ 'Vancouver' ] }
-	),
+	// Parked: has been failing to configure the block since April 2026. Was muted project-wide
+	// under the Jest test ID (TeamCity mute 1501); the migrated suite is one test, so a mute
+	// would now take every other block here down with it.
+	// new AIAssistantFlow(
+	// 	{
+	// 		query: 'In two short sentences, tell me about Vancouver, Canada.',
+	// 		tone: 'Passionate',
+	// 		improve: 'Make shorter',
+	// 	},
+	// 	{ keywords: [ 'Vancouver' ] }
+	// ),
 	new MarkdownFlow(
 		{
 			text: '### Markdown Header',

--- a/test/e2e/specs/editor/editor__post-basic-flow.spec.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.spec.ts
@@ -157,29 +157,14 @@ test.describe(
 				await test.step( 'Then I can view the published post', async () => {
 					const newPage = await page.context().newPage();
 
-					// Parked (TESTOPS-148): the Jetpack Stats tracking pixel does not load on
-					// every Atomic variation. The mute this had under the Jest test ID, where it
-					// was its own `it()`, died with the migration; the migrated test is a single
-					// test, so a mute would now take the whole post flow down with it.
-					// const trackingPixelLoaded = newPage.waitForResponse(
-					// 	new RegExp(
-					// 		`pixel.wp.com/g.gif.*blog=${ testAccount!.credentials.testSites?.primary
-					// 			.id }+.*&post=[\\d]+`
-					// 	)
-					// );
+					// The Jetpack Stats tracking pixel assertions were dropped here
+					// (TESTOPS-148): the pixel does not load on every Atomic variation. They had
+					// their own `it()` under Jest and so their own mute, which died with the
+					// migration; this is now a single test, so a mute would take the whole post
+					// flow down with it.
 					await newPage.goto( publishedURL!.href );
 
-					// let response;
-					// try {
-					// 	response = await trackingPixelLoaded;
-					// } catch {
-					// 	// noop
-					// }
-
 					expect( publishedURL!.href ).toStrictEqual( newPage.url() );
-
-					// expect( response ).toBeDefined();
-					// expect( response!.status() ).toBe( 200 );
 
 					publishedPostPage = new PublishedPostPage( newPage );
 					await publishedPostPage.validateTitle( title );

--- a/test/e2e/specs/editor/editor__post-basic-flow.spec.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.spec.ts
@@ -157,25 +157,29 @@ test.describe(
 				await test.step( 'Then I can view the published post', async () => {
 					const newPage = await page.context().newPage();
 
-					const trackingPixelLoaded = newPage.waitForResponse(
-						new RegExp(
-							`pixel.wp.com/g.gif.*blog=${ testAccount!.credentials.testSites?.primary
-								.id }+.*&post=[\\d]+`
-						)
-					);
+					// Parked: the Jetpack Stats tracking pixel does not load on every Atomic
+					// variation. Was muted project-wide under the Jest test ID (TeamCity mute
+					// 1495), where it was its own `it()`; the migrated test is a single test,
+					// so a mute would now take the whole post flow down with it.
+					// const trackingPixelLoaded = newPage.waitForResponse(
+					// 	new RegExp(
+					// 		`pixel.wp.com/g.gif.*blog=${ testAccount!.credentials.testSites?.primary
+					// 			.id }+.*&post=[\\d]+`
+					// 	)
+					// );
 					await newPage.goto( publishedURL!.href );
 
-					let response;
-					try {
-						response = await trackingPixelLoaded;
-					} catch {
-						// noop - will throw in next step
-					}
+					// let response;
+					// try {
+					// 	response = await trackingPixelLoaded;
+					// } catch {
+					// 	// noop
+					// }
 
 					expect( publishedURL!.href ).toStrictEqual( newPage.url() );
 
-					expect( response ).toBeDefined();
-					expect( response!.status() ).toBe( 200 );
+					// expect( response ).toBeDefined();
+					// expect( response!.status() ).toBe( 200 );
 
 					publishedPostPage = new PublishedPostPage( newPage );
 					await publishedPostPage.validateTitle( title );

--- a/test/e2e/specs/editor/editor__post-basic-flow.spec.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.spec.ts
@@ -157,10 +157,10 @@ test.describe(
 				await test.step( 'Then I can view the published post', async () => {
 					const newPage = await page.context().newPage();
 
-					// Parked: the Jetpack Stats tracking pixel does not load on every Atomic
-					// variation. Was muted project-wide under the Jest test ID (TeamCity mute
-					// 1495), where it was its own `it()`; the migrated test is a single test,
-					// so a mute would now take the whole post flow down with it.
+					// Parked (TESTOPS-148): the Jetpack Stats tracking pixel does not load on
+					// every Atomic variation. The mute this had under the Jest test ID, where it
+					// was its own `it()`, died with the migration; the migrated test is a single
+					// test, so a mute would now take the whole post flow down with it.
 					// const trackingPixelLoaded = newPage.waitForResponse(
 					// 	new RegExp(
 					// 		`pixel.wp.com/g.gif.*blog=${ testAccount!.credentials.testSites?.primary

--- a/test/e2e/specs/jetpack/jetpack__dashboard-smoke.spec.ts
+++ b/test/e2e/specs/jetpack/jetpack__dashboard-smoke.spec.ts
@@ -23,12 +23,13 @@ test.describe(
 	DataHelper.createSuiteTitle( 'Jetpack: Dashboard Smoke Test' ),
 	{ tag: [ tags.JETPACK_WPCOM_INTEGRATION ] },
 	() => {
-		const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
-		const testAccount = new TestAccount( accountName );
-
 		test( 'As a user, I can navigate Jetpack Dashboard tabs and Settings', async ( { page } ) => {
 			test.skip( envVariables.TEST_ON_ATOMIC !== true, 'Only runs on Atomic sites' );
 
+			// Must resolve inside the test: a throw at describe scope aborts collection for the entire run.
+			const testAccount = new TestAccount(
+				getTestAccountByFeature( envToFeatureKey( envVariables ) )
+			);
 			let jetpackDashboardPage: JetpackDashboardPage;
 
 			await test.step( 'Authenticate', async () => {
@@ -57,6 +58,8 @@ test.describe(
 				} );
 			}
 
+			// Newsletter is deliberately absent: Jetpack does not render that tab on any Atomic
+			// variation, and this test only runs on Atomic. See TESTOPS-148.
 			for ( const tab of [
 				'Security',
 				'Performance',
@@ -64,10 +67,6 @@ test.describe(
 				'Sharing',
 				'Discussion',
 				'Traffic',
-				// Parked (TESTOPS-148): the Newsletter tab is not rendered on any of the seven
-				// Atomic variations, so clicking it always times out. The pre-migration Jest
-				// spec never covered this tab; it was added by the migration in #112865.
-				// 'Newsletter',
 			] as SettingsTabs[] ) {
 				await test.step( `Click on ${ tab } tab in the Settings view`, async () => {
 					await jetpackDashboardPage.clickTab( { view: 'Settings', tab } );

--- a/test/e2e/specs/jetpack/jetpack__dashboard-smoke.spec.ts
+++ b/test/e2e/specs/jetpack/jetpack__dashboard-smoke.spec.ts
@@ -64,7 +64,10 @@ test.describe(
 				'Sharing',
 				'Discussion',
 				'Traffic',
-				'Newsletter',
+				// Parked: the Newsletter tab is not rendered on any of the seven Atomic
+				// variations, so clicking it always times out. The pre-migration Jest spec
+				// never covered this tab; it was added by the Playwright migration in #112865.
+				// 'Newsletter',
 			] as SettingsTabs[] ) {
 				await test.step( `Click on ${ tab } tab in the Settings view`, async () => {
 					await jetpackDashboardPage.clickTab( { view: 'Settings', tab } );

--- a/test/e2e/specs/jetpack/jetpack__dashboard-smoke.spec.ts
+++ b/test/e2e/specs/jetpack/jetpack__dashboard-smoke.spec.ts
@@ -64,9 +64,9 @@ test.describe(
 				'Sharing',
 				'Discussion',
 				'Traffic',
-				// Parked: the Newsletter tab is not rendered on any of the seven Atomic
-				// variations, so clicking it always times out. The pre-migration Jest spec
-				// never covered this tab; it was added by the Playwright migration in #112865.
+				// Parked (TESTOPS-148): the Newsletter tab is not rendered on any of the seven
+				// Atomic variations, so clicking it always times out. The pre-migration Jest
+				// spec never covered this tab; it was added by the migration in #112865.
 				// 'Newsletter',
 			] as SettingsTabs[] ) {
 				await test.step( `Click on ${ tab } tab in the Settings view`, async () => {


### PR DESCRIPTION
Part of [TESTOPS-148](https://linear.app/a8c/issue/TESTOPS-148). Follow-up to #112865.
Slack thread: p1785315490493389/1785312942.354229-slack-C01U2KGS2PQ

## Proposed Changes

* Resolve the test account inside the test body instead of at `describe` scope, in the four `blocks__coblocks__*.spec.ts` files and in `jetpack__dashboard-smoke.spec.ts`.
* Drop `GifFlow` from `blocks__jetpack-other.spec.ts`, `AIAssistantFlow` from `blocks__jetpack-writing.spec.ts`, the Jetpack Stats tracking pixel assertions from `editor__post-basic-flow.spec.ts` and the Newsletter tab from `jetpack__dashboard-smoke.spec.ts`. Each leaves a comment with the reason and a TESTOPS-148 reference.

## Why are these changes being made?

#112865 dropped the Jest step from the Jetpack builds and renamed the migrated specs to `.spec.ts`. Two things fell out of that.

Playwright loads every `.spec.ts` under `testDir` during collection, `--grep` or not, and a throw at collection kills the whole run rather than the one file. That's why `WPComTests_jetpack_atomic_build_smoke_e2e_desktop` reported 0 passed tests. Under Jest these files were only loaded for the CoBlocks group, and a throw in a `describe` body took down that file alone. Resolving in the test body gets that blast radius back.

The GIF and AI Assistant block flows, and the Stats tracking pixel check, were all failing before the migration and were muted project-wide under their Jest test IDs. Those IDs are gone, so the mutes are gone with them. Each migrated spec now runs a whole block group, or a whole post flow, as a single test with a step per item, so a mute would take everything else in that test down too; dropping the item is what the old per-step mute did anyway. They're deleted rather than commented out: `git log -S` brings them back just as cheaply, and commented-out code is neither type-checked nor linted, so it rots against the page objects around it.

The Newsletter tab isn't a parked check, it's a wrong list entry. The pre-migration spec didn't cover it, #112865 added it to `SettingsTabs`, and Jetpack doesn't render it on any Atomic variation. This test only runs on Atomic, so there's no environment left where it could pass.

### Why only the CoBlocks specs

`getTestAccountByFeature()` throws only on a lookup miss, so `describe`-scope resolution isn't itself the trigger. 20 other files do the same and pass, because `criteria-for-test-accounts.ts` has a row for every key the builds produce.

The CoBlocks specs set `features.coblocks = 'edge'` whenever `TEST_ON_ATOMIC` is set, regardless of `COBLOCKS_EDGE`. The only `coblocks: 'edge'` rows (`criteria-for-test-accounts.ts:13-45`) carry no `jetpackTarget` and no `atomicVariation`, so the Jetpack Atomic key has no row.

This contains the miss, it doesn't fix it. The other 20 files are covered, not safe: one new `atomicVariation` or `jetpackTarget` without matching rows takes all 20 down at once. That, and dropping the `coblocks: 'edge'` mutation when `JETPACK_TARGET` is set, are tracked under [TESTOPS-148](https://linear.app/a8c/issue/TESTOPS-148).

## Testing Instructions

Set `CALYPSO_BASE_URL` to the host in `CALYPSO_STAGING_URL` for the Simple runs.

Collection under the Atomic smoke environment, which is what regressed:

```
cd test/e2e
TEST_ON_ATOMIC=true ATOMIC_VARIATION=mixed JETPACK_TARGET=wpcom-deployment \
  VIEWPORT_NAME=desktop NODE_CONFIG_ENV=test \
  yarn playwright test --project=chrome --grep=@jetpack-wpcom-integration --list --reporter=list
```

On trunk that prints `No account found for this feature` four times and `Total: 0 tests in 0 files`. Here it lists 28 tests in 19 files.

Collection under the environment where the CoBlocks specs actually run, to confirm the moved resolution still resolves:

```
cd test/e2e
TEST_ON_ATOMIC=true COBLOCKS_EDGE=true VIEWPORT_NAME=desktop NODE_CONFIG_ENV=test \
  yarn playwright test --project=chrome --grep=@gutenberg --list --reporter=list
```

28 tests in 20 files, all four CoBlocks specs among them.

The two specs with dropped block flows, against Simple:

```
cd test/e2e
CALYPSO_BASE_URL=$CALYPSO_STAGING_URL VIEWPORT_NAME=desktop NODE_CONFIG_ENV=test \
  yarn playwright test --project=chrome \
  specs/blocks/blocks__jetpack-writing.spec.ts specs/blocks/blocks__jetpack-other.spec.ts \
  --repeat-each=3 --reporter=list
```

7 passed.

The tracking pixel removal, pinned to the variation it was failing on:

```
cd test/e2e
TEST_ON_ATOMIC=true ATOMIC_VARIATION=wp-beta JETPACK_TARGET=wpcom-deployment \
  VIEWPORT_NAME=desktop NODE_CONFIG_ENV=test \
  yarn playwright test --project=chrome specs/editor/editor__post-basic-flow.spec.ts \
  --repeat-each=2 --reporter=list
```

On trunk that fails 2 out of 2 on `expect( response ).toBeDefined()`. Here it passes 2 out of 2.

The Newsletter tab removal has no run behind it; the tab's absence came from the failing Atomic smoke builds, not a local repro.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
