### PR TITLE
A4A: Route Boost purchase for WoA sites to the in-A4A checkout instead of WP Admin

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
@@ -25,7 +25,7 @@ export default function BoostLicenseInfoModal( { onClose, site, upgradeOnly }: P
 
 	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( [ site ], isLargeScreen );
 
-	const { blog_id: siteId, url: siteUrl, is_atomic, url_with_scheme } = site;
+	const { blog_id: siteId, url: siteUrl } = site;
 
 	const { installBoost, status } = useInstallBoost( siteId, siteUrl );
 
@@ -66,13 +66,7 @@ export default function BoostLicenseInfoModal( { onClose, site, upgradeOnly }: P
 			onClose={ onClose }
 			siteId={ siteId }
 			onCtaClick={ handlePurchaseBoost }
-			isCTAExternalLink={ is_atomic }
-			ctaHref={
-				is_atomic
-					? `${ url_with_scheme }/wp-admin/admin.php?page=jetpack#/dashboard`
-					: productPurchaseLink
-			}
-			showPaymentPlan={ ! is_atomic }
+			ctaHref={ productPurchaseLink }
 			extraAsideContent={
 				<>
 					{ ! upgradeOnly && (


### PR DESCRIPTION
In the A4A Boost product modal, the "Purchase Boost License" CTA branched on `site.is_atomic`. Non-Atomic (self-hosted Jetpack) sites went to the internal A4A `/marketplace/checkout`; WoA/Atomic sites instead got an external-link CTA that opened the site's `wp-admin`, and the price panel was hidden for them. That branch was added deliberately in 2024 (#85923 / #85935) because A4A could not issue a Boost license for an Atomic site.

The problem is that the `wp-admin` destination is a dead end for this purpose: an agency can't actually complete a Boost purchase there, and with the price panel hidden the modal offers no path to buy. So for WoA/Atomic sites, Boost is effectively unpurchasable through Automattic for Agencies — the same product a `*.jurassic.ninja` site can buy in two clicks.

This change drops the `is_atomic` special-casing for that CTA so WoA/Atomic sites take the same branch as non-Atomic sites: the CTA links to the internal `/marketplace/checkout` (no external-link icon), and the price panel shows. Because the CTA is no longer the "external" variant, it also regains its click handler — `LicenseLightbox` passed `onClick={ undefined }` only for external links, which had silently disabled the `issue_license_info` / `boost_info_modal_purchase_click` Tracks events for Atomic sites; those fire again.

Verified in a browser on a real WoA site (`*.wpcomstaging.com`): the CTA now navigates in-app to the A4A checkout, which renders Boost at US$9.95/mo with an enabled Purchase button, instead of bouncing to `wp-admin`. Before/after screenshots are in the worktree deliverables.

**Draft — do not merge yet.** This has been verified to *load and price* the checkout for a WoA site, but **not** that fulfillment actually *issues* the Boost license for an Atomic site. The 2024 redirect existed because that issuance wasn't supported (`Automattic/jetpack-manage#205`). If that constraint still holds, this moves the dead end from `wp-admin` into checkout rather than removing it. Kept as a draft pending confirmation (product/eng) that A4A Boost fulfillment issues for Atomic sites — see `Automattic/jetpack-manage#205`. The wpcom fulfillment layer already threads a site target through the Billing Dragon cart extra for Pressable (`a4a_pressable_site_domain` in `wp-content/admin-plugins/wpcom-billing/products/a4a-products.php`), so extending it for this case is plausible but unconfirmed.

Out of scope (unchanged): the separate Boost *score* button (`site-boost-column/index.tsx:47`) still routes Atomic sites to `wp-admin`; that is a different CTA.

Fixes [A4A-3107](https://linear.app/a8c/issue/A4A-3107).

## Testing Instructions

Prerequisites: A4A dev environment (`yarn start-a8c-for-agencies`) signed in to an agency that has a WoA/Atomic site (WordPress-logo avatar; `*.wpcomstaging.com`).

1. Open the Sites dashboard, find the WoA site, and open the **Boost** modal.
2. Confirm the "Purchase Boost License" button has **no** external-link icon and the **price panel is shown** (US$9.95/mo).
3. Click it. Confirm it navigates **in-app** to `/marketplace/checkout?product_slug=jetpack-boost…` (not to `wp-admin`), and the checkout renders Boost with an enabled Purchase button.
4. Repeat on a non-Atomic site (`*.jurassic.ninja`) and confirm its behavior is unchanged.
