### PR TITLE
Stats: replace commercial-license copy in the purchase flow

### DIFF
--- a/client/my-sites/stats/const.js
+++ b/client/my-sites/stats/const.js
@@ -11,10 +11,6 @@ export const INSIGHTS_SUPPORT_URL =
 	// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
 	'https://wordpress.com/support/stats/learn-insights-about-your-website/';
 
-export const JETPACK_BLOG_ABOUT_COMMERCIAL_STATS_URL =
-	// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
-	'https://jetpack.com/blog/updates-to-jetpack-stats-for-commercial-sites/';
-
 export const JETPACK_SUPPORT_AI_URL = 'https://jetpack.com/ai';
 export const JETPACK_SUPPORT_NEWSLETTER_URL = 'https://jetpack.com/support/newsletter';
 export const JETPACK_SUPPORT_SOCIAL_URL = 'https://jetpack.com/support/jetpack-social/';

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -104,7 +104,7 @@ const PersonalPurchase = ( {
 
 			<div className={ `${ COMPONENT_CLASS_NAME }__notice` }>
 				{ translate(
-					'To unlock UTM tracking, device attribution, commercial use and more, {{Button}}upgrade to a commercial license{{/Button}}.',
+					'To unlock UTM tracking, device attribution and more, {{Button}}upgrade to a paid plan{{/Button}}.',
 					{
 						components: {
 							Button: <Button variant="link" href="#" onClick={ handleClick } />,

--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -205,7 +205,6 @@ const StatsBenefitsPersonal = () => {
 			<ul className={ `${ COMPONENT_CLASS_NAME }__benefits--not-included` }>
 				<li>{ translate( 'No UTM tracking' ) }</li>
 				<li>{ translate( 'No access to upcoming advanced features' ) }</li>
-				<li>{ translate( 'No commercial use' ) }</li>
 			</ul>
 		</div>
 	);
@@ -226,7 +225,6 @@ const StatsBenefitsFree = () => {
 				<li>{ translate( 'No UTM tracking' ) }</li>
 				<li>{ translate( 'No access to upcoming advanced features' ) }</li>
 				<li>{ translate( 'No Email support (supported by forum)' ) }</li>
-				<li>{ translate( 'No commercial use' ) }</li>
 			</ul>
 		</div>
 	);

--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -56,7 +56,6 @@ const StatsBenefitsCommercial = () => {
 	const spikeInfoIconRef = useRef( null );
 	const overageInfoIconRef = useRef( null );
 	const trackingInfoIconRef = useRef( null );
-	const commercialInfoIconRef = useRef( null );
 	const customDateRangesInfoIconRef = useRef( null );
 	const deviceAttributesInfoIconRef = useRef( null );
 	const [ spikeInfoShow, setSpikeInfoShow ] = useState( false );
@@ -68,9 +67,6 @@ const StatsBenefitsCommercial = () => {
 	const [ trackingInfoShow, setTrackingInfoShow ] = useState( false );
 	const handleUTMTrackingPopoverOpen = () => setTrackingInfoShow( true );
 	const handleUTMTrackingPopoverClose = () => setTrackingInfoShow( false );
-	const [ commercialInfoShow, setCommercialInfoShow ] = useState( false );
-	const handleCommercialUsePopoverOpen = () => setCommercialInfoShow( true );
-	const handleCommercialUsePopoverClose = () => setCommercialInfoShow( false );
 	const [ customDateRangesInfoShow, setCustomDateRangesInfoShow ] = useState( false );
 	const handleCustomDatesPopoverOpen = () => setCustomDateRangesInfoShow( true );
 	const handleCustomDatesPopoverClose = () => setCustomDateRangesInfoShow( false );
@@ -87,17 +83,6 @@ const StatsBenefitsCommercial = () => {
 				<li>{ translate( 'GDPR compliance' ) }</li>
 				<li>{ translate( 'Access to upcoming advanced features' ) }</li>
 				<li>{ translate( 'Priority support' ) }</li>
-				<li>
-					{ translate( '{{strong}}Commercial use{{/strong}}', {
-						components: { strong: <strong /> },
-					} ) }
-					<Icon
-						icon={ info }
-						ref={ commercialInfoIconRef }
-						onMouseEnter={ handleCommercialUsePopoverOpen }
-						onMouseLeave={ handleCommercialUsePopoverClose }
-					/>
-				</li>
 				<li>
 					{ translate( 'Custom date ranges' ) }
 					<Icon
@@ -177,18 +162,6 @@ const StatsBenefitsCommercial = () => {
 				<div className="stats-purchase__info-popover-content">
 					{ translate(
 						'It enables you to measure and track traffic through UTM parameters in your URLs, providing a method to assess the success of your campaigns.'
-					) }
-				</div>
-			</Popover>
-			<Popover
-				position="right"
-				isVisible={ commercialInfoShow }
-				context={ commercialInfoIconRef.current }
-				className="stats-purchase__info-popover"
-			>
-				<div className="stats-purchase__info-popover-content">
-					{ translate(
-						'Your Stats license will be valid for commercial use. Any site with commercial activity requires a commercial-use license.'
 					) }
 				</div>
 			</Popover>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -23,7 +23,6 @@ import {
 	getIsSimpleSite,
 } from 'calypso/state/sites/selectors';
 import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
-import { JETPACK_BLOG_ABOUT_COMMERCIAL_STATS_URL } from '../const';
 import useAvailableUpgradeTiers from '../hooks/use-available-upgrade-tiers';
 import useOnDemandCommercialClassificationMutation from '../hooks/use-on-demand-site-identification-mutation';
 import usePlanUsageQuery, { getUsageLimitStatus } from '../hooks/use-plan-usage-query';
@@ -205,12 +204,8 @@ const useLocalizedStrings = ( isCommercial: boolean ) => {
 				args: { product: STATS_PRODUCT_NAME },
 			} ),
 			infoText: translate(
-				'To continue using Stats and access its newest premium features you need to get a commercial license. {{link}}Learn more about this update{{/link}}.',
+				'Unlock UTM stats, device stats, and region and city locations with a paid plan.',
 				{
-					comment: '{{link}} links to explainer post on Jetpack blog.',
-					components: {
-						link: <a href={ JETPACK_BLOG_ABOUT_COMMERCIAL_STATS_URL } />,
-					},
 					context: 'Stats: Descriptive text in the commercial purchase flow',
 				}
 			),
@@ -221,7 +216,7 @@ const useLocalizedStrings = ( isCommercial: boolean ) => {
 	return {
 		pageTitle: translate( 'Simple, yet powerful stats to grow your site' ),
 		infoText: translate(
-			'%(product)s makes it easy to see how your site is doing. No data science skills needed. Start with a commercial license and get premium access to:',
+			'%(product)s makes it easy to see how your site is doing. No data science skills needed. Start with a paid plan and get premium access to:',
 			{ args: { product: STATS_PRODUCT_NAME } }
 		),
 		continueButtonText: translate( 'Get Stats to grow my site' ),

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -206,7 +206,7 @@ const useLocalizedStrings = ( isCommercial: boolean ) => {
 			infoText: translate(
 				'Unlock UTM stats, device stats, and region and city locations with a paid plan.',
 				{
-					context: 'Stats: Descriptive text in the commercial purchase flow',
+					context: 'Stats: Descriptive text in the purchase flow',
 				}
 			),
 			continueButtonText: translate( 'Upgrade now and continue' ),


### PR DESCRIPTION
Part of STATS-399 (parent: STATS-364).

## Proposed Changes

* `stats-purchase-single-item.tsx`: the commercial-flow intro no longer says "you need to get a commercial license" — it now reads "Unlock UTM stats, device stats, and region and city locations with a paid plan." The "Learn more about this update" blog link is dropped with it, and the now-unused `JETPACK_BLOG_ABOUT_COMMERCIAL_STATS_URL` constant is removed from `const.js`. The string's i18n context also drops "commercial" ("Stats: Descriptive text in the purchase flow").
* `stats-purchase-single-item.tsx`: the non-commercial-flow intro now says "Start with a paid plan and get premium access to:" instead of "Start with a commercial license…".
* `stats-purchase-shared.tsx`: removed the "Commercial use" entry (and its info popover saying "Any site with commercial activity requires a commercial-use license") from the paid-plan benefits list, per the issue's rule to drop commercial-use eligibility as a listed benefit. The "No commercial use" rows in the personal and free benefit lists are removed for the same reason — they're the negative mirror of that eligibility framing.
* `stats-purchase-personal.tsx`: the upsell notice now reads "To unlock UTM tracking, device attribution and more, upgrade to a paid plan." — "commercial use" is dropped from the feature list and "commercial license" becomes "paid plan".

Left alone per the issue: `tier-upgrade-notice.tsx`, `stats-purchase-notice.jsx`, `paid-plan-purchase-success-notice.tsx` (they serve people who already pay). The commercial-classification opt-out form strings are unchanged too — they describe eligibility for the free/non-commercial license, not a commercial-license requirement.

## Why are these changes being made?

With commercial-use enforcement retired, purchase-flow copy that tells people they "need a commercial license" or frames the upgrade around their site type no longer matches reality and doesn't sell the product. The copy now leads with the features a paid plan unlocks (UTM stats, device stats, region and city locations). These components are shared between Calypso and Odyssey Stats, so both surfaces pick up the change.

## Screenshots

| Page | Before | After |
| -- | -- | -- |
| `/stats/purchase?productType=commercial` | <img alt="before-commercial" src="https://github.com/user-attachments/assets/337b2530-c7dd-422c-b534-644c38350680" /> | <img alt="after-commercial" src="https://github.com/user-attachments/assets/19b5f50d-cb9e-4480-aa4a-f56988073087" /> |
| `/stats/purchase?productType=personal` | <img alt="before-personal" src="https://github.com/user-attachments/assets/875862e8-baa6-4dec-a899-25f3c07828b1" /> | <img alt="after-personal" src="https://github.com/user-attachments/assets/32ef1258-0351-4021-a47a-251b36aecb2a" /> |

Commercial page: the intro drops "Start with a commercial license…" for "Start with a paid plan…", and the bolded "Commercial use" benefit row is gone. Personal page: the upsell notice drops "commercial use" and links "upgrade to a paid plan" instead of "upgrade to a commercial license".

## Testing Instructions

1. On a site without a paid Stats plan, visit `/stats/purchase/:site?productType=commercial` — the intro under the title should read "Unlock UTM stats, device stats, and region and city locations with a paid plan." (commercially-classified sites) or "…Start with a paid plan and get premium access to:" (others), and the benefits list should no longer include a "Commercial use" row.
2. Visit `/stats/purchase/:site?productType=personal` — the notice above the contribution slider should read "To unlock UTM tracking, device attribution and more, upgrade to a paid plan."
3. On a site with a personal or free Stats license, open the purchase notice — the "not included" lists no longer show "No commercial use".
4. Grep check: `grep -rn "commercial license" client/my-sites/stats/stats-purchase/` returns only opt-out-form strings about the non-commercial license.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?