### PR TITLE
Emails: redirect the remaining classic email pages to MSD behind titan-tiers

### DIFF
--- a/client/controller/test/controller.js
+++ b/client/controller/test/controller.js
@@ -29,6 +29,8 @@ describe( 'maybeRedirectToMultiSiteDashboard', () => {
 	// `config/test.json` enables `dashboard/enable-percentage-rollout`, so the
 	// user ID has to fall outside the cohort (`id % 100 >= 50`, below the
 	// new-user threshold) for enrollment to be driven by the preference alone.
+	const targetPath = ( params ) => `/emails/choose-email-solution/${ params.domain }`;
+
 	const buildContext = ( optIn ) => ( {
 		store: mockStore( {
 			currentUser: { id: 99 },
@@ -36,9 +38,9 @@ describe( 'maybeRedirectToMultiSiteDashboard', () => {
 				remoteValues: optIn ? { 'hosting-dashboard-opt-in': { value: optIn } } : {},
 			},
 		} ),
-		params: { site: 'example.wordpress.com' },
+		params: { domain: 'example.com', site: 'example.wordpress.com' },
 		query: {},
-		path: '/email/example.wordpress.com',
+		path: '/email/example.com/purchase/example.wordpress.com',
 	} );
 
 	let next;
@@ -50,51 +52,26 @@ describe( 'maybeRedirectToMultiSiteDashboard', () => {
 	} );
 
 	it( 'does not redirect when the flag is disabled and the user is not force-enrolled', () => {
-		const context = buildContext();
-
-		maybeRedirectToMultiSiteDashboard( '/emails', () => false )( context, next );
+		maybeRedirectToMultiSiteDashboard( targetPath, () => false )( buildContext(), next );
 
 		expect( navigate ).not.toHaveBeenCalled();
 		expect( next ).toHaveBeenCalled();
 	} );
 
-	it( 'redirects when the flag predicate returns true', () => {
-		const context = buildContext();
+	it( 'redirects to the flag target when the predicate returns true', () => {
+		maybeRedirectToMultiSiteDashboard( targetPath, () => true )( buildContext(), next );
 
-		maybeRedirectToMultiSiteDashboard( '/emails', () => true )( context, next );
-
-		expect( navigate ).toHaveBeenCalledWith( 'https://my.wordpress.com/emails' );
+		expect( navigate ).toHaveBeenCalledWith(
+			'https://my.wordpress.com/emails/choose-email-solution/example.com'
+		);
 		expect( next ).not.toHaveBeenCalled();
 	} );
 
 	it( 'redirects force-enrolled users even when the flag is disabled', () => {
-		const context = buildContext( 'forced-opt-in' );
-
-		maybeRedirectToMultiSiteDashboard( '/emails', () => false )( context, next );
-
-		expect( navigate ).toHaveBeenCalledWith( 'https://my.wordpress.com/emails' );
-		expect( next ).not.toHaveBeenCalled();
-	} );
-
-	it( 'does not redirect users who merely opted in when the flag is disabled', () => {
-		const context = buildContext( 'opt-in' );
-
-		maybeRedirectToMultiSiteDashboard( '/emails', () => false )( context, next );
-
-		expect( navigate ).not.toHaveBeenCalled();
-		expect( next ).toHaveBeenCalled();
-	} );
-
-	it( 'builds the target path from the route params', () => {
-		const context = {
-			...buildContext(),
-			params: { domain: 'example.com', site: 'example.wordpress.com' },
-		};
-
-		maybeRedirectToMultiSiteDashboard(
-			( params ) => `/emails/choose-email-solution/${ params.domain }`,
-			() => true
-		)( context, next );
+		maybeRedirectToMultiSiteDashboard( targetPath, () => false )(
+			buildContext( 'forced-opt-in' ),
+			next
+		);
 
 		expect( navigate ).toHaveBeenCalledWith(
 			'https://my.wordpress.com/emails/choose-email-solution/example.com'

--- a/client/controller/test/controller.js
+++ b/client/controller/test/controller.js
@@ -4,15 +4,104 @@
 
 import * as page from '@automattic/calypso-router';
 import configureStore from 'redux-mock-store';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
+import { navigate } from 'calypso/lib/navigate';
 import addQueryArgs from 'calypso/lib/url/add-query-args';
-import { redirectLoggedOut, redirectMyJetpack } from '../index.web';
+import {
+	maybeRedirectToMultiSiteDashboard,
+	redirectLoggedOut,
+	redirectMyJetpack,
+} from '../index.web';
 
 jest.mock( '@automattic/calypso-router' );
 jest.mock( 'wpcom-proxy-request', () => ( {
 	isCookieAuthMissing: jest.fn( () => false ),
 } ) );
+jest.mock( 'calypso/lib/navigate', () => ( { navigate: jest.fn() } ) );
+jest.mock( 'calypso/dashboard/utils/link', () => ( {
+	dashboardLink: jest.fn( ( path ) => `https://my.wordpress.com${ path }` ),
+} ) );
+jest.mock( 'calypso/lib/analytics/mc', () => ( { bumpStat: jest.fn() } ) );
 
 const mockStore = configureStore();
+
+describe( 'maybeRedirectToMultiSiteDashboard', () => {
+	// `config/test.json` enables `dashboard/enable-percentage-rollout`, so the
+	// user ID has to fall outside the cohort (`id % 100 >= 50`, below the
+	// new-user threshold) for enrollment to be driven by the preference alone.
+	const buildContext = ( optIn ) => ( {
+		store: mockStore( {
+			currentUser: { id: 99 },
+			preferences: {
+				remoteValues: optIn ? { 'hosting-dashboard-opt-in': { value: optIn } } : {},
+			},
+		} ),
+		params: { site: 'example.wordpress.com' },
+		query: {},
+		path: '/email/example.wordpress.com',
+	} );
+
+	let next;
+
+	beforeEach( () => {
+		next = jest.fn();
+		navigate.mockClear();
+		dashboardLink.mockClear();
+	} );
+
+	it( 'does not redirect when the flag is disabled and the user is not force-enrolled', () => {
+		const context = buildContext();
+
+		maybeRedirectToMultiSiteDashboard( '/emails', () => false )( context, next );
+
+		expect( navigate ).not.toHaveBeenCalled();
+		expect( next ).toHaveBeenCalled();
+	} );
+
+	it( 'redirects when the flag predicate returns true', () => {
+		const context = buildContext();
+
+		maybeRedirectToMultiSiteDashboard( '/emails', () => true )( context, next );
+
+		expect( navigate ).toHaveBeenCalledWith( 'https://my.wordpress.com/emails' );
+		expect( next ).not.toHaveBeenCalled();
+	} );
+
+	it( 'redirects force-enrolled users even when the flag is disabled', () => {
+		const context = buildContext( 'forced-opt-in' );
+
+		maybeRedirectToMultiSiteDashboard( '/emails', () => false )( context, next );
+
+		expect( navigate ).toHaveBeenCalledWith( 'https://my.wordpress.com/emails' );
+		expect( next ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not redirect users who merely opted in when the flag is disabled', () => {
+		const context = buildContext( 'opt-in' );
+
+		maybeRedirectToMultiSiteDashboard( '/emails', () => false )( context, next );
+
+		expect( navigate ).not.toHaveBeenCalled();
+		expect( next ).toHaveBeenCalled();
+	} );
+
+	it( 'builds the target path from the route params', () => {
+		const context = {
+			...buildContext(),
+			params: { domain: 'example.com', site: 'example.wordpress.com' },
+		};
+
+		maybeRedirectToMultiSiteDashboard(
+			( params ) => `/emails/choose-email-solution/${ params.domain }`,
+			() => true
+		)( context, next );
+
+		expect( navigate ).toHaveBeenCalledWith(
+			'https://my.wordpress.com/emails/choose-email-solution/example.com'
+		);
+		expect( next ).not.toHaveBeenCalled();
+	} );
+} );
 
 describe( 'redirectLoggedOut', () => {
 	const originalLocation = Object.getOwnPropertyDescriptor( window, 'location' );

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
 import clsx from 'clsx';
@@ -7,10 +8,12 @@ import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
 import SectionHeader from 'calypso/components/section-header';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import { useIsLoading as useAddEmailForwardMutationIsLoading } from 'calypso/data/emails/use-add-email-forward-mutation';
 import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import { hasGSuiteWithUs } from 'calypso/lib/gsuite';
+import { navigate } from 'calypso/lib/navigate';
 import { getConfiguredTitanMailboxCount, hasTitanMailWithUs } from 'calypso/lib/titan';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import EmailListActive from 'calypso/my-sites/email/email-management/home/email-list-active';
@@ -190,6 +193,13 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 	}
 
 	if ( domainsWithEmail.length < 1 && domainsWithNoEmail.length === 1 ) {
+		if ( isEnabled( 'emails/titan-tiers' ) ) {
+			navigate(
+				dashboardLink( `/emails/choose-email-solution/${ domainsWithNoEmail[ 0 ].name }` )
+			);
+			return null;
+		}
+
 		return (
 			<EmailProvidersStackedComparisonPage
 				comparisonContext="email-home-single-domain"

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
@@ -109,13 +109,14 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 
 	const addEmailForwardMutationActive = useAddEmailForwardMutationIsLoading();
 
-	const { data: allDomains = [], isLoading: isSiteDomainLoading } = useGetDomainsQuery(
-		selectedSite?.ID ?? null,
-		{
-			refetchOnMount: ! addEmailForwardMutationActive,
-			retry: false,
-		}
-	);
+	const {
+		data: allDomains = [],
+		isLoading: isSiteDomainLoading,
+		isFetching: isSiteDomainFetching,
+	} = useGetDomainsQuery( selectedSite?.ID ?? null, {
+		refetchOnMount: ! addEmailForwardMutationActive,
+		retry: false,
+	} );
 
 	const domains = allDomains.map( createSiteDomainObject );
 	const nonWpcomDomains = domains.filter( ( domain ) => ! domain.isWPCOMDomain );
@@ -125,6 +126,30 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 
 	const isSingleDomainThatHasEmail =
 		domainsWithEmail.length === 1 && domainsWithNoEmail.length === 0;
+
+	// The domains query is persisted to localStorage for up to a week, so the
+	// first render can run on stale data. Waiting for the refetch to settle
+	// avoids sending someone who already bought email off to a purchase page,
+	// which a cross-origin navigation would make unrecoverable.
+	const redirectDomainName =
+		isEnabled( 'emails/titan-tiers' ) &&
+		! selectedDomainName &&
+		! isSiteDomainLoading &&
+		! isSiteDomainFetching &&
+		domainsWithEmail.length < 1 &&
+		domainsWithNoEmail.length === 1
+			? domainsWithNoEmail[ 0 ].name
+			: undefined;
+
+	useEffect( () => {
+		if ( redirectDomainName ) {
+			navigate(
+				dashboardLink(
+					`/emails/choose-email-solution/${ encodeURIComponent( redirectDomainName ) }`
+				)
+			);
+		}
+	}, [ redirectDomainName ] );
 
 	if ( isSiteDomainLoading || ! hasSitesLoaded || ! selectedSite || ! domains ) {
 		return (
@@ -193,11 +218,12 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 	}
 
 	if ( domainsWithEmail.length < 1 && domainsWithNoEmail.length === 1 ) {
-		if ( isEnabled( 'emails/titan-tiers' ) ) {
-			navigate(
-				dashboardLink( `/emails/choose-email-solution/${ domainsWithNoEmail[ 0 ].name }` )
+		if ( redirectDomainName ) {
+			return (
+				<LoadingPlaceholder
+					className={ clsx( { 'context-all-domain-management': isAllDomainManagementContext } ) }
+				/>
 			);
-			return null;
 		}
 
 		return (

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -218,14 +218,6 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 	}
 
 	if ( domainsWithEmail.length < 1 && domainsWithNoEmail.length === 1 ) {
-		if ( redirectDomainName ) {
-			return (
-				<LoadingPlaceholder
-					className={ clsx( { 'context-all-domain-management': isAllDomainManagementContext } ) }
-				/>
-			);
-		}
-
 		return (
 			<EmailProvidersStackedComparisonPage
 				comparisonContext="email-home-single-domain"

--- a/client/my-sites/email/index.jsx
+++ b/client/my-sites/email/index.jsx
@@ -65,6 +65,8 @@ export default function () {
 
 	page(
 		paths.getEmailManagementPath( ':site' ),
+		setupPreferences,
+		maybeRedirectToMultiSiteDashboard( '/emails' ),
 		...commonHandlers,
 		controller.emailManagement,
 		makeLayout,

--- a/client/my-sites/email/index.jsx
+++ b/client/my-sites/email/index.jsx
@@ -65,6 +65,8 @@ export default function () {
 
 	page(
 		paths.getEmailManagementPath( ':site' ),
+		setupPreferences,
+		maybeRedirectToMultiSiteDashboard( '/emails', () => isEnabled( 'emails/titan-tiers' ) ),
 		...commonHandlers,
 		controller.emailManagement,
 		makeLayout,
@@ -170,7 +172,8 @@ export default function () {
 		handlers: [
 			setupPreferences,
 			maybeRedirectToMultiSiteDashboard(
-				( params ) => `/emails/choose-email-solution/${ params.domain }`
+				( params ) => `/emails/choose-email-solution/${ params.domain }`,
+				() => isEnabled( 'emails/titan-tiers' )
 			),
 			...commonHandlers,
 			controller.emailManagementPurchaseNewEmailAccount,

--- a/client/my-sites/email/index.jsx
+++ b/client/my-sites/email/index.jsx
@@ -65,8 +65,6 @@ export default function () {
 
 	page(
 		paths.getEmailManagementPath( ':site' ),
-		setupPreferences,
-		maybeRedirectToMultiSiteDashboard( '/emails', () => isEnabled( 'emails/titan-tiers' ) ),
 		...commonHandlers,
 		controller.emailManagement,
 		makeLayout,


### PR DESCRIPTION
Follow-up to #112806

## Proposed Changes

Two classic email surfaces still render the deprecated "Pick an email solution" page when `emails/titan-tiers` is on. Both now hand off to the MSD:

* `email-home.tsx` — a site whose only custom domain has no email renders the comparison inline. Redirect to `/emails/choose-email-solution/<domain>`.
* `/email/:domain/purchase/:site` — the route already had the redirect middleware but no flag predicate, so it only fired for forced-opt-in users. Pass the flag check.

Also adds tests for `maybeRedirectToMultiSiteDashboard`.

## Why are these changes being made?

#112806 redirected the classic email management page to the MSD when `emails/titan-tiers` is on, so users outside the dashboard rollout don't stay on the deprecated page where the new Titan tier functionality is not applied. These two surfaces were missed.

The email home case is the one users actually hit. `/email/:site` has no redirect of its own, and the neighbouring single-domain branch that *does* redirect (to `/email/:domain/manage/:site`, which #112806 flag-gated) only fires when the domain already has email. A domain with no email fell through both and rendered the comparison inline, so the flag had no effect on that page at all. The redirect goes in the component rather than route middleware because the domain name is only known there.

## Testing Instructions

`yarn test-client client/controller/test/controller.js`

Manual, on wpcalypso (flag overrides are not read on production — see `packages/calypso-config/src/index.ts`). Use a site with exactly one custom domain that has no email:

1. `/email/<site-slug>?flags=-dashboard/enable-percentage-rollout,emails/titan-tiers` -> redirects to `/emails/choose-email-solution/<domain>`.
2. Same URL with `-emails/titan-tiers` -> the classic "Pick an email solution" page renders.
3. Repeat both on `/email/<domain>/purchase/<site-slug>`.

`-dashboard/enable-percentage-rollout` is needed because `isForcedOptIn` is the other, independent redirect trigger: since #112778 that flag is on in every environment, so any user with `id % 100 < 50` or `id > 282953237` is force-enrolled and redirected regardless of `emails/titan-tiers`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
