### PR TITLE
Desktop: fix electron-builder 26 config schema

### DIFF
--- a/desktop/electron-builder.json
+++ b/desktop/electron-builder.json
@@ -41,8 +41,10 @@
 		"artifactName": "wordpress.com-macOS-dmg-${version}-${arch}.${ext}"
 	},
 	"win": {
-		"publisherName": [ "Automattic, Inc.", "Automattic Inc." ],
-		"sign": "./bin/windows-sign.js",
+		"signtoolOptions": {
+			"publisherName": [ "Automattic, Inc.", "Automattic Inc." ],
+			"sign": "./bin/windows-sign.js"
+		},
 		"icon": "./resource/icon.ico",
 		"target": [
 			{
@@ -62,7 +64,9 @@
 		"synopsis": "WordPress.com Desktop Client",
 		"category": "Social",
 		"desktop": {
-			"StartupNotify": true
+			"entry": {
+				"StartupNotify": "true"
+			}
 		},
 		"artifactName": "wordpress.com-linux-x64-${version}.${ext}"
 	},


### PR DESCRIPTION
## Proposed Changes

Update `desktop/electron-builder.json` for the two breaking schema changes in electron-builder 26:

* `linux.desktop` moved from a flat name→value map to a `LinuxDesktopFile` object, so the entries now live under `desktop.entry` (and values must be strings):
  ```diff
   "desktop": {
  -    "StartupNotify": true
  +    "entry": { "StartupNotify": "true" }
   }
  ```
* `win.publisherName` and `win.sign` were removed from the `win` root and moved under `win.signtoolOptions`.

## Why are these changes being made?

electron-builder was bumped `24.13.3` → `26.15.0` in #113027. Its config validator (`@develar/schema-utils`) checks the whole config up front and rejects any unknown/mis-shaped property, so the schema errors above failed **every** desktop build — including mac — before packaging even started:

```
⨯ Invalid configuration object. electron-builder 26.15.0 ... does not match the API schema.
 - configuration.linux.desktop should be one of these: null
 - configuration.win should be one of these: null
```

The custom Windows sign hook (`bin/windows-sign.js`) already uses the v26 `async (configuration) => …` signature, so no change was needed there.

## Testing Instructions

* Validated the updated config against the actual electron-builder 26 `scheme.json` using the same `@develar/schema-utils` validator the build uses — it now passes (and reproduced the original CI errors against the old config first).
* This branch uses the `desktop/` prefix so all four desktop builds (mac, linux, windows store, windows nsis) run on the PR per `.buildkite/pipeline.yml` branch filters.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?