### PR TITLE
Stats: standardise feature names to “device stats” and “region and city stats”

### DIFF
--- a/client/my-sites/stats/stats-card-upsell/stats-upsell-copy.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-upsell-copy.tsx
@@ -84,7 +84,7 @@ const getUpsellCopy = ( statType: string ) => {
 		case STATS_FEATURE_LOCATION_CITY_VIEWS:
 			// TODO: Add link to proper support page
 			return translate(
-				'Access to visitor stats at the {{link}}regional and city{{/link}} level for more accurate analysis.',
+				'Access to {{link}}region and city stats{{/link}} for more accurate analysis.',
 				{
 					components: {
 						link: jetpackTrafficSupportLinkWithAnchor( 'countries' ),

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -132,7 +132,7 @@ const DoYouLoveJetpackStatsNotice = ( {
 	const description = isWPCOMPaidStatsFlow
 		? paidStatsRemoveHardcoding
 		: translate(
-				'Upgrade to unlock UTM tracking, device stats, and region and city locations, and get priority support.'
+				'Upgrade to unlock UTM tracking, device stats, and region and city stats, and get priority support.'
 		  );
 
 	const CTAText = isWPCOMPaidStatsFlow ? translate( 'Upgrade' ) : translate( 'Upgrade my Stats' );

--- a/client/my-sites/stats/stats-notices/free-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-site-upgrade-notice.tsx
@@ -117,7 +117,7 @@ const FreeSiteUpgradeNotice = ( { siteId, hasFreeStats, isOdysseyStats }: StatsN
 				}
 		  )
 		: translate(
-				'%(product)s is free to keep using. A paid plan adds UTM stats, device stats, and region and city locations.',
+				'%(product)s is free to keep using. A paid plan adds UTM stats, device stats, and region and city stats.',
 				{ args: { product: STATS_PRODUCT_NAME } }
 		  );
 

--- a/client/my-sites/stats/stats-notices/test/free-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/test/free-site-upgrade-notice.tsx
@@ -83,7 +83,7 @@ describe( 'FreeSiteUpgradeNotice', () => {
 		expect( screen.getByText( 'Unlock more Stats with a paid plan' ) ).toBeVisible();
 		expect(
 			screen.getByText(
-				'Jetpack Stats is free to keep using. A paid plan adds UTM stats, device stats, and region and city locations.'
+				'Jetpack Stats is free to keep using. A paid plan adds UTM stats, device stats, and region and city stats.'
 			)
 		).toBeVisible();
 		expect( screen.getByRole( 'button', { name: 'Upgrade' } ) ).toBeVisible();

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -104,7 +104,7 @@ const PersonalPurchase = ( {
 
 			<div className={ `${ COMPONENT_CLASS_NAME }__notice` }>
 				{ translate(
-					'To unlock UTM tracking, device attribution and more, {{Button}}upgrade to a paid plan{{/Button}}.',
+					'To unlock UTM tracking, device stats and more, {{Button}}upgrade to a paid plan{{/Button}}.',
 					{
 						components: {
 							Button: <Button variant="link" href="#" onClick={ handleClick } />,
@@ -258,10 +258,10 @@ function StatsBenefitsListing( {
 					{ translate( 'No UTM tracking for your marketing campaigns' ) }
 				</li>
 				<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--not-included` }>
-					{ translate( 'No granular location stats' ) }
+					{ translate( 'No region and city stats' ) }
 				</li>
 				<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--not-included` }>
-					{ translate( 'No device attribution' ) }
+					{ translate( 'No device stats' ) }
 				</li>
 				<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--not-included` }>
 					{ translate( 'No access to upcoming advanced features' ) }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -93,7 +93,7 @@ const StatsBenefitsCommercial = () => {
 					/>
 				</li>
 				<li>
-					{ translate( 'View device attributes' ) }
+					{ translate( 'View device stats' ) }
 					<Icon
 						icon={ info }
 						ref={ deviceAttributesInfoIconRef }
@@ -182,7 +182,7 @@ const StatsBenefitsCommercial = () => {
 				className="stats-purchase__info-popover"
 			>
 				<div className="stats-purchase__info-popover-content">
-					{ translate( 'Get detailed devices stats for your site visitors.' ) }
+					{ translate( 'Get detailed device stats for your site visitors.' ) }
 				</div>
 			</Popover>
 		</div>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -57,7 +57,7 @@ const StatsBenefitsCommercial = () => {
 	const overageInfoIconRef = useRef( null );
 	const trackingInfoIconRef = useRef( null );
 	const customDateRangesInfoIconRef = useRef( null );
-	const deviceAttributesInfoIconRef = useRef( null );
+	const deviceStatsInfoIconRef = useRef( null );
 	const [ spikeInfoShow, setSpikeInfoShow ] = useState( false );
 	const handleSpikePopoverOpen = () => setSpikeInfoShow( true );
 	const handleSpikePopoverClose = () => setSpikeInfoShow( false );
@@ -70,9 +70,9 @@ const StatsBenefitsCommercial = () => {
 	const [ customDateRangesInfoShow, setCustomDateRangesInfoShow ] = useState( false );
 	const handleCustomDatesPopoverOpen = () => setCustomDateRangesInfoShow( true );
 	const handleCustomDatesPopoverClose = () => setCustomDateRangesInfoShow( false );
-	const [ deviceAttributesInfoShow, setDeviceAttributesInfoShow ] = useState( false );
-	const handleDeviceAttributesPopoverOpen = () => setDeviceAttributesInfoShow( true );
-	const handleDeviceAttributesPopoverClose = () => setDeviceAttributesInfoShow( false );
+	const [ deviceStatsInfoShow, setDeviceStatsInfoShow ] = useState( false );
+	const handleDeviceStatsPopoverOpen = () => setDeviceStatsInfoShow( true );
+	const handleDeviceStatsPopoverClose = () => setDeviceStatsInfoShow( false );
 
 	return (
 		<div className={ `${ COMPONENT_CLASS_NAME }__benefits` }>
@@ -96,9 +96,9 @@ const StatsBenefitsCommercial = () => {
 					{ translate( 'View device stats' ) }
 					<Icon
 						icon={ info }
-						ref={ deviceAttributesInfoIconRef }
-						onMouseEnter={ handleDeviceAttributesPopoverOpen }
-						onMouseLeave={ handleDeviceAttributesPopoverClose }
+						ref={ deviceStatsInfoIconRef }
+						onMouseEnter={ handleDeviceStatsPopoverOpen }
+						onMouseLeave={ handleDeviceStatsPopoverClose }
 					/>
 				</li>
 				<li>
@@ -177,8 +177,8 @@ const StatsBenefitsCommercial = () => {
 			</Popover>
 			<Popover
 				position="right"
-				isVisible={ deviceAttributesInfoShow }
-				context={ deviceAttributesInfoIconRef.current }
+				isVisible={ deviceStatsInfoShow }
+				context={ deviceStatsInfoIconRef.current }
 				className="stats-purchase__info-popover"
 			>
 				<div className="stats-purchase__info-popover-content">

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -205,7 +205,7 @@ const useLocalizedStrings = ( isCommercial: boolean ) => {
 				args: { product: STATS_PRODUCT_NAME },
 			} ),
 			infoText: translate(
-				'Unlock UTM stats, device stats, and region and city locations with a paid plan.',
+				'Unlock UTM stats, device stats, and region and city stats with a paid plan.',
 				{
 					context: 'Stats: Descriptive text in the purchase flow',
 				}


### PR DESCRIPTION
Fixes STATS-400 (sub-issue of STATS-364).

## Proposed Changes

* Standardise the two Paid Stats feature names across every upsell surface (locked-module cards, notices, and purchase pages), for both Calypso and Odyssey Stats (shared components):
  * **device stats** — replaces "device attribution", "device attributes", and "devices stats".
  * **region and city stats** — replaces "region and city locations", "granular location stats", and "regional and city level".
* Touched surfaces:
  * Purchase flow personal plan step (`stats-purchase-personal.tsx`): upgrade notice and the "not included" benefits list.
  * Purchase flow benefits listing (`stats-purchase-shared.tsx`): benefit item and its info popover.
  * Purchase flow commercial info text (`stats-purchase-single-item.tsx`).
  * Upgrade notices (`do-you-love-jetpack-stats-notice.tsx`, `free-site-upgrade-notice.tsx`) and the matching test expectation.
  * Locked-module card copy for the region/city views upsell (`stats-upsell-copy.tsx`).

## Why are these changes being made?

* Feature names had drifted across upsell surfaces, mixing several terms for the same two features. "Device attribution" is also actively misleading — attribution means something else and will clash with WooCommerce order attribution later. This settles on a single term per feature everywhere.

## Testing Instructions

* Run `yarn test-client client/my-sites/stats` — all suites pass.
* Grep check: `grep -rniE "device attribution|device attributes|devices stats|granular location|region and city locations|regional and city" client/ --include="*.tsx" --include="*.ts"` returns no user-facing strings.
* Visual spot-check: visit `/stats/purchase/:site` on a free site and confirm the benefits list and notice copy read "device stats" / "region and city stats"; on a free site's Traffic page, confirm the locked Locations module upsell copy reads "region and city stats".

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?