### PR TITLE
A4A MSD: Add Overview earnings, event, and helpful links cards

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayment-landing/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayment-landing/index.tsx
@@ -1,9 +1,4 @@
-import {
-	JetpackLicenseFilter,
-	JetpackLicenseSortField,
-	JetpackLicenseSortDirection,
-} from '@automattic/api-core';
-import { jetpackAgencyLicensesQuery } from '@automattic/api-queries';
+import { wooPaymentsLicensesQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
@@ -23,12 +18,7 @@ const WooPaymentsLanding = () => {
 	const agencyId = useSelector( getActiveAgencyId );
 
 	const { data: licenses, isFetched } = useQuery( {
-		...jetpackAgencyLicensesQuery( agencyId ?? 0, {
-			filter: JetpackLicenseFilter.Attached,
-			search: 'woopayments',
-			sortField: JetpackLicenseSortField.IssuedAt,
-			sortDirection: JetpackLicenseSortDirection.Descending,
-		} ),
+		...wooPaymentsLicensesQuery( agencyId ?? 0 ),
 		enabled: !! agencyId,
 		refetchOnWindowFocus: false,
 	} );

--- a/client/dashboard/agency/earn/woopayments/use-woopayments-dashboard-data.ts
+++ b/client/dashboard/agency/earn/woopayments/use-woopayments-dashboard-data.ts
@@ -1,13 +1,9 @@
 import {
-	JetpackLicenseFilter,
-	JetpackLicenseSortField,
-	JetpackLicenseSortDirection,
-} from '@automattic/api-core';
-import {
 	agencySitesWithPluginsQuery,
 	agencyWooPaymentsDataQuery,
-	jetpackAgencyLicensesQuery,
 	jetpackTestConnectionQuery,
+	wooPaymentsLicensesQuery,
+	WOOPAYMENTS_PLUGIN,
 } from '@automattic/api-queries';
 import { useQueries, useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
@@ -54,12 +50,7 @@ export interface WooPaymentsDashboardData {
  */
 export default function useWooPaymentsDashboardData( agencyId: number ): WooPaymentsDashboardData {
 	const { data: licenseSites, isLoading: isLoadingLicensesWithWooPayments } = useQuery( {
-		...jetpackAgencyLicensesQuery( agencyId, {
-			filter: JetpackLicenseFilter.Attached,
-			search: 'woopayments',
-			sortField: JetpackLicenseSortField.IssuedAt,
-			sortDirection: JetpackLicenseSortDirection.Descending,
-		} ),
+		...wooPaymentsLicensesQuery( agencyId ),
 		enabled: !! agencyId,
 		refetchOnWindowFocus: false,
 		select: ( licenses ) =>
@@ -71,7 +62,7 @@ export default function useWooPaymentsDashboardData( agencyId: number ): WooPaym
 	} );
 
 	const { isLoading: isLoadingSitesWithPlugins, data: sitesWithPlugins } = useQuery( {
-		...agencySitesWithPluginsQuery( agencyId, [ 'woocommerce-payments/woocommerce-payments' ] ),
+		...agencySitesWithPluginsQuery( agencyId, [ WOOPAYMENTS_PLUGIN ] ),
 		enabled: !! agencyId,
 		refetchOnWindowFocus: false,
 	} );

--- a/client/dashboard/agency/overview/constants.ts
+++ b/client/dashboard/agency/overview/constants.ts
@@ -4,6 +4,8 @@ import type { AgencyTierType } from '../tiers/types';
 export const PARTNER_PROGRAM_GUIDE_URL =
 	'https://agencieshelp.automattic.com/knowledge-base/agency-tiering-benefits';
 
+export const PROGRAM_INCENTIVES_URL = 'https://automattic.com/for-agencies/program-incentives/';
+
 interface TierOverviewContent {
 	description: string;
 	hasPartnerManager: boolean;

--- a/client/dashboard/agency/overview/event-card.tsx
+++ b/client/dashboard/agency/overview/event-card.tsx
@@ -1,0 +1,69 @@
+import {
+	Button,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { ButtonStack } from '../../components/button-stack';
+import { Card, CardBody } from '../../components/card';
+import { Text } from '../../components/text';
+import { FEATURED_EVENT } from './events';
+import NewTabLabel from './new-tab-label';
+import type { RecordTracksEvent } from '../tiers/types';
+
+interface EventCardProps {
+	recordTracksEvent?: RecordTracksEvent;
+}
+
+export default function EventCard( { recordTracksEvent }: EventCardProps ) {
+	if ( ! FEATURED_EVENT ) {
+		return null;
+	}
+
+	const { id, logo, logoAlt, when, title, subtitle, description, ctaLabel, url } = FEATURED_EVENT;
+
+	return (
+		<Card>
+			<CardBody>
+				<VStack spacing={ 4 }>
+					<HStack spacing={ 3 } justify="flex-start" alignment="center">
+						{ logo && <img src={ logo } alt={ logoAlt ?? '' } width={ 64 } height={ 64 } /> }
+						<VStack spacing={ 1 }>
+							<Text variant="muted" size={ 11 } weight={ 500 } lineHeight="16px" upperCase>
+								{ when }
+							</Text>
+							<Text size={ 15 } weight={ 500 } lineHeight="20px" as="h2">
+								{ title }
+							</Text>
+							<Text variant="muted" size={ 12 } lineHeight="16px">
+								{ subtitle }
+							</Text>
+						</VStack>
+					</HStack>
+					<VStack spacing={ 4 }>
+						{ description.map( ( paragraph ) => (
+							<Text key={ paragraph } lineHeight="20px">
+								{ paragraph }
+							</Text>
+						) ) }
+					</VStack>
+					<ButtonStack justify="flex-start">
+						<Button
+							size="compact"
+							variant="secondary"
+							href={ url }
+							target="_blank"
+							rel="noreferrer"
+							onClick={ () =>
+								recordTracksEvent?.( 'calypso_a4a_overview_event_register_click', {
+									event_id: id,
+								} )
+							}
+						>
+							<NewTabLabel>{ ctaLabel }</NewTabLabel>
+						</Button>
+					</ButtonStack>
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/agency/overview/event-card.tsx
+++ b/client/dashboard/agency/overview/event-card.tsx
@@ -41,7 +41,7 @@ export default function EventCard( { recordTracksEvent }: EventCardProps ) {
 					</HStack>
 					<VStack spacing={ 4 }>
 						{ description.map( ( paragraph ) => (
-							<Text key={ paragraph } lineHeight="20px">
+							<Text key={ paragraph } size={ 13 } lineHeight="20px">
 								{ paragraph }
 							</Text>
 						) ) }

--- a/client/dashboard/agency/overview/event-card.tsx
+++ b/client/dashboard/agency/overview/event-card.tsx
@@ -1,5 +1,6 @@
 import {
 	Button,
+	__experimentalHeading as Heading,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -15,7 +16,7 @@ interface EventCardProps {
 }
 
 export default function EventCard( { recordTracksEvent }: EventCardProps ) {
-	if ( ! FEATURED_EVENT ) {
+	if ( ! FEATURED_EVENT || new Date() >= new Date( FEATURED_EVENT.endsAt ) ) {
 		return null;
 	}
 
@@ -31,9 +32,9 @@ export default function EventCard( { recordTracksEvent }: EventCardProps ) {
 							<Text variant="muted" size={ 11 } weight={ 500 } lineHeight="16px" upperCase>
 								{ when }
 							</Text>
-							<Text size={ 15 } weight={ 500 } lineHeight="20px" as="h2">
+							<Heading level={ 2 } size={ 15 } weight={ 500 } lineHeight="20px">
 								{ title }
-							</Text>
+							</Heading>
 							<Text variant="muted" size={ 12 } lineHeight="16px">
 								{ subtitle }
 							</Text>

--- a/client/dashboard/agency/overview/events.ts
+++ b/client/dashboard/agency/overview/events.ts
@@ -16,13 +16,15 @@ export interface FeaturedEvent {
 	description: string[];
 	ctaLabel: string;
 	url: string;
+	/** ISO date the card stops showing itself, typically the day after the event. */
+	endsAt: string;
 }
 
 /**
  * The event promoted on the agency overview, curated by hand.
  *
- * Replace the whole object when the next event comes round, and set it to `null`
- * in between — the card hides itself rather than advertising a past event. The
+ * Replace the whole object when the next event comes round — the card hides
+ * itself once `endsAt` passes rather than advertising a past event. The
  * legacy list lives in client/a8c-for-agencies/sections/overview/body/events.
  */
 export const FEATURED_EVENT: FeaturedEvent | null = {
@@ -42,4 +44,5 @@ export const FEATURED_EVENT: FeaturedEvent | null = {
 	],
 	ctaLabel: __( 'Get your spot!' ),
 	url: 'https://us.wordcamp.org/2026/',
+	endsAt: '2026-08-20',
 };

--- a/client/dashboard/agency/overview/events.ts
+++ b/client/dashboard/agency/overview/events.ts
@@ -1,0 +1,45 @@
+import { __ } from '@wordpress/i18n';
+
+export interface FeaturedEvent {
+	/** Used as the `event_id` tracks property, so keep it stable per event. */
+	id: string;
+	/**
+	 * Square event logo, rendered at 64px. Prefer a hosted URL over a committed
+	 * asset. Optional, so the card still renders without one.
+	 */
+	logo?: string;
+	logoAlt?: string;
+	when: string;
+	title: string;
+	subtitle: string;
+	/** One entry per paragraph. */
+	description: string[];
+	ctaLabel: string;
+	url: string;
+}
+
+/**
+ * The event promoted on the agency overview, curated by hand.
+ *
+ * Replace the whole object when the next event comes round, and set it to `null`
+ * in between — the card hides itself rather than advertising a past event. The
+ * legacy list lives in client/a8c-for-agencies/sections/overview/body/events.
+ */
+export const FEATURED_EVENT: FeaturedEvent | null = {
+	id: 'a4a-wordcamp-us-2026',
+	logo: 'https://automattic.wordpress.com/wp-content/uploads/2026/07/wcus_2026.png',
+	logoAlt: __( 'WordCamp US 2026' ),
+	when: __( 'August 16th–19th, Phoenix, Arizona' ),
+	title: __( 'Join us at WordCamp US 2026!' ),
+	subtitle: __( 'Automattic for Agencies' ),
+	description: [
+		__(
+			'Join us at WordCamp US in Phoenix, August 16 to 19 at the Phoenix Convention Center. The Automattic for Agencies team will be there, along with the people behind WordPress.com, Pressable, WordPress VIP, Woo, and Jetpack.'
+		),
+		__(
+			'Come talk shop with our partner managers, get answers in person, and grab a pin while they last.'
+		),
+	],
+	ctaLabel: __( 'Get your spot!' ),
+	url: 'https://us.wordcamp.org/2026/',
+};

--- a/client/dashboard/agency/overview/helpful-links-card.tsx
+++ b/client/dashboard/agency/overview/helpful-links-card.tsx
@@ -1,0 +1,58 @@
+import { __ } from '@wordpress/i18n';
+import SummaryButton from '../../components/summary-button';
+import { SummaryButtonList } from '../../components/summary-button-list';
+import NewTabLabel from './new-tab-label';
+import type { RecordTracksEvent } from '../tiers/types';
+
+export interface HelpfulLink {
+	id: string;
+	label: string;
+	href?: string;
+	/** Opens in a new tab. `SummaryButton` has no `target`, so the click is handled here. */
+	isExternal?: boolean;
+	onClick?: () => void;
+}
+
+interface HelpfulLinksCardProps {
+	links: HelpfulLink[];
+	recordTracksEvent?: RecordTracksEvent;
+}
+
+export default function HelpfulLinksCard( { links, recordTracksEvent }: HelpfulLinksCardProps ) {
+	return (
+		<SummaryButtonList title={ __( 'Helpful links' ) }>
+			{ links.map( ( link ) => (
+				<SummaryButton
+					key={ link.id }
+					title={
+						link.isExternal ? (
+							<NewTabLabel justify="flex-start">{ link.label }</NewTabLabel>
+						) : (
+							link.label
+						)
+					}
+					href={ link.href }
+					showArrow={ false }
+					onClick={ ( event ) => {
+						recordTracksEvent?.( 'calypso_a4a_overview_helpful_link_click', {
+							link_id: link.id,
+						} );
+						// Leave modifier clicks to the browser so they keep their native
+						// new-tab and new-window behavior.
+						if (
+							link.isExternal &&
+							link.href &&
+							! event.metaKey &&
+							! event.ctrlKey &&
+							! event.shiftKey
+						) {
+							event.preventDefault();
+							window.open( link.href, '_blank', 'noreferrer' );
+						}
+						link.onClick?.();
+					} }
+				/>
+			) ) }
+		</SummaryButtonList>
+	);
+}

--- a/client/dashboard/agency/overview/helpful-links-card.tsx
+++ b/client/dashboard/agency/overview/helpful-links-card.tsx
@@ -8,7 +8,7 @@ export interface HelpfulLink {
 	id: string;
 	label: string;
 	href?: string;
-	/** Opens in a new tab. `SummaryButton` has no `target`, so the click is handled here. */
+	/** Opens the link in a new tab. */
 	isExternal?: boolean;
 	onClick?: () => void;
 }
@@ -32,23 +32,13 @@ export default function HelpfulLinksCard( { links, recordTracksEvent }: HelpfulL
 						)
 					}
 					href={ link.href }
+					target={ link.isExternal ? '_blank' : undefined }
+					rel={ link.isExternal ? 'noreferrer' : undefined }
 					showArrow={ false }
-					onClick={ ( event ) => {
+					onClick={ () => {
 						recordTracksEvent?.( 'calypso_a4a_overview_helpful_link_click', {
 							link_id: link.id,
 						} );
-						// Leave modifier clicks to the browser so they keep their native
-						// new-tab and new-window behavior.
-						if (
-							link.isExternal &&
-							link.href &&
-							! event.metaKey &&
-							! event.ctrlKey &&
-							! event.shiftKey
-						) {
-							event.preventDefault();
-							window.open( link.href, '_blank', 'noreferrer' );
-						}
 						link.onClick?.();
 					} }
 				/>

--- a/client/dashboard/agency/overview/index.tsx
+++ b/client/dashboard/agency/overview/index.tsx
@@ -10,6 +10,7 @@ import PageLayout from '../../components/page-layout';
 import { Text } from '../../components/text';
 import { formatDate } from '../../utils/datetime';
 import { useScheduleCall } from '../tiers/use-schedule-call';
+import { PROGRAM_INCENTIVES_URL } from './constants';
 import AgencyOverviewContent from './overview-content';
 
 // TODO: the MSD dashboard has no contact-support entry point yet. This matches the
@@ -38,6 +39,7 @@ function AgencyOverviewDescription( { url, createdAt }: { url?: string; createdA
 export default function AgencyOverview() {
 	const { data: agency } = useQuery( activeAgencyQuery() );
 	const { recordTracksEvent } = useAnalytics();
+	const agencyId = agency?.id ?? 0;
 	const approvalStatus = agency?.approval_status;
 	const { scheduleCall, isLoading: isSchedulingCall } = useScheduleCall( agency?.id );
 
@@ -62,12 +64,29 @@ export default function AgencyOverview() {
 				message={ __( 'You don’t have permission to view the requested page.' ) }
 			/>
 			<AgencyOverviewContent
+				agencyId={ agencyId }
 				tierId={ agency.tier?.id }
 				influencedRevenue={ agency.influenced_revenue ?? 0 }
 				approvalStatus={ approvalStatus }
 				links={ {
 					tiers: '/agency/tiers',
+					referrals: '/earn/referrals',
+					woopayments: '/earn/woopayments',
 					contactSupport: CONTACT_SUPPORT_URL,
+					helpful: [
+						{
+							// TODO: wire up once the MSD dashboard has a contact-support entry
+							// point (see CONTACT_SUPPORT_URL above).
+							id: 'contact-support',
+							label: __( 'Contact sales & support' ),
+						},
+						{
+							id: 'program-incentives',
+							label: __( 'Program incentive details' ),
+							href: PROGRAM_INCENTIVES_URL,
+							isExternal: true,
+						},
+					],
 				} }
 				onScheduleCall={ scheduleCall }
 				isSchedulingCall={ isSchedulingCall }

--- a/client/dashboard/agency/overview/index.tsx
+++ b/client/dashboard/agency/overview/index.tsx
@@ -68,6 +68,7 @@ export default function AgencyOverview() {
 				tierId={ agency.tier?.id }
 				influencedRevenue={ agency.influenced_revenue ?? 0 }
 				approvalStatus={ approvalStatus }
+				capabilities={ agency.user?.capabilities }
 				links={ {
 					tiers: '/agency/tiers',
 					referrals: '/earn/referrals',

--- a/client/dashboard/agency/overview/overview-content.tsx
+++ b/client/dashboard/agency/overview/overview-content.tsx
@@ -1,16 +1,26 @@
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import { __experimentalGrid as Grid, __experimentalVStack as VStack } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
 import { PendingTierCard, RejectedTierCard } from './application-status-cards';
+import EventCard from './event-card';
+import HelpfulLinksCard from './helpful-links-card';
+import ReferralEarningsCard from './referral-earnings-card';
 import TierOverviewCard from './tier-overview-card';
+import WooPaymentsRevenueCard from './woopayments-revenue-card';
+import type { HelpfulLink } from './helpful-links-card';
 import type { AgencyTierType, RecordTracksEvent } from '../tiers/types';
 import type { AgencyApprovalStatus } from '@automattic/api-core';
 
 export interface AgencyOverviewLinks {
 	tiers: string;
+	referrals: string;
+	woopayments: string;
 	contactSupport: string;
+	helpful: HelpfulLink[];
 }
 
 export interface AgencyOverviewContentProps {
+	agencyId: number;
 	tierId?: AgencyTierType;
 	influencedRevenue: number;
 	/** Agencies predating the field report an empty string and are treated as approved. */
@@ -29,6 +39,7 @@ export interface AgencyOverviewContentProps {
  * links, and analytics client.
  */
 export default function AgencyOverviewContent( {
+	agencyId,
 	tierId,
 	influencedRevenue,
 	approvalStatus,
@@ -43,27 +54,52 @@ export default function AgencyOverviewContent( {
 	const spacing = isSmallViewport ? 4 : 6;
 	const isPending = approvalStatus === 'pending';
 	const isRejected = approvalStatus === 'rejected';
+	// A rejection is already spelled out by the tier card, so only pending accounts get the note.
+	const isLocked = isPending || isRejected;
+	const lockedNote = isPending ? __( 'Unlocks when your account is activated' ) : undefined;
 
 	return (
-		<VStack spacing={ spacing } justify="flex-start">
-			{ isRejected && <RejectedTierCard contactSupportHref={ links.contactSupport } /> }
-			{ isPending && (
-				<PendingTierCard
-					onRelaunchTour={ onRelaunchTour }
-					recordTracksEvent={ recordTracksEvent }
-				/>
-			) }
-			{ ! isRejected && ! isPending && (
-				<TierOverviewCard
-					tierId={ tierId }
-					influencedRevenue={ influencedRevenue }
-					tiersHref={ links.tiers }
+		<Grid columns={ isSmallViewport ? 1 : 2 } gap={ spacing }>
+			<VStack spacing={ spacing } justify="flex-start">
+				{ isRejected && <RejectedTierCard contactSupportHref={ links.contactSupport } /> }
+				{ isPending && (
+					<PendingTierCard
+						onRelaunchTour={ onRelaunchTour }
+						recordTracksEvent={ recordTracksEvent }
+					/>
+				) }
+				{ ! isRejected && ! isPending && (
+					<TierOverviewCard
+						tierId={ tierId }
+						influencedRevenue={ influencedRevenue }
+						tiersHref={ links.tiers }
+						useRouterLink={ useRouterLink }
+						onScheduleCall={ onScheduleCall }
+						isSchedulingCall={ isSchedulingCall }
+						recordTracksEvent={ recordTracksEvent }
+					/>
+				) }
+				<ReferralEarningsCard
+					agencyId={ agencyId }
+					locked={ isLocked }
+					lockedNote={ lockedNote }
+					referralsHref={ links.referrals }
 					useRouterLink={ useRouterLink }
-					onScheduleCall={ onScheduleCall }
-					isSchedulingCall={ isSchedulingCall }
 					recordTracksEvent={ recordTracksEvent }
 				/>
-			) }
-		</VStack>
+				<WooPaymentsRevenueCard
+					agencyId={ agencyId }
+					locked={ isLocked }
+					lockedNote={ lockedNote }
+					woopaymentsHref={ links.woopayments }
+					useRouterLink={ useRouterLink }
+					recordTracksEvent={ recordTracksEvent }
+				/>
+			</VStack>
+			<VStack spacing={ spacing } justify="flex-start">
+				<EventCard recordTracksEvent={ recordTracksEvent } />
+				<HelpfulLinksCard links={ links.helpful } recordTracksEvent={ recordTracksEvent } />
+			</VStack>
+		</Grid>
 	);
 }

--- a/client/dashboard/agency/overview/overview-content.tsx
+++ b/client/dashboard/agency/overview/overview-content.tsx
@@ -11,6 +11,10 @@ import type { HelpfulLink } from './helpful-links-card';
 import type { AgencyTierType, RecordTracksEvent } from '../tiers/types';
 import type { AgencyApprovalStatus } from '@automattic/api-core';
 
+// The WooPayments routes gate on the referrals capability too (see
+// a8c-for-agencies/lib/permission.ts), so one capability locks both earning cards.
+const REFERRALS_CAPABILITY = 'a4a_read_referrals';
+
 export interface AgencyOverviewLinks {
 	tiers: string;
 	referrals: string;
@@ -25,8 +29,10 @@ export interface AgencyOverviewContentProps {
 	influencedRevenue: number;
 	/** Agencies predating the field report an empty string and are treated as approved. */
 	approvalStatus?: AgencyApprovalStatus | '';
+	/** The current user's agency capabilities; the earning cards lock without referrals access. */
+	capabilities?: string[];
 	links: AgencyOverviewLinks;
-	useRouterLink?: boolean;
+	shouldUseRouterLink?: boolean;
 	onScheduleCall?: () => void;
 	isSchedulingCall?: boolean;
 	onRelaunchTour?: () => void;
@@ -43,8 +49,9 @@ export default function AgencyOverviewContent( {
 	tierId,
 	influencedRevenue,
 	approvalStatus,
+	capabilities,
 	links,
-	useRouterLink,
+	shouldUseRouterLink,
 	onScheduleCall,
 	isSchedulingCall,
 	onRelaunchTour,
@@ -54,8 +61,9 @@ export default function AgencyOverviewContent( {
 	const spacing = isSmallViewport ? 4 : 6;
 	const isPending = approvalStatus === 'pending';
 	const isRejected = approvalStatus === 'rejected';
+	const canAccessEarnings = ! capabilities || capabilities.includes( REFERRALS_CAPABILITY );
 	// A rejection is already spelled out by the tier card, so only pending accounts get the note.
-	const isLocked = isPending || isRejected;
+	const isLocked = isPending || isRejected || ! canAccessEarnings;
 	const lockedNote = isPending ? __( 'Unlocks when your account is activated' ) : undefined;
 
 	return (
@@ -73,7 +81,7 @@ export default function AgencyOverviewContent( {
 						tierId={ tierId }
 						influencedRevenue={ influencedRevenue }
 						tiersHref={ links.tiers }
-						useRouterLink={ useRouterLink }
+						shouldUseRouterLink={ shouldUseRouterLink }
 						onScheduleCall={ onScheduleCall }
 						isSchedulingCall={ isSchedulingCall }
 						recordTracksEvent={ recordTracksEvent }
@@ -84,7 +92,7 @@ export default function AgencyOverviewContent( {
 					locked={ isLocked }
 					lockedNote={ lockedNote }
 					referralsHref={ links.referrals }
-					useRouterLink={ useRouterLink }
+					shouldUseRouterLink={ shouldUseRouterLink }
 					recordTracksEvent={ recordTracksEvent }
 				/>
 				<WooPaymentsRevenueCard
@@ -92,7 +100,7 @@ export default function AgencyOverviewContent( {
 					locked={ isLocked }
 					lockedNote={ lockedNote }
 					woopaymentsHref={ links.woopayments }
-					useRouterLink={ useRouterLink }
+					shouldUseRouterLink={ shouldUseRouterLink }
 					recordTracksEvent={ recordTracksEvent }
 				/>
 			</VStack>

--- a/client/dashboard/agency/overview/overview-link-button.tsx
+++ b/client/dashboard/agency/overview/overview-link-button.tsx
@@ -1,0 +1,39 @@
+import { Button } from '@wordpress/components';
+import RouterLinkButton from '../../components/router-link-button';
+import type { ComponentProps, ReactNode } from 'react';
+
+interface OverviewLinkButtonProps {
+	href: string;
+	children: ReactNode;
+	variant?: ComponentProps< typeof Button >[ 'variant' ];
+	size?: ComponentProps< typeof Button >[ 'size' ];
+	onClick?: React.MouseEventHandler< HTMLAnchorElement >;
+	/**
+	 * Set to false in apps without the dashboard's TanStack Router, so the button
+	 * renders a plain anchor for the host app's own router to pick up.
+	 */
+	useRouterLink?: boolean;
+}
+
+export default function OverviewLinkButton( {
+	href,
+	children,
+	variant,
+	size,
+	onClick,
+	useRouterLink = true,
+}: OverviewLinkButtonProps ) {
+	if ( useRouterLink ) {
+		return (
+			<RouterLinkButton to={ href } variant={ variant } size={ size } onClick={ onClick }>
+				{ children }
+			</RouterLinkButton>
+		);
+	}
+
+	return (
+		<Button href={ href } variant={ variant } size={ size } onClick={ onClick }>
+			{ children }
+		</Button>
+	);
+}

--- a/client/dashboard/agency/overview/overview-link-button.tsx
+++ b/client/dashboard/agency/overview/overview-link-button.tsx
@@ -12,7 +12,7 @@ interface OverviewLinkButtonProps {
 	 * Set to false in apps without the dashboard's TanStack Router, so the button
 	 * renders a plain anchor for the host app's own router to pick up.
 	 */
-	useRouterLink?: boolean;
+	shouldUseRouterLink?: boolean;
 }
 
 export default function OverviewLinkButton( {
@@ -21,9 +21,9 @@ export default function OverviewLinkButton( {
 	variant,
 	size,
 	onClick,
-	useRouterLink = true,
+	shouldUseRouterLink = true,
 }: OverviewLinkButtonProps ) {
-	if ( useRouterLink ) {
+	if ( shouldUseRouterLink ) {
 		return (
 			<RouterLinkButton to={ href } variant={ variant } size={ size } onClick={ onClick }>
 				{ children }

--- a/client/dashboard/agency/overview/referral-earnings-card.tsx
+++ b/client/dashboard/agency/overview/referral-earnings-card.tsx
@@ -3,6 +3,7 @@ import { formatCurrency, formatNumber } from '@automattic/number-formatters';
 import { Badge } from '@automattic/ui';
 import { useQuery } from '@tanstack/react-query';
 import {
+	__experimentalHeading as Heading,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -21,7 +22,7 @@ interface ReferralEarningsCardProps {
 	locked?: boolean;
 	lockedNote?: string;
 	referralsHref: string;
-	useRouterLink?: boolean;
+	shouldUseRouterLink?: boolean;
 	recordTracksEvent?: RecordTracksEvent;
 }
 
@@ -29,20 +30,20 @@ function ReferralEarningsEmptyState( {
 	locked,
 	lockedNote,
 	referralsHref,
-	useRouterLink,
+	shouldUseRouterLink,
 	recordTracksEvent,
 }: {
 	locked?: boolean;
 	lockedNote?: string;
 	referralsHref: string;
-	useRouterLink?: boolean;
+	shouldUseRouterLink?: boolean;
 	recordTracksEvent?: RecordTracksEvent;
 } ) {
 	return (
 		<VStack spacing={ 4 }>
-			<Text size={ 15 } weight={ 500 } lineHeight="20px" as="h2">
+			<Heading level={ 2 } size={ 15 } weight={ 500 } lineHeight="20px">
 				{ __( 'Referral earnings' ) }
-			</Text>
+			</Heading>
 			<Text variant="muted" lineHeight="20px">
 				{ __(
 					'Earn 20% recurring commissions on hosting and 50% on plugins when you refer clients through your dashboard.'
@@ -59,7 +60,7 @@ function ReferralEarningsEmptyState( {
 						size="compact"
 						variant="secondary"
 						href={ referralsHref }
-						useRouterLink={ useRouterLink }
+						shouldUseRouterLink={ shouldUseRouterLink }
 						onClick={ () =>
 							recordTracksEvent?.( 'calypso_a4a_overview_referrals_make_referral_click' )
 						}
@@ -72,12 +73,14 @@ function ReferralEarningsEmptyState( {
 	);
 }
 
+// Not OverviewCard: it renders the whole card as a single link, while this card
+// needs inline actions and non-interactive stat rows.
 export default function ReferralEarningsCard( {
 	agencyId,
 	locked,
 	lockedNote,
 	referralsHref,
-	useRouterLink,
+	shouldUseRouterLink,
 	recordTracksEvent,
 }: ReferralEarningsCardProps ) {
 	const { data: referrals = [], isLoading: isLoadingReferrals } = useQuery( {
@@ -102,7 +105,7 @@ export default function ReferralEarningsCard( {
 						locked={ locked }
 						lockedNote={ lockedNote }
 						referralsHref={ referralsHref }
-						useRouterLink={ useRouterLink }
+						shouldUseRouterLink={ shouldUseRouterLink }
 						recordTracksEvent={ recordTracksEvent }
 					/>
 				</CardBody>
@@ -118,9 +121,9 @@ export default function ReferralEarningsCard( {
 		<Card>
 			<CardBody>
 				<VStack spacing={ 4 }>
-					<Text size={ 15 } weight={ 500 } lineHeight="20px" as="h2">
+					<Heading level={ 2 } size={ 15 } weight={ 500 } lineHeight="20px">
 						{ __( 'Referral earnings' ) }
-					</Text>
+					</Heading>
 					<HStack spacing={ 2 } justify="flex-start" alignment="baseline" expanded={ false }>
 						<Text size={ 20 } weight={ 500 } lineHeight="24px">
 							{ isLoading ? (
@@ -152,7 +155,7 @@ export default function ReferralEarningsCard( {
 							size="compact"
 							variant="secondary"
 							href={ referralsHref }
-							useRouterLink={ useRouterLink }
+							shouldUseRouterLink={ shouldUseRouterLink }
 							onClick={ () =>
 								recordTracksEvent?.( 'calypso_a4a_overview_referrals_view_details_click' )
 							}

--- a/client/dashboard/agency/overview/referral-earnings-card.tsx
+++ b/client/dashboard/agency/overview/referral-earnings-card.tsx
@@ -1,0 +1,167 @@
+import { referralCommissionPayoutQuery, referralsQuery } from '@automattic/api-queries';
+import { formatCurrency, formatNumber } from '@automattic/number-formatters';
+import { Badge } from '@automattic/ui';
+import { useQuery } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { ButtonStack } from '../../components/button-stack';
+import { Card, CardBody } from '../../components/card';
+import { Text } from '../../components/text';
+import { TextSkeleton } from '../../components/text-skeleton';
+import useConsolidatedPayoutData from '../earn/referrals/hooks/use-consolidated-payout-data';
+import OverviewLinkButton from './overview-link-button';
+import StatList from './stat-list';
+import type { RecordTracksEvent } from '../tiers/types';
+
+interface ReferralEarningsCardProps {
+	agencyId: number;
+	locked?: boolean;
+	lockedNote?: string;
+	referralsHref: string;
+	useRouterLink?: boolean;
+	recordTracksEvent?: RecordTracksEvent;
+}
+
+function ReferralEarningsEmptyState( {
+	locked,
+	lockedNote,
+	referralsHref,
+	useRouterLink,
+	recordTracksEvent,
+}: {
+	locked?: boolean;
+	lockedNote?: string;
+	referralsHref: string;
+	useRouterLink?: boolean;
+	recordTracksEvent?: RecordTracksEvent;
+} ) {
+	return (
+		<VStack spacing={ 4 }>
+			<Text size={ 15 } weight={ 500 } lineHeight="20px" as="h2">
+				{ __( 'Referral earnings' ) }
+			</Text>
+			<Text variant="muted" lineHeight="20px">
+				{ __(
+					'Earn 20% recurring commissions on hosting and 50% on plugins when you refer clients through your dashboard.'
+				) }
+			</Text>
+			{ lockedNote && (
+				<HStack justify="flex-start" expanded={ false }>
+					<Badge>{ lockedNote }</Badge>
+				</HStack>
+			) }
+			{ ! locked && (
+				<ButtonStack justify="flex-start">
+					<OverviewLinkButton
+						size="compact"
+						variant="secondary"
+						href={ referralsHref }
+						useRouterLink={ useRouterLink }
+						onClick={ () =>
+							recordTracksEvent?.( 'calypso_a4a_overview_referrals_make_referral_click' )
+						}
+					>
+						{ __( 'Make a referral' ) }
+					</OverviewLinkButton>
+				</ButtonStack>
+			) }
+		</VStack>
+	);
+}
+
+export default function ReferralEarningsCard( {
+	agencyId,
+	locked,
+	lockedNote,
+	referralsHref,
+	useRouterLink,
+	recordTracksEvent,
+}: ReferralEarningsCardProps ) {
+	const { data: referrals = [], isLoading: isLoadingReferrals } = useQuery( {
+		...referralsQuery( agencyId ),
+		enabled: !! agencyId && ! locked,
+	} );
+	const { data: referralCommissionPayout, isLoading: isLoadingPayout } = useQuery( {
+		...referralCommissionPayoutQuery( agencyId ),
+		enabled: !! agencyId && ! locked,
+	} );
+	const isLoading = isLoadingReferrals || isLoadingPayout;
+	const { previousQuarterExpectedCommission, currentQuarterExpectedCommission } =
+		useConsolidatedPayoutData( referrals );
+
+	const hasReferrals = referrals.length > 0;
+
+	if ( locked || ( ! hasReferrals && ! isLoading ) ) {
+		return (
+			<Card>
+				<CardBody>
+					<ReferralEarningsEmptyState
+						locked={ locked }
+						lockedNote={ lockedNote }
+						referralsHref={ referralsHref }
+						useRouterLink={ useRouterLink }
+						recordTracksEvent={ recordTracksEvent }
+					/>
+				</CardBody>
+			</Card>
+		);
+	}
+
+	const activeReferrals = referrals.filter( ( referral ) =>
+		referral.referralStatuses.includes( 'active' )
+	).length;
+
+	return (
+		<Card>
+			<CardBody>
+				<VStack spacing={ 4 }>
+					<Text size={ 15 } weight={ 500 } lineHeight="20px" as="h2">
+						{ __( 'Referral earnings' ) }
+					</Text>
+					<HStack spacing={ 2 } justify="flex-start" alignment="baseline" expanded={ false }>
+						<Text size={ 20 } weight={ 500 } lineHeight="24px">
+							{ isLoading ? (
+								<TextSkeleton length={ 6 } />
+							) : (
+								formatCurrency( currentQuarterExpectedCommission, 'USD' )
+							) }
+						</Text>
+						<Text intent="success" size={ 12 } lineHeight="16px">
+							{ __( 'estimated this quarter' ) }
+						</Text>
+					</HStack>
+					<StatList
+						isLoading={ isLoading }
+						stats={ [
+							{ label: __( 'Active referrals' ), value: formatNumber( activeReferrals ) },
+							{
+								label: __( 'Pending payout' ),
+								value: formatCurrency( previousQuarterExpectedCommission, 'USD' ),
+							},
+							{
+								label: __( 'Lifetime earnings' ),
+								value: formatCurrency( referralCommissionPayout?.total_commission ?? 0, 'USD' ),
+							},
+						] }
+					/>
+					<ButtonStack justify="flex-start">
+						<OverviewLinkButton
+							size="compact"
+							variant="secondary"
+							href={ referralsHref }
+							useRouterLink={ useRouterLink }
+							onClick={ () =>
+								recordTracksEvent?.( 'calypso_a4a_overview_referrals_view_details_click' )
+							}
+						>
+							{ __( 'View referral details' ) }
+						</OverviewLinkButton>
+					</ButtonStack>
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/agency/overview/stat-list.tsx
+++ b/client/dashboard/agency/overview/stat-list.tsx
@@ -1,0 +1,33 @@
+import {
+	__experimentalDivider as Divider,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { Fragment } from 'react';
+import { Text } from '../../components/text';
+import { TextSkeleton } from '../../components/text-skeleton';
+
+interface Stat {
+	label: string;
+	value: string;
+}
+
+export default function StatList( { stats, isLoading }: { stats: Stat[]; isLoading?: boolean } ) {
+	return (
+		<VStack spacing={ 2 }>
+			{ stats.map( ( stat, index ) => (
+				<Fragment key={ stat.label }>
+					{ index > 0 && <Divider style={ { color: 'var(--dashboard-header__divider-color)' } } /> }
+					<HStack justify="space-between">
+						<Text variant="muted" lineHeight="20px">
+							{ stat.label }
+						</Text>
+						<Text weight={ 500 } lineHeight="20px">
+							{ isLoading ? <TextSkeleton length={ 5 } /> : stat.value }
+						</Text>
+					</HStack>
+				</Fragment>
+			) ) }
+		</VStack>
+	);
+}

--- a/client/dashboard/agency/overview/stat-list.tsx
+++ b/client/dashboard/agency/overview/stat-list.tsx
@@ -15,17 +15,17 @@ interface Stat {
 export default function StatList( { stats, isLoading }: { stats: Stat[]; isLoading?: boolean } ) {
 	return (
 		<VStack spacing={ 2 }>
-			{ stats.map( ( stat, index ) => (
+			{ stats.map( ( stat ) => (
 				<Fragment key={ stat.label }>
-					{ index > 0 && <Divider style={ { color: 'var(--dashboard-header__divider-color)' } } /> }
 					<HStack justify="space-between">
-						<Text variant="muted" lineHeight="20px">
+						<Text variant="muted" size={ 13 } lineHeight="20px">
 							{ stat.label }
 						</Text>
-						<Text weight={ 500 } lineHeight="20px">
+						<Text weight={ 500 } size={ 13 } lineHeight="20px">
 							{ isLoading ? <TextSkeleton length={ 5 } /> : stat.value }
 						</Text>
 					</HStack>
+					<Divider style={ { color: 'var(--dashboard-header__divider-color)' } } />
 				</Fragment>
 			) ) }
 		</VStack>

--- a/client/dashboard/agency/overview/tier-overview-card.tsx
+++ b/client/dashboard/agency/overview/tier-overview-card.tsx
@@ -38,7 +38,9 @@ function TierFooterSection( {
 				{ label }
 			</Text>
 			<HStack justify="space-between" alignment="center" wrap>
-				<Text lineHeight="20px">{ title }</Text>
+				<Text size={ 13 } lineHeight="20px">
+					{ title }
+				</Text>
 				{ action }
 			</HStack>
 		</VStack>

--- a/client/dashboard/agency/overview/tier-overview-card.tsx
+++ b/client/dashboard/agency/overview/tier-overview-card.tsx
@@ -37,7 +37,7 @@ function TierFooterSection( {
 			<Text variant="muted" size={ 11 } weight={ 500 } lineHeight="16px" upperCase>
 				{ label }
 			</Text>
-			<HStack justify="space-between" alignment="center">
+			<HStack justify="space-between" alignment="center" wrap>
 				<Text lineHeight="20px">{ title }</Text>
 				{ action }
 			</HStack>

--- a/client/dashboard/agency/overview/tier-overview-card.tsx
+++ b/client/dashboard/agency/overview/tier-overview-card.tsx
@@ -17,7 +17,7 @@ interface TierOverviewCardProps {
 	tierId?: AgencyTierType;
 	influencedRevenue: number;
 	tiersHref: string;
-	useRouterLink?: boolean;
+	shouldUseRouterLink?: boolean;
 	onScheduleCall?: () => void;
 	isSchedulingCall?: boolean;
 	recordTracksEvent?: RecordTracksEvent;
@@ -51,7 +51,7 @@ export default function TierOverviewCard( {
 	tierId,
 	influencedRevenue,
 	tiersHref,
-	useRouterLink,
+	shouldUseRouterLink,
 	onScheduleCall,
 	isSchedulingCall,
 	recordTracksEvent,
@@ -72,7 +72,7 @@ export default function TierOverviewCard( {
 			heading={ tier.name }
 			description={ content.description }
 			link={ tiersHref }
-			useRouterLink={ useRouterLink }
+			shouldUseRouterLink={ shouldUseRouterLink }
 			tracksId="agency-overview-tier"
 			bottom={
 				<VStack spacing={ 4 }>

--- a/client/dashboard/agency/overview/use-woopayments-store-count.ts
+++ b/client/dashboard/agency/overview/use-woopayments-store-count.ts
@@ -1,0 +1,33 @@
+import {
+	agencySitesWithPluginsQuery,
+	wooPaymentsLicensesQuery,
+	WOOPAYMENTS_PLUGIN,
+} from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+
+/**
+ * Counts the agency's WooPayments stores the way the WooPayments dashboard does:
+ * attached WooPayments licenses plus sites running the plugin, de-duplicated by blog.
+ */
+export default function useWooPaymentsStoreCount( agencyId: number, enabled = true ) {
+	const isEnabled = !! agencyId && enabled;
+
+	const { data: licenseBlogIds, isLoading: isLoadingLicenses } = useQuery( {
+		...wooPaymentsLicensesQuery( agencyId ),
+		enabled: isEnabled,
+		select: ( licenses ) => licenses.map( ( license ) => license.blog_id ?? 0 ),
+	} );
+
+	const { data: pluginBlogIds, isLoading: isLoadingSites } = useQuery( {
+		...agencySitesWithPluginsQuery( agencyId, [ WOOPAYMENTS_PLUGIN ] ),
+		enabled: isEnabled,
+		select: ( sites ) => sites.map( ( site ) => site.blog_id ),
+	} );
+
+	const blogIds = new Set( [ ...( licenseBlogIds ?? [] ), ...( pluginBlogIds ?? [] ) ] );
+
+	return {
+		storeCount: blogIds.size,
+		isLoading: isLoadingLicenses || isLoadingSites,
+	};
+}

--- a/client/dashboard/agency/overview/use-woopayments-store-count.ts
+++ b/client/dashboard/agency/overview/use-woopayments-store-count.ts
@@ -6,8 +6,9 @@ import {
 import { useQuery } from '@tanstack/react-query';
 
 /**
- * Counts the agency's WooPayments stores the way the WooPayments dashboard does:
- * attached WooPayments licenses plus sites running the plugin, de-duplicated by blog.
+ * Counts the agency's WooPayments stores: attached WooPayments licenses plus
+ * sites running the plugin, de-duplicated by blog — matching the site list the
+ * WooPayments dashboard renders.
  */
 export default function useWooPaymentsStoreCount( agencyId: number, enabled = true ) {
 	const isEnabled = !! agencyId && enabled;
@@ -15,12 +16,17 @@ export default function useWooPaymentsStoreCount( agencyId: number, enabled = tr
 	const { data: licenseBlogIds, isLoading: isLoadingLicenses } = useQuery( {
 		...wooPaymentsLicensesQuery( agencyId ),
 		enabled: isEnabled,
-		select: ( licenses ) => licenses.map( ( license ) => license.blog_id ?? 0 ),
+		refetchOnWindowFocus: false,
+		// A license can be attached without a blog; folding nulls into a
+		// placeholder id would count a phantom store.
+		select: ( licenses ) =>
+			licenses.flatMap( ( license ) => ( license.blog_id ? [ license.blog_id ] : [] ) ),
 	} );
 
 	const { data: pluginBlogIds, isLoading: isLoadingSites } = useQuery( {
 		...agencySitesWithPluginsQuery( agencyId, [ WOOPAYMENTS_PLUGIN ] ),
 		enabled: isEnabled,
+		refetchOnWindowFocus: false,
 		select: ( sites ) => sites.map( ( site ) => site.blog_id ),
 	} );
 

--- a/client/dashboard/agency/overview/woopayments-illustration.tsx
+++ b/client/dashboard/agency/overview/woopayments-illustration.tsx
@@ -1,0 +1,67 @@
+import { SVG, Rect, Path, Circle } from '@wordpress/primitives';
+
+/**
+ * Two stacked SVG layers, both stretched to the callout's image panel: the dot
+ * pattern tiles at a fixed density so it fills any panel size, while the
+ * storefront art scales to fit (never crops), centered in the panel.
+ */
+export default function WooPaymentsIllustration( { title }: { title?: string } ) {
+	return (
+		<>
+			<SVG aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+				<defs>
+					<pattern id="pattern0_woopayments" patternUnits="userSpaceOnUse" width="6" height="6">
+						<image
+							width="12"
+							height="12"
+							transform="scale(0.5)"
+							preserveAspectRatio="none"
+							xlinkHref="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAAGklEQVR4nGNgGAUo4D82QSYCirFqIsmG4QAAKKwD//0jFGoAAAAASUVORK5CYII="
+						/>
+					</pattern>
+				</defs>
+				<Rect width="100%" height="100%" fill="url(#pattern0_woopayments)" fillOpacity="0.12" />
+			</SVG>
+			<SVG
+				viewBox="-2 30 294 152"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+				preserveAspectRatio="xMidYMid meet"
+			>
+				{ title && <title>{ title }</title> }
+				<Rect x="68" y="82" width="104" height="74" rx="4.62" fill="white" stroke="#C3C4C7" />
+				<Rect x="44" y="100" width="32" height="56" rx="4.62" fill="white" stroke="#C3C4C7" />
+				<Rect
+					x="105"
+					y="56"
+					width="141"
+					height="100"
+					rx="4.62"
+					fill="white"
+					stroke="url(#paint0_linear_woopayments)"
+				/>
+				<Circle cx="113" cy="65" r="2" stroke="#C3C4C7" />
+				<Circle cx="121.172" cy="65" r="2" stroke="#C3C4C7" />
+				<Circle cx="129.34" cy="65" r="2" stroke="#C3C4C7" />
+				<Rect x="163" y="94" width="24" height="24" rx="2" fill="#7A00DF" />
+				<Path
+					d="M171.5 111C170.7 111 170 111.7 170 112.5C170 113.3 170.7 114 171.5 114C172.3 114 173 113.3 173 112.5C173 111.7 172.3 111 171.5 111ZM178.5 111C177.7 111 177 111.7 177 112.5C177 113.3 177.7 114 178.5 114C179.3 114 180 113.3 180 112.5C180 111.7 179.3 111 178.5 111ZM172.5 107.2H177.6C178.8 107.2 179.8 106.5 180.2 105.4L181.5 101.9C181.8 101.1 181.2 100.2 180.3 100.2H170.3L169.5 98.2H166.5V99.7H168.5L171.2 106.4L170.6 107.7C170 108.9 170.9 110.2 172.2 110.2H180.6V108.7H172.2C172 108.7 171.9 108.5 172 108.3L172.6 107.2H172.5Z"
+					fill="white"
+				/>
+				<defs>
+					<linearGradient
+						id="paint0_linear_woopayments"
+						x1="114.895"
+						y1="96"
+						x2="233.667"
+						y2="96.5597"
+						gradientUnits="userSpaceOnUse"
+					>
+						<stop stopColor="#3858E9" />
+						<stop offset="1" stopColor="#069E08" />
+					</linearGradient>
+				</defs>
+			</SVG>
+		</>
+	);
+}

--- a/client/dashboard/agency/overview/woopayments-revenue-card.tsx
+++ b/client/dashboard/agency/overview/woopayments-revenue-card.tsx
@@ -1,0 +1,168 @@
+import { agencyWooPaymentsDataQuery } from '@automattic/api-queries';
+import { formatCurrency, formatNumber } from '@automattic/number-formatters';
+import { Badge } from '@automattic/ui';
+import { useQuery } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { ButtonStack } from '../../components/button-stack';
+import { Callout } from '../../components/callout';
+import { Card, CardBody } from '../../components/card';
+import { Text } from '../../components/text';
+import { TextSkeleton } from '../../components/text-skeleton';
+import OverviewLinkButton from './overview-link-button';
+import StatList from './stat-list';
+import useWooPaymentsStoreCount from './use-woopayments-store-count';
+import WooPaymentsIllustration from './woopayments-illustration';
+import type { RecordTracksEvent } from '../tiers/types';
+
+interface WooPaymentsRevenueCardProps {
+	agencyId: number;
+	locked?: boolean;
+	lockedNote?: string;
+	woopaymentsHref: string;
+	useRouterLink?: boolean;
+	recordTracksEvent?: RecordTracksEvent;
+}
+
+function WooPaymentsEmptyState( {
+	locked,
+	lockedNote,
+	woopaymentsHref,
+	useRouterLink,
+	recordTracksEvent,
+}: {
+	locked?: boolean;
+	lockedNote?: string;
+	woopaymentsHref: string;
+	useRouterLink?: boolean;
+	recordTracksEvent?: RecordTracksEvent;
+} ) {
+	return (
+		<Callout
+			title={ __( 'WooPayments revenue' ) }
+			titleAs="h2"
+			image={ <WooPaymentsIllustration title={ __( 'A client store using WooPayments' ) } /> }
+			imageVariant="full-bleed"
+			description={
+				<VStack spacing={ 2 }>
+					<Text variant="muted" lineHeight="20px">
+						{ __(
+							'Earn 0.05% on Total Payments Volume when your clients use WooPayments — automatically, with no ongoing management.'
+						) }
+					</Text>
+					{ lockedNote && (
+						<HStack justify="flex-start" expanded={ false }>
+							<Badge>{ lockedNote }</Badge>
+						</HStack>
+					) }
+				</VStack>
+			}
+			actions={
+				locked ? undefined : (
+					<ButtonStack justify="flex-start">
+						<OverviewLinkButton
+							size="compact"
+							variant="secondary"
+							href={ woopaymentsHref }
+							useRouterLink={ useRouterLink }
+							onClick={ () =>
+								recordTracksEvent?.( 'calypso_a4a_overview_woopayments_connect_store_click' )
+							}
+						>
+							{ __( 'Connect a client store' ) }
+						</OverviewLinkButton>
+					</ButtonStack>
+				)
+			}
+		/>
+	);
+}
+
+export default function WooPaymentsRevenueCard( {
+	agencyId,
+	locked,
+	lockedNote,
+	woopaymentsHref,
+	useRouterLink,
+	recordTracksEvent,
+}: WooPaymentsRevenueCardProps ) {
+	const { storeCount, isLoading: isLoadingStoreCount } = useWooPaymentsStoreCount(
+		agencyId,
+		! locked
+	);
+	const { data: wooPaymentsData, isPending: isPendingData } = useQuery( {
+		...agencyWooPaymentsDataQuery( agencyId ),
+		// The revenue payload can't distinguish "no stores", so gate on the store count.
+		enabled: !! agencyId && ! locked && storeCount > 0,
+	} );
+	// isPending rather than isLoading: on the render where the store count resolves
+	// and the query flips enabled, isFetching is still false — isLoading would show
+	// $0 stats for that frame.
+	const isLoading = isLoadingStoreCount || ( storeCount > 0 && isPendingData );
+
+	const total = wooPaymentsData?.data?.total;
+	const currentQuarter = wooPaymentsData?.data?.estimated?.current_quarter;
+
+	if ( locked || ( storeCount === 0 && ! isLoading ) ) {
+		return (
+			<WooPaymentsEmptyState
+				locked={ locked }
+				lockedNote={ lockedNote }
+				woopaymentsHref={ woopaymentsHref }
+				useRouterLink={ useRouterLink }
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		);
+	}
+
+	const totalProcessed = total?.tpv ?? 0;
+	const averagePerStore = storeCount > 0 ? totalProcessed / storeCount : 0;
+
+	return (
+		<Card>
+			<CardBody>
+				<VStack spacing={ 4 }>
+					<Text size={ 15 } weight={ 500 } lineHeight="20px" as="h2">
+						{ __( 'WooPayments revenue' ) }
+					</Text>
+					<HStack spacing={ 2 } justify="flex-start" alignment="baseline" expanded={ false }>
+						<Text size={ 20 } weight={ 500 } lineHeight="24px">
+							{ isLoading ? (
+								<TextSkeleton length={ 6 } />
+							) : (
+								formatCurrency( currentQuarter?.payout ?? 0, 'USD' )
+							) }
+						</Text>
+						<Text intent="success" size={ 12 } lineHeight="16px">
+							{ __( 'estimated this quarter' ) }
+						</Text>
+					</HStack>
+					<StatList
+						isLoading={ isLoading }
+						stats={ [
+							{ label: __( 'Active stores' ), value: formatNumber( storeCount ) },
+							{ label: __( 'Total processed' ), value: formatCurrency( totalProcessed, 'USD' ) },
+							{ label: __( 'Avg. per store' ), value: formatCurrency( averagePerStore, 'USD' ) },
+						] }
+					/>
+					<ButtonStack justify="flex-start">
+						<OverviewLinkButton
+							size="compact"
+							variant="secondary"
+							href={ woopaymentsHref }
+							useRouterLink={ useRouterLink }
+							onClick={ () =>
+								recordTracksEvent?.( 'calypso_a4a_overview_woopayments_view_details_click' )
+							}
+						>
+							{ __( 'View WooPayments details' ) }
+						</OverviewLinkButton>
+					</ButtonStack>
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/agency/overview/woopayments-revenue-card.tsx
+++ b/client/dashboard/agency/overview/woopayments-revenue-card.tsx
@@ -3,6 +3,7 @@ import { formatCurrency, formatNumber } from '@automattic/number-formatters';
 import { Badge } from '@automattic/ui';
 import { useQuery } from '@tanstack/react-query';
 import {
+	__experimentalHeading as Heading,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -23,7 +24,7 @@ interface WooPaymentsRevenueCardProps {
 	locked?: boolean;
 	lockedNote?: string;
 	woopaymentsHref: string;
-	useRouterLink?: boolean;
+	shouldUseRouterLink?: boolean;
 	recordTracksEvent?: RecordTracksEvent;
 }
 
@@ -31,13 +32,13 @@ function WooPaymentsEmptyState( {
 	locked,
 	lockedNote,
 	woopaymentsHref,
-	useRouterLink,
+	shouldUseRouterLink,
 	recordTracksEvent,
 }: {
 	locked?: boolean;
 	lockedNote?: string;
 	woopaymentsHref: string;
-	useRouterLink?: boolean;
+	shouldUseRouterLink?: boolean;
 	recordTracksEvent?: RecordTracksEvent;
 } ) {
 	return (
@@ -67,7 +68,7 @@ function WooPaymentsEmptyState( {
 							size="compact"
 							variant="secondary"
 							href={ woopaymentsHref }
-							useRouterLink={ useRouterLink }
+							shouldUseRouterLink={ shouldUseRouterLink }
 							onClick={ () =>
 								recordTracksEvent?.( 'calypso_a4a_overview_woopayments_connect_store_click' )
 							}
@@ -81,12 +82,14 @@ function WooPaymentsEmptyState( {
 	);
 }
 
+// Not OverviewCard: it renders the whole card as a single link, while this card
+// needs inline actions and non-interactive stat rows.
 export default function WooPaymentsRevenueCard( {
 	agencyId,
 	locked,
 	lockedNote,
 	woopaymentsHref,
-	useRouterLink,
+	shouldUseRouterLink,
 	recordTracksEvent,
 }: WooPaymentsRevenueCardProps ) {
 	const { storeCount, isLoading: isLoadingStoreCount } = useWooPaymentsStoreCount(
@@ -112,7 +115,7 @@ export default function WooPaymentsRevenueCard( {
 				locked={ locked }
 				lockedNote={ lockedNote }
 				woopaymentsHref={ woopaymentsHref }
-				useRouterLink={ useRouterLink }
+				shouldUseRouterLink={ shouldUseRouterLink }
 				recordTracksEvent={ recordTracksEvent }
 			/>
 		);
@@ -125,9 +128,9 @@ export default function WooPaymentsRevenueCard( {
 		<Card>
 			<CardBody>
 				<VStack spacing={ 4 }>
-					<Text size={ 15 } weight={ 500 } lineHeight="20px" as="h2">
+					<Heading level={ 2 } size={ 15 } weight={ 500 } lineHeight="20px">
 						{ __( 'WooPayments revenue' ) }
-					</Text>
+					</Heading>
 					<HStack spacing={ 2 } justify="flex-start" alignment="baseline" expanded={ false }>
 						<Text size={ 20 } weight={ 500 } lineHeight="24px">
 							{ isLoading ? (
@@ -153,7 +156,7 @@ export default function WooPaymentsRevenueCard( {
 							size="compact"
 							variant="secondary"
 							href={ woopaymentsHref }
-							useRouterLink={ useRouterLink }
+							shouldUseRouterLink={ shouldUseRouterLink }
 							onClick={ () =>
 								recordTracksEvent?.( 'calypso_a4a_overview_woopayments_view_details_click' )
 							}

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -1,9 +1,4 @@
 import {
-	JetpackLicenseFilter,
-	JetpackLicenseSortField,
-	JetpackLicenseSortDirection,
-} from '@automattic/api-core';
-import {
 	activeAgencyQuery,
 	agencyProductsQuery,
 	agencyQuery,
@@ -11,7 +6,6 @@ import {
 	agencySiteQuery,
 	agencySitesWithPluginsQuery,
 	agencyWooPaymentsDataQuery,
-	jetpackAgencyLicensesQuery,
 	mcpSettingsQuery,
 	queryClient,
 	rawUserPreferencesQuery,
@@ -22,6 +16,8 @@ import {
 	referralsQuery,
 	referralCommissionPayoutQuery,
 	tipaltiPayeeQuery,
+	wooPaymentsLicensesQuery,
+	WOOPAYMENTS_PLUGIN,
 } from '@automattic/api-queries';
 import { createRoute, createLazyRoute, notFound, Outlet } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
@@ -307,16 +303,9 @@ export const earnWooPaymentsRoute = createRoute( {
 		}
 		const [ sitesWithPlugins, licenses ] = await Promise.all( [
 			queryClient.ensureQueryData(
-				agencySitesWithPluginsQuery( agency.id, [ 'woocommerce-payments/woocommerce-payments' ] )
+				agencySitesWithPluginsQuery( agency.id, [ WOOPAYMENTS_PLUGIN ] )
 			),
-			queryClient.ensureQueryData(
-				jetpackAgencyLicensesQuery( agency.id, {
-					filter: JetpackLicenseFilter.Attached,
-					search: 'woopayments',
-					sortField: JetpackLicenseSortField.IssuedAt,
-					sortDirection: JetpackLicenseSortDirection.Descending,
-				} )
-			),
+			queryClient.ensureQueryData( wooPaymentsLicensesQuery( agency.id ) ),
 		] );
 		if ( sitesWithPlugins.length > 0 || licenses.length > 0 ) {
 			await Promise.all( [

--- a/client/dashboard/components/overview-card/index.tsx
+++ b/client/dashboard/components/overview-card/index.tsx
@@ -50,7 +50,7 @@ export interface OverviewCardProps {
 	upsellFeatureId?: string;
 
 	/** Set to false in apps outside the dashboard's TanStack Router, so relative links render as plain anchors. */
-	useRouterLink?: boolean;
+	shouldUseRouterLink?: boolean;
 
 	bottom?: ReactNode;
 	onClick?: () => void;
@@ -69,7 +69,7 @@ export default function OverviewCard( {
 	externalLink: externalLinkProp,
 	tracksId,
 	upsellFeatureId,
-	useRouterLink = true,
+	shouldUseRouterLink = true,
 	bottom,
 	onClick,
 }: OverviewCardProps ) {
@@ -105,7 +105,7 @@ export default function OverviewCard( {
 	} else if ( isOnboarding ) {
 		plainAnchorLink = link;
 	} else if ( isRelativeLink ) {
-		if ( useRouterLink ) {
+		if ( shouldUseRouterLink ) {
 			relativeLink = link;
 		} else {
 			plainAnchorLink = link;

--- a/packages/api-queries/src/agency-woopayments.ts
+++ b/packages/api-queries/src/agency-woopayments.ts
@@ -1,8 +1,29 @@
-import { fetchAgencyWooPaymentsData } from '@automattic/api-core';
+import {
+	fetchAgencyWooPaymentsData,
+	JetpackLicenseFilter,
+	JetpackLicenseSortDirection,
+	JetpackLicenseSortField,
+} from '@automattic/api-core';
 import { queryOptions } from '@tanstack/react-query';
+import { jetpackAgencyLicensesQuery } from './jetpack-agency-licenses';
+
+export const WOOPAYMENTS_PLUGIN = 'woocommerce-payments/woocommerce-payments';
 
 export const agencyWooPaymentsDataQuery = ( agencyId: number ) =>
 	queryOptions( {
 		queryKey: [ 'agency', agencyId, 'woopayments', 'data' ],
 		queryFn: () => fetchAgencyWooPaymentsData( agencyId ),
+	} );
+
+/**
+ * The agency's attached WooPayments licenses. Canonical options shared by the
+ * WooPayments dashboard and the overview store count, so both read the same
+ * cache entry — diverging options would silently split the query keys.
+ */
+export const wooPaymentsLicensesQuery = ( agencyId: number ) =>
+	jetpackAgencyLicensesQuery( agencyId, {
+		filter: JetpackLicenseFilter.Attached,
+		search: 'woopayments',
+		sortField: JetpackLicenseSortField.IssuedAt,
+		sortDirection: JetpackLicenseSortDirection.Descending,
 	} );

--- a/packages/components/src/summary-button/types.ts
+++ b/packages/components/src/summary-button/types.ts
@@ -30,6 +30,15 @@ export interface SummaryButtonProps {
 	 */
 	href?: string;
 	/**
+	 * The anchor `target` attribute, forwarded to the underlying element when
+	 * an `href` is given.
+	 */
+	target?: string;
+	/**
+	 * The anchor `rel` attribute, forwarded alongside `target`.
+	 */
+	rel?: string;
+	/**
 	 * A callback to handle clicking an item.
 	 */
 	onClick?: React.MouseEventHandler;


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/113214.

Part of A4A-2840.

## Proposed Changes

* Completes the revamped Overview layout with a two-column grid and the remaining cards:
  * **Referral earnings** — estimated commission this quarter, active referrals, pending payout, and lifetime earnings. The empty state pitches the commission rates with a "Make a referral" action.
  * **WooPayments revenue** — quarterly payout estimate, active stores, total processed, and average per store, with an illustrated empty state. The store count combines attached licenses and sites running the plugin, since the revenue data alone can't tell "no stores" apart from "no revenue yet".
  * **Featured event** — promotes the current Automattic for Agencies event (WordCamp US 2026), curated from a single content file; the card hides itself between events.
  * **Helpful links** — contact support and program incentive details. The contact-support row is present but inert for now; it gets wired up once the dashboard has a contact-support entry point.
* While an agency application is pending, the earning cards show an "Unlocks when your account is activated" note instead of their actions.
* Cards load their own data through the shared data layer, reading the same cached referrals and WooPayments data as the Referrals and WooPayments sections.

## Why are these changes being made?

* Second slice of the Overview revamp (A4A-2840): the overview should surface earnings at a glance and route agencies to the detailed Referrals and WooPayments sections.

## Testing Instructions

Using this PR's Calypso Live link with the agency dashboard, sign in as an agency and go to **Overview**.

* With referrals: the earnings figures match the Referrals page. Without: the empty state with "Make a referral" appears.
* With WooPayments stores: the revenue figures match the WooPayments page. Without: the illustrated empty state with "Connect a client store" appears.
* The event card links to the WordCamp US 2026 site in a new tab.
* The program incentives helpful link opens in a new tab; the contact-support row is intentionally inert for now.
* As an agency with a pending application, both earning cards show the locked note and no actions.

Agency pending state:

<img width="1352" height="762" alt="Screenshot 2026-08-03 at 4 33 34 PM" src="https://github.com/user-attachments/assets/c0b3dec8-96ef-4282-b7fe-dbe7a23cb939" />


Agency rejected state:

<img width="1352" height="664" alt="Screenshot 2026-08-03 at 4 34 09 PM" src="https://github.com/user-attachments/assets/91ffdf9d-6ad2-4fbb-95fb-000fc73d1a71" />


Empty Referrals/WooPayment state:

<img width="1352" height="745" alt="Screenshot 2026-08-03 at 4 39 42 PM" src="https://github.com/user-attachments/assets/f61d2635-9392-4a81-8ffe-c42a3aee0bea" />


Referrals/WooPayment (with data) state:

<img width="2704" height="1614" alt="screencapture-my-a4a-localhost-3000-overview-2026-08-03-16_36_08" src="https://github.com/user-attachments/assets/dd88fca9-de56-43d1-80e7-c19e7ab679dd" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
