### PR TITLE
Dashboard dark mode: fix activity type filter dropdown legibility (DOTMSD-1383)

### DIFF
--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -520,4 +520,5 @@
 	@include color-scheme-dark-theme-site-icon;
 	@include dashboard-dark-theme-site-logs-badges;
 	@include color-scheme-dark-theme-summary-button;
+	@include color-scheme-dark-theme-dataviews-filters-search-widget;
 }

--- a/client/lib/color-scheme/dark-theme.scss
+++ b/client/lib/color-scheme/dark-theme.scss
@@ -879,3 +879,57 @@ This mixin generates alias variables for a color palette. For example, the
 		--color-neutral-20: var( --dashboard__text-muted-color );
 	}
 }
+
+// The DataViews filter dropdown ("search widget") comes from the
+// @wordpress/dataviews package, whose CSS prefers --wpds-* tokens with
+// light-only fallbacks. Those tokens are not defined here, so hovered rows
+// fall back to a near-white color-mix and the radio/checkbox indicators to
+// light-mode borders and backgrounds.
+@mixin color-scheme-dark-theme-dataviews-filters-search-widget {
+	.dataviews-filters__search-widget-listitem {
+		color: var( --dashboard__text-color );
+
+		&:hover,
+		&[data-active-item],
+		&:focus {
+			background-color: var( --dashboard-item-selected__background-color );
+		}
+
+		.dataviews-filters__search-widget-listitem-description {
+			color: var( --dashboard-subtle__color );
+		}
+
+		// Scoped to unselected indicators so the accent fill on selected
+		// ones still wins.
+		.dataviews-filters__search-widget-listitem-single-selection:not( .is-selected, :checked ),
+		.dataviews-filters__search-widget-listitem-multi-selection:not( .is-selected, :checked ) {
+			border-color: var( --dashboard-field__border-color );
+			background: var( --dashboard-surface__background-color );
+		}
+	}
+
+	.dataviews-filters__search-widget-filter-combobox-list {
+		border-top-color: var( --dashboard-surface__border-color );
+	}
+
+	.dataviews-filters__search-widget-filter-combobox__wrapper
+		.dataviews-filters__search-widget-filter-combobox__input {
+		&:focus {
+			background: var( --dashboard-surface__background-color );
+		}
+
+		&::placeholder {
+			color: var( --dashboard-subtle__color );
+		}
+	}
+
+	.dataviews-filters__summary-operators-container:has( + .dataviews-filters__search-widget-listbox ),
+	.dataviews-filters__summary-operators-container:has( + .dataviews-filters__search-widget-no-elements ),
+	.dataviews-filters__summary-operators-container:has( + .dataviews-filters__user-input-widget ) {
+		border-bottom-color: var( --dashboard-surface__border-color );
+	}
+
+	.dataviews-filters__summary-operators-container .dataviews-filters__summary-operators-filter-name {
+		color: var( --dashboard-subtle__color );
+	}
+}


### PR DESCRIPTION
Fixes DOTMSD-1383

## Proposed Changes

* In dark mode, hovering a row in the Activity Log's activity type filter dropdown turned the row near-white while the text stayed light, so you couldn't read it. The dropdown is `@wordpress/dataviews`' internal search widget, and its package CSS falls back to light-only values (a `color-mix(... 12%, white)` hover, a `#1e1e1e` radio border, white indicator and search-input backgrounds) because the `--wpds-*` tokens it prefers aren't defined in Calypso.
* Adds a `color-scheme-dark-theme-dataviews-filters-search-widget` mixin to `client/lib/color-scheme/dark-theme.scss` covering the list item hover/active/focus background, item and description text, unselected radio/checkbox borders and backgrounds, the search input's focus background and placeholder, and the popover's internal divider borders. Included from `dashboard-dark-theme` in `client/dashboard/app/_dark-theme.scss`.
* Uses the same tokens the existing dataviews dark mixin already uses (`--dashboard-item-selected__background-color`, `--dashboard__text-color`, `--dashboard-subtle__color`, `--dashboard-field__border-color`, `--dashboard-surface__border-color`). No new colors.

## Why are these changes being made?

* The existing dark overrides for DataViews stop at the table, chips, and filter toggle. Nothing covers the search widget popover, so the package's light fallbacks win and the filter is unreadable in dark mode. This is the smallest override that makes it legible without touching the package or the existing mixin bodies.

## Testing Instructions

1. Run `yarn start-dashboard` and open a site with Activity Log access at `/sites/<site>/logs/activity`.
2. Enable dark mode (debug menu in the bottom-right, Preferences, set `hosting-dashboard-color-scheme` to `dark`, per docs/dark-mode.md).
3. Open the activity type filter above the log list and hover the options.
4. Rows should show a subtle accent hover with readable text, the radio/checkbox indicators should be visible against the dark popover, and selecting an option should still show the accent-filled indicator.
5. Check light mode is unchanged (the overrides only apply under `data-theme='dark'`).

Static verification only so far (stylelint passes); I haven't eyeballed the dropdown in a running dashboard yet, so screenshots to follow.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
