### PR TITLE
A4A Licenses: Fix the list loading placeholder (single Product bar, aligned columns)

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -442,32 +442,22 @@ export function LicensePreviewPlaceholder() {
 		<div className="license-preview license-preview--placeholder">
 			<LicenseListItem className="license-preview__card">
 				<div>
-					<h3 className="license-preview__domain">{ translate( 'Loading' ) }</h3>
-
-					<div className="license-preview__product" />
+					<div className="license-preview__placeholder-bar">{ translate( 'Loading' ) }</div>
 				</div>
 
 				<div>
-					<div className="license-preview__label">{ translate( 'Issued on:' ) }</div>
-
-					<div />
+					<div className="license-preview__placeholder-bar" />
 				</div>
 
 				<div>
-					<div className="license-preview__label">{ translate( 'Assigned on:' ) }</div>
-
-					<div />
+					<div className="license-preview__placeholder-bar" />
 				</div>
 
 				<div>
-					<div className="license-preview__label">{ translate( 'Revoked on:' ) }</div>
-
-					<div />
+					<div className="license-preview__placeholder-bar" />
 				</div>
 
-				<div>
-					<div className="license-preview__copy-license-key" />
-				</div>
+				<div />
 
 				<div />
 			</LicenseListItem>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -55,29 +55,6 @@
 	}
 }
 
-.license-preview__domain {
-	padding: 0;
-	margin: 0 0 4px;
-	@include body-x-large;
-	color: var(--color-neutral-100);
-	overflow: hidden;
-	word-break: break-all;
-
-	span + span {
-		margin-inline-start: 12px;
-
-		@include break-xlarge() {
-			display: block;
-			margin-inline-start: 0;
-		}
-
-		@include break-wide() {
-			display: inline;
-			margin-inline-start: 12px;
-		}
-	}
-}
-
 .license-preview__tag {
 	white-space: nowrap;
 	@include body-medium;
@@ -123,14 +100,6 @@
 	}
 }
 
-.license-preview__copy-license-key {
-	&.button {
-		font-weight: 600;
-		color: var(--color-neutral-80);
-		border-color: var(--color-text-subtle);
-	}
-}
-
 .license-preview__toggle {
 	padding: 0;
 }
@@ -149,10 +118,7 @@
 }
 
 .license-preview--placeholder {
-	.license-preview__domain,
-	.license-preview__product,
-	.license-preview__label + div,
-	.license-preview__copy-license-key {
+	.license-preview__placeholder-bar {
 		@include placeholder( --color-neutral-10 );
 	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -286,32 +286,22 @@ export function LicensePreviewPlaceholder() {
 		<div className="license-preview license-preview--placeholder">
 			<LicenseListItem className="license-preview__card">
 				<div>
-					<h3 className="license-preview__domain">{ translate( 'Loading' ) }</h3>
-
-					<div className="license-preview__product" />
+					<div className="license-preview__placeholder-bar">{ translate( 'Loading' ) }</div>
 				</div>
 
 				<div>
-					<div className="license-preview__label">{ translate( 'Issued on:' ) }</div>
-
-					<div />
+					<div className="license-preview__placeholder-bar" />
 				</div>
 
 				<div>
-					<div className="license-preview__label">{ translate( 'Assigned on:' ) }</div>
-
-					<div />
+					<div className="license-preview__placeholder-bar" />
 				</div>
 
 				<div>
-					<div className="license-preview__label">{ translate( 'Revoked on:' ) }</div>
-
-					<div />
+					<div className="license-preview__placeholder-bar" />
 				</div>
 
-				<div>
-					<div className="license-preview__copy-license-key" />
-				</div>
+				<div />
 
 				<div />
 			</LicenseListItem>

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
@@ -44,32 +44,6 @@
 		top: 3px;
 	}
 
-	&__domain {
-		padding: 0;
-		margin: 0 0 4px;
-		font-size: 1.25rem;
-		font-weight: normal;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-		line-height: 1.75rem;
-		color: var(--studio-gray-100);
-		overflow: hidden;
-		word-break: break-all;
-
-		span + span {
-			margin-left: 12px;
-
-			@include break-xlarge() {
-				display: block;
-				margin-left: 0;
-			}
-
-			@include break-wide() {
-				display: inline;
-				margin-left: 12px;
-			}
-		}
-	}
-
 	&__tag {
 		white-space: nowrap;
 		font-size: 0.875rem;
@@ -117,22 +91,11 @@
 		}
 	}
 
-	&__copy-license-key {
-		&.button {
-			font-weight: 600;
-			color: var(--studio-gray-80);
-			border-color: var(--color-text-subtle);
-		}
-	}
-
 	&__toggle {
 		padding: 0;
 	}
 
-	&--placeholder &__domain,
-	&--placeholder &__product,
-	&--placeholder &__label + div,
-	&--placeholder &__copy-license-key {
+	&--placeholder &__placeholder-bar {
 		@include placeholder( --color-neutral-10 );
 	}
 


### PR DESCRIPTION
On the Licenses list (`/purchases/licenses`, all tabs), the **loading placeholder** row had two problems:

1. The **Product** column rendered **two stacked skeleton bars** while every other column rendered a single bar — the real (loaded) Product cell is a single line, so the second bar was just a leftover `__domain` element that never matched real content.
2. The placeholder's **columns didn't line up with the real row / header.** It emitted cells for Product / Issued on / Assigned on / Revoked on / copy-key / (empty) against the real row's Product / Site / Issued on / Assigned on / badges / actions. Above `break-xlarge` the stray labels are `display: none` so it looked fine, but below it an "Issued on:" label sat where **Site** belongs.

This change:

- Collapses the Product placeholder cell to a **single** `license-preview__product` bar (keeping the transparent "Loading" string so it's still exposed to assistive tech), and removes the now-dead `__domain` rules.
- Realigns the placeholder's columns to match the real row's columns, so the skeleton lines up with the header at **all** breakpoints.

Both fixes are applied to both copies of the component — the Automattic for Agencies `license-preview` and the Jetpack Cloud partner-portal `license-preview` (they're identical, and A4A's bundle details still render the local one) — so the A4A list, A4A bundle details, and the Jetpack Cloud partner portal stay consistent.

No tests: this deletes and reorders presentational skeleton markup and removes dead CSS — no logic or state. A test pinning "N grey divs in this order" would assert markup rather than behavior and break on any restyle; the before/after screenshots are the proportionate evidence.

Follow-up (not in this PR): A4A imports the Jetpack Cloud placeholder while also shipping an identical local one — worth collapsing to a single component later.

Related (already merged, not part of this diff): the "Manage in Pressable" link's doubled underline and its text color were fixed in #113119, so the licenses list's other visual polish is already on trunk.

## Testing Instructions

Prerequisites: A4A dev environment (`yarn start-a8c-for-agencies`) or this PR's calypso.live build, on an agency with licenses so `/licenses` has rows.

1. Open `/licenses` (any tab) and observe the loading state (throttle the network, or reload). Confirm the **Product** column shows a **single** skeleton bar, consistent with the other columns.
2. Confirm the placeholder's columns **line up with the header** — check both a wide viewport and a narrower one (below `break-xlarge`); no label should sit under the wrong column.
