### PR TITLE
Themes: find the Twenty * themes when searching by year

### DIFF
--- a/client/my-sites/themes/search-results-modern/index.tsx
+++ b/client/my-sites/themes/search-results-modern/index.tsx
@@ -72,7 +72,7 @@ export default function SearchResultsModern( {
 	// Get wpcom themes.
 	const {
 		getPrice,
-		themes: wpcomThemes,
+		themes: allWpcomThemes,
 		isActive,
 		isInstalling,
 		isLivePreviewStarted,
@@ -82,6 +82,14 @@ export default function SearchResultsModern( {
 		filterString,
 		getThemeDetailsUrl,
 	} = useThemeCollection( wpcomQuery );
+
+	// The themes endpoint returns retired themes whenever there is a search term, so that a
+	// theme retired on wpcom still takes precedence over its wporg counterpart. They are not
+	// activatable, so drop them here as `interlaceThemes` does for the classic showcase.
+	const wpcomThemes = useMemo(
+		() => allWpcomThemes.filter( ( theme: Theme ) => ! theme.retired ),
+		[ allWpcomThemes ]
+	);
 
 	// Get wporg themes from Redux.
 	const wporgThemes: Theme[] =

--- a/client/state/themes/actions/request-themes.js
+++ b/client/state/themes/actions/request-themes.js
@@ -8,6 +8,7 @@ import { receiveThemes } from 'calypso/state/themes/actions/receive-themes';
 import { getThemeTier, prependThemeFilterKeys } from 'calypso/state/themes/selectors';
 import {
 	normalizeJetpackTheme,
+	normalizeThemeSearchTerm,
 	normalizeWpcomTheme,
 	normalizeWporgTheme,
 } from 'calypso/state/themes/utils';
@@ -40,17 +41,24 @@ export function requestThemes( siteId, query = {}, locale ) {
 			query,
 		} );
 
+		// Only the outgoing request sees the rewritten search term. Everything keyed on
+		// `query` — the Redux cache, the search box, the tracks payload — stays on what
+		// the user actually typed.
+		const requestQuery = query.search
+			? { ...query, search: normalizeThemeSearchTerm( query.search ) }
+			: query;
+
 		let request;
 
 		if ( siteId === 'wporg' ) {
-			request = () => fetchWporgThemesList( query );
+			request = () => fetchWporgThemesList( requestQuery );
 		} else if ( siteId === 'wpcom' ) {
 			request = () =>
 				wpcom.req.get(
 					'/themes',
 					Object.assign(
 						{
-							...query,
+							...requestQuery,
 							apiNamespace: 'wpcom/v2',
 							// We should keep the blank-canvas-3 stay hidden according to below discussion
 							// https://github.com/Automattic/wp-calypso/issues/71911#issuecomment-1381284172
@@ -66,7 +74,8 @@ export function requestThemes( siteId, query = {}, locale ) {
 					)
 				);
 		} else if ( isAtomic || isJetpack ) {
-			request = () => wpcom.req.get( `/sites/${ siteId }/themes`, { ...query, apiVersion: '1' } );
+			request = () =>
+				wpcom.req.get( `/sites/${ siteId }/themes`, { ...requestQuery, apiVersion: '1' } );
 		} else {
 			request = () =>
 				wpcom.req.get( `/sites/${ siteId }/themes/activation-history`, {

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -236,6 +236,34 @@ describe( 'actions', () => {
 			} );
 		} );
 
+		describe( 'with a year search term', () => {
+			let requestedQuery;
+			useNock( ( nock ) => {
+				requestedQuery = undefined;
+				nock( 'https://public-api.wordpress.com:443' )
+					.get( '/wpcom/v2/themes' )
+					.query( ( query ) => {
+						requestedQuery = query;
+						return true;
+					} )
+					.reply( 200, {
+						found: 1,
+						themes: [ { ID: 'twentyeleven', name: 'Twenty Eleven' } ],
+					} );
+			} );
+
+			test( 'should search the API for the default theme slug released that year, while keeping the typed term in state', async () => {
+				await requestThemes( 'wpcom', { search: '2011' } )( spy, getState );
+
+				expect( requestedQuery.search ).toBe( 'twentyeleven' );
+				expect( spy ).toHaveBeenCalledWith( {
+					type: THEMES_REQUEST,
+					siteId: 'wpcom',
+					query: { search: '2011' },
+				} );
+			} );
+		} );
+
 		describe( 'with a Jetpack site', () => {
 			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )

--- a/client/state/themes/test/utils.js
+++ b/client/state/themes/test/utils.js
@@ -4,6 +4,7 @@ import {
 	normalizeWpcomTheme,
 	normalizeWporgTheme,
 	getNormalizedThemesQuery,
+	normalizeThemeSearchTerm,
 	getSerializedThemesQuery,
 	getDeserializedThemesQueryDetails,
 	getSerializedThemesQueryWithoutPage,
@@ -147,6 +148,44 @@ describe( 'utils', () => {
 				},
 				theme_tier: { slug: 'community' },
 			} );
+		} );
+	} );
+
+	describe( '#normalizeThemeSearchTerm()', () => {
+		test( 'should rewrite a year to the default theme slug released that year', () => {
+			expect( normalizeThemeSearchTerm( '2011' ) ).toBe( 'twentyeleven' );
+			expect( normalizeThemeSearchTerm( '2010' ) ).toBe( 'twentyten' );
+			expect( normalizeThemeSearchTerm( '2019' ) ).toBe( 'twentynineteen' );
+			expect( normalizeThemeSearchTerm( '2020' ) ).toBe( 'twentytwenty' );
+			expect( normalizeThemeSearchTerm( '2024' ) ).toBe( 'twentytwentyfour' );
+			expect( normalizeThemeSearchTerm( '2029' ) ).toBe( 'twentytwentynine' );
+		} );
+
+		test( 'should rewrite a year appearing alongside other terms', () => {
+			expect( normalizeThemeSearchTerm( '2011 dark' ) ).toBe( 'twentyeleven dark' );
+			expect( normalizeThemeSearchTerm( 'dark 2011' ) ).toBe( 'dark twentyeleven' );
+		} );
+
+		test( 'should leave years outside the naming scheme alone', () => {
+			expect( normalizeThemeSearchTerm( '2009' ) ).toBe( '2009' );
+			expect( normalizeThemeSearchTerm( '2030' ) ).toBe( '2030' );
+			expect( normalizeThemeSearchTerm( '1999' ) ).toBe( '1999' );
+		} );
+
+		test( 'should only rewrite whole terms', () => {
+			expect( normalizeThemeSearchTerm( 'theme2011' ) ).toBe( 'theme2011' );
+			expect( normalizeThemeSearchTerm( '20111' ) ).toBe( '20111' );
+		} );
+
+		test( 'should pass other search terms through untouched', () => {
+			expect( normalizeThemeSearchTerm( 'twentyeleven' ) ).toBe( 'twentyeleven' );
+			expect( normalizeThemeSearchTerm( 'twenty eleven' ) ).toBe( 'twenty eleven' );
+			expect( normalizeThemeSearchTerm( 'blog' ) ).toBe( 'blog' );
+		} );
+
+		test( 'should pass empty search terms through untouched', () => {
+			expect( normalizeThemeSearchTerm( '' ) ).toBe( '' );
+			expect( normalizeThemeSearchTerm( undefined ) ).toBeUndefined();
 		} );
 	} );
 

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -21,6 +21,34 @@ const DELISTED_TAXONOMY_TERM_SLUGS = [ 'auto-loading-homepage' ];
 // directly from wp.org, which is why they cannot be removed in the endpoint payload.
 const DELISTED_WPORG_THEMES = [ 'shopline', 'store-shopline' ];
 
+// Word forms used to spell out a year the way WordPress names its default themes:
+// `twenty` + a teens word for 2010-2019, `twentytwenty` + a ones word for 2020-2029.
+const YEAR_TEENS_WORDS = [
+	'ten',
+	'eleven',
+	'twelve',
+	'thirteen',
+	'fourteen',
+	'fifteen',
+	'sixteen',
+	'seventeen',
+	'eighteen',
+	'nineteen',
+];
+const YEAR_ONES_WORDS = [
+	'',
+	'one',
+	'two',
+	'three',
+	'four',
+	'five',
+	'six',
+	'seven',
+	'eight',
+	'nine',
+];
+const REGEXP_YEAR = /\b(20[12]\d)\b/g;
+
 /**
  * Utility
  */
@@ -125,6 +153,49 @@ export function normalizeWporgTheme( theme, tier ) {
 			} ) ),
 		},
 	};
+}
+
+/**
+ * Returns the slug of the WordPress default theme released in a given year,
+ * e.g. 2011 -> 'twentyeleven', 2024 -> 'twentytwentyfour'.
+ *
+ * Only the naming scheme is encoded here, not which themes exist: 2018 yields
+ * 'twentyeighteen' even though WordPress shipped no default theme that year, and
+ * years map ahead of a theme's release. Those simply find nothing, as today.
+ * @param  {number} year Four-digit year
+ * @returns {?string}     Theme slug, or null for years outside the naming scheme
+ */
+function getDefaultThemeSlugForYear( year ) {
+	if ( year >= 2010 && year <= 2019 ) {
+		return `twenty${ YEAR_TEENS_WORDS[ year - 2010 ] }`;
+	}
+
+	if ( year >= 2020 && year <= 2029 ) {
+		return `twentytwenty${ YEAR_ONES_WORDS[ year - 2020 ] }`;
+	}
+
+	return null;
+}
+
+/**
+ * Rewrites year terms in a theme search string to the slug of the default theme
+ * released that year, so that searching "2011" finds Twenty Eleven.
+ *
+ * The WPCOM theme search index holds no year keyword for the Twenty * themes, so
+ * every year term returns zero results on its own. This is applied to the outgoing
+ * request only; callers keep displaying and caching against what the user typed.
+ * @param  {string} search Search string
+ * @returns {string}        Search string with year terms replaced by theme slugs
+ */
+export function normalizeThemeSearchTerm( search ) {
+	if ( ! search ) {
+		return search;
+	}
+
+	return search.replace(
+		REGEXP_YEAR,
+		( year ) => getDefaultThemeSlugForYear( Number( year ) ) ?? year
+	);
 }
 
 /**

--- a/client/types.ts
+++ b/client/types.ts
@@ -42,6 +42,7 @@ export interface Theme {
 	popularity_rank: string;
 	product_details?: MarketplaceThemeProductDetails[];
 	preview_url: string;
+	retired?: boolean;
 	screenshot: string;
 	screenshots: string[];
 	style_variations: StyleVariation[];


### PR DESCRIPTION
Fixes #94312
Fixes DOTCOM-12284

## Proposed Changes

* Add `normalizeThemeSearchTerm()` in `client/state/themes/utils.js`, which rewrites a standalone four-digit year in a theme search string to the slug of the default theme WordPress released that year (`2011` → `twentyeleven`, `2024` → `twentytwentyfour`). The slug is derived from the naming scheme rather than a hardcoded table, so no entry has to be added when the next default theme ships.
* Apply it in `requestThemes()` to the **outgoing request only**. `THEMES_REQUEST`, `receiveThemes()`, and the `calypso_themeshowcase_search` payload keep the original `query`, so the Redux cache key, the search box, the `Results for "2011"` heading, and the reported `search_term` all continue to use what the user typed. One chokepoint covers the modern logged-out showcase, the classic showcase, WP.org community results, and Jetpack/Atomic site searches.
* Drop retired themes from `SearchResultsModern`, mirroring what `interlaceThemes()` already does for the classic showcase (`client/my-sites/themes/helpers.js`).
* Add `retired?: boolean` to the `Theme` interface — the endpoint already returns it and `interlaceThemes()` already reads it, but it was missing from the type.
* Unit tests for the rewrite, plus a `requestThemes()` test asserting the request carries `search=twentyeleven` while state stays keyed on `2011`.

## Why are these changes being made?

Searching the showcase for `2011` returned "No themes found" instead of Twenty Eleven.

The cause is server side, not in Calypso's query building — the `s=` param is passed through untouched. The WPCOM theme search index holds no year keyword for the `Twenty *` themes:

| request | found |
| --- | --- |
| `wpcom/v2/themes?search=2011&filter=blog` | **0** |
| `wpcom/v2/themes?search=twentyeleven&filter=blog` | 1 — `twentyeleven` |

This is not limited to 2011 and 2012 as the original report guessed: **every** year from 2010 through 2025 returns zero results. Notably, the WP.org API *does* match `2011` → `twentyeleven`, so the two sources disagree.

The proper long-term fix is to index the release year as a searchable keyword for these themes, but that lives outside this repo. The rewrite here is a self-contained, testable client-side alias that makes year searches work today, and it becomes a harmless no-op if the index is fixed later.

Two intentional non-cases in the year → slug mapping: 2018 maps to `twentyeighteen`, which does not exist because WordPress shipped no default theme that year, and future years map ahead of a theme's release. Both return nothing, which is exactly today's behaviour, so neither is a regression.

The retired-theme filter is needed for the fix to look right rather than being a separate cleanup. `requestThemes()` deliberately asks the endpoint to include retired themes whenever there is a search term, and the classic showcase filters them back out in `interlaceThemes()`. `SearchResultsModern` never got that filter, and `wpcom/v2/themes?search=twentyeleven` returns retired `duster` ahead of `twentyeleven` — so without it, searching `2011` would surface a retired theme above the one being looked for.

### Note on the report's second symptom

The original report also noted that `blog` + `twenty eleven` returned nothing. That no longer reproduces — `search=twenty+eleven&filter=blog` now returns `twentyeleven` as the first of five results, so it appears to have been fixed server side since the report was filed.

### Adjacent bug found while investigating, not fixed here

The WP.org "Community themes" query concatenates the active filter slugs onto the search string — `search: \`${ search } ${ filter… }\`` in `client/my-sites/themes/search-results-modern/index.tsx` and `client/my-sites/themes/themes-selection.jsx`. WP.org treats that as free text, so `search=2011 blog` returns 0 where `search=2011` returns `twentyeleven`. The effect is that `/themes/filter/<anything>?s=X` silently returns zero community themes for every search, while `/themes?s=X` works. WP.org has a real `tag` parameter for this. It is left out of this PR to keep the change reviewable, and is worth a separate issue.

## Testing Instructions

Run the tests:

```
yarn test-client client/state/themes
yarn typecheck-client
```

Then, logged out (`themes/showcase-modern` is enabled for logged-out users):

1. Load `/themes/filter/blog?s=2011`. **Before:** "No themes found". **After:** a `Results for "2011"` section containing Twenty Eleven.
2. Confirm the URL and the search box still read `2011`, and the heading still says `Results for "2011"` — the rewrite must not leak into the UI.
3. From `/themes/blog`, type `2011` in the search box and press Enter. Twenty Eleven is returned.
4. Spot-check other years: `?s=2020` (Twenty Twenty first), `?s=2024` (Twenty Twenty-Four).
5. Confirm `/themes?s=2011` does not list retired "Duster" above Twenty Eleven.
6. Regression check — these should behave exactly as before: `?s=blog`, `?s=twenty eleven`, `?s=twentyeleven`, an empty search, and `/themes/filter/blog` with no search.
7. Logged in (classic showcase): `/themes?s=2011` and `/themes/filter/blog?s=2011` both surface Twenty Eleven.
8. In the network panel, confirm the outgoing `/wpcom/v2/themes` request carries `search=twentyeleven` while Redux state stays keyed on `2011` — no duplicate query buckets and no refetch loop.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
