### PR TITLE
A4A Licenses: Push instead of replace when navigating from a license row

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -168,7 +168,7 @@ export default function LicensePreview( {
 			return;
 		}
 
-		page.redirect( redirectUrl );
+		page( redirectUrl );
 	}, [ isWPCOMLicense, licenseKey, paymentMethodRequired, referral, translate, dispatch ] );
 
 	useEffect( () => {


### PR DESCRIPTION
On the Licenses list (`/purchases/licenses`), clicking **"Create site"** (WordPress.com licenses) or **"Assign"** (other licenses) from a **collapsed** license row runs a shared callback in `LicensePreview` that navigated with `page.redirect( redirectUrl )`. In `@automattic/calypso-router`, single-argument `page.redirect()` is `page.replace()` → `history.replaceState` — so `/sites/need-setup` (or the assign flow) **replaced** the `/purchases/licenses` history entry instead of pushing a new one.

Because the licenses entry is destroyed, clicking the browser **Back** button lands on **`/overview`** — the entry that happened to precede licenses (the post-sign-in landing) — instead of returning to `/licenses`. The user is sent to a page they never navigated to. The same action from the **expanded** license details uses `href={ redirectUrl }` (which pushes), so the collapsed and expanded controls had opposite history semantics.

This change uses `page( redirectUrl )` (push) instead of `page.redirect( redirectUrl )` (replace) for that user-initiated navigation, so Back returns to `/licenses`. It's a shared callback, so the one change fixes both the "Create site" and "Assign" branches. The other `page.redirect` in the component (which strips a `?highlight=` query param on load) is left as a replace — that one is a URL-correction and should not add a history entry.

Known separate issue (not addressed here): the "Assign" path currently needs **two** Backs, because `/marketplace/assign-license` pushes an extra history entry when it syncs `?search=&page=1` into its own URL on mount. That's pre-existing behavior in the assign-license page (previously hidden behind the replace) and is a distinct fix.

Fixes [A4A-3113](https://linear.app/a8c/issue/A4A-3113).

## Testing Instructions

Prerequisites: A4A dev environment (`yarn start-a8c-for-agencies`) or this PR's calypso.live build, signed in to an agency that has at least one **unassigned** license.

1. Navigate to `/overview`, then via the sidebar to **Purchases → Licenses** (`/purchases/licenses`).
2. On a **collapsed** unassigned **WordPress.com** license row, click **"Create site"** (goes to `/sites/need-setup`).
3. Click the browser **Back** button. Confirm you return to **`/purchases/licenses`** (not `/overview`).
4. Repeat with a non-WordPress.com unassigned license's **"Assign"** and confirm Back returns toward `/licenses` (note the separate two-Backs caveat above for the assign flow).
