### PR TITLE
Site page: Add "all purchases" link

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -32,7 +32,6 @@ import {
 	siteCrontabsQuery,
 	sitePreviewLinksQuery,
 	sitePrimaryDataCenterQuery,
-	purchaseQuery,
 	sitePurchasesQuery,
 	siteRedirectQuery,
 	siteScanQuery,
@@ -220,10 +219,8 @@ export const siteOverviewRoute = createRoute( {
 				queryClient.prefetchQuery( sitePreviewLinksQuery( site.ID ) );
 			}
 
-			const currentPlan = await queryClient.ensureQueryData( siteCurrentPlanQuery( site.ID ) );
-			if ( currentPlan.id ) {
-				queryClient.ensureQueryData( purchaseQuery( currentPlan.id ) );
-			}
+			queryClient.prefetchQuery( siteCurrentPlanQuery( site.ID ) );
+			queryClient.prefetchQuery( sitePurchasesQuery( site.ID ) );
 		}
 
 		await Promise.all( [

--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -1,5 +1,5 @@
 import { DotcomPlans, JetpackPlans, WooHostedPlans } from '@automattic/api-core';
-import { siteCurrentPlanQuery, siteByIdQuery, purchaseQuery } from '@automattic/api-queries';
+import { siteCurrentPlanQuery, siteByIdQuery, sitePurchasesQuery } from '@automattic/api-queries';
 import { JetpackLogo } from '@automattic/components/src/logos/jetpack-logo';
 import { useQuery } from '@tanstack/react-query';
 import {
@@ -136,10 +136,12 @@ function JetpackPlanCard( {
 function WpcomPlanCard( {
 	site,
 	purchase,
+	hasPurchases,
 	isLoading,
 }: {
 	site: Site;
 	purchase?: Purchase;
+	hasPurchases: boolean;
 	isLoading: boolean;
 } ) {
 	return (
@@ -154,7 +156,7 @@ function WpcomPlanCard( {
 			bottom={
 				<VStack spacing={ 3 }>
 					<SitePlanStats site={ site } />
-					{ purchase && <SeeAllPurchasesLink site={ site } /> }
+					{ hasPurchases && <SeeAllPurchasesLink site={ site } /> }
 				</VStack>
 			}
 		/>
@@ -224,12 +226,12 @@ function CommerceGardenPlanCard( {
 
 export default function PlanCard( { site }: { site: Site } ) {
 	const { data: plan, isLoading: isLoadingPlan } = useQuery( siteCurrentPlanQuery( site.ID ) );
-	const { data: purchase, isLoading: isLoadingPurchase } = useQuery( {
-		...purchaseQuery( plan?.id ?? 0 ),
-		enabled: !! plan?.id,
-	} );
+	const { data: purchases, isLoading: isLoadingPurchases } = useQuery(
+		sitePurchasesQuery( site.ID )
+	);
+	const purchase = purchases?.find( ( sitePurchase ) => sitePurchase.ID === plan?.id );
 
-	const isLoading = isLoadingPlan || isLoadingPurchase;
+	const isLoading = isLoadingPlan || isLoadingPurchases;
 
 	if ( site.is_a4a_dev_site ) {
 		return <AgencyPlanCard site={ site } isLoading={ isLoading } />;
@@ -247,7 +249,14 @@ export default function PlanCard( { site }: { site: Site } ) {
 		return <WpcomStagingSitePlanCard site={ site } />;
 	}
 
-	return <WpcomPlanCard site={ site } purchase={ purchase } isLoading={ isLoading } />;
+	return (
+		<WpcomPlanCard
+			site={ site }
+			purchase={ purchase }
+			hasPurchases={ ( purchases?.length ?? 0 ) > 0 }
+			isLoading={ isLoading }
+		/>
+	);
 }
 
 function getCardDescription( site: Site, purchase?: Purchase ) {

--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -3,6 +3,7 @@ import { siteCurrentPlanQuery, siteByIdQuery, purchaseQuery } from '@automattic/
 import { JetpackLogo } from '@automattic/components/src/logos/jetpack-logo';
 import { useQuery } from '@tanstack/react-query';
 import {
+	Button,
 	__experimentalGrid as Grid,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
@@ -11,9 +12,13 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
+import { useAnalytics } from '../../app/analytics';
+import { purchasesRoute } from '../../app/router/me';
 import { commerceGardenPlan } from '../../components/icons';
 import OverviewCard from '../../components/overview-card';
 import { PurchaseExpiryStatus } from '../../components/purchase-expiry-status';
+import RouterLinkButton from '../../components/router-link-button';
+import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import {
 	getJetpackProductsForSite,
 	getSitePlanDisplayName,
@@ -48,6 +53,37 @@ function SitePlanStats( { site }: { site: Site } ) {
 			<SiteStorageStat site={ site } />
 			<SiteBandwidthStat site={ site } />
 		</VStack>
+	);
+}
+
+function SeeAllPurchasesLink( { site }: { site: Site } ) {
+	const { recordTracksEvent } = useAnalytics();
+
+	const handleClick = () => {
+		recordTracksEvent( 'calypso_dashboard_site_overview_see_all_purchases_click' );
+	};
+
+	if ( isDashboardBackport() ) {
+		return (
+			<Button
+				variant="link"
+				href={ `/purchases/subscriptions/${ site.slug }` }
+				onClick={ handleClick }
+			>
+				{ __( 'See all purchases' ) }
+			</Button>
+		);
+	}
+
+	return (
+		<RouterLinkButton
+			variant="link"
+			to={ purchasesRoute.fullPath }
+			search={ { site: site.ID } }
+			onClick={ handleClick }
+		>
+			{ __( 'See all purchases' ) }
+		</RouterLinkButton>
 	);
 }
 
@@ -115,7 +151,12 @@ function WpcomPlanCard( {
 			link={ getSitePlanUrl( site, purchase ) }
 			tracksId="site-overview-plan"
 			isLoading={ isLoading }
-			bottom={ <SitePlanStats site={ site } /> }
+			bottom={
+				<VStack spacing={ 3 }>
+					<SitePlanStats site={ site } />
+					{ purchase && <SeeAllPurchasesLink site={ site } /> }
+				</VStack>
+			}
 		/>
 	);
 }


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/DOTMSD-1385/no-path-to-billing-for-domains-or-email-purchases-from-site-overview

## Proposed changes

Adds a "See all purchases" link to the Plan card on the Dashboard's single-site overview page, linking to the purchases list pre-filtered to that site.

* Add a "See all purchases" link to the Plan card, navigating to `/me/billing/purchases?site=<siteId>` (or the classic `/purchases/subscriptions/<slug>` when running in dashboard-backport mode)
* Replace the current-plan-only `purchaseQuery` call with `sitePurchasesQuery(site.ID)`, so purchases like domain registrations or email subscriptions are fetched alongside the plan purchase
* Gate the new link on the site having any purchases at all (`hasPurchases`), rather than requiring a plan purchase specifically, so it still appears for Free-plan sites that only have a domain or email purchase

Before             |  After
:-------------------------:|:-------------------------:
<img width="990" height="452" alt="Screenshot 2026-07-29 at 5 49 18 PM" src="https://github.com/user-attachments/assets/7edf8859-5162-4a30-b9d9-c00c8bfee0c5" /> | <img width="992" height="466" alt="Screenshot 2026-07-29 at 5 44 12 PM" src="https://github.com/user-attachments/assets/2231fed1-c682-4ca6-8dee-79d08904cc1e" />

## Why are these changes being made?

On the Dashboard's single-site overview page, the only existing path to a site's billing was the Plan card's own link, which only surfaces when the site has a purchase tied to its *current plan*. A site on the Free plan with a separately purchased domain or email subscription had no way to reach its purchases from the overview page at all.

This adds a lightweight, site-scoped "See all purchases" link, reusing the same `search={ { site: site.ID } }` filtering pattern already used elsewhere (e.g. the site deletion and leave-site flows) to open the purchases list pre-filtered to just this site's purchases.

## Testing instructions

* Use a local Dashboard instance (`yarn start-dashboard`) or a sandbox
* Visit `/sites/<site-slug>` for a WordPress.com site with a plan purchase — confirm a "See all purchases" link appears under the Plan card's storage/bandwidth stats, and clicking it opens `/me/billing/purchases` pre-filtered to that site
* Confirm Jetpack self-hosted connected sites and A4A dev sites are unaffected (they already have their own purchase-management links elsewhere)

