### PR TITLE
A4A Sites: Hide the empty fields row in the sites list preview mode

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -237,8 +237,7 @@
 				}
 
 				.dataviews-view-list__fields {
-					display: flex;
-					justify-content: space-between;
+					display: none;
 				}
 
 				/* This styling is a bit of a hack: To make the site name clickable area larger, will need

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -240,44 +240,6 @@
 					display: none;
 				}
 
-				/* This styling is a bit of a hack: To make the site name clickable area larger, will need
-				 * to hide the other fields when in preview mode.
-				 */
-				.dataviews-view-list__field {
-					// Hide the field except first (Site name) and last (actions menu)
-					&:not( :first-child ):not( :last-child ) {
-						display: none;
-					}
-
-					// Force the site name to take up the full width
-					&:first-child {
-						flex-grow: 1;
-
-						.sites-dataviews__site {
-							width: 100%;
-							justify-content: flex-start;
-						}
-					}
-				}
-
-				// Ideally instead of reusing the site name full field
-				// We should be setting a media field and a primary field.
-				.dataviews-view-list__media-wrapper {
-					display: none;
-				}
-				.dataviews-view-list__primary-field {
-					display: none;
-				}
-
-				.sites-overview__stats-trend,
-				.sites-overview__column-action-button,
-				.sites-overview__row-status,
-				.toggle-activate-monitoring__toggle-button,
-				.sites-dataviews__favorite-btn-wrapper,
-				.sites-overview__boost-score {
-					display: none;
-				}
-
 				.site-actions__actions-large-screen {
 					display: block;
 				}


### PR DESCRIPTION


## Proposed Changes

* Hide the `.dataviews-view-list__fields` container in the A4A Sites list when the preview pane is open.

| Before | After |
|--------|--------|
|  <img width="867" height="602" alt="Screenshot 2026-08-04 at 9 36 27 PM" src="https://github.com/user-attachments/assets/8223cf21-d631-47b7-80bb-1f10f6b1a3a8" /> | <img width="781" height="612" alt="Screenshot 2026-08-04 at 9 36 35 PM" src="https://github.com/user-attachments/assets/4c2a82ed-3b56-45f2-96d8-904b41cff6d9" /> | 

## Why are these changes being made?

* In preview mode the sites list collapses to a narrow column, and every field rendered inside `.dataviews-view-list__fields` (stats trend, row status, monitoring toggle, favorite button, Boost score, action buttons) is already hidden individually. The container itself was still laid out as a flex row, so each list item reserved extra vertical space for content that is never visible. Setting it to `display: none` removes that empty gap and tightens the list rows.

## Testing Instructions

* Go to the A4A Sites dashboard.
* Click a site to open the preview pane.
* Confirm the site rows in the narrow list no longer have an empty gap below the site name, and rows are more compact.
* Close the preview pane and confirm the full-width table view is unchanged (all columns still render normally).
* Repeat in dark mode and on a small viewport to confirm nothing else shifted.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
