### PR TITLE
E2E: fix likes__comment on Atomic

### DIFF
--- a/packages/calypso-e2e/src/lib/components/comments-component.ts
+++ b/packages/calypso-e2e/src/lib/components/comments-component.ts
@@ -2,6 +2,9 @@ import { Page } from 'playwright';
 import { envVariables } from '../..';
 import { waitForWPWidgetsIfNecessary } from '../../element-helper';
 
+// Atomic's like widget relabels itself slowly; every wait around it gets the same budget.
+const likeWidgetTimeout = envVariables.TEST_ON_ATOMIC ? 30 * 1000 : undefined;
+
 /**
  * Represents the comments section of a post.
  */
@@ -18,40 +21,36 @@ export class CommentsComponent {
 	}
 
 	/**
-	 * Posts a comment with given text.
+	 * Returns the like widget of a comment in both of its states.
 	 *
-	 * @param {string} comment Comment text.
+	 * @param {string} comment Text of the comment.
 	 */
-	async postComment( comment: string ): Promise< void > {
-		const commentForm = this.page.locator( '#commentform' );
-		await commentForm.scrollIntoViewIfNeeded();
-
-		let commentField;
-		let submitButton;
+	private async likeLocators( comment: string ) {
+		const commentContent = this.page.locator( '.comment-content', { hasText: comment } );
 
 		if ( envVariables.TEST_ON_ATOMIC ) {
-			// Although the comment iframe does not come from widgets.wp.com,
-			// there are other widgets on the same page that do, and until
-			// they're not fully loaded, the layout will keep shifting causing
-			// misclicks from time to time. The general reason for the layout
-			// shifting is that all the widgets are loaded via an iframe, and
-			// their sizes are not immediately set. For example, the Likes
-			// button height is re-calculated within a 500ms interval which can
-			// bypass Playwright's stability check.
+			// The button turns actionable only once the widget script has initialised,
+			// which nothing in the DOM reflects, so Playwright's own checks cannot see it.
+			// The widgets also keep resizing until then, which would fail the scroll below.
 			await waitForWPWidgetsIfNecessary( this.page );
-
-			const parentFrame = this.page.frameLocator( '#jetpack_remote_comment' );
-
-			commentField = parentFrame.locator( '#comment' );
-			submitButton = parentFrame.locator( 'input:has-text("Post Comment")' );
-		} else {
-			commentField = this.page.locator( '#comment' );
-			submitButton = this.page.locator( 'input:has-text("Post Comment")' );
 		}
 
-		await commentField.type( comment );
+		await commentContent.scrollIntoViewIfNeeded( { timeout: likeWidgetTimeout } );
 
-		await submitButton.click();
+		if ( envVariables.TEST_ON_ATOMIC ) {
+			const frame = commentContent.frameLocator( 'iframe[name^="like-comment-frame"]' );
+
+			// Without `exact`, "Like" also matches "Liked by you".
+			return {
+				notLiked: frame.getByRole( 'link', { name: 'Like', exact: true } ),
+				liked: frame.getByRole( 'link', { name: 'Liked by you' } ),
+			};
+		}
+
+		return {
+			notLiked: commentContent.locator( '.comment-not-liked > span:text-is("Like"):visible' ),
+			liked: commentContent.locator( '.comment-liked:has-text("Liked by") > a' ),
+		};
 	}
 
 	/**
@@ -60,42 +59,10 @@ export class CommentsComponent {
 	 * @param {string} comment Text of the comment to like.
 	 */
 	async like( comment: string ): Promise< void > {
-		let likeButton;
-		let likedStatus;
+		const { notLiked, liked } = await this.likeLocators( comment );
 
-		if ( envVariables.TEST_ON_ATOMIC ) {
-			// Atomic site loads the like button via a widgets.wp.com iframe.
-			// Playwright's actionability checks are no good here because the
-			// button becomes actionable after the widget script is fully
-			// initialized, which is not indicated anywhere in the DOM. We need
-			// to use the following custom waiter to ensure the button is ready
-			// to be interacted with. Otherwise, the like click will most likely
-			// do nothing.
-			await waitForWPWidgetsIfNecessary( this.page );
-
-			const likeButtonFrame = this.page
-				.frameLocator( `iframe[name^="like-comment-frame"]:below(:text("${ comment }"))` )
-				.first();
-
-			likeButton = likeButtonFrame.getByRole( 'link', { name: 'Like' } );
-			likedStatus = likeButtonFrame.getByRole( 'link', { name: 'Liked by you' } );
-		} else {
-			const commentContent = this.page.locator( '.comment-content', { hasText: comment } );
-
-			likeButton = commentContent.locator( ':text-is("Like"):visible' );
-			likedStatus = commentContent.locator( ':text("Liked by"):visible' );
-		}
-
-		await this.page.getByText( comment ).scrollIntoViewIfNeeded();
-		await likeButton.waitFor();
-		await likeButton.click();
-		// On Atomic, we add a second click since the first one opens a window to log-in the user.
-		if ( envVariables.TEST_ON_ATOMIC ) {
-			await this.page.waitForTimeout( 5 * 1000 );
-			await likeButton.waitFor();
-			await likeButton.click();
-		}
-		await likedStatus.waitFor();
+		await notLiked.click( { timeout: likeWidgetTimeout } );
+		await liked.waitFor( { timeout: likeWidgetTimeout } );
 	}
 
 	/**
@@ -104,27 +71,9 @@ export class CommentsComponent {
 	 * @param {string} comment Text of the comment to unlike.
 	 */
 	async unlike( comment: string ): Promise< void > {
-		let unlikeButton;
-		let unlikedStatus;
+		const { notLiked, liked } = await this.likeLocators( comment );
 
-		if ( envVariables.TEST_ON_ATOMIC ) {
-			// See the like() method for info on the following method call.
-			await waitForWPWidgetsIfNecessary( this.page );
-
-			const commentContent = this.page.locator( '.comment-content', { hasText: comment } );
-			const likeButtonFrame = commentContent.frameLocator( "iframe[name^='like-comment-frame']" );
-
-			unlikeButton = likeButtonFrame.getByRole( 'link', { name: 'Liked by you' } );
-			unlikedStatus = likeButtonFrame.getByRole( 'link', { name: 'Like' } );
-		} else {
-			const commentContent = this.page.locator( '.comment-content', { hasText: comment } );
-
-			unlikeButton = commentContent.locator( '.comment-liked:has-text("Liked by") > a' );
-			unlikedStatus = commentContent.locator( '.comment-not-liked > span:text-is("Like"):visible' );
-		}
-
-		await this.page.getByText( comment ).scrollIntoViewIfNeeded();
-		await unlikeButton.click();
-		await unlikedStatus.waitFor();
+		await liked.click( { timeout: likeWidgetTimeout } );
+		await notLiked.waitFor( { timeout: likeWidgetTimeout } );
 	}
 }

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -1149,6 +1149,37 @@ export class RestAPIClient {
 	}
 
 	/**
+	 * Unlikes a comment.
+	 *
+	 * @param {number} siteID Target site ID.
+	 * @param {number} commentID Target comment ID.
+	 */
+	async unlikeComment( siteID: number, commentID: number ): Promise< CommentLikeResponse > {
+		const params: RequestParams = {
+			method: 'post',
+			headers: {
+				Authorization: await this.getAuthorizationHeader( 'bearer' ),
+				'Content-Type': this.getContentTypeHeader( 'json' ),
+			},
+		};
+
+		const response = await this.sendRequest(
+			this.getRequestURL( '1.1', `/sites/${ siteID }/comments/${ commentID }/likes/mine/delete` ),
+			params
+		);
+
+		if ( response.i_like ) {
+			throw new Error(
+				`Failed to unlike ${ commentID } on site ${ siteID }. Response: ${ JSON.stringify(
+					response
+				) }`
+			);
+		}
+
+		return response;
+	}
+
+	/**
 	 * Likes or unlikes a post.
 	 *
 	 * @param {'like'|'unlike'} action Action to perform on the post.

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -1118,17 +1118,12 @@ export class RestAPIClient {
 	}
 
 	/**
-	 * Method to perform two similar operations - like and unlike a comment.
+	 * Likes a comment.
 	 *
-	 * @param {'like'|'unlike'} action Action to perform on the comment.
 	 * @param {number} siteID Target site ID.
 	 * @param {number} commentID Target comment ID.
 	 */
-	async commentAction(
-		action: 'like' | 'unlike',
-		siteID: number,
-		commentID: number
-	): Promise< CommentLikeResponse > {
+	async likeComment( siteID: number, commentID: number ): Promise< CommentLikeResponse > {
 		const params: RequestParams = {
 			method: 'post',
 			headers: {
@@ -1137,33 +1132,19 @@ export class RestAPIClient {
 			},
 		};
 
-		let endpoint: URL;
-		if ( action === 'like' ) {
-			endpoint = this.getRequestURL(
-				'1.1',
-				`/sites/${ siteID }/comments/${ commentID }/likes/new`
+		const response = await this.sendRequest(
+			this.getRequestURL( '1.1', `/sites/${ siteID }/comments/${ commentID }/likes/new` ),
+			params
+		);
+
+		if ( ! response.i_like ) {
+			throw new Error(
+				`Failed to like ${ commentID } on site ${ siteID }. Response: ${ JSON.stringify(
+					response
+				) }`
 			);
-		} else {
-			endpoint = this.getRequestURL(
-				'1.1',
-				`/sites/${ siteID }/comments/${ commentID }/likes/mine/delete`
-			);
 		}
 
-		const response = await this.sendRequest( endpoint, params );
-
-		// Tried to like the comment, but failed to do so
-		// and the user still has not liked the comment.
-		if ( action === 'like' && response.like_count !== 1 ) {
-			throw new Error( `Failed to like ${ commentID } on site ${ siteID }` );
-		}
-		// Tried to unlike the comment, but failed to do so
-		// and the user still likes the comment.
-		if ( action === 'unlike' && response.like_count !== 0 ) {
-			throw new Error( `Failed to unlike ${ commentID } on site ${ siteID }` );
-		}
-
-		// Otherwise, consider it a success.
 		return response;
 	}
 

--- a/test/e2e/specs/published-content/likes__comment.spec.ts
+++ b/test/e2e/specs/published-content/likes__comment.spec.ts
@@ -38,6 +38,7 @@ test.describe( 'Likes: Comment', { tag: [ tags.GUTENBERG ] }, () => {
 		if ( envVariables.TEST_ON_ATOMIC ) {
 			test.setTimeout( 450_000 );
 		}
+		const commentSyncTimeout = envVariables.TEST_ON_ATOMIC ? 150_000 : 15_000;
 
 		testAccount = new TestAccount( accountName );
 		restAPIClient = new RestAPIClient( testAccount.credentials );
@@ -69,14 +70,23 @@ test.describe( 'Likes: Comment', { tag: [ tags.GUTENBERG ] }, () => {
 
 			// On Atomic the comment is created on the site and reaches WordPress.com
 			// only once Jetpack sync mirrors it, which can take over two minutes. Until then the
-			// likes endpoint answers `unknown_comment` and no like button renders. Since
-			// comments sync in creation order, once the second is likeable, the first is too.
+			// likes endpoint answers `unknown_comment` and no like button renders. Reading the
+			// comment is not a usable readiness signal: the GET succeeds while `likes/new` still
+			// answers `unknown_comment`, so each comment has to prove itself by being liked.
 			await expect( async () => {
-				await restAPIClient.likeComment(
-					testAccount.credentials.testSites?.primary.id as number,
-					commentToBeUnliked.ID
-				);
-			} ).toPass( { timeout: 150_000, intervals: [ 5000 ] } );
+				for ( const comment of [ commentToBeLiked, commentToBeUnliked ] ) {
+					await restAPIClient.likeComment(
+						testAccount.credentials.testSites?.primary.id as number,
+						comment.ID
+					);
+				}
+			} ).toPass( { timeout: commentSyncTimeout, intervals: [ 5000 ] } );
+
+			// Liking the first comment was only the readiness proof; the test likes it via the UI.
+			await restAPIClient.unlikeComment(
+				testAccount.credentials.testSites?.primary.id as number,
+				commentToBeLiked.ID
+			);
 
 			await testAccount.authenticate( page );
 		} );

--- a/test/e2e/specs/published-content/likes__comment.spec.ts
+++ b/test/e2e/specs/published-content/likes__comment.spec.ts
@@ -9,7 +9,7 @@ import {
 	envToFeatureKey,
 	getTestAccountByFeature,
 } from '@automattic/calypso-e2e';
-import { tags, test } from '../../lib/pw-base';
+import { expect, tags, test } from '../../lib/pw-base';
 
 test.describe( 'Likes: Comment', { tag: [ tags.GUTENBERG ] }, () => {
 	const features = envToFeatureKey( envVariables );
@@ -35,6 +35,10 @@ test.describe( 'Likes: Comment', { tag: [ tags.GUTENBERG ] }, () => {
 	} );
 
 	test( 'As a user, I can like and unlike a comment', async ( { page } ) => {
+		if ( envVariables.TEST_ON_ATOMIC ) {
+			test.setTimeout( 450_000 );
+		}
+
 		testAccount = new TestAccount( accountName );
 		restAPIClient = new RestAPIClient( testAccount.credentials );
 		let commentToBeLiked: NewCommentResponse;
@@ -63,23 +67,16 @@ test.describe( 'Likes: Comment', { tag: [ tags.GUTENBERG ] }, () => {
 				DataHelper.getRandomPhrase()
 			);
 
-			// The comment takes some time to settle. Retry to handle `unknown_comment` errors.
-			const likeRetryCount = 10;
-			for ( let i = 0; i <= likeRetryCount; i++ ) {
-				try {
-					await restAPIClient.commentAction(
-						'like',
-						testAccount.credentials.testSites?.primary.id as number,
-						commentToBeUnliked.ID
-					);
-					break;
-				} catch ( error ) {
-					if ( i === likeRetryCount ) {
-						throw error;
-					}
-					await page.waitForTimeout( 1000 );
-				}
-			}
+			// On Atomic the comment is created on the site and reaches WordPress.com
+			// only once Jetpack sync mirrors it, which can take over two minutes. Until then the
+			// likes endpoint answers `unknown_comment` and no like button renders. Since
+			// comments sync in creation order, once the second is likeable, the first is too.
+			await expect( async () => {
+				await restAPIClient.likeComment(
+					testAccount.credentials.testSites?.primary.id as number,
+					commentToBeUnliked.ID
+				);
+			} ).toPass( { timeout: 150_000, intervals: [ 5000 ] } );
 
 			await testAccount.authenticate( page );
 		} );


### PR DESCRIPTION
Fixes TESTOPS-251

## Proposed Changes

* `RestAPIClient.commentAction` splits into `likeComment` and `unlikeComment`. Both read the caller's own like state from `i_like` and put the raw response in the error they throw.
* `CommentsComponent` resolves the Atomic like widget inside the comment, clicks once, and matches the `Like` accessible name exactly. `postComment` goes; no spec called it.
* `likes__comment.spec.ts` likes both comments over the API until they stick, undoes the one the UI drives, and only then starts the test.

## Why are these changes being made?

Setup died with `Failed to like N on site X` on every Atomic config and never on Simple. The throw discarded the response body; restoring it gave the answer:

```
Response: {"error":"unknown_comment","message":"Unknown comment"}
```

A new comment is readable right away, but the comment likes index picks it up separately and on Atomic lags behind: 17s, 51s, 8s, 35s against the fixture site at a 5s poll. The old retry allowed about 10s, so it was always short on Atomic and never needed on Simple. `like_count !== 1` was a second, independent defect: an error body carries no `like_count`, so an API error got reported as a like failure and stayed hidden.

Reading the comment back is no help as a readiness signal; the GET succeeds while `likes/new` still answers `unknown_comment`. Neither does waiting on one comment and assuming the other followed it in. Each comment has to prove itself by being liked, so setup likes both and then unlikes the one the UI is going to click.

The wait is Atomic-only: 150s there against 15s on Simple, with the whole test given 450s on Atomic to fit it. Simple keeps the short budget so a real regression there still fails fast.

With setup unblocked, the UI steps ran on Atomic for the first time since the 2023 mute and exposed the widget bugs above.

## Evidence

TeamCity personal builds carrying this branch, both green:

* `gutenberg_atomic_production_desktop` 19120763: `Likes: Comment` in 83.8s, well inside the 150s sync budget.
* `gutenberg_simple_production_desktop` 19120765: 5.9s.

`gutenberg_atomic_production_desktop` had failed 4 out of 4 on trunk between 4 and 7 August.

## What to check

The spec still likes one comment through the UI and unlikes a second one that was liked over the API, so a page loading with an already-liked comment stays covered. The setup like on the first comment is only a readiness probe: it has to be undone before the UI runs, or the UI like step finds the comment already liked and the test passes for the wrong reason.

After merge the spec needs unmuting in the WPCom Tests project (mute 1605), along with two stale mutes left behind by the old jest path (650, 860).

## Testing Instructions

```
CALYPSO_BASE_URL=$CALYPSO_STAGING_URL yarn workspace wp-e2e-tests exec playwright test \
  specs/published-content/likes__comment.spec.ts --repeat-each=5
```

`test:pw --` swallows `--repeat-each`, so use `exec playwright test` when you want the repeats.

Add `TEST_ON_ATOMIC=true` for Atomic, and `TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment` for Jetpack Atomic deployment. Self-hosted Jetpack (`JETPACK_TARGET=remote-site`) wasn't exercised.

`packages/calypso-e2e` is consumed from its build output, so run `yarn workspace @automattic/calypso-e2e build` after checking out or the component changes won't take effect.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
