### PR TITLE
Fix logged-out Help Center loading

### DIFF
--- a/apps/help-center/async-help-center.jsx
+++ b/apps/help-center/async-help-center.jsx
@@ -1,4 +1,6 @@
 /* global helpCenterData */
+import './config';
+import './help-center.scss';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { dispatch } from '@wordpress/data';
 import { createRoot } from 'react-dom/client';

--- a/apps/help-center/help-center-logged-out.js
+++ b/apps/help-center/help-center-logged-out.js
@@ -1,6 +1,7 @@
-import './config';
-import './help-center.scss';
-import loadHelpCenter from './async-help-center';
+const loadHelpCenter = () =>
+	import( './async-help-center' ).then( ( { default: asyncLoadHelpCenter } ) =>
+		asyncLoadHelpCenter()
+	);
 
 /**
  * Checks if the help center should be automatically to keep session continuity.

--- a/apps/help-center/webpack.config.js
+++ b/apps/help-center/webpack.config.js
@@ -10,6 +10,7 @@ const isDevelopment = process.env.NODE_ENV !== 'production';
 
 function getIndividualConfig( options = {} ) {
 	const { name, env, argv, injectPolyfill = true } = options;
+	const isLoggedOutEntry = name === 'help-center-logged-out';
 
 	const outputPath = path.join( __dirname, 'dist' );
 	const webpackConfig = getBaseWebpackConfig( env, argv );
@@ -52,10 +53,15 @@ function getIndividualConfig( options = {} ) {
 				output: path.resolve( './dist/chunks-map.json' ),
 			} ),
 			new DependencyExtractionWebpackPlugin( {
-				injectPolyfill,
+				injectPolyfill: isLoggedOutEntry ? false : injectPolyfill,
 				outputFilename: '[name].asset.json',
 				outputFormat: 'json',
+				useDefaults: ! isLoggedOutEntry,
 				requestToExternal( request ) {
+					if ( isLoggedOutEntry ) {
+						return null;
+					}
+
 					// The extraction logic will only extract a package if requestToExternal
 					// explicitly returns undefined for the given request. Null
 					// shortcuts the logic such that the package will be bundled instead.


### PR DESCRIPTION

## Proposed Changes

* Load the logged-out Help Center bootstrap, configuration, and styles only after engagement.
* Bundle its React and WordPress dependencies into asynchronous chunks so WordPress does not enqueue them with the entry script.

## Why are these changes being made?

The logged-out entry's asset manifest included dependencies reached through the Help Center's dynamic import. WordPress therefore enqueued those handles synchronously, defeating the intended deferred loading. The logged-out build now emits an empty dependency list and loads the complete Help Center graph asynchronously.

## Testing Instructions

### Automated

1. Run `cd apps/help-center && NODE_ENV=production yarn build:app`.
2. Confirm `dist/help-center-logged-out.asset.json` contains `"dependencies": []`.
3. Run `yarn lint:js apps/help-center/help-center-logged-out.js apps/help-center/async-help-center.jsx apps/help-center/webpack.config.js`.
4. Run `yarn prettier --check apps/help-center/help-center-logged-out.js apps/help-center/async-help-center.jsx apps/help-center/webpack.config.js`.

### Simple, Atomic, and self-hosted Jetpack

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. On a logged-out page, confirm the initial page load does not enqueue Help Center dependency handles.
4. Open Help Center from a support link and confirm the UI and styles load successfully.

`yarn typecheck-apps` currently fails in unrelated apps and generated dependency declarations, including `apps/o2-blocks`, `apps/odyssey-stats`, and `packages/api-queries`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
