### PR TITLE
Emails: fix dead Continue button when the account email is on the purchased domain

### DIFF
--- a/client/dashboard/emails/add-mailbox/components/mailbox-form.tsx
+++ b/client/dashboard/emails/add-mailbox/components/mailbox-form.tsx
@@ -39,8 +39,16 @@ export const MailboxForm = ( {
 } ) => {
 	const { domainName } = useDomainFromUrlParam();
 
-	const [ isPasswordResetEmailVisible, setIsPasswordResetEmailVisible ] = useState( false );
+	const [ isPasswordResetEmailVisible, setIsPasswordResetEmailVisible ] = useState(
+		() => ! mailboxEntity.getFieldValue< string >( FIELD_PASSWORD_RESET_EMAIL )
+	);
 	const [ isPasswordVisible, setIsPasswordVisible ] = useState( false );
+
+	// Never leave this field collapsed while it holds an error, otherwise submit
+	// fails validation with nothing on screen to explain why.
+	const showPasswordResetEmailField =
+		isPasswordResetEmailVisible ||
+		Boolean( mailboxEntity.getFieldError( FIELD_PASSWORD_RESET_EMAIL ) );
 
 	const onRequestFieldValidation = ( field: MailboxFormFieldBase< string > ) =>
 		mailboxEntity.validateField( field.fieldName );
@@ -152,7 +160,7 @@ export const MailboxForm = ( {
 					onChange={ changeHandler }
 				/>
 
-				{ ! isPasswordResetEmailVisible && (
+				{ ! showPasswordResetEmailField && (
 					<Text variant="muted">
 						{ createInterpolateElement(
 							sprintf(
@@ -183,7 +191,7 @@ export const MailboxForm = ( {
 				) }
 			</VStack>
 
-			{ isPasswordResetEmailVisible && (
+			{ showPasswordResetEmailField && (
 				<MailboxInput
 					fieldName={ FIELD_PASSWORD_RESET_EMAIL }
 					mailboxEntity={ mailboxEntity }

--- a/client/dashboard/emails/hooks/use-create-new-mailbox.ts
+++ b/client/dashboard/emails/hooks/use-create-new-mailbox.ts
@@ -16,6 +16,11 @@ export const useCreateNewMailbox = ( {
 } ) => {
 	const { user } = useAuth();
 
+	// The password reset email must live on a different domain than the mailbox.
+	const passwordResetEmail = user.email?.toLowerCase().endsWith( `@${ domainName.toLowerCase() }` )
+		? ''
+		: user.email;
+
 	return () => {
 		const mailbox = new MailboxFormEntity< MailboxProvider >(
 			provider,
@@ -27,7 +32,7 @@ export const useCreateNewMailbox = ( {
 
 		// Set initial values
 		Object.entries( {
-			[ FIELD_PASSWORD_RESET_EMAIL ]: user.email,
+			[ FIELD_PASSWORD_RESET_EMAIL ]: passwordResetEmail,
 		} ).forEach( ( [ fieldName, value ] ) => {
 			mailbox.setFieldValue( fieldName as FormFieldNames, value );
 		} );


### PR DESCRIPTION
## Proposed Changes

* When the account's own email address is on the same domain the user is buying mailboxes for, stop pre-filling it as the password reset address and show the field so it can be filled in.
* Keep the password reset field expanded whenever it holds an error, instead of hiding the error along with the field.

## Why are these changes being made?

A mailbox needs a password reset address on a different domain than the mailbox itself. The form pre-fills it from the account's WordPress.com email and hides it behind a "Change it" link. So when the account email is on the domain being purchased, submit fails validation against a field that isn't on screen.

The user gets a Continue button that does nothing: no cart, no error, no way to work out why. It affects both Google Workspace and Professional Email, which share this form. The classic flow already guards against this.

## Testing Instructions

The bug only shows up when the account email is on the purchased domain, so the quickest way to see it is to force that condition. In `client/dashboard/emails/hooks/use-create-new-mailbox.ts`, temporarily set the initial password reset value to `` `${ user.email.split( '@' )[ 0 ] }@${ domainName }` ``.

Before (on trunk, with that tweak):

1. Go to `/emails/add-mailbox/<your-domain>/google_workspace/annually`.
2. Fill in first name, last name, mailbox, and a password of at least 12 characters.
3. Click **Continue**. Nothing happens, and nothing on the page explains why.

After (on this branch, with the same tweak):

1. Same page. The **Password reset email address** field is now visible and empty rather than collapsed.
2. Enter an address on any other domain and click **Continue**. The mailbox is added to the cart and checkout opens.
3. Enter an address on the purchased domain instead. The field stays visible and explains that a different domain is required.

Also worth confirming nothing changed for the normal case: with an account email on an unrelated domain, the reset address is still pre-filled and still collapsed behind "Change it".

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
