### PR TITLE
Jetpack AI: show block edit outcomes with Undo

### DIFF
--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -8,6 +8,7 @@ import type { ComponentProps } from 'react';
 
 const mockUseAgentChat = jest.fn();
 const mockUseRegenerateAction = jest.fn();
+const mockUseCheckpointAction = jest.fn();
 const mockUseConversation = jest.fn();
 const mockUseImageUpload = jest.fn();
 const mockIsReaderChatAgent = jest.fn();
@@ -189,7 +190,10 @@ jest.mock( '../../utils/tracks', () => ( {
 jest.mock( '../../hooks/use-abilities-registration', () => () => {} );
 jest.mock( '../../hooks/use-conversation', () => () => mockUseConversation() );
 jest.mock( '../../hooks/use-save-new-chat-route', () => () => {} );
-jest.mock( '../../hooks/use-checkpoint-action', () => () => {} );
+jest.mock( '../../hooks/use-checkpoint-action', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockUseCheckpointAction( ...args ),
+} ) );
 jest.mock( '../../hooks/use-feedback-action', () => () => ( {
 	showFeedbackInput: false,
 	submitFeedbackText: jest.fn(),
@@ -326,6 +330,7 @@ const countShowComponentMessages = () => {
 describe( 'OrchestratorChat', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockUseCheckpointAction.mockReturnValue( () => [] );
 		// Default getter: contributes no actions.
 		mockUseRegenerateAction.mockReturnValue( () => [] );
 		mockUseConversation.mockReturnValue( { isLoading: false } );
@@ -1021,6 +1026,79 @@ describe( 'OrchestratorChat', () => {
 
 		expect( mockUseRegenerateAction ).toHaveBeenCalledWith(
 			expect.objectContaining( { enabled: false } )
+		);
+	} );
+
+	it( 'derives and deduplicates checkpoint actions for synthetic streaming messages', () => {
+		const checkpointAction = {
+			id: 'checkpoint',
+			label: 'Undo',
+			onClick: jest.fn(),
+			order: 1,
+		};
+		const createOutcomeMessage = ( id: string, actions?: unknown[] ) => ( {
+			id,
+			role: 'agent',
+			content: [
+				{
+					type: 'text',
+					text: JSON.stringify( {
+						tool_id: 'big_sky__apply_block_edits',
+						tool_call_id: 'tool-call-1',
+						data: {
+							result: { success: true, outcome: 'updated', message: 'Updated the block.' },
+						},
+					} ),
+				},
+			],
+			timestamp: 1,
+			archived: false,
+			showIcon: true,
+			...( actions ? { actions } : {} ),
+		} );
+		const getCheckpointActions = jest.fn( ( message: { id: string } ) =>
+			message.id === 'agent-streaming-stale' ? [] : [ checkpointAction ]
+		);
+		mockUseCheckpointAction.mockReturnValue( getCheckpointActions );
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( {
+				messages: [
+					createOutcomeMessage( 'agent-streaming-new' ),
+					createOutcomeMessage( 'agent-streaming-duplicate', [
+						{ ...checkpointAction, label: 'Old Undo' },
+					] ),
+					createOutcomeMessage( 'agent-streaming-stale', [ checkpointAction ] ),
+				],
+			} )
+		);
+
+		render( chat() );
+
+		const messages = mockAgentChat.mock.calls[ 0 ][ 0 ].messages as Array< {
+			id: string;
+			actions?: Array< { id: string; label: string } >;
+		} >;
+		const getCheckpointActionsFromMessage = ( id: string ) =>
+			messages
+				.find( ( message ) => message.id === id )
+				?.actions?.filter( ( action ) => action.id === 'checkpoint' ) ?? [];
+
+		expect( getCheckpointActionsFromMessage( 'agent-streaming-new' ) ).toEqual( [
+			expect.objectContaining( { id: 'checkpoint', label: 'Undo' } ),
+		] );
+		expect( getCheckpointActionsFromMessage( 'agent-streaming-duplicate' ) ).toEqual( [
+			expect.objectContaining( { id: 'checkpoint', label: 'Undo' } ),
+		] );
+		expect( getCheckpointActionsFromMessage( 'agent-streaming-stale' ) ).toEqual( [] );
+		expect( getCheckpointActions ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				id: 'agent-streaming-new',
+				content: expect.arrayContaining( [
+					expect.objectContaining( {
+						text: expect.stringContaining( 'big_sky__apply_block_edits' ),
+					} ),
+				] ),
+			} )
 		);
 	} );
 

--- a/packages/agents-manager/src/components/agent-dock/chat-ui.scss
+++ b/packages/agents-manager/src/components/agent-dock/chat-ui.scss
@@ -107,14 +107,19 @@ body.wp-admin.modal-open .agents-manager-chat--docked {
 				font-weight: 500;
 				cursor: pointer;
 
-				&:hover {
+				&:hover:not( :disabled ) {
 					background: var( --color-muted );
 				}
 
-				&:focus-visible {
+				&:focus-visible:not( :disabled ) {
 					background: var( --color-muted );
 					outline: 2px solid var( --wp-admin-theme-color, #3858e9 );
 					outline-offset: 1px;
+				}
+
+				&:disabled {
+					cursor: default;
+					opacity: 0.5;
 				}
 			}
 

--- a/packages/agents-manager/src/components/agent-dock/chat-ui.scss
+++ b/packages/agents-manager/src/components/agent-dock/chat-ui.scss
@@ -94,8 +94,8 @@ body.wp-admin.modal-open .agents-manager-chat--docked {
 			}
 
 			&__status {
-				background: rgba( 74, 184, 102, 0.2 );
-				color: #4ab866;
+				background: var( --color-success-background );
+				color: var( --color-success );
 				font-weight: 600;
 			}
 

--- a/packages/agents-manager/src/components/agent-dock/chat-ui.scss
+++ b/packages/agents-manager/src/components/agent-dock/chat-ui.scss
@@ -75,6 +75,54 @@ body.wp-admin.modal-open .agents-manager-chat--docked {
 				fill: var( --color-foreground );
 			}
 		}
+
+		.agents-manager-resolved-edit-action {
+			display: inline-flex;
+			flex: 0 0 100%;
+			align-items: center;
+			gap: 0.25rem;
+
+			&__status,
+			&__undo {
+				display: inline-flex;
+				align-items: center;
+				gap: 0.25rem;
+				min-height: 32px;
+				padding: 0.4rem 0.75rem;
+				border-radius: 4px;
+				font-size: 13px;
+			}
+
+			&__status {
+				background: var( --color-success-background, rgba( 74, 184, 102, 0.2 ) );
+				color: var( --color-success, #4ab866 );
+				font-weight: 600;
+			}
+
+			&__undo {
+				border: 0;
+				background: transparent;
+				color: var( --color-foreground );
+				font-family: inherit;
+				font-weight: 500;
+				cursor: pointer;
+
+				&:hover {
+					background: var( --color-muted );
+				}
+
+				&:focus-visible {
+					background: var( --color-muted );
+					outline: 2px solid var( --wp-admin-theme-color, #3858e9 );
+					outline-offset: 1px;
+				}
+			}
+
+			&__icon {
+				flex: 0 0 auto;
+				fill: currentColor;
+			}
+		}
 	}
 
 	// Prevent content overflow

--- a/packages/agents-manager/src/components/agent-dock/chat-ui.scss
+++ b/packages/agents-manager/src/components/agent-dock/chat-ui.scss
@@ -98,6 +98,12 @@ body.wp-admin.modal-open .agents-manager-chat--docked {
 				background: rgba( 74, 184, 102, 0.2 );
 				color: #4ab866;
 				font-weight: 600;
+
+				&--reverted {
+					background: transparent;
+					color: var( --color-foreground );
+					font-weight: 500;
+				}
 			}
 
 			&__undo {
@@ -120,8 +126,12 @@ body.wp-admin.modal-open .agents-manager-chat--docked {
 
 				&:disabled {
 					cursor: default;
-					opacity: 0.5;
 				}
+			}
+
+			&__status--reverted,
+			&__undo:disabled {
+				opacity: 0.66;
 			}
 
 			&__icon {

--- a/packages/agents-manager/src/components/agent-dock/chat-ui.scss
+++ b/packages/agents-manager/src/components/agent-dock/chat-ui.scss
@@ -94,8 +94,9 @@ body.wp-admin.modal-open .agents-manager-chat--docked {
 			}
 
 			&__status {
-				background: var( --color-success-background );
-				color: var( --color-success );
+				// Agenttic's success token is white in dark mode; match the Editorial Review treatment.
+				background: rgba( 74, 184, 102, 0.2 );
+				color: #4ab866;
 				font-weight: 600;
 			}
 

--- a/packages/agents-manager/src/components/agent-dock/chat-ui.scss
+++ b/packages/agents-manager/src/components/agent-dock/chat-ui.scss
@@ -94,8 +94,8 @@ body.wp-admin.modal-open .agents-manager-chat--docked {
 			}
 
 			&__status {
-				background: var( --color-success-background, rgba( 74, 184, 102, 0.2 ) );
-				color: var( --color-success, #4ab866 );
+				background: rgba( 74, 184, 102, 0.2 );
+				color: #4ab866;
 				font-weight: 600;
 			}
 

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -446,7 +446,7 @@ export default function OrchestratorChat( {
 
 	// Register an "Undo" action on agent messages with checkpoints.
 	const checkpoint = useCheckpoint?.();
-	useCheckpointAction( registerMessageActions, checkpoint );
+	const getCheckpointActionsForMessage = useCheckpointAction( registerMessageActions, checkpoint );
 
 	// TODO (ability-migration): Remove once the last checkpoint-writing Big Sky
 	// ability migrates. Keeps the provider checkpoint store reachable for the
@@ -865,6 +865,13 @@ export default function OrchestratorChat( {
 			);
 		}
 
+		const checkpointActionsByMessageId = new Map(
+			currentMessages.map( ( message ) => [
+				message.id,
+				getCheckpointActionsForMessage( message ),
+			] )
+		);
+
 		// Group site-build messages only when needed
 		const hasBuildMessages = siteBuildUtils?.hasSiteBuildMessages( currentMessages );
 
@@ -890,6 +897,7 @@ export default function OrchestratorChat( {
 			const messageWithTraceId = traceId ? { ...message, traceId } : message;
 
 			const directActions = [
+				...( checkpointActionsByMessageId.get( message.id ) ?? [] ),
 				...getFeedbackActionsForMessage( message ),
 				...getCopyActionsForMessage( message ),
 				...getRegenerateActionsForMessage( message, {
@@ -897,12 +905,16 @@ export default function OrchestratorChat( {
 					isStreaming: isProcessing,
 				} ),
 			];
-			if ( directActions.length === 0 ) {
+			const hasRegisteredCheckpointAction = message.actions?.some(
+				( action ) => action.id === 'checkpoint'
+			);
+			if ( directActions.length === 0 && ! hasRegisteredCheckpointAction ) {
 				return messageWithTraceId;
 			}
 
 			const existingActions = message.actions?.filter(
 				( action ) =>
+					action.id !== 'checkpoint' &&
 					! action.id.startsWith( 'feedback-' ) &&
 					action.id !== 'copy' &&
 					action.id !== 'regenerate'
@@ -922,6 +934,7 @@ export default function OrchestratorChat( {
 		deletedMessageIds,
 		getChatComponent,
 		getCopyActionsForMessage,
+		getCheckpointActionsForMessage,
 		getShowComponentOrder,
 		getFeedbackActionsForMessage,
 		getTraceIdForMessage,

--- a/packages/agents-manager/src/components/resolved-edit-action.tsx
+++ b/packages/agents-manager/src/components/resolved-edit-action.tsx
@@ -28,7 +28,12 @@ export default function ResolvedEditAction( { onUndo }: ResolvedEditActionProps 
 
 	return (
 		<div className="agents-manager-resolved-edit-action">
-			<span className="agents-manager-resolved-edit-action__status" role="status">
+			<span
+				className={ `agents-manager-resolved-edit-action__status${
+					isReverted ? ' agents-manager-resolved-edit-action__status--reverted' : ''
+				}` }
+				role="status"
+			>
 				<Icon className="agents-manager-resolved-edit-action__icon" icon={ check } size={ 20 } />
 				{ isReverted
 					? __( 'Reverted', __i18n_text_domain__ )

--- a/packages/agents-manager/src/components/resolved-edit-action.tsx
+++ b/packages/agents-manager/src/components/resolved-edit-action.tsx
@@ -1,11 +1,28 @@
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { check, Icon, undo } from '@wordpress/icons';
 
 type ResolvedEditActionProps = {
-	onUndo: () => void | Promise< void >;
+	onUndo: () => Promise< boolean >;
 };
 
 export default function ResolvedEditAction( { onUndo }: ResolvedEditActionProps ) {
+	const [ isUndoDisabled, setIsUndoDisabled ] = useState( false );
+	const handleUndo = async () => {
+		if ( isUndoDisabled ) {
+			return;
+		}
+
+		setIsUndoDisabled( true );
+		try {
+			if ( ! ( await onUndo() ) ) {
+				setIsUndoDisabled( false );
+			}
+		} catch {
+			setIsUndoDisabled( false );
+		}
+	};
+
 	return (
 		<div className="agents-manager-resolved-edit-action">
 			<span className="agents-manager-resolved-edit-action__status" role="status">
@@ -15,7 +32,8 @@ export default function ResolvedEditAction( { onUndo }: ResolvedEditActionProps 
 			<button
 				type="button"
 				className="agents-manager-resolved-edit-action__undo"
-				onClick={ () => void onUndo() }
+				onClick={ () => void handleUndo() }
+				disabled={ isUndoDisabled }
 			>
 				<Icon className="agents-manager-resolved-edit-action__icon" icon={ undo } size={ 20 } />
 				{ __( 'Undo', __i18n_text_domain__ ) }

--- a/packages/agents-manager/src/components/resolved-edit-action.tsx
+++ b/packages/agents-manager/src/components/resolved-edit-action.tsx
@@ -7,33 +7,38 @@ type ResolvedEditActionProps = {
 };
 
 export default function ResolvedEditAction( { onUndo }: ResolvedEditActionProps ) {
-	const [ isUndoDisabled, setIsUndoDisabled ] = useState( false );
+	const [ undoState, setUndoState ] = useState< 'ready' | 'pending' | 'reverted' >( 'ready' );
 	const handleUndo = async () => {
-		if ( isUndoDisabled ) {
+		if ( undoState !== 'ready' ) {
 			return;
 		}
 
-		setIsUndoDisabled( true );
+		setUndoState( 'pending' );
 		try {
-			if ( ! ( await onUndo() ) ) {
-				setIsUndoDisabled( false );
+			if ( await onUndo() ) {
+				setUndoState( 'reverted' );
+			} else {
+				setUndoState( 'ready' );
 			}
 		} catch {
-			setIsUndoDisabled( false );
+			setUndoState( 'ready' );
 		}
 	};
+	const isReverted = undoState === 'reverted';
 
 	return (
 		<div className="agents-manager-resolved-edit-action">
 			<span className="agents-manager-resolved-edit-action__status" role="status">
 				<Icon className="agents-manager-resolved-edit-action__icon" icon={ check } size={ 20 } />
-				{ __( 'Updated', __i18n_text_domain__ ) }
+				{ isReverted
+					? __( 'Reverted', __i18n_text_domain__ )
+					: __( 'Updated', __i18n_text_domain__ ) }
 			</span>
 			<button
 				type="button"
 				className="agents-manager-resolved-edit-action__undo"
 				onClick={ () => void handleUndo() }
-				disabled={ isUndoDisabled }
+				disabled={ undoState !== 'ready' }
 			>
 				<Icon className="agents-manager-resolved-edit-action__icon" icon={ undo } size={ 20 } />
 				{ __( 'Undo', __i18n_text_domain__ ) }

--- a/packages/agents-manager/src/components/resolved-edit-action.tsx
+++ b/packages/agents-manager/src/components/resolved-edit-action.tsx
@@ -1,6 +1,6 @@
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { check, Icon, undo } from '@wordpress/icons';
+import { check, closeSmall, Icon, undo } from '@wordpress/icons';
 
 type ResolvedEditActionProps = {
 	onUndo: () => Promise< boolean >;
@@ -34,7 +34,11 @@ export default function ResolvedEditAction( { onUndo }: ResolvedEditActionProps 
 				}` }
 				role="status"
 			>
-				<Icon className="agents-manager-resolved-edit-action__icon" icon={ check } size={ 20 } />
+				<Icon
+					className="agents-manager-resolved-edit-action__icon"
+					icon={ isReverted ? closeSmall : check }
+					size={ 20 }
+				/>
 				{ isReverted
 					? __( 'Reverted', __i18n_text_domain__ )
 					: __( 'Updated', __i18n_text_domain__ ) }

--- a/packages/agents-manager/src/components/resolved-edit-action.tsx
+++ b/packages/agents-manager/src/components/resolved-edit-action.tsx
@@ -1,0 +1,25 @@
+import { __ } from '@wordpress/i18n';
+import { check, Icon, undo } from '@wordpress/icons';
+
+type ResolvedEditActionProps = {
+	onUndo: () => void | Promise< void >;
+};
+
+export default function ResolvedEditAction( { onUndo }: ResolvedEditActionProps ) {
+	return (
+		<div className="agents-manager-resolved-edit-action">
+			<span className="agents-manager-resolved-edit-action__status" role="status">
+				<Icon className="agents-manager-resolved-edit-action__icon" icon={ check } size={ 20 } />
+				{ __( 'Updated', __i18n_text_domain__ ) }
+			</span>
+			<button
+				type="button"
+				className="agents-manager-resolved-edit-action__undo"
+				onClick={ () => void onUndo() }
+			>
+				<Icon className="agents-manager-resolved-edit-action__icon" icon={ undo } size={ 20 } />
+				{ __( 'Undo', __i18n_text_domain__ ) }
+			</button>
+		</div>
+	);
+}

--- a/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
@@ -1,7 +1,15 @@
 /**
  * @jest-environment jsdom
  */
-import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react';
+import {
+	act,
+	fireEvent,
+	render,
+	renderHook,
+	screen,
+	waitFor,
+	within,
+} from '@testing-library/react';
 import { createElement } from '@wordpress/element';
 import { recordBigSkyTracksEvent } from '../../utils/tracks';
 import useCheckpointAction from '../use-checkpoint-action';
@@ -11,6 +19,25 @@ import type { UIMessage, UseAgentChatReturn } from '@automattic/agenttic-client'
 jest.mock( '../../utils/tracks', () => ( {
 	recordBigSkyTracksEvent: jest.fn(),
 } ) );
+jest.mock( '@wordpress/icons', () => {
+	const { createElement: mockCreateElement } = jest.requireActual( '@wordpress/element' );
+
+	return {
+		check: 'check',
+		closeSmall: 'closeSmall',
+		undo: 'undo',
+		Icon: ( { className, icon }: { className?: string; icon: unknown } ) => {
+			if ( typeof icon !== 'string' ) {
+				throw new Error( 'Unexpected unmocked icon' );
+			}
+
+			return mockCreateElement( 'span', {
+				className,
+				'data-testid': `icon-${ icon }`,
+			} );
+		},
+	};
+} );
 
 type MessageActionsRegistration = Parameters< UseAgentChatReturn[ 'registerMessageActions' ] >[ 0 ];
 
@@ -112,6 +139,7 @@ describe( 'useCheckpointAction', () => {
 		render( createElement( actions[ 0 ].component, actions[ 0 ].componentProps ) );
 		const status = screen.getByRole( 'status' );
 		expect( status ).toHaveTextContent( 'Updated' );
+		expect( within( status ).getByTestId( 'icon-check' ) ).toBeInTheDocument();
 		expect( status ).not.toHaveClass( 'agents-manager-resolved-edit-action__status--reverted' );
 		const undoButton = screen.getByRole( 'button', { name: 'Undo' } );
 		fireEvent.click( undoButton );
@@ -122,6 +150,7 @@ describe( 'useCheckpointAction', () => {
 		} );
 		expect( undoButton ).toBeDisabled();
 		expect( status ).toHaveTextContent( 'Updated' );
+		expect( within( status ).getByTestId( 'icon-check' ) ).toBeInTheDocument();
 		expect( status ).not.toHaveClass( 'agents-manager-resolved-edit-action__status--reverted' );
 		fireEvent.click( undoButton );
 		expect( checkpoint.restoreCheckpoint ).toHaveBeenCalledTimes( 1 );
@@ -130,6 +159,7 @@ describe( 'useCheckpointAction', () => {
 
 		expect( undoButton ).toBeDisabled();
 		expect( status ).toHaveTextContent( 'Reverted' );
+		expect( within( status ).getByTestId( 'icon-closeSmall' ) ).toBeInTheDocument();
 		expect( status ).toHaveClass( 'agents-manager-resolved-edit-action__status--reverted' );
 	} );
 

--- a/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
@@ -145,9 +145,7 @@ describe( 'useCheckpointAction', () => {
 		fireEvent.click( undoButton );
 
 		expect( checkpoint.restoreCheckpoint ).toHaveBeenCalledWith( 'tool-call-1' );
-		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'restore_checkpoint_action', {
-			id: 'tool-call-1',
-		} );
+		expect( recordBigSkyTracksEvent ).not.toHaveBeenCalled();
 		expect( undoButton ).toBeDisabled();
 		expect( status ).toHaveTextContent( 'Updated' );
 		expect( within( status ).getByTestId( 'icon-check' ) ).toBeInTheDocument();
@@ -157,6 +155,11 @@ describe( 'useCheckpointAction', () => {
 
 		await act( async () => resolveRestore() );
 
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 1 );
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'restore_checkpoint_action', {
+			id: 'tool-call-1',
+			outcome: 'success',
+		} );
 		expect( undoButton ).toBeDisabled();
 		expect( status ).toHaveTextContent( 'Reverted' );
 		expect( within( status ).getByTestId( 'icon-closeSmall' ) ).toBeInTheDocument();
@@ -204,6 +207,11 @@ describe( 'useCheckpointAction', () => {
 
 		await act( async () => rejectRestore( new Error( 'Restore failed' ) ) );
 
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 1 );
+		expect( recordBigSkyTracksEvent ).toHaveBeenLastCalledWith( 'restore_checkpoint_action', {
+			id: 'tool-call-1',
+			outcome: 'failed',
+		} );
 		expect( undoButton ).toBeEnabled();
 		expect( status ).toHaveTextContent( 'Updated' );
 		expect( status ).not.toHaveClass( 'agents-manager-resolved-edit-action__status--reverted' );
@@ -216,6 +224,11 @@ describe( 'useCheckpointAction', () => {
 		expect( checkpoint.restoreCheckpoint ).toHaveBeenCalledTimes( 2 );
 		expect( undoButton ).toBeDisabled();
 		await waitFor( () => expect( status ).toHaveTextContent( 'Reverted' ) );
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 2 );
+		expect( recordBigSkyTracksEvent ).toHaveBeenLastCalledWith( 'restore_checkpoint_action', {
+			id: 'tool-call-1',
+			outcome: 'success',
+		} );
 	} );
 
 	it( 'uses the Jetpack tool call id for its block edit checkpoint', async () => {

--- a/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { fireEvent, render, renderHook, screen } from '@testing-library/react';
+import { act, fireEvent, render, renderHook, screen } from '@testing-library/react';
 import { createElement } from '@wordpress/element';
 import { recordBigSkyTracksEvent } from '../../utils/tracks';
 import useCheckpointAction from '../use-checkpoint-action';
@@ -68,13 +68,23 @@ describe( 'useCheckpointAction', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 	} );
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
 
-	it( 'shows the resolved edit action for a successful block edit', async () => {
+	it( 'disables Undo after restoring a successful block edit', async () => {
 		let registration: MessageActionsRegistration | undefined;
 		const registerMessageActions = jest.fn( ( nextRegistration ) => {
 			registration = nextRegistration;
 		} ) as UseAgentChatReturn[ 'registerMessageActions' ];
 		const checkpoint = createCheckpoint();
+		let resolveRestore!: () => void;
+		( checkpoint.restoreCheckpoint as jest.Mock ).mockImplementation(
+			() =>
+				new Promise< void >( ( resolve ) => {
+					resolveRestore = resolve;
+				} )
+		);
 		const message = createToolMessage( {
 			toolCallId: 'tool-call-1',
 			data: {
@@ -101,12 +111,71 @@ describe( 'useCheckpointAction', () => {
 		}
 		render( createElement( actions[ 0 ].component, actions[ 0 ].componentProps ) );
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Updated' );
-		fireEvent.click( screen.getByRole( 'button', { name: 'Undo' } ) );
+		const undoButton = screen.getByRole( 'button', { name: 'Undo' } );
+		fireEvent.click( undoButton );
 
 		expect( checkpoint.restoreCheckpoint ).toHaveBeenCalledWith( 'tool-call-1' );
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'restore_checkpoint_action', {
 			id: 'tool-call-1',
 		} );
+		expect( undoButton ).toBeDisabled();
+		fireEvent.click( undoButton );
+		expect( checkpoint.restoreCheckpoint ).toHaveBeenCalledTimes( 1 );
+
+		await act( async () => resolveRestore() );
+
+		expect( undoButton ).toBeDisabled();
+	} );
+
+	it( 're-enables Undo when restoring the checkpoint fails', async () => {
+		let registration: MessageActionsRegistration | undefined;
+		const registerMessageActions = jest.fn( ( nextRegistration ) => {
+			registration = nextRegistration;
+		} ) as UseAgentChatReturn[ 'registerMessageActions' ];
+		const checkpoint = createCheckpoint();
+		let rejectRestore!: ( error: Error ) => void;
+		( checkpoint.restoreCheckpoint as jest.Mock )
+			.mockImplementationOnce(
+				() =>
+					new Promise< void >( ( _resolve, reject ) => {
+						rejectRestore = reject;
+					} )
+			)
+			.mockResolvedValueOnce( undefined );
+		const consoleError = jest.spyOn( console, 'error' ).mockImplementation();
+		const message = createToolMessage( {
+			toolCallId: 'tool-call-1',
+			data: {
+				result: {
+					success: true,
+					message: 'Corrected the grammar.',
+					outcome: 'updated',
+				},
+			},
+		} );
+
+		renderHook( () => useCheckpointAction( registerMessageActions, checkpoint ) );
+
+		const actions = getActions( registration, message );
+		if ( actions[ 0 ]?.type !== 'component' ) {
+			throw new Error( 'Expected a component action.' );
+		}
+		render( createElement( actions[ 0 ].component, actions[ 0 ].componentProps ) );
+		const undoButton = screen.getByRole( 'button', { name: 'Undo' } );
+		fireEvent.click( undoButton );
+		expect( undoButton ).toBeDisabled();
+
+		await act( async () => rejectRestore( new Error( 'Restore failed' ) ) );
+
+		expect( undoButton ).toBeEnabled();
+		expect( consoleError ).toHaveBeenCalledWith(
+			'[useCheckpointAction] Failed to restore checkpoint:',
+			expect.any( Error )
+		);
+
+		fireEvent.click( undoButton );
+		expect( checkpoint.restoreCheckpoint ).toHaveBeenCalledTimes( 2 );
+		expect( undoButton ).toBeDisabled();
 	} );
 
 	it( 'uses the Jetpack tool call id for its block edit checkpoint', async () => {

--- a/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
@@ -1,0 +1,193 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fireEvent, render, renderHook, screen } from '@testing-library/react';
+import { createElement } from '@wordpress/element';
+import { recordBigSkyTracksEvent } from '../../utils/tracks';
+import useCheckpointAction from '../use-checkpoint-action';
+import type { UseCheckpointReturn } from '../../utils/load-external-providers';
+import type { UIMessage, UseAgentChatReturn } from '@automattic/agenttic-client';
+
+jest.mock( '../../utils/tracks', () => ( {
+	recordBigSkyTracksEvent: jest.fn(),
+} ) );
+
+type MessageActionsRegistration = Parameters< UseAgentChatReturn[ 'registerMessageActions' ] >[ 0 ];
+
+function createToolMessage( {
+	toolCallId,
+	toolId = 'big_sky__apply_block_edits',
+	data,
+}: {
+	toolCallId?: string;
+	toolId?: string;
+	data: Record< string, unknown >;
+} ): UIMessage {
+	return {
+		id: 'message-1',
+		role: 'agent',
+		content: [
+			{
+				type: 'text',
+				text: JSON.stringify( {
+					tool_call_id: toolCallId,
+					tool_id: toolId,
+					data,
+				} ),
+			},
+		],
+	} as UIMessage;
+}
+
+function getActions( registration: MessageActionsRegistration | undefined, message: UIMessage ) {
+	if ( ! registration ) {
+		return [];
+	}
+
+	return typeof registration.actions === 'function'
+		? registration.actions( message )
+		: registration.actions;
+}
+
+function createCheckpoint(): UseCheckpointReturn {
+	return {
+		getLastEditorState: jest.fn(),
+		setCheckpoint: jest.fn(),
+		addCheckpointKeys: jest.fn(),
+		restoreCheckpoint: jest.fn().mockResolvedValue( undefined ),
+		addNewPageToCheckpoint: jest.fn(),
+		addPageRenameToCheckpoint: jest.fn(),
+		addPageRemovalToCheckpoint: jest.fn(),
+		getLatestUserMessageId: jest.fn(),
+		clearCheckpoint: jest.fn(),
+		hasCheckpoint: jest.fn().mockReturnValue( true ),
+	};
+}
+
+describe( 'useCheckpointAction', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'shows the resolved edit action for a successful block edit', async () => {
+		let registration: MessageActionsRegistration | undefined;
+		const registerMessageActions = jest.fn( ( nextRegistration ) => {
+			registration = nextRegistration;
+		} ) as UseAgentChatReturn[ 'registerMessageActions' ];
+		const checkpoint = createCheckpoint();
+		const message = createToolMessage( {
+			toolCallId: 'tool-call-1',
+			data: {
+				result: {
+					success: true,
+					message: 'Corrected the grammar.',
+					outcome: 'updated',
+				},
+			},
+		} );
+
+		renderHook( () => useCheckpointAction( registerMessageActions, checkpoint ) );
+
+		const actions = getActions( registration, message );
+		expect( actions ).toHaveLength( 1 );
+		expect( actions[ 0 ] ).toMatchObject( {
+			type: 'component',
+			id: 'checkpoint',
+			label: 'Updated and Undo',
+		} );
+
+		if ( actions[ 0 ]?.type !== 'component' ) {
+			throw new Error( 'Expected a component action.' );
+		}
+		render( createElement( actions[ 0 ].component, actions[ 0 ].componentProps ) );
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Updated' );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Undo' } ) );
+
+		expect( checkpoint.restoreCheckpoint ).toHaveBeenCalledWith( 'tool-call-1' );
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'restore_checkpoint_action', {
+			id: 'tool-call-1',
+		} );
+	} );
+
+	it( 'uses the Jetpack tool call id for its block edit checkpoint', async () => {
+		let registration: MessageActionsRegistration | undefined;
+		const registerMessageActions = jest.fn( ( nextRegistration ) => {
+			registration = nextRegistration;
+		} ) as UseAgentChatReturn[ 'registerMessageActions' ];
+		const checkpoint = createCheckpoint();
+		const message = createToolMessage( {
+			toolCallId: 'jetpack-tool-call-1',
+			toolId: 'wpcom__update_block_content',
+			data: {
+				result: {
+					success: true,
+					message: 'Corrected the grammar.',
+					outcome: 'updated',
+				},
+			},
+		} );
+
+		renderHook( () => useCheckpointAction( registerMessageActions, checkpoint ) );
+
+		const actions = getActions( registration, message );
+		expect( actions[ 0 ] ).toMatchObject( {
+			type: 'component',
+			id: 'checkpoint',
+			label: 'Updated and Undo',
+		} );
+
+		if ( actions[ 0 ]?.type !== 'component' ) {
+			throw new Error( 'Expected a component action.' );
+		}
+		render( createElement( actions[ 0 ].component, actions[ 0 ].componentProps ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Undo' } ) );
+
+		expect( checkpoint.hasCheckpoint ).toHaveBeenCalledWith( 'jetpack-tool-call-1' );
+		expect( checkpoint.restoreCheckpoint ).toHaveBeenCalledWith( 'jetpack-tool-call-1' );
+	} );
+
+	it( 'does not show Undo for a successful no-op block edit', () => {
+		let registration: MessageActionsRegistration | undefined;
+		const registerMessageActions = jest.fn( ( nextRegistration ) => {
+			registration = nextRegistration;
+		} ) as UseAgentChatReturn[ 'registerMessageActions' ];
+		const checkpoint = createCheckpoint();
+		const message = createToolMessage( {
+			toolCallId: 'tool-call-1',
+			data: {
+				result: {
+					success: true,
+					message: 'No edits were necessary.',
+					outcome: 'no-changes',
+				},
+			},
+		} );
+
+		renderHook( () => useCheckpointAction( registerMessageActions, checkpoint ) );
+
+		expect( getActions( registration, message ) ).toEqual( [] );
+		expect( checkpoint.hasCheckpoint ).not.toHaveBeenCalled();
+	} );
+
+	it( 'uses the resolved edit action for legacy block edit checkpoints', () => {
+		let registration: MessageActionsRegistration | undefined;
+		const registerMessageActions = jest.fn( ( nextRegistration ) => {
+			registration = nextRegistration;
+		} ) as UseAgentChatReturn[ 'registerMessageActions' ];
+		const checkpoint = createCheckpoint();
+		const message = createToolMessage( {
+			data: {
+				summary: 'Updated the paragraph.',
+				calypsoCheckpointId: 'legacy-checkpoint-1',
+			},
+		} );
+
+		renderHook( () => useCheckpointAction( registerMessageActions, checkpoint ) );
+
+		expect( getActions( registration, message )[ 0 ] ).toMatchObject( {
+			type: 'component',
+			id: 'checkpoint',
+			label: 'Updated and Undo',
+		} );
+	} );
+} );

--- a/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
@@ -112,6 +112,7 @@ describe( 'useCheckpointAction', () => {
 		render( createElement( actions[ 0 ].component, actions[ 0 ].componentProps ) );
 		const status = screen.getByRole( 'status' );
 		expect( status ).toHaveTextContent( 'Updated' );
+		expect( status ).not.toHaveClass( 'agents-manager-resolved-edit-action__status--reverted' );
 		const undoButton = screen.getByRole( 'button', { name: 'Undo' } );
 		fireEvent.click( undoButton );
 
@@ -121,6 +122,7 @@ describe( 'useCheckpointAction', () => {
 		} );
 		expect( undoButton ).toBeDisabled();
 		expect( status ).toHaveTextContent( 'Updated' );
+		expect( status ).not.toHaveClass( 'agents-manager-resolved-edit-action__status--reverted' );
 		fireEvent.click( undoButton );
 		expect( checkpoint.restoreCheckpoint ).toHaveBeenCalledTimes( 1 );
 
@@ -128,6 +130,7 @@ describe( 'useCheckpointAction', () => {
 
 		expect( undoButton ).toBeDisabled();
 		expect( status ).toHaveTextContent( 'Reverted' );
+		expect( status ).toHaveClass( 'agents-manager-resolved-edit-action__status--reverted' );
 	} );
 
 	it( 're-enables Undo when restoring the checkpoint fails', async () => {
@@ -173,6 +176,7 @@ describe( 'useCheckpointAction', () => {
 
 		expect( undoButton ).toBeEnabled();
 		expect( status ).toHaveTextContent( 'Updated' );
+		expect( status ).not.toHaveClass( 'agents-manager-resolved-edit-action__status--reverted' );
 		expect( consoleError ).toHaveBeenCalledWith(
 			'[useCheckpointAction] Failed to restore checkpoint:',
 			expect.any( Error )

--- a/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { act, fireEvent, render, renderHook, screen } from '@testing-library/react';
+import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react';
 import { createElement } from '@wordpress/element';
 import { recordBigSkyTracksEvent } from '../../utils/tracks';
 import useCheckpointAction from '../use-checkpoint-action';
@@ -72,7 +72,7 @@ describe( 'useCheckpointAction', () => {
 		jest.restoreAllMocks();
 	} );
 
-	it( 'disables Undo after restoring a successful block edit', async () => {
+	it( 'shows Reverted and disables Undo after restoring a successful block edit', async () => {
 		let registration: MessageActionsRegistration | undefined;
 		const registerMessageActions = jest.fn( ( nextRegistration ) => {
 			registration = nextRegistration;
@@ -110,7 +110,8 @@ describe( 'useCheckpointAction', () => {
 			throw new Error( 'Expected a component action.' );
 		}
 		render( createElement( actions[ 0 ].component, actions[ 0 ].componentProps ) );
-		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Updated' );
+		const status = screen.getByRole( 'status' );
+		expect( status ).toHaveTextContent( 'Updated' );
 		const undoButton = screen.getByRole( 'button', { name: 'Undo' } );
 		fireEvent.click( undoButton );
 
@@ -119,12 +120,14 @@ describe( 'useCheckpointAction', () => {
 			id: 'tool-call-1',
 		} );
 		expect( undoButton ).toBeDisabled();
+		expect( status ).toHaveTextContent( 'Updated' );
 		fireEvent.click( undoButton );
 		expect( checkpoint.restoreCheckpoint ).toHaveBeenCalledTimes( 1 );
 
 		await act( async () => resolveRestore() );
 
 		expect( undoButton ).toBeDisabled();
+		expect( status ).toHaveTextContent( 'Reverted' );
 	} );
 
 	it( 're-enables Undo when restoring the checkpoint fails', async () => {
@@ -161,6 +164,7 @@ describe( 'useCheckpointAction', () => {
 			throw new Error( 'Expected a component action.' );
 		}
 		render( createElement( actions[ 0 ].component, actions[ 0 ].componentProps ) );
+		const status = screen.getByRole( 'status' );
 		const undoButton = screen.getByRole( 'button', { name: 'Undo' } );
 		fireEvent.click( undoButton );
 		expect( undoButton ).toBeDisabled();
@@ -168,6 +172,7 @@ describe( 'useCheckpointAction', () => {
 		await act( async () => rejectRestore( new Error( 'Restore failed' ) ) );
 
 		expect( undoButton ).toBeEnabled();
+		expect( status ).toHaveTextContent( 'Updated' );
 		expect( consoleError ).toHaveBeenCalledWith(
 			'[useCheckpointAction] Failed to restore checkpoint:',
 			expect.any( Error )
@@ -176,6 +181,7 @@ describe( 'useCheckpointAction', () => {
 		fireEvent.click( undoButton );
 		expect( checkpoint.restoreCheckpoint ).toHaveBeenCalledTimes( 2 );
 		expect( undoButton ).toBeDisabled();
+		await waitFor( () => expect( status ).toHaveTextContent( 'Reverted' ) );
 	} );
 
 	it( 'uses the Jetpack tool call id for its block edit checkpoint', async () => {
@@ -213,6 +219,7 @@ describe( 'useCheckpointAction', () => {
 
 		expect( checkpoint.hasCheckpoint ).toHaveBeenCalledWith( 'jetpack-tool-call-1' );
 		expect( checkpoint.restoreCheckpoint ).toHaveBeenCalledWith( 'jetpack-tool-call-1' );
+		await waitFor( () => expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Reverted' ) );
 	} );
 
 	it( 'does not show Undo for a successful no-op block edit', () => {

--- a/packages/agents-manager/src/hooks/use-checkpoint-action.ts
+++ b/packages/agents-manager/src/hooks/use-checkpoint-action.ts
@@ -68,20 +68,24 @@ export default function useCheckpointAction(
 		}
 
 		const restoreCheckpoint = async (): Promise< boolean > => {
-			recordBigSkyTracksEvent( 'restore_checkpoint_action', {
-				id: checkpointInfo.checkpointId,
-			} );
+			let outcome: 'success' | 'failed' = 'failed';
 			try {
 				const checkpointToRestore = checkpointRef.current;
 				if ( ! checkpointToRestore ) {
 					return false;
 				}
 				await checkpointToRestore.restoreCheckpoint( checkpointInfo.checkpointId );
+				outcome = 'success';
 				return true;
 			} catch ( error ) {
 				// eslint-disable-next-line no-console
 				console.error( '[useCheckpointAction] Failed to restore checkpoint:', error );
 				return false;
+			} finally {
+				recordBigSkyTracksEvent( 'restore_checkpoint_action', {
+					id: checkpointInfo.checkpointId,
+					outcome,
+				} );
 			}
 		};
 

--- a/packages/agents-manager/src/hooks/use-checkpoint-action.ts
+++ b/packages/agents-manager/src/hooks/use-checkpoint-action.ts
@@ -1,33 +1,47 @@
-import { createElement, useEffect, useRef } from '@wordpress/element';
+import { createElement, useCallback, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { undo, Icon } from '@wordpress/icons';
+import ResolvedEditAction from '../components/resolved-edit-action';
+import { getApplyBlockEditsOutcome } from '../utils/tool-message-utils';
 import { recordBigSkyTracksEvent } from '../utils/tracks';
 import type { UseCheckpointReturn } from '../utils/load-external-providers';
-import type { UseAgentChatReturn, UIMessage } from '@automattic/agenttic-client';
+import type { UIMessage, UIMessageAction, UseAgentChatReturn } from '@automattic/agenttic-client';
 
 type RegisterMessageActions = UseAgentChatReturn[ 'registerMessageActions' ];
 
 /**
- * Gets the checkpoint ID embedded in a tool message, or an empty string
- * if the message doesn't contain one.
+ * Gets checkpoint details embedded in a tool message.
  *
- * Checkpoint IDs are not available in past or restored conversations
- * because they are only stored in-memory for the current session.
+ * Restored conversations can carry a checkpoint ID, but provider checkpoint
+ * state is session-only; `hasCheckpoint` filters out stale IDs.
  */
-function getCheckpointId( message: UIMessage ): string {
+function getCheckpointInfo(
+	message: UIMessage
+): { checkpointId: string; showResolvedEditAction: boolean } | undefined {
 	const firstPartText = message.content?.[ 0 ]?.text ?? '';
 
 	try {
 		const parsed = JSON.parse( firstPartText );
+		const blockEditOutcome = getApplyBlockEditsOutcome( parsed.tool_id, parsed.data );
 
-		if ( parsed.data?.calypsoCheckpointId ) {
-			return parsed.data.calypsoCheckpointId;
+		if ( blockEditOutcome === 'no-changes' ) {
+			return undefined;
+		}
+
+		const checkpointId =
+			parsed.data?.calypsoCheckpointId ??
+			( blockEditOutcome === 'updated' ? parsed.tool_call_id : undefined );
+		if ( typeof checkpointId === 'string' && checkpointId ) {
+			return {
+				checkpointId,
+				showResolvedEditAction: blockEditOutcome === 'updated',
+			};
 		}
 	} catch {
 		// Not JSON — not a tool message.
 	}
 
-	return '';
+	return undefined;
 }
 
 /**
@@ -36,50 +50,68 @@ function getCheckpointId( message: UIMessage ): string {
 export default function useCheckpointAction(
 	registerMessageActions: RegisterMessageActions,
 	checkpoint?: UseCheckpointReturn
-): void {
+): ( message: UIMessage ) => UIMessageAction[] {
 	// Ref avoids infinite re-renders caused by unstable `checkpoint` reference.
 	const checkpointRef = useRef( checkpoint );
 	checkpointRef.current = checkpoint;
+	const getCheckpointActionsForMessage = useCallback( ( message: UIMessage ): UIMessageAction[] => {
+		const currentCheckpoint = checkpointRef.current;
+
+		if ( ! currentCheckpoint || message.role !== 'agent' ) {
+			return [];
+		}
+
+		const checkpointInfo = getCheckpointInfo( message );
+
+		if ( ! checkpointInfo || ! currentCheckpoint.hasCheckpoint( checkpointInfo.checkpointId ) ) {
+			return [];
+		}
+
+		const restoreCheckpoint = async () => {
+			recordBigSkyTracksEvent( 'restore_checkpoint_action', {
+				id: checkpointInfo.checkpointId,
+			} );
+			try {
+				await checkpointRef.current?.restoreCheckpoint( checkpointInfo.checkpointId );
+			} catch ( error ) {
+				// eslint-disable-next-line no-console
+				console.error( '[useCheckpointAction] Failed to restore checkpoint:', error );
+			}
+		};
+
+		if ( checkpointInfo.showResolvedEditAction ) {
+			return [
+				{
+					type: 'component',
+					id: 'checkpoint',
+					label: __( 'Updated and Undo', __i18n_text_domain__ ),
+					component: ResolvedEditAction,
+					componentProps: { onUndo: restoreCheckpoint },
+					order: 1,
+				},
+			];
+		}
+
+		return [
+			{
+				id: 'checkpoint',
+				label: __( 'Undo', __i18n_text_domain__ ),
+				icon: createElement( Icon, {
+					icon: undo,
+					className: 'agents-manager-message-action-icon',
+				} ),
+				onClick: restoreCheckpoint,
+				order: 1,
+			},
+		];
+	}, [] );
 
 	useEffect( () => {
 		registerMessageActions( {
 			id: 'agents-manager-checkpoint',
-			actions: ( message: UIMessage ) => {
-				const currentCheckpoint = checkpointRef.current;
-
-				if ( ! currentCheckpoint || message.role !== 'agent' ) {
-					return [];
-				}
-
-				const checkpointId = getCheckpointId( message );
-
-				if ( ! checkpointId || ! currentCheckpoint.hasCheckpoint( checkpointId ) ) {
-					return [];
-				}
-
-				return [
-					{
-						id: 'checkpoint',
-						label: __( 'Undo', __i18n_text_domain__ ),
-						icon: createElement( Icon, {
-							icon: undo,
-							className: 'agents-manager-message-action-icon',
-						} ),
-						onClick: async () => {
-							recordBigSkyTracksEvent( 'restore_checkpoint_action', {
-								id: checkpointId,
-							} );
-							try {
-								await checkpointRef.current?.restoreCheckpoint( checkpointId );
-							} catch ( error ) {
-								// eslint-disable-next-line no-console
-								console.error( '[useCheckpointAction] Failed to restore checkpoint:', error );
-							}
-						},
-						order: 1,
-					},
-				];
-			},
+			actions: getCheckpointActionsForMessage,
 		} );
-	}, [ registerMessageActions ] );
+	}, [ getCheckpointActionsForMessage, registerMessageActions ] );
+
+	return getCheckpointActionsForMessage;
 }

--- a/packages/agents-manager/src/hooks/use-checkpoint-action.ts
+++ b/packages/agents-manager/src/hooks/use-checkpoint-action.ts
@@ -67,15 +67,21 @@ export default function useCheckpointAction(
 			return [];
 		}
 
-		const restoreCheckpoint = async () => {
+		const restoreCheckpoint = async (): Promise< boolean > => {
 			recordBigSkyTracksEvent( 'restore_checkpoint_action', {
 				id: checkpointInfo.checkpointId,
 			} );
 			try {
-				await checkpointRef.current?.restoreCheckpoint( checkpointInfo.checkpointId );
+				const checkpointToRestore = checkpointRef.current;
+				if ( ! checkpointToRestore ) {
+					return false;
+				}
+				await checkpointToRestore.restoreCheckpoint( checkpointInfo.checkpointId );
+				return true;
 			} catch ( error ) {
 				// eslint-disable-next-line no-console
 				console.error( '[useCheckpointAction] Failed to restore checkpoint:', error );
+				return false;
 			}
 		};
 
@@ -100,7 +106,9 @@ export default function useCheckpointAction(
 					icon: undo,
 					className: 'agents-manager-message-action-icon',
 				} ),
-				onClick: restoreCheckpoint,
+				onClick: async () => {
+					await restoreCheckpoint();
+				},
 				order: 1,
 			},
 		];

--- a/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
@@ -61,6 +61,25 @@ const createToolMessage = (
 		...overrides,
 	} );
 
+const createApplyBlockEditsMessage = (
+	toolCallId: string,
+	data: object,
+	overrides?: Partial< UIMessage >
+): UIMessage =>
+	createMessage( {
+		content: [
+			{
+				type: 'text',
+				text: JSON.stringify( {
+					tool_id: 'big_sky__apply_block_edits',
+					tool_call_id: toolCallId,
+					data,
+				} ),
+			},
+		],
+		...overrides,
+	} );
+
 describe( 'convertToolMessagesToComponents', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -342,15 +361,12 @@ describe( 'convertToolMessagesToComponents', () => {
 			expected: 'Updated the heading and added a new paragraph.',
 		},
 		{
-			name: 'apply-block-edits structured result',
+			name: 'legacy apply-block-edits structured result',
 			toolId: 'big_sky__apply_block_edits',
 			data: {
 				result: {
 					success: true,
 					message: 'Updated the header and footer.',
-					details: {
-						changes: { added: [], removed: [], modified: [] },
-					},
 				},
 			},
 			expected: 'Updated the header and footer.',
@@ -396,6 +412,179 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 	} );
 
+	it.each( [ 'big_sky__apply_block_edits', 'wpcom__update_block_content' ] )(
+		'hides a request-shaped %s message until the client reports its outcome',
+		( toolId ) => {
+			const message = createToolMessage( toolId, {
+				summary: 'Corrected the grammar in the selected paragraph.',
+				updates: [ { clientId: 'block-1' } ],
+			} );
+
+			expect( convertToolMessagesToComponents( { messages: [ message ] } ) ).toEqual( [] );
+		}
+	);
+
+	it( 'hides a successful Jetpack result without an explicit outcome', () => {
+		const message = createToolMessage( 'wpcom__update_block_content', {
+			result: {
+				success: true,
+				message: 'Corrected the grammar in the selected paragraph.',
+			},
+		} );
+
+		expect( convertToolMessagesToComponents( { messages: [ message ] } ) ).toEqual( [] );
+	} );
+
+	it.each( [ 'big_sky__apply_block_edits', 'wpcom__update_block_content' ] )(
+		'keeps only the concrete summary for a successful %s edit',
+		( toolId ) => {
+			const message = createToolMessage( toolId, {
+				result: {
+					success: true,
+					message: 'Corrected the grammar in the selected paragraph.',
+					outcome: 'updated',
+					details: { appliedOperations: { modified: 1 } },
+				},
+			} );
+
+			const result = convertToolMessagesToComponents( { messages: [ message ] } );
+
+			expect( result[ 0 ].content ).toEqual( [
+				{ type: 'text', text: 'Corrected the grammar in the selected paragraph.' },
+			] );
+		}
+	);
+
+	it.each( [ 'big_sky__apply_block_edits', 'wpcom__update_block_content' ] )(
+		'replaces a successful no-op %s summary with a clear outcome',
+		( toolId ) => {
+			const message = createToolMessage( toolId, {
+				result: {
+					success: true,
+					message: 'Corrected the grammar in the selected paragraph.',
+					outcome: 'no-changes',
+				},
+			} );
+
+			const result = convertToolMessagesToComponents( { messages: [ message ] } );
+
+			expect( result[ 0 ].content ).toEqual( [ { type: 'text', text: '✓ No changes needed' } ] );
+		}
+	);
+
+	it( 'renders an explicit Jetpack no-op outcome even when no summary was provided', () => {
+		const message = createToolMessage( 'wpcom__update_block_content', {
+			result: {
+				success: true,
+				outcome: 'no-changes',
+			},
+		} );
+
+		const result = convertToolMessagesToComponents( { messages: [ message ] } );
+
+		expect( result[ 0 ].content ).toEqual( [ { type: 'text', text: '✓ No changes needed' } ] );
+	} );
+
+	it( 'replaces the requested edit payload with its authoritative applied outcome', () => {
+		const requestedEdit = createApplyBlockEditsMessage(
+			'tool-call-1',
+			{
+				updates: [ { clientId: 'block-1' } ],
+				summary: 'Corrected one misspelling.',
+				followUpTasks: false,
+			},
+			{ id: 'requested-edit' }
+		);
+		const appliedOutcome = createApplyBlockEditsMessage(
+			'tool-call-1',
+			{
+				result: {
+					success: true,
+					message: 'Corrected one misspelling.',
+					outcome: 'updated',
+				},
+				followUpTasks: false,
+			},
+			{ id: 'applied-outcome' }
+		);
+
+		const result = convertToolMessagesToComponents( {
+			messages: [ requestedEdit, appliedOutcome ],
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].id ).toBe( 'applied-outcome' );
+		expect( result[ 0 ].content ).toEqual( [
+			{ type: 'text', text: 'Corrected one misspelling.' },
+		] );
+	} );
+
+	it( 'suppresses trailing prose after a terminal no-change outcome', () => {
+		const noChangeOutcome = createApplyBlockEditsMessage(
+			'tool-call-1',
+			{
+				result: {
+					success: true,
+					message: 'The requested changes were already applied.',
+					outcome: 'no-changes',
+				},
+				followUpTasks: false,
+			},
+			{ id: 'no-change-outcome' }
+		);
+		const prose = createMessage( {
+			id: 'prose',
+			content: [
+				{
+					type: 'text',
+					text: 'The paragraph reads well overall, with some optional style advice.',
+				},
+			],
+		} );
+
+		const result = convertToolMessagesToComponents( {
+			messages: [ noChangeOutcome, prose ],
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].id ).toBe( 'no-change-outcome' );
+		expect( result[ 0 ].content ).toEqual( [ { type: 'text', text: '✓ No changes needed' } ] );
+	} );
+
+	it( 'suppresses duplicate trailing prose after a terminal applied outcome', () => {
+		const appliedOutcome = createApplyBlockEditsMessage(
+			'tool-call-1',
+			{
+				result: {
+					success: true,
+					message: 'Corrected one misspelling.',
+					outcome: 'updated',
+				},
+				followUpTasks: false,
+			},
+			{ id: 'applied-outcome' }
+		);
+		const prose = createMessage( {
+			id: 'prose',
+			content: [
+				{
+					type: 'text',
+					text: 'I corrected one misspelling in the selected paragraph.',
+				},
+			],
+		} );
+
+		const result = convertToolMessagesToComponents( {
+			messages: [ appliedOutcome, prose ],
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].id ).toBe( 'applied-outcome' );
+		expect( result[ 0 ].content ).toEqual( [
+			{ type: 'text', text: 'Corrected one misspelling.' },
+		] );
+	} );
+
 	it( 'filters out unsuccessful apply-block-edits tool summaries', () => {
 		const message = createToolMessage( 'big_sky__apply_block_edits', {
 			success: false,
@@ -412,7 +601,11 @@ describe( 'convertToolMessagesToComponents', () => {
 	it( 'suppresses transient thinking for converted apply-block-edits messages', () => {
 		const message = createToolMessage( 'big_sky__apply_block_edits', {
 			followUpTasks: true,
-			summary: 'Updated the header and footer.',
+			result: {
+				success: true,
+				message: 'Updated the header and footer.',
+				outcome: 'updated',
+			},
 		} );
 
 		const result = convertToolMessagesToComponents( {
@@ -517,7 +710,13 @@ describe( 'convertToolMessagesToComponents', () => {
 		} );
 		const toolMessage = createToolMessage(
 			'big_sky__apply_block_edits',
-			{ result: { success: true, message: 'Updated the header.' } },
+			{
+				result: {
+					success: true,
+					message: 'Updated the header.',
+					outcome: 'updated',
+				},
+			},
 			{ id: 'tool-1' }
 		);
 

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -15,7 +15,11 @@ import {
 	getProviderCheckpointRecords,
 } from '../provider-checkpoints';
 import type { Ability } from '../../extension-types';
-import type { ProviderCapabilities, UseSuggestionsHook } from '../load-external-providers';
+import type {
+	ProviderCapabilities,
+	UseCheckpointReturn,
+	UseSuggestionsHook,
+} from '../load-external-providers';
 
 jest.mock( '@automattic/agenttic-client', () => ( { getAgentManager: jest.fn() } ), {
 	virtual: true,
@@ -54,6 +58,24 @@ function createAbility( name: string ): Ability {
 		label: name,
 		description: `${ name } description`,
 		category: 'test',
+	};
+}
+
+function createCheckpointReturn(
+	overrides: Partial< UseCheckpointReturn > = {}
+): UseCheckpointReturn {
+	return {
+		getLastEditorState: jest.fn( () => null ),
+		setCheckpoint: jest.fn(),
+		addCheckpointKeys: jest.fn(),
+		restoreCheckpoint: jest.fn( () => Promise.resolve() ),
+		addNewPageToCheckpoint: jest.fn(),
+		addPageRenameToCheckpoint: jest.fn(),
+		addPageRemovalToCheckpoint: jest.fn(),
+		getLatestUserMessageId: jest.fn( () => undefined ),
+		clearCheckpoint: jest.fn(),
+		hasCheckpoint: jest.fn( () => false ),
+		...overrides,
 	};
 }
 
@@ -662,20 +684,18 @@ describe( 'loadExternalProviders', () => {
 		expect( providers.getChatComponent?.( 'chat-suggestions' ) ).toBeNull();
 	} );
 
-	it( 'uses the first provider for singleton exports', async () => {
+	it( 'uses the first provider for onTaskUpdate', async () => {
 		const firstOnTaskUpdate = jest.fn();
-		const firstUseCheckpoint = jest.fn();
 		setAgentsManagerData( {
 			agentProviders: [
-				{ onTaskUpdate: firstOnTaskUpdate, useCheckpoint: firstUseCheckpoint },
-				{ onTaskUpdate: jest.fn(), useCheckpoint: jest.fn() },
+				{ onTaskUpdate: firstOnTaskUpdate },
+				{ onTaskUpdate: jest.fn() },
 			],
 		} );
 
 		const providers = await loadExternalProviders();
 
 		expect( providers.onTaskUpdate ).toBe( firstOnTaskUpdate );
-		expect( providers.useCheckpoint ).toBe( firstUseCheckpoint );
 	} );
 
 	it( 'merges empty view suggestions from multiple providers and dedupes by id', async () => {
@@ -742,6 +762,65 @@ describe( 'loadExternalProviders', () => {
 			updates: [],
 		} );
 		expect( otherProvider.executeAbility ).not.toHaveBeenCalled();
+	} );
+
+	it( 'composes checkpoint hooks so id lookups search every provider store', async () => {
+		const firstReturn = createCheckpointReturn( {
+			getLastEditorState: jest.fn( () => 'first-editor-state' ),
+			hasCheckpoint: jest.fn( ( id: string ) => id === 'first-cp' ),
+		} );
+		const secondReturn = createCheckpointReturn( {
+			hasCheckpoint: jest.fn( ( id: string ) => id === 'second-cp' ),
+		} );
+		const firstHook = jest.fn( () => firstReturn );
+		const secondHook = jest.fn( () => secondReturn );
+		setAgentsManagerData( {
+			agentProviders: [ { useCheckpoint: firstHook }, { useCheckpoint: secondHook } ],
+		} );
+
+		const providers = await loadExternalProviders();
+		const checkpoint = providers.useCheckpoint?.();
+
+		expect( firstHook ).toHaveBeenCalled();
+		expect( secondHook ).toHaveBeenCalled();
+		expect( checkpoint?.hasCheckpoint( 'second-cp' ) ).toBe( true );
+		await checkpoint?.restoreCheckpoint( 'second-cp' );
+		expect( secondReturn.restoreCheckpoint ).toHaveBeenCalledWith( 'second-cp' );
+		expect( firstReturn.restoreCheckpoint ).not.toHaveBeenCalled();
+		checkpoint?.clearCheckpoint( 'second-cp' );
+		expect( secondReturn.clearCheckpoint ).toHaveBeenCalledWith( 'second-cp' );
+		expect( firstReturn.clearCheckpoint ).not.toHaveBeenCalled();
+
+		expect( checkpoint?.hasCheckpoint( 'missing-cp' ) ).toBe( false );
+		await checkpoint?.restoreCheckpoint( 'missing-cp' );
+		expect( firstReturn.restoreCheckpoint ).not.toHaveBeenCalled();
+		expect( secondReturn.restoreCheckpoint ).toHaveBeenCalledTimes( 1 );
+
+		expect( checkpoint?.getLastEditorState() ).toBe( 'first-editor-state' );
+		checkpoint?.setCheckpoint( 'new-cp', [ 'title' ] );
+		expect( firstReturn.setCheckpoint ).toHaveBeenCalledWith( 'new-cp', [ 'title' ] );
+		expect( secondReturn.setCheckpoint ).not.toHaveBeenCalled();
+	} );
+
+	it( 'passes a single provider checkpoint hook through unchanged', async () => {
+		const hook = jest.fn( () => createCheckpointReturn() );
+		setAgentsManagerData( {
+			agentProviders: [ { useCheckpoint: hook } ],
+		} );
+
+		const providers = await loadExternalProviders();
+
+		expect( providers.useCheckpoint ).toBe( hook );
+	} );
+
+	it( 'leaves useCheckpoint undefined when no provider exports one', async () => {
+		setAgentsManagerData( {
+			agentProviders: [ { getEmptyViewSuggestions: () => [] } ],
+		} );
+
+		const providers = await loadExternalProviders();
+
+		expect( providers.useCheckpoint ).toBeUndefined();
 	} );
 } );
 

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -687,10 +687,7 @@ describe( 'loadExternalProviders', () => {
 	it( 'uses the first provider for onTaskUpdate', async () => {
 		const firstOnTaskUpdate = jest.fn();
 		setAgentsManagerData( {
-			agentProviders: [
-				{ onTaskUpdate: firstOnTaskUpdate },
-				{ onTaskUpdate: jest.fn() },
-			],
+			agentProviders: [ { onTaskUpdate: firstOnTaskUpdate }, { onTaskUpdate: jest.fn() } ],
 		} );
 
 		const providers = await loadExternalProviders();

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -3,7 +3,13 @@ import { EscalationButton } from '../components/escalation-button';
 import isAmAbilitiesDisabled from './is-am-abilities-disabled';
 import lazyComponent from './lazy-component';
 import { isShowComponentTool } from './show-component-tools';
-import { getDisplayMessageFromToolData, isDisplayableToolMessageTool } from './tool-message-utils';
+import {
+	APPLY_BLOCK_EDITS_TOOL_ID,
+	getApplyBlockEditsOutcome,
+	getDisplayMessageFromToolData,
+	isBlockEditToolId,
+	isDisplayableToolMessageTool,
+} from './tool-message-utils';
 import type { GetChatComponent } from './load-external-providers';
 import type { ShowComponentType } from '../abilities/show-component';
 import type { UIMessage } from '@automattic/agenttic-client';
@@ -143,6 +149,68 @@ function hasLaterAgentToolMessageInSameTurn(
 	return false;
 }
 
+function hasLaterApplyBlockEditsOutcome(
+	messages: UIMessage[],
+	currentIndex: number,
+	toolCallId: string
+): boolean {
+	for ( const laterMessage of messages.slice( currentIndex + 1 ) ) {
+		if ( laterMessage.role === 'user' ) {
+			return false;
+		}
+
+		const laterText = laterMessage.content?.[ 0 ]?.text;
+		if ( ! hasAgentRole( laterMessage ) || ! laterText ) {
+			continue;
+		}
+
+		try {
+			const laterData = JSON.parse( laterText );
+			if (
+				laterData?.tool_call_id === toolCallId &&
+				getApplyBlockEditsOutcome( laterData.tool_id, laterData.data )
+			) {
+				return true;
+			}
+		} catch ( _error ) {}
+	}
+
+	return false;
+}
+
+function followsTerminalApplyBlockEditsOutcome(
+	messages: UIMessage[],
+	currentIndex: number
+): boolean {
+	for ( let index = currentIndex - 1; index >= 0; index-- ) {
+		const earlierMessage = messages[ index ];
+		if ( earlierMessage.role === 'user' ) {
+			return false;
+		}
+
+		const earlierText = earlierMessage.content?.[ 0 ]?.text;
+		if ( ! hasAgentRole( earlierMessage ) || ! earlierText ) {
+			continue;
+		}
+
+		try {
+			const earlierData = JSON.parse( earlierText );
+			if ( typeof earlierData?.tool_id !== 'string' ) {
+				continue;
+			}
+
+			return (
+				!! getApplyBlockEditsOutcome( earlierData.tool_id, earlierData.data ) &&
+				earlierData.data?.followUpTasks !== true
+			);
+		} catch ( _error ) {
+			return false;
+		}
+	}
+
+	return false;
+}
+
 /**
  * Converts tool-related messages to component messages.
  */
@@ -195,7 +263,7 @@ export default function convertToolMessagesToComponents( {
 		try {
 			textData = JSON.parse( firstContentText );
 		} catch ( _error ) {
-			return [ message ];
+			return followsTerminalApplyBlockEditsOutcome( array, index ) ? [] : [ message ];
 		}
 
 		if (
@@ -203,7 +271,7 @@ export default function convertToolMessagesToComponents( {
 			textData === null ||
 			typeof textData.tool_id !== 'string'
 		) {
-			return [ message ];
+			return followsTerminalApplyBlockEditsOutcome( array, index ) ? [] : [ message ];
 		}
 
 		// Handle `show-component` tool message
@@ -291,10 +359,40 @@ export default function convertToolMessagesToComponents( {
 				return [];
 			}
 
-			const summary = getDisplayMessageFromToolData( textData.data );
-			if ( ! summary ) {
+			const blockEditOutcome = getApplyBlockEditsOutcome( textData.tool_id, textData.data );
+			const isLegacySuccessfulApplyBlockEditsResult =
+				textData.tool_id === APPLY_BLOCK_EDITS_TOOL_ID && textData.data?.result?.success === true;
+			if (
+				isBlockEditToolId( textData.tool_id ) &&
+				! blockEditOutcome &&
+				! isLegacySuccessfulApplyBlockEditsResult
+			) {
 				return [];
 			}
+			const summary = getDisplayMessageFromToolData( textData.data );
+			if ( ! summary && blockEditOutcome !== 'no-changes' ) {
+				return [];
+			}
+			if (
+				typeof textData.tool_call_id === 'string' &&
+				hasLaterApplyBlockEditsOutcome( array, index, textData.tool_call_id )
+			) {
+				return [];
+			}
+			const content =
+				blockEditOutcome === 'no-changes'
+					? [
+							{
+								type: 'text' as const,
+								text: __( '✓ No changes needed', __i18n_text_domain__ ),
+							},
+					  ]
+					: [
+							{
+								type: 'text' as const,
+								text: summary as string,
+							},
+					  ];
 
 			// Tool summaries with follow-up tasks are intermediate status updates. When
 			// rehydrating history, a later tool message in the same user turn (for example,
@@ -311,12 +409,7 @@ export default function convertToolMessagesToComponents( {
 				{
 					...message,
 					suppressThinking: true,
-					content: [
-						{
-							type: 'text' as const,
-							text: summary,
-						},
-					],
+					content,
 				},
 			];
 		}

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -238,6 +238,59 @@ export function mergeUseSuggestionsHooks(
 	};
 }
 
+/**
+ * Merge provider checkpoint hooks. Each provider owns its own checkpoint store,
+ * so id-based lookups must search every loaded provider. Other methods keep
+ * delegating to the first provider to preserve the previous behavior.
+ */
+export function mergeUseCheckpointHooks(
+	hooks: UseCheckpointHook[]
+): UseCheckpointHook | undefined {
+	if ( hooks.length === 0 ) {
+		return undefined;
+	}
+
+	if ( hooks.length === 1 ) {
+		return hooks[ 0 ];
+	}
+
+	return () => {
+		const instances: Array< Partial< UseCheckpointReturn > | undefined > = hooks.map( ( hook ) =>
+			hook()
+		);
+		const first = instances[ 0 ];
+		const findOwner = ( id: string ) =>
+			instances.find( ( instance ) => instance?.hasCheckpoint?.( id ) );
+
+		return {
+			hasCheckpoint: ( id: string ) =>
+				instances.some( ( instance ) => instance?.hasCheckpoint?.( id ) ),
+			restoreCheckpoint: async ( id: string ) => {
+				await findOwner( id )?.restoreCheckpoint?.( id );
+			},
+			clearCheckpoint: ( id: string ) => {
+				for ( const instance of instances ) {
+					if ( instance?.hasCheckpoint?.( id ) ) {
+						instance.clearCheckpoint?.( id );
+					}
+				}
+			},
+			getLastEditorState: () => first?.getLastEditorState?.(),
+			setCheckpoint: ( id: string, keys?: string[] ) => first?.setCheckpoint?.( id, keys ),
+			addCheckpointKeys: ( id: string, keys: string[] ) => first?.addCheckpointKeys?.( id, keys ),
+			addNewPageToCheckpoint: ( pageId: string ) => first?.addNewPageToCheckpoint?.( pageId ),
+			addPageRenameToCheckpoint: ( pageId: string, oldTitle: string, newTitle: string ) =>
+				first?.addPageRenameToCheckpoint?.( pageId, oldTitle, newTitle ),
+			addPageRemovalToCheckpoint: (
+				pageId: string,
+				pageTitle: string,
+				options?: { shouldRestoreNavigation?: boolean }
+			) => first?.addPageRemovalToCheckpoint?.( pageId, pageTitle, options ),
+			getLatestUserMessageId: () => first?.getLatestUserMessageId?.(),
+		};
+	};
+}
+
 function isRecord( value: unknown ): value is Record< string, unknown > {
 	return typeof value === 'object' && value !== null;
 }
@@ -533,7 +586,6 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	let mergedAbilitiesSetup: AbilitiesSetupHook | undefined;
 	let mergedGetChatComponent: GetChatComponent | undefined;
 	let mergedSiteBuildUtils: SiteBuildUtils | undefined;
-	let mergedUseCheckpoint: UseCheckpointHook | undefined;
 	let mergedOnTaskUpdate: LoadedProviders[ 'onTaskUpdate' ] | undefined;
 	// OR-merged across all providers.
 	const mergedCapabilities: ProviderCapabilities = {};
@@ -551,6 +603,7 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	const allAbilitiesSetups: AbilitiesSetupHook[] = [];
 	const allUseSuggestions: UseSuggestionsHook[] = [];
 	const allGetEmptyViewSuggestions: ( () => Suggestion[] )[] = [];
+	const allUseCheckpoints: UseCheckpointHook[] = [];
 	const allProviderIds: string[] = [];
 
 	// Load all providers in parallel to avoid serializing network/module fetches.
@@ -607,6 +660,9 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		if ( module.getEmptyViewSuggestions ) {
 			allGetEmptyViewSuggestions.push( module.getEmptyViewSuggestions );
 		}
+		if ( module.useCheckpoint ) {
+			allUseCheckpoints.push( module.useCheckpoint );
+		}
 		if ( module.contextProvider ) {
 			allContextProviders.push( module.contextProvider );
 		}
@@ -623,9 +679,6 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		}
 		if ( module.siteBuildUtils && ! mergedSiteBuildUtils ) {
 			mergedSiteBuildUtils = module.siteBuildUtils;
-		}
-		if ( module.useCheckpoint && ! mergedUseCheckpoint ) {
-			mergedUseCheckpoint = module.useCheckpoint;
 		}
 		if ( module.onTaskUpdate && ! mergedOnTaskUpdate ) {
 			mergedOnTaskUpdate = module.onTaskUpdate;
@@ -735,6 +788,9 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 
 	// Merge useSuggestions: combine from all providers, dedupe by id.
 	const mergedUseSuggestions = mergeUseSuggestionsHooks( allUseSuggestions );
+
+	// Merge useCheckpoint: run every provider's hook, search all stores by id.
+	const mergedUseCheckpoint = mergeUseCheckpointHooks( allUseCheckpoints );
 
 	// Merge getEmptyViewSuggestions: combine from all providers, dedupe by id.
 	if ( allGetEmptyViewSuggestions.length === 1 ) {

--- a/packages/agents-manager/src/utils/tool-message-utils.ts
+++ b/packages/agents-manager/src/utils/tool-message-utils.ts
@@ -1,5 +1,11 @@
+export const APPLY_BLOCK_EDITS_TOOL_ID = 'big_sky__apply_block_edits';
+export const UPDATE_BLOCK_CONTENT_TOOL_ID = 'wpcom__update_block_content';
+
+const BLOCK_EDIT_TOOL_IDS = new Set( [ APPLY_BLOCK_EDITS_TOOL_ID, UPDATE_BLOCK_CONTENT_TOOL_ID ] );
+
 const DISPLAYABLE_TOOL_MESSAGE_TOOL_IDS = new Set( [
-	'big_sky__apply_block_edits',
+	APPLY_BLOCK_EDITS_TOOL_ID,
+	UPDATE_BLOCK_CONTENT_TOOL_ID,
 	'big_sky__apply_update_theme',
 	'big_sky__edit_entity_record',
 	'big_sky__set_site_logo',
@@ -35,4 +41,42 @@ export function getDisplayMessageFromToolData( data: unknown ): string | undefin
 	}
 
 	return undefined;
+}
+
+export type ApplyBlockEditsOutcome = 'updated' | 'no-changes';
+
+export function isBlockEditToolId( toolId: unknown ): boolean {
+	return typeof toolId === 'string' && BLOCK_EDIT_TOOL_IDS.has( toolId );
+}
+
+export function getApplyBlockEditsOutcome(
+	toolId: unknown,
+	data: unknown
+): ApplyBlockEditsOutcome | undefined {
+	if ( ! isBlockEditToolId( toolId ) || typeof data !== 'object' || data === null ) {
+		return undefined;
+	}
+
+	const toolData = data as {
+		calypsoCheckpointId?: unknown;
+		result?: {
+			success?: unknown;
+			outcome?: unknown;
+		};
+	};
+	const result = toolData.result;
+
+	if ( result && typeof result === 'object' && result.success === true ) {
+		return result.outcome === 'updated' || result.outcome === 'no-changes'
+			? result.outcome
+			: undefined;
+	}
+
+	// Older tool results predate the structured result, but only include a
+	// checkpoint when an edit was applied.
+	return toolId === APPLY_BLOCK_EDITS_TOOL_ID &&
+		typeof toolData.calypsoCheckpointId === 'string' &&
+		toolData.calypsoCheckpointId
+		? 'updated'
+		: undefined;
 }

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -2927,6 +2927,7 @@ describe( 'toolProvider', () => {
 	} );
 
 	afterEach( () => {
+		jest.useRealTimers();
 		delete ( globalThis as any ).agentsManagerData;
 		delete ( window as any ).wp;
 	} );
@@ -3007,6 +3008,42 @@ describe( 'toolProvider', () => {
 			] );
 			expect( blocks[ '550e8400-e29b-41d4-a716-446655440000' ].attributes.content ).toBe(
 				'original block content'
+			);
+			checkpoint.clearCheckpoint( 'call-update-block' );
+		} );
+
+		it( 'surfaces a failed block checkpoint restore', async () => {
+			jest.useFakeTimers();
+			const { blockUpdates, blocks } = installWpDataMockWithBlockEditor();
+			const checkpoint = useCheckpoint();
+			const abilities = await toolProvider.getAbilities();
+			const updateBlock = abilities.find(
+				( ability: any ) => ability.name === 'wpcom/update-block-content'
+			);
+
+			const pending = updateBlock.callback( {
+				clientId: '550e8400-e29b-41d4-a716-446655440000',
+				content: 'Corrected block content.',
+				summary: 'Corrected the grammar in the selected paragraph.',
+				toolCallId: 'call-update-block',
+				toolId: UPDATE_BLOCK_CONTENT_TOOL_ID,
+			} );
+			jest.advanceTimersByTime( 1000 );
+			await pending;
+
+			blocks[ '550e8400-e29b-41d4-a716-446655440000' ].attributes.content = 'A later block edit.';
+
+			await expect( checkpoint.restoreCheckpoint( 'call-update-block' ) ).rejects.toThrow(
+				'Failed to restore block edit checkpoint.'
+			);
+			expect( blockUpdates ).toEqual( [
+				{
+					clientId: '550e8400-e29b-41d4-a716-446655440000',
+					attrs: { content: 'Corrected block content.' },
+				},
+			] );
+			expect( blocks[ '550e8400-e29b-41d4-a716-446655440000' ].attributes.content ).toBe(
+				'A later block edit.'
 			);
 			checkpoint.clearCheckpoint( 'call-update-block' );
 		} );

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -2969,7 +2969,7 @@ describe( 'toolProvider', () => {
 			const pending = updateBlock.callback( {
 				clientId: '550e8400-e29b-41d4-a716-446655440000',
 				content: 'Corrected block content.',
-				summary: 'Corrected the grammar in the selected paragraph.',
+				summary: 'Changed "stuffs" to "stuff".',
 				toolCallId: 'call-update-block',
 				toolId: UPDATE_BLOCK_CONTENT_TOOL_ID,
 			} );
@@ -2987,7 +2987,7 @@ describe( 'toolProvider', () => {
 				data: {
 					result: {
 						success: true,
-						message: 'Corrected the grammar in the selected paragraph.',
+						message: 'Changed "stuffs" to "stuff".',
 						outcome: 'updated',
 					},
 					followUpTasks: false,
@@ -3024,7 +3024,7 @@ describe( 'toolProvider', () => {
 			const pending = updateBlock.callback( {
 				clientId: '550e8400-e29b-41d4-a716-446655440000',
 				content: 'Corrected block content.',
-				summary: 'Corrected the grammar in the selected paragraph.',
+				summary: 'Changed "stuffs" to "stuff".',
 				toolCallId: 'call-update-block',
 				toolId: UPDATE_BLOCK_CONTENT_TOOL_ID,
 			} );
@@ -3060,7 +3060,7 @@ describe( 'toolProvider', () => {
 			const pending = updateBlock.callback( {
 				clientId: '550e8400-e29b-41d4-a716-446655440000',
 				content: 'original block content',
-				summary: 'Proofread the selected paragraph.',
+				summary: 'No changes were needed.',
 				toolCallId: 'call-no-block-change',
 				toolId: UPDATE_BLOCK_CONTENT_TOOL_ID,
 			} );
@@ -3082,6 +3082,20 @@ describe( 'toolProvider', () => {
 			} );
 			expect( blockUpdates ).toEqual( [] );
 			expect( checkpoint.hasCheckpoint( 'call-no-block-change' ) ).toBe( false );
+		} );
+
+		it( 'documents the completed-edit summary contract in the update-block-content schema', async () => {
+			const abilities = await toolProvider.getAbilities();
+			const updateBlock = abilities.find( ( a: any ) => a.name === 'wpcom/update-block-content' );
+			const summaryDescription = updateBlock?.input_schema?.properties?.summary?.description;
+
+			expect( updateBlock ).toBeDefined();
+			expect( summaryDescription ).toContain( 'concrete completed edit' );
+			expect( summaryDescription ).toContain( 'language of the current user message' );
+			expect( summaryDescription ).toContain( 'name the exact corrections' );
+			expect( summaryDescription ).toContain( 'Changed "stuffs" to "stuff".' );
+			expect( summaryDescription ).toContain( 'no changes were needed' );
+			expect( summaryDescription ).not.toContain( 'brief user-friendly description' );
 		} );
 
 		it( 'delegates non-Jetpack legacy show-component callbacks to Big Sky', async () => {

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -60,6 +60,7 @@ let mockBlocksByClientId: Record< string, any > = {};
 let mockEditorBlocks: any[] = [];
 const SHOW_COMPONENT_TOOL_ID = 'jetpack_ai__show_component';
 const LEGACY_SHOW_COMPONENT_TOOL_ID = 'big_sky__show_component';
+const UPDATE_BLOCK_CONTENT_TOOL_ID = 'wpcom__update_block_content';
 const SHOW_COMPONENT_ABILITY_NAME = 'jetpack-ai/show-component';
 const LEGACY_SHOW_COMPONENT_ABILITY_NAME = 'big-sky/show-component';
 
@@ -2175,6 +2176,7 @@ describe( 'useSuggestions', () => {
 	} );
 
 	afterEach( () => {
+		jest.useRealTimers();
 		delete ( globalThis as any ).agentsManagerData;
 		delete ( window as any ).wp;
 	} );
@@ -2952,6 +2954,97 @@ describe( 'toolProvider', () => {
 			expect( typeof showComponent?.callback ).toBe( 'function' );
 			expect( typeof legacyShowComponent?.callback ).toBe( 'function' );
 			expect( typeof updateBlock?.callback ).toBe( 'function' );
+		} );
+
+		it( 'emits an updated outcome with a restorable block checkpoint', async () => {
+			jest.useFakeTimers();
+			const { blockUpdates, blocks } = installWpDataMockWithBlockEditor();
+			const checkpoint = useCheckpoint();
+			const abilities = await toolProvider.getAbilities();
+			const updateBlock = abilities.find(
+				( ability: any ) => ability.name === 'wpcom/update-block-content'
+			);
+
+			const pending = updateBlock.callback( {
+				clientId: '550e8400-e29b-41d4-a716-446655440000',
+				content: 'Corrected block content.',
+				summary: 'Corrected the grammar in the selected paragraph.',
+				toolCallId: 'call-update-block',
+				toolId: UPDATE_BLOCK_CONTENT_TOOL_ID,
+			} );
+			jest.advanceTimersByTime( 1000 );
+			const result = await pending;
+
+			expect( result ).toMatchObject( {
+				success: true,
+				outcome: 'updated',
+				returnToAgent: false,
+			} );
+			expect( JSON.parse( result.agentMessage ) ).toEqual( {
+				tool_id: UPDATE_BLOCK_CONTENT_TOOL_ID,
+				tool_call_id: 'call-update-block',
+				data: {
+					result: {
+						success: true,
+						message: 'Corrected the grammar in the selected paragraph.',
+						outcome: 'updated',
+					},
+					followUpTasks: false,
+				},
+			} );
+			expect( checkpoint.hasCheckpoint( 'call-update-block' ) ).toBe( true );
+
+			await checkpoint.restoreCheckpoint( 'call-update-block' );
+			expect( blockUpdates ).toEqual( [
+				{
+					clientId: '550e8400-e29b-41d4-a716-446655440000',
+					attrs: { content: 'Corrected block content.' },
+				},
+				{
+					clientId: '550e8400-e29b-41d4-a716-446655440000',
+					attrs: { content: 'original block content' },
+				},
+			] );
+			expect( blocks[ '550e8400-e29b-41d4-a716-446655440000' ].attributes.content ).toBe(
+				'original block content'
+			);
+			checkpoint.clearCheckpoint( 'call-update-block' );
+		} );
+
+		it( 'emits a no-change outcome without mutating or checkpointing the block', async () => {
+			jest.useFakeTimers();
+			const { blockUpdates } = installWpDataMockWithBlockEditor();
+			const checkpoint = useCheckpoint();
+			const abilities = await toolProvider.getAbilities();
+			const updateBlock = abilities.find(
+				( ability: any ) => ability.name === 'wpcom/update-block-content'
+			);
+
+			const pending = updateBlock.callback( {
+				clientId: '550e8400-e29b-41d4-a716-446655440000',
+				content: 'original block content',
+				summary: 'Proofread the selected paragraph.',
+				toolCallId: 'call-no-block-change',
+				toolId: UPDATE_BLOCK_CONTENT_TOOL_ID,
+			} );
+			jest.advanceTimersByTime( 1000 );
+			const result = await pending;
+			const agentMessage = JSON.parse( result.agentMessage );
+
+			expect( result ).toMatchObject( {
+				success: true,
+				outcome: 'no-changes',
+				returnToAgent: false,
+			} );
+			expect( agentMessage ).toMatchObject( {
+				tool_id: UPDATE_BLOCK_CONTENT_TOOL_ID,
+				tool_call_id: 'call-no-block-change',
+				data: {
+					result: { success: true, outcome: 'no-changes' },
+				},
+			} );
+			expect( blockUpdates ).toEqual( [] );
+			expect( checkpoint.hasCheckpoint( 'call-no-block-change' ) ).toBe( false );
 		} );
 
 		it( 'delegates non-Jetpack legacy show-component callbacks to Big Sky', async () => {

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -45,6 +45,7 @@ import {
 	rememberSelectedBlock,
 	clearRememberedSelectedBlock,
 	notifyBlockActionComplete,
+	undoBlockEdit,
 	BLOCK_ACTION_COMPLETE_EVENT,
 	SELECTED_BLOCK_CLEAR_EVENT,
 } from './utils/block-actions';
@@ -83,6 +84,15 @@ let wasAgentProcessing = false;
 let pendingBlockShimmerClientId: string | null = null;
 let blockShimmerStartedForRequest = false;
 let suppressCurrentPageContentForNextContext = false;
+
+type BlockEditSnapshot = {
+	clientId: string;
+	contentBefore: string;
+	contentAfter: string;
+	editableAttribute?: string;
+};
+
+const blockEditSnapshots = new Map< string, BlockEditSnapshot >();
 
 /** Whether `_suggestion_rendered` has fired this page life (once-per-session). */
 let suggestionRenderedFiredOnce = false;
@@ -397,6 +407,7 @@ function applySuggestionLimit< T extends { id: string } >(
 
 const SHOW_COMPONENT_TOOL_ID = 'jetpack_ai__show_component';
 const LEGACY_SHOW_COMPONENT_TOOL_ID = 'big_sky__show_component';
+const UPDATE_BLOCK_CONTENT_AGENT_TOOL_ID = 'wpcom__update_block_content';
 const SHOW_COMPONENT_ABILITY_NAME = 'jetpack-ai/show-component';
 const LEGACY_SHOW_COMPONENT_ABILITY_NAME = 'big-sky/show-component';
 const SHOW_COMPONENT_TOOL_IDS = [ SHOW_COMPONENT_TOOL_ID, LEGACY_SHOW_COMPONENT_TOOL_ID ];
@@ -631,6 +642,73 @@ function isLegacyShowComponentTool( toolId: string ): boolean {
 	return toolId === LEGACY_SHOW_COMPONENT_TOOL_ID || toolId === LEGACY_SHOW_COMPONENT_ABILITY_NAME;
 }
 
+async function handleUpdateBlockContentForChat( input: any ): Promise< any > {
+	const toolCallId =
+		typeof input?.toolCallId === 'string' && input.toolCallId ? input.toolCallId : undefined;
+	const result = await handleUpdateBlockContent( input );
+	if ( result?.success !== true ) {
+		if ( toolCallId ) {
+			blockEditSnapshots.delete( toolCallId );
+		}
+		return result;
+	}
+
+	const outcome =
+		typeof result.contentBefore === 'string' &&
+		typeof result.contentAfter === 'string' &&
+		result.contentBefore === result.contentAfter
+			? 'no-changes'
+			: 'updated';
+
+	if ( toolCallId ) {
+		if (
+			outcome === 'updated' &&
+			typeof result.clientId === 'string' &&
+			typeof result.contentBefore === 'string' &&
+			typeof result.contentAfter === 'string'
+		) {
+			blockEditSnapshots.set( toolCallId, {
+				clientId: result.clientId,
+				contentBefore: result.contentBefore,
+				contentAfter: result.contentAfter,
+				...( typeof result.editableAttribute === 'string' && {
+					editableAttribute: result.editableAttribute,
+				} ),
+			} );
+		} else {
+			blockEditSnapshots.delete( toolCallId );
+		}
+	}
+
+	let message = typeof input?.summary === 'string' ? input.summary.trim() : '';
+	if ( ! message ) {
+		message =
+			outcome === 'updated'
+				? __( 'Updated the selected block.', __i18n_text_domain__ )
+				: __( 'No changes were needed.', __i18n_text_domain__ );
+	}
+	const agentMessage = toolCallId
+		? JSON.stringify( {
+				tool_id: UPDATE_BLOCK_CONTENT_AGENT_TOOL_ID,
+				tool_call_id: toolCallId,
+				data: {
+					result: {
+						success: true,
+						message,
+						outcome,
+					},
+					followUpTasks: false,
+				},
+		  } )
+		: result.agentMessage;
+
+	return {
+		...result,
+		outcome,
+		...( agentMessage && { agentMessage } ),
+	};
+}
+
 export const toolProvider = {
 	/**
 	 * Client-side abilities this provider handles: `wpcom/update-block-content`
@@ -663,7 +741,7 @@ export const toolProvider = {
 				? [
 						{
 							...UPDATE_BLOCK_CONTENT_ABILITY,
-							callback: handleUpdateBlockContent,
+							callback: handleUpdateBlockContentForChat,
 						},
 				  ]
 				: [] ),
@@ -688,8 +766,12 @@ export const toolProvider = {
 	 */
 	async executeAbility( name: string, args: any ): Promise< any > {
 		if ( isUpdateBlockContentTool( name ) ) {
-			const result = await handleUpdateBlockContent( args );
-			return { result, returnToAgent: false };
+			const result = await handleUpdateBlockContentForChat( args );
+			return {
+				result,
+				returnToAgent: false,
+				...( result.agentMessage && { agentMessage: result.agentMessage } ),
+			};
 		}
 
 		if ( isLegacyShowComponentTool( name ) && shouldDelegateLegacyShowComponent( args ) ) {
@@ -847,13 +929,13 @@ export function getChatComponent( type: string ): ComponentType | null {
 
 /**
  * Provider hook consumed by AM's `use-checkpoint-action` so Undo buttons
- * can attach to show-component messages. Snapshots the selected top-level
- * post fields (title by default, excerpt for the excerpt picker) on
+ * can attach to show-component and block-edit messages. Snapshots the selected
+ * top-level post fields (title by default, excerpt for the excerpt picker) on
  * `setCheckpoint(id, fields)` and restores exactly those fields on
  * `restoreCheckpoint(id)` via `core/editor` dispatch — restoring one picker's
- * checkpoint must not clobber another field's later edits. Only title and
- * excerpt are supported: meta (SEO pickers) and block-attribute (image alt
- * text) changes are not checkpointed. Stubs the rest of AM's
+ * checkpoint must not clobber another field's later edits. Block-edit snapshots
+ * are captured by `handleUpdateBlockContentForChat`; meta (SEO pickers) and
+ * image alt text changes are not checkpointed. Stubs the rest of AM's
  * `UseCheckpointReturn` interface — only the three methods above are used on
  * this path.
  * @returns {Object} The checkpoint API AM consumes.
@@ -871,9 +953,20 @@ export function useCheckpoint(): any {
 			postSnapshots.set( id, snapshot );
 		},
 		hasCheckpoint( id: string ): boolean {
-			return postSnapshots.has( id );
+			return postSnapshots.has( id ) || blockEditSnapshots.has( id );
 		},
 		async restoreCheckpoint( id: string ): Promise< void > {
+			const blockEditSnapshot = blockEditSnapshots.get( id );
+			if ( blockEditSnapshot ) {
+				undoBlockEdit(
+					blockEditSnapshot.clientId,
+					blockEditSnapshot.contentBefore,
+					blockEditSnapshot.contentAfter,
+					blockEditSnapshot.editableAttribute
+				);
+				return;
+			}
+
 			const previous = postSnapshots.get( id );
 			if ( previous === undefined ) {
 				return;
@@ -888,7 +981,7 @@ export function useCheckpoint(): any {
 
 	// Return the full shape AM's UseCheckpointReturn expects. Methods we
 	// don't implement are safe no-op stubs — AM only calls the three above
-	// for the show-component / title-picker flow.
+	// for the show-component and block-edit flows.
 	return {
 		...api,
 		getLastEditorState: () => null,
@@ -899,6 +992,7 @@ export function useCheckpoint(): any {
 		getLatestUserMessageId: () => undefined,
 		clearCheckpoint: ( id: string ) => {
 			postSnapshots.delete( id );
+			blockEditSnapshots.delete( id );
 		},
 	};
 }

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -958,12 +958,15 @@ export function useCheckpoint(): any {
 		async restoreCheckpoint( id: string ): Promise< void > {
 			const blockEditSnapshot = blockEditSnapshots.get( id );
 			if ( blockEditSnapshot ) {
-				undoBlockEdit(
+				const didRestore = undoBlockEdit(
 					blockEditSnapshot.clientId,
 					blockEditSnapshot.contentBefore,
 					blockEditSnapshot.contentAfter,
 					blockEditSnapshot.editableAttribute
 				);
+				if ( ! didRestore ) {
+					throw new Error( 'Failed to restore block edit checkpoint.' );
+				}
 				return;
 			}
 

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -807,6 +807,23 @@ export function handleUpdateBlockContent( input: any ): any {
 				return;
 			}
 
+			if ( nextContent === latestSnapshot.content ) {
+				if ( blockEl ) {
+					removeProcessingEffect( blockEl );
+				}
+				notifyBlockActionComplete();
+				resolve( {
+					success: true,
+					clientId: targetClientId,
+					contentBefore: latestSnapshot.content,
+					contentAfter: nextContent,
+					editableAttribute: latestSnapshot.attributeName,
+					returnToAgent: false,
+					...( summary ? { agentMessage: summary } : {} ),
+				} );
+				return;
+			}
+
 			try {
 				blockEditor.updateBlockAttributes( targetClientId, {
 					[ latestSnapshot.attributeName ]: nextContent,

--- a/packages/jetpack-ai-sidebar/src/utils/tool-provider.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tool-provider.ts
@@ -32,7 +32,8 @@ export const UPDATE_BLOCK_CONTENT_ABILITY: Tool = {
 			},
 			summary: {
 				type: 'string',
-				description: 'A brief user-friendly description of what was changed.',
+				description:
+					'A concise confirmation of the concrete completed edit, in the language of the current user message. For spelling or grammar changes, name the exact corrections when they fit in one sentence; if there are too many, state the count. For example: Changed "stuffs" to "stuff". Never merely restate the request, scope, or action category. If the text is unchanged, say that no changes were needed.',
 			},
 			currentText: {
 				type: 'string',


### PR DESCRIPTION
Part of FORNO-451

<img width="355" height="234" alt="Screenshot 2026-08-05 at 16 47 28" src="https://github.com/user-attachments/assets/82e29525-17a8-4a88-ba02-fd487c56ca4e" />
<img width="302" height="266" alt="Screenshot 2026-08-05 at 16 48 01" src="https://github.com/user-attachments/assets/6672fa33-0eae-411f-9454-06f93707bc55" />
<img width="315" height="179" alt="Screenshot 2026-08-11 at 17 22 30" src="https://github.com/user-attachments/assets/0aac30d6-5ead-4d2c-a155-ccc54242b2c3" />

## Proposed Changes

* Render only authoritative post-execution outcomes for block-edit tools: a concrete summary for applied edits and `No changes needed` for a true no-op.
* Show applied edits as a green `Updated` status with adjacent `Undo`, while keeping feedback and Copy actions on the following row.
* Give the Jetpack `update-block-content` client ability a restorable block snapshot and structured `updated` / `no-changes` result.
* Require the model-facing `update-block-content` summary to name concrete spelling or grammar corrections, follow the request language, and report when no changes were needed.
* Compose provider checkpoint hooks so Undo resolves through the provider that owns the tool-call checkpoint, while preserving legacy Big Sky checkpoint messages.

## Why are these changes being made?

* A requested edit summary describes what the model asked the client to do, not whether the editor actually changed. Rendering it before execution could make a no-op look successful.
* Gutenberg sessions without the Big Sky rewrite ability use `wpcom/update-block-content` and render its summary directly. The old schema only asked for a brief description, so a real `stuffs` to `stuff` correction could still show `Corrected spelling and grammar in the selected paragraph.`
* On editor surfaces with multiple providers, Agents Manager kept only the first checkpoint hook. A later provider could apply an edit but its checkpoint could not be found, so Updated and Undo did not render.
* This keeps outcome rendering tied to explicit tool results instead of guessing from generated prose. The paired WPCOM prompt change remains responsible for clean grammar checks that do not invoke an edit tool.
* #112370 contains overlapping multi-provider checkpoint composition for picker Undo. Whichever PR lands second should rebase and keep one shared composition implementation.

## Testing Instructions

* Run:
  `yarn test-packages packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts packages/jetpack-ai-sidebar/src/index.test.ts --runInBand --no-watchman`
  * 5 suites and 321 tests pass.
* Run `yarn workspace @automattic/jetpack-ai-sidebar typecheck`.
* Run focused ESLint, Stylelint, Prettier, and `git diff --check` for the changed files.
* Run `yarn workspace @automattic/agents-manager-app build`.
* Confirm the built sidebar provider contains `concrete completed edit` and no longer contains `A brief user-friendly description of what was changed.`
* In the post editor, apply a selected-block grammar edit. Confirm the response names the exact correction, followed by one green Updated status and a working Undo; thumbs up/down and Copy appear on the next row.
* Click Undo and confirm the block returns to its pre-edit content and the restored draft saves.
* Submit a block edit whose explicit provider outcome is `no-changes`. Confirm `No changes needed` appears with no Undo.
* Reload the conversation and confirm session-only Undo is not rendered as a dead action.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks/useMemo) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Related

* Big Sky PR 6233.
* WPCOM PR 233020.