### PR TITLE
Purchase Management: Update the purchase listing pages to improve expiring and expired subscription handling

### DIFF
--- a/client/dashboard/components/plan-expiry-notice/get-plan-expiry-notice.ts
+++ b/client/dashboard/components/plan-expiry-notice/get-plan-expiry-notice.ts
@@ -3,6 +3,8 @@ import { translationExists } from '@automattic/i18n-utils';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { formatDate, getCalendarDaysUntil, getRelativeDayString } from '../../utils/datetime';
 import {
+	EXPIRY_ERROR_DAYS,
+	EXPIRY_WARNING_DAYS,
 	getRenewalUrlFromPurchase,
 	isDotcomPlan,
 	isExpiredAndInGracePeriod,
@@ -11,19 +13,6 @@ import {
 } from '../../utils/purchase';
 import { getPlanStorageInGb } from './plan-storage';
 import type { Purchase } from '@automattic/api-core';
-
-/**
- * Once expiration is this close, a plan that cannot renew itself is a problem
- * worth raising rather than a date still comfortably far off, so this is where
- * the messaging begins, as a warning.
- */
-const WARNING_DAYS_BEFORE_EXPIRY = 60;
-
-/**
- * Once expiration is this close, losing the plan is the most likely outcome
- * rather than a distant possibility, so the messaging switches to an error.
- */
-const ERROR_DAYS_BEFORE_EXPIRY = 7;
 
 export type PlanExpiryUrgency = 'info' | 'warning' | 'error';
 
@@ -271,7 +260,7 @@ function resolveNotice(
 	);
 
 	// The day of expiration, or the last few days before it.
-	if ( daysUntilExpiry <= ERROR_DAYS_BEFORE_EXPIRY ) {
+	if ( daysUntilExpiry <= EXPIRY_ERROR_DAYS ) {
 		const isExpiringToday = daysUntilExpiry <= 0;
 
 		if ( canAutoRenew ) {
@@ -342,7 +331,7 @@ function resolveNotice(
 		};
 	}
 
-	if ( daysUntilExpiry <= WARNING_DAYS_BEFORE_EXPIRY ) {
+	if ( daysUntilExpiry <= EXPIRY_WARNING_DAYS ) {
 		return {
 			variant: 'warning',
 			titleSource: expiresInDaysTitleSource,

--- a/client/dashboard/components/purchase-expiry-status/index.tsx
+++ b/client/dashboard/components/purchase-expiry-status/index.tsx
@@ -1,16 +1,21 @@
+import './style.scss';
+
 import { SubscriptionBillPeriod, getPlanNames } from '@automattic/api-core';
-import { translationExists } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
-import { Button, ExternalLink } from '@wordpress/components';
+import { Button, ExternalLink, Icon } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { arrowUpRight } from '@wordpress/icons';
+import { useAnalytics } from '../../app/analytics';
+import { useAuth } from '../../app/auth';
 import { useHelpCenter } from '../../app/help-center';
 import { useLocale } from '../../app/locale';
 import { Text } from '../../components/text';
 import { formatDate, getCalendarDaysUntil, getRelativeDayString } from '../../utils/datetime';
 import {
+	EXPIRY_ERROR_DAYS,
+	EXPIRY_WARNING_DAYS,
 	isA4ABillingDragonPurchase,
-	isRecentMonthlyPurchase,
 	isRenewingBeforeExpiration,
 	isExpiring,
 	isExpiredOrRemoved,
@@ -20,7 +25,15 @@ import {
 	creditCardHasAlreadyExpired,
 	creditCardExpiresBeforeSubscription,
 	isCentennialPurchase,
+	getRenewalUrlFromPurchase,
 } from '../../utils/purchase';
+import {
+	getExpiredCopy,
+	getExpiredRenewalTitle,
+	getExpiringSoonCopy,
+	getExpiringSoonRenewalTitle,
+} from '../../utils/purchase-expiry-copy';
+import type { ExpiryStatusCopy } from '../../utils/purchase-expiry-copy';
 import type { Purchase } from '@automattic/api-core';
 
 // Renders a formatted purchase's expiry date in an inline-block span
@@ -32,6 +45,100 @@ function FormattedExpiryDate( { locale, purchase }: { locale: string; purchase: 
 				dateStyle: 'long',
 			} ) }
 		</span>
+	);
+}
+
+/**
+ * The expiry status of a subscription that is close to expiring or has already
+ * expired: colored to draw attention, and linked to renewal checkout where
+ * renewing is something the viewer can act on right now.
+ *
+ * Expiry further off than the warning window is not urgent, and is rendered as
+ * plain text by the caller rather than through here.
+ */
+function UrgentExpiryStatus( {
+	purchase,
+	copy,
+	hasExpired,
+	untranslatedFallbackText,
+}: {
+	purchase: Purchase;
+	copy: ExpiryStatusCopy;
+
+	/**
+	 * Whether `copy` describes a lapsed subscription rather than one still
+	 * heading for expiry. Taken from the caller because that is decided by the
+	 * subscription's status, which can disagree with its date in both
+	 * directions — and the tooltip has to read the same way the status does.
+	 */
+	hasExpired: boolean;
+
+	/**
+	 * Wording for locales that have no translation for `copy` yet. A `ReactNode`
+	 * because that older sentence interpolates the date into an element. Both
+	 * this and `copy.text`'s nullability go away once the copy is translated.
+	 */
+	untranslatedFallbackText?: React.ReactNode;
+} ) {
+	const locale = useLocale();
+	const { user } = useAuth();
+	const { recordTracksEvent } = useAnalytics();
+
+	// The wording drops the expiry date to keep the column short, so it moves to
+	// a tooltip rather than disappearing.
+	const daysUntilExpiry = getCalendarDaysUntil( new Date( purchase.expiry_date ) );
+	const expiryDateTitle = formatDate( new Date( purchase.expiry_date ), locale, {
+		dateStyle: 'long',
+	} );
+
+	// The purchase page gates its "Renew now" action on these same two
+	// conditions. Calypso's equivalent surfaces apply a longer list; the two
+	// clients are knowingly out of step here.
+	const canRenew = purchase.can_explicit_renew && String( user.ID ) === String( purchase.user_id );
+
+	// How close to expiry a subscription has to be before renewal is worth
+	// offering. A monthly subscription is never far from expiring, so the annual
+	// window would ask for a renewal within days of the purchase; it gets the
+	// last week instead. Anything already past its expiry date is inside either.
+	const renewalWindowDays =
+		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD
+			? EXPIRY_ERROR_DAYS
+			: EXPIRY_WARNING_DAYS;
+	const isRenewalWorthOffering = canRenew && daysUntilExpiry <= renewalWindowDays;
+
+	const expiryText = copy.text ?? untranslatedFallbackText;
+
+	if ( ! isRenewalWorthOffering ) {
+		return (
+			<Text intent={ copy.intent } title={ expiryDateTitle }>
+				{ expiryText }
+			</Text>
+		);
+	}
+
+	const renewalTitle = hasExpired
+		? getExpiredRenewalTitle( expiryDateTitle )
+		: getExpiringSoonRenewalTitle( expiryDateTitle );
+
+	return (
+		<Text intent={ copy.intent }>
+			<a
+				className="purchase-expiry-status__renew-link"
+				// On the link rather than the wrapper, so that it describes the link
+				// to a screen reader as well as showing on hover.
+				title={ renewalTitle ?? expiryDateTitle }
+				href={ getRenewalUrlFromPurchase( purchase ) }
+				onClick={ () =>
+					recordTracksEvent( 'calypso_purchases_renew_now_click', {
+						product_slug: purchase.product_slug,
+						position: 'purchase-list',
+					} )
+				}
+			>
+				{ expiryText }
+				<Icon icon={ arrowUpRight } size={ 18 } />
+			</a>
+		</Text>
 	);
 }
 
@@ -312,54 +419,42 @@ export function PurchaseExpiryStatus( {
 		}
 	}
 
-	const expiresOnText = createInterpolateElement(
-		// translators: date is a formatted expiry date
-		__( 'Expires on <date />' ),
-		{
-			date: <FormattedExpiryDate locale={ locale } purchase={ purchase } />,
-		}
-	);
-
 	if ( isExpiring( purchase ) && ! isAkismetFreeProduct( purchase ) ) {
-		const daysUntilExpiry = getCalendarDaysUntil( new Date( purchase.expiry_date ) );
+		const copy = getExpiringSoonCopy( new Date( purchase.expiry_date ) );
 
-		// Covers both "later today" and a purchase whose expiry date has passed
-		// but which the backend still reports as expiring.
-		if ( daysUntilExpiry <= 0 ) {
-			return (
-				<Text intent="error">
-					{ translationExists( 'Expires today' ) ? __( 'Expires today' ) : expiresOnText }
-				</Text>
+		if ( ! copy ) {
+			return createInterpolateElement(
+				// translators: date is a formatted expiry date
+				__( 'Expires on <date />' ),
+				{
+					date: <FormattedExpiryDate locale={ locale } purchase={ purchase } />,
+				}
 			);
 		}
 
-		if ( daysUntilExpiry <= 30 && ! isRecentMonthlyPurchase( purchase ) ) {
-			const intent = daysUntilExpiry <= 7 ? ( 'error' as const ) : ( 'warning' as const );
+		// Only reached where the day-count copy has no translation yet. Delete
+		// this and the prop it is passed to once it does; see `getExpiringSoonCopy`.
+		const untranslatedFallbackText = createInterpolateElement(
+			sprintf(
+				// translators: timeUntilExpiry is a formatted expiration string like "in 30 days" and date is a formatted expiry date
+				__( 'Expires %(timeUntilExpiry)s on <date />' ),
+				{
+					timeUntilExpiry: getRelativeDayString( new Date( purchase.expiry_date ), 'upcoming' ),
+				}
+			),
+			{
+				date: <FormattedExpiryDate locale={ locale } purchase={ purchase } />,
+			}
+		);
 
-			return (
-				<Text intent={ intent }>
-					{ createInterpolateElement(
-						sprintf(
-							// translators: timeUntilExpiry is a formatted expiration string like "in 30 days" and date is a formatted expiry date
-							__( 'Expires %(timeUntilExpiry)s on <date />' ),
-							{
-								// The branch above already excludes today and past dates, but
-								// the clamp keeps that guarantee local to this call.
-								timeUntilExpiry: getRelativeDayString(
-									new Date( purchase.expiry_date ),
-									'upcoming'
-								),
-							}
-						),
-						{
-							date: <FormattedExpiryDate locale={ locale } purchase={ purchase } />,
-						}
-					) }
-				</Text>
-			);
-		}
-
-		return expiresOnText;
+		return (
+			<UrgentExpiryStatus
+				purchase={ purchase }
+				copy={ copy }
+				hasExpired={ false }
+				untranslatedFallbackText={ untranslatedFallbackText }
+			/>
+		);
 	}
 	if ( isExpiredOrRemoved( purchase ) && 'concierge-session' === purchase.product_slug ) {
 		// translators: %s is a formatted expiry date
@@ -369,19 +464,12 @@ export function PurchaseExpiryStatus( {
 	}
 
 	if ( isExpiredOrRemoved( purchase ) ) {
-		// getCalendarDaysUntil counts forward, so this is negative once the expiry
-		// date has passed. Anything else means the expiry lands today or later —
-		// later being a purchase removed ahead of its expiry date — and both read
-		// as "Expired today" rather than "Expired in 3 days".
-		const expiredBeforeToday = getCalendarDaysUntil( new Date( purchase.expiry_date ) ) < 0;
-		const expiredTodayText = __( 'Expired today' );
-		// translators: timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"
-		const expiredFromNowText = sprintf( __( 'Expired %(timeSinceExpiry)s' ), {
-			timeSinceExpiry: getRelativeDayString( new Date( purchase.expiry_date ), 'past' ),
-		} );
-
 		return (
-			<Text intent="error">{ expiredBeforeToday ? expiredFromNowText : expiredTodayText }</Text>
+			<UrgentExpiryStatus
+				purchase={ purchase }
+				copy={ getExpiredCopy( new Date( purchase.expiry_date ) ) }
+				hasExpired
+			/>
 		);
 	}
 

--- a/client/dashboard/components/purchase-expiry-status/style.scss
+++ b/client/dashboard/components/purchase-expiry-status/style.scss
@@ -1,0 +1,19 @@
+.purchase-expiry-status__renew-link {
+	// The parent carries the warning and error colors, which the dashboard's
+	// default link styling would otherwise override.
+	color: inherit;
+	text-decoration: underline;
+
+	&:hover,
+	&:focus {
+		color: inherit;
+	}
+
+	svg {
+		// The glyph is inset by a quarter of the icon box on every side, so the
+		// box has to hang below the baseline for the arrow itself to sit near
+		// it. Keep in step with the icon's size.
+		vertical-align: -3.5px;
+		fill: currentColor;
+	}
+}

--- a/client/dashboard/components/purchase-expiry-status/test/index.test.tsx
+++ b/client/dashboard/components/purchase-expiry-status/test/index.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment jsdom
+ */
+import { SubscriptionBillPeriod } from '@automattic/api-core';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MockDate from 'mockdate';
+import { render } from '../../../test-utils';
+import { PurchaseExpiryStatus } from '../index';
+import type { Purchase } from '@automattic/api-core';
+
+// The copy counts whole calendar days in the viewer's time zone, so these
+// assertions only hold against a fixed clock.
+const NOW = '2026-02-24T18:00:00Z';
+
+const daysFromNow = ( days: number ) => {
+	const date = new Date( NOW );
+	date.setUTCDate( date.getUTCDate() + days );
+	return date.toISOString();
+};
+
+const OWNER_ID = 1;
+
+const createPurchase = ( overrides: Partial< Purchase > = {} ): Purchase =>
+	( {
+		ID: 123,
+		user_id: OWNER_ID,
+		product_slug: 'business-bundle',
+		product_name: 'Business',
+		product_type: 'bundle',
+		amount: 300,
+		expiry_status: 'manual-renew',
+		subscription_status: 'active',
+		expiry_date: daysFromNow( 45 ),
+		bill_period_days: SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD,
+		can_explicit_renew: true,
+		is_renewable: true,
+		is_locked: false,
+		is_attached_to_holding_site: false,
+		...overrides,
+	} ) as Purchase;
+
+const renewLink = () => screen.queryByRole( 'link' );
+
+describe( '<PurchaseExpiryStatus>', () => {
+	beforeEach( () => MockDate.set( NOW ) );
+	afterEach( () => MockDate.reset() );
+
+	test( 'says only when a distant expiry falls due', () => {
+		render(
+			<PurchaseExpiryStatus purchase={ createPurchase( { expiry_date: daysFromNow( 90 ) } ) } />
+		);
+
+		expect( screen.getByText( /expires on/i ) ).toBeVisible();
+		expect( screen.queryByText( /expires in/i ) ).toBeNull();
+		expect( renewLink() ).toBeNull();
+	} );
+
+	test( 'counts the days exactly rather than rounding to months', () => {
+		render( <PurchaseExpiryStatus purchase={ createPurchase() } /> );
+
+		expect( screen.getByText( /expires in 45 days/i ) ).toBeVisible();
+		expect( screen.queryByText( /1 month/i ) ).toBeNull();
+	} );
+
+	test( 'offers renewal, named for what the reader can see', () => {
+		render( <PurchaseExpiryStatus purchase={ createPurchase() } /> );
+
+		const link = screen.getByRole( 'link' );
+		expect( link ).toHaveTextContent( 'Expires in 45 days' );
+		expect( link ).toHaveAttribute( 'title', 'Expires on April 10, 2026 (renew this purchase)' );
+	} );
+
+	test( 'records the renewal click where it happened', async () => {
+		const user = userEvent.setup();
+		const { recordTracksEvent } = render( <PurchaseExpiryStatus purchase={ createPurchase() } /> );
+
+		await user.click( screen.getByRole( 'link' ) );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_purchases_renew_now_click', {
+			product_slug: 'business-bundle',
+			position: 'purchase-list',
+		} );
+	} );
+
+	test( 'says how long ago an expired purchase lapsed, and still offers renewal', () => {
+		render(
+			<PurchaseExpiryStatus
+				purchase={ createPurchase( { expiry_status: 'expired', expiry_date: daysFromNow( -3 ) } ) }
+			/>
+		);
+
+		expect( screen.getByText( /expired 3 days ago/i ) ).toBeVisible();
+		expect( renewLink() ).toBeVisible();
+	} );
+
+	describe( 'a monthly subscription', () => {
+		const monthly = { bill_period_days: SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD };
+
+		test( 'is flagged well before it lapses, but not yet worth renewing', () => {
+			render(
+				<PurchaseExpiryStatus
+					purchase={ createPurchase( { ...monthly, expiry_date: daysFromNow( 20 ) } ) }
+				/>
+			);
+
+			expect( screen.getByText( /expires in 20 days/i ) ).toBeVisible();
+			expect( renewLink() ).toBeNull();
+		} );
+
+		test( 'can be renewed once it is nearly up', () => {
+			render(
+				<PurchaseExpiryStatus
+					purchase={ createPurchase( { ...monthly, expiry_date: daysFromNow( 5 ) } ) }
+				/>
+			);
+
+			expect( renewLink() ).toBeVisible();
+		} );
+	} );
+
+	describe( 'a purchase the viewer cannot renew', () => {
+		test.each( [
+			[ 'is not theirs', { user_id: OWNER_ID + 1 } ],
+			[ 'cannot be explicitly renewed', { can_explicit_renew: false } ],
+		] )( 'is still flagged, but offers nothing to click, when it %s', ( _label, overrides ) => {
+			render(
+				<PurchaseExpiryStatus purchase={ createPurchase( overrides as Partial< Purchase > ) } />
+			);
+
+			expect( screen.getByText( /expires in 45 days/i ) ).toBeVisible();
+			expect( renewLink() ).toBeNull();
+		} );
+	} );
+} );

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -258,6 +258,7 @@ function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
 	const hasEnTranslation = useHasEnTranslation();
 	const { user } = useAuth();
 	const isOwner = String( user.ID ) === String( purchase.user_id );
+	// The purchase list gates its renewal link on these same two conditions.
 	const canBeRenewed = purchase.can_explicit_renew && isOwner;
 	const upgradeAction = getHeaderUpgradeAction( purchase );
 	const storageUpgradeUrl = getSitePurchaseStorageUpgradeUrl( purchase );
@@ -294,6 +295,7 @@ function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
 				onClick={ () => {
 					recordTracksEvent( 'calypso_purchases_renew_now_click', {
 						product_slug: purchase.product_slug,
+						position: 'purchase-settings',
 					} );
 					renewPurchase( purchase );
 				} }
@@ -577,6 +579,7 @@ export function ProductChangeActionItem( { purchase }: { purchase: Purchase } ) 
 
 function RenewActionButton( { purchase }: { purchase: Purchase } ) {
 	const { user } = useAuth();
+	// The purchase list gates its renewal link on these same two conditions.
 	const canBeRenewed =
 		purchase.can_explicit_renew && String( user.ID ) === String( purchase.user_id );
 	const { recordTracksEvent } = useAnalytics();
@@ -595,6 +598,7 @@ function RenewActionButton( { purchase }: { purchase: Purchase } ) {
 					onClick={ () => {
 						recordTracksEvent( 'calypso_purchases_renew_now_click', {
 							product_slug: purchase.product_slug,
+							position: 'purchase-settings',
 						} );
 						renewPurchase( purchase );
 					} }

--- a/client/dashboard/utils/purchase-expiry-copy.ts
+++ b/client/dashboard/utils/purchase-expiry-copy.ts
@@ -1,0 +1,114 @@
+import { translationExists } from '@automattic/i18n-utils';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { getCalendarDaysUntil, getRelativeDayString } from './datetime';
+import { EXPIRY_ERROR_DAYS, EXPIRY_WARNING_DAYS } from './purchase';
+
+export interface ExpiryStatusCopy {
+	intent: 'warning' | 'error';
+
+	/**
+	 * Null only where this locale has no translation for the wording yet, in
+	 * which case the caller should render its own older sentence and keep the
+	 * intent — the color is right either way. Once the copy below is translated
+	 * this stops being nullable, and those fallbacks can go with it.
+	 */
+	text: string | null;
+}
+
+/**
+ * How to describe a subscription that is heading for expiration, or null when it
+ * is far enough out that there is nothing to say.
+ *
+ * Counts the days exactly rather than using `getRelativeDayString`, which
+ * collapses to the largest unit and would render everything from 31 to 60 days
+ * as "in 1 month" — the whole span this window added.
+ */
+export function getExpiringSoonCopy( expiryDate: Date ): ExpiryStatusCopy | null {
+	const days = getCalendarDaysUntil( expiryDate );
+
+	// Covers both "later today" and a date that has passed while the backend
+	// still reports the subscription as expiring.
+	if ( days <= 0 ) {
+		return {
+			intent: 'error',
+			text: translationExists( 'Expires today' ) ? __( 'Expires today' ) : null,
+		};
+	}
+
+	if ( days > EXPIRY_WARNING_DAYS ) {
+		return null;
+	}
+
+	return {
+		intent: days <= EXPIRY_ERROR_DAYS ? 'error' : 'warning',
+		// The singular, because that is the key translations are stored under.
+		text: translationExists( 'Expires in %(days)d day' )
+			? sprintf(
+					// translators: %(days)d is a number of days
+					_n( 'Expires in %(days)d day', 'Expires in %(days)d days', days ),
+					{ days }
+			  )
+			: null,
+	};
+}
+
+/**
+ * How to describe a subscription whose expiration date has passed. Always has
+ * wording of its own, and is always an error: the subscription has lapsed.
+ */
+export function getExpiredCopy( expiryDate: Date ): ExpiryStatusCopy {
+	const daysAgo = -getCalendarDaysUntil( expiryDate );
+
+	if ( daysAgo <= 0 ) {
+		return { intent: 'error', text: __( 'Expired today' ) };
+	}
+
+	// The singular, because that is the key translations are stored under.
+	const hasDayCountTranslation = translationExists( 'Expired %(days)d day ago' );
+
+	// Counting the days exactly only reads well for a while — "Expired 243 days
+	// ago" does not — so anything older rounds to the largest unit. So does copy
+	// this locale hasn't translated yet, which lands on the same sentence.
+	if ( daysAgo > EXPIRY_WARNING_DAYS || ! hasDayCountTranslation ) {
+		return {
+			intent: 'error',
+			text: sprintf(
+				// translators: timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"
+				__( 'Expired %(timeSinceExpiry)s' ),
+				{ timeSinceExpiry: getRelativeDayString( expiryDate, 'past' ) }
+			),
+		};
+	}
+
+	return {
+		intent: 'error',
+		text: sprintf(
+			// translators: %(days)d is a number of days
+			_n( 'Expired %(days)d day ago', 'Expired %(days)d days ago', daysAgo ),
+			{ days: daysAgo }
+		),
+	};
+}
+
+/**
+ * Tooltip for a status that links to renewal checkout, for a subscription that
+ * has not lapsed yet. The status counts days rather than naming the date, and
+ * says nothing about where the link goes, so this supplies both. Null where the
+ * wording has no translation yet.
+ */
+export function getExpiringSoonRenewalTitle( formattedExpiryDate: string ): string | null {
+	return translationExists( 'Expires on %s (renew this purchase)' )
+		? // translators: %s is a formatted date
+		  sprintf( __( 'Expires on %s (renew this purchase)' ), formattedExpiryDate )
+		: null;
+}
+
+/**
+ * As {@link getExpiringSoonRenewalTitle}, for a subscription that has lapsed.
+ */
+export function getExpiredRenewalTitle( formattedExpiryDate: string ): string | null {
+	return translationExists( 'Expired on %s (renew this purchase)' )
+		? // translators: %s is a formatted date
+		  sprintf( __( 'Expired on %s (renew this purchase)' ), formattedExpiryDate )
+		: null;
+}

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -33,6 +33,18 @@ export const CANCEL_FLOW_TYPE = {
 export type CancelFlowType = ( typeof CANCEL_FLOW_TYPE )[ keyof typeof CANCEL_FLOW_TYPE ];
 
 /**
+ * Once expiration is this close, a subscription that will not renew itself is a
+ * problem worth raising rather than a date still comfortably far off.
+ */
+export const EXPIRY_WARNING_DAYS = 60;
+
+/**
+ * Once expiration is this close, losing the subscription is the most likely
+ * outcome rather than a distant possibility.
+ */
+export const EXPIRY_ERROR_DAYS = 7;
+
+/**
  * Returns true if the purchase is auto-renewing and not yet expired.
  */
 export function isRenewingBeforeExpiration( purchase: Purchase ): boolean {

--- a/client/dashboard/utils/test/purchase-expiry-copy.ts
+++ b/client/dashboard/utils/test/purchase-expiry-copy.ts
@@ -1,0 +1,87 @@
+import MockDate from 'mockdate';
+import { getExpiredCopy, getExpiringSoonCopy } from '../purchase-expiry-copy';
+
+// The copy counts whole calendar days in the viewer's time zone, so these
+// assertions only hold against a fixed clock.
+const NOW = '2026-02-24T18:00:00Z';
+
+const daysFromNow = ( days: number ) => {
+	const date = new Date( NOW );
+	date.setUTCDate( date.getUTCDate() + days );
+	return date;
+};
+
+describe( 'getExpiringSoonCopy', () => {
+	beforeEach( () => MockDate.set( NOW ) );
+	afterEach( () => MockDate.reset() );
+
+	test( 'says nothing about a date beyond the warning window', () => {
+		expect( getExpiringSoonCopy( daysFromNow( 61 ) ) ).toBeNull();
+	} );
+
+	test( 'warns from the edge of the window', () => {
+		expect( getExpiringSoonCopy( daysFromNow( 60 ) ) ).toEqual( {
+			intent: 'warning',
+			text: 'Expires in 60 days',
+		} );
+	} );
+
+	test( 'counts the days exactly rather than rounding to months', () => {
+		expect( getExpiringSoonCopy( daysFromNow( 45 ) )?.text ).toBe( 'Expires in 45 days' );
+	} );
+
+	test( 'escalates to an error in the last week', () => {
+		expect( getExpiringSoonCopy( daysFromNow( 8 ) )?.intent ).toBe( 'warning' );
+		expect( getExpiringSoonCopy( daysFromNow( 7 ) )?.intent ).toBe( 'error' );
+	} );
+
+	test( 'uses the singular for one day', () => {
+		expect( getExpiringSoonCopy( daysFromNow( 1 ) )?.text ).toBe( 'Expires in 1 day' );
+	} );
+
+	test( 'reads as today on the day itself', () => {
+		expect( getExpiringSoonCopy( daysFromNow( 0 ) ) ).toEqual( {
+			intent: 'error',
+			text: 'Expires today',
+		} );
+	} );
+
+	test( 'never points backwards, even if the date has passed', () => {
+		expect( getExpiringSoonCopy( daysFromNow( -3 ) )?.text ).toBe( 'Expires today' );
+	} );
+} );
+
+describe( 'getExpiredCopy', () => {
+	beforeEach( () => MockDate.set( NOW ) );
+	afterEach( () => MockDate.reset() );
+
+	test( 'counts the days since expiration', () => {
+		expect( getExpiredCopy( daysFromNow( -3 ) ) ).toEqual( {
+			intent: 'error',
+			text: 'Expired 3 days ago',
+		} );
+	} );
+
+	test( 'uses the singular for one day', () => {
+		expect( getExpiredCopy( daysFromNow( -1 ) ).text ).toBe( 'Expired 1 day ago' );
+	} );
+
+	test( 'reads as today on the day itself', () => {
+		expect( getExpiredCopy( daysFromNow( 0 ) ).text ).toBe( 'Expired today' );
+	} );
+
+	test( 'never points forwards, even if the date has not arrived', () => {
+		expect( getExpiredCopy( daysFromNow( 3 ) ).text ).toBe( 'Expired today' );
+	} );
+
+	test( 'still counts the days at the edge of the window', () => {
+		expect( getExpiredCopy( daysFromNow( -60 ) ).text ).toBe( 'Expired 60 days ago' );
+	} );
+
+	test( 'stops counting days once an exact count reads badly', () => {
+		// Which larger unit it rounds to is `getRelativeDayString`'s business, so
+		// this only asserts that the day count is gone.
+		expect( getExpiredCopy( daysFromNow( -61 ) ).text ).not.toMatch( /\d+ days? ago/ );
+		expect( getExpiredCopy( daysFromNow( -400 ) ).text ).toBe( 'Expired 1 year ago' );
+	} );
+} );

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -37,6 +37,7 @@ import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getRenewalItemFromProduct } from 'calypso/lib/cart-values/cart-items';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { addQueryArgs } from 'calypso/lib/url';
 import {
 	isMarketplaceHoldingSitePurchase,
 	isA4AHoldingSitePurchase,
@@ -343,12 +344,13 @@ export function getSubscriptionEndDate( purchase: Purchase ): string {
  * @param {string} siteSlug - the site slug to renew the purchase for
  * @param {Object} [options] - optional information
  * @param {string} [options.redirectTo] - Passed as redirect_to in checkout
+ * @param {string} [options.cancelTo] - Passed as cancel_to in checkout
  * @param {Object} [options.tracksProps] - where was the renew button clicked from
  */
 export function handleRenewNowClick(
 	purchase: Purchase,
 	siteSlug: string,
-	options: { redirectTo?: string; tracksProps?: TracksProps } = {}
+	options: { redirectTo?: string; cancelTo?: string; tracksProps?: TracksProps } = {}
 ) {
 	return ( dispatch: CalypsoDispatch ) => {
 		try {
@@ -379,9 +381,11 @@ export function handleRenewNowClick(
 			let renewalUrl = `/checkout/${ serviceSlug }${ productSlugs[ 0 ] }/renew/${
 				purchaseIds[ 0 ]
 			}/${ siteSlug || '' }`;
-			if ( options.redirectTo ) {
-				renewalUrl += '?redirect_to=' + encodeURIComponent( options.redirectTo );
-			}
+
+			renewalUrl = addQueryArgs(
+				{ redirect_to: options.redirectTo, cancel_to: options.cancelTo },
+				renewalUrl
+			);
 			debug( 'handling renewal click', purchase, siteSlug, renewItem, renewalUrl );
 
 			page(

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -294,7 +294,7 @@ class ManagePurchase extends Component<
 			return;
 		}
 
-		const options = redirectTo ? { redirectTo } : undefined;
+		const options = { redirectTo, tracksProps: { position: 'manage-purchase' } };
 		const isSitelessRenewal =
 			isAkismetHoldingSitePurchase( purchase ) ||
 			isMarketplaceHoldingSitePurchase( purchase ) ||
@@ -353,6 +353,22 @@ class ManagePurchase extends Component<
 		return domain?.pendingRegistrationAtRegistry ?? false;
 	}
 
+	/**
+	 * The prominent renewal control. Note that the "Renew now" nav item further
+	 * down applies fewer conditions than this, so there are purchases it offers
+	 * to renew that this one does not. Whether that difference is intentional
+	 * isn't clear.
+	 *
+	 * The purchase list applies the same conditions to its own renewal link:
+	 * both the ones below and the ownership and lock checks in the JSX that
+	 * renders this. It copied this control rather than the nav item because the
+	 * purchase list link is prominent in the same way this one is.
+	 *
+	 * The conditions are repeated rather than shared because this page reads the
+	 * raw `@automattic/api-core` purchase while the list still reads the
+	 * camelCase `@automattic/data-stores` one (SHILL-2256), so each side needs
+	 * different field names.
+	 */
 	renderRenewButton() {
 		const { purchase, translate } = this.props;
 		if ( ! purchase ) {
@@ -1475,6 +1491,10 @@ class ManagePurchase extends Component<
 				) }
 				{ isProductOwner && ! purchase.is_locked && (
 					<>
+						{ /* Applies fewer conditions than `renderRenewButton` above, which also
+						     rules out partner-managed, non-renewable, site-less and free
+						     Akismet subscriptions. Whether that difference is intentional
+						     isn't clear. */ }
 						{ ! preventRenewal &&
 							! renderMonthlyRenewalOption &&
 							! isActive100YearPurchase &&

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -10,6 +10,7 @@ import {
 	isJetpackPlan,
 	isJetpackProduct,
 	getPlan,
+	is100Year,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { CompactCard, Gridicon } from '@automattic/components';
@@ -17,9 +18,9 @@ import { formatCurrency } from '@automattic/number-formatters';
 import { CALYPSO_CONTACT } from '@automattic/urls';
 import { getPaymentMethodImageURL, razorpayImage as upiImage } from '@automattic/wpcom-checkout';
 import { ExternalLink, Button } from '@wordpress/components';
-import { Icon, cautionFilled as warningIcon } from '@wordpress/icons';
+import { Icon, arrowUpRight, cautionFilled as warningIcon } from '@wordpress/icons';
 import clsx from 'clsx';
-import { fixMe, localize, useTranslate } from 'i18n-calypso';
+import { localize, useTranslate } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import akismetIcon from 'calypso/assets/images/icons/akismet-icon.svg';
@@ -30,6 +31,13 @@ import SiteIcon from 'calypso/blocks/site-icon';
 import InfoPopover from 'calypso/components/info-popover';
 import { withLocalizedMoment, useLocalizedMoment } from 'calypso/components/localized-moment';
 import { getCalendarDaysUntil, getRelativeDayString } from 'calypso/dashboard/utils/datetime';
+import { EXPIRY_ERROR_DAYS, EXPIRY_WARNING_DAYS } from 'calypso/dashboard/utils/purchase';
+import {
+	getExpiredCopy,
+	getExpiredRenewalTitle,
+	getExpiringSoonCopy,
+	getExpiringSoonRenewalTitle,
+} from 'calypso/dashboard/utils/purchase-expiry-copy';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import {
@@ -41,7 +49,8 @@ import {
 	isIncludedWithPlan,
 	isOneTimePurchase,
 	isPartnerPurchase,
-	isRecentMonthlyPurchase,
+	isRenewable,
+	isCloseToExpiration,
 	isRenewingBeforeExpiration,
 	isRemoved,
 	purchaseType,
@@ -53,8 +62,11 @@ import {
 	hasPaymentMethod,
 	isPaidWithCredits,
 	mightStillAutoRenew,
+	handleRenewNowClick,
 } from 'calypso/lib/purchases';
 import { getPurchaseListUrlFor } from 'calypso/my-sites/purchases/paths';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import getSiteIconUrl from 'calypso/state/selectors/get-site-icon-url';
 import { getSite } from 'calypso/state/sites/selectors';
 import { isTransferredOwnership } from '../hooks/use-is-transferred-ownership';
@@ -69,6 +81,7 @@ import OwnerInfo from './owner-info';
 import type { Purchases, SiteDetails } from '@automattic/data-stores';
 import 'calypso/me/purchases/style.scss';
 import type { Site } from 'calypso/blocks/site-icon';
+import type { ExpiryStatusCopy } from 'calypso/dashboard/utils/purchase-expiry-copy';
 import type { GetManagePurchaseUrlFor } from 'calypso/lib/purchases/types';
 import type { AppState } from 'calypso/types';
 import type { LocalizeProps } from 'i18n-calypso';
@@ -313,6 +326,130 @@ export function PurchaseItemProduct( {
 	return productType;
 }
 
+/**
+ * The expiry status of a subscription that is close to expiring or has already
+ * expired: colored to draw attention, and linked to renewal checkout where
+ * renewing is something the viewer can act on right now.
+ *
+ * Expiry further off than the warning window is not urgent, and is rendered as
+ * plain text by the caller rather than through here.
+ */
+function UrgentExpiryStatus( {
+	purchase,
+	copy,
+	hasExpired,
+	untranslatedFallbackText,
+	isDisconnectedSite,
+	impression,
+}: {
+	purchase: Purchases.Purchase;
+	copy: ExpiryStatusCopy;
+
+	/**
+	 * Whether `copy` describes a lapsed subscription rather than one still
+	 * heading for expiry. Taken from the caller because that is decided by the
+	 * subscription's status, which can disagree with its date in both
+	 * directions — and the tooltip has to read the same way the status does.
+	 */
+	hasExpired: boolean;
+
+	/**
+	 * Wording for locales that have no translation for `copy` yet. A `ReactNode`
+	 * because that older sentence interpolates the date into an element. Both
+	 * this and `copy.text`'s nullability go away once the copy is translated.
+	 */
+	untranslatedFallbackText?: React.ReactNode;
+	isDisconnectedSite?: boolean;
+
+	/** Rendered alongside the status, but outside the renewal link. */
+	impression: React.ReactNode;
+} ) {
+	const dispatch = useDispatch();
+	const moment = useLocalizedMoment();
+	const currentUserId = useSelector( getCurrentUserId );
+	const expiry = moment( purchase.expiryDate );
+	const className =
+		copy.intent === 'error' ? 'purchase-item__is-error' : 'purchase-item__is-warning';
+	const expiryText = copy.text ?? untranslatedFallbackText;
+
+	// The same conditions as `renderRenewButton` in `manage-purchase/index.tsx`:
+	// both the ones inside it and the ownership and lock checks in the JSX that
+	// renders it. That page also has a "Renew now" nav item which applies fewer
+	// conditions, and it isn't clear whether the difference between the two is
+	// intentional; these were copied from the header control because the link
+	// below is prominent in the same way that one is.
+	//
+	// Repeated rather than shared because that page reads the raw
+	// `@automattic/api-core` purchase and this list still reads the camelCase
+	// `@automattic/data-stores` one (SHILL-2256), so each side needs different
+	// field names.
+	const canRenewNow =
+		( ! isPartnerPurchase( purchase ) || isA4ABillingDragonPurchase( purchase ) ) &&
+		isRenewable( purchase ) &&
+		( ! isDisconnectedSite ||
+			isAkismetHoldingSitePurchase( purchase ) ||
+			isMarketplaceHoldingSitePurchase( purchase ) ||
+			isA4ABillingDragonPurchase( purchase ) ) &&
+		! isAkismetFreeProduct( purchase ) &&
+		! ( is100Year( purchase ) && ! isCloseToExpiration( purchase ) ) &&
+		purchase.canExplicitRenew &&
+		purchase.userId === currentUserId &&
+		! purchase.isLocked;
+
+	// How close to expiry a subscription has to be before renewal is worth
+	// offering. A monthly subscription is never far from expiring, so the annual
+	// window would ask for a renewal within days of the purchase; it gets the
+	// last week instead. Anything already past its expiry date is inside either.
+	const renewalWindowDays =
+		purchase.billPeriodDays === PLAN_MONTHLY_PERIOD ? EXPIRY_ERROR_DAYS : EXPIRY_WARNING_DAYS;
+	const daysUntilExpiry = getCalendarDaysUntil( expiry.toDate() );
+	const isRenewalWorthOffering = canRenewNow && daysUntilExpiry <= renewalWindowDays;
+
+	if ( ! isRenewalWorthOffering ) {
+		return (
+			<span className={ className } title={ expiry.format( 'LL' ) }>
+				{ expiryText }
+				{ impression }
+			</span>
+		);
+	}
+
+	const renewalTitle = hasExpired
+		? getExpiredRenewalTitle( expiry.format( 'LL' ) )
+		: getExpiringSoonRenewalTitle( expiry.format( 'LL' ) );
+
+	return (
+		<span className={ className }>
+			<button
+				className="purchase-item__expiry-link"
+				// On the button rather than the wrapper, so that it describes the
+				// control to a screen reader as well as showing on hover.
+				title={ renewalTitle ?? expiry.format( 'LL' ) }
+				onClick={ ( event ) => {
+					event.preventDefault();
+					event.stopPropagation();
+					// Come back to the list afterwards, whether the renewal goes
+					// through or is abandoned, since that is where they were.
+					// Absolute, since checkout runs on wordpress.com and the purchase
+					// listing page can run on other hosts like Jetpack Cloud and A4A.
+					const backUrl = window.location.href;
+					dispatch(
+						handleRenewNowClick( purchase, purchase.siteSlug ?? '', {
+							redirectTo: backUrl,
+							cancelTo: backUrl,
+							tracksProps: { position: 'purchase-list' },
+						} )
+					);
+				} }
+			>
+				{ expiryText }
+				<Icon icon={ arrowUpRight } size={ 18 } />
+			</button>
+			{ impression }
+		</span>
+	);
+}
+
 export function PurchaseItemStatus( {
 	purchase,
 	translate,
@@ -325,6 +462,7 @@ export function PurchaseItemStatus( {
 	isDisconnectedSite?: boolean;
 } ) {
 	const expiry = moment( purchase.expiryDate );
+
 	// @todo: There isn't currently a way to get the taxName based on the
 	// country. The country is not included in the purchase information
 	// envelope. We should add this information so we can utilize useTaxName
@@ -590,52 +728,42 @@ export function PurchaseItemStatus( {
 	}
 
 	if ( isExpiring( purchase ) && ! isAkismetFreeProduct( purchase ) ) {
-		const expiresOnText = translate( 'Expires on {{span}}%s{{/span}}', {
-			args: expiry.format( 'LL' ),
-			components: {
-				span: <span className="purchase-item__date" />,
-			},
-		} );
-		const daysUntilExpiry = getCalendarDaysUntil( expiry.toDate() );
+		const copy = getExpiringSoonCopy( expiry.toDate() );
 
-		// Covers both "later today" and a purchase whose expiry date has passed
-		// but which the backend still reports as expiring.
-		if ( daysUntilExpiry <= 0 ) {
-			return (
-				<span className="purchase-item__is-error">
-					{ fixMe( {
-						text: 'Expires today',
-						newCopy: translate( 'Expires today' ),
-						oldCopy: expiresOnText,
-					} ) }
-					<TrackImpression warning="purchase-expiring" />
-				</span>
-			);
+		if ( ! copy ) {
+			return translate( 'Expires on {{span}}%s{{/span}}', {
+				args: expiry.format( 'LL' ),
+				components: {
+					span: <span className="purchase-item__date" />,
+				},
+			} );
 		}
 
-		if ( daysUntilExpiry <= 30 && ! isRecentMonthlyPurchase( purchase ) ) {
-			const expiryClass =
-				daysUntilExpiry <= 7 ? 'purchase-item__is-error' : 'purchase-item__is-warning';
+		// Only reached where the day-count copy has no translation yet. Delete
+		// this and the prop it is passed to once it does; see `getExpiringSoonCopy`.
+		const untranslatedFallbackText = translate(
+			'Expires %(timeUntilExpiry)s on {{span}}%(date)s{{/span}}',
+			{
+				args: {
+					timeUntilExpiry: getRelativeDayString( expiry.toDate(), 'upcoming' ),
+					date: expiry.format( 'LL' ),
+				},
+				components: {
+					span: <span className="purchase-item__date" />,
+				},
+			}
+		);
 
-			return (
-				<span className={ expiryClass }>
-					{ translate( 'Expires %(timeUntilExpiry)s on {{span}}%(date)s{{/span}}', {
-						args: {
-							// The branch above already excludes today and past dates, but
-							// the clamp keeps that guarantee local to this call.
-							timeUntilExpiry: getRelativeDayString( expiry.toDate(), 'upcoming' ),
-							date: expiry.format( 'LL' ),
-						},
-						components: {
-							span: <span className="purchase-item__date" />,
-						},
-					} ) }
-					<TrackImpression warning="purchase-expiring" />
-				</span>
-			);
-		}
-
-		return expiresOnText;
+		return (
+			<UrgentExpiryStatus
+				purchase={ purchase }
+				copy={ copy }
+				hasExpired={ false }
+				untranslatedFallbackText={ untranslatedFallbackText }
+				isDisconnectedSite={ isDisconnectedSite }
+				impression={ <TrackImpression warning="purchase-expiring" /> }
+			/>
+		);
 	}
 
 	if ( isExpiredOrRemoved( purchase ) ) {
@@ -645,24 +773,14 @@ export function PurchaseItemStatus( {
 			} );
 		}
 
-		// getCalendarDaysUntil counts forward, so this is negative once the expiry
-		// date has passed. Anything else means the expiry lands today or later —
-		// later being a purchase removed ahead of its expiry date — and both read
-		// as "Expired today" rather than "Expired in 3 days".
-		const expiredBeforeToday = getCalendarDaysUntil( expiry.toDate() ) < 0;
-		const expiredTodayText = translate( 'Expired today' );
-		const expiredFromNowText = translate( 'Expired %(timeSinceExpiry)s', {
-			args: {
-				timeSinceExpiry: getRelativeDayString( expiry.toDate(), 'past' ),
-			},
-			context: 'timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"',
-		} );
-
 		return (
-			<span className="purchase-item__is-error">
-				{ expiredBeforeToday ? expiredFromNowText : expiredTodayText }
-				<TrackImpression warning="purchase-expired" />
-			</span>
+			<UrgentExpiryStatus
+				purchase={ purchase }
+				copy={ getExpiredCopy( expiry.toDate() ) }
+				hasExpired
+				isDisconnectedSite={ isDisconnectedSite }
+				impression={ <TrackImpression warning="purchase-expired" /> }
+			/>
 		);
 	}
 

--- a/client/me/purchases/purchase-item/test/index.js
+++ b/client/me/purchases/purchase-item/test/index.js
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { screen } from '@testing-library/react';
+import { defaultI18n } from '@wordpress/i18n';
 import i18n from 'i18n-calypso';
 import MockDate from 'mockdate';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
@@ -18,9 +19,10 @@ describe( 'PurchaseItem', () => {
 
 	afterEach( () => {
 		MockDate.reset();
-		// i18n-calypso is a module-level singleton, so translations added by one
-		// test would otherwise change the copy every later test asserts on.
+		// Both i18n libraries are module-level singletons, so translations added
+		// by one test would otherwise change the copy every later test asserts on.
 		i18n.setLocale();
+		defaultI18n.resetLocaleData();
 	} );
 
 	describe( 'a purchase that expired earlier today', () => {
@@ -39,7 +41,11 @@ describe( 'PurchaseItem', () => {
 
 		test( 'should be described with a translated label', () => {
 			const translation = 'Vandaag verlopen';
+			// The expiry copy comes from a helper shared with the dashboard, which
+			// reads @wordpress/i18n. In the app `CalypsoI18nProvider` keeps the two
+			// in step; nothing mounts it here, so both are set directly.
 			i18n.addTranslations( { 'Expired today': [ translation ] } );
+			defaultI18n.setLocaleData( { 'Expired today': [ translation ] } );
 
 			renderWithProvider( <PurchaseItem purchase={ purchase } /> );
 
@@ -112,7 +118,7 @@ describe( 'PurchaseItem', () => {
 		} );
 	} );
 
-	describe( 'a purchase expiring within the next 30 days', () => {
+	describe( 'a purchase expiring soon', () => {
 		const purchase = {
 			productSlug: 'business-bundle',
 			expiryStatus: 'manualRenew',
@@ -124,7 +130,43 @@ describe( 'PurchaseItem', () => {
 		test( 'should count the same calendar days as the date it displays', () => {
 			renderWithProvider( <PurchaseItem purchase={ purchase } /> );
 
-			expect( screen.getByText( /expires in 3 days on/i ) ).toBeInTheDocument();
+			expect( screen.getByText( /expires in 3 days/i ) ).toHaveAttribute(
+				'title',
+				'February 27, 2026'
+			);
+		} );
+	} );
+
+	describe( 'a purchase expiring further out', () => {
+		const purchase = {
+			productSlug: 'business-bundle',
+			expiryStatus: 'manualRenew',
+			subscriptionStatus: 'active',
+			// 45 days out, which the relative-date helpers would round to "1 month".
+			expiryDate: '2026-04-10T12:00:00+00:00',
+		};
+
+		test( 'should count the days exactly rather than rounding to months', () => {
+			renderWithProvider( <PurchaseItem purchase={ purchase } /> );
+
+			expect( screen.getByText( /expires in 45 days/i ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'a purchase expiring beyond the warning window', () => {
+		const purchase = {
+			productSlug: 'business-bundle',
+			expiryStatus: 'manualRenew',
+			subscriptionStatus: 'active',
+			// 90 days out.
+			expiryDate: '2026-05-25T12:00:00+00:00',
+		};
+
+		test( 'should just say when it expires', () => {
+			renderWithProvider( <PurchaseItem purchase={ purchase } /> );
+
+			expect( screen.getByText( /expires on/i ) ).toBeInTheDocument();
+			expect( screen.queryByText( /expires in/i ) ).toBeNull();
 		} );
 	} );
 

--- a/client/me/purchases/style.scss
+++ b/client/me/purchases/style.scss
@@ -201,30 +201,31 @@ a.purchase-item__link {
 		color: var(--color-error-50);
 		position: relative;
 		display: inline-block;
-
-		@include breakpoint-deprecated( ">960px" ) {
-			&::after {
-				content: "";
-				display: block;
-				width: 8px;
-				height: 8px;
-				position: absolute;
-				top: calc(50% - 4px);
-				left: -16px;
-				background: var(--color-error-50);
-				border-radius: 100%;
-			}
-		}
 	}
 
 	.purchase-item__is-warning {
 		color: var(--color-warning-50);
+	}
+}
 
-		@include breakpoint-deprecated( ">960px" ) {
-			&::after {
-				background: var(--color-warning-50);
-			}
-		}
+// A button that has to read as text: `inline` so it still wraps in the narrow
+// column, and `inherit` so the wrapper's colors come through.
+.purchase-item__expiry-link {
+	display: inline;
+	padding: 0;
+	border: 0;
+	background: none;
+	font: inherit;
+	color: inherit;
+	cursor: pointer;
+	text-decoration: underline;
+
+	svg {
+		// The glyph is inset by a quarter of the icon box on every side, so the
+		// box has to hang below the baseline for the arrow itself to sit near
+		// it. Keep in step with the icon's size.
+		vertical-align: -3.5px;
+		fill: currentColor;
 	}
 }
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2335/implement-the-changes-to-the-purchase-listing-pages-for-expiring-or

## Proposed Changes

This pull request complements the changes to the purchase management detail pages (https://github.com/Automattic/wp-calypso/pull/113195) by implementing smaller changes from the designs that affect the purchase listing pages, for both Calypso and the Dashboard.

This includes tweaks to the text that is printed next to each expiring/expired subscription, changing the warning level to match those used on the purchase detail page, and conditionally rendering the text as a link to checkout, for subscriptions that are close enough to their renewal date for that to make sense.

Unlike the change to the purchase management detail pages, which only affected WordPress.com plans (Personal, Premium, Business, and Commerce), this affects all subscriptions on the purchase listing page, since it would be confusing to have different behaviors for different rows in the same table.

Some of the different possible behaviors are shown in the screenshots below -- everything depends on whether the subscription is expiring soon or already expired. (Note that unlike the purchase management detail pages, we aren't introducing any new warning statuses here for subscriptions that are approaching their expiration date but still scheduled to auto-renew.)

| | Before | After |
| :---: | :---: | :---: |
| Calypso | <img width="1071" height="1426" alt="calypso-BEFORE" src="https://github.com/user-attachments/assets/b26063b6-d0e7-4ea8-a072-fc1ea738b814" /> | <img width="1058" height="1430" alt="calypso-AFTER" src="https://github.com/user-attachments/assets/81cb081f-dc24-4514-ab3a-ac740422ab68" /> |
| Dashboard | <img width="1355" height="1264" alt="dashboard-BEFORE" src="https://github.com/user-attachments/assets/fbaac8c6-f7c1-444a-8eed-a1eb1ca3bd71" /> | <img width="1367" height="1266" alt="dashboard-AFTER" src="https://github.com/user-attachments/assets/f068afab-8d18-4f65-a3b3-4073b9f0b1e8" /> |

## Testing Instructions

I tested Calypso at `/me/purchases` and the Multi-Site Dashboard at `/me/billing/purchases` with a bunch of subscriptions (differently-configured WordPress.com plans, as shown in the above screenshots, but also other types of products) and confirmed that the dates and wording made sense for each, that the renewal links pointed to the correct place, etc.