### PR TITLE
Prefer Playground onboarding when Blueprint parameters are retained

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -100,6 +100,7 @@ const onboarding: FlowV2< typeof initialize > = {
 		const { setShouldShowNotification } = usePurchasePlanNotification();
 
 		const playgroundId = queryParams.get( 'playground' );
+		const blueprintArchiveSlug = playgroundId ? null : blueprint;
 
 		/**
 		 * Returns [destination, backDestination] for the post-checkout destination.
@@ -127,12 +128,12 @@ const onboarding: FlowV2< typeof initialize > = {
 				// setup-your-site-ai chooser. Land on the AI site-spec, which kicks off
 				// the background transfer-to-Atomic + blueprint-archive import and, on
 				// confirm, polls the import and redirects to the Atomic Site Editor.
-				if ( blueprint ) {
+				if ( blueprintArchiveSlug ) {
 					return [
 						getBlueprintArchiveSiteSpecUrl( {
 							siteSlug: providedDependencies.siteSlug as string,
 							siteId: providedDependencies.siteId as number,
-							blueprintSlug: blueprint,
+							blueprintSlug: blueprintArchiveSlug,
 							ref: refParameter,
 						} ),
 						null,
@@ -421,7 +422,7 @@ const onboarding: FlowV2< typeof initialize > = {
 								addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
 									// Blueprint archive flow goes straight from checkout to the AI
 									// site-spec (no post-checkout-onboarding hop, no chooser).
-									redirect_to: blueprint ? destination : redirectTo,
+									redirect_to: blueprintArchiveSlug ? destination : redirectTo,
 									signup: 1,
 									flow: ONBOARDING_FLOW,
 									checkoutBackUrl: pathToUrl( backDestination ?? '' ),
@@ -436,7 +437,7 @@ const onboarding: FlowV2< typeof initialize > = {
 						} else if ( diyLaunchpad ) {
 							// The diy-launchpad cohort skips the AI/manual chooser and lands straight in Site Setup.
 							window.location.replace( destination );
-						} else if ( blueprint ) {
+						} else if ( blueprintArchiveSlug ) {
 							// Blueprint archive flow never shows the setup-your-site-ai chooser;
 							// go straight to the AI site-spec destination.
 							window.location.replace( destination );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-plans-intent.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-plans-intent.ts
@@ -38,15 +38,15 @@ export function getPlansIntent( flowName: string | null ): PlansIntent | null {
 		case AI_SITE_BUILDER_ONBOARDING_FLOW:
 			return 'plans-ai-assembler-paid-only';
 		case ONBOARDING_FLOW:
+			if ( search.has( 'playground' ) ) {
+				return playgroundPlansIntent( search.get( 'playground' )! );
+			}
 			// The blueprint variation (/setup/onboarding/blueprint) offers paid plans
 			// only — Personal, Premium, Business, Commerce — to match the blueprint
 			// archive it builds from. Reuse the AI-site-builder intent purely for that
 			// plan-tier set (it carries no other AI-assembler behavior).
 			if ( search.has( 'blueprint' ) ) {
 				return 'plans-ai-assembler-paid-only';
-			}
-			if ( search.has( 'playground' ) ) {
-				return playgroundPlansIntent( search.get( 'playground' )! );
 			}
 			if ( search.get( 'ref' ) === WOO_HOSTING_SOLUTIONS_REF ) {
 				return 'plans-woo-hosting-solutions';


### PR DESCRIPTION
## Proposed Changes

* Give the Playground onboarding flow (`/setup/onboarding/playground/`) precedence when both `playground` and `blueprint` query parameters are present.
* Resolve the Playground-specific plan intent before the generic Blueprint archive plan intent.
* Preserve the existing Blueprint archive routing when no Playground ID is present.

## Why are these changes being made?

* Playground onboarding retains the Blueprint Library ID used to initialize the site after generating a Playground ID. The Blueprint archive flow treated the retained `blueprint` parameter as authoritative, so checkout redirected these sites to the AI site specification flow instead of the Playground importer.
* Using the presence of `playground` to distinguish the flows lets saved Playground sites reach their export/import step while leaving standalone Blueprint archive onboarding unchanged.

## Testing Instructions

1. Start Calypso locally and open `/setup/onboarding/playground?blueprint=945`.
2. Wait for Playground to load and confirm the URL gains a `playground=<UUID>` parameter while retaining `blueprint=945`.
3. Click **Launch on WordPress.com**, select a plan, and complete checkout.
4. Verify checkout redirects to the Playground site-setup importer rather than `ai-site-builder-spec`.
5. Verify the Playground export/import process starts.
6. As a control, start the standalone Blueprint archive flow with a `blueprint` parameter but no `playground` parameter and verify it still uses the Blueprint archive destination.
7. Run `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client`.

Manual verification: the Playground onboarding flow reached the Playground importer after checkout.

Automated verification: `yarn typecheck-client` passes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g. browsers), interfaces (e.g. keyboard navigation), and assistive technologies (e.g. screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md), [Memoizing](https://react-redux.js.org/api/hooks#using-memoizing-selectors), and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?