### PR TITLE
E2E: fix the Atomic test-user leak in account teardown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,8 @@ playwright-report/
 .playwright-mcp/
 /cookies
 output/
+# Deferred account closes; hold bearer tokens, so kept out of the published output/.
+.teardown-pending/
 
 # Claude settings and rules
 # Allow user-contributed files, but keep Claude.md and main settings under version control

--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -196,6 +196,9 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				# Recursive over output/: markers should land in output/teardown-leaks, but a
 				# path drift must not leave a stale marker that fails a later run.
 				find output -name 'account-*.json' -delete 2>/dev/null || true
+				# Same for deferred closes: a record left by a previous run holds a dead
+				# token and would be reported as a leak this run.
+				rm -rf .teardown-pending 2>/dev/null || true
 				echo "CALYPSO_BASE_URL=%CALYPSO_BASE_URL%"
 				export CALYPSO_BASE_URL="%CALYPSO_BASE_URL%"
 				echo "DASHBOARD_BASE_URL=%DASHBOARD_BASE_URL%"
@@ -217,6 +220,18 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				# check would find nothing and pass a leaking run green. Markers are named
 				# account-*.json wherever they land.
 				MARKERS=${'$'}( find test/e2e/output -name 'account-*.json' 2>/dev/null || true )
+				# The end-of-run reaper clears a record once its account is closed or
+				# written out as a marker above. A record still here means that never
+				# happened - the reaper did not run (aborted run, crashed worker), timed
+				# out, or could not record the leak - so the account is still open.
+				# Count only: these records hold bearer tokens and must not be echoed
+				# into the build log.
+				PENDING=${'$'}( find test/e2e/.teardown-pending -name 'pending-*.json' 2>/dev/null || true )
+				if [ -n "${'$'}PENDING" ]; then
+					PENDING_COUNT=${'$'}( printf '%s\n' "${'$'}PENDING" | wc -l | tr -d ' ' )
+					echo "E2E TEARDOWN LEAK - ${'$'}PENDING_COUNT deferred account close(s) were not completed."
+					echo "##teamcity[buildProblem description='E2E teardown leak: ${'$'}PENDING_COUNT deferred close(s) not completed' identity='e2e_teardown_pending']"
+				fi
 				if [ -n "${'$'}MARKERS" ]; then
 					COUNT=${'$'}( printf '%s\n' "${'$'}MARKERS" | wc -l | tr -d ' ' )
 					echo "E2E TEARDOWN LEAK - the following test users were not closed (their blogs leak with them):"

--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -196,9 +196,6 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				# Recursive over output/: markers should land in output/teardown-leaks, but a
 				# path drift must not leave a stale marker that fails a later run.
 				find output -name 'account-*.json' -delete 2>/dev/null || true
-				# Same for deferred closes: a record left by a previous run holds a dead
-				# token and would be reported as a leak this run.
-				rm -rf .teardown-pending 2>/dev/null || true
 				echo "CALYPSO_BASE_URL=%CALYPSO_BASE_URL%"
 				export CALYPSO_BASE_URL="%CALYPSO_BASE_URL%"
 				echo "DASHBOARD_BASE_URL=%DASHBOARD_BASE_URL%"

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -155,6 +155,21 @@ export class RestAPIClient {
 	}
 
 	/**
+	 * Returns the store sandbox cookie header.
+	 *
+	 * E2E purchases are made in the browser with the `store_sandbox` cookie set
+	 * (see `BrowserManager.setStoreCookie`), which routes the request to the
+	 * sandboxed store and its own ownership registry. Store-facing REST calls
+	 * made from Node must carry the same cookie, or they read the production
+	 * store and see none of the purchases the tests created.
+	 *
+	 * @returns {string} Cookie header string.
+	 */
+	private getStoreSandboxCookieHeader(): string {
+		return `store_sandbox=${ SecretsManager.secrets.storeSandboxCookieValue }`;
+	}
+
+	/**
 	 * Returns a fully constructed URL object pointing to the request endpoint.
 	 *
 	 * @param {EndpointVersions} version Version of the API to use.
@@ -632,24 +647,29 @@ export class RestAPIClient {
 	/* Purchases */
 
 	/**
-	 * Returns all purchases belonging to the authenticated user.
+	 * Returns purchases belonging to the authenticated user.
 	 *
 	 * Discovery is bearer-scoped and needs no site ID, so it works even when the
-	 * test failed before a site slug/ID was known.
+	 * test failed before a site slug/ID was known. Pass `siteId` to scope the
+	 * listing to one site: the long-lived shared accounts have accumulated enough
+	 * sandbox purchases that the unscoped listing times out at the gateway.
 	 *
+	 * @param {number|string} [siteId] List only this site's purchases.
 	 * @returns {Promise<AllPurchasesResponse>} Array of the user's purchases.
 	 * @throws {Error} If the API responded with an error.
 	 */
-	async getAllPurchases(): Promise< AllPurchasesResponse > {
+	async getAllPurchases( siteId?: number | string ): Promise< AllPurchasesResponse > {
 		const params: RequestParams = {
 			method: 'get',
 			headers: {
 				Authorization: await this.getAuthorizationHeader( 'bearer' ),
 				'Content-Type': this.getContentTypeHeader( 'json' ),
+				Cookie: this.getStoreSandboxCookieHeader(),
 			},
 		};
 
-		const response = await this.sendRequest( this.getRequestURL( '1.2', '/me/purchases' ), params );
+		const endpoint = siteId === undefined ? '/me/purchases' : `/sites/${ siteId }/purchases`;
+		const response = await this.sendRequest( this.getRequestURL( '1.2', endpoint ), params );
 
 		if ( response.hasOwnProperty( 'error' ) ) {
 			throw new Error(
@@ -677,6 +697,7 @@ export class RestAPIClient {
 			headers: {
 				Authorization: await this.getAuthorizationHeader( 'bearer' ),
 				'Content-Type': this.getContentTypeHeader( 'json' ),
+				Cookie: this.getStoreSandboxCookieHeader(),
 			},
 			body: JSON.stringify( body ),
 		};
@@ -700,7 +721,7 @@ export class RestAPIClient {
 	 * @throws {Error} If listing purchases responded with an error.
 	 */
 	async cancelAtomicPlan( siteId?: number | string ): Promise< any | null > {
-		const purchases = await this.getAllPurchases();
+		const purchases = await this.getAllPurchases( siteId );
 
 		const plan = purchases.find(
 			( purchase ) =>

--- a/packages/calypso-e2e/src/teardown-markers.ts
+++ b/packages/calypso-e2e/src/teardown-markers.ts
@@ -549,16 +549,6 @@ export async function closeAccountAndRecordLeak(
 		await new Promise( ( resolve ) => setTimeout( resolve, pollMs ) );
 	}
 
-	if ( sawAtomicSite ) {
-		console.log(
-			`[atomic-teardown] user ${
-				accountDetails.userID
-			} still blocked by an Atomic site after ${ attempts } attempt(s) over ${
-				Date.now() - startedAt
-			}ms; recording leak.`
-		);
-	}
-
 	try {
 		await client.getMyAccountInformation();
 		// Account still exists and we failed to close it: a real leak.

--- a/packages/calypso-e2e/src/teardown-markers.ts
+++ b/packages/calypso-e2e/src/teardown-markers.ts
@@ -1,6 +1,7 @@
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import type { RestAPIClient } from './rest-api-client';
+import { setTimeout as delay } from 'node:timers/promises';
+import { RestAPIClient } from './rest-api-client';
 import type { AccountClosureResponse, AccountDetails } from './types';
 
 const MAX_ERROR_LENGTH = 300;
@@ -15,6 +16,24 @@ const ATOMIC_DEPROVISION_POLL_MS = 15 * 1000;
 // Fresh signup tokens can reach `/me` before the account-close endpoint.
 const TOKEN_PROPAGATION_TIMEOUT_MS = 30 * 1000;
 const TOKEN_PROPAGATION_POLL_MS = 5 * 1000;
+
+// The reap runs in `globalTeardown`, which no Playwright timeout bounds, and
+// `sendRequest` issues bare `fetch` calls that can stall far longer than a poll
+// interval. Cap the whole thing so it cannot consume the build's remaining time
+// and starve the leak-check step that reports the outcome.
+const REAP_TOTAL_TIMEOUT_MS = ATOMIC_DEPROVISION_TIMEOUT_MS + 60 * 1000;
+
+export interface PendingClose {
+	userID: number;
+	username: string;
+	email: string;
+	/**
+	 * Needed to close the account later. Signup accounts are passwordless, so the
+	 * token is the only lever and cannot be re-derived from the credentials.
+	 * Keep pending records off `test/e2e/output`, which CI publishes as artifacts.
+	 */
+	bearerToken: string;
+}
 
 export interface AccountLeak {
 	/**
@@ -148,8 +167,10 @@ export function isAccountClosedError( error: unknown ): boolean {
  *
  * @param {string} leakDir Directory where markers are written.
  * @param {AccountLeak} leak Details of the leaked account.
+ * @returns {boolean} Whether the marker reached disk. Callers that are about to
+ * discard their own copy of the evidence must check it.
  */
-export function recordAccountLeak( leakDir: string, leak: AccountLeak ): void {
+export function recordAccountLeak( leakDir: string, leak: AccountLeak ): boolean {
 	const key = leak.userID || leak.email;
 	try {
 		mkdirSync( leakDir, { recursive: true } );
@@ -161,8 +182,10 @@ export function recordAccountLeak( leakDir: string, leak: AccountLeak ): void {
 			error: errorMessage( leak.error ),
 		};
 		writeFileSync( markerPath( leakDir, key ), JSON.stringify( payload ) + '\n' );
+		return true;
 	} catch ( error ) {
 		console.warn( `Failed to record teardown leak marker for account ${ key }: ${ error }` );
+		return false;
 	}
 }
 
@@ -182,6 +205,232 @@ export function clearAccountLeak( leakDir: string, userID: number ): void {
 }
 
 /**
+ * Absolute path of the pending-close record for an account inside `pendingDir`.
+ *
+ * @param {string} pendingDir Directory where pending records are written.
+ * @param {number} userID The user ID.
+ * @returns {string} Absolute record file path.
+ */
+function pendingPath( pendingDir: string, userID: number ): string {
+	return path.join( pendingDir, `pending-${ userID }.json` );
+}
+
+/**
+ * Defers an account close that is blocked by an Atomic site still deprovisioning.
+ *
+ * The spec has already cancelled the plan, so deprovision is in flight; blocking
+ * the `afterAll` on it burns minutes of the run per Atomic spec and still leaks
+ * whenever deprovision outlasts the window. Recording the account instead lets
+ * `reapPendingCloses` retry once the rest of the suite has run, spending the
+ * remaining run time as the wait. Never throws.
+ *
+ * @param {string} pendingDir Directory where pending records are written.
+ * @param {PendingClose} pending Account to close later.
+ * @returns {boolean} Whether the record reached disk. A false here means the
+ * account has no deferred owner, so the caller must fall back to a leak marker.
+ */
+export function recordPendingClose( pendingDir: string, pending: PendingClose ): boolean {
+	try {
+		mkdirSync( pendingDir, { recursive: true } );
+		writeFileSync( pendingPath( pendingDir, pending.userID ), JSON.stringify( pending ) + '\n' );
+		return true;
+	} catch ( error ) {
+		console.warn( `Failed to record pending close for user ${ pending.userID }: ${ error }` );
+		return false;
+	}
+}
+
+/**
+ * Removes a pending-close record. Idempotent and never throws.
+ *
+ * @param {string} pendingDir Directory where pending records are written.
+ * @param {number} userID The user ID.
+ */
+function clearPendingClose( pendingDir: string, userID: number ): void {
+	try {
+		rmSync( pendingPath( pendingDir, userID ), { force: true } );
+	} catch ( error ) {
+		console.warn( `Failed to clear pending close for user ${ userID }: ${ error }` );
+	}
+}
+
+/**
+ * Reads every pending-close record in `pendingDir`. Malformed records are skipped
+ * with a warning rather than failing the whole reap.
+ *
+ * @param {string} pendingDir Directory where pending records are written.
+ * @returns {PendingClose[]} The records that parsed.
+ */
+function readPendingCloses( pendingDir: string ): PendingClose[] {
+	let entries: string[];
+	try {
+		entries = readdirSync( pendingDir ).filter( ( name ) => name.startsWith( 'pending-' ) );
+	} catch {
+		// No directory means nothing was deferred.
+		return [];
+	}
+
+	const pending: PendingClose[] = [];
+	for ( const entry of entries ) {
+		let record: unknown;
+		try {
+			record = JSON.parse( readFileSync( path.join( pendingDir, entry ), 'utf8' ) );
+		} catch ( error ) {
+			console.warn( `Skipping unreadable pending close ${ entry }: ${ error }` );
+			continue;
+		}
+		if ( ! isPendingClose( record ) ) {
+			// Left in place on purpose: the CI check reports it, which is the only
+			// remaining signal for an account whose identity we cannot recover.
+			console.warn( `Skipping malformed pending close ${ entry }.` );
+			continue;
+		}
+		pending.push( record );
+	}
+	return pending;
+}
+
+/**
+ * Whether a value read back from disk is a usable pending-close record.
+ *
+ * A record can be truncated by a killed worker or left over in an older format,
+ * and the reaper acts on every field: an empty token silently degrades into a
+ * password login, and a non-object crashes the reap outright.
+ *
+ * @param {unknown} value Parsed record.
+ * @returns {boolean} True when every field the reaper needs is present and usable.
+ */
+function isPendingClose( value: unknown ): value is PendingClose {
+	if ( ! value || typeof value !== 'object' ) {
+		return false;
+	}
+	const record = value as Record< string, unknown >;
+	return (
+		Number.isFinite( record.userID ) &&
+		[ record.username, record.email, record.bearerToken ].every(
+			( field ) => typeof field === 'string' && field.length > 0
+		)
+	);
+}
+
+/**
+ * Hands a close blocked by Atomic deprovision to the end-of-run reaper.
+ *
+ * Falls back to a leak marker when the bearer token cannot be read, since without
+ * it the reaper has no way to authenticate and the account would vanish silently.
+ *
+ * @param {RestAPIClient} client REST API client authenticated as the account.
+ * @param {AccountDetails} accountDetails Identity of the account to close.
+ * @param {string} leakDir Directory where leak markers are written.
+ * @param {string} pendingDir Directory where pending records are written.
+ */
+async function deferClose(
+	client: RestAPIClient,
+	accountDetails: AccountDetails,
+	leakDir: string,
+	pendingDir: string
+): Promise< void > {
+	let bearerToken: string;
+	try {
+		bearerToken = await client.getBearerToken();
+	} catch ( error ) {
+		recordAccountLeak( leakDir, { ...accountDetails, error } );
+		return;
+	}
+
+	const deferred = recordPendingClose( pendingDir, {
+		userID: accountDetails.userID,
+		username: accountDetails.username,
+		email: accountDetails.email,
+		bearerToken,
+	} );
+
+	if ( ! deferred ) {
+		// Nothing owns the close now, so fall back to the pre-deferral contract:
+		// report it as a leak rather than let the account vanish from CI.
+		recordAccountLeak( leakDir, {
+			...accountDetails,
+			error: 'Atomic site still deprovisioning and the pending-close record could not be written.',
+		} );
+		return;
+	}
+
+	console.log(
+		`[atomic-teardown] user ${ accountDetails.userID } is blocked by an Atomic site; deferring close to the end of the run.`
+	);
+}
+
+/**
+ * Retries every deferred account close, then converts whatever is still blocked
+ * into a leak marker so CI reports it.
+ *
+ * Runs after the suite, when an Atomic site cancelled early in the run has had
+ * the whole run to deprovision. Accounts are reaped concurrently so the total
+ * wait is bounded by the slowest one rather than their sum. Each gets a fresh
+ * deprovision window, so an account that is already free closes on the first
+ * attempt and one that is not still has room to absorb a transient error.
+ *
+ * The pending record is cleared only once the account is accounted for - closed,
+ * confirmed gone, or written out as a leak marker. Clearing it unconditionally
+ * would discard the last evidence of an account whose marker failed to write,
+ * and the record is also the CI backstop for a reap that never finished.
+ *
+ * Never throws: `globalTeardown` rejecting would fail an otherwise green run.
+ *
+ * @param {string} pendingDir Directory where pending records are written.
+ * @param {string} leakDir Directory where leak markers are written.
+ */
+export async function reapPendingCloses( pendingDir: string, leakDir: string ): Promise< void > {
+	const pending = readPendingCloses( pendingDir );
+	if ( ! pending.length ) {
+		return;
+	}
+
+	console.log( `[atomic-teardown] reaping ${ pending.length } deferred account close(s).` );
+
+	const reaps = pending.map( async ( record ) => {
+		const client = new RestAPIClient(
+			{ username: record.username, password: '' },
+			record.bearerToken
+		);
+		const accountDetails: AccountDetails = {
+			userID: record.userID,
+			username: record.username,
+			email: record.email,
+		};
+
+		// The spec's cancel is best-effort (it warns and continues), so a run where
+		// it failed leaves a deprovision that never started and a close that can
+		// never succeed. Re-issuing it is a no-op once the plan is already gone.
+		try {
+			await client.cancelAtomicPlan();
+		} catch ( error ) {
+			console.warn( `Error re-cancelling Atomic plan for user ${ record.userID }: ${ error }` );
+		}
+
+		// No `pendingDir`: the reaper is the last stop, so it waits inline for the
+		// full deprovision window rather than deferring again.
+		const accountedFor = await closeAccountAndRecordLeak( client, accountDetails, leakDir );
+
+		if ( accountedFor ) {
+			clearPendingClose( pendingDir, record.userID );
+		} else {
+			console.warn(
+				`[atomic-teardown] user ${ record.userID } is neither closed nor leak-marked; keeping its pending record as the remaining evidence.`
+			);
+		}
+	} );
+
+	// `allSettled` so a single bad record cannot abandon the others mid-poll, and a
+	// deadline so the reap cannot eat the CI build's remaining time: the leak-check
+	// step runs after this and is the only thing that reports what was left behind.
+	await Promise.race( [
+		Promise.allSettled( reaps ),
+		delay( REAP_TOTAL_TIMEOUT_MS, undefined, { ref: false } ),
+	] );
+}
+
+/**
  * Closes a test account and maintains its teardown leak marker as CI evidence.
  *
  * Records a marker only when the account is confirmed to still exist after a
@@ -192,15 +441,25 @@ export function clearAccountLeak( leakDir: string, userID: number ): void {
  * (recorded), so a transient error never silently drops a real leak. Never throws,
  * so it is safe to call from an `afterAll`.
  *
+ * When `pendingDir` is given and the close is refused because the account's Atomic
+ * site is still deprovisioning, the account is deferred to `reapPendingCloses`
+ * rather than waited on here. Callers without a `pendingDir` (the reaper itself)
+ * fall back to waiting inline.
+ *
  * @param {RestAPIClient} client REST API client authenticated as the account.
  * @param {AccountDetails} accountDetails Identity of the account to close.
  * @param {string} leakDir Directory where leak markers are written.
+ * @param {string} [pendingDir] Directory where deferred closes are recorded.
+ * @returns {Promise<boolean>} Whether the account ended up accounted for: closed,
+ * confirmed already gone, deferred, or recorded as a leak. False means every
+ * signal failed, so a caller holding its own evidence must keep it.
  */
 export async function closeAccountAndRecordLeak(
 	client: RestAPIClient,
 	accountDetails: AccountDetails,
-	leakDir: string
-): Promise< void > {
+	leakDir: string,
+	pendingDir?: string
+): Promise< boolean > {
 	const hasUserID = Number.isInteger( accountDetails.userID ) && accountDetails.userID > 0;
 	const username =
 		typeof accountDetails.username === 'string' ? accountDetails.username.trim() : '';
@@ -209,7 +468,7 @@ export async function closeAccountAndRecordLeak(
 	if ( ! hasUserID || ! username || ! email ) {
 		console.warn( 'Skipping remote account teardown: account identity is incomplete.' );
 		if ( hasUserID || email ) {
-			recordAccountLeak( leakDir, {
+			return recordAccountLeak( leakDir, {
 				...( hasUserID ? { userID: accountDetails.userID } : {} ),
 				username,
 				email,
@@ -217,7 +476,8 @@ export async function closeAccountAndRecordLeak(
 					'Remote teardown skipped because the signup response contained an incomplete account identity.',
 			} );
 		}
-		return;
+		// No recordable key: nothing to close and nothing that could be leaking.
+		return true;
 	}
 
 	console.log( `Closing account ${ accountDetails.userID }.` );
@@ -251,7 +511,7 @@ export async function closeAccountAndRecordLeak(
 				}
 				console.log( `Successfully deleted user ID ${ accountDetails.userID }` );
 				clearAccountLeak( leakDir, accountDetails.userID );
-				return;
+				return true;
 			}
 
 			console.warn( `Failed to delete user ID ${ accountDetails.userID }` );
@@ -263,8 +523,17 @@ export async function closeAccountAndRecordLeak(
 		}
 
 		let pollMs: number;
-		if ( isActiveAtomicSiteError( closeError ) && Date.now() < atomicDeadline ) {
+		if ( isActiveAtomicSiteError( closeError ) ) {
+			// Hand the wait to the end-of-run reaper instead of holding the spec's
+			// `afterAll` open while the site deprovisions.
+			if ( pendingDir ) {
+				await deferClose( client, accountDetails, leakDir, pendingDir );
+				return true;
+			}
 			sawAtomicSite = true;
+			if ( Date.now() >= atomicDeadline ) {
+				break;
+			}
 			pollMs = ATOMIC_DEPROVISION_POLL_MS;
 		} else if ( isTransientInvalidTokenCloseResponse( closeError ) ) {
 			if ( tokenDeadline === undefined ) {
@@ -293,15 +562,15 @@ export async function closeAccountAndRecordLeak(
 	try {
 		await client.getMyAccountInformation();
 		// Account still exists and we failed to close it: a real leak.
-		recordAccountLeak( leakDir, { ...accountDetails, error: closeError } );
+		return recordAccountLeak( leakDir, { ...accountDetails, error: closeError } );
 	} catch ( probeError ) {
 		if ( isAccountClosedError( probeError ) ) {
 			// Dead token: the account is already gone. Not a leak.
 			clearAccountLeak( leakDir, accountDetails.userID );
-		} else {
-			// Could not confirm the account is gone (transient/network error).
-			// Be conservative and record so the CI check does not miss a real leak.
-			recordAccountLeak( leakDir, { ...accountDetails, error: closeError } );
+			return true;
 		}
+		// Could not confirm the account is gone (transient/network error).
+		// Be conservative and record so the CI check does not miss a real leak.
+		return recordAccountLeak( leakDir, { ...accountDetails, error: closeError } );
 	}
 }

--- a/packages/calypso-e2e/src/test/rest-api-client.purchases.test.ts
+++ b/packages/calypso-e2e/src/test/rest-api-client.purchases.test.ts
@@ -14,6 +14,7 @@ const fakeSecrets = {
 		client_id: 'some_value',
 		client_secret: 'some_value',
 	},
+	storeSandboxCookieValue: 'sandbox_ticket',
 } as unknown as Secrets;
 
 jest.spyOn( SecretsManager, 'secrets', 'get' ).mockImplementation( () => fakeSecrets );
@@ -53,6 +54,32 @@ describe( 'RestAPIClient: purchases', function () {
 
 		expect( response ).toHaveLength( 2 );
 		expect( response[ 0 ].product_slug ).toBe( 'business-bundle' );
+	} );
+
+	// Tests buy against the sandboxed store (browser-side `store_sandbox` cookie),
+	// which keeps its own ownership registry. Without the same cookie these calls
+	// read the production store, find no purchase, and the Atomic site is never
+	// deprovisioned - leaking the account.
+	test( 'store-facing requests carry the store sandbox cookie', async function () {
+		const cancelURL = restAPIClient.getRequestURL( '2', '/purchases/111/cancel', 'wpcom' );
+		const matchCookie = { reqheaders: { cookie: 'store_sandbox=sandbox_ticket' } };
+
+		const purchasesScope = nock( purchasesURL.origin, matchCookie )
+			.get( purchasesURL.pathname )
+			.reply( 200, [] );
+		const cancelScope = nock( cancelURL.origin, matchCookie )
+			.post( cancelURL.pathname )
+			.reply( 200, { status: 'completed' } );
+
+		await restAPIClient.getAllPurchases();
+		await restAPIClient.cancelPurchase( '111', {
+			product_id: '1008',
+			cancel_bundled_domain: 0,
+			email_variant: 'control',
+		} );
+
+		expect( purchasesScope.isDone() ).toBe( true );
+		expect( cancelScope.isDone() ).toBe( true );
 	} );
 
 	test( 'getAllPurchases throws when the API returns an error', async function () {
@@ -102,12 +129,18 @@ describe( 'RestAPIClient: purchases', function () {
 		};
 
 		/**
-		 * Stubs GET /me/purchases with the given list.
+		 * Stubs the purchases listing with the given list. Scoped to a site when
+		 * `siteId` is given, matching what `cancelAtomicPlan` requests.
 		 *
 		 * @param {unknown[]} purchases Raw purchase objects to return.
+		 * @param {number|string} [siteId] Site the listing is scoped to.
 		 */
-		function mockPurchases( purchases: unknown[] ) {
-			nock( purchasesURL.origin ).get( purchasesURL.pathname ).reply( 200, purchases );
+		function mockPurchases( purchases: unknown[], siteId?: number | string ) {
+			const url =
+				siteId === undefined
+					? purchasesURL
+					: restAPIClient.getRequestURL( '1.2', `/sites/${ siteId }/purchases` );
+			nock( url.origin ).get( url.pathname ).reply( 200, purchases );
 		}
 
 		test( 'cancels the first Business plan when no siteId is given', async function () {
@@ -136,7 +169,7 @@ describe( 'RestAPIClient: purchases', function () {
 		} );
 
 		test( 'cancels only the Business plan matching the given siteId', async function () {
-			mockPurchases( [ otherSitePlan, businessPlan ] );
+			mockPurchases( [ otherSitePlan, businessPlan ], 5 );
 			const cancelURL = restAPIClient.getRequestURL( '2', '/purchases/111/cancel', 'wpcom' );
 			const cancelScope = nock( cancelURL.origin )
 				.post( cancelURL.pathname )
@@ -148,7 +181,7 @@ describe( 'RestAPIClient: purchases', function () {
 		} );
 
 		test( 'returns null when no Business plan matches the given siteId', async function () {
-			mockPurchases( [ businessPlan ] );
+			mockPurchases( [ businessPlan ], 999 );
 
 			const response = await restAPIClient.cancelAtomicPlan( 999 );
 

--- a/packages/calypso-e2e/src/test/teardown-markers.test.ts
+++ b/packages/calypso-e2e/src/test/teardown-markers.test.ts
@@ -1,23 +1,52 @@
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, expect, test, jest, beforeEach, afterEach } from '@jest/globals';
+import nock from 'nock';
+import { SecretsManager } from '../secrets';
 import {
 	clearAccountLeak,
 	closeAccountAndRecordLeak,
 	isAccountClosedError,
+	reapPendingCloses,
 	recordAccountLeak,
+	recordPendingClose,
 } from '../teardown-markers';
 import type { RestAPIClient } from '../rest-api-client';
+import type { Secrets } from '../secrets';
+
+// The reap tests drive a real RestAPIClient, whose closeAccount reads secrets.
+// `SecretsManager.secrets` throws when decrypted-secrets.json is absent, and the
+// unit-test CI build never decrypts it.
+jest.spyOn( SecretsManager, 'secrets', 'get' ).mockImplementation(
+	() =>
+		( {
+			calypsoOauthApplication: { client_id: 'some_value', client_secret: 'some_value' },
+			gmailTestEmail: 'a8c.e2e@gmail.com',
+			storeSandboxCookieValue: 'sandbox_ticket',
+		} ) as unknown as Secrets
+);
 
 let leakDir: string;
+let pendingDir: string;
 
 beforeEach( () => {
 	leakDir = mkdtempSync( path.join( tmpdir(), 'teardown-markers-' ) );
+	pendingDir = mkdtempSync( path.join( tmpdir(), 'teardown-pending-' ) );
 } );
 
 afterEach( () => {
 	rmSync( leakDir, { recursive: true, force: true } );
+	rmSync( pendingDir, { recursive: true, force: true } );
+	nock.cleanAll();
 } );
 
 const markerFile = ( userID: number ): string => path.join( leakDir, `account-${ userID }.json` );
@@ -36,6 +65,7 @@ const details = {
 const fakeClient = ( impl: {
 	closeAccount: () => Promise< unknown >;
 	getMyAccountInformation: () => Promise< unknown >;
+	getBearerToken?: () => Promise< string >;
 } ): RestAPIClient => impl as unknown as RestAPIClient;
 
 describe( 'teardown-markers: record / clear', () => {
@@ -380,6 +410,8 @@ describe( 'closeAccountAndRecordLeak', () => {
 	} );
 
 	test( 'never throws even when the client throws', async () => {
+		// Resolving to true means the account was accounted for: the probe could not
+		// confirm it was gone, so a leak marker was written.
 		await expect(
 			closeAccountAndRecordLeak(
 				fakeClient( {
@@ -393,6 +425,176 @@ describe( 'closeAccountAndRecordLeak', () => {
 				details,
 				leakDir
 			)
-		).resolves.toBeUndefined();
+		).resolves.toBe( true );
+	} );
+} );
+
+describe( 'teardown-markers: deferred Atomic closes', () => {
+	const atomicRefusal = { error: 'atomic-site', message: 'active atomic sites' };
+	const pendingFile = ( userID: number ): string =>
+		path.join( pendingDir, `pending-${ userID }.json` );
+	// `closeAccount` refuses to act unless `/me` confirms the token belongs to the
+	// very account it was asked to close, so the stub has to match on all three.
+	const me = { ID: details.userID, username: details.username, email: details.email };
+
+	/**
+	 * Stubs every endpoint a reap touches: the identity precheck, the plan-cancel
+	 * retry, and the close itself.
+	 *
+	 * @param {unknown} closeReply Body the close endpoint returns.
+	 */
+	function mockReapEndpoints( closeReply: unknown ) {
+		nock( 'https://public-api.wordpress.com' ).persist().get( '/rest/v1.1/me' ).reply( 200, me );
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( '/rest/v1.2/me/purchases' )
+			.reply( 200, [] );
+		return nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.post( '/rest/v1.1/me/account/close' )
+			.reply( 200, closeReply as nock.Body );
+	}
+
+	test( 'defers instead of waiting when the Atomic site is still deprovisioning', async () => {
+		const closeAccount = jest.fn( async () => atomicRefusal );
+
+		await closeAccountAndRecordLeak(
+			fakeClient( {
+				closeAccount,
+				getMyAccountInformation: jest.fn( async () => ( {} ) ),
+				getBearerToken: jest.fn( async () => 'token-2001' ),
+			} ),
+			details,
+			leakDir,
+			pendingDir
+		);
+
+		// One attempt, no poll: the wait now belongs to the end-of-run reaper.
+		expect( closeAccount ).toHaveBeenCalledTimes( 1 );
+		expect( existsSync( markerFile( details.userID ) ) ).toBe( false );
+
+		const record = JSON.parse( readFileSync( pendingFile( details.userID ), 'utf8' ) );
+		expect( record.userID ).toBe( details.userID );
+		expect( record.bearerToken ).toBe( 'token-2001' );
+	} );
+
+	test( 'records a leak rather than deferring when the bearer token is unavailable', async () => {
+		await closeAccountAndRecordLeak(
+			fakeClient( {
+				closeAccount: jest.fn( async () => atomicRefusal ),
+				getMyAccountInformation: jest.fn( async () => ( {} ) ),
+				getBearerToken: jest.fn( async () => {
+					throw new Error( 'no token' );
+				} ),
+			} ),
+			details,
+			leakDir,
+			pendingDir
+		);
+
+		expect( existsSync( pendingFile( details.userID ) ) ).toBe( false );
+		expect( existsSync( markerFile( details.userID ) ) ).toBe( true );
+	} );
+
+	test( 'reap closes a deferred account and leaves no leak marker', async () => {
+		recordPendingClose( pendingDir, {
+			userID: details.userID,
+			username: details.username,
+			email: details.email,
+			bearerToken: 'token-2001',
+		} );
+
+		const close = mockReapEndpoints( { success: true } );
+
+		await reapPendingCloses( pendingDir, leakDir );
+
+		expect( close.isDone() ).toBe( true );
+		expect( existsSync( pendingFile( details.userID ) ) ).toBe( false );
+		expect( existsSync( markerFile( details.userID ) ) ).toBe( false );
+	} );
+
+	test( 'reap turns an account it cannot close into a leak marker', async () => {
+		recordPendingClose( pendingDir, {
+			userID: details.userID,
+			username: details.username,
+			email: details.email,
+			bearerToken: 'token-2001',
+		} );
+		// A non-atomic refusal ends the close loop immediately, so this covers the
+		// reaper's bookkeeping without waiting out the deprovision retry window.
+		mockReapEndpoints( { success: false, error: 'unknown_error' } );
+
+		await reapPendingCloses( pendingDir, leakDir );
+
+		// Cleared only because the leak is now reported by the marker instead; the
+		// record carries a bearer token and must not outlive its evidence.
+		expect( existsSync( pendingFile( details.userID ) ) ).toBe( false );
+		expect( existsSync( markerFile( details.userID ) ) ).toBe( true );
+	} );
+
+	test( 'reap is a no-op when nothing was deferred', async () => {
+		await expect( reapPendingCloses( pendingDir, leakDir ) ).resolves.toBeUndefined();
+		expect( readdirSync( leakDir ) ).toEqual( [] );
+	} );
+
+	test( 'records a leak rather than deferring when the pending record cannot be written', async () => {
+		// An unwritable pendingDir must not swallow the account: with no deferred
+		// owner, the leak marker is the only remaining signal.
+		rmSync( pendingDir, { recursive: true, force: true } );
+		writeFileSync( pendingDir, 'not a directory' );
+
+		await closeAccountAndRecordLeak(
+			fakeClient( {
+				closeAccount: jest.fn( async () => atomicRefusal ),
+				getMyAccountInformation: jest.fn( async () => ( {} ) ),
+				getBearerToken: jest.fn( async () => 'token-2001' ),
+			} ),
+			details,
+			leakDir,
+			pendingDir
+		);
+
+		expect( existsSync( markerFile( details.userID ) ) ).toBe( true );
+	} );
+
+	test( 'reap keeps the pending record when the leak marker cannot be written', async () => {
+		recordPendingClose( pendingDir, {
+			userID: details.userID,
+			username: details.username,
+			email: details.email,
+			bearerToken: 'token-2001',
+		} );
+		// Losing both signals at once would leave the account invisible to CI.
+		rmSync( leakDir, { recursive: true, force: true } );
+		writeFileSync( leakDir, 'not a directory' );
+
+		mockReapEndpoints( { success: false, error: 'unknown_error' } );
+
+		await reapPendingCloses( pendingDir, leakDir );
+
+		expect( existsSync( pendingFile( details.userID ) ) ).toBe( true );
+	} );
+
+	test( 'reap skips a malformed record instead of crashing, and leaves it for CI', async () => {
+		mkdirSync( pendingDir, { recursive: true } );
+		writeFileSync( path.join( pendingDir, 'pending-2001.json' ), 'null' );
+		writeFileSync( path.join( pendingDir, 'pending-2002.json' ), '{"userID":2002' );
+
+		await expect( reapPendingCloses( pendingDir, leakDir ) ).resolves.toBeUndefined();
+
+		expect( existsSync( path.join( pendingDir, 'pending-2001.json' ) ) ).toBe( true );
+		expect( existsSync( path.join( pendingDir, 'pending-2002.json' ) ) ).toBe( true );
+	} );
+
+	test( 'reap skips a record with an empty token rather than falling back to a password login', async () => {
+		mkdirSync( pendingDir, { recursive: true } );
+		writeFileSync(
+			path.join( pendingDir, `pending-${ details.userID }.json` ),
+			JSON.stringify( { ...details, bearerToken: '' } )
+		);
+
+		// No nock scopes: any HTTP attempt (notably a wp-login.php password login
+		// with an empty password) would throw a disallowed-net-connect error.
+		await expect( reapPendingCloses( pendingDir, leakDir ) ).resolves.toBeUndefined();
 	} );
 } );

--- a/test/e2e/lib/global-setup.ts
+++ b/test/e2e/lib/global-setup.ts
@@ -1,0 +1,15 @@
+import { rmSync } from 'node:fs';
+import { PENDING_CLOSE_DIR } from '../specs/shared/api-close-account';
+
+/**
+ * Drops deferred-close records left by an earlier run.
+ *
+ * Records hold live bearer tokens, and nothing else removes them outside CI: an
+ * aborted local run would otherwise leave credentials on disk indefinitely. They
+ * are also keyed only by user ID, so a later unrelated run would adopt them and
+ * report someone else's account as its own leak - with no retry budget, since
+ * their deprovision deadline is long past.
+ */
+export default function globalSetup(): void {
+	rmSync( PENDING_CLOSE_DIR, { recursive: true, force: true } );
+}

--- a/test/e2e/lib/global-setup.ts
+++ b/test/e2e/lib/global-setup.ts
@@ -1,15 +1,9 @@
 import { rmSync } from 'node:fs';
 import { PENDING_CLOSE_DIR } from '../specs/shared/api-close-account';
 
-/**
- * Drops deferred-close records left by an earlier run.
- *
- * Records hold live bearer tokens, and nothing else removes them outside CI: an
- * aborted local run would otherwise leave credentials on disk indefinitely. They
- * are also keyed only by user ID, so a later unrelated run would adopt them and
- * report someone else's account as its own leak - with no retry budget, since
- * their deprovision deadline is long past.
- */
 export default function globalSetup(): void {
+	// Records left by an earlier run hold live bearer tokens, and nothing else
+	// removes them outside CI. They are keyed only by user ID, so a later run
+	// would also adopt them and report someone else's account as its own leak.
 	rmSync( PENDING_CLOSE_DIR, { recursive: true, force: true } );
 }

--- a/test/e2e/lib/global-teardown.ts
+++ b/test/e2e/lib/global-teardown.ts
@@ -1,0 +1,17 @@
+import { reapPendingCloses } from '@automattic/calypso-e2e';
+import { LEAK_DIR, PENDING_CLOSE_DIR } from '../specs/shared/api-close-account';
+
+/**
+ * Closes the accounts whose teardown was deferred because their Atomic site was
+ * still deprovisioning.
+ *
+ * Cancelling the plan (done in the spec's `afterAll`) starts the deprovision, but
+ * the account cannot be closed until it finishes. Waiting for that inside the
+ * spec costs the run minutes per Atomic spec and still leaks whenever deprovision
+ * outlasts the window. Deferring to here spends the rest of the suite as the wait
+ * instead. Anything still blocked becomes a leak marker, so CI reports it exactly
+ * as before.
+ */
+export default async function globalTeardown(): Promise< void > {
+	await reapPendingCloses( PENDING_CLOSE_DIR, LEAK_DIR );
+}

--- a/test/e2e/lib/global-teardown.ts
+++ b/test/e2e/lib/global-teardown.ts
@@ -1,17 +1,9 @@
 import { reapPendingCloses } from '@automattic/calypso-e2e';
 import { LEAK_DIR, PENDING_CLOSE_DIR } from '../specs/shared/api-close-account';
 
-/**
- * Closes the accounts whose teardown was deferred because their Atomic site was
- * still deprovisioning.
- *
- * Cancelling the plan (done in the spec's `afterAll`) starts the deprovision, but
- * the account cannot be closed until it finishes. Waiting for that inside the
- * spec costs the run minutes per Atomic spec and still leaks whenever deprovision
- * outlasts the window. Deferring to here spends the rest of the suite as the wait
- * instead. Anything still blocked becomes a leak marker, so CI reports it exactly
- * as before.
- */
 export default async function globalTeardown(): Promise< void > {
+	// Closes the accounts whose close was deferred because their Atomic site was
+	// still deprovisioning. Waiting that out in each spec's `afterAll` costs
+	// minutes per Atomic spec; here the rest of the suite has served as the wait.
 	await reapPendingCloses( PENDING_CLOSE_DIR, LEAK_DIR );
 }

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -83,9 +83,9 @@ export default defineConfig( {
 	},
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
 	reporter,
-	/* Drops deferred-close records (and their bearer tokens) left by an earlier run. */
+	/* Runs once before the suite, before any worker starts */
 	globalSetup: require.resolve( './lib/global-setup' ),
-	/* Closes the accounts whose Atomic site was still deprovisioning when their spec finished. */
+	/* Runs once after the suite, when every worker has finished */
 	globalTeardown: require.resolve( './lib/global-teardown' ),
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	outputDir: `${ outputPath }/test-results`,

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -83,6 +83,10 @@ export default defineConfig( {
 	},
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
 	reporter,
+	/* Drops deferred-close records (and their bearer tokens) left by an earlier run. */
+	globalSetup: require.resolve( './lib/global-setup' ),
+	/* Closes the accounts whose Atomic site was still deprovisioning when their spec finished. */
+	globalTeardown: require.resolve( './lib/global-teardown' ),
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	outputDir: `${ outputPath }/test-results`,
 	use: {

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
@@ -35,7 +35,8 @@ test.describe(
 			// site via API"), so the only lever is cancelling the Business plan, which
 			// deprovisions the site asynchronously. The in-test cancellation only runs
 			// on the happy path; cancel here too (bearer-scoped) so a mid-test failure
-			// still deprovisions. apiCloseAccount then polls the close past that wait.
+			// still deprovisions. apiCloseAccount defers the close that deprovision
+			// blocks to the end-of-run reaper, so this hook does not wait it out.
 			test.setTimeout( 300 * 1000 );
 
 			const restAPIClient = new RestAPIClient(

--- a/test/e2e/specs/shared/api-close-account.ts
+++ b/test/e2e/specs/shared/api-close-account.ts
@@ -5,7 +5,11 @@ import type { AccountDetails, AccountLeak, RestAPIClient } from '@automattic/cal
 // Teardown leak markers live under the published, gitignored e2e output dir.
 // Playwright transpiles TS in place, so `__dirname` is the source dir:
 // `test/e2e/specs/shared` -> `test/e2e/output/teardown-leaks`.
-const LEAK_DIR = path.resolve( __dirname, '..', '..', 'output', 'teardown-leaks' );
+export const LEAK_DIR = path.resolve( __dirname, '..', '..', 'output', 'teardown-leaks' );
+
+// Deferred closes carry a bearer token, so they must stay out of `output/`:
+// CI publishes that whole directory as build artifacts.
+export const PENDING_CLOSE_DIR = path.resolve( __dirname, '..', '..', '.teardown-pending' );
 
 /**
  * Makes an API request to close the user account, maintaining a teardown leak
@@ -17,6 +21,9 @@ const LEAK_DIR = path.resolve( __dirname, '..', '..', 'output', 'teardown-leaks'
  * calling this on an already-closed account (e.g. one closed via the UI) is a
  * safe no-op. Never throws. See `closeAccountAndRecordLeak` for the full logic.
  *
+ * An account whose Atomic site is still deprovisioning is deferred to the
+ * end-of-run reaper (see the `globalTeardown`) instead of being waited on here.
+ *
  * @param {RestAPIClient} client Client to interact with the WP REST API.
  * @param {AccountDetails} accountDetails Details of the account to close.
  */
@@ -24,7 +31,7 @@ export async function apiCloseAccount(
 	client: RestAPIClient,
 	accountDetails: AccountDetails
 ): Promise< void > {
-	await closeAccountAndRecordLeak( client, accountDetails, LEAK_DIR );
+	await closeAccountAndRecordLeak( client, accountDetails, LEAK_DIR, PENDING_CLOSE_DIR );
 }
 
 /**


### PR DESCRIPTION
Slack thead: p1785492337740089-slack-C0E1C5NCR

## Proposed Changes

* `RestAPIClient` sends the `store_sandbox` cookie on store-facing calls (`getAllPurchases`, `cancelPurchase`).
* `getAllPurchases` takes an optional `siteId` and lists `/sites/<id>/purchases` when it gets one; `cancelAtomicPlan` passes it through.
* A close refused with `atomic-site` is deferred instead of waited out in the spec's `afterAll`. A reaper in `globalTeardown` retries it once the rest of the suite has run.
* `globalSetup` drops deferred records left by an earlier run.
* Records live in `test/e2e/.teardown-pending/`, gitignored and kept out of `output/`, which CI publishes as artifacts.
* `globalSetup` clears that directory at the start of every run, so a dead token from an earlier run is never adopted as this run's leak. TeamCity reports any surviving record as a build problem; it counts records, never prints them, since they hold bearer tokens.

## Why are these changes being made?

The pre-release builds have been failing the teardown leak check, and the leaked users drag their Atomic blogs along with them.

Checkout happens in a browser with the `store_sandbox` cookie set, so the purchase lands in the sandboxed store's own ownership registry. `RestAPIClient` was authenticating with the bearer token alone, so `/me/purchases` read the **production** store and came back empty. `cancelAtomicPlan` never found a Business plan to cancel, the site was never deprovisioned, and `/me/account/close` kept answering `atomic-site` until the retry window ran out.

Two things pinned it down: `Cancelling Business plan purchase` has never once appeared in a build since it was added, while `No Business plan purchase found` shows up per Atomic spec; and the production store had zero receipts and zero ownerships for a user whose browser had just rendered a receipt.

Cancelling the plan is only half of it. Deprovision is asynchronous and took 70 to 85 seconds in the runs I watched; blocking each `afterAll` on that costs minutes per spec and still leaks whenever deprovision outlasts the window. Deferring spends the rest of the suite as the wait instead, for no added build time. Whatever is still blocked at the end becomes a leak marker, so CI reports it exactly as before.

## Testing Instructions

Unit tests:

```
yarn jest --config=test/packages/jest.config.js packages/calypso-e2e
```

`rest-api-client.purchases.test.ts` asserts the cookie is on the outgoing request and that the site-scoped endpoint is used. `teardown-markers.test.ts` covers the deferral, the reaper's close and leak-marker paths, and the fallbacks when a directory is unwritable or a record is malformed.

End to end, the way the **Pre-Release E2E Tests** build runs it. The reaper ships in `@automattic/calypso-e2e`, so build the package first or `test/e2e` picks up a stale `dist`:

```
yarn workspace @automattic/calypso-e2e build
```

Then, with secrets decrypted:

```
cd test/e2e
NODE_CONFIG_ENV=test \
LOCALE=en \
BRANCH_NAME=trunk \
CALYPSO_BASE_URL=<CALYPSO_STAGING_URL> \
DASHBOARD_BASE_URL=<DASHBOARD_URL> \
yarn test:pw:desktop --grep=@calypso-release \
  specs/onboarding/onboarding__new-hosted-site.spec.ts --reporter=list
```

`BRANCH_NAME=trunk` is not optional: the spec is guarded by `skipIfNotTrunk()`, and without it Playwright skips the suite and the teardown path is never reached.

Expected log sequence — the `afterAll` defers instead of polling, and the reaper closes the account after the run:

```
Closing account <id>.
Failed to delete user ID <id>  { error: 'atomic-site', … }
[atomic-teardown] user <id> is blocked by an Atomic site; deferring close to the end of the run.
  ✓  … › As a new user, I can purchase a hosted site and cancel it @calypso-release (2.0m)
[atomic-teardown] reaping 1 deferred account close(s).
…
[atomic-teardown] user <id> closed after 5 attempt(s) over 69883ms of Atomic deprovision wait.
Successfully deleted user ID <id>
```

Then confirm the run left nothing behind, which is what the CI leak-check step reads:

```
find test/e2e/.teardown-pending -name 'pending-*.json'   # empty
find test/e2e/output -name 'account-*.json'              # empty
```

Mid-run, `test/e2e/.teardown-pending/pending-<id>.json` holds the deferred record.

For the store-sandbox half of the change, run the spec whose teardown cancels a live Business purchase. It exercises the site-scoped listing and logs `Cancelling Business plan purchase`, which has never appeared in a build before this change:

```
… yarn test:pw:desktop --grep=@calypso-release \
  specs/plans/plans__signup-business.spec.ts --reporter=list
```

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

