### PR TITLE
A4A Sites: Gate Performance on site visibility and guard Performance/Details for no-access users

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx
@@ -178,7 +178,7 @@ export function OverviewPreviewPane( {
 							true,
 							selectedSiteFeature,
 							setSelectedSiteFeature,
-							<SiteDetails site={ site } />
+							showNoAccess ? <A4ARequestWPAdminAccess /> : <SiteDetails site={ site } />
 						),
 				  ]
 				: [] ),

--- a/client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx
@@ -152,9 +152,13 @@ export function OverviewPreviewPane( {
 							true,
 							selectedSiteFeature,
 							setSelectedSiteFeature,
-							<div className="a4a-site-performance">
-								<SitePerformance />
-							</div>
+							showNoAccess ? (
+								<A4ARequestWPAdminAccess />
+							) : (
+								<div className="a4a-site-performance">
+									<SitePerformance />
+								</div>
+							)
 						),
 				  ]
 				: [] ),

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -7,7 +7,6 @@ import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
 import { useEffect, useMemo, useState } from 'react';
-import { useSiteSettings } from 'calypso/blocks/plugins-scheduled-updates/hooks/use-site-settings';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import {
@@ -37,7 +36,7 @@ import { DeviceTabControls } from './components/device-tab-control';
 import { ExpiredReportNotice } from './components/expired-report-notice/expired-report-notice';
 import { usePerformanceReport } from './hooks/usePerformanceReport';
 import { useSitePerformancePageReports } from './hooks/useSitePerformancePageReports';
-import { getSupportLinkProps } from './utils';
+import { getSupportLinkProps, isPublicSite } from './utils';
 
 import './style.scss';
 
@@ -55,9 +54,7 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 	const { activeTab, setActiveTab } = useDeviceTab();
 	const site = useSelector( getSelectedSite );
 	const siteId = site?.ID;
-	const { getSiteSetting } = useSiteSettings( site?.slug );
-	const blog_public = getSiteSetting( 'blog_public' );
-	const isSitePublic = site && blog_public === 1;
+	const isSitePublic = isPublicSite( site );
 	const isSiteAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 	const isSiteFlex = useSelector( ( state ) => isWpcomFlexSite( state, siteId ) );
 

--- a/client/hosting/performance/test/utils.test.ts
+++ b/client/hosting/performance/test/utils.test.ts
@@ -1,0 +1,43 @@
+import { isPublicSite } from '../utils';
+import type { SiteDetails } from '@automattic/data-stores';
+
+const createSite = ( overrides: Partial< SiteDetails > = {} ) =>
+	( {
+		ID: 1,
+		slug: 'example.wordpress.com',
+		is_coming_soon: false,
+		is_private: false,
+		launch_status: 'launched',
+		...overrides,
+	} ) as SiteDetails;
+
+describe( 'isPublicSite', () => {
+	it( 'is public for a launched site', () => {
+		expect( isPublicSite( createSite() ) ).toBe( true );
+	} );
+
+	it( 'is public regardless of launch status', () => {
+		expect( isPublicSite( createSite( { launch_status: 'unlaunched' } ) ) ).toBe( true );
+	} );
+
+	it( 'is public when the visibility flags are absent', () => {
+		expect(
+			isPublicSite( createSite( { is_coming_soon: undefined, is_private: undefined } ) )
+		).toBe( true );
+	} );
+
+	it( 'is not public for a coming soon site', () => {
+		expect(
+			isPublicSite( createSite( { is_coming_soon: true, launch_status: 'unlaunched' } ) )
+		).toBe( false );
+	} );
+
+	it( 'is not public for a private site', () => {
+		expect( isPublicSite( createSite( { is_private: true } ) ) ).toBe( false );
+	} );
+
+	it( 'is not public without a site', () => {
+		expect( isPublicSite( undefined ) ).toBe( false );
+		expect( isPublicSite( null ) ).toBe( false );
+	} );
+} );

--- a/client/hosting/performance/utils.ts
+++ b/client/hosting/performance/utils.ts
@@ -1,4 +1,9 @@
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
+import type { SiteDetails } from '@automattic/data-stores';
+
+export function isPublicSite( site: SiteDetails | null | undefined ) {
+	return !! site && ! site.is_coming_soon && ! site.is_private;
+}
 
 export function isValidURL( url: string ) {
 	if ( 'canParse' in URL ) {


### PR DESCRIPTION
The site preview pane's **Performance** tab decides between showing performance stats and a "Launch your site to start measuring performance" empty state. It made that call by reading `blog_public` from `GET /sites/<id>/settings` and checking `=== 1` — with no loading or error state. Separately, most preview-pane tabs wrap their content in a `showNoAccess` guard (a request-access notice for users who lack access to the site), but the **Performance** and **Details** tabs did not.

Two problems fell out of that:

1. **Launched, public sites showed "Launch your site."** Because the gate had no loading/error handling, a not-yet-fetched *or failed* settings request was indistinguishable from "not public" — so the prompt showed on every mount until the request landed, and **permanently when it 403'd**. And it 403s for `a4a_manager` users: `/settings` requires `manage_options`, which they lack. So those users saw "Launch your site" permanently on launched sites. (`blog_public === 0` — public but discouraging search engines — also wrongly got the prompt, and `blog_public` went stale after an in-place launch.)
2. **No access guard on Performance/Details.** A user without access saw a broken/empty tab instead of the consistent request-access UI the sibling tabs show.

This change:

- **Gates the Performance report on site visibility instead of `blog_public`** — `!! site && ! site.is_coming_soon && ! site.is_private`, matching the newer dashboard (`client/dashboard/sites/performance/index.tsx`). Those fields are already in `SITE_REQUEST_FIELDS` and kept in sync by the sites reducer, so this drops the `/settings` fetch entirely: no 403 for `a4a_manager`, no loading hole, no post-launch staleness. The "Prepare for launch" CTA still shows for genuinely unlaunched sites.
- **Wraps the Performance and Details tabs in the same `showNoAccess` guard** the sibling tabs use, so a user without access gets the consistent request-access notice.

Fixes [A4A-3112](https://linear.app/a8c/issue/A4A-3112).

## Caveats for review

Not browser-verified: I can't impersonate an `a4a_manager` without `manage_options`, and the Details tab is behind a config flag that's off outside development/horizon. The predicate fix is covered by unit tests (public/launched → stats; coming-soon or private → prompt); the guard wraps are traced against how the sibling tabs apply the guard. One layout note: Performance previously wrapped its content in `.a4a-site-performance`, which the no-access branch now bypasses (matching the siblings) — worth a glance for padding in `features/a4a/style.scss`.

## Testing Instructions

Prerequisites: A4A dev environment (or this PR's calypso.live build) with an agency that has a launched public site and a coming-soon/private site.

1. Open a **launched, public** site's preview pane → **Performance**. Confirm it shows performance stats (or the loading state), **not** "Launch your site."
2. Open a **coming-soon or private** site → Performance. Confirm the "Launch your site / Prepare for launch" prompt still shows.
3. As an `a4a_manager` who lacks access, open Performance and Details. Confirm each shows the request-access notice rather than a broken/empty tab.
4. As an agency owner, confirm Performance and Details render unchanged.
