### PR TITLE
Billing: fix empty cancellation survey for Google Workspace removals

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -14,7 +14,7 @@ import { getSolutionsForReason } from '../get-solutions-for-reason';
 import { useIsSplitCancelRemoveEnabled } from '../use-is-split-cancel-remove-enabled';
 import { AtomicRevertStep } from './step-components/atomic-revert-step';
 import EducationContentStep from './step-components/educational-content-step';
-import FeedbackStep from './step-components/feedback-step';
+import FeedbackStep, { shouldShowCancellationReason } from './step-components/feedback-step';
 import JetpackCancellationOfferStep from './step-components/jetpack-cancellation-offer-step';
 import NextAdventureStep from './step-components/next-adventure-step';
 import SolutionsCardsUpsellStep from './step-components/solutions-cards-upsell-step';
@@ -489,6 +489,12 @@ function canGoToNextStep( {
 	}
 
 	if ( surveyStep === FEEDBACK_STEP ) {
+		// Nothing to answer, so nothing to wait for. Without this the step would
+		// render empty and leave the user unable to continue.
+		if ( ! shouldShowCancellationReason( purchase ) ) {
+			return true;
+		}
+
 		if ( isImport && ! importQuestionRadio ) {
 			return false;
 		}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/options-for-product.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/options-for-product.ts
@@ -1,4 +1,3 @@
-import { isGSuiteOrGoogleWorkspaceProductSlug } from '../../../../utils/purchase';
 import {
 	CANCELLATION_REASONS,
 	DOMAIN_TRANSFER_CANCELLATION_REASONS,
@@ -9,7 +8,7 @@ import {
 import type { Purchase } from '@automattic/api-core';
 
 export const cancellationOptionsForPurchase = ( purchase: Purchase ) => {
-	if ( isGSuiteOrGoogleWorkspaceProductSlug( purchase?.product_slug ) ) {
+	if ( purchase.is_google_workspace_product ) {
 		return [
 			...GSUITE_CANCELLATION_REASONS.map( ( { value } ) => value ),
 			'downgradeToAnotherPlan',

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/feedback-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/feedback-step.tsx
@@ -157,6 +157,13 @@ function ImportQuestion( { onChange }: { onChange?: ChangeCallback } ) {
 	);
 }
 
+// Must stay in sync with the survey step routing in cancel-purchase/index.tsx.
+export function shouldShowCancellationReason( purchase: Purchase ): boolean {
+	return (
+		purchase.is_plan || purchase.is_google_workspace_product || purchase.is_domain_registration
+	);
+}
+
 type FeedbackStepProps = {
 	purchase: Purchase;
 	plans: PlanProduct[];
@@ -178,10 +185,7 @@ export default function FeedbackStep( {
 	onChangeCancellationReasonDetails,
 	onChangeImportFeedback,
 }: FeedbackStepProps ) {
-	const isPlanPurchase = purchase.is_plan;
-	const isGSuite = purchase.is_google_workspace_product;
-	const isDomain = purchase.is_domain_registration;
-	const showCancellationReason = isPlanPurchase || isGSuite || isDomain;
+	const showCancellationReason = shouldShowCancellationReason( purchase );
 
 	return (
 		<VStack spacing={ 6 }>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/test/index.test.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/test/index.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import { render } from '../../../../../test-utils';
+import CancelPurchaseForm from '../index';
+import { FEEDBACK_STEP, NEXT_ADVENTURE_STEP } from '../steps';
+import type { Purchase } from '@automattic/api-core';
+
+function makePurchase( overrides: Partial< Purchase > = {} ): Purchase {
+	return {
+		ID: 123,
+		product_name: 'WordPress.com Business',
+		product_slug: 'business-bundle',
+		is_plan: true,
+		is_domain_registration: false,
+		is_jetpack_plan_or_product: false,
+		meta: '',
+		domain: 'example.com',
+		blog_id: 1,
+		...overrides,
+	} as Purchase;
+}
+
+const noop = () => {};
+const defaultProps = {
+	isVisible: true,
+	intent: 'remove' as const,
+	surveyStep: FEEDBACK_STEP,
+	allSteps: [ FEEDBACK_STEP ],
+	plans: [],
+	siteSlug: 'example.com',
+	questionOneOrder: [],
+	offerDiscountBasedFromPurchasePrice: 0,
+	atomicRevertOnClickCheckOne: noop,
+	atomicRevertOnClickCheckTwo: noop,
+	onGetCancellationOffer: noop,
+	onImportRadioChange: noop,
+	onRadioOneChange: noop,
+	onTextOneChange: noop,
+};
+
+describe( '<CancelPurchaseForm />', () => {
+	test( 'asks for a cancellation reason for a Google Workspace purchase', () => {
+		render(
+			<CancelPurchaseForm
+				{ ...defaultProps }
+				allSteps={ [ FEEDBACK_STEP, NEXT_ADVENTURE_STEP ] }
+				purchase={ makePurchase( {
+					product_name: 'Google Workspace Business Starter',
+					product_slug: 'wp_google_workspace_business_starter_yearly',
+					is_plan: false,
+					is_google_workspace_product: true,
+					meta: 'example.com',
+				} ) }
+				questionOneOrder={ [ 'doNotNeedIt', 'purchasedByMistake' ] }
+			/>
+		);
+
+		expect( screen.getByRole( 'radio', { name: 'I purchased it by mistake.' } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Continue removal' } ) ).toBeDisabled();
+	} );
+
+	test( 'enables the next step once a Google Workspace reason is selected', () => {
+		render(
+			<CancelPurchaseForm
+				{ ...defaultProps }
+				allSteps={ [ FEEDBACK_STEP, NEXT_ADVENTURE_STEP ] }
+				purchase={ makePurchase( {
+					product_name: 'Google Workspace Business Starter',
+					product_slug: 'wp_google_workspace_business_starter_yearly',
+					is_plan: false,
+					is_google_workspace_product: true,
+					meta: 'example.com',
+				} ) }
+				questionOneOrder={ [ 'doNotNeedIt', 'purchasedByMistake' ] }
+				questionOneRadio="purchasedByMistake"
+			/>
+		);
+
+		expect( screen.getByRole( 'button', { name: 'Continue removal' } ) ).toBeEnabled();
+	} );
+
+	test( 'does not block the removal when the step has no question to answer', () => {
+		render(
+			<CancelPurchaseForm
+				{ ...defaultProps }
+				purchase={ makePurchase( {
+					product_name: 'Jetpack VaultPress Backup',
+					product_slug: 'jetpack_backup_t1_yearly',
+					is_plan: false,
+					is_jetpack_plan_or_product: true,
+				} ) }
+			/>
+		);
+
+		expect( screen.queryByRole( 'radio' ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Complete removal' } ) ).toBeEnabled();
+	} );
+} );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -63,7 +63,6 @@ import {
 	hasQueryableSite,
 	isAgencyPartnerType,
 	isRemoved,
-	isGSuiteOrGoogleWorkspaceProductSlug,
 	isJetpackHoldingSitePurchase,
 	isAkismetProduct,
 	isPartnerPurchase,
@@ -324,7 +323,7 @@ function getBasicSurveySteps( {
 	if ( purchase.is_domain_registration ) {
 		return [ FEEDBACK_STEP, NEXT_ADVENTURE_STEP ];
 	}
-	if ( ! isGSuiteOrGoogleWorkspaceProductSlug( purchase.product_slug ) && ! purchase.is_plan ) {
+	if ( ! purchase.is_google_workspace_product && ! purchase.is_plan ) {
 		return [ NEXT_ADVENTURE_STEP ];
 	}
 	if ( upsell && ! hasBeenRemoved && ! isDowngradePlan ) {


### PR DESCRIPTION
Closes CHE-523

## Proposed Changes

* `feedback-step.tsx`: decide whether to render the cancellation-reason question from the product slug (`isGSuiteOrGoogleWorkspaceProductSlug`) rather than from `purchase.is_google_workspace_product`. Extracted as an exported `shouldShowCancellationReason( purchase )` so both callers share one source of truth.
* `cancel-purchase-form/index.tsx`: `canGoToNextStep()` no longer requires an answer on the feedback step when that step renders no question.
* `utils/purchase.ts`: same slug-based check for the "Mailboxes and Productivity Tools at %(domain)s" subtitle, which was silently falling through on the same flag. This matches Classic, which uses the slug helper in `client/me/purchases/lib/raw-purchase-helpers.ts`.
* Added `cancel-purchase-form/test/index.test.tsx` covering both dead ends.

## Why are these changes being made?

Removing a Google Workspace subscription dead-ends: the survey renders "Before you go, please answer a few quick questions to help us improve.", no questions below it, and a permanently disabled "Continue removal" button.

Two gates disagreed about what counts as a Google Workspace purchase:

1. The survey step list (`cancel-purchase/index.tsx`) routes a purchase into `FEEDBACK_STEP` based on the **product slug**, so Google Workspace lands there.
2. `FeedbackStep` decided whether to draw any question from the **API boolean** `purchase.is_google_workspace_product`. Google Workspace purchases have `is_plan === false` and `is_domain_registration === false`, so when that flag is falsy nothing renders.
3. `canGoToNextStep()` then gates the primary button on `questionOneRadio`, which can only be set by a radio that was never rendered.

`is_google_workspace_product` is read in only two places in the whole repo and has no equivalent in Classic, which uses the slug helpers throughout. Keying everything off the slug removes the possibility of the two gates drifting.

This also fixes a second instance of the same dead end: Jetpack products that are not plans (e.g. `jetpack_backup_t1_yearly`) are routed to `FEEDBACK_STEP` by `availableJetpackSurveySteps()` and render no question either, leaving "Complete removal" disabled (users could only escape via "Skip and remove").

## Testing Instructions

1. `yarn start-dashboard`.
2. Go to a Google Workspace purchase and start a removal: `/me/billing/purchases/{purchaseId}/cancel?intent=remove`.
3. Before: the survey heading renders with empty space below it and "Continue removal" is disabled with no way to enable it.
4. After: "Why would you like to remove?" renders with the Google Workspace reasons plus "Another reason...", and "Continue removal" enables once a reason is selected.
5. Repeat with `?intent=cancel` and confirm the label reads "Why would you like to cancel?".
6. Regression check a plan and a domain registration removal, which already worked, and a Jetpack product (e.g. VaultPress Backup) where "Complete removal" should no longer be disabled.
7. `yarn test-client client/dashboard/me/billing-purchases/cancel-purchase`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
