### PR TITLE
Login: fix vertical misalignment of "Last used" badge

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -483,10 +483,6 @@ export class LoginForm extends Component {
 			return this.props.translate( 'Your username' );
 		}
 
-		if ( this.isPasswordView() ) {
-			return this.renderChangeUsername();
-		}
-
 		return (
 			// Since the input receives focus on page load, screen reader users don't have any context
 			// for what credentials to use. Unlike other users, they won't have seen the informative
@@ -787,6 +783,8 @@ export class LoginForm extends Component {
 				<div className="login__form-userdata">
 					{ linkingSocialUser && renderSocialLinkingNotice() }
 					{ isUserAccountEmailUpdateRedirect && renderUserAccountEmailUpdateNotice() }
+
+					{ this.isPasswordView() && this.renderChangeUsername() }
 
 					<FormLabel
 						htmlFor="usernameOrEmail"

--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -28,7 +28,12 @@ $breakpoint-mobile: 782px; //Mobile size.
 // "Last used" badge is shown — gives the badge breathing room above the input
 // without modifying the global `.form-label-core-styles` rule. Marker class
 // is only set when the badge ships, so default spacing is preserved otherwise.
+// display: flex + align-items: center keeps the badge vertically centered
+// against its sibling, which can be a plain text label or a `Button` (in the
+// password view) — the two don't share a consistent inline baseline.
 .form-label.has-last-used-badge {
+	display: flex;
+	align-items: center;
 	margin-bottom: 8px;
 }
 

--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -28,12 +28,7 @@ $breakpoint-mobile: 782px; //Mobile size.
 // "Last used" badge is shown — gives the badge breathing room above the input
 // without modifying the global `.form-label-core-styles` rule. Marker class
 // is only set when the badge ships, so default spacing is preserved otherwise.
-// display: flex + align-items: center keeps the badge vertically centered
-// against its sibling, which can be a plain text label or a `Button` (in the
-// password view) — the two don't share a consistent inline baseline.
 .form-label.has-last-used-badge {
-	display: flex;
-	align-items: center;
 	margin-bottom: 8px;
 }
 

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -197,6 +197,10 @@ $breakpoint-mobile: 782px; //Mobile size.
 }
 
 .login__form-change-username {
+	&.is-link {
+		margin-bottom: 6px;
+	}
+	
 	font-weight: inherit;
 
 	.gridicon {


### PR DESCRIPTION
Fixes DOTCOM-18101

| Before  | After |
| ------------- | ------------- |
| <img width="3818" height="1790" alt="image" src="https://github.com/user-attachments/assets/7eb206c5-c673-45d8-9a4e-54d127dc9da2" />  | <img width="969" height="757" alt="Screenshot 2026-08-05 at 18 46 26" src="https://github.com/user-attachments/assets/8ea0511c-dc94-48ba-b7a4-261307d23bed" />  |

## Proposed Changes

* Aligns the "Last used" badge with its sibling label content (plain text or the "Change email address" button) on the login form's password view by making `.form-label.has-last-used-badge` a flex container with `align-items: center`.

## Why are these changes being made?

* The badge and its sibling relied on default inline baseline alignment. That works fine when the sibling is plain text, but when the sibling is the "Change email address" `Button` (an `inline-flex` element with an icon), the two don't share a consistent baseline, so the badge renders visibly offset above the link text.

## Testing Instructions

* Start Calypso locally (`yarn start`).
* Visit `http://calypso.localhost:3000/log-in?last_used=password` (dev-only query override for the `last_used_authentication_method` cookie).
* Enter the email/username of a regular WordPress.com account (password-based) and continue past the account-type lookup to the password view.
* Before the fix: the "Last used" badge sits noticeably higher than the "Change email address" link text.
* After the fix: the badge is vertically centered against the link text.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?