### PR TITLE
Blueprint onboarding: show only paid plans on the plans step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/test/get-plans-intent.test.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/test/get-plans-intent.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { PLAN_UPGRADE_FLOW } from '@automattic/onboarding';
+import { ONBOARDING_FLOW, PLAN_UPGRADE_FLOW } from '@automattic/onboarding';
 import { getPlansIntent } from '../util/get-plans-intent';
 
 describe( 'getPlansIntent', () => {
@@ -11,6 +11,17 @@ describe( 'getPlansIntent', () => {
 
 	it( 'maps the ai-site-builder-onboarding flow to the four paid plans intent', () => {
 		expect( getPlansIntent( 'ai-site-builder-onboarding' ) ).toBe( 'plans-ai-assembler-paid-only' );
+	} );
+
+	describe( 'onboarding flow blueprint variation', () => {
+		it( 'maps to the four paid plans intent when a blueprint param is present', () => {
+			window.history.replaceState( {}, '', '/?blueprint=coachava' );
+			expect( getPlansIntent( ONBOARDING_FLOW ) ).toBe( 'plans-ai-assembler-paid-only' );
+		} );
+
+		it( 'does not force the paid-only intent for a plain onboarding flow', () => {
+			expect( getPlansIntent( ONBOARDING_FLOW ) ).toBeNull();
+		} );
 	} );
 
 	describe( 'plan-upgrade flow (dashboard "Change plan" downgrade entry point)', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-plans-intent.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-plans-intent.ts
@@ -38,6 +38,13 @@ export function getPlansIntent( flowName: string | null ): PlansIntent | null {
 		case AI_SITE_BUILDER_ONBOARDING_FLOW:
 			return 'plans-ai-assembler-paid-only';
 		case ONBOARDING_FLOW:
+			// The blueprint variation (/setup/onboarding/blueprint) offers paid plans
+			// only — Personal, Premium, Business, Commerce — to match the blueprint
+			// archive it builds from. Reuse the AI-site-builder intent purely for that
+			// plan-tier set (it carries no other AI-assembler behavior).
+			if ( search.has( 'blueprint' ) ) {
+				return 'plans-ai-assembler-paid-only';
+			}
 			if ( search.has( 'playground' ) ) {
 				return playgroundPlansIntent( search.get( 'playground' )! );
 			}


### PR DESCRIPTION
## Why

Related to BLU-9

In the blueprint variation of the `onboarding` flow (`/setup/onboarding/blueprint`), the user is building a WoA site from a pre-built blueprint archive, so the **Free** plan isn't a meaningful choice. The plans step currently shows the full grid (Free + Personal + Premium + Business + Commerce + Enterprise).

This limits it to **Personal, Premium, Business, Commerce** — matching the AI-site-builder onboarding plans page (`/setup/ai-site-builder-onboarding/plans`).

## What

One line in `get-plans-intent.ts`: in the `ONBOARDING_FLOW` case, when the `blueprint` query param is present, return `plans-ai-assembler-paid-only`.

- That intent resolves to `[ PERSONAL, PREMIUM, BUSINESS, ECOMMERCE ]` in `plans-grid-next`'s `use-grid-plans` — no Free, no Enterprise.
- It's reused **only** for its plan-tier set; it's referenced in exactly one behavioral spot (the tier list), so no AI-assembler copy or side effects come along.
- Detection via `search.has('blueprint')` mirrors the existing `search.has('playground')` check in the same function. `customNavigate` preserves the `blueprint` query param across `blueprint → domains → plans`, so it's reliably present at the plans step.

## Testing

- `get-plans-intent.test.ts`: 6 passing (4 existing + 2 new — blueprint param present → paid-only; plain onboarding → null).
- eslint clean.

Behind the existing `themes/blueprint-cta` gating for the overall flow; no flag of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)