### PR TITLE
Onboarding: fix use-my-domain form submit navigating to domains step

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -218,7 +218,7 @@ const onboarding: FlowV2< typeof initialize > = {
 						providedDependencies.mode &&
 						providedDependencies.domain
 					) {
-						const destination = addQueryArgs( '/use-my-domain', {
+						const destination = addQueryArgs( 'use-my-domain', {
 							...getQueryArgs( window.location.href ),
 							step: providedDependencies.mode,
 							initialQuery: providedDependencies.domain,

--- a/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding.ts
@@ -11,8 +11,16 @@ jest.mock( 'calypso/components/domains/wpcom-domain-search/use-query-handler', (
 
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( { resetOnboardStore: jest.fn() } ),
-	useSelect: jest.fn(),
+	useSelect: jest.fn( () => ( {} ) ),
 	resolveSelect: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/landing/stepper/hooks/use-query', () => ( {
+	useQuery: jest.fn( () => new URLSearchParams( '' ) ),
+} ) );
+
+jest.mock( 'calypso/landing/stepper/hooks/use-flow-locale', () => ( {
+	useFlowLocale: jest.fn( () => 'en' ),
 } ) );
 
 jest.mock( 'calypso/state', () => ( {
@@ -42,7 +50,7 @@ jest.mock( '@automattic/data-stores', () => ( {} ) );
 jest.mock(
 	'calypso/landing/stepper/declarative-flow/internals/hooks/use-purchase-plan-notification',
 	() => ( {
-		usePurchasePlanNotification: jest.fn(),
+		usePurchasePlanNotification: jest.fn( () => ( { setShouldShowNotification: jest.fn() } ) ),
 	} )
 );
 
@@ -90,5 +98,52 @@ describe( 'onboarding flow side effects', () => {
 		renderSideEffect( 'domains' );
 
 		expect( clearSessionStorageQuery ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'onboarding flow use-my-domain navigation', () => {
+	const submitUseMyDomain = ( providedDependencies: Record< string, unknown > ) => {
+		const navigate = jest.fn();
+		const { result } = renderHook( () =>
+			// `useStepNavigation` reads `this.name`, so it must be invoked bound to the flow.
+			onboarding.useStepNavigation.call(
+				onboarding,
+				'use-my-domain' as Parameters< typeof onboarding.useStepNavigation >[ 0 ],
+				navigate
+			)
+		);
+
+		result.current.submit?.( {
+			slug: 'use-my-domain',
+			providedDependencies,
+		} as Parameters< NonNullable< typeof result.current.submit > >[ 0 ] );
+
+		return { navigate };
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	// Regression: the destination must be the bare `use-my-domain` slug. A leading
+	// slash makes navigate() pass `/use-my-domain` as the router step param, which
+	// doesn't match a step and drops the user back on the domains step.
+	it( 'navigates to the use-my-domain step (no leading slash) when a mode and domain are submitted', () => {
+		const { navigate } = submitUseMyDomain( {
+			mode: 'transfer-or-connect',
+			domain: 'example.com',
+		} );
+
+		expect( navigate ).toHaveBeenCalledTimes( 1 );
+
+		const destination = navigate.mock.calls[ 0 ][ 0 ] as string;
+		expect( destination.startsWith( '/' ) ).toBe( false );
+
+		const [ pathname, queryString ] = destination.split( '?' );
+		expect( pathname ).toBe( 'use-my-domain' );
+
+		const query = new URLSearchParams( queryString );
+		expect( query.get( 'step' ) ).toBe( 'transfer-or-connect' );
+		expect( query.get( 'initialQuery' ) ).toBe( 'example.com' );
 	} );
 } );


### PR DESCRIPTION
## Proposed Changes

* Fix the onboarding `use-my-domain` step submit handler so its redirect uses the bare `use-my-domain` slug instead of `/use-my-domain` (leading slash).
* Add a regression unit test asserting the destination has no leading slash and carries the `step`/`initialQuery` query args.

## Why are these changes being made?

https://github.com/user-attachments/assets/31afe68d-3cc7-4837-a06f-a7c4a98886da

<!-- -->
On the onboarding domain step, clicking "Already have a domain?", entering a domain, and submitting the form redirected back to the `domains` step (e.g. `setup/onboarding/domains?step=transfer-or-connect&initialQuery=<domain>`) instead of staying on `use-my-domain`.

The submit handler built its redirect with a leading slash (`addQueryArgs( '/use-my-domain', … )`). `navigate()` passes `nextStep.split('?')[0]` as the router `:step` param, so `/use-my-domain` became a malformed step that didn't match the registered step, and the flow fell back to its landing step (`domains`). The parallel `domains` case and the `domain` flow already build the slug without a leading slash, which is why re-clicking "Already have a domain?" resolved correctly.

Note: the same leading-slash pattern exists in several sibling flows (`copy-site`, `education`, `reblogging`, `newsletter`, `domain-and-plan`); this PR intentionally fixes only the onboarding flow. The others can follow in a separate change. Done here: https://github.com/Automattic/wp-calypso/pull/113225

## Regression

**Introduced by:** #113028 ("Security: update React Router to 7.18.0"), which bumped react-router `6.30.4 → 7.18.0`. Merged 2026-07-29, so it has been live in production since ~2026-07-29/30 (a handful of days).

**Why the upgrade exposed it:** react-router v7 changed `generatePath` to URL-encode path parameters. Stepper passes the flow's redirect string as the `:step` route param, and the affected flows built that string with a leading slash:

- **react-router 6.30.4 (before):** the leading slash was tolerated and resolved to the `use-my-domain` step → the flow worked.
- **react-router 7.18.0 (after):** the `/` is encoded to `%2F`, so the path becomes `/<flow>/%2Fuse-my-domain`, which matches no registered step and falls through to the flow's catch-all route → the user is bounced back to the `domains` step.

The leading slash was always technically incorrect but latent; the v7 upgrade turned it into a user-visible regression. Confirmed manually by checking out the pre-upgrade commit (react-router 6.30.4), where the flow behaves correctly.

## Testing Instructions

<!-- -->
1. Go to `setup/onboarding/domains`.
2. Click "Already have a domain?" — lands on `setup/onboarding/use-my-domain`.
3. Enter a domain you own and submit the form.
4. Verify: you stay on `setup/onboarding/use-my-domain?step=transfer-or-connect&initialQuery=<domain>` (previously it bounced back to the `domains` step).

Automated test:

```
yarn test-client client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding.ts
```

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
