### PR TITLE
Jetpack AI: gate review Apply on the same match the apply uses

### DIFF
--- a/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.test.tsx
@@ -37,6 +37,10 @@ jest.mock( '../utils/block-actions', () => ( {
 	clearActiveBlockFocus: ( ...args: any[] ) => mockClearActiveBlockFocus( ...args ),
 	clearActiveBlockFocusUnlessBlockReferenceClick: ( ...args: any[] ) =>
 		mockClearActiveBlockFocusUnlessBlockReferenceClick( ...args ),
+	// Real implementation: the card must gate Apply on the same count the apply
+	// itself uses, so a stub would hide the mismatch this guards against.
+	countCurrentTextOccurrences:
+		jest.requireActual( '../utils/block-actions' ).countCurrentTextOccurrences,
 	getEditableBlockContent: ( block: any, attributeName?: string, currentText?: string ) => {
 		if ( attributeName ) {
 			return block?.attributes?.[ attributeName ] ?? '';
@@ -611,6 +615,38 @@ describe( 'AiEditorialReview — smoke render', () => {
 		expect( screen.getByTitle( 'Jump to conflicts' ).textContent ).toMatch( /1/ );
 		expect( screen.getByTitle( 'Jump to implications' ).textContent ).toMatch( /1/ );
 		expect( screen.getByTitle( 'Jump to suggested edits' ).textContent ).toMatch( /1/ );
+	} );
+
+	it( 'offers Apply when the model retyped a typographic apostrophe', () => {
+		// The block holds a typographic apostrophe; the model quoted a straight one.
+		// The apply path treats those as equivalent, so the card must not gate the
+		// edit behind "source text changed".
+		mockBlocks = [
+			{
+				clientId: 'b0',
+				name: 'core/paragraph',
+				attributes: { content: 'Whether you\u2019re after a thin, crispy margherita.' },
+			},
+		];
+		render(
+			<AiEditorialReview
+				{ ...basePayload( {
+					suggested_edits: [
+						{
+							block_index: 0,
+							editable_attribute: 'content',
+							current_text: "Whether you're after a thin",
+							suggested_text: 'Whether you prefer a thin',
+							rationale: 'Concise.',
+							supported_by_reviewers: [],
+						},
+					],
+				} ) }
+			/>
+		);
+
+		expect( screen.getByRole( 'button', { name: 'Apply change' } ) ).toBeEnabled();
+		expect( screen.queryByText( 'Manual edit' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'does not tag a stale AER edit "Manual edit" even when the source text is absent', () => {

--- a/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.tsx
@@ -19,13 +19,13 @@ import {
 	applyReviewEdit,
 	clearActiveBlockFocus,
 	clearActiveBlockFocusUnlessBlockReferenceClick,
+	countCurrentTextOccurrences,
 	getEditableBlockContent,
 	hasEditableBlockTarget,
 	toggleBlockReferenceFocus,
 	undoBlockEdit,
 } from '../utils/block-actions';
 import {
-	countOccurrences,
 	flattenBlocks,
 	getEditorContentBlocks,
 	type BlockEditorStore,
@@ -260,7 +260,7 @@ function getTextTargetDisabledReason(
 	if ( ! hasEditableBlockTarget( block, editableAttribute, currentText ) ) {
 		return __( 'Needs manual edit — unsupported edit target', __i18n_text_domain__ );
 	}
-	const occurrences = countOccurrences(
+	const occurrences = countCurrentTextOccurrences(
 		getEditableBlockContent( block, editableAttribute, currentText ),
 		currentText
 	);
@@ -1483,7 +1483,7 @@ export default function AiEditorialReview( {
 											const currentTextPresent =
 												!! edit.current_text &&
 												!! targetBlock &&
-												countOccurrences(
+												countCurrentTextOccurrences(
 													getEditableBlockContent(
 														targetBlock,
 														edit.editable_attribute,

--- a/packages/jetpack-ai-sidebar/src/components/feedback-list.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/feedback-list.tsx
@@ -30,13 +30,13 @@ import {
 	applyReviewEdit,
 	clearActiveBlockFocus,
 	clearActiveBlockFocusUnlessBlockReferenceClick,
+	countCurrentTextOccurrences,
 	getEditableBlockContent,
 	hasEditableBlockTarget,
 	toggleBlockReferenceFocus,
 	undoBlockEdit,
 } from '../utils/block-actions';
 import {
-	countOccurrences,
 	flattenBlocks,
 	getEditorContentBlocks,
 	type BlockEditorStore,
@@ -189,7 +189,7 @@ function getApplyUnavailableReason(
 		return __( 'Needs manual edit - unsupported edit target.', __i18n_text_domain__ );
 	}
 
-	const occurrences = countOccurrences(
+	const occurrences = countCurrentTextOccurrences(
 		getEditableBlockContent( block, item.editable_attribute, item.current_text ),
 		item.current_text
 	);
@@ -451,7 +451,7 @@ export default function FeedbackList( {
 								const currentTextPresent =
 									!! item.current_text &&
 									!! block &&
-									countOccurrences(
+									countCurrentTextOccurrences(
 										getEditableBlockContent( block, item.editable_attribute, item.current_text ),
 										item.current_text
 									) >= 1;

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -446,7 +446,12 @@ function normaliseQuotationMarks( text: string ): string {
 	return text.replace( /[\u2018\u2019]/g, "'" ).replace( /[\u201c\u201d]/g, '"' );
 }
 
-function countCurrentTextOccurrences( source: string, currentText: string ): number {
+/**
+ * Count the spans of block content currentText could replace. Exported so the
+ * review cards gate the Apply control on the same count the apply itself uses;
+ * a stricter gate disables edits that would have applied cleanly.
+ */
+export function countCurrentTextOccurrences( source: string, currentText: string ): number {
 	return countOccurrences(
 		normaliseQuotationMarks( source ),
 		normaliseQuotationMarks( currentText )


### PR DESCRIPTION
Relates to: FORNO-453

## Proposed Changes

* Export `countCurrentTextOccurrences` and use it at the four places that decide whether to offer Apply, instead of the strict `countOccurrences`.
* Add a regression test.

## Why are these changes being made?

The review cards decided whether to offer Apply with `countOccurrences`, a strict comparison, while `handleUpdateBlockContent` applies with `countCurrentTextOccurrences`, which treats typographic and straight quotation marks as equivalent. So the gate was stricter than the thing it was gating: an edit the apply path would have found was disabled with "Needs manual edit - source text changed".

The gate, the diff preview and the apply now agree by construction.

Pairs with wpcom PR 232356, which stops the server marking these edits manual before they reach the card. This one should merge and deploy first: on its own it only makes the client less strict, whereas the server change landing first would mark edits applicable that the deployed client still refuses.

## Testing Instructions

* `yarn test-packages packages/jetpack-ai-sidebar -t "offers Apply when the model retyped"`
* Revert the four call sites to `countOccurrences` and re-run to see it fail.
