### PR TITLE
Help Center: record when in the purchase window the CTA is used

### DIFF
--- a/packages/help-center/src/components/help-center-cta.tsx
+++ b/packages/help-center/src/components/help-center-cta.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useLocale } from '@automattic/i18n-utils';
 import { useEffect } from 'react';
 import { Banner, LinkListItem } from './help-center-cta-variants';
 import './help-center-cta.scss';
@@ -24,35 +25,78 @@ export type HelpCenterCTAVariant = keyof typeof HELP_CENTER_CTA_VARIANTS;
 export interface HelpCenterCTAProps extends Omit< HelpCenterCTAVariantProps, 'onClick' > {
 	variant: HelpCenterCTAVariant;
 	ctaId: string;
+	purchasedAt?: number;
+	planFamily?: string;
 }
 
 // Module-level so it survives remounts (e.g. search filtering the More
 // resources list) and only resets on a full page load, per cta_id.
 const reportedCtaIds = new Set< string >();
 
-function useCTATracking(
-	eventProps: { cta_id: string; variant: string; placement: string } | null
-) {
+const DAYS_SINCE_PURCHASE_MAX = 29;
+
+/** `purchasedAt` is a unix timestamp in seconds. Clamped to the 0-29 day window. */
+function daysSincePurchase( purchasedAt: number ): number {
+	const days = Math.floor( ( Date.now() / 1000 - purchasedAt ) / 86400 );
+	return Math.min( Math.max( days, 0 ), DAYS_SINCE_PURCHASE_MAX );
+}
+
+type CTAEventProps = {
+	cta_id: string;
+	variant: string;
+	placement: string;
+	plan_family?: string;
+	locale?: string;
+};
+
+function useCTATracking( eventProps: CTAEventProps | null, purchasedAt?: number ) {
 	useEffect( () => {
 		if ( ! eventProps || reportedCtaIds.has( eventProps.cta_id ) ) {
 			return;
 		}
 		reportedCtaIds.add( eventProps.cta_id );
-		recordTracksEvent( 'calypso_helpcenter_cta_impression', eventProps );
+		recordTracksEvent( 'calypso_helpcenter_cta_impression', {
+			...eventProps,
+			...( Number.isFinite( purchasedAt ) && {
+				days_since_purchase: daysSincePurchase( purchasedAt as number ),
+			} ),
+		} );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ eventProps?.cta_id ] );
 
 	return () => {
-		if ( eventProps ) {
-			recordTracksEvent( 'calypso_helpcenter_cta_click', eventProps );
+		if ( ! eventProps ) {
+			return;
 		}
+		recordTracksEvent( 'calypso_helpcenter_cta_click', {
+			...eventProps,
+			...( Number.isFinite( purchasedAt ) && {
+				days_since_purchase: daysSincePurchase( purchasedAt as number ),
+			} ),
+		} );
 	};
 }
 
-export const HelpCenterCTA: React.FC< HelpCenterCTAProps > = ( { variant, ctaId, ...content } ) => {
+export const HelpCenterCTA: React.FC< HelpCenterCTAProps > = ( {
+	variant,
+	ctaId,
+	purchasedAt,
+	planFamily,
+	...content
+} ) => {
 	const variantDefinition = HELP_CENTER_CTA_VARIANTS[ variant ];
+	const locale = useLocale();
 	const trackClick = useCTATracking(
-		variantDefinition ? { cta_id: ctaId, variant, placement: variantDefinition.placement } : null
+		variantDefinition
+			? {
+					cta_id: ctaId,
+					variant,
+					placement: variantDefinition.placement,
+					...( planFamily && { plan_family: planFamily } ),
+					...( locale && { locale } ),
+			  }
+			: null,
+		purchasedAt
 	);
 
 	if ( ! variantDefinition ) {

--- a/packages/help-center/src/components/test/help-center-cta.tsx
+++ b/packages/help-center/src/components/test/help-center-cta.tsx
@@ -55,6 +55,7 @@ describe( 'HelpCenterCTA', () => {
 				cta_id: baseProps.ctaId,
 				variant: 'banner',
 				placement: 'help-center-home',
+				locale: 'en',
 			} );
 		} );
 
@@ -72,6 +73,7 @@ describe( 'HelpCenterCTA', () => {
 				cta_id: baseProps.ctaId,
 				variant: 'banner',
 				placement: 'help-center-home',
+				locale: 'en',
 			} );
 		} );
 
@@ -107,6 +109,7 @@ describe( 'HelpCenterCTA', () => {
 				cta_id: baseProps.ctaId,
 				variant: 'banner',
 				placement: 'help-center-home',
+				locale: 'en',
 			} );
 		} );
 
@@ -122,6 +125,7 @@ describe( 'HelpCenterCTA', () => {
 				cta_id: baseProps.ctaId,
 				variant: 'banner',
 				placement: 'help-center-home',
+				locale: 'en',
 			} );
 		} );
 	} );
@@ -167,6 +171,7 @@ describe( 'HelpCenterCTA', () => {
 				cta_id: baseProps.ctaId,
 				variant: 'link-list-item',
 				placement: 'help-center-more-resources',
+				locale: 'en',
 			} );
 		} );
 
@@ -186,6 +191,7 @@ describe( 'HelpCenterCTA', () => {
 				cta_id: baseProps.ctaId,
 				variant: 'link-list-item',
 				placement: 'help-center-more-resources',
+				locale: 'en',
 			} );
 		} );
 
@@ -245,6 +251,138 @@ describe( 'HelpCenterCTA', () => {
 				( [ eventName ] ) => eventName === 'calypso_helpcenter_cta_click'
 			);
 			expect( clickCalls ).toHaveLength( 2 );
+		} );
+	} );
+
+	describe( 'day-of-window and campaign properties', () => {
+		beforeEach( () => {
+			jest.useFakeTimers();
+			jest.setSystemTime( new Date( '2026-07-29T00:00:00Z' ) );
+		} );
+
+		afterEach( () => {
+			jest.useRealTimers();
+		} );
+
+		function setupUserEvent() {
+			return userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
+		}
+
+		it( 'includes days_since_purchase, plan_family, and locale on the impression', () => {
+			const baseProps = makeBaseProps();
+			const purchasedAt = Math.floor( Date.now() / 1000 ) - 3 * 86400;
+
+			render(
+				<HelpCenterCTA
+					{ ...baseProps }
+					variant="banner"
+					purchasedAt={ purchasedAt }
+					planFamily="business"
+				/>
+			);
+
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_helpcenter_cta_impression', {
+				cta_id: baseProps.ctaId,
+				variant: 'banner',
+				placement: 'help-center-home',
+				plan_family: 'business',
+				locale: 'en',
+				days_since_purchase: 3,
+			} );
+		} );
+
+		it( 'includes days_since_purchase, plan_family, and locale on the click', async () => {
+			const user = setupUserEvent();
+			const baseProps = makeBaseProps();
+			const purchasedAt = Math.floor( Date.now() / 1000 ) - 3 * 86400;
+
+			render(
+				<HelpCenterCTA
+					{ ...baseProps }
+					variant="banner"
+					purchasedAt={ purchasedAt }
+					planFamily="business"
+				/>
+			);
+			mockRecordTracksEvent.mockClear();
+
+			await user.click( screen.getByRole( 'link' ) );
+
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_helpcenter_cta_click', {
+				cta_id: baseProps.ctaId,
+				variant: 'banner',
+				placement: 'help-center-home',
+				plan_family: 'business',
+				locale: 'en',
+				days_since_purchase: 3,
+			} );
+		} );
+
+		it( 'reports a later day on a click that happens days after the impression', async () => {
+			const user = setupUserEvent();
+			const baseProps = makeBaseProps();
+			const purchasedAt = Math.floor( Date.now() / 1000 );
+
+			render( <HelpCenterCTA { ...baseProps } variant="banner" purchasedAt={ purchasedAt } /> );
+
+			const [ , impressionProps ] = mockRecordTracksEvent.mock.calls.find(
+				( [ eventName ] ) => eventName === 'calypso_helpcenter_cta_impression'
+			);
+			mockRecordTracksEvent.mockClear();
+
+			jest.setSystemTime( new Date( Date.now() + 3 * 86400 * 1000 ) );
+			await user.click( screen.getByRole( 'link' ) );
+
+			const [ , clickProps ] = mockRecordTracksEvent.mock.calls.find(
+				( [ eventName ] ) => eventName === 'calypso_helpcenter_cta_click'
+			);
+			expect( clickProps.days_since_purchase ).toBeGreaterThan(
+				impressionProps.days_since_purchase
+			);
+		} );
+
+		it( 'clamps a purchase far in the past to day 29', () => {
+			const baseProps = makeBaseProps();
+			const purchasedAt = Math.floor( Date.now() / 1000 ) - 45 * 86400;
+
+			render( <HelpCenterCTA { ...baseProps } variant="banner" purchasedAt={ purchasedAt } /> );
+
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_helpcenter_cta_impression',
+				expect.objectContaining( { days_since_purchase: 29 } )
+			);
+		} );
+
+		it( 'clamps a purchase timestamp in the future to day 0', () => {
+			const baseProps = makeBaseProps();
+			const purchasedAt = Math.floor( Date.now() / 1000 ) + 86400;
+
+			render( <HelpCenterCTA { ...baseProps } variant="banner" purchasedAt={ purchasedAt } /> );
+
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_helpcenter_cta_impression',
+				expect.objectContaining( { days_since_purchase: 0 } )
+			);
+		} );
+
+		it( 'omits days_since_purchase from both events when purchasedAt is not supplied', async () => {
+			const user = setupUserEvent();
+			const baseProps = makeBaseProps();
+
+			render( <HelpCenterCTA { ...baseProps } variant="banner" /> );
+
+			const [ , impressionProps ] = mockRecordTracksEvent.mock.calls.find(
+				( [ eventName ] ) => eventName === 'calypso_helpcenter_cta_impression'
+			);
+			expect( impressionProps ).not.toHaveProperty( 'days_since_purchase' );
+
+			mockRecordTracksEvent.mockClear();
+			await user.click( screen.getByRole( 'link' ) );
+
+			const [ , clickProps ] = mockRecordTracksEvent.mock.calls.find(
+				( [ eventName ] ) => eventName === 'calypso_helpcenter_cta_click'
+			);
+			expect( clickProps ).not.toHaveProperty( 'days_since_purchase' );
 		} );
 	} );
 } );

--- a/packages/help-center/src/hooks/test/use-help-center-cta.tsx
+++ b/packages/help-center/src/hooks/test/use-help-center-cta.tsx
@@ -154,6 +154,41 @@ describe( 'useHelpCenterCTA', () => {
 		expect( setup( { cta: { ...bannerCta, url: '/help/contact' } } ).result.current ).toBeNull();
 	} );
 
+	it( 'passes through purchased_at and plan_family, renamed to camelCase', () => {
+		const { result } = setup( {
+			cta: { ...bannerCta, purchased_at: 1234567890, plan_family: 'business' },
+		} );
+
+		expect( result.current ).toMatchObject( {
+			purchasedAt: 1234567890,
+			planFamily: 'business',
+		} );
+	} );
+
+	it( 'drops purchased_at and plan_family when they are not of the right type', () => {
+		const cta = {
+			...bannerCta,
+			purchased_at: 'yesterday',
+			plan_family: 42,
+		} as unknown as SupportStatus[ 'cta' ];
+
+		const { result } = setup( { cta } );
+
+		expect( result.current ).toMatchObject( {
+			purchasedAt: undefined,
+			planFamily: undefined,
+		} );
+	} );
+
+	it( 'renders the CTA without purchasedAt or planFamily when they are absent from the payload', () => {
+		const { result } = setup();
+
+		expect( result.current ).toMatchObject( {
+			purchasedAt: undefined,
+			planFamily: undefined,
+		} );
+	} );
+
 	it( 'returns null and asks the support-status query to stay disabled when the product disables it', () => {
 		const { result } = setup( { enabled: false } );
 

--- a/packages/help-center/src/hooks/use-help-center-cta.ts
+++ b/packages/help-center/src/hooks/use-help-center-cta.ts
@@ -50,5 +50,7 @@ export function useHelpCenterCTA( variant: HelpCenterCTAVariant ): HelpCenterCTA
 		title: cta.title,
 		description: typeof cta.description === 'string' ? cta.description : undefined,
 		actionLabel: typeof cta.url_text === 'string' ? cta.url_text : undefined,
+		purchasedAt: Number.isFinite( cta.purchased_at ) ? cta.purchased_at : undefined,
+		planFamily: typeof cta.plan_family === 'string' ? cta.plan_family : undefined,
 	};
 }

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -90,8 +90,9 @@ interface SupportStatusCTA {
 	title: string;
 	description?: string;
 	url_text?: string;
-	/** Unix timestamp, seconds. Not yet returned by the backend. */
+	/** Unix timestamp (UTC) in seconds representing the time of purchase. */
 	purchased_at?: number;
+	/** Plan family slug (e.g. "business", "commerce"). */
 	plan_family?: string;
 }
 

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -90,6 +90,9 @@ interface SupportStatusCTA {
 	title: string;
 	description?: string;
 	url_text?: string;
+	/** Unix timestamp, seconds. Not yet returned by the backend. */
+	purchased_at?: number;
+	plan_family?: string;
 }
 
 export interface SupportStatus {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-496/track-cta-engagement-timing-within-the-30-day-post-purchase-window

## Proposed Changes

**The Help Center contextual CTA now reports which day of the 30-day post-purchase window each impression and click happened on.**

- Both `calypso_helpcenter_cta_impression` and `calypso_helpcenter_cta_click` gain `days_since_purchase` (0–29), `plan_family` and `locale`.
- The backend sends the purchase moment as `purchased_at` (unix epoch seconds, UTC) rather than a precomputed day number, and each event does its own subtraction at the instant it fires.
- Both payload fields are optional and every property is omitted when the data is missing, so a `days_since_purchase` of `0` always means a genuine day-0 event and never “no data”.

## Why are these changes being made?

The CTA offers an onboarding call to people who have just bought a Business or Commerce plan, and it stays visible for 30 days. Nobody knows *when* in those 30 days people actually act on it. If almost everyone clicks in the first few days, the window is longer than it needs to be. If clicks cluster near the end, an earlier nudge is pointless and the window might even be too short. Today the events record that a click happened, but not where in the window it sat, so the question can’t be answered at all.

The day number is deliberately calculated in the browser at the moment of the event, from a raw purchase timestamp, instead of arriving pre-calculated from the server. The Help Center loads its support status once when it opens and never refreshes it, so a pre-calculated number goes stale in any long-lived tab — a click on day 15 would be filed under day 12. That error only ever points one way, toward earlier days, which would make engagement look front-loaded and produce exactly the wrong conclusion about the window length.

The server side is already live: it ships the two fields on the CTA payload, on top of the eligibility work in [DOTSUP-495](https://linear.app/a8c/issue/DOTSUP-495).

## Testing Instructions

1. Check out this branch and run `yarn start`.
2. Log in as a user with a Business or Commerce plan bought in the last 30 days, then open the Help Center — the CTA appears on the home panel.
3. Confirm the `support-status` response carries `purchased_at` and `plan_family` inside its `cta` object.
4. Watch the Tracks events. The impression should carry `days_since_purchase` matching the number of days since that purchase, plus `plan_family` and `locale`.
5. Click the CTA and confirm the click event carries the same three properties.

The last two cases still need the response overridden in devtools, since a real account only ever sits on one day of the window at a time:

6. Set `purchased_at` to more than 30 days ago and confirm the value clamps to `29`.
7. Remove `purchased_at` entirely and confirm `days_since_purchase` is absent from both events rather than being sent as `0`.

To confirm the staleness behaviour the design turns on: open the Help Center, leave the tab untouched for a while without reloading, then click the CTA. The click must report a higher `days_since_purchase` than the impression did.


