### PR TITLE
Marketplace: stop re-activating a plugin that is already active

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-post-transfer-plugin-recovery.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-post-transfer-plugin-recovery.tsx
@@ -5,8 +5,15 @@ import { renderHook } from '@testing-library/react';
 import { usePostTransferPluginRecovery } from '../use-post-transfer-plugin-recovery';
 
 const mockDispatch = jest.fn();
+const mockStore = { getState: () => ( {} ) };
 jest.mock( 'calypso/state', () => ( {
 	useDispatch: () => mockDispatch,
+	useStore: () => mockStore,
+} ) );
+// What the refreshed plugin list says, which is what the hook decides on.
+const mockIsPluginActive = jest.fn( () => false );
+jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
+	isPluginActive: () => mockIsPluginActive(),
 } ) );
 jest.mock( 'calypso/state/plugins/installed/actions', () => ( {
 	fetchSitePlugins: jest.fn( ( siteId: number ) => ( { type: 'FETCH_SITE_PLUGINS', siteId } ) ),
@@ -31,7 +38,7 @@ const { fetchSitePlugins, activatePlugin } = jest.requireMock(
 	'calypso/state/plugins/installed/actions'
 );
 
-const INSTALLED = { slug: 'sensei-pro', id: 'sensei-pro/sensei-pro' };
+const INSTALLED = { slug: 'sensei-pro', id: 'sensei-pro/sensei-pro', active: false };
 
 type Props = Parameters< typeof usePostTransferPluginRecovery >[ 0 ];
 const defaults: Props = {
@@ -45,21 +52,27 @@ const render = ( props?: Partial< Props > ) =>
 	renderHook( ( p: Props ) => usePostTransferPluginRecovery( p ), {
 		initialProps: { ...defaults, ...props },
 	} );
-const tick = () => mockIntervalCallback?.();
-// The in-flight guard clears in the dispatched thunk's `.finally`, a microtask; let it settle.
-const settle = () => Promise.resolve();
+// A tick refreshes the plugin list and only then decides, so let those promises settle before
+// asserting. `settle` is kept separate for the tests that assert on a tick still in flight.
+const settle = () => new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+const startTick = () => mockIntervalCallback?.();
+const tick = async () => {
+	startTick();
+	await settle();
+};
 
 describe( 'usePostTransferPluginRecovery', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockIsPluginActive.mockReturnValue( false );
 		mockIntervalCallback = null;
 		mockIntervalDelay = null;
 	} );
 
-	it( 'polls the site plugins on an interval while enabled', () => {
+	it( 'polls the site plugins on an interval while enabled', async () => {
 		render( { installedPlugin: null } );
 		expect( mockIntervalDelay ).toBe( 3000 );
-		tick();
+		await tick();
 		expect( fetchSitePlugins ).toHaveBeenCalledWith( 1 );
 	} );
 
@@ -68,71 +81,101 @@ describe( 'usePostTransferPluginRecovery', () => {
 		expect( mockIntervalDelay ).toBeNull();
 	} );
 
-	it( 'nudges an installed-but-inactive plugin active on a tick', () => {
+	it( 'nudges an installed-but-inactive plugin active on a tick', async () => {
 		render();
-		tick();
-		expect( activatePlugin ).toHaveBeenCalledWith( 1, {
-			slug: 'sensei-pro',
-			id: 'sensei-pro/sensei-pro',
-		} );
+		await tick();
+		// The plugin goes over as the store has it, so activatePlugin can read `active` off it.
+		expect( activatePlugin ).toHaveBeenCalledWith( 1, INSTALLED );
+	} );
+
+	it( 'refreshes the plugin list before deciding whether to activate', async () => {
+		render();
+		startTick();
+		// The refresh is dispatched up front; the activation waits on its result.
+		expect( fetchSitePlugins ).toHaveBeenCalledWith( 1 );
+		expect( activatePlugin ).not.toHaveBeenCalled();
+
+		await settle();
+		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not activate a plugin the refreshed list already reports active', async () => {
+		mockIsPluginActive.mockReturnValue( true );
+		render();
+		await tick();
+		expect( fetchSitePlugins ).toHaveBeenCalledWith( 1 );
+		expect( activatePlugin ).not.toHaveBeenCalled();
+	} );
+
+	// The endpoint may not be able to report the benign already-active case, in which case a
+	// redundant activation comes back as a plain failure and the plugin stays inactive in the props
+	// this hook was rendered with. The refreshed list is what settles it either way.
+	it( 'stops re-activating once the refreshed list reports active, even while the props say otherwise', async () => {
+		render();
+		await tick();
+		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
+
+		// No rerender: the failed activation left `active` false on the props, as it would in the
+		// browser. Only the refreshed list knows better.
+		mockIsPluginActive.mockReturnValue( true );
+		await tick();
+		await tick();
+		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'does not consume the retry budget while it cannot yet activate', async () => {
 		const { rerender } = render( { canActivate: false } );
-		tick();
-		tick();
+		await tick();
+		await tick();
 		expect( activatePlugin ).not.toHaveBeenCalled();
 
 		// Once ready, all attempts remain available.
 		rerender( defaults );
-		tick();
-		await settle();
-		tick();
-		await settle();
-		tick();
+		await tick();
+		await tick();
+		await tick();
 		expect( activatePlugin ).toHaveBeenCalledTimes( 3 );
 	} );
 
 	it( 'does not start a new attempt while the previous one is still in flight', () => {
 		render();
-		tick();
-		tick();
-		tick();
-		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
+		startTick();
+		startTick();
+		startTick();
+		expect( activatePlugin ).not.toHaveBeenCalled();
 	} );
 
 	it( 'retries a bounded number of times once attempts settle, not forever', async () => {
 		render();
 		for ( let i = 0; i < 6; i++ ) {
-			tick();
-			await settle();
+			await tick();
 		}
 		expect( activatePlugin ).toHaveBeenCalledTimes( 3 );
 	} );
 
 	it( 'refreshes the plugin list right after activating, without waiting for the next poll', async () => {
 		render();
-		tick();
-		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
+		startTick();
 		const pollFetches = fetchSitePlugins.mock.calls.length;
 		await settle();
+		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
 		expect( fetchSitePlugins.mock.calls.length ).toBeGreaterThan( pollFetches );
 		expect( fetchSitePlugins ).toHaveBeenLastCalledWith( 1 );
 	} );
 
-	it( 'does not activate when it does not own activation (the step-driven flow does)', () => {
+	it( 'does not activate when it does not own activation (the step-driven flow does)', async () => {
 		render( { ownsActivation: false } );
-		tick();
+		await tick();
 		expect( activatePlugin ).not.toHaveBeenCalled();
 	} );
 
-	it( 'waits to activate until the plugin appears in the refreshed list', () => {
+	it( 'waits to activate until the plugin appears in the refreshed list', async () => {
 		const { rerender } = render( { installedPlugin: null } );
-		tick();
+		await tick();
 		expect( activatePlugin ).not.toHaveBeenCalled();
 
 		rerender( defaults );
-		tick();
+		await tick();
 		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-post-transfer-plugin-recovery.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-post-transfer-plugin-recovery.tsx
@@ -52,8 +52,8 @@ const render = ( props?: Partial< Props > ) =>
 	renderHook( ( p: Props ) => usePostTransferPluginRecovery( p ), {
 		initialProps: { ...defaults, ...props },
 	} );
-// A tick refreshes the plugin list and only then decides, so let those promises settle before
-// asserting. `settle` is kept separate for the tests that assert on a tick still in flight.
+// A tick refreshes the plugin list before deciding, so let it settle. The two are kept separate for
+// the tests that assert mid-tick.
 const settle = () => new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
 const startTick = () => mockIntervalCallback?.();
 const tick = async () => {
@@ -90,7 +90,6 @@ describe( 'usePostTransferPluginRecovery', () => {
 	it( 'refreshes the plugin list before deciding whether to activate', async () => {
 		render();
 		startTick();
-		// The refresh is dispatched up front; the activation waits on its result.
 		expect( fetchSitePlugins ).toHaveBeenCalledWith( 1 );
 		expect( activatePlugin ).not.toHaveBeenCalled();
 
@@ -98,29 +97,23 @@ describe( 'usePostTransferPluginRecovery', () => {
 		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'does not activate a plugin the refreshed list already reports active', async () => {
+	it( 'does not activate when the refreshed list has no inactive plugin to act on', async () => {
 		mockGetPluginOnSite.mockReturnValue( { ...INSTALLED, active: true } );
 		render();
 		await tick();
-		expect( fetchSitePlugins ).toHaveBeenCalledWith( 1 );
 		expect( activatePlugin ).not.toHaveBeenCalled();
-	} );
 
-	it( 'does not activate when the refreshed list does not have the plugin', async () => {
 		mockGetPluginOnSite.mockReturnValue( undefined );
-		render();
 		await tick();
 		expect( activatePlugin ).not.toHaveBeenCalled();
 
-		// The budget is intact for when it does show up.
+		// Neither skip spent an attempt.
 		mockGetPluginOnSite.mockReturnValue( INSTALLED );
 		await tick();
-		await tick();
-		await tick();
-		expect( activatePlugin ).toHaveBeenCalledTimes( 3 );
+		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	// The budget used to go on redundant attempts: an endpoint with no way to report the benign
+	// The budget used to go on redundant attempts: an endpoint that cannot report the benign
 	// already-active case answers each one with a plain failure, which never flips `active`.
 	it( 'spends no further attempts once a later refresh reports the plugin active', async () => {
 		render();

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-post-transfer-plugin-recovery.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-post-transfer-plugin-recovery.tsx
@@ -46,7 +46,7 @@ const defaults: Props = {
 	enabled: true,
 	canActivate: true,
 	ownsActivation: true,
-	installedPlugin: INSTALLED,
+	installedPluginSlug: INSTALLED.slug,
 };
 const render = ( props?: Partial< Props > ) =>
 	renderHook( ( p: Props ) => usePostTransferPluginRecovery( p ), {
@@ -70,7 +70,7 @@ describe( 'usePostTransferPluginRecovery', () => {
 	} );
 
 	it( 'polls the site plugins on an interval while enabled', async () => {
-		render( { installedPlugin: null } );
+		render( { installedPluginSlug: undefined } );
 		expect( mockIntervalDelay ).toBe( 3000 );
 		await tick();
 		expect( fetchSitePlugins ).toHaveBeenCalledWith( 1 );
@@ -120,10 +120,9 @@ describe( 'usePostTransferPluginRecovery', () => {
 		expect( activatePlugin ).toHaveBeenCalledTimes( 3 );
 	} );
 
-	// An endpoint with no way to report the benign already-active case answers a redundant activation
-	// with a plain failure, leaving the plugin reading inactive in the props this hook was rendered
-	// with. Nothing here rerenders, mirroring that.
-	it( 'stops re-activating once the refreshed list reports active, even while the props say otherwise', async () => {
+	// The budget used to go on redundant attempts: an endpoint with no way to report the benign
+	// already-active case answers each one with a plain failure, which never flips `active`.
+	it( 'spends no further attempts once a later refresh reports the plugin active', async () => {
 		render();
 		await tick();
 		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
@@ -181,7 +180,7 @@ describe( 'usePostTransferPluginRecovery', () => {
 	} );
 
 	it( 'waits to activate until the caller knows which plugin was installed', async () => {
-		const { rerender } = render( { installedPlugin: null } );
+		const { rerender } = render( { installedPluginSlug: undefined } );
 		await tick();
 		expect( activatePlugin ).not.toHaveBeenCalled();
 

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-post-transfer-plugin-recovery.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-post-transfer-plugin-recovery.tsx
@@ -11,9 +11,9 @@ jest.mock( 'calypso/state', () => ( {
 	useStore: () => mockStore,
 } ) );
 // What the refreshed plugin list says, which is what the hook decides on.
-const mockIsPluginActive = jest.fn( () => false );
+const mockGetPluginOnSite = jest.fn();
 jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
-	isPluginActive: () => mockIsPluginActive(),
+	getPluginOnSite: () => mockGetPluginOnSite(),
 } ) );
 jest.mock( 'calypso/state/plugins/installed/actions', () => ( {
 	fetchSitePlugins: jest.fn( ( siteId: number ) => ( { type: 'FETCH_SITE_PLUGINS', siteId } ) ),
@@ -64,7 +64,7 @@ const tick = async () => {
 describe( 'usePostTransferPluginRecovery', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		mockIsPluginActive.mockReturnValue( false );
+		mockGetPluginOnSite.mockReturnValue( INSTALLED );
 		mockIntervalCallback = null;
 		mockIntervalDelay = null;
 	} );
@@ -84,7 +84,6 @@ describe( 'usePostTransferPluginRecovery', () => {
 	it( 'nudges an installed-but-inactive plugin active on a tick', async () => {
 		render();
 		await tick();
-		// The plugin goes over as the store has it, so activatePlugin can read `active` off it.
 		expect( activatePlugin ).toHaveBeenCalledWith( 1, INSTALLED );
 	} );
 
@@ -100,24 +99,36 @@ describe( 'usePostTransferPluginRecovery', () => {
 	} );
 
 	it( 'does not activate a plugin the refreshed list already reports active', async () => {
-		mockIsPluginActive.mockReturnValue( true );
+		mockGetPluginOnSite.mockReturnValue( { ...INSTALLED, active: true } );
 		render();
 		await tick();
 		expect( fetchSitePlugins ).toHaveBeenCalledWith( 1 );
 		expect( activatePlugin ).not.toHaveBeenCalled();
 	} );
 
-	// The endpoint may not be able to report the benign already-active case, in which case a
-	// redundant activation comes back as a plain failure and the plugin stays inactive in the props
-	// this hook was rendered with. The refreshed list is what settles it either way.
+	it( 'does not activate when the refreshed list does not have the plugin', async () => {
+		mockGetPluginOnSite.mockReturnValue( undefined );
+		render();
+		await tick();
+		expect( activatePlugin ).not.toHaveBeenCalled();
+
+		// The budget is intact for when it does show up.
+		mockGetPluginOnSite.mockReturnValue( INSTALLED );
+		await tick();
+		await tick();
+		await tick();
+		expect( activatePlugin ).toHaveBeenCalledTimes( 3 );
+	} );
+
+	// An endpoint with no way to report the benign already-active case answers a redundant activation
+	// with a plain failure, leaving the plugin reading inactive in the props this hook was rendered
+	// with. Nothing here rerenders, mirroring that.
 	it( 'stops re-activating once the refreshed list reports active, even while the props say otherwise', async () => {
 		render();
 		await tick();
 		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
 
-		// No rerender: the failed activation left `active` false on the props, as it would in the
-		// browser. Only the refreshed list knows better.
-		mockIsPluginActive.mockReturnValue( true );
+		mockGetPluginOnSite.mockReturnValue( { ...INSTALLED, active: true } );
 		await tick();
 		await tick();
 		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
@@ -169,7 +180,7 @@ describe( 'usePostTransferPluginRecovery', () => {
 		expect( activatePlugin ).not.toHaveBeenCalled();
 	} );
 
-	it( 'waits to activate until the plugin appears in the refreshed list', async () => {
+	it( 'waits to activate until the caller knows which plugin was installed', async () => {
 		const { rerender } = render( { installedPlugin: null } );
 		await tick();
 		expect( activatePlugin ).not.toHaveBeenCalled();

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
@@ -185,8 +185,6 @@ describe( 'useProductInstall progression', () => {
 			);
 		} );
 		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
-		// The plugin goes over as the store has it, `active` included, so activatePlugin can skip the
-		// request for one that is already active.
 		expect( activatePlugin ).toHaveBeenCalledWith(
 			SITE_ID,
 			expect.objectContaining( { slug: 'give', id: 'give/give', active: false } )

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
@@ -185,7 +185,12 @@ describe( 'useProductInstall progression', () => {
 			);
 		} );
 		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
-		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, { slug: 'give', id: 'give/give' } );
+		// The plugin goes over as the store has it, `active` included, so activatePlugin can skip the
+		// request for one that is already active.
+		expect( activatePlugin ).toHaveBeenCalledWith(
+			SITE_ID,
+			expect.objectContaining( { slug: 'give', id: 'give/give', active: false } )
+		);
 		expect( result.current.currentStep ).toBe( 2 );
 	} );
 

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-post-transfer-plugin-recovery.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-post-transfer-plugin-recovery.ts
@@ -16,13 +16,14 @@ export function usePostTransferPluginRecovery( {
 	enabled,
 	canActivate,
 	ownsActivation,
-	installedPlugin,
+	installedPluginSlug,
 }: {
 	siteId: number;
 	enabled: boolean;
 	canActivate: boolean;
 	ownsActivation: boolean;
-	installedPlugin: { slug?: string; id?: string } | null | undefined;
+	// The slug the plugin installed under, which for a marketplace product is not the route slug.
+	installedPluginSlug: string | undefined;
 } ): void {
 	const dispatch = useDispatch();
 	const store = useStore();
@@ -38,21 +39,20 @@ export function usePostTransferPluginRecovery( {
 			if (
 				! canActivate ||
 				! ownsActivation ||
-				! installedPlugin?.slug ||
+				! installedPluginSlug ||
 				inFlightRef.current ||
 				attemptsRef.current >= MAX_ACTIVATION_ATTEMPTS
 			) {
 				return;
 			}
 
-			const { slug } = installedPlugin;
 			inFlightRef.current = true;
 			refreshed
 				.then( () => {
 					// An endpoint with no way to report the benign already-active case answers a redundant
 					// activation with a plain failure, which leaves `active` false in the store. The
 					// refreshed list is what settles it either way.
-					const plugin = getPluginOnSite( store.getState(), siteId, slug );
+					const plugin = getPluginOnSite( store.getState(), siteId, installedPluginSlug );
 					if ( ! plugin || plugin.active ) {
 						return;
 					}

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-post-transfer-plugin-recovery.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-post-transfer-plugin-recovery.ts
@@ -2,7 +2,7 @@ import { useRef } from 'react';
 import { useInterval } from 'calypso/lib/interval';
 import { useDispatch, useStore } from 'calypso/state';
 import { activatePlugin, fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
-import { isPluginActive } from 'calypso/state/plugins/installed/selectors-ts';
+import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors-ts';
 
 const POLL_INTERVAL_MS = 3000;
 const MAX_ACTIVATION_ATTEMPTS = 3;
@@ -22,7 +22,7 @@ export function usePostTransferPluginRecovery( {
 	enabled: boolean;
 	canActivate: boolean;
 	ownsActivation: boolean;
-	installedPlugin: { slug?: string; id?: string; active?: boolean } | null | undefined;
+	installedPlugin: { slug?: string; id?: string } | null | undefined;
 } ): void {
 	const dispatch = useDispatch();
 	const store = useStore();
@@ -35,12 +35,10 @@ export function usePostTransferPluginRecovery( {
 
 			// Gate activation on: the transfer being usable (capability gap); this hook owning activation
 			// (the step-driven flow owns it otherwise); one settled attempt at a time; a bounded budget.
-			// Checked now rather than after the refresh, so a flow that has moved on in the meantime does
-			// not get an activation it no longer owns.
 			if (
 				! canActivate ||
 				! ownsActivation ||
-				! installedPlugin?.id ||
+				! installedPlugin?.slug ||
 				inFlightRef.current ||
 				attemptsRef.current >= MAX_ACTIVATION_ATTEMPTS
 			) {
@@ -51,23 +49,19 @@ export function usePostTransferPluginRecovery( {
 			inFlightRef.current = true;
 			refreshed
 				.then( () => {
-					// Decide from the refreshed list read straight off the store, not from the props this
-					// tick closed over. An endpoint that cannot report the benign already-active case
-					// answers a redundant activation with a plain failure, which leaves `active` false in
-					// the store — so props alone would have this poll spend its whole budget re-activating
-					// a plugin the refresh has already shown to be active.
-					if ( ! slug || isPluginActive( store.getState(), siteId, slug ) ) {
+					// An endpoint with no way to report the benign already-active case answers a redundant
+					// activation with a plain failure, which leaves `active` false in the store. The
+					// refreshed list is what settles it either way.
+					const plugin = getPluginOnSite( store.getState(), siteId, slug );
+					if ( ! plugin || plugin.active ) {
 						return;
 					}
 
 					attemptsRef.current += 1;
-					// Hand over the plugin as the store has it rather than a slug/id pair, so
-					// activatePlugin can apply its own already-active guard too.
-					return Promise.resolve( dispatch( activatePlugin( siteId, installedPlugin ) ) ).finally(
-						() =>
-							// Refresh right away so the now-active plugin is observed immediately, rather than
-							// waiting for the next poll — the caller's redirect is gated on that active state.
-							dispatch( fetchSitePlugins( siteId ) )
+					return Promise.resolve( dispatch( activatePlugin( siteId, plugin ) ) ).finally( () =>
+						// Refresh right away so the now-active plugin is observed immediately, rather than
+						// waiting for the next poll — the caller's redirect is gated on that active state.
+						dispatch( fetchSitePlugins( siteId ) )
 					);
 				} )
 				.finally( () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-post-transfer-plugin-recovery.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-post-transfer-plugin-recovery.ts
@@ -1,7 +1,8 @@
 import { useRef } from 'react';
 import { useInterval } from 'calypso/lib/interval';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useStore } from 'calypso/state';
 import { activatePlugin, fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
+import { isPluginActive } from 'calypso/state/plugins/installed/selectors-ts';
 
 const POLL_INTERVAL_MS = 3000;
 const MAX_ACTIVATION_ATTEMPTS = 3;
@@ -21,18 +22,21 @@ export function usePostTransferPluginRecovery( {
 	enabled: boolean;
 	canActivate: boolean;
 	ownsActivation: boolean;
-	installedPlugin: { slug?: string; id?: string } | null | undefined;
+	installedPlugin: { slug?: string; id?: string; active?: boolean } | null | undefined;
 } ): void {
 	const dispatch = useDispatch();
+	const store = useStore();
 	const attemptsRef = useRef( 0 );
 	const inFlightRef = useRef( false );
 
 	useInterval(
 		() => {
-			dispatch( fetchSitePlugins( siteId ) );
+			const refreshed = Promise.resolve( dispatch( fetchSitePlugins( siteId ) ) );
 
 			// Gate activation on: the transfer being usable (capability gap); this hook owning activation
 			// (the step-driven flow owns it otherwise); one settled attempt at a time; a bounded budget.
+			// Checked now rather than after the refresh, so a flow that has moved on in the meantime does
+			// not get an activation it no longer owns.
 			if (
 				! canActivate ||
 				! ownsActivation ||
@@ -43,16 +47,32 @@ export function usePostTransferPluginRecovery( {
 				return;
 			}
 
-			attemptsRef.current += 1;
+			const { slug } = installedPlugin;
 			inFlightRef.current = true;
-			Promise.resolve(
-				dispatch( activatePlugin( siteId, { slug: installedPlugin.slug, id: installedPlugin.id } ) )
-			).finally( () => {
-				inFlightRef.current = false;
-				// Refresh right away so the now-active plugin is observed immediately, rather than waiting
-				// for the next poll — the caller's redirect is gated on that active state.
-				dispatch( fetchSitePlugins( siteId ) );
-			} );
+			refreshed
+				.then( () => {
+					// Decide from the refreshed list read straight off the store, not from the props this
+					// tick closed over. An endpoint that cannot report the benign already-active case
+					// answers a redundant activation with a plain failure, which leaves `active` false in
+					// the store — so props alone would have this poll spend its whole budget re-activating
+					// a plugin the refresh has already shown to be active.
+					if ( ! slug || isPluginActive( store.getState(), siteId, slug ) ) {
+						return;
+					}
+
+					attemptsRef.current += 1;
+					// Hand over the plugin as the store has it rather than a slug/id pair, so
+					// activatePlugin can apply its own already-active guard too.
+					return Promise.resolve( dispatch( activatePlugin( siteId, installedPlugin ) ) ).finally(
+						() =>
+							// Refresh right away so the now-active plugin is observed immediately, rather than
+							// waiting for the next poll — the caller's redirect is gated on that active state.
+							dispatch( fetchSitePlugins( siteId ) )
+					);
+				} )
+				.finally( () => {
+					inFlightRef.current = false;
+				} );
 		},
 		enabled ? POLL_INTERVAL_MS : null
 	);

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-post-transfer-plugin-recovery.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-post-transfer-plugin-recovery.ts
@@ -49,9 +49,8 @@ export function usePostTransferPluginRecovery( {
 			inFlightRef.current = true;
 			refreshed
 				.then( () => {
-					// An endpoint with no way to report the benign already-active case answers a redundant
-					// activation with a plain failure, which leaves `active` false in the store. The
-					// refreshed list is what settles it either way.
+					// An endpoint that cannot report the benign already-active case answers a redundant
+					// activation with a plain failure, which never flips `active`. Only the refresh does.
 					const plugin = getPluginOnSite( store.getState(), siteId, installedPluginSlug );
 					if ( ! plugin || plugin.active ) {
 						return;

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -249,8 +249,6 @@ export function useProductInstall( {
 			( ! isPluginUploadFlow || pluginUploadComplete )
 		) {
 			if ( ! isTransferredUpload ) {
-				// Hand over the plugin as the store has it rather than a slug/id pair, so activatePlugin
-				// can read `active` off it and skip the request for a plugin that is already active.
 				dispatch( activatePlugin( siteId, installedPlugin ) );
 			}
 			setCurrentStep( 2 );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -249,12 +249,9 @@ export function useProductInstall( {
 			( ! isPluginUploadFlow || pluginUploadComplete )
 		) {
 			if ( ! isTransferredUpload ) {
-				dispatch(
-					activatePlugin( siteId, {
-						slug: installedPlugin?.slug,
-						id: installedPlugin?.id,
-					} )
-				);
+				// Hand over the plugin as the store has it rather than a slug/id pair, so activatePlugin
+				// can read `active` off it and skip the request for a plugin that is already active.
+				dispatch( activatePlugin( siteId, installedPlugin ) );
 			}
 			setCurrentStep( 2 );
 		}

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
@@ -36,7 +36,7 @@ export function useThankYouRedirect( {
 	themeSlug: string;
 	wpOrgTheme: { id?: string } | null | undefined;
 	isThemeActive: boolean;
-	installedPlugin: { slug?: string; id?: string } | null | undefined;
+	installedPlugin: { slug?: string; id?: string; active?: boolean } | null | undefined;
 	pluginActive: boolean;
 	atomicFlow: boolean;
 	automatedTransferStatus: string | null;

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
@@ -36,7 +36,7 @@ export function useThankYouRedirect( {
 	themeSlug: string;
 	wpOrgTheme: { id?: string } | null | undefined;
 	isThemeActive: boolean;
-	installedPlugin: { slug?: string; id?: string; active?: boolean } | null | undefined;
+	installedPlugin: { slug?: string; id?: string } | null | undefined;
 	pluginActive: boolean;
 	atomicFlow: boolean;
 	automatedTransferStatus: string | null;

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
@@ -97,7 +97,7 @@ export function useThankYouRedirect( {
 			uploadTransferSettled ||
 			( ! atomicFlow && currentStep === 0 ) ||
 			( atomicFlow && currentStep === 2 ),
-		installedPlugin,
+		installedPluginSlug: installedPlugin?.slug,
 	} );
 	// Every plugin flow lands here the same way: the plugin reads active. For the ones a transfer
 	// drives, that is only true once the transfer is far enough along and the site is reachable, which


### PR DESCRIPTION
Part of DOTMKT-41

Follows the prior change that taught the plugin activation actions to branch on the reason the endpoint reports. That one addressed how a redundant activation is reported; this one stops the marketplace install flow from making it.

## Proposed Changes

* Both activation paths in the install flow hand the activation action the plugin as the store has it, rather than a rebuilt slug/id pair, so the action's own already-active guard can apply.
* Each tick of the post-transfer recovery poll refreshes the plugin list and decides on the result, read from the store, instead of on the props the tick closed over.
* The recovery hook takes the installed plugin's slug rather than a plugin object, since the object it acts on now always comes from the refresh.
* Test coverage for the refresh-then-decide ordering and for the skips that no longer spend the retry budget.

## Why are these changes being made?

Installing from the marketplace on an Atomic site could show a red "An error occurred while activating" notice on a plugin that had activated successfully, and inflate the activation failure stat — roughly 100 a day, almost all on Atomic. The transfer can complete before the plugin is activated, so a recovery poll watches for that and nudges it active. Once something else has already activated the plugin those nudges are redundant, and the endpoint answers them with an error that reaches the user.

The activation action has a guard for exactly this, but both callers built an object carrying no site data, which the guard can never be satisfied by. Passing the real plugin object fixes the step-driven path, which runs against fresh state. It is not enough for the poll, which cannot assume the store is right: an endpoint with no way to report the benign already-active case answers a redundant activation with a plain failure, and a failure never flips the plugin active. The poll would keep retrying against state its own last attempt had disproved.

Refreshing first and deciding on the result is correct however the endpoint reports, which matters while the server-side change rolls out and for sites that lag behind it. The store has to be read directly rather than through props, because the refresh resolves before React has re-rendered. Note that an activation which genuinely reaches the server in an already-active state can still surface an error on those sites; that is existing deliberate behavior, and what this removes is the redundant requests provoking it.

## Testing Instructions

```
yarn test-client client/my-sites/marketplace/ client/state/plugins/installed/
```

All 220 pass. Reverting `use-post-transfer-plugin-recovery.ts` fails five of them.

In a browser, install a plugin from the marketplace on a site that transfers to Atomic as part of the install, and keep the tab open through the transfer. The plugin should end up active and land on wp-admin's plugins page with no error notice, and the network panel should show a single activation request where previously there could be three.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? <!-- Not yet exercised in a browser; reproducing needs a real transfer landing mid-poll. -->
- [x] Have you checked for TypeScript, React or other console errors? <!-- yarn typecheck-client passes -->
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
