### PR TITLE
Stats: Follow admin accent on post card upload button

### DIFF
--- a/client/components/post-stats-card/index.tsx
+++ b/client/components/post-stats-card/index.tsx
@@ -1,7 +1,8 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Card, Button } from '@automattic/components';
+import { Card } from '@automattic/components';
 import { eye } from '@automattic/components/src/icons';
 import { formatNumberCompact } from '@automattic/number-formatters';
+import { Button } from '@wordpress/components';
 import { Icon, commentContent, starEmpty } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -106,7 +107,9 @@ export default function PostStatsCard( {
 			{ ( isLoading || ( ! post?.post_thumbnail && uploadHref ) ) && (
 				<div className="post-stats-card__upload">
 					<Button
-						className="post-stats-card__upload-btn is-compact"
+						variant="secondary"
+						size="compact"
+						className="post-stats-card__upload-btn"
 						onClick={ recordClickOnUploadImageButton }
 					>
 						{ translate( 'Add featured image' ) }

--- a/client/components/post-stats-card/style.scss
+++ b/client/components/post-stats-card/style.scss
@@ -132,7 +132,7 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 
 .post-stats-card__upload {
 	max-width: 500px;
-	padding: 0 8px;
+	padding: $card-padding;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -141,16 +141,11 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 	box-sizing: border-box;
 }
 
-.post-stats-card__upload-btn {
-	color: var(--studio-gray-100);
-	font-family: $font-sf-pro-display;
-	font-size: $font-body-small;
-	font-weight: 500;
-	line-height: 20px;
-	letter-spacing: 0.32px;
-	border: 1px solid var(--studio-gray-5);
-	border-radius: 4px;
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+.post-stats-card__upload-btn.components-button {
+	max-width: 100%;
+	min-height: 32px;
+	height: auto;
+	white-space: normal;
 }
 
 @media (max-width: $break-large) {


### PR DESCRIPTION
Fixes STATS-361

## Why

In Stats Insights, the "Add featured image" prompt shown on posts without a featured image had a border in the site's admin color but gray text, so it looked half-styled and inconsistent. It now follows the admin color scheme fully — text and border both match the chosen admin color — and the label wraps neatly instead of spilling out of its slot in longer languages.

## Proposed Changes

* Swap the post stats card's "Add featured image" button from the `@automattic/components` Button to the `@wordpress/components` secondary Button, so text and border both follow the admin accent.
* Drop the custom button theming CSS — the secondary variant themes itself.
* Give the upload slot real padding and let the label wrap (`white-space: normal`, `height: auto`) rather than overflowing.

## Screenshots

Stats → Insights, on a post with no featured image.

**Before** — gray text and border, unthemed

<img width="1214" height="558" alt="before-gray" src="https://github.com/user-attachments/assets/c46b7528-b4e8-4256-8fce-2f6b32ca835c" />

**After** — text and border follow the admin accent, with padding around the slot

<img width="1184" height="546" alt="after-themed" src="https://github.com/user-attachments/assets/ad7d0f97-a961-483b-a851-524f7070030d" />

## Why are these changes being made?

The button previously mixed a themed border with gray text. Routing it through the design system's secondary variant makes it consistent and removes the hand-rolled color CSS.

The secondary variant works in Calypso because it reads `--wp-admin-theme-color` directly, which Calypso aliases to `--color-accent` inside each `.color-scheme` block, so it re-resolves per scheme. Note that `@wordpress/ui`'s `tone="brand"` does **not** work here: its `--wpds-*-brand` tokens resolve at `:root`, where the scheme class is not applied, so they stay the default blue regardless of the admin color.

The button appears on the "Latest post" / "Most popular post" cards for a post that has **no featured image**.

### Calypso Stats

1. Open **Stats → Insights** for a site whose admin color scheme is set to a non-default color (e.g. Coffee, via **Users → Profile**).
2. Locate the "Add featured image" button on the highlights card.
3. Confirm the button's **text and border both match the admin color** (previously the text was gray).
4. Change the admin color scheme and reload — the button follows the new color.
5. Optional: temporarily lengthen the label to confirm it wraps within its slot instead of overflowing.

### Odyssey Stats (wp-admin)

1. On a Jetpack-connected site, set the wp-admin color scheme to a non-default color (**Users → Profile → Admin Color Scheme**, e.g. Coffee).
2. Open **Jetpack → Stats → Insights** in wp-admin.
3. Confirm the "Add featured image" button's text and border both follow the wp-admin color scheme, and that the button is fully styled (the `@wordpress/components` secondary styles load inside the Odyssey bundle).

Verified in **Calypso** (Simple site, Coffee and default schemes) and in **Odyssey / wp-admin** (Coffee scheme) — the button themes correctly in both, matching the admin accent.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)


