### PR TITLE
Sites: don't select a fetched site the user can't manage

### DIFF
--- a/client/my-sites/controller.jsx
+++ b/client/my-sites/controller.jsx
@@ -668,20 +668,22 @@ export function siteSelection( context, next ) {
 		dispatch( requestSite( siteFragment ) )
 			.catch( () => null )
 			.then( ( site ) => {
-				let freshSiteId;
+				// `requestSite` doesn't store sites the user can't manage, so an ID that isn't
+				// in state means the fragment resolved to a site that isn't theirs.
+				let freshSiteId = getSiteId( getState(), site?.ID );
 
 				// If we found a site using the fragment and the fragment matches the *.wordpress.com domain for a site with a mapped domain,
 				// redirect to the mapped domain, e.g /site-editor/example.wordpress.com -> /site-editor/example.com
-				if ( site && site.ID ) {
-					const siteSlug = getSiteSlug( getState(), site.ID );
-					const unmappedSlug = withoutHttp( getSiteOption( getState(), site.ID, 'unmapped_url' ) );
+				if ( freshSiteId ) {
+					const siteSlug = getSiteSlug( getState(), freshSiteId );
+					const unmappedSlug = withoutHttp(
+						getSiteOption( getState(), freshSiteId, 'unmapped_url' )
+					);
 
 					if ( unmappedSlug !== siteSlug && unmappedSlug === siteFragment ) {
 						const hash = context.hashstring ? `#${ context.hashstring }` : '';
 						return page.redirect( context.path.replace( siteFragment, siteSlug ) + hash );
 					}
-
-					freshSiteId = site.ID;
 				}
 
 				freshSiteId ??= getSiteId( getState(), siteFragment );

--- a/client/my-sites/test/controller.js
+++ b/client/my-sites/test/controller.js
@@ -6,13 +6,19 @@ import page from '@automattic/calypso-router';
 import configureStore from 'redux-mock-store';
 import { thunk } from 'redux-thunk';
 import * as pageView from 'calypso/lib/analytics/page-view';
-import { PREFERENCES_SET } from 'calypso/state/action-types';
+import { PREFERENCES_SET, SELECTED_SITE_SET } from 'calypso/state/action-types';
+import { requestSite } from 'calypso/state/sites/actions';
 import {
 	updateRecentSitesPreferences,
 	recordNoSitesPageView,
 	recordNoVisibleSitesPageView,
 	redirectToPrimary,
+	siteSelection,
 } from '../controller';
+
+jest.mock( 'calypso/state/sites/actions', () => ( {
+	requestSite: jest.fn(),
+} ) );
 
 const middlewares = [ thunk ];
 const mockStore = configureStore( middlewares );
@@ -180,6 +186,82 @@ describe( 'recordNoSitesPageView', () => {
 		} );
 
 		spy.mockRestore();
+	} );
+} );
+
+describe( 'siteSelection', () => {
+	const siteId = 1;
+	const siteFragment = 'example.com';
+
+	// A mock store never reduces the `setSelectedSiteId` this dispatches, so
+	// `selectedSiteId` stands in for the state after it.
+	const buildStore = ( items, selectedSiteId = null ) =>
+		mockStore( {
+			currentUser: { user: { site_count: 2, visible_site_count: 2 } },
+			sites: { items, domains: { items: {} }, plans: {} },
+			ui: { selectedSiteId },
+			preferences: { remoteValues: null },
+		} );
+
+	const buildContext = ( store ) => ( {
+		store,
+		path: `/home/${ siteFragment }`,
+		pathname: `/home/${ siteFragment }`,
+		params: { site: siteFragment },
+		query: {},
+		querystring: '',
+		section: { enableNoSites: false },
+	} );
+
+	const selectedSiteAction = ( store ) =>
+		store.getActions().find( ( { type } ) => type === SELECTED_SITE_SET );
+
+	let redirectSpy;
+	let next;
+
+	beforeEach( () => {
+		redirectSpy = jest.spyOn( page, 'redirect' ).mockImplementation( () => {} );
+		next = jest.fn();
+	} );
+
+	afterEach( () => {
+		redirectSpy.mockRestore();
+	} );
+
+	it( 'should not select a fetched site that is absent from state', async () => {
+		requestSite.mockReturnValue( () => Promise.resolve( { ID: 2, URL: 'https://example.com' } ) );
+		const store = buildStore( { [ siteId ]: {} } );
+
+		siteSelection( buildContext( store ), next );
+		await new Promise( process.nextTick );
+
+		expect( selectedSiteAction( store ) ).toBeUndefined();
+		expect( next ).not.toHaveBeenCalled();
+		expect( redirectSpy ).toHaveBeenCalledWith( '/home' );
+	} );
+
+	it( 'should select a fetched site that is in state under a different slug', async () => {
+		requestSite.mockReturnValue( () =>
+			Promise.resolve( { ID: siteId, URL: 'https://example.wordpress.com' } )
+		);
+		const store = buildStore(
+			{
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://example.wordpress.com',
+					capabilities: { manage_options: true },
+					options: { unmapped_url: 'https://example.wordpress.com' },
+				},
+			},
+			siteId
+		);
+
+		siteSelection( buildContext( store ), next );
+		await new Promise( process.nextTick );
+
+		expect( selectedSiteAction( store )?.siteId ).toEqual( siteId );
+		expect( redirectSpy ).not.toHaveBeenCalled();
+		expect( next ).toHaveBeenCalled();
 	} );
 } );
 


### PR DESCRIPTION
## Proposed Changes

* When a URL's site fragment resolves to a site the current user has no access to, site selection no longer treats it as the selected site. It falls through to the existing redirect to the site list instead.

## Why are these changes being made?

* Selecting a site that was deliberately not loaded leaves the router unable to resolve any site, so these routes render a "You don't have access to that site" dead end. The only way forward is to manually pick another site, which is a poor landing spot — particularly right after checkout, where a stale URL can drop someone here having just paid.
* A site fragment can resolve to somebody else's site more easily than it looks. A domain registered here may still be claimed by an unrelated, long-dormant Jetpack record of the same name, and a site's slug can change while a URL built from it is still in flight. Neither is something Calypso controls, so the routing layer needs to degrade into something recoverable.
* Support sees this error from several unrelated causes — connection problems, ownership transfers, unlinked accounts. All of them land in the same dead end, and all of them get a way forward from this change.
* The Jetpack Cloud and signup controllers already resolve the selected site from loaded state rather than from the response. This brings the last one in line.

## Testing Instructions

* Sign in, then visit `/home/<slug>` for any public WordPress.com site that is not on your account.
  * Before: "You don't have access to that site", with no way forward but the site picker.
  * After: redirected to the site list.
* Confirm ordinary navigation is unchanged:
  * `/home/<your own site slug>` still loads.
  * For a site whose primary domain differs from its `*.wordpress.com` address, visiting the `*.wordpress.com` form still redirects to the mapped domain.
* Unit tests: `yarn test-client client/my-sites/test/controller.js`. The added coverage fails without this change and passes with it.
* Verified so far via unit tests, ESLint, and `yarn typecheck-client`. Not yet exercised in a browser.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
