### PR TITLE
Backups: add Select all/Deselect all aria-label to file browser header checkbox

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
@@ -27,6 +27,9 @@ function FileBrowserHeader( { rewindId }: { rewindId: number } ) {
 					checked={ rootNode ? rootNode.checkState === 'checked' : false }
 					indeterminate={ rootNode?.checkState === 'mixed' }
 					onChange={ onCheckboxChange }
+					aria-label={
+						rootNode?.checkState === 'unchecked' ? __( 'Select all' ) : __( 'Deselect all' )
+					}
 				/>
 				<Text size="small">
 					{ browserCheckList.totalItems } { __( 'files selected' ) }


### PR DESCRIPTION
Fixes DOTMSD-1476

## Proposed Changes

* Add an `aria-label` to the "select all" checkbox in the backup file browser header (`file-browser-header.tsx`). The label toggles between "Select all" and "Deselect all" to match the checkbox's actual click behavior, mirroring how DataViews labels its equivalent checkbox.

## Why are these changes being made?

The root/select-all checkbox in the file browser header had no accessible label, while the per-file checkboxes already do (`Select <file name>`). Screen reader users had no context for the control. The label reflects the outcome of clicking: when nothing is selected a click selects all ("Select all"); when a partial or full selection exists a click clears it ("Deselect all").

## Testing Instructions

* Open a site's Backups, select a backup, and expand the file browser.
* Inspect the header checkbox with a screen reader or dev tools.
* With no files selected, the label reads "Select all".
* With some or all files selected, the label reads "Deselect all", matching the click behavior (which deselects all).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
