### PR TITLE
A4A Amplify: select the error notice from the top-level error code

### DIFF
--- a/client/a8c-for-agencies/data/amplify/types.ts
+++ b/client/a8c-for-agencies/data/amplify/types.ts
@@ -41,20 +41,11 @@ export interface ArchiveAmplifyReportParams {
 	reportId: string;
 }
 
-export interface AmplifyApiErrorDetail {
-	code: string;
-	message: string;
-}
-
 export interface AmplifyApiError {
 	status: number;
 	code: string | null;
 	message: string;
-	// A parameter validation failure surfaces as `rest_invalid_param` at the
-	// top level; the code that actually says what went wrong sits under
-	// `data.details`, keyed by parameter name.
 	data?: {
 		status?: number;
-		details?: Record< string, AmplifyApiErrorDetail >;
 	};
 }

--- a/client/a8c-for-agencies/sections/amplify/add-site/modal.tsx
+++ b/client/a8c-for-agencies/sections/amplify/add-site/modal.tsx
@@ -19,13 +19,19 @@ import type { AmplifyApiError, AmplifyMode } from 'calypso/a8c-for-agencies/data
 
 import './style.scss';
 
-function isSiteUnreachableError( error: AmplifyApiError | null ) {
-	return (
-		error?.code === 'site_unreachable' ||
-		Object.values( error?.data?.details ?? {} ).some(
-			( detail ) => detail.code === 'site_unreachable'
-		)
-	);
+function getErrorMessage( error: AmplifyApiError | null ) {
+	switch ( error?.code ) {
+		case 'site_unreachable':
+			return __(
+				'We couldn’t reach this site to analyze it. Make sure it’s online and publicly accessible, then try again.'
+			);
+		case 'amplify_report_rate_limited':
+			return __(
+				'You’ve reached the limit of 10 Amplify reports in a 24-hour period. Try again after one of your earlier reports is more than 24 hours old.'
+			);
+		default:
+			return __( 'Could not start the analysis. Please try again.' );
+	}
 }
 
 export default function AmplifyAddSiteModal( { onClose }: { onClose: () => void } ) {
@@ -43,11 +49,7 @@ export default function AmplifyAddSiteModal( { onClose }: { onClose: () => void 
 		// to the progress view instead of showing a notice.
 		onSuccess: () => setInProgress( true ),
 		onError: ( error ) => {
-			const message = isSiteUnreachableError( error )
-				? __(
-						'We couldn’t reach this site to analyze it. Make sure it’s online and publicly accessible, then try again.'
-				  )
-				: __( 'Could not start the analysis. Please try again.' );
+			const message = getErrorMessage( error );
 			dispatch(
 				errorNotice( message, {
 					id: 'amplify-analysis-error',


### PR DESCRIPTION
The create-report endpoint now returns actionable failures as top-level error codes in the standard REST shape (`site_unreachable` / 400, `amplify_report_rate_limited` / 429), so the client can select its notice from the code alone. Ships after the wpcom PR deploys.

## Proposed Changes

* **`modal.tsx`** — the start-analysis `onError` switches on `error?.code`: `site_unreachable` keeps **We couldn’t reach this site to analyze it. Make sure it’s online and publicly accessible, then try again.**, `amplify_report_rate_limited` shows **You’ve reached the limit of 10 Amplify reports in a 24-hour period. Try again after one of your earlier reports is more than 24 hours old.**, and anything else keeps the generic **Could not start the analysis. Please try again.**
* **`types.ts`** — drop `AmplifyApiErrorDetail` and the nested `data.details` shape from `AmplifyApiError`.

## Why are these changes being made?

* An agency at the 10-report cap got the generic "please try again", which is wrong — retrying won't help until an earlier report ages out. The 429 code lets the notice say so.
* Reading the top-level code replaces the `data.details` scan added in #113024. The backend reports both cases consistently now, so there's nothing left to unwrap.

## Testing Instructions

1. Run `yarn start-a8c-for-agencies` and open `agencies.localhost:3000/amplify` as an agency user with the amplify capabilities.
2. Open **Amplify a site**, enter a URL for a site that's offline / doesn't resolve, choose an analysis, and submit. Confirm the notice reads **We couldn’t reach this site to analyze it…**.
3. With 10 reports created in the last 24 hours, submit another one. Confirm the notice reads **You’ve reached the limit of 10 Amplify reports in a 24-hour period…**.
4. Trigger any other failure (e.g. block the request in devtools) and confirm the generic notice still shows.
5. Submit a reachable site under the limit and confirm the analysis starts as before.
6. Confirm no TypeScript/React console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_01Y6RrE7iiB9wXinWCHVSCT9
