### PR TITLE
New Playground flow

### DIFF
--- a/client/blocks/importer/wordpress/index.tsx
+++ b/client/blocks/importer/wordpress/index.tsx
@@ -3,7 +3,7 @@ import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useSelector } from 'calypso/state';
 import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import { getSite, isJetpackSite, hasAllSitesList } from 'calypso/state/sites/selectors';
+import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import { Importer, ImportJob, StepNavigator } from '../types';
 import ImportContentOnly from './import-content-only';
 
@@ -23,25 +23,17 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	const siteItem = useSelector( ( state ) => getSite( state, siteId ) );
 	const isSiteAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
 	const isSiteJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
-	const hasAllSitesFetched = useSelector( hasAllSitesList );
 	const fromSiteAnalyzedData = useSelector( getUrlData );
+	const shouldRedirectToWpAdmin = ! isSiteAtomic && isSiteJetpack;
 
 	/**
 	 ↓ Effects
 	 */
-	useEffect( checkImporterAvailability, [ siteId ] );
-
-	function checkImporterAvailability() {
-		isNotAtomicJetpack() && redirectToWpAdminImportPage();
-	}
-
-	function isNotAtomicJetpack() {
-		return ! isSiteAtomic && isSiteJetpack;
-	}
-
-	function redirectToWpAdminImportPage() {
-		stepNavigator?.goToWpAdminImportPage?.();
-	}
+	useEffect( () => {
+		if ( shouldRedirectToWpAdmin ) {
+			stepNavigator?.goToWpAdminImportPage?.();
+		}
+	}, [ shouldRedirectToWpAdmin, stepNavigator ] );
 
 	/**
 	 ↓ HTML
@@ -49,10 +41,10 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	return (
 		<>
 			{ ( () => {
-				if ( isNotAtomicJetpack() || ! hasAllSitesFetched ) {
+				if ( shouldRedirectToWpAdmin ) {
 					return (
 						<div className="import-layout__center">
-							<LoadingEllipsis />;
+							<LoadingEllipsis />
 						</div>
 					);
 				}

--- a/client/blocks/importer/wordpress/test/index.tsx
+++ b/client/blocks/importer/wordpress/test/index.tsx
@@ -1,0 +1,50 @@
+/** @jest-environment jsdom */
+
+import { render, screen } from '@testing-library/react';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { WordpressImporter } from '..';
+
+jest.mock( 'calypso/state', () => ( {
+	useSelector: ( selector: ( state: object ) => unknown ) => selector( {} ),
+} ) );
+
+jest.mock( 'calypso/state/selectors/is-site-automated-transfer', () => jest.fn() );
+
+jest.mock( 'calypso/state/sites/selectors', () => ( {
+	getSite: () => ( { ID: 123 } ),
+	isJetpackSite: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/imports/url-analyzer/selectors', () => ( {
+	getUrlData: () => null,
+} ) );
+
+jest.mock( '../import-content-only', () => () => <div>Import content</div> );
+
+describe( 'WordpressImporter', () => {
+	beforeEach( () => {
+		jest.mocked( isSiteAutomatedTransfer ).mockReturnValue( true );
+		jest.mocked( isJetpackSite ).mockReturnValue( false );
+	} );
+
+	it( 'renders without waiting for the complete sites list', () => {
+		render(
+			<WordpressImporter siteId={ 123 } siteSlug="example.wordpress.com" renderHeading={ false } />
+		);
+
+		expect( screen.getByText( 'Import content' ) ).toBeVisible();
+	} );
+
+	it( 'does not render punctuation next to the loading indicator', () => {
+		jest.mocked( isSiteAutomatedTransfer ).mockReturnValue( false );
+		jest.mocked( isJetpackSite ).mockReturnValue( true );
+
+		const { container } = render(
+			<WordpressImporter siteId={ 123 } siteSlug="example.wordpress.com" renderHeading={ false } />
+		);
+
+		expect( container.querySelector( '.wpcom__loading-ellipsis' ) ).toBeInTheDocument();
+		expect( container ).not.toHaveTextContent( ';' );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -648,7 +648,9 @@ const onboarding: FlowV2< typeof initialize > = {
 					}
 
 					const launchpadPersonalizationVariation =
-						await resolveLaunchpadPersonalizationVariation( diyLaunchpad );
+						playgroundId || blueprint
+							? 'control'
+							: await resolveLaunchpadPersonalizationVariation( diyLaunchpad );
 					const [ destination, backDestination, backDestinationDomains ] =
 						await getPostCheckoutDestination(
 							providedDependencies,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -65,6 +65,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		const dispatch = useDispatch();
 		const { importer, navigation, flow } = props;
 		const currentSearchParams = useQuery();
+		const isPlaygroundImport = currentSearchParams.has( 'playground' );
 		/**
 	 	↓ Fields
 		 */
@@ -85,8 +86,17 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		);
 
 		const isLoading = useMemo( () => {
-			return ! isImporterStatusHydrated || ! hasAllSitesFetched || isRequestingCurrentSite;
-		}, [ isImporterStatusHydrated, hasAllSitesFetched, isRequestingCurrentSite ] );
+			return (
+				! isImporterStatusHydrated ||
+				( ! isPlaygroundImport && ! hasAllSitesFetched ) ||
+				isRequestingCurrentSite
+			);
+		}, [
+			isImporterStatusHydrated,
+			isPlaygroundImport,
+			hasAllSitesFetched,
+			isRequestingCurrentSite,
+		] );
 
 		const skipToDashboardAction = useCallback( () => {
 			recordTracksEvent( 'calypso_site_importer_skip_to_dashboard', {
@@ -101,8 +111,10 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 	 	↓ Effects
 		 */
 		useEffect( () => {
-			dispatch( requestSites() );
-		}, [ dispatch ] );
+			if ( ! isPlaygroundImport ) {
+				dispatch( requestSites() );
+			}
+		}, [ dispatch, isPlaygroundImport ] );
 
 		useAtomicTransferQueryParamUpdate( siteId );
 		useEffect( fetchImporters, [ siteId ] );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-setup/index.tsx
@@ -52,29 +52,6 @@ export const PlaygroundSetupStep: Step< {
 		}
 	}, [ query, submit, siteSlug, siteId, importBlueprint ] );
 
-	useEffect( () => {
-		// Clean up any playground-related localStorage items on unmount
-		return () => {
-			const playgroundId = query.get( 'playground' );
-			const currentTimestamp = Math.floor( Date.now() / 1000 );
-
-			if ( playgroundId ) {
-				window.localStorage.removeItem( 'playground-plans-intent-' + playgroundId );
-				window.localStorage.removeItem( 'playground-plans-intent-' + playgroundId + '-ts' );
-			}
-
-			Object.keys( window.localStorage ).forEach( ( key ) => {
-				if ( key.startsWith( 'playground-plans-intent-' ) && key.endsWith( '-ts' ) ) {
-					const storedAt = parseInt( window.localStorage.getItem( key ) || '0' );
-					if ( currentTimestamp - storedAt > 7 * 24 * 60 * 60 ) {
-						window.localStorage.removeItem( key );
-						window.localStorage.removeItem( key.replace( '-ts', '' ) );
-					}
-				}
-			} );
-		};
-	}, [] );
-
 	const startImport = async ( client: PlaygroundClient ) => {
 		if ( ! client ) {
 			return;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/index.tsx
@@ -21,8 +21,6 @@ export const PlaygroundStep: StepType = ( { navigation, flow } ) => {
 	// For preventing double click on launch button
 	const [ isLaunching, setIsLaunching ] = useState( false );
 
-	const [ pgIntent, setPgIntent ] = useState< string >( DEFAULT_PLAN_INTENT );
-
 	useEffect( () => {
 		if ( query.get( 'intent' ) === 'woocommerce' ) {
 			sessionStorage.setItem( SESSION_KEY_PLAYGROUND_WOO_INTENT, '1' );
@@ -37,16 +35,6 @@ export const PlaygroundStep: StepType = ( { navigation, flow } ) => {
 		playgroundClientRef.current = client;
 	};
 
-	const fetchIntent = () => {
-		setPgIntent( DEFAULT_PLAN_INTENT ); // hardcode
-		const playgroundId = query.get( 'playground' );
-		if ( playgroundId ) {
-			const keyName = 'playground-plans-intent-' + playgroundId;
-			window.localStorage.setItem( keyName, DEFAULT_PLAN_INTENT );
-			window.localStorage.setItem( keyName + '-ts', String( Math.floor( Date.now() / 1000 ) ) );
-		}
-	};
-
 	const launchSite = async () => {
 		if ( ! submit || isLaunching ) {
 			return;
@@ -59,7 +47,7 @@ export const PlaygroundStep: StepType = ( { navigation, flow } ) => {
 				flow,
 				step: 'playground',
 				blueprint: getBlueprintLabelForTracking( query ),
-				intent: pgIntent,
+				intent: DEFAULT_PLAN_INTENT,
 			} );
 
 			submit();
@@ -78,7 +66,6 @@ export const PlaygroundStep: StepType = ( { navigation, flow } ) => {
 						rightElement={
 							<Step.PrimaryButton
 								onClick={ launchSite }
-								onMouseEnter={ fetchIntent }
 								disabled={ isLaunching || ! readyForLaunch }
 							>
 								{ isWooCommerceIntent

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/import-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/import-playground.ts
@@ -31,6 +31,22 @@ export class ImportFailureError extends Error {
 	}
 }
 
+export async function startPlaygroundImportIfReady(
+	siteId: number,
+	status: ReturnType< typeof fromApi >
+): Promise< boolean > {
+	if (
+		status.importerState !== appStates.UPLOAD_SUCCESS ||
+		status.importerFileType !== 'playground'
+	) {
+		return false;
+	}
+
+	const startPayload = toApi( { ...status, importerState: appStates.IMPORTING } );
+	await updateImporter( siteId, startPayload );
+	return true;
+}
+
 export async function getSiteZip( playgroundSlug: string ) {
 	const apiIframe = document.createElement( 'iframe' );
 	apiIframe.hidden = true;
@@ -102,9 +118,9 @@ foreach ( $plugins as $slug ) {
  * Export the current Playground state and import it to a wp.com site.
  *
  * Pass waitForCompletion: true when the caller has no surrounding Redux
- * importer machinery to handle the uploadSuccess → startImporting trigger
- * (e.g. the entrepreneur flow). Leave false (default) for flows that route
- * to importerWordpress afterwards — that step's Redux monitoring handles it.
+ * importer machinery (e.g. the entrepreneur flow). The default path starts
+ * ready uploads immediately, then routes to importerWordpress for fallback
+ * state transitions and completion monitoring.
  */
 export async function importPlaygroundSite(
 	playgroundSlug: string,
@@ -116,7 +132,18 @@ export async function importPlaygroundSite(
 	const importer = await uploadExportFile( siteId, {
 		importStatus: { importStatus: 'importer-ready-for-upload', siteId, type: 'wordpress' },
 		file: siteZip,
+		autoStart: true,
 	} );
+	const importerStatus = fromApi( importer );
+	let started = false;
+
+	try {
+		started = await startPlaygroundImportIfReady( siteId, importerStatus );
+	} catch ( error ) {
+		if ( waitForCompletion ) {
+			throw error;
+		}
+	}
 
 	if ( ! waitForCompletion ) {
 		return importer.importId;
@@ -128,11 +155,7 @@ export async function importPlaygroundSite(
 	// — the backup_import job requires an explicit POST before beginning the
 	// Atomic restore. Uses fromApi/toApi/appStates to match the rest of the
 	// importer codebase rather than comparing raw API strings.
-	let started = false;
-
 	for ( let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++ ) {
-		await new Promise( ( resolve ) => setTimeout( resolve, POLL_INTERVAL_MS ) );
-
 		const raw = await wpcomRequest< Record< string, unknown > >( {
 			path: `/sites/${ siteId }/imports/${ importId }`,
 			apiVersion: '1.1',
@@ -149,10 +172,12 @@ export async function importPlaygroundSite(
 			return importId;
 		}
 
-		if ( status.importerState === appStates.UPLOAD_SUCCESS && ! started ) {
-			started = true;
-			const startPayload = toApi( { ...status, importerState: appStates.IMPORTING } );
-			await updateImporter( siteId, startPayload );
+		if ( ! started ) {
+			started = await startPlaygroundImportIfReady( siteId, status );
+		}
+
+		if ( attempt < MAX_POLL_ATTEMPTS - 1 ) {
+			await new Promise( ( resolve ) => setTimeout( resolve, POLL_INTERVAL_MS ) );
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/plans.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/plans.ts
@@ -1,7 +1,6 @@
 import { PlansIntent } from '@automattic/plans-grid-next';
 import { DEFAULT_PLAN_INTENT } from './constants';
 
-export function playgroundPlansIntent( playgroundId: string ): PlansIntent {
-	return ( window.localStorage.getItem( 'playground-plans-intent-' + playgroundId ) ??
-		DEFAULT_PLAN_INTENT ) as PlansIntent;
+export function playgroundPlansIntent(): PlansIntent {
+	return DEFAULT_PLAN_INTENT as PlansIntent;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/import-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/import-playground.ts
@@ -1,0 +1,60 @@
+import { updateImporter } from 'calypso/state/imports/actions';
+import { appStates } from 'calypso/state/imports/constants';
+import { startPlaygroundImportIfReady } from '../lib/import-playground';
+
+jest.mock( 'calypso/state/imports/actions', () => ( {
+	uploadExportFile: jest.fn(),
+	updateImporter: jest.fn(),
+} ) );
+
+const updateImporterMock = updateImporter as jest.Mock;
+
+describe( 'startPlaygroundImportIfReady', () => {
+	const siteId = 123;
+	const status = {
+		importerId: 'import-id',
+		importerState: appStates.UPLOAD_SUCCESS,
+		importerFileType: 'playground',
+		type: 'importer-type-wordpress',
+		site: { ID: siteId },
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		updateImporterMock.mockResolvedValue( {} );
+	} );
+
+	it( 'starts a Playground import as soon as its upload succeeds', async () => {
+		await expect( startPlaygroundImportIfReady( siteId, status ) ).resolves.toBe( true );
+
+		expect( updateImporterMock ).toHaveBeenCalledWith( siteId, {
+			importerId: 'import-id',
+			progress: undefined,
+			importStatus: 'importing',
+			siteId,
+			type: 'wordpress',
+		} );
+	} );
+
+	it( 'waits when the Playground upload is still processing', async () => {
+		await expect(
+			startPlaygroundImportIfReady( siteId, {
+				...status,
+				importerState: appStates.UPLOAD_PROCESSING,
+			} )
+		).resolves.toBe( false );
+
+		expect( updateImporterMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not start a non-Playground upload', async () => {
+		await expect(
+			startPlaygroundImportIfReady( siteId, {
+				...status,
+				importerFileType: 'content',
+			} )
+		).resolves.toBe( false );
+
+		expect( updateImporterMock ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/test/get-plans-intent.test.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/test/get-plans-intent.test.ts
@@ -7,10 +7,18 @@ import { getPlansIntent } from '../util/get-plans-intent';
 describe( 'getPlansIntent', () => {
 	afterEach( () => {
 		window.history.replaceState( {}, '', '/' );
+		window.localStorage.clear();
 	} );
 
 	it( 'maps the ai-site-builder-onboarding flow to the four paid plans intent', () => {
 		expect( getPlansIntent( 'ai-site-builder-onboarding' ) ).toBe( 'plans-ai-assembler-paid-only' );
+	} );
+
+	it( 'uses the fixed Playground plans intent', () => {
+		window.history.replaceState( {}, '', '/?playground=playground-id' );
+		window.localStorage.setItem( 'playground-plans-intent-playground-id', 'plans-blog-onboarding' );
+
+		expect( getPlansIntent( ONBOARDING_FLOW ) ).toBe( 'plans-playground' );
 	} );
 
 	describe( 'onboarding flow blueprint param (legacy behavior)', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-plans-intent.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-plans-intent.ts
@@ -39,7 +39,7 @@ export function getPlansIntent( flowName: string | null ): PlansIntent | null {
 			return 'plans-ai-assembler-paid-only';
 		case ONBOARDING_FLOW:
 			if ( search.has( 'playground' ) ) {
-				return playgroundPlansIntent( search.get( 'playground' )! );
+				return playgroundPlansIntent();
 			}
 			// WoW funnel: the site is always transferred to Atomic, so only plans that grant
 			// the transfer make sense. Hide the free plan. Kept after the playground check so a

--- a/client/state/imports/actions.js
+++ b/client/state/imports/actions.js
@@ -71,6 +71,9 @@ export const uploadExportFile = ( siteId, params ) =>
 		if ( params.url ) {
 			formData.push( [ 'url', params.url ] );
 		}
+		if ( params.autoStart ) {
+			formData.push( [ 'autoStart', '1' ] );
+		}
 
 		const req = wp.req.post(
 			{

--- a/client/state/imports/test/upload-export-file.js
+++ b/client/state/imports/test/upload-export-file.js
@@ -1,0 +1,57 @@
+import wp from 'calypso/lib/wp';
+import { uploadExportFile } from 'calypso/state/imports/actions';
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: {
+		post: jest.fn(),
+	},
+} ) );
+
+describe( 'uploadExportFile', () => {
+	const siteId = 123;
+	const importStatus = {
+		importStatus: 'importer-ready-for-upload',
+		siteId,
+		type: 'wordpress',
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		wp.req.post.mockReturnValue( { upload: {} } );
+	} );
+
+	it( 'requests an auto-starting import when enabled', () => {
+		const file = new File( [ 'contents' ], 'export.zip', { type: 'application/zip' } );
+
+		uploadExportFile( siteId, { importStatus, file, autoStart: true } );
+
+		expect( wp.req.post ).toHaveBeenCalledWith(
+			{
+				path: '/sites/123/imports/new',
+				formData: [
+					[ 'importStatus', JSON.stringify( importStatus ) ],
+					[ 'import', file ],
+					[ 'autoStart', '1' ],
+				],
+			},
+			expect.any( Function )
+		);
+	} );
+
+	it( 'does not auto-start other uploads by default', () => {
+		const file = new File( [ 'contents' ], 'export.zip', { type: 'application/zip' } );
+
+		uploadExportFile( siteId, { importStatus, file } );
+
+		expect( wp.req.post ).toHaveBeenCalledWith(
+			{
+				path: '/sites/123/imports/new',
+				formData: [
+					[ 'importStatus', JSON.stringify( importStatus ) ],
+					[ 'import', file ],
+				],
+			},
+			expect.any( Function )
+		);
+	} );
+} );

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -274,7 +274,7 @@ export const usePlanTypesWithIntent = ( {
 			planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
 			break;
 		case 'plans-playground':
-			planTypes = [ TYPE_BUSINESS, TYPE_ECOMMERCE ];
+			planTypes = [ TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
 			break;
 		case 'plans-playground-premium':
 			// This plan intent is currently not utilized but will be soon


### PR DESCRIPTION
This PR adds the new Playground flow:

1. Playground page: http://calypso.localhost:3000/setup/onboarding/playground
2. Cart: buy the site
3. The import is created on `/sites/${ siteId }/imports/new`
4. The media is saved in the site library, and the import is auto-started
6. The user is redirected to the new site

Previous flow was:

1. Playground page: http://calypso.localhost:3000/setup/onboarding/playground
2. Cart: buy the site
3. A new import is created by sending the .zip to `/sites/${ siteId }/imports/new`
4. The .zip is saved in the files blog
5. Calypso waits for the ok and starts the import and waits
7. The site is moved to WoA
8. The .zip is downloaded
9. The .zip is uploaded to the new WoA site
10. The import starts on the target machine
11. The user is redirected to the new site

## Proposed Changes

1. Auto-start
2. Imports start immediately instead of waiting for the importer page
3. Removed initial 5-second delay, not needed
4. Prevent fetch of `/me/sites`, slow for people with +10 sites and fetch only the needed
5. Removed launchpad, not needed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply 225213-ghe-Automattic/wpcom
* Visit http://calypso.localhost:3000/setup/onboarding/playground
* Buy a site, see PCYsg-IA-p2 on how to do it
* Wait for the process to finish
* Be sure the new site is ok

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?