### PR TITLE
Purchase management: Unify and fix the action components and URL constructors for switching to a new product

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/get-plan-change-action.ts
+++ b/client/dashboard/me/billing-purchases/purchase-settings/get-plan-change-action.ts
@@ -1,0 +1,42 @@
+import { __ } from '@wordpress/i18n';
+import { getWpcomPlanChangeTarget } from '../../../utils/site-url';
+import type { WpcomPlanChangeInput, WpcomPlanChangeTarget } from '../../../utils/site-url';
+import type { Purchase } from '@automattic/api-core';
+
+export interface PlanChangeAction extends WpcomPlanChangeTarget {
+	title: string;
+	description: string;
+}
+
+export type PlanChangeActionInput = WpcomPlanChangeInput;
+
+/**
+ * The single "pick a different plan" action for a WordPress.com plan, shared by
+ * the dashboard and legacy manage-purchase screens so the label and the
+ * destination can't disagree. Returns `null` when there is no such action to
+ * offer.
+ *
+ * Callers are responsible for checking that the user has permission to perform
+ * the action.
+ */
+export function getPlanChangeAction(
+	purchase: Purchase,
+	input: PlanChangeActionInput
+): PlanChangeAction | null {
+	const target = getWpcomPlanChangeTarget( purchase, input );
+	if ( ! target ) {
+		return null;
+	}
+
+	return target.offersDowngrades
+		? {
+				...target,
+				title: __( 'Change plan' ),
+				description: __( 'Upgrade or downgrade to a plan that works for you.' ),
+		  }
+		: {
+				...target,
+				title: __( 'Upgrade plan' ),
+				description: __( 'Find the best fit for your needs.' ),
+		  };
+}

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -4,7 +4,6 @@ import {
 	WPCOM_DIFM_LITE,
 	OFFSITE_REDIRECT,
 	DomainTransferStatus,
-	SubscriptionBillPeriod,
 } from '@automattic/api-core';
 import {
 	domainQuery,
@@ -18,6 +17,7 @@ import {
 } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { domainManagementEdit, domainUseMyDomain } from '@automattic/domains-table/src/utils/paths';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import { INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS } from '@automattic/urls';
 import { useQuery, useMutation, useSuspenseQuery } from '@tanstack/react-query';
@@ -49,7 +49,6 @@ import {
 	info,
 	check,
 } from '@wordpress/icons';
-import { addQueryArgs } from '@wordpress/url';
 import { useAnalytics } from '../../../app/analytics';
 import { useAuth } from '../../../app/auth';
 import Breadcrumbs from '../../../app/breadcrumbs';
@@ -61,7 +60,6 @@ import {
 	changePaymentMethodRoute,
 	purchaseSettingsRoute,
 } from '../../../app/router/me';
-import { getCurrentDashboard } from '../../../app/routing';
 import { withSnackbar } from '../../../app/snackbars/with-snackbar';
 import { ActionList } from '../../../components/action-list';
 import { Card, CardBody } from '../../../components/card';
@@ -108,7 +106,7 @@ import {
 	hasAmountAvailableToRefund,
 } from '../../../utils/purchase';
 import {
-	getChangedPlanRedirectUrl,
+	getPurchaseSettingsRedirectBase,
 	getSitePurchaseUpgradeUrl,
 	getSitePurchaseStorageUpgradeUrl,
 	getUpgradedPurchaseRedirectUrl,
@@ -125,6 +123,7 @@ import {
 	isEmailPlanManagementEnabled,
 } from './email-plan';
 import { getCancelButtonCopy, getRemoveButtonCopy } from './get-cancel-remove-copy';
+import { getPlanChangeAction } from './get-plan-change-action';
 import JetpackLicenseKeyCard from './jetpack-license-key-card';
 import { PurchaseNotice } from './purchase-notice';
 import type { User, Purchase, Site, CancellationFeature } from '@automattic/api-core';
@@ -141,48 +140,75 @@ function renewPurchase( purchase: Purchase ): void {
 	window.location.href = getRenewalUrlFromPurchase( purchase );
 }
 
-function getExpiredNewPlanUrl( purchase: Purchase ): string {
-	if ( purchase.is_jetpack_plan_or_product ) {
-		return wpcomLink( `/plans/${ purchase.site_slug }` );
+/** Where to send anything that isn't a WordPress.com plan to upgrade. */
+function getNonPlanUpgradeAction(
+	purchase: Purchase
+): { href: string; title: string } | undefined {
+	if ( ! purchase.is_upgradable ) {
+		return undefined;
 	}
-
-	if ( purchase.is_plan ) {
-		return getWpcomPlanGridUrl( purchase );
+	// Titan email upgrades route through the flag-gated tier grid; without the flag
+	// the upgrade URL would fall through to the wrong (site plan) page.
+	if ( isTitanMail( purchase ) && ! config.isEnabled( 'emails/titan-tiers' ) ) {
+		return undefined;
 	}
-
-	return wpcomLink( `/plans/${ purchase.site_slug }` );
+	const href = getSitePurchaseUpgradeUrl( purchase, getUpgradedPurchaseRedirectUrl() );
+	return href
+		? {
+				href,
+				// Jetpack plans are plans too, even though they route through here
+				// rather than the WordPress.com plan-change helper.
+				title: purchase.is_plan ? __( 'Upgrade plan' ) : __( 'Upgrade subscription' ),
+		  }
+		: undefined;
 }
 
-// Map the purchase's billing term to the plans grid's `intervalType` param so the
-// grid opens on the same term as the current plan. Downgrades only work within the
-// same term, and the grid hides the term selector in the downgrade flow.
-function getPlanGridIntervalType( purchase: Purchase ): string | undefined {
-	switch ( purchase.bill_period_days ) {
-		case SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD:
-			return 'monthly';
-		case SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD:
-			return 'yearly';
-		case SubscriptionBillPeriod.PLAN_BIENNIAL_PERIOD:
-			return '2yearly';
-		case SubscriptionBillPeriod.PLAN_TRIENNIAL_PERIOD:
-			return '3yearly';
-		default:
-			return undefined;
-	}
+/** Whether the storage upgrade action is offered. */
+function isStorageUpgradeShown( purchase: Purchase ): boolean {
+	return isStorageUpgradeEligible( purchase ) && ! isExpiredOrRemoved( purchase );
 }
 
-function getWpcomPlanGridUrl( purchase: Purchase ): string {
-	const backUrl = redirectToDashboardLink();
-	const siteSlug = purchase.site_slug;
-	const intervalType = getPlanGridIntervalType( purchase );
-	return addQueryArgs( wpcomLink( '/setup/plan-upgrade' ), {
-		...( siteSlug && { siteSlug } ),
-		...( intervalType && { intervalType } ),
-		cancel_to: backUrl,
-		dashboard: getCurrentDashboard(),
-		redirect_to: getChangedPlanRedirectUrl(),
-		allow_downgrade: 'true',
+/**
+ * The label for the control that starts an upgrade — the body button, the header
+ * CTA and the quick-actions menu item.
+ *
+ * Usually just "Upgrade", since the surrounding title already says what is being
+ * upgraded. The exception is when the storage upgrade action is alongside it, in
+ * which case the label has to name what it upgrades so the two can be told apart.
+ */
+function getUpgradeControlLabel(
+	purchase: Purchase,
+	distinguishingLabel: string,
+	hasEnTranslation: ( single: string, context?: string ) => boolean
+): string {
+	if ( isStorageUpgradeShown( purchase ) ) {
+		return distinguishingLabel;
+	}
+	// "Upgrade" under this context is new to this codebase, so it is not
+	// translated here yet. Until it syncs, fall back to the longer label, which
+	// is translated everywhere.
+	return hasEnTranslation( 'Upgrade', 'Call to action to buy a new plan' )
+		? _x( 'Upgrade', 'Call to action to buy a new plan' )
+		: distinguishingLabel;
+}
+
+/**
+ * Label and destination for the header CTA and quick-actions menu, which promote
+ * upgrades only — offering downgrades is the body action's job.
+ */
+function getHeaderUpgradeAction( purchase: Purchase ): { href: string; title: string } | undefined {
+	// WordPress.com plans go through the shared helper. A plan that gets nothing
+	// back has no upgrade to offer, and the non-plan path rejects it too.
+	const planAction = getPlanChangeAction( purchase, {
+		upgradeOnly: true,
+		cancelTo: redirectToDashboardLink(),
+		redirectTo: getPurchaseSettingsRedirectBase(),
 	} );
+	if ( planAction ) {
+		return { href: planAction.href, title: planAction.title };
+	}
+
+	return getNonPlanUpgradeAction( purchase );
 }
 
 function isAutoRenewToggleDisabled( purchase: Purchase, user: User ): boolean {
@@ -228,42 +254,40 @@ function ProductLink( { purchase }: { purchase: Purchase } ) {
 }
 
 function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
+	const hasEnTranslation = useHasEnTranslation();
 	const { user } = useAuth();
 	const isOwner = String( user.ID ) === String( purchase.user_id );
 	const canBeRenewed = purchase.can_explicit_renew && isOwner;
-	const upgradeUrl = getSitePurchaseUpgradeUrl( purchase, getUpgradedPurchaseRedirectUrl() );
+	const upgradeAction = getHeaderUpgradeAction( purchase );
 	const storageUpgradeUrl = getSitePurchaseStorageUpgradeUrl( purchase );
 	const { recordTracksEvent } = useAnalytics();
 	const menuItems = [
-		canUpgradePurchase( purchase ) && upgradeUrl && isOwner && (
+		upgradeAction && isOwner && (
 			<MenuItem
 				onClick={ () => {
 					recordTracksEvent( 'calypso_purchases_upgrade_plan', {
 						status: isExpiredOrRemoved( purchase ) ? 'expired' : 'active',
 						plan: purchase.product_name,
 					} );
-					upgradePurchase( upgradeUrl );
+					upgradePurchase( upgradeAction.href );
 				} }
 			>
-				{ _x( 'Upgrade plan', 'Change to a plan with more features.' ) }
+				{ getUpgradeControlLabel( purchase, upgradeAction.title, hasEnTranslation ) }
 			</MenuItem>
 		),
-		isStorageUpgradeEligible( purchase ) &&
-			storageUpgradeUrl &&
-			isOwner &&
-			! isExpiredOrRemoved( purchase ) && (
-				<MenuItem
-					onClick={ () => {
-						recordTracksEvent( 'calypso_purchases_upgrade_storage', {
-							status: isExpiredOrRemoved( purchase ) ? 'expired' : 'active',
-							plan: purchase.product_name,
-						} );
-						upgradePurchase( storageUpgradeUrl );
-					} }
-				>
-					{ _x( 'Upgrade storage', 'Buy more storage space for the subscription.' ) }
-				</MenuItem>
-			),
+		isStorageUpgradeShown( purchase ) && storageUpgradeUrl && isOwner && (
+			<MenuItem
+				onClick={ () => {
+					recordTracksEvent( 'calypso_purchases_upgrade_storage', {
+						status: isExpiredOrRemoved( purchase ) ? 'expired' : 'active',
+						plan: purchase.product_name,
+					} );
+					upgradePurchase( storageUpgradeUrl );
+				} }
+			>
+				{ _x( 'Upgrade storage', 'Buy more storage space for the subscription.' ) }
+			</MenuItem>
+		),
 		canBeRenewed && (
 			<MenuItem
 				onClick={ () => {
@@ -423,84 +447,13 @@ export function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase }
 	);
 }
 
-/**
- * Whether the "Change plan" action should be offered for this purchase. Covers
- * three downgrade flows, each gated by its own flag:
- *   - past expiry (downgrade-to-checkout) — `plans/expired-downgrade`
- *   - within refund window (instant downgrade) — `plans/expired-downgrade`
- *   - active downgradable plan (delayed downgrade) — `plans/delayed-downgrade`
- */
-function shouldShowChangePlan( purchase: Purchase ): boolean {
-	if ( ! purchase.is_plan || ! purchase.is_plan_type_downgradable ) {
-		return false;
-	}
-	const expiredOrRefundDowngrade =
-		config.isEnabled( 'plans/expired-downgrade' ) &&
-		( purchase.is_past_expiry_date || isWithinRefundWindowDowngradeEligible( purchase ) );
-	const delayedDowngrade = config.isEnabled( 'plans/delayed-downgrade' );
-	return expiredOrRefundDowngrade || delayedDowngrade;
-}
-
-// Titan email upgrades route through the flag-gated tier grid; without the flag the
-// upgrade URL would fall through to the wrong (site plan) page, so hide the action.
-function canUpgradePurchase( purchase: Purchase ): boolean {
-	if ( ! purchase.is_upgradable ) {
-		return false;
-	}
-	if ( isTitanMail( purchase ) && ! config.isEnabled( 'emails/titan-tiers' ) ) {
-		return false;
-	}
-	return true;
-}
-
-function UpgradeActionButton( { purchase }: { purchase: Purchase } ) {
-	const { user } = useAuth();
-	const { recordTracksEvent } = useAnalytics();
-	if ( String( user.ID ) !== String( purchase.user_id ) ) {
-		return null;
-	}
-	if ( ! canUpgradePurchase( purchase ) ) {
-		return null;
-	}
-	// When "Change plan" is offered (downgrade-eligible), it supersedes the
-	// upgrade action — matching the classic purchases page.
-	if ( shouldShowChangePlan( purchase ) ) {
-		return null;
-	}
-	const upgradeUrl = getSitePurchaseUpgradeUrl( purchase, getUpgradedPurchaseRedirectUrl() );
-	if ( ! upgradeUrl ) {
-		return null;
-	}
-	return (
-		<ActionList.ActionItem
-			title={ __( 'Upgrade subscription' ) }
-			description={ __( 'Find the best fit for your needs.' ) }
-			actions={
-				<Button
-					variant="secondary"
-					size="compact"
-					onClick={ () => {
-						recordTracksEvent( 'calypso_purchases_upgrade_plan', {
-							status: isExpiredOrRemoved( purchase ) ? 'expired' : 'active',
-							plan: purchase.product_name,
-						} );
-						upgradePurchase( upgradeUrl );
-					} }
-				>
-					{ _x( 'Upgrade plan', 'Change to a plan with more features.' ) }
-				</Button>
-			}
-		/>
-	);
-}
-
 export function StorageUpgradeActionButton( { purchase }: { purchase: Purchase } ) {
 	const { user } = useAuth();
 	const { recordTracksEvent } = useAnalytics();
 	if ( String( user.ID ) !== String( purchase.user_id ) ) {
 		return null;
 	}
-	if ( ! isStorageUpgradeEligible( purchase ) || isExpiredOrRemoved( purchase ) ) {
+	if ( ! isStorageUpgradeShown( purchase ) ) {
 		return null;
 	}
 	const storageUpgradeUrl = getSitePurchaseStorageUpgradeUrl( purchase );
@@ -530,35 +483,94 @@ export function StorageUpgradeActionButton( { purchase }: { purchase: Purchase }
 	);
 }
 
-function ReSubscribeActionButton( { purchase }: { purchase: Purchase } ) {
+// Which downgrade flow the user is about to enter, for analytics.
+function getDowngradeMode( purchase: Purchase ): string {
+	if ( purchase.is_past_expiry_date && purchase.is_plan ) {
+		return 'expired';
+	}
+	if ( isWithinRefundWindowDowngradeEligible( purchase ) ) {
+		return 'refund-window';
+	}
+	return 'delayed-downgrade';
+}
+
+/**
+ * The single entry point for moving a purchase onto something else.
+ * WordPress.com plans can change in either direction; everything else can only
+ * upgrade.
+ */
+export function ProductChangeActionItem( { purchase }: { purchase: Purchase } ) {
+	const hasEnTranslation = useHasEnTranslation();
+	const { user } = useAuth();
 	const { recordTracksEvent } = useAnalytics();
-	// @todo Conditionally show this for expired purchases in the grace period
-	// too, but some additional fixes are needed first.
-	if ( ! isRemoved( purchase ) ) {
+
+	if ( String( user.ID ) !== String( purchase.user_id ) ) {
 		return null;
 	}
-	// When "Change plan" is offered (downgrade-eligible), it supersedes the
-	// resubscribe action.
-	if ( shouldShowChangePlan( purchase ) ) {
+
+	const recordUpgradeClick = () =>
+		recordTracksEvent( 'calypso_purchases_upgrade_plan', {
+			status: isExpiredOrRemoved( purchase ) ? 'expired' : 'active',
+			plan: purchase.product_name,
+		} );
+
+	if ( isDotcomPlan( purchase ) ) {
+		const action = getPlanChangeAction( purchase, {
+			cancelTo: redirectToDashboardLink(),
+			redirectTo: getPurchaseSettingsRedirectBase(),
+		} );
+		if ( ! action ) {
+			return null;
+		}
+
+		return (
+			<ActionList.ActionItem
+				title={ action.title }
+				description={ action.description }
+				actions={
+					<Button
+						variant="secondary"
+						size="compact"
+						onClick={ () => {
+							if ( action.offersDowngrades ) {
+								recordTracksEvent( 'calypso_purchases_change_plan_click', {
+									product_slug: purchase.product_slug,
+									mode: getDowngradeMode( purchase ),
+								} );
+							} else {
+								recordUpgradeClick();
+							}
+							window.location.href = action.href;
+						} }
+					>
+						{ action.offersDowngrades
+							? __( 'View plans' )
+							: getUpgradeControlLabel( purchase, action.title, hasEnTranslation ) }
+					</Button>
+				}
+			/>
+		);
+	}
+
+	const upgradeAction = getNonPlanUpgradeAction( purchase );
+	if ( ! upgradeAction ) {
 		return null;
 	}
+
 	return (
 		<ActionList.ActionItem
-			title={ purchase.is_plan ? __( 'Pick another plan' ) : __( 'Pick another product' ) }
+			title={ upgradeAction.title }
 			description={ __( 'Find the best fit for your needs.' ) }
 			actions={
 				<Button
 					variant="secondary"
 					size="compact"
 					onClick={ () => {
-						recordTracksEvent( 'calypso_purchases_upgrade_plan', {
-							status: isExpiredOrRemoved( purchase ) ? 'expired' : 'active',
-							plan: purchase.product_name,
-						} );
-						window.location.href = getExpiredNewPlanUrl( purchase );
+						recordUpgradeClick();
+						upgradePurchase( upgradeAction.href );
 					} }
 				>
-					{ purchase.is_plan ? __( 'Pick another plan' ) : __( 'Pick another product' ) }
+					{ getUpgradeControlLabel( purchase, upgradeAction.title, hasEnTranslation ) }
 				</Button>
 			}
 		/>
@@ -666,51 +678,6 @@ function ReinstallButton( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
-function ChangePlanActionItem( { purchase }: { purchase: Purchase } ) {
-	const { user } = useAuth();
-	const { recordTracksEvent } = useAnalytics();
-
-	if ( String( user.ID ) !== String( purchase.user_id ) ) {
-		return null;
-	}
-	if ( ! shouldShowChangePlan( purchase ) ) {
-		return null;
-	}
-
-	const isPastExpiryDowngrade = purchase.is_past_expiry_date && purchase.is_plan;
-	const mode = ( () => {
-		if ( isPastExpiryDowngrade ) {
-			return 'expired';
-		}
-		if ( isWithinRefundWindowDowngradeEligible( purchase ) ) {
-			return 'refund-window';
-		}
-		return 'delayed-downgrade';
-	} )();
-
-	return (
-		<ActionList.ActionItem
-			title={ __( 'Change plan' ) }
-			description={ __( 'Upgrade or downgrade to a plan that works for you.' ) }
-			actions={
-				<Button
-					variant="secondary"
-					size="compact"
-					onClick={ () => {
-						recordTracksEvent( 'calypso_purchases_change_plan_click', {
-							product_slug: purchase.product_slug,
-							mode,
-						} );
-						window.location.href = getExpiredNewPlanUrl( purchase );
-					} }
-				>
-					{ __( 'View plans' ) }
-				</Button>
-			}
-		/>
-	);
-}
-
 function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 	const { user } = useAuth();
 	const isOwner = String( user.ID ) === String( purchase.user_id );
@@ -737,13 +704,11 @@ function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 			<ActionList>
 				<ReinstallButton purchase={ purchase } />
 				<JetpackCRMDownloadsButton purchase={ purchase } />
-				<UpgradeActionButton purchase={ purchase } />
+				<ProductChangeActionItem purchase={ purchase } />
 				<StorageUpgradeActionButton purchase={ purchase } />
 				{ ! isExpiredOrRemoved( purchase ) && isEmailPlanManagementEnabled( purchase ) && (
 					<AddMailboxesActionItem purchase={ purchase } />
 				) }
-				<ReSubscribeActionButton purchase={ purchase } />
-				<ChangePlanActionItem purchase={ purchase } />
 				<RenewActionButton purchase={ purchase } />
 				<CancelOrRemoveActionButton purchase={ purchase } />
 			</ActionList>
@@ -1468,7 +1433,8 @@ export default function PurchaseSettings() {
 	const formattedRenewal = useFormattedTime( purchase.renew_date ?? '' );
 	const formattedParentExpiry = useFormattedTime( parentPurchase?.expiry_date ?? '' );
 	const formattedParentRenewal = useFormattedTime( parentPurchase?.renew_date ?? '' );
-	const upgradeUrl = getSitePurchaseUpgradeUrl( purchase, getUpgradedPurchaseRedirectUrl() );
+	const hasEnTranslation = useHasEnTranslation();
+	const upgradeAction = getHeaderUpgradeAction( purchase );
 	// During the expiration grace period, we don't want to display the
 	// purchase.renew_date from the server even if there is an upcoming
 	// auto-renewal attempt (since we want to communicate the urgency of the
@@ -1510,7 +1476,7 @@ export default function PurchaseSettings() {
 	const columns = isSmallViewport ? 1 : 2;
 	const spacing = isSmallViewport ? SPACING.SMALL : SPACING.DEFAULT;
 	const isCurrentPurchaseOwner = String( user.ID ) === String( purchase.user_id );
-	const canHeaderUpgrade = canUpgradePurchase( purchase ) && Boolean( upgradeUrl );
+	const canHeaderUpgrade = Boolean( upgradeAction );
 	const shouldShowHeaderUpgradeAction = canHeaderUpgrade && isCurrentPurchaseOwner;
 	const shouldShowHeaderActionMenu =
 		isCurrentPurchaseOwner && ( canHeaderUpgrade || purchase.can_explicit_renew );
@@ -1576,9 +1542,9 @@ export default function PurchaseSettings() {
 						actions={
 							shouldShowHeaderActions && (
 								<HStack justify="space-between">
-									{ shouldShowHeaderUpgradeAction && upgradeUrl && (
-										<Button __next40pxDefaultSize variant="primary" href={ upgradeUrl }>
-											{ _x( 'Upgrade plan', 'Change to a plan with more features.' ) }
+									{ shouldShowHeaderUpgradeAction && upgradeAction && (
+										<Button __next40pxDefaultSize variant="primary" href={ upgradeAction.href }>
+											{ getUpgradeControlLabel( purchase, upgradeAction.title, hasEnTranslation ) }
 										</Button>
 									) }
 									{ /* Email plans surface every action in the list below, so the

--- a/client/dashboard/me/billing-purchases/purchase-settings/test/get-plan-change-action.test.ts
+++ b/client/dashboard/me/billing-purchases/purchase-settings/test/get-plan-change-action.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { getPlanChangeAction } from '../get-plan-change-action';
+import type { Purchase } from '@automattic/api-core';
+
+const URLS = {
+	cancelTo: '/me/billing/purchases/1',
+	redirectTo: '/me/billing/purchases/:purchaseId',
+};
+
+function makePlan( overrides: Partial< Purchase > = {} ): Purchase {
+	return {
+		product_slug: 'personal-bundle',
+		site_slug: 'example.com',
+		is_plan: true,
+		is_upgradable: true,
+		is_jetpack_plan_or_product: false,
+		is_plan_type_downgradable: false,
+		is_trial_plan: false,
+		is_woo_hosted_product: false,
+		expiry_status: 'active',
+		subscription_status: 'active',
+		...overrides,
+	} as Purchase;
+}
+
+function action( purchase: Purchase, upgradeOnly = false ) {
+	return getPlanChangeAction( purchase, { ...URLS, upgradeOnly } );
+}
+
+describe( 'getPlanChangeAction', () => {
+	test( 'offers "Change plan" for a downgradable plan', () => {
+		const result = action( makePlan( { is_plan_type_downgradable: true } ) );
+		expect( result?.title ).toBe( 'Change plan' );
+		expect( result?.offersDowngrades ).toBe( true );
+		expect( result?.href ).toContain( 'allow_downgrade=true' );
+	} );
+
+	test( 'offers "Upgrade plan" for a plan with nothing below it', () => {
+		const result = action( makePlan() );
+		expect( result?.title ).toBe( 'Upgrade plan' );
+		expect( result?.offersDowngrades ).toBe( false );
+		expect( result?.href ).not.toContain( 'allow_downgrade' );
+	} );
+
+	test( 'renders for an expired plan that cannot be downgraded', () => {
+		expect(
+			action(
+				makePlan( {
+					expiry_status: 'expired',
+					subscription_status: 'active',
+					is_past_expiry_date: true,
+				} )
+			)
+		).not.toBeNull();
+	} );
+
+	test( 'offers "Upgrade plan" for a removed plan, since the site is back on free', () => {
+		const result = action( makePlan( { subscription_status: 'inactive' } ) );
+		expect( result?.title ).toBe( 'Upgrade plan' );
+		expect( result?.href ).not.toContain( 'allow_downgrade' );
+	} );
+
+	test( 'offers "Change plan" for a top-tier plan that can only be downgraded', () => {
+		const topTier = makePlan( { is_upgradable: false, is_plan_type_downgradable: true } );
+		const result = action( topTier );
+		expect( result?.title ).toBe( 'Change plan' );
+		expect( result?.href ).toContain( 'allow_downgrade=true' );
+	} );
+
+	test( 'offers nothing to a top-tier plan when the caller wants upgrades only', () => {
+		const topTier = makePlan( { is_upgradable: false, is_plan_type_downgradable: true } );
+		expect( action( topTier, true ) ).toBeNull();
+	} );
+
+	test( 'pairs each destination with its own post-checkout redirect', () => {
+		const changed = action( makePlan( { is_plan_type_downgradable: true } ) );
+		expect( decodeURIComponent( changed?.href ?? '' ) ).toContain( 'plan_changed=true' );
+
+		const upgraded = action( makePlan() );
+		expect( decodeURIComponent( upgraded?.href ?? '' ) ).toContain( 'upgraded=true' );
+	} );
+
+	describe( 'upgradeOnly', () => {
+		test( 'forces the label and the URL to upgrade-only together', () => {
+			const result = action( makePlan( { is_plan_type_downgradable: true } ), true );
+			expect( result?.title ).toBe( 'Upgrade plan' );
+			expect( result?.offersDowngrades ).toBe( false );
+			expect( result?.href ).not.toContain( 'allow_downgrade' );
+		} );
+
+		test( 'can only subtract — it never manufactures a downgrade link', () => {
+			const notDowngradable = makePlan();
+			expect( action( notDowngradable, false )?.href ).not.toContain( 'allow_downgrade' );
+			expect( action( notDowngradable, true )?.href ).not.toContain( 'allow_downgrade' );
+		} );
+	} );
+
+	describe( 'returns null', () => {
+		test( 'when the plan is not upgradable', () => {
+			expect( action( makePlan( { is_upgradable: false } ) ) ).toBeNull();
+		} );
+
+		test( 'for a Jetpack plan', () => {
+			expect( action( makePlan( { is_jetpack_plan_or_product: true } ) ) ).toBeNull();
+		} );
+
+		test( 'for a non-plan product', () => {
+			expect( action( makePlan( { is_plan: false } ) ) ).toBeNull();
+		} );
+	} );
+} );

--- a/client/dashboard/me/billing-purchases/purchase-settings/test/product-change-action-item.test.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/test/product-change-action-item.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import { render } from '../../../../test-utils';
+import { ProductChangeActionItem } from '../index';
+import type { Purchase } from '@automattic/api-core';
+
+// The rendering wrapper's default user has ID 1, so a purchase owned by user 1
+// belongs to the current user.
+function makePlan( overrides: Partial< Purchase > = {} ): Purchase {
+	return {
+		ID: 1,
+		user_id: 1,
+		product_name: 'WordPress.com Personal',
+		product_slug: 'personal-bundle',
+		site_slug: 'example.com',
+		is_plan: true,
+		is_upgradable: true,
+		is_jetpack_plan_or_product: false,
+		is_plan_type_downgradable: false,
+		is_trial_plan: false,
+		is_woo_hosted_product: false,
+		subscription_status: 'active',
+		expiry_status: 'auto-renewing',
+		...overrides,
+	} as Purchase;
+}
+
+describe( '<ProductChangeActionItem />', () => {
+	test( 'offers to change plan when the plan can be downgraded', () => {
+		render(
+			<ProductChangeActionItem purchase={ makePlan( { is_plan_type_downgradable: true } ) } />
+		);
+		expect( screen.getByText( 'Change plan' ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'View plans' } ) ).toBeVisible();
+	} );
+
+	test( 'offers to upgrade when the plan has nothing below it', () => {
+		render( <ProductChangeActionItem purchase={ makePlan() } /> );
+		expect( screen.getByText( 'Upgrade plan' ) ).toBeVisible();
+		expect( screen.queryByText( 'Change plan' ) ).not.toBeInTheDocument();
+		// Terse, because no "Upgrade storage" action sits alongside it.
+		expect( screen.getByRole( 'button', { name: 'Upgrade' } ) ).toBeVisible();
+	} );
+
+	test( 'names what it upgrades when the storage action is alongside it', () => {
+		render(
+			<ProductChangeActionItem
+				purchase={ makePlan( {
+					is_plan: false,
+					product_slug: 'jetpack_backup_t1_yearly',
+					is_jetpack_backup_t1: true,
+					is_jetpack_plan_or_product: true,
+				} ) }
+			/>
+		);
+		expect( screen.getByRole( 'button', { name: 'Upgrade subscription' } ) ).toBeVisible();
+	} );
+
+	test( 'still offers a way to pick a different plan once expired', () => {
+		render(
+			<ProductChangeActionItem
+				purchase={ makePlan( {
+					expiry_status: 'expired',
+					subscription_status: 'active',
+					is_past_expiry_date: true,
+				} ) }
+			/>
+		);
+		expect( screen.getByText( 'Upgrade plan' ) ).toBeVisible();
+	} );
+
+	test( 'renders nothing when the current user does not own the purchase', () => {
+		const { container } = render(
+			<ProductChangeActionItem purchase={ makePlan( { user_id: 2 } ) } />
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'renders nothing when the plan is not upgradable', () => {
+		const { container } = render(
+			<ProductChangeActionItem purchase={ makePlan( { is_upgradable: false } ) } />
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'offers an upgrade-only action for a Jetpack plan', () => {
+		render(
+			<ProductChangeActionItem purchase={ makePlan( { is_jetpack_plan_or_product: true } ) } />
+		);
+		// A plan, so it says so — but it cannot downgrade.
+		expect( screen.getByText( 'Upgrade plan' ) ).toBeVisible();
+		expect( screen.queryByText( 'Change plan' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'offers an upgrade-only action for a non-plan product', () => {
+		render( <ProductChangeActionItem purchase={ makePlan( { is_plan: false } ) } /> );
+		expect( screen.getByText( 'Upgrade subscription' ) ).toBeVisible();
+		expect( screen.queryByText( 'Change plan' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders nothing for a non-plan product that cannot be upgraded', () => {
+		const { container } = render(
+			<ProductChangeActionItem purchase={ makePlan( { is_plan: false, is_upgradable: false } ) } />
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -10,6 +10,7 @@ import {
 	WPCOM_DIFM_LITE,
 	OFFSITE_REDIRECT,
 } from '@automattic/api-core';
+import config from '@automattic/calypso-config';
 import { formatNumber } from '@automattic/number-formatters';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -787,6 +788,26 @@ export function isWithinRefundWindowDowngradeEligible( purchase: Purchase ): boo
 		purchase.is_within_initial_refund_window &&
 		! isExpiredOrRemoved( purchase )
 	);
+}
+
+/**
+ * Whether to offer this purchase downgrade options as well as upgrades. Covers
+ * three downgrade flows, each gated by its own flag:
+ *   - past expiry (downgrade-to-checkout) — `plans/expired-downgrade`
+ *   - within refund window (instant downgrade) — `plans/expired-downgrade`
+ *   - active downgradable plan (delayed downgrade) — `plans/delayed-downgrade`
+ *
+ * Only ever true for WordPress.com plans.
+ */
+export function isPurchaseDowngradeEligible( purchase: Purchase ): boolean {
+	if ( ! purchase.is_plan || ! purchase.is_plan_type_downgradable ) {
+		return false;
+	}
+	const expiredOrRefundDowngrade =
+		config.isEnabled( 'plans/expired-downgrade' ) &&
+		( purchase.is_past_expiry_date || isWithinRefundWindowDowngradeEligible( purchase ) );
+	const delayedDowngrade = config.isEnabled( 'plans/delayed-downgrade' );
+	return expiredOrRefundDowngrade || delayedDowngrade;
 }
 
 /**

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -1,11 +1,21 @@
-import { ProductUpgradeMap, AkismetUpgradesProductMap } from '@automattic/api-core';
+import {
+	ProductUpgradeMap,
+	AkismetUpgradesProductMap,
+	SubscriptionBillPeriod,
+} from '@automattic/api-core';
 import config from '@automattic/calypso-config';
 import { addQueryArgs } from '@wordpress/url';
 import { getCurrentDashboard } from '../app/routing';
 import { isSitePlanTrial, isSitePlanWooHosted } from '../sites/plans';
 import { isDashboardBackport } from './is-dashboard-backport';
 import { dashboardLink, redirectToDashboardLink, wpcomLink } from './link';
-import { isAkismetProduct, isStorageUpgradeEligible, isTitanMail } from './purchase';
+import {
+	isAkismetProduct,
+	isDotcomPlan,
+	isPurchaseDowngradeEligible,
+	isStorageUpgradeEligible,
+	isTitanMail,
+} from './purchase';
 import { isSelfHostedJetpackConnected } from './site-types';
 import type { Purchase, Site } from '@automattic/api-core';
 
@@ -88,29 +98,35 @@ export function getSitePlanUpgradeUrl( site: Site ) {
 		isTrial: isSitePlanTrial( site ),
 		isWooHosted: isSitePlanWooHosted( site ),
 		redirectTo: redirectToDashboardLink(),
+		cancelTo: redirectToDashboardLink(),
 	} );
 }
 
 /**
- * `redirect_to` URL for plan upgrades that should land on the Dashboard
- * purchase-settings page for the newly-provisioned plan. The `:purchaseId`
- * placeholder is substituted by the checkout pending page once the new
- * subscription appears in the user's purchases (or it falls back to the site
+ * The Dashboard purchase-settings page for a newly-provisioned purchase. The
+ * `:purchaseId` placeholder is substituted by the checkout pending page once the
+ * new subscription appears in the user's purchases (or it falls back to the site
  * overview after a timeout — see `pending-page.ts`).
  */
-export function getUpgradedPurchaseRedirectUrl(): string {
-	return dashboardLink( '/me/billing/purchases/:purchaseId?upgraded=true' );
+export function getPurchaseSettingsRedirectBase(): string {
+	return dashboardLink( '/me/billing/purchases/:purchaseId' );
 }
 
 /**
- * `redirect_to` URL for the change-plan flow, which can result in either an
- * upgrade or a downgrade. Unlike `getUpgradedPurchaseRedirectUrl`, it lands on
- * the purchase-settings page with a neutral "plan changed" notice rather than
- * an upgrade-specific one. The `:purchaseId` placeholder resolves to the newly
- * provisioned plan's purchase (see `getUpgradedPurchaseRedirectUrl`).
+ * Tags a post-checkout `redirect_to` with the success notice the destination
+ * should show on arrival.
  */
-export function getChangedPlanRedirectUrl(): string {
-	return dashboardLink( '/me/billing/purchases/:purchaseId?plan_changed=true' );
+function withPurchaseNotice( url: string, notice: 'upgraded' | 'plan_changed' ): string {
+	return addQueryArgs( url, { [ notice ]: 'true' } );
+}
+
+/**
+ * `redirect_to` for flows that can only ever upgrade, so the notice is known up
+ * front. Plan changes tag their own inside {@link getWpcomPlanChangeUrl}, where
+ * it depends on the purchase.
+ */
+export function getUpgradedPurchaseRedirectUrl(): string {
+	return withPurchaseNotice( getPurchaseSettingsRedirectBase(), 'upgraded' );
 }
 
 export function getSitePurchaseUpgradeUrl( purchase: Purchase, redirectTo?: string ) {
@@ -153,6 +169,7 @@ export function getSitePurchaseUpgradeUrl( purchase: Purchase, redirectTo?: stri
 		isTrial: purchase.is_trial_plan,
 		isWooHosted: purchase.is_woo_hosted_product,
 		redirectTo: redirectTo ?? redirectToDashboardLink(),
+		cancelTo: redirectToDashboardLink(),
 	} );
 }
 
@@ -163,29 +180,144 @@ export function getSitePurchaseStorageUpgradeUrl( purchase: Purchase ): string |
 	return wpcomLink( `/plans/storage/${ purchase.site_slug }` );
 }
 
+// Map the purchase's billing term to the plans grid's `intervalType` param so the
+// grid opens on the same term as the current plan. Downgrades only work within the
+// same term, and the grid hides the term selector in the downgrade flow.
+function getPlanGridIntervalType( purchase: Purchase ): string | undefined {
+	switch ( purchase.bill_period_days ) {
+		case SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD:
+			return 'monthly';
+		case SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD:
+			return 'yearly';
+		case SubscriptionBillPeriod.PLAN_BIENNIAL_PERIOD:
+			return '2yearly';
+		case SubscriptionBillPeriod.PLAN_TRIENNIAL_PERIOD:
+			return '3yearly';
+		default:
+			return undefined;
+	}
+}
+
+export interface WpcomPlanChangeTarget {
+	href: string;
+	/**
+	 * Allows callers to determine if the target points to a page that offers
+	 * downgrade options.
+	 */
+	offersDowngrades: boolean;
+}
+
+export interface WpcomPlanChangeInput {
+	cancelTo: string;
+	/**
+	 * Base URL without a success-notice param; one is automatically appended
+	 * based on the destination.
+	 */
+	redirectTo: string;
+	/**
+	 * Forces the target to be a page without downgrade options; useful for
+	 * callers that want to deliberately promote upgrades.
+	 */
+	upgradeOnly?: boolean;
+}
+
+/**
+ * Where to send someone who wants to move a WordPress.com plan to a different
+ * one, and whether that destination offers downgrades. Returns `undefined` when
+ * there is nowhere to send them — either this is not a WordPress.com plan (those
+ * keep their own destinations via {@link getSitePurchaseUpgradeUrl}), or the plan
+ * can be neither upgraded nor downgraded.
+ *
+ * Downgrade eligibility is decided here rather than by the caller, so
+ * `upgradeOnly` can only suppress downgrades, never request them. That eligibility
+ * comes back as `offersDowngrades`, so labels derived from it cannot disagree with
+ * where the link actually goes.
+ *
+ * Callers are responsible for checking that the user has permission to change the
+ * plan; this only reports what the purchase itself allows.
+ */
+export function getWpcomPlanChangeTarget(
+	purchase: Purchase,
+	{ cancelTo, redirectTo, upgradeOnly = false }: WpcomPlanChangeInput
+): WpcomPlanChangeTarget | undefined {
+	if ( ! isDotcomPlan( purchase ) ) {
+		return undefined;
+	}
+
+	const offersDowngrades = ! upgradeOnly && isPurchaseDowngradeEligible( purchase );
+
+	if ( ! purchase.is_upgradable && ! offersDowngrades ) {
+		return undefined;
+	}
+
+	const taggedRedirectTo = withPurchaseNotice(
+		redirectTo,
+		offersDowngrades ? 'plan_changed' : 'upgraded'
+	);
+
+	if ( offersDowngrades ) {
+		const intervalType = getPlanGridIntervalType( purchase );
+		return {
+			href: addQueryArgs( wpcomLink( '/setup/plan-upgrade' ), {
+				...( purchase.site_slug && { siteSlug: purchase.site_slug } ),
+				...( intervalType && { intervalType } ),
+				cancel_to: cancelTo,
+				dashboard: getCurrentDashboard(),
+				redirect_to: taggedRedirectTo,
+				allow_downgrade: 'true',
+			} ),
+			offersDowngrades,
+		};
+	}
+
+	return {
+		href: buildSitePlanUpgradeUrl( {
+			siteSlug: purchase.site_slug,
+			isTrial: purchase.is_trial_plan,
+			isWooHosted: purchase.is_woo_hosted_product,
+			redirectTo: taggedRedirectTo,
+			cancelTo,
+		} ),
+		offersDowngrades,
+	};
+}
+
+/**
+ * {@link getWpcomPlanChangeTarget} for callers that only need somewhere to link
+ * to. A URL comes back only when the purchase allows a plan change; callers are
+ * still responsible for checking that the user has permission to make it.
+ */
+export function getWpcomPlanChangeUrl(
+	purchase: Purchase,
+	input: WpcomPlanChangeInput
+): string | undefined {
+	return getWpcomPlanChangeTarget( purchase, input )?.href;
+}
+
 function buildSitePlanUpgradeUrl( {
 	siteSlug,
 	isTrial,
 	isWooHosted,
 	redirectTo,
+	cancelTo,
 }: {
 	siteSlug: string;
 	isTrial: boolean;
 	isWooHosted: boolean;
 	redirectTo: string;
+	cancelTo: string;
 } ) {
 	if ( isTrial && ! isWooHosted ) {
 		return wpcomLink( `/plans/${ siteSlug }` );
 	}
 
-	const backUrl = redirectToDashboardLink();
 	const link = isWooHosted
 		? wpcomLink( '/setup/woo-hosted-plans' )
 		: wpcomLink( '/setup/plan-upgrade' );
 
 	return addQueryArgs( link, {
 		siteSlug: siteSlug,
-		cancel_to: backUrl,
+		cancel_to: cancelTo,
 		dashboard: getCurrentDashboard(),
 		redirect_to: redirectTo,
 	} );

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -181,8 +181,7 @@ export function getSitePurchaseStorageUpgradeUrl( purchase: Purchase ): string |
 }
 
 // Map the purchase's billing term to the plans grid's `intervalType` param so the
-// grid opens on the same term as the current plan. Downgrades only work within the
-// same term, and the grid hides the term selector in the downgrade flow.
+// grid opens on the same term as the current plan.
 function getPlanGridIntervalType( purchase: Purchase ): string | undefined {
 	switch ( purchase.bill_period_days ) {
 		case SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD:

--- a/client/dashboard/utils/test/purchase.ts
+++ b/client/dashboard/utils/test/purchase.ts
@@ -16,6 +16,7 @@ import {
 	isExpiredWithNoAutoRenewAttemptsLeft,
 	creditCardExpiresBeforeSubscription,
 	getRenewalUrlFromPurchase,
+	isPurchaseDowngradeEligible,
 } from '../purchase';
 import type { Purchase } from '@automattic/api-core';
 
@@ -438,5 +439,59 @@ describe( 'getRenewalUrlFromPurchase', () => {
 		);
 
 		expect( url ).toContain( '/checkout/business-bundle/renew/12345/example.wordpress.com?' );
+	} );
+} );
+
+describe( 'isPurchaseDowngradeEligible', () => {
+	// Both `plans/expired-downgrade` and `plans/delayed-downgrade` are enabled in
+	// every config, so these exercise the shipping behaviour.
+	test( 'is true for a downgradable plan', () => {
+		expect(
+			isPurchaseDowngradeEligible(
+				makePurchase( { is_plan: true, is_plan_type_downgradable: true } )
+			)
+		).toBe( true );
+	} );
+
+	test( 'is false for a plan with nothing below it', () => {
+		expect(
+			isPurchaseDowngradeEligible(
+				makePurchase( { is_plan: true, is_plan_type_downgradable: false } )
+			)
+		).toBe( false );
+	} );
+
+	test( 'is false for a non-plan product', () => {
+		expect(
+			isPurchaseDowngradeEligible(
+				makePurchase( { is_plan: false, is_plan_type_downgradable: true } )
+			)
+		).toBe( false );
+	} );
+
+	test( 'is true for a downgradable plan past its expiry date', () => {
+		expect(
+			isPurchaseDowngradeEligible(
+				makePurchase( {
+					is_plan: true,
+					is_plan_type_downgradable: true,
+					is_past_expiry_date: true,
+					expiry_status: 'expired',
+					subscription_status: 'active',
+				} )
+			)
+		).toBe( true );
+	} );
+
+	test( 'is true for a downgradable plan inside its refund window', () => {
+		expect(
+			isPurchaseDowngradeEligible(
+				makePurchase( {
+					is_plan: true,
+					is_plan_type_downgradable: true,
+					is_within_initial_refund_window: true,
+				} )
+			)
+		).toBe( true );
 	} );
 } );

--- a/client/dashboard/utils/test/site-url.ts
+++ b/client/dashboard/utils/test/site-url.ts
@@ -2,8 +2,13 @@
  * @jest-environment jsdom
  */
 
-import { JetpackPlans, type Purchase } from '@automattic/api-core';
-import { getSitePurchaseStorageUpgradeUrl, getSitePurchaseUpgradeUrl } from '../site-url';
+import { JetpackPlans, SubscriptionBillPeriod, type Purchase } from '@automattic/api-core';
+import {
+	getSitePurchaseStorageUpgradeUrl,
+	getSitePurchaseUpgradeUrl,
+	getWpcomPlanChangeTarget,
+	getWpcomPlanChangeUrl,
+} from '../site-url';
 
 function makePurchase( overrides: Partial< Purchase > = {} ): Purchase {
 	return {
@@ -13,6 +18,43 @@ function makePurchase( overrides: Partial< Purchase > = {} ): Purchase {
 		is_jetpack_plan_or_product: true,
 		...overrides,
 	} as Purchase;
+}
+
+// Shaped like the real callers': no success-notice param, since
+// getWpcomPlanChangeUrl adds one, and carrying the `:purchaseId` placeholder that
+// checkout substitutes afterwards.
+const REDIRECT_TO = '/me/billing/purchases/:purchaseId';
+const CANCEL_TO = '/me/billing/purchases/1';
+
+function makeDotcomPlan( overrides: Partial< Purchase > = {} ): Purchase {
+	return {
+		product_slug: 'personal-bundle',
+		site_slug: 'example.com',
+		is_plan: true,
+		is_upgradable: true,
+		is_jetpack_plan_or_product: false,
+		is_plan_type_downgradable: false,
+		is_trial_plan: false,
+		is_woo_hosted_product: false,
+		bill_period_days: SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD,
+		...overrides,
+	} as Purchase;
+}
+
+function changeUrl( purchase: Purchase, upgradeOnly = false ) {
+	return getWpcomPlanChangeUrl( purchase, {
+		cancelTo: CANCEL_TO,
+		redirectTo: REDIRECT_TO,
+		upgradeOnly,
+	} );
+}
+
+function changeTarget( purchase: Purchase, upgradeOnly = false ) {
+	return getWpcomPlanChangeTarget( purchase, {
+		cancelTo: CANCEL_TO,
+		redirectTo: REDIRECT_TO,
+		upgradeOnly,
+	} );
 }
 
 describe( 'getSitePurchaseStorageUpgradeUrl', () => {
@@ -47,5 +89,131 @@ describe( 'getSitePurchaseUpgradeUrl', () => {
 		const url = getSitePurchaseUpgradeUrl( makePurchase() );
 		expect( url ).not.toContain( '/plans/storage' );
 		expect( url ).toContain( '/plans/example.com' );
+	} );
+} );
+
+describe( 'getWpcomPlanChangeUrl', () => {
+	test( 'offers downgrades for a downgradable plan', () => {
+		const url = changeUrl( makeDotcomPlan( { is_plan_type_downgradable: true } ) );
+		expect( url ).toContain( '/setup/plan-upgrade' );
+		expect( url ).toContain( 'allow_downgrade=true' );
+	} );
+
+	test( 'omits the downgrade flag for a plan with nothing below it', () => {
+		const url = changeUrl( makeDotcomPlan() );
+		expect( url ).toContain( '/setup/plan-upgrade' );
+		expect( url ).not.toContain( 'allow_downgrade' );
+	} );
+
+	test( 'still returns a URL for an expired plan that cannot be downgraded', () => {
+		const url = changeUrl(
+			makeDotcomPlan( {
+				expiry_status: 'expired',
+				subscription_status: 'active',
+				is_past_expiry_date: true,
+			} )
+		);
+		expect( url ).toContain( '/setup/plan-upgrade' );
+	} );
+
+	test( 'upgradeOnly suppresses downgrades that would otherwise be offered', () => {
+		const purchase = makeDotcomPlan( { is_plan_type_downgradable: true } );
+		expect( changeUrl( purchase ) ).toContain( 'allow_downgrade=true' );
+		expect( changeUrl( purchase, true ) ).not.toContain( 'allow_downgrade' );
+	} );
+
+	test( 'upgradeOnly cannot manufacture a downgrade link', () => {
+		expect( changeUrl( makeDotcomPlan(), false ) ).not.toContain( 'allow_downgrade' );
+		expect( changeUrl( makeDotcomPlan(), true ) ).not.toContain( 'allow_downgrade' );
+	} );
+
+	test( 'carries the caller-supplied redirectTo and cancelTo', () => {
+		const url = changeUrl( makeDotcomPlan( { is_plan_type_downgradable: true } ) ) as string;
+		expect( decodeURIComponent( url ) ).toContain( REDIRECT_TO );
+		expect( decodeURIComponent( url ) ).toContain( CANCEL_TO );
+	} );
+
+	test( 'tags the redirect with the notice matching the grid it opened', () => {
+		const downgradable = decodeURIComponent(
+			changeUrl( makeDotcomPlan( { is_plan_type_downgradable: true } ) ) as string
+		);
+		expect( downgradable ).toContain( 'plan_changed=true' );
+		expect( downgradable ).not.toContain( 'upgraded=true' );
+
+		const upgradeOnly = decodeURIComponent( changeUrl( makeDotcomPlan() ) as string );
+		expect( upgradeOnly ).toContain( 'upgraded=true' );
+		expect( upgradeOnly ).not.toContain( 'plan_changed=true' );
+	} );
+
+	test( 'tags the redirect as upgrade-only when upgradeOnly suppresses downgrades', () => {
+		const url = decodeURIComponent(
+			changeUrl( makeDotcomPlan( { is_plan_type_downgradable: true } ), true ) as string
+		);
+		expect( url ).toContain( 'upgraded=true' );
+		expect( url ).not.toContain( 'plan_changed=true' );
+	} );
+
+	test( 'derives intervalType from the billing term', () => {
+		const url = changeUrl(
+			makeDotcomPlan( {
+				is_plan_type_downgradable: true,
+				bill_period_days: SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD,
+			} )
+		);
+		expect( url ).toContain( 'intervalType=monthly' );
+	} );
+
+	test( 'sends a trial to the plans page rather than the stepper flow', () => {
+		const url = changeUrl( makeDotcomPlan( { is_trial_plan: true } ) );
+		expect( url ).toContain( '/plans/example.com' );
+		expect( url ).not.toContain( '/setup/plan-upgrade' );
+	} );
+
+	test( 'sends a Woo-hosted plan to the Woo plans flow', () => {
+		const url = changeUrl( makeDotcomPlan( { is_woo_hosted_product: true } ) );
+		expect( url ).toContain( '/setup/woo-hosted-plans' );
+	} );
+
+	test( 'returns undefined for anything that is not a WordPress.com plan', () => {
+		expect( changeUrl( makePurchase() ) ).toBeUndefined();
+		expect( changeUrl( makeDotcomPlan( { is_plan: false } ) ) ).toBeUndefined();
+		expect( changeUrl( makeDotcomPlan( { is_jetpack_plan_or_product: true } ) ) ).toBeUndefined();
+	} );
+
+	test( 'returns undefined for a plan that can be neither upgraded nor downgraded', () => {
+		expect( changeUrl( makeDotcomPlan( { is_upgradable: false } ) ) ).toBeUndefined();
+	} );
+} );
+
+describe( 'getWpcomPlanChangeTarget', () => {
+	test( 'reports whether the destination offers downgrades', () => {
+		expect( changeTarget( makeDotcomPlan() )?.offersDowngrades ).toBe( false );
+		expect(
+			changeTarget( makeDotcomPlan( { is_plan_type_downgradable: true } ) )?.offersDowngrades
+		).toBe( true );
+	} );
+
+	test( 'still offers a target for a top tier plan, which can only be downgraded', () => {
+		const target = changeTarget(
+			makeDotcomPlan( { is_upgradable: false, is_plan_type_downgradable: true } )
+		);
+		expect( target?.href ).toContain( 'allow_downgrade=true' );
+		expect( target?.offersDowngrades ).toBe( true );
+	} );
+
+	test( 'reports no downgrades once upgradeOnly suppresses them', () => {
+		expect(
+			changeTarget( makeDotcomPlan( { is_plan_type_downgradable: true } ), true )?.offersDowngrades
+		).toBe( false );
+	} );
+
+	// Suppressing downgrades leaves a top tier plan with nowhere to go.
+	test( 'returns undefined when upgradeOnly suppresses the only available change', () => {
+		expect(
+			changeTarget(
+				makeDotcomPlan( { is_upgradable: false, is_plan_type_downgradable: true } ),
+				true
+			)
+		).toBeUndefined();
 	} );
 } );

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -15,7 +15,6 @@ import {
 	isPersonal,
 	isPremium,
 	isBusiness,
-	isEcommerce,
 	isPlan,
 	isComplete,
 	isDomainProduct,
@@ -27,7 +26,6 @@ import {
 	isJetpackProduct,
 	isConciergeSession,
 	isTitanMail,
-	isPro,
 	applyTestFiltersToPlansList,
 	isWpComMonthlyPlan,
 	JETPACK_BACKUP_T1_PRODUCTS,
@@ -35,7 +33,6 @@ import {
 	JETPACK_LEGACY_PLANS,
 	JETPACK_PRODUCTS_LIST,
 	JETPACK_SECURITY_T1_PLANS,
-	isP2Plus,
 	getMonthlyPlanByYearly,
 	hasMarketplaceProduct,
 	isDIFMProduct,
@@ -48,10 +45,6 @@ import {
 	is100Year,
 	isJetpackGrowthPlan,
 	JETPACK_GROWTH_UPGRADE_MAP,
-	PLAN_MONTHLY_PERIOD,
-	PLAN_ANNUAL_PERIOD,
-	PLAN_BIENNIAL_PERIOD,
-	PLAN_TRIENNIAL_PERIOD,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import {
@@ -92,12 +85,13 @@ import {
 	getCancelButtonCopy,
 	getRemoveButtonCopy,
 } from 'calypso/dashboard/me/billing-purchases/purchase-settings/get-cancel-remove-copy';
+import { getPlanChangeAction } from 'calypso/dashboard/me/billing-purchases/purchase-settings/get-plan-change-action';
 import {
 	getPurchaseCancellationFlowType,
 	isA4ABillingDragonPurchase,
 	isA4AHoldingSitePurchase,
 	isAkismetHoldingSitePurchase,
-	isJetpackHoldingSitePurchase,
+	isDotcomPlan,
 	isMarketplaceHoldingSitePurchase,
 	isPartnerPurchase,
 } from 'calypso/dashboard/utils/purchase';
@@ -163,7 +157,6 @@ import {
 	isPaidWithCredits,
 	isRemoved,
 	isRenewable,
-	isWithinRefundWindowDowngradeEligible,
 	needsToRenewSoon,
 	purchaseType,
 	shouldRenderMonthlyRenewalOption,
@@ -253,24 +246,6 @@ interface ManagePurchaseState {
 	isRemoving: boolean;
 	isCancelSurveyVisible: boolean;
 	isReinstalling: boolean;
-}
-
-// Map the purchase's billing term to the plan grid's `intervalType` param so the
-// Stepper grid opens on the same term as the current plan. Downgrades only work
-// within the same term, and the grid hides the term selector in the downgrade flow.
-function getPlanGridIntervalType( billPeriodDays: number ): string | undefined {
-	switch ( billPeriodDays ) {
-		case PLAN_MONTHLY_PERIOD:
-			return 'monthly';
-		case PLAN_ANNUAL_PERIOD:
-			return 'yearly';
-		case PLAN_BIENNIAL_PERIOD:
-			return '2yearly';
-		case PLAN_TRIENNIAL_PERIOD:
-			return '3yearly';
-		default:
-			return undefined;
-	}
 }
 
 class ManagePurchase extends Component<
@@ -421,26 +396,36 @@ class ManagePurchase extends Component<
 			return null;
 		}
 
-		if ( isPartnerPurchase( purchase ) || isA4ABillingDragonPurchase( purchase ) ) {
+		if ( ! purchase.is_upgradable ) {
 			return null;
 		}
 
-		const isUpgradeablePlan =
-			isPlan( purchase ) &&
-			! isEcommerce( purchase ) &&
-			! isPro( purchase ) &&
-			! isComplete( purchase ) &&
-			! is100Year( purchase ) &&
-			! isP2Plus( purchase );
+		// Deliberately hidden once expired: the nav item still offers the link, we
+		// just don't give it prominence here.
+		if ( isExpiredOrRemoved( purchase ) ) {
+			return null;
+		}
+
+		// Shares its destination with the nav item so the two can't disagree, but
+		// always promotes upgrades — downgrades are offered in the list below.
+		if ( isDotcomPlan( purchase ) ) {
+			const action = this.buildPlanChangeAction( { upgradeOnly: true } );
+			if ( ! action ) {
+				return null;
+			}
+			return (
+				<Button primary={ !! preventRenewal } compact href={ action.href }>
+					{ action.title }
+				</Button>
+			);
+		}
+
+		const isUpgradeablePlan = isPlan( purchase ) && ! isComplete( purchase );
 		const isUpgradeableProduct =
 			! isPlan( purchase ) &&
 			( isJetpackBackupT1Slug( purchase.product_slug ) || isAkismetProduct( purchase ) );
 
 		if ( ! isUpgradeablePlan && ! isUpgradeableProduct ) {
-			return null;
-		}
-
-		if ( isExpiredOrRemoved( purchase ) ) {
 			return null;
 		}
 
@@ -454,7 +439,7 @@ class ManagePurchase extends Component<
 		// Show the upgrade button without the primary style if both buttons are present
 		return (
 			<Button primary={ !! preventRenewal } compact href={ upgradeUrl }>
-				{ translate( 'Upgrade plan' ) }
+				{ isUpgradeablePlan ? translate( 'Upgrade plan' ) : translate( 'Upgrade product' ) }
 			</Button>
 		);
 	}
@@ -628,80 +613,65 @@ class ManagePurchase extends Component<
 		return `/plans/${ siteSlug }`;
 	}
 
-	shouldRenderDowngradeOption(): boolean {
-		const { purchase } = this.props;
-		if ( ! purchase || ! isPlan( purchase ) ) {
-			return false;
-		}
-		if ( ! purchase.is_plan_type_downgradable ) {
-			return false;
-		}
-		const expiredOrRefundDowngrade =
-			config.isEnabled( 'plans/expired-downgrade' ) &&
-			( isExpiredAndInGracePeriod( purchase ) ||
-				isWithinRefundWindowDowngradeEligible( purchase ) );
-		const delayedDowngrade = config.isEnabled( 'plans/delayed-downgrade' );
-		return expiredOrRefundDowngrade || delayedDowngrade;
-	}
-
-	renderChangePlanNavItem() {
-		const { purchase, siteSlug, getManagePurchaseUrlFor = managePurchase, translate } = this.props;
-		if ( ! this.shouldRenderDowngradeOption() || ! purchase ) {
-			return null;
-		}
-		// Route to the Stepper plan-upgrade flow, whose plan grid and downgrade
-		// dialog are more polished than the classic `/plans` page. The downgrade
-		// logic itself is shared (both pages render `PlansFeaturesMain`), and it
-		// reads `redirect_to`/`cancel_to` straight off the URL, so we still land
-		// back on this manage-purchase page afterwards. The `:purchaseId`
-		// placeholder is substituted with the newly-provisioned plan's purchase by
-		// either the instant-downgrade handler or the checkout pending page
-		// (analogous to `:receiptId`).
-		const redirectTo = getManagePurchaseUrlFor( siteSlug, ':purchaseId' ) + '?plan_changed=true';
-		const cancelTo = getManagePurchaseUrlFor( siteSlug, purchase.ID );
-		const intervalType = getPlanGridIntervalType( purchase.bill_period_days );
-		const href = addQueryArgs(
-			{
-				siteSlug,
-				allow_downgrade: 'true',
-				redirect_to: redirectTo,
-				cancel_to: cancelTo,
-				...( intervalType && { intervalType } ),
-			},
-			'/setup/plan-upgrade'
-		);
-		return (
-			<CompactCard tagName="a" displayAsLink href={ href }>
-				<Icon icon={ column } className="card__icon" />
-				{ translate( 'Change plan' ) }
-			</CompactCard>
-		);
-	}
-
-	renderUpgradeNavItem() {
-		const { purchase, translate } = this.props;
-		if ( this.shouldRenderDowngradeOption() ) {
-			return null;
-		}
+	/**
+	 * The `:purchaseId` placeholder is substituted with the newly-provisioned
+	 * plan's purchase by either the instant-downgrade handler or the checkout
+	 * pending page (analogous to `:receiptId`).
+	 */
+	buildPlanChangeAction( { upgradeOnly = false }: { upgradeOnly?: boolean } = {} ) {
+		const { purchase, siteSlug, getManagePurchaseUrlFor = managePurchase } = this.props;
 		if ( ! purchase ) {
 			return null;
 		}
-		if (
-			isJetpackHoldingSitePurchase( purchase ) ||
-			isPartnerPurchase( purchase ) ||
-			isA4ABillingDragonPurchase( purchase )
-		) {
+		return getPlanChangeAction( purchase, {
+			upgradeOnly,
+			cancelTo: getManagePurchaseUrlFor( siteSlug, purchase.ID ),
+			redirectTo: getManagePurchaseUrlFor( siteSlug, ':purchaseId' ),
+		} );
+	}
+
+	/**
+	 * The single entry point for moving a purchase onto something else.
+	 * WordPress.com plans can change in either direction and route to the Stepper
+	 * plan-upgrade flow, whose plan grid and downgrade dialog are more polished
+	 * than the classic `/plans` page. The downgrade logic itself is shared (both
+	 * pages render `PlansFeaturesMain`), and it reads `redirect_to`/`cancel_to`
+	 * straight off the URL, so we still land back on this manage-purchase page
+	 * afterwards. Everything else can only upgrade, and keeps its own
+	 * per-product destination.
+	 */
+	renderProductChangeNavItem() {
+		const { purchase, translate } = this.props;
+		if ( ! purchase ) {
+			return null;
+		}
+		if ( isDotcomPlan( purchase ) ) {
+			const action = this.buildPlanChangeAction();
+			if ( ! action ) {
+				return null;
+			}
+			return (
+				<CompactCard
+					tagName="a"
+					displayAsLink
+					href={ action.href }
+					// Downgrades are not tracked here; they could be if desired, but
+					// historically only the upgrade case ever was.
+					onClick={ action.offersDowngrades ? undefined : this.handleUpgradeClick }
+				>
+					<Icon icon={ column } className="card__icon" />
+					{ action.title }
+				</CompactCard>
+			);
+		}
+
+		if ( ! purchase.is_upgradable ) {
 			return null;
 		}
 
-		const isUpgradeablePlan =
-			purchase &&
-			isPlan( purchase ) &&
-			! isEcommerce( purchase ) &&
-			! isPro( purchase ) &&
-			! isComplete( purchase ) &&
-			! isP2Plus( purchase ) &&
-			! is100Year( purchase );
+		// Allow Jetpack plans except the top one (Jetpack Complete) to be
+		// upgraded. WordPress.com plans were already handled above.
+		const isUpgradeablePlan = isPlan( purchase ) && ! isComplete( purchase );
 
 		const isUpgradeableBackupProduct = (
 			JETPACK_BACKUP_T1_PRODUCTS as ReadonlyArray< string >
@@ -709,6 +679,12 @@ class ManagePurchase extends Component<
 		const isUpgradeableProduct = isUpgradeableBackupProduct;
 
 		if ( ! isUpgradeablePlan && ! isUpgradeableProduct ) {
+			return null;
+		}
+
+		const upgradeUrl = this.getUpgradeUrl();
+
+		if ( ! upgradeUrl ) {
 			return null;
 		}
 
@@ -721,8 +697,6 @@ class ManagePurchase extends Component<
 		} else {
 			buttonText = isUpgradeablePlan ? translate( 'Upgrade plan' ) : translate( 'Upgrade product' );
 		}
-
-		const upgradeUrl = this.getUpgradeUrl();
 
 		return (
 			<CompactCard
@@ -1510,7 +1484,6 @@ class ManagePurchase extends Component<
 				) }
 				{ isProductOwner && ! purchase.is_locked && (
 					<>
-						{ this.renderChangePlanNavItem() }
 						{ ! preventRenewal &&
 							! renderMonthlyRenewalOption &&
 							! isActive100YearPurchase &&
@@ -1519,7 +1492,7 @@ class ManagePurchase extends Component<
 						{ ! preventRenewal && renderMonthlyRenewalOption && this.renderRenewAnnuallyNavItem() }
 						{ ! preventRenewal && renderMonthlyRenewalOption && this.renderRenewMonthlyNavItem() }
 						{ /* TODO: Add ability to Renew Akismet subscription */ }
-						{ this.renderUpgradeNavItem() }
+						{ this.renderProductChangeNavItem() }
 						{ this.renderUpgradeStorageNavItem() }
 						{ this.renderEditPaymentMethodNavItem() }
 						{ config.isEnabled( 'jetpack/crm-downloads' ) && this.renderCrmDownloadsNavItem() }

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -323,6 +323,7 @@ describe( 'Purchase Management Buttons', () => {
 			...purchase,
 			domain: 'siteless.akismet.com',
 			product_slug: product_slug,
+			is_upgradable: true,
 		} );
 
 		render(
@@ -354,6 +355,9 @@ describe( 'Purchase Management Buttons', () => {
 				...purchase,
 				domain: 'siteless.akismet.com',
 				product_slug: product_slug,
+				// Upgradable per the server, so the absent CTA is down to the
+				// product having no upgrade path rather than the gate.
+				is_upgradable: true,
 			} );
 
 			render(
@@ -377,7 +381,7 @@ describe( 'Purchase Management Buttons', () => {
 	// (/plans/storage), each rendered both in the button row and in the
 	// options list at the bottom. Backup T1 exercises the shared render path
 	// without pulling in the Jetpack-plan plugin-keys query.
-	it( 'renders both a plan upgrade and a storage upgrade CTA for a storage-eligible product', async () => {
+	it( 'renders both a product upgrade and a storage upgrade CTA for a storage-eligible product', async () => {
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.2/me/payment-methods?expired=include' )
 			.reply( 200 );
@@ -385,6 +389,7 @@ describe( 'Purchase Management Buttons', () => {
 		const store = createMockReduxStoreForPurchase( {
 			...purchase,
 			product_slug: PRODUCT_JETPACK_BACKUP_T1_YEARLY,
+			is_upgradable: true,
 		} );
 
 		render(
@@ -399,9 +404,11 @@ describe( 'Purchase Management Buttons', () => {
 			</QueryClientProvider>
 		);
 
-		expect( await screen.findByText( 'Upgrade plan' ) ).toHaveAttribute(
-			'href',
-			'/plans/onecooltestsite.com'
+		// Header and nav item should agree on the noun for a non-plan product.
+		const upgradeCtas = await screen.findAllByText( 'Upgrade product' );
+		expect( upgradeCtas ).toHaveLength( 2 );
+		upgradeCtas.forEach( ( cta ) =>
+			expect( cta ).toHaveAttribute( 'href', '/plans/onecooltestsite.com' )
 		);
 
 		const storageCtas = screen.getAllByText( 'Upgrade storage' );
@@ -409,6 +416,73 @@ describe( 'Purchase Management Buttons', () => {
 		storageCtas.forEach( ( cta ) =>
 			expect( cta ).toHaveAttribute( 'href', '/plans/storage/onecooltestsite.com' )
 		);
+	} );
+
+	// A WordPress.com plan uses the shared plan-change action, so its nav item and
+	// header button must agree on the Stepper flow rather than the classic
+	// `/plans` page.
+	describe( 'WordPress.com plans', () => {
+		const dotcomPlan = {
+			...purchase,
+			is_plan: true,
+			is_upgradable: true,
+			is_jetpack_plan_or_product: false,
+			is_plan_type_downgradable: false,
+		};
+
+		async function renderPurchase( overrides = {} ) {
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/rest/v1.2/me/payment-methods?expired=include' )
+				.reply( 200 );
+
+			const store = createMockReduxStoreForPurchase( { ...dotcomPlan, ...overrides } );
+
+			render(
+				<QueryClientProvider client={ queryClient }>
+					<ReduxProvider store={ store }>
+						<ManagePurchase
+							purchaseId={ Number( purchase.ID ) }
+							isSiteLevel
+							siteSlug="onecooltestsite.com"
+						/>
+					</ReduxProvider>
+				</QueryClientProvider>
+			);
+		}
+
+		it( 'points the nav item and the header button at the same Stepper flow', async () => {
+			await renderPurchase();
+
+			const ctas = await screen.findAllByText( 'Upgrade plan' );
+			expect( ctas ).toHaveLength( 2 );
+			ctas.forEach( ( cta ) => {
+				expect( cta ).toHaveAttribute( 'href', expect.stringContaining( '/setup/plan-upgrade' ) );
+				expect( cta ).not.toHaveAttribute( 'href', expect.stringContaining( 'allow_downgrade' ) );
+			} );
+		} );
+
+		it( 'offers to change plan when the plan can be downgraded', async () => {
+			await renderPurchase( { is_plan_type_downgradable: true } );
+
+			expect( await screen.findByText( 'Change plan' ) ).toHaveAttribute(
+				'href',
+				expect.stringContaining( 'allow_downgrade=true' )
+			);
+			// The header keeps promoting upgrades only, so it must not carry the flag.
+			expect( screen.getByText( 'Upgrade plan' ) ).not.toHaveAttribute(
+				'href',
+				expect.stringContaining( 'allow_downgrade' )
+			);
+		} );
+
+		it( 'still offers a way to pick a different plan once expired', async () => {
+			await renderPurchase( { expiry_status: 'expired', subscription_status: 'active' } );
+
+			const cta = await screen.findByText( 'Upgrade plan' );
+			expect( cta ).toHaveAttribute( 'href', expect.stringContaining( '/setup/plan-upgrade' ) );
+			// Hidden from the header once expired, so the nav item is the only one.
+			expect( screen.getAllByText( 'Upgrade plan' ) ).toHaveLength( 1 );
+		} );
 	} );
 
 	it( 'renders payment method nav item for A4A billingdragon purchase on a real site', async () => {
@@ -548,9 +622,12 @@ describe( 'Purchase Management Buttons', () => {
 			.get( '/rest/v1.2/me/payment-methods?expired=include' )
 			.reply( 200 );
 
+		// The server excludes A4A purchases from `is_upgradable`; there is no
+		// longer a client-side check for them.
 		const store = createMockReduxStoreForPurchase( {
 			...purchase,
 			meta: 'is-a4a',
+			is_upgradable: false,
 		} );
 
 		render(

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -845,8 +845,8 @@ const PlansFeaturesMain = ( {
 	};
 
 	// Badge the plan a scheduled downgrade will land on so the user remembers it
-	// is queued. The term selector is hidden while a downgrade is pending, so the
-	// target product slug always matches the displayed plan slug.
+	// is queued. Keyed by exact product slug, so the badge only shows while the grid
+	// is displaying the downgrade target's term.
 	const highlightLabelOverridesWithDowngrade = useMemo( () => {
 		if ( ! delayedDowngradeToProductSlug ) {
 			return highlightLabelOverrides;

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -539,6 +539,10 @@ export interface Purchase {
 	 * link will typically go to the plans page for the site or some other
 	 * location depending on the product. To cause these buttons to instead add
 	 * a product directly to the cart, also set `upgrade_product_slug`.
+	 *
+	 * Note that a subscription may be upgradable even if it is past its expiry
+	 * date (i.e. in its grace period). This allows lapsed customers to choose
+	 * a different plan.
 	 */
 	is_upgradable: boolean;
 
@@ -546,11 +550,9 @@ export interface Purchase {
 	 * True if this subscription's plan can be downgraded to a different, lower
 	 * plan type (eg: Business to Personal).
 	 *
-	 * Only ever true for plans. Like `is_upgradable`, this is false for A4A
-	 * plans, bundle-`included` subscriptions, and (for Jetpack plans) holding
-	 * sites. Unlike `is_upgradable`, an active subscription that is merely past
-	 * its expiry date (grace period) is still considered downgradable; only
-	 * inactive ('expired') subscriptions are excluded.
+	 * Only ever true for WordPress.com plans. Like `is_upgradable`, it may
+	 * return true for expired subscriptions that are in their grace period, to
+	 * allow lapsed customers to downgrade to a lower plan.
 	 */
 	is_plan_type_downgradable: boolean;
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2255/create-a-canonical-url-and-canonical-action-component-for-switching-to

## Proposed Changes

Within Calypso and the Dashboard, there are a few different components for displaying an action link to either upgrade or downgrade the current purchase to something else.  And there are also a few different ways for generating the URL that the link points to. For example, in the Dashboard:
- The `ChangePlanActionItem` component ("Change plan" action) appears if the product is downgrade-eligible and takes you to `/setup/plan-upgrade...allow_downgrade=true`.
- The `ReSubscribeActionButton` component ("Pick another plan" action) is currently dead code, but would take you to the same downgrade-enabled URL as above (however, without doing the downgrade eligibility check).
- The `UpgradeActionButton` component ("Upgrade subscription" action) appears when the product isn't downgrade-eligible and takes you to the upgrade-only version of `/setup/plan-upgrade` (without the `allow_downgrade=true` flag).

This pull request consolidates things into single components as much as possible and fixes the fragmentation (since we never want more than one link for upgrading/downgrading a plan, it makes sense to have them share the same component).  The main goal of this refactoring is to ensure that we have an easy way to display a "View other plans" link in the message at the top of this page later on (via https://linear.app/a8c/issue/SHILL-2267/implement-the-new-messaging-at-the-top-of-the-purchase-management) and be confident that it will point to the correct place.  But it also has the side effect of fixing a variety of problems, inconsistencies, and bugs.

### Documentation of user interface changes

Here are the expected changes in the user interface (everything else stays the same):
- In Calypso, the "Change plan" navigation item was previously above the "Renew now" item, while the "Upgrade plan" item was below it. Combining them into one component requires making a choice, so we're standardizing on the older behavior (keeping it below).  This is different from the Dashboard (where "Change plan"/"Upgrade plan" is at the top) but that discrepancy is actually in the designs at p9Jlb4-h0E-p2.
- In the Dashboard, we're renaming the "Upgrade subscription" navigation item to "Upgrade plan" (when the purchase is a non-downgradable plan), which matches Calypso and therefore allows us to share the components (and also matches previous Dashboard designs).  Pulling on that thread, though, forces us to fix and standardize another thing as well: The button next to the navigation item goes back to "Upgrade" (as it was a few days ago prior to https://github.com/Automattic/wp-calypso/pull/112975) -- the longer "Upgrade plan" or "Upgrade subscription" button name is now only used when it's adjacent to an "Upgrade storage" item (the scenario that pull request was specifically addressing), which limits the cases where the item title and button duplicate each other.
- For a Personal plan, if the plan was expired the Dashboard previously showed no upgrade link at all (a bug) and Calypso showed "Pick another plan" (rather than the normal "Upgrade plan"). And regardless of whether the Personal plan was active or expired, the Calypso version linked to the old plans page rather than the new one.  The shared component fixes all that; Personal plans (which are upgradable but not downgradable) now consistently say "Upgrade plan" and link to the new `/setup/plan-upgrade` plans page.
- Both Dashboard and Calypso have some tweaks to make the header link wording consistently match the navigation item wording on the same page (other than cases where they appear to be deliberately different, like promoting "Upgrade plan" in a prominent spot in the header, with the downgrade-enabled "Change plan" only available further down).
- By having Calypso respect `purchase.is_upgradable` from the server like the Dashboard already did (a partial consequence of combining the components) and moving relevant checks to the server-side code in a companion server-side pull request, we get a few more fixes:
  - Some purchases (specifically the P2+ plan and Jetpack partner purchases) had their upgrade links suppressed in Calypso but not in the Dashboard but are now correctly *suppressed* in both.
  - Some purchases (specifically the Pro plan) had their upgrade links suppressed in Calypso but not in the Dashboard but are now correctly *shown* in both.  (The Pro plan can be upgraded, so it makes sense to show the link just like we do for other legacy plans.)  Note that upgrade links for the Commerce plan were previously suppressed in Calypso also, but that bug effectively got fixed already when the "Change plan" option was recently introduced to replace it for downgradable plans. However, the server-side code now handles it correctly also, just in case; `is_upgradable` will now only be `false` for a *three-year* Commerce plan, but will return `true` for the other Commerce plans since they are still eligible for term upgrades.
  - Some purchases (for example siteless Jetpack purchases for products like Jetpack Growth) are intended to have their upgrade links suppressed everywhere (because the links are broken and upgrading doesn't make sense for a siteless purchase) but still showed the links in the Calypso header; those now have the links correctly suppressed everywhere.

### Screenshots of some of the user interface changes

#### Business plan

This shows the new ordering of the action items in Calypso and part of the "Upgrade" rename in the Dashboard.

| | Before | After |
| :---: | :---: | :---: |
| Calypso | <img width="1053" height="802" alt="calypso-business-BEFORE" src="https://github.com/user-attachments/assets/8c4bdd7d-790d-40cb-aed8-4e3a8b70e674" /> | <img width="1053" height="802" alt="calypso-business-AFTER" src="https://github.com/user-attachments/assets/ee608699-8ada-413e-b7d3-ce8bc9a4b972" /> |
| Dashboard | <img width="862" height="193" alt="dashboard-business-BEFORE" src="https://github.com/user-attachments/assets/4fe85bd5-3303-451d-9fae-8ee42b7ad7f4" /> | <img width="862" height="193" alt="dashboard-business-AFTER" src="https://github.com/user-attachments/assets/87692410-c694-461b-9126-0031dd7f30fb" /> |

#### Personal plan

This shows the remainder of the "Upgrade" renaming in the dashboard.

| Before | After |
| :---: | :---: |
| <img width="676" height="253" alt="dashboard-personal-BEFORE" src="https://github.com/user-attachments/assets/0c2d4700-d2cb-4aaf-9fd8-d456228d5c71" /> | <img width="676" height="253" alt="dashboard-personal-AFTER" src="https://github.com/user-attachments/assets/2aca0c40-b626-445d-bab5-5714dc938a4a" /> |

#### Expired Personal plan

This is the main bugfix noted above (inconsistently-labeled upgrade link in Calypso and missing upgrade link in the Dashboard are both fixed).

| | Before | After |
| :---: | :---: | :---: |
| Calypso | <img width="1053" height="281" alt="calypso-expired-personal-BEFORE" src="https://github.com/user-attachments/assets/a784537f-f807-4ab6-b1bd-b1c7f82cd470" /> | <img width="1054" height="282" alt="calypso-expired-personal-AFTER" src="https://github.com/user-attachments/assets/5524d10c-134c-4025-b1ee-c7d28a01108e" /> |
| Dashboard | <img width="673" height="175" alt="dashboard-expired-personal-BEFORE" src="https://github.com/user-attachments/assets/a234b921-f7d9-4a27-ac48-6fdca56f3bbb" /> | <img width="674" height="255" alt="dashboard-expired-personal-AFTER" src="https://github.com/user-attachments/assets/f2b33762-1559-47fa-a799-e3e9586a47f6" /> |

#### Jetpack Security (with a storage upgrade link)

This shows that the changes from https://github.com/Automattic/wp-calypso/pull/112975 are still in place when they actually matter.

| Calypso | Dashboard |
| :---: | :---: |
| <img width="1051" height="331" alt="calypso-storage-upgrade-AFTER" src="https://github.com/user-attachments/assets/c3754d05-518e-41a4-b750-ec8f13dc0445" /> | <img width="671" height="330" alt="dashboard-storage-upgrade-AFTER" src="https://github.com/user-attachments/assets/c25928e9-88c2-4fef-a489-ab73358dd38a" /> |

## Testing Instructions

This requires a server-side pull request (231367-ghe-Automattic/wpcom) in order to test.

I tested the purchase management pages (Calypso and Dashboard) for a bunch of different types of purchases -- including the ones mentioned above -- and checked the links that were displayed as well as their destinations to make sure everything behaved as expected.