### PR TITLE
E2E: re-enable LOHP theme Premium-plan signup against the Multi-site Dashboard

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/lohp-theme-signup-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/lohp-theme-signup-flow.ts
@@ -1,14 +1,11 @@
 import { Page } from 'playwright';
 import {
-	cancelAtomicPurchaseFlow,
 	CartCheckoutPage,
 	DataHelper,
 	DomainSearchComponent,
 	LoggedOutHomePage,
 	LoggedOutThemesPage,
 	MyHomePage,
-	NoticeComponent,
-	PurchasesPage,
 	SignupPickPlanPage,
 	ThemesDetailPage,
 	UserSignupPage,
@@ -18,7 +15,6 @@ import {
  * Class encapsulating the flow when starting at the logged out home page (LOHP) and selecting a theme for a new site
  */
 export class LOHPThemeSignupFlow {
-	private page: Page;
 	readonly loggedOutHomePage: LoggedOutHomePage;
 	readonly loggedOutThemesPage: LoggedOutThemesPage;
 	readonly userSignupPage: UserSignupPage;
@@ -27,8 +23,6 @@ export class LOHPThemeSignupFlow {
 	readonly cartCheckoutPage: CartCheckoutPage;
 	readonly themesDetailPage: ThemesDetailPage;
 	readonly myHomePage: MyHomePage;
-	readonly purchasesPage: PurchasesPage;
-	readonly noticeComponent: NoticeComponent;
 
 	/**
 	 * Constructs an instance of the flow.
@@ -36,7 +30,6 @@ export class LOHPThemeSignupFlow {
 	 * @param {Page} page The underlying page.
 	 */
 	constructor( page: Page ) {
-		this.page = page;
 		this.loggedOutHomePage = new LoggedOutHomePage( page );
 		this.loggedOutThemesPage = new LoggedOutThemesPage( page );
 		this.userSignupPage = new UserSignupPage( page );
@@ -45,19 +38,6 @@ export class LOHPThemeSignupFlow {
 		this.cartCheckoutPage = new CartCheckoutPage( page );
 		this.themesDetailPage = new ThemesDetailPage( page );
 		this.myHomePage = new MyHomePage( page );
-		this.purchasesPage = new PurchasesPage( page );
-		this.noticeComponent = new NoticeComponent( page );
-	}
-
-	/**
-	 * Cancels the plan purchase during the flow.
-	 * @returns {Promise<void>}
-	 */
-	async cancelPlanPurchase(): Promise< void > {
-		await cancelAtomicPurchaseFlow( this.page, {
-			reason: 'Another reason…',
-			customReasonText: 'E2E TEST CANCELLATION',
-		} );
 	}
 
 	/**

--- a/test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts
@@ -1,8 +1,12 @@
 import {
+	DashboardMeSidebarComponent,
+	DashboardPurchasesPage,
+	DashboardSnackbarComponent,
 	NewSiteResponse,
 	NewTestUserDetails,
 	NewUserResponse,
 	RestAPIClient,
+	cancelDashboardPurchaseFlow,
 } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
 import { apiCloseAccount } from '../shared';
@@ -22,13 +26,11 @@ test.describe(
 		let testUserThemeSignup: NewTestUserDetails;
 		let newSiteDetails: NewSiteResponse;
 
-		// Skipped for now; can be updated once we're sure all onboarding tests will go
-		// through the MSD flow. See https://github.com/Automattic/wp-calypso/pull/112586
-		// and https://github.com/Automattic/wp-calypso/pull/112587.
-		test.skip( 'One: As a new WordPress.com user I can sign up for a new Premium plan site using a theme from the Logged Out Home Page', async ( {
+		test( 'One: As a new WordPress.com user I can sign up for a new Premium plan site using a theme from the Logged Out Home Page', async ( {
 			flowLOHPThemeSignup,
 			helperData,
 			secrets,
+			page,
 		} ) => {
 			let themeSlug: string | null = null;
 			const planName = 'Premium';
@@ -135,27 +137,32 @@ test.describe(
 				expect( theme ).toBe( `pub/${ themeSlug }` );
 			} );
 
-			await test.step( 'When I cancel my plan from the purchases page', async function () {
-				await flowLOHPThemeSignup.purchasesPage.visit();
+			await test.step( 'When I navigate to Billing > Active upgrades', async function () {
+				await page.goto( helperData.getDashboardURL( '/me' ) );
+				const meSidebar = new DashboardMeSidebarComponent( page );
+				await meSidebar.openMobileMenu();
+				await meSidebar.navigate( 'Billing' );
+				await page.getByRole( 'link', { name: 'Active upgrades', exact: true } ).click();
+			} );
 
-				await flowLOHPThemeSignup.purchasesPage.clickOnPurchase(
+			await test.step( 'When I cancel my plan', async function () {
+				const purchasesPage = new DashboardPurchasesPage( page );
+				await purchasesPage.clickOnPurchase(
 					`WordPress.com ${ planName }`,
 					newSiteDetails.blog_details.site_slug
 				);
-				await flowLOHPThemeSignup.purchasesPage.cancelPurchase( 'Cancel plan' );
-			} );
-
-			await test.step( 'And I confirm the cancellation', async function () {
-				await flowLOHPThemeSignup.cancelPlanPurchase();
+				await purchasesPage.cancelPurchase();
+				await cancelDashboardPurchaseFlow( page, {
+					reason: 'Another reason…',
+					customReasonText: 'E2E TEST CANCELLATION',
+				} );
 			} );
 
 			await test.step( 'Then I see a cancellation confirmation notice', async function () {
-				await flowLOHPThemeSignup.noticeComponent.noticeShown(
-					'Your refund has been processed and your purchase removed.',
-					{
-						timeout: 30000,
-					}
-				);
+				const snackbar = new DashboardSnackbarComponent( page );
+				await snackbar.noticeShown( 'Your refund has been processed and your purchase removed.', {
+					exact: true,
+				} );
 			} );
 		} );
 


### PR DESCRIPTION
Fixes DOTMSD-1446. Part of DOTMSD-1443.

## Proposed Changes

* Re-enable the skipped E2E test `One: As a new WordPress.com user I can sign up for a new Premium plan site using a theme from the Logged Out Home Page` in `signup__with-theme-LOHP.spec.ts` (removes the `test.skip`).
* Rewrite only the **cancellation half** for the Multi-site Dashboard: navigate `/me` → Billing → Active upgrades and cancel via `DashboardPurchasesPage` / `cancelDashboardPurchaseFlow` / `DashboardSnackbarComponent` (shared with the other re-enabled onboarding specs), replacing Calypso's Me > Purchases + `NoticeComponent`. The success snackbar is now a hard assertion.
* Drop the now-unused Calypso cancellation members (`purchasesPage`, `noticeComponent`, `cancelPlanPurchase`) from `LOHPThemeSignupFlow`.
* Signup, checkout, the theme-details step, the My Home landing, and the REST active-theme check are unchanged — new users still land where they used to; only cancellation moved to the MSD.

## Why are these changes being made?

New users now land in the Multi-site Dashboard, whose cancellation UI differs from Calypso's, so the old cancellation steps no longer applied and the test was skipped during the MSD rollout. DOTMSD-1443 tracks re-enabling these onboarding specs one file at a time; this is the sub-task for this file.

## Testing Instructions

Real purchase (Premium plan, USD + test coupon) — needs a local dev server, E2E secrets (test payment card + coupon), and ~4 min.

```bash
cd test/e2e
yarn playwright test \
  specs/onboarding/signup__with-theme-LOHP.spec.ts \
  --project=chrome --reporter=list
```

Signup from the LOHP → select a free theme → Premium plan checkout → coupon → purchase → onboarding → My Home → REST confirms the selected theme → MSD cancellation reaches the `Your refund has been processed and your purchase removed.` snackbar → `afterAll` API account cleanup passes.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
