### PR TITLE
Fix the overlapping menus on themes and plugins details pages

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -612,8 +612,7 @@ body.is-mobile-app-view {
 
 // These surfaces float the nav over their hero, so don't reserve its space.
 .layout.is-section-patterns:has( .x-nav--2026-redesign ) .layout__header-section,
-.layout.is-theme-showcase-modern:has( .x-nav--2026-redesign ) .layout__header-section,
-.layout.is-section-plugins:not( .is-logged-in ):has( .x-nav--2026-redesign ) .layout__header-section {
+.layout.is-section-themes.is-theme-showcase-modern:has( .x-nav--2026-redesign ) .layout__header-section,
+.layout.is-section-plugins:not( .is-logged-in ):has( .plugins-browser ):has( .x-nav--2026-redesign ) .layout__header-section {
 	min-height: 0;
 }
-


### PR DESCRIPTION
Fixes MARTECH-2588

<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

- Scope the modern theme nav-over-hero exception to the `/themes` directory.
- Scope the logged-out plugin exception to pages containing `.plugins-browser`.
- Restore consistent spacing between the global navigation and breadcrumbs on individual theme and plugin pages.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The 2026 global navigation reserves space for its fixed header. Theme and plugin directory pages intentionally opt out so their hero sections can extend beneath the navigation, but those exceptions were broad enough to include individual detail pages that do not have the same hero layout.

As a result, theme breadcrumbs overlapped the global navigation and plugin breadcrumbs appeared too close to it. Narrowing the selectors preserves the directory hero treatments while restoring the standard navigation spacing on detail pages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit an individual theme route such as `/theme/noteslab`. Confirm the theme breadcrumb no longer overlaps the global navigation.
- Visit an individual plugin route such as `/plugins/js-composer`. Confirm the plugin breadcrumb has the same spacing below the global navigation.
- Visit the `/themes` and `/plugins` directory pages. Confirm their hero sections continue to extend beneath the global navigation as designed.

**Before:** 
<img width="1210" height="346" alt="Screenshot 2026-08-03 at 1 37 44 PM" src="https://github.com/user-attachments/assets/ab445352-b584-4e28-b576-0b8c02e5e95c" />
<img width="871" height="250" alt="Screenshot 2026-08-03 at 1 44 08 PM" src="https://github.com/user-attachments/assets/019fe9fc-fd54-4121-bd84-ad214fbe3258" />


**After:**
<img width="1206" height="407" alt="Screenshot 2026-08-03 at 1 37 23 PM" src="https://github.com/user-attachments/assets/4f2a0468-e818-4b42-b854-308aed0fe33b" />
<img width="871" height="314" alt="Screenshot 2026-08-03 at 1 44 42 PM" src="https://github.com/user-attachments/assets/f8102c54-c2e7-4377-aa5a-0375a1fd797b" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
