### PR TITLE
A4A MSD: Add the agency Overview tier card and page shell

### DIFF
--- a/client/dashboard/agency/overview/application-status-cards.tsx
+++ b/client/dashboard/agency/overview/application-status-cards.tsx
@@ -1,0 +1,127 @@
+import {
+	Button,
+	__experimentalHeading as Heading,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Icon,
+} from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { published } from '@wordpress/icons';
+import { ButtonStack } from '../../components/button-stack';
+import { Card, CardBody } from '../../components/card';
+import { caution } from '../../components/notice/icons';
+import { Text } from '../../components/text';
+import { PARTNER_PROGRAM_GUIDE_URL } from './constants';
+import NewTabLabel from './new-tab-label';
+import type { RecordTracksEvent } from '../tiers/types';
+import type { ReactNode } from 'react';
+
+function ApplicationStatusCard( {
+	decoration,
+	label,
+	heading,
+	children,
+}: {
+	decoration: ReactNode;
+	label: string;
+	heading: string;
+	children: ReactNode;
+} ) {
+	return (
+		<Card>
+			<CardBody>
+				<VStack spacing={ 4 }>
+					<HStack spacing={ 2 } justify="flex-start" expanded={ false }>
+						{ decoration }
+						<Text variant="muted" size={ 11 } weight={ 500 } lineHeight="16px" upperCase>
+							{ label }
+						</Text>
+					</HStack>
+					<VStack spacing={ 2 }>
+						<Heading level={ 2 } size={ 20 } weight={ 500 }>
+							{ heading }
+						</Heading>
+						{ children }
+					</VStack>
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}
+
+export function PendingTierCard( {
+	onRelaunchTour,
+	recordTracksEvent,
+}: {
+	onRelaunchTour?: () => void;
+	recordTracksEvent?: RecordTracksEvent;
+} ) {
+	return (
+		<ApplicationStatusCard
+			decoration={
+				<Icon icon={ published } size={ 24 } style={ { fill: 'var(--wp-admin-theme-color)' } } />
+			}
+			label={ __( 'Welcome' ) }
+			heading={ __( 'We’re reviewing your account' ) }
+		>
+			<Text variant="muted" lineHeight="20px">
+				{ __(
+					'While we review, you can’t make purchases yet, but feel free to explore the tools and set up your agency profile. Most are activated within one business day.'
+				) }
+			</Text>
+			<ButtonStack justify="flex-start" style={ { paddingTop: '8px' } }>
+				<Button
+					size="compact"
+					variant="primary"
+					href={ PARTNER_PROGRAM_GUIDE_URL }
+					target="_blank"
+					rel="noreferrer"
+					onClick={ () =>
+						recordTracksEvent?.( 'calypso_a4a_overview_tier_card_program_guide_click' )
+					}
+				>
+					<NewTabLabel>{ __( 'Read the partner program guide' ) }</NewTabLabel>
+				</Button>
+				{ onRelaunchTour && (
+					<Button
+						size="compact"
+						variant="tertiary"
+						onClick={ () => {
+							recordTracksEvent?.( 'calypso_a4a_overview_relaunch_welcome_tour_click' );
+							onRelaunchTour();
+						} }
+					>
+						{ __( 'Relaunch welcome tour' ) }
+					</Button>
+				) }
+			</ButtonStack>
+		</ApplicationStatusCard>
+	);
+}
+
+export function RejectedTierCard( { contactSupportHref }: { contactSupportHref: string } ) {
+	return (
+		<ApplicationStatusCard
+			decoration={
+				<Text intent="error" as="span">
+					<Icon icon={ caution } size={ 24 } fill="currentColor" />
+				</Text>
+			}
+			label={ __( 'Application status' ) }
+			heading={ __( 'Your application wasn’t approved' ) }
+		>
+			<Text variant="muted" lineHeight="20px">
+				{ __( 'We have not approved your application for the Automattic for Agencies program.' ) }
+			</Text>
+			<Text variant="muted" lineHeight="20px">
+				{ createInterpolateElement(
+					__(
+						'Please <a>contact support</a> to discuss this further if you think this was done in error.'
+					),
+					{ a: <a href={ contactSupportHref } /> }
+				) }
+			</Text>
+		</ApplicationStatusCard>
+	);
+}

--- a/client/dashboard/agency/overview/constants.ts
+++ b/client/dashboard/agency/overview/constants.ts
@@ -1,0 +1,45 @@
+import { __ } from '@wordpress/i18n';
+import type { AgencyTierType } from '../tiers/types';
+
+export const PARTNER_PROGRAM_GUIDE_URL =
+	'https://agencieshelp.automattic.com/knowledge-base/agency-tiering-benefits';
+
+export const PROGRAM_INCENTIVES_URL = 'https://automattic.com/for-agencies/program-incentives/';
+
+interface TierOverviewContent {
+	description: string;
+	hasPartnerManager: boolean;
+}
+
+export const TIER_OVERVIEW_CONTENT: Record< AgencyTierType, TierOverviewContent > = {
+	'emerging-partner': {
+		description: __(
+			'You’re in the program. Refer or buy one Automattic product a year to stay active.'
+		),
+		hasPartnerManager: false,
+	},
+	'agency-partner': {
+		description: __(
+			'Listed in agency directories, a partner badge, and early access to new features.'
+		),
+		hasPartnerManager: false,
+	},
+	'pro-agency-partner': {
+		description: __(
+			'Free agency hosting, a dedicated Partner Manager, priority support, and co-marketing.'
+		),
+		hasPartnerManager: true,
+	},
+	'vip-pro-agency-partner': {
+		description: __(
+			'Free agency hosting, a dedicated Partner Manager, priority support, and co-marketing.'
+		),
+		hasPartnerManager: true,
+	},
+	'premier-partner': {
+		description: __(
+			'Top tier — Marketing Development Funds, a Parse.ly trial, co-marketing and dedicated support.'
+		),
+		hasPartnerManager: true,
+	},
+};

--- a/client/dashboard/agency/overview/constants.ts
+++ b/client/dashboard/agency/overview/constants.ts
@@ -4,8 +4,6 @@ import type { AgencyTierType } from '../tiers/types';
 export const PARTNER_PROGRAM_GUIDE_URL =
 	'https://agencieshelp.automattic.com/knowledge-base/agency-tiering-benefits';
 
-export const PROGRAM_INCENTIVES_URL = 'https://automattic.com/for-agencies/program-incentives/';
-
 interface TierOverviewContent {
 	description: string;
 	hasPartnerManager: boolean;

--- a/client/dashboard/agency/overview/constants.ts
+++ b/client/dashboard/agency/overview/constants.ts
@@ -30,7 +30,7 @@ export const TIER_OVERVIEW_CONTENT: Record< AgencyTierType, TierOverviewContent 
 	},
 	'vip-pro-agency-partner': {
 		description: __(
-			'Free agency hosting, a dedicated Partner Manager, priority support, and co-marketing.'
+			'Everything in Pro, plus higher WordPress VIP referral commissions and annual extension credits.'
 		),
 		hasPartnerManager: true,
 	},

--- a/client/dashboard/agency/overview/index.tsx
+++ b/client/dashboard/agency/overview/index.tsx
@@ -1,15 +1,77 @@
-import { __ } from '@wordpress/i18n';
+import { activeAgencyQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { ExternalLink } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { useAnalytics } from '../../app/analytics';
+import { useLocale } from '../../app/locale';
 import FlashMessage from '../../components/flash-message';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { Text } from '../../components/text';
+import { formatDate } from '../../utils/datetime';
+import { useScheduleCall } from '../tiers/use-schedule-call';
+import AgencyOverviewContent from './overview-content';
+
+// TODO: the MSD dashboard has no contact-support entry point yet. This matches the
+// '#contact-support' placeholder in agency/tiers/constants.ts — wire both up together.
+const CONTACT_SUPPORT_URL = '#contact-support';
+
+function AgencyOverviewDescription( { url, createdAt }: { url?: string; createdAt?: string } ) {
+	const locale = useLocale();
+	const parsedDate = createdAt ? new Date( createdAt ) : undefined;
+	const joinedDate = parsedDate && ! isNaN( parsedDate.getTime() ) ? parsedDate : undefined;
+
+	return (
+		<Text variant="muted" lineHeight="20px">
+			{ url && <ExternalLink href={ url }>{ url.replace( /^https?:\/\//, '' ) }</ExternalLink> }
+			{ url && joinedDate && ' · ' }
+			{ joinedDate &&
+				sprintf(
+					/* translators: %s is the date the agency joined the program. */
+					__( 'Joined %s' ),
+					formatDate( joinedDate, locale )
+				) }
+		</Text>
+	);
+}
 
 export default function AgencyOverview() {
+	const { data: agency } = useQuery( activeAgencyQuery() );
+	const { recordTracksEvent } = useAnalytics();
+	const approvalStatus = agency?.approval_status;
+	const { scheduleCall, isLoading: isSchedulingCall } = useScheduleCall( agency?.id );
+
+	if ( ! agency ) {
+		return <PageLayout header={ <PageHeader title={ __( 'Overview' ) } /> } />;
+	}
+
 	return (
-		<PageLayout header={ <PageHeader description="This is a sample overview page." /> }>
+		<PageLayout
+			header={
+				<PageHeader
+					title={ agency.name }
+					description={
+						<AgencyOverviewDescription url={ agency.url } createdAt={ agency.created_at } />
+					}
+				/>
+			}
+		>
 			<FlashMessage
 				id="route-not-allowed"
 				type="error"
 				message={ __( 'You don’t have permission to view the requested page.' ) }
+			/>
+			<AgencyOverviewContent
+				tierId={ agency.tier?.id }
+				influencedRevenue={ agency.influenced_revenue ?? 0 }
+				approvalStatus={ approvalStatus }
+				links={ {
+					tiers: '/agency/tiers',
+					contactSupport: CONTACT_SUPPORT_URL,
+				} }
+				onScheduleCall={ scheduleCall }
+				isSchedulingCall={ isSchedulingCall }
+				recordTracksEvent={ recordTracksEvent }
 			/>
 		</PageLayout>
 	);

--- a/client/dashboard/agency/overview/new-tab-label.tsx
+++ b/client/dashboard/agency/overview/new-tab-label.tsx
@@ -1,0 +1,18 @@
+import { __experimentalHStack as HStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import type { ReactNode } from 'react';
+
+export default function NewTabLabel( {
+	children,
+	justify = 'center',
+}: {
+	children: ReactNode;
+	justify?: 'center' | 'flex-start';
+} ) {
+	return (
+		<HStack as="span" spacing={ 1 } justify={ justify } expanded={ false }>
+			<span>{ children }</span>
+			<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
+		</HStack>
+	);
+}

--- a/client/dashboard/agency/overview/overview-content.tsx
+++ b/client/dashboard/agency/overview/overview-content.tsx
@@ -1,0 +1,63 @@
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
+import TierOverviewCard from './tier-overview-card';
+import type { AgencyTierType, RecordTracksEvent } from '../tiers/types';
+import type { AgencyApprovalStatus } from '@automattic/api-core';
+
+export interface AgencyOverviewLinks {
+	tiers: string;
+	contactSupport: string;
+}
+
+export interface AgencyOverviewContentProps {
+	tierId?: AgencyTierType;
+	influencedRevenue: number;
+	/** Agencies predating the field report an empty string and are treated as approved. */
+	approvalStatus?: AgencyApprovalStatus | '';
+	links: AgencyOverviewLinks;
+	useRouterLink?: boolean;
+	onScheduleCall?: () => void;
+	isSchedulingCall?: boolean;
+	onRelaunchTour?: () => void;
+	recordTracksEvent?: RecordTracksEvent;
+}
+
+/**
+ * Shared body of the agency Overview screen. The dashboard and
+ * a8c-for-agencies both render it, each injecting its own data,
+ * links, and analytics client.
+ */
+export default function AgencyOverviewContent( {
+	tierId,
+	influencedRevenue,
+	approvalStatus,
+	links,
+	useRouterLink,
+	onScheduleCall,
+	isSchedulingCall,
+	onRelaunchTour,
+	recordTracksEvent,
+}: AgencyOverviewContentProps ) {
+	const isSmallViewport = useViewportMatch( 'medium', '<' );
+	const spacing = isSmallViewport ? 4 : 6;
+	const isPending = approvalStatus === 'pending';
+	const isRejected = approvalStatus === 'rejected';
+
+	return (
+		<VStack spacing={ spacing } justify="flex-start">
+			<TierOverviewCard
+				tierId={ tierId }
+				influencedRevenue={ influencedRevenue }
+				isPending={ isPending }
+				isRejected={ isRejected }
+				tiersHref={ links.tiers }
+				contactSupportHref={ links.contactSupport }
+				useRouterLink={ useRouterLink }
+				onScheduleCall={ onScheduleCall }
+				isSchedulingCall={ isSchedulingCall }
+				onRelaunchTour={ onRelaunchTour }
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		</VStack>
+	);
+}

--- a/client/dashboard/agency/overview/overview-content.tsx
+++ b/client/dashboard/agency/overview/overview-content.tsx
@@ -1,5 +1,6 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
+import { PendingTierCard, RejectedTierCard } from './application-status-cards';
 import TierOverviewCard from './tier-overview-card';
 import type { AgencyTierType, RecordTracksEvent } from '../tiers/types';
 import type { AgencyApprovalStatus } from '@automattic/api-core';
@@ -45,19 +46,24 @@ export default function AgencyOverviewContent( {
 
 	return (
 		<VStack spacing={ spacing } justify="flex-start">
-			<TierOverviewCard
-				tierId={ tierId }
-				influencedRevenue={ influencedRevenue }
-				isPending={ isPending }
-				isRejected={ isRejected }
-				tiersHref={ links.tiers }
-				contactSupportHref={ links.contactSupport }
-				useRouterLink={ useRouterLink }
-				onScheduleCall={ onScheduleCall }
-				isSchedulingCall={ isSchedulingCall }
-				onRelaunchTour={ onRelaunchTour }
-				recordTracksEvent={ recordTracksEvent }
-			/>
+			{ isRejected && <RejectedTierCard contactSupportHref={ links.contactSupport } /> }
+			{ isPending && (
+				<PendingTierCard
+					onRelaunchTour={ onRelaunchTour }
+					recordTracksEvent={ recordTracksEvent }
+				/>
+			) }
+			{ ! isRejected && ! isPending && (
+				<TierOverviewCard
+					tierId={ tierId }
+					influencedRevenue={ influencedRevenue }
+					tiersHref={ links.tiers }
+					useRouterLink={ useRouterLink }
+					onScheduleCall={ onScheduleCall }
+					isSchedulingCall={ isSchedulingCall }
+					recordTracksEvent={ recordTracksEvent }
+				/>
+			) }
 		</VStack>
 	);
 }

--- a/client/dashboard/agency/overview/tier-overview-card.tsx
+++ b/client/dashboard/agency/overview/tier-overview-card.tsx
@@ -215,7 +215,7 @@ export default function TierOverviewCard( {
 					{ showAdvisorCall && (
 						<TierFooterSection
 							label={ __( 'Your free advisor call' ) }
-							title={ __( 'Learn how to grow with Automattic' ) }
+							title={ __( 'Learn how to grow with Automattic.' ) }
 							action={
 								<Button
 									size="compact"

--- a/client/dashboard/agency/overview/tier-overview-card.tsx
+++ b/client/dashboard/agency/overview/tier-overview-card.tsx
@@ -1,0 +1,262 @@
+import {
+	Button,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Icon,
+} from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { published } from '@wordpress/icons';
+import { ButtonStack } from '../../components/button-stack';
+import { Card, CardBody } from '../../components/card';
+import { caution } from '../../components/notice/icons';
+import OverviewCard from '../../components/overview-card';
+import { Text } from '../../components/text';
+import getCurrentAgencyTier from '../tiers/get-current-agency-tier';
+import InfluencedRevenue from '../tiers/influenced-revenue';
+import { PARTNER_PROGRAM_GUIDE_URL, TIER_OVERVIEW_CONTENT } from './constants';
+import NewTabLabel from './new-tab-label';
+import type { AgencyTierType, RecordTracksEvent } from '../tiers/types';
+import type { ReactNode } from 'react';
+
+interface TierOverviewCardProps {
+	tierId?: AgencyTierType;
+	influencedRevenue: number;
+	isPending: boolean;
+	isRejected: boolean;
+	tiersHref: string;
+	contactSupportHref: string;
+	useRouterLink?: boolean;
+	onScheduleCall?: () => void;
+	isSchedulingCall?: boolean;
+	onRelaunchTour?: () => void;
+	recordTracksEvent?: RecordTracksEvent;
+}
+
+function ApplicationStatusCard( {
+	decoration,
+	label,
+	heading,
+	children,
+}: {
+	decoration: ReactNode;
+	label: string;
+	heading: string;
+	children: ReactNode;
+} ) {
+	return (
+		<Card>
+			<CardBody>
+				<VStack spacing={ 4 }>
+					<HStack spacing={ 2 } justify="flex-start" expanded={ false }>
+						{ decoration }
+						<Text variant="muted" size={ 11 } weight={ 500 } lineHeight="16px" upperCase>
+							{ label }
+						</Text>
+					</HStack>
+					<VStack spacing={ 2 }>
+						<Text size={ 20 } weight={ 500 } lineHeight="24px" as="h2">
+							{ heading }
+						</Text>
+						{ children }
+					</VStack>
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}
+
+function TierFooterSection( {
+	label,
+	title,
+	action,
+}: {
+	label: string;
+	title: string;
+	action: ReactNode;
+} ) {
+	return (
+		<VStack spacing={ 2 }>
+			<Text variant="muted" size={ 11 } weight={ 500 } lineHeight="16px" upperCase>
+				{ label }
+			</Text>
+			<HStack justify="space-between" alignment="center">
+				<Text lineHeight="20px">{ title }</Text>
+				{ action }
+			</HStack>
+		</VStack>
+	);
+}
+
+function PendingTierCard( {
+	onRelaunchTour,
+	recordTracksEvent,
+}: {
+	onRelaunchTour?: () => void;
+	recordTracksEvent?: RecordTracksEvent;
+} ) {
+	return (
+		<ApplicationStatusCard
+			decoration={
+				<Icon icon={ published } size={ 24 } style={ { fill: 'var(--wp-admin-theme-color)' } } />
+			}
+			label={ __( 'Welcome' ) }
+			heading={ __( 'We’re reviewing your account' ) }
+		>
+			<Text variant="muted" lineHeight="20px">
+				{ __(
+					'While we review, you can’t make purchases yet, but feel free to explore the tools and set up your agency profile. Most are activated within one business day.'
+				) }
+			</Text>
+			<ButtonStack justify="flex-start" style={ { paddingTop: '8px' } }>
+				<Button
+					size="compact"
+					variant="primary"
+					href={ PARTNER_PROGRAM_GUIDE_URL }
+					target="_blank"
+					rel="noreferrer"
+					onClick={ () =>
+						recordTracksEvent?.( 'calypso_a4a_overview_tier_card_program_guide_click' )
+					}
+				>
+					<NewTabLabel>{ __( 'Read the partner program guide' ) }</NewTabLabel>
+				</Button>
+				{ onRelaunchTour && (
+					<Button
+						size="compact"
+						variant="tertiary"
+						onClick={ () => {
+							recordTracksEvent?.( 'calypso_a4a_overview_relaunch_welcome_tour_click' );
+							onRelaunchTour();
+						} }
+					>
+						{ __( 'Relaunch welcome tour' ) }
+					</Button>
+				) }
+			</ButtonStack>
+		</ApplicationStatusCard>
+	);
+}
+
+function RejectedTierCard( { contactSupportHref }: { contactSupportHref: string } ) {
+	return (
+		<ApplicationStatusCard
+			decoration={
+				<Text intent="error" as="span">
+					<Icon icon={ caution } size={ 24 } fill="currentColor" />
+				</Text>
+			}
+			label={ __( 'Application status' ) }
+			heading={ __( 'Your application wasn’t approved' ) }
+		>
+			<Text variant="muted" lineHeight="20px">
+				{ __( 'We have not approved your application for the Automattic for Agencies program.' ) }
+			</Text>
+			<Text variant="muted" lineHeight="20px">
+				{ createInterpolateElement(
+					__(
+						'Please <a>contact support</a> to discuss this further if you think this was done in error.'
+					),
+					{ a: <a href={ contactSupportHref } /> }
+				) }
+			</Text>
+		</ApplicationStatusCard>
+	);
+}
+
+export default function TierOverviewCard( {
+	tierId,
+	influencedRevenue,
+	isPending,
+	isRejected,
+	tiersHref,
+	contactSupportHref,
+	useRouterLink,
+	onScheduleCall,
+	isSchedulingCall,
+	onRelaunchTour,
+	recordTracksEvent,
+}: TierOverviewCardProps ) {
+	if ( isRejected ) {
+		return <RejectedTierCard contactSupportHref={ contactSupportHref } />;
+	}
+
+	if ( isPending ) {
+		return (
+			<PendingTierCard onRelaunchTour={ onRelaunchTour } recordTracksEvent={ recordTracksEvent } />
+		);
+	}
+
+	const tier = getCurrentAgencyTier( tierId );
+	if ( ! tier ) {
+		return null;
+	}
+
+	const content = TIER_OVERVIEW_CONTENT[ tier.id ];
+	const showAdvisorCall = tier.level === 0 && !! onScheduleCall;
+	const showPartnerManager = content.hasPartnerManager && !! onScheduleCall;
+
+	return (
+		<OverviewCard
+			icon={ published }
+			title={ __( 'Your agency tier' ) }
+			heading={ tier.name }
+			description={ content.description }
+			link={ tiersHref }
+			useRouterLink={ useRouterLink }
+			tracksId="agency-overview-tier"
+			bottom={
+				<VStack spacing={ 4 }>
+					<InfluencedRevenue
+						currentAgencyTierId={ tierId }
+						totalInfluencedRevenue={ influencedRevenue }
+						recordTracksEvent={ recordTracksEvent }
+					/>
+					{ showAdvisorCall && (
+						<TierFooterSection
+							label={ __( 'Your free advisor call' ) }
+							title={ __( 'Learn how to grow with Automattic' ) }
+							action={
+								<Button
+									size="compact"
+									variant="secondary"
+									isBusy={ isSchedulingCall }
+									onClick={ () => {
+										recordTracksEvent?.( 'calypso_a4a_overview_tier_card_schedule_call_click', {
+											agency_tier: tier.id,
+										} );
+										onScheduleCall?.();
+									} }
+								>
+									{ __( 'Schedule your 30 minute advisor call' ) }
+								</Button>
+							}
+						/>
+					) }
+					{ showPartnerManager && (
+						<TierFooterSection
+							label={ __( 'Your partner manager' ) }
+							title={ __( 'Get strategic guidance from your dedicated partner manager.' ) }
+							action={
+								<Button
+									size="compact"
+									variant="secondary"
+									isBusy={ isSchedulingCall }
+									onClick={ () => {
+										recordTracksEvent?.(
+											'calypso_a4a_overview_partner_manager_schedule_call_click',
+											{ agency_tier: tier.id }
+										);
+										onScheduleCall?.();
+									} }
+								>
+									{ __( 'Schedule a check-in' ) }
+								</Button>
+							}
+						/>
+					) }
+				</VStack>
+			}
+		/>
+	);
+}

--- a/client/dashboard/agency/overview/tier-overview-card.tsx
+++ b/client/dashboard/agency/overview/tier-overview-card.tsx
@@ -2,68 +2,25 @@ import {
 	Button,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	Icon,
 } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { published } from '@wordpress/icons';
-import { ButtonStack } from '../../components/button-stack';
-import { Card, CardBody } from '../../components/card';
-import { caution } from '../../components/notice/icons';
 import OverviewCard from '../../components/overview-card';
 import { Text } from '../../components/text';
 import getCurrentAgencyTier from '../tiers/get-current-agency-tier';
 import InfluencedRevenue from '../tiers/influenced-revenue';
-import { PARTNER_PROGRAM_GUIDE_URL, TIER_OVERVIEW_CONTENT } from './constants';
-import NewTabLabel from './new-tab-label';
+import { TIER_OVERVIEW_CONTENT } from './constants';
 import type { AgencyTierType, RecordTracksEvent } from '../tiers/types';
 import type { ReactNode } from 'react';
 
 interface TierOverviewCardProps {
 	tierId?: AgencyTierType;
 	influencedRevenue: number;
-	isPending: boolean;
-	isRejected: boolean;
 	tiersHref: string;
-	contactSupportHref: string;
 	useRouterLink?: boolean;
 	onScheduleCall?: () => void;
 	isSchedulingCall?: boolean;
-	onRelaunchTour?: () => void;
 	recordTracksEvent?: RecordTracksEvent;
-}
-
-function ApplicationStatusCard( {
-	decoration,
-	label,
-	heading,
-	children,
-}: {
-	decoration: ReactNode;
-	label: string;
-	heading: string;
-	children: ReactNode;
-} ) {
-	return (
-		<Card>
-			<CardBody>
-				<VStack spacing={ 4 }>
-					<HStack spacing={ 2 } justify="flex-start" expanded={ false }>
-						{ decoration }
-						<Text variant="muted" size={ 11 } weight={ 500 } lineHeight="16px" upperCase>
-							{ label }
-						</Text>
-					</HStack>
-					<VStack spacing={ 2 }>
-						<Text size={ 20 } weight={ 500 } lineHeight="24px" as="h2">
-							{ heading }
-						</Text>
-						{ children }
-					</VStack>
-				</VStack>
-			</CardBody>
-		</Card>
-	);
 }
 
 function TierFooterSection( {
@@ -88,105 +45,15 @@ function TierFooterSection( {
 	);
 }
 
-function PendingTierCard( {
-	onRelaunchTour,
-	recordTracksEvent,
-}: {
-	onRelaunchTour?: () => void;
-	recordTracksEvent?: RecordTracksEvent;
-} ) {
-	return (
-		<ApplicationStatusCard
-			decoration={
-				<Icon icon={ published } size={ 24 } style={ { fill: 'var(--wp-admin-theme-color)' } } />
-			}
-			label={ __( 'Welcome' ) }
-			heading={ __( 'We’re reviewing your account' ) }
-		>
-			<Text variant="muted" lineHeight="20px">
-				{ __(
-					'While we review, you can’t make purchases yet, but feel free to explore the tools and set up your agency profile. Most are activated within one business day.'
-				) }
-			</Text>
-			<ButtonStack justify="flex-start" style={ { paddingTop: '8px' } }>
-				<Button
-					size="compact"
-					variant="primary"
-					href={ PARTNER_PROGRAM_GUIDE_URL }
-					target="_blank"
-					rel="noreferrer"
-					onClick={ () =>
-						recordTracksEvent?.( 'calypso_a4a_overview_tier_card_program_guide_click' )
-					}
-				>
-					<NewTabLabel>{ __( 'Read the partner program guide' ) }</NewTabLabel>
-				</Button>
-				{ onRelaunchTour && (
-					<Button
-						size="compact"
-						variant="tertiary"
-						onClick={ () => {
-							recordTracksEvent?.( 'calypso_a4a_overview_relaunch_welcome_tour_click' );
-							onRelaunchTour();
-						} }
-					>
-						{ __( 'Relaunch welcome tour' ) }
-					</Button>
-				) }
-			</ButtonStack>
-		</ApplicationStatusCard>
-	);
-}
-
-function RejectedTierCard( { contactSupportHref }: { contactSupportHref: string } ) {
-	return (
-		<ApplicationStatusCard
-			decoration={
-				<Text intent="error" as="span">
-					<Icon icon={ caution } size={ 24 } fill="currentColor" />
-				</Text>
-			}
-			label={ __( 'Application status' ) }
-			heading={ __( 'Your application wasn’t approved' ) }
-		>
-			<Text variant="muted" lineHeight="20px">
-				{ __( 'We have not approved your application for the Automattic for Agencies program.' ) }
-			</Text>
-			<Text variant="muted" lineHeight="20px">
-				{ createInterpolateElement(
-					__(
-						'Please <a>contact support</a> to discuss this further if you think this was done in error.'
-					),
-					{ a: <a href={ contactSupportHref } /> }
-				) }
-			</Text>
-		</ApplicationStatusCard>
-	);
-}
-
 export default function TierOverviewCard( {
 	tierId,
 	influencedRevenue,
-	isPending,
-	isRejected,
 	tiersHref,
-	contactSupportHref,
 	useRouterLink,
 	onScheduleCall,
 	isSchedulingCall,
-	onRelaunchTour,
 	recordTracksEvent,
 }: TierOverviewCardProps ) {
-	if ( isRejected ) {
-		return <RejectedTierCard contactSupportHref={ contactSupportHref } />;
-	}
-
-	if ( isPending ) {
-		return (
-			<PendingTierCard onRelaunchTour={ onRelaunchTour } recordTracksEvent={ recordTracksEvent } />
-		);
-	}
-
 	const tier = getCurrentAgencyTier( tierId );
 	if ( ! tier ) {
 		return null;

--- a/client/dashboard/agency/tiers/style.scss
+++ b/client/dashboard/agency/tiers/style.scss
@@ -11,6 +11,11 @@
 // https://wordpress.github.io/gutenberg/?path=/docs/components-progressbar--docs#with-custom-width
 .agency-tiers-influenced-revenue-bar {
 	width: 100%;
+
+	// ProgressBar has no colour prop: its track and indicator both derive from
+	// `--wp-components-color-foreground`, so rebind it here to keep the override
+	// scoped to the bar.
+	--wp-components-color-foreground: var(--wp-admin-theme-color);
 }
 
 // Wrapper provides the gradient fade — must sit outside the scroll container

--- a/client/dashboard/components/overview-card/index.tsx
+++ b/client/dashboard/components/overview-card/index.tsx
@@ -49,6 +49,9 @@ export interface OverviewCardProps {
 
 	upsellFeatureId?: string;
 
+	/** Set to false in apps outside the dashboard's TanStack Router, so relative links render as plain anchors. */
+	useRouterLink?: boolean;
+
 	bottom?: ReactNode;
 	onClick?: () => void;
 }
@@ -66,6 +69,7 @@ export default function OverviewCard( {
 	externalLink: externalLinkProp,
 	tracksId,
 	upsellFeatureId,
+	useRouterLink = true,
 	bottom,
 	onClick,
 }: OverviewCardProps ) {
@@ -93,15 +97,19 @@ export default function OverviewCard( {
 	const isRelativeLink = link && isRelativeUrl( link ) && ! isOnboarding;
 
 	let relativeLink: string | undefined = undefined;
-	let onboardingLink: string | undefined = undefined;
+	let plainAnchorLink: string | undefined = undefined;
 	let externalLink: string | undefined = undefined;
 
 	if ( externalLinkProp ) {
 		externalLink = externalLinkProp;
 	} else if ( isOnboarding ) {
-		onboardingLink = link;
+		plainAnchorLink = link;
 	} else if ( isRelativeLink ) {
-		relativeLink = link;
+		if ( useRouterLink ) {
+			relativeLink = link;
+		} else {
+			plainAnchorLink = link;
+		}
 	} else {
 		externalLink = link;
 	}
@@ -127,7 +135,7 @@ export default function OverviewCard( {
 							{ title }
 						</Text>
 					</HStack>
-					{ ( relativeLink || onboardingLink ) && ! progress && (
+					{ ( relativeLink || plainAnchorLink ) && ! progress && (
 						<Icon
 							className="dashboard-overview-card__link-icon"
 							icon={ isRTL() ? chevronLeft : chevronRight }
@@ -211,10 +219,10 @@ export default function OverviewCard( {
 			);
 		}
 
-		if ( onboardingLink ) {
+		if ( plainAnchorLink ) {
 			return (
 				<a
-					href={ onboardingLink }
+					href={ plainAnchorLink }
 					className="dashboard-overview-card__link"
 					onClick={ handleClick }
 				>

--- a/packages/api-core/src/agency/types.ts
+++ b/packages/api-core/src/agency/types.ts
@@ -7,6 +7,8 @@ export type AgencyTierId =
 
 export type AgencyTierStatus = 'early_access' | 'tier_protected';
 
+export type AgencyApprovalStatus = 'pending' | 'approved' | 'rejected';
+
 export interface AgencyTier {
 	id?: AgencyTierId;
 	label?: string;
@@ -51,6 +53,7 @@ export interface Agency {
 		allowed: boolean;
 	};
 	influenced_revenue?: number;
+	approval_status?: AgencyApprovalStatus | '';
 	created_at: string;
 	billing_system?: 'billingdragon' | 'legacy';
 	user?: {

--- a/packages/api-queries/src/agency.ts
+++ b/packages/api-queries/src/agency.ts
@@ -50,9 +50,7 @@ export const agencyQuery = () =>
 			return agency;
 		},
 		// Agency membership rarely changes within a session, so we avoid
-		// refetching on every mount, focus, and route-guard check. Not persisted,
-		// so a page reload always revalidates.
-		meta: { persist: false },
+		// refetching on every mount, focus, and route-guard check.
 		staleTime: 5 * 60 * 1000,
 	} );
 

--- a/packages/api-queries/src/agency.ts
+++ b/packages/api-queries/src/agency.ts
@@ -50,7 +50,9 @@ export const agencyQuery = () =>
 			return agency;
 		},
 		// Agency membership rarely changes within a session, so we avoid
-		// refetching on every mount, focus, and route-guard check.
+		// refetching on every mount, focus, and route-guard check. Not persisted,
+		// so a page reload always revalidates.
+		meta: { persist: false },
 		staleTime: 5 * 60 * 1000,
 	} );
 
@@ -68,6 +70,9 @@ export const activeAgencyQuery = () =>
 			}
 			return null;
 		},
+		// Not persisted: tier, influenced revenue and approval status change server-side
+		// and are shown prominently on the overview, so a reload must revalidate them.
+		meta: { persist: false },
 		staleTime: 5 * 60 * 1000,
 		retry: false,
 	} );


### PR DESCRIPTION
Part of A4A-2840.

## Proposed Changes

* First slice of the revamped agency Overview screen: a page header with the agency's name, site link, and join date, and the agency tier card below it.
* The tier card shows the current tier, influenced revenue progress toward the next tier, and a scheduling action — the free advisor call for agencies on the starter tier, or a check-in with the dedicated partner manager on higher tiers.
* While an agency application is under review, the card shows a welcome state with a link to the partner program guide (opens in a new tab). Declined applications see a notice with a contact-support link.
* Groundwork used by the card:
  * The agency data now includes the account approval status, and is refreshed on page reload so tier, revenue, and status stay current.
  * Overview cards can render their link as a plain anchor, so the card also works in apps outside the new dashboard's router (needed when the classic agencies dashboard adopts this screen).
  * The influenced-revenue progress bar picks up the admin theme color.

The card lives in a router-free shared component so the classic agencies dashboard can reuse it in a follow-up PR.

Render tests covering the tier card’s states (pending, declined, per-tier actions) will be added in a follow-up PR stacked on this one.

## Why are these changes being made?

* This starts the Overview screen revamp (A4A-2840): a single overview that works in both the new agency dashboard and the classic agencies dashboard, built once as shared components.

## Testing Instructions

* Open the Dashboard Live (A4A) link > Replace the `/sites` in the URL with `/overview` to see the A4A dashboard.
* The header shows your agency name, site, and join date.
* The tier card shows your tier, description, and influenced revenue progress; clicking the card opens the Tiers page.
* On the starter tier, the advisor-call action appears; on tiers with a partner manager, the check-in action appears. Both open the scheduling flow.
* As an agency with a pending application, the card shows the "We're reviewing your account" state; a declined application shows the not-approved notice.

Agency pending state:

<img width="1352" height="482" alt="Screenshot 2026-08-03 at 3 21 20 PM" src="https://github.com/user-attachments/assets/a63e6f69-1133-4693-abed-982ae7b12b49" />

Agency rejected state:

<img width="1352" height="470" alt="Screenshot 2026-08-03 at 2 50 57 PM" src="https://github.com/user-attachments/assets/c78283a1-29a8-4900-8e35-daa667e659ce" />

When no tier is set or an emerging tier:

<img width="1352" height="482" alt="Screenshot 2026-08-03 at 2 51 23 PM" src="https://github.com/user-attachments/assets/48610243-2523-4290-b872-4608cfc56142" />

Other partner tiers:

<img width="1352" height="482" alt="Screenshot 2026-08-03 at 2 53 41 PM" src="https://github.com/user-attachments/assets/49524d45-d4b1-473d-b5fe-e754fbdf9815" />

<img width="1352" height="482" alt="Screenshot 2026-08-03 at 2 54 09 PM" src="https://github.com/user-attachments/assets/5073884c-29f0-4153-8037-755baca27d18" />

<img width="1352" height="476" alt="Screenshot 2026-08-04 at 12 14 57 PM" src="https://github.com/user-attachments/assets/0797e345-4eec-418b-af64-d588163cb5b4" />

<img width="1352" height="482" alt="Screenshot 2026-08-03 at 2 54 34 PM" src="https://github.com/user-attachments/assets/4bd0253c-b717-43e7-9f26-ad718eedbe69" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
