### PR TITLE
Stats: reassure free sites the upsell is optional

### DIFF
--- a/client/my-sites/stats/stats-notices/free-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-site-upgrade-notice.tsx
@@ -100,7 +100,7 @@ const FreeSiteUpgradeNotice = ( { siteId, hasFreeStats, isOdysseyStats }: StatsN
 		? ( translate( 'Grow faster with %(product)s', {
 				args: { product: STATS_PRODUCT_NAME },
 		  } ) as string )
-		: ( translate( 'Unlock premium features' ) as string );
+		: ( translate( 'Unlock more Stats with a paid plan' ) as string );
 	const freeTitle = translate( 'Want to get the most out of %(product)s?', {
 		args: { product: STATS_PRODUCT_NAME },
 	} ) as string;
@@ -117,7 +117,8 @@ const FreeSiteUpgradeNotice = ( { siteId, hasFreeStats, isOdysseyStats }: StatsN
 				}
 		  )
 		: translate(
-				'Upgrade to unlock UTM tracking, device stats, and region and city locations, and get priority support.'
+				'%(product)s is free to keep using. A paid plan adds UTM stats, device stats, and region and city locations.',
+				{ args: { product: STATS_PRODUCT_NAME } }
 		  );
 
 	const CTAText = translate( 'Upgrade' );

--- a/client/my-sites/stats/stats-notices/test/free-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/test/free-site-upgrade-notice.tsx
@@ -80,10 +80,10 @@ describe( 'FreeSiteUpgradeNotice', () => {
 		renderNotice();
 
 		expect( screen.getByRole( 'button', { name: 'close' } ) ).toBeVisible();
-		expect( screen.getByText( 'Unlock premium features' ) ).toBeVisible();
+		expect( screen.getByText( 'Unlock more Stats with a paid plan' ) ).toBeVisible();
 		expect(
 			screen.getByText(
-				'Upgrade to unlock UTM tracking, device stats, and region and city locations, and get priority support.'
+				'Jetpack Stats is free to keep using. A paid plan adds UTM stats, device stats, and region and city locations.'
 			)
 		).toBeVisible();
 		expect( screen.getByRole( 'button', { name: 'Upgrade' } ) ).toBeVisible();


### PR DESCRIPTION
Fixes STATS-401

## Proposed Changes

* Apply STATS-401's copy to the Jetpack/Odyssey branch of the `free_site_upgrade` notice: title "Unlock more Stats with a paid plan", body "Jetpack Stats is free to keep using. A paid plan adds UTM stats, device stats, and region and city locations."
* The WPCOM paid-flow branch and the free-Stats title are unchanged.

## Why are these changes being made?

* STATS-401 asked for this exact copy on the hard paywall notice ("You need to upgrade to a commercial license…"). Since #113252, that paywall variant can no longer render: the STATS-387 kill switch neutralises the sticker data and the commercial notice's registry entry is disabled, so already-flagged sites see the unified `free_site_upgrade` notice instead. Landing the rewrite there reaches the audience the ticket cares about — no already-flagged site sees anything about commercial licenses, and the message now leads with Stats staying free.
* The dormant paywall variant keeps its copy verbatim, consistent with #113252's rule that the pre-kill machinery stays untouched for kill-switch flip-back.

## Testing Instructions

1. On a self-hosted Jetpack site without a paid Stats purchase, open Calypso Stats (`/stats/day/:site`) or Odyssey Stats. (Until the `free_site_upgrade` server allow-list ships, force the notice visible locally.)
2. Verify the notice reads "Unlock more Stats with a paid plan" with the free-to-keep-using body.
3. On a WPCOM site with `stats/paid-wpcom-v2`, verify the notice still shows the unchanged "Grow faster with Jetpack Stats" copy.
4. `yarn test-client client/my-sites/stats/stats-notices` passes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?