### PR TITLE
MSD: Fix command palette dark mode

### DIFF
--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -21,6 +21,10 @@
 
 /* Command Palette */
 @mixin dashboard-dark-theme-command-palette {
+	.commands-command-menu__header-search-icon {
+		fill: var( --dashboard__text-color );
+	}
+
 	.commands-command-menu__header .components-button {
 		border-color: var( --dashboard-field__border-color );
 	}

--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -19,6 +19,67 @@
 	}
 }
 
+/* Command Palette */
+@mixin dashboard-dark-theme-command-palette {
+	.commands-command-menu__header .components-button {
+		border-color: var( --dashboard-field__border-color );
+	}
+
+	.commands-command-menu__container {
+		[cmdk-input] {
+			background: transparent;
+			color: var( --dashboard__text-color );
+
+			&::placeholder {
+				color: var( --dashboard__text-muted-color );
+			}
+		}
+
+		[cmdk-item] {
+			color: var( --dashboard__text-color );
+
+			&[aria-disabled='true'] {
+				color: var( --dashboard__text-muted-color );
+			}
+
+			svg {
+				fill: currentColor;
+			}
+
+			&[aria-selected='true'] > div,
+			&:active > div {
+				color: var( --wp-components-color-foreground-inverted );
+			}
+		}
+
+		[cmdk-root] > [cmdk-list] {
+			&:has( [cmdk-group-items]:not( :empty ) ),
+			&:has( [cmdk-empty] ) {
+				border-top-color: var( --dashboard-surface__border-color );
+			}
+
+			[cmdk-group-heading] {
+				color: var( --dashboard__text-color );
+			}
+		}
+
+		[cmdk-empty] {
+			color: var( --dashboard__text-color );
+		}
+	}
+
+	.commands-command-menu__item-category {
+		color: var( --dashboard__text-muted-color );
+	}
+
+	.commands-command-menu__container
+		[cmdk-item][aria-selected='true']
+		.commands-command-menu__item-category,
+	.commands-command-menu__container [cmdk-item]:active .commands-command-menu__item-category {
+		color: var( --wp-components-color-foreground-inverted );
+	}
+}
+
 /* Card */
 @mixin dashboard-dark-theme-card {
 	@include color-scheme-dark-theme-card;
@@ -428,6 +489,7 @@
 	@include dashboard-dark-theme-breadcrumbs;
 	@include dashboard-dark-theme-callout;
 	@include dashboard-dark-theme-card;
+	@include dashboard-dark-theme-command-palette;
 	@include dashboard-dark-theme-dataviews;
 	@include dashboard-dark-theme-destructive-secondary-button;
 	@include dashboard-dark-theme-emails;


### PR DESCRIPTION
## Proposed Changes

Add dark-mode specific styles to the MSD command palette. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* `@wordpress/commands` uses hard-coded colors specific to "Light" mode. "Dark" mode was partially applied to the command palette, updating the modal's background color but keeping the component colors the same.
<img width="560" height="376" alt="image" src="https://github.com/user-attachments/assets/fa7383d5-b56c-4cac-aca7-e40c6cc8ea7e" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `me/preferences/appearance` and set your color scheme to "Dark" 
* Go to `/sites`, press `Ctrl`/`Cmd` + `k` and confirm the command palette is displayed correctly. 
* Set the color scheme to "Light" and confirm the command palette is still displayed correctly. 

<img width="560" height="376" alt="image" src="https://github.com/user-attachments/assets/87921024-3069-4237-bf7c-7cfa03c482ae" />

<img width="560" height="376" alt="image" src="https://github.com/user-attachments/assets/7c9bbc91-0e07-4ea9-8a05-ed013b01f3c3" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
