### PR TITLE
Plugins: activate and deactivate over REST v1.2

### DIFF
--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -82,18 +82,14 @@ const getPluginHandler = ( siteId, pluginId ) => {
 };
 
 /*
- * Map a plugin from the v1.2 response format to the v1.1 one. The two carry the same
- * values under different keys: v1.2 exposes the plugin file as `name` and the title as
- * `display_name`, where v1.1 calls them `id` and `name`. Everything downstream — the
- * reducer's identity check included — reads the v1.1 shape, which is also what the
- * plugin list is fetched in.
- *
- * v1.2 additionally drops `next_autoupdate`, which nothing reads.
+ * Restate a v1.2 plugin in the v1.1 format. The store is populated from the v1.1 plugin
+ * list and everything downstream — the reducer's identity check included — reads that
+ * shape. v1.2 also drops `next_autoupdate`, which nothing reads.
  */
-const fromApiV1_2 = ( { name, display_name, ...plugin } ) => ( {
+const fromApiV1_2 = ( { name: id, display_name: name, ...plugin } ) => ( {
 	...plugin,
-	id: name,
-	name: display_name,
+	id,
+	name,
 } );
 
 /*
@@ -498,12 +494,6 @@ function installPluginHelper(
 				}
 				return doUpdate( plugin )
 					.then( doActivate )
-					.then( doAutoupdates )
-					.then( successCallback )
-					.catch( errorCallback );
-			}
-			if ( error.name === 'ActivationErrorError' ) {
-				return doUpdate( plugin )
 					.then( doAutoupdates )
 					.then( successCallback )
 					.catch( errorCallback );

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -81,6 +81,36 @@ const getPluginHandler = ( siteId, pluginId ) => {
 	return siteHandler.plugin( pluginId );
 };
 
+/*
+ * Map a plugin from the v1.2 response format to the v1.1 one. The two carry the same
+ * values under different keys: v1.2 exposes the plugin file as `name` and the title as
+ * `display_name`, where v1.1 calls them `id` and `name`. Everything downstream — the
+ * reducer's identity check included — reads the v1.1 shape, which is also what the
+ * plugin list is fetched in.
+ *
+ * v1.2 additionally drops `next_autoupdate`, which nothing reads.
+ */
+const fromApiV1_2 = ( { name, display_name, ...plugin } ) => ( {
+	...plugin,
+	id: name,
+	name: display_name,
+} );
+
+/*
+ * Activation and deactivation go through v1.2, which treats a plugin that is already in
+ * the requested state as a no-op success. v1.1 answers those with an `activation_error` /
+ * `deactivation_error` that is indistinguishable from a genuine failure, so a stale view
+ * of a plugin's state surfaces to the user as an error.
+ *
+ * Note that the query object is consumed (and emptied) by the request layer, so each call
+ * needs its own.
+ */
+const activate = ( siteId, pluginId ) =>
+	getPluginHandler( siteId, pluginId ).activate( { apiVersion: '1.2' } ).then( fromApiV1_2 );
+
+const deactivate = ( siteId, pluginId ) =>
+	getPluginHandler( siteId, pluginId ).deactivate( { apiVersion: '1.2' } ).then( fromApiV1_2 );
+
 /**
  * Helper thunk for recording tracks events and bumping stats for plugin events.
  * Useful to record events and bump stats by following a certain naming pattern.
@@ -185,22 +215,12 @@ export function activatePlugin( siteId, plugin ) {
 		};
 
 		const errorCallback = ( error ) => {
-			// `activation_error` wraps both real failures and the benign case where the plugin
-			// is already active. Only endpoints that attach `data.reason` can tell them apart;
-			// without it, assume a real failure rather than reporting a success we can't confirm.
-			if ( error?.data?.reason === 'already_active' ) {
-				return successCallback( { ...plugin, active: true } );
-			}
-
 			dispatch( { ...defaultAction, type: PLUGIN_ACTIVATE_REQUEST_FAILURE, error } );
 
 			afterActivationCallback( error, undefined );
 		};
 
-		return getPluginHandler( siteId, pluginId )
-			.activate()
-			.then( successCallback )
-			.catch( errorCallback );
+		return activate( siteId, pluginId ).then( successCallback ).catch( errorCallback );
 	};
 }
 
@@ -252,20 +272,11 @@ export function deactivatePlugin( siteId, plugin ) {
 		};
 
 		const errorCallback = ( error ) => {
-			// See the note in activatePlugin(): `deactivation_error` is just as generic, so the
-			// already-inactive case is only safe to treat as a success when the server says so.
-			if ( error?.data?.reason === 'already_inactive' ) {
-				return successCallback( { ...plugin, active: false } );
-			}
-
 			dispatch( { ...defaultAction, type: PLUGIN_DEACTIVATE_REQUEST_FAILURE, error } );
 			afterDeactivationCallback( error );
 		};
 
-		return getPluginHandler( siteId, pluginId )
-			.deactivate()
-			.then( successCallback )
-			.catch( errorCallback );
+		return deactivate( siteId, pluginId ).then( successCallback ).catch( errorCallback );
 	};
 }
 
@@ -450,7 +461,7 @@ function installPluginHelper(
 
 		const doActivate = function ( pluginData ) {
 			lastStep = 'doActivate';
-			return getPluginHandler( siteId, pluginData.id ).activate();
+			return activate( siteId, pluginData.id );
 		};
 
 		const doUpdate = function ( pluginData ) {
@@ -545,7 +556,7 @@ export function removePlugin( siteId, plugin ) {
 
 		const doDeactivate = function ( pluginData ) {
 			if ( pluginData.active ) {
-				return getPluginHandler( siteId, pluginData.id ).deactivate();
+				return deactivate( siteId, pluginData.id );
 			}
 			return Promise.resolve( pluginData );
 		};

--- a/client/state/plugins/installed/test/actions.js
+++ b/client/state/plugins/installed/test/actions.js
@@ -711,6 +711,14 @@ describe( 'actions', () => {
 			},
 		};
 
+		// Installs cleanly, then fails to activate.
+		const unactivatable = {
+			id: 'unactivatable/unactivatable',
+			slug: 'unactivatable',
+			name: 'Unactivatable',
+			active: false,
+		};
+
 		beforeAll( () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
@@ -720,7 +728,26 @@ describe( 'actions', () => {
 				.reply( 400, {
 					error: 'unknown_plugin',
 					message: 'Plugin file does not exist.',
+				} )
+				.post( '/rest/v1.1/sites/2916284/plugins/install', { slug: 'unactivatable' } )
+				.reply( 200, unactivatable );
+			nock( 'https://public-api.wordpress.com:443' )
+				.persist()
+				.post( '/rest/v1.2/sites/2916284/plugins/unactivatable%2Funactivatable', { active: true } )
+				.reply( 400, {
+					error: 'activation_error',
+					message: 'The plugin generated unexpected output.',
 				} );
+			// Answer the update and autoupdate calls too, so that a caller recovering from the
+			// activation error would reach a success rather than stalling on an unmocked request.
+			nock( 'https://public-api.wordpress.com:443' )
+				.persist()
+				.post( '/rest/v1.1/sites/2916284/plugins/unactivatable%2Funactivatable/update' )
+				.reply( 200, unactivatable )
+				.post( '/rest/v1.1/sites/2916284/plugins/unactivatable%2Funactivatable', {
+					autoupdate: true,
+				} )
+				.reply( 200, { ...unactivatable, autoupdate: true } );
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.post( '/rest/v1.1/sites/2916284/plugins/jetpack%2Fjetpack', { autoupdate: true } )
@@ -772,6 +799,28 @@ describe( 'actions', () => {
 				pluginId: 'fake/fake',
 				data: {},
 				error: expect.objectContaining( { message: 'Plugin file does not exist.' } ),
+			} );
+		} );
+
+		// On v1.2 an already-active plugin activates successfully, so an activation error is a
+		// genuine failure and must not be reported as an install that worked.
+		test( 'should dispatch fail action when activation fails after the install succeeds', async () => {
+			const response = installPlugin( site.ID, {
+				slug: 'unactivatable',
+				id: 'unactivatable/unactivatable',
+			} )( spy, getState );
+
+			await expect( response ).rejects.toThrow( 'The plugin generated unexpected output.' );
+			expect( spy ).not.toHaveBeenCalledWith(
+				expect.objectContaining( { type: PLUGIN_INSTALL_REQUEST_SUCCESS } )
+			);
+			expect( spy ).toHaveBeenCalledWith( {
+				type: PLUGIN_INSTALL_REQUEST_FAILURE,
+				action: INSTALL_PLUGIN,
+				siteId: 2916284,
+				pluginId: 'unactivatable/unactivatable',
+				data: {},
+				error: expect.objectContaining( { message: 'The plugin generated unexpected output.' } ),
 			} );
 		} );
 	} );

--- a/client/state/plugins/installed/test/actions.js
+++ b/client/state/plugins/installed/test/actions.js
@@ -61,6 +61,7 @@ import {
 	jetpack,
 	jetpackWithSites,
 	jetpackUpdated,
+	inApiV1_2Format,
 } from './fixtures/plugins';
 
 describe( 'actions', () => {
@@ -231,21 +232,25 @@ describe( 'actions', () => {
 		beforeAll( () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
-				.post( '/rest/v1.1/sites/2916284/plugins/akismet%2Fakismet', { active: true } )
-				.reply( 200, { ...akismet, active: true, log: [ 'Plugin activated.' ] } )
-				.post( '/rest/v1.1/sites/2916284/plugins/fake%2Ffake' )
+				.post( '/rest/v1.2/sites/2916284/plugins/akismet%2Fakismet', { active: true } )
+				.reply( 200, inApiV1_2Format( { ...akismet, active: true, log: [ 'Plugin activated.' ] } ) )
+				.post( '/rest/v1.2/sites/2916284/plugins/fake%2Ffake' )
 				.reply( 400, {
 					error: 'activation_error',
 					message: 'Plugin file does not exist.',
 				} )
-				.post( '/rest/v1.1/sites/2916284/plugins/alreadyactive%2Falreadyactive', {
+				.post( '/rest/v1.2/sites/2916284/plugins/alreadyactive%2Falreadyactive', {
 					active: true,
 				} )
-				.reply( 400, {
-					error: 'activation_error',
-					message: 'The Plugin is already active.',
-					data: { reason: 'already_active' },
-				} );
+				.reply(
+					200,
+					inApiV1_2Format( {
+						id: 'alreadyactive/alreadyactive',
+						slug: 'alreadyactive',
+						name: 'Already Active',
+						active: true,
+					} )
+				);
 		} );
 
 		afterAll( () => {
@@ -306,7 +311,7 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		test( 'should record one failure and no success when the error carries no reason', async () => {
+		test( 'should record one failure and no success when the request fails', async () => {
 			await activatePlugin( 2916284, {
 				slug: 'fake',
 				id: 'fake/fake',
@@ -328,7 +333,12 @@ describe( 'actions', () => {
 				action: ACTIVATE_PLUGIN,
 				siteId: 2916284,
 				pluginId: 'alreadyactive/alreadyactive',
-				data: { ...alreadyActive, active: true },
+				data: {
+					id: 'alreadyactive/alreadyactive',
+					slug: 'alreadyactive',
+					name: 'Already Active',
+					active: true,
+				},
 			} );
 			expect( spy ).not.toHaveBeenCalledWith(
 				expect.objectContaining( { type: PLUGIN_ACTIVATE_REQUEST_FAILURE } )
@@ -342,21 +352,28 @@ describe( 'actions', () => {
 		beforeAll( () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
-				.post( '/rest/v1.1/sites/2916284/plugins/akismet%2Fakismet', { active: false } )
-				.reply( 200, { ...akismet, active: false, log: [ 'Plugin deactivated.' ] } )
-				.post( '/rest/v1.1/sites/2916284/plugins/fake%2Ffake' )
+				.post( '/rest/v1.2/sites/2916284/plugins/akismet%2Fakismet', { active: false } )
+				.reply(
+					200,
+					inApiV1_2Format( { ...akismet, active: false, log: [ 'Plugin deactivated.' ] } )
+				)
+				.post( '/rest/v1.2/sites/2916284/plugins/fake%2Ffake' )
 				.reply( 400, {
 					error: 'deactivation_error',
 					message: 'Plugin file does not exist.',
 				} )
-				.post( '/rest/v1.1/sites/2916284/plugins/alreadyinactive%2Falreadyinactive', {
+				.post( '/rest/v1.2/sites/2916284/plugins/alreadyinactive%2Falreadyinactive', {
 					active: false,
 				} )
-				.reply( 400, {
-					error: 'deactivation_error',
-					message: 'The Plugin is already deactivated.',
-					data: { reason: 'already_inactive' },
-				} );
+				.reply(
+					200,
+					inApiV1_2Format( {
+						id: 'alreadyinactive/alreadyinactive',
+						slug: 'alreadyinactive',
+						name: 'Already Inactive',
+						active: false,
+					} )
+				);
 		} );
 
 		afterAll( () => {
@@ -406,7 +423,7 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		test( 'should record one failure and no success when the error carries no reason', async () => {
+		test( 'should record one failure and no success when the request fails', async () => {
 			await deactivatePlugin( 2916284, { slug: 'fake', id: 'fake/fake', active: true } )(
 				spy,
 				getState
@@ -427,7 +444,12 @@ describe( 'actions', () => {
 				action: DEACTIVATE_PLUGIN,
 				siteId: 2916284,
 				pluginId: 'alreadyinactive/alreadyinactive',
-				data: { ...alreadyInactive, active: false },
+				data: {
+					id: 'alreadyinactive/alreadyinactive',
+					slug: 'alreadyinactive',
+					name: 'Already Inactive',
+					active: false,
+				},
 			} );
 			expect( spy ).not.toHaveBeenCalledWith(
 				expect.objectContaining( { type: PLUGIN_DEACTIVATE_REQUEST_FAILURE } )
@@ -705,8 +727,11 @@ describe( 'actions', () => {
 				.reply( 200, { ...jetpackUpdated, autoupdate: true } );
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
-				.post( '/rest/v1.1/sites/2916284/plugins/jetpack%2Fjetpack', { active: true } )
-				.reply( 200, { ...jetpackUpdated, active: true, log: [ 'Plugin activated.' ] } );
+				.post( '/rest/v1.2/sites/2916284/plugins/jetpack%2Fjetpack', { active: true } )
+				.reply(
+					200,
+					inApiV1_2Format( { ...jetpackUpdated, active: true, log: [ 'Plugin activated.' ] } )
+				);
 		} );
 
 		afterAll( () => {
@@ -778,8 +803,11 @@ describe( 'actions', () => {
 				.reply( 200, { ...akismet, autoupdate: false } );
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
-				.post( '/rest/v1.1/sites/2916284/plugins/akismet%2Fakismet', { active: false } )
-				.reply( 200, { ...akismet, active: false, log: [ 'Plugin deactivated.' ] } );
+				.post( '/rest/v1.2/sites/2916284/plugins/akismet%2Fakismet', { active: false } )
+				.reply(
+					200,
+					inApiV1_2Format( { ...akismet, active: false, log: [ 'Plugin deactivated.' ] } )
+				);
 		} );
 
 		afterAll( () => {

--- a/client/state/plugins/installed/test/fixtures/plugins.js
+++ b/client/state/plugins/installed/test/fixtures/plugins.js
@@ -16,6 +16,16 @@ const placeSitePropsOnSiteObject = ( pluginObject ) => {
 	};
 };
 
+/*
+ * Restate a v1.1 plugin fixture in the v1.2 response format: the plugin file moves from
+ * `id` to `name`, and the title from `name` to `display_name`.
+ */
+export const inApiV1_2Format = ( { id, name, ...rest } ) => ( {
+	...rest,
+	name: id,
+	display_name: name,
+} );
+
 export const akismet = {
 	id: 'akismet/akismet',
 	slug: 'akismet',


### PR DESCRIPTION
## Proposed Changes

* Move the installed-plugins activate and deactivate calls from REST v1.1 to v1.2, including the activate and deactivate legs of install and remove.
* Map v1.2 responses back to the v1.1 shape at the call boundary, since the installed-plugins store is populated from the v1.1 plugin list. The reducer, the selectors and the plugin UI are unchanged.
* Drop the previous attempt at distinguishing the already-active case from a real failure, which relied on a marker the API does not deliver to clients.

## Why are these changes being made?

Asking v1.1 to put a plugin into the state it is already in returns an `activation_error` (or `deactivation_error`) that is indistinguishable from a genuine failure — same code, differing only in a translated, human-readable message. Whenever Calypso's view of a plugin's state is stale, the user sees an error for an operation that had nothing to do. v1.2 already treats "already in the requested state" as a no-op success in both directions, and real failures and permission errors still come back exactly as before, so no API-side change is needed.

The version bump is not a drop-in: v1.2 exposes the plugin file and the plugin title under different keys than v1.1. Mapping at the boundary keeps the change contained and avoids the failure mode where plugin titles silently render as plugin file paths. The Dashboard client is already fully on v1.2 and is unaffected.

The Jetpack plugin-setup flow is intentionally left on v1.1: it already absorbs the already-active case, so nothing surfaces to the user there today. If it moves later, its error-swallowing branch has to be removed at the same time, or genuine activation failures would be reported as successes.

## Testing Instructions

1. Go to a site's plugin management screen and toggle a plugin on and off. Confirm activation and deactivation both work, and that the plugin's title, description and status render correctly throughout.
2. Verify the fix for a stale state: open the same site's plugin screen in two tabs, activate a plugin in the first, then activate the same plugin in the second (whose view is now stale). Previously this reported an activation error; it should now report success and settle on the correct state.
3. Repeat in the other direction for deactivation.
4. Install a plugin and remove an installed plugin, confirming both complete and the list updates.
5. Worth covering on Atomic and self-hosted Jetpack sites, since the endpoint runs site-side.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
