### PR TITLE
Odyssey Stats: unhide the post-detail View Post preview modal

### DIFF
--- a/apps/odyssey-stats/src/lib/test/css-scope.test.js
+++ b/apps/odyssey-stats/src/lib/test/css-scope.test.js
@@ -145,4 +145,35 @@ describe( 'Odyssey Stats CSS scoping (webpack-css-scope.js)', () => {
 		expect( compiled ).not.toContain( ':where(' );
 		expect( compiled ).toMatch( /^\.components-tooltip/m );
 	} );
+
+	it( 'leaves the WebPreview modal root unprefixed — RootChild portals it into a classless body div', () => {
+		const compiled = compile(
+			'.web-preview { opacity: 0; }\n.web-preview.is-visible { opacity: 1; }',
+			{ from: 'client/components/web-preview/style.scss' }
+		);
+
+		expect( compiled ).not.toContain( ':where(' );
+		expect( compiled ).toMatch( /^\.web-preview \{/m );
+		expect( compiled ).toMatch( /^\.web-preview\.is-visible/m );
+	} );
+
+	it( 'scopes WebPreview BEM descendants under the .web-preview root (STATS-393)', () => {
+		const compiled = compile( '.web-preview__backdrop { color: rgb(7, 8, 9); }', {
+			from: 'client/components/web-preview/style.scss',
+		} );
+		document.body.innerHTML =
+			'<div><div class="web-preview"><div class="web-preview__backdrop" id="backdrop"></div></div></div>' +
+			'<div id="adminmenu"><div class="web-preview__backdrop" id="adminmenu-backdrop"></div></div>';
+		const style = document.createElement( 'style' );
+		style.textContent = compiled;
+		document.head.appendChild( style );
+
+		expect( compiled ).toContain( ':where(' );
+		expect( getComputedStyle( document.getElementById( 'backdrop' ) ).color ).toBe(
+			'rgb(7, 8, 9)'
+		);
+		expect( getComputedStyle( document.getElementById( 'adminmenu-backdrop' ) ).color ).not.toBe(
+			'rgb(7, 8, 9)'
+		);
+	} );
 } );

--- a/apps/odyssey-stats/src/lib/test/verify-css-scope.test.js
+++ b/apps/odyssey-stats/src/lib/test/verify-css-scope.test.js
@@ -1,7 +1,5 @@
 import { findScopeFailures } from '../../../bin/verify-css-scope';
-
-const PREFIX =
-	':where(.jp-stats-dashboard, .color-scheme, .ReactModalPortal, [data-base-ui-portal], [data-wp-compat-overlay-slot], .components-modal__screen-overlay, .components-popover__fallback-container, .jp-stats-widget)';
+import { prefix as PREFIX } from '../../../webpack-css-scope';
 
 // One prefixed rule, both entry points self-styled unprefixed, and a portal root legitimately
 // nested inside the prefix — satisfies every check.
@@ -110,8 +108,7 @@ describe( 'verify-css-scope findScopeFailures', () => {
 	} );
 
 	it( 'is unaffected by minification stripping whitespace after commas in :where(...)', () => {
-		const minifiedPrefix =
-			':where(.jp-stats-dashboard,.color-scheme,.ReactModalPortal,[data-base-ui-portal],[data-wp-compat-overlay-slot],.components-modal__screen-overlay,.components-popover__fallback-container,.jp-stats-widget)';
+		const minifiedPrefix = PREFIX.replace( /,\s+/g, ',' );
 		const css = `
 			${ minifiedPrefix } .card{color:red}
 			.jp-stats-dashboard{--sidebar-width-max:160px}

--- a/apps/odyssey-stats/webpack-css-scope.js
+++ b/apps/odyssey-stats/webpack-css-scope.js
@@ -11,9 +11,11 @@
 // The rest are portal roots: .color-scheme/.ReactModalPortal (Popover/Dialog),
 // [data-base-ui-portal]/[data-wp-compat-overlay-slot] (@wordpress/ui), .components-modal__screen-overlay
 // (@wordpress/components Modal), .components-popover__fallback-container (@wordpress/components
-// Popover/Dropdown, document.body-appended since we render no <Popover.Slot>/SlotFillProvider).
+// Popover/Dropdown, document.body-appended since we render no <Popover.Slot>/SlotFillProvider),
+// .web-preview (the post-preview modal, RootChild-portaled into a classless document.body div —
+// the modal's own root rules are `exclude`d below for the same reason).
 const prefix =
-	':where(.jp-stats-dashboard, .color-scheme, .ReactModalPortal, [data-base-ui-portal], [data-wp-compat-overlay-slot], .components-modal__screen-overlay, .components-popover__fallback-container, .jp-stats-widget)';
+	':where(.jp-stats-dashboard, .color-scheme, .ReactModalPortal, [data-base-ui-portal], [data-wp-compat-overlay-slot], .components-modal__screen-overlay, .components-popover__fallback-container, .jp-stats-widget, .web-preview)';
 
 // `prefix` roots that are always document.body-appended and never nested inside another root, so
 // self-nesting them under `prefix` is always dead — unlike the portal roots below, which routinely
@@ -23,6 +25,7 @@ const entryPointRoots = [
 	'.jp-stats-dashboard',
 	'.jp-stats-widget',
 	'.components-popover__fallback-container',
+	'.web-preview',
 ];
 
 // The rest of `prefix`'s roots: legitimately nestable inside entryPointRoots. verify-css-scope.js
@@ -74,6 +77,11 @@ const exclude = [
 	// class/attribute on the wrapper — only its content carries `.components-tooltip`. Nothing
 	// targets it today; excluded pre-emptively so that stays true if something ever does.
 	/^\.components-tooltip(?![\w-])/,
+	// The WebPreview modal (post detail "View Post") styling itself, incl. compound forms like
+	// `.web-preview.is-visible` and descendant rules anchored on the root. RootChild portals it
+	// into a classless document.body div, so the root has no scope ancestor; its BEM descendants
+	// (`.web-preview__*`) don't match this anchor and stay scoped via `.web-preview` in `prefix`.
+	/^\.web-preview(?![\w-])/,
 ];
 
 module.exports = { prefix, entryPointRoots, portalRoots, ignoreFiles, exclude };


### PR DESCRIPTION
Fixes STATS-393

## Proposed Changes

* In wp-admin (Odyssey Stats), the post-detail header's **View Post** button appeared to do nothing. It actually opens the `WebPreview` modal — but `WebPreview` portals via `RootChild` into a **classless `document.body` div**, which matches none of the CSS-scoping prefix roots. Every `.web-preview*` rule went dead in the Odyssey bundle, so clicking the button appended an invisible, unstyled modal to the end of the page (the report's "the Stats page stays/expands in place" is literally the page growing taller).
* Fix in `webpack-css-scope.js`, following the established pattern:
  * Add `.web-preview` to the `prefix` root list, so the modal's BEM descendants (`.web-preview__backdrop`, `.web-preview__content`, …) scope under the modal root.
  * Classify it in `entryPointRoots` (it is always body-appended, never nested inside another root) so `verify-css-scope`'s dead-self-nesting check covers it.
  * `exclude` the modal root's own rules (`.web-preview`, `.web-preview.is-visible`, …) — the classless portal wrapper means they can never have a scope ancestor, same treatment as `.jp-stats-dashboard`'s own rules.
* Also covers the identical **View Post** button on the email-detail page (same `WebPreview`).
* Test housekeeping: `verify-css-scope.test.js` now imports the real `prefix` from `webpack-css-scope.js` instead of a hard-coded copy, so future root additions don't silently drift the fixtures.

## Why are these changes being made?

* Regression from the recent Odyssey CSS-scoping work — this is the fourth body-portal scoping gap after the three fixed in #112989 (STATS-368 class of failure), reported by a Simple-site owner and independently reproduced. Calypso proper (wordpress.com/stats) is unaffected since it doesn't scope.

## Testing Instructions

1. `cd apps/odyssey-stats && yarn test:js` — 70 tests green, including the two new cases: WebPreview BEM descendants scope under the `.web-preview` root, and the modal root's own rules stay unprefixed.
2. `NODE_ENV=production yarn dev && yarn verify:css-scope` — passes; compiled CSS shows `:where(…, .web-preview) .web-preview__backdrop` and an unprefixed `.web-preview.is-visible`.
3. In a wp-admin Odyssey Stats build (Simple or Jetpack site): open Stats → a post's detail page → click **View Post** in the header — the preview modal opens styled (backdrop, toolbar, iframe). Escape / X closes it.
4. Same check on an email's detail page (Stats → Emails → an email).
5. Calypso proper (wordpress.com/stats) post detail: View Post modal unchanged.

Manually verified on a self-hosted Jetpack site (local Odyssey build via `STATS_PACKAGE_PATH` into `stats-admin`) **and on a Simple site in wp-admin** (local Odyssey build synced to a sandbox): the View Post modal opens styled on post detail, closes via Esc/X, and no unstyled content is appended to the page.

### Before / After recording

#### Before - View post button is not working

https://github.com/user-attachments/assets/39f720cd-5823-489c-a5d1-5cdde0824b13

#### After - View post button shows the preview modal

https://github.com/user-attachments/assets/dc1b1f0b-d1be-4b03-a7fe-4fd0ff784d6b

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)



