### PR TITLE
Stepper: treat a reverted transfer as a real ending, not a timeout

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/automated-copy-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/automated-copy-site/index.tsx
@@ -1,4 +1,5 @@
 import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 import { useEffect, useRef } from 'react';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
@@ -6,28 +7,15 @@ import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import {
 	createRevertedTransferWatcher,
 	getTransferFailureMessage,
+	transferStates,
 } from 'calypso/landing/stepper/utils/atomic-transfer-outcome';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import wpcom from 'calypso/lib/wp';
 import type { Step } from '../../types';
 import type { SiteSelect } from '@automattic/data-stores';
 
 const TIME_CHECK_TRANSFER_STATUS = 3000;
-
-export const transferStates = {
-	PENDING: 'pending',
-	ACTIVE: 'active',
-	PROVISIONED: 'provisioned',
-	COMPLETED: 'completed',
-	ERROR: 'error',
-	REVERTED: 'reverted',
-	RELOCATING_REVERT: 'relocating_revert',
-	RELOCATING_SWITCHEROO: 'relocating_switcheroo',
-	REVERTING: 'reverting',
-	RENAMING: 'renaming',
-	EXPORTING: 'exporting',
-	IMPORTING: 'importing',
-	CLEANUP: 'cleanup',
-} as const;
+const TRANSFER_TIMEOUT = 1000 * 300;
 
 const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, ms ) );
 
@@ -73,14 +61,28 @@ const AutomatedCopySite: Step = function AutomatedCopySite( { navigation } ) {
 					},
 				} );
 			} catch ( _error ) {
-				throw new Error( 'Error copying site' );
+				throw new Error( __( 'Error copying site' ) );
 			}
 		}
 		initCopySite();
 		setPendingAction( async () => {
 			setProgress( 0 );
 			let stopPollingTransfer = false;
+			const maxFinishTime = new Date().getTime() + TRANSFER_TIMEOUT;
 			const isRevertOfThisTransfer = createRevertedTransferWatcher();
+
+			const recordTransferFailure = ( failureInfo: {
+				type: string;
+				error: string;
+				code: string;
+			} ) => {
+				recordTracksEvent( 'calypso_copy_site_transfer_failure', {
+					type: failureInfo.type,
+					error: failureInfo.error,
+					code: failureInfo.code,
+					site: site.URL,
+				} );
+			};
 
 			while ( ! stopPollingTransfer ) {
 				await wait( TIME_CHECK_TRANSFER_STATUS );
@@ -106,11 +108,30 @@ const AutomatedCopySite: Step = function AutomatedCopySite( { navigation } ) {
 				}
 
 				if ( isTransferringStatusFailed || transferStatus === transferStates.ERROR ) {
+					recordTransferFailure( {
+						type: 'transfer_error',
+						error: transferError?.message || '',
+						code: String( transferError?.code || '' ),
+					} );
 					throw new Error( getTransferFailureMessage( 'error' ) );
 				}
 
 				if ( isRevertOfThisTransfer( transfer ) ) {
+					recordTransferFailure( {
+						type: 'transfer_reverted',
+						error: `transfer reverted (status: ${ transferStatus })`,
+						code: 'transfer_reverted',
+					} );
 					throw new Error( getTransferFailureMessage( 'reverted' ) );
+				}
+
+				if ( maxFinishTime < new Date().getTime() ) {
+					recordTransferFailure( {
+						type: 'transfer_timeout',
+						error: 'transfer took too long',
+						code: 'transfer_timeout',
+					} );
+					throw new Error( getTransferFailureMessage( 'timeout' ) );
 				}
 
 				stopPollingTransfer = transferStatus === transferStates.COMPLETED;
@@ -129,6 +150,7 @@ const AutomatedCopySite: Step = function AutomatedCopySite( { navigation } ) {
 		setPendingAction,
 		setProgress,
 		site?.ID,
+		site?.URL,
 		siteSlug,
 		sourceSiteId,
 		submit,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/automated-copy-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/automated-copy-site/index.tsx
@@ -3,6 +3,10 @@ import { useEffect, useRef } from 'react';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
+import {
+	createRevertedTransferWatcher,
+	getTransferFailureMessage,
+} from 'calypso/landing/stepper/utils/atomic-transfer-outcome';
 import wpcom from 'calypso/lib/wp';
 import type { Step } from '../../types';
 import type { SiteSelect } from '@automattic/data-stores';
@@ -76,6 +80,7 @@ const AutomatedCopySite: Step = function AutomatedCopySite( { navigation } ) {
 		setPendingAction( async () => {
 			setProgress( 0 );
 			let stopPollingTransfer = false;
+			const isRevertOfThisTransfer = createRevertedTransferWatcher();
 
 			while ( ! stopPollingTransfer ) {
 				await wait( TIME_CHECK_TRANSFER_STATUS );
@@ -101,7 +106,11 @@ const AutomatedCopySite: Step = function AutomatedCopySite( { navigation } ) {
 				}
 
 				if ( isTransferringStatusFailed || transferStatus === transferStates.ERROR ) {
-					throw new Error( 'Error copying site' );
+					throw new Error( getTransferFailureMessage( 'error' ) );
+				}
+
+				if ( isRevertOfThisTransfer( transfer ) ) {
+					throw new Error( getTransferFailureMessage( 'reverted' ) );
 				}
 
 				stopPollingTransfer = transferStatus === transferStates.COMPLETED;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-install-plugins/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-install-plugins/index.tsx
@@ -9,6 +9,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { useBundleSettings } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
+import { getTransferFailureMessage } from '../../../../utils/atomic-transfer-outcome';
 import type { Step } from '../../types';
 import type { AtomicSoftwareStatus, OnboardSelect, SiteSelect } from '@automattic/data-stores';
 
@@ -110,7 +111,7 @@ const BundleInstallPlugins: Step = function BundleInstallPlugins( { navigation }
 						error: 'transfer took too long',
 						code: 'transfer_timeout',
 					} );
-					throw new Error( 'transfer timeout' );
+					throw new Error( getTransferFailureMessage( 'timeout' ) );
 				}
 
 				requestAtomicSoftwareStatus( site.ID, softwareSet );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-transfer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-transfer/index.tsx
@@ -11,6 +11,7 @@ import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import {
 	createRevertedTransferWatcher,
 	getTransferFailureMessage,
+	transferStates,
 } from '../../../../utils/atomic-transfer-outcome';
 import type { Step } from '../../types';
 import type { OnboardSelect, SiteSelect } from '@automattic/data-stores';
@@ -20,22 +21,6 @@ export interface FailureInfo {
 	code: number | string;
 	error: string;
 }
-
-export const transferStates = {
-	PENDING: 'pending',
-	ACTIVE: 'active',
-	PROVISIONED: 'provisioned',
-	COMPLETED: 'completed',
-	ERROR: 'error',
-	REVERTED: 'reverted',
-	RELOCATING_REVERT: 'relocating_revert',
-	RELOCATING_SWITCHEROO: 'relocating_switcheroo',
-	REVERTING: 'reverting',
-	RENAMING: 'renaming',
-	EXPORTING: 'exporting',
-	IMPORTING: 'importing',
-	CLEANUP: 'cleanup',
-} as const;
 
 const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, ms ) );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-transfer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-transfer/index.tsx
@@ -8,6 +8,10 @@ import { useSitePluginSlug } from 'calypso/landing/stepper/hooks/use-site-plugin
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
+import {
+	createRevertedTransferWatcher,
+	getTransferFailureMessage,
+} from '../../../../utils/atomic-transfer-outcome';
 import type { Step } from '../../types';
 import type { OnboardSelect, SiteSelect } from '@automattic/data-stores';
 
@@ -126,6 +130,7 @@ const BundleTransfer: Step = function BundleTransfer( { navigation, flow } ) {
 
 			// Poll for transfer status
 			let stopPollingTransfer = false;
+			const isRevertOfThisTransfer = createRevertedTransferWatcher();
 
 			while ( ! stopPollingTransfer ) {
 				await wait( 3000 );
@@ -156,7 +161,16 @@ const BundleTransfer: Step = function BundleTransfer( { navigation, flow } ) {
 						error: transferError?.message || '',
 						code: transferError?.code || '',
 					} );
-					throw new Error( 'transfer error' );
+					throw new Error( getTransferFailureMessage( 'error' ) );
+				}
+
+				if ( isRevertOfThisTransfer( transfer ) ) {
+					handleTransferFailure( {
+						type: 'transfer_reverted',
+						error: `transfer reverted (status: ${ transferStatus })`,
+						code: 'transfer_reverted',
+					} );
+					throw new Error( getTransferFailureMessage( 'reverted' ) );
 				}
 
 				if ( maxFinishTime < new Date().getTime() ) {
@@ -165,7 +179,7 @@ const BundleTransfer: Step = function BundleTransfer( { navigation, flow } ) {
 						error: 'transfer took too long',
 						code: 'transfer_timeout',
 					} );
-					throw new Error( 'transfer timeout' );
+					throw new Error( getTransferFailureMessage( 'timeout' ) );
 				}
 
 				stopPollingTransfer = transferStatus === transferStates.COMPLETED;

--- a/client/landing/stepper/hooks/use-wait-for-atomic.ts
+++ b/client/landing/stepper/hooks/use-wait-for-atomic.ts
@@ -5,6 +5,10 @@ import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { requestSite } from 'calypso/state/sites/actions';
 import { fetchSiteFeatures } from 'calypso/state/sites/features/actions';
 import { initiateThemeTransfer } from 'calypso/state/themes/actions';
+import {
+	createRevertedTransferWatcher,
+	getTransferFailureMessage,
+} from '../utils/atomic-transfer-outcome';
 import { useSiteData } from './use-site-data';
 import type { SiteSelect, SiteDetails } from '@automattic/data-stores';
 
@@ -75,6 +79,7 @@ export const useWaitForAtomic = ( {
 		const startTime = new Date().getTime();
 		const totalTimeout = 1000 * 300;
 		const maxFinishTime = startTime + totalTimeout;
+		const isRevertOfThisTransfer = createRevertedTransferWatcher();
 
 		while ( true ) {
 			await wait( 3000 );
@@ -90,7 +95,16 @@ export const useWaitForAtomic = ( {
 					error: transferError?.message || '',
 					code: transferError?.code || '',
 				} );
-				throw new Error( 'transfer error' );
+				throw new Error( getTransferFailureMessage( 'error' ) );
+			}
+
+			if ( isRevertOfThisTransfer( transfer ) ) {
+				handleTransferFailure?.( {
+					type: 'transfer_reverted',
+					error: `transfer reverted (status: ${ transferStatus })`,
+					code: 'transfer_reverted',
+				} );
+				throw new Error( getTransferFailureMessage( 'reverted' ) );
 			}
 
 			if ( maxFinishTime < new Date().getTime() ) {
@@ -99,7 +113,7 @@ export const useWaitForAtomic = ( {
 					error: 'transfer took too long',
 					code: 'transfer_timeout',
 				} );
-				throw new Error( 'transfer timeout' );
+				throw new Error( getTransferFailureMessage( 'timeout' ) );
 			}
 
 			if ( transferStatus === transferStates.COMPLETED ) {

--- a/client/landing/stepper/hooks/use-wait-for-atomic.ts
+++ b/client/landing/stepper/hooks/use-wait-for-atomic.ts
@@ -8,6 +8,7 @@ import { initiateThemeTransfer } from 'calypso/state/themes/actions';
 import {
 	createRevertedTransferWatcher,
 	getTransferFailureMessage,
+	transferStates,
 } from '../utils/atomic-transfer-outcome';
 import { useSiteData } from './use-site-data';
 import type { SiteSelect, SiteDetails } from '@automattic/data-stores';
@@ -19,22 +20,6 @@ export interface FailureInfo {
 	code: number | string;
 	error: string;
 }
-
-export const transferStates = {
-	PENDING: 'pending',
-	ACTIVE: 'active',
-	PROVISIONED: 'provisioned',
-	COMPLETED: 'completed',
-	ERROR: 'error',
-	REVERTED: 'reverted',
-	RELOCATING_REVERT: 'relocating_revert',
-	RELOCATING_SWITCHEROO: 'relocating_switcheroo',
-	REVERTING: 'reverting',
-	RENAMING: 'renaming',
-	EXPORTING: 'exporting',
-	IMPORTING: 'importing',
-	CLEANUP: 'cleanup',
-} as const;
 
 interface UseWaitForAtomicProps {
 	handleTransferFailure?: ( failureInfo: FailureInfo ) => void;

--- a/client/landing/stepper/utils/atomic-transfer-outcome.ts
+++ b/client/landing/stepper/utils/atomic-transfer-outcome.ts
@@ -1,8 +1,30 @@
 import { __ } from '@wordpress/i18n';
 
+// The full status vocabulary the transfer wait loops understand. Kept in one
+// place so every wait recognises the same outcomes.
+export const transferStates = {
+	PENDING: 'pending',
+	ACTIVE: 'active',
+	PROVISIONED: 'provisioned',
+	COMPLETED: 'completed',
+	ERROR: 'error',
+	REVERTED: 'reverted',
+	RELOCATING_REVERT: 'relocating_revert',
+	RELOCATING_SWITCHEROO: 'relocating_switcheroo',
+	REVERTING: 'reverting',
+	RENAMING: 'renaming',
+	EXPORTING: 'exporting',
+	IMPORTING: 'importing',
+	CLEANUP: 'cleanup',
+} as const;
+
 // `reverting` and `relocating_revert` always end at `reverted`, so treat all
 // three as final rather than making the user wait for the last one.
-const REVERTED_TRANSFER_STATUSES = [ 'reverted', 'reverting', 'relocating_revert' ];
+const REVERTED_TRANSFER_STATUSES: string[] = [
+	transferStates.REVERTED,
+	transferStates.REVERTING,
+	transferStates.RELOCATING_REVERT,
+];
 
 export function isRevertedTransferStatus( status?: string ): boolean {
 	return !! status && REVERTED_TRANSFER_STATUSES.includes( status );

--- a/client/landing/stepper/utils/atomic-transfer-outcome.ts
+++ b/client/landing/stepper/utils/atomic-transfer-outcome.ts
@@ -13,25 +13,23 @@ interface PolledTransfer {
 	status?: string;
 }
 
-// ~15s at the 3s poll interval every caller uses.
-const POLLS_BEFORE_TRUSTING_A_REVERT_SEEN_ON_ARRIVAL = 5;
-
 /**
- * Tells a revert of the transfer being waited on from a revert of an older one.
- * The endpoint returns the site's latest transfer, which early on can still be a
- * previous one — re-upgrading after a downgrade is an ordinary path, and failing
- * on that would break a healthy wait.
+ * Reports a revert of the transfer being waited on, and only that.
  *
- * A revert we watched go in flight is ours. A revert already there on arrival is
- * ambiguous, so we give it a few polls: if it was stale a new transfer takes
- * over, otherwise nothing is coming and it is ours.
+ * The endpoint returns the site's latest transfer, not the one we asked about,
+ * so a revert is only ours once we have watched that same transfer id in flight.
+ * Early in a wait the latest transfer can still be an older, long-reverted one —
+ * re-upgrading after a downgrade is an ordinary path, and failing on that would
+ * break a healthy wait.
+ *
+ * Known gap: a transfer already reverted before our first poll is indistinguishable
+ * from stale history without a transfer id to correlate against, so it falls
+ * through to the caller's timeout. See DOTCOM-18112.
  *
  * One watcher per wait; call on every poll.
  */
 export function createRevertedTransferWatcher() {
 	let transferSeenInFlight: number | undefined;
-	let unexplainedRevertId: number | undefined;
-	let unexplainedRevertPolls = 0;
 
 	return function isRevertOfThisTransfer( transfer?: PolledTransfer ): boolean {
 		if ( ! transfer || transfer.atomic_transfer_id === undefined ) {
@@ -42,23 +40,10 @@ export function createRevertedTransferWatcher() {
 
 		if ( ! isRevertedTransferStatus( transfer.status ) ) {
 			transferSeenInFlight = transferId;
-			unexplainedRevertId = undefined;
-			unexplainedRevertPolls = 0;
 			return false;
 		}
 
-		if ( transferId === transferSeenInFlight ) {
-			return true;
-		}
-
-		if ( transferId !== unexplainedRevertId ) {
-			unexplainedRevertId = transferId;
-			unexplainedRevertPolls = 0;
-		}
-
-		unexplainedRevertPolls++;
-
-		return unexplainedRevertPolls >= POLLS_BEFORE_TRUSTING_A_REVERT_SEEN_ON_ARRIVAL;
+		return transferId === transferSeenInFlight;
 	};
 }
 

--- a/client/landing/stepper/utils/atomic-transfer-outcome.ts
+++ b/client/landing/stepper/utils/atomic-transfer-outcome.ts
@@ -1,0 +1,78 @@
+import { __ } from '@wordpress/i18n';
+
+// `reverting` and `relocating_revert` always end at `reverted`, so treat all
+// three as final rather than making the user wait for the last one.
+const REVERTED_TRANSFER_STATUSES = [ 'reverted', 'reverting', 'relocating_revert' ];
+
+export function isRevertedTransferStatus( status?: string ): boolean {
+	return !! status && REVERTED_TRANSFER_STATUSES.includes( status );
+}
+
+interface PolledTransfer {
+	atomic_transfer_id?: number;
+	status?: string;
+}
+
+// ~15s at the 3s poll interval every caller uses.
+const POLLS_BEFORE_TRUSTING_A_REVERT_SEEN_ON_ARRIVAL = 5;
+
+/**
+ * Tells a revert of the transfer being waited on from a revert of an older one.
+ * The endpoint returns the site's latest transfer, which early on can still be a
+ * previous one — re-upgrading after a downgrade is an ordinary path, and failing
+ * on that would break a healthy wait.
+ *
+ * A revert we watched go in flight is ours. A revert already there on arrival is
+ * ambiguous, so we give it a few polls: if it was stale a new transfer takes
+ * over, otherwise nothing is coming and it is ours.
+ *
+ * One watcher per wait; call on every poll.
+ */
+export function createRevertedTransferWatcher() {
+	let transferSeenInFlight: number | undefined;
+	let unexplainedRevertId: number | undefined;
+	let unexplainedRevertPolls = 0;
+
+	return function isRevertOfThisTransfer( transfer?: PolledTransfer ): boolean {
+		if ( ! transfer || transfer.atomic_transfer_id === undefined ) {
+			return false;
+		}
+
+		const transferId = transfer.atomic_transfer_id;
+
+		if ( ! isRevertedTransferStatus( transfer.status ) ) {
+			transferSeenInFlight = transferId;
+			unexplainedRevertId = undefined;
+			unexplainedRevertPolls = 0;
+			return false;
+		}
+
+		if ( transferId === transferSeenInFlight ) {
+			return true;
+		}
+
+		if ( transferId !== unexplainedRevertId ) {
+			unexplainedRevertId = transferId;
+			unexplainedRevertPolls = 0;
+		}
+
+		unexplainedRevertPolls++;
+
+		return unexplainedRevertPolls >= POLLS_BEFORE_TRUSTING_A_REVERT_SEEN_ON_ARRIVAL;
+	};
+}
+
+export type TransferFailureOutcome = 'reverted' | 'error' | 'timeout';
+
+// Shown to the user on the error step, so these are sentences, not codes. The
+// machine-readable outcome goes separately, via handleTransferFailure.
+export function getTransferFailureMessage( outcome: TransferFailureOutcome ): string {
+	switch ( outcome ) {
+		case 'reverted':
+			return __( "We stopped setting up your site because the upgrade didn't go through." );
+		case 'timeout':
+			return __( 'Setting up your site is taking longer than expected.' );
+		default:
+			return __( 'Something went wrong while setting up your site.' );
+	}
+}

--- a/client/landing/stepper/utils/test/atomic-transfer-outcome.ts
+++ b/client/landing/stepper/utils/test/atomic-transfer-outcome.ts
@@ -1,0 +1,127 @@
+import {
+	createRevertedTransferWatcher,
+	getTransferFailureMessage,
+	isRevertedTransferStatus,
+} from '../atomic-transfer-outcome';
+
+describe( 'isRevertedTransferStatus', () => {
+	it.each( [ 'reverted', 'reverting', 'relocating_revert' ] )(
+		'treats %s as a transfer that will not complete',
+		( status ) => {
+			expect( isRevertedTransferStatus( status ) ).toBe( true );
+		}
+	);
+
+	it.each( [
+		'pending',
+		'active',
+		'provisioned',
+		'completed',
+		'error',
+		'relocating_switcheroo',
+		'renaming',
+		'exporting',
+		'importing',
+		'cleanup',
+	] )( 'leaves %s alone', ( status ) => {
+		expect( isRevertedTransferStatus( status ) ).toBe( false );
+	} );
+
+	it( 'handles a missing status', () => {
+		expect( isRevertedTransferStatus( undefined ) ).toBe( false );
+	} );
+} );
+
+describe( 'createRevertedTransferWatcher', () => {
+	it( 'reports a revert once the transfer it is watching rolls back', () => {
+		const isRevertOfThisTransfer = createRevertedTransferWatcher();
+
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 7, status: 'pending' } ) ).toBe( false );
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 7, status: 'active' } ) ).toBe( false );
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 7, status: 'reverting' } ) ).toBe( true );
+	} );
+
+	it( 'ignores a previous transfer that was already reverted before this wait', () => {
+		const isRevertOfThisTransfer = createRevertedTransferWatcher();
+
+		// Latest transfer is still the old one.
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 1, status: 'reverted' } ) ).toBe( false );
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 1, status: 'reverted' } ) ).toBe( false );
+
+		// The new one shows up.
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 2, status: 'pending' } ) ).toBe( false );
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 2, status: 'active' } ) ).toBe( false );
+
+		// Only its revert counts.
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 2, status: 'reverted' } ) ).toBe( true );
+	} );
+
+	it( 'does not fire on an empty poll', () => {
+		const isRevertOfThisTransfer = createRevertedTransferWatcher();
+
+		expect( isRevertOfThisTransfer( undefined ) ).toBe( false );
+		expect( isRevertOfThisTransfer( { status: 'reverted' } ) ).toBe( false );
+	} );
+
+	it( 'catches a transfer that rolled back before the first poll', () => {
+		const isRevertOfThisTransfer = createRevertedTransferWatcher();
+
+		// Already reverting on arrival, and nothing replaces it.
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 9, status: 'reverting' } ) ).toBe(
+			false
+		);
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 9, status: 'reverting' } ) ).toBe(
+			false
+		);
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 9, status: 'reverted' } ) ).toBe( false );
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 9, status: 'reverted' } ) ).toBe( false );
+
+		// Fifth poll: nothing is coming.
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 9, status: 'reverted' } ) ).toBe( true );
+	} );
+
+	it( 'still stands down if a new transfer replaces a stale reverted one', () => {
+		const isRevertOfThisTransfer = createRevertedTransferWatcher();
+
+		// Same start, but this one is history.
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 1, status: 'reverted' } ) ).toBe( false );
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 1, status: 'reverted' } ) ).toBe( false );
+
+		// Real transfer arrives in time.
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 2, status: 'pending' } ) ).toBe( false );
+
+		// Old record no longer counts.
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 2, status: 'active' } ) ).toBe( false );
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 2, status: 'completed' } ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'restarts the count when a different reverted transfer appears', () => {
+		const isRevertOfThisTransfer = createRevertedTransferWatcher();
+
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 1, status: 'reverted' } ) ).toBe( false );
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 1, status: 'reverted' } ) ).toBe( false );
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 1, status: 'reverted' } ) ).toBe( false );
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 1, status: 'reverted' } ) ).toBe( false );
+
+		// Different transfer, own grace period.
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 2, status: 'reverted' } ) ).toBe( false );
+	} );
+} );
+
+describe( 'getTransferFailureMessage', () => {
+	it( 'gives each outcome its own message', () => {
+		const messages = [
+			getTransferFailureMessage( 'reverted' ),
+			getTransferFailureMessage( 'timeout' ),
+			getTransferFailureMessage( 'error' ),
+		];
+
+		expect( new Set( messages ).size ).toBe( 3 );
+	} );
+
+	it( 'blames the upgrade, not the clock, when the transfer was rolled back', () => {
+		expect( getTransferFailureMessage( 'reverted' ) ).toMatch( /upgrade/ );
+	} );
+} );

--- a/client/landing/stepper/utils/test/atomic-transfer-outcome.ts
+++ b/client/landing/stepper/utils/test/atomic-transfer-outcome.ts
@@ -63,50 +63,29 @@ describe( 'createRevertedTransferWatcher', () => {
 		expect( isRevertOfThisTransfer( { status: 'reverted' } ) ).toBe( false );
 	} );
 
-	it( 'catches a transfer that rolled back before the first poll', () => {
+	it( 'leaves a transfer that was already reverted on arrival to the caller timeout', () => {
 		const isRevertOfThisTransfer = createRevertedTransferWatcher();
 
-		// Already reverting on arrival, and nothing replaces it.
-		expect( isRevertOfThisTransfer( { atomic_transfer_id: 9, status: 'reverting' } ) ).toBe(
-			false
-		);
+		// Indistinguishable from stale history without an id to correlate against.
 		expect( isRevertOfThisTransfer( { atomic_transfer_id: 9, status: 'reverting' } ) ).toBe(
 			false
 		);
 		expect( isRevertOfThisTransfer( { atomic_transfer_id: 9, status: 'reverted' } ) ).toBe( false );
 		expect( isRevertOfThisTransfer( { atomic_transfer_id: 9, status: 'reverted' } ) ).toBe( false );
-
-		// Fifth poll: nothing is coming.
-		expect( isRevertOfThisTransfer( { atomic_transfer_id: 9, status: 'reverted' } ) ).toBe( true );
 	} );
 
-	it( 'still stands down if a new transfer replaces a stale reverted one', () => {
+	it( 'never claims a stale reverted transfer, however long it stays latest', () => {
 		const isRevertOfThisTransfer = createRevertedTransferWatcher();
 
-		// Same start, but this one is history.
-		expect( isRevertOfThisTransfer( { atomic_transfer_id: 1, status: 'reverted' } ) ).toBe( false );
-		expect( isRevertOfThisTransfer( { atomic_transfer_id: 1, status: 'reverted' } ) ).toBe( false );
+		for ( let poll = 0; poll < 20; poll++ ) {
+			expect( isRevertOfThisTransfer( { atomic_transfer_id: 1, status: 'reverted' } ) ).toBe(
+				false
+			);
+		}
 
-		// Real transfer arrives in time.
+		// The real transfer arrives late and still runs normally.
 		expect( isRevertOfThisTransfer( { atomic_transfer_id: 2, status: 'pending' } ) ).toBe( false );
-
-		// Old record no longer counts.
-		expect( isRevertOfThisTransfer( { atomic_transfer_id: 2, status: 'active' } ) ).toBe( false );
-		expect( isRevertOfThisTransfer( { atomic_transfer_id: 2, status: 'completed' } ) ).toBe(
-			false
-		);
-	} );
-
-	it( 'restarts the count when a different reverted transfer appears', () => {
-		const isRevertOfThisTransfer = createRevertedTransferWatcher();
-
-		expect( isRevertOfThisTransfer( { atomic_transfer_id: 1, status: 'reverted' } ) ).toBe( false );
-		expect( isRevertOfThisTransfer( { atomic_transfer_id: 1, status: 'reverted' } ) ).toBe( false );
-		expect( isRevertOfThisTransfer( { atomic_transfer_id: 1, status: 'reverted' } ) ).toBe( false );
-		expect( isRevertOfThisTransfer( { atomic_transfer_id: 1, status: 'reverted' } ) ).toBe( false );
-
-		// Different transfer, own grace period.
-		expect( isRevertOfThisTransfer( { atomic_transfer_id: 2, status: 'reverted' } ) ).toBe( false );
+		expect( isRevertOfThisTransfer( { atomic_transfer_id: 2, status: 'reverted' } ) ).toBe( true );
 	} );
 } );
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-18112/transfers-reverted-mid-wait-leave-the-user-watching-a-fake-bar-until-a

## Proposed Changes

**The Stepper transfer waits now treat a rolled-back transfer as a real ending, instead of polling it until the timeout fires.**

- Recognise `reverted`, `reverting` and `relocating_revert` as final. The last two always end at `reverted`, so waiting for it only adds seconds of fake progress.
- Each outcome gets its own user-facing sentence. The screens used to surface raw strings like `transfer timeout`, untranslated.
- Rollbacks report a distinct `transfer_reverted` failure type, so Tracks stops counting them as timeouts — now including copy-site, which previously reported nothing on failure.
- The copy-site wait also gains the same five-minute cap as the other waits; it had none, so the one case we cannot detect (below) meant an endless progress bar there.
- A revert counts only once we have watched that same transfer id in flight. The status endpoint returns the site's *latest* transfer rather than the one we asked about, and early in a wait that can still be an older, long-reverted one — re-upgrading after a downgrade is an ordinary path, and failing on it would break a healthy wait.
- The full status vocabulary moves into one shared helper, `client/landing/stepper/utils/atomic-transfer-outcome.ts`. The wait loops each had their own copy of `transferStates`, which is why the same gap existed in all of them.

Applied to every Stepper wait that polls transfer status: `wait-for-atomic`, `bundle-transfer`, `automated-copy-site`. `bundle-install-plugins` polls plugin installs rather than transfers, so it only picks up the message change.

One case is deliberately left alone: a transfer that was *already* reverted before the first poll. Without a transfer id to correlate against, that is indistinguishable from an old record that has not been superseded yet, and any client-side guess can call a healthy run failed. It now ends at the caller's timeout on every wait, and is written up on the issue as follow-up.

## Why are these changes being made?

When someone buys a plan, installs a bundled plugin, or copies a site, we move the site to Atomic hosting and park them on a waiting screen while it runs.

That move does not always succeed. The platform can roll it back — most often because the plan behind it was deactivated moments after purchase, which is what a payment that never captured looks like from our side. The waiting screens did not know that outcome existed. They understood “finished” and “failed”, nothing else, so a rolled-back transfer looked like one still in progress and they kept asking about it until a stopwatch ran out — and on copy-site, which had no stopwatch at all, indefinitely.

The user then got told the transfer took too long. It did not. It was cancelled, and the reason was something we could have named. They sat through minutes of a progress bar that was never going to finish, and were handed the wrong explanation at the end of it — in an internal error string, in English, whatever their language.

About 42 people land in this in a 28-day window, most of them copying a site ([DOTCOM-18112](https://linear.app/a8c/issue/DOTCOM-18112/transfers-reverted-mid-wait-leave-the-user-watching-a-fake-bar-until-a) has the breakdown). It is a small number, and it is the wrong thing to tell every one of them about their own purchase. It also means our data cannot currently separate a slow server from a cancelled upgrade, since both arrive labelled as a timeout — which matters for measuring the wait experience later.

## Testing Instructions

Reverts are triggered by the billing system, so the realistic check is that the normal paths are untouched and the new branch behaves when forced.

1. Run `yarn start`.
2. On a Simple site with a plan, go through `/setup/copy-site` and copy a site. The wait should behave exactly as before and land on the copied site.
3. Buy a hosting plan and let `/setup/transferring-hosted-site` run to completion. Again, no change expected on the happy path.
4. To exercise the new branch, intercept the transfer status response (DevTools request blocking, or a local stub in `use-wait-for-atomic.ts`) and return `"status": "reverted"` only *after* the transfer has been seen running. The wait should stop within a poll and the error step should read “We stopped setting up your site because the upgrade didn't go through.” — not a timeout message.
5. Return `"status": "reverted"` with an `atomic_transfer_id` that never appeared in a running state, and keep it there. The wait should ignore it and carry on, since that record cannot be shown to belong to this wait.
