### PR TITLE
Jetpack AI: Remove AI Editorial Review legacy markers

### DIFF
--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -359,7 +359,7 @@ describe( 'OrchestratorChat', () => {
 		window.removeEventListener( 'big-sky-inline-suggestion-click', listener );
 	} );
 
-	it( 'dispatches and tracks the canonical AI Editorial Review suggestion ID once', () => {
+	it( 'dispatches and tracks the AI Editorial Review suggestion ID once', () => {
 		const listener = jest.fn();
 		window.addEventListener( 'big-sky-inline-suggestion-click', listener );
 		const suggestion = {

--- a/packages/agents-manager/src/utils/__tests__/orchestrator-error-message.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/orchestrator-error-message.test.ts
@@ -15,24 +15,18 @@ describe( 'getOrchestratorErrorMessage', () => {
 		);
 	} );
 
-	it( 'keeps mapping the legacy over-limit error code for delayed responses', () => {
-		expect( getOrchestratorErrorMessage( 'review_mediator_over_limit' ) ).toBe(
-			'You have reached your Jetpack AI usage limit. Upgrade your plan to continue.'
-		);
-	} );
-
 	it( 'maps a differently-worded over-limit message to localized upgrade copy', () => {
 		expect( getOrchestratorErrorMessage( 'HTTP 429: Jetpack AI usage limit reached.' ) ).toBe(
 			'You have reached your Jetpack AI usage limit. Upgrade your plan to continue.'
 		);
 	} );
 
-	it.each( [ 'ai_editorial_review_over_limit_retryable', 'prefix_review_mediator_over_limit' ] )(
-		'passes the near-miss error code %s through unchanged',
-		( error ) => {
-			expect( getOrchestratorErrorMessage( error ) ).toBe( error );
-		}
-	);
+	it.each( [
+		'ai_editorial_review_over_limit_retryable',
+		'prefix_ai_editorial_review_over_limit',
+	] )( 'passes the near-miss error code %s through unchanged', ( error ) => {
+		expect( getOrchestratorErrorMessage( error ) ).toBe( error );
+	} );
 
 	it( 'passes other errors through unchanged', () => {
 		expect( getOrchestratorErrorMessage( 'Some other error.' ) ).toBe( 'Some other error.' );

--- a/packages/agents-manager/src/utils/orchestrator-error-message.ts
+++ b/packages/agents-manager/src/utils/orchestrator-error-message.ts
@@ -8,11 +8,7 @@ export function getOrchestratorErrorMessage( error: string | null ): string | nu
 		return null;
 	}
 
-	if (
-		error === 'ai_editorial_review_over_limit' ||
-		error === 'review_mediator_over_limit' ||
-		/jetpack ai usage limit/i.test( error )
-	) {
+	if ( error === 'ai_editorial_review_over_limit' || /jetpack ai usage limit/i.test( error ) ) {
 		return __(
 			'You have reached your Jetpack AI usage limit. Upgrade your plan to continue.',
 			__i18n_text_domain__

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -61,11 +61,6 @@ const SHOW_COMPONENT_TOOL_ID = 'jetpack_ai__show_component';
 const LEGACY_SHOW_COMPONENT_TOOL_ID = 'big_sky__show_component';
 const SHOW_COMPONENT_ABILITY_NAME = 'jetpack-ai/show-component';
 const LEGACY_SHOW_COMPONENT_ABILITY_NAME = 'big-sky/show-component';
-const AI_EDITORIAL_REVIEW_CONTRACT_ENTRY = {
-	id: 'ai-editorial-review-contract',
-	type: 'ai-editorial-review-contract',
-	data: { version: 2 },
-};
 
 function appendRootBlockListLayout( doc: Document = document ): HTMLElement {
 	const layout = doc.createElement( 'div' );
@@ -356,7 +351,7 @@ describe( 'contextProvider.getClientContext', () => {
 		mockSelectedBlock = null;
 	} );
 
-	it( 'advertises AI Editorial Review contract version 2 alongside selected block context', () => {
+	it( 'provides selected block context when no block is selected', () => {
 		installPostTypeMock( 'post' );
 
 		expect( contextProvider.getClientContext().contextEntries ).toEqual( [
@@ -365,40 +360,10 @@ describe( 'contextProvider.getClientContext', () => {
 				type: 'selected-block-content',
 				data: null,
 			},
-			AI_EDITORIAL_REVIEW_CONTRACT_ENTRY,
 		] );
 	} );
 
-	it( 'advertises the contract independently of AI Editorial Review availability', () => {
-		installAiEditorialReviewData( { aiEditorialReview: false } );
-		expect( contextProvider.getClientContext().contextEntries ).toContainEqual(
-			AI_EDITORIAL_REVIEW_CONTRACT_ENTRY
-		);
-
-		delete ( globalThis as any ).agentsManagerData;
-		expect( contextProvider.getClientContext().contextEntries ).toContainEqual(
-			AI_EDITORIAL_REVIEW_CONTRACT_ENTRY
-		);
-	} );
-
-	it( 'returns one fresh contract entry with every client context', () => {
-		const firstEntries = contextProvider.getClientContext().contextEntries;
-		const secondEntries = contextProvider.getClientContext().contextEntries;
-
-		expect( firstEntries ).not.toBe( secondEntries );
-		expect(
-			firstEntries.filter(
-				( entry: { id: string } ) => entry.id === AI_EDITORIAL_REVIEW_CONTRACT_ENTRY.id
-			)
-		).toHaveLength( 1 );
-		expect(
-			secondEntries.filter(
-				( entry: { id: string } ) => entry.id === AI_EDITORIAL_REVIEW_CONTRACT_ENTRY.id
-			)
-		).toHaveLength( 1 );
-	} );
-
-	it( 'keeps selected block content beside the contract entry', () => {
+	it( 'provides the selected block content', () => {
 		mockSelectedBlock = {
 			clientId: 'selected-block',
 			name: 'core/paragraph',
@@ -412,7 +377,6 @@ describe( 'contextProvider.getClientContext', () => {
 				type: 'selected-block-content',
 				data: { content: 'Selected paragraph' },
 			},
-			AI_EDITORIAL_REVIEW_CONTRACT_ENTRY,
 		] );
 	} );
 
@@ -440,8 +404,8 @@ describe( 'getChatComponent', () => {
 		expect( getChatComponent( 'ai-editorial-review' ) ).toBe( AiEditorialReview );
 	} );
 
-	it( 'does not register the legacy AI Editorial Review component type', () => {
-		expect( getChatComponent( 'review-mediation' ) ).toBeNull();
+	it( 'returns null for an unknown component type', () => {
+		expect( getChatComponent( 'unregistered-component' ) ).toBeNull();
 	} );
 
 	it( 'returns PostFeedback for type "post-feedback"', () => {
@@ -1861,7 +1825,7 @@ describe( 'getEmptyViewSuggestions', () => {
 		expect( labels ).not.toContain( 'Editorial Review' );
 	} );
 
-	it( 'returns one canonical AI Editorial Review suggestion with the existing UX label', () => {
+	it( 'returns one AI Editorial Review suggestion with the existing UX label', () => {
 		installAiEditorialReviewData();
 		installPostTypeMock( 'post' );
 
@@ -2813,7 +2777,6 @@ describe( 'contextProvider', () => {
 		const feedbackContext = contextProvider.getClientContext();
 		expect( feedbackContext.currentPageContent ).toEqual( [] );
 		expect( feedbackContext.jetpackAi ).toBeUndefined();
-		expect( feedbackContext.contextEntries ).toContainEqual( AI_EDITORIAL_REVIEW_CONTRACT_ENTRY );
 		expect( contextProvider.getClientContext().currentPageContent ).toHaveLength( 1 );
 		expect( contextProvider.getClientContext().jetpackAi ).toBeUndefined();
 	} );
@@ -3163,22 +3126,19 @@ describe( 'toolProvider', () => {
 		it.each( [
 			[ 'Jetpack AI', SHOW_COMPONENT_TOOL_ID ],
 			[ 'legacy Big Sky', LEGACY_SHOW_COMPONENT_TOOL_ID ],
-		] )(
-			'rejects the old AI Editorial Review type through the %s tool',
-			async ( _label, toolId ) => {
-				const { result } = ( await toolProvider.executeAbility( toolId, {
-					type: 'review-mediation',
-					props: {},
-				} ) ) as any;
+		] )( 'rejects an unknown component type through the %s tool', async ( _label, toolId ) => {
+			const { result } = ( await toolProvider.executeAbility( toolId, {
+				type: 'unregistered-component',
+				props: {},
+			} ) ) as any;
 
-				expect( result ).toMatchObject( {
-					success: false,
-					error: 'show-component: no component registered for type "review-mediation"',
-					returnToAgent: false,
-				} );
-				expect( result.agentMessage ).toBeUndefined();
-			}
-		);
+			expect( result ).toMatchObject( {
+				success: false,
+				error: 'show-component: no component registered for type "unregistered-component"',
+				returnToAgent: false,
+			} );
+			expect( result.agentMessage ).toBeUndefined();
+		} );
 
 		it( 'delegates non-Jetpack legacy show-component calls to Big Sky', async () => {
 			const args = {

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -804,11 +804,6 @@ export const contextProvider = {
 					type: 'selected-block-content',
 					data: selectedBlockContent ? { content: selectedBlockContent } : null,
 				},
-				{
-					id: 'ai-editorial-review-contract',
-					type: 'ai-editorial-review-contract',
-					data: { version: 2 },
-				},
 			],
 		};
 	},


### PR DESCRIPTION
## Proposed Changes

* Stop sending the obsolete versioned AI Editorial Review client-context marker.
* Stop mapping the retired quota error code while retaining the current `ai_editorial_review_over_limit` code and generic Jetpack AI usage-limit messages.
* Replace old component-name fixtures with generic unknown-component coverage.
* Preserve the current AI Editorial Review component, suggestion, selected-block context, and shared Big Sky provider compatibility.

## Why are these changes being made?

* WordPress.com now uses AI Editorial Review nomenclature and contracts unconditionally. The server-side contraction is split across `231204-ghe-Automattic/wpcom`, `231206-ghe-Automattic/wpcom`, and `231207-ghe-Automattic/wpcom`.
* This removes the remaining client compatibility markers so maintained Calypso code and tests describe only the current product contract.
* The Agents Manager release containing this change must wait until `231207-ghe-Automattic/wpcom` is fully deployed.

## Testing Instructions

1. Sandbox `widgets.wp.com`.
2. In this Calypso branch, run:

   ```sh
   yarn dev --sync
   ```

3. Sandbox the final WordPress.com stack through `231207-ghe-Automattic/wpcom`, then follow the regression testing instructions in `231204-ghe-Automattic/wpcom`.
4. Open a saved draft post and run Editorial Review. Confirm the review renders and remains usable.
5. Force the WordPress.com AI Editorial Review quota to one in the sandbox. Run Editorial Review once on a cache miss, modify and save the draft to force a new review state, then run it again. Confirm the second request displays:

   > You have reached your Jetpack AI usage limit. Upgrade your plan to continue.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
