### PR TITLE
Exclude vulnerable WPCS sniff from pre-commit checks

### DIFF
--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -6,6 +6,7 @@ const chalk = require( 'chalk' );
 
 const phpcsPath = getPathForCommand( 'phpcs' );
 const phpcbfPath = getPathForCommand( 'phpcbf' );
+const phpcsExclusions = '--exclude=WordPress.WP.EnqueuedResourceParameters';
 
 // Groups an array's items into an object keyed by the iteratee's return value.
 function groupBy( collection, iteratee ) {
@@ -146,7 +147,11 @@ toPHPCBF.forEach( ( file ) => console.log( `PHPCBF formatting staged file: ${ fi
 if ( toPHPCBF.length ) {
 	if ( phpcs ) {
 		try {
-			execSync( `${ quotedPath( phpcbfPath ) } --standard=WordPress ${ toPHPCBF.join( ' ' ) }` );
+			execSync(
+				`${ quotedPath( phpcbfPath ) } --standard=WordPress ${ phpcsExclusions } ${ toPHPCBF.join(
+					' '
+				) }`
+			);
 		} catch ( error ) {
 			// PHPCBF returns a `0` or `1` exit code on success, and `2` on failures. ¯\_(ツ)_/¯
 			// https://github.com/squizlabs/PHP_CodeSniffer/blob/HEAD/src/Runner.php#L210
@@ -207,10 +212,14 @@ if ( toEslint.length ) {
 // and finally PHPCS
 if ( toPHPCS.length ) {
 	if ( phpcs ) {
-		const lintResult = spawnSync( quotedPath( phpcsPath ), [ '--standard=WordPress', ...toPHPCS ], {
-			shell: true,
-			stdio: 'inherit',
-		} );
+		const lintResult = spawnSync(
+			quotedPath( phpcsPath ),
+			[ '--standard=WordPress', phpcsExclusions, ...toPHPCS ],
+			{
+				shell: true,
+				stdio: 'inherit',
+			}
+		);
 
 		if ( lintResult.status ) {
 			linterFailure();

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -6,7 +6,10 @@ const chalk = require( 'chalk' );
 
 const phpcsPath = getPathForCommand( 'phpcs' );
 const phpcbfPath = getPathForCommand( 'phpcbf' );
-const phpcsExclusions = '--exclude=WordPress.WP.EnqueuedResourceParameters';
+// WPCS < 3.4.1 passes untrusted code through eval() in this sniff (GHSA-3pwp-g2mj-5p3v).
+// --no-cache is load-bearing: PHPCS discards all --exclude restrictions when caching is on.
+// Remove both once wp-coding-standards/wpcs >= 3.4.1 is installable.
+const phpcsExclusions = [ '--exclude=WordPress.WP.EnqueuedResourceParameters', '--no-cache' ];
 
 // Groups an array's items into an object keyed by the iteratee's return value.
 function groupBy( collection, iteratee ) {
@@ -148,9 +151,9 @@ if ( toPHPCBF.length ) {
 	if ( phpcs ) {
 		try {
 			execSync(
-				`${ quotedPath( phpcbfPath ) } --standard=WordPress ${ phpcsExclusions } ${ toPHPCBF.join(
+				`${ quotedPath( phpcbfPath ) } --standard=WordPress ${ phpcsExclusions.join(
 					' '
-				) }`
+				) } ${ toPHPCBF.join( ' ' ) }`
 			);
 		} catch ( error ) {
 			// PHPCBF returns a `0` or `1` exit code on success, and `2` on failures. ¯\_(ツ)_/¯
@@ -214,7 +217,7 @@ if ( toPHPCS.length ) {
 	if ( phpcs ) {
 		const lintResult = spawnSync(
 			quotedPath( phpcsPath ),
-			[ '--standard=WordPress', phpcsExclusions, ...toPHPCS ],
+			[ '--standard=WordPress', ...phpcsExclusions, ...toPHPCS ],
 			{
 				shell: true,
 				stdio: 'inherit',


### PR DESCRIPTION
Addresses https://github.com/Automattic/wp-calypso/security/dependabot/549

## Proposed Changes

* Exclude `WordPress.WP.EnqueuedResourceParameters` from PHP formatting and linting in the pre-commit hook.
* Use one shared argument list for PHPCBF and PHPCS, including `--no-cache` so persisted PHPCS caching cannot discard the exclusion.

## Why are these changes being made?

* WPCS versions before 3.4.1 can execute code from PHP files through this sniff.
* Current parent-package constraints block WPCS 3.4.1. This applies the advisory's documented workaround while keeping the existing coding standard.
* PHPCS discards CLI exclusions when caching is enabled, so the hook explicitly disables caching until WPCS 3.4.1 is installable.

## Testing Instructions

* Run `node --check bin/pre-commit-hook.js`.
* Run `yarn prettier --check bin/pre-commit-hook.js`.
* Run `ESLINT_USE_FLAT_CONFIG=false yarn eslint --no-ignore bin/pre-commit-hook.js`.
* Run `vendor/bin/phpcs -e --standard=WordPress` and confirm the sniff is listed.
* Set persisted PHPCS caching with `vendor/bin/phpcs --config-set cache 1`.
* Confirm the sniff remains listed with only `--exclude=WordPress.WP.EnqueuedResourceParameters`.
* Add `--no-cache` and confirm the sniff is no longer listed.
* Restore the original PHPCS configuration.
* The repository pre-commit hook passed while creating the commit.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Our Approach](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have you tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?