### PR TITLE
Agents Manager: open the chat via the ai-open=true URL param

### DIFF
--- a/apps/agents-manager/README.md
+++ b/apps/agents-manager/README.md
@@ -15,6 +15,10 @@ The Agents Manager runs in multiple different environments:
    - as a wpadminbar menu item.
 4. In CIAB (Commerce in a Box)
    - as a Next Admin SPA integration.
+5. In the WooCommerce AI admin
+   - as a standalone chat container, without touching the admin bar.
+6. On public blog frontends
+   - as Reader Chat for logged-out visitors.
 
 ### How to develop the Agents Manager
 
@@ -51,6 +55,7 @@ After every change to the Agents Manager, the development process is two parts:
 This simply means deploying Calypso as you normally would.
 
 #### Deploy the Agents Manager for Jetpack consumption
+
 1. Connect to your sandbox and run: `install-plugin.sh am --release`
 2. When prompted where to push the branch, select the WPCOM repository.
 3. This will create a PR on the WPCOM repository.

--- a/apps/agents-manager/README.md
+++ b/apps/agents-manager/README.md
@@ -16,7 +16,7 @@ The Agents Manager runs in multiple different environments:
 4. In CIAB (Commerce in a Box)
    - as a Next Admin SPA integration.
 5. In the WooCommerce AI admin
-   - as a standalone chat container, without touching the admin bar.
+   - as a standalone chat container.
 6. On public blog frontends
    - as Reader Chat for logged-out visitors.
 

--- a/packages/agents-manager/README.md
+++ b/packages/agents-manager/README.md
@@ -94,14 +94,17 @@ The host page URL can carry these query parameters:
 
 ### AgentsManager Props
 
-| Prop            | Type                           | Description                                                                                                              |
-| --------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
-| `sectionName`   | `string`                       | The name of the current section (e.g., 'wp-admin', 'gutenberg').                                                         |
-| `currentUser`   | `CurrentUser` (optional)       | Current user (from `@automattic/data-stores`). Sets `isLoggedIn`.                                                        |
-| `site`          | `AgentsManagerSite` (optional) | The selected site object (from `@automattic/data-stores`).                                                               |
-| `currentRoute`  | `string` (optional)            | The current route path.                                                                                                  |
-| `currentSiteId` | `number` (optional)            | The ID of the selected site. When set, chat state is scoped to this site. When omitted, uses a shared "no-site" context. |
-| `agentId`       | `string` (optional)            | Explicit agent ID for hosts that must not fall back to Unified Chat.                                                     |
+| Prop                             | Type                           | Description                                                                                                              |
+| -------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| `sectionName`                    | `string`                       | The name of the current section (e.g., 'wp-admin', 'gutenberg').                                                         |
+| `currentUser`                    | `CurrentUser` (optional)       | Current user (from `@automattic/data-stores`). Sets `isLoggedIn`.                                                        |
+| `site`                           | `AgentsManagerSite` (optional) | The selected site object (from `@automattic/data-stores`).                                                               |
+| `currentRoute`                   | `string` (optional)            | The current route path.                                                                                                  |
+| `currentSiteId`                  | `number` (optional)            | The ID of the selected site. When set, chat state is scoped to this site. When omitted, uses a shared "no-site" context. |
+| `agentId`                        | `string` (optional)            | Explicit agent ID for hosts that must not fall back to Unified Chat.                                                     |
+| `zendeskConversationTags`        | `string[]` (optional)          | Zendesk conversation tags to apply when a new support conversation is created.                                           |
+| `zendeskSmoochIntegrationKey`    | `string` (optional)            | Index selecting a dedicated Smooch integration for new support conversations (e.g. `woo`).                               |
+| `zendeskTicketProductFieldValue` | `string` (optional)            | Zendesk Product ticket-field value to apply to new support conversations.                                                |
 
 ### Exported Hooks and Utilities
 
@@ -117,6 +120,8 @@ function MyComponent() {
 	const useUnifiedExperience = getAgentsManagerInlineData()?.useUnifiedExperience;
 }
 ```
+
+Feedback utilities are also exported: `useFeedbackAction`, `submitFeedback`, `rateMessage`, and the `FeedbackInput` component.
 
 ### Exported Types
 

--- a/packages/agents-manager/README.md
+++ b/packages/agents-manager/README.md
@@ -4,9 +4,7 @@ Unified AI Agent manager for WordPress and Calypso.
 
 ## Installation
 
-```bash
-yarn add @automattic/agents-manager
-```
+An internal workspace package, not published to npm — add `@automattic/agents-manager` as a dependency in the consuming `wp-calypso` workspace (used by Calypso and `apps/agents-manager`).
 
 ## Usage
 

--- a/packages/agents-manager/README.md
+++ b/packages/agents-manager/README.md
@@ -80,6 +80,16 @@ The Agents Manager exposes a `window.__agentsManagerActions` API for controlling
 
 See `src/hooks/custom-actions/README.md` for details.
 
+### URL Parameters
+
+The host page URL can carry these query parameters:
+
+| Parameter | Description                                                                                                                                                   |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ai-open` | `ai-open=true` auto-opens the chat (docked or undocked) on page load, e.g. for links from emails. The parameter is stripped from the URL after being applied. |
+| `agent`   | Overrides the agent ID, for testing (e.g., `?agent=wpcom-workflow-support_chat`).                                                                             |
+| `version` | Overrides the agent version, for testing (e.g., `?version=1.0.25`).                                                                                           |
+
 ## API Reference
 
 ### AgentsManager Props

--- a/packages/agents-manager/src/components/__tests__/agents-manager.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agents-manager.test.tsx
@@ -32,6 +32,9 @@ jest.mock( '../../contexts', () => ( {
 jest.mock( '../../stores', () => ( { AGENTS_MANAGER_STORE: 'agents-manager' } ) );
 jest.mock( '../../utils/create-agent-config', () => ( {} ) );
 jest.mock( '../../hooks/use-agent-config', () => ( {} ) );
+jest.mock( '../../hooks/use-open-chat-url-param', () => ( {
+	useOpenChatUrlParam: () => true,
+} ) );
 jest.mock( '../../utils/agent-session', () => ( {} ) );
 jest.mock( '../../utils/load-external-providers', () => ( {} ) );
 jest.mock( '../../hooks/use-empty-view-suggestions', () => ( {} ) );

--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -11,6 +11,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { AgentsManagerContextProvider, useAgentsManagerContext } from '../contexts';
 import { useAgentConfig } from '../hooks/use-agent-config';
 import { useEmptyViewSuggestions } from '../hooks/use-empty-view-suggestions';
+import { useOpenChatUrlParam } from '../hooks/use-open-chat-url-param';
 import { AGENTS_MANAGER_STORE } from '../stores';
 import { clearSessionId, getOrCreateSessionId } from '../utils/agent-session';
 import { createAgentConfig } from '../utils/create-agent-config';
@@ -65,7 +66,11 @@ export default function AgentsManager( {
 		return store.getAgentsManagerState();
 	}, [] );
 
-	if ( ! isStoreReady ) {
+	// `?ai-open=true` must be applied to the store before `AgentDock` mounts, so
+	// the chat first-renders already open in both docked and undocked modes.
+	const isOpenParamHandled = useOpenChatUrlParam();
+
+	if ( ! isStoreReady || ! isOpenParamHandled ) {
 		return null;
 	}
 

--- a/packages/agents-manager/src/hooks/__tests__/use-open-chat-url-param.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-open-chat-url-param.test.ts
@@ -1,0 +1,172 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/order -- jest.mock calls must precede imports */
+jest.mock( '../../stores', () => ( { AGENTS_MANAGER_STORE: 'automattic/agents-manager' } ) );
+jest.mock( '../../utils/is-reader-chat-agent', () => ( { isReaderChatHost: jest.fn() } ) );
+jest.mock( '../../utils/tracks', () => ( { recordBigSkyTracksEvent: jest.fn() } ) );
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+
+import { renderHook } from '@testing-library/react';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { isReaderChatHost } from '../../utils/is-reader-chat-agent';
+import { recordBigSkyTracksEvent } from '../../utils/tracks';
+import { useOpenChatUrlParam } from '../use-open-chat-url-param';
+
+const mockUseDispatch = useDispatch as jest.Mock;
+const mockUseSelect = useSelect as jest.Mock;
+const mockIsReaderChatHost = isReaderChatHost as jest.Mock;
+
+const setIsOpen = jest.fn();
+const setIsMinimized = jest.fn();
+
+const mockStoreState = (
+	state: { hasLoaded?: boolean; isOpen?: boolean; isMinimized?: boolean } = {}
+) => {
+	mockUseSelect.mockImplementation( () => ( {
+		hasLoaded: true,
+		isOpen: false,
+		isMinimized: false,
+		...state,
+	} ) );
+};
+
+describe( 'useOpenChatUrlParam', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockUseDispatch.mockReturnValue( { setIsOpen, setIsMinimized } );
+		mockIsReaderChatHost.mockReturnValue( false );
+		mockStoreState();
+		window.history.replaceState( null, '', '/' );
+	} );
+
+	it.each( [
+		{
+			isOpen: false,
+			isMinimized: true,
+			openCalls: [ [ true, true ] ],
+			minimizeCalls: [ [ false, true ] ],
+			handled: false,
+		},
+		{
+			isOpen: false,
+			isMinimized: false,
+			openCalls: [ [ true, true ] ],
+			minimizeCalls: [],
+			handled: false,
+		},
+		{
+			isOpen: true,
+			isMinimized: true,
+			openCalls: [],
+			minimizeCalls: [ [ false, true ] ],
+			handled: false,
+		},
+		{ isOpen: true, isMinimized: false, openCalls: [], minimizeCalls: [], handled: true },
+	] )(
+		'dispatches only the needed updates when isOpen=$isOpen and isMinimized=$isMinimized',
+		( { isOpen, isMinimized, openCalls, minimizeCalls, handled } ) => {
+			window.history.replaceState( null, '', '/?ai-open=true' );
+			mockStoreState( { isOpen, isMinimized } );
+
+			const { result } = renderHook( () => useOpenChatUrlParam() );
+
+			expect( setIsOpen.mock.calls ).toEqual( openCalls );
+			expect( setIsMinimized.mock.calls ).toEqual( minimizeCalls );
+			expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'ai_editor_menu_opened' );
+			expect( window.location.search ).toBe( '' );
+			expect( result.current ).toBe( handled );
+		}
+	);
+
+	it( 'strips only `ai-open` and reports handled once the store reflects the open state', () => {
+		window.history.replaceState( null, '', '/?canvas=edit&ai-open=true' );
+		mockStoreState( { isMinimized: true } );
+
+		const { result, rerender } = renderHook( () => useOpenChatUrlParam() );
+
+		expect( result.current ).toBe( false );
+		expect( window.location.search ).toBe( '?canvas=edit' );
+
+		mockStoreState( { isOpen: true } );
+		rerender();
+
+		expect( result.current ).toBe( true );
+		expect( setIsOpen ).toHaveBeenCalledTimes( 1 );
+		expect( setIsMinimized ).toHaveBeenCalledTimes( 1 );
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it.each( [ '/', '/?ai-open=false', '/?ai-open=1' ] )( 'does nothing for URL `%s`', ( url ) => {
+		window.history.replaceState( null, '', url );
+
+		const { result } = renderHook( () => useOpenChatUrlParam() );
+
+		expect( result.current ).toBe( true );
+		expect( setIsOpen ).not.toHaveBeenCalled();
+		expect( setIsMinimized ).not.toHaveBeenCalled();
+		expect( recordBigSkyTracksEvent ).not.toHaveBeenCalled();
+		expect( window.location.pathname + window.location.search ).toBe( url );
+	} );
+
+	it( 'opens even when the host rewrote the URL before the persisted state loaded', () => {
+		window.history.replaceState( null, '', '/?ai-open=true' );
+		mockStoreState( { hasLoaded: false } );
+
+		const { rerender } = renderHook( () => useOpenChatUrlParam() );
+
+		// Simulate the Site Editor router dropping the param during boot.
+		window.history.replaceState( null, '', '/?canvas=edit' );
+		mockStoreState( { hasLoaded: true } );
+		rerender();
+
+		expect( setIsOpen ).toHaveBeenCalledWith( true, true );
+		expect( window.location.search ).toBe( '?canvas=edit' );
+	} );
+
+	it( 'waits for the persisted state to load before opening', () => {
+		window.history.replaceState( null, '', '/?ai-open=true' );
+		mockStoreState( { hasLoaded: false } );
+
+		const { result, rerender } = renderHook( () => useOpenChatUrlParam() );
+
+		expect( result.current ).toBe( false );
+		expect( setIsOpen ).not.toHaveBeenCalled();
+		expect( window.location.search ).toBe( '?ai-open=true' );
+
+		mockStoreState( { hasLoaded: true } );
+		rerender();
+
+		expect( setIsOpen ).toHaveBeenCalledWith( true, true );
+		expect( window.location.search ).toBe( '' );
+
+		mockStoreState( { isOpen: true } );
+		rerender();
+
+		expect( result.current ).toBe( true );
+	} );
+
+	it( 'opens without persisting or tracking on reader-chat hosts', () => {
+		window.history.replaceState( null, '', '/?ai-open=true' );
+		mockStoreState( { isMinimized: true } );
+		mockIsReaderChatHost.mockReturnValue( true );
+
+		renderHook( () => useOpenChatUrlParam() );
+
+		expect( setIsOpen ).toHaveBeenCalledWith( true, false );
+		expect( setIsMinimized ).toHaveBeenCalledWith( false, false );
+		expect( recordBigSkyTracksEvent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'preserves the existing history state when stripping the param', () => {
+		window.history.replaceState( { canvas: 'edit' }, '', '/?ai-open=true' );
+
+		renderHook( () => useOpenChatUrlParam() );
+
+		expect( window.history.state ).toEqual( { canvas: 'edit' } );
+		expect( window.location.search ).toBe( '' );
+	} );
+} );

--- a/packages/agents-manager/src/hooks/use-open-chat-url-param.ts
+++ b/packages/agents-manager/src/hooks/use-open-chat-url-param.ts
@@ -1,0 +1,70 @@
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect, useRef, useState } from '@wordpress/element';
+import { AGENTS_MANAGER_STORE } from '../stores';
+import { isReaderChatHost } from '../utils/is-reader-chat-agent';
+import { recordBigSkyTracksEvent } from '../utils/tracks';
+import type { AgentsManagerSelect } from '@automattic/data-stores';
+
+const OPEN_CHAT_URL_PARAM = 'ai-open';
+
+const hasOpenChatUrlParam = () =>
+	new URLSearchParams( window.location.search ).get( OPEN_CHAT_URL_PARAM ) === 'true';
+
+/**
+ * Opens the chat when the page URL carries `?ai-open=true` (e.g. promo links
+ * from emails), then strips the param so reloads don't re-open it. The param
+ * is captured on the first render since hosts like the Site Editor rewrite
+ * the URL during boot. Returns `true` once handled — `AgentsManager` gates
+ * rendering on it so the chat first-renders already open; without the param
+ * it returns `true` immediately.
+ */
+export function useOpenChatUrlParam(): boolean {
+	const [ isHandled, setIsHandled ] = useState( () => ! hasOpenChatUrlParam() );
+	const hasOpenedRef = useRef( false );
+	const { setIsOpen, setIsMinimized } = useDispatch( AGENTS_MANAGER_STORE );
+	const { hasLoaded, isOpen, isMinimized } = useSelect( ( select ) => {
+		const store: AgentsManagerSelect = select( AGENTS_MANAGER_STORE );
+		return store.getAgentsManagerState();
+	}, [] );
+
+	useEffect( () => {
+		if ( isHandled || ! hasLoaded ) {
+			return;
+		}
+
+		if ( ! hasOpenedRef.current ) {
+			hasOpenedRef.current = true;
+
+			// Reader chat runs on public blog frontends: Big Sky parity events
+			// don't apply there, and open state must not persist to the
+			// logged-in REST endpoint.
+			const isReaderChat = isReaderChatHost();
+
+			if ( ! isReaderChat ) {
+				recordBigSkyTracksEvent( 'ai_editor_menu_opened' );
+			}
+
+			if ( ! isOpen ) {
+				setIsOpen( true, ! isReaderChat );
+			}
+
+			if ( isMinimized ) {
+				setIsMinimized( false, ! isReaderChat );
+			}
+
+			const url = new URL( window.location.href );
+			if ( url.searchParams.has( OPEN_CHAT_URL_PARAM ) ) {
+				url.searchParams.delete( OPEN_CHAT_URL_PARAM );
+				window.history.replaceState( window.history.state, '', url );
+			}
+		}
+
+		// Handled only once the store reflects the open state; the dispatches
+		// above re-run this effect via the `isOpen`/`isMinimized` deps.
+		if ( isOpen && ! isMinimized ) {
+			setIsHandled( true );
+		}
+	}, [ hasLoaded, isHandled, isMinimized, isOpen, setIsMinimized, setIsOpen ] );
+
+	return isHandled;
+}

--- a/packages/agents-manager/src/hooks/use-open-chat-url-param.ts
+++ b/packages/agents-manager/src/hooks/use-open-chat-url-param.ts
@@ -8,6 +8,7 @@ import type { AgentsManagerSelect } from '@automattic/data-stores';
 const OPEN_CHAT_URL_PARAM = 'ai-open';
 
 const hasOpenChatUrlParam = () =>
+	typeof window !== 'undefined' &&
 	new URLSearchParams( window.location.search ).get( OPEN_CHAT_URL_PARAM ) === 'true';
 
 /**


### PR DESCRIPTION
Fixes AI-1097

## Proposed Changes

* Add a `useOpenChatUrlParam` hook to `@automattic/agents-manager` that auto-opens the chat when the page URL carries `?ai-open=true` (e.g. promo links from emails), then strips the param so reloads and copied URLs don't re-open it.
* The param is captured on the first render — hosts like the Site Editor rewrite the URL during boot, before the persisted chat state finishes loading — and acted on once the store loads: `setIsOpen( true )` + `setIsMinimized( false )`, skipping redundant saves when the chat is already open.
* `AgentsManager` gates rendering on the hook so `AgentDock` first-renders with the open state already applied. This is required for the docked sidebar, whose layout manager reads the open state only in its `useState` initializer. It makes auto-open work in both docked and undocked modes.
* Records the existing `jetpack_big_sky_ai_editor_menu_opened` Tracks event (same name Big Sky used for this flow) so the existing dashboards keep working. Reader-chat hosts open without persisting state or recording the event.
* Without the param, the hook reports handled on the very first render — the render gate is identical to the current `! isStoreReady` condition, so normal page loads are byte-for-byte unchanged.
* Document the supported URL parameters (`ai-open`, `agent`, `version`) in the package README.

## Why are these changes being made?

* The `ai-open=true` query param used to auto-open the Big Sky sidebar when entering the editor from a link, but it has no effect with the Agents Manager — the old handling in the Big Sky plugin only records a Tracks event today, and nothing in AM reads the param. This restores the auto-open behavior for the unified AM chat so links (e.g. from emails) can land users directly in the chat.

## Testing Instructions

https://github.com/user-attachments/assets/f456b3e8-99b2-48cd-aa2d-8d636fe2a24c

### Calypso

1. Run `yarn start` and log in.
2. Visit any section with the param appended, e.g. `/home/<site>?ai-open=true`.
3. The AM chat opens automatically and `ai-open` is stripped from the URL.
4. Reload the page: the chat state follows your persisted preference as usual (no forced re-open beyond it having been opened).

### Simple/Atomic (sandbox)

1. Sandbox `widgets.wp.com` and run `cd apps/agents-manager && yarn dev --sync`.
2. Open the Site Editor with the param: `/wp-admin/site-editor.php?canvas=edit&ai-open=true` (also works in the post editor, e.g. `/wp-admin/post-new.php?ai-open=true`).
3. The AM chat opens automatically — docked or floating, following your last docking preference — and `ai-open` is stripped from the URL.
4. Repeat with the chat previously minimized: it expands.
5. Regression check: load the same pages **without** the param — behavior is unchanged from trunk (chat stays closed/minimized per your persisted state).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)