### PR TITLE
Stats: drop the settings tooltip notice ids

### DIFF
--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -7,8 +7,6 @@ export const NOTICES_KEY_SHOW_FLOATING_USER_FEEDBACK_PANEL = 'show_floating_user
 
 const DEFAULT_SERVER_NOTICES_VISIBILITY = {
 	opt_in_new_stats: false,
-	traffic_page_highlights_module_settings: false,
-	traffic_page_settings: false,
 	do_you_love_jetpack_stats: false,
 	commercial_site_upgrade: false,
 	// Defaults to hidden until the server includes it in the notices response,
@@ -34,7 +32,6 @@ export type NoticeIdType = keyof Notices;
 // These notices are mutually exclusive, so if one is active, the other should be hidden.
 // The IDs are sorted by priory from high to low.
 const CONFLICT_NOTICE_ID_GROUPS: Record< string, Array< NoticeIdType > > = {
-	settings_tool_tips: [ 'traffic_page_settings', 'traffic_page_highlights_module_settings' ],
 	dashboard_notices: [
 		// Set the highest priority to prevent blocking Stats under any circumstances.
 		'gdpr_cookie_consent',


### PR DESCRIPTION
Part of STATS-409. Follow-up to #113271 — **stacked on that branch**, so review only the last commit until it merges (GitHub will retarget this to `trunk` automatically).

## Proposed Changes

* Remove the `traffic_page_settings` and `traffic_page_highlights_module_settings` notice ids from `DEFAULT_SERVER_NOTICES_VISIBILITY`.
* Remove the now-empty `settings_tool_tips` conflict group.

## Why are these changes being made?

#113271 removed the Traffic page settings tour, which was the last consumer of `traffic_page_settings`. `traffic_page_highlights_module_settings` had already been orphaned before that, so the `settings_tool_tips` conflict group was left with nothing to arbitrate between. Raised in review on #113271.

`NoticeIdType` derives from the defaults object, so dropping the keys is sufficient — nothing else references them. The server may still return these ids in the notices payload; the extra keys are spread in and ignored, exactly as they are for any id the client does not know about.

Note that `opt_in_new_stats` also has no client consumers, but it has been that way independently of this work, so it is left alone rather than folded into this cleanup.

## Testing Instructions

This is dead-code removal with no runtime behavior change; the notices that remain are unaffected.

1. Visit Stats → Traffic and confirm the page renders normally with no console errors.
2. On a site eligible for an upsell notice, confirm the notice still renders and dismisses as before (the `dashboard_notices` conflict group is untouched).
3. `yarn test-client client/my-sites/stats/stats-notices` passes.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
