### PR TITLE
Domain flow: fix double-click on `Bring it over` for owned domains

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -231,7 +231,7 @@ const domain: FlowV2< typeof initialize > = {
 						providedDependencies.mode &&
 						providedDependencies.domain
 					) {
-						const destination = addQueryArgs( '/use-my-domain', {
+						const destination = addQueryArgs( 'use-my-domain', {
 							...getQueryArgs( window.location.href ),
 							step: providedDependencies.mode,
 							initialQuery: providedDependencies.domain,


### PR DESCRIPTION
Fixes DOTOBRD-579

## Proposed Changes

* Drop the leading slash from the `use-my-domain` self-navigation slug in the `domain` flow (`'/use-my-domain'` → `'use-my-domain'`).

## Why are these changes being made?

Connecting an already-owned domain via **"Bring it over"** required two clicks — the first click bounced back to domain search.

The one-click action is actually two navigations:
1. "Bring it over" → `DOMAIN_SEARCH` submits `navigateToUseMyDomain` → flow navigates to `use-my-domain`.
2. The `use-my-domain` step, seeing `initialQuery` but no `step`, auto-advances and re-submits `{ mode, domain }`, and the `USE_MY_DOMAIN` handler self-navigates to append `step=transfer-or-connect`.

Step 2 built its destination with `addQueryArgs( '/use-my-domain', … )`. The leading slash made Stepper's router encode the slug as `%2Fuse-my-domain`, which matched no registered step, so it fell back to the first step (`domains`) — bouncing the user back to search. The second click only worked because the URL then already carried `step=transfer-or-connect`, so the step rendered directly without self-navigating.

The sibling `DOMAIN_SEARCH` navigation already used the slug without a leading slash; this makes the two consistent.

## Testing Instructions

1. Go to `/setup/domain`.
2. Search for a domain you already own (e.g. `testwoo.com`).
3. Click **"Bring it over"**.
4. Verify you land on the "Set up your domain" (transfer/connect) page in a **single** click, with no flash back to the domain search page.

Also covered by the E2E spec `setup-domain__flows.spec.ts` → `As a new user I can connect an external domain to a new site`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
