### PR TITLE
Email verification: stop a resend and a cancellation from undoing each other

### DIFF
--- a/client/dashboard/me/profile-personal-details/email-section.tsx
+++ b/client/dashboard/me/profile-personal-details/email-section.tsx
@@ -49,8 +49,6 @@ export default function EmailSection( {
 	onValidationChange,
 }: EmailSectionProps ) {
 	const mutation = cancelPendingEmailChangeMutation();
-	// Also true while the banner's resend or cancellation is running, so the two controls that
-	// offer a cancellation can't both fire, and neither can race a resend.
 	const isEmailWritePending = useIsEmailWritePending();
 
 	const { mutate: cancelPendingEmail } = useMutation( {

--- a/client/dashboard/me/profile-personal-details/email-section.tsx
+++ b/client/dashboard/me/profile-personal-details/email-section.tsx
@@ -10,6 +10,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { recoveryEmailMatchesAccountEmail } from '../security-account-recovery/utils';
 import { isCustomDomainEmail } from './email-utils';
+import { useIsEmailWritePending } from './use-email-write-pending';
 import type { UserSettings } from '@automattic/api-core';
 import './style.scss';
 
@@ -48,8 +49,11 @@ export default function EmailSection( {
 	onValidationChange,
 }: EmailSectionProps ) {
 	const mutation = cancelPendingEmailChangeMutation();
+	// Also true while the banner's resend or cancellation is running, so the two controls that
+	// offer a cancellation can't both fire, and neither can race a resend.
+	const isEmailWritePending = useIsEmailWritePending();
 
-	const { mutate: cancelPendingEmail, isPending: isCancelPending } = useMutation( {
+	const { mutate: cancelPendingEmail } = useMutation( {
 		...withSnackbar( mutation, {
 			success: __( 'Pending email change canceled.' ),
 			error: __( 'Failed to cancel pending email change.' ),
@@ -142,7 +146,7 @@ export default function EmailSection( {
 					<Button
 						variant="link"
 						onClick={ handleCancelPendingEmail }
-						disabled={ isCancelPending }
+						disabled={ isEmailWritePending }
 						style={ {
 							padding: 0,
 							height: 'auto',
@@ -211,7 +215,7 @@ export default function EmailSection( {
 		currentEmail,
 		emailValidationState,
 		handleCancelPendingEmail,
-		isCancelPending,
+		isEmailWritePending,
 	] );
 
 	return (

--- a/client/dashboard/me/profile-personal-details/index.tsx
+++ b/client/dashboard/me/profile-personal-details/index.tsx
@@ -35,11 +35,13 @@ export default function PersonalDetailsSection() {
 	const [ edits, setEdits ] = useState< Partial< UserSettings > >( {} );
 	const [ isEmailValid, setIsEmailValid ] = useState< boolean >( true );
 
-	const mutation = useMutation(
-		withSnackbar( userSettingsMutation(), {
-			success: __( 'Settings saved.' ),
-			error: { source: 'server' },
-		} )
+	const snackbar = { success: __( 'Settings saved.' ), error: { source: 'server' as const } };
+	const mutation = useMutation( withSnackbar( userSettingsMutation(), snackbar ) );
+	// Only a save that carries `user_email` is ordered against the resend and cancellation
+	// controls. Kept as its own instance rather than switching one mutation's options, which an
+	// in-flight save would pick up.
+	const emailMutation = useMutation(
+		withSnackbar( userSettingsMutation( { includesEmail: true } ), snackbar )
 	);
 
 	const data = useMemo( () => ( { ...userSettings, ...edits } ), [ userSettings, edits ] );
@@ -63,7 +65,8 @@ export default function PersonalDetailsSection() {
 			return;
 		}
 
-		mutation.mutate( submissionEdits, {
+		const save = 'user_email' in submissionEdits ? emailMutation : mutation;
+		save.mutate( submissionEdits, {
 			onSuccess: () => {
 				setEdits( {} );
 			},
@@ -85,7 +88,7 @@ export default function PersonalDetailsSection() {
 		return data[ key as keyof UserSettings ] !== userSettings[ key as keyof UserSettings ];
 	} );
 
-	const isSaving = mutation.isPending;
+	const isSaving = mutation.isPending || emailMutation.isPending;
 
 	// DataForm fields
 	const nameFields: Field< UserSettings >[] = [

--- a/client/dashboard/me/profile-personal-details/index.tsx
+++ b/client/dashboard/me/profile-personal-details/index.tsx
@@ -1,5 +1,6 @@
 import {
 	isAutomatticianQuery,
+	userEmailSettingsMutation,
 	userSettingsMutation,
 	userSettingsQuery,
 } from '@automattic/api-queries';
@@ -37,12 +38,9 @@ export default function PersonalDetailsSection() {
 
 	const snackbar = { success: __( 'Settings saved.' ), error: { source: 'server' as const } };
 	const mutation = useMutation( withSnackbar( userSettingsMutation(), snackbar ) );
-	// Only a save that carries `user_email` is ordered against the resend and cancellation
-	// controls. Kept as its own instance rather than switching one mutation's options, which an
-	// in-flight save would pick up.
-	const emailMutation = useMutation(
-		withSnackbar( userSettingsMutation( { includesEmail: true } ), snackbar )
-	);
+	// Two instances rather than one whose options change with the payload, which a save already
+	// in flight would pick up.
+	const emailMutation = useMutation( withSnackbar( userEmailSettingsMutation(), snackbar ) );
 
 	const data = useMemo( () => ( { ...userSettings, ...edits } ), [ userSettings, edits ] );
 

--- a/client/dashboard/me/profile-personal-details/test/index.test.tsx
+++ b/client/dashboard/me/profile-personal-details/test/index.test.tsx
@@ -254,6 +254,42 @@ describe( '<PersonalDetailsSection>', () => {
 			} );
 		} );
 
+		test( 'holds back the email field cancellation while the banner is resending', async () => {
+			const user = userEvent.setup();
+			const pending = {
+				...settings,
+				user_email_change_pending: true,
+				new_user_email: 'pending@example.com',
+			} as unknown as UserSettings;
+			mockUserSettings( pending );
+			mockIsAutomattician( false );
+
+			render( <PersonalDetailsSection /> );
+
+			// Held open so the resend is still running while the cancellation is checked.
+			let deliverResend: () => void;
+			nock( 'https://public-api.wordpress.com' )
+				.post( '/rest/v1.1/me/settings', ( body ) => 'user_email' in body )
+				.reply(
+					() =>
+						new Promise( ( resolve ) => {
+							deliverResend = () => resolve( [ 200, pending ] );
+						} )
+				);
+
+			await user.click( await screen.findByRole( 'button', { name: 'Resend email' } ) );
+
+			// The banner and the email field each offer a cancellation and neither can see the
+			// other's state, so a resend re-saving the pending address has to lock both.
+			const cancelLink = screen.getByRole( 'button', {
+				name: 'Cancel the pending email change.',
+			} );
+			expect( cancelLink ).toBeDisabled();
+			deliverResend!();
+
+			await waitFor( () => expect( cancelLink ).toBeEnabled() );
+		} );
+
 		test( 'warns when the account email uses a custom domain and no recovery method is set', async () => {
 			mockUserSettings( {
 				...settings,

--- a/client/dashboard/me/profile-personal-details/update-email/email-verification-banner.tsx
+++ b/client/dashboard/me/profile-personal-details/update-email/email-verification-banner.tsx
@@ -171,16 +171,12 @@ export default function EmailVerificationBanner( {
 
 	// The address is a mutation variable, so a response that lands late is still reported against
 	// the address it was sent to rather than whichever one is on screen by then.
-	const pendingResend = resendEmailVerificationMutation();
 	const { mutate: resendToPending, isPending: isPendingResendPending } = useMutation( {
-		...pendingResend,
+		...resendEmailVerificationMutation(),
 		// Deliberately not passed to `mutate()`, where these would usually go: TanStack skips
 		// per-call callbacks once the observer loses its listeners, so a resend outliving the
-		// banner would report nothing at all. Declaring it here replaces the factory's, so that
-		// one is called on: forwarded whole, so a change to its arguments can't drift from this.
-		onSuccess: ( ...args ) => {
-			pendingResend.onSuccess?.( ...args );
-			const [ , email ] = args;
+		// banner would report nothing at all.
+		onSuccess: ( _data, email ) => {
 			createSuccessNotice( sentToEmail( email ), { type: 'snackbar' } );
 			// A wait is meaningless once the address has moved on.
 			if ( email === pendingEmailRef.current ) {

--- a/client/dashboard/me/profile-personal-details/update-email/email-verification-banner.tsx
+++ b/client/dashboard/me/profile-personal-details/update-email/email-verification-banner.tsx
@@ -20,6 +20,7 @@ import {
 	resendThrottleRetryAfter,
 } from '../../../utils/email-verification-resend';
 import { useResendCooldown } from '../../../utils/use-resend-cooldown';
+import { useIsEmailWritePending } from '../use-email-write-pending';
 import type { UserSettings } from '@automattic/api-core';
 
 // Get email verification params from URL
@@ -170,11 +171,15 @@ export default function EmailVerificationBanner( {
 
 	// The address is a mutation variable, so a response that lands late is still reported against
 	// the address it was sent to rather than whichever one is on screen by then.
+	const pendingResend = resendEmailVerificationMutation();
 	const { mutate: resendToPending, isPending: isPendingResendPending } = useMutation( {
-		...resendEmailVerificationMutation(),
+		...pendingResend,
 		// On the options rather than the `mutate()` call: TanStack skips per-call callbacks once
 		// the observer loses its listeners, so navigating away mid-request would report nothing.
-		onSuccess: ( data, email ) => {
+		onSuccess: ( data, email, context ) => {
+			// Declaring onSuccess here would otherwise replace the factory's, losing the cache
+			// update it makes.
+			pendingResend.onSuccess?.( data, email, context );
 			createSuccessNotice( sentToEmail( email ), { type: 'snackbar' } );
 			// A wait is meaningless once the address has moved on.
 			if ( email === pendingEmailRef.current ) {
@@ -188,6 +193,7 @@ export default function EmailVerificationBanner( {
 	const resendEmail = () =>
 		isEmailChangePending ? resendToPending( pendingEmail || '' ) : sendToOriginal();
 	const isResendPending = isSendPending || isPendingResendPending;
+	const isEmailWritePending = useIsEmailWritePending();
 
 	const { mutate: cancelPendingEmail, isPending: isCancelPending } = useMutation(
 		withSnackbar( cancelPendingEmailChangeMutation(), {
@@ -240,7 +246,7 @@ export default function EmailVerificationBanner( {
 							variant="primary"
 							__next40pxDefaultSize
 							onClick={ resendEmail }
-							disabled={ isResendPending || isAwaitingResend }
+							disabled={ isEmailWritePending || isSendPending || isAwaitingResend }
 							isBusy={ isResendPending }
 						>
 							{ isAwaitingResend
@@ -256,7 +262,7 @@ export default function EmailVerificationBanner( {
 								variant="secondary"
 								__next40pxDefaultSize
 								onClick={ () => cancelPendingEmail() }
-								disabled={ isCancelPending }
+								disabled={ isEmailWritePending }
 								isBusy={ isCancelPending }
 							>
 								{ __( 'Cancel the pending email change' ) }

--- a/client/dashboard/me/profile-personal-details/update-email/email-verification-banner.tsx
+++ b/client/dashboard/me/profile-personal-details/update-email/email-verification-banner.tsx
@@ -174,12 +174,13 @@ export default function EmailVerificationBanner( {
 	const pendingResend = resendEmailVerificationMutation();
 	const { mutate: resendToPending, isPending: isPendingResendPending } = useMutation( {
 		...pendingResend,
-		// On the options rather than the `mutate()` call: TanStack skips per-call callbacks once
-		// the observer loses its listeners, so navigating away mid-request would report nothing.
-		onSuccess: ( data, email, context ) => {
-			// Declaring onSuccess here would otherwise replace the factory's, losing the cache
-			// update it makes.
-			pendingResend.onSuccess?.( data, email, context );
+		// Deliberately not passed to `mutate()`, where these would usually go: TanStack skips
+		// per-call callbacks once the observer loses its listeners, so a resend outliving the
+		// banner would report nothing at all. Declaring it here replaces the factory's, so that
+		// one is called on: forwarded whole, so a change to its arguments can't drift from this.
+		onSuccess: ( ...args ) => {
+			pendingResend.onSuccess?.( ...args );
+			const [ , email ] = args;
 			createSuccessNotice( sentToEmail( email ), { type: 'snackbar' } );
 			// A wait is meaningless once the address has moved on.
 			if ( email === pendingEmailRef.current ) {

--- a/client/dashboard/me/profile-personal-details/update-email/test/email-verification-banner.test.tsx
+++ b/client/dashboard/me/profile-personal-details/update-email/test/email-verification-banner.test.tsx
@@ -146,12 +146,11 @@ describe( '<EmailVerificationBanner>', () => {
 		).toBeDisabled();
 	} );
 
-	test( 'keeps the cached settings in step with a pending resend', async () => {
+	test( 'a resend cannot put back settings saved while it was in flight', async () => {
 		const user = userEvent.setup();
-		// Deliberately stale, so only the response can bring it back into line.
 		queryClient.setQueryData( userSettingsQuery().queryKey, {
 			...pendingSettings,
-			new_user_email: 'stale@example.com',
+			first_name: 'Jon',
 		} );
 
 		render( <EmailVerificationBanner userSettings={ pendingSettings } isEmailVerified />, {
@@ -160,17 +159,34 @@ describe( '<EmailVerificationBanner>', () => {
 
 		expect( await screen.findByText( 'Verify your email' ) ).toBeVisible();
 
+		// The endpoint answers with the whole account, as it stood before the save below.
+		let deliverReply: () => void;
 		nock( 'https://public-api.wordpress.com' )
 			.post( '/rest/v1.1/me/settings', ( body ) => 'user_email' in body )
-			.reply( 200, pendingSettings );
+			.reply(
+				() =>
+					new Promise( ( resolve ) => {
+						deliverReply = () => resolve( [ 200, { ...pendingSettings, first_name: 'Jon' } ] );
+					} )
+			);
 
 		await user.click( screen.getByRole( 'button', { name: 'Resend email' } ) );
 
+		// An ordinary settings save lands first. It carries no address, so nothing orders it
+		// against the resend.
+		queryClient.setQueryData( userSettingsQuery().queryKey, {
+			...pendingSettings,
+			first_name: 'Jane',
+		} );
+		deliverReply!();
+
+		// The button taking up its wait is what tells us the response has been handled.
 		await waitFor( () =>
-			expect(
-				queryClient.getQueryData< UserSettings >( userSettingsQuery().queryKey )?.new_user_email
-			).toBe( 'pending@example.com' )
+			expect( screen.getByRole( 'button', { name: /Resend email \(/ } ) ).toBeDisabled()
 		);
+		expect(
+			queryClient.getQueryData< UserSettings >( userSettingsQuery().queryKey )?.first_name
+		).toBe( 'Jane' );
 	} );
 
 	test( 'withholds the resend while a cancellation is in flight', async () => {

--- a/client/dashboard/me/profile-personal-details/update-email/test/email-verification-banner.test.tsx
+++ b/client/dashboard/me/profile-personal-details/update-email/test/email-verification-banner.test.tsx
@@ -3,6 +3,7 @@
  */
 
 import '@testing-library/jest-dom';
+import { queryClient, userSettingsQuery } from '@automattic/api-queries';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { dispatch } from '@wordpress/data';
@@ -143,6 +144,78 @@ describe( '<EmailVerificationBanner>', () => {
 		expect(
 			await screen.findByRole( 'button', { name: 'Resend email (4:00:00)' } )
 		).toBeDisabled();
+	} );
+
+	test( 'keeps the cached settings in step with a pending resend', async () => {
+		const user = userEvent.setup();
+		// Deliberately stale, so only the response can bring it back into line.
+		queryClient.setQueryData( userSettingsQuery().queryKey, {
+			...pendingSettings,
+			new_user_email: 'stale@example.com',
+		} );
+
+		render( <EmailVerificationBanner userSettings={ pendingSettings } isEmailVerified />, {
+			queryClient,
+		} );
+
+		expect( await screen.findByText( 'Verify your email' ) ).toBeVisible();
+
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/rest/v1.1/me/settings', ( body ) => 'user_email' in body )
+			.reply( 200, pendingSettings );
+
+		await user.click( screen.getByRole( 'button', { name: 'Resend email' } ) );
+
+		await waitFor( () =>
+			expect(
+				queryClient.getQueryData< UserSettings >( userSettingsQuery().queryKey )?.new_user_email
+			).toBe( 'pending@example.com' )
+		);
+	} );
+
+	test( 'withholds the resend while a cancellation is in flight', async () => {
+		const user = userEvent.setup();
+		queryClient.setQueryData( userSettingsQuery().queryKey, pendingSettings );
+
+		render( <EmailVerificationBanner userSettings={ pendingSettings } isEmailVerified />, {
+			queryClient,
+		} );
+
+		expect( await screen.findByText( 'Verify your email' ) ).toBeVisible();
+
+		let resendReached = false;
+		// Held open so the cancellation is still running while the resend is checked.
+		let deliverCancel: () => void;
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/rest/v1.1/me/settings', ( body ) => 'user_email_change_pending' in body )
+			.reply(
+				() =>
+					new Promise( ( resolve ) => {
+						deliverCancel = () =>
+							resolve( [ 200, { ...pendingSettings, user_email_change_pending: false } ] );
+					} )
+			);
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/rest/v1.1/me/settings', ( body ) => 'user_email' in body )
+			.reply( 200, () => {
+				resendReached = true;
+				return pendingSettings;
+			} );
+
+		await user.click( screen.getByRole( 'button', { name: 'Cancel the pending email change' } ) );
+
+		// The other order matters just as much: a resend started here would re-save the address
+		// the cancellation is in the middle of clearing, putting the change straight back.
+		expect( screen.getByRole( 'button', { name: 'Resend email' } ) ).toBeDisabled();
+		deliverCancel!();
+
+		await waitFor( () =>
+			expect(
+				queryClient.getQueryData< UserSettings >( userSettingsQuery().queryKey )
+					?.user_email_change_pending
+			).toBe( false )
+		);
+		expect( resendReached ).toBe( false );
 	} );
 
 	test( 'reports a refused send rather than announcing an email nobody was sent', async () => {

--- a/client/dashboard/me/profile-personal-details/use-email-write-pending.ts
+++ b/client/dashboard/me/profile-personal-details/use-email-write-pending.ts
@@ -1,0 +1,14 @@
+import { emailWriteFilters } from '@automattic/api-queries';
+import { useIsMutating } from '@tanstack/react-query';
+
+/**
+ * Whether any write that can change the email address is in flight, wherever it was started.
+ *
+ * The controls that issue them are spread across the verification banner and the email field, and
+ * none of them can see the others' state. A resend queued behind a cancellation would re-save the
+ * address that was just cancelled, so a control that can't tell whether one is running has no way
+ * to keep the reader from asking for both.
+ */
+export function useIsEmailWritePending() {
+	return useIsMutating( emailWriteFilters ) > 0;
+}

--- a/packages/api-queries/src/__tests__/query-client-persistence.test.ts
+++ b/packages/api-queries/src/__tests__/query-client-persistence.test.ts
@@ -1,0 +1,30 @@
+import { QueryClient, dehydrate, onlineManager } from '@tanstack/react-query';
+import { dehydrateOptions } from '../query-client';
+
+describe( 'cache persistence', () => {
+	test( 'persists queries but not a mutation left paused by going offline', async () => {
+		const client = new QueryClient();
+
+		await client.prefetchQuery( { queryKey: [ 'thing' ], queryFn: () => 'value' } );
+
+		onlineManager.setOnline( false );
+		try {
+			const mutation = client
+				.getMutationCache()
+				.build( client, { mutationFn: () => Promise.resolve( 'ok' ) } );
+			// Never settles while offline, and is not awaited: pausing is the point.
+			mutation.execute( undefined ).catch( () => {} );
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+			expect( mutation.state.isPaused ).toBe( true );
+
+			const dehydrated = dehydrate( client, dehydrateOptions );
+
+			// Nothing can resume it after a reload, and restoring it would hold its scope forever.
+			expect( dehydrated.mutations ).toHaveLength( 0 );
+			// The queries it travels with are unaffected.
+			expect( dehydrated.queries ).toHaveLength( 1 );
+		} finally {
+			onlineManager.setOnline( true );
+		}
+	} );
+} );

--- a/packages/api-queries/src/__tests__/query-client-persistence.test.ts
+++ b/packages/api-queries/src/__tests__/query-client-persistence.test.ts
@@ -1,5 +1,5 @@
 import { QueryClient, dehydrate, onlineManager } from '@tanstack/react-query';
-import { dehydrateOptions } from '../query-client';
+import { dehydrateOptions } from '../dehydrate-options';
 
 describe( 'cache persistence', () => {
 	test( 'persists queries but not a mutation left paused by going offline', async () => {

--- a/packages/api-queries/src/dehydrate-options.ts
+++ b/packages/api-queries/src/dehydrate-options.ts
@@ -1,0 +1,26 @@
+import { defaultShouldDehydrateQuery, type Query } from '@tanstack/react-query';
+
+// What is written to storage, and what is left out of it.
+//
+// A paused mutation is persisted by default, but nothing here registers mutation defaults or
+// calls `resumePausedMutations`, so a restored one has no function to run and nothing to resume
+// it. It would sit in the cache as permanently pending, holding any scope it declared and
+// counting towards `useIsMutating` for the rest of the session.
+//
+// Not re-exported from the package barrel: this is internal policy, not API.
+export const dehydrateOptions = {
+	shouldRedactErrors: () => false,
+	shouldDehydrateMutation: () => false,
+	shouldDehydrateQuery: ( query: Query ) => {
+		const persist = query.meta?.persist;
+		if ( persist === false ) {
+			return false;
+		}
+		// Gate the predicate behind the default check so it is never handed the
+		// data of a query that hasn't succeeded.
+		if ( ! defaultShouldDehydrateQuery( query ) ) {
+			return false;
+		}
+		return typeof persist === 'function' ? persist( query.state.data ) : true;
+	},
+};

--- a/packages/api-queries/src/dehydrate-options.ts
+++ b/packages/api-queries/src/dehydrate-options.ts
@@ -2,10 +2,12 @@ import { defaultShouldDehydrateQuery, type Query } from '@tanstack/react-query';
 
 // What is written to storage, and what is left out of it.
 //
-// A paused mutation is persisted by default, but nothing here registers mutation defaults or
-// calls `resumePausedMutations`, so a restored one has no function to run and nothing to resume
-// it. It would sit in the cache as permanently pending, holding any scope it declared and
-// counting towards `useIsMutating` for the rest of the session.
+// A paused mutation is persisted by default, on the expectation that the app registers mutation
+// defaults and calls `resumePausedMutations` after restoring. Nothing here does either, and
+// dehydration carries no `mutationFn`, so a restored mutation has nothing to run and nothing to
+// ask it to. It would sit in the cache as permanently pending, holding any scope it declared and
+// counting towards `useIsMutating` for the rest of the session. Excluding them takes away
+// nothing that worked.
 //
 // Not re-exported from the package barrel: this is internal policy, not API.
 export const dehydrateOptions = {

--- a/packages/api-queries/src/me-settings.ts
+++ b/packages/api-queries/src/me-settings.ts
@@ -8,9 +8,24 @@ export const userSettingsQuery = () =>
 		queryFn: fetchUserSettings,
 	} );
 
-export const userSettingsMutation = () =>
+// Resending re-saves the address already pending, so it is a write like the others. Two landing
+// out of order can leave the account holding a change the reader cancelled: the scope keeps them
+// to one at a time, the key lets a control tell when any is running.
+const emailWriteOptions = {
+	mutationKey: [ 'me', 'settings', 'email' ],
+	scope: { id: 'me-email' },
+};
+
+export const emailWriteFilters = { mutationKey: emailWriteOptions.mutationKey };
+
+// `includesEmail` opts a save into the ordering above; callers saving unrelated settings should
+// not queue behind an email resend.
+export const userSettingsMutation = ( {
+	includesEmail = false,
+}: { includesEmail?: boolean } = {} ) =>
 	mutationOptions( {
 		meta: { statId: 'user-settings-update' },
+		...( includesEmail ? emailWriteOptions : {} ),
 		mutationFn: updateUserSettings,
 		onSuccess: ( newData, variables ) => {
 			queryClient.setQueryData(
@@ -31,6 +46,7 @@ export const userSettingsMutation = () =>
 export const cancelPendingEmailChangeMutation = () =>
 	mutationOptions( {
 		meta: { statId: 'email-change-cancel' },
+		...emailWriteOptions,
 		mutationFn: () => updateUserSettings( { user_email_change_pending: false } ),
 		onSuccess: ( newData ) => {
 			queryClient.setQueryData(
@@ -45,16 +61,23 @@ export const cancelPendingEmailChangeMutation = () =>
 	} );
 
 // Re-saves the address already pending, which is what prompts another email.
-//
-// Deliberately leaves the settings cache alone. It changes nothing, and both writing the response
-// back and refetching can lose a race with a cancellation — either reinstating a change already
-// cancelled, or reading the settings before it lands and overwriting them afterwards.
 export const resendEmailVerificationMutation = () =>
 	mutationOptions( {
 		meta: { statId: 'email-verify-resend' },
+		...emailWriteOptions,
 		// The address is a variable rather than closed over, so a caller can tell which request a
 		// late response belongs to.
 		mutationFn: ( email: string ) => updateUserSettings( { user_email: email } ),
+		onSuccess: ( newData ) => {
+			queryClient.setQueryData(
+				userSettingsQuery().queryKey,
+				( oldData ) =>
+					oldData && {
+						...oldData,
+						...newData,
+					}
+			);
+		},
 	} );
 
 export const sendEmailVerificationMutation = () =>

--- a/packages/api-queries/src/me-settings.ts
+++ b/packages/api-queries/src/me-settings.ts
@@ -18,14 +18,9 @@ const emailWriteOptions = {
 
 export const emailWriteFilters = { mutationKey: emailWriteOptions.mutationKey };
 
-// `includesEmail` opts a save into the ordering above; callers saving unrelated settings should
-// not queue behind an email resend.
-export const userSettingsMutation = ( {
-	includesEmail = false,
-}: { includesEmail?: boolean } = {} ) =>
+export const userSettingsMutation = () =>
 	mutationOptions( {
 		meta: { statId: 'user-settings-update' },
-		...( includesEmail ? emailWriteOptions : {} ),
 		mutationFn: updateUserSettings,
 		onSuccess: ( newData, variables ) => {
 			queryClient.setQueryData(
@@ -41,6 +36,16 @@ export const userSettingsMutation = ( {
 				clearQueryClient();
 			}
 		},
+	} );
+
+// The same write, for a form that can carry `user_email` and so has to be ordered against the
+// controls above. Its own factory rather than a flag on the one above, so a caller opts in by
+// reaching for it rather than by remembering.
+export const userEmailSettingsMutation = () =>
+	mutationOptions( {
+		...userSettingsMutation(),
+		...emailWriteOptions,
+		meta: { statId: 'user-settings-email-update' },
 	} );
 
 export const cancelPendingEmailChangeMutation = () =>

--- a/packages/api-queries/src/me-settings.ts
+++ b/packages/api-queries/src/me-settings.ts
@@ -61,6 +61,9 @@ export const cancelPendingEmailChangeMutation = () =>
 	} );
 
 // Re-saves the address already pending, which is what prompts another email.
+//
+// Deliberately leaves the cache alone. It changes nothing, and its response is a whole settings
+// object: merging one that was read before an unrelated save would put the older values back.
 export const resendEmailVerificationMutation = () =>
 	mutationOptions( {
 		meta: { statId: 'email-verify-resend' },
@@ -68,16 +71,6 @@ export const resendEmailVerificationMutation = () =>
 		// The address is a variable rather than closed over, so a caller can tell which request a
 		// late response belongs to.
 		mutationFn: ( email: string ) => updateUserSettings( { user_email: email } ),
-		onSuccess: ( newData ) => {
-			queryClient.setQueryData(
-				userSettingsQuery().queryKey,
-				( oldData ) =>
-					oldData && {
-						...oldData,
-						...newData,
-					}
-			);
-		},
 	} );
 
 export const sendEmailVerificationMutation = () =>

--- a/packages/api-queries/src/query-client.ts
+++ b/packages/api-queries/src/query-client.ts
@@ -1,7 +1,8 @@
 import { isSupportSession } from '@automattic/calypso-support-session';
 import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister';
-import { QueryClient, defaultShouldDehydrateQuery, type Query } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
 import { persistQueryClient } from '@tanstack/react-query-persist-client';
+import { dehydrateOptions } from './dehydrate-options';
 import { startSiteCollisionListener } from './site-collision-listener';
 
 // Open to augmentation: apps consuming this package add their own meta by extending
@@ -73,29 +74,6 @@ let persistence: { userId: number; promise: Promise< void >; disable: () => void
  * Memoized per user, so callers can invoke it freely (e.g. from an effect).
  * While the user is unknown we neither restore nor persist.
  */
-// What is written to storage, and what is left out of it.
-//
-// A paused mutation is persisted by default, but nothing here registers mutation defaults or
-// calls `resumePausedMutations`, so a restored one has no function to run and nothing to resume
-// it. It would sit in the cache as permanently pending, holding any scope it declared and
-// counting towards `useIsMutating` for the rest of the session.
-export const dehydrateOptions = {
-	shouldRedactErrors: () => false,
-	shouldDehydrateMutation: () => false,
-	shouldDehydrateQuery: ( query: Query ) => {
-		const persist = query.meta?.persist;
-		if ( persist === false ) {
-			return false;
-		}
-		// Gate the predicate behind the default check so it is never handed the
-		// data of a query that hasn't succeeded.
-		if ( ! defaultShouldDehydrateQuery( query ) ) {
-			return false;
-		}
-		return typeof persist === 'function' ? persist( query.state.data ) : true;
-	},
-};
-
 export function getPersistQueryClientPromise( userId?: number ): Promise< void > {
 	if ( userId === undefined ) {
 		return Promise.resolve();

--- a/packages/api-queries/src/query-client.ts
+++ b/packages/api-queries/src/query-client.ts
@@ -1,6 +1,6 @@
 import { isSupportSession } from '@automattic/calypso-support-session';
 import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister';
-import { QueryClient, defaultShouldDehydrateQuery } from '@tanstack/react-query';
+import { QueryClient, defaultShouldDehydrateQuery, type Query } from '@tanstack/react-query';
 import { persistQueryClient } from '@tanstack/react-query-persist-client';
 import { startSiteCollisionListener } from './site-collision-listener';
 
@@ -73,6 +73,29 @@ let persistence: { userId: number; promise: Promise< void >; disable: () => void
  * Memoized per user, so callers can invoke it freely (e.g. from an effect).
  * While the user is unknown we neither restore nor persist.
  */
+// What is written to storage, and what is left out of it.
+//
+// A paused mutation is persisted by default, but nothing here registers mutation defaults or
+// calls `resumePausedMutations`, so a restored one has no function to run and nothing to resume
+// it. It would sit in the cache as permanently pending, holding any scope it declared and
+// counting towards `useIsMutating` for the rest of the session.
+export const dehydrateOptions = {
+	shouldRedactErrors: () => false,
+	shouldDehydrateMutation: () => false,
+	shouldDehydrateQuery: ( query: Query ) => {
+		const persist = query.meta?.persist;
+		if ( persist === false ) {
+			return false;
+		}
+		// Gate the predicate behind the default check so it is never handed the
+		// data of a query that hasn't succeeded.
+		if ( ! defaultShouldDehydrateQuery( query ) ) {
+			return false;
+		}
+		return typeof persist === 'function' ? persist( query.state.data ) : true;
+	},
+};
+
 export function getPersistQueryClientPromise( userId?: number ): Promise< void > {
 	if ( userId === undefined ) {
 		return Promise.resolve();
@@ -89,21 +112,7 @@ export function getPersistQueryClientPromise( userId?: number ): Promise< void >
 		persister,
 		buster: `${ cacheDataShapeVersion }-${ userId }`,
 		maxAge,
-		dehydrateOptions: {
-			shouldRedactErrors: () => false,
-			shouldDehydrateQuery: ( query ) => {
-				const persist = query.meta?.persist;
-				if ( persist === false ) {
-					return false;
-				}
-				// Gate the predicate behind the default check so it is never handed the
-				// data of a query that hasn't succeeded.
-				if ( ! defaultShouldDehydrateQuery( query ) ) {
-					return false;
-				}
-				return typeof persist === 'function' ? persist( query.state.data ) : true;
-			},
-		},
+		dehydrateOptions,
 	} );
 	persistence = { userId, promise, disable };
 


### PR DESCRIPTION
Part of DOTPROD "Add Email Verification Step to the Onboarding Flow".

Follow-up to the Dashboard resend-throttling change, now on trunk.

## Proposed Changes

* Resending a verification email re-saves the address already pending, so it is a settings write rather than a side-effect-only call. Nothing stopped it overlapping a cancellation, and the two could reach the server in either order.
* Every write that can touch the email address now shares an identity: one runs at a time, and the controls that issue them disable themselves while any is in flight. The signal comes from the mutation cache rather than component state, so controls living in separate components lock each other out without holding references to each other.
* Only a settings save that actually carries the address takes part, so saving a name isn't held up behind a resend.
* Mutations are no longer written to the persisted cache. A paused one was restored on the next load with nothing able to resume it, which an ordering scope turns from a wasted cache entry into a queue that never drains.

## Why are these changes being made?

Two controls offer to cancel a pending email change — one on the verification notice, one beside the email field — and a third control resends the verification email. None of them could see the others' state, so a reader could start a resend and a cancellation together.

Either order loses. Cancelling and then resending re-saves the address that was just cleared, so the account keeps a change the reader asked to drop. Resending and then cancelling can reinstate it after the fact, depending on which write the server applies last.

This is longstanding rather than new: on trunk each button is disabled only by its own pending state.

## Testing Instructions

With a pending email change, go to your profile in the Dashboard.

1. Click "Resend email". While it is in flight, both cancellation controls — the button on the notice and the link beside the email field — should be unavailable, and become available again once it finishes.
2. Click either cancellation control. While it is in flight, "Resend email" should be unavailable.
3. Cancel the change and confirm it stays cancelled, rather than reappearing after a reload.
4. Edit only your first or last name and save. The resend and cancellation controls should stay available throughout, since that save doesn't touch the address.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Notes

This is a holding measure. The awkwardness underneath it is that resending is implemented as a re-save of the pending address, so a call that wants to be side-effect-only is a state-changing write. A dedicated endpoint that doesn't touch `user_email` would remove the conflict outright rather than ordering around it, and would let all of this go.

Ordering alone would not have been enough, which is why the controls also lock each other: with the writes merely serialized, a cancellation followed by a resend still recreates the change, just deterministically.

The persistence change is broader than this feature, so the reasoning in full: TanStack persists paused mutations expecting the app to register mutation defaults and call `resumePausedMutations()` after restoring. Neither exists here, and dehydration carries no `mutationFn`, so a restored mutation has nothing to run and nothing to ask it to — for every mutation in the app, not only these. It would hold any scope it declared and keep `useIsMutating` switched on for the session. Excluding them takes away nothing that worked, and covers any scoped mutation added later without its author having to know.

The narrower alternative — a `meta.persist` opt-out on the email mutations only — was considered and not taken for that last reason: it leaves the same deadlock waiting for whoever adds the next scoped mutation and forgets the flag.

The three cases are covered by tests that were each checked against their own removal. The cross-component one renders the whole personal-details screen, since the point of it is that two components with no shared state still lock each other.
