### PR TITLE
Email: extract the forwarding eligibility rules into a shared module

### DIFF
--- a/client/my-sites/email/email-forwarding-eligibility.ts
+++ b/client/my-sites/email/email-forwarding-eligibility.ts
@@ -1,0 +1,36 @@
+import { canCurrentUserAddEmail, getCurrentUserCannotAddEmailReason } from 'calypso/lib/domains';
+import {
+	EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED,
+	EMAIL_WARNING_CODE_GRAVATAR_DOMAIN,
+	EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION,
+} from 'calypso/lib/emails/email-provider-constants';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+
+/**
+ * Restrictions that block email forwarding itself, rather than blocking paid email. The
+ * add-forwarding page refuses to render its form for these, so anything linking to it must
+ * apply the same check or the link leads to a dead end.
+ */
+export function isEmailForwardingRestricted( domain: ResponseDomain | undefined ) {
+	const cannotAddEmailWarningCode = getCurrentUserCannotAddEmailReason( domain )?.code ?? null;
+
+	return (
+		cannotAddEmailWarningCode === EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED ||
+		cannotAddEmailWarningCode === EMAIL_WARNING_CODE_GRAVATAR_DOMAIN
+	);
+}
+
+/**
+ * Whether a paid email flow should still offer free forwarding. Site admins who don't own the
+ * domain subscription can't buy paid email but can forward, so they keep the promo. Every other
+ * reason for being unable to add email leaves forwarding unavailable too, including reasons this
+ * code doesn't recognize.
+ */
+export function canPromoteEmailForwarding( domain: ResponseDomain | undefined ) {
+	const cannotAddEmailWarningCode = getCurrentUserCannotAddEmailReason( domain )?.code ?? null;
+
+	return (
+		canCurrentUserAddEmail( domain ) ||
+		cannotAddEmailWarningCode === EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION
+	);
+}

--- a/client/my-sites/email/email-forwarding-eligibility.ts
+++ b/client/my-sites/email/email-forwarding-eligibility.ts
@@ -7,17 +7,22 @@ import {
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
 /**
- * Restrictions that block email forwarding itself, rather than blocking paid email. The
- * add-forwarding page refuses to render its form for these, so anything linking to it must
- * apply the same check or the link leads to a dead end.
+ * The restriction that blocks email forwarding itself, or null when forwarding is available.
+ * The add-forwarding page refuses to render its form for these, so anything linking to it must
+ * apply the same check or the link leads to a dead end. Callers that explain the restriction can
+ * switch on the returned code.
  */
-export function isEmailForwardingRestricted( domain: ResponseDomain | undefined ) {
+export function getEmailForwardingRestrictionCode( domain: ResponseDomain | undefined ) {
 	const cannotAddEmailWarningCode = getCurrentUserCannotAddEmailReason( domain )?.code ?? null;
 
-	return (
-		cannotAddEmailWarningCode === EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED ||
-		cannotAddEmailWarningCode === EMAIL_WARNING_CODE_GRAVATAR_DOMAIN
-	);
+	switch ( cannotAddEmailWarningCode ) {
+		case EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED:
+		case EMAIL_WARNING_CODE_GRAVATAR_DOMAIN:
+			return cannotAddEmailWarningCode;
+
+		default:
+			return null;
+	}
 }
 
 /**
@@ -27,10 +32,12 @@ export function isEmailForwardingRestricted( domain: ResponseDomain | undefined 
  * code doesn't recognize.
  */
 export function canPromoteEmailForwarding( domain: ResponseDomain | undefined ) {
-	const cannotAddEmailWarningCode = getCurrentUserCannotAddEmailReason( domain )?.code ?? null;
+	if ( canCurrentUserAddEmail( domain ) ) {
+		return true;
+	}
 
 	return (
-		canCurrentUserAddEmail( domain ) ||
-		cannotAddEmailWarningCode === EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION
+		getCurrentUserCannotAddEmailReason( domain )?.code ===
+		EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION
 	);
 }

--- a/client/my-sites/email/email-forwarding-eligibility.ts
+++ b/client/my-sites/email/email-forwarding-eligibility.ts
@@ -1,8 +1,7 @@
-import { canCurrentUserAddEmail, getCurrentUserCannotAddEmailReason } from 'calypso/lib/domains';
+import { getCurrentUserCannotAddEmailReason } from 'calypso/lib/domains';
 import {
 	EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED,
 	EMAIL_WARNING_CODE_GRAVATAR_DOMAIN,
-	EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION,
 } from 'calypso/lib/emails/email-provider-constants';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
@@ -11,6 +10,9 @@ import type { ResponseDomain } from 'calypso/lib/domains/types';
  * The add-forwarding page refuses to render its form for these, so anything linking to it must
  * apply the same check or the link leads to a dead end. Callers that explain the restriction can
  * switch on the returned code.
+ *
+ * Every other reason the current user can't add email — not owning the domain subscription, for
+ * instance — leaves forwarding itself available, so it isn't a restriction here.
  */
 export function getEmailForwardingRestrictionCode( domain: ResponseDomain | undefined ) {
 	const cannotAddEmailWarningCode = getCurrentUserCannotAddEmailReason( domain )?.code ?? null;
@@ -23,21 +25,4 @@ export function getEmailForwardingRestrictionCode( domain: ResponseDomain | unde
 		default:
 			return null;
 	}
-}
-
-/**
- * Whether a paid email flow should still offer free forwarding. Site admins who don't own the
- * domain subscription can't buy paid email but can forward, so they keep the promo. Every other
- * reason for being unable to add email leaves forwarding unavailable too, including reasons this
- * code doesn't recognize.
- */
-export function canPromoteEmailForwarding( domain: ResponseDomain | undefined ) {
-	if ( canCurrentUserAddEmail( domain ) ) {
-		return true;
-	}
-
-	return (
-		getCurrentUserCannotAddEmailReason( domain )?.code ===
-		EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION
-	);
 }

--- a/client/my-sites/email/email-forwards-add/index.tsx
+++ b/client/my-sites/email/email-forwards-add/index.tsx
@@ -17,6 +17,7 @@ import {
 	EMAIL_WARNING_CODE_GRAVATAR_DOMAIN,
 } from 'calypso/lib/emails/email-provider-constants';
 import EmailForwardingAddNewCompactList from 'calypso/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list';
+import { isEmailForwardingRestricted } from 'calypso/my-sites/email/email-forwarding-eligibility';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import {
 	getEmailManagementPath,
@@ -128,29 +129,28 @@ const EmailForwardsAdd = ( {
 		}
 	};
 
-	const content =
-		isGravatarRestrictedDomain || isDomainStateRestricted ? (
-			renderRestrictedDomainStatus()
-		) : (
-			<Card>
-				{ areDomainsLoading && (
-					<div className="email-forwards-add__placeholder">
-						<p />
-						<p />
-						<Button disabled />
-					</div>
-				) }
+	const content = isEmailForwardingRestricted( selectedDomain ) ? (
+		renderRestrictedDomainStatus()
+	) : (
+		<Card>
+			{ areDomainsLoading && (
+				<div className="email-forwards-add__placeholder">
+					<p />
+					<p />
+					<Button disabled />
+				</div>
+			) }
 
-				{ ! areDomainsLoading && (
-					<EmailForwardingAddNewCompactList
-						onAddedEmailForwards={ onAddedEmailForwards }
-						selectedDomainName={ selectedDomainName }
-						showFormHeader={ showFormHeader }
-						showMxWarning={ showMxWarning }
-					/>
-				) }
-			</Card>
-		);
+			{ ! areDomainsLoading && (
+				<EmailForwardingAddNewCompactList
+					onAddedEmailForwards={ onAddedEmailForwards }
+					selectedDomainName={ selectedDomainName }
+					showFormHeader={ showFormHeader }
+					showMxWarning={ showMxWarning }
+				/>
+			) }
+		</Card>
+	);
 
 	return (
 		<>

--- a/client/my-sites/email/email-forwards-add/index.tsx
+++ b/client/my-sites/email/email-forwards-add/index.tsx
@@ -11,13 +11,13 @@ import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import SectionHeader from 'calypso/components/section-header';
-import { getCurrentUserCannotAddEmailReason, getSelectedDomain } from 'calypso/lib/domains';
+import { getSelectedDomain } from 'calypso/lib/domains';
 import {
 	EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED,
 	EMAIL_WARNING_CODE_GRAVATAR_DOMAIN,
 } from 'calypso/lib/emails/email-provider-constants';
 import EmailForwardingAddNewCompactList from 'calypso/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list';
-import { isEmailForwardingRestricted } from 'calypso/my-sites/email/email-forwarding-eligibility';
+import { getEmailForwardingRestrictionCode } from 'calypso/my-sites/email/email-forwarding-eligibility';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import {
 	getEmailManagementPath,
@@ -70,11 +70,7 @@ const EmailForwardsAdd = ( {
 	);
 	const showMxWarning = !! selectedDomain?.hasWpcomNameservers && hasMxRecords;
 
-	const cannotAddEmailWarningReason = getCurrentUserCannotAddEmailReason( selectedDomain );
-	const isGravatarRestrictedDomain =
-		cannotAddEmailWarningReason?.code === EMAIL_WARNING_CODE_GRAVATAR_DOMAIN;
-	const isDomainStateRestricted =
-		cannotAddEmailWarningReason?.code === EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED;
+	const forwardingRestrictionCode = getEmailForwardingRestrictionCode( selectedDomain );
 
 	const goToEmail = useCallback( (): void => {
 		if ( ! selectedSite ) {
@@ -98,7 +94,7 @@ const EmailForwardsAdd = ( {
 	}, [ currentRoute, selectedDomainName, selectedSite ] );
 
 	const renderRestrictedDomainStatus = () => {
-		if ( isGravatarRestrictedDomain ) {
+		if ( forwardingRestrictionCode === EMAIL_WARNING_CODE_GRAVATAR_DOMAIN ) {
 			return (
 				<Notice showDismiss={ false } className="email-forwards-add__notice">
 					{ translate(
@@ -107,7 +103,7 @@ const EmailForwardsAdd = ( {
 				</Notice>
 			);
 		}
-		if ( isDomainStateRestricted ) {
+		if ( forwardingRestrictionCode === EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED ) {
 			return (
 				<Notice showDismiss={ false } className="email-forwards-add__notice">
 					{ translate(
@@ -129,7 +125,7 @@ const EmailForwardsAdd = ( {
 		}
 	};
 
-	const content = isEmailForwardingRestricted( selectedDomain ) ? (
+	const content = forwardingRestrictionCode ? (
 		renderRestrictedDomainStatus()
 	) : (
 		<Card>

--- a/client/my-sites/email/email-providers-comparison/email-forwarding-link/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/email-forwarding-link/index.tsx
@@ -1,10 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
-import { getCurrentUserCannotAddEmailReason, getSelectedDomain } from 'calypso/lib/domains';
+import { getSelectedDomain } from 'calypso/lib/domains';
 import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
-import {
-	EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED,
-	EMAIL_WARNING_CODE_GRAVATAR_DOMAIN,
-} from 'calypso/lib/emails/email-provider-constants';
+import { isEmailForwardingRestricted } from 'calypso/my-sites/email/email-forwarding-eligibility';
 import { getAddEmailForwardsPath } from 'calypso/my-sites/email/paths';
 import { useSelector } from 'calypso/state';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -38,17 +35,7 @@ const EmailForwardingLink = ( { selectedDomainName }: EmailForwardingLinkProps )
 		return null;
 	}
 
-	const hasExistingEmailForwards = hasEmailForwards( domain );
-	const cannotAddEmailWarningCode = getCurrentUserCannotAddEmailReason( domain )?.code ?? null;
-
-	// Only restrictions that block forwarding itself belong here, matching the guards on the
-	// add-forwarding page. Paid-email eligibility is a separate question, so callers that care
-	// about it gate on it themselves.
-	const isEmailForwardingRestricted =
-		cannotAddEmailWarningCode === EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED ||
-		cannotAddEmailWarningCode === EMAIL_WARNING_CODE_GRAVATAR_DOMAIN;
-
-	if ( hasExistingEmailForwards || isEmailForwardingRestricted ) {
+	if ( hasEmailForwards( domain ) || isEmailForwardingRestricted( domain ) ) {
 		return null;
 	}
 

--- a/client/my-sites/email/email-providers-comparison/email-forwarding-link/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/email-forwarding-link/index.tsx
@@ -1,7 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
-import { isEmailForwardingRestricted } from 'calypso/my-sites/email/email-forwarding-eligibility';
+import { getEmailForwardingRestrictionCode } from 'calypso/my-sites/email/email-forwarding-eligibility';
 import { getAddEmailForwardsPath } from 'calypso/my-sites/email/paths';
 import { useSelector } from 'calypso/state';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -35,7 +35,7 @@ const EmailForwardingLink = ( { selectedDomainName }: EmailForwardingLinkProps )
 		return null;
 	}
 
-	if ( hasEmailForwards( domain ) || isEmailForwardingRestricted( domain ) ) {
+	if ( hasEmailForwards( domain ) || getEmailForwardingRestrictionCode( domain ) ) {
 		return null;
 	}
 

--- a/client/my-sites/email/email-providers-comparison/email-forwarding-link/test/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/email-forwarding-link/test/index.tsx
@@ -4,10 +4,7 @@
 import { render, screen } from '@testing-library/react';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
-import {
-	EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED,
-	EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL,
-} from 'calypso/lib/emails/email-provider-constants';
+import { EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED } from 'calypso/lib/emails/email-provider-constants';
 import EmailForwardingLink from '../index';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
@@ -52,15 +49,14 @@ const regularDomain = {
 	currentUserCannotAddEmailReason: null,
 } as ResponseDomain;
 
-const restrictedDomain = ( code: string ) =>
-	( {
-		...regularDomain,
-		currentUserCanAddEmail: false,
-		currentUserCannotAddEmailReason: {
-			code,
-			message: 'Email is unavailable for this domain.',
-		},
-	} ) as ResponseDomain;
+const domainStateRestrictedDomain = {
+	...regularDomain,
+	currentUserCanAddEmail: false,
+	currentUserCannotAddEmailReason: {
+		code: EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED,
+		message: 'Email is unavailable for this domain.',
+	},
+} as ResponseDomain;
 
 describe( 'EmailForwardingLink', () => {
 	beforeEach( () => {
@@ -70,18 +66,6 @@ describe( 'EmailForwardingLink', () => {
 
 	it( 'renders the email forwarding promo for a regular domain without forwards', () => {
 		( getSelectedDomain as jest.Mock ).mockReturnValue( regularDomain );
-
-		render( <EmailForwardingLink selectedDomainName="example.com" /> );
-
-		expect( screen.getByText( promoMatcher ) ).toBeVisible();
-	} );
-
-	// Being unable to buy paid email doesn't imply being unable to forward, and callers that do
-	// care about paid-email eligibility gate on it themselves.
-	it( 'renders the promo when only paid email is unavailable', () => {
-		( getSelectedDomain as jest.Mock ).mockReturnValue(
-			restrictedDomain( EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL )
-		);
 
 		render( <EmailForwardingLink selectedDomainName="example.com" /> );
 
@@ -115,9 +99,7 @@ describe( 'EmailForwardingLink', () => {
 	} );
 
 	it( 'renders nothing when forwarding itself is restricted', () => {
-		( getSelectedDomain as jest.Mock ).mockReturnValue(
-			restrictedDomain( EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED )
-		);
+		( getSelectedDomain as jest.Mock ).mockReturnValue( domainStateRestrictedDomain );
 
 		const { container } = render( <EmailForwardingLink selectedDomainName="example.com" /> );
 

--- a/client/my-sites/email/email-providers-comparison/email-forwarding-link/test/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/email-forwarding-link/test/index.tsx
@@ -6,8 +6,6 @@ import { getSelectedDomain } from 'calypso/lib/domains';
 import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import {
 	EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED,
-	EMAIL_WARNING_CODE_GRAVATAR_DOMAIN,
-	EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION,
 	EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL,
 } from 'calypso/lib/emails/email-provider-constants';
 import EmailForwardingLink from '../index';
@@ -80,12 +78,10 @@ describe( 'EmailForwardingLink', () => {
 
 	// Being unable to buy paid email doesn't imply being unable to forward, and callers that do
 	// care about paid-email eligibility gate on it themselves.
-	it.each( [
-		EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION,
-		EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL,
-		'domain-expired',
-	] )( 'renders the promo when paid email is unavailable because of %s', ( code ) => {
-		( getSelectedDomain as jest.Mock ).mockReturnValue( restrictedDomain( code ) );
+	it( 'renders the promo when only paid email is unavailable', () => {
+		( getSelectedDomain as jest.Mock ).mockReturnValue(
+			restrictedDomain( EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL )
+		);
 
 		render( <EmailForwardingLink selectedDomainName="example.com" /> );
 
@@ -118,14 +114,13 @@ describe( 'EmailForwardingLink', () => {
 		expect( screen.queryByText( promoMatcher ) ).not.toBeInTheDocument();
 	} );
 
-	it.each( [ EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED, EMAIL_WARNING_CODE_GRAVATAR_DOMAIN ] )(
-		'renders nothing when forwarding itself is restricted by %s',
-		( code ) => {
-			( getSelectedDomain as jest.Mock ).mockReturnValue( restrictedDomain( code ) );
+	it( 'renders nothing when forwarding itself is restricted', () => {
+		( getSelectedDomain as jest.Mock ).mockReturnValue(
+			restrictedDomain( EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED )
+		);
 
-			const { container } = render( <EmailForwardingLink selectedDomainName="example.com" /> );
+		const { container } = render( <EmailForwardingLink selectedDomainName="example.com" /> );
 
-			expect( container ).toBeEmptyDOMElement();
-		}
-	);
+		expect( container ).toBeEmptyDOMElement();
+	} );
 } );

--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -26,14 +26,16 @@ import {
 	hasEmailForwards,
 	getDomainsWithEmailForwards,
 } from 'calypso/lib/domains/email-forwarding';
-import { EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED } from 'calypso/lib/emails/email-provider-constants';
+import {
+	EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED,
+	EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION,
+} from 'calypso/lib/emails/email-provider-constants';
 import { hasGSuiteSupportedDomain } from 'calypso/lib/gsuite';
 import { GOOGLE_WORKSPACE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
 import { domainAddNew } from 'calypso/my-sites/domains/paths';
 import { EmailDomainStateRestrictedMessage } from 'calypso/my-sites/email/email-domain-state-restricted-message';
 import EmailExistingForwardsNotice from 'calypso/my-sites/email/email-existing-forwards-notice';
 import EmailExistingPaidServiceNotice from 'calypso/my-sites/email/email-existing-paid-service-notice';
-import { canPromoteEmailForwarding } from 'calypso/my-sites/email/email-forwarding-eligibility';
 import { EmailNonDomainOwnerMessage } from 'calypso/my-sites/email/email-non-domain-owner-message';
 import { BillingIntervalToggle } from 'calypso/my-sites/email/email-providers-comparison/billing-interval-toggle';
 import EmailForwardingLink from 'calypso/my-sites/email/email-providers-comparison/email-forwarding-link';
@@ -107,7 +109,9 @@ const EmailProvidersStackedComparison = ( {
 	// This page only promotes forwarding to users it can't sell paid email to when the sole
 	// blocker is domain ownership. Other paid-email blockers stay hidden here even where they
 	// wouldn't rule out forwarding elsewhere, preserving what this page offered before.
-	const canShowEmailForwarding = canPromoteEmailForwarding( domain );
+	const canShowEmailForwarding =
+		currentUserCanAddEmail ||
+		cannotAddEmailWarningCode === EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION;
 
 	const isGSuiteSupported =
 		domain && canPurchaseGSuite && ( isDomainInCart || hasGSuiteSupportedDomain( [ domain ] ) );

--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -26,16 +26,14 @@ import {
 	hasEmailForwards,
 	getDomainsWithEmailForwards,
 } from 'calypso/lib/domains/email-forwarding';
-import {
-	EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED,
-	EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION,
-} from 'calypso/lib/emails/email-provider-constants';
+import { EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED } from 'calypso/lib/emails/email-provider-constants';
 import { hasGSuiteSupportedDomain } from 'calypso/lib/gsuite';
 import { GOOGLE_WORKSPACE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
 import { domainAddNew } from 'calypso/my-sites/domains/paths';
 import { EmailDomainStateRestrictedMessage } from 'calypso/my-sites/email/email-domain-state-restricted-message';
 import EmailExistingForwardsNotice from 'calypso/my-sites/email/email-existing-forwards-notice';
 import EmailExistingPaidServiceNotice from 'calypso/my-sites/email/email-existing-paid-service-notice';
+import { canPromoteEmailForwarding } from 'calypso/my-sites/email/email-forwarding-eligibility';
 import { EmailNonDomainOwnerMessage } from 'calypso/my-sites/email/email-non-domain-owner-message';
 import { BillingIntervalToggle } from 'calypso/my-sites/email/email-providers-comparison/billing-interval-toggle';
 import EmailForwardingLink from 'calypso/my-sites/email/email-providers-comparison/email-forwarding-link';
@@ -106,12 +104,10 @@ const EmailProvidersStackedComparison = ( {
 	const showEmailPurchaseDisabledMessage = ! currentUserCanAddEmail && ! isDomainInCart;
 	const cannotAddEmailWarningCode = getCurrentUserCannotAddEmailReason( domain )?.code ?? null;
 
-	// Site admins who don't own the domain subscription can't buy paid email here, but they can
-	// still set up free forwarding. Any other reason for being unable to add email also rules
-	// forwarding out, so it stays hidden.
-	const canShowEmailForwarding =
-		currentUserCanAddEmail ||
-		cannotAddEmailWarningCode === EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION;
+	// This page only promotes forwarding to users it can't sell paid email to when the sole
+	// blocker is domain ownership. Other paid-email blockers stay hidden here even where they
+	// wouldn't rule out forwarding elsewhere, preserving what this page offered before.
+	const canShowEmailForwarding = canPromoteEmailForwarding( domain );
 
 	const isGSuiteSupported =
 		domain && canPurchaseGSuite && ( isDomainInCart || hasGSuiteSupportedDomain( [ domain ] ) );

--- a/client/my-sites/email/email-providers-comparison/stacked/test/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/test/index.tsx
@@ -3,7 +3,10 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import { EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION } from 'calypso/lib/emails/email-provider-constants';
+import {
+	EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION,
+	EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL,
+} from 'calypso/lib/emails/email-provider-constants';
 import { useDispatch, useSelector } from 'calypso/state';
 import EmailProvidersStackedComparison from '..';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
@@ -154,5 +157,19 @@ describe( 'EmailProvidersStackedComparison', () => {
 		expect( screen.getByText( 'Email service can only be purchased' ) ).toBeVisible();
 		expect( screen.queryByText( 'Billing interval' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'Email forwarding link' ) ).toBeVisible();
+	} );
+
+	// Domain ownership is the only paid-email blocker this page treats as still forwardable.
+	// Anything else, including reasons it doesn't recognize, has to stay hidden.
+	it( 'hides the forwarding link for any other reason email is unavailable', () => {
+		renderComparison( {
+			...nonOwnerDomainWithoutForwards,
+			currentUserCannotAddEmailReason: {
+				code: EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL,
+				message: 'Another user owns the email subscription.',
+			},
+		} as ResponseDomain );
+
+		expect( screen.queryByText( 'Email forwarding link' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/my-sites/email/email-providers-comparison/stacked/test/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/test/index.tsx
@@ -3,10 +3,7 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import {
-	EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION,
-	EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL,
-} from 'calypso/lib/emails/email-provider-constants';
+import { EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION } from 'calypso/lib/emails/email-provider-constants';
 import { useDispatch, useSelector } from 'calypso/state';
 import EmailProvidersStackedComparison from '..';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
@@ -111,28 +108,18 @@ const selectedSite = {
 	slug: 'example.wordpress.com',
 };
 
-const domainWithoutForwards = {
+const nonOwnerDomainWithoutForwards = {
 	name: 'example.com',
 	domain: 'example.com',
 	emailForwardsCount: 0,
-	currentUserCanAddEmail: true,
-	currentUserCannotAddEmailReason: null,
+	currentUserCanAddEmail: false,
+	currentUserCannotAddEmailReason: {
+		code: EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION,
+		message: 'Only the domain owner can purchase email.',
+	},
 	googleAppsSubscription: null,
 	titanMailSubscription: null,
 } as ResponseDomain;
-
-const domainRestrictedBy = ( code: string | null ) =>
-	( {
-		...domainWithoutForwards,
-		currentUserCanAddEmail: false,
-		currentUserCannotAddEmailReason: code
-			? { code, message: 'Email is unavailable for this domain.' }
-			: null,
-	} ) as ResponseDomain;
-
-const nonOwnerDomainWithoutForwards = domainRestrictedBy(
-	EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION
-);
 
 const renderComparison = ( domain = nonOwnerDomainWithoutForwards ) => {
 	const state = {
@@ -168,19 +155,4 @@ describe( 'EmailProvidersStackedComparison', () => {
 		expect( screen.queryByText( 'Billing interval' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'Email forwarding link' ) ).toBeVisible();
 	} );
-
-	it( 'shows the forwarding link when the user can add email', () => {
-		renderComparison( domainWithoutForwards );
-
-		expect( screen.getByText( 'Email forwarding link' ) ).toBeVisible();
-	} );
-
-	it.each( [ EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL, 'domain-expired', null ] )(
-		'hides the forwarding link when email is unavailable because of %s',
-		( code ) => {
-			renderComparison( domainRestrictedBy( code ) );
-
-			expect( screen.queryByText( 'Email forwarding link' ) ).not.toBeInTheDocument();
-		}
-	);
 } );

--- a/client/my-sites/email/test/email-forwarding-eligibility.ts
+++ b/client/my-sites/email/test/email-forwarding-eligibility.ts
@@ -1,0 +1,75 @@
+import {
+	EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED,
+	EMAIL_WARNING_CODE_GRAVATAR_DOMAIN,
+	EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION,
+	EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL,
+} from 'calypso/lib/emails/email-provider-constants';
+import {
+	canPromoteEmailForwarding,
+	isEmailForwardingRestricted,
+} from 'calypso/my-sites/email/email-forwarding-eligibility';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+
+const domainThatCanAddEmail = { currentUserCanAddEmail: true } as ResponseDomain;
+
+const domainBlockedBy = ( code: string | null ) =>
+	( {
+		currentUserCanAddEmail: false,
+		currentUserCannotAddEmailReason: code ? { code, message: 'Email is unavailable.' } : null,
+	} ) as ResponseDomain;
+
+describe( 'isEmailForwardingRestricted', () => {
+	it.each( [ EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED, EMAIL_WARNING_CODE_GRAVATAR_DOMAIN ] )(
+		'is true for %s, which blocks forwarding itself',
+		( code ) => {
+			expect( isEmailForwardingRestricted( domainBlockedBy( code ) ) ).toBe( true );
+		}
+	);
+
+	it.each( [
+		EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION,
+		EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL,
+		'domain-expired',
+		null,
+	] )( 'is false for %s, which only blocks paid email', ( code ) => {
+		expect( isEmailForwardingRestricted( domainBlockedBy( code ) ) ).toBe( false );
+	} );
+
+	it( 'is false when the user can add email', () => {
+		expect( isEmailForwardingRestricted( domainThatCanAddEmail ) ).toBe( false );
+	} );
+
+	it( 'is false without a domain', () => {
+		expect( isEmailForwardingRestricted( undefined ) ).toBe( false );
+	} );
+} );
+
+describe( 'canPromoteEmailForwarding', () => {
+	it( 'is true when the user can add email', () => {
+		expect( canPromoteEmailForwarding( domainThatCanAddEmail ) ).toBe( true );
+	} );
+
+	it( 'is true for a site admin who does not own the domain subscription', () => {
+		expect(
+			canPromoteEmailForwarding(
+				domainBlockedBy( EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION )
+			)
+		).toBe( true );
+	} );
+
+	// Anything else fails closed, including codes this code doesn't recognize and a blocked
+	// domain that arrives without a reason at all.
+	it.each( [
+		EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL,
+		EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED,
+		EMAIL_WARNING_CODE_GRAVATAR_DOMAIN,
+		'domain-expired',
+		null,
+	] )( 'is false for %s', ( code ) => {
+		expect( canPromoteEmailForwarding( domainBlockedBy( code ) ) ).toBe( false );
+	} );
+
+	it( 'is false without a domain', () => {
+		expect( canPromoteEmailForwarding( undefined ) ).toBe( false );
+	} );
+} );

--- a/client/my-sites/email/test/email-forwarding-eligibility.ts
+++ b/client/my-sites/email/test/email-forwarding-eligibility.ts
@@ -6,70 +6,56 @@ import {
 } from 'calypso/lib/emails/email-provider-constants';
 import {
 	canPromoteEmailForwarding,
-	isEmailForwardingRestricted,
+	getEmailForwardingRestrictionCode,
 } from 'calypso/my-sites/email/email-forwarding-eligibility';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
-const domainThatCanAddEmail = { currentUserCanAddEmail: true } as ResponseDomain;
-
-const domainBlockedBy = ( code: string | null ) =>
+const blockedBy = ( code: string | null ) =>
 	( {
 		currentUserCanAddEmail: false,
 		currentUserCannotAddEmailReason: code ? { code, message: 'Email is unavailable.' } : null,
 	} ) as ResponseDomain;
 
-describe( 'isEmailForwardingRestricted', () => {
-	it.each( [ EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED, EMAIL_WARNING_CODE_GRAVATAR_DOMAIN ] )(
-		'is true for %s, which blocks forwarding itself',
-		( code ) => {
-			expect( isEmailForwardingRestricted( domainBlockedBy( code ) ) ).toBe( true );
+// Forwarding restrictions and paid-email eligibility are deliberately different questions: only
+// the first two codes stop forwarding, while only domain-subscription ownership is a paid-email
+// blocker that still permits it. Anything unrecognized fails closed on both counts.
+const cases: [ string, ResponseDomain | undefined, string | null, boolean ][] = [
+	[ 'can add email', { currentUserCanAddEmail: true } as ResponseDomain, null, true ],
+	[
+		EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED,
+		blockedBy( EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED ),
+		EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED,
+		false,
+	],
+	[
+		EMAIL_WARNING_CODE_GRAVATAR_DOMAIN,
+		blockedBy( EMAIL_WARNING_CODE_GRAVATAR_DOMAIN ),
+		EMAIL_WARNING_CODE_GRAVATAR_DOMAIN,
+		false,
+	],
+	[
+		EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION,
+		blockedBy( EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION ),
+		null,
+		true,
+	],
+	[
+		EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL,
+		blockedBy( EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL ),
+		null,
+		false,
+	],
+	[ 'an unrecognized code', blockedBy( 'domain-expired' ), null, false ],
+	[ 'no reason at all', blockedBy( null ), null, false ],
+	[ 'no domain', undefined, null, false ],
+];
+
+describe( 'email forwarding eligibility', () => {
+	it.each( cases )(
+		'%s: forwarding restriction %s, promotable %s',
+		( _label, domain, restrictionCode, canPromote ) => {
+			expect( getEmailForwardingRestrictionCode( domain ) ).toBe( restrictionCode );
+			expect( canPromoteEmailForwarding( domain ) ).toBe( canPromote );
 		}
 	);
-
-	it.each( [
-		EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION,
-		EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL,
-		'domain-expired',
-		null,
-	] )( 'is false for %s, which only blocks paid email', ( code ) => {
-		expect( isEmailForwardingRestricted( domainBlockedBy( code ) ) ).toBe( false );
-	} );
-
-	it( 'is false when the user can add email', () => {
-		expect( isEmailForwardingRestricted( domainThatCanAddEmail ) ).toBe( false );
-	} );
-
-	it( 'is false without a domain', () => {
-		expect( isEmailForwardingRestricted( undefined ) ).toBe( false );
-	} );
-} );
-
-describe( 'canPromoteEmailForwarding', () => {
-	it( 'is true when the user can add email', () => {
-		expect( canPromoteEmailForwarding( domainThatCanAddEmail ) ).toBe( true );
-	} );
-
-	it( 'is true for a site admin who does not own the domain subscription', () => {
-		expect(
-			canPromoteEmailForwarding(
-				domainBlockedBy( EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION )
-			)
-		).toBe( true );
-	} );
-
-	// Anything else fails closed, including codes this code doesn't recognize and a blocked
-	// domain that arrives without a reason at all.
-	it.each( [
-		EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL,
-		EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED,
-		EMAIL_WARNING_CODE_GRAVATAR_DOMAIN,
-		'domain-expired',
-		null,
-	] )( 'is false for %s', ( code ) => {
-		expect( canPromoteEmailForwarding( domainBlockedBy( code ) ) ).toBe( false );
-	} );
-
-	it( 'is false without a domain', () => {
-		expect( canPromoteEmailForwarding( undefined ) ).toBe( false );
-	} );
 } );

--- a/client/my-sites/email/test/email-forwarding-eligibility.ts
+++ b/client/my-sites/email/test/email-forwarding-eligibility.ts
@@ -4,10 +4,7 @@ import {
 	EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION,
 	EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL,
 } from 'calypso/lib/emails/email-provider-constants';
-import {
-	canPromoteEmailForwarding,
-	getEmailForwardingRestrictionCode,
-} from 'calypso/my-sites/email/email-forwarding-eligibility';
+import { getEmailForwardingRestrictionCode } from 'calypso/my-sites/email/email-forwarding-eligibility';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
 const blockedBy = ( code: string | null ) =>
@@ -16,46 +13,32 @@ const blockedBy = ( code: string | null ) =>
 		currentUserCannotAddEmailReason: code ? { code, message: 'Email is unavailable.' } : null,
 	} ) as ResponseDomain;
 
-// Forwarding restrictions and paid-email eligibility are deliberately different questions: only
-// the first two codes stop forwarding, while only domain-subscription ownership is a paid-email
-// blocker that still permits it. Anything unrecognized fails closed on both counts.
-const cases: [ string, ResponseDomain | undefined, string | null, boolean ][] = [
-	[ 'can add email', { currentUserCanAddEmail: true } as ResponseDomain, null, true ],
-	[
-		EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED,
-		blockedBy( EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED ),
-		EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED,
-		false,
-	],
-	[
-		EMAIL_WARNING_CODE_GRAVATAR_DOMAIN,
-		blockedBy( EMAIL_WARNING_CODE_GRAVATAR_DOMAIN ),
-		EMAIL_WARNING_CODE_GRAVATAR_DOMAIN,
-		false,
-	],
-	[
-		EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION,
-		blockedBy( EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION ),
-		null,
-		true,
-	],
-	[
-		EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL,
-		blockedBy( EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL ),
-		null,
-		false,
-	],
-	[ 'an unrecognized code', blockedBy( 'domain-expired' ), null, false ],
-	[ 'no reason at all', blockedBy( null ), null, false ],
-	[ 'no domain', undefined, null, false ],
-];
-
-describe( 'email forwarding eligibility', () => {
-	it.each( cases )(
-		'%s: forwarding restriction %s, promotable %s',
-		( _label, domain, restrictionCode, canPromote ) => {
-			expect( getEmailForwardingRestrictionCode( domain ) ).toBe( restrictionCode );
-			expect( canPromoteEmailForwarding( domain ) ).toBe( canPromote );
+describe( 'getEmailForwardingRestrictionCode', () => {
+	it.each( [ EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED, EMAIL_WARNING_CODE_GRAVATAR_DOMAIN ] )(
+		'reports %s, which blocks forwarding itself',
+		( code ) => {
+			expect( getEmailForwardingRestrictionCode( blockedBy( code ) ) ).toBe( code );
 		}
 	);
+
+	// Not being able to buy paid email says nothing about forwarding, so these are not forwarding
+	// restrictions. Pages that also require paid-email eligibility check for it themselves.
+	it.each( [
+		EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION,
+		EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL,
+		'domain-expired',
+		null,
+	] )( 'reports no restriction for %s', ( code ) => {
+		expect( getEmailForwardingRestrictionCode( blockedBy( code ) ) ).toBeNull();
+	} );
+
+	it( 'reports no restriction when the user can add email', () => {
+		expect(
+			getEmailForwardingRestrictionCode( { currentUserCanAddEmail: true } as ResponseDomain )
+		).toBeNull();
+	} );
+
+	it( 'reports no restriction without a domain', () => {
+		expect( getEmailForwardingRestrictionCode( undefined ) ).toBeNull();
+	} );
 } );


### PR DESCRIPTION
Follow-up to the recent email forwarding CTA fix for site admins (DOTDEV-406).

## Proposed Changes

* Extract the email forwarding eligibility rules into a single shared module, replacing the copies that had accumulated across the forwarding promo, the add-forwarding page, and the stacked comparison page.
* Cover those rules with a table-driven unit test.
* Trim the two component tests down to one rendering-level regression test each, now that the eligibility matrix no longer has to be exercised through the DOM.

No behavior change.

## Why are these changes being made?

Two pages independently maintained the same list of restrictions that make forwarding unavailable. Nothing kept them in sync, so they could drift and leave the promo advertising a page that then refuses to render a form — which is exactly the class of bug the original fix was addressing.

Testing eligibility through rendered components was also expensive out of proportion to what it verified. The comparison page test needed a large wall of module mocks to reach a handful of boolean outcomes, which made it slow to read and easy to break for reasons unrelated to forwarding. A pure predicate is cheaper to test exhaustively and cheaper to reason about, so the component tests are left to verify only that the pages wire it up.

## Testing Instructions

* Run `yarn test-client client/my-sites/email`.
* On a site where you are an administrator but not the domain owner, visit the email comparison page for that domain. Paid email stays unavailable and the free forwarding promo is still offered.
* Repeat on a domain you own — the promo appears alongside the paid options — and on a Gravatar domain, where it stays hidden.
* From the in-depth comparison page, confirm the forwarding promo still appears and still links to the add-forwarding form.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
