### PR TITLE
Purchases: allow undefined renew_date

### DIFF
--- a/client/dashboard/components/purchase-expiry-status/index.tsx
+++ b/client/dashboard/components/purchase-expiry-status/index.tsx
@@ -205,7 +205,9 @@ export function PurchaseExpiryStatus( {
 					// translators: %(date)s: a formatted date
 					__( 'Credit card expires before your next renewal on %(date)s' ),
 					{
-						date: formatDate( new Date( purchase.renew_date ), locale, { dateStyle: 'long' } ),
+						date: formatDate( new Date( purchase.renew_date ?? '' ), locale, {
+							dateStyle: 'long',
+						} ),
 					}
 				) }
 			</span>
@@ -219,7 +221,7 @@ export function PurchaseExpiryStatus( {
 		const slug = purchase.delayed_downgrade_to_product_slug;
 		const planNames = getPlanNames() as Record< string, string | undefined >;
 		const targetPlanName = slug ? planNames[ slug ] ?? null : null;
-		const renewalDate = formatDate( new Date( purchase.renew_date ), locale, {
+		const renewalDate = formatDate( new Date( purchase.renew_date ?? '' ), locale, {
 			dateStyle: 'long',
 		} );
 		if ( targetPlanName ) {
@@ -250,7 +252,7 @@ export function PurchaseExpiryStatus( {
 				isSmallestUnit: true,
 				stripZeros: true,
 			} ),
-			date: formatDate( new Date( purchase.renew_date ), locale, { dateStyle: 'long' } ),
+			date: formatDate( new Date( purchase.renew_date ?? '' ), locale, { dateStyle: 'long' } ),
 		};
 		const translateComponents = {
 			excludeTaxStringAbbreviation: (

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -802,7 +802,9 @@ function getFields( {
 					) {
 						// translators: %(date)s is a formatted date string
 						return sprintf( __( 'You will be billed on %(date)s' ), {
-							date: formatDate( new Date( purchase.renew_date ), locale, { dateStyle: 'long' } ),
+							date: formatDate( new Date( purchase.renew_date ?? '' ), locale, {
+								dateStyle: 'long',
+							} ),
 						} );
 					}
 					if ( ! purchase.is_auto_renew_enabled && purchase.expiry_date ) {

--- a/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
@@ -38,7 +38,7 @@ function getRenewalDescription(
 	} );
 
 	if ( isRenewingBeforeExpiration( item ) ) {
-		const date = formatDate( new Date( item.renew_date ), locale, { dateStyle: 'long' } );
+		const date = formatDate( new Date( item.renew_date ?? '' ), locale, { dateStyle: 'long' } );
 		if ( subtitleText && hasEnTranslation( '%1$s: Renews at %2$s on %3$s' ) ) {
 			return sprintf(
 				// translators: %1$s: purchase type subtitle (e.g. “Site plan”), %2$s: formatted price, %3$s: formatted date
@@ -97,7 +97,7 @@ export function UpcomingRenewalsDialog( {
 			[ ...purchases ].sort( ( a, b ) => {
 				const compareDateA = isRenewingBeforeExpiration( a ) ? a.renew_date : a.expiry_date;
 				const compareDateB = isRenewingBeforeExpiration( b ) ? b.renew_date : b.expiry_date;
-				return compareDateA?.localeCompare?.( compareDateB );
+				return ( compareDateA ?? '' ).localeCompare( compareDateB ?? '' );
 			} ),
 		[ purchases ]
 	);

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -170,7 +170,7 @@ function PurchaseMetaExpiration( {
 		) {
 			subsBillingText = translate( 'You will be billed on {{dateSpan}}%(renewDate)s{{/dateSpan}}', {
 				args: {
-					renewDate: purchase.renew_date && moment( purchase.renew_date ).format( 'LL' ),
+					renewDate: purchase.renew_date ? moment( purchase.renew_date ).format( 'LL' ) : '',
 				},
 				components: {
 					dateSpan,

--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -253,7 +253,7 @@ function renderRenewsOrExpiresOn( {
 	}
 
 	if ( isRenewingBeforeExpiration( purchase ) ) {
-		return <>{ moment( purchase.renew_date ).format( 'LL' ) }</>;
+		return <>{ moment( purchase.renew_date ?? '' ).format( 'LL' ) }</>;
 	}
 
 	if ( isPurchaseOneTimePurchase( purchase ) ) {

--- a/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
@@ -40,7 +40,9 @@ function getExpiresText(
 		return translate( 'renews %(renewDate)s', {
 			comment:
 				'"renewDate" is relative to the present time and it is already localized, eg. "in a year", "in a month", "today"',
-			args: { renewDate: getRelativeDayString( new Date( purchase.renew_date ), 'upcoming' ) },
+			args: {
+				renewDate: getRelativeDayString( new Date( purchase.renew_date ?? '' ), 'upcoming' ),
+			},
 		} );
 	}
 	if ( isExpiredOrRemoved( purchase ) ) {
@@ -78,7 +80,7 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 				const compareDateA = isRenewingBeforeExpiration( a ) ? a.renew_date : a.expiry_date;
 				const compareDateB = isRenewingBeforeExpiration( b ) ? b.renew_date : b.expiry_date;
 
-				return compareDateA?.localeCompare?.( compareDateB );
+				return ( compareDateA ?? '' ).localeCompare( compareDateB ?? '' );
 			} ),
 		[ purchases ]
 	);

--- a/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
+++ b/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
@@ -335,7 +335,10 @@ function getMessages( {
 				'"relativeRenewDate" is relative to the present time and it is already localized, eg. "in a year", "in a month", "today"',
 			args: {
 				purchaseName: getName( purchase ),
-				relativeRenewDate: getRelativeDayString( new Date( purchase.renew_date ), 'upcoming' ),
+				relativeRenewDate: getRelativeDayString(
+					new Date( purchase.renew_date ?? '' ),
+					'upcoming'
+				),
 			},
 		};
 		if ( isDomainRegistration( purchase ) ) {

--- a/packages/api-core/src/upgrades/fetchers.ts
+++ b/packages/api-core/src/upgrades/fetchers.ts
@@ -20,6 +20,7 @@ export function normalizePurchase( rawPurchase: RawPurchase ): Purchase {
 		user_id: parseInt( String( rawPurchase.user_id ), 10 ),
 		is_domain: Boolean( rawPurchase.is_domain ),
 		is_domain_registration: Boolean( rawPurchase.is_domain_registration ),
+		renew_date: rawPurchase.renew_date || undefined,
 	};
 }
 

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -387,8 +387,8 @@ export interface Purchase {
 	regular_price_integer: number;
 
 	/**
-	 * The date of the next scheduled auto-renewal attempt (ISO 8601), or an
-	 * empty string when no renewal is scheduled.
+	 * The date of the next scheduled auto-renewal attempt (ISO 8601), or
+	 * `undefined` when no renewal is scheduled.
 	 *
 	 * Populated only when the subscription is set to auto-renew and a renewal
 	 * attempt is still upcoming. WordPress.com begins attempting renewals before
@@ -397,12 +397,13 @@ export interface Purchase {
 	 * post-expiry grace period, so this date may fall before or after
 	 * `expiry_date`.
 	 *
-	 * An empty string means no attempt is scheduled: auto-renew is off, or the
+	 * `undefined` means no attempt is scheduled: auto-renew is off, or the
 	 * subscription is in its grace period past the final auto-renewal attempt.
 	 * It does NOT fall back to the expiry date — read `expiry_date` explicitly
-	 * where an expiry date is wanted.
+	 * where an expiry date is wanted. The server may also send an empty string
+	 * for the same "unset" meaning; treat both as falsy.
 	 */
-	renew_date: string;
+	renew_date?: string;
 
 	sale_amount?: number;
 	sale_amount_integer?: number;

--- a/packages/data-stores/src/purchases/lib/assembler.ts
+++ b/packages/data-stores/src/purchases/lib/assembler.ts
@@ -114,7 +114,7 @@ export function createPurchaseObject( purchase: RawPurchase ): Purchase {
 		refundPeriodInDays: purchase.refund_period_in_days,
 		regularPriceText: purchase.regular_price_text,
 		regularPriceInteger: purchase.regular_price_integer,
-		renewDate: purchase.renew_date,
+		renewDate: purchase.renew_date ?? '',
 		saleAmount: purchase.sale_amount,
 		saleAmountInteger: purchase.sale_amount_integer,
 		siteId: Number( purchase.blog_id ),


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-2293/make-billing-upgrade-renew-date-null-when-empty

## Proposed changes

Changes `Purchase.renew_date` in `@automattic/api-core` from an always-present `string` (empty when unset) to an optional `string`, so "no renewal scheduled" is representable as `undefined` instead of an empty string. `normalizePurchase()` now folds the empty string the API still sends into `undefined`, and every call site that read `renew_date` without a truthy guard was updated to keep behaving exactly as before.

* Change `Purchase.renew_date` to `renew_date?: string` and update its doc comment
* Normalize `''` to `undefined` in `normalizePurchase()` (`packages/api-core`)
* Keep the classic camelCase `Purchase.renewDate` (data-stores) as a required `string` by absorbing the new optionality with `?? ''` in `createPurchaseObject()`, so `client/me/purchases` behavior is unaffected there
* Add `?? ''` fallbacks at `new Date( purchase.renew_date )` / `moment( purchase.renew_date )` call sites that weren't already narrowed by a truthy check, preserving today's "Invalid Date" rendering for the unset case
* Give the two upcoming-renewals sort comparators (dashboard and classic) an explicit `?? ''` fallback instead of relying on optional chaining silently returning `undefined`

## Why are these changes being made?

`renew_date` used an empty string to mean "no renewal scheduled," which let `undefined`-style bugs hide as valid strings — `new Date('')` and `moment('')` both silently produce an Invalid Date instead of failing at compile time. Making the field optional lets the compiler flag call sites that don't guard against the unset case, catching a real class of bug: `moment(undefined)` (as opposed to `moment('')` or `moment(null)`) returns *the current time* rather than an invalid date, so an unguarded call site would have silently rendered today's date as if it were a real renewal date.

Only two call sites lacked an existing truthy guard around `renew_date` (`client/dashboard/components/purchase-expiry-status/index.tsx` and `purchase-meta.tsx`); both got an explicit `?? ''` fallback so behavior is unchanged. The classic camelCase `Purchase` type in `data-stores` is left untouched (`renewDate: string`) to avoid touching the wider `client/me/purchases` surface — it absorbs the new optionality at the assembler boundary instead.

## Testing instructions

* On a sandbox, view a purchase with an upcoming scheduled auto-renewal (Manage Purchase page, both Calypso classic and the Dashboard) and confirm the renewal date still renders correctly
* View a purchase with no scheduled renewal (auto-renew off, or past the final renewal attempt) and confirm it falls back to expiry-based copy rather than showing today's date
* Open the "Upcoming renewals" dialog (checkout reminder, classic, and Dashboard) with a mix of renewing and non-renewing purchases and confirm the sort order is unchanged

