### PR TITLE
Email verification: keep checking for the confirmation, and back it off

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/inbox-links.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/inbox-links.ts
@@ -14,6 +14,8 @@ const PROVIDER_INBOX_URL: Record< string, ( email: string ) => string > = {
 	gmail: ( email ) => getGmailUrl( email ),
 	outlook: () => 'https://outlook.live.com/mail/',
 	yahoo: () => 'https://mail.yahoo.com/',
+	// Yahoo Japan is a separate service from the rest of Yahoo, with its own mailbox.
+	yahoojp: () => 'https://mail.yahoo.co.jp/',
 	icloud: () => 'https://www.icloud.com/mail/',
 	aol: () => 'https://mail.aol.com/',
 	proton: () => 'https://mail.proton.me/',
@@ -22,22 +24,45 @@ const PROVIDER_INBOX_URL: Record< string, ( email: string ) => string > = {
 const DOMAIN_TO_PROVIDER: Record< string, string > = {
 	'gmail.com': 'gmail',
 	'googlemail.com': 'gmail',
-	'outlook.com': 'outlook',
-	'hotmail.com': 'outlook',
-	'live.com': 'outlook',
-	'msn.com': 'outlook',
-	'yahoo.com': 'yahoo',
+	'yahoo.co.jp': 'yahoojp',
 	'icloud.com': 'icloud',
 	'me.com': 'icloud',
 	'mac.com': 'icloud',
-	'aol.com': 'aol',
 	'proton.me': 'proton',
 	'protonmail.com': 'proton',
+	'pm.me': 'proton',
 };
+
+// Microsoft, Yahoo and AOL each run dozens of per-country domains — hotmail.co.uk, yahoo.fr,
+// outlook.com.br — and serve them all from the one webmail host, so they're matched by brand
+// instead of enumerated. `me`, `mac` and the Google brands stay exact: they're either too short
+// to be distinctive as a label, or have no country domains to match.
+const BRAND_TO_PROVIDER: Record< string, string > = {
+	hotmail: 'outlook',
+	live: 'outlook',
+	outlook: 'outlook',
+	msn: 'outlook',
+	yahoo: 'yahoo',
+	ymail: 'yahoo',
+	rocketmail: 'yahoo',
+	aol: 'aol',
+};
+
+// A brand followed by a country suffix and nothing else, so a host that merely starts with one
+// of the brands — live.somecompany.com — isn't taken for the webmail provider.
+const BRAND_WITH_COUNTRY_SUFFIX = /^([a-z]+)\.(?:[a-z]{2,3}\.)?[a-z]{2,4}$/;
 
 // The inbox link for an email's provider, or null for an unrecognized/self-hosted domain.
 export function getInboxLink( email: string | undefined ): InboxLink | null {
 	const domain = email ? extractDomainWithExtension( email ) : undefined;
-	const provider = domain ? DOMAIN_TO_PROVIDER[ domain ] : undefined;
-	return provider && email ? { provider, url: PROVIDER_INBOX_URL[ provider ]( email ) } : null;
+	if ( ! email || ! domain ) {
+		return null;
+	}
+
+	const brand = BRAND_WITH_COUNTRY_SUFFIX.exec( domain )?.[ 1 ];
+	// Exact first, so a domain that needs its own mailbox isn't swept up by its brand.
+	const provider =
+		DOMAIN_TO_PROVIDER[ domain ] ?? ( brand ? BRAND_TO_PROVIDER[ brand ] : undefined );
+
+	return provider ? { provider, url: PROVIDER_INBOX_URL[ provider ]( email ) } : null;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/inbox-links.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/inbox-links.ts
@@ -21,48 +21,143 @@ const PROVIDER_INBOX_URL: Record< string, ( email: string ) => string > = {
 	proton: () => 'https://mail.proton.me/',
 };
 
-const DOMAIN_TO_PROVIDER: Record< string, string > = {
-	'gmail.com': 'gmail',
-	'googlemail.com': 'gmail',
-	'yahoo.co.jp': 'yahoojp',
-	'icloud.com': 'icloud',
-	'me.com': 'icloud',
-	'mac.com': 'icloud',
-	'proton.me': 'proton',
-	'protonmail.com': 'proton',
-	'pm.me': 'proton',
+// An allowlist, not a pattern: a brand name in the domain proves nothing about who runs the
+// mail. `live.io` is a Google-hosted business domain, so anything matching `live.*` would send
+// its owner to a Microsoft mailbox they have no account on. A domain that isn't listed here
+// gets no link at all, which is the safe answer — the poll resolves the gate regardless.
+// Adding a country domain a provider actually runs is a one-line change.
+const PROVIDER_DOMAINS: Record< string, string[] > = {
+	gmail: [ 'gmail.com', 'googlemail.com' ],
+	outlook: [
+		'outlook.com',
+		'outlook.at',
+		'outlook.be',
+		'outlook.cl',
+		'outlook.co.id',
+		'outlook.co.nz',
+		'outlook.co.th',
+		'outlook.com.au',
+		'outlook.com.br',
+		'outlook.com.tr',
+		'outlook.com.vn',
+		'outlook.cz',
+		'outlook.de',
+		'outlook.dk',
+		'outlook.es',
+		'outlook.fr',
+		'outlook.hu',
+		'outlook.ie',
+		'outlook.in',
+		'outlook.it',
+		'outlook.jp',
+		'outlook.kr',
+		'outlook.my',
+		'outlook.ph',
+		'outlook.pt',
+		'outlook.sa',
+		'outlook.sg',
+		'hotmail.com',
+		'hotmail.at',
+		'hotmail.be',
+		'hotmail.ca',
+		'hotmail.ch',
+		'hotmail.co.il',
+		'hotmail.co.jp',
+		'hotmail.co.nz',
+		'hotmail.co.th',
+		'hotmail.co.uk',
+		'hotmail.com.ar',
+		'hotmail.com.br',
+		'hotmail.com.mx',
+		'hotmail.com.tr',
+		'hotmail.cz',
+		'hotmail.de',
+		'hotmail.dk',
+		'hotmail.es',
+		'hotmail.fi',
+		'hotmail.fr',
+		'hotmail.gr',
+		'hotmail.hu',
+		'hotmail.it',
+		'hotmail.nl',
+		'hotmail.no',
+		'hotmail.se',
+		'live.com',
+		'live.at',
+		'live.be',
+		'live.ca',
+		'live.cl',
+		'live.cn',
+		'live.co.uk',
+		'live.co.za',
+		'live.com.ar',
+		'live.com.au',
+		'live.com.mx',
+		'live.de',
+		'live.dk',
+		'live.fi',
+		'live.fr',
+		'live.hk',
+		'live.ie',
+		'live.in',
+		'live.it',
+		'live.jp',
+		'live.nl',
+		'live.no',
+		'live.pt',
+		'live.ru',
+		'live.se',
+		'msn.com',
+	],
+	yahoo: [
+		'yahoo.com',
+		'yahoo.ca',
+		'yahoo.co.id',
+		'yahoo.co.in',
+		'yahoo.co.nz',
+		'yahoo.co.th',
+		'yahoo.co.uk',
+		'yahoo.com.ar',
+		'yahoo.com.au',
+		'yahoo.com.br',
+		'yahoo.com.hk',
+		'yahoo.com.mx',
+		'yahoo.com.ph',
+		'yahoo.com.sg',
+		'yahoo.com.tr',
+		'yahoo.com.tw',
+		'yahoo.com.vn',
+		'yahoo.de',
+		'yahoo.dk',
+		'yahoo.es',
+		'yahoo.fi',
+		'yahoo.fr',
+		'yahoo.gr',
+		'yahoo.ie',
+		'yahoo.it',
+		'yahoo.nl',
+		'yahoo.no',
+		'yahoo.pl',
+		'yahoo.pt',
+		'yahoo.se',
+		'ymail.com',
+		'rocketmail.com',
+	],
+	yahoojp: [ 'yahoo.co.jp' ],
+	icloud: [ 'icloud.com', 'me.com', 'mac.com' ],
+	aol: [ 'aol.com', 'aol.co.uk', 'aol.de', 'aol.fr' ],
+	proton: [ 'proton.me', 'protonmail.com', 'pm.me' ],
 };
 
-// Microsoft, Yahoo and AOL each run dozens of per-country domains — hotmail.co.uk, yahoo.fr,
-// outlook.com.br — and serve them all from the one webmail host, so they're matched by brand
-// instead of enumerated. `me`, `mac` and the Google brands stay exact: they're either too short
-// to be distinctive as a label, or have no country domains to match.
-const BRAND_TO_PROVIDER: Record< string, string > = {
-	hotmail: 'outlook',
-	live: 'outlook',
-	outlook: 'outlook',
-	msn: 'outlook',
-	yahoo: 'yahoo',
-	ymail: 'yahoo',
-	rocketmail: 'yahoo',
-	aol: 'aol',
-};
-
-// A brand followed by a country suffix and nothing else, so a host that merely starts with one
-// of the brands — live.somecompany.com — isn't taken for the webmail provider.
-const BRAND_WITH_COUNTRY_SUFFIX = /^([a-z]+)\.(?:[a-z]{2,3}\.)?[a-z]{2,4}$/;
+const DOMAIN_TO_PROVIDER: Record< string, string > = Object.fromEntries(
+	Object.entries( PROVIDER_DOMAINS ).flatMap( ( [ provider, domains ] ) =>
+		domains.map( ( domain ) => [ domain, provider ] )
+	)
+);
 
 // The inbox link for an email's provider, or null for an unrecognized/self-hosted domain.
 export function getInboxLink( email: string | undefined ): InboxLink | null {
 	const domain = email ? extractDomainWithExtension( email ) : undefined;
-	if ( ! email || ! domain ) {
-		return null;
-	}
-
-	const brand = BRAND_WITH_COUNTRY_SUFFIX.exec( domain )?.[ 1 ];
-	// Exact first, so a domain that needs its own mailbox isn't swept up by its brand.
-	const provider =
-		DOMAIN_TO_PROVIDER[ domain ] ?? ( brand ? BRAND_TO_PROVIDER[ brand ] : undefined );
-
-	return provider ? { provider, url: PROVIDER_INBOX_URL[ provider ]( email ) } : null;
+	const provider = domain ? DOMAIN_TO_PROVIDER[ domain ] : undefined;
+	return provider && email ? { provider, url: PROVIDER_INBOX_URL[ provider ]( email ) } : null;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/inbox-links.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/inbox-links.ts
@@ -7,150 +7,77 @@ export interface InboxLink {
 	url: string;
 }
 
-// Inbox URLs by provider, built from the signup address. Gmail routes through the account
-// chooser so multi-account users land on the right mailbox; the rest are the vetted URLs from
+interface Provider {
+	// Every domain this provider actually runs mail for. A brand in the name proves nothing:
+	// live.io is Google-hosted, so `live.*` would send its owner to a mailbox they have no
+	// account on — worse than the no link an unlisted domain gets. Verify MX before adding one.
+	domains: string[];
+	inboxUrl: ( email: string ) => string;
+}
+
+// Deliberately short: the top handful of domains cover almost every signup, and a long tail
+// invites entries that have since been parked. URLs other than Gmail's come from
 // client/login/magic-login/magic-login-email.
-const PROVIDER_INBOX_URL: Record< string, ( email: string ) => string > = {
-	gmail: ( email ) => getGmailUrl( email ),
-	outlook: () => 'https://outlook.live.com/mail/',
-	yahoo: () => 'https://mail.yahoo.com/',
-	// Yahoo Japan is a separate service from the rest of Yahoo, with its own mailbox.
-	yahoojp: () => 'https://mail.yahoo.co.jp/',
-	icloud: () => 'https://www.icloud.com/mail/',
-	aol: () => 'https://mail.aol.com/',
-	proton: () => 'https://mail.proton.me/',
+const PROVIDERS: Record< string, Provider > = {
+	gmail: {
+		domains: [ 'gmail.com', 'googlemail.com' ],
+		// The account chooser, so multi-account users land on the right mailbox.
+		inboxUrl: ( email ) => getGmailUrl( email ),
+	},
+	outlook: {
+		domains: [
+			'outlook.com',
+			'hotmail.com',
+			'hotmail.be',
+			'hotmail.co.uk',
+			'hotmail.de',
+			'hotmail.es',
+			'hotmail.fr',
+			'hotmail.it',
+			'hotmail.nl',
+			'live.com',
+			'live.co.uk',
+			'live.fr',
+			'live.nl',
+			'msn.com',
+		],
+		inboxUrl: () => 'https://outlook.live.com/mail/',
+	},
+	yahoo: {
+		domains: [
+			'yahoo.com',
+			'yahoo.ca',
+			'yahoo.co.uk',
+			'yahoo.com.br',
+			'yahoo.de',
+			'yahoo.es',
+			'yahoo.fr',
+			'yahoo.it',
+			'ymail.com',
+		],
+		inboxUrl: () => 'https://mail.yahoo.com/',
+	},
+	// A separate service from the rest of Yahoo, with its own mailbox.
+	yahoojp: {
+		domains: [ 'yahoo.co.jp' ],
+		inboxUrl: () => 'https://mail.yahoo.co.jp/',
+	},
+	icloud: {
+		domains: [ 'icloud.com', 'me.com', 'mac.com' ],
+		inboxUrl: () => 'https://www.icloud.com/mail/',
+	},
+	aol: {
+		domains: [ 'aol.com' ],
+		inboxUrl: () => 'https://mail.aol.com/',
+	},
+	proton: {
+		domains: [ 'proton.me', 'protonmail.com', 'pm.me' ],
+		inboxUrl: () => 'https://mail.proton.me/',
+	},
 };
 
-// An allowlist, not a pattern: a brand name in the domain proves nothing about who runs the
-// mail. `live.io` is a Google-hosted business domain, so anything matching `live.*` would send
-// its owner to a Microsoft mailbox they have no account on. A domain that isn't listed here
-// gets no link at all, which is the safe answer — the poll resolves the gate regardless.
-// Adding a country domain a provider actually runs is a one-line change.
-const PROVIDER_DOMAINS: Record< string, string[] > = {
-	gmail: [ 'gmail.com', 'googlemail.com' ],
-	outlook: [
-		'outlook.com',
-		'outlook.at',
-		'outlook.be',
-		'outlook.cl',
-		'outlook.co.id',
-		'outlook.co.nz',
-		'outlook.co.th',
-		'outlook.com.au',
-		'outlook.com.br',
-		'outlook.com.tr',
-		'outlook.com.vn',
-		'outlook.cz',
-		'outlook.de',
-		'outlook.dk',
-		'outlook.es',
-		'outlook.fr',
-		'outlook.hu',
-		'outlook.ie',
-		'outlook.in',
-		'outlook.it',
-		'outlook.jp',
-		'outlook.kr',
-		'outlook.my',
-		'outlook.ph',
-		'outlook.pt',
-		'outlook.sa',
-		'outlook.sg',
-		'hotmail.com',
-		'hotmail.at',
-		'hotmail.be',
-		'hotmail.ca',
-		'hotmail.ch',
-		'hotmail.co.il',
-		'hotmail.co.jp',
-		'hotmail.co.nz',
-		'hotmail.co.th',
-		'hotmail.co.uk',
-		'hotmail.com.ar',
-		'hotmail.com.br',
-		'hotmail.com.mx',
-		'hotmail.com.tr',
-		'hotmail.cz',
-		'hotmail.de',
-		'hotmail.dk',
-		'hotmail.es',
-		'hotmail.fi',
-		'hotmail.fr',
-		'hotmail.gr',
-		'hotmail.hu',
-		'hotmail.it',
-		'hotmail.nl',
-		'hotmail.no',
-		'hotmail.se',
-		'live.com',
-		'live.at',
-		'live.be',
-		'live.ca',
-		'live.cl',
-		'live.cn',
-		'live.co.uk',
-		'live.co.za',
-		'live.com.ar',
-		'live.com.au',
-		'live.com.mx',
-		'live.de',
-		'live.dk',
-		'live.fi',
-		'live.fr',
-		'live.hk',
-		'live.ie',
-		'live.in',
-		'live.it',
-		'live.jp',
-		'live.nl',
-		'live.no',
-		'live.pt',
-		'live.ru',
-		'live.se',
-		'msn.com',
-	],
-	yahoo: [
-		'yahoo.com',
-		'yahoo.ca',
-		'yahoo.co.id',
-		'yahoo.co.in',
-		'yahoo.co.nz',
-		'yahoo.co.th',
-		'yahoo.co.uk',
-		'yahoo.com.ar',
-		'yahoo.com.au',
-		'yahoo.com.br',
-		'yahoo.com.hk',
-		'yahoo.com.mx',
-		'yahoo.com.ph',
-		'yahoo.com.sg',
-		'yahoo.com.tr',
-		'yahoo.com.tw',
-		'yahoo.com.vn',
-		'yahoo.de',
-		'yahoo.dk',
-		'yahoo.es',
-		'yahoo.fi',
-		'yahoo.fr',
-		'yahoo.gr',
-		'yahoo.ie',
-		'yahoo.it',
-		'yahoo.nl',
-		'yahoo.no',
-		'yahoo.pl',
-		'yahoo.pt',
-		'yahoo.se',
-		'ymail.com',
-		'rocketmail.com',
-	],
-	yahoojp: [ 'yahoo.co.jp' ],
-	icloud: [ 'icloud.com', 'me.com', 'mac.com' ],
-	aol: [ 'aol.com', 'aol.co.uk', 'aol.de', 'aol.fr' ],
-	proton: [ 'proton.me', 'protonmail.com', 'pm.me' ],
-};
-
-const DOMAIN_TO_PROVIDER: Record< string, string > = Object.fromEntries(
-	Object.entries( PROVIDER_DOMAINS ).flatMap( ( [ provider, domains ] ) =>
+const DOMAIN_TO_PROVIDER: Record< string, keyof typeof PROVIDERS > = Object.fromEntries(
+	Object.entries( PROVIDERS ).flatMap( ( [ provider, { domains } ] ) =>
 		domains.map( ( domain ) => [ domain, provider ] )
 	)
 );
@@ -159,5 +86,5 @@ const DOMAIN_TO_PROVIDER: Record< string, string > = Object.fromEntries(
 export function getInboxLink( email: string | undefined ): InboxLink | null {
 	const domain = email ? extractDomainWithExtension( email ) : undefined;
 	const provider = domain ? DOMAIN_TO_PROVIDER[ domain ] : undefined;
-	return provider && email ? { provider, url: PROVIDER_INBOX_URL[ provider ]( email ) } : null;
+	return provider && email ? { provider, url: PROVIDERS[ provider ].inboxUrl( email ) } : null;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/index.tsx
@@ -34,10 +34,13 @@ interface Props {
 const EmailVerificationGate = ( { flow, scope, logo, onDone }: Props ) => {
 	const { __ } = useI18n();
 	const email = useSelector( getCurrentUserEmail );
-	const { isVerified, sendStatus, secondsUntilResend, checkStatus, checkNow, resend } =
-		useEmailVerification( flow, scope );
+	const { isVerified, sendStatus, secondsUntilResend, resend } = useEmailVerification(
+		flow,
+		scope
+	);
 
 	const hasSubmitted = useRef( false );
+	const hasRecordedView = useRef( false );
 	const headingRef = useRef< HTMLDivElement >( null );
 	const inboxLink = getInboxLink( email ?? undefined );
 
@@ -56,6 +59,19 @@ const EmailVerificationGate = ( { flow, scope, logo, onDone }: Props ) => {
 	useEffect( () => {
 		markGateShown( scope );
 	}, [ scope ] );
+
+	// The denominator for everything that follows: `provider` names which variant was shown
+	// (`none` when the address has no inbox link), and a view with no confirmation is a drop-off.
+	useEffect( () => {
+		if ( hasRecordedView.current ) {
+			return;
+		}
+		hasRecordedView.current = true;
+		recordTracksEvent( 'calypso_signup_email_verification_view', {
+			flow,
+			provider: inboxLink?.provider ?? 'none',
+		} );
+	}, [ flow, inboxLink ] );
 
 	// The gate replaces the account form without a route change, so move focus onto its heading
 	// — otherwise it strands on the unmounted submit button and the screen change goes unsaid.
@@ -139,21 +155,18 @@ const EmailVerificationGate = ( { flow, scope, logo, onDone }: Props ) => {
 
 					<VStack spacing={ 3 }>
 						{ /* Calypso's Button, not the Step.* ones: the design follows its outline, radius,
-						   and weight. A known provider gets an inbox deep link — confirming there
-						   resolves the gate by polling; the rest get a manual re-check. */ }
-						{ inboxLink ? (
-							<Button primary href={ inboxLink.url } target="_blank" onClick={ openInbox }>
-								{ __( 'Open email inbox' ) }
-								<Icon icon={ arrowUpRight } size={ 16 } fill="currentColor" />
-							</Button>
-						) : (
+						   and weight. A known provider gets an inbox deep link; confirming there — or
+						   anywhere else — resolves the gate by polling, so nothing else is needed. */ }
+						{ inboxLink && (
 							<Button
 								primary
-								onClick={ checkNow }
-								busy={ checkStatus === 'checking' }
-								disabled={ checkStatus === 'checking' }
+								href={ inboxLink.url }
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ openInbox }
 							>
-								{ __( 'I’ve confirmed my email' ) }
+								{ __( 'Open email inbox' ) }
+								<Icon icon={ arrowUpRight } size={ 16 } fill="currentColor" />
 							</Button>
 						) }
 
@@ -164,20 +177,6 @@ const EmailVerificationGate = ( { flow, scope, logo, onDone }: Props ) => {
 						>
 							{ resendLabel }
 						</Button>
-
-						{ checkStatus === 'unconfirmed' && (
-							<p className="onboarding-email-verification__notice" role="status">
-								{ __(
-									'We haven’t received your confirmation yet. Open the link in your inbox, then try again.'
-								) }
-							</p>
-						) }
-
-						{ checkStatus === 'error' && (
-							<p className="onboarding-email-verification__notice is-error" role="alert">
-								{ __( 'We couldn’t check right now. Please try again in a moment.' ) }
-							</p>
-						) }
 
 						{ sendStatus === 'error' && (
 							<p className="onboarding-email-verification__notice is-error" role="alert">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/index.tsx
@@ -40,9 +40,10 @@ const EmailVerificationGate = ( { flow, scope, logo, onDone }: Props ) => {
 	);
 
 	const hasSubmitted = useRef( false );
-	const hasRecordedView = useRef( false );
 	const headingRef = useRef< HTMLDivElement >( null );
 	const inboxLink = getInboxLink( email ?? undefined );
+	// A stable dependency: `inboxLink` is a fresh object every render.
+	const provider = inboxLink?.provider ?? 'none';
 
 	const title = __( 'Verify your email' );
 
@@ -55,23 +56,13 @@ const EmailVerificationGate = ( { flow, scope, logo, onDone }: Props ) => {
 			  )
 			: __( 'Resend' );
 
-	// Stamp the shown-at time now the gate is actually on screen (see storage.ts).
-	useEffect( () => {
-		markGateShown( scope );
-	}, [ scope ] );
-
 	// The denominator for everything that follows: `provider` names which variant was shown
 	// (`none` when the address has no inbox link), and a view with no confirmation is a drop-off.
 	useEffect( () => {
-		if ( hasRecordedView.current ) {
-			return;
+		if ( markGateShown( scope ) ) {
+			recordTracksEvent( 'calypso_signup_email_verification_view', { flow, provider } );
 		}
-		hasRecordedView.current = true;
-		recordTracksEvent( 'calypso_signup_email_verification_view', {
-			flow,
-			provider: inboxLink?.provider ?? 'none',
-		} );
-	}, [ flow, inboxLink ] );
+	}, [ scope, flow, provider ] );
 
 	// The gate replaces the account form without a route change, so move focus onto its heading
 	// — otherwise it strands on the unmounted submit button and the screen change goes unsaid.

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/storage.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/storage.ts
@@ -39,13 +39,24 @@ export function beginGate( scope: string ): void {
 	write( scope, { resendAvailableAt: 0, shownAt: 0 } );
 }
 
-// Stamped when the gate first renders, so the duration metric excludes the token-load and
-// user-hydration wait before it.
-export function markGateShown( scope: string ): void {
+/**
+ * Stamps the gate as shown, so the duration metric excludes the token-load and user-hydration
+ * wait before it, and reports whether this call was the one that stamped it — which is what
+ * makes a per-gate event fire once rather than once per mount.
+ *
+ * True when nothing is stored, so a caller isn't silenced by unavailable storage; it falls back
+ * to once per mount rather than never.
+ */
+export function markGateShown( scope: string ): boolean {
 	const record = read( scope );
-	if ( record && ! record.shownAt ) {
-		write( scope, { ...record, shownAt: Date.now() } );
+	if ( ! record ) {
+		return true;
 	}
+	if ( record.shownAt ) {
+		return false;
+	}
+	write( scope, { ...record, shownAt: Date.now() } );
+	return true;
 }
 
 export function isGatePending( scope: string ): boolean {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/inbox-links.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/inbox-links.ts
@@ -1,7 +1,7 @@
 import { getInboxLink } from '../inbox-links';
 
 describe( 'getInboxLink', () => {
-	it( 'matches a provider across its country domains', () => {
+	it( 'matches a provider across the country domains it runs', () => {
 		expect( getInboxLink( 'a@hotmail.co.uk' )?.provider ).toBe( 'outlook' );
 		expect( getInboxLink( 'a@outlook.com.br' )?.provider ).toBe( 'outlook' );
 		expect( getInboxLink( 'a@live.fr' )?.provider ).toBe( 'outlook' );
@@ -10,14 +10,17 @@ describe( 'getInboxLink', () => {
 		expect( getInboxLink( 'a@aol.co.uk' )?.provider ).toBe( 'aol' );
 	} );
 
-	it( 'sends Yahoo Japan to its own mailbox rather than the brand default', () => {
+	it( 'sends Yahoo Japan to its own mailbox rather than the shared one', () => {
 		expect( getInboxLink( 'a@yahoo.co.jp' )?.url ).toBe( 'https://mail.yahoo.co.jp/' );
 		expect( getInboxLink( 'a@yahoo.com' )?.url ).toBe( 'https://mail.yahoo.com/' );
 	} );
 
-	it( 'does not take a host that merely starts with a brand for that provider', () => {
-		expect( getInboxLink( 'a@live.somecompany.com' ) ).toBeNull();
-		expect( getInboxLink( 'a@outlook.internal.example.org' ) ).toBeNull();
+	// A brand name in a domain says nothing about who runs its mail: live.io is Google-hosted,
+	// and a link to Microsoft would be worse than the no link an unknown domain gets.
+	it( 'does not claim a domain a provider does not run', () => {
+		expect( getInboxLink( 'a@live.io' ) ).toBeNull();
+		expect( getInboxLink( 'a@outlook.somecompany.com' ) ).toBeNull();
+		expect( getInboxLink( 'a@gmail.io' ) ).toBeNull();
 	} );
 
 	it( 'returns null for a self-hosted domain and for no address at all', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/inbox-links.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/inbox-links.ts
@@ -1,0 +1,27 @@
+import { getInboxLink } from '../inbox-links';
+
+describe( 'getInboxLink', () => {
+	it( 'matches a provider across its country domains', () => {
+		expect( getInboxLink( 'a@hotmail.co.uk' )?.provider ).toBe( 'outlook' );
+		expect( getInboxLink( 'a@outlook.com.br' )?.provider ).toBe( 'outlook' );
+		expect( getInboxLink( 'a@live.fr' )?.provider ).toBe( 'outlook' );
+		expect( getInboxLink( 'a@yahoo.de' )?.provider ).toBe( 'yahoo' );
+		expect( getInboxLink( 'a@ymail.com' )?.provider ).toBe( 'yahoo' );
+		expect( getInboxLink( 'a@aol.co.uk' )?.provider ).toBe( 'aol' );
+	} );
+
+	it( 'sends Yahoo Japan to its own mailbox rather than the brand default', () => {
+		expect( getInboxLink( 'a@yahoo.co.jp' )?.url ).toBe( 'https://mail.yahoo.co.jp/' );
+		expect( getInboxLink( 'a@yahoo.com' )?.url ).toBe( 'https://mail.yahoo.com/' );
+	} );
+
+	it( 'does not take a host that merely starts with a brand for that provider', () => {
+		expect( getInboxLink( 'a@live.somecompany.com' ) ).toBeNull();
+		expect( getInboxLink( 'a@outlook.internal.example.org' ) ).toBeNull();
+	} );
+
+	it( 'returns null for a self-hosted domain and for no address at all', () => {
+		expect( getInboxLink( 'a@example.com' ) ).toBeNull();
+		expect( getInboxLink( undefined ) ).toBeNull();
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/inbox-links.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/inbox-links.ts
@@ -3,11 +3,9 @@ import { getInboxLink } from '../inbox-links';
 describe( 'getInboxLink', () => {
 	it( 'matches a provider across the country domains it runs', () => {
 		expect( getInboxLink( 'a@hotmail.co.uk' )?.provider ).toBe( 'outlook' );
-		expect( getInboxLink( 'a@outlook.com.br' )?.provider ).toBe( 'outlook' );
 		expect( getInboxLink( 'a@live.fr' )?.provider ).toBe( 'outlook' );
 		expect( getInboxLink( 'a@yahoo.de' )?.provider ).toBe( 'yahoo' );
 		expect( getInboxLink( 'a@ymail.com' )?.provider ).toBe( 'yahoo' );
-		expect( getInboxLink( 'a@aol.co.uk' )?.provider ).toBe( 'aol' );
 	} );
 
 	it( 'sends Yahoo Japan to its own mailbox rather than the shared one', () => {
@@ -15,10 +13,13 @@ describe( 'getInboxLink', () => {
 		expect( getInboxLink( 'a@yahoo.com' )?.url ).toBe( 'https://mail.yahoo.com/' );
 	} );
 
-	// A brand name in a domain says nothing about who runs its mail: live.io is Google-hosted,
-	// and a link to Microsoft would be worse than the no link an unknown domain gets.
-	it( 'does not claim a domain a provider does not run', () => {
+	// A brand in the name says nothing about who runs the mail, and a domain a provider once ran
+	// may since have been parked. Either way a wrong link is worse than none: hotmail.com.mx and
+	// live.pt publish no working MX, and live.io is Google-hosted.
+	it( 'does not claim a domain the provider does not run mail for', () => {
 		expect( getInboxLink( 'a@live.io' ) ).toBeNull();
+		expect( getInboxLink( 'a@hotmail.com.mx' ) ).toBeNull();
+		expect( getInboxLink( 'a@live.pt' ) ).toBeNull();
 		expect( getInboxLink( 'a@outlook.somecompany.com' ) ).toBeNull();
 		expect( getInboxLink( 'a@gmail.io' ) ).toBeNull();
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/index.tsx
@@ -11,6 +11,7 @@ import { applyMiddleware, combineReducers, createStore } from 'redux';
 import { thunk as thunkMiddleware } from 'redux-thunk';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { CURRENT_USER_RECEIVE } from 'calypso/state/action-types';
+import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import currentUserReducer from 'calypso/state/current-user/reducer';
 import documentHeadReducer from 'calypso/state/document-head/reducer';
 import uiReducer from 'calypso/state/ui/reducer';
@@ -48,15 +49,6 @@ const mockSendVerificationEmailThrottled = ( retryAfter: number ) =>
 			data: { retry_after: retryAfter },
 		} );
 
-const mockFetchUser = ( emailVerified: boolean ) =>
-	mockApi()
-		.get( '/rest/v1.1/me' )
-		.query( true )
-		.reply( 200, { ID: USER_ID, email: EMAIL, email_verified: emailVerified } );
-
-const mockFetchUserError = () =>
-	mockApi().get( '/rest/v1.1/me' ).query( true ).reply( 500, { error: 'server_error' } );
-
 const currentUserState = ( emailVerified: boolean ) => ( {
 	currentUser: {
 		id: USER_ID,
@@ -65,6 +57,15 @@ const currentUserState = ( emailVerified: boolean ) => ( {
 } );
 
 const SCOPE = `${ FLOW }:${ USER_ID }`;
+
+const MINUTE = 60 * 1000;
+
+// One step of fake time. The poll's interval is re-registered by an effect, so each change of
+// rung needs its own `act` boundary to take hold.
+const advance = ( ms: number ) =>
+	act( () => {
+		jest.advanceTimersByTime( ms );
+	} );
 
 const render = ( { onDone = jest.fn(), logo }: { onDone?: jest.Mock; logo?: ReactNode } = {} ) => {
 	// The account step opens the gate on account creation; simulate that once.
@@ -122,10 +123,10 @@ describe( 'EmailVerificationGate', () => {
 
 		const openButton = await screen.findByRole( 'link', { name: 'Open email inbox' } );
 		expect( openButton.getAttribute( 'href' ) ).toContain( 'mail.google.com' );
-		// The manual re-check is the fallback for providers without an inbox link.
-		expect(
-			screen.queryByRole( 'button', { name: /confirmed my email/ } )
-		).not.toBeInTheDocument();
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_signup_email_verification_view',
+			expect.objectContaining( { flow: FLOW, provider: 'gmail' } )
+		);
 
 		await userEvent.click( openButton );
 		expect( recordTracksEvent ).toHaveBeenCalledWith(
@@ -134,12 +135,18 @@ describe( 'EmailVerificationGate', () => {
 		);
 	} );
 
-	it( 'falls back to a manual re-check for an unrecognized provider', () => {
+	it( 'leaves resend as the only action for an unrecognized provider', () => {
 		render();
 
-		// `onboarder@example.com` has no known inbox link.
-		expect( screen.getByRole( 'button', { name: 'I’ve confirmed my email' } ) ).toBeVisible();
+		// `onboarder@example.com` has no known inbox link, and the poll is what resolves the
+		// gate either way, so nothing stands in for the missing one.
 		expect( screen.queryByRole( 'link', { name: /^Open / } ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Resend' } ) ).toBeVisible();
+		// The cohort still has to be countable, or its confirmations have nothing to divide by.
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_signup_email_verification_view',
+			expect.objectContaining( { flow: FLOW, provider: 'none' } )
+		);
 	} );
 
 	it( 'finishes as soon as the confirmation lands in another tab', async () => {
@@ -179,26 +186,43 @@ describe( 'EmailVerificationGate', () => {
 		);
 	} );
 
-	it( 'finishes when the manual check finds the email confirmed', async () => {
-		mockFetchUser( true );
-		const { onDone } = render();
+	it( 'walks down the poll schedule without ever stopping', () => {
+		jest.useFakeTimers();
+		render();
+		const poll = fetchCurrentUser as jest.Mock;
 
-		await userEvent.click( screen.getByRole( 'button', { name: 'I’ve confirmed my email' } ) );
+		// The span of each rung in minutes, so a rung's cost is what its own chunk of time bought.
+		const requestsPerRung = [ 5, 5, 20, 30, 60 ].map( ( minutes ) => {
+			poll.mockClear();
+			advance( minutes * MINUTE );
+			return poll.mock.calls.length;
+		} );
 
-		await waitFor( () => expect( onDone ).toHaveBeenCalled() );
+		// Every 10s for five minutes, then 30s, a minute, five minutes, and ten minutes from an
+		// hour on — where a tab left open sits, still able to catch a confirmation from a phone.
+		expect( requestsPerRung ).toEqual( [ 30, 10, 20, 6, 6 ] );
 	} );
 
-	it( 'distinguishes a failed check request from an unconfirmed email', async () => {
-		mockFetchUserError();
-		const { onDone } = render();
+	it( 'polls at the opening rate again after a resend', async () => {
+		jest.useFakeTimers();
+		const user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
+		const request = mockSendVerificationEmail();
+		render();
+		const poll = fetchCurrentUser as jest.Mock;
 
-		await userEvent.click( screen.getByRole( 'button', { name: 'I’ve confirmed my email' } ) );
+		// Out to the slowest rung, where a minute buys no request at all.
+		[ 5, 5, 20, 30, 60 ].forEach( ( minutes ) => advance( minutes * MINUTE ) );
+		poll.mockClear();
+		advance( MINUTE );
+		expect( poll ).not.toHaveBeenCalled();
 
-		expect( await screen.findByText( /We couldn’t check right now\./ ) ).toBeVisible();
-		expect(
-			screen.queryByText( /We haven’t received your confirmation yet\./ )
-		).not.toBeInTheDocument();
-		expect( onDone ).not.toHaveBeenCalled();
+		await user.click( await screen.findByRole( 'button', { name: 'Resend' } ) );
+		await waitFor( () => expect( request.isDone() ).toBe( true ) );
+		await screen.findByRole( 'button', { name: /^Resend \(/ } );
+
+		poll.mockClear();
+		advance( MINUTE );
+		expect( poll ).toHaveBeenCalledTimes( 6 );
 	} );
 
 	it( 'holds the button for as long as the server says when it throttles', async () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/index.tsx
@@ -149,6 +149,20 @@ describe( 'EmailVerificationGate', () => {
 		);
 	} );
 
+	it( 'records the view once per gate, not once per mount', () => {
+		const viewEvents = () =>
+			( recordTracksEvent as jest.Mock ).mock.calls.filter(
+				( [ event ] ) => event === 'calypso_signup_email_verification_view'
+			);
+
+		render().unmount();
+		expect( viewEvents() ).toHaveLength( 1 );
+
+		// A refresh lands on the same pending gate; the denominator must not count it twice.
+		render();
+		expect( viewEvents() ).toHaveLength( 1 );
+	} );
+
 	it( 'finishes as soon as the confirmation lands in another tab', async () => {
 		const onDone = jest.fn();
 		// Only the slices this gate touches, plus the two `DocumentHead` reads.

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/index.tsx
@@ -198,9 +198,9 @@ describe( 'EmailVerificationGate', () => {
 			return poll.mock.calls.length;
 		} );
 
-		// Every 10s for five minutes, then 30s, a minute, five minutes, and ten minutes from an
-		// hour on — where a tab left open sits, still able to catch a confirmation from a phone.
-		expect( requestsPerRung ).toEqual( [ 30, 10, 20, 6, 6 ] );
+		// Every 10s for five minutes, then 30s, a minute, and three minutes from half an hour on
+		// — the floor, so a confirmation from a phone is never more than three minutes stale.
+		expect( requestsPerRung ).toEqual( [ 30, 10, 20, 10, 20 ] );
 	} );
 
 	it( 'polls at the opening rate again after a resend', async () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/index.tsx
@@ -217,6 +217,22 @@ describe( 'EmailVerificationGate', () => {
 		expect( requestsPerRung ).toEqual( [ 30, 10, 20, 10, 20 ] );
 	} );
 
+	it( 'checks on focus, which is all a desktop mail client leaves to go on', () => {
+		jest.useFakeTimers();
+		render();
+		const poll = fetchCurrentUser as jest.Mock;
+
+		// Out to the slowest rung, where the next tick is minutes away.
+		[ 5, 5, 20, 30 ].forEach( ( minutes ) => advance( minutes * MINUTE ) );
+
+		// The tab was never hidden — verifying in another app raises no visibility change.
+		poll.mockClear();
+		act( () => {
+			window.dispatchEvent( new Event( 'focus' ) );
+		} );
+		expect( poll ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	it( 'polls at the opening rate again after a resend', async () => {
 		jest.useFakeTimers();
 		const user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/use-email-verification.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/use-email-verification.ts
@@ -98,18 +98,33 @@ export function useEmailVerification( flow: string, scope: string ) {
 		}
 	};
 
-	// On becoming visible, check `/me` without waiting for the next poll tick.
+	// Coming back to this screen is the strongest signal there is that the link has just been
+	// opened, so check `/me` then rather than waiting for the next tick — which at the slowest
+	// rung is three minutes away. Focus as well as visibility: verifying in a desktop mail client
+	// never hides the tab, so `visibilitychange` alone would miss it. Only `visibilitychange`
+	// owns `isVisible`, since that decides whether the interval runs at all.
 	useEffect( () => {
-		const onVisibilityChange = () => {
-			const visible = document.visibilityState === 'visible';
-			setIsVisible( visible );
-			if ( visible && ! isVerified ) {
+		const checkNow = () => {
+			if ( ! isVerified ) {
+				// Concurrent calls collapse into one request via the in-flight guard in
+				// `fetchCurrentUser`, so overlapping with a visibility change costs nothing.
 				dispatch( fetchCurrentUser() );
 				syncPollDelay();
 			}
 		};
+		const onVisibilityChange = () => {
+			const visible = document.visibilityState === 'visible';
+			setIsVisible( visible );
+			if ( visible ) {
+				checkNow();
+			}
+		};
 		document.addEventListener( 'visibilitychange', onVisibilityChange );
-		return () => document.removeEventListener( 'visibilitychange', onVisibilityChange );
+		window.addEventListener( 'focus', checkNow );
+		return () => {
+			document.removeEventListener( 'visibilitychange', onVisibilityChange );
+			window.removeEventListener( 'focus', checkNow );
+		};
 	}, [ isVerified, dispatch, syncPollDelay ] );
 
 	useInterval(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/use-email-verification.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/use-email-verification.ts
@@ -20,15 +20,15 @@ import type { TimeoutMS } from 'calypso/types';
 
 // Polling is for the confirmation this tab can't otherwise see: `UserVerificationChecker` covers
 // the same browser instantly, and leaving for an inbox hides the tab, which pauses the poll and
-// re-checks on return. What's left is a link opened on another device, where someone is watching
-// this screen for it to resolve — so the opening rate is quick enough not to feel stuck, then
-// backs off rather than stopping, so a link opened an hour later still lands.
+// re-checks on return. What's left is a link opened on another device, which raises no signal at
+// all — polling is the only thing that will notice it. So the rate backs off rather than
+// stopping, and the slowest rung stays short: past it, the wait is time an already-verified
+// person spends looking at a screen that has nothing left to tell them.
 const POLL_SCHEDULE: { after: TimeoutMS; delay: TimeoutMS }[] = [
 	{ after: 0, delay: EVERY_TEN_SECONDS },
 	{ after: 5 * EVERY_MINUTE, delay: EVERY_THIRTY_SECONDS },
 	{ after: 10 * EVERY_MINUTE, delay: EVERY_MINUTE },
-	{ after: 30 * EVERY_MINUTE, delay: 5 * EVERY_MINUTE },
-	{ after: 60 * EVERY_MINUTE, delay: 10 * EVERY_MINUTE },
+	{ after: 30 * EVERY_MINUTE, delay: 3 * EVERY_MINUTE },
 ];
 
 function pollDelayAfter( elapsed: number ): TimeoutMS {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/use-email-verification.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/use-email-verification.ts
@@ -1,5 +1,4 @@
-import { fetchUser } from '@automattic/api-core';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
 	resendAcceptedRetryAfter,
 	resendThrottleRetryAfter,
@@ -7,22 +6,43 @@ import {
 import { useResendCooldown } from 'calypso/dashboard/utils/use-resend-cooldown';
 import { useSendEmailVerification } from 'calypso/landing/stepper/hooks/use-send-email-verification';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { EVERY_FIVE_SECONDS, useInterval } from 'calypso/lib/interval';
+import {
+	EVERY_MINUTE,
+	EVERY_TEN_SECONDS,
+	EVERY_THIRTY_SECONDS,
+	useInterval,
+} from 'calypso/lib/interval';
 import { useDispatch, useSelector } from 'calypso/state';
-import { fetchCurrentUser, setUserEmailVerified } from 'calypso/state/current-user/actions';
+import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { gateResendAvailableAt, markResendUnavailableUntil } from './storage';
+import type { TimeoutMS } from 'calypso/types';
 
-// Cross-device confirmation only reaches this tab by polling `/me` (`UserVerificationChecker`
-// covers the same browser instantly). Cap it so a tab left open overnight doesn't poll forever.
-const POLL_LIMIT_MS = 15 * 60 * 1000;
+// Polling is for the confirmation this tab can't otherwise see: `UserVerificationChecker` covers
+// the same browser instantly, and leaving for an inbox hides the tab, which pauses the poll and
+// re-checks on return. What's left is a link opened on another device, where someone is watching
+// this screen for it to resolve — so the opening rate is quick enough not to feel stuck, then
+// backs off rather than stopping, so a link opened an hour later still lands.
+const POLL_SCHEDULE: { after: TimeoutMS; delay: TimeoutMS }[] = [
+	{ after: 0, delay: EVERY_TEN_SECONDS },
+	{ after: 5 * EVERY_MINUTE, delay: EVERY_THIRTY_SECONDS },
+	{ after: 10 * EVERY_MINUTE, delay: EVERY_MINUTE },
+	{ after: 30 * EVERY_MINUTE, delay: 5 * EVERY_MINUTE },
+	{ after: 60 * EVERY_MINUTE, delay: 10 * EVERY_MINUTE },
+];
 
-// `error` (the request failed) is kept distinct from `unconfirmed` so a network failure
-// isn't mistaken for an unverified email.
-type CheckStatus = 'idle' | 'checking' | 'unconfirmed' | 'error';
+function pollDelayAfter( elapsed: number ): TimeoutMS {
+	let delay = POLL_SCHEDULE[ 0 ].delay;
+	for ( const step of POLL_SCHEDULE ) {
+		if ( elapsed >= step.after ) {
+			delay = step.delay;
+		}
+	}
+	return delay;
+}
 
-// `throttled` is distinct from `error` for the same reason: the send was refused, not failed. It
-// says only why the button is held — the countdown says whether it still is.
+// `throttled` is distinct from `error`: the send was refused, not failed. It says only why the
+// button is held — the countdown says whether it still is.
 type SendStatus = 'idle' | 'sending' | 'error' | 'throttled';
 
 export function useEmailVerification( flow: string, scope: string ) {
@@ -36,10 +56,15 @@ export function useEmailVerification( flow: string, scope: string ) {
 		initialDeadline: gateResendAvailableAt( scope ),
 		onHold: ( deadline ) => markResendUnavailableUntil( scope, deadline ),
 	} );
-	const [ isPollingExpired, setIsPollingExpired ] = useState( false );
-	const [ pollWindowKey, setPollWindowKey ] = useState( 0 );
-	const [ checkStatus, setCheckStatus ] = useState< CheckStatus >( 'idle' );
+	const pollStartedAt = useRef( Date.now() );
+	const [ pollDelay, setPollDelay ] = useState< TimeoutMS >( POLL_SCHEDULE[ 0 ].delay );
 	const [ isVisible, setIsVisible ] = useState( () => document.visibilityState === 'visible' );
+
+	// Moves the poll onto the rung its elapsed time has reached. Called from the tick itself and
+	// on return to the tab, which is where a long stretch of not polling gets accounted for.
+	const syncPollDelay = useCallback( () => {
+		setPollDelay( pollDelayAfter( Date.now() - pollStartedAt.current ) );
+	}, [] );
 
 	// The initial email is the activation email from account creation; this only resends.
 	const resend = async () => {
@@ -51,10 +76,9 @@ export function useEmailVerification( flow: string, scope: string ) {
 				throw new Error( 'unsuccessful_response' );
 			}
 			holdResend( resendAcceptedRetryAfter( response ) );
-			// A fresh link restarts the polling window; it may be confirmed long after the last.
-			setIsPollingExpired( false );
-			setPollWindowKey( ( key ) => key + 1 );
-			setCheckStatus( 'idle' );
+			// A fresh link is about to be opened, so poll tightly again from here.
+			pollStartedAt.current = Date.now();
+			setPollDelay( POLL_SCHEDULE[ 0 ].delay );
 			setSendStatus( 'idle' );
 			recordTracksEvent( 'calypso_signup_email_verification_email_sent', {
 				flow,
@@ -83,52 +107,25 @@ export function useEmailVerification( flow: string, scope: string ) {
 			setIsVisible( visible );
 			if ( visible && ! isVerified ) {
 				dispatch( fetchCurrentUser() );
+				syncPollDelay();
 			}
 		};
 		document.addEventListener( 'visibilitychange', onVisibilityChange );
 		return () => document.removeEventListener( 'visibilitychange', onVisibilityChange );
-	}, [ isVerified, dispatch ] );
-
-	useEffect( () => {
-		if ( isVerified ) {
-			return;
-		}
-		const timer = setTimeout( () => setIsPollingExpired( true ), POLL_LIMIT_MS );
-		return () => clearTimeout( timer );
-	}, [ isVerified, pollWindowKey ] );
+	}, [ isVerified, dispatch, syncPollDelay ] );
 
 	useInterval(
-		() => dispatch( fetchCurrentUser() ),
-		isVisible && ! isVerified && ! isPollingExpired && EVERY_FIVE_SECONDS
+		() => {
+			dispatch( fetchCurrentUser() );
+			syncPollDelay();
+		},
+		isVisible && ! isVerified && pollDelay
 	);
-
-	const checkNow = useCallback( async () => {
-		setCheckStatus( 'checking' );
-		// Clear a stale send failure, but not a throttle — that one is still true, and the
-		// button is still counting down against it.
-		setSendStatus( ( status ) => ( status === 'error' ? 'idle' : status ) );
-		recordTracksEvent( 'calypso_signup_email_verification_check_click', { flow } );
-
-		try {
-			// `fetchUser` throws on a failed request, so a network problem can't be
-			// mistaken for an unconfirmed email the way `fetchCurrentUser` would.
-			const { email_verified } = await fetchUser();
-			if ( email_verified ) {
-				dispatch( setUserEmailVerified( true ) );
-			} else {
-				setCheckStatus( 'unconfirmed' );
-			}
-		} catch {
-			setCheckStatus( 'error' );
-		}
-	}, [ dispatch, flow ] );
 
 	return {
 		isVerified,
 		sendStatus,
 		secondsUntilResend,
-		checkStatus,
-		checkNow,
 		resend,
 	};
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/use-email-verification.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/use-email-verification.ts
@@ -18,12 +18,10 @@ import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors
 import { gateResendAvailableAt, markResendUnavailableUntil } from './storage';
 import type { TimeoutMS } from 'calypso/types';
 
-// Polling is for the confirmation this tab can't otherwise see: `UserVerificationChecker` covers
-// the same browser instantly, and leaving for an inbox hides the tab, which pauses the poll and
-// re-checks on return. What's left is a link opened on another device, which raises no signal at
-// all — polling is the only thing that will notice it. So the rate backs off rather than
-// stopping, and the slowest rung stays short: past it, the wait is time an already-verified
-// person spends looking at a screen that has nothing left to tell them.
+// A confirmation on another device raises no signal — `UserVerificationChecker` covers the same
+// browser, and returning to the tab re-checks — so polling is the only thing that notices it.
+// Hence a floor rather than an expiry: past the last rung the wait is time an already-verified
+// person spends on a screen with nothing left to tell them.
 const POLL_SCHEDULE: { after: TimeoutMS; delay: TimeoutMS }[] = [
 	{ after: 0, delay: EVERY_TEN_SECONDS },
 	{ after: 5 * EVERY_MINUTE, delay: EVERY_THIRTY_SECONDS },


### PR DESCRIPTION
Part of DOTCOM-18087.

## Proposed Changes

* The email verification gate keeps checking for the confirmation for as long as it is open, instead of giving up after fifteen minutes. The rate backs off in stages rather than running at a fixed interval.
* Removed the manual "I've confirmed my email" fallback. The screen now offers an inbox link where the provider is recognised, and a resend either way, matching the magic login screen.
* Added a view event carrying the email provider.
* Recognise the country domains that Microsoft, Yahoo and AOL each serve from a single mailbox, so international addresses get an inbox link too.

The feature flag remains off everywhere; none of this is live yet.

## Why are these changes being made?

The gate is resolved by checking whether the account has been verified. Stopping that check after fifteen minutes meant a link opened later — most often on a phone, while the signup tab sits untouched on screen — never reached the tab waiting for it, leaving a screen that would never advance. Backing off instead of stopping removes that dead end, and costs substantially fewer requests than the fixed five-second poll it replaces.

Once the check no longer expires, the manual fallback has nothing left to catch: anything it could find, the check now finds on its own. Dropping it also means an unrecognised provider gets the same screen the magic login flow already gives them.

The provider on the view event is the missing denominator for the existing click and confirmation events. Without it there is no way to tell whether the inbox link is what closes the loop, or how large the group without one is — and that group is smaller now that international addresses are matched.

## Testing Instructions

1. Run Calypso locally and open `/setup/onboarding?flags=onboarding/email-verification`.
2. Create an account with an email address you can read. Use a Gmail address to get the inbox link variant, or any unrecognised domain for the resend-only variant. The gate should appear once the account is created.
3. Confirm the email somewhere other than this browser — a phone, or a different browser — without touching the signup tab. The gate should resolve on its own and the flow should continue.
4. Repeat, but leave the tab open for more than fifteen minutes before confirming. It should still resolve; previously it would not have.
5. Watch the network panel over a few minutes: requests to `/me` should space out as time passes rather than firing at a fixed interval, and should keep going indefinitely.
6. Press Resend and check the requests return to the opening rate.
7. Check that no "I've confirmed my email" button appears for an unrecognised domain, and that an address at a country domain such as `hotmail.co.uk` now gets an inbox link.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
