### PR TITLE
Stats: keep the infotip popup clear of the wp-admin side nav

### DIFF
--- a/client/my-sites/stats/components/stats-infotip/index.tsx
+++ b/client/my-sites/stats/components/stats-infotip/index.tsx
@@ -1,6 +1,7 @@
 import { info } from '@wordpress/icons';
 import { Icon, Popover, VisuallyHidden } from '@wordpress/ui';
 import clsx from 'clsx';
+import { useRef } from 'react';
 import useWPAdminTheme from 'calypso/my-sites/stats/hooks/use-wp-admin-theme';
 import type { ComponentProps, MouseEvent, ReactNode } from 'react';
 
@@ -39,10 +40,13 @@ export default function StatsInfotip( {
 	triggerClassName,
 }: StatsInfotipProps ) {
 	const customTheme = useWPAdminTheme();
+	const triggerRef = useRef< HTMLButtonElement >( null );
+
 	return (
 		<span className={ clsx( 'stats-infotip', className ) }>
 			<Popover.Root>
 				<Popover.Trigger
+					ref={ triggerRef }
 					type="button"
 					openOnHover
 					delay={ HOVER_DELAY_MS }
@@ -65,6 +69,14 @@ export default function StatsInfotip( {
 							side={ side }
 							align={ align }
 							sideOffset={ POPUP_SIDE_OFFSET_PX }
+							// wp-admin's fixed left side nav isn't a clipping ancestor of the popup
+							// (it's a sibling, not an overflow:hidden container), so the default
+							// 'clipping-ancestors' collision boundary never sees it and the popup
+							// can render underneath it. Point collision detection at the actual
+							// content area instead, same as DateRange does for its own Popover.
+							collisionBoundary={
+								triggerRef.current?.closest( '.main, #wpcontent, .layout__content' ) ?? undefined
+							}
 						/>
 					}
 				>


### PR DESCRIPTION
Fixes STATS-358

## Proposed Changes

* Give `StatsInfotip`'s `Popover.Positioner` an explicit `collisionBoundary`, resolved from the trigger's nearest `.main` / `#wpcontent` / `.layout__content` ancestor, instead of leaving it on the default `'clipping-ancestors'` boundary.

## Why are these changes being made?

* In Odyssey Stats (Jetpack Stats embedded in wp-admin), the UTM module's info-icon popup could render partly behind wp-admin's fixed left side nav. The popup's collision detection (Floating UI, via `@wordpress/ui`'s `Popover`) only checks overflow ancestors and the browser viewport by default — the side nav is a DOM-unrelated, `position: fixed` sibling with a much higher `z-index`, so it's invisible to that check. `DateRange` already solves this same class of problem for its own `Popover` by pointing collision detection at the actual content area; this applies the same fix here.

## Testing Instructions

* Load Jetpack Stats inside wp-admin (Odyssey Stats), go to the Traffic tab, and open the UTM module's info icon (the small "i" next to the "UTM" heading).
* Before this change: on a narrow enough viewport/sidebar combination, the popup can render partly underneath the wp-admin side nav, cutting off its text on the left.
* After this change: the popup stays clear of the side nav.
* `yarn typecheck-client` and `yarn eslint client/my-sites/stats/components/stats-infotip/index.tsx` pass.


| Before | After |
|-|-|
| <img width="467" height="207" alt="image" src="https://github.com/user-attachments/assets/fa8cfcdb-1610-44e0-b3a0-f3e299e9ecf2" /> | <img width="521" height="207" alt="image" src="https://github.com/user-attachments/assets/ceea1180-f917-41ae-aa89-54abbe5765ce" /> |

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?