### PR TITLE
Email verification: let a mistyped address be corrected from the gate

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -20,6 +20,7 @@ import { isThrottledError, getThrottledErrorMessage } from 'calypso/lib/signup/i
 import wpcom from 'calypso/lib/wp';
 import ValidationFieldset from 'calypso/signup/validation-fieldset';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { setCurrentUser } from 'calypso/state/current-user/actions';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import SignupSubmitButton from './signup-submit-button';
 
@@ -38,6 +39,9 @@ class PasswordlessSignupForm extends Component {
 		disableTosText: PropTypes.bool,
 		// Names the signup's origin to the backend, which aims the activation link on it.
 		activationEmailFrom: PropTypes.string,
+		// Replaces account creation with a change to the account the caller already has. It reports
+		// its own failures, so nothing update-specific belongs in here.
+		onUpdateEmail: PropTypes.func,
 		useConnectScreenActions: PropTypes.bool,
 	};
 
@@ -73,6 +77,23 @@ class PasswordlessSignupForm extends Component {
 			return;
 		}
 
+		// --- TEMPORARY LOCAL DEV SHORTCUT — remove before merging this PR. ---
+		// `?fake_signup=1` on the onboarding flow skips real account creation and drops
+		// straight onto the email-verification gate with a fake unverified user, so the
+		// gate can be viewed without registering a new account each time. Requires the
+		// `onboarding/email-verification` flag (already on for wpcalypso; locally add
+		// `?flags=onboarding/email-verification`). Resend / re-check won't work against
+		// the fake session — this is only for viewing the screen.
+		if (
+			this.props.flowName === 'onboarding' &&
+			new URLSearchParams( window.location.search ).get( 'fake_signup' )
+		) {
+			this.props.setCurrentUser( { ID: 1, email: this.state.email, email_verified: false } );
+			this.props.onCreateAccountSuccess?.( { ID: 1, email: this.state.email } );
+			return;
+		}
+		// --- end temporary shortcut ---
+
 		// Save form state in a format that is compatible with the standard SignupForm used in the user step.
 		const form = {
 			firstName: '',
@@ -84,6 +105,13 @@ class PasswordlessSignupForm extends Component {
 		const { activationEmailFrom, flowName, queryArgs = {} } = this.props;
 		const devAccountLandingPageRefs = [ 'hosting-lp', 'developer-lp' ];
 		const isDevAccount = devAccountLandingPageRefs.includes( queryArgs.ref );
+
+		if ( this.props.onUpdateEmail ) {
+			this.setState( { isSubmitting: true } );
+			await this.props.onUpdateEmail( this.state.email.trim() );
+			this.setState( { isSubmitting: false } );
+			return;
+		}
 
 		// If not in a flow, submit the form as a standard signup form.
 		// Since it is a passwordless form, we don't need to submit a password.
@@ -408,4 +436,6 @@ export default connect( null, {
 	recordTracksEvent,
 	saveSignupStep,
 	submitCreateAccountStep: submitSignupStep,
+	// TEMPORARY (remove before merging): used by the `?fake_signup=1` dev shortcut.
+	setCurrentUser,
 } )( localize( PasswordlessSignupForm ) );

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -56,6 +56,9 @@ interface SignupFormSocialFirst {
 	customTosElement?: JSX.Element;
 	activationEmailFrom?: string;
 	onUpdateEmail?: ( email: string ) => Promise< void >;
+	// Drops both routes from the email screen back to the social one, for a caller whose screen is
+	// about the address rather than about how to sign up.
+	hideSocialOptions?: boolean;
 }
 
 const options = {
@@ -116,6 +119,7 @@ const SignupFormSocialFirst = ( {
 	customTosElement,
 	activationEmailFrom,
 	onUpdateEmail,
+	hideSocialOptions,
 }: SignupFormSocialFirst ) => {
 	const [ currentStep, setCurrentStep ] = useState< Screen >( userEmail ? 'email' : 'initial' );
 	const { __ } = useI18n();
@@ -296,14 +300,14 @@ const SignupFormSocialFirst = ( {
 						{ ...passwordlessFormProps }
 						renderTerms={ renderEmailStepTermsOfService }
 						secondaryFooterButton={
-							backButtonInFooter ? undefined : (
+							backButtonInFooter || hideSocialOptions ? undefined : (
 								<Button onClick={ () => setCurrentStep( 'initial' ) } icon={ chevronLeft }>
 									{ __( 'See all options' ) }
 								</Button>
 							)
 						}
 					/>
-					{ backButtonInFooter ? (
+					{ backButtonInFooter && ! hideSocialOptions ? (
 						<Button
 							onClick={ () => setCurrentStep( 'initial' ) }
 							className="back-button"

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -55,6 +55,7 @@ interface SignupFormSocialFirst {
 	allowedSocialServices?: SignupAllowedService[];
 	customTosElement?: JSX.Element;
 	activationEmailFrom?: string;
+	onUpdateEmail?: ( email: string ) => Promise< void >;
 }
 
 const options = {
@@ -114,6 +115,7 @@ const SignupFormSocialFirst = ( {
 	allowedSocialServices,
 	customTosElement,
 	activationEmailFrom,
+	onUpdateEmail,
 }: SignupFormSocialFirst ) => {
 	const [ currentStep, setCurrentStep ] = useState< Screen >( userEmail ? 'email' : 'initial' );
 	const { __ } = useI18n();
@@ -188,6 +190,7 @@ const SignupFormSocialFirst = ( {
 		stepName,
 		flowName,
 		activationEmailFrom,
+		onUpdateEmail,
 		goToNextStep,
 		logInUrl,
 		queryArgs,

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -193,6 +193,32 @@ describe( 'SignupFormSocialFirst', () => {
 		} );
 	} );
 
+	// Both are routes from the email screen back to the social one, and which of the two renders
+	// depends on where the step container puts its back button.
+	describe( 'hideSocialOptions', () => {
+		it.each( [
+			[ 'in the footer', true ],
+			[ 'in the form', false ],
+		] )(
+			'drops the way back to the social screen with the back button %s',
+			( _label, backButtonInFooter ) => {
+				render(
+					<SignupFormSocialFirst
+						{ ...defaultProps }
+						userEmail="typo@example.com"
+						backButtonInFooter={ backButtonInFooter }
+						hideSocialOptions
+					/>
+				);
+
+				expect(
+					screen.queryByRole( 'button', { name: 'See all options' } )
+				).not.toBeInTheDocument();
+				expect( screen.queryByRole( 'button', { name: 'Back' } ) ).not.toBeInTheDocument();
+			}
+		);
+	} );
+
 	describe( 'MobileCompactTosNotice', () => {
 		test( 'renders the "options above" copy', () => {
 			render( <MobileCompactTosNotice /> );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/index.tsx
@@ -27,9 +27,11 @@ interface Props {
 	scope: string;
 	// Partner/Woo branding, so the top bar doesn't change when the gate replaces the form.
 	logo?: ReactNode;
+	// Sends the user back to the account step to correct the address they signed up with.
+	onEditEmail: () => void;
 }
 
-const EmailVerificationGate = ( { flow, scope, logo }: Props ) => {
+const EmailVerificationGate = ( { flow, scope, logo, onEditEmail }: Props ) => {
 	const { __ } = useI18n();
 	const email = useSelector( getCurrentUserEmail );
 	const { sendStatus, secondsUntilResend, resend } = useEmailVerification( flow, scope );
@@ -76,13 +78,24 @@ const EmailVerificationGate = ( { flow, scope, logo }: Props ) => {
 				sprintf(
 					// translators: %s is the email address the verification link was sent to.
 					__(
-						'We just sent an email to <email>%s</email>. Click the link in the email to verify your account.'
+						'We just sent an email to <email>%s</email> (<edit>edit</edit>). Click the link in the email to verify your account.'
 					),
 					email ?? ''
 				),
-				{ email: <strong /> }
+				{
+					email: <strong />,
+					edit: (
+						<Button
+							plain
+							onClick={ () => {
+								recordTracksEvent( 'calypso_signup_email_verification_edit_click', { flow } );
+								onEditEmail();
+							} }
+						/>
+					),
+				}
 			),
-		[ __, email ]
+		[ __, email, flow, onEditEmail ]
 	);
 
 	return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/test/index.tsx
@@ -73,7 +73,7 @@ const advance = ( ms: number ) =>
 
 const render = ( { logo }: { logo?: ReactNode } = {} ) => {
 	const result = renderStep(
-		<EmailVerificationGate flow={ FLOW } scope={ SCOPE } logo={ logo } />,
+		<EmailVerificationGate flow={ FLOW } scope={ SCOPE } logo={ logo } onEditEmail={ jest.fn() } />,
 		{
 			initialState: currentUserState( false ),
 		}
@@ -116,7 +116,7 @@ describe( 'EmailVerificationGate', () => {
 	} );
 
 	it( 'offers an inbox button that deep-links to a known provider', async () => {
-		renderStep( <EmailVerificationGate flow={ FLOW } scope={ SCOPE } />, {
+		renderStep( <EmailVerificationGate flow={ FLOW } scope={ SCOPE } onEditEmail={ jest.fn() } />, {
 			initialState: {
 				currentUser: {
 					id: USER_ID,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -1,3 +1,4 @@
+import { updateUserSettings } from '@automattic/api-core';
 import config from '@automattic/calypso-config';
 import { Step, StepContainer } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
@@ -12,6 +13,7 @@ import OneTapAuthLoaderOverlay from 'calypso/blocks/login/one-tap-auth-loader-ov
 import SignupFormSocialFirst from 'calypso/blocks/signup-form/signup-form-social-first';
 import FormattedHeader from 'calypso/components/formatted-header';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
+import Notice from 'calypso/components/notice';
 import { WOO_HOSTING_SOLUTIONS_REF } from 'calypso/landing/stepper/constants';
 import { useFlowLocale } from 'calypso/landing/stepper/hooks/use-flow-locale';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
@@ -24,7 +26,11 @@ import { setSignupIsNewUser } from 'calypso/signup/storageUtils';
 import WpcomLoginForm from 'calypso/signup/wpcom-login-form';
 import { useSelector } from 'calypso/state';
 import { fetchCurrentUser } from 'calypso/state/current-user/actions';
-import { getCurrentUserId, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import {
+	getCurrentUserEmail,
+	getCurrentUserId,
+	isUserLoggedIn,
+} from 'calypso/state/current-user/selectors';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import { Step as StepType } from '../../types';
 import EmailVerificationGate from './email-verification';
@@ -70,10 +76,15 @@ const UserStepComponent: StepType< { accepts: UserStepAccepts } > = function Use
 	const translate = useTranslate();
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const userId = useSelector( getCurrentUserId );
+	const currentEmail = useSelector( getCurrentUserEmail );
 	const queryArgs = useQuery();
 	const dispatch = useDispatch();
 	const { handleSocialResponse, notice, accountCreateResponse } = useHandleSocialResponse( flow );
 	const [ wpAccountCreateResponse, setWpAccountCreateResponse ] = useState< AccountCreateReturn >();
+	// Set only by the gate's edit link. The account screen is otherwise kept from a user who has an
+	// account; this is the one case where showing it to one is the whole point.
+	const [ isEditingEmail, setIsEditingEmail ] = useState( false );
+	const [ editEmailError, setEditEmailError ] = useState< string | null >( null );
 
 	const { isEnabled: gateEnabled, status: gateStatus } = useEmailVerificationGate( flow );
 	const gateScopeForUser = gateScope( flow, userId );
@@ -149,6 +160,23 @@ const UserStepComponent: StepType< { accepts: UserStepAccepts } > = function Use
 		from: partnerConfig?.id ?? queryArgs.get( 'from' ) ?? undefined,
 	} );
 
+	// Changing an unverified address takes effect immediately and re-sends the activation email, so
+	// there is nothing to confirm and nowhere else to go: the gate re-renders against the corrected
+	// address once `/me` catches up.
+	const updateEmail = async ( email: string ) => {
+		setEditEmailError( null );
+		try {
+			await updateUserSettings( { user_email: email } );
+			dispatch( fetchCurrentUser() as unknown as AnyAction );
+			setIsEditingEmail( false );
+		} catch ( error ) {
+			setEditEmailError(
+				( error as { message?: string } )?.message ??
+					translate( 'We couldn’t update your email address. Please try again.' )
+			);
+		}
+	};
+
 	const shouldRenderLocaleSuggestions = ! isLoggedIn; // For logged-in users, we respect the user language settings
 
 	const handleCreateAccountSuccess = ( data: AccountCreateReturn ) => {
@@ -211,8 +239,16 @@ const UserStepComponent: StepType< { accepts: UserStepAccepts } > = function Use
 				socialServiceResponse={ socialServiceResponse }
 				redirectToAfterLoginUrl={ window.location.href }
 				queryArgs={ {} }
-				userEmail={ queryArgs.get( 'user_email' ) || '' }
-				notice={ notice }
+				userEmail={ ( isEditingEmail ? currentEmail : queryArgs.get( 'user_email' ) ) || '' }
+				notice={
+					editEmailError ? (
+						<Notice status="is-error" showDismiss={ false }>
+							{ editEmailError }
+						</Notice>
+					) : (
+						notice
+					)
+				}
 				isSocialFirst
 				onCreateAccountSuccess={ handleCreateAccountSuccess }
 				backButtonInFooter={ ! isStepContainerV2 }
@@ -223,6 +259,7 @@ const UserStepComponent: StepType< { accepts: UserStepAccepts } > = function Use
 				allowedSocialServices={ allowedSocialServices }
 				customTosElement={ signupTosElement }
 				activationEmailFrom={ gateEnabled ? ACTIVATION_EMAIL_SOURCE : undefined }
+				onUpdateEmail={ isEditingEmail ? updateEmail : undefined }
 			/>
 			{ accountCreateResponse && 'bearer_token' in accountCreateResponse && (
 				<WpcomLoginForm
@@ -234,9 +271,10 @@ const UserStepComponent: StepType< { accepts: UserStepAccepts } > = function Use
 		</>
 	);
 
-	if ( gateStatus === 'gated' ) {
+	if ( gateStatus === 'gated' && ! isEditingEmail ) {
 		return (
 			<EmailVerificationGate
+				onEditEmail={ () => setIsEditingEmail( true ) }
 				// A different account is a different attempt: without this the cooldown, the send
 				// state and the poll's ladder would all carry over to whoever `/me` resolved.
 				key={ gateScopeForUser }
@@ -250,7 +288,7 @@ const UserStepComponent: StepType< { accepts: UserStepAccepts } > = function Use
 	// Nobody with an account has any business being offered another one — including someone whose
 	// account exists but whose `/me` hasn't landed, who would otherwise be looking at live social
 	// buttons and a "See all options" link moments after signing up.
-	if ( isLoggedIn || isWaitingForCreatedAccount ) {
+	if ( ( isLoggedIn || isWaitingForCreatedAccount ) && ! isEditingEmail ) {
 		return <Step.Loading />;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -260,6 +260,7 @@ const UserStepComponent: StepType< { accepts: UserStepAccepts } > = function Use
 				customTosElement={ signupTosElement }
 				activationEmailFrom={ gateEnabled ? ACTIVATION_EMAIL_SOURCE : undefined }
 				onUpdateEmail={ isEditingEmail ? updateEmail : undefined }
+				hideSocialOptions={ isEditingEmail }
 			/>
 			{ accountCreateResponse && 'bearer_token' in accountCreateResponse && (
 				<WpcomLoginForm

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/email-verification-gate.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/email-verification-gate.tsx
@@ -28,6 +28,7 @@ let activationEmailFromProp: string | undefined;
 let signupFormProps: {
 	userEmail?: string;
 	onUpdateEmail?: ( email: string ) => Promise< void >;
+	hideSocialOptions?: boolean;
 } = {};
 
 jest.mock( 'calypso/lib/analytics/tracks' );
@@ -75,15 +76,17 @@ jest.mock( 'calypso/blocks/signup-form/signup-form-social-first', () => ( {
 		activationEmailFrom,
 		userEmail,
 		onUpdateEmail,
+		hideSocialOptions,
 	}: {
 		onCreateAccountSuccess?: ( data: { ID: number } ) => void;
 		goToNextStep?: ( data: { bearer_token: string; ID: number } ) => void;
 		activationEmailFrom?: string;
 		userEmail?: string;
 		onUpdateEmail?: ( email: string ) => Promise< void >;
+		hideSocialOptions?: boolean;
 	} ) => {
 		activationEmailFromProp = activationEmailFrom;
-		signupFormProps = { userEmail, onUpdateEmail };
+		signupFormProps = { userEmail, onUpdateEmail, hideSocialOptions };
 		return (
 			<>
 				<button
@@ -190,6 +193,8 @@ describe( 'account step email verification gate', () => {
 		await user.click( screen.getByRole( 'button', { name: 'edit' } ) );
 
 		expect( signupFormProps.userEmail ).toBe( EMAIL );
+		// Signing up again is the one thing this screen must not offer someone fixing a typo.
+		expect( signupFormProps.hideSocialOptions ).toBe( true );
 		await user.click( screen.getByRole( 'button', { name: 'submit-email' } ) );
 
 		expect( updateUserSettings ).toHaveBeenCalledWith( { user_email: 'fixed@example.com' } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/email-verification-gate.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/email-verification-gate.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { updateUserSettings } from '@automattic/api-core';
 import config from '@automattic/calypso-config';
 import { screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -24,8 +25,16 @@ import useAccountCreationExperiment from '../use-account-creation-experiment';
 let mockUserId = 0;
 
 let activationEmailFromProp: string | undefined;
+let signupFormProps: {
+	userEmail?: string;
+	onUpdateEmail?: ( email: string ) => Promise< void >;
+} = {};
 
 jest.mock( 'calypso/lib/analytics/tracks' );
+jest.mock( '@automattic/api-core', () => ( {
+	...jest.requireActual( '@automattic/api-core' ),
+	updateUserSettings: jest.fn( () => Promise.resolve( {} ) ),
+} ) );
 
 // Keep the poll from reaching the network — the gate polls `fetchCurrentUser`.
 jest.mock( 'calypso/state/current-user/actions', () => ( {
@@ -64,22 +73,30 @@ jest.mock( 'calypso/blocks/signup-form/signup-form-social-first', () => ( {
 		onCreateAccountSuccess,
 		goToNextStep,
 		activationEmailFrom,
+		userEmail,
+		onUpdateEmail,
 	}: {
 		onCreateAccountSuccess?: ( data: { ID: number } ) => void;
 		goToNextStep?: ( data: { bearer_token: string; ID: number } ) => void;
 		activationEmailFrom?: string;
+		userEmail?: string;
+		onUpdateEmail?: ( email: string ) => Promise< void >;
 	} ) => {
 		activationEmailFromProp = activationEmailFrom;
+		signupFormProps = { userEmail, onUpdateEmail };
 		return (
-			<button
-				onClick={ () => {
-					// Production order: goToNextStep fires before onCreateAccountSuccess.
-					goToNextStep?.( { bearer_token: 'test-token', ID: mockUserId } );
-					onCreateAccountSuccess?.( { ID: mockUserId } );
-				} }
-			>
-				create-email-account
-			</button>
+			<>
+				<button
+					onClick={ () => {
+						// Production order: goToNextStep fires before onCreateAccountSuccess.
+						goToNextStep?.( { bearer_token: 'test-token', ID: mockUserId } );
+						onCreateAccountSuccess?.( { ID: mockUserId } );
+					} }
+				>
+					create-email-account
+				</button>
+				<button onClick={ () => onUpdateEmail?.( 'fixed@example.com' ) }>submit-email</button>
+			</>
 		);
 	},
 	MobileCompactTosNotice: () => null,
@@ -160,6 +177,22 @@ describe( 'account step email verification gate', () => {
 		renderUser( makeLoggedOutStore() );
 
 		expect( activationEmailFromProp ).toBeUndefined();
+	} );
+
+	// The gate is a dead end for a mistyped address, so edit leaves it for the account screen
+	// carrying the address to fix, and what that screen submits changes the account rather than
+	// making a second one.
+	it( 'hands a mistyped address back to the account screen to be updated', async () => {
+		const user = userEvent.setup();
+		renderUser( makeStore( false ) );
+		await screen.findByRole( 'heading', { name: GATE_HEADING } );
+
+		await user.click( screen.getByRole( 'button', { name: 'edit' } ) );
+
+		expect( signupFormProps.userEmail ).toBe( EMAIL );
+		await user.click( screen.getByRole( 'button', { name: 'submit-email' } ) );
+
+		expect( updateUserSettings ).toHaveBeenCalledWith( { user_email: 'fixed@example.com' } );
 	} );
 
 	it( 'confirmation continues exactly once (no double submit)', async () => {


### PR DESCRIPTION
Part of DOTCOM-18086. Needs a backend change before it does anything; until then the update is refused and the gate is no worse than it is today.

## Proposed Changes

* An `edit` link beside the address on the email verification gate, returning to the account screen with the field prefilled.
* What that screen submits changes while editing: the address on the existing account, rather than a new account.
* Both routes from the email screen back to the social one are dropped while editing.

The feature flag remains off everywhere.

## Why are these changes being made?

The gate holds a new account until its email is confirmed, which makes a mistyped address a dead end: the only things on offer are an inbox link and a resend, both aimed somewhere no mail will ever arrive. The design asks for a way back, and this is it.

Correcting the address updates the account rather than creating another one. The alternative is worse than it looks — accounts here are created *and* activated, so a second signup leaves the first behind holding the mistyped address forever, and nothing can register that address again. Where the typo lands on a real person's address, that person is silently locked out. It would also split one gate attempt across two accounts, and the view and the confirmation with it.

For the same reason the edit screen drops the two controls that lead back to social signup. Both would take someone who came to fix their address to a screen that makes a second account instead. The signup form itself learns none of this: it takes an optional callback that replaces account creation, and reports nothing, so account creation stays the only thing it knows how to describe.

## Testing Instructions

The backend half is not deployed, so the update is refused. What can be checked is everything up to it.

1. Run Calypso locally and open `/setup/onboarding?flags=onboarding/email-verification`.
2. Create an account with an address you can read. The gate appears naming it.
3. Press `edit`. The account screen should appear with the address already in the field, and with no way back to the social buttons — neither "See all options" nor "Back".
4. Submit. The request should be a settings write, not `/users/new`, and its refusal should surface as a notice above the form.
5. Reload and repeat without the flag. Nothing about the account screen changes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
