### PR TITLE
A4A Licenses: Match "Manage in Pressable" color to the row action links

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -46,12 +46,12 @@
 	&:visited,
 	&:active {
 		@include heading-medium;
-		color: var(--color-text-subtle);
+		color: var(--color-accent-80);
 	}
 
 	&:hover,
 	&:focus {
-		color: var(--color-neutral-70);
+		color: var(--color-accent-80);
 	}
 }
 


### PR DESCRIPTION
On the Licenses list (`/purchases/licenses`), the **"Manage in Pressable"** link is meant to match the row's action links — **"Assign"** and **"Create site"** — which are a `<Button borderless compact>` rendering at a flat `rgb(44, 51, 56)` (`#2c3338`).

A previous fix (#113119) tried to match them but took its tokens from the base Calypso button rule (`--color-text-subtle` / `--color-neutral-70`). That base rule never applies inside Automattic for Agencies: `client/a8c-for-agencies/style.scss:202-206` overrides `.button.is-borderless` at higher specificity with a flat `color: var(--color-accent-80)` (remapped to `--studio-gray-80` = `#2c3338`). So the link matched a button that doesn't actually render — it stayed `rgb(100,105,112)` at rest and shifted to `rgb(60,67,74)` on hover, visibly different from "Assign"/"Create site".

This change sets `.license-preview__product-pressable-link` to `var(--color-accent-80)` for `&, &:visited, &:active` **and** `&:hover, &:focus` — the same flat token the action links use, with no hover shift. The explicit `:hover`/`:focus` block is kept (removing it would let `.theme-a8c-for-agencies .components-external-link:hover` win and repaint the link blue).

Verified: all three links now compute to `rgb(44, 51, 56)` at rest **and** hover, flat, matching each other; the single underline is unchanged.

Fixes [A4A-3116](https://linear.app/a8c/issue/A4A-3116). Follow-up to #113119.

## Testing Instructions

Prerequisites: A4A dev environment (`yarn start-a8c-for-agencies`) or this PR's calypso.live build, on `/licenses` for an agency that has a **Pressable** license (shows "Manage in Pressable") and an **unassigned** license (shows "Create site"/"Assign").

1. Open `/licenses` and compare the **"Manage in Pressable"** link to **"Create site"** / **"Assign"** in other rows. Confirm they are the **same color** (`#2c3338`).
2. Hover "Manage in Pressable" and confirm the color **does not shift** (matching the action links, which don't shift either).
3. Confirm "Manage in Pressable" still shows a single underline and its external-link icon.
