### PR TITLE
Backups: show the file browser for aggregated entries

### DIFF
--- a/client/dashboard/sites/backups/backup-details.tsx
+++ b/client/dashboard/sites/backups/backup-details.tsx
@@ -151,7 +151,7 @@ export function BackupDetails( {
 							<ImagePreview item={ backup } />
 						) }
 					</Grid>
-					{ !! backup.object?.backup_period && (
+					{ !! backup.rewind_id && (
 						<div className="backup-details__file-browser">
 							<FileBrowser
 								key={ backup.rewind_id }

--- a/client/dashboard/sites/backups/backups-browser.tsx
+++ b/client/dashboard/sites/backups/backups-browser.tsx
@@ -1,25 +1,34 @@
+import { siteBackupActivityLogGroupCountsQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
 import { __experimentalGrid as Grid } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { useMemo } from 'react';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+import { useEffect, useMemo } from 'react';
+import { usePersistentView } from '../../app/hooks/use-persistent-view';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
 import { Card, CardBody } from '../../components/card';
 import { BackupDetails } from './backup-details';
 import { BackupDetailsSkeleton } from './backup-details-skeleton';
-import { BackupsList } from './backups-list';
+import { BackupsList, defaultView } from './backups-list';
+import { getFields } from './dataviews/fields';
 import { useActivityLog } from './use-activity-log';
 import type { ActivityLogEntry, Site } from '@automattic/api-core';
+import type { Field, View } from '@wordpress/dataviews';
 
 export function useIsBackupsSmallViewport() {
 	return useViewportMatch( 'xlarge', '<' );
 }
 
 // Single owner of the resolved selection so the page header and browser body can't disagree.
+// The view lives here too: the selection has to be resolved against the rows the list actually
+// renders, because DataViews drops any selection that isn't in the data it was handed.
 export function useBackupsBrowserState( {
 	site,
 	rewindId,
 	dateRange,
 	timezoneString,
 	gmtOffset,
+	searchParams,
 	enabled,
 }: {
 	site: Site;
@@ -27,11 +36,12 @@ export function useBackupsBrowserState( {
 	dateRange?: { start: Date; end: Date };
 	timezoneString?: string;
 	gmtOffset?: number;
+	searchParams?: Record< string, unknown >;
 	enabled?: boolean;
 } ) {
 	const isSmallViewport = useIsBackupsSmallViewport();
 
-	const { activityLog, isLoadingActivityLog } = useActivityLog( {
+	const { activityLog, isLoadingActivityLog, after, before } = useActivityLog( {
 		siteId: site.ID,
 		dateRange,
 		gmtOffset,
@@ -39,29 +49,67 @@ export function useBackupsBrowserState( {
 		enabled,
 	} );
 
+	const { view, updateView, resetView } = usePersistentView( {
+		slug: 'site-backups',
+		defaultView,
+		queryParams: searchParams,
+	} );
+
+	const { data: groupCountsData } = useQuery(
+		siteBackupActivityLogGroupCountsQuery( site.ID, after, before )
+	);
+
+	const fields = getFields( groupCountsData?.groups, timezoneString, gmtOffset );
+	const { data: filteredData, paginationInfo } = filterSortAndPaginate( activityLog, view, fields );
+
+	useEffect( () => {
+		updateView( { ...view, page: 1 } );
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- reset page only when dateRange changes
+	}, [ dateRange ] );
+
 	const selectedBackup = useMemo< ActivityLogEntry | null >( () => {
 		if ( rewindId ) {
-			return activityLog?.find( ( item ) => item.rewind_id === rewindId ) ?? null;
+			// Prefer a visible row so the list highlight and the details panel agree; `rewind_id`
+			// isn't a unique key across the aggregated activity log, so an unfiltered lookup can
+			// land on a sibling entry with a different `activity_id`.
+			return (
+				filteredData.find( ( item ) => item.rewind_id === rewindId ) ??
+				activityLog.find( ( item ) => item.rewind_id === rewindId ) ??
+				null
+			);
 		}
 		if ( ! isSmallViewport ) {
-			return activityLog?.[ 0 ] ?? null;
+			return filteredData[ 0 ] ?? null;
 		}
 		return null;
-	}, [ rewindId, activityLog, isSmallViewport ] );
+	}, [ rewindId, filteredData, activityLog, isSmallViewport ] );
 
-	return { activityLog, isLoadingActivityLog, selectedBackup, isSmallViewport };
+	return {
+		isLoadingActivityLog,
+		selectedBackup,
+		isSmallViewport,
+		view,
+		updateView,
+		resetView,
+		fields,
+		filteredData,
+		paginationInfo,
+	};
 }
 
 interface BackupsBrowserProps {
 	site: Site;
-	activityLog: ActivityLogEntry[];
 	isLoadingActivityLog: boolean;
 	selectedBackup: ActivityLogEntry | null;
 	isSmallViewport: boolean;
-	dateRange?: { start: Date; end: Date };
 	timezoneString?: string;
 	gmtOffset?: number;
-	searchParams?: Record< string, unknown >;
+	view: View;
+	updateView: ( view: View ) => void;
+	resetView?: () => void;
+	fields: Field< ActivityLogEntry >[];
+	filteredData: ActivityLogEntry[];
+	paginationInfo: { totalItems: number; totalPages: number };
 	onSelectBackup: ( backup: ActivityLogEntry | null ) => void;
 	onRequestRestore?: ( backup: ActivityLogEntry ) => void;
 	onRequestDownload?: ( backup: ActivityLogEntry ) => void;
@@ -70,14 +118,17 @@ interface BackupsBrowserProps {
 
 export function BackupsBrowser( {
 	site,
-	activityLog,
 	isLoadingActivityLog,
 	selectedBackup,
 	isSmallViewport,
-	dateRange,
 	timezoneString,
 	gmtOffset,
-	searchParams,
+	view,
+	updateView,
+	resetView,
+	fields,
+	filteredData,
+	paginationInfo,
 	onSelectBackup,
 	onRequestRestore,
 	onRequestDownload,
@@ -101,15 +152,15 @@ export function BackupsBrowser( {
 
 	const renderList = () => (
 		<BackupsList
-			siteId={ site.ID }
-			searchParams={ searchParams }
-			activityLog={ activityLog }
+			view={ view }
+			updateView={ updateView }
+			resetView={ resetView }
+			fields={ fields }
+			filteredData={ filteredData }
+			paginationInfo={ paginationInfo }
 			isLoadingActivityLog={ isLoadingActivityLog }
 			selectedBackup={ selectedBackup }
 			setSelectedBackup={ onSelectBackup }
-			dateRange={ dateRange }
-			timezoneString={ timezoneString }
-			gmtOffset={ gmtOffset }
 		/>
 	);
 

--- a/client/dashboard/sites/backups/backups-list.tsx
+++ b/client/dashboard/sites/backups/backups-list.tsx
@@ -1,16 +1,9 @@
-import { siteBackupActivityLogGroupCountsQuery } from '@automattic/api-queries';
-import { useQuery } from '@tanstack/react-query';
-import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useMemo } from 'react';
-import { usePersistentView } from '../../app/hooks/use-persistent-view';
 import { DataViews, DataViewsCard } from '../../components/dataviews';
-import { buildTimeRangeForActivityLog } from '../../utils/site-activity-log';
-import { getFields } from './dataviews/fields';
 import type { ActivityLogEntry } from '@automattic/api-core';
-import type { View } from '@wordpress/dataviews';
+import type { Field, View } from '@wordpress/dataviews';
 
-const defaultView: View = {
+export const defaultView: View = {
 	type: 'list',
 	fields: [ 'date', 'content_text' ],
 	mediaField: 'icon',
@@ -27,61 +20,30 @@ const defaultView: View = {
 };
 
 export function BackupsList( {
-	siteId,
-	searchParams,
+	view,
+	updateView,
+	resetView,
+	fields,
+	filteredData,
+	paginationInfo,
 	selectedBackup,
 	setSelectedBackup,
-	dateRange,
-	timezoneString,
-	gmtOffset,
-	activityLog,
 	isLoadingActivityLog,
 }: {
-	siteId: number;
-	searchParams?: Record< string, unknown >;
+	view: View;
+	updateView: ( view: View ) => void;
+	resetView?: () => void;
+	fields: Field< ActivityLogEntry >[];
+	filteredData: ActivityLogEntry[];
+	paginationInfo: { totalItems: number; totalPages: number };
 	selectedBackup: ActivityLogEntry | null;
 	setSelectedBackup: ( backup: ActivityLogEntry | null ) => void;
-	dateRange?: { start: Date; end: Date };
-	timezoneString?: string;
-	gmtOffset?: number;
-	activityLog: ActivityLogEntry[];
 	isLoadingActivityLog: boolean;
 } ) {
-	const { view, updateView, resetView } = usePersistentView( {
-		slug: 'site-backups',
-		defaultView,
-		queryParams: searchParams,
-	} );
-
-	const { after, before } = useMemo( () => {
-		if ( ! dateRange ) {
-			return { after: undefined, before: undefined };
-		}
-
-		return buildTimeRangeForActivityLog(
-			dateRange.start,
-			dateRange.end,
-			timezoneString,
-			gmtOffset
-		);
-	}, [ dateRange, timezoneString, gmtOffset ] );
-
-	const { data: groupCountsData } = useQuery(
-		siteBackupActivityLogGroupCountsQuery( siteId, after, before )
-	);
-
-	const fields = getFields( groupCountsData?.groups, timezoneString, gmtOffset );
-	const { data: filteredData, paginationInfo } = filterSortAndPaginate( activityLog, view, fields );
-
-	useEffect( () => {
-		updateView( { ...view, page: 1 } );
-		// eslint-disable-next-line react-hooks/exhaustive-deps -- reset page only when dateRange changes
-	}, [ dateRange ] );
-
 	const onChangeSelection = ( selection: string[] ) => {
 		const backup =
 			selection.length > 0
-				? activityLog.find( ( item ) => item.activity_id === selection[ 0 ] ) || null
+				? filteredData.find( ( item ) => item.activity_id === selection[ 0 ] ) || null
 				: null;
 		setSelectedBackup( backup );
 	};

--- a/client/dashboard/sites/backups/backups-page.tsx
+++ b/client/dashboard/sites/backups/backups-page.tsx
@@ -53,15 +53,25 @@ export function BackupsPage( {
 		defaultDays: 30,
 	} );
 
-	const { activityLog, isLoadingActivityLog, selectedBackup, isSmallViewport } =
-		useBackupsBrowserState( {
-			site,
-			rewindId,
-			dateRange,
-			timezoneString,
-			gmtOffset,
-			enabled: hasBackups,
-		} );
+	const {
+		isLoadingActivityLog,
+		selectedBackup,
+		isSmallViewport,
+		view,
+		updateView,
+		resetView,
+		fields,
+		filteredData,
+		paginationInfo,
+	} = useBackupsBrowserState( {
+		site,
+		rewindId,
+		dateRange,
+		timezoneString,
+		gmtOffset,
+		searchParams,
+		enabled: hasBackups,
+	} );
 	const isMobileDetailsView = isSmallViewport && !! selectedBackup;
 	const shouldShowActions = hasBackups && ! isMobileDetailsView;
 
@@ -118,14 +128,17 @@ export function BackupsPage( {
 			{ hasBackups ? (
 				<BackupsBrowser
 					site={ site }
-					activityLog={ activityLog }
 					isLoadingActivityLog={ isLoadingActivityLog }
 					selectedBackup={ selectedBackup }
 					isSmallViewport={ isSmallViewport }
-					dateRange={ dateRange }
 					timezoneString={ timezoneString }
 					gmtOffset={ gmtOffset }
-					searchParams={ searchParams }
+					view={ view }
+					updateView={ updateView }
+					resetView={ resetView }
+					fields={ fields }
+					filteredData={ filteredData }
+					paginationInfo={ paginationInfo }
 					onSelectBackup={ ( selected ) => navigation.selectBackup( selected?.rewind_id ?? null ) }
 					onRequestRestore={ ( selected ) => navigation.requestRestore( selected.rewind_id ) }
 					onRequestDownload={ ( selected ) => navigation.requestDownload( selected.rewind_id ) }

--- a/client/dashboard/sites/backups/test/index.test.tsx
+++ b/client/dashboard/sites/backups/test/index.test.tsx
@@ -53,6 +53,9 @@ jest.mock(
 					excludeList: [],
 					totalItems: 0,
 				} ),
+				getNode: () => undefined,
+				setNodeCheckState: jest.fn(),
+				addChildNodes: jest.fn(),
 			},
 			locale: 'en',
 			notices: {
@@ -135,6 +138,21 @@ const mockBackupEntries = [
 		name: 'rewind__backup_complete_full',
 		is_rewindable: true,
 	},
+	// An aggregated row: several activities bundled into one entry. It has a restore point but
+	// no `object.backup_period`, which only backup-complete entries carry.
+	{
+		activity_id: '6',
+		rewind_id: '1758967800.1234',
+		summary: 'Zeta images uploaded',
+		content: { text: 'Three images were uploaded' },
+		published: '2025-09-27T10:00:00Z',
+		name: 'attachment__uploaded',
+		is_rewindable: true,
+		streams: [
+			{ activity_id: '6a', rewind_id: '1758967800.1234' },
+			{ activity_id: '6b', rewind_id: '1758967800.1234' },
+		],
+	},
 ] as unknown as ActivityLogEntry[];
 
 const summaryTestCases: ReadonlyArray< readonly [ string, string ] > = [
@@ -142,12 +160,14 @@ const summaryTestCases: ReadonlyArray< readonly [ string, string ] > = [
 	[ 'rewind-456', 'Third backup completed successfully' ],
 ];
 
+const mockSearchParams: Record< string, unknown > = {};
+
 jest.mock( '../../../app/router/sites', () => ( {
 	siteRoute: {
 		useParams: () => ( { siteSlug: 'test-site' } ),
 	},
 	siteBackupsRoute: {
-		useSearch: () => ( {} ),
+		useSearch: () => mockSearchParams,
 	},
 } ) );
 
@@ -187,8 +207,24 @@ function renderBackupsListPage( {
 		.query( true )
 		.reply( 200, { calypso_preferences: {} } );
 
+	nock( API_BASE )
+		.persist()
+		.post( `/wpcom/v2/sites/${ mockSiteId }/rewind/backup/ls` )
+		.reply( 200, {
+			ok: true,
+			contents: {
+				wordpress: { type: 'wordpress', label: 'WordPress', has_children: false },
+				plugins: { type: 'dir', label: 'Plugins', has_children: true },
+				wp_options: { type: 'table', label: 'wp_options', has_children: false, row_count: 3 },
+			},
+		} );
+
 	return render( <BackupsListPage /> );
 }
+
+afterEach( () => {
+	Object.keys( mockSearchParams ).forEach( ( key ) => delete mockSearchParams[ key ] );
+} );
 
 test.each( summaryTestCases )(
 	'renders the details section correctly for rewindId %s',
@@ -201,3 +237,28 @@ test.each( summaryTestCases )(
 		} );
 	}
 );
+
+test( 'renders the file browser for an aggregated entry, which has no backup period', async () => {
+	mockRouterParams.rewindId = '1758967800.1234';
+	renderBackupsListPage();
+
+	await waitFor( () => {
+		expect( screen.getAllByText( 'Zeta images uploaded' ) ).toHaveLength( 2 );
+	} );
+
+	expect( await screen.findByText( 'WordPress' ) ).toBeVisible();
+	expect( await screen.findByText( 'wp_options' ) ).toBeVisible();
+	expect( screen.getByText( /files selected/ ) ).toBeVisible();
+} );
+
+test( 'selects the matching entry from the search results rather than the newest one', async () => {
+	mockRouterParams.rewindId = '';
+	mockSearchParams.search = 'Third backup';
+	renderBackupsListPage();
+
+	await waitFor( () => {
+		expect( screen.getAllByText( 'Third backup completed successfully' ) ).toHaveLength( 2 );
+	} );
+
+	expect( screen.queryByText( 'Zeta images uploaded' ) ).not.toBeInTheDocument();
+} );

--- a/client/dashboard/sites/backups/use-activity-log.ts
+++ b/client/dashboard/sites/backups/use-activity-log.ts
@@ -16,6 +16,8 @@ export interface UseActivityLogOptions {
 export interface UseActivityLogResult {
 	activityLog: ActivityLogEntry[];
 	isLoadingActivityLog: boolean;
+	after?: string;
+	before?: string;
 }
 
 /**
@@ -67,5 +69,7 @@ export function useActivityLog( {
 	return {
 		activityLog: queryResult.data ?? [],
 		isLoadingActivityLog: queryResult.isLoading,
+		after,
+		before,
 	};
 }


### PR DESCRIPTION
Fixes LIN-DOTMSD-761

## Proposed Changes

* `backup-details.tsx`: gate the granular file browser on `backup.rewind_id` instead of `backup.object?.backup_period`.
* `backups-browser.tsx` / `backups-list.tsx` / `backups-page.tsx`: move the DataViews view (`usePersistentView`, `getFields`, `filterSortAndPaginate`) into `useBackupsBrowserState`, and resolve the selected backup against the rows the list actually renders. `BackupsList` is now presentational.
* `use-activity-log.ts`: return the `after` / `before` it already computes, so the group-counts query reuses them instead of recomputing the same range.
* Two new tests, both verified to fail without the corresponding fix.

## Why are these changes being made?

**The file browser.** `object.backup_period` only exists on `rewind__backup_complete_*` entries. The list is fed by `siteBackupActivityLogEntriesQuery( …, aggregate: true, … )`, so `/activity/rewindable` returns aggregated rows — several activities bundled into one entry, carrying `streams` and a valid `rewind_id` but no backup period. Selecting one of those dropped the entire granular UI: no "N files selected" header, no WordPress / SQL / Plugins / Themes / Uploads tree, no checkboxes.

Nothing else in the panel was gated that way. The Download / Restore buttons already use `showActions && backup.rewind_id`, `FileBrowser` is driven by `Number( backup.rewind_id )`, and the `ls` endpoint takes `backup_id: rewindId` — `backup_period` was only ever a proxy for "this row is a backup event", so any row with a restore point is browsable.

Reported as a search-related bug, but searching was only how you reached such a row: the tree stays missing for the same row with the search cleared.

**The selection.** DataViews discards any selection id absent from the data it is handed (`_selection` in `@wordpress/dataviews`), but `useBackupsBrowserState` resolved the selection against the *unfiltered* activity log. With no `rewindId`, desktop fell back to `activityLog[0]` — the newest row overall, which a search almost always filters out — so searching left the details panel showing a row the list did not contain, with nothing highlighted. And because `rewind_id` is not a unique key across the aggregated log, an unfiltered lookup could land on a sibling entry with a different `activity_id`. The file's own comment already called it the "single owner of the resolved selection"; it just didn't own the view.

**Known limitation:** widening the gate means a rewind point the server cannot serve contents for renders an empty tree under the header. `file-browser-node.tsx` already carries a `@TODO: Add a message when the API fails to fetch` for that case; left as-is.

## Testing Instructions

Needs a site with real-time backups — aggregated rows only appear there.

1. Open `/v2/sites/<site>/backups`.
2. Find a row that bundles several activities (multiple thumbnails, or a count in the summary). Click it.
   * **Before:** the details panel ends after the image previews.
   * **After:** the "0 files selected" checkbox header and the WordPress / SQL / Plugins / Themes / Uploads tree render.
3. Tick a file — the buttons flip to "Download selected file" / "Restore selected file".
4. Search for a term matching a single older entry. That row should be highlighted in the left column and shown in the right column, both before and after clicking it.
5. Repeat below the `xlarge` breakpoint to check the mobile master/detail path.

Automated:

```
yarn test-client client/dashboard/sites/backups   # 16 passed
yarn eslint client/dashboard/sites/backups        # clean
yarn typecheck-client                             # clean
```

Note: the `Received the string \`true\` for the boolean attribute \`inert\`` console warning on this page is pre-existing and unrelated to this PR. It comes from `@wordpress/dataviews` (the list layout and footer pass `inert="true"` while loading) and from `SidebarExpandableMenuItem`; React 19 made `inert` a real boolean prop.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
