### PR TITLE
Purchase Management: Update the notices on the purchase management page, especially for expiring WordPress.com plans

### DIFF
--- a/client/blocks/product-plan-overlap-notices/index.tsx
+++ b/client/blocks/product-plan-overlap-notices/index.tsx
@@ -8,7 +8,7 @@ import { useTranslate } from 'i18n-calypso';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
-import Notice from 'calypso/components/notice';
+import Notice from 'calypso/dashboard/components/notice';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -116,9 +116,8 @@ export default function ProductPlanOverlapNotices( {
 			<QueryProductsList />
 
 			{ showOverlap && (
-				<Notice
-					showDismiss={ false }
-					text={ translate(
+				<Notice variant="info">
+					{ translate(
 						'Your %(planName)s Plan includes:' +
 							'{{list/}}' +
 							'Consider removing conflicting products.',
@@ -137,7 +136,7 @@ export default function ProductPlanOverlapNotices( {
 							},
 						}
 					) }
-				/>
+				</Notice>
 			) }
 		</>
 	);

--- a/client/blocks/product-plan-overlap-notices/style.scss
+++ b/client/blocks/product-plan-overlap-notices/style.scss
@@ -1,3 +1,3 @@
-.calypso-notice__content .calypso-notice__text .product-plan-overlap-notices__product-list {
+.dashboard-notice .product-plan-overlap-notices__product-list {
 	margin-bottom: 0.5em;
 }

--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -89,6 +89,14 @@
 	@include color-scheme-dark-theme-card;
 
 	.components-surface.components-card.dashboard-notice {
+		// White would be wrong here. Use a grey slightly lighter than the notice,
+		// so the button still stands out from it.
+		--dashboard-notice-action__background-color: color-mix(
+			in srgb,
+			var( --dashboard-surface__background-color ) 90%,
+			var( --dashboard__text-color )
+		);
+
 		&.is-info {
 			background-color: color-mix(
 				in srgb,

--- a/client/dashboard/components/notice/style.scss
+++ b/client/dashboard/components/notice/style.scss
@@ -2,6 +2,13 @@
 @import "@wordpress/base-styles/variables";
 
 .dashboard-notice {
+	// Background for action buttons, which are otherwise transparent and let the
+	// notice's color show through them. White here; the dark theme overrides it.
+	--dashboard-notice-action__background-color: var(
+		--dashboard-surface__background-color,
+		var( --color-surface )
+	);
+
 	/**
 	 * Density
 	 */
@@ -90,6 +97,20 @@
 
 .dashboard-notice__actions {
 	padding-bottom: $grid-unit-05;
+
+	.components-button.is-secondary:not( :disabled, [aria-disabled="true"] ) {
+		background: var( --dashboard-notice-action__background-color );
+
+		// Repeat the button's usual hover shade on top of that background, since
+		// the default one is transparent.
+		&:hover:not( .is-pressed ) {
+			background: color-mix(
+				in srgb,
+				var( --wp-components-color-accent, var( --wp-admin-theme-color ) ) 4%,
+				var( --dashboard-notice-action__background-color )
+			);
+		}
+	}
 }
 
 .dashboard-notice__close-button {

--- a/client/dashboard/components/plan-expiry-notice/get-plan-expiry-notice.ts
+++ b/client/dashboard/components/plan-expiry-notice/get-plan-expiry-notice.ts
@@ -1,0 +1,471 @@
+import { SubscriptionBillPeriod, getPlanNames } from '@automattic/api-core';
+import { translationExists } from '@automattic/i18n-utils';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { formatDate, getCalendarDaysUntil, getRelativeDayString } from '../../utils/datetime';
+import {
+	getRenewalUrlFromPurchase,
+	isDotcomPlan,
+	isExpiredAndInGracePeriod,
+	isRemoved,
+	mightStillAutoRenew,
+} from '../../utils/purchase';
+import { getPlanStorageInGb } from './plan-storage';
+import type { Purchase } from '@automattic/api-core';
+
+/**
+ * Once expiration is this close, a plan that cannot renew itself is a problem
+ * worth raising rather than a date still comfortably far off, so this is where
+ * the messaging begins, as a warning.
+ */
+const WARNING_DAYS_BEFORE_EXPIRY = 60;
+
+/**
+ * Once expiration is this close, losing the plan is the most likely outcome
+ * rather than a distant possibility, so the messaging switches to an error.
+ */
+const ERROR_DAYS_BEFORE_EXPIRY = 7;
+
+export type PlanExpiryUrgency = 'info' | 'warning' | 'error';
+
+export type PlanExpiryNoticeAction =
+	| { type: 'link'; label: string; href: string }
+	| { type: 'enable-auto-renew'; label: string }
+	| { type: 'add-payment-method'; label: string };
+
+export interface PlanExpiryNoticeOptions {
+	/**
+	 * Where to send someone who would rather move to a different plan than renew
+	 * this one. Each surface has to return to itself afterwards, so the caller
+	 * builds this; the action is left out entirely when there is nowhere to send
+	 * them.
+	 */
+	viewOtherPlansUrl?: string;
+
+	/**
+	 * The viewer's locale, for the expiration dates in the copy. Optional because
+	 * callers that only ask whether a notice applies, or at what urgency, never
+	 * read its text.
+	 */
+	locale?: string;
+
+	/**
+	 * Where renewal checkout returns to. Defaults to the dashboard page the user
+	 * is on, so surfaces outside the dashboard have to say where they are.
+	 */
+	renewReturnUrl?: string;
+}
+
+export interface PlanExpiryNoticeContent {
+	variant: PlanExpiryUrgency;
+	title?: string;
+	body: string;
+	primaryAction?: PlanExpiryNoticeAction;
+	secondaryAction?: PlanExpiryNoticeAction;
+}
+
+/**
+ * A notice plus the source text of its title and body, so that we can tell
+ * whether both have been translated yet before committing to showing it.
+ */
+interface ResolvedNotice extends PlanExpiryNoticeContent {
+	title: string;
+	titleSource: string;
+	bodySource: string;
+}
+
+/**
+ * Whether a purchase is eligible to show this component's notice, regardless of
+ * whether it is actually showing under the current conditions. Use
+ * {@link hasPlanExpiryNotice} to find out if the notice will be displayed.
+ *
+ * An eligible plan may intentionally have no plan-expiry notice under certain
+ * conditions — for example, if it is renewing normally. The weaker, more
+ * generic expiry notices that this one supersedes call this function to find
+ * out if they should stay quiet too; their silence is this notice's decision,
+ * not a gap to fill with a closely-related message.
+ *
+ * This function is also where the set of products the notice covers is
+ * decided: in practice the first two checks below narrow it to Personal,
+ * Premium, Business and Commerce, in every billing term. Trials, Jetpack, Woo,
+ * Akismet, domains and the free plan are all excluded because they appear in
+ * neither lookup. Adding a new plan tier means adding it to both.
+ */
+export function isEligibleForPlanExpiryNotice( purchase: Purchase ): boolean {
+	return Boolean(
+		// Names the plan for the copy, and covers exactly the four paid tiers.
+		getPlanName( purchase ) &&
+			// The copy always quotes a storage figure, so a plan we have no number
+			// for cannot be described. Doubles as the same allowlist.
+			getPlanStorageInGb( purchase.product_slug ) !== null &&
+			// The copy is all about a site losing plan features, so require the
+			// purchase to actually be a WordPress.com plan and not merely carry a
+			// plan-shaped product slug.
+			isDotcomPlan( purchase ) &&
+			purchase.expiry_date &&
+			// Agency- and host-managed plans can't be renewed by the customer.
+			! purchase.partner_type &&
+			// Removed subscriptions keep their existing "no longer in use" copy.
+			! isRemoved( purchase )
+	);
+}
+
+/**
+ * Whether the notice will actually be displayed for this purchase right now.
+ * Narrower than {@link isEligibleForPlanExpiryNotice}, which stays true for an
+ * eligible plan even while there is nothing to say about it.
+ *
+ * Callers use this when only the presence of the notice matters, not what it
+ * says: the purchase pages hide their own prominent buttons while it is up, so
+ * that it is the only thing on the page asking the customer to act.
+ */
+export function hasPlanExpiryNotice( purchase: Purchase ): boolean {
+	return getPlanExpiryNotice( purchase ) !== null;
+}
+
+/**
+ * The urgency the notice would be shown at, or null if it would not be shown.
+ *
+ * The expiry date and auto-renew status displayed elsewhere on the purchase page
+ * are colored from this, so that they agree with the notice when it makes sense
+ * to color them at all.
+ */
+export function getPlanExpiryUrgency( purchase: Purchase ): PlanExpiryUrgency | null {
+	return getPlanExpiryNotice( purchase )?.variant ?? null;
+}
+
+/**
+ * Content for a notice about a WordPress.com plan that is approaching or past
+ * its expiration date, or is otherwise at risk of not renewing. Returns null
+ * when there is nothing worth saying.
+ */
+export function getPlanExpiryNotice(
+	purchase: Purchase,
+	options: PlanExpiryNoticeOptions = {}
+): PlanExpiryNoticeContent | null {
+	if ( ! isEligibleForPlanExpiryNotice( purchase ) ) {
+		return null;
+	}
+
+	const resolved = resolveNotice( purchase, options );
+	if ( ! resolved ) {
+		return null;
+	}
+
+	const { titleSource, bodySource, ...notice } = resolved;
+	if ( translationExists( titleSource ) && translationExists( bodySource ) ) {
+		return notice;
+	}
+
+	// The copy above hasn't been translated for this locale yet, so fall back
+	// to the closest existing message for the same situation rather than
+	// showing the reader English.
+	if ( isExpiredAndInGracePeriod( purchase ) ) {
+		return expiredFallbackNotice( notice.primaryAction );
+	}
+
+	// A plan that might still renew itself has no older message to fall back on:
+	// the notices this one supersedes are gated on an expiry status it does not
+	// have, so before this notice existed these purchases were told nothing.
+	// Saying they will be removed would be worse than staying quiet.
+	if ( mightStillAutoRenew( purchase ) ) {
+		return null;
+	}
+
+	return notice.variant === 'info'
+		? autoRenewOffFallbackNotice( purchase, notice.primaryAction )
+		: expiringFallbackNotice( purchase, notice.primaryAction );
+}
+
+function resolveNotice(
+	purchase: Purchase,
+	{ viewOtherPlansUrl, locale, renewReturnUrl }: PlanExpiryNoticeOptions
+): ResolvedNotice | null {
+	const planName = getPlanName( purchase ) as string;
+	const storageGb = getPlanStorageInGb( purchase.product_slug ) as number;
+	const canAutoRenew = mightStillAutoRenew( purchase );
+	const daysUntilExpiry = getCalendarDaysUntil( new Date( purchase.expiry_date ) );
+	const expiryDate = formatDate( new Date( purchase.expiry_date ), locale ?? 'en', {
+		dateStyle: 'long',
+	} );
+	const isAnnualOrLonger = purchase.bill_period_days >= SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD;
+
+	const renewAction: PlanExpiryNoticeAction = {
+		type: 'link',
+		label: __( 'Renew now' ),
+		href: getRenewalUrlFromPurchase( purchase, undefined, renewReturnUrl ),
+	};
+
+	// Past the expiry date, still inside the grace period. Note that
+	// `mightStillAutoRenew` is already false once the final auto-renewal
+	// attempt has passed, so those purchases fall through to the "can't
+	// auto-renew" wording on their own.
+	if ( isExpiredAndInGracePeriod( purchase ) ) {
+		return {
+			variant: 'error',
+			titleSource: 'Your %(planName)s plan has expired',
+			// translators: %(planName)s is a short plan name, like "Business"
+			title: sprintf( __( 'Your %(planName)s plan has expired' ), { planName } ),
+			bodySource: canAutoRenew
+				? 'If renewal doesn’t go through, your site will move to the Free plan. That means losing plugins, custom themes, and %(storageGb)d GB of storage. But it’s not too late. Renew now to keep your site as it is.'
+				: 'Your site will move to the Free plan. That means losing plugins, custom themes, and %(storageGb)d GB of storage. But it’s not too late. Renew now to keep your site as it is.',
+			body: canAutoRenew
+				? sprintf(
+						// translators: %(storageGb)d is a number of gigabytes of storage
+						__(
+							'If renewal doesn’t go through, your site will move to the Free plan. That means losing plugins, custom themes, and %(storageGb)d GB of storage. But it’s not too late. Renew now to keep your site as it is.'
+						),
+						{ storageGb }
+				  )
+				: sprintf(
+						// translators: %(storageGb)d is a number of gigabytes of storage
+						__(
+							'Your site will move to the Free plan. That means losing plugins, custom themes, and %(storageGb)d GB of storage. But it’s not too late. Renew now to keep your site as it is.'
+						),
+						{ storageGb }
+				  ),
+			primaryAction: renewAction,
+			// This label is new, so it may not be translated yet. Drop the action
+			// rather than show one English button among translated copy; the primary
+			// action is always there to fall back on.
+			secondaryAction:
+				viewOtherPlansUrl && translationExists( 'View other plans' )
+					? { type: 'link', label: __( 'View other plans' ), href: viewOtherPlansUrl }
+					: undefined,
+		};
+	}
+
+	// A monthly plan that is billing normally has nothing to warn about.
+	if ( canAutoRenew && ! isAnnualOrLonger ) {
+		return null;
+	}
+
+	// Close in, count the days exactly. `getRelativeDayString` would round a
+	// month-and-change up to "in 1 month", which reads as far less urgent than
+	// the 29 days it actually is.
+	const expiresInDaysTitleSource = 'Your %(planName)s plan expires in %(days)d days';
+	const expiresInDaysTitle = sprintf(
+		// translators: %(planName)s is a short plan name like "Business", and %(days)d is a number of days
+		_n(
+			'Your %(planName)s plan expires in %(days)d day',
+			'Your %(planName)s plan expires in %(days)d days',
+			daysUntilExpiry
+		),
+		{ planName, days: daysUntilExpiry }
+	);
+
+	const expiresTodayTitleSource = 'Your %(planName)s plan expires today';
+	// translators: %(planName)s is a short plan name, like "Business"
+	const expiresTodayTitle = sprintf( __( 'Your %(planName)s plan expires today' ), { planName } );
+
+	const remainingTitleSource = 'Your %(planName)s plan has %(days)d days remaining';
+	const remainingTitle = sprintf(
+		// translators: %(planName)s is a short plan name like "Business", and %(days)d is a number of days
+		_n(
+			'Your %(planName)s plan has %(days)d day remaining',
+			'Your %(planName)s plan has %(days)d days remaining',
+			daysUntilExpiry
+		),
+		{ planName, days: daysUntilExpiry }
+	);
+
+	// The day of expiration, or the last few days before it.
+	if ( daysUntilExpiry <= ERROR_DAYS_BEFORE_EXPIRY ) {
+		const isExpiringToday = daysUntilExpiry <= 0;
+
+		if ( canAutoRenew ) {
+			return {
+				variant: 'error',
+				titleSource: isExpiringToday ? expiresTodayTitleSource : remainingTitleSource,
+				title: isExpiringToday ? expiresTodayTitle : remainingTitle,
+				bodySource:
+					'If renewal doesn’t go through, your site will move to the Free plan and you’ll lose plugins, custom themes, and %(storageGb)d GB of storage. Renew now to keep everything in place.',
+				body: sprintf(
+					// translators: %(storageGb)d is a number of gigabytes of storage
+					__(
+						'If renewal doesn’t go through, your site will move to the Free plan and you’ll lose plugins, custom themes, and %(storageGb)d GB of storage. Renew now to keep everything in place.'
+					),
+					{ storageGb }
+				),
+				primaryAction: renewAction,
+			};
+		}
+
+		return {
+			variant: 'error',
+			titleSource: isExpiringToday ? expiresTodayTitleSource : expiresInDaysTitleSource,
+			title: isExpiringToday ? expiresTodayTitle : expiresInDaysTitle,
+			bodySource: isExpiringToday
+				? 'Unless you renew your plan, your site will move to the Free plan, and you’ll lose plugins, custom themes, and %(storageGb)d GB of storage. Renew now to keep everything in place.'
+				: 'Your site will move to the Free plan and you’ll lose plugins, custom themes, and %(storageGb)d GB of storage. Renew now to keep everything in place.',
+			body: isExpiringToday
+				? sprintf(
+						// translators: %(storageGb)d is a number of gigabytes of storage
+						__(
+							'Unless you renew your plan, your site will move to the Free plan, and you’ll lose plugins, custom themes, and %(storageGb)d GB of storage. Renew now to keep everything in place.'
+						),
+						{ storageGb }
+				  )
+				: sprintf(
+						// translators: %(storageGb)d is a number of gigabytes of storage
+						__(
+							'Your site will move to the Free plan and you’ll lose plugins, custom themes, and %(storageGb)d GB of storage. Renew now to keep everything in place.'
+						),
+						{ storageGb }
+				  ),
+			primaryAction: renewAction,
+		};
+	}
+
+	// Further out than a week, only annual-and-above plans have anything to
+	// say: a monthly plan that can't auto-renew has no meaningful runway
+	// before the window above.
+	if ( ! isAnnualOrLonger ) {
+		return null;
+	}
+
+	// A plan that can still auto-renew is only worth mentioning once its first
+	// scheduled attempt has come and gone without renewing it.
+	if ( canAutoRenew ) {
+		if ( ! purchase.is_past_first_auto_renew_attempt_date ) {
+			return null;
+		}
+
+		return {
+			variant: 'warning',
+			titleSource: remainingTitleSource,
+			title: remainingTitle,
+			bodySource:
+				'If renewal doesn’t go through, your site will move to the Free plan, and you’ll lose access to plugins, custom themes, and %(storageGb)d GB of storage.',
+			body: sprintf(
+				// translators: %(storageGb)d is a number of gigabytes of storage
+				__(
+					'If renewal doesn’t go through, your site will move to the Free plan, and you’ll lose access to plugins, custom themes, and %(storageGb)d GB of storage.'
+				),
+				{ storageGb }
+			),
+			primaryAction: renewAction,
+		};
+	}
+
+	if ( daysUntilExpiry <= WARNING_DAYS_BEFORE_EXPIRY ) {
+		return {
+			variant: 'warning',
+			titleSource: expiresInDaysTitleSource,
+			title: expiresInDaysTitle,
+			bodySource:
+				'After %(expiryDate)s, your site will move to the Free plan, which means you’ll lose access to plugins, custom themes, and %(storageGb)d GB of storage.',
+			body: sprintf(
+				// translators: %(expiryDate)s is a date like "August 15, 2026", and %(storageGb)d is a number of gigabytes of storage
+				__(
+					'After %(expiryDate)s, your site will move to the Free plan, which means you’ll lose access to plugins, custom themes, and %(storageGb)d GB of storage.'
+				),
+				{ expiryDate, storageGb }
+			),
+			primaryAction: renewAction,
+		};
+	}
+
+	// Far enough out that months read more naturally than a day count.
+	return {
+		variant: 'info',
+		titleSource: 'Your %(planName)s plan expires %(timeUntilExpiry)s',
+		title: sprintf(
+			// translators: %(planName)s is a short plan name like "Business", and %(timeUntilExpiry)s is a relative time like "in 3 months"
+			__( 'Your %(planName)s plan expires %(timeUntilExpiry)s' ),
+			{
+				planName,
+				timeUntilExpiry: getRelativeDayString( new Date( purchase.expiry_date ), 'upcoming' ),
+			}
+		),
+		bodySource:
+			'After %(expiryDate)s, your site will move to the Free plan, and you’ll lose access to plugins, custom themes, and %(storageGb)d GB of storage. Turn on auto-renew to keep everything in place.',
+		body: sprintf(
+			// translators: %(expiryDate)s is a date like "August 15, 2026", and %(storageGb)d is a number of gigabytes of storage
+			__(
+				'After %(expiryDate)s, your site will move to the Free plan, and you’ll lose access to plugins, custom themes, and %(storageGb)d GB of storage. Turn on auto-renew to keep everything in place.'
+			),
+			{ expiryDate, storageGb }
+		),
+		primaryAction: getTurnOnAutoRenewAction( purchase ),
+	};
+}
+
+function getPlanName( purchase: Purchase ): string | undefined {
+	return ( getPlanNames() as Record< string, string | undefined > )[ purchase.product_slug ];
+}
+
+/**
+ * Adding a payment method turns auto-renew on by itself, so both routes back
+ * to a renewing plan share the same label.
+ *
+ * Which route applies turns on whether there is a chargeable payment method,
+ * not on whether auto-renew is switched on: turning it on does nothing without
+ * one, so a purchase with no method has to add one either way.
+ */
+function getTurnOnAutoRenewAction( purchase: Purchase ): PlanExpiryNoticeAction {
+	const label = __( 'Turn on auto-renew' );
+
+	return purchase.is_rechargeable
+		? { type: 'enable-auto-renew', label }
+		: { type: 'add-payment-method', label };
+}
+
+/**
+ * Until the strings above are translated, say something the reader can
+ * actually read: the closest existing message for the same situation.
+ */
+function expiredFallbackNotice( primaryAction?: PlanExpiryNoticeAction ): PlanExpiryNoticeContent {
+	return {
+		variant: 'error',
+		body: translationExists(
+			'This purchase has expired and will be removed soon unless it is renewed.'
+		)
+			? __( 'This purchase has expired and will be removed soon unless it is renewed.' )
+			: __( 'This purchase has expired and is no longer in use.' ),
+		primaryAction,
+	};
+}
+
+function expiringFallbackNotice(
+	purchase: Purchase,
+	primaryAction?: PlanExpiryNoticeAction
+): PlanExpiryNoticeContent {
+	return {
+		variant: 'warning',
+		body: sprintf(
+			// translators: %(purchaseName)s is the name of the plan and %(expiry)s is a relative time like "in 3 months"
+			__( '%(purchaseName)s will expire and be removed from your site %(expiry)s.' ),
+			{
+				purchaseName: purchase.product_name,
+				expiry: getRelativeDayString( new Date( purchase.expiry_date ), 'upcoming' ),
+			}
+		),
+		primaryAction,
+	};
+}
+
+/**
+ * The calmest of the fallbacks, for a plan whose expiry is still some way off
+ * and whose only problem is that auto-renew is switched off. Kept at `info` so
+ * that falling back cannot leave the page more alarmed than the untranslated
+ * copy would have been.
+ */
+function autoRenewOffFallbackNotice(
+	purchase: Purchase,
+	primaryAction?: PlanExpiryNoticeAction
+): PlanExpiryNoticeContent {
+	return {
+		variant: 'info',
+		body: sprintf(
+			// translators: %(purchaseName)s is the name of the plan and %(expiry)s is a relative time like "in 3 months"
+			__(
+				'%(purchaseName)s will expire and be removed from your site %(expiry)s. Please enable auto-renewal so you don‘t lose out on your paid features!'
+			),
+			{
+				purchaseName: purchase.product_name,
+				expiry: getRelativeDayString( new Date( purchase.expiry_date ), 'upcoming' ),
+			}
+		),
+		primaryAction,
+	};
+}

--- a/client/dashboard/components/plan-expiry-notice/get-plan-expiry-notice.ts
+++ b/client/dashboard/components/plan-expiry-notice/get-plan-expiry-notice.ts
@@ -316,13 +316,6 @@ function resolveNotice(
 		};
 	}
 
-	// Further out than a week, only annual-and-above plans have anything to
-	// say: a monthly plan that can't auto-renew has no meaningful runway
-	// before the window above.
-	if ( ! isAnnualOrLonger ) {
-		return null;
-	}
-
 	// A plan that can still auto-renew is only worth mentioning once its first
 	// scheduled attempt has come and gone without renewing it.
 	if ( canAutoRenew ) {
@@ -361,7 +354,11 @@ function resolveNotice(
 				),
 				{ expiryDate, storageGb }
 			),
-			primaryAction: renewAction,
+			// Renewing early only makes sense once expiration is close relative to
+			// the billing period. A month is most of a monthly plan's cycle, so
+			// paying again that far ahead would be premature; turning auto-renew
+			// back on is the fix at this distance.
+			primaryAction: isAnnualOrLonger ? renewAction : getTurnOnAutoRenewAction( purchase ),
 		};
 	}
 

--- a/client/dashboard/components/plan-expiry-notice/get-plan-expiry-notice.ts
+++ b/client/dashboard/components/plan-expiry-notice/get-plan-expiry-notice.ts
@@ -243,7 +243,8 @@ function resolveNotice(
 	// Close in, count the days exactly. `getRelativeDayString` would round a
 	// month-and-change up to "in 1 month", which reads as far less urgent than
 	// the 29 days it actually is.
-	const expiresInDaysTitleSource = 'Your %(planName)s plan expires in %(days)d days';
+	// The singular, because that is the key translations are stored under.
+	const expiresInDaysTitleSource = 'Your %(planName)s plan expires in %(days)d day';
 	const expiresInDaysTitle = sprintf(
 		// translators: %(planName)s is a short plan name like "Business", and %(days)d is a number of days
 		_n(
@@ -258,7 +259,7 @@ function resolveNotice(
 	// translators: %(planName)s is a short plan name, like "Business"
 	const expiresTodayTitle = sprintf( __( 'Your %(planName)s plan expires today' ), { planName } );
 
-	const remainingTitleSource = 'Your %(planName)s plan has %(days)d days remaining';
+	const remainingTitleSource = 'Your %(planName)s plan has %(days)d day remaining';
 	const remainingTitle = sprintf(
 		// translators: %(planName)s is a short plan name like "Business", and %(days)d is a number of days
 		_n(

--- a/client/dashboard/components/plan-expiry-notice/get-plan-expiry-notice.ts
+++ b/client/dashboard/components/plan-expiry-notice/get-plan-expiry-notice.ts
@@ -28,7 +28,8 @@ const ERROR_DAYS_BEFORE_EXPIRY = 7;
 export type PlanExpiryUrgency = 'info' | 'warning' | 'error';
 
 export type PlanExpiryNoticeAction =
-	| { type: 'link'; label: string; href: string }
+	| { type: 'renew'; label: string; href: string }
+	| { type: 'view-other-plans'; label: string; href: string }
 	| { type: 'enable-auto-renew'; label: string }
 	| { type: 'add-payment-method'; label: string };
 
@@ -190,7 +191,7 @@ function resolveNotice(
 	const isAnnualOrLonger = purchase.bill_period_days >= SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD;
 
 	const renewAction: PlanExpiryNoticeAction = {
-		type: 'link',
+		type: 'renew',
 		label: __( 'Renew now' ),
 		href: getRenewalUrlFromPurchase( purchase, undefined, renewReturnUrl ),
 	};
@@ -229,7 +230,7 @@ function resolveNotice(
 			// action is always there to fall back on.
 			secondaryAction:
 				viewOtherPlansUrl && translationExists( 'View other plans' )
-					? { type: 'link', label: __( 'View other plans' ), href: viewOtherPlansUrl }
+					? { type: 'view-other-plans', label: __( 'View other plans' ), href: viewOtherPlansUrl }
 					: undefined,
 		};
 	}

--- a/client/dashboard/components/plan-expiry-notice/index.tsx
+++ b/client/dashboard/components/plan-expiry-notice/index.tsx
@@ -1,0 +1,200 @@
+import { userPurchaseSetAutoRenewQuery } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import { Button } from '@wordpress/components';
+import { useEffect, useMemo } from 'react';
+import { getCalendarDaysUntil } from '../../utils/datetime';
+import { isExpiredOrRemoved, mightStillAutoRenew } from '../../utils/purchase';
+import Notice from '../notice';
+import { getPlanExpiryNotice } from './get-plan-expiry-notice';
+import type { PlanExpiryNoticeAction } from './get-plan-expiry-notice';
+import type { Purchase } from '@automattic/api-core';
+
+export {
+	getPlanExpiryNotice,
+	getPlanExpiryUrgency,
+	hasPlanExpiryNotice,
+	isEligibleForPlanExpiryNotice,
+} from './get-plan-expiry-notice';
+export type {
+	PlanExpiryNoticeContent,
+	PlanExpiryNoticeOptions,
+	PlanExpiryUrgency,
+} from './get-plan-expiry-notice';
+
+interface PlanExpiryNoticeProps {
+	purchase: Purchase;
+
+	/**
+	 * Where to send someone who needs to attach a payment method to this
+	 * purchase. Calypso and the dashboard route to this differently, so the
+	 * caller supplies it. Omit it when the purchase's payment details can't be
+	 * edited; the notice then explains the problem without offering a fix.
+	 */
+	addPaymentMethodUrl?: string;
+
+	/**
+	 * Where to send someone who would rather move to a different plan than renew
+	 * this one. Omit it when the purchase has no such destination; the action
+	 * then isn't offered.
+	 */
+	viewOtherPlansUrl?: string;
+
+	/**
+	 * The viewer's locale, for the expiration dates in the copy. Supplied by the
+	 * caller because the dashboard's `useLocale` reads app context that Calypso
+	 * doesn't have.
+	 */
+	locale: string;
+
+	/**
+	 * Where renewal checkout returns to. Defaults to the dashboard page the user
+	 * is on, so surfaces outside the dashboard have to say where they are.
+	 */
+	renewReturnUrl?: string;
+
+	/**
+	 * Which page is rendering the notice, recorded with its events so that the
+	 * surfaces can be told apart in the data.
+	 */
+	surface: string;
+
+	/**
+	 * Taken as a prop because the dashboard's analytics context is not available
+	 * to callers outside the dashboard. Each host passes its own.
+	 */
+	recordTracksEvent: ( eventName: string, properties?: Record< string, unknown > ) => void;
+
+	/**
+	 * Called once auto-renew has been turned on. The mutation invalidates the
+	 * `@automattic/api-queries` client, which is only the one the page is reading
+	 * from inside the dashboard app; hosts with a query client of their own have
+	 * to refresh the purchase themselves or the page will not update.
+	 */
+	onAutoRenewEnabled?: () => void;
+}
+
+/**
+ * A prominent notice for a WordPress.com plan that is approaching or past its
+ * expiration date, or is otherwise at risk of not renewing. Renders nothing for
+ * any other purchase, or when the plan is renewing normally.
+ *
+ * Deliberately free of assumptions about its surroundings so that it can be
+ * rendered from both Calypso and the dashboard: it takes host-specific
+ * destinations as props and reaches for no app context of its own.
+ */
+export function PlanExpiryNotice( {
+	purchase,
+	addPaymentMethodUrl,
+	viewOtherPlansUrl,
+	locale,
+	renewReturnUrl,
+	surface,
+	recordTracksEvent,
+	onAutoRenewEnabled,
+}: PlanExpiryNoticeProps ) {
+	const { mutate: setAutoRenew, isPending } = useMutation( userPurchaseSetAutoRenewQuery() );
+
+	const notice = getPlanExpiryNotice( purchase, {
+		viewOtherPlansUrl,
+		locale,
+		renewReturnUrl,
+	} );
+
+	// Pulled out as primitives so that they, and the memo below, stay stable
+	// across renders. `purchase` and `notice` are both new objects every time.
+	const purchaseId = purchase.ID;
+	const productSlug = purchase.product_slug;
+	const status = isExpiredOrRemoved( purchase ) ? 'expired' : 'active';
+	const daysUntilExpiry = getCalendarDaysUntil( new Date( purchase.expiry_date ) );
+	const canStillAutoRenew = mightStillAutoRenew( purchase );
+	const variant = notice?.variant;
+
+	const eventProperties = useMemo(
+		() => ( {
+			surface,
+			purchase_id: purchaseId,
+			product_slug: productSlug,
+			status,
+			days_until_expiry: daysUntilExpiry,
+			might_still_auto_renew: canStillAutoRenew,
+			variant,
+		} ),
+		[ surface, purchaseId, productSlug, status, daysUntilExpiry, canStillAutoRenew, variant ]
+	);
+
+	// Records again whenever any of the above changes, since that means the
+	// reader is being shown a different message.
+	useEffect( () => {
+		if ( ! variant ) {
+			return;
+		}
+		recordTracksEvent( 'calypso_purchases_plan_expiry_notice_impression', eventProperties );
+	}, [ eventProperties, variant, recordTracksEvent ] );
+
+	if ( ! notice ) {
+		return null;
+	}
+
+	const renderAction = ( action: PlanExpiryNoticeAction, isPrimary: boolean ) => {
+		if ( action.type === 'add-payment-method' && ! addPaymentMethodUrl ) {
+			return null;
+		}
+
+		const variant = isPrimary ? 'primary' : 'secondary';
+
+		const track = () =>
+			recordTracksEvent( 'calypso_purchases_plan_expiry_notice_click', {
+				...eventProperties,
+				action: action.type,
+			} );
+
+		if ( action.type === 'enable-auto-renew' ) {
+			return (
+				<Button
+					variant={ variant }
+					disabled={ isPending }
+					isBusy={ isPending }
+					onClick={ () => {
+						track();
+						setAutoRenew(
+							{ purchaseId: purchase.ID, autoRenew: true },
+							{ onSuccess: () => onAutoRenewEnabled?.() }
+						);
+					} }
+				>
+					{ action.label }
+				</Button>
+			);
+		}
+
+		const href = action.type === 'add-payment-method' ? addPaymentMethodUrl : action.href;
+
+		return (
+			<Button variant={ variant } href={ href } onClick={ track }>
+				{ action.label }
+			</Button>
+		);
+	};
+
+	const primary = notice.primaryAction && renderAction( notice.primaryAction, true );
+	const secondary = notice.secondaryAction && renderAction( notice.secondaryAction, false );
+
+	return (
+		<Notice
+			variant={ notice.variant }
+			title={ notice.title }
+			actions={
+				( primary || secondary ) && (
+					<>
+						{ primary }
+						{ secondary }
+					</>
+				)
+			}
+		>
+			{ notice.body }
+		</Notice>
+	);
+}
+
+export default PlanExpiryNotice;

--- a/client/dashboard/components/plan-expiry-notice/index.tsx
+++ b/client/dashboard/components/plan-expiry-notice/index.tsx
@@ -73,6 +73,53 @@ interface PlanExpiryNoticeProps {
 	onAutoRenewEnabled?: () => void;
 }
 
+function PlanExpiryNoticeButton( {
+	action,
+	variant,
+	purchaseId,
+	addPaymentMethodUrl,
+	onClick,
+	onAutoRenewEnabled,
+}: {
+	action: PlanExpiryNoticeAction;
+	variant: 'primary' | 'secondary';
+	purchaseId: number;
+	addPaymentMethodUrl?: string;
+	onClick: () => void;
+	onAutoRenewEnabled?: () => void;
+} ) {
+	const { mutate: setAutoRenew, isPending } = useMutation( userPurchaseSetAutoRenewQuery() );
+
+	if ( action.type === 'enable-auto-renew' ) {
+		return (
+			<Button
+				variant={ variant }
+				disabled={ isPending }
+				isBusy={ isPending }
+				onClick={ () => {
+					onClick();
+					setAutoRenew(
+						{ purchaseId, autoRenew: true },
+						{ onSuccess: () => onAutoRenewEnabled?.() }
+					);
+				} }
+			>
+				{ action.label }
+			</Button>
+		);
+	}
+
+	return (
+		<Button
+			variant={ variant }
+			href={ action.type === 'add-payment-method' ? addPaymentMethodUrl : action.href }
+			onClick={ onClick }
+		>
+			{ action.label }
+		</Button>
+	);
+}
+
 /**
  * A prominent notice for a WordPress.com plan that is approaching or past its
  * expiration date, or is otherwise at risk of not renewing. Renders nothing for
@@ -92,8 +139,6 @@ export function PlanExpiryNotice( {
 	recordTracksEvent,
 	onAutoRenewEnabled,
 }: PlanExpiryNoticeProps ) {
-	const { mutate: setAutoRenew, isPending } = useMutation( userPurchaseSetAutoRenewQuery() );
-
 	const notice = getPlanExpiryNotice( purchase, {
 		viewOtherPlansUrl,
 		locale,
@@ -135,59 +180,46 @@ export function PlanExpiryNotice( {
 		return null;
 	}
 
-	const renderAction = ( action: PlanExpiryNoticeAction, isPrimary: boolean ) => {
-		if ( action.type === 'add-payment-method' && ! addPaymentMethodUrl ) {
-			return null;
-		}
+	// Kept out of the buttons themselves: the notice has to know whether it has
+	// any action at all, or it renders an empty, padded action row.
+	const shown = ( action?: PlanExpiryNoticeAction ) =>
+		action && ( action.type !== 'add-payment-method' || addPaymentMethodUrl ) ? action : undefined;
+	const primaryAction = shown( notice.primaryAction );
+	const secondaryAction = shown( notice.secondaryAction );
 
-		const variant = isPrimary ? 'primary' : 'secondary';
-
-		const track = () =>
-			recordTracksEvent( 'calypso_purchases_plan_expiry_notice_click', {
-				...eventProperties,
-				action: action.type,
-			} );
-
-		if ( action.type === 'enable-auto-renew' ) {
-			return (
-				<Button
-					variant={ variant }
-					disabled={ isPending }
-					isBusy={ isPending }
-					onClick={ () => {
-						track();
-						setAutoRenew(
-							{ purchaseId: purchase.ID, autoRenew: true },
-							{ onSuccess: () => onAutoRenewEnabled?.() }
-						);
-					} }
-				>
-					{ action.label }
-				</Button>
-			);
-		}
-
-		const href = action.type === 'add-payment-method' ? addPaymentMethodUrl : action.href;
-
-		return (
-			<Button variant={ variant } href={ href } onClick={ track }>
-				{ action.label }
-			</Button>
-		);
-	};
-
-	const primary = notice.primaryAction && renderAction( notice.primaryAction, true );
-	const secondary = notice.secondaryAction && renderAction( notice.secondaryAction, false );
+	const recordClick = ( action: PlanExpiryNoticeAction ) =>
+		recordTracksEvent( 'calypso_purchases_plan_expiry_notice_click', {
+			...eventProperties,
+			action: action.type,
+		} );
 
 	return (
 		<Notice
 			variant={ notice.variant }
 			title={ notice.title }
 			actions={
-				( primary || secondary ) && (
+				( primaryAction || secondaryAction ) && (
 					<>
-						{ primary }
-						{ secondary }
+						{ primaryAction && (
+							<PlanExpiryNoticeButton
+								action={ primaryAction }
+								variant="primary"
+								purchaseId={ purchase.ID }
+								addPaymentMethodUrl={ addPaymentMethodUrl }
+								onClick={ () => recordClick( primaryAction ) }
+								onAutoRenewEnabled={ onAutoRenewEnabled }
+							/>
+						) }
+						{ secondaryAction && (
+							<PlanExpiryNoticeButton
+								action={ secondaryAction }
+								variant="secondary"
+								purchaseId={ purchase.ID }
+								addPaymentMethodUrl={ addPaymentMethodUrl }
+								onClick={ () => recordClick( secondaryAction ) }
+								onAutoRenewEnabled={ onAutoRenewEnabled }
+							/>
+						) }
 					</>
 				)
 			}

--- a/client/dashboard/components/plan-expiry-notice/plan-storage.ts
+++ b/client/dashboard/components/plan-expiry-notice/plan-storage.ts
@@ -1,0 +1,47 @@
+import { DotcomPlans } from '@automattic/api-core';
+
+/**
+ * Storage included with each WordPress.com plan, in GB.
+ *
+ * Note that this map doubles as the plan-expiry notice's product allowlist: a
+ * slug missing from it is not eligible for the notice at all. See
+ * `isEligibleForPlanExpiryNotice`. A new plan tier has to be added here as well
+ * as to `getPlanNames()`, or the notice silently skips it.
+ *
+ * TODO: these numbers should not be hardcoded. They should eventually come from
+ * the server — but that has to be done consistently across the whole interface
+ * (the plans grid, the cancellation feature lists, the storage meters) rather
+ * than only here, so that a single source of truth is established instead of a
+ * third one being introduced.
+ *
+ * These mirror what `getStorageFeature()` returns for each plan in
+ * `packages/calypso-products/src/plans-list.tsx`, which this file cannot
+ * import: the dashboard is not allowed to depend on
+ * `@automattic/calypso-products`.
+ */
+const PLAN_STORAGE_IN_GB: Record< string, number > = {
+	[ DotcomPlans.PERSONAL ]: 6,
+	[ DotcomPlans.PERSONAL_MONTHLY ]: 6,
+	[ DotcomPlans.PERSONAL_2_YEARS ]: 6,
+	[ DotcomPlans.PERSONAL_3_YEARS ]: 6,
+	[ DotcomPlans.PREMIUM ]: 13,
+	[ DotcomPlans.PREMIUM_MONTHLY ]: 13,
+	[ DotcomPlans.PREMIUM_2_YEARS ]: 13,
+	[ DotcomPlans.PREMIUM_3_YEARS ]: 13,
+	[ DotcomPlans.BUSINESS ]: 50,
+	[ DotcomPlans.BUSINESS_MONTHLY ]: 50,
+	[ DotcomPlans.BUSINESS_2_YEARS ]: 50,
+	[ DotcomPlans.BUSINESS_3_YEARS ]: 50,
+	[ DotcomPlans.ECOMMERCE ]: 50,
+	[ DotcomPlans.ECOMMERCE_MONTHLY ]: 50,
+	[ DotcomPlans.ECOMMERCE_2_YEARS ]: 50,
+	[ DotcomPlans.ECOMMERCE_3_YEARS ]: 50,
+};
+
+/**
+ * Storage included with the given plan, in GB, or null for a product slug that
+ * is not a WordPress.com plan.
+ */
+export function getPlanStorageInGb( productSlug: string ): number | null {
+	return PLAN_STORAGE_IN_GB[ productSlug ] ?? null;
+}

--- a/client/dashboard/components/plan-expiry-notice/test/get-plan-expiry-notice.ts
+++ b/client/dashboard/components/plan-expiry-notice/test/get-plan-expiry-notice.ts
@@ -166,7 +166,7 @@ describe( 'within 60 days of expiration', () => {
 		expect( notice?.variant ).toBe( 'warning' );
 		// Days, not "in 1 month" — a rounded month reads far less urgent.
 		expect( notice?.title ).toBe( 'Your Business plan expires in 45 days' );
-		expect( notice?.primaryAction ).toMatchObject( { type: 'link', label: 'Renew now' } );
+		expect( notice?.primaryAction ).toMatchObject( { type: 'renew', label: 'Renew now' } );
 	} );
 
 	test( 'sends renewal checkout back where the caller says, not hardcoded to the dashboard', () => {

--- a/client/dashboard/components/plan-expiry-notice/test/get-plan-expiry-notice.ts
+++ b/client/dashboard/components/plan-expiry-notice/test/get-plan-expiry-notice.ts
@@ -342,12 +342,37 @@ describe( 'storage figures', () => {
 } );
 
 describe( 'monthly plans that cannot auto-renew', () => {
-	test( 'stay quiet until the last week', () => {
-		const monthly = makePurchase( {
-			bill_period_days: SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD,
-			expiry_date: expiryInDays( 20 ),
-		} );
+	const monthlyExpiringIn = ( days: number ) =>
+		getPlanExpiryNotice(
+			makePurchase( {
+				bill_period_days: SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD,
+				expiry_date: expiryInDays( days ),
+			} )
+		);
 
-		expect( getPlanExpiryNotice( monthly ) ).toBeNull();
+	test( 'are warned further out than a week, like any other term', () => {
+		expect( monthlyExpiringIn( 8 )?.variant ).toBe( 'warning' );
+	} );
+
+	test( 'are asked to turn auto-renew on rather than to renew a month early', () => {
+		expect( monthlyExpiringIn( 20 ) ).toMatchObject( {
+			variant: 'warning',
+			// The day count, not "in 1 month", which reads far less urgent.
+			title: 'Your Business plan expires in 20 days',
+			primaryAction: { label: 'Turn on auto-renew' },
+		} );
+	} );
+
+	test( 'are asked to renew once expiration is imminent', () => {
+		expect( monthlyExpiringIn( 3 )?.primaryAction ).toMatchObject( { label: 'Renew now' } );
+	} );
+
+	// Uncommon for a monthly plan, but reachable: stacked renewals or a custom
+	// expiration date can put one further out than the warning window.
+	test( 'are told about auto-renew when expiration is further off still', () => {
+		const notice = monthlyExpiringIn( 90 );
+
+		expect( notice?.variant ).toBe( 'info' );
+		expect( notice?.primaryAction ).toMatchObject( { label: 'Turn on auto-renew' } );
 	} );
 } );

--- a/client/dashboard/components/plan-expiry-notice/test/get-plan-expiry-notice.ts
+++ b/client/dashboard/components/plan-expiry-notice/test/get-plan-expiry-notice.ts
@@ -1,0 +1,353 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { DotcomPlans, SubscriptionBillPeriod } from '@automattic/api-core';
+import MockDate from 'mockdate';
+import { getPlanExpiryNotice, isEligibleForPlanExpiryNotice } from '../get-plan-expiry-notice';
+import type { Purchase } from '@automattic/api-core';
+
+const NOW = '2026-02-24T12:00:00Z';
+
+/**
+ * Noon UTC keeps the calendar-day arithmetic stable regardless of the time
+ * zone the test runner happens to be in.
+ */
+function expiryInDays( days: number ): string {
+	return new Date( Date.UTC( 2026, 1, 24 + days, 12 ) ).toISOString();
+}
+
+function makePurchase( overrides: Partial< Purchase > = {} ): Purchase {
+	return {
+		ID: 1234,
+		product_slug: DotcomPlans.BUSINESS,
+		product_name: 'WordPress.com Business',
+		expiry_date: expiryInDays( 120 ),
+		expiry_status: 'manual-renew',
+		subscription_status: 'active',
+		is_plan: true,
+		is_jetpack_plan_or_product: false,
+		bill_period_days: SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD,
+		is_auto_renew_enabled: false,
+		is_rechargeable: true,
+		might_still_auto_renew: false,
+		is_past_first_auto_renew_attempt_date: false,
+		is_past_last_auto_renew_attempt_date: false,
+		...overrides,
+	} as Purchase;
+}
+
+/** A plan that is auto-renewing normally. */
+function autoRenewing( overrides: Partial< Purchase > = {} ): Purchase {
+	return makePurchase( {
+		expiry_status: 'active',
+		is_auto_renew_enabled: true,
+		might_still_auto_renew: true,
+		...overrides,
+	} );
+}
+
+beforeEach( () => {
+	MockDate.set( NOW );
+} );
+
+afterEach( () => {
+	MockDate.reset();
+} );
+
+describe( 'isEligibleForPlanExpiryNotice', () => {
+	test( 'accepts each WordPress.com plan family', () => {
+		[
+			DotcomPlans.PERSONAL,
+			DotcomPlans.PREMIUM,
+			DotcomPlans.BUSINESS_2_YEARS,
+			DotcomPlans.ECOMMERCE_MONTHLY,
+		].forEach( ( product_slug ) => {
+			expect( isEligibleForPlanExpiryNotice( makePurchase( { product_slug } ) ) ).toBe( true );
+		} );
+	} );
+
+	test( 'rejects anything that is not one of those plans', () => {
+		[
+			'jetpack_security_t1_yearly',
+			'domain_reg',
+			'free_plan',
+			'ecommerce-trial-bundle-monthly',
+		].forEach( ( product_slug ) => {
+			expect( isEligibleForPlanExpiryNotice( makePurchase( { product_slug } ) ) ).toBe( false );
+		} );
+	} );
+
+	test( 'rejects a purchase that carries a plan slug but is not a plan', () => {
+		expect(
+			isEligibleForPlanExpiryNotice(
+				makePurchase( { is_plan: false, is_domain_registration: true } )
+			)
+		).toBe( false );
+	} );
+
+	test( 'rejects partner-managed plans, which the customer cannot renew', () => {
+		expect( isEligibleForPlanExpiryNotice( makePurchase( { partner_type: 'agency' } ) ) ).toBe(
+			false
+		);
+	} );
+
+	test( 'rejects removed subscriptions, which keep their existing copy', () => {
+		expect(
+			isEligibleForPlanExpiryNotice(
+				makePurchase( { expiry_status: 'expired', subscription_status: 'inactive' } )
+			)
+		).toBe( false );
+	} );
+
+	test( 'is true even when no notice is shown, so weaker notices stay suppressed', () => {
+		const purchase = autoRenewing( { expiry_date: expiryInDays( 120 ) } );
+		expect( isEligibleForPlanExpiryNotice( purchase ) ).toBe( true );
+		expect( getPlanExpiryNotice( purchase ) ).toBeNull();
+	} );
+} );
+
+describe( 'more than 60 days before expiration', () => {
+	test( 'warns an annual plan that cannot auto-renew, at info urgency', () => {
+		const notice = getPlanExpiryNotice( makePurchase( { expiry_date: expiryInDays( 120 ) } ) );
+
+		expect( notice?.variant ).toBe( 'info' );
+		expect( notice?.title ).toBe( 'Your Business plan expires in 4 months' );
+		expect( notice?.body ).toContain( '50 GB of storage' );
+		expect( notice?.body ).toContain( 'Turn on auto-renew' );
+	} );
+
+	test( 'names the expiration date in the body', () => {
+		const notice = getPlanExpiryNotice( makePurchase( { expiry_date: expiryInDays( 120 ) } ), {
+			locale: 'en',
+		} );
+
+		expect( notice?.body ).toContain( 'After June 24, 2026,' );
+	} );
+
+	test( 'offers to turn auto-renew on when it is simply switched off', () => {
+		const notice = getPlanExpiryNotice(
+			makePurchase( { expiry_date: expiryInDays( 120 ), is_auto_renew_enabled: false } )
+		);
+
+		expect( notice?.primaryAction ).toEqual( {
+			type: 'enable-auto-renew',
+			label: 'Turn on auto-renew',
+		} );
+	} );
+
+	test( 'sends the reader to add a payment method when that is what is missing', () => {
+		const notice = getPlanExpiryNotice(
+			makePurchase( {
+				expiry_date: expiryInDays( 120 ),
+				is_auto_renew_enabled: true,
+				is_rechargeable: false,
+				might_still_auto_renew: false,
+			} )
+		);
+
+		expect( notice?.primaryAction ).toEqual( {
+			type: 'add-payment-method',
+			label: 'Turn on auto-renew',
+		} );
+	} );
+
+	test( 'says nothing about a plan that is auto-renewing normally', () => {
+		expect(
+			getPlanExpiryNotice( autoRenewing( { expiry_date: expiryInDays( 120 ) } ) )
+		).toBeNull();
+	} );
+} );
+
+describe( 'within 60 days of expiration', () => {
+	test( 'escalates an annual plan that cannot auto-renew to a warning', () => {
+		const notice = getPlanExpiryNotice( makePurchase( { expiry_date: expiryInDays( 45 ) } ) );
+
+		expect( notice?.variant ).toBe( 'warning' );
+		// Days, not "in 1 month" — a rounded month reads far less urgent.
+		expect( notice?.title ).toBe( 'Your Business plan expires in 45 days' );
+		expect( notice?.primaryAction ).toMatchObject( { type: 'link', label: 'Renew now' } );
+	} );
+
+	test( 'sends renewal checkout back where the caller says, not hardcoded to the dashboard', () => {
+		const notice = getPlanExpiryNotice( makePurchase( { expiry_date: expiryInDays( 45 ) } ), {
+			renewReturnUrl: '/me/purchases/example.com/1234',
+		} );
+
+		const href =
+			notice?.primaryAction && 'href' in notice.primaryAction && notice.primaryAction.href;
+		expect( href ).toContain( 'cancel_to=%2Fme%2Fpurchases%2Fexample.com%2F1234' );
+		expect( href ).toContain( 'redirect_to=%2Fme%2Fpurchases%2Fexample.com%2F1234' );
+	} );
+
+	test( 'names the expiration date in the body', () => {
+		const notice = getPlanExpiryNotice( makePurchase( { expiry_date: expiryInDays( 45 ) } ), {
+			locale: 'en',
+		} );
+
+		expect( notice?.body ).toContain( 'After April 10, 2026,' );
+	} );
+
+	test( 'stays quiet about an auto-renewing plan whose first attempt is still ahead', () => {
+		expect( getPlanExpiryNotice( autoRenewing( { expiry_date: expiryInDays( 45 ) } ) ) ).toBeNull();
+	} );
+} );
+
+describe( 'past the first scheduled auto-renewal attempt', () => {
+	test( 'counts down an auto-renewing plan that failed its first attempt', () => {
+		const notice = getPlanExpiryNotice(
+			autoRenewing( {
+				expiry_date: expiryInDays( 29 ),
+				is_past_first_auto_renew_attempt_date: true,
+			} )
+		);
+
+		expect( notice?.variant ).toBe( 'warning' );
+		expect( notice?.title ).toBe( 'Your Business plan has 29 days remaining' );
+		expect( notice?.body ).toContain( 'If renewal doesn’t go through' );
+	} );
+
+	test( 'keeps the "cannot auto-renew" wording for a plan that never could', () => {
+		const notice = getPlanExpiryNotice(
+			makePurchase( {
+				expiry_date: expiryInDays( 29 ),
+				is_past_first_auto_renew_attempt_date: true,
+			} )
+		);
+
+		expect( notice?.variant ).toBe( 'warning' );
+		expect( notice?.title ).toBe( 'Your Business plan expires in 29 days' );
+	} );
+} );
+
+describe( 'within 7 days of expiration', () => {
+	test( 'escalates a plan that cannot auto-renew to an error, whatever its term', () => {
+		[
+			SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD,
+			SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD,
+		].forEach( ( bill_period_days ) => {
+			const notice = getPlanExpiryNotice(
+				makePurchase( { expiry_date: expiryInDays( 5 ), bill_period_days } )
+			);
+
+			expect( notice?.variant ).toBe( 'error' );
+			expect( notice?.title ).toBe( 'Your Business plan expires in 5 days' );
+		} );
+	} );
+
+	test( 'counts down an annual plan that can still auto-renew', () => {
+		const notice = getPlanExpiryNotice( autoRenewing( { expiry_date: expiryInDays( 5 ) } ) );
+
+		expect( notice?.variant ).toBe( 'error' );
+		expect( notice?.title ).toBe( 'Your Business plan has 5 days remaining' );
+	} );
+
+	test( 'says nothing about a monthly plan that is billing normally', () => {
+		const notice = getPlanExpiryNotice(
+			autoRenewing( {
+				expiry_date: expiryInDays( 5 ),
+				bill_period_days: SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD,
+			} )
+		);
+
+		expect( notice ).toBeNull();
+	} );
+} );
+
+describe( 'on the day of expiration', () => {
+	test( 'reads "expires today" whether or not the plan can auto-renew', () => {
+		[ makePurchase(), autoRenewing() ].forEach( ( base ) => {
+			const notice = getPlanExpiryNotice( { ...base, expiry_date: expiryInDays( 0 ) } );
+
+			expect( notice?.variant ).toBe( 'error' );
+			expect( notice?.title ).toBe( 'Your Business plan expires today' );
+		} );
+	} );
+
+	test( 'distinguishes the two cases in the body copy', () => {
+		expect(
+			getPlanExpiryNotice( makePurchase( { expiry_date: expiryInDays( 0 ) } ) )?.body
+		).toMatch( /^Unless you renew your plan/ );
+
+		expect(
+			getPlanExpiryNotice( autoRenewing( { expiry_date: expiryInDays( 0 ) } ) )?.body
+		).toMatch( /^If renewal doesn’t go through/ );
+	} );
+} );
+
+describe( 'after the expiration date', () => {
+	const expired = ( overrides: Partial< Purchase > = {} ) =>
+		makePurchase( {
+			expiry_date: expiryInDays( -3 ),
+			expiry_status: 'expired',
+			subscription_status: 'active',
+			...overrides,
+		} );
+
+	test( 'reports the plan as expired and offers a way out', () => {
+		const notice = getPlanExpiryNotice( expired(), {
+			viewOtherPlansUrl: '/setup/plan-upgrade',
+		} );
+
+		expect( notice?.variant ).toBe( 'error' );
+		expect( notice?.title ).toBe( 'Your Business plan has expired' );
+		expect( notice?.primaryAction ).toMatchObject( { label: 'Renew now' } );
+		expect( notice?.secondaryAction ).toMatchObject( {
+			label: 'View other plans',
+			href: '/setup/plan-upgrade',
+		} );
+	} );
+
+	test( 'leaves out the other-plans action when there is nowhere to send them', () => {
+		expect( getPlanExpiryNotice( expired() )?.secondaryAction ).toBeUndefined();
+	} );
+
+	test( 'softens the copy while an auto-renewal attempt may still land', () => {
+		const notice = getPlanExpiryNotice(
+			expired( { is_auto_renew_enabled: true, might_still_auto_renew: true } )
+		);
+
+		expect( notice?.body ).toMatch( /^If renewal doesn’t go through/ );
+	} );
+
+	test( 'falls back to the definite wording once the attempts are exhausted', () => {
+		// `might_still_auto_renew` is already false past the final attempt, so
+		// this needs no branch of its own — but that must stay true.
+		const notice = getPlanExpiryNotice(
+			expired( {
+				is_auto_renew_enabled: true,
+				might_still_auto_renew: false,
+				is_past_last_auto_renew_attempt_date: true,
+			} )
+		);
+
+		expect( notice?.body ).toMatch( /^Your site will move to the Free plan\./ );
+	} );
+} );
+
+describe( 'storage figures', () => {
+	test.each( [
+		[ DotcomPlans.PERSONAL, 'Personal', 6 ],
+		[ DotcomPlans.PREMIUM, 'Premium', 13 ],
+		[ DotcomPlans.BUSINESS, 'Business', 50 ],
+		[ DotcomPlans.ECOMMERCE, 'Commerce', 50 ],
+	] )( '%s reads as the %s plan with %d GB', ( product_slug, planName, storageGb ) => {
+		const notice = getPlanExpiryNotice(
+			makePurchase( { product_slug: product_slug as string, expiry_date: expiryInDays( 45 ) } )
+		);
+
+		expect( notice?.title ).toContain( planName );
+		expect( notice?.body ).toContain( `${ storageGb } GB of storage` );
+	} );
+} );
+
+describe( 'monthly plans that cannot auto-renew', () => {
+	test( 'stay quiet until the last week', () => {
+		const monthly = makePurchase( {
+			bill_period_days: SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD,
+			expiry_date: expiryInDays( 20 ),
+		} );
+
+		expect( getPlanExpiryNotice( monthly ) ).toBeNull();
+	} );
+} );

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -69,11 +69,13 @@ import { MetadataList, MetadataItem } from '../../../components/metadata-list';
 import OverviewCard from '../../../components/overview-card';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
+import { getPlanExpiryUrgency, hasPlanExpiryNotice } from '../../../components/plan-expiry-notice';
 import SiteIcon from '../../../components/site-icon';
+import { Text as IntentText } from '../../../components/text';
 import SiteBandwidthStat from '../../../sites/overview-plan-card/site-bandwidth-stat';
 import SiteStorageStat from '../../../sites/overview-plan-card/site-storage-stat';
 import { formatDate } from '../../../utils/datetime';
-import { redirectToDashboardLink, wpcomLink } from '../../../utils/link';
+import { wpcomLink } from '../../../utils/link';
 import {
 	getBillPeriodLabel,
 	getTitleForDisplay,
@@ -106,7 +108,7 @@ import {
 	hasAmountAvailableToRefund,
 } from '../../../utils/purchase';
 import {
-	getPurchaseSettingsRedirectBase,
+	getPlanChangeReturnUrls,
 	getSitePurchaseUpgradeUrl,
 	getSitePurchaseStorageUpgradeUrl,
 	getUpgradedPurchaseRedirectUrl,
@@ -200,9 +202,8 @@ function getHeaderUpgradeAction( purchase: Purchase ): { href: string; title: st
 	// WordPress.com plans go through the shared helper. A plan that gets nothing
 	// back has no upgrade to offer, and the non-plan path rejects it too.
 	const planAction = getPlanChangeAction( purchase, {
+		...getPlanChangeReturnUrls(),
 		upgradeOnly: true,
-		cancelTo: redirectToDashboardLink(),
-		redirectTo: getPurchaseSettingsRedirectBase(),
 	} );
 	if ( planAction ) {
 		return { href: planAction.href, title: planAction.title };
@@ -515,10 +516,7 @@ export function ProductChangeActionItem( { purchase }: { purchase: Purchase } ) 
 		} );
 
 	if ( isDotcomPlan( purchase ) ) {
-		const action = getPlanChangeAction( purchase, {
-			cancelTo: redirectToDashboardLink(),
-			redirectTo: getPurchaseSettingsRedirectBase(),
-		} );
+		const action = getPlanChangeAction( purchase, getPlanChangeReturnUrls() );
 		if ( ! action ) {
 			return null;
 		}
@@ -826,6 +824,18 @@ function getFields( {
 					}
 					return undefined;
 				} )();
+				// The first branch above reads "You will be billed on 1 August", a
+				// statement of what is going to happen; coloring it would contradict
+				// it. Only the expiry wordings take a color.
+				const expiryUrgency = isRenewingBeforeExpiration( purchase )
+					? null
+					: getPlanExpiryUrgency( purchase );
+				const help =
+					helpText && ( expiryUrgency === 'warning' || expiryUrgency === 'error' ) ? (
+						<IntentText intent={ expiryUrgency }>{ helpText }</IntentText>
+					) : (
+						helpText
+					);
 				if ( purchase.is_auto_renew_enabled && ! purchase.is_rechargeable ) {
 					if ( String( user.ID ) !== String( purchase.user_id ) ) {
 						return null;
@@ -867,7 +877,7 @@ function getFields( {
 						checked={ getValue( { item: purchase } ) }
 						disabled={ isMutationPending || isAutoRenewToggleDisabled( purchase, user ) }
 						onChange={ ( value: boolean ) => onChange( { is_auto_renew_enabled: value } ) }
-						help={ helpText }
+						help={ help }
 					/>
 				);
 			},
@@ -1471,13 +1481,23 @@ export default function PurchaseSettings() {
 	} );
 	const features = cancelFeaturesResponse?.features ?? null;
 	const hasExpiryInfo = ! purchase.partner_name || isA4ABillingDragonPurchase( purchase );
+	// These two are deliberately separate: the header stands down whenever there
+	// is a notice at all, while the expiry card only takes a color when there is
+	// something the customer has to act on. While a renewal is still expected the
+	// card reads "Auto-renew is enabled", or "Pending renewal" once past the
+	// expiry date; coloring either would contradict what they say.
+	const expiryUrgency = mightStillAutoRenew( purchase ) ? null : getPlanExpiryUrgency( purchase );
+	const planExpiryNoticeShowing = hasPlanExpiryNotice( purchase );
 
 	const isSmallViewport = useViewportMatch( 'medium', '<' );
 	const columns = isSmallViewport ? 1 : 2;
 	const spacing = isSmallViewport ? SPACING.SMALL : SPACING.DEFAULT;
 	const isCurrentPurchaseOwner = String( user.ID ) === String( purchase.user_id );
 	const canHeaderUpgrade = Boolean( upgradeAction );
-	const shouldShowHeaderUpgradeAction = canHeaderUpgrade && isCurrentPurchaseOwner;
+	// While the plan-expiry notice is up, keep the header on the one thing that
+	// needs doing. The quick-actions menu still holds everything else.
+	const shouldShowHeaderUpgradeAction =
+		canHeaderUpgrade && isCurrentPurchaseOwner && ! planExpiryNoticeShowing;
 	const shouldShowHeaderActionMenu =
 		isCurrentPurchaseOwner && ( canHeaderUpgrade || purchase.can_explicit_renew );
 	const shouldShowHeaderActions =
@@ -1591,6 +1611,7 @@ export default function PurchaseSettings() {
 							<OverviewCard
 								icon={ calendar }
 								title={ expiryDateTitle }
+								intent={ expiryUrgency === 'info' ? undefined : expiryUrgency ?? undefined }
 								heading={ ( () => {
 									if ( isIncluded && parentPurchase ) {
 										return parentWillRenew ? formattedParentRenewal : formattedParentExpiry;

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
@@ -5,6 +5,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { purchaseSettingsRoute } from '../../../app/router/me';
 import Notice from '../../../components/notice';
+import { isEligibleForPlanExpiryNotice } from '../../../components/plan-expiry-notice';
 import { getCalendarDaysUntil, getRelativeDayString } from '../../../utils/datetime';
 import {
 	isIncludedWithPlan,
@@ -40,6 +41,13 @@ export function shouldShowExpiringNotice(
 	}
 
 	if ( purchase.is_hundred_year_domain ) {
+		return false;
+	}
+
+	// PlanExpiryNotice owns this scenario for the plans it covers. When it
+	// stays quiet for one of them that is a decision, not a gap, so we must
+	// not fall back on this weaker message.
+	if ( isEligibleForPlanExpiryNotice( currentPurchase ) ) {
 		return false;
 	}
 

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -14,7 +14,7 @@ import {
 } from '@automattic/api-queries';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { Link } from '@tanstack/react-router';
+import { Link, useRouter } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -27,6 +27,11 @@ import { useAuth } from '../../../app/auth';
 import { useLocale } from '../../../app/locale';
 import { changePaymentMethodRoute, purchaseSettingsRoute } from '../../../app/router/me';
 import Notice from '../../../components/notice';
+import {
+	PlanExpiryNotice,
+	hasPlanExpiryNotice,
+	isEligibleForPlanExpiryNotice,
+} from '../../../components/plan-expiry-notice';
 import { formatDate } from '../../../utils/datetime';
 import { wpcomLink } from '../../../utils/link';
 import {
@@ -42,7 +47,12 @@ import {
 	getRenewalUrlFromPurchase,
 	isAkismetFreeProduct,
 } from '../../../utils/purchase';
-import { getSitePurchaseUpgradeUrl, getUpgradedPurchaseRedirectUrl } from '../../../utils/site-url';
+import {
+	getPlanChangeReturnUrls,
+	getSitePurchaseUpgradeUrl,
+	getUpgradedPurchaseRedirectUrl,
+	getWpcomPlanChangeUrl,
+} from '../../../utils/site-url';
 import { useIsSplitCancelRemoveEnabled } from '../cancel-purchase/use-is-split-cancel-remove-enabled';
 import { CancellationOfferNotice } from './cancellation-offer-notice';
 import {
@@ -69,6 +79,7 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 		intent,
 	} = purchaseSettingsRoute.useSearch();
 	const navigate = purchaseSettingsRoute.useNavigate();
+	const router = useRouter();
 	// Show the transient cancelled success notice once after a cancel redirects
 	// here. The URL search param is cleared immediately so that a refresh / back
 	// navigation falls through to the regular expiring notice.
@@ -321,6 +332,27 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 		return <ConciergeConsumedNotice />;
 	}
 
+	// A plan that is expiring, expired, or otherwise at risk of not renewing
+	// takes precedence over everything below: it is the one thing on this page
+	// that needs the customer to act.
+	if ( hasPlanExpiryNotice( purchase ) ) {
+		return (
+			<PlanExpiryNotice
+				purchase={ purchase }
+				addPaymentMethodUrl={
+					router.buildLocation( {
+						to: changePaymentMethodRoute.fullPath,
+						params: { purchaseId: purchase.ID },
+					} ).href
+				}
+				viewOtherPlansUrl={ getWpcomPlanChangeUrl( purchase, getPlanChangeReturnUrls() ) }
+				locale={ locale }
+				surface="dashboard-purchase-settings"
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		);
+	}
+
 	if (
 		shouldShowOtherRenewablePurchasesNotice(
 			purchase,
@@ -393,6 +425,13 @@ function shouldShowExpiredRenewNotice(
 	}
 
 	if ( isAkismetFreeProduct( currentPurchase ) ) {
+		return false;
+	}
+
+	// PlanExpiryNotice owns this scenario for the plans it covers. When it
+	// stays quiet for one of them that is a decision, not a gap, so we must
+	// not fall back on this weaker message.
+	if ( isEligibleForPlanExpiryNotice( currentPurchase ) ) {
 		return false;
 	}
 

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -637,14 +637,21 @@ function getCheckoutSiteSlugForPurchase( purchase: Purchase ): string {
 
 export function getRenewalUrlFromPurchase(
 	purchase: Purchase,
-	checkoutSiteSlugForUrl?: string
+	checkoutSiteSlugForUrl?: string,
+	backUrl?: string
 ): string {
-	return getRenewUrlForPurchases( [ purchase ], checkoutSiteSlugForUrl );
+	return getRenewUrlForPurchases( [ purchase ], checkoutSiteSlugForUrl, backUrl );
 }
 
+/**
+ * `backUrl` is where checkout returns to, whether the renewal goes through or is
+ * abandoned. It defaults to the dashboard page the user is on, so surfaces
+ * outside the dashboard have to say where they are.
+ */
 export function getRenewUrlForPurchases(
 	purchases: Purchase[],
-	checkoutSiteSlugForUrl?: string
+	checkoutSiteSlugForUrl?: string,
+	backUrl: string = redirectToDashboardLink()
 ): string {
 	if ( purchases.length < 1 ) {
 		throw new Error( 'Could not find product slug or purchase id for renewal.' );
@@ -657,7 +664,6 @@ export function getRenewUrlForPurchases(
 		checkoutSiteSlugForUrl || getCheckoutSiteSlugForPurchase( firstPurchase );
 	const servicePath = getServicePathForCheckoutFromPurchase( firstPurchase );
 	const purchaseIds = purchases.map( ( purchase ) => purchase.ID ).join( ',' );
-	const backUrl = redirectToDashboardLink();
 	return addQueryArgs(
 		wpcomLink(
 			`/checkout/${ servicePath }${ checkoutProductSlug }/renew/${ purchaseIds }/${ checkoutSiteSlug }`

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -293,6 +293,25 @@ export function getWpcomPlanChangeUrl(
 	return getWpcomPlanChangeTarget( purchase, input )?.href;
 }
 
+/**
+ * Where a plan change started from the Dashboard ends up: abandoning it returns
+ * the user to where they were, and completing it lands them on the new purchase.
+ * Shared by everything that offers a plan change, so they can't send people to
+ * different places.
+ *
+ * Not the plan-change URL itself — that comes back from
+ * {@link getWpcomPlanChangeTarget}, which these are an input to.
+ */
+export function getPlanChangeReturnUrls(): {
+	cancelTo: string;
+	redirectTo: string;
+} {
+	return {
+		cancelTo: redirectToDashboardLink(),
+		redirectTo: getPurchaseSettingsRedirectBase(),
+	};
+}
+
 function buildSitePlanUpgradeUrl( {
 	siteSlug,
 	isTrial,

--- a/client/lib/purchases/actions.ts
+++ b/client/lib/purchases/actions.ts
@@ -41,7 +41,7 @@ interface SurveyResponse {
 // through `@automattic/api-queries` (e.g. the manage-purchase page) won't see the
 // change until their queries are refetched. Invalidate the `[ 'upgrades' ]` root
 // key on the app's query client to cover every purchase query at once.
-function invalidatePurchaseQueries() {
+export function invalidatePurchaseQueries() {
 	getCalypsoQueryClient()?.invalidateQueries( userPurchasesQuery() );
 }
 

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -62,6 +62,7 @@ import { Plans, type SiteDetails } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { DOMAIN_CANCEL, SUPPORT_ROOT } from '@automattic/urls';
 import { useQuery } from '@tanstack/react-query';
+import { Button as WPButton } from '@wordpress/components';
 import { check, column, Icon, payment, reusableBlock, tool, trash, cloud } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize, LocalizeProps, useTranslate } from 'i18n-calypso';
@@ -78,9 +79,9 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import HeaderCake from 'calypso/components/header-cake';
 import CancelPurchaseForm from 'calypso/components/marketing-survey/cancel-purchase-form';
-import Notice from 'calypso/components/notice';
-import NoticeAction from 'calypso/components/notice/notice-action';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
+import Notice from 'calypso/dashboard/components/notice';
+import { hasPlanExpiryNotice } from 'calypso/dashboard/components/plan-expiry-notice';
 import {
 	getCancelButtonCopy,
 	getRemoveButtonCopy,
@@ -209,6 +210,12 @@ export interface ManagePurchaseConnectedProps {
 	hasLoadedDomains?: boolean;
 	hasLoadedPurchasesFromServer: boolean;
 	hasLoadedSites: boolean;
+	/**
+	 * Refetches the purchase this page is showing. Needed because Calypso reads
+	 * it from its own query client, which the `@automattic/api-queries` mutations
+	 * do not invalidate.
+	 */
+	refetchPurchase?: () => void;
 	hasCompletedCancelPurchaseSurvey: boolean | null;
 	hasNonPrimaryDomainsFlag?: boolean;
 	hasSetupAds?: boolean;
@@ -1445,7 +1452,7 @@ class ManagePurchase extends Component<
 								) }
 							</div>
 						</div>
-						{ isProductOwner && ! purchase.is_locked && (
+						{ isProductOwner && ! purchase.is_locked && ! hasPlanExpiryNotice( purchase ) && (
 							<div className="manage-purchase__renew-upgrade-buttons">
 								{ this.renderUpgradeButton( preventRenewal ) }
 								{ this.renderStorageUpgradeButton( preventRenewal ) }
@@ -1572,36 +1579,49 @@ class ManagePurchase extends Component<
 				>
 					{ this.props.cardTitle || titles.managePurchase }
 				</HeaderCake>
-				{ showExpiryNotice ? (
-					<Notice status="is-info" text={ <PlanRenewalMessage /> } showDismiss={ false }>
-						<NoticeAction href={ `/plans/${ siteSlug || '' }` }>
-							{ translate( 'View plans' ) }
-						</NoticeAction>
-					</Notice>
-				) : (
-					<PurchaseNotice
-						isDataLoading={ this.isDataLoading( this.props ) }
-						handleRenew={ this.handleRenew }
-						handleRenewMultiplePurchases={ this.handleRenewMultiplePurchases }
-						selectedSite={ site }
+				<div className="manage-purchase__notices">
+					{ showExpiryNotice ? (
+						<Notice
+							variant="info"
+							actions={
+								<WPButton variant="secondary" href={ `/plans/${ siteSlug || '' }` }>
+									{ translate( 'View plans' ) }
+								</WPButton>
+							}
+						>
+							<PlanRenewalMessage />
+						</Notice>
+					) : (
+						<PurchaseNotice
+							isDataLoading={ this.isDataLoading( this.props ) }
+							handleRenew={ this.handleRenew }
+							handleRenewMultiplePurchases={ this.handleRenewMultiplePurchases }
+							selectedSite={ site }
+							purchase={ purchase }
+							purchaseAttachedTo={ purchaseAttachedTo }
+							renewableSitePurchases={ renewableSitePurchases }
+							changePaymentMethodPath={ changePaymentMethodPath }
+							viewOtherPlansUrl={ this.buildPlanChangeAction()?.href }
+							renewReturnUrl={ ( getManagePurchaseUrlFor ?? managePurchase )(
+								siteSlug,
+								purchase.ID
+							) }
+							getManagePurchaseUrlFor={ getManagePurchaseUrlFor ?? managePurchase }
+							isProductOwner={ isProductOwner ?? false }
+							willAtomicSiteRevert={ willAtomicSiteRevert }
+							getAddNewPaymentMethodUrlFor={
+								getAddNewPaymentMethodUrlFor ?? getAddNewPaymentMethodPath
+							}
+							refetchPurchase={ this.props.refetchPurchase }
+						/>
+					) }
+					<PlanOverlapNotice
+						isSiteLevel={ this.props.isSiteLevel ?? false }
+						selectedSiteId={ this.props.selectedSiteId ?? 0 }
+						siteId={ this.props.siteId ?? 0 }
 						purchase={ purchase }
-						purchaseAttachedTo={ purchaseAttachedTo }
-						renewableSitePurchases={ renewableSitePurchases }
-						changePaymentMethodPath={ changePaymentMethodPath }
-						getManagePurchaseUrlFor={ getManagePurchaseUrlFor ?? managePurchase }
-						isProductOwner={ isProductOwner ?? false }
-						willAtomicSiteRevert={ willAtomicSiteRevert }
-						getAddNewPaymentMethodUrlFor={
-							getAddNewPaymentMethodUrlFor ?? getAddNewPaymentMethodPath
-						}
 					/>
-				) }
-				<PlanOverlapNotice
-					isSiteLevel={ this.props.isSiteLevel ?? false }
-					selectedSiteId={ this.props.selectedSiteId ?? 0 }
-					siteId={ this.props.siteId ?? 0 }
-					purchase={ purchase }
-				/>
+				</div>
 				{ this.renderPurchaseDetail( preventRenewal ) }
 			</Fragment>
 		);
@@ -1808,6 +1828,7 @@ const ConnectedManagePurchase = connect(
 			purchases: Purchase[] | undefined;
 			renewableSitePurchases: Purchase[];
 			hasLoadedPurchasesFromServer: boolean;
+			refetchPurchase?: () => void;
 		}
 	) => {
 		const { purchase, purchaseAttachedTo, purchases, renewableSitePurchases } = props;
@@ -1890,7 +1911,11 @@ function ManagePurchaseWithExperiment( props: ManagePurchaseProps ) {
 		...purchaseCancelFeaturesQuery( props.purchaseId ),
 	} );
 	const cancellationFeatures = cancelFeaturesResponse?.features ?? null;
-	const { data: purchase, isPending: isPurchasePending } = useQuery( {
+	const {
+		data: purchase,
+		isPending: isPurchasePending,
+		refetch: refetchPurchase,
+	} = useQuery( {
 		...purchaseQuery( Number( props.purchaseId ) ),
 		enabled: Boolean( props.purchaseId ),
 	} );
@@ -1912,6 +1937,7 @@ function ManagePurchaseWithExperiment( props: ManagePurchaseProps ) {
 			purchases={ sitePurchases }
 			renewableSitePurchases={ renewableSitePurchases }
 			hasLoadedPurchasesFromServer={ ! isPurchasePending }
+			refetchPurchase={ refetchPurchase }
 		/>
 	);
 }

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -210,12 +210,6 @@ export interface ManagePurchaseConnectedProps {
 	hasLoadedDomains?: boolean;
 	hasLoadedPurchasesFromServer: boolean;
 	hasLoadedSites: boolean;
-	/**
-	 * Refetches the purchase this page is showing. Needed because Calypso reads
-	 * it from its own query client, which the `@automattic/api-queries` mutations
-	 * do not invalidate.
-	 */
-	refetchPurchase?: () => void;
 	hasCompletedCancelPurchaseSurvey: boolean | null;
 	hasNonPrimaryDomainsFlag?: boolean;
 	hasSetupAds?: boolean;
@@ -1612,7 +1606,6 @@ class ManagePurchase extends Component<
 							getAddNewPaymentMethodUrlFor={
 								getAddNewPaymentMethodUrlFor ?? getAddNewPaymentMethodPath
 							}
-							refetchPurchase={ this.props.refetchPurchase }
 						/>
 					) }
 					<PlanOverlapNotice
@@ -1828,7 +1821,6 @@ const ConnectedManagePurchase = connect(
 			purchases: Purchase[] | undefined;
 			renewableSitePurchases: Purchase[];
 			hasLoadedPurchasesFromServer: boolean;
-			refetchPurchase?: () => void;
 		}
 	) => {
 		const { purchase, purchaseAttachedTo, purchases, renewableSitePurchases } = props;
@@ -1911,11 +1903,7 @@ function ManagePurchaseWithExperiment( props: ManagePurchaseProps ) {
 		...purchaseCancelFeaturesQuery( props.purchaseId ),
 	} );
 	const cancellationFeatures = cancelFeaturesResponse?.features ?? null;
-	const {
-		data: purchase,
-		isPending: isPurchasePending,
-		refetch: refetchPurchase,
-	} = useQuery( {
+	const { data: purchase, isPending: isPurchasePending } = useQuery( {
 		...purchaseQuery( Number( props.purchaseId ) ),
 		enabled: Boolean( props.purchaseId ),
 	} );
@@ -1937,7 +1925,6 @@ function ManagePurchaseWithExperiment( props: ManagePurchaseProps ) {
 			purchases={ sitePurchases }
 			renewableSitePurchases={ renewableSitePurchases }
 			hasLoadedPurchasesFromServer={ ! isPurchasePending }
-			refetchPurchase={ refetchPurchase }
 		/>
 	);
 }

--- a/client/me/purchases/manage-purchase/notices.scss
+++ b/client/me/purchases/manage-purchase/notices.scss
@@ -3,7 +3,7 @@
 	border: none;
 	border-radius: 0;
 	padding: 0;
-	color: var(--color-text-inverted);
+	color: var(--color-link);
 	font-weight: 400;
 	font-size: inherit;
 	line-height: 1.65;
@@ -12,7 +12,7 @@
 
 	&:hover,
 	&:focus {
-		color: var(--color-link-light);
+		color: var(--color-link-dark);
 		box-shadow: none;
 	}
 }

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -40,6 +40,7 @@ import { getProductNounForCategory } from 'calypso/dashboard/me/billing-purchase
 import { getCalendarDaysUntil, getRelativeDayString } from 'calypso/dashboard/utils/datetime';
 import { isPartnerPurchase } from 'calypso/dashboard/utils/purchase';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { invalidatePurchaseQueries } from 'calypso/lib/purchases/actions';
 import { createPurchasesArray } from 'calypso/lib/purchases/assembler';
 import { getTrialCheckoutUrl } from 'calypso/lib/trials/get-trial-checkout-url';
 import { managePurchase } from 'calypso/me/purchases/paths';
@@ -92,8 +93,6 @@ export interface PurchaseNoticeProps {
 	purchase: Purchase;
 	purchaseAttachedTo: Purchase | null | undefined;
 	renewableSitePurchases: Purchase[];
-	/** Refreshes the purchase after the notice turns auto-renew on. */
-	refetchPurchase?: () => void;
 	selectedSite: SiteDetails | null | undefined;
 	/** Shared with the page's plan-change nav item, so the two can't disagree. */
 	viewOtherPlansUrl?: string;
@@ -1689,7 +1688,7 @@ class PurchaseNotice extends Component<
 					locale={ i18n.getLocaleSlug() ?? 'en' }
 					surface="calypso-manage-purchase"
 					recordTracksEvent={ this.props.recordTracksEvent }
-					onAutoRenewEnabled={ this.props.refetchPurchase }
+					onAutoRenewEnabled={ invalidatePurchaseQueries }
 				/>
 			);
 		}

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -22,13 +22,19 @@ import {
 import page from '@automattic/calypso-router';
 import { minBy } from '@automattic/js-utils';
 import { useMutation } from '@tanstack/react-query';
-import { localize, useTranslate, fixMe } from 'i18n-calypso';
+import { Button } from '@wordpress/components';
+import { info } from '@wordpress/icons';
+import i18n, { localize, useTranslate, fixMe } from 'i18n-calypso';
 import moment from 'moment';
 import { Component } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import Notice, { NoticeStatus } from 'calypso/components/notice';
-import NoticeAction from 'calypso/components/notice/notice-action';
+import Notice from 'calypso/dashboard/components/notice';
+import {
+	PlanExpiryNotice,
+	hasPlanExpiryNotice,
+	isEligibleForPlanExpiryNotice,
+} from 'calypso/dashboard/components/plan-expiry-notice';
 import { useIsSplitCancelRemoveEnabled } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled';
 import { getProductNounForCategory } from 'calypso/dashboard/me/billing-purchases/purchase-settings/classify-purchase-for-copy';
 import { getCalendarDaysUntil, getRelativeDayString } from 'calypso/dashboard/utils/datetime';
@@ -65,6 +71,8 @@ import { classifyPurchaseForCopy } from './classify-purchase-for-copy';
 import type { GetManagePurchaseUrlFor } from '../lib/types';
 import type { Purchase, PurchasePaymentCreditCard } from '@automattic/api-core';
 import type { SiteDetails } from '@automattic/data-stores';
+import type { IconType } from '@wordpress/components';
+import type { NoticeVariant } from 'calypso/dashboard/components/notice/types';
 import type { LocalizeProps, TranslateOptions } from 'i18n-calypso';
 import type { ReactNode, ReactElement } from 'react';
 
@@ -84,7 +92,13 @@ export interface PurchaseNoticeProps {
 	purchase: Purchase;
 	purchaseAttachedTo: Purchase | null | undefined;
 	renewableSitePurchases: Purchase[];
+	/** Refreshes the purchase after the notice turns auto-renew on. */
+	refetchPurchase?: () => void;
 	selectedSite: SiteDetails | null | undefined;
+	/** Shared with the page's plan-change nav item, so the two can't disagree. */
+	viewOtherPlansUrl?: string;
+	/** Where renewal checkout comes back to; Calypso-relative, not the dashboard. */
+	renewReturnUrl?: string;
 	willAtomicSiteRevert?: boolean;
 	/** Called when the user clicks the cancel button on the pending delayed-downgrade notice. */
 	onCancelDelayedDowngrade?: () => void;
@@ -238,18 +252,18 @@ class PurchaseNotice extends Component<
 
 		return (
 			<Notice
-				className="manage-purchase__delayed-downgrade-pending-notice"
-				showDismiss={ false }
-				status="is-warning"
-				text={ noticeText }
+				variant="warning"
+				actions={
+					onCancelDelayedDowngrade && (
+						<Button variant="secondary" onClick={ onCancelDelayedDowngrade }>
+							{ isCancellingDelayedDowngrade
+								? translate( 'Cancelling…' )
+								: translate( 'Cancel downgrade' ) }
+						</Button>
+					)
+				}
 			>
-				{ onCancelDelayedDowngrade && (
-					<NoticeAction onClick={ onCancelDelayedDowngrade }>
-						{ isCancellingDelayedDowngrade
-							? translate( 'Cancelling…' )
-							: translate( 'Cancel downgrade' ) }
-					</NoticeAction>
-				) }
+				{ noticeText }
 			</Notice>
 		);
 	}
@@ -280,24 +294,15 @@ class PurchaseNotice extends Component<
 				}
 			);
 			return (
-				<Notice
-					className="manage-purchase__purchase-expiring-notice"
-					showDismiss
-					onDismissClick={ this.dismissCancelledRedirectNotice }
-					status="is-success"
-					text={ noticeText }
-				/>
+				<Notice variant="success" onClose={ this.dismissCancelledRedirectNotice }>
+					{ noticeText }
+				</Notice>
 			);
 		}
 		if ( willAtomicSiteRevert ) {
 			const exportUrl = `https://${ purchase.domain }/wp-admin/export.php`;
 			return (
-				<Notice
-					className="manage-purchase__purchase-expiring-notice"
-					showDismiss
-					onDismissClick={ this.dismissCancelledRedirectNotice }
-					status="is-success"
-				>
+				<Notice variant="success" onClose={ this.dismissCancelledRedirectNotice }>
 					{ translate(
 						'Your subscription is cancelled and you won\u2019t be billed again. Your site stays live until %(expiryDate)s. {{a}}Download a backup{{/a}} to save your content, themes, and plugins.',
 						{
@@ -320,13 +325,9 @@ class PurchaseNotice extends Component<
 			}
 		);
 		return (
-			<Notice
-				className="manage-purchase__purchase-expiring-notice"
-				showDismiss
-				onDismissClick={ this.dismissCancelledRedirectNotice }
-				status="is-success"
-				text={ noticeText }
-			/>
+			<Notice variant="success" onClose={ this.dismissCancelledRedirectNotice }>
+				{ noticeText }
+			</Notice>
 		);
 	}
 
@@ -335,13 +336,9 @@ class PurchaseNotice extends Component<
 			return null;
 		}
 		return (
-			<Notice
-				className="manage-purchase__purchase-expiring-notice"
-				showDismiss
-				onDismissClick={ this.dismissDowngradedRedirectNotice }
-				status="is-success"
-				text={ this.props.translate( 'You\u2019ve switched to monthly billing.' ) }
-			/>
+			<Notice variant="success" onClose={ this.dismissDowngradedRedirectNotice }>
+				{ this.props.translate( 'You\u2019ve switched to monthly billing.' ) }
+			</Notice>
 		);
 	}
 
@@ -357,15 +354,11 @@ class PurchaseNotice extends Component<
 			return null;
 		}
 		return (
-			<Notice
-				className="manage-purchase__purchase-expiring-notice"
-				showDismiss
-				onDismissClick={ this.dismissPlanChangedRedirectNotice }
-				status="is-success"
-				text={ translate( 'Your plan has been updated to %(planName)s.', {
+			<Notice variant="success" onClose={ this.dismissPlanChangedRedirectNotice }>
+				{ translate( 'Your plan has been updated to %(planName)s.', {
 					args: { planName: getName( purchase ) },
 				} ) }
-			/>
+			</Notice>
 		);
 	}
 
@@ -413,13 +406,9 @@ class PurchaseNotice extends Component<
 			text = translate( 'Your plan downgrade has been scheduled for your next renewal.' );
 		}
 		return (
-			<Notice
-				className="manage-purchase__purchase-expiring-notice"
-				showDismiss
-				onDismissClick={ this.dismissDelayedDowngradeScheduledNotice }
-				status="is-success"
-				text={ text }
-			/>
+			<Notice variant="success" onClose={ this.dismissDelayedDowngradeScheduledNotice }>
+				{ text }
+			</Notice>
 		);
 	}
 
@@ -562,9 +551,12 @@ class PurchaseNotice extends Component<
 			( ! purchase.can_explicit_renew || shouldAddPaymentSourceInsteadOfRenewingNow( purchase ) )
 		) {
 			return (
-				<NoticeAction href={ changePaymentMethodPath ? changePaymentMethodPath : undefined }>
+				<Button
+					variant="primary"
+					href={ changePaymentMethodPath ? changePaymentMethodPath : undefined }
+				>
 					{ translate( 'Add Payment Method' ) }
-				</NoticeAction>
+				</Button>
 			);
 		}
 
@@ -572,11 +564,14 @@ class PurchaseNotice extends Component<
 		// credits, we should show an "Add Payment Method" action.
 		if ( isPaidWithCredits( purchase ) && purchase.expiry_status === 'manual-renew' ) {
 			return (
-				<NoticeAction href={ changePaymentMethodPath ? changePaymentMethodPath : undefined }>
+				<Button
+					variant="primary"
+					href={ changePaymentMethodPath ? changePaymentMethodPath : undefined }
+				>
 					{ config.isEnabled( 'purchases/new-payment-methods' )
 						? translate( 'Add Payment Method' )
 						: translate( 'Add Credit Card' ) }
-				</NoticeAction>
+				</Button>
 			);
 		}
 
@@ -584,7 +579,11 @@ class PurchaseNotice extends Component<
 			! isRechargeable( purchase ) ||
 			( purchase.can_explicit_renew && isExpiredAndInGracePeriod( purchase ) )
 		) {
-			return <NoticeAction onClick={ onClick }>{ translate( 'Renew Now' ) }</NoticeAction>;
+			return (
+				<Button variant="primary" onClick={ onClick }>
+					{ translate( 'Renew Now' ) }
+				</Button>
+			);
 		}
 
 		return null;
@@ -677,10 +676,17 @@ class PurchaseNotice extends Component<
 			return null;
 		}
 
-		let noticeStatus: NoticeStatus = 'is-info';
+		// PlanExpiryNotice owns this scenario for the plans it covers. When it
+		// stays quiet for one of them that is a decision, not a gap, so we must
+		// not fall back on this weaker message.
+		if ( isEligibleForPlanExpiryNotice( currentPurchase ) ) {
+			return null;
+		}
+
+		let noticeVariant: NoticeVariant = 'info';
 
 		if ( isCloseToExpiration( currentPurchase ) && ! isRecentMonthlyPurchase( currentPurchase ) ) {
-			noticeStatus = 'is-error';
+			noticeVariant = 'error';
 		}
 
 		if ( usePlanInsteadOfIncludedPurchase && ! selectedSite ) {
@@ -708,12 +714,8 @@ class PurchaseNotice extends Component<
 			// So we have to rely on the user going to the manage purchase page
 			// for the plan to renew it there.
 			return (
-				<Notice
-					className="manage-purchase__purchase-expiring-notice"
-					showDismiss={ false }
-					status={ noticeStatus }
-					text={ noticeText }
-				>
+				<Notice variant={ noticeVariant }>
+					{ noticeText }
 					{ this.trackImpression( 'purchase-expiring' ) }
 				</Notice>
 			);
@@ -722,12 +724,10 @@ class PurchaseNotice extends Component<
 		const noticeText = this.getExpiringText( currentPurchase );
 		return (
 			<Notice
-				className="manage-purchase__purchase-expiring-notice"
-				showDismiss={ false }
-				status={ noticeStatus }
-				text={ noticeText }
+				variant={ noticeVariant }
+				actions={ this.renderRenewNoticeAction( this.handleExpiringNoticeRenewal ) }
 			>
-				{ this.renderRenewNoticeAction( this.handleExpiringNoticeRenewal ) }
+				{ noticeText }
 				{ this.trackImpression( 'purchase-expiring' ) }
 			</Notice>
 		);
@@ -833,8 +833,8 @@ class PurchaseNotice extends Component<
 			},
 		};
 
-		let noticeStatus: NoticeStatus = 'is-info';
-		let noticeIcon = null;
+		let noticeVariant: NoticeVariant = 'info';
+		let noticeIcon: IconType | null = null;
 		let noticeActionHref = null;
 		let noticeActionOnClick = null;
 		let noticeActionText = '';
@@ -847,10 +847,10 @@ class PurchaseNotice extends Component<
 			currentPurchaseIsExpiring &&
 			anotherPurchaseIsExpiring
 		) {
-			noticeStatus =
+			noticeVariant =
 				suppressErrorStylingForCurrentPurchase && suppressErrorStylingForOtherPurchases
-					? 'is-info'
-					: 'is-error';
+					? 'info'
+					: 'error';
 			noticeActionOnClick = this.handleExpiringNoticeRenewAll;
 			noticeActionText = translate( 'Renew all' );
 			noticeImpressionName = 'current-expires-soon-others-expire-soon';
@@ -934,7 +934,7 @@ class PurchaseNotice extends Component<
 			currentPurchaseIsExpiring &&
 			! anotherPurchaseIsExpiring
 		) {
-			noticeStatus = suppressErrorStylingForCurrentPurchase ? 'is-info' : 'is-error';
+			noticeVariant = suppressErrorStylingForCurrentPurchase ? 'info' : 'error';
 			noticeImpressionName = 'current-expires-soon-others-renew-soon';
 
 			if ( isExpiredAndInGracePeriod( currentPurchase ) ) {
@@ -992,7 +992,7 @@ class PurchaseNotice extends Component<
 			! currentPurchaseIsExpiring &&
 			anotherPurchaseIsExpiring
 		) {
-			noticeStatus = suppressErrorStylingForOtherPurchases ? 'is-info' : 'is-error';
+			noticeVariant = suppressErrorStylingForOtherPurchases ? 'info' : 'error';
 			noticeActionOnClick = this.handleExpiringNoticeRenewAll;
 			noticeActionText = translate( 'Renew all' );
 			noticeImpressionName = 'current-renews-soon-others-expire-soon';
@@ -1053,15 +1053,15 @@ class PurchaseNotice extends Component<
 			! anotherPurchaseIsExpiring
 		) {
 			if ( ! currentPurchaseCreditCardExpiresBeforeSubscription ) {
-				noticeStatus = suppressErrorStylingForOtherPurchases ? 'is-info' : 'is-error';
-				noticeIcon = 'info';
+				noticeVariant = suppressErrorStylingForOtherPurchases ? 'info' : 'error';
+				noticeIcon = info;
 				noticeImpressionName = 'current-renews-soon-others-renew-soon';
 				noticeText = translate(
 					'You have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
 					translateOptions
 				);
 			} else if ( getPurchasePayment( currentPurchase ).creditCard ) {
-				noticeStatus = showCreditCardExpiringWarning( currentPurchase ) ? 'is-error' : 'is-info';
+				noticeVariant = showCreditCardExpiringWarning( currentPurchase ) ? 'error' : 'info';
 				noticeActionHref = getAddNewPaymentMethodUrlFor( selectedSite.slug );
 				noticeActionOnClick = this.handleExpiringCardNoticeUpdateAll;
 				noticeActionText = translate( 'Update all' );
@@ -1094,7 +1094,7 @@ class PurchaseNotice extends Component<
 			currentPurchaseIsExpiring &&
 			anotherPurchaseIsExpiring
 		) {
-			noticeStatus = suppressErrorStylingForOtherPurchases ? 'is-info' : 'is-error';
+			noticeVariant = suppressErrorStylingForOtherPurchases ? 'info' : 'error';
 			noticeActionOnClick = this.handleExpiringNoticeRenewAll;
 			noticeActionText = translate( 'Renew Now' );
 			noticeImpressionName = 'current-expires-later-others-expire-soon';
@@ -1118,11 +1118,11 @@ class PurchaseNotice extends Component<
 			currentPurchaseIsExpiring &&
 			! anotherPurchaseIsExpiring
 		) {
-			noticeStatus = 'is-info';
+			noticeVariant = 'info';
 			noticeImpressionName = 'current-expires-later-others-renew-soon';
 
 			if ( isExpiredAndInGracePeriod( currentPurchase ) ) {
-				noticeStatus = suppressErrorStylingForOtherPurchases ? 'is-info' : 'is-error';
+				noticeVariant = suppressErrorStylingForOtherPurchases ? 'info' : 'error';
 				if ( isDomainRegistration( currentPurchase ) ) {
 					noticeText = translate(
 						'Your %(purchaseName)s domain expired %(expiry)s and will be removed soon unless you take action. You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
@@ -1162,7 +1162,7 @@ class PurchaseNotice extends Component<
 			! currentPurchaseIsExpiring &&
 			anotherPurchaseIsExpiring
 		) {
-			noticeStatus = suppressErrorStylingForOtherPurchases ? 'is-info' : 'is-error';
+			noticeVariant = suppressErrorStylingForOtherPurchases ? 'info' : 'error';
 			noticeActionOnClick = this.handleExpiringNoticeRenewAll;
 			noticeActionText = translate( 'Renew Now' );
 			noticeImpressionName = 'current-renews-later-others-expire-soon';
@@ -1188,15 +1188,15 @@ class PurchaseNotice extends Component<
 			! is100Year( purchase )
 		) {
 			if ( ! currentPurchaseCreditCardExpiresBeforeSubscription ) {
-				noticeStatus = 'is-success';
-				noticeIcon = 'info';
+				noticeVariant = 'success';
+				noticeIcon = info;
 				noticeImpressionName = 'current-renews-later-others-renew-soon';
 				noticeText = translate(
 					'You have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
 					translateOptions
 				);
 			} else if ( getPurchasePayment( currentPurchase ).creditCard ) {
-				noticeStatus = 'is-info';
+				noticeVariant = 'info';
 				noticeActionHref = getAddNewPaymentMethodUrlFor( selectedSite.slug );
 				noticeActionOnClick = this.handleExpiringCardNoticeUpdateAll;
 				noticeActionText = translate( 'Update all' );
@@ -1252,20 +1252,21 @@ class PurchaseNotice extends Component<
 					onClose={ this.closeUpcomingRenewalsDialog }
 				/>
 				<Notice
-					className="manage-purchase__other-renewable-purchases-notice"
-					showDismiss={ false }
-					status={ noticeStatus }
-					icon={ noticeIcon }
-					text={ noticeText }
+					variant={ noticeVariant }
+					icon={ noticeIcon ?? undefined }
+					actions={
+						( noticeActionHref || noticeActionOnClick ) && (
+							<Button
+								variant="primary"
+								href={ noticeActionHref ?? undefined }
+								onClick={ noticeActionOnClick ?? undefined }
+							>
+								{ noticeActionText }
+							</Button>
+						)
+					}
 				>
-					{ ( noticeActionHref || noticeActionOnClick ) && (
-						<NoticeAction
-							href={ noticeActionHref ?? undefined }
-							onClick={ noticeActionOnClick ?? undefined }
-						>
-							{ noticeActionText }
-						</NoticeAction>
-					) }
+					{ noticeText }
 					{ noticeImpressionName && this.trackImpression( noticeImpressionName ) }
 				</Notice>
 			</>
@@ -1319,11 +1320,7 @@ class PurchaseNotice extends Component<
 				<span />
 			);
 			return (
-				<Notice
-					className="manage-purchase__expiring-credit-card-notice"
-					showDismiss={ false }
-					status={ showCreditCardExpiringWarning( purchase ) ? 'is-error' : 'is-info' }
-				>
+				<Notice variant={ showCreditCardExpiringWarning( purchase ) ? 'error' : 'info' }>
 					{ creditCardHasAlreadyExpired( purchase )
 						? translate(
 								'Your %(cardType)s ending in %(cardNumber)d expired %(cardExpiry)s ' +
@@ -1389,6 +1386,13 @@ class PurchaseNotice extends Component<
 			return null;
 		}
 
+		// PlanExpiryNotice owns this scenario for the plans it covers. When it
+		// stays quiet for one of them that is a decision, not a gap, so we must
+		// not fall back on this weaker message.
+		if ( isEligibleForPlanExpiryNotice( currentPurchase ) ) {
+			return null;
+		}
+
 		if ( isRenewable( purchase ) ) {
 			const noticeText = ( () => {
 				if ( isRemoved( currentPurchase ) ) {
@@ -1405,8 +1409,11 @@ class PurchaseNotice extends Component<
 			} )();
 
 			return (
-				<Notice showDismiss={ false } status="is-error" text={ noticeText }>
-					{ this.renderRenewNoticeAction( this.handleExpiredNoticeRenewal ) }
+				<Notice
+					variant="error"
+					actions={ this.renderRenewNoticeAction( this.handleExpiredNoticeRenewal ) }
+				>
+					{ noticeText }
 					{ this.trackImpression( 'purchase-expired' ) }
 				</Notice>
 			);
@@ -1451,7 +1458,8 @@ class PurchaseNotice extends Component<
 		// So we have to rely on the user going to the manage purchase page
 		// for the plan to renew it there.
 		return (
-			<Notice showDismiss={ false } status="is-error" text={ noticeText }>
+			<Notice variant="error">
+				{ noticeText }
 				{ this.trackImpression( 'purchase-expired' ) }
 			</Notice>
 		);
@@ -1471,11 +1479,8 @@ class PurchaseNotice extends Component<
 	renderConciergeConsumedNotice() {
 		const { translate } = this.props;
 		return (
-			<Notice
-				showDismiss={ false }
-				status="is-info"
-				text={ translate( 'This session has been used.' ) }
-			>
+			<Notice variant="info">
+				{ translate( 'This session has been used.' ) }
 				{ this.trackImpression( 'concierge-session-used' ) }
 			</Notice>
 		);
@@ -1485,13 +1490,11 @@ class PurchaseNotice extends Component<
 		const { translate } = this.props;
 
 		return (
-			<Notice
-				showDismiss={ false }
-				status="is-info"
-				text={ translate(
+			<Notice variant="info">
+				{ translate(
 					'This product was purchased by a different WordPress.com account. To manage this product, log in to that account or contact the account owner.'
 				) }
-			></Notice>
+			</Notice>
 		);
 	}
 
@@ -1499,10 +1502,8 @@ class PurchaseNotice extends Component<
 		const { purchase, translate } = this.props;
 
 		return (
-			<Notice
-				showDismiss={ false }
-				status="is-info"
-				text={ translate(
+			<Notice variant="info">
+				{ translate(
 					'This product is an in-app purchase. You can manage it from within {{managePurchase}}the app store{{/managePurchase}}.',
 					{
 						components: {
@@ -1510,7 +1511,7 @@ class PurchaseNotice extends Component<
 						},
 					}
 				) }
-			/>
+			</Notice>
 		);
 	}
 
@@ -1580,8 +1581,15 @@ class PurchaseNotice extends Component<
 		}
 
 		return (
-			<Notice showDismiss={ false } status="is-info" text={ noticeText }>
-				<NoticeAction onClick={ onClick }>{ translate( 'Upgrade Now' ) }</NoticeAction>
+			<Notice
+				variant="info"
+				actions={
+					<Button variant="primary" onClick={ onClick }>
+						{ translate( 'Upgrade Now' ) }
+					</Button>
+				}
+			>
+				{ noticeText }
 			</Notice>
 		);
 	}
@@ -1592,7 +1600,7 @@ class PurchaseNotice extends Component<
 			'There is currently a payment processing for this subscription. Please wait for the payment to complete before attempting to make any changes.'
 		);
 
-		return <Notice showDismiss={ false } status="is-warning" text={ noticeText }></Notice>;
+		return <Notice variant="warning">{ noticeText }</Notice>;
 	}
 
 	render() {
@@ -1666,6 +1674,24 @@ class PurchaseNotice extends Component<
 
 		if ( this.shouldRenderConciergeConsumedNotice() ) {
 			return this.renderConciergeConsumedNotice();
+		}
+
+		// A plan that is expiring, expired, or otherwise at risk of not renewing
+		// takes precedence over everything below: it is the one thing on this
+		// page that needs the customer to act.
+		if ( hasPlanExpiryNotice( purchase ) ) {
+			return (
+				<PlanExpiryNotice
+					purchase={ purchase }
+					addPaymentMethodUrl={ this.props.changePaymentMethodPath || undefined }
+					viewOtherPlansUrl={ this.props.viewOtherPlansUrl }
+					renewReturnUrl={ this.props.renewReturnUrl }
+					locale={ i18n.getLocaleSlug() ?? 'en' }
+					surface="calypso-manage-purchase"
+					recordTracksEvent={ this.props.recordTracksEvent }
+					onAutoRenewEnabled={ this.props.refetchPurchase }
+				/>
+			);
 		}
 
 		const otherRenewablePurchasesNotice = this.renderOtherRenewablePurchasesNotice();

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -1,3 +1,4 @@
+import { isPurchaseExpiring } from '@automattic/api-core';
 import config from '@automattic/calypso-config';
 import {
 	isAkismetFreeProduct,
@@ -12,6 +13,10 @@ import { useTranslate } from 'i18n-calypso';
 import InfoPopover from 'calypso/components/info-popover';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import {
+	getPlanExpiryUrgency,
+	isEligibleForPlanExpiryNotice,
+} from 'calypso/dashboard/components/plan-expiry-notice';
 import { useIsSplitCancelRemoveEnabled } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled';
 import {
 	isAkismetHoldingSitePurchase,
@@ -28,6 +33,7 @@ import {
 	isCloseToExpiration,
 	isRenewable,
 	isExpiredAndInGracePeriod,
+	isExpiredOrRemoved,
 	isExpiredWithNoAutoRenewAttemptsLeft,
 	isRemoved,
 } from '../lib/raw-purchase-helpers';
@@ -70,6 +76,20 @@ function PurchaseMetaExpiration( {
 	const isJetpackPurchaseUsingPrimaryCancellationFlow =
 		isJetpackPurchase && config.isEnabled( 'jetpack/cancel-through-main-flow' );
 
+	// Both returns below render a date. While the purchase is simply renewing,
+	// that date is when the next payment is due — "You will be billed on 1
+	// August" — and coloring a statement of what is going to happen would
+	// contradict it. Once it is a deadline, or already past, it takes color.
+	const showsUpcomingRenewalDate =
+		! isPurchaseExpiring( purchase ) && ! isExpiredOrRemoved( purchase );
+	const expiryUrgency = showsUpcomingRenewalDate ? null : getPlanExpiryUrgency( purchase );
+	// The plan-expiry notice owns the coloring for the purchases it covers, so
+	// `is-expiring` is left to the ones it does not.
+	const expiryClasses = {
+		'is-expiring-warning': expiryUrgency === 'warning',
+		'is-expiring-error': expiryUrgency === 'error',
+		'is-expiring': ! isEligibleForPlanExpiryNotice( purchase ) && isCloseToExpiration( purchase ),
+	};
 	const allDomains = useSelector( getAllDomains );
 	const domainDetails = allDomains?.[ purchase.blog_id ]?.find(
 		( domain: ResponseDomain ) => domain.domain === purchase.meta
@@ -223,11 +243,7 @@ function PurchaseMetaExpiration( {
 						) }
 					</div>
 				) }
-				<span
-					className={ clsx( 'manage-purchase__detail', {
-						'is-expiring': isCloseToExpiration( purchase ),
-					} ) }
-				>
+				<span className={ clsx( 'manage-purchase__detail', expiryClasses ) }>
 					{ subsBillingText }
 					{ shouldShowTooltip() && (
 						<InfoPopover position="bottom right">
@@ -267,7 +283,7 @@ function PurchaseMetaExpiration( {
 			<em className="manage-purchase__detail-label">
 				{ renderRenewsOrExpiresOnLabel( { purchase, domainDetails, translate } ) }
 			</em>
-			<span className="manage-purchase__detail">
+			<span className={ clsx( 'manage-purchase__detail', expiryClasses ) }>
 				{ renderRenewsOrExpiresOn( {
 					moment,
 					purchase,

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -1,6 +1,8 @@
 @import "@automattic/typography/styles/variables";
 @import "calypso/assets/stylesheets/shared/mixins/breakpoints";
 @import "calypso/assets/stylesheets/shared/mixins/placeholder";
+@import "calypso/dashboard/app-dotcom/style.scss";
+@import "calypso/dashboard/app/wp-components-overrides.scss";
 
 .manage-purchase > button.card,
 .manage-purchase > a.card,
@@ -49,14 +51,6 @@
 		.manage-purchase__detail,
 		.manage-purchase__detail .user {
 			opacity: 0.7;
-		}
-	}
-
-	&.is-expired + .calypso-notice {
-		margin-top: -10px;
-
-		@include breakpoint-deprecated( '>480px' ) {
-			margin-top: -16px;
 		}
 	}
 
@@ -409,6 +403,16 @@
 	&.is-expiring .manage-purchase__detail-date-span {
 		color: var( --studio-red );
 	}
+
+	// Use the same tokens the dashboard Notice does, so these and the notice are
+	// literally the same color rather than two hand-matched hexes.
+	&.is-expiring-warning {
+		color: var( --dashboard__foreground-color-warning );
+	}
+
+	&.is-expiring-error {
+		color: var( --dashboard__foreground-color-error );
+	}
 }
 
 .manage-purchase__renewal-text {
@@ -427,29 +431,14 @@
 	margin-bottom: 6px;
 }
 
-.manage-purchase__delayed-downgrade-pending-notice.calypso-notice,
-.manage-purchase__expiring-credit-card-notice.calypso-notice,
-.manage-purchase__other-renewable-purchases-notice.calypso-notice,
-.manage-purchase__purchase-expiring-notice.calypso-notice {
-	// Inset the notice to match its neighbors. width:auto is required: the base
-	// .calypso-notice is width:100% border-box, so margin-inline alone overflows.
-	width: auto;
+// Match the spacing of the cards below, which are full-width with their own
+// internal padding. The notice pads its own contents too, so only the gap
+// underneath needs setting here.
+.manage-purchase__notices .dashboard-notice {
 	margin-bottom: 10px;
-	margin-inline: 16px;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		margin-bottom: 16px;
-		margin-inline: 24px;
-	}
-
-	// On mobile, drop the action onto its own full-width row instead of cramming
-	// it inline beside the notice text (same idiom as step-wrapper's header).
-	@include breakpoint-deprecated( '<660px' ) {
-		flex-wrap: wrap;
-
-		.calypso-notice__action {
-			flex-basis: 100%;
-		}
 	}
 }
 

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -428,6 +428,12 @@ describe( 'Purchase Management Buttons', () => {
 			is_upgradable: true,
 			is_jetpack_plan_or_product: false,
 			is_plan_type_downgradable: false,
+			// Renewing normally, well clear of expiration. Otherwise the plan-expiry
+			// notice takes over the header and drops the CTA under test. Computed so
+			// the fixture can't age into that window.
+			expiry_date: new Date( Date.now() + 365 * 24 * 60 * 60 * 1000 ).toISOString(),
+			expiry_status: 'auto-renewing',
+			might_still_auto_renew: true,
 		};
 
 		async function renderPurchase( overrides = {} ) {
@@ -476,7 +482,12 @@ describe( 'Purchase Management Buttons', () => {
 		} );
 
 		it( 'still offers a way to pick a different plan once expired', async () => {
-			await renderPurchase( { expiry_status: 'expired', subscription_status: 'active' } );
+			await renderPurchase( {
+				expiry_date: '2023-11-27T00:00:00+00:00',
+				expiry_status: 'expired',
+				subscription_status: 'active',
+				might_still_auto_renew: false,
+			} );
 
 			const cta = await screen.findByText( 'Upgrade plan' );
 			expect( cta ).toHaveAttribute( 'href', expect.stringContaining( '/setup/plan-upgrade' ) );

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -452,6 +452,18 @@ export interface Purchase {
 	is_auto_renew_enabled: boolean;
 
 	/**
+	 * True if the purchase is past the UTC date of its first auto-renewal attempt.
+	 *
+	 * Once this is `true` the subscription has had at least one chance to renew
+	 * itself and has not taken it.
+	 *
+	 * The same caveats as `is_past_last_auto_renew_attempt_date` apply: it is
+	 * unaffected by whether auto-renew is actually enabled, and it is
+	 * day-granular.
+	 */
+	is_past_first_auto_renew_attempt_date: boolean;
+
+	/**
 	 * True if the purchase is past the UTC date of its final auto-renewal attempt.
 	 *
 	 * Note that whether or not auto-renew is actually enabled has no bearing


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2267/

## Proposed Changes
This pull request improves the notices at the top of the purchase management pages, with a focus on WordPress.com plans that are already expired or at risk of expiring.
- Designs: https://linear.app/a8c/project/milestone-1-purchase-management-page-shows-expirygrace-state-and-renew-b3e0cd708161/overview
- Final wording for the notices: p9Jlb4-gPV-p2#comment-16640

WordPress.com plans (Personal, Premium, Business, and Commerce) get the new notices.  Other purchases keep the same messaging they had before, but for consistency their notices are updated to the same visual style as in the new designs.

The designs originally called for using Dashboard notice styles in the Dashboard itself and also on the Calypso *per-user* purchase management pages (under `/me/purchases...`), but then using styling similar to `wp-admin` notices on the Calypso *per-site* purchase management pages.  However, I opted to use Dashboard notice styling in all three locations instead, because:
1. It's more consistent (allowing the same component with the same design and layout to be shared in all three places)
2. There are no `wp-admin`-like notices in this codebase, so using them would involve creating a new style when there are so many different ones already
3. The two Calypso purchase management pages essentially share all their code, so differentiating the design between those would probably have been complicated

Note there are some other places in Calypso which import and use the Dashboard notices already; this is not the first.

As part of this work, I also converted secondary actions in the Dashboard notices to have a white background, to match the designs (see "View other plans" in the post-expiration cases below).  Previously their background was transparent, which probably made sense in the original WordPress notice component they inherit from, but because the Dashboard adds colored backgrounds to the notices (e.g. light yellow for a warning message and light red for an error message) it looks odd; the white background clearly seems better.  Note that outside of the new notices being added here, only a few places in the entire codebase use secondary actions inside Dashboard notices anyway; the most prominent existing one is probably the action for cancelling an already-scheduled plan downgrade (recently added on the same purchase management screen as this work).  Those existing ones will inherit the white background as a result of this pull request.

### Screenshots

#### Won't auto-renew (e.g. auto-renew is off), and more than 60 days before expiration

Note:
- Prominent header actions (e.g. "Upgrade") that might interfere with the task being promoted by the notice disappear when these new notices are displayed; those actions are still available from elsewhere on the page (e.g. the action links at the bottom of the page which aren't shown in the screenshots below)
- If there's no payment method attached, the "Turn on auto-renew" action takes you to add a payment method instead (which turns on auto-renew as a side effect)

| | Before | After |
| :---: | :---: | :---: |
| Calypso | <img width="1056" height="734" alt="calypso-more-than-60-auto-renew-off-BEFORE" src="https://github.com/user-attachments/assets/e734b36c-1b6f-47e8-9243-4c49263b7de6" /> | <img width="1057" height="871" alt="calypso-more-than-60-auto-renew-off-AFTER" src="https://github.com/user-attachments/assets/7767bd3f-3883-41fc-b09a-75a14f088092" /> |
| Dashboard | <img width="684" height="526" alt="dashboard-more-than-60-auto-renew-off-BEFORE" src="https://github.com/user-attachments/assets/67d4bd13-6628-4a0b-bcc8-df683f64a2ec" /> | <img width="680" height="601" alt="dashboard-more-than-60-auto-renew-off-AFTER" src="https://github.com/user-attachments/assets/af058e72-c0fd-42a3-b84f-4e202cd534d6" /> |

#### Won't auto-renew, starting at 60 days before expiration

Note:
- The orange styling in a couple places further down the page matches the severity of the new notice at the top of the page
- For monthly plans (not shown in the screenshots below), the "Renew now" button is replaced with "Turn on auto-renew" during this phase, since it doesn't make sense to ask people to renew a monthly plan much more than a few days before it's due; but otherwise the notice is the same as for annual-and-above

| | Before | After |
| :---: | :---: | :---: |
| Calypso | <img width="1061" height="766" alt="calypso-60-auto-renew-off-BEFORE" src="https://github.com/user-attachments/assets/524ebfcf-fbe1-4dc6-9c86-c114bfe9c00e" /> | <img width="1061" height="848" alt="calypso-60-auto-renew-off-AFTER" src="https://github.com/user-attachments/assets/bce5d0f4-585f-409f-86a3-0d0aa8fccec0" /> |
| Dashboard | <img width="682" height="1089" alt="dashboard-60-auto-renew-off-BEFORE" src="https://github.com/user-attachments/assets/feb3465d-33b0-4da7-bb90-6b082a391f95" /> | <img width="677" height="1189" alt="dashboard-60-auto-renew-off-AFTER" src="https://github.com/user-attachments/assets/d20eb314-b387-4dde-a9ed-919fab4624b7" /> |

#### Auto-renew on, but past the first renewal attempt, indicating a likely renewal failure (typically this starts at ~29 days before expiration)

*In practice this is for annual-or-above plans only (since monthly plans don't attempt renewal until the day of expiration).*

Note:
- This is an important case, and previously we didn't show any notices for it at all
- Unlike the previous example, there is no orange styling further down the page (the message itself is a warning, but the dates/etc. elsewhere the page shouldn't be, given that they simply communicate that auto-renew is on)

| | Before | After |
| :---: | :---: | :---: |
| Calypso | <img width="1053" height="703" alt="calypso-auto-renew-on-after-first-attempt-BEFORE" src="https://github.com/user-attachments/assets/aad861f3-1840-47c4-87fa-2606f903b894" /> | <img width="1054" height="769" alt="calypso-auto-renew-on-after-first-attempt-AFTER" src="https://github.com/user-attachments/assets/56c1d6f5-1405-44c0-a62a-f47031bceb9e" /> |
| Dashboard | <img width="684" height="1063" alt="dashboard-auto-renew-on-after-first-attempt-BEFORE" src="https://github.com/user-attachments/assets/163e862a-10a0-4cf8-8993-85bccc7d816b" /> | <img width="685" height="1237" alt="dashboard-auto-renew-on-after-first-attempt-AFTER" src="https://github.com/user-attachments/assets/aa51b6dd-4e3c-470b-855d-d7abc2169850" /> |

#### Starting at 7 days before expiration

Notes:
- Everything now moves to an error-level severity

For subscriptions that won't auto-renew:

| | Before | After |
| :---: | :---: | :---: |
| Calypso | <img width="1055" height="767" alt="calypso-7-auto-renew-off-BEFORE" src="https://github.com/user-attachments/assets/c4f192ce-6d89-4919-86db-fc664b210564" /> | <img width="1055" height="850" alt="calypso-7-auto-renew-off-AFTER" src="https://github.com/user-attachments/assets/a83fb891-44e1-4183-b769-6280194e7efb" /> |
| Dashboard | <img width="684" height="1093" alt="dashboard-7-auto-renew-off-BEFORE" src="https://github.com/user-attachments/assets/cda64c4b-944c-4cc5-8668-9572903a932d" /> | <img width="677" height="1191" alt="dashboard-7-auto-renew-off-AFTER" src="https://github.com/user-attachments/assets/52e9bef4-977e-440c-a658-8eb6019c69ea" /> |

Subscriptions with auto-renew on that should have renewed (but haven't successfully done so yet) move to error-level severity too, with slightly different messaging from the above (the example below is from the Dashboard but Calypso is similar):

<img width="685" height="273" alt="dashboard-7-auto-renew-on-message-AFTER" src="https://github.com/user-attachments/assets/89782e20-d09a-43aa-976f-8c964c8fcadb" />

Also, on the day **of** expiration there are a couple additional changes (Dashboard is shown below, but Calypso is similar):

| Won't auto-renew | Auto-renew on and should have renewed but didn't |
| :---: | :---: |
| <img width="685" height="273" alt="dashboard-today-auto-renew-off-message-AFTER" src="https://github.com/user-attachments/assets/a7a2b7f5-02e8-416e-9298-42e7f71992ff" /> | <img width="685" height="273" alt="dashboard-today-auto-renew-on-message-AFTER" src="https://github.com/user-attachments/assets/553344a6-4622-40db-9fff-01b8e4bd72ea" /> |

#### After expiration

If the subscription is expired but we aren't yet past the date of the final scheduled auto-renewal attempt, then subscriptions that won't auto-renew look like this:

| | Before | After |
| :---: | :---: | :---: |
| Calypso | <img width="1051" height="750" alt="calypso-post-expiry-auto-renew-off-BEFORE" src="https://github.com/user-attachments/assets/370ebf3d-5226-45e4-9917-2c0d30dac80c" /> | <img width="1053" height="823" alt="calypso-post-expiry-auto-renew-off-AFTER" src="https://github.com/user-attachments/assets/749962a3-5990-4f06-b1d5-9736fceb202a" /> |
| Dashboard | <img width="727" height="1114" alt="dashboard-post-expiry-auto-renew-off-BEFORE" src="https://github.com/user-attachments/assets/5399b1ea-d235-463d-bd23-c8c6f75fee38" /> | <img width="731" height="1158" alt="dashboard-post-expiry-auto-renew-off-AFTER" src="https://github.com/user-attachments/assets/e21654b5-fc20-4e1a-a50c-4eca1318200e" /> |

And subscriptions that might still auto-renew are similar (but with some indication on the page that an auto-renewal is still technically possible):

| | Before | After |
| :---: | :---: | :---: |
| Calypso | <img width="1056" height="750" alt="calypso-post-expiry-auto-renew-on-BEFORE" src="https://github.com/user-attachments/assets/1eeb53f5-362c-4188-86df-50c909e4de9b" /> | <img width="1056" height="842" alt="calypso-post-expiry-auto-renew-on-AFTER" src="https://github.com/user-attachments/assets/235eb815-8f84-41c8-b91a-b919acd766be" /> |
| Dashboard | <img width="729" height="1144" alt="dashboard-post-expiry-auto-renew-on-BEFORE" src="https://github.com/user-attachments/assets/833027c8-8743-4efa-b6fb-cc9dc5b1c9d1" /> | <img width="718" height="1193" alt="dashboard-post-expiry-auto-renew-on-AFTER" src="https://github.com/user-attachments/assets/ff2600e3-ed63-4fcb-9bd8-3d9068bbcbf6" /> |

After the date of the final renewal attempt, the two cases converge (both use the same wording as the "won't auto-renew" screenshots from above, and there are some other previously-deployed changes also, such as not showing the auto-renew toggle).

#### Other notices

These screenshots from Calypso illustrate:
- The conversion of other, existing notices on the Calypso purchase management pages to Dashboard notice styling
- The fact that when WordPress.com plans are in a state where none of the new messages above need to supersede them, messages about other renewal-related topics can still be shown (such as the credit card expiring notice below) -- notice that in this case, the header actions, e.g. "Upgrade plan", aren't suppressed anymore

| Before | After |
| :---: | :---: |
| <img width="1052" height="583" alt="calypso-other-message-BEFORE" src="https://github.com/user-attachments/assets/5373d7ee-941e-4144-a50c-7c549bc27788" /> | <img width="1052" height="583" alt="calypso-other-message-AFTER" src="https://github.com/user-attachments/assets/9e0a5f64-5c5b-4aa4-89d2-bfe48848b4a5" /> |

### Detailed implementation spec

Below is the detailed spec I originally used to implement this (although various changes were made later on, notably to the exact wording of the notices and the destination of the "View other plans" link):

<details>
  <summary>Click to expand</summary>

```
The goal here is to implement new, non-dismissable notices on the purchase management pages for WordPress.com Personal, Premium, Business and Commerce plans that are approaching or beyond their expiration date, or otherwise at risk of not renewing.

These should display on both the Calypso purchase management page for an individual subscription, and the Dashboard purchase management page for an individual subscription.  However, we will use the Dashboard Notice component for both.  In fact, we want the whole thing to be an assumption-free, reusable component that can be included from both places (and eventually, later, from other places throughout both Calypso and the Dashboard).

These notices should replace or take precendence over other, existing notices on the purchase management page -- we only want a maximum of one notice to appear.  So basically, if this new component returns a message, bypass any other logic for displaying messages at the top of the page (this includes things like notices about expiring credit cards on the subscription, notices about other subscriptions on the same site that need to be renewed, etc).  The idea is that these new messages are more important, since they're for cases where it's highly likely that the subscription *currently* being viewed needs manual action taken.  The code for the existing messages should be touched as little as possible; however, for visual consistency, they should be converted to the Dashboard Notice component also.  But no changes beyond that basic conversion should be made to them.

As mentioned, when this component doesn't return a message, it can fall back on the other existing notices.  However, we do not want it to fall back on closely-related existing messages for a similar scenario.  For example, if we have a notice that appears when a plan has auto-renew is off and is far from expiration, never fall back on displaying that notice when this component returns nothing (since this component has within it a message that covers that same type of case).  Similarly, the current code that displays "This purchase has expired and will be removed soon unless it is renewed" in the case of an expired subscription (and that lives outside of the new component) should not be triggered if the new component chooses not to display a message for an expired plan subscription.

For purchases other than WordPress.com Personal, Premium, Business and Commerce plans, however, this component should not be used at all.  We just want to fall back on the *exact* same logic and behavior that those types of purchases currently have for the message at the top (including things like the "This purchase has expired and will be removed soon unless it is renewed" message for expired subscriptions).  But as above, for visual consistency, they will all need to be converted to use the Dashboard Notice component also.

The content of the new component under various scenarios is documented below:

---
## More than 60 days before expiration

Messages here use “info” styling.

### Annual-or-above plan that can’t auto-renew (auto-renew off, missing payment method, etc)

Heading: Your [plan-type] plan expires in [X] months
Body: After that, your site will move to the Free plan and you’ll lose access to plugins, custom themes, and [X] GB of storage. Turn on auto-renew to keep everything in place.
Action link: Turn on auto-renew

## Starting at 60 days before expiration

Messages here use “warning” styling.

### Annual-or-above plan that can’t auto-renew (auto-renew off, missing payment method, etc)

Heading: Your [plan-type] plan expires in [X] days
Body: After that, your site moves to the Free plan, which means losing access to plugins, custom themes, and [X] GB of storage.
Action link: Renew now

## Starting at 29 days before expiration (i.e. the day after the first scheduled auto-renew attempt for annual-and-above plans)

Messages here use “warning” styling.

### Annual-or-above plan that can’t auto-renew (auto-renew off, missing payment method, etc)

Same as above

### Annual-or-above plan that can auto-renew

Heading: Your [plan-type] plan has [X] days remaining
Body: If the plan isn’t renewed, your site will move to the Free plan, which means losing access to plugins, custom themes, and [X] GB of storage.
Action link: Renew now

## Starting at 7 days before expiration

Messages here use “error” styling.

### Plan with any billing term that can’t auto-renew (auto-renew off, missing payment method, etc)

Heading: Your [plan-type] plan expires in [X] days
Body: Your site will move to the Free plan and you’ll lose plugins, custom themes, and [X] GB of storage.
Action link: Renew now

### Annual-or-above plan that can auto-renew

Heading: Your [plan-type] plan has [X] days remaining
Body: If the plan isn’t renewed, your site will move to the Free plan and you’ll lose plugins, custom themes, and [X] GB of storage.
Action link: Renew now

## On the day of expiration

Messages here use “error” styling.

### Plan with any billing term that can’t auto-renew (auto-renew off, missing payment method, etc)

Heading: Your [plan-type] plan expires today
Body: Your site will move to the Free plan soon and you’ll lose plugins, custom themes, and [X] GB of storage.
Action link: Renew now

### Annual-or-above plan that can auto-renew

Heading: Your [plan-type] plan expires today
Body: If the plan isn’t renewed soon, your site will move to the Free plan and you’ll lose plugins, custom themes, and [X] GB of storage.
Action link: Renew now

## After the day of expiration, but before the date of the final scheduled auto-renewal attempt

Messages here use “error” styling.

### Plan with any billing term that can’t auto-renew (auto-renew off, missing payment method, etc)

Heading: Your [plan-type] plan has expired
Body: Your site will be moved to the Free plan soon. That means losing plugins, custom themes, and [X] GB of storage. Renew now to keep your site as it is.
Action link (primary): Renew now
Action link (secondary): View other plans

### Plan with any billing term that can auto-renew

Heading: Your [plan-type] plan has expired
Body: If the plan isn’t renewed soon, your site will be moved to the Free plan. That means losing plugins, custom themes, and [X] GB of storage. Renew now to keep your site as it is.
Action link (primary): Renew now
Action link (secondary): View other plans

## After the date of the final scheduled auto-renewal attempt

All cases (regardless of auto-renew status) should now use the same messaging as in the “Plan with any billing term that can’t auto-renew” scenario above.
---

Some notes on all the above:
- Translations: If any text isn't translated yet, fall back on copying the most-closely-related existing message for the same kind of scenario, if there is one (for example, "This purchase has expired and will be removed soon unless it is renewed" in the case of an expired subscription) and use it in this component.
- The "[plan-type]" text should be the short plan name, for example "Business" (not "WordPress.com Business").  It should be possible to pull this from the purchase/plan configuration.
- For the "[X] GB of storage" text, the X should come from whatever the existing codebase uses for feature lists on this page, most likely the getStorageFeature() method.
- The "in [X] days" and "in [X] months" text and similar should come from getRelativeDayString() (when that function returns the exact needed phrasing).  For cases where we need custom phrasing, use getCalendarDaysUntil().
- Similarly, the transitions between the different types of messages should generally be based on getCalendarDaysUntil() (i.e. the user's timezone), but there are several exceptions:
  - In the "Starting at 29 days before expiration (i.e. the day after the first scheduled auto-renew attempt for annual-and-above plans)" transition, the 29 is just an example.  This transition should actually come from checking a new property on the purchase object that is being returned by the server, is_past_first_auto_renew_attempt_date.
  - The transition to "After the date of expiration" should come from the `expiry_status` on the purchase object (or specifically from helper methods already in this codebase that check that).
  - The transition to "After the date of the final scheduled auto-renewal attempt" should also come from an existing helper method, presumably isExpiredWithNoAutoRenewAttemptsLeft().
- The "can auto-renew" determination should be based on an existing helper method, presumably mightStillAutoRenew().
- The "Renew now" action should point to the standard checkout renewal URL.
- The "View other plans" action can just point to a placeholder URL for now (it will be populated later).
- The "Turn on auto-renew" action (in the greater than 60 days until expiration case) should turn on auto-renew if it is currently off, same as if the auto-renew toggle/link on the same purchase management page was clicked. However, if the component is displaying because there's no payment method, then it should instead link to the page for adding a payment method to the purchase (it can use the same "Turn on auto-renew" wording, though, since adding a payment method automatically turns auto-renew on).

Finally, there are a few other minor changes to the purchase management page that need to happen here that aren't within the new component itself:
  - The expiration date under the auto-renew setting (both Calypso and Dashboard) and the "auto-renew is disabled" message (Dashboard) should change colors, to orange/warning at 60 days, and to red/error at 7 days, thereby matching the status of the new component's message.
  - The prominent "Renew" and "Upgrade" actions in the purchase management page header should disappear (both Calypso and Dashboard) whenever the new component has something to display.  (However, actions hidden behind an action dropdown menu don't need to disappear.)  This is to focus the user on the task at hand.
```
</details>

## Testing Instructions

This requires a server-side pull request (231758-ghe-Automattic/wpcom) in order to test.

I tried this out with the various scenarios shown in the screenshots above (checking both the visual appearance and also the operation of the actions) as well as some other scenarios.  Everything seemed to work correctly.