### PR TITLE
Site Generation: poll Generate Theme progress events

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/build-progress-poller.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/build-progress-poller.ts
@@ -39,6 +39,7 @@ const TOOL_MILESTONES: Record< string, string > = {
 	'generate-images': 'polishing',
 	'page-styles': 'polishing',
 	'custom-motion': 'polishing',
+	'bundle-fonts': 'polishing',
 	'fonts-php': 'polishing',
 	'finalize-theme': 'polishing',
 	'validate-theme': 'polishing',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/build-progress-poller.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/build-progress-poller.ts
@@ -1,72 +1,87 @@
-import wpcom from 'calypso/lib/wp';
+import { fetchSiteEndpoint, reportSafely, startPolling } from './poller';
 
 const BUILD_TERMINAL_STATUSES = new Set( [ 'done', 'fail' ] );
 
 export type BuildProgressResponse = {
 	current?: string | null;
-	last_update?: number | null;
 	history?: Array< {
-		timestamp?: number;
 		status?: string;
 	} >;
 };
 
-const TOOL_MILESTONES: Record< string, string > = {
-	'scaffold-theme': 'preparing',
-	'scaffold-plugin': 'preparing',
-	'refine-prompt': 'preparing',
-	'site-spec': 'preparing',
-	'apply-identity': 'designing',
-	'design-direction': 'designing',
-	'theme-json': 'designing',
-	'page-plan': 'designing',
-	'theme-json+page-plan': 'designing',
-	queue: 'building',
-	execute_batch_1: 'building',
-	execute_batch_2: 'building',
-	'big-sky/generate-header': 'building',
-	'big-sky/generate-footer': 'building',
-	'big-sky/generate-section': 'building',
-	sections: 'building',
-	'section-rhythm': 'building',
-	'collect-images': 'building',
-	'normalize-layout': 'building',
-	'header-hero': 'building',
-	'contrast-fix': 'building',
-	'motion-sanity': 'building',
-	'fix-blocks': 'building',
-	'assemble-pages': 'images',
-	'generate-images': 'polishing',
-	'page-styles': 'polishing',
-	'custom-motion': 'polishing',
-	'bundle-fonts': 'polishing',
-	'fonts-php': 'polishing',
-	'finalize-theme': 'polishing',
-	'validate-theme': 'polishing',
-	'cover-contrast': 'polishing',
-	finish: 'polishing',
-	generate: 'publishing',
-	apply: 'publishing',
+// Coarse UI milestones for the persisted pipeline step ids. This map chases
+// backend pipeline internals across a repo boundary, so it will lag when steps
+// are inserted or renamed upstream — an unmapped id degrades to the previous
+// milestone, never to breakage. The server owns two sibling maps over the same
+// step stream (Builder_Progress_Reader::MILESTONE_LABELS and the Big Sky
+// editor's toolId labels); the durable fix is the endpoint serving interpreted
+// milestones so the client stops tracking pipeline internals.
+const MILESTONE_TOOLS: Record< string, string[] > = {
+	preparing: [ 'scaffold-theme', 'scaffold-plugin', 'refine-prompt', 'site-spec' ],
+	designing: [
+		'apply-identity',
+		'design-direction',
+		'theme-json',
+		'page-plan',
+		'theme-json+page-plan',
+	],
+	building: [
+		'queue',
+		'execute_batch_1',
+		'execute_batch_2',
+		'big-sky/generate-header',
+		'big-sky/generate-footer',
+		'big-sky/generate-section',
+		'sections',
+		'section-rhythm',
+		'collect-images',
+		'normalize-layout',
+		'header-hero',
+		'contrast-fix',
+		'motion-sanity',
+		'fix-blocks',
+	],
+	images: [ 'assemble-pages' ],
+	polishing: [
+		'generate-images',
+		'page-styles',
+		'custom-motion',
+		'bundle-fonts',
+		'fonts-php',
+		'finalize-theme',
+		'validate-theme',
+		'cover-contrast',
+		'finish',
+	],
+	publishing: [ 'generate', 'apply' ],
 };
+
+const TOOL_MILESTONES: Record< string, string > = Object.fromEntries(
+	Object.entries( MILESTONE_TOOLS ).flatMap( ( [ milestone, toolIds ] ) =>
+		toolIds.map( ( toolId ) => [ toolId, milestone ] )
+	)
+);
 
 export function getStepIndexForProgress(
 	response: BuildProgressResponse,
 	stepIds: string[]
 ): number | null {
+	// The backend refreshes a repeated step's timestamp (heartbeat), so history
+	// order does not track milestone order — a long-running tool can resurface
+	// after later steps. Take the furthest recognized milestone across the whole
+	// history instead of the most recent entry.
 	const recordedStatuses = [
 		...( response.history ?? [] ).map( ( entry ) => entry.status ),
 		response.current,
 	];
-	const milestone = recordedStatuses.reduceRight< string | undefined >(
-		( found, toolId ) => found ?? ( toolId ? TOOL_MILESTONES[ toolId ] : undefined ),
-		undefined
-	);
-	if ( ! milestone ) {
-		return null;
+	let furthestIndex = -1;
+	for ( const toolId of recordedStatuses ) {
+		const milestone = toolId ? TOOL_MILESTONES[ toolId ] : undefined;
+		if ( milestone ) {
+			furthestIndex = Math.max( furthestIndex, stepIds.indexOf( milestone ) );
+		}
 	}
-
-	const milestoneIndex = stepIds.indexOf( milestone );
-	return milestoneIndex === -1 ? null : milestoneIndex;
+	return furthestIndex === -1 ? null : furthestIndex;
 }
 
 type FetchProgress = (
@@ -74,21 +89,20 @@ type FetchProgress = (
 	signal: AbortSignal
 ) => Promise< BuildProgressResponse >;
 
-const fetchBuildProgress: FetchProgress = async ( siteIdentifier, signal ) => {
-	const response = ( await wpcom.req.get( {
-		path: `/sites/${ siteIdentifier }/big-sky/build-progress`,
-		apiNamespace: 'wpcom/v2',
-		signal,
-	} ) ) as BuildProgressResponse | null;
-
-	return response ?? {};
-};
+const fetchBuildProgress: FetchProgress = async ( siteIdentifier, signal ) =>
+	( await fetchSiteEndpoint< BuildProgressResponse >(
+		siteIdentifier,
+		'build-progress',
+		signal
+	) ) ?? {};
 
 export function pollForBuildProgress( {
 	siteIdentifier,
 	onProgress,
-	pollIntervalMs = 3000,
-	requestTimeoutMs = 15000,
+	// Milestones advance on the order of tens of seconds, and this poller only
+	// supplements the 3s build-status poller — a slower interval loses nothing.
+	pollIntervalMs = 10000,
+	requestTimeoutMs,
 	fetchProgress = fetchBuildProgress,
 }: {
 	siteIdentifier: string;
@@ -97,64 +111,19 @@ export function pollForBuildProgress( {
 	requestTimeoutMs?: number;
 	fetchProgress?: FetchProgress;
 } ): () => void {
-	let isActive = true;
-	let pollTimeout: ReturnType< typeof setTimeout > | undefined;
-	let requestTimeout: ReturnType< typeof setTimeout > | undefined;
-	let requestController: AbortController | undefined;
-
-	const poll = async () => {
-		const controller = new AbortController();
-		const timeout = setTimeout( () => controller.abort(), requestTimeoutMs );
-		requestController = controller;
-		requestTimeout = timeout;
-
-		let response: BuildProgressResponse | undefined;
-
-		try {
-			response = await fetchProgress( siteIdentifier, controller.signal );
-		} catch {
-			// Progress is supplementary; readiness and failure continue to come
-			// from the build-status poller if this request fails.
-		} finally {
-			clearTimeout( timeout );
-			requestController = undefined;
-			requestTimeout = undefined;
-		}
-
-		if ( ! isActive ) {
-			return;
-		}
-
-		const status = typeof response?.current === 'string' ? response.current : undefined;
-
-		if ( response ) {
-			const progressResponse = response;
-			try {
-				onProgress( progressResponse );
-			} catch {}
-		}
-
-		// Readiness and failure are owned by the build-status poller. These values
-		// only stop progress polling after the final history has been reported.
-		if ( status && BUILD_TERMINAL_STATUSES.has( status ) ) {
-			return;
-		}
-
-		pollTimeout = setTimeout( () => {
-			void poll().catch( () => {} );
-		}, pollIntervalMs );
-	};
-
-	void poll().catch( () => {} );
-
-	return () => {
-		isActive = false;
-		if ( pollTimeout !== undefined ) {
-			clearTimeout( pollTimeout );
-		}
-		requestController?.abort();
-		if ( requestTimeout !== undefined ) {
-			clearTimeout( requestTimeout );
-		}
-	};
+	return startPolling< BuildProgressResponse >( {
+		fetch: ( signal ) => fetchProgress( siteIdentifier, signal ),
+		pollIntervalMs,
+		requestTimeoutMs,
+		onResponse: ( response ) => {
+			reportSafely( () => onProgress( response ) );
+			// Readiness and failure are owned by the build-status poller. These
+			// values only stop progress polling after the final history has been
+			// reported.
+			const status = typeof response.current === 'string' ? response.current : undefined;
+			if ( status && BUILD_TERMINAL_STATUSES.has( status ) ) {
+				return 'stop';
+			}
+		},
+	} );
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/build-progress-poller.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/build-progress-poller.ts
@@ -1,0 +1,159 @@
+import wpcom from 'calypso/lib/wp';
+
+const BUILD_TERMINAL_STATUSES = new Set( [ 'done', 'fail' ] );
+
+export type BuildProgressResponse = {
+	current?: string | null;
+	last_update?: number | null;
+	history?: Array< {
+		timestamp?: number;
+		status?: string;
+	} >;
+};
+
+const TOOL_MILESTONES: Record< string, string > = {
+	'scaffold-theme': 'preparing',
+	'scaffold-plugin': 'preparing',
+	'refine-prompt': 'preparing',
+	'site-spec': 'preparing',
+	'apply-identity': 'designing',
+	'design-direction': 'designing',
+	'theme-json': 'designing',
+	'page-plan': 'designing',
+	'theme-json+page-plan': 'designing',
+	queue: 'building',
+	execute_batch_1: 'building',
+	execute_batch_2: 'building',
+	'big-sky/generate-header': 'building',
+	'big-sky/generate-footer': 'building',
+	'big-sky/generate-section': 'building',
+	sections: 'building',
+	'section-rhythm': 'building',
+	'collect-images': 'building',
+	'normalize-layout': 'building',
+	'header-hero': 'building',
+	'contrast-fix': 'building',
+	'motion-sanity': 'building',
+	'fix-blocks': 'building',
+	'assemble-pages': 'images',
+	'generate-images': 'polishing',
+	'page-styles': 'polishing',
+	'custom-motion': 'polishing',
+	'fonts-php': 'polishing',
+	'finalize-theme': 'polishing',
+	'validate-theme': 'polishing',
+	'cover-contrast': 'polishing',
+	finish: 'polishing',
+	generate: 'publishing',
+	apply: 'publishing',
+};
+
+export function getStepIndexForProgress(
+	response: BuildProgressResponse,
+	stepIds: string[]
+): number | null {
+	const recordedStatuses = [
+		...( response.history ?? [] ).map( ( entry ) => entry.status ),
+		response.current,
+	];
+	const milestone = recordedStatuses.reduceRight< string | undefined >(
+		( found, toolId ) => found ?? ( toolId ? TOOL_MILESTONES[ toolId ] : undefined ),
+		undefined
+	);
+	if ( ! milestone ) {
+		return null;
+	}
+
+	const milestoneIndex = stepIds.indexOf( milestone );
+	return milestoneIndex === -1 ? null : milestoneIndex;
+}
+
+type FetchProgress = (
+	siteIdentifier: string,
+	signal: AbortSignal
+) => Promise< BuildProgressResponse >;
+
+const fetchBuildProgress: FetchProgress = async ( siteIdentifier, signal ) => {
+	const response = ( await wpcom.req.get( {
+		path: `/sites/${ siteIdentifier }/big-sky/build-progress`,
+		apiNamespace: 'wpcom/v2',
+		signal,
+	} ) ) as BuildProgressResponse | null;
+
+	return response ?? {};
+};
+
+export function pollForBuildProgress( {
+	siteIdentifier,
+	onProgress,
+	pollIntervalMs = 3000,
+	requestTimeoutMs = 15000,
+	fetchProgress = fetchBuildProgress,
+}: {
+	siteIdentifier: string;
+	onProgress: ( response: BuildProgressResponse ) => void;
+	pollIntervalMs?: number;
+	requestTimeoutMs?: number;
+	fetchProgress?: FetchProgress;
+} ): () => void {
+	let isActive = true;
+	let pollTimeout: ReturnType< typeof setTimeout > | undefined;
+	let requestTimeout: ReturnType< typeof setTimeout > | undefined;
+	let requestController: AbortController | undefined;
+
+	const poll = async () => {
+		const controller = new AbortController();
+		const timeout = setTimeout( () => controller.abort(), requestTimeoutMs );
+		requestController = controller;
+		requestTimeout = timeout;
+
+		let response: BuildProgressResponse | undefined;
+
+		try {
+			response = await fetchProgress( siteIdentifier, controller.signal );
+		} catch {
+			// Progress is supplementary; readiness and failure continue to come
+			// from the build-status poller if this request fails.
+		} finally {
+			clearTimeout( timeout );
+			requestController = undefined;
+			requestTimeout = undefined;
+		}
+
+		if ( ! isActive ) {
+			return;
+		}
+
+		const status = typeof response?.current === 'string' ? response.current : undefined;
+
+		if ( response ) {
+			const progressResponse = response;
+			try {
+				onProgress( progressResponse );
+			} catch {}
+		}
+
+		// Readiness and failure are owned by the build-status poller. These values
+		// only stop progress polling after the final history has been reported.
+		if ( status && BUILD_TERMINAL_STATUSES.has( status ) ) {
+			return;
+		}
+
+		pollTimeout = setTimeout( () => {
+			void poll().catch( () => {} );
+		}, pollIntervalMs );
+	};
+
+	void poll().catch( () => {} );
+
+	return () => {
+		isActive = false;
+		if ( pollTimeout !== undefined ) {
+			clearTimeout( pollTimeout );
+		}
+		requestController?.abort();
+		if ( requestTimeout !== undefined ) {
+			clearTimeout( requestTimeout );
+		}
+	};
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/build-status-poller.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/build-status-poller.ts
@@ -1,4 +1,4 @@
-import wpcom from 'calypso/lib/wp';
+import { fetchSiteEndpoint, startPolling } from './poller';
 
 // The build-wow backend records progress in the `big_sky_build_wow_build_status`
 // blog option, walked through by big_sky_build_wow_activate_and_verify():
@@ -12,46 +12,8 @@ import wpcom from 'calypso/lib/wp';
 const BUILD_WOW_LIVE_STATUS = 'live';
 const BUILD_WOW_FAILED_STATUS_PREFIX = 'failed:';
 
-export const BUILD_WOW_DELIVERY_PHASES = [ 'delivering', 'activating', 'verifying' ] as const;
-
-const MAX_REPORTED_ERROR_REASONS = 3;
-
-// Maps a delivery phase onto the tail of the designed step list, so a build that
-// is already `delivering` when this screen loads does not jump straight to the
-// last step. Returns null for a status outside the known walk.
-export function getStepIndexForStatus( status: string, stepCount: number ): number | null {
-	const phase = ( BUILD_WOW_DELIVERY_PHASES as readonly string[] ).indexOf( status );
-	if ( phase === -1 || stepCount === 0 ) {
-		return null;
-	}
-	const firstDeliveryStep = Math.max( 0, stepCount - BUILD_WOW_DELIVERY_PHASES.length );
-	return Math.min( stepCount - 1, firstDeliveryStep + phase );
-}
-
 function isBuildWowFailedStatus( status: string ): boolean {
 	return status.startsWith( BUILD_WOW_FAILED_STATUS_PREFIX );
-}
-
-// Non-terminal callbacks run through this so a throwing consumer cannot escape
-// poll() and leave the loop unscheduled, which would stall polling for the rest
-// of the generation window.
-function reportSafely( report: () => void ): void {
-	try {
-		report();
-	} catch {}
-}
-
-// An aborted proxy request rejects with a DOM Event rather than an Error
-// (wpcom-proxy-request passes the abort event straight to the callback), which
-// stringifies to a useless "[object Event]".
-function describeRequestError( error: unknown ): string {
-	if ( error instanceof Error ) {
-		return error.message;
-	}
-	if ( error && typeof error === 'object' && 'message' in error ) {
-		return String( ( error as { message: unknown } ).message );
-	}
-	return String( error );
 }
 
 type BuildWowStatusResponse = {
@@ -63,112 +25,45 @@ type FetchStatus = (
 	signal: AbortSignal
 ) => Promise< BuildWowStatusResponse >;
 
-const fetchBuildWowStatus: FetchStatus = async ( siteIdentifier, signal ) => {
-	const response = ( await wpcom.req.get( {
-		path: `/sites/${ siteIdentifier }/big-sky/build-wow/status`,
-		apiNamespace: 'wpcom/v2',
-		signal,
-	} ) ) as BuildWowStatusResponse | null;
-
-	return response ?? {};
-};
+const fetchBuildWowStatus: FetchStatus = async ( siteIdentifier, signal ) =>
+	( await fetchSiteEndpoint< BuildWowStatusResponse >(
+		siteIdentifier,
+		'build-wow/status',
+		signal
+	) ) ?? {};
 
 export function pollForBuildWowStatus( {
 	siteIdentifier,
 	onReady,
 	onFailed,
-	onProgress,
 	onRequestError,
-	pollIntervalMs = 3000,
-	requestTimeoutMs = 15000,
+	pollIntervalMs,
+	requestTimeoutMs,
 	fetchStatus = fetchBuildWowStatus,
 }: {
 	siteIdentifier: string;
 	onReady: () => void;
 	onFailed: ( status: string ) => void;
-	onProgress?: ( status: string ) => void;
 	onRequestError?: ( reason: string ) => void;
 	pollIntervalMs?: number;
 	requestTimeoutMs?: number;
 	fetchStatus?: FetchStatus;
 } ): () => void {
-	let isActive = true;
-	let pollTimeout: ReturnType< typeof setTimeout > | undefined;
-	let requestTimeout: ReturnType< typeof setTimeout > | undefined;
-	let requestController: AbortController | undefined;
-	const reportedReasons = new Set< string >();
-
-	const poll = async () => {
-		const controller = new AbortController();
-		const timeout = setTimeout( () => controller.abort(), requestTimeoutMs );
-		requestController = controller;
-		requestTimeout = timeout;
-
-		let status: string | undefined;
-
-		try {
-			const response = await fetchStatus( siteIdentifier, controller.signal );
-			status = typeof response.build_status === 'string' ? response.build_status : undefined;
-		} catch ( error ) {
-			// A failed status request does not mean the generation failed; keep polling.
-			// Nothing is reported once the poller has been stopped: tearing down aborts
-			// the in-flight request, and a user navigating away must not look like an
-			// outage. Otherwise report each distinct reason once, up to a small cap, so
-			// a 3s interval cannot emit hundreds of entries but a later, more
-			// informative error is not hidden behind the first one either.
-			if ( isActive ) {
-				const reason = controller.signal.aborted
-					? `request timed out after ${ requestTimeoutMs }ms`
-					: describeRequestError( error );
-				if (
-					! reportedReasons.has( reason ) &&
-					reportedReasons.size < MAX_REPORTED_ERROR_REASONS
-				) {
-					reportedReasons.add( reason );
-					reportSafely( () => onRequestError?.( reason ) );
-				}
+	return startPolling< BuildWowStatusResponse >( {
+		fetch: ( signal ) => fetchStatus( siteIdentifier, signal ),
+		onRequestError,
+		pollIntervalMs,
+		requestTimeoutMs,
+		onResponse: ( response ) => {
+			const status = typeof response.build_status === 'string' ? response.build_status : undefined;
+			if ( status === BUILD_WOW_LIVE_STATUS ) {
+				onReady();
+				return 'stop';
 			}
-		} finally {
-			clearTimeout( timeout );
-			requestController = undefined;
-			requestTimeout = undefined;
-		}
-
-		if ( ! isActive ) {
-			return;
-		}
-
-		// Terminal callbacks are dispatched outside the try so a throw from one of them
-		// cannot be mistaken for a request failure and silently reschedule the poll.
-		if ( status === BUILD_WOW_LIVE_STATUS ) {
-			onReady();
-			return;
-		}
-		if ( status && isBuildWowFailedStatus( status ) ) {
-			onFailed( status );
-			return;
-		}
-		// onProgress is not terminal, so a throw from it must not kill the loop.
-		if ( status ) {
-			const progressStatus = status;
-			reportSafely( () => onProgress?.( progressStatus ) );
-		}
-
-		pollTimeout = setTimeout( () => {
-			void poll().catch( () => {} );
-		}, pollIntervalMs );
-	};
-
-	void poll().catch( () => {} );
-
-	return () => {
-		isActive = false;
-		if ( pollTimeout !== undefined ) {
-			clearTimeout( pollTimeout );
-		}
-		requestController?.abort();
-		if ( requestTimeout !== undefined ) {
-			clearTimeout( requestTimeout );
-		}
-	};
+			if ( status && isBuildWowFailedStatus( status ) ) {
+				onFailed( status );
+				return 'stop';
+			}
+		},
+	} );
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/index.tsx
@@ -17,8 +17,9 @@ const SiteGeneration: StepType = function SiteGeneration() {
 			{ id: 'preparing', label: translate( 'Preparing your site' ) },
 			{ id: 'designing', label: translate( 'Choosing your design' ) },
 			{ id: 'building', label: translate( 'Building your pages' ) },
-			{ id: 'polishing', label: translate( 'Polishing your design' ) },
-			{ id: 'finalizing', label: translate( 'Getting everything ready' ) },
+			{ id: 'images', label: translate( 'Adding your images' ) },
+			{ id: 'polishing', label: translate( 'Polishing your site' ) },
+			{ id: 'publishing', label: translate( 'Publishing your site' ) },
 		],
 		[ translate ]
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/poller.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/poller.ts
@@ -1,0 +1,132 @@
+import wpcom from 'calypso/lib/wp';
+
+// Shared polling loop for the build-wow pollers in this directory: fetch with
+// a timeout + abort, report request errors (each distinct reason once, up to a
+// small cap), hand the response to the consumer, and reschedule until the
+// consumer says stop or the caller tears the loop down.
+
+const MAX_REPORTED_ERROR_REASONS = 3;
+
+// Non-terminal callbacks run through this so a throwing consumer cannot escape
+// poll() and leave the loop unscheduled, which would stall polling for the rest
+// of the generation window.
+export function reportSafely( report: () => void ): void {
+	try {
+		report();
+	} catch {}
+}
+
+// An aborted proxy request rejects with a DOM Event rather than an Error
+// (wpcom-proxy-request passes the abort event straight to the callback), which
+// stringifies to a useless "[object Event]".
+function describeRequestError( error: unknown ): string {
+	if ( error instanceof Error ) {
+		return error.message;
+	}
+	if ( error && typeof error === 'object' && 'message' in error ) {
+		return String( ( error as { message: unknown } ).message );
+	}
+	return String( error );
+}
+
+export function fetchSiteEndpoint< T >(
+	siteIdentifier: string,
+	endpoint: string,
+	signal: AbortSignal
+): Promise< T | null > {
+	return wpcom.req.get( {
+		path: `/sites/${ siteIdentifier }/big-sky/${ endpoint }`,
+		apiNamespace: 'wpcom/v2',
+		signal,
+	} ) as Promise< T | null >;
+}
+
+export function startPolling< T >( {
+	fetch: fetchResponse,
+	onResponse,
+	onRequestError,
+	pollIntervalMs = 3000,
+	requestTimeoutMs = 15000,
+}: {
+	fetch: ( signal: AbortSignal ) => Promise< T >;
+	// Runs outside the request try/catch: a throw from a consumer callback ends
+	// the loop instead of being mistaken for a request failure and silently
+	// rescheduling the poll. Return 'stop' to end polling.
+	onResponse: ( response: T ) => 'stop' | void;
+	onRequestError?: ( reason: string ) => void;
+	pollIntervalMs?: number;
+	requestTimeoutMs?: number;
+} ): () => void {
+	let isActive = true;
+	let pollTimeout: ReturnType< typeof setTimeout > | undefined;
+	let requestTimeout: ReturnType< typeof setTimeout > | undefined;
+	let requestController: AbortController | undefined;
+	const reportedReasons = new Set< string >();
+
+	const poll = async () => {
+		const controller = new AbortController();
+		const timeout = setTimeout( () => controller.abort(), requestTimeoutMs );
+		requestController = controller;
+		requestTimeout = timeout;
+
+		let response: T | undefined;
+
+		try {
+			response = await fetchResponse( controller.signal );
+		} catch ( error ) {
+			// A failed request does not mean the generation failed; keep polling.
+			// Nothing is reported once the poller has been stopped: tearing down
+			// aborts the in-flight request, and a user navigating away must not
+			// look like an outage. Otherwise report each distinct reason once, up
+			// to a small cap, so a short interval cannot emit hundreds of entries
+			// but a later, more informative error is not hidden behind the first
+			// one either.
+			if ( isActive ) {
+				const reason = controller.signal.aborted
+					? `request timed out after ${ requestTimeoutMs }ms`
+					: describeRequestError( error );
+				if (
+					! reportedReasons.has( reason ) &&
+					reportedReasons.size < MAX_REPORTED_ERROR_REASONS
+				) {
+					reportedReasons.add( reason );
+					reportSafely( () => onRequestError?.( reason ) );
+				}
+			}
+		} finally {
+			clearTimeout( timeout );
+			requestController = undefined;
+			requestTimeout = undefined;
+		}
+
+		if ( ! isActive ) {
+			return;
+		}
+
+		if ( response !== undefined && onResponse( response ) === 'stop' ) {
+			return;
+		}
+
+		// onResponse may have torn the loop down (a consumer stopping itself).
+		if ( ! isActive ) {
+			return;
+		}
+
+		pollTimeout = setTimeout( () => {
+			void poll().catch( () => {} );
+		}, pollIntervalMs );
+	};
+
+	void poll().catch( () => {} );
+
+	return () => {
+		isActive = false;
+		if ( pollTimeout !== undefined ) {
+			clearTimeout( pollTimeout );
+		}
+		requestController?.abort();
+		if ( requestTimeout !== undefined ) {
+			clearTimeout( requestTimeout );
+		}
+	};
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/build-progress-poller.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/build-progress-poller.ts
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { getStepIndexForProgress, pollForBuildProgress } from '../build-progress-poller';
+
+describe( 'getStepIndexForProgress', () => {
+	const stepIds = [ 'preparing', 'designing', 'building', 'images', 'polishing', 'publishing' ];
+
+	it( 'maps persisted workflow events to their matching UI steps', () => {
+		expect( getStepIndexForProgress( { current: 'site-spec' }, stepIds ) ).toBe( 0 );
+		expect( getStepIndexForProgress( { current: 'theme-json+page-plan' }, stepIds ) ).toBe( 1 );
+		expect( getStepIndexForProgress( { current: 'header-hero' }, stepIds ) ).toBe( 2 );
+		expect( getStepIndexForProgress( { current: 'assemble-pages' }, stepIds ) ).toBe( 3 );
+		expect( getStepIndexForProgress( { current: 'generate-images' }, stepIds ) ).toBe( 4 );
+		expect( getStepIndexForProgress( { current: 'generate' }, stepIds ) ).toBe( 5 );
+	} );
+
+	it( 'uses the most recent recognized event when the current event is internal', () => {
+		expect(
+			getStepIndexForProgress(
+				{
+					current: 'prepare',
+					history: [
+						{ timestamp: 1, status: 'theme-json' },
+						{ timestamp: 2, status: 'prepare' },
+					],
+				},
+				stepIds
+			)
+		).toBe( 1 );
+	} );
+
+	it( 'returns null when the response has no recognized progress', () => {
+		expect( getStepIndexForProgress( { current: 'done' }, stepIds ) ).toBeNull();
+		expect( getStepIndexForProgress( { current: 'fail' }, stepIds ) ).toBeNull();
+		expect( getStepIndexForProgress( {}, stepIds ) ).toBeNull();
+	} );
+} );
+
+describe( 'pollForBuildProgress', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'reports generation events and stops after reporting the final history', async () => {
+		const finalProgress = {
+			current: 'done',
+			history: [ { timestamp: 1, status: 'generate' } ],
+		};
+		const fetchProgress = jest
+			.fn()
+			.mockResolvedValueOnce( { current: 'theme-json' } )
+			.mockResolvedValueOnce( finalProgress );
+		const onProgress = jest.fn();
+
+		pollForBuildProgress( {
+			siteIdentifier: '123',
+			onProgress,
+			pollIntervalMs: 1000,
+			fetchProgress,
+		} );
+
+		await jest.advanceTimersByTimeAsync( 5000 );
+
+		expect( onProgress ).toHaveBeenNthCalledWith( 1, { current: 'theme-json' } );
+		expect( onProgress ).toHaveBeenNthCalledWith( 2, finalProgress );
+		expect( fetchProgress ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'continues polling after a temporary request failure', async () => {
+		const fetchProgress = jest
+			.fn()
+			.mockRejectedValueOnce( new Error( 'Unavailable' ) )
+			.mockResolvedValueOnce( { current: 'site-spec' } )
+			.mockResolvedValueOnce( { current: 'done' } );
+		const onProgress = jest.fn();
+
+		pollForBuildProgress( {
+			siteIdentifier: '123',
+			onProgress,
+			pollIntervalMs: 1000,
+			fetchProgress,
+		} );
+
+		await jest.advanceTimersByTimeAsync( 2000 );
+
+		expect( onProgress ).toHaveBeenCalledWith( { current: 'site-spec' } );
+		expect( fetchProgress ).toHaveBeenCalledTimes( 3 );
+	} );
+
+	it( 'stops polling and aborts the current request when cancelled', async () => {
+		const fetchProgress = jest.fn().mockResolvedValue( {} );
+		const stop = pollForBuildProgress( {
+			siteIdentifier: '123',
+			onProgress: jest.fn(),
+			pollIntervalMs: 1000,
+			fetchProgress,
+		} );
+
+		await jest.advanceTimersByTimeAsync( 0 );
+		stop();
+		await jest.advanceTimersByTimeAsync( 5000 );
+
+		expect( fetchProgress ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/build-progress-poller.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/build-progress-poller.ts
@@ -16,19 +16,30 @@ describe( 'getStepIndexForProgress', () => {
 		expect( getStepIndexForProgress( { current: 'generate' }, stepIds ) ).toBe( 5 );
 	} );
 
-	it( 'uses the most recent recognized event when the current event is internal', () => {
+	it( 'uses the furthest recognized event when the current event is internal', () => {
 		expect(
 			getStepIndexForProgress(
 				{
 					current: 'prepare',
-					history: [
-						{ timestamp: 1, status: 'theme-json' },
-						{ timestamp: 2, status: 'prepare' },
-					],
+					history: [ { status: 'theme-json' }, { status: 'prepare' } ],
 				},
 				stepIds
 			)
 		).toBe( 1 );
+	} );
+
+	it( 'does not move backwards when a heartbeat resurfaces an earlier step', () => {
+		// The backend refreshes a repeated step's timestamp, so a long-running
+		// early tool can reappear at the end of the history after later steps.
+		expect(
+			getStepIndexForProgress(
+				{
+					current: 'theme-json',
+					history: [ { status: 'generate-images' }, { status: 'theme-json' } ],
+				},
+				stepIds
+			)
+		).toBe( 4 );
 	} );
 
 	it( 'returns null when the response has no recognized progress', () => {
@@ -50,7 +61,7 @@ describe( 'pollForBuildProgress', () => {
 	it( 'reports generation events and stops after reporting the final history', async () => {
 		const finalProgress = {
 			current: 'done',
-			history: [ { timestamp: 1, status: 'generate' } ],
+			history: [ { status: 'generate' } ],
 		};
 		const fetchProgress = jest
 			.fn()

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/build-status-poller.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/build-status-poller.ts
@@ -2,32 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { getStepIndexForStatus, pollForBuildWowStatus } from '../build-status-poller';
-
-describe( 'getStepIndexForStatus', () => {
-	// The shipping step list has six entries (see site-generation/index.tsx), which
-	// is the arity that matters and the one a three-step fixture cannot exercise —
-	// at three, the tail offset is zero and every mapping looks like identity.
-	it( 'maps the delivery walk onto the last three of the six shipping steps', () => {
-		expect( getStepIndexForStatus( 'delivering', 6 ) ).toBe( 3 );
-		expect( getStepIndexForStatus( 'activating', 6 ) ).toBe( 4 );
-		expect( getStepIndexForStatus( 'verifying', 6 ) ).toBe( 5 );
-	} );
-
-	it( 'returns null for a status outside the known walk', () => {
-		expect( getStepIndexForStatus( 'live', 6 ) ).toBeNull();
-		expect( getStepIndexForStatus( 'failed:whatever', 6 ) ).toBeNull();
-		expect( getStepIndexForStatus( '', 6 ) ).toBeNull();
-	} );
-
-	it( 'stays in range for step lists shorter than the delivery walk', () => {
-		expect( getStepIndexForStatus( 'delivering', 3 ) ).toBe( 0 );
-		expect( getStepIndexForStatus( 'verifying', 3 ) ).toBe( 2 );
-		expect( getStepIndexForStatus( 'verifying', 2 ) ).toBe( 1 );
-		expect( getStepIndexForStatus( 'verifying', 1 ) ).toBe( 0 );
-		expect( getStepIndexForStatus( 'delivering', 0 ) ).toBeNull();
-	} );
-} );
+import { pollForBuildWowStatus } from '../build-status-poller';
 
 describe( 'pollForBuildWowStatus', () => {
 	beforeEach( () => {
@@ -38,26 +13,23 @@ describe( 'pollForBuildWowStatus', () => {
 		jest.useRealTimers();
 	} );
 
-	it( 'reports progress and calls onReady once the status is live', async () => {
+	it( 'calls onReady once the status is live', async () => {
 		const fetchStatus = jest
 			.fn()
 			.mockResolvedValueOnce( { build_status: 'delivering' } )
 			.mockResolvedValueOnce( { build_status: 'live' } );
 		const onReady = jest.fn();
 		const onFailed = jest.fn();
-		const onProgress = jest.fn();
 
 		pollForBuildWowStatus( {
 			siteIdentifier: '123',
 			onReady,
 			onFailed,
-			onProgress,
 			pollIntervalMs: 1000,
 			fetchStatus,
 		} );
 
 		await jest.advanceTimersByTimeAsync( 0 );
-		expect( onProgress ).toHaveBeenCalledWith( 'delivering' );
 		expect( onReady ).not.toHaveBeenCalled();
 
 		await jest.advanceTimersByTimeAsync( 1000 );
@@ -115,19 +87,17 @@ describe( 'pollForBuildWowStatus', () => {
 			.mockResolvedValueOnce( { build_status: 1 } )
 			.mockResolvedValueOnce( { build_status: 'live' } );
 		const onReady = jest.fn();
-		const onProgress = jest.fn();
 
 		pollForBuildWowStatus( {
 			siteIdentifier: '123',
 			onReady,
 			onFailed: jest.fn(),
-			onProgress,
 			pollIntervalMs: 1000,
 			fetchStatus,
 		} );
 
 		await jest.advanceTimersByTimeAsync( 0 );
-		expect( onProgress ).not.toHaveBeenCalled();
+		expect( onReady ).not.toHaveBeenCalled();
 
 		await jest.advanceTimersByTimeAsync( 1000 );
 		expect( onReady ).toHaveBeenCalledTimes( 1 );
@@ -269,27 +239,6 @@ describe( 'pollForBuildWowStatus', () => {
 			'Service unavailable',
 			'Internal server error',
 		] );
-	} );
-
-	it( 'keeps polling when onProgress throws', async () => {
-		const fetchStatus = jest.fn().mockResolvedValue( { build_status: 'delivering' } );
-		const onProgress = jest.fn( () => {
-			throw new Error( 'Render blew up' );
-		} );
-
-		pollForBuildWowStatus( {
-			siteIdentifier: '123',
-			onReady: jest.fn(),
-			onFailed: jest.fn(),
-			onProgress,
-			pollIntervalMs: 1000,
-			fetchStatus,
-		} );
-
-		await jest.advanceTimersByTimeAsync( 3000 );
-
-		expect( onProgress.mock.calls.length ).toBeGreaterThan( 1 );
-		expect( fetchStatus.mock.calls.length ).toBeGreaterThan( 1 );
 	} );
 
 	it( 'keeps polling when onRequestError throws', async () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/build-status-poller.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/build-status-poller.ts
@@ -5,19 +5,19 @@
 import { getStepIndexForStatus, pollForBuildWowStatus } from '../build-status-poller';
 
 describe( 'getStepIndexForStatus', () => {
-	// The shipping step list has five entries (see site-generation/index.tsx), which
+	// The shipping step list has six entries (see site-generation/index.tsx), which
 	// is the arity that matters and the one a three-step fixture cannot exercise —
 	// at three, the tail offset is zero and every mapping looks like identity.
-	it( 'maps the delivery walk onto the last three of the five shipping steps', () => {
-		expect( getStepIndexForStatus( 'delivering', 5 ) ).toBe( 2 );
-		expect( getStepIndexForStatus( 'activating', 5 ) ).toBe( 3 );
-		expect( getStepIndexForStatus( 'verifying', 5 ) ).toBe( 4 );
+	it( 'maps the delivery walk onto the last three of the six shipping steps', () => {
+		expect( getStepIndexForStatus( 'delivering', 6 ) ).toBe( 3 );
+		expect( getStepIndexForStatus( 'activating', 6 ) ).toBe( 4 );
+		expect( getStepIndexForStatus( 'verifying', 6 ) ).toBe( 5 );
 	} );
 
 	it( 'returns null for a status outside the known walk', () => {
-		expect( getStepIndexForStatus( 'live', 5 ) ).toBeNull();
-		expect( getStepIndexForStatus( 'failed:whatever', 5 ) ).toBeNull();
-		expect( getStepIndexForStatus( '', 5 ) ).toBeNull();
+		expect( getStepIndexForStatus( 'live', 6 ) ).toBeNull();
+		expect( getStepIndexForStatus( 'failed:whatever', 6 ) ).toBeNull();
+		expect( getStepIndexForStatus( '', 6 ) ).toBeNull();
 	} );
 
 	it( 'stays in range for step lists shorter than the delivery walk', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/use-site-generation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/use-site-generation.tsx
@@ -4,8 +4,14 @@
 
 import { act, renderHook } from '@testing-library/react';
 import { logBuildWowEvent } from 'calypso/landing/stepper/utils/build-wow';
+import { pollForBuildProgress } from '../build-progress-poller';
 import { pollForBuildWowStatus } from '../build-status-poller';
 import { useSiteGeneration } from '../use-site-generation';
+
+jest.mock( '../build-progress-poller', () => ( {
+	...jest.requireActual( '../build-progress-poller' ),
+	pollForBuildProgress: jest.fn( () => jest.fn() ),
+} ) );
 
 jest.mock( '../build-status-poller', () => ( {
 	...jest.requireActual( '../build-status-poller' ),
@@ -16,44 +22,62 @@ jest.mock( 'calypso/landing/stepper/utils/build-wow', () => ( {
 	logBuildWowEvent: jest.fn(),
 } ) );
 
-const pollMock = pollForBuildWowStatus as jest.Mock;
+const progressPollMock = pollForBuildProgress as jest.Mock;
+const statusPollMock = pollForBuildWowStatus as jest.Mock;
 const logMock = logBuildWowEvent as jest.Mock;
+const originalLocation = window.location;
 
-// Mirrors the five steps site-generation/index.tsx ships. A shorter fixture would
-// be degenerate: at three steps the delivery-phase mapping collapses to identity.
 const STEPS = [
 	{ id: 'preparing', label: 'Preparing your site' },
 	{ id: 'designing', label: 'Choosing your design' },
 	{ id: 'building', label: 'Building your pages' },
-	{ id: 'polishing', label: 'Polishing your design' },
-	{ id: 'finalizing', label: 'Getting everything ready' },
+	{ id: 'images', label: 'Adding your images' },
+	{ id: 'polishing', label: 'Polishing your site' },
+	{ id: 'publishing', label: 'Publishing your site' },
 ];
 
 describe( 'useSiteGeneration', () => {
 	beforeEach( () => {
 		jest.useFakeTimers();
-		pollMock.mockClear();
-		pollMock.mockReturnValue( jest.fn() );
+		Object.defineProperty( window, 'location', {
+			value: { ...originalLocation, assign: jest.fn() },
+			configurable: true,
+		} );
+		progressPollMock.mockClear();
+		progressPollMock.mockReturnValue( jest.fn() );
+		statusPollMock.mockClear();
+		statusPollMock.mockReturnValue( jest.fn() );
 		logMock.mockClear();
 	} );
 
 	afterEach( () => {
 		jest.useRealTimers();
+		Object.defineProperty( window, 'location', {
+			value: originalLocation,
+			configurable: true,
+		} );
 	} );
 
 	it( 'fails with missing-parameters when the editor URL is absent', () => {
 		const { result } = renderHook( () =>
-			useSiteGeneration( { siteIdentifier: '123', editorUrl: null, steps: STEPS } )
+			useSiteGeneration( {
+				siteIdentifier: '123',
+				editorUrl: null,
+				steps: STEPS,
+			} )
 		);
 
 		expect( result.current.status ).toBe( 'failed' );
 		expect( result.current.failureReason ).toBe( 'missing-parameters' );
-		expect( pollMock ).not.toHaveBeenCalled();
+		expect( progressPollMock ).not.toHaveBeenCalled();
+		expect( statusPollMock ).not.toHaveBeenCalled();
 	} );
 
 	it( 'polls while working and fails with timed-out after the generation deadline', () => {
-		const stopPolling = jest.fn();
-		pollMock.mockReturnValue( stopPolling );
+		const stopProgressPolling = jest.fn();
+		const stopStatusPolling = jest.fn();
+		progressPollMock.mockReturnValue( stopProgressPolling );
+		statusPollMock.mockReturnValue( stopStatusPolling );
 
 		const { result } = renderHook( () =>
 			useSiteGeneration( {
@@ -64,7 +88,8 @@ describe( 'useSiteGeneration', () => {
 		);
 
 		expect( result.current.status ).toBe( 'working' );
-		expect( pollMock ).toHaveBeenCalledTimes( 1 );
+		expect( progressPollMock ).toHaveBeenCalledTimes( 1 );
+		expect( statusPollMock ).toHaveBeenCalledTimes( 1 );
 
 		act( () => {
 			jest.advanceTimersByTime( 30 * 60 * 1000 );
@@ -72,7 +97,8 @@ describe( 'useSiteGeneration', () => {
 
 		expect( result.current.status ).toBe( 'failed' );
 		expect( result.current.failureReason ).toBe( 'timed-out' );
-		expect( stopPolling ).toHaveBeenCalled();
+		expect( stopProgressPolling ).toHaveBeenCalled();
+		expect( stopStatusPolling ).toHaveBeenCalled();
 	} );
 
 	it( 'shows the calm fallback (never an error) when the backend reports a failed build', () => {
@@ -84,7 +110,7 @@ describe( 'useSiteGeneration', () => {
 			} )
 		);
 
-		const { onFailed } = pollMock.mock.calls[ 0 ][ 0 ];
+		const { onFailed } = statusPollMock.mock.calls[ 0 ][ 0 ];
 		act( () => {
 			onFailed( 'failed:build_wow_theme_activation_failed' );
 		} );
@@ -97,7 +123,31 @@ describe( 'useSiteGeneration', () => {
 		} );
 	} );
 
-	it( 'maps each delivery phase to its own step rather than jumping to the last', () => {
+	it( 'redirects only when the build status poller reports that the site is ready', () => {
+		renderHook( () =>
+			useSiteGeneration( {
+				siteIdentifier: '123',
+				editorUrl: 'https://example.wordpress.com/wp-admin/site-editor.php',
+				steps: STEPS,
+			} )
+		);
+
+		const { onProgress } = progressPollMock.mock.calls[ 0 ][ 0 ];
+		act( () => {
+			onProgress( { current: 'done' } );
+		} );
+		expect( window.location.assign ).not.toHaveBeenCalled();
+
+		const { onReady } = statusPollMock.mock.calls[ 0 ][ 0 ];
+		act( () => {
+			onReady();
+		} );
+		expect( window.location.assign ).toHaveBeenCalledWith(
+			'https://example.wordpress.com/wp-admin/site-editor.php'
+		);
+	} );
+
+	it( 'advances from persisted generation milestones and keeps completed steps visible', () => {
 		const { result } = renderHook( () =>
 			useSiteGeneration( {
 				siteIdentifier: '123',
@@ -106,36 +156,48 @@ describe( 'useSiteGeneration', () => {
 			} )
 		);
 
-		const { onProgress } = pollMock.mock.calls[ 0 ][ 0 ];
+		const { onProgress } = progressPollMock.mock.calls[ 0 ][ 0 ];
 
-		// `delivering` is the status already recorded when this screen loads, so it
-		// must not complete the whole list.
 		act( () => {
-			onProgress( 'delivering' );
+			onProgress( { current: 'theme-json' } );
 		} );
 		expect( result.current.steps.map( ( step ) => step.status ) ).toEqual( [
+			'complete',
+			'active',
+			'pending',
+			'pending',
+			'pending',
+			'pending',
+		] );
+
+		act( () => {
+			onProgress( { current: 'assemble-pages' } );
+		} );
+		expect( result.current.steps.map( ( step ) => step.status ) ).toEqual( [
+			'complete',
 			'complete',
 			'complete',
 			'active',
 			'pending',
 			'pending',
 		] );
+	} );
 
+	it( 'moves to publishing when theme generation completes', () => {
+		const { result } = renderHook( () =>
+			useSiteGeneration( {
+				siteIdentifier: '123',
+				editorUrl: 'https://example.wordpress.com/wp-admin/site-editor.php',
+				steps: STEPS,
+			} )
+		);
+
+		const { onProgress } = progressPollMock.mock.calls[ 0 ][ 0 ];
 		act( () => {
-			onProgress( 'activating' );
+			onProgress( { current: 'generate' } );
 		} );
 		expect( result.current.steps.map( ( step ) => step.status ) ).toEqual( [
 			'complete',
-			'complete',
-			'complete',
-			'active',
-			'pending',
-		] );
-
-		act( () => {
-			onProgress( 'verifying' );
-		} );
-		expect( result.current.steps.map( ( step ) => step.status ) ).toEqual( [
 			'complete',
 			'complete',
 			'complete',
@@ -153,14 +215,13 @@ describe( 'useSiteGeneration', () => {
 			} )
 		);
 
-		const { onProgress } = pollMock.mock.calls[ 0 ][ 0 ];
+		const { onProgress } = progressPollMock.mock.calls[ 0 ][ 0 ];
 		act( () => {
-			onProgress( 'verifying' );
-			onProgress( 'delivering' );
+			onProgress( { current: 'validate-theme' } );
+			onProgress( { current: 'theme-json' } );
 		} );
 
-		const steps = result.current.steps;
-		expect( steps[ steps.length - 1 ].status ).toBe( 'active' );
+		expect( result.current.steps[ 4 ].status ).toBe( 'active' );
 	} );
 
 	it( 'ignores an unrecognized status instead of advancing progress', () => {
@@ -172,9 +233,9 @@ describe( 'useSiteGeneration', () => {
 			} )
 		);
 
-		const { onProgress } = pollMock.mock.calls[ 0 ][ 0 ];
+		const { onProgress } = progressPollMock.mock.calls[ 0 ][ 0 ];
 		act( () => {
-			onProgress( 'something-unexpected' );
+			onProgress( { current: 'internal-step' } );
 		} );
 
 		expect( result.current.steps[ 0 ].status ).toBe( 'active' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/use-site-generation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/use-site-generation.tsx
@@ -39,10 +39,6 @@ const STEPS = [
 describe( 'useSiteGeneration', () => {
 	beforeEach( () => {
 		jest.useFakeTimers();
-		Object.defineProperty( window, 'location', {
-			value: { ...originalLocation, assign: jest.fn() },
-			configurable: true,
-		} );
 		progressPollMock.mockClear();
 		progressPollMock.mockReturnValue( jest.fn() );
 		statusPollMock.mockClear();
@@ -52,10 +48,6 @@ describe( 'useSiteGeneration', () => {
 
 	afterEach( () => {
 		jest.useRealTimers();
-		Object.defineProperty( window, 'location', {
-			value: originalLocation,
-			configurable: true,
-		} );
 	} );
 
 	it( 'fails with missing-parameters when the editor URL is absent', () => {
@@ -124,27 +116,41 @@ describe( 'useSiteGeneration', () => {
 	} );
 
 	it( 'redirects only when the build status poller reports that the site is ready', () => {
-		renderHook( () =>
-			useSiteGeneration( {
-				siteIdentifier: '123',
-				editorUrl: 'https://example.wordpress.com/wp-admin/site-editor.php',
-				steps: STEPS,
-			} )
-		);
-
-		const { onProgress } = progressPollMock.mock.calls[ 0 ][ 0 ];
-		act( () => {
-			onProgress( { current: 'done' } );
+		// The stub is scoped here because this is the only test that asserts on
+		// window.location.assign.
+		Object.defineProperty( window, 'location', {
+			value: { ...originalLocation, assign: jest.fn() },
+			configurable: true,
 		} );
-		expect( window.location.assign ).not.toHaveBeenCalled();
 
-		const { onReady } = statusPollMock.mock.calls[ 0 ][ 0 ];
-		act( () => {
-			onReady();
-		} );
-		expect( window.location.assign ).toHaveBeenCalledWith(
-			'https://example.wordpress.com/wp-admin/site-editor.php'
-		);
+		try {
+			renderHook( () =>
+				useSiteGeneration( {
+					siteIdentifier: '123',
+					editorUrl: 'https://example.wordpress.com/wp-admin/site-editor.php',
+					steps: STEPS,
+				} )
+			);
+
+			const { onProgress } = progressPollMock.mock.calls[ 0 ][ 0 ];
+			act( () => {
+				onProgress( { current: 'done' } );
+			} );
+			expect( window.location.assign ).not.toHaveBeenCalled();
+
+			const { onReady } = statusPollMock.mock.calls[ 0 ][ 0 ];
+			act( () => {
+				onReady();
+			} );
+			expect( window.location.assign ).toHaveBeenCalledWith(
+				'https://example.wordpress.com/wp-admin/site-editor.php'
+			);
+		} finally {
+			Object.defineProperty( window, 'location', {
+				value: originalLocation,
+				configurable: true,
+			} );
+		}
 	} );
 
 	it( 'advances from persisted generation milestones and keeps completed steps visible', () => {
@@ -181,18 +187,7 @@ describe( 'useSiteGeneration', () => {
 			'pending',
 			'pending',
 		] );
-	} );
 
-	it( 'moves to publishing when theme generation completes', () => {
-		const { result } = renderHook( () =>
-			useSiteGeneration( {
-				siteIdentifier: '123',
-				editorUrl: 'https://example.wordpress.com/wp-admin/site-editor.php',
-				steps: STEPS,
-			} )
-		);
-
-		const { onProgress } = progressPollMock.mock.calls[ 0 ][ 0 ];
 		act( () => {
 			onProgress( { current: 'generate' } );
 		} );
@@ -204,6 +199,30 @@ describe( 'useSiteGeneration', () => {
 			'complete',
 			'active',
 		] );
+	} );
+
+	it( 'stops progress polling once the last milestone is reached', () => {
+		const stopProgressPolling = jest.fn();
+		progressPollMock.mockReturnValue( stopProgressPolling );
+
+		renderHook( () =>
+			useSiteGeneration( {
+				siteIdentifier: '123',
+				editorUrl: 'https://example.wordpress.com/wp-admin/site-editor.php',
+				steps: STEPS,
+			} )
+		);
+
+		const { onProgress } = progressPollMock.mock.calls[ 0 ][ 0 ];
+		act( () => {
+			onProgress( { current: 'assemble-pages' } );
+		} );
+		expect( stopProgressPolling ).not.toHaveBeenCalled();
+
+		act( () => {
+			onProgress( { current: 'generate' } );
+		} );
+		expect( stopProgressPolling ).toHaveBeenCalled();
 	} );
 
 	it( 'never moves progress backwards when statuses arrive out of order', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/use-site-generation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/use-site-generation.ts
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { logBuildWowEvent } from 'calypso/landing/stepper/utils/build-wow';
-import { getStepIndexForStatus, pollForBuildWowStatus } from './build-status-poller';
+import { getStepIndexForProgress, pollForBuildProgress } from './build-progress-poller';
+import { pollForBuildWowStatus } from './build-status-poller';
 
 export type SiteGenerationStep = {
 	id: string;
@@ -16,7 +17,6 @@ export type SiteGenerationState = {
 	steps: SiteGenerationStep[];
 };
 
-const STEP_DELAYS = [ 20000, 50000, 90000, 140000 ];
 const GENERATION_TIMEOUT_MS = 30 * 60 * 1000;
 
 function getStepsWithProgress(
@@ -44,27 +44,20 @@ export function useSiteGeneration( {
 	steps: Array< Pick< SiteGenerationStep, 'id' | 'label' > >;
 } ): SiteGenerationState {
 	const [ activeStepIndex, setActiveStepIndex ] = useState( 0 );
-	const [ statusStepIndex, setStatusStepIndex ] = useState( -1 );
 	const [ hasTimedOut, setHasTimedOut ] = useState( false );
 	const hasRequiredParameters = Boolean( siteIdentifier && editorUrl );
-	const stepCount = steps.length;
+	const stepIds = useMemo( () => steps.map( ( step ) => step.id ), [ steps ] );
 
 	useEffect( () => {
 		if ( ! siteIdentifier || ! editorUrl || hasTimedOut ) {
 			return;
 		}
 
-		const progressTimeouts = STEP_DELAYS.map( ( delay, index ) =>
-			window.setTimeout(
-				() => setActiveStepIndex( ( previous ) => Math.max( previous, index + 1 ) ),
-				delay
-			)
-		);
 		const generationTimeout = window.setTimeout(
 			() => setHasTimedOut( true ),
 			GENERATION_TIMEOUT_MS
 		);
-		const stopPolling = pollForBuildWowStatus( {
+		const stopStatusPolling = pollForBuildWowStatus( {
 			siteIdentifier,
 			onReady: () => window.location.assign( editorUrl ),
 			// A failed build is logged for us but never surfaced as an error: the
@@ -77,23 +70,26 @@ export function useSiteGeneration( {
 				} );
 				setHasTimedOut( true );
 			},
-			onProgress: ( status ) =>
-				setStatusStepIndex( ( previous ) =>
-					Math.max( previous, getStepIndexForStatus( status, stepCount ) ?? -1 )
-				),
 			onRequestError: ( reason ) =>
 				logBuildWowEvent( 'site_generation_status_request_failed', {
 					site_identifier: siteIdentifier,
 					error: reason,
 				} ),
 		} );
+		const stopProgressPolling = pollForBuildProgress( {
+			siteIdentifier,
+			onProgress: ( response ) =>
+				setActiveStepIndex( ( previous ) =>
+					Math.max( previous, getStepIndexForProgress( response, stepIds ) ?? 0 )
+				),
+		} );
 
 		return () => {
-			progressTimeouts.forEach( window.clearTimeout );
 			window.clearTimeout( generationTimeout );
-			stopPolling();
+			stopStatusPolling();
+			stopProgressPolling();
 		};
-	}, [ editorUrl, siteIdentifier, hasTimedOut, stepCount ] );
+	}, [ editorUrl, hasTimedOut, siteIdentifier, stepIds ] );
 
 	let failureReason: SiteGenerationFailureReason | undefined;
 	if ( ! hasRequiredParameters ) {
@@ -102,19 +98,9 @@ export function useSiteGeneration( {
 		failureReason = 'timed-out';
 	}
 
-	// Real delivery-phase statuses drive the progress ahead of the fixed timers,
-	// never behind them, so the display only ever moves forward (keeping the
-	// designed step labels as-is). Clamped because STEP_DELAYS can outrun a step
-	// list shorter than its own length, which would leave every step complete and
-	// none active.
-	const effectiveActiveIndex = Math.min(
-		stepCount - 1,
-		Math.max( activeStepIndex, statusStepIndex )
-	);
-
 	return {
 		status: failureReason ? 'failed' : 'working',
 		failureReason,
-		steps: getStepsWithProgress( steps, effectiveActiveIndex ),
+		steps: getStepsWithProgress( steps, Math.min( steps.length - 1, activeStepIndex ) ),
 	};
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/use-site-generation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/use-site-generation.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { logBuildWowEvent } from 'calypso/landing/stepper/utils/build-wow';
 import { getStepIndexForProgress, pollForBuildProgress } from './build-progress-poller';
 import { pollForBuildWowStatus } from './build-status-poller';
@@ -46,12 +46,13 @@ export function useSiteGeneration( {
 	const [ activeStepIndex, setActiveStepIndex ] = useState( 0 );
 	const [ hasTimedOut, setHasTimedOut ] = useState( false );
 	const hasRequiredParameters = Boolean( siteIdentifier && editorUrl );
-	const stepIds = useMemo( () => steps.map( ( step ) => step.id ), [ steps ] );
 
 	useEffect( () => {
 		if ( ! siteIdentifier || ! editorUrl || hasTimedOut ) {
 			return;
 		}
+
+		const stepIds = steps.map( ( step ) => step.id );
 
 		const generationTimeout = window.setTimeout(
 			() => setHasTimedOut( true ),
@@ -76,12 +77,25 @@ export function useSiteGeneration( {
 					error: reason,
 				} ),
 		} );
-		const stopProgressPolling = pollForBuildProgress( {
+		// `let` so onProgress below can stop its own poller; the callback only
+		// ever fires after pollForBuildProgress has returned.
+		let stopProgressPolling = () => {};
+		stopProgressPolling = pollForBuildProgress( {
 			siteIdentifier,
-			onProgress: ( response ) =>
-				setActiveStepIndex( ( previous ) =>
-					Math.max( previous, getStepIndexForProgress( response, stepIds ) ?? 0 )
-				),
+			onProgress: ( response ) => {
+				const stepIndex = getStepIndexForProgress( response, stepIds );
+				if ( stepIndex === null ) {
+					return;
+				}
+				// Monotonic floor: the backend can reset or reorder the recorded
+				// history (heartbeats, requeues), and the UI must never move back.
+				setActiveStepIndex( ( previous ) => Math.max( previous, stepIndex ) );
+				// The last milestone is as far as this poller can advance the UI;
+				// from here readiness comes from the build-status poller alone.
+				if ( stepIndex >= stepIds.length - 1 ) {
+					stopProgressPolling();
+				}
+			},
 		} );
 
 		return () => {
@@ -89,7 +103,7 @@ export function useSiteGeneration( {
 			stopStatusPolling();
 			stopProgressPolling();
 		};
-	}, [ editorUrl, hasTimedOut, siteIdentifier, stepIds ] );
+	}, [ editorUrl, hasTimedOut, siteIdentifier, steps ] );
 
 	let failureReason: SiteGenerationFailureReason | undefined;
 	if ( ! hasRequiredParameters ) {


### PR DESCRIPTION
Part of [BIGR-655](https://linear.app/a8c/issue/BIGR-655/wpcom-show-progress-updates-so-generation-never-looks-hung)

Depends on 231333-gh-Automattic/wpcom

## Proposed Changes

* Poll persisted Generate Theme workflow events and map them to six user-facing generation stages.
* Replace timer-driven step changes with real progress while preventing the sidebar from moving backwards.
* Keep the existing build-status endpoint responsible for failure handling and redirect only after it reports the site as `live`.

## Why are these changes being made?

* Theme generation can be quiet for long periods, making the screen appear frozen. The wpcom change records workflow events; this change uses them to show real progress in place of previously faked events.
* Generation progress is kept separate from site readiness so finishing the agent workflow cannot redirect users before delivery, activation, and verification complete.

## Testing Instructions

* Apply the companion wpcom PR to a sandbox and run the asynchronous job watcher.
* Start Calypso locally and complete the Generate Theme flow.
* Confirm the sidebar advances through preparing, designing, building, images, polishing, and publishing as workflow events are recorded.
* Confirm progress reaching `done` does not redirect by itself.
* Confirm the user is redirected only after the build status becomes `live`.
* Run:

  ```sh
  yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test
  ```

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
  - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
