### PR TITLE
Help Center: prominent Zendesk staging badge and dismissible notice

### DIFF
--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -21,6 +21,7 @@ import { Container } from '../types';
 import HelpCenterContent from './help-center-content';
 import HelpCenterFooter from './help-center-footer';
 import HelpCenterHeader from './help-center-header';
+import { ZendeskStagingNotice } from './help-center-zendesk-staging-notice';
 import { PersistentRouter } from './persistent-router';
 import type { HelpCenterSelect } from '@automattic/data-stores';
 interface OptionalDraggableProps extends Partial< DraggableProps > {
@@ -170,6 +171,7 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden, curr
 			>
 				<Card className={ classNames } ref={ cardMergeRefs }>
 					<HelpCenterHeader onDismiss={ onDismiss } />
+					{ ! isMinimized && <ZendeskStagingNotice /> }
 					<HelpCenterContent currentRoute={ currentRoute } />
 					{ ! isMinimized && <HelpCenterFooter /> }
 					{ ! isMobile && (

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -29,6 +29,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useFeatureConfig, useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { HELP_CENTER_STORE } from '../stores';
 import { BackButton } from './back-button';
+import { ZendeskStagingBadge } from './help-center-zendesk-staging-badge';
 import type { Header } from '../types';
 import type { HelpCenterSelect } from '@automattic/data-stores';
 
@@ -232,8 +233,8 @@ const HelpCenterHeader = ( { onDismiss }: Header ) => {
 		}
 	);
 
-	const userAskingSupport =
-		pathname.startsWith( '/odie' ) || pathname.startsWith( '/contact-form' );
+	const isOdieRoute = pathname.startsWith( '/odie' );
+	const userAskingSupport = isOdieRoute || pathname.startsWith( '/contact-form' );
 	const isHelpCenterHome = pathname === '/';
 	// Show the back button if it's not the help center home page and:
 	// - it's a chat and the hideBackButton option is not set
@@ -253,6 +254,7 @@ const HelpCenterHeader = ( { onDismiss }: Header ) => {
 				<HStack alignment="center" justify="space-between" spacing={ 5 }>
 					<HStack justify="flex-start">
 						<HeaderText />
+						{ isOdieRoute && <ZendeskStagingBadge /> }
 					</HStack>
 					<Icon icon={ chevronUp } />
 				</HStack>
@@ -265,6 +267,7 @@ const HelpCenterHeader = ( { onDismiss }: Header ) => {
 			<Flex>
 				{ shouldShowBackButton ? <BackButton /> : null }
 				<HeaderText />
+				{ isOdieRoute && <ZendeskStagingBadge /> }
 				{ featureConfig.header.ellipsisMenu ? (
 					<EllipsisMenu />
 				) : (

--- a/packages/help-center/src/components/help-center-zendesk-staging-badge.scss
+++ b/packages/help-center/src/components/help-center-zendesk-staging-badge.scss
@@ -1,0 +1,20 @@
+@import "variables";
+
+.help-center-zendesk-staging-badge {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	margin-left: 8px;
+	padding: 1px 6px;
+	border-radius: 4px;
+	background-color: $help-center-notice-background;
+	color: $help-center-notice-color;
+	font-size: $font-body-extra-small;
+	font-weight: 500;
+	white-space: nowrap;
+
+	.components-icon {
+		flex-shrink: 0;
+		fill: currentColor;
+	}
+}

--- a/packages/help-center/src/components/help-center-zendesk-staging-badge.tsx
+++ b/packages/help-center/src/components/help-center-zendesk-staging-badge.tsx
@@ -1,0 +1,26 @@
+import { isTestModeEnvironment } from '@automattic/zendesk-client';
+import { Icon, cautionFilled as warning } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+
+import './help-center-zendesk-staging-badge.scss';
+
+export function ZendeskStagingBadge() {
+	const { __ } = useI18n();
+
+	if ( ! isTestModeEnvironment() ) {
+		return null;
+	}
+
+	return (
+		<span
+			className="help-center-zendesk-staging-badge"
+			title={ __(
+				'Zendesk staging — chats here will not reach a real support agent.',
+				__i18n_text_domain__
+			) }
+		>
+			<Icon icon={ warning } size={ 14 } />
+			{ __( 'Staging', __i18n_text_domain__ ) }
+		</span>
+	);
+}

--- a/packages/help-center/src/components/help-center-zendesk-staging-notice.scss
+++ b/packages/help-center/src/components/help-center-zendesk-staging-notice.scss
@@ -1,0 +1,29 @@
+@import "variables";
+
+.help-center-zendesk-staging-notice {
+	display: flex;
+	align-items: flex-start;
+	column-gap: 8px;
+	margin: 12px 16px;
+	padding: 8px 12px;
+	border-radius: 4px;
+	background-color: $help-center-notice-background;
+	color: $help-center-notice-color;
+	font-size: $font-body-small;
+
+	&__icon {
+		flex: 0 0 auto;
+		fill: $help-center-notice-color;
+		margin-top: 2px;
+	}
+
+	p {
+		flex: 1;
+		margin: 0;
+	}
+
+	&__dismiss {
+		flex: 0 0 auto;
+		color: $help-center-notice-color;
+	}
+}

--- a/packages/help-center/src/components/help-center-zendesk-staging-notice.tsx
+++ b/packages/help-center/src/components/help-center-zendesk-staging-notice.tsx
@@ -1,0 +1,60 @@
+import { isTestModeEnvironment } from '@automattic/zendesk-client';
+import { Button } from '@wordpress/components';
+import { Icon, cautionFilled as warning, close } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import { useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import './help-center-zendesk-staging-notice.scss';
+
+const DISMISSED_STORAGE_KEY = 'help-center-zendesk-staging-notice-dismissed';
+
+function readDismissed(): boolean {
+	try {
+		return window.localStorage.getItem( DISMISSED_STORAGE_KEY ) === 'true';
+	} catch {
+		return false;
+	}
+}
+
+function persistDismissed() {
+	try {
+		window.localStorage.setItem( DISMISSED_STORAGE_KEY, 'true' );
+	} catch {
+		// Storage may be unavailable (e.g. private browsing); dismissal just won't persist.
+	}
+}
+
+export function ZendeskStagingNotice() {
+	const { __ } = useI18n();
+	const { pathname } = useLocation();
+	const [ isDismissed, setIsDismissed ] = useState( readDismissed );
+
+	const isOdieRoute = pathname.startsWith( '/odie' );
+
+	if ( ! isOdieRoute || ! isTestModeEnvironment() || isDismissed ) {
+		return null;
+	}
+
+	return (
+		<div className="help-center-zendesk-staging-notice">
+			<Icon icon={ warning } className="help-center-zendesk-staging-notice__icon" />
+			<p>
+				<strong>{ __( 'You’re on Zendesk staging', __i18n_text_domain__ ) }</strong>{ ' ' }
+				{ __(
+					'Conversations here are for testing and will never reach a real support agent. To test the production experience, use a production environment.',
+					__i18n_text_domain__
+				) }
+			</p>
+			<Button
+				className="help-center-zendesk-staging-notice__dismiss"
+				icon={ close }
+				label={ __( 'Dismiss', __i18n_text_domain__ ) }
+				onClick={ () => {
+					persistDismissed();
+					setIsDismissed( true );
+				} }
+			/>
+		</div>
+	);
+}

--- a/packages/help-center/src/components/test/help-center-zendesk-staging-badge.tsx
+++ b/packages/help-center/src/components/test/help-center-zendesk-staging-badge.tsx
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { isTestModeEnvironment } from '@automattic/zendesk-client';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { ZendeskStagingBadge } from '../help-center-zendesk-staging-badge';
+
+jest.mock( '@automattic/zendesk-client', () => ( {
+	isTestModeEnvironment: jest.fn(),
+} ) );
+
+const mockIsTestModeEnvironment = isTestModeEnvironment as jest.Mock;
+
+describe( 'ZendeskStagingBadge', () => {
+	afterEach( () => {
+		mockIsTestModeEnvironment.mockReset();
+	} );
+
+	it( 'renders the badge when running against Zendesk staging', () => {
+		mockIsTestModeEnvironment.mockReturnValue( true );
+
+		render( <ZendeskStagingBadge /> );
+
+		expect( screen.getByText( 'Staging' ) ).toBeVisible();
+	} );
+
+	it( 'renders nothing when not running against Zendesk staging', () => {
+		mockIsTestModeEnvironment.mockReturnValue( false );
+
+		const { container } = render( <ZendeskStagingBadge /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/packages/help-center/src/components/test/help-center-zendesk-staging-notice.tsx
+++ b/packages/help-center/src/components/test/help-center-zendesk-staging-notice.tsx
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { isTestModeEnvironment } from '@automattic/zendesk-client';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { ZendeskStagingNotice } from '../help-center-zendesk-staging-notice';
+
+jest.mock( '@automattic/zendesk-client', () => ( {
+	isTestModeEnvironment: jest.fn(),
+} ) );
+
+const mockIsTestModeEnvironment = isTestModeEnvironment as jest.Mock;
+
+const DISMISSED_STORAGE_KEY = 'help-center-zendesk-staging-notice-dismissed';
+
+function renderNotice( pathname = '/odie' ) {
+	return render(
+		<MemoryRouter initialEntries={ [ { pathname } ] }>
+			<ZendeskStagingNotice />
+		</MemoryRouter>
+	);
+}
+
+describe( 'ZendeskStagingNotice', () => {
+	afterEach( () => {
+		mockIsTestModeEnvironment.mockReset();
+		window.localStorage.clear();
+	} );
+
+	it( 'renders when in an Odie chat against Zendesk staging', () => {
+		mockIsTestModeEnvironment.mockReturnValue( true );
+
+		renderNotice();
+
+		expect( screen.getByText( 'You’re on Zendesk staging' ) ).toBeVisible();
+	} );
+
+	it( 'renders nothing outside the Odie chat', () => {
+		mockIsTestModeEnvironment.mockReturnValue( true );
+
+		const { container } = renderNotice( '/' );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders nothing when not running against Zendesk staging', () => {
+		mockIsTestModeEnvironment.mockReturnValue( false );
+
+		const { container } = renderNotice();
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders nothing when previously dismissed', () => {
+		mockIsTestModeEnvironment.mockReturnValue( true );
+		window.localStorage.setItem( DISMISSED_STORAGE_KEY, 'true' );
+
+		const { container } = renderNotice();
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'persists dismissal across sessions when dismissed', async () => {
+		mockIsTestModeEnvironment.mockReturnValue( true );
+		const user = userEvent.setup();
+
+		renderNotice();
+
+		await user.click( screen.getByLabelText( 'Dismiss' ) );
+
+		expect( screen.queryByText( 'You’re on Zendesk staging' ) ).not.toBeInTheDocument();
+		expect( window.localStorage.getItem( DISMISSED_STORAGE_KEY ) ).toBe( 'true' );
+	} );
+} );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-499/add-a-more-prominent-infobadge-about-zendesk-staging-starting-from

## Proposed Changes

**The Help Center now clearly labels Zendesk-staging sessions from the moment an AI chat opens: a persistent “Staging” pill in the header plus a dismissible notice right below it.**

- New `ZendeskStagingBadge`: small warning-yellow pill next to the header title on Odie routes, with a tooltip explaining chats won’t reach a real agent.
- New `ZendeskStagingNotice`: dismissible banner under the header (non-scrolling slot) — “You’re on Zendesk staging. Conversations here are for testing and will never reach a real support agent.” Dismissal persists via `localStorage`.
- Both render only when `isTestModeEnvironment()` is true — the same gate that decides the actual Zendesk routing — so production users see no change at all, and the label can never disagree with where the chat really goes.

<img width="465" height="454" alt="image" src="https://github.com/user-attachments/assets/025a0a7d-7487-4f23-97d4-bf1ffc3caaaa" />

## Why are these changes being made?

When the Help Center targets the Zendesk staging sandbox (test environments), the only hint used to be a chat message after escalating to a human, plus a subtle “(staging)” title suffix. People testing support flows kept being surprised that no agent ever answered ([DOTSUP-499](https://linear.app/a8c/issue/DOTSUP-499)). Now the staging state is visible up front, before any message is sent. Companion to [DOTSUP-498](https://linear.app/a8c/issue/DOTSUP-498), which limits staging routing to development environments.

## Testing Instructions

1. Run `yarn start` (localhost is a test-mode environment).
2. Open the Help Center and start an AI chat: the “Staging” pill appears next to the header title and the yellow notice appears under the header.
3. Hover the pill: tooltip explains the staging behavior.
4. Dismiss the notice, reload, and reopen the AI chat: the notice stays dismissed; the pill remains.
5. Minimize the Help Center: the pill is still visible in the minimized bar on chat routes.
6. Verify a production build shows neither pill nor notice.
