### PR TITLE
Notifications: add dark mode overrides for hardcoded light literals (DOTMSD-1296)

### DIFF
--- a/apps/notifications/src/app/note-icon/style.scss
+++ b/apps/notifications/src/app/note-icon/style.scss
@@ -1,3 +1,4 @@
+@use "calypso/assets/stylesheets/shared/mixins/dark-theme" as ui-mixins;
 @import '@wordpress/base-styles/colors';
 
 // Nudge the icon down so it visually aligns with the cap-height of adjacent
@@ -20,6 +21,10 @@
 	.wpnc__note-icon-placeholder {
 		background: $gray-100;
 		border-radius: 50%;
+
+		@include ui-mixins.when-dark-theme {
+			background: var(--wp-components-color-gray-800, #2c3338);
+		}
 	}
 
 	&::after {
@@ -33,8 +38,20 @@
 		border-radius: 50%;
 		transition: border-color 0.15s ease-in-out;
 
+		// Mirror the subtle black overlay ring with a white one on dark
+		// avatars; a black ring disappears against the dark surface.
+		@include ui-mixins.when-dark-theme {
+			border-color: rgba(255, 255, 255, 0.15);
+		}
+
 		a:hover & {
 			border: solid 1px var(--wp-admin-theme-color);
+
+			// Restate for dark: the dark base ring above out-specifies this
+			// hover rule, so the accent needs its own dark-scoped selector.
+			@include ui-mixins.when-dark-theme {
+				border-color: var(--wp-admin-theme-color);
+			}
 		}
 	}
 }

--- a/apps/notifications/src/app/note-list/style.scss
+++ b/apps/notifications/src/app/note-list/style.scss
@@ -1,3 +1,4 @@
+@use "calypso/assets/stylesheets/shared/mixins/dark-theme" as ui-mixins;
 @import '@wordpress/base-styles/colors';
 
 .wpnc__note-list {
@@ -54,4 +55,8 @@
 	display: inline-block;
 	transform: translateY(2px);
 	fill: #8c8f94;
+
+	@include ui-mixins.when-dark-theme {
+		fill: var(--wp-components-color-gray-700, #9aa2b1);
+	}
 }

--- a/apps/notifications/src/app/note-shortcuts/style.scss
+++ b/apps/notifications/src/app/note-shortcuts/style.scss
@@ -1,3 +1,5 @@
+@use "calypso/assets/stylesheets/shared/mixins/dark-theme" as ui-mixins;
+
 .wpnc__keyboard-shortcuts-popover {
 	width: min-content;
 
@@ -14,6 +16,10 @@
 		min-height: 25px;
 		text-align: center;
 		margin-right: 5px;
+
+		@include ui-mixins.when-dark-theme {
+			border-color: var(--wp-components-color-gray-400, #424855);
+		}
 	}
 
 	.shortcut.letter {

--- a/apps/notifications/src/app/note/style.scss
+++ b/apps/notifications/src/app/note/style.scss
@@ -397,5 +397,11 @@
 		.wpnc-app__detail-pane {
 			border-color: var( --wpnc-divider__color );
 		}
+
+		// The reply gridicon ships a light-mode gray fill; lighten it so it
+		// stays legible on the dark surface.
+		.wpnc__gridicon .gridicons-reply {
+			fill: var( --wp-components-color-gray-700, #9aa2b1 );
+		}
 	}
 }

--- a/apps/notifications/src/app/style.scss
+++ b/apps/notifications/src/app/style.scss
@@ -177,6 +177,12 @@ $wpnc-slide-easing: cubic-bezier(0.33, 0, 0, 1);
 		border-radius: $wpnc-pane-radius;
 		box-shadow: $wpnc-pane-shadow;
 		pointer-events: auto;
+
+		// The light 12% shadow is invisible on a dark backdrop; deepen it so
+		// the pane still reads as elevated.
+		@include ui-mixins.when-dark-theme {
+			box-shadow: 0 0 16px rgba(0, 0, 0, 0.5);
+		}
 	}
 
 	.wpnc-app__detail-pane {

--- a/apps/notifications/src/standalone-app/style.scss
+++ b/apps/notifications/src/standalone-app/style.scss
@@ -1,3 +1,4 @@
+@use "calypso/assets/stylesheets/shared/mixins/dark-theme" as ui-mixins;
 @import "@wordpress/base-styles/variables";
 @import "@wordpress/base-styles/colors";
 @import "@wordpress/base-styles/breakpoints";
@@ -37,6 +38,18 @@ body {
 	border-radius: 4px;
 	box-shadow: 0 0 16px rgba(0, 0, 0, 0.12);
 	overflow: hidden;
+
+	@include ui-mixins.when-dark-theme {
+		border-color: var(--wp-components-color-gray-400, #424855);
+	}
+
+	// Scoped below the large breakpoint so the dark shadow doesn't override
+	// the `box-shadow: none` reset in the break-large block further down.
+	@media (max-width: #{$break-large - 1px}) {
+		@include ui-mixins.when-dark-theme {
+			box-shadow: 0 0 16px rgba(0, 0, 0, 0.5);
+		}
+	}
 
 	@include break-small {
 		max-width: 448px;


### PR DESCRIPTION
Part of DOTMSD-1296

## Proposed Changes

The redesigned notifications panel hardcodes a handful of light-mode color literals with no dark counterpart. In dark mode the reply gridicon sits at a gray tuned for white surfaces, the keyboard shortcut chips keep a `#ccc` border, the avatar ring is a black overlay that vanishes on dark, the avatar loading placeholder stays light gray, and the pane shadow (12% black) is invisible on a dark backdrop.

* Add `when-dark-theme` overrides for each of these, matching the values the panel's existing dark overrides already use (`--wp-components-color-gray-700` for muted icon fills, `gray-400` for borders, `gray-800` for raised surfaces).
* Avatar ring: mirror the subtle `rgba(0,0,0,0.1)` overlay with `rgba(255,255,255,0.15)` so it still tints the image edge instead of drawing a solid border. The hover accent ring is restated in dark because the base dark rule out-specifies the light hover rule.
* Pane shadow and the standalone widget frame get a deeper shadow (50% black) and a `gray-400` border in dark. The standalone shadow override is scoped below the large breakpoint so the existing `box-shadow: none` reset there still wins.

Every override is inside a `when-dark-theme` block, so light mode output is unchanged apart from the added dark-gated selectors.

Deliberately left out (follow-ups, not loaded by the redesigned panel or owned elsewhere):

* `src/panel/boot/stylesheets/note-common.scss` and `main.scss` literals. Those load only through the legacy `src/panel` and `src/standalone` entries, not the redesigned app.
* `$wpnc__rich-blue` primary buttons in `panel/boot/stylesheets/shared/colors.scss`. Same reason, and there is no existing dark treatment pattern for them to follow.
* The white ring and `$gray-600` badge colors on the note-list mini icon, and `$gray-700` user description separator. Borderline rather than broken; happy to fold them in if a reviewer wants.
* `note-list/dataviews-overrides.scss` is intentionally untouched. An open PR owns it.

## Why are these changes being made?

Dark mode support for the redesigned panel. Some text and icons fail contrast in dark mode and some dividers and backgrounds read wrong because these literals only ever had light-mode values.

## Testing Instructions

1. Run `yarn start-dashboard` and open `http://my.localhost:3000`.
2. Switch the dashboard to dark mode (preference `hosting-dashboard-color-scheme`, or the debug menu's preferences helper).
3. Open the notifications panel from the bell.
4. Check a note with a reply snippet: the reply arrow icon should be a lighter gray, not the light-mode `#8c8f94`.
5. Open the actions menu, then keyboard shortcuts: the key chips should have a visible dark-gray border rather than `#ccc`.
6. In the list, avatars should show a faint light ring (and a dark placeholder while loading), with the accent ring still appearing on hover.
7. At a wide viewport with a note open, the list pane should still read as elevated over the page.
8. Confirm light mode is visually unchanged.

I verified selector output by compiling the changed stylesheets and running stylelint. I did not run the app itself, so the dark values should be eyeballed once in a live panel before merge.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
