### PR TITLE
Agents Manager: keep docked chat behind wp-admin modals

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/fixes-jetpack.scss
+++ b/packages/agents-manager/src/components/agent-dock/fixes-jetpack.scss
@@ -1,4 +1,4 @@
-body.wp-admin.agents-manager-sidebar-container--sidebar-open:not( .modal-open ) {
+body.wp-admin.agents-manager-sidebar-container--sidebar-open {
 	&:is(
 			[class*='jetpack_page_'],
 			[class*='plugins_page_wpcom-'],

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -97,7 +97,7 @@ body.wp-admin.agents-manager-sidebar-container--closing {
 	}
 }
 
-body.wp-admin.agents-manager-sidebar-container--sidebar-open:not( .modal-open ) {
+body.wp-admin.agents-manager-sidebar-container--sidebar-open {
 	@include wp-admin-sidebar-open-specific( $admin-menu-width-classic );
 	@include notice-panel-open( '#wpnt-notes-panel2' );
 
@@ -432,7 +432,7 @@ body.post-new-php.agents-manager-sidebar-container {
 }
 
 // Base layout for the docked chat sidebar
-@include docked-chat-without-modal {
+@include docked-chat {
 	visibility: hidden;
 	position: fixed;
 	top: 0;
@@ -462,6 +462,11 @@ body.post-new-php.agents-manager-sidebar-container {
 			height: 32px;
 		}
 	}
+}
+
+body.wp-admin.modal-open .agents-manager-chat--docked {
+	pointer-events: none;
+	z-index: $agents-manager-z-index-below-modal !important;
 }
 
 /* Agenttic UI: Styles for both docked and undocked chat */
@@ -656,7 +661,7 @@ body.post-new-php.agents-manager-sidebar-container {
 }
 
 /* Agenttic UI: Styles for the docked chat */
-@include docked-chat-without-modal {
+@include docked-chat {
 	.agenttic {
 		.Message-module_message {
 			.big-sky__dock__menu__variation-picker {

--- a/packages/agents-manager/src/components/conversation-history-view/style.scss
+++ b/packages/agents-manager/src/components/conversation-history-view/style.scss
@@ -80,7 +80,7 @@
 }
 
 // Docked chat dark-mode overrides
-@include docked-chat-without-modal {
+@include docked-chat {
 	.agents-manager-conversation-history-view {
 		&__content {
 			padding-top: 0;

--- a/packages/agents-manager/src/components/selected-block/style.scss
+++ b/packages/agents-manager/src/components/selected-block/style.scss
@@ -55,7 +55,7 @@
 }
 
 // Docked chat overrides
-@include docked-chat-without-modal {
+@include docked-chat {
 	.agents-manager-selected-block {
 		margin-top: 8px;
 	}

--- a/packages/agents-manager/src/components/support-guides/style.scss
+++ b/packages/agents-manager/src/components/support-guides/style.scss
@@ -91,7 +91,7 @@
 }
 
 // Docked chat overrides
-@include docked-chat-without-modal {
+@include docked-chat {
 	.agent-manager-support-guides-wrapper {
 		padding-left: 0;
 		padding-right: 0;

--- a/packages/agents-manager/src/styles/mixins.scss
+++ b/packages/agents-manager/src/styles/mixins.scss
@@ -1,6 +1,5 @@
-// Apply styles to `.agents-manager-chat--docked` only when no modal is open.
-@mixin docked-chat-without-modal {
-	body:not( .modal-open.wp-admin ) .agents-manager-chat--docked {
+@mixin docked-chat {
+	.agents-manager-chat--docked {
 		@content;
 	}
 }

--- a/packages/agents-manager/src/styles/variables.scss
+++ b/packages/agents-manager/src/styles/variables.scss
@@ -17,6 +17,8 @@ $overlay-panel-z-index-focused: 999995;
 $agents-manager-z-index-docked: $overlay-panel-z-index-base;
 $agents-manager-z-index-focused: $overlay-panel-z-index-focused;
 $agents-manager-z-index-sidebar: $overlay-panel-z-index-base - 1;
+// Core wp-admin modal backdrops start above this layer.
+$agents-manager-z-index-below-modal: 100000;
 
 /* WP Admin */
 $admin-menu-width-unified: 272px;


### PR DESCRIPTION
Part of WOOAI-822

## Proposed Changes

* Keep the docked Agents Manager sidebar mounted when a wp-admin modal adds `modal-open`.
* Place the dock below the modal backdrop and disable its pointer events while the modal is open.
* Leave the undocked pop-out layer unchanged above the backdrop.

## Why are these changes being made?

* The shared dock layout excluded every `modal-open` wp-admin page. WordPress plugin details use that generic class, so opening the modal moved a docked chat into document flow below the page and made it look like the sidebar had disappeared.
* This behavior belongs in the shared Agents Manager frontend rather than in a Woo-specific mutation observer. Keeping the dock mounted preserves the user's selected mode while the modal backdrop safely makes it temporarily inaccessible.

Related pull requests:

* Woo integration: https://github.com/woocommerce/woocommerce-ai/pull/376
* Plugin-information iframe exclusion: https://github.com/Automattic/jetpack/pull/50921

## Testing Instructions

### Calypso

1. Run `yarn start`.
2. Open an Agents Manager surface in Calypso.
3. Move the chat between docked and pop-out modes and confirm both layouts continue to work.

### Sandbox

1. Run `cd apps/agents-manager && yarn dev --sync`.
2. On a site with Agents Manager enabled, open `/wp-admin/plugins.php` at a viewport wide enough for sidebar mode.
3. Move the chat to the sidebar, open an installed plugin's **View details** modal, and verify:
   * the dock remains visibly mounted at the right beneath the backdrop;
   * the dock cannot be interacted with while the modal is open;
   * closing the modal restores access without changing the selected mode.
4. Move the chat to pop-out mode and open **View details** again.
5. Verify the existing pop-out remains visible and interactive above the backdrop.
6. Run Stylelint for the changed Agents Manager styles.

## Proofs

Captured on the same self-hosted wp-admin page at 1809×1220.

### Docked mode: disappearing → still mounted beneath the backdrop

| Before | After |
|---|---|
| ![Before: the plugin details modal is open and the docked chat is absent from the viewport](https://gist.githubusercontent.com/aaronfc/0192f9886b230c90138a357ef42c0d38/raw/464d8d5f6ca66ee06cc8baaab09224a6d405064a/sidebar-modal-before.png) | ![After: the plugin details modal is open and the dimmed docked chat remains visible beneath the backdrop at the right](https://gist.githubusercontent.com/aaronfc/0192f9886b230c90138a357ef42c0d38/raw/464d8d5f6ca66ee06cc8baaab09224a6d405064a/sidebar-modal-after.png) |

Before this change, `modal-open` removed the fixed dock layout: the chat was `position: static` below the visible page. After this change, the dock remains `position: fixed` at `x=1459`, `350px` wide and the full `1220px` viewport height. It is non-interactive at `z-index: 100000`, beneath the Thickbox backdrop at `z-index: 100050`.

### Pop-out mode: existing above-backdrop behavior is preserved

| Before | After |
|---|---|
| ![Before: the existing pop-out chat remains visible above the plugin details backdrop](https://gist.githubusercontent.com/aaronfc/0192f9886b230c90138a357ef42c0d38/raw/464d8d5f6ca66ee06cc8baaab09224a6d405064a/popout-modal-before.png) | ![After: the existing pop-out chat remains visible above the plugin details backdrop](https://gist.githubusercontent.com/aaronfc/0192f9886b230c90138a357ef42c0d38/raw/464d8d5f6ca66ee06cc8baaab09224a6d405064a/popout-modal-after.png) |

The undocked chat remains fixed and interactive at `z-index: 999990`; this change only lowers and disables the docked variant while a modal is open.

Automated verification:

* Stylelint passed for all changed Agents Manager SCSS files.
* The Agents Manager app bundle compiled successfully; only the existing Sass deprecation warnings were reported.
* `yarn typecheck-packages` was run and failed on untouched `agent-chat/index.tsx` prop mismatches for `complianceDisclosure`, `disabled`, and `imageUploadDisabled`; this PR's diff contains only SCSS.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
