### PR TITLE
A4A Licenses: Match "Manage in Pressable" link color to the sibling row actions

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -44,14 +44,11 @@
 
 	&,
 	&:visited,
-	&:active {
-		@include heading-medium;
-		color: var(--color-text-subtle);
-	}
-
+	&:active,
 	&:hover,
 	&:focus {
-		color: var(--color-neutral-70);
+		@include heading-medium;
+		color: var(--color-accent-80);
 	}
 }
 


### PR DESCRIPTION
In the Licenses list (`/licenses`) in Automattic for Agencies, each license row for a Pressable-hosted site shows a **Manage in Pressable** external link. The sibling row actions in the same column — **Create site** and **Assign** — render in the theme's accent color.

The Pressable link did not match them. Its stylesheet set `color: var(--color-text-subtle)` for the resting, visited, and active states and `var(--color-neutral-70)` on hover, so the link rendered **gray** while the sibling actions next to it rendered in the accent color. The result read as an inconsistent, muted link sitting beside darker actions in the same list.

This change unifies every state of `.license-preview__product-pressable-link` on the same token the sibling actions use (`var(--color-accent-80)`) and applies `heading-medium` across all states, so the link's text and external-link icon match **Create site** / **Assign** in normal, hover, visited, focus, and active. It does not reintroduce the second underline that a previous change removed — `ExternalLink` already draws its own underline.

No behavior change: the link's `href` and handler are untouched; this is a color-token swap only.

No tests: this is a cosmetic CSS change with no logic to assert, and nothing outside the two files in this folder references the affected class.

Follow-up to [A4A-3116](https://linear.app/a8c/issue/A4A-3116).

## Before / after

Before — the link renders gray (`--color-text-subtle`) next to the darker sibling actions:

<img width="800" alt="pressable-link-before" src="https://github.com/user-attachments/assets/f2c964eb-fe53-46e1-8256-d7597ba17951" />

After — the link matches the **Create site** / **Assign** actions:

<img width="800" alt="pressable-link-after" src="https://github.com/user-attachments/assets/fd2223de-ba50-48a6-a7f9-7790b99cdbb4" />

## Testing Instructions

Prerequisites: an A4A dev environment (`yarn start-a8c-for-agencies`) signed in to an agency that has at least one license assigned to a **Pressable** site.

1. Open `/licenses`.
2. Find a license row for a Pressable-hosted site and locate the **Manage in Pressable** link.
3. Compare its color to the **Create site** and **Assign** actions in the same column. Confirm the text and the ↗ icon now match those actions (not gray) in the resting state.
4. Hover, focus, and — if the link has been visited — confirm it stays matched in those states too, with a single underline.
5. Click the link and confirm it still opens the Pressable management destination (behavior unchanged).
