### PR TITLE
A4A: Fix 21 content-quality issues from the agencies.automattic.com audit

### DIFF
--- a/client/a8c-for-agencies/hooks/use-onboarding-tours.ts
+++ b/client/a8c-for-agencies/hooks/use-onboarding-tours.ts
@@ -116,7 +116,7 @@ export default function useOnboardingTours() {
 								);
 							},
 							id: 'boost_agency_visibility',
-							title: translate( "Boost your agency's visibilty across our Partner Directories" ),
+							title: translate( "Boost your agency's visibility across our Partner Directories" ),
 							useCalypsoPath: true,
 						},
 				  ]

--- a/client/a8c-for-agencies/sections/agency-tier/lib/get-tier-benefits.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/lib/get-tier-benefits.ts
@@ -118,7 +118,7 @@ const getTierBenefits = ( translate: ( key: string ) => string ): Benefit[] => [
 	{
 		title: translate( 'Pre-qualified sales leads' ),
 		description: translate(
-			'Pro Partners eligible to receive pre-qualified leads from Automattic sales teams when opportunities arise as well as leads generated through agency directory listings.'
+			'Pro Partners are eligible to receive pre-qualified leads from Automattic sales teams when opportunities arise, as well as leads generated through agency directory listings.'
 		),
 		features: [],
 		isComingSoon: false,

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-wpcom-plan-description.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-wpcom-plan-description.ts
@@ -26,7 +26,7 @@ export default function useWPCOMPlanDescription( slug: string ) {
 
 		features2 = [
 			translate( 'Priority support 24/7' ),
-			translate( 'DDOS mitigation' ),
+			translate( 'DDoS mitigation' ),
 			translate( 'Free staging environment' ),
 			translate( 'Isolated site infrastructure' ),
 			translate( 'Malware detection & removal' ),

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/common/hosting-features.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/common/hosting-features.tsx
@@ -50,7 +50,7 @@ export default function HostingFeatures( {
 					title: translate( 'Security' ),
 					items: [
 						translate( 'Real-time backups' ),
-						translate( 'DDOS protection and mitigation' ),
+						translate( 'DDoS protection and mitigation' ),
 						translate( 'Brute-force protection' ),
 						translate( 'Malware detection & removal' ),
 						translate( 'Spam protection with Akismet' ),

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/index.tsx
@@ -125,7 +125,7 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 				heading={ translate( 'Jetpack Complete included' ) }
 				subheading={ translate( "Supercharge your clients' sites" ) }
 				description={ translate(
-					'Every Pressable site comes with a free Jetpack Complete license — an %(amount)s/year/site value.',
+					'Every Pressable site comes with a free Jetpack Complete license — a %(amount)s/year/site value.',
 					{
 						args: {
 							amount: formatCurrency( 899, 'USD' ),

--- a/client/a8c-for-agencies/sections/marketplace/refer-hosting/form.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/refer-hosting/form.tsx
@@ -219,7 +219,7 @@ export default function ReferHostingForm( {
 			title={ formTitle }
 			autocomplete="off"
 			description={ translate(
-				'Once submitted, our team will take it from there. We will keep you informed of our progress along the way. All fields are required unless marked as optional'
+				'Once submitted, our team will take it from there. We will keep you informed of our progress along the way. All fields are required unless marked as optional.'
 			) }
 		>
 			<FormSection title={ companyTitle }>

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-faqs/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-faqs/index.tsx
@@ -1,12 +1,9 @@
-import { formatCurrency } from '@automattic/number-formatters';
-import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import PageSection from 'calypso/a8c-for-agencies/components/page-section';
 import { A4A_MIGRATIONS_PAYMENT_SETTINGS } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import FoldableFAQ from 'calypso/components/foldable-faq';
-import { preventWidows } from 'calypso/lib/formatting';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
@@ -73,51 +70,6 @@ export default function MigrationsFAQs() {
 			question: translate( 'How do you calculate my buyout credit?' ),
 			answer: translate(
 				'We will ask you to provide a copy of your current contract or invoice to determine the remaining time on your plan. We will then credit you for the same amount of time left on the plan that you choose in Automattic for Agencies.'
-			),
-		},
-		{
-			id: 'multiple-sites-migration-offers',
-			question: translate( 'Are there any special offers for agencies moving multiple sites?' ),
-			answer: (
-				<>
-					{ preventWidows(
-						translate(
-							"Receive %(amount)s for each site you migrate to Pressable or WordPress.com, up to %(maxAmount)s.* If you're a WP\u00A0Engine customer, we'll also credit the costs to set you free. {{a}}Full Terms{{/a}}",
-							{
-								args: {
-									amount: formatCurrency( 100, 'USD' ),
-									maxAmount: formatCurrency( 10000, 'USD' ),
-								},
-								components: {
-									a: (
-										<ExternalLink
-											href="https://automattic.com/for-agencies/program-incentives"
-											children={ null }
-										/>
-									),
-								},
-							}
-						)
-					) }
-					<br />
-					<br />
-					{ translate(
-						'* The migration limit is %(maxAmount)s for WP\u00A0Engine and %(maxAmount)s for other hosts. Offer valid until %(endDate)s',
-						{
-							args: {
-								maxAmount: formatCurrency( 10000, 'USD' ),
-								endDate: new Date( '2025-01-31T00:00:00' ).toLocaleDateString(
-									translate.localeSlug,
-									{
-										year: 'numeric',
-										month: 'long',
-										day: 'numeric',
-									}
-								),
-							},
-						}
-					) }
-				</>
 			),
 		},
 		{

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/index.tsx
@@ -64,8 +64,7 @@ export default function MigrationsHostingFeatures() {
 						title={ translate( 'Security' ) }
 						items={ [
 							translate( 'Real-time backups' ),
-							translate( 'Global CDN with 28+ locations' ),
-							translate( 'DDOS protection and mitigation' ),
+							translate( 'DDoS protection and mitigation' ),
 							translate( 'Brute-force protection' ),
 							translate( 'Malware detection & removal' ),
 							translate( 'Spam protection with Akismet' ),

--- a/client/a8c-for-agencies/sections/migrations/primary/self-migration-tool/migration-info.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/self-migration-tool/migration-info.tsx
@@ -28,7 +28,7 @@ const pressableSteps = (
 	{
 		stepId: 'create-site',
 		count: 2,
-		title: translate( 'Create a "Migration placeholder" site in Pressable' ),
+		title: translate( 'Create a “Migration placeholder” site in Pressable' ),
 		description: translate(
 			'In Pressable, click “Add site” and set “Migration placeholder” to yes.'
 		),
@@ -46,7 +46,7 @@ const pressableSteps = (
 		count: 3,
 		title: translate( 'Install the Pressable Migration plugin' ),
 		description: translate(
-			'Login to the site that you will be moving to the Pressable platform (the source site) and navigate to Plugins > Add New. In the plugin search box, search for {{a}}“Pressable Automated Migration”{{/a}} (or upload the plugin if you downloaded it instead). When the plugin listing comes up, click on Install Now and then Activate',
+			'Log in to the site that you will be moving to the Pressable platform (the source site) and navigate to Plugins > Add New. In the plugin search box, search for {{a}}“Pressable Automated Migration”{{/a}} (or upload the plugin if you downloaded it instead). When the plugin listing comes up, click on Install Now and then Activate.',
 			{
 				components: {
 					a: (
@@ -72,7 +72,7 @@ const pressableSteps = (
 		count: 4,
 		title: translate( 'Use the SFTP credentials provided in Pressable to migrate the site' ),
 		description: translate(
-			'Login to the {{a}}My.Pressable.com Dashboard{{/a}} and open up the settings page for the site you would like to migrate to. In the left menu, you will see a Site Actions tab. From that, navigate to the Migrate Site section. This section will show the details you will need for the Pressable Automated Migration plugin.',
+			'Log in to the {{a}}My.Pressable.com Dashboard{{/a}} and open up the settings page for the site you would like to migrate to. In the left menu, you will see a Site Actions tab. From that, navigate to the Migrate Site section. This section will show the details you will need for the Pressable Automated Migration plugin.',
 			{
 				components: {
 					a: <ExternalLink href="https://my.pressable.com" children={ null } />,
@@ -135,11 +135,11 @@ const pressableSteps = (
 		count: 7,
 		title: translate( 'Fill in your payment information to receive commissions' ),
 		description: translate(
-			'Add you bank and business information so that we can send you commission payments.'
+			'Add your bank and business information so that we can send you commission payments.'
 		),
 		buttonProps: {
 			variant: 'primary',
-			label: translate( 'Add my bank infomation' ),
+			label: translate( 'Add my bank information' ),
 			href: A4A_MIGRATIONS_PAYMENT_SETTINGS,
 			eventName: 'calypso_a4a_migrate_to_pressable_add_bank_info_click',
 		},
@@ -233,11 +233,11 @@ const wpcomSteps = (
 		count: 6,
 		title: translate( 'Fill in your payment information to receive commissions' ),
 		description: translate(
-			'Add you bank and business information so that we can send you commission payments.'
+			'Add your bank and business information so that we can send you commission payments.'
 		),
 		buttonProps: {
 			variant: 'primary',
-			label: translate( 'Add my bank infomation' ),
+			label: translate( 'Add my bank information' ),
 			href: A4A_MIGRATIONS_PAYMENT_SETTINGS,
 			eventName: 'calypso_a4a_migration_to_wpcom_add_bank_info_click',
 		},

--- a/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
@@ -43,7 +43,7 @@ const OverviewBodyHosting = () => {
 			translate(
 				'24/7 expert security team, malware scanning and removal, and DDoS and WAF protection.'
 			),
-			translate( 'Realtime backups with one-click restores.' ),
+			translate( 'Real-time backups with one-click restores.' ),
 			translate( 'Round-the-clock support from WordPress experts.' ),
 		],
 		// translators: Button navigating to A4A Marketplace

--- a/client/a8c-for-agencies/sections/overview/body/products/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/products/index.tsx
@@ -63,7 +63,7 @@ const OverviewBodyProducts = () => {
 		title: translate( 'WooCommerce' ),
 		titleIcon: <img width={ 40 } src={ WooLogoColor } alt="WooCommerce" />,
 		description: translate(
-			'WooCommerce is the platform that offers unlimited potential to build the perfect ecommerce experiences for your clients. No matter what success looks like, you can do it with WooCommerce. Purchase Woo extensions in bulk to save big.'
+			'WooCommerce is the platform that offers unlimited potential to build perfect ecommerce experiences for your clients. No matter what success looks like, you can do it with WooCommerce. Purchase Woo extensions in bulk to save big.'
 		),
 		highlights: [
 			translate( 'AutomateWoo: Grow sales with less effort using powerful marketing automation.' ),

--- a/client/a8c-for-agencies/sections/purchases/billing/billing-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/billing/billing-details/index.tsx
@@ -145,7 +145,7 @@ export default function BillingDetails() {
 						{ billing.isSuccess &&
 							translate( 'Projected cost for {{bold}}%(date)s{{/bold}}', {
 								components: { bold: <strong style={ { whiteSpace: 'nowrap' } } /> },
-								args: { date: moment( billing.data.date ).format( 'MMMM, YYYY' ) },
+								args: { date: moment( billing.data.date ).format( 'MMMM YYYY' ) },
 							} ) }
 
 						{ billing.isLoading && <TextPlaceholder /> }

--- a/client/a8c-for-agencies/sections/purchases/billing/billing-summary/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/billing/billing-summary/index.tsx
@@ -102,7 +102,7 @@ export default function BillingSummary() {
 					{ billing.isSuccess && <CostTooltip /> }
 					{ billing.isSuccess &&
 						/* translators: fullMonth (e.g. "January") and fullYear (e.g. "2024") */
-						translate( 'Projected cost for %(fullMonth)s, %(fullYear)s', {
+						translate( 'Projected cost for %(fullMonth)s %(fullYear)s', {
 							args: {
 								fullMonth: moment( billing.data.date ).format( 'MMMM' ),
 								fullYear: moment( billing.data.date ).format( 'YYYY' ),

--- a/client/a8c-for-agencies/sections/referrals/primary/footer/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/footer/index.tsx
@@ -11,7 +11,7 @@ export default function ReferralsFooter() {
 	return (
 		<div className="referrals-footer">
 			{ translate(
-				'Payments are issued once a quarter with 60 day terms and are net of refunds and chargebacks. See the {{a}}payout schedule{{/a}} for more exact dates.',
+				'Payments are issued once a quarter with 60-day terms and are net of refunds and chargebacks. See the {{a}}payout schedule{{/a}} for more exact dates.',
 				{
 					components: {
 						a: <ExternalLink href={ link } children={ null } />,

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
@@ -50,7 +50,7 @@ export const ReportDateColumn = ( { date }: { date: number | null } ) => {
 	}
 
 	const dateObj = new Date( date * 1000 );
-	return <FormattedDate date={ dateObj } format="DD MMM YYYY HH:mm" />;
+	return <FormattedDate date={ dateObj } format="ll HH:mm" />;
 };
 
 export const ReportTimeframeColumn = ( {
@@ -86,8 +86,8 @@ export const ReportTimeframeColumn = ( {
 					{ timeframeText }
 				</span>
 				<Tooltip context={ tooltipRef.current } isVisible={ showTooltip } position="top">
-					<FormattedDate date={ startDateObj } format="DD MMM YYYY" /> -
-					<FormattedDate date={ endDateObj } format="DD MMM YYYY" />
+					<FormattedDate date={ startDateObj } format="ll" /> -
+					<FormattedDate date={ endDateObj } format="ll" />
 				</Tooltip>
 			</>
 		);

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/index.tsx
@@ -86,7 +86,7 @@ const WooPaymentsOverview = () => {
 				'Multi-Currency support is built-in. Accept payments in 135+ currencies using WooPayments.'
 			),
 			translate(
-				'Increase conversions by enabling payment methods including {{wooPay}}WooPay{{/wooPay}}, {{applePay}}Apple Pay®{{/applePay}}, {{googlePay}}Google Pay{{/googlePay}}, {{iDeal}}iDeal{{/iDeal}}, {{p24}}P24{{/p24}}, {{eps}}EPS{{/eps}}, and {{bancontact}}Bancontact{{/bancontact}}.',
+				'Increase conversions by enabling payment methods including {{wooPay}}WooPay{{/wooPay}}, {{applePay}}Apple Pay®{{/applePay}}, {{googlePay}}Google Pay{{/googlePay}}, {{iDeal}}iDEAL{{/iDeal}}, {{p24}}P24{{/p24}}, {{eps}}EPS{{/eps}}, and {{bancontact}}Bancontact{{/bancontact}}.',
 				{
 					components: {
 						wooPay: (
@@ -170,7 +170,7 @@ const WooPaymentsOverview = () => {
 				}
 			),
 			translate(
-				'You may be eligible to earn up to {{a}}20% discount on Payment Processing Fees{{/a}}.',
+				'You may be eligible to earn up to a {{a}}20% discount on Payment Processing Fees{{/a}}.',
 				{
 					components: {
 						a: (
@@ -212,7 +212,7 @@ const WooPaymentsOverview = () => {
 				}
 			),
 			translate(
-				"Simplify your workflow. No more logging into third-party payment processor sites - manage everything from the comfort of your store's dashboard."
+				"Simplify your workflow. No more logging into third-party payment processor sites — manage everything from the comfort of your store's dashboard."
 			),
 			translate(
 				'Set a custom payout schedule to get your funds into your bank account as often as you need — daily, weekly, monthly, or even on-demand.'
@@ -434,7 +434,7 @@ const WooPaymentsOverview = () => {
 							</table>
 							<div className="woopayments-overview__legend">
 								{ translate(
-									"*Example earnings are calculated annually based on the TPV and revenue share rate shown and are subject change based on your client's TPV."
+									"*Example earnings are calculated annually based on the TPV and revenue share rate shown and are subject to change based on your client's TPV."
 								) }
 							</div>
 							<div className="woopayments-overview__legend">

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-site-setup/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-site-setup/index.tsx
@@ -240,7 +240,7 @@ const WooPaymentsSiteSetup = ( { siteId }: { siteId: string } ) => {
 									<>
 										<div>
 											{ translate(
-												"Once the plugin is installed and configured, each time a transaction occurs, you'll earn commisions!"
+												"Once the plugin is installed and configured, each time a transaction occurs, you'll earn commissions!"
 											) }
 										</div>
 										<Button

--- a/client/dashboard/agency/earn/migrations/commissions-list/commission-columns.tsx
+++ b/client/dashboard/agency/earn/migrations/commissions-list/commission-columns.tsx
@@ -26,7 +26,7 @@ export const MigratedOnColumn = ( {
 	locale: string;
 } ) => {
 	const date = new Date( migratedOn * 1000 );
-	return <>{ formatDate( date, locale, { day: '2-digit', month: 'short', year: 'numeric' } ) }</>;
+	return <>{ formatDate( date, locale ) }</>;
 };
 
 export const ReviewStatusColumn = ( {

--- a/client/dashboard/agency/team/dataviews/fields.tsx
+++ b/client/dashboard/agency/team/dataviews/fields.tsx
@@ -73,7 +73,7 @@ function formatAddedDate( value?: string ): string | null {
 	// Active members provide a Unix-seconds timestamp; invites provide an ISO date string.
 	const numeric = Number( value );
 	const date = Number.isNaN( numeric ) ? new Date( value ) : new Date( numeric * 1000 );
-	return Number.isNaN( date.getTime() ) ? null : dateI18n( 'F j, Y', date );
+	return Number.isNaN( date.getTime() ) ? null : dateI18n( 'M j, Y', date );
 }
 
 export function useTeamFields(): Field< TeamMember >[] {

--- a/client/dashboard/agency/tiers/constants.ts
+++ b/client/dashboard/agency/tiers/constants.ts
@@ -189,7 +189,7 @@ export const ALL_TIERS: TierItem[] = [
 				icon: envelope,
 				title: __( 'Pre-qualified sales leads' ),
 				description: __(
-					'Pro Partners eligible to receive pre-qualified leads from Automattic sales teams when opportunities arise as well as leads generated through agency directory listings.'
+					'Pro Partners are eligible to receive pre-qualified leads from Automattic sales teams when opportunities arise, as well as leads generated through agency directory listings.'
 				),
 			},
 			{


### PR DESCRIPTION
A content audit of the agency-facing surfaces on agencies.automattic.com (the Automattic for Agencies app) surfaced 20 visible copy defects across the Migrations, Referrals, Billing, WooPayments, hosting, and onboarding areas. Each was confirmed rendering live and traced to its source string.

The defects fall into a few groups: plain typos (`commisions`, `visibilty`, `infomation`), missing words (`are subject change`, `Pro Partners eligible to receive`), wrong articles (`an US$899.00`, `earn up to 20% discount`), grammar (`Login to` used as a verb, `build the perfect ecommerce experiences`), brand/capitalization slips (`DDOS` for DDoS, `iDeal` for iDEAL), and punctuation inconsistencies (straight quotes next to curly ones, unterminated sentences, a spaced hyphen beside an em dash, `July, 2026`).

Some are worse than cosmetic. The WooPayments "Benefits to share with your client" bullets sit behind a "Copy to clipboard" button, so the errors get pasted verbatim into agency-to-client messaging. The referrals payout footer states payment terms. The `Projected cost for %(fullMonth)s, %(fullYear)s` template rendered a spurious comma every month, in two places on the Billing page.

This change corrects the human-readable words at each source string, leaving every `translate()` call, placeholder token, and embedded component intact. A few items needed more than a single-string edit:

- **A8C-006** — the broken sentence was duplicated in `client/dashboard/agency/tiers/constants.ts`; both copies are fixed.
- **A8C-008** — the second occurrence's comma lived in `moment().format('MMMM, YYYY')`, not the `translate()` template, so it is fixed at the format pattern.
- **A8C-018** — "Global CDN with 28+ locations" appeared under both Performance and Security; the duplicate under Security is removed rather than replaced (a content decision worth a reviewer's eye).
- **A8C-021** — the Team, Commissions, and Referrals tables used three different date formats; all three are unified on the medium form using each caller's own locale-aware formatter.
- **A8C-009** — the Migrations → Overview FAQ *"Are there any special offers for agencies moving multiple sites?"* advertised an offer *"valid until January 31, 2025"* (18 months expired), hardcoded with no active-offer guard. The whole FAQ entry (question and answer) is removed, along with the now-dead date logic.

No tests: every change is a string edit, a format-token swap, or the removal of a static FAQ entry — no branching logic, and no existing test or snapshot asserted the old text (verified by grep).

Audit reference: `state/results/a8c-content-audit/` (issue IDs A8C-001 … A8C-028).

## Testing Instructions

Prerequisites: an A4A dev environment (`yarn start-a8c-for-agencies`) signed in to an agency account. Some strings are behind specific surfaces noted per step.

1. **WooPayments benefits** — open the WooPayments referral/site-setup flow and read the "Benefits to share with your client" bullets. Confirm no `commisions`, correct articles, and clean punctuation. Use "Copy to clipboard" and paste into a plain-text editor to confirm the copied text is clean.
2. **Billing** — open the Billing page and check the "Projected cost for <Month> <Year>" heading. Confirm it reads `Projected cost for July 2026` (no comma) in both places it appears.
3. **Migrations steps** — open the migration steps and confirm instructions read `Log in to …` (not `Login to …`) and end with full stops.
4. **Hosting feature lists** — confirm `DDoS` (not `DDOS`) and that a payment method reads `iDEAL` (not `iDeal`).
5. **Referrals payout footer** — confirm `60-day terms` (hyphenated) and `are subject to change`.
6. **Dashboard tables** — open the Team, Commissions, and Referrals tables and confirm all three render dates in the same format.
7. **Migrations FAQ (A8C-009)** — open Migrations → Overview and expand the FAQ. Confirm the *"Are there any special offers for agencies moving multiple sites?"* entry is gone and the other FAQ items still render.
