### PR TITLE
Extract Blackbox tests and harden

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -224,7 +224,7 @@
 	"dolly_telegram_show_userpic": false,
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js",
 	"blackbox_url": "https://blackbox-api.wp.com/v1/dist/v.js",
-	"blackbox_api_key": "e16ecd5d7848b169d97088e4c69065d8",
+	"blackbox_api_key": "1b4f123e7dae4d83bbd18170c4358f8e",
 	"site_spec": {
 		"script_url": "https://widgets.wp.com/site-spec/v1.13.3/index.js",
 		"css_url": "https://widgets.wp.com/site-spec/v1.13.3/style.css"

--- a/config/test.json
+++ b/config/test.json
@@ -16,6 +16,7 @@
 	"boom_analytics_key": "development",
 	"google_recaptcha_site_key": "",
 	"theme_color": "#1D2327",
+	"blackbox_api_key": "1xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
 	"hotjar_enabled": true,
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",

--- a/test/e2e/lib/blackbox-test-key.ts
+++ b/test/e2e/lib/blackbox-test-key.ts
@@ -1,16 +1,29 @@
 import type { Page } from '@playwright/test';
 
-// Intentionally public Blackbox test key. It mirrors Turnstile-style test keys and
-// always allows `/v1/collect`, so auth E2E tests do not depend on live challenges.
-const BLACKBOX_ALWAYS_ALLOW_PUBLIC_TEST_KEY = '1xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const BLACKBOX_COLLECT_ROUTE = 'https://blackbox-api.wp.com/v1/collect**';
 
-export async function useBlackboxTestKeyForCollect( page: Page ): Promise< void > {
-	await page.route( 'https://blackbox-api.wp.com/v1/collect**', async ( route ) => {
+// Intentionally public Blackbox test collect keys (bbtest_* outcomes).
+export const BLACKBOX_TEST_COLLECT_KEYS = {
+	allow: '1xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+	block: '2xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+	challenge: '3xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+} as const;
+
+export type BlackboxTestCollectOutcome = keyof typeof BLACKBOX_TEST_COLLECT_KEYS;
+
+export async function useBlackboxTestKeyForCollect(
+	page: Page,
+	outcome: BlackboxTestCollectOutcome = 'allow'
+): Promise< void > {
+	const collectKey = BLACKBOX_TEST_COLLECT_KEYS[ outcome ];
+
+	await page.unroute( BLACKBOX_COLLECT_ROUTE );
+	await page.route( BLACKBOX_COLLECT_ROUTE, async ( route ) => {
 		const request = route.request();
 
 		if ( request.method() === 'GET' ) {
 			const url = new URL( request.url() );
-			url.searchParams.set( 'apikey', BLACKBOX_ALWAYS_ALLOW_PUBLIC_TEST_KEY );
+			url.searchParams.set( 'apikey', collectKey );
 			await route.continue( { url: url.toString() } );
 			return;
 		}
@@ -23,7 +36,7 @@ export async function useBlackboxTestKeyForCollect( page: Page ): Promise< void 
 		await route.continue( {
 			headers: {
 				...request.headers(),
-				'x-blackbox-api-key': BLACKBOX_ALWAYS_ALLOW_PUBLIC_TEST_KEY,
+				'x-blackbox-api-key': collectKey,
 			},
 		} );
 	} );

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -41,6 +41,22 @@ const E2E_USER_AGENT_SUFFIX = 'wp-e2e-tests';
 
 const appendE2EUserAgent = ( userAgent: string ) => `${ userAgent } ${ E2E_USER_AGENT_SUFFIX }`;
 
+const loginBrowserUse = {
+	...devices[ 'Desktop Chrome HiDPI' ],
+	bypassCSP: true,
+	launchOptions: {
+		args: [
+			'--disable-blink-features=AutomationControlled',
+			'--disable-features=IsolateOrigins,site-per-process',
+		],
+		slowMo: 1000,
+		env: {},
+		channel: '',
+	},
+	userAgent:
+		'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.61 Safari/537.36',
+};
+
 function getWorkers(): number | string {
 	if ( process.env.PW_WORKERS ) {
 		return parseInt( process.env.PW_WORKERS, 10 );
@@ -151,21 +167,7 @@ export default defineConfig( {
 			dependencies: [ 'mailosaur-usage-check' ],
 			retries: 0,
 			testDir: './specs/authentication',
-			use: {
-				...devices[ 'Desktop Chrome HiDPI' ],
-				bypassCSP: true,
-				launchOptions: {
-					args: [
-						'--disable-blink-features=AutomationControlled',
-						'--disable-features=IsolateOrigins,site-per-process',
-					],
-					slowMo: 1000,
-					env: {},
-					channel: '',
-				},
-				userAgent:
-					'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML. like Gecko) Chrome/94.0.4606.61 Safari/537.36',
-			},
+			use: loginBrowserUse,
 		},
 	],
 } );

--- a/test/e2e/specs/authentication/authentication__blackbox-login-allow.spec.ts
+++ b/test/e2e/specs/authentication/authentication__blackbox-login-allow.spec.ts
@@ -1,0 +1,66 @@
+import { useBlackboxTestKeyForCollect } from '../../lib/blackbox-test-key';
+import { expect, tags, test } from '../../lib/pw-base';
+
+test.describe( 'Authentication: Blackbox login allow', { tag: [ tags.AUTHENTICATION ] }, () => {
+	test( 'As a WordPress.com user, I can log in when Blackbox returns allow', async ( {
+		page,
+		pageLogin,
+		secrets,
+	}, workerInfo ) => {
+		test.skip(
+			workerInfo.project.name !== 'authentication',
+			'The authentication project is the only one that has the right browser settings for authentication tests'
+		);
+
+		const credentials = secrets.testAccounts.defaultUser;
+
+		await test.step( 'Given Blackbox collect uses the public allow test key', async function () {
+			await useBlackboxTestKeyForCollect( page, 'allow' );
+		} );
+
+		await test.step( 'When I visit the login page', async function () {
+			const collectResponse = page.waitForResponse(
+				( response ) =>
+					response.request().method() === 'POST' &&
+					response.url().includes( 'blackbox-api.wp.com/v1/collect' )
+			);
+
+			await pageLogin.visit();
+			await page.waitForURL( /log-in/ );
+
+			const response = await collectResponse;
+			const body = await response.json();
+			expect( body?.data?.session_id ).toBe( 'bbtest_allow__________' );
+		} );
+
+		await test.step( 'And I submit valid credentials', async function () {
+			await pageLogin.fillUsername( credentials.username as string );
+			await pageLogin.clickSubmit();
+			await pageLogin.fillPassword( credentials.password );
+
+			const loginResponse = page.waitForResponse(
+				( response ) =>
+					response.request().method() === 'POST' &&
+					response.url().includes( 'action=login-endpoint' )
+			);
+			const loginRequest = page.waitForRequest(
+				( request ) =>
+					request.method() === 'POST' && request.url().includes( 'action=login-endpoint' )
+			);
+
+			await pageLogin.clickSubmit();
+			const request = await loginRequest;
+			const response = await loginResponse;
+			const body = await response.json();
+			const postData = new URLSearchParams( request.postData() ?? '' );
+
+			expect( postData.get( 'blackbox_session_id' ) ).toBe( 'bbtest_allow__________' );
+			expect( response.status() ).toBe( 200 );
+			expect( body?.success ).toBe( true );
+		} );
+
+		await test.step( 'Then I leave the login page', async function () {
+			await expect( page ).not.toHaveURL( /log-in/ );
+		} );
+	} );
+} );

--- a/test/e2e/specs/authentication/authentication__blackbox-login-block.spec.ts
+++ b/test/e2e/specs/authentication/authentication__blackbox-login-block.spec.ts
@@ -1,0 +1,70 @@
+import { useBlackboxTestKeyForCollect } from '../../lib/blackbox-test-key';
+import { expect, tags, test } from '../../lib/pw-base';
+
+test.describe( 'Authentication: Blackbox login block', { tag: [ tags.AUTHENTICATION ] }, () => {
+	test( 'As a WordPress.com user, I cannot log in when Blackbox returns block', async ( {
+		page,
+		pageLogin,
+		secrets,
+	}, workerInfo ) => {
+		test.skip(
+			workerInfo.project.name !== 'authentication',
+			'The authentication project is the only one that has the right browser settings for authentication tests'
+		);
+
+		const credentials = secrets.testAccounts.defaultUser;
+
+		await test.step( 'Given Blackbox collect uses the public block test key', async function () {
+			await useBlackboxTestKeyForCollect( page, 'block' );
+		} );
+
+		await test.step( 'When I visit the login page', async function () {
+			const collectResponse = page.waitForResponse(
+				( response ) =>
+					response.request().method() === 'POST' &&
+					response.url().includes( 'blackbox-api.wp.com/v1/collect' )
+			);
+
+			await pageLogin.visit();
+			await page.waitForURL( /log-in/ );
+
+			const response = await collectResponse;
+			const body = await response.json();
+			expect( body?.data?.session_id ).toBe( 'bbtest_block__________' );
+		} );
+
+		await test.step( 'And I submit valid credentials', async function () {
+			await pageLogin.fillUsername( credentials.username as string );
+			await pageLogin.clickSubmit();
+			await pageLogin.fillPassword( credentials.password );
+
+			const loginResponse = page.waitForResponse(
+				( response ) =>
+					response.request().method() === 'POST' &&
+					response.url().includes( 'action=login-endpoint' )
+			);
+			const loginRequest = page.waitForRequest(
+				( request ) =>
+					request.method() === 'POST' && request.url().includes( 'action=login-endpoint' )
+			);
+
+			await pageLogin.clickSubmit();
+			const request = await loginRequest;
+			const response = await loginResponse;
+			const body = await response.json();
+			const postData = new URLSearchParams( request.postData() ?? '' );
+
+			expect( postData.get( 'blackbox_session_id' ) ).toBe( 'bbtest_block__________' );
+			expect( response.status() ).toBe( 400 );
+			expect( body?.success ).toBe( false );
+		} );
+
+		await test.step( 'Then I see a login error', async function () {
+			await expect( page.locator( '.calypso-notice.is-error' ) ).toBeVisible();
+		} );
+
+		await test.step( 'And I remain on the login page', async function () {
+			await expect( page ).toHaveURL( /log-in/ );
+		} );
+	} );
+} );

--- a/test/e2e/specs/authentication/authentication__blackbox-login-challenge.spec.ts
+++ b/test/e2e/specs/authentication/authentication__blackbox-login-challenge.spec.ts
@@ -1,0 +1,42 @@
+import { useBlackboxTestKeyForCollect } from '../../lib/blackbox-test-key';
+import { expect, tags, test } from '../../lib/pw-base';
+
+test.describe( 'Authentication: Blackbox login challenge', { tag: [ tags.AUTHENTICATION ] }, () => {
+	test( 'As a WordPress.com user, I see a challenge and cannot submit while it is active', async ( {
+		page,
+		pageLogin,
+	}, workerInfo ) => {
+		test.skip(
+			workerInfo.project.name !== 'authentication',
+			'The authentication project is the only one that has the right browser settings for authentication tests'
+		);
+
+		await test.step( 'Given Blackbox collect uses the public challenge test key', async function () {
+			await useBlackboxTestKeyForCollect( page, 'challenge' );
+		} );
+
+		await test.step( 'When I visit the login page', async function () {
+			const collectResponse = page.waitForResponse(
+				( response ) =>
+					response.request().method() === 'POST' &&
+					response.url().includes( 'blackbox-api.wp.com/v1/collect' )
+			);
+
+			await pageLogin.visit();
+			await page.waitForURL( /log-in/ );
+
+			const response = await collectResponse;
+			const body = await response.json();
+
+			expect( body?.data?.session_id ).toBe( 'bbtest_challenge______' );
+			expect( body?.data?.challenge ).toBeTruthy();
+		} );
+
+		await test.step( 'Then the challenge widget is shown and submit is blocked', async function () {
+			await expect(
+				page.locator( '.login__form-blackbox-challenge.has-visible-challenge' )
+			).toBeVisible();
+			await expect( page.locator( 'button[type="submit"]' ) ).toBeDisabled();
+		} );
+	} );
+} );


### PR DESCRIPTION
Adds additional tests for different Blackbox states. Uses the new test keys (only valid with test users) to provoke certain verdicts.

By default development envs will use the real Blackbox.

More context on 231278-ghe-Automattic/wpcom.