### PR TITLE
A4A Licenses: Adjust the "Manage in Pressable" link typography

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -47,7 +47,7 @@
 	&:active,
 	&:hover,
 	&:focus {
-		@include heading-medium;
+		font-size: $font-size-small;
 		color: var(--color-accent-80);
 	}
 }


### PR DESCRIPTION
The "Manage in Pressable" link on the Automattic for Agencies licenses list at `/purchases/licenses` styled itself with `@include heading-medium`. That mixin expands to four declarations: a font-family, `font-weight: 499`, `font-size: 13px` and `line-height: 20px`.

The link should be 12px, and it should not declare its own font-weight or line-height. Because those values arrived through a mixin rather than as individual declarations, there was no way to drop two of them while keeping the third.

This unrolls the mixin so the rule sets only `font-size: $font-size-small` (12px) and keeps the existing color. The `font-weight` and `line-height` declarations are gone rather than overridden, so both now inherit from `.license-preview`, which applies `body-medium`.

What that inheritance works out to:

- `line-height` is unchanged in practice. It inherits the same 20px the mixin was declaring.
- `font-weight` goes from 499 to 400. `$font-weight-medium: 499` is a deliberate trick to force a fallback to 400 instead of 600, so on a font without a 500 weight this renders identically. On a font that has one, the link will be a hair lighter.
- The mixin's font-family was redundant. `$font-family-headings` and `$font-family-body` are byte-identical stacks in `_variables.scss`, so dropping it changes nothing. No compensating declaration was added.

The rule lives on `.theme-a8c-for-agencies a.license-preview__product-pressable-link`. That class appears once in the codebase and its component has a single call site, so no shared rule was touched and nothing else is affected.

This was not visually verified in a browser, at the maintainer's request. `yarn stylelint` passes on the file. No tests: a font-size value in a leaf SCSS rule has no behavior to assert.

## Testing instructions

Prerequisites: an Automattic for Agencies account with at least one Pressable license.

1. Open `/purchases/licenses` and find a license row for a Pressable product.
2. Confirm the "Manage in Pressable" link renders at 12px.
3. Inspect the link and confirm its rule declares only `font-size` and `color`, with no `font-weight` or `line-height` of its own.
4. Hover and focus the link and confirm the size and color are the same as at rest.
