### PR TITLE
A4A Sites: Scope the sites dashboard styles to the Sites section

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -6,7 +6,7 @@
 @import '@wordpress/base-styles/mixins';
 @import '@wordpress/base-styles/variables';
 
-.main.hosting-dashboard-layout.sites-dashboard {
+.is-section-a8c-for-agencies-sites .main.hosting-dashboard-layout.sites-dashboard {
 	.hosting-dashboard-layout-column {
 		.hosting-dashboard-layout-column__container {
 			display: flex;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/A4A-3034/tri-state-checkbox-partial-dash-vs-checkmark-misalignment

## Proposed Changes

* Scope the A4A Sites dashboard stylesheet to the Sites section, so its rules stop applying to other sections that reuse the `sites-dashboard` layout class.

**Issue affecting the Plugins page:**
<img width="385" height="356" alt="Screenshot 2026-08-05 at 1 20 19 AM" src="https://github.com/user-attachments/assets/858a10dc-f7c7-4c09-a080-5bc1547910ff" />


## Why are these changes being made?

`client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss` declared its entire ~900-line block under `.main.hosting-dashboard-layout.sites-dashboard`, with nothing tying it to the Sites section.

The Plugins dashboard renders through `client/my-sites/plugins/plugins-dashboard/index.tsx`, which puts `sites-dashboard sites-dashboard__layout` on the very same `Layout` element — so every one of those rules matched the Plugins page too.

`a8c-for-agencies-sites` and `a8c-for-agencies-plugins` are separate sections, so the stylesheet ships in the lazily loaded Sites chunk and isn't in the document until `/sites` is visited. Once loaded it never unloads, which is why the Plugins page looked correct on a direct visit and broke only after a trip through Sites.

The most visible symptom was the bulk-selection column: measuring the checkbox inset against the content edge in before/after screenshots gives exactly 24px (the `@wordpress/dataviews` default, `padding-left: var(--wpds-dimension-padding-2xl, 24px)`) and then 64px (this stylesheet's override), a 40px jump that pushed the checkboxes out of alignment with the rest of the page.

The gutter was just the most noticeable part — the sticky `thead`, the `.dataviews__view-actions` padding, and the mobile `width: 80%` first-column rule were all bleeding across as well.

Prefixing the block with `.is-section-a8c-for-agencies-sites` (the body class from `client/layout/index.jsx`, already used further down in this same file) contains all of it. Nothing outside the Sites section imports this stylesheet.

## Testing Instructions

Reproducing the bug on trunk:

1. Load A4A and go straight to Plugins (`/plugins/manage/sites`) in a fresh tab, without visiting Sites first.
2. Note the selection checkbox column — it sits at the DataViews default 24px gutter.
3. Navigate to Sites, then back to Plugins.
4. The checkbox column jumps 40px to the right (64px gutter).

With this branch, step 4 no longer shifts the column — Plugins keeps the 24px gutter regardless of navigation order.

Also confirm the Sites dashboard itself is unchanged: `/sites` list and preview pane, table gutters, sticky header, filter bar padding, and the narrow-viewport layout.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
