### PR TITLE
Site Chat: apply the expanded brand kit

### DIFF
--- a/apps/agents-manager/__tests__/reader-chat.test.js
+++ b/apps/agents-manager/__tests__/reader-chat.test.js
@@ -76,6 +76,7 @@ const {
 	parseSuggestionsResponse,
 	getSuggestionsFetchHeaders,
 	injectScopedReset,
+	injectBrandTokens,
 	watchFirstChatOpen,
 } = require( '../reader-chat' );
 
@@ -296,6 +297,86 @@ describe( 'getReaderEmptyViewHeading', () => {
 				currentPost: { id: 1, title: 'Home', url: 'https://example.com/' },
 			} )
 		).toBe( 'Ask me anything about this blog.' );
+	} );
+
+	it( 'prefers an owner-set greeting over the contextual default', () => {
+		expect(
+			getReaderEmptyViewHeading( {
+				currentPost: { id: 1 },
+				brand: { greeting: 'What can I find for you?' },
+			} )
+		).toBe( 'What can I find for you?' );
+	} );
+
+	it( 'falls back to contextual copy when the brand carries no greeting', () => {
+		expect( getReaderEmptyViewHeading( { brand: {} } ) ).toBe( 'Ask me anything about this blog.' );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// injectBrandTokens
+// ---------------------------------------------------------------------------
+
+describe( 'injectBrandTokens', () => {
+	beforeEach( () => {
+		document.head.querySelector( '#jetpack-reader-chat-brand' )?.remove();
+		getElementByIdSpy.mockImplementation( getElementById );
+	} );
+
+	afterEach( () => {
+		getElementByIdSpy.mockReturnValue( null );
+	} );
+
+	it( 'emits nothing when the site has no accent', () => {
+		injectBrandTokens( {} );
+		expect( document.head.querySelector( '#jetpack-reader-chat-brand' ) ).toBeNull();
+	} );
+
+	it( 'emits nothing when there is no brand at all', () => {
+		injectBrandTokens( undefined );
+		expect( document.head.querySelector( '#jetpack-reader-chat-brand' ) ).toBeNull();
+	} );
+
+	it( 'sets the accent tokens from the brand', () => {
+		injectBrandTokens( { accent: '#2271b1', accentForeground: '#ffffff' } );
+
+		const css = document.head.querySelector( '#jetpack-reader-chat-brand' ).textContent;
+		expect( css ).toContain( '--color-primary: #2271b1;' );
+		expect( css ).toContain( '--color-primary-foreground: #ffffff;' );
+	} );
+
+	it( 'targets the portalled selectors, since the panel mounts on body', () => {
+		injectBrandTokens( { accent: '#2271b1', accentForeground: '#ffffff' } );
+
+		const css = document.head.querySelector( '#jetpack-reader-chat-brand' ).textContent;
+		expect( css ).toContain( '.agents-manager-chat' );
+		expect( css ).toContain( '.agents-manager-sidebar-fab' );
+		expect( css ).toContain( '.components-popover' );
+	} );
+
+	it( 'never defines the tokens globally, which would restyle the host theme', () => {
+		injectBrandTokens( { accent: '#2271b1', accentForeground: '#ffffff' } );
+
+		const css = document.head.querySelector( '#jetpack-reader-chat-brand' ).textContent;
+		expect( css ).not.toMatch( /:root/ );
+		expect( css ).not.toMatch( /(^|[^-\w])html\s*[,{]/ );
+	} );
+
+	it( 'defaults the foreground when an older deploy sends an accent without one', () => {
+		injectBrandTokens( { accent: '#2271b1' } );
+
+		const css = document.head.querySelector( '#jetpack-reader-chat-brand' ).textContent;
+		expect( css ).toContain( '--color-primary-foreground: #ffffff;' );
+	} );
+
+	it( 'does not inject twice', () => {
+		injectBrandTokens( { accent: '#2271b1', accentForeground: '#ffffff' } );
+		injectBrandTokens( { accent: '#ff0000', accentForeground: '#000000' } );
+
+		expect( document.head.querySelectorAll( '#jetpack-reader-chat-brand' ) ).toHaveLength( 1 );
+		expect( document.head.querySelector( '#jetpack-reader-chat-brand' ).textContent ).toContain(
+			'#2271b1'
+		);
 	} );
 } );
 

--- a/apps/agents-manager/__tests__/reader-chat.test.js
+++ b/apps/agents-manager/__tests__/reader-chat.test.js
@@ -387,7 +387,27 @@ describe( 'injectBrandTokens', () => {
 		);
 	} );
 
-	it( 'inherits the host theme font when the site font is selected', () => {
+	it( 'uses the resolved host theme font when the site font is selected', () => {
+		injectBrandTokens( { fontFamily: 'site', siteFontFamily: 'Manrope, sans-serif' } );
+
+		const css = document.head.querySelector( '#jetpack-reader-chat-brand' ).textContent;
+		expect( css ).toContain( '--reader-chat-font-family: Manrope, sans-serif;' );
+		expect( css ).toContain( '.agents-manager-chat-header__menu-popover *' );
+		expect( css ).toContain( 'font-family: var( --reader-chat-font-family, inherit ) !important;' );
+	} );
+
+	it( 'keeps the Site Logo contained without a circular crop', () => {
+		injectBrandTokens( { accent: '#2271b1' } );
+
+		const css = document.head.querySelector( '#jetpack-reader-chat-brand' ).textContent;
+		expect( css ).toContain(
+			`.agents-manager-brand-logo {
+			object-fit: contain;
+		}`
+		);
+	} );
+
+	it( 'falls back to inheriting when the site font stack is unavailable', () => {
 		injectBrandTokens( { fontFamily: 'site' } );
 
 		const css = document.head.querySelector( '#jetpack-reader-chat-brand' ).textContent;
@@ -395,6 +415,27 @@ describe( 'injectBrandTokens', () => {
 		expect( css ).toContain( '.agents-manager-chat *' );
 		expect( css ).toContain( 'font-family: inherit !important;' );
 		expect( css ).not.toContain( '--reader-chat-font-family: inherit;' );
+	} );
+
+	it( 'keeps a selected preset ahead of an unrelated resolved site font', () => {
+		injectBrandTokens( { fontFamily: 'serif', siteFontFamily: 'Manrope, sans-serif' } );
+
+		const css = document.head.querySelector( '#jetpack-reader-chat-brand' ).textContent;
+		expect( css ).toContain( '--reader-chat-font-family: Georgia' );
+		expect( css ).not.toContain( '--reader-chat-font-family: Manrope' );
+	} );
+
+	it.each( [
+		[ 'extra declaration', 'Arial; color: red' ],
+		[ 'CSS comment', 'Arial/*' ],
+		[ 'CSS escape', 'Arial\\3b color: red' ],
+		[ 'oversized stack', 'A'.repeat( 201 ) ],
+	] )( 'rejects a resolved site font stack containing %s', ( _case, siteFontFamily ) => {
+		injectBrandTokens( { fontFamily: 'site', siteFontFamily } );
+
+		const css = document.head.querySelector( '#jetpack-reader-chat-brand' ).textContent;
+		expect( css ).toContain( 'font-family: inherit !important;' );
+		expect( css ).not.toContain( siteFontFamily );
 	} );
 
 	it( 'ignores malformed and unsupported appearance values', () => {

--- a/apps/agents-manager/__tests__/reader-chat.test.js
+++ b/apps/agents-manager/__tests__/reader-chat.test.js
@@ -99,7 +99,7 @@ describe( 'injectScopedReset', () => {
 
 		const css = document.head.querySelector( '#jetpack-reader-chat-reset' ).textContent;
 
-		expect( css ).toContain( 'font-size: 16px !important;' );
+		expect( css ).toContain( 'font-size: var( --base-font-size, 16px ) !important;' );
 		expect( css ).toContain( '--base-font-size: 16px !important;' );
 		expect( css ).toContain(
 			'.agents-manager-chat .components-button.has-icon:not(.components-dropdown-menu__menu-item)'
@@ -329,7 +329,7 @@ describe( 'injectBrandTokens', () => {
 		getElementByIdSpy.mockReturnValue( null );
 	} );
 
-	it( 'emits nothing when the site has no accent', () => {
+	it( 'emits nothing when the site has no appearance overrides', () => {
 		injectBrandTokens( {} );
 		expect( document.head.querySelector( '#jetpack-reader-chat-brand' ) ).toBeNull();
 	} );
@@ -345,6 +345,46 @@ describe( 'injectBrandTokens', () => {
 		const css = document.head.querySelector( '#jetpack-reader-chat-brand' ).textContent;
 		expect( css ).toContain( '--color-primary: #2271b1;' );
 		expect( css ).toContain( '--color-primary-foreground: #ffffff;' );
+	} );
+
+	it( 'sets background, text, outline, font, and text-size tokens from the brand', () => {
+		injectBrandTokens( {
+			background: '#112233',
+			text: '#f2eff6',
+			outline: '#445566',
+			fontFamily: 'rounded',
+			fontSize: 15,
+		} );
+
+		const css = document.head.querySelector( '#jetpack-reader-chat-brand' ).textContent;
+		expect( css ).toContain( '--color-background: #112233;' );
+		expect( css ).toContain( '--color-popover: #112233;' );
+		expect( css ).toContain( '--color-popover-muted: color-mix(in srgb, #112233 80%, #445566);' );
+		expect( css ).toContain( '--color-foreground: #f2eff6;' );
+		expect( css ).toContain( '--color-muted: #445566;' );
+		expect( css ).toContain( '--base-font-size: 15px !important;' );
+		expect( css ).toContain( 'font-family: ui-rounded' );
+	} );
+
+	it( 'ignores malformed and unsupported appearance values', () => {
+		injectBrandTokens( {
+			background: 'url(javascript:alert(1))',
+			text: '#abcd',
+			outline: false,
+			fontFamily: 'toString',
+			fontSize: 100,
+		} );
+
+		expect( document.head.querySelector( '#jetpack-reader-chat-brand' ) ).toBeNull();
+	} );
+
+	it( 'uses a literal background fallback for text-only muted colors', () => {
+		injectBrandTokens( { text: '#f2eff6' } );
+
+		const css = document.head.querySelector( '#jetpack-reader-chat-brand' ).textContent;
+		expect( css ).toContain(
+			'--color-muted-foreground: color-mix(in srgb, #f2eff6 62%, var(--color-background, #fcfcfc));'
+		);
 	} );
 
 	it( 'overrides the default token defined directly on the Agenttic widget', () => {
@@ -374,7 +414,8 @@ describe( 'injectBrandTokens', () => {
 		expect( css ).toContain( '.agents-manager-chat' );
 		expect( css ).toContain( '.agents-manager-chat .agenttic' );
 		expect( css ).toContain( '.agents-manager-sidebar-fab' );
-		expect( css ).toContain( '.components-popover' );
+		expect( css ).toContain( '.agents-manager-chat-header__menu-popover' );
+		expect( css ).not.toContain( '.components-popover {' );
 	} );
 
 	it( 'never defines the tokens globally, which would restyle the host theme', () => {

--- a/apps/agents-manager/__tests__/reader-chat.test.js
+++ b/apps/agents-manager/__tests__/reader-chat.test.js
@@ -103,6 +103,12 @@ describe( 'injectScopedReset', () => {
 		expect( css ).toContain( 'font-size: var( --base-font-size, 16px ) !important;' );
 		expect( css ).toContain( '--base-font-size: 16px !important;' );
 		expect( css ).toContain( 'font-family: var( --reader-chat-font-family,' );
+		expect( css ).toContain( '.agents-manager-chat [data-slot="message"][data-role="user"]' );
+		expect( css ).toContain(
+			'--color-foreground: var( --reader-chat-user-message-foreground, #1f1f1f );'
+		);
+		expect( css ).toContain( '.agents-manager-chat [data-slot="message"][data-role="user"] a' );
+		expect( css ).toContain( 'text-decoration: underline !important;' );
 		expect( css ).toContain(
 			'.agents-manager-chat .components-button.has-icon:not(.components-dropdown-menu__menu-item)'
 		);
@@ -362,7 +368,7 @@ describe( 'injectBrandTokens', () => {
 		injectBrandTokens( {
 			background: '#112233',
 			outline: '#f2eff6',
-			fontFamily: 'rounded',
+			fontFamily: 'serif',
 		} );
 
 		const css = document.head.querySelector( '#jetpack-reader-chat-brand' ).textContent;
@@ -372,7 +378,8 @@ describe( 'injectBrandTokens', () => {
 		expect( css ).toContain( '--color-foreground: #ffffff;' );
 		expect( css ).toContain( '--color-muted-foreground: #d6d6d6;' );
 		expect( css ).toContain( '--color-muted: #f2eff6;' );
-		expect( css ).toContain( '--reader-chat-font-family: ui-rounded' );
+		expect( css ).toContain( '--reader-chat-user-message-foreground: #1f1f1f;' );
+		expect( css ).toContain( '--reader-chat-font-family: Georgia' );
 		expect( css ).toContain( '--reader-chat-menu-background: #112233;' );
 		expect( css ).toContain( '--reader-chat-menu-foreground: #ffffff;' );
 		expect( css ).toContain(
@@ -407,6 +414,12 @@ describe( 'injectBrandTokens', () => {
 		expect( document.head.querySelector( '#jetpack-reader-chat-brand' ) ).toBeNull();
 	} );
 
+	it( 'ignores the removed rounded font value', () => {
+		injectBrandTokens( { fontFamily: 'rounded' } );
+
+		expect( document.head.querySelector( '#jetpack-reader-chat-brand' ) ).toBeNull();
+	} );
+
 	it( 'keeps the selected outline separate from automatic text contrast', () => {
 		injectBrandTokens( { background: '#ffffff', outline: '#f2eff6' } );
 
@@ -414,6 +427,21 @@ describe( 'injectBrandTokens', () => {
 		expect( css ).toContain( '--color-muted: #f2eff6;' );
 		expect( css ).toContain( '--color-foreground: #000000;' );
 		expect( css ).toContain( '--color-muted-foreground: #595959;' );
+	} );
+
+	it( 'uses light text on a dark outgoing message bubble', () => {
+		injectBrandTokens( { background: '#ffffff', outline: '#222222' } );
+
+		const css = document.head.querySelector( '#jetpack-reader-chat-brand' ).textContent;
+		expect( css ).toContain( '--reader-chat-user-message-foreground: #ffffff;' );
+	} );
+
+	it( 'keeps the default light outgoing bubble readable with a dark panel', () => {
+		injectBrandTokens( { background: '#112233' } );
+
+		const css = document.head.querySelector( '#jetpack-reader-chat-brand' ).textContent;
+		expect( css ).not.toContain( '--color-muted:' );
+		expect( css ).toContain( '--reader-chat-user-message-foreground: #1f1f1f;' );
 	} );
 
 	it( 'overrides the default token defined directly on the Agenttic widget', () => {

--- a/apps/agents-manager/__tests__/reader-chat.test.js
+++ b/apps/agents-manager/__tests__/reader-chat.test.js
@@ -324,6 +324,8 @@ describe( 'injectBrandTokens', () => {
 	} );
 
 	afterEach( () => {
+		document.head.querySelector( '#agenttic-test-defaults' )?.remove();
+		document.body.querySelector( '.agents-manager-chat' )?.remove();
 		getElementByIdSpy.mockReturnValue( null );
 	} );
 
@@ -345,11 +347,32 @@ describe( 'injectBrandTokens', () => {
 		expect( css ).toContain( '--color-primary-foreground: #ffffff;' );
 	} );
 
+	it( 'overrides the default token defined directly on the Agenttic widget', () => {
+		const defaults = document.createElement( 'style' );
+		defaults.id = 'agenttic-test-defaults';
+		defaults.textContent = '.agenttic { --color-primary: #2d5af2; }';
+		document.head.appendChild( defaults );
+
+		const portal = document.createElement( 'div' );
+		portal.className = 'agents-manager-chat';
+		portal.innerHTML = '<div class="agenttic"></div>';
+		document.body.appendChild( portal );
+
+		injectBrandTokens( { accent: '#2271b1', accentForeground: '#ffffff' } );
+
+		expect(
+			window
+				.getComputedStyle( portal.querySelector( '.agenttic' ) )
+				.getPropertyValue( '--color-primary' )
+		).toBe( '#2271b1' );
+	} );
+
 	it( 'targets the portalled selectors, since the panel mounts on body', () => {
 		injectBrandTokens( { accent: '#2271b1', accentForeground: '#ffffff' } );
 
 		const css = document.head.querySelector( '#jetpack-reader-chat-brand' ).textContent;
 		expect( css ).toContain( '.agents-manager-chat' );
+		expect( css ).toContain( '.agents-manager-chat .agenttic' );
 		expect( css ).toContain( '.agents-manager-sidebar-fab' );
 		expect( css ).toContain( '.components-popover' );
 	} );

--- a/apps/agents-manager/__tests__/reader-chat.test.js
+++ b/apps/agents-manager/__tests__/reader-chat.test.js
@@ -71,6 +71,7 @@ const {
 	normalizeReaderSiteId,
 	decodeHtmlEntities,
 	getReaderEmptyViewHeading,
+	getAccessibleColor,
 	getReaderClientContext,
 	normalizeSuggestions,
 	parseSuggestionsResponse,
@@ -101,6 +102,7 @@ describe( 'injectScopedReset', () => {
 
 		expect( css ).toContain( 'font-size: var( --base-font-size, 16px ) !important;' );
 		expect( css ).toContain( '--base-font-size: 16px !important;' );
+		expect( css ).toContain( 'font-family: var( --reader-chat-font-family,' );
 		expect( css ).toContain(
 			'.agents-manager-chat .components-button.has-icon:not(.components-dropdown-menu__menu-item)'
 		);
@@ -116,7 +118,7 @@ describe( 'injectScopedReset', () => {
 		expect( css ).toContain( 'background: transparent !important;' );
 		expect( css ).toContain( 'color: var( --color-foreground, #1e1e1e ) !important;' );
 		expect( css ).toContain(
-			'background: var( --color-muted, rgba( 0, 0, 0, 0.06 ) ) !important;'
+			'background: var( --reader-chat-control-hover, var( --color-muted, rgba( 0, 0, 0, 0.06 ) ) ) !important;'
 		);
 		expect( css ).toContain( ':not([aria-disabled="true"])' );
 		expect( css ).toContain( '.agents-manager-chat-header__menu-popover' );
@@ -129,6 +131,15 @@ describe( 'injectScopedReset', () => {
 		);
 		expect( css ).toContain( 'cursor: default !important;' );
 		expect( css ).toContain( 'opacity: 0.5 !important;' );
+		expect( css ).toContain(
+			'.agents-manager-chat-header__menu-popover .components-popover__content'
+		);
+		expect( css ).toContain(
+			'.agents-manager-chat-header__menu-popover .components-dropdown-menu__menu-item:focus-visible'
+		);
+		expect( css ).toContain( 'outline: 2px solid var( --reader-chat-menu-focus ) !important;' );
+		expect( css ).not.toMatch( /^\s*\.components-popover\s*\{/m );
+		expect( css ).not.toMatch( /--reader-chat-font-family\s*:/ );
 	} );
 
 	it( 'does not inject duplicate reset styles', () => {
@@ -347,29 +358,41 @@ describe( 'injectBrandTokens', () => {
 		expect( css ).toContain( '--color-primary-foreground: #ffffff;' );
 	} );
 
-	it( 'sets background, text, outline, font, and text-size tokens from the brand', () => {
+	it( 'sets background, accessible text, outline, and font tokens from the brand', () => {
 		injectBrandTokens( {
 			background: '#112233',
-			text: '#f2eff6',
-			outline: '#445566',
+			outline: '#f2eff6',
 			fontFamily: 'rounded',
-			fontSize: 15,
 		} );
 
 		const css = document.head.querySelector( '#jetpack-reader-chat-brand' ).textContent;
 		expect( css ).toContain( '--color-background: #112233;' );
 		expect( css ).toContain( '--color-popover: #112233;' );
-		expect( css ).toContain( '--color-popover-muted: color-mix(in srgb, #112233 80%, #445566);' );
-		expect( css ).toContain( '--color-foreground: #f2eff6;' );
-		expect( css ).toContain( '--color-muted: #445566;' );
-		expect( css ).toContain( '--base-font-size: 15px !important;' );
-		expect( css ).toContain( 'font-family: ui-rounded' );
+		expect( css ).toContain( '--color-popover-muted: color-mix(in srgb, #112233 80%, #f2eff6);' );
+		expect( css ).toContain( '--color-foreground: #ffffff;' );
+		expect( css ).toContain( '--color-muted-foreground: #d6d6d6;' );
+		expect( css ).toContain( '--color-muted: #f2eff6;' );
+		expect( css ).toContain( '--reader-chat-font-family: ui-rounded' );
+		expect( css ).toContain( '--reader-chat-menu-background: #112233;' );
+		expect( css ).toContain( '--reader-chat-menu-foreground: #ffffff;' );
+		expect( css ).toContain(
+			'--reader-chat-control-hover: color-mix( in srgb, #ffffff 14%, #112233 );'
+		);
+	} );
+
+	it( 'inherits the host theme font when the site font is selected', () => {
+		injectBrandTokens( { fontFamily: 'site' } );
+
+		const css = document.head.querySelector( '#jetpack-reader-chat-brand' ).textContent;
+		expect( css ).toContain( '#jetpack-reader-chat *' );
+		expect( css ).toContain( '.agents-manager-chat *' );
+		expect( css ).toContain( 'font-family: inherit !important;' );
+		expect( css ).not.toContain( '--reader-chat-font-family: inherit;' );
 	} );
 
 	it( 'ignores malformed and unsupported appearance values', () => {
 		injectBrandTokens( {
 			background: 'url(javascript:alert(1))',
-			text: '#abcd',
 			outline: false,
 			fontFamily: 'toString',
 			fontSize: 100,
@@ -378,13 +401,19 @@ describe( 'injectBrandTokens', () => {
 		expect( document.head.querySelector( '#jetpack-reader-chat-brand' ) ).toBeNull();
 	} );
 
-	it( 'uses a literal background fallback for text-only muted colors', () => {
-		injectBrandTokens( { text: '#f2eff6' } );
+	it( 'ignores removed text color and font size values', () => {
+		injectBrandTokens( { text: '#ff0000', fontSize: 15 } );
+
+		expect( document.head.querySelector( '#jetpack-reader-chat-brand' ) ).toBeNull();
+	} );
+
+	it( 'keeps the selected outline separate from automatic text contrast', () => {
+		injectBrandTokens( { background: '#ffffff', outline: '#f2eff6' } );
 
 		const css = document.head.querySelector( '#jetpack-reader-chat-brand' ).textContent;
-		expect( css ).toContain(
-			'--color-muted-foreground: color-mix(in srgb, #f2eff6 62%, var(--color-background, #fcfcfc));'
-		);
+		expect( css ).toContain( '--color-muted: #f2eff6;' );
+		expect( css ).toContain( '--color-foreground: #000000;' );
+		expect( css ).toContain( '--color-muted-foreground: #595959;' );
 	} );
 
 	it( 'overrides the default token defined directly on the Agenttic widget', () => {
@@ -441,6 +470,28 @@ describe( 'injectBrandTokens', () => {
 		expect( document.head.querySelector( '#jetpack-reader-chat-brand' ).textContent ).toContain(
 			'#2271b1'
 		);
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// getAccessibleColor
+// ---------------------------------------------------------------------------
+
+describe( 'getAccessibleColor', () => {
+	it( 'chooses dark text for a light background', () => {
+		expect( getAccessibleColor( '#ffffff' ) ).toBe( '#000000' );
+	} );
+
+	it( 'chooses light text for a dark background', () => {
+		expect( getAccessibleColor( '#700f1b' ) ).toBe( '#ffffff' );
+	} );
+
+	it( 'keeps a preferred color when it meets the requested contrast', () => {
+		expect( getAccessibleColor( '#ffffff', '#3858e9', 3 ) ).toBe( '#3858e9' );
+	} );
+
+	it( 'replaces a preferred color that does not meet contrast', () => {
+		expect( getAccessibleColor( '#700f1b', '#8a101e', 3 ) ).toBe( '#ffffff' );
 	} );
 } );
 

--- a/apps/agents-manager/reader-chat.js
+++ b/apps/agents-manager/reader-chat.js
@@ -285,6 +285,23 @@ function normalizeHexColor( value ) {
 }
 
 /**
+ * Normalize a server-resolved theme font stack before writing it to CSS.
+ * Keep this aligned with Jetpack's get_site_font_family() and settings preview.
+ * @param {string} value Candidate font-family value.
+ * @returns {string} A safe font-family value, or an empty string.
+ */
+function normalizeFontFamily( value ) {
+	return typeof value === 'string' &&
+		value.trim() &&
+		value.trim().length <= 200 &&
+		! value.includes( '/' ) &&
+		! value.includes( '\\' ) &&
+		! /[;{}()\r\n\f]/.test( value )
+		? value.trim()
+		: '';
+}
+
+/**
  * Return a color that meets the requested contrast against a background.
  * Black and white are the final candidates because one of them always reaches
  * at least 4.5:1 against an opaque color.
@@ -355,9 +372,13 @@ function injectBrandTokens( brand ) {
 		serif: 'Georgia, Cambria, "Times New Roman", Times, serif',
 	};
 	const usesSiteFont = brand?.fontFamily === 'site';
-	const fontFamily = Object.prototype.hasOwnProperty.call( fontFamilies, brand?.fontFamily )
-		? fontFamilies[ brand.fontFamily ]
-		: '';
+	const siteFontFamily = normalizeFontFamily( brand?.siteFontFamily );
+	let fontFamily = '';
+	if ( usesSiteFont ) {
+		fontFamily = siteFontFamily;
+	} else if ( Object.prototype.hasOwnProperty.call( fontFamilies, brand?.fontFamily ) ) {
+		fontFamily = fontFamilies[ brand.fontFamily ];
+	}
 	const foreground = background ? getAccessibleColor( background ) : '';
 	const mutedForeground = background
 		? getAccessibleColor( background, foreground === '#000000' ? '#595959' : '#d6d6d6' )
@@ -422,7 +443,9 @@ function injectBrandTokens( brand ) {
 		.agents-manager-chat *,
 		.agents-manager-chat-header__menu-popover,
 		.agents-manager-chat-header__menu-popover * {
-			font-family: inherit !important;
+			font-family: ${
+				siteFontFamily ? 'var( --reader-chat-font-family, inherit )' : 'inherit'
+			} !important;
 		}`
 		: '';
 	const style = document.createElement( 'style' );
@@ -440,8 +463,7 @@ function injectBrandTokens( brand ) {
 			--reader-chat-control-hover: color-mix( in srgb, ${ menuForeground } 14%, ${ menuBackground } );
 		}
 		.agents-manager-brand-logo {
-			border-radius: 50%;
-			object-fit: cover;
+			object-fit: contain;
 		}
 	`;
 	document.head.appendChild( style );

--- a/apps/agents-manager/reader-chat.js
+++ b/apps/agents-manager/reader-chat.js
@@ -279,11 +279,12 @@ function injectScopedReset() {
  * Two things make this trickier than it looks:
  *
  * 1. The chat panel is portalled to `body`, so a rule scoped to the
- *    `#jetpack-reader-chat` mount node never reaches it. We target the same
- *    selectors `injectScopedReset` already relies on.
- * 2. The variables are NOT set on `:root`. `--color-primary` is a common
- *    custom property name, and defining it globally would silently restyle
- *    the host blog's own theme.
+ *    `#jetpack-reader-chat` mount node never reaches it. We target the
+ *    portalled chat, launcher, and popover surfaces directly.
+ * 2. Agenttic defines its default tokens directly on `.agenttic`, so the
+ *    branded values must also be set on that element rather than inherited
+ *    from the portal wrapper. The variables are NOT set on `:root` because
+ *    that would silently restyle the host blog's own theme.
  *
  * Emits nothing when the site has no accent — agenttic's default stands.
  * @param {Object} brand The brand object from JetpackReaderChatConfig.
@@ -302,6 +303,7 @@ function injectBrandTokens( brand ) {
 	style.id = 'jetpack-reader-chat-brand';
 	style.textContent = `
 		.agents-manager-chat,
+		.agents-manager-chat .agenttic,
 		.agents-manager-sidebar-fab,
 		.components-popover {
 			--color-primary: ${ accent };

--- a/apps/agents-manager/reader-chat.js
+++ b/apps/agents-manager/reader-chat.js
@@ -273,8 +273,51 @@ function injectScopedReset() {
 	document.head.appendChild( style );
 }
 
+/**
+ * Apply the Site Chat brand accent as agenttic-ui design tokens.
+ *
+ * Two things make this trickier than it looks:
+ *
+ * 1. The chat panel is portalled to `body`, so a rule scoped to the
+ *    `#jetpack-reader-chat` mount node never reaches it. We target the same
+ *    selectors `injectScopedReset` already relies on.
+ * 2. The variables are NOT set on `:root`. `--color-primary` is a common
+ *    custom property name, and defining it globally would silently restyle
+ *    the host blog's own theme.
+ *
+ * Emits nothing when the site has no accent — agenttic's default stands.
+ * @param {Object} brand The brand object from JetpackReaderChatConfig.
+ */
+function injectBrandTokens( brand ) {
+	const accent = brand?.accent;
+	if ( ! accent || document.getElementById( 'jetpack-reader-chat-brand' ) ) {
+		return;
+	}
+
+	// Jetpack precomputes the accessible foreground; fall back to white only
+	// if an older PHP deploy sent an accent without one.
+	const accentForeground = brand?.accentForeground || '#ffffff';
+
+	const style = document.createElement( 'style' );
+	style.id = 'jetpack-reader-chat-brand';
+	style.textContent = `
+		.agents-manager-chat,
+		.agents-manager-sidebar-fab,
+		.components-popover {
+			--color-primary: ${ accent };
+			--color-primary-foreground: ${ accentForeground };
+		}
+		.agents-manager-brand-logo {
+			border-radius: 50%;
+			object-fit: cover;
+		}
+	`;
+	document.head.appendChild( style );
+}
+
 // Read config injected by PHP.
 const readerConfig = window.JetpackReaderChatConfig || {};
+const readerBrand = readerConfig.brand || {};
 const readerAgentId = readerConfig.agentId || 'reader-chat';
 const readerSiteId = normalizeReaderSiteId( readerConfig.siteId );
 const readerCurrentPost = getReaderCurrentPost( readerConfig );
@@ -291,6 +334,12 @@ window.agentsManagerData.emptyViewHeading = getReaderEmptyViewHeading( readerCon
 window.agentsManagerData.currentPost = readerCurrentPost;
 window.agentsManagerData.siteName = readerConfig.siteName || '';
 window.agentsManagerData.siteUrl = readerConfig.siteUrl || '';
+
+// Site Chat brand kit. Jetpack omits keys that resolve to nothing, and an
+// older cached copy of this bundle may run against PHP that sends no brand at
+// all — so both sides degrade to the unbranded look rather than throwing.
+window.agentsManagerData.brandName = readerBrand.name || '';
+window.agentsManagerData.brandLogoUrl = readerBrand.logoUrl || '';
 
 /**
  * Build fallback suggested prompts based on the current page context.
@@ -392,6 +441,12 @@ function getReaderCurrentPost( config ) {
 }
 
 function getReaderEmptyViewHeading( config ) {
+	// An owner-set greeting wins; otherwise stay contextual to the page.
+	const greeting = config?.brand?.greeting;
+	if ( greeting ) {
+		return greeting;
+	}
+
 	return getReaderCurrentPost( config )
 		? 'Ask me anything about this post.'
 		: 'Ask me anything about this blog.';
@@ -1109,6 +1164,7 @@ function ReaderChatApp() {
 const container = document.getElementById( 'jetpack-reader-chat' );
 if ( container ) {
 	injectScopedReset();
+	injectBrandTokens( readerBrand );
 	setupFollowupChips();
 	setupTracksEvents();
 	setupCollapsedLauncherPointerFallback();
@@ -1150,6 +1206,7 @@ export {
 	normalizeReaderSiteId,
 	decodeHtmlEntities,
 	getReaderEmptyViewHeading,
+	injectBrandTokens,
 	getReaderClientContext,
 	normalizeSuggestions,
 	parseSuggestionsResponse,

--- a/apps/agents-manager/reader-chat.js
+++ b/apps/agents-manager/reader-chat.js
@@ -60,9 +60,9 @@ function injectScopedReset() {
 		#jetpack-reader-chat *,
 		.agents-manager-chat,
 		.agents-manager-chat *,
-		.components-popover,
-		.components-popover * {
-			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif !important;
+		.agents-manager-chat-header__menu-popover,
+		.agents-manager-chat-header__menu-popover * {
+			font-family: var( --reader-chat-font-family, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif ) !important;
 		}
 		/*
 		 * Form controls don't inherit font-family by default — browsers
@@ -152,15 +152,25 @@ function injectScopedReset() {
 		.agents-manager-chat .agents-manager-chat-header .components-button.has-icon:not(.components-dropdown-menu__menu-item):hover:not(:disabled):not([aria-disabled="true"]),
 		.agents-manager-chat .agents-manager-copy-action-button.components-button.has-icon:hover:not(:disabled):not([aria-disabled="true"]),
 		.agents-manager-chat .agents-manager-zoom-action-button.components-button.has-icon:hover:not(:disabled):not([aria-disabled="true"]) {
-			background: var( --color-muted, rgba( 0, 0, 0, 0.06 ) ) !important;
+			background: var( --reader-chat-control-hover, var( --color-muted, rgba( 0, 0, 0, 0.06 ) ) ) !important;
 		}
 		.agents-manager-chat-header__menu-popover {
-			--color-foreground: #1e1e1e;
-			--color-muted: rgba( 0, 0, 0, 0.06 );
-			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif !important;
+			--reader-chat-menu-background: #ffffff;
+			--reader-chat-menu-foreground: #1e1e1e;
+			--reader-chat-menu-focus: #3858e9;
+			--reader-chat-menu-hover: #f0f0f0;
 			font-size: 13px !important;
 			line-height: 1.4 !important;
-			color: var( --color-foreground, #1e1e1e ) !important;
+			color: var( --reader-chat-menu-foreground ) !important;
+			z-index: 2147483647 !important;
+		}
+		.agents-manager-chat-header__menu-popover .components-popover__content {
+			box-sizing: border-box !important;
+			padding: 4px !important;
+			background: var( --reader-chat-menu-background ) !important;
+			border: 1px solid color-mix( in srgb, var( --reader-chat-menu-foreground ) 24%, var( --reader-chat-menu-background ) ) !important;
+			border-radius: 6px !important;
+			box-shadow: 0 4px 14px rgba( 0, 0, 0, 0.18 ) !important;
 		}
 		.agents-manager-chat-header__menu-popover .components-button,
 		.agents-manager-chat-header__menu-popover .components-dropdown-menu__menu-item {
@@ -169,7 +179,7 @@ function injectScopedReset() {
 			background: transparent !important;
 			border: 0 !important;
 			box-shadow: none !important;
-			color: var( --color-foreground, #1e1e1e ) !important;
+			color: var( --reader-chat-menu-foreground ) !important;
 			font-family: inherit !important;
 			font-size: inherit !important;
 			font-weight: 400 !important;
@@ -197,60 +207,34 @@ function injectScopedReset() {
 			max-width: none !important;
 		}
 		.agents-manager-chat-header__menu-popover .components-dropdown-menu__menu-item:hover:not(:disabled):not([aria-disabled="true"]) {
-			background: var( --color-muted, rgba( 0, 0, 0, 0.06 ) ) !important;
+			background: var( --reader-chat-menu-hover ) !important;
+		}
+		.agents-manager-chat-header__menu-popover .components-dropdown-menu__menu-item:active:not(:disabled):not([aria-disabled="true"]) {
+			background: color-mix( in srgb, var( --reader-chat-menu-foreground ) 20%, var( --reader-chat-menu-background ) ) !important;
+		}
+		.agents-manager-chat-header__menu-popover .components-dropdown-menu__menu-item:focus-visible {
+			outline: 2px solid var( --reader-chat-menu-focus ) !important;
+			outline-offset: -2px !important;
 		}
 		.agents-manager-chat-header__menu-popover .components-dropdown-menu__menu-item[aria-disabled="true"],
 		.agents-manager-chat-header__menu-popover .components-dropdown-menu__menu-item:disabled {
 			background: transparent !important;
-			color: var( --color-foreground, #1e1e1e ) !important;
+			color: var( --reader-chat-menu-foreground ) !important;
 			cursor: default !important;
 			opacity: 0.5 !important;
 		}
 		.agents-manager-chat-header__menu-popover .components-dropdown-menu__menu-item svg {
 			fill: currentColor !important;
 		}
-		/*
-		 * wp-components dropdown/menu fix: the popover is portalled to body
-		 * and the theme's global CSS doesn't always include the full
-		 * components-dropdown-menu rules. Items default to display: inline-block
-		 * via .components-button and end up flowing horizontally. Force them
-		 * block and give the menu a usable layout.
-		 */
-		/*
-		 * Popover itself has z-index: auto by default — sits behind the
-		 * chat container's stacking context. Force it above everything
-		 * so the menu is actually visible when opened.
-		 */
-		.components-popover {
-			z-index: 2147483647 !important;
-		}
-		.components-dropdown-menu__menu {
+		.agents-manager-chat-header__menu-popover .components-dropdown-menu__menu {
 			display: flex !important;
 			flex-direction: column !important;
 			min-width: 200px !important;
-			padding: 4px !important;
-			background: var( --color-background, #ffffff ) !important;
-			border: 1px solid var( --color-muted, #dddddd ) !important;
-			border-radius: 4px !important;
-			box-shadow: 0 2px 10px rgba(0,0,0,0.1) !important;
-		}
-		.components-dropdown-menu__menu-item {
-			display: flex !important;
-			align-items: center !important;
-			gap: 8px !important;
-			width: 100% !important;
-			padding: 8px 12px !important;
+			padding: 0 !important;
 			background: transparent !important;
 			border: 0 !important;
-			text-align: left !important;
-			cursor: pointer !important;
-		}
-		.components-dropdown-menu__menu-item:hover {
-			background: color-mix( in srgb, var( --color-background, #ffffff ) 50%, var( --color-muted, #f0f0f0 ) ) !important;
-		}
-		.components-dropdown-menu__menu-item[aria-disabled="true"] {
-			opacity: 0.5 !important;
-			cursor: default !important;
+			border-radius: 4px !important;
+			box-shadow: none !important;
 		}
 		/*
 		 * Move reader-chat launcher and panel to the bottom-left.
@@ -274,21 +258,73 @@ function injectScopedReset() {
 }
 
 /**
+ * Normalize a color before it is written into the public-page style element.
+ * @param {string} value Candidate hex color.
+ * @returns {string} A normalized hex color, or an empty string.
+ */
+function normalizeHexColor( value ) {
+	return typeof value === 'string' && /^#[0-9a-f]{3}([0-9a-f]{3})?$/i.test( value )
+		? value.toLowerCase()
+		: '';
+}
+
+/**
+ * Return a color that meets the requested contrast against a background.
+ * Black and white are the final candidates because one of them always reaches
+ * at least 4.5:1 against an opaque color.
+ * @param {string} background      Background hex color.
+ * @param {string} preferred       Preferred foreground hex color.
+ * @param {number} minimumContrast Required contrast ratio.
+ * @returns {string} Accessible foreground color.
+ */
+function getAccessibleColor( background, preferred = '', minimumContrast = 4.5 ) {
+	const normalizedBackground = normalizeHexColor( background );
+	const normalizedPreferred = normalizeHexColor( preferred );
+	if ( ! normalizedBackground ) {
+		return normalizedPreferred;
+	}
+
+	const expandHex = ( color ) =>
+		color.length === 4
+			? `#${ color[ 1 ] }${ color[ 1 ] }${ color[ 2 ] }${ color[ 2 ] }${ color[ 3 ] }${ color[ 3 ] }`
+			: color;
+	const luminance = ( color ) => {
+		const expanded = expandHex( color );
+		const channels = [ 1, 3, 5 ].map( ( offset ) => {
+			const channel = Number.parseInt( expanded.slice( offset, offset + 2 ), 16 ) / 255;
+			return channel <= 0.04045 ? channel / 12.92 : ( ( channel + 0.055 ) / 1.055 ) ** 2.4;
+		} );
+		return 0.2126 * channels[ 0 ] + 0.7152 * channels[ 1 ] + 0.0722 * channels[ 2 ];
+	};
+	const contrast = ( first, second ) => {
+		const firstLuminance = luminance( first );
+		const secondLuminance = luminance( second );
+		return (
+			( Math.max( firstLuminance, secondLuminance ) + 0.05 ) /
+			( Math.min( firstLuminance, secondLuminance ) + 0.05 )
+		);
+	};
+
+	if (
+		normalizedPreferred &&
+		contrast( normalizedBackground, normalizedPreferred ) >= minimumContrast
+	) {
+		return normalizedPreferred;
+	}
+
+	return contrast( normalizedBackground, '#000000' ) >= contrast( normalizedBackground, '#ffffff' )
+		? '#000000'
+		: '#ffffff';
+}
+
+/**
  * Apply Site Chat appearance settings as agenttic-ui design tokens.
  *
- * Two things make this trickier than it looks:
- *
- * 1. The chat panel is portalled to `body`, so a rule scoped to the
- *    `#jetpack-reader-chat` mount node never reaches it. We target the
- *    portalled chat, launcher, and popover surfaces directly.
- * 2. Agenttic defines its default tokens directly on `.agenttic`, so the
- *    branded values must also be set on that element rather than inherited
- *    from the portal wrapper. The variables are NOT set on `:root` because
- *    that would silently restyle the host blog's own theme.
- *
- * Emits nothing when the site has no appearance overrides — agenttic's
- * defaults stand. Every value is allowlisted before interpolation because
- * this function writes a style element on a public page.
+ * The chat panel is portalled to `body`, and Agenttic defines its defaults on
+ * `.agenttic`, so the allowlisted values target both elements directly. Text
+ * is derived from the background instead of owner-selected, keeping normal
+ * text at 4.5:1 contrast or better. The variables are deliberately not set on
+ * `:root`, where they would also restyle the host blog theme.
  * @param {Object} brand The brand object from JetpackReaderChatConfig.
  */
 function injectBrandTokens( brand ) {
@@ -296,34 +332,31 @@ function injectBrandTokens( brand ) {
 		return;
 	}
 
-	const hexColor = ( value ) =>
-		typeof value === 'string' && /^#[0-9a-f]{3}([0-9a-f]{3})?$/i.test( value ) ? value : '';
-	const accent = hexColor( brand?.accent );
-	const background = hexColor( brand?.background );
-	const text = hexColor( brand?.text );
-	const outline = hexColor( brand?.outline );
+	const accent = normalizeHexColor( brand?.accent );
+	const background = normalizeHexColor( brand?.background );
+	const outline = normalizeHexColor( brand?.outline );
 	const fontFamilies = {
-		site: 'inherit',
 		rounded:
 			'ui-rounded, "SF Pro Rounded", "Nunito Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
 		serif: 'Georgia, Cambria, "Times New Roman", Times, serif',
 	};
+	const usesSiteFont = brand?.fontFamily === 'site';
 	const fontFamily = Object.prototype.hasOwnProperty.call( fontFamilies, brand?.fontFamily )
 		? fontFamilies[ brand.fontFamily ]
 		: '';
-	const requestedFontSize = Number( brand?.fontSize );
-	const fontSize =
-		Number.isInteger( requestedFontSize ) && requestedFontSize >= 13 && requestedFontSize <= 18
-			? requestedFontSize
-			: 0;
+	const foreground = background ? getAccessibleColor( background ) : '';
+	const mutedForeground = background
+		? getAccessibleColor( background, foreground === '#000000' ? '#595959' : '#d6d6d6' )
+		: '';
+	const menuBackground = background || '#ffffff';
+	const menuForeground = getAccessibleColor( menuBackground, '#1e1e1e' );
+	const menuFocus = getAccessibleColor( menuBackground, accent || '#3858e9', 3 );
 	const declarations = [];
 
 	if ( accent ) {
-		// Jetpack precomputes the accessible foreground; fall back to white only
-		// if an older PHP deploy sent an accent without one.
 		declarations.push( `--color-primary: ${ accent }` );
 		declarations.push(
-			`--color-primary-foreground: ${ hexColor( brand?.accentForeground ) || '#ffffff' }`
+			`--color-primary-foreground: ${ normalizeHexColor( brand?.accentForeground ) || '#ffffff' }`
 		);
 	}
 	if ( background ) {
@@ -334,49 +367,56 @@ function injectBrandTokens( brand ) {
 				outline || 'var(--color-muted, #e9e9e9)'
 			})`
 		);
-	}
-	if ( text ) {
-		declarations.push( `--color-foreground: ${ text }` );
-		declarations.push(
-			`--color-muted-foreground: color-mix(in srgb, ${ text } 62%, ${
-				background || 'var(--color-background, #fcfcfc)'
-			})`
-		);
+		declarations.push( `--color-foreground: ${ foreground }` );
+		declarations.push( `--color-muted-foreground: ${ mutedForeground }` );
 	}
 	if ( outline ) {
 		declarations.push( `--color-muted: ${ outline }` );
 	}
 	if ( fontFamily ) {
 		declarations.push( `--font-sans: ${ fontFamily }` );
-	}
-	if ( fontSize ) {
-		declarations.push( `--base-font-size: ${ fontSize }px !important` );
+		declarations.push( `--reader-chat-font-family: ${ fontFamily }` );
 	}
 
-	if ( declarations.length === 0 ) {
+	if ( declarations.length === 0 && ! usesSiteFont ) {
 		return;
 	}
 
-	const fontRule = fontFamily
+	const tokenRule = declarations.length
 		? `
 		#jetpack-reader-chat,
-		.agents-manager-chat,
-		.agents-manager-chat .agenttic,
-		.agents-manager-chat-header__menu-popover {
-			font-family: ${ fontFamily } !important;
-		}`
-		: '';
-
-	const style = document.createElement( 'style' );
-	style.id = 'jetpack-reader-chat-brand';
-	style.textContent = `
 		.agents-manager-chat,
 		.agents-manager-chat .agenttic,
 		.agents-manager-sidebar-fab,
 		.agents-manager-chat-header__menu-popover {
 			${ declarations.join( ';\n\t\t\t' ) };
+		}`
+		: '';
+	const siteFontRule = usesSiteFont
+		? `
+		#jetpack-reader-chat,
+		#jetpack-reader-chat *,
+		.agents-manager-chat,
+		.agents-manager-chat *,
+		.agents-manager-chat-header__menu-popover,
+		.agents-manager-chat-header__menu-popover * {
+			font-family: inherit !important;
+		}`
+		: '';
+	const style = document.createElement( 'style' );
+	style.id = 'jetpack-reader-chat-brand';
+	style.textContent = `
+		${ tokenRule }
+		${ siteFontRule }
+		.agents-manager-chat-header__menu-popover {
+			--reader-chat-menu-background: ${ menuBackground };
+			--reader-chat-menu-foreground: ${ menuForeground };
+			--reader-chat-menu-focus: ${ menuFocus };
+			--reader-chat-menu-hover: color-mix( in srgb, ${ menuForeground } 14%, ${ menuBackground } );
 		}
-		${ fontRule }
+		.agents-manager-chat {
+			--reader-chat-control-hover: color-mix( in srgb, ${ menuForeground } 14%, ${ menuBackground } );
+		}
 		.agents-manager-brand-logo {
 			border-radius: 50%;
 			object-fit: cover;
@@ -1276,6 +1316,7 @@ export {
 	normalizeReaderSiteId,
 	decodeHtmlEntities,
 	getReaderEmptyViewHeading,
+	getAccessibleColor,
 	injectBrandTokens,
 	getReaderClientContext,
 	normalizeSuggestions,

--- a/apps/agents-manager/reader-chat.js
+++ b/apps/agents-manager/reader-chat.js
@@ -41,6 +41,9 @@ function recordTracksEvent( eventName, props ) {
 }
 
 const queryClient = new QueryClient();
+// Agenttic 0.1.80 uses --color-muted for outgoing-message bubbles and defaults
+// that token to this value in global.css. Keep this fallback aligned on upgrade.
+const AGENTTIC_DEFAULT_MUTED_COLOR = '#e9e9e9';
 
 /**
  * Reset inherited styles from the host theme. Blog themes often set a
@@ -119,6 +122,19 @@ function injectScopedReset() {
 		 */
 		.agents-manager-chat .agenttic {
 			--base-font-size: 16px !important;
+		}
+		/*
+		 * Agenttic uses --color-muted as the outgoing-message bubble fill.
+		 * Site Chat maps the selected outline color to that token, so the
+		 * bubble needs its own foreground rather than the panel foreground.
+		 */
+		.agents-manager-chat [data-slot="message"][data-role="user"] {
+			--color-foreground: var( --reader-chat-user-message-foreground, #1f1f1f );
+			--color-link: var( --reader-chat-user-message-foreground, #1f1f1f );
+		}
+		.agents-manager-chat [data-slot="message"][data-role="user"] a {
+			text-decoration: underline !important;
+			text-underline-offset: 2px !important;
 		}
 		.agents-manager-chat .components-button {
 			-webkit-appearance: none !important;
@@ -336,8 +352,6 @@ function injectBrandTokens( brand ) {
 	const background = normalizeHexColor( brand?.background );
 	const outline = normalizeHexColor( brand?.outline );
 	const fontFamilies = {
-		rounded:
-			'ui-rounded, "SF Pro Rounded", "Nunito Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
 		serif: 'Georgia, Cambria, "Times New Roman", Times, serif',
 	};
 	const usesSiteFont = brand?.fontFamily === 'site';
@@ -351,7 +365,15 @@ function injectBrandTokens( brand ) {
 	const menuBackground = background || '#ffffff';
 	const menuForeground = getAccessibleColor( menuBackground, '#1e1e1e' );
 	const menuFocus = getAccessibleColor( menuBackground, accent || '#3858e9', 3 );
+	const userMessageForeground = getAccessibleColor(
+		outline || AGENTTIC_DEFAULT_MUTED_COLOR,
+		'#1f1f1f'
+	);
 	const declarations = [];
+
+	if ( background || outline ) {
+		declarations.push( `--reader-chat-user-message-foreground: ${ userMessageForeground }` );
+	}
 
 	if ( accent ) {
 		declarations.push( `--color-primary: ${ accent }` );

--- a/apps/agents-manager/reader-chat.js
+++ b/apps/agents-manager/reader-chat.js
@@ -107,9 +107,9 @@ function injectScopedReset() {
 		}
 		#jetpack-reader-chat,
 		.agents-manager-chat {
-			font-size: 16px !important;
+			font-size: var( --base-font-size, 16px ) !important;
 			line-height: 1.5 !important;
-			color: #1e1e1e !important;
+			color: var( --color-foreground, #1e1e1e ) !important;
 		}
 		/*
 		 * The .agenttic widget's sizes are derived from --base-font-size. Some blog
@@ -229,8 +229,8 @@ function injectScopedReset() {
 			flex-direction: column !important;
 			min-width: 200px !important;
 			padding: 4px !important;
-			background: #ffffff !important;
-			border: 1px solid #dddddd !important;
+			background: var( --color-background, #ffffff ) !important;
+			border: 1px solid var( --color-muted, #dddddd ) !important;
 			border-radius: 4px !important;
 			box-shadow: 0 2px 10px rgba(0,0,0,0.1) !important;
 		}
@@ -246,7 +246,7 @@ function injectScopedReset() {
 			cursor: pointer !important;
 		}
 		.components-dropdown-menu__menu-item:hover {
-			background: #f0f0f0 !important;
+			background: color-mix( in srgb, var( --color-background, #ffffff ) 50%, var( --color-muted, #f0f0f0 ) ) !important;
 		}
 		.components-dropdown-menu__menu-item[aria-disabled="true"] {
 			opacity: 0.5 !important;
@@ -266,7 +266,7 @@ function injectScopedReset() {
 			right: auto !important;
 		}
 		.agents-manager-chat--undocked [data-slot="chat-footer"] > [data-slot="suggestions"] button {
-			background: #ffffff !important;
+			background: var( --color-background, #ffffff ) !important;
 		}
 
 	`;
@@ -274,7 +274,7 @@ function injectScopedReset() {
 }
 
 /**
- * Apply the Site Chat brand accent as agenttic-ui design tokens.
+ * Apply Site Chat appearance settings as agenttic-ui design tokens.
  *
  * Two things make this trickier than it looks:
  *
@@ -286,18 +286,86 @@ function injectScopedReset() {
  *    from the portal wrapper. The variables are NOT set on `:root` because
  *    that would silently restyle the host blog's own theme.
  *
- * Emits nothing when the site has no accent — agenttic's default stands.
+ * Emits nothing when the site has no appearance overrides — agenttic's
+ * defaults stand. Every value is allowlisted before interpolation because
+ * this function writes a style element on a public page.
  * @param {Object} brand The brand object from JetpackReaderChatConfig.
  */
 function injectBrandTokens( brand ) {
-	const accent = brand?.accent;
-	if ( ! accent || document.getElementById( 'jetpack-reader-chat-brand' ) ) {
+	if ( document.getElementById( 'jetpack-reader-chat-brand' ) ) {
 		return;
 	}
 
-	// Jetpack precomputes the accessible foreground; fall back to white only
-	// if an older PHP deploy sent an accent without one.
-	const accentForeground = brand?.accentForeground || '#ffffff';
+	const hexColor = ( value ) =>
+		typeof value === 'string' && /^#[0-9a-f]{3}([0-9a-f]{3})?$/i.test( value ) ? value : '';
+	const accent = hexColor( brand?.accent );
+	const background = hexColor( brand?.background );
+	const text = hexColor( brand?.text );
+	const outline = hexColor( brand?.outline );
+	const fontFamilies = {
+		site: 'inherit',
+		rounded:
+			'ui-rounded, "SF Pro Rounded", "Nunito Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+		serif: 'Georgia, Cambria, "Times New Roman", Times, serif',
+	};
+	const fontFamily = Object.prototype.hasOwnProperty.call( fontFamilies, brand?.fontFamily )
+		? fontFamilies[ brand.fontFamily ]
+		: '';
+	const requestedFontSize = Number( brand?.fontSize );
+	const fontSize =
+		Number.isInteger( requestedFontSize ) && requestedFontSize >= 13 && requestedFontSize <= 18
+			? requestedFontSize
+			: 0;
+	const declarations = [];
+
+	if ( accent ) {
+		// Jetpack precomputes the accessible foreground; fall back to white only
+		// if an older PHP deploy sent an accent without one.
+		declarations.push( `--color-primary: ${ accent }` );
+		declarations.push(
+			`--color-primary-foreground: ${ hexColor( brand?.accentForeground ) || '#ffffff' }`
+		);
+	}
+	if ( background ) {
+		declarations.push( `--color-background: ${ background }` );
+		declarations.push( `--color-popover: ${ background }` );
+		declarations.push(
+			`--color-popover-muted: color-mix(in srgb, ${ background } 80%, ${
+				outline || 'var(--color-muted, #e9e9e9)'
+			})`
+		);
+	}
+	if ( text ) {
+		declarations.push( `--color-foreground: ${ text }` );
+		declarations.push(
+			`--color-muted-foreground: color-mix(in srgb, ${ text } 62%, ${
+				background || 'var(--color-background, #fcfcfc)'
+			})`
+		);
+	}
+	if ( outline ) {
+		declarations.push( `--color-muted: ${ outline }` );
+	}
+	if ( fontFamily ) {
+		declarations.push( `--font-sans: ${ fontFamily }` );
+	}
+	if ( fontSize ) {
+		declarations.push( `--base-font-size: ${ fontSize }px !important` );
+	}
+
+	if ( declarations.length === 0 ) {
+		return;
+	}
+
+	const fontRule = fontFamily
+		? `
+		#jetpack-reader-chat,
+		.agents-manager-chat,
+		.agents-manager-chat .agenttic,
+		.agents-manager-chat-header__menu-popover {
+			font-family: ${ fontFamily } !important;
+		}`
+		: '';
 
 	const style = document.createElement( 'style' );
 	style.id = 'jetpack-reader-chat-brand';
@@ -305,10 +373,10 @@ function injectBrandTokens( brand ) {
 		.agents-manager-chat,
 		.agents-manager-chat .agenttic,
 		.agents-manager-sidebar-fab,
-		.components-popover {
-			--color-primary: ${ accent };
-			--color-primary-foreground: ${ accentForeground };
+		.agents-manager-chat-header__menu-popover {
+			${ declarations.join( ';\n\t\t\t' ) };
 		}
+		${ fontRule }
 		.agents-manager-brand-logo {
 			border-radius: 50%;
 			object-fit: cover;
@@ -342,6 +410,7 @@ window.agentsManagerData.siteUrl = readerConfig.siteUrl || '';
 // all — so both sides degrade to the unbranded look rather than throwing.
 window.agentsManagerData.brandName = readerBrand.name || '';
 window.agentsManagerData.brandLogoUrl = readerBrand.logoUrl || '';
+window.agentsManagerData.emptyViewHelp = readerBrand.help || '';
 
 /**
  * Build fallback suggested prompts based on the current page context.
@@ -953,7 +1022,6 @@ function setupFollowupChips() {
  * Checks current state first (covers a relaunch where the panel is
  * already open), then watches the shared store for isOpen turning
  * true. Fires at most once.
- *
  * @param {Function} onFirstOpen    Callback to run on the first open.
  * @param {Object}   deps           Store accessors, injectable for tests.
  * @param {Function} deps.select    @wordpress/data select.

--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -111,11 +111,13 @@ jest.mock(
 
 		function MockEmptyView( {
 			heading,
+			help,
 			icon,
 			suggestions = [],
 			onSuggestionClick,
 		}: {
 			heading?: string;
+			help?: string;
 			icon?: ReactNode;
 			suggestions?: Suggestion[];
 			onSuggestionClick?: (
@@ -128,6 +130,7 @@ jest.mock(
 					{ icon }
 					{ heading && <p>{ heading }</p> }
 					<MockSuggestionButtons suggestions={ suggestions } onSubmit={ onSuggestionClick } />
+					{ help && <p>{ help }</p> }
 				</div>
 			);
 		}
@@ -272,6 +275,22 @@ describe( 'AgentChat', () => {
 		expect( identity.compareDocumentPosition( greeting ) ).toBe( Node.DOCUMENT_POSITION_FOLLOWING );
 		expect( mockChatHeaderProps ).toHaveBeenCalled();
 		expect( mockChatHeaderProps.mock.calls.at( -1 )?.[ 0 ] ).not.toHaveProperty( 'title' );
+	} );
+
+	it( 'shows the Site Chat help override below starter suggestions', () => {
+		mockIsReaderChatHost.mockReturnValue( true );
+		( window as unknown as { agentsManagerData?: unknown } ).agentsManagerData = {
+			emptyViewHelp: 'Choose a prompt or ask below.',
+		};
+
+		renderAgentChat( {
+			isOpen: true,
+			emptyViewSuggestions: [
+				{ id: 'featured', label: 'Featured posts', prompt: 'Show featured posts' },
+			],
+		} );
+
+		expect( screen.getByText( 'Choose a prompt or ask below.' ) ).toBeInTheDocument();
 	} );
 
 	const imageUpload = ( isUploadingImages: boolean ) =>

--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -13,6 +13,8 @@ const mockContainerProps = jest.fn();
 const mockInputProps = jest.fn();
 const mockImageUploaderProps = jest.fn();
 const mockHasAiChatEntry = jest.fn();
+const mockIsReaderChatHost = jest.fn();
+const mockChatHeaderProps = jest.fn();
 
 jest.mock(
 	'@automattic/agenttic-ui',
@@ -108,16 +110,26 @@ jest.mock(
 		}
 
 		function MockEmptyView( {
+			heading,
+			icon,
 			suggestions = [],
 			onSuggestionClick,
 		}: {
+			heading?: string;
+			icon?: ReactNode;
 			suggestions?: Suggestion[];
 			onSuggestionClick?: (
 				selectedSuggestion: Suggestion,
 				availableSuggestions: Suggestion[]
 			) => void;
 		} ) {
-			return <MockSuggestionButtons suggestions={ suggestions } onSubmit={ onSuggestionClick } />;
+			return (
+				<div>
+					{ icon }
+					{ heading && <p>{ heading }</p> }
+					<MockSuggestionButtons suggestions={ suggestions } onSubmit={ onSuggestionClick } />
+				</div>
+			);
 		}
 
 		function MockSuggestions( {
@@ -182,7 +194,10 @@ jest.mock( '../../stores', () => ( {
 } ) );
 jest.mock( '../chat-header', () => ( {
 	__esModule: true,
-	default: () => null,
+	default: ( props: unknown ) => {
+		mockChatHeaderProps( props );
+		return null;
+	},
 } ) );
 jest.mock( '../context-cards', () => ( {
 	__esModule: true,
@@ -203,7 +218,7 @@ jest.mock( '../../utils/is-plugin-compass-agent', () => ( {
 	isPluginCompassHost: () => false,
 } ) );
 jest.mock( '../../utils/is-reader-chat-agent', () => ( {
-	isReaderChatHost: () => false,
+	isReaderChatHost: () => mockIsReaderChatHost(),
 } ) );
 jest.mock( '../../hooks/use-has-ai-chat-entry-button', () => ( {
 	__esModule: true,
@@ -238,7 +253,25 @@ describe( 'AgentChat', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockHasAiChatEntry.mockReturnValue( false );
+		mockIsReaderChatHost.mockReturnValue( false );
+		delete ( window as unknown as { agentsManagerData?: unknown } ).agentsManagerData;
 		document.body.className = '';
+	} );
+
+	it( 'shows the Site Chat identity above the greeting instead of in the header', () => {
+		mockIsReaderChatHost.mockReturnValue( true );
+		( window as unknown as { agentsManagerData?: unknown } ).agentsManagerData = {
+			brandName: 'Sa Islang Pantropiko',
+		};
+
+		renderAgentChat( { isOpen: true } );
+
+		const identity = screen.getByText( 'Sa Islang Pantropiko' );
+		const greeting = screen.getByText( 'Ask me anything about this blog.' );
+		expect( identity ).toHaveClass( 'agents-manager-brand-identity__name' );
+		expect( identity.compareDocumentPosition( greeting ) ).toBe( Node.DOCUMENT_POSITION_FOLLOWING );
+		expect( mockChatHeaderProps ).toHaveBeenCalled();
+		expect( mockChatHeaderProps.mock.calls.at( -1 )?.[ 0 ] ).not.toHaveProperty( 'title' );
 	} );
 
 	const imageUpload = ( isUploadingImages: boolean ) =>

--- a/packages/agents-manager/src/components/agent-chat/grouped-empty-view.scss
+++ b/packages/agents-manager/src/components/agent-chat/grouped-empty-view.scss
@@ -128,3 +128,24 @@
 	border-start-start-radius: 0;
 	border-start-end-radius: 0;
 }
+
+.agents-manager-brand-identity {
+	display: flex;
+	min-width: 0;
+	align-items: center;
+	gap: var( --spacing-3 );
+
+	> svg,
+	> .agents-manager-brand-logo {
+		flex-shrink: 0;
+	}
+
+	&__name {
+		min-width: 0;
+		color: var( --color-foreground );
+		font-size: var( --text-base );
+		font-weight: var( --font-weight-semibold );
+		line-height: var( --text-base--line-height );
+		overflow-wrap: anywhere;
+	}
+}

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -165,6 +165,24 @@ function BrandLogo( { src, size = 32 }: { src: string; size?: number } ) {
 	);
 }
 
+/**
+ * Keep Site Chat's mark and assistant name together in the empty state.
+ */
+function BrandIdentity( { name, logoUrl }: { name?: string; logoUrl?: string } ) {
+	const mark = logoUrl ? <BrandLogo src={ logoUrl } /> : <AI size={ 32 } />;
+
+	if ( ! name ) {
+		return mark;
+	}
+
+	return (
+		<span className="agents-manager-brand-identity">
+			{ mark }
+			<span className="agents-manager-brand-identity__name">{ name }</span>
+		</span>
+	);
+}
+
 function getEmptyViewHelp(): string {
 	const override = getAgentsManagerInlineData()?.emptyViewHelp;
 	if ( override ) {
@@ -360,18 +378,13 @@ export default function AgentChat( {
 						suggestions={ emptyViewSuggestions }
 						groupWritingSuggestions={ groupWritingSuggestions }
 						onSuggestionClick={ onSuggestionClick }
-						icon={ brandLogoUrl ? <BrandLogo src={ brandLogoUrl } /> : <AI size={ 32 } /> }
+						icon={ <BrandIdentity name={ brandName } logoUrl={ brandLogoUrl } /> }
 					/>
 				)
 			}
 		>
 			<AgentUI.ConversationView ref={ conversationViewRef }>
-				<ChatHeader
-					onClose={ onClose }
-					options={ chatHeaderOptions }
-					isDocked={ isDocked }
-					title={ brandName }
-				/>
+				<ChatHeader onClose={ onClose } options={ chatHeaderOptions } isDocked={ isDocked } />
 				{ isLoadingConversation ? <ChatMessageSkeleton count={ 3 } /> : <AgentUI.Messages /> }
 				{ ( onContextCardAction || onContextCardDismiss ) && (
 					<ContextCards onAction={ onContextCardAction } onDismiss={ onContextCardDismiss } />

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -10,7 +10,7 @@ import {
 	type UploadedImage,
 } from '@automattic/agenttic-ui';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback, useMemo, useRef } from '@wordpress/element';
+import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { formatWritingSuggestionLabels } from '../../hooks/use-empty-view-suggestions';
@@ -19,6 +19,7 @@ import { AGENTS_MANAGER_STORE } from '../../stores';
 import { getAgentsManagerInlineData } from '../../utils/get-agents-manager-inline-data';
 import { isEditorPage } from '../../utils/is-editor-page';
 import { isReaderChatHost } from '../../utils/is-reader-chat-agent';
+import { getBrandName, getBrandLogoUrl } from '../../utils/site-chat-brand';
 import { recordBigSkyTracksEvent } from '../../utils/tracks';
 import ChatHeader, { type Options as ChatHeaderOptions } from '../chat-header';
 import ChatMessageSkeleton from '../chat-message-skeleton';
@@ -135,6 +136,33 @@ function getEmptyViewHeading(): string {
 		return __( 'Ask me anything about this blog.', __i18n_text_domain__ );
 	}
 	return __( 'Howdy! How can I help you today?', __i18n_text_domain__ );
+}
+
+/**
+ * Renders the site's logo, falling back to the default agent icon if the image
+ * fails to load.
+ *
+ * The fallback matters: this mounts on every page of a public blog, so a
+ * deleted or unreachable Site Icon must degrade to the stock mark rather than
+ * paint a broken-image box across the whole site.
+ */
+function BrandLogo( { src, size = 32 }: { src: string; size?: number } ) {
+	const [ failed, setFailed ] = useState( false );
+
+	if ( failed ) {
+		return <AI size={ size } />;
+	}
+
+	return (
+		<img
+			src={ src }
+			alt=""
+			width={ size }
+			height={ size }
+			className="agents-manager-brand-logo"
+			onError={ () => setFailed( true ) }
+		/>
+	);
 }
 
 function getEmptyViewHelp(): string {
@@ -287,8 +315,13 @@ export default function AgentChat( {
 		}
 	}, [ trackImageUpload ] );
 
+	const brandName = getBrandName();
+	const brandLogoUrl = getBrandLogoUrl();
+
 	return (
 		<AgentUI.Container
+			triggerTitle={ brandName }
+			triggerIcon={ brandLogoUrl ? <BrandLogo src={ brandLogoUrl } /> : undefined }
 			initialChatPosition={ floatingPosition }
 			onChatPositionChange={ ( position ) => setFloatingPosition( position ) }
 			initialFreeDragPosition={ freeDragPosition ?? undefined }
@@ -327,13 +360,18 @@ export default function AgentChat( {
 						suggestions={ emptyViewSuggestions }
 						groupWritingSuggestions={ groupWritingSuggestions }
 						onSuggestionClick={ onSuggestionClick }
-						icon={ <AI size={ 32 } /> }
+						icon={ brandLogoUrl ? <BrandLogo src={ brandLogoUrl } /> : <AI size={ 32 } /> }
 					/>
 				)
 			}
 		>
 			<AgentUI.ConversationView ref={ conversationViewRef }>
-				<ChatHeader onClose={ onClose } options={ chatHeaderOptions } isDocked={ isDocked } />
+				<ChatHeader
+					onClose={ onClose }
+					options={ chatHeaderOptions }
+					isDocked={ isDocked }
+					title={ brandName }
+				/>
 				{ isLoadingConversation ? <ChatMessageSkeleton count={ 3 } /> : <AgentUI.Messages /> }
 				{ ( onContextCardAction || onContextCardDismiss ) && (
 					<ContextCards onAction={ onContextCardAction } onDismiss={ onContextCardDismiss } />

--- a/packages/agents-manager/src/global.d.ts
+++ b/packages/agents-manager/src/global.d.ts
@@ -30,6 +30,14 @@ declare const agentsManagerData:
 			isDevMode?: boolean;
 			emptyViewHeading?: string;
 			emptyViewHelp?: string;
+			/**
+			 * Site Chat brand kit, set by the reader-chat entry from the
+			 * `brand` object Jetpack injects. Both are optional: Jetpack omits
+			 * keys that resolve to nothing, and an older cached bundle may run
+			 * against PHP that sends no brand at all.
+			 */
+			brandName?: string;
+			brandLogoUrl?: string;
 	  }
 	| undefined;
 

--- a/packages/agents-manager/src/utils/__tests__/site-chat-brand.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/site-chat-brand.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment jsdom
+ */
+import { getBrandName, getBrandLogoUrl } from '../site-chat-brand';
+
+declare global {
+	// eslint-disable-next-line no-var
+	var agentsManagerData: Record< string, unknown > | undefined;
+}
+
+function setInlineData( data: Record< string, unknown > | undefined ) {
+	( window as unknown as { agentsManagerData?: unknown } ).agentsManagerData = data;
+}
+
+describe( 'site chat brand', () => {
+	afterEach( () => {
+		setInlineData( undefined );
+	} );
+
+	describe( 'on the reader-chat host', () => {
+		beforeEach( () => {
+			setInlineData( {
+				agentId: 'reader-chat',
+				brandName: 'Ada',
+				brandLogoUrl: 'https://example.com/icon.png',
+			} );
+		} );
+
+		it( 'returns the name', () => {
+			expect( getBrandName() ).toBe( 'Ada' );
+		} );
+
+		it( 'returns the logo URL', () => {
+			expect( getBrandLogoUrl() ).toBe( 'https://example.com/icon.png' );
+		} );
+
+		it( 'treats an empty string as unbranded', () => {
+			setInlineData( { agentId: 'reader-chat', brandName: '', brandLogoUrl: '' } );
+
+			expect( getBrandName() ).toBeUndefined();
+			expect( getBrandLogoUrl() ).toBeUndefined();
+		} );
+
+		it( 'tolerates a brand that was never set', () => {
+			setInlineData( { agentId: 'reader-chat' } );
+
+			expect( getBrandName() ).toBeUndefined();
+			expect( getBrandLogoUrl() ).toBeUndefined();
+		} );
+
+		it( 'applies to every reader-chat variant', () => {
+			setInlineData( { agentId: 'p2-reader-chat', brandName: 'Ada' } );
+
+			expect( getBrandName() ).toBe( 'Ada' );
+		} );
+	} );
+
+	describe( 'off-host', () => {
+		// A blog's branding must never leak into wp-admin, Big Sky, or the
+		// orchestrator — they all share these components.
+		it( 'ignores a brand on the orchestrator', () => {
+			setInlineData( {
+				agentId: 'wp-orchestrator',
+				brandName: 'Ada',
+				brandLogoUrl: 'https://example.com/icon.png',
+			} );
+
+			expect( getBrandName() ).toBeUndefined();
+			expect( getBrandLogoUrl() ).toBeUndefined();
+		} );
+
+		it( 'ignores a brand when no agent is identified', () => {
+			setInlineData( { brandName: 'Ada', brandLogoUrl: 'https://example.com/icon.png' } );
+
+			expect( getBrandName() ).toBeUndefined();
+			expect( getBrandLogoUrl() ).toBeUndefined();
+		} );
+
+		it( 'tolerates missing inline data entirely', () => {
+			setInlineData( undefined );
+
+			expect( getBrandName() ).toBeUndefined();
+			expect( getBrandLogoUrl() ).toBeUndefined();
+		} );
+	} );
+} );

--- a/packages/agents-manager/src/utils/site-chat-brand.ts
+++ b/packages/agents-manager/src/utils/site-chat-brand.ts
@@ -1,0 +1,37 @@
+import { getAgentsManagerInlineData } from './get-agents-manager-inline-data';
+import { isReaderChatHost } from './is-reader-chat-agent';
+
+/**
+ * Site Chat brand kit accessors.
+ *
+ * Jetpack resolves a site's brand (name, logo, accent, greeting) server-side
+ * and the reader-chat entry copies it onto `agentsManagerData`. Only the
+ * reader-chat host may read it: a blog's branding must never leak into
+ * wp-admin, Big Sky, or the orchestrator, all of which share these components.
+ *
+ * Every accessor is defensive. Jetpack omits keys that resolve to nothing, and
+ * a cached copy of the reader-chat bundle can run against a PHP deploy that
+ * sends no brand at all — so "absent" is a normal state, not an error.
+ */
+
+/**
+ * The site's assistant name, or undefined when unbranded or off-host.
+ */
+export function getBrandName(): string | undefined {
+	if ( ! isReaderChatHost() ) {
+		return undefined;
+	}
+
+	return getAgentsManagerInlineData()?.brandName || undefined;
+}
+
+/**
+ * The site's logo URL, or undefined when unbranded or off-host.
+ */
+export function getBrandLogoUrl(): string | undefined {
+	if ( ! isReaderChatHost() ) {
+		return undefined;
+	}
+
+	return getAgentsManagerInlineData()?.brandLogoUrl || undefined;
+}


### PR DESCRIPTION
## Proposed Changes

Step 2 of 3 for the Site Chat brand kit. This consumes the expanded `brand` object injected through `JetpackReaderChatConfig` and applies it to the public widget.

| Step | Repo | Status |
| --- | --- | --- |
| 1. Option, resolver, config contract, settings UI | jetpack | Automattic/jetpack#50945 |
| 2. Token injection and widget presentation | wp-calypso | this PR |
| 3. Server-side name to system prompt | wpcom | separate PR |

**Contract consumed** — every key is optional so old and new deploys remain compatible:

| Key | Use |
| --- | --- |
| `brand.name` | Launcher tooltip and empty-view identity row |
| `brand.logoUrl` | Launcher logo and empty-view identity mark |
| `brand.greeting` | Empty-view heading |
| `brand.help` | Help text below starter prompts |
| `brand.accent` / `brand.accentForeground` | Primary and primary-foreground tokens |
| `brand.background` | Chat and popover background; also selects accessible foreground colors |
| `brand.outline` | Muted and outline token |
| `brand.fontFamily` / `brand.siteFontFamily` | Allowlisted preset or server-resolved site font stack |

### Details worth reviewing

**Text contrast is automatic.** A selected background derives black or white primary text at 4.5:1 contrast or better. Secondary text uses a softer accessible candidate when possible and falls back to the primary accessible foreground when necessary. Outgoing messages derive their own foreground from the muted bubble fill, so a light bubble cannot inherit white text from a dark panel. Links in those messages stay visibly underlined. Removed `text` and `fontSize` values are intentionally ignored.

**The New chat menu is scoped and branded.** Popover rules now target only the Site Chat header menu instead of globally restyling WordPress component popovers on the host page. Its surface, label, hover/active state, and keyboard focus ring adapt to the selected background. Header action hover surfaces are derived separately from the owner-selected outline so light outlines cannot wash out controls on dark backgrounds.

**The token rule targets only Site Chat surfaces, not `:root`.** The panel and menu can be portalled, so declarations target the chat, launcher, Agenttic root, and Site Chat header menu directly. Common variables such as `--color-primary` never leak into the host theme.

**Every interpolated value is allowlisted.** Colors must be short or full hex values. Font selection is allowlisted, and the server-resolved site stack is checked again before it reaches CSS. Unsupported values emit no override.

**Font choices reach the complete widget.** Serif and the resolved Site font flow through the same scoped reset, including the portalled menu. Site font falls back to explicit inheritance when the server cannot resolve a global theme stack. Site Logos preserve their aspect ratio instead of being forced into a circular crop. Rounded was removed before release, so no production migration is required.

**Partial deployments degrade safely.** A cached bundle can receive no brand, and a fresh bundle can meet older PHP. Missing values leave Agenttic defaults in place.

## Why are these changes being made?

Site owners need the public chat to reflect the identity and appearance configured in Search settings without making unsafe text-color combinations possible. The widget also needs to remain readable across light and dark panels, message bubbles, menus, and focus states.

## Testing Instructions

* Deploy Automattic/jetpack#50945 and enable Site Chat.
* Configure a dark background, a light outline, an accent, and each supported font choice in turn.
* Open the public widget and confirm the identity appears above the greeting; the top bar contains only menu and close controls.
* Confirm greeting and help text appear with starter prompts, then disappear with the empty view after the first message.
* Confirm dark backgrounds use light text and light backgrounds use dark text.
* Send a message with both light and dark outline colors. Confirm the outgoing bubble text and links remain readable, and links remain visibly underlined.
* Open the header menu and confirm the outer white panel is gone; menu text, hover/active states, disabled state, and keyboard focus remain visible.
* Hover header, copy, and zoom controls and confirm the selected Outline cannot wash out the icon.
* Switch between System default, Site font, and Serif. Confirm header, messages, composer, buttons, and menu change together while code blocks remain monospace.
* Confirm the Site Logo renders without cropping in the launcher and identity row, the Site Icon is used when no logo exists, and a missing/broken image falls back to the stock mark.
* Open the orchestrator in wp-admin on the same site and confirm none of the Site Chat branding appears there.
* Confirm an unrelated WordPress component popover on the host page is not restyled.

### Automated

- `apps/agents-manager/__tests__/reader-chat.test.js` — 75 passed.
- ESLint and the production Agents Manager build passed.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [x] Have you used memoizing on expensive computations? Not applicable; this is a one-time widget bootstrap.
- [ ] Have we added the String Freeze label for the new UI strings?
    - [ ] For UI changes, have you tested the change in various languages?
- [x] For changes affecting Jetpack: no new tracking or data use is introduced.

## Related

* Automattic/jetpack#50945
