### PR TITLE
Stats: fix Views/Visitors chart contrast to meet WCAG 1.4.11

### DIFF
--- a/apps/odyssey-stats/src/widget/mini-chart.scss
+++ b/apps/odyssey-stats/src/widget/mini-chart.scss
@@ -1,7 +1,5 @@
 @import "@automattic/typography/styles/variables";
 
-$barDarkColor: var(--color-primary-60);
-
 .stats-widget-minichart {
 	border-bottom: 1px solid #c3c4c7;
 
@@ -17,7 +15,7 @@ $barDarkColor: var(--color-primary-60);
 			&,
 			&:hover {
 				.chart__bar-section {
-					background-color: var(--studio-blue-0);
+					background-color: var(--color-accent-0);
 				}
 			}
 		}
@@ -56,10 +54,6 @@ $barDarkColor: var(--color-primary-60);
 			height: 14px;
 			vertical-align: middle;
 			margin-top: -3px;
-
-			&.is-secondary {
-				background-color: $barDarkColor;
-			}
 		}
 	}
 
@@ -89,10 +83,6 @@ $barDarkColor: var(--color-primary-60);
 			color: var(--color-neutral-60);
 			white-space: nowrap;
 		}
-	}
-
-	.chart__bar-section-inner {
-		background-color: $barDarkColor;
 	}
 
 	.stats__empty-state {

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -11,6 +11,7 @@ $year-bar-chart-border-radius: 4px;
 :root {
 	--chart-series-views: var(--color-accent-40);
 	--chart-series-visitors: var(--color-accent-90);
+	--chart-line-visitors: var(--color-accent-dark);
 }
 
 .color-scheme.is-classic-bright,
@@ -60,6 +61,33 @@ $year-bar-chart-border-radius: 4px;
 .color-scheme.is-contrast {
 	--chart-series-views: var(--color-accent-50);
 	--chart-series-visitors: var(--color-accent-100);
+}
+
+.color-scheme.is-aquatic,
+.color-scheme.is-blue,
+.color-scheme.is-classic-blue,
+.color-scheme.is-coffee,
+.color-scheme.is-contrast,
+.color-scheme.is-default,
+.color-scheme.is-ectoplasm,
+.color-scheme.is-fresh,
+.color-scheme.is-jetpack-cloud,
+.color-scheme.is-light,
+.color-scheme.is-nightfall,
+.color-scheme.is-ocean,
+.color-scheme.is-powder-snow,
+.color-scheme.is-sakura,
+.color-scheme.is-sunrise,
+.color-scheme.is-sunset {
+	--chart-line-visitors: var(--color-accent-dark);
+}
+
+.color-scheme.is-classic-bright,
+.color-scheme.is-classic-dark,
+.color-scheme.is-global,
+.color-scheme.is-midnight,
+.color-scheme.is-modern {
+	--chart-line-visitors: var(--color-accent-80);
 }
 
 // Chart

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -11,50 +11,35 @@ $year-bar-chart-border-radius: 4px;
 :root {
 	--chart-series-views: var(--color-accent-40);
 	--chart-series-visitors: var(--color-accent-90);
-	--chart-line-visitors: var(--color-accent-dark);
+}
+
+.color-scheme.is-aquatic,
+.color-scheme.is-blue,
+.color-scheme.is-classic-blue,
+.color-scheme.is-coffee,
+.color-scheme.is-fresh,
+.color-scheme.is-light,
+.color-scheme.is-nightfall,
+.color-scheme.is-ocean,
+.color-scheme.is-powder-snow,
+.color-scheme.is-sakura,
+.color-scheme.is-sunrise,
+.color-scheme.is-sunset {
+	--chart-series-views: var(--color-accent-40);
+	--chart-series-visitors: var(--color-accent-80);
 }
 
 .color-scheme.is-classic-bright,
 .color-scheme.is-classic-dark,
-.color-scheme.is-default,
 .color-scheme.is-global,
+.color-scheme.is-midnight,
 .color-scheme.is-modern {
-	--chart-series-views: var(--color-accent-40);
-	--chart-series-visitors: var(--color-accent-90);
-}
-
-.color-scheme.is-coffee,
-.color-scheme.is-light,
-.color-scheme.is-ocean,
-.color-scheme.is-sunrise {
-	--chart-series-views: var(--color-accent);
-	--chart-series-visitors: var(--color-accent-dark);
-}
-
-.color-scheme.is-ectoplasm {
-	--chart-series-views: var(--color-accent);
+	--chart-series-views: var(--color-accent-30);
 	--chart-series-visitors: var(--color-accent-80);
 }
 
-.color-scheme.is-aquatic,
-.color-scheme.is-classic-blue,
-.color-scheme.is-fresh,
-.color-scheme.is-midnight,
-.color-scheme.is-nightfall,
-.color-scheme.is-powder-snow,
-.color-scheme.is-sakura,
-.color-scheme.is-sunset {
-	--chart-series-views: var(--color-accent);
-	--chart-series-visitors: var(--color-accent-90);
-}
-
-.color-scheme.is-jetpack-cloud {
-	--chart-series-views: var(--color-accent);
-	--chart-series-visitors: var(--color-accent-50);
-}
-
-.color-scheme.is-blue {
-	--chart-series-views: var(--color-accent-50);
+.color-scheme.is-default {
+	--chart-series-views: var(--color-accent-40);
 	--chart-series-visitors: var(--color-accent-90);
 }
 
@@ -63,31 +48,14 @@ $year-bar-chart-border-radius: 4px;
 	--chart-series-visitors: var(--color-accent-100);
 }
 
-.color-scheme.is-aquatic,
-.color-scheme.is-blue,
-.color-scheme.is-classic-blue,
-.color-scheme.is-coffee,
-.color-scheme.is-contrast,
-.color-scheme.is-default,
-.color-scheme.is-ectoplasm,
-.color-scheme.is-fresh,
-.color-scheme.is-jetpack-cloud,
-.color-scheme.is-light,
-.color-scheme.is-nightfall,
-.color-scheme.is-ocean,
-.color-scheme.is-powder-snow,
-.color-scheme.is-sakura,
-.color-scheme.is-sunrise,
-.color-scheme.is-sunset {
-	--chart-line-visitors: var(--color-accent-dark);
+.color-scheme.is-ectoplasm {
+	--chart-series-views: var(--color-accent-50);
+	--chart-series-visitors: var(--color-accent-90);
 }
 
-.color-scheme.is-classic-bright,
-.color-scheme.is-classic-dark,
-.color-scheme.is-global,
-.color-scheme.is-midnight,
-.color-scheme.is-modern {
-	--chart-line-visitors: var(--color-accent-80);
+.color-scheme.is-jetpack-cloud {
+	--chart-series-views: var(--color-accent-30);
+	--chart-series-visitors: var(--color-accent-70);
 }
 
 // Chart

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -203,7 +203,7 @@ $y-axis-padding: 0 20px;
 
 .chart__bar-section {
 	display: inline-block;
-	background-color: var(--color-accent);
+	background-color: var(--color-accent-50);
 	position: absolute;
 	right: 16%; // 1
 	bottom: 0; // 1
@@ -218,7 +218,7 @@ $y-axis-padding: 0 20px;
 }
 
 .chart__bar-section-inner {
-	background-color: var(--color-accent-dark);
+	background-color: var(--color-accent-100);
 	position: absolute;
 	right: 23.33%;
 	bottom: 0;
@@ -286,14 +286,14 @@ $y-axis-padding: 0 20px;
 	.chart__legend-color {
 		width: 20px;
 		height: 20px;
-		background: var(--color-accent);
+		background: var(--color-accent-50);
 		display: inline-block;
 		border-radius: 4px;
 		vertical-align: top;
 		margin: 0 8px 0 0;
 
 		&.is-secondary {
-			background: var(--color-accent-dark);
+			background: var(--color-accent-100);
 		}
 	}
 

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -8,6 +8,52 @@
 $bar-chart-border-radius: 2px;
 $year-bar-chart-border-radius: 4px;
 
+// Chart series colours
+// Per-scheme pairs chosen so Views and Visitors each clear 3:1 against the
+// surface and against each other (WCAG 2.1 SC 1.4.11), without pushing
+// Visitors to near-black on schemes with widely spaced accent ramps.
+
+:root {
+	--chart-series-views: var(--color-accent-40);
+	--chart-series-visitors: var(--color-accent-90);
+}
+
+.color-scheme.is-aquatic,
+.color-scheme.is-blue,
+.color-scheme.is-classic-blue,
+.color-scheme.is-coffee,
+.color-scheme.is-contrast,
+.color-scheme.is-fresh,
+.color-scheme.is-light,
+.color-scheme.is-nightfall,
+.color-scheme.is-ocean,
+.color-scheme.is-powder-snow,
+.color-scheme.is-sakura,
+.color-scheme.is-sunrise,
+.color-scheme.is-sunset {
+	--chart-series-views: var(--color-accent-40);
+	--chart-series-visitors: var(--color-accent-80);
+}
+
+.color-scheme.is-classic-bright,
+.color-scheme.is-classic-dark,
+.color-scheme.is-global,
+.color-scheme.is-midnight,
+.color-scheme.is-modern {
+	--chart-series-views: var(--color-accent-30);
+	--chart-series-visitors: var(--color-accent-80);
+}
+
+.color-scheme.is-ectoplasm {
+	--chart-series-views: var(--color-accent-50);
+	--chart-series-visitors: var(--color-accent-90);
+}
+
+.color-scheme.is-jetpack-cloud {
+	--chart-series-views: var(--color-accent-30);
+	--chart-series-visitors: var(--color-accent-70);
+}
+
 // Chart
 // Life is a statistical anomaly
 
@@ -203,7 +249,7 @@ $y-axis-padding: 0 20px;
 
 .chart__bar-section {
 	display: inline-block;
-	background-color: var(--color-accent-50);
+	background-color: var(--chart-series-views);
 	position: absolute;
 	right: 16%; // 1
 	bottom: 0; // 1
@@ -218,7 +264,7 @@ $y-axis-padding: 0 20px;
 }
 
 .chart__bar-section-inner {
-	background-color: var(--color-accent-100);
+	background-color: var(--chart-series-visitors);
 	position: absolute;
 	right: 23.33%;
 	bottom: 0;
@@ -286,14 +332,14 @@ $y-axis-padding: 0 20px;
 	.chart__legend-color {
 		width: 20px;
 		height: 20px;
-		background: var(--color-accent-50);
+		background: var(--chart-series-views);
 		display: inline-block;
 		border-radius: 4px;
 		vertical-align: top;
 		margin: 0 8px 0 0;
 
 		&.is-secondary {
-			background: var(--color-accent-100);
+			background: var(--chart-series-visitors);
 		}
 	}
 

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -8,54 +8,49 @@
 $bar-chart-border-radius: 2px;
 $year-bar-chart-border-radius: 4px;
 
-// Chart series colours
-// Per-scheme pairs chosen so Views and Visitors each clear 3:1 against the
-// surface and against each other (WCAG 2.1 SC 1.4.11), without pushing
-// Visitors to near-black on schemes with widely spaced accent ramps.
-
 :root {
 	--chart-series-views: var(--color-accent-40);
 	--chart-series-visitors: var(--color-accent-90);
 }
 
-.color-scheme.is-aquatic,
-.color-scheme.is-blue,
-.color-scheme.is-classic-blue,
-.color-scheme.is-fresh,
-.color-scheme.is-light,
-.color-scheme.is-nightfall,
-.color-scheme.is-powder-snow,
-.color-scheme.is-sakura,
-.color-scheme.is-sunrise,
-.color-scheme.is-sunset {
-	--chart-series-views: var(--color-accent-40);
-	--chart-series-visitors: var(--color-accent-80);
-}
-
 .color-scheme.is-coffee,
-.color-scheme.is-contrast,
-.color-scheme.is-ocean {
-	--chart-series-views: var(--color-accent-50);
-	--chart-series-visitors: var(--color-accent-100);
-}
-
-.color-scheme.is-classic-bright,
-.color-scheme.is-classic-dark,
-.color-scheme.is-global,
-.color-scheme.is-midnight,
-.color-scheme.is-modern {
-	--chart-series-views: var(--color-accent-30);
-	--chart-series-visitors: var(--color-accent-80);
+.color-scheme.is-light,
+.color-scheme.is-ocean,
+.color-scheme.is-sunrise {
+	--chart-series-views: var(--color-accent);
+	--chart-series-visitors: var(--color-accent-dark);
 }
 
 .color-scheme.is-ectoplasm {
-	--chart-series-views: var(--color-accent-50);
+	--chart-series-views: var(--color-accent);
+	--chart-series-visitors: var(--color-accent-80);
+}
+
+.color-scheme.is-aquatic,
+.color-scheme.is-classic-blue,
+.color-scheme.is-fresh,
+.color-scheme.is-midnight,
+.color-scheme.is-nightfall,
+.color-scheme.is-powder-snow,
+.color-scheme.is-sakura,
+.color-scheme.is-sunset {
+	--chart-series-views: var(--color-accent);
 	--chart-series-visitors: var(--color-accent-90);
 }
 
 .color-scheme.is-jetpack-cloud {
-	--chart-series-views: var(--color-accent-30);
-	--chart-series-visitors: var(--color-accent-70);
+	--chart-series-views: var(--color-accent);
+	--chart-series-visitors: var(--color-accent-50);
+}
+
+.color-scheme.is-blue {
+	--chart-series-views: var(--color-accent-50);
+	--chart-series-visitors: var(--color-accent-90);
+}
+
+.color-scheme.is-contrast {
+	--chart-series-views: var(--color-accent-50);
+	--chart-series-visitors: var(--color-accent-100);
 }
 
 // Chart

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -21,18 +21,22 @@ $year-bar-chart-border-radius: 4px;
 .color-scheme.is-aquatic,
 .color-scheme.is-blue,
 .color-scheme.is-classic-blue,
-.color-scheme.is-coffee,
-.color-scheme.is-contrast,
 .color-scheme.is-fresh,
 .color-scheme.is-light,
 .color-scheme.is-nightfall,
-.color-scheme.is-ocean,
 .color-scheme.is-powder-snow,
 .color-scheme.is-sakura,
 .color-scheme.is-sunrise,
 .color-scheme.is-sunset {
 	--chart-series-views: var(--color-accent-40);
 	--chart-series-visitors: var(--color-accent-80);
+}
+
+.color-scheme.is-coffee,
+.color-scheme.is-contrast,
+.color-scheme.is-ocean {
+	--chart-series-views: var(--color-accent-50);
+	--chart-series-visitors: var(--color-accent-100);
 }
 
 .color-scheme.is-classic-bright,

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -13,6 +13,15 @@ $year-bar-chart-border-radius: 4px;
 	--chart-series-visitors: var(--color-accent-90);
 }
 
+.color-scheme.is-classic-bright,
+.color-scheme.is-classic-dark,
+.color-scheme.is-default,
+.color-scheme.is-global,
+.color-scheme.is-modern {
+	--chart-series-views: var(--color-accent-40);
+	--chart-series-visitors: var(--color-accent-90);
+}
+
 .color-scheme.is-coffee,
 .color-scheme.is-light,
 .color-scheme.is-ocean,

--- a/client/components/chart/test/chart-contrast.ts
+++ b/client/components/chart/test/chart-contrast.ts
@@ -4,8 +4,8 @@
 import fs from 'fs';
 import path from 'path';
 import chroma from 'chroma-js';
-import postcss from 'postcss';
 import postcssScss from 'postcss-scss';
+import type postcss from 'postcss';
 
 const REPO_ROOT = path.resolve( __dirname, '../../../..' );
 const SCHEME_DIR = path.join(

--- a/client/components/chart/test/chart-contrast.ts
+++ b/client/components/chart/test/chart-contrast.ts
@@ -1,0 +1,182 @@
+/**
+ * @jest-environment node
+ */
+import fs from 'fs';
+import path from 'path';
+
+const REPO_ROOT = path.resolve( __dirname, '../../../..' );
+const SCHEME_DIR = path.join(
+	REPO_ROOT,
+	'packages/calypso-color-schemes/src/shared/color-schemes'
+);
+const PALETTE = path.join( REPO_ROOT, 'packages/calypso-color-schemes/src/shared/_colors.scss' );
+const COLOR_STUDIO = path.join(
+	REPO_ROOT,
+	'packages/calypso-color-schemes/src/__color-studio/color-properties.css'
+);
+const CHART_STYLE = path.join( REPO_ROOT, 'client/components/chart/style.scss' );
+const LINE_CHART = path.join( REPO_ROOT, 'client/my-sites/stats/stats-chart-tabs/index.jsx' );
+const WIDGET_CHART = path.join( REPO_ROOT, 'apps/odyssey-stats/src/widget/mini-chart.scss' );
+
+const MIN_RATIO = 3;
+
+const readDeclarations = ( file: string ) => {
+	const map = new Map< string, string >();
+	for ( const line of fs.readFileSync( file, 'utf8' ).split( '\n' ) ) {
+		const match = line.match( /^\s*(--[\w-]+):\s*([^;]+);/ );
+		if ( match ) {
+			map.set( match[ 1 ], match[ 2 ].trim() );
+		}
+	}
+	return map;
+};
+
+const luminance = ( hex: string ) => {
+	const channels = [ 0, 2, 4 ].map(
+		( offset ) => parseInt( hex.slice( offset + 1, offset + 3 ), 16 ) / 255
+	);
+	const [ r, g, b ] = channels.map( ( c ) =>
+		c <= 0.03928 ? c / 12.92 : ( ( c + 0.055 ) / 1.055 ) ** 2.4
+	);
+	return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+};
+
+const contrast = ( a: string, b: string ) => {
+	const [ hi, lo ] = [ luminance( a ), luminance( b ) ].sort( ( x, y ) => y - x );
+	return ( hi + 0.05 ) / ( lo + 0.05 );
+};
+
+const palette = readDeclarations( PALETTE );
+const colorStudio = readDeclarations( COLOR_STUDIO );
+const schemes = new Map< string, Map< string, string > >();
+for ( const file of fs.readdirSync( SCHEME_DIR ).sort() ) {
+	if ( file.endsWith( '.scss' ) ) {
+		schemes.set(
+			file.replace( /^_|\.scss$/g, '' ),
+			readDeclarations( path.join( SCHEME_DIR, file ) )
+		);
+	}
+}
+
+const resolve = ( value: string, scheme: string, depth = 0 ): string | null => {
+	if ( depth > 15 ) {
+		return null;
+	}
+	const trimmed = value.trim();
+	if ( /^#[0-9a-f]{6}$/i.test( trimmed ) ) {
+		return trimmed.toLowerCase();
+	}
+	if ( /^#[0-9a-f]{3}$/i.test( trimmed ) ) {
+		return `#${ trimmed
+			.slice( 1 )
+			.split( '' )
+			.map( ( c ) => c + c )
+			.join( '' ) }`;
+	}
+	const reference = trimmed.match( /^var\(\s*(--[\w-]+)/ );
+	if ( ! reference ) {
+		return null;
+	}
+	const sources = [
+		schemes.get( scheme ),
+		schemes.get( 'global' ),
+		schemes.get( 'default' ),
+		palette,
+		colorStudio,
+	];
+	for ( const source of sources ) {
+		if ( source?.has( reference[ 1 ] ) ) {
+			const resolved = resolve( source.get( reference[ 1 ] ) as string, scheme, depth + 1 );
+			if ( resolved ) {
+				return resolved;
+			}
+		}
+	}
+	return null;
+};
+
+const tokenValue = ( scheme: string, token: string ) => {
+	for ( const source of [ schemes.get( scheme ), schemes.get( 'default' ) ] ) {
+		if ( source?.has( token ) ) {
+			const resolved = resolve( source.get( token ) as string, scheme );
+			if ( resolved ) {
+				return resolved;
+			}
+		}
+	}
+	throw new Error( `Could not resolve ${ token } for scheme ${ scheme }` );
+};
+
+const chartStyle = fs.readFileSync( CHART_STYLE, 'utf8' );
+
+const topLevelBlock = ( selector: string ) => {
+	const start = chartStyle.search( new RegExp( `^\\${ selector } \\{$`, 'm' ) );
+	if ( start === -1 ) {
+		throw new Error( `No top-level block for ${ selector } in chart/style.scss` );
+	}
+	return chartStyle.slice( start, chartStyle.indexOf( '\n}', start ) );
+};
+
+const backgroundToken = ( block: string, label: string ) => {
+	const match = block.match( /background(?:-color)?:\s*var\(\s*(--[\w-]+)\s*\)/ );
+	if ( ! match ) {
+		throw new Error( `No background custom property found for ${ label }` );
+	}
+	return match[ 1 ];
+};
+
+const legendBlock = chartStyle.slice(
+	chartStyle.indexOf( '.chart__legend-color {' ),
+	chartStyle.indexOf( '.chart__legend-checkbox' )
+);
+
+const SERIES = {
+	viewsBar: backgroundToken( topLevelBlock( '.chart__bar-section' ), 'views bar' ),
+	visitorsBar: backgroundToken( topLevelBlock( '.chart__bar-section-inner' ), 'visitors bar' ),
+	viewsSwatch: backgroundToken( legendBlock, 'views legend swatch' ),
+	visitorsSwatch: backgroundToken(
+		legendBlock.slice( legendBlock.indexOf( '&.is-secondary' ) ),
+		'visitors legend swatch'
+	),
+};
+
+const schemeNames = [ ...schemes.keys() ];
+
+describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
+	it.each( schemeNames )( 'bar chart passes 3:1 in the %s scheme', ( scheme ) => {
+		const surface = tokenValue( scheme, '--color-surface' );
+		const views = tokenValue( scheme, SERIES.viewsBar );
+		const visitors = tokenValue( scheme, SERIES.visitorsBar );
+
+		expect( contrast( views, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
+		expect( contrast( visitors, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
+		expect( contrast( views, visitors ) ).toBeGreaterThanOrEqual( MIN_RATIO );
+	} );
+
+	it( 'legend swatches use the same tokens as the bars they label', () => {
+		expect( SERIES.viewsSwatch ).toBe( SERIES.viewsBar );
+		expect( SERIES.visitorsSwatch ).toBe( SERIES.visitorsBar );
+	} );
+
+	it.each( schemeNames )( 'line chart passes 3:1 in the %s scheme', ( scheme ) => {
+		const source = fs.readFileSync( LINE_CHART, 'utf8' );
+		const tokens = [ ...source.matchAll( /useCssVariable\(\s*'(--[\w-]+)'/g ) ].map(
+			( m ) => m[ 1 ]
+		);
+		expect( tokens ).toHaveLength( 2 );
+
+		const surface = tokenValue( scheme, '--color-surface' );
+		const [ views, visitors ] = tokens.map( ( token ) => tokenValue( scheme, token ) );
+
+		expect( contrast( views, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
+		expect( contrast( visitors, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
+		expect( contrast( views, visitors ) ).toBeGreaterThanOrEqual( MIN_RATIO );
+	} );
+
+	it( 'Odyssey widget mini-chart does not override the shared series colours', () => {
+		const source = fs.readFileSync( WIDGET_CHART, 'utf8' );
+		expect( source ).not.toMatch( /--color-primary/ );
+		expect( source ).not.toMatch( /\.chart__bar-section-inner\s*\{/ );
+		expect( source ).not.toMatch( /&\.is-secondary\s*\{/ );
+	} );
+} );

--- a/client/components/chart/test/chart-contrast.ts
+++ b/client/components/chart/test/chart-contrast.ts
@@ -214,6 +214,22 @@ describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
 	} );
 
 	it.each( schemeNames )(
+		'has an explicit .color-scheme.is-%s rule declaring --chart-series-views and --chart-series-visitors',
+		( scheme ) => {
+			if ( ! seriesOverrides.has( scheme ) ) {
+				throw new Error(
+					`.color-scheme.is-${ scheme } has no explicit --chart-series-views/--chart-series-visitors rule in chart/style.scss. ` +
+						'A scheme cannot rely on the :root fallback: CSS substitutes var() at the element where a custom ' +
+						'property is declared, not where it is used, so --chart-series-views declared on :root resolves ' +
+						"--color-accent-40 against :root (the default scheme's ramp), not against this scheme's ramp. " +
+						`Add an explicit .color-scheme.is-${ scheme } rule with both declarations.`
+				);
+			}
+			expect( seriesOverrides.has( scheme ) ).toBe( true );
+		}
+	);
+
+	it.each( schemeNames )(
 		'Views and Visitors meet the 3:1 pair-contrast rule against each other in the %s scheme',
 		( scheme ) => {
 			const views = seriesHex( scheme, 'views' );

--- a/client/components/chart/test/chart-contrast.ts
+++ b/client/components/chart/test/chart-contrast.ts
@@ -251,41 +251,11 @@ const VIEWS_VS_SURFACE_EXEMPT_SCHEMES = [ 'coffee', 'ocean', 'light', 'sunrise',
 
 const VISITORS_100_ALLOWED_SCHEMES = [ 'contrast', 'jetpack-cloud' ];
 
-// Captured contrast of the line chart's Views colour (--color-accent-light)
-// against each scheme's surface, as it ships today. STATS-369 fixed a
-// regression where the line chart was accidentally pointed at the bar
-// chart's --color-accent token, which changed these numbers for coffee,
-// ocean and light. This table pins the correct, pre-regression values so
-// any future change to the line chart's Views token is caught here.
-const LINE_VIEWS_VS_SURFACE_CONTRAST: Record< string, number > = {
-	aquatic: 2.638239,
-	blue: 2.983561,
-	'classic-blue': 2.596347,
-	'classic-bright': 3.078489,
-	'classic-dark': 3.078489,
-	coffee: 2.596347,
-	contrast: 4.828292,
-	default: 2.886402,
-	ectoplasm: 1.565615,
-	fresh: 2.983561,
-	global: 3.615935,
-	'jetpack-cloud': 3.244898,
-	light: 2.983561,
-	midnight: 3.010354,
-	modern: 3.615935,
-	nightfall: 2.983561,
-	ocean: 2.638239,
-	'powder-snow': 2.983561,
-	sakura: 2.983561,
-	sunrise: 2.596347,
-	sunset: 2.596347,
-};
-
 const lineChartSource = fs.readFileSync( LINE_CHART, 'utf8' );
 const LINE_CHART_TOKENS = [ ...lineChartSource.matchAll( /useCssVariable\(\s*'(--[\w-]+)'/g ) ].map(
 	( m ) => m[ 1 ]
 );
-const [ LINE_CHART_VIEWS_TOKEN, LINE_CHART_VISITORS_TOKEN ] = LINE_CHART_TOKENS;
+const [ , LINE_CHART_VISITORS_TOKEN ] = LINE_CHART_TOKENS;
 
 describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
 	it( 'bar chart series read the shared --chart-series custom properties', () => {
@@ -341,17 +311,6 @@ describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
 		}
 	);
 
-	it.each( VIEWS_VS_SURFACE_EXEMPT_SCHEMES )(
-		"bar chart: Views is left untouched at the scheme's own --color-accent in the %s scheme, which is pre-existing and out of scope for the Views-vs-surface rule",
-		( scheme ) => {
-			const views = pairForScheme( scheme ).views;
-			const accent = tokenValue( scheme, '--color-accent' );
-
-			expect( views ).toBe( 'var(--color-accent)' );
-			expect( seriesHex( scheme, 'views' ) ).toBe( accent );
-		}
-	);
-
 	it.each( schemeNames.filter( ( scheme ) => ! VISITORS_100_ALLOWED_SCHEMES.includes( scheme ) ) )(
 		'bar chart: Visitors does not resolve to --color-accent-100 in the %s scheme',
 		( scheme ) => {
@@ -374,10 +333,6 @@ describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
 	it( 'line chart: tokens are entirely separate from the bar chart tokens', () => {
 		expect( LINE_CHART_TOKENS ).not.toContain( SERIES.viewsBar );
 		expect( LINE_CHART_TOKENS ).not.toContain( SERIES.visitorsBar );
-	} );
-
-	it( 'line chart: Views token is unchanged from before this branch, --color-accent-light', () => {
-		expect( LINE_CHART_VIEWS_TOKEN ).toBe( '--color-accent-light' );
 	} );
 
 	it( 'line chart: Visitors token is the dedicated --chart-line-visitors custom property', () => {
@@ -407,19 +362,6 @@ describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
 			const visitors = lineVisitorsHex( scheme );
 
 			expect( contrast( views, visitors ) ).toBeGreaterThanOrEqual( MIN_RATIO );
-		}
-	);
-
-	it.each( schemeNames )(
-		'line chart: Views-vs-background contrast is unchanged from --color-accent-light in the %s scheme',
-		( scheme ) => {
-			const surface = tokenValue( scheme, '--color-surface' );
-			const views = lineViewsHex( scheme );
-
-			expect( contrast( views, surface ) ).toBeCloseTo(
-				LINE_VIEWS_VS_SURFACE_CONTRAST[ scheme ],
-				3
-			);
 		}
 	);
 

--- a/client/components/chart/test/chart-contrast.ts
+++ b/client/components/chart/test/chart-contrast.ts
@@ -77,13 +77,7 @@ const resolve = ( value: string, scheme: string, depth = 0 ): string | null => {
 	if ( ! reference ) {
 		return null;
 	}
-	const sources = [
-		schemes.get( scheme ),
-		schemes.get( 'global' ),
-		schemes.get( 'default' ),
-		palette,
-		colorStudio,
-	];
+	const sources = [ schemes.get( scheme ), schemes.get( 'default' ), palette, colorStudio ];
 	for ( const source of sources ) {
 		if ( source?.has( reference[ 1 ] ) ) {
 			const resolved = resolve( source.get( reference[ 1 ] ) as string, scheme, depth + 1 );

--- a/client/components/chart/test/chart-contrast.ts
+++ b/client/components/chart/test/chart-contrast.ts
@@ -134,6 +134,61 @@ const SERIES = {
 	),
 };
 
+type SeriesPair = { views: string; visitors: string };
+
+const parseSeriesBody = ( body: string ): SeriesPair => {
+	const values: Partial< Record< 'views' | 'visitors', string > > = {};
+	for ( const match of body.matchAll( /--chart-series-(views|visitors):\s*(var\([^)]+\));/g ) ) {
+		values[ match[ 1 ] as 'views' | 'visitors' ] = match[ 2 ];
+	}
+	if ( ! values.views || ! values.visitors ) {
+		throw new Error( `Incomplete chart-series rule in chart/style.scss: ${ body }` );
+	}
+	return { views: values.views, visitors: values.visitors };
+};
+
+const parseSeriesRules = ( source: string ) => {
+	const ruleRegex =
+		/^((?:(?:\.color-scheme\.is-[\w-]+|:root)(?:,\n)?)+) \{\n((?:\t--chart-series-[\w-]+:[^\n]+;\n)+)\}$/gm;
+	let base: SeriesPair | null = null;
+	const overrides = new Map< string, SeriesPair >();
+	let match: RegExpExecArray | null;
+	while ( ( match = ruleRegex.exec( source ) ) !== null ) {
+		const [ , selectorList, body ] = match;
+		const pair = parseSeriesBody( body );
+		for ( const selector of selectorList.split( ',' ).map( ( s ) => s.trim() ) ) {
+			if ( selector === ':root' ) {
+				base = pair;
+				continue;
+			}
+			const schemeMatch = selector.match( /^\.color-scheme\.is-([\w-]+)$/ );
+			if ( schemeMatch ) {
+				overrides.set( schemeMatch[ 1 ], pair );
+			}
+		}
+	}
+	if ( ! base ) {
+		throw new Error( 'No :root base chart-series rule found in chart/style.scss' );
+	}
+	return { base, overrides };
+};
+
+const { base: baseSeriesPair, overrides: seriesOverrides } = parseSeriesRules( chartStyle );
+
+const pairForScheme = ( scheme: string ): SeriesPair =>
+	seriesOverrides.get( scheme ) ?? baseSeriesPair;
+
+const seriesHex = ( scheme: string, series: 'views' | 'visitors' ) => {
+	const value = pairForScheme( scheme )[ series ];
+	const resolved = resolve( value, scheme );
+	if ( ! resolved ) {
+		throw new Error(
+			`Could not resolve --chart-series-${ series } (${ value }) for scheme ${ scheme }`
+		);
+	}
+	return resolved;
+};
+
 const schemeNames = [ ...schemes.keys() ];
 
 const lineChartSource = fs.readFileSync( LINE_CHART, 'utf8' );
@@ -142,12 +197,17 @@ const LINE_CHART_TOKENS = [ ...lineChartSource.matchAll( /useCssVariable\(\s*'(-
 );
 
 describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
+	it( 'bar chart series read the shared --chart-series custom properties', () => {
+		expect( SERIES.viewsBar ).toBe( '--chart-series-views' );
+		expect( SERIES.visitorsBar ).toBe( '--chart-series-visitors' );
+	} );
+
 	it.each( schemeNames )(
 		'bar chart series meet the 3:1 adjacency rule (each other and the surface) in the %s scheme',
 		( scheme ) => {
 			const surface = tokenValue( scheme, '--color-surface' );
-			const views = tokenValue( scheme, SERIES.viewsBar );
-			const visitors = tokenValue( scheme, SERIES.visitorsBar );
+			const views = seriesHex( scheme, 'views' );
+			const visitors = seriesHex( scheme, 'visitors' );
 
 			expect( contrast( views, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
 			expect( contrast( visitors, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
@@ -165,15 +225,19 @@ describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
 		expect( LINE_CHART_TOKENS[ 0 ] ).not.toBe( LINE_CHART_TOKENS[ 1 ] );
 	} );
 
+	it( 'line chart uses the same two tokens as the bar chart', () => {
+		expect( new Set( LINE_CHART_TOKENS ) ).toEqual(
+			new Set( [ SERIES.viewsBar, SERIES.visitorsBar ] )
+		);
+	} );
+
 	it.each( schemeNames )(
 		'line chart series each meet the 3:1 background-contrast rule (no adjacency requirement) in the %s scheme',
 		( scheme ) => {
 			const surface = tokenValue( scheme, '--color-surface' );
-			const [ viewsToken, visitorsToken ] = LINE_CHART_TOKENS;
-			const views = tokenValue( scheme, viewsToken );
-			const visitors = tokenValue( scheme, visitorsToken );
+			const views = seriesHex( scheme, 'views' );
+			const visitors = seriesHex( scheme, 'visitors' );
 
-			expect( viewsToken ).not.toBe( visitorsToken );
 			expect( contrast( views, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
 			expect( contrast( visitors, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
 		}

--- a/client/components/chart/test/chart-contrast.ts
+++ b/client/components/chart/test/chart-contrast.ts
@@ -3,6 +3,9 @@
  */
 import fs from 'fs';
 import path from 'path';
+import chroma from 'chroma-js';
+import postcss from 'postcss';
+import postcssScss from 'postcss-scss';
 
 const REPO_ROOT = path.resolve( __dirname, '../../../..' );
 const SCHEME_DIR = path.join(
@@ -22,29 +25,14 @@ const MIN_RATIO = 3;
 
 const readDeclarations = ( file: string ) => {
 	const map = new Map< string, string >();
-	for ( const line of fs.readFileSync( file, 'utf8' ).split( '\n' ) ) {
-		const match = line.match( /^\s*(--[\w-]+):\s*([^;]+);/ );
-		if ( match ) {
-			map.set( match[ 1 ], match[ 2 ].trim() );
-		}
-	}
+	const root = postcssScss.parse( fs.readFileSync( file, 'utf8' ) );
+	root.walkDecls( /^--/, ( decl ) => {
+		map.set( decl.prop, decl.value.trim() );
+	} );
 	return map;
 };
 
-const luminance = ( hex: string ) => {
-	const channels = [ 0, 2, 4 ].map(
-		( offset ) => parseInt( hex.slice( offset + 1, offset + 3 ), 16 ) / 255
-	);
-	const [ r, g, b ] = channels.map( ( c ) =>
-		c <= 0.03928 ? c / 12.92 : ( ( c + 0.055 ) / 1.055 ) ** 2.4
-	);
-	return 0.2126 * r + 0.7152 * g + 0.0722 * b;
-};
-
-const contrast = ( a: string, b: string ) => {
-	const [ hi, lo ] = [ luminance( a ), luminance( b ) ].sort( ( x, y ) => y - x );
-	return ( hi + 0.05 ) / ( lo + 0.05 );
-};
+const contrast = ( a: string, b: string ) => chroma.contrast( a, b );
 
 const palette = readDeclarations( PALETTE );
 const colorStudio = readDeclarations( COLOR_STUDIO );
@@ -102,61 +90,75 @@ const tokenValue = ( scheme: string, token: string ) => {
 };
 
 const chartStyle = fs.readFileSync( CHART_STYLE, 'utf8' );
+const chartStyleRoot = postcssScss.parse( chartStyle );
 
-const topLevelBlock = ( selector: string ) => {
-	const start = chartStyle.search( new RegExp( `^\\${ selector } \\{$`, 'm' ) );
-	if ( start === -1 ) {
-		throw new Error( `No top-level block for ${ selector } in chart/style.scss` );
+const directRule = ( container: postcss.Container, selector: string ) => {
+	const found = container.nodes?.find(
+		( node ): node is postcss.Rule => node.type === 'rule' && node.selector === selector
+	);
+	if ( ! found ) {
+		throw new Error( `No rule found for ${ selector } in chart/style.scss` );
 	}
-	return chartStyle.slice( start, chartStyle.indexOf( '\n}', start ) );
+	return found;
 };
 
-const backgroundToken = ( block: string, label: string ) => {
-	const match = block.match( /background(?:-color)?:\s*var\(\s*(--[\w-]+)\s*\)/ );
-	if ( ! match ) {
+const backgroundToken = ( rule: postcss.Rule, label: string ) => {
+	let token: string | null = null;
+	rule.each( ( node ) => {
+		if ( node.type === 'decl' && /^background(-color)?$/.test( node.prop ) ) {
+			const match = node.value.match( /var\(\s*(--[\w-]+)\s*\)/ );
+			if ( match ) {
+				token = match[ 1 ];
+			}
+		}
+	} );
+	if ( ! token ) {
 		throw new Error( `No background custom property found for ${ label }` );
 	}
-	return match[ 1 ];
+	return token;
 };
 
-const legendBlock = chartStyle.slice(
-	chartStyle.indexOf( '.chart__legend-color {' ),
-	chartStyle.indexOf( '.chart__legend-checkbox' )
-);
+const legendOptionRule = directRule( chartStyleRoot, '.chart__legend-option' );
+const legendColorRule = directRule( legendOptionRule, '.chart__legend-color' );
+const legendSecondaryRule = directRule( legendColorRule, '&.is-secondary' );
 
 const SERIES = {
-	viewsBar: backgroundToken( topLevelBlock( '.chart__bar-section' ), 'views bar' ),
-	visitorsBar: backgroundToken( topLevelBlock( '.chart__bar-section-inner' ), 'visitors bar' ),
-	viewsSwatch: backgroundToken( legendBlock, 'views legend swatch' ),
-	visitorsSwatch: backgroundToken(
-		legendBlock.slice( legendBlock.indexOf( '&.is-secondary' ) ),
-		'visitors legend swatch'
+	viewsBar: backgroundToken( directRule( chartStyleRoot, '.chart__bar-section' ), 'views bar' ),
+	visitorsBar: backgroundToken(
+		directRule( chartStyleRoot, '.chart__bar-section-inner' ),
+		'visitors bar'
 	),
+	viewsSwatch: backgroundToken( legendColorRule, 'views legend swatch' ),
+	visitorsSwatch: backgroundToken( legendSecondaryRule, 'visitors legend swatch' ),
 };
 
 type SeriesPair = { views: string; visitors: string };
 
-const parseSeriesBody = ( body: string ): SeriesPair => {
-	const values: Partial< Record< 'views' | 'visitors', string > > = {};
-	for ( const match of body.matchAll( /--chart-series-(views|visitors):\s*(var\([^)]+\));/g ) ) {
-		values[ match[ 1 ] as 'views' | 'visitors' ] = match[ 2 ];
-	}
-	if ( ! values.views || ! values.visitors ) {
-		throw new Error( `Incomplete chart-series rule in chart/style.scss: ${ body }` );
-	}
-	return { views: values.views, visitors: values.visitors };
-};
-
-const parseSeriesRules = ( source: string ) => {
-	const ruleRegex =
-		/^((?:(?:\.color-scheme\.is-[\w-]+|:root)(?:,\n)?)+) \{\n((?:\t--chart-series-[\w-]+:[^\n]+;\n)+)\}$/gm;
+const parseSeriesRules = ( root: postcss.Root ) => {
 	let base: SeriesPair | null = null;
 	const overrides = new Map< string, SeriesPair >();
-	let match: RegExpExecArray | null;
-	while ( ( match = ruleRegex.exec( source ) ) !== null ) {
-		const [ , selectorList, body ] = match;
-		const pair = parseSeriesBody( body );
-		for ( const selector of selectorList.split( ',' ).map( ( s ) => s.trim() ) ) {
+	root.each( ( node ) => {
+		if ( node.type !== 'rule' ) {
+			return;
+		}
+		const values: Partial< Record< 'views' | 'visitors', string > > = {};
+		node.each( ( child ) => {
+			if ( child.type !== 'decl' ) {
+				return;
+			}
+			const match = child.prop.match( /^--chart-series-(views|visitors)$/ );
+			if ( match ) {
+				values[ match[ 1 ] as 'views' | 'visitors' ] = child.value.trim();
+			}
+		} );
+		if ( ! values.views && ! values.visitors ) {
+			return;
+		}
+		if ( ! values.views || ! values.visitors ) {
+			throw new Error( `Incomplete chart-series rule in chart/style.scss: ${ node.selector }` );
+		}
+		const pair: SeriesPair = { views: values.views, visitors: values.visitors };
+		for ( const selector of node.selectors ) {
 			if ( selector === ':root' ) {
 				base = pair;
 				continue;
@@ -166,14 +168,14 @@ const parseSeriesRules = ( source: string ) => {
 				overrides.set( schemeMatch[ 1 ], pair );
 			}
 		}
-	}
+	} );
 	if ( ! base ) {
 		throw new Error( 'No :root base chart-series rule found in chart/style.scss' );
 	}
 	return { base, overrides };
 };
 
-const { base: baseSeriesPair, overrides: seriesOverrides } = parseSeriesRules( chartStyle );
+const { base: baseSeriesPair, overrides: seriesOverrides } = parseSeriesRules( chartStyleRoot );
 
 const pairForScheme = ( scheme: string ): SeriesPair =>
 	seriesOverrides.get( scheme ) ?? baseSeriesPair;

--- a/client/components/chart/test/chart-contrast.ts
+++ b/client/components/chart/test/chart-contrast.ts
@@ -191,6 +191,55 @@ const seriesHex = ( scheme: string, series: 'views' | 'visitors' ) => {
 	return resolved;
 };
 
+const parseLineVisitorsRule = ( root: postcss.Root ) => {
+	let base: string | null = null;
+	const overrides = new Map< string, string >();
+	root.each( ( node ) => {
+		if ( node.type !== 'rule' ) {
+			return;
+		}
+		let value: string | null = null;
+		node.each( ( child ) => {
+			if ( child.type === 'decl' && child.prop === '--chart-line-visitors' ) {
+				value = child.value.trim();
+			}
+		} );
+		if ( ! value ) {
+			return;
+		}
+		for ( const selector of node.selectors ) {
+			if ( selector === ':root' ) {
+				base = value;
+				continue;
+			}
+			const schemeMatch = selector.match( /^\.color-scheme\.is-([\w-]+)$/ );
+			if ( schemeMatch ) {
+				overrides.set( schemeMatch[ 1 ], value );
+			}
+		}
+	} );
+	if ( ! base ) {
+		throw new Error( 'No :root base --chart-line-visitors rule found in chart/style.scss' );
+	}
+	return { base, overrides };
+};
+
+const { base: lineVisitorsBase, overrides: lineVisitorsOverrides } =
+	parseLineVisitorsRule( chartStyleRoot );
+
+const lineVisitorsHex = ( scheme: string ) => {
+	const value = lineVisitorsOverrides.get( scheme ) ?? lineVisitorsBase;
+	const resolved = resolve( value, scheme );
+	if ( ! resolved ) {
+		throw new Error(
+			`Could not resolve --chart-line-visitors (${ value }) for scheme ${ scheme }`
+		);
+	}
+	return resolved;
+};
+
+const lineViewsHex = ( scheme: string ) => tokenValue( scheme, '--color-accent-light' );
+
 const schemeNames = [ ...schemes.keys() ];
 
 // These schemes' Views colour is the scheme's raw wp-admin --color-accent
@@ -202,10 +251,41 @@ const VIEWS_VS_SURFACE_EXEMPT_SCHEMES = [ 'coffee', 'ocean', 'light', 'sunrise',
 
 const VISITORS_100_ALLOWED_SCHEMES = [ 'contrast', 'jetpack-cloud' ];
 
+// Captured contrast of the line chart's Views colour (--color-accent-light)
+// against each scheme's surface, as it ships today. STATS-369 fixed a
+// regression where the line chart was accidentally pointed at the bar
+// chart's --color-accent token, which changed these numbers for coffee,
+// ocean and light. This table pins the correct, pre-regression values so
+// any future change to the line chart's Views token is caught here.
+const LINE_VIEWS_VS_SURFACE_CONTRAST: Record< string, number > = {
+	aquatic: 2.638239,
+	blue: 2.983561,
+	'classic-blue': 2.596347,
+	'classic-bright': 3.078489,
+	'classic-dark': 3.078489,
+	coffee: 2.596347,
+	contrast: 4.828292,
+	default: 2.886402,
+	ectoplasm: 1.565615,
+	fresh: 2.983561,
+	global: 3.615935,
+	'jetpack-cloud': 3.244898,
+	light: 2.983561,
+	midnight: 3.010354,
+	modern: 3.615935,
+	nightfall: 2.983561,
+	ocean: 2.638239,
+	'powder-snow': 2.983561,
+	sakura: 2.983561,
+	sunrise: 2.596347,
+	sunset: 2.596347,
+};
+
 const lineChartSource = fs.readFileSync( LINE_CHART, 'utf8' );
 const LINE_CHART_TOKENS = [ ...lineChartSource.matchAll( /useCssVariable\(\s*'(--[\w-]+)'/g ) ].map(
 	( m ) => m[ 1 ]
 );
+const [ LINE_CHART_VIEWS_TOKEN, LINE_CHART_VISITORS_TOKEN ] = LINE_CHART_TOKENS;
 
 describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
 	it( 'bar chart series read the shared --chart-series custom properties', () => {
@@ -214,7 +294,7 @@ describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
 	} );
 
 	it.each( schemeNames )(
-		'has an explicit .color-scheme.is-%s rule declaring --chart-series-views and --chart-series-visitors',
+		'bar chart: has an explicit .color-scheme.is-%s rule declaring --chart-series-views and --chart-series-visitors',
 		( scheme ) => {
 			if ( ! seriesOverrides.has( scheme ) ) {
 				throw new Error(
@@ -230,7 +310,7 @@ describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
 	);
 
 	it.each( schemeNames )(
-		'Views and Visitors meet the 3:1 pair-contrast rule against each other in the %s scheme',
+		'bar chart: Views and Visitors meet the 3:1 pair-contrast rule against each other in the %s scheme',
 		( scheme ) => {
 			const views = seriesHex( scheme, 'views' );
 			const visitors = seriesHex( scheme, 'visitors' );
@@ -240,7 +320,7 @@ describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
 	);
 
 	it.each( schemeNames )(
-		'Visitors meets the 3:1 contrast rule against the surface in the %s scheme',
+		'bar chart: Visitors meets the 3:1 contrast rule against the surface in the %s scheme',
 		( scheme ) => {
 			const surface = tokenValue( scheme, '--color-surface' );
 			const visitors = seriesHex( scheme, 'visitors' );
@@ -251,15 +331,18 @@ describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
 
 	it.each(
 		schemeNames.filter( ( scheme ) => ! VIEWS_VS_SURFACE_EXEMPT_SCHEMES.includes( scheme ) )
-	)( 'Views meets the 3:1 contrast rule against the surface in the %s scheme', ( scheme ) => {
-		const surface = tokenValue( scheme, '--color-surface' );
-		const views = seriesHex( scheme, 'views' );
+	)(
+		'bar chart: Views meets the 3:1 contrast rule against the surface in the %s scheme',
+		( scheme ) => {
+			const surface = tokenValue( scheme, '--color-surface' );
+			const views = seriesHex( scheme, 'views' );
 
-		expect( contrast( views, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
-	} );
+			expect( contrast( views, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
+		}
+	);
 
 	it.each( VIEWS_VS_SURFACE_EXEMPT_SCHEMES )(
-		"Views is left untouched at the scheme's own --color-accent in the %s scheme, which is pre-existing and out of scope for the Views-vs-surface rule",
+		"bar chart: Views is left untouched at the scheme's own --color-accent in the %s scheme, which is pre-existing and out of scope for the Views-vs-surface rule",
 		( scheme ) => {
 			const views = pairForScheme( scheme ).views;
 			const accent = tokenValue( scheme, '--color-accent' );
@@ -270,7 +353,7 @@ describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
 	);
 
 	it.each( schemeNames.filter( ( scheme ) => ! VISITORS_100_ALLOWED_SCHEMES.includes( scheme ) ) )(
-		'Visitors does not resolve to --color-accent-100 in the %s scheme',
+		'bar chart: Visitors does not resolve to --color-accent-100 in the %s scheme',
 		( scheme ) => {
 			const visitors = pairForScheme( scheme ).visitors;
 
@@ -278,7 +361,7 @@ describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
 		}
 	);
 
-	it( 'legend swatches use the same tokens as the bars they label', () => {
+	it( 'bar chart: legend swatches use the same tokens as the bars they label', () => {
 		expect( SERIES.viewsSwatch ).toBe( SERIES.viewsBar );
 		expect( SERIES.visitorsSwatch ).toBe( SERIES.visitorsBar );
 	} );
@@ -288,11 +371,57 @@ describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
 		expect( LINE_CHART_TOKENS[ 0 ] ).not.toBe( LINE_CHART_TOKENS[ 1 ] );
 	} );
 
-	it( 'line chart uses the same two tokens as the bar chart', () => {
-		expect( new Set( LINE_CHART_TOKENS ) ).toEqual(
-			new Set( [ SERIES.viewsBar, SERIES.visitorsBar ] )
-		);
+	it( 'line chart: tokens are entirely separate from the bar chart tokens', () => {
+		expect( LINE_CHART_TOKENS ).not.toContain( SERIES.viewsBar );
+		expect( LINE_CHART_TOKENS ).not.toContain( SERIES.visitorsBar );
 	} );
+
+	it( 'line chart: Views token is unchanged from before this branch, --color-accent-light', () => {
+		expect( LINE_CHART_VIEWS_TOKEN ).toBe( '--color-accent-light' );
+	} );
+
+	it( 'line chart: Visitors token is the dedicated --chart-line-visitors custom property', () => {
+		expect( LINE_CHART_VISITORS_TOKEN ).toBe( '--chart-line-visitors' );
+	} );
+
+	it.each( schemeNames )(
+		'line chart: has an explicit .color-scheme.is-%s rule declaring --chart-line-visitors',
+		( scheme ) => {
+			if ( ! lineVisitorsOverrides.has( scheme ) ) {
+				throw new Error(
+					`.color-scheme.is-${ scheme } has no explicit --chart-line-visitors rule in chart/style.scss. ` +
+						'A scheme cannot rely on the :root fallback: CSS substitutes var() at the element where a custom ' +
+						'property is declared, not where it is used, so --chart-line-visitors declared on :root resolves ' +
+						"--color-accent-dark against :root (the default scheme's ramp), not against this scheme's ramp. " +
+						`Add an explicit .color-scheme.is-${ scheme } rule with the declaration.`
+				);
+			}
+			expect( lineVisitorsOverrides.has( scheme ) ).toBe( true );
+		}
+	);
+
+	it.each( schemeNames )(
+		'line chart: Views and Visitors meet the 3:1 pair-contrast rule against each other in the %s scheme',
+		( scheme ) => {
+			const views = lineViewsHex( scheme );
+			const visitors = lineVisitorsHex( scheme );
+
+			expect( contrast( views, visitors ) ).toBeGreaterThanOrEqual( MIN_RATIO );
+		}
+	);
+
+	it.each( schemeNames )(
+		'line chart: Views-vs-background contrast is unchanged from --color-accent-light in the %s scheme',
+		( scheme ) => {
+			const surface = tokenValue( scheme, '--color-surface' );
+			const views = lineViewsHex( scheme );
+
+			expect( contrast( views, surface ) ).toBeCloseTo(
+				LINE_VIEWS_VS_SURFACE_CONTRAST[ scheme ],
+				3
+			);
+		}
+	);
 
 	it( 'Odyssey widget mini-chart does not override the shared series colours', () => {
 		const source = fs.readFileSync( WIDGET_CHART, 'utf8' );

--- a/client/components/chart/test/chart-contrast.ts
+++ b/client/components/chart/test/chart-contrast.ts
@@ -193,6 +193,15 @@ const seriesHex = ( scheme: string, series: 'views' | 'visitors' ) => {
 
 const schemeNames = [ ...schemes.keys() ];
 
+// These schemes' Views colour is the scheme's raw wp-admin --color-accent
+// highlight rather than a ramp step, so Views itself can fall short of 3:1
+// against the surface. Fixing that is out of scope for STATS-369 — it would
+// replace the scheme's deliberate muted identity with a saturated ramp
+// colour. The pair contrast (Views vs Visitors) is still required to pass.
+const VIEWS_VS_SURFACE_EXEMPT_SCHEMES = [ 'coffee', 'ocean', 'light', 'sunrise', 'ectoplasm' ];
+
+const VISITORS_100_ALLOWED_SCHEMES = [ 'contrast', 'jetpack-cloud' ];
+
 const lineChartSource = fs.readFileSync( LINE_CHART, 'utf8' );
 const LINE_CHART_TOKENS = [ ...lineChartSource.matchAll( /useCssVariable\(\s*'(--[\w-]+)'/g ) ].map(
 	( m ) => m[ 1 ]
@@ -205,15 +214,51 @@ describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
 	} );
 
 	it.each( schemeNames )(
-		'bar chart series meet the 3:1 adjacency rule (each other and the surface) in the %s scheme',
+		'Views and Visitors meet the 3:1 pair-contrast rule against each other in the %s scheme',
 		( scheme ) => {
-			const surface = tokenValue( scheme, '--color-surface' );
 			const views = seriesHex( scheme, 'views' );
 			const visitors = seriesHex( scheme, 'visitors' );
 
-			expect( contrast( views, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
-			expect( contrast( visitors, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
 			expect( contrast( views, visitors ) ).toBeGreaterThanOrEqual( MIN_RATIO );
+		}
+	);
+
+	it.each( schemeNames )(
+		'Visitors meets the 3:1 contrast rule against the surface in the %s scheme',
+		( scheme ) => {
+			const surface = tokenValue( scheme, '--color-surface' );
+			const visitors = seriesHex( scheme, 'visitors' );
+
+			expect( contrast( visitors, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
+		}
+	);
+
+	it.each(
+		schemeNames.filter( ( scheme ) => ! VIEWS_VS_SURFACE_EXEMPT_SCHEMES.includes( scheme ) )
+	)( 'Views meets the 3:1 contrast rule against the surface in the %s scheme', ( scheme ) => {
+		const surface = tokenValue( scheme, '--color-surface' );
+		const views = seriesHex( scheme, 'views' );
+
+		expect( contrast( views, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
+	} );
+
+	it.each( VIEWS_VS_SURFACE_EXEMPT_SCHEMES )(
+		"Views is left untouched at the scheme's own --color-accent in the %s scheme, which is pre-existing and out of scope for the Views-vs-surface rule",
+		( scheme ) => {
+			const views = pairForScheme( scheme ).views;
+			const accent = tokenValue( scheme, '--color-accent' );
+
+			expect( views ).toBe( 'var(--color-accent)' );
+			expect( seriesHex( scheme, 'views' ) ).toBe( accent );
+		}
+	);
+
+	it.each( schemeNames.filter( ( scheme ) => ! VISITORS_100_ALLOWED_SCHEMES.includes( scheme ) ) )(
+		'Visitors does not resolve to --color-accent-100 in the %s scheme',
+		( scheme ) => {
+			const visitors = pairForScheme( scheme ).visitors;
+
+			expect( visitors ).not.toBe( 'var(--color-accent-100)' );
 		}
 	);
 
@@ -232,18 +277,6 @@ describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
 			new Set( [ SERIES.viewsBar, SERIES.visitorsBar ] )
 		);
 	} );
-
-	it.each( schemeNames )(
-		'line chart series each meet the 3:1 background-contrast rule (no adjacency requirement) in the %s scheme',
-		( scheme ) => {
-			const surface = tokenValue( scheme, '--color-surface' );
-			const views = seriesHex( scheme, 'views' );
-			const visitors = seriesHex( scheme, 'visitors' );
-
-			expect( contrast( views, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
-			expect( contrast( visitors, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
-		}
-	);
 
 	it( 'Odyssey widget mini-chart does not override the shared series colours', () => {
 		const source = fs.readFileSync( WIDGET_CHART, 'utf8' );

--- a/client/components/chart/test/chart-contrast.ts
+++ b/client/components/chart/test/chart-contrast.ts
@@ -238,8 +238,6 @@ const lineVisitorsHex = ( scheme: string ) => {
 	return resolved;
 };
 
-const lineViewsHex = ( scheme: string ) => tokenValue( scheme, '--color-accent-light' );
-
 const schemeNames = [ ...schemes.keys() ];
 
 // These schemes' Views colour is the scheme's raw wp-admin --color-accent
@@ -255,7 +253,9 @@ const lineChartSource = fs.readFileSync( LINE_CHART, 'utf8' );
 const LINE_CHART_TOKENS = [ ...lineChartSource.matchAll( /useCssVariable\(\s*'(--[\w-]+)'/g ) ].map(
 	( m ) => m[ 1 ]
 );
-const [ , LINE_CHART_VISITORS_TOKEN ] = LINE_CHART_TOKENS;
+const [ LINE_CHART_VIEWS_TOKEN, LINE_CHART_VISITORS_TOKEN ] = LINE_CHART_TOKENS;
+
+const lineViewsHex = ( scheme: string ) => tokenValue( scheme, LINE_CHART_VIEWS_TOKEN );
 
 describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
 	it( 'bar chart series read the shared --chart-series custom properties', () => {

--- a/client/components/chart/test/chart-contrast.ts
+++ b/client/components/chart/test/chart-contrast.ts
@@ -191,71 +191,15 @@ const seriesHex = ( scheme: string, series: 'views' | 'visitors' ) => {
 	return resolved;
 };
 
-const parseLineVisitorsRule = ( root: postcss.Root ) => {
-	let base: string | null = null;
-	const overrides = new Map< string, string >();
-	root.each( ( node ) => {
-		if ( node.type !== 'rule' ) {
-			return;
-		}
-		let value: string | null = null;
-		node.each( ( child ) => {
-			if ( child.type === 'decl' && child.prop === '--chart-line-visitors' ) {
-				value = child.value.trim();
-			}
-		} );
-		if ( ! value ) {
-			return;
-		}
-		for ( const selector of node.selectors ) {
-			if ( selector === ':root' ) {
-				base = value;
-				continue;
-			}
-			const schemeMatch = selector.match( /^\.color-scheme\.is-([\w-]+)$/ );
-			if ( schemeMatch ) {
-				overrides.set( schemeMatch[ 1 ], value );
-			}
-		}
-	} );
-	if ( ! base ) {
-		throw new Error( 'No :root base --chart-line-visitors rule found in chart/style.scss' );
-	}
-	return { base, overrides };
-};
-
-const { base: lineVisitorsBase, overrides: lineVisitorsOverrides } =
-	parseLineVisitorsRule( chartStyleRoot );
-
-const lineVisitorsHex = ( scheme: string ) => {
-	const value = lineVisitorsOverrides.get( scheme ) ?? lineVisitorsBase;
-	const resolved = resolve( value, scheme );
-	if ( ! resolved ) {
-		throw new Error(
-			`Could not resolve --chart-line-visitors (${ value }) for scheme ${ scheme }`
-		);
-	}
-	return resolved;
-};
-
 const schemeNames = [ ...schemes.keys() ];
 
-// These schemes' Views colour is the scheme's raw wp-admin --color-accent
-// highlight rather than a ramp step, so Views itself can fall short of 3:1
-// against the surface. Fixing that is out of scope for STATS-369 — it would
-// replace the scheme's deliberate muted identity with a saturated ramp
-// colour. The pair contrast (Views vs Visitors) is still required to pass.
-const VIEWS_VS_SURFACE_EXEMPT_SCHEMES = [ 'coffee', 'ocean', 'light', 'sunrise', 'ectoplasm' ];
-
-const VISITORS_100_ALLOWED_SCHEMES = [ 'contrast', 'jetpack-cloud' ];
+const VISITORS_100_ALLOWED_SCHEMES = [ 'contrast' ];
 
 const lineChartSource = fs.readFileSync( LINE_CHART, 'utf8' );
 const LINE_CHART_TOKENS = [ ...lineChartSource.matchAll( /useCssVariable\(\s*'(--[\w-]+)'/g ) ].map(
 	( m ) => m[ 1 ]
 );
 const [ LINE_CHART_VIEWS_TOKEN, LINE_CHART_VISITORS_TOKEN ] = LINE_CHART_TOKENS;
-
-const lineViewsHex = ( scheme: string ) => tokenValue( scheme, LINE_CHART_VIEWS_TOKEN );
 
 describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
 	it( 'bar chart series read the shared --chart-series custom properties', () => {
@@ -299,9 +243,7 @@ describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
 		}
 	);
 
-	it.each(
-		schemeNames.filter( ( scheme ) => ! VIEWS_VS_SURFACE_EXEMPT_SCHEMES.includes( scheme ) )
-	)(
+	it.each( schemeNames )(
 		'bar chart: Views meets the 3:1 contrast rule against the surface in the %s scheme',
 		( scheme ) => {
 			const surface = tokenValue( scheme, '--color-surface' );
@@ -325,45 +267,11 @@ describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
 		expect( SERIES.visitorsSwatch ).toBe( SERIES.visitorsBar );
 	} );
 
-	it( 'line chart declares exactly two distinct series colour tokens', () => {
+	it( 'line chart reads the same --chart-series-views and --chart-series-visitors tokens as the bar chart, keeping the shared legend correct', () => {
 		expect( LINE_CHART_TOKENS ).toHaveLength( 2 );
-		expect( LINE_CHART_TOKENS[ 0 ] ).not.toBe( LINE_CHART_TOKENS[ 1 ] );
+		expect( LINE_CHART_VIEWS_TOKEN ).toBe( SERIES.viewsBar );
+		expect( LINE_CHART_VISITORS_TOKEN ).toBe( SERIES.visitorsBar );
 	} );
-
-	it( 'line chart: tokens are entirely separate from the bar chart tokens', () => {
-		expect( LINE_CHART_TOKENS ).not.toContain( SERIES.viewsBar );
-		expect( LINE_CHART_TOKENS ).not.toContain( SERIES.visitorsBar );
-	} );
-
-	it( 'line chart: Visitors token is the dedicated --chart-line-visitors custom property', () => {
-		expect( LINE_CHART_VISITORS_TOKEN ).toBe( '--chart-line-visitors' );
-	} );
-
-	it.each( schemeNames )(
-		'line chart: has an explicit .color-scheme.is-%s rule declaring --chart-line-visitors',
-		( scheme ) => {
-			if ( ! lineVisitorsOverrides.has( scheme ) ) {
-				throw new Error(
-					`.color-scheme.is-${ scheme } has no explicit --chart-line-visitors rule in chart/style.scss. ` +
-						'A scheme cannot rely on the :root fallback: CSS substitutes var() at the element where a custom ' +
-						'property is declared, not where it is used, so --chart-line-visitors declared on :root resolves ' +
-						"--color-accent-dark against :root (the default scheme's ramp), not against this scheme's ramp. " +
-						`Add an explicit .color-scheme.is-${ scheme } rule with the declaration.`
-				);
-			}
-			expect( lineVisitorsOverrides.has( scheme ) ).toBe( true );
-		}
-	);
-
-	it.each( schemeNames )(
-		'line chart: Views and Visitors meet the 3:1 pair-contrast rule against each other in the %s scheme',
-		( scheme ) => {
-			const views = lineViewsHex( scheme );
-			const visitors = lineVisitorsHex( scheme );
-
-			expect( contrast( views, visitors ) ).toBeGreaterThanOrEqual( MIN_RATIO );
-		}
-	);
 
 	it( 'Odyssey widget mini-chart does not override the shared series colours', () => {
 		const source = fs.readFileSync( WIDGET_CHART, 'utf8' );

--- a/client/components/chart/test/chart-contrast.ts
+++ b/client/components/chart/test/chart-contrast.ts
@@ -136,36 +136,48 @@ const SERIES = {
 
 const schemeNames = [ ...schemes.keys() ];
 
-describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
-	it.each( schemeNames )( 'bar chart passes 3:1 in the %s scheme', ( scheme ) => {
-		const surface = tokenValue( scheme, '--color-surface' );
-		const views = tokenValue( scheme, SERIES.viewsBar );
-		const visitors = tokenValue( scheme, SERIES.visitorsBar );
+const lineChartSource = fs.readFileSync( LINE_CHART, 'utf8' );
+const LINE_CHART_TOKENS = [ ...lineChartSource.matchAll( /useCssVariable\(\s*'(--[\w-]+)'/g ) ].map(
+	( m ) => m[ 1 ]
+);
 
-		expect( contrast( views, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
-		expect( contrast( visitors, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
-		expect( contrast( views, visitors ) ).toBeGreaterThanOrEqual( MIN_RATIO );
-	} );
+describe( 'Stats chart series colours meet WCAG 1.4.11', () => {
+	it.each( schemeNames )(
+		'bar chart series meet the 3:1 adjacency rule (each other and the surface) in the %s scheme',
+		( scheme ) => {
+			const surface = tokenValue( scheme, '--color-surface' );
+			const views = tokenValue( scheme, SERIES.viewsBar );
+			const visitors = tokenValue( scheme, SERIES.visitorsBar );
+
+			expect( contrast( views, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
+			expect( contrast( visitors, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
+			expect( contrast( views, visitors ) ).toBeGreaterThanOrEqual( MIN_RATIO );
+		}
+	);
 
 	it( 'legend swatches use the same tokens as the bars they label', () => {
 		expect( SERIES.viewsSwatch ).toBe( SERIES.viewsBar );
 		expect( SERIES.visitorsSwatch ).toBe( SERIES.visitorsBar );
 	} );
 
-	it.each( schemeNames )( 'line chart passes 3:1 in the %s scheme', ( scheme ) => {
-		const source = fs.readFileSync( LINE_CHART, 'utf8' );
-		const tokens = [ ...source.matchAll( /useCssVariable\(\s*'(--[\w-]+)'/g ) ].map(
-			( m ) => m[ 1 ]
-		);
-		expect( tokens ).toHaveLength( 2 );
-
-		const surface = tokenValue( scheme, '--color-surface' );
-		const [ views, visitors ] = tokens.map( ( token ) => tokenValue( scheme, token ) );
-
-		expect( contrast( views, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
-		expect( contrast( visitors, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
-		expect( contrast( views, visitors ) ).toBeGreaterThanOrEqual( MIN_RATIO );
+	it( 'line chart declares exactly two distinct series colour tokens', () => {
+		expect( LINE_CHART_TOKENS ).toHaveLength( 2 );
+		expect( LINE_CHART_TOKENS[ 0 ] ).not.toBe( LINE_CHART_TOKENS[ 1 ] );
 	} );
+
+	it.each( schemeNames )(
+		'line chart series each meet the 3:1 background-contrast rule (no adjacency requirement) in the %s scheme',
+		( scheme ) => {
+			const surface = tokenValue( scheme, '--color-surface' );
+			const [ viewsToken, visitorsToken ] = LINE_CHART_TOKENS;
+			const views = tokenValue( scheme, viewsToken );
+			const visitors = tokenValue( scheme, visitorsToken );
+
+			expect( viewsToken ).not.toBe( visitorsToken );
+			expect( contrast( views, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
+			expect( contrast( visitors, surface ) ).toBeGreaterThanOrEqual( MIN_RATIO );
+		}
+	);
 
 	it( 'Odyssey widget mini-chart does not override the shared series colours', () => {
 		const source = fs.readFileSync( WIDGET_CHART, 'utf8' );

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -416,7 +416,7 @@ const withCssColors = ( WrappedComponent ) => {
 		const chartContainerRef = useRef( null );
 
 		const primaryColor = useCssVariable( '--color-accent-50', chartContainerRef.current );
-		const secondaryColor = useCssVariable( '--color-accent-100', chartContainerRef.current );
+		const secondaryColor = useCssVariable( '--color-accent-70', chartContainerRef.current );
 
 		return (
 			<WrappedComponent

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -415,8 +415,8 @@ const withCssColors = ( WrappedComponent ) => {
 	const WithCssColorsComponent = ( props ) => {
 		const chartContainerRef = useRef( null );
 
-		const primaryColor = useCssVariable( '--color-accent-light', chartContainerRef.current );
-		const secondaryColor = useCssVariable( '--chart-line-visitors', chartContainerRef.current );
+		const primaryColor = useCssVariable( '--chart-series-views', chartContainerRef.current );
+		const secondaryColor = useCssVariable( '--chart-series-visitors', chartContainerRef.current );
 
 		return (
 			<WrappedComponent

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -415,8 +415,8 @@ const withCssColors = ( WrappedComponent ) => {
 	const WithCssColorsComponent = ( props ) => {
 		const chartContainerRef = useRef( null );
 
-		const primaryColor = useCssVariable( '--color-accent-50', chartContainerRef.current );
-		const secondaryColor = useCssVariable( '--color-accent-70', chartContainerRef.current );
+		const primaryColor = useCssVariable( '--chart-series-views', chartContainerRef.current );
+		const secondaryColor = useCssVariable( '--chart-series-visitors', chartContainerRef.current );
 
 		return (
 			<WrappedComponent

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -415,8 +415,8 @@ const withCssColors = ( WrappedComponent ) => {
 	const WithCssColorsComponent = ( props ) => {
 		const chartContainerRef = useRef( null );
 
-		const primaryColor = useCssVariable( '--chart-series-views', chartContainerRef.current );
-		const secondaryColor = useCssVariable( '--chart-series-visitors', chartContainerRef.current );
+		const primaryColor = useCssVariable( '--color-accent-light', chartContainerRef.current );
+		const secondaryColor = useCssVariable( '--chart-line-visitors', chartContainerRef.current );
 
 		return (
 			<WrappedComponent

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -415,8 +415,8 @@ const withCssColors = ( WrappedComponent ) => {
 	const WithCssColorsComponent = ( props ) => {
 		const chartContainerRef = useRef( null );
 
-		const primaryColor = useCssVariable( '--color-accent-light', chartContainerRef.current );
-		const secondaryColor = useCssVariable( '--color-accent-dark', chartContainerRef.current );
+		const primaryColor = useCssVariable( '--color-accent-50', chartContainerRef.current );
+		const secondaryColor = useCssVariable( '--color-accent-100', chartContainerRef.current );
 
 		return (
 			<WrappedComponent

--- a/package.json
+++ b/package.json
@@ -307,6 +307,7 @@
 		"postcss": "^8.5.15",
 		"postcss-cli": "^9.0.1",
 		"postcss-custom-properties": "^12.1.11",
+		"postcss-scss": "^4.0.9",
 		"prettier": "npm:wp-prettier@3.0.3",
 		"react-refresh": "^0.17.0",
 		"readline-sync": "^1.4.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34066,6 +34066,7 @@ __metadata:
     postcss: "npm:^8.5.15"
     postcss-cli: "npm:^9.0.1"
     postcss-custom-properties: "npm:^12.1.11"
+    postcss-scss: "npm:^4.0.9"
     prettier: "npm:wp-prettier@3.0.3"
     react: "npm:19.2.7"
     react-dom: "npm:19.2.7"


### PR DESCRIPTION
Fixes STATS-369
Fixes STATS-380

## Why

A customer reported the Stats chart as "light blue on light blue" — the Views and Visitors bars are hard to tell apart. They are right, and it is not a perception issue: the two bars are `--color-accent` and `--color-accent-dark`, which are steps 50 and 70 of the same hue ramp. That is **1.68:1** against each other, where WCAG 2.1 SC 1.4.11 requires **3:1** for graphical objects. Two steps apart on one ramp can never reach 3:1, so every one of the 21 admin colour schemes fails, not just the default.

Measuring the rest of the chart turned up more of the same. The Views bar itself was as low as **2.10:1** against the white chart background in schemes whose `--color-accent` is the raw wp-admin highlight rather than a ramp step. The line chart was worse: it read `--color-accent-light`, down at **1.57:1**.

In total, **40 of the 42 chart-and-scheme combinations failed at least one threshold.**

## Proposed Changes

Two tokens, `--chart-series-views` and `--chart-series-visitors`, assigned per colour scheme. **The bar chart and the line chart both read them**, and so does the legend.

That last point forced the shape of this change. `stats-chart-tabs/chart-header.jsx` renders a **single** `<Legend>` for both modes — `chartType` only picks the toggle button's variant. So the legend can match at most one chart type unless both use the same colours. Making them match means one pair has to satisfy both geometries at once:

- **Bar chart** — the Visitors bar is nested inside the Views bar, so the two fills are adjacent: the **pair** needs ≥ 3:1, and Views needs ≥ 3:1 against the surface.
- **Line chart** — two strokes on the plot background: **each** needs ≥ 3:1 against the surface.

The union is Views ≥ 3:1 vs surface, Visitors ≥ 3:1 vs surface, and pair ≥ 3:1. All 21 schemes now meet all three, with no exemptions.

| Views | Visitors | Schemes |
| --- | --- | --- |
| `--color-accent-40` | `--color-accent-80` | aquatic, blue, classic-blue, coffee, fresh, light, nightfall, ocean, powder-snow, sakura, sunrise, sunset |
| `--color-accent-30` | `--color-accent-80` | classic-bright, classic-dark, global, midnight, modern |
| `--color-accent-40` | `--color-accent-90` | default |
| `--color-accent-50` | `--color-accent-100` | contrast |
| `--color-accent-50` | `--color-accent-90` | ectoplasm |
| `--color-accent-30` | `--color-accent-70` | jetpack-cloud |

Worst case across all 21 schemes and both chart types:

| | Before | After |
| --- | --- | --- |
| Views vs Visitors | 1.38:1 | **3.09:1** |
| Views vs background (bar) | 2.10:1 | **3.01:1** |
| Views vs background (line) | 1.57:1 | **3.01:1** |
| Visitors vs background | 6.35:1 | **10.03:1** |

Per-scheme pairs are not gold-plating — they are forced. The ramps are spaced differently in each scheme, so the lightest pair clearing all three thresholds differs. A single fixed pair does exist, but it drives Visitors to near-black (`#040f29`), which is a worse chart than a short lookup table.

`contrast` is the one scheme on `--color-accent-100`, where a very dark second series is the point. `jetpack-cloud` is the one scheme whose Visitors is *lighter* than its Views, because its accent is pure black — the direction it already ships in, now with enough separation (2.09:1 → 3.09:1).

### What this costs

Five schemes map `--color-accent` to the raw wp-admin highlight rather than a ramp step, and those highlights are pastels that cannot reach 3:1 against white by any route — `coffee` is a 36%-saturation beige, `ocean` a 17%-saturation sage. Moving them onto ramp steps is the only way to make them conform, and it visibly changes their character: coffee reads orange, ocean green. `jetpack-cloud` goes from black bars to grey.

I looked for a way to keep their muted identity. These schemes do define darker colours — `--theme-base-color` is a dark brown in coffee, 7.68:1 — but there is no ramp behind it: `--theme-base-color` versus `--theme-submenu-background-color` is about 1.3:1 in every scheme. And base is too dark to be Views (sitting 3:1 below 7.68:1 needs 23:1, past black) and too dark to be Visitors (Views would then have to fall under 2.56:1 and fail the background rule). There is no compliant pair among the admin theme colours.

Files:

* `client/components/chart/style.scss` — the token definitions, the bar fills, and the legend swatches.
* `client/my-sites/stats/stats-chart-tabs/index.jsx` — the line chart reads the same two tokens.
* `apps/odyssey-stats/src/widget/mini-chart.scss` — drops a local override that painted the widget's Visitors bar with `--color-primary-60`, one step lighter than the shared chart. It now inherits, which is what STATS-380 asked for. The placeholder bars also move off the hue-locked `--studio-blue-0` onto `--color-accent-0`.
* `client/components/chart/test/chart-contrast.ts` — the regression guard.
* `package.json` / `yarn.lock` — declares `postcss-scss`, which the test parses SCSS with. It was already resolved in the lockfile via `stylelint-scss`, so nothing new is installed.

`--color-accent` and `--color-accent-dark` keep their current definitions, because the Insights heat map, posting activity, the all-time table and the devices module read them as a sequential ramp.

### Screenshots

One row per scheme: bar before and after, then line before and after. Rendered from the real compiled colour-scheme CSS, with the "after" cells reading the branch's own `--chart-series-*` tokens. Every ratio is measured from the rendered pixels, and all three are shown per cell. Red is a WCAG failure.

**40 of the 42 "before" cells fail at least one threshold. None of the 42 "after" cells do.**

<img alt="Bar and line charts, before and after, across all 21 admin colour schemes" src="https://github.com/user-attachments/assets/3effe1a3-fcf4-4fbe-9987-027a3c564387" />

One thing that looks like a rendering error but is not: `classic-blue`, `coffee`, `sunrise` and `sunset` are identical in the line chart's "before" column. All four define `--color-accent-light` as `studio-orange-30` and `--color-accent-dark` as `studio-orange-70`, and the old line chart used only those two.

### One bug worth calling out

An earlier revision put the shared pair on `:root` and let most schemes inherit it. That silently did not work. **CSS substitutes `var()` where a custom property is declared, not where it is used** — so `:root { --chart-series-views: var(--color-accent-40) }` resolved against `:root`, and the resulting *colour* inherited. Schemes that redefine `--color-accent-40` further down the tree could not change it, and five of them rendered in the default scheme's blue regardless of the admin colour scheme.

The unit suite was green throughout, because it resolves tokens statically per scheme — modelling a re-resolution the browser never performs. It was only caught by rendering every scheme and noticing `classic-bright` came out blue instead of pink.

Every scheme now carries its own explicit rule, `:root` is only the fallback for when no scheme class is present at all, and the test asserts that no scheme relies on inheritance — so a scheme added later without a rule fails loudly instead of silently rendering in the wrong hue.

### The regression guard

`chart-contrast.ts` does not restate the chosen values. It parses `style.scss` with `postcss-scss` to rebuild the scheme→pair map, resolves each pair through the colour-scheme SCSS, and uses `chroma-js` for the contrast maths. 108 cases covering: all three thresholds for all 21 schemes with no exemptions; that every scheme has an explicit rule rather than inheriting; that the legend swatches use the same tokens as the bars; that the line chart reads those same tokens, which is what keeps the shared legend correct; and that `--color-accent-100` is confined to `contrast`.

Every assertion states a rule that will still be true in a year. There are deliberately none of the form "this PR did not change X" — that framing rots the moment it merges.

Known limitation, stated plainly: it measures flat token contrast, not the rendered output. It cannot see `color-mix`, alpha compositing, `@media` overrides, or the `var()` substitution semantics described above. Both bugs found on this branch were caught by rendering, not by the suite.

## Testing Instructions

1. Open Stats for a site with traffic. The Views bar is the accent colour; the nested Visitors bar is clearly darker and readable at a glance.
2. Toggle between the bar and line chart views. Both use the same two colours, and the legend swatches match either way.
3. Change the site's admin colour scheme to a non-blue one (`sunset`, `midnight`, `classic-bright`). Both series follow that scheme's own hue — the case the `var()` bug above broke.
4. Check the wp-admin Dashboard Stats widget: its Visitors bar and legend swatch now match the full chart instead of being a step lighter.
5. `yarn test-client client/components/chart/test/chart-contrast.ts` — 108 passing.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
