### PR TITLE
Reader: Remove fading of ReaderPostCards on likes and conversations view

### DIFF
--- a/client/reader/data/seen-posts/test/use-is-seen-enabled.test.tsx
+++ b/client/reader/data/seen-posts/test/use-is-seen-enabled.test.tsx
@@ -26,6 +26,7 @@ interface SetUp {
 	isAutomattician?: boolean;
 	wpForTeamsBlogIds?: number[];
 	subscribedListFeedIds?: number[];
+	route?: string;
 }
 
 function setUp( {
@@ -33,6 +34,7 @@ function setUp( {
 	isAutomattician = false,
 	wpForTeamsBlogIds = [],
 	subscribedListFeedIds = [],
+	route,
 }: SetUp = {} ) {
 	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
 
@@ -72,6 +74,7 @@ function setUp( {
 				wpForTeamsBlogIds.map( ( id ) => [ id, { options: { is_wpforteams_site: true } } ] )
 			),
 		},
+		route: { path: { current: route ?? null } },
 	};
 	const store = createStore( () => state );
 
@@ -259,6 +262,41 @@ describe( 'useIsSeenEnabled', () => {
 				() => useIsSeenEnabled( { feedId: FEED_ID, post: { is_seen: false } } ),
 				{ wrapper: setUp( eligible ) }
 			);
+
+			expect( result.current ).toBe( true );
+		} );
+	} );
+
+	describe( 'disabled routes', () => {
+		const eligible = { subscriptions: [ organizationSubscription ] };
+
+		it.each( [ '/activities/likes', '/reader/conversations', '/reader/conversations/a8c' ] )(
+			'returns false on %s even when the post already carries the seen flag',
+			( route ) => {
+				const { result } = renderHook(
+					() => useIsSeenEnabled( { feedId: FEED_ID, post: { is_seen: true } } ),
+					{ wrapper: setUp( { ...eligible, route } ) }
+				);
+
+				expect( result.current ).toBe( false );
+			}
+		);
+
+		it.each( [ '/activities/likes', '/reader/conversations', '/reader/conversations/a8c' ] )(
+			'returns false on %s for an automattician',
+			( route ) => {
+				const { result } = renderHook( () => useIsSeenEnabled( { feedId: FEED_ID } ), {
+					wrapper: setUp( { isAutomattician: true, route } ),
+				} );
+
+				expect( result.current ).toBe( false );
+			}
+		);
+
+		it( 'returns true on non-disabled route route when the user is otherwise eligible', () => {
+			const { result } = renderHook( () => useIsSeenEnabled( { feedId: FEED_ID } ), {
+				wrapper: setUp( { ...eligible, route: '/reader' } ),
+			} );
 
 			expect( result.current ).toBe( true );
 		} );

--- a/client/reader/data/seen-posts/use-is-seen-enabled.ts
+++ b/client/reader/data/seen-posts/use-is-seen-enabled.ts
@@ -5,7 +5,14 @@ import {
 	useIsSubscribed,
 } from 'calypso/reader/data/site-subscriptions';
 import { useSelector } from 'calypso/state';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+
+const SEEN_DISABLED_ROUTES = [
+	'/activities/likes',
+	'/reader/conversations',
+	'/reader/conversations/a8c',
+];
 
 interface IsSeenEnabledArgs {
 	feedId?: number | string; // Route params arrive as strings.
@@ -22,6 +29,11 @@ export function useIsSeenEnabled( { feedId, blogId, post }: IsSeenEnabledArgs ):
 	const hasOrganization = useHasSiteSubscriptionOrganization( feedId, blogId );
 	const isWPForTeamsItem = useSelector( ( state ) => isSiteWPForTeams( state, Number( blogId ) ) );
 	const { data: subscribedLists } = useQuery( readSubscribedListsQuery() );
+	const currentRoute = useSelector( getCurrentRoute );
+
+	if ( currentRoute && SEEN_DISABLED_ROUTES.includes( currentRoute ) ) {
+		return false;
+	}
 
 	// If the post is already marked as seen, then prefer that over the subscription check.
 	if ( post?.is_seen ) {


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: https://linear.app/a8c/issue/READ-660

## Proposed Changes

Add `SEEN_DISABLED_ROUTES` in `useIsSeenEnabled` hook that disables the fading of Reader post cards on selected views.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

All cards on likes, and conversations view are already read so showing them as faded doesn't provide any value.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to Likes, Conversation and A8C Conversation view.
- Verify no card is faded now.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
