### PR TITLE
Purchases: pass raw linked purchases to the cancel form

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.tsx
@@ -69,7 +69,6 @@ import type { UpsellType } from './get-upsell-type';
 import type { Purchase } from '@automattic/api-core';
 import type { PlanSlug } from '@automattic/calypso-products';
 import type { SiteDetails } from '@automattic/data-stores';
-import type { Purchase as LegacyPurchase } from 'calypso/lib/purchases/types';
 import type { DisplayVariant } from 'calypso/lib/purchases/utils';
 import type { IAppState } from 'calypso/state/types';
 import type { ReactNode } from 'react';
@@ -100,7 +99,7 @@ export interface CancelPurchaseFormOwnProps {
 	flowType: string;
 	cancelBundledDomain?: boolean;
 	includedDomainPurchase?: object;
-	linkedPurchases?: LegacyPurchase[];
+	linkedPurchases?: Purchase[];
 	skipRemovePlanSurvey?: boolean;
 	cancellationInProgress?: boolean;
 	intent?: DisplayVariant | null;

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -916,9 +916,7 @@ class ManagePurchase extends Component<
 			<CancelPurchaseForm
 				disableButtons={ this.state.isRemoving }
 				purchase={ purchase }
-				linkedPurchases={ this.getActiveMarketplaceSubscriptions().map( ( p ) =>
-					createPurchaseObject( p as unknown as Parameters< typeof createPurchaseObject >[ 0 ] )
-				) }
+				linkedPurchases={ this.getActiveMarketplaceSubscriptions() }
 				isVisible={ this.state.isCancelSurveyVisible }
 				onClose={ this.closeDialog }
 				onSurveyComplete={ this.cancelSubscription }

--- a/client/me/purchases/remove-purchase/index.tsx
+++ b/client/me/purchases/remove-purchase/index.tsx
@@ -28,7 +28,6 @@ import {
 	isAkismetHoldingSitePurchase,
 	isJetpackHoldingSitePurchase,
 } from 'calypso/dashboard/utils/purchase';
-import { createPurchaseObject } from 'calypso/lib/purchases/assembler';
 import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
 import WordAdsEligibilityWarningDialog from 'calypso/me/purchases/wordads-eligibility-warning-dialog';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -318,7 +317,7 @@ class RemovePurchase extends Component< RemovePurchaseProps, RemovePurchaseState
 			<CancelPurchaseForm
 				disableButtons={ this.state.isRemoving }
 				purchase={ purchase }
-				linkedPurchases={ activeSubscriptions?.map( createPurchaseObject ) }
+				linkedPurchases={ activeSubscriptions }
 				isVisible={ this.state.isDialogVisible }
 				onClose={ this.closeDialog }
 				onSurveyComplete={ this.removePurchase }

--- a/client/state/purchases/selectors/will-atomic-site-revert-after-purchase-deactivation.ts
+++ b/client/state/purchases/selectors/will-atomic-site-revert-after-purchase-deactivation.ts
@@ -3,6 +3,8 @@ import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getByPurchaseId } from './get-by-purchase-id';
 import { getSitePurchases } from './get-site-purchases';
+import type { Purchase } from '@automattic/api-core';
+import type { AppState } from 'calypso/types';
 
 import 'calypso/state/purchases/init';
 
@@ -11,17 +13,17 @@ import 'calypso/state/purchases/init';
  * The backend has the final say on if this actually happens, see:
  * revert_atomic_site_on_subscription_removal() and deactivate_product().
  * This is a helper for UI elements only, it does not control actual revert decisions.
- * @param   {Object} state           global state
- * @param   {number} purchaseId      the purchase id
- * @param   {Array}  linkedPurchases List of purchases that will be also deactivated because they are
- *                                   linked to the given purchase
- * @returns {boolean} True if the Atomic revert will happen, false otherwise.
+ * @param   state           global state
+ * @param   purchaseId      the purchase id
+ * @param   linkedPurchases List of purchases that will be also deactivated because they are
+ *                          linked to the given purchase
+ * @returns True if the Atomic revert will happen, false otherwise.
  */
 export const willAtomicSiteRevertAfterPurchaseDeactivation = (
-	state,
-	purchaseId,
-	linkedPurchases
-) => {
+	state: AppState,
+	purchaseId: number | undefined | null,
+	linkedPurchases: Purchase[] = []
+): boolean => {
 	if ( ! purchaseId ) {
 		return false;
 	}
@@ -36,7 +38,7 @@ export const willAtomicSiteRevertAfterPurchaseDeactivation = (
 		return false;
 	}
 
-	const isAtomicSupportedProduct = ( productSlug ) => {
+	const isAtomicSupportedProduct = ( productSlug: string ) => {
 		if ( isMarketplaceProduct( state, productSlug ) ) {
 			return true;
 		}
@@ -44,15 +46,11 @@ export const willAtomicSiteRevertAfterPurchaseDeactivation = (
 		return planHasFeature( productSlug, WPCOM_FEATURES_ATOMIC );
 	};
 
-	if ( ! Array.isArray( linkedPurchases ) ) {
-		linkedPurchases = [];
-	}
-
 	// Bail if none of the purchases to deactivate supports Atomic.
 	if (
 		! isAtomicSupportedProduct( purchase.productSlug ) &&
 		linkedPurchases.every(
-			( linkedPurchase ) => ! isAtomicSupportedProduct( linkedPurchase.productSlug )
+			( linkedPurchase ) => ! isAtomicSupportedProduct( linkedPurchase.product_slug )
 		)
 	) {
 		return false;
@@ -61,7 +59,7 @@ export const willAtomicSiteRevertAfterPurchaseDeactivation = (
 	const remainingPurchases = getSitePurchases( state, purchase.siteId ).filter(
 		( sitePurchase ) =>
 			sitePurchase.id !== purchaseId &&
-			linkedPurchases.every( ( linkedPurchase ) => sitePurchase.id !== linkedPurchase.id )
+			linkedPurchases.every( ( linkedPurchase ) => sitePurchase.id !== linkedPurchase.ID )
 	);
 
 	// If there is at least one remaining Atomic supported purchase, the site will be kept in the Atomic infra.


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-2256/

## Proposed Changes

Moves the `linkedPurchases` data path off the assembled camelCase `Purchase` and onto the raw `Purchase` from `@automattic/api-core`. `willAtomicSiteRevertAfterPurchaseDeactivation` only ever reads two fields off that parameter, so re-typing it is enough to let three callers stop converting their already-raw purchases.

* Convert `client/state/purchases/selectors/will-atomic-site-revert-after-purchase-deactivation.js` to TypeScript and type its `linkedPurchases` parameter as the raw api-core `Purchase` (`productSlug` → `product_slug`, `id` → `ID`).
* Replace that selector's `Array.isArray` guard with a default parameter, now that both call sites are typed.
* Re-type `CancelPurchaseForm`'s `linkedPurchases` prop as the raw `Purchase`, removing the last camelCase `Purchase` import from that component.
* Drop the `createPurchaseObject` bridge in `manage-purchase/index.tsx`, which already had raw purchases from `getActiveMarketplaceSubscriptions()`.
* Drop the `createPurchaseObject` bridge in `remove-purchase/index.tsx`, which already had raw purchases in `activeSubscriptions`; that file no longer imports the assembler at all.

## Why are these changes being made?

This is another incremental slice of the assembler removal. Classic Calypso keeps a duplicate camelCase `Purchase` type built by `createPurchaseObject`/`createPurchasesArray`, and the goal is to retire it so consumers read the raw snake_case `Purchase` that the API already returns. Each slice migrates one data path and deletes the temporary conversion calls that were bridging migrated code back to unmigrated code.

`linkedPurchases` was a good candidate because the conversion was doing almost no work. `manage-purchase` and `remove-purchase` had already been migrated, so both were holding raw purchases and mapping them through `createPurchaseObject` purely to satisfy `CancelPurchaseForm`'s prop type — which in turn only existed because the Redux selector behind it read `productSlug` and `id`. Re-typing the selector's parameter removes the reason for the whole chain.

Only the `linkedPurchases` parameter changes shape. The selector's other reads — `purchase.siteId`, `purchase.productSlug`, `sitePurchase.id` — come from `getByPurchaseId` and `getSitePurchases`, which still return assembled camelCase objects, and are deliberately left alone; those move when the `getPurchases` assembly point itself is retired. Converting the file to TypeScript is what makes that split safe to review: the raw `Purchase` has no camelCase properties, so a missed rename is a compile error rather than a silent `undefined`.

The `Array.isArray` guard was removed rather than kept because the parameter is now typed and both remaining callers pass an array unconditionally; a default parameter covers the `undefined` case that `CancelPurchaseForm` was already defending against with `linkedPurchases ?? []`.

## Testing Instructions

TC:

```
yarn test-client client/me/purchases client/state/purchases client/components/marketing-survey
```

Manual testing:

This affects the "your Atomic site will revert" warning shown in the cancellation flow, so it needs an Atomic site with a plan plus at least one Marketplace plugin subscription.

* On an Atomic site, go to **Me → Purchases** and open the plan's Manage Purchase page.
* Click **Cancel plan** to open the cancellation dialog.
* Confirm the Atomic revert warning appears exactly as it did before, and that the linked Marketplace subscriptions are still listed as things that will be deactivated alongside the plan.
* Repeat on an Atomic site whose plan has no Marketplace subscriptions, and on a Simple site, to confirm the warning still does not appear where it shouldn't.
* Check the browser console for errors on both pages.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
