### PR TITLE
Agents Manager: Keep WooCommerce's parked activity panel off the docked chat

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/page-layout.scss
+++ b/packages/agents-manager/src/components/agent-dock/page-layout.scss
@@ -129,6 +129,18 @@ body.wp-admin.woocommerce-admin-page.agents-manager-sidebar-container {
 		&.folded .woocommerce-layout__header {
 			width: calc( 100% - $admin-sidebar-width-collapsed - $sidebar-width ) !important;
 		}
+
+		// The closed activity panel parks an opaque, viewport-fixed wrapper
+		// (z-index 1000) at the page's right edge; shrinking moves that edge
+		// into the chat strip, and the settled chat has released its z-index,
+		// so the wrapper both paints over the chat and swallows its pointer
+		// events. Neutralize it until it actually opens — an open panel is a
+		// transient overlay that intentionally stacks above the settled chat,
+		// same as the notifications panel.
+		.woocommerce-layout__activity-panel-wrapper:not( .is-open ) {
+			opacity: 0;
+			pointer-events: none;
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes [WOOAI-864](https://linear.app/a8c/issue/WOOAI-864/woocommerce-activity-panel-layer-hides-the-docked-woo-ai-chat) — regression from #113160.

## Proposed Changes

Restore the WooCommerce activity-panel protection that the shrink layout dropped, inside `page-layout.scss`'s existing `wp-admin: WooCommerce` section:

```scss
.woocommerce-layout__activity-panel-wrapper:not( .is-open ) {
	opacity: 0;
	pointer-events: none;
}
```

## Why

#113160 retired `fixes-woocommerce.scss`, including the rule that hid WooCommerce's **closed** activity panel while the dock is open. That closed panel parks an opaque, viewport-anchored wrapper (`z-index: 1000`, 430px wide) at the page's right edge. The shrink layout moves that edge into the chat strip, and the settled chat deliberately releases its z-index — so on every wp-admin page that renders the wrapper (Orders, Products, Coupons, Analytics, WooCommerce Home, Woo AI Overview, …) the wrapper paints over the docked chat and swallows its pointer events. Verified live against WC 11.0-rc.3: closed wrapper at `right: 0`, `width: 430px`, `z-index: 1000`, opaque background, no `is-open` class.

One deliberate addition over the old rule: **`pointer-events: none`**. `opacity: 0` alone was only sufficient before because the framed layout force-elevated the chat's z-index (`$agents-manager-z-index-docked !important`); under the new released stacking, an invisible wrapper still wins hit-testing. Reinstating a blanket chat z-index is explicitly avoided — admin menus, notifications, and modals rely on the released stacking.

An **open** activity panel is untouched: it remains a transient overlay that stacks above the settled chat, the same call #113160 made for the notifications panel.

## Testing Instructions

**wp-admin (where the bug lives) — sandbox:**
1. `cd apps/agents-manager && yarn dev --sync`, sandbox `widgets.wp.com`.
2. On a WooCommerce site with an agent provider (e.g. Woo AI), viewport ≥ 1200px, open the docked chat.
3. Visit **Orders**, **Products**, **Analytics → Overview**, and **WooCommerce → Home**: the docked chat is fully visible and clickable (before this fix, a gray panel covers it and clicks land on the invisible wrapper).
4. Open the **activity panel** (bell/inbox tab in the WC header): it opens and is usable, overlaying the chat while open; closing it returns the chat.
5. Control pages: **WooCommerce → Settings**, **Plugins**, **Dashboard** — unchanged (no wrapper there).
6. Below 1200px the floating presentation is unaffected.

**Calypso (`yarn start`):** no behavior change expected — the rule is scoped to `body.wp-admin.woocommerce-admin-page`; spot-check a docked chat on Calypso surfaces for no regressions.

cc @WellyShen (author of #113160), @peterfabian (assigned to WOOAI-864)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrR3712gF5nmbbomZ82Fs1