### PR TITLE
E2E: fix flaky security key login in the dashboard two-step spec

### DIFF
--- a/test/e2e/specs/authentication/authentication__dashboard-two-step.spec.ts
+++ b/test/e2e/specs/authentication/authentication__dashboard-two-step.spec.ts
@@ -94,11 +94,13 @@ async function continueWithSecurityKey( page: Page ): Promise< void > {
 		await switchToSecurityKey.click();
 	}
 
-	const continueButton = page.getByRole( 'button', { name: 'Continue with security key' } );
-	const isContinueButtonVisible = await continueButton.isVisible();
-	if ( isContinueButtonVisible ) {
-		await continueButton.click();
-	}
+	// The button is disabled for the duration of the ceremony, so the nudge is best-effort:
+	// a disabled or detached button means the ceremony is already under way, and the
+	// navigation below is the real signal that it succeeded.
+	await page
+		.getByRole( 'button', { name: 'Continue with security key' } )
+		.click( { timeout: 5_000 } )
+		.catch( () => undefined );
 
 	await page.waitForURL( ( url ) => ! url.pathname.includes( '/log-in' ), { timeout: 30_000 } );
 }

--- a/test/e2e/specs/authentication/authentication__dashboard-two-step.spec.ts
+++ b/test/e2e/specs/authentication/authentication__dashboard-two-step.spec.ts
@@ -94,13 +94,12 @@ async function continueWithSecurityKey( page: Page ): Promise< void > {
 		await switchToSecurityKey.click();
 	}
 
-	// The button is disabled for the duration of the ceremony, so the nudge is best-effort:
-	// a disabled or detached button means the ceremony is already under way, and the
-	// navigation below is the real signal that it succeeded.
+	// The button stays aria-disabled until the ceremony resolves and navigates away, so the
+	// nudge is best-effort; the navigation below is the real signal.
 	await page
 		.getByRole( 'button', { name: 'Continue with security key' } )
 		.click( { timeout: 5_000 } )
-		.catch( () => undefined );
+		.catch( ( error ) => console.warn( `Security key nudge skipped: ${ error }` ) );
 
 	await page.waitForURL( ( url ) => ! url.pathname.includes( '/log-in' ), { timeout: 30_000 } );
 }


### PR DESCRIPTION
## Proposed Changes

* Make the "Continue with security key" click in `continueWithSecurityKey` best-effort instead of guarding it with `isVisible()`, so the helper no longer fails when the WebAuthn ceremony completes on its own.

## Why are these changes being made?

`authentication__dashboard-two-step.spec.ts:187` (security key login case) failed in 3 of the last 4 scheduled runs of the `Authentication E2E Tests` job on trunk, all un-muted:

- https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Authentication/18748312
- https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Authentication/18758259
- https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Authentication/18759970

The login form auto-starts the WebAuthn ceremony on mount and keeps the button `aria-disabled="true"` until the ceremony resolves and the page navigates away. The button is therefore **never enabled on the happy path**. The old `isVisible()`-then-`click()` sequence checked visibility, then raced the navigation:

```
- locator resolved to <button type="submit" aria-disabled="true" …>Continue with security key</button>
- attempting click action
  2 × waiting for element to be visible, enabled and stable
    - element is not enabled
- element was detached from the DOM, retrying
  - navigated to "https://my.wordpress.com/me/security/two-step-auth"
```

In all three builds **the login actually succeeded** — the page reached the dashboard. Only the nudge click failed. Waiting for the button to become enabled would not have helped, since it never does; the click is a fallback for the case where auto-start needs a gesture, and the `waitForURL` below it is the real assertion that login completed. That assertion and its 30s timeout are unchanged.

## Testing Instructions

This spec is gated to the `authentication` Playwright project and to `DASHBOARD_BASE_URL` being `my.wordpress.com`. Note it runs against **production**, not staging: WebAuthn credentials are origin-scoped, so on `wpcalypso.wordpress.com` the ceremony fails with "Oops! Something went wrong." and the spec fails identically with or without this change.

```bash
CALYPSO_BASE_URL=https://wordpress.com \
DASHBOARD_BASE_URL=https://my.wordpress.com \
yarn workspace wp-e2e-tests playwright test \
  specs/authentication/authentication__dashboard-two-step.spec.ts \
  --project=authentication --repeat-each=5 --reporter=list
```

Verified against production with the same configuration the CI job uses: **5/5 repeats passed** (`6 passed (1.8m)`, including the `mailosaur-usage-check` setup). Each repeat signs up a throwaway account and closes it in `afterAll`; all five were confirmed deleted in the run output. For contrast, the unmodified spec was also run and fails on staging for the origin-scoped reason above.

`tsc --noEmit -p test/e2e/tsconfig.json` and ESLint are clean.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
