### PR TITLE
Dashboard: fix unread dot fallback color on dark omnibar (DOTMSD-1290)

### DIFF
--- a/client/dashboard/app/interim-omnibar/style.scss
+++ b/client/dashboard/app/interim-omnibar/style.scss
@@ -12,7 +12,7 @@ body:has(#wpcom-omnibar) #wpcom {
 	--color-masterbar-border: #303030;
 	--color-masterbar-item-hover-background: #0c0c0c;
 	--color-masterbar-item-active-background: #0c0c0c;
-	--color-masterbar-unread-dot-background: var(--studio-wordpress-blue-20, #3858e9);
+	--color-masterbar-unread-dot-background: var(--studio-wordpress-blue-20, #adbaf3);
 	--color-masterbar-submenu-text: #bcbcbc;
 
 	button.masterbar__item {

--- a/client/dashboard/app/omnibar/plugin-notifications.scss
+++ b/client/dashboard/app/omnibar/plugin-notifications.scss
@@ -16,7 +16,7 @@
 }
 
 .omnibar .omnibar__notifications-unread-dot {
-	fill: var( --studio-wordpress-blue-20, #3858e9 );
+	fill: var( --studio-wordpress-blue-20, #adbaf3 );
 	stroke: var( --omnibar-background );
 	stroke-width: 6%;
 }


### PR DESCRIPTION
Fixes DOTMSD-1290

## Proposed Changes

* Correct the fallback hex for the notifications unread dot in `client/dashboard/app/interim-omnibar/style.scss` from `#3858e9` to `#adbaf3`.
* Same one-line fix in `client/dashboard/app/omnibar/plugin-notifications.scss`, which repeats the identical pattern for the new omnibar's bell.

## Why are these changes being made?

The unread dot over the notifications bell renders as dim dark blue on the always-dark `#1e1e1e` bar. You can barely see it.

Both files ask for `var(--studio-wordpress-blue-20, #3858e9)`, but the dashboard never loads the color-studio custom properties, so the fallback always wins. And the fallback is the wrong swatch: `#3858e9` is studio blue-50, not blue-20. Blue-20 is `#adbaf3`, the light periwinkle the classic masterbar's Global scheme resolves to for this dot (`_global.scss` maps `--theme-notification-color` to `--studio-wordpress-blue-20`). This keeps the `var()` intact and just corrects the fallback, so if the studio properties ever do load, nothing changes.

The same custom property also colors the cart icon's dot in the classic masterbar, so that picks up the fix inside the omnibar too.

Not touched here: the support-session omnibar palette hardcodes `#3858e9` for the dot on the orange bar, and the dashboard bell in `client/dashboard/app/notifications/style.scss` fills its dot with `--wp-admin-theme-color` on a light surface. Different situations, out of scope.

## Testing Instructions

I verified the token resolution in code (the studio custom properties are not loaded in the dashboard bundle, so the fallback is what renders). Visual check for the reviewer:

1. Run `yarn start-dashboard` and open `http://my.localhost:3000/sites`.
2. With unread notifications on your account, look at the bell in the top bar. Before: a dim dark-blue dot that nearly disappears into the `#1e1e1e` bar. After: a light periwinkle dot (`#adbaf3`), matching the classic wordpress.com masterbar.
3. Repeat with the OS/system in dark mode. The bar is always dark, so the dot should look the same in both modes.
4. If your dashboard variant uses the new omnibar bell instead, check the same dot there.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
