### PR TITLE
A4A Sites: Add top spacing above the Development badge

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
@@ -36,6 +36,10 @@
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 12px;
 	}
+
+	.sites-dataviews__site-development-badge {
+		margin-block-start: 4px;
+	}
 }
 
 .sites-dataviews__site-url {

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
@@ -48,7 +48,10 @@ const SiteDataField = ( {
 					</Badge>
 				) }
 				{ isDevSite && (
-					<Badge className="status-badge" type="info-purple">
+					<Badge
+						className="status-badge sites-dataviews__site-development-badge"
+						type="info-purple"
+					>
 						{ translate( 'Development' ) }
 					</Badge>
 				) }


### PR DESCRIPTION
On the Sites dashboard (`/sites`) in Automattic for Agencies, each site's name cell stacks the site title, its domain, and — for development sites — a purple "Development" badge. The badge is rendered directly beneath the domain line with no vertical gap.

Because there is no spacing above it, the badge sits flush against the domain, so the cell reads as cramped.

This change adds a `sites-dataviews__site-development-badge` class to the Development badge and gives it `margin-block-start: 4px`, so the badge has a small gap from the domain above it. It is a spacing-only change: the condition that shows the badge (`isDevSite`) and everything else in the cell are unchanged.

No tests: this is a presentational spacing change with no logic to assert.

Fixes [A4A-3105](https://linear.app/a8c/issue/A4A-3105).

## Testing Instructions

Prerequisites: an A4A dev environment (`yarn start-a8c-for-agencies`) signed in to an agency that has at least one **Development** site in its Sites list.

1. Open `/sites`.
2. Find a site row tagged **Development** (the purple badge under the domain).
3. Confirm the Development badge now has a small gap (4px) above it and no longer sits flush against the domain line.
4. Confirm non-development rows and the rest of the site-name cell are unchanged.
