### PR TITLE
A4A-3129: Stop wrapped copy stranding single words on their own line

### DIFF
--- a/client/a8c-for-agencies/sections/reports/primary/overview/sections/reports-banner/style.scss
+++ b/client/a8c-for-agencies/sections/reports/primary/overview/sections/reports-banner/style.scss
@@ -45,7 +45,7 @@
 .reports-banner__heading {
 	@include heading-2x-large;
 	margin-block-end: 8px;
-	// Reads as a heading but isn't an h1-h6, so it misses the section-wide rule.
+	// A heading in everything but tag name, so the section-wide rule misses it.
 	text-wrap: balance;
 }
 

--- a/client/a8c-for-agencies/sections/reports/primary/overview/sections/reports-banner/style.scss
+++ b/client/a8c-for-agencies/sections/reports/primary/overview/sections/reports-banner/style.scss
@@ -45,6 +45,8 @@
 .reports-banner__heading {
 	@include heading-2x-large;
 	margin-block-end: 8px;
+	// Reads as a heading but isn't an h1-h6, so it misses the section-wide rule.
+	text-wrap: balance;
 }
 
 .reports-banner__description {

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/sections/woopayments-banner/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/sections/woopayments-banner/style.scss
@@ -54,7 +54,7 @@
 .woopayments-banner__heading {
 	@include heading-2x-large;
 	margin-block-end: 8px;
-	// Reads as a heading but isn't an h1-h6, so it misses the section-wide rule.
+	// A heading in everything but tag name, so the section-wide rule misses it.
 	text-wrap: balance;
 }
 

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/sections/woopayments-banner/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/sections/woopayments-banner/style.scss
@@ -54,6 +54,8 @@
 .woopayments-banner__heading {
 	@include heading-2x-large;
 	margin-block-end: 8px;
+	// Reads as a heading but isn't an h1-h6, so it misses the section-wide rule.
+	text-wrap: balance;
 }
 
 .woopayments-banner__description {

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -91,14 +91,11 @@
 }
 
 .theme-a8c-for-agencies {
-	// Stop wrapped copy from stranding a single word on its own last line.
-	// `text-wrap` is inherited, so declaring it here also covers the shared
-	// components A4A pulls in from other clients. Elements that set their own
-	// `white-space: nowrap` still win for themselves and their children.
+	// Keep wrapped text from stranding a single word on the last line. This is
+	// inherited, so it reaches components borrowed from other clients too.
 	text-wrap: pretty;
 
-	// `pretty` only shortens the rag; short blocks need the lines evened out.
-	// Browsers stop balancing past a handful of lines, so long copy keeps `pretty`.
+	// `pretty` only fixes the last line. Short blocks need every line evened out.
 	:is(h1, h2, h3, h4, h5, h6, li, td, th, dd, figcaption) {
 		text-wrap: balance;
 	}

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -91,6 +91,17 @@
 }
 
 .theme-a8c-for-agencies {
+	// Stop wrapped copy from stranding a single word on its own last line.
+	// `text-wrap` is inherited, so declaring it here also covers the shared
+	// components A4A pulls in from other clients. Elements that set their own
+	// `white-space: nowrap` still win for themselves and their children.
+	text-wrap: pretty;
+
+	// `pretty` only shortens the rag; short blocks need the lines evened out.
+	// Browsers stop balancing past a handful of lines, so long copy keeps `pretty`.
+	:is(h1, h2, h3, h4, h5, h6, li, td, th, dd, figcaption) {
+		text-wrap: balance;
+	}
 
 	.button.split-button__toggle {
 		border-radius: 0 4px 4px 0;


### PR DESCRIPTION
Linear: A4A-3129

Across the A4A dashboard, wrapped text regularly leaves a single orphaned word stranded on its own last line. It's a small thing, but it shows up on almost every page and makes the UI look less polished than it could.

## Proposed Changes

* Set `text-wrap: pretty` on the `.theme-a8c-for-agencies` root, and `text-wrap: balance` on short block elements (`h1`–`h6`, `li`, `td`, `th`, `dd`, `figcaption`).
* Add a targeted `text-wrap: balance` to `.reports-banner__heading` and `.woopayments-banner__heading`, which read as headings but are `div`s and so miss the rule above.

These are css-only changes.

## Why are these changes being made?

To add a tad more visual polish to the UI.

## Testing Instructions

Run the dashboard locally and compare a few pages at narrow-ish widths (960px is the most productive) with and without the change. To toggle it off in devtools without disturbing anything else, add:

```css
.theme-a8c-for-agencies, .theme-a8c-for-agencies * { text-wrap-style: auto !important; }
```

---

### Before / after

Four representative cases out of 67 — these are the ones worth looking at.

**Reports banner heading** — `/reports` @960 · stranded `clients`

| Before | After |
| --- | --- |
| <img width="256" alt="reports banner heading before" src="https://github.com/user-attachments/assets/e6ffbbbd-eb0f-4cf7-9a73-abc46a867bae" /> | <img width="256" alt="reports banner heading after" src="https://github.com/user-attachments/assets/8d3100b8-0fd1-4dbb-9191-4d36151b36a0" /> |

**WooPayments banner heading** — `/woopayments/overview` @960 · stranded `Revenue`

| Before | After |
| --- | --- |
| <img width="256" alt="woopayments banner heading before" src="https://github.com/user-attachments/assets/ee5b151c-c05d-4b49-8791-b0c1271cf73c" /> | <img width="256" alt="woopayments banner heading after" src="https://github.com/user-attachments/assets/e8634b07-85f5-45f2-8f79-bcf0be3efdef" /> |

**Marketplace product card** — `/marketplace` @960 · stranded `Subscriptions`

| Before | After |
| --- | --- |
| <img width="264" alt="marketplace product card before" src="https://github.com/user-attachments/assets/b932dd3c-b9f1-4a67-9e2e-fd9e7e3632fe" /> | <img width="264" alt="marketplace product card after" src="https://github.com/user-attachments/assets/4bae08e5-cb4c-4d4c-834a-98d51ef93a9b" /> |

**Reports value list** — `/reports` @1440 · stranded `communication.` (third item)

| Before | After |
| --- | --- |
| <img width="440" alt="reports value list before" src="https://github.com/user-attachments/assets/d37172c9-5541-4e29-81a0-540c98aed00f" /> | <img width="440" alt="reports value list after" src="https://github.com/user-attachments/assets/e970776b-d491-427c-89bd-302bc0af5330" /> |

### Side effect: short blocks get rebalanced

`balance` evens out every line in a block, not just the last one, so short lists and table cells are restyled even where there was no orphan to fix. This list had none — it just wraps more evenly now:

| Before | After |
| --- | --- |
| <img width="440" alt="list rebalanced, before" src="https://github.com/user-attachments/assets/fd101b24-1aeb-452c-9dcd-436723a321d6" /> | <img width="440" alt="list rebalanced, after" src="https://github.com/user-attachments/assets/4782bbb4-7bda-4368-8ada-693f83e38620" /> |


### Measured results

Counted with a script that measures every word's line box and flags any block wrapping to 2+ lines with a single word on the last. Coverage: 15 routes × 4 viewport widths (1440 / 1280 / 960 / 390) = 60 page states. Both columns were measured against real builds — the branch reverted for "before", restored for "after".

| Route | Before | After |
| --- | --- | --- |
| `/woopayments/overview` | 32 | 5 |
| `/marketplace` | 8 | 0 |
| `/marketplace/products` | 8 | 0 |
| `/reports` | 4 | 0 |
| `/exclusive-offers` | 3 | 0 |
| `/overview` | 2 | 0 |
| `/referrals/dashboard` | 2 | 0 |
| `/migrations` | 2 | 2 |
| `/team` | 2 | 1 |
| `/plugins` | 2 | 0 |
| `/agency-tier` | 1 | 0 |
| `/referrals/payment-settings` | 1 | 0 |
| **Total** | **67** | **8** |

`/sites`, `/purchases/licenses` and `/partner-directory/dashboard` had no orphans at any width and are omitted.

No layout regressions: no button started wrapping, and no page gained horizontal overflow at any of the four widths.

The remaining 8 want copy edits or non-breaking spaces rather than CSS — narrow table cells (`Revenue Share (bps)`), short inline links, and two long paragraphs on `/migrations`. Non-breaking spaces are awkward there because the strings go through `translate()`, so I've left them for a follow-up.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Crafted by Travbot (Claude-powered)
