### PR TITLE
Reader: fix comment author and respondee vertical misalignment

### DIFF
--- a/client/blocks/comments/post-comment.scss
+++ b/client/blocks/comments/post-comment.scss
@@ -67,6 +67,7 @@
 }
 
 .comments__comment-author {
+	align-items: baseline;
 	color: var(--color-text);
 	display: flex;
 	flex-wrap: wrap;
@@ -82,7 +83,6 @@
 
 .comments__comment-username {
 	color: var(--color-text);
-	height: 21px;
 	margin-right: 7px;
 	white-space: nowrap;
 	overflow: hidden;
@@ -92,7 +92,6 @@
 
 a.comments__comment-username {
 	color: var(--color-link);
-	height: 21px;
 
 	&:hover {
 		color: var(--color-link-light);


### PR DESCRIPTION
## Proposed Changes

* Add `align-items: baseline` to `.comments__comment-author` so the author name, respondee name and timestamp share a text baseline.
* Drop the now-unnecessary `height: 21px` from the two `.comments__comment-username` rules.

## Why are these changes being made?

In the Reader, the comment author name can render a few pixels above the respondee name beside it - up to 5px when the respondee has the external-link icon.

`.comments__comment-author` is a flex container using the default `align-items: stretch`, so children align by their **box tops**, not their text baselines. Inline SVGs default to `vertical-align: baseline` and reserve their full height above it, so each child's baseline sits wherever its tallest icon puts it. Aligning the row on the baseline instead zeroes the offset in every combination and is immune to future icon size changes.

Before:
<img width="263" height="87" alt="Screenshot 2026-07-30 at 15 51 46" src="https://github.com/user-attachments/assets/7b61561c-6d69-45f7-bf41-0fa91432630d" />

After:
<img width="317" height="94" alt="Screenshot 2026-07-30 at 15 52 05" src="https://github.com/user-attachments/assets/c5f18a67-9684-4280-839d-2400f55436a8" />

## Testing Instructions

1. Open `/reader/conversations` and find a reply whose parent comment author has an external site URL, so their name is followed by the external-link icon. The author name should no longer sit above the respondee name.
2. Spot-check the other surfaces using this block: comments under a Reader stream post card, the full post view, and a trackback/pingback comment.
3. Check dark mode and mobile widths, where the author row wraps.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

