### PR TITLE
Stats: fix the chart cursor flicker — contiguous bar columns, persistent tooltip

### DIFF
--- a/client/components/chart/bar-container.jsx
+++ b/client/components/chart/bar-container.jsx
@@ -22,10 +22,12 @@ export default class ChartBarContainer extends PureComponent {
 		hideXAxis: false,
 	};
 
+	clearTooltip = () => this.props.setTooltip( null );
+
 	render() {
 		return (
 			<>
-				<div className="chart__bars">
+				<div className="chart__bars" onMouseLeave={ this.clearTooltip }>
 					{ this.props.data.map( ( item, index ) => (
 						<Bar
 							index={ index }

--- a/client/components/chart/bar.jsx
+++ b/client/components/chart/bar.jsx
@@ -35,19 +35,21 @@ export default class ChartBar extends PureComponent {
 	}
 
 	mouseEnter = () => {
-		if (
-			! this.props.data.tooltipData ||
-			! this.props.data.tooltipData.length ||
-			this.props.isTouch
-		) {
+		if ( this.props.isTouch ) {
+			return null;
+		}
+
+		// Hide (rather than keep a stale neighbor's tooltip) when this bar has
+		// nothing to show. The tooltip is NOT hidden when leaving a bar — only
+		// the container's mouseleave does that — so crossing bars updates the
+		// mounted popover in place instead of unmounting and remounting it,
+		// which made the cursor flicker on every bar boundary.
+		if ( ! this.props.data.tooltipData || ! this.props.data.tooltipData.length ) {
+			this.props.setTooltip( null );
 			return null;
 		}
 
 		this.props.setTooltip( this.bar, this.computeTooltipPosition(), this.getTooltipData() );
-	};
-
-	mouseLeave = () => {
-		this.props.setTooltip( null );
 	};
 
 	getTooltipData() {
@@ -107,7 +109,6 @@ export default class ChartBar extends PureComponent {
 				aria-hidden="true"
 				onClick={ this.clickHandler }
 				onMouseEnter={ this.mouseEnter }
-				onMouseLeave={ this.mouseLeave }
 				className={ clsx( 'chart__bar', this.props.className ) }
 			>
 				{ this.renderBar() }

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -198,7 +198,6 @@ class StatModuleChartTabs extends Component {
 			className,
 			{
 				'is-loading': isActiveTabLoading,
-				'has-less-than-three-bars': this.props.chartData.length < 3,
 			},
 		];
 

--- a/client/my-sites/stats/stats-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-chart-tabs/style.scss
@@ -235,14 +235,15 @@ ul.module-tabs {
 
 .is-chart-tabs {
 
-	.chart__bars {
-		justify-content: space-between;
-	}
-	&.has-less-than-three-bars .chart__bars {
-		justify-content: space-around;
-	}
-	.chart__bar {
-		max-width: 156px;
+	// Cap the visible bar, not the .chart__bar column. The columns are the
+	// hover/click targets and the x-axis labels and tooltips assume every
+	// column spans chart-width / bar-count; capping the columns left dead
+	// gaps between them (cursor flicker, shrunken click targets, labels
+	// drifting off the bars). 106px keeps the previous visible width:
+	// the old 156px column cap times the bar's 68% inset width.
+	.chart__bar-section {
+		margin-inline: auto;
+		max-width: 106px;
 	}
 
 	/* styles border around chart for new date filtering design */

--- a/client/my-sites/stats/stats-video-detail/style.scss
+++ b/client/my-sites/stats/stats-video-detail/style.scss
@@ -25,14 +25,6 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 	}
 }
 
-// The x-axis places labels at equal-slot centers (chart width / bar count),
-// but `.is-chart-tabs` caps bars at 156px and lays them out space-between, so
-// with few bars (e.g. ~5 weekly buckets) bars drift away from their labels.
-// space-around keeps every capped bar centered in its slot.
-.stats-video-summary.is-chart-tabs .chart__bars {
-	justify-content: space-around;
-}
-
 .stats-video-summary {
 	.stats__period-header {
 		justify-content: space-between;


### PR DESCRIPTION
Noticed while verifying STATS-375 (screen recording of the cursor flicker on the video details summary chart).

## Proposed Changes

* Stop capping `.chart__bar` columns at 156px in `.is-chart-tabs` charts; cap the visible `.chart__bar-section` at 106px (the old 156px column cap × the bar's 68% inset width) and center it with auto inline margins instead.
* Remove the two workarounds the column cap required: the `has-less-than-three-bars` → `space-around` override in `stats-chart-tabs` and the `space-around` override on the video details summary chart.
* Keep the chart tooltip mounted while the pointer crosses bars: bars no longer hide it on their own mouseleave — the `.chart__bars` container's mouseleave hides it instead, and entering a bar with no tooltip data hides it explicitly.

## Why are these changes being made?

`.chart__bar` columns are the chart's full-height hover/click targets, and both the x-axis labels and the tooltip positioning (`bar.jsx`'s `barWidth = chartWidth / count`) assume every column spans chart-width ÷ bar-count. Capping the columns at 156px broke that assumption whenever slots would exceed 156px (few bars, or wide screens): the flex container distributed the leftover width as dead gaps between columns, causing:

* the cursor flickering between pointer and default while sweeping across the chart (column → gap → column),
* shrunken click targets with unclickable dead zones between bars,
* bars drifting away from their x-axis labels — which the two `space-around` overrides only partially patched.

Capping the visible bar instead keeps the exact same rendered bar width in every case (the visible bar is 68% of the column, and 68% × 156px ≈ 106px, now applied directly), while the columns return to contiguous `flex: 1` slots: continuous pointer cursor, full-slot click targets, and label/tooltip alignment that holds by construction — so the `space-around` patches become dead code and are removed, along with the now-unused `has-less-than-three-bars` class assignment.

The cursor flicker turned out to have a second, independent source on charts with tooltips (e.g. the Traffic page): every bar hid the tooltip on its own mouseleave, and `Popover` renders `null` when hidden, so crossing a bar boundary fully unmounted and remounted the tooltip's portal subtree — and Chromium re-resolves the hover cursor on that DOM churn, blinking it back to the default arrow on every boundary. Keeping the popover mounted and updating its anchor/content in place (its `componentDidUpdate` already schedules a reposition) removes the churn; this matches the line-chart tooltip, which updates a persistent element and never flickered. Verified locally: contiguous columns alone fixed the tooltip-less video details chart, but the Traffic chart kept flickering until the tooltip churn was removed too.

Visual trade-off to sanity-check: the hover highlight (and click target) now spans the full slot instead of at most 156px, so on sparse charts the highlight column is wider. Bar-dense views (e.g. Traffic day view with 30 bars) are pixel-identical — the cap never engaged there.

## Testing Instructions

1. Traffic page, day view (30 bars): before/after should be pixel-identical (the cap never engaged).
2. Traffic page, week view on a wide window (> ~1100px, so 7 slots exceed 156px): sweeping the cursor across the chart no longer flickers between pointer and arrow; the tooltip follows smoothly from bar to bar and disappears when the pointer leaves the chart; hovering highlights the full slot; clicking anywhere in a slot selects that bar; bars sit centered under their x-axis labels.
3. Video details page (`/stats/day/videodetails/:site?post=<id>`), Months view (~11 bars): same checks as 2; visible bar width unchanged from trunk.
4. A chart with 1–2 bars (new site, or a video with little history): bars centered in their slots without the removed `space-around` rules.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

