### PR TITLE
E2E: skip broken new-hosted-site purchase+cancel test (DOTMSD-1480)

### DIFF
--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
@@ -52,7 +52,8 @@ test.describe(
 			} );
 		} );
 
-		test( 'As a new user, I can purchase a hosted site and cancel it', async ( { page } ) => {
+		// Test currently broken on opening the dashboard sidebar on mobile DOTMSD-1480
+		test.skip( 'As a new user, I can purchase a hosted site and cancel it', async ( { page } ) => {
 			// ~360s of dominant waits (90s purchase + 180s Atomic transfer + 30s
 			// checkout + two 30s refund notices) plus signup, billing and two
 			// cancellation navigations; 420s covers the worst case.


### PR DESCRIPTION
## Proposed Changes

* Skip the `As a new user, I can purchase a hosted site and cancel it` E2E test in `onboarding__new-hosted-site.spec.ts`.

## Why are these changes being made?

* The test is currently broken on opening the dashboard sidebar on mobile (DOTMSD-1480). Skipping it keeps CI green while the underlying issue is investigated.

## Testing Instructions

* Confirm the test is skipped in the onboarding E2E run.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
