### PR TITLE
E2E: re-enable Premium theme signup+cancel against the Multi-site Dashboard

### DIFF
--- a/test/e2e/specs/onboarding/signup__with-theme-premium.spec.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.spec.ts
@@ -5,21 +5,20 @@
 import {
 	BrowserManager,
 	CartCheckoutPage,
+	DashboardMeSidebarComponent,
+	DashboardPurchasesPage,
+	DashboardSnackbarComponent,
 	DataHelper,
 	DomainSearchComponent,
 	LoggedOutThemesPage,
-	MeSidebarComponent,
-	MyProfilePage,
 	NewSiteResponse,
 	NewUserResponse,
-	NoticeComponent,
-	PurchasesPage,
 	RestAPIClient,
 	SecretsManager,
 	SignupPickPlanPage,
 	ThemesPage,
 	UserSignupPage,
-	cancelAtomicPurchaseFlow,
+	cancelDashboardPurchaseFlow,
 } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
 import { apiCloseAccount } from '../shared';
@@ -52,10 +51,7 @@ test.describe(
 			} );
 		} );
 
-		// Skipped for now; can be updated once we're sure all onboarding tests will go
-		// through the MSD flow. See https://github.com/Automattic/wp-calypso/pull/112586
-		// and https://github.com/Automattic/wp-calypso/pull/112587.
-		test.skip( 'Signup, purchase, and cancel a Premium theme plan', async ( { page } ) => {
+		test( 'Signup, purchase, and cancel a Premium theme plan', async ( { page } ) => {
 			// Signup + purchase + atomic cancel stacks a 90s purchase timeout
 			// with several 30s waits; the 120s config default is not enough.
 			test.setTimeout( 240 * 1000 );
@@ -133,32 +129,31 @@ test.describe(
 				expect( theme ).toContain( themeSlug );
 			} );
 
-			await test.step( 'Navigate to Me > Purchases', async () => {
-				const mePage = new MyProfilePage( page );
-				await mePage.visit();
-
-				const meSidebarComponent = new MeSidebarComponent( page );
-				await meSidebarComponent.openMobileMenu();
-				await meSidebarComponent.navigate( 'Purchases' );
+			await test.step( 'Navigate to Billing > Active upgrades', async () => {
+				await page.goto( DataHelper.getDashboardURL( '/me' ) );
+				const meSidebar = new DashboardMeSidebarComponent( page );
+				await meSidebar.openMobileMenu();
+				await meSidebar.navigate( 'Billing' );
+				await page.getByRole( 'link', { name: 'Active upgrades', exact: true } ).click();
 			} );
 
 			await test.step( 'View details of purchased plan and cancel plan', async () => {
-				const purchasesPage = new PurchasesPage( page );
+				const purchasesPage = new DashboardPurchasesPage( page );
 
 				await purchasesPage.clickOnPurchase(
 					`WordPress.com ${ planName }`,
 					newSiteDetails.blog_details.site_slug
 				);
-				await purchasesPage.cancelPurchase( 'Cancel plan' );
-				await cancelAtomicPurchaseFlow( page, {
+				await purchasesPage.cancelPurchase();
+				await cancelDashboardPurchaseFlow( page, {
 					reason: 'Another reason…',
 					customReasonText: 'E2E TEST CANCELLATION',
 				} );
-				const noticeComponent = new NoticeComponent( page );
-				await noticeComponent.noticeShown(
-					'Your refund has been processed and your purchase removed.',
-					{ timeout: 30 * 1000 }
-				);
+
+				const snackbar = new DashboardSnackbarComponent( page );
+				await snackbar.noticeShown( 'Your refund has been processed and your purchase removed.', {
+					exact: true,
+				} );
 			} );
 		} );
 	}


### PR DESCRIPTION
Fixes DOTMSD-1447. Part of DOTMSD-1443.

## Proposed Changes

* Re-enable the skipped E2E test `Signup, purchase, and cancel a Premium theme plan` in `signup__with-theme-premium.spec.ts` (removes the `test.skip`).
* Rewrite only the **cancellation half** for the Multi-site Dashboard: navigate `/me` → Billing → Active upgrades and cancel via `DashboardPurchasesPage` / `cancelDashboardPurchaseFlow` / `DashboardSnackbarComponent`, replacing Calypso's Me > Purchases (`MeSidebarComponent` / `MyProfilePage` / `PurchasesPage` / `cancelAtomicPurchaseFlow` / `NoticeComponent`). The success snackbar is a hard, exact assertion.
* Theme showcase, signup, checkout + coupon, the Marketplace thank-you install, and the REST active-theme check are unchanged — new users still land where they used to; only cancellation moved to the MSD.
* Mirrors #113212 (the LOHP theme spec), applied to this spec which builds its page objects directly rather than through the flow fixture.

## Why are these changes being made?

New users now land in the Multi-site Dashboard, whose cancellation UI differs from Calypso's, so the old cancellation steps no longer applied and the test was skipped during the MSD rollout. DOTMSD-1443 tracks re-enabling these onboarding specs one file at a time; this is the sub-task for this file.

## Testing Instructions

Real purchase (Premium plan, USD + test coupon) — needs a local dev server, E2E secrets (test payment card + coupon), and ~4 min.

```bash
cd test/e2e
yarn playwright test \
  specs/onboarding/signup__with-theme-premium.spec.ts \
  --project=chrome --reporter=list
```

Theme Showcase → filter Premium → start signup → Premium plan checkout → coupon → purchase → Marketplace install → REST confirms the selected theme → MSD cancellation reaches the `Your refund has been processed and your purchase removed.` snackbar → `afterAll` API account cleanup passes.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
