### PR TITLE
Dashboard: only redirect to login on genuine 401 auth errors

### DIFF
--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -144,15 +144,7 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 	// out, redirect the user to the log in screen.
 	useEffect( () => {
 		const isAuthError = ( { statusCode, error = '' }: WPError ) => {
-			if ( [ 'authorization_required' ].includes( error ) ) {
-				return true;
-			}
-
-			if ( statusCode === 401 && error === 'rest_forbidden' ) {
-				return true;
-			}
-
-			return false;
+			return statusCode === 401 && [ 'authorization_required', 'rest_forbidden' ].includes( error );
 		};
 
 		const handleEvent = ( event: MutationCacheNotifyEvent | QueryCacheNotifyEvent ) => {


### PR DESCRIPTION
## Proposed Changes

* Require a `401` status code before treating a query/mutation error as an auth failure that redirects the user to login. Both `authorization_required` and `rest_forbidden` are now gated on `401`.

## Why are these changes being made?

The dashboard subscribes to query/mutation errors and redirects to the login screen when it sees an auth error. Previously `authorization_required` triggered that redirect regardless of status code.

But a **403** `authorization_required` means the user *is* logged in and simply lacks access to a specific resource (e.g. a site or domain they don't own) — not that they're logged out. Redirecting them to login can't fix a permission problem: they log in again, hit the same 403, and bounce.

Only a genuine **401** (unauthenticated request) should send the user to login. The `rest_forbidden` branch already made this distinction; this applies the same gate to `authorization_required`.

## Testing Instructions

* Load the dashboard while logged in and open a site/resource the account has no access to, so a request returns `403 authorization_required` → you should stay on the page (no redirect to login).
* Simulate a `401` (e.g. an expired/cleared session) → you should be redirected to login as before.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
