### PR TITLE
Add-ons: hide Manage add-on links when not needed

### DIFF
--- a/client/sites/components/add-ons/add-ons-card/index.tsx
+++ b/client/sites/components/add-ons/add-ons-card/index.tsx
@@ -118,7 +118,10 @@ const AddOnCard = ( { addOnMeta, actionPrimary, actionSecondary, highlightFeatur
 
 	const shouldRenderLoadingState = addOnMeta.isLoading;
 	const shouldRenderPrimaryAction = purchaseStatus?.available && ! shouldRenderLoadingState;
-	const shouldRenderSecondaryAction = ! purchaseStatus?.available && ! shouldRenderLoadingState;
+	const shouldRenderPurchaseStatus = ! purchaseStatus?.available && ! shouldRenderLoadingState;
+	// Only a separately purchased add-on has something to manage in the site's subscriptions.
+	const shouldRenderSecondaryAction =
+		purchaseStatus?.reason === 'purchased' && ! shouldRenderLoadingState;
 
 	// Return null if the add-on isn't already purchased and the amount of storage isn't available
 	// for purchase
@@ -152,20 +155,16 @@ const AddOnCard = ( { addOnMeta, actionPrimary, actionSecondary, highlightFeatur
 					{ shouldRenderLoadingState && (
 						<Spinner size={ 24 } className="spinner-button__spinner" />
 					) }
-					{ shouldRenderSecondaryAction && (
-						<>
-							{ actionSecondary && (
-								<Button onClick={ onActionSecondary } variant="secondary">
-									{ translate( 'Manage add-on' ) }
-								</Button>
-							) }
-							{ purchaseStatus?.text && (
-								<div className="add-ons-card__selected-tag">
-									<Gridicon size={ 16 } icon="checkmark" className="add-ons-card__checkmark" />
-									<span>{ purchaseStatus.text }</span>
-								</div>
-							) }
-						</>
+					{ shouldRenderSecondaryAction && actionSecondary && (
+						<Button onClick={ onActionSecondary } variant="secondary">
+							{ translate( 'Manage add-on' ) }
+						</Button>
+					) }
+					{ shouldRenderPurchaseStatus && purchaseStatus?.text && (
+						<div className="add-ons-card__selected-tag">
+							<Gridicon size={ 16 } icon="checkmark" className="add-ons-card__checkmark" />
+							<span>{ purchaseStatus.text }</span>
+						</div>
 					) }
 					{ shouldRenderPrimaryAction && actionPrimary && (
 						<Button variant="primary" onClick={ onActionPrimary }>

--- a/client/sites/components/add-ons/add-ons-card/index.tsx
+++ b/client/sites/components/add-ons/add-ons-card/index.tsx
@@ -95,6 +95,9 @@ const Container = styled.div`
 			align-items: center;
 			gap: 0.5em;
 			font-size: 13px;
+			// Match the action button's height so the footer is the same height with or
+			// without a button, keeping the status text aligned across cards.
+			min-height: 36px;
 
 			.add-ons-card__checkmark {
 				color: var( --studio-green-30 );

--- a/packages/data-stores/src/add-ons/hooks/use-add-on-purchase-status.ts
+++ b/packages/data-stores/src/add-ons/hooks/use-add-on-purchase-status.ts
@@ -8,14 +8,16 @@ interface Props {
 	selectedSiteId?: number | null;
 }
 
-type AddOnPurchaseStatus = {
-	available: boolean;
-	/**
-	 * Why the add-on is unavailable: bought separately, or granted by the site's plan.
-	 */
-	reason?: 'purchased' | 'included';
-	text?: ReturnType< typeof i18n.translate >;
-};
+type AddOnPurchaseStatus =
+	| { available: true; reason?: never; text?: never }
+	| {
+			available: false;
+			/**
+			 * Why the add-on is unavailable: bought separately, or granted by the site's plan.
+			 */
+			reason: 'purchased' | 'included';
+			text: ReturnType< typeof i18n.translate >;
+	  };
 
 /**
  * Returns whether add-on product has been purchased or included in site plan.
@@ -39,8 +41,14 @@ const useAddOnPurchaseStatus = ( { addOnMeta, selectedSiteId }: Props ): AddOnPu
 	 */
 	if ( matchingPurchases ) {
 		if ( addOnMeta.quantity ) {
-			const purchase: Purchases.RawPurchase = Object.values( matchingPurchases )[ 0 ];
-			if ( purchase.renewal_price_tier_usage_quantity === addOnMeta.quantity ) {
+			// A site can hold several purchases of the same product slug, so check them all
+			// rather than assuming the matching quantity is on the first one.
+			const purchases: Purchases.RawPurchase[] = Object.values( matchingPurchases );
+			if (
+				purchases.some(
+					( purchase ) => purchase.renewal_price_tier_usage_quantity === addOnMeta.quantity
+				)
+			) {
 				return { available: false, reason: 'purchased', text: translate( 'Purchased' ) };
 			}
 		} else {

--- a/packages/data-stores/src/add-ons/hooks/use-add-on-purchase-status.ts
+++ b/packages/data-stores/src/add-ons/hooks/use-add-on-purchase-status.ts
@@ -10,6 +10,10 @@ interface Props {
 
 type AddOnPurchaseStatus = {
 	available: boolean;
+	/**
+	 * Why the add-on is unavailable: bought separately, or granted by the site's plan.
+	 */
+	reason?: 'purchased' | 'included';
 	text?: ReturnType< typeof i18n.translate >;
 };
 
@@ -37,15 +41,15 @@ const useAddOnPurchaseStatus = ( { addOnMeta, selectedSiteId }: Props ): AddOnPu
 		if ( addOnMeta.quantity ) {
 			const purchase: Purchases.RawPurchase = Object.values( matchingPurchases )[ 0 ];
 			if ( purchase.renewal_price_tier_usage_quantity === addOnMeta.quantity ) {
-				return { available: false, text: translate( 'Purchased' ) };
+				return { available: false, reason: 'purchased', text: translate( 'Purchased' ) };
 			}
 		} else {
-			return { available: false, text: translate( 'Purchased' ) };
+			return { available: false, reason: 'purchased', text: translate( 'Purchased' ) };
 		}
 	}
 
 	if ( isSiteFeature ) {
-		return { available: false, text: translate( 'Included in your plan' ) };
+		return { available: false, reason: 'included', text: translate( 'Included in your plan' ) };
 	}
 
 	return { available: true };


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DSGCOM-717

## Proposed Changes

* When the add-on is already included in the plan the 'Manage add-on' link still links to the site subscriptions page, which doesn't provide any value, so the solution is to hide the button in this case.

**Before**
<img width="1081" height="572" alt="Screenshot 2026-08-03 at 18 36 57" src="https://github.com/user-attachments/assets/19d3fe48-6413-4418-85a1-c21842f56c4c" />

**After**
<img width="1081" height="572" alt="Screenshot 2026-08-03 at 18 36 38" src="https://github.com/user-attachments/assets/901e8df1-ebd9-4f41-b00b-484a5099bf44" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a Personal site go to /add-ons/{your site} and purchase the Premium Themes add-on. Test the Manage add-on links.
* With the fix in place, confirm that the Manage add-on link doesn't appear for Custom CSS add-on.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
