### PR TITLE
Purchases: read remove-purchase from api-core

### DIFF
--- a/client/me/purchases/remove-purchase/index.tsx
+++ b/client/me/purchases/remove-purchase/index.tsx
@@ -14,17 +14,21 @@ import page from '@automattic/calypso-router';
 import { CompactCard, Gridicon } from '@automattic/components';
 import { invokeSurvicateEvent } from '@automattic/survicate';
 import clsx from 'clsx';
-import { localize } from 'i18n-calypso';
-import PropTypes from 'prop-types';
-import { Component } from 'react';
+import { localize, LocalizeProps } from 'i18n-calypso';
+import { Component, type MouseEvent, type ReactNode } from 'react';
 import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import CancelJetpackForm from 'calypso/components/marketing-survey/cancel-jetpack-form';
 import CancelPurchaseForm from 'calypso/components/marketing-survey/cancel-purchase-form';
 import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-purchase-form/constants';
 import PrecancellationChatButton from 'calypso/components/marketing-survey/cancel-purchase-form/precancellation-chat-button';
 import GSuiteCancellationPurchaseDialog from 'calypso/components/marketing-survey/gsuite-cancel-purchase-dialog';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
-import { getName, isRemovable } from 'calypso/lib/purchases';
+import {
+	isAkismetHoldingSitePurchase,
+	isJetpackHoldingSitePurchase,
+} from 'calypso/dashboard/utils/purchase';
+import { createPurchaseObject } from 'calypso/lib/purchases/assembler';
 import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
 import WordAdsEligibilityWarningDialog from 'calypso/me/purchases/wordads-eligibility-warning-dialog';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -36,43 +40,67 @@ import isDomainOnly from 'calypso/state/selectors/is-domain-only-site';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { receiveDeletedSite } from 'calypso/state/sites/actions';
 import { setAllSitesSelected } from 'calypso/state/ui/actions';
+import { getName } from '../lib/raw-purchase-helpers';
 import { MarketPlaceSubscriptionsDialog } from '../marketplace-subscriptions-dialog';
 import { purchasesRoot } from '../paths';
-import {
-	isDataLoading,
-	isAkismetHoldingSitePurchase,
-	isJetpackHoldingSitePurchase,
-} from '../utils';
+import { isDataLoading } from '../utils';
 import RemoveDomainDialog from './remove-domain-dialog';
+import type { Purchase } from '@automattic/api-core';
+import type { SiteDetails } from '@automattic/data-stores';
+import type { CalypsoDispatch } from 'calypso/state/types';
+import type { AppState } from 'calypso/types';
 import './style.scss';
 
-class RemovePurchase extends Component {
-	static propTypes = {
-		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
-		hasNonPrimaryDomainsFlag: PropTypes.bool,
-		hasSetupAds: PropTypes.bool,
-		isDomainOnlySite: PropTypes.bool,
-		hasCustomPrimaryDomain: PropTypes.bool,
-		receiveDeletedSite: PropTypes.func.isRequired,
-		removePurchase: PropTypes.func.isRequired,
-		purchase: PropTypes.object,
-		site: PropTypes.object,
-		setAllSitesSelected: PropTypes.func.isRequired,
-		userId: PropTypes.number.isRequired,
-		useVerticalNavItem: PropTypes.bool,
-		onClickTracks: PropTypes.func,
-		purchaseListUrl: PropTypes.string,
-		activeSubscriptions: PropTypes.array,
-		linkIcon: PropTypes.string,
-		primaryDomain: PropTypes.object,
-		skipRemovePlanSurvey: PropTypes.bool,
-	};
+interface RemovePurchaseOwnProps {
+	hasLoadedSites: boolean;
+	hasLoadedUserPurchasesFromServer: boolean;
+	hasNonPrimaryDomainsFlag?: boolean;
+	hasSetupAds?: boolean;
+	hasCustomPrimaryDomain?: boolean;
+	purchase: Purchase;
+	site?: SiteDetails | null;
+	useVerticalNavItem?: boolean;
+	onClickTracks?: ( event: MouseEvent ) => void;
+	purchaseListUrl?: string;
+	activeSubscriptions?: Purchase[];
+	linkIcon?: string;
+	skipRemovePlanSurvey?: boolean;
+	className?: string;
+	children?: ReactNode;
+}
 
+interface RemovePurchaseConnectedProps {
+	isDomainOnlySite: boolean | null;
+	isAtomicSite: boolean | null;
+	isJetpack: boolean;
+	isAkismet: boolean;
+	userId: number | null;
+	primaryDomain: ReturnType< typeof getPrimaryDomainBySiteId >;
+	errorNotice: typeof errorNotice;
+	receiveDeletedSite: typeof receiveDeletedSite;
+	recordTracksEvent: typeof recordTracksEvent;
+	removePurchase: typeof removePurchase;
+	setAllSitesSelected: typeof setAllSitesSelected;
+	successNotice: typeof successNotice;
+}
+
+type RemovePurchaseProps = RemovePurchaseOwnProps & RemovePurchaseConnectedProps & LocalizeProps;
+
+interface RemovePurchaseState {
+	isDialogVisible: boolean;
+	isRemoving: boolean;
+	isShowingNonPrimaryDomainWarning: boolean;
+	isShowingMarketplaceSubscriptionsDialog: boolean;
+	isShowingPreCancellationDialog: boolean;
+	isShowingWordAdsEligibilityWarningDialog: boolean;
+}
+
+class RemovePurchase extends Component< RemovePurchaseProps, RemovePurchaseState > {
 	static defaultProps = {
 		purchaseListUrl: purchasesRoot,
 	};
 
-	state = {
+	state: RemovePurchaseState = {
 		isDialogVisible: false,
 		isRemoving: false,
 		isShowingNonPrimaryDomainWarning: false,
@@ -101,7 +129,7 @@ class RemovePurchase extends Component {
 		} );
 	};
 
-	openDialog = () => {
+	openDialog = ( event: MouseEvent ) => {
 		event.preventDefault();
 		if ( this.props.onClickTracks ) {
 			this.props.onClickTracks( event );
@@ -146,12 +174,6 @@ class RemovePurchase extends Component {
 		}
 	};
 
-	componentDidMount = () => {
-		if ( this.props.showDialog ) {
-			this.actuallyOpenDialog();
-		}
-	};
-
 	onClickChatButton = () => {
 		this.setState( { isDialogVisible: false } );
 	};
@@ -166,20 +188,20 @@ class RemovePurchase extends Component {
 			// no need to await here, as
 			// - the success/error messages are handled for each request separately
 			// - the plan removal is awaited below
-			activeSubscriptions.forEach( ( s ) => this.handlePurchaseRemoval( s ) );
+			activeSubscriptions?.forEach( ( s ) => this.handlePurchaseRemoval( s ) );
 		}
 
 		await this.handlePurchaseRemoval( purchase );
 		invokeSurvicateEvent( 'purchaseRemoved' );
 
-		page( purchaseListUrl );
+		page( purchaseListUrl ?? purchasesRoot );
 	};
 
-	handlePurchaseRemoval = async ( purchase ) => {
+	handlePurchaseRemoval = async ( purchase: Purchase ) => {
 		const { userId, isDomainOnlySite, translate } = this.props;
 
 		try {
-			await this.props.removePurchase( purchase.id, userId );
+			await this.props.removePurchase( purchase.ID, userId );
 
 			const productName = getName( purchase );
 			let successMessage;
@@ -197,7 +219,7 @@ class RemovePurchase extends Component {
 
 			if ( isDomainRegistration( purchase ) ) {
 				if ( isDomainOnlySite ) {
-					this.props.receiveDeletedSite( purchase.siteId );
+					this.props.receiveDeletedSite( purchase.blog_id );
 					this.props.setAllSitesSelected();
 				}
 
@@ -210,14 +232,14 @@ class RemovePurchase extends Component {
 		} catch ( error ) {
 			this.setState( { isRemoving: false } );
 			this.closeDialog();
-			this.props.errorNotice( error.message, { displayOnNextPage: true } );
+			this.props.errorNotice( ( error as Error ).message, { displayOnNextPage: true } );
 		}
 	};
 
 	getChatButton = () => (
 		<PrecancellationChatButton
 			onClick={ this.onClickChatButton }
-			purchase={ this.props.purchase.rawPurchase }
+			purchase={ this.props.purchase }
 			className="remove-domain-dialog__chat-button"
 		/>
 	);
@@ -242,8 +264,8 @@ class RemovePurchase extends Component {
 				closeDialog={ this.closeDialog }
 				removePlan={ this.showRemovePlanDialog }
 				planName={ getName( purchase ) }
-				oldDomainName={ site.domain }
-				newDomainName={ site.wpcom_url }
+				oldDomainName={ site?.domain }
+				newDomainName={ site?.wpcom_url }
 				hasSetupAds={ hasSetupAds }
 			/>
 		);
@@ -280,7 +302,7 @@ class RemovePurchase extends Component {
 		return (
 			<CancelPurchaseForm
 				disableButtons={ this.state.isRemoving }
-				purchase={ purchase.rawPurchase }
+				purchase={ purchase }
 				isVisible={ this.state.isDialogVisible }
 				onClose={ this.closeDialog }
 				onSurveyComplete={ this.removePurchase }
@@ -295,8 +317,8 @@ class RemovePurchase extends Component {
 		return (
 			<CancelPurchaseForm
 				disableButtons={ this.state.isRemoving }
-				purchase={ purchase.rawPurchase }
-				linkedPurchases={ activeSubscriptions }
+				purchase={ purchase }
+				linkedPurchases={ activeSubscriptions?.map( createPurchaseObject ) }
 				isVisible={ this.state.isDialogVisible }
 				onClose={ this.closeDialog }
 				onSurveyComplete={ this.removePurchase }
@@ -312,8 +334,8 @@ class RemovePurchase extends Component {
 		return (
 			<CancelJetpackForm
 				disableButtons={ this.state.isRemoving }
-				purchase={ purchase }
-				purchaseListUrl={ purchaseListUrl }
+				purchase={ createPurchaseObject( purchase ) }
+				purchaseListUrl={ purchaseListUrl ?? purchasesRoot }
 				isVisible={ this.state.isDialogVisible }
 				onClose={ this.closeDialog }
 				onSurveyComplete={ this.removePurchase }
@@ -325,7 +347,7 @@ class RemovePurchase extends Component {
 	shouldHandleMarketplaceSubscriptions() {
 		const { activeSubscriptions } = this.props;
 
-		return activeSubscriptions?.length > 0;
+		return Boolean( activeSubscriptions?.length );
 	}
 
 	renderMarketplaceSubscriptionsDialog() {
@@ -336,7 +358,12 @@ class RemovePurchase extends Component {
 				closeDialog={ this.closeDialog }
 				removePlan={ this.showRemovePlanDialog }
 				planName={ getName( purchase ) }
-				activeSubscriptions={ activeSubscriptions }
+				activeSubscriptions={
+					activeSubscriptions?.map( ( subscription ) => ( {
+						id: subscription.ID,
+						productName: subscription.product_name,
+					} ) ) ?? []
+				}
 			/>
 		);
 	}
@@ -361,7 +388,7 @@ class RemovePurchase extends Component {
 				<GSuiteCancellationPurchaseDialog
 					isVisible={ this.state.isDialogVisible }
 					onClose={ this.closeDialog }
-					purchase={ purchase }
+					purchase={ createPurchaseObject( purchase ) }
 					site={ this.props.site }
 				/>
 			);
@@ -388,7 +415,7 @@ class RemovePurchase extends Component {
 		const { className, purchase, translate, useVerticalNavItem } = this.props;
 		const productName = getName( purchase );
 
-		if ( ! isRemovable( purchase ) ) {
+		if ( ! purchase.is_removable ) {
 			return null;
 		}
 
@@ -432,25 +459,29 @@ class RemovePurchase extends Component {
 	}
 }
 
-export default connect(
-	( state, { purchase } ) => {
-		const isJetpack = purchase && ( isJetpackPlan( purchase ) || isJetpackProduct( purchase ) );
-		const isAkismet = purchase && isAkismetProduct( purchase );
-		return {
-			isDomainOnlySite: purchase && isDomainOnly( state, purchase.siteId ),
-			isAtomicSite: isSiteAutomatedTransfer( state, purchase.siteId ),
-			isJetpack,
-			isAkismet,
-			userId: getCurrentUserId( state ),
-			primaryDomain: getPrimaryDomainBySiteId( state, purchase.siteId ),
-		};
-	},
-	{
-		errorNotice,
-		receiveDeletedSite,
-		recordTracksEvent,
-		removePurchase,
-		setAllSitesSelected,
-		successNotice,
-	}
-)( localize( RemovePurchase ) );
+function mapDispatchToProps( dispatch: CalypsoDispatch ) {
+	return bindActionCreators(
+		{
+			errorNotice,
+			receiveDeletedSite,
+			recordTracksEvent,
+			removePurchase,
+			setAllSitesSelected,
+			successNotice,
+		},
+		dispatch
+	);
+}
+
+export default connect( ( state: AppState, { purchase }: RemovePurchaseOwnProps ) => {
+	const isJetpack = purchase && ( isJetpackPlan( purchase ) || isJetpackProduct( purchase ) );
+	const isAkismet = purchase && isAkismetProduct( purchase );
+	return {
+		isDomainOnlySite: purchase && isDomainOnly( state, purchase.blog_id ),
+		isAtomicSite: isSiteAutomatedTransfer( state, purchase.blog_id ),
+		isJetpack,
+		isAkismet,
+		userId: getCurrentUserId( state ),
+		primaryDomain: getPrimaryDomainBySiteId( state, purchase.blog_id ),
+	};
+}, mapDispatchToProps )( localize( RemovePurchase ) );

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.tsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.tsx
@@ -1,35 +1,56 @@
 import { Dialog, FormLabel } from '@automattic/components';
-import { localize } from 'i18n-calypso';
-import PropTypes from 'prop-types';
-import { Component, Fragment } from 'react';
+import clsx from 'clsx';
+import { localize, LocalizeProps } from 'i18n-calypso';
+import { Component, Fragment, type ReactElement } from 'react';
 import { connect } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { getSelectedDomain } from 'calypso/lib/domains';
-import { getName } from 'calypso/lib/purchases';
 import { hasTitanMailWithUs } from 'calypso/lib/titan';
 import { domainManagementEdit, domainManagementTransferOut } from 'calypso/my-sites/domains/paths';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getName } from '../../lib/raw-purchase-helpers';
+import type { Purchase } from '@automattic/api-core';
+import type { BaseButton } from '@automattic/components';
+import type { AppState } from 'calypso/types';
 
-class RemoveDomainDialog extends Component {
-	static propTypes = {
-		isRemoving: PropTypes.bool.isRequired,
-		isDialogVisible: PropTypes.bool.isRequired,
-		removePurchase: PropTypes.func.isRequired,
-		closeDialog: PropTypes.func.isRequired,
-		purchase: PropTypes.object,
-	};
+interface RemoveDomainDialogOwnProps {
+	isRemoving: boolean;
+	isDialogVisible: boolean;
+	removePurchase: ( closeDialog: () => void ) => void;
+	closeDialog: () => void;
+	purchase: Purchase;
+	chatButton?: ReactElement;
+}
 
-	state = {
+interface RemoveDomainDialogConnectedProps {
+	isGravatarRestrictedDomain: boolean | undefined;
+	hasTitanWithUs: boolean;
+	currentRoute: string | null;
+	userEmail: string | null;
+	slug: string | null;
+}
+
+type RemoveDomainDialogProps = RemoveDomainDialogOwnProps &
+	RemoveDomainDialogConnectedProps &
+	LocalizeProps;
+
+interface RemoveDomainDialogState {
+	step: number;
+	domainValidated: boolean;
+}
+
+class RemoveDomainDialog extends Component< RemoveDomainDialogProps, RemoveDomainDialogState > {
+	state: RemoveDomainDialogState = {
 		step: 1,
 		domainValidated: false,
 	};
 
-	renderDomainDeletionWarning( productName ) {
+	renderDomainDeletionWarning( productName: string ) {
 		const { translate, slug, currentRoute, isGravatarRestrictedDomain } = this.props;
 
 		return (
@@ -53,9 +74,17 @@ class RemoveDomainDialog extends Component {
 							args: { domain: productName },
 							components: {
 								strong: <strong />,
-								moveAnchor: <a href={ domainManagementEdit( slug, productName, currentRoute ) } />,
+								moveAnchor: (
+									<a href={ domainManagementEdit( slug ?? '', productName, currentRoute ?? '' ) } />
+								),
 								transferAnchor: (
-									<a href={ domainManagementTransferOut( slug, productName, currentRoute ) } />
+									<a
+										href={ domainManagementTransferOut(
+											slug ?? '',
+											productName,
+											currentRoute ?? ''
+										) }
+									/>
 								),
 							},
 						}
@@ -66,7 +95,7 @@ class RemoveDomainDialog extends Component {
 		);
 	}
 
-	renderFirstStep( productName ) {
+	renderFirstStep( productName: string ) {
 		const { translate } = this.props;
 
 		return (
@@ -83,7 +112,7 @@ class RemoveDomainDialog extends Component {
 		);
 	}
 
-	onDomainChange = ( event ) => {
+	onDomainChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		const productName = getName( this.props.purchase );
 		this.setState( { domainValidated: event.currentTarget.value === productName } );
 	};
@@ -118,7 +147,7 @@ class RemoveDomainDialog extends Component {
 		);
 	}
 
-	renderFinalStep( productName ) {
+	renderFinalStep( productName: string ) {
 		const { translate } = this.props;
 
 		return (
@@ -152,13 +181,13 @@ class RemoveDomainDialog extends Component {
 		);
 	}
 
-	nextStep = ( closeDialog ) => {
+	nextStep = ( closeDialog: () => void ) => {
 		if ( this.props.isRemoving ) {
 			return;
 		}
 
 		const productName = getName( this.props.purchase );
-		const isEmailBasedOnDomain = this.props.userEmail.endsWith( productName );
+		const isEmailBasedOnDomain = Boolean( this.props.userEmail?.endsWith( productName ) );
 
 		switch ( this.state.step ) {
 			case 1:
@@ -185,7 +214,7 @@ class RemoveDomainDialog extends Component {
 		const { purchase, translate, chatButton } = this.props;
 		const productName = getName( purchase );
 
-		const buttons = [
+		const buttons: ( ReactElement | BaseButton )[] = [
 			{
 				action: 'cancel',
 				disabled: this.props.isRemoving,
@@ -195,11 +224,11 @@ class RemoveDomainDialog extends Component {
 				? [
 						{
 							action: 'remove',
-							additionalClassNames: [
-								this.props.isRemoving ? 'is-busy' : '',
-								this.state.step === 3 ? 'is-scary' : '',
-								'dialog__button--domains-remove',
-							],
+							additionalClassNames: clsx(
+								this.props.isRemoving && 'is-busy',
+								this.state.step === 3 && 'is-scary',
+								'dialog__button--domains-remove'
+							),
 							isPrimary: true,
 							disabled: this.state.step === 3 && ! this.state.domainValidated,
 							label:
@@ -227,15 +256,15 @@ class RemoveDomainDialog extends Component {
 				leaveTimeout={ 0 }
 			>
 				{ this.state.step === 1 && this.renderFirstStep( productName ) }
-				{ this.state.step === 2 && this.renderUpdateEmailStep( productName ) }
+				{ this.state.step === 2 && this.renderUpdateEmailStep() }
 				{ this.state.step === 3 && this.renderFinalStep( productName ) }
 			</Dialog>
 		);
 	}
 }
 
-export default connect( ( state, ownProps ) => {
-	const domains = getDomainsBySiteId( state, ownProps.purchase.siteId );
+export default connect( ( state: AppState, ownProps: RemoveDomainDialogOwnProps ) => {
+	const domains = getDomainsBySiteId( state, ownProps.purchase.blog_id );
 	const selectedDomainName = getName( ownProps.purchase );
 	const selectedDomain = getSelectedDomain( { domains, selectedDomainName } );
 	return {
@@ -243,6 +272,6 @@ export default connect( ( state, ownProps ) => {
 		hasTitanWithUs: hasTitanMailWithUs( selectedDomain ),
 		currentRoute: getCurrentRoute( state ),
 		userEmail: getCurrentUserEmail( state ),
-		slug: getSiteSlug( state, ownProps.purchase.siteId ),
+		slug: getSiteSlug( state, ownProps.purchase.blog_id ),
 	};
 } )( localize( RemoveDomainDialog ) );

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
@@ -53,7 +53,7 @@ const DomainDeleteInfoCard = ( {
 			hasLoadedSites
 			hasLoadedUserPurchasesFromServer
 			site={ selectedSite }
-			purchase={ purchase }
+			purchase={ purchase.rawPurchase }
 			className={ removePurchaseClassName }
 		>
 			{ buttonLabel }


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-2256/remove-the-purchases-assembler-read-the-raw-purchase-object-directly

## Proposed Changes

This converts `client/me/purchases/remove-purchase` off the data-stores purchases assembler, reading the raw snake_case `Purchase` from `@automattic/api-core` directly instead of the assembled camelCase shape. It's one incremental slice of the broader assembler-removal effort, following the same pattern already used for `manage-purchase`, `CancelPurchaseForm`, and `confirm-cancel-domain`.

* Convert `remove-purchase/index.jsx` → `.tsx` and `remove-purchase/remove-domain-dialog/index.jsx` → `.tsx` to the raw `Purchase` type, renaming fields accordingly (`id` → `ID`, `siteId` → `blog_id`, etc.)
* Use the existing `purchase.is_removable` raw field instead of re-deriving removal eligibility client-side
* Bridge the single remaining caller (`domain-info-card/delete`) and the two still-camelCase shared dialogs (`CancelJetpackForm`, `GSuiteCancellationPurchaseDialog`) via the established `purchase.rawPurchase` / `createPurchaseObject` boundary-bridge pattern
* Remove dead code surfaced by the strict TypeScript conversion: a `componentDidMount` calling a method that never existed anywhere in the codebase, gated behind a prop no caller ever passes; and fix `openDialog` to take its click event as a real handler argument instead of relying on the deprecated ambient `window.event` global

## Why are these changes being made?

The purchases assembler duplicates purchase data client-side in a camelCase shape that has to be kept in sync with the raw API response by hand, and it's slated for removal (SHILL-2256). Rather than a single large rewrite, this migration proceeds page-by-page so each slice stays reviewable; `remove-purchase` is next in that queue after `manage-purchase` and `confirm-cancel-domain`.

This component doesn't fetch its own purchase data (it receives one as a prop from its single caller), so unlike the earlier slices there's no TanStack Query change here — it's purely a type/field-rename conversion plus the boundary bridges needed because its neighbors (the domain settings page, `CancelJetpackForm`, `GSuiteCancellationPurchaseDialog`) haven't migrated yet.

## Testing Instructions

No existing unit tests for this component.

Manual testing:
* On a domain settings page (`/domains/manage/:domain/settings/:site`), for a removable purchase (e.g. an expired or auto-renewing domain registration, a Jetpack/Akismet holding-site purchase, a domain mapping, or a domain-bundled plan), open the "Delete"/"Cancel" card action and confirm the removal dialog still renders correctly and completes the removal flow.
* Confirm the various dialog variants still route correctly: domain registration removal, domain mapping cancellation, domain transfer/Titan Mail, G Suite/Google Workspace, and Jetpack plan/product cancellation.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?