### PR TITLE
A4A Licenses: Fix doubled underline on the "Manage in Pressable" link

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -45,17 +45,7 @@
 	&,
 	&:visited {
 		@include heading-medium;
-		display: flex;
-		flex-direction: row;
-		gap: 4px;
-		align-items: center;
-		text-decoration: underline;
 		color: var(--color-text);
-	}
-
-	.gridicon {
-		fill: var(--color-text);
-
 	}
 }
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -40,12 +40,18 @@
 	inset-block-start: 3px;
 }
 
-.license-preview__product-pressable-link {
+.theme-a8c-for-agencies a.license-preview__product-pressable-link {
 
 	&,
-	&:visited {
+	&:visited,
+	&:active {
 		@include heading-medium;
-		color: var(--color-text);
+		color: var(--color-text-subtle);
+	}
+
+	&:hover,
+	&:focus {
+		color: var(--color-neutral-70);
 	}
 }
 


### PR DESCRIPTION
In the Licenses list (`/licenses`) in Automattic for Agencies, a license row for a Pressable site shows a "Manage in Pressable" link. That link is rendered with the shared `ExternalLink` component, which already draws its own underline.

The link's own stylesheet (`.license-preview__product-pressable-link`) additionally set `text-decoration: underline`. The two underlines stacked, so the link rendered with a doubled, heavy underline that reads as a double underscore beneath the text.

This change removes the redundant `text-decoration: underline` from the link's stylesheet, so the link shows only the single underline that `ExternalLink` already provides. It also drops layout rules that no longer do anything on this element — `display: flex` / `flex-direction` / `gap` / `align-items`, and a `.gridicon` fill rule that never applied because `ExternalLink` renders its icon as spans, not a Gridicon. The typography (`heading-medium`) and the deliberate body-text color are kept, matching how the same label already renders in `referrals/referral-details/purchases.tsx`.

No behavior change: the link's `href`, its redirect handler, and the `isAgencyOwner` branch in `index.tsx` are untouched — this only changes styling.

No tests: this is a presentational CSS change; a jsdom unit test cannot assert a rendered underline, and no existing test or snapshot references the affected class.

Fixes [A4A-3106](https://linear.app/a8c/issue/A4A-3106).

## Testing Instructions

Prerequisites: an A4A dev environment (`yarn start-a8c-for-agencies`) signed in to an agency that has at least one license assigned to a **Pressable** site.

1. Open `/licenses`.
2. Find a license row for a Pressable-hosted site and locate the **Manage in Pressable** link.
3. Confirm the link now has a single underline (the `ExternalLink` default) rather than a doubled/heavy underline.
4. Click the link and confirm it still opens the Pressable management destination as before (behavior unchanged).
