### PR TITLE
Jetpack AI: survive an editorial review implication with no affected_blocks

### DIFF
--- a/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.test.tsx
@@ -465,6 +465,43 @@ describe( 'AiEditorialReview — smoke render', () => {
 		expect( mockedRecordTracksEvent ).not.toHaveBeenCalled();
 	} );
 
+	it( 'renders a conflict that omits positions', () => {
+		render(
+			<AiEditorialReview
+				{ ...basePayload( {
+					conflicts: [
+						{
+							subject: 'Tone of the opening',
+							guideline_anchor: null,
+							recommended_resolution: 'Use neutral phrasing.',
+						},
+					] as any,
+				} ) }
+			/>
+		);
+
+		expect( screen.getByText( 'Tone of the opening' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a suggested edit that omits supported_by_reviewers', () => {
+		render(
+			<AiEditorialReview
+				{ ...basePayload( {
+					suggested_edits: [
+						{
+							block_index: 1,
+							current_text: 'voted last Tuesday',
+							suggested_text: 'voted on Tuesday',
+							rationale: 'Concise.',
+						},
+					] as any,
+				} ) }
+			/>
+		);
+
+		expect( screen.getByText( 'Concise.' ) ).toBeInTheDocument();
+	} );
+
 	it( 'renders an implication that omits affected_blocks', () => {
 		// The tool schema marks affected_blocks required but the tool is not strict,
 		// so the model can omit it. Indexing it directly used to blank the card.

--- a/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.test.tsx
@@ -465,6 +465,23 @@ describe( 'AiEditorialReview — smoke render', () => {
 		expect( mockedRecordTracksEvent ).not.toHaveBeenCalled();
 	} );
 
+	it( 'renders an implication that omits affected_blocks', () => {
+		// The tool schema marks affected_blocks required but the tool is not strict,
+		// so the model can omit it. Indexing it directly used to blank the card.
+		render(
+			<AiEditorialReview
+				{ ...basePayload( {
+					implications: [
+						{ change: 'Tone shift', implies: 'May affect downstream FAQ wording.' },
+					] as any,
+				} ) }
+			/>
+		);
+
+		expect( screen.getByText( 'Tone shift' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Affects:' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'does not tag a stale AER edit "Manual edit" even when the source text is absent', () => {
 		// Editor moved to post 999 (stale) AND the current block doesn't contain the
 		// edit's source text — so the frontend reason is truthy. Without the

--- a/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.test.tsx
@@ -519,6 +519,100 @@ describe( 'AiEditorialReview — smoke render', () => {
 		expect( screen.queryByText( 'Affects:' ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'renders a payload whose list fields are null', () => {
+		// Destructuring defaults would not catch this: an explicit null is not
+		// undefined, so `= []` never fires.
+		render(
+			<AiEditorialReview
+				{ ...basePayload( {
+					conflicts: null as any,
+					implications: null as any,
+					suggested_edits: null as any,
+					guideline_violations: null as any,
+				} ) }
+			/>
+		);
+
+		expect(
+			screen.getByText( 'Two reviewers disagree on the procedural framing.' )
+		).toBeInTheDocument();
+		expect( screen.queryByText( /Apply all/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'drops null items from every model-supplied list and renders the rest', () => {
+		render(
+			<AiEditorialReview
+				{ ...basePayload( {
+					conflicts: [
+						null,
+						{
+							subject: 'Procedural framing',
+							positions: [ null, { reviewer: 'Marcus', position: 'Soften.' } ],
+							guideline_anchor: null,
+							recommended_resolution: 'Use neutral phrasing.',
+							candidate_resolutions: [
+								null,
+								{
+									source: 'ai',
+									reviewer_name: null,
+									label: 'AI resolution',
+									block_index: 1,
+									current_text: 'voted last Tuesday',
+									text: 'voted on Tuesday',
+									rationale: '',
+								},
+							],
+						},
+					] as any,
+					implications: [
+						null,
+						{
+							change: 'Tone shift',
+							implies: 'May affect downstream FAQ wording.',
+							affected_blocks: [ null, 1 ],
+						},
+					] as any,
+					suggested_edits: [
+						null,
+						{
+							block_index: 1,
+							current_text: 'voted last Tuesday',
+							suggested_text: 'voted on Tuesday',
+							rationale: 'Concise.',
+							supported_by_reviewers: [ null, {}, 'Priya' ],
+						},
+					] as any,
+					guideline_violations: [
+						null,
+						{
+							category: 'copy',
+							block_name: null,
+							guideline_quote: 'Avoid passive voice.',
+							block_index: 1,
+							violating_text: 'was voted upon',
+							issue: 'Passive voice detected.',
+						},
+					] as any,
+				} ) }
+			/>
+		);
+
+		// Every real item renders.
+		expect( screen.getByText( 'Procedural framing' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Soften.' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Apply AI change' } ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Tone shift' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Affects:' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Concise.' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Priya' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Passive voice detected.' ) ).toBeInTheDocument();
+
+		// The null entries are not counted by the stats chips.
+		expect( screen.getByTitle( 'Jump to conflicts' ).textContent ).toMatch( /1/ );
+		expect( screen.getByTitle( 'Jump to implications' ).textContent ).toMatch( /1/ );
+		expect( screen.getByTitle( 'Jump to suggested edits' ).textContent ).toMatch( /1/ );
+	} );
+
 	it( 'does not tag a stale AER edit "Manual edit" even when the source text is absent', () => {
 		// Editor moved to post 999 (stale) AND the current block doesn't contain the
 		// edit's source text — so the frontend reason is truthy. Without the

--- a/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.tsx
@@ -73,7 +73,7 @@ interface Conflict {
 interface Implication {
 	change: string;
 	implies: string;
-	affected_blocks: number[];
+	affected_blocks?: number[];
 }
 
 interface SuggestedEdit {
@@ -1389,27 +1389,33 @@ export default function AiEditorialReview( {
 									onToggle={ ( next: boolean ) => setSectionOpen( 'implications', next ) }
 								>
 									<ul>
-										{ implications.map( ( imp, i ) => (
-											<li key={ `imp-${ i }` }>
-												<strong>{ imp.change }</strong> — { imp.implies }
-												{ imp.affected_blocks.length > 0 && (
-													<span className="jetpack-ai-editorial-review__affected-blocks">
-														{ ' ' }
-														{ __( 'Affects:', __i18n_text_domain__ ) }{ ' ' }
-														{ imp.affected_blocks.map( ( b, j ) => (
-															<span key={ `imp-${ i }-aff-${ j }` }>
-																{ j > 0 && ', ' }
-																<BlockRef
-																	index={ b }
-																	blocks={ blocks }
-																	onFocus={ focusCurrentPostBlock }
-																/>
-															</span>
-														) ) }
-													</span>
-												) }
-											</li>
-										) ) }
+										{ implications.map( ( imp, i ) => {
+											// A non-strict payload can omit affected_blocks.
+											const affectedBlocks = Array.isArray( imp.affected_blocks )
+												? imp.affected_blocks
+												: [];
+											return (
+												<li key={ `imp-${ i }` }>
+													<strong>{ imp.change }</strong> — { imp.implies }
+													{ affectedBlocks.length > 0 && (
+														<span className="jetpack-ai-editorial-review__affected-blocks">
+															{ ' ' }
+															{ __( 'Affects:', __i18n_text_domain__ ) }{ ' ' }
+															{ affectedBlocks.map( ( b, j ) => (
+																<span key={ `imp-${ i }-aff-${ j }` }>
+																	{ j > 0 && ', ' }
+																	<BlockRef
+																		index={ b }
+																		blocks={ blocks }
+																		onFocus={ focusCurrentPostBlock }
+																	/>
+																</span>
+															) ) }
+														</span>
+													) }
+												</li>
+											);
+										} ) }
 									</ul>
 								</PanelBody>
 							</div>

--- a/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.tsx
@@ -103,10 +103,15 @@ type EditorPostId = number | string;
 
 interface AiEditorialReviewProps {
 	summary: string;
-	conflicts: Conflict[];
-	implications: Implication[];
-	suggested_edits: SuggestedEdit[];
-	guideline_violations: GuidelineViolation[];
+	/**
+	 * The list props mirror required tool-schema fields, but chat history
+	 * re-renders payloads produced before the server-side guards existed, so
+	 * each one can arrive missing or null. Normalised through toList().
+	 */
+	conflicts?: Conflict[] | null;
+	implications?: Implication[] | null;
+	suggested_edits?: SuggestedEdit[] | null;
+	guideline_violations?: GuidelineViolation[] | null;
 	review_context?: ReviewContext;
 	/** Source post the review was generated for. Used to detect navigation to a different post. */
 	postId?: EditorPostId;
@@ -200,11 +205,12 @@ function formatRelativeTime( timestamp: number ): string {
 
 /**
  * Model-supplied list fields are typed as required by the tool schema, but the
- * provider drops `strict`, so any of them can arrive missing or malformed.
- * Reading `.length` or `.map` off one that did unmounts the whole card.
+ * provider drops `strict`, so any of them can arrive missing, null, or with
+ * null items inside an otherwise valid list. Reading `.length`, `.map`, or a
+ * property off one of those unmounts the whole card.
  */
-function toList< T >( value: T[] | undefined ): T[] {
-	return Array.isArray( value ) ? value : [];
+function toList< T >( value: ( T | null )[] | null | undefined ): T[] {
+	return Array.isArray( value ) ? value.filter( ( item ): item is T => item != null ) : [];
 }
 
 function getGuidelineCategoryLabel( category: GuidelineViolation[ 'category' ] ): string {
@@ -312,16 +318,25 @@ function getConflictApplyUnavailableReason(
  */
 export default function AiEditorialReview( {
 	summary,
-	conflicts,
-	implications,
-	suggested_edits,
-	guideline_violations,
+	conflicts: conflictsProp,
+	implications: implicationsProp,
+	suggested_edits: suggestedEditsProp,
+	guideline_violations: guidelineViolationsProp,
 	review_context,
 	postId,
 	isMessageStale = false,
 	reviewers_metadata,
 	cached_at,
 }: AiEditorialReviewProps ) {
+	// Normalised once per payload; useMemo keeps each list's identity stable
+	// across renders for the hooks that list them as dependencies.
+	const conflicts = useMemo( () => toList( conflictsProp ), [ conflictsProp ] );
+	const implications = useMemo( () => toList( implicationsProp ), [ implicationsProp ] );
+	const suggested_edits = useMemo( () => toList( suggestedEditsProp ), [ suggestedEditsProp ] );
+	const guideline_violations = useMemo(
+		() => toList( guidelineViolationsProp ),
+		[ guidelineViolationsProp ]
+	);
 	// Review actions are only safe when the result can be tied to the current editor entity.
 	const currentPostId = useSelect( ( select ) => {
 		const editor = select( 'core/editor' ) as WpCurrentPostStore;
@@ -756,20 +771,25 @@ export default function AiEditorialReview( {
 	);
 
 	// ---------- Bulk apply ----------
+	const findApplicableAiCandidate = useCallback(
+		( conflict: Conflict ) =>
+			toList( conflict.candidate_resolutions ).find(
+				( c ) =>
+					c.source === 'ai' &&
+					! getBlockEditDisabledReason( c.block_index, c.current_text, c.editable_attribute )
+			),
+		[ getBlockEditDisabledReason ]
+	);
+
 	const pendingAiConflictCount = useMemo( () => {
 		return conflicts.reduce( ( acc, conflict, i ) => {
 			const status = conflictStatuses[ i ] ?? 'pending';
 			if ( status !== 'pending' && status !== 'failed' ) {
 				return acc;
 			}
-			const aiCandidate = conflict.candidate_resolutions?.find(
-				( c ) =>
-					c.source === 'ai' &&
-					! getBlockEditDisabledReason( c.block_index, c.current_text, c.editable_attribute )
-			);
-			return aiCandidate ? acc + 1 : acc;
+			return findApplicableAiCandidate( conflict ) ? acc + 1 : acc;
 		}, 0 );
-	}, [ conflicts, conflictStatuses, getBlockEditDisabledReason ] );
+	}, [ conflicts, conflictStatuses, findApplicableAiCandidate ] );
 
 	const pendingEditCount = useMemo( () => {
 		return suggested_edits.reduce( ( acc, edit, i ) => {
@@ -822,11 +842,7 @@ export default function AiEditorialReview( {
 				if ( status !== 'pending' && status !== 'failed' ) {
 					continue;
 				}
-				const aiCandidate = conflicts[ i ].candidate_resolutions?.find(
-					( c ) =>
-						c.source === 'ai' &&
-						! getBlockEditDisabledReason( c.block_index, c.current_text, c.editable_attribute )
-				);
+				const aiCandidate = findApplicableAiCandidate( conflicts[ i ] );
 				if ( ! aiCandidate ) {
 					continue;
 				}
@@ -933,6 +949,7 @@ export default function AiEditorialReview( {
 		suggested_edits,
 		editStatuses,
 		applyTextToBlock,
+		findApplicableAiCandidate,
 		fireItemAction,
 		getBlockEditDisabledReason,
 		isLatestPostContextStale,
@@ -1155,7 +1172,7 @@ export default function AiEditorialReview( {
 								>
 									{ conflicts.map( ( conflict, i ) => {
 										const status = conflictStatuses[ i ] ?? 'pending';
-										const candidates = conflict.candidate_resolutions ?? [];
+										const candidates = toList( conflict.candidate_resolutions );
 										const getCandidateDisabledReason = ( candidate: CandidateResolution ) =>
 											getBlockEditDisabledReason(
 												candidate.block_index,

--- a/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.tsx
@@ -64,7 +64,7 @@ interface CandidateResolution {
 
 interface Conflict {
 	subject: string;
-	positions: ReviewerPosition[];
+	positions?: ReviewerPosition[];
 	guideline_anchor: string | null;
 	recommended_resolution: string;
 	candidate_resolutions?: CandidateResolution[];
@@ -84,7 +84,7 @@ interface SuggestedEdit {
 	suggested_text: string;
 	suggested_text_html?: string;
 	rationale: string;
-	supported_by_reviewers: string[];
+	supported_by_reviewers?: string[];
 	requires_manual?: boolean;
 	/** Optional short editorial category for the card badge (e.g. "Tone"). */
 	feedback_category?: string;
@@ -196,6 +196,15 @@ function formatRelativeTime( timestamp: number ): string {
 		_n( '%d day ago', '%d days ago', days, __i18n_text_domain__ ),
 		days
 	);
+}
+
+/**
+ * Model-supplied list fields are typed as required by the tool schema, but the
+ * provider drops `strict`, so any of them can arrive missing or malformed.
+ * Reading `.length` or `.map` off one that did unmounts the whole card.
+ */
+function toList< T >( value: T[] | undefined ): T[] {
+	return Array.isArray( value ) ? value : [];
 }
 
 function getGuidelineCategoryLabel( category: GuidelineViolation[ 'category' ] ): string {
@@ -1282,7 +1291,7 @@ export default function AiEditorialReview( {
 													) }
 												</header>
 												<ul className="jetpack-ai-editorial-review__positions">
-													{ conflict.positions.map( ( pos, j ) => (
+													{ toList( conflict.positions ).map( ( pos, j ) => (
 														<li
 															className="jetpack-ai-editorial-review__position"
 															key={ `pos-${ i }-${ j }` }
@@ -1391,9 +1400,7 @@ export default function AiEditorialReview( {
 									<ul>
 										{ implications.map( ( imp, i ) => {
 											// A non-strict payload can omit affected_blocks.
-											const affectedBlocks = Array.isArray( imp.affected_blocks )
-												? imp.affected_blocks
-												: [];
+											const affectedBlocks = toList( imp.affected_blocks );
 											return (
 												<li key={ `imp-${ i }` }>
 													<strong>{ imp.change }</strong> — { imp.implies }
@@ -1515,11 +1522,12 @@ export default function AiEditorialReview( {
 													element: 'text',
 												} );
 											}
+											const supportedByReviewers = toList( edit.supported_by_reviewers );
 											const footer =
-												edit.supported_by_reviewers.length > 0 ? (
+												supportedByReviewers.length > 0 ? (
 													<p className="jetpack-ai-editorial-review__reviewers">
 														{ __( 'Requested by:', __i18n_text_domain__ ) }{ ' ' }
-														{ edit.supported_by_reviewers.map( ( r, j ) => (
+														{ supportedByReviewers.map( ( r, j ) => (
 															<span key={ `edit-${ i }-rev-${ j }` }>
 																{ j > 0 && ' ' }
 																<ReviewerChip

--- a/packages/jetpack-ai-sidebar/src/components/reviewer-chip.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/reviewer-chip.test.tsx
@@ -101,4 +101,18 @@ describe( 'ReviewerChip', () => {
 		);
 		expect( container.querySelector( '.jetpack-ai-reviewer-chip.is-pill' ) ).not.toBeNull();
 	} );
+
+	// The name comes straight from model output, which is not guaranteed to
+	// honour the tool schema: a list item can be null or the wrong type.
+	it.each( [
+		[ 'null', null ],
+		[ 'undefined', undefined ],
+		[ 'an object', {} ],
+		[ 'a number', 7 ],
+		[ 'an empty string', '' ],
+		[ 'whitespace-only', '   ' ],
+	] )( 'renders nothing when name is %s', ( _label, name ) => {
+		const { container } = render( <ReviewerChip name={ name as unknown as string } /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
 } );

--- a/packages/jetpack-ai-sidebar/src/components/reviewer-chip.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/reviewer-chip.tsx
@@ -13,8 +13,11 @@ export interface ReviewerMetadata {
 }
 
 interface ReviewerChipProps {
-	/** The display name exactly as it appears in the review payload. */
-	name: string;
+	/**
+	 * The display name exactly as it appears in the review payload. Model
+	 * output, so it may not be a usable string; the chip renders nothing then.
+	 */
+	name?: string | null;
 	/** Server-provided metadata keyed by name; may be missing for some reviewers. */
 	metadata?: ReviewerMetadata | null;
 	/** Optional tooltip content. Default: the bio (if present) or display name. */
@@ -68,6 +71,12 @@ export default function ReviewerChip( {
 	title,
 	variant = 'inline',
 }: ReviewerChipProps ) {
+	// The name is model output and may not be a usable string; without one
+	// there is nothing to show, and hashName() would throw.
+	if ( typeof name !== 'string' || name.trim() === '' ) {
+		return null;
+	}
+
 	const tooltip = title ?? metadata?.bio ?? name;
 	const avatarUrl = safeImageUrl( metadata?.avatar_url );
 


### PR DESCRIPTION
## Proposed Changes

* Make `affected_blocks` optional on the `Implication` type and guard the render in `AiEditorialReview`.
* Add a regression test covering an implication with the field missing.

## Why are these changes being made?

The `submit_ai_editorial_review` tool schema lists `affected_blocks` as required, but the provider drops `strict` when it builds the Anthropic envelope, so `required` is only a hint. The model occasionally leaves the field out.

Reading `.length` off it threw `TypeError: Cannot read properties of undefined (reading 'length')` during render, which leads to `The "jetpack-agents-manager" plugin has encountered an error and cannot be rendered.` and the sidebar unmounting.

```
imp.affected_blocks.length > 0 && ...
      at Array.map (<anonymous>)
```

## Testing Instructions

* `yarn test-packages packages/jetpack-ai-sidebar -t "renders an implication that omits"`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
