### PR TITLE
Agents Manager: align the context-cards margin with the conversation layout

### DIFF
--- a/packages/agents-manager/src/components/context-cards/style.scss
+++ b/packages/agents-manager/src/components/context-cards/style.scss
@@ -3,7 +3,7 @@ $context-card-leave-duration: 220ms;
 $context-card-leave-easing: cubic-bezier(0.4, 0, 0.2, 1);
 
 .agents-manager-context-cards {
-	margin: 12px 16px 4px;
+	margin: 4px 0 16px;
 }
 
 .agents-manager-context-card-wrapper {


### PR DESCRIPTION
One-line fix for a stale margin, tracked in [WOOAI-818](https://linear.app/a8c/issue/WOOAI-818/agents-manager-calypso-fix-context-cards-margin-then-drop-woo-ais).

## Why

`.agents-manager-context-cards` ships `margin: 12px 16px 4px`, which predates the current conversation layout — the container already sits inside the padded column, so the extra 16px sides render context cards narrower than the composer with a visible right gutter. `4px 0 16px` lets the cards span the composer's width, matching the rest of the conversation rhythm.

Evidence this is the right value: the Woo AI plugin has shipped an identical override (`.agents-manager-chat .agents-manager-context-cards`) since late July as a temporary workaround, verified live on its surfaces daily — it gets removed once this deploys (that's WOOAI-818's cleanup step).

## Testing Instructions

Context cards render in all chat presentations, so check the three modes:

**wp-admin (sandbox):** `cd apps/agents-manager && yarn dev --sync`, sandbox `widgets.wp.com`, open a site with an agent provider that emits context cards (e.g. Woo AI on a WooCommerce admin page). Docked (≥1200px) and floating: cards should align flush with the composer's edges, no right gutter.

**Calypso (`yarn start`):** same check on a Calypso surface with context cards; split-screen mode included.

cc @WellyShen @evilluendas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrR3712gF5nmbbomZ82Fs1