### PR TITLE
Notifications: cache each filtered tab so switching keeps its last result

### DIFF
--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -210,9 +210,11 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 
 	// `groupBy` forces DataViews' list layout off its infinite-scroll path, which
 	// is the only path that renders its built-in load-more spinner — so we render
-	// our own at the foot of the list while a page is in flight over an
-	// already-populated list. An empty list uses the `empty` slot above instead.
-	const showLoadMore = tab.isLoading && data.length > 0;
+	// our own at the foot of the list. Key it on "more to load" rather than the
+	// in-flight fetch so it's already present when the bottom scrolls into view,
+	// not a beat later once `loadMore` dispatches. An empty list uses the `empty`
+	// slot above instead.
+	const showLoadMore = hasMoreNotes && data.length > 0;
 
 	// Full-panel spinner until this tab's first load settles; after that DataViews
 	// is mounted and in-flight loading shows in the `empty` slot or the foot.

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -51,21 +51,21 @@ type NoteListProps = {
 const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListProps ) => {
 	const filter = getFilters()[ filterName ];
 	const allNotes = useSelector( ( state ) => getAllNotes( state ) || [] ) as Note[];
-	const filteredNoteIds = useSelector( ( state ) => getFilteredNoteIds( state ) ) as number[];
-
-	// `filteredNoteIds` still holds the previous tab's list until the effect below
-	// applies this tab's filter, so ignore it until then to avoid a stale flash.
-	const [ hasAppliedFilter, setHasAppliedFilter ] = useState( false );
+	// This tab's cached id list, keyed by tab name, or undefined until its first
+	// fetch. A tab never reads the previous tab's list.
+	const cachedNoteIds = useSelector( ( state ) => getFilteredNoteIds( state, filterName ) ) as
+		| number[]
+		| undefined;
 
 	// The "All" tab renders the whole cache; every filtered tab renders the
-	// server's id list for the active filter. `filter.filter` still runs on top so
-	// an in-app change (e.g. reading a note on Unread) drops it out before a refetch.
+	// server's id list for its filter. `filter.filter` still runs on top so an
+	// in-app change (e.g. reading a note on Unread) drops it out before a refetch.
 	let notes: Note[];
 	if ( filterName === 'all' ) {
 		notes = allNotes.filter( ( note ) => filter.filter( note ) );
 	} else {
 		const notesById = new Map( allNotes.map( ( note ) => [ note.id, note ] ) );
-		notes = ( hasAppliedFilter ? filteredNoteIds : [] )
+		notes = ( cachedNoteIds ?? [] )
 			.map( ( id ) => notesById.get( id ) )
 			.filter( ( note ): note is Note => !! note )
 			.filter( ( note ) => filter.filter( note ) );
@@ -79,27 +79,28 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 	const filteredLoading = useSelector( ( state ) => getFilteredLoading( state ) );
 	const { client } = useAppContext();
 
-	// DataViews 14 binds its infinite-scroll listener in an effect that runs
-	// once and only attaches if the scroll container exists at that point.
-	// That container is rendered only after DataViews' `hasInitiallyLoaded`
-	// turns true, which is seeded from `! isLoading` on the first render. If
-	// DataViews first renders while notes are still loading, the listener is
-	// never bound and scroll-driven loading stays dead until the list
-	// remounts (e.g. on a tab switch). Defer mounting DataViews until the
-	// first load settles so it always mounts with the container present.
+	// Loading scoped to this tab, so another tab's fetch (or the background poll)
+	// can't show a loader over this one's cached notes. A filtered tab loads only
+	// while its own fetch is in flight; the All tab uses the shared flag, but not
+	// while a filtered fetch owns it.
+	const isThisTabLoading =
+		filterName === 'all' ? isLoading && ! filteredLoading : filteredLoading === filterName;
+
+	// DataViews binds its infinite-scroll listener once, on mount, and only after it
+	// first renders as not-loading (with its scroll container present). So mount it
+	// only once this tab's first load has settled — a filtered tab once its cached
+	// list exists (even empty), the All tab once its fetch is done — and pass it
+	// isLoading={false} from then on. A cached tab is already settled, so switching
+	// back mounts it immediately, with its rows.
+	const firstLoadSettled = filterName === 'all' ? ! isThisTabLoading : cachedNoteIds !== undefined;
 	const hasInitiallyLoaded = useRef( false );
-	if ( ! isLoading ) {
+	if ( firstLoadSettled ) {
 		hasInitiallyLoaded.current = true;
 	}
 
-	// Drive the client's server-side filter from the active tab. Each filter maps
-	// to a query fragment (or null for "All"); the client refetches on change.
+	// Drive the client's active tab; it refetches (or shows the cached list) on change.
 	useEffect( () => {
-		if ( ! client ) {
-			return;
-		}
-		client.setFilter( getFilters()[ filterName ].query );
-		setHasAppliedFilter( true );
+		client?.setFilter( filterName );
 	}, [ client, filterName ] );
 
 	const onChangeSelection = ( selection: string[] ) => {
@@ -155,7 +156,9 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 	// `onChangeView` fires, and `loadMore()` is never called again. Report an
 	// optimistic total while the REST client still has notes left to fetch so
 	// DataViews keeps advancing the window and driving `loadMore()`.
-	const hasMoreNotes = client?.hasMoreNotes() ?? false;
+	// Pass the rendered tab: the client's own `filterName` lags a render behind
+	// a switch, which would answer for the previous tab and stall scroll.
+	const hasMoreNotes = client?.hasMoreNotes( filterName ) ?? false;
 	const effectivePaginationInfo = hasMoreNotes
 		? { ...paginationInfo, totalItems: paginationInfo.totalItems + NOTES_PER_PAGE }
 		: paginationInfo;
@@ -166,16 +169,23 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 		}
 	}, [ client, isLoading ] );
 
-	// Keep enough notes loaded to cover the current scroll window, and to
-	// overflow the panel on first paint so a scrollbar exists for DataViews to
-	// drive further loading. A network page (`increment_limit`) can be smaller
-	// than this window, so fetch one page at a time until the window is filled or
-	// the server runs out — re-runs after each page as `visibleNotes` grows.
+	// Fetch pages until the window is filled (a network page can be smaller), so a
+	// short list still overflows the panel and gets a scrollbar to drive more.
+	// Depend on `cachedNoteIds` by reference, not length: a same-length refresh must
+	// still re-run this to retry a `loadMore` the client's in-flight lock had
+	// blocked — else a switch back to a short cached tab strands it with no scrollbar.
 	useEffect( () => {
 		if ( startPosition + NOTES_PER_PAGE > visibleNotes.length && ! isLoading && hasMoreNotes ) {
 			infiniteScrollHandler();
 		}
-	}, [ startPosition, visibleNotes.length, isLoading, hasMoreNotes, infiniteScrollHandler ] );
+	}, [
+		startPosition,
+		visibleNotes.length,
+		cachedNoteIds,
+		isLoading,
+		hasMoreNotes,
+		infiniteScrollHandler,
+	] );
 
 	// DataViews drives infinite scroll by advancing `startPosition`; the effect
 	// above reacts to that and loads more as the window nears the loaded notes.
@@ -187,21 +197,19 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 	useNoteListNavigationKeyboardShortcuts( { noteListRef, visibleNotes } );
 
 	// Spinner instead of an empty message while the view may still be filling: more
-	// notes to page, a filtered fetch in flight, or the tab's filter not yet applied.
-	// A filtered tab keys off the in-flight filter, not the shared `isLoading` the
-	// background poll also toggles.
+	// notes to page, this tab's fetch in flight, or a tab never fetched yet (no
+	// cached list).
 	const showEmptyLoader =
-		hasMoreNotes || ( filterName !== 'all' && ( ! hasAppliedFilter || !! filteredLoading ) );
+		hasMoreNotes || ( filterName !== 'all' && ( cachedNoteIds === undefined || isThisTabLoading ) );
 
 	// `groupBy` forces DataViews' list layout off its infinite-scroll path, which
 	// is the only path that renders its built-in load-more spinner — so we render
 	// our own at the foot of the list while a page is in flight over an
 	// already-populated list. An empty list uses the `empty` slot above instead.
-	const showLoadMore = isLoading && data.length > 0;
+	const showLoadMore = isThisTabLoading && data.length > 0;
 
-	// Loader only until DataViews first mounts, then never again: it binds its
-	// scroll listener once, on mount, only if the container exists, so a remount
-	// mid-load leaves scrolling dead. In-flight loading uses the `empty` slot.
+	// Full-panel spinner until this tab's first load settles; after that DataViews
+	// is mounted and in-flight loading shows in the `empty` slot or the foot.
 	if ( ! hasInitiallyLoaded.current ) {
 		return (
 			<div ref={ noteListRef } className="wpnc__note-list">
@@ -218,7 +226,10 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 				data={ data }
 				fields={ fields }
 				view={ view }
-				isLoading={ isLoading }
+				// We drive all loading UI ourselves (full-panel spinner before mount,
+				// the `empty` slot and our load-more spinner after), and never want
+				// DataViews to hide the cached rows it just mounted with.
+				isLoading={ false }
 				defaultLayouts={ DEFAULT_LAYOUTS }
 				paginationInfo={ effectivePaginationInfo }
 				empty={

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -50,52 +50,58 @@ type NoteListProps = {
 
 const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListProps ) => {
 	const filter = getFilters()[ filterName ];
+	const isAllTab = filterName === 'all';
 	const allNotes = useSelector( ( state ) => getAllNotes( state ) || [] ) as Note[];
 	// This tab's cached id list, keyed by tab name, or undefined until its first
 	// fetch. A tab never reads the previous tab's list.
 	const cachedNoteIds = useSelector( ( state ) => getFilteredNoteIds( state, filterName ) ) as
 		| number[]
 		| undefined;
-
-	// The "All" tab renders the whole cache; every filtered tab renders the
-	// server's id list for its filter. `filter.filter` still runs on top so an
-	// in-app change (e.g. reading a note on Unread) drops it out before a refetch.
-	let notes: Note[];
-	if ( filterName === 'all' ) {
-		notes = allNotes.filter( ( note ) => filter.filter( note ) );
-	} else {
-		const notesById = new Map( allNotes.map( ( note ) => [ note.id, note ] ) );
-		notes = ( cachedNoteIds ?? [] )
-			.map( ( id ) => notesById.get( id ) )
-			.filter( ( note ): note is Note => !! note )
-			.filter( ( note ) => filter.filter( note ) );
-	}
-
-	// Filter out hidden notes, i.e. notes that have been just marked as spam or moved to the trash.
 	const hiddenNoteIds = useSelector( ( state ) => getHiddenNoteIds( state ) );
-	const visibleNotes = notes.filter( ( note ) => hiddenNoteIds[ note.id ] !== true );
-
 	const isLoading = useSelector( ( state ) => getIsLoading( state ) );
 	const filteredLoading = useSelector( ( state ) => getFilteredLoading( state ) );
 	const { client } = useAppContext();
 
-	// Loading scoped to this tab, so another tab's fetch (or the background poll)
-	// can't show a loader over this one's cached notes. A filtered tab loads only
-	// while its own fetch is in flight; the All tab uses the shared flag, but not
-	// while a filtered fetch owns it.
-	const isThisTabLoading =
-		filterName === 'all' ? isLoading && ! filteredLoading : filteredLoading === filterName;
+	// Everything the render needs that depends on which tab is active, derived in
+	// one place so the All-vs-filtered split lives here and nowhere else.
+	const tab = useMemo( () => {
+		const { filter: matches } = getFilters()[ filterName ];
+
+		// The All tab renders the whole store; a filtered tab renders the server's
+		// id list for its filter. `matches` still runs on top so an in-app change
+		// (e.g. reading a note on Unread) drops it out before a refetch.
+		const notesById = new Map( allNotes.map( ( note ) => [ note.id, note ] ) );
+		const source = isAllTab
+			? allNotes
+			: ( cachedNoteIds ?? [] )
+					.map( ( id ) => notesById.get( id ) )
+					.filter( ( note ): note is Note => !! note );
+		const notes = source.filter( ( note ) => matches( note ) );
+
+		// Loading scoped to this tab, so another tab's fetch (or the background
+		// poll) can't show a loader over this one's cached notes. A filtered tab
+		// loads only while its own fetch is in flight; the All tab uses the shared
+		// flag, but not while a filtered fetch owns it.
+		const loading = isAllTab ? isLoading && ! filteredLoading : filteredLoading === filterName;
+
+		// Whether this tab's first load has settled — the All tab once its fetch is
+		// done, a filtered tab once its cached list exists (even empty).
+		const hasInitiallyLoaded = isAllTab ? ! loading : cachedNoteIds !== undefined;
+
+		return { notes, isLoading: loading, hasInitiallyLoaded };
+	}, [ isAllTab, allNotes, cachedNoteIds, isLoading, filteredLoading, filterName ] );
+
+	// Filter out hidden notes, i.e. notes that have been just marked as spam or moved to the trash.
+	const visibleNotes = tab.notes.filter( ( note ) => hiddenNoteIds[ note.id ] !== true );
 
 	// DataViews binds its infinite-scroll listener once, on mount, and only after it
 	// first renders as not-loading (with its scroll container present). So mount it
-	// only once this tab's first load has settled — a filtered tab once its cached
-	// list exists (even empty), the All tab once its fetch is done — and pass it
-	// isLoading={false} from then on. A cached tab is already settled, so switching
-	// back mounts it immediately, with its rows.
-	const firstLoadSettled = filterName === 'all' ? ! isThisTabLoading : cachedNoteIds !== undefined;
-	const hasInitiallyLoaded = useRef( false );
-	if ( firstLoadSettled ) {
-		hasInitiallyLoaded.current = true;
+	// only once this tab's first load has settled, and pass it isLoading={false}
+	// from then on. A cached tab is already settled, so switching back mounts it
+	// immediately, with its rows.
+	const hasInitiallyLoadedRef = useRef( false );
+	if ( tab.hasInitiallyLoaded ) {
+		hasInitiallyLoadedRef.current = true;
 	}
 
 	// Drive the client's active tab; it refetches (or shows the cached list) on change.
@@ -193,24 +199,24 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 
 	const noteListRef = useRef< HTMLObjectElement >( null );
 
-	useNoteListFocusToLastSelectedNote( { noteListRef, notes } );
+	useNoteListFocusToLastSelectedNote( { noteListRef, notes: tab.notes } );
 	useNoteListNavigationKeyboardShortcuts( { noteListRef, visibleNotes } );
 
 	// Spinner instead of an empty message while the view may still be filling: more
 	// notes to page, this tab's fetch in flight, or a tab never fetched yet (no
 	// cached list).
 	const showEmptyLoader =
-		hasMoreNotes || ( filterName !== 'all' && ( cachedNoteIds === undefined || isThisTabLoading ) );
+		hasMoreNotes || ( ! isAllTab && ( cachedNoteIds === undefined || tab.isLoading ) );
 
 	// `groupBy` forces DataViews' list layout off its infinite-scroll path, which
 	// is the only path that renders its built-in load-more spinner — so we render
 	// our own at the foot of the list while a page is in flight over an
 	// already-populated list. An empty list uses the `empty` slot above instead.
-	const showLoadMore = isThisTabLoading && data.length > 0;
+	const showLoadMore = tab.isLoading && data.length > 0;
 
 	// Full-panel spinner until this tab's first load settles; after that DataViews
 	// is mounted and in-flight loading shows in the `empty` slot or the foot.
-	if ( ! hasInitiallyLoaded.current ) {
+	if ( ! hasInitiallyLoadedRef.current ) {
 		return (
 			<div ref={ noteListRef } className="wpnc__note-list">
 				<VStack alignment="center" style={ { padding: '40px 0' } }>

--- a/apps/notifications/src/app/note-list/test/index.test.tsx
+++ b/apps/notifications/src/app/note-list/test/index.test.tsx
@@ -50,14 +50,16 @@ describe( 'NoteList loading state', () => {
 
 	it( 'shows the loader, not the empty message, while a filtered fetch is in flight', () => {
 		const store = initStore();
-		// Settle once with no notes so DataViews has mounted and shows its empty state.
+		// Settle once with an empty (but fetched) unread list so DataViews has mounted
+		// and shows its empty state.
+		store.dispatch( actions.notes.setFilteredNoteIds( 'unread', [] ) );
 		store.dispatch( actions.ui.loadedNotes() );
 		const { container } = renderUnread( store );
 		expect( screen.getByText( "You're all caught up!" ) ).toBeVisible();
 
 		// A filtered fetch begins: loading is true while the data is still empty.
 		act( () => {
-			store.dispatch( actions.ui.loadNotes( { filter: { unread: 1 } } ) );
+			store.dispatch( actions.ui.loadNotes( { filter: 'unread' } ) );
 		} );
 
 		// The "all caught up" message must not show until the fetch settles.
@@ -70,13 +72,14 @@ describe( 'NoteList loading state', () => {
 	// filtered fetch is still in flight (the "loading → empty → list" flash).
 	it( 'keeps the loader when the background poll clears shared loading mid-fetch', () => {
 		const store = initStore();
+		store.dispatch( actions.notes.setFilteredNoteIds( 'unread', [] ) );
 		store.dispatch( actions.ui.loadedNotes() );
 		const { container } = renderUnread( store );
 		expect( screen.getByText( "You're all caught up!" ) ).toBeVisible();
 
 		// The Unread fetch begins.
 		act( () => {
-			store.dispatch( actions.ui.loadNotes( { filter: { unread: 1 } } ) );
+			store.dispatch( actions.ui.loadNotes( { filter: 'unread' } ) );
 		} );
 		expect( screen.queryByText( "You're all caught up!" ) ).not.toBeInTheDocument();
 
@@ -94,18 +97,18 @@ describe( 'NoteList loading state', () => {
 	it( 'keeps DataViews mounted when the Unread list empties mid-fetch', () => {
 		const store = initStore();
 		store.dispatch( actions.notes.addNotes( [ makeNote( 800, 'Unread one' ) ] ) );
-		store.dispatch( actions.notes.setFilteredNoteIds( [ 800 ] ) );
+		store.dispatch( actions.notes.setFilteredNoteIds( 'unread', [ 800 ] ) );
 		store.dispatch( actions.ui.loadedNotes() );
 		const { container } = renderUnread( store );
 
 		const dataViews = container.querySelector( '.dataviews-layout__container' );
 		expect( dataViews ).toBeTruthy();
 
-		// A refetch clears the id list and flips loading on: the list is empty while
+		// A refetch empties the id list and flips loading on: the list is empty while
 		// the request is in flight.
 		act( () => {
-			store.dispatch( actions.notes.setFilteredNoteIds( [] ) );
-			store.dispatch( actions.ui.loadNotes( { filter: { unread: 1 } } ) );
+			store.dispatch( actions.notes.setFilteredNoteIds( 'unread', [] ) );
+			store.dispatch( actions.ui.loadNotes( { filter: 'unread' } ) );
 		} );
 
 		// The same DataViews node is still mounted — it was not swapped for the
@@ -123,7 +126,7 @@ describe( 'NoteList loading state', () => {
 				makeNote( 801, 'Only in cache' ),
 			] )
 		);
-		store.dispatch( actions.notes.setFilteredNoteIds( [ 800 ] ) );
+		store.dispatch( actions.notes.setFilteredNoteIds( 'unread', [ 800 ] ) );
 		store.dispatch( actions.ui.loadedNotes() );
 
 		renderUnread( store );
@@ -139,7 +142,7 @@ describe( 'NoteList loading state', () => {
 		store.dispatch(
 			actions.notes.addNotes( [ makeNote( 800, 'Unread one' ), makeNote( 801, 'Unread two' ) ] )
 		);
-		store.dispatch( actions.notes.setFilteredNoteIds( [ 800, 801 ] ) );
+		store.dispatch( actions.notes.setFilteredNoteIds( 'unread', [ 800, 801 ] ) );
 		store.dispatch( actions.notes.readNote( 800 ) );
 		store.dispatch( actions.ui.loadedNotes() );
 
@@ -154,7 +157,7 @@ describe( 'NoteList loading state', () => {
 		store.dispatch(
 			actions.notes.addNotes( [ makeNote( 810, 'Keep me' ), makeNote( 811, 'Trash me' ) ] )
 		);
-		store.dispatch( actions.notes.setFilteredNoteIds( [ 810, 811 ] ) );
+		store.dispatch( actions.notes.setFilteredNoteIds( 'unread', [ 810, 811 ] ) );
 		store.dispatch( actions.notes.trashNote( 811 ) );
 		store.dispatch( actions.ui.loadedNotes() );
 
@@ -213,7 +216,7 @@ describe( 'NoteList loading state', () => {
 				makeNote( 901, 'A like', 'like' ),
 			] )
 		);
-		store.dispatch( actions.notes.setFilteredNoteIds( [ 900 ] ) );
+		store.dispatch( actions.notes.setFilteredNoteIds( 'comments', [ 900 ] ) );
 		store.dispatch( actions.ui.loadedNotes() );
 
 		renderTab( store, 'comments' as FilterName );
@@ -226,6 +229,7 @@ describe( 'NoteList loading state', () => {
 	// not flash the spinner over the settled empty message.
 	it( 'keeps the empty message on a settled filtered tab during a refresh', () => {
 		const store = initStore();
+		store.dispatch( actions.notes.setFilteredNoteIds( 'comments', [] ) );
 		store.dispatch( actions.ui.loadedNotes() );
 		renderTab( store, 'comments' as FilterName ); // client.hasMoreNotes() is false
 		expect( screen.getByText( 'No new comments yet!' ) ).toBeVisible();
@@ -248,6 +252,111 @@ describe( 'NoteList loading state', () => {
 
 		expect( screen.queryByText( 'No new comments yet!' ) ).not.toBeInTheDocument();
 		expect( container.querySelector( '.components-spinner' ) ).toBeTruthy();
+	} );
+
+	// A tab that has never been fetched (no cached id list) shows the loader rather
+	// than its empty message, since its first fetch is imminent.
+	it( 'shows the loader on a never-fetched filtered tab', () => {
+		const store = initStore();
+		store.dispatch( actions.ui.loadedNotes() );
+		const { container } = renderTab( store, 'comments' as FilterName );
+
+		expect( screen.queryByText( 'No new comments yet!' ) ).not.toBeInTheDocument();
+		expect( container.querySelector( '.components-spinner' ) ).toBeTruthy();
+	} );
+
+	// A never-fetched tab must defer DataViews until its first load settles, so it
+	// never mounts mid-load (when DataViews renders no scroll container).
+	it( 'defers mounting DataViews until a filtered tab has loaded', () => {
+		const store = initStore();
+		// Global loading has settled, but this tab has never fetched (no cached list).
+		store.dispatch( actions.ui.loadedNotes() );
+		const { container } = renderTab( store, 'comments' as FilterName );
+
+		// No DataViews yet — the full-panel spinner stands in.
+		expect( container.querySelector( '.dataviews-layout__container' ) ).toBeNull();
+
+		// Its list lands: DataViews mounts, now with the note (so its scroll
+		// container is present).
+		act( () => {
+			store.dispatch( actions.notes.addNotes( [ makeNote( 900, 'A comment', 'comment' ) ] ) );
+			store.dispatch( actions.notes.setFilteredNoteIds( 'comments', [ 900 ] ) );
+		} );
+
+		expect( container.querySelector( '.dataviews-layout__container' ) ).toBeTruthy();
+		expect( screen.getByText( 'A comment' ) ).toBeVisible();
+	} );
+
+	// A tab that settles empty mounts DataViews with its scroll container present
+	// (it binds the listener there); notes arriving later render into that same
+	// container without a remount.
+	it( 'keeps the same DataViews when an empty filtered tab gains its first notes', () => {
+		const store = initStore();
+		store.dispatch( actions.notes.setFilteredNoteIds( 'comments', [] ) );
+		store.dispatch( actions.ui.loadedNotes() );
+		const { container } = renderTab( store, 'comments' as FilterName );
+
+		const emptyDataViews = container.querySelector( '.dataviews-layout__container' );
+		expect( emptyDataViews ).toBeTruthy();
+
+		act( () => {
+			store.dispatch( actions.notes.addNotes( [ makeNote( 900, 'A comment', 'comment' ) ] ) );
+			store.dispatch( actions.notes.setFilteredNoteIds( 'comments', [ 900 ] ) );
+		} );
+
+		expect( screen.getByText( 'A comment' ) ).toBeVisible();
+		expect( container.querySelector( '.dataviews-layout__container' ) ).toBe( emptyDataViews );
+	} );
+
+	// Keep-previous-data: a tab with a cached list renders it immediately, and a
+	// silent refresh (which the client runs without dispatching any loading state
+	// when a cached list already exists) never flashes a loader over it.
+	it( 'renders a tab’s cached notes without a loader during a silent refresh', () => {
+		const store = initStore();
+		store.dispatch( actions.notes.addNotes( [ makeNote( 900, 'A comment', 'comment' ) ] ) );
+		store.dispatch( actions.notes.setFilteredNoteIds( 'comments', [ 900 ] ) );
+		store.dispatch( actions.ui.loadedNotes() );
+
+		const { container } = renderTab( store, 'comments' as FilterName );
+		expect( screen.getByText( 'A comment' ) ).toBeVisible();
+		expect( container.querySelector( '.components-spinner' ) ).toBeFalsy();
+
+		// The refresh lands and re-sets the same list — no loading was ever toggled,
+		// so the notes stay put with no spinner.
+		act( () => {
+			store.dispatch( actions.notes.setFilteredNoteIds( 'comments', [ 900 ] ) );
+		} );
+		expect( screen.getByText( 'A comment' ) ).toBeVisible();
+		expect( container.querySelector( '.components-spinner' ) ).toBeFalsy();
+	} );
+
+	// A cached tab must show its notes on switch-back even while another tab's fetch
+	// still has the shared loading flag on — not the full-panel spinner.
+	it( 'shows a cached tab’s notes while another tab is mid-fetch', () => {
+		const store = initStore();
+		store.dispatch( actions.notes.addNotes( [ makeNote( 900, 'A comment', 'comment' ) ] ) );
+		store.dispatch( actions.notes.setFilteredNoteIds( 'comments', [ 900 ] ) );
+		// Another tab's fetch is in flight, so the shared loading flag is on.
+		store.dispatch( actions.ui.loadNotes( { filter: 'unread' } ) );
+
+		renderTab( store, 'comments' as FilterName );
+
+		expect( screen.getByText( 'A comment' ) ).toBeVisible();
+	} );
+
+	// A cached tab loading more (its own fetch in flight) must keep its rows
+	// rendered, so DataViews mounts loaded and binds its scroll listener — else
+	// load-more dies after switching away and back mid-fetch.
+	it( 'renders a cached tab’s rows while it is loading more', () => {
+		const store = initStore();
+		store.dispatch( actions.notes.addNotes( [ makeNote( 900, 'A comment', 'comment' ) ] ) );
+		store.dispatch( actions.notes.setFilteredNoteIds( 'comments', [ 900 ] ) );
+		// This tab's own fetch is in flight (e.g. paging older notes).
+		store.dispatch( actions.ui.loadNotes( { filter: 'comments' } ) );
+
+		renderTab( store, 'comments' as FilterName );
+
+		expect( screen.getByText( 'A comment' ) ).toBeVisible();
 	} );
 
 	it( 'marks only the open note row with the active highlight', () => {

--- a/apps/notifications/src/app/note-list/test/switch-during-loadmore.test.tsx
+++ b/apps/notifications/src/app/note-list/test/switch-during-loadmore.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, act } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import Client from '../../../panel/rest-client';
+import { init as initWpcom } from '../../../panel/rest-client/wpcom';
+import { init as initStore } from '../../../panel/state';
+import getFilteredNoteIds from '../../../panel/state/selectors/get-filtered-note-ids';
+import { AppProvider } from '../../context';
+import NoteList from '../index';
+import type { FilterName } from '../../types';
+
+const noop = () => {};
+
+// Valid, monotonic timestamps (higher id = newer note).
+const makeNote = ( id: number, label: string, type = 'comment' ) => ( {
+	id,
+	type,
+	read: 0,
+	noticon: '',
+	timestamp: new Date( Date.UTC( 2026, 5, 1, 0, 0, id ) ).toISOString(),
+	title: `${ label } title`,
+	subject: [ { text: label, ranges: [], media: [] } ],
+} );
+
+const page = ( ids: number[] ) => ids.map( ( id ) => makeNote( id, `note ${ id }` ) );
+
+describe( 'load-more after a tab switch (integration)', () => {
+	let getCalls: Array< {
+		query: Record< string, unknown >;
+		callback: ( e: unknown, d: unknown ) => void;
+	} >;
+	let client: Client;
+	let store: ReturnType< typeof initStore >;
+
+	beforeAll( () => {
+		Element.prototype.scrollIntoView = noop;
+	} );
+
+	beforeEach( () => {
+		jest.useFakeTimers();
+		store = initStore();
+		getCalls = [];
+		initWpcom( {
+			req: {
+				get: ( _path: string, query: Record< string, unknown >, callback: never ) =>
+					getCalls.push( { query, callback } ),
+				post: noop,
+			},
+			pinghub: { connect: noop },
+		} as never );
+		client = new Client();
+		client.isVisible = true;
+		getCalls.length = 0;
+	} );
+
+	afterEach( () => {
+		jest.clearAllTimers();
+		jest.useRealTimers();
+	} );
+
+	const list = ( filterName: FilterName ) => (
+		<Provider store={ store }>
+			<AppProvider client={ client as never } locale="en">
+				{ /* Key by filterName so a switch remounts the list, like the real panel. */ }
+				<NoteList
+					key={ filterName }
+					filterName={ filterName }
+					selectedNoteId={ undefined }
+					setSelectedNoteId={ noop }
+				/>
+			</AppProvider>
+		</Provider>
+	);
+
+	const unreadCall = () => getCalls.find( ( c ) => c.query.unread );
+
+	// The reported bug: 16 comments, first 10 shown, load more in flight, switch
+	// away and back — the next 6 were fetched but dropped, so they never appeared.
+	it( 'stores and shows notes whose load-more lands after switching away and back', () => {
+		const { rerender } = render( list( 'unread' as FilterName ) );
+
+		// First page: 10 of 16 (ids 116..107, a full page ⇒ more to come).
+		act( () => {
+			unreadCall()!.callback( null, {
+				notes: page( [ 116, 115, 114, 113, 112, 111, 110, 109, 108, 107 ] ),
+				last_seen_time: 0,
+			} );
+		} );
+		expect( screen.getByText( 'note 116' ) ).toBeVisible();
+
+		// The list auto-pages to fill its window: a load-more (with `before`) is now
+		// in flight for the remaining notes.
+		const loadMore = getCalls.find( ( c ) => c.query.unread && c.query.before );
+		expect( loadMore ).toBeTruthy();
+
+		// Switch away and back while that request is in flight.
+		act( () => {
+			rerender( list( 'comments' as FilterName ) );
+		} );
+		act( () => {
+			rerender( list( 'unread' as FilterName ) );
+		} );
+
+		// The load-more response lands (the final 6: ids 106..101).
+		act( () => {
+			loadMore!.callback( null, {
+				notes: page( [ 106, 105, 104, 103, 102, 101 ] ),
+				last_seen_time: 0,
+			} );
+		} );
+
+		// All 16 are stored for the Unread tab…
+		expect( getFilteredNoteIds( store.getState(), 'unread' ) ).toHaveLength( 16 );
+		// …and a note from the previously-dropped page is on screen.
+		expect( screen.getAllByText( 'note 101' ).length ).toBeGreaterThan( 0 );
+	} );
+} );

--- a/apps/notifications/src/app/types.ts
+++ b/apps/notifications/src/app/types.ts
@@ -148,10 +148,10 @@ export interface Client {
 	getNotes: () => void;
 	getNotesList: () => void;
 	getFilteredNotes: () => void;
-	setFilter: ( filter: Record< string, unknown > | null ) => void;
+	setFilter: ( filterName: FilterName ) => void;
 	updateLastSeenTime: ( proposedTime: number, fromStorage: boolean ) => boolean;
 	loadMore: () => void;
-	hasMoreNotes: () => boolean;
+	hasMoreNotes: ( filterName?: FilterName ) => boolean;
 	refreshNotes: () => void;
 	setVisibility: ( { isShowing, isVisible }: { isShowing: boolean; isVisible: boolean } ) => void;
 }

--- a/apps/notifications/src/app/types.ts
+++ b/apps/notifications/src/app/types.ts
@@ -131,7 +131,7 @@ export interface Client {
 	isShowing: boolean;
 	lastSeenTime: number;
 	filter: Record< string, unknown > | null;
-	filteredHasMore: boolean;
+	filteredHasMore: Record< string, boolean >;
 	gettingFilteredNotes: boolean;
 	retries: number;
 	subscribeTry: number;
@@ -147,7 +147,7 @@ export interface Client {
 	getNote: ( note_id: number ) => void;
 	getNotes: () => void;
 	getNotesList: () => void;
-	getFilteredNotes: () => void;
+	getFilteredNotes: ( before?: number ) => void;
 	setFilter: ( filterName: FilterName ) => void;
 	updateLastSeenTime: ( proposedTime: number, fromStorage: boolean ) => boolean;
 	loadMore: () => void;

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -5,6 +5,7 @@ import { store } from '../state';
 import actions from '../state/actions';
 import getAllNotes from '../state/selectors/get-all-notes';
 import getFilteredNoteIds from '../state/selectors/get-filtered-note-ids';
+import { getFilters } from '../templates/filters';
 import { fetchNote, listNotes, sendLastSeenTime, subscribeToNoteStream } from './wpcom';
 
 const debug = debugFactory( 'notifications:rest-client' );
@@ -32,11 +33,11 @@ export function Client() {
 	// Active tab's server-side filter (e.g. `{ unread: 1 }`), or null for the
 	// unfiltered "all" list. When set, getFilteredNotes fetches matching notes.
 	this.filter = null;
-	this.filteredHasMore = false;
+	// Active tab name; the cache key for its id list and load-more state.
+	this.filterName = 'all';
+	// Per-tab load-more exhaustion, keyed by tab name.
+	this.filteredHasMore = {};
 	this.gettingFilteredNotes = false;
-	// Bumped on every setFilter so an in-flight fetch whose filter was reset
-	// (tab switched away and back) can discard its now-stale response.
-	this.filterGeneration = 0;
 	this.retries = 0;
 	this.subscribeTry = 0;
 	this.subscribeTries = 3;
@@ -415,22 +416,17 @@ function getNotesList() {
 }
 
 /**
- * Set the active server-side filter for the visible tab and (re)fetch.
+ * Set the active tab and (re)fetch its filtered notes.
  *
- * Pass `null` for the unfiltered "all" tab, or a query fragment such as
- * `{ unread: 1 }` for a filtered tab. Switching tabs resets the filtered
- * pagination window and, for a filtered tab, kicks off a fresh fetch so the
- * list reflects the server's filtered results immediately.
- * @param {?Object} filter Query fragment to send to the notes endpoint, or null.
+ * Pass a tab name such as `'unread'` (see getFilters); `'all'` is the unfiltered
+ * list. For a filtered tab this kicks off a fetch; the tab's cached id list is
+ * kept (never cleared here) so a revisit shows its last result while the fetch
+ * refreshes it in the background.
+ * @param {string} filterName Name of the tab to activate.
  */
-function setFilter( filter ) {
-	this.filter = filter ?? null;
-	this.filteredHasMore = false;
-	this.filterGeneration++;
-
-	// Reset the filtered view's id list so the tab doesn't show a stale set
-	// before the fresh fetch lands.
-	store.dispatch( actions.notes.setFilteredNoteIds( [] ) );
+function setFilter( filterName ) {
+	this.filterName = filterName ?? 'all';
+	this.filter = getFilters()[ this.filterName ]?.query ?? null;
 
 	if ( this.filter && this.isVisible ) {
 		this.getFilteredNotes();
@@ -450,12 +446,12 @@ function getFilteredNotes( before ) {
 		return;
 	}
 	this.gettingFilteredNotes = true;
-	const generation = this.filterGeneration;
-	// Tag this fetch's loading dispatches with its filter, stable even if the
-	// active filter changes mid-flight.
+	// Tag this fetch's dispatches and cache writes with the tab it was made for,
+	// stable even if the active tab changes mid-flight.
 	const filter = this.filter;
+	const key = this.filterName;
 
-	const filteredIds = getFilteredNoteIds( store.getState() );
+	const filteredIds = getFilteredNoteIds( store.getState(), key ) ?? [];
 
 	const parameters = {
 		fields: 'id,type,unread,body,subject,timestamp,meta,note_hash,variant',
@@ -472,15 +468,21 @@ function getFilteredNotes( before ) {
 		parameters.before = before;
 	}
 
-	// Loading state on the first page (the full-panel spinner shows while the list
-	// is empty) and while paging older notes (`before` → the list's load-more
-	// indicator); a steady-state refresh of a non-empty list stays silent.
-	if ( before || filteredIds.length === 0 ) {
-		store.dispatch( actions.ui.loadNotes( { filter } ) );
+	// Loading state on a tab's first-ever fetch (the full-panel spinner shows while
+	// it has no cached list yet) and while paging older notes (`before` → the
+	// list's load-more indicator); a refresh over a cached list stays silent so the
+	// previous result keeps showing.
+	if ( before || getFilteredNoteIds( store.getState(), key ) === undefined ) {
+		store.dispatch( actions.ui.loadNotes( { filter: key } ) );
 	}
 
 	listNotes( parameters, ( error, data ) => {
 		this.gettingFilteredNotes = false;
+
+		// A tab switch while this was in flight left the newly-active tab's own
+		// fetch skipped (this request held the lock); run it once we're done. Its
+		// cached list, if any, keeps showing meanwhile.
+		const activeTabNeedsFetch = this.filter && this.isVisible && this.filterName !== key;
 
 		if ( error ) {
 			logError( error, {
@@ -489,72 +491,62 @@ function getFilteredNotes( before ) {
 				status: error.status,
 				code: error.error,
 			} );
-			// Leave the polling path's state untouched; it will recover on its
-			// own schedule. A retry happens when the user re-enters the tab.
-			store.dispatch( actions.ui.loadedNotes( { filter } ) );
-			return;
-		}
-
-		// The filter was reset (tab switched away and back) while this was in
-		// flight: drop the stale response and refetch the current view, since
-		// setFilter's own fetch was skipped while this request held the lock.
-		if ( generation !== this.filterGeneration ) {
-			if ( this.filter && this.isVisible ) {
-				// The refetch keeps the loading state; don't clear it here.
+			store.dispatch( actions.ui.loadedNotes( { filter: key } ) );
+			if ( activeTabNeedsFetch ) {
 				this.getFilteredNotes();
-			} else {
-				store.dispatch( actions.ui.loadedNotes( { filter } ) );
 			}
 			return;
 		}
 
 		store.dispatch( actions.notes.addNotes( data.notes ) );
 
-		// Guard on the filter so a response landing after a tab switch is ignored.
-		// The generation check above already dropped stale responses; this keeps the
-		// id-list writes out of the unfiltered "all" path.
-		if ( this.filter ) {
-			const pageIds = data.notes.map( ( note ) => note.id );
-			if ( before ) {
-				// Append the older page to the view's id list, de-duped — a filtered
-				// fetch can return notes an earlier page already loaded.
-				const current = getFilteredNoteIds( store.getState() );
-				const known = new Set( current );
-				const fresh = pageIds.filter( ( id ) => ! known.has( id ) );
-				const appended = current.concat( fresh );
-				store.dispatch( actions.notes.setFilteredNoteIds( appended ) );
+		// Apply the response to the tab it was fetched for (`key`), never the tab
+		// that happens to be active now. A response that lands after a switch away
+		// and back is still that tab's data, so it's stored and shown — not dropped.
+		const pageIds = data.notes.map( ( note ) => note.id );
+		if ( before ) {
+			// Append the older page to the view's id list, de-duped — a filtered
+			// fetch can return notes an earlier page already loaded.
+			const current = getFilteredNoteIds( store.getState(), key ) ?? [];
+			const known = new Set( current );
+			const fresh = pageIds.filter( ( id ) => ! known.has( id ) );
+			const appended = current.concat( fresh );
+			store.dispatch( actions.notes.setFilteredNoteIds( key, appended ) );
 
-				// More only while the page is full, adds new ids (an inclusive
-				// `before` can echo the anchor), and the list is under the cap.
-				this.filteredHasMore =
-					fresh.length > 0 &&
-					data.notes.length >= parameters.number &&
-					appended.length < settings.max_limit;
-			} else {
-				// Merge the head over the list, keeping the older paged-in tail. Drop
-				// within-head ids the server no longer returns (read/deleted elsewhere).
-				const current = getFilteredNoteIds( store.getState() );
-				const serverIdSet = new Set( pageIds );
-				const oldestServerId = pageIds[ pageIds.length - 1 ];
-				const boundary = current.findIndex( ( id ) => id === oldestServerId );
-				const tail = (
-					boundary >= 0 ? current.slice( boundary + 1 ) : current.slice( pageIds.length )
-				).filter( ( id ) => ! serverIdSet.has( id ) );
-				const merged = pageIds.concat( tail );
-				store.dispatch( actions.notes.setFilteredNoteIds( merged ) );
+			// More only while the page is full, adds new ids (an inclusive
+			// `before` can echo the anchor), and the list is under the cap.
+			this.filteredHasMore[ key ] =
+				fresh.length > 0 &&
+				data.notes.length >= parameters.number &&
+				appended.length < settings.max_limit;
+		} else {
+			// Merge the head over the list, keeping the older paged-in tail. Drop
+			// within-head ids the server no longer returns (read/deleted elsewhere).
+			const current = getFilteredNoteIds( store.getState(), key ) ?? [];
+			const serverIdSet = new Set( pageIds );
+			const oldestServerId = pageIds[ pageIds.length - 1 ];
+			const boundary = current.findIndex( ( id ) => id === oldestServerId );
+			const tail = (
+				boundary >= 0 ? current.slice( boundary + 1 ) : current.slice( pageIds.length )
+			).filter( ( id ) => ! serverIdSet.has( id ) );
+			const merged = pageIds.concat( tail );
+			store.dispatch( actions.notes.setFilteredNoteIds( key, merged ) );
 
-				// First page: a full head implies more older notes. Later refreshes keep
-				// the load-more exhaustion state instead of resetting it from the head.
-				this.filteredHasMore =
-					( current.length === 0
-						? data.notes.length >= parameters.number
-						: this.filteredHasMore ) && merged.length < settings.max_limit;
-			}
+			// First page: a full head implies more older notes. Later refreshes keep
+			// the load-more exhaustion state instead of resetting it from the head.
+			this.filteredHasMore[ key ] =
+				( current.length === 0
+					? data.notes.length >= parameters.number
+					: this.filteredHasMore[ key ] ) && merged.length < settings.max_limit;
 		}
 
 		// Clear loading only after the notes and ids are in the store, so the list
 		// never flashes empty between "loaded" and the ids landing.
-		store.dispatch( actions.ui.loadedNotes( { filter } ) );
+		store.dispatch( actions.ui.loadedNotes( { filter: key } ) );
+
+		if ( activeTabNeedsFetch ) {
+			this.getFilteredNotes();
+		}
 	} );
 }
 
@@ -721,12 +713,13 @@ function loadMore() {
 	// Filtered tabs paginate their own window, advancing only while the server
 	// still has matching notes.
 	if ( this.filter ) {
-		if ( this.gettingFilteredNotes || ! this.filteredHasMore ) {
+		const key = this.filterName;
+		if ( this.gettingFilteredNotes || ! this.filteredHasMore[ key ] ) {
 			return;
 		}
 		// Page older notes additively, anchored on the view's oldest. `before` is
 		// epoch seconds, not the ISO timestamp.
-		const filteredIds = getFilteredNoteIds( store.getState() );
+		const filteredIds = getFilteredNoteIds( store.getState(), key ) ?? [];
 		const oldestId = filteredIds[ filteredIds.length - 1 ];
 		const oldest = oldestId && getAllNotes( store.getState() ).find( ( n ) => n.id === oldestId );
 		if ( ! oldest ) {
@@ -762,9 +755,14 @@ function loadMore() {
 // until then there may be more, capped at max_limit. The note list uses this to
 // keep its optimistic `totalItems` ahead of the scroll window so DataViews
 // keeps advancing it.
-function hasMoreNotes() {
-	if ( this.filter ) {
-		return this.filteredHasMore;
+//
+// Pass the tab being rendered: the component reads this during render, before its
+// effect calls setFilter, so relying on `this.filterName` would return the
+// previous tab's answer on the first render after a switch — stalling DataViews'
+// infinite scroll for good.
+function hasMoreNotes( filterName = this.filterName ) {
+	if ( filterName !== 'all' ) {
+		return this.filteredHasMore[ filterName ] ?? false;
 	}
 	// Measure this view's own window (`noteList`), not the shared store, which a
 	// filtered fetch can inflate to the cap with notes outside this window.

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { store } from '../../state';
+import { store, init as initState } from '../../state';
 import actions from '../../state/actions';
 import getAllNotes from '../../state/selectors/get-all-notes';
 import getFilteredLoading from '../../state/selectors/get-filtered-loading';
@@ -12,6 +12,9 @@ import { init } from '../wpcom';
 
 // Mirrors settings.max_limit in the client.
 const MAX_LIMIT = 200;
+
+// Every filtered test here uses the Unread tab; its id list is cached under its name.
+const UNREAD_KEY = 'unread';
 
 // Distinct, monotonic timestamps so ordering is unambiguous: a higher id is a
 // newer note, so the lowest id is always the oldest (last) in the sorted list.
@@ -33,11 +36,9 @@ describe( 'RestClient', () => {
 	beforeEach( () => {
 		jest.useFakeTimers();
 
-		// The redux store is a shared singleton; clear it so each test starts empty.
-		const ids = getAllNotes( store.getState() ).map( ( note ) => note.id );
-		if ( ids.length ) {
-			store.dispatch( actions.notes.removeNotes( ids ) );
-		}
+		// The redux store is a shared singleton; re-init it so each test starts empty,
+		// including the per-tab cached filtered id lists.
+		initState();
 
 		getCalls = [];
 		init( {
@@ -216,7 +217,7 @@ describe( 'RestClient', () => {
 			seedFirstWindow();
 
 			// Visit Unread; the response includes a note far older than the window.
-			client.setFilter( { unread: 1 } );
+			client.setFilter( 'unread' );
 			getCalls[ 0 ].callback( null, {
 				notes: [ makeNote( 91 ), makeNote( 5 ) ],
 				last_seen_time: 0,
@@ -224,7 +225,7 @@ describe( 'RestClient', () => {
 			getCalls.length = 0;
 
 			// Back to the All view.
-			client.setFilter( null );
+			client.setFilter( 'all' );
 			getCalls.length = 0;
 
 			// Load-more must anchor on the All window's oldest (91), not the stray
@@ -314,7 +315,7 @@ describe( 'RestClient', () => {
 
 	describe( 'server-side (unread) filtering', () => {
 		it( 'sends unread=1 to the server and adds the returned notes', () => {
-			client.setFilter( { unread: 1 } );
+			client.setFilter( 'unread' );
 
 			expect( getCalls ).toHaveLength( 1 );
 			expect( getCalls[ 0 ].query ).toMatchObject( { unread: 1, number: 10 } );
@@ -326,11 +327,11 @@ describe( 'RestClient', () => {
 		} );
 
 		it( 'stops paginating when the server returns a short page (empty Unread case)', () => {
-			client.setFilter( { unread: 1 } );
+			client.setFilter( 'unread' );
 			// A short page (fewer than `number`) means the server is exhausted.
 			getCalls[ 0 ].callback( null, { notes: [], last_seen_time: 0 } );
 
-			expect( client.filteredHasMore ).toBe( false );
+			expect( client.filteredHasMore[ UNREAD_KEY ] ).toBe( false );
 
 			getCalls.length = 0;
 			client.loadMore();
@@ -339,11 +340,11 @@ describe( 'RestClient', () => {
 		} );
 
 		it( 'pages older unread notes in with a before cursor while the server has more', () => {
-			client.setFilter( { unread: 1 } );
+			client.setFilter( 'unread' );
 			// A full first window (newest-first, oldest id 200) implies more may exist.
 			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } );
 
-			expect( client.filteredHasMore ).toBe( true );
+			expect( client.filteredHasMore[ UNREAD_KEY ] ).toBe( true );
 
 			getCalls.length = 0;
 			client.loadMore();
@@ -358,7 +359,7 @@ describe( 'RestClient', () => {
 		} );
 
 		it( 'de-dupes an older unread page that echoes an already-loaded id', () => {
-			client.setFilter( { unread: 1 } );
+			client.setFilter( 'unread' );
 			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } ); // 209..200
 			getCalls.length = 0;
 
@@ -368,30 +369,32 @@ describe( 'RestClient', () => {
 			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 200 ), last_seen_time: 0 } );
 
 			// Only the nine genuinely-older ids are appended; the anchor isn't duped.
-			expect( getFilteredNoteIds( store.getState() ) ).toHaveLength( 19 );
+			expect( getFilteredNoteIds( store.getState(), UNREAD_KEY ) ).toHaveLength( 19 );
 		} );
 
 		it( 'replaces the unread id list with the response, leaving the shared store intact', () => {
 			// A note already cached (e.g. read on another device since it was loaded).
 			store.dispatch( actions.notes.addNotes( [ makeNote( 500 ) ] ) );
 
-			client.setFilter( { unread: 1 } );
+			client.setFilter( 'unread' );
 			getCalls[ 0 ].callback( null, { notes: [ makeNote( 501 ) ], last_seen_time: 0 } );
 
 			// The Unread view follows the server's id list, so 500 drops out of it…
-			expect( getFilteredNoteIds( store.getState() ) ).toEqual( [ 501 ] );
+			expect( getFilteredNoteIds( store.getState(), UNREAD_KEY ) ).toEqual( [ 501 ] );
 			// …but the shared store is untouched, so the "All" view keeps both notes.
 			const allIds = getAllNotes( store.getState() ).map( ( note ) => note.id );
 			expect( allIds ).toEqual( expect.arrayContaining( [ 500, 501 ] ) );
 		} );
 
-		it( 'clears the unread id list when the filter changes', () => {
-			client.setFilter( { unread: 1 } );
+		// Switching tabs keeps each tab's cached list so a revisit shows its last
+		// result instead of a loader; the list is refreshed, not cleared.
+		it( 'keeps the unread id list cached when the filter changes', () => {
+			client.setFilter( 'unread' );
 			getCalls[ 0 ].callback( null, { notes: [ makeNote( 700 ) ], last_seen_time: 0 } );
-			expect( getFilteredNoteIds( store.getState() ) ).toEqual( [ 700 ] );
+			expect( getFilteredNoteIds( store.getState(), UNREAD_KEY ) ).toEqual( [ 700 ] );
 
-			client.setFilter( null ); // switch back to "All"
-			expect( getFilteredNoteIds( store.getState() ) ).toEqual( [] );
+			client.setFilter( 'all' ); // switch back to "All"
+			expect( getFilteredNoteIds( store.getState(), UNREAD_KEY ) ).toEqual( [ 700 ] );
 		} );
 
 		// A filtered fetch must never remove notes from the shared store, so the
@@ -401,7 +404,7 @@ describe( 'RestClient', () => {
 			store.dispatch( actions.notes.addNotes( all ) );
 			const before = getAllNotes( store.getState() ).length;
 
-			client.setFilter( { unread: 1 } );
+			client.setFilter( 'unread' );
 			// The unread response is a subset of what's already cached.
 			getCalls[ 0 ].callback( null, {
 				notes: [ makeNote( 1000 ), makeNote( 1001 ) ],
@@ -411,11 +414,28 @@ describe( 'RestClient', () => {
 			expect( getAllNotes( store.getState() ).length ).toBe( before );
 		} );
 
+		// The note list reads hasMoreNotes during render — before its effect calls
+		// setFilter — so it must answer for the tab it passes, not the client's own
+		// (lagging) filterName. A wrong answer there stalls DataViews' infinite
+		// scroll for good, so load-more dies after a tab switch.
+		it( 'reports hasMoreNotes for the requested tab, not the active one', () => {
+			client.setFilter( 'unread' );
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } );
+			expect( client.filteredHasMore[ UNREAD_KEY ] ).toBe( true );
+
+			// The client still points at a not-yet-loaded tab (the render-before-effect
+			// window right after a switch). hasMoreNotes must key off its argument.
+			client.filterName = 'comments';
+			client.filter = { type: 'comment' };
+			expect( client.hasMoreNotes( 'unread' ) ).toBe( true );
+			expect( client.hasMoreNotes( 'comments' ) ).toBe( false );
+		} );
+
 		it( 'pages older unread notes in additively and stops when exhausted', () => {
-			client.setFilter( { unread: 1 } );
+			client.setFilter( 'unread' );
 			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } ); // 209..200
-			expect( getFilteredNoteIds( store.getState() ) ).toHaveLength( 10 );
-			expect( client.filteredHasMore ).toBe( true );
+			expect( getFilteredNoteIds( store.getState(), UNREAD_KEY ) ).toHaveLength( 10 );
+			expect( client.filteredHasMore[ UNREAD_KEY ] ).toBe( true );
 
 			// Page 2: a fixed increment older than the oldest loaded note (200).
 			getCalls.length = 0;
@@ -426,8 +446,8 @@ describe( 'RestClient', () => {
 				before: Math.floor( Date.parse( makeNote( 200 ).timestamp ) / 1000 ),
 			} );
 			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 199 ), last_seen_time: 0 } ); // 199..190
-			expect( getFilteredNoteIds( store.getState() ) ).toHaveLength( 20 );
-			expect( client.filteredHasMore ).toBe( true );
+			expect( getFilteredNoteIds( store.getState(), UNREAD_KEY ) ).toHaveLength( 20 );
+			expect( client.filteredHasMore[ UNREAD_KEY ] ).toBe( true );
 
 			// Page 3: older than the new oldest (190); a short page means exhausted.
 			getCalls.length = 0;
@@ -438,8 +458,8 @@ describe( 'RestClient', () => {
 				before: Math.floor( Date.parse( makeNote( 190 ).timestamp ) / 1000 ),
 			} );
 			getCalls[ 0 ].callback( null, { notes: fullPage( 5, 189 ), last_seen_time: 0 } ); // 189..185
-			expect( getFilteredNoteIds( store.getState() ) ).toHaveLength( 25 );
-			expect( client.filteredHasMore ).toBe( false );
+			expect( getFilteredNoteIds( store.getState(), UNREAD_KEY ) ).toHaveLength( 25 );
+			expect( client.filteredHasMore[ UNREAD_KEY ] ).toBe( false );
 
 			// No more pages: load-more is a no-op.
 			getCalls.length = 0;
@@ -450,7 +470,7 @@ describe( 'RestClient', () => {
 		// Reaching the cap with a full page must clear `filteredHasMore`, or the next
 		// load-more fires a zero-count request (number = max_limit - 100).
 		it( 'stops filtered paging at the cap without a zero-count request', () => {
-			client.setFilter( { unread: 1 } );
+			client.setFilter( 'unread' );
 			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } );
 
 			// Page in full older pages (10 at a time) until the list reaches max_limit.
@@ -461,8 +481,8 @@ describe( 'RestClient', () => {
 				getCalls[ 0 ].callback( null, { notes: fullPage( 10, oldest ), last_seen_time: 0 } );
 			}
 
-			expect( getFilteredNoteIds( store.getState() ) ).toHaveLength( MAX_LIMIT );
-			expect( client.filteredHasMore ).toBe( false );
+			expect( getFilteredNoteIds( store.getState(), UNREAD_KEY ) ).toHaveLength( MAX_LIMIT );
+			expect( client.filteredHasMore[ UNREAD_KEY ] ).toBe( false );
 
 			// At the cap, load-more must not fire another request.
 			getCalls.length = 0;
@@ -470,37 +490,55 @@ describe( 'RestClient', () => {
 			expect( getCalls ).toHaveLength( 0 );
 		} );
 
-		// Switching tabs away and back while a load-more is in flight resets the
-		// filter; the stale older-page response must not append to the cleared list.
-		it( 'discards a stale unread load-more response after a filter reset', () => {
-			client.setFilter( { unread: 1 } );
-			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } );
+		// Regression: a load-more response that lands after the user switched away
+		// and back must be applied to its tab's list, not dropped — else the fetched
+		// notes are lost and the tab is stuck missing them.
+		it( 'applies an unread load-more response that lands after a switch away and back', () => {
+			client.setFilter( 'unread' );
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } ); // 209..200
+			expect( getFilteredNoteIds( store.getState(), UNREAD_KEY ) ).toHaveLength( 10 );
 
 			// Start a load-more; capture its still-pending callback.
 			getCalls.length = 0;
 			client.loadMore();
-			const staleCallback = getCalls[ 0 ].callback;
+			const lateCallback = getCalls[ 0 ].callback;
 
-			// User switches to All and back to Unread before it resolves. The fresh
-			// fetch is skipped because the in-flight request still holds the lock.
-			client.setFilter( null );
-			client.setFilter( { unread: 1 } );
-			expect( getFilteredNoteIds( store.getState() ) ).toEqual( [] );
+			// User switches to All and back to Unread before it resolves; the
+			// re-selection's own fetch is skipped because this request holds the lock.
+			client.setFilter( 'all' );
+			client.setFilter( 'unread' );
 
-			// The stale older page lands: it must be dropped, not appended…
+			// The older page lands: its notes are appended to the unread list.
+			lateCallback( null, { notes: fullPage( 10, 199 ), last_seen_time: 0 } ); // 199..190
+			expect( getFilteredNoteIds( store.getState(), UNREAD_KEY ) ).toHaveLength( 20 );
+		} );
+
+		// A response that lands while a different tab is active is cached under its
+		// own tab, and the now-active tab's skipped fetch is kicked off.
+		it( 'caches a late response for its tab and fetches the newly-active tab', () => {
+			client.setFilter( 'unread' );
+			const unreadCallback = getCalls[ 0 ].callback; // unread fetch in flight
+
+			// Switch to Comments before unread resolves; its fetch is skipped (locked).
+			client.setFilter( 'comments' );
+
 			getCalls.length = 0;
-			staleCallback( null, { notes: fullPage( 10, 199 ), last_seen_time: 0 } );
-			expect( getFilteredNoteIds( store.getState() ) ).toEqual( [] );
-			// …and a fresh fetch for the re-selected filter must be kicked off.
-			expect( getCalls.find( ( call ) => call.query.unread ) ).toBeTruthy();
+			unreadCallback( null, { notes: fullPage( 5, 300 ), last_seen_time: 0 } );
+			// Unread's notes are cached under 'unread'…
+			expect( getFilteredNoteIds( store.getState(), 'unread' ) ).toHaveLength( 5 );
+			// …and Comments' skipped fetch is now issued.
+			const commentsCall = getCalls.find( ( call ) => call.query.type === 'comment' );
+			expect( commentsCall ).toBeTruthy();
+			commentsCall.callback( null, { notes: [ makeNote( 400 ) ], last_seen_time: 0 } );
+			expect( getFilteredNoteIds( store.getState(), 'comments' ) ).toHaveLength( 1 );
 		} );
 
 		// A new note arriving via the polling/push path (getNotes) while a filter is
 		// active should refresh the filtered id list so the view picks it up live.
 		it( 'refreshes the unread list when new notes arrive via the polling path', () => {
-			client.setFilter( { unread: 1 } );
+			client.setFilter( 'unread' );
 			getCalls[ 0 ].callback( null, { notes: [ makeNote( 900 ) ], last_seen_time: 0 } );
-			expect( getFilteredNoteIds( store.getState() ) ).toEqual( [ 900 ] );
+			expect( getFilteredNoteIds( store.getState(), UNREAD_KEY ) ).toEqual( [ 900 ] );
 
 			// The polling/push path fetches the unfiltered list (no `unread` param).
 			getCalls.length = 0;
@@ -518,7 +556,7 @@ describe( 'RestClient', () => {
 				last_seen_time: 0,
 			} );
 
-			expect( getFilteredNoteIds( store.getState() ) ).toEqual( [ 900, 901 ] );
+			expect( getFilteredNoteIds( store.getState(), UNREAD_KEY ) ).toEqual( [ 900, 901 ] );
 		} );
 
 		// Polling's getNotesList() prunes against the unfiltered window. While a
@@ -547,7 +585,7 @@ describe( 'RestClient', () => {
 		// The filtered refresh/poll must keep a small fixed window too, instead of
 		// growing to cover everything paged into the Unread tab.
 		it( 'keeps the filtered poll window fixed after paging unread notes in', () => {
-			client.setFilter( { unread: 1 } );
+			client.setFilter( 'unread' );
 			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } ); // 209..200
 			getCalls.length = 0;
 			client.loadMore();
@@ -564,12 +602,12 @@ describe( 'RestClient', () => {
 		} );
 
 		it( 'keeps older paged-in unread notes on a head-only refresh', () => {
-			client.setFilter( { unread: 1 } );
+			client.setFilter( 'unread' );
 			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } ); // 209..200
 			getCalls.length = 0;
 			client.loadMore();
 			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 199 ), last_seen_time: 0 } ); // 199..190
-			expect( getFilteredNoteIds( store.getState() ) ).toHaveLength( 20 );
+			expect( getFilteredNoteIds( store.getState(), UNREAD_KEY ) ).toHaveLength( 20 );
 			getCalls.length = 0;
 
 			// The refresh returns only the head window (209..200); the older paged-in
@@ -577,7 +615,7 @@ describe( 'RestClient', () => {
 			client.getFilteredNotes();
 			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } );
 
-			const unread = getFilteredNoteIds( store.getState() );
+			const unread = getFilteredNoteIds( store.getState(), UNREAD_KEY );
 			expect( unread ).toHaveLength( 20 );
 			expect( unread ).toContain( 209 ); // head kept
 			expect( unread ).toContain( 190 ); // older paged-in id kept
@@ -608,7 +646,7 @@ describe( 'RestClient', () => {
 
 		// The filtered (Unread) tab gets the same load-more indicator as the others.
 		it( 'flips loading on while paging older unread notes', () => {
-			client.setFilter( { unread: 1 } );
+			client.setFilter( 'unread' );
 			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } );
 			getCalls.length = 0;
 			expect( getIsLoading( store.getState() ) ).toBe( false );
@@ -624,14 +662,14 @@ describe( 'RestClient', () => {
 		// the list render an empty frame between "loaded" and the ids ("small
 		// loading → empty → list"). Loading must clear only once the ids are set.
 		it( 'sets the unread ids before clearing the loading state', () => {
-			client.setFilter( { unread: 1 } );
+			client.setFilter( 'unread' );
 			expect( getIsLoading( store.getState() ) ).toBe( true );
 
 			const frames = [];
 			const unsubscribe = store.subscribe( () =>
 				frames.push( {
 					isLoading: getIsLoading( store.getState() ),
-					unreadCount: getFilteredNoteIds( store.getState() ).length,
+					unreadCount: ( getFilteredNoteIds( store.getState(), UNREAD_KEY ) ?? [] ).length,
 				} )
 			);
 			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 50 ), last_seen_time: 0 } );
@@ -640,7 +678,7 @@ describe( 'RestClient', () => {
 			// No frame may show "done loading" over a still-empty list.
 			expect( frames.some( ( f ) => ! f.isLoading && f.unreadCount === 0 ) ).toBe( false );
 			expect( getIsLoading( store.getState() ) ).toBe( false );
-			expect( getFilteredNoteIds( store.getState() ) ).toHaveLength( 10 );
+			expect( getFilteredNoteIds( store.getState(), UNREAD_KEY ) ).toHaveLength( 10 );
 		} );
 
 		// Regression: the always-running unfiltered poll shares the global loading
@@ -653,8 +691,8 @@ describe( 'RestClient', () => {
 			store.dispatch( actions.notes.addNotes( fullPage( 10, 100 ) ) );
 			client.noteList = fullPage( 10, 100 ).map( ( { id, note_hash } ) => ( { id, note_hash } ) );
 
-			client.setFilter( { unread: 1 } ); // filtered fetch A in flight
-			expect( getFilteredLoading( store.getState() ) ).toEqual( { unread: 1 } );
+			client.setFilter( 'unread' ); // filtered fetch A in flight
+			expect( getFilteredLoading( store.getState() ) ).toBe( 'unread' );
 			getCalls.length = 0;
 
 			client.getNotes(); // background poll B
@@ -662,7 +700,7 @@ describe( 'RestClient', () => {
 
 			// B cleared the shared flag, but A is still in flight — the filter holds.
 			expect( getIsLoading( store.getState() ) ).toBe( false );
-			expect( getFilteredLoading( store.getState() ) ).toEqual( { unread: 1 } );
+			expect( getFilteredLoading( store.getState() ) ).toBe( 'unread' );
 			expect( client.gettingFilteredNotes ).toBe( true );
 		} );
 	} );

--- a/apps/notifications/src/panel/state/notes/actions.js
+++ b/apps/notifications/src/panel/state/notes/actions.js
@@ -11,10 +11,11 @@ export const removeNotes = ( noteIds, isComment = false ) => ( {
 	isComment,
 } );
 
-// Replace the active filtered view's id list. This only sets the list; note
-// content lives in `allNotes` and is unaffected.
-export const setFilteredNoteIds = ( noteIds ) => ( {
+// Replace one filtered view's id list, keyed by filter. This only sets the list;
+// note content lives in `allNotes` and is unaffected.
+export const setFilteredNoteIds = ( filterKey, noteIds ) => ( {
 	type: types.SET_FILTERED_NOTE_IDS,
+	filterKey,
 	noteIds,
 } );
 

--- a/apps/notifications/src/panel/state/notes/reducer.js
+++ b/apps/notifications/src/panel/state/notes/reducer.js
@@ -61,12 +61,12 @@ export const noteLikes = ( state = {}, { type, noteId, isLiked } ) => {
 	return state;
 };
 
-// Ordered id list backing the active server-filtered view (Unread, Comments,
-// Subscribers, Likes). Holds the server's answer for which notes belong to the
-// current filter; the notes themselves live in `allNotes`.
-export const filteredNoteIds = ( state = [], { type, noteIds } ) => {
+// Ordered id lists for the filtered tabs, keyed by tab name so each keeps its own
+// last result. Absent key = never fetched (show the loader); present (even []) =
+// loaded. The notes themselves live in `allNotes`.
+export const filteredNoteIds = ( state = {}, { type, filterKey, noteIds } ) => {
 	if ( types.SET_FILTERED_NOTE_IDS === type ) {
-		return noteIds;
+		return { ...state, [ filterKey ]: noteIds };
 	}
 
 	return state;

--- a/apps/notifications/src/panel/state/selectors/get-filtered-loading.js
+++ b/apps/notifications/src/panel/state/selectors/get-filtered-loading.js
@@ -1,6 +1,6 @@
 import getUi from './get-ui';
 
-// The filter fragment whose fetch is currently loading (e.g. `{ unread: 1 }`),
+// The name of the tab whose filtered fetch is currently loading (e.g. `'unread'`),
 // or null. See the `filteredLoading` reducer.
 export const getFilteredLoading = ( uiState ) => uiState.filteredLoading;
 

--- a/apps/notifications/src/panel/state/selectors/get-filtered-note-ids.js
+++ b/apps/notifications/src/panel/state/selectors/get-filtered-note-ids.js
@@ -1,5 +1,7 @@
 import getNotes from './get-notes';
 
-export const getFilteredNoteIds = ( notesState ) => notesState.filteredNoteIds;
+// The cached id list for `filterKey`, or undefined if that tab was never fetched.
+export const getFilteredNoteIds = ( notesState, filterKey ) =>
+	notesState.filteredNoteIds[ filterKey ];
 
-export default ( state ) => getFilteredNoteIds( getNotes( state ) );
+export default ( state, filterKey ) => getFilteredNoteIds( getNotes( state ), filterKey );

--- a/apps/notifications/src/panel/state/ui/reducer.js
+++ b/apps/notifications/src/panel/state/ui/reducer.js
@@ -21,8 +21,8 @@ export const isLoading = ( state = true, { type } ) => {
 	return state;
 };
 
-// The filter fragment whose fetch is currently loading (e.g. `{ unread: 1 }`), or
-// null. Only load actions tagged with a `filter` touch it, so the unfiltered
+// The name of the tab whose filtered fetch is currently loading (e.g. `'unread'`),
+// or null. Only load actions tagged with a `filter` touch it, so the unfiltered
 // background poll can't clear it mid-fetch (which would flash a filtered tab's
 // empty message). Reset on SET_FILTER so a tab switch starts clean.
 export const filteredLoading = ( state = null, { type, filter } ) => {


### PR DESCRIPTION
Follow-up to #113085.

## Proposed Changes

Cache each filtered notifications tab's server id list **per tab** instead of in a single shared slot, so switching tabs keeps the last result instead of reloading from scratch.

* The `filteredNoteIds` reducer state goes from one array to a map keyed by **tab name**. `setFilter` now takes the tab name (deriving the query internally), so the key is just the name — no query serialization.
* A tab renders its own cached list immediately on revisit and refreshes it silently in the background; the full-panel spinner shows only on a tab's **first-ever** fetch.
* Pagination exhaustion (`filteredHasMore`) is keyed per tab to match.
* Loading state is scoped to the active tab (`filteredLoading` stores the loading tab's name), so another tab's fetch or the background poll can't show a loader over a cached tab's notes.

Keying per tab also makes cross-tab contamination impossible by construction, which supersedes (and removes) the render-time guard added in #113085 for the stale-flash fix.

Three fixes were needed for load-more to keep working across a tab switch:

1. **A response is applied to the tab it was fetched for**, keyed by that tab — so a load-more that lands after switching away and back is stored and shown, not dropped. (Removes the old generation-based discard, which was only needed for the single shared slot.)
2. **`hasMoreNotes` takes the rendered tab**, so the note list's optimistic pagination total is correct on the first render after a switch. The client's own `filterName` lags a render behind the switch and would otherwise answer for the previous tab and stall DataViews' infinite scroll.
3. **The fill effect depends on the cached id list by reference**, so a same-length background refresh (which releases the client's in-flight lock) re-runs it and retries a `loadMore` the lock had blocked. Without this, switching back to a short cached tab stranded it at the first page with no scrollbar to load more manually.

### Readability refactor

The `all` tab stays fetched through the base note stream (it's the authoritative, pruning stream the filters layer on top of), so the All-vs-filtered split can't be unified away. But the render-side branching for it was spread across `NoteList` in four places. This pulls it into a single `tab` view-model:

* One `useMemo` now derives everything that depends on the active tab — the rendered `notes`, `tab.isLoading`, and `tab.hasInitiallyLoaded` — so the `filterName === 'all'` split lives in one spot instead of being re-derived at each use. Deriving the filter from `filterName` inside the memo (rather than the render-fresh filter object) also makes it memoize properly.
* Renamed for clarity now that they're namespaced under `tab`: `isThisTabLoading` → `tab.isLoading`, `firstLoadSettled` → `tab.hasInitiallyLoaded`, with the latching ref as `hasInitiallyLoadedRef`.
* Corrected the `Client` type to match the implementation: `filteredHasMore` is a per-tab map (`Record<string, boolean>`), and `getFilteredNotes` takes an optional `before`.

No behavior change; the same 66 tests pass.

## Why are these changes being made?

With the shared slot, every tab switch cleared the list and refetched, so each visit flashed a loader even when returning to a tab just viewed. Keying the cache by tab gives a stale-while-revalidate experience: instant previous data, silent refresh — and, with the fixes above, load-more continues to work after switching tabs mid-load.

## Testing Instructions

* Open the notifications panel and load a few tabs (Unread, Comments, Likes) so each has content, scrolling to page in more.
* Switch back and forth between tabs. Expect the previously-loaded notes to appear **immediately** with no loader; the list refreshes in place.
* Visit a tab for the first time in a session — expect the full-panel spinner until its first fetch lands.
* On a tab with more than one page: start loading more, switch to another tab and back — the remaining notes must still load (not stall at the first page).
* Confirm a note read/trashed in-app drops out of the relevant tab without a full reload, and reads/deletes from elsewhere reconcile on the next refresh.
* `yarn test-apps apps/notifications` passes (66 tests).

### A note on test coverage

Most of the behavior is covered by unit and real-client integration tests, including a test that a load-more response landing after a switch is stored and shown (verified to fail on the pre-fix code). One fix — the fill effect's reference dependency — has no regression test: jsdom's DataViews fires its scroll callback on mount, which masks the stall, so the test passed with and without the fix. It was verified manually instead.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

