### PR TITLE
Blueprint onboarding: accept dotcomblueprints slugs in the blueprint step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blueprint/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blueprint/index.tsx
@@ -5,7 +5,7 @@ import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
 import Loading from 'calypso/components/loading';
-import { getBlueprintID } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint';
+import { getBlueprintArchiveIdentifier } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { checkBlueprintExists } from 'calypso/landing/stepper/utils/blueprint-archive-import';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -19,7 +19,7 @@ export const BlueprintStep: StepType = ( { navigation } ) => {
 
 	useEffect( () => {
 		const fetchBlueprint = async () => {
-			const id = getBlueprintID( query );
+			const id = getBlueprintArchiveIdentifier( query );
 
 			if ( ! id ) {
 				return;
@@ -33,7 +33,7 @@ export const BlueprintStep: StepType = ( { navigation } ) => {
 				return;
 			}
 
-			// Save the Blueprint library ID to the store
+			// Save the blueprint identifier (dotcomblueprints slug or numeric id) to the store.
 			setBlueprint( id );
 			submit();
 		};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
@@ -145,6 +145,20 @@ export function getBlueprintID( query: URLSearchParams ): string | null {
 	return null;
 }
 
+/**
+ * The blueprint identifier for the onboarding blueprint flow
+ * (`/setup/onboarding/blueprint/?blueprint=<id>`). Unlike getBlueprintID — which
+ * is scoped to numeric Playground / blueprint-library ids — this also accepts a
+ * dotcomblueprints post slug, the value blueprint-archive-import resolves against
+ * the dotcomblueprints host. The archive's existence is validated server-side
+ * (checkBlueprintExists), so we only shape-check here: a non-empty numeric id or
+ * slug (lowercase alphanumerics + hyphens).
+ */
+export function getBlueprintArchiveIdentifier( query: URLSearchParams ): string | null {
+	const raw = query.get( 'blueprint' )?.trim() ?? '';
+	return /^[a-z0-9-]+$/i.test( raw ) ? raw : null;
+}
+
 // Used in sending the Tracks event
 export function getBlueprintLabelForTracking( query: URLSearchParams ): string {
 	const blueprint = getBlueprintID( query );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/blueprint.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/blueprint.tsx
@@ -2,7 +2,12 @@
  * @jest-environment jsdom
  */
 // @ts-nocheck - TODO: Fix TypeScript issues
-import { getBlueprint, getBlueprintID, getBlueprintLabelForTracking } from '../lib/blueprint';
+import {
+	getBlueprint,
+	getBlueprintArchiveIdentifier,
+	getBlueprintID,
+	getBlueprintLabelForTracking,
+} from '../lib/blueprint';
 
 const DEFAULT_BLUEPRINT = {
 	preferredVersions: {
@@ -289,6 +294,44 @@ describe( 'getBlueprintID', () => {
 		params.set( 'blueprint-url', 'https://blueprintlibrary.wordpress.com?blueprint=notanumber' );
 		const id = getBlueprintID( params );
 		expect( id ).toBeNull();
+	} );
+} );
+
+describe( 'getBlueprintArchiveIdentifier', () => {
+	it( 'returns a numeric blueprint id', () => {
+		const params = new URLSearchParams( 'blueprint=12345' );
+		expect( getBlueprintArchiveIdentifier( params ) ).toBe( '12345' );
+	} );
+
+	it( 'returns a dotcomblueprints post slug', () => {
+		const params = new URLSearchParams( 'blueprint=coachava' );
+		expect( getBlueprintArchiveIdentifier( params ) ).toBe( 'coachava' );
+	} );
+
+	it( 'returns a hyphenated slug', () => {
+		const params = new URLSearchParams( 'blueprint=my-cool-blueprint' );
+		expect( getBlueprintArchiveIdentifier( params ) ).toBe( 'my-cool-blueprint' );
+	} );
+
+	it( 'trims surrounding whitespace', () => {
+		const params = new URLSearchParams();
+		params.set( 'blueprint', '  coachava  ' );
+		expect( getBlueprintArchiveIdentifier( params ) ).toBe( 'coachava' );
+	} );
+
+	it( 'returns null for an empty blueprint parameter', () => {
+		const params = new URLSearchParams( 'blueprint=' );
+		expect( getBlueprintArchiveIdentifier( params ) ).toBeNull();
+	} );
+
+	it( 'returns null when no blueprint parameter is present', () => {
+		expect( getBlueprintArchiveIdentifier( new URLSearchParams() ) ).toBeNull();
+	} );
+
+	it( 'returns null for a value with invalid slug characters', () => {
+		const params = new URLSearchParams();
+		params.set( 'blueprint', 'has spaces/and-slashes' );
+		expect( getBlueprintArchiveIdentifier( params ) ).toBeNull();
 	} );
 } );
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -248,8 +248,9 @@ class ThemeSheet extends Component {
 		softLaunched: PropTypes.bool,
 		// eslint-disable-next-line camelcase -- passed through from the wpcom theme API.
 		has_blueprint: PropTypes.bool,
+		// A dotcomblueprints post slug (string); numeric blueprint-library ids are also tolerated.
 		// eslint-disable-next-line camelcase -- passed through from the wpcom theme API.
-		blueprint_id: PropTypes.number,
+		blueprint_id: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ),
 		defaultOption: PropTypes.shape( {
 			label: PropTypes.string,
 			action: PropTypes.func,


### PR DESCRIPTION
## Why

Follow-up to #112534. The wpcom Themes API now surfaces a **dotcomblueprints post slug** as `blueprint_id` (the blueprint archive host is slug-addressed; see wpcom PR "Themes API: detect theme blueprints on dotcomblueprints"). The theme CTA passes that value into `/setup/onboarding/blueprint/?blueprint=<slug>`, so the blueprint step must accept a **slug**, not just a numeric id.

`getBlueprintID` is shared with the Playground flow and is intentionally **numeric-only** — predefined Playground blueprint names (`woocommerce`, `design1`, …) must return `null` there, and its tracking-label contract depends on that. Broadening it would break those semantics and ~10 tests.

## What

- **`lib/blueprint.ts`** — add `getBlueprintArchiveIdentifier()`: accepts a numeric id **or** a slug (`/^[a-z0-9-]+$/i`), trims whitespace. Existence is validated server-side via `checkBlueprintExists`. `getBlueprintID` is unchanged.
- **`blueprint/index.tsx`** — read the identifier via the new helper.
- **`theme/main.jsx`** — `blueprint_id` PropType `number` → `oneOfType([string, number])`.
- **Tests** — cover the new helper; existing `getBlueprintID` / tracking tests untouched.

## Testing

- `blueprint.tsx`: 38 passing (31 existing + 7 new).
- `theme/test/main.jsx`: 3 passing.
- eslint clean on all four files.

Behind the `themes/blueprint-cta` feature flag (Automattician-only), same as #112534.

🤖 Generated with [Claude Code](https://claude.com/claude-code)