### PR TITLE
Analytics: update the Tracks script version to pick up the event-loss fix

### DIFF
--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -45,7 +45,7 @@ let _superProps: any; // Added to all Tracks events.
 let _loadTracksResult = Promise.resolve(); // default value for non-BOM environments.
 
 if ( typeof document !== 'undefined' ) {
-	_loadTracksResult = loadScript( '//stats.wp.com/w.js?67' );
+	_loadTracksResult = loadScript( '//stats.wp.com/w.js?69' );
 }
 
 function createRandomId( randomBytesLength = 9 ): string {


### PR DESCRIPTION
Part of an upstream Tracks script fix (internal: Automattic/analytics#80).

## Proposed Changes

* Load the latest version of the Tracks script (w.js 69).

## Why are these changes being made?

* The Tracks script got a fix so queued events aren't silently lost on event-heavy pages. Calypso pins the script version, so it keeps loading the old cached build until this number is bumped.

## Testing Instructions

* Once w.js 69 is deployed: open any Calypso page and confirm the network tab loads `//stats.wp.com/w.js?69`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility (PCYsg-S3g-p2) for your changes?

**Draft until w.js 69 is live on stats.wp.com** — requesting `?69` earlier would cache the old build under the new number.
