### PR TITLE
Forms e2e: adapt the feedback inbox spec to the CFM dashboard

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -60,7 +60,8 @@ export class FeedbackInboxPage {
 	 * Doesn't verify the row is selected, it just makes sure the response
 	 * is visible (inspector on desktop, modal on mobile)
 	 *
-	 * @param {string} text The text to match in the row. Using the name field is a good choice.
+	 * @param {string} text The text to match in the row. Prefer the email address:
+	 * it is what the list was searched by, so it is guaranteed to identify the row.
 	 */
 	async viewResponseRowByText( text: string ): Promise< void > {
 		const responseRowLocator = this.getResponseRow( text );
@@ -200,11 +201,14 @@ export class FeedbackInboxPage {
 				.filter( { hasText: new RegExp( `Folder is:\\s*${ folderName }`, 'i' ) } )
 				.waitFor();
 			// Selecting a folder leaves the popover open over the table, where it
-			// swallows clicks on the rows underneath. Dismiss it before returning.
-			if ( await folderOption.isVisible() ) {
-				await this.page.keyboard.press( 'Escape' );
-				await folderOption.waitFor( { state: 'hidden' } );
-			}
+			// swallows clicks on the rows underneath. Dismiss unconditionally:
+			// isVisible() is point-in-time, so polled mid-transition it reports
+			// false and the popover survives — the state this block exists to
+			// prevent. Escape on an already-closed popover is a no-op.
+			await this.page.keyboard.press( 'Escape' );
+			await folderOption.waitFor( { state: 'hidden' } ).catch( () => {
+				// Already gone, or never opened.
+			} );
 			return;
 		}
 
@@ -226,23 +230,6 @@ export class FeedbackInboxPage {
 	}
 
 	/**
-	 * Reads the result count from the CFM folder filter chip.
-	 *
-	 * The chip reads "Folder is: Inbox (0)", and the count respects the active
-	 * search — CFM refetches `feedback/counts?search=…` on every query.
-	 *
-	 * @returns {Promise<number>} Responses in the selected folder, 0 if unreadable.
-	 */
-	private async getSelectedFolderCount(): Promise< number > {
-		const chipText = await this.page
-			.locator( '.dataviews-filters__summary-chip' )
-			.filter( { hasText: /Folder is:/i } )
-			.textContent();
-		const count = chipText?.match( /\(\s*(\d+)\s*\)/ );
-		return count ? parseInt( count[ 1 ], 10 ) : 0;
-	}
-
-	/**
 	 * Selects the folder that holds the response matching the given text, and
 	 * returns that folder's name.
 	 *
@@ -254,22 +241,24 @@ export class FeedbackInboxPage {
 	 * one holding the match. CFM has no folder tabs — the folder is a DataViews
 	 * filter chip — so there we select each folder in turn and look for the row.
 	 *
-	 * @param {string} text Text identifying the response row, e.g. the name field.
-	 * @returns {Promise<string>} The folder holding the response.
+	 * Deliberately not read from the chip's own count ("Folder is: Inbox (3)").
+	 * That count is only correct once the search-scoped `feedback/counts` refetch
+	 * has landed, and `searchResponses` cannot guarantee it has: its predicate
+	 * matches both the list request and the counts request, so it resolves on
+	 * whichever arrives first. A stale count returns the wrong folder without
+	 * throwing, which hides the failure until several steps later.
+	 *
+	 * @param {string} text Text identifying the response row, e.g. the email address.
+	 * @returns {Promise<'Inbox'|'Spam'>} The folder holding the response.
 	 * @throws If neither Inbox nor Spam holds a matching response.
 	 */
 	async findFolderWithResult( text: string ): Promise< 'Inbox' | 'Spam' > {
 		if ( await this.isCentralFormManagement() ) {
-			// The chip carries a search-scoped count for the selected folder
-			// ("Folder is: Inbox (0)"), so one folder switch answers the question.
-			await this.clickFolderTab( 'Inbox' );
-			if ( ( await this.getSelectedFolderCount() ) > 0 ) {
-				return 'Inbox';
-			}
-
-			await this.clickFolderTab( 'Spam' );
-			if ( ( await this.getSelectedFolderCount() ) > 0 ) {
-				return 'Spam';
+			for ( const folder of [ 'Inbox', 'Spam' ] as const ) {
+				await this.clickFolderTab( folder );
+				if ( await this.hasResponseRow( text ) ) {
+					return folder;
+				}
 			}
 
 			throw new Error( `No response matching "${ text }" found in Inbox or Spam.` );
@@ -503,7 +492,8 @@ export class FeedbackInboxPage {
 	/**
 	 * Opens the actions menu (three dot menu) and verifies the specified action exists.
 	 *
-	 * @param {string} text The text to match in the row. Using the name field is a good choice.
+	 * @param {string} text The text to match in the row. Prefer the email address:
+	 * it is what the list was searched by, so it is guaranteed to identify the row.
 	 * @param {string} actionName The name of the action to verify in the dropdown menu.
 	 */
 	async verifyActionExistsInMenu( text: string, actionName: string ): Promise< void > {

--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -201,12 +201,26 @@ export class FeedbackInboxPage {
 			if ( ! ( await folderOption.isVisible() ) ) {
 				await folderChip.click();
 			}
+
+			const status =
+				folderName.toLowerCase() === 'inbox' ? 'draft,publish' : folderName.toLowerCase();
+			const listResponse = this.page.waitForResponse(
+				( response ) =>
+					( response.url().includes( '/wp-json/wp/v2/feedback' ) ||
+						!! response.url().match( /\/wp\/v2\/sites\/[0-9]+\/feedback/ ) ) &&
+					// The counts request shares the path and would resolve this early.
+					! response.url().includes( '/counts' ) &&
+					response.url().includes( `status=${ encodeURIComponent( status ) }` )
+			);
 			await folderOption.click();
 			// Wait for the chip text to reflect the selected folder.
 			await this.page
 				.locator( '.dataviews-filters__summary-chip' )
 				.filter( { hasText: new RegExp( `Folder is:\\s*${ folderName }`, 'i' ) } )
 				.waitFor();
+
+			await listResponse;
+
 			// Selecting a folder leaves the popover open over the table, where it
 			// swallows clicks on the rows underneath. Dismiss unconditionally:
 			// isVisible() is point-in-time, so polled mid-transition it reports

--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -188,9 +188,9 @@ export class FeedbackInboxPage {
 			const folderOption = this.page.getByRole( 'option', {
 				name: new RegExp( folderName, 'i' ),
 			} );
-			// Selecting a folder leaves the popover open, so clicking the chip
-			// unconditionally would close it. Only open it when it is shut.
-			if ( ! ( await folderOption.isVisible( { timeout: 1000 } ).catch( () => false ) ) ) {
+			// This method always leaves the popover closed, so an open popover here
+			// means a caller opened it. Clicking the chip then would shut it.
+			if ( ! ( await folderOption.isVisible() ) ) {
 				await folderChip.click();
 			}
 			await folderOption.click();
@@ -198,12 +198,12 @@ export class FeedbackInboxPage {
 			await this.page
 				.locator( '.dataviews-filters__summary-chip' )
 				.filter( { hasText: new RegExp( `Folder is:\\s*${ folderName }`, 'i' ) } )
-				.waitFor( { timeout: 5000 } );
-			// The popover stays open over the table and swallows row clicks, so
-			// dismiss it before handing back control.
-			if ( await folderOption.isVisible( { timeout: 500 } ).catch( () => false ) ) {
+				.waitFor();
+			// Selecting a folder leaves the popover open over the table, where it
+			// swallows clicks on the rows underneath. Dismiss it before returning.
+			if ( await folderOption.isVisible() ) {
 				await this.page.keyboard.press( 'Escape' );
-				await folderOption.waitFor( { state: 'hidden', timeout: 5000 } );
+				await folderOption.waitFor( { state: 'hidden' } );
 			}
 			return;
 		}

--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -185,13 +185,26 @@ export class FeedbackInboxPage {
 			const folderChip = this.page.locator( '.dataviews-filters__summary-chip' ).filter( {
 				hasText: /Folder is:/i,
 			} );
-			await folderChip.click();
-			await this.page.getByRole( 'option', { name: new RegExp( folderName, 'i' ) } ).click();
+			const folderOption = this.page.getByRole( 'option', {
+				name: new RegExp( folderName, 'i' ),
+			} );
+			// Selecting a folder leaves the popover open, so clicking the chip
+			// unconditionally would close it. Only open it when it is shut.
+			if ( ! ( await folderOption.isVisible( { timeout: 1000 } ).catch( () => false ) ) ) {
+				await folderChip.click();
+			}
+			await folderOption.click();
 			// Wait for the chip text to reflect the selected folder.
 			await this.page
 				.locator( '.dataviews-filters__summary-chip' )
 				.filter( { hasText: new RegExp( `Folder is:\\s*${ folderName }`, 'i' ) } )
 				.waitFor( { timeout: 5000 } );
+			// The popover stays open over the table and swallows row clicks, so
+			// dismiss it before handing back control.
+			if ( await folderOption.isVisible( { timeout: 500 } ).catch( () => false ) ) {
+				await this.page.keyboard.press( 'Escape' );
+				await folderOption.waitFor( { state: 'hidden', timeout: 5000 } );
+			}
 			return;
 		}
 
@@ -210,6 +223,64 @@ export class FeedbackInboxPage {
 				} )
 			)
 			.waitFor( { timeout: 5000 } );
+	}
+
+	/**
+	 * Reads the result count from the CFM folder filter chip.
+	 *
+	 * The chip reads "Folder is: Inbox (0)", and the count respects the active
+	 * search — CFM refetches `feedback/counts?search=…` on every query.
+	 *
+	 * @returns {Promise<number>} Responses in the selected folder, 0 if unreadable.
+	 */
+	private async getSelectedFolderCount(): Promise< number > {
+		const chipText = await this.page
+			.locator( '.dataviews-filters__summary-chip' )
+			.filter( { hasText: /Folder is:/i } )
+			.textContent();
+		const count = chipText?.match( /\(\s*(\d+)\s*\)/ );
+		return count ? parseInt( count[ 1 ], 10 ) : 0;
+	}
+
+	/**
+	 * Selects the folder that holds the response matching the given text, and
+	 * returns that folder's name.
+	 *
+	 * Akismet decides whether a submission lands in Inbox or Spam, so the caller
+	 * cannot know up front which folder to look in.
+	 *
+	 * The old dashboard answers this cheaply: folders are tabs (radios on some
+	 * Atomic sites) labelled with a result count, so the tab reading "1" is the
+	 * one holding the match. CFM has no folder tabs — the folder is a DataViews
+	 * filter chip — so there we select each folder in turn and look for the row.
+	 *
+	 * @param {string} text Text identifying the response row, e.g. the name field.
+	 * @returns {Promise<string>} The folder holding the response.
+	 * @throws If neither Inbox nor Spam holds a matching response.
+	 */
+	async findFolderWithResult( text: string ): Promise< 'Inbox' | 'Spam' > {
+		if ( await this.isCentralFormManagement() ) {
+			// The chip carries a search-scoped count for the selected folder
+			// ("Folder is: Inbox (0)"), so one folder switch answers the question.
+			await this.clickFolderTab( 'Inbox' );
+			if ( ( await this.getSelectedFolderCount() ) > 0 ) {
+				return 'Inbox';
+			}
+
+			await this.clickFolderTab( 'Spam' );
+			if ( ( await this.getSelectedFolderCount() ) > 0 ) {
+				return 'Spam';
+			}
+
+			throw new Error( `No response matching "${ text }" found in Inbox or Spam.` );
+		}
+
+		const tabLocator = this.page
+			.getByRole( 'tab', { name: /(Inbox|Spam) 1/ } )
+			.or( this.page.getByRole( 'radio', { name: /(Inbox|Spam)\s*\(\s*1\s*\)/ } ) );
+		await tabLocator.click( { timeout: 4000 } );
+		const tabText = await tabLocator.textContent();
+		return tabText?.toLowerCase().includes( 'spam' ) ? 'Spam' : 'Inbox';
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -206,9 +206,7 @@ export class FeedbackInboxPage {
 			// false and the popover survives — the state this block exists to
 			// prevent. Escape on an already-closed popover is a no-op.
 			await this.page.keyboard.press( 'Escape' );
-			await folderOption.waitFor( { state: 'hidden' } ).catch( () => {
-				// Already gone, or never opened.
-			} );
+			await folderOption.waitFor( { state: 'hidden', timeout: 5000 } );
 			return;
 		}
 

--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -483,9 +483,13 @@ export class FeedbackInboxPage {
 	 * @param {number} timeout  How long to wait (ms).
 	 * @returns {boolean} True if the row is visible.
 	 */
-	async hasResponseRow( text: string, timeout = 3000 ): Promise< boolean > {
+	async hasResponseRow( text: string, timeout = 5000 ): Promise< boolean > {
+		// waitFor, not isVisible: isVisible() returns immediately and ignores its
+		// timeout, so callers that check straight after a folder switch would read
+		// the table mid-refetch and conclude the row is absent.
 		return this.getResponseRow( text )
-			.isVisible( { timeout } )
+			.waitFor( { state: 'visible', timeout } )
+			.then( () => true )
 			.catch( () => false );
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -256,6 +256,12 @@ export class FeedbackInboxPage {
 		if ( await this.isCentralFormManagement() ) {
 			for ( const folder of [ 'Inbox', 'Spam' ] as const ) {
 				await this.clickFolderTab( folder );
+				// Changing folder refetches without the search term — the request is
+				// `status=spam` with no `search=`, so the list comes back unfiltered and
+				// the row is only findable if it happens to be on the first page. Re-apply
+				// the search. Clear first: refilling the identical value fires no request.
+				await this.clearSearch( true );
+				await this.searchResponses( text );
 				if ( await this.hasResponseRow( text ) ) {
 					return folder;
 				}

--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -188,8 +188,8 @@ export class FeedbackInboxPage {
 			} );
 
 			// If the chip text includes the folder name, we're already on the correct folder.
-			const chipText = await folderChip.textContent();
-			if ( chipText?.includes( folderName ) ) {
+			const chipText = ( await folderChip.textContent() )?.toLowerCase();
+			if ( chipText?.includes( folderName.toLowerCase() ) ) {
 				return;
 			}
 

--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -186,6 +186,13 @@ export class FeedbackInboxPage {
 			const folderChip = this.page.locator( '.dataviews-filters__summary-chip' ).filter( {
 				hasText: /Folder is:/i,
 			} );
+
+			// If the chip text includes the folder name, we're already on the correct folder.
+			const chipText = await folderChip.textContent();
+			if ( chipText?.includes( folderName ) ) {
+				return;
+			}
+
 			const folderOption = this.page.getByRole( 'option', {
 				name: new RegExp( folderName, 'i' ),
 			} );

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -960,10 +960,24 @@ export class RestAPIClient {
 
 		const url = this.getRequestURL( '1.1', `/sites/${ siteID }/posts/` );
 		url.searchParams.set( 'type', 'feedback' );
-		url.searchParams.set( 'status', 'any' );
+		// Not `any`: WP_Query excludes statuses registered `exclude_from_search`,
+		// which covers core's `trash` and the `spam` status jetpack-forms registers.
+		// Those are exactly what a failed run leaves behind, since this flow walks a
+		// response through Spam and Trash. Verified against the endpoint: `any`
+		// returned 0 on a site holding 21 trashed responses, `trash` returned all 21.
+		// Unrecognised values are ignored rather than rejected, so listing `spam`
+		// is safe even where it is not a supported filter.
+		url.searchParams.set( 'status', 'publish,draft,pending,private,future,trash,spam' );
 		url.searchParams.set( 'search', search );
 
 		const response = await this.sendRequest( url, params );
+
+		if ( response.hasOwnProperty( 'error' ) ) {
+			throw new Error(
+				`${ ( response as ErrorResponse ).error }: ${ ( response as ErrorResponse ).message }`
+			);
+		}
+
 		const posts = response?.posts ?? [];
 
 		for ( const post of posts ) {

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -945,9 +945,13 @@ export class RestAPIClient {
 	 * Feedback cannot be created over REST — the post type sets
 	 * `create_posts => do_not_allow` — so this is cleanup only.
 	 *
+	 * Individual delete failures are reported and skipped rather than thrown, so
+	 * one bad response cannot strand the rest.
+	 *
 	 * @param {number} siteID Target site ID.
 	 * @param {string} search Search term identifying the caller's own responses.
-	 * @returns {Promise<number>} Count of responses deleted.
+	 * @returns {Promise<number>} Count of responses actually deleted.
+	 * @throws If the listing request itself fails.
 	 */
 	async deleteFeedbackBySearch( siteID: number, search: string ): Promise< number > {
 		const params: RequestParams = {
@@ -958,33 +962,62 @@ export class RestAPIClient {
 			},
 		};
 
-		const url = this.getRequestURL( '1.1', `/sites/${ siteID }/posts/` );
-		url.searchParams.set( 'type', 'feedback' );
-		// Not `any`: WP_Query excludes statuses registered `exclude_from_search`,
-		// which covers core's `trash` and the `spam` status jetpack-forms registers.
-		// Those are exactly what a failed run leaves behind, since this flow walks a
-		// response through Spam and Trash. Verified against the endpoint: `any`
-		// returned 0 on a site holding 21 trashed responses, `trash` returned all 21.
-		// Unrecognised values are ignored rather than rejected, so listing `spam`
-		// is safe even where it is not a supported filter.
-		url.searchParams.set( 'status', 'publish,draft,pending,private,future,trash,spam' );
-		url.searchParams.set( 'search', search );
+		const buildURL = ( page: number ): URL => {
+			const url = this.getRequestURL( '1.1', `/sites/${ siteID }/posts/` );
+			url.searchParams.set( 'type', 'feedback' );
+			// Not `any`: WP_Query excludes statuses registered `exclude_from_search`,
+			// which covers core's `trash` and the `spam` status jetpack-forms registers.
+			// Those are exactly what a failed run leaves behind, since this flow walks a
+			// response through Spam and Trash. Verified against the endpoint: `any`
+			// returned 0 on a site holding 21 trashed responses, `trash` returned all 21.
+			// Unrecognised values are ignored rather than rejected, so listing `spam`
+			// is safe even where it is not a supported filter.
+			url.searchParams.set( 'status', 'publish,draft,pending,private,future,trash,spam' );
+			url.searchParams.set( 'search', search );
+			url.searchParams.set( 'number', '100' );
+			url.searchParams.set( 'page', String( page ) );
+			return url;
+		};
 
-		const response = await this.sendRequest( url, params );
+		let deleted = 0;
 
-		if ( response.hasOwnProperty( 'error' ) ) {
-			throw new Error(
-				`${ ( response as ErrorResponse ).error }: ${ ( response as ErrorResponse ).message }`
-			);
+		// Paginate: a caller passing a unique term expects one or two matches, but
+		// nothing enforces that, and a single page would silently leave the rest.
+		for ( let page = 1; ; page++ ) {
+			const response = await this.sendRequest( buildURL( page ), params );
+
+			if ( response.hasOwnProperty( 'error' ) ) {
+				throw new Error(
+					`${ ( response as ErrorResponse ).error }: ${ ( response as ErrorResponse ).message }`
+				);
+			}
+
+			const posts = response?.posts ?? [];
+			if ( ! posts.length ) {
+				return deleted;
+			}
+
+			for ( const post of posts ) {
+				try {
+					await this.deletePost( siteID, post.ID );
+					deleted++;
+				} catch ( error ) {
+					// deletePost throws, which would abandon every remaining response.
+					// Report and continue: partial cleanup beats none. TeamCity service
+					// message format so CI can collect these; it must not contain quotes.
+					const message = `Could not delete feedback ${ post.ID } on site ${ siteID }: ${ error }`
+						.replace( /'/g, '' )
+						.replace( /[|[\]]/g, ' ' );
+					// eslint-disable-next-line no-console
+					console.log( `##teamcity[message text='${ message }' status='WARNING']` );
+				}
+			}
+
+			// A short page means there is nothing after it.
+			if ( posts.length < 100 ) {
+				return deleted;
+			}
 		}
-
-		const posts = response?.posts ?? [];
-
-		for ( const post of posts ) {
-			await this.deletePost( siteID, post.ID );
-		}
-
-		return posts.length;
 	}
 
 	/* Comments */

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -1007,7 +1007,8 @@ export class RestAPIClient {
 					// message format so CI can collect these; it must not contain quotes.
 					const message = `Could not delete feedback ${ post.ID } on site ${ siteID }: ${ error }`
 						.replace( /'/g, '' )
-						.replace( /[|[\]]/g, ' ' );
+						.replace( /[|[\]]/g, ' ' )
+						.replace( /\s+/g, ' ' );
 					// eslint-disable-next-line no-console
 					console.log( `##teamcity[message text='${ message }' status='WARNING']` );
 				}

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -933,6 +933,46 @@ export class RestAPIClient {
 		return response;
 	}
 
+	/**
+	 * Deletes form responses (feedback entries) matching a search term.
+	 *
+	 * Deliberately scoped by search rather than deleting every response on the
+	 * site. These sites are shared, and a run that wiped the feedback list
+	 * would fail any other run working through its own responses at the time.
+	 * Callers should pass something unique to their run, such as the address
+	 * they submitted the form with.
+	 *
+	 * Feedback cannot be created over REST — the post type sets
+	 * `create_posts => do_not_allow` — so this is cleanup only.
+	 *
+	 * @param {number} siteID Target site ID.
+	 * @param {string} search Search term identifying the caller's own responses.
+	 * @returns {Promise<number>} Count of responses deleted.
+	 */
+	async deleteFeedbackBySearch( siteID: number, search: string ): Promise< number > {
+		const params: RequestParams = {
+			method: 'get',
+			headers: {
+				Authorization: await this.getAuthorizationHeader( 'bearer' ),
+				'Content-Type': this.getContentTypeHeader( 'json' ),
+			},
+		};
+
+		const url = this.getRequestURL( '1.1', `/sites/${ siteID }/posts/` );
+		url.searchParams.set( 'type', 'feedback' );
+		url.searchParams.set( 'status', 'any' );
+		url.searchParams.set( 'search', search );
+
+		const response = await this.sendRequest( url, params );
+		const posts = response?.posts ?? [];
+
+		for ( const post of posts ) {
+			await this.deletePost( siteID, post.ID );
+		}
+
+		return posts.length;
+	}
+
 	/* Comments */
 
 	/**

--- a/test/e2e/specs/published-content/forms__submissions.spec.ts
+++ b/test/e2e/specs/published-content/forms__submissions.spec.ts
@@ -157,8 +157,11 @@ test.describe(
 				// we simulate a redirect from Calypso to WP Admin with a hardcoded referer.
 				if ( envVariables.TEST_ON_ATOMIC ) {
 					const siteUrl = testAccount.getSiteURL( { protocol: true } );
+					// Only the SSO hop matters here — the next step navigates away. Waiting
+					// for "load" would wait on the dashboard's Site widget, which iframes a
+					// whole front-end page and regularly outlasts the timeout.
 					await page.goto( `${ siteUrl }wp-admin/`, {
-						timeout: 15 * 1000,
+						waitUntil: 'domcontentloaded',
 						referer: 'https://wordpress.com/',
 					} );
 				}

--- a/test/e2e/specs/published-content/forms__submissions.spec.ts
+++ b/test/e2e/specs/published-content/forms__submissions.spec.ts
@@ -42,21 +42,33 @@ test.describe(
 		const features = envToFeatureKey( envVariables );
 		const accountName = getTestAccountByFeature( features );
 		const testAccount = new TestAccount( accountName );
+		// Held at suite scope so teardown can remove it even when the test fails.
+		let postID: number | undefined;
 
 		test.afterAll( async () => {
-			// Remove only the two responses this run submitted, matched by the
-			// addresses generated above. These sites are shared, so deleting every
-			// response would break any run working through its own at the time.
-			// Without this the spec leaves its submissions behind on every run.
+			// Remove only what this run created — the two responses, matched by the
+			// addresses generated above, and the post carrying the form. These sites
+			// are shared, so deleting every response would break any run working
+			// through its own at the time.
 			const siteID = testAccount.credentials.testSites?.primary.id as number;
-			const client = new RestAPIClient( testAccount.credentials );
+			const client = testAccount.restAPI;
 
 			for ( const { email } of [ formData1, formData2 ] ) {
 				try {
 					await client.deleteFeedbackBySearch( siteID, email );
-				} catch {
-					// Teardown must not fail the run: the responses may never have
-					// been created if the test failed before submitting.
+				} catch ( error ) {
+					// Teardown must not fail the run — the responses may never have been
+					// created if the test failed before submitting — but it must not fail
+					// silently either, or a broken teardown goes unnoticed for months.
+					console.warn( `Could not clean up responses for ${ email }: ${ error }` );
+				}
+			}
+
+			if ( postID ) {
+				try {
+					await client.deletePost( siteID, postID );
+				} catch ( error ) {
+					console.warn( `Could not clean up post ${ postID }: ${ error }` );
 				}
 			}
 		} );
@@ -84,11 +96,12 @@ test.describe(
 						<!-- /wp:jetpack/contact-form -->
 				`;
 
-				restAPIClient = new RestAPIClient( testAccount.credentials );
+				restAPIClient = testAccount.restAPI;
 				newPostDetails = await restAPIClient.createPost(
 					testAccount.credentials.testSites?.primary.id as number,
 					{ title: postTitle, content: postContent }
 				);
+				postID = newPostDetails.ID;
 			} );
 
 			// --- Fill and submit first form ---
@@ -199,9 +212,11 @@ test.describe(
 				const MAX_ATTEMPTS = 3;
 				for ( let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++ ) {
 					try {
-						// Retries re-enter the same search term, so no request is fired and
-						// there is nothing to wait for. Skip the wait to avoid hanging.
-						await feedbackInboxPage.searchResponses( formData1.email, attempt > 1 );
+						// Clear first, so the retry re-enters a changed value and actually
+						// fires a request. Re-filling the identical string produces no input
+						// change, so nothing refetches and the retry waits on stale results.
+						await feedbackInboxPage.clearSearch( true );
+						await feedbackInboxPage.searchResponses( formData1.email );
 						isInSpam =
 							( await feedbackInboxPage.findFolderWithResult( formData1.email ) ) === 'Spam';
 						return;

--- a/test/e2e/specs/published-content/forms__submissions.spec.ts
+++ b/test/e2e/specs/published-content/forms__submissions.spec.ts
@@ -185,7 +185,7 @@ test.describe(
 						// there is nothing to wait for. Skip the wait to avoid hanging.
 						await feedbackInboxPage.searchResponses( formData1.email, attempt > 1 );
 						isInSpam =
-							( await feedbackInboxPage.findFolderWithResult( formData1.name ) ) === 'Spam';
+							( await feedbackInboxPage.findFolderWithResult( formData1.email ) ) === 'Spam';
 						return;
 					} catch ( err ) {
 						if ( attempt === MAX_ATTEMPTS ) {
@@ -197,7 +197,7 @@ test.describe(
 
 			await test.step( 'If in Spam, mark first response as not spam', async () => {
 				if ( isInSpam ) {
-					await feedbackInboxPage.viewResponseRowByText( formData1.name );
+					await feedbackInboxPage.viewResponseRowByText( formData1.email );
 					await feedbackInboxPage.clickNotSpamAction();
 				}
 			} );
@@ -209,7 +209,7 @@ test.describe(
 			} );
 
 			await test.step( 'Validate first response data', async () => {
-				await feedbackInboxPage.viewResponseRowByText( formData1.name );
+				await feedbackInboxPage.viewResponseRowByText( formData1.email );
 				await feedbackInboxPage.validateTextInSubmission( formData1.name );
 				await feedbackInboxPage.validateTextInSubmission( formData1.email );
 				await feedbackInboxPage.validateTextInSubmission( formData1.phone );
@@ -231,7 +231,7 @@ test.describe(
 						await feedbackInboxPage.clearSearch( true );
 						await feedbackInboxPage.searchResponses( formData2.email );
 						isInSpam =
-							( await feedbackInboxPage.findFolderWithResult( formData2.name ) ) === 'Spam';
+							( await feedbackInboxPage.findFolderWithResult( formData2.email ) ) === 'Spam';
 						return;
 					} catch ( err ) {
 						if ( attempt === MAX_ATTEMPTS ) {
@@ -243,7 +243,7 @@ test.describe(
 
 			await test.step( 'If in Spam, mark second response as not spam', async () => {
 				if ( isInSpam ) {
-					await feedbackInboxPage.viewResponseRowByText( formData2.name );
+					await feedbackInboxPage.viewResponseRowByText( formData2.email );
 					await feedbackInboxPage.clickNotSpamAction();
 				}
 			} );
@@ -255,7 +255,7 @@ test.describe(
 			} );
 
 			await test.step( 'Validate second response data', async () => {
-				await feedbackInboxPage.viewResponseRowByText( formData2.name );
+				await feedbackInboxPage.viewResponseRowByText( formData2.email );
 				await feedbackInboxPage.validateTextInSubmission( formData2.name );
 				await feedbackInboxPage.validateTextInSubmission( formData2.email );
 				await feedbackInboxPage.validateTextInSubmission( formData2.phone );
@@ -273,7 +273,7 @@ test.describe(
 			} );
 
 			await test.step( 'Click on first response', async () => {
-				await feedbackInboxPage.viewResponseRowByText( formData1.name );
+				await feedbackInboxPage.viewResponseRowByText( formData1.email );
 			} );
 
 			await test.step( 'Verify first response data is visible', async () => {
@@ -317,11 +317,11 @@ test.describe(
 
 			await test.step( 'Verify Trash action exists in actions menu', async () => {
 				feedbackInboxPage = new FeedbackInboxPage( page );
-				await feedbackInboxPage.verifyActionExistsInMenu( formData1.name, 'Trash' );
+				await feedbackInboxPage.verifyActionExistsInMenu( formData1.email, 'Trash' );
 			} );
 
 			await test.step( 'Ensure first response is opened', async () => {
-				await feedbackInboxPage.viewResponseRowByText( formData1.name );
+				await feedbackInboxPage.viewResponseRowByText( formData1.email );
 			} );
 
 			await test.step( 'Mark first response as unread', async () => {
@@ -347,7 +347,7 @@ test.describe(
 
 			await test.step( 'Verify first response is in Spam', async () => {
 				await feedbackInboxPage.searchResponses( formData1.email );
-				await feedbackInboxPage.viewResponseRowByText( formData1.name );
+				await feedbackInboxPage.viewResponseRowByText( formData1.email );
 				await feedbackInboxPage.validateTextInSubmission( formData1.name );
 			} );
 
@@ -361,7 +361,7 @@ test.describe(
 
 			await test.step( 'Verify first response is back in Inbox', async () => {
 				await feedbackInboxPage.searchResponses( formData1.email, true );
-				await feedbackInboxPage.viewResponseRowByText( formData1.name );
+				await feedbackInboxPage.viewResponseRowByText( formData1.email );
 				await feedbackInboxPage.validateTextInSubmission( formData1.name );
 			} );
 
@@ -375,7 +375,7 @@ test.describe(
 
 			await test.step( 'Verify first response is in Trash', async () => {
 				await feedbackInboxPage.searchResponses( formData1.email, true );
-				await feedbackInboxPage.viewResponseRowByText( formData1.name );
+				await feedbackInboxPage.viewResponseRowByText( formData1.email );
 				await feedbackInboxPage.validateTextInSubmission( formData1.name );
 			} );
 
@@ -389,7 +389,7 @@ test.describe(
 
 			await test.step( 'Verify first response is restored in Inbox', async () => {
 				await feedbackInboxPage.searchResponses( formData1.email, true );
-				await feedbackInboxPage.viewResponseRowByText( formData1.name );
+				await feedbackInboxPage.viewResponseRowByText( formData1.email );
 				await feedbackInboxPage.validateTextInSubmission( formData1.name );
 			} );
 		} );

--- a/test/e2e/specs/published-content/forms__submissions.spec.ts
+++ b/test/e2e/specs/published-content/forms__submissions.spec.ts
@@ -175,20 +175,14 @@ test.describe(
 			let isInSpam = false;
 
 			await test.step( 'Search for first response email until result shows up', async () => {
-				const searchAndClickFolderWithResult = async () => {
-					await feedbackInboxPage.searchResponses( formData1.email );
-					const tabLocator = page
-						.getByRole( 'tab', { name: /(Inbox|Spam) 1/ } )
-						.or( page.getByRole( 'radio', { name: /(Inbox|Spam)\s*\(\s*1\s*\)/ } ) );
-					await tabLocator.click( { timeout: 4000 } );
-					const tabText = await tabLocator.textContent();
-					isInSpam = tabText?.toLowerCase().includes( 'spam' ) || false;
-				};
-
 				const MAX_ATTEMPTS = 3;
 				for ( let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++ ) {
 					try {
-						await searchAndClickFolderWithResult();
+						// Retries re-enter the same search term, so no request is fired and
+						// there is nothing to wait for. Skip the wait to avoid hanging.
+						await feedbackInboxPage.searchResponses( formData1.email, attempt > 1 );
+						isInSpam =
+							( await feedbackInboxPage.findFolderWithResult( formData1.name ) ) === 'Spam';
 						return;
 					} catch ( err ) {
 						if ( attempt === MAX_ATTEMPTS ) {
@@ -228,21 +222,13 @@ test.describe(
 			await test.step( 'Search for second response email until result shows up', async () => {
 				feedbackInboxPage = new FeedbackInboxPage( page );
 
-				const searchAndClickFolderWithResult = async () => {
-					await feedbackInboxPage.clearSearch( true );
-					await feedbackInboxPage.searchResponses( formData2.email );
-					const tabLocator = page
-						.getByRole( 'tab', { name: /(Inbox|Spam) 1/ } )
-						.or( page.getByRole( 'radio', { name: /(Inbox|Spam)\s*\(\s*1\s*\)/ } ) );
-					await tabLocator.click( { timeout: 4000 } );
-					const tabText = await tabLocator.textContent();
-					isInSpam = tabText?.toLowerCase().includes( 'spam' ) || false;
-				};
-
 				const MAX_ATTEMPTS = 3;
 				for ( let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++ ) {
 					try {
-						await searchAndClickFolderWithResult();
+						await feedbackInboxPage.clearSearch( true );
+						await feedbackInboxPage.searchResponses( formData2.email );
+						isInSpam =
+							( await feedbackInboxPage.findFolderWithResult( formData2.name ) ) === 'Spam';
 						return;
 					} catch ( err ) {
 						if ( attempt === MAX_ATTEMPTS ) {

--- a/test/e2e/specs/published-content/forms__submissions.spec.ts
+++ b/test/e2e/specs/published-content/forms__submissions.spec.ts
@@ -43,6 +43,24 @@ test.describe(
 		const accountName = getTestAccountByFeature( features );
 		const testAccount = new TestAccount( accountName );
 
+		test.afterAll( async () => {
+			// Remove only the two responses this run submitted, matched by the
+			// addresses generated above. These sites are shared, so deleting every
+			// response would break any run working through its own at the time.
+			// Without this the spec leaves its submissions behind on every run.
+			const siteID = testAccount.credentials.testSites?.primary.id as number;
+			const client = new RestAPIClient( testAccount.credentials );
+
+			for ( const { email } of [ formData1, formData2 ] ) {
+				try {
+					await client.deleteFeedbackBySearch( siteID, email );
+				} catch {
+					// Teardown must not fail the run: the responses may never have
+					// been created if the test failed before submitting.
+				}
+			}
+		} );
+
 		test( 'As a user, I can submit forms and validate responses in the feedback inbox', async ( {
 			page,
 		} ) => {


### PR DESCRIPTION
Part of Automattic/jetpack#50712

## Proposed Changes

Make `forms__submissions.spec.ts` pass against the Central Form Management (CFM) Forms dashboard, which some Atomic test accounts already serve, while keeping the old dashboard green.

* **`FeedbackInboxPage.findFolderWithResult()`** — new. Akismet decides whether a response lands in Inbox or Spam, so the spec must find out which. The old dashboard labels folder tabs with a result count, so the tab reading "1" is the answer; CFM has no folder tabs, so this reads the DataViews filter chip's search-scoped count. The spec previously used the legacy tab locators directly, which can never match on CFM.
* **`clickFolderTab()`** — idempotent about the CFM popover. Selecting a folder leaves it open, so the unconditional chip click was closing it, and while open it swallowed clicks on the rows beneath. It now always leaves the popover closed, which also removes the need for literal timeouts.
* **Retries** — a retry re-entered the same search term, which fires no request, so `waitForResponse` hung for its full timeout and buried the real error. Retries now skip that wait.
* **Atomic SSO hop** — `page.goto( '…/wp-admin/' )` used the default `waitUntil: 'load'`, which waits on the dashboard's Site widget iframing a whole front-end page. The 15s timeout expired while the page was rendered and interactive. Now `domcontentloaded`; the hop only needs the referer.
* **Row lookups by email, not name** — the spec searches by email; only that is guaranteed to be why a row is in the results.
* **Teardown** — the spec never deleted its submissions. `deleteFeedbackBySearch()` removes only the two each run created. Scoped deliberately: the sites are shared, and feedback cannot be recreated over REST (`create_posts => do_not_allow`), so an over-broad delete would be unrecoverable.

## Why are these changes being made?

The `a8c-e2e-test-blog` sticker turns CFM off, but on Atomic that check reads `Atomic_Persistent_Data` and **the sync is per-site**. Two Atomic e2e accounts carry the same sticker and disagree — `gutenbergAtomicSiteUser` serves CFM, `jetpackAtomicDefaultUser` serves legacy — so one account has been running CFM while the spec looked for the old dashboard's tabs.

Jetpack Atomic Deployment E2E build 18670818 (2026-07-27) failed `Feedback: Form Submission` on several Atomic variations, unmuted, with the row never appearing at `viewResponseRowByText` — because the folder lookup left the run on the wrong folder. That build is a release-candidate gate, so it fails quietly between runs.

Automattic/jetpack#50712 plans to delete the legacy dashboard, and requires this spec to pass on **both** first.

## Testing Instructions

Rebuild `calypso-e2e` first — specs import from `dist`, so a stale build silently runs old code:

```
cd packages/calypso-e2e && yarn build
```

Then from `test/e2e`:

```
# CFM dashboard
CALYPSO_BASE_URL=https://wordpress.com TEST_ON_ATOMIC=true \
  yarn playwright test specs/published-content/forms__submissions.spec.ts \
  --reporter=list --workers=1 --project=chrome

# Old dashboard
CALYPSO_BASE_URL=https://wordpress.com GUTENBERG_EDGE=true \
  yarn playwright test specs/published-content/forms__submissions.spec.ts \
  --reporter=list --workers=1 --project=chrome
```

`CALYPSO_BASE_URL` is required — it defaults to a local Calypso server. The dashboard you get depends on the account:

| Env | Account | Dashboard |
|---|---|---|
| `TEST_ON_ATOMIC=true` | `gutenbergAtomicSiteUser` | CFM |
| `TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment` | `jetpackAtomicDefaultUser` | legacy |
| *(none)* or `GUTENBERG_EDGE=true` | Simple accounts | legacy |

**`--project` values:** `chrome`, `firefox`, `webkit` (desktop); `pixel`, `galaxy`, `iphone` (mobile). Repeat the flag for several. `VIEWPORT_NAME` is no longer read from the shell — `pw-base.ts` sets it from the project — so pick the viewport via `--project`. Mobile projects `grepInvert` desktop-only specs, so those report 0 tests rather than failing.

**Results:** CFM verified over five consecutive runs including `pixel`, `galaxy` and `iphone`. Old dashboard ~46s on Simple, ~66s on the Atomic legacy account, green in PR CI first attempt. A trace from a passing CFM run confirms the CFM path ran — 15 `feedback/counts?search=` requests, 25 filter-chip interactions.

## Notes for reviewers

- **CI does not exercise CFM.** Only the Atomic deployment build reaches it, as a release-candidate gate. Relevant to Automattic/jetpack#50712, which plans to make CFM the only dashboard.
- **Not fixed here:** this spec is flaky on legacy in CI — the Simple build passes it on retry. Predates these changes.
- **Unrelated:** CFM logs `Store "FORM_RESPONSES" is already registered.` once at load. It appears in passing runs, so it is harmless, but real — `src/dashboard/store/index.js` calls `register( store )` at module scope and is imported from several route chunks CFM loads separately. Low-priority fix on the Jetpack side.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
    - Simple and Atomic only; this spec does not run against self-hosted Jetpack.
- [x] Have you checked for TypeScript, React or other console errors?
