### PR TITLE
A4A Sites: Add empty states for no sites / favorites / development

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/empty-state.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/empty-state.scss
@@ -1,0 +1,8 @@
+.sites-dashboard__empty-state {
+	display: flex;
+	flex: 1;
+	align-items: center;
+	justify-content: center;
+	padding: 24px;
+	text-align: center;
+}

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/empty-state.tsx
@@ -1,0 +1,22 @@
+import { __experimentalText as Text, __experimentalVStack as VStack } from '@wordpress/components';
+import { preventWidows } from 'calypso/lib/formatting';
+
+import './empty-state.scss';
+
+interface Props {
+	title: string;
+	message: string;
+}
+
+export default function SitesDashboardEmptyState( { title, message }: Props ) {
+	return (
+		<div className="sites-dashboard__empty-state">
+			<VStack spacing={ 2 } alignment="center">
+				<Text size={ 20 } weight={ 600 }>
+					{ title }
+				</Text>
+				<Text variant="muted">{ preventWidows( message ) }</Text>
+			</VStack>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/empty-state.tsx
@@ -1,14 +1,39 @@
 import { __experimentalText as Text, __experimentalVStack as VStack } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
 import { preventWidows } from 'calypso/lib/formatting';
 
 import './empty-state.scss';
 
-interface Props {
-	title: string;
-	message: string;
-}
+export type SitesEmptyStateVariant = 'no-sites' | 'no-favorites' | 'no-development';
 
-export default function SitesDashboardEmptyState( { title, message }: Props ) {
+export default function SitesDashboardEmptyState( {
+	variant,
+}: {
+	variant: SitesEmptyStateVariant;
+} ) {
+	const translate = useTranslate();
+
+	const content: Record< SitesEmptyStateVariant, { title: string; message: string } > = {
+		'no-sites': {
+			title: translate( 'Add your first site' ),
+			message: translate(
+				'To get started, add a site using the “Add sites” button at the top of the page.'
+			),
+		},
+		'no-favorites': {
+			title: translate( 'No favorite sites yet' ),
+			message: translate( 'Mark a site as a favorite with the star icon to quickly find it here.' ),
+		},
+		'no-development': {
+			title: translate( 'No development sites yet' ),
+			message: translate(
+				'Create a free development site using the “Add sites” button at the top of the page.'
+			),
+		},
+	};
+
+	const { title, message } = content[ variant ];
+
 	return (
 		<div className="sites-dashboard__empty-state">
 			<VStack spacing={ 2 } alignment="center">

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -39,7 +39,7 @@ import { OverviewPreviewPane } from '../features/a4a/overview-preview-pane';
 import SitesDashboardContext from '../sites-dashboard-context';
 import SitesHeaderActions from '../sites-header-actions';
 import SiteNotifications from '../sites-notifications';
-import SitesDashboardEmptyState from './empty-state';
+import SitesDashboardEmptyState, { type SitesEmptyStateVariant } from './empty-state';
 import { getSelectedFilters } from './get-selected-filters';
 import ProvisioningSiteNotification from './provisioning-site-notification';
 import { updateSitesDashboardUrl } from './update-sites-dashboard-url';
@@ -145,6 +145,9 @@ export function SitesDashboard() {
 
 	const hasNoFavoritesYet =
 		isUnfilteredView && showOnlyFavorites && ( data?.totalFavorites ?? 0 ) === 0;
+
+	const hasNoDevelopmentSitesYet =
+		isUnfilteredView && showOnlyDevelopmentSites && ( data?.totalDevelopmentSites ?? 0 ) === 0;
 
 	useEffect( () => {
 		if ( dataViewsState.selectedItem && ! initialSelectedSiteUrl ) {
@@ -253,7 +256,16 @@ export function SitesDashboard() {
 		tourId = 'addSiteStep1';
 	}
 
-	const shouldShowEmptyState = ! tourId && ( hasNoSitesYet || hasNoFavoritesYet );
+	let emptyStateVariant: SitesEmptyStateVariant | null = null;
+	if ( ! tourId ) {
+		if ( hasNoSitesYet ) {
+			emptyStateVariant = 'no-sites';
+		} else if ( hasNoFavoritesYet ) {
+			emptyStateVariant = 'no-favorites';
+		} else if ( hasNoDevelopmentSitesYet ) {
+			emptyStateVariant = 'no-development';
+		}
+	}
 
 	return (
 		<Layout
@@ -286,23 +298,8 @@ export function SitesDashboard() {
 
 				<SiteNotifications />
 				{ tourId && <GuidedTour defaultTourId={ tourId } /> }
-				{ shouldShowEmptyState ? (
-					<SitesDashboardEmptyState
-						title={
-							hasNoSitesYet
-								? translate( 'Add your first site' )
-								: translate( 'No favorite sites yet' )
-						}
-						message={
-							hasNoSitesYet
-								? translate(
-										'To get started, add a site using the “Add sites” button at the top of the page.'
-								  )
-								: translate(
-										'Mark a site as a favorite with the star icon to quickly find it here.'
-								  )
-						}
-					/>
+				{ emptyStateVariant ? (
+					<SitesDashboardEmptyState variant={ emptyStateVariant } />
 				) : (
 					<DashboardDataContext.Provider
 						value={ {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -253,6 +253,8 @@ export function SitesDashboard() {
 		tourId = 'addSiteStep1';
 	}
 
+	const shouldShowEmptyState = ! tourId && ( hasNoSitesYet || hasNoFavoritesYet );
+
 	return (
 		<Layout
 			className={ clsx(
@@ -284,7 +286,7 @@ export function SitesDashboard() {
 
 				<SiteNotifications />
 				{ tourId && <GuidedTour defaultTourId={ tourId } /> }
-				{ ! tourId && ( hasNoSitesYet || hasNoFavoritesYet ) ? (
+				{ shouldShowEmptyState ? (
 					<SitesDashboardEmptyState
 						title={
 							hasNoSitesYet

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -257,14 +257,12 @@ export function SitesDashboard() {
 	}
 
 	let emptyStateVariant: SitesEmptyStateVariant | null = null;
-	if ( ! tourId ) {
-		if ( hasNoSitesYet ) {
-			emptyStateVariant = 'no-sites';
-		} else if ( hasNoFavoritesYet ) {
-			emptyStateVariant = 'no-favorites';
-		} else if ( hasNoDevelopmentSitesYet ) {
-			emptyStateVariant = 'no-development';
-		}
+	if ( hasNoSitesYet ) {
+		emptyStateVariant = 'no-sites';
+	} else if ( hasNoFavoritesYet ) {
+		emptyStateVariant = 'no-favorites';
+	} else if ( hasNoDevelopmentSitesYet ) {
+		emptyStateVariant = 'no-development';
 	}
 
 	return (

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -39,6 +39,7 @@ import { OverviewPreviewPane } from '../features/a4a/overview-preview-pane';
 import SitesDashboardContext from '../sites-dashboard-context';
 import SitesHeaderActions from '../sites-header-actions';
 import SiteNotifications from '../sites-notifications';
+import SitesDashboardEmptyState from './empty-state';
 import { getSelectedFilters } from './get-selected-filters';
 import ProvisioningSiteNotification from './provisioning-site-notification';
 import { updateSitesDashboardUrl } from './update-sites-dashboard-url';
@@ -130,6 +131,20 @@ export function SitesDashboard() {
 		perPage: sitesPerPage,
 		agencyId,
 	} );
+
+	// Show an onboarding empty state when the current view is empty on its own — not
+	// because a search or filter narrowed it down.
+	const isUnfilteredView =
+		! isLoading && ! isError && ! dataViewsState.search && selectedFilters.length === 0;
+
+	const hasNoSitesYet =
+		isUnfilteredView &&
+		! showOnlyFavorites &&
+		! showOnlyDevelopmentSites &&
+		( data?.total ?? 0 ) === 0;
+
+	const hasNoFavoritesYet =
+		isUnfilteredView && showOnlyFavorites && ( data?.totalFavorites ?? 0 ) === 0;
 
 	useEffect( () => {
 		if ( dataViewsState.selectedItem && ! initialSelectedSiteUrl ) {
@@ -269,33 +284,52 @@ export function SitesDashboard() {
 
 				<SiteNotifications />
 				{ tourId && <GuidedTour defaultTourId={ tourId } /> }
-				<DashboardDataContext.Provider
-					value={ {
-						verifiedContacts: {
-							emails: verifiedContacts?.emails ?? [],
-							phoneNumbers: verifiedContacts?.phoneNumbers ?? [],
-							refetchIfFailed: () => {
-								if ( fetchContactFailed ) {
-									refetchContacts();
-								}
-								return;
-							},
-						},
-						products: products ?? [],
-						isLargeScreen: isLargeScreen || false,
-					} }
-				>
-					<JetpackSitesDataViews
-						className={ clsx( 'sites-overview__content' ) }
-						data={ data }
-						isLoading={ isLoading }
-						isLargeScreen={ isLargeScreen || false }
-						setDataViewsState={ setDataViewsState }
-						setSelectedSiteFeature={ setSelectedSiteFeature }
-						dataViewsState={ dataViewsState }
-						onRefetchSite={ refetch }
+				{ ! tourId && ( hasNoSitesYet || hasNoFavoritesYet ) ? (
+					<SitesDashboardEmptyState
+						title={
+							hasNoSitesYet
+								? translate( 'Add your first site' )
+								: translate( 'No favorite sites yet' )
+						}
+						message={
+							hasNoSitesYet
+								? translate(
+										'To get started, add a site using the “Add sites” button at the top of the page.'
+								  )
+								: translate(
+										'Mark a site as a favorite with the star icon to quickly find it here.'
+								  )
+						}
 					/>
-				</DashboardDataContext.Provider>
+				) : (
+					<DashboardDataContext.Provider
+						value={ {
+							verifiedContacts: {
+								emails: verifiedContacts?.emails ?? [],
+								phoneNumbers: verifiedContacts?.phoneNumbers ?? [],
+								refetchIfFailed: () => {
+									if ( fetchContactFailed ) {
+										refetchContacts();
+									}
+									return;
+								},
+							},
+							products: products ?? [],
+							isLargeScreen: isLargeScreen || false,
+						} }
+					>
+						<JetpackSitesDataViews
+							className={ clsx( 'sites-overview__content' ) }
+							data={ data }
+							isLoading={ isLoading }
+							isLargeScreen={ isLargeScreen || false }
+							setDataViewsState={ setDataViewsState }
+							setSelectedSiteFeature={ setSelectedSiteFeature }
+							dataViewsState={ dataViewsState }
+							onRefetchSite={ refetch }
+						/>
+					</DashboardDataContext.Provider>
+				) }
 			</LayoutColumn>
 
 			{ dataViewsState.selectedItem && (


### PR DESCRIPTION
## Proposed Changes

* Add an onboarding **empty state** to the A4A Sites dashboard, shown when the current view is empty on its own (not because a search or filter narrowed it down). Three variants:
  * **No sites** — "Add your first site".
  * **No favorites** (Favorites view) — "No favorite sites yet".
  * **No development sites** (Development view) — "No development sites yet".
* The empty state replaces the dataviews (and its lone search box) and is centered in the content area. Copy for each variant lives in the `SitesDashboardEmptyState` component, keyed by a `variant` prop; the dashboard just computes which variant applies.

<img width="1867" height="833" alt="Screenshot 2026-07-30 at 11 11 08 PM" src="https://github.com/user-attachments/assets/00cb83f7-1aed-4b1e-8651-2ad8198a9cff" />
<img width="1868" height="839" alt="Screenshot 2026-07-30 at 11 34 53 PM" src="https://github.com/user-attachments/assets/23cf6a31-3b55-40f9-9cdc-51bc92f902a0" />
<img width="1866" height="834" alt="Screenshot 2026-07-30 at 11 19 01 PM" src="https://github.com/user-attachments/assets/73d5b9c9-ce5c-4084-96d5-a85c1ee818ea" />



## Why are these changes being made?

Previously, an agency with no sites (or an empty Favorites/Development view) saw an empty dataviews with a stray search box and no guidance — and typing in that search box showed no loading state. Showing a clear, centered empty state with a next step is friendlier and removes the confusing empty-search behavior.

Detection is derived from the same `useFetchDashboardSites` query that powers the list (`total` / `totalFavorites` / `totalDevelopmentSites`), so the empty state clears on its own when a site is added — the add refresh already refetches that query, no page reload needed. The shared `isUnfilteredView` guard prevents a zero-result search/filter from being mistaken for an empty account.

## Testing Instructions

* As an agency with **no sites**, open **Sites** → you should see "Add your first site" (no search box), centered. Add/connect a site → it clears without a reload.
* With sites present, open **Sites → Favorites** with nothing favorited → "No favorite sites yet". Star a site → the favorite appears.
* Open **Sites → Development** with no development sites → "No development sites yet".
* Confirm a zero-result **search** still shows the normal "No results" (not the onboarding empty state).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
