### PR TITLE
Pass configured bot slugs to Help Center app

### DIFF
--- a/apps/help-center/async-help-center.jsx
+++ b/apps/help-center/async-help-center.jsx
@@ -11,9 +11,6 @@ export default function loadHelpCenter() {
 	const container = document.createElement( 'div' );
 	container.id = 'jetpack-help-center';
 	document.body.appendChild( container );
-	const botProps = helpCenterData.isCommerceGarden
-		? { newInteractionsBotSlug: 'ciab-workflow-support_chat' }
-		: {};
 
 	return import( '@automattic/help-center' ).then( ( { default: HelpCenter } ) =>
 		createRoot( container ).render(
@@ -27,7 +24,8 @@ export default function loadHelpCenter() {
 					onboardingUrl="https://wordpress.com/start"
 					handleClose={ () => dispatch( 'automattic/help-center' ).setShowHelpCenter( false ) }
 					product={ helpCenterData.isCommerceGarden ? 'commerce-garden' : undefined }
-					{ ...botProps }
+					newInteractionsBotSlug={ helpCenterData.newInteractionsBotSlug }
+					newLoggedOutInteractionsBotSlug={ helpCenterData.newLoggedOutInteractionsBotSlug }
 				/>
 			</QueryClientProvider>
 		)

--- a/apps/help-center/help-center-ciab-admin.jsx
+++ b/apps/help-center/help-center-ciab-admin.jsx
@@ -45,9 +45,6 @@ function useCurrentRoute() {
 
 function HelpCenterWithRouteTracking( { HelpCenter } ) {
 	const currentRoute = useCurrentRoute();
-	const botProps = helpCenterData.isCommerceGarden
-		? { newInteractionsBotSlug: 'ciab-workflow-support_chat' }
-		: {};
 
 	return (
 		<HelpCenter
@@ -60,7 +57,8 @@ function HelpCenterWithRouteTracking( { HelpCenter } ) {
 			handleClose={ () => dispatch( 'automattic/help-center' ).setShowHelpCenter( false ) }
 			product={ helpCenterData.isCommerceGarden ? 'commerce-garden' : undefined }
 			currentRoute={ currentRoute }
-			{ ...botProps }
+			newInteractionsBotSlug={ helpCenterData.newInteractionsBotSlug }
+			newLoggedOutInteractionsBotSlug={ helpCenterData.newLoggedOutInteractionsBotSlug }
 		/>
 	);
 }

--- a/apps/help-center/help-center-customizer.jsx
+++ b/apps/help-center/help-center-customizer.jsx
@@ -91,6 +91,8 @@ function CustomizerHelpCenterContent() {
 			onboardingUrl="https://wordpress.com/start"
 			handleClose={ closeCallback }
 			isCommerceGarden={ helpCenterData.isCommerceGarden }
+			newInteractionsBotSlug={ helpCenterData.newInteractionsBotSlug }
+			newLoggedOutInteractionsBotSlug={ helpCenterData.newLoggedOutInteractionsBotSlug }
 		/>
 	);
 }

--- a/apps/help-center/help-center-gutenberg.jsx
+++ b/apps/help-center/help-center-gutenberg.jsx
@@ -250,10 +250,6 @@ function HelpCenterContent() {
 		/>
 	);
 
-	const botProps = helpCenterData.isCommerceGarden
-		? { newInteractionsBotSlug: 'ciab-workflow-support_chat' }
-		: {};
-
 	return (
 		<>
 			{ showHelpIcon &&
@@ -272,7 +268,8 @@ function HelpCenterContent() {
 				onboardingUrl="https://wordpress.com/start"
 				handleClose={ closeCallback }
 				product={ helpCenterData.isCommerceGarden ? 'commerce-garden' : undefined }
-				{ ...botProps }
+				newInteractionsBotSlug={ helpCenterData.newInteractionsBotSlug }
+				newLoggedOutInteractionsBotSlug={ helpCenterData.newLoggedOutInteractionsBotSlug }
 			/>
 		</>
 	);

--- a/apps/help-center/help-center-wp-admin.jsx
+++ b/apps/help-center/help-center-wp-admin.jsx
@@ -211,10 +211,6 @@ function AdminHelpCenterContent() {
 		};
 	}, [] );
 
-	const botProps = helpCenterData.isCommerceGarden
-		? { newInteractionsBotSlug: 'ciab-workflow-support_chat' }
-		: {};
-
 	return (
 		<HelpCenter
 			locale={ helpCenterData.locale }
@@ -225,7 +221,8 @@ function AdminHelpCenterContent() {
 			onboardingUrl="https://wordpress.com/start"
 			handleClose={ closeCallback }
 			product={ helpCenterData.isCommerceGarden ? 'commerce-garden' : undefined }
-			{ ...botProps }
+			newInteractionsBotSlug={ helpCenterData.newInteractionsBotSlug }
+			newLoggedOutInteractionsBotSlug={ helpCenterData.newLoggedOutInteractionsBotSlug }
 		/>
 	);
 }


### PR DESCRIPTION
## Proposed Changes

* Pass `helpCenterData.newInteractionsBotSlug` and `helpCenterData.newLoggedOutInteractionsBotSlug` to every `HelpCenter` mount in `apps/help-center`.
* Remove the hardcoded Commerce Garden bot override so deployed Help Center bundles use the bot configuration supplied by their host.

## Why are these changes being made?

The Help Center package accepts separate bot slugs for new logged-in and logged-out interactions, but the standalone app bundles did not forward those values from `helpCenterData`. As a result, consumers of the deployed bundles could provide the configuration without it reaching the Help Center component.

Forwarding both values keeps the app entry points aligned with the package API and lets each host select its logged-in and logged-out bot routes.

## Testing Instructions

1. Sandbox `widgets.wp.com` (the sites themselves do not need sandboxing).
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site.
4. Open the Help Center and verify it loads and functions correctly.
5. Verify new logged-in and logged-out chats use the bot slugs supplied in `helpCenterData`.

Automated checks:

* `yarn workspace @automattic/help-center-app build:app`
* Scoped ESLint
* Prettier
* `git diff --check`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
