### PR TITLE
MSD Emails: unblock email forwarding for non-owner administrators

### DIFF
--- a/client/dashboard/emails/add-forwarder/index.tsx
+++ b/client/dashboard/emails/add-forwarder/index.tsx
@@ -1,10 +1,5 @@
-import { EmailProvider } from '@automattic/api-core';
-import {
-	addEmailForwarderMutation,
-	domainDnsQuery,
-	domainQuery,
-	userMailboxesQuery,
-} from '@automattic/api-queries';
+import { DomainSubtype } from '@automattic/api-core';
+import { addEmailForwarderMutation, domainDnsQuery, domainQuery } from '@automattic/api-queries';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import {
@@ -49,7 +44,7 @@ export interface FormData {
 }
 
 function AddEmailForwarder() {
-	const { basePath } = useAppContext();
+	const { basePath, queries } = useAppContext();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { recordTracksEvent } = useAnalytics();
 
@@ -58,19 +53,18 @@ function AddEmailForwarder() {
 	);
 	const navigate = useNavigate();
 
-	const { data: allEmailAccounts, isLoading: isLoadingEmailAccounts } = useQuery(
-		userMailboxesQuery()
+	const { data: allDomains, isLoading: isLoadingDomains } = useQuery( queries.domainsQuery() );
+
+	// Forwarding is free, so it doesn't depend on who owns the domain subscription — that
+	// only decides who may buy paid email. Listing the user's own domains keeps this form
+	// reachable for administrators who aren't the owner.
+	const eligibleDomains = useMemo(
+		() =>
+			( allDomains ?? [] )
+				.filter( ( d ) => d.subtype.id !== DomainSubtype.DEFAULT_ADDRESS )
+				.map( ( d ) => d.domain ),
+		[ allDomains ]
 	);
-
-	const eligibleDomains = useMemo( () => {
-		const forwardingAccounts = ( allEmailAccounts ?? [] ).filter(
-			( account ) => account.account_type === EmailProvider.Forwarding && account.can_user_add_email
-		);
-
-		return forwardingAccounts.flatMap( ( account ) =>
-			account.domains.map( ( { domain } ) => domain )
-		);
-	}, [ allEmailAccounts ] );
 
 	const [ formData, setFormData ] = useState< FormData >( {
 		localPart: '',
@@ -157,7 +151,7 @@ function AddEmailForwarder() {
 
 	const isBusy =
 		isAddingEmailForwarder ||
-		isLoadingEmailAccounts ||
+		isLoadingDomains ||
 		isLoadingDomainMaxForwards ||
 		isLoadingNewForwardingAddresses;
 	const allFieldsSet = !! formData.localPart && !! formData.domain && !! forwardingAddresses.length;
@@ -257,7 +251,7 @@ function AddEmailForwarder() {
 		);
 	};
 
-	if ( isLoadingEmailAccounts ) {
+	if ( isLoadingDomains ) {
 		return (
 			<PageLayout header={ <PageHeader prefix={ <Breadcrumbs length={ 2 } /> } /> } size="small">
 				<Spinner

--- a/client/dashboard/emails/add-forwarder/index.tsx
+++ b/client/dashboard/emails/add-forwarder/index.tsx
@@ -62,8 +62,8 @@ function AddEmailForwarder() {
 		userMailboxesQuery()
 	);
 
-	// Forwarding is free, so don't gate it on `can_user_add_email` — that only decides who
-	// may buy paid email, and it excludes administrators who don't own the domain.
+	// The endpoint emits a forwarding account for every domain that can host forwarding, whether
+	// or not any forwarders exist on it yet, so this covers the first-forwarder case too.
 	const eligibleDomains = useMemo( () => {
 		const forwardingAccounts = ( allEmailAccounts ?? [] ).filter(
 			( account ) => account.account_type === EmailProvider.Forwarding

--- a/client/dashboard/emails/add-forwarder/index.tsx
+++ b/client/dashboard/emails/add-forwarder/index.tsx
@@ -1,5 +1,10 @@
-import { DomainSubtype } from '@automattic/api-core';
-import { addEmailForwarderMutation, domainDnsQuery, domainQuery } from '@automattic/api-queries';
+import { EmailProvider } from '@automattic/api-core';
+import {
+	addEmailForwarderMutation,
+	domainDnsQuery,
+	domainQuery,
+	userMailboxesQuery,
+} from '@automattic/api-queries';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import {
@@ -44,7 +49,7 @@ export interface FormData {
 }
 
 function AddEmailForwarder() {
-	const { basePath, queries } = useAppContext();
+	const { basePath } = useAppContext();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { recordTracksEvent } = useAnalytics();
 
@@ -53,18 +58,21 @@ function AddEmailForwarder() {
 	);
 	const navigate = useNavigate();
 
-	const { data: allDomains, isLoading: isLoadingDomains } = useQuery( queries.domainsQuery() );
-
-	// Forwarding is free, so it doesn't depend on who owns the domain subscription — that
-	// only decides who may buy paid email. Listing the user's own domains keeps this form
-	// reachable for administrators who aren't the owner.
-	const eligibleDomains = useMemo(
-		() =>
-			( allDomains ?? [] )
-				.filter( ( d ) => d.subtype.id !== DomainSubtype.DEFAULT_ADDRESS )
-				.map( ( d ) => d.domain ),
-		[ allDomains ]
+	const { data: allEmailAccounts, isLoading: isLoadingEmailAccounts } = useQuery(
+		userMailboxesQuery()
 	);
+
+	// Forwarding is free, so don't gate it on `can_user_add_email` — that only decides who
+	// may buy paid email, and it excludes administrators who don't own the domain.
+	const eligibleDomains = useMemo( () => {
+		const forwardingAccounts = ( allEmailAccounts ?? [] ).filter(
+			( account ) => account.account_type === EmailProvider.Forwarding
+		);
+
+		return forwardingAccounts.flatMap( ( account ) =>
+			account.domains.map( ( { domain } ) => domain )
+		);
+	}, [ allEmailAccounts ] );
 
 	const [ formData, setFormData ] = useState< FormData >( {
 		localPart: '',
@@ -151,7 +159,7 @@ function AddEmailForwarder() {
 
 	const isBusy =
 		isAddingEmailForwarder ||
-		isLoadingDomains ||
+		isLoadingEmailAccounts ||
 		isLoadingDomainMaxForwards ||
 		isLoadingNewForwardingAddresses;
 	const allFieldsSet = !! formData.localPart && !! formData.domain && !! forwardingAddresses.length;
@@ -251,7 +259,7 @@ function AddEmailForwarder() {
 		);
 	};
 
-	if ( isLoadingDomains ) {
+	if ( isLoadingEmailAccounts ) {
 		return (
 			<PageLayout header={ <PageHeader prefix={ <Breadcrumbs length={ 2 } /> } /> } size="small">
 				<Spinner

--- a/client/dashboard/emails/add-forwarder/test/index.test.tsx
+++ b/client/dashboard/emails/add-forwarder/test/index.test.tsx
@@ -1,28 +1,29 @@
 /**
  * @jest-environment jsdom
  */
-import { EmailProvider } from '@automattic/api-core';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { render } from '../../../test-utils';
 import AddEmailForwarder from '../index';
-import type { EmailAccount } from '@automattic/api-core';
+import type { DomainSummary } from '@automattic/api-core';
 
 const DOMAIN = 'example.com';
 
-function mockApi() {
+function mockApi( { domains }: { domains?: DomainSummary[] } = {} ) {
 	// Eligible forwarding domain so the form renders.
 	nock( 'https://public-api.wordpress.com' )
-		.get( '/rest/v1/me/mailboxes' )
+		.get( '/rest/v1.2/all-domains' )
 		.query( true )
-		.reply( 200, [
-			{
-				account_type: EmailProvider.Forwarding,
-				can_user_add_email: true,
-				domains: [ { domain: DOMAIN } ],
-			},
-		] as EmailAccount[] );
+		.reply( 200, {
+			domains: domains ?? [
+				{
+					domain: DOMAIN,
+					subtype: { id: 'domain_registration', label: 'Domain Registration' },
+					current_user_is_owner: true,
+				} as DomainSummary,
+			],
+		} );
 
 	// Existing forwarders for the eligible domain (queried on render).
 	nock( 'https://public-api.wordpress.com' )
@@ -76,5 +77,42 @@ describe( '<AddEmailForwarder>', () => {
 		expect( screen.getByText( 'first@example.com' ) ).toBeVisible();
 		expect( screen.getByText( 'second@example.com' ) ).toBeVisible();
 		expect( screen.queryByText( 'Please enter a valid email address.' ) ).not.toBeInTheDocument();
+	} );
+
+	// DOTMSD-1477
+	test( 'offers a domain the user administers but does not own', async () => {
+		mockApi( {
+			domains: [
+				{
+					domain: DOMAIN,
+					subtype: { id: 'domain_registration', label: 'Domain Registration' },
+					current_user_is_owner: false,
+				} as DomainSummary,
+			],
+		} );
+		render( <AddEmailForwarder /> );
+
+		expect( await screen.findByLabelText( 'Forward to' ) ).toBeVisible();
+		expect( screen.getByRole( 'option', { name: DOMAIN } ) ).toBeInTheDocument();
+		expect(
+			screen.queryByText( 'You do not have any domains eligible for email forwarding.' )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'keeps the empty state when the user only has a default address', async () => {
+		mockApi( {
+			domains: [
+				{
+					domain: 'example.wordpress.com',
+					subtype: { id: 'default_address', label: 'Default Address' },
+					current_user_is_owner: true,
+				} as DomainSummary,
+			],
+		} );
+		render( <AddEmailForwarder /> );
+
+		expect(
+			await screen.findByText( 'You do not have any domains eligible for email forwarding.' )
+		).toBeVisible();
 	} );
 } );

--- a/client/dashboard/emails/add-forwarder/test/index.test.tsx
+++ b/client/dashboard/emails/add-forwarder/test/index.test.tsx
@@ -1,29 +1,31 @@
 /**
  * @jest-environment jsdom
  */
+import { EmailProvider } from '@automattic/api-core';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { render } from '../../../test-utils';
 import AddEmailForwarder from '../index';
-import type { DomainSummary } from '@automattic/api-core';
+import type { EmailAccount } from '@automattic/api-core';
 
 const DOMAIN = 'example.com';
 
-function mockApi( { domains }: { domains?: DomainSummary[] } = {} ) {
+function mockApi( { accounts }: { accounts?: EmailAccount[] } = {} ) {
 	// Eligible forwarding domain so the form renders.
 	nock( 'https://public-api.wordpress.com' )
-		.get( '/rest/v1.2/all-domains' )
+		.get( '/rest/v1/me/mailboxes' )
 		.query( true )
-		.reply( 200, {
-			domains: domains ?? [
+		.reply(
+			200,
+			accounts ?? [
 				{
-					domain: DOMAIN,
-					subtype: { id: 'domain_registration', label: 'Domain Registration' },
-					current_user_is_owner: true,
-				} as DomainSummary,
-			],
-		} );
+					account_type: EmailProvider.Forwarding,
+					can_user_add_email: true,
+					domains: [ { domain: DOMAIN } ],
+				},
+			]
+		);
 
 	// Existing forwarders for the eligible domain (queried on render).
 	nock( 'https://public-api.wordpress.com' )
@@ -80,14 +82,14 @@ describe( '<AddEmailForwarder>', () => {
 	} );
 
 	// DOTMSD-1477
-	test( 'offers a domain the user administers but does not own', async () => {
+	test( 'offers a domain the user cannot buy paid email for', async () => {
 		mockApi( {
-			domains: [
+			accounts: [
 				{
-					domain: DOMAIN,
-					subtype: { id: 'domain_registration', label: 'Domain Registration' },
-					current_user_is_owner: false,
-				} as DomainSummary,
+					account_type: EmailProvider.Forwarding,
+					can_user_add_email: false,
+					domains: [ { domain: DOMAIN } ],
+				} as EmailAccount,
 			],
 		} );
 		render( <AddEmailForwarder /> );
@@ -99,16 +101,8 @@ describe( '<AddEmailForwarder>', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	test( 'keeps the empty state when the user only has a default address', async () => {
-		mockApi( {
-			domains: [
-				{
-					domain: 'example.wordpress.com',
-					subtype: { id: 'default_address', label: 'Default Address' },
-					current_user_is_owner: true,
-				} as DomainSummary,
-			],
-		} );
+	test( 'keeps the empty state when no domain supports forwarding', async () => {
+		mockApi( { accounts: [] } );
 		render( <AddEmailForwarder /> );
 
 		expect(

--- a/client/dashboard/emails/choose-domain/index.tsx
+++ b/client/dashboard/emails/choose-domain/index.tsx
@@ -28,8 +28,10 @@ export default function ChooseDomain() {
 	const router = useRouter();
 
 	const { data: allDomains, isLoading: isLoading } = useQuery( queries.domainsQuery() );
+	// Non-owners are allowed through: the next step explains what they can't buy via
+	// EmailNonDomainOwnerNotice rather than hiding the domain outright.
 	const eligibleDomains = ( allDomains ?? [] ).filter(
-		( d ) => d.current_user_is_owner && d.subtype.id !== DomainSubtype.DEFAULT_ADDRESS
+		( d ) => d.subtype.id !== DomainSubtype.DEFAULT_ADDRESS
 	);
 
 	const { recordTracksEvent } = useAnalytics();

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -1,4 +1,4 @@
-import { DomainSubtype, EmailBox } from '@automattic/api-core';
+import { DomainSubtype } from '@automattic/api-core';
 import { userMailboxesQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
@@ -33,8 +33,6 @@ function Emails() {
 	const { data: allEmailAccounts } = useSuspenseQuery( userMailboxesQuery() );
 	const { domainName: domainNameFilter }: { domainName?: string } = emailsRoute.useSearch();
 	const { data: allDomains } = useSuspenseQuery( queries.domainsQuery() );
-	// Domain ownership gates buying paid email, not managing email on the domain, so
-	// administrators who don't own the domain still belong here.
 	const domains = ( allDomains ?? [] ).filter(
 		( d ) => d.subtype.id !== DomainSubtype.DEFAULT_ADDRESS
 	);
@@ -46,13 +44,13 @@ function Emails() {
 		return domains.filter( ( d ) => domainsWithEmailsList.includes( d.domain ) );
 	}, [ allEmailAccounts, domains ] );
 
-	const emails: Email[] = useMemo( () => {
+	const emails = useMemo( () => {
 		if ( ! allEmailAccounts?.length ) {
 			return [];
 		}
 		return allEmailAccounts.flatMap( ( account ) =>
-			account.emails.map( ( box: EmailBox ) => mapMailboxToEmail( box, account ) )
-		) as Email[];
+			account.emails.map( ( box ) => mapMailboxToEmail( box, account ) )
+		);
 	}, [ allEmailAccounts ] );
 
 	// Gather domains with unused mailbox warnings

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -33,8 +33,10 @@ function Emails() {
 	const { data: allEmailAccounts } = useSuspenseQuery( userMailboxesQuery() );
 	const { domainName: domainNameFilter }: { domainName?: string } = emailsRoute.useSearch();
 	const { data: allDomains } = useSuspenseQuery( queries.domainsQuery() );
+	// Domain ownership gates buying paid email, not managing email on the domain, so
+	// administrators who don't own the domain still belong here. See DOTMSD-1477.
 	const domains = ( allDomains ?? [] ).filter(
-		( d ) => d.current_user_is_owner && d.subtype.id !== DomainSubtype.DEFAULT_ADDRESS
+		( d ) => d.subtype.id !== DomainSubtype.DEFAULT_ADDRESS
 	);
 
 	// Aggregate all domains into a single array
@@ -48,11 +50,9 @@ function Emails() {
 		if ( ! allEmailAccounts?.length ) {
 			return [];
 		}
-		return allEmailAccounts
-			.flatMap( ( account ) =>
-				account.emails.map( ( box: EmailBox ) => mapMailboxToEmail( box, account ) )
-			)
-			.filter( ( email ) => email.canUserManage ) as Email[];
+		return allEmailAccounts.flatMap( ( account ) =>
+			account.emails.map( ( box: EmailBox ) => mapMailboxToEmail( box, account ) )
+		) as Email[];
 	}, [ allEmailAccounts ] );
 
 	// Gather domains with unused mailbox warnings

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -34,7 +34,7 @@ function Emails() {
 	const { domainName: domainNameFilter }: { domainName?: string } = emailsRoute.useSearch();
 	const { data: allDomains } = useSuspenseQuery( queries.domainsQuery() );
 	// Domain ownership gates buying paid email, not managing email on the domain, so
-	// administrators who don't own the domain still belong here. See DOTMSD-1477.
+	// administrators who don't own the domain still belong here.
 	const domains = ( allDomains ?? [] ).filter(
 		( d ) => d.subtype.id !== DomainSubtype.DEFAULT_ADDRESS
 	);

--- a/client/dashboard/emails/mappers/mailbox-to-email-mapper.ts
+++ b/client/dashboard/emails/mappers/mailbox-to-email-mapper.ts
@@ -41,6 +41,5 @@ export const mapMailboxToEmail = ( box: EmailBox, emailAccount: EmailAccount ): 
 		providerDisplayName,
 		domainName: box.domain,
 		status,
-		canUserManage: emailAccount.can_user_add_email,
 	};
 };

--- a/client/dashboard/emails/test/index.test.tsx
+++ b/client/dashboard/emails/test/index.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { EmailProvider } from '@automattic/api-core';
+import { screen } from '@testing-library/react';
+import nock from 'nock';
+import { render } from '../../test-utils';
+import Emails from '../index';
+import type { DomainSummary, EmailAccount } from '@automattic/api-core';
+
+jest.mock( '../../app/router/emails', () => {
+	const actual = jest.requireActual( '../../app/router/emails' );
+	return {
+		...actual,
+		emailsRoute: {
+			...actual.emailsRoute,
+			useSearch: () => ( {} ),
+		},
+	};
+} );
+
+const DOMAIN = 'cool.webrw.blog';
+
+// A domain the current user administers but does not own, as returned by /all-domains.
+const nonOwnedDomain = {
+	domain: DOMAIN,
+	blog_id: 1,
+	blog_name: 'webrw',
+	site_slug: 'webrw.blog',
+	subtype: { id: 'domain_registration', label: 'Domain Registration' },
+	current_user_is_owner: false,
+} as DomainSummary;
+
+const forwardingAccount = {
+	account_type: EmailProvider.Forwarding,
+	// The domain owner holds the subscription, so this user cannot buy paid email.
+	can_user_add_email: false,
+	status: 'active',
+	warnings: [],
+	domains: [ { domain: DOMAIN, is_primary: true } ],
+	emails: [
+		{
+			mailbox: 'yea',
+			domain: DOMAIN,
+			target: 'someone@example.com',
+			email_type: 'email_forward',
+			role: 'standard',
+			warnings: [],
+		},
+	],
+} as unknown as EmailAccount;
+
+function mockApi( { domains, accounts }: { domains: DomainSummary[]; accounts: EmailAccount[] } ) {
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( '/rest/v1.1/me/preferences' )
+		.query( true )
+		.reply( 200, { calypso_preferences: {} } );
+
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.2/all-domains' )
+		.query( true )
+		.reply( 200, { domains } );
+
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1/me/mailboxes' )
+		.query( true )
+		.reply( 200, accounts );
+}
+
+describe( '<Emails>', () => {
+	// DOTMSD-1477
+	test( 'lists forwards on a domain the user administers but does not own', async () => {
+		mockApi( { domains: [ nonOwnedDomain ], accounts: [ forwardingAccount ] } );
+		render( <Emails /> );
+
+		expect( await screen.findByText( `yea@${ DOMAIN }` ) ).toBeVisible();
+		expect( screen.queryByText( 'You need a domain to set up email' ) ).not.toBeInTheDocument();
+	} );
+
+	// DOTMSD-1477
+	test( 'does not claim the user has no domain when they only administer one', async () => {
+		mockApi( { domains: [ nonOwnedDomain ], accounts: [] } );
+		render( <Emails /> );
+
+		expect( await screen.findByText( 'Set up email for your domain' ) ).toBeVisible();
+		expect( screen.queryByText( 'You need a domain to set up email' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'shows the no-domain empty state when the user has only a default address', async () => {
+		mockApi( {
+			domains: [
+				{
+					...nonOwnedDomain,
+					domain: 'webrw.wordpress.com',
+					subtype: { id: 'default_address', label: 'Default Address' },
+				} as DomainSummary,
+			],
+			accounts: [],
+		} );
+		render( <Emails /> );
+
+		expect( await screen.findByText( 'You need a domain to set up email' ) ).toBeVisible();
+	} );
+} );

--- a/client/dashboard/emails/test/index.test.tsx
+++ b/client/dashboard/emails/test/index.test.tsx
@@ -63,9 +63,11 @@ function mockApi( { domains, accounts }: { domains: DomainSummary[]; accounts: E
 		.query( true )
 		.reply( 200, { domains } );
 
+	// The flag is what makes the endpoint report domains the user manages but doesn't own,
+	// so match on it rather than accepting any query.
 	nock( 'https://public-api.wordpress.com' )
 		.get( '/rest/v1/me/mailboxes' )
-		.query( true )
+		.query( ( q ) => q.include_all_managed_domains === 'true' )
 		.reply( 200, accounts );
 }
 

--- a/client/dashboard/emails/types.ts
+++ b/client/dashboard/emails/types.ts
@@ -13,7 +13,6 @@ export interface Email {
 	forwardingTo?: string;
 	storageUsed?: number;
 	storageLimit?: number;
-	canUserManage: boolean;
 	status:
 		| 'active'
 		| 'pending'

--- a/packages/api-core/src/me-mailboxes/fetchers.tsx
+++ b/packages/api-core/src/me-mailboxes/fetchers.tsx
@@ -2,5 +2,10 @@ import { EmailAccount } from '../emails';
 import { wpcom } from '../wpcom-fetcher';
 
 export async function fetchUserMailboxes(): Promise< EmailAccount[] > {
-	return await wpcom.req.get( { path: '/me/mailboxes', apiVersion: '1' } );
+	// Without this the response omits domains the user manages but doesn't own the
+	// subscription for, hiding their email from site administrators.
+	return await wpcom.req.get(
+		{ path: '/me/mailboxes', apiVersion: '1' },
+		{ include_all_managed_domains: true }
+	);
 }


### PR DESCRIPTION
Fixes DOTMSD-1477

Depends on the WPCom-side change that adds `include_all_managed_domains` to `/me/mailboxes`.

## Proposed Changes

* Ask `/me/mailboxes` for all domains the user manages, not only those they could buy paid email for.
* Stop filtering the Emails page and the email domain picker by domain ownership.
* Stop dropping mailbox and forwarder rows for users who can't purchase paid email.
* Stop gating the Add email forwarder domain picker on that same purchase flag.

## Why are these changes being made?

A site Administrator who doesn't own the site's domain opened Emails and was told "You need a domain to set up email". Going to Add email forwarder told them "You do not have any domains eligible for email forwarding". Both dead ends, with none of the site's existing forwarders listed. The owner saw everything normally.

Four things were gating free email forwarding on signals that describe who may *buy paid* email:

* `/me/mailboxes` omitted domains the user manages but doesn't hold the subscription for, so the page had no email accounts to show at all.
* The Emails page filtered the domain list by whether the current user owns the domain. For a non-owner that list came back empty, which the page reads as "this user has no domains at all".
* It then dropped every row whose account was flagged as not purchasable by this user.
* The forwarder form built its domain list from accounts carrying that same flag.

Ownership decides who may buy Professional Email or Google Workspace. It says nothing about managing forwarding, which is free, and administrators are documented as being able to manage it. This is the same distinction #110622 drew for the classic email comparison page, applied to the dashboard.

Measured against a real non-owner administrator before the fix: `/all-domains` returned the domain with `current_user_is_owner: false`, `/me/mailboxes` returned `[]`, while both `/domains/{domain}/email` and `/sites/{blogId}/emails/accounts/{domain}/mailboxes` returned the forwarder — the last with `can_user_add_email: false`. So the user was always allowed to read their own forwarder; the page just asked the one endpoint that withheld it.

## Considerations

The removed row filter was the only consumer of the "can this user add email" flag on the mailbox model — no action was gated on it, so it served purely to hide rows. Dropped rather than repurposed. Authorization for anything a user then attempts is still enforced server-side, and accounts now arrive with that flag set to `false` for non-owners rather than being withheld.

The forwarder picker keeps sourcing its domains from `/me/mailboxes` rather than from the domains list. The endpoint emits a forwarding account per domain that can host forwarding, whether or not any forwarders exist yet, so restricted cases — Gravatar domains, `domain-state-restricted` — stay out of the picker instead of being offered and then rejected on submit. Only the purchase-flag condition was removed.

Letting non-owners into the mailbox domain picker is safe because the screen it leads to was already built for them: it marks the paid providers unavailable and explains why. It just was never reachable.

`include_all_managed_domains` is sent unconditionally. The endpoint has one consumer, the Emails page, which wants every domain the user manages; there's no caller that benefits from the narrower response.

The alternative was to drop `/me/mailboxes` and fan out `mailboxAccountsQuery( blogId, domain )` per domain, which is what this page did before #106691 (DOTMSD-638) consolidated it into one call. Fixing the endpoint keeps that consolidation instead of reverting it.

## Testing Instructions

Verified against a local dev server as a site Administrator who does not own the domain, with the API change in place:

* Emails lists the domain's forwarder, where before it showed "You need a domain to set up email".
* The request goes out as `/rest/v1/me/mailboxes?include_all_managed_domains=true` and comes back with the account.
* Add email forwarder renders the form with the custom domain in the picker, where before it showed "You do not have any domains eligible for email forwarding".
* The row's actions offer Resend verification, Edit forwarder and Delete forwarder.

To reproduce:

* On a site with an email forwarder on its custom domain, invite a second user as Administrator.
* Log in as that administrator and open Emails, then Add email forwarder.
* Confirm the site owner's view is unchanged.
* Confirm a user whose only domain is the free `*.wordpress.com` address still sees the "no domain" empty state.
* Unit tests: `yarn test-client client/dashboard/emails`

The first-forwarder case is covered too: with every forwarder removed from the domain, the endpoint still returns a forwarding account for it (`emails: []`), so the domain stays in the picker and an administrator can create the first one. That was the original DOTDEV-406 complaint.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
