### PR TITLE
Show the Feature Clip panel only in the Jetpack sidebar

### DIFF
--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
@@ -40,6 +40,7 @@ let mockReelVisible = false;
 let mockGenericVisible = false;
 let mockReelIsConfirming = false;
 let mockReelIgDisplayName: string | null = null;
+let mockSlotIsRendering = true;
 const mockReelRequestShare = jest.fn();
 const mockReelConfirmShare = jest.fn();
 const mockReelCancelShare = jest.fn();
@@ -65,13 +66,14 @@ jest.mock( '@wordpress/components', () => ( {
 			{ children ?? icon }
 		</button>
 	),
-	// Stands in for the Jetpack sidebar Slot, which Jetpack's editor bundle
-	// mounts in production but nothing mounts in jsdom. Rendering children
-	// inline puts the panel body in the DOM for the queries below; recording
-	// the name asserts the Fill targets Jetpack's sidebar.
+	// Stands in for the Jetpack sidebar Slot. `mockSlotIsRendering` picks which
+	// real-world case to simulate: children rendered inline (Jetpack's sidebar
+	// is open, so the Slot renders its fills) or nothing at all (no Jetpack
+	// bundle, or the sidebar is closed — a Fill with no rendering Slot mounts
+	// no children). Recording the name asserts the Fill targets Jetpack.
 	Fill: ( { name, children }: { name: string; children: React.ReactNode } ) => {
 		mockFill( name );
-		return <>{ children }</>;
+		return mockSlotIsRendering ? <>{ children }</> : null;
 	},
 	PanelBody: ( { children }: { children: React.ReactNode } ) => <>{ children }</>,
 	VisuallyHidden: ( { children }: { children: React.ReactNode } ) => <span>{ children }</span>,
@@ -241,6 +243,7 @@ describe( 'feature-clip-sidebar-extension', () => {
 		mockGenericVisible = false;
 		mockReelIsConfirming = false;
 		mockReelIgDisplayName = null;
+		mockSlotIsRendering = true;
 		( window as Record< string, unknown > ).imageStudioData = { canGenerateVideoClips: true };
 		jest.resetModules();
 	} );
@@ -291,6 +294,21 @@ describe( 'feature-clip-sidebar-extension', () => {
 			expect( screen.getAllByText( 'Turn this post into a short vertical video.' ) ).toHaveLength(
 				1
 			);
+		} );
+
+		it( 'renders no body and fires no impression when the Slot is not rendering', () => {
+			// No Jetpack editor bundle, or the sidebar is closed. The body must
+			// stay unmounted so its getMedia resolution and panel-viewed
+			// impression never run on an editor load nobody looked at.
+			mockSlotIsRendering = false;
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+
+			expect( mockFill ).toHaveBeenCalledWith( 'JetpackPluginSidebar' );
+			expect(
+				screen.queryByText( 'Turn this post into a short vertical video.' )
+			).not.toBeInTheDocument();
+			expect( mockTrackPanelViewed ).not.toHaveBeenCalled();
 		} );
 
 		it( 'fills the Jetpack sidebar regardless of clip state', () => {

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
@@ -65,13 +65,13 @@ jest.mock( '@wordpress/components', () => ( {
 			{ children ?? icon }
 		</button>
 	),
-	// Faithful to real SlotFill semantics: a Fill with no matching Slot
-	// mounted (none in jsdom) renders nothing. Recording the name lets us
-	// assert the Jetpack-sidebar wiring without duplicating the body in the
-	// DOM (which would break every single-match query below).
-	Fill: ( { name }: { name: string } ) => {
+	// Stands in for the Jetpack sidebar Slot, which Jetpack's editor bundle
+	// mounts in production but nothing mounts in jsdom. Rendering children
+	// inline puts the panel body in the DOM for the queries below; recording
+	// the name asserts the Fill targets Jetpack's sidebar.
+	Fill: ( { name, children }: { name: string; children: React.ReactNode } ) => {
 		mockFill( name );
-		return null;
+		return <>{ children }</>;
 	},
 	PanelBody: ( { children }: { children: React.ReactNode } ) => <>{ children }</>,
 	VisuallyHidden: ( { children }: { children: React.ReactNode } ) => <span>{ children }</span>,
@@ -139,16 +139,6 @@ const mockUseEffect = jest.requireActual< typeof import('react') >( 'react' ).us
 
 jest.mock( '@wordpress/element', () => ( {
 	useEffect: mockUseEffect,
-} ) );
-
-jest.mock( '@wordpress/editor', () => ( {
-	PluginDocumentSettingPanel: ( {
-		children,
-		title,
-	}: {
-		children: React.ReactNode;
-		title: string;
-	} ) => <section aria-label={ title }>{ children }</section>,
 } ) );
 
 jest.mock( '@wordpress/i18n', () => ( {
@@ -285,13 +275,22 @@ describe( 'feature-clip-sidebar-extension', () => {
 		expect( mockRegisterPlugin.mock.calls[ 0 ][ 0 ] ).toBe( 'image-studio-feature-clip' );
 	} );
 
-	describe( 'dual-render (document + Jetpack sidebars)', () => {
-		it( 'also fills the Jetpack sidebar SlotFill', () => {
+	describe( 'render target (Jetpack sidebar only)', () => {
+		it( 'fills the Jetpack sidebar SlotFill', () => {
 			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
 			render( <FeatureClipPanel /> );
-			// The document-sidebar copy is asserted by every other test; this
-			// confirms the second render target — Jetpack's sidebar slot.
 			expect( mockFill ).toHaveBeenCalledWith( 'JetpackPluginSidebar' );
+		} );
+
+		it( 'renders into the Jetpack sidebar and nowhere else', () => {
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+			// One render target only — a second Fill (or a document-sidebar
+			// panel alongside it) would duplicate the body.
+			expect( mockFill ).toHaveBeenCalledTimes( 1 );
+			expect( screen.getAllByText( 'Turn this post into a short vertical video.' ) ).toHaveLength(
+				1
+			);
 		} );
 
 		it( 'fills the Jetpack sidebar regardless of clip state', () => {

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
@@ -2,8 +2,11 @@
  * "Generate Feature Clip" post-editor sidebar panel.
  *
  * Rendered only into the Jetpack sidebar, via a `Fill` into Jetpack's
- * `"JetpackPluginSidebar"` SlotFill. The Fill is inert when the Jetpack editor
- * bundle isn't loaded, so the panel simply doesn't appear there.
+ * `"JetpackPluginSidebar"` SlotFill. Jetpack feeds that Slot's fills through
+ * `PluginSidebar`, whose children mount only while the sidebar is open — so
+ * the Fill's contents stay unmounted both when the Jetpack editor bundle is
+ * absent and when the user simply hasn't opened the sidebar. Everything with
+ * a side effect therefore lives inside the Fill (see `FeatureClipPanel`).
  *
  * When no clip is linked to the post, shows a short description + Generate
  * clip button. Once a clip exists (via the `_jetpack_feature_clip_id` post
@@ -257,7 +260,16 @@ function FeatureClipPanel(): JSX.Element | null {
 		return null;
 	}
 
-	return <FeatureClipPanelBody postType={ postType } postId={ postId } />;
+	// The body lives INSIDE the Fill on purpose. A Fill whose Slot isn't
+	// rendering renders no children, so every hook below — the `getMedia`
+	// resolution and the panel-viewed impression — stays dormant until
+	// Jetpack's sidebar actually shows the panel. Hoisting the body out here
+	// would fire both on every editor load instead.
+	return (
+		<Fill name="JetpackPluginSidebar">
+			<FeatureClipPanelBody postType={ postType } postId={ postId } />
+		</Fill>
+	);
 }
 
 interface FeatureClipPanelBodyProps {
@@ -351,16 +363,14 @@ function FeatureClipPanelBody( { postType, postId }: FeatureClipPanelBodyProps )
 	} )();
 
 	return (
-		<Fill name="JetpackPluginSidebar">
-			<PanelBody
-				// PanelBody.title is typed as string but renders any ReactNode at runtime;
-				// the badge must live in the title row so it stays visible when the panel is collapsed.
-				title={ titleNode as unknown as string }
-				className="image-studio-feature-clip-panel"
-			>
-				{ body }
-			</PanelBody>
-		</Fill>
+		<PanelBody
+			// PanelBody.title is typed as string but renders any ReactNode at runtime;
+			// the badge must live in the title row so it stays visible when the panel is collapsed.
+			title={ titleNode as unknown as string }
+			className="image-studio-feature-clip-panel"
+		>
+			{ body }
+		</PanelBody>
 	);
 }
 

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
@@ -1,12 +1,9 @@
 /**
  * "Generate Feature Clip" post-editor sidebar panel.
  *
- * Dual-rendered, mirroring Jetpack SEO's pattern: the same body renders into
- * BOTH the default WordPress document sidebar (via `PluginDocumentSettingPanel`
- * from `@wordpress/editor`) AND the Jetpack sidebar (via a `Fill` into
- * Jetpack's `"JetpackPluginSidebar"` SlotFill). The Fill is inert when the
- * Jetpack editor bundle isn't loaded, so the document-sidebar copy always
- * shows and the Jetpack-sidebar copy is purely additive.
+ * Rendered only into the Jetpack sidebar, via a `Fill` into Jetpack's
+ * `"JetpackPluginSidebar"` SlotFill. The Fill is inert when the Jetpack editor
+ * bundle isn't loaded, so the panel simply doesn't appear there.
  *
  * When no clip is linked to the post, shows a short description + Generate
  * clip button. Once a clip exists (via the `_jetpack_feature_clip_id` post
@@ -17,7 +14,6 @@ import { createBlock } from '@wordpress/blocks';
 import { Button, Fill, Notice, PanelBody, VisuallyHidden } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
 import { dispatch, useSelect } from '@wordpress/data';
-import { PluginDocumentSettingPanel } from '@wordpress/editor';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { share } from '@wordpress/icons';
@@ -40,7 +36,6 @@ import type { JSX } from 'react';
 import './feature-clip-sidebar.scss';
 
 const PLUGIN_NAME = 'image-studio-feature-clip';
-const PANEL_NAME = 'image-studio-feature-clip-panel';
 
 interface MediaRecord {
 	id: number;
@@ -339,11 +334,6 @@ function FeatureClipPanelBody( { postType, postId }: FeatureClipPanelBodyProps )
 	const hasLoadError =
 		!! featureClipId && hasResolvedAttachment && ! attachment && !! resolutionError;
 
-	// Body is described once and rendered into both sidebars. Each SlotFill
-	// portal instantiates its own subtree, so FeatureClipPreview's share
-	// hooks get one instance per sidebar — safe: the hooks have no
-	// mount-time side effects and only the visible sidebar is interacted
-	// with (same dual-instance shape as Jetpack SEO's shared panels).
 	const body = ( () => {
 		if ( hasUsableClip ) {
 			return (
@@ -361,27 +351,16 @@ function FeatureClipPanelBody( { postType, postId }: FeatureClipPanelBodyProps )
 	} )();
 
 	return (
-		<>
-			<PluginDocumentSettingPanel
-				name={ PANEL_NAME }
-				// PluginDocumentSettingPanel.title is typed as string but renders any ReactNode at runtime;
+		<Fill name="JetpackPluginSidebar">
+			<PanelBody
+				// PanelBody.title is typed as string but renders any ReactNode at runtime;
 				// the badge must live in the title row so it stays visible when the panel is collapsed.
 				title={ titleNode as unknown as string }
 				className="image-studio-feature-clip-panel"
 			>
 				{ body }
-			</PluginDocumentSettingPanel>
-			<Fill name="JetpackPluginSidebar">
-				<PanelBody
-					// PanelBody.title is typed as string but renders any ReactNode
-					// at runtime — same cast rationale as the document panel above.
-					title={ titleNode as unknown as string }
-					className="image-studio-feature-clip-panel"
-				>
-					{ body }
-				</PanelBody>
-			</Fill>
-		</>
+			</PanelBody>
+		</Fill>
 	);
 }
 
@@ -391,7 +370,7 @@ let pluginRegistered = false;
  * Register the "Generate Feature Clip" sidebar plugin.
  *
  * Idempotent — safe to call multiple times. Skips registration when the
- * editor package isn't loaded on the page (e.g. wp-admin Media Library).
+ * plugins package isn't loaded on the page (e.g. wp-admin Media Library).
  */
 export function registerFeatureClipSidebar(): void {
 	if ( window.imageStudioData?.canGenerateVideoClips !== true ) {
@@ -402,7 +381,7 @@ export function registerFeatureClipSidebar(): void {
 		return;
 	}
 
-	if ( typeof PluginDocumentSettingPanel !== 'function' ) {
+	if ( typeof registerPlugin !== 'function' ) {
 		return;
 	}
 
@@ -418,5 +397,4 @@ export {
 	FeatureClipEmptyState,
 	FeatureClipSkeleton,
 	PLUGIN_NAME,
-	PANEL_NAME,
 };


### PR DESCRIPTION
Removes the Feature Clip panel from the default document sidebar; it now renders only in the Jetpack sidebar.