### PR TITLE
Reader: Add Unsubscribe action on sidebar

### DIFF
--- a/client/reader/data/site-subscriptions/index.ts
+++ b/client/reader/data/site-subscriptions/index.ts
@@ -2,4 +2,3 @@ export * from './cache';
 export * from './use-follow-mutations';
 export * from './use-follow-selectors';
 export * from './use-site-subscriptions';
-export * from './use-unsubscribe-with-undo';

--- a/client/reader/data/site-subscriptions/index.ts
+++ b/client/reader/data/site-subscriptions/index.ts
@@ -2,3 +2,4 @@ export * from './cache';
 export * from './use-follow-mutations';
 export * from './use-follow-selectors';
 export * from './use-site-subscriptions';
+export * from './use-unsubscribe-with-undo';

--- a/client/reader/data/site-subscriptions/test/use-unsubscribe-with-undo.test.tsx
+++ b/client/reader/data/site-subscriptions/test/use-unsubscribe-with-undo.test.tsx
@@ -24,13 +24,12 @@ jest.mock( 'calypso/state', () => ( {
 
 const params = {
 	feedUrl: 'https://example.com/feed',
-	blogId: 42,
 	siteName: 'Example Blog',
 	source: 'recent',
 };
 
-const target = { feedUrl: params.feedUrl, blogId: params.blogId };
-const eventProps = { blog_id: params.blogId, source: params.source };
+const target = { feedUrl: params.feedUrl };
+const eventProps = { feed_url: params.feedUrl, source: params.source };
 
 // The notice action carries the Undo handler in its options, which is the only  way to exercise undo without rendering the global notices tree.
 const getNotice = () => mockDispatch.mock.calls[ 0 ][ 0 ].notice;
@@ -50,7 +49,7 @@ describe( 'useUnsubscribeWithUndo', () => {
 			'calypso_reader_unsubscribe_clicked',
 			eventProps
 		);
-		expect( getNotice().text ).toBe( 'Unsubscribed from Example Blog.' );
+		expect( getNotice().text ).toBe( 'Success! You are now unsubscribed from "Example Blog".' );
 		expect( getNotice().button ).toBe( 'Undo' );
 	} );
 
@@ -59,7 +58,9 @@ describe( 'useUnsubscribeWithUndo', () => {
 
 		result.current( { ...params, siteName: undefined } );
 
-		expect( getNotice().text ).toBe( `Unsubscribed from ${ params.feedUrl }.` );
+		expect( getNotice().text ).toBe(
+			`Success! You are now unsubscribed from "${ params.feedUrl }".`
+		);
 	} );
 
 	test( 'undo re-subscribes and dismisses the notice', () => {

--- a/client/reader/data/site-subscriptions/test/use-unsubscribe-with-undo.test.tsx
+++ b/client/reader/data/site-subscriptions/test/use-unsubscribe-with-undo.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { useUnsubscribeWithUndo } from '../use-unsubscribe-with-undo';
+
+const mockFollowSite = jest.fn();
+const mockUnfollowSite = jest.fn();
+jest.mock( '../use-follow-mutations', () => ( {
+	useFollowSite: () => ( { mutate: mockFollowSite } ),
+	useUnfollowSite: () => ( { mutate: mockUnfollowSite } ),
+} ) );
+
+const mockRecordReaderTracksEvent = jest.fn();
+jest.mock( 'calypso/state/reader/analytics/useRecordReaderTracksEvent', () => ( {
+	useRecordReaderTracksEvent: () => mockRecordReaderTracksEvent,
+} ) );
+
+const mockDispatch = jest.fn();
+jest.mock( 'calypso/state', () => ( {
+	...jest.requireActual( 'calypso/state' ),
+	useDispatch: () => mockDispatch,
+} ) );
+
+const params = {
+	feedUrl: 'https://example.com/feed',
+	blogId: 42,
+	siteName: 'Example Blog',
+	source: 'recent',
+};
+
+const target = { feedUrl: params.feedUrl, blogId: params.blogId };
+const eventProps = { blog_id: params.blogId, source: params.source };
+
+// The notice action carries the Undo handler in its options, which is the only  way to exercise undo without rendering the global notices tree.
+const getNotice = () => mockDispatch.mock.calls[ 0 ][ 0 ].notice;
+
+describe( 'useUnsubscribeWithUndo', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'unsubscribes, records the tracks event, and shows an undo notice', () => {
+		const { result } = renderHook( () => useUnsubscribeWithUndo() );
+
+		result.current( params );
+
+		expect( mockUnfollowSite ).toHaveBeenCalledWith( target );
+		expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_unsubscribe_clicked',
+			eventProps
+		);
+		expect( getNotice().text ).toBe( 'Unsubscribed from Example Blog.' );
+		expect( getNotice().button ).toBe( 'Undo' );
+	} );
+
+	test( 'falls back to the feed URL when the site has no name', () => {
+		const { result } = renderHook( () => useUnsubscribeWithUndo() );
+
+		result.current( { ...params, siteName: undefined } );
+
+		expect( getNotice().text ).toBe( `Unsubscribed from ${ params.feedUrl }.` );
+	} );
+
+	test( 'undo re-subscribes and dismisses the notice', () => {
+		const { result } = renderHook( () => useUnsubscribeWithUndo() );
+
+		result.current( params );
+		const notice = getNotice();
+		notice.onClick();
+
+		expect( mockFollowSite ).toHaveBeenCalledWith( target );
+		expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_unsubscribe_undo_clicked',
+			eventProps
+		);
+		expect( mockDispatch ).toHaveBeenCalledWith(
+			expect.objectContaining( { type: 'NOTICE_REMOVE', noticeId: notice.noticeId } )
+		);
+	} );
+} );

--- a/client/reader/data/site-subscriptions/use-unsubscribe-with-undo.ts
+++ b/client/reader/data/site-subscriptions/use-unsubscribe-with-undo.ts
@@ -1,0 +1,49 @@
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'calypso/state';
+import { removeNotice, successNotice } from 'calypso/state/notices/actions';
+import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
+import { useFollowSite, useUnfollowSite } from './use-follow-mutations';
+
+const UNSUBSCRIBE_NOTICE_ID = 'reader-sidebar-unsubscribe-with-undo';
+
+interface UnsubscribeWithUndoParams {
+	feedUrl: string;
+	blogId?: number;
+	siteName?: string;
+	source?: string;
+}
+
+/**
+ * Unsubscribes from a site and offers an Undo in the success notice.
+ */
+export const useUnsubscribeWithUndo = () => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const recordReaderTracksEvent = useRecordReaderTracksEvent();
+	const { mutate: followSite } = useFollowSite();
+	const { mutate: unfollowSite } = useUnfollowSite();
+
+	return ( { feedUrl, blogId, siteName, source }: UnsubscribeWithUndoParams ): void => {
+		const target = { feedUrl, blogId: blogId ?? undefined };
+		const eventProps = { blog_id: target.blogId, feed_url: target.feedUrl, source };
+
+		recordReaderTracksEvent( 'calypso_reader_unsubscribe_clicked', eventProps );
+		unfollowSite( target );
+
+		dispatch(
+			successNotice(
+				translate( 'Success! You are now unsubscribed from "%s".', { args: siteName || feedUrl } ),
+				{
+					id: UNSUBSCRIBE_NOTICE_ID,
+					duration: 5000,
+					button: translate( 'Undo' ) as string,
+					onClick: () => {
+						recordReaderTracksEvent( 'calypso_reader_unsubscribe_undo_clicked', eventProps );
+						followSite( target );
+						dispatch( removeNotice( UNSUBSCRIBE_NOTICE_ID ) );
+					},
+				}
+			)
+		);
+	};
+};

--- a/client/reader/data/site-subscriptions/use-unsubscribe-with-undo.ts
+++ b/client/reader/data/site-subscriptions/use-unsubscribe-with-undo.ts
@@ -8,7 +8,6 @@ const UNSUBSCRIBE_NOTICE_ID = 'reader-sidebar-unsubscribe-with-undo';
 
 interface UnsubscribeWithUndoParams {
 	feedUrl: string;
-	blogId?: number;
 	siteName?: string;
 	source?: string;
 }
@@ -23,9 +22,9 @@ export const useUnsubscribeWithUndo = () => {
 	const { mutate: followSite } = useFollowSite();
 	const { mutate: unfollowSite } = useUnfollowSite();
 
-	return ( { feedUrl, blogId, siteName, source }: UnsubscribeWithUndoParams ): void => {
-		const target = { feedUrl, blogId: blogId ?? undefined };
-		const eventProps = { blog_id: target.blogId, feed_url: target.feedUrl, source };
+	return ( { feedUrl, siteName, source }: UnsubscribeWithUndoParams ): void => {
+		const target = { feedUrl };
+		const eventProps = { feed_url: target.feedUrl, source };
 
 		recordReaderTracksEvent( 'calypso_reader_unsubscribe_clicked', eventProps );
 		unfollowSite( target );

--- a/client/reader/get-helpers.ts
+++ b/client/reader/get-helpers.ts
@@ -272,3 +272,40 @@ export const getFollowerCount = ( feed: ReaderFeed, site: ReaderSite ): number |
 
 	return null;
 };
+
+interface GetSiteNameForSidebarArgs {
+	name?: string;
+	URL?: string;
+}
+
+const isFreeWpcomSubdomain = ( host = '' ): boolean => /\.wordpress\.com$/i.test( host );
+
+/**
+ * Label for a followed site: real title, else an `r/subreddit` handle, else the
+ * resolved domain. Untitled WordPress.com sites come back named after their free
+ * subdomain, so those fall through to the domain from `URL`.
+ */
+export function getReaderSidebarSiteName( site: GetSiteNameForSidebarArgs ): string {
+	const siteName = site.name ?? '';
+	// `name` may be URL-shaped, so normalize before the subdomain check.
+	const normalizedName = formatUrlForDisplay( siteName ) || siteName;
+
+	if ( siteName && ! isFreeWpcomSubdomain( normalizedName ) ) {
+		return siteName;
+	}
+
+	// A title-less subreddit reads best as its `r/name` (or `u/name`) handle, since
+	// every subreddit resolves to the same generic `reddit.com` domain. The host is
+	// anchored so only genuine `reddit.com` feeds qualify.
+	const reddit = site.URL?.match( /^https?:\/\/(?:[^/]+\.)?reddit\.com\/(r|user)\/([^/?#]+)/i );
+	if ( reddit ) {
+		return `${ reddit[ 1 ].toLowerCase() === 'user' ? 'u' : 'r' }/${ reddit[ 2 ] }`;
+	}
+
+	const siteDomain = site.URL ? getSiteDomain( { site: { URL: site.URL } } ) : undefined;
+	if ( siteDomain ) {
+		return siteDomain;
+	}
+
+	return siteName;
+}

--- a/client/reader/list/controller.jsx
+++ b/client/reader/list/controller.jsx
@@ -30,14 +30,22 @@ export const createList = ( context, next ) => {
 	next();
 };
 
+/**
+ * Returns a unique stream key for a list based on the owner and slug.
+ * @param {string} owner
+ * @param {string} slug
+ * @returns {string}
+ */
+export const getListStreamKey = ( owner, slug ) => {
+	return `list:${ JSON.stringify( { owner, slug } ) }`;
+};
+
 export const listListing = ( context, next ) => {
 	const basePath = '/reader/list/:owner/:slug';
 	const view = context.params.view || 'posts';
 	const fullAnalyticsPageTitle =
 		analyticsPageTitle + ' > List > ' + context.params.user + ' - ' + context.params.list;
 	const mcKey = 'list';
-	const streamKey =
-		'list:' + JSON.stringify( { owner: context.params.user, slug: context.params.list } );
 	const state = context.store.getState();
 
 	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
@@ -53,8 +61,8 @@ export const listListing = ( context, next ) => {
 	context.primary = (
 		<AsyncLoad
 			require={ loadList }
-			key={ 'tag-' + context.params.user + '-' + context.params.list }
-			streamKey={ streamKey }
+			key={ 'list-' + context.params.user + '-' + context.params.list }
+			streamKey={ getListStreamKey( context.params.user, context.params.list ) }
 			owner={ encodeURIComponent( context.params.user ) }
 			slug={ encodeURIComponent( context.params.list ) }
 			view={ view }

--- a/client/reader/sidebar/more-menu-actions/index.tsx
+++ b/client/reader/sidebar/more-menu-actions/index.tsx
@@ -6,7 +6,7 @@ import { DropdownMenu } from '@wordpress/components';
 import { check, moreHorizontal, trash } from '@wordpress/icons';
 import { fixMe, useTranslate } from 'i18n-calypso';
 import { useMarkAllAsSeenMutation } from 'calypso/reader/data/seen-posts';
-import { useUnsubscribeWithUndo } from 'calypso/reader/data/site-subscriptions';
+import { useUnsubscribeWithUndo } from 'calypso/reader/data/site-subscriptions/use-unsubscribe-with-undo';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
 
 type MoreMenuActionsProps = {
@@ -17,7 +17,6 @@ type MoreMenuActionsProps = {
 	unseenCount: number;
 
 	// Props for the single feed case.
-	blogId?: number;
 	isSingleFeed?: boolean;
 	siteName?: string;
 	onUnsubscribed?: () => void;
@@ -30,7 +29,6 @@ export default function MoreMenuActions( {
 	feedUrls,
 	source,
 	unseenCount,
-	blogId,
 	siteName,
 	onUnsubscribed,
 }: MoreMenuActionsProps ) {
@@ -57,7 +55,7 @@ export default function MoreMenuActions( {
 			return;
 		}
 
-		unsubscribeWithUndo( { feedUrl, blogId, siteName, source } );
+		unsubscribeWithUndo( { feedUrl, siteName, source } );
 		onUnsubscribed?.();
 	};
 
@@ -98,16 +96,20 @@ export default function MoreMenuActions( {
 		isDisabled: unseenCount === 0,
 	};
 
-	const unsubscribeControl = {
-		title: translate( 'Unsubscribe' ) as string,
-		icon: trash,
-		onClick: handleUnsubscribe,
-	};
-
 	// Each nested set renders as its own group; DropdownMenu draws a separator before the first item of every set after the first.
-	const controls = isSingleFeed
-		? [ [ markAsSeenControl ], [ unsubscribeControl ] ]
-		: [ [ markAsSeenControl ] ];
+	const controls = [ [ markAsSeenControl ] ];
+
+	// Add the unsubscribe control if this is a single feed.
+	if ( isSingleFeed && feedUrls.length === 1 ) {
+		const unsubscribeControl = {
+			title: translate( 'Unsubscribe' ) as string,
+			icon: trash,
+			onClick: handleUnsubscribe,
+			isDisabled: false,
+		};
+
+		controls.push( [ unsubscribeControl ] );
+	}
 
 	return (
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions

--- a/client/reader/sidebar/more-menu-actions/index.tsx
+++ b/client/reader/sidebar/more-menu-actions/index.tsx
@@ -3,30 +3,42 @@ import './style.scss';
 import { isAutomatticianQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { DropdownMenu } from '@wordpress/components';
-import { check, moreHorizontal } from '@wordpress/icons';
+import { check, moreHorizontal, trash } from '@wordpress/icons';
 import { fixMe, useTranslate } from 'i18n-calypso';
 import { useMarkAllAsSeenMutation } from 'calypso/reader/data/seen-posts';
+import { useUnsubscribeWithUndo } from 'calypso/reader/data/site-subscriptions';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
 
 type MoreMenuActionsProps = {
-	identifier: string;
-	isSingleFeed?: boolean;
 	feedIds: number[];
 	feedUrls: string[];
+	identifier: string;
+	source: string;
 	unseenCount: number;
+
+	// Props for the single feed case.
+	blogId?: number;
+	isSingleFeed?: boolean;
+	siteName?: string;
+	onUnsubscribed?: () => void;
 };
 
-export function MoreMenuActions( {
+export default function MoreMenuActions( {
 	identifier,
 	isSingleFeed = true,
 	feedIds,
 	feedUrls,
+	source,
 	unseenCount,
+	blogId,
+	siteName,
+	onUnsubscribed,
 }: MoreMenuActionsProps ) {
 	const translate = useTranslate();
 	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
 	const recordReaderTracksEvent = useRecordReaderTracksEvent();
 	const { mutate: markAllAsSeen } = useMarkAllAsSeenMutation();
+	const unsubscribeWithUndo = useUnsubscribeWithUndo();
 
 	// Remove when "Mark all as seen" is available to all users.
 	if ( ! isAutomattician ) {
@@ -34,8 +46,19 @@ export function MoreMenuActions( {
 	}
 
 	const handleMarkAllAsSeen = () => {
-		recordReaderTracksEvent( 'calypso_reader_mark_all_as_seen_clicked', { source: identifier } );
+		recordReaderTracksEvent( 'calypso_reader_mark_all_as_seen_clicked', { source } );
 		markAllAsSeen( { identifier, feedIds, feedUrls } );
+	};
+
+	const handleUnsubscribe = () => {
+		// A single feed always carries exactly one URL.
+		const feedUrl = isSingleFeed ? feedUrls[ 0 ] : undefined;
+		if ( ! feedUrl ) {
+			return;
+		}
+
+		unsubscribeWithUndo( { feedUrl, blogId, siteName, source } );
+		onUnsubscribed?.();
 	};
 
 	// The trigger sits inside an <a href> (menu-item rows) or an <a> with a
@@ -68,6 +91,24 @@ export function MoreMenuActions( {
 				oldCopy: translate( 'Mark all as seen' ),
 		  } ) as string );
 
+	const markAsSeenControl = {
+		title,
+		icon: check,
+		onClick: handleMarkAllAsSeen,
+		isDisabled: unseenCount === 0,
+	};
+
+	const unsubscribeControl = {
+		title: translate( 'Unsubscribe' ) as string,
+		icon: trash,
+		onClick: handleUnsubscribe,
+	};
+
+	// Each nested set renders as its own group; DropdownMenu draws a separator before the first item of every set after the first.
+	const controls = isSingleFeed
+		? [ [ markAsSeenControl ], [ unsubscribeControl ] ]
+		: [ [ markAsSeenControl ] ];
+
 	return (
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<span
@@ -84,14 +125,7 @@ export function MoreMenuActions( {
 					focusOnMount: true,
 					placement: 'bottom-end',
 				} }
-				controls={ [
-					{
-						title,
-						icon: check,
-						onClick: handleMarkAllAsSeen,
-						isDisabled: unseenCount === 0,
-					},
-				] }
+				controls={ controls }
 			/>
 		</span>
 	);

--- a/client/reader/sidebar/more-menu-actions/test/index.test.tsx
+++ b/client/reader/sidebar/more-menu-actions/test/index.test.tsx
@@ -19,7 +19,7 @@ jest.mock( 'calypso/state/reader/analytics/useRecordReaderTracksEvent', () => ( 
 } ) );
 
 const mockUnsubscribeWithUndo = jest.fn();
-jest.mock( 'calypso/reader/data/site-subscriptions', () => ( {
+jest.mock( 'calypso/reader/data/site-subscriptions/use-unsubscribe-with-undo', () => ( {
 	useUnsubscribeWithUndo: () => mockUnsubscribeWithUndo,
 } ) );
 
@@ -29,15 +29,17 @@ const defaultProps: ComponentProps< typeof MoreMenuActions > = {
 	feedIds: [ 1, 2 ],
 	feedUrls: [ 'https://example.com/feed', 'https://another.example.com/feed' ],
 	unseenCount: 3,
+	source: 'testing',
 };
 
-const singleFeedProps = {
+const singleFeedProps: ComponentProps< typeof MoreMenuActions > = {
+	identifier: 'feed:1',
 	isSingleFeed: true,
 	feedIds: [ 1 ],
 	feedUrls: [ 'https://example.com/feed' ],
-	blogId: 42,
 	siteName: 'Example Blog',
-	source: 'recent',
+	source: 'testing',
+	unseenCount: 0,
 };
 
 function renderMoreMenuActions( props = {} ) {
@@ -88,7 +90,7 @@ describe( 'MoreMenuActions', () => {
 
 		expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
 			'calypso_reader_mark_all_as_seen_clicked',
-			{ source: defaultProps.identifier }
+			{ source: defaultProps.source }
 		);
 		expect( mockMarkAllAsSeen ).toHaveBeenCalledWith( {
 			identifier: defaultProps.identifier,
@@ -186,7 +188,6 @@ describe( 'MoreMenuActions', () => {
 
 			expect( mockUnsubscribeWithUndo ).toHaveBeenCalledWith( {
 				feedUrl: singleFeedProps.feedUrls[ 0 ],
-				blogId: singleFeedProps.blogId,
 				siteName: singleFeedProps.siteName,
 				source: singleFeedProps.source,
 			} );

--- a/client/reader/sidebar/more-menu-actions/test/index.test.tsx
+++ b/client/reader/sidebar/more-menu-actions/test/index.test.tsx
@@ -6,7 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ComponentProps } from 'react';
-import { MoreMenuActions } from '../index';
+import MoreMenuActions from '../index';
 
 const mockMarkAllAsSeen = jest.fn();
 jest.mock( 'calypso/reader/data/seen-posts', () => ( {
@@ -18,12 +18,26 @@ jest.mock( 'calypso/state/reader/analytics/useRecordReaderTracksEvent', () => ( 
 	useRecordReaderTracksEvent: () => mockRecordReaderTracksEvent,
 } ) );
 
+const mockUnsubscribeWithUndo = jest.fn();
+jest.mock( 'calypso/reader/data/site-subscriptions', () => ( {
+	useUnsubscribeWithUndo: () => mockUnsubscribeWithUndo,
+} ) );
+
 const defaultProps: ComponentProps< typeof MoreMenuActions > = {
 	identifier: 'following',
 	isSingleFeed: false,
 	feedIds: [ 1, 2 ],
 	feedUrls: [ 'https://example.com/feed', 'https://another.example.com/feed' ],
 	unseenCount: 3,
+};
+
+const singleFeedProps = {
+	isSingleFeed: true,
+	feedIds: [ 1 ],
+	feedUrls: [ 'https://example.com/feed' ],
+	blogId: 42,
+	siteName: 'Example Blog',
+	source: 'recent',
 };
 
 function renderMoreMenuActions( props = {} ) {
@@ -131,6 +145,52 @@ describe( 'MoreMenuActions', () => {
 			expect(
 				screen.queryByRole( 'menuitem', { name: 'Mark all as read' } )
 			).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'unsubscribe', () => {
+		test( 'renders the action for a single feed', async () => {
+			const user = userEvent.setup();
+			renderMoreMenuActions( singleFeedProps );
+
+			await openMoreActionsMenu( user );
+
+			expect( screen.getByRole( 'menuitem', { name: 'Unsubscribe' } ) ).toBeEnabled();
+		} );
+
+		test( 'is hidden on a section header', async () => {
+			const user = userEvent.setup();
+			renderMoreMenuActions( { ...singleFeedProps, isSingleFeed: false } );
+
+			await openMoreActionsMenu( user );
+
+			expect( screen.queryByRole( 'menuitem', { name: 'Unsubscribe' } ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'is hidden when there is no feed URL', async () => {
+			const user = userEvent.setup();
+			renderMoreMenuActions( { ...singleFeedProps, feedUrls: [] } );
+
+			await openMoreActionsMenu( user );
+
+			expect( screen.queryByRole( 'menuitem', { name: 'Unsubscribe' } ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'unsubscribes the feed and notifies the host', async () => {
+			const user = userEvent.setup();
+			const onUnsubscribed = jest.fn();
+			renderMoreMenuActions( { ...singleFeedProps, onUnsubscribed } );
+
+			await openMoreActionsMenu( user );
+			await user.click( screen.getByRole( 'menuitem', { name: 'Unsubscribe' } ) );
+
+			expect( mockUnsubscribeWithUndo ).toHaveBeenCalledWith( {
+				feedUrl: singleFeedProps.feedUrls[ 0 ],
+				blogId: singleFeedProps.blogId,
+				siteName: singleFeedProps.siteName,
+				source: singleFeedProps.source,
+			} );
+			expect( onUnsubscribed ).toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/client/reader/sidebar/reader-sidebar-lists/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-lists/index.tsx
@@ -57,10 +57,11 @@ const ReaderSidebarLists = ( {
 				expandableIconClick={ onClick }
 				moreMenuActions={
 					<MoreMenuActions
-						identifier="sidebar-lists"
+						identifier=""
 						isSingleFeed={ false }
 						feedIds={ allFeedIds }
 						feedUrls={ [] }
+						source="sidebar-list-header"
 						unseenCount={ totalUnseenCount }
 					/>
 				}

--- a/client/reader/sidebar/reader-sidebar-lists/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-lists/index.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import ReaderUnreadCount from 'calypso/layout/sidebar/reader-unread-count';
-import { MoreMenuActions } from '../more-menu-actions';
+import MoreMenuActions from '../more-menu-actions';
 import ReaderSidebarListsList from './list';
 
 interface ReaderSidebarListsProps {

--- a/client/reader/sidebar/reader-sidebar-lists/list-item.tsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import AutoDirection from 'calypso/components/auto-direction';
 import ReaderUnreadCount from 'calypso/layout/sidebar/reader-unread-count';
+import { getListStreamKey } from 'calypso/reader/list/controller';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
@@ -100,10 +101,11 @@ const ReaderSidebarListsListItem = ( {
 				{ isSeenEnabled && (
 					<span className="sidebar__actions-and-count">
 						<MoreMenuActions
-							identifier="sidebar-list"
+							identifier={ getListStreamKey( list.owner, list.slug ) }
 							isSingleFeed={ false }
 							feedIds={ feedIds }
 							feedUrls={ [] }
+							source="sidebar-list-item"
 							unseenCount={ unseenCount }
 						/>
 						<ReaderUnreadCount count={ unseenCount } />

--- a/client/reader/sidebar/reader-sidebar-lists/list-item.tsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item.tsx
@@ -11,7 +11,7 @@ import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
 import ReaderSidebarHelper from '../helper';
 import { MenuItem, MenuItemLink } from '../menu';
-import { MoreMenuActions } from '../more-menu-actions';
+import MoreMenuActions from '../more-menu-actions';
 
 interface ReaderSidebarListsListItemProps {
 	list: ReadList;

--- a/client/reader/sidebar/reader-sidebar-lists/test/index.test.tsx
+++ b/client/reader/sidebar/reader-sidebar-lists/test/index.test.tsx
@@ -109,7 +109,7 @@ describe( 'ReaderSidebarLists', () => {
 			await user.click( screen.getByRole( 'menuitem', { name: 'Mark all as read' } ) );
 
 			expect( mockMarkAllAsSeen ).toHaveBeenCalledWith( {
-				identifier: 'sidebar-lists',
+				identifier: '',
 				feedIds: [ 10, 11, 20 ],
 				feedUrls: [],
 			} );

--- a/client/reader/sidebar/reader-sidebar-lists/test/list-item.test.tsx
+++ b/client/reader/sidebar/reader-sidebar-lists/test/list-item.test.tsx
@@ -4,6 +4,7 @@
 import { ReadList } from '@automattic/api-core';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { getListStreamKey } from 'calypso/reader/list/controller';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import ReaderSidebarListsListItem from '../list-item';
 
@@ -145,7 +146,7 @@ describe( 'ReaderSidebarListsListItem', () => {
 			await user.click( screen.getByRole( 'menuitem', { name: 'Mark all as read' } ) );
 
 			expect( mockMarkAllAsSeen ).toHaveBeenCalledWith( {
-				identifier: 'sidebar-list',
+				identifier: getListStreamKey( listWithUnseen.owner, listWithUnseen.slug ),
 				feedIds: [ 1, 2 ],
 				feedUrls: [],
 			} );

--- a/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
@@ -6,8 +6,8 @@ import { SiteIcon } from 'calypso/blocks/site-icon';
 import AutoDirection from 'calypso/components/auto-direction';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import ReaderUnreadCount from 'calypso/layout/sidebar/reader-unread-count';
-import { MoreMenuActions } from 'calypso/reader/sidebar/more-menu-actions';
-import { getReaderSidebarSiteName } from 'calypso/reader/sidebar/reader-sidebar-recent';
+import { getReaderSidebarSiteName } from 'calypso/reader/get-helpers';
+import MoreMenuActions from 'calypso/reader/sidebar/more-menu-actions';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import ReaderSidebarHelper from '../helper';
@@ -62,7 +62,6 @@ export class ReaderSidebarOrganizationsListItem extends Component {
 								feedIds={ [ feedId ] }
 								feedUrls={ [ site.feed_URL ] }
 								unseenCount={ site.unseen_count }
-								blogId={ site.blog_ID }
 								siteName={ getReaderSidebarSiteName( site ) }
 								source="reader-organization-item"
 								onUnsubscribed={ () => {

--- a/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -6,6 +7,7 @@ import AutoDirection from 'calypso/components/auto-direction';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import ReaderUnreadCount from 'calypso/layout/sidebar/reader-unread-count';
 import { MoreMenuActions } from 'calypso/reader/sidebar/more-menu-actions';
+import { getReaderSidebarSiteName } from 'calypso/reader/sidebar/reader-sidebar-recent';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import ReaderSidebarHelper from '../helper';
@@ -15,6 +17,7 @@ export class ReaderSidebarOrganizationsListItem extends Component {
 	static propTypes = {
 		site: PropTypes.object,
 		path: PropTypes.string,
+		fallbackPath: PropTypes.string,
 	};
 
 	handleSidebarClick = () => {
@@ -26,7 +29,7 @@ export class ReaderSidebarOrganizationsListItem extends Component {
 	};
 
 	render() {
-		const { site, path, moment } = this.props;
+		const { site, path, moment, fallbackPath } = this.props;
 		const computedClassName = ReaderSidebarHelper.itemLinkClass(
 			'/reader/feeds/' + site.feed_ID,
 			path
@@ -59,6 +62,14 @@ export class ReaderSidebarOrganizationsListItem extends Component {
 								feedIds={ [ feedId ] }
 								feedUrls={ [ site.feed_URL ] }
 								unseenCount={ site.unseen_count }
+								blogId={ site.blog_ID }
+								siteName={ getReaderSidebarSiteName( site ) }
+								source="reader-organization-item"
+								onUnsubscribed={ () => {
+									if ( selected && fallbackPath ) {
+										page( fallbackPath );
+									}
+								} }
 							/>
 						) }
 						<ReaderUnreadCount count={ site.unseen_count } />

--- a/client/reader/sidebar/reader-sidebar-organizations/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list.jsx
@@ -12,7 +12,7 @@ import {
 import { AUTOMATTIC_ORG_ID, P2_ORG_ID } from 'calypso/state/reader/organizations/constants';
 import { toggleReaderSidebarOrganization } from 'calypso/state/reader-ui/sidebar/actions';
 import { isOrganizationOpen } from 'calypso/state/reader-ui/sidebar/selectors';
-import { MoreMenuActions } from '../more-menu-actions';
+import MoreMenuActions from '../more-menu-actions';
 import ReaderSidebarOrganizationsListItem from './list-item';
 
 export class ReaderSidebarOrganizationsList extends Component {
@@ -41,10 +41,19 @@ export class ReaderSidebarOrganizationsList extends Component {
 	};
 
 	renderSites() {
-		const { sites, path } = this.props;
+		const { sites, path, organization } = this.props;
+		const fallbackPath = organization.slug ? `/reader/${ organization.slug }` : '/reader';
+
 		return sites.map(
 			( site ) =>
-				site && <ReaderSidebarOrganizationsListItem key={ site.ID } path={ path } site={ site } />
+				site && (
+					<ReaderSidebarOrganizationsListItem
+						key={ site.ID }
+						path={ path }
+						site={ site }
+						fallbackPath={ fallbackPath }
+					/>
+				)
 		);
 	}
 
@@ -88,6 +97,7 @@ export class ReaderSidebarOrganizationsList extends Component {
 						isSingleFeed={ false }
 						feedIds={ feedsInfo.feedIds }
 						feedUrls={ feedsInfo.feedUrls }
+						source="reader-organization-header"
 						unseenCount={ feedsInfo.unseenCount }
 					/>
 				}

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -12,8 +12,7 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import ReaderUnreadCount from 'calypso/layout/sidebar/reader-unread-count';
 import { useSubscribedFeedsInfo, useSubscribedSites } from 'calypso/reader/data/site-subscriptions';
-import { getSiteDomain } from 'calypso/reader/get-helpers';
-import { formatUrlForDisplay } from 'calypso/reader/lib/feed-display-helper';
+import { getReaderSidebarSiteName } from 'calypso/reader/get-helpers';
 import MoreMenuActions from 'calypso/reader/sidebar/more-menu-actions';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
@@ -30,40 +29,6 @@ type Props = {
 
 const SITE_DISPLAY_CUTOFF = 5;
 const RECENT_PATH_REGEX = /^\/reader(?:\/recent\/\d+)?\/?(?:\?|$)/;
-
-type ReaderSidebarSite = Pick< ReturnType< typeof useSubscribedSites >[ number ], 'name' | 'URL' >;
-
-const isFreeWpcomSubdomain = ( host = '' ): boolean => /\.wordpress\.com$/i.test( host );
-
-/**
- * Label for a followed site: real title, else an `r/subreddit` handle, else the
- * resolved domain. Untitled WordPress.com sites come back named after their free
- * subdomain, so those fall through to the domain from `URL`.
- */
-export function getReaderSidebarSiteName( site: ReaderSidebarSite ): string {
-	const siteName = site.name ?? '';
-	// `name` may be URL-shaped, so normalize before the subdomain check.
-	const normalizedName = formatUrlForDisplay( siteName ) || siteName;
-
-	if ( siteName && ! isFreeWpcomSubdomain( normalizedName ) ) {
-		return siteName;
-	}
-
-	// A title-less subreddit reads best as its `r/name` (or `u/name`) handle, since
-	// every subreddit resolves to the same generic `reddit.com` domain. The host is
-	// anchored so only genuine `reddit.com` feeds qualify.
-	const reddit = site.URL?.match( /^https?:\/\/(?:[^/]+\.)?reddit\.com\/(r|user)\/([^/?#]+)/i );
-	if ( reddit ) {
-		return `${ reddit[ 1 ].toLowerCase() === 'user' ? 'u' : 'r' }/${ reddit[ 2 ] }`;
-	}
-
-	const siteDomain = site.URL ? getSiteDomain( { site: { URL: site.URL } } ) : undefined;
-	if ( siteDomain ) {
-		return siteDomain;
-	}
-
-	return siteName;
-}
 
 const ReaderSidebarRecent = ( { isOpen, onClick, path, className }: Props ): React.JSX.Element => {
 	const translate = useTranslate();
@@ -169,7 +134,6 @@ const ReaderSidebarRecent = ( { isOpen, onClick, path, className }: Props ): Rea
 											feedUrls={ [ site.feed_URL ] }
 											source="sidebar-recent-item"
 											unseenCount={ unseenCount }
-											blogId={ Number( site.blog_ID ) }
 											siteName={ displayName }
 											onUnsubscribed={ () => {
 												if ( feedId === selectedSiteFeedId ) {

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -14,7 +14,7 @@ import ReaderUnreadCount from 'calypso/layout/sidebar/reader-unread-count';
 import { useSubscribedFeedsInfo, useSubscribedSites } from 'calypso/reader/data/site-subscriptions';
 import { getSiteDomain } from 'calypso/reader/get-helpers';
 import { formatUrlForDisplay } from 'calypso/reader/lib/feed-display-helper';
-import { MoreMenuActions } from 'calypso/reader/sidebar/more-menu-actions';
+import MoreMenuActions from 'calypso/reader/sidebar/more-menu-actions';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
 import { getSelectedRecentFeedId } from 'calypso/state/reader-ui/sidebar/selectors';
@@ -134,6 +134,7 @@ const ReaderSidebarRecent = ( { isOpen, onClick, path, className }: Props ): Rea
 					isSingleFeed={ false }
 					feedIds={ feedsInfo.feedIds }
 					feedUrls={ feedsInfo.feedUrls }
+					source="sidebar-recent-header"
 					unseenCount={ feedsInfo.unseenCount }
 				/>
 			}
@@ -166,7 +167,15 @@ const ReaderSidebarRecent = ( { isOpen, onClick, path, className }: Props ): Rea
 											identifier={ `feed:${ feedId }` }
 											feedIds={ [ feedId ] }
 											feedUrls={ [ site.feed_URL ] }
+											source="sidebar-recent-item"
 											unseenCount={ unseenCount }
+											blogId={ Number( site.blog_ID ) }
+											siteName={ displayName }
+											onUnsubscribed={ () => {
+												if ( feedId === selectedSiteFeedId ) {
+													page( '/reader' );
+												}
+											} }
 										/>
 									) }
 									{ isSeenEnabled && <ReaderUnreadCount count={ unseenCount } /> }

--- a/client/reader/sidebar/reader-sidebar-recent/test/index.test.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/test/index.test.tsx
@@ -31,6 +31,7 @@ let mockSubscribedFeedsInfo = { unseenCount: 0, feedIds: [], feedUrls: [] };
 jest.mock( 'calypso/reader/data/site-subscriptions', () => ( {
 	useSubscribedSites: () => mockSubscribedSites,
 	useSubscribedFeedsInfo: () => mockSubscribedFeedsInfo,
+	useUnsubscribeWithUndo: () => jest.fn(),
 } ) );
 
 function createSubscriptionItem(

--- a/client/reader/sidebar/reader-sidebar-recent/test/index.test.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/test/index.test.tsx
@@ -5,7 +5,7 @@ import { SiteSubscriptionItem } from '@automattic/data-stores/src/reader/types';
 import { screen } from '@testing-library/react';
 import readerUi from 'calypso/state/reader-ui/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
-import ReaderSidebarRecent, { getReaderSidebarSiteName } from '../index';
+import ReaderSidebarRecent from '../index';
 
 jest.mock( '@automattic/calypso-router', () => ( {
 	__esModule: true,
@@ -31,6 +31,9 @@ let mockSubscribedFeedsInfo = { unseenCount: 0, feedIds: [], feedUrls: [] };
 jest.mock( 'calypso/reader/data/site-subscriptions', () => ( {
 	useSubscribedSites: () => mockSubscribedSites,
 	useSubscribedFeedsInfo: () => mockSubscribedFeedsInfo,
+} ) );
+
+jest.mock( 'calypso/reader/data/site-subscriptions/use-unsubscribe-with-undo', () => ( {
 	useUnsubscribeWithUndo: () => jest.fn(),
 } ) );
 
@@ -95,99 +98,5 @@ describe( 'ReaderSidebarRecent unseen counts', () => {
 		expect( alphaRow?.querySelector( '.a8c-count' ) ).toHaveTextContent( '4' );
 		expect( alphaRow?.querySelector( '.a8c-count' ) ).toHaveAccessibleName( '4 unread (30 days)' );
 		expect( betaRow?.querySelector( '.a8c-count' ) ).toBeNull();
-	} );
-} );
-
-// Untitled sites come back from the API URL-shaped with a trailing slash,
-// e.g. "example.wordpress.com/".
-describe( 'getReaderSidebarSiteName', () => {
-	test( 'shows the mapped custom domain when the name is the free subdomain (with trailing slash)', () => {
-		expect(
-			getReaderSidebarSiteName( {
-				name: 'exampleblog.wordpress.com/',
-				URL: 'https://example.com',
-			} )
-		).toBe( 'example.com' );
-	} );
-
-	test( 'handles a name with protocol and trailing slash', () => {
-		expect(
-			getReaderSidebarSiteName( {
-				name: 'https://exampleblog.wordpress.com/',
-				URL: 'https://example.org',
-			} )
-		).toBe( 'example.org' );
-	} );
-
-	test( 'shows the mapped custom domain when the site has no name at all', () => {
-		expect( getReaderSidebarSiteName( { name: '', URL: 'https://example.net' } ) ).toBe(
-			'example.net'
-		);
-	} );
-
-	test( 'keeps a real site title untouched', () => {
-		expect(
-			getReaderSidebarSiteName( { name: 'Example Site Title', URL: 'https://example.com' } )
-		).toBe( 'Example Site Title' );
-	} );
-
-	test( 'shows the clean subdomain (no trailing slash) when the site has no custom domain', () => {
-		expect(
-			getReaderSidebarSiteName( {
-				name: 'exampleblog.wordpress.com/',
-				URL: 'https://exampleblog.wordpress.com',
-			} )
-		).toBe( 'exampleblog.wordpress.com' );
-	} );
-
-	test( 'falls back to the raw name when there is no URL to derive a domain from', () => {
-		expect( getReaderSidebarSiteName( { name: 'Example Site Title', URL: '' } ) ).toBe(
-			'Example Site Title'
-		);
-	} );
-
-	test( 'derives an r/subreddit label from the URL for an unresolved subreddit', () => {
-		expect(
-			getReaderSidebarSiteName( {
-				name: '',
-				URL: 'https://www.reddit.com/r/simracing/.rss',
-			} )
-		).toBe( 'r/simracing' );
-	} );
-
-	test( 'derives a u/user label from a Reddit user URL', () => {
-		expect(
-			getReaderSidebarSiteName( {
-				name: '',
-				URL: 'https://www.reddit.com/user/spez/.rss',
-			} )
-		).toBe( 'u/spez' );
-	} );
-
-	test( 'prefers the r/subreddit handle over the generic reddit.com domain when the title is missing', () => {
-		expect(
-			getReaderSidebarSiteName( {
-				name: '',
-				URL: 'https://www.reddit.com/r/simracing/',
-			} )
-		).toBe( 'r/simracing' );
-	} );
-
-	test( 'keeps the resolved title for a subreddit once it has one', () => {
-		expect(
-			getReaderSidebarSiteName( {
-				name: 'SimRacing',
-				URL: 'https://www.reddit.com/r/simracing/',
-			} )
-		).toBe( 'SimRacing' );
-	} );
-
-	test( 'does not treat a reddit.com look-alike host as Reddit', () => {
-		expect(
-			getReaderSidebarSiteName( {
-				name: '',
-				URL: 'https://fakereddit.com/r/simracing/',
-			} )
-		).toBe( 'fakereddit.com' );
 	} );
 } );

--- a/client/reader/test/get-helpers.ts
+++ b/client/reader/test/get-helpers.ts
@@ -1,4 +1,4 @@
-import { getSiteUrl, getSiteName, getPostIcon } from '../get-helpers';
+import { getSiteUrl, getSiteName, getPostIcon, getReaderSidebarSiteName } from '../get-helpers';
 
 describe( 'getSiteUrl', () => {
 	const siteWithUrl = { URL: 'siteWithUrl.com' };
@@ -117,5 +117,99 @@ describe( 'getSiteName', () => {
 		expect( getSiteName() ).toBeNull();
 
 		expect( getSiteName( { feed: {}, site: {}, post: {} } ) ).toBeNull();
+	} );
+} );
+
+// Untitled sites come back from the API URL-shaped with a trailing slash,
+// e.g. "example.wordpress.com/".
+describe( 'getReaderSidebarSiteName', () => {
+	test( 'shows the mapped custom domain when the name is the free subdomain (with trailing slash)', () => {
+		expect(
+			getReaderSidebarSiteName( {
+				name: 'exampleblog.wordpress.com/',
+				URL: 'https://example.com',
+			} )
+		).toBe( 'example.com' );
+	} );
+
+	test( 'handles a name with protocol and trailing slash', () => {
+		expect(
+			getReaderSidebarSiteName( {
+				name: 'https://exampleblog.wordpress.com/',
+				URL: 'https://example.org',
+			} )
+		).toBe( 'example.org' );
+	} );
+
+	test( 'shows the mapped custom domain when the site has no name at all', () => {
+		expect( getReaderSidebarSiteName( { name: '', URL: 'https://example.net' } ) ).toBe(
+			'example.net'
+		);
+	} );
+
+	test( 'keeps a real site title untouched', () => {
+		expect(
+			getReaderSidebarSiteName( { name: 'Example Site Title', URL: 'https://example.com' } )
+		).toBe( 'Example Site Title' );
+	} );
+
+	test( 'shows the clean subdomain (no trailing slash) when the site has no custom domain', () => {
+		expect(
+			getReaderSidebarSiteName( {
+				name: 'exampleblog.wordpress.com/',
+				URL: 'https://exampleblog.wordpress.com',
+			} )
+		).toBe( 'exampleblog.wordpress.com' );
+	} );
+
+	test( 'falls back to the raw name when there is no URL to derive a domain from', () => {
+		expect( getReaderSidebarSiteName( { name: 'Example Site Title', URL: '' } ) ).toBe(
+			'Example Site Title'
+		);
+	} );
+
+	test( 'derives an r/subreddit label from the URL for an unresolved subreddit', () => {
+		expect(
+			getReaderSidebarSiteName( {
+				name: '',
+				URL: 'https://www.reddit.com/r/simracing/.rss',
+			} )
+		).toBe( 'r/simracing' );
+	} );
+
+	test( 'derives a u/user label from a Reddit user URL', () => {
+		expect(
+			getReaderSidebarSiteName( {
+				name: '',
+				URL: 'https://www.reddit.com/user/spez/.rss',
+			} )
+		).toBe( 'u/spez' );
+	} );
+
+	test( 'prefers the r/subreddit handle over the generic reddit.com domain when the title is missing', () => {
+		expect(
+			getReaderSidebarSiteName( {
+				name: '',
+				URL: 'https://www.reddit.com/r/simracing/',
+			} )
+		).toBe( 'r/simracing' );
+	} );
+
+	test( 'keeps the resolved title for a subreddit once it has one', () => {
+		expect(
+			getReaderSidebarSiteName( {
+				name: 'SimRacing',
+				URL: 'https://www.reddit.com/r/simracing/',
+			} )
+		).toBe( 'SimRacing' );
+	} );
+
+	test( 'does not treat a reddit.com look-alike host as Reddit', () => {
+		expect(
+			getReaderSidebarSiteName( {
+				name: '',
+				URL: 'https://fakereddit.com/r/simracing/',
+			} )
+		).toBe( 'fakereddit.com' );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: https://linear.app/a8c/issue/READ-645

## Proposed Changes

Add unsubscribe action on Recent, Automattic, P2 dropdowns of the sidebar.

<img width="300" height="394" alt="image" src="https://github.com/user-attachments/assets/141aa89a-b03f-43ea-a191-1bf3f720ecef" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To make it easy to unsubscribe from the feed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to /reader
- Verify unsubscribe from the sidebar.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
