### PR TITLE
Revert "Domain-only flow: skip site-or-domain for logged-out users too"

### DIFF
--- a/client/signup/steps/domains/index.tsx
+++ b/client/signup/steps/domains/index.tsx
@@ -28,7 +28,7 @@ import {
 	domainManagementTransferToOtherSite,
 } from 'calypso/my-sites/domains/paths';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { getNextStepName, getStepUrl } from 'calypso/signup/utils';
+import { getStepUrl } from 'calypso/signup/utils';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
@@ -60,7 +60,6 @@ const DomainSearchUI = (
 		stepName,
 		submitSignupStep,
 		goToNextStep,
-		goToStep,
 		locale,
 		queryObject,
 		baseSubmitStepProps,
@@ -72,7 +71,6 @@ const DomainSearchUI = (
 	const isDomainOnlyFlow = flowName === 'domain';
 	const isOnboardingWithEmailFlow = flowName === 'onboarding-with-email';
 
-	const isLoggedIn = useSelector( isUserLoggedIn );
 	const site = useSelector( getSelectedSite );
 
 	const siteSlug = queryObject.siteSlug;
@@ -222,19 +220,6 @@ const DomainSearchUI = (
 						{ stepName: 'plans-site-selected', wasSkipped: true },
 						{ cartItems: null }
 					);
-
-					// For logged-out users the account step is still pending, so the flow isn't
-					// "every step submitted" and the default goToNextStep() advances by array index
-					// from 'domain-only' back onto the just-skipped 'site-or-domain' step. Advance
-					// from the last auto-submitted step instead: logged-out users go to the account
-					// step, logged-in users fall through to checkout.
-					const nextStep = getNextStepName( flowName, 'plans-site-selected', isLoggedIn );
-					if ( nextStep ) {
-						goToStep( nextStep );
-					} else {
-						goToNextStep();
-					}
-					return;
 				}
 
 				goToNextStep();
@@ -272,8 +257,6 @@ const DomainSearchUI = (
 		clearQuery,
 		submitSignupStep,
 		goToNextStep,
-		goToStep,
-		isLoggedIn,
 		locale,
 		isDomainOnlyFlow,
 		baseSubmitStepProps,

--- a/client/signup/steps/domains/test/index.tsx
+++ b/client/signup/steps/domains/test/index.tsx
@@ -34,13 +34,11 @@ const baseProps = {
 	previousStepName: null,
 };
 
-function renderStep( props = baseProps, options = {} ) {
+function renderStep( props = baseProps ) {
 	mockWPCOMDomainSearch.mockClear();
-	renderWithProvider( <DomainSearchStep { ...props } />, options );
+	renderWithProvider( <DomainSearchStep { ...props } /> );
 	return mockWPCOMDomainSearch.mock.calls[ 0 ][ 0 ].events;
 }
-
-const LOGGED_IN_STATE = { currentUser: { id: 12345 } };
 
 describe( 'DomainSearchStep — domain-only checkout simplification', () => {
 	beforeEach( () => {
@@ -48,11 +46,10 @@ describe( 'DomainSearchStep — domain-only checkout simplification', () => {
 		mockWPCOMDomainSearch.mockReturnValue( null );
 	} );
 
-	it( 'auto-submits the skipped steps and routes logged-out users to the account step', () => {
+	it( 'auto-submits site-or-domain, site-picker, and plans-site-selected in the domain flow', () => {
 		const submitSignupStep = jest.fn();
-		const goToStep = jest.fn();
 		const goToNextStep = jest.fn();
-		const events = renderStep( { ...baseProps, submitSignupStep, goToStep, goToNextStep } );
+		const events = renderStep( { ...baseProps, submitSignupStep, goToNextStep } );
 
 		events.onContinue( [ domainItem ] );
 
@@ -86,27 +83,7 @@ describe( 'DomainSearchStep — domain-only checkout simplification', () => {
 			expect.objectContaining( { stepName: 'plans-site-selected', wasSkipped: true } ),
 			expect.objectContaining( { cartItems: null } )
 		);
-		// Logged out: jump to the account step instead of the skipped site-or-domain step.
-		expect( goToStep ).toHaveBeenCalledTimes( 1 );
-		expect( goToStep ).toHaveBeenCalledWith( expect.stringMatching( /^user/ ) );
-		expect( goToNextStep ).not.toHaveBeenCalled();
-	} );
-
-	it( 'skips straight to checkout for logged-in users in the domain flow', () => {
-		const submitSignupStep = jest.fn();
-		const goToStep = jest.fn();
-		const goToNextStep = jest.fn();
-		const events = renderStep(
-			{ ...baseProps, submitSignupStep, goToStep, goToNextStep },
-			{ initialState: LOGGED_IN_STATE }
-		);
-
-		events.onContinue( [ domainItem ] );
-
-		// Same auto-submitted steps, but no account step remains, so proceed to checkout.
-		expect( submitSignupStep ).toHaveBeenCalledTimes( 4 );
 		expect( goToNextStep ).toHaveBeenCalledTimes( 1 );
-		expect( goToStep ).not.toHaveBeenCalled();
 	} );
 
 	it( 'submits the domain step and does not skip steps in a non-domain flow', () => {

--- a/client/signup/steps/domains/types.ts
+++ b/client/signup/steps/domains/types.ts
@@ -2,7 +2,7 @@ export type StepProps = {
 	stepSectionName: string | null;
 	stepName: string;
 	flowName: string;
-	goToStep: ( stepName?: string, stepSectionName?: string, flowName?: string ) => void;
+	goToStep: () => void;
 	goToNextStep: () => void;
 	submitSignupStep: ( step: unknown, dependencies: unknown ) => void;
 	queryObject: Record< string, string | undefined >;

--- a/test/e2e/specs/flows/start-domain__purchase-flows.spec.ts
+++ b/test/e2e/specs/flows/start-domain__purchase-flows.spec.ts
@@ -2,10 +2,11 @@ import {
 	BrowserManager,
 	NewTestUserDetails,
 	NewUserResponse,
+	NewSiteResponse,
 	RestAPIClient,
 } from '@automattic/calypso-e2e';
 import { skipIfNotTrunk, tags, test } from '../../lib/pw-base';
-import { apiCloseAccount } from '../shared';
+import { apiCloseAccount, apiDeleteSite } from '../shared';
 
 test.describe(
 	'Start Domain Only Flows',
@@ -18,7 +19,65 @@ test.describe(
 		const accountsToCleanup: {
 			testUser: NewTestUserDetails;
 			newUserDetails: NewUserResponse;
+			newSiteDetails?: NewSiteResponse;
 		}[] = [];
+
+		test( 'As a new user, I can complete the domain-only flow and purchase a domain with a plan', async ( {
+			page,
+			componentDomainSearch,
+			helperData,
+			pageCartCheckout,
+			pageSignupPickPlan,
+			pageUserSignUp,
+		} ) => {
+			const testUser = helperData.getNewTestUser();
+			const planName = 'Personal';
+			let selectedDomain: string;
+			let newUserDetails: NewUserResponse;
+			let newSiteDetails: NewSiteResponse;
+
+			await test.step( 'When I enter the domain-only flow', async function () {
+				BrowserManager.setStoreCookie( page, { currency: 'USD' } );
+				await page.goto( helperData.getCalypsoURL( '/start/domain' ) );
+			} );
+
+			await test.step( 'And I search for a domain', async function () {
+				await componentDomainSearch.search( helperData.getBlogName() );
+			} );
+
+			await test.step( 'And I add the first suggestion to the cart', async function () {
+				selectedDomain = await componentDomainSearch.selectFirstSuggestion();
+			} );
+
+			await test.step( 'And I continue to the next step', async function () {
+				await componentDomainSearch.continue();
+			} );
+
+			await test.step( 'And I select "New site" option', async function () {
+				await componentDomainSearch.selectNewSite();
+			} );
+
+			await test.step( `And I select the ${ planName } plan`, async function () {
+				await pageSignupPickPlan.selectPlanWithoutSiteCreation(
+					planName,
+					new RegExp( '.*start/domain/user-social.*' )
+				);
+			} );
+
+			await test.step( 'And I sign up as a new user and wait for site creation', async function () {
+				[ newUserDetails, newSiteDetails ] =
+					await pageUserSignUp.signupWithEmailAndWaitForSiteCreation( testUser.email );
+				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
+			} );
+
+			await test.step( 'Then I see the plan at checkout', async function () {
+				await pageCartCheckout.validateCartItem( `WordPress.com ${ planName }` );
+			} );
+
+			await test.step( 'And I see the domain at checkout', async function () {
+				await pageCartCheckout.validateCartItem( selectedDomain );
+			} );
+		} );
 
 		test( 'As a new user, I can complete the domain-only flow and purchase just a domain (no site)', async ( {
 			page,
@@ -48,6 +107,10 @@ test.describe(
 				await componentDomainSearch.continue();
 			} );
 
+			await test.step( 'And I select "Just buy a domain" option', async function () {
+				await componentDomainSearch.selectJustBuyADomain();
+			} );
+
 			await test.step( 'And I sign up as a new user', async function () {
 				newUserDetails = await pageUserSignUp.signupWithEmail( testUser.email );
 				accountsToCleanup.push( { testUser, newUserDetails } );
@@ -67,6 +130,14 @@ test.describe(
 					},
 					account.newUserDetails.body.bearer_token
 				);
+
+				if ( account.newSiteDetails ) {
+					await apiDeleteSite( restAPIClient, {
+						url: account.newSiteDetails.blog_details.url,
+						id: account.newSiteDetails.blog_details.blogid,
+						name: account.newSiteDetails.blog_details.blogname,
+					} );
+				}
 
 				await apiCloseAccount( restAPIClient, {
 					userID: account.newUserDetails.body.user_id,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#112957