### PR TITLE
Notifications: keep panel tabs on one row in long locales (DOTMSD-1373)

### DIFF
--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -131,7 +131,15 @@ const NotePanel = ( {
 								<Tabs.Tab
 									key={ name }
 									tabId={ name }
-									style={ { fontFamily: 'inherit', fontWeight: 500, lineHeight: '16px' } }
+									style={ {
+										fontFamily: 'inherit',
+										fontWeight: 500,
+										lineHeight: '16px',
+										// Compact padding so all five tabs fit the pane in wider
+										// locales (DE/ES/PT); locales that still overflow fall back
+										// to the TabList's built-in horizontal scroll and fades.
+										paddingInline: '8px',
+									} }
 									ref={ ( element: HTMLButtonElement ) => {
 										tabRefs.current[ name ] = element;
 									} }

--- a/apps/notifications/src/panel/boot/stylesheets/actions.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/actions.scss
@@ -130,5 +130,6 @@
 
 	p {
 		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 }


### PR DESCRIPTION
Fixes DOTMSD-1373

## Proposed Changes

* Compact the notification panel's filter tab padding (16px to 8px inline) via the `style` prop on `Tabs.Tab`, so all five tabs fit the pane in wider locales.
* Add `text-overflow: ellipsis` to the note action button labels in `actions.scss`, so text that can't fit truncates with an ellipsis instead of a hard clip.

## Why are these changes being made?

The issue was reported as button text truncating in some locales. That's real, but it's the secondary problem. The action buttons fit at the standard 448px pane; their hard clip only bites in narrower panes. The structural break is the tab row: in English the five tabs measure 394px in a 394px row, zero slack. Any longer locale overflows. German comes to roughly 435px, which pushes the last tab out of the row with no wrap strategy, so "Likes" ends up cut off behind the overflow fade with no visible scrollbar.

I verified the widths by measuring the actual label strings at the tab typography (13px system font, weight 500) in headless Chromium. At the current 16px inline padding, DE, ES, PT and FR all overflow the 394px row. At 8px padding they all fit, with EN at 314px. Very long scripts (Russian measures ~515px even at 8px) still overflow, and for those the `Tabs` component's built-in behavior takes over: the tab list is a horizontal scroll container with fade indicators, and it auto-scrolls the selected tab into view. No component internals are restyled; the padding goes through the same public `style` prop the tabs already use for font overrides.

The button half keeps its current wrap behavior. The ellipsis only changes what happens when a single word is wider than the button: previously it clipped mid-glyph, now it truncates legibly. The full label remains available via the button's `title` attribute.

## Testing Instructions

1. Open the notifications panel from the bell.
2. Check the tab row in English: five tabs on one row, no clipping.
3. Force a long locale. Either switch the account language to Deutsch, or in DevTools replace the tab labels with the German strings (Alle, Ungelesen, Kommentare, Abonnenten, Likes). All five tabs should fit on one row with no clipping.
4. Replace a label with something absurdly long (or switch to Russian). The row should scroll horizontally with fade indicators at the overflowing edge, and clicking or arrow-keying to an off-screen tab should scroll it into view.
5. Open a comment notification and narrow the pane below 448px. Long action button labels should show an ellipsis instead of a hard clip.

I verified the fit math with real font metrics per locale (headless Chromium canvas measurement, values above). I have not eyeballed a live German-locale session yet; before/after screenshots to follow.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
