### PR TITLE
A4A: Fix AI and MCP sidebar menu icon color mismatch

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-learn-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-learn-menu-items.tsx
@@ -53,7 +53,11 @@ const useLearnMenuItems = ( path: string ) => {
 			...( isAiMcpEnabled
 				? [
 						{
-							icon: <BigSkyLogo.CentralLogo heartless size={ 24 } />,
+							icon: (
+								<span className="sidebar__menu-icon">
+									<BigSkyLogo.CentralLogo heartless size={ 24 } fill="currentColor" />
+								</span>
+							),
 							path: A4A_AI_MCP_LINK,
 							link: A4A_AI_MCP_LINK,
 							title: translate( 'AI and MCP' ),

--- a/client/a8c-for-agencies/components/sidebar/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/style.scss
@@ -15,6 +15,7 @@
 
 	.sidebar__menu-icon {
 		margin: 0;
+		max-height: 24px !important;
 	}
 
 	.sidebar-v2__navigator-sub-menu .components-navigator-back-button.components-navigator-back-button.components-navigator-back-button {

--- a/client/a8c-for-agencies/components/sidebar/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/style.scss
@@ -13,9 +13,9 @@
 	--color-sidebar-text-alternative: var(--color-primary-5);
 	--color-sidebar-gridicon-fill: var(--color-primary-5);
 
-	.sidebar__menu-icon {
+	.sidebar__menu-icon.sidebar__menu-icon.sidebar__menu-icon {
 		margin: 0;
-		max-height: 24px !important;
+		max-height: 24px;
 	}
 
 	.sidebar-v2__navigator-sub-menu .components-navigator-back-button.components-navigator-back-button.components-navigator-back-button {


### PR DESCRIPTION
## Proposed Changes

* Wrap the "AI and MCP" sidebar menu icon in a `<span className="sidebar__menu-icon">` and pass `fill="currentColor"` to `BigSkyLogo.CentralLogo`, so the icon inherits the sidebar's icon color like every other menu item.

| Before | After |
|--------|--------|
| <img width="251" height="58" alt="Screenshot 2026-08-04 at 11 28 05 PM" src="https://github.com/user-attachments/assets/71d9798b-9e0d-408f-a2c4-fe38ed946b0e" /> | <img width="251" height="58" alt="Screenshot 2026-08-04 at 11 50 38 PM" src="https://github.com/user-attachments/assets/2b488e85-a7bf-49a1-b58e-64e695d4c172" /> | 

## Why are these changes being made?

* The Big Sky logo ships with its own hardcoded fill, so the "AI and MCP" item rendered in a different color than the neighboring sidebar icons, and it did not respond to the hover/active/selected states. Routing it through the shared `sidebar__menu-icon` wrapper with `currentColor` puts it back in sync with the rest of the menu.

## Testing Instructions

* Enable the AI and MCP feature flag so the "AI and MCP" item appears under the Learn section of the A4A sidebar.
* Confirm the "AI and MCP" icon is the same color as the other icons in the sidebar, in the default, hover, and selected states.
* Verify in both light and dark mode.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
