### PR TITLE
A4A Sites: Open the internal Scan pane from the threat popover

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/hooks/use-get-site-errors.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/hooks/use-get-site-errors.tsx
@@ -1,6 +1,8 @@
 import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
+import { urlToSlug } from 'calypso/lib/url/http-utils';
+import { JETPACK_SCAN_ID } from '../../features/features';
 import { SiteData, SiteError } from '../../types';
 
 export default function useGetSiteErrors() {
@@ -14,15 +16,23 @@ export default function useGetSiteErrors() {
 			}
 
 			if ( data?.scan?.status === 'failed' ) {
+				const scanLink = `/sites/overview/${ urlToSlug(
+					data.site?.value?.url
+				) }/${ JETPACK_SCAN_ID }`;
+
 				errors.push( {
 					severity: 'medium',
-					message: translate( '%(count)s threat found', '%(count)s threats found', {
-						count: data.scan.threats,
-						args: {
-							count: data.scan.threats,
-						},
-						comment: '%(count) here is the number of threats found',
-					} ),
+					message: (
+						<a href={ scanLink } onClick={ ( event ) => event.stopPropagation() }>
+							{ translate( '%(count)s threat found', '%(count)s threats found', {
+								count: data.scan.threats,
+								args: {
+									count: data.scan.threats,
+								},
+								comment: '%(count) here is the number of threats found',
+							} ) }
+						</a>
+					),
 				} );
 			}
 


### PR DESCRIPTION
In the Automattic for Agencies Sites dashboard, a site row with a security threat shows a "N threat found" orange popover next to the site name. Clicking it opened the **Backup** tab instead of **Scan**, sending the agency to the wrong place when responding to a threat.

The popover is rendered through a React portal but stays a **React-tree child** of the indicator inside the site-name `<Button>`. React routes portal events through the React tree, so a click on the popover text reached the enclosing button, which selects the site with no feature — and the preview pane falls back to its default tab (Backup).

This change wraps the "N threat(s) found" message in an anchor that opens the **internal Scan preview pane** (`/sites/overview/<slug>/scan`), with `stopPropagation()` so the click no longer bubbles to the site-name button. It reuses the same scan-link mechanism the row's "N Threat" Scan-column CTA already uses, and mirrors the existing external-link pattern a few lines below in the same hook.

Atomic/WoA sites open the **same internal Scan pane** as non-atomic sites (rather than the external `wordpress.com/scan` that the Scan-column CTA opens for atomic), keeping the flow inside A4A — consistent with the ongoing move of WoA flows into A4A.

One consequence worth noting: on atomic/WoA sites the popover and the Scan-column "N Threat" CTA now point to different places (popover → internal A4A Scan pane; CTA → `wordpress.com/scan` in a new tab). That's deliberate here; aligning the CTA itself would be a separate change.

No tests: this is a small navigation redirect that delegates to the existing scan-link builder — a test would mostly assert that builder's return value through layers of indirection. (This replaces the earlier, larger approach that added a `SiteError.feature` field and feature-plumbing; that has been reverted in favor of this one-file change.)

Fixes [A4A-3110](https://linear.app/a8c/issue/A4A-3110).

## Testing Instructions

Prerequisites: A4A dev environment (or this PR's calypso.live build), signed in to an agency that has a site currently reporting a threat (row shows "N threat found").

1. In the Sites list, click the **"N threat found"** text (the popover, not just the ⚠ icon).
2. Confirm the preview pane opens on **Scan** (`/sites/overview/<slug>/scan`), not Backup — for both a non-atomic (`*.jurassic.ninja`) and an atomic (`*.wpcomstaging.com`) site.
3. Click a different site's **name** (no threat). Confirm it still opens **Backup** (unchanged default).
