### PR TITLE
Odyssey Stats: fix the stale is_running_in_jetpack_site/is_odyssey comment

### DIFF
--- a/apps/odyssey-stats/src/lib/create-odyssey-config.ts
+++ b/apps/odyssey-stats/src/lib/create-odyssey-config.ts
@@ -121,7 +121,7 @@ export class ConfigApi extends Function {
 
 		// Set a flag to identify if the app is running in WP Admin.
 		// `is_running_in_jetpack_site` now means whether the app calls public-api directly or use the Jetpack ones.
-		// For Simple sites running Odyssey Stats, `is_running_in_jetpack_site` is true and `is_odyssey` is false.
+		// It is false on Simple sites, so use `is_odyssey` — always true here — to detect the wp-admin app.
 		this.configData.features.is_odyssey = true;
 
 		// Sets the Blaze Dashboard path prefix.


### PR DESCRIPTION
Follow-up to #113096

## Proposed Changes

* Correct the stale comment in `create-odyssey-config.ts` describing the `is_running_in_jetpack_site` / `is_odyssey` flags on Simple sites.

## Why are these changes being made?

The comment claimed that on Simple sites `is_running_in_jetpack_site` is true and `is_odyssey` is false — both backwards. The injected config sets `is_running_in_jetpack_site` to `false` on Simple sites (it only signals which API the app calls), and `is_odyssey` is unconditionally set to `true` on the next line. Reading the old comment leads to picking the wrong flag for wp-admin environment detection, which is exactly the bug #113096 fixed.

## Testing Instructions

* Comment-only change; no behavior to test.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
