### PR TITLE
A4A: Use the new badge style on all the A4A pages

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/amplify.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/amplify.tsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { Badge } from '@automattic/components';
+import { Badge } from '@automattic/ui';
 import { __ } from '@wordpress/i18n';
 import { chevronLeft } from '@wordpress/icons';
 import Sidebar from '../sidebar';
@@ -19,7 +19,7 @@ export default function AmplifySidebar( { path }: Props ) {
 			title={
 				<div className="sidebar-menu-item__title-with-badge">
 					<span>{ __( 'Amplify' ) }</span>
-					<Badge type="info">{ __( 'Beta' ) }</Badge>
+					<Badge>{ __( 'Beta' ) }</Badge>
 				</div>
 			}
 			backButtonProps={ {

--- a/client/a8c-for-agencies/components/sidebar-menu/reports.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/reports.tsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { Badge } from '@automattic/components';
+import { Badge } from '@automattic/ui';
 import { chevronLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { A4A_REPORTS_LINK } from 'calypso/a8c-for-agencies/sections/reports/constants';
@@ -21,7 +21,7 @@ export default function ReportsSidebar( { path }: Props ) {
 			title={
 				<div className="sidebar-menu-item__title-with-badge">
 					<span>{ translate( 'Reports' ) }</span>
-					<Badge type="info">{ translate( 'Beta' ) }</Badge>
+					<Badge>{ translate( 'Beta' ) }</Badge>
 				</div>
 			}
 			backButtonProps={ {

--- a/client/a8c-for-agencies/components/step-section-item/index.tsx
+++ b/client/a8c-for-agencies/components/step-section-item/index.tsx
@@ -1,9 +1,8 @@
-import { Button, Badge } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import React, { type JSX } from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
-import StatusBadge from './status-badge';
 import type { TranslateResult } from 'i18n-calypso';
 
 import './style.scss';
@@ -15,7 +14,7 @@ interface StepSectionItemProps {
 	heading: string;
 	description: TranslateResult;
 	buttonProps?: React.ComponentProps< typeof Button >;
-	statusProps?: React.ComponentProps< typeof Badge > & { tooltip?: string };
+	status?: React.ReactNode;
 	className?: string;
 	iconClassName?: string;
 	stepNumber?: number;
@@ -27,14 +26,12 @@ export default function StepSectionItem( {
 	heading,
 	description,
 	buttonProps,
-	statusProps,
+	status,
 	className,
 	iconClassName,
 	stepNumber,
 	children,
 }: StepSectionItemProps ) {
-	const status = <StatusBadge statusProps={ statusProps } />;
-
 	return (
 		<div className={ clsx( 'step-section-item', className ) }>
 			{ icon && (
@@ -44,14 +41,10 @@ export default function StepSectionItem( {
 			) }
 			{ stepNumber && <span className="step-section-item__step-number">{ stepNumber }</span> }
 			<div className="step-section-item__content">
-				{ statusProps && (
-					<div className="step-section-item__status is-small-screen">{ status }</div>
-				) }
+				{ status && <div className="step-section-item__status is-small-screen">{ status }</div> }
 				<div className="step-section-item__heading">
 					{ heading }
-					{ statusProps && (
-						<div className="step-section-item__status is-large-screen">{ status }</div>
-					) }
+					{ status && <div className="step-section-item__status is-large-screen">{ status }</div> }
 				</div>
 				<div className="step-section-item__description">{ preventWidows( description ) }</div>
 			</div>

--- a/client/a8c-for-agencies/sections/amplify/primary/overview/sections/score-card.tsx
+++ b/client/a8c-for-agencies/sections/amplify/primary/overview/sections/score-card.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@automattic/components';
+import { Badge } from '@automattic/ui';
 import {
 	Card,
 	CardBody,
@@ -135,7 +135,7 @@ export default function AmplifyScoreCard() {
 						<Text as="code" variant="muted" size={ 12 }>
 							{ SAMPLE_URL }
 						</Text>
-						<Badge type="success">{ __( 'Audit complete' ) }</Badge>
+						<Badge intent="success">{ __( 'Audit complete' ) }</Badge>
 					</HStack>
 
 					<ToggleGroupControl

--- a/client/a8c-for-agencies/sections/amplify/primary/reports/reports-content.scss
+++ b/client/a8c-for-agencies/sections/amplify/primary/reports/reports-content.scss
@@ -1,6 +1,0 @@
-// Soften the Human mode pill to the light-background, dark-text tone of the AI
-// (purple) and Full (green) pills instead of the bright solid blue.
-.amplify-report-mode-badge.is-human {
-	background-color: var(--color-primary-5);
-	color: var(--color-primary-80);
-}

--- a/client/a8c-for-agencies/sections/amplify/primary/reports/reports-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/primary/reports/reports-content.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@automattic/components';
+import { Badge } from '@automattic/ui';
 import { useBreakpoint } from '@automattic/viewport-react';
 import {
 	Button,
@@ -25,12 +25,9 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import ArchiveReportConfirmationDialog from './archive-report-confirmation-dialog';
 import useAmplifyReportRows, { AmplifyReportRow } from './use-report-rows';
-import type { BadgeType } from '@automattic/components';
 import type { Action, Field } from '@wordpress/dataviews';
 import type { AmplifyMode } from 'calypso/a8c-for-agencies/data/amplify/types';
 import type { ReactNode } from 'react';
-
-import './reports-content.scss';
 
 function modeLabel( mode: AmplifyMode ): string {
 	switch ( mode ) {
@@ -45,12 +42,6 @@ function modeLabel( mode: AmplifyMode ): string {
 	}
 }
 
-const MODE_BADGE_TYPE: Record< AmplifyMode, BadgeType > = {
-	human: 'info-blue',
-	ai: 'info-purple',
-	full: 'info-green',
-};
-
 function formatTimestamp( iso: string ): string {
 	return new Date( iso ).toLocaleString( undefined, {
 		month: 'short',
@@ -64,16 +55,16 @@ function ScoreBadge( { score, label }: { score: number | null; label: string } )
 	if ( score === null ) {
 		return null;
 	}
-	let type: BadgeType;
+	let intent: 'success' | 'warning' | 'error';
 	if ( score >= 80 ) {
-		type = 'success';
+		intent = 'success';
 	} else if ( score >= 50 ) {
-		type = 'warning';
+		intent = 'warning';
 	} else {
-		type = 'error';
+		intent = 'error';
 	}
 	return (
-		<Badge type={ type }>
+		<Badge intent={ intent }>
 			{ sprintf(
 				/* translators: %1$s is the score label (e.g. Human), %2$d is the numeric score */
 				__( '%1$s %2$d' ),
@@ -132,12 +123,7 @@ export default function AmplifyReportsContent() {
 				label: __( 'Analysis type' ),
 				getValue: ( { item }: { item: AmplifyReportRow } ) => modeLabel( item.mode ),
 				render: ( { item }: { item: AmplifyReportRow } ): ReactNode => (
-					<Badge
-						type={ MODE_BADGE_TYPE[ item.mode ] }
-						className={ `amplify-report-mode-badge is-${ item.mode }` }
-					>
-						{ modeLabel( item.mode ) }
-					</Badge>
+					<Badge>{ modeLabel( item.mode ) }</Badge>
 				),
 				enableHiding: true,
 				enableSorting: true,
@@ -190,7 +176,7 @@ export default function AmplifyReportsContent() {
 				render: ( { item }: { item: AmplifyReportRow } ): ReactNode => {
 					if ( item.rowStatus === 'failed' ) {
 						return (
-							<Badge type="error" title={ item.failureReason }>
+							<Badge intent="error" title={ item.failureReason }>
 								{ __( 'Analysis failed' ) }
 							</Badge>
 						);

--- a/client/a8c-for-agencies/sections/client/lib/get-subscription-status.tsx
+++ b/client/a8c-for-agencies/sections/client/lib/get-subscription-status.tsx
@@ -3,7 +3,7 @@ export const getSubscriptionStatus = (
 	translate: ( key: string ) => string
 ): {
 	children: string | undefined;
-	type: 'success' | 'warning' | 'info' | 'error' | undefined;
+	type: 'default' | 'success' | 'warning' | 'info' | 'error' | undefined;
 } => {
 	switch ( status ) {
 		case 'pending':
@@ -24,7 +24,7 @@ export const getSubscriptionStatus = (
 		case 'canceled':
 			return {
 				children: translate( 'Canceled' ),
-				type: 'info',
+				type: 'default',
 			};
 		default:
 			return {

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
@@ -1,8 +1,8 @@
 import { formatCurrency } from '@automattic/number-formatters';
+import { Badge } from '@automattic/ui';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { EXTERNAL_PRESSABLE_AUTH_URL } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import CancelSubscriptionAction from '../../cancel-subscription-confirmation-dialog';
 import { getSubscriptionStatus } from '../../lib/get-subscription-status';
@@ -74,7 +74,13 @@ export function SubscriptionStatus( {
 	translate: ( key: string ) => string;
 } ) {
 	const { children, type } = getSubscriptionStatus( status, translate );
-	return children ? <StatusBadge statusProps={ { children, type } } /> : '-';
+	return children ? (
+		<Badge className="step-section-item__status" intent={ type }>
+			{ children }
+		</Badge>
+	) : (
+		'-'
+	);
 }
 
 export function SubscriptionAction( {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-usage-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-usage-section/index.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@automattic/components';
+import { Badge } from '@automattic/ui';
 import { useTranslate } from 'i18n-calypso';
 import PageSection from 'calypso/a8c-for-agencies/components/page-section';
 import PressableUsageDetails from 'calypso/a8c-for-agencies/components/pressable-usage-details';
@@ -20,7 +20,7 @@ export default function PressableUsageSection( { existingPlan }: Props ) {
 		>
 			<div className="pressable-usage-card">
 				<div className="pressable-usage-card__heading">
-					{ existingPlan.name } <Badge type="info">{ translate( 'Plan' ) }</Badge>
+					{ existingPlan.name } <Badge>{ translate( 'Plan' ) }</Badge>
 				</div>
 				<PressableUsageDetails existingPlan={ existingPlan } />
 			</div>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-usage-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-usage-section/style.scss
@@ -27,9 +27,4 @@
 	justify-content: space-between;
 	margin-block-end: 16px;
 	align-items: center;
-
-	.badge.badge--info {
-		@include body-small;
-		background-color: var( --color-neutral-0 );
-	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/style.scss
@@ -60,13 +60,6 @@
 }
 
 .wpcom-plan-selector__owned-plan {
-	@include heading-medium;
-
-	display: inline-block;
-	border: 1px solid var( --color-neutral-5 );
-	background-color: var( --color-neutral-0 );
-	padding: 4px 16px;
-	border-radius: 16px;
 	margin-block-end: 8px;
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
@@ -136,6 +136,7 @@ export default function WPCOMPlanSelector( {
 							},
 							count: ownedPlans,
 							comment: '%(count)s is the number of WordPress.com sites owned by the user',
+							textOnly: true,
 						} ) }
 					</Badge>
 				) }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { formatCurrency } from '@automattic/number-formatters';
+import { Badge } from '@automattic/ui';
 import { Button } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -128,7 +129,7 @@ export default function WPCOMPlanSelector( {
 		>
 			<div className="wpcom-plan-selector__top">
 				{ ownedPlans > 0 && (
-					<div className="wpcom-plan-selector__owned-plan">
+					<Badge className="wpcom-plan-selector__owned-plan">
 						{ translate( 'You own %(count)s site', 'You own %(count)s sites', {
 							args: {
 								count: ownedPlans,
@@ -136,7 +137,7 @@ export default function WPCOMPlanSelector( {
 							count: ownedPlans,
 							comment: '%(count)s is the number of WordPress.com sites owned by the user',
 						} ) }
-					</div>
+					</Badge>
 				) }
 
 				<div className="wpcom-plan-selector__plan-name">

--- a/client/a8c-for-agencies/sections/overview/sidebar/featured-woopayments/featured-card.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/featured-woopayments/featured-card.tsx
@@ -1,4 +1,5 @@
-import { Badge, Card } from '@automattic/components';
+import { Card } from '@automattic/components';
+import { Badge } from '@automattic/ui';
 import { Button } from '@wordpress/components';
 import { close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';

--- a/client/a8c-for-agencies/sections/overview/sidebar/featured-woopayments/featured-card.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/featured-woopayments/featured-card.tsx
@@ -17,7 +17,7 @@ const WooPaymentsFeaturedCard = ( { onDismiss, onClick }: Props ) => {
 	return (
 		<Card className="overview__featured-woopayments">
 			<div className="overview__featured-woopayments-top">
-				<Badge className="overview__featured-woopayments-badge">{ translate( 'Featured' ) }</Badge>
+				<Badge>{ translate( 'Featured' ) }</Badge>
 
 				<Button
 					className="overview__featured-dismiss-button"

--- a/client/a8c-for-agencies/sections/overview/sidebar/featured-woopayments/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/featured-woopayments/style.scss
@@ -49,8 +49,7 @@ $woocommerce-purple-50: #720EEC;
 	}
 }
 
-.badge.overview__featured-woopayments-badge {
-	display: inline-block;
+.overview__featured-woopayments .overview__featured-woopayments-badge {
 	background-color: var(--color-surface);
 	color: $woocommerce-purple-50;
 	text-transform: uppercase;

--- a/client/a8c-for-agencies/sections/overview/sidebar/featured-woopayments/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/featured-woopayments/style.scss
@@ -49,12 +49,6 @@ $woocommerce-purple-50: #720EEC;
 	}
 }
 
-.overview__featured-woopayments .overview__featured-woopayments-badge {
-	background-color: var(--color-surface);
-	color: $woocommerce-purple-50;
-	text-transform: uppercase;
-}
-
 .overview__featured-woopayments-logo {
 	margin-block-end: 16px;
 	display: block;

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -84,12 +84,12 @@ const PartnerDirectoryDashboard = () => {
 			closed: {
 				key: 'closed',
 				label: translate( 'Closed' ),
-				intent: 'info',
+				intent: 'default',
 			},
 			unknown: {
 				key: 'unknown',
 				label: '-',
-				intent: 'info',
+				intent: 'default',
 			},
 		};
 	}, [ translate ] );

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -1,4 +1,3 @@
-import { BadgeType } from '@automattic/components';
 import { Button, ExternalLink } from '@wordpress/components';
 import { check } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -27,7 +26,7 @@ import {
 	mapAgencyDetailsFormData,
 	mapApplicationFormData,
 } from '../utils/map-application-form-data';
-import DashboardStatusBadge from './status-badge';
+import DashboardStatusBadge, { StatusBadgeIntent } from './status-badge';
 
 import './style.scss';
 
@@ -35,13 +34,13 @@ interface DirectoryApplicationStatus {
 	key: string;
 	brand: string;
 	status: string;
-	type: BadgeType;
+	intent: StatusBadgeIntent;
 }
 
 interface StatusBadge {
 	key: string;
 	label: string;
-	type: BadgeType;
+	intent: StatusBadgeIntent;
 }
 
 const PartnerDirectoryDashboard = () => {
@@ -70,27 +69,27 @@ const PartnerDirectoryDashboard = () => {
 			pending: {
 				key: 'pending',
 				label: translate( 'Pending' ),
-				type: 'warning',
+				intent: 'warning',
 			},
 			approved: {
 				key: 'approved',
 				label: translate( 'Approved' ),
-				type: 'success',
+				intent: 'success',
 			},
 			rejected: {
 				key: 'rejected',
 				label: translate( 'Not approved' ),
-				type: 'error',
+				intent: 'error',
 			},
 			closed: {
 				key: 'closed',
 				label: translate( 'Closed' ),
-				type: 'info',
+				intent: 'info',
 			},
 			unknown: {
 				key: 'unknown',
 				label: '-',
-				type: 'info',
+				intent: 'info',
 			},
 		};
 	}, [ translate ] );
@@ -177,7 +176,7 @@ const PartnerDirectoryDashboard = () => {
 			statuses.push( {
 				brand: availableDirectories[ directory.directory ],
 				status: applicationStatusTypeMap[ directory.status || 'unknown' ].label,
-				type: applicationStatusTypeMap[ directory.status || 'unknown' ].type,
+				intent: applicationStatusTypeMap[ directory.status || 'unknown' ].intent,
 				key: applicationStatusTypeMap[ directory.status || 'unknown' ].key,
 			} );
 			return statuses;
@@ -266,7 +265,7 @@ const PartnerDirectoryDashboard = () => {
 					<DashboardStatusBadge
 						statusProps={ {
 							status: application.status,
-							type: application.type,
+							intent: application.intent,
 						} }
 						showPopoverOnLoad={ showPopoverOnLoad }
 					/>
@@ -361,7 +360,7 @@ const PartnerDirectoryDashboard = () => {
 					description={
 						applicationWasSubmitted && directoryApplicationStatuses.length > 0 ? (
 							<div className="partner-directory-dashboard__brand-status-section">
-								{ directoryApplicationStatuses.map( ( { brand, status, type } ) => {
+								{ directoryApplicationStatuses.map( ( { brand, status, intent } ) => {
 									const showPopoverOnLoad =
 										directoryApplicationStatuses.filter( ( { key } ) => key === 'rejected' )
 											.length === 1;
@@ -370,7 +369,7 @@ const PartnerDirectoryDashboard = () => {
 											<DashboardStatusBadge
 												statusProps={ {
 													status,
-													type,
+													intent,
 												} }
 												showPopoverOnLoad={ showPopoverOnLoad }
 											/>

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/status-badge.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/status-badge.tsx
@@ -1,16 +1,19 @@
-import { BadgeType, Button, Badge } from '@automattic/components';
+import { Button } from '@automattic/components';
+import { Badge } from '@automattic/ui';
 import { useTranslate } from 'i18n-calypso';
-import { useRef, useState, useCallback, useEffect } from 'react';
+import { useRef, useState, useCallback, useEffect, ComponentProps } from 'react';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import A4APopover from '../../../components/a4a-popover';
 
+export type StatusBadgeIntent = ComponentProps< typeof Badge >[ 'intent' ];
+
 interface Props {
 	statusProps: {
 		status: string;
-		type: BadgeType;
+		intent: StatusBadgeIntent;
 	};
 	showPopoverOnLoad: boolean;
 }
@@ -66,11 +69,9 @@ export default function DashboardStatusBadge( { statusProps, showPopoverOnLoad }
 	if ( ! popoverContent ) {
 		return (
 			<span>
-				<Badge
-					className="step-section-item__status"
-					children={ statusProps.status }
-					type={ statusProps.type }
-				/>
+				<Badge className="step-section-item__status" intent={ statusProps.intent }>
+					{ statusProps.status }
+				</Badge>
 			</span>
 		);
 	}
@@ -88,11 +89,9 @@ export default function DashboardStatusBadge( { statusProps, showPopoverOnLoad }
 			tabIndex={ 0 }
 			ref={ wrapperRef }
 		>
-			<Badge
-				className="step-section-item__status"
-				children={ statusProps.status }
-				type={ statusProps.type }
-			/>
+			<Badge className="step-section-item__status" intent={ statusProps.intent }>
+				{ statusProps.status }
+			</Badge>
 			{ showPopover && popoverContent && (
 				<A4APopover
 					title={ translate(

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/style.scss
@@ -48,14 +48,14 @@
 	flex-direction: column;
 	gap: 8px;
 
-	.badge {
-		min-width: 100px;
-		margin-inline-end: 8px;
-		text-align: center;
-	}
+	> div {
+		display: flex;
+		align-items: center;
+		gap: 8px;
 
-	span {
-		color: var(--color-text-black);
+		> span {
+			color: var(--color-text-black);
+		}
 	}
 }
 

--- a/client/a8c-for-agencies/sections/partner-directory/lead-matching/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/lead-matching/index.tsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { Badge } from '@automattic/components';
+import { Badge } from '@automattic/ui';
 import { Card, CardBody, ToggleControl, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
@@ -513,7 +513,7 @@ const LeadMatchingForm = ( { initialFormData, profile }: Props ) => {
 					<CardBody className="partner-directory-lead-matching__status-content">
 						{ eligibilityState === 'eligible' && (
 							<>
-								<Badge type="success">{ __( 'Eligible for leads' ) }</Badge>
+								<Badge intent="success">{ __( 'Eligible for leads' ) }</Badge>
 								<span className="partner-directory-lead-matching__status-text">
 									{ __( 'Your preferences are saved. You can update them anytime.' ) }
 								</span>
@@ -521,7 +521,7 @@ const LeadMatchingForm = ( { initialFormData, profile }: Props ) => {
 						) }
 						{ eligibilityState === 'not-accepting' && (
 							<>
-								<Badge type="warning">{ __( 'Not eligible' ) }</Badge>
+								<Badge intent="warning">{ __( 'Not eligible' ) }</Badge>
 								<span className="partner-directory-lead-matching__status-text">
 									{ __(
 										'Turn on Accepting new clients to be included in lead matching and receive leads.'
@@ -531,7 +531,7 @@ const LeadMatchingForm = ( { initialFormData, profile }: Props ) => {
 						) }
 						{ eligibilityState === 'ready' && (
 							<>
-								<Badge type="info-blue">{ __( '1 step left' ) }</Badge>
+								<Badge intent="info">{ __( '1 step left' ) }</Badge>
 								<span className="partner-directory-lead-matching__status-text">
 									{ __(
 										'All questions answered — click Update preferences to start receiving leads'

--- a/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-card/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-card/index.tsx
@@ -1,13 +1,13 @@
-import { Badge, Button } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
+import { Badge } from '@automattic/ui';
 import { useTranslate } from 'i18n-calypso';
-import { memo } from 'react';
+import { memo, ComponentProps } from 'react';
 import EmptyValueIndicator from 'calypso/a8c-for-agencies/components/empty-value-indicator';
 import FormattedDate from 'calypso/components/formatted-date';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import usePayInvoiceMutation from '../hooks/use-pay-invoice-mutation';
 import InvoicesListRow from '../invoices-list-row';
-import type { BadgeType } from '@automattic/components';
 import type { Invoice } from 'calypso/state/partner-portal/types';
 
 import './style.scss';
@@ -18,32 +18,32 @@ function InvoicesListCard( { id, number, dueDate, status, total, currency, pdfUr
 	const dueDateMoment = moment( dueDate );
 	const payInvoice = usePayInvoiceMutation();
 
-	let badgeType: BadgeType = 'info';
+	let badgeIntent: ComponentProps< typeof Badge >[ 'intent' ] = 'default';
 	let badgeLabel = translate( 'Draft' );
 
 	switch ( status ) {
 		case 'open':
-			badgeType = 'info-blue';
+			badgeIntent = 'info';
 			badgeLabel = translate( 'Open' );
 
 			if ( dueDateMoment.isBefore( moment() ) ) {
-				badgeType = 'warning';
+				badgeIntent = 'warning';
 				badgeLabel = translate( 'Past due' );
 			}
 			break;
 
 		case 'paid':
-			badgeType = 'success';
+			badgeIntent = 'success';
 			badgeLabel = translate( 'Paid' );
 			break;
 
 		case 'uncollectible':
-			badgeType = 'error';
+			badgeIntent = 'error';
 			badgeLabel = translate( 'Uncollectible' );
 			break;
 
 		case 'void':
-			badgeType = 'info';
+			badgeIntent = 'default';
 			badgeLabel = translate( 'Void' );
 			break;
 	}
@@ -56,7 +56,7 @@ function InvoicesListCard( { id, number, dueDate, status, total, currency, pdfUr
 				{ ! dueDate && <EmptyValueIndicator /> }
 			</div>
 			<div>
-				<Badge type={ badgeType }>{ badgeLabel }</Badge>
+				<Badge intent={ badgeIntent }>{ badgeLabel }</Badge>
 			</div>
 			<div>{ formatCurrency( total, currency.toUpperCase() ) }</div>
 			<div className="invoices-list-card__actions">

--- a/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-row/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-row/style.scss
@@ -23,7 +23,7 @@
 	@include body-x-large;
 
 	@include break-xlarge() {
-		grid-template-columns: 160px 1fr 100px 100px 128px;
+		grid-template-columns: 160px 1fr 120px 100px 128px;
 	}
 }
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
@@ -1,4 +1,5 @@
-import { Badge, Card, Gridicon } from '@automattic/components';
+import { Card, Gridicon } from '@automattic/components';
+import { Badge } from '@automattic/ui';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import EmptyValueIndicator from 'calypso/a8c-for-agencies/components/empty-value-indicator';
@@ -197,7 +198,7 @@ export default function LicenseDetails( {
 				<div className="license-details__subscription-row">
 					{ subscriptionBadgeLabel && (
 						<Badge
-							type={ subscription?.status === 'inactive' ? 'info-green' : 'info' }
+							intent={ subscription?.status === 'inactive' ? 'success' : 'info' }
 							className="license-details__subscription-badge"
 						>
 							{ subscriptionBadgeLabel }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/style.scss
@@ -125,7 +125,6 @@
 
 	.license-details__subscription-badge {
 		margin: 0;
-		font-size: $font-size-x-small;
 	}
 
 	.license-details__subscription-label {

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -191,6 +191,7 @@ export default function LicensePreview( {
 				args: {
 					quantity,
 				},
+				textOnly: true,
 			} ) }
 		</Badge>
 	);

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -1,6 +1,7 @@
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
-import { Badge, Button, Gridicon } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
+import { Badge } from '@automattic/ui';
 import { ExternalLink } from '@wordpress/components';
 import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
@@ -184,7 +185,7 @@ export default function LicensePreview( {
 	const isSiteAtomic = site?.is_wpcom_atomic;
 
 	const bundleCountContent = quantity && (
-		<Badge className="license-preview__license-count" type="info">
+		<Badge className="license-preview__license-count">
 			{ translate( '%(quantity)d License Bundle', {
 				context: 'bundle license count',
 				args: {
@@ -217,7 +218,7 @@ export default function LicensePreview( {
 				ref={ wrapperRef }
 				onActivate={ () => setShowPopover( true ) }
 			>
-				<Badge className="license-preview__migration-badge" type="info-green">
+				<Badge className="license-preview__migration-badge" intent="success">
 					{ translate( 'Transferred' ) }
 				</Badge>
 				{ showPopover && (
@@ -286,9 +287,7 @@ export default function LicensePreview( {
 						<div className="license-preview__product-title">
 							{ productTitle }
 							{ referral && (
-								<Badge className="license-preview__client-badge" type="info">
-									{ translate( 'Referral' ) }
-								</Badge>
+								<Badge className="license-preview__client-badge">{ translate( 'Referral' ) }</Badge>
 							) }
 						</div>
 						{ referral && (
@@ -315,7 +314,7 @@ export default function LicensePreview( {
 							) }
 							{ ! domain && licenseState === LicenseState.Detached && ! isPressableAddonLicense && (
 								<span className="license-preview__unassigned">
-									<Badge type="warning">{ translate( 'Unassigned' ) }</Badge>
+									<Badge intent="warning">{ translate( 'Unassigned' ) }</Badge>
 									{ licenseType === LicenseType.Partner && ! isPressableAddonLicense && (
 										<Button
 											className="license-preview__assign-button"
@@ -330,7 +329,7 @@ export default function LicensePreview( {
 							) }
 							{ revokedAt && (
 								<span>
-									<Badge type="error">{ translate( 'Revoked' ) }</Badge>
+									<Badge intent="error">{ translate( 'Revoked' ) }</Badge>
 								</span>
 							) }
 						</>
@@ -375,10 +374,12 @@ export default function LicensePreview( {
 					</div>
 				) }
 
-				<div className="license-preview__badge-container">
-					{ !! isParentLicense && bundleCountContent }
-					{ isDevelopmentSite && <Badge type="info-purple">{ translate( 'Development' ) }</Badge> }
-					{ shouldShowTransferredBadge() && <TransferredBadge /> }
+				<div className="license-preview__badge-container-wrapper">
+					<div className="license-preview__badge-container">
+						{ !! isParentLicense && bundleCountContent }
+						{ isDevelopmentSite && <Badge>{ translate( 'Development' ) }</Badge> }
+						{ shouldShowTransferredBadge() && <TransferredBadge /> }
+					</div>
 				</div>
 
 				<div>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -178,6 +178,12 @@ button.button.is-borderless.license-bundle-dropdown__button {
 	}
 }
 
+// Boxless wrapper: the row's `> *` cell rules (overflow: hidden) hit this
+// wrapper instead of the badge container, so wide badges are not clipped.
+.license-list-item > div.license-preview__badge-container-wrapper {
+	display: contents;
+}
+
 .license-preview__migration-badge {
 	cursor: pointer;
 }

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
@@ -1,4 +1,6 @@
+import { Badge } from '@automattic/ui';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
+import { Tooltip } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
@@ -8,7 +10,6 @@ import {
 	A4A_MIGRATIONS_LINK,
 	A4A_WOOPAYMENTS_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
 import { getAccountStatus } from 'calypso/dashboard/agency/earn/payout-settings/get-account-status';
 import { TipaltiPayoutSettings } from 'calypso/dashboard/agency/earn/payout-settings/tipalti-payout-settings';
 import LayoutBody from 'calypso/layout/hosting-dashboard/body';
@@ -61,6 +62,20 @@ const getPageInfo = (
 			};
 	}
 };
+
+function PaymentStatusBadge( {
+	intent,
+	tooltip,
+	children,
+}: {
+	intent: 'success' | 'warning' | 'error';
+	tooltip?: string;
+	children?: string;
+} ) {
+	const badge = <Badge intent={ intent }>{ children ?? '' }</Badge>;
+	return tooltip ? <Tooltip text={ tooltip }>{ badge }</Tooltip> : badge;
+}
+
 export default function ReferralsBankDetails( { type }: { type?: 'migrations' | 'woopayments' } ) {
 	const translate = useTranslate();
 	const isDesktop = useDesktopBreakpoint();
@@ -98,12 +113,9 @@ export default function ReferralsBankDetails( { type }: { type?: 'migrations' | 
 									comment: '%(status) is subscription status',
 									components: {
 										badge: (
-											<StatusBadge
-												statusProps={ {
-													children: accountStatus.status,
-													type: accountStatus.statusType,
-													tooltip: accountStatus.statusReason,
-												} }
+											<PaymentStatusBadge
+												intent={ accountStatus.statusType }
+												tooltip={ accountStatus.statusReason }
 											/>
 										),
 									},

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/style.scss
@@ -26,10 +26,9 @@ $iframe-background-color: #f7f7f7;
 .bank-details__status {
 	@include body-large;
 	color: var(--color-accent-80);
-
-	.badge {
-		margin-inline-start: 6px;
-	}
+	display: flex;
+	align-items: center;
+	gap: 6px;
 }
 
 .referrals-overview__link {

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -1,7 +1,8 @@
 import { Button, WordPressLogo } from '@automattic/components';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { formatNumber } from '@automattic/number-formatters';
-import { ExternalLink } from '@wordpress/components';
+import { Badge } from '@automattic/ui';
+import { ExternalLink, Tooltip } from '@wordpress/components';
 import { chevronRight, reusableBlock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useState, useEffect } from 'react';
@@ -73,6 +74,18 @@ export default function LayoutBodyContent( {
 	);
 
 	const accountStatus = getAccountStatus( tipaltiData );
+
+	const paymentStatusBadge = ( () => {
+		if ( ! accountStatus ) {
+			return undefined;
+		}
+		const badge = <Badge intent={ accountStatus.statusType }>{ accountStatus.status }</Badge>;
+		return accountStatus.statusReason ? (
+			<Tooltip text={ accountStatus.statusReason }>{ badge }</Tooltip>
+		) : (
+			badge
+		);
+	} )();
 
 	const hasPayeeAccount = !! accountStatus?.status;
 	const bankAccountCTAText = hasPayeeAccount
@@ -244,15 +257,7 @@ export default function LayoutBodyContent( {
 									primary: ! hasPayeeAccount,
 									compact: true,
 								} }
-								statusProps={
-									accountStatus
-										? {
-												children: accountStatus?.status,
-												type: accountStatus?.statusType,
-												tooltip: accountStatus?.statusReason,
-										  }
-										: undefined
-								}
+								status={ paymentStatusBadge }
 							/>
 						</StepSection>
 						<StepSection

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -174,13 +174,20 @@ $data-view-border-color: #f1f1f1;
 			}
 		}
 
+		.step-section-item__heading {
+			@include break-large {
+				display: flex;
+				align-items: center;
+				gap: 8px;
+			}
+		}
+
+		// Boxless wrapper: the base 30% width no longer constrains the badge,
+		// so the payment status is not truncated.
 		.step-section-item__status.is-large-screen {
 			@include break-large {
-				display: inline-flex;
-				position: relative;
-				left: 8px;
+				display: contents;
 			}
-
 		}
 	}
 }

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
@@ -1,9 +1,9 @@
-import { type BadgeType, Tooltip } from '@automattic/components';
+import { Tooltip } from '@automattic/components';
+import { Badge } from '@automattic/ui';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
 import EmptyValueIndicator from 'calypso/a8c-for-agencies/components/empty-value-indicator';
-import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
 import { getTimeframeText } from 'calypso/a8c-for-agencies/sections/reports/lib/timeframes';
 import FormattedDate from 'calypso/components/formatted-date';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
@@ -29,10 +29,10 @@ export const ReportStatusColumn = ( { status }: { status: ReportStatus } ) => {
 	const translate = useTranslate();
 
 	const statusConfig = {
-		pending: { type: 'info', text: translate( 'Preparing' ) },
-		processed: { type: 'success', text: translate( 'Ready to send' ) },
-		sent: { type: 'success', text: translate( 'Sent' ) },
-		error: { type: 'error', text: translate( 'Error' ) },
+		pending: { intent: 'info' as const, text: translate( 'Preparing' ) },
+		processed: { intent: 'success' as const, text: translate( 'Ready to send' ) },
+		sent: { intent: 'success' as const, text: translate( 'Sent' ) },
+		error: { intent: 'error' as const, text: translate( 'Error' ) },
 	};
 
 	const config = statusConfig[ status ];
@@ -41,7 +41,7 @@ export const ReportStatusColumn = ( { status }: { status: ReportStatus } ) => {
 		return <EmptyValueIndicator />;
 	}
 
-	return <StatusBadge statusProps={ { children: config.text, type: config.type as BadgeType } } />;
+	return <Badge intent={ config.intent }>{ config.text }</Badge>;
 };
 
 export const ReportDateColumn = ( { date }: { date: number | null } ) => {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
@@ -37,11 +37,6 @@
 	@include heading-medium;
 	margin-inline-end: 16px;
 
-	.status-badge {
-		/* stylelint-disable-next-line scales/radii */
-		border-radius: 12px;
-	}
-
 	.sites-dataviews__site-development-badge {
 		margin-block-start: 4px;
 	}

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
@@ -1,4 +1,5 @@
-import { Badge, Button } from '@automattic/components';
+import { Button } from '@automattic/components';
+import { Badge } from '@automattic/ui';
 import { translate } from 'i18n-calypso';
 import SiteFavicon from 'calypso/blocks/site-favicon';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
@@ -43,15 +44,10 @@ const SiteDataField = ( {
 				<div>{ site.blogname }</div>
 				{ ! migrationInProgress && <div className="sites-dataviews__site-url">{ site.url }</div> }
 				{ migrationInProgress && (
-					<Badge className="status-badge" type="info-blue">
-						{ translate( 'Migration in progress' ) }
-					</Badge>
+					<Badge intent="info">{ translate( 'Migration in progress' ) }</Badge>
 				) }
 				{ isDevSite && (
-					<Badge
-						className="status-badge sites-dataviews__site-development-badge"
-						type="info-purple"
-					>
+					<Badge className="sites-dataviews__site-development-badge">
 						{ translate( 'Development' ) }
 					</Badge>
 				) }

--- a/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@automattic/components';
+import { Badge } from '@automattic/ui';
 import {
 	__experimentalNavigatorButton as NavigatorButton,
 	__experimentalItem as Item,
@@ -78,7 +78,7 @@ export const SidebarNavigatorMenuItem = ( {
 		<li>
 			<NavigatorButton as={ SidebarItem } path={ path }>
 				<div className="sidebar-menu-item__title-with-badge">
-					{ title } { badge && <Badge type="info">{ badge }</Badge> }
+					{ title } { badge && <Badge>{ badge }</Badge> }
 				</div>
 			</NavigatorButton>
 		</li>


### PR DESCRIPTION
Resolves A4A-3045

## Proposed Changes

* Update the status labels on several screens to the new badge style already used on WooPayments, Referrals, and Migrations, so labels look the same across the product:
  * Reports — the report status labels (Preparing, Ready to send, Sent, Error).
  * Amplify — the “Audit complete” label on the overview card, and the score and analysis-type labels on the reports list.
  * Partner Directory — the directory application statuses (Pending, Approved, Not approved, Closed) and the lead matching eligibility labels.
  * Payment settings pages for Referrals, Migrations, and WooPayments commissions — the “Payment status” label in the page header.
  * Sidebar — the “Beta” tags next to Reports, Amplify, and menu items like Agent Studio.
  * Overview — the “Featured” tag on the WooPayments card now uses the standard badge with no custom styling.
  * Sites — the “Development” and “Migration in progress” labels on the site list.
  * Marketplace — the “You own N sites” tag and the Pressable “Plan” tag.
  * Purchases — the license labels (Unassigned, Revoked, Transferred, Referral, Development, license bundle count, Refundable) and the invoice statuses (Draft, Open, Past due, Paid, Uncollectible, Void).
  * Referrals — the payment status label on the “Prepare to get paid” step of the overview, which was also getting cut off before.
  * Client dashboard — the subscription status labels clients see (Active, Pending, Error, Canceled).
* Labels that are categories rather than statuses (Beta, Development, Referral, analysis type, bundle count) use the neutral gray badge, since the new badge set doesn’t include the old custom colors.
* Wide license labels like “100 License Bundle” are no longer cut off, and the invoice status column is slightly wider so “Uncollectible” fits on one line.

## Why are these changes being made?

* Some screens still used the old badge design while newer screens use the new one, so the same kind of label looked different from page to page. This was raised in the A4A dashboard QA walkthrough (A4A-3045).

## Testing Instructions

* Open the live link for this branch (A8C for Agencies) and log in as an agency.
* Go to **Reports** — the status column should show the new-style labels with icons.

<img width="1352" height="347" alt="Screenshot 2026-08-04 at 3 37 40 PM" src="https://github.com/user-attachments/assets/827f0778-4f0f-4411-88a1-698c2269e500" />

* Go to **Amplify** — the overview card shows the new “Audit complete” label; on the reports list, the score labels and analysis-type labels use the new style.

<img width="428" height="508" alt="Screenshot 2026-08-04 at 3 44 37 PM" src="https://github.com/user-attachments/assets/4012d9da-ac03-451e-b80e-dd31e95c53dd" />

<img width="1352" height="371" alt="Screenshot 2026-08-04 at 3 49 15 PM" src="https://github.com/user-attachments/assets/60459eea-7a4e-4ba4-a800-823030f457d2" />


* Go to **Partner Directory** — the “Share your expertise” step shows the directory statuses in the new style; the “Not approved” popover still opens. Also check the status card on the Lead matching page.

<img width="790" height="87" alt="Screenshot 2026-08-04 at 3 33 55 PM" src="https://github.com/user-attachments/assets/4258addf-1de2-48ba-b2be-47773a4628ad" />

<img width="790" height="87" alt="Screenshot 2026-08-04 at 3 34 39 PM" src="https://github.com/user-attachments/assets/c1f9d4ea-2ae3-432a-b9dd-95053eedb249" />

<img width="790" height="87" alt="Screenshot 2026-08-04 at 3 36 57 PM" src="https://github.com/user-attachments/assets/1e578840-ee1a-424d-8a6a-cff00d200bb4" />

<img width="741" height="257" alt="Screenshot 2026-08-04 at 3 40 10 PM" src="https://github.com/user-attachments/assets/21bcf861-2470-4dcb-9c77-f4f8e04c4a4d" />


* Go to **Referrals → Payment settings** (and the same page under Migrations and WooPayments) — the “Payment status” label in the header uses the new style; when the account has an issue, hovering it shows the reason in a tooltip.

<img width="1049" height="338" alt="Screenshot 2026-08-04 at 3 59 31 PM" src="https://github.com/user-attachments/assets/f03b3532-5f7f-4556-b984-df1a907aeebb" />

* Check the **sidebar** — the “Beta” tags next to Reports, Amplify, and Agent Studio use the new neutral badge.

<img width="231" height="151" alt="Screenshot 2026-08-06 at 11 37 14 AM" src="https://github.com/user-attachments/assets/e9223f8a-c4c5-4015-8375-d1a328188f9c" />


* Go to **Overview** — the WooPayments card shows the “Featured” tag as a standard badge.

<img width="346" height="285" alt="Screenshot 2026-08-06 at 12 32 18 PM" src="https://github.com/user-attachments/assets/e25b2ad3-9070-4c42-b976-35c03a2b9d7e" />


* Go to **Sites** — dev sites show the gray “Development” label; sites mid-migration show the blue “Migration in progress” label.

<img width="966" height="106" alt="Screenshot 2026-08-06 at 11 59 49 AM" src="https://github.com/user-attachments/assets/5ff5a637-9e53-4d94-bec8-defbaf19564a" />

<img width="970" height="78" alt="Screenshot 2026-08-06 at 12 01 36 PM" src="https://github.com/user-attachments/assets/99c28887-e3df-4081-b329-a1d0ecae77e4" />


* Go to **Marketplace → Hosting** — the WordPress.com plan card shows the “You own N sites” tag, and the Pressable section shows the “Plan” tag next to your plan name.

<img width="392" height="276" alt="Screenshot 2026-08-06 at 11 55 41 AM" src="https://github.com/user-attachments/assets/26676480-8190-4e98-90c3-4a7a60a9eb25" />

<img width="998" height="333" alt="Screenshot 2026-08-06 at 11 55 49 AM" src="https://github.com/user-attachments/assets/fda95093-a3b6-4435-8315-fb03876920b4" />


* Go to **Purchases → Licenses** — check the labels across the tabs: “Unassigned” (yellow), “Revoked” (red), and the gray tags (Development, Referral, bundle count). Wide labels like “100 License Bundle” should not be cut off.

<img width="947" height="152" alt="Screenshot 2026-08-06 at 11 57 52 AM" src="https://github.com/user-attachments/assets/b34606f1-0a9d-43ba-9107-56aae19b46b8" />

<img width="925" height="440" alt="Screenshot 2026-08-06 at 11 58 14 AM" src="https://github.com/user-attachments/assets/7bab95b0-ebe7-425c-ac74-db4d75a08784" />

<img width="939" height="219" alt="Screenshot 2026-08-06 at 11 58 22 AM" src="https://github.com/user-attachments/assets/566c94b7-7bac-408d-9d2e-7c26acd6db5b" />

<img width="913" height="65" alt="Screenshot 2026-08-06 at 12 00 47 PM" src="https://github.com/user-attachments/assets/e9bb6e9d-073a-4915-ab94-a71b73ec5acf" />


* Go to **Purchases → Invoices** — the status column shows the new labels; “Uncollectible” fits on one line.

<img width="950" height="540" alt="Screenshot 2026-08-06 at 12 27 11 PM" src="https://github.com/user-attachments/assets/3b7dcfc6-7771-4ee2-a346-03f9d65fa1d0" />


* Go to **Referrals** with an account that has no referrals — the “Prepare to get paid” step shows the payment status label next to the heading, fully visible (it was truncated before).

<img width="802" height="531" alt="Screenshot 2026-08-06 at 12 50 43 PM" src="https://github.com/user-attachments/assets/ca56fd33-bd9a-4da0-90b1-43355f1f6795" />

<img width="812" height="580" alt="Screenshot 2026-08-06 at 12 50 59 PM" src="https://github.com/user-attachments/assets/c835f66d-2cbe-4492-ae14-89595f2c7126" />



* Log in as a **client** and open the subscriptions list — the status column shows the new-style labels (Active, Pending, Error, Canceled).

<img width="645" height="385" alt="Screenshot 2026-08-06 at 12 52 35 PM" src="https://github.com/user-attachments/assets/1dc4922c-5cee-42bb-b82d-2056907371ab" />

<img width="651" height="345" alt="Screenshot 2026-08-06 at 12 52 58 PM" src="https://github.com/user-attachments/assets/a1604ece-9eb9-4589-a1d5-1d2516c07ff1" />

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

