### PR TITLE
Stats: stop escalating the commercial notice to a lockout banner

### DIFF
--- a/client/my-sites/stats/hooks/test/use-stats-purchases-enforced.ts
+++ b/client/my-sites/stats/hooks/test/use-stats-purchases-enforced.ts
@@ -6,7 +6,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { STAT_TYPE_CLICKS, STATS_FEATURE_DATE_CONTROL_LAST_30_DAYS } from '../../constants';
 import { shouldGateStats } from '../use-should-gate-stats';
-import { shouldShowPaywallAfterGracePeriod } from '../use-stats-purchases';
+import { shouldShowPaywallAfterGracePeriod, shouldShowPaywallNotice } from '../use-stats-purchases';
 
 jest.mock( '../../constants', () => ( {
 	...jest.requireActual( '../../constants' ),
@@ -65,6 +65,19 @@ describe( 'with COMMERCIAL_PAYWALL_KILLED flipped back to false', () => {
 
 	it( 'reports the paywall again for a walled commercial site', () => {
 		expect( shouldShowPaywallAfterGracePeriod( walledCommercialSiteState, siteId ) ).toBe( true );
+	} );
+
+	it( 'escalates the upgrade notice to its lockout variant again', () => {
+		const walledWithStickerDate = {
+			...walledCommercialSiteState,
+			stats: {
+				planUsage: {
+					data: { [ siteId ]: { should_show_paywall: true, paywall_date_from: '2026-07-14' } },
+				},
+			},
+		};
+
+		expect( shouldShowPaywallNotice( walledWithStickerDate, siteId ) ).toBe( true );
 	} );
 
 	it( 'gates basic stats again', () => {

--- a/client/my-sites/stats/hooks/test/use-stats-purchases.ts
+++ b/client/my-sites/stats/hooks/test/use-stats-purchases.ts
@@ -46,13 +46,12 @@ describe( 'shouldShowPaywallAfterGracePeriod', () => {
 	} );
 } );
 
-// The upgrade notice is handled separately, so this PR must leave it escalating as it does today.
 describe( 'shouldShowPaywallNotice', () => {
-	it( 'still reports the sticker, so the notice behaviour is unchanged here', () => {
-		expect( shouldShowPaywallNotice( walledState, siteId ) ).toBe( true );
+	it( 'ignores the commercial paywall sticker while the kill switch is on', () => {
+		expect( shouldShowPaywallNotice( walledState, siteId ) ).toBe( false );
 	} );
 
-	it( 'is false for a site that owns commercial use', () => {
+	it( 'stays false for a site that owns commercial use', () => {
 		expect(
 			shouldShowPaywallNotice(
 				{ ...walledState, purchases: { data: [ commercialPurchase ] } },

--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -113,6 +113,13 @@ export const hasSupportedVideoPressUse = ( state: object, siteId: number | null 
 };
 
 export const shouldShowPaywallNotice = ( state: object, siteId: number | null ): boolean => {
+	// `paywall_date_from` is only set for sites carrying the commercial paywall sticker, which
+	// the client ignores. Suppressing it here keeps the upgrade notice on its dismissible
+	// variant instead of escalating to the non-dismissible lockout banner.
+	if ( COMMERCIAL_PAYWALL_KILLED ) {
+		return false;
+	}
+
 	return (
 		! hasSupportedCommercialUse( state, siteId ) && getShouldShowPaywallNotice( state, siteId )
 	);

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -118,7 +118,8 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 	);
 
 	// Show the paywall notice if the site has reached the monthly views limit
-	// and no commercial purchase.
+	// and no commercial purchase. Inert while COMMERCIAL_PAYWALL_KILLED is true (STATS-387),
+	// which keeps the notice on its dismissible upgrade variant.
 	const showPaywallNotice =
 		useSelector( ( state ) => {
 			return shouldShowPaywallNotice( state, siteId );

--- a/client/my-sites/stats/stats-notices/test/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/test/all-notice-definitions.ts
@@ -1,0 +1,62 @@
+import ALL_STATS_NOTICES from '../all-notice-definitions';
+import type { StatsNoticeProps } from '../types';
+
+const commercialSiteUpgradeNotice = ALL_STATS_NOTICES.find(
+	( notice ) => notice.noticeId === 'commercial_site_upgrade'
+);
+
+// A self-hosted Jetpack site flagged commercial, with no purchase supporting commercial use —
+// the population that carried the `jetpack-site-has-commercial-paywall` sticker.
+const walledJetpackSite: StatsNoticeProps = {
+	siteId: 123,
+	isOdysseyStats: false,
+	isSiteJetpackNotAtomic: true,
+	isCommercial: true,
+	isVip: false,
+	hasPaidStats: false,
+	supportCommercialUse: false,
+};
+
+describe( 'commercial_site_upgrade notice visibility', () => {
+	it( 'is registered and enabled', () => {
+		expect( commercialSiteUpgradeNotice ).toBeDefined();
+		expect( commercialSiteUpgradeNotice?.disabled ).toBe( false );
+	} );
+
+	it( 'still shows for a previously walled commercial Jetpack site once the sticker is ignored', () => {
+		expect(
+			commercialSiteUpgradeNotice?.isVisibleFunc( {
+				...walledJetpackSite,
+				showPaywallNotice: false,
+			} )
+		).toBe( true );
+	} );
+
+	it( 'shows for a commercial WPCOM site, which never had the paywall variant', () => {
+		expect(
+			commercialSiteUpgradeNotice?.isVisibleFunc( {
+				siteId: 123,
+				isOdysseyStats: false,
+				isWpcom: true,
+				isCommercial: true,
+				hasPaidStats: false,
+				showPaywallNotice: false,
+			} )
+		).toBe( true );
+	} );
+
+	it( 'stays hidden for non-commercial and VIP sites', () => {
+		expect(
+			commercialSiteUpgradeNotice?.isVisibleFunc( { ...walledJetpackSite, isCommercial: false } )
+		).toBe( false );
+		expect(
+			commercialSiteUpgradeNotice?.isVisibleFunc( { ...walledJetpackSite, isVip: true } )
+		).toBe( false );
+	} );
+
+	it( 'stays hidden once the site has paid stats', () => {
+		expect(
+			commercialSiteUpgradeNotice?.isVisibleFunc( { ...walledJetpackSite, hasPaidStats: true } )
+		).toBe( false );
+	} );
+} );


### PR DESCRIPTION
Part of STATS-387

> [!NOTE]
> Stacked on #113205, which introduces `COMMERCIAL_PAYWALL_KILLED`. Based on that branch, so review this one on its own diff and merge it after.

## Proposed Changes

* Guard `shouldShowPaywallNotice()` in `use-stats-purchases.tsx` with `COMMERCIAL_PAYWALL_KILLED`, the same switch that already fronts the module gate. Guarding the selector rather than the call site means any future consumer inherits the behaviour instead of having to remember the switch exists.
* Add `stats-notices/test/all-notice-definitions.ts` covering the `commercial_site_upgrade` visibility rules, which had none.
* Extend the kill-switch suites from #113205 with the notice selector, on both sides of the switch.

No change to `CommercialSiteUpgradeNotice` itself, no change to any other notice, and no strings added or altered.

## Why are these changes being made?

`CommercialSiteUpgradeNotice` is one component with one registration that renders two ways off a single boolean:

| `showPaywallNotice` | Level | Dismissible | Title |
|---|---|---|---|
| `true` | `error` (red) | ❌ close button hidden | *"You need to upgrade to a commercial license to continue using Jetpack Stats"* + `upgrade_deadline_date` |
| `false` | `info` (blue) | ✅ 30-day postpone | *"Upgrade to Stats Commercial"* |

That boolean resolves to `!! paywall_date_from`, which the API only sets for sites carrying a `jetpack-site-has-commercial-paywall` sticker. Since those stickers are deliberately staying put so the cohort remains observable, the notice has to ignore them the same way the module gate now does — otherwise #113205 leaves an affected site with fully ungated modules while a red banner still says access is about to be cut off.

## What changes, and what doesn't

| Site | Before | After | Changed? |
|---|---|---|---|
| Jetpack self-hosted, commercial, **carrying a sticker** | 🔴 red lockout banner, cannot dismiss | 🔵 blue upgrade banner, dismissible 30d | ✅ **yes** |
| Jetpack self-hosted, commercial, **no sticker** | 🔵 blue upgrade banner | 🔵 blue upgrade banner | no |
| **WPCOM Simple / Atomic**, commercial | 🔵 blue upgrade banner | 🔵 blue upgrade banner | no |
| Any site with a commercial purchase | no banner | no banner | no |
| VIP, P2, Team51-owned | no banner | no banner | no |

The red variant was already limited to self-hosted Jetpack by `isSiteJetpackNotAtomic`, so nothing here can reach WPCOM.

Also unchanged:

| Thing | State |
|---|---|
| Whether the notice appears at all | Still governed by `isCommercial && ! isVip && ! hasPaidStats`, unchanged — the site falls back to the softer variant rather than losing the notice |
| `DoYouLoveJetpackStatsNotice` | Untouched; still blocked by `! isCommercial` |
| Tier upgrade, GDPR, purchase-success notices | Untouched |
| Notice copy | Untouched — no String Freeze implications |

### Why suppress only the escalation, rather than disable the notice

* It is the literal reading of "ignore the sticker" — the site behaves as though it never had one.
* The upgrade path stays visible. Silencing the notice entirely would have removed that entry point for a large population, and `DoYouLoveJetpackStatsNotice` would not fill the gap because it is blocked by `! isCommercial`.
* The blast radius matches the problem. Disabling the registration outright would also have silenced the blue banner on WPCOM commercial sites, which never had the paywall variant and are not part of this issue.

The soft variant's *"you'll need to purchase a commercial license based on your site type"* wording still carries classifier framing. That is a copy question, separable from this change, and better handled alongside the wider documentation alignment.

## Test coverage

| What it pins | Where |
|---|---|
| The selector ignores the sticker | `hooks/test/use-stats-purchases.ts` |
| Flipping the constant back to `false` re-escalates the notice to its lockout variant | `hooks/test/use-stats-purchases-enforced.ts` |
| A previously walled Jetpack site still shows the notice rather than losing it | `stats-notices/test/all-notice-definitions.ts` |
| WPCOM commercial sites still show it | `stats-notices/test/all-notice-definitions.ts` |
| Non-commercial, VIP and already-paid sites stay hidden | `stats-notices/test/all-notice-definitions.ts` |

## Testing Instructions

Automated:

```
yarn test-client client/my-sites/stats
```

Manual, on a self-hosted Jetpack site carrying the sticker with no commercial Stats purchase:

1. Confirm `/wpcom/v2/sites/<id>/jetpack-stats/usage` still returns a non-null `paywall_date_from` — the sticker is intentionally left in place.
2. The Stats page shows the blue, dismissible **"Upgrade to Stats Commercial"** banner instead of the red **"You need to upgrade to a commercial license to continue using Jetpack Stats"** one.
3. The banner has a working close button and stays dismissed on reload.
4. On a commercial WPCOM site with no paid Stats, the same blue banner appears exactly as before.
5. On a site with a commercial Stats purchase, no banner appears.

## Deployment note

As with #113205, the affected sites are self-hosted Jetpack and reach Stats through Odyssey Stats, which ships separately to `widgets.wp.com/odyssey-stats/v1`. Merging alone will not change what those sites see.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
