### PR TITLE
Purchases: read the renewal click handlers from api-core

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -54,6 +54,8 @@ export type ResolveDomainStatusOptionsBag = {
 
 export function resolveDomainStatus(
 	domain: ResponseDomain,
+	// Temporary bridge (SHILL-2256): callers still pass the camelCase Purchase,
+	// so the renewal handlers below are given `purchase.rawPurchase`.
 	purchase: Purchase | null = null,
 	translate: I18N[ 'translate' ],
 	dispatch: CalypsoDispatch,
@@ -320,7 +322,9 @@ export function resolveDomainStatus(
 											a: (
 												<Button
 													plain
-													onClick={ () => dispatch( handleRenewNowClick( purchase, siteSlug ) ) }
+													onClick={ () =>
+														dispatch( handleRenewNowClick( purchase.rawPurchase, siteSlug ) )
+													}
 												/>
 											),
 										},
@@ -349,7 +353,9 @@ export function resolveDomainStatus(
 											a: (
 												<Button
 													plain
-													onClick={ () => dispatch( handleRenewNowClick( purchase, siteSlug ) ) }
+													onClick={ () =>
+														dispatch( handleRenewNowClick( purchase.rawPurchase, siteSlug ) )
+													}
 												/>
 											),
 										},
@@ -402,7 +408,9 @@ export function resolveDomainStatus(
 									a: (
 										<Button
 											plain
-											onClick={ () => dispatch( handleRenewNowClick( purchase, siteSlug ) ) }
+											onClick={ () =>
+												dispatch( handleRenewNowClick( purchase.rawPurchase, siteSlug ) )
+											}
 										/>
 									),
 								},

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -33,6 +33,7 @@ import { encodeProductForUrl } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
 import i18n, { type TranslateResult } from 'i18n-calypso';
 import moment from 'moment';
+import { isMarketplaceHoldingSitePurchase as isRawMarketplaceHoldingSitePurchase } from 'calypso/dashboard/utils/purchase';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getRenewalItemFromProduct } from 'calypso/lib/cart-values/cart-items';
@@ -44,6 +45,7 @@ import {
 } from 'calypso/me/purchases/utils';
 import { errorNotice } from 'calypso/state/notices/actions';
 import type { Purchase } from './types';
+import type { Purchase as RawPurchase } from '@automattic/api-core';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type {
@@ -348,17 +350,20 @@ export function getSubscriptionEndDate( purchase: Purchase ): string {
  * @param {Object} [options.tracksProps] - where was the renew button clicked from
  */
 export function handleRenewNowClick(
-	purchase: Purchase,
+	purchase: RawPurchase,
 	siteSlug: string,
 	options: { redirectTo?: string; cancelTo?: string; tracksProps?: TracksProps } = {}
 ) {
 	return ( dispatch: CalypsoDispatch ) => {
 		try {
-			const renewItem = getRenewalItemFromProduct( purchase, { domain: purchase.meta } );
+			const renewItem = getRenewalItemFromProduct(
+				{ ...purchase, id: Number( purchase.ID ), isRenewable: purchase.is_renewable },
+				{ domain: purchase.meta }
+			);
 
 			// Track the renew now submit.
 			recordTracksEvent( 'calypso_purchases_renew_now_click', {
-				product_slug: purchase.productSlug,
+				product_slug: purchase.product_slug,
 				...options.tracksProps,
 			} );
 
@@ -374,7 +379,7 @@ export function handleRenewNowClick(
 
 			if ( isAkismetProduct( { product_slug: productSlugs[ 0 ] } ) ) {
 				serviceSlug = 'akismet/';
-			} else if ( isMarketplaceHoldingSitePurchase( purchase ) ) {
+			} else if ( isRawMarketplaceHoldingSitePurchase( purchase ) ) {
 				serviceSlug = 'marketplace/';
 			}
 
@@ -406,7 +411,7 @@ export function handleRenewNowClick(
  * @param {Object} [options.tracksProps] - where was the renew button clicked from
  */
 export function handleRenewMultiplePurchasesClick(
-	purchases: Purchase[],
+	purchases: RawPurchase[],
 	siteSlug: string,
 	options: { redirectTo?: string; tracksProps?: TracksProps } = {}
 ) {
@@ -415,15 +420,20 @@ export function handleRenewMultiplePurchasesClick(
 			purchases.forEach( ( purchase ) => {
 				// Track the renew now submit.
 				recordTracksEvent( 'calypso_purchases_renew_multiple_click', {
-					product_slug: purchase.productSlug,
+					product_slug: purchase.product_slug,
 					...options.tracksProps,
 				} );
 			} );
 
 			const renewItems = purchases.map( ( otherPurchase ) =>
-				getRenewalItemFromProduct( otherPurchase, {
-					domain: otherPurchase.meta,
-				} )
+				getRenewalItemFromProduct(
+					{
+						...otherPurchase,
+						id: Number( otherPurchase.ID ),
+						isRenewable: otherPurchase.is_renewable,
+					},
+					{ domain: otherPurchase.meta }
+				)
 			);
 			const { productSlugs, purchaseIds } = getProductSlugsAndPurchaseIds( renewItems );
 

--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -291,11 +291,11 @@ describe( 'index', () => {
 
 	describe( '#handleRenewNowClick', () => {
 		const purchase = {
-			id: 1,
-			currencyCode: 'USD',
-			expiryDate: '2020-05-20T00:00:00+00:00',
-			productSlug: 'personal-bundle',
-			productName: 'Personal Plan',
+			ID: 1,
+			currency_code: 'USD',
+			expiry_date: '2020-05-20T00:00:00+00:00',
+			product_slug: 'personal-bundle',
+			product_name: 'Personal Plan',
 			amount: 100,
 		};
 		const siteSlug = 'my-site.wordpress.com';
@@ -329,7 +329,7 @@ describe( 'index', () => {
 		describe( 'when the purchase id does not exist', () => {
 			test( 'should report error', () => {
 				const dispatch = jest.fn();
-				handleRenewNowClick( { ...purchase, id: null }, siteSlug )( dispatch );
+				handleRenewNowClick( { ...purchase, ID: null }, siteSlug )( dispatch );
 				expect( dispatch ).toHaveBeenCalledWith(
 					expect.objectContaining( {
 						notice: expect.objectContaining( {
@@ -344,7 +344,7 @@ describe( 'index', () => {
 		describe( 'when the product slug does not exist', () => {
 			test( 'should report error', () => {
 				const dispatch = jest.fn();
-				handleRenewNowClick( { ...purchase, productSlug: '' }, siteSlug )( dispatch );
+				handleRenewNowClick( { ...purchase, product_slug: '' }, siteSlug )( dispatch );
 				expect( dispatch ).toHaveBeenCalledWith(
 					expect.objectContaining( {
 						notice: expect.objectContaining( {
@@ -359,11 +359,11 @@ describe( 'index', () => {
 
 	describe( '#handleRenewNowClickSiteless', () => {
 		const purchase = {
-			id: 1,
-			currencyCode: 'USD',
-			expiryDate: '2020-05-20T00:00:00+00:00',
-			productSlug: 'ak_plus_yearly_1',
-			productName: 'Akismet Plus',
+			ID: 1,
+			currency_code: 'USD',
+			expiry_date: '2020-05-20T00:00:00+00:00',
+			product_slug: 'ak_plus_yearly_1',
+			product_name: 'Akismet Plus',
 			amount: 100,
 		};
 
@@ -380,21 +380,21 @@ describe( 'index', () => {
 	describe( '#handleRenewMultiplePurchasesClick', () => {
 		const purchases = [
 			{
-				id: 1,
-				currencyCode: 'USD',
-				expiryDate: '2020-05-20T00:00:00+00:00',
-				productSlug: 'personal-bundle',
-				productName: 'Personal Plan',
+				ID: 1,
+				currency_code: 'USD',
+				expiry_date: '2020-05-20T00:00:00+00:00',
+				product_slug: 'personal-bundle',
+				product_name: 'Personal Plan',
 				amount: 100,
 			},
 			{
-				id: 2,
-				currencyCode: 'USD',
-				expiryDate: '2020-05-15T00:00:00+00:00',
-				productSlug: 'dotlive_domain',
+				ID: 2,
+				currency_code: 'USD',
+				expiry_date: '2020-05-15T00:00:00+00:00',
+				product_slug: 'dotlive_domain',
 				meta: 'personalsitetest1234.live',
-				productName: 'DotLive Domain Registration',
-				isDomainRegistration: true,
+				product_name: 'DotLive Domain Registration',
+				is_domain_registration: true,
 				amount: 200,
 			},
 		];
@@ -409,7 +409,7 @@ describe( 'index', () => {
 		describe( 'when the none of the purchase ids exist', () => {
 			test( 'should report error', () => {
 				const dispatch = jest.fn();
-				const purchasesWithoutId = purchases.map( ( purchase ) => ( { ...purchase, id: null } ) );
+				const purchasesWithoutId = purchases.map( ( purchase ) => ( { ...purchase, ID: null } ) );
 				handleRenewMultiplePurchasesClick( purchasesWithoutId, siteSlug )( dispatch );
 				expect( dispatch ).toHaveBeenCalledWith(
 					expect.objectContaining( {
@@ -425,7 +425,7 @@ describe( 'index', () => {
 		describe( 'when at least one purchase can be renewed', () => {
 			test( 'should redirect to checkout with only the valid purchases to renew', () => {
 				const dispatch = jest.fn();
-				const purchasesPartiallyValid = [ purchases[ 1 ], { ...purchases[ 0 ], id: null } ];
+				const purchasesPartiallyValid = [ purchases[ 1 ], { ...purchases[ 0 ], ID: null } ];
 				handleRenewMultiplePurchasesClick( purchasesPartiallyValid, siteSlug )( dispatch );
 				expect( page ).toHaveBeenCalledWith(
 					'/checkout/dotlive_domain:personalsitetest1234.live/renew/2/my-site.wordpress.com'

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -301,13 +301,7 @@ class ManagePurchase extends Component<
 			isA4AHoldingSitePurchase( purchase );
 
 		// If this renewal is for a siteless purchase, we'll drop the site slug
-		// Temporary bridge (SHILL-2256): handleRenewNowClick still expects the
-		// camelCase Purchase. Remove once it reads the raw shape.
-		this.props.handleRenewNowClick(
-			createPurchaseObject( purchase as unknown as Parameters< typeof createPurchaseObject >[ 0 ] ),
-			! isSitelessRenewal ? siteSlug : '',
-			options
-		);
+		this.props.handleRenewNowClick( purchase, ! isSitelessRenewal ? siteSlug : '', options );
 	};
 
 	handleRenewMonthly = () => {
@@ -332,15 +326,7 @@ class ManagePurchase extends Component<
 	handleRenewMultiplePurchases = ( purchases: Purchase[] ) => {
 		const { siteSlug, redirectTo } = this.props;
 		const options = redirectTo ? { redirectTo } : undefined;
-		// Temporary bridge (SHILL-2256): handleRenewMultiplePurchasesClick still
-		// expects the camelCase Purchase. Remove once it reads the raw shape.
-		this.props.handleRenewMultiplePurchasesClick(
-			purchases.map( ( p ) =>
-				createPurchaseObject( p as unknown as Parameters< typeof createPurchaseObject >[ 0 ] )
-			),
-			siteSlug,
-			options
-		);
+		this.props.handleRenewMultiplePurchasesClick( purchases, siteSlug, options );
 	};
 
 	isPendingDomainRegistration( purchase: Purchase ): boolean {

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -103,7 +103,6 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSelectedDomain, resolveDomainStatus } from 'calypso/lib/domains';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { handleRenewMultiplePurchasesClick, handleRenewNowClick } from 'calypso/lib/purchases';
-import { createPurchaseObject } from 'calypso/lib/purchases/assembler';
 import { hasCustomDomain } from 'calypso/lib/site/utils';
 import { addQueryArgs } from 'calypso/lib/url';
 import ProductLink from 'calypso/me/purchases/product-link';

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -53,7 +53,6 @@ import {
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { handleRenewNowClick } from 'calypso/lib/purchases';
-import { createPurchaseObject } from 'calypso/lib/purchases/assembler';
 import {
 	getDisplayName,
 	isExpiredOrRemoved,
@@ -433,19 +432,11 @@ function UrgentExpiryStatus( {
 					// listing page can run on other hosts like Jetpack Cloud and A4A.
 					const backUrl = window.location.href;
 					dispatch(
-						// Temporary bridge (SHILL-2256): handleRenewNowClick still expects
-						// the camelCase Purchase. Remove once it reads the raw shape.
-						handleRenewNowClick(
-							createPurchaseObject(
-								purchase as unknown as Parameters< typeof createPurchaseObject >[ 0 ]
-							),
-							purchase.site_slug ?? '',
-							{
-								redirectTo: backUrl,
-								cancelTo: backUrl,
-								tracksProps: { position: 'purchase-list' },
-							}
-						)
+						handleRenewNowClick( purchase, purchase.site_slug ?? '', {
+							redirectTo: backUrl,
+							cancelTo: backUrl,
+							tracksProps: { position: 'purchase-list' },
+						} )
 					);
 				} }
 			>

--- a/client/me/purchases/site-level-actions/index.tsx
+++ b/client/me/purchases/site-level-actions/index.tsx
@@ -56,7 +56,9 @@ export default function SiteActionInterstitial( {
 			return;
 		}
 		if ( purchase ) {
-			dispatch( handleRenewMultiplePurchasesClick( [ purchase ], siteSlug ) );
+			// Temporary bridge (SHILL-2256): this page still reads the camelCase
+			// Purchase from Redux. Remove once it reads the raw shape.
+			dispatch( handleRenewMultiplePurchasesClick( [ purchase.rawPurchase ], siteSlug ) );
 		} else {
 			page( managePurchase( siteSlug, String( purchaseId ) ) );
 		}
@@ -141,7 +143,12 @@ export default function SiteActionInterstitial( {
 	const handleContinue = () => {
 		const selectedPurchases = purchases.filter( ( p ) => selectedIds.has( p.id ) );
 		if ( actionType === 'renew' ) {
-			dispatch( handleRenewMultiplePurchasesClick( selectedPurchases, siteSlug ) );
+			dispatch(
+				handleRenewMultiplePurchasesClick(
+					selectedPurchases.map( ( p ) => p.rawPurchase ),
+					siteSlug
+				)
+			);
 			return;
 		}
 		const intent = actionType;

--- a/client/my-sites/domains/domain-management/edit/card/renew-button/index.tsx
+++ b/client/my-sites/domains/domain-management/edit/card/renew-button/index.tsx
@@ -69,7 +69,13 @@ function RenewButton( {
 	}
 
 	function handleRenew() {
-		dispatch( handleRenewNowClick( purchase as Purchase, selectedSite.slug, { tracksProps } ) );
+		// Temporary bridge (SHILL-2256): this component still receives the
+		// camelCase Purchase. Remove once it takes the raw shape.
+		dispatch(
+			handleRenewNowClick( ( purchase as Purchase ).rawPurchase, selectedSite.slug, {
+				tracksProps,
+			} )
+		);
 	}
 
 	return (

--- a/client/my-sites/domains/domain-management/list/use-purchase-actions.ts
+++ b/client/my-sites/domains/domain-management/list/use-purchase-actions.ts
@@ -42,7 +42,9 @@ export const usePurchaseActions = () => {
 			( p ) => p.id === parseInt( domain.subscriptionId ?? '', 10 )
 		);
 		if ( purchase ) {
-			dispatch( handleRenewNowClick( purchase, siteSlug ) );
+			// Temporary bridge (SHILL-2256): this hook still reads the camelCase
+			// Purchase from Redux. Remove once it reads the raw shape.
+			dispatch( handleRenewNowClick( purchase.rawPurchase, siteSlug ) );
 		}
 	};
 

--- a/client/my-sites/email/email-management/home/email-plan/index.jsx
+++ b/client/my-sites/email/email-management/home/email-plan/index.jsx
@@ -144,7 +144,9 @@ function EmailPlan( {
 		event.preventDefault();
 
 		dispatch(
-			handleRenewNowClick( purchase, selectedSite.slug, {
+			// Temporary bridge (SHILL-2256): this page still reads the camelCase
+			// Purchase from Redux. Remove once it reads the raw shape.
+			handleRenewNowClick( purchase.rawPurchase, selectedSite.slug, {
 				tracksProps: { source: 'email-plan-view' },
 			} )
 		);


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-2256/

## Proposed changes

This converts the two renewal click handlers in `client/lib/purchases` — `handleRenewNowClick` and `handleRenewMultiplePurchasesClick` — to take the raw snake_case `Purchase` from `@automattic/api-core` instead of the assembled camelCase one, which removes three of the four remaining `createPurchaseObject` bridges in `client/me/purchases`.

* Type both renewal handlers with the api-core `Purchase`; read `product_slug` for the Tracks props, and coerce `Number( purchase.ID )` plus `isRenewable: purchase.is_renewable` when building the renewal cart item.
* Source `isMarketplaceHoldingSitePurchase` from `calypso/dashboard/utils/purchase` (the raw version) for the siteless renewal URL; the camelCase import stays for the other consumers in that file.
* Drop the temporary bridges in `manage-purchase/index.tsx` (renew now + renew multiple) and `purchase-item/index.tsx`, which already hold raw purchases — `purchase-item` no longer imports the assembler at all.
* Bridge the five call sites that still read camelCase purchases out of Redux by passing `purchase.rawPurchase`: `site-level-actions`, `renew-button`, `use-purchase-actions`, `email-plan`, and `resolve-domain-status`.
* Update the renewal handler fixtures in `client/lib/purchases/test/index.js` to the raw shape.

## Why are these changes being made?

SHILL-2256 is removing the data-stores purchases assembler so consumers read the raw `Purchase` object directly. The work is going page by page, and each slice either converts a leaf component or a shared helper. The renewal handlers were the last shared helper standing between three already-converted callers and their raw data, so converting them deletes three `createPurchaseObject` calls instead of relocating them.

`getRenewalItemFromProduct` still wants a camelCase `id` and `isRenewable`, so the handlers adapt those two fields at the call site rather than widening the shared checkout helper. The `Number()` coercion on `ID` matters: raw purchase IDs can arrive as strings, the assembler used to coerce them, and TypeScript can't catch it because api-core types the field as `number`. A string ID silently breaks cart dedup in checkout.

The five remaining callers still get their purchases from the camelCase Redux selectors, so they hand over `purchase.rawPurchase` — the same one-line bridge used for the cancel-form callers in earlier slices. Those bridges disappear when each of those pages moves off `getByPurchaseId` / `getUserPurchases`.

After this, the only `createPurchaseObject` calls left in app code are the `ProductPlanOverlapNotices` bridge in `manage-purchase` and the root assembly point in `getPurchases`.

## Testing instructions

TC:
```
yarn test-client client/lib/purchases client/me/purchases
```

Manual testing:
* On a site with at least one expiring or expired subscription, go to `/me/purchases`.
* Click the expiry link on a purchase in the list — confirm you land on `/checkout/<product>/renew/<purchase id>/<site slug>` with a `redirect_to` back to the list, and that the cart shows the renewal.
* Open a purchase's management page and use **Renew now** — confirm the same checkout URL, and that the purchase ID in the URL is the numeric ID.
* Repeat with a siteless purchase (Akismet or a Marketplace plugin) and confirm the URL keeps its `akismet/` or `marketplace/` segment and drops the site slug.
* From the purchase management page, use **Renew all** on a site with multiple expiring purchases — confirm every purchase lands in the cart with comma-separated slugs and IDs.
* From Domains → a domain's settings, use the **Renew now** button, and from the email management page for a Titan or Google Workspace subscription, use its renew action — both should reach checkout with the right product.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
