### PR TITLE
A4A Sites: Keep the selected-row highlight in sync with the preview pane

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
@@ -45,7 +45,8 @@ const ItemsDataViews = ( {
 
 		if ( ! previousDataViewsState?.selectedItem && data.dataViewsState.selectedItem ) {
 			window.setTimeout(
-				() => scrollContainerRef.current?.querySelector( 'li.is-selected' )?.scrollIntoView(),
+				() =>
+					scrollContainerRef.current?.querySelector( '[role="row"].is-selected' )?.scrollIntoView(),
 				300
 			);
 			return;
@@ -69,9 +70,8 @@ const ItemsDataViews = ( {
 				getItemId={
 					data.getItemId ??
 					( ( item: any ) => {
-						// todo: this item.id assignation is to fix an issue with the DataViews component and item selection. It should be removed once the issue is fixed.
-						item.id = data.itemFieldId && getIdByPath( item, data.itemFieldId );
-						return item.id;
+						const id = data.itemFieldId && getIdByPath( item, data.itemFieldId );
+						return id === undefined ? '' : String( id );
 					} )
 				}
 				isLoading={ isLoading }

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -1,9 +1,8 @@
 import config from '@automattic/calypso-config';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { Icon, starFilled } from '@wordpress/icons';
-import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useContext, useMemo, useState, ReactNode } from 'react';
+import { useCallback, useEffect, useContext, useMemo, useRef, useState, ReactNode } from 'react';
 import { DATAVIEWS_LIST } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import {
@@ -25,6 +24,8 @@ import { useSiteActionsDataViews } from '../../site-actions/use-site-actions';
 import useGetSiteErrors from '../../sites-dataviews/hooks/use-get-site-errors';
 import { AllowedTypes, Site, SiteData } from '../../types';
 import type { Action, Field } from '@wordpress/dataviews';
+
+const EMPTY_SELECTION: string[] = [];
 
 const SitePreviewTourTarget = ( { children }: { children: ReactNode } ) => {
 	const [ context, setContext ] = useState< HTMLElement | null >();
@@ -102,6 +103,26 @@ export const JetpackSitesDataViews = ( {
 			} ) );
 		},
 		[ isNotProduction, setDataViewsState ]
+	);
+
+	const selectedSiteId = dataViewsState.selectedItem?.blog_id;
+
+	const selection = useMemo(
+		() => ( selectedSiteId ? [ String( selectedSiteId ) ] : EMPTY_SELECTION ),
+		[ selectedSiteId ]
+	);
+
+	const sitesRef = useRef( sites );
+	sitesRef.current = sites;
+
+	const onSelectionChange = useCallback(
+		( items: string[] ) => {
+			const selectedItem = sitesRef.current.find( ( site ) => String( site.ref ) === items[ 0 ] );
+			if ( selectedItem ) {
+				openSitePreviewPane( selectedItem.site.value );
+			}
+		},
+		[ openSitePreviewPane ]
 	);
 
 	const renderField = useCallback(
@@ -196,19 +217,13 @@ export const JetpackSitesDataViews = ( {
 					const isSitePreviewTourTarget = site.blog_id === sitePreviewTourTargetId;
 
 					const siteField = (
-						<div
-							className={ clsx( {
-								'is-site-selected': site.blog_id === dataViewsState.selectedItem?.blog_id,
-							} ) }
-						>
-							<SiteDataField
-								site={ site }
-								isLoading={ isLoading }
-								isDevSite={ item.isDevSite }
-								onSiteTitleClick={ openSitePreviewPane }
-								errors={ getSiteErrors( item ) }
-							/>
-						</div>
+						<SiteDataField
+							site={ site }
+							isLoading={ isLoading }
+							isDevSite={ item.isDevSite }
+							onSiteTitleClick={ openSitePreviewPane }
+							errors={ getSiteErrors( item ) }
+						/>
 					);
 
 					return isSitePreviewTourTarget ? (
@@ -413,7 +428,6 @@ export const JetpackSitesDataViews = ( {
 			pluginsRef,
 			sitePreviewTourTargetId,
 			isLoading,
-			dataViewsState.selectedItem?.blog_id,
 			openSitePreviewPane,
 			getSiteErrors,
 			renderField,
@@ -437,22 +451,16 @@ export const JetpackSitesDataViews = ( {
 		actions: [],
 		setDataViewsState: setDataViewsState,
 		dataViewsState: dataViewsState,
-		onSelectionChange: ( items: string[] ) => {
-			const selectedItem = sites.find( ( site ) => site.ref === items[ 0 ] );
-			if ( selectedItem ) {
-				openSitePreviewPane( selectedItem.site.value );
-			}
-		},
+		selection,
+		onSelectionChange,
 		defaultLayouts: { table: {}, list: {} },
 	} );
 
 	useEffect( () => {
-		// If the user clicks on a row, open the preview pane by triggering the View details button click.
+		// Only the table layout needs this; the list layout ships its own full-row button.
 		const handleRowClick = ( event: Event ) => {
 			const target = event.target as HTMLElement;
-			const row = target.closest(
-				'.dataviews-view-table__row, li:has(.dataviews-view-list__item)'
-			);
+			const row = target.closest( '.dataviews-view-table__row' );
 
 			if ( row ) {
 				const isButtonOrLink = target.closest( 'button, a' );
@@ -465,23 +473,10 @@ export const JetpackSitesDataViews = ( {
 			}
 		};
 
-		const rowsContainer = document.querySelector( '.dataviews-view-table, .dataviews-view-list' );
+		const rowsContainer = document.querySelector( '.dataviews-view-table' );
 
 		if ( rowsContainer ) {
 			rowsContainer.addEventListener( 'click', handleRowClick as EventListener );
-		}
-
-		// We need to trigger the click event on the View details button when the selected item changes to ensure highlighted row is correct.
-		if (
-			rowsContainer?.classList.contains( 'dataviews-view-list' ) &&
-			dataViewsState?.selectedItem?.client_id
-		) {
-			const trigger: HTMLButtonElement | null = rowsContainer.querySelector(
-				'li:not(.is-selected) .sites-dataviews__site'
-			);
-			if ( trigger ) {
-				trigger.click();
-			}
 		}
 
 		return () => {
@@ -512,9 +507,10 @@ export const JetpackSitesDataViews = ( {
 			},
 			setDataViewsState: setDataViewsState,
 			dataViewsState: dataViewsState,
-			selectedItem: dataViewsState.selectedItem,
+			selection,
+			onSelectionChange,
 		} ) );
-	}, [ fields, dataViewsState, setDataViewsState, data, actions ] );
+	}, [ fields, dataViewsState, setDataViewsState, data, actions, selection, onSelectionChange ] );
 
 	return (
 		<ItemsDataViews data={ itemsData } isLoading={ isLoading } className={ className }>

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/style.scss
@@ -6,23 +6,4 @@
 	.dataviews-view-table__row {
 		cursor: pointer;
 	}
-
-	.dataviews-wrapper ul.dataviews-view-list .is-selected,
-	.dataviews-wrapper ul.dataviews-view-list li:has(.is-site-selected) {
-		border-block-start: 0;
-		background-color: var(--color-neutral-0);
-	}
-
-	// To avoid, conflicting state, we cancel the is-selected styling by replacing with base color
-	.dataviews-wrapper ul.dataviews-view-list .is-selected .dataviews-view-list__item-wrapper {
-		background-color: var(--color-surface);
-	}
-
-	.dataviews-wrapper ul.dataviews-view-list li:has(.is-site-selected) .dataviews-view-list__item-wrapper {
-		background-color: color-mix(in srgb, var(--wp-admin-theme-color) 4%, transparent);
-	}
-
-	.dataviews-view-list li.is-selected.is-selected + li {
-		border-block-start: 0;
-	}
 }


### PR DESCRIPTION
In the Automattic for Agencies Sites dashboard split view, the selected-row highlight and the detail pane are driven by two separate mechanisms. The detail pane is derived from the route — `dataViewsState.selectedItem`, re-matched to the URL. The row highlight relied on DataViews' internal `selection`, but A4A never actually fed it: the sites packet set a `selectedItem` key that DataViews doesn't read, so DataViews' selection stayed **uncontrolled** and only advanced when its own row button handled a click. A separate `.is-site-selected` CSS highlight existed but was scoped to `ul.dataviews-view-list li` markup the list no longer renders (it's now `div[role="row"]`), so it never matched.

The result: clicking between sites switches the pane, but the highlight often doesn't follow — nothing is highlighted, or a stale row stays lit. It's intermittent, and worst on deep links, back/forward, the first click, and after any search / pagination / filter / refetch (DataViews filters its selection against the current page of data).

This change makes the highlight controlled and driven by the same source as the pane:

- Pass a controlled `selection` to DataViews derived from `dataViewsState.selectedItem`, set in the update effect (instead of the packet's unread `selectedItem` key).
- Move `onSelectionChange` out of the `useState` initializer — it was closing over the first render's (empty) sites.
- Make `getItemId` return a string; it returned the numeric `blog_id`, but DataViews' item-id contract is string.
- Delete the dead `ul`/`li`-scoped `.is-site-selected` CSS.

Fixes [A4A-3111](https://linear.app/a8c/issue/A4A-3111).

## Testing Instructions

Prerequisites: A4A dev environment or this PR's calypso.live build, signed in to an agency with several sites.

1. Open the **Sites** dashboard (split view). Click between several sites.
2. Confirm the highlighted row **always matches** the site shown in the detail pane.
3. Test the intermittent cases: open a site via a **deep link**, use **back/forward**, and **search / paginate** the list — confirm the highlight stays in sync with the pane in each.
4. Glance at the highlight color and confirm it reads correctly against the design.
