### PR TITLE
E2E: skip Jetpack site-feature specs outside Jetpack builds

### DIFF
--- a/test/e2e/lib/pw-base.ts
+++ b/test/e2e/lib/pw-base.ts
@@ -788,12 +788,12 @@ export function skipIfNotTrunk(): void {
  * @example
  * ```typescript
  * test.describe( 'My Test Suite', () => {
- *   skipIfNotJetpackTarget();
+ *   skipIfNotJetpackDeployment();
  *   test( 'my test', async () => { ... });
  * });
  * ```
  */
-export function skipIfNotJetpackTarget(): void {
+export function skipIfNotJetpackDeployment(): void {
 	test.skip(
 		envVariables.JETPACK_TARGET !== 'wpcom-deployment',
 		'Skipping: requires a test site with Jetpack features (JETPACK_TARGET=wpcom-deployment)'

--- a/test/e2e/lib/pw-base.ts
+++ b/test/e2e/lib/pw-base.ts
@@ -777,6 +777,30 @@ export function skipIfNotTrunk(): void {
 }
 
 /**
+ * Skips the current test suite when the run does not target a Jetpack deployment site.
+ *
+ * `wpcom-deployment` is the only value any build type sets, and only it resolves an
+ * account owning a site with the Jetpack site features (Instant Search, Subscriptions)
+ * some specs need. Every other run resolves an account whose site has none of them —
+ * the Calypso PR matrix reaches these specs whenever a shared E2E file change drops
+ * its `--grep` and runs the whole suite.
+ *
+ * @example
+ * ```typescript
+ * test.describe( 'My Test Suite', () => {
+ *   skipIfNotJetpackTarget();
+ *   test( 'my test', async () => { ... });
+ * });
+ * ```
+ */
+export function skipIfNotJetpackTarget(): void {
+	test.skip(
+		envVariables.JETPACK_TARGET !== 'wpcom-deployment',
+		'Skipping: requires a test site with Jetpack features (JETPACK_TARGET=wpcom-deployment)'
+	);
+}
+
+/**
  * Deletes an ephemeral test site. Retries transient failures and never throws:
  * it runs from fixture teardown, which Playwright executes even when the test
  * fails or times out, so a cleanup hiccup must not redden a passing test. On

--- a/test/e2e/specs/search/search__jetpack-instant.spec.ts
+++ b/test/e2e/specs/search/search__jetpack-instant.spec.ts
@@ -13,14 +13,14 @@ import {
 	envVariables,
 	getTestAccountByFeature,
 } from '@automattic/calypso-e2e';
-import { expect, skipIfNotJetpackTarget, tags, test } from '../../lib/pw-base';
+import { expect, skipIfNotJetpackDeployment, tags, test } from '../../lib/pw-base';
 
 test.describe(
 	DataHelper.createSuiteTitle( 'Jetpack Instant Search' ),
 	{ tag: [ tags.JETPACK_WPCOM_INTEGRATION ] },
 	() => {
 		// Instant Search only loads on a site with the Jetpack Search product.
-		skipIfNotJetpackTarget();
+		skipIfNotJetpackDeployment();
 
 		test( 'As a user, I can use Jetpack Instant Search', async ( { page } ) => {
 			test.skip(

--- a/test/e2e/specs/search/search__jetpack-instant.spec.ts
+++ b/test/e2e/specs/search/search__jetpack-instant.spec.ts
@@ -13,20 +13,23 @@ import {
 	envVariables,
 	getTestAccountByFeature,
 } from '@automattic/calypso-e2e';
-import { expect, tags, test } from '../../lib/pw-base';
+import { expect, skipIfNotJetpackTarget, tags, test } from '../../lib/pw-base';
 
 test.describe(
 	DataHelper.createSuiteTitle( 'Jetpack Instant Search' ),
 	{ tag: [ tags.JETPACK_WPCOM_INTEGRATION ] },
 	() => {
-		const features = envToFeatureKey( envVariables );
-		const accountName = getTestAccountByFeature( features );
+		// Instant Search only loads on a site with the Jetpack Search product.
+		skipIfNotJetpackTarget();
 
 		test( 'As a user, I can use Jetpack Instant Search', async ( { page } ) => {
 			test.skip(
 				envVariables.ATOMIC_VARIATION === 'private',
 				'Search not available on private sites'
 			);
+
+			// Must resolve inside the test: a throw at describe scope aborts collection for the entire run.
+			const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
 
 			const searchString = DataHelper.getRandomPhrase();
 			const postWithSearchBlockTitle = `Search Block ${ DataHelper.getTimestamp() }-${ DataHelper.getRandomInteger(

--- a/test/e2e/specs/users/newsletter__subscribe-remove.spec.ts
+++ b/test/e2e/specs/users/newsletter__subscribe-remove.spec.ts
@@ -18,7 +18,7 @@ import {
 	envVariables,
 	getTestAccountByFeature,
 } from '@automattic/calypso-e2e';
-import { expect, skipIfNotJetpackTarget, tags, test } from '../../lib/pw-base';
+import { expect, skipIfNotJetpackDeployment, tags, test } from '../../lib/pw-base';
 
 test.describe(
 	DataHelper.createSuiteTitle( 'Newsletter: Subscribe and Remove' ),
@@ -26,7 +26,7 @@ test.describe(
 	() => {
 		// Subscription confirmation emails only go out from a site with Jetpack
 		// Subscriptions; the default account's site does not have them.
-		skipIfNotJetpackTarget();
+		skipIfNotJetpackDeployment();
 
 		const inboxID = SecretsManager.secrets.mailosaur.manualTesting;
 		const postTitle = DataHelper.getDateString( 'ISO-8601' ) as string;

--- a/test/e2e/specs/users/newsletter__subscribe-remove.spec.ts
+++ b/test/e2e/specs/users/newsletter__subscribe-remove.spec.ts
@@ -18,27 +18,28 @@ import {
 	envVariables,
 	getTestAccountByFeature,
 } from '@automattic/calypso-e2e';
-import { expect, tags, test } from '../../lib/pw-base';
+import { expect, skipIfNotJetpackTarget, tags, test } from '../../lib/pw-base';
 
 test.describe(
 	DataHelper.createSuiteTitle( 'Newsletter: Subscribe and Remove' ),
 	{ tag: [ tags.JETPACK_WPCOM_INTEGRATION ] },
 	() => {
+		// Subscription confirmation emails only go out from a site with Jetpack
+		// Subscriptions; the default account's site does not have them.
+		skipIfNotJetpackTarget();
+
 		const inboxID = SecretsManager.secrets.mailosaur.manualTesting;
 		const postTitle = DataHelper.getDateString( 'ISO-8601' ) as string;
 		const emailClient = new EmailClient();
 		const testEmail = emailClient.getTestEmailAddress( inboxID );
 
-		const features = envToFeatureKey( envVariables );
-		const accountName = getTestAccountByFeature( features );
-		const testAccount = new TestAccount( accountName );
-
+		let testAccount: TestAccount;
 		let newPostDetails: PostResponse;
 		let restAPIClient: RestAPIClient;
 
 		test.afterAll( async () => {
 			try {
-				if ( restAPIClient && newPostDetails ) {
+				if ( testAccount && restAPIClient && newPostDetails ) {
 					await restAPIClient.deleteSubscriber(
 						testAccount.credentials.testSites?.primary.id as number,
 						testEmail
@@ -63,6 +64,8 @@ test.describe(
 			);
 
 			await test.step( 'Setup: create post with Subscribe block via API', async () => {
+				// Must resolve inside the test: a throw at describe scope aborts collection for the entire run.
+				testAccount = new TestAccount( getTestAccountByFeature( envToFeatureKey( envVariables ) ) );
 				restAPIClient = new RestAPIClient( testAccount.credentials );
 				newPostDetails = await restAPIClient.createPost(
 					testAccount.credentials.testSites?.primary.id as number,


### PR DESCRIPTION
Fixes [TESTOPS-250](https://linear.app/a8c/issue/TESTOPS-250)

## Proposed Changes

* Add `skipIfNotJetpackDeployment()` to `test/e2e/lib/pw-base.ts`, following the pattern of the `skipIfMailosaurLimitReached()` and `skipIfNotTrunk()` helpers. It skips the suite unless `JETPACK_TARGET` is `wpcom-deployment`. Named for that value, not the variable: `remote-site` is also a Jetpack target but is skipped too.
* Gate `search__jetpack-instant.spec.ts` and `newsletter__subscribe-remove.spec.ts` on it.
* Resolve the test account inside the test body in both specs, instead of at describe scope.

## Why are these changes being made?

Both specs need a site that owns Jetpack Search and Jetpack Subscriptions. Only the seven Jetpack build configurations set `JETPACK_TARGET=wpcom-deployment`, and only that value makes `envToFeatureKey()` resolve an account whose site has those features. Everywhere else the key resolves the default account, and both specs fail: no `jp-search` payload, no subscription confirmation email.

The Calypso PR matrix reaches them because `IGNORE_TEST_GROUP_FOR_E2E_CHANGES=true` makes `bin/e2e-grep-flag.sh` drop `--grep` and run the whole suite whenever a shared E2E file changes. The same script also unions the group with the paths of changed specs, so editing either spec selects it in a PR run regardless of its tag. Confirmed by looking at failing builds from PRs that would cause the test group to be cleared.

Scoped to two specs on purpose. Twenty-four specs carry `@jetpack-wpcom-integration`, but eighteen also carry `@calypso-pr`, `@gutenberg`, or `@calypso-release` and are meant to run outside Jetpack builds. That leaves four other Jetpack-only specs: `forms__submissions`, `social-connections__tumblr`, `help-center__wp-admin`, `jetpack__dashboard-smoke`. They pass against the default account in the same full-suite runs, so gating them would drop working coverage.

Resolving the account inside the test body is the pattern from #113089: `getTestAccountByFeature()` throws on a criteria miss, and at describe scope that aborts collection for the entire run rather than failing one test. Tracked more broadly in [TESTOPS-249](https://linear.app/a8c/issue/TESTOPS-249). Note that `test.skip()` at describe scope registers a conditional skip but does not stop the describe body, so the skip alone would not have protected these two.

## Testing Instructions

Build the E2E package first: `yarn workspace @automattic/calypso-e2e build`.

Skipped in the Calypso PR environment:

```
cd test/e2e
yarn playwright test --project=chrome --reporter=list \
  specs/search/search__jetpack-instant.spec.ts \
  specs/users/newsletter__subscribe-remove.spec.ts
```

Expected: both tests reported as skipped, no network traffic, under a second.

Not skipped in the Jetpack environment. `--list` alone cannot show this, since it prints collected tests without their skip state, so count the skip annotations instead. The describe body runs during collection, so the annotation is already registered and nothing has to execute:

```
cd test/e2e
for t in "" "wpcom-deployment"; do
  n=$(JETPACK_TARGET="$t" yarn playwright test --project=chrome --list --reporter=json \
    specs/search/search__jetpack-instant.spec.ts \
    specs/users/newsletter__subscribe-remove.spec.ts 2>/dev/null \
    | grep -o '"type": *"skip"' | wc -l | tr -d ' ')
  echo "JETPACK_TARGET='${t}' -> skip annotations: $n"
done
```

Expected: `2` with no target set, `0` with `wpcom-deployment`. Running the specs for real under `wpcom-deployment` writes to the shared Jetpack staging site, so leave that to the `Jetpack Simple Deployment E2E Tests` builds.

Also run: `yarn tsc --noEmit -p test/e2e/tsconfig.json`.

Verified on this branch. `Jetpack Simple Deployment E2E Tests (desktop)` build #6424 passed 23 tests with 5 ignored, and both gated specs ran there instead of skipping. The Calypso PR matrix counted the same two among its 73 ignored tests and stayed green.

## Notes

An alternative approach is to override the criteria table so these specs always resolve the Jetpack staging account. That keeps them running in PR builds, but points the PR matrix at the site the hourly Jetpack deployment gate uses. Skipping restores the pre-migration behaviour instead and is a more conservative measure.

A broader alternative is to exclude `@jetpack-wpcom-integration` on the cleared-group path in `bin/e2e-grep-flag.sh`. That needs no new env plumbing, since the script only runs in the PR matrix, the one build setting `IGNORE_TEST_GROUP_FOR_E2E_CHANGES=true`. But the exclusion is tag-based and cannot tell a Jetpack-only spec from a dual-tagged one. Adding `--grep-invert=@jetpack-wpcom-integration` takes the `@calypso-pr` group from 40 tests to 26, dropping far more than the two specs at issue.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
