### PR TITLE
A4A Migrations: Disclose migration steps progressively and fix doubled underlines

### DIFF
--- a/client/a8c-for-agencies/components/task-steps/index.tsx
+++ b/client/a8c-for-agencies/components/task-steps/index.tsx
@@ -30,6 +30,7 @@ export interface TaskStepItemWithCompletion extends TaskStepItem {
 
 interface TaskStepProps {
 	step: TaskStepItemWithCompletion;
+	isExpanded: boolean;
 	toggleTaskStatus: ( step: TaskStepItem ) => void;
 }
 
@@ -40,7 +41,7 @@ interface TaskStepsProps {
 	sessionStorageKey: string;
 }
 
-export function TaskStep( { step, toggleTaskStatus }: TaskStepProps ) {
+export function TaskStep( { step, isExpanded, toggleTaskStatus }: TaskStepProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -65,7 +66,7 @@ export function TaskStep( { step, toggleTaskStatus }: TaskStepProps ) {
 					<div className="task-step__title">{ step.title }</div>
 				</div>
 			}
-			expanded={ ! step.isCompleted }
+			expanded={ isExpanded }
 			clickableHeader
 			summary={ false }
 		>
@@ -97,6 +98,16 @@ export function TaskSteps( { heading, subheading, steps, sessionStorageKey }: Ta
 	const updatedStepIds = JSON.parse( sessionStorage.getItem( sessionStorageKey ) || '[]' );
 	const [ completedStepIds, setCompletedStepIds ] = useState< string[] >( updatedStepIds );
 
+	const getStepToExpand = ( completedIds: string[], fromIndex: number ) => {
+		const isIncomplete = ( step: TaskStepItem ) => ! completedIds.includes( step.stepId );
+		const step = steps.slice( fromIndex ).find( isIncomplete ) ?? steps.find( isIncomplete );
+		return step?.stepId ?? null;
+	};
+
+	const [ expandedStepId, setExpandedStepId ] = useState< string | null >( () =>
+		getStepToExpand( updatedStepIds, 0 )
+	);
+
 	const updatedSteps = steps.map( ( step ) => {
 		return {
 			...step,
@@ -111,6 +122,10 @@ export function TaskSteps( { heading, subheading, steps, sessionStorageKey }: Ta
 			: [ ...completedStepIds, step.stepId ];
 		setCompletedStepIds( updatedStepIds );
 		sessionStorage.setItem( sessionStorageKey, JSON.stringify( updatedStepIds ) );
+		const stepIndex = steps.findIndex( ( { stepId } ) => stepId === step.stepId );
+		setExpandedStepId(
+			getStepToExpand( updatedStepIds, checkIfTaskIsCompleted ? stepIndex : stepIndex + 1 )
+		);
 		dispatch(
 			recordTracksEvent(
 				checkIfTaskIsCompleted
@@ -126,6 +141,7 @@ export function TaskSteps( { heading, subheading, steps, sessionStorageKey }: Ta
 	const resetAllTasks = () => {
 		setCompletedStepIds( [] );
 		sessionStorage.removeItem( sessionStorageKey );
+		setExpandedStepId( getStepToExpand( [], 0 ) );
 		dispatch( recordTracksEvent( 'calypso_a8c_for_agencies_reset_all_tasks' ) );
 	};
 
@@ -142,7 +158,12 @@ export function TaskSteps( { heading, subheading, steps, sessionStorageKey }: Ta
 			</div>
 			<div className="task-steps__steps">
 				{ updatedSteps.map( ( step ) => (
-					<TaskStep key={ step.stepId } step={ step } toggleTaskStatus={ toggleTaskStatus } />
+					<TaskStep
+						key={ step.stepId }
+						step={ step }
+						isExpanded={ step.stepId === expandedStepId }
+						toggleTaskStatus={ toggleTaskStatus }
+					/>
 				) ) }
 			</div>
 		</div>

--- a/client/a8c-for-agencies/components/task-steps/style.scss
+++ b/client/a8c-for-agencies/components/task-steps/style.scss
@@ -2,13 +2,6 @@
 @import '@wordpress/base-styles/mixins';
 @import '@wordpress/base-styles/variables';
 
-.task-steps {
-	a {
-		text-decoration: underline;
-		color: unset;
-	}
-}
-
 .task-steps__steps {
 	display: flex;
 	flex-direction: column;
@@ -40,6 +33,11 @@
 .task-steps__subheading {
 	@include body-large;
 	color: var( --color-accent-60 );
+
+	a {
+		text-decoration: underline;
+		color: unset;
+	}
 }
 
 .task-step {

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/style.scss
@@ -31,7 +31,6 @@
 
 			li a {
 				color: var(--color-text-black);
-				text-decoration: underline;
 			}
 		}
 	}


### PR DESCRIPTION
The Automattic for Agencies migration overview pages (`/migrations/overview/migrate-to-wpcom` and `/migrations/overview/migrate-to-pressable`) present a numbered checklist of steps. Both render the same `task-steps` accordion (via `self-migration-tool`). Two things needed attention:

1. **All steps were expanded on load.** Every section opened at once (`expanded={ ! step.isCompleted }`), so the page was a long wall of open steps with no sense of where to start or how far along you are.
2. **Doubled underlines.** Several links in the steps are the shared `ExternalLink` component, which already draws its own underline — but a stylesheet added `text-decoration: underline` on top, so they rendered with a heavy double underline. The `/migrations/commissions` "Automattic for Agencies plugin" link had the same problem.

This change:

- **Progressive disclosure.** The `task-steps` accordion now opens only the **first not-yet-completed step** on load. Marking a step done collapses it and opens the next; "Reset all tasks" returns to step 1; resetting a single task reopens it. Manual expand/collapse still works — `FoldableCard` keeps its own state, so a user can open any step by hand. Driven by a `getStepToExpand( completedIds, fromIndex )` helper and an `expandedStepId` derived from the completion set.
- **Single underlines.** The `text-decoration: underline` rule that was hitting every anchor in the steps is rescoped to `.task-steps__subheading a` — the one plain `<a>` ("contact us"), which needs its own underline — so the `ExternalLink` instances keep just their own single underline. On the commissions page, the redundant `text-decoration: underline` on `li a` is removed (color preserved).

One focused test covers the disclosure logic (first incomplete step open on load, mark-done advances, manual expand still works); it fails against the previous behavior. The underline changes are declaration removals/rescopes with no logic to test — verified via computed styles in the browser.

## Testing Instructions

Prerequisites: A4A dev environment (`yarn start-a8c-for-agencies`) on an agency that can reach the migration overview pages.

1. Open `/migrations/overview/migrate-to-wpcom` (and `/migrate-to-pressable`). Confirm only the **first incomplete step** is expanded on load; the rest are collapsed.
2. Click **"Mark as done"** on the open step. Confirm it collapses and the **next** step opens.
3. Click a collapsed step's header. Confirm it still expands/collapses manually.
4. Click **"Reset all tasks"**. Confirm the checklist returns to step 1 open.
5. Confirm the step links (e.g. "Migrate to WordPress.com plugin") and the `/migrations/commissions` "Automattic for Agencies plugin" link each show a **single** underline, not a doubled one.
