### PR TITLE
Omnibar: remove focus outline

### DIFF
--- a/packages/omnibar/src/components/omnibar.scss
+++ b/packages/omnibar/src/components/omnibar.scss
@@ -63,6 +63,10 @@ body:has( .omnibar ) {
 			outline: none;
 		}
 
+		&:focus {
+			outline: none;
+		}
+
 		&:focus-visible {
 			box-shadow: inset 0 0 0 2px $omnibar-highlight-color;
 			outline-offset: -2px;


### PR DESCRIPTION
## Proposed Changes

This PR hides the focus outline from omnibar nodes, which currently look bad as it overflows the bar.

<img width="164" height="53" alt="image" src="https://github.com/user-attachments/assets/55fe8b84-25c9-4f11-9b26-752136aee78b" />

## Testing Instructions

Test with `dashboard/omnibar-radical` flag turned on.

1. Click the command palette.
2. Click outside the modal to dismiss the modal.
3. Verify you no longer see the broken focus outline.