### PR TITLE
A4A Marketplace: Auto-assign the purchased license to the site it was bought for

### DIFF
--- a/client/a8c-for-agencies/data/purchases/use-fetch-licenses.ts
+++ b/client/a8c-for-agencies/data/purchases/use-fetch-licenses.ts
@@ -10,6 +10,8 @@ import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import formatLicenses from './lib/format-licenses';
 
+export const FETCH_LICENSES_QUERY_KEY_PREFIX = 'a4a-licenses';
+
 export const getFetchLicensesQueryKey = (
 	filter: LicenseFilter,
 	search: string,
@@ -19,7 +21,16 @@ export const getFetchLicensesQueryKey = (
 	perPage: number,
 	agencyId?: number
 ) => {
-	return [ 'a4a-licenses', filter, search, sortField, sortDirection, page, perPage, agencyId ];
+	return [
+		FETCH_LICENSES_QUERY_KEY_PREFIX,
+		filter,
+		search,
+		sortField,
+		sortDirection,
+		page,
+		perPage,
+		agencyId,
+	];
 };
 
 export default function useFetchLicenses(
@@ -28,7 +39,8 @@ export default function useFetchLicenses(
 	sortField: LicenseSortField,
 	sortDirection: LicenseSortDirection,
 	page: number,
-	perPage: number = LICENSES_PER_PAGE
+	perPage: number = LICENSES_PER_PAGE,
+	enabled: boolean = true
 ) {
 	const agencyId = useSelector( getActiveAgencyId );
 
@@ -66,7 +78,7 @@ export default function useFetchLicenses(
 				totalPages: data.total_pages,
 			};
 		},
-		enabled: !! agencyId,
+		enabled: enabled && !! agencyId,
 		refetchOnWindowFocus: false,
 	} );
 }

--- a/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
@@ -38,6 +38,7 @@ import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { DEFAULT_SORT_DIRECTION, DEFAULT_SORT_FIELD } from '../../sites/constants';
 import { Site } from '../../sites/types';
 import AssignLicenseStepProgress from '../assign-license-step-progress';
+import { isFromSitesDashboard } from '../lib/assign-license-url';
 import getAssignLicenseSuccessMessage from '../lib/get-assign-license-success-message';
 import useAssignLicensesToSite from '../products-overview/hooks/use-assign-licenses-to-site';
 import { SITE_CARDS_PER_PAGE } from './constants';
@@ -47,9 +48,10 @@ import './styles.scss';
 type Props = {
 	initialPage: number;
 	initialSearch: string;
+	preselectedSiteId?: number;
 };
 
-export default function AssignLicense( { initialPage, initialSearch }: Props ) {
+export default function AssignLicense( { initialPage, initialSearch, preselectedSiteId }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -136,6 +138,18 @@ export default function AssignLicense( { initialPage, initialSearch }: Props ) {
 
 		setTotalSites( data?.total );
 	}, [ data, isError, isLoading ] );
+
+	useEffect( () => {
+		if ( ! preselectedSiteId || selectedSite.ID ) {
+			return;
+		}
+
+		const site = data?.sites?.find( ( s: Site ) => s.blog_id === preselectedSiteId );
+
+		if ( site ) {
+			setSelectedSite( { ID: site.blog_id, domain: site.url_with_scheme } );
+		}
+	}, [ data?.sites, preselectedSiteId, selectedSite.ID ] );
 
 	useEffect( () => {
 		const urlSearch = getQueryArg( window.location.search, 'search' );
@@ -233,7 +247,7 @@ export default function AssignLicense( { initialPage, initialSearch }: Props ) {
 			);
 		}
 
-		const fromDashboard = getQueryArg( window.location.href, 'source' ) === 'dashboard';
+		const fromDashboard = isFromSitesDashboard( window.location.href );
 		const redirectUrl = fromDashboard ? A4A_SITES_LINK : A4A_LICENSES_LINK;
 		return isFeedbackShown
 			? page.redirect( redirectUrl )

--- a/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
@@ -2,11 +2,15 @@ import page from '@automattic/calypso-router';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { createRequestCartProduct, useShoppingCart } from '@automattic/shopping-cart';
+import { getQueryArg } from '@wordpress/url';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
-import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_LICENSES_LINK,
+	A4A_MARKETPLACE_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import CheckoutMain from 'calypso/my-sites/checkout/src/components/checkout-main';
@@ -17,6 +21,7 @@ import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
 import getSite from 'calypso/state/sites/selectors/get-site';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import { getAutoAssignLicenseUrl } from '../lib/assign-license-url';
 import ClientCheckoutError from './checkout-error';
 import ClientCheckoutPlaceholder from './checkout-placeholder';
 import type { ShoppingCartItem } from '../types';
@@ -214,6 +219,14 @@ function BillingDragonCheckoutContent( {
 		}
 	}, [ isReady, error, replaceProductsInCart, responseCart, agency, cartItems, isPlanCheckout ] );
 
+	const assignToSiteId = Number( getQueryArg( window.location.href, 'site_id' ) ) || undefined;
+
+	const redirectTo =
+		window.location.origin +
+		( assignToSiteId && cartItems.length === 1
+			? getAutoAssignLicenseUrl( assignToSiteId, cartItems[ 0 ].slug )
+			: A4A_LICENSES_LINK );
+
 	// Debugging: Set a timeout to force showing the checkout after 2 seconds
 	// Todo: This was reduced from 10 seconds to 2 seconds to check if it works well. Better UX.
 	useEffect( () => {
@@ -248,7 +261,7 @@ function BillingDragonCheckoutContent( {
 			) }
 			<CheckoutMain
 				sitelessCheckoutType="a4a"
-				redirectTo={ window.location.origin + '/purchases/licenses' }
+				redirectTo={ redirectTo }
 				customizedPreviousPath="/marketplace"
 				siteSlug={ siteSlug ?? '' }
 				siteId={ siteId ?? 0 }

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -163,14 +163,19 @@ export const checkoutContext: Callback = ( context, next ) => {
 	next();
 };
 export const assignLicenseContext: Callback = ( context, next ) => {
-	const { page, search } = context.query;
+	const { page, search, site_id } = context.query;
 	const initialPage = parseInt( page ) || 1;
+	const siteId = parseInt( site_id );
 
 	context.secondary = <MarketplaceSidebar path={ context.path } />;
 	context.primary = (
 		<>
 			<PageViewTracker title="Marketplace > Assign License" path={ context.path } />
-			<AssignLicense initialPage={ initialPage } initialSearch={ search || '' } />
+			<AssignLicense
+				initialPage={ initialPage }
+				initialSearch={ search || '' }
+				preselectedSiteId={ siteId > 0 ? siteId : undefined }
+			/>
 		</>
 	);
 	next();

--- a/client/a8c-for-agencies/sections/marketplace/lib/assign-license-url.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/assign-license-url.ts
@@ -1,0 +1,29 @@
+import { getQueryArg } from '@wordpress/url';
+import {
+	A4A_LICENSES_LINK,
+	A4A_MARKETPLACE_ASSIGN_LICENSE_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { addQueryArgs } from 'calypso/lib/url';
+
+// A4A spells this `sitesdashboard`; the Jetpack Cloud partner portal uses `dashboard` for the
+// same idea on its own routes. Mixing them up silently disables the return-to-sites redirect.
+const SITES_DASHBOARD_SOURCE = 'sitesdashboard';
+
+// Built by hand rather than with addQueryArgs because `:receiptId` has to reach the post-checkout
+// pending page as a literal for it to interpolate, and URLSearchParams would escape the colon.
+export function getAutoAssignLicenseUrl( siteId: number, productSlug: string ) {
+	return `${ A4A_LICENSES_LINK }?site_id=${ siteId }&product_slug=${ encodeURIComponent(
+		productSlug
+	) }&receipt_id=:receiptId`;
+}
+
+export function getManualAssignLicenseUrl( licenseKey: string, siteId: number ) {
+	return addQueryArgs(
+		{ key: licenseKey, site_id: siteId, source: SITES_DASHBOARD_SOURCE },
+		A4A_MARKETPLACE_ASSIGN_LICENSE_LINK
+	);
+}
+
+export function isFromSitesDashboard( url: string ) {
+	return getQueryArg( url, 'source' ) === SITES_DASHBOARD_SOURCE;
+}

--- a/client/a8c-for-agencies/sections/marketplace/lib/test/assign-license-url.test.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/test/assign-license-url.test.ts
@@ -1,0 +1,41 @@
+import {
+	getAutoAssignLicenseUrl,
+	getManualAssignLicenseUrl,
+	isFromSitesDashboard,
+} from '../assign-license-url';
+
+describe( 'getAutoAssignLicenseUrl', () => {
+	it( 'leaves `:receiptId` unescaped so the pending page can interpolate it', () => {
+		expect( getAutoAssignLicenseUrl( 123, 'jetpack-boost' ) ).toBe(
+			'/purchases/licenses?site_id=123&product_slug=jetpack-boost&receipt_id=:receiptId'
+		);
+	} );
+} );
+
+describe( 'getManualAssignLicenseUrl', () => {
+	it( 'carries the license key the manual page pre-fills', () => {
+		expect( getManualAssignLicenseUrl( 'jetpack-boost_abc', 123 ) ).toBe(
+			'/marketplace/assign-license?key=jetpack-boost_abc&site_id=123&source=sitesdashboard'
+		);
+	} );
+
+	// The manual page reads this back to decide between /sites and /purchases/licenses. It used to
+	// compare against the partner portal's `dashboard`, which this URL never matches.
+	it( 'emits a source the manual page recognises', () => {
+		expect( isFromSitesDashboard( getManualAssignLicenseUrl( 'jetpack-boost_abc', 123 ) ) ).toBe(
+			true
+		);
+	} );
+} );
+
+describe( 'isFromSitesDashboard', () => {
+	it( 'rejects a URL with no source', () => {
+		expect( isFromSitesDashboard( '/marketplace/assign-license?key=jetpack-boost_abc' ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'rejects the partner portal spelling', () => {
+		expect( isFromSitesDashboard( '/marketplace/assign-license?source=dashboard' ) ).toBe( false );
+	} );
+} );

--- a/client/a8c-for-agencies/sections/purchases/licenses/hooks/test/use-auto-assign-license.test.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/hooks/test/use-auto-assign-license.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import page from '@automattic/calypso-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import wpcom from 'calypso/lib/wp';
+import useAutoAssignLicense from '../use-auto-assign-license';
+import type { ReactNode } from 'react';
+
+jest.mock( '@automattic/calypso-router', () => ( {
+	__esModule: true,
+	default: { redirect: jest.fn(), replace: jest.fn() },
+} ) );
+
+jest.mock( 'calypso/state', () => ( {
+	useSelector: jest.fn( () => 42 ),
+	useDispatch: () => jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	__esModule: true,
+	default: {
+		req: {
+			get: jest.fn(),
+			post: jest.fn(),
+		},
+	},
+} ) );
+
+const mockedGet = wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get >;
+const mockedPost = wpcom.req.post as jest.MockedFunction< typeof wpcom.req.post >;
+const mockedRedirect = page.redirect as jest.MockedFunction< typeof page.redirect >;
+const mockedReplace = page.replace as jest.MockedFunction< typeof page.replace >;
+
+const SITE_ID = 123;
+
+function apiLicense( license_key: string, issued_at: string ) {
+	return { license_key, issued_at, blog_id: null, product: 'Jetpack Boost' };
+}
+
+function respondWithLicenses( items: ReturnType< typeof apiLicense >[] ) {
+	mockedGet.mockResolvedValue( {
+		items,
+		total_items: items.length,
+		items_per_page: 100,
+		total_pages: 1,
+	} );
+}
+
+function wrapper( { children }: { children: ReactNode } ) {
+	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
+}
+
+function render( search = `?site_id=${ SITE_ID }&product_slug=jetpack-boost&receipt_id=999` ) {
+	window.history.replaceState( {}, '', `/purchases/licenses${ search }` );
+	return renderHook( () => useAutoAssignLicense(), { wrapper } );
+}
+
+describe( 'useAutoAssignLicense', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'assigns the single unassigned license matching the purchased product', async () => {
+		respondWithLicenses( [
+			apiLicense( 'jetpack-boost_abc', '2026-07-30 10:00:00' ),
+			apiLicense( 'jetpack-scan_xyz', '2026-07-30 11:00:00' ),
+		] );
+		mockedPost.mockResolvedValue( {} );
+
+		render();
+
+		await waitFor( () => expect( mockedPost ).toHaveBeenCalled() );
+		expect( mockedPost ).toHaveBeenCalledWith( {
+			apiNamespace: 'wpcom/v2',
+			path: '/jetpack-licensing/license/jetpack-boost_abc/site',
+			body: { site: SITE_ID, agency_id: 42 },
+		} );
+		await waitFor( () =>
+			expect( mockedReplace ).toHaveBeenCalledWith( '/purchases/licenses', undefined, false, false )
+		);
+		expect( mockedRedirect ).not.toHaveBeenCalled();
+	} );
+
+	it( 'routes to the manual assign flow pre-filled with the site when several licenses match', async () => {
+		respondWithLicenses( [
+			apiLicense( 'jetpack-boost_older', '2026-07-29 10:00:00' ),
+			apiLicense( 'jetpack-boost_newer', '2026-07-30 10:00:00' ),
+		] );
+
+		render();
+
+		await waitFor( () =>
+			expect( mockedRedirect ).toHaveBeenCalledWith(
+				'/marketplace/assign-license?key=jetpack-boost_newer&site_id=123&source=sitesdashboard'
+			)
+		);
+		expect( mockedPost ).not.toHaveBeenCalled();
+	} );
+
+	it( 'stays on the licenses list when no license matches the purchased product', async () => {
+		respondWithLicenses( [ apiLicense( 'jetpack-scan_xyz', '2026-07-30 10:00:00' ) ] );
+
+		render();
+
+		await waitFor( () => expect( mockedReplace ).toHaveBeenCalled() );
+		expect( mockedRedirect ).not.toHaveBeenCalled();
+		expect( mockedPost ).not.toHaveBeenCalled();
+	} );
+
+	it( 'routes to the manual assign flow when the assignment request fails', async () => {
+		respondWithLicenses( [ apiLicense( 'jetpack-boost_abc', '2026-07-30 10:00:00' ) ] );
+		mockedPost.mockRejectedValue( new Error( 'Nope' ) );
+
+		render();
+
+		await waitFor( () =>
+			expect( mockedRedirect ).toHaveBeenCalledWith(
+				'/marketplace/assign-license?key=jetpack-boost_abc&site_id=123&source=sitesdashboard'
+			)
+		);
+	} );
+
+	it( 'does nothing on a plain visit to the licenses list', async () => {
+		respondWithLicenses( [ apiLicense( 'jetpack-boost_abc', '2026-07-30 10:00:00' ) ] );
+
+		render( '' );
+
+		await waitFor( () => expect( mockedGet ).not.toHaveBeenCalled() );
+		expect( mockedPost ).not.toHaveBeenCalled();
+		expect( mockedRedirect ).not.toHaveBeenCalled();
+		expect( mockedReplace ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/a8c-for-agencies/sections/purchases/licenses/hooks/use-auto-assign-license.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/hooks/use-auto-assign-license.tsx
@@ -1,0 +1,147 @@
+import page from '@automattic/calypso-router';
+import { useQueryClient } from '@tanstack/react-query';
+import { getQueryArg } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useRef } from 'react';
+import { getFetchLicenseCountsQueryKey } from 'calypso/a8c-for-agencies/data/purchases/use-fetch-license-counts';
+import useFetchLicenses, {
+	FETCH_LICENSES_QUERY_KEY_PREFIX,
+} from 'calypso/a8c-for-agencies/data/purchases/use-fetch-licenses';
+import useAssignLicenseMutation from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-assign-license-mutation';
+import { getManualAssignLicenseUrl } from 'calypso/a8c-for-agencies/sections/marketplace/lib/assign-license-url';
+import { getProductSlugFromLicenseKey } from 'calypso/jetpack-cloud/sections/partner-portal/lib';
+import {
+	LicenseFilter,
+	LicenseSortDirection,
+	LicenseSortField,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import type { License } from 'calypso/state/partner-portal/types';
+
+// License keys embed at most the first 38 characters of the product slug.
+const LICENSE_KEY_SLUG_LENGTH = 38;
+
+function findUnassignedLicensesForProduct( licenses: License[], productSlug: string ) {
+	const keySlug = productSlug.substring( 0, LICENSE_KEY_SLUG_LENGTH );
+
+	return licenses
+		.filter(
+			( license ) =>
+				! license.blogId && getProductSlugFromLicenseKey( license.licenseKey ) === keySlug
+		)
+		.sort( ( a, b ) => Date.parse( b.issuedAt ) - Date.parse( a.issuedAt ) );
+}
+
+function readNumberArg( name: string ) {
+	return Number( getQueryArg( window.location.href, name ) ) || undefined;
+}
+
+/**
+ * Assigns a freshly purchased license to the site it was bought for.
+ *
+ * Checkout sends the buyer back here with the site and product it bought so the
+ * license they just paid for does not land unassigned in the list.
+ */
+export default function useAutoAssignLicense() {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const queryClient = useQueryClient();
+	const agencyId = useSelector( getActiveAgencyId );
+	const hasStarted = useRef( false );
+
+	const siteId = readNumberArg( 'site_id' );
+	const receiptId = readNumberArg( 'receipt_id' );
+	const productSlug = getQueryArg( window.location.href, 'product_slug' )?.toString();
+	const isRequested = !! siteId && !! productSlug;
+
+	const { data, isPending } = useFetchLicenses(
+		LicenseFilter.Detached,
+		'',
+		LicenseSortField.IssuedAt,
+		LicenseSortDirection.Descending,
+		1,
+		undefined,
+		isRequested
+	);
+
+	const { mutateAsync: assignLicense } = useAssignLicenseMutation();
+
+	useEffect( () => {
+		if ( ! siteId || ! productSlug || hasStarted.current || isPending ) {
+			return;
+		}
+		hasStarted.current = true;
+
+		const track = ( outcome: string, licenseKey?: string ) =>
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_marketplace_auto_assign_license', {
+					outcome,
+					site_id: siteId,
+					product_slug: productSlug,
+					receipt_id: receiptId,
+					license_key: licenseKey,
+				} )
+			);
+
+		const clearQueryArgs = () => page.replace( window.location.pathname, undefined, false, false );
+
+		const candidates = findUnassignedLicensesForProduct( data?.items ?? [], productSlug );
+
+		if ( candidates.length === 0 ) {
+			track( 'no_match' );
+			clearQueryArgs();
+			return;
+		}
+
+		// More than one unassigned license matches the product we just bought, so we
+		// cannot tell which one it is. Let the user confirm rather than guess.
+		if ( candidates.length > 1 ) {
+			track( 'ambiguous', candidates[ 0 ].licenseKey );
+			page.redirect( getManualAssignLicenseUrl( candidates[ 0 ].licenseKey, siteId ) );
+			return;
+		}
+
+		const [ license ] = candidates;
+
+		assignLicense( { licenseKey: license.licenseKey, selectedSite: siteId } )
+			.then( () => {
+				track( 'assigned', license.licenseKey );
+				queryClient.invalidateQueries( { queryKey: [ FETCH_LICENSES_QUERY_KEY_PREFIX ] } );
+				queryClient.invalidateQueries( { queryKey: getFetchLicenseCountsQueryKey( agencyId ) } );
+				dispatch(
+					successNotice(
+						translate(
+							'{{strong}}%(licenseItem)s{{/strong}} was assigned to your site. Please allow a few minutes for your features to activate.',
+							{
+								args: { licenseItem: license.product },
+								components: { strong: <strong /> },
+							}
+						),
+						{ id: 'assign_license_success' }
+					)
+				);
+				clearQueryArgs();
+			} )
+			.catch( ( error: Error ) => {
+				track( 'assign_failed', license.licenseKey );
+				dispatch(
+					errorNotice( error.message, { id: 'assign_license_error', displayOnNextPage: true } )
+				);
+				page.redirect( getManualAssignLicenseUrl( license.licenseKey, siteId ) );
+			} );
+	}, [
+		agencyId,
+		assignLicense,
+		data?.items,
+		dispatch,
+		isPending,
+		productSlug,
+		queryClient,
+		receiptId,
+		siteId,
+		translate,
+	] );
+}

--- a/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
@@ -19,6 +19,7 @@ import LayoutHeader, {
 } from 'calypso/layout/hosting-dashboard/header';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import useAutoAssignLicense from '../hooks/use-auto-assign-license';
 import LicenseList from '../license-list';
 import LicenseSearch from '../license-search';
 import LicenseStateFilter from '../license-state-filter';
@@ -44,6 +45,8 @@ export default function LicensesOverview( {
 }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	useAutoAssignLicense();
 
 	const title = translate( 'Licenses' );
 


### PR DESCRIPTION
The Sites-list "Add" buttons build a checkout URL that includes the target site's blog id (`?…&site_id=<blog_id>`) so an agency can buy a product for one specific site. Under the older (V1) checkout that id was read and the issued license was assigned to the site in one step. The Billing Dragon (V2) checkout dropped it: `checkoutContext` never read `site_id`, so after purchase the agency landed on the Licenses page with a fresh **unassigned** license and had to find the site and assign it manually.

This change carries the blog id through the BD checkout and auto-assigns the license after purchase, **entirely client-side** — it reuses the existing assign endpoint (`POST /jetpack-licensing/license/<key>/site`), so there are **no backend/PHP changes**:

1. **Read the dropped param.** `controller.tsx` `checkoutContext` reads `context.query.site_id` and threads it through the BD checkout. When a target site is present and the cart holds exactly one product, the post-purchase `redirectTo` carries the site, product slug, and receipt id back to the **Licenses list**; every other checkout keeps its existing `/purchases/licenses` redirect unchanged.
2. **Assign from the Licenses list.** The `/licenses` overview calls a new self-contained hook, `useAutoAssignLicense()`, which reads those query params itself, finds the newest detached license matching the slug, assigns it to the site, and refreshes the list. This adds **3 lines** to the overview — the licenses controller and `LicensesOverview`'s props are untouched, so there is no new controller code (and no new controller test).
3. **Ambiguity guard.** Receipts don't expose the license key client-side, so identification is "newest detached license matching the slug." If **more than one** detached license matches, it makes **no assignment** and routes to the manual assign flow with the site + product pre-selected. Zero matches → nothing to auto-assign.

This is a **reworked, simplified** version of the original approach. The earlier draft added a dedicated `AutoAssignLicense` interstitial page and an anti-loop discriminator on the assign route; both are removed. Because the trigger (`/licenses`) and the ambiguity fallback (`/marketplace/assign-license`) are now **different** routes, there is no loop to guard against — the `assign-license` controller is back to forwarding `site_id` as `preselectedSiteId` with no branching. The one cost of moving the logic into a shared spot: `useFetchLicenses` gained an `enabled` flag (a plain visit to `/licenses` fires no extra request) and exports its query-key prefix (so the list and counts refresh after the assign).

Fixes [A4A-3109](https://linear.app/a8c/issue/A4A-3109).

## Caveats for review

- **Not verified end-to-end.** A real BD purchase needs a live payment method, and exercising the auto path against a real agency would perform a live assignment on someone's site — deliberately not done. Traced statically end-to-end and covered by unit tests (the auto-assign hook's decision table).
- **Manual-fallback pre-select limit:** it only pre-fills the site if that site is on the current page of the paginated site list (the sites API has no filter-by-blog-id); otherwise the user searches for it.
- **Follow-ups (not in this PR):** two sibling "Add" entry points (the upsell product card and the Boost modal) build the same URL and would want the same treatment.

## Testing Instructions

Prerequisites: an A4A dev environment (or this PR's calypso.live build), an agency with sites and a working billing method for a real Billing Dragon purchase.

1. From the Sites list, click **"Add"** for a product on a specific site and complete the Billing Dragon checkout.
2. Confirm you're returned to the **Licenses list** with the license **already assigned** to that site — not a bare unassigned list.
3. Ambiguity case: with a pre-existing unassigned license of the same product on the account, repeat — confirm it does **not** auto-assign and instead lands on the manual assign page with the site pre-selected.
4. Confirm a normal (non-"Add") marketplace checkout still redirects to `/purchases/licenses`, and that a manual assign (license key, no `site_id`) is unchanged.
