### PR TITLE
Dashboard: Show AI tools settings below the upgrade prompt

### DIFF
--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -275,7 +275,6 @@ function EmailAssistantCard( {
 						__nextHasNoMarginBottom
 						checked={ isAgentEmailEnabled }
 						disabled={ isEmailAddressActionDisabled }
-						help={ disabled ? upgradeRequiredText : undefined }
 						label={ __( 'Enable WordPress Agent email address' ) }
 						onChange={ handleEmailAddressToggle }
 					/>
@@ -455,7 +454,6 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 								__nextHasNoMarginBottom
 								checked={ isEnabled }
 								disabled={ ! isAvailable || mutation.isPending }
-								help={ ! isAvailable ? upgradeRequiredText : undefined }
 								label={ __( 'Enable WordPress Agent' ) }
 								onChange={ handleToggle }
 							/>
@@ -515,7 +513,6 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 										__nextHasNoMarginBottom
 										checked={ isMcpEnabled }
 										disabled={ ! isAvailable || mcpMutation.isPending }
-										help={ ! isAvailable ? upgradeRequiredText : undefined }
 										label={ __( 'Enable MCP access for this site' ) }
 										onChange={ handleMcpToggle }
 									/>

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -113,6 +113,9 @@ const features = [
 	__( 'Create beautiful images without leaving WordPress' ),
 ];
 
+const upgradeRequiredText = __( 'Upgrade your plan to enable this setting.' );
+const upgradeRequiredBadge = { text: __( 'Upgrade required' ) };
+
 const TELEGRAM_CONNECTION_PATH = '/me/developer';
 
 const INVALID_POST_BY_EMAIL_VALUES = new Set( [
@@ -261,6 +264,7 @@ function EmailAssistantCard( {
 						__nextHasNoMarginBottom
 						checked={ isAgentEmailEnabled }
 						disabled={ isEmailAddressActionDisabled }
+						help={ disabled ? upgradeRequiredText : undefined }
 						label={ __( 'Enable WordPress Agent email address' ) }
 						onChange={ handleEmailAddressToggle }
 					/>
@@ -439,6 +443,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 								__nextHasNoMarginBottom
 								checked={ isEnabled }
 								disabled={ ! isAvailable || mutation.isPending }
+								help={ ! isAvailable ? upgradeRequiredText : undefined }
 								label={ __( 'Enable WordPress Agent' ) }
 								onChange={ handleToggle }
 							/>
@@ -479,6 +484,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 								site_id: site.ID,
 							} );
 						} }
+						badges={ ! isAvailable ? [ upgradeRequiredBadge ] : undefined }
 						disabled={ ! isAvailable }
 					/>
 				) }
@@ -496,6 +502,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 										__nextHasNoMarginBottom
 										checked={ isMcpEnabled }
 										disabled={ ! isAvailable || mcpMutation.isPending }
+										help={ ! isAvailable ? upgradeRequiredText : undefined }
 										label={ __( 'Enable MCP access for this site' ) }
 										onChange={ handleMcpToggle }
 									/>
@@ -509,7 +516,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 										density="medium"
 										title={ __( 'Read' ) }
 										decoration={ <Icon icon={ seen } size={ 24 } /> }
-										badges={ [ readBadge ] }
+										badges={ ! isAvailable ? [ readBadge, upgradeRequiredBadge ] : [ readBadge ] }
 										disabled={ ! isAvailable }
 									/>
 									<RouterLinkSummaryButton
@@ -517,7 +524,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 										density="medium"
 										title={ __( 'Write' ) }
 										decoration={ <Icon icon={ pencil } size={ 24 } /> }
-										badges={ [ writeBadge ] }
+										badges={ ! isAvailable ? [ writeBadge, upgradeRequiredBadge ] : [ writeBadge ] }
 										disabled={ ! isAvailable }
 									/>
 								</>
@@ -529,6 +536,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 								title={ __( 'Connect external AI agent' ) }
 								description={ __( 'Get instructions for connecting your external AI assistant.' ) }
 								decoration={ <Icon icon={ connection } size={ 24 } /> }
+								badges={ ! isAvailable ? [ upgradeRequiredBadge ] : undefined }
 								disabled={ ! isAvailable }
 							/>
 						) }
@@ -557,6 +565,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 							<SummaryButton
 								title={ __( 'Get answers' ) }
 								decoration={ <Icon icon={ help } /> }
+								badges={ ! isAvailable ? [ upgradeRequiredBadge ] : undefined }
 								disabled={ ! isAvailable }
 								onClick={ () => {
 									recordTracksEvent( 'calypso_dashboard_ai_tool_get_answers_click' );
@@ -568,6 +577,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 								href={ `${ site.options?.admin_url }site-editor.php?canvas=edit` }
 								title={ __( 'Update your site design' ) }
 								decoration={ <Icon icon={ brush } /> }
+								badges={ ! isAvailable ? [ upgradeRequiredBadge ] : undefined }
 								disabled={ ! isAvailable }
 								onClick={ () => {
 									recordTracksEvent( 'calypso_dashboard_ai_tool_edit_site_click' );
@@ -577,6 +587,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 								href={ `${ site.options?.admin_url }post-new.php` }
 								title={ __( 'Draft and revise content' ) }
 								decoration={ <Icon icon={ termDescription } /> }
+								badges={ ! isAvailable ? [ upgradeRequiredBadge ] : undefined }
 								disabled={ ! isAvailable }
 								onClick={ () => {
 									recordTracksEvent( 'calypso_dashboard_ai_tool_draft_post_click' );
@@ -586,6 +597,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 								href={ `${ site.options?.admin_url }upload.php?ai-assistant` }
 								title={ __( 'Create beautiful images' ) }
 								decoration={ <Icon icon={ image } /> }
+								badges={ ! isAvailable ? [ upgradeRequiredBadge ] : undefined }
 								disabled={ ! isAvailable }
 								onClick={ () => {
 									recordTracksEvent( 'calypso_dashboard_ai_tool_create_images_click' );

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -116,7 +116,7 @@ const features = [
 ];
 
 const upgradeRequiredText = __( 'Upgrade your plan to enable this setting.' );
-const upgradeRequiredBadge = { text: __( 'Upgrade required' ) };
+const upgradeRequiredBadge = { text: __( 'Upgrade required' ), intent: 'info' as const };
 
 function UpgradeRequiredBadge() {
 	return (
@@ -482,22 +482,23 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 					disabled={ ! isAvailable }
 				/>
 				{ config.isEnabled( 'dolly/telegram' ) && (
-					<SummaryButton
-						className={ ! isAvailable ? 'ai-tools-settings__locked-card' : undefined }
-						href={ wpcomLink( TELEGRAM_CONNECTION_PATH ) }
-						title={ __( 'Connect Telegram' ) }
-						description={ __(
-							'Connect your WordPress.com account to Telegram. This connection is shared across multiple sites.'
-						) }
-						decoration={ <Icon icon={ send } size={ 24 } /> }
-						onClick={ () => {
-							recordTracksEvent( 'calypso_dashboard_ai_tool_connect_telegram_click', {
-								site_id: site.ID,
-							} );
-						} }
-						badges={ ! isAvailable ? [ upgradeRequiredBadge ] : undefined }
-						disabled={ ! isAvailable }
-					/>
+					<div className={ ! isAvailable ? 'ai-tools-settings__locked-card' : undefined }>
+						<SummaryButton
+							href={ wpcomLink( TELEGRAM_CONNECTION_PATH ) }
+							title={ __( 'Connect Telegram' ) }
+							description={ __(
+								'Connect your WordPress.com account to Telegram. This connection is shared across multiple sites.'
+							) }
+							decoration={ <Icon icon={ send } size={ 24 } /> }
+							onClick={ () => {
+								recordTracksEvent( 'calypso_dashboard_ai_tool_connect_telegram_click', {
+									site_id: site.ID,
+								} );
+							} }
+							badges={ ! isAvailable ? [ upgradeRequiredBadge ] : undefined }
+							disabled={ ! isAvailable }
+						/>
+					</div>
 				) }
 				{ config.isEnabled( 'mcp-settings' ) && isAvailable && (
 					<>

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -181,13 +181,16 @@ function getVCardFileName( siteDomain: string ) {
 function EmailAssistantCard( {
 	site,
 	recordTracksEvent,
+	disabled = false,
 }: {
 	site: Site;
 	recordTracksEvent: ReturnType< typeof useAnalytics >[ 'recordTracksEvent' ];
+	disabled?: boolean;
 } ) {
-	const { data: postByEmailSettings, isLoading: isPostByEmailSettingsLoading } = useQuery(
-		sitePostByEmailSettingsQuery( site )
-	);
+	const { data: postByEmailSettings, isLoading: isPostByEmailSettingsLoading } = useQuery( {
+		...sitePostByEmailSettingsQuery( site ),
+		enabled: ! disabled,
+	} );
 	const agentEmailAddress = getAgentEmailAddress( postByEmailSettings?.post_by_email_address );
 	const isAgentEmailEnabled = !! agentEmailAddress;
 	const vCardHref = agentEmailAddress ? getVCardDataUrl( site.slug, agentEmailAddress ) : undefined;
@@ -200,7 +203,7 @@ function EmailAssistantCard( {
 		} )
 	);
 	const isEmailAddressActionDisabled =
-		isPostByEmailSettingsLoading || emailAddressMutation.isPending;
+		disabled || isPostByEmailSettingsLoading || emailAddressMutation.isPending;
 
 	const handleEmailAddressToggle = ( enabled: boolean ) => {
 		emailAddressMutation.mutate(
@@ -421,24 +424,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 		);
 	};
 
-	const renderContent = () => {
-		if ( ! isAvailable ) {
-			return (
-				<UpsellCallout
-					site={ site }
-					feature={ HostingFeatures.BIG_SKY }
-					upsellId="ai-tools"
-					upsellPlanRequirement="any"
-					upsellTitle={ __( 'Your dream site is just a prompt away' ) }
-					upsellDescription={ __(
-						'Get WordPress Agent to help you build, edit, and redesign your site with ease.'
-					) }
-					upsellIcon={ comment }
-					upsellImage={ upsellIllustrationUrl }
-				/>
-			);
-		}
-
+	const renderSettings = () => {
 		return (
 			<>
 				<Card>
@@ -452,7 +438,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 							<ToggleControl
 								__nextHasNoMarginBottom
 								checked={ isEnabled }
-								disabled={ mutation.isPending }
+								disabled={ ! isAvailable || mutation.isPending }
 								label={ __( 'Enable WordPress Agent' ) }
 								onChange={ handleToggle }
 							/>
@@ -475,7 +461,11 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 						</CardFooter>
 					) }
 				</Card>
-				<EmailAssistantCard site={ site } recordTracksEvent={ recordTracksEvent } />
+				<EmailAssistantCard
+					site={ site }
+					recordTracksEvent={ recordTracksEvent }
+					disabled={ ! isAvailable }
+				/>
 				{ config.isEnabled( 'dolly/telegram' ) && (
 					<SummaryButton
 						href={ wpcomLink( TELEGRAM_CONNECTION_PATH ) }
@@ -489,6 +479,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 								site_id: site.ID,
 							} );
 						} }
+						disabled={ ! isAvailable }
 					/>
 				) }
 				{ config.isEnabled( 'mcp-settings' ) && (
@@ -504,7 +495,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 									<ToggleControl
 										__nextHasNoMarginBottom
 										checked={ isMcpEnabled }
-										disabled={ mcpMutation.isPending }
+										disabled={ ! isAvailable || mcpMutation.isPending }
 										label={ __( 'Enable MCP access for this site' ) }
 										onChange={ handleMcpToggle }
 									/>
@@ -519,6 +510,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 										title={ __( 'Read' ) }
 										decoration={ <Icon icon={ seen } size={ 24 } /> }
 										badges={ [ readBadge ] }
+										disabled={ ! isAvailable }
 									/>
 									<RouterLinkSummaryButton
 										to={ `/sites/${ siteSlug }/settings/ai-tools/write` }
@@ -526,6 +518,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 										title={ __( 'Write' ) }
 										decoration={ <Icon icon={ pencil } size={ 24 } /> }
 										badges={ [ writeBadge ] }
+										disabled={ ! isAvailable }
 									/>
 								</>
 							) }
@@ -536,6 +529,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 								title={ __( 'Connect external AI agent' ) }
 								description={ __( 'Get instructions for connecting your external AI assistant.' ) }
 								decoration={ <Icon icon={ connection } size={ 24 } /> }
+								disabled={ ! isAvailable }
 							/>
 						) }
 					</>
@@ -563,6 +557,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 							<SummaryButton
 								title={ __( 'Get answers' ) }
 								decoration={ <Icon icon={ help } /> }
+								disabled={ ! isAvailable }
 								onClick={ () => {
 									recordTracksEvent( 'calypso_dashboard_ai_tool_get_answers_click' );
 									setNavigateToRoute( '/odie' );
@@ -573,6 +568,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 								href={ `${ site.options?.admin_url }site-editor.php?canvas=edit` }
 								title={ __( 'Update your site design' ) }
 								decoration={ <Icon icon={ brush } /> }
+								disabled={ ! isAvailable }
 								onClick={ () => {
 									recordTracksEvent( 'calypso_dashboard_ai_tool_edit_site_click' );
 								} }
@@ -581,6 +577,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 								href={ `${ site.options?.admin_url }post-new.php` }
 								title={ __( 'Draft and revise content' ) }
 								decoration={ <Icon icon={ termDescription } /> }
+								disabled={ ! isAvailable }
 								onClick={ () => {
 									recordTracksEvent( 'calypso_dashboard_ai_tool_draft_post_click' );
 								} }
@@ -589,6 +586,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 								href={ `${ site.options?.admin_url }upload.php?ai-assistant` }
 								title={ __( 'Create beautiful images' ) }
 								decoration={ <Icon icon={ image } /> }
+								disabled={ ! isAvailable }
 								onClick={ () => {
 									recordTracksEvent( 'calypso_dashboard_ai_tool_create_images_click' );
 								} }
@@ -611,7 +609,21 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 				/>
 			}
 		>
-			{ renderContent() }
+			{ ! isAvailable && (
+				<UpsellCallout
+					site={ site }
+					feature={ HostingFeatures.BIG_SKY }
+					upsellId="ai-tools"
+					upsellPlanRequirement="any"
+					upsellTitle={ __( 'Your dream site is just a prompt away' ) }
+					upsellDescription={ __(
+						'Get WordPress Agent to help you build, edit, and redesign your site with ease.'
+					) }
+					upsellIcon={ comment }
+					upsellImage={ upsellIllustrationUrl }
+				/>
+			) }
+			{ renderSettings() }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -262,7 +262,7 @@ function EmailAssistantCard( {
 	};
 
 	return (
-		<Card>
+		<Card className={ disabled ? 'ai-tools-settings__locked-card' : undefined }>
 			<CardBody>
 				<VStack spacing={ 4 }>
 					<SectionHeader
@@ -441,7 +441,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 	const renderSettings = () => {
 		return (
 			<>
-				<Card>
+				<Card className={ ! isAvailable ? 'ai-tools-settings__locked-card' : undefined }>
 					<CardBody>
 						<VStack spacing={ 4 }>
 							<SectionHeader
@@ -483,6 +483,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 				/>
 				{ config.isEnabled( 'dolly/telegram' ) && (
 					<SummaryButton
+						className={ ! isAvailable ? 'ai-tools-settings__locked-card' : undefined }
 						href={ wpcomLink( TELEGRAM_CONNECTION_PATH ) }
 						title={ __( 'Connect Telegram' ) }
 						description={ __(
@@ -498,7 +499,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 						disabled={ ! isAvailable }
 					/>
 				) }
-				{ config.isEnabled( 'mcp-settings' ) && (
+				{ config.isEnabled( 'mcp-settings' ) && isAvailable && (
 					<>
 						<Card className="mcp-settings__access-card">
 							<CardBody>
@@ -506,13 +507,12 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 									<SectionHeader
 										title={ __( 'External AI agent access' ) }
 										description={ __( 'Allow external AI agents to access this site via MCP.' ) }
-										actions={ ! isAvailable ? <UpgradeRequiredBadge /> : undefined }
 										level={ 3 }
 									/>
 									<ToggleControl
 										__nextHasNoMarginBottom
 										checked={ isMcpEnabled }
-										disabled={ ! isAvailable || mcpMutation.isPending }
+										disabled={ mcpMutation.isPending }
 										label={ __( 'Enable MCP access for this site' ) }
 										onChange={ handleMcpToggle }
 									/>
@@ -526,16 +526,14 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 										density="medium"
 										title={ __( 'Read' ) }
 										decoration={ <Icon icon={ seen } size={ 24 } /> }
-										badges={ ! isAvailable ? [ readBadge, upgradeRequiredBadge ] : [ readBadge ] }
-										disabled={ ! isAvailable }
+										badges={ [ readBadge ] }
 									/>
 									<RouterLinkSummaryButton
 										to={ `/sites/${ siteSlug }/settings/ai-tools/write` }
 										density="medium"
 										title={ __( 'Write' ) }
 										decoration={ <Icon icon={ pencil } size={ 24 } /> }
-										badges={ ! isAvailable ? [ writeBadge, upgradeRequiredBadge ] : [ writeBadge ] }
-										disabled={ ! isAvailable }
+										badges={ [ writeBadge ] }
 									/>
 								</>
 							) }
@@ -546,8 +544,6 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 								title={ __( 'Connect external AI agent' ) }
 								description={ __( 'Get instructions for connecting your external AI assistant.' ) }
 								decoration={ <Icon icon={ connection } size={ 24 } /> }
-								badges={ ! isAvailable ? [ upgradeRequiredBadge ] : undefined }
-								disabled={ ! isAvailable }
 							/>
 						) }
 					</>
@@ -569,7 +565,10 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 					</ConfirmModal>
 				) }
 				{ isEnabled && (
-					<VStack spacing={ 3 }>
+					<VStack
+						className={ ! isAvailable ? 'ai-tools-settings__locked-card' : undefined }
+						spacing={ 3 }
+					>
 						<SectionHeader
 							title={ __( 'Ways to get started' ) }
 							actions={ ! isAvailable ? <UpgradeRequiredBadge /> : undefined }

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -11,6 +11,7 @@ import {
 	userSettingsQuery,
 } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
+import { Badge } from '@automattic/ui';
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
@@ -19,6 +20,7 @@ import {
 	Button,
 	Icon,
 	ToggleControl,
+	Tooltip,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -115,6 +117,14 @@ const features = [
 
 const upgradeRequiredText = __( 'Upgrade your plan to enable this setting.' );
 const upgradeRequiredBadge = { text: __( 'Upgrade required' ) };
+
+function UpgradeRequiredBadge() {
+	return (
+		<Tooltip text={ upgradeRequiredText } placement="top">
+			<Badge intent="info">{ upgradeRequiredBadge.text }</Badge>
+		</Tooltip>
+	);
+}
 
 const TELEGRAM_CONNECTION_PATH = '/me/developer';
 
@@ -258,6 +268,7 @@ function EmailAssistantCard( {
 					<SectionHeader
 						title={ __( 'Email WordPress Agent' ) }
 						description={ __( 'Email this site’s WordPress Agent using a private address.' ) }
+						actions={ disabled ? <UpgradeRequiredBadge /> : undefined }
 						level={ 3 }
 					/>
 					<ToggleControl
@@ -437,6 +448,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 							<SectionHeader
 								title={ __( 'WordPress Agent' ) }
 								description={ __( 'Helps with site setup, content, design, and more.' ) }
+								actions={ ! isAvailable ? <UpgradeRequiredBadge /> : undefined }
 								level={ 3 }
 							/>
 							<ToggleControl
@@ -496,6 +508,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 									<SectionHeader
 										title={ __( 'External AI agent access' ) }
 										description={ __( 'Allow external AI agents to access this site via MCP.' ) }
+										actions={ ! isAvailable ? <UpgradeRequiredBadge /> : undefined }
 										level={ 3 }
 									/>
 									<ToggleControl
@@ -560,7 +573,11 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 				) }
 				{ isEnabled && (
 					<VStack spacing={ 3 }>
-						<SectionHeader title={ __( 'Ways to get started' ) } level={ 3 } />
+						<SectionHeader
+							title={ __( 'Ways to get started' ) }
+							actions={ ! isAvailable ? <UpgradeRequiredBadge /> : undefined }
+							level={ 3 }
+						/>
 						<SummaryButtonList>
 							<SummaryButton
 								title={ __( 'Get answers' ) }

--- a/client/dashboard/sites/settings-ai-tools/style.scss
+++ b/client/dashboard/sites/settings-ai-tools/style.scss
@@ -1,4 +1,12 @@
-@use "calypso/assets/stylesheets/shared/mixins/dark-theme" as ui-mixins;
+@use 'calypso/assets/stylesheets/shared/mixins/dark-theme' as ui-mixins;
+
+.ai-tools-settings__locked-card {
+	opacity: 0.6;
+}
+
+.ai-tools-settings__locked-card .summary-button.components-button[aria-disabled='true'] {
+	opacity: 1;
+}
 
 .ai-tools-settings__features-footer {
 	background: color-mix( in srgb, var( --dashboard-surface__background-color ) 98%, #000 );

--- a/client/dashboard/sites/settings-ai-tools/summary.tsx
+++ b/client/dashboard/sites/settings-ai-tools/summary.tsx
@@ -44,7 +44,7 @@ export default function AISiteToolsSettingsSummary( {
 	return (
 		<RouterLinkSummaryButton
 			to={ `/sites/${ site.slug }/settings/ai-tools` }
-			title={ __( 'AI tools (early access)' ) }
+			title={ __( 'AI tools' ) }
 			density={ density }
 			decoration={ <BigSkyLogo.CentralLogo heartless size={ 24 } /> }
 			badges={ getBadge() }

--- a/client/dashboard/sites/settings-ai-tools/test/index.test.tsx
+++ b/client/dashboard/sites/settings-ai-tools/test/index.test.tsx
@@ -230,18 +230,12 @@ describe( '<AIToolsSettings>', () => {
 		expect( screen.getByRole( 'heading', { name: 'WordPress Agent' } ) ).toBeVisible();
 		const agentToggle = screen.getByRole( 'checkbox', { name: 'Enable WordPress Agent' } );
 		expect( agentToggle ).toBeDisabled();
-		expect( agentToggle ).toHaveAccessibleDescription(
-			'Upgrade your plan to enable this setting.'
-		);
 
 		expect( screen.getByRole( 'heading', { name: 'Email WordPress Agent' } ) ).toBeVisible();
 		const emailToggle = screen.getByRole( 'checkbox', {
 			name: 'Enable WordPress Agent email address',
 		} );
 		expect( emailToggle ).toBeDisabled();
-		expect( emailToggle ).toHaveAccessibleDescription(
-			'Upgrade your plan to enable this setting.'
-		);
 		expect(
 			queryClient.getQueryState( sitePostByEmailSettingsQuery( site ).queryKey )?.fetchStatus
 		).toBe( 'idle' );
@@ -251,7 +245,9 @@ describe( '<AIToolsSettings>', () => {
 			name: 'Enable MCP access for this site',
 		} );
 		expect( mcpToggle ).toBeDisabled();
-		expect( mcpToggle ).toHaveAccessibleDescription( 'Upgrade your plan to enable this setting.' );
+		expect(
+			screen.queryByText( 'Upgrade your plan to enable this setting.' )
+		).not.toBeInTheDocument();
 		const upgradeBadges = screen.getAllByText( 'Upgrade required' );
 		expect( upgradeBadges ).toHaveLength( 7 );
 		await user.hover( upgradeBadges[ 0 ] );

--- a/client/dashboard/sites/settings-ai-tools/test/index.test.tsx
+++ b/client/dashboard/sites/settings-ai-tools/test/index.test.tsx
@@ -220,7 +220,8 @@ describe( 'getAgentEmailVCard', () => {
 } );
 
 describe( '<AIToolsSettings>', () => {
-	test( 'shows the settings as disabled below the upgrade callout when unavailable', () => {
+	test( 'shows the settings as disabled below the upgrade callout when unavailable', async () => {
+		const user = userEvent.setup();
 		renderAIToolsSettings( '', false, site, false, true );
 
 		expect( screen.getByText( 'Your dream site is just a prompt away' ) ).toBeVisible();
@@ -251,7 +252,12 @@ describe( '<AIToolsSettings>', () => {
 		} );
 		expect( mcpToggle ).toBeDisabled();
 		expect( mcpToggle ).toHaveAccessibleDescription( 'Upgrade your plan to enable this setting.' );
-		expect( screen.getAllByText( 'Upgrade required' ) ).toHaveLength( 4 );
+		const upgradeBadges = screen.getAllByText( 'Upgrade required' );
+		expect( upgradeBadges ).toHaveLength( 7 );
+		await user.hover( upgradeBadges[ 0 ] );
+		expect( await screen.findByRole( 'tooltip' ) ).toHaveTextContent(
+			'Upgrade your plan to enable this setting.'
+		);
 
 		expect( screen.getByRole( 'button', { name: /Connect Telegram/ } ) ).toHaveAttribute(
 			'aria-disabled',

--- a/client/dashboard/sites/settings-ai-tools/test/index.test.tsx
+++ b/client/dashboard/sites/settings-ai-tools/test/index.test.tsx
@@ -251,10 +251,9 @@ describe( '<AIToolsSettings>', () => {
 			'Upgrade your plan to enable this setting.'
 		);
 
-		expect( screen.getByRole( 'button', { name: /Connect Telegram/ } ) ).toHaveAttribute(
-			'aria-disabled',
-			'true'
-		);
+		const telegramButton = screen.getByRole( 'button', { name: /Connect Telegram/ } );
+		expect( telegramButton ).toHaveClass( 'dashboard-summary-button' );
+		expect( telegramButton ).toHaveAttribute( 'aria-disabled', 'true' );
 
 		expect(
 			screen.queryByRole( 'heading', { name: 'External AI agent access' } )

--- a/client/dashboard/sites/settings-ai-tools/test/index.test.tsx
+++ b/client/dashboard/sites/settings-ai-tools/test/index.test.tsx
@@ -47,16 +47,32 @@ afterAll( () => {
 	disable( 'dolly/telegram' );
 } );
 
-function seedQueries( postByEmailAddress = '', seedPostByEmailSettings = true, activeSite = site ) {
+function seedQueries(
+	postByEmailAddress = '',
+	seedPostByEmailSettings = true,
+	activeSite = site,
+	isAvailable = true,
+	isMcpEnabled = false
+) {
 	queryClient.setQueryData( siteBySlugQuery( activeSite.slug ).queryKey, activeSite );
 	queryClient.setQueryData( bigSkyPluginQuery( activeSite.ID ).queryKey, {
 		blog_id: activeSite.ID,
 		enabled: false,
-		available: true,
+		available: isAvailable,
 		on_free_trial: false,
 	} );
 	queryClient.setQueryData( userSettingsQuery().queryKey, {
-		mcp_abilities: {},
+		mcp_abilities: {
+			sites: isMcpEnabled
+				? [
+						{
+							blog_id: activeSite.ID,
+							site_level_enabled: true,
+							abilities: {},
+						},
+				  ]
+				: [],
+		},
 	} as UserSettings );
 	if ( seedPostByEmailSettings ) {
 		queryClient.setQueryData( sitePostByEmailSettingsQuery( activeSite ).queryKey, {
@@ -129,9 +145,11 @@ function mockJetpackPostByEmailSettingsFailure() {
 function renderAIToolsSettings(
 	postByEmailAddress = '',
 	seedPostByEmailSettings = true,
-	activeSite = site
+	activeSite = site,
+	isAvailable = true,
+	isMcpEnabled = false
 ) {
-	seedQueries( postByEmailAddress, seedPostByEmailSettings, activeSite );
+	seedQueries( postByEmailAddress, seedPostByEmailSettings, activeSite, isAvailable, isMcpEnabled );
 
 	return render( <AIToolsSettings siteSlug={ activeSite.slug } />, { queryClient } );
 }
@@ -202,6 +220,43 @@ describe( 'getAgentEmailVCard', () => {
 } );
 
 describe( '<AIToolsSettings>', () => {
+	test( 'shows the settings as disabled below the upgrade callout when unavailable', () => {
+		renderAIToolsSettings( '', false, site, false, true );
+
+		expect( screen.getByText( 'Your dream site is just a prompt away' ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Upgrade plan' } ) ).toBeEnabled();
+
+		expect( screen.getByRole( 'heading', { name: 'WordPress Agent' } ) ).toBeVisible();
+		expect( screen.getByRole( 'checkbox', { name: 'Enable WordPress Agent' } ) ).toBeDisabled();
+
+		expect( screen.getByRole( 'heading', { name: 'Email WordPress Agent' } ) ).toBeVisible();
+		expect(
+			screen.getByRole( 'checkbox', {
+				name: 'Enable WordPress Agent email address',
+			} )
+		).toBeDisabled();
+		expect(
+			queryClient.getQueryState( sitePostByEmailSettingsQuery( site ).queryKey )?.fetchStatus
+		).toBe( 'idle' );
+
+		expect( screen.getByRole( 'heading', { name: 'External AI agent access' } ) ).toBeVisible();
+		expect(
+			screen.getByRole( 'checkbox', { name: 'Enable MCP access for this site' } )
+		).toBeDisabled();
+
+		expect( screen.getByRole( 'button', { name: /Connect Telegram/ } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+
+		for ( const linkName of [ 'Read', 'Write', 'Connect external AI agent' ] ) {
+			expect( screen.getByRole( 'link', { name: new RegExp( linkName ) } ) ).toHaveAttribute(
+				'aria-disabled',
+				'true'
+			);
+		}
+	} );
+
 	test( 'enables, copies, regenerates, and disables the WordPress Agent email address', async () => {
 		const user = userEvent.setup();
 		mockClipboard();

--- a/client/dashboard/sites/settings-ai-tools/test/index.test.tsx
+++ b/client/dashboard/sites/settings-ai-tools/test/index.test.tsx
@@ -222,10 +222,11 @@ describe( 'getAgentEmailVCard', () => {
 describe( '<AIToolsSettings>', () => {
 	test( 'shows the settings as disabled below the upgrade callout when unavailable', async () => {
 		const user = userEvent.setup();
-		renderAIToolsSettings( '', false, site, false, true );
+		const { container } = renderAIToolsSettings( '', false, site, false, true );
 
 		expect( screen.getByText( 'Your dream site is just a prompt away' ) ).toBeVisible();
 		expect( screen.getByRole( 'button', { name: 'Upgrade plan' } ) ).toBeEnabled();
+		expect( container.querySelectorAll( '.ai-tools-settings__locked-card' ) ).toHaveLength( 3 );
 
 		expect( screen.getByRole( 'heading', { name: 'WordPress Agent' } ) ).toBeVisible();
 		const agentToggle = screen.getByRole( 'checkbox', { name: 'Enable WordPress Agent' } );
@@ -240,16 +241,11 @@ describe( '<AIToolsSettings>', () => {
 			queryClient.getQueryState( sitePostByEmailSettingsQuery( site ).queryKey )?.fetchStatus
 		).toBe( 'idle' );
 
-		expect( screen.getByRole( 'heading', { name: 'External AI agent access' } ) ).toBeVisible();
-		const mcpToggle = screen.getByRole( 'checkbox', {
-			name: 'Enable MCP access for this site',
-		} );
-		expect( mcpToggle ).toBeDisabled();
 		expect(
 			screen.queryByText( 'Upgrade your plan to enable this setting.' )
 		).not.toBeInTheDocument();
 		const upgradeBadges = screen.getAllByText( 'Upgrade required' );
-		expect( upgradeBadges ).toHaveLength( 7 );
+		expect( upgradeBadges ).toHaveLength( 3 );
 		await user.hover( upgradeBadges[ 0 ] );
 		expect( await screen.findByRole( 'tooltip' ) ).toHaveTextContent(
 			'Upgrade your plan to enable this setting.'
@@ -260,12 +256,29 @@ describe( '<AIToolsSettings>', () => {
 			'true'
 		);
 
-		for ( const linkName of [ 'Read', 'Write', 'Connect external AI agent' ] ) {
-			expect( screen.getByRole( 'link', { name: new RegExp( linkName ) } ) ).toHaveAttribute(
-				'aria-disabled',
-				'true'
-			);
-		}
+		expect(
+			screen.queryByRole( 'heading', { name: 'External AI agent access' } )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'checkbox', { name: 'Enable MCP access for this site' } )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'link', { name: /^Connect external AI agent/ } )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'shows MCP settings without upgrade badging when available', async () => {
+		renderAIToolsSettings( '', true, site, true, true );
+
+		expect( await screen.findByText( 'Learn more' ) ).toBeVisible();
+		expect( screen.getByRole( 'heading', { name: 'External AI agent access' } ) ).toBeVisible();
+		expect(
+			screen.getByRole( 'checkbox', { name: 'Enable MCP access for this site' } )
+		).toBeEnabled();
+		expect( screen.getByRole( 'link', { name: /^Read/ } ) ).toBeVisible();
+		expect( screen.getByRole( 'link', { name: /^Write/ } ) ).toBeVisible();
+		expect( screen.getByRole( 'link', { name: /^Connect external AI agent/ } ) ).toBeVisible();
+		expect( screen.queryByText( 'Upgrade required' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'enables, copies, regenerates, and disables the WordPress Agent email address', async () => {

--- a/client/dashboard/sites/settings-ai-tools/test/index.test.tsx
+++ b/client/dashboard/sites/settings-ai-tools/test/index.test.tsx
@@ -227,22 +227,31 @@ describe( '<AIToolsSettings>', () => {
 		expect( screen.getByRole( 'button', { name: 'Upgrade plan' } ) ).toBeEnabled();
 
 		expect( screen.getByRole( 'heading', { name: 'WordPress Agent' } ) ).toBeVisible();
-		expect( screen.getByRole( 'checkbox', { name: 'Enable WordPress Agent' } ) ).toBeDisabled();
+		const agentToggle = screen.getByRole( 'checkbox', { name: 'Enable WordPress Agent' } );
+		expect( agentToggle ).toBeDisabled();
+		expect( agentToggle ).toHaveAccessibleDescription(
+			'Upgrade your plan to enable this setting.'
+		);
 
 		expect( screen.getByRole( 'heading', { name: 'Email WordPress Agent' } ) ).toBeVisible();
-		expect(
-			screen.getByRole( 'checkbox', {
-				name: 'Enable WordPress Agent email address',
-			} )
-		).toBeDisabled();
+		const emailToggle = screen.getByRole( 'checkbox', {
+			name: 'Enable WordPress Agent email address',
+		} );
+		expect( emailToggle ).toBeDisabled();
+		expect( emailToggle ).toHaveAccessibleDescription(
+			'Upgrade your plan to enable this setting.'
+		);
 		expect(
 			queryClient.getQueryState( sitePostByEmailSettingsQuery( site ).queryKey )?.fetchStatus
 		).toBe( 'idle' );
 
 		expect( screen.getByRole( 'heading', { name: 'External AI agent access' } ) ).toBeVisible();
-		expect(
-			screen.getByRole( 'checkbox', { name: 'Enable MCP access for this site' } )
-		).toBeDisabled();
+		const mcpToggle = screen.getByRole( 'checkbox', {
+			name: 'Enable MCP access for this site',
+		} );
+		expect( mcpToggle ).toBeDisabled();
+		expect( mcpToggle ).toHaveAccessibleDescription( 'Upgrade your plan to enable this setting.' );
+		expect( screen.getAllByText( 'Upgrade required' ) ).toHaveLength( 4 );
 
 		expect( screen.getByRole( 'button', { name: /Connect Telegram/ } ) ).toHaveAttribute(
 			'aria-disabled',


### PR DESCRIPTION
## Proposed Changes

Internal discussion at p1785436249573679/1784208885.420909-slack-C097SQTJV9S

* Keep the WordPress Agent upgrade callout at the top of the AI tools page when the feature is unavailable.
* Render the Agent, email, and Telegram settings below the callout with a consistent card-level disabled treatment.
* Hide the MCP settings from the unavailable preview while leaving them unchanged for eligible sites.
* Show an "Upgrade required" badge on each locked settings card, with an upgrade explanation on hover.
* Skip the Post by Email settings request while the page is locked and cover the upgrade-preview behavior with a focused test.

<img width="2410" height="2412" alt="image" src="https://github.com/user-attachments/assets/040a6093-6bcf-43dd-8f73-405d34a47f07" />


## Why are these changes being made?

* The upgrade-only state does not show users what they will gain by upgrading.
* A disabled preview makes the available settings and benefits visible without exposing actions that the current plan cannot use.

## Testing Instructions

1. Open `/sites/:site/settings/ai-tools` for a site where WordPress Agent is unavailable.
2. Verify the upgrade callout remains the first item on the page.
3. Verify the WordPress Agent, email, and Telegram settings appear below it with the same disabled opacity.
4. Verify MCP settings and connection rows are not shown.
5. Verify each locked settings card shows an **Upgrade required** badge and hovering it explains that the plan must be upgraded.
6. Verify the settings controls and navigation rows cannot be activated, while the **Upgrade plan** button remains active.
7. Open the page for a site where WordPress Agent is available and verify the existing settings, including MCP, remain interactive without upgrade badges.

Automated checks:

* `yarn test-client client/dashboard/sites/settings-ai-tools/test/index.test.tsx --runInBand`
* `yarn eslint client/dashboard/sites/settings-ai-tools/index.tsx client/dashboard/sites/settings-ai-tools/test/index.test.tsx`
* `yarn prettier --check client/dashboard/sites/settings-ai-tools/index.tsx client/dashboard/sites/settings-ai-tools/style.scss client/dashboard/sites/settings-ai-tools/test/index.test.tsx`
* `yarn stylelint client/dashboard/sites/settings-ai-tools/style.scss`
* `yarn typecheck-client`
* `git diff --check`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have you tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?