### PR TITLE
Dashboard: stop guided-tour completion retrying POST /me/preferences forever

### DIFF
--- a/client/dashboard/components/guided-tour/context.tsx
+++ b/client/dashboard/components/guided-tour/context.tsx
@@ -5,7 +5,6 @@ import {
 	useCallback,
 	useMemo,
 	useState,
-	useEffect,
 	useRef,
 	type JSX,
 	type ReactNode,
@@ -26,7 +25,7 @@ type GuidedTourContextType = {
 	isCompleted: boolean;
 	isSkippable?: boolean;
 	startTour: () => void;
-	endTour: () => void;
+	endTour: ( isCompleted: boolean ) => void;
 	previousStep: () => void;
 	nextStep: () => void;
 };
@@ -80,14 +79,17 @@ export const GuidedTourContextProvider = ( {
 		}
 	}, [ isStartedRef, tourId, recordTracksEvent ] );
 
-	const endTour = useCallback( () => {
-		// Save the dismissed timestamp so we can show the new steps that are added after it in the future.
-		updateCompletedTimestamp( new Date().toISOString() );
-		recordTracksEvent( 'calypso_dashboard_end_tour', {
-			tour_id: tourId,
-			is_completed: currentStep === guidedTours.length,
-		} );
-	}, [ tourId, updateCompletedTimestamp, recordTracksEvent, currentStep, guidedTours.length ] );
+	const endTour = useCallback(
+		( isCompleted: boolean ) => {
+			// Save the dismissed timestamp so we can show the new steps that are added after it in the future.
+			updateCompletedTimestamp( new Date().toISOString() );
+			recordTracksEvent( 'calypso_dashboard_end_tour', {
+				tour_id: tourId,
+				is_completed: isCompleted,
+			} );
+		},
+		[ tourId, updateCompletedTimestamp, recordTracksEvent ]
+	);
 
 	const previousStep = useCallback( () => {
 		setCurrentStep( ( step ) => {
@@ -102,18 +104,18 @@ export const GuidedTourContextProvider = ( {
 	}, [ tourId, recordTracksEvent ] );
 
 	const nextStep = useCallback( () => {
-		setCurrentStep( ( step ) => {
-			const nextStep = step + 1;
-			if ( nextStep < guidedTours.length ) {
-				recordTracksEvent( 'calypso_dashboard_tour_next_step', {
-					tour_id: tourId,
-					to: nextStep,
-				} );
-			}
-
-			return nextStep;
-		} );
-	}, [ tourId, guidedTours.length, recordTracksEvent ] );
+		const next = currentStep + 1;
+		if ( next < guidedTours.length ) {
+			recordTracksEvent( 'calypso_dashboard_tour_next_step', {
+				tour_id: tourId,
+				to: next,
+			} );
+			setCurrentStep( next );
+		} else {
+			// Advancing past the last step is the completion event.
+			endTour( true );
+		}
+	}, [ currentStep, guidedTours.length, recordTracksEvent, tourId, endTour ] );
 
 	const value = useMemo(
 		() => ( {
@@ -138,12 +140,6 @@ export const GuidedTourContextProvider = ( {
 			nextStep,
 		]
 	);
-
-	useEffect( () => {
-		if ( currentStep === guidedTours.length && ! isCompleted ) {
-			endTour();
-		}
-	}, [ currentStep, guidedTours, isCompleted, endTour ] );
 
 	if ( isLoading || isCompleted ) {
 		return null;

--- a/client/dashboard/components/guided-tour/step/index.tsx
+++ b/client/dashboard/components/guided-tour/step/index.tsx
@@ -120,7 +120,12 @@ export function GuidedTourStep( {
 						<HStack justify="space-between">
 							<SectionHeader title={ currentTour.title } level={ 3 } />
 							{ totalSteps > 1 && currentStep + 1 < totalSteps && isSkippable && (
-								<Button icon={ closeSmall } iconSize={ 24 } onClick={ () => endTour( false ) } />
+								<Button
+									icon={ closeSmall }
+									iconSize={ 24 }
+									label={ __( 'Close tour' ) }
+									onClick={ () => endTour( false ) }
+								/>
 							) }
 						</HStack>
 						<Text as="p" lineHeight="20px">

--- a/client/dashboard/components/guided-tour/step/index.tsx
+++ b/client/dashboard/components/guided-tour/step/index.tsx
@@ -120,7 +120,7 @@ export function GuidedTourStep( {
 						<HStack justify="space-between">
 							<SectionHeader title={ currentTour.title } level={ 3 } />
 							{ totalSteps > 1 && currentStep + 1 < totalSteps && isSkippable && (
-								<Button icon={ closeSmall } iconSize={ 24 } onClick={ endTour } />
+								<Button icon={ closeSmall } iconSize={ 24 } onClick={ () => endTour( false ) } />
 							) }
 						</HStack>
 						<Text as="p" lineHeight="20px">

--- a/client/dashboard/components/guided-tour/test/context.test.tsx
+++ b/client/dashboard/components/guided-tour/test/context.test.tsx
@@ -11,8 +11,8 @@ import type { TourStep } from '../context';
 
 const TOUR_ID = 'hosting-dashboard-tours-sites' as const;
 
-// Let any re-triggered completion write fire. On the buggy code the write is
-// re-armed on each failed attempt, so this real-time wait exposes the loop.
+// Give pending effects (and any network writes they trigger) time to run, so a
+// tour that wrongly retried its completion write would make extra requests here.
 function settle() {
 	return act( async () => {
 		await new Promise( ( resolve ) => setTimeout( resolve, 100 ) );
@@ -26,8 +26,8 @@ function mockPreferencesRead() {
 		.reply( 200, { calypso_preferences: {} } );
 }
 
-// The completion write always fails. Before the fix, the effect that fired it
-// re-armed on the failed write and retried forever.
+// The completion write always fails (e.g. rate-limited). A persistent failure
+// must not cause the write to be retried in a loop.
 function mockFailingPreferencesWrite() {
 	const counter = { count: 0 };
 	nock( 'https://public-api.wordpress.com' )
@@ -75,9 +75,10 @@ function renderTour( tours: TourStep[], { isSkippable }: { isSkippable?: boolean
 
 describe( '<GuidedTourContextProvider>', () => {
 	afterEach( () => {
+		// The shared query client is a module singleton; clear it so a completed tour
+		// cached by one test doesn't suppress the tour in the next. (nock cleanup and
+		// DOM teardown are handled by the standard test setup.)
 		queryClient.clear();
-		nock.cleanAll();
-		document.body.innerHTML = '';
 	} );
 
 	test( 'completing a one-step tour writes once when the write succeeds', async () => {
@@ -115,7 +116,7 @@ describe( '<GuidedTourContextProvider>', () => {
 		await waitFor( () => expect( write.count ).toBe( 1 ) );
 		await settle();
 
-		// Before the fix this climbed without bound as the effect re-fired.
+		// A persistently failing write must be attempted once, never retried in a loop.
 		expect( write.count ).toBe( 1 );
 		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_dashboard_end_tour', {
 			tour_id: TOUR_ID,

--- a/client/dashboard/components/guided-tour/test/context.test.tsx
+++ b/client/dashboard/components/guided-tour/test/context.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * @jest-environment jsdom
+ */
+import { queryClient } from '@automattic/api-queries';
+import { act, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import { GuidedTourContextProvider, GuidedTourStep } from '../index';
+import type { TourStep } from '../context';
+
+const TOUR_ID = 'hosting-dashboard-tours-sites' as const;
+
+// Flush pending microtasks/effects so a hypothetical re-triggered write would fire.
+function flush() {
+	return act( async () => {} );
+}
+
+function mockPreferencesRead() {
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( '/rest/v1.1/me/preferences' )
+		.reply( 200, { calypso_preferences: {} } );
+}
+
+// The completion write always fails. Before the fix, the effect that fired it
+// re-armed on the failed write and retried forever.
+function mockFailingPreferencesWrite() {
+	const counter = { count: 0 };
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.post( '/rest/v1.1/me/preferences' )
+		.reply( () => {
+			counter.count += 1;
+			return [ 405, { error: 'not_allowed' } ];
+		} );
+	return counter;
+}
+
+function renderTour( tours: TourStep[], { isSkippable }: { isSkippable?: boolean } = {} ) {
+	// A real element so the step's anchor resolves synchronously (no selector poll).
+	const target = document.createElement( 'div' );
+	document.body.appendChild( target );
+
+	return render(
+		<GuidedTourContextProvider tourId={ TOUR_ID } guidedTours={ tours } isSkippable={ isSkippable }>
+			{ tours.map( ( tour ) => (
+				<GuidedTourStep key={ tour.id } id={ tour.id } target={ target } inline />
+			) ) }
+		</GuidedTourContextProvider>
+	);
+}
+
+describe( '<GuidedTourContextProvider>', () => {
+	afterEach( () => {
+		queryClient.clear();
+		nock.cleanAll();
+		document.body.innerHTML = '';
+	} );
+
+	test( 'completing a one-step tour writes exactly once when the write keeps failing', async () => {
+		mockPreferencesRead();
+		const write = mockFailingPreferencesWrite();
+
+		const { recordTracksEvent } = renderTour( [
+			{ id: 'step-1', title: 'Step 1', description: 'First' },
+		] );
+
+		const gotIt = await screen.findByRole( 'button', { name: 'Got it' } );
+		await userEvent.click( gotIt );
+
+		await waitFor( () => expect( write.count ).toBe( 1 ) );
+		await flush();
+
+		// Before the fix this climbed without bound as the effect re-fired.
+		expect( write.count ).toBe( 1 );
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_dashboard_end_tour', {
+			tour_id: TOUR_ID,
+			is_completed: true,
+		} );
+	} );
+
+	test( 'finishing a multi-step tour writes exactly once when the write keeps failing', async () => {
+		mockPreferencesRead();
+		const write = mockFailingPreferencesWrite();
+
+		const { recordTracksEvent } = renderTour( [
+			{ id: 'step-1', title: 'Step 1', description: 'First' },
+			{ id: 'step-2', title: 'Step 2', description: 'Second' },
+		] );
+
+		await userEvent.click( await screen.findByRole( 'button', { name: 'Next' } ) );
+		await userEvent.click( await screen.findByRole( 'button', { name: 'Finish' } ) );
+
+		await waitFor( () => expect( write.count ).toBe( 1 ) );
+		await flush();
+
+		expect( write.count ).toBe( 1 );
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_dashboard_end_tour', {
+			tour_id: TOUR_ID,
+			is_completed: true,
+		} );
+	} );
+
+	test( 'skipping a tour records is_completed:false and writes exactly once', async () => {
+		mockPreferencesRead();
+		const write = mockFailingPreferencesWrite();
+
+		const { recordTracksEvent } = renderTour(
+			[
+				{ id: 'step-1', title: 'Step 1', description: 'First' },
+				{ id: 'step-2', title: 'Step 2', description: 'Second' },
+			],
+			{ isSkippable: true }
+		);
+
+		// The skip (X) button has no accessible name; it's the only button besides Next/Previous.
+		await screen.findByRole( 'button', { name: 'Next' } );
+		const skip = screen.getAllByRole( 'button' ).find( ( button ) => ! button.textContent?.trim() );
+		await userEvent.click( skip! );
+
+		await waitFor( () => expect( write.count ).toBe( 1 ) );
+		await flush();
+
+		expect( write.count ).toBe( 1 );
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_dashboard_end_tour', {
+			tour_id: TOUR_ID,
+			is_completed: false,
+		} );
+	} );
+} );

--- a/client/dashboard/components/guided-tour/test/context.test.tsx
+++ b/client/dashboard/components/guided-tour/test/context.test.tsx
@@ -11,9 +11,12 @@ import type { TourStep } from '../context';
 
 const TOUR_ID = 'hosting-dashboard-tours-sites' as const;
 
-// Flush pending microtasks/effects so a hypothetical re-triggered write would fire.
-function flush() {
-	return act( async () => {} );
+// Let any re-triggered completion write fire. On the buggy code the write is
+// re-armed on each failed attempt, so this real-time wait exposes the loop.
+function settle() {
+	return act( async () => {
+		await new Promise( ( resolve ) => setTimeout( resolve, 100 ) );
+	} );
 }
 
 function mockPreferencesRead() {
@@ -37,17 +40,36 @@ function mockFailingPreferencesWrite() {
 	return counter;
 }
 
+// The completion write succeeds and persists the timestamp — the happy path.
+function mockSucceedingPreferencesWrite() {
+	const counter = { count: 0 };
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.post( '/rest/v1.1/me/preferences' )
+		.reply( ( _uri, body ) => {
+			counter.count += 1;
+			return [
+				200,
+				{ calypso_preferences: ( body as { calypso_preferences: unknown } ).calypso_preferences },
+			];
+		} );
+	return counter;
+}
+
 function renderTour( tours: TourStep[], { isSkippable }: { isSkippable?: boolean } = {} ) {
 	// A real element so the step's anchor resolves synchronously (no selector poll).
 	const target = document.createElement( 'div' );
 	document.body.appendChild( target );
 
+	// Use the shared query client so the mutation's `onSuccess` cache write and the
+	// component's `useQuery` read are the same client, as in production.
 	return render(
 		<GuidedTourContextProvider tourId={ TOUR_ID } guidedTours={ tours } isSkippable={ isSkippable }>
 			{ tours.map( ( tour ) => (
 				<GuidedTourStep key={ tour.id } id={ tour.id } target={ target } inline />
 			) ) }
-		</GuidedTourContextProvider>
+		</GuidedTourContextProvider>,
+		{ queryClient }
 	);
 }
 
@@ -58,6 +80,28 @@ describe( '<GuidedTourContextProvider>', () => {
 		document.body.innerHTML = '';
 	} );
 
+	test( 'completing a one-step tour writes once when the write succeeds', async () => {
+		mockPreferencesRead();
+		const write = mockSucceedingPreferencesWrite();
+
+		const { recordTracksEvent } = renderTour( [
+			{ id: 'step-1', title: 'Step 1', description: 'First' },
+		] );
+
+		await userEvent.click( await screen.findByRole( 'button', { name: 'Got it' } ) );
+
+		await waitFor( () => expect( write.count ).toBe( 1 ) );
+		await settle();
+
+		expect( write.count ).toBe( 1 );
+		// The persisted timestamp completes the tour, so the step is gone.
+		expect( screen.queryByRole( 'button', { name: 'Got it' } ) ).not.toBeInTheDocument();
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_dashboard_end_tour', {
+			tour_id: TOUR_ID,
+			is_completed: true,
+		} );
+	} );
+
 	test( 'completing a one-step tour writes exactly once when the write keeps failing', async () => {
 		mockPreferencesRead();
 		const write = mockFailingPreferencesWrite();
@@ -66,11 +110,10 @@ describe( '<GuidedTourContextProvider>', () => {
 			{ id: 'step-1', title: 'Step 1', description: 'First' },
 		] );
 
-		const gotIt = await screen.findByRole( 'button', { name: 'Got it' } );
-		await userEvent.click( gotIt );
+		await userEvent.click( await screen.findByRole( 'button', { name: 'Got it' } ) );
 
 		await waitFor( () => expect( write.count ).toBe( 1 ) );
-		await flush();
+		await settle();
 
 		// Before the fix this climbed without bound as the effect re-fired.
 		expect( write.count ).toBe( 1 );
@@ -93,7 +136,7 @@ describe( '<GuidedTourContextProvider>', () => {
 		await userEvent.click( await screen.findByRole( 'button', { name: 'Finish' } ) );
 
 		await waitFor( () => expect( write.count ).toBe( 1 ) );
-		await flush();
+		await settle();
 
 		expect( write.count ).toBe( 1 );
 		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_dashboard_end_tour', {
@@ -120,7 +163,7 @@ describe( '<GuidedTourContextProvider>', () => {
 		await userEvent.click( skip! );
 
 		await waitFor( () => expect( write.count ).toBe( 1 ) );
-		await flush();
+		await settle();
 
 		expect( write.count ).toBe( 1 );
 		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_dashboard_end_tour', {

--- a/client/dashboard/components/guided-tour/test/context.test.tsx
+++ b/client/dashboard/components/guided-tour/test/context.test.tsx
@@ -158,10 +158,7 @@ describe( '<GuidedTourContextProvider>', () => {
 			{ isSkippable: true }
 		);
 
-		// The skip (X) button has no accessible name; it's the only button besides Next/Previous.
-		await screen.findByRole( 'button', { name: 'Next' } );
-		const skip = screen.getAllByRole( 'button' ).find( ( button ) => ! button.textContent?.trim() );
-		await userEvent.click( skip! );
+		await userEvent.click( await screen.findByRole( 'button', { name: 'Close tour' } ) );
 
 		await waitFor( () => expect( write.count ).toBe( 1 ) );
 		await settle();


### PR DESCRIPTION
## Proposed Changes

* Drive guided-tour completion from the event that ends the tour (advancing past the last step, or the skip button) instead of a `useEffect`.
* Make `endTour( isCompleted )` take an explicit flag rather than deriving `is_completed` from `currentStep === guidedTours.length` internally.
* Add a regression test that fails without this change: a persistently-failing completion write is retried forever.
* Give the tour's close (X) button an accessible name (new string `Close tour`) — it was icon-only with no label, so screen readers announced only "button".

## Why are these changes being made?

Completing a tour calls `endTour()` → `updateCompletedTimestamp()` → `userPreferenceMutation( tourId )` → `POST /me/preferences`. That write was fired from an effect:

```ts
useEffect( () => {
  if ( currentStep === guidedTours.length && ! isCompleted ) {
    endTour();
  }
}, [ currentStep, guidedTours, isCompleted, endTour ] );
```

`isCompleted = isDismissing || !! completedISODate`. On a **persistent write failure** the loop is:

1. Reach the last step; effect fires `endTour()`.
2. In flight, `isDismissing` (isPending) is true → `isCompleted` true → effect quiet.
3. Write fails: `isDismissing` → false and `completedISODate` stays `undefined` (no `onSuccess`) → `isCompleted` flips back to **false**.
4. `currentStep === guidedTours.length` still holds and `isCompleted` is a dep → effect re-runs → `endTour()` again → fails → loop, at network speed.

Each iteration is one failed mutation (bumping the `user-pref-update.tours` mutation-error stat) plus one `calypso_dashboard_end_tour` Tracks event. Telemetry showed individual users emitting thousands of `calypso_dashboard_end_tour` events for `hosting-dashboard-tours-sites` in minutes, with flat `start_tour`/`next_step` — i.e. a loop, not real usage. See p1785707689432259-slack-CRWCHQGUB.

This is the ["you might not need an effect"](https://react.dev/learn/you-might-not-need-an-effect) antipattern: completing the tour is an **event**, not something to derive reactively from state. The effect reacts to a value (`isCompleted`) that its own side effect mutates.

## The fix

Completion now fires from `nextStep()` when the advance crosses the end, and from the skip (X) button. The completion effect is deleted, so there is no feedback edge to loop on. A failed completion write no longer re-arms anything; the user can retry by clicking Finish again (one write per click — bounded).

Same bug class and fix philosophy as #112821 ("Dashboard: stop retrying recent-sites write in an infinite loop"), which likewise removed a reactive effect that re-ran on a value its own side effect mutated, rather than papering over it with a fire-once ref.

Behavior preserved: `Got it`/`Finish` complete with `is_completed: true`; skip completes with `is_completed: false`; intermediate `Next` still records `calypso_dashboard_tour_next_step`; `start_tour` is unchanged.

## Testing Instructions

Automated:

```
yarn test-client client/dashboard/components/guided-tour
```

The one-step-completion test makes `POST /me/preferences` return 405 persistently and asserts the write is attempted exactly once. Before this change it climbs without bound.

Manual:

1. Open the dashboard and trigger a guided tour (e.g. the sites tour).
2. In DevTools, force `POST **/me/preferences**` to fail (status 405).
3. Complete the tour (Finish / Got it).
4. Before: `POST /me/preferences` fires on an unbroken loop. After: it fires once and stops.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [x] Have you tested accessibility for your changes? The close (X) button now has an accessible name (`Close tour`); verified via the skip test querying it by role/name.
- [ ] Have you used memoizing on expensive computations?
- [-] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation? Adds one string: `Close tour`. But no string freeze because this is an important bug fix.
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?
