### PR TITLE
Cancellations: cancel immediately after the confirmation step

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/domain-cancellation-survey.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/domain-cancellation-survey.tsx
@@ -28,6 +28,11 @@ interface Props {
 	onClose: () => void;
 	onSurveyComplete: () => void;
 	cancellationInProgress?: boolean;
+	/**
+	 * True once the cancel mutation has already fired at confirm-time, so this
+	 * survey is an optional questionnaire rather than the destructive step.
+	 */
+	cancellationCompleted?: boolean;
 }
 
 interface DomainCancellationReason {
@@ -146,11 +151,13 @@ const DomainCancellationSurvey: React.FC< Props > = ( {
 	}, [ selectedReason, cancellationReasons ] );
 
 	const renderButtons = () => {
-		const { disableButtons, cancellationInProgress } = props;
+		const { disableButtons, cancellationInProgress, cancellationCompleted } = props;
 		const disabled = disableButtons || ! selectedReason;
 		const isRemoveIntent = intent === 'remove';
+		// Once the cancellation has already fired, this survey performs nothing
+		// destructive — the buttons should read (and look) like a questionnaire.
 		const getCompleteLabel = () => {
-			if ( ! isSplitEnabled ) {
+			if ( cancellationCompleted || ! isSplitEnabled ) {
 				return translate( 'Submit' );
 			}
 			return isRemoveIntent
@@ -160,29 +167,38 @@ const DomainCancellationSurvey: React.FC< Props > = ( {
 		const getCompletingLabel = () =>
 			isRemoveIntent ? translate( 'Completing removal' ) : translate( 'Completing cancellation' );
 		const primaryLabel =
-			isSplitEnabled && cancellationInProgress ? getCompletingLabel() : getCompleteLabel();
+			isSplitEnabled && ! cancellationCompleted && cancellationInProgress
+				? getCompletingLabel()
+				: getCompleteLabel();
 
 		return (
 			<div className="cancel-purchase-form__actions">
 				<div className="cancel-purchase-form__buttons">
 					<Button
 						variant="primary"
-						isDestructive={ isSplitEnabled }
+						isDestructive={ isSplitEnabled && ! cancellationCompleted }
 						isBusy={ cancellationInProgress }
 						disabled={ disabled }
 						onClick={ handleSubmit }
 					>
 						{ primaryLabel }
 					</Button>
-					{ isSplitEnabled && disabled && (
+					{ ( cancellationCompleted || isSplitEnabled ) && disabled && (
 						<Button
 							variant="tertiary"
-							isDestructive
+							isDestructive={ ! cancellationCompleted }
 							isBusy={ cancellationInProgress }
 							disabled={ cancellationInProgress }
 							onClick={ handleSubmit }
 						>
-							{ isRemoveIntent ? translate( 'Skip and remove' ) : translate( 'Skip and cancel' ) }
+							{ ( () => {
+								if ( cancellationCompleted ) {
+									return translate( 'Skip survey' );
+								}
+								return isRemoveIntent
+									? translate( 'Skip and remove' )
+									: translate( 'Skip and cancel' );
+							} )() }
 						</Button>
 					) }
 				</div>

--- a/client/components/marketing-survey/cancel-purchase-form/index.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.tsx
@@ -712,7 +712,7 @@ class CancelPurchaseForm extends Component< CancelPurchaseFormProps, CancelPurch
 							disabled={ isCancelling }
 							onClick={ this.onSubmit }
 						>
-							{ translate( 'No, thanks' ) }
+							{ translate( 'Skip survey' ) }
 						</GutenbergButton>
 					) }
 				</>
@@ -792,7 +792,7 @@ class CancelPurchaseForm extends Component< CancelPurchaseFormProps, CancelPurch
 						disabled={ isCancelling }
 						onClick={ this.onSubmit }
 					>
-						{ translate( 'No, thanks' ) }
+						{ translate( 'Skip survey' ) }
 					</GutenbergButton>
 				) }
 			</>

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/next-adventure-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/next-adventure-step.tsx
@@ -2,7 +2,6 @@ import { TextareaControl, TextControl, SelectControl } from '@wordpress/componen
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { useIsSplitCancelRemoveEnabled } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled';
 import { toSelectOption } from '../to-select-options';
 import type { DisplayVariant } from 'calypso/lib/purchases/utils';
 
@@ -20,8 +19,11 @@ interface Props {
 export default function NextAdventureStep( props: Props ) {
 	const translate = useTranslate();
 	const { isPlan, isOnlyStep, intent, onValidationChange } = props;
-	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
-	const isCancelPostMutation = isSplitEnabled && intent !== 'remove';
+	// Only the cancel intents fire their mutation before the survey renders, so
+	// only they can claim the cancellation already happened. Tested positively
+	// rather than as `!== 'remove'` so a no-intent deep link — which still
+	// submits at survey-end — falls through to the pre-cancellation copy.
+	const isCancelPostMutation = intent === 'cancel' || intent === 'auto-renew';
 	const [ text, setText ] = useState( '' );
 	const [ nextAdventure, setNextAdventure ] = useState( '' );
 	const [ nextAdventureDetails, setNextAdventureDetails ] = useState( '' );
@@ -89,7 +91,7 @@ export default function NextAdventureStep( props: Props ) {
 
 	let headerText;
 	let subHeaderText;
-	if ( ! isSplitEnabled ) {
+	if ( ! intent ) {
 		headerText = translate( 'Sorry to see you go' );
 		subHeaderText = translate( 'One last thing', {
 			context: 'This is the last step before cancelling the plan.',

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/test/next-adventure-step.test.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/test/next-adventure-step.test.tsx
@@ -1,23 +1,15 @@
 /**
  * @jest-environment jsdom
  */
-import config from '@automattic/calypso-config';
 import { render, screen } from '@testing-library/react';
 import NextAdventureStep from '../next-adventure-step';
-
-jest.mock( '@automattic/calypso-config', () => {
-	const isEnabled = jest.fn();
-	return { __esModule: true, default: { isEnabled }, isEnabled };
-} );
 
 const SUBTITLE = 'Before you go, please answer a quick question to help us improve WordPress.com.';
 
 describe( 'NextAdventureStep', () => {
-	describe( 'with purchases/split-cancel-remove enabled', () => {
-		beforeEach( () => {
-			( config.isEnabled as jest.Mock ).mockReturnValue( true );
-		} );
-
+	// The cancel intents fire their mutation before the survey renders, so their
+	// headings can state that the cancellation already happened.
+	describe( 'with a cancel intent (mutation already fired)', () => {
 		it( 'shows "Cancellation confirmed" title with subtitle when isOnlyStep and cancel intent', () => {
 			render(
 				<NextAdventureStep isPlan={ false } isOnlyStep adventureOptions={ [] } intent="cancel" />
@@ -26,11 +18,16 @@ describe( 'NextAdventureStep', () => {
 			expect( screen.getByText( SUBTITLE ) ).toBeVisible();
 		} );
 
-		it( 'shows "Share your feedback" title with subtitle when isOnlyStep and remove intent', () => {
+		it( 'shows "Auto-renew disabled" title with subtitle when isOnlyStep and auto-renew intent', () => {
 			render(
-				<NextAdventureStep isPlan={ false } isOnlyStep adventureOptions={ [] } intent="remove" />
+				<NextAdventureStep
+					isPlan={ false }
+					isOnlyStep
+					adventureOptions={ [] }
+					intent="auto-renew"
+				/>
 			);
-			expect( screen.getByRole( 'heading', { name: /Share your feedback/ } ) ).toBeVisible();
+			expect( screen.getByRole( 'heading', { name: /Auto-renew disabled/ } ) ).toBeVisible();
 			expect( screen.getByText( SUBTITLE ) ).toBeVisible();
 		} );
 
@@ -46,8 +43,19 @@ describe( 'NextAdventureStep', () => {
 			expect( screen.getByRole( 'heading', { name: /Thanks for your feedback/ } ) ).toBeVisible();
 			expect( screen.queryByText( SUBTITLE ) ).not.toBeInTheDocument();
 		} );
+	} );
 
-		it( 'shows "One last thing" title without subtitle in multi-step remove flow', () => {
+	// Remove submits at survey-end, so nothing has happened yet.
+	describe( 'with a remove intent (mutation deferred to survey-end)', () => {
+		it( 'shows "Share your feedback" title with subtitle when isOnlyStep', () => {
+			render(
+				<NextAdventureStep isPlan={ false } isOnlyStep adventureOptions={ [] } intent="remove" />
+			);
+			expect( screen.getByRole( 'heading', { name: /Share your feedback/ } ) ).toBeVisible();
+			expect( screen.getByText( SUBTITLE ) ).toBeVisible();
+		} );
+
+		it( 'shows "One last thing" title without subtitle in a multi-step flow', () => {
 			render(
 				<NextAdventureStep
 					isPlan={ false }
@@ -61,16 +69,21 @@ describe( 'NextAdventureStep', () => {
 		} );
 	} );
 
-	describe( 'with purchases/split-cancel-remove disabled', () => {
-		beforeEach( () => {
-			( config.isEnabled as jest.Mock ).mockReturnValue( false );
-		} );
-
-		it( 'renders the trunk header regardless of intent or isOnlyStep', () => {
-			render( <NextAdventureStep isPlan={ false } adventureOptions={ [] } /> );
+	// No intent means a legacy deep link, which also submits at survey-end. It
+	// must never claim the cancellation is confirmed.
+	describe( 'with no intent (legacy deep link)', () => {
+		it( 'renders the pre-cancellation header regardless of isOnlyStep', () => {
+			render( <NextAdventureStep isPlan={ false } isOnlyStep adventureOptions={ [] } /> );
 			expect( screen.getByRole( 'heading', { name: /Sorry to see you go/ } ) ).toBeVisible();
 			expect( screen.getByText( /One last thing/ ) ).toBeVisible();
 			expect( screen.queryByText( SUBTITLE ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'never claims the cancellation is confirmed', () => {
+			render( <NextAdventureStep isPlan={ false } isOnlyStep adventureOptions={ [] } /> );
+			expect(
+				screen.queryByRole( 'heading', { name: /Cancellation confirmed/ } )
+			).not.toBeInTheDocument();
 		} );
 	} );
 } );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-header-title.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-header-title.tsx
@@ -1,11 +1,12 @@
 import { __ } from '@wordpress/i18n';
-import { DisplayVariant } from '../../../utils/purchase';
+import { CancelIntent, DisplayVariant } from '../../../utils/purchase';
 import { CANCELLATION_OFFER_STEP } from './cancel-purchase-form/steps';
 import { getCancellationHeading } from './get-confirmation-copy';
 import type { Purchase } from '@automattic/api-core';
 
 interface CancelHeaderTitleProps {
 	displayVariant: DisplayVariant;
+	intent: CancelIntent | null;
 	purchase: Purchase;
 	surveyStep?: string;
 	surveyShown?: boolean;
@@ -13,6 +14,7 @@ interface CancelHeaderTitleProps {
 
 export default function CancelHeaderTitle( {
 	displayVariant,
+	intent,
 	purchase,
 	surveyStep,
 	surveyShown,
@@ -20,12 +22,14 @@ export default function CancelHeaderTitle( {
 	if ( surveyStep === CANCELLATION_OFFER_STEP ) {
 		return __( 'Thanks for your feedback' );
 	}
-	// Once the cancel mutation has resolved and the user is on the survey,
-	// the cancellation has already happened — reflect that in the title.
-	if ( surveyShown && displayVariant === 'auto-renew' ) {
+	// Only the cancel intents fire their mutation at confirm-time, so only they
+	// have actually happened by the time the survey renders. Keying on `intent`
+	// rather than `displayVariant` matters because displayVariant falls back to
+	// 'cancel' for no-intent deep links, which still submit at survey-end.
+	if ( surveyShown && intent === 'auto-renew' ) {
 		return __( 'Auto-renew disabled' );
 	}
-	if ( surveyShown && displayVariant === 'cancel' ) {
+	if ( surveyShown && intent === 'cancel' ) {
 		return __( 'Cancellation confirmed' );
 	}
 	return getCancellationHeading( {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -361,7 +361,7 @@ function StepButtons( {
 						disabled={ isCancelling }
 						onClick={ onSubmit }
 					>
-						{ __( 'No, thanks' ) }
+						{ __( 'Skip survey' ) }
 					</Button>
 				) }
 			</ButtonStack>
@@ -462,7 +462,7 @@ function StepButtons( {
 					disabled={ isCancelling }
 					onClick={ onSubmit }
 				>
-					{ __( 'No, thanks' ) }
+					{ __( 'Skip survey' ) }
 				</Button>
 			) }
 		</ButtonStack>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -559,6 +559,12 @@ function CancelPurchaseInner() {
 	const cancelSearch = useSearch( { from: cancelPurchaseRoute.fullPath } );
 	const intent = getCancelIntentFromSearch( cancelSearch );
 	const displayVariant = getDisplayVariant( intent, flowType );
+	// Fire-on-confirm applies to the Cancel and Auto-renew intents — the user
+	// clicked "Cancel" on Purchase Settings or toggled off auto-renew, and we
+	// want the mutation to settle before the survey appears (so the heading can
+	// read "Cancellation confirmed" / "Auto-renew disabled"). Remove, and the
+	// no-intent legacy deep link, defer the mutation to onSurveyComplete.
+	const fireOnConfirm = intent === 'cancel' || intent === 'auto-renew';
 	const getCancelledSearch = () => ( {
 		cancelled: true as const,
 		...( intent === 'auto-renew' ? { intent: 'auto-renew' as const } : {} ),
@@ -590,7 +596,7 @@ function CancelPurchaseInner() {
 		cancellationOffer,
 		hasQuestionTwo: Boolean( state.questionTwoOrder?.length ),
 		plans,
-		userHasCompletedCancelSurveyForPurchase: isSplitCancelRemoveEnabled
+		userHasCompletedCancelSurveyForPurchase: fireOnConfirm
 			? false
 			: userHasCompletedCancelSurveyForPurchase,
 		isSplitCancelRemoveEnabled,
@@ -1003,14 +1009,6 @@ function CancelPurchaseInner() {
 		}
 	};
 
-	// Fire-on-confirm applies to the URL-intent Cancel and Auto-renew paths —
-	// the user clicked "Cancel" on Purchase Settings or toggled off auto-renew,
-	// and we want the mutation to settle before the survey appears (so the
-	// heading can read "Cancellation confirmed" / "Auto-renew disabled"). Remove
-	// (and the no-intent legacy deep link) defer the mutation to onSurveyComplete.
-	const shouldFireMutationOnConfirm = (): boolean =>
-		isSplitCancelRemoveEnabled && ( intent === 'cancel' || intent === 'auto-renew' );
-
 	const onCancellationComplete = () => {
 		recordTracksEvent( 'calypso_purchases_cancel_form_start', {
 			cancellation_flow: flowType,
@@ -1023,7 +1021,7 @@ function CancelPurchaseInner() {
 		// after it resolves — see fireMutationFromConfirm. Remove (and any non-
 		// intent path) defers to onSurveyComplete and navigates to the survey
 		// synchronously.
-		if ( shouldFireMutationOnConfirm() ) {
+		if ( fireOnConfirm ) {
 			fireMutationFromConfirm( effectiveFlowType, state.cancelBundledDomain ?? false );
 			return;
 		}
@@ -1039,8 +1037,11 @@ function CancelPurchaseInner() {
 		// When the eligibility notice is active and the user clicks the default cancel button
 		// (not the refund link), they're opting for an auto-renew cancellation — no refund, so
 		// no need to ask about the domain. Skip straight to the survey.
-		const skippingDomainOptionsForAutoRenew =
-			isSplitCancelRemoveEnabled && cancelIntent !== 'refund';
+		// Only the cancel intents skip this: their effective flow is always
+		// CANCEL_AUTORENEW, so unbundling the domain can't affect anything. The
+		// no-intent path can still resolve to CANCEL_WITH_REFUND, and intent=remove
+		// can refund a bundled domain — both need the question.
+		const skippingDomainOptionsForAutoRenew = fireOnConfirm && cancelIntent !== 'refund';
 
 		const needsDomainOptions =
 			! skippingDomainOptionsForAutoRenew &&
@@ -1064,7 +1065,7 @@ function CancelPurchaseInner() {
 			const effectiveFlowType = computeEffectiveFlowType( cancelIntent );
 			// See onCancellationComplete for the rationale on why the cancel
 			// intent path defers surveyShown until the mutation resolves.
-			if ( shouldFireMutationOnConfirm() ) {
+			if ( fireOnConfirm ) {
 				setState( ( state ) => ( {
 					...state,
 					cancelIntent,
@@ -1424,7 +1425,7 @@ function CancelPurchaseInner() {
 
 		const effectiveFlowType = computeEffectiveFlowType( state.cancelIntent );
 
-		if ( shouldFireMutationOnConfirm() ) {
+		if ( fireOnConfirm ) {
 			// The mutation already fired at confirm-click via fireMutationFromConfirm.
 			// A refund removes the purchase, so route away like the other removal
 			// paths; disabling auto-renew keeps it, so return to its settings page
@@ -1522,17 +1523,13 @@ function CancelPurchaseInner() {
 			return false;
 		}
 
-		// Under the split flag, if intent=cancel/auto-renew but auto-renew is
-		// already off (e.g. page refresh after the mutation), redirect to
-		// Purchase Settings instead of re-showing the confirmation screen.
-		// Bypass when surveyShown is true — the post-mutation survey should
-		// still render within the same session.
-		const isAlreadyCancelledForSplitFlag =
-			isSplitCancelRemoveEnabled &&
-			( intent === 'cancel' || intent === 'auto-renew' ) &&
-			! purchase.is_auto_renew_enabled;
+		// If intent=cancel/auto-renew but auto-renew is already off (e.g. page
+		// refresh after the mutation), redirect to Purchase Settings instead of
+		// re-showing the confirmation screen. Bypass when surveyShown is true —
+		// the post-mutation survey should still render within the same session.
+		const isAlreadyCancelled = fireOnConfirm && ! purchase.is_auto_renew_enabled;
 
-		if ( isAlreadyCancelledForSplitFlag && ! state.surveyShown ) {
+		if ( isAlreadyCancelled && ! state.surveyShown ) {
 			return false;
 		}
 
@@ -1580,14 +1577,7 @@ function CancelPurchaseInner() {
 		}
 
 		return true;
-	}, [
-		createErrorNotice,
-		intent,
-		isDataLoading,
-		isSplitCancelRemoveEnabled,
-		purchase,
-		state.surveyShown,
-	] );
+	}, [ createErrorNotice, fireOnConfirm, isDataLoading, purchase, state.surveyShown ] );
 
 	const didRunEffect = useRef< boolean >( false );
 
@@ -1685,7 +1675,13 @@ function CancelPurchaseInner() {
 				size="small"
 				header={
 					<PageHeader
-						title={ <CancelHeaderTitle displayVariant={ displayVariant } purchase={ purchase } /> }
+						title={
+							<CancelHeaderTitle
+								displayVariant={ displayVariant }
+								intent={ intent }
+								purchase={ purchase }
+							/>
+						}
 						prefix={ <Breadcrumbs length={ 4 } /> }
 						description={ __( 'Please confirm that you want to remove this domain.' ) }
 					/>
@@ -1718,9 +1714,7 @@ function CancelPurchaseInner() {
 	// Under the split cancel/remove experiment the pre-survey confirmation screen
 	// gates the survey on `confirmationPassed`. Flag-off keeps the legacy
 	// `surveyShown` gate.
-	const atSurvey = Boolean(
-		isSplitCancelRemoveEnabled ? state.confirmationPassed : state.surveyShown
-	);
+	const atSurvey = Boolean( state.confirmationPassed || state.surveyShown );
 	const form = (
 		<CancelPurchaseForm
 			atomicRevertCheckOne={ state.atomicRevertCheckOne }
@@ -1788,6 +1782,7 @@ function CancelPurchaseInner() {
 					title={
 						<CancelHeaderTitle
 							displayVariant={ displayVariant }
+							intent={ intent }
 							purchase={ purchase }
 							surveyStep={ state.surveyStep }
 							surveyShown={ state.surveyShown }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/cancel-header-title.test.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/cancel-header-title.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import CancelHeaderTitle from '../cancel-header-title';
+import type { Purchase } from '@automattic/api-core';
+
+function makePurchase( overrides: Partial< Purchase > = {} ): Purchase {
+	return {
+		ID: 123,
+		product_name: 'WordPress.com Business',
+		product_slug: 'business-bundle',
+		is_plan: true,
+		is_domain_registration: false,
+		is_auto_renew_enabled: true,
+		...overrides,
+	} as Purchase;
+}
+
+// CancelHeaderTitle returns a string rather than an element, so call it directly.
+function titleFor( props: Partial< Parameters< typeof CancelHeaderTitle >[ 0 ] > ) {
+	return CancelHeaderTitle( {
+		displayVariant: 'cancel',
+		intent: null,
+		purchase: makePurchase(),
+		...props,
+	} as Parameters< typeof CancelHeaderTitle >[ 0 ] );
+}
+
+describe( 'CancelHeaderTitle', () => {
+	describe( 'once the survey is showing', () => {
+		test( 'reports the cancellation as confirmed for the cancel intent', () => {
+			expect( titleFor( { intent: 'cancel', displayVariant: 'cancel', surveyShown: true } ) ).toBe(
+				'Cancellation confirmed'
+			);
+		} );
+
+		test( 'reports auto-renew as disabled for the auto-renew intent', () => {
+			expect(
+				titleFor( { intent: 'auto-renew', displayVariant: 'auto-renew', surveyShown: true } )
+			).toBe( 'Auto-renew disabled' );
+		} );
+
+		// The no-intent deep link still submits at survey-end, so nothing has
+		// happened yet. displayVariant falls back to 'cancel' here, which is
+		// exactly the trap this guards against.
+		test( 'does not claim a cancellation happened with no intent', () => {
+			const title = titleFor( { intent: null, displayVariant: 'cancel', surveyShown: true } );
+			expect( title ).not.toBe( 'Cancellation confirmed' );
+			expect( title ).not.toBe( 'Auto-renew disabled' );
+		} );
+
+		// Remove defers its mutation to survey-end too.
+		test( 'does not claim a cancellation happened for the remove intent', () => {
+			const title = titleFor( { intent: 'remove', displayVariant: 'remove', surveyShown: true } );
+			expect( title ).not.toBe( 'Cancellation confirmed' );
+			expect( title ).not.toBe( 'Auto-renew disabled' );
+		} );
+	} );
+
+	test( 'shows the pre-cancellation heading before the survey is reached', () => {
+		const title = titleFor( { intent: 'cancel', displayVariant: 'cancel', surveyShown: false } );
+		expect( title ).not.toBe( 'Cancellation confirmed' );
+	} );
+} );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/use-cancel-mutation-on-confirm.test.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/use-cancel-mutation-on-confirm.test.tsx
@@ -165,7 +165,13 @@ describe( 'useCancelMutationOnConfirm', () => {
 		} );
 	} );
 
-	test( 'fireMutationOnConfirm does NOT capture snapshotPurchase for CANCEL_AUTORENEW flow', async () => {
+	// The auto-renew mutation invalidates userPurchasesQuery, whose ['upgrades']
+	// key is a prefix of purchaseQuery's ['upgrades', id]. Without a snapshot the
+	// live purchase refetches mid-survey with is_auto_renew_enabled: false, which
+	// re-derives the flow type under the survey — a refundable purchase flips to
+	// CANCEL_WITH_REFUND and onSurveyComplete then reports a refund that never
+	// happened.
+	test( 'fireMutationOnConfirm captures snapshotPurchase for CANCEL_AUTORENEW flow', async () => {
 		const mutations = makeMutations();
 		const queryClient = makeQueryClient();
 
@@ -185,7 +191,7 @@ describe( 'useCancelMutationOnConfirm', () => {
 		await waitFor( () =>
 			expect( mutations.setPurchaseAutoRenewMutation.mutateAsync ).toHaveBeenCalled()
 		);
-		expect( result.current.snapshotPurchase ).toBeNull();
+		expect( result.current.snapshotPurchase ).toBe( mockPurchase );
 	} );
 
 	test( 'isPending is true while the mutation is in flight, false after it resolves', async () => {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/use-cancel-mutation-on-confirm.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/use-cancel-mutation-on-confirm.ts
@@ -29,7 +29,7 @@ interface UseCancelMutationOnConfirmArgs {
 
 // Hook for the Cancel paths (CANCEL_AUTORENEW, CANCEL_WITH_REFUND) only —
 // REMOVE defers its mutation to survey-submit, so it doesn't need the
-// snapshot/cache-guard machinery here.
+// cache-guard machinery here.
 export function useCancelMutationOnConfirm( {
 	purchase,
 	cancelAndRefundMutation,
@@ -43,9 +43,17 @@ export function useCancelMutationOnConfirm( {
 		( effectiveFlowType: CancelFlowType, cancelBundledDomain?: boolean ): Promise< void > => {
 			setIsPending( true );
 
+			// Freeze the purchase before either mutation runs. Both invalidate
+			// `userPurchasesQuery`, whose ['upgrades'] key is a prefix of
+			// purchaseQuery's ['upgrades', id], so the live purchase refetches
+			// mid-survey. Without the snapshot, `is_auto_renew_enabled` flipping
+			// false re-derives the flow type under the survey and onSurveyComplete
+			// reports a refund that never happened.
+			setSnapshotPurchase( purchase );
+
 			// CANCEL_AUTORENEW just disables auto-renew — the purchase stays in
-			// the user's list. None of the deletion-flow cache machinery
-			// (strip-from-list, snapshot) applies.
+			// the user's list, so the deletion-flow cache machinery
+			// (strip-from-list) doesn't apply.
 			if ( effectiveFlowType === CANCEL_FLOW_TYPE.CANCEL_AUTORENEW ) {
 				return setPurchaseAutoRenewMutation
 					.mutateAsync( { purchaseId: purchase.ID, autoRenew: false } )
@@ -54,11 +62,6 @@ export function useCancelMutationOnConfirm( {
 						setIsPending( false );
 					} );
 			}
-
-			// CANCEL_WITH_REFUND deletes the purchase. Capture a snapshot
-			// synchronously so survey rendering keeps working after the
-			// mutation's invalidation tears down the live purchase query.
-			setSnapshotPurchase( purchase );
 
 			return cancelAndRefundMutation
 				.mutateAsync( {

--- a/client/me/purchases/cancel-purchase/button.tsx
+++ b/client/me/purchases/cancel-purchase/button.tsx
@@ -48,6 +48,12 @@ export interface CancelPurchaseButtonProps {
 	isLinkStyle?: boolean;
 	isInline?: boolean;
 	cancelIntentOverride?: 'refund' | 'autorenew';
+	/**
+	 * True once the cancel mutation has already fired at confirm-time, so the
+	 * in-dialog survey is a post-cancellation questionnaire rather than the
+	 * thing that performs the cancellation.
+	 */
+	cancellationCompleted?: boolean;
 	activeSubscriptions: Array< { id: number; productName: string } >;
 	onCancellationStart: null | ( ( intent?: 'refund' | 'autorenew' ) => void );
 	onCancellationComplete: () => void;
@@ -231,6 +237,7 @@ class CancelPurchaseButton extends Component<
 						flowType={ flowType }
 						isAkismet={ isAkismet }
 						cancellationInProgress={ isLoading }
+						cancellationCompleted={ this.props.cancellationCompleted }
 					/>
 				) }
 
@@ -243,6 +250,7 @@ class CancelPurchaseButton extends Component<
 						onClose={ this.closeDialog }
 						onSurveyComplete={ this.props.onSurveyComplete }
 						cancellationInProgress={ isLoading }
+						cancellationCompleted={ this.props.cancellationCompleted }
 						intent={ this.props.displayVariant === 'remove' ? 'remove' : 'cancel' }
 					/>
 				) }

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -302,13 +302,12 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			return true;
 		}
 
-		// Under the split flag, if intent=cancel/auto-renew but auto-renew is
-		// already off (e.g. page refresh after cancel-autorenew mutation),
-		// redirect to Purchase Settings instead of re-showing the confirmation
-		// screen. Bypass when surveyShown is true — the post-mutation survey
-		// should still render within the same session.
+		// If intent=cancel/auto-renew but auto-renew is already off (e.g. page
+		// refresh after the cancel-autorenew mutation), redirect to Purchase
+		// Settings instead of re-showing the confirmation screen. Bypass when
+		// surveyShown is true — the post-mutation survey should still render
+		// within the same session.
 		if (
-			props.isSplitCancelRemoveEnabled &&
 			( props.intent === 'cancel' || props.intent === 'auto-renew' ) &&
 			! purchase.is_auto_renew_enabled &&
 			! this.state.surveyShown
@@ -332,8 +331,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		const { purchase, siteSlug } = this.props;
 		let redirectPath = this.props.purchaseListUrl ?? purchasesRoot;
 
-		const isAlreadyCancelledForSplitFlag =
-			this.props.isSplitCancelRemoveEnabled &&
+		const isAlreadyCancelled =
 			( this.props.intent === 'cancel' || this.props.intent === 'auto-renew' ) &&
 			purchase &&
 			! purchase.is_auto_renew_enabled;
@@ -341,7 +339,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		if (
 			siteSlug &&
 			purchase &&
-			( isAlreadyCancelledForSplitFlag ||
+			( isAlreadyCancelled ||
 				! canAutoRenewBeTurnedOff( purchase ) ||
 				isDomainTransfer( purchase ) )
 		) {
@@ -460,14 +458,13 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		}
 	};
 
-	// Fire-on-confirm applies to the URL-intent Cancel path only — the user
+	// Fire-on-confirm applies to the Cancel and Auto-renew intents — the user
 	// clicked "Cancel" on Purchase Settings and we want their cancellation to
 	// settle before the survey appears (so the heading reads "Cancellation
 	// confirmed"). Remove (and the no-intent legacy deep link) defer the
 	// mutation to onSurveyComplete, matching trunk's submit-handlers.
 	shouldFireMutationOnConfirm = (): boolean =>
-		this.props.isSplitCancelRemoveEnabled &&
-		( this.props.intent === 'cancel' || this.props.intent === 'auto-renew' );
+		this.props.intent === 'cancel' || this.props.intent === 'auto-renew';
 
 	// Fire the cancel mutation when the user confirms, then advance to the
 	// survey. The success notice is queued with displayOnNextPage so it shows
@@ -1102,6 +1099,10 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			cancelBundledDomain: this.state.cancelBundledDomain,
 			purchaseListUrl: purchaseListUrl ?? purchasesRoot,
 			displayVariant: this.props.intent ?? undefined,
+			// The dialog products (Jetpack/Akismet/domain) render their survey after
+			// the mutation has already fired, so the dialog must present itself as a
+			// questionnaire rather than offering to cancel a second time.
+			cancellationCompleted: this.state.surveyShown && this.shouldFireMutationOnConfirm(),
 			showMarketplaceDialog: ! isSplitCancelRemoveEnabled,
 			cancelIntentOverride:
 				urlIntentOverride ??
@@ -1455,13 +1456,15 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		const { blogname: siteName, blog_id: siteId } = purchase;
 
 		const displayVariant = this.getDisplayVariant();
-		// Once the cancel mutation has resolved and the user is on the survey,
-		// the cancellation has already happened — reflect that in the heading.
+		// Only the cancel intents fire their mutation at confirm-time, so only they
+		// have actually happened by the time the survey renders. Keying on `intent`
+		// rather than `displayVariant` matters because displayVariant falls back to
+		// 'cancel' for no-intent deep links, which still submit at survey-end.
 		const heading = ( () => {
-			if ( this.state.surveyShown && displayVariant === 'cancel' ) {
+			if ( this.state.surveyShown && intent === 'cancel' ) {
 				return this.props.translate( 'Cancellation confirmed' );
 			}
-			if ( this.state.surveyShown && displayVariant === 'auto-renew' ) {
+			if ( this.state.surveyShown && intent === 'auto-renew' ) {
 				return this.props.translate( 'Auto-renew disabled' );
 			}
 			return getCancellationHeading( {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-526/

## Proposed Changes

This makes the subscription cancellation action fire immediately after the confirmation step (before the survey), to meet requirements for cancellation flows and align with the post-confirmation wording of the flow. This leaves the removal flow (`?intent=remove`) behavior as-is, requiring the user to complete the survey before removing.

* Make fire-on-confirm the default for the `cancel` and `auto-renew` intents in both Calypso and the Dashboard, instead of gating it behind `purchases/split-cancel-remove`.
* Bring the state that path depends on out from behind the flag in lockstep: the already-cancelled redirect guard, the survey-visibility gate, the domain-options skip, and the survey-completed step override.
* Snapshot the purchase on the auto-renew path so a mid-survey refetch can't re-derive the flow type.
* Key the confirmation headings on URL intent rather than `displayVariant`, which falls back to `'cancel'` for no-intent deep links that still submit at survey-end.
* Pass the previously-dead `cancellationCompleted` prop to the Jetpack/Akismet and domain dialogs so they stop offering to cancel something already cancelled.
* Rename the survey-skip button from "No, thanks" to "Skip survey". Offer-decline buttons keep "No, thanks".

## Why are these changes being made?

The fire-on-confirm path was built behind the RSM `purchases/split-cancel-remove` feature flag, but the gating for the headings written for it had since been removed, creating a flow where the user was shown "Cancellation confirmed" before the survey had been completed and the cancellation processed. Rather than hide the heading, we make the behavior match it: the confirmation step is where a user reasonably believes the decision is committed. This aligns with cancellation flow compliance.

Removal is different. It is destructive and irreversible, so it keeps its existing contract of submitting only once the survey is complete.

Two related bugs surfaced while tracing the change and are fixed here because ungating the path is what makes them reachable:

* `useCancelMutationOnConfirm` only snapshotted the purchase on the refund path. Both cancel mutations invalidate `userPurchasesQuery`, whose `['upgrades']` key is a prefix of `purchaseQuery`'s `['upgrades', id]`, so the live purchase refetched mid-survey with `is_auto_renew_enabled: false`. That re-derived the flow type under the survey — a refundable purchase flipped to `CANCEL_WITH_REFUND`, and `onSurveyComplete` then announced "Your refund has been processed and your purchase removed" for a cancellation that refunded and removed nothing.
* `cancellationCompleted` was declared and consumed throughout `cancel-jetpack-form` but never passed by any caller. Post-cancellation the dialog rendered a red "Cancel subscription" button for an already-cancelled subscription. It did not double-submit, but it was the same class of lie this issue is about.

## Testing Instructions

TC:

```
yarn test-client client/dashboard/me/billing-purchases/cancel-purchase client/me/purchases/cancel-purchase client/components/marketing-survey
```

19 suites / 110 tests pass. New and updated coverage:

* `cancel-header-title.test.tsx` (new) — the confirmed heading requires a real URL intent; no-intent and remove must not claim a cancellation happened.
* `use-cancel-mutation-on-confirm.test.tsx` — inverted the assertion that previously locked in the missing auto-renew snapshot.
* `next-adventure-step.test.tsx` — rekeyed from the feature flag to intent, plus a no-intent case.
* `remove-intent.jsx` — unchanged, and still passing; this is the guard that removal continues to submit only at survey end.

Manual testing:

* Buy any auto-renewing subscription.
* In both Calypso and the Dashboard, visit Active Upgrades and select the subscription.
* Verify that the subscription has auto-renew on, and the CTA at the bottom of the page is for cancelling the subscription (current behavior)
* Click to cancel the plan and then confirm the cancellation on the next step
* Verify that you see "Cancellation confirmed" as the page heading on the first step of the survey
* Leave the flow without completing the survey (either via "Skip survey" or by navigating back to the purchase management page)
* Verify that auto-renew is off and that the CTA at the bottom of the page is for removing the subscription