### PR TITLE
Help Center: route proxied users to Zendesk production

### DIFF
--- a/apps/help-center/config.js
+++ b/apps/help-center/config.js
@@ -1,11 +1,6 @@
-/* global helpCenterData */
-const isProxied = typeof helpCenterData !== 'undefined' && helpCenterData?.isProxied;
-const isCIAB = typeof helpCenterData !== 'undefined' && helpCenterData?.isCommerceGarden;
-const envValue = isProxied && ! isCIAB ? 'staging' : 'production';
-
 window.configData = {
-	env_id: envValue,
-	env: envValue,
+	env_id: 'production',
+	env: 'production',
 	features: {
 		'help/gpt-response': true,
 	},

--- a/packages/zendesk-client/src/util.tsx
+++ b/packages/zendesk-client/src/util.tsx
@@ -93,12 +93,10 @@ export const isTestModeEnvironment = () => {
 		return false;
 	}
 
-	// In the Calypso SPA context, env_id follows the config file convention and ends with
-	// 'development', 'horizon', or 'stage' (e.g. 'dashboard-stage', 'jetpack-cloud-horizon').
-	// In the widgets.wp.com bundle context, apps/help-center/config.js always declares
-	// 'production' (that bundle never runs on localhost), while apps/agents-manager/config.js
-	// still sets env_id to 'staging' for dev-mode users. Both map to test mode.
-	const testEnvironmentSuffixes = [ 'development', 'horizon', 'stage', 'staging' ];
+	// In the Calypso SPA context, only local development env_ids are test mode, e.g.
+	// 'development' or 'jetpack-cloud-development'. 'staging' is set by
+	// apps/agents-manager/config.js for dev-mode users and also maps to test mode.
+	const testEnvironmentSuffixes = [ 'development', 'staging' ];
 	const isTestEnvironment = testEnvironmentSuffixes.some(
 		( suffix ) => envId === suffix || envId?.endsWith( `-${ suffix }` )
 	);

--- a/packages/zendesk-client/src/util.tsx
+++ b/packages/zendesk-client/src/util.tsx
@@ -95,8 +95,9 @@ export const isTestModeEnvironment = () => {
 
 	// In the Calypso SPA context, env_id follows the config file convention and ends with
 	// 'development', 'horizon', or 'stage' (e.g. 'dashboard-stage', 'jetpack-cloud-horizon').
-	// In the widgets.wp.com bundle context (apps/help-center, apps/agents-manager), config.js
-	// sets env_id to 'staging' for proxied/dev users. Both map to test mode.
+	// In the widgets.wp.com bundle context, apps/help-center/config.js always declares
+	// 'production' (that bundle never runs on localhost), while apps/agents-manager/config.js
+	// still sets env_id to 'staging' for dev-mode users. Both map to test mode.
 	const testEnvironmentSuffixes = [ 'development', 'horizon', 'stage', 'staging' ];
 	const isTestEnvironment = testEnvironmentSuffixes.some(
 		( suffix ) => envId === suffix || envId?.endsWith( `-${ suffix }` )

--- a/packages/zendesk-client/test/util.test.tsx
+++ b/packages/zendesk-client/test/util.test.tsx
@@ -41,19 +41,11 @@ describe( 'isTestModeEnvironment', () => {
 		} );
 	} );
 
-	describe( 'Test environments (development, horizon, stage)', () => {
+	describe( 'Test environments (development, staging)', () => {
 		const testConfigFiles = [
-			'stage',
-			'horizon',
 			'dashboard-development',
-			'dashboard-horizon',
-			'dashboard-stage',
 			'jetpack-cloud-development',
-			'jetpack-cloud-horizon',
-			'jetpack-cloud-stage',
 			'a8c-for-agencies-development',
-			'a8c-for-agencies-horizon',
-			'a8c-for-agencies-stage',
 		];
 
 		testConfigFiles.forEach( ( configFile ) => {
@@ -77,13 +69,21 @@ describe( 'isTestModeEnvironment', () => {
 		} );
 	} );
 
-	describe( 'Production environments', () => {
+	describe( 'Production environments (including stage, horizon)', () => {
 		const productionConfigFiles = [
 			'production',
 			'wpcalypso',
 			'dashboard-production',
 			'jetpack-cloud-production',
 			'a8c-for-agencies-production',
+			'stage',
+			'horizon',
+			'dashboard-horizon',
+			'dashboard-stage',
+			'jetpack-cloud-horizon',
+			'jetpack-cloud-stage',
+			'a8c-for-agencies-horizon',
+			'a8c-for-agencies-stage',
 		];
 
 		productionConfigFiles.forEach( ( configFile ) => {
@@ -122,7 +122,21 @@ describe( 'isTestModeEnvironment', () => {
 			expect( isTestModeEnvironment() ).toBe( false );
 		} );
 
-		test( 'should automatically treat new test environment as test mode', () => {
+		test( 'should automatically treat new "-development"/"-staging" environment as test mode', () => {
+			( config as unknown as jest.Mock ).mockImplementation( ( key: string ) => {
+				if ( key === 'env_id' ) {
+					return 'new-product-staging';
+				}
+				if ( key === 'env' ) {
+					return 'production';
+				}
+				return undefined;
+			} );
+
+			expect( isTestModeEnvironment() ).toBe( true );
+		} );
+
+		test( 'should automatically treat new "-stage" environment as production', () => {
 			( config as unknown as jest.Mock ).mockImplementation( ( key: string ) => {
 				if ( key === 'env_id' ) {
 					return 'new-product-stage';
@@ -133,7 +147,7 @@ describe( 'isTestModeEnvironment', () => {
 				return undefined;
 			} );
 
-			expect( isTestModeEnvironment() ).toBe( true );
+			expect( isTestModeEnvironment() ).toBe( false );
 		} );
 
 		test( 'should default to production when config is unavailable (env undefined)', () => {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-498/proxied-users-should-now-go-to-production-when-trying-to-start-a-live

## Proposed Changes

**Proxied users who start a live chat from the Help Center are now routed to Zendesk production instead of the staging sandbox — in both the widgets bundle and the Calypso SPA.**

- `apps/help-center/config.js` now always declares a production environment, instead of switching to `staging` when `helpCenterData.isProxied` is set.
- `isTestModeEnvironment()` (`packages/zendesk-client`) now treats only local development env ids as test mode (`development`, `-development` suffixes, plus the `staging` value the agents-manager bundle sets for dev mode). The `stage`, `-stage`, and `horizon` environments — including the Calypso staging build served to proxied users — now target Zendesk production.

## Why are these changes being made?

While the Zendesk integration was being set up, chats started by proxied Automatticians were deliberately routed to the Zendesk staging sandbox so months of test chats wouldn’t flood Happiness Engineers. That integration has long been live, and the guard now does more harm than good: proxied colleagues trying to reach a human end up in a sandbox where no agent will ever answer ([DOTSUP-498](https://linear.app/a8c/issue/DOTSUP-498)).

Sandbox routing is now limited to local development. A follow-up ([DOTSUP-499](https://linear.app/a8c/issue/DOTSUP-499)) will add a prominent badge whenever a chat does land on staging.

## Testing Instructions

1. Sandbox `widgets.wp.com` (the sites themselves do not need sandboxing).
2. Run `cd apps/help-center && yarn dev --sync`.
3. While proxied, visit a Simple or Atomic site, open the Help Center, start an AI chat, and ask to talk to a human.
4. Verify the chat connects to Zendesk production: no “staging version of Zendesk” notice appears.
5. Still proxied, open the Help Center from the Calypso staging build (e.g. /home) and repeat: live chat should also target production.
6. Sanity-check local development (`yarn start`, Calypso on localhost): live chat should still target the Zendesk sandbox.
