### PR TITLE
Purchases: read the purchases list from api-core

### DIFF
--- a/client/me/purchases/lib/raw-purchase-helpers.ts
+++ b/client/me/purchases/lib/raw-purchase-helpers.ts
@@ -203,6 +203,18 @@ export function isWithinIntroductoryOfferPeriod( purchase: Purchase ): boolean {
 	return purchase.introductory_offer?.is_within_period ?? false;
 }
 
+export function isIntroductoryOfferFreeTrial( purchase: Purchase ): boolean {
+	return purchase.introductory_offer?.cost_per_interval === 0;
+}
+
+export function mightStillAutoRenew( purchase: Purchase ): boolean {
+	return purchase.might_still_auto_renew;
+}
+
+export function getPartnerName( purchase: Purchase ): string | null {
+	return isPartnerPurchase( purchase ) ? purchase.partner_name ?? null : null;
+}
+
 export function canEditPaymentDetails( purchase: Purchase ): boolean {
 	return (
 		// Normally a purchase past its expiry date can't have its payment details

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -1,3 +1,4 @@
+import { getPurchasePayment, isPurchaseOneTimePurchase } from '@automattic/api-core';
 import {
 	isDomainTransfer,
 	isDomainRegistration,
@@ -31,7 +32,17 @@ import SiteIcon from 'calypso/blocks/site-icon';
 import InfoPopover from 'calypso/components/info-popover';
 import { withLocalizedMoment, useLocalizedMoment } from 'calypso/components/localized-moment';
 import { getCalendarDaysUntil, getRelativeDayString } from 'calypso/dashboard/utils/datetime';
-import { EXPIRY_ERROR_DAYS, EXPIRY_WARNING_DAYS } from 'calypso/dashboard/utils/purchase';
+import {
+	EXPIRY_ERROR_DAYS,
+	EXPIRY_WARNING_DAYS,
+	isA4ABillingDragonPurchase,
+	isA4AHoldingSitePurchase,
+	isAkismetHoldingSitePurchase,
+	isJetpackHoldingSitePurchase,
+	isMarketplaceHoldingSitePurchase,
+	isPartnerPurchase,
+	isTransferredOwnership,
+} from 'calypso/dashboard/utils/purchase';
 import {
 	getExpiredCopy,
 	getExpiredRenewalTitle,
@@ -40,6 +51,8 @@ import {
 } from 'calypso/dashboard/utils/purchase-expiry-copy';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { handleRenewNowClick } from 'calypso/lib/purchases';
+import { createPurchaseObject } from 'calypso/lib/purchases/assembler';
 import {
 	getDisplayName,
 	isExpiredOrRemoved,
@@ -47,8 +60,6 @@ import {
 	isExpiring,
 	isRechargeable,
 	isIncludedWithPlan,
-	isOneTimePurchase,
-	isPartnerPurchase,
 	isRenewable,
 	isCloseToExpiration,
 	isRenewingBeforeExpiration,
@@ -62,23 +73,15 @@ import {
 	hasPaymentMethod,
 	isPaidWithCredits,
 	mightStillAutoRenew,
-	handleRenewNowClick,
-} from 'calypso/lib/purchases';
+} from 'calypso/me/purchases/lib/raw-purchase-helpers';
 import { getPurchaseListUrlFor } from 'calypso/my-sites/purchases/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import getSiteIconUrl from 'calypso/state/selectors/get-site-icon-url';
 import { getSite } from 'calypso/state/sites/selectors';
-import { isTransferredOwnership } from '../hooks/use-is-transferred-ownership';
-import {
-	isJetpackHoldingSitePurchase,
-	isAkismetHoldingSitePurchase,
-	isMarketplaceHoldingSitePurchase,
-	isA4AHoldingSitePurchase,
-	isA4ABillingDragonPurchase,
-} from '../utils';
 import OwnerInfo from './owner-info';
-import type { Purchases, SiteDetails } from '@automattic/data-stores';
+import type { Purchase } from '@automattic/api-core';
+import type { SiteDetails } from '@automattic/data-stores';
 import 'calypso/me/purchases/style.scss';
 import type { Site } from 'calypso/blocks/site-icon';
 import type { ExpiryStatusCopy } from 'calypso/dashboard/utils/purchase-expiry-copy';
@@ -94,7 +97,7 @@ interface PurchaseItemPropsPlaceholder {
 
 interface PurchaseItemProps {
 	getManagePurchaseUrlFor: GetManagePurchaseUrlFor;
-	purchase: Purchases.Purchase;
+	purchase: Purchase;
 	site?: SiteDetails | null | undefined;
 	slug?: string;
 	showSite?: boolean;
@@ -102,7 +105,7 @@ interface PurchaseItemProps {
 	isJetpack?: boolean;
 	isDisconnectedSite?: boolean;
 	isBackupMethodAvailable?: boolean;
-	transferredOwnershipPurchases?: Purchases.Purchase[];
+	transferredOwnershipPurchases?: Purchase[];
 }
 
 interface PurchaseItemPropsConnected {
@@ -127,7 +130,7 @@ export function PurchaseItemSiteIcon( {
 	purchase,
 	iconUrl,
 }: {
-	purchase: Purchases.Purchase;
+	purchase: Purchase;
 	site?: Site | null | undefined;
 	isDisconnectedSite?: boolean;
 	iconUrl?: string | null;
@@ -142,7 +145,7 @@ export function PurchaseItemSiteIcon( {
 		);
 	}
 	if ( isMarketplaceHoldingSitePurchase( purchase ) ) {
-		if ( purchase.productSlug.startsWith( 'passport' ) ) {
+		if ( purchase.product_slug.startsWith( 'passport' ) ) {
 			content = (
 				<div className="purchase-item__static-icon">
 					<img src={ passportIcon } alt="Passport icon" />
@@ -182,14 +185,14 @@ export function PurchaseItemProduct( {
 	showSite,
 	isDisconnectedSite,
 }: {
-	purchase: Purchases.Purchase;
+	purchase: Purchase;
 	site?: SiteDetails | null | undefined;
 	translate: LocalizeProps[ 'translate' ];
 	slug?: string | number | null;
 	showSite?: boolean;
 	isDisconnectedSite?: boolean;
 } ) {
-	if ( purchase.isAttachedToHoldingSite ) {
+	if ( purchase.is_attached_to_holding_site ) {
 		return null;
 	}
 
@@ -342,7 +345,7 @@ function UrgentExpiryStatus( {
 	isDisconnectedSite,
 	impression,
 }: {
-	purchase: Purchases.Purchase;
+	purchase: Purchase;
 	copy: ExpiryStatusCopy;
 
 	/**
@@ -367,7 +370,7 @@ function UrgentExpiryStatus( {
 	const dispatch = useDispatch();
 	const moment = useLocalizedMoment();
 	const currentUserId = useSelector( getCurrentUserId );
-	const expiry = moment( purchase.expiryDate );
+	const expiry = moment( purchase.expiry_date );
 	const className =
 		copy.intent === 'error' ? 'purchase-item__is-error' : 'purchase-item__is-warning';
 	const expiryText = copy.text ?? untranslatedFallbackText;
@@ -378,11 +381,6 @@ function UrgentExpiryStatus( {
 	// conditions, and it isn't clear whether the difference between the two is
 	// intentional; these were copied from the header control because the link
 	// below is prominent in the same way that one is.
-	//
-	// Repeated rather than shared because that page reads the raw
-	// `@automattic/api-core` purchase and this list still reads the camelCase
-	// `@automattic/data-stores` one (SHILL-2256), so each side needs different
-	// field names.
 	const canRenewNow =
 		( ! isPartnerPurchase( purchase ) || isA4ABillingDragonPurchase( purchase ) ) &&
 		isRenewable( purchase ) &&
@@ -392,16 +390,16 @@ function UrgentExpiryStatus( {
 			isA4ABillingDragonPurchase( purchase ) ) &&
 		! isAkismetFreeProduct( purchase ) &&
 		! ( is100Year( purchase ) && ! isCloseToExpiration( purchase ) ) &&
-		purchase.canExplicitRenew &&
-		purchase.userId === currentUserId &&
-		! purchase.isLocked;
+		purchase.can_explicit_renew &&
+		purchase.user_id === currentUserId &&
+		! purchase.is_locked;
 
 	// How close to expiry a subscription has to be before renewal is worth
 	// offering. A monthly subscription is never far from expiring, so the annual
 	// window would ask for a renewal within days of the purchase; it gets the
 	// last week instead. Anything already past its expiry date is inside either.
 	const renewalWindowDays =
-		purchase.billPeriodDays === PLAN_MONTHLY_PERIOD ? EXPIRY_ERROR_DAYS : EXPIRY_WARNING_DAYS;
+		purchase.bill_period_days === PLAN_MONTHLY_PERIOD ? EXPIRY_ERROR_DAYS : EXPIRY_WARNING_DAYS;
 	const daysUntilExpiry = getCalendarDaysUntil( expiry.toDate() );
 	const isRenewalWorthOffering = canRenewNow && daysUntilExpiry <= renewalWindowDays;
 
@@ -434,11 +432,19 @@ function UrgentExpiryStatus( {
 					// listing page can run on other hosts like Jetpack Cloud and A4A.
 					const backUrl = window.location.href;
 					dispatch(
-						handleRenewNowClick( purchase, purchase.siteSlug ?? '', {
-							redirectTo: backUrl,
-							cancelTo: backUrl,
-							tracksProps: { position: 'purchase-list' },
-						} )
+						// Temporary bridge (SHILL-2256): handleRenewNowClick still expects
+						// the camelCase Purchase. Remove once it reads the raw shape.
+						handleRenewNowClick(
+							createPurchaseObject(
+								purchase as unknown as Parameters< typeof createPurchaseObject >[ 0 ]
+							),
+							purchase.site_slug ?? '',
+							{
+								redirectTo: backUrl,
+								cancelTo: backUrl,
+								tracksProps: { position: 'purchase-list' },
+							}
+						)
 					);
 				} }
 			>
@@ -456,12 +462,12 @@ export function PurchaseItemStatus( {
 	moment,
 	isDisconnectedSite,
 }: {
-	purchase: Purchases.Purchase;
+	purchase: Purchase;
 	translate: LocalizeProps[ 'translate' ];
 	moment: ReturnType< typeof useLocalizedMoment >;
 	isDisconnectedSite?: boolean;
 } ) {
-	const expiry = moment( purchase.expiryDate );
+	const expiry = moment( purchase.expiry_date );
 
 	// @todo: There isn't currently a way to get the taxName based on the
 	// country. The country is not included in the purchase information
@@ -524,7 +530,7 @@ export function PurchaseItemStatus( {
 			);
 		}
 
-		if ( purchase.isJetpackPlanOrProduct ) {
+		if ( purchase.is_jetpack_plan_or_product ) {
 			return (
 				<span className="purchase-item__is-error">
 					{ translate( 'Disconnected from WordPress.com' ) }
@@ -556,12 +562,12 @@ export function PurchaseItemStatus( {
 		);
 	}
 
-	if ( purchase.isInAppPurchase && purchase.iapPurchaseManagementLink ) {
+	if ( purchase.is_iap_purchase && purchase.iap_purchase_management_link ) {
 		return translate(
 			'This product is an in-app purchase. You can manage it from within {{managePurchase}}the app store{{/managePurchase}}.',
 			{
 				components: {
-					managePurchase: <a href={ purchase.iapPurchaseManagementLink } />,
+					managePurchase: <a href={ purchase.iap_purchase_management_link } />,
 				},
 			}
 		);
@@ -578,7 +584,7 @@ export function PurchaseItemStatus( {
 				{
 					args: {
 						date: expiry.format( 'LL' ),
-						amount: formatCurrency( purchase.priceInteger, purchase.currencyCode, {
+						amount: formatCurrency( purchase.price_integer, purchase.currency_code, {
 							isSmallestUnit: true,
 							stripZeros: true,
 						} ),
@@ -610,8 +616,8 @@ export function PurchaseItemStatus( {
 		);
 	}
 
-	if ( isRenewingBeforeExpiration( purchase ) && purchase.renewDate ) {
-		const renewDate = moment( purchase.renewDate );
+	if ( isRenewingBeforeExpiration( purchase ) && purchase.renew_date ) {
+		const renewDate = moment( purchase.renew_date );
 
 		if ( creditCardHasAlreadyExpired( purchase ) ) {
 			return (
@@ -644,9 +650,9 @@ export function PurchaseItemStatus( {
 		// When a downgrade is scheduled for the next renewal, the plan won't simply
 		// renew at its current price — it changes to a lower-tier plan. Say so instead
 		// of the usual "Renews ... on <date>" line.
-		if ( purchase.isDelayedDowngradePending ) {
-			const targetPlanName = purchase.delayedDowngradeToProductSlug
-				? getPlan( purchase.delayedDowngradeToProductSlug )?.getTitle()
+		if ( purchase.is_delayed_downgrade_pending ) {
+			const targetPlanName = purchase.delayed_downgrade_to_product_slug
+				? getPlan( purchase.delayed_downgrade_to_product_slug )?.getTitle()
 				: null;
 			if ( targetPlanName ) {
 				return translate( 'Changing to %(plan)s on {{span}}%(date)s{{/span}}', {
@@ -669,10 +675,10 @@ export function PurchaseItemStatus( {
 			} );
 		}
 
-		if ( purchase.billPeriodDays ) {
+		if ( purchase.bill_period_days ) {
 			const translateOptions = {
 				args: {
-					amount: formatCurrency( purchase.priceInteger, purchase.currencyCode, {
+					amount: formatCurrency( purchase.price_integer, purchase.currency_code, {
 						isSmallestUnit: true,
 						stripZeros: true,
 					} ),
@@ -684,7 +690,7 @@ export function PurchaseItemStatus( {
 					span: <span className="purchase-item__date" />,
 				},
 			};
-			switch ( purchase.billPeriodDays ) {
+			switch ( purchase.bill_period_days ) {
 				case PLAN_MONTHLY_PERIOD:
 					return translate(
 						'Renews monthly at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
@@ -712,7 +718,7 @@ export function PurchaseItemStatus( {
 			'Renews at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
 			{
 				args: {
-					amount: formatCurrency( purchase.priceInteger, purchase.currencyCode, {
+					amount: formatCurrency( purchase.price_integer, purchase.currency_code, {
 						isSmallestUnit: true,
 						stripZeros: true,
 					} ),
@@ -789,7 +795,7 @@ export function PurchaseItemStatus( {
 	}
 
 	if (
-		( isOneTimePurchase( purchase ) || isAkismetFreeProduct( purchase ) ) &&
+		( isPurchaseOneTimePurchase( purchase ) || isAkismetFreeProduct( purchase ) ) &&
 		! isDomainTransfer( purchase )
 	) {
 		return translate( 'Never Expires' );
@@ -803,7 +809,7 @@ export function PurchaseItemPaymentMethod( {
 	translate,
 	isDisconnectedSite,
 }: {
-	purchase: Purchases.Purchase;
+	purchase: Purchase;
 	translate: LocalizeProps[ 'translate' ];
 	isDisconnectedSite?: boolean;
 } ) {
@@ -815,7 +821,7 @@ export function PurchaseItemPaymentMethod( {
 		return translate( 'Included with Plan' );
 	}
 
-	if ( purchase.isInAppPurchase ) {
+	if ( purchase.is_iap_purchase ) {
 		return (
 			<div>
 				<span>{ translate( 'In-App Purchase' ) }</span>
@@ -841,7 +847,7 @@ export function PurchaseItemPaymentMethod( {
 	};
 
 	if (
-		purchase.isAutoRenewEnabled &&
+		purchase.is_auto_renew_enabled &&
 		( ! hasPaymentMethod( purchase ) || isPaidWithCredits( purchase ) ) &&
 		! isExpiredWithNoAutoRenewAttemptsLeft( purchase ) &&
 		! isPartnerPurchase( purchase ) &&
@@ -854,7 +860,7 @@ export function PurchaseItemPaymentMethod( {
 						variant="link"
 						size="compact"
 						onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) =>
-							goToAddPaymentMethod( e, purchase.siteId, purchase.id )
+							goToAddPaymentMethod( e, purchase.blog_id, purchase.ID )
 						}
 					>
 						{ translate( 'Add payment method' ) }
@@ -868,7 +874,7 @@ export function PurchaseItemPaymentMethod( {
 		! isAkismetFreeProduct( purchase ) &&
 		! isRechargeable( purchase ) &&
 		hasPaymentMethod( purchase ) && // why does it check for payment method type but shows missing method?
-		purchase.isAutoRenewEnabled
+		purchase.is_auto_renew_enabled
 	) {
 		return (
 			<div className="purchase-item__no-payment-method">
@@ -879,10 +885,12 @@ export function PurchaseItemPaymentMethod( {
 	}
 
 	if ( mightStillAutoRenew( purchase ) ) {
-		if ( purchase.payment.type === 'credit_card' && purchase.payment.creditCard ) {
-			const paymentMethodType = purchase.payment.creditCard.displayBrand
-				? purchase.payment.creditCard.displayBrand
-				: purchase.payment.creditCard.type || purchase.payment.paymentPartner || '';
+		const payment = getPurchasePayment( purchase );
+
+		if ( payment.type === 'credit_card' && payment.creditCard ) {
+			const paymentMethodType = payment.creditCard.displayBrand
+				? payment.creditCard.displayBrand
+				: payment.creditCard.type || '';
 
 			return (
 				<>
@@ -891,19 +899,17 @@ export function PurchaseItemPaymentMethod( {
 						alt={ paymentMethodType }
 						className="purchase-item__payment-method-card"
 					/>
-					{ purchase.payment.creditCard.number }
+					{ payment.creditCard.number }
 				</>
 			);
 		}
 
-		if ( purchase.payment.type === 'paypal' ) {
-			return (
-				<img src={ payPalImage } alt={ purchase.payment.type } className="purchase-item__paypal" />
-			);
+		if ( payment.type === 'paypal' ) {
+			return <img src={ payPalImage } alt={ payment.type } className="purchase-item__paypal" />;
 		}
 
-		if ( purchase.payment.type === 'upi' ) {
-			return <img src={ upiImage } alt={ purchase.payment.type } />;
+		if ( payment.type === 'upi' ) {
+			return <img src={ upiImage } alt={ payment.type } />;
 		}
 
 		return null;
@@ -957,7 +963,7 @@ class PurchaseItem extends Component<
 		} = this.props;
 
 		const isOwnershipTransferred = isTransferredOwnership(
-			purchase.id,
+			purchase.ID,
 			transferredOwnershipPurchases
 		);
 
@@ -1040,7 +1046,7 @@ class PurchaseItem extends Component<
 		} );
 
 		const isOwnershipTransferred = isTransferredOwnership(
-			purchase.id,
+			purchase.ID,
 			transferredOwnershipPurchases
 		);
 
@@ -1053,14 +1059,14 @@ class PurchaseItem extends Component<
 			// WPCOM generated temporary site, which is created during the siteless checkout flow. (currently Jetpack & Akismet can have siteless purchases).
 			if (
 				! isDisconnectedSite ||
-				purchase.isJetpackPlanOrProduct ||
-				purchase.isAttachedToHoldingSite ||
+				purchase.is_jetpack_plan_or_product ||
+				purchase.is_attached_to_holding_site ||
 				isA4ABillingDragonPurchase( purchase )
 			) {
 				onClick = () => {
 					window.scrollTo( 0, 0 );
 				};
-				href = getManagePurchaseUrlFor( slug, purchase.id );
+				href = getManagePurchaseUrlFor( slug, purchase.ID );
 			}
 		}
 

--- a/client/me/purchases/purchase-item/owner-info.tsx
+++ b/client/me/purchases/purchase-item/owner-info.tsx
@@ -1,8 +1,9 @@
 import { JETPACK_CONTACT_SUPPORT } from '@automattic/urls';
 import { useTranslate } from 'i18n-calypso';
 import InfoPopover from 'calypso/components/info-popover';
-import { Purchase } from 'calypso/lib/purchases/types';
-import { useIsUserPurchaseOwner } from 'calypso/state/purchases/utils';
+import { useSelector } from 'calypso/state';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import type { Purchase } from '@automattic/api-core';
 
 type OwnProps = {
 	purchase: Purchase;
@@ -11,9 +12,9 @@ type OwnProps = {
 
 const OwnerInfo: React.FC< OwnProps > = ( { purchase, isTransferredOwnership = false } ) => {
 	const translate = useTranslate();
-	const isCurrentUserPurchaseOwner = useIsUserPurchaseOwner();
+	const currentUserId = useSelector( getCurrentUserId );
 
-	if ( isCurrentUserPurchaseOwner( purchase ) ) {
+	if ( currentUserId === purchase.user_id ) {
 		return null;
 	}
 
@@ -23,7 +24,7 @@ const OwnerInfo: React.FC< OwnProps > = ( { purchase, isTransferredOwnership = f
 				"This license was activated on {{strong}}%(domain)s{{/strong}} by another user. If you haven't given the license to them on purpose, {{link}}contact our support team{{/link}} for more assistance.",
 				{
 					args: {
-						domain: purchase.domain || purchase.siteName || translate( 'a site' ),
+						domain: purchase.domain || purchase.blogname || translate( 'a site' ),
 					},
 					components: {
 						strong: <strong />,

--- a/client/me/purchases/purchase-item/owner-info.tsx
+++ b/client/me/purchases/purchase-item/owner-info.tsx
@@ -4,9 +4,15 @@ import InfoPopover from 'calypso/components/info-popover';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import type { Purchase } from '@automattic/api-core';
+import type { Purchase as CamelCasePurchase } from 'calypso/lib/purchases/types';
 
 type OwnProps = {
-	purchase: Purchase;
+	/**
+	 * Accepts either purchase shape because callers outside /me/purchases still
+	 * read the Redux-assembled camelCase one (SHILL-2256). Drop the camelCase
+	 * half once they don't.
+	 */
+	purchase: Purchase | CamelCasePurchase;
 	isTransferredOwnership?: boolean;
 };
 
@@ -14,7 +20,16 @@ const OwnerInfo: React.FC< OwnProps > = ( { purchase, isTransferredOwnership = f
 	const translate = useTranslate();
 	const currentUserId = useSelector( getCurrentUserId );
 
-	if ( currentUserId === purchase.user_id ) {
+	// The camelCase shape carries a `userIsOwner` flag that the raw purchase has
+	// no equivalent for; some callers pass a site plan, which only sets that flag
+	// and no owner id.
+	const isOwner =
+		'user_id' in purchase
+			? currentUserId === purchase.user_id
+			: purchase.userIsOwner || currentUserId === purchase.userId;
+	const siteName = 'blogname' in purchase ? purchase.blogname : purchase.siteName;
+
+	if ( isOwner ) {
 		return null;
 	}
 
@@ -24,7 +39,7 @@ const OwnerInfo: React.FC< OwnProps > = ( { purchase, isTransferredOwnership = f
 				"This license was activated on {{strong}}%(domain)s{{/strong}} by another user. If you haven't given the license to them on purpose, {{link}}contact our support team{{/link}} for more assistance.",
 				{
 					args: {
-						domain: purchase.domain || purchase.blogname || translate( 'a site' ),
+						domain: purchase.domain || siteName || translate( 'a site' ),
 					},
 					components: {
 						strong: <strong />,

--- a/client/me/purchases/purchase-item/test/index.js
+++ b/client/me/purchases/purchase-item/test/index.js
@@ -27,10 +27,10 @@ describe( 'PurchaseItem', () => {
 
 	describe( 'a purchase that expired earlier today', () => {
 		const purchase = {
-			productSlug: 'business-bundle',
-			expiryStatus: 'expired',
-			subscriptionStatus: 'active',
-			expiryDate: '2026-02-24T08:00:00+00:00',
+			product_slug: 'business-bundle',
+			expiry_status: 'expired',
+			subscription_status: 'active',
+			expiry_date: '2026-02-24T08:00:00+00:00',
 		};
 
 		test( 'should be described as "Expired today"', () => {
@@ -55,10 +55,10 @@ describe( 'PurchaseItem', () => {
 
 	describe( 'a purchase that expired on an earlier day', () => {
 		const purchase = {
-			productSlug: 'business-bundle',
-			expiryStatus: 'expired',
-			subscriptionStatus: 'active',
-			expiryDate: '2026-02-21T08:00:00+00:00',
+			product_slug: 'business-bundle',
+			expiry_status: 'expired',
+			subscription_status: 'active',
+			expiry_date: '2026-02-21T08:00:00+00:00',
 		};
 
 		test( 'should be described with how long ago it expired', () => {
@@ -70,10 +70,10 @@ describe( 'PurchaseItem', () => {
 
 	describe( 'a purchase that expires later today', () => {
 		const purchase = {
-			productSlug: 'business-bundle',
-			expiryStatus: 'manualRenew',
-			subscriptionStatus: 'active',
-			expiryDate: '2026-02-24T23:00:00+00:00',
+			product_slug: 'business-bundle',
+			expiry_status: 'manual-renew',
+			subscription_status: 'active',
+			expiry_date: '2026-02-24T23:00:00+00:00',
 		};
 
 		test( 'should be described as "Expires today" rather than a count of hours', () => {
@@ -88,10 +88,10 @@ describe( 'PurchaseItem', () => {
 		// The backend does not flip expiry_status the moment the date passes, so
 		// this state is reachable for a while after expiry.
 		const purchase = {
-			productSlug: 'business-bundle',
-			expiryStatus: 'manualRenew',
-			subscriptionStatus: 'active',
-			expiryDate: '2026-02-23T23:00:00+00:00',
+			product_slug: 'business-bundle',
+			expiry_status: 'manual-renew',
+			subscription_status: 'active',
+			expiry_date: '2026-02-23T23:00:00+00:00',
 		};
 
 		test( 'should say "Expires today", never a past interval in a future sentence', () => {
@@ -104,10 +104,10 @@ describe( 'PurchaseItem', () => {
 
 	describe( 'a purchase removed before its expiry date', () => {
 		const purchase = {
-			productSlug: 'business-bundle',
-			expiryStatus: 'expired',
-			subscriptionStatus: 'inactive',
-			expiryDate: '2026-02-27T23:00:00+00:00',
+			product_slug: 'business-bundle',
+			expiry_status: 'expired',
+			subscription_status: 'inactive',
+			expiry_date: '2026-02-27T23:00:00+00:00',
 		};
 
 		test( 'should not describe a future date as "Expired in N days"', () => {
@@ -120,11 +120,11 @@ describe( 'PurchaseItem', () => {
 
 	describe( 'a purchase expiring soon', () => {
 		const purchase = {
-			productSlug: 'business-bundle',
-			expiryStatus: 'manualRenew',
-			subscriptionStatus: 'active',
+			product_slug: 'business-bundle',
+			expiry_status: 'manual-renew',
+			subscription_status: 'active',
 			// Renders as February 27 in UTC, three calendar days out.
-			expiryDate: '2026-02-27T23:00:00+00:00',
+			expiry_date: '2026-02-27T23:00:00+00:00',
 		};
 
 		test( 'should count the same calendar days as the date it displays', () => {
@@ -139,11 +139,11 @@ describe( 'PurchaseItem', () => {
 
 	describe( 'a purchase expiring further out', () => {
 		const purchase = {
-			productSlug: 'business-bundle',
-			expiryStatus: 'manualRenew',
-			subscriptionStatus: 'active',
+			product_slug: 'business-bundle',
+			expiry_status: 'manual-renew',
+			subscription_status: 'active',
 			// 45 days out, which the relative-date helpers would round to "1 month".
-			expiryDate: '2026-04-10T12:00:00+00:00',
+			expiry_date: '2026-04-10T12:00:00+00:00',
 		};
 
 		test( 'should count the days exactly rather than rounding to months', () => {
@@ -155,11 +155,11 @@ describe( 'PurchaseItem', () => {
 
 	describe( 'a purchase expiring beyond the warning window', () => {
 		const purchase = {
-			productSlug: 'business-bundle',
-			expiryStatus: 'manualRenew',
-			subscriptionStatus: 'active',
+			product_slug: 'business-bundle',
+			expiry_status: 'manual-renew',
+			subscription_status: 'active',
 			// 90 days out.
-			expiryDate: '2026-05-25T12:00:00+00:00',
+			expiry_date: '2026-05-25T12:00:00+00:00',
 		};
 
 		test( 'should just say when it expires', () => {
@@ -172,9 +172,9 @@ describe( 'PurchaseItem', () => {
 
 	describe( 'an in-app purchase', () => {
 		const purchase = {
-			isInAppPurchase: true,
-			isAutoRenewEnabled: false,
-			subscriptionStatus: 'active',
+			is_iap_purchase: true,
+			is_auto_renew_enabled: false,
+			subscription_status: 'active',
 		};
 
 		test( 'should not display warning', () => {
@@ -193,9 +193,9 @@ describe( 'PurchaseItem', () => {
 
 	test( 'should display "Add payment method" button if auto-renew is enabled but no payment method', () => {
 		const purchase = {
-			productSlug: 'business-bundle',
-			isAutoRenewEnabled: true,
-			subscriptionStatus: 'active',
+			product_slug: 'business-bundle',
+			is_auto_renew_enabled: true,
+			subscription_status: 'active',
 		};
 
 		renderWithProvider( <PurchaseItem purchase={ purchase } /> );
@@ -205,9 +205,9 @@ describe( 'PurchaseItem', () => {
 
 	test( 'should not display warning if auto-renew is disabled with no payment method', () => {
 		const purchase = {
-			productSlug: 'business-bundle',
-			isAutoRenewEnabled: false,
-			subscriptionStatus: 'active',
+			product_slug: 'business-bundle',
+			is_auto_renew_enabled: false,
+			subscription_status: 'active',
 		};
 
 		renderWithProvider( <PurchaseItem purchase={ purchase } /> );

--- a/client/me/purchases/purchases-list-in-dataviews/hooks/use-field-definitions.ts
+++ b/client/me/purchases/purchases-list-in-dataviews/hooks/use-field-definitions.ts
@@ -1,4 +1,4 @@
-import { SiteDetails, Purchases } from '@automattic/data-stores';
+import { SiteDetails } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -8,6 +8,7 @@ import {
 	getPurchasesFieldDefinitions,
 	getMembershipsFieldDefinitions,
 } from '../purchases-data-field';
+import type { Purchase } from '@automattic/api-core';
 
 export function usePurchasesFieldDefinitions( {
 	sites,
@@ -16,7 +17,7 @@ export function usePurchasesFieldDefinitions( {
 	visibleFields,
 }: {
 	sites: SiteDetails[];
-	transferredOwnershipPurchases?: Purchases.Purchase[];
+	transferredOwnershipPurchases?: Purchase[];
 	getManagePurchaseUrlFor: GetManagePurchaseUrlFor;
 	visibleFields?: string[];
 } ) {

--- a/client/me/purchases/purchases-list-in-dataviews/index.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/index.tsx
@@ -1,15 +1,15 @@
+import { userPurchasesQuery, userTransferredPurchasesQuery } from '@automattic/api-queries';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { CompactCard } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
-import useGetJetpackTransferredLicensePurchases from '@automattic/data-stores/src/purchases/queries/use-get-jetpack-transferred-license-purchases';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
+import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { connect } from 'react-redux';
 import noSitesIllustration from 'calypso/assets/images/illustrations/illustration-nosites.svg';
 import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
 import QueryMembershipsSubscriptions from 'calypso/components/data/query-memberships-subscriptions';
-import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import EmptyContent from 'calypso/components/empty-content';
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -19,11 +19,7 @@ import Notice from 'calypso/components/notice';
 import { useIsSplitCancelRemoveEnabled } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import {
-	type GetManagePurchaseUrlFor,
-	MembershipSubscription,
-	Purchase,
-} from 'calypso/lib/purchases/types';
+import { type GetManagePurchaseUrlFor, MembershipSubscription } from 'calypso/lib/purchases/types';
 import { PurchaseListConciergeBanner } from 'calypso/me/purchases/purchases-list/purchase-list-concierge-banner';
 import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
 import titles from 'calypso/me/purchases/titles';
@@ -31,13 +27,7 @@ import {
 	WithStoredPaymentMethodsProps,
 	withStoredPaymentMethods,
 } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getAllSubscriptions } from 'calypso/state/memberships/subscriptions/selectors';
-import {
-	getUserPurchases,
-	hasLoadedUserPurchasesFromServer,
-	isFetchingUserPurchases,
-} from 'calypso/state/purchases/selectors';
 import getAvailableConciergeSessions from 'calypso/state/selectors/get-available-concierge-sessions';
 import getConciergeNextAppointment, {
 	NextAppointment,
@@ -49,6 +39,7 @@ import { AppState } from 'calypso/types';
 import { PurchasesByOtherAdminsNotice } from '../purchases-list/purchases-by-other-admins-notice';
 import PurchasesSite from '../purchases-site';
 import { PurchasesDataViews, MembershipsDataViews } from './purchases-data-view';
+import type { Purchase } from '@automattic/api-core';
 import './style.scss';
 
 export interface PurchasesListProps {
@@ -57,16 +48,12 @@ export interface PurchasesListProps {
 }
 
 export interface PurchasesListConnectedProps {
-	hasLoadedUserPurchasesFromServer: boolean;
-	isFetchingUserPurchases: boolean;
-	purchases: Purchase[];
 	subscriptions: MembershipSubscription[];
 	sites: SiteDetails[];
 	nextAppointment: NextAppointment | null;
 	isUserBlocked: boolean;
 	availableSessions: number[];
 	siteId: number | null;
-	userId?: number | null;
 }
 
 function MembershipSubscriptions( {
@@ -84,16 +71,12 @@ function MembershipSubscriptions( {
 const PurchasesListDataView: React.FC<
 	PurchasesListProps & PurchasesListConnectedProps & WithStoredPaymentMethodsProps
 > = ( {
-	hasLoadedUserPurchasesFromServer,
-	isFetchingUserPurchases,
 	getManagePurchaseUrlFor,
-	purchases,
 	subscriptions,
 	sites,
 	nextAppointment,
 	isUserBlocked,
 	availableSessions,
-	userId,
 } ) => {
 	const translate = useTranslate();
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
@@ -122,14 +105,19 @@ const PurchasesListDataView: React.FC<
 	} );
 	const [ showRemovedNotice, setShowRemovedNotice ] = useState( Boolean( removedNoticeData ) );
 
+	const {
+		data: purchases,
+		isLoading: isFetchingUserPurchases,
+		isSuccess: hasLoadedUserPurchasesFromServer,
+	} = useQuery( userPurchasesQuery() );
+
 	// Dismiss the success notice when the background mutation rolls back —
 	// detected by the captured purchase reappearing in the user's purchase list.
-	// `purchases` is camelCase via getUserPurchases → createPurchasesArray.
 	useEffect( () => {
 		if ( ! removedNoticeData?.purchaseId ) {
 			return;
 		}
-		if ( purchases?.some( ( p ) => String( p.id ) === String( removedNoticeData.purchaseId ) ) ) {
+		if ( purchases?.some( ( p ) => String( p.ID ) === String( removedNoticeData.purchaseId ) ) ) {
 			setShowRemovedNotice( false );
 		}
 	}, [ purchases, removedNoticeData ] );
@@ -138,7 +126,7 @@ const PurchasesListDataView: React.FC<
 		data: transferredOwnershipPurchases = [],
 		isLoading,
 		isSuccess: hasLoadedTransferredOwnershipPurchases,
-	} = useGetJetpackTransferredLicensePurchases( { userId: userId || undefined } );
+	} = useQuery( userTransferredPurchasesQuery() );
 
 	const isDataLoading = useCallback( () => {
 		if (
@@ -168,7 +156,6 @@ const PurchasesListDataView: React.FC<
 
 	return (
 		<Main wideLayout className="purchases-list">
-			<QueryUserPurchases />
 			<QueryMembershipsSubscriptions />
 			<PageViewTracker path="/me/purchases" title="Purchases" />
 
@@ -323,14 +310,10 @@ function PurchasesContent( {
 }
 
 export default connect( ( state: AppState ) => ( {
-	hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
-	isFetchingUserPurchases: isFetchingUserPurchases( state ),
-	purchases: getUserPurchases( state ) ?? [],
 	subscriptions: getAllSubscriptions( state ),
 	sites: getSites( state ).filter( isValueTruthy ),
 	nextAppointment: getConciergeNextAppointment( state ),
 	isUserBlocked: getConciergeUserBlocked( state ),
 	availableSessions: getAvailableConciergeSessions( state ),
 	siteId: getSiteId( state, null ),
-	userId: getCurrentUserId( state ),
 } ) )( withStoredPaymentMethods( PurchasesListDataView, { type: 'card', expired: true } ) );

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -1,14 +1,19 @@
-import { Purchases, SiteDetails } from '@automattic/data-stores';
+import { getPurchasePayment } from '@automattic/api-core';
+import { SiteDetails } from '@automattic/data-stores';
 import { StoredPaymentMethod } from '@automattic/wpcom-checkout';
 import { Fields } from '@wordpress/dataviews';
 import { fixMe, LocalizeProps } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { isTransferredOwnership } from 'calypso/dashboard/utils/purchase';
 import { logToLogstash } from 'calypso/lib/logstash';
-import { getDisplayName, mightStillAutoRenew, purchaseType } from 'calypso/lib/purchases';
 import { GetManagePurchaseUrlFor, MembershipSubscription } from 'calypso/lib/purchases/types';
+import {
+	getDisplayName,
+	mightStillAutoRenew,
+	purchaseType,
+} from 'calypso/me/purchases/lib/raw-purchase-helpers';
 import { useSelector } from 'calypso/state';
 import { getSite } from 'calypso/state/sites/selectors';
-import { isTransferredOwnership } from '../hooks/use-is-transferred-ownership';
 import { Icon, MembershipType, MembershipTerms } from '../membership-item';
 import {
 	PurchaseItemSiteIcon,
@@ -18,13 +23,14 @@ import {
 	BackupPaymentMethodNotice,
 } from '../purchase-item';
 import OwnerInfo from '../purchase-item/owner-info';
+import type { Purchase } from '@automattic/api-core';
 
 function PurchaseItemRowProduct( props: {
-	purchase: Purchases.Purchase;
+	purchase: Purchase;
 	translate: LocalizeProps[ 'translate' ];
 } ) {
 	const { purchase, translate } = props;
-	const site = useSelector( ( state ) => getSite( state, purchase.siteId ?? 0 ) );
+	const site = useSelector( ( state ) => getSite( state, purchase.blog_id ?? 0 ) );
 	const slug = site?.domain ?? undefined;
 	return (
 		<PurchaseItemProduct
@@ -39,7 +45,7 @@ function PurchaseItemRowProduct( props: {
 }
 
 function PurchaseItemRowStatus( props: {
-	purchase: Purchases.Purchase;
+	purchase: Purchase;
 	translate: LocalizeProps[ 'translate' ];
 	moment: ReturnType< typeof useLocalizedMoment >;
 	isDisconnectedSite?: boolean;
@@ -74,12 +80,12 @@ export function getPurchasesFieldDefinitions( {
 	sites: SiteDetails[];
 	getManagePurchaseUrlFor: GetManagePurchaseUrlFor;
 	fieldIds?: string[];
-	transferredOwnershipPurchases?: Purchases.Purchase[];
+	transferredOwnershipPurchases?: Purchase[];
 	visibleFields?: string[];
-} ): Fields< Purchases.Purchase > {
-	const getListTitle = ( item: Purchases.Purchase ) => {
-		if ( item.isDomainRegistration && item.meta ) {
-			if ( item.isHundredYearDomain ) {
+} ): Fields< Purchase > {
+	const getListTitle = ( item: Purchase ) => {
+		if ( item.is_domain_registration && item.meta ) {
+			if ( item.is_hundred_year_domain ) {
 				// translators: %(domain)s is the domain name, e.g. "100-Year Domain Registration: example.com"
 				return translate( '100-Year Domain Registration: %(domain)s', {
 					args: { domain: item.meta },
@@ -97,9 +103,9 @@ export function getPurchasesFieldDefinitions( {
 		( paymentMethod ) => paymentMethod.is_backup === true
 	);
 
-	const getPurchaseUrl = ( item: Purchases.Purchase ) => {
-		const siteUrl = item.siteSlug || item.domain;
-		const subscriptionId = item.id;
+	const getPurchaseUrl = ( item: Purchase ) => {
+		const siteUrl = item.site_slug || item.domain;
+		const subscriptionId = item.ID;
 		if ( ! siteUrl ) {
 			// eslint-disable-next-line no-console
 			console.error( 'Cannot display manage purchase page for subscription without site' );
@@ -115,7 +121,7 @@ export function getPurchasesFieldDefinitions( {
 
 	// No point in having a filter if there's only one site.
 	const shouldAllowSiteFiltering = sites.length > 1;
-	const fields: Fields< Purchases.Purchase > = [
+	const fields: Fields< Purchase > = [
 		{
 			id: 'site',
 			label: translate( 'Site' ),
@@ -130,13 +136,13 @@ export function getPurchasesFieldDefinitions( {
 				  } ) )
 				: undefined,
 			filterBy: shouldAllowSiteFiltering ? { operators: [ 'isAny' ] } : false,
-			getValue: ( { item }: { item: Purchases.Purchase } ) => {
+			getValue: ( { item }: { item: Purchase } ) => {
 				// getValue must return a string because the DataViews search feature calls `trim()` on it.
-				return String( item.siteId );
+				return String( item.blog_id );
 			},
 			// Render the site icon
-			render: ( { item }: { item: Purchases.Purchase } ) => {
-				const site = { ID: item.siteId };
+			render: ( { item }: { item: Purchase } ) => {
+				const site = { ID: item.blog_id };
 				return (
 					<a
 						title={ translate( 'Manage purchase', { textOnly: true } ) }
@@ -155,24 +161,24 @@ export function getPurchasesFieldDefinitions( {
 			enableSorting: true,
 			enableHiding: false,
 			filterBy: false,
-			getValue: ( { item }: { item: Purchases.Purchase } ) => {
+			getValue: ( { item }: { item: Purchase } ) => {
 				// Render a bunch of things to make this easily searchable.
-				const site = sites.find( ( site ) => site.ID === item.siteId );
+				const site = sites.find( ( site ) => site.ID === item.blog_id );
 				return (
 					getListTitle( item ) +
 					' ' +
 					( purchaseType( item ) || '' ) +
 					' ' +
-					item.siteName +
+					item.blogname +
 					' ' +
-					( item.siteSlug || item.domain ) +
+					( item.site_slug || item.domain ) +
 					' ' +
 					( site?.URL ?? '' )
 				);
 			},
-			render: ( { item }: { item: Purchases.Purchase } ) => {
+			render: ( { item }: { item: Purchase } ) => {
 				const hasTransferredOwnership = isTransferredOwnership(
-					item.id,
+					item.ID,
 					transferredOwnershipPurchases
 				);
 				return (
@@ -209,13 +215,13 @@ export function getPurchasesFieldDefinitions( {
 			enableSorting: true,
 			enableHiding: false,
 			filterBy: false,
-			getValue: ( { item }: { item: Purchases.Purchase } ) => {
+			getValue: ( { item }: { item: Purchase } ) => {
 				// Render a bunch of things to make this easily searchable.
-				const site = sites.find( ( site ) => site.ID === item.siteId );
-				return item.siteName + ' ' + ( item.siteSlug || item.domain ) + ' ' + ( site?.URL ?? '' );
+				const site = sites.find( ( site ) => site.ID === item.blog_id );
+				return item.blogname + ' ' + ( item.site_slug || item.domain ) + ' ' + ( site?.URL ?? '' );
 			},
-			render: ( { item }: { item: Purchases.Purchase } ) => {
-				const site = sites.find( ( s ) => s.ID === item.siteId );
+			render: ( { item }: { item: Purchase } ) => {
+				const site = sites.find( ( s ) => s.ID === item.blog_id );
 				return (
 					<div className="purchase-item__information">
 						<div className="purchase-item__purchase-type">
@@ -248,10 +254,10 @@ export function getPurchasesFieldDefinitions( {
 			],
 			filterBy: { operators: [ 'is' ] },
 			getValue: ( { item } ) => {
-				if ( item.isDomain || item.isDomainRegistration ) {
+				if ( item.is_domain || item.is_domain_registration ) {
 					return 'domain';
 				}
-				if ( item.productType === 'bundle' ) {
+				if ( item.product_type === 'bundle' ) {
 					return 'plan';
 				}
 				return 'other';
@@ -288,8 +294,8 @@ export function getPurchasesFieldDefinitions( {
 			filterBy: { operators: [ 'is' ] },
 			getValue: ( { item } ) => {
 				const now = Date.now();
-				const expiryDate = Date.parse( item.expiryDate );
-				if ( ! item.isRenewable || ! expiryDate || expiryDate < now ) {
+				const expiryDate = Date.parse( item.expiry_date );
+				if ( ! item.is_renewable || ! expiryDate || expiryDate < now ) {
 					return 'not-expiring-soon';
 				}
 				const msPerDay = 86_400_000;
@@ -320,12 +326,12 @@ export function getPurchasesFieldDefinitions( {
 			enableSorting: true,
 			enableHiding: false,
 			filterBy: false,
-			getValue: ( { item }: { item: Purchases.Purchase } ) => {
+			getValue: ( { item }: { item: Purchase } ) => {
 				// Include date in value to sort similar expiries together.
-				return item.expiryDate + ' ' + item.expiryStatus;
+				return item.expiry_date + ' ' + item.expiry_status;
 			},
-			render: ( { item }: { item: Purchases.Purchase } ) => {
-				const site = sites.find( ( site ) => site.ID === item.siteId );
+			render: ( { item }: { item: Purchase } ) => {
+				const site = sites.find( ( site ) => site.ID === item.blog_id );
 				return (
 					<PurchaseItemRowStatus
 						purchase={ item }
@@ -344,10 +350,11 @@ export function getPurchasesFieldDefinitions( {
 			enableSorting: true,
 			enableHiding: false,
 			filterBy: false,
-			getValue: ( { item }: { item: Purchases.Purchase } ) => {
+			getValue: ( { item }: { item: Purchase } ) => {
+				const payment = getPurchasePayment( item );
 				// This should not be possible. Investigating a bug:
 				// https://linear.app/a8c/issue/SHILL-901/
-				if ( ! item?.payment ) {
+				if ( ! payment.type ) {
 					logToLogstash( {
 						feature: 'calypso_client',
 						message: 'Purchase payment method data field getValue got unexpected data',
@@ -364,15 +371,16 @@ export function getPurchasesFieldDefinitions( {
 					  // use, since it won't be displayed; sorting it alongside active
 					  // purchases that have the same card would look wrong.
 					  'expired'
-					: item.payment.creditCard?.number ?? item.payment.type ?? 'no-payment-method';
+					: payment.creditCard?.number ?? payment.type ?? 'no-payment-method';
 			},
-			render: ( { item }: { item: Purchases.Purchase } ) => {
+			render: ( { item }: { item: Purchase } ) => {
 				let isBackupMethodAvailable = false;
 
 				if ( backupPaymentMethods ) {
+					const payment = getPurchasePayment( item );
 					const backupPaymentMethodsWithoutCurrentPurchase = backupPaymentMethods.filter(
 						// A payment method is only a back up if it isn't already assigned to the current purchase
-						( paymentMethod ) => item.payment.storedDetailsId !== paymentMethod.stored_details_id
+						( paymentMethod ) => payment.storedDetailsId !== paymentMethod.stored_details_id
 					);
 
 					isBackupMethodAvailable = backupPaymentMethodsWithoutCurrentPurchase.length >= 1;

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
-import { Purchases, SiteDetails } from '@automattic/data-stores';
+import { SiteDetails } from '@automattic/data-stores';
 import { DESKTOP_BREAKPOINT, WIDE_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
 import {
@@ -12,14 +12,15 @@ import {
 } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
+import { isTransferredOwnership } from 'calypso/dashboard/utils/purchase';
 import { MembershipSubscription } from 'calypso/lib/purchases/types';
 import { reduxDispatch } from 'calypso/lib/redux-bridge';
 import { setRoute } from 'calypso/state/route/actions';
-import { isTransferredOwnership } from '../hooks/use-is-transferred-ownership';
 import {
 	usePurchasesFieldDefinitions,
 	useMembershipsFieldDefinitions,
 } from './hooks/use-field-definitions';
+import type { Purchase } from '@automattic/api-core';
 import type { GetManagePurchaseUrlFor } from 'calypso/lib/purchases/types';
 
 import './style.scss';
@@ -212,9 +213,9 @@ export function PurchasesDataViews( {
 	transferredOwnershipPurchases = [],
 	getManagePurchaseUrlFor,
 }: {
-	purchases: Purchases.Purchase[];
+	purchases: Purchase[];
 	sites: SiteDetails[];
-	transferredOwnershipPurchases?: Purchases.Purchase[];
+	transferredOwnershipPurchases?: Purchase[];
 	getManagePurchaseUrlFor: GetManagePurchaseUrlFor;
 } ) {
 	const translate = useTranslate();
@@ -229,7 +230,7 @@ export function PurchasesDataViews( {
 	const sitesWithPurchases = useMemo( () => {
 		return Array.from(
 			purchases.reduce( ( collected, purchase ) => {
-				const siteForPurchase = sites.find( ( site ) => site.ID === purchase.siteId );
+				const siteForPurchase = sites.find( ( site ) => site.ID === purchase.blog_id );
 				if ( siteForPurchase ) {
 					collected.add( siteForPurchase );
 				}
@@ -253,17 +254,17 @@ export function PurchasesDataViews( {
 			{
 				id: 'manage-purchase',
 				label: translate( 'Manage purchase', { textOnly: true } ),
-				isEligible: ( item: Purchases.Purchase ) => {
+				isEligible: ( item: Purchase ) => {
 					// Hide manage button for transferred ownership purchases
 					const hasTransferredOwnership = isTransferredOwnership(
-						item.id,
+						item.ID,
 						transferredOwnershipPurchases
 					);
-					return Boolean( item.domain && item.id ) && ! hasTransferredOwnership;
+					return Boolean( item.domain && item.ID ) && ! hasTransferredOwnership;
 				},
-				callback: ( items: Purchases.Purchase[] ) => {
-					const siteUrl = items[ 0 ].siteSlug || items[ 0 ].domain;
-					const subscriptionId = items[ 0 ].id;
+				callback: ( items: Purchase[] ) => {
+					const siteUrl = items[ 0 ].site_slug || items[ 0 ].domain;
+					const subscriptionId = items[ 0 ].ID;
 					if ( ! siteUrl ) {
 						// eslint-disable-next-line no-console
 						console.error( 'Cannot display manage purchase page for subscription without site' );
@@ -281,8 +282,8 @@ export function PurchasesDataViews( {
 		[ translate, getManagePurchaseUrlFor, transferredOwnershipPurchases ]
 	);
 
-	const getItemId = ( item: Purchases.Purchase ) => {
-		return item.id.toString();
+	const getItemId = ( item: Purchase ) => {
+		return item.ID.toString();
 	};
 	return (
 		<Card id="purchases-list" className="section-content" tagName="section">

--- a/client/me/purchases/purchases-site/index.tsx
+++ b/client/me/purchases/purchases-site/index.tsx
@@ -1,3 +1,4 @@
+import { getPurchasePayment } from '@automattic/api-core';
 import {
 	isJetpackPlan,
 	isJetpackProduct,
@@ -10,8 +11,9 @@ import { useSelector } from 'calypso/state';
 import { getSite } from 'calypso/state/sites/selectors';
 import { managePurchase } from '../paths';
 import PurchaseItem from '../purchase-item';
+import type { Purchase } from '@automattic/api-core';
 import type { StoredPaymentMethod } from '@automattic/wpcom-checkout';
-import type { Purchase, GetManagePurchaseUrlFor } from 'calypso/lib/purchases/types';
+import type { GetManagePurchaseUrlFor } from 'calypso/lib/purchases/types';
 
 import './style.scss';
 
@@ -66,13 +68,15 @@ export default function PurchasesSite(
 
 			{ purchases.map( ( purchase ) => {
 				const isBackupMethodAvailable = cards.some(
-					( card ) => card.stored_details_id !== purchase.payment.storedDetailsId && card.is_backup
+					( card ) =>
+						card.stored_details_id !== getPurchasePayment( purchase ).storedDetailsId &&
+						card.is_backup
 				);
 
 				return (
 					<PurchaseItem
 						getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
-						key={ purchase.id }
+						key={ purchase.ID }
 						slug={ slug }
 						isDisconnectedSite={ ! site }
 						purchase={ purchase }

--- a/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
+++ b/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
@@ -1,6 +1,8 @@
+import { sitePurchasesQuery } from '@automattic/api-queries';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { CompactCard } from '@automattic/components';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
+import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import EmptyContent from 'calypso/components/empty-content';
@@ -14,11 +16,6 @@ import { PurchasesDataViews } from 'calypso/me/purchases/purchases-list-in-datav
 import PurchasesSite from 'calypso/me/purchases/purchases-site';
 import { useSelector } from 'calypso/state';
 import { hasJetpackPartnerAccess as hasJetpackPartnerAccessSelector } from 'calypso/state/partner-portal/partner/selectors';
-import {
-	getSitePurchases,
-	hasLoadedSitePurchasesFromServer,
-	isFetchingSitePurchases,
-} from 'calypso/state/purchases/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { GetManagePurchaseUrlFor } from 'calypso/lib/purchases/types';
@@ -28,11 +25,16 @@ import './style.scss';
 export default function SubscriptionsContentWrapper() {
 	const translate = useTranslate();
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
-	const isFetchingPurchases = useSelector( isFetchingSitePurchases );
-	const hasLoadedPurchases = useSelector( hasLoadedSitePurchasesFromServer );
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const selectedSite = useSelector( getSelectedSite );
-	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSiteId ) );
+	const {
+		data: purchases = [],
+		isLoading: isFetchingPurchases,
+		isSuccess: hasLoadedPurchases,
+	} = useQuery( {
+		...sitePurchasesQuery( selectedSiteId ?? 0 ),
+		enabled: Boolean( selectedSiteId ),
+	} );
 	const sites = useSelector( getSites ).filter( isValueTruthy );
 	const getManagePurchaseUrlFor: GetManagePurchaseUrlFor = useCallback(
 		( siteSlug, purchaseId ) => `/purchases/subscriptions/${ siteSlug }/${ purchaseId }`,


### PR DESCRIPTION
Part of [SHILL-2256](https://linear.app/a8c/issue/SHILL-2256)

## Proposed Changes

Converts the `/me/purchases` DataViews list page and its leaf renderers off the camelCase Redux-assembled `Purchase` type onto the raw snake_case `Purchase` from `@automattic/api-core`, continuing the incremental SHILL-2256 assembler-removal effort.

* Source purchases via `userPurchasesQuery`/`userTransferredPurchasesQuery` (TanStack Query) instead of the `getUserPurchases` Redux selector and the data-stores `useGetJetpackTransferredLicensePurchases` hook
* Convert `purchase-item` (the row renderer) and `owner-info` to the raw `Purchase` type, swapping helper imports to `raw-purchase-helpers`/`dashboard/utils/purchase`
* Convert `purchases-data-view`/`purchases-data-field`/`use-field-definitions` (DataViews field, sort, and filter logic) to the raw shape
* Convert `purchases-site`'s non-placeholder branch so it stays compiling against the now-raw `PurchaseItem`
* Add `mightStillAutoRenew`, `getPartnerName`, and `isIntroductoryOfferFreeTrial` to the local `raw-purchase-helpers` module
* Rewrite `purchase-item` test fixtures to the raw snake_case shape

## Why are these changes being made?

SHILL-2256 is removing the client-side purchases assembler (`createPurchaseObject`/`createPurchasesArray`) page by page, since it duplicates data the backend already owns and blocks the `client/me/purchases` pages from sharing logic with the Dashboard's raw-`Purchase` equivalents. This was the next flagged slice after `manage-purchase`, `cancel-purchase`, `confirm-cancel-domain`, `remove-purchase`, and `upcoming-renewals`.

Two other candidate slices were considered and set aside: converting the shared `handleRenewNowClick`/`handleRenewMultiplePurchasesClick` renewal handlers touches 6 scattered call sites outside `client/me/purchases` and needs its own slice; the 3 remaining `createPurchaseObject` bridges in `manage-purchase/index.tsx` are intentional boundary bridges (the same pattern earlier slices used to hand a raw purchase to a not-yet-migrated shared function), not cleanup debt.

## Testing Instructions

TC:
```
yarn test-client client/me/purchases
```

Manual testing:
* Visit `/me/purchases` on a user with purchases across multiple sites
* Confirm the list renders, and sorting by site/product/status/payment method still works
* Confirm the "expiring soon" filter still buckets purchases correctly
* Confirm the owner-info tooltip still appears for transferred-ownership and non-owner purchases
* Confirm payment method icons render correctly for credit card/PayPal/UPI purchases

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
