### PR TITLE
E2E: run the authentication project in Chromium's new headless mode

### DIFF
--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -51,10 +51,9 @@ const loginBrowserUse = {
 		],
 		slowMo: 1000,
 		env: {},
-		channel: '',
+		// Google OAuth rejects the headless shell as an insecure browser.
+		channel: 'chromium',
 	},
-	userAgent:
-		'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.61 Safari/537.36',
 };
 
 function getWorkers(): number | string {

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -54,6 +54,8 @@ const loginBrowserUse = {
 		// Google OAuth rejects the headless shell as an insecure browser.
 		channel: 'chromium',
 	},
+	// Google OAuth also rejects stale user agents: don't pin `userAgent` here,
+	// let the device descriptor track the bundled Chromium.
 };
 
 function getWorkers(): number | string {


### PR DESCRIPTION
## Proposed Changes

* Switch the `authentication` Playwright project to `channel: 'chromium'`, so it launches the full Chromium build rather than the headless shell.
* Drop the hardcoded `Chrome/94.0.4606.61` user agent, so the project uses the current one from `devices['Desktop Chrome HiDPI']`.

## Why are these changes being made?

`authentication__google.spec.ts` has failed every scheduled run since 2026-07-31, timing out on `locator.elementHandle` in `GoogleLoginPage.waitUntilStable` while waiting for the password field.

Neither our test code nor the Google sign-in markup changed. Google now rejects the browser: after the username is submitted, the popup is redirected to `accounts.google.com/v3/signin/rejected` showing “Couldn’t sign you in — This browser or app may not be secure.” That page has no password field, so the wait times out. The failure screenshot is byte-identical across all four failing builds, and the e2e tree is byte-identical between the last passing and first failing revision — 12 commits landed, none touching `test/e2e/` or `packages/calypso-e2e/`.

The test account is fine: a randomly generated, non-existent Gmail address gets the same rejection page, so this happens before Google evaluates the account at all.

Two independent signals each trigger the rejection, verified against production with a non-existent address:

| User agent | Browser binary | Result |
|---|---|---|
| Chrome/94 | headless shell | rejected 3/3 |
| Chrome/143 | headless shell | rejected 3/3 |
| Chrome/94 | `channel: 'chromium'` | rejected 2/2 |
| Chrome/94 | branded Chrome | rejected |
| Chrome/143 | `channel: 'chromium'` | **accepted 3/3** |
| Chrome/143 | branded Chrome | accepted 3/3 |

Both changes are required — either alone is still rejected. `channel: 'chromium'` is preferred over `'chrome'` because CI already downloads that build alongside the headless shell, so no Docker image change or extra browser install is needed.

## Testing Instructions

Verified in CI with a **personal build** of `Authentication E2E Tests` carrying this diff on top of `trunk` ([build 18762006](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Authentication/18762006)): **13 passed, 1 ignored, 0 failed**, with the Google spec passing in 18.1s. The four preceding scheduled builds each failed this spec.

To reproduce locally:

```bash
cd test/e2e
CALYPSO_BASE_URL=<production> yarn playwright test \
  --project=authentication specs/authentication/authentication__google.spec.ts \
  --repeat-each=5 --workers=1 --reporter=list
```

The spec only runs against production — it self-skips elsewhere, since Google auth needs prod callbacks.

Two notes for anyone running this locally:

* From an EU IP the spec cannot complete unmodified. The `sensitive_pixel_options` consent cookie set in `test/e2e/lib/pw-base.ts` suppresses the OAuth popup, so it fails earlier at `clickLoginWithGoogle`. Temporarily guard that `addCookies` call to run it. CI is unaffected.
* A separate, pre-existing flake lives at the 2FA step: `authentication__google.spec.ts:48` generates the TOTP token, then several `slowMo: 1000` actions elapse before submission, so a token minted late in its 30-second window arrives stale (“Wrong code. Try again.”). It hit 2 of 10 local runs and is latency-sensitive. Not addressed here.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label (p4TIVU-aUh-p2)?
