### PR TITLE
Omnibar: show menu dropdown on hover

### DIFF
--- a/packages/omnibar/src/components/omnibar-menu.tsx
+++ b/packages/omnibar/src/components/omnibar-menu.tsx
@@ -1,6 +1,7 @@
 import { privateApis } from '@wordpress/components';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { Button } from '@wordpress/ui';
+import { useRef, useState } from 'react';
 import { OmnibarNodeContent } from './omnibar-node';
 import type { OmnibarNode } from '../types';
 
@@ -66,6 +67,9 @@ function OmnibarMenuContent( { nodes }: { nodes: OmnibarNode[] } ) {
 
 export function OmnibarMenu( { node, style }: { node: OmnibarNode; style?: React.CSSProperties } ) {
 	const label = node.title || node.label || '';
+	const [ isOpen, setIsOpen ] = useState( false );
+	const triggerRef = useRef< HTMLElement >( null );
+	const popoverRef = useRef< HTMLElement >( null );
 
 	if ( ! node.children ) {
 		return (
@@ -74,6 +78,7 @@ export function OmnibarMenu( { node, style }: { node: OmnibarNode; style?: React
 				className="omnibar__menu"
 				style={ style }
 				render={ node.href ? <a href={ node.href } /> : undefined }
+				nativeButton={ ! node.href }
 				onClick={ node.onClick }
 				aria-label={ label }
 			>
@@ -82,16 +87,36 @@ export function OmnibarMenu( { node, style }: { node: OmnibarNode; style?: React
 		);
 	}
 
+	const handleMouseLeave = ( event: React.MouseEvent ) => {
+		const movingTo = event.relatedTarget as Node | null;
+		if (
+			! triggerRef.current?.contains( movingTo ) &&
+			! popoverRef.current?.contains( movingTo )
+		) {
+			setIsOpen( false );
+		}
+	};
+
 	return (
-		<Menu>
+		<Menu open={ isOpen } onOpenChange={ setIsOpen }>
 			<Menu.TriggerButton
+				ref={ triggerRef }
+				onMouseEnter={ () => setIsOpen( true ) }
+				onMouseLeave={ handleMouseLeave }
 				render={
 					<Button variant="unstyled" className="omnibar__menu" style={ style } aria-label={ label }>
 						<OmnibarNodeContent node={ node } />
 					</Button>
 				}
 			/>
-			<Menu.Popover className="omnibar__popover" gutter={ 0 } overflowPadding={ 0 }>
+			<Menu.Popover
+				ref={ popoverRef }
+				className="omnibar__popover"
+				gutter={ 0 }
+				overflowPadding={ 0 }
+				modal={ false }
+				onMouseLeave={ handleMouseLeave }
+			>
 				<OmnibarMenuContent nodes={ node.children } />
 			</Menu.Popover>
 		</Menu>

--- a/packages/omnibar/src/components/omnibar.scss
+++ b/packages/omnibar/src/components/omnibar.scss
@@ -51,7 +51,7 @@ body:has( .omnibar ) {
 		cursor: pointer;
 
 		&:hover,
-		&:focus,
+		&:focus-visible,
 		&:active,
 		&[aria-expanded='true'] {
 			background-color: $omnibar-submenu-background;


### PR DESCRIPTION
## Proposed Changes

Open the omnibar's top-level menus on hover instead of on click, and close them as soon as the pointer leaves both the trigger and the dropdown.

Note that we need to handle the state manually, as there's no built-in way in `wp/components` / `wp/ui` to do this.

## Why are these changes being made?

We want to match React omnibar with PHP admin bar behavior.

## Testing Instructions

Test with `dashboard/omnibar-radical` flag turned on.