### PR TITLE
E2E: harden Atomic private setup

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -373,6 +373,17 @@ export class EditorPage {
 		type: 'post' | 'page' = 'post',
 		{ siteSlug = '' }: { siteSlug?: string } = {}
 	): Promise< Response | null > {
+		if ( envVariables.TEST_ON_ATOMIC && envVariables.ATOMIC_VARIATION === 'private' && siteSlug ) {
+			const siteHost = siteSlug.replace( /^https?:\/\//, '' ).replace( /\/$/, '' );
+
+			// Private Atomic sites can show Jetpack SSO when wp-admin is opened directly.
+			await this.page.goto( `https://${ siteHost }/wp-admin/`, {
+				timeout: 15 * 1000,
+				waitUntil: 'domcontentloaded',
+				referer: 'https://wordpress.com/',
+			} );
+		}
+
 		const request = await this.page.goto( getCalypsoURL( `${ type }/${ siteSlug }` ), {
 			timeout: 30 * 1000,
 			waitUntil: 'domcontentloaded',

--- a/test/e2e/specs/blocks/blocks__jetpack-forms.spec.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-forms.spec.ts
@@ -2,6 +2,7 @@ import {
 	AllFormFieldsFlow,
 	BlockFlow,
 	ContactFormFlow,
+	envVariables,
 	FormAiFlow,
 	FormPatternsFlow,
 } from '@automattic/calypso-e2e';
@@ -32,7 +33,12 @@ const blockFlows: BlockFlow[] = [
 	} ),
 ];
 
-createBlockTests( 'Blocks: Jetpack Forms', blockFlows, [
-	tags.GUTENBERG,
-	tags.JETPACK_WPCOM_INTEGRATION,
-] );
+createBlockTests(
+	'Blocks: Jetpack Forms',
+	blockFlows,
+	[ tags.GUTENBERG, tags.JETPACK_WPCOM_INTEGRATION ],
+	{
+		condition: envVariables.TEST_ON_ATOMIC && envVariables.ATOMIC_VARIATION === 'private',
+		reason: 'Forms block smoke test requires a public Atomic site',
+	}
+);

--- a/test/e2e/specs/blocks/blocks__media.spec.ts
+++ b/test/e2e/specs/blocks/blocks__media.spec.ts
@@ -67,7 +67,7 @@ test.describe(
 				};
 
 				testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 			} );
 
 			await test.step( 'Start new post', async () => {

--- a/test/e2e/specs/blocks/blocks__story.spec.ts
+++ b/test/e2e/specs/blocks/blocks__story.spec.ts
@@ -51,8 +51,7 @@ test.describe(
 			await test.step( 'When I add Story block', async () => {
 				await pageEditor.addBlockFromSidebar(
 					StoryBlock.blockName,
-					StoryBlock.blockEditorSelector,
-					{ noSearch: true }
+					StoryBlock.blockEditorSelector
 				);
 			} );
 

--- a/test/e2e/specs/blocks/blocks__story.spec.ts
+++ b/test/e2e/specs/blocks/blocks__story.spec.ts
@@ -32,7 +32,7 @@ test.describe(
 
 			await test.step( 'Given I am authenticated', async () => {
 				const testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 
 				for ( const path of [ TEST_IMAGE_PATH, ALT_TEST_IMAGE_PATH ] ) {
 					const testFile = await MediaHelper.createTestFile( path );

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -20,9 +20,14 @@ import { expect, tags as allTags, test } from '../../../lib/pw-base';
 export function createBlockTests(
 	specName: string,
 	blockFlows: BlockFlow[],
-	testTags: string[] = [ allTags.GUTENBERG ]
+	testTags: string[] = [ allTags.GUTENBERG ],
+	skip?: { condition: boolean; reason: string }
 ): void {
 	test.describe( DataHelper.createSuiteTitle( specName ), { tag: testTags }, () => {
+		if ( skip ) {
+			test.skip( skip.condition, skip.reason );
+		}
+
 		const features = envToFeatureKey( envVariables );
 		const accountName = getTestAccountByFeature( features, [
 			{
@@ -38,7 +43,7 @@ export function createBlockTests(
 
 			await test.step( 'Given I am authenticated', async () => {
 				const testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 			} );
 
 			await test.step( 'When I visit the new post page', async () => {

--- a/test/e2e/specs/editor/editor__navbar.spec.ts
+++ b/test/e2e/specs/editor/editor__navbar.spec.ts
@@ -33,7 +33,7 @@ test.describe(
 				editorPage = new EditorPage( page );
 
 				const testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 				siteSlug = testAccount.getSiteURL( { protocol: false } );
 			} );
 

--- a/test/e2e/specs/editor/editor__page-basic-flow.spec.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.spec.ts
@@ -33,7 +33,7 @@ test.describe(
 
 			await test.step( 'Given I am authenticated', async () => {
 				const testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 			} );
 
 			await test.step( 'When I visit the Pages page', async () => {

--- a/test/e2e/specs/editor/editor__post-advanced-flow.spec.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.spec.ts
@@ -48,7 +48,7 @@ test.describe(
 
 			await test.step( 'Authenticate and setup the test', async () => {
 				testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 				siteSlug = testAccount.getSiteURL( { protocol: false } );
 			} );
 

--- a/test/e2e/specs/editor/editor__post-basic-flow.spec.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.spec.ts
@@ -33,7 +33,7 @@ test.describe(
 
 			await test.step( 'Given I am authenticated', async () => {
 				testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 			} );
 
 			await test.step( 'When I go to the new post page', async () => {

--- a/test/e2e/specs/editor/editor__schedule.spec.ts
+++ b/test/e2e/specs/editor/editor__schedule.spec.ts
@@ -33,7 +33,7 @@ test.describe(
 
 			await test.step( 'Given I am authenticated', async () => {
 				const testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 			} );
 
 			await test.step( 'When I go to the new post page', async () => {

--- a/test/e2e/specs/fse/fse__temp-smoke-test.spec.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.spec.ts
@@ -57,6 +57,11 @@ test.describe(
 			},
 		] );
 
+		test.skip(
+			envVariables.TEST_ON_ATOMIC && envVariables.ATOMIC_VARIATION === 'private',
+			'Private Atomic site cannot reach Site Editor through the Calypso sidebar setup'
+		);
+
 		test( 'As a user, I can navigate to the Full Site Editor and load the editor canvas', async ( {
 			page,
 		} ) => {

--- a/test/e2e/specs/jetpack/jetpack__dashboard-smoke.spec.ts
+++ b/test/e2e/specs/jetpack/jetpack__dashboard-smoke.spec.ts
@@ -33,7 +33,7 @@ test.describe(
 			let jetpackDashboardPage: JetpackDashboardPage;
 
 			await test.step( 'Authenticate', async () => {
-				await testAccount.authenticate( page );
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 				jetpackDashboardPage = new JetpackDashboardPage( page );
 
 				// Atomic tests sites might have local users, so the Jetpack SSO login will

--- a/test/e2e/specs/published-content/forms__submissions.spec.ts
+++ b/test/e2e/specs/published-content/forms__submissions.spec.ts
@@ -46,6 +46,11 @@ test.describe(
 		test( 'As a user, I can submit forms and validate responses in the feedback inbox', async ( {
 			page,
 		} ) => {
+			test.skip(
+				envVariables.TEST_ON_ATOMIC && envVariables.ATOMIC_VARIATION === 'private',
+				'Form submission flow requires a public Atomic site'
+			);
+
 			let publishedFormLocator: Locator;
 			let restAPIClient: RestAPIClient;
 			let newPostDetails: PostResponse;
@@ -150,7 +155,7 @@ test.describe(
 			// --- Validate responses ---
 
 			await test.step( 'Authenticate as site owner', async () => {
-				await testAccount.authenticate( page );
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 
 				// Atomic tests sites might have local users, so the Jetpack SSO login will
 				// show up when visiting the Jetpack dashboard directly. We can bypass it if

--- a/test/e2e/specs/settings/settings__database-phpmyadmin.spec.ts
+++ b/test/e2e/specs/settings/settings__database-phpmyadmin.spec.ts
@@ -31,7 +31,7 @@ test.describe(
 
 			await test.step( 'Authenticate and setup the test', async () => {
 				testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 			} );
 
 			await test.step( 'Navigate to Settings > Hosting Configuration', async () => {


### PR DESCRIPTION
Part of TESTOPS-148.

Follow up to https://github.com/Automattic/wp-calypso/pull/112865

## Proposed Changes

* Stop direct-navigation Atomic smoke tests from waiting for the Calypso home sidebar after authentication when they immediately navigate to editor or wp-admin paths.
* Warm up private Atomic wp-admin sessions before editor visits so direct editor routes do not stop at Jetpack SSO.
* Use the normal block inserter search path for the Story block instead of clicking it from the full inserter list.
* Skip private-Atomic-only cases where the flow requires a public site surface: form submissions, Jetpack Forms block smoke, and the temporary Site Editor sidebar smoke test.

## Why are these changes being made?

Recent Atomic Build Smoke desktop runs are failing before many specs reach the behavior they intend to test. The first broad failure was authentication waiting for the Calypso home/sidebar to stabilize on a private Atomic test site, even when the spec immediately navigates to an editor or wp-admin URL.

Root-cause notes:

* The code-side activation point was the Playwright migration that made these Jetpack/Gutenberg specs discoverable by the Atomic smoke job.
* The first red run after the last green run had no VCS changes, so this is not a clean single-commit product regression.
* The latest broad private-Atomic failures mix setup coupling with true private-site applicability gaps: public form submission/API setup cannot run against a private site, the temporary Site Editor smoke test depends on Calypso sidebar navigation, direct editor visits need a wp-admin session warm-up to avoid Jetpack SSO, and Story block insertion is more reliable through search than the full inserter list.

## Testing Instructions

* `git diff --check`
* `yarn eslint packages/calypso-e2e/src/lib/pages/editor-page.ts test/e2e/specs/blocks/blocks__jetpack-forms.spec.ts test/e2e/specs/blocks/blocks__media.spec.ts test/e2e/specs/blocks/blocks__story.spec.ts test/e2e/specs/blocks/shared/block-smoke-testing.ts test/e2e/specs/editor/editor__navbar.spec.ts test/e2e/specs/editor/editor__page-basic-flow.spec.ts test/e2e/specs/editor/editor__post-advanced-flow.spec.ts test/e2e/specs/editor/editor__post-basic-flow.spec.ts test/e2e/specs/editor/editor__schedule.spec.ts test/e2e/specs/fse/fse__temp-smoke-test.spec.ts test/e2e/specs/jetpack/jetpack__dashboard-smoke.spec.ts test/e2e/specs/published-content/forms__submissions.spec.ts test/e2e/specs/settings/settings__database-phpmyadmin.spec.ts`
* `yarn workspace @automattic/calypso-e2e build`
* `CALYPSO_BASE_URL=https://wordpress.com TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment ATOMIC_VARIATION=private VIEWPORT_NAME=desktop HEADLESS=true yarn --cwd test/e2e playwright test specs/editor/editor__navbar.spec.ts specs/published-content/forms__submissions.spec.ts specs/fse/fse__temp-smoke-test.spec.ts specs/blocks/blocks__jetpack-forms.spec.ts --project=chrome --workers=1 --reporter=list`
* `CALYPSO_BASE_URL=https://wordpress.com TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment ATOMIC_VARIATION=private VIEWPORT_NAME=desktop HEADLESS=true yarn --cwd test/e2e playwright test specs/blocks/blocks__jetpack-other.spec.ts --project=chrome --workers=1 --reporter=list`
* `CALYPSO_BASE_URL=https://wordpress.com TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment ATOMIC_VARIATION=private VIEWPORT_NAME=desktop HEADLESS=true yarn --cwd test/e2e playwright test specs/jetpack/jetpack__dashboard-smoke.spec.ts --project=chrome --workers=1 --reporter=list`
* `CALYPSO_BASE_URL=https://wordpress.com TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment ATOMIC_VARIATION=private VIEWPORT_NAME=desktop HEADLESS=true yarn --cwd test/e2e playwright test specs/blocks/blocks__jetpack-earn.spec.ts specs/blocks/blocks__story.spec.ts --project=chrome --workers=1 --reporter=list`
* Personal TeamCity run before the wp-admin warm-up improved the active failure from 14 failed / 3 passed to 5 failed / 9 passed / 14 ignored, then exposed the remaining editor SSO path: https://teamcity.a8c.com/build/18749722
* Personal TeamCity run after the wp-admin warm-up improved to 1 failed / 13 passed / 14 ignored, then exposed the remaining Story insertion timeout: https://teamcity.a8c.com/build/18749863
* Follow-up personal TeamCity run on the latest commit is pending.
* `yarn tsc --project test/e2e/tsconfig.json` still fails on pre-existing local E2E type errors unrelated to this change.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
