### PR TITLE
Site Chat: skip unavailable persisted state request

### DIFF
--- a/packages/agents-manager/src/__tests__/stores.test.ts
+++ b/packages/agents-manager/src/__tests__/stores.test.ts
@@ -1,0 +1,32 @@
+jest.mock( '@automattic/data-stores', () => ( {
+	AgentsManager: {
+		register: jest.fn( () => 'automattic/agents-manager' ),
+		persistAgentsManagerState: jest.fn(),
+	},
+} ) );
+
+jest.mock( '../utils/is-reader-chat-agent', () => ( {
+	isReaderChatHost: jest.fn(),
+} ) );
+
+import { AgentsManager } from '@automattic/data-stores';
+import { isReaderChatHost } from '../utils/is-reader-chat-agent';
+import '../stores';
+
+const mockRegister = AgentsManager.register as jest.MockedFunction< typeof AgentsManager.register >;
+const mockIsReaderChatHost = isReaderChatHost as jest.MockedFunction< typeof isReaderChatHost >;
+
+describe( 'Agents Manager store', () => {
+	it( 'loads persisted state only for non-Reader Chat hosts', () => {
+		const shouldLoadPersistedState = mockRegister.mock.calls[ 0 ]?.[ 0 ]?.shouldLoadPersistedState;
+		if ( ! shouldLoadPersistedState ) {
+			throw new Error( 'Expected the store to register a persisted-state callback.' );
+		}
+
+		mockIsReaderChatHost.mockReturnValue( false );
+		expect( shouldLoadPersistedState() ).toBe( true );
+
+		mockIsReaderChatHost.mockReturnValue( true );
+		expect( shouldLoadPersistedState() ).toBe( false );
+	} );
+} );

--- a/packages/agents-manager/src/__tests__/stores.test.ts
+++ b/packages/agents-manager/src/__tests__/stores.test.ts
@@ -17,16 +17,16 @@ const mockRegister = AgentsManager.register as jest.MockedFunction< typeof Agent
 const mockIsReaderChatHost = isReaderChatHost as jest.MockedFunction< typeof isReaderChatHost >;
 
 describe( 'Agents Manager store', () => {
-	it( 'loads persisted state only for non-Reader Chat hosts', () => {
-		const shouldLoadPersistedState = mockRegister.mock.calls[ 0 ]?.[ 0 ]?.shouldLoadPersistedState;
-		if ( ! shouldLoadPersistedState ) {
+	it( 'uses persisted state only for non-Reader Chat hosts', () => {
+		const shouldUsePersistedState = mockRegister.mock.calls[ 0 ]?.[ 0 ]?.shouldUsePersistedState;
+		if ( ! shouldUsePersistedState ) {
 			throw new Error( 'Expected the store to register a persisted-state callback.' );
 		}
 
 		mockIsReaderChatHost.mockReturnValue( false );
-		expect( shouldLoadPersistedState() ).toBe( true );
+		expect( shouldUsePersistedState() ).toBe( true );
 
 		mockIsReaderChatHost.mockReturnValue( true );
-		expect( shouldLoadPersistedState() ).toBe( false );
+		expect( shouldUsePersistedState() ).toBe( false );
 	} );
 } );

--- a/packages/agents-manager/src/stores.ts
+++ b/packages/agents-manager/src/stores.ts
@@ -2,8 +2,11 @@
  * External Dependencies
  */
 import { AgentsManager } from '@automattic/data-stores';
+import { isReaderChatHost } from './utils/is-reader-chat-agent';
 
-export const AGENTS_MANAGER_STORE = AgentsManager.register();
+export const AGENTS_MANAGER_STORE = AgentsManager.register( {
+	shouldLoadPersistedState: () => ! isReaderChatHost(),
+} );
 
 // Serializes + coalesces concurrent saves so they can't clobber each other on
 // the server's shared prefs blob. Re-exported here so the rest of the package

--- a/packages/agents-manager/src/stores.ts
+++ b/packages/agents-manager/src/stores.ts
@@ -5,7 +5,7 @@ import { AgentsManager } from '@automattic/data-stores';
 import { isReaderChatHost } from './utils/is-reader-chat-agent';
 
 export const AGENTS_MANAGER_STORE = AgentsManager.register( {
-	shouldLoadPersistedState: () => ! isReaderChatHost(),
+	shouldUsePersistedState: () => ! isReaderChatHost(),
 } );
 
 // Serializes + coalesces concurrent saves so they can't clobber each other on

--- a/packages/data-stores/src/agents-manager/index.ts
+++ b/packages/data-stores/src/agents-manager/index.ts
@@ -14,12 +14,19 @@ export { persistAgentsManagerState } from './persist-state';
 
 let isRegistered = false;
 
-export function register(): typeof STORE_KEY {
+type RegisterOptions = {
+	shouldLoadPersistedState?: () => boolean;
+};
+
+export function register( options: RegisterOptions = {} ): typeof STORE_KEY {
 	if ( isRegistered ) {
 		return STORE_KEY;
 	}
 
 	registerPlugins();
+	const resolveAgentsManagerState = function* () {
+		yield* getAgentsManagerState( options.shouldLoadPersistedState );
+	};
 
 	registerStore( STORE_KEY, {
 		actions,
@@ -28,7 +35,7 @@ export function register(): typeof STORE_KEY {
 		selectors,
 		persist: [],
 		// Don't restore persisted state for e2e users, because parallel tests will start interfering with each other.
-		resolvers: isE2ETest() ? undefined : { getAgentsManagerState },
+		resolvers: isE2ETest() ? undefined : { getAgentsManagerState: resolveAgentsManagerState },
 	} );
 
 	isRegistered = true;

--- a/packages/data-stores/src/agents-manager/index.ts
+++ b/packages/data-stores/src/agents-manager/index.ts
@@ -5,6 +5,7 @@ import { isE2ETest } from '../utils';
 import { controls as wpcomRequestControls } from '../wpcom-request-controls';
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
+import { setShouldPersistState } from './persist-state';
 import reducer, { State } from './reducer';
 import { getAgentsManagerState } from './resolvers';
 import * as selectors from './selectors';
@@ -15,7 +16,7 @@ export { persistAgentsManagerState } from './persist-state';
 let isRegistered = false;
 
 type RegisterOptions = {
-	shouldLoadPersistedState?: () => boolean;
+	shouldUsePersistedState?: () => boolean;
 };
 
 export function register( options: RegisterOptions = {} ): typeof STORE_KEY {
@@ -24,8 +25,10 @@ export function register( options: RegisterOptions = {} ): typeof STORE_KEY {
 	}
 
 	registerPlugins();
+	const shouldUsePersistedState = options.shouldUsePersistedState ?? ( () => true );
+	setShouldPersistState( shouldUsePersistedState );
 	const resolveAgentsManagerState = function* () {
-		yield* getAgentsManagerState( options.shouldLoadPersistedState );
+		yield* getAgentsManagerState( shouldUsePersistedState );
 	};
 
 	registerStore( STORE_KEY, {

--- a/packages/data-stores/src/agents-manager/persist-state.ts
+++ b/packages/data-stores/src/agents-manager/persist-state.ts
@@ -14,6 +14,11 @@ import type { APIFetchOptions } from '../shared-types';
  */
 let pending: Record< string, unknown > = {};
 let inFlight = false;
+let shouldPersistState = () => true;
+
+export function setShouldPersistState( predicate: () => boolean ): void {
+	shouldPersistState = predicate;
+}
 
 function send( state: Record< string, unknown > ): Promise< unknown > {
 	if ( canAccessWpcomApis() ) {
@@ -55,6 +60,10 @@ function flush(): void {
  * @param state - Object with the prefs to save (e.g. `{ agents_manager_minimized: false }`).
  */
 export function persistAgentsManagerState( state: Record< string, unknown > ): void {
+	if ( ! shouldPersistState() ) {
+		return;
+	}
+
 	Object.assign( pending, state );
 	flush();
 }

--- a/packages/data-stores/src/agents-manager/resolvers.ts
+++ b/packages/data-stores/src/agents-manager/resolvers.ts
@@ -37,8 +37,8 @@ type AgentsManagerStateResponse = {
 	agents_manager_last_activity?: PerSiteLastActivity;
 };
 
-export function* getAgentsManagerState( shouldLoadPersistedState: () => boolean = () => true ) {
-	if ( ! shouldLoadPersistedState() ) {
+export function* getAgentsManagerState( shouldUsePersistedState: () => boolean ) {
+	if ( ! shouldUsePersistedState() ) {
 		yield setHasLoaded( true );
 		return;
 	}

--- a/packages/data-stores/src/agents-manager/resolvers.ts
+++ b/packages/data-stores/src/agents-manager/resolvers.ts
@@ -37,7 +37,12 @@ type AgentsManagerStateResponse = {
 	agents_manager_last_activity?: PerSiteLastActivity;
 };
 
-export function* getAgentsManagerState() {
+export function* getAgentsManagerState( shouldLoadPersistedState: () => boolean = () => true ) {
+	if ( ! shouldLoadPersistedState() ) {
+		yield setHasLoaded( true );
+		return;
+	}
+
 	yield setIsLoading( true );
 	try {
 		const state: AgentsManagerStateResponse = canAccessWpcomApis()

--- a/packages/data-stores/src/agents-manager/test/persist-state.test.ts
+++ b/packages/data-stores/src/agents-manager/test/persist-state.test.ts
@@ -1,6 +1,6 @@
 import apiFetch from '@wordpress/api-fetch';
 import wpcomRequest, { canAccessWpcomApis } from '../../wpcom-request';
-import { persistAgentsManagerState } from '../persist-state';
+import { persistAgentsManagerState, setShouldPersistState } from '../persist-state';
 
 jest.mock( '@wordpress/api-fetch', () => ( {
 	__esModule: true,
@@ -23,9 +23,20 @@ const tick = () => new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
 describe( 'persistAgentsManagerState', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		setShouldPersistState( () => true );
 		mockCanAccess.mockReturnValue( true );
 		mockRequest.mockResolvedValue( undefined );
 		mockApiFetch.mockResolvedValue( undefined );
+	} );
+
+	it( 'skips save requests when the host opts out of persisted state', () => {
+		setShouldPersistState( () => false );
+
+		persistAgentsManagerState( { agents_manager_router_history: 'a' } );
+
+		expect( mockCanAccess ).not.toHaveBeenCalled();
+		expect( mockRequest ).not.toHaveBeenCalled();
+		expect( mockApiFetch ).not.toHaveBeenCalled();
 	} );
 
 	it( 'sends a single save as one wpcom request', async () => {

--- a/packages/data-stores/src/agents-manager/test/resolvers.test.ts
+++ b/packages/data-stores/src/agents-manager/test/resolvers.test.ts
@@ -1,0 +1,41 @@
+import { apiFetch } from '@wordpress/data-controls';
+import { canAccessWpcomApis } from '../../wpcom-request';
+import { setHasLoaded, setIsLoading } from '../actions';
+import { getAgentsManagerState } from '../resolvers';
+
+jest.mock( '../../wpcom-request', () => ( {
+	canAccessWpcomApis: jest.fn(),
+} ) );
+
+const mockCanAccessWpcomApis = canAccessWpcomApis as jest.MockedFunction<
+	typeof canAccessWpcomApis
+>;
+
+describe( 'Agents Manager resolvers', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'skips persisted state requests when the host opts out', () => {
+		const shouldLoadPersistedState = jest.fn( () => false );
+		const resolver = getAgentsManagerState( shouldLoadPersistedState );
+
+		expect( resolver.next().value ).toEqual( setHasLoaded( true ) );
+		expect( resolver.next().done ).toBe( true );
+		expect( shouldLoadPersistedState ).toHaveBeenCalledTimes( 1 );
+		expect( mockCanAccessWpcomApis ).not.toHaveBeenCalled();
+	} );
+
+	it( 'keeps loading persisted state by default', () => {
+		mockCanAccessWpcomApis.mockReturnValue( false );
+		const resolver = getAgentsManagerState();
+
+		expect( resolver.next().value ).toEqual( setIsLoading( true ) );
+		expect( resolver.next().value ).toEqual(
+			apiFetch( {
+				global: true,
+				path: '/agents-manager/open-state',
+			} )
+		);
+	} );
+} );

--- a/packages/data-stores/src/agents-manager/test/resolvers.test.ts
+++ b/packages/data-stores/src/agents-manager/test/resolvers.test.ts
@@ -4,6 +4,8 @@ import { setHasLoaded, setIsLoading } from '../actions';
 import { getAgentsManagerState } from '../resolvers';
 
 jest.mock( '../../wpcom-request', () => ( {
+	__esModule: true,
+	default: jest.fn(),
 	canAccessWpcomApis: jest.fn(),
 } ) );
 
@@ -17,18 +19,18 @@ describe( 'Agents Manager resolvers', () => {
 	} );
 
 	it( 'skips persisted state requests when the host opts out', () => {
-		const shouldLoadPersistedState = jest.fn( () => false );
-		const resolver = getAgentsManagerState( shouldLoadPersistedState );
+		const shouldUsePersistedState = jest.fn( () => false );
+		const resolver = getAgentsManagerState( shouldUsePersistedState );
 
 		expect( resolver.next().value ).toEqual( setHasLoaded( true ) );
 		expect( resolver.next().done ).toBe( true );
-		expect( shouldLoadPersistedState ).toHaveBeenCalledTimes( 1 );
+		expect( shouldUsePersistedState ).toHaveBeenCalledTimes( 1 );
 		expect( mockCanAccessWpcomApis ).not.toHaveBeenCalled();
 	} );
 
-	it( 'keeps loading persisted state by default', () => {
+	it( 'loads persisted state when the host opts in', () => {
 		mockCanAccessWpcomApis.mockReturnValue( false );
-		const resolver = getAgentsManagerState();
+		const resolver = getAgentsManagerState( () => true );
 
 		expect( resolver.next().value ).toEqual( setIsLoading( true ) );
 		expect( resolver.next().value ).toEqual(


### PR DESCRIPTION
## Proposed Changes

* Allow Agents Manager store consumers to decide whether server-persisted UI state should be loaded.
* Skip the persisted-state resolver on Reader Chat/Site Chat public hosts while still marking the store as loaded.
* Add regression coverage for the skipped public-host path and the unchanged authenticated path.

## Why are these changes being made?

The standalone Site Chat bundle runs on public site frontends, where Agents Manager's authenticated persisted-state endpoint is unavailable. The shared resolver was therefore sending a request to `/agents-manager/open-state`, producing a 404 even though chat continued to work.

Site Chat already keeps its open state in local storage and suppresses server-backed open-state writes, so the public host does not need this resolver. Authenticated editor hosts retain the existing behavior.

## Testing Instructions

Automated checks completed:

* `yarn jest -c test/packages/jest.config.js packages/agents-manager packages/data-stores/src/agents-manager --runInBand --no-watchman` (43 suites, 488 tests)
* `yarn test-apps apps/agents-manager --runInBand --no-watchman` (6 suites, 77 tests)
* `yarn typecheck-packages`
* ESLint and Prettier checks for all changed files
* `yarn workspace @automattic/agents-manager-app build`

Calypso:

1. Run `yarn start`.
2. Open an authenticated Agents Manager surface.
3. In the browser network panel, confirm the persisted-state request still uses `/wp-json/agents-manager/open-state`.
4. Change the chat open state, reload, and confirm it restores.

Sandbox/self-hosted Site Chat:

1. From `apps/agents-manager`, run `yarn dev --sync` against the sandbox.
2. Enable Site Chat on a connected standalone self-hosted site and load its public frontend.
3. Filter the browser network panel for `open-state`; confirm no request is sent.
4. Open and close Site Chat, reload, and confirm its local open state still persists.
5. Start a conversation and confirm messages continue to send and receive.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?