### PR TITLE
Omnibar: add the command palette button

### DIFF
--- a/client/dashboard/app/boot.tsx
+++ b/client/dashboard/app/boot.tsx
@@ -42,7 +42,7 @@ function boot( config: AppConfig ) {
 	const root = createRoot( rootElement );
 
 	if ( isEnabled( 'dashboard/omnibar-radical' ) ) {
-		import( './omnibar' ).then( ( m ) => m.default() ).catch( captureException );
+		import( './omnibar' ).then( ( m ) => m.default( config ) ).catch( captureException );
 	} else {
 		import( './interim-omnibar' )
 			.then( ( m ) => m.default( omnibarEvents, config ) )

--- a/client/dashboard/app/omnibar/index.tsx
+++ b/client/dashboard/app/omnibar/index.tsx
@@ -1,9 +1,11 @@
 import { queryClient } from '@automattic/api-queries';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { hydrateRoot } from 'react-dom/client';
+import { AppProvider } from '../context';
 import OmnibarContainer from './omnibar';
+import type { AppConfig } from '../context';
 
-export default function loadOmnibar() {
+export default function loadOmnibar( config: AppConfig ) {
 	const container = document.getElementById( 'wpcom-omnibar' );
 	if ( ! container ) {
 		return;
@@ -11,8 +13,10 @@ export default function loadOmnibar() {
 
 	hydrateRoot(
 		container,
-		<QueryClientProvider client={ queryClient }>
-			<OmnibarContainer user={ window.currentUser } />
-		</QueryClientProvider>
+		<AppProvider config={ config }>
+			<QueryClientProvider client={ queryClient }>
+				<OmnibarContainer user={ window.currentUser } />
+			</QueryClientProvider>
+		</AppProvider>
 	);
 }

--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -10,12 +10,14 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useEffect, useMemo, useState } from 'react';
 import SiteIcon from '../../components/site-icon';
 import { getSiteDisplayName } from '../../utils/site-name';
+import { useAppContext } from '../context';
 import { omnibarEvents } from './events';
 import { OmnibarHomeIcon } from './home';
 import { useHelpCenterPlugin } from './plugin-help-center';
 import { useNotificationsPlugin } from './plugin-notifications';
 import { useStatsSparklinePlugin } from './plugin-stats-sparkline';
 import type { User } from '@automattic/api-core';
+import type { OmnibarNode } from '@automattic/omnibar';
 
 const onClickResponsiveMenu = () => omnibarEvents.mobileMenu.emit();
 
@@ -31,6 +33,7 @@ function removeUnsupportedDotcomNodes( nodes: AdminBarNode[] ) {
 }
 
 export default function OmnibarContainer( { user }: { user?: User } ) {
+	const { supports } = useAppContext();
 	const [ hydrated, setHydrated ] = useState( false );
 	useEffect( () => {
 		setHydrated( true );
@@ -79,9 +82,12 @@ export default function OmnibarContainer( { user }: { user?: User } ) {
 	const helpCenterPluginNode = useHelpCenterPlugin();
 	const notificationsPluginNode = useNotificationsPlugin( { user } );
 	const statsSparklineNode = useStatsSparklinePlugin( { siteId, site } );
-	const siteActions = statsSparklineNode
-		? [ ...( baseOmnibarNodes.siteActions ?? [] ), statsSparklineNode ]
-		: baseOmnibarNodes.siteActions;
+	const siteActions = [ ...( baseOmnibarNodes.siteActions ?? [] ), statsSparklineNode ].filter(
+		// The palette is only mounted where the app supports it, so elsewhere the
+		// admin bar's button would open nothing.
+		( node ): node is OmnibarNode =>
+			!! node && ( node.id !== 'command-palette' || supports.commandPalette )
+	);
 
 	const omnibarNodes = {
 		...baseOmnibarNodes,

--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -16,8 +16,8 @@ import { OmnibarHomeIcon } from './home';
 import { useHelpCenterPlugin } from './plugin-help-center';
 import { useNotificationsPlugin } from './plugin-notifications';
 import { useStatsSparklinePlugin } from './plugin-stats-sparkline';
+import type { AppConfig } from '../context';
 import type { User } from '@automattic/api-core';
-import type { OmnibarNode } from '@automattic/omnibar';
 
 const onClickResponsiveMenu = () => omnibarEvents.mobileMenu.emit();
 
@@ -28,8 +28,15 @@ const UNSUPPORTED_DOTCOM_NODE_IDS = new Set( [
 	'my-wpcom-account',
 ] );
 
-function removeUnsupportedDotcomNodes( nodes: AdminBarNode[] ) {
-	return nodes.filter( ( node ) => ! UNSUPPORTED_DOTCOM_NODE_IDS.has( node.id ) );
+function removeUnsupportedNodes( nodes: AdminBarNode[], supports: AppConfig[ 'supports' ] ) {
+	return nodes.filter( ( node ) => {
+		if ( UNSUPPORTED_DOTCOM_NODE_IDS.has( node.id ) ) {
+			return false;
+		}
+		// The palette is only mounted where the app supports it, so elsewhere the
+		// admin bar's button would open nothing.
+		return node.id !== 'command-palette' || supports.commandPalette;
+	} );
 }
 
 export default function OmnibarContainer( { user }: { user?: User } ) {
@@ -56,7 +63,7 @@ export default function OmnibarContainer( { user }: { user?: User } ) {
 
 	const baseOmnibarNodes = useMemo( () => {
 		const nodes = siteNodes ?? dashboardNodes ?? [];
-		const result = buildOmnibarNodesFromAdminBarNodes( removeUnsupportedDotcomNodes( nodes ) );
+		const result = buildOmnibarNodesFromAdminBarNodes( removeUnsupportedNodes( nodes, supports ) );
 
 		if ( ! result.home ) {
 			result.home = { id: '' };
@@ -77,17 +84,14 @@ export default function OmnibarContainer( { user }: { user?: User } ) {
 		}
 
 		return result;
-	}, [ dashboardNodes, siteNodes, site, siteIconSize ] );
+	}, [ dashboardNodes, siteNodes, site, siteIconSize, supports ] );
 
 	const helpCenterPluginNode = useHelpCenterPlugin();
 	const notificationsPluginNode = useNotificationsPlugin( { user } );
 	const statsSparklineNode = useStatsSparklinePlugin( { siteId, site } );
-	const siteActions = [ ...( baseOmnibarNodes.siteActions ?? [] ), statsSparklineNode ].filter(
-		// The palette is only mounted where the app supports it, so elsewhere the
-		// admin bar's button would open nothing.
-		( node ): node is OmnibarNode =>
-			!! node && ( node.id !== 'command-palette' || supports.commandPalette )
-	);
+	const siteActions = statsSparklineNode
+		? [ ...( baseOmnibarNodes.siteActions ?? [] ), statsSparklineNode ]
+		: baseOmnibarNodes.siteActions;
 
 	const omnibarNodes = {
 		...baseOmnibarNodes,

--- a/packages/omnibar/src/components/omnibar.scss
+++ b/packages/omnibar/src/components/omnibar.scss
@@ -145,6 +145,10 @@ body:has( .omnibar ) {
 	.dashicons-admin-comments::before {
 		top: 1px;
 	}
+
+	.dashicons-search::before {
+		top: 3px;
+	}
 }
 
 .omnibar .dashicons-before {

--- a/packages/omnibar/src/components/omnibar.scss
+++ b/packages/omnibar/src/components/omnibar.scss
@@ -142,10 +142,7 @@ body:has( .omnibar ) {
 		top: 2px;
 	}
 
-	.dashicons-admin-comments::before {
-		top: 1px;
-	}
-
+	.dashicons-admin-comments::before,
 	.dashicons-search::before {
 		top: 1px;
 	}
@@ -173,7 +170,8 @@ body:has( .omnibar ) {
 	}
 }
 
-.omnibar .dashicons-admin-comments::before {
+.omnibar .dashicons-admin-comments::before,
+.omnibar .dashicons-search::before {
 	height: 34px;
 	font-size: 34px;
 	top: 0.5px;
@@ -182,28 +180,6 @@ body:has( .omnibar ) {
 		height: 20px;
 		font-size: 20px;
 		top: 1px;
-	}
-}
-
-.omnibar .dashicons-search {
-	height: 46px;
-
-	&::before {
-		height: 46px;
-		font-size: 34px;
-		line-height: 1.38235294;
-		top: 0;
-	}
-
-	@media ( min-width: 782px ) {
-		height: 20px;
-
-		&::before {
-			height: 20px;
-			font-size: 20px;
-			line-height: 1;
-			top: 1px;
-		}
 	}
 }
 

--- a/packages/omnibar/src/components/omnibar.scss
+++ b/packages/omnibar/src/components/omnibar.scss
@@ -147,7 +147,7 @@ body:has( .omnibar ) {
 	}
 
 	.dashicons-search::before {
-		top: 3px;
+		top: 1px;
 	}
 }
 
@@ -182,6 +182,16 @@ body:has( .omnibar ) {
 		height: 20px;
 		font-size: 20px;
 		top: 1px;
+	}
+}
+
+.omnibar .dashicons-search::before {
+	height: 32px;
+	font-size: 32px;
+
+	@media ( min-width: 782px ) {
+		height: 20px;
+		font-size: 20px;
 	}
 }
 

--- a/packages/omnibar/src/components/omnibar.scss
+++ b/packages/omnibar/src/components/omnibar.scss
@@ -185,13 +185,25 @@ body:has( .omnibar ) {
 	}
 }
 
-.omnibar .dashicons-search::before {
-	height: 32px;
-	font-size: 32px;
+.omnibar .dashicons-search {
+	height: 46px;
+
+	&::before {
+		height: 46px;
+		font-size: 34px;
+		line-height: 1.38235294;
+		top: 0;
+	}
 
 	@media ( min-width: 782px ) {
 		height: 20px;
-		font-size: 20px;
+
+		&::before {
+			height: 20px;
+			font-size: 20px;
+			line-height: 1;
+			top: 1px;
+		}
 	}
 }
 

--- a/packages/omnibar/src/utils/admin-bar.tsx
+++ b/packages/omnibar/src/utils/admin-bar.tsx
@@ -1,3 +1,4 @@
+import { dispatch } from '@wordpress/data';
 import type { AdminBarNode, OmnibarNode, OmnibarNodes } from '../types';
 
 export function buildOmnibarNodesFromAdminBarNodes( adminBarNodes: AdminBarNode[] ): OmnibarNodes {
@@ -45,6 +46,20 @@ export function buildOmnibarNodesFromAdminBarNodes( adminBarNodes: AdminBarNode[
 				omnibarNode.meta = {
 					subtitle: doc.querySelector( '.ab-label' )?.textContent?.trim(),
 				};
+				siteActionNodes.push( omnibarNode );
+				break;
+			}
+			case 'command-palette': {
+				const doc = new DOMParser().parseFromString( node.title || '', 'text/html' );
+				omnibarNode.title = undefined;
+				omnibarNode.label = doc.querySelector( '.screen-reader-text' )?.textContent?.trim();
+				omnibarNode.icon = <span className="dashicons-before dashicons-search" />;
+				omnibarNode.meta = {
+					subtitle: doc.querySelector( 'kbd' )?.textContent?.trim(),
+				};
+				// The node points at `#` and relies on an inline onclick handler.
+				omnibarNode.href = undefined;
+				omnibarNode.onClick = () => dispatch( 'core/commands' ).open();
 				siteActionNodes.push( omnibarNode );
 				break;
 			}

--- a/packages/omnibar/src/utils/admin-bar.tsx
+++ b/packages/omnibar/src/utils/admin-bar.tsx
@@ -59,7 +59,7 @@ export function buildOmnibarNodesFromAdminBarNodes( adminBarNodes: AdminBarNode[
 				};
 				// The node points at `#` and relies on an inline onclick handler.
 				omnibarNode.href = undefined;
-				omnibarNode.onClick = () => dispatch( 'core/commands' ).open();
+				omnibarNode.onClick = () => ( dispatch( 'core/commands' ) as { open: () => void } ).open();
 				siteActionNodes.push( omnibarNode );
 				break;
 			}


### PR DESCRIPTION
## Proposed Changes

* Teach the omnibar's admin bar util to transform the command palette node that core registers, so the button is driven by the endpoint rather than injected client-side.
* Pass the app config into the omnibar's React root, so Calypso can drop the button on dashboards that never mount a palette.

The node was added to the admin bar endpoint's allowlist in Automattic/jetpack#51026, which is deployed.

## Why are these changes being made?

The new omnibar (behind the `dashboard/omnibar-radical` flag) is still missing a number of items the interim omnibar has. The command palette is one of them, so on the new bar there is no visible way to reach the palette — only the keyboard shortcut, which is undiscoverable.

The new omnibar also mounts in its own React root without the app config provider that the interim one already gets. Without it, the omnibar cannot tell which features the surrounding dashboard supports. Dotcom mounts the palette; the agency and CIAB dashboards do not, and a button there would open nothing.

## Testing Instructions

* Set `dashboard/omnibar-radical` to `true` in `config/dashboard-development.json` and start the dashboard.
* Open a site whose admin bar returns the command palette node. A search icon plus the shortcut appears alongside Updates and Comments.
* Click it — the palette opens. Confirm the keyboard shortcut still opens it too.
* Confirm the shortcut matches the platform — ⌘K on macOS, Ctrl+K elsewhere.
* Below 782px, confirm the shortcut label hides and the icon remains, like the neighbouring actions.
* Confirm the button is absent on dashboards that don't support the palette.

Not yet verified in a browser.

## Considerations

**Nothing is re-derived on the client.** The shortcut and the accessible label are both read from the node's markup, where they arrive translated and already resolved for the visitor's platform. The node also ships an inline script that rewrites the shortcut for Apple platforms; it cannot run inside a rendered React tree, but it is only a fallback for when the user agent doesn't reach the site.

**No new dependencies.** Core opens the palette by dispatching to a store by name, so this reaches it through the `@wordpress/data` peer dependency the package already declared but never used. Dispatching by name rather than by store descriptor is untyped — it resolves to `unknown` — so the result carries a narrow assertion to the one action being called. The alternative, importing the descriptor from `@wordpress/commands`, would add a dependency that ships no types of its own and so needs suppressing anyway.

**Behaviour lives in the package.** The util attaches the click handler, so any consumer of the omnibar gets a working button and Calypso is left with just the support gate. This differs from the other interactive nodes, where the client supplies behaviour — but those aren't described by the admin bar response, and this one is.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
