### PR TITLE
Try/playground export opfs

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-iframe/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-iframe/index.tsx
@@ -16,11 +16,11 @@ import './style.scss';
 
 export function PlaygroundIframe( {
 	className,
-	playgroundClient,
+	hasPlaygroundClient,
 	setPlaygroundClient,
 }: {
 	className?: string;
-	playgroundClient: PlaygroundClient | null;
+	hasPlaygroundClient: boolean;
 	setPlaygroundClient: ( client: PlaygroundClient ) => void;
 } ) {
 	const siteId = useSelector( getSelectedSiteId ) ?? 0;
@@ -44,7 +44,7 @@ export function PlaygroundIframe( {
 			return;
 		}
 
-		if ( playgroundClient ) {
+		if ( hasPlaygroundClient ) {
 			return;
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-setup/index.tsx
@@ -131,7 +131,7 @@ export const PlaygroundSetupStep: Step< {
 				{ ! hasBlueprint && (
 					<PlaygroundIframe
 						className="playground__onboarding-iframe"
-						playgroundClient={ playgroundClientRef.current }
+						hasPlaygroundClient={ Boolean( playgroundClientRef.current ) }
 						setPlaygroundClient={ startImport }
 					/>
 				) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-setup/index.tsx
@@ -84,6 +84,11 @@ export const PlaygroundSetupStep: Step< {
 			return;
 		}
 
+		const playgroundSlug = query.get( 'playground' );
+		if ( ! playgroundSlug ) {
+			return;
+		}
+
 		// When launched from the Playground publish flow (entrepreneur) there is no
 		// surrounding Redux importer machinery to handle the start trigger and
 		// polling — so importPlaygroundSite must block until the import completes.
@@ -94,7 +99,7 @@ export const PlaygroundSetupStep: Step< {
 			const importStartedAt = Date.now();
 			recordTracksEvent( 'calypso_playground_woo_import_started', { site_id: siteId } );
 			try {
-				await importPlaygroundSite( client, siteId, { waitForCompletion: true } );
+				await importPlaygroundSite( playgroundSlug, siteId, { waitForCompletion: true } );
 				recordTracksEvent( 'calypso_playground_woo_import_succeeded', {
 					site_id: siteId,
 					duration_seconds: Math.round( ( Date.now() - importStartedAt ) / 1000 ),
@@ -108,7 +113,7 @@ export const PlaygroundSetupStep: Step< {
 				throw error;
 			}
 		} else {
-			await importPlaygroundSite( client, siteId, { waitForCompletion: false } );
+			await importPlaygroundSite( playgroundSlug, siteId, { waitForCompletion: false } );
 		}
 
 		submit( {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/index.tsx
@@ -91,7 +91,7 @@ export const PlaygroundStep: StepType = ( { navigation, flow } ) => {
 			>
 				<PlaygroundIframe
 					className="playground__onboarding-iframe"
-					playgroundClient={ playgroundClientRef.current }
+					hasPlaygroundClient={ Boolean( playgroundClientRef.current ) }
 					setPlaygroundClient={ setPlaygroundClient }
 				/>
 			</Step.PlaygroundLayout>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/import-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/import-playground.ts
@@ -9,6 +9,7 @@ const POLL_INTERVAL_MS = 5000;
 // 120 attempts × 5 s = 10 min. Atomic restores typically finish in 2–4 min;
 // 10 min covers worst-case load spikes without leaving users stuck indefinitely.
 const MAX_POLL_ATTEMPTS = 120;
+const EXPORT_DEBUG_OPFS_DIRECTORY = 'playground-exports';
 const EXPORT_EXCLUDE_PATTERNS = [
 	'/*',
 	'!/wp-content/',
@@ -53,7 +54,22 @@ export async function getSiteZip( playgroundSlug: string ) {
 			throw new Error( `No exportable saved Playground found for ${ playgroundSlug }.` );
 		}
 
-		return new File( [ zipBlob ], 'site.zip', { type: 'application/zip' } );
+		const siteZip = new File( [ zipBlob ], 'site.zip', { type: 'application/zip' } );
+		const opfsRoot = await navigator.storage.getDirectory();
+		const exportDirectory = await opfsRoot.getDirectoryHandle( EXPORT_DEBUG_OPFS_DIRECTORY, {
+			create: true,
+		} );
+		const exportFileName = `${ encodeURIComponent( playgroundSlug ) }.zip`;
+		const exportFile = await exportDirectory.getFileHandle( exportFileName, { create: true } );
+		const writable = await exportFile.createWritable();
+
+		await writable.write( siteZip );
+		await writable.close();
+		window.console.log(
+			`Playground export saved to OPFS at /${ EXPORT_DEBUG_OPFS_DIRECTORY }/${ exportFileName }`
+		);
+
+		return siteZip;
 	} finally {
 		apiIframe.remove();
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/import-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/import-playground.ts
@@ -9,6 +9,13 @@ const POLL_INTERVAL_MS = 5000;
 // 120 attempts × 5 s = 10 min. Atomic restores typically finish in 2–4 min;
 // 10 min covers worst-case load spikes without leaving users stuck indefinitely.
 const MAX_POLL_ATTEMPTS = 120;
+const EXPORT_EXCLUDE_PATTERNS = [
+	'/*',
+	'!/wp-content/',
+	'!/wp-content/**',
+	'/wp-content/db.php',
+	'/wp-content/mu-plugins/',
+];
 
 export class ImportTimeoutError extends Error {
 	constructor() {
@@ -24,21 +31,37 @@ export class ImportFailureError extends Error {
 	}
 }
 
-export async function getSiteZip( playground: PlaygroundClient ) {
-	const { zipWpContent } = await import(
-		/* webpackIgnore: true */ PLAYGROUND_HOST + '/client/index.js'
-	);
-	const zipBytes = await zipWpContent( playground, {
-		selfContained: true,
-	} );
+export async function getSiteZip( playgroundSlug: string ) {
+	const apiIframe = document.createElement( 'iframe' );
+	apiIframe.hidden = true;
+	apiIframe.setAttribute( 'sandbox', 'allow-scripts allow-same-origin' );
+	document.body.appendChild( apiIframe );
 
-	return new File( [ zipBytes ], 'site.zip', { type: 'application/zip' } );
+	try {
+		const { startPlaygroundAPI } = await import(
+			/* webpackIgnore: true */ PLAYGROUND_HOST + '/client/index.js'
+		);
+		const playgroundAPI = await startPlaygroundAPI( {
+			iframe: apiIframe,
+			apiUrl: PLAYGROUND_HOST + '/api.html',
+		} );
+		const zipBlob = await playgroundAPI.exportSavedSiteAsZip( playgroundSlug, {
+			excludePatterns: EXPORT_EXCLUDE_PATTERNS,
+		} );
+
+		if ( ! zipBlob ) {
+			throw new Error( `No exportable saved Playground found for ${ playgroundSlug }.` );
+		}
+
+		return new File( [ zipBlob ], 'site.zip', { type: 'application/zip' } );
+	} finally {
+		apiIframe.remove();
+	}
 }
 
 export async function removeSandboxPlugins( playground: PlaygroundClient ): Promise< void > {
 	// Haydi and wccom-ai-connector are sandbox-only tools — remove them from the
-	// in-memory filesystem before exporting so they don't land on the live site.
-	// The OPFS is read-only at this point (opfs-to-memfs boot) so this is safe.
+	// mounted filesystem before exporting so they don't land on the live site.
 	await playground.run( {
 		code: `<?php
 require_once '/wordpress/wp-load.php';
@@ -80,11 +103,11 @@ foreach ( $plugins as $slug ) {
  * to importerWordpress afterwards — that step's Redux monitoring handles it.
  */
 export async function importPlaygroundSite(
-	playground: PlaygroundClient,
+	playgroundSlug: string,
 	siteId: number,
 	{ waitForCompletion = false }: { waitForCompletion?: boolean } = {}
 ): Promise< string | undefined > {
-	const siteZip = await getSiteZip( playground );
+	const siteZip = await getSiteZip( playgroundSlug );
 
 	const importer = await uploadExportFile( siteId, {
 		importStatus: { importStatus: 'importer-ready-for-upload', siteId, type: 'wordpress' },

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
@@ -4,8 +4,6 @@ import { getBlueprint } from './blueprint';
 import { PLAYGROUND_HOST } from './constants';
 import type { Blueprint, BlueprintV1, MountDescriptor, PlaygroundClient } from './types';
 
-const OPFS_PATH_PREFIX = '/wpcom-onboarding';
-
 export async function initializeWordPressPlayground(
 	iframe: HTMLIFrameElement,
 	recommendedPhpVersion: string,
@@ -27,29 +25,57 @@ export async function initializeWordPressPlayground(
 	}
 
 	try {
+		// The Calypso Playground ID is also the saved-site slug used by the export API.
+		const playgroundSlug = playgroundId;
 		const mountDescriptor: MountDescriptor = {
 			device: {
 				type: 'opfs',
-				path: `${ OPFS_PATH_PREFIX }/${ playgroundId }/`,
+				path: `/sites/site-${ encodeURIComponent( playgroundSlug ) }`,
 			},
 			mountpoint: '/wordpress',
 			initialSyncDirection: isWordPressInstalled ? 'opfs-to-memfs' : 'memfs-to-opfs',
 		};
 
 		const blueprint = await getBlueprint( isWordPressInstalled, recommendedPhpVersion );
-		const { startPlaygroundWeb } = await import(
+		const { getBlueprintDeclaration, startPlaygroundWeb } = await import(
 			/* webpackIgnore: true */ PLAYGROUND_HOST + '/client/index.js'
 		);
 		onPlaygroundClientLoaded?.();
 		const client = await startPlaygroundWeb( {
 			iframe,
 			remoteUrl: PLAYGROUND_HOST + '/remote.html',
+			scope: playgroundSlug,
 			blueprint: blueprint as BlueprintV1,
 			shouldInstallWordPress: ! isWordPressInstalled,
 			mounts: isWordPressInstalled ? [ mountDescriptor ] : [],
 		} );
 
 		if ( ! isWordPressInstalled ) {
+			const blueprintDeclaration = await getBlueprintDeclaration( blueprint );
+			await client.writeFile(
+				'/wordpress/wp-runtime.json',
+				JSON.stringify(
+					{
+						id: playgroundSlug,
+						name: 'WordPress.com Playground',
+						originalBlueprint: blueprintDeclaration,
+						originalBlueprintSource: { type: 'none' },
+						persistence: 'explicit',
+						runtimeConfiguration: {
+							constants: blueprintDeclaration.constants ?? {},
+							extraLibraries: blueprintDeclaration.extraLibraries ?? [],
+							intl: blueprintDeclaration.features?.intl ?? false,
+							networking: blueprintDeclaration.features?.networking ?? true,
+							phpVersion: blueprintDeclaration.preferredVersions?.php ?? recommendedPhpVersion,
+							wpVersion: blueprintDeclaration.preferredVersions?.wp ?? 'latest',
+						},
+						slug: playgroundSlug,
+						storage: 'opfs',
+					},
+					null,
+					2
+				)
+			);
 			await client.mountOpfs( mountDescriptor );
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/types.ts
@@ -79,4 +79,5 @@ export interface PlaygroundClient {
 	isReady(): Promise< void >;
 	run( options: { code: string } ): Promise< { text: string } >;
 	mountOpfs( options: MountDescriptor ): Promise< void >;
+	writeFile( path: string, data: string | Uint8Array ): Promise< void >;
 }


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
