### PR TITLE
E2E: fix mobile sidebar open in dashboard /me flow (DOTMSD-1480)

### DIFF
--- a/client/dashboard/app/responsive-sidebar/index.tsx
+++ b/client/dashboard/app/responsive-sidebar/index.tsx
@@ -54,6 +54,7 @@ export default function ResponsiveSidebar( {
 					<div
 						role="presentation"
 						className="dashboard-responsive-sidebar__overlay"
+						data-testid="dashboard-responsive-sidebar-overlay"
 						onClick={ handleOverlayClick }
 						onKeyDown={ handleOverlayKeyDown }
 					/>,

--- a/packages/calypso-e2e/src/lib/components/me/dashboard-me-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/me/dashboard-me-sidebar-component.ts
@@ -24,9 +24,35 @@ export class DashboardMeSidebarComponent {
 	 * clicked. No-op on wider viewports, where the sidebar is always visible.
 	 */
 	async openMobileMenu() {
-		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			await this.page.getByRole( 'button', { name: 'Menu' } ).click();
+		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
+			return;
 		}
+
+		// The toggle is an icon-only button whose accessible name is empty (the
+		// icon is a CSS pseudo-element and it carries no aria-label), so matching
+		// by role and name never resolves it. Match its `title` instead.
+		const menuToggle = this.page.getByTitle( 'Menu' ).first();
+		// The overlay is portalled into place only while the sidebar is open, so
+		// its presence is a reliable "sidebar is open" signal.
+		const openSidebar = this.page.getByTestId( 'dashboard-responsive-sidebar-overlay' );
+
+		await menuToggle.waitFor( { state: 'visible' } );
+
+		// The toggle lives in the omnibar, which hydrates in a React root separate
+		// from — and asynchronously after — the main app. Its server-rendered
+		// markup is clickable before the click handler is wired, so an early click
+		// is a silent no-op. Retry until the sidebar actually slides open.
+		for ( let attempt = 0; attempt < 15; attempt++ ) {
+			await menuToggle.click();
+			try {
+				await openSidebar.waitFor( { state: 'visible', timeout: 1000 } );
+				return;
+			} catch {
+				// Sidebar still closed — the omnibar likely has not hydrated yet.
+			}
+		}
+
+		throw new Error( 'Mobile sidebar did not open after clicking the Menu toggle.' );
 	}
 
 	/**

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
@@ -12,14 +12,14 @@ import {
 	cancelDashboardPurchaseFlow,
 	removeDashboardUpgradeFlow,
 } from '@automattic/calypso-e2e';
-import { skipIfNotTrunk, tags, test } from '../../lib/pw-base';
+import { /*skipIfNotTrunk,*/ tags, test, expect } from '../../lib/pw-base';
 import { apiCancelAtomicPlan, apiCloseAccount } from '../shared';
 
 test.describe(
 	DataHelper.createSuiteTitle( 'New Hosted Site Flow: Purchase a hosted site and cancel it' ),
 	{ tag: [ tags.CALYPSO_RELEASE ] },
 	() => {
-		skipIfNotTrunk();
+		// skipIfNotTrunk();
 
 		const planName = 'Business';
 		const testUser = DataHelper.getNewTestUser();
@@ -154,6 +154,10 @@ test.describe(
 				await snackbar.noticeShown( 'Your refund has been processed and your purchase removed.', {
 					exact: true,
 				} );
+			} );
+
+			await test.step( 'intentional fail', () => {
+				expect( 1 ).toBe( 2 );
 			} );
 		} );
 	}

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
@@ -12,14 +12,14 @@ import {
 	cancelDashboardPurchaseFlow,
 	removeDashboardUpgradeFlow,
 } from '@automattic/calypso-e2e';
-import { /*skipIfNotTrunk,*/ tags, test, expect } from '../../lib/pw-base';
+import { skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 import { apiCancelAtomicPlan, apiCloseAccount } from '../shared';
 
 test.describe(
 	DataHelper.createSuiteTitle( 'New Hosted Site Flow: Purchase a hosted site and cancel it' ),
 	{ tag: [ tags.CALYPSO_RELEASE ] },
 	() => {
-		// skipIfNotTrunk();
+		skipIfNotTrunk();
 
 		const planName = 'Business';
 		const testUser = DataHelper.getNewTestUser();
@@ -154,10 +154,6 @@ test.describe(
 				await snackbar.noticeShown( 'Your refund has been processed and your purchase removed.', {
 					exact: true,
 				} );
-			} );
-
-			await test.step( 'intentional fail', () => {
-				expect( 1 ).toBe( 2 );
 			} );
 		} );
 	}

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
@@ -52,8 +52,7 @@ test.describe(
 			} );
 		} );
 
-		// Test currently broken on opening the dashboard sidebar on mobile DOTMSD-1480
-		test.skip( 'As a new user, I can purchase a hosted site and cancel it', async ( { page } ) => {
+		test( 'As a new user, I can purchase a hosted site and cancel it', async ( { page } ) => {
 			// ~360s of dominant waits (90s purchase + 180s Atomic transfer + 30s
 			// checkout + two 30s refund notices) plus signup, billing and two
 			// cancellation navigations; 420s covers the worst case.


### PR DESCRIPTION
Fixes DOTMSD-1480

## Proposed Changes

* Fix the mobile Menu toggle locator in `DashboardMeSidebarComponent.openMobileMenu` and retry the click until the sidebar actually opens.
* Add a `data-testid` to the responsive sidebar's overlay so the test has a stable "sidebar is open" signal.
* Re-enable the skipped new-hosted-site purchase + cancel E2E.

## Why are these changes being made?

The mobile `/me` sidebar step in this flow was skipped under DOTMSD-1480. Reproducing it against a local dashboard on a mobile viewport surfaced two separate causes:

1. **Locator never matched.** The toggle is an icon-only button (icon is a CSS pseudo-element, no `aria-label`), so its accessible name is empty. `getByRole( 'button', { name: 'Menu' } )` matched nothing and the click timed out — this failed on every run, independent of timing. Matching the `title` (as the classic `/me` sidebar already does) resolves it.
2. **Early click was a no-op.** The toggle lives in the omnibar, which hydrates in a React root separate from — and asynchronously after — the main app. Its server-rendered markup is clickable before the handler is wired, so a single click can silently do nothing. The open step now retries until the sidebar slides in.

The ticket only hypothesised the second cause; the first was the dominant one.

## Considerations

For the "is open" signal, an alternative was the `.is-open` SCSS class on the sidebar container. A `data-testid` on the overlay is preferred: the overlay is rendered only while the sidebar is open, and a test id is an explicit contract rather than a styling detail. There is no accessible signal to rely on here — the sidebar nav stays in the DOM when closed (just translated off screen) and the toggle exposes no `aria-expanded`.

## Testing Instructions

* ⚠️ **Temporary commit "Run test in PR so we can confirm it passes on TeamCity" must be reverted before merge** — it comments out `skipIfNotTrunk()` and adds an intentional failing step so the test runs (and its result is visible) in this PR's CI. Once green through the sidebar steps, drop that commit.
* On a mobile viewport, load the dashboard `/me`, open the menu, and navigate to Billing — the sidebar opens and navigation succeeds even when omnibar hydration is slow.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
