### PR TITLE
Dashboard: fix sidebar text AA contrast (DOTMSD-1472)

### DIFF
--- a/client/dashboard/app-a4a/style.scss
+++ b/client/dashboard/app-a4a/style.scss
@@ -26,7 +26,7 @@
 	--dashboard-header__divider-color: #{$gray-200};
 
 	// Menu
-	--dashboard-menu-item__color: #{$gray-700};
+	--dashboard-menu-item__color: var( --wpds-color-fg-interactive-neutral-weak, #707070 );
 	--dashboard-menu-item-active__color: #{$gray-900};
 
 	// Headings

--- a/client/dashboard/app-ciab/style.scss
+++ b/client/dashboard/app-ciab/style.scss
@@ -37,7 +37,7 @@
 	--dashboard-header__divider-color: #{$gray-900};
 
 	// Menu
-	--dashboard-menu-item__color: #{$gray-700};
+	--dashboard-menu-item__color: var( --wpds-color-fg-interactive-neutral-weak, #707070 );
 	--dashboard-menu-item-active__color: #{$gray-900};
 
 	// Headings

--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -39,7 +39,7 @@
 	--dashboard-header__divider-color: #{$gray-200};
 
 	// Menu
-	--dashboard-menu-item__color: #{$gray-700};
+	--dashboard-menu-item__color: var( --wpds-color-fg-interactive-neutral-weak, #707070 );
 	--dashboard-menu-item-active__color: #{$gray-900};
 
 	// Headings


### PR DESCRIPTION
Fixes DOTMSD-1472

## Proposed Changes

* Change `--dashboard-menu-item__color` from `$gray-700` (#757575) to `var( --wpds-color-fg-interactive-neutral-weak, #707070 )` in all three dashboard variants (dotcom, CIAB, A4A).

## Why are these changes being made?

Sidebar text (back button and every menu item, on every page) renders #757575 on the #fcfcfc sidebar background. That is a 4.49:1 contrast ratio, just under the 4.5:1 WCAG AA minimum for body text. The new value is #707070, which measures 4.83:1 on #fcfcfc and passes.

On the token choice: the dashboard already loads the prebuilt WPDS token sheet, and there were two candidate tokens with the same light value (#707070). I went with `fg-interactive-neutral-weak` over `fg-content-neutral-weak` because menu items are interactive, and the interactive family carries state variants (active, disabled, strong) that the content family doesn't. When the runtime ThemeProvider lands this should keep resolving to the same token family rather than needing another migration, though the generated values will need a re-check at that point. The hex fallback keeps the fix working anywhere the token sheet isn't loaded.

The active menu color is untouched. It stays `$gray-900` (#1e1e1e), which is the same value as the `fg-interactive-neutral` base token, so rest and active states now map onto weak and base of one token family.

One caveat: CIAB's sidebar sits on `$gray-100` (#f0f0f0), where #707070 measures 4.35:1. That improves on the current 4.04:1 but still misses AA. Passing there needs either a darker text value that diverges from the token or a lighter CIAB background, which felt like a separate design call rather than something to bundle in here.

## Testing Instructions

1. Run `yarn start-dashboard` and open `http://my.localhost:3000/sites`.
2. In light mode, inspect any sidebar menu item. Computed color should be `rgb(112, 112, 112)` instead of `rgb(117, 117, 117)`.
3. Check the sidebar text against the background with any contrast checker: #707070 on #fcfcfc should read 4.83:1 (was #757575 at 4.49:1).
4. Navigate into a site to confirm the back button and nested menu items pick up the same color, and that the active item still renders in the accent blue.
5. Switch to dark mode and confirm the sidebar is unchanged (dark mode overrides this variable separately with #bdbdbd).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
