### PR TITLE
composite-checkout: Prevent submit completing step if out of view

### DIFF
--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -43,6 +43,8 @@ import type { ReactNode, HTMLAttributes, PropsWithChildren, ReactElement } from 
 const debug = debugFactory( 'composite-checkout:checkout-steps' );
 
 const customPropertyForSubmitButtonHeight = '--submit-button-height';
+const submitButtonWrapperClassName = 'checkout-steps__submit-button-wrapper';
+const stepContentClassName = 'checkout-steps__step-content';
 
 interface CheckoutSingleStepDataContext {
 	stepNumber: number;
@@ -67,6 +69,7 @@ const CheckoutStepGroupContext = createContext< CheckoutStepGroupStore >( {
 		stepCompleteCallbackMap: {},
 		stepSkipValidationOnSubmitMap: {},
 		suppressNextForwardScroll: false,
+		hasUserInteractedWithSteps: false,
 	},
 	actions: {
 		makeStepActive: noop,
@@ -79,6 +82,7 @@ const CheckoutStepGroupContext = createContext< CheckoutStepGroupStore >( {
 		getStepNumberFromId: noop,
 		setTotalSteps: noop,
 		setSuppressNextForwardScroll: noop,
+		setHasUserInteractedWithSteps: noop,
 	},
 	subscription: new SubscriptionManager(),
 } );
@@ -103,6 +107,7 @@ function createCheckoutStepGroupState(): CheckoutStepGroupState {
 		stepCompleteCallbackMap: {},
 		stepSkipValidationOnSubmitMap: {},
 		suppressNextForwardScroll: false,
+		hasUserInteractedWithSteps: false,
 	};
 }
 
@@ -265,6 +270,12 @@ function createCheckoutStepGroupActions(
 		state.suppressNextForwardScroll = value;
 	};
 
+	// Records that the shopper has touched the step content at least once. Read
+	// synchronously at click time, so it deliberately does not notify subscribers.
+	const setHasUserInteractedWithSteps = ( value: boolean ) => {
+		state.hasUserInteractedWithSteps = value;
+	};
+
 	return {
 		setActiveStepNumber,
 		setStepCompleteStatus,
@@ -276,6 +287,7 @@ function createCheckoutStepGroupActions(
 		completeAllSteps,
 		makeStepActive,
 		setSuppressNextForwardScroll,
+		setHasUserInteractedWithSteps,
 	};
 }
 
@@ -332,6 +344,76 @@ export const CheckoutSummaryArea = ( {
 		</CheckoutSummary>
 	);
 };
+
+/**
+ * True when the shopper can actually see some part of the element right now.
+ *
+ * Overlapping the viewport is not enough on its own: a checkout step is often
+ * taller than a phone screen, so its rect nearly always overlaps, and the sticky
+ * summary pinned to the bottom of the screen can be covering every pixel of it
+ * that is on-screen. So once the rect says "on-screen", hit-test points down the
+ * element's visible height to see whether anything is painted over it.
+ *
+ * Elements that are missing or have no layout box at all (so there is nothing to
+ * scroll to) count as visible, and so does the case where the environment has no
+ * hit-testing, so that callers fall back to their normal behavior.
+ */
+function isElementVisibleInViewport( el: HTMLElement | null ): boolean {
+	if ( ! el ) {
+		return true;
+	}
+	const rect = el.getBoundingClientRect();
+	if ( rect.width === 0 && rect.height === 0 ) {
+		return true;
+	}
+	const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+	const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
+	const top = Math.max( rect.top, 0 );
+	const bottom = Math.min( rect.bottom, viewportHeight );
+	const left = Math.max( rect.left, 0 );
+	const right = Math.min( rect.right, viewportWidth );
+	if ( bottom <= top || right <= left ) {
+		return false;
+	}
+	if ( typeof document.elementFromPoint !== 'function' ) {
+		return true;
+	}
+	const x = Math.min( ( left + right ) / 2, viewportWidth - 1 );
+	const sampleCount = 8;
+	for ( let sample = 0; sample <= sampleCount; sample++ ) {
+		const y = Math.min( top + ( ( bottom - top ) * sample ) / sampleCount, viewportHeight - 1 );
+		const topmostElement = document.elementFromPoint( x, y );
+		if ( topmostElement && el.contains( topmostElement ) ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * The first form control the shopper would fill in for a step (e.g. the country
+ * dropdown on the contact step), or null when the step has none.
+ *
+ * A checkout step is often taller than a phone screen, so "part of the step is
+ * visible" can be true while the shopper sees only its heading. Where the step
+ * has fields, whether the first of them is visible is the better question.
+ * Controls with no layout box are skipped: they are hidden, so seeing them tells
+ * the shopper nothing.
+ */
+function getFirstFormFieldInStep( stepEl: HTMLElement ): HTMLElement | null {
+	// Steps render their active and complete content at the same time, so restrict
+	// this to the active content and fall back to the step for stepless layouts.
+	const activeContent = stepEl.querySelector( `.${ stepContentClassName }` ) ?? stepEl;
+	const fields = Array.from(
+		activeContent.querySelectorAll< HTMLElement >( 'input:not([type="hidden"]), select, textarea' )
+	);
+	return (
+		fields.find( ( field ) => {
+			const rect = field.getBoundingClientRect();
+			return rect.width > 0 || rect.height > 0;
+		} ) ?? null
+	);
+}
 
 function isElementAStep( el: ReactNode ): boolean {
 	const childStep = el as { type?: { isCheckoutStep?: boolean } };
@@ -680,9 +762,34 @@ function CheckoutStepArea( {
 }: PropsWithChildren< {
 	className?: string;
 } > ) {
-	const { state } = useContext( CheckoutStepGroupContext );
+	const { state, actions } = useContext( CheckoutStepGroupContext );
 	const { activeStepNumber, totalSteps } = state;
+	const { setHasUserInteractedWithSteps } = actions;
 	const isThereAnotherNumberedStep = activeStepNumber < totalSteps;
+
+	// Native (not React) listeners on purpose: a submit button rendered into this
+	// group but portaled elsewhere in the DOM would still bubble its React events
+	// through here, and pressing that button is not "interacting with the steps".
+	// The submit area is excluded for the same reason when it is not portaled.
+	const stepAreaRef = useRef< HTMLDivElement >( null );
+	useEffect( () => {
+		const stepArea = stepAreaRef.current;
+		if ( ! stepArea ) {
+			return;
+		}
+		const onInteract = ( event: Event ) => {
+			const target = event.target as HTMLElement | null;
+			if ( target?.closest?.( `.${ submitButtonWrapperClassName }` ) ) {
+				return;
+			}
+			setHasUserInteractedWithSteps( true );
+		};
+		const events = [ 'pointerdown', 'keydown', 'change' ] as const;
+		events.forEach( ( event ) => stepArea.addEventListener( event, onInteract ) );
+		return () => {
+			events.forEach( ( event ) => stepArea.removeEventListener( event, onInteract ) );
+		};
+	}, [ setHasUserInteractedWithSteps ] );
 
 	const classNames = joinClasses( [
 		'checkout__step-wrapper',
@@ -690,7 +797,11 @@ function CheckoutStepArea( {
 		...( ! isThereAnotherNumberedStep ? [ 'checkout__step-wrapper--last-step' ] : [] ),
 	] );
 
-	return <CheckoutStepAreaWrapper className={ classNames }>{ children }</CheckoutStepAreaWrapper>;
+	return (
+		<CheckoutStepAreaWrapper className={ classNames } ref={ stepAreaRef }>
+			{ children }
+		</CheckoutStepAreaWrapper>
+	);
 }
 
 export function CheckoutFormSubmit( {
@@ -787,7 +898,6 @@ export function CheckoutFormSubmit( {
 	}, [
 		activeStepNumber,
 		totalSteps,
-		stepCompleteStatus,
 		stepSkipValidationOnSubmitMap,
 		getStepCompleteCallback,
 		setStepCompleteStatus,
@@ -850,6 +960,29 @@ export function CheckoutFormSubmit( {
 		if ( ! targetStepId ) {
 			return;
 		}
+		// When the step needing the shopper's attention is not visible — off-screen,
+		// or hidden behind the sticky summary — this press only reveals that step.
+		// Validating it here would flag errors on fields they have not yet seen.
+		// Once the step is on-screen the button submits as usual. Visibility is
+		// judged by the step's first form field where it has one, since a step
+		// taller than the screen can have its heading showing and every field
+		// covered.
+		//
+		// Anyone who has already touched the steps is exempt: on a step taller than
+		// the screen, working down the form scrolls that first field off the top, and
+		// they should get a real submit rather than being thrown back to the heading.
+		const targetStepEl = document.getElementById( targetStepId );
+		if (
+			targetStepEl &&
+			stepIdMap[ targetStepId ] === activeStepNumber &&
+			! state.hasUserInteractedWithSteps
+		) {
+			const elementToReveal = getFirstFormFieldInStep( targetStepEl ) ?? targetStepEl;
+			if ( ! isElementVisibleInViewport( elementToReveal ) ) {
+				targetStepEl.scrollIntoView?.( { behavior: 'smooth', block: 'start' } );
+				return;
+			}
+		}
 		if ( stepIdMap[ targetStepId ] === activeStepNumber ) {
 			// The active step is itself the step that still needs completing.
 			// makeStepActive would be a no-op here because it only runs completion
@@ -875,7 +1008,7 @@ export function CheckoutFormSubmit( {
 	};
 
 	return (
-		<SubmitButtonWrapper className="checkout-steps__submit-button-wrapper" ref={ submitWrapperRef }>
+		<SubmitButtonWrapper className={ submitButtonWrapperClassName } ref={ submitWrapperRef }>
 			{ submitButtonHeader || null }
 			{ showContinueToNextIncompleteStep ? (
 				<Button
@@ -1011,7 +1144,7 @@ export function CheckoutStepBody( {
 				<StepContentWrapper
 					data-testid={ activeStepTestId }
 					isVisible={ isStepActive }
-					className="checkout-steps__step-content"
+					className={ stepContentClassName }
 				>
 					{ activeStepContent }
 					{ goToNextStep && isStepActive && (

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -295,6 +295,7 @@ export interface CheckoutStepGroupState {
 	stepCompleteCallbackMap: StepCompleteCallbackMap;
 	stepSkipValidationOnSubmitMap: Record< number, boolean >;
 	suppressNextForwardScroll: boolean;
+	hasUserInteractedWithSteps: boolean;
 }
 
 export interface CheckoutStepGroupActions {
@@ -313,6 +314,7 @@ export interface CheckoutStepGroupActions {
 	getStepCompleteCallback: ( stepNumber: number ) => StepCompleteCallback;
 	setTotalSteps: ( totalSteps: number ) => void;
 	setSuppressNextForwardScroll: ( value: boolean ) => void;
+	setHasUserInteractedWithSteps: ( value: boolean ) => void;
 }
 
 export type TogglePaymentMethod = ( paymentMethodId: string, available: boolean ) => void;

--- a/packages/composite-checkout/test/checkout.tsx
+++ b/packages/composite-checkout/test/checkout.tsx
@@ -885,6 +885,39 @@ describe( 'Checkout', () => {
 		const getSubmitArea = ( container ) =>
 			container.querySelector( '.checkout-steps__submit-button-wrapper' );
 
+		// jsdom has no layout, so every element reports a 0x0 rect, which counts as
+		// visible (there is nothing to scroll to). Tests that care about position say
+		// where the elements they are about live. `top` is viewport-relative, so a
+		// value >= window.innerHeight puts the element off-screen.
+		const byId = ( id ) => ( el ) => el.id === id;
+		const byTagName = ( tagName ) => ( el ) => el.tagName === tagName;
+		const positionElements = ( positions ) => {
+			const original = window.HTMLElement.prototype.getBoundingClientRect;
+			jest
+				.spyOn( window.HTMLElement.prototype, 'getBoundingClientRect' )
+				.mockImplementation( function () {
+					const position = positions.find( ( [ matches ] ) => matches( this ) );
+					if ( ! position ) {
+						return original.call( this );
+					}
+					const top = position[ 1 ];
+					return { top, bottom: top + 400, left: 0, right: 400, width: 400, height: 400 };
+				} );
+		};
+		const putStepAt = ( stepId, top ) => positionElements( [ [ byId( stepId ), top ] ] );
+
+		// jsdom has no layout, so it has no hit-testing either; the production code
+		// falls back to the rect alone without it. Tests that need to simulate the
+		// sticky summary covering an on-screen step provide it.
+		const putElementOverEverything = ( element ) => {
+			document.elementFromPoint = jest.fn( () => element );
+		};
+
+		afterEach( () => {
+			jest.restoreAllMocks();
+			delete ( document as unknown as { elementFromPoint?: unknown } ).elementFromPoint;
+		} );
+
 		it( 'renders an enabled Continue button instead of a disabled submit button when a later step exists', () => {
 			const { container } = render(
 				<ContinueCheckout withProp steps={ [ steps[ 0 ], steps[ 1 ], steps[ 3 ] ] } />
@@ -945,6 +978,156 @@ describe( 'Checkout', () => {
 				expect( ( scrollIntoView.mock.instances[ 0 ] as HTMLElement ).id ).toBe(
 					'custom-incomplete-step'
 				);
+			} );
+		} );
+
+		it( 'only scrolls the active step into view when it is entirely off-screen', async () => {
+			const scrollIntoView = jest.fn();
+			window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+			const isCompleteCallback = jest.fn( () => false );
+			const invalidActiveStep = { ...steps[ 3 ], isCompleteCallback };
+			putStepAt( 'custom-incomplete-step', window.innerHeight + 100 );
+			const { container } = render(
+				<ContinueCheckout withProp steps={ [ steps[ 0 ], invalidActiveStep, steps[ 1 ] ] } />
+			);
+			const submitArea = getSubmitArea( container );
+			const user = userEvent.setup();
+			await user.click( getByTextInNode( submitArea, 'Continue' ) );
+
+			await waitFor( () => {
+				expect( ( scrollIntoView.mock.instances[ 0 ] as HTMLElement ).id ).toBe(
+					'custom-incomplete-step'
+				);
+			} );
+			// The shopper has not seen the step yet, so it must not be validated: that
+			// would show errors for fields they have had no chance to fill in.
+			expect( isCompleteCallback ).not.toHaveBeenCalled();
+		} );
+
+		it( 'only scrolls the active step into view when something is covering it', async () => {
+			const scrollIntoView = jest.fn();
+			window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+			const isCompleteCallback = jest.fn( () => false );
+			const invalidActiveStep = { ...steps[ 3 ], isCompleteCallback };
+			// On-screen by its rect, but taller than the viewport, which is the normal
+			// case for a checkout step on a phone.
+			putStepAt( 'custom-incomplete-step', 100 );
+			const { container } = render(
+				<ContinueCheckout withProp steps={ [ steps[ 0 ], invalidActiveStep, steps[ 1 ] ] } />
+			);
+			// Every hit-test lands on the sticky summary rather than the step.
+			putElementOverEverything( container );
+			const submitArea = getSubmitArea( container );
+			const user = userEvent.setup();
+			await user.click( getByTextInNode( submitArea, 'Continue' ) );
+
+			await waitFor( () => {
+				expect( ( scrollIntoView.mock.instances[ 0 ] as HTMLElement ).id ).toBe(
+					'custom-incomplete-step'
+				);
+			} );
+			expect( isCompleteCallback ).not.toHaveBeenCalled();
+		} );
+
+		it( 'only scrolls the active step into view when its first field is off-screen', async () => {
+			const scrollIntoView = jest.fn();
+			window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+			const isCompleteCallback = jest.fn( () => false );
+			const stepWithAField = {
+				...steps[ 3 ],
+				isCompleteCallback,
+				activeStepContent: <input aria-label="Country" />,
+			};
+			// The step itself is on-screen but its first field is not, which is what a
+			// step taller than the phone screen looks like: heading showing, form not.
+			positionElements( [
+				[ byId( 'custom-incomplete-step' ), 100 ],
+				[ byTagName( 'INPUT' ), window.innerHeight + 100 ],
+			] );
+			const { container } = render(
+				<ContinueCheckout withProp steps={ [ steps[ 0 ], stepWithAField, steps[ 1 ] ] } />
+			);
+			const submitArea = getSubmitArea( container );
+			const user = userEvent.setup();
+			await user.click( getByTextInNode( submitArea, 'Continue' ) );
+
+			await waitFor( () => {
+				expect( ( scrollIntoView.mock.instances[ 0 ] as HTMLElement ).id ).toBe(
+					'custom-incomplete-step'
+				);
+			} );
+			expect( isCompleteCallback ).not.toHaveBeenCalled();
+		} );
+
+		it( 'validates the active step with an off-screen first field once the shopper has touched the steps', async () => {
+			const scrollIntoView = jest.fn();
+			window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+			const isCompleteCallback = jest.fn( () => false );
+			const stepWithAField = {
+				...steps[ 3 ],
+				isCompleteCallback,
+				activeStepContent: <input aria-label="Country" />,
+			};
+			// A shopper working down a step taller than the screen: the first field has
+			// scrolled off the top, but they have plainly seen the form.
+			positionElements( [
+				[ byId( 'custom-incomplete-step' ), -300 ],
+				[ byTagName( 'INPUT' ), -500 ],
+			] );
+			const { container, getByLabelText } = render(
+				<ContinueCheckout withProp steps={ [ steps[ 0 ], stepWithAField, steps[ 1 ] ] } />
+			);
+			const submitArea = getSubmitArea( container );
+			const user = userEvent.setup();
+			await user.click( getByLabelText( 'Country' ) );
+			await user.click( getByTextInNode( submitArea, 'Continue' ) );
+
+			await waitFor( () => {
+				expect( isCompleteCallback ).toHaveBeenCalled();
+			} );
+		} );
+
+		it( 'validates the active step when its first field is on-screen', async () => {
+			const scrollIntoView = jest.fn();
+			window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+			const isCompleteCallback = jest.fn( () => false );
+			const stepWithAField = {
+				...steps[ 3 ],
+				isCompleteCallback,
+				activeStepContent: <input aria-label="Country" />,
+			};
+			positionElements( [
+				[ byId( 'custom-incomplete-step' ), 100 ],
+				[ byTagName( 'INPUT' ), 200 ],
+			] );
+			const { container } = render(
+				<ContinueCheckout withProp steps={ [ steps[ 0 ], stepWithAField, steps[ 1 ] ] } />
+			);
+			const submitArea = getSubmitArea( container );
+			const user = userEvent.setup();
+			await user.click( getByTextInNode( submitArea, 'Continue' ) );
+
+			await waitFor( () => {
+				expect( isCompleteCallback ).toHaveBeenCalled();
+			} );
+		} );
+
+		it( 'validates the active step when it is on-screen and nothing is covering it', async () => {
+			const scrollIntoView = jest.fn();
+			window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+			const isCompleteCallback = jest.fn( () => false );
+			const invalidActiveStep = { ...steps[ 3 ], isCompleteCallback };
+			putStepAt( 'custom-incomplete-step', 100 );
+			const { container } = render(
+				<ContinueCheckout withProp steps={ [ steps[ 0 ], invalidActiveStep, steps[ 1 ] ] } />
+			);
+			putElementOverEverything( document.getElementById( 'custom-incomplete-step' ) );
+			const submitArea = getSubmitArea( container );
+			const user = userEvent.setup();
+			await user.click( getByTextInNode( submitArea, 'Continue' ) );
+
+			await waitFor( () => {
+				expect( isCompleteCallback ).toHaveBeenCalled();
 			} );
 		} );
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2344/

## Proposed changes

When checkout's submit button reads "Continue" (when we are not on the last step) and the step it would act on is not actually visible to the shopper, the first press now just scrolls that step into view instead of running validation on it. Pressing it again — once the form is on screen — submits as usual.

After first click             |  After second click
:-------------------------:|:-------------------------:
<img width="281" height="539" alt="Screenshot 2026-08-05 at 11 26 24 AM" src="https://github.com/user-attachments/assets/56f39435-2478-4043-a5d4-719ca975bfb0" /> | <img width="281" height="540" alt="Screenshot 2026-08-05 at 11 26 31 AM" src="https://github.com/user-attachments/assets/1884b207-f8c4-41d1-85a6-d81ad76a5299" />
<img width="911" height="816" alt="Screenshot 2026-08-05 at 11 41 09 AM" src="https://github.com/user-attachments/assets/d00be34b-0472-4358-829d-c4c4703e5711" /> | <img width="910" height="815" alt="Screenshot 2026-08-05 at 11 41 15 AM" src="https://github.com/user-attachments/assets/d690cb06-f056-4980-94be-ab9ab49d426c" />



## Why are these changes being made?

Under the mobile sticky summary experiment (`calypso_mobile_checkout_sticky_summary_v1`) the submit button is portaled into a bar pinned to the bottom of the screen, so it is reachable before the shopper has scrolled to the contact form at all. Pressing it ran the step's completion callback, which failed and painted validation errors across fields they had never seen.

Two details drove the implementation. First, a plain "does the step's rect overlap the viewport" check is close to useless here: a checkout step is routinely taller than a phone screen (measured ~978px in a 915px viewport), so its rect overlaps at almost any scroll position while the sticky summary covers every on-screen pixel of it. Hit-testing with `elementFromPoint` answers the real question — is anything painted over it — without hardcoding knowledge of the summary, and generalises to any future overlay.

Second, measuring the first form field rather than the step introduces a failure mode of its own: a shopper working down a form taller than the screen has scrolled that first field off the *top*, which reads as "not visible" and would throw them back to the step heading mid-task. The interaction latch covers that case. It is one-way and can only ever suppress a reveal, never cause one, and because it listens for `pointerdown`, scrolling the form on a touch device is enough to set it.

## Testing instructions

* Make sure your user has no cached contact details saved. Either use a new user or use Payments Admin on the backend to delete your cached contact details.
* Mobile viewport (or a phone), in a StepContainerV2 flow, possibly with `?mobile_checkout_sticky_summary=1` appended to the checkout URL to force the treatment unless you are already in it. eg: http://calypso.localhost:3000/checkout/unified/value_bundle,domain_reg:adjakjaohfieuahgiurhgrg.com?redirect_to=%2Fsetup%2Fonboarding%2Fpost-checkout-onboarding%3FsiteSlug%example.com&signup=1&flow=onboarding&checkoutBackUrl=https%3A%2F%2Fwordpress.com%2Fsetup%2Fonboarding%2Fplans%3FsiteSlug%example.com&checkoutBackUrlDomains=https%3A%2F%2Fwordpress.com%2Fsetup%2Fonboarding%2Fdomains%3FsiteSlug%3Dexample.com&coupon=&steps_current=3&steps_total=3
* Load checkout and, without scrolling or touching anything, press "Continue" in the sticky summary. Confirm the contact step scrolls to the top of the screen and no validation errors appear.
* Press "Continue" again. Confirm it now validates and shows errors as usual.
* Reload, scroll down to the bottom of the contact form so the country dropdown is off the top of the screen, and press "Continue". Confirm it validates immediately rather than jumping back to the step heading.
* Confirm desktop is unaffected: the sidebar "Continue" button validates on the first press when the step is visible.

