### PR TITLE
Stats: replace the 'stop the upgrade banners' notice copy with feature-led copy

### DIFF
--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -21,16 +21,9 @@ import { StatsNoticeProps } from './types';
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
-const getStatsPurchaseURL = (
-	siteId: number | null,
-	isOdysseyStats: boolean,
-	hasFreeStats = false
-) => {
+const getStatsPurchaseURL = ( siteId: number | null, isOdysseyStats: boolean ) => {
 	const from = isOdysseyStats ? 'jetpack' : 'calypso';
-	const purchasePath = `/stats/purchase/${ siteId }?from=${ from }-stats-upgrade-notice${
-		hasFreeStats ? '&productType=personal' : ''
-	}`;
-	return purchasePath;
+	return `/stats/purchase/${ siteId }?from=${ from }-stats-upgrade-notice`;
 };
 
 const DoYouLoveJetpackStatsNotice = ( {
@@ -54,9 +47,11 @@ const DoYouLoveJetpackStatsNotice = ( {
 	const { setShowHelpCenter, setShowSupportDoc } = useDataStoreDispatch( HELP_CENTER_STORE );
 
 	const dismissNotice = () => {
-		isOdysseyStats
-			? recordTracksEvent( 'jetpack_odyssey_stats_do_you_love_jetpack_stats_notice_dismissed' )
-			: recordTracksEvent( 'calypso_stats_do_you_love_jetpack_stats_notice_dismissed' );
+		recordTracksEvent(
+			isOdysseyStats
+				? 'jetpack_odyssey_stats_do_you_love_jetpack_stats_notice_dismissed'
+				: 'calypso_stats_do_you_love_jetpack_stats_notice_dismissed'
+		);
 
 		setNoticeDismissed( true );
 		postponeNoticeAsync();
@@ -68,20 +63,18 @@ const DoYouLoveJetpackStatsNotice = ( {
 	};
 
 	const gotoJetpackStatsProduct = () => {
-		isOdysseyStats
-			? recordTracksEvent(
-					'jetpack_odyssey_stats_do_you_love_jetpack_stats_notice_support_button_clicked'
-			  )
-			: recordTracksEvent(
-					'calypso_stats_do_you_love_jetpack_stats_notice_support_button_clicked'
-			  );
+		recordTracksEvent(
+			isOdysseyStats
+				? 'jetpack_odyssey_stats_do_you_love_jetpack_stats_notice_support_button_clicked'
+				: 'calypso_stats_do_you_love_jetpack_stats_notice_support_button_clicked'
+		);
 
 		trackStatsAnalyticsEvent( 'stats_upgrade_clicked', {
 			type: 'notice-love-stats',
 		} );
 
 		// Allow some time for the event to be recorded before redirecting.
-		setTimeout( () => page( getStatsPurchaseURL( siteId, isOdysseyStats, hasFreeStats ) ), 250 );
+		setTimeout( () => page( getStatsPurchaseURL( siteId, isOdysseyStats ) ), 250 );
 	};
 
 	const handleCTAClick = () => {
@@ -93,9 +86,11 @@ const DoYouLoveJetpackStatsNotice = ( {
 
 	useEffect( () => {
 		if ( ! noticeDismissed ) {
-			isOdysseyStats
-				? recordTracksEvent( 'jetpack_odyssey_stats_do_you_love_jetpack_stats_notice_viewed' )
-				: recordTracksEvent( 'calypso_stats_do_you_love_jetpack_stats_notice_viewed' );
+			recordTracksEvent(
+				isOdysseyStats
+					? 'jetpack_odyssey_stats_do_you_love_jetpack_stats_notice_viewed'
+					: 'calypso_stats_do_you_love_jetpack_stats_notice_viewed'
+			);
 		}
 	}, [ noticeDismissed, isOdysseyStats ] );
 
@@ -136,7 +131,9 @@ const DoYouLoveJetpackStatsNotice = ( {
 
 	const description = isWPCOMPaidStatsFlow
 		? paidStatsRemoveHardcoding
-		: translate( 'Upgrade to support future development and stop the upgrade banners.' );
+		: translate(
+				'Upgrade to unlock UTM tracking, device stats, and region and city locations, and get priority support.'
+		  );
 
 	const CTAText = isWPCOMPaidStatsFlow ? translate( 'Upgrade' ) : translate( 'Upgrade my Stats' );
 

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -23,7 +23,7 @@ const HELP_CENTER_STORE = HelpCenter.register();
 
 const getStatsPurchaseURL = ( siteId: number | null, isOdysseyStats: boolean ) => {
 	const from = isOdysseyStats ? 'jetpack' : 'calypso';
-	return `/stats/purchase/${ siteId }?from=${ from }-stats-upgrade-notice`;
+	return `/stats/purchase/${ siteId }?from=${ from }-stats-upgrade-notice&productType=commercial`;
 };
 
 const DoYouLoveJetpackStatsNotice = ( {


### PR DESCRIPTION
Fixes STATS-363

## Proposed Changes

* Replace the description of the "Do you love Jetpack Stats?" notice (the non-WPCOM branch) with feature-led copy: "Upgrade to unlock UTM tracking, device stats, and region and city locations, and get priority support." The old copy — "Upgrade to support future development and stop the upgrade banners." — offered paying as a way to make our own banners go away.
* Switch the notice CTA (`getStatsPurchaseURL`) from `productType=personal` to `productType=commercial`. The personal (PWYW) track doesn't unlock the three features the new copy promises (they sit behind the commercial-use paywall), so the CTA now forces the commercial purchase page. PWYW remains reachable via that page's "This is not a commercial site" switch link.
* Lint cleanup in the same file: convert three ternary-as-statement `recordTracksEvent` calls (which failed `@typescript-eslint/no-unused-expressions` and blocked the pre-commit hook) into single calls with a ternary argument. No behavior change.

## Why are these changes being made?

* Now that forced upgrades are gone (STATS-342), "pay us to stop the upgrade banners" is a message we don't want in production. The replacement copy sells what paid actually includes.
* Sending people to the personal/PWYW track right after promising UTM tracking, device stats, and region & city locations would be a jarring sequence, since that track doesn't include them.

## Notes

* **i18n:** the new description will render in English for non-English locales until translations land. `hasEnTranslation` gating was deliberately not used — falling back would reinstate exactly the copy this PR removes.
* **CTA landing:** simply dropping the pre-select (the first revision of this PR) was not enough. Without a `productType`, the purchase page derives its variant from the site's classification (`client/my-sites/stats/pages/purchase/index.tsx`): non-commercial sites — this banner's entire audience — get the PWYW view, and sites owning free Stats get the "you already have a free license" notice, whose own upgrade button also routes to personal. Neither unlocks what the copy promises, so the CTA forces `productType=commercial` (the alternative explicitly floated in STATS-363).
* **Out of scope:** `productType=personal` pre-selects still exist in `free-plan-purchase-success-notice.tsx` and in the purchase page's own "switch from commercial" link; neither is reachable from this banner. Follow-up candidates.

## Screenshots

Captured on the Calypso dev server against free self-hosted Jetpack sites (banner: `sweetly-aesthetic-red.jurassic.ninja`; CTA landing: `jp-echo.jurassic.tube`).

### 🔴 Banner before (trunk)

The description offers paying to stop our own banners:

<img width="1567" height="253" alt="Before: banner reading 'Upgrade to support future development and stop the upgrade banners.'" src="https://github.com/user-attachments/assets/7c965f65-6d27-4d57-9572-9c27ca0f0672" />

### 🟢 Banner after (this PR)

Only the description line changed — title, CTA label, "Learn more" link, and dismiss behavior are untouched:

<img width="1567" height="253" alt="After: banner reading 'Upgrade to unlock UTM tracking, device stats, and region and city locations, and get priority support.'" src="https://github.com/user-attachments/assets/0f67205a-af3f-4bb6-8d3d-23e4f42a7833" />

### 🟢 CTA landing after (this PR)

"Upgrade my Stats" now lands on `/stats/purchase/:site?from=…-stats-upgrade-notice&productType=commercial` — the commercial purchase page, selling exactly what the banner promises (UTM tracking, device attributes, priority support). Before, `hasFreeStats` sites were pre-selected into the personal/PWYW track, which includes none of those features:

<img width="1512" height="729" alt="After: commercial purchase page reached from the banner CTA, listing UTM tracking, device attributes and priority support" src="https://github.com/user-attachments/assets/9e89a2cc-cb6d-4990-941c-99cb9807fdb6" />

## Testing Instructions

Tested locally on self-hosted Jetpack sites via the Calypso dev server (evidence: [banner](https://github.com/Automattic/wp-calypso/pull/113248#issuecomment-5172753143), [CTA landing](https://github.com/Automattic/wp-calypso/pull/113248#issuecomment-5173417321)).

1. Use a free self-hosted Jetpack site (no paid or free Stats product), and open Calypso Stats (`/stats/day/:site`) or Odyssey Stats in wp-admin.
2. Verify the "Do you love Jetpack Stats?" notice shows the new description.
3. Click "Upgrade my Stats" and verify it lands on `/stats/purchase/:site?from=…-stats-upgrade-notice&productType=commercial`, showing the commercial purchase page (which lists UTM tracking, device attributes, and priority support).
4. On a WPCOM site with the `stats/paid-wpcom-v2` flow, verify the notice still shows the unchanged "Finesse your scaling-up strategy…" copy.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
