### PR TITLE
Jetpack AI: Use content-neutral sidebar copy

### DIFF
--- a/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.test.tsx
@@ -1661,7 +1661,11 @@ describe( 'AiEditorialReview — cached-run hint', () => {
 		const cached_at = Math.floor( Date.now() / 1000 ) - 600;
 		render( <AiEditorialReview { ...basePayload( { cached_at } ) } /> );
 
-		expect( screen.getByText( /Reusing review from .* ago/ ) ).toBeInTheDocument();
+		const note = screen.getByText( /Reusing review from .* ago\. Edit the content to re-run\./ );
+		expect( note ).toHaveAttribute(
+			'title',
+			'The inputs (content, notes, comments, guidelines) have not changed since the previous run, so the saved result is being reused to avoid a duplicate LLM call.'
+		);
 	} );
 
 	it( 'omits the note when cached_at is not provided', () => {

--- a/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.tsx
@@ -1116,13 +1116,13 @@ export default function AiEditorialReview( {
 							<p
 								className="jetpack-ai-editorial-review__cached-hint"
 								title={ __(
-									'The inputs (post content, notes, comments, guidelines) have not changed since the previous run, so the saved result is being reused to avoid a duplicate LLM call.',
+									'The inputs (content, notes, comments, guidelines) have not changed since the previous run, so the saved result is being reused to avoid a duplicate LLM call.',
 									__i18n_text_domain__
 								) }
 							>
 								{ sprintf(
 									/* translators: %s is a short relative-time phrase, e.g. "3 minutes ago" */
-									__( 'Reusing review from %s. Edit the post to re-run.', __i18n_text_domain__ ),
+									__( 'Reusing review from %s. Edit the content to re-run.', __i18n_text_domain__ ),
 									formatRelativeTime( cached_at )
 								) }
 							</p>

--- a/packages/jetpack-ai-sidebar/src/components/block-ref.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/block-ref.test.tsx
@@ -63,9 +63,9 @@ describe( 'BlockRef', () => {
 		mockGetBlockType.mockReturnValue( undefined );
 	} );
 
-	it( 'renders "Post-wide" for null index, non-clickable, with no block icon', () => {
+	it( 'renders "Content-wide" for null index, non-clickable, with no block icon', () => {
 		render( <BlockRef index={ null } blocks={ blocks } /> );
-		const el = screen.getByText( 'Post-wide' );
+		const el = screen.getByText( 'Content-wide' );
 		expect( el.tagName ).toBe( 'SPAN' );
 		expect( screen.queryByTestId( 'block-icon' ) ).not.toBeInTheDocument();
 	} );

--- a/packages/jetpack-ai-sidebar/src/components/block-ref.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/block-ref.tsx
@@ -1,8 +1,8 @@
 /**
  * BlockRef — chip for a block referenced by 0-based index. Renders the block's
  * registered icon plus a short content snippet ("Revenue grew 23%…"); clicking
- * invokes `onFocus(index)` to anchor the editor to that block. A post-wide item
- * (null index) has no anchorable block, so it renders a plain "Post-wide" label.
+ * invokes `onFocus(index)` to anchor the editor to that block. A content-wide item
+ * (null index) has no anchorable block, so it renders a plain "Content-wide" label.
  */
 
 /**
@@ -34,7 +34,7 @@ export interface BlockSnapshot {
 }
 
 interface BlockRefProps {
-	/** 0-based block index from the review payload. Null = post-wide. */
+	/** 0-based block index from the review payload. Null = content-wide. */
 	index: number | null;
 	/** Flat pre-order block list from the review/editor block tree. */
 	blocks: BlockSnapshot[];
@@ -137,7 +137,7 @@ function BlockChipContent( { block }: { block: BlockSnapshot } ) {
 /**
  * Render a block reference.
  * @param           props             BlockRefProps.
- * @param {number}  props.index       0-based block index, or null for post-wide.
+ * @param {number}  props.index       0-based block index, or null for content-wide.
  * @param           props.blocks      Flat pre-order block snapshot list.
  * @param           props.onFocus     Optional click handler; when omitted the ref renders as a plain span.
  * @param {string}  props.className   Optional extra class name.
@@ -147,7 +147,7 @@ export default function BlockRef( { index, blocks, onFocus, className = '' }: Bl
 	if ( index === null || index === undefined ) {
 		return (
 			<span className={ `jetpack-ai-block-ref is-post-wide ${ className }`.trim() }>
-				{ __( 'Post-wide', __i18n_text_domain__ ) }
+				{ __( 'Content-wide', __i18n_text_domain__ ) }
 			</span>
 		);
 	}

--- a/packages/jetpack-ai-sidebar/src/components/excerpt-picker.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/excerpt-picker.test.tsx
@@ -50,6 +50,11 @@ describe( 'ExcerptPicker', () => {
 
 	it( 'renders every suggested excerpt', () => {
 		render( <ExcerptPicker excerpts={ excerpts } /> );
+		expect(
+			screen.getByText(
+				'Choose an excerpt for your content — ask for a different length or tone if you’d like:'
+			)
+		).toBeInTheDocument();
 		expect( screen.getByText( excerpts[ 0 ].excerpt ) ).toBeInTheDocument();
 		expect( screen.getByText( excerpts[ 1 ].excerpt ) ).toBeInTheDocument();
 	} );

--- a/packages/jetpack-ai-sidebar/src/components/excerpt-picker.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/excerpt-picker.tsx
@@ -65,7 +65,7 @@ export default function ExcerptPicker( { excerpts, onComplete }: ExcerptPickerPr
 	return (
 		<BaseSuggestionPicker
 			intro={ __(
-				'Choose an excerpt for your post — ask for a different length or tone if you’d like:',
+				'Choose an excerpt for your content — ask for a different length or tone if you’d like:',
 				'jetpack'
 			) }
 			options={ options }

--- a/packages/jetpack-ai-sidebar/src/components/post-feedback.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/post-feedback.tsx
@@ -50,7 +50,7 @@ export default function PostFeedback( {
 			isMessageStale={ isMessageStale }
 			sectionFallbackTitle={ __( 'Suggested edits', __i18n_text_domain__ ) }
 			staleWarning={ __(
-				'Feedback context changed. Generate feedback again for this post.',
+				'Feedback context changed. Generate feedback again for this content.',
 				__i18n_text_domain__
 			) }
 			failureMessage={ __(

--- a/packages/jetpack-ai-sidebar/src/components/proofread.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/proofread.tsx
@@ -48,7 +48,7 @@ export default function Proofread( {
 			isMessageStale={ isMessageStale }
 			sectionFallbackTitle={ __( 'Suggested edits', __i18n_text_domain__ ) }
 			staleWarning={ __(
-				'Review context changed. Run the spelling and grammar check again for this post.',
+				'Review context changed. Run the spelling and grammar check again for this content.',
 				__i18n_text_domain__
 			) }
 			failureMessage={ __(

--- a/packages/jetpack-ai-sidebar/src/components/seo-description-picker.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/seo-description-picker.test.tsx
@@ -50,6 +50,7 @@ describe( 'SeoDescriptionPicker', () => {
 
 	it( 'renders every suggested SEO description', () => {
 		render( <SeoDescriptionPicker descriptions={ descriptions } /> );
+		expect( screen.getByText( 'Choose an SEO description for your content:' ) ).toBeInTheDocument();
 		expect( screen.getByText( descriptions[ 0 ].description ) ).toBeInTheDocument();
 		expect( screen.getByText( descriptions[ 1 ].description ) ).toBeInTheDocument();
 	} );

--- a/packages/jetpack-ai-sidebar/src/components/seo-description-picker.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/seo-description-picker.tsx
@@ -67,7 +67,7 @@ export default function SeoDescriptionPicker( {
 
 	return (
 		<BaseSuggestionPicker
-			intro={ __( 'Choose an SEO description for your post:', 'jetpack' ) }
+			intro={ __( 'Choose an SEO description for your content:', 'jetpack' ) }
 			options={ descriptions.map( ( option ) => option.description ) }
 			onApply={ handleApply }
 			appliedMessage={ __( 'SEO description updated.', 'jetpack' ) }

--- a/packages/jetpack-ai-sidebar/src/components/seo-title-picker.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/seo-title-picker.test.tsx
@@ -44,6 +44,7 @@ describe( 'SeoTitlePicker', () => {
 
 	it( 'renders every suggested SEO title', () => {
 		render( <SeoTitlePicker titles={ titles } /> );
+		expect( screen.getByText( 'Choose an SEO title for your content:' ) ).toBeInTheDocument();
 		expect( screen.getByText( titles[ 0 ].title ) ).toBeInTheDocument();
 		expect( screen.getByText( titles[ 1 ].title ) ).toBeInTheDocument();
 	} );

--- a/packages/jetpack-ai-sidebar/src/components/seo-title-picker.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/seo-title-picker.tsx
@@ -65,7 +65,7 @@ export default function SeoTitlePicker( { titles, onComplete }: SeoTitlePickerPr
 
 	return (
 		<BaseSuggestionPicker
-			intro={ __( 'Choose an SEO title for your post:', 'jetpack' ) }
+			intro={ __( 'Choose an SEO title for your content:', 'jetpack' ) }
 			options={ titles.map( ( option ) => option.title ) }
 			onApply={ handleApply }
 			appliedMessage={ __( 'SEO title updated.', 'jetpack' ) }

--- a/packages/jetpack-ai-sidebar/src/components/title-picker.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/title-picker.test.tsx
@@ -44,6 +44,7 @@ describe( 'TitlePicker', () => {
 
 	it( 'renders every suggested title', () => {
 		render( <TitlePicker titles={ titles } /> );
+		expect( screen.getByText( 'Choose a title for your content:' ) ).toBeInTheDocument();
 		expect( screen.getByText( titles[ 0 ].title ) ).toBeInTheDocument();
 		expect( screen.getByText( titles[ 1 ].title ) ).toBeInTheDocument();
 	} );

--- a/packages/jetpack-ai-sidebar/src/components/title-picker.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/title-picker.tsx
@@ -57,7 +57,7 @@ export default function TitlePicker( { titles, onComplete }: TitlePickerProps ) 
 
 	return (
 		<BaseSuggestionPicker
-			intro={ __( 'Choose a title for your post:', __i18n_text_domain__ ) }
+			intro={ __( 'Choose a title for your content:', __i18n_text_domain__ ) }
 			options={ titles.map( ( option ) => option.title ) }
 			onApply={ handleApply }
 			appliedMessage={ __( 'Title updated.', __i18n_text_domain__ ) }

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -831,7 +831,7 @@ describe( 'PostFeedback', () => {
 		);
 
 		expect( container.querySelector( '.jetpack-ai-feedback-list__block-ref' )?.textContent ).toBe(
-			'Post-wide'
+			'Content-wide'
 		);
 		const goto = findButton( container, 'Go to section' );
 		expect( goto ).toBeDefined();
@@ -934,7 +934,9 @@ describe( 'PostFeedback', () => {
 		);
 
 		// Stale banner is shown, but the card keeps its category badge and no tag.
-		expect( container.textContent ).toContain( 'Feedback context changed' );
+		expect( container.textContent ).toContain(
+			'Feedback context changed. Generate feedback again for this content.'
+		);
 		expect( container.querySelector( '.jetpack-ai-feedback-list__item-badge' )?.textContent ).toBe(
 			'Spacing (1/1)'
 		);
@@ -1510,6 +1512,20 @@ describe( 'Proofread', () => {
 		expect( container.textContent ).toContain( 'Punctuation' );
 	} );
 
+	it( 'uses content-neutral copy when the review context is stale', () => {
+		const { container } = render(
+			React.createElement( Proofread, {
+				summary: 'Summary.',
+				postId: 999,
+				items: [],
+			} )
+		);
+
+		expect( container.textContent ).toContain(
+			'Review context changed. Run the spelling and grammar check again for this content.'
+		);
+	} );
+
 	it( 'renders server-sanitised backend fragments in Current and New rows', () => {
 		const currentText =
 			'<strong><em>Consultation</em></strong> <a href="https://example.com"><strong><em>opens</em>s</strong></a> next week, <s>not this week</s>, ref<sup>2</sup>';
@@ -2003,6 +2019,55 @@ describe( 'getEmptyViewSuggestions', () => {
 		} );
 	} );
 
+	it( 'uses content-neutral descriptions and prompts for editor-level suggestions', () => {
+		installAiEditorialReviewData( {
+			optimizeTitleSuggestion: true,
+			proofreadContent: true,
+			seoSuggestions: true,
+			excerptSuggestion: true,
+		} );
+		installPostTypeMock( 'page', 123, true );
+
+		const suggestions = getEmptyViewSuggestions();
+		const byId = ( id: string ) => suggestions.find( ( suggestion ) => suggestion.id === id );
+
+		expect( byId( 'optimize-title' ) ).toEqual(
+			expect.objectContaining( {
+				description: 'Refine the title based on your content and SEO best practices.',
+				prompt: 'Optimize the title of this content',
+			} )
+		);
+		expect( byId( 'generate-excerpt' ) ).toEqual(
+			expect.objectContaining( {
+				description: 'Generate an excerpt for your content.',
+				prompt: 'Generate an excerpt for this content',
+			} )
+		);
+		expect( byId( 'generate-feedback' ) ).toEqual(
+			expect.objectContaining( {
+				prompt:
+					'Generate feedback for this saved content. Review the saved title and saved block content for content structure, reader clarity, completeness, media/caption/link issues, and obvious publishability concerns. Return practical feedback with one-click suggestions when safe.',
+			} )
+		);
+		expect( byId( 'proofread-content' ) ).toEqual(
+			expect.objectContaining( {
+				prompt:
+					'Proofread this saved content for spelling, grammar, and punctuation. Review the saved title and saved block content, and return practical fixes with one-click suggestions when safe.',
+			} )
+		);
+		expect( byId( 'ai-editorial-review' ) ).toEqual(
+			expect.objectContaining( {
+				prompt:
+					'Run an AI Editorial Review for this content. Check the content, reviewer notes, and site guidelines, then surface conflicts, implications, guideline issues, and suggested edits.',
+			} )
+		);
+		expect( byId( 'seo-enhancer' ) ).toEqual(
+			expect.objectContaining( {
+				description: 'Generate metadata for the content to optimize SEO.',
+			} )
+		);
+	} );
+
 	it( 'shows Generate Excerpt when the excerptSuggestion feature is enabled', () => {
 		installAiEditorialReviewData( { excerptSuggestion: true } );
 		installPostTypeMock( 'post' );
@@ -2012,7 +2077,7 @@ describe( 'getEmptyViewSuggestions', () => {
 		);
 
 		expect( excerptChip?.label ).toBe( 'Generate Excerpt' );
-		expect( excerptChip?.prompt ).toBe( 'Generate an excerpt for this post' );
+		expect( excerptChip?.prompt ).toBe( 'Generate an excerpt for this content' );
 	} );
 
 	it( 'hides Generate Excerpt when the feature is disabled', () => {
@@ -2122,17 +2187,17 @@ describe( 'getEmptyViewSuggestions', () => {
 			{
 				id: 'seo-title',
 				label: 'Title',
-				value: 'Generate an SEO title (meta title) for this post',
+				value: 'Generate an SEO title (meta title) for this content',
 			},
 			{
 				id: 'seo-description',
 				label: 'Description',
-				value: 'Generate an SEO meta description for this post',
+				value: 'Generate an SEO meta description for this content',
 			},
 			{
 				id: 'image-alt-text',
 				label: 'Image Alt Text',
-				value: 'Generate descriptive alt text for the images in this post',
+				value: 'Generate descriptive alt text for the images in this content',
 			},
 		] );
 	} );

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -94,10 +94,10 @@ const OPTIMIZE_TITLE_SUGGESTION = {
 	id: 'optimize-title',
 	label: __( 'Optimize Title', __i18n_text_domain__ ),
 	description: __(
-		'Refine the title based on your post’s content and SEO best practices.',
+		'Refine the title based on your content and SEO best practices.',
 		__i18n_text_domain__
 	),
-	prompt: __( 'Optimize the title of this post', __i18n_text_domain__ ),
+	prompt: __( 'Optimize the title of this content', __i18n_text_domain__ ),
 };
 
 /**
@@ -109,8 +109,8 @@ const OPTIMIZE_TITLE_SUGGESTION = {
 const GENERATE_EXCERPT_SUGGESTION = {
 	id: 'generate-excerpt',
 	label: __( 'Generate Excerpt', __i18n_text_domain__ ),
-	description: __( 'Generate an excerpt for your post.', __i18n_text_domain__ ),
-	prompt: __( 'Generate an excerpt for this post', __i18n_text_domain__ ),
+	description: __( 'Generate an excerpt for your content.', __i18n_text_domain__ ),
+	prompt: __( 'Generate an excerpt for this content', __i18n_text_domain__ ),
 };
 
 /**
@@ -132,27 +132,24 @@ const GENERATE_EXCERPT_SUGGESTION = {
 const SEO_ENHANCER_SUGGESTION = {
 	id: 'seo-enhancer',
 	label: __( 'SEO Enhancer', __i18n_text_domain__ ),
-	description: __(
-		'Generate metadata for the contents of the post to optimize SEO.',
-		__i18n_text_domain__
-	),
+	description: __( 'Generate metadata for the content to optimize SEO.', __i18n_text_domain__ ),
 	prompt: '',
 	options: [
 		{
 			id: 'seo-title',
 			label: _x( 'Title', 'SEO Enhancer dropdown option', __i18n_text_domain__ ),
-			value: __( 'Generate an SEO title (meta title) for this post', __i18n_text_domain__ ),
+			value: __( 'Generate an SEO title (meta title) for this content', __i18n_text_domain__ ),
 		},
 		{
 			id: 'seo-description',
 			label: _x( 'Description', 'SEO Enhancer dropdown option', __i18n_text_domain__ ),
-			value: __( 'Generate an SEO meta description for this post', __i18n_text_domain__ ),
+			value: __( 'Generate an SEO meta description for this content', __i18n_text_domain__ ),
 		},
 		{
 			id: 'image-alt-text',
 			label: _x( 'Image Alt Text', 'SEO Enhancer dropdown option', __i18n_text_domain__ ),
 			value: __(
-				'Generate descriptive alt text for the images in this post',
+				'Generate descriptive alt text for the images in this content',
 				__i18n_text_domain__
 			),
 		},
@@ -165,7 +162,7 @@ const AI_EDITORIAL_REVIEW_SUGGESTION = {
 	label: __( 'Editorial Review', __i18n_text_domain__ ),
 	description: __( 'In-depth review against your content guidelines.', __i18n_text_domain__ ),
 	prompt: __(
-		'Run an AI Editorial Review for this post. Check the content, reviewer notes, and site guidelines, then surface conflicts, implications, guideline issues, and suggested edits.',
+		'Run an AI Editorial Review for this content. Check the content, reviewer notes, and site guidelines, then surface conflicts, implications, guideline issues, and suggested edits.',
 		__i18n_text_domain__
 	),
 };
@@ -175,7 +172,7 @@ const POST_FEEDBACK_SUGGESTION = {
 	label: __( 'Simple Review', __i18n_text_domain__ ),
 	description: __( 'Quick feedback on your content’s structure.', __i18n_text_domain__ ),
 	prompt: __(
-		'Generate feedback for this saved post. Review the saved title and saved block content for content structure, reader clarity, completeness, media/caption/link issues, and obvious publishability concerns. Return practical feedback with one-click suggestions when safe.',
+		'Generate feedback for this saved content. Review the saved title and saved block content for content structure, reader clarity, completeness, media/caption/link issues, and obvious publishability concerns. Return practical feedback with one-click suggestions when safe.',
 		__i18n_text_domain__
 	),
 };
@@ -185,7 +182,7 @@ const PROOFREAD_SUGGESTION = {
 	label: __( 'Proofread', __i18n_text_domain__ ),
 	description: __( 'Correct spelling, grammar, and punctuation.', __i18n_text_domain__ ),
 	prompt: __(
-		'Proofread this saved post for spelling, grammar, and punctuation. Review the saved title and saved block content, and return practical fixes with one-click suggestions when safe.',
+		'Proofread this saved content for spelling, grammar, and punctuation. Review the saved title and saved block content, and return practical fixes with one-click suggestions when safe.',
 		__i18n_text_domain__
 	),
 };


### PR DESCRIPTION
## Proposed Changes

* Replace post-specific Jetpack AI sidebar copy with neutral `content` wording across editor-level suggestions, starter prompts, title/excerpt/SEO pickers, review messages, and content-wide references.
* Add focused assertions for the shared page-editor prompts, picker introductions, cached-review copy, stale warnings, and content-wide labels.
* Keep WordPress post/page contracts, capability gates, context payloads, component identifiers, CSS classes, URLs, and provider-generated prose unchanged.

## Why are these changes being made?

The writing tools support both post and page editors, but their deterministic frontend copy still referred to the current item as a post. Because the same suggestions and picker components are shared across both editors, page users saw post-specific wording.

Using `content` keeps the UI accurate without adding editor-aware branching or changing any underlying WordPress behavior. These source-string changes will refresh the corresponding translation entries; the internal `post` identifiers remain intentionally unchanged for compatibility.

## Testing Instructions

Automated checks:

* `./node_modules/.bin/jest -c=test/packages/jest.config.js --runInBand --no-watchman packages/jetpack-ai-sidebar` — 17 suites and 359 tests passed.
* `ESLINT_USE_FLAT_CONFIG=false ./node_modules/.bin/eslint packages/jetpack-ai-sidebar/src/` — passed.
* Package TypeScript no-emit compile — passed.
* Prettier check for all changed files — passed.
* `git diff --check origin/trunk...HEAD` — passed.

Manual verification:

1. Open the AI sidebar in a page editor with no block selected.
2. Confirm the editor-level suggestion descriptions and prompts refer to `content`, not a post or page.
3. Open the title, excerpt, SEO title, and SEO description pickers and confirm each introduction uses `content`.
4. Open Simple Review, Proofread, and Editorial Review results and confirm content-wide, stale-context, and cached-review messages use neutral wording.
5. Confirm block selection behavior, post/page availability gates, and the underlying editor actions are unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?