### PR TITLE
A4A Sites: Use DataViews' loading dim instead of TextPlaceholder skeletons

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -18,7 +18,6 @@ import { DataViews } from 'calypso/components/dataviews';
 import { GuidedTourStep } from 'calypso/components/guided-tour/step';
 import SiteStatusContent from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content';
 import { JETPACK_MANAGE_ONBOARDING_TOURS_EXAMPLE_SITE } from 'calypso/jetpack-cloud/sections/onboarding-tours/constants';
-import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { useFetchTestConnections } from '../../hooks/use-fetch-test-connection';
 import useFormattedSites from '../../hooks/use-formatted-sites';
 import { useSiteActionsDataViews } from '../../site-actions/use-site-actions';
@@ -44,6 +43,7 @@ const SitePreviewTourTarget = ( { children }: { children: ReactNode } ) => {
 export const JetpackSitesDataViews = ( {
 	data,
 	isLoading,
+	isFetching,
 	isLargeScreen,
 	setDataViewsState,
 	setSelectedSiteFeature,
@@ -106,10 +106,6 @@ export const JetpackSitesDataViews = ( {
 
 	const renderField = useCallback(
 		( column: AllowedTypes, item: SiteData ) => {
-			if ( isLoading ) {
-				return <TextPlaceholder />;
-			}
-
 			if ( column ) {
 				return (
 					<>
@@ -124,7 +120,7 @@ export const JetpackSitesDataViews = ( {
 				);
 			}
 		},
-		[ isLoading, isLargeScreen ]
+		[ isLargeScreen ]
 	);
 
 	// Legacy refs for guided tour popovers
@@ -188,9 +184,6 @@ export const JetpackSitesDataViews = ( {
 				),
 				getValue: ( { item }: { item: SiteData } ) => item.site.value.url,
 				render: ( { item }: { item: SiteData } ): ReactNode => {
-					if ( isLoading ) {
-						return <TextPlaceholder />;
-					}
 					const site = item.site.value;
 
 					const isSitePreviewTourTarget = site.blog_id === sitePreviewTourTargetId;
@@ -203,7 +196,6 @@ export const JetpackSitesDataViews = ( {
 						>
 							<SiteDataField
 								site={ site }
-								isLoading={ isLoading }
 								isDevSite={ item.isDevSite }
 								onSiteTitleClick={ openSitePreviewPane }
 								errors={ getSiteErrors( item ) }
@@ -382,10 +374,6 @@ export const JetpackSitesDataViews = ( {
 				),
 				getValue: ( { item }: { item: SiteData } ) => item.isFavorite,
 				render: ( { item }: { item: SiteData } ) => {
-					if ( isLoading ) {
-						return <TextPlaceholder />;
-					}
-
 					return (
 						<>
 							<span className="sites-dataviews__favorite-btn-wrapper">
@@ -412,7 +400,6 @@ export const JetpackSitesDataViews = ( {
 			scanRef,
 			pluginsRef,
 			sitePreviewTourTargetId,
-			isLoading,
 			dataViewsState.selectedItem?.blog_id,
 			openSitePreviewPane,
 			getSiteErrors,
@@ -517,7 +504,11 @@ export const JetpackSitesDataViews = ( {
 	}, [ fields, dataViewsState, setDataViewsState, data, actions ] );
 
 	return (
-		<ItemsDataViews data={ itemsData } isLoading={ isLoading } className={ className }>
+		<ItemsDataViews
+			data={ itemsData }
+			isLoading={ isFetching ?? isLoading }
+			className={ className }
+		>
 			<HStack
 				className="dataviews__view-actions"
 				alignment="top"

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -121,7 +121,7 @@ export function SitesDashboard() {
 	// Temporarily set perPage to 100 on Development sites page due to unresolved ES issue (https://github.com/Automattic/dotcom-forge/issues/8806)
 	const sitesPerPage = showOnlyDevelopmentSites ? 100 : dataViewsState.perPage;
 
-	const { data, isError, isLoading, refetch } = useFetchDashboardSites( {
+	const { data, isError, isLoading, isFetching, refetch } = useFetchDashboardSites( {
 		isPartnerOAuthTokenLoaded: false,
 		searchQuery: dataViewsState?.search,
 		currentPage: dataViewsState.page ?? 1,
@@ -129,6 +129,7 @@ export function SitesDashboard() {
 		sort: dataViewsState.sort,
 		perPage: sitesPerPage,
 		agencyId,
+		keepPreviousData: true,
 	} );
 
 	useEffect( () => {
@@ -289,6 +290,7 @@ export function SitesDashboard() {
 						className={ clsx( 'sites-overview__content' ) }
 						data={ data }
 						isLoading={ isLoading }
+						isFetching={ isFetching }
 						isLargeScreen={ isLargeScreen || false }
 						setDataViewsState={ setDataViewsState }
 						setSelectedSiteFeature={ setSelectedSiteFeature }

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/interfaces.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/interfaces.ts
@@ -15,6 +15,7 @@ export interface SitesDataViewsProps {
 	forceTourExampleSite?: boolean;
 	isLargeScreen: boolean;
 	isLoading: boolean;
+	isFetching?: boolean;
 	setDataViewsState: ( callback: ( prevState: DataViewsState ) => DataViewsState ) => void;
 	setSelectedSiteFeature: ( siteFeature: string | undefined ) => void;
 	dataViewsState: DataViewsState;

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
@@ -1,29 +1,17 @@
 import { Badge, Button } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import SiteFavicon from 'calypso/blocks/site-favicon';
-import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { Site, SiteError } from '../types';
 import SiteDataFieldErrorIndicator from './site-data-field-error-indicator';
 
 interface SiteDataFieldProps {
-	isLoading: boolean;
 	site: Site;
 	isDevSite?: boolean;
 	errors?: SiteError[];
 	onSiteTitleClick: ( site: Site ) => void;
 }
 
-const SiteDataField = ( {
-	isLoading,
-	site,
-	isDevSite,
-	errors,
-	onSiteTitleClick,
-}: SiteDataFieldProps ) => {
-	if ( isLoading ) {
-		return <TextPlaceholder />;
-	}
-
+const SiteDataField = ( { site, isDevSite, errors, onSiteTitleClick }: SiteDataFieldProps ) => {
 	const migrationInProgress = site.sticker?.includes( 'migration-in-progress' );
 
 	return (

--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import wpcom, { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 import type {
@@ -45,6 +45,9 @@ export interface FetchDashboardSitesArgsInterface {
 	sort?: DashboardSortInterface;
 	perPage?: number;
 	agencyId?: number;
+	// Keep the previous results visible (dimmed) while a new query fetches, instead
+	// of blanking the list. Opt-in so other consumers of this hook are unaffected.
+	keepPreviousData?: boolean;
 }
 
 const useFetchDashboardSites = (
@@ -56,6 +59,7 @@ const useFetchDashboardSites = (
 		sort,
 		perPage,
 		agencyId,
+		keepPreviousData: shouldKeepPreviousData = false,
 	}: FetchDashboardSitesArgsInterface,
 	isEnabled = true
 ) => {
@@ -111,6 +115,7 @@ const useFetchDashboardSites = (
 				totalFavorites: data.total_favorites,
 			};
 		},
+		placeholderData: shouldKeepPreviousData ? keepPreviousData : undefined,
 		enabled: isAgencyOrPartnerAuthEnabled && isEnabled,
 	} );
 };


### PR DESCRIPTION
## Proposed Changes

* Remove the per-cell `TextPlaceholder` skeletons from the A4A Sites dataview and rely on DataViews' **built-in loading state** — the dimmed, non-interactive table (`.dataviews-view-table.is-refreshing`), which DataViews applies automatically from its `isLoading` prop (with its own 400ms anti-flicker delay, `aria-busy`, and `inert`).
* Add an **opt-in `keepPreviousData`** flag to `useFetchDashboardSites` so the Sites dashboard keeps the previous rows on screen while a search / sort / pagination fetch runs, instead of blanking the list. The flag is opt-in, so the hook's other consumers are unaffected.
* Drive the table's loading off **`isFetching`** rather than `isLoading`. With `keepPreviousData`, React Query serves the previous rows as placeholder data during a refetch, so `isLoading` stays `false`; `isFetching` is what reflects the in-flight request and therefore triggers the dim on the visible rows.


https://github.com/user-attachments/assets/28e6457b-90da-4d33-a5a5-719b88984fb9



## Why are these changes being made?

The Sites dataview rendered its own `TextPlaceholder` skeleton in each field's render function, but those branches only run for rows that exist — during a cold fetch the list is empty, so the skeletons never actually appeared, and a search/sort/page change blanked the list to "No results" before repopulating.

Using the loading state DataViews already provides is simpler and gives a smoother result: the current rows dim in place while the new query loads, then swap in. It also removes bespoke placeholder markup in favor of framework behavior.

## Testing Instructions

* Open the A4A **Sites** dashboard with sites present.
* **Search**: type in the search box → the current rows dim (and become non-interactive), then swap to the filtered results — no blank/"No results" flash in between.
* **Sort** a column and **change pages** → same dim-then-swap behavior.
* The dim appears only if the fetch exceeds DataViews' built-in 400ms delay, so a very fast response may swap without a visible dim (intended anti-flicker behavior).
* Confirm rows still render normally once loaded (Site name/URL, status columns, favorite star), and row actions still work.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
