### PR TITLE
Billing: Link between single-site filter purchases and receipts

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -189,6 +189,20 @@ export const billingHistoryIndexRoute = createRoute( {
 	path: '/',
 	loader: () => {
 		queryClient.prefetchQuery( userReceiptsQuery() );
+		queryClient.prefetchQuery( allSitesQuery() );
+	},
+	validateSearch: (
+		search
+	): {
+		page?: number;
+		search?: string;
+		site?: number;
+	} => {
+		return {
+			page: typeof search.page === 'number' ? search.page : undefined,
+			search: typeof search.search === 'string' ? search.search : undefined,
+			site: typeof search.site === 'number' ? search.site : undefined,
+		};
 	},
 } ).lazy( () =>
 	import( '../../me/billing-history' ).then( ( d ) =>

--- a/client/dashboard/me/billing-history/dataviews.tsx
+++ b/client/dashboard/me/billing-history/dataviews.tsx
@@ -17,7 +17,7 @@ import {
 	summarizeReceiptItems,
 	transactionIncludesTax,
 } from './utils';
-import type { CountryListItem, Receipt } from '@automattic/api-core';
+import type { CountryListItem, Receipt, Site } from '@automattic/api-core';
 import type { Fields, Operator, SortDirection, View } from '@wordpress/dataviews';
 
 import './styles.scss';
@@ -97,9 +97,36 @@ export function getFields(
 	receipts: Receipt[],
 	countryList: CountryListItem[] = [],
 	visibleFields: string[] = WIDE_FIELDS,
-	locale: string
+	locale: string,
+	sites: Site[] = [],
+	siteFilter?: number
 ): Fields< Receipt > {
+	// No point in having a filter if there's only one site.
+	const shouldAllowSiteFilter = sites.length > 1;
+
 	return [
+		{
+			id: 'site',
+			label: __( 'Site' ),
+			type: 'text',
+			enableGlobalSearch: true,
+			enableSorting: false,
+			enableHiding: false,
+			...( shouldAllowSiteFilter
+				? {
+						elements: sites.map( ( site ) => {
+							return { value: String( site.ID ), label: `${ site.name } (${ site.slug })` };
+						} ),
+						filterBy: {
+							operators: [ 'isAny' as Operator ],
+							...( siteFilter && { isPrimary: true } ),
+						},
+				  }
+				: { filterBy: false } ),
+			getValue: ( { item }: { item: Receipt } ) => {
+				return getReceiptSiteIds( item );
+			},
+		},
 		{
 			id: 'date',
 			label: __( 'Date' ),
@@ -309,6 +336,10 @@ function formatReceiptDate( receipt: Receipt, locale: string ): string {
 		month: 'short',
 		day: 'numeric',
 	} );
+}
+
+function getReceiptSiteIds( receipt: Receipt ): string[] {
+	return [ ...new Set( receipt.items.map( ( item ) => String( item.site_id ) ) ) ];
 }
 
 function getServicesForFiltering( receipts: Receipt[] ): Array< { value: string; label: string } > {

--- a/client/dashboard/me/billing-history/index.tsx
+++ b/client/dashboard/me/billing-history/index.tsx
@@ -1,17 +1,19 @@
-import { countryListQuery, userReceiptsQuery } from '@automattic/api-queries';
+import { allSitesQuery, countryListQuery, userReceiptsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { useResizeObserver } from '@wordpress/compose';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo } from 'react';
+import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { usePersistentView } from '../../app/hooks/use-persistent-view';
 import { useLocale } from '../../app/locale';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
-import { billingHistoryRoute } from '../../app/router/me';
+import { billingHistoryRoute, purchasesRoute } from '../../app/router/me';
 import { DataViews, DataViewsCard } from '../../components/dataviews';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import RouterLinkButton from '../../components/router-link-button';
 import { adjustDataViewFieldsForWidth } from '../../utils/dataviews-width';
 import {
 	WIDE_FIELDS,
@@ -26,8 +28,12 @@ import type { Receipt } from '@automattic/api-core';
 const emptyReceipts: Receipt[] = [];
 
 export default function BillingHistory() {
-	const { data: receipts = emptyReceipts, isLoading } = useQuery( userReceiptsQuery() );
+	const { data: receipts = emptyReceipts, isLoading: isLoadingReceipts } = useQuery(
+		userReceiptsQuery()
+	);
 	const { data: countryList = [] } = useQuery( countryListQuery() );
+	const { data: sites = [], isLoading: isLoadingSites } = useQuery( allSitesQuery() );
+	const isLoading = isLoadingReceipts || isLoadingSites;
 
 	const locale = useLocale();
 	const searchParams = billingHistoryRoute.useSearch();
@@ -36,6 +42,7 @@ export default function BillingHistory() {
 		slug: 'me-billing-history',
 		defaultView,
 		queryParams: searchParams,
+		queryParamFilterFields: [ 'site' ],
 	} );
 
 	const ref = useResizeObserver( ( entries ) => {
@@ -52,8 +59,16 @@ export default function BillingHistory() {
 	} );
 
 	const fields = useMemo(
-		() => getFields( receipts, countryList, view.fields ?? WIDE_FIELDS, locale ),
-		[ receipts, countryList, view.fields, locale ]
+		() =>
+			getFields(
+				receipts,
+				countryList,
+				view.fields ?? WIDE_FIELDS,
+				locale,
+				sites,
+				searchParams.site
+			),
+		[ receipts, countryList, view.fields, locale, sites, searchParams.site ]
 	);
 
 	const { data: filteredReceipts, paginationInfo } = useMemo( () => {
@@ -66,6 +81,13 @@ export default function BillingHistory() {
 		return receipt.id.toString();
 	};
 
+	const { recordTracksEvent } = useAnalytics();
+	const siteFilterValue = view.filters?.find( ( filter ) => filter.field === 'site' )?.value;
+	const activeSiteId =
+		Array.isArray( siteFilterValue ) && siteFilterValue.length === 1
+			? Number( siteFilterValue[ 0 ] )
+			: undefined;
+
 	return (
 		<PageLayout
 			size="large"
@@ -74,6 +96,22 @@ export default function BillingHistory() {
 					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ __( 'Billing history' ) }
 					description={ __( 'View receipts and billing history for your purchases.' ) }
+					actions={
+						activeSiteId !== undefined && (
+							<RouterLinkButton
+								variant="secondary"
+								to={ purchasesRoute.fullPath }
+								search={ { site: activeSiteId } }
+								onClick={ () =>
+									recordTracksEvent(
+										'calypso_dashboard_billing_history_see_purchases_for_site_click'
+									)
+								}
+							>
+								{ __( 'View active upgrades for this site' ) }
+							</RouterLinkButton>
+						)
+					}
 				/>
 			}
 		>

--- a/client/dashboard/me/billing-history/test/dataviews.test.tsx
+++ b/client/dashboard/me/billing-history/test/dataviews.test.tsx
@@ -2,10 +2,11 @@
  * @jest-environment jsdom
  */
 import { screen } from '@testing-library/react';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { type ComponentType } from 'react';
 import { render } from '../../../test-utils';
 import { getFields } from '../dataviews';
-import type { Receipt, User } from '@automattic/api-core';
+import type { Receipt, Site, User } from '@automattic/api-core';
 
 const receipt = {
 	id: 1,
@@ -97,5 +98,59 @@ describe( '<BillingHistory>', () => {
 		expect( screen.queryByText( 'Type' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Amount' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Date' ) ).not.toBeInTheDocument();
+	} );
+
+	describe( 'site filtering', () => {
+		const siteA = { ID: 1, name: 'Site A', slug: 'site-a.wordpress.com' } as Site;
+		const siteB = { ID: 2, name: 'Site B', slug: 'site-b.wordpress.com' } as Site;
+
+		const receiptForSiteA = receipt;
+		const receiptForSiteB = {
+			...receipt,
+			id: 2,
+			items: [ { ...receipt.items[ 0 ], id: 2, site_id: 2 } ],
+		} as Receipt;
+
+		test( 'offers a site filter when the user has more than one site', () => {
+			const fields = getFields( [ receiptForSiteA ], [], [ 'date', 'service' ], LOCALE, [
+				siteA,
+				siteB,
+			] );
+			const siteField = fields.find( ( field ) => field.id === 'site' )!;
+
+			expect( siteField.filterBy ).not.toBe( false );
+			expect( siteField.elements ).toEqual( [
+				{ value: '1', label: 'Site A (site-a.wordpress.com)' },
+				{ value: '2', label: 'Site B (site-b.wordpress.com)' },
+			] );
+		} );
+
+		test( 'does not offer a site filter when the user has only one site', () => {
+			const fields = getFields( [ receiptForSiteA ], [], [ 'date', 'service' ], LOCALE, [ siteA ] );
+			const siteField = fields.find( ( field ) => field.id === 'site' )!;
+
+			expect( siteField.filterBy ).toBe( false );
+		} );
+
+		test( 'filtering by site only keeps receipts with a matching line item', () => {
+			const fields = getFields(
+				[ receiptForSiteA, receiptForSiteB ],
+				[],
+				[ 'date', 'service' ],
+				LOCALE,
+				[ siteA, siteB ]
+			);
+
+			const { data } = filterSortAndPaginate(
+				[ receiptForSiteA, receiptForSiteB ],
+				{
+					type: 'table',
+					filters: [ { field: 'site', operator: 'isAny', value: [ '1' ] } ],
+				},
+				fields
+			);
+
+			expect( data ).toEqual( [ receiptForSiteA ] );
+		} );
 	} );
 } );

--- a/client/dashboard/me/billing-history/test/index.test.tsx
+++ b/client/dashboard/me/billing-history/test/index.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import BillingHistory from '../index';
+import type { Receipt, Site, User } from '@automattic/api-core';
+
+const SITE_A_ID = 1;
+const SITE_B_ID = 2;
+
+const sites = [
+	{
+		ID: SITE_A_ID,
+		name: 'Site A',
+		slug: 'site-a.wordpress.com',
+	} as Site,
+	{
+		ID: SITE_B_ID,
+		name: 'Site B',
+		slug: 'site-b.wordpress.com',
+	} as Site,
+];
+
+function makeReceipt( id: number, siteId: number, variation: string ): Receipt {
+	return {
+		id,
+		service: 'WordPress.com',
+		service_slug: 'wpcom',
+		currency: 'USD',
+		subtotal_integer: 9600,
+		tax_integer: 0,
+		amount_integer: 9600,
+		tax_country_code: 'US',
+		date: '2026-05-21T00:00:00+00:00',
+		desc: '',
+		org: '',
+		address: null,
+		icon: '',
+		url: '',
+		support: '',
+		pay_ref: '',
+		pay_part: '',
+		cc_type: '',
+		cc_display_brand: '',
+		cc_num: '',
+		cc_name: '',
+		cc_email: '',
+		credit: '',
+		items: [
+			{
+				id,
+				type: 'recurring',
+				type_localized: 'Renewal',
+				domain: null,
+				site_id: siteId,
+				subtotal_integer: 9600,
+				tax_integer: 0,
+				amount_integer: 9600,
+				currency: 'USD',
+				licensed_quantity: 0,
+				new_quantity: 0,
+				product: variation,
+				product_slug: 'personal-bundle',
+				variation,
+				variation_slug: '',
+				months_per_renewal_interval: 12,
+				wpcom_product_slug: 'personal-bundle',
+				cost_overrides: [],
+				volume: 0,
+				credits_used: null,
+				introductory_offer_terms: null,
+				price_tier_slug: '',
+				saas_redirect_url: '',
+			},
+		],
+	} as unknown as Receipt;
+}
+
+const receipts = [
+	makeReceipt( 1, SITE_A_ID, 'Site A Personal Plan' ),
+	makeReceipt( 2, SITE_B_ID, 'Site B Business Plan' ),
+];
+
+const testUser = { ID: 1, username: 'testuser', language: 'en' } as User;
+
+function mockEndpoints( { siteList = sites }: { siteList?: Site[] } = {} ) {
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( '/rest/v1.1/me/preferences' )
+		.query( true )
+		.reply( 200, { calypso_preferences: {} } );
+
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.3/me/billing-history/past' )
+		.query( true )
+		.reply( 200, { billing_history: receipts, billing_history_total: receipts.length } );
+
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.2/me/sites' )
+		.query( true )
+		.reply( 200, { sites: siteList, total: siteList.length } );
+}
+
+describe( '<BillingHistory>', () => {
+	test( 'shows receipts for every site', async () => {
+		mockEndpoints();
+		render( <BillingHistory />, { user: testUser } );
+
+		const table = await screen.findByRole( 'table' );
+		expect( within( table ).getByText( 'Site A Personal Plan' ) ).toBeVisible();
+		expect( within( table ).getByText( 'Site B Business Plan' ) ).toBeVisible();
+	} );
+
+	test( 'offers a site filter when the user has more than one site', async () => {
+		mockEndpoints();
+		const user = userEvent.setup();
+		render( <BillingHistory />, { user: testUser } );
+
+		await screen.findByRole( 'table' );
+		await user.click( screen.getByRole( 'button', { name: 'Add filter' } ) );
+
+		expect( screen.getByRole( 'menuitem', { name: 'Site' } ) ).toBeVisible();
+	} );
+
+	test( 'does not offer a site filter when the user only has one site', async () => {
+		mockEndpoints( { siteList: [ sites[ 0 ] ] } );
+		const user = userEvent.setup();
+		render( <BillingHistory />, { user: testUser } );
+
+		await screen.findByRole( 'table' );
+		await user.click( screen.getByRole( 'button', { name: 'Add filter' } ) );
+
+		expect( screen.queryByRole( 'menuitem', { name: 'Site' } ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/me/billing-purchases/index.tsx
+++ b/client/dashboard/me/billing-purchases/index.tsx
@@ -9,13 +9,15 @@ import { useResizeObserver } from '@wordpress/compose';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useMemo, useState } from 'react';
+import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { usePersistentView } from '../../app/hooks/use-persistent-view';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
-import { purchasesIndexRoute, purchasesRoute } from '../../app/router/me';
+import { billingHistoryRoute, purchasesIndexRoute, purchasesRoute } from '../../app/router/me';
 import { DataViews, DataViewsCard } from '../../components/dataviews';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import RouterLinkButton from '../../components/router-link-button';
 import { adjustDataViewFieldsForWidth } from '../../utils/dataviews-width';
 import { useIsSplitCancelRemoveEnabled } from './cancel-purchase/use-is-split-cancel-remove-enabled';
 import {
@@ -117,6 +119,13 @@ export default function PurchasesList() {
 		transferredPurchases,
 	} );
 
+	const { recordTracksEvent } = useAnalytics();
+	const siteFilterValue = view.filters?.find( ( filter ) => filter.field === 'site' )?.value;
+	const activeSiteId =
+		Array.isArray( siteFilterValue ) && siteFilterValue.length === 1
+			? Number( siteFilterValue[ 0 ] )
+			: undefined;
+
 	return (
 		<PageLayout
 			size="large"
@@ -125,6 +134,22 @@ export default function PurchasesList() {
 					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ __( 'Active upgrades' ) }
 					description={ __( 'View and manage your active plans and purchases.' ) }
+					actions={
+						activeSiteId !== undefined && (
+							<RouterLinkButton
+								variant="secondary"
+								to={ billingHistoryRoute.fullPath }
+								search={ { site: activeSiteId } }
+								onClick={ () =>
+									recordTracksEvent(
+										'calypso_dashboard_purchases_see_billing_history_for_site_click'
+									)
+								}
+							>
+								{ __( 'View billing history for this site' ) }
+							</RouterLinkButton>
+						)
+					}
 				/>
 			}
 		>


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTMSD-1385/no-path-to-billing-for-domains-or-email-purchases-from-site-overview

## Proposed Changes

This PR adds links between the Active upgrades and Billing history pages of the Dashboard when either one is filtered to a single-site view.

Billing history             |  Active upgrades
:-------------------------:|:-------------------------:
<img width="993" height="458" alt="history-to-purchases" src="https://github.com/user-attachments/assets/e1402f35-7413-41bb-85db-21038eabc8e2" /> | <img width="994" height="399" alt="upgrades-to-receipts" src="https://github.com/user-attachments/assets/67101100-24eb-48d1-8f56-2c53166f10ae" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

While many users are ok with managing the billing for their entire account, some prefer to view the purchases or receipts for a single site at a time. Calypso's previous billing pages allowed for this easily. However, currently there's no easy way in the Dashboard billing history page or active upgrades page to link from one to the other even if the purchases for a single site are being displayed without first going back to the user-level account page and then adding the same filter.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit http://my.localhost:3000/me/billing/history and filter your purchases by a single site.
- Click the "View active upgrades for this site" button that appears in the upper-right.
- Verify that the active upgrades page is also filtered by that same site.
- Click the "View billing history for this site" button.
- Verify that you return to the billing history page, still filtered.
- Remove the filter (or select multiple sites) and verify that the button disappears.

