### PR TITLE
Email verification: aim the activation email back at the onboarding flow

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -20,6 +20,7 @@ import { isThrottledError, getThrottledErrorMessage } from 'calypso/lib/signup/i
 import wpcom from 'calypso/lib/wp';
 import ValidationFieldset from 'calypso/signup/validation-fieldset';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { setCurrentUser } from 'calypso/state/current-user/actions';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import SignupSubmitButton from './signup-submit-button';
 
@@ -36,8 +37,7 @@ class PasswordlessSignupForm extends Component {
 		onCreateAccountError: PropTypes.func,
 		onCreateAccountSuccess: PropTypes.func,
 		disableTosText: PropTypes.bool,
-		// Names the caller in the activation email, so the link back can be aimed at where the
-		// account was created rather than the usual destination.
+		// Names the signup's origin to the backend, which aims the activation link on it.
 		activationEmailFrom: PropTypes.string,
 		useConnectScreenActions: PropTypes.bool,
 	};
@@ -73,6 +73,23 @@ class PasswordlessSignupForm extends Component {
 			this.submitTracksEvent( false, { action_message: 'Please provide a valid email address.' } );
 			return;
 		}
+
+		// --- TEMPORARY LOCAL DEV SHORTCUT — remove before merging this PR. ---
+		// `?fake_signup=1` on the onboarding flow skips real account creation and drops
+		// straight onto the email-verification gate with a fake unverified user, so the
+		// gate can be viewed without registering a new account each time. Requires the
+		// `onboarding/email-verification` flag (already on for wpcalypso; locally add
+		// `?flags=onboarding/email-verification`). Resend / re-check won't work against
+		// the fake session — this is only for viewing the screen.
+		if (
+			this.props.flowName === 'onboarding' &&
+			new URLSearchParams( window.location.search ).get( 'fake_signup' )
+		) {
+			this.props.setCurrentUser( { ID: 1, email: this.state.email, email_verified: false } );
+			this.props.onCreateAccountSuccess?.( { ID: 1, email: this.state.email } );
+			return;
+		}
+		// --- end temporary shortcut ---
 
 		// Save form state in a format that is compatible with the standard SignupForm used in the user step.
 		const form = {
@@ -129,8 +146,6 @@ class PasswordlessSignupForm extends Component {
 				is_dev_account: isDevAccount,
 				extra: {
 					has_segmentation_survey: queryArgs.variationName === 'entrepreneur',
-					// Absent unless the caller asks for it, so the activation email keeps its usual
-					// destination for every flow that doesn't need to be returned somewhere.
 					...( activationEmailFrom && { from: activationEmailFrom } ),
 				},
 			};
@@ -411,4 +426,6 @@ export default connect( null, {
 	recordTracksEvent,
 	saveSignupStep,
 	submitCreateAccountStep: submitSignupStep,
+	// TEMPORARY (remove before merging): used by the `?fake_signup=1` dev shortcut.
+	setCurrentUser,
 } )( localize( PasswordlessSignupForm ) );

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -20,7 +20,6 @@ import { isThrottledError, getThrottledErrorMessage } from 'calypso/lib/signup/i
 import wpcom from 'calypso/lib/wp';
 import ValidationFieldset from 'calypso/signup/validation-fieldset';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { setCurrentUser } from 'calypso/state/current-user/actions';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import SignupSubmitButton from './signup-submit-button';
 
@@ -73,23 +72,6 @@ class PasswordlessSignupForm extends Component {
 			this.submitTracksEvent( false, { action_message: 'Please provide a valid email address.' } );
 			return;
 		}
-
-		// --- TEMPORARY LOCAL DEV SHORTCUT — remove before merging this PR. ---
-		// `?fake_signup=1` on the onboarding flow skips real account creation and drops
-		// straight onto the email-verification gate with a fake unverified user, so the
-		// gate can be viewed without registering a new account each time. Requires the
-		// `onboarding/email-verification` flag (already on for wpcalypso; locally add
-		// `?flags=onboarding/email-verification`). Resend / re-check won't work against
-		// the fake session — this is only for viewing the screen.
-		if (
-			this.props.flowName === 'onboarding' &&
-			new URLSearchParams( window.location.search ).get( 'fake_signup' )
-		) {
-			this.props.setCurrentUser( { ID: 1, email: this.state.email, email_verified: false } );
-			this.props.onCreateAccountSuccess?.( { ID: 1, email: this.state.email } );
-			return;
-		}
-		// --- end temporary shortcut ---
 
 		// Save form state in a format that is compatible with the standard SignupForm used in the user step.
 		const form = {
@@ -426,6 +408,4 @@ export default connect( null, {
 	recordTracksEvent,
 	saveSignupStep,
 	submitCreateAccountStep: submitSignupStep,
-	// TEMPORARY (remove before merging): used by the `?fake_signup=1` dev shortcut.
-	setCurrentUser,
 } )( localize( PasswordlessSignupForm ) );

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -36,6 +36,9 @@ class PasswordlessSignupForm extends Component {
 		onCreateAccountError: PropTypes.func,
 		onCreateAccountSuccess: PropTypes.func,
 		disableTosText: PropTypes.bool,
+		// Names the caller in the activation email, so the link back can be aimed at where the
+		// account was created rather than the usual destination.
+		activationEmailFrom: PropTypes.string,
 		useConnectScreenActions: PropTypes.bool,
 	};
 
@@ -79,7 +82,7 @@ class PasswordlessSignupForm extends Component {
 			username: '',
 			password: '',
 		};
-		const { flowName, queryArgs = {} } = this.props;
+		const { activationEmailFrom, flowName, queryArgs = {} } = this.props;
 		const devAccountLandingPageRefs = [ 'hosting-lp', 'developer-lp' ];
 		const isDevAccount = devAccountLandingPageRefs.includes( queryArgs.ref );
 
@@ -124,7 +127,12 @@ class PasswordlessSignupForm extends Component {
 				} ),
 				anon_id: getTracksAnonymousUserId(),
 				is_dev_account: isDevAccount,
-				extra: { has_segmentation_survey: queryArgs.variationName === 'entrepreneur' },
+				extra: {
+					has_segmentation_survey: queryArgs.variationName === 'entrepreneur',
+					// Absent unless the caller asks for it, so the activation email keeps its usual
+					// destination for every flow that doesn't need to be returned somewhere.
+					...( activationEmailFrom && { from: activationEmailFrom } ),
+				},
 			};
 
 			const { search = '' } = typeof window !== 'undefined' ? window.location : {};

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -54,8 +54,6 @@ interface SignupFormSocialFirst {
 	isMobileCompactVariant?: boolean;
 	allowedSocialServices?: SignupAllowedService[];
 	customTosElement?: JSX.Element;
-	// Forwarded to the email form only. Social accounts arrive already verified, so there is no
-	// activation email for it to aim.
 	activationEmailFrom?: string;
 }
 
@@ -184,8 +182,8 @@ const SignupFormSocialFirst = ( {
 		} );
 	};
 
-	// Shared by the email-first (Woo or experiment) branch and the mobile-compact
-	// branch so the conversion-critical existing-account redirect lives in one place.
+	// Shared by every branch that renders the email form, so the conversion-critical
+	// existing-account redirect lives in one place.
 	const passwordlessFormProps = {
 		stepName,
 		flowName,
@@ -292,15 +290,7 @@ const SignupFormSocialFirst = ( {
 			<div className={ getVisibilityClassName( 'email' ) }>
 				<div className="signup-form-social-first-email">
 					<PasswordlessSignupForm
-						stepName={ stepName }
-						flowName={ flowName }
-						activationEmailFrom={ activationEmailFrom }
-						goToNextStep={ goToNextStep }
-						logInUrl={ logInUrl }
-						queryArgs={ queryArgs }
-						labelText={ emailLabelText ?? __( 'Your email' ) }
-						submitButtonLabel={ __( 'Continue' ) }
-						userEmail={ userEmail }
+						{ ...passwordlessFormProps }
 						renderTerms={ renderEmailStepTermsOfService }
 						secondaryFooterButton={
 							backButtonInFooter ? undefined : (
@@ -309,24 +299,6 @@ const SignupFormSocialFirst = ( {
 								</Button>
 							)
 						}
-						passDataToNextStep={ passDataToNextStep }
-						onCreateAccountError={ ( error: { error: string }, email: string ) => {
-							if ( isExistingAccountError( error.error ) ) {
-								window.location.assign(
-									addQueryArgs(
-										{
-											email_address: email,
-											is_signup_existing_account: true,
-											redirect_to: queryArgs?.redirect_to,
-										},
-										logInUrl
-									)
-								);
-							}
-						} }
-						onCreateAccountSuccess={ onCreateAccountSuccess }
-						inputPlaceholder={ isGravatar ? __( 'Enter your email address' ) : undefined }
-						submitButtonLoadingLabel={ isGravatar ? __( 'Continue' ) : undefined }
 					/>
 					{ backButtonInFooter ? (
 						<Button

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -54,6 +54,9 @@ interface SignupFormSocialFirst {
 	isMobileCompactVariant?: boolean;
 	allowedSocialServices?: SignupAllowedService[];
 	customTosElement?: JSX.Element;
+	// Forwarded to the email form only. Social accounts arrive already verified, so there is no
+	// activation email for it to aim.
+	activationEmailFrom?: string;
 }
 
 const options = {
@@ -112,6 +115,7 @@ const SignupFormSocialFirst = ( {
 	isMobileCompactVariant,
 	allowedSocialServices,
 	customTosElement,
+	activationEmailFrom,
 }: SignupFormSocialFirst ) => {
 	const [ currentStep, setCurrentStep ] = useState< Screen >( userEmail ? 'email' : 'initial' );
 	const { __ } = useI18n();
@@ -185,6 +189,7 @@ const SignupFormSocialFirst = ( {
 	const passwordlessFormProps = {
 		stepName,
 		flowName,
+		activationEmailFrom,
 		goToNextStep,
 		logInUrl,
 		queryArgs,
@@ -289,6 +294,7 @@ const SignupFormSocialFirst = ( {
 					<PasswordlessSignupForm
 						stepName={ stepName }
 						flowName={ flowName }
+						activationEmailFrom={ activationEmailFrom }
 						goToNextStep={ goToNextStep }
 						logInUrl={ logInUrl }
 						queryArgs={ queryArgs }

--- a/client/blocks/signup-form/test/passwordless.jsx
+++ b/client/blocks/signup-form/test/passwordless.jsx
@@ -104,8 +104,7 @@ describe( 'activation email source', () => {
 		} );
 	} );
 
-	// Every other signup, the control arm included: the activation email keeps its usual
-	// destination, and nothing about this request changes.
+	// The control arm and every other flow, whose email keeps its usual destination.
 	it( 'says nothing about where the signup came from otherwise', async () => {
 		const body = await submitWith( {} );
 

--- a/client/blocks/signup-form/test/passwordless.jsx
+++ b/client/blocks/signup-form/test/passwordless.jsx
@@ -66,3 +66,49 @@ describe( 'createAccountError', () => {
 		} );
 	} );
 } );
+
+describe( 'activation email source', () => {
+	const mockStore = configureStore( [ thunk ] );
+
+	// The response doesn't matter — what is being asserted is what was asked for.
+	const submitWith = async ( props ) => {
+		const sent = [];
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/rest/v1.1/users/new', ( body ) => {
+				sent.push( body );
+				return true;
+			} )
+			.reply( 500, { error: 'internal_server_error' } );
+
+		render(
+			<Provider store={ mockStore( {} ) }>
+				<PasswordlessSignupForm flowName="onboarding" { ...props } />
+			</Provider>
+		);
+
+		fireEvent.change( screen.getByRole( 'textbox', { name: /email/i } ), {
+			target: { value: 'test@example.com' },
+		} );
+		fireEvent.click( screen.getByRole( 'button', { name: /create your account/i } ) );
+
+		await waitFor( () => expect( sent ).toHaveLength( 1 ) );
+		return sent[ 0 ];
+	};
+
+	it( 'names the caller when given one, without displacing what extra already carries', async () => {
+		const body = await submitWith( { activationEmailFrom: 'onboarding-with-email-verification' } );
+
+		expect( body.extra ).toEqual( {
+			has_segmentation_survey: false,
+			from: 'onboarding-with-email-verification',
+		} );
+	} );
+
+	// Every other signup, the control arm included: the activation email keeps its usual
+	// destination, and nothing about this request changes.
+	it( 'says nothing about where the signup came from otherwise', async () => {
+		const body = await submitWith( {} );
+
+		expect( body.extra ).toEqual( { has_segmentation_survey: false } );
+	} );
+} );

--- a/client/blocks/signup-form/test/passwordless.jsx
+++ b/client/blocks/signup-form/test/passwordless.jsx
@@ -104,7 +104,6 @@ describe( 'activation email source', () => {
 		} );
 	} );
 
-	// The control arm and every other flow, whose email keeps its usual destination.
 	it( 'says nothing about where the signup came from otherwise', async () => {
 		const body = await submitWith( {} );
 

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -207,8 +207,7 @@ describe( 'SignupFormSocialFirst', () => {
 		} );
 	} );
 
-	// The email form is rendered from three places here, and the marker has to reach whichever one
-	// the user is looking at — a signup that loses it gets an activation link to somewhere else.
+	// A signup whose form never received it gets an activation link to somewhere else.
 	describe( 'activationEmailFrom', () => {
 		beforeEach( () => ( mockPasswordlessProps.length = 0 ) );
 

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -207,7 +207,6 @@ describe( 'SignupFormSocialFirst', () => {
 		} );
 	} );
 
-	// A signup whose form never received it gets an activation link to somewhere else.
 	describe( 'activationEmailFrom', () => {
 		beforeEach( () => ( mockPasswordlessProps.length = 0 ) );
 

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -37,20 +37,6 @@ jest.mock( '@automattic/calypso-config', () => {
 	return config;
 } );
 
-const mockPasswordlessProps: { activationEmailFrom?: string }[] = [];
-
-jest.mock( '../passwordless', () => {
-	const { createElement } = jest.requireActual( 'react' );
-	const Actual = jest.requireActual( '../passwordless' ).default;
-	return {
-		__esModule: true,
-		default: ( props: { activationEmailFrom?: string } ) => {
-			mockPasswordlessProps.push( props );
-			return createElement( Actual, props );
-		},
-	};
-} );
-
 const defaultProps = {
 	goToNextStep: jest.fn(),
 	stepName: 'user',
@@ -204,39 +190,6 @@ describe( 'SignupFormSocialFirst', () => {
 			expect( screen.getByText( /Continue with Google/i ) ).toBeInTheDocument();
 			expect( screen.getByText( /Continue with PayPal/i ) ).toBeInTheDocument();
 			expect( screen.queryByText( /Continue with GitHub/i ) ).not.toBeInTheDocument();
-		} );
-	} );
-
-	describe( 'activationEmailFrom', () => {
-		beforeEach( () => ( mockPasswordlessProps.length = 0 ) );
-
-		// Between them these cover all three places the email form is rendered: the email-first
-		// layout renders two of them, the mobile-compact layout the third.
-		it.each( [
-			[ 'the email-first layout', { isEmailFirstVariant: true } ],
-			[ 'the mobile-compact layout', { isMobileCompactVariant: true } ],
-		] )( 'reaches every email form in %s', ( _label, layout ) => {
-			render(
-				<SignupFormSocialFirst
-					{ ...defaultProps }
-					{ ...layout }
-					activationEmailFrom="onboarding-with-email-verification"
-				/>
-			);
-
-			expect( mockPasswordlessProps.length ).toBeGreaterThan( 0 );
-			mockPasswordlessProps.forEach( ( props ) =>
-				expect( props.activationEmailFrom ).toBe( 'onboarding-with-email-verification' )
-			);
-		} );
-
-		it( 'passes nothing on when it was given nothing', () => {
-			render( <SignupFormSocialFirst { ...defaultProps } isEmailFirstVariant /> );
-
-			expect( mockPasswordlessProps.length ).toBeGreaterThan( 0 );
-			mockPasswordlessProps.forEach( ( props ) =>
-				expect( props.activationEmailFrom ).toBeUndefined()
-			);
 		} );
 	} );
 

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -37,6 +37,20 @@ jest.mock( '@automattic/calypso-config', () => {
 	return config;
 } );
 
+const mockPasswordlessProps: { activationEmailFrom?: string }[] = [];
+
+jest.mock( '../passwordless', () => {
+	const { createElement } = jest.requireActual( 'react' );
+	const Actual = jest.requireActual( '../passwordless' ).default;
+	return {
+		__esModule: true,
+		default: ( props: { activationEmailFrom?: string } ) => {
+			mockPasswordlessProps.push( props );
+			return createElement( Actual, props );
+		},
+	};
+} );
+
 const defaultProps = {
 	goToNextStep: jest.fn(),
 	stepName: 'user',
@@ -190,6 +204,40 @@ describe( 'SignupFormSocialFirst', () => {
 			expect( screen.getByText( /Continue with Google/i ) ).toBeInTheDocument();
 			expect( screen.getByText( /Continue with PayPal/i ) ).toBeInTheDocument();
 			expect( screen.queryByText( /Continue with GitHub/i ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	// The email form is rendered from three places here, and the marker has to reach whichever one
+	// the user is looking at — a signup that loses it gets an activation link to somewhere else.
+	describe( 'activationEmailFrom', () => {
+		beforeEach( () => ( mockPasswordlessProps.length = 0 ) );
+
+		it.each( [
+			[ 'the email-first layout', { isEmailFirstVariant: true } ],
+			[ 'the mobile-compact layout', { isMobileCompactVariant: true } ],
+			[ 'the default layout', {} ],
+		] )( 'reaches the email form in %s', ( _label, layout ) => {
+			render(
+				<SignupFormSocialFirst
+					{ ...defaultProps }
+					{ ...layout }
+					activationEmailFrom="onboarding-with-email-verification"
+				/>
+			);
+
+			expect( mockPasswordlessProps.length ).toBeGreaterThan( 0 );
+			mockPasswordlessProps.forEach( ( props ) =>
+				expect( props.activationEmailFrom ).toBe( 'onboarding-with-email-verification' )
+			);
+		} );
+
+		it( 'passes nothing on when it was given nothing', () => {
+			render( <SignupFormSocialFirst { ...defaultProps } isEmailFirstVariant /> );
+
+			expect( mockPasswordlessProps.length ).toBeGreaterThan( 0 );
+			mockPasswordlessProps.forEach( ( props ) =>
+				expect( props.activationEmailFrom ).toBeUndefined()
+			);
 		} );
 	} );
 

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -210,11 +210,12 @@ describe( 'SignupFormSocialFirst', () => {
 	describe( 'activationEmailFrom', () => {
 		beforeEach( () => ( mockPasswordlessProps.length = 0 ) );
 
+		// Between them these cover all three places the email form is rendered: the email-first
+		// layout renders two of them, the mobile-compact layout the third.
 		it.each( [
 			[ 'the email-first layout', { isEmailFirstVariant: true } ],
 			[ 'the mobile-compact layout', { isMobileCompactVariant: true } ],
-			[ 'the default layout', {} ],
-		] )( 'reaches the email form in %s', ( _label, layout ) => {
+		] )( 'reaches every email form in %s', ( _label, layout ) => {
 			render(
 				<SignupFormSocialFirst
 					{ ...defaultProps }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/index.tsx
@@ -30,7 +30,6 @@ const mockSendVerificationEmail = (
 	response: { success: boolean; retry_after?: number } = { success: true }
 ) => mockApi().post( '/rest/v1.1/me/send-verification-email' ).reply( 200, response );
 
-// What the resend asked for, rather than only that it asked.
 const captureSendVerificationEmail = () => {
 	const sent: { from?: string }[] = [];
 	mockApi()

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/index.tsx
@@ -267,7 +267,6 @@ describe( 'EmailVerificationGate', () => {
 		);
 	} );
 
-	// A resend without it sends the user somewhere the activation email wouldn't have.
 	it( 'asks for a link back to this flow, the same as the activation email did', async () => {
 		const user = userEvent.setup();
 		const sent = captureSendVerificationEmail();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/index.tsx
@@ -30,7 +30,7 @@ const mockSendVerificationEmail = (
 	response: { success: boolean; retry_after?: number } = { success: true }
 ) => mockApi().post( '/rest/v1.1/me/send-verification-email' ).reply( 200, response );
 
-// Captures what the resend actually asked for, rather than only that it asked.
+// What the resend asked for, rather than only that it asked.
 const captureSendVerificationEmail = () => {
 	const sent: { from?: string }[] = [];
 	mockApi()
@@ -267,8 +267,7 @@ describe( 'EmailVerificationGate', () => {
 		);
 	} );
 
-	// The backend picks the link's destination from this, so a resend without it sends the user
-	// somewhere other than the flow the gate is holding them in.
+	// A resend without it sends the user somewhere the activation email wouldn't have.
 	it( 'asks for a link back to this flow, the same as the activation email did', async () => {
 		const user = userEvent.setup();
 		const sent = captureSendVerificationEmail();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/index.tsx
@@ -30,6 +30,18 @@ const mockSendVerificationEmail = (
 	response: { success: boolean; retry_after?: number } = { success: true }
 ) => mockApi().post( '/rest/v1.1/me/send-verification-email' ).reply( 200, response );
 
+// Captures what the resend actually asked for, rather than only that it asked.
+const captureSendVerificationEmail = () => {
+	const sent: { from?: string }[] = [];
+	mockApi()
+		.post( '/rest/v1.1/me/send-verification-email', ( body ) => {
+			sent.push( body );
+			return true;
+		} )
+		.reply( 200, { success: true } );
+	return sent;
+};
+
 const mockSendVerificationEmailThrottled = ( retryAfter: number ) =>
 	mockApi()
 		.post( '/rest/v1.1/me/send-verification-email' )
@@ -253,5 +265,18 @@ describe( 'EmailVerificationGate', () => {
 			'calypso_signup_email_verification_email_sent',
 			expect.objectContaining( { flow: FLOW, is_resend: true } )
 		);
+	} );
+
+	// The backend picks the link's destination from this, so a resend without it sends the user
+	// somewhere other than the flow the gate is holding them in.
+	it( 'asks for a link back to this flow, the same as the activation email did', async () => {
+		const user = userEvent.setup();
+		const sent = captureSendVerificationEmail();
+
+		render();
+		await user.click( await screen.findByRole( 'button', { name: 'Resend' } ) );
+
+		await waitFor( () => expect( sent ).toHaveLength( 1 ) );
+		expect( sent[ 0 ].from ).toBe( 'onboarding-with-email-verification' );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/use-email-verification.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/use-email-verification.ts
@@ -10,6 +10,7 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { useBackoffPoll } from '../use-backoff-poll';
+import { ACTIVATION_EMAIL_SOURCE } from '../use-email-verification-gate';
 import { gateResendAvailableAt, markResendUnavailableUntil } from './storage';
 
 // `throttled` is distinct from `error`: the send was refused, not failed. It says only why the
@@ -19,7 +20,9 @@ type SendStatus = 'idle' | 'sending' | 'error' | 'throttled';
 export function useEmailVerification( flow: string, scope: string ) {
 	const dispatch = useDispatch();
 	const isVerified = useSelector( isCurrentUserEmailVerified );
-	const sendVerificationEmail = useSendEmailVerification();
+	// A resend has to land the user back here, the same as the activation email account creation
+	// sent — otherwise pressing Resend is how you get sent somewhere else.
+	const sendVerificationEmail = useSendEmailVerification( { from: ACTIVATION_EMAIL_SOURCE } );
 
 	const [ sendStatus, setSendStatus ] = useState< SendStatus >( 'idle' );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/use-email-verification.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/use-email-verification.ts
@@ -20,8 +20,6 @@ type SendStatus = 'idle' | 'sending' | 'error' | 'throttled';
 export function useEmailVerification( flow: string, scope: string ) {
 	const dispatch = useDispatch();
 	const isVerified = useSelector( isCurrentUserEmailVerified );
-	// A resend has to land the user back here, the same as the activation email account creation
-	// sent — otherwise pressing Resend is how you get sent somewhere else.
 	const sendVerificationEmail = useSendEmailVerification( { from: ACTIVATION_EMAIL_SOURCE } );
 
 	const [ sendStatus, setSendStatus ] = useState< SendStatus >( 'idle' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -222,8 +222,6 @@ const UserStepComponent: StepType< { accepts: UserStepAccepts } > = function Use
 				isMobileCompactVariant={ isMobileCompactLayout }
 				allowedSocialServices={ allowedSocialServices }
 				customTosElement={ signupTosElement }
-				// Same switch that decides whether the gate is shown, so the link in the activation
-				// email can only aim back here for the accounts that will be held here.
 				activationEmailFrom={ gateEnabled ? ACTIVATION_EMAIL_SOURCE : undefined }
 			/>
 			{ accountCreateResponse && 'bearer_token' in accountCreateResponse && (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -33,7 +33,7 @@ import { useHandleSocialResponse } from './handle-social-response';
 import { SignupSlider } from './signup-slider';
 import useAccountCreationExperiment from './use-account-creation-experiment';
 import { useBackoffPoll } from './use-backoff-poll';
-import { useEmailVerificationGate } from './use-email-verification-gate';
+import { ACTIVATION_EMAIL_SOURCE, useEmailVerificationGate } from './use-email-verification-gate';
 import { useSocialService } from './use-social-service';
 import type { SignupAllowedService } from 'calypso/components/social-buttons/utils';
 
@@ -222,6 +222,9 @@ const UserStepComponent: StepType< { accepts: UserStepAccepts } > = function Use
 				isMobileCompactVariant={ isMobileCompactLayout }
 				allowedSocialServices={ allowedSocialServices }
 				customTosElement={ signupTosElement }
+				// Same switch that decides whether the gate is shown, so the link in the activation
+				// email can only aim back here for the accounts that will be held here.
+				activationEmailFrom={ gateEnabled ? ACTIVATION_EMAIL_SOURCE : undefined }
 			/>
 			{ accountCreateResponse && 'bearer_token' in accountCreateResponse && (
 				<WpcomLoginForm

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/email-verification-gate.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/email-verification-gate.tsx
@@ -23,8 +23,7 @@ import useAccountCreationExperiment from '../use-account-creation-experiment';
 // A different user per test, so each one's isolation is its own rather than teardown's.
 let mockUserId = 0;
 
-// What the step handed the signup form, so what the activation email will be aimed at can be
-// asserted without reaching into the request the real form would make.
+// What the step handed the signup form.
 let activationEmailFromProp: string | undefined;
 
 jest.mock( 'calypso/lib/analytics/tracks' );
@@ -154,9 +153,8 @@ describe( 'account step email verification gate', () => {
 		jest.clearAllMocks();
 	} );
 
-	// The backend decides the activation link's destination from this, so it has to travel with
-	// exactly the signups that will be held on the gate — and with none of the others, whose email
-	// should keep landing where it always has.
+	// It has to travel with exactly the signups that will be held on the gate, and with no others —
+	// their activation email should keep landing where it always has.
 	it( 'asks for a link back to the flow only when the gate is on', async () => {
 		renderUser( makeLoggedOutStore() ).unmount();
 		expect( activationEmailFromProp ).toBe( 'onboarding-with-email-verification' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/email-verification-gate.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/email-verification-gate.tsx
@@ -23,6 +23,10 @@ import useAccountCreationExperiment from '../use-account-creation-experiment';
 // A different user per test, so each one's isolation is its own rather than teardown's.
 let mockUserId = 0;
 
+// What the step handed the signup form, so what the activation email will be aimed at can be
+// asserted without reaching into the request the real form would make.
+let activationEmailFromProp: string | undefined;
+
 jest.mock( 'calypso/lib/analytics/tracks' );
 
 // Keep the poll from reaching the network — the gate polls `fetchCurrentUser`.
@@ -61,20 +65,25 @@ jest.mock( 'calypso/blocks/signup-form/signup-form-social-first', () => ( {
 	default: ( {
 		onCreateAccountSuccess,
 		goToNextStep,
+		activationEmailFrom,
 	}: {
 		onCreateAccountSuccess?: ( data: { ID: number } ) => void;
 		goToNextStep?: ( data: { bearer_token: string; ID: number } ) => void;
-	} ) => (
-		<button
-			onClick={ () => {
-				// Production order: goToNextStep fires before onCreateAccountSuccess.
-				goToNextStep?.( { bearer_token: 'test-token', ID: mockUserId } );
-				onCreateAccountSuccess?.( { ID: mockUserId } );
-			} }
-		>
-			create-email-account
-		</button>
-	),
+		activationEmailFrom?: string;
+	} ) => {
+		activationEmailFromProp = activationEmailFrom;
+		return (
+			<button
+				onClick={ () => {
+					// Production order: goToNextStep fires before onCreateAccountSuccess.
+					goToNextStep?.( { bearer_token: 'test-token', ID: mockUserId } );
+					onCreateAccountSuccess?.( { ID: mockUserId } );
+				} }
+			>
+				create-email-account
+			</button>
+		);
+	},
 	MobileCompactTosNotice: () => null,
 } ) );
 
@@ -137,11 +146,25 @@ describe( 'account step email verification gate', () => {
 	} );
 
 	afterEach( () => {
+		activationEmailFromProp = undefined;
 		// A test that fails before restoring them would otherwise time out every test after it.
 		jest.useRealTimers();
 		mockConfig.enabledFlags.clear();
 		localStorage.clear();
 		jest.clearAllMocks();
+	} );
+
+	// The backend decides the activation link's destination from this, so it has to travel with
+	// exactly the signups that will be held on the gate — and with none of the others, whose email
+	// should keep landing where it always has.
+	it( 'asks for a link back to the flow only when the gate is on', async () => {
+		renderUser( makeLoggedOutStore() ).unmount();
+		expect( activationEmailFromProp ).toBe( 'onboarding-with-email-verification' );
+
+		mockConfig.enabledFlags.clear();
+		renderUser( makeLoggedOutStore() );
+
+		expect( activationEmailFromProp ).toBeUndefined();
 	} );
 
 	it( 'confirmation continues exactly once (no double submit)', async () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/email-verification-gate.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/email-verification-gate.tsx
@@ -153,8 +153,7 @@ describe( 'account step email verification gate', () => {
 		jest.clearAllMocks();
 	} );
 
-	// It has to travel with exactly the signups that will be held on the gate, and with no others —
-	// their activation email should keep landing where it always has.
+	// Ungated signups keep the activation email they have always had.
 	it( 'asks for a link back to the flow only when the gate is on', async () => {
 		renderUser( makeLoggedOutStore() ).unmount();
 		expect( activationEmailFromProp ).toBe( 'onboarding-with-email-verification' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/email-verification-gate.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/email-verification-gate.tsx
@@ -23,7 +23,6 @@ import useAccountCreationExperiment from '../use-account-creation-experiment';
 // A different user per test, so each one's isolation is its own rather than teardown's.
 let mockUserId = 0;
 
-// What the step handed the signup form.
 let activationEmailFromProp: string | undefined;
 
 jest.mock( 'calypso/lib/analytics/tracks' );
@@ -153,7 +152,6 @@ describe( 'account step email verification gate', () => {
 		jest.clearAllMocks();
 	} );
 
-	// Ungated signups keep the activation email they have always had.
 	it( 'asks for a link back to the flow only when the gate is on', async () => {
 		renderUser( makeLoggedOutStore() ).unmount();
 		expect( activationEmailFromProp ).toBe( 'onboarding-with-email-verification' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-email-verification-gate.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-email-verification-gate.ts
@@ -3,6 +3,11 @@ import { ONBOARDING_FLOW } from '@automattic/onboarding';
 import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
+// Tells the backend to send an activation email whose link returns here rather than to the usual
+// destination, so a gated user lands back on the flow they are being held in. The backend matches
+// on the exact string; changing it here without changing it there drops them somewhere else.
+export const ACTIVATION_EMAIL_SOURCE = 'onboarding-with-email-verification';
+
 // `pending` is not a kind of `clear`: the user's ID survives a reload but the user object does
 // not, so there is a window where the account is logged in and nothing is known about it. Reading
 // those absent fields as an unverified email opens the gate onto a blank address.

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-email-verification-gate.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-email-verification-gate.ts
@@ -3,9 +3,8 @@ import { ONBOARDING_FLOW } from '@automattic/onboarding';
 import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
-// Tells the backend to send an activation email whose link returns here rather than to the usual
-// destination, so a gated user lands back on the flow they are being held in. The backend matches
-// on the exact string; changing it here without changing it there drops them somewhere else.
+// Names this flow to the backend, which routes the activation link on it so a gated user lands
+// back here. Matched as an exact string: changing it here alone sends them somewhere else.
 export const ACTIVATION_EMAIL_SOURCE = 'onboarding-with-email-verification';
 
 // `pending` is not a kind of `clear`: the user's ID survives a reload but the user object does


### PR DESCRIPTION
Part of DOTCOM-18084. Needs the matching backend change to land before it does anything; until then the marker is sent and ignored.

## Proposed Changes

* Onboarding signups that will meet the email-verification gate name their source in the account-creation request, and resends send the same name.
* The signup form takes that source as an optional prop rather than deciding anything itself.
* One constant beside the gate, shared by both senders.

The feature flag remains off everywhere, so nothing changes for anyone yet.

## Why are these changes being made?

The gate holds a new account on the account step until its email is confirmed, and the confirmation arrives by clicking a link in an email. That link goes wherever the backend decides, which is not the flow the user is being held in — so confirming worked but left them somewhere they had to find their way back from. The backend can route on where the signup came from; this is the half that tells it.

The marker travels with exactly the signups that will be gated. It comes off the same value that decides whether the gate is shown, so the control arm and every other flow send a request that is byte-for-byte what they send today, and their activation email keeps its usual destination. Social signups are untouched — they arrive verified, so there is no activation email to aim.

The form serving every signup in Calypso shouldn't know what the gate is, so it takes an explicit prop and passes it along. Resends carry the same value as account creation, because a resent email that landed somewhere else would be a worse trap than the one being fixed: the user would be told to check their inbox, do exactly that, and end up further from where they started.

## Testing Instructions

The backend half is not deployed, so this is verified at the request rather than by following a link.

1. Run Calypso locally, open the onboarding flow with `?flags=onboarding/email-verification`, and create an account with an email address you can read.
2. In the Network tab, check the `users/new` request: `extra` should contain both `has_segmentation_survey` and `from: "onboarding-with-email-verification"`.
3. On the gate, press Resend. The `me/send-verification-email` request should carry the same `from`.
4. Repeat step 1 without the flag. `extra` should contain `has_segmentation_survey` only, with no `from` key at all.
5. Sign up with Google or Apple instead. Nothing about that request changes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
