### PR TITLE
SFTP: Keep reset password action available

### DIFF
--- a/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
@@ -5,7 +5,6 @@ import {
 	__experimentalVStack as VStack,
 	BaseControl,
 	Button,
-	Tooltip,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
@@ -167,14 +166,22 @@ export default function SftpCard( {
 		return () => window.clearTimeout( timeoutId );
 	}, [ isResetPasswordRateLimited ] );
 
+	const resetPasswordLabel = __( 'Reset password' );
+	const resetPasswordDescription = isResetPasswordRateLimited
+		? __( 'You reset the password recently. Please wait a minute and try again.' )
+		: undefined;
 	const resetPasswordButton = (
 		<Button
 			variant="secondary"
 			isBusy={ mutation.isPending }
 			disabled={ mutation.isPending || isResetPasswordRateLimited }
+			accessibleWhenDisabled
+			label={ resetPasswordLabel }
+			description={ resetPasswordDescription }
+			showTooltip={ isResetPasswordRateLimited }
 			onClick={ () => setShowResetPasswordConfirmDialog( true ) }
 		>
-			{ __( 'Reset password' ) }
+			{ resetPasswordLabel }
 		</Button>
 	);
 
@@ -200,20 +207,7 @@ export default function SftpCard( {
 						form={ form }
 						onChange={ noop }
 					/>
-					<ButtonStack justify="flex-start">
-						{ isResetPasswordRateLimited ? (
-							<Tooltip
-								text={ __(
-									'You reset the password recently. Please wait a minute and try again.'
-								) }
-								placement="top"
-							>
-								<div>{ resetPasswordButton }</div>
-							</Tooltip>
-						) : (
-							resetPasswordButton
-						) }
-					</ButtonStack>
+					<ButtonStack justify="flex-start">{ resetPasswordButton }</ButtonStack>
 				</VStack>
 			</CardBody>
 			<ConfirmDialog

--- a/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
@@ -5,13 +5,14 @@ import {
 	__experimentalVStack as VStack,
 	BaseControl,
 	Button,
+	Tooltip,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import ClipboardInputControl from '../../components/clipboard-input-control';
@@ -23,6 +24,8 @@ import type { DataFormControlProps, Field } from '@wordpress/dataviews';
 const SFTP_URL = 'sftp.wp.com';
 
 const SFTP_PORT = '22';
+
+const RESET_PASSWORD_RATE_LIMIT_MILLISECONDS = 60 * 1000;
 
 const noop = () => {};
 
@@ -44,6 +47,7 @@ export default function SftpCard( {
 	const mutation = useMutation( siteSftpUsersResetPasswordMutation( siteId ) );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const [ showResetPasswordConfirmDialog, setShowResetPasswordConfirmDialog ] = useState( false );
+	const [ isResetPasswordRateLimited, setIsResetPasswordRateLimited ] = useState( false );
 	const formData = {
 		url: SFTP_URL,
 		port: SFTP_PORT,
@@ -132,8 +136,10 @@ export default function SftpCard( {
 	};
 
 	const handleConfirmResetPassword = () => {
+		setIsResetPasswordRateLimited( true );
 		mutation.mutate( username, {
 			onError: () => {
+				setIsResetPasswordRateLimited( false );
 				createErrorNotice(
 					__(
 						'Sorry, we had a problem retrieving your SFTP user details. Please refresh the page and try again.'
@@ -147,6 +153,30 @@ export default function SftpCard( {
 
 		setShowResetPasswordConfirmDialog( false );
 	};
+
+	useEffect( () => {
+		if ( ! isResetPasswordRateLimited ) {
+			return;
+		}
+
+		const timeoutId = window.setTimeout(
+			() => setIsResetPasswordRateLimited( false ),
+			RESET_PASSWORD_RATE_LIMIT_MILLISECONDS
+		);
+
+		return () => window.clearTimeout( timeoutId );
+	}, [ isResetPasswordRateLimited ] );
+
+	const resetPasswordButton = (
+		<Button
+			variant="secondary"
+			isBusy={ mutation.isPending }
+			disabled={ mutation.isPending || isResetPasswordRateLimited }
+			onClick={ () => setShowResetPasswordConfirmDialog( true ) }
+		>
+			{ __( 'Reset password' ) }
+		</Button>
+	);
 
 	return (
 		<Card>
@@ -170,17 +200,20 @@ export default function SftpCard( {
 						form={ form }
 						onChange={ noop }
 					/>
-					{ ! password && (
-						<ButtonStack justify="flex-start">
-							<Button
-								variant="secondary"
-								isBusy={ mutation.isPending }
-								onClick={ () => setShowResetPasswordConfirmDialog( true ) }
+					<ButtonStack justify="flex-start">
+						{ isResetPasswordRateLimited ? (
+							<Tooltip
+								text={ __(
+									'You reset the password recently. Please wait a minute and try again.'
+								) }
+								placement="top"
 							>
-								{ __( 'Reset password' ) }
-							</Button>
-						</ButtonStack>
-					) }
+								<div>{ resetPasswordButton }</div>
+							</Tooltip>
+						) : (
+							resetPasswordButton
+						) }
+					</ButtonStack>
 				</VStack>
 			</CardBody>
 			<ConfirmDialog

--- a/client/dashboard/sites/settings-sftp-ssh/test/sftp-card.test.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/test/sftp-card.test.tsx
@@ -36,10 +36,13 @@ describe( '<SftpCard>', () => {
 
 		await waitFor( () => expect( resetRequest.isDone() ).toBe( true ) );
 
-		const resetButton = screen.getByRole( 'button', { name: 'Reset password' } );
-		expect( resetButton ).toBeDisabled();
+		const resetButton = screen.getByRole( 'button', {
+			name: 'Reset password',
+			description: 'You reset the password recently. Please wait a minute and try again.',
+		} );
+		expect( resetButton ).toHaveAttribute( 'aria-disabled', 'true' );
 
-		await user.hover( resetButton.parentElement as HTMLElement );
+		await user.hover( resetButton );
 		expect( await screen.findByRole( 'tooltip' ) ).toHaveTextContent(
 			'You reset the password recently. Please wait a minute and try again.'
 		);

--- a/client/dashboard/sites/settings-sftp-ssh/test/sftp-card.test.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/test/sftp-card.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import SftpCard from '../sftp-card';
+
+const siteId = 123;
+const username = 'example.wordpress.com';
+
+describe( '<SftpCard>', () => {
+	test( 'keeps the reset password button visible while the password is displayed', async () => {
+		render( <SftpCard siteId={ siteId } sftpUsers={ [ { username, password: 'secret' } ] } /> );
+
+		await screen.findByText( 'Learn more' );
+		expect( screen.getByRole( 'button', { name: 'Reset password' } ) ).toBeVisible();
+	} );
+
+	test( 'temporarily disables the reset password button after confirming a reset', async () => {
+		const user = userEvent.setup();
+		const resetRequest = nock( 'https://public-api.wordpress.com' )
+			.post( `/wpcom/v2/sites/${ siteId }/hosting/ssh-user/${ username }/reset-password` )
+			.reply( 200, JSON.stringify( { username, password: 'new-secret' } ), {
+				'Content-Type': 'application/json',
+			} );
+
+		render( <SftpCard siteId={ siteId } sftpUsers={ [ { username, password: '' } ] } /> );
+
+		await screen.findByText( 'Learn more' );
+		await user.click( screen.getByRole( 'button', { name: 'Reset password' } ) );
+		const dialog = await screen.findByRole( 'dialog' );
+		await user.click( within( dialog ).getByRole( 'button', { name: 'Reset password' } ) );
+
+		await waitFor( () => expect( resetRequest.isDone() ).toBe( true ) );
+
+		const resetButton = screen.getByRole( 'button', { name: 'Reset password' } );
+		expect( resetButton ).toBeDisabled();
+
+		await user.hover( resetButton.parentElement as HTMLElement );
+		expect( await screen.findByRole( 'tooltip' ) ).toHaveTextContent(
+			'You reset the password recently. Please wait a minute and try again.'
+		);
+	} );
+} );


### PR DESCRIPTION
Fixes #98805

## Proposed Changes

* Keep the **Reset password** button visible while the newly reset password is displayed.
* Disable the button for one minute after a reset is confirmed and explain the temporary lockout in a tooltip.
* Remove the temporary lockout if the password reset request fails.
* Add focused tests for the visible and rate-limited button states.

## Why are these changes being made?

The reset action was rendered only when no password was available. A successful reset populated the password field, which removed the action until the page was refreshed.

Keeping the action visible avoids that dead end. The temporary disabled state reflects the existing one-minute reset limit while explaining when the action can be used again.

## Screenshots

The **Reset password** button is temporarily disabled after a successful reset. Hovering over it explains the one-minute cooldown.

<img width="880" height="700" alt="SFTP reset password cooldown tooltip" src="https://github.com/user-attachments/assets/382909c4-8949-4012-90f3-9e293ddbabf9" />

## Testing Instructions

* Run `yarn test-client client/dashboard/sites/settings-sftp-ssh/test/sftp-card.test.tsx --runInBand`.
* Run `yarn eslint client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx client/dashboard/sites/settings-sftp-ssh/test/sftp-card.test.tsx`.
* Run `yarn prettier --check client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx client/dashboard/sites/settings-sftp-ssh/test/sftp-card.test.tsx`.
* Run `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
