### PR TITLE
Domains: point the "search for a domain" link at the Stepper search step

### DIFF
--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -55,6 +55,7 @@ function UseMyDomain( props ) {
 		setUseMyDomainMode,
 		isStepper = false,
 		stepLocation,
+		getDomainSearchUrl,
 		registerNowAction,
 		hideHeader,
 		render,
@@ -159,10 +160,18 @@ function UseMyDomain( props ) {
 				domainName: filteredDomainName,
 				dashboard,
 				selectedSite,
+				getDomainSearchUrl,
 				registerNowAction,
 			} ),
 		};
-	}, [ filterDomainName, domainName, selectedSite, registerNowAction, dashboard ] );
+	}, [
+		filterDomainName,
+		domainName,
+		selectedSite,
+		getDomainSearchUrl,
+		registerNowAction,
+		dashboard,
+	] );
 
 	const getAvailability = useCallback( async () => {
 		const filteredDomainName = filterDomainName( domainName );
@@ -183,6 +192,7 @@ function UseMyDomain( props ) {
 				domainName: filteredDomainName,
 				dashboard,
 				selectedSite,
+				getDomainSearchUrl,
 				registerNowAction,
 			} ),
 		};
@@ -191,6 +201,7 @@ function UseMyDomain( props ) {
 		domainName,
 		getWpcomAvailabilityErrors,
 		selectedSite,
+		getDomainSearchUrl,
 		registerNowAction,
 		dashboard,
 	] );
@@ -496,6 +507,7 @@ UseMyDomain.propTypes = {
 	setUseMyDomainMode: PropTypes.func,
 	isStepper: PropTypes.bool,
 	stepLocation: PropTypes.object,
+	getDomainSearchUrl: PropTypes.func,
 	registerNowAction: PropTypes.func,
 	hideHeader: PropTypes.bool,
 	render: PropTypes.func,

--- a/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
+++ b/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
@@ -9,6 +9,7 @@ export function getAvailabilityErrorMessage( {
 	domainName,
 	dashboard,
 	selectedSite,
+	getDomainSearchUrl = undefined,
 	registerNowAction = undefined,
 } ) {
 	const { status, mappable, maintenance_end_time, other_site_domain, other_site_domain_only } =
@@ -16,7 +17,9 @@ export function getAvailabilityErrorMessage( {
 
 	if ( [ status, mappable ].includes( domainAvailability.AVAILABLE ) ) {
 		if ( selectedSite ) {
-			const searchPageLink = domainAddNew( selectedSite.slug, domainName );
+			const searchPageLink = getDomainSearchUrl
+				? getDomainSearchUrl( status === domainAvailability.TLD_NOT_SUPPORTED ? '' : domainName )
+				: domainAddNew( selectedSite.slug, domainName );
 			return createInterpolateElement(
 				__( "This domain isn't registered. Did you mean to <a>search for a domain</a> instead?" ),
 				{

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -6,7 +6,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { help } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { getQueryArg, removeQueryArgs } from '@wordpress/url';
+import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -34,6 +34,10 @@ import type { HelpCenterSelect } from '@automattic/data-stores';
 import './style.scss';
 
 const HELP_CENTER_STORE = HelpCenter.register();
+
+// A literal rather than STEPS.DOMAIN_SEARCH: importing the registry that lazy-loads this
+// step from inside the step would be circular.
+const DOMAIN_SEARCH_STEP_SLUG = 'domains';
 
 type OwnershipVerificationData = {
 	ownership_verification_data: {
@@ -157,6 +161,20 @@ const UseMyDomain: StepType< {
 		return lastQuery || initialQuery;
 	};
 
+	// The search step is a sibling in every flow that includes this one, so the destination is
+	// the current location with the step slug swapped. It reads the search term from `new`.
+	const getDomainSearchUrl = ( domain: string ) => {
+		const { step, initialQuery, lastQuery, ...queryArgs } = getQueryArgs( location.search );
+		const pathname = location.pathname
+			.replace( /\/+$/, '' )
+			.replace( /[^/]*$/, DOMAIN_SEARCH_STEP_SLUG );
+
+		return addQueryArgs( `/setup${ pathname }`, {
+			...queryArgs,
+			...( domain && { new: domain } ),
+		} );
+	};
+
 	const getInitialMode = function () {
 		const stepQueryParam = getQueryArg( window.location.search, 'step' );
 		if ( stepQueryParam === 'transfer-or-connect' ) {
@@ -190,6 +208,7 @@ const UseMyDomain: StepType< {
 					onNextStep={ handleOnNext }
 					isStepper
 					stepLocation={ location }
+					getDomainSearchUrl={ getDomainSearchUrl }
 					registerNowAction={ handleGoBack }
 					hideHeader={ shouldUseStepContainerV2( flow ) }
 				/>


### PR DESCRIPTION
Fixes DOMENG-911

## Proposed Changes

* The Stepper `use-my-domain` step now supplies the destination for the "search for a domain" link shown when a searched domain isn't registered. It points at the sibling `domains` step of the current flow, carrying over the existing query args (`siteSlug`, `domainConnectionSetupUrl`, `dashboard`, `back_to`, `redirect_to`) and the search term.
* `getAvailabilityErrorMessage()` uses that URL when it's given one, and keeps building the classic `domainAddNew()` link otherwise, so classic Calypso is unchanged.
* The term is passed as `new=<domain>` — the param the domain search step actually reads. The old link used `suggestion=`, which Stepper ignores, so the term was being dropped even when the link happened to land somewhere usable.
* The term is omitted when the availability status is `TLD_NOT_SUPPORTED`, since pre-filling a TLD the search can't offer only produces an error on arrival.

## Why are these changes being made?

The link was built unconditionally with `domainAddNew()`, a classic Calypso path builder. Stepper populates `selectedSite` from the URL for every flow (`client/landing/stepper/index.tsx`), so the branch that builds the classic link always won inside `/setup/<flow>/use-my-domain` — a user who reached "Use a domain I own" from the new dashboard was dropped out of the flow into the old domain search, losing the dashboard context (`back_to`, `domainConnectionSetupUrl`) along the way.

Deriving the destination from the live location rather than hardcoding it means every flow containing `USE_MY_DOMAIN` is fixed by the same change — `domain`, `domain-and-plan`, `education`, `onboarding`, `newsletter`, `copy-site`, `reblogging`, `new-hosted-site-flow`, `ai-site-builder-onboarding` — with no per-flow edits.

## Testing Instructions

1. From the new dashboard, open a site's domains screen.
2. Click "Add domain name" → "Use a domain name I own". You should land on `/setup/domain/use-my-domain?siteSlug=…&dashboard=dotcom&back_to=…`.
3. Search for a domain that isn't registered, e.g. `some-unregistered-name.space`.
4. Observe the message: "This domain isn't registered. Did you mean to search for a domain instead?"
5. Verify the link now points to `/setup/domain/domains` with the same `siteSlug`, `domainConnectionSetupUrl`, `dashboard` and `back_to` args, plus `new=<the domain you typed>`.
6. Follow it and confirm the search step opens with the term pre-filled and the flow's back navigation still returns to the dashboard.

Classic Calypso regression check:

7. Go to `/domains/add/<your-site>/use-your-domain` directly and repeat steps 3–4. The link should still be the classic `/domains/add/<site>?suggestion=<domain>`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
