### PR TITLE
Plugins: tell an already-active plugin apart from a real activation failure

### DIFF
--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -189,8 +189,7 @@ export function activatePlugin( siteId, plugin ) {
 			// is already active. Only endpoints that attach `data.reason` can tell them apart;
 			// without it, assume a real failure rather than reporting a success we can't confirm.
 			if ( error?.data?.reason === 'already_active' ) {
-				successCallback( { ...plugin, active: true } );
-				return;
+				return successCallback( { ...plugin, active: true } );
 			}
 
 			dispatch( { ...defaultAction, type: PLUGIN_ACTIVATE_REQUEST_FAILURE, error } );
@@ -256,8 +255,7 @@ export function deactivatePlugin( siteId, plugin ) {
 			// See the note in activatePlugin(): `deactivation_error` is just as generic, so the
 			// already-inactive case is only safe to treat as a success when the server says so.
 			if ( error?.data?.reason === 'already_inactive' ) {
-				successCallback( { ...plugin, active: false } );
-				return;
+				return successCallback( { ...plugin, active: false } );
 			}
 
 			dispatch( { ...defaultAction, type: PLUGIN_DEACTIVATE_REQUEST_FAILURE, error } );

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -156,11 +156,7 @@ export function activatePlugin( siteId, plugin ) {
 		const afterActivationCallback = ( error, data ) => {
 			// Sometime data can be empty or the plugin always
 			// return the active state even when the error is empty.
-			// Activation error is ok, because it means the plugin is already active
-			if (
-				( error && error.error !== 'activation_error' ) ||
-				( ! ( data && data.active ) && ! error )
-			) {
+			if ( error || ! ( data && data.active ) ) {
 				dispatch( bumpStat( 'calypso_plugin_activated', 'failed' ) );
 				dispatch(
 					recordTracksEvent( 'calypso_plugin_activated_error', {
@@ -189,10 +185,14 @@ export function activatePlugin( siteId, plugin ) {
 		};
 
 		const errorCallback = ( error ) => {
-			// This error means it's already active.
-			if ( error && error.error === 'activation_error' ) {
-				successCallback( plugin );
+			// `activation_error` wraps both real failures and the benign case where the plugin
+			// is already active. Only endpoints that attach `data.reason` can tell them apart;
+			// without it, assume a real failure rather than reporting a success we can't confirm.
+			if ( error?.data?.reason === 'already_active' ) {
+				successCallback( { ...plugin, active: true } );
+				return;
 			}
+
 			dispatch( { ...defaultAction, type: PLUGIN_ACTIVATE_REQUEST_FAILURE, error } );
 
 			afterActivationCallback( error, undefined );
@@ -225,10 +225,7 @@ export function deactivatePlugin( siteId, plugin ) {
 		dispatch( { ...defaultAction, type: PLUGIN_DEACTIVATE_REQUEST } );
 
 		const afterDeactivationCallback = ( error ) => {
-			// Sometime data can be empty or the plugin always
-			// return the active state even when the error is empty.
-			// Activation error is ok, because it means the plugin is already active
-			if ( error && error.error !== 'deactivation_error' ) {
+			if ( error ) {
 				dispatch( bumpStat( 'calypso_plugin_deactivated', 'failed' ) );
 				dispatch(
 					recordTracksEvent( 'calypso_plugin_deactivated_error', {
@@ -256,10 +253,13 @@ export function deactivatePlugin( siteId, plugin ) {
 		};
 
 		const errorCallback = ( error ) => {
-			// This error means it's already inactive.
-			if ( error && error.error === 'deactivation_error' ) {
-				successCallback( plugin );
+			// See the note in activatePlugin(): `deactivation_error` is just as generic, so the
+			// already-inactive case is only safe to treat as a success when the server says so.
+			if ( error?.data?.reason === 'already_inactive' ) {
+				successCallback( { ...plugin, active: false } );
+				return;
 			}
+
 			dispatch( { ...defaultAction, type: PLUGIN_DEACTIVATE_REQUEST_FAILURE, error } );
 			afterDeactivationCallback( error );
 		};

--- a/client/state/plugins/installed/test/actions.js
+++ b/client/state/plugins/installed/test/actions.js
@@ -66,6 +66,13 @@ import {
 describe( 'actions', () => {
 	const spy = jest.fn();
 
+	const statBumps = ( group, name ) =>
+		spy.mock.calls
+			.map( ( [ action ] ) => action )
+			.filter( ( action ) => action?.type === ANALYTICS_STAT_BUMP )
+			.map( ( action ) => action.meta.analytics[ 0 ].payload )
+			.filter( ( payload ) => payload.group === group && payload.name === name );
+
 	const getState = () => ( {
 		currentUser: {
 			capabilities: {
@@ -230,12 +237,27 @@ describe( 'actions', () => {
 				.reply( 400, {
 					error: 'activation_error',
 					message: 'Plugin file does not exist.',
+				} )
+				.post( '/rest/v1.1/sites/2916284/plugins/alreadyactive%2Falreadyactive', {
+					active: true,
+				} )
+				.reply( 400, {
+					error: 'activation_error',
+					message: 'The Plugin is already active.',
+					data: { reason: 'already_active' },
 				} );
 		} );
 
 		afterAll( () => {
 			nock.cleanAll();
 		} );
+
+		// Calypso still believes the plugin is inactive, so the early-return guard does not apply.
+		const alreadyActive = {
+			slug: 'alreadyactive',
+			id: 'alreadyactive/alreadyactive',
+			sites: { [ 2916284 ]: { active: false } },
+		};
 
 		test( 'should dispatch request action when triggered', () => {
 			activatePlugin( 2916284, {
@@ -283,64 +305,41 @@ describe( 'actions', () => {
 				error: expect.objectContaining( { message: 'Plugin file does not exist.' } ),
 			} );
 		} );
-	} );
 
-	// One activation of an already-active plugin runs both the success and failure paths.
-	// These assertions describe the behavior we want; Jest records that it does not hold yet.
-	describe( '#activatePlugin() when the API reports activation_error (plugin already active)', () => {
-		beforeAll( () => {
-			nock( 'https://public-api.wordpress.com:443' )
-				.persist()
-				.post( '/rest/v1.1/sites/2916284/plugins/alreadyactive%2Falreadyactive', {
-					active: true,
-				} )
-				.reply( 400, {
-					error: 'activation_error',
-					message: 'The Plugin is already active.',
-				} );
-		} );
-
-		afterAll( () => {
-			nock.cleanAll();
-		} );
-
-		test.failing(
-			'should bump the succeeded stat exactly once and the failed stat zero times',
-			async () => {
-				await activatePlugin( 2916284, {
-					slug: 'alreadyactive',
-					id: 'alreadyactive/alreadyactive',
-					sites: { [ 2916284 ]: { active: false } },
-				} )( spy, getState );
-
-				const statBumpPayloads = spy.mock.calls
-					.map( ( [ action ] ) => action )
-					.filter( ( action ) => action.type === ANALYTICS_STAT_BUMP )
-					.map( ( action ) => action.meta.analytics[ 0 ].payload );
-
-				const succeededBumps = statBumpPayloads.filter(
-					( payload ) =>
-						payload.group === 'calypso_plugin_activated' && payload.name === 'succeeded'
-				);
-				const failedBumps = statBumpPayloads.filter(
-					( payload ) => payload.group === 'calypso_plugin_activated' && payload.name === 'failed'
-				);
-
-				expect( succeededBumps ).toHaveLength( 1 );
-				expect( failedBumps ).toHaveLength( 0 );
-			}
-		);
-
-		test.failing( 'should not dispatch a user-facing activation failure', async () => {
+		test( 'should record one failure and no success when the error carries no reason', async () => {
 			await activatePlugin( 2916284, {
-				slug: 'alreadyactive',
-				id: 'alreadyactive/alreadyactive',
+				slug: 'fake',
+				id: 'fake/fake',
 				sites: { [ 2916284 ]: { active: false } },
 			} )( spy, getState );
 
 			expect( spy ).not.toHaveBeenCalledWith(
+				expect.objectContaining( { type: PLUGIN_ACTIVATE_REQUEST_SUCCESS } )
+			);
+			expect( statBumps( 'calypso_plugin_activated', 'failed' ) ).toHaveLength( 1 );
+			expect( statBumps( 'calypso_plugin_activated', 'succeeded' ) ).toHaveLength( 0 );
+		} );
+
+		test( 'should dispatch success with the plugin marked active when it is already active', async () => {
+			await activatePlugin( 2916284, alreadyActive )( spy, getState );
+
+			expect( spy ).toHaveBeenCalledWith( {
+				type: PLUGIN_ACTIVATE_REQUEST_SUCCESS,
+				action: ACTIVATE_PLUGIN,
+				siteId: 2916284,
+				pluginId: 'alreadyactive/alreadyactive',
+				data: { ...alreadyActive, active: true },
+			} );
+		} );
+
+		test( 'should record one success and no failure when the plugin is already active', async () => {
+			await activatePlugin( 2916284, alreadyActive )( spy, getState );
+
+			expect( spy ).not.toHaveBeenCalledWith(
 				expect.objectContaining( { type: PLUGIN_ACTIVATE_REQUEST_FAILURE } )
 			);
+			expect( statBumps( 'calypso_plugin_activated', 'succeeded' ) ).toHaveLength( 1 );
+			expect( statBumps( 'calypso_plugin_activated', 'failed' ) ).toHaveLength( 0 );
 		} );
 	} );
 
@@ -354,12 +353,27 @@ describe( 'actions', () => {
 				.reply( 400, {
 					error: 'deactivation_error',
 					message: 'Plugin file does not exist.',
+				} )
+				.post( '/rest/v1.1/sites/2916284/plugins/alreadyinactive%2Falreadyinactive', {
+					active: false,
+				} )
+				.reply( 400, {
+					error: 'deactivation_error',
+					message: 'The Plugin is already deactivated.',
+					data: { reason: 'already_inactive' },
 				} );
 		} );
 
 		afterAll( () => {
 			nock.cleanAll();
 		} );
+
+		// Calypso still believes the plugin is active, so the early-return guard does not apply.
+		const alreadyInactive = {
+			slug: 'alreadyinactive',
+			id: 'alreadyinactive/alreadyinactive',
+			sites: { [ 2916284 ]: { active: true } },
+		};
 
 		test( 'should dispatch request action when triggered', () => {
 			deactivatePlugin( 2916284, akismetWithSites )( spy, getState );
@@ -396,54 +410,40 @@ describe( 'actions', () => {
 				error: expect.objectContaining( { message: 'Plugin file does not exist.' } ),
 			} );
 		} );
-	} );
 
-	// The deactivatePlugin() twin: 'succeeded' is bumped twice and a false error is shown.
-	describe( '#deactivatePlugin() when the API reports deactivation_error (plugin already inactive)', () => {
-		beforeAll( () => {
-			nock( 'https://public-api.wordpress.com:443' )
-				.persist()
-				.post( '/rest/v1.1/sites/2916284/plugins/alreadyinactive%2Falreadyinactive', {
-					active: false,
-				} )
-				.reply( 400, {
-					error: 'deactivation_error',
-					message: 'The Plugin is already deactivated.',
-				} );
+		test( 'should record one failure and no success when the error carries no reason', async () => {
+			await deactivatePlugin( 2916284, { slug: 'fake', id: 'fake/fake', active: true } )(
+				spy,
+				getState
+			);
+
+			expect( spy ).not.toHaveBeenCalledWith(
+				expect.objectContaining( { type: PLUGIN_DEACTIVATE_REQUEST_SUCCESS } )
+			);
+			expect( statBumps( 'calypso_plugin_deactivated', 'failed' ) ).toHaveLength( 1 );
+			expect( statBumps( 'calypso_plugin_deactivated', 'succeeded' ) ).toHaveLength( 0 );
 		} );
 
-		afterAll( () => {
-			nock.cleanAll();
-		} );
-
-		const alreadyInactive = {
-			slug: 'alreadyinactive',
-			id: 'alreadyinactive/alreadyinactive',
-			// Calypso still believes it is active, so the early-return guard does not apply.
-			sites: { [ 2916284 ]: { active: true } },
-		};
-
-		test.failing( 'should bump the succeeded stat exactly once', async () => {
+		test( 'should dispatch success with the plugin marked inactive when it is already inactive', async () => {
 			await deactivatePlugin( 2916284, alreadyInactive )( spy, getState );
 
-			const succeededBumps = spy.mock.calls
-				.map( ( [ action ] ) => action )
-				.filter( ( action ) => action.type === ANALYTICS_STAT_BUMP )
-				.map( ( action ) => action.meta.analytics[ 0 ].payload )
-				.filter(
-					( payload ) =>
-						payload.group === 'calypso_plugin_deactivated' && payload.name === 'succeeded'
-				);
-
-			expect( succeededBumps ).toHaveLength( 1 );
+			expect( spy ).toHaveBeenCalledWith( {
+				type: PLUGIN_DEACTIVATE_REQUEST_SUCCESS,
+				action: DEACTIVATE_PLUGIN,
+				siteId: 2916284,
+				pluginId: 'alreadyinactive/alreadyinactive',
+				data: { ...alreadyInactive, active: false },
+			} );
 		} );
 
-		test.failing( 'should not dispatch a user-facing deactivation failure', async () => {
+		test( 'should record one success and no failure when the plugin is already inactive', async () => {
 			await deactivatePlugin( 2916284, alreadyInactive )( spy, getState );
 
 			expect( spy ).not.toHaveBeenCalledWith(
 				expect.objectContaining( { type: PLUGIN_DEACTIVATE_REQUEST_FAILURE } )
 			);
+			expect( statBumps( 'calypso_plugin_deactivated', 'succeeded' ) ).toHaveLength( 1 );
+			expect( statBumps( 'calypso_plugin_deactivated', 'failed' ) ).toHaveLength( 0 );
 		} );
 	} );
 

--- a/client/state/plugins/installed/test/actions.js
+++ b/client/state/plugins/installed/test/actions.js
@@ -40,6 +40,7 @@ import {
 	PLUGIN_REMOVE_REQUEST_FAILURE,
 	SITE_PLUGIN_UPDATED,
 	PLUGIN_ACTION_STATUS_UPDATE,
+	ANALYTICS_STAT_BUMP,
 } from 'calypso/state/action-types';
 import {
 	fetchSitePlugins,
@@ -284,6 +285,65 @@ describe( 'actions', () => {
 		} );
 	} );
 
+	// One activation of an already-active plugin runs both the success and failure paths.
+	// These assertions describe the behavior we want; Jest records that it does not hold yet.
+	describe( '#activatePlugin() when the API reports activation_error (plugin already active)', () => {
+		beforeAll( () => {
+			nock( 'https://public-api.wordpress.com:443' )
+				.persist()
+				.post( '/rest/v1.1/sites/2916284/plugins/alreadyactive%2Falreadyactive', {
+					active: true,
+				} )
+				.reply( 400, {
+					error: 'activation_error',
+					message: 'The Plugin is already active.',
+				} );
+		} );
+
+		afterAll( () => {
+			nock.cleanAll();
+		} );
+
+		test.failing(
+			'should bump the succeeded stat exactly once and the failed stat zero times',
+			async () => {
+				await activatePlugin( 2916284, {
+					slug: 'alreadyactive',
+					id: 'alreadyactive/alreadyactive',
+					sites: { [ 2916284 ]: { active: false } },
+				} )( spy, getState );
+
+				const statBumpPayloads = spy.mock.calls
+					.map( ( [ action ] ) => action )
+					.filter( ( action ) => action.type === ANALYTICS_STAT_BUMP )
+					.map( ( action ) => action.meta.analytics[ 0 ].payload );
+
+				const succeededBumps = statBumpPayloads.filter(
+					( payload ) =>
+						payload.group === 'calypso_plugin_activated' && payload.name === 'succeeded'
+				);
+				const failedBumps = statBumpPayloads.filter(
+					( payload ) => payload.group === 'calypso_plugin_activated' && payload.name === 'failed'
+				);
+
+				expect( succeededBumps ).toHaveLength( 1 );
+				expect( failedBumps ).toHaveLength( 0 );
+			}
+		);
+
+		test.failing( 'should not dispatch a user-facing activation failure', async () => {
+			await activatePlugin( 2916284, {
+				slug: 'alreadyactive',
+				id: 'alreadyactive/alreadyactive',
+				sites: { [ 2916284 ]: { active: false } },
+			} )( spy, getState );
+
+			expect( spy ).not.toHaveBeenCalledWith(
+				expect.objectContaining( { type: PLUGIN_ACTIVATE_REQUEST_FAILURE } )
+			);
+		} );
+	} );
+
 	describe( '#deactivatePlugin()', () => {
 		beforeAll( () => {
 			nock( 'https://public-api.wordpress.com:443' )
@@ -335,6 +395,55 @@ describe( 'actions', () => {
 				pluginId: 'fake/fake',
 				error: expect.objectContaining( { message: 'Plugin file does not exist.' } ),
 			} );
+		} );
+	} );
+
+	// The deactivatePlugin() twin: 'succeeded' is bumped twice and a false error is shown.
+	describe( '#deactivatePlugin() when the API reports deactivation_error (plugin already inactive)', () => {
+		beforeAll( () => {
+			nock( 'https://public-api.wordpress.com:443' )
+				.persist()
+				.post( '/rest/v1.1/sites/2916284/plugins/alreadyinactive%2Falreadyinactive', {
+					active: false,
+				} )
+				.reply( 400, {
+					error: 'deactivation_error',
+					message: 'The Plugin is already deactivated.',
+				} );
+		} );
+
+		afterAll( () => {
+			nock.cleanAll();
+		} );
+
+		const alreadyInactive = {
+			slug: 'alreadyinactive',
+			id: 'alreadyinactive/alreadyinactive',
+			// Calypso still believes it is active, so the early-return guard does not apply.
+			sites: { [ 2916284 ]: { active: true } },
+		};
+
+		test.failing( 'should bump the succeeded stat exactly once', async () => {
+			await deactivatePlugin( 2916284, alreadyInactive )( spy, getState );
+
+			const succeededBumps = spy.mock.calls
+				.map( ( [ action ] ) => action )
+				.filter( ( action ) => action.type === ANALYTICS_STAT_BUMP )
+				.map( ( action ) => action.meta.analytics[ 0 ].payload )
+				.filter(
+					( payload ) =>
+						payload.group === 'calypso_plugin_deactivated' && payload.name === 'succeeded'
+				);
+
+			expect( succeededBumps ).toHaveLength( 1 );
+		} );
+
+		test.failing( 'should not dispatch a user-facing deactivation failure', async () => {
+			await deactivatePlugin( 2916284, alreadyInactive )( spy, getState );
+
+			expect( spy ).not.toHaveBeenCalledWith(
+				expect.objectContaining( { type: PLUGIN_DEACTIVATE_REQUEST_FAILURE } )
+			);
 		} );
 	} );
 

--- a/client/state/plugins/installed/test/actions.js
+++ b/client/state/plugins/installed/test/actions.js
@@ -320,7 +320,7 @@ describe( 'actions', () => {
 			expect( statBumps( 'calypso_plugin_activated', 'succeeded' ) ).toHaveLength( 0 );
 		} );
 
-		test( 'should dispatch success with the plugin marked active when it is already active', async () => {
+		test( 'should record one success with the plugin marked active when it is already active', async () => {
 			await activatePlugin( 2916284, alreadyActive )( spy, getState );
 
 			expect( spy ).toHaveBeenCalledWith( {
@@ -330,11 +330,6 @@ describe( 'actions', () => {
 				pluginId: 'alreadyactive/alreadyactive',
 				data: { ...alreadyActive, active: true },
 			} );
-		} );
-
-		test( 'should record one success and no failure when the plugin is already active', async () => {
-			await activatePlugin( 2916284, alreadyActive )( spy, getState );
-
 			expect( spy ).not.toHaveBeenCalledWith(
 				expect.objectContaining( { type: PLUGIN_ACTIVATE_REQUEST_FAILURE } )
 			);
@@ -424,7 +419,7 @@ describe( 'actions', () => {
 			expect( statBumps( 'calypso_plugin_deactivated', 'succeeded' ) ).toHaveLength( 0 );
 		} );
 
-		test( 'should dispatch success with the plugin marked inactive when it is already inactive', async () => {
+		test( 'should record one success with the plugin marked inactive when it is already inactive', async () => {
 			await deactivatePlugin( 2916284, alreadyInactive )( spy, getState );
 
 			expect( spy ).toHaveBeenCalledWith( {
@@ -434,11 +429,6 @@ describe( 'actions', () => {
 				pluginId: 'alreadyinactive/alreadyinactive',
 				data: { ...alreadyInactive, active: false },
 			} );
-		} );
-
-		test( 'should record one success and no failure when the plugin is already inactive', async () => {
-			await deactivatePlugin( 2916284, alreadyInactive )( spy, getState );
-
 			expect( spy ).not.toHaveBeenCalledWith(
 				expect.objectContaining( { type: PLUGIN_DEACTIVATE_REQUEST_FAILURE } )
 			);


### PR DESCRIPTION
Part of DOTMKT-41
Part of DOTCOM-18116

Server-side counterpart: Automattic/jetpack PR 51019, now merged. It attaches a `data.reason` field to these errors so the benign "already in that state" case can be told apart from a real failure.

## Proposed Changes

* `activatePlugin()` and `deactivatePlugin()` now decide what happened from the reason the endpoint reports, rather than from the generic error code. When the server confirms the plugin is already in the requested state, the call is recorded as a single success carrying a payload that reflects the plugin's real state.
* When the error carries no reason — an older Jetpack that has not picked up the server change yet — the call is recorded as a single failure. Nothing is assumed about a state the server did not confirm.
* Test coverage for both response shapes on both actions. This replaces the `test.failing()` cases this branch previously carried, which are no longer needed now that the behavior they described holds.

## Why are these changes being made?

`activation_error` and `deactivation_error` are generic codes: the endpoint wraps every failure in them, so they cover a real failure and the benign no-op alike. The client used to read them as "already active" unconditionally and, because that branch fell through, ran the success and failure paths on the same request. One activation of an already-active plugin therefore:

* bumped both `calypso_plugin_activated/succeeded` and `calypso_plugin_activated/failed`
* recorded a `calypso_plugin_activated_error` Tracks event reading `Undefined activation error`
* dispatched `PLUGIN_ACTIVATE_REQUEST_FAILURE`, showing a red "An error occurred while activating" notice on a plugin that is active

`deactivatePlugin()` had the same shape, double-counting `calypso_plugin_deactivated/succeeded` and showing the same false error.

Matching on the message is not viable, since those strings are translated server-side, which is why the signal had to come from the API. The server change is deliberately additive: the code, message, and status are unchanged, and the reason rides along in `data`. That makes this side safe to ship during the Jetpack rollout — sites that already serve the reason get the corrected success, and sites that do not keep behaving as a plain failure until they catch up.

## Testing Instructions

```
yarn test-client client/state/plugins/installed/test/actions.js
```

All 39 tests pass. Reverting the changes to `client/state/plugins/installed/actions.js` fails the six new ones.

To reproduce the original bug in a browser on an Atomic site running a Jetpack version without the server change:

1. Open the plugin page for an installed but inactive plugin, so the store caches the inactive state.
2. Activate the plugin from wp-admin, leaving the first tab untouched.
3. Click Activate in the first tab. Before this change a red error notice appeared on a plugin that is now active, alongside a success event.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? <!-- Behavior originally reproduced on Atomic. -->
- [x] Have you checked for TypeScript, React or other console errors? <!-- yarn typecheck-client passes -->
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
