### PR TITLE
E2E: fall back to default URLs when the env var is an empty string

### DIFF
--- a/packages/calypso-e2e/src/env-variables.ts
+++ b/packages/calypso-e2e/src/env-variables.ts
@@ -287,8 +287,7 @@ class EnvVariables implements SupportedEnvVariables {
 			const envVarName = property as keyof SupportedEnvVariables;
 			// Access each property
 			// Any validation errors within the getter will throw an exception here.
-			// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-			this[ envVarName ];
+			void this[ envVarName ];
 		}
 	}
 }

--- a/packages/calypso-e2e/src/env-variables.ts
+++ b/packages/calypso-e2e/src/env-variables.ts
@@ -1,4 +1,4 @@
-/* eslint-disable require-jsdoc */
+/* eslint-disable jsdoc/require-jsdoc */
 import crypto from 'crypto';
 import path from 'path';
 import { getMag16Locales, getViewports } from './data-helper';
@@ -205,12 +205,12 @@ class EnvVariables implements SupportedEnvVariables {
 	private getValidatedUrlEnvVar( envVarName: keyof SupportedEnvVariables ): string {
 		const value = process.env[ envVarName as string ];
 		const defaultValue = this._defaultEnvVariables[ envVarName ];
-		const url = value ?? defaultValue;
+		const url = value || defaultValue;
 
 		try {
 			// eslint-disable-next-line no-new
 			new URL( url as string );
-		} catch ( error ) {
+		} catch {
 			throw new Error( `Invalid ${ envVarName } value: ${ url }.\nYou must provide a valid URL.` );
 		}
 		return url as string;
@@ -287,6 +287,7 @@ class EnvVariables implements SupportedEnvVariables {
 			const envVarName = property as keyof SupportedEnvVariables;
 			// Access each property
 			// Any validation errors within the getter will throw an exception here.
+			// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 			this[ envVarName ];
 		}
 	}

--- a/packages/calypso-e2e/src/test/env-variables.test.ts
+++ b/packages/calypso-e2e/src/test/env-variables.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test, afterEach } from '@jest/globals';
+import envVariables from '../env-variables';
+
+const URL_ENV_VARS = [
+	'A8C_FOR_AGENCIES_URL',
+	'CALYPSO_BASE_URL',
+	'DASHBOARD_BASE_URL',
+	'PARTNER_DIRECTORY_BASE_URL',
+	'WOO_BASE_URL',
+	'WPCOM_BASE_URL',
+] as const;
+
+describe( 'EnvVariables Tests', function () {
+	afterEach( function () {
+		URL_ENV_VARS.forEach( ( name ) => delete process.env[ name ] );
+	} );
+
+	// CI templates export these unconditionally, so an unset variable arrives as an
+	// empty string rather than undefined. Falling through to the default keeps a
+	// build that never opted into an override from crashing at spec collection.
+	describe( 'Test: URL environment variables fall back to defaults when empty', function () {
+		test.each( URL_ENV_VARS )( '%s falls back when set to an empty string', function ( name ) {
+			const unset = envVariables[ name ];
+
+			process.env[ name ] = '';
+
+			expect( envVariables[ name ] ).toBe( unset );
+		} );
+	} );
+
+	describe( 'Test: URL environment variables honour overrides', function () {
+		test.each( URL_ENV_VARS )( '%s uses the provided value', function ( name ) {
+			process.env[ name ] = 'https://example.com/';
+
+			expect( envVariables[ name ] ).toBe( 'https://example.com/' );
+		} );
+
+		test.each( URL_ENV_VARS )( '%s rejects a malformed value', function ( name ) {
+			process.env[ name ] = 'not-a-url';
+
+			expect( () => envVariables[ name ] ).toThrow( `Invalid ${ name } value` );
+		} );
+	} );
+} );

--- a/packages/calypso-e2e/src/test/env-variables.test.ts
+++ b/packages/calypso-e2e/src/test/env-variables.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, afterEach } from '@jest/globals';
+import { afterAll, beforeEach, describe, expect, test } from '@jest/globals';
 import envVariables from '../env-variables';
 
 const URL_ENV_VARS = [
@@ -10,9 +10,25 @@ const URL_ENV_VARS = [
 	'WPCOM_BASE_URL',
 ] as const;
 
+const AMBIENT_VALUES = URL_ENV_VARS.map( ( name ) => process.env[ name ] );
+
 describe( 'EnvVariables Tests', function () {
-	afterEach( function () {
+	// Each case starts from the unset state so the assertions never depend on the
+	// shell that launched Jest, or on the order the cases run in.
+	beforeEach( function () {
 		URL_ENV_VARS.forEach( ( name ) => delete process.env[ name ] );
+	} );
+
+	// Jest workers are reused across test files, so hand the environment back.
+	afterAll( function () {
+		URL_ENV_VARS.forEach( ( name, index ) => {
+			const ambient = AMBIENT_VALUES[ index ];
+			if ( ambient === undefined ) {
+				delete process.env[ name ];
+			} else {
+				process.env[ name ] = ambient;
+			}
+		} );
 	} );
 
 	// CI templates export these unconditionally, so an unset variable arrives as an


### PR DESCRIPTION
Part of [TESTOPS-148](https://linear.app/a8c/issue/TESTOPS-148)

Slack thread: p1785404995081239-slack-C020H2DD6MD

## Proposed Changes

* `EnvVariables.getValidatedUrlEnvVar` now falls back to its default with `||` instead of `??`, so a URL environment variable exported as an empty string is treated as unset rather than as an invalid URL. Affects `A8C_FOR_AGENCIES_URL`, `CALYPSO_BASE_URL`, `DASHBOARD_BASE_URL`, `PARTNER_DIRECTORY_BASE_URL`, `WOO_BASE_URL` and `WPCOM_BASE_URL`.
* Adds `packages/calypso-e2e/src/test/env-variables.test.ts` covering the empty-string fallback, explicit overrides and malformed values for all six getters.
* Clears the pre-existing lint errors in `env-variables.ts` so the file passes the branch style check: the file-level `eslint-disable` still named `require-jsdoc` after the rule was renamed to `jsdoc/require-jsdoc`, an unused `catch` binding, and the deliberate property access in `validate()`.

## Why are these changes being made?

All ten scheduled `Gutenberg {simple,atomic} E2E tests {production,edge,nightly} ({desktop,mobile})` builds have been reporting zero tests since #112865. They fail the "number of passed tests dropped" condition, which reads as a test regression but is not one: Playwright throws during collection, so no test ever starts.

The chain:

1. `CalypsoE2ETestsBuildTemplate` declares `text("DASHBOARD_BASE_URL", "")` and its "Run e2e tests" step runs `export DASHBOARD_BASE_URL="%DASHBOARD_BASE_URL%"` unconditionally. A build that does not override the parameter exports an empty string, not an unset variable.
2. `getValidatedUrlEnvVar` used `value ?? defaultValue`, and `??` only falls back on `null`/`undefined`. The empty string skipped the default and `new URL( '' )` threw.
3. `specs/authentication/authentication__dashboard-two-step.spec.ts` calls `DataHelper.getDashboardURL()` in a top-level `test.skip()` inside the `describe` body, which runs at collection time.
4. `playwright.config.ts` sets `testDir: './specs'` for the whole config, so the `chrome` and `pixel` projects load `specs/authentication/` too. `--grep` filters after collection and does not prevent the module from being evaluated.

#112865 re-templated `gutenbergPlaywrightBuildType()` from `E2EBuildType` onto `CalypsoE2ETestsBuildTemplate`. The previous form never exported `DASHBOARD_BASE_URL`; the template does, which is what exposed the fallback bug.

An earlier fix set `DASHBOARD_BASE_URL` explicitly on three build configurations (I18N, P2, `GutenbergPlaywrightTests`), which is why `Gutenberg E2E Tests` is unaffected while the ten matrix builds are not. Adding the parameter to `gutenbergPlaywrightBuildType()` would unblock those ten too, but it leaves the same trap for the next configuration that inherits the template. Fixing the fallback handles every current and future caller in one place, and matches both the template's own semantics (its "Determine Dashboard URL" step already treats empty as "not needed, skipping") and the other getters in `env-variables.ts`, which use falsy checks.

## Testing Instructions

* `yarn jest --config packages/calypso-e2e/jest.config.js` — 16 suites, 146 tests pass.
* To confirm the new test covers the regression, change `||` back to `??` in `getValidatedUrlEnvVar` and re-run: the six empty-string cases fail with `Invalid <VAR> value: .`, the same error seen in CI.
* To reproduce the original failure end to end: `cd test/e2e && DASHBOARD_BASE_URL="" CALYPSO_BASE_URL="https://wordpress.com" yarn test:pw:desktop --grep=@gutenberg --list`. Before this change it throws during collection and lists nothing; after, it lists the Gutenberg specs.
* CI verification: `Gutenberg atomic E2E tests edge (desktop)` build number 2405 (build id [18721840](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_gutenberg_atomic_edge_desktop/18721840)) ran against this branch. Collection now succeeds: `Running 28 tests using 1 worker`, finishing `24 passed, 4 skipped` in 11.4m with no failures. On trunk the same configuration collects nothing and dies ~4s into the "Run e2e tests" step.
* Note that build 2405 is still marked failed, for an unrelated and pre-existing reason: the "number of passed tests" condition compares against 240 from build number 2402, which ran on 792d838845c, i.e. before #112865 migrated these specs from Jest to Playwright. 28 is the correct post-migration population; 28 spec files carry `tags.GUTENBERG` and the run reported `28 suites, 28 tests`. That stale anchor is out of scope here and needs its own decision, since the anchor is taken from the latest successful build and no post-migration build can become that "latest successful" while the condition keeps failing them.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?