### PR TITLE
E2E: wait out the post-login redirect in the Blackbox allow spec

### DIFF
--- a/test/e2e/specs/authentication/authentication__blackbox-login-allow.spec.ts
+++ b/test/e2e/specs/authentication/authentication__blackbox-login-allow.spec.ts
@@ -60,7 +60,13 @@ test.describe( 'Authentication: Blackbox login allow', { tag: [ tags.AUTHENTICAT
 		} );
 
 		await test.step( 'Then I leave the login page', async function () {
-			await expect( page ).not.toHaveURL( /log-in/ );
+			// The redirect only fires once remoteLoginUser has settled its token-link
+			// iframes, which it allows 25s each, and is then a full page load. Budget
+			// past that and wait for the URL to change rather than for it to load.
+			await page.waitForURL( ( url ) => ! /log-in/.test( url.toString() ), {
+				waitUntil: 'commit',
+				timeout: 60 * 1000,
+			} );
 		} );
 	} );
 } );

--- a/test/e2e/specs/authentication/authentication__blackbox-login-allow.spec.ts
+++ b/test/e2e/specs/authentication/authentication__blackbox-login-allow.spec.ts
@@ -63,7 +63,7 @@ test.describe( 'Authentication: Blackbox login allow', { tag: [ tags.AUTHENTICAT
 			// The redirect only fires once remoteLoginUser has settled its token-link
 			// iframes, which it allows 25s each, and is then a full page load. Budget
 			// past that and wait for the URL to change rather than for it to load.
-			await page.waitForURL( ( url ) => ! /log-in/.test( url.toString() ), {
+			await page.waitForURL( ( url ) => ! url.pathname.includes( '/log-in' ), {
 				waitUntil: 'commit',
 				timeout: 60 * 1000,
 			} );


### PR DESCRIPTION
Reported in p1785715368781069-slack-C0E1C5NCR

## Proposed Changes

* Replace `await expect( page ).not.toHaveURL( /log-in/ )` in `authentication__blackbox-login-allow.spec.ts` with a `page.waitForURL()` that waits on `commit` and allows 60s.

## Why are these changes being made?

The spec landed recently and immediately started flaking in the Authentication E2E job on trunk: builds 5102 and 5103 failed, 5100, 5101 and 5104 passed.

Every failure was the last assertion, with the login already successful — the preceding step asserts the `action=login-endpoint` POST returned 200 with `success: true` and the expected `blackbox_session_id`. The Playwright call log reads `waiting for "…/" navigation to finish`, the failure video shows the Log In button enabled with no challenge on screen, and the passing runs take ~8s end to end against ~23-27s for the failing ones. Blackbox is not involved; the whole test is just slower on those runs.

`expect.timeout` in `playwright.config.ts` is 10000ms, and the redirect cannot reliably fit in that. `rebootAfterLogin` only runs after `remoteLoginUser` has settled the login `token_links`, each loaded in a hidden iframe with a 25s budget of its own (`client/state/login/actions/remote-login-user.js`), and it then does a full document navigation into a cold Calypso bundle. Waiting for the URL to change — rather than asserting on it once — with a budget past that 25s worst case removes the race.

## Testing Instructions

Run the Blackbox specs under the authentication project, with `CALYPSO_BASE_URL` pointed at production, as the Authentication job does:

```
yarn workspace wp-e2e-tests test:pw:authentication -- --grep "Blackbox" --repeat-each=5
```

All 15 pass (5 each of allow, block, challenge).

To confirm the change actually fixes the race rather than just not regressing, register a route that delays every non-`log-in` navigation by 15s before submitting. With the old assertion the test fails with the exact CI signature (`Received string: "…/log-in"`, `Timeout: 10000ms`); with this change it passes.

Note: `authentication__blackbox-login-challenge.spec.ts:19` flaked once during these runs on its own `page.waitForResponse` for the Blackbox collect POST. Same 10s-default family, different spec, not addressed here.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
