### PR TITLE
Stats: show the Search terms module by default

### DIFF
--- a/client/blocks/stats-navigation/constants.ts
+++ b/client/blocks/stats-navigation/constants.ts
@@ -39,7 +39,7 @@ export const AVAILABLE_PAGE_MODULES: Record< string, ModuleToggleItem[] > = {
 				return translate( 'Search terms' );
 			},
 			icon: search,
-			defaultValue: false,
+			defaultValue: true,
 			disabled: false,
 		},
 		{

--- a/client/blocks/stats-navigation/test/page-module-toggler.test.tsx
+++ b/client/blocks/stats-navigation/test/page-module-toggler.test.tsx
@@ -91,6 +91,7 @@ describe( 'PageModuleToggler', () => {
 		await user.click( screen.getByRole( 'button', { name: 'Settings' } ) );
 
 		expect( getToggle( 'Authors' ) ).toBeChecked();
+		expect( getToggle( 'Search terms' ) ).toBeChecked();
 		expect( getToggle( 'Videos' ) ).toBeChecked();
 
 		rerender(


### PR DESCRIPTION
Part of STATS-409

## Proposed Changes

* Make the Search terms module visible by default on the Traffic page by flipping its client-side `defaultValue` to `true` in `AVAILABLE_PAGE_MODULES`.
* Extend the `PageModuleToggler` test to assert the Search terms toggle is checked by default.

## Why are these changes being made?

Search terms has been the only Traffic page module unconditionally hidden by default (since #98311). The other two toggleable modules already have conditional defaults keyed on meaningful signals: Authors is hidden server-side only for single-author sites, and Videos is shown only when the site has VideoPress. Hiding Search terms unconditionally made the module effectively undiscoverable, which came up in STATS-409.

This only affects sites that have never saved module toggles — the server never returns a `search-terms` value unless the user has explicitly set it, so stored preferences always win over this default.

## Testing Instructions

1. On a site that has never touched the module visibility toggles (no saved `search-terms` preference), visit Stats → Traffic.
2. Verify the Search terms module now renders on the page, and the gear icon’s “Modules visibility” popover shows Search terms toggled on.
3. Toggle it off and reload — it should stay hidden (saved preference wins).

|Before|After|
|-|-|
|<img width="1190" height="860" alt="截圖 2026-08-05 凌晨1 27 31" src="https://github.com/user-attachments/assets/0c4d17bf-5eb6-4984-b530-d4dbc775bb76" />|<img width="1206" height="864" alt="截圖 2026-08-05 凌晨1 27 14" src="https://github.com/user-attachments/assets/4d179525-d0e9-4f20-837f-a8deb2faa0c5" />|

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
