### PR TITLE
Stats: Add thumbnails to the video lists

### DIFF
--- a/client/my-sites/stats/stats-list/stats-list-card.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-card.jsx
@@ -122,8 +122,8 @@ const StatsListCard = ( {
 		// left icon visible for avatars, contry flags or tags and categories.
 		if ( item?.countryCode ) {
 			leftSideItem = <StatsListCountryFlag countryCode={ item.countryCode } />;
-		} else if ( showLeftIcon && moduleType === 'videoplays' ) {
-			leftSideItem = <StatsListVideoThumbnail poster={ item?.icon } />;
+		} else if ( moduleType === 'videoplays' ) {
+			leftSideItem = <StatsListVideoThumbnail poster={ item?.poster } />;
 		} else if ( showLeftIcon && item?.icon ) {
 			leftSideItem = <StatsCardAvatar url={ item?.icon } altName={ item?.label } />;
 		} else if ( Array.isArray( item?.label ) ) {

--- a/client/my-sites/stats/stats-list/stats-list-card.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-card.jsx
@@ -15,6 +15,7 @@ import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import OpenLink from './action-link';
 import StatsListActions from './stats-list-actions';
 import StatsListCountryFlag from './stats-list-country-flag';
+import StatsListVideoThumbnail from './stats-list-video-thumbnail';
 
 const StatsListCard = ( {
 	data,
@@ -121,6 +122,8 @@ const StatsListCard = ( {
 		// left icon visible for avatars, contry flags or tags and categories.
 		if ( item?.countryCode ) {
 			leftSideItem = <StatsListCountryFlag countryCode={ item.countryCode } />;
+		} else if ( showLeftIcon && moduleType === 'videoplays' ) {
+			leftSideItem = <StatsListVideoThumbnail poster={ item?.icon } />;
 		} else if ( showLeftIcon && item?.icon ) {
 			leftSideItem = <StatsCardAvatar url={ item?.icon } altName={ item?.label } />;
 		} else if ( Array.isArray( item?.label ) ) {

--- a/client/my-sites/stats/stats-list/stats-list-card.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-card.jsx
@@ -119,7 +119,7 @@ const StatsListCard = ( {
 	const generateLeftItem = ( item ) => {
 		let leftSideItem; // undefined value avoids rendering an empty node if nothing generates the output
 
-		// left icon visible for avatars, contry flags or tags and categories.
+		// Left icon is shown for country flags, video thumbnails, avatars, and tag/category icons.
 		if ( item?.countryCode ) {
 			leftSideItem = <StatsListCountryFlag countryCode={ item.countryCode } />;
 		} else if ( moduleType === 'videoplays' ) {

--- a/client/my-sites/stats/stats-list/stats-list-video-thumbnail.scss
+++ b/client/my-sites/stats/stats-list/stats-list-video-thumbnail.scss
@@ -1,0 +1,21 @@
+.stats-list__video-thumbnail {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	width: 32px;
+	height: 18px;
+	border-radius: 2px;
+	overflow: hidden;
+	background-color: var(--color-neutral-5);
+
+	.stats-list__video-thumbnail-image {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+
+	svg {
+		fill: var(--color-neutral-40);
+	}
+}

--- a/client/my-sites/stats/stats-list/stats-list-video-thumbnail.scss
+++ b/client/my-sites/stats/stats-list/stats-list-video-thumbnail.scss
@@ -1,4 +1,6 @@
 .stats-list__video-thumbnail {
+	position: relative;
+	z-index: 1;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/client/my-sites/stats/stats-list/stats-list-video-thumbnail.scss
+++ b/client/my-sites/stats/stats-list/stats-list-video-thumbnail.scss
@@ -21,3 +21,11 @@
 		fill: var(--color-neutral-40);
 	}
 }
+
+// horizontal-bar-list paints every svg in a hovered row white, which vanishes against the thumbnail's own light background.
+.horizontal-bar-list .horizontal-bar-list-item:hover,
+.horizontal-bar-list .horizontal-bar-list-item:focus {
+	.stats-list__video-thumbnail svg {
+		fill: var(--color-neutral-40);
+	}
+}

--- a/client/my-sites/stats/stats-list/stats-list-video-thumbnail.tsx
+++ b/client/my-sites/stats/stats-list/stats-list-video-thumbnail.tsx
@@ -17,6 +17,7 @@ export default function StatsListVideoThumbnail( { poster }: { poster?: string |
 					className="stats-list__video-thumbnail-image"
 					src={ posterUrl }
 					alt=""
+					loading="lazy"
 					onError={ () => setFailedPoster( posterUrl ) }
 				/>
 			) : (

--- a/client/my-sites/stats/stats-list/stats-list-video-thumbnail.tsx
+++ b/client/my-sites/stats/stats-list/stats-list-video-thumbnail.tsx
@@ -17,7 +17,6 @@ export default function StatsListVideoThumbnail( { poster }: { poster?: string |
 					className="stats-list__video-thumbnail-image"
 					src={ posterUrl }
 					alt=""
-					loading="lazy"
 					onError={ () => setFailedPoster( posterUrl ) }
 				/>
 			) : (

--- a/client/my-sites/stats/stats-list/stats-list-video-thumbnail.tsx
+++ b/client/my-sites/stats/stats-list/stats-list-video-thumbnail.tsx
@@ -1,0 +1,27 @@
+import { Icon, video } from '@wordpress/icons';
+import { useState } from 'react';
+
+import './stats-list-video-thumbnail.scss';
+
+export default function StatsListVideoThumbnail( { poster }: { poster?: string | null } ) {
+	// Posters of private videos come back as tokenless CDN URLs that the CDN
+	// rejects (STATS-374), so fall back to the placeholder rather than showing
+	// a broken image.
+	const [ failedPoster, setFailedPoster ] = useState< string | null >( null );
+	const posterUrl = poster && poster !== failedPoster ? poster : null;
+
+	return (
+		<span className="stats-list__video-thumbnail">
+			{ posterUrl ? (
+				<img
+					className="stats-list__video-thumbnail-image"
+					src={ posterUrl }
+					alt=""
+					onError={ () => setFailedPoster( posterUrl ) }
+				/>
+			) : (
+				<Icon icon={ video } size={ 16 } />
+			) }
+		</span>
+	);
+}

--- a/client/my-sites/stats/stats-list/test/stats-list-video-thumbnail.tsx
+++ b/client/my-sites/stats/stats-list/test/stats-list-video-thumbnail.tsx
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fireEvent, render } from '@testing-library/react';
+import StatsListVideoThumbnail from '../stats-list-video-thumbnail';
+
+const POSTER = 'https://videos.files.wordpress.com/abc123/poster.jpg';
+
+describe( 'StatsListVideoThumbnail', () => {
+	test( 'renders the poster as a decorative image', () => {
+		const { container } = render( <StatsListVideoThumbnail poster={ POSTER } /> );
+
+		const img = container.querySelector( 'img.stats-list__video-thumbnail-image' );
+		expect( img ).toHaveAttribute( 'src', POSTER );
+		expect( img ).toHaveAttribute( 'alt', '' );
+		expect( container.querySelector( 'svg' ) ).toBeNull();
+	} );
+
+	test( 'renders the placeholder when there is no poster', () => {
+		const { container } = render( <StatsListVideoThumbnail poster={ null } /> );
+
+		expect( container.querySelector( 'img' ) ).toBeNull();
+		expect( container.querySelector( 'svg' ) ).toBeVisible();
+	} );
+
+	test( 'swaps in the placeholder when the poster fails to load', () => {
+		const { container } = render( <StatsListVideoThumbnail poster={ POSTER } /> );
+
+		fireEvent.error( container.querySelector( 'img.stats-list__video-thumbnail-image' )! );
+
+		expect( container.querySelector( 'img' ) ).toBeNull();
+		expect( container.querySelector( 'svg' ) ).toBeVisible();
+	} );
+
+	test( 'keeps the slot reserved in every state', () => {
+		const withPoster = render( <StatsListVideoThumbnail poster={ POSTER } /> );
+		const withoutPoster = render( <StatsListVideoThumbnail poster={ null } /> );
+
+		expect( withPoster.container.querySelector( '.stats-list__video-thumbnail' ) ).toBeVisible();
+		expect( withoutPoster.container.querySelector( '.stats-list__video-thumbnail' ) ).toBeVisible();
+	} );
+} );

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -346,7 +346,7 @@ class StatsModule extends Component {
 					toggleControl={ toggleControl }
 					multiHeader={ isAllTime }
 					mainItemLabel={ mainItemLabel }
-					showLeftIcon={ path === 'authors' }
+					showLeftIcon={ path === 'authors' || path === 'videoplays' }
 					listItemClassName={ listItemClassName }
 					hasNoBackground={ hasNoBackground }
 					overlay={

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -346,7 +346,7 @@ class StatsModule extends Component {
 					toggleControl={ toggleControl }
 					multiHeader={ isAllTime }
 					mainItemLabel={ mainItemLabel }
-					showLeftIcon={ path === 'authors' || path === 'videoplays' }
+					showLeftIcon={ path === 'authors' }
 					listItemClassName={ listItemClassName }
 					hasNoBackground={ hasNoBackground }
 					overlay={

--- a/client/my-sites/stats/videopress-stats-module/index.jsx
+++ b/client/my-sites/stats/videopress-stats-module/index.jsx
@@ -18,6 +18,7 @@ import {
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EmptyModuleCardVideo from '../features/modules/shared/stats-empty-module-video';
 import ErrorPanel from '../stats-error';
+import StatsListVideoThumbnail from '../stats-list/stats-list-video-thumbnail';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import '../stats-module/style.scss';
 import './style.scss';
@@ -83,7 +84,7 @@ class VideoPressStatsModule extends Component {
 		return Math.max( ...data.map( ( item ) => item[ field ] || 0 ) );
 	}
 
-	renderTitleCell( { title, views, maxViews, onClick, href } ) {
+	renderTitleCell( { title, poster, views, maxViews, onClick, href } ) {
 		const fillPercentage = maxViews > 0 ? ( views / maxViews ) * 100 : 0;
 		return (
 			<div className="videopress-stats-module__grid-cell videopress-stats-module__grid-link">
@@ -92,6 +93,7 @@ class VideoPressStatsModule extends Component {
 						className="videopress-stats-module__bar"
 						style={ { '--bar-fill-percentage': `${ fillPercentage }%` } }
 					>
+						<StatsListVideoThumbnail poster={ poster } />
 						<a href={ href } onClick={ onClick }>
 							{ title }
 						</a>
@@ -225,6 +227,7 @@ class VideoPressStatsModule extends Component {
 							>
 								{ this.renderTitleCell( {
 									title: row.title,
+									poster: row.poster,
 									views: row.views,
 									maxViews,
 									href: videoDetailsHref( row.post_id ),

--- a/client/my-sites/stats/videopress-stats-module/index.jsx
+++ b/client/my-sites/stats/videopress-stats-module/index.jsx
@@ -93,9 +93,9 @@ class VideoPressStatsModule extends Component {
 						className="videopress-stats-module__bar"
 						style={ { '--bar-fill-percentage': `${ fillPercentage }%` } }
 					>
-						<StatsListVideoThumbnail poster={ poster } />
 						<a href={ href } onClick={ onClick }>
-							{ title }
+							<StatsListVideoThumbnail poster={ poster } />
+							<span className="videopress-stats-module__title">{ title }</span>
 						</a>
 					</div>
 				</div>

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -63,14 +63,16 @@
 			height: 100%;
 			display: flex;
 			align-items: center;
+			gap: 8px;
 			padding-left: 10px;
-			
+
 			a {
 				overflow: hidden;
 				white-space: nowrap;
 				text-overflow: ellipsis;
 				display: block;
 				width: 100%;
+				min-width: 0;
 				cursor: pointer;
 				position: relative;
 				z-index: 1;
@@ -82,6 +84,11 @@
 				&:visited {
 					color: var(--color-text);
 				}
+			}
+
+			.stats-list__video-thumbnail {
+				position: relative;
+				z-index: 1;
 			}
 
 			&::before {

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -64,7 +64,7 @@
 			display: flex;
 			align-items: center;
 			gap: 8px;
-			padding-left: 10px;
+			padding-inline-start: 10px;
 
 			a {
 				overflow: hidden;
@@ -84,11 +84,6 @@
 				&:visited {
 					color: var(--color-text);
 				}
-			}
-
-			.stats-list__video-thumbnail {
-				position: relative;
-				z-index: 1;
 			}
 
 			&::before {

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -63,14 +63,12 @@
 			height: 100%;
 			display: flex;
 			align-items: center;
-			gap: 8px;
 			padding-inline-start: 10px;
 
 			a {
-				overflow: hidden;
-				white-space: nowrap;
-				text-overflow: ellipsis;
-				display: block;
+				display: flex;
+				align-items: center;
+				gap: 8px;
 				width: 100%;
 				min-width: 0;
 				cursor: pointer;
@@ -84,6 +82,12 @@
 				&:visited {
 					color: var(--color-text);
 				}
+			}
+
+			.videopress-stats-module__title {
+				overflow: hidden;
+				white-space: nowrap;
+				text-overflow: ellipsis;
 			}
 
 			&::before {

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1623,7 +1623,7 @@ describe( 'utils', () => {
 								type: 'link',
 							},
 						],
-						icon: null,
+						poster: null,
 						label: 'Press This!',
 						page: '/stats/day/videodetails/en.blog.wordpress.com?post=111111111',
 						post_id: 111111111,
@@ -1632,7 +1632,7 @@ describe( 'utils', () => {
 				] );
 			} );
 
-			test( 'should map the API poster onto the icon field', () => {
+			test( 'should pass the API poster through', () => {
 				expect(
 					normalizers.statsVideoPlays(
 						{
@@ -1668,7 +1668,7 @@ describe( 'utils', () => {
 								type: 'link',
 							},
 						],
-						icon: 'https://videos.files.wordpress.com/abc123/poster.jpg',
+						poster: 'https://videos.files.wordpress.com/abc123/poster.jpg',
 						label: 'Press This!',
 						page: '/stats/day/videodetails/en.blog.wordpress.com?post=111111111',
 						post_id: 111111111,
@@ -1677,7 +1677,7 @@ describe( 'utils', () => {
 				] );
 			} );
 
-			test( 'should fall back to a null icon when the API sends no poster', () => {
+			test( 'should fall back to a null poster when the API sends none', () => {
 				const [ item ] = normalizers.statsVideoPlays(
 					{
 						date: '2017-01-12',
@@ -1704,7 +1704,7 @@ describe( 'utils', () => {
 					}
 				);
 
-				expect( item.icon ).toBeNull();
+				expect( item.poster ).toBeNull();
 				expect( item.post_id ).toBe( 111111111 );
 			} );
 		} );

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1623,10 +1623,9 @@ describe( 'utils', () => {
 								type: 'link',
 							},
 						],
-						poster: null,
+						poster: '',
 						label: 'Press This!',
 						page: '/stats/day/videodetails/en.blog.wordpress.com?post=111111111',
-						post_id: 111111111,
 						value: 32,
 					},
 				] );
@@ -1671,13 +1670,12 @@ describe( 'utils', () => {
 						poster: 'https://videos.files.wordpress.com/abc123/poster.jpg',
 						label: 'Press This!',
 						page: '/stats/day/videodetails/en.blog.wordpress.com?post=111111111',
-						post_id: 111111111,
 						value: 32,
 					},
 				] );
 			} );
 
-			test( 'should fall back to a null poster when the API sends none', () => {
+			test( 'should fall back to an empty poster when the API sends none', () => {
 				const [ item ] = normalizers.statsVideoPlays(
 					{
 						date: '2017-01-12',
@@ -1704,8 +1702,7 @@ describe( 'utils', () => {
 					}
 				);
 
-				expect( item.poster ).toBeNull();
-				expect( item.post_id ).toBe( 111111111 );
+				expect( item.poster ).toBe( '' );
 			} );
 		} );
 

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1623,11 +1623,89 @@ describe( 'utils', () => {
 								type: 'link',
 							},
 						],
+						icon: null,
 						label: 'Press This!',
 						page: '/stats/day/videodetails/en.blog.wordpress.com?post=111111111',
+						post_id: 111111111,
 						value: 32,
 					},
 				] );
+			} );
+
+			test( 'should map the API poster onto the icon field', () => {
+				expect(
+					normalizers.statsVideoPlays(
+						{
+							date: '2017-01-12',
+							days: {
+								'2017-01-12': {
+									plays: [
+										{
+											plays: 32,
+											post_id: 111111111,
+											title: 'Press This!',
+											url: 'http://en.blog.wordpress.com/wp-admin/media.php?action=edit&attachment_id=111111111',
+											poster: 'https://videos.files.wordpress.com/abc123/poster.jpg',
+										},
+									],
+								},
+							},
+						},
+						{
+							period: 'day',
+							date: '2017-01-12',
+						},
+						10,
+						{
+							slug: 'en.blog.wordpress.com',
+						}
+					)
+				).toEqual( [
+					{
+						actions: [
+							{
+								data: 'http://en.blog.wordpress.com/wp-admin/media.php?action=edit&attachment_id=111111111',
+								type: 'link',
+							},
+						],
+						icon: 'https://videos.files.wordpress.com/abc123/poster.jpg',
+						label: 'Press This!',
+						page: '/stats/day/videodetails/en.blog.wordpress.com?post=111111111',
+						post_id: 111111111,
+						value: 32,
+					},
+				] );
+			} );
+
+			test( 'should fall back to a null icon when the API sends no poster', () => {
+				const [ item ] = normalizers.statsVideoPlays(
+					{
+						date: '2017-01-12',
+						days: {
+							'2017-01-12': {
+								plays: [
+									{
+										plays: 32,
+										post_id: 111111111,
+										title: 'Press This!',
+										url: 'http://en.blog.wordpress.com/wp-admin/media.php?action=edit&attachment_id=111111111',
+									},
+								],
+							},
+						},
+					},
+					{
+						period: 'day',
+						date: '2017-01-12',
+					},
+					10,
+					{
+						slug: 'en.blog.wordpress.com',
+					}
+				);
+
+				expect( item.icon ).toBeNull();
+				expect( item.post_id ).toBe( 111111111 );
 			} );
 		} );
 

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -669,11 +669,10 @@ export const normalizers = {
 				? `/stats/${ query.period }/videodetails/${ site.slug }?post=${ item.post_id }`
 				: null;
 			return {
-				post_id: item.post_id,
 				label: item.title,
 				page: detailPage,
 				value: item.plays,
-				poster: item.poster ?? null,
+				poster: item.poster ?? '',
 				actions: [
 					{
 						type: 'link',

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -673,7 +673,7 @@ export const normalizers = {
 				label: item.title,
 				page: detailPage,
 				value: item.plays,
-				icon: item.poster ?? null,
+				poster: item.poster ?? null,
 				actions: [
 					{
 						type: 'link',

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -669,9 +669,11 @@ export const normalizers = {
 				? `/stats/${ query.period }/videodetails/${ site.slug }?post=${ item.post_id }`
 				: null;
 			return {
+				post_id: item.post_id,
 				label: item.title,
 				page: detailPage,
 				value: item.plays,
+				icon: item.poster ?? null,
 				actions: [
 					{
 						type: 'link',


### PR DESCRIPTION
Part of STATS-407

## Why

Both video lists in Stats read as rows of text today, so a site owner scanning them has to recognise every video by its filename — and filenames like `jetpack-newsletter-final-cut-2` tell them nothing. This puts a thumbnail at the start of each row, in the same position the Authors list uses for its avatar, so the lists read as video lists.

The thumbnails are not visible yet. The `stats/video-plays` endpoint does not return a poster, so every row currently shows a neutral video placeholder. STATS-412 covers the API change; once it ships, real thumbnails appear here with no further Calypso work.

## Proposed Changes

* Add a shared `StatsListVideoThumbnail` component (`client/my-sites/stats/stats-list/`) that renders a 32×18 poster or a placeholder icon, and hides a poster that fails to load.
* Render it in the Traffic page "Videos" card, via the existing `StatsListCard` left-side-item slot.
* Render it in the All Videos summary grid, inside the title cell's bar.
* Carry a new `poster` field through the `statsVideoPlays` normalizer.

Notes for reviewers:

* **The two surfaces read the poster from two different payloads.** The Traffic card goes through the `statsVideoPlays` normalizer and reads `days.<date>.plays[]`; the All Videos grid reads the raw `complete_stats=1` response at `days.<date>.data[]`. STATS-412 has to add `poster` to **both** arrays or only one list will light up — and nothing here will fail or warn if it doesn't.
* The normalizer emits `poster`, deliberately **not** `icon`. In `stats-list-card.jsx`, `icon` means "avatar URL" and renders as a 20px circle; a 16:9 poster in that field would be a trap for the next person editing the branch order.
* `statsVideoPlaysCompleteStats` is intentionally untouched. It feeds the videos CSV export, so adding `poster` there would append a poster-URL column to a user-facing download.
* No row heights changed. The thumbnail fits inside the existing 36px rows on both surfaces.
* `loading="lazy"` was tried and removed. With it, the thumbnails never loaded at all — every row sat inside the viewport with `src` set and `currentSrc` empty, and stripping the attribute from a single image made it fetch immediately. If request volume matters once posters exist, the answer is a smaller image, not a deferred one.

### Screenshots

The `poster` field does not exist on the API yet, so the first two shots were taken with a stub poster substituted locally to show the intended result. The third is the real current state.

**Traffic page "Videos" card — with posters (simulated)**

<img width="1456" height="834" alt="Traffic page Videos card with thumbnails" src="https://github.com/user-attachments/assets/67f42505-08ce-4c2d-930d-2ceecfbfb13a" />

**All Videos summary grid — with posters (simulated)**

<img width="1456" height="834" alt="All Videos grid with thumbnails" src="https://github.com/user-attachments/assets/86bac408-883f-49e5-8e90-ad8b066b0a88" />

**Placeholder state at 406px — what ships today, until STATS-412 lands**

<img width="805" height="1513" alt="Traffic page Videos card on mobile showing placeholder icons" src="https://github.com/user-attachments/assets/227acb15-1225-4b71-bbd4-12f4dd303faf" />

## Testing Instructions

The poster field does not exist on the API yet, so the default state on any site is the placeholder.

1. Open the Stats Traffic page for a site with VideoPress videos that have plays. The "Videos" card should show a placeholder icon at the start of every bar, with titles left-aligned down the column and no change in row height.
2. Open All Videos (`/stats/day/videoplays/<site>`). Same placeholder at the start of each title bar; the Impressions / Hours Watched / Retention Rate / Views columns are unchanged.
3. Check the Authors card on the Traffic page still shows round avatars — the left-icon branch is shared.
4. To see the image state, temporarily give the poster a value: in `client/state/stats/lists/utils.js` change `poster: item.poster ?? null` to `poster: item.poster ?? '<any image URL>'`, and in `client/my-sites/stats/videopress-stats-module/index.jsx` change `poster: row.poster` to `poster: row.poster ?? '<any image URL>'`. The image should fill the slot without distortion and without overlapping the bar fill or the title.
5. Narrow the window below 450px on All Videos — the title should ellipsise and the thumbnail should keep its size.

Verified locally on both surfaces in both states, at desktop and at 406px wide.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

Checklist notes: no new user-facing strings, so no string freeze needed. The thumbnail is decorative (`alt=""`, and the placeholder SVG is `aria-hidden`), with the adjacent title link carrying the accessible name. Dark mode and multi-environment testing are still outstanding.
