### PR TITLE
Signup: protect passwordless signup with Blackbox

### DIFF
--- a/client/blocks/login/use-blackbox-protection.tsx
+++ b/client/blocks/login/use-blackbox-protection.tsx
@@ -22,6 +22,12 @@ interface UseBlackboxProtectionOptions {
 	 * `getSessionId` is a no-op so no SDK load/collect happens.
 	 */
 	feature: string;
+	/**
+	 * Keep Blackbox off while the host form is mounted but not the active
+	 * surface (e.g. hidden behind another step). No collect happens and no
+	 * challenge can render until this flips back to false.
+	 */
+	suspended?: boolean;
 }
 
 const noopGetSessionId = () => Promise.resolve( undefined );
@@ -31,8 +37,10 @@ const noopGetSessionId = () => Promise.resolve( undefined );
  */
 export function useBlackboxProtection( {
 	feature,
+	suspended,
 }: UseBlackboxProtectionOptions ): BlackboxProtection {
 	const enabled =
+		! suspended &&
 		!! config( 'blackbox_api_key' ) &&
 		config.isEnabled( 'blackbox' ) &&
 		config.isEnabled( feature );

--- a/client/blocks/login/use-blackbox-protection.tsx
+++ b/client/blocks/login/use-blackbox-protection.tsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import BlackboxChallenge from 'calypso/blocks/login/blackbox-challenge';
 import { getBlackboxSessionId } from 'calypso/blocks/login/utils/get-blackbox-session-id';
 import type { ReactElement } from 'react';
@@ -45,6 +45,15 @@ export function useBlackboxProtection( {
 		config.isEnabled( 'blackbox' ) &&
 		config.isEnabled( feature );
 	const [ isSubmitBlocked, setIsSubmitBlocked ] = useState( enabled );
+
+	// Re-block during render when a suspended surface re-enables: the challenge
+	// only re-blocks from a post-paint effect, which would leave the submit
+	// button clickable for a frame.
+	const prevEnabled = useRef( enabled );
+	if ( prevEnabled.current !== enabled ) {
+		prevEnabled.current = enabled;
+		setIsSubmitBlocked( enabled );
+	}
 
 	const handleSubmitBlockedChange = useCallback( ( isBlocked: boolean ) => {
 		setIsSubmitBlocked( isBlocked );

--- a/client/blocks/login/utils/test/use-blackbox.jsx
+++ b/client/blocks/login/utils/test/use-blackbox.jsx
@@ -12,11 +12,11 @@ jest.mock( '../blackbox-sdk', () => ( {
 	loadBlackboxSdk: jest.fn( () => Promise.resolve() ),
 } ) );
 
-function TestComponent() {
+function TestComponent( { enabled = true } ) {
 	const containerRef = useRef( null );
 	const { hasChallengeContent, isChallengeActive, isLoading } = useBlackbox( {
 		containerRef,
-		enabled: true,
+		enabled,
 	} );
 
 	return (
@@ -117,6 +117,50 @@ describe( 'useBlackbox', () => {
 		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/content' );
 
 		act( () => callbacks.onChallengeComplete() );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
+	} );
+
+	test( 'does not load the SDK while disabled', async () => {
+		render( <TestComponent enabled={ false } /> );
+
+		await act( async () => {} );
+
+		expect( loadBlackboxSdk ).not.toHaveBeenCalled();
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
+	} );
+
+	test( 'starts loading and configures when enabled after mount', async () => {
+		const { rerender } = render( <TestComponent enabled={ false } /> );
+
+		await act( async () => {} );
+		rerender( <TestComponent enabled /> );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'loading/inactive/empty' );
+
+		await act( async () => {} );
+
+		expect( window.Blackbox.configure ).toHaveBeenCalled();
+
+		act( () => jest.advanceTimersByTime( 500 ) );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
+	} );
+
+	test( 'clears blocking state when disabled mid-challenge', async () => {
+		let callbacks;
+		window.Blackbox.configure.mockImplementationOnce( ( config ) => {
+			callbacks = config;
+		} );
+
+		const { rerender } = render( <TestComponent /> );
+
+		await act( async () => {} );
+		act( () => callbacks.onChallengeStart() );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/active/empty' );
+
+		rerender( <TestComponent enabled={ false } /> );
 
 		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
 	} );

--- a/client/blocks/login/utils/use-blackbox.js
+++ b/client/blocks/login/utils/use-blackbox.js
@@ -47,8 +47,17 @@ export function useBlackbox( { containerRef, enabled } ) {
 
 	useEffect( () => {
 		if ( ! isEnabled ) {
+			// Covers the surface being suspended after a challenge appeared: drop
+			// all blocking state so the form isn't wedged when it re-enables.
+			setIsLoading( false );
+			setIsChallengeActive( false );
+			setHasChallengeContent( false );
 			return;
 		}
+
+		// The initial state only covers enabled-at-mount; this covers a surface
+		// that enables later (e.g. a hidden signup step becoming active).
+		setIsLoading( true );
 
 		let cancelled = false;
 		let hasStartedChallenge = false;

--- a/client/blocks/login/with-blackbox-protection.tsx
+++ b/client/blocks/login/with-blackbox-protection.tsx
@@ -7,6 +7,11 @@ interface WithBlackboxProtectionOptions {
 	feature: string;
 }
 
+interface WithBlackboxProtectionProps {
+	/** Suspend Blackbox while the host form is mounted but not the active surface. */
+	blackboxSuspended?: boolean;
+}
+
 /**
  * HOC that injects `useBlackboxProtection()` as a `blackbox` prop, for class
  * components that can't call the hook directly.
@@ -14,9 +19,12 @@ interface WithBlackboxProtectionOptions {
 export function withBlackboxProtection< P extends object >(
 	WrappedComponent: ComponentType< P & { blackbox: BlackboxProtection } >,
 	options: WithBlackboxProtectionOptions
-): ComponentType< P > {
-	return function WithBlackboxProtection( props: P ) {
-		const blackbox = useBlackboxProtection( options );
-		return <WrappedComponent { ...props } blackbox={ blackbox } />;
+): ComponentType< P & WithBlackboxProtectionProps > {
+	return function WithBlackboxProtection( {
+		blackboxSuspended,
+		...props
+	}: P & WithBlackboxProtectionProps ) {
+		const blackbox = useBlackboxProtection( { ...options, suspended: blackboxSuspended } );
+		return <WrappedComponent { ...( props as P ) } blackbox={ blackbox } />;
 	};
 }

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -585,13 +585,13 @@ class SignupForm extends Component {
 		return this.props.displayUsernameInput;
 	}
 
-	handlePasswordlessSubmit = ( passwordLessData ) => {
+	handlePasswordlessSubmit = ( passwordLessData, afterSubmit ) => {
 		this.formStateController.handleSubmit( ( hasErrors ) => {
 			if ( hasErrors ) {
 				this.setState( { submitting: false } );
 				return;
 			}
-			this.props.submitForm( this.state.form, passwordLessData );
+			this.props.submitForm( this.state.form, passwordLessData, undefined, afterSubmit );
 		} );
 	};
 

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { withBlackboxProtection } from 'calypso/blocks/login/with-blackbox-protection';
 import { ActionButtons } from 'calypso/components/connect-screen/action-buttons';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import LoggedOutForm from 'calypso/components/logged-out-form';
@@ -25,6 +26,12 @@ import SignupSubmitButton from './signup-submit-button';
 
 class PasswordlessSignupForm extends Component {
 	static propTypes = {
+		blackbox: PropTypes.shape( {
+			isSubmitBlocked: PropTypes.bool.isRequired,
+			challenge: PropTypes.node.isRequired,
+			getSessionId: PropTypes.func.isRequired,
+			reset: PropTypes.func.isRequired,
+		} ).isRequired,
 		locale: PropTypes.string,
 		inputPlaceholder: PropTypes.string,
 		submitButtonLabel: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
@@ -109,11 +116,24 @@ class PasswordlessSignupForm extends Component {
 		// If not in a flow, submit the form as a standard signup form.
 		// Since it is a passwordless form, we don't need to submit a password.
 		if ( flowName === '' && this.props.submitForm ) {
-			this.props.submitForm( {
-				email: this.state.email,
-				is_passwordless: true,
-				is_dev_account: isDevAccount,
-			} );
+			const blackboxSessionId = await this.props.blackbox.getSessionId();
+
+			// The parent spreads this payload into its /users/new request body.
+			this.props.submitForm(
+				{
+					email: this.state.email,
+					is_passwordless: true,
+					is_dev_account: isDevAccount,
+					...( blackboxSessionId && { blackbox_session_id: blackboxSessionId } ),
+				},
+				( error ) => {
+					// The handed-off session was consumed by the parent's failed
+					// request; reset so a retry gets a verifiable one.
+					if ( error ) {
+						this.props.blackbox.reset();
+					}
+				}
+			);
 			return;
 		}
 		this.setState( {
@@ -133,6 +153,8 @@ class PasswordlessSignupForm extends Component {
 		const signup_flow_name = queryArgs.variationName === 'entrepreneur' ? 'entrepreneur' : flowName;
 
 		try {
+			const blackboxSessionId = await this.props.blackbox.getSessionId();
+
 			const body = {
 				email: typeof this.state.email === 'string' ? this.state.email.trim() : '',
 				is_passwordless: true,
@@ -151,6 +173,7 @@ class PasswordlessSignupForm extends Component {
 					has_segmentation_survey: queryArgs.variationName === 'entrepreneur',
 					...( activationEmailFrom && { from: activationEmailFrom } ),
 				},
+				...( blackboxSessionId && { blackbox_session_id: blackboxSessionId } ),
 			};
 
 			const { search = '' } = typeof window !== 'undefined' ? window.location : {};
@@ -171,6 +194,9 @@ class PasswordlessSignupForm extends Component {
 
 	createAccountError = async ( error ) => {
 		this.submitTracksEvent( false, { action_message: error.message, error_code: error.error } );
+
+		// Reset Blackbox so the next signup attempt gets a fresh session.
+		this.props.blackbox.reset();
 
 		if ( ! isExistingAccountError( error.error ) ) {
 			if ( isThrottledError( error.error ) ) {
@@ -348,7 +374,10 @@ class PasswordlessSignupForm extends Component {
 	formFooter() {
 		const { isSubmitting } = this.state;
 		const isPrimaryDisabled =
-			isSubmitting || !! this.props.disabled || !! this.props.disableSubmitButton;
+			isSubmitting ||
+			!! this.props.disabled ||
+			!! this.props.disableSubmitButton ||
+			this.props.blackbox.isSubmitBlocked;
 		const submitButtonText = isSubmitting
 			? this.props.submitButtonLoadingLabel || this.props.translate( 'Creating Your Account…' )
 			: this.props.submitButtonLabel || this.props.translate( 'Create your account' );
@@ -409,6 +438,7 @@ class PasswordlessSignupForm extends Component {
 						/>
 						{ this.props.children }
 					</ValidationFieldset>
+					{ this.props.blackbox.challenge }
 					{ ! this.props.termsAfterActions && terms }
 					{ this.formFooter() }
 					{ this.props.termsAfterActions && terms }
@@ -421,4 +451,4 @@ export default connect( null, {
 	recordTracksEvent,
 	saveSignupStep,
 	submitCreateAccountStep: submitSignupStep,
-} )( localize( PasswordlessSignupForm ) );
+} )( localize( withBlackboxProtection( PasswordlessSignupForm, { feature: 'blackbox-signup' } ) ) );

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -234,7 +234,10 @@ const SignupFormSocialFirst = ( {
 
 	const emailLoginBlock = isEmailFirstVariant ? (
 		<div className="signup-form-social-first-email">
-			<PasswordlessSignupForm { ...passwordlessFormProps } />
+			<PasswordlessSignupForm
+				{ ...passwordlessFormProps }
+				blackboxSuspended={ currentStep !== 'initial' }
+			/>
 		</div>
 	) : null;
 
@@ -251,6 +254,7 @@ const SignupFormSocialFirst = ( {
 		<div className="signup-form-social-first-email">
 			<PasswordlessSignupForm
 				{ ...passwordlessFormProps }
+				blackboxSuspended={ currentStep !== 'email' }
 				renderTerms={ renderEmailStepTermsOfService }
 				// Partner copy is positionally worded — Woo's says "the options below".
 				termsAfterActions={ ! showsPartnerTerms }

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -232,6 +232,9 @@ const SignupFormSocialFirst = ( {
 		submitButtonLoadingLabel,
 	};
 
+	// Both screens stay mounted (stacked, toggled via CSS visibility) and share the
+	// global Blackbox singleton, so at most one PasswordlessSignupForm may be
+	// unsuspended at a time — each instance gates on its own screen being active.
 	const emailLoginBlock = isEmailFirstVariant ? (
 		<div className="signup-form-social-first-email">
 			<PasswordlessSignupForm

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -107,9 +107,9 @@
 	}
 
 	// The challenge container renders even without a visible challenge; scope
-	// the spacing to `.has-visible-challenge` to avoid a permanent gap.
+	// spacing to `.has-visible-challenge` to avoid a permanent gap.
 	.login__form-blackbox-challenge.has-visible-challenge {
-		margin-block-end: 8px;
+		margin-block-start: 8px;
 	}
 }
 

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -105,6 +105,12 @@
 	.validation-fieldset__validation-message {
 		min-height: auto;
 	}
+
+	// The challenge container renders even without a visible challenge; scope
+	// the spacing to `.has-visible-challenge` to avoid a permanent gap.
+	.login__form-blackbox-challenge.has-visible-challenge {
+		margin-block-end: 8px;
+	}
 }
 
 .signup-form__recaptcha-tos {

--- a/client/blocks/signup-form/test/passwordless.jsx
+++ b/client/blocks/signup-form/test/passwordless.jsx
@@ -2,12 +2,27 @@
  * @jest-environment jsdom
  */
 
+import config from '@automattic/calypso-config';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { thunk } from 'redux-thunk';
+import { getBlackboxSessionId } from 'calypso/blocks/login/utils/get-blackbox-session-id';
 import PasswordlessSignupForm from '../passwordless';
+
+jest.mock( 'calypso/blocks/login/utils/get-blackbox-session-id', () => ( {
+	getBlackboxSessionId: jest.fn().mockResolvedValue( undefined ),
+} ) );
+
+jest.mock( 'calypso/blocks/login/blackbox-challenge', () => {
+	const { useEffect } = require( 'react' );
+	// Stand-in widget that reports "not blocking" so an enabled form stays submittable.
+	return ( { onSubmitBlockedChange } ) => {
+		useEffect( () => onSubmitBlockedChange?.( false ), [ onSubmitBlockedChange ] );
+		return null;
+	};
+} );
 
 describe( 'createAccountError', () => {
 	const mockStore = configureStore( [ thunk ] );
@@ -165,5 +180,145 @@ describe( 'email update mode', () => {
 		);
 		expect( screen.getByRole( 'button', { name: 'Go back' } ) ).toBeEnabled();
 		nock.cleanAll();
+	} );
+} );
+
+describe( 'Blackbox integration', () => {
+	const mockStore = configureStore( [ thunk ] );
+
+	const renderFormAndSubmit = () => {
+		const store = mockStore( {} );
+
+		render(
+			<Provider store={ store }>
+				<PasswordlessSignupForm />
+			</Provider>
+		);
+
+		const emailInput = screen.getByRole( 'textbox', { name: /email/i } );
+		fireEvent.change( emailInput, { target: { value: 'test@example.com' } } );
+
+		const submitButton = screen.getByRole( 'button', { name: /create your account/i } );
+		fireEvent.click( submitButton );
+	};
+
+	const interceptUsersNew = ( status, responseBody ) => {
+		let requestBody;
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/rest/v1.1/users/new', ( body ) => {
+				requestBody = body;
+				return true;
+			} )
+			.reply( status, responseBody );
+		return () => requestBody;
+	};
+
+	afterEach( () => {
+		// Restore the enabled baseline from config/test.json.
+		config.enable( 'blackbox' );
+		config.enable( 'blackbox-signup' );
+		getBlackboxSessionId.mockReset();
+		getBlackboxSessionId.mockResolvedValue( undefined );
+		delete window.Blackbox;
+		nock.cleanAll();
+	} );
+
+	it( 'attaches blackbox_session_id to the signup request when available', async () => {
+		getBlackboxSessionId.mockResolvedValue( 'ABCDEFGHIJKLMNOPQRSTuv' );
+		const getRequestBody = interceptUsersNew( 403, { error: 'throttled' } );
+
+		renderFormAndSubmit();
+
+		await waitFor( () => expect( getRequestBody() ).toBeTruthy() );
+		expect( getRequestBody().blackbox_session_id ).toBe( 'ABCDEFGHIJKLMNOPQRSTuv' );
+	} );
+
+	it( 'omits blackbox_session_id when the signup feature flag is off', async () => {
+		config.disable( 'blackbox-signup' );
+		getBlackboxSessionId.mockResolvedValue( 'ABCDEFGHIJKLMNOPQRSTuv' );
+		const getRequestBody = interceptUsersNew( 403, { error: 'throttled' } );
+
+		renderFormAndSubmit();
+
+		await waitFor( () => expect( getRequestBody() ).toBeTruthy() );
+		expect( getRequestBody() ).not.toHaveProperty( 'blackbox_session_id' );
+		expect( getBlackboxSessionId ).not.toHaveBeenCalled();
+	} );
+
+	it( 'resets Blackbox when the signup request fails', async () => {
+		window.Blackbox = { reset: jest.fn() };
+		interceptUsersNew( 500, { error: 'internal_server_error' } );
+
+		renderFormAndSubmit();
+
+		await waitFor( () => expect( window.Blackbox.reset ).toHaveBeenCalledTimes( 1 ) );
+	} );
+
+	describe( 'standalone form (no flow, parent-owned submit)', () => {
+		const renderStandaloneFormAndSubmit = ( submitForm ) => {
+			const store = mockStore( {} );
+
+			render(
+				<Provider store={ store }>
+					<PasswordlessSignupForm flowName="" submitForm={ submitForm } />
+				</Provider>
+			);
+
+			const emailInput = screen.getByRole( 'textbox', { name: /email/i } );
+			fireEvent.change( emailInput, { target: { value: 'test@example.com' } } );
+
+			fireEvent.click( screen.getByRole( 'button', { name: /create your account/i } ) );
+		};
+
+		it( 'attaches blackbox_session_id to the submitForm payload', async () => {
+			getBlackboxSessionId.mockResolvedValue( 'ABCDEFGHIJKLMNOPQRSTuv' );
+			const submitForm = jest.fn();
+
+			renderStandaloneFormAndSubmit( submitForm );
+
+			await waitFor( () => expect( submitForm ).toHaveBeenCalledTimes( 1 ) );
+			expect( submitForm ).toHaveBeenCalledWith(
+				expect.objectContaining( { blackbox_session_id: 'ABCDEFGHIJKLMNOPQRSTuv' } ),
+				expect.any( Function )
+			);
+		} );
+
+		it( 'omits blackbox_session_id when no session is available', async () => {
+			getBlackboxSessionId.mockResolvedValue( undefined );
+			const submitForm = jest.fn();
+
+			renderStandaloneFormAndSubmit( submitForm );
+
+			await waitFor( () => expect( submitForm ).toHaveBeenCalledTimes( 1 ) );
+			expect( submitForm.mock.calls[ 0 ][ 0 ] ).not.toHaveProperty( 'blackbox_session_id' );
+		} );
+
+		it( 'resets Blackbox when the parent reports a submit error', async () => {
+			window.Blackbox = { reset: jest.fn() };
+			getBlackboxSessionId.mockResolvedValue( 'ABCDEFGHIJKLMNOPQRSTuv' );
+			const submitForm = jest.fn();
+
+			renderStandaloneFormAndSubmit( submitForm );
+			await waitFor( () => expect( submitForm ).toHaveBeenCalledTimes( 1 ) );
+
+			const afterSubmit = submitForm.mock.calls[ 0 ][ 1 ];
+			afterSubmit( { error: 'email_exists' } );
+
+			expect( window.Blackbox.reset ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'does not reset Blackbox when the parent submit succeeds', async () => {
+			window.Blackbox = { reset: jest.fn() };
+			getBlackboxSessionId.mockResolvedValue( 'ABCDEFGHIJKLMNOPQRSTuv' );
+			const submitForm = jest.fn();
+
+			renderStandaloneFormAndSubmit( submitForm );
+			await waitFor( () => expect( submitForm ).toHaveBeenCalledTimes( 1 ) );
+
+			const afterSubmit = submitForm.mock.calls[ 0 ][ 1 ];
+			afterSubmit();
+
+			expect( window.Blackbox.reset ).not.toHaveBeenCalled();
+		} );
 	} );
 } );

--- a/client/jetpack-connect/signup.jsx
+++ b/client/jetpack-connect/signup.jsx
@@ -191,8 +191,16 @@ export class JetpackSignup extends Component {
 						plugins: this.props.authQuery.plugins,
 					},
 				} )
-				.then( this.handleUserCreationSuccess, this.handleUserCreationError )
-				.finally( afterSubmit )
+				.then(
+					( result ) => {
+						this.handleUserCreationSuccess( result );
+						afterSubmit();
+					},
+					( error ) => {
+						this.handleUserCreationError( error );
+						afterSubmit( error );
+					}
+				)
 		);
 	};
 

--- a/client/jetpack-connect/signup.jsx
+++ b/client/jetpack-connect/signup.jsx
@@ -178,6 +178,7 @@ export class JetpackSignup extends Component {
 
 	handleSubmitSignup = ( _, userData, analyticsData, afterSubmit = noop ) => {
 		debug( 'submitting new account', userData );
+		let submitError;
 		this.setState( { isCreatingAccount: true }, () =>
 			this.props
 				.createAccount( {
@@ -191,16 +192,11 @@ export class JetpackSignup extends Component {
 						plugins: this.props.authQuery.plugins,
 					},
 				} )
-				.then(
-					( result ) => {
-						this.handleUserCreationSuccess( result );
-						afterSubmit();
-					},
-					( error ) => {
-						this.handleUserCreationError( error );
-						afterSubmit( error );
-					}
-				)
+				.then( this.handleUserCreationSuccess, ( error ) => {
+					submitError = error;
+					this.handleUserCreationError( error );
+				} )
+				.finally( () => afterSubmit( submitError ) )
 		);
 	};
 

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -149,10 +149,14 @@ exports[`JetpackSignup should render 1`] = `
                 />
               </fieldset>
               <div
+                class="login__form-blackbox-challenge"
+              />
+              <div
                 class="card logged-out-form__footer"
               >
                 <button
                   class="components-button signup-form__submit is-next-40px-default-size is-primary"
+                  disabled=""
                   type="submit"
                 >
                   Continue
@@ -340,10 +344,14 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
                 />
               </fieldset>
               <div
+                class="login__form-blackbox-challenge"
+              />
+              <div
                 class="card logged-out-form__footer"
               >
                 <button
                   class="components-button signup-form__submit is-next-40px-default-size is-primary"
+                  disabled=""
                   type="submit"
                 >
                   Continue
@@ -456,10 +464,14 @@ exports[`JetpackSignup should render with the connector branding when from=jetpa
                 />
               </fieldset>
               <div
+                class="login__form-blackbox-challenge"
+              />
+              <div
                 class="card logged-out-form__footer"
               >
                 <button
                   class="components-button signup-form__submit is-next-40px-default-size is-primary"
+                  disabled=""
                   type="submit"
                 >
                   Continue

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -70,20 +70,21 @@ class InviteAcceptLoggedOut extends Component {
 			enhancedUserData.signup_flow_name = 'p2';
 		}
 
-		this.props.createAccount( enhancedUserData, invite ).then(
-			( response ) => {
+		let submitError;
+		this.props
+			.createAccount( enhancedUserData, invite )
+			.then( ( response ) => {
 				const bearerToken = response.bearer_token;
 				debug( 'Create account bearerToken: ' + bearerToken );
 				this.setState( { bearerToken, userData } );
-				afterSubmitCallback();
-			},
-			( error ) => {
+			} )
+			.catch( ( error ) => {
+				submitError = error;
 				debug( 'Create account error: ' + JSON.stringify( error ) );
 				store.remove( 'invite_accepted' );
 				this.setState( { submitting: false } );
-				afterSubmitCallback( error );
-			}
-		);
+			} )
+			.finally( () => afterSubmitCallback( submitError ) );
 	};
 
 	handleSocialResponse = ( service, access_token, id_token = null, socialUserData = {} ) => {

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -70,19 +70,20 @@ class InviteAcceptLoggedOut extends Component {
 			enhancedUserData.signup_flow_name = 'p2';
 		}
 
-		this.props
-			.createAccount( enhancedUserData, invite )
-			.then( ( response ) => {
+		this.props.createAccount( enhancedUserData, invite ).then(
+			( response ) => {
 				const bearerToken = response.bearer_token;
 				debug( 'Create account bearerToken: ' + bearerToken );
 				this.setState( { bearerToken, userData } );
-			} )
-			.catch( ( error ) => {
+				afterSubmitCallback();
+			},
+			( error ) => {
 				debug( 'Create account error: ' + JSON.stringify( error ) );
 				store.remove( 'invite_accepted' );
 				this.setState( { submitting: false } );
-			} )
-			.finally( afterSubmitCallback );
+				afterSubmitCallback( error );
+			}
+		);
 	};
 
 	handleSocialResponse = ( service, access_token, id_token = null, socialUserData = {} ) => {

--- a/config/development.json
+++ b/config/development.json
@@ -54,6 +54,7 @@
 		"blackbox": true,
 		"blackbox-login": true,
 		"blackbox-lost-password": true,
+		"blackbox-signup": true,
 		"calypso/ai-blogging-prompts": true,
 		"calypso/ai-site-builder-flow": true,
 		"calypso/all-domain-management": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -16,6 +16,7 @@
 		"blackbox": true,
 		"blackbox-login": true,
 		"blackbox-lost-password": true,
+		"blackbox-signup": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/all-domain-management": false,
 		"calypso/big-sky": true,

--- a/config/production.json
+++ b/config/production.json
@@ -28,6 +28,7 @@
 		"blackbox": true,
 		"blackbox-login": true,
 		"blackbox-lost-password": true,
+		"blackbox-signup": false,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-site-builder-flow": true,
 		"calypso/all-domain-management": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -25,6 +25,7 @@
 		"blackbox": true,
 		"blackbox-login": true,
 		"blackbox-lost-password": true,
+		"blackbox-signup": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-site-builder-flow": true,
 		"calypso/all-domain-management": true,

--- a/config/test.json
+++ b/config/test.json
@@ -28,6 +28,7 @@
 		"blackbox": true,
 		"blackbox-login": true,
 		"blackbox-lost-password": true,
+		"blackbox-signup": true,
 		"calypso/all-domain-management": true,
 		"calypso/domains-dataviews": true,
 		"catch-js-errors": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -24,6 +24,7 @@
 		"blackbox": true,
 		"blackbox-login": true,
 		"blackbox-lost-password": true,
+		"blackbox-signup": true,
 		"calypso/ai-blogging-prompts": true,
 		"calypso/ai-site-builder-flow": true,
 		"calypso/all-domain-management": true,

--- a/test/e2e/specs/authentication/authentication__blackbox-signup-invite.spec.ts
+++ b/test/e2e/specs/authentication/authentication__blackbox-signup-invite.spec.ts
@@ -1,0 +1,271 @@
+import {
+	DataHelper,
+	EmailClient,
+	RestAPIClient,
+	SecretsManager,
+	UserSignupPage,
+} from '@automattic/calypso-e2e';
+import { useBlackboxTestKeyForCollect } from '../../lib/blackbox-test-key';
+import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
+import { apiCloseAccount } from '../shared';
+import type { NewTestUserDetails, NewUserResponse } from '@automattic/calypso-e2e';
+import type { Page, Request } from '@playwright/test';
+
+/**
+ * Blackbox verdicts on the logged-out invite-accept signup form.
+ *
+ * Invites are created via the REST API, but the accept-invite URL must be
+ * taken from the invite email (Mailosaur): a valid accept URL requires the
+ * invite secret, which is only ever embedded in the emailed link — the REST
+ * API exposes just the bare invite slug, which the server rejects.
+ *
+ * Signup verification currently runs in shadow mode on the server
+ * (blackbox_signup_enforcement_enabled() is off), so a block verdict is
+ * recorded but must not prevent the signup. When enforcement is enabled,
+ * the block test below needs to assert a rejected signup instead.
+ */
+test.describe( 'Signup: Blackbox invite accept', { tag: [ tags.AUTHENTICATION ] }, () => {
+	skipIfMailosaurLimitReached();
+	const credentials = SecretsManager.secrets.testAccounts.defaultUser;
+	const siteID = credentials.testSites?.primary?.id as number;
+
+	const accountsToCleanup: { user: NewUserResponse[ 'body' ]; password: string; email: string }[] =
+		[];
+	// Emails this suite has invited; only their pending invites are deleted in
+	// teardown so concurrent runs' invites are never touched.
+	const createdInviteEmails: string[] = [];
+
+	test.afterAll( async function () {
+		for ( const account of accountsToCleanup ) {
+			const restAPIClient = new RestAPIClient(
+				{ username: account.user.username, password: account.password },
+				account.user.bearer_token
+			);
+			await apiCloseAccount( restAPIClient, {
+				userID: account.user.user_id,
+				username: account.user.username,
+				email: account.email,
+			} );
+		}
+
+		if ( ! createdInviteEmails.length ) {
+			return;
+		}
+		// Best-effort cleanup: a failure here must not fail an otherwise-passing
+		// run, so swallow errors and log them instead.
+		try {
+			const restAPIClient = new RestAPIClient( credentials );
+			const staleKeys = ( await restAPIClient.getInvites( siteID, 100 ) )
+				.filter(
+					( invite ) => invite.is_pending && createdInviteEmails.includes( invite.user.email )
+				)
+				.map( ( invite ) => invite.invite_key );
+			if ( staleKeys.length ) {
+				await restAPIClient.deleteInvites( siteID, staleKeys );
+			}
+		} catch ( error ) {
+			process.stderr.write( `[blackbox-signup-invite] invite teardown failed: ${ error }\n` );
+		}
+	} );
+
+	/**
+	 * Creates an invite for the test user via the REST API and returns the
+	 * accept-invite URL from the invite email, rehosted onto the Calypso
+	 * environment under test (the emailed link always points at wordpress.com).
+	 */
+	const createAcceptInviteURL = async (
+		clientEmail: EmailClient,
+		testUser: NewTestUserDetails
+	): Promise< string > => {
+		const restAPIClient = new RestAPIClient( credentials );
+
+		// Track before the call: createInvite can create the invite server-side
+		// and still throw, so the email must be queued for teardown regardless.
+		createdInviteEmails.push( testUser.email );
+		await restAPIClient.createInvite( siteID, { email: [ testUser.email ], role: 'Editor' } );
+
+		const message = await clientEmail.getLastMatchingMessage( {
+			inboxId: testUser.inboxId,
+			sentTo: testUser.email,
+		} );
+		const links = await clientEmail.getLinksFromMessage( message );
+		const acceptInviteLink = links.find( ( link ) => link.includes( 'accept-invite' ) );
+		expect( acceptInviteLink ).toBeDefined();
+
+		// The emailed link is a click-tracking redirect; the real accept URL
+		// (with the invite key and email_verification_secret) is in redirect_to.
+		const trackingURL = new URL( acceptInviteLink as string );
+		const acceptInviteURL = new URL(
+			trackingURL.searchParams.get( 'redirect_to' ) ?? ( acceptInviteLink as string )
+		);
+		// Fail loudly if the email's tracking-link format changes: rehosting a
+		// non-accept path would otherwise surface as an opaque collect timeout.
+		expect( acceptInviteURL.pathname ).toContain( '/accept-invite/' );
+
+		return DataHelper.getCalypsoURL( acceptInviteURL.pathname + acceptInviteURL.search );
+	};
+
+	const waitForCollectResponse = ( page: Page ) =>
+		page.waitForResponse(
+			( response ) =>
+				response.request().method() === 'POST' &&
+				response.url().includes( 'blackbox-api.wp.com/v1/collect' ),
+			{ timeout: 60 * 1000 }
+		);
+
+	const waitForUsersNewRequest = ( page: Page ): Promise< Request > =>
+		page.waitForRequest(
+			( request ) => request.method() === 'POST' && /\/users\/new\?/.test( request.url() ),
+			{ timeout: 60 * 1000 }
+		);
+
+	test( 'As an invited new user, I can sign up when Blackbox returns allow', async ( {
+		page,
+		clientEmail,
+	}, workerInfo ) => {
+		test.skip(
+			workerInfo.project.name !== 'authentication',
+			'The authentication project is the only one that has the right browser settings for authentication tests'
+		);
+
+		const testUser = DataHelper.getNewTestUser( {
+			useMailosaur: true,
+			usernamePrefix: 'blackbox',
+		} );
+		let acceptInviteURL: string;
+		let newUserDetails: NewUserResponse;
+
+		await test.step( 'Given an invite exists for my email', async function () {
+			acceptInviteURL = await createAcceptInviteURL( clientEmail, testUser );
+		} );
+
+		await test.step( 'And Blackbox collect uses the public allow test key', async function () {
+			await useBlackboxTestKeyForCollect( page, 'allow' );
+		} );
+
+		const collectResponse = waitForCollectResponse( page );
+
+		await test.step( 'When I visit the accept-invite page', async function () {
+			await page.goto( acceptInviteURL );
+
+			const collectBody = await ( await collectResponse ).json();
+			expect( collectBody?.data?.session_id ).toBe( 'bbtest_allow__________' );
+		} );
+
+		await test.step( 'And I sign up with my email', async function () {
+			const usersNewRequest = waitForUsersNewRequest( page );
+
+			newUserDetails = await new UserSignupPage( page ).signupThroughInvite( testUser.email );
+			// Queue teardown before asserting so a created account never leaks.
+			accountsToCleanup.push( {
+				user: newUserDetails.body,
+				password: testUser.password,
+				email: testUser.email,
+			} );
+
+			const request = await usersNewRequest;
+			expect( request.postDataJSON()?.blackbox_session_id ).toBe( 'bbtest_allow__________' );
+		} );
+
+		await test.step( 'Then the account is created', async function () {
+			expect( newUserDetails.body.user_id ).toBeTruthy();
+			expect( newUserDetails.body.bearer_token ).toBeTruthy();
+		} );
+	} );
+
+	test( 'As an invited new user, I see a challenge and cannot submit while it is active', async ( {
+		page,
+		clientEmail,
+	}, workerInfo ) => {
+		test.skip(
+			workerInfo.project.name !== 'authentication',
+			'The authentication project is the only one that has the right browser settings for authentication tests'
+		);
+
+		const testUser = DataHelper.getNewTestUser( {
+			useMailosaur: true,
+			usernamePrefix: 'blackbox',
+		} );
+		let acceptInviteURL: string;
+
+		await test.step( 'Given an invite exists for my email', async function () {
+			acceptInviteURL = await createAcceptInviteURL( clientEmail, testUser );
+		} );
+
+		await test.step( 'And Blackbox collect uses the public challenge test key', async function () {
+			await useBlackboxTestKeyForCollect( page, 'challenge' );
+		} );
+
+		const collectResponse = waitForCollectResponse( page );
+
+		await test.step( 'When I visit the accept-invite page', async function () {
+			await page.goto( acceptInviteURL );
+
+			const collectBody = await ( await collectResponse ).json();
+			expect( collectBody?.data?.session_id ).toBe( 'bbtest_challenge______' );
+			expect( collectBody?.data?.challenge ).toBeTruthy();
+		} );
+
+		await test.step( 'Then the challenge widget is shown and submit is blocked', async function () {
+			await expect(
+				page.locator( '.login__form-blackbox-challenge.has-visible-challenge' )
+			).toBeVisible();
+			await expect(
+				page.locator( '.signup-form__passwordless-form-wrapper button[type="submit"]' )
+			).toBeDisabled();
+		} );
+	} );
+
+	test( 'As an invited new user, my signup still succeeds when Blackbox returns block (shadow mode)', async ( {
+		page,
+		clientEmail,
+	}, workerInfo ) => {
+		test.skip(
+			workerInfo.project.name !== 'authentication',
+			'The authentication project is the only one that has the right browser settings for authentication tests'
+		);
+
+		const testUser = DataHelper.getNewTestUser( {
+			useMailosaur: true,
+			usernamePrefix: 'blackbox',
+		} );
+		let acceptInviteURL: string;
+		let newUserDetails: NewUserResponse;
+
+		await test.step( 'Given an invite exists for my email', async function () {
+			acceptInviteURL = await createAcceptInviteURL( clientEmail, testUser );
+		} );
+
+		await test.step( 'And Blackbox collect uses the public block test key', async function () {
+			await useBlackboxTestKeyForCollect( page, 'block' );
+		} );
+
+		const collectResponse = waitForCollectResponse( page );
+
+		await test.step( 'When I visit the accept-invite page', async function () {
+			await page.goto( acceptInviteURL );
+
+			const collectBody = await ( await collectResponse ).json();
+			expect( collectBody?.data?.session_id ).toBe( 'bbtest_block__________' );
+		} );
+
+		await test.step( 'And I sign up with my email', async function () {
+			const usersNewRequest = waitForUsersNewRequest( page );
+
+			newUserDetails = await new UserSignupPage( page ).signupThroughInvite( testUser.email );
+			accountsToCleanup.push( {
+				user: newUserDetails.body,
+				password: testUser.password,
+				email: testUser.email,
+			} );
+
+			const request = await usersNewRequest;
+			expect( request.postDataJSON()?.blackbox_session_id ).toBe( 'bbtest_block__________' );
+		} );
+
+		await test.step( 'Then the account is still created (enforcement is off)', async function () {
+			expect( newUserDetails.body.user_id ).toBeTruthy();
+			expect( newUserDetails.body.bearer_token ).toBeTruthy();
+		} );
+	} );
+} );

--- a/test/e2e/specs/authentication/authentication__blackbox-signup-jetpack-connect.spec.ts
+++ b/test/e2e/specs/authentication/authentication__blackbox-signup-jetpack-connect.spec.ts
@@ -1,0 +1,187 @@
+import { DataHelper, RestAPIClient, UserSignupPage } from '@automattic/calypso-e2e';
+import { useBlackboxTestKeyForCollect } from '../../lib/blackbox-test-key';
+import { expect, tags, test } from '../../lib/pw-base';
+import { apiCloseAccount } from '../shared';
+import type { NewUserResponse } from '@automattic/calypso-e2e';
+import type { Page, Request } from '@playwright/test';
+
+/**
+ * Blackbox verdicts on the Jetpack Connect signup (logged-out
+ * /jetpack/connect/authorize).
+ *
+ * The authorize query is only schema-validated client-side, so placeholder
+ * values render the real signup form and the /users/new account creation
+ * succeeds; only the Jetpack site authorization after signup would fail,
+ * which these tests never reach.
+ *
+ * Signup verification currently runs in shadow mode on the server
+ * (blackbox_signup_enforcement_enabled() is off), so a block verdict is
+ * recorded but must not prevent the signup. When enforcement is enabled,
+ * the block test below needs to assert a rejected signup instead.
+ */
+test.describe( 'Signup: Blackbox Jetpack Connect', { tag: [ tags.AUTHENTICATION ] }, () => {
+	const jetpackAuthorizeURL = DataHelper.getCalypsoURL( 'jetpack/connect/authorize', {
+		_wp_nonce: 'e2enonce',
+		blogname: 'Blackbox E2E',
+		client_id: '12345',
+		home_url: 'https://example.com',
+		redirect_uri: 'https://example.com/wp-admin/admin.php?page=jetpack',
+		scope: 'administrator:e2ehash',
+		secret: 'e2esecret',
+		site: 'https://example.com',
+		site_url: 'https://example.com',
+		state: '1',
+	} );
+
+	const accountsToCleanup: { user: NewUserResponse[ 'body' ]; password: string; email: string }[] =
+		[];
+
+	test.afterAll( async function () {
+		for ( const account of accountsToCleanup ) {
+			const restAPIClient = new RestAPIClient(
+				{ username: account.user.username, password: account.password },
+				account.user.bearer_token
+			);
+			await apiCloseAccount( restAPIClient, {
+				userID: account.user.user_id,
+				username: account.user.username,
+				email: account.email,
+			} );
+		}
+	} );
+
+	const waitForCollectResponse = ( page: Page ) =>
+		page.waitForResponse(
+			( response ) =>
+				response.request().method() === 'POST' &&
+				response.url().includes( 'blackbox-api.wp.com/v1/collect' ),
+			{ timeout: 60 * 1000 }
+		);
+
+	const waitForUsersNewRequest = ( page: Page ): Promise< Request > =>
+		page.waitForRequest(
+			( request ) => request.method() === 'POST' && /\/users\/new\?/.test( request.url() ),
+			{ timeout: 60 * 1000 }
+		);
+
+	test( 'As a new user, I can sign up through Jetpack Connect when Blackbox returns allow', async ( {
+		page,
+	}, workerInfo ) => {
+		test.skip(
+			workerInfo.project.name !== 'authentication',
+			'The authentication project is the only one that has the right browser settings for authentication tests'
+		);
+
+		const testUser = DataHelper.getNewTestUser( { usernamePrefix: 'blackbox' } );
+		let newUserDetails: NewUserResponse;
+
+		await test.step( 'Given Blackbox collect uses the public allow test key', async function () {
+			await useBlackboxTestKeyForCollect( page, 'allow' );
+		} );
+
+		const collectResponse = waitForCollectResponse( page );
+
+		await test.step( 'When I visit the Jetpack Connect authorize page', async function () {
+			await page.goto( jetpackAuthorizeURL );
+
+			const collectBody = await ( await collectResponse ).json();
+			expect( collectBody?.data?.session_id ).toBe( 'bbtest_allow__________' );
+		} );
+
+		await test.step( 'And I sign up with my email', async function () {
+			const usersNewRequest = waitForUsersNewRequest( page );
+
+			newUserDetails = await new UserSignupPage( page ).signupWithEmail( testUser.email );
+			// Queue teardown before asserting so a created account never leaks.
+			accountsToCleanup.push( {
+				user: newUserDetails.body,
+				password: testUser.password,
+				email: testUser.email,
+			} );
+
+			const request = await usersNewRequest;
+			expect( request.postDataJSON()?.blackbox_session_id ).toBe( 'bbtest_allow__________' );
+		} );
+
+		await test.step( 'Then the account is created', async function () {
+			expect( newUserDetails.body.user_id ).toBeTruthy();
+			expect( newUserDetails.body.bearer_token ).toBeTruthy();
+		} );
+	} );
+
+	test( 'As a new user, I see a challenge and cannot submit while it is active', async ( {
+		page,
+	}, workerInfo ) => {
+		test.skip(
+			workerInfo.project.name !== 'authentication',
+			'The authentication project is the only one that has the right browser settings for authentication tests'
+		);
+
+		await test.step( 'Given Blackbox collect uses the public challenge test key', async function () {
+			await useBlackboxTestKeyForCollect( page, 'challenge' );
+		} );
+
+		const collectResponse = waitForCollectResponse( page );
+
+		await test.step( 'When I visit the Jetpack Connect authorize page', async function () {
+			await page.goto( jetpackAuthorizeURL );
+
+			const collectBody = await ( await collectResponse ).json();
+			expect( collectBody?.data?.session_id ).toBe( 'bbtest_challenge______' );
+			expect( collectBody?.data?.challenge ).toBeTruthy();
+		} );
+
+		await test.step( 'Then the challenge widget is shown and submit is blocked', async function () {
+			await expect(
+				page.locator( '.login__form-blackbox-challenge.has-visible-challenge' )
+			).toBeVisible();
+			await expect(
+				page.locator( '.signup-form__passwordless-form-wrapper button[type="submit"]' )
+			).toBeDisabled();
+		} );
+	} );
+
+	test( 'As a new user, my signup still succeeds when Blackbox returns block (shadow mode)', async ( {
+		page,
+	}, workerInfo ) => {
+		test.skip(
+			workerInfo.project.name !== 'authentication',
+			'The authentication project is the only one that has the right browser settings for authentication tests'
+		);
+
+		const testUser = DataHelper.getNewTestUser( { usernamePrefix: 'blackbox' } );
+		let newUserDetails: NewUserResponse;
+
+		await test.step( 'Given Blackbox collect uses the public block test key', async function () {
+			await useBlackboxTestKeyForCollect( page, 'block' );
+		} );
+
+		const collectResponse = waitForCollectResponse( page );
+
+		await test.step( 'When I visit the Jetpack Connect authorize page', async function () {
+			await page.goto( jetpackAuthorizeURL );
+
+			const collectBody = await ( await collectResponse ).json();
+			expect( collectBody?.data?.session_id ).toBe( 'bbtest_block__________' );
+		} );
+
+		await test.step( 'And I sign up with my email', async function () {
+			const usersNewRequest = waitForUsersNewRequest( page );
+
+			newUserDetails = await new UserSignupPage( page ).signupWithEmail( testUser.email );
+			accountsToCleanup.push( {
+				user: newUserDetails.body,
+				password: testUser.password,
+				email: testUser.email,
+			} );
+
+			const request = await usersNewRequest;
+			expect( request.postDataJSON()?.blackbox_session_id ).toBe( 'bbtest_block__________' );
+		} );
+
+		await test.step( 'Then the account is still created (enforcement is off)', async function () {
+			expect( newUserDetails.body.user_id ).toBeTruthy();
+			expect( newUserDetails.body.bearer_token ).toBeTruthy();
+		} );
+	} );
+} );

--- a/test/e2e/specs/authentication/authentication__blackbox-signup-start-account.spec.ts
+++ b/test/e2e/specs/authentication/authentication__blackbox-signup-start-account.spec.ts
@@ -1,0 +1,189 @@
+import { DataHelper, RestAPIClient, UserSignupPage } from '@automattic/calypso-e2e';
+import { useBlackboxTestKeyForCollect } from '../../lib/blackbox-test-key';
+import { expect, tags, test } from '../../lib/pw-base';
+import { apiCloseAccount } from '../shared';
+import type { NewUserResponse } from '@automattic/calypso-e2e';
+import type { Page, Request } from '@playwright/test';
+
+/**
+ * Blackbox verdicts on the /start/account passwordless email signup.
+ *
+ * Signup verification currently runs in shadow mode on the server
+ * (blackbox_signup_enforcement_enabled() is off), so a block verdict is
+ * recorded but must not prevent the signup. When enforcement is enabled,
+ * the block test below needs to assert a rejected signup instead.
+ */
+test.describe( 'Signup: Blackbox /start/account', { tag: [ tags.AUTHENTICATION ] }, () => {
+	const accountsToCleanup: { user: NewUserResponse[ 'body' ]; password: string; email: string }[] =
+		[];
+
+	test.afterAll( async function () {
+		for ( const account of accountsToCleanup ) {
+			const restAPIClient = new RestAPIClient(
+				{ username: account.user.username, password: account.password },
+				account.user.bearer_token
+			);
+			await apiCloseAccount( restAPIClient, {
+				userID: account.user.user_id,
+				username: account.user.username,
+				email: account.email,
+			} );
+		}
+	} );
+
+	const waitForCollectResponse = ( page: Page ) =>
+		page.waitForResponse(
+			( response ) =>
+				response.request().method() === 'POST' &&
+				response.url().includes( 'blackbox-api.wp.com/v1/collect' ),
+			{ timeout: 60 * 1000 }
+		);
+
+	const waitForUsersNewRequest = ( page: Page ): Promise< Request > =>
+		page.waitForRequest(
+			( request ) => request.method() === 'POST' && /\/users\/new\?/.test( request.url() ),
+			{ timeout: 60 * 1000 }
+		);
+
+	test( 'As a new user, I can sign up when Blackbox returns allow', async ( {
+		page,
+	}, workerInfo ) => {
+		test.skip(
+			workerInfo.project.name !== 'authentication',
+			'The authentication project is the only one that has the right browser settings for authentication tests'
+		);
+
+		const testUser = DataHelper.getNewTestUser( { usernamePrefix: 'blackbox' } );
+		let newUserDetails: NewUserResponse;
+
+		await test.step( 'Given Blackbox collect uses the public allow test key', async function () {
+			await useBlackboxTestKeyForCollect( page, 'allow' );
+		} );
+
+		await test.step( 'When I visit the signup page', async function () {
+			await new UserSignupPage( page ).visit( { path: 'account' } );
+		} );
+
+		await test.step( 'And I sign up with my email', async function () {
+			// Blackbox is suspended until the email form becomes the active
+			// surface, so the collect only fires during the signup interaction.
+			const collectResponse = waitForCollectResponse( page );
+			const usersNewRequest = waitForUsersNewRequest( page );
+
+			newUserDetails = await new UserSignupPage( page ).signupSocialFirstWithEmail(
+				testUser.email
+			);
+			// Queue teardown before asserting so a created account never leaks.
+			accountsToCleanup.push( {
+				user: newUserDetails.body,
+				password: testUser.password,
+				email: testUser.email,
+			} );
+
+			const collectBody = await ( await collectResponse ).json();
+			expect( collectBody?.data?.session_id ).toBe( 'bbtest_allow__________' );
+
+			const request = await usersNewRequest;
+			expect( request.postDataJSON()?.blackbox_session_id ).toBe( 'bbtest_allow__________' );
+		} );
+
+		await test.step( 'Then the account is created', async function () {
+			expect( newUserDetails.body.user_id ).toBeTruthy();
+			expect( newUserDetails.body.bearer_token ).toBeTruthy();
+		} );
+	} );
+
+	test( 'As a new user, I see a challenge and cannot submit while it is active', async ( {
+		page,
+	}, workerInfo ) => {
+		test.skip(
+			workerInfo.project.name !== 'authentication',
+			'The authentication project is the only one that has the right browser settings for authentication tests'
+		);
+
+		await test.step( 'Given Blackbox collect uses the public challenge test key', async function () {
+			await useBlackboxTestKeyForCollect( page, 'challenge' );
+		} );
+
+		const collectResponse = waitForCollectResponse( page );
+
+		await test.step( 'When I visit the signup page and reveal the email form', async function () {
+			await new UserSignupPage( page ).visit( { path: 'account' } );
+
+			// Depending on the variant the email form is either inline or behind
+			// a "Continue with email" button; Blackbox activates when it becomes
+			// the active surface.
+			const continueWithEmailButton = page.getByRole( 'button', {
+				name: /continue with email/i,
+			} );
+			await Promise.race( [
+				continueWithEmailButton.waitFor( { state: 'visible', timeout: 30 * 1000 } ),
+				page
+					.locator( 'input[name="email"]:visible' )
+					.first()
+					.waitFor( { state: 'visible', timeout: 30 * 1000 } ),
+			] );
+			if ( await continueWithEmailButton.isVisible() ) {
+				await continueWithEmailButton.click();
+			}
+
+			const collectBody = await ( await collectResponse ).json();
+			expect( collectBody?.data?.session_id ).toBe( 'bbtest_challenge______' );
+			expect( collectBody?.data?.challenge ).toBeTruthy();
+		} );
+
+		await test.step( 'Then the challenge widget is shown and submit is blocked', async function () {
+			await expect(
+				page.locator( '.login__form-blackbox-challenge.has-visible-challenge' )
+			).toBeVisible();
+			await expect(
+				page.locator( '.signup-form__passwordless-form-wrapper button[type="submit"]' )
+			).toBeDisabled();
+		} );
+	} );
+
+	test( 'As a new user, my signup still succeeds when Blackbox returns block (shadow mode)', async ( {
+		page,
+	}, workerInfo ) => {
+		test.skip(
+			workerInfo.project.name !== 'authentication',
+			'The authentication project is the only one that has the right browser settings for authentication tests'
+		);
+
+		const testUser = DataHelper.getNewTestUser( { usernamePrefix: 'blackbox' } );
+		let newUserDetails: NewUserResponse;
+
+		await test.step( 'Given Blackbox collect uses the public block test key', async function () {
+			await useBlackboxTestKeyForCollect( page, 'block' );
+		} );
+
+		await test.step( 'When I visit the signup page', async function () {
+			await new UserSignupPage( page ).visit( { path: 'account' } );
+		} );
+
+		await test.step( 'And I sign up with my email', async function () {
+			const collectResponse = waitForCollectResponse( page );
+			const usersNewRequest = waitForUsersNewRequest( page );
+
+			newUserDetails = await new UserSignupPage( page ).signupSocialFirstWithEmail(
+				testUser.email
+			);
+			accountsToCleanup.push( {
+				user: newUserDetails.body,
+				password: testUser.password,
+				email: testUser.email,
+			} );
+
+			const collectBody = await ( await collectResponse ).json();
+			expect( collectBody?.data?.session_id ).toBe( 'bbtest_block__________' );
+
+			const request = await usersNewRequest;
+			expect( request.postDataJSON()?.blackbox_session_id ).toBe( 'bbtest_block__________' );
+		} );
+
+		await test.step( 'Then the account is still created (enforcement is off)', async function () {
+			expect( newUserDetails.body.user_id ).toBeTruthy();
+			expect( newUserDetails.body.bearer_token ).toBeTruthy();
+		} );
+	} );
+} );


### PR DESCRIPTION
Fixes BBOX-310

Load the Blackbox client in `PasswordlessSignupForm` behind a new `blackbox-signup` feature flag: render the challenge container, block submit while the SDK initializes, and attach `blackbox_session_id` to the `/users/new` request.

The standalone path (no flow name, parent-owned submit — Jetpack Connect signup and logged-out invite accept) hands the session ID off through the `submitForm` payload. `handlePasswordlessSubmit` now forwards an `afterSubmit` callback so those parents can report the request outcome; on failure the form resets Blackbox so a retry gets a fresh, verifiable session.

**Depends on server-side changes 232387-ghe-Automattic/wpcom.** Also, note the protection is disabled for `production.json` right now via the feature flag.