### PR TITLE
E2E: prime login cookies once before the suite

### DIFF
--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -23,7 +23,6 @@ object CalypsoE2ETestsBuildTemplate : Template({
 		param("env.NODE_CONFIG_ENV", "test")
 		param("env.PLAYWRIGHT_BROWSERS_PATH", "0")
 		param("env.LOCALE", "en")
-		param("env.AUTHENTICATE_ACCOUNTS", "simpleSitePersonalPlanUser,gutenbergSimpleSiteUser,defaultUser")
 		// required in the CTRF report
 		param("env.BRANCH_NAME", "%teamcity.build.branch%")
 		param("PROJECT", "desktop")

--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -23,6 +23,10 @@ object CalypsoE2ETestsBuildTemplate : Template({
 		param("env.NODE_CONFIG_ENV", "test")
 		param("env.PLAYWRIGHT_BROWSERS_PATH", "0")
 		param("env.LOCALE", "en")
+		// No AUTHENTICATE_ACCOUNTS on purpose: setting it replaces the whole list the
+		// prime-logins setup project logs in as, so a value here would skip every account it
+		// doesn't name. Set it only on a build type running a narrow group, or to an empty
+		// value to skip priming. See test/e2e/setup/prime-logins.setup.ts.
 		// required in the CTRF report
 		param("env.BRANCH_NAME", "%teamcity.build.branch%")
 		param("PROJECT", "desktop")

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -391,6 +391,7 @@ private object I18NTests : BuildType({
 		param("CALYPSO_BASE_URL", "https://wordpress.com")
 		param("DASHBOARD_BASE_URL", "https://my.wordpress.com")
 		param("env.E2E_CTRF_APP_NAME", "i18n (calypso)")
+		param("env.AUTHENTICATE_ACCOUNTS", "i18nUser")
 	}
 
 	features {
@@ -435,6 +436,7 @@ private object P2E2ETests : BuildType({
 		param("CALYPSO_BASE_URL", "https://wpcalypso.wordpress.com")
 		param("DASHBOARD_BASE_URL", "https://my.wordpress.com")
 		param("env.E2E_CTRF_APP_NAME", "p2 (calypso)")
+		param("env.AUTHENTICATE_ACCOUNTS", "p2User")
 	}
 
 	features {

--- a/test/e2e/AGENTS.md
+++ b/test/e2e/AGENTS.md
@@ -141,7 +141,7 @@ test( 'Test', async ( { pageLogin, componentSidebar } ) => {
 
 ### Available Fixtures
 
-**Accounts**: `accountDefaultUser`, `accountGivenByEnvironment`, `accountAtomic`, `accountGutenbergSimple`, `accounti18n`, `accountPreRelease`, `accountSimpleSiteFreePlan`, `accountSMS`
+**Accounts**: one fixture per key of `fixtureAccounts` in [`lib/pw-base.ts`](lib/pw-base.ts), plus `accountGivenByEnvironment` and `accountSMS`. Adding a key there adds the fixture and primes the account before the suite.
 
 **Pages/Components**: Follow naming conventions:
 

--- a/test/e2e/docs/environment_variables.md
+++ b/test/e2e/docs/environment_variables.md
@@ -9,7 +9,7 @@ Environment Variables control much of the runtime configuration for E2E tests.
 | Name                  | Description                                                                                                           | Default                                             | Required |
 | --------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | -------- |
 | ARTIFACTS_PATH        | Path on disk to test artifacts (screenshots, logs, etc).                                                              | `./results/`                                        | Optional |
-| AUTHENTICATE_ACCOUNTS | Comma-delimited list of accounts to pre-authenticate for later use.                                                   | `simpleSitePersonalPlanUser,atomicUser,defaultUser` | Optional |
+| AUTHENTICATE_ACCOUNTS | Comma-delimited list of accounts to log in as before the suite runs. An empty value primes no account at all.         | the list in `setup/prime-logins.setup.ts`           | Optional |
 | CALYPSO_BASE_URL      | The base URL to use for Calypso e.g. `https://wordpress.com`, `http://calypso.localhost:3000`, etc.                   | `http://calypso.localhost:3000`                     | Optional |
 | COBLOCKS_EDGE         | Use the bleeding edge CoBlocks build.                                                                                 | `false`                                             | Optional |
 | COOKIES_PATH          | Path on disk to the saved authenticated cookies.                                                                      | `./cookies/`                                        | Optional |

--- a/test/e2e/docs/tests_local.md
+++ b/test/e2e/docs/tests_local.md
@@ -70,13 +70,15 @@ See the [list of groups](tests_ci.md#featuretest-groups).
 
 ### Save authentication cookies
 
-Specified accounts will be pre-authenticated prior to the main test suite executions and their cookies saved to be re-used until expiry (typically 3 days).
+The `prime-logins` setup project logs in as a list of accounts before the main test suite runs and saves their cookies to be re-used until expiry (typically 3 days). Every project except `authentication` waits for it, so the specs read those cookies instead of logging in themselves.
 
-Specify a list of user accounts found in [Secret Manager](../../../packages/calypso-e2e/src/secrets/secrets-manager.ts), separated by commas:
+By default it primes the list in [`setup/prime-logins.setup.ts`](../setup/prime-logins.setup.ts). To prime a different set, name the accounts found in [Secret Manager](../../../packages/calypso-e2e/src/secrets/secrets-manager.ts), separated by commas:
 
 ```bash
 export AUTHENTICATE_ACCOUNTS=simpleSitePersonalPlanUser,atomicUser,defaultUser
 ```
+
+Set it to an empty value to skip priming altogether; whatever needs an account then logs in when it first runs.
 
 ### Use the mobile viewport
 

--- a/test/e2e/docs/tests_local.md
+++ b/test/e2e/docs/tests_local.md
@@ -78,6 +78,8 @@ By default it primes the list in [`setup/prime-logins.setup.ts`](../setup/prime-
 export AUTHENTICATE_ACCOUNTS=simpleSitePersonalPlanUser,atomicUser,defaultUser
 ```
 
+Either list is primed alongside the account the current environment variables select, the one behind the `accountGivenByEnvironment` fixture.
+
 Set it to an empty value to skip priming altogether; whatever needs an account then logs in when it first runs.
 
 ### Use the mobile viewport

--- a/test/e2e/lib/get-account.ts
+++ b/test/e2e/lib/get-account.ts
@@ -13,10 +13,17 @@ import { Page } from 'playwright';
  */
 export async function getAccount(
 	page: Page,
-	accountName: TestAccountName
+	accountName: TestAccountName,
+	{ isPriming = false }: { isPriming?: boolean } = {}
 ): Promise< TestAccount > {
 	const testAccount = new TestAccount( accountName );
 	if ( ! ( await testAccount.hasFreshAuthCookies() ) ) {
+		if ( ! isPriming ) {
+			// The prime-logins setup project should have left cookies for this account. Say so
+			// when it didn't: a quiet run means priming worked, and a noisy one names the
+			// accounts that fell back to logging in one worker at a time.
+			console.log( `Logging in as ${ accountName }, no primed cookies to reuse.` );
+		}
 		await testAccount.logInViaLoginPage( page );
 		await testAccount.saveAuthCookies( page.context() );
 	}

--- a/test/e2e/lib/pw-base.ts
+++ b/test/e2e/lib/pw-base.ts
@@ -81,6 +81,7 @@ import {
 	SiteSelectComponent,
 	SignupPickPlanPage,
 	TestAccount,
+	TestAccountName,
 	ThemesDetailPage,
 	ThemesPage,
 	UserSignupPage,
@@ -89,7 +90,7 @@ import {
 	UseADomainIOwnPage,
 	SelectItemsComponent,
 } from '@automattic/calypso-e2e';
-import { test as base, expect } from '@playwright/test';
+import { test as base, expect, type Page } from '@playwright/test';
 import {
 	apiCloseAccount,
 	apiWaitForBearerTokenAcceptance,
@@ -107,44 +108,41 @@ export type CustomOptions = {
 	viewportName: string;
 };
 
+/**
+ * Test accounts exposed as a fixture of the same name, logged in on first use.
+ *
+ * The `prime-logins` setup project logs in as each of these before the suite starts, so
+ * an account added here is primed rather than logged in inline. Two accounts are fixtures
+ * without belonging here: `accountGivenByEnvironment`, which resolves at run time, and
+ * `accountSMS`, whose 2FA code costs a Mailosaur email only a couple of specs need.
+ */
+export const fixtureAccounts = {
+	accountAtomic: 'atomicUser',
+	accountDefaultUser: 'defaultUser',
+	accountGutenbergSimple: 'gutenbergSimpleSiteUser',
+	accounti18n: 'i18nUser',
+	accountP2: 'p2User',
+	accountPreRelease: 'calypsoPreReleaseUser',
+	accountSimpleSiteFreePlan: 'simpleSiteFreePlanUser',
+} as const satisfies Record< string, TestAccountName >;
+
+type AccountFixture = (
+	args: { page: Page },
+	use: ( account: TestAccount ) => Promise< void >
+) => Promise< void >;
+
 export const test = base.extend<
 	CustomOptions & {
-		/**
-		 * Test account used to test atomic sites (Business plans)
-		 */
-		accountAtomic: TestAccount;
+		[ K in keyof typeof fixtureAccounts ]: TestAccount;
+	} & {
 		/**
 		 * Test account selected based on the current environment variables.
 		 */
 		accountGivenByEnvironment: TestAccount;
 		/**
-		 * Default test account.
-		 */
-		accountDefaultUser: TestAccount;
-		/**
-		 * Test account with a simple Gutenberg site.
-		 */
-		accountGutenbergSimple: TestAccount;
-		/**
-		 * Test account used for i18n locale switching.
-		 */
-		accounti18n: TestAccount;
-		/**
-		 * Test account used for pre-release testing.
-		 */
-		accountPreRelease: TestAccount;
-		/**
-		 * Test account used to test atomic sites (Business plans)
-		 */
-		accountSimpleSiteFreePlan: TestAccount;
-		/**
 		 * Test account used for SMS-based 2FA.
 		 */
 		accountSMS: TestAccount;
-		/**
-		 * Test account used for P2 tests.
-		 */
-		accountP2: TestAccount;
 		/**
 		 * Client for interacting with emails during tests.
 		 */
@@ -391,41 +389,22 @@ export const test = base.extend<
 
 		await use( page );
 	},
-	accountAtomic: async ( { page }, use ) => {
-		const testAccount = await getAccount( page, 'atomicUser' );
-		await use( testAccount );
-	},
+	...( Object.fromEntries(
+		Object.entries( fixtureAccounts ).map( ( [ fixtureName, accountName ] ) => [
+			fixtureName,
+			async ( { page }, use ) => {
+				const testAccount = await getAccount( page, accountName );
+				await use( testAccount );
+			},
+		] )
+	) as Record< keyof typeof fixtureAccounts, AccountFixture > ),
 	accountGivenByEnvironment: async ( { page }, use ) => {
 		const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
 		const testAccount = await getAccount( page, accountName );
 		await use( testAccount );
 	},
-	accountDefaultUser: async ( { page }, use ) => {
-		const testAccount = await getAccount( page, 'defaultUser' );
-		await use( testAccount );
-	},
-	accountGutenbergSimple: async ( { page }, use ) => {
-		const testAccount = await getAccount( page, 'gutenbergSimpleSiteUser' );
-		await use( testAccount );
-	},
-	accounti18n: async ( { page }, use ) => {
-		const testAccount = await getAccount( page, 'i18nUser' );
-		await use( testAccount );
-	},
-	accountPreRelease: async ( { page }, use ) => {
-		const testAccount = await getAccount( page, 'calypsoPreReleaseUser' );
-		await use( testAccount );
-	},
-	accountSimpleSiteFreePlan: async ( { page }, use ) => {
-		const testAccount = await getAccount( page, 'simpleSiteFreePlanUser' );
-		await use( testAccount );
-	},
 	accountSMS: async ( { page }, use ) => {
 		const testAccount = await getAccount( page, 'smsUser' );
-		await use( testAccount );
-	},
-	accountP2: async ( { page }, use ) => {
-		const testAccount = await getAccount( page, 'p2User' );
 		await use( testAccount );
 	},
 	clientEmail: async ( {}, use ) => {

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -119,7 +119,6 @@ export default defineConfig( {
 			use: withCustomOptions( {
 				...devices[ 'Desktop Chrome HiDPI' ],
 				userAgent: appendE2EUserAgent( devices[ 'Desktop Chrome HiDPI' ].userAgent ),
-				viewportName: 'desktop',
 			} ),
 		},
 		{

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -113,12 +113,17 @@ export default defineConfig( {
 			name: 'prime-logins',
 			testMatch: /prime-logins\.setup\.ts/,
 			testDir: './setup',
-			// Same context as the `chrome` project: priming must look to the backend like
-			// the e2e session it stands in for, down to the user agent suffix.
+			// Borrows the `chrome` context so the login carries the e2e user agent suffix the
+			// backend expects. The cookies it leaves are per account, not per device, so the
+			// mobile projects reuse them too.
 			use: withCustomOptions( {
 				...devices[ 'Desktop Chrome HiDPI' ],
 				userAgent: appendE2EUserAgent( devices[ 'Desktop Chrome HiDPI' ].userAgent ),
 				viewportName: 'desktop',
+				// A priming failure is swallowed so it can't skip the dependent projects, which
+				// also means the default `on failure` rules would throw the artifacts away.
+				trace: 'on',
+				video: 'on',
 			} ),
 		},
 		{

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -120,10 +120,6 @@ export default defineConfig( {
 				...devices[ 'Desktop Chrome HiDPI' ],
 				userAgent: appendE2EUserAgent( devices[ 'Desktop Chrome HiDPI' ].userAgent ),
 				viewportName: 'desktop',
-				// A priming failure is swallowed so it can't skip the dependent projects, which
-				// also means the default `on failure` rules would throw the artifacts away.
-				trace: 'on',
-				video: 'on',
 			} ),
 		},
 		{

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -110,8 +110,20 @@ export default defineConfig( {
 			testDir: './setup',
 		},
 		{
+			name: 'prime-logins',
+			testMatch: /prime-logins\.setup\.ts/,
+			testDir: './setup',
+			// Same context as the `chrome` project: priming must look to the backend like
+			// the e2e session it stands in for, down to the user agent suffix.
+			use: withCustomOptions( {
+				...devices[ 'Desktop Chrome HiDPI' ],
+				userAgent: appendE2EUserAgent( devices[ 'Desktop Chrome HiDPI' ].userAgent ),
+				viewportName: 'desktop',
+			} ),
+		},
+		{
 			name: 'chrome',
-			dependencies: [ 'mailosaur-usage-check' ],
+			dependencies: [ 'mailosaur-usage-check', 'prime-logins' ],
 			use: withCustomOptions( {
 				...devices[ 'Desktop Chrome HiDPI' ],
 				userAgent: appendE2EUserAgent( devices[ 'Desktop Chrome HiDPI' ].userAgent ),
@@ -120,7 +132,7 @@ export default defineConfig( {
 		},
 		{
 			name: 'firefox',
-			dependencies: [ 'mailosaur-usage-check' ],
+			dependencies: [ 'mailosaur-usage-check', 'prime-logins' ],
 			use: withCustomOptions( {
 				...devices[ 'Desktop Firefox' ],
 				userAgent: appendE2EUserAgent( devices[ 'Desktop Firefox' ].userAgent ),
@@ -129,7 +141,7 @@ export default defineConfig( {
 		},
 		{
 			name: 'webkit',
-			dependencies: [ 'mailosaur-usage-check' ],
+			dependencies: [ 'mailosaur-usage-check', 'prime-logins' ],
 			use: withCustomOptions( {
 				...devices[ 'Desktop Safari' ],
 				userAgent: appendE2EUserAgent( devices[ 'Desktop Safari' ].userAgent ),
@@ -138,7 +150,7 @@ export default defineConfig( {
 		},
 		{
 			name: 'pixel',
-			dependencies: [ 'mailosaur-usage-check' ],
+			dependencies: [ 'mailosaur-usage-check', 'prime-logins' ],
 			use: withCustomOptions( {
 				...devices[ 'Pixel 7' ],
 				userAgent: appendE2EUserAgent( devices[ 'Pixel 7' ].userAgent ),
@@ -148,7 +160,7 @@ export default defineConfig( {
 		},
 		{
 			name: 'galaxy',
-			dependencies: [ 'mailosaur-usage-check' ],
+			dependencies: [ 'mailosaur-usage-check', 'prime-logins' ],
 			use: withCustomOptions( {
 				...devices[ 'Galaxy S24' ],
 				userAgent: appendE2EUserAgent( devices[ 'Galaxy S24' ].userAgent ),
@@ -158,7 +170,7 @@ export default defineConfig( {
 		},
 		{
 			name: 'iphone',
-			dependencies: [ 'mailosaur-usage-check' ],
+			dependencies: [ 'mailosaur-usage-check', 'prime-logins' ],
 			use: withCustomOptions( {
 				...devices[ 'iPhone 15 Pro' ],
 				userAgent: appendE2EUserAgent( devices[ 'iPhone 15 Pro' ].userAgent ),
@@ -168,6 +180,8 @@ export default defineConfig( {
 		},
 		{
 			name: 'authentication',
+			// No 'prime-logins': these specs exercise the login flow itself, so warming
+			// the cookie cache would only add wall clock.
 			dependencies: [ 'mailosaur-usage-check' ],
 			retries: 0,
 			testDir: './specs/authentication',

--- a/test/e2e/setup/prime-logins.setup.ts
+++ b/test/e2e/setup/prime-logins.setup.ts
@@ -92,13 +92,18 @@ for ( const accountName of new Set( getAccountNamesToPrime() ) ) {
 				} ),
 			] );
 		} catch ( error ) {
-			const { retry, project } = setup.info();
+			const info = setup.info();
 			// Retrying is worth it, a stuck login usually succeeds second time round. Only
 			// the last attempt has to pass, so the project stays green either way.
-			if ( retry < project.retries ) {
+			if ( info.retry < info.project.retries ) {
 				throw error;
 			}
-			console.warn( `Could not prime login cookies for ${ accountName }: ${ error }` );
+			// Annotate rather than only log: the last attempt passes, so the reports are the
+			// only place a reader would otherwise see nothing at all.
+			info.annotations.push( {
+				type: 'prime-failed',
+				description: `Could not prime login cookies for ${ accountName }: ${ error }`,
+			} );
 		} finally {
 			clearTimeout( timer );
 		}

--- a/test/e2e/setup/prime-logins.setup.ts
+++ b/test/e2e/setup/prime-logins.setup.ts
@@ -5,7 +5,7 @@ import {
 	type TestAccountName,
 } from '@automattic/calypso-e2e';
 import { getAccount } from '../lib/get-account';
-import { test as setup } from '../lib/pw-base';
+import { fixtureAccounts, test as setup } from '../lib/pw-base';
 
 // Accounts logged in as before the suite starts, so the specs read cookies instead of all
 // logging in at once.
@@ -15,18 +15,11 @@ import { test as setup } from '../lib/pw-base';
 // log in through the UI concurrently, against a calypso.live container that has just been
 // created, which is where most of the CI login timeouts come from.
 //
-// Keep this in step with the account fixtures in ../lib/pw-base.ts. An account missing here
-// still works: getAccount falls back to logging in inline, which is what every account did
-// before this project existed. smsUser is left out on purpose, its 2FA code costs a
-// Mailosaur email and only a couple of specs need it.
+// The account fixtures own this list, so adding a fixture primes it. An account missing from
+// it still works: getAccount falls back to logging in inline, which is what every account did
+// before this project existed.
 const defaultAccountNames: TestAccountName[] = [
-	'atomicUser',
-	'calypsoPreReleaseUser',
-	'defaultUser',
-	'gutenbergSimpleSiteUser',
-	'i18nUser',
-	'p2User',
-	'simpleSiteFreePlanUser',
+	...Object.values( fixtureAccounts ),
 	// Not a fixture, but the account many specs select through a criteria override.
 	'simpleSitePersonalPlanUser',
 ];

--- a/test/e2e/setup/prime-logins.setup.ts
+++ b/test/e2e/setup/prime-logins.setup.ts
@@ -69,8 +69,13 @@ for ( const accountName of new Set( getAccountNamesToPrime() ) ) {
 			// can't be caught here, and a setup project that ends with a failing test makes
 			// Playwright skip every project that depends on it. That would cost the whole
 			// run instead of one account's inline login.
+			const priming = getAccount( page, accountName, { isPriming: true } );
+			// When the deadline wins, the login keeps running until teardown closes the page
+			// and then rejects. Playwright charges an unhandled rejection to the test, which
+			// is the failure the deadline exists to avoid, so keep a handler on it.
+			priming.catch( () => {} );
 			await Promise.race( [
-				getAccount( page, accountName, { isPriming: true } ),
+				priming,
 				new Promise( ( _resolve, reject ) => {
 					timer = setTimeout(
 						() => reject( new Error( `timed out after ${ PRIME_TIMEOUT }ms` ) ),

--- a/test/e2e/setup/prime-logins.setup.ts
+++ b/test/e2e/setup/prime-logins.setup.ts
@@ -29,18 +29,22 @@ const defaultAccountNames: TestAccountName[] = [
  *
  * A build type that runs a narrow group can list just the accounts it needs in
  * AUTHENTICATE_ACCOUNTS, or opt out of priming altogether by setting it to an empty value;
- * the ToS build does the latter. Anything else gets the default list above plus whichever
- * account this environment resolves `accountGivenByEnvironment` to, since the Gutenberg
- * edge, nightly and Atomic builds each run against a different one and it is the busiest
- * account of those runs.
+ * the ToS build does the latter.
+ *
+ * Whichever list is used, the account this environment resolves `accountGivenByEnvironment`
+ * to is added to it: the Gutenberg edge, nightly, CoBlocks and Atomic builds each run
+ * against a different one, and it is the busiest account of those runs. It comes from a
+ * static table, so resolving it here costs nothing.
  */
 function getAccountNamesToPrime(): TestAccountName[] {
+	let accountNames = defaultAccountNames;
+
 	// Read process.env rather than the envVariables getter: the getter returns an empty array
 	// both when the variable is unset and when it is set to an empty value, and those mean
 	// different things here.
 	if ( process.env.AUTHENTICATE_ACCOUNTS !== undefined ) {
 		try {
-			return envVariables.AUTHENTICATE_ACCOUNTS;
+			accountNames = envVariables.AUTHENTICATE_ACCOUNTS;
 		} catch ( error ) {
 			// An unknown account name throws. This runs while the file is being collected, so
 			// letting it escape would fail the run before a single spec starts.
@@ -48,13 +52,17 @@ function getAccountNamesToPrime(): TestAccountName[] {
 		}
 	}
 
-	const accountNames = [ ...defaultAccountNames ];
+	// An empty AUTHENTICATE_ACCOUNTS asks for no priming at all, so don't add back to it.
+	if ( accountNames.length === 0 ) {
+		return [];
+	}
+
 	try {
-		accountNames.push( getTestAccountByFeature( envToFeatureKey( envVariables ) ) );
+		return [ ...accountNames, getTestAccountByFeature( envToFeatureKey( envVariables ) ) ];
 	} catch {
 		// No account is mapped to this environment; whatever needs one logs in inline.
+		return accountNames;
 	}
-	return accountNames;
 }
 
 // Well under the 120s test timeout. A login takes about 5s, so this only trips when

--- a/test/e2e/setup/prime-logins.setup.ts
+++ b/test/e2e/setup/prime-logins.setup.ts
@@ -1,0 +1,100 @@
+import {
+	envToFeatureKey,
+	envVariables,
+	getTestAccountByFeature,
+	type TestAccountName,
+} from '@automattic/calypso-e2e';
+import { getAccount } from '../lib/get-account';
+import { test as setup } from '../lib/pw-base';
+
+// Accounts logged in as before the suite starts, so the specs read cookies instead of all
+// logging in at once.
+//
+// Every worker begins by checking the shared cookie cache in COOKIES_PATH, which the
+// TeamCity checkout wipes before each build. Without this project they all miss at once and
+// log in through the UI concurrently, against a calypso.live container that has just been
+// created, which is where most of the CI login timeouts come from.
+//
+// Keep this in step with the account fixtures in ../lib/pw-base.ts. An account missing here
+// still works: getAccount falls back to logging in inline, which is what every account did
+// before this project existed. smsUser is left out on purpose, its 2FA code costs a
+// Mailosaur email and only a couple of specs need it.
+const defaultAccountNames: TestAccountName[] = [
+	'atomicUser',
+	'calypsoPreReleaseUser',
+	'defaultUser',
+	'gutenbergSimpleSiteUser',
+	'i18nUser',
+	'p2User',
+	'simpleSiteFreePlanUser',
+	// Not a fixture, but the account many specs select through a criteria override.
+	'simpleSitePersonalPlanUser',
+];
+
+/**
+ * Returns the accounts to log in as before the suite starts.
+ *
+ * A build type that runs a narrow group can list just the accounts it needs in
+ * AUTHENTICATE_ACCOUNTS, or opt out of priming altogether by setting it to an empty value;
+ * the ToS build does the latter. Anything else gets the default list above plus whichever
+ * account this environment resolves `accountGivenByEnvironment` to, since the Gutenberg
+ * edge, nightly and Atomic builds each run against a different one and it is the busiest
+ * account of those runs.
+ */
+function getAccountNamesToPrime(): TestAccountName[] {
+	// Read process.env rather than the envVariables getter: the getter returns an empty array
+	// both when the variable is unset and when it is set to an empty value, and those mean
+	// different things here.
+	if ( process.env.AUTHENTICATE_ACCOUNTS !== undefined ) {
+		try {
+			return envVariables.AUTHENTICATE_ACCOUNTS;
+		} catch ( error ) {
+			// An unknown account name throws. This runs while the file is being collected, so
+			// letting it escape would fail the run before a single spec starts.
+			console.warn( `Ignoring AUTHENTICATE_ACCOUNTS: ${ error }` );
+		}
+	}
+
+	const accountNames = [ ...defaultAccountNames ];
+	try {
+		accountNames.push( getTestAccountByFeature( envToFeatureKey( envVariables ) ) );
+	} catch {
+		// No account is mapped to this environment; whatever needs one logs in inline.
+	}
+	return accountNames;
+}
+
+// Well under the 120s test timeout. A login takes about 5s, so this only trips when
+// something is badly wrong, and it leaves room for the retry to still finish in time.
+const PRIME_TIMEOUT = 30 * 1000;
+
+for ( const accountName of new Set( getAccountNamesToPrime() ) ) {
+	setup( `prime login cookies: ${ accountName }`, async ( { page } ) => {
+		let timer: NodeJS.Timeout | undefined;
+		try {
+			// Race our own deadline: Playwright's test timeout aborts from the outside and
+			// can't be caught here, and a setup project that ends with a failing test makes
+			// Playwright skip every project that depends on it. That would cost the whole
+			// run instead of one account's inline login.
+			await Promise.race( [
+				getAccount( page, accountName, { isPriming: true } ),
+				new Promise( ( _resolve, reject ) => {
+					timer = setTimeout(
+						() => reject( new Error( `timed out after ${ PRIME_TIMEOUT }ms` ) ),
+						PRIME_TIMEOUT
+					);
+				} ),
+			] );
+		} catch ( error ) {
+			const { retry, project } = setup.info();
+			// Retrying is worth it, a stuck login usually succeeds second time round. Only
+			// the last attempt has to pass, so the project stays green either way.
+			if ( retry < project.retries ) {
+				throw error;
+			}
+			console.warn( `Could not prime login cookies for ${ accountName }: ${ error }` );
+		} finally {
+			clearTimeout( timer );
+		}
+	} );
+}

--- a/test/e2e/tsconfig.json
+++ b/test/e2e/tsconfig.json
@@ -5,5 +5,5 @@
 		"noEmit": true, // just type checking, no output. The output is handled by babel.
 		"types": [ "jest", "node" ]
 	},
-	"include": [ "specs", "lib", "jest-helpers" ]
+	"include": [ "specs", "lib", "setup", "jest-helpers" ]
 }


### PR DESCRIPTION
## Proposed Changes

* Add a `prime-logins` setup project that logs in as each account once, before any spec runs. Every project except `authentication` depends on it, so specs read its cookies instead of logging in themselves.
* Take the account list from the fixtures in `pw-base.ts`. `AUTHENTICATE_ACCOUNTS` narrows it, or turns priming off when empty; the account the environment resolves is primed either way.

## Why are these changes being made?

The TeamCity checkout wipes the cookie cache in `COOKIES_PATH` before each build, so every worker misses it at once and logs in through the UI against a just-created calypso.live container. The login form often doesn't render inside the 10s action timeout. Priming takes the `login-page.ts:88` signature out of the matrix logs, 6 occurrences to 0.

Priming fails open. A prime that runs out of retries can't fail its own test, or Playwright would skip every project depending on it; it annotates instead, and that account logs in inline as it did before.

## Testing Instructions

Touching `test/e2e/` clears the `--grep` group, so the build here runs the full suite. `prime-logins` should finish within ~10s of the start, and `login-page.ts:88` and `login-page.ts:52` shouldn't appear.

Personal builds on `9027ccf` of the four configurations that use the template: [18787858](https://teamcity.a8c.com/build/18787858) matrix, [18787509](https://teamcity.a8c.com/build/18787509) Gutenberg, [18787512](https://teamcity.a8c.com/build/18787512) ToS, [18787513](https://teamcity.a8c.com/build/18787513) Authentication.

Every account primes except `p2User`, which times out on both attempts; the two specs that need it fall back to an inline login, and the failed attempt keeps its screenshot and video. Remaining reds: `authentication__google.spec.ts`, which fails on trunk and runs in the one project without `prime-logins`, and `blocks__jetpack-forms.spec.ts`, which failed on this branch before these commits too.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
