### PR TITLE
Jetpack AI Sidebar: Restore suggestions after title and excerpt updates

### DIFF
--- a/packages/jetpack-ai-sidebar/src/components/excerpt-picker.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/excerpt-picker.test.tsx
@@ -7,6 +7,7 @@
 import '@testing-library/jest-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
+import { SUGGESTION_ACTION_COMPLETE_EVENT } from '../utils/suggestion-events';
 import ExcerptPicker from './excerpt-picker';
 
 const mockEditPost = jest.fn();
@@ -69,6 +70,20 @@ describe( 'ExcerptPicker', () => {
 		fireEvent.click( button );
 		expect( button ).toHaveAttribute( 'aria-pressed', 'true' );
 		expect( onComplete ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'notifies the sidebar when an excerpt is applied', () => {
+		const handleComplete = jest.fn();
+		window.addEventListener( SUGGESTION_ACTION_COMPLETE_EVENT, handleComplete );
+		try {
+			render( <ExcerptPicker excerpts={ excerpts } /> );
+
+			fireEvent.click( screen.getByText( excerpts[ 0 ].excerpt ) );
+
+			expect( handleComplete ).toHaveBeenCalledTimes( 1 );
+		} finally {
+			window.removeEventListener( SUGGESTION_ACTION_COMPLETE_EVENT, handleComplete );
+		}
 	} );
 
 	it( 'renders no options without crashing when the excerpts prop is malformed', () => {

--- a/packages/jetpack-ai-sidebar/src/components/excerpt-picker.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/excerpt-picker.tsx
@@ -16,6 +16,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { notifySuggestionActionComplete } from '../utils/suggestion-events';
 import BaseSuggestionPicker from './base-suggestion-picker';
 
 /**
@@ -49,6 +50,7 @@ export default function ExcerptPicker( { excerpts, onComplete }: ExcerptPickerPr
 	const handleApply = useCallback(
 		( excerpt: string ) => {
 			editPost( { excerpt } );
+			notifySuggestionActionComplete();
 			onComplete?.();
 		},
 		[ editPost, onComplete ]

--- a/packages/jetpack-ai-sidebar/src/components/title-picker.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/title-picker.test.tsx
@@ -7,6 +7,7 @@
 import '@testing-library/jest-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
+import { SUGGESTION_ACTION_COMPLETE_EVENT } from '../utils/suggestion-events';
 import TitlePicker from './title-picker';
 
 const mockEditPost = jest.fn();
@@ -59,6 +60,20 @@ describe( 'TitlePicker', () => {
 		render( <TitlePicker titles={ titles } onComplete={ onComplete } /> );
 		fireEvent.click( screen.getByText( titles[ 1 ].title ) );
 		expect( onComplete ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'notifies the sidebar when a title is applied', () => {
+		const handleComplete = jest.fn();
+		window.addEventListener( SUGGESTION_ACTION_COMPLETE_EVENT, handleComplete );
+		try {
+			render( <TitlePicker titles={ titles } /> );
+
+			fireEvent.click( screen.getByText( titles[ 0 ].title ) );
+
+			expect( handleComplete ).toHaveBeenCalledTimes( 1 );
+		} finally {
+			window.removeEventListener( SUGGESTION_ACTION_COMPLETE_EVENT, handleComplete );
+		}
 	} );
 
 	it( 'marks the option matching the current post title as applied on mount', () => {

--- a/packages/jetpack-ai-sidebar/src/components/title-picker.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/title-picker.tsx
@@ -15,6 +15,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { notifySuggestionActionComplete } from '../utils/suggestion-events';
 import BaseSuggestionPicker from './base-suggestion-picker';
 
 /**
@@ -50,6 +51,7 @@ export default function TitlePicker( { titles, onComplete }: TitlePickerProps ) 
 	const handleApply = useCallback(
 		( title: string ) => {
 			editPost( { title } );
+			notifySuggestionActionComplete();
 			onComplete?.();
 		},
 		[ editPost, onComplete ]

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -19,6 +19,7 @@ import SeoDescriptionPicker from './components/seo-description-picker';
 import SeoTitlePicker from './components/seo-title-picker';
 import TitlePicker from './components/title-picker';
 import { clearActiveBlockFocus, undoBlockEdit } from './utils/block-actions';
+import { SUGGESTION_ACTION_COMPLETE_EVENT } from './utils/suggestion-events';
 import {
 	applyReviewEdit,
 	findBlockElement,
@@ -2630,6 +2631,35 @@ describe( 'useSuggestions', () => {
 			'Check grammar',
 			'Simplify text',
 		] );
+	} );
+
+	it( 're-shows editor suggestions when a generated title is applied', () => {
+		installAiEditorialReviewData( { optimizeTitleSuggestion: true } );
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		act( () => {
+			window.dispatchEvent(
+				new CustomEvent( 'big-sky-inline-suggestion-click', {
+					detail: { suggestionId: 'optimize-title' },
+				} )
+			);
+		} );
+
+		let latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions ).toEqual( [] );
+
+		act( () => {
+			window.dispatchEvent( new Event( SUGGESTION_ACTION_COMPLETE_EVENT ) );
+		} );
+
+		latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect(
+			latestSuggestions.map( ( suggestion: { label: string } ) => suggestion.label )
+		).toEqual( [ 'Optimize Title', 'Simple Review', 'Editorial Review' ] );
 	} );
 
 	it( 'keeps block suggestions hidden after a Proofread request finishes', () => {

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -58,6 +58,7 @@ import {
 	isOptimizeTitleSuggestionEnabled,
 	isSeoSuggestionsEnabled,
 } from './utils/preview-features';
+import { SUGGESTION_ACTION_COMPLETE_EVENT } from './utils/suggestion-events';
 import {
 	UPDATE_BLOCK_CONTENT_TOOL_ID,
 	UPDATE_BLOCK_CONTENT_ABILITY,
@@ -1155,8 +1156,8 @@ export const capabilities = {
  * Block-aware dynamic suggestions for the AM sidebar.
  *
  * Returns contextual suggestions based on the selected block type.
- * Hides after a suggestion is clicked, then restores block suggestions only
- * after a block action completes.
+ * Hides after a suggestion is clicked, then restores suggestions after a
+ * suggestion action completes.
  * @returns {Object} Object containing a suggestions array.
  */
 export function useSuggestions(
@@ -1199,6 +1200,17 @@ export function useSuggestions(
 		window.addEventListener( 'big-sky-inline-suggestion-click', handleSuggestionClick, true );
 		return () => {
 			window.removeEventListener( 'big-sky-inline-suggestion-click', handleSuggestionClick, true );
+		};
+	}, [] );
+
+	useEffect( () => {
+		const handleSuggestionActionComplete = () => setHidden( false );
+		window.addEventListener( SUGGESTION_ACTION_COMPLETE_EVENT, handleSuggestionActionComplete );
+		return () => {
+			window.removeEventListener(
+				SUGGESTION_ACTION_COMPLETE_EVENT,
+				handleSuggestionActionComplete
+			);
 		};
 	}, [] );
 

--- a/packages/jetpack-ai-sidebar/src/utils/suggestion-events.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/suggestion-events.ts
@@ -1,0 +1,9 @@
+export const SUGGESTION_ACTION_COMPLETE_EVENT = 'jetpack-ai-sidebar-suggestion-action-complete';
+
+export function notifySuggestionActionComplete(): void {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+
+	window.dispatchEvent( new Event( SUGGESTION_ACTION_COMPLETE_EVENT ) );
+}


### PR DESCRIPTION
Fixes FORNO-448

## Proposed Changes

* Restore the post-wide Jetpack AI Sidebar suggestions after a generated title or excerpt is applied.
* Emit a shared completion signal from the title and excerpt pickers after updating the editor.
* Cover both picker notifications and the hide-to-restore suggestion state transition with focused tests.

## Why are these changes being made?

Selecting a post-wide suggestion hides and clears the suggestion row while the action runs. Block actions already publish a completion event that restores the row, but the generated title and excerpt pickers only updated the editor and their local chat callback. Their actions never reset the suggestion hook's hidden state, so the bottom actions remained absent after applying a result.

This adds the equivalent completion contract for the two reproduced picker flows without changing block-action behavior.

## Testing Instructions

Automated checks:

* `yarn test-packages packages/jetpack-ai-sidebar --runInBand --no-watchman` — 17 suites and 360 tests passed.
* Targeted ESLint and Prettier checks for all changed files.
* `yarn tsc --noEmit --project packages/jetpack-ai-sidebar/tsconfig.json --pretty false`
* `yarn workspace @automattic/jetpack-ai-sidebar build`
* `yarn typecheck-packages`
* Required Claude review loop completed with no blockers.

Manual browser verification on a Simple sandbox:

1. Open a draft post with no block selected and confirm the post-wide actions are visible.
2. Run Optimize Title and apply a generated title.
3. Confirm the title updates and all post-wide actions reappear.
5. Run Generate Excerpt and apply a generated excerpt.
6. Confirm the excerpt updates and all post-wide actions reappear.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g. browsers), interfaces (e.g. keyboard navigation), and assistive technologies (e.g. screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
