### PR TITLE
Omnibar: derive site icon from backend instead of initial letter

### DIFF
--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -6,9 +6,7 @@ import {
 } from '@automattic/api-queries';
 import { AdminBarNode, Omnibar, buildOmnibarNodesFromAdminBarNodes } from '@automattic/omnibar';
 import { useQuery } from '@tanstack/react-query';
-import { useViewportMatch } from '@wordpress/compose';
 import { useEffect, useMemo, useState } from 'react';
-import SiteIcon from '../../components/site-icon';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { useAppContext } from '../context';
 import { omnibarEvents } from './events';
@@ -58,9 +56,6 @@ export default function OmnibarContainer( { user }: { user?: User } ) {
 		enabled: hydrated && !! siteId,
 	} );
 
-	const isDesktop = useViewportMatch( 'medium' );
-	const siteIconSize = isDesktop ? 20 : 28;
-
 	const baseOmnibarNodes = useMemo( () => {
 		const nodes = siteNodes ?? dashboardNodes ?? [];
 		const result = buildOmnibarNodesFromAdminBarNodes( removeUnsupportedNodes( nodes, supports ) );
@@ -75,16 +70,16 @@ export default function OmnibarContainer( { user }: { user?: User } ) {
 			if ( ! result.site ) {
 				result.site = {
 					id: 'site-name',
+					icon: <span className="omnibar__site-icon" />,
 					children: [],
 				};
 			}
 
-			result.site.icon = <SiteIcon site={ site } size={ siteIconSize } />;
 			result.site.title = getSiteDisplayName( site );
 		}
 
 		return result;
-	}, [ dashboardNodes, siteNodes, site, siteIconSize, supports ] );
+	}, [ dashboardNodes, siteNodes, site, supports ] );
 
 	const helpCenterPluginNode = useHelpCenterPlugin();
 	const notificationsPluginNode = useNotificationsPlugin( { user } );

--- a/client/dashboard/app/omnibar/style.scss
+++ b/client/dashboard/app/omnibar/style.scss
@@ -1,17 +1,6 @@
-@import '@wordpress/base-styles/variables';
-
 #wpcom-omnibar {
 	position: fixed;
 	top: 0;
 	inset-inline: 0;
 	z-index: 999;
-}
-
-.omnibar .site-icon,
-.omnibar .site-letter {
-	border-radius: $radius-medium;
-
-	@media ( min-width: 782px ) {
-		border-radius: $radius-small;
-	}
 }

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -28,6 +28,7 @@ import {
 	sitePlansQuery,
 	siteBySlugQuery,
 	siteByIdQuery,
+	siteAdminBarQuery,
 	siteAdminMenuQuery,
 	siteCrontabsQuery,
 	sitePreviewLinksQuery,
@@ -180,8 +181,8 @@ export const siteRoute = createRoute( {
 			? site.options?.wpcom_production_blog_id
 			: site.options?.wpcom_staging_blog_ids?.[ 0 ];
 
-		// Warm the omnibar admin menu without gating the route transition.
 		queryClient.prefetchQuery( siteAdminMenuQuery( site.ID ) );
+		queryClient.prefetchQuery( siteAdminBarQuery( site.ID ) );
 
 		await Promise.all( [
 			otherEnvironmentSiteId &&

--- a/packages/omnibar/src/components/omnibar.scss
+++ b/packages/omnibar/src/components/omnibar.scss
@@ -95,6 +95,20 @@ body:has( .omnibar ) {
 		@media ( min-width: 782px ) {
 			min-width: 0;
 		}
+
+		.omnibar__site-icon {
+			display: block;
+			width: 28px;
+			height: 28px;
+			border-radius: 4px;
+			object-fit: cover;
+
+			@media ( min-width: 782px ) {
+				width: 20px;
+				height: 20px;
+				border-radius: 2px;
+			}
+		}
 	}
 
 	.omnibar__responsive-menu {
@@ -167,6 +181,16 @@ body:has( .omnibar ) {
 			font-size: 20px;
 			text-align: initial;
 		}
+	}
+}
+
+.omnibar .dashicons-admin-home::before {
+	height: 32px;
+	font-size: 32px;
+
+	@media ( min-width: 782px ) {
+		height: 20px;
+		font-size: 20px;
 	}
 }
 

--- a/packages/omnibar/src/utils/admin-bar.tsx
+++ b/packages/omnibar/src/utils/admin-bar.tsx
@@ -19,9 +19,23 @@ export function buildOmnibarNodesFromAdminBarNodes( adminBarNodes: AdminBarNode[
 				omnibarNodes.home = omnibarNode;
 				omnibarNodes.home.title = undefined;
 				break;
-			case 'site-name':
+			case 'site-name': {
+				const doc = new DOMParser().parseFromString( node.title || '', 'text/html' );
+				const siteIcon = doc.querySelector( 'img' );
+				const siteIconSrc = siteIcon?.getAttribute( 'src' );
+				omnibarNode.icon = siteIconSrc ? (
+					<img
+						className="omnibar__site-icon"
+						src={ siteIconSrc }
+						srcSet={ siteIcon?.getAttribute( 'srcset' ) || '' }
+						alt={ siteIcon?.getAttribute( 'alt' ) || '' }
+					/>
+				) : (
+					<span className="dashicons-before dashicons-admin-home" />
+				);
 				omnibarNodes.site = omnibarNode;
 				break;
+			}
 			case 'new-content': {
 				omnibarNode.icon = <span className="dashicons-before dashicons-plus" />;
 				siteActionNodes.push( omnibarNode );


### PR DESCRIPTION
## Proposed Changes

Previously, the omnibar shows site letter initials if the site does not have site icon. Now, it shows the old house dashicon instead. This works by avoiding `<SiteIcon>` and parse the image from the backend `admin-bar` endpoint instead.

Also, this PR prefetches the admin-bar endpoint in the site route loader.


Before
<img width="325" height="33" alt="image" src="https://github.com/user-attachments/assets/961717f2-4584-40b5-ab6d-f0254bf467d7" />


After
<img width="325" height="33" alt="image" src="https://github.com/user-attachments/assets/d786c42e-f929-4214-a5e5-6108df345bd9" />

## Why are these changes being made?

We want to match React omnibar with PHP admin bar behavior.

## Testing Instructions

Test with `dashboard/omnibar-radical` flag turned on.

Test the following matrix; verify it matches 100% pixel-perfect with wp-admin

1. Site with and without site icon
2. Desktop vs mobile resolutions