### PR TITLE
Stepper: fix use-my-domain form submit navigating to domains step across flows

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/copy-site/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/flows/copy-site/copy-site.tsx
@@ -138,7 +138,7 @@ const copySite: Flow = {
 						providedDependencies.mode &&
 						providedDependencies.domain
 					) {
-						const destination = addQueryArgs( '/use-my-domain', {
+						const destination = addQueryArgs( 'use-my-domain', {
 							...getQueryArgs( window.location.href ),
 							step: providedDependencies.mode,
 							initialQuery: providedDependencies.domain,

--- a/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
@@ -96,7 +96,7 @@ const domainUpsell: Flow = {
 						const currentQueryArgs = getQueryArgs( window.location.href );
 						currentQueryArgs.step = 'domain-input';
 
-						let useMyDomainURL = addQueryArgs( '/use-my-domain', currentQueryArgs );
+						let useMyDomainURL = addQueryArgs( 'use-my-domain', currentQueryArgs );
 
 						const lastQueryParam = providedDependencies.lastQuery as string | undefined;
 
@@ -129,7 +129,7 @@ const domainUpsell: Flow = {
 						providedDependencies.mode &&
 						providedDependencies.domain
 					) {
-						const destination = addQueryArgs( '/use-my-domain', {
+						const destination = addQueryArgs( 'use-my-domain', {
 							...getQueryArgs( window.location.href ),
 							step: providedDependencies.mode,
 							initialQuery: providedDependencies.domain,

--- a/client/landing/stepper/declarative-flow/flows/education/education.ts
+++ b/client/landing/stepper/declarative-flow/flows/education/education.ts
@@ -107,7 +107,7 @@ const education: FlowV2< typeof initialize > = {
 						providedDependencies.mode &&
 						providedDependencies.domain
 					) {
-						const destination = addQueryArgs( '/use-my-domain', {
+						const destination = addQueryArgs( 'use-my-domain', {
 							...getQueryArgs( window.location.href ),
 							step: providedDependencies.mode,
 							initialQuery: providedDependencies.domain,

--- a/client/landing/stepper/declarative-flow/flows/newsletter/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/flows/newsletter/newsletter.ts
@@ -126,7 +126,7 @@ const newsletter: Flow = {
 						providedDependencies.mode &&
 						providedDependencies.domain
 					) {
-						const destination = addQueryArgs( '/use-my-domain', {
+						const destination = addQueryArgs( 'use-my-domain', {
 							...getQueryArgs( window.location.href ),
 							step: providedDependencies.mode,
 							initialQuery: providedDependencies.domain,

--- a/client/landing/stepper/declarative-flow/flows/reblogging/reblogging.ts
+++ b/client/landing/stepper/declarative-flow/flows/reblogging/reblogging.ts
@@ -80,7 +80,7 @@ const reblogging: Flow = {
 						providedDependencies.mode &&
 						providedDependencies.domain
 					) {
-						const destination = addQueryArgs( '/use-my-domain', {
+						const destination = addQueryArgs( 'use-my-domain', {
 							...getQueryArgs( window.location.href ),
 							step: providedDependencies.mode,
 							initialQuery: providedDependencies.domain,


### PR DESCRIPTION
## Proposed Changes

* Apply the same `use-my-domain` navigation fix from #113224 to the remaining Stepper flows that share the pattern: `copy-site`, `education`, `reblogging`, `newsletter`, and `domain-and-plan`.
* Each flow's `use-my-domain` submit built its redirect with a leading slash (`addQueryArgs( '/use-my-domain', … )`); dropping the slash so the destination is the bare `use-my-domain` step slug.
* `domain-and-plan` also used the leading slash in its `domains`-step (`navigateToUseMyDomain`) navigation, so both navigation points are fixed there.

## Why are these changes being made?

<!-- -->
Follow-up to #113224, which fixed the onboarding flow. The submit handler passed `/use-my-domain` (leading slash) to `navigate()`, which uses `nextStep.split('?')[0]` as the router `:step` param. `/use-my-domain` doesn't match a registered step, so the flow fell back to its landing (`domains`) step — the user entered a domain, submitted, and got bounced back to the domain search screen instead of staying on `use-my-domain`.

The `domain` flow already builds the slug without a leading slash, which is the correct reference form applied here.

## Regression

**Introduced by:** #113028 ("Security: update React Router to 7.18.0"), which bumped react-router `6.30.4 → 7.18.0`. Merged 2026-07-29, so it has been live in production since ~2026-07-29/30 (a handful of days). All five flows here — including `education`, which is newer — began exhibiting the bug on that same date, since they all route through the shared Stepper navigation.

**Why the upgrade exposed it:** react-router v7 changed `generatePath` to URL-encode path parameters. Stepper passes the flow's redirect string as the `:step` route param, and the affected flows built that string with a leading slash:

- **react-router 6.30.4 (before):** the leading slash was tolerated and resolved to the `use-my-domain` step → the flow worked.
- **react-router 7.18.0 (after):** the `/` is encoded to `%2F`, so the path becomes `/<flow>/%2Fuse-my-domain`, which matches no registered step and falls through to the flow's catch-all route → the user is bounced back to the `domains` step.

The leading slash was always technically incorrect but latent; the v7 upgrade turned it into a user-visible regression. Confirmed manually by checking out the pre-upgrade commit (react-router 6.30.4), where the flows behave correctly.

## Testing Instructions

<!-- -->
For each flow, land on its `domains` step, click "Already have a domain?", enter a domain you own, and submit the form. Verify you stay on `.../use-my-domain?step=transfer-or-connect&initialQuery=<domain>` instead of bouncing back to the `domains` step.

Entry points (prefix with your local dev host):
* `copy-site` — `/setup/copy-site/domains?sourceSlug=<a-site-you-own>.wordpress.com`
* `education` — `/setup/education` (step through student validation to reach domains)
* `reblogging` — `/setup/reblogging/domains`
* `newsletter` — `/setup/newsletter` (step through setup + goals to reach domains)
* `domain-and-plan` — `/setup/domain-and-plan/domains?siteSlug=<a-site-you-own>.wordpress.com` (also verify the first "Already have a domain?" click, which was affected here too)

## Related

* Part of the same fix as #113224 (onboarding flow). That PR also adds a regression unit test for the pattern.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
