### PR TITLE
Stats: remove the Traffic page settings onboarding tour

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -133,7 +133,6 @@ $z-layers: (
 		".drop-zone__content": 1010,
 		".tooltip.popover": 100000,
 		".tooltip.popover.page-modules-settings-popover": 175,
-		".tooltip.popover.highlight-card__settings-tooltip": 170,
 		".fullscreen-overlay": 100005,
 		"#wp_editbtns": 100020,
 		"#wp-fullscreen-body": 100010,

--- a/client/blocks/stats-navigation/index.jsx
+++ b/client/blocks/stats-navigation/index.jsx
@@ -11,8 +11,6 @@ import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
-import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
-import { useNoticeVisibilityQuery } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isGoogleMyBusinessLocationConnectedSelector from 'calypso/state/selectors/is-google-my-business-location-connected';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
@@ -42,29 +40,6 @@ import './style.scss';
  * }} StatsNavItem
  */
 
-// Use HOC to wrap hooks of `react-query` for fetching the notice visibility state.
-function withNoticeHook( HookedComponent ) {
-	return function WrappedComponent( props ) {
-		const { data: showSettingsTooltip, refetch: refetchNotices } = useNoticeVisibilityQuery(
-			props.siteId,
-			'traffic_page_settings'
-		);
-
-		const { mutateAsync: mutateNoticeVisbilityAsync } = useNoticeVisibilityMutation(
-			props.siteId,
-			'traffic_page_settings'
-		);
-
-		return (
-			<HookedComponent
-				{ ...props }
-				showSettingsTooltip={ showSettingsTooltip }
-				refetchNotices={ refetchNotices }
-				mutateNoticeVisbilityAsync={ mutateNoticeVisbilityAsync }
-			/>
-		);
-	};
-}
 /**
  * @param { { navItems: StatsNavItem[], selectedItemName: keyof typeof allNavItems, isLegacy: boolean, interval: string, pathTemplate: string } } props
  */
@@ -166,7 +141,6 @@ class StatsNavigation extends Component {
 		isLegacy: PropTypes.bool,
 		adminUrl: PropTypes.string,
 		showLock: PropTypes.bool,
-		delayTooltipPresentation: PropTypes.bool,
 	};
 
 	isValidItem = ( item ) => {
@@ -271,25 +245,6 @@ class StatsNavigation extends Component {
 	}
 }
 
-function shouldDelayTooltipPresentation( state, siteId ) {
-	// Check the 'created_at' time stamp.
-	// Can return null (Redux hydration?) which we'll treat as a delay.
-	const siteCreatedTimeStamp = getSiteOption( state, siteId, 'created_at' );
-	if ( siteCreatedTimeStamp === null ) {
-		return true;
-	}
-
-	// Check if the site is less than one week old.
-	const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
-	const siteIsLessThanOneWeekOld =
-		new Date( siteCreatedTimeStamp ) > new Date( Date.now() - WEEK_IN_MILLISECONDS );
-	if ( siteIsLessThanOneWeekOld ) {
-		return true;
-	}
-
-	return false;
-}
-
 export default connect(
 	( state, { siteId, selectedItem } ) => {
 		return {
@@ -307,8 +262,7 @@ export default connect(
 			siteId,
 			pageModuleToggles: getModuleToggles( state, siteId, [ selectedItem ] ),
 			adminUrl: getSiteAdminUrl( state, siteId ),
-			delayTooltipPresentation: shouldDelayTooltipPresentation( state, siteId ),
 		};
 	},
 	{ requestModuleToggles, updateModuleToggles }
-)( localize( withNoticeHook( StatsNavigation ) ) );
+)( localize( StatsNavigation ) );

--- a/client/blocks/stats-navigation/page-module-toggler.tsx
+++ b/client/blocks/stats-navigation/page-module-toggler.tsx
@@ -12,8 +12,6 @@ import { AVAILABLE_PAGE_MODULES, ModuleToggleItem } from './constants';
 
 type PageModuleTogglerProps = {
 	moduleToggles: { [ name: string ]: boolean };
-	isTooltipShown: boolean;
-	onTooltipDismiss: () => void;
 	customToggleIcon?: React.ReactNode;
 	siteId: number;
 	selectedItem: string;
@@ -40,8 +38,6 @@ export default function PageModuleToggler( {
 	selectedItem,
 	moduleToggles,
 	siteId,
-	isTooltipShown,
-	onTooltipDismiss,
 	customToggleIcon = <Icon className="gridicon" icon={ cog } />,
 }: PageModuleTogglerProps ) {
 	const translate = useTranslate();
@@ -63,7 +59,6 @@ export default function PageModuleToggler( {
 	}, [] );
 
 	const toggleSettingsMenu = () => {
-		onTooltipDismiss();
 		setIsSettingsMenuVisible( ( isSettingsMenuVisible ) => {
 			return ! isSettingsMenuVisible;
 		} );
@@ -89,17 +84,6 @@ export default function PageModuleToggler( {
 			>
 				{ customToggleIcon }
 			</button>
-			<Popover
-				className="tooltip tooltip--darker highlight-card-tooltip highlight-card__settings-tooltip"
-				isVisible={ isTooltipShown }
-				position="bottom left"
-				context={ settingsActionElement }
-			>
-				<div className="highlight-card-tooltip-content">
-					<p>{ translate( 'Here’s where you can find all your Jetpack Stats settings.' ) }</p>
-					<button onClick={ onTooltipDismiss }>{ translate( 'Got it' ) }</button>
-				</div>
-			</Popover>
 			<Popover
 				className="tooltip highlight-card-popover page-modules-settings-popover"
 				isVisible={ isSettingsMenuVisible }

--- a/client/blocks/stats-navigation/test/page-module-toggler.test.tsx
+++ b/client/blocks/stats-navigation/test/page-module-toggler.test.tsx
@@ -62,8 +62,6 @@ jest.mock( '@wordpress/icons', () => ( {
 const defaultProps = {
 	selectedItem: 'traffic',
 	siteId: 123,
-	isTooltipShown: false,
-	onTooltipDismiss: jest.fn(),
 	customToggleIcon: <span>Settings</span>,
 };
 

--- a/client/my-sites/stats/components/highlight-cards/style.scss
+++ b/client/my-sites/stats/components/highlight-cards/style.scss
@@ -201,11 +201,6 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 		}
 	}
 
-	&.highlight-card__settings-tooltip {
-		// Make the popover under `.page-modules-settings-popover` of z-index: 175.
-		z-index: z-index("root", ".tooltip.popover.highlight-card__settings-tooltip");
-	}
-
 	// @TODO: Introduce the support for the border of white background arrows in the popover component.
 	// Set the border of the white background bottom arrows.
 	&.highlight-card-popover {
@@ -344,29 +339,6 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 	color: var(--studio-gray-30);
 	font-size: $font-body-small;
 }
-.highlight-card__settings-tooltip {
-	.highlight-card-tooltip-content {
-		flex-direction: column;
-		align-items: flex-end;
-
-		p {
-			margin-bottom: 24px;
-		}
-
-		button {
-			font-family: $font-sf-pro-text;
-			font-weight: 600;
-			font-size: $font-body-extra-small;
-			line-height: 20px;
-			color: var(--studio-black);
-			padding: 4px 8px;
-			background-color: var(--studio-white);
-			border-radius: 4px;
-			cursor: pointer;
-		}
-	}
-}
-
 @media (max-width: $custom-mobile-breakpoint) {
 	.highlight-cards-heading {
 		margin-left: $font-body-small;

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -31,8 +31,6 @@ import {
 	STATS_PRODUCT_NAME,
 } from 'calypso/my-sites/stats/constants';
 import { useMomentInSite } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
-import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
-import { useNoticeVisibilityQuery } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import { recordCurrentScreen } from 'calypso/my-sites/stats/hooks/use-stats-navigation-history';
 import { getChartRangeParams } from 'calypso/my-sites/stats/utils';
 import {
@@ -208,9 +206,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 	const moduleToggles = useSelector( ( state ) => getModuleToggles( state, siteId, 'traffic' ) );
 	const momentInSite = useMomentInSite( siteId );
 	const hasVideoPress = useSelector( ( state ) => siteHasFeature( state, siteId, 'videopress' ) );
-	const [ isPageSettingsTooltipDismissed, setIsPageSettingsTooltipDismissed ] = useState(
-		!! localStorage.getItem( 'notices_dismissed__traffic_page_settings' )
-	);
 
 	// Determine module visibility based on user settings, VideoPress availability, AND defaults.
 	const moduleVisibility = useMemo(
@@ -548,25 +543,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		getJetpackStatsAdminVersion( state, siteId )
 	);
 
-	const { data: showSettingsTooltip, refetch: refetchNotices } = useNoticeVisibilityQuery(
-		siteId,
-		'traffic_page_settings'
-	);
-	const { mutateAsync: mutateNoticeVisbilityAsync } = useNoticeVisibilityMutation(
-		siteId,
-		'traffic_page_settings'
-	);
-
-	const onTooltipDismiss = () => {
-		if ( isPageSettingsTooltipDismissed || ! showSettingsTooltip ) {
-			return;
-		}
-
-		setIsPageSettingsTooltipDismissed( true );
-		localStorage.setItem( 'notices_dismissed__traffic_page_settings', 1 );
-		mutateNoticeVisbilityAsync().finally( refetchNotices );
-	};
-
 	// Module settings for Odyssey are not supported until stats-admin@0.9.0-alpha.
 	const isModuleSettingsSupported =
 		! config.isEnabled( 'is_running_in_jetpack_site' ) ||
@@ -610,8 +586,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 									selectedItem="traffic"
 									moduleToggles={ moduleToggles }
 									siteId={ siteId }
-									isTooltipShown={ showSettingsTooltip && ! isPageSettingsTooltipDismissed }
-									onTooltipDismiss={ onTooltipDismiss }
 									customToggleIcon={ <Icon className="gridicon" icon={ settings } /> }
 								/>
 							)


### PR DESCRIPTION
Part of STATS-409

## Proposed Changes

* Remove the first-visit onboarding tour tooltip on the Traffic page settings (gear) icon — the one saying “Here’s where you can find all your Jetpack Stats settings.”
* Remove the `traffic_page_settings` notice wiring that only served the tour: the `useNoticeVisibilityQuery`/`useNoticeVisibilityMutation` calls and the `notices_dismissed__traffic_page_settings` localStorage dismissal state in `site.jsx`.
* Remove dead tour-era code from `StatsNavigation`: the `withNoticeHook` HOC and `shouldDelayTooltipPresentation()` were still fetching the notice and passing props that nothing in the component reads (leftovers from when the module toggler lived in the navigation block).
* Remove the now-unused `.highlight-card__settings-tooltip` styles and z-index entry.

The gear icon and the “Modules visibility” toggle popover are unchanged — only the tour bubble is removed.

## Why are these changes being made?

The tour copy is inaccurate: the gear icon only toggles visibility of three modules (Authors, Search terms, Videos), not “all your Jetpack Stats settings.” The copy was written for planned widget-settings features that never shipped, so the highlight has been overselling a minor feature as the first thing users see in Stats. See STATS-409.

## Testing Instructions

1. On a site that has never dismissed the tour (or after clearing the `notices_dismissed__traffic_page_settings` localStorage key and resetting the notice), visit Stats → Traffic.
2. Verify no tour tooltip appears pointing at the gear icon next to the date controls.
3. Click the gear icon and verify the “Modules visibility” popover still opens and the toggles still work.

|Before|After|
|-|-|
|<img width="500" height="235" alt="截圖 2026-08-05 凌晨1 21 52" src="https://github.com/user-attachments/assets/7ba43bf3-450b-4c7a-a833-65bbe6589088" />|<img width="376" height="222" alt="截圖 2026-08-05 凌晨1 24 55" src="https://github.com/user-attachments/assets/6299f65f-3b61-4cf7-a52b-4abe3f9fb8e0" />|

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
