### PR TITLE
Odie: fix AI disclosure contrast on the dark theme

### DIFF
--- a/packages/odie-client/src/style.scss
+++ b/packages/odie-client/src/style.scss
@@ -102,11 +102,23 @@ $blueberry-blue: #3858e9;
 	text-align: center;
 	padding: 8px 8px 0;
 
+	@media screen {
+		:root[data-theme='dark'] & {
+			color: var( --dashboard__text-muted-color, var( --studio-gray-50 ) );
+		}
+	}
+
+	@media screen and ( prefers-color-scheme: dark ) {
+		:root[data-theme='system'] & {
+			color: var( --dashboard__text-muted-color, var( --studio-gray-50 ) );
+		}
+	}
+
 	a,
 	a:visited {
 		color: inherit;
 		text-decoration: underline;
-		text-decoration-color: var( --studio-gray-10 );
+		text-decoration-color: currentcolor;
 		text-decoration-thickness: 1px;
 		text-underline-offset: 2px;
 		font-size: inherit;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-500/help-center-ai-disclosure-text-fails-contrast-on-the-dark-theme

## Proposed Changes

**The AI disclosure line under the chat input now switches to the dark-theme muted color instead of staying locked to a light-theme gray.**

- `.odie-ai-disclosure` picks up `--dashboard__text-muted-color` under `:root[data-theme='dark']` (and under `data-theme='system'` when the OS prefers dark), falling back to `--studio-gray-50` everywhere else.
- The "Learn more" underline now uses `currentcolor` rather than the near-white `--studio-gray-10`.
- Same override pattern already used by `help-center-support-chat-message.scss`, so this only aligns Odie with its neighbour.

## Why are these changes being made?

On the dark theme, the "You’re chatting with an AI assistant. Responses may be inaccurate." line is a dim gray on a near-black background — roughly a 3:1 contrast ratio, where the accessibility floor for text that small is 4.5:1 ([DOTSUP-500](https://linear.app/a8c/issue/DOTSUP-500/help-center-ai-disclosure-text-fails-contrast-on-the-dark-theme)). It reads as barely-there placeholder text, which is a poor outcome for a disclosure we are specifically meant to make legible.

The underline had the opposite problem: it was a much lighter gray than the text it belonged to, so the link's underline was brighter than the link itself.

## Testing Instructions

### Calypso

1. Run `yarn start`.
2. Switch the dashboard to the dark theme (Profile → Appearance, or set the OS to dark with the theme on "System").
3. Open the Help Center and start an AI chat.
4. Confirm the disclosure text below the input is comfortably readable, and that the "Learn more" underline matches the text color.
5. Switch back to the light theme and confirm nothing changed there.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
4. Open the Help Center, start an AI chat, and confirm the disclosure text still renders exactly as before (these contexts don't set `data-theme`, so they keep the light-theme color).

