### PR TITLE
SEO: handle non-array title formats

### DIFF
--- a/client/components/seo/meta-title-editor/mappings.js
+++ b/client/components/seo/meta-title-editor/mappings.js
@@ -50,7 +50,7 @@ const mergeStringPieces = ( a, b ) => ( {
  * @returns {Array} List of native format pieces
  */
 export const rawToNative = ( list ) =>
-	list.map( ( p ) =>
+	( Array.isArray( list ) ? list : [] ).map( ( p ) =>
 		'string' === p.type ? { type: 'string', value: p.value } : { type: camelCase( p.value ) }
 	);
 
@@ -74,7 +74,7 @@ export const nativeToRaw = compose(
 			return [ ...format, piece ];
 		}, [] ),
 	( list ) =>
-		list.map( ( p ) => ( {
+		( Array.isArray( list ) ? list : [] ).map( ( p ) => ( {
 			type: p.type === 'string' ? 'string' : 'token',
 			value: p?.value ?? snakeCase( p.type ),
 		} ) )

--- a/client/components/seo/meta-title-editor/test/index.js
+++ b/client/components/seo/meta-title-editor/test/index.js
@@ -63,6 +63,13 @@ describe( 'SEO', () => {
 				expect( fromApi( {} ) ).toEqual( {} );
 			} );
 
+			test( 'should handle non-array formats', () => {
+				expect( fromApi( { front_page: null, posts: '' } ) ).toEqual( {
+					frontPage: [],
+					posts: [],
+				} );
+			} );
+
 			test( 'should remap keys and values', () => {
 				expect(
 					fromApi( {
@@ -86,6 +93,13 @@ describe( 'SEO', () => {
 		describe( '#toApi', () => {
 			test( 'should produce empty formats', () => {
 				expect( toApi( {} ) ).toEqual( {} );
+			} );
+
+			test( 'should handle non-array formats', () => {
+				expect( toApi( { frontPage: null, posts: '' } ) ).toEqual( {
+					front_page: [],
+					posts: [],
+				} );
 			} );
 
 			test( 'should remap keys and values', () => {


### PR DESCRIPTION
Fixes DOTCOM-17944

## Proposed Changes

- Treat non-array SEO title format values as empty formats in both API mapping directions.
- Add regression coverage for `null` and empty-string format values.

## Why are these changes being made?

The native `Array.prototype.map` migration in #112102 changed the previous Lodash behavior for malformed or empty format values. The API can expose `null` or an empty-string clear sentinel, so the SEO settings mapper throws before the Marketing > Traffic page can render.

This restores the mapper's previous empty-format fallback while preserving valid array behavior.

## Testing Instructions

1. Run `yarn test-client client/components/seo/meta-title-editor/test/index.js --runInBand`.
2. Confirm all 12 tests pass, including the non-array format cases.
3. On a controlled Simple site with Advanced SEO enabled and uninitialized title formats, open Marketing > Traffic.
4. Confirm the page renders instead of displaying a white screen and the console does not report `.map is not a function`.

Local verification completed with Node 24.15.0:

- `yarn test-client client/components/seo/meta-title-editor/test/index.js --runInBand`
- `yarn eslint client/components/seo/meta-title-editor/mappings.js client/components/seo/meta-title-editor/test/index.js`
- `yarn prettier --ignore-path .eslintignore --check client/components/seo/meta-title-editor/mappings.js client/components/seo/meta-title-editor/test/index.js`
- `yarn typecheck-client`

The new regression tests failed against `trunk` with `Cannot read properties of null (reading 'map')` and pass with this change.

Manual smoke test on a controlled Simple Premium site:

- Production control rendered Marketing > Traffic, so the original failure was not reproducible with this site's current title-format data.
- Calypso Live build `191840` rendered Marketing > Traffic successfully.
- Neither console showed `.map is not a function`; observed warnings were unrelated CSP and service-worker messages.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g. browsers), interfaces (e.g. keyboard navigation), and assistive technologies (e.g. screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?