### PR TITLE
Help Center: Prevent repeated article ratings

### DIFF
--- a/packages/agents-manager/src/components/support-guide/index.tsx
+++ b/packages/agents-manager/src/components/support-guide/index.tsx
@@ -35,7 +35,7 @@ export default function SupportGuide( {
 	onClose,
 	onExpand,
 }: SupportGuideProps ) {
-	const { site, sectionName, isEligibleForChat } = useAgentsManagerContext();
+	const { currentUser, site, sectionName, isEligibleForChat } = useAgentsManagerContext();
 	const navigate = useNavigate();
 	const { state } = useLocation();
 	const { setFloatingPosition, setFreeDragPosition, setFloatingSize } =
@@ -96,6 +96,7 @@ export default function SupportGuide( {
 					<div className="agent-manager-support-guide-content help-center__container-content">
 						<HelpCenterArticle
 							sectionName={ sectionName }
+							userId={ currentUser?.ID }
 							currentSiteDomain={ site?.domain }
 							isEligibleForChat={ isEligibleForChat }
 							forceEmailSupport={ false }

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -82,7 +82,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 	const containerRef = useRef< HTMLDivElement >( null );
 	const navigate = useNavigate();
 	const { setNavigateToRoute } = useDispatch( HELP_CENTER_STORE );
-	const { sectionName, site } = useHelpCenterContext();
+	const { currentUser, sectionName, site } = useHelpCenterContext();
 	const featureConfig = useFeatureConfig();
 	const { data, isLoading: isLoadingSupportStatus } = useSupportStatus();
 	const { forceEmailSupport } = useChatStatus();
@@ -176,6 +176,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 							element={
 								<HelpCenterArticle
 									sectionName={ sectionName }
+									userId={ currentUser.ID }
 									currentSiteDomain={ currentSiteDomain }
 									isEligibleForChat={ isUserEligibleForPaidSupport }
 									forceEmailSupport={ !! forceEmailSupport || ! featureConfig.chat.enabled }

--- a/packages/support-articles/jest.config.js
+++ b/packages/support-articles/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	preset: '../../test/packages/jest-preset.js',
+	testEnvironment: 'jsdom',
+};

--- a/packages/support-articles/src/components/help-center-article/help-center-article-content.tsx
+++ b/packages/support-articles/src/components/help-center-article/help-center-article-content.tsx
@@ -10,6 +10,7 @@ import type { ArticleContentProps } from '../../types';
 const ArticleContent = ( {
 	post,
 	isLoading,
+	userId,
 	currentSiteDomain,
 	isEligibleForChat,
 	forceEmailSupport,
@@ -38,7 +39,9 @@ const ArticleContent = ( {
 							ref={ articleContentRef }
 						/>
 						<HelpCenterFeedbackForm
+							key={ `${ userId ?? 'anonymous' }-${ post.ID }` }
 							postId={ post.ID }
+							userId={ userId }
 							isEligibleForChat={ isEligibleForChat }
 							forceEmailSupport={ forceEmailSupport }
 						/>

--- a/packages/support-articles/src/components/help-center-article/index.tsx
+++ b/packages/support-articles/src/components/help-center-article/index.tsx
@@ -14,11 +14,13 @@ declare const __i18n_text_domain__: string;
 
 export const HelpCenterArticle = ( {
 	sectionName,
+	userId,
 	currentSiteDomain,
 	isEligibleForChat,
 	forceEmailSupport,
 }: {
 	sectionName: string;
+	userId?: number;
 	currentSiteDomain?: string;
 	isEligibleForChat: boolean;
 	forceEmailSupport: boolean;
@@ -109,6 +111,7 @@ export const HelpCenterArticle = ( {
 				<ArticleContent
 					post={ post }
 					isLoading={ isLoading }
+					userId={ userId }
 					currentSiteDomain={ currentSiteDomain }
 					isEligibleForChat={ isEligibleForChat }
 					forceEmailSupport={ forceEmailSupport }

--- a/packages/support-articles/src/components/help-center-feedback-form/index.tsx
+++ b/packages/support-articles/src/components/help-center-feedback-form/index.tsx
@@ -9,24 +9,61 @@ declare const __i18n_text_domain__: string;
 
 import './help-center-feedback-form.scss';
 
+type FeedbackAnswer = 1 | 2;
+
+const getFeedbackStorageKey = ( postId: number, userId?: number ) =>
+	`help-center-article-feedback-${ userId ?? 'anonymous' }-${ postId }`;
+
+const getStoredFeedback = ( postId: number, userId?: number ): FeedbackAnswer | null => {
+	try {
+		const value = window.localStorage.getItem( getFeedbackStorageKey( postId, userId ) );
+		if ( value === '1' ) {
+			return 1;
+		}
+		if ( value === '2' ) {
+			return 2;
+		}
+		return null;
+	} catch {
+		return null;
+	}
+};
+
+const storeFeedback = ( postId: number, value: FeedbackAnswer, userId?: number ) => {
+	try {
+		window.localStorage.setItem( getFeedbackStorageKey( postId, userId ), String( value ) );
+	} catch {
+		return;
+	}
+};
+
 const HelpCenterFeedbackForm = ( {
 	postId,
+	userId,
 	isEligibleForChat,
 	forceEmailSupport,
 }: {
 	postId: number;
+	userId?: number;
 	isEligibleForChat: boolean;
 	forceEmailSupport: boolean;
 } ) => {
 	const { __ } = useI18n();
-	const [ startedFeedback, setStartedFeedback ] = useState< boolean | null >( null );
-	const [ answerValue, setAnswerValue ] = useState< number | null >( null );
+	const [ answerValue, setAnswerValue ] = useState< FeedbackAnswer | null >( () =>
+		getStoredFeedback( postId, userId )
+	);
 
 	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging();
 
-	const handleFeedbackClick = ( value: number ) => {
-		setStartedFeedback( true );
+	const handleFeedbackClick = ( value: FeedbackAnswer ) => {
+		const storedFeedback = getStoredFeedback( postId, userId );
+		if ( storedFeedback !== null ) {
+			setAnswerValue( storedFeedback );
+			return;
+		}
+
 		setAnswerValue( value );
+		storeFeedback( postId, value, userId );
 
 		recordTracksEvent( 'calypso_inlinehelp_article_feedback_click', {
 			did_the_article_help: value === 1 ? 'yes' : 'no',
@@ -66,11 +103,9 @@ const HelpCenterFeedbackForm = ( {
 
 	return (
 		<div className="help-center-feedback__form">
-			{ startedFeedback === null && <FeedbackButtons /> }
-			{ startedFeedback !== null && answerValue === 1 && (
-				<p>{ __( 'Great! Thanks.', __i18n_text_domain__ ) }</p>
-			) }
-			{ startedFeedback !== null && answerValue === 2 && (
+			{ answerValue === null && <FeedbackButtons /> }
+			{ answerValue === 1 && <p>{ __( 'Great! Thanks.', __i18n_text_domain__ ) }</p> }
+			{ answerValue === 2 && (
 				<>
 					<div className="odie-chatbox-dislike-feedback-message">
 						<p>

--- a/packages/support-articles/src/types.ts
+++ b/packages/support-articles/src/types.ts
@@ -22,6 +22,7 @@ export interface PostObject {
 export interface ArticleContentProps {
 	post?: PostObject;
 	isLoading?: boolean;
+	userId?: number;
 	currentSiteDomain?: string;
 	isEligibleForChat: boolean;
 	forceEmailSupport: boolean;

--- a/packages/support-articles/test/help-center-feedback-form.tsx
+++ b/packages/support-articles/test/help-center-feedback-form.tsx
@@ -1,0 +1,88 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import HelpCenterFeedbackForm from '../src/components/help-center-feedback-form';
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/odie-client', () => ( {
+	GetSupport: () => null,
+} ) );
+
+jest.mock( '@automattic/zendesk-client', () => ( {
+	useCanConnectToZendeskMessaging: () => ( { data: true } ),
+} ) );
+
+jest.mock( '@wordpress/react-i18n', () => ( {
+	useI18n: () => ( { __: ( text: string ) => text } ),
+} ) );
+
+const renderFeedbackForm = ( postId: number, userId = 1 ) =>
+	render(
+		<HelpCenterFeedbackForm
+			postId={ postId }
+			userId={ userId }
+			isEligibleForChat={ false }
+			forceEmailSupport={ false }
+		/>
+	);
+
+describe( 'HelpCenterFeedbackForm', () => {
+	beforeEach( () => {
+		window.localStorage.clear();
+		jest.mocked( recordTracksEvent ).mockClear();
+	} );
+
+	it( 'does not offer another rating after remounting an article in the same browser', () => {
+		const { unmount } = renderFeedbackForm( 123 );
+
+		fireEvent.click( screen.getByRole( 'button', { name: /yes/i } ) );
+
+		expect( screen.getByText( 'Great! Thanks.' ) ).toBeVisible();
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_inlinehelp_article_feedback_click', {
+			did_the_article_help: 'yes',
+			post_id: 123,
+		} );
+
+		unmount();
+		renderFeedbackForm( 123 );
+
+		expect( screen.queryByRole( 'button', { name: /yes/i } ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Great! Thanks.' ) ).toBeVisible();
+		expect( recordTracksEvent ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'allows rating a different article in the same browser', () => {
+		const { unmount } = renderFeedbackForm( 123 );
+		fireEvent.click( screen.getByRole( 'button', { name: /no/i } ) );
+		unmount();
+
+		renderFeedbackForm( 456 );
+
+		expect( screen.getByRole( 'button', { name: /yes/i } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: /no/i } ) ).toBeVisible();
+	} );
+
+	it( 'keeps ratings isolated between users', () => {
+		const { unmount } = renderFeedbackForm( 123, 1 );
+		fireEvent.click( screen.getByRole( 'button', { name: /yes/i } ) );
+		unmount();
+
+		renderFeedbackForm( 123, 2 );
+
+		expect( screen.getByRole( 'button', { name: /yes/i } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: /no/i } ) ).toBeVisible();
+	} );
+
+	it( 'does not record feedback already stored by another tab', () => {
+		renderFeedbackForm( 123, 1 );
+		window.localStorage.setItem( 'help-center-article-feedback-1-123', '1' );
+
+		fireEvent.click( screen.getByRole( 'button', { name: /no/i } ) );
+
+		expect( screen.getByText( 'Great! Thanks.' ) ).toBeVisible();
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
Fixes DOTCOM-18102

## Proposed Changes

* Persist Help Center article ratings in `localStorage`, scoped by user ID and article ID.
* Restore submitted feedback when an article is reopened and prevent duplicate Tracks events, including stale UI in another browser tab.
* Pass current user IDs through both Help Center and Agents Manager article renderers.
* Add focused tests for remount persistence, article isolation, user isolation, and cross-tab duplicate protection.

## Why are these changes being made?

* Article feedback previously lived only in React component state. Closing and reopening an article reset that state, allowing the same user to emit repeated `calypso_inlinehelp_article_feedback_click` events for one article.
* Browser-persistent, account-scoped state prevents ordinary repeat submissions without mixing feedback between users sharing a browser.

## Testing Instructions

* Open Help Center and select an article.
* Submit either Yes or No feedback.
* Close and reopen Help Center, or reload the page and reopen the same article. Confirm feedback buttons are no longer offered.
* Open a different article. Confirm feedback buttons remain available.
* Automated checks:
  * `yarn jest -c packages/support-articles/jest.config.js --runInBand`
  * `yarn jest -c packages/help-center/jest.config.js --runInBand`
  * `yarn jest -c packages/agents-manager/jest.config.js --runInBand`
  * `yarn typecheck-packages`
  * ESLint and Prettier on changed files

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
