### PR TITLE
Purchases: read cancel-jetpack-form/gsuite dialog from api-core

### DIFF
--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -11,11 +11,14 @@ import JetpackCancellationOfferStep from 'calypso/components/marketing-survey/ca
 import JetpackCancellationOfferAccepted from 'calypso/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-offer-accepted';
 import JetpackCancellationSurvey from 'calypso/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey';
 import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-purchase-form/constants';
-import enrichedSurveyData from 'calypso/components/marketing-survey/cancel-purchase-form/enriched-survey-data';
-import { getName, isRemoved } from 'calypso/lib/purchases';
+import { isJetpackHoldingSitePurchase } from 'calypso/dashboard/utils/purchase';
 import { submitSurvey } from 'calypso/lib/purchases/actions';
 import { isOutsideCalypso } from 'calypso/lib/url';
-import { isJetpackHoldingSitePurchase } from 'calypso/me/purchases/utils';
+import {
+	enrichedSurveyData,
+	getName,
+	isRemoved,
+} from 'calypso/me/purchases/lib/raw-purchase-helpers';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCancellationOfferApplySuccess from 'calypso/state/cancellation-offers/selectors/get-cancellation-offer-apply-success';
@@ -25,7 +28,7 @@ import isFetchingCancellationOffers from 'calypso/state/cancellation-offers/sele
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import nextStep from '../cancel-purchase-form/next-step';
 import * as steps from './steps';
-import type { Purchase } from 'calypso/lib/purchases/types';
+import type { Purchase } from '@automattic/api-core';
 
 /**
  * Style dependencies
@@ -84,11 +87,11 @@ const CancelJetpackForm: React.FC< Props > = ( {
 	const [ disableContinuation, setDisableContinuation ] = useState< boolean >( false );
 
 	const isAtomicSite = useSelector( ( state ) =>
-		isSiteAutomatedTransfer( state, purchase.siteId )
+		isSiteAutomatedTransfer( state, purchase.blog_id )
 	);
 
 	const cancellationOffer = useSelector( ( state ) => {
-		const offers = getCancellationOffers( state, purchase.id );
+		const offers = getCancellationOffers( state, purchase.ID );
 		if ( 1 === offers.length ) {
 			return offers[ 0 ];
 		}
@@ -97,15 +100,15 @@ const CancelJetpackForm: React.FC< Props > = ( {
 	} );
 
 	const fetchingCancellationOffers = useSelector( ( state ) =>
-		isFetchingCancellationOffers( state, purchase.id )
+		isFetchingCancellationOffers( state, purchase.ID )
 	);
 
 	const applyingCancellationOffer = useSelector( ( state ) =>
-		isApplyingCancellationOffer( state, purchase.id )
+		isApplyingCancellationOffer( state, purchase.ID )
 	);
 
 	const cancellationOfferApplySuccess = useSelector( ( state ) =>
-		getCancellationOfferApplySuccess( state, purchase.id )
+		getCancellationOfferApplySuccess( state, purchase.ID )
 	);
 
 	const isOfferPriceSameOrLowerThanPurchasePrice = useMemo( () => {
@@ -138,14 +141,14 @@ const CancelJetpackForm: React.FC< Props > = ( {
 			dispatch(
 				recordTracksEvent( name, {
 					cancellation_flow: flowType,
-					product_slug: purchase.productSlug,
+					product_slug: purchase.product_slug,
 					is_atomic: isAtomicSite,
 
 					...properties,
 				} )
 			);
 		},
-		[ dispatch, flowType, isAtomicSite, purchase.productSlug ]
+		[ dispatch, flowType, isAtomicSite, purchase.product_slug ]
 	);
 
 	/**
@@ -278,7 +281,7 @@ const CancelJetpackForm: React.FC< Props > = ( {
 			const surveyData = {
 				'why-cancel': {
 					response: surveyAnswerId,
-					text: surveyAnswerText,
+					text: String( surveyAnswerText ),
 				},
 				type: 'cancel',
 			};
@@ -286,7 +289,7 @@ const CancelJetpackForm: React.FC< Props > = ( {
 			dispatch(
 				submitSurvey(
 					props.isAkismet ? 'calypso-cancel-akismet' : 'calypso-cancel-jetpack',
-					purchase.siteId,
+					purchase.blog_id,
 					enrichedSurveyData( surveyData, purchase )
 				)
 			);
@@ -460,9 +463,9 @@ const CancelJetpackForm: React.FC< Props > = ( {
 			// this differs a bit depending on the product/ what JP modules are active
 			return (
 				<JetpackBenefitsStep
-					siteId={ purchase.siteId }
+					siteId={ purchase.blog_id }
 					purchase={ purchase }
-					productSlug={ purchase.productSlug }
+					productSlug={ purchase.product_slug }
 				/>
 			);
 		}
@@ -487,7 +490,7 @@ const CancelJetpackForm: React.FC< Props > = ( {
 			// Show an offer, the user can accept it or go ahead with the cancellation.
 			return (
 				<JetpackCancellationOfferStep
-					siteId={ purchase.siteId }
+					siteId={ purchase.blog_id }
 					purchase={ purchase }
 					offer={ cancellationOffer }
 					percentDiscount={ offerDiscountBasedFromPurchasePrice }
@@ -502,7 +505,7 @@ const CancelJetpackForm: React.FC< Props > = ( {
 			// Show after an offer discount has been accepted
 			return (
 				<JetpackCancellationOfferAccepted
-					siteId={ purchase.siteId }
+					siteId={ purchase.blog_id }
 					percentDiscount={ offerDiscountBasedFromPurchasePrice }
 					productName={ productName }
 					isAkismet={ !! props?.isAkismet }
@@ -530,8 +533,8 @@ const CancelJetpackForm: React.FC< Props > = ( {
 
 	return (
 		<>
-			{ purchase.siteId && purchase.id && (
-				<QueryPurchaseCancellationOffers siteId={ purchase.siteId } purchaseId={ purchase.id } />
+			{ purchase.blog_id && purchase.ID && (
+				<QueryPurchaseCancellationOffers siteId={ purchase.blog_id } purchaseId={ purchase.ID } />
 			) }
 			<Dialog
 				leaveTimeout={ 0 } // this closes the modal immediately, which makes the experience feel snappier

--- a/client/components/marketing-survey/cancel-jetpack-form/jetpack-benefits-step.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/jetpack-benefits-step.tsx
@@ -15,11 +15,11 @@ import JetpackBenefits from 'calypso/blocks/jetpack-benefits';
 import JetpackGeneralBenefits from 'calypso/blocks/jetpack-benefits/general-benefits';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { isPartnerPurchase } from 'calypso/lib/purchases';
+import { isPartnerPurchase } from 'calypso/dashboard/utils/purchase';
 import { useSelector } from 'calypso/state';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
+import type { Purchase } from '@automattic/api-core';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
-import type { Purchase } from 'calypso/lib/purchases/types';
 
 interface Props {
 	siteId: number;
@@ -36,7 +36,7 @@ const JetpackBenefitsStep: React.FC< Props > = ( props ) => {
 	const moment = useLocalizedMoment();
 
 	const getTimeRemainingForSubscription = ( purchase: Purchase ) => {
-		const purchaseExpiryDate = moment.utc( purchase.expiryDate );
+		const purchaseExpiryDate = moment.utc( purchase.expiry_date );
 
 		return moment.duration( purchaseExpiryDate.diff( moment.utc() ) );
 	};
@@ -80,7 +80,7 @@ const JetpackBenefitsStep: React.FC< Props > = ( props ) => {
 		}
 
 		// if this product/ plan is partner managed, it won't really "expire" from the user's perspective
-		if ( isPartnerPurchase( purchase ) || ! purchase.expiryDate ) {
+		if ( isPartnerPurchase( purchase ) || ! purchase.expiry_date ) {
 			return (
 				<React.Fragment>
 					{ translate(

--- a/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-offer.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-offer.tsx
@@ -18,7 +18,7 @@ import getCancellationOfferApplyError from 'calypso/state/cancellation-offers/se
 import getCancellationOfferApplySuccess from 'calypso/state/cancellation-offers/selectors/get-cancellation-offer-apply-success';
 import isApplyingCancellationOffer from 'calypso/state/cancellation-offers/selectors/is-applying-cancellation-offer';
 import { CancellationOffer } from 'calypso/state/cancellation-offers/types';
-import type { Purchase } from 'calypso/lib/purchases/types';
+import type { Purchase } from '@automattic/api-core';
 import type { FC } from 'react';
 
 interface Props {
@@ -35,13 +35,13 @@ const JetpackCancellationOffer: FC< Props > = ( props ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const isApplyingOffer = useSelector( ( state ) =>
-		isApplyingCancellationOffer( state, purchase.id )
+		isApplyingCancellationOffer( state, purchase.ID )
 	);
 	const offerApplySuccess = useSelector( ( state ) =>
-		getCancellationOfferApplySuccess( state, purchase.id )
+		getCancellationOfferApplySuccess( state, purchase.ID )
 	);
 	const offerApplyError = useSelector( ( state ) =>
-		getCancellationOfferApplyError( state, purchase.id )
+		getCancellationOfferApplyError( state, purchase.ID )
 	);
 	const { offerHeadline, renewalCopy } = useMemo( () => {
 		const periods = offer.discountedPeriods;
@@ -51,7 +51,7 @@ const JetpackCancellationOffer: FC< Props > = ( props ) => {
 			args: {
 				periods,
 				discount: percentDiscount,
-				name: purchase.productName,
+				name: purchase.product_name,
 			},
 		};
 		const renewalCopyOptions = {
@@ -68,7 +68,7 @@ const JetpackCancellationOffer: FC< Props > = ( props ) => {
 		let offerHeadline;
 		let renewalCopy;
 
-		switch ( purchase.billPeriodDays ) {
+		switch ( purchase.bill_period_days ) {
 			case PLAN_BIENNIAL_PERIOD:
 				/* Translators: %(discount)d%% is a discount percentage like 15% or 20% */
 				offerHeadline = translate(
@@ -142,7 +142,7 @@ const JetpackCancellationOffer: FC< Props > = ( props ) => {
 	const onClickAccept = useCallback( () => {
 		// is the offer being claimed/ is there already a success or error
 		if ( ! isApplyingOffer && offerApplySuccess === false && ! offerApplyError ) {
-			dispatch( applyCancellationOffer( siteId, purchase.id ) );
+			dispatch( applyCancellationOffer( siteId, purchase.ID ) );
 			onGetDiscount(); // Takes care of analytics.
 		}
 	}, [
@@ -150,7 +150,7 @@ const JetpackCancellationOffer: FC< Props > = ( props ) => {
 		offerApplySuccess,
 		offerApplyError,
 		siteId,
-		purchase.id,
+		purchase.ID,
 		onGetDiscount,
 		dispatch,
 	] );

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.tsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.tsx
@@ -1,5 +1,4 @@
-import { localize } from 'i18n-calypso';
-import PropTypes from 'prop-types';
+import { localize, LocalizeProps } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
@@ -9,8 +8,34 @@ import { getSelectedDomain } from 'calypso/lib/domains';
 import { getGoogleMailServiceFamily, getGSuiteSubscriptionStatus } from 'calypso/lib/gsuite';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import type { Purchase } from '@automattic/api-core';
+import type { AppState } from 'calypso/types';
 
-class GSuiteCancellationFeatures extends Component {
+interface GSuiteCancellationFeaturesOwnProps {
+	purchase: Purchase;
+}
+
+function mapStateToProps( state: AppState, { purchase }: GSuiteCancellationFeaturesOwnProps ) {
+	return {
+		selectedDomain: getSelectedDomain( {
+			domains: getDomainsBySiteId( state, purchase.blog_id ),
+			selectedDomainName: purchase.meta ?? '',
+		} ),
+	};
+}
+
+const mapDispatchToProps = {
+	recordTracksEvent,
+};
+
+type GSuiteCancellationFeaturesProps = GSuiteCancellationFeaturesOwnProps &
+	ReturnType< typeof mapStateToProps > &
+	typeof mapDispatchToProps &
+	LocalizeProps;
+
+class GSuiteCancellationFeatures extends Component< GSuiteCancellationFeaturesProps > {
+	static defaultProps = {};
+
 	componentDidMount() {
 		this.props.recordTracksEvent( 'calypso_purchases_gsuite_remove_purchase_features_view' );
 	}
@@ -21,7 +46,8 @@ class GSuiteCancellationFeatures extends Component {
 
 	getAccessMessage = () => {
 		const { selectedDomain, purchase, translate } = this.props;
-		const { meta: domainName, productSlug } = purchase;
+		const domainName = purchase.meta ?? '';
+		const { product_slug: productSlug } = purchase;
 		const googleMailService = getGoogleMailServiceFamily( productSlug );
 		const googleSubscriptionStatus = getGSuiteSubscriptionStatus( selectedDomain );
 
@@ -68,7 +94,8 @@ class GSuiteCancellationFeatures extends Component {
 
 	render() {
 		const { purchase, translate } = this.props;
-		const { meta: domainName, productSlug } = purchase;
+		const domainName = purchase.meta ?? '';
+		const { product_slug: productSlug } = purchase;
 
 		return (
 			<div className="gsuite-cancel-purchase-dialog__features">
@@ -84,28 +111,16 @@ class GSuiteCancellationFeatures extends Component {
 
 				<GSuiteFeatures productSlug={ productSlug } domainName={ domainName } type="list" />
 
-				<GSuiteLearnMore onClick={ this.handleLearnMoreClick } productSlug={ productSlug } />
+				<GSuiteLearnMore
+					onLearnMoreClick={ this.handleLearnMoreClick }
+					productSlug={ productSlug }
+				/>
 			</div>
 		);
 	}
 }
 
-GSuiteCancellationFeatures.propTypes = {
-	purchase: PropTypes.object.isRequired,
-	recordTracksEvent: PropTypes.func.isRequired,
-	translate: PropTypes.func.isRequired,
-};
-
 export default connect(
-	( state, { purchase } ) => {
-		return {
-			selectedDomain: getSelectedDomain( {
-				domains: getDomainsBySiteId( state, purchase.siteId ),
-				selectedDomainName: purchase.meta,
-			} ),
-		};
-	},
-	{
-		recordTracksEvent,
-	}
+	mapStateToProps,
+	mapDispatchToProps
 )( localize( GSuiteCancellationFeatures ) );

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-survey.tsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-survey.tsx
@@ -1,12 +1,30 @@
-import { localize } from 'i18n-calypso';
-import PropTypes from 'prop-types';
+import { localize, LocalizeProps } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import MultipleChoiceQuestion from 'calypso/components/multiple-choice-question';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import type { Purchase } from '@automattic/api-core';
 
-class GSuiteCancellationSurvey extends Component {
+interface GSuiteCancellationSurveyOwnProps {
+	disabled: boolean;
+	onSurveyAnswerChange: ( surveyAnswerId: string | null, surveyAnswerText: string ) => void;
+	purchase: Purchase;
+	surveyAnswerId?: string | null;
+	surveyAnswerText?: string;
+}
+
+const mapDispatchToProps = {
+	recordTracksEvent,
+};
+
+type GSuiteCancellationSurveyProps = GSuiteCancellationSurveyOwnProps &
+	typeof mapDispatchToProps &
+	LocalizeProps;
+
+class GSuiteCancellationSurvey extends Component< GSuiteCancellationSurveyProps > {
+	static defaultProps = {};
+
 	componentDidMount() {
 		this.props.recordTracksEvent( 'calypso_purchases_gsuite_remove_purchase_survey_view' );
 	}
@@ -15,7 +33,7 @@ class GSuiteCancellationSurvey extends Component {
 		const {
 			disabled,
 			onSurveyAnswerChange,
-			purchase: { productSlug },
+			purchase: { product_slug: productSlug },
 			surveyAnswerId,
 			surveyAnswerText,
 			translate,
@@ -67,15 +85,4 @@ class GSuiteCancellationSurvey extends Component {
 	}
 }
 
-GSuiteCancellationSurvey.propTypes = {
-	disabled: PropTypes.bool.isRequired,
-	onSurveyAnswerChange: PropTypes.func.isRequired,
-	purchase: PropTypes.object.isRequired,
-	translate: PropTypes.func.isRequired,
-	surveyAnswerId: PropTypes.string,
-	surveyAnswerText: PropTypes.string,
-};
-
-export default connect( null, {
-	recordTracksEvent,
-} )( localize( GSuiteCancellationSurvey ) );
+export default connect( null, mapDispatchToProps )( localize( GSuiteCancellationSurvey ) );

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.tsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.tsx
@@ -1,12 +1,11 @@
 import page from '@automattic/calypso-router';
 import { Dialog } from '@automattic/components';
-import { localize } from 'i18n-calypso';
-import PropTypes from 'prop-types';
+import { localize, LocalizeProps } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import enrichedSurveyData from 'calypso/components/marketing-survey/cancel-purchase-form/enriched-survey-data';
-import { getName } from 'calypso/lib/purchases';
+import { bindActionCreators } from 'redux';
 import { submitSurvey } from 'calypso/lib/purchases/actions';
+import { enrichedSurveyData, getName } from 'calypso/me/purchases/lib/raw-purchase-helpers';
 import { purchasesRoot } from 'calypso/me/purchases/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
@@ -16,16 +15,66 @@ import { getPurchasesError } from 'calypso/state/purchases/selectors';
 import GSuiteCancellationFeatures from './gsuite-cancellation-features';
 import GSuiteCancellationSurvey from './gsuite-cancellation-survey';
 import * as steps from './steps';
+import type { Purchase } from '@automattic/api-core';
+import type { SiteDetails } from '@automattic/data-stores';
+import type { CalypsoDispatch } from 'calypso/state/types';
+import type { AppState } from 'calypso/types';
 
 import './style.scss';
 
-class GSuiteCancelPurchaseDialog extends Component {
-	constructor( props ) {
+interface GSuiteCancelPurchaseDialogOwnProps {
+	isVisible: boolean;
+	onClose: () => void;
+	purchase: Purchase;
+	site?: SiteDetails | null;
+}
+
+function mapStateToProps( state: AppState, { purchase }: GSuiteCancelPurchaseDialogOwnProps ) {
+	return {
+		domain: purchase.meta,
+		productName: getName( purchase ),
+		purchasesError: ( getPurchasesError( state ) || null ) as string | null,
+		userId: getCurrentUserId( state ),
+	};
+}
+
+function mapDispatchToProps( dispatch: CalypsoDispatch ) {
+	return bindActionCreators(
+		{
+			errorNotice,
+			recordTracksEvent,
+			removePurchase,
+			successNotice,
+			submitSurvey,
+		},
+		dispatch
+	);
+}
+
+type GSuiteCancelPurchaseDialogProps = GSuiteCancelPurchaseDialogOwnProps &
+	ReturnType< typeof mapStateToProps > &
+	ReturnType< typeof mapDispatchToProps > &
+	LocalizeProps;
+
+interface GSuiteCancelPurchaseDialogState {
+	step: string;
+	surveyAnswerId: string | null;
+	surveyAnswerText: string;
+	isRemoving: boolean;
+}
+
+class GSuiteCancelPurchaseDialog extends Component<
+	GSuiteCancelPurchaseDialogProps,
+	GSuiteCancelPurchaseDialogState
+> {
+	static defaultProps = {};
+
+	constructor( props: GSuiteCancelPurchaseDialogProps ) {
 		super( props );
 		this.state = this.initialState;
 	}
 
-	get initialState() {
+	get initialState(): GSuiteCancelPurchaseDialogState {
 		return {
 			step: steps.GSUITE_INITIAL_STEP,
 			surveyAnswerId: null,
@@ -40,7 +89,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 
 	nextStepButtonClick = () => {
 		const { step } = this.state;
-		const nextStep = steps.nextStep( step );
+		const nextStep = steps.nextStep();
 
 		this.props.recordTracksEvent( 'calypso_purchases_gsuite_remove_purchase_next_step_click', {
 			step,
@@ -51,7 +100,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 
 	previousStepButtonClick = () => {
 		const { step } = this.state;
-		const prevStep = steps.previousStep( step );
+		const prevStep = steps.previousStep();
 
 		this.props.recordTracksEvent( 'calypso_purchases_gsuite_remove_purchase_prev_step_click', {
 			step,
@@ -60,13 +109,13 @@ class GSuiteCancelPurchaseDialog extends Component {
 		this.setState( { step: prevStep } );
 	};
 
-	cancelButtonClick = ( closeDialog ) => {
+	cancelButtonClick = ( closeDialog: () => void ) => {
 		this.props.recordTracksEvent( 'calypso_purchases_gsuite_remove_purchase_keep_it_click' );
 		closeDialog();
 		this.resetState();
 	};
 
-	removeButtonClick = async ( closeDialog ) => {
+	removeButtonClick = async ( closeDialog: () => void ) => {
 		this.props.recordTracksEvent( 'calypso_purchases_gsuite_remove_purchase_click' );
 
 		this.setState( {
@@ -88,7 +137,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 		const { surveyAnswerId, surveyAnswerText } = this.state;
 		const surveyData = {
 			'why-cancel': {
-				response: surveyAnswerId,
+				response: surveyAnswerId ?? undefined,
 				text: surveyAnswerText,
 			},
 			type: 'remove',
@@ -96,7 +145,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 
 		this.props.submitSurvey(
 			'calypso-gsuite-remove-purchase',
-			purchase.siteId,
+			purchase.blog_id,
 			enrichedSurveyData( surveyData, purchase )
 		);
 	};
@@ -104,7 +153,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 	removePurchase = async () => {
 		const { domain, productName, purchase, translate, userId } = this.props;
 
-		await this.props.removePurchase( purchase.id, userId );
+		await this.props.removePurchase( purchase.ID, userId );
 
 		const { purchasesError } = this.props;
 
@@ -122,7 +171,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 		return true;
 	};
 
-	onSurveyAnswerChange = ( surveyAnswerId, surveyAnswerText ) => {
+	onSurveyAnswerChange = ( surveyAnswerId: string | null, surveyAnswerText: string ) => {
 		if ( surveyAnswerId !== this.state.surveyAnswerId ) {
 			this.props.recordTracksEvent(
 				'calypso_purchases_gsuite_remove_purchase_survey_answer_change',
@@ -174,7 +223,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 			{
 				action: 'remove',
 				// used to get a busy button
-				additionalClassNames: isRemoving ? [ 'is-busy' ] : undefined,
+				additionalClassNames: isRemoving ? 'is-busy' : undefined,
 				// don't allow the user to complete the survey without an selection
 				disabled: isRemoving || null === surveyAnswerId,
 				isPrimary: true,
@@ -214,31 +263,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 	}
 }
 
-GSuiteCancelPurchaseDialog.propTypes = {
-	domain: PropTypes.string.isRequired,
-	isVisible: PropTypes.bool.isRequired,
-	onClose: PropTypes.func.isRequired,
-	productName: PropTypes.string.isRequired,
-	purchase: PropTypes.object.isRequired,
-	purchasesError: PropTypes.string,
-	site: PropTypes.object.isRequired,
-	translate: PropTypes.func.isRequired,
-};
-
 export default connect(
-	( state, { purchase } ) => {
-		return {
-			domain: purchase.meta,
-			productName: getName( purchase ),
-			purchasesError: getPurchasesError( state ),
-			userId: getCurrentUserId( state ),
-		};
-	},
-	{
-		errorNotice,
-		recordTracksEvent,
-		removePurchase,
-		successNotice,
-		submitSurvey,
-	}
+	mapStateToProps,
+	mapDispatchToProps
 )( localize( GSuiteCancelPurchaseDialog ) );

--- a/client/me/purchases/cancel-purchase/button.tsx
+++ b/client/me/purchases/cancel-purchase/button.tsx
@@ -224,7 +224,7 @@ class CancelPurchaseButton extends Component<
 				{ ( isJetpack || isAkismet ) && (
 					<CancelJetpackForm
 						disableButtons={ disableButtons }
-						purchase={ purchase }
+						purchase={ purchase.rawPurchase }
 						purchaseListUrl={ purchaseListUrl ?? purchasesRoot }
 						isVisible={ showDialog }
 						onClose={ this.closeDialog }

--- a/client/me/purchases/lib/raw-purchase-helpers.ts
+++ b/client/me/purchases/lib/raw-purchase-helpers.ts
@@ -41,14 +41,16 @@ import {
 	isPartnerPurchase,
 } from 'calypso/dashboard/utils/purchase';
 import { addPaymentMethod, changePaymentMethod } from '../paths';
-import type { Purchase } from '@automattic/api-core';
+import type { MarketingSurveyResponses, Purchase } from '@automattic/api-core';
 import type { TranslateResult } from 'i18n-calypso';
+
+const DAY_IN_MS = 1000 * 60 * 60 * 24;
 
 /**
  * Raw-`Purchase` ports of the `calypso/lib/purchases` helpers used by the legacy
- * `client/me/purchases` pages while they migrate off the data-stores assembler
- * (SHILL-2256). These read the snake_case `Purchase` from `@automattic/api-core`
- * directly.
+ * `client/me/purchases` pages, and the marketing-survey cancellation dialogs they
+ * render, while they migrate off the data-stores assembler (SHILL-2256). These
+ * read the snake_case `Purchase` from `@automattic/api-core` directly.
  *
  * This module is intentionally local and not exported from any shared package:
  * several of these helpers have historically misleading names and should not be
@@ -62,6 +64,31 @@ export function getName( purchase: Purchase ): string {
 		return purchase.meta ?? '';
 	}
 	return purchase.product_name;
+}
+
+export function enrichedSurveyData(
+	surveyData: Omit< MarketingSurveyResponses, 'purchaseId' | 'purchase' >,
+	purchase?: Pick< Purchase, 'subscribed_date' | 'blog_created_date' | 'ID' | 'product_slug' >,
+	timestamp = new Date()
+): MarketingSurveyResponses {
+	const purchaseStartDate = purchase?.subscribed_date;
+	const siteStartDate = purchase?.blog_created_date;
+	const purchaseId = purchase?.ID ?? 0;
+	const productSlug = purchase?.product_slug ?? '';
+
+	return {
+		purchase: productSlug,
+		purchaseId,
+		...( purchaseStartDate && {
+			daysSincePurchase:
+				( new Date( timestamp ).getTime() - new Date( purchaseStartDate ).getTime() ) / DAY_IN_MS,
+		} ),
+		...( siteStartDate && {
+			daysSinceSiteCreation:
+				( new Date( timestamp ).getTime() - new Date( siteStartDate ).getTime() ) / DAY_IN_MS,
+		} ),
+		...surveyData,
+	};
 }
 
 export function isIncludedWithPlan( purchase: Purchase ): boolean {

--- a/client/me/purchases/remove-purchase/index.tsx
+++ b/client/me/purchases/remove-purchase/index.tsx
@@ -334,7 +334,7 @@ class RemovePurchase extends Component< RemovePurchaseProps, RemovePurchaseState
 		return (
 			<CancelJetpackForm
 				disableButtons={ this.state.isRemoving }
-				purchase={ createPurchaseObject( purchase ) }
+				purchase={ purchase }
 				purchaseListUrl={ purchaseListUrl ?? purchasesRoot }
 				isVisible={ this.state.isDialogVisible }
 				onClose={ this.closeDialog }
@@ -388,7 +388,7 @@ class RemovePurchase extends Component< RemovePurchaseProps, RemovePurchaseState
 				<GSuiteCancellationPurchaseDialog
 					isVisible={ this.state.isDialogVisible }
 					onClose={ this.closeDialog }
-					purchase={ createPurchaseObject( purchase ) }
+					purchase={ purchase }
 					site={ this.props.site }
 				/>
 			);


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-2256/remove-the-purchases-assembler-read-the-raw-purchase-object-directly

## Proposed changes

Converts `CancelJetpackForm` and `GSuiteCancelPurchaseDialog` (and their child components) off the data-stores purchases assembler onto the raw `Purchase` type from `@automattic/api-core`, then removes the `createPurchaseObject` shims that were bridging them from `remove-purchase` and `cancel-purchase/button`.

* Convert `CancelJetpackForm`, `jetpack-benefits-step`, and `jetpack-cancellation-offer` to the raw `Purchase` type, switching camelCase field reads (`siteId`, `id`, `productSlug`, `productName`, `billPeriodDays`, `expiryDate`) to their snake_case/raw equivalents.
* Convert `GSuiteCancelPurchaseDialog`, `gsuite-cancellation-features`, and `gsuite-cancellation-survey` the same way, converting each from `.jsx` to `.tsx`.
* Add a raw-`Purchase` port of `enrichedSurveyData` to `client/me/purchases/lib/raw-purchase-helpers.ts`, mirroring the existing Dashboard implementation.
* Drop the `createPurchaseObject` shims in `remove-purchase` and `cancel-purchase/button` now that both dialogs accept the raw purchase directly.
* Fix `GSuiteCancellationFeatures` passing `onClick` instead of `onLearnMoreClick` to `GSuiteLearnMore`, which meant the "learn more" Tracks event was never actually firing.

## Why are these changes being made?

This continues the SHILL-2256 effort to remove the purchases data-stores assembler in favor of reading the raw api-core `Purchase` object directly, following the same incremental-conversion approach used for `remove-purchase` and `confirm-cancel-domain`. These two dialogs were the last consumers standing between `remove-purchase` and full removal of its `createPurchaseObject` shim, so converting them now unblocks that cleanup.

## Testing instructions

TC:
```
yarn test-client --findRelatedTests client/components/marketing-survey/cancel-jetpack-form/index.tsx client/components/marketing-survey/cancel-jetpack-form/jetpack-benefits-step.tsx client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-offer.tsx client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.tsx client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.tsx client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-survey.tsx client/me/purchases/cancel-purchase/button.tsx client/me/purchases/lib/raw-purchase-helpers.ts client/me/purchases/remove-purchase/index.tsx
```

Manual testing:
* On a WoA/sandbox environment, find a Jetpack or Akismet purchase and start the cancel/remove flow (`/me/purchases` → purchase detail → Cancel or Remove) to confirm the `CancelJetpackForm` dialog steps, benefits copy, and any active cancellation offer still render and submit correctly.
* Find a GSuite/Google Workspace purchase and start its remove flow to confirm `GSuiteCancelPurchaseDialog` still walks through the features/survey steps and removes the purchase.
* Confirm clicking "Learn more" in the GSuite features step now fires `calypso_purchases_gsuite_remove_purchase_learn_more_click` in the Tracks debugger (previously a no-op due to the `onClick`/`onLearnMoreClick` mismatch).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?