### PR TITLE
E2E: use-my-domain transfer-or-connect regression tests

### DIFF
--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -171,10 +171,17 @@ export class DomainSearchComponent {
 	}
 
 	/**
-	 * Clicks on the button to use a domain I already own
+	 * Clicks on the button to use a domain I already own.
+	 *
+	 * The CTA has two copy variants depending on state: the top-bar "Use a domain I own"
+	 * link (shown once a search has been performed, or on mobile) and the empty-state card
+	 * "Already have a domain? Bring it over to WordPress.com." Match either.
 	 */
 	async clickUseADomainIAlreadyOwn(): Promise< void > {
-		await this.page.getByRole( 'button', { name: 'Use a domain I own' } ).click();
+		await this.page
+			.getByRole( 'button', { name: /Use a domain I own|Already have a domain/ } )
+			.first()
+			.click();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -26,6 +26,8 @@ export * from './login-page';
 export * from './marketing-page';
 export * from './media-page';
 export * from './my-home-page';
+export * from './newsletter-goals-page';
+export * from './newsletter-setup-page';
 export * from './p2-page';
 export * from './pages-page';
 export * from './people-page';

--- a/packages/calypso-e2e/src/lib/pages/newsletter-goals-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/newsletter-goals-page.ts
@@ -1,0 +1,29 @@
+import { Page } from 'playwright';
+
+const selectors = {
+	// Each goal is a `FlowCard`, rendered as a clickable `.flow-question` card containing its title.
+	optionCard: ( title: string ) => `.flow-question:has-text("${ title }")`,
+};
+
+/**
+ * Represents the "goals" step (Free / Paid / Import) of the Stepper newsletter flow.
+ */
+export class NewsletterGoalsPage {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Selects the "Free newsletter" option, advancing to the domains step.
+	 */
+	async selectFreeNewsletter(): Promise< void > {
+		await this.page.click( selectors.optionCard( 'Free newsletter' ) );
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/newsletter-setup-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/newsletter-setup-page.ts
@@ -1,0 +1,32 @@
+import { Page } from 'playwright';
+
+const selectors = {
+	nameInput: '#setup-form-input-name',
+	continueButton: '.setup-form__submit',
+};
+
+/**
+ * Represents the "setup" step (newsletter name + description) of the Stepper newsletter flow.
+ */
+export class NewsletterSetupPage {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Enters the newsletter name and submits the step, advancing to the goals step.
+	 *
+	 * @param {string} name The newsletter name.
+	 */
+	async enterNameAndContinue( name: string ): Promise< void > {
+		await this.page.fill( selectors.nameInput, name );
+		await this.page.click( selectors.continueButton );
+	}
+}

--- a/test/e2e/specs/flows/use-my-domain__transfer-or-connect.spec.ts
+++ b/test/e2e/specs/flows/use-my-domain__transfer-or-connect.spec.ts
@@ -45,7 +45,7 @@ async function assertLandsOnTransferOrConnect(
 
 test.describe(
 	DataHelper.createSuiteTitle( 'Use My Domain: transfer-or-connect renders across flows' ),
-	{ tag: [ tags.CALYPSO_PR ] },
+	{ tag: [ tags.CALYPSO_PR, tags.DESKTOP_ONLY ] },
 	() => {
 		test( 'Onboarding flow shows transfer-or-connect after entering an owned domain', async ( {
 			page,

--- a/test/e2e/specs/flows/use-my-domain__transfer-or-connect.spec.ts
+++ b/test/e2e/specs/flows/use-my-domain__transfer-or-connect.spec.ts
@@ -1,0 +1,141 @@
+import {
+	DataHelper,
+	DomainSearchComponent,
+	NewsletterGoalsPage,
+	NewsletterSetupPage,
+	UseADomainIOwnPage,
+} from '@automattic/calypso-e2e';
+import { Page } from 'playwright';
+import { tags, test, expect } from '../../lib/pw-base';
+
+/**
+ * A domain that is already registered (i.e. not available for purchase) so that submitting
+ * it on the "use my domain" step routes to the transfer-or-connect chooser.
+ *
+ * NOTE: verify this is a suitable owned/registered domain for the test environment before
+ * relying on it — the step hits the real domain-availability API.
+ */
+const OWNED_DOMAIN = 'example.com';
+
+/**
+ * Shared assertion: from a flow's domain search step, choose "Already have a domain?",
+ * enter an owned domain, and confirm we land on the transfer-or-connect screen.
+ *
+ * This is the exact segment that regressed: a leading slash in the flow's redirect made
+ * the router bounce the user back to the `domains` step instead of `use-my-domain`.
+ */
+async function assertLandsOnTransferOrConnect(
+	page: Page,
+	componentDomainSearch: DomainSearchComponent,
+	pageUseADomainIAlreadyOwn: UseADomainIOwnPage,
+	ownedDomain: string
+): Promise< void > {
+	await test.step( 'When I choose "Already have a domain?" and submit an owned domain', async () => {
+		await componentDomainSearch.clickUseADomainIAlreadyOwn();
+		await pageUseADomainIAlreadyOwn.fillUseDomainIOwnInput( ownedDomain );
+	} );
+
+	await test.step( 'Then I land on the transfer-or-connect screen (not bounced back to domains)', async () => {
+		// Regression guard: the bug changed this URL to `.../domains?step=transfer-or-connect`.
+		await expect( page ).toHaveURL( /\/use-my-domain\?.*step=transfer-or-connect/ );
+		await pageUseADomainIAlreadyOwn.validateButtonToTransferDomain();
+		await pageUseADomainIAlreadyOwn.validateButtonToConnectDomain();
+	} );
+}
+
+test.describe(
+	DataHelper.createSuiteTitle( 'Use My Domain: transfer-or-connect renders across flows' ),
+	{ tag: [ tags.CALYPSO_PR ] },
+	() => {
+		test( 'Onboarding flow shows transfer-or-connect after entering an owned domain', async ( {
+			page,
+			accountDefaultUser,
+			componentDomainSearch,
+			pageUseADomainIAlreadyOwn,
+		} ) => {
+			await test.step( 'Given I am authenticated', async () => {
+				await accountDefaultUser.authenticate( page );
+			} );
+
+			await test.step( 'And I am on the onboarding domains step', async () => {
+				await page.goto( DataHelper.getCalypsoURL( '/setup/onboarding/domains' ) );
+			} );
+
+			await assertLandsOnTransferOrConnect(
+				page,
+				componentDomainSearch,
+				pageUseADomainIAlreadyOwn,
+				OWNED_DOMAIN
+			);
+		} );
+
+		test( 'Newsletter flow shows transfer-or-connect after entering an owned domain', async ( {
+			page,
+			accountDefaultUser,
+			componentDomainSearch,
+			pageUseADomainIAlreadyOwn,
+		} ) => {
+			await test.step( 'Given I am authenticated', async () => {
+				await accountDefaultUser.authenticate( page );
+			} );
+
+			await test.step( 'And I walk the newsletter preamble to the domains step', async () => {
+				await page.goto( DataHelper.getCalypsoURL( '/setup/newsletter' ) );
+				await new NewsletterSetupPage( page ).enterNameAndContinue( DataHelper.getBlogName() );
+				await new NewsletterGoalsPage( page ).selectFreeNewsletter();
+			} );
+
+			await assertLandsOnTransferOrConnect(
+				page,
+				componentDomainSearch,
+				pageUseADomainIAlreadyOwn,
+				OWNED_DOMAIN
+			);
+		} );
+
+		test( 'Reblogging flow shows transfer-or-connect after entering an owned domain', async ( {
+			page,
+			accountDefaultUser,
+			componentDomainSearch,
+			pageUseADomainIAlreadyOwn,
+		} ) => {
+			await test.step( 'Given I am authenticated', async () => {
+				await accountDefaultUser.authenticate( page );
+			} );
+
+			await test.step( 'And I am on the reblogging domains step', async () => {
+				await page.goto( DataHelper.getCalypsoURL( '/setup/reblogging' ) );
+			} );
+
+			await assertLandsOnTransferOrConnect(
+				page,
+				componentDomainSearch,
+				pageUseADomainIAlreadyOwn,
+				OWNED_DOMAIN
+			);
+		} );
+
+		test( 'Domain-and-plan flow shows transfer-or-connect after entering an owned domain', async ( {
+			page,
+			accountAtomic,
+			componentDomainSearch,
+			pageUseADomainIAlreadyOwn,
+		} ) => {
+			await test.step( 'Given I am authenticated with a site', async () => {
+				await accountAtomic.authenticate( page );
+			} );
+
+			await test.step( 'And I am on the domain-and-plan domains step', async () => {
+				const siteSlug = accountAtomic.getSiteURL( { protocol: false } );
+				await page.goto( DataHelper.getCalypsoURL( '/setup/domain-and-plan', { siteSlug } ) );
+			} );
+
+			await assertLandsOnTransferOrConnect(
+				page,
+				componentDomainSearch,
+				pageUseADomainIAlreadyOwn,
+				OWNED_DOMAIN
+			);
+		} );
+	}
+);

--- a/test/e2e/specs/flows/use-my-domain__transfer-or-connect.spec.ts
+++ b/test/e2e/specs/flows/use-my-domain__transfer-or-connect.spec.ts
@@ -15,7 +15,7 @@ import { tags, test, expect } from '../../lib/pw-base';
  * NOTE: verify this is a suitable owned/registered domain for the test environment before
  * relying on it — the step hits the real domain-availability API.
  */
-const OWNED_DOMAIN = 'example.com';
+const OWNED_DOMAIN = 'dev-testing.com';
 
 /**
  * Shared assertion: from a flow's domain search step, choose "Already have a domain?",


### PR DESCRIPTION
## Proposed Changes

* Add Playwright E2E specs covering the recently-fixed "use my domain" regression across four Stepper flows: **onboarding, newsletter, reblogging, domain-and-plan**.
* Each test authenticates, reaches the flow's domain search step, chooses "Already have a domain?", submits an owned domain, and asserts it lands on the transfer-or-connect screen (URL `use-my-domain?…step=transfer-or-connect` + the transfer/connect buttons) instead of bouncing back to the `domains` step.
* Add `NewsletterSetupPage` and `NewsletterGoalsPage` page objects for the newsletter preamble steps.

## Why are these changes being made?

<!-- -->
Regression tests for the fixes in #113224 (onboarding) and #113225 (copy-site, education, reblogging, newsletter, domain-and-plan).

The regression came from the React Router v7 upgrade (#113028): the flows built their redirect with a leading slash, and v7 URL-encodes `generatePath` params, so `/use-my-domain` became `%2Fuse-my-domain`, matched no step, and fell through to the flow's catch-all route — bouncing the user back to the `domains` step after they submitted an owned domain.

These specs exercise the **real router** — the exact layer that regressed — which unit tests with a mocked `navigate` cannot cover. Each test **stops at the transfer-or-connect screen** (authenticated account, no site creation) to keep them fast and side-effect-free.

Scope: `copy-site` and `education` are intentionally deferred — their preconditions (a source site to copy; invite-code validation) make E2E costly; those are better covered at the unit layer.

## Testing Instructions

<!-- -->
Run against a live Calypso instance with E2E secrets:

```
yarn workspace @automattic/calypso-e2e build
cd test/e2e
yarn playwright test specs/flows/use-my-domain__transfer-or-connect.spec.ts --reporter=list
```

The following are grounded in the flow source but should be confirmed on a first live run (flagged in code comments):
* `OWNED_DOMAIN` is a placeholder (`example.com`) — set it to a registered domain that routes to transfer-or-connect (the step hits the real domain-availability API).
* Authenticated deep-links land on each flow's domains step (especially `reblogging`, entered without a `blog_post` param).
* The transfer-or-connect chooser appears immediately after submitting the domain (no intermediate "Continue").

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
