### PR TITLE
A4A-3130: Always show the View details action on the referrals table

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -93,6 +93,12 @@ $data-view-border-color: #f1f1f1;
 		max-width: 700px;
 	}
 
+	// DataViews hides table row actions until the row is hovered or focused.
+	// Opening a referral is the point of the row, so keep the action visible.
+	.dataviews-view-table tr .dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
+		opacity: 1;
+	}
+
 	// Scoped to the list column so the detail view's cards keep their own inset.
 	.referrals-layout__column .referrals-consolidated-views {
 		// The HStack is `width: 100%` and content-box, so the inline padding would


### PR DESCRIPTION
Linear: A4A-3130

## Proposed Changes

* Keep the "View details" action in the Referrals table's Actions column visible at all times, instead of only on row hover or focus.

## Why are these changes being made?

* So people can more easily find this actionable link.

## Testing Instructions

* Go to Referrals → Dashboard on an agency account with at least one referral.
* Verify the "View details" link is visible on every row without hovering, and clicking it still opens the referral details column.

**Before** 
<img width="1514" height="333" alt="Screenshot 2026-08-03 at 12 53 33 PM" src="https://github.com/user-attachments/assets/ba0050a2-3400-45f1-906d-d512fbd8d076" />

**After**
<img width="1496" height="316" alt="Screenshot 2026-08-03 at 12 55 12 PM" src="https://github.com/user-attachments/assets/b82439ab-3b88-464e-980f-4879f4f8d4f0" />

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Crafted by Travbot (Claude-powered)
