### PR TITLE
A4A: Show the revamped Overview behind the a4a-overview-revamp flag

### DIFF
--- a/client/a8c-for-agencies/sections/overview/dashboard-overview-body/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/dashboard-overview-body/index.tsx
@@ -11,16 +11,12 @@ import useScheduleCall from 'calypso/a8c-for-agencies/hooks/use-schedule-call';
 import { PROGRAM_INCENTIVES_URL } from 'calypso/dashboard/agency/overview/constants';
 import AgencyOverviewContent from 'calypso/dashboard/agency/overview/overview-content';
 import { useDispatch, useSelector } from 'calypso/state';
-import {
-	getActiveAgency,
-	getActiveAgencyId,
-} from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 export default function DashboardOverviewBody() {
 	const dispatch = useDispatch();
 	const agency = useSelector( getActiveAgency );
-	const agencyId = useSelector( getActiveAgencyId );
 	const approvalStatus = agency?.approval_status;
 
 	const { scheduleCall, isLoading: isSchedulingCall } = useScheduleCall();
@@ -32,13 +28,17 @@ export default function DashboardOverviewBody() {
 		[ dispatch ]
 	);
 
+	const handleRelaunchTour = useCallback( () => {
+		window.location.hash = ONBOARDING_TOUR_HASH;
+	}, [] );
+
 	if ( ! agency ) {
 		return null;
 	}
 
 	return (
 		<AgencyOverviewContent
-			agencyId={ agencyId ?? 0 }
+			agencyId={ agency.id }
 			tierId={ agency.tier?.id }
 			influencedRevenue={ agency.influenced_revenue ?? 0 }
 			approvalStatus={ approvalStatus }
@@ -57,9 +57,7 @@ export default function DashboardOverviewBody() {
 					{
 						id: 'relaunch-welcome-tour',
 						label: __( 'Relaunch welcome tour' ),
-						onClick: () => {
-							window.location.hash = ONBOARDING_TOUR_HASH;
-						},
+						onClick: handleRelaunchTour,
 					},
 					{
 						id: 'program-incentives',
@@ -72,9 +70,7 @@ export default function DashboardOverviewBody() {
 			shouldUseRouterLink={ false }
 			onScheduleCall={ scheduleCall }
 			isSchedulingCall={ isSchedulingCall }
-			onRelaunchTour={ () => {
-				window.location.hash = ONBOARDING_TOUR_HASH;
-			} }
+			onRelaunchTour={ handleRelaunchTour }
 			recordTracksEvent={ handleRecordTracksEvent }
 		/>
 	);

--- a/client/a8c-for-agencies/sections/overview/dashboard-overview-body/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/dashboard-overview-body/index.tsx
@@ -1,0 +1,81 @@
+import { __ } from '@wordpress/i18n';
+import { useCallback } from 'react';
+import { CONTACT_URL_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
+import { ONBOARDING_TOUR_HASH } from 'calypso/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour';
+import {
+	A4A_AGENCY_TIER_LINK,
+	A4A_REFERRALS_DASHBOARD,
+	A4A_WOOPAYMENTS_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useScheduleCall from 'calypso/a8c-for-agencies/hooks/use-schedule-call';
+import { PROGRAM_INCENTIVES_URL } from 'calypso/dashboard/agency/overview/constants';
+import AgencyOverviewContent from 'calypso/dashboard/agency/overview/overview-content';
+import { useDispatch, useSelector } from 'calypso/state';
+import {
+	getActiveAgency,
+	getActiveAgencyId,
+} from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+export default function DashboardOverviewBody() {
+	const dispatch = useDispatch();
+	const agency = useSelector( getActiveAgency );
+	const agencyId = useSelector( getActiveAgencyId );
+	const approvalStatus = agency?.approval_status;
+
+	const { scheduleCall, isLoading: isSchedulingCall } = useScheduleCall();
+
+	const handleRecordTracksEvent = useCallback(
+		( eventName: string, properties?: Record< string, unknown > ) => {
+			dispatch( recordTracksEvent( eventName, properties ) );
+		},
+		[ dispatch ]
+	);
+
+	if ( ! agency ) {
+		return null;
+	}
+
+	return (
+		<AgencyOverviewContent
+			agencyId={ agencyId ?? 0 }
+			tierId={ agency.tier?.id }
+			influencedRevenue={ agency.influenced_revenue ?? 0 }
+			approvalStatus={ approvalStatus }
+			capabilities={ agency.user?.capabilities }
+			links={ {
+				tiers: A4A_AGENCY_TIER_LINK,
+				referrals: A4A_REFERRALS_DASHBOARD,
+				woopayments: A4A_WOOPAYMENTS_LINK,
+				contactSupport: CONTACT_URL_HASH_FRAGMENT,
+				helpful: [
+					{
+						id: 'contact-support',
+						label: __( 'Contact sales & support' ),
+						href: CONTACT_URL_HASH_FRAGMENT,
+					},
+					{
+						id: 'relaunch-welcome-tour',
+						label: __( 'Relaunch welcome tour' ),
+						onClick: () => {
+							window.location.hash = ONBOARDING_TOUR_HASH;
+						},
+					},
+					{
+						id: 'program-incentives',
+						label: __( 'Program incentive details' ),
+						href: PROGRAM_INCENTIVES_URL,
+						isExternal: true,
+					},
+				],
+			} }
+			shouldUseRouterLink={ false }
+			onScheduleCall={ scheduleCall }
+			isSchedulingCall={ isSchedulingCall }
+			onRelaunchTour={ () => {
+				window.location.hash = ONBOARDING_TOUR_HASH;
+			} }
+			recordTracksEvent={ handleRecordTracksEvent }
+		/>
+	);
+}

--- a/client/a8c-for-agencies/sections/overview/overview.tsx
+++ b/client/a8c-for-agencies/sections/overview/overview.tsx
@@ -1,3 +1,5 @@
+import { isEnabled } from '@automattic/calypso-config';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
 import ContentSidebar from 'calypso/a8c-for-agencies/components/content-sidebar';
@@ -6,14 +8,20 @@ import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-pa
 import PaymentRiskNoticeBanner from 'calypso/a8c-for-agencies/components/payment-risk-notice-banner';
 import PressableUsageLimitNotice from 'calypso/a8c-for-agencies/components/pressable-usage-limit-notice';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { AgencyOverviewHeaderInfo } from 'calypso/dashboard/agency/overview/overview-header';
 import LayoutBody from 'calypso/layout/hosting-dashboard/body';
 import LayoutHeader, {
 	LayoutHeaderActions as Actions,
+	LayoutHeaderSubtitle as Subtitle,
 	LayoutHeaderTitle as Title,
 } from 'calypso/layout/hosting-dashboard/header';
+import { useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { MissingPaymentSettingsNotice } from '../referrals/common/missing-payment-settings-notice';
 import useHasCommissionActivity from '../referrals/common/missing-payment-settings-notice/use-has-commission-activity';
 import OverviewBody from './body';
+import DashboardOverviewBody from './dashboard-overview-body';
 import OverviewHeaderActions from './header-actions';
 import PartnerDirectoryOnboardingCard from './partner-directory-onboarding-card';
 import OverviewSidebar from './sidebar';
@@ -23,6 +31,10 @@ import './style.scss';
 export default function Overview() {
 	const translate = useTranslate();
 	const title = translate( 'Agency overview' );
+	const isRevamp = isEnabled( 'a4a-overview-revamp' );
+	const agency = useSelector( getActiveAgency );
+	const locale = useSelector( getCurrentUserLocale );
+	const showAgencyHeader = isRevamp && !! agency;
 
 	const { hasActivity, isLoading: isLoadingActivity } = useHasCommissionActivity();
 
@@ -35,15 +47,28 @@ export default function Overview() {
 				<PaymentRiskNoticeBanner source="overview" />
 
 				<LayoutHeader className="a4a-overview-header">
-					<Title>{ title }</Title>
+					<Title>{ showAgencyHeader ? agency?.name : title }</Title>
+					{ showAgencyHeader && (
+						<Subtitle>
+							<AgencyOverviewHeaderInfo
+								url={ agency?.url }
+								createdAt={ agency?.created_at }
+								locale={ locale }
+							/>
+						</Subtitle>
+					) }
 					<Actions className="a4a-overview__header-actions">
 						<MobileSidebarNavigation />
-						<OverviewHeaderActions />
+						{ ! isRevamp && <OverviewHeaderActions /> }
 					</Actions>
 				</LayoutHeader>
 			</LayoutTop>
-			<LayoutBody className="a4a-overview-content">
-				<ContentSidebar mainContent={ <OverviewBody /> } rightSidebar={ <OverviewSidebar /> } />
+			<LayoutBody className={ clsx( 'a4a-overview-content', { 'is-revamp': isRevamp } ) }>
+				{ isRevamp ? (
+					<DashboardOverviewBody />
+				) : (
+					<ContentSidebar mainContent={ <OverviewBody /> } rightSidebar={ <OverviewSidebar /> } />
+				) }
 			</LayoutBody>
 
 			<PartnerDirectoryOnboardingCard />

--- a/client/a8c-for-agencies/sections/overview/overview.tsx
+++ b/client/a8c-for-agencies/sections/overview/overview.tsx
@@ -17,6 +17,7 @@ import LayoutHeader, {
 } from 'calypso/layout/hosting-dashboard/header';
 import { useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { ApprovalStatus } from 'calypso/state/a8c-for-agencies/types';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { MissingPaymentSettingsNotice } from '../referrals/common/missing-payment-settings-notice';
 import useHasCommissionActivity from '../referrals/common/missing-payment-settings-notice/use-has-commission-activity';
@@ -35,6 +36,10 @@ export default function Overview() {
 	const agency = useSelector( getActiveAgency );
 	const locale = useSelector( getCurrentUserLocale );
 	const showAgencyHeader = isRevamp && !! agency;
+	// The revamped overview renders pending and rejected applications as tier-card
+	// states, so the approval banner is redundant here; the approved welcome
+	// banner has no card equivalent and stays. Other pages keep the banner.
+	const showApprovalNotice = ! isRevamp || agency?.approval_status === ApprovalStatus.APPROVED;
 
 	const { hasActivity, isLoading: isLoadingActivity } = useHasCommissionActivity();
 
@@ -42,7 +47,7 @@ export default function Overview() {
 		<Layout title={ title } wide>
 			<LayoutTop>
 				{ ! isLoadingActivity && hasActivity && <MissingPaymentSettingsNotice /> }
-				<A4AAgencyApprovalNotice />
+				{ showApprovalNotice && <A4AAgencyApprovalNotice /> }
 				<PressableUsageLimitNotice />
 				<PaymentRiskNoticeBanner source="overview" />
 

--- a/client/a8c-for-agencies/sections/overview/style.scss
+++ b/client/a8c-for-agencies/sections/overview/style.scss
@@ -9,10 +9,11 @@
 }
 
 // The shared dashboard overview cards assume the dashboard app's styling
-// context, which the classic app does not provide: its 13px base font size
-// (the dashboard Text component inherits it whenever no explicit size is set)
-// and the dashboard color variables. Scoped to the revamp so the legacy
-// overview keeps the classic typography.
+// context, which the classic app does not provide. This maps only the pieces
+// the overview cards consume today — the 13px base font size (the dashboard
+// Text component inherits it whenever no explicit size is set) and the color
+// variables below — not the dashboard's full token set. Scoped to the revamp
+// so the legacy overview keeps the classic typography.
 .a4a-overview-content.is-revamp {
 	font-size: $font-size-medium;
 
@@ -20,6 +21,8 @@
 	--dashboard__foreground-color-success: var(--color-success);
 	--dashboard__foreground-color-warning: var(--color-warning);
 	--dashboard__foreground-color-error: var(--color-error);
+	--dashboard__text-color: var(--color-text);
+	--dashboard__text-muted-color: var(--color-text-subtle);
 }
 
 .a4a-overview-header {

--- a/client/a8c-for-agencies/sections/overview/style.scss
+++ b/client/a8c-for-agencies/sections/overview/style.scss
@@ -2,9 +2,24 @@
 
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .a4a-overview-content {
 	padding-block-start: 1rem;
+}
+
+// The shared dashboard overview cards assume the dashboard app's styling
+// context, which the classic app does not provide: its 13px base font size
+// (the dashboard Text component inherits it whenever no explicit size is set)
+// and the dashboard color variables. Scoped to the revamp so the legacy
+// overview keeps the classic typography.
+.a4a-overview-content.is-revamp {
+	font-size: $font-size-medium;
+
+	--dashboard-header__divider-color: var(--color-border-subtle);
+	--dashboard__foreground-color-success: var(--color-success);
+	--dashboard__foreground-color-warning: var(--color-warning);
+	--dashboard__foreground-color-error: var(--color-error);
 }
 
 .a4a-overview-header {

--- a/client/dashboard/agency/overview/application-status-cards.tsx
+++ b/client/dashboard/agency/overview/application-status-cards.tsx
@@ -7,10 +7,9 @@ import {
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { published } from '@wordpress/icons';
+import { error, published } from '@wordpress/icons';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
-import { caution } from '../../components/notice/icons';
 import { Text } from '../../components/text';
 import { PARTNER_PROGRAM_GUIDE_URL } from './constants';
 import NewTabLabel from './new-tab-label';
@@ -105,7 +104,7 @@ export function RejectedTierCard( { contactSupportHref }: { contactSupportHref: 
 		<ApplicationStatusCard
 			decoration={
 				<Text intent="error" as="span">
-					<Icon icon={ caution } size={ 24 } fill="currentColor" />
+					<Icon icon={ error } size={ 24 } fill="currentColor" />
 				</Text>
 			}
 			label={ __( 'Application status' ) }
@@ -113,8 +112,7 @@ export function RejectedTierCard( { contactSupportHref }: { contactSupportHref: 
 		>
 			<Text variant="muted" lineHeight="20px">
 				{ __( 'We have not approved your application for the Automattic for Agencies program.' ) }
-			</Text>
-			<Text variant="muted" lineHeight="20px">
+				<br />
 				{ createInterpolateElement(
 					__(
 						'Please <a>contact support</a> to discuss this further if you think this was done in error.'

--- a/client/dashboard/agency/overview/index.tsx
+++ b/client/dashboard/agency/overview/index.tsx
@@ -1,44 +1,24 @@
 import { activeAgencyQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import { ExternalLink } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
 import { useLocale } from '../../app/locale';
 import FlashMessage from '../../components/flash-message';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { Text } from '../../components/text';
-import { formatDate } from '../../utils/datetime';
 import { useScheduleCall } from '../tiers/use-schedule-call';
 import { PROGRAM_INCENTIVES_URL } from './constants';
 import AgencyOverviewContent from './overview-content';
+import AgencyOverviewHeader from './overview-header';
 
 // TODO: the MSD dashboard has no contact-support entry point yet. This matches the
 // '#contact-support' placeholder in agency/tiers/constants.ts — wire both up together.
 const CONTACT_SUPPORT_URL = '#contact-support';
 
-function AgencyOverviewDescription( { url, createdAt }: { url?: string; createdAt?: string } ) {
-	const locale = useLocale();
-	const parsedDate = createdAt ? new Date( createdAt ) : undefined;
-	const joinedDate = parsedDate && ! isNaN( parsedDate.getTime() ) ? parsedDate : undefined;
-
-	return (
-		<Text variant="muted" lineHeight="20px">
-			{ url && <ExternalLink href={ url }>{ url.replace( /^https?:\/\//, '' ) }</ExternalLink> }
-			{ url && joinedDate && ' · ' }
-			{ joinedDate &&
-				sprintf(
-					/* translators: %s is the date the agency joined the program. */
-					__( 'Joined %s' ),
-					formatDate( joinedDate, locale )
-				) }
-		</Text>
-	);
-}
-
 export default function AgencyOverview() {
 	const { data: agency } = useQuery( activeAgencyQuery() );
 	const { recordTracksEvent } = useAnalytics();
+	const locale = useLocale();
 	const agencyId = agency?.id ?? 0;
 	const approvalStatus = agency?.approval_status;
 	const { scheduleCall, isLoading: isSchedulingCall } = useScheduleCall( agency?.id );
@@ -50,11 +30,11 @@ export default function AgencyOverview() {
 	return (
 		<PageLayout
 			header={
-				<PageHeader
-					title={ agency.name }
-					description={
-						<AgencyOverviewDescription url={ agency.url } createdAt={ agency.created_at } />
-					}
+				<AgencyOverviewHeader
+					name={ agency.name }
+					url={ agency.url }
+					createdAt={ agency.created_at }
+					locale={ locale }
 				/>
 			}
 		>

--- a/client/dashboard/agency/overview/overview-header.tsx
+++ b/client/dashboard/agency/overview/overview-header.tsx
@@ -11,10 +11,7 @@ interface AgencyOverviewHeaderInfoProps {
 	createdAt?: string;
 }
 
-/**
- * The agency's site link and join date. Rendered under the agency name by both
- * hosts: the dashboard's page header and the a8c-for-agencies layout header.
- */
+// Shared between the dashboard PageHeader and the a8c-for-agencies LayoutHeader.
 export function AgencyOverviewHeaderInfo( {
 	url,
 	createdAt,

--- a/client/dashboard/agency/overview/overview-header.tsx
+++ b/client/dashboard/agency/overview/overview-header.tsx
@@ -1,0 +1,54 @@
+import { ExternalLink } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { PageHeader } from '../../components/page-header';
+import { Text } from '../../components/text';
+import { formatDate } from '../../utils/datetime';
+
+interface AgencyOverviewHeaderInfoProps {
+	url?: string;
+	/** Injected by the host app; the dashboard's locale hook is not available in a8c-for-agencies. */
+	locale: string;
+	createdAt?: string;
+}
+
+/**
+ * The agency's site link and join date. Rendered under the agency name by both
+ * hosts: the dashboard's page header and the a8c-for-agencies layout header.
+ */
+export function AgencyOverviewHeaderInfo( {
+	url,
+	createdAt,
+	locale,
+}: AgencyOverviewHeaderInfoProps ) {
+	const parsedDate = createdAt ? new Date( createdAt ) : undefined;
+	const joinedDate = parsedDate && ! isNaN( parsedDate.getTime() ) ? parsedDate : undefined;
+
+	return (
+		<Text variant="muted" size={ 13 } lineHeight="20px">
+			{ url && <ExternalLink href={ url }>{ url.replace( /^https?:\/\//, '' ) }</ExternalLink> }
+			{ url && joinedDate && ' · ' }
+			{ joinedDate &&
+				sprintf(
+					/* translators: %s is the date the agency joined the program. */
+					__( 'Joined %s' ),
+					formatDate( joinedDate, locale )
+				) }
+		</Text>
+	);
+}
+
+export default function AgencyOverviewHeader( {
+	name,
+	url,
+	createdAt,
+	locale,
+}: AgencyOverviewHeaderInfoProps & { name?: string } ) {
+	return (
+		<PageHeader
+			title={ name }
+			description={
+				<AgencyOverviewHeaderInfo url={ url } createdAt={ createdAt } locale={ locale } />
+			}
+		/>
+	);
+}

--- a/client/dashboard/agency/tiers/style.scss
+++ b/client/dashboard/agency/tiers/style.scss
@@ -9,7 +9,9 @@
 // The ProgressBar component officially supports a custom width via its
 // `className` prop — see the "With Custom Width" Storybook example:
 // https://wordpress.github.io/gutenberg/?path=/docs/components-progressbar--docs#with-custom-width
-.agency-tiers-influenced-revenue-bar {
+// The class is doubled to outrank the track's own emotion styles (width: 160px),
+// which have equal specificity and would otherwise win or lose on injection order.
+.agency-tiers-influenced-revenue-bar.agency-tiers-influenced-revenue-bar {
 	width: 100%;
 
 	// ProgressBar has no colour prop: its track and indicator both derive from

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -33,6 +33,7 @@
 		"a4a-bd-checkout": false,
 		"a4a-bd-term-pricing": true,
 		"a4a-migrations-request-verification": true,
+		"a4a-overview-revamp": true,
 		"a4a-partner-directory": false,
 		"a4a-pressable-referrals": true,
 		"a4a-signup-v2": true,


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/113215.

Part of A4A-2840.

## Proposed Changes

* Render the revamped Overview inside the classic agencies dashboard when the `a4a-overview-revamp` feature flag is on (enabled in development only).
* The classic app injects its own agency data, routes, contact-support and welcome-tour entries, and analytics into the shared overview content. Card links render as plain anchors so the classic router handles navigation.
* The header shows the agency’s name, site link, and join date instead of the “Agency overview” title, using a header component shared with the new dashboard, and the old header action buttons are removed.
* Visual parity for the shared cards inside the classic app: divider and status colors, the 13px base font size, and the influenced-revenue bar spanning the full card width regardless of stylesheet load order.
* Tracks note: the "Program incentive details" link now fires the generic `calypso_a4a_overview_helpful_link_click` (with `link_id: 'program-incentives'`) instead of the legacy sidebar's dedicated `calypso_a4a_overview_program_incentive_click`, so reports keyed on the old name go flat for flagged users.
* With the flag off, the existing overview is unchanged.

## Why are these changes being made?

* Final slice of the Overview revamp (A4A-2840): both dashboards now render the same overview from one set of shared components, so future changes land in both at once.
* Because the referrals data layer is shared since #113126, archiving or adding a referral in the Referrals section is reflected on the overview immediately.

## Testing Instructions

Using this PR's Calypso Live link with the `a8c-for-agencies` environment, sign in as an agency.

* Open the overview with the flag: append `?flags=a4a-overview-revamp` — the new two-column overview renders (tier card, referral earnings, WooPayments revenue, event, helpful links).
* Card links route within the app: tier card → Agency tier, earnings cards → Referrals / WooPayments.
* "Contact sales & support" opens the contact widget; "Relaunch welcome tour" replays the tour.
* Archive a referral under **Referrals**, go back to the overview — the earnings card reflects it without a reload.
* The header shows your agency name, site link, and join date; the old header buttons are gone (the mobile navigation still works).
* Without the flag, the existing overview renders as before, including its header and title.

<img width="2704" height="1694" alt="screencapture-agencies-localhost-3000-overview-2026-08-04-13_52_00" src="https://github.com/user-attachments/assets/543133b8-b317-4799-bbf6-46bf3575437d" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

