### PR TITLE
Stats: fix the video details thumbnail link in Odyssey on Simple sites

### DIFF
--- a/client/my-sites/stats/stats-video-detail/index.tsx
+++ b/client/my-sites/stats/stats-video-detail/index.tsx
@@ -63,9 +63,14 @@ export default function StatsVideoDetail( { postId, period, context }: StatsVide
 
 	// Per the STATS-296 spec the thumbnail links to the video in the media
 	// library: wp-admin's upload.php in Odyssey, the /media route in Calypso
-	// (which itself forwards default-interface sites to upload.php). The
-	// video's stats id is its attachment id.
-	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	// (which itself forwards default-interface sites to upload.php). Unlike the
+	// VideoPress details page, upload.php exists regardless of the site's plan,
+	// so the link survives a downgrade. Detect wp-admin with `is_odyssey`, not
+	// `is_running_in_jetpack_site` — the latter only signals which API the app
+	// calls and is false on Simple sites, where the Calypso-relative path would
+	// resolve against the site's own domain and 404. The video's stats id is
+	// its attachment id.
+	const isOdysseyStats = config.isEnabled( 'is_odyssey' );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 	const mediaLibraryUrl = isOdysseyStats


### PR DESCRIPTION
Part of STATS-375

## Proposed Changes

* Detect the wp-admin (Odyssey) environment with the `is_odyssey` flag instead of `is_running_in_jetpack_site` when building the video details thumbnail link.

## Why are these changes being made?

`is_running_in_jetpack_site` only signals which API the Odyssey app should call, and it is `false` on Simple sites (see `apps/odyssey-stats/src/lib/create-odyssey-config.ts`). On a Simple site the thumbnail therefore rendered the Calypso-relative `/media/<site>/<id>` link; inside wp-admin that resolves against the site's own origin, and on domain-mapped sites the request then redirects to the primary domain's front end, which 404s. `is_odyssey` is the flag the rest of the stats codebase uses to detect the wp-admin app (e.g. `site.jsx`, `stats-post-detail/index.jsx`), and it is `true` there regardless of Simple/Atomic.

The destination stays the media library (`upload.php?item=<id>`) per the STATS-296 spec: unlike the VideoPress details page, `upload.php` exists regardless of the site's plan, so the link keeps working if the site later downgrades away from VideoPress.

## Testing Instructions

1. On a Simple site with VideoPress videos, open Jetpack Stats in wp-admin (`admin.php?page=stats`) and navigate to a video's details page (`#!/stats/day/videodetails/<site>?post=<id>`).
2. Click the thumbnail in the Video details card: it should open `<site>/wp-admin/upload.php?item=<id>` in a new tab (previously it navigated to a Calypso-relative `/media/...` path that 404s — on domain-mapped sites via a redirect to the primary domain).
3. Repeat on an Atomic or self-hosted Jetpack site: the destination is unchanged there (`upload.php?item=<id>`).
4. In Calypso, open `/stats/day/videodetails/<site>?post=<id>`: the thumbnail should still link to `/media/<site>/<id>`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
