### PR TITLE
A4A: Fix accent hover bleeding onto sidebar and dark buttons

### DIFF
--- a/client/a8c-for-agencies/components/sidebar/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/style.scss
@@ -17,7 +17,7 @@
 		margin: 0;
 	}
 
-	.sidebar-v2__navigator-sub-menu .components-navigator-back-button {
+	.sidebar-v2__navigator-sub-menu .components-navigator-back-button.components-navigator-back-button.components-navigator-back-button {
 		background: none;
 
 		&:hover {
@@ -68,7 +68,7 @@
 		margin: 0;
 	}
 
-	.components-button.sidebar__item-help {
+	.components-button.sidebar__item-help.components-button.sidebar__item-help.components-button.sidebar__item-help {
 		svg {
 			&.help-center__icon-has-new-items circle {
 				transform: translate(-1px, 3px);
@@ -76,7 +76,6 @@
 
 			fill: var(--color-sidebar-text);
 		}
-	
 		&:hover {
 			background: var(--color-sidebar-menu-hover-background);
 		}

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -92,7 +92,7 @@
 
 .theme-a8c-for-agencies {
 
-	.components-button:not( .dataviews-view-table-header-button ):not( .components-navigator-back-button ),
+	.components-button:not( .dataviews-view-table-header-button ),
 	.button {
 		display: inline-flex;
 		align-items: center;


### PR DESCRIPTION
## Proposed Changes

* Fix the sidebar navigator **back button** and **help center button** rendering with a light grey accent hover background (`--color-accent-0`) instead of the intended sidebar hover color.
* Remove the extra `:not( .components-navigator-back-button )` carve-out from the generic A4A button rule in `client/a8c-for-agencies/style.scss` so the catch-all no longer out-specifies component-level hover rules.
* Raise the specificity of the affected sidebar rules (`.components-navigator-back-button`, `.sidebar__item-help`) in `client/a8c-for-agencies/components/sidebar/style.scss` so their intended hover styles win.

## Why are these changes being made?

The generic A4A button rule (`.theme-a8c-for-agencies .components-button:not( … ):hover`) paints a light `--color-accent-0` hover background on essentially every button. Each `:not()` carve-out added to it raises its specificity, and it had crept above the sidebar and `is-dark`/`is-link` hover rules:

- Originally `.components-button:hover` → `(0,3,0)`
- Adding `:not( .dataviews-view-table-header-button )` → `(0,4,0)` — this first introduced the sidebar back-button hover regression.
- Adding `:not( .components-navigator-back-button )` → `(0,5,0)` — this fixed the back button but pushed the catch-all above other `(0,4,0)` rules (the help center button, `is-dark`, `is-link`), so those started showing the grey accent hover too.

Rather than keep adding carve-outs (which inflate the catch-all further and clobber more sibling rules), this drops the second carve-out to de-inflate the catch-all and instead gives the specific sidebar rules enough specificity to win on their own. This is the same regression originally reported for the back button, so the fix addresses the affected sibling elements together.

## Testing Instructions

1. Open the A4A dashboard.
2. Navigate into a sidebar sub-menu that shows the **Back** navigator button and hover/focus it.
3. Hover/focus the **help center** icon button in the sidebar.
4. **Before:** these show a light grey accent background on hover. **After:** they show the normal sidebar hover background, consistent with the other sidebar items.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?