### PR TITLE
Stats: Fix stray accent border on Jetpack emerald primary buttons

### DIFF
--- a/apps/odyssey-stats/src/app.scss
+++ b/apps/odyssey-stats/src/app.scss
@@ -104,6 +104,14 @@
 		&.is-primary {
 			color: var(--studio-white);
 			background: var(--studio-black);
+			border-color: var(--studio-black);
+
+			&:hover:not(.is-busy),
+			&:focus {
+				color: var(--studio-white);
+				background: $emerald-hover-color;
+				border-color: $emerald-hover-color;
+			}
 		}
 
 		// Use `transparent` styling as secondary styles

--- a/apps/odyssey-stats/src/styles/variables.scss
+++ b/apps/odyssey-stats/src/styles/variables.scss
@@ -5,6 +5,8 @@ $display-type-font: $sans;
 $display-type-weight: 400;
 $display-type-line-height: 40px;
 
+$emerald-hover-color: #414141;
+
 // Manual styling override mixin for Jetpack.
 @mixin stats-section-header-for-jetpack {
 	font-family: $display-type-font;

--- a/apps/odyssey-stats/src/widget/modules.scss
+++ b/apps/odyssey-stats/src/widget/modules.scss
@@ -1,6 +1,5 @@
 @import "../styles/typography";
 
-$emerald-hover-color: #414141;
 $jp-gray: #dcdcde;
 
 .stats-widget-modules {


### PR DESCRIPTION
Fixes STATS-379

## Why

On a self-hosted Jetpack site, the "Upgrade to Commercial" button in the locked Stats modules (UTM, Devices) rendered as a black button wrapped in a mismatched red/orange border, and turned that accent color completely when hovered — it looked broken next to the link beside it, which correctly follows the admin color scheme. This restores the button to a clean, intentional black so the upsell no longer looks half-styled.

## Proposed Changes

* Make the Odyssey emerald primary button override in `app.scss` self-contained: pin the resting `border-color` to the black background, and define the hover/focus fill so the button stops inheriting `var(--color-accent)` from the base `@automattic/components` `.button.is-primary` rules.
* Hoist the shared `$emerald-hover-color` into `styles/variables.scss` so the main app and the widget stylesheet use a single source instead of duplicating the value.

## Screenshots

Self-hosted Jetpack, orange admin color scheme, UTM locked module.

**Before** — black button with a stray orange border that matches the accent link above it

<img width="1176" height="1034" alt="before-utm-module" src="https://github.com/user-attachments/assets/cc8dff49-fed9-467f-8346-f7c288da221d" />

**After** — clean black button, border matches the background; the accent link is untouched

<img width="1176" height="1034" alt="after-utm-module" src="https://github.com/user-attachments/assets/4754cb18-4dd4-4e5c-92d8-665cb90f843b" />

**After (hover)** — darkens to a neutral gray instead of flashing the admin accent

<img width="516" height="134" alt="after-button-hover" src="https://github.com/user-attachments/assets/8e65ba79-b776-4fa1-9baf-e672157b3db7" />

## Why are these changes being made?

The emerald override only set the primary button's `background` and text `color`, leaving its border (resting) and its entire hover/focus state to fall through to the base `@automattic/components` `.button.is-primary` rules, which are colored with `var(--color-accent)`. On self-hosted Jetpack that accent is not mapped to the admin theme, so it surfaced as the stray red/orange border and the accent-colored hover fill. Overriding those states on the emerald rule keeps the button black in every state.

This also fixes the same latent glitch on the other emerald primary button in the main app (the "Update Jetpack" prompt), since both share the `.button.jetpack-emerald-button.is-primary` rule.

## Testing Instructions

This only affects **self-hosted Jetpack** sites (Odyssey Stats), where the emerald button styling applies. WordPress.com Simple and Atomic sites use a different button path and are unaffected.

1. On a self-hosted site with Jetpack connected and a non-default WP admin color scheme, open **Jetpack → Stats**.
2. Scroll to a locked module (**UTM** or **Devices**) to reveal the **"Upgrade to Commercial"** button.
3. Confirm the button is solid black with **no** stray red/orange border.
4. Hover the button — it darkens to a neutral gray (`#414141`) rather than flashing the admin accent color.

Verified on a self-hosted Jetpack site (Odyssey Stats, orange admin scheme) — see the before/after screenshots above.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? <!-- Only self-hosted Jetpack is affected (verified); Simple/Atomic use a different button path and are unchanged. -->

- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

