### PR TITLE
Signup form: an email-only mode for a caller changing an address

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -6,7 +6,7 @@ import { debounce } from '@wordpress/compose';
 import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { Component, cloneElement, isValidElement } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 import { ActionButtons } from 'calypso/components/connect-screen/action-buttons';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -45,9 +45,6 @@ class PasswordlessSignupForm extends Component {
 			submit: PropTypes.func.isRequired,
 			cancel: PropTypes.func.isRequired,
 		} ),
-		// Replaces account creation with a change to the account the caller already has, and
-		// reports its own failures.
-		onUpdateEmail: PropTypes.func,
 		useConnectScreenActions: PropTypes.bool,
 	};
 
@@ -79,14 +76,11 @@ class PasswordlessSignupForm extends Component {
 				errorMessages: [ this.props.translate( 'Please provide a valid email address.' ) ],
 				isSubmitting: false,
 			} );
-			this.submitTracksEvent( false, { action_message: 'Please provide a valid email address.' } );
-			return;
-		}
-
-		if ( this.props.onUpdateEmail ) {
-			this.setState( { isSubmitting: true } );
-			await this.props.onUpdateEmail( this.state.email.trim() );
-			this.setState( { isSubmitting: false } );
+			if ( ! this.props.emailUpdate ) {
+				this.submitTracksEvent( false, {
+					action_message: 'Please provide a valid email address.',
+				} );
+			}
 			return;
 		}
 
@@ -344,14 +338,6 @@ class PasswordlessSignupForm extends Component {
 		this.props.onInputBlur?.( event );
 	};
 
-	// The secondary action leaves the screen, and a write already in flight would land anyway.
-	secondaryFooterButton() {
-		const { secondaryFooterButton } = this.props;
-		return this.state.isSubmitting && isValidElement( secondaryFooterButton )
-			? cloneElement( secondaryFooterButton, { disabled: true } )
-			: secondaryFooterButton;
-	}
-
 	renderNotice() {
 		return (
 			<Notice showDismiss={ false } status="is-error">
@@ -380,7 +366,7 @@ class PasswordlessSignupForm extends Component {
 						primaryLoading={ isSubmitting }
 						primaryDisabled={ isPrimaryDisabled }
 					/>
-					{ this.secondaryFooterButton() }
+					{ this.props.secondaryFooterButton }
 				</>
 			);
 		}
@@ -390,7 +376,7 @@ class PasswordlessSignupForm extends Component {
 				<SignupSubmitButton isBusy={ isSubmitting } isDisabled={ isPrimaryDisabled }>
 					{ submitButtonText }
 				</SignupSubmitButton>
-				{ this.secondaryFooterButton() }
+				{ this.props.secondaryFooterButton }
 			</LoggedOutFormFooter>
 		);
 	}
@@ -426,7 +412,7 @@ class PasswordlessSignupForm extends Component {
 						/>
 						{ this.props.children }
 					</ValidationFieldset>
-					{ this.secondaryFooterButton() ? (
+					{ this.props.secondaryFooterButton ? (
 						<>
 							{ this.formFooter() }
 							{ terms }

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -6,7 +6,7 @@ import { debounce } from '@wordpress/compose';
 import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
+import { Component, cloneElement, isValidElement } from 'react';
 import { connect } from 'react-redux';
 import { ActionButtons } from 'calypso/components/connect-screen/action-buttons';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -38,6 +38,13 @@ class PasswordlessSignupForm extends Component {
 		disableTosText: PropTypes.bool,
 		// Names the signup's origin to the backend, which aims the activation link on it.
 		activationEmailFrom: PropTypes.string,
+		// Replaces account creation with a change to the account the caller already has, and
+		// reports its own failures. `cancel` is the only way off the screen it makes, so the two
+		// travel together.
+		emailUpdate: PropTypes.shape( {
+			submit: PropTypes.func.isRequired,
+			cancel: PropTypes.func.isRequired,
+		} ),
 		// Replaces account creation with a change to the account the caller already has, and
 		// reports its own failures.
 		onUpdateEmail: PropTypes.func,
@@ -80,6 +87,19 @@ class PasswordlessSignupForm extends Component {
 			this.setState( { isSubmitting: true } );
 			await this.props.onUpdateEmail( this.state.email.trim() );
 			this.setState( { isSubmitting: false } );
+			return;
+		}
+
+		if ( this.props.emailUpdate ) {
+			this.setState( { isSubmitting: true } );
+			try {
+				await this.props.emailUpdate.submit( this.state.email.trim() );
+			} catch {
+				// The caller reports its own failures. This only keeps one it didn't from leaving
+				// the screen disabled with nothing to press.
+			} finally {
+				this.setState( { isSubmitting: false } );
+			}
 			return;
 		}
 
@@ -324,6 +344,14 @@ class PasswordlessSignupForm extends Component {
 		this.props.onInputBlur?.( event );
 	};
 
+	// The secondary action leaves the screen, and a write already in flight would land anyway.
+	secondaryFooterButton() {
+		const { secondaryFooterButton } = this.props;
+		return this.state.isSubmitting && isValidElement( secondaryFooterButton )
+			? cloneElement( secondaryFooterButton, { disabled: true } )
+			: secondaryFooterButton;
+	}
+
 	renderNotice() {
 		return (
 			<Notice showDismiss={ false } status="is-error">
@@ -352,7 +380,7 @@ class PasswordlessSignupForm extends Component {
 						primaryLoading={ isSubmitting }
 						primaryDisabled={ isPrimaryDisabled }
 					/>
-					{ this.props.secondaryFooterButton }
+					{ this.secondaryFooterButton() }
 				</>
 			);
 		}
@@ -362,7 +390,7 @@ class PasswordlessSignupForm extends Component {
 				<SignupSubmitButton isBusy={ isSubmitting } isDisabled={ isPrimaryDisabled }>
 					{ submitButtonText }
 				</SignupSubmitButton>
-				{ this.props.secondaryFooterButton }
+				{ this.secondaryFooterButton() }
 			</LoggedOutFormFooter>
 		);
 	}
@@ -398,7 +426,7 @@ class PasswordlessSignupForm extends Component {
 						/>
 						{ this.props.children }
 					</ValidationFieldset>
-					{ this.props.secondaryFooterButton ? (
+					{ this.secondaryFooterButton() ? (
 						<>
 							{ this.formFooter() }
 							{ terms }

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -38,6 +38,9 @@ class PasswordlessSignupForm extends Component {
 		disableTosText: PropTypes.bool,
 		// Names the signup's origin to the backend, which aims the activation link on it.
 		activationEmailFrom: PropTypes.string,
+		// Replaces account creation with a change to the account the caller already has, and
+		// reports its own failures.
+		onUpdateEmail: PropTypes.func,
 		useConnectScreenActions: PropTypes.bool,
 	};
 
@@ -70,6 +73,13 @@ class PasswordlessSignupForm extends Component {
 				isSubmitting: false,
 			} );
 			this.submitTracksEvent( false, { action_message: 'Please provide a valid email address.' } );
+			return;
+		}
+
+		if ( this.props.onUpdateEmail ) {
+			this.setState( { isSubmitting: true } );
+			await this.props.onUpdateEmail( this.state.email.trim() );
+			this.setState( { isSubmitting: false } );
 			return;
 		}
 

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -6,7 +6,7 @@ import { debounce } from '@wordpress/compose';
 import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
+import { Component, cloneElement, isValidElement } from 'react';
 import { connect } from 'react-redux';
 import { ActionButtons } from 'calypso/components/connect-screen/action-buttons';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -36,15 +36,16 @@ class PasswordlessSignupForm extends Component {
 		onCreateAccountError: PropTypes.func,
 		onCreateAccountSuccess: PropTypes.func,
 		disableTosText: PropTypes.bool,
-		// Names the signup's origin to the backend, which aims the activation link on it.
-		activationEmailFrom: PropTypes.string,
 		// Replaces account creation with a change to the account the caller already has, and
-		// reports its own failures. `cancel` is the only way off the screen it makes, so the two
-		// travel together.
+		// reports its own failures. `cancel` is the way off the screen that leaves in its place,
+		// so the two travel together. Cancel is shut for as long as `submit` is pending — a caller
+		// that waits on anything after the write should resolve first and wait separately.
 		emailUpdate: PropTypes.shape( {
 			submit: PropTypes.func.isRequired,
 			cancel: PropTypes.func.isRequired,
 		} ),
+		// Names the signup's origin to the backend, which aims the activation link on it.
+		activationEmailFrom: PropTypes.string,
 		useConnectScreenActions: PropTypes.bool,
 	};
 
@@ -338,6 +339,13 @@ class PasswordlessSignupForm extends Component {
 		this.props.onInputBlur?.( event );
 	};
 
+	secondaryFooterButton() {
+		const { emailUpdate, secondaryFooterButton } = this.props;
+		return emailUpdate && this.state.isSubmitting && isValidElement( secondaryFooterButton )
+			? cloneElement( secondaryFooterButton, { disabled: true } )
+			: secondaryFooterButton;
+	}
+
 	renderNotice() {
 		return (
 			<Notice showDismiss={ false } status="is-error">
@@ -366,7 +374,7 @@ class PasswordlessSignupForm extends Component {
 						primaryLoading={ isSubmitting }
 						primaryDisabled={ isPrimaryDisabled }
 					/>
-					{ this.props.secondaryFooterButton }
+					{ this.secondaryFooterButton() }
 				</>
 			);
 		}
@@ -376,7 +384,7 @@ class PasswordlessSignupForm extends Component {
 				<SignupSubmitButton isBusy={ isSubmitting } isDisabled={ isPrimaryDisabled }>
 					{ submitButtonText }
 				</SignupSubmitButton>
-				{ this.props.secondaryFooterButton }
+				{ this.secondaryFooterButton() }
 			</LoggedOutFormFooter>
 		);
 	}
@@ -412,7 +420,7 @@ class PasswordlessSignupForm extends Component {
 						/>
 						{ this.props.children }
 					</ValidationFieldset>
-					{ this.props.secondaryFooterButton ? (
+					{ this.secondaryFooterButton() ? (
 						<>
 							{ this.formFooter() }
 							{ terms }

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -6,7 +6,7 @@ import { debounce } from '@wordpress/compose';
 import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { Component, cloneElement, isValidElement } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 import { ActionButtons } from 'calypso/components/connect-screen/action-buttons';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -339,13 +339,6 @@ class PasswordlessSignupForm extends Component {
 		this.props.onInputBlur?.( event );
 	};
 
-	secondaryFooterButton() {
-		const { emailUpdate, secondaryFooterButton } = this.props;
-		return emailUpdate && this.state.isSubmitting && isValidElement( secondaryFooterButton )
-			? cloneElement( secondaryFooterButton, { disabled: true } )
-			: secondaryFooterButton;
-	}
-
 	renderNotice() {
 		return (
 			<Notice showDismiss={ false } status="is-error">
@@ -374,7 +367,7 @@ class PasswordlessSignupForm extends Component {
 						primaryLoading={ isSubmitting }
 						primaryDisabled={ isPrimaryDisabled }
 					/>
-					{ this.secondaryFooterButton() }
+					{ this.props.secondaryFooterButton }
 				</>
 			);
 		}
@@ -384,7 +377,7 @@ class PasswordlessSignupForm extends Component {
 				<SignupSubmitButton isBusy={ isSubmitting } isDisabled={ isPrimaryDisabled }>
 					{ submitButtonText }
 				</SignupSubmitButton>
-				{ this.secondaryFooterButton() }
+				{ this.props.secondaryFooterButton }
 			</LoggedOutFormFooter>
 		);
 	}
@@ -420,7 +413,7 @@ class PasswordlessSignupForm extends Component {
 						/>
 						{ this.props.children }
 					</ValidationFieldset>
-					{ this.secondaryFooterButton() ? (
+					{ this.props.secondaryFooterButton ? (
 						<>
 							{ this.formFooter() }
 							{ terms }

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -37,13 +37,8 @@ class PasswordlessSignupForm extends Component {
 		onCreateAccountSuccess: PropTypes.func,
 		disableTosText: PropTypes.bool,
 		// Replaces account creation with a change to the account the caller already has, and
-		// reports its own failures. `cancel` is the way off the screen that leaves in its place,
-		// so the two travel together. Cancel is shut for as long as `submit` is pending — a caller
-		// that waits on anything after the write should resolve first and wait separately.
-		emailUpdate: PropTypes.shape( {
-			submit: PropTypes.func.isRequired,
-			cancel: PropTypes.func.isRequired,
-		} ),
+		// reports its own failures.
+		onUpdateEmail: PropTypes.func,
 		// Names the signup's origin to the backend, which aims the activation link on it.
 		activationEmailFrom: PropTypes.string,
 		useConnectScreenActions: PropTypes.bool,
@@ -77,7 +72,7 @@ class PasswordlessSignupForm extends Component {
 				errorMessages: [ this.props.translate( 'Please provide a valid email address.' ) ],
 				isSubmitting: false,
 			} );
-			if ( ! this.props.emailUpdate ) {
+			if ( ! this.props.onUpdateEmail ) {
 				this.submitTracksEvent( false, {
 					action_message: 'Please provide a valid email address.',
 				} );
@@ -85,10 +80,10 @@ class PasswordlessSignupForm extends Component {
 			return;
 		}
 
-		if ( this.props.emailUpdate ) {
+		if ( this.props.onUpdateEmail ) {
 			this.setState( { isSubmitting: true } );
 			try {
-				await this.props.emailUpdate.submit( this.state.email.trim() );
+				await this.props.onUpdateEmail( this.state.email.trim() );
 			} catch {
 				// The caller reports its own failures. This only keeps one it didn't from leaving
 				// the screen disabled with nothing to press.

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -56,14 +56,9 @@ interface SignupFormSocialFirst {
 	customTosElement?: JSX.Element;
 	activationEmailFrom?: string;
 	// Replaces account creation with a change to the account the caller already has, making this an
-	// email-only screen: the way back to the social one gives way to `cancel`, and nothing else
-	// offers a second account.
-	emailUpdate?: {
-		submit: ( email: string ) => Promise< void >;
-		cancel: () => void;
-		// A write on its way can't be called back, so the caller shuts this while one is.
-		cancelDisabled?: boolean;
-	};
+	// email-only screen: nothing on it offers a second account. Submitting the address unchanged is
+	// how the caller gets its user back, so there is nothing else to leave by.
+	onUpdateEmail?: ( email: string ) => Promise< void >;
 }
 
 const options = {
@@ -123,20 +118,17 @@ const SignupFormSocialFirst = ( {
 	allowedSocialServices,
 	customTosElement,
 	activationEmailFrom,
-	emailUpdate,
+	onUpdateEmail,
 }: SignupFormSocialFirst ) => {
 	const [ currentStep, setCurrentStep ] = useState< Screen >( userEmail ? 'email' : 'initial' );
 	// No other screen to be on, whatever the caller was given to start from.
-	const visibleStep = emailUpdate ? 'email' : currentStep;
-	// The one legal copy or the other, never both: whichever renders here has to be the one the
-	// form is then told not to render again.
-	const showsPartnerTerms = Boolean( emailUpdate && customTosElement );
+	const visibleStep = onUpdateEmail ? 'email' : currentStep;
 	const { __ } = useI18n();
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 	const isWoo = useSelector( getIsWoo );
 	const isGravatar = isGravatarOAuth2Client( oauth2Client );
 	let submitButtonLoadingLabel;
-	if ( emailUpdate ) {
+	if ( onUpdateEmail ) {
 		submitButtonLoadingLabel = __( 'Updating…' );
 	} else if ( isGravatar ) {
 		submitButtonLoadingLabel = __( 'Continue' );
@@ -183,6 +175,10 @@ const SignupFormSocialFirst = ( {
 	};
 
 	const renderEmailStepTermsOfService = () => {
+		// Partner legal copy is otherwise only on the screen this mode never shows.
+		if ( onUpdateEmail && customTosElement ) {
+			return <p className="signup-form-social-first__email-tos-link">{ customTosElement }</p>;
+		}
 		return (
 			<p className="signup-form-social-first__email-tos-link">
 				{ createInterpolateElement(
@@ -232,22 +228,12 @@ const SignupFormSocialFirst = ( {
 		},
 		onCreateAccountSuccess,
 		inputPlaceholder: isGravatar ? __( 'Enter your email address' ) : undefined,
-		onUpdateEmail: emailUpdate?.submit,
+		onUpdateEmail,
 		submitButtonLoadingLabel,
 	};
 
 	let secondaryFooterButton;
-	if ( emailUpdate ) {
-		secondaryFooterButton = (
-			<Button
-				onClick={ emailUpdate.cancel }
-				disabled={ emailUpdate.cancelDisabled }
-				icon={ chevronLeft }
-			>
-				{ __( 'Cancel' ) }
-			</Button>
-		);
-	} else if ( ! backButtonInFooter ) {
+	if ( ! onUpdateEmail && ! backButtonInFooter ) {
 		secondaryFooterButton = (
 			<Button onClick={ () => setCurrentStep( 'initial' ) } icon={ chevronLeft }>
 				{ __( 'See all options' ) }
@@ -270,7 +256,7 @@ const SignupFormSocialFirst = ( {
 	);
 
 	// This layout has no screens: it puts the social form and the email one on the same page.
-	if ( isMobileCompactVariant && ! emailUpdate ) {
+	if ( isMobileCompactVariant && ! onUpdateEmail ) {
 		// In-form ToS: partner branding wins via customTosElement (rendered by
 		// renderTermsOfService); otherwise the compact "options above" notice.
 		const inFormTosElement = customTosElement ? renderTermsOfService() : <MobileCompactTosNotice />;
@@ -303,7 +289,7 @@ const SignupFormSocialFirst = ( {
 		<div className="signup-form signup-form-social-first">
 			{ /* Not merely hidden: it stacks in the same grid cell, and the email-first variants mount
 			     a second `signup-email` input on it that steals the visible label and the focus. */ }
-			{ ! emailUpdate && (
+			{ ! onUpdateEmail && (
 				<div className={ getVisibilityClassName( 'initial' ) }>
 					{ notice }
 					{ renderTermsOfService() }
@@ -334,17 +320,14 @@ const SignupFormSocialFirst = ( {
 				</div>
 			) }
 			<div className={ getVisibilityClassName( 'email' ) }>
-				{ emailUpdate && notice }
-				{ /* Partner copy points at the options below it, and the form puts what it is given
-				     after the footer whenever there is a secondary action. */ }
-				{ showsPartnerTerms && renderTermsOfService() }
+				{ onUpdateEmail && notice }
 				<div className="signup-form-social-first-email">
 					<PasswordlessSignupForm
 						{ ...passwordlessFormProps }
-						renderTerms={ showsPartnerTerms ? undefined : renderEmailStepTermsOfService }
+						renderTerms={ renderEmailStepTermsOfService }
 						secondaryFooterButton={ secondaryFooterButton }
 					/>
-					{ backButtonInFooter && ! emailUpdate ? (
+					{ backButtonInFooter && ! onUpdateEmail ? (
 						<Button
 							onClick={ () => setCurrentStep( 'initial' ) }
 							className="back-button"

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -298,34 +298,38 @@ const SignupFormSocialFirst = ( {
 
 	return (
 		<div className="signup-form signup-form-social-first">
-			<div className={ getVisibilityClassName( 'initial' ) }>
-				{ ! emailUpdate && notice }
-				{ renderTermsOfService() }
-				{ emailLoginBlock && ! isEmailAtBottom && (
-					<>
-						{ emailLoginBlock }
-						<FormDivider isHorizontal />
-					</>
-				) }
-				<SocialSignupForm
-					handleResponse={ handleSocialResponse }
-					setCurrentStep={ setCurrentStep }
-					socialServiceResponse={ socialServiceResponse }
-					redirectToAfterLoginUrl={ redirectToAfterLoginUrl }
-					disableTosText
-					compact
-					isSocialFirst={ isSocialFirst }
-					shouldShowEmailButton={ ! isEmailFirstVariant }
-					allowedSocialServices={ allowedSocialServices }
-				/>
-				{ emailLoginBlock && isEmailAtBottom && (
-					<>
-						<FormDivider isHorizontal />
-						{ emailLoginBlock }
-					</>
-				) }
-				{ isEmailFirstVariant && loginLinkParagraph }
-			</div>
+			{ /* Not merely hidden: it stacks in the same grid cell, and the email-first variants mount
+			     a second `signup-email` input on it that steals the visible label and the focus. */ }
+			{ ! emailUpdate && (
+				<div className={ getVisibilityClassName( 'initial' ) }>
+					{ notice }
+					{ renderTermsOfService() }
+					{ emailLoginBlock && ! isEmailAtBottom && (
+						<>
+							{ emailLoginBlock }
+							<FormDivider isHorizontal />
+						</>
+					) }
+					<SocialSignupForm
+						handleResponse={ handleSocialResponse }
+						setCurrentStep={ setCurrentStep }
+						socialServiceResponse={ socialServiceResponse }
+						redirectToAfterLoginUrl={ redirectToAfterLoginUrl }
+						disableTosText
+						compact
+						isSocialFirst={ isSocialFirst }
+						shouldShowEmailButton={ ! isEmailFirstVariant }
+						allowedSocialServices={ allowedSocialServices }
+					/>
+					{ emailLoginBlock && isEmailAtBottom && (
+						<>
+							<FormDivider isHorizontal />
+							{ emailLoginBlock }
+						</>
+					) }
+					{ isEmailFirstVariant && loginLinkParagraph }
+				</div>
+			) }
 			<div className={ getVisibilityClassName( 'email' ) }>
 				{ emailUpdate && notice }
 				{ /* Partner copy points at the options below it, and the form puts what it is given

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -55,6 +55,12 @@ interface SignupFormSocialFirst {
 	allowedSocialServices?: SignupAllowedService[];
 	customTosElement?: JSX.Element;
 	activationEmailFrom?: string;
+	// Replaces account creation with a change to the account the caller already has. Its presence
+	// makes this an email-only screen: every route to signing up again is dropped, since taking
+	// one would make the second account the caller is here to avoid.
+	onUpdateEmail?: ( email: string ) => Promise< void >;
+	// Without it there is no way off an email-only screen but submitting it.
+	onCancelEmailUpdate?: () => void;
 }
 
 const options = {
@@ -114,12 +120,21 @@ const SignupFormSocialFirst = ( {
 	allowedSocialServices,
 	customTosElement,
 	activationEmailFrom,
+	onUpdateEmail,
+	onCancelEmailUpdate,
 }: SignupFormSocialFirst ) => {
 	const [ currentStep, setCurrentStep ] = useState< Screen >( userEmail ? 'email' : 'initial' );
+	const isEmailOnly = Boolean( onUpdateEmail );
 	const { __ } = useI18n();
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 	const isWoo = useSelector( getIsWoo );
 	const isGravatar = isGravatarOAuth2Client( oauth2Client );
+	let emailOnlyOrGravatarLoadingLabel;
+	if ( isEmailOnly ) {
+		emailOnlyOrGravatarLoadingLabel = __( 'Updating…' );
+	} else if ( isGravatar ) {
+		emailOnlyOrGravatarLoadingLabel = __( 'Continue' );
+	}
 
 	const renderTermsOfService = () => {
 		// Custom ToS element takes priority (from partner branding)
@@ -188,6 +203,7 @@ const SignupFormSocialFirst = ( {
 		stepName,
 		flowName,
 		activationEmailFrom,
+		onUpdateEmail,
 		goToNextStep,
 		logInUrl,
 		queryArgs,
@@ -211,8 +227,23 @@ const SignupFormSocialFirst = ( {
 		},
 		onCreateAccountSuccess,
 		inputPlaceholder: isGravatar ? __( 'Enter your email address' ) : undefined,
-		submitButtonLoadingLabel: isGravatar ? __( 'Continue' ) : undefined,
+		submitButtonLoadingLabel: emailOnlyOrGravatarLoadingLabel,
 	};
+
+	let secondaryFooterButton;
+	if ( isEmailOnly ) {
+		secondaryFooterButton = onCancelEmailUpdate && (
+			<Button onClick={ onCancelEmailUpdate } icon={ chevronLeft }>
+				{ __( 'Cancel' ) }
+			</Button>
+		);
+	} else if ( ! backButtonInFooter ) {
+		secondaryFooterButton = (
+			<Button onClick={ () => setCurrentStep( 'initial' ) } icon={ chevronLeft }>
+				{ __( 'See all options' ) }
+			</Button>
+		);
+	}
 
 	const emailLoginBlock = isEmailFirstVariant ? (
 		<div className="signup-form-social-first-email">
@@ -228,7 +259,7 @@ const SignupFormSocialFirst = ( {
 		</p>
 	);
 
-	if ( isMobileCompactVariant ) {
+	if ( isMobileCompactVariant && ! isEmailOnly ) {
 		// In-form ToS: partner branding wins via customTosElement (rendered by
 		// renderTermsOfService); otherwise the compact "options above" notice.
 		const inFormTosElement = customTosElement ? renderTermsOfService() : <MobileCompactTosNotice />;
@@ -259,48 +290,48 @@ const SignupFormSocialFirst = ( {
 
 	return (
 		<div className="signup-form signup-form-social-first">
-			<div className={ getVisibilityClassName( 'initial' ) }>
-				{ notice }
-				{ renderTermsOfService() }
-				{ emailLoginBlock && ! isEmailAtBottom && (
-					<>
-						{ emailLoginBlock }
-						<FormDivider isHorizontal />
-					</>
-				) }
-				<SocialSignupForm
-					handleResponse={ handleSocialResponse }
-					setCurrentStep={ setCurrentStep }
-					socialServiceResponse={ socialServiceResponse }
-					redirectToAfterLoginUrl={ redirectToAfterLoginUrl }
-					disableTosText
-					compact
-					isSocialFirst={ isSocialFirst }
-					shouldShowEmailButton={ ! isEmailFirstVariant }
-					allowedSocialServices={ allowedSocialServices }
-				/>
-				{ emailLoginBlock && isEmailAtBottom && (
-					<>
-						<FormDivider isHorizontal />
-						{ emailLoginBlock }
-					</>
-				) }
-				{ isEmailFirstVariant && loginLinkParagraph }
-			</div>
+			{ /* Not merely hidden: an unrendered screen can't be tabbed into, and doesn't leave the
+			     one guarantee this mode makes resting on a stylesheet. */ }
+			{ isEmailOnly ? (
+				notice
+			) : (
+				<div className={ getVisibilityClassName( 'initial' ) }>
+					{ notice }
+					{ renderTermsOfService() }
+					{ emailLoginBlock && ! isEmailAtBottom && (
+						<>
+							{ emailLoginBlock }
+							<FormDivider isHorizontal />
+						</>
+					) }
+					<SocialSignupForm
+						handleResponse={ handleSocialResponse }
+						setCurrentStep={ setCurrentStep }
+						socialServiceResponse={ socialServiceResponse }
+						redirectToAfterLoginUrl={ redirectToAfterLoginUrl }
+						disableTosText
+						compact
+						isSocialFirst={ isSocialFirst }
+						shouldShowEmailButton={ ! isEmailFirstVariant }
+						allowedSocialServices={ allowedSocialServices }
+					/>
+					{ emailLoginBlock && isEmailAtBottom && (
+						<>
+							<FormDivider isHorizontal />
+							{ emailLoginBlock }
+						</>
+					) }
+					{ isEmailFirstVariant && loginLinkParagraph }
+				</div>
+			) }
 			<div className={ getVisibilityClassName( 'email' ) }>
 				<div className="signup-form-social-first-email">
 					<PasswordlessSignupForm
 						{ ...passwordlessFormProps }
 						renderTerms={ renderEmailStepTermsOfService }
-						secondaryFooterButton={
-							backButtonInFooter ? undefined : (
-								<Button onClick={ () => setCurrentStep( 'initial' ) } icon={ chevronLeft }>
-									{ __( 'See all options' ) }
-								</Button>
-							)
-						}
+						secondaryFooterButton={ secondaryFooterButton }
 					/>
-					{ backButtonInFooter ? (
+					{ backButtonInFooter && ! isEmailOnly ? (
 						<Button
 							onClick={ () => setCurrentStep( 'initial' ) }
 							className="back-button"

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -128,6 +128,9 @@ const SignupFormSocialFirst = ( {
 	const [ currentStep, setCurrentStep ] = useState< Screen >( userEmail ? 'email' : 'initial' );
 	// No other screen to be on, whatever the caller was given to start from.
 	const visibleStep = emailUpdate ? 'email' : currentStep;
+	// The one legal copy or the other, never both: whichever renders here has to be the one the
+	// form is then told not to render again.
+	const showsPartnerTerms = Boolean( emailUpdate && customTosElement );
 	const { __ } = useI18n();
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 	const isWoo = useSelector( getIsWoo );
@@ -334,13 +337,11 @@ const SignupFormSocialFirst = ( {
 				{ emailUpdate && notice }
 				{ /* Partner copy points at the options below it, and the form puts what it is given
 				     after the footer whenever there is a secondary action. */ }
-				{ emailUpdate && customTosElement && renderTermsOfService() }
+				{ showsPartnerTerms && renderTermsOfService() }
 				<div className="signup-form-social-first-email">
 					<PasswordlessSignupForm
 						{ ...passwordlessFormProps }
-						renderTerms={
-							emailUpdate && customTosElement ? undefined : renderEmailStepTermsOfService
-						}
+						renderTerms={ showsPartnerTerms ? undefined : renderEmailStepTermsOfService }
 						secondaryFooterButton={ secondaryFooterButton }
 					/>
 					{ backButtonInFooter && ! emailUpdate ? (

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -57,10 +57,12 @@ interface SignupFormSocialFirst {
 	activationEmailFrom?: string;
 	// Replaces account creation with a change to the account the caller already has. Its presence
 	// makes this an email-only screen: every route to signing up again is dropped, since taking
-	// one would make the second account the caller is here to avoid.
-	onUpdateEmail?: ( email: string ) => Promise< void >;
-	// Without it there is no way off an email-only screen but submitting it.
-	onCancelEmailUpdate?: () => void;
+	// one would make the second account the caller is here to avoid. `cancel` is then the only way
+	// off that screen, so it isn't separately optional.
+	emailUpdate?: {
+		submit: ( email: string ) => Promise< void >;
+		cancel: () => void;
+	};
 }
 
 const options = {
@@ -120,11 +122,13 @@ const SignupFormSocialFirst = ( {
 	allowedSocialServices,
 	customTosElement,
 	activationEmailFrom,
-	onUpdateEmail,
-	onCancelEmailUpdate,
+	emailUpdate,
 }: SignupFormSocialFirst ) => {
 	const [ currentStep, setCurrentStep ] = useState< Screen >( userEmail ? 'email' : 'initial' );
-	const isEmailOnly = Boolean( onUpdateEmail );
+	const isEmailOnly = Boolean( emailUpdate );
+	// Not `currentStep`, which is fixed at mount from the address it was given: an email-only
+	// screen has no other screen to be on, whenever it is switched into and whatever it starts with.
+	const activeStep = isEmailOnly ? 'email' : currentStep;
 	const { __ } = useI18n();
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 	const isWoo = useSelector( getIsWoo );
@@ -193,7 +197,7 @@ const SignupFormSocialFirst = ( {
 	// to handle the visibility of the steps while preserving their layout properties and avoiding shifts.
 	const getVisibilityClassName = ( step: Screen ) => {
 		return clsx( 'signup-form-social-first-screen', {
-			visible: currentStep === step,
+			visible: activeStep === step,
 		} );
 	};
 
@@ -203,7 +207,7 @@ const SignupFormSocialFirst = ( {
 		stepName,
 		flowName,
 		activationEmailFrom,
-		onUpdateEmail,
+		emailUpdate,
 		goToNextStep,
 		logInUrl,
 		queryArgs,
@@ -231,9 +235,9 @@ const SignupFormSocialFirst = ( {
 	};
 
 	let secondaryFooterButton;
-	if ( isEmailOnly ) {
-		secondaryFooterButton = onCancelEmailUpdate && (
-			<Button onClick={ onCancelEmailUpdate } icon={ chevronLeft }>
+	if ( emailUpdate ) {
+		secondaryFooterButton = (
+			<Button onClick={ emailUpdate.cancel } icon={ chevronLeft }>
 				{ __( 'Cancel' ) }
 			</Button>
 		);
@@ -292,9 +296,7 @@ const SignupFormSocialFirst = ( {
 		<div className="signup-form signup-form-social-first">
 			{ /* Not merely hidden: an unrendered screen can't be tabbed into, and doesn't leave the
 			     one guarantee this mode makes resting on a stylesheet. */ }
-			{ isEmailOnly ? (
-				notice
-			) : (
+			{ ! isEmailOnly && (
 				<div className={ getVisibilityClassName( 'initial' ) }>
 					{ notice }
 					{ renderTermsOfService() }
@@ -325,6 +327,7 @@ const SignupFormSocialFirst = ( {
 				</div>
 			) }
 			<div className={ getVisibilityClassName( 'email' ) }>
+				{ isEmailOnly && notice }
 				<div className="signup-form-social-first-email">
 					<PasswordlessSignupForm
 						{ ...passwordlessFormProps }

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -261,7 +261,10 @@ const SignupFormSocialFirst = ( {
 		</p>
 	);
 
-	if ( isMobileCompactVariant ) {
+	// This layout has no screens to be on — it puts the social form and the email one on the same
+	// page — so a caller changing an address takes the standard one, where the email screen is
+	// already only the field.
+	if ( isMobileCompactVariant && ! emailUpdate ) {
 		// In-form ToS: partner branding wins via customTosElement (rendered by
 		// renderTermsOfService); otherwise the compact "options above" notice.
 		const inFormTosElement = customTosElement ? renderTermsOfService() : <MobileCompactTosNotice />;

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -55,14 +55,13 @@ interface SignupFormSocialFirst {
 	allowedSocialServices?: SignupAllowedService[];
 	customTosElement?: JSX.Element;
 	activationEmailFrom?: string;
-	// Replaces account creation with a change to the account the caller already has. The email
-	// screen is already only the email field, so all this mode does is take away the way back to
-	// the social one and put `cancel` in its place — the caller's own way out.
+	// Replaces account creation with a change to the account the caller already has, making this an
+	// email-only screen: the way back to the social one gives way to `cancel`, and nothing else
+	// offers a second account.
 	emailUpdate?: {
 		submit: ( email: string ) => Promise< void >;
 		cancel: () => void;
-		// The write itself can't be called back, so the caller shuts this while one is on its way.
-		// Whatever it goes on to wait for afterwards is its own business, and leaving is allowed.
+		// A write on its way can't be called back, so the caller shuts this while one is.
 		cancelDisabled?: boolean;
 	};
 }
@@ -127,6 +126,8 @@ const SignupFormSocialFirst = ( {
 	emailUpdate,
 }: SignupFormSocialFirst ) => {
 	const [ currentStep, setCurrentStep ] = useState< Screen >( userEmail ? 'email' : 'initial' );
+	// No other screen to be on, whatever the caller was given to start from.
+	const visibleStep = emailUpdate ? 'email' : currentStep;
 	const { __ } = useI18n();
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 	const isWoo = useSelector( getIsWoo );
@@ -179,25 +180,23 @@ const SignupFormSocialFirst = ( {
 	};
 
 	const renderEmailStepTermsOfService = () => {
-		// Partner legal copy is otherwise only on the screen this mode never shows, so its users
-		// would be given WordPress.com's terms in place of the ones they were meant to see.
-		const terms =
-			emailUpdate && customTosElement
-				? customTosElement
-				: createInterpolateElement(
-						__(
-							'By clicking "Continue," you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
-						),
-						options
-				  );
-		return <p className="signup-form-social-first__email-tos-link">{ terms }</p>;
+		return (
+			<p className="signup-form-social-first__email-tos-link">
+				{ createInterpolateElement(
+					__(
+						'By clicking "Continue," you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+					),
+					options
+				) }
+			</p>
+		);
 	};
 
 	// This component uses a technique from this video https://www.youtube.com/watch?v=8327_1PINWI
 	// to handle the visibility of the steps while preserving their layout properties and avoiding shifts.
 	const getVisibilityClassName = ( step: Screen ) => {
 		return clsx( 'signup-form-social-first-screen', {
-			visible: currentStep === step,
+			visible: visibleStep === step,
 		} );
 	};
 
@@ -230,13 +229,10 @@ const SignupFormSocialFirst = ( {
 		},
 		onCreateAccountSuccess,
 		inputPlaceholder: isGravatar ? __( 'Enter your email address' ) : undefined,
-		emailUpdate,
-		// The one moment the button says what it is doing, so it mustn't say account creation.
+		onUpdateEmail: emailUpdate?.submit,
 		submitButtonLoadingLabel,
 	};
 
-	// Signing up again is the one thing this screen mustn't offer a caller changing an address, so
-	// the way back to the social options gives way to the caller's own.
 	let secondaryFooterButton;
 	if ( emailUpdate ) {
 		secondaryFooterButton = (
@@ -270,9 +266,7 @@ const SignupFormSocialFirst = ( {
 		</p>
 	);
 
-	// This layout has no screens to be on — it puts the social form and the email one on the same
-	// page — so a caller changing an address takes the standard one, where the email screen is
-	// already only the field.
+	// This layout has no screens: it puts the social form and the email one on the same page.
 	if ( isMobileCompactVariant && ! emailUpdate ) {
 		// In-form ToS: partner branding wins via customTosElement (rendered by
 		// renderTermsOfService); otherwise the compact "options above" notice.
@@ -334,10 +328,15 @@ const SignupFormSocialFirst = ( {
 			</div>
 			<div className={ getVisibilityClassName( 'email' ) }>
 				{ emailUpdate && notice }
+				{ /* Partner copy points at the options below it, and the form puts what it is given
+				     after the footer whenever there is a secondary action. */ }
+				{ emailUpdate && customTosElement && renderTermsOfService() }
 				<div className="signup-form-social-first-email">
 					<PasswordlessSignupForm
 						{ ...passwordlessFormProps }
-						renderTerms={ renderEmailStepTermsOfService }
+						renderTerms={
+							emailUpdate && customTosElement ? undefined : renderEmailStepTermsOfService
+						}
 						secondaryFooterButton={ secondaryFooterButton }
 					/>
 					{ backButtonInFooter && ! emailUpdate ? (

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -62,6 +62,9 @@ interface SignupFormSocialFirst {
 	emailUpdate?: {
 		submit: ( email: string ) => Promise< void >;
 		cancel: () => void;
+		// Only the caller can tell a write still in flight — which cancelling wouldn't call back —
+		// from whatever it goes on to wait for afterwards, which cancelling should always leave.
+		cancelDisabled?: boolean;
 	};
 }
 
@@ -237,7 +240,11 @@ const SignupFormSocialFirst = ( {
 	let secondaryFooterButton;
 	if ( emailUpdate ) {
 		secondaryFooterButton = (
-			<Button onClick={ emailUpdate.cancel } icon={ chevronLeft }>
+			<Button
+				onClick={ emailUpdate.cancel }
+				disabled={ emailUpdate.cancelDisabled }
+				icon={ chevronLeft }
+			>
 				{ __( 'Cancel' ) }
 			</Button>
 		);

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -61,6 +61,9 @@ interface SignupFormSocialFirst {
 	emailUpdate?: {
 		submit: ( email: string ) => Promise< void >;
 		cancel: () => void;
+		// The write itself can't be called back, so the caller shuts this while one is on its way.
+		// Whatever it goes on to wait for afterwards is its own business, and leaving is allowed.
+		cancelDisabled?: boolean;
 	};
 }
 
@@ -176,16 +179,18 @@ const SignupFormSocialFirst = ( {
 	};
 
 	const renderEmailStepTermsOfService = () => {
-		return (
-			<p className="signup-form-social-first__email-tos-link">
-				{ createInterpolateElement(
-					__(
-						'By clicking "Continue," you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
-					),
-					options
-				) }
-			</p>
-		);
+		// Partner legal copy is otherwise only on the screen this mode never shows, so its users
+		// would be given WordPress.com's terms in place of the ones they were meant to see.
+		const terms =
+			emailUpdate && customTosElement
+				? customTosElement
+				: createInterpolateElement(
+						__(
+							'By clicking "Continue," you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+						),
+						options
+				  );
+		return <p className="signup-form-social-first__email-tos-link">{ terms }</p>;
 	};
 
 	// This component uses a technique from this video https://www.youtube.com/watch?v=8327_1PINWI
@@ -235,7 +240,11 @@ const SignupFormSocialFirst = ( {
 	let secondaryFooterButton;
 	if ( emailUpdate ) {
 		secondaryFooterButton = (
-			<Button onClick={ emailUpdate.cancel } icon={ chevronLeft }>
+			<Button
+				onClick={ emailUpdate.cancel }
+				disabled={ emailUpdate.cancelDisabled }
+				icon={ chevronLeft }
+			>
 				{ __( 'Cancel' ) }
 			</Button>
 		);
@@ -296,7 +305,7 @@ const SignupFormSocialFirst = ( {
 	return (
 		<div className="signup-form signup-form-social-first">
 			<div className={ getVisibilityClassName( 'initial' ) }>
-				{ notice }
+				{ ! emailUpdate && notice }
 				{ renderTermsOfService() }
 				{ emailLoginBlock && ! isEmailAtBottom && (
 					<>
@@ -324,6 +333,7 @@ const SignupFormSocialFirst = ( {
 				{ isEmailFirstVariant && loginLinkParagraph }
 			</div>
 			<div className={ getVisibilityClassName( 'email' ) }>
+				{ emailUpdate && notice }
 				<div className="signup-form-social-first-email">
 					<PasswordlessSignupForm
 						{ ...passwordlessFormProps }

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -136,11 +136,11 @@ const SignupFormSocialFirst = ( {
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 	const isWoo = useSelector( getIsWoo );
 	const isGravatar = isGravatarOAuth2Client( oauth2Client );
-	let emailOnlyOrGravatarLoadingLabel;
+	let submitButtonLoadingLabel;
 	if ( isEmailOnly ) {
-		emailOnlyOrGravatarLoadingLabel = __( 'Updating…' );
+		submitButtonLoadingLabel = __( 'Updating…' );
 	} else if ( isGravatar ) {
-		emailOnlyOrGravatarLoadingLabel = __( 'Continue' );
+		submitButtonLoadingLabel = __( 'Continue' );
 	}
 
 	const renderTermsOfService = () => {
@@ -186,12 +186,16 @@ const SignupFormSocialFirst = ( {
 	const renderEmailStepTermsOfService = () => {
 		return (
 			<p className="signup-form-social-first__email-tos-link">
-				{ createInterpolateElement(
-					__(
-						'By clicking "Continue," you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
-					),
-					options
-				) }
+				{ /* Partner legal copy otherwise appears only on the screen an email-only caller
+				     doesn't render, so its users would be shown WordPress.com's terms instead. */ }
+				{ isEmailOnly && customTosElement
+					? customTosElement
+					: createInterpolateElement(
+							__(
+								'By clicking "Continue," you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+							),
+							options
+					  ) }
 			</p>
 		);
 	};
@@ -234,7 +238,7 @@ const SignupFormSocialFirst = ( {
 		},
 		onCreateAccountSuccess,
 		inputPlaceholder: isGravatar ? __( 'Enter your email address' ) : undefined,
-		submitButtonLoadingLabel: emailOnlyOrGravatarLoadingLabel,
+		submitButtonLoadingLabel,
 	};
 
 	let secondaryFooterButton;

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -121,8 +121,6 @@ const SignupFormSocialFirst = ( {
 	onUpdateEmail,
 }: SignupFormSocialFirst ) => {
 	const [ currentStep, setCurrentStep ] = useState< Screen >( userEmail ? 'email' : 'initial' );
-	// No other screen to be on, whatever the caller was given to start from.
-	const visibleStep = onUpdateEmail ? 'email' : currentStep;
 	const { __ } = useI18n();
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 	const isWoo = useSelector( getIsWoo );
@@ -195,7 +193,7 @@ const SignupFormSocialFirst = ( {
 	// to handle the visibility of the steps while preserving their layout properties and avoiding shifts.
 	const getVisibilityClassName = ( step: Screen ) => {
 		return clsx( 'signup-form-social-first-screen', {
-			visible: visibleStep === step,
+			visible: currentStep === step,
 		} );
 	};
 
@@ -232,15 +230,6 @@ const SignupFormSocialFirst = ( {
 		submitButtonLoadingLabel,
 	};
 
-	let secondaryFooterButton;
-	if ( ! onUpdateEmail && ! backButtonInFooter ) {
-		secondaryFooterButton = (
-			<Button onClick={ () => setCurrentStep( 'initial' ) } icon={ chevronLeft }>
-				{ __( 'See all options' ) }
-			</Button>
-		);
-	}
-
 	const emailLoginBlock = isEmailFirstVariant ? (
 		<div className="signup-form-social-first-email">
 			<PasswordlessSignupForm { ...passwordlessFormProps } />
@@ -255,8 +244,26 @@ const SignupFormSocialFirst = ( {
 		</p>
 	);
 
-	// This layout has no screens: it puts the social form and the email one on the same page.
-	if ( isMobileCompactVariant && ! onUpdateEmail ) {
+	// Only the email field, and no way from it to a second account: no social form, nothing that
+	// returns to one, and no other screen mounted — the signup screen stacks in the same grid cell
+	// and the email-first variants mount a second `signup-email` input on it.
+	if ( onUpdateEmail ) {
+		return (
+			<div className="signup-form signup-form-social-first">
+				<div className={ clsx( 'signup-form-social-first-screen', 'visible' ) }>
+					{ notice }
+					<div className="signup-form-social-first-email">
+						<PasswordlessSignupForm
+							{ ...passwordlessFormProps }
+							renderTerms={ renderEmailStepTermsOfService }
+						/>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	if ( isMobileCompactVariant ) {
 		// In-form ToS: partner branding wins via customTosElement (rendered by
 		// renderTermsOfService); otherwise the compact "options above" notice.
 		const inFormTosElement = customTosElement ? renderTermsOfService() : <MobileCompactTosNotice />;
@@ -287,47 +294,48 @@ const SignupFormSocialFirst = ( {
 
 	return (
 		<div className="signup-form signup-form-social-first">
-			{ /* Not merely hidden: it stacks in the same grid cell, and the email-first variants mount
-			     a second `signup-email` input on it that steals the visible label and the focus. */ }
-			{ ! onUpdateEmail && (
-				<div className={ getVisibilityClassName( 'initial' ) }>
-					{ notice }
-					{ renderTermsOfService() }
-					{ emailLoginBlock && ! isEmailAtBottom && (
-						<>
-							{ emailLoginBlock }
-							<FormDivider isHorizontal />
-						</>
-					) }
-					<SocialSignupForm
-						handleResponse={ handleSocialResponse }
-						setCurrentStep={ setCurrentStep }
-						socialServiceResponse={ socialServiceResponse }
-						redirectToAfterLoginUrl={ redirectToAfterLoginUrl }
-						disableTosText
-						compact
-						isSocialFirst={ isSocialFirst }
-						shouldShowEmailButton={ ! isEmailFirstVariant }
-						allowedSocialServices={ allowedSocialServices }
-					/>
-					{ emailLoginBlock && isEmailAtBottom && (
-						<>
-							<FormDivider isHorizontal />
-							{ emailLoginBlock }
-						</>
-					) }
-					{ isEmailFirstVariant && loginLinkParagraph }
-				</div>
-			) }
+			<div className={ getVisibilityClassName( 'initial' ) }>
+				{ notice }
+				{ renderTermsOfService() }
+				{ emailLoginBlock && ! isEmailAtBottom && (
+					<>
+						{ emailLoginBlock }
+						<FormDivider isHorizontal />
+					</>
+				) }
+				<SocialSignupForm
+					handleResponse={ handleSocialResponse }
+					setCurrentStep={ setCurrentStep }
+					socialServiceResponse={ socialServiceResponse }
+					redirectToAfterLoginUrl={ redirectToAfterLoginUrl }
+					disableTosText
+					compact
+					isSocialFirst={ isSocialFirst }
+					shouldShowEmailButton={ ! isEmailFirstVariant }
+					allowedSocialServices={ allowedSocialServices }
+				/>
+				{ emailLoginBlock && isEmailAtBottom && (
+					<>
+						<FormDivider isHorizontal />
+						{ emailLoginBlock }
+					</>
+				) }
+				{ isEmailFirstVariant && loginLinkParagraph }
+			</div>
 			<div className={ getVisibilityClassName( 'email' ) }>
-				{ onUpdateEmail && notice }
 				<div className="signup-form-social-first-email">
 					<PasswordlessSignupForm
 						{ ...passwordlessFormProps }
 						renderTerms={ renderEmailStepTermsOfService }
-						secondaryFooterButton={ secondaryFooterButton }
+						secondaryFooterButton={
+							backButtonInFooter ? undefined : (
+								<Button onClick={ () => setCurrentStep( 'initial' ) } icon={ chevronLeft }>
+									{ __( 'See all options' ) }
+								</Button>
+							)
+						}
 					/>
-					{ backButtonInFooter && ! onUpdateEmail ? (
+					{ backButtonInFooter ? (
 						<Button
 							onClick={ () => setCurrentStep( 'initial' ) }
 							className="back-button"

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -55,16 +55,12 @@ interface SignupFormSocialFirst {
 	allowedSocialServices?: SignupAllowedService[];
 	customTosElement?: JSX.Element;
 	activationEmailFrom?: string;
-	// Replaces account creation with a change to the account the caller already has. Its presence
-	// makes this an email-only screen: every route to signing up again is dropped, since taking
-	// one would make the second account the caller is here to avoid. `cancel` is then the only way
-	// off that screen, so it isn't separately optional.
+	// Replaces account creation with a change to the account the caller already has. The email
+	// screen is already only the email field, so all this mode does is take away the way back to
+	// the social one and put `cancel` in its place — the caller's own way out.
 	emailUpdate?: {
 		submit: ( email: string ) => Promise< void >;
 		cancel: () => void;
-		// Only the caller can tell a write still in flight — which cancelling wouldn't call back —
-		// from whatever it goes on to wait for afterwards, which cancelling should always leave.
-		cancelDisabled?: boolean;
 	};
 }
 
@@ -128,16 +124,12 @@ const SignupFormSocialFirst = ( {
 	emailUpdate,
 }: SignupFormSocialFirst ) => {
 	const [ currentStep, setCurrentStep ] = useState< Screen >( userEmail ? 'email' : 'initial' );
-	const isEmailOnly = Boolean( emailUpdate );
-	// Not `currentStep`, which is fixed at mount from the address it was given: an email-only
-	// screen has no other screen to be on, whenever it is switched into and whatever it starts with.
-	const activeStep = isEmailOnly ? 'email' : currentStep;
 	const { __ } = useI18n();
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 	const isWoo = useSelector( getIsWoo );
 	const isGravatar = isGravatarOAuth2Client( oauth2Client );
 	let submitButtonLoadingLabel;
-	if ( isEmailOnly ) {
+	if ( emailUpdate ) {
 		submitButtonLoadingLabel = __( 'Updating…' );
 	} else if ( isGravatar ) {
 		submitButtonLoadingLabel = __( 'Continue' );
@@ -186,16 +178,12 @@ const SignupFormSocialFirst = ( {
 	const renderEmailStepTermsOfService = () => {
 		return (
 			<p className="signup-form-social-first__email-tos-link">
-				{ /* Partner legal copy otherwise appears only on the screen an email-only caller
-				     doesn't render, so its users would be shown WordPress.com's terms instead. */ }
-				{ isEmailOnly && customTosElement
-					? customTosElement
-					: createInterpolateElement(
-							__(
-								'By clicking "Continue," you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
-							),
-							options
-					  ) }
+				{ createInterpolateElement(
+					__(
+						'By clicking "Continue," you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+					),
+					options
+				) }
 			</p>
 		);
 	};
@@ -204,7 +192,7 @@ const SignupFormSocialFirst = ( {
 	// to handle the visibility of the steps while preserving their layout properties and avoiding shifts.
 	const getVisibilityClassName = ( step: Screen ) => {
 		return clsx( 'signup-form-social-first-screen', {
-			visible: activeStep === step,
+			visible: currentStep === step,
 		} );
 	};
 
@@ -214,7 +202,6 @@ const SignupFormSocialFirst = ( {
 		stepName,
 		flowName,
 		activationEmailFrom,
-		emailUpdate,
 		goToNextStep,
 		logInUrl,
 		queryArgs,
@@ -238,17 +225,17 @@ const SignupFormSocialFirst = ( {
 		},
 		onCreateAccountSuccess,
 		inputPlaceholder: isGravatar ? __( 'Enter your email address' ) : undefined,
+		emailUpdate,
+		// The one moment the button says what it is doing, so it mustn't say account creation.
 		submitButtonLoadingLabel,
 	};
 
+	// Signing up again is the one thing this screen mustn't offer a caller changing an address, so
+	// the way back to the social options gives way to the caller's own.
 	let secondaryFooterButton;
 	if ( emailUpdate ) {
 		secondaryFooterButton = (
-			<Button
-				onClick={ emailUpdate.cancel }
-				disabled={ emailUpdate.cancelDisabled }
-				icon={ chevronLeft }
-			>
+			<Button onClick={ emailUpdate.cancel } icon={ chevronLeft }>
 				{ __( 'Cancel' ) }
 			</Button>
 		);
@@ -274,7 +261,7 @@ const SignupFormSocialFirst = ( {
 		</p>
 	);
 
-	if ( isMobileCompactVariant && ! isEmailOnly ) {
+	if ( isMobileCompactVariant ) {
 		// In-form ToS: partner branding wins via customTosElement (rendered by
 		// renderTermsOfService); otherwise the compact "options above" notice.
 		const inFormTosElement = customTosElement ? renderTermsOfService() : <MobileCompactTosNotice />;
@@ -305,47 +292,42 @@ const SignupFormSocialFirst = ( {
 
 	return (
 		<div className="signup-form signup-form-social-first">
-			{ /* Not merely hidden: an unrendered screen can't be tabbed into, and doesn't leave the
-			     one guarantee this mode makes resting on a stylesheet. */ }
-			{ ! isEmailOnly && (
-				<div className={ getVisibilityClassName( 'initial' ) }>
-					{ notice }
-					{ renderTermsOfService() }
-					{ emailLoginBlock && ! isEmailAtBottom && (
-						<>
-							{ emailLoginBlock }
-							<FormDivider isHorizontal />
-						</>
-					) }
-					<SocialSignupForm
-						handleResponse={ handleSocialResponse }
-						setCurrentStep={ setCurrentStep }
-						socialServiceResponse={ socialServiceResponse }
-						redirectToAfterLoginUrl={ redirectToAfterLoginUrl }
-						disableTosText
-						compact
-						isSocialFirst={ isSocialFirst }
-						shouldShowEmailButton={ ! isEmailFirstVariant }
-						allowedSocialServices={ allowedSocialServices }
-					/>
-					{ emailLoginBlock && isEmailAtBottom && (
-						<>
-							<FormDivider isHorizontal />
-							{ emailLoginBlock }
-						</>
-					) }
-					{ isEmailFirstVariant && loginLinkParagraph }
-				</div>
-			) }
+			<div className={ getVisibilityClassName( 'initial' ) }>
+				{ notice }
+				{ renderTermsOfService() }
+				{ emailLoginBlock && ! isEmailAtBottom && (
+					<>
+						{ emailLoginBlock }
+						<FormDivider isHorizontal />
+					</>
+				) }
+				<SocialSignupForm
+					handleResponse={ handleSocialResponse }
+					setCurrentStep={ setCurrentStep }
+					socialServiceResponse={ socialServiceResponse }
+					redirectToAfterLoginUrl={ redirectToAfterLoginUrl }
+					disableTosText
+					compact
+					isSocialFirst={ isSocialFirst }
+					shouldShowEmailButton={ ! isEmailFirstVariant }
+					allowedSocialServices={ allowedSocialServices }
+				/>
+				{ emailLoginBlock && isEmailAtBottom && (
+					<>
+						<FormDivider isHorizontal />
+						{ emailLoginBlock }
+					</>
+				) }
+				{ isEmailFirstVariant && loginLinkParagraph }
+			</div>
 			<div className={ getVisibilityClassName( 'email' ) }>
-				{ isEmailOnly && notice }
 				<div className="signup-form-social-first-email">
 					<PasswordlessSignupForm
 						{ ...passwordlessFormProps }
 						renderTerms={ renderEmailStepTermsOfService }
 						secondaryFooterButton={ secondaryFooterButton }
 					/>
-					{ backButtonInFooter && ! isEmailOnly ? (
+					{ backButtonInFooter && ! emailUpdate ? (
 						<Button
 							onClick={ () => setCurrentStep( 'initial' ) }
 							className="back-button"

--- a/client/blocks/signup-form/test/passwordless.jsx
+++ b/client/blocks/signup-form/test/passwordless.jsx
@@ -110,3 +110,26 @@ describe( 'activation email source', () => {
 		expect( body.extra ).toEqual( { has_segmentation_survey: false } );
 	} );
 } );
+
+describe( 'email update mode', () => {
+	const mockStore = configureStore( [ thunk ] );
+
+	// A second typo while correcting the first is not a signup that failed, and the signup funnel
+	// shouldn't carry it.
+	it( 'records no signup failure when a correction is invalid', () => {
+		const store = mockStore( {} );
+		render(
+			<Provider store={ store }>
+				<PasswordlessSignupForm emailUpdate={ { submit: jest.fn(), cancel: jest.fn() } } />
+			</Provider>
+		);
+
+		fireEvent.change( screen.getByRole( 'textbox', { name: /email/i } ), {
+			target: { value: 'still-not-an-email' },
+		} );
+		fireEvent.click( screen.getByRole( 'button', { name: /create your account/i } ) );
+
+		expect( screen.getByText( /valid email address/i ) ).toBeInTheDocument();
+		expect( store.getActions() ).toHaveLength( 0 );
+	} );
+} );

--- a/client/blocks/signup-form/test/passwordless.jsx
+++ b/client/blocks/signup-form/test/passwordless.jsx
@@ -114,6 +114,23 @@ describe( 'activation email source', () => {
 describe( 'email update mode', () => {
 	const mockStore = configureStore( [ thunk ] );
 
+	const renderWith = ( props ) =>
+		render(
+			<Provider store={ mockStore( {} ) }>
+				<PasswordlessSignupForm
+					secondaryFooterButton={ <button type="button">Go back</button> }
+					{ ...props }
+				/>
+			</Provider>
+		);
+
+	const submit = async () => {
+		fireEvent.change( screen.getByRole( 'textbox', { name: /email/i } ), {
+			target: { value: 'test@example.com' },
+		} );
+		fireEvent.click( screen.getByRole( 'button', { name: /create your account/i } ) );
+	};
+
 	// A second typo while correcting the first is not a signup that failed, and the signup funnel
 	// shouldn't carry it.
 	it( 'records no signup failure when a correction is invalid', () => {
@@ -131,5 +148,22 @@ describe( 'email update mode', () => {
 
 		expect( screen.getByText( /valid email address/i ) ).toBeInTheDocument();
 		expect( store.getActions() ).toHaveLength( 0 );
+	} );
+
+	// What this mode must not change: an ordinary signup keeps its way back while it waits.
+	it( 'leaves an ordinary signup its way back while the account is being created', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/rest/v1.1/users/new' )
+			.delay( 10000 )
+			.reply( 200, {} );
+
+		renderWith( {} );
+		await submit();
+
+		await waitFor( () =>
+			expect( screen.getByRole( 'button', { name: /creating your account/i } ) ).toBeDisabled()
+		);
+		expect( screen.getByRole( 'button', { name: 'Go back' } ) ).toBeEnabled();
+		nock.cleanAll();
 	} );
 } );

--- a/client/blocks/signup-form/test/passwordless.jsx
+++ b/client/blocks/signup-form/test/passwordless.jsx
@@ -137,7 +137,7 @@ describe( 'email update mode', () => {
 		const store = mockStore( {} );
 		render(
 			<Provider store={ store }>
-				<PasswordlessSignupForm emailUpdate={ { submit: jest.fn(), cancel: jest.fn() } } />
+				<PasswordlessSignupForm onUpdateEmail={ jest.fn() } />
 			</Provider>
 		);
 

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -226,13 +226,7 @@ describe( 'SignupFormSocialFirst', () => {
 		it( 'takes the standard layout rather than the compact one that shows social', () => {
 			renderUpdating( { isMobileCompactVariant: true } );
 
-			// The compact layout has no screens and no Cancel; the standard one keeps social on the
-			// screen it isn't showing.
-			expect(
-				screen
-					.getAllByRole( 'button', { name: /Continue with/ } )[ 0 ]
-					.closest( '.signup-form-social-first-screen' )
-			).not.toHaveClass( 'visible' );
+			expect( screen.queryByRole( 'button', { name: /Continue with/ } ) ).not.toBeInTheDocument();
 			expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeVisible();
 		} );
 
@@ -263,6 +257,19 @@ describe( 'SignupFormSocialFirst', () => {
 			await userEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
 
 			expect( cancel ).toHaveBeenCalled();
+		} );
+
+		// The email-first variants mount a second form on the social screen, which shares the
+		// visible one's input id and its autofocus.
+		it( 'mounts the email field once, with nothing to sign up with', () => {
+			renderUpdating( {
+				isEmailFirstVariant: true,
+				customTosElement: <span>Partner terms apply.</span>,
+			} );
+
+			expect( screen.getAllByRole( 'textbox' ) ).toHaveLength( 1 );
+			expect( screen.queryByRole( 'button', { name: /Continue with/ } ) ).not.toBeInTheDocument();
+			expect( screen.getAllByText( 'Partner terms apply.' ) ).toHaveLength( 1 );
 		} );
 
 		it( 'shows the email screen even when it was given no address to start from', () => {

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -223,6 +223,21 @@ describe( 'SignupFormSocialFirst', () => {
 			expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeVisible();
 		} );
 
+		// The compact layout puts the social form on the same page rather than a screen behind, so
+		// it is the one layout where email-only has to mean a different layout.
+		it( 'takes the standard layout rather than the compact one that shows social', () => {
+			renderUpdating( { isMobileCompactVariant: true } );
+
+			// The compact layout has no screens and no Cancel; the standard one keeps social on the
+			// screen it isn't showing.
+			expect(
+				screen
+					.getAllByRole( 'button', { name: /Continue with/ } )[ 0 ]
+					.closest( '.signup-form-social-first-screen' )
+			).not.toHaveClass( 'visible' );
+			expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeVisible();
+		} );
+
 		it( 'says it is updating, not signing up, while the request is in flight', async () => {
 			renderUpdating( {
 				emailUpdate: { submit: () => new Promise< void >( () => {} ), cancel: jest.fn() },

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -261,8 +261,25 @@ describe( 'SignupFormSocialFirst', () => {
 			expect( screenEl ).toContainElement( screen.getByText( 'That address is already in use.' ) );
 		} );
 
-		// It leaves the screen, and a write already in flight would land anyway.
-		it( 'holds the way back shut while a change is being written', async () => {
+		// Only the caller can tell a write in flight from what it waits for afterwards, so it says
+		// when there is nothing to go back to yet.
+		it( 'holds the way back shut when the caller says to', async () => {
+			const cancel = jest.fn();
+			render(
+				<SignupFormSocialFirst
+					{ ...defaultProps }
+					userEmail="typo@example.com"
+					emailUpdate={ { submit: jest.fn(), cancel, cancelDisabled: true } }
+				/>
+			);
+
+			await userEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+			expect( cancel ).not.toHaveBeenCalled();
+		} );
+
+		// The way off the screen for a caller whose wait outlives its write.
+		it( 'leaves the way back open while a change is in flight', async () => {
 			const cancel = jest.fn();
 			render(
 				<SignupFormSocialFirst
@@ -273,9 +290,9 @@ describe( 'SignupFormSocialFirst', () => {
 			);
 
 			await userEvent.click( screen.getByRole( 'button', { name: 'Continue' } ) );
-			await userEvent.click( await screen.findByRole( 'button', { name: 'Cancel' } ) );
+			await userEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
 
-			expect( cancel ).not.toHaveBeenCalled();
+			expect( cancel ).toHaveBeenCalled();
 		} );
 
 		// Otherwise a refusal leaves the field and the button disabled with no way to try again.
@@ -307,6 +324,20 @@ describe( 'SignupFormSocialFirst', () => {
 
 			expect( onCancelEmailUpdate ).toHaveBeenCalled();
 		} );
+	} );
+
+	it( 'keeps an ordinary signup able to leave while its request is running', async () => {
+		render(
+			<SignupFormSocialFirst
+				{ ...defaultProps }
+				userEmail="new@example.com"
+				backButtonInFooter={ false }
+			/>
+		);
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+		expect( screen.getByRole( 'button', { name: 'See all options' } ) ).toBeEnabled();
 	} );
 
 	// One expression picks between these three and the Cancel above, so an ordinary signup has to

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -195,37 +195,45 @@ describe( 'SignupFormSocialFirst', () => {
 	} );
 
 	describe( 'emailUpdate', () => {
-		const emailUpdate = { submit: jest.fn(), cancel: jest.fn() };
 		const renderUpdating = ( props = {} ) =>
 			render(
 				<SignupFormSocialFirst
 					{ ...defaultProps }
 					userEmail="typo@example.com"
-					emailUpdate={ emailUpdate }
+					onUpdateEmail={ jest.fn() }
 					{ ...props }
 				/>
 			);
 
 		beforeEach( () => jest.clearAllMocks() );
 
-		it( "replaces the way back to the social screen with the caller's own", () => {
-			renderUpdating();
+		// Which of the two would otherwise render depends on where the step container puts its back
+		// button, so neither may.
+		it.each( [
+			[ 'the footer', true ],
+			[ 'the form', false ],
+		] )(
+			'offers no way back to signing up with the back button in %s',
+			( _label, backButtonInFooter ) => {
+				renderUpdating( { backButtonInFooter } );
 
-			expect( screen.queryByRole( 'button', { name: 'See all options' } ) ).not.toBeInTheDocument();
-			expect( screen.queryByRole( 'button', { name: 'Back' } ) ).not.toBeInTheDocument();
-			expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeVisible();
-		} );
+				expect(
+					screen.queryByRole( 'button', { name: 'See all options' } )
+				).not.toBeInTheDocument();
+				expect( screen.queryByRole( 'button', { name: 'Back' } ) ).not.toBeInTheDocument();
+			}
+		);
 
 		it( 'takes the standard layout rather than the compact one that shows social', () => {
 			renderUpdating( { isMobileCompactVariant: true } );
 
 			expect( screen.queryByRole( 'button', { name: /Continue with/ } ) ).not.toBeInTheDocument();
-			expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeVisible();
+			expect( screen.getByRole( 'textbox' ) ).toBeVisible();
 		} );
 
 		it( 'says it is updating, not signing up, while the request is in flight', async () => {
 			renderUpdating( {
-				emailUpdate: { submit: () => new Promise< void >( () => {} ), cancel: jest.fn() },
+				onUpdateEmail: () => new Promise< void >( () => {} ),
 			} );
 
 			await userEvent.click( screen.getByRole( 'button', { name: 'Continue' } ) );
@@ -233,27 +241,6 @@ describe( 'SignupFormSocialFirst', () => {
 			expect( await screen.findByRole( 'button', { name: 'Updating…' } ) ).toBeVisible();
 		} );
 
-		it( 'holds the way back shut when the caller says a change is on its way', async () => {
-			const cancel = jest.fn();
-			renderUpdating( { emailUpdate: { submit: jest.fn(), cancel, cancelDisabled: true } } );
-
-			await userEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
-
-			expect( cancel ).not.toHaveBeenCalled();
-		} );
-
-		it( 'leaves the way back open otherwise', async () => {
-			const cancel = jest.fn();
-			renderUpdating( { emailUpdate: { submit: () => new Promise< void >( () => {} ), cancel } } );
-
-			await userEvent.click( screen.getByRole( 'button', { name: 'Continue' } ) );
-			await userEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
-
-			expect( cancel ).toHaveBeenCalled();
-		} );
-
-		// The email-first variants mount a second form on the social screen, which shares the
-		// visible one's input id and its autofocus.
 		it( 'mounts the email field once, with nothing to sign up with', () => {
 			renderUpdating( {
 				isEmailFirstVariant: true,
@@ -297,7 +284,7 @@ describe( 'SignupFormSocialFirst', () => {
 		// Otherwise a refusal leaves the field and the button with nothing to press.
 		it( 'gives the screen back when the change is refused', async () => {
 			renderUpdating( {
-				emailUpdate: { submit: () => Promise.reject( new Error( 'nope' ) ), cancel: jest.fn() },
+				onUpdateEmail: () => Promise.reject( new Error( 'nope' ) ),
 			} );
 
 			await userEvent.click( screen.getByRole( 'button', { name: 'Continue' } ) );

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -194,172 +194,74 @@ describe( 'SignupFormSocialFirst', () => {
 		} );
 	} );
 
-	// Three routes lead back to signing up: the two ways to the social screen, whichever the step
-	// container's back button leaves showing, and the mobile-compact layout, which renders the
-	// social form outright.
-	describe( 'email-only mode', () => {
-		it.each( [
-			[ 'the back button in the footer', { backButtonInFooter: true } ],
-			[ 'the back button in the form', { backButtonInFooter: false } ],
-			[ 'the mobile-compact layout', { isMobileCompactVariant: true } ],
-		] )( 'offers no way to sign up again with %s', ( _label, layout ) => {
+	describe( 'emailUpdate', () => {
+		const emailUpdate = { submit: jest.fn(), cancel: jest.fn() };
+		const renderUpdating = ( props = {} ) =>
 			render(
 				<SignupFormSocialFirst
 					{ ...defaultProps }
-					{ ...layout }
 					userEmail="typo@example.com"
-					emailUpdate={ { submit: jest.fn(), cancel: jest.fn() } }
+					emailUpdate={ emailUpdate }
+					{ ...props }
 				/>
 			);
+
+		beforeEach( () => jest.clearAllMocks() );
+
+		it( "replaces the way back to the social screen with the caller's own", () => {
+			renderUpdating();
 
 			expect( screen.queryByRole( 'button', { name: 'See all options' } ) ).not.toBeInTheDocument();
 			expect( screen.queryByRole( 'button', { name: 'Back' } ) ).not.toBeInTheDocument();
-			expect( screen.queryByRole( 'button', { name: /Continue with/ } ) ).not.toBeInTheDocument();
+			expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeVisible();
+		} );
+
+		it( "keeps the caller's own way back where the step container owns the footer", () => {
+			renderUpdating( { backButtonInFooter: true } );
+
+			expect( screen.queryByRole( 'button', { name: 'Back' } ) ).not.toBeInTheDocument();
+			expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeVisible();
 		} );
 
 		it( 'says it is updating, not signing up, while the request is in flight', async () => {
-			render(
-				<SignupFormSocialFirst
-					{ ...defaultProps }
-					userEmail="typo@example.com"
-					emailUpdate={ { submit: () => new Promise< void >( () => {} ), cancel: jest.fn() } }
-				/>
-			);
+			renderUpdating( {
+				emailUpdate: { submit: () => new Promise< void >( () => {} ), cancel: jest.fn() },
+			} );
 
 			await userEvent.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 
 			expect( await screen.findByRole( 'button', { name: 'Updating…' } ) ).toBeVisible();
 		} );
 
-		it( 'shows the email field when it was given no address to start from', () => {
-			render(
-				<SignupFormSocialFirst
-					{ ...defaultProps }
-					emailUpdate={ { submit: jest.fn(), cancel: jest.fn() } }
-				/>
-			);
-
-			expect(
-				screen.getByRole( 'textbox' ).closest( '.signup-form-social-first-screen' )
-			).toHaveClass( 'visible' );
-		} );
-
-		// Outside the screen it lands in a grid row of its own, beneath the field, the footer and
-		// the terms — which is where a failed update would explain itself.
-		it( 'puts what the caller has to say above the form it is about', () => {
-			render(
-				<SignupFormSocialFirst
-					{ ...defaultProps }
-					userEmail="typo@example.com"
-					notice={ <div>That address is already in use.</div> }
-					emailUpdate={ { submit: jest.fn(), cancel: jest.fn() } }
-				/>
-			);
-
-			const screenEl = screen.getByRole( 'textbox' ).closest( '.signup-form-social-first-screen' );
-			expect( screenEl ).toContainElement( screen.getByText( 'That address is already in use.' ) );
-		} );
-
-		// Partner legal copy lives on the screen this mode doesn't render, so it has to be carried
-		// over rather than replaced by WordPress.com's.
-		it( "keeps a partner's own terms rather than the generic ones", () => {
-			render(
-				<SignupFormSocialFirst
-					{ ...defaultProps }
-					userEmail="typo@example.com"
-					customTosElement={ <span>Partner terms apply.</span> }
-					emailUpdate={ { submit: jest.fn(), cancel: jest.fn() } }
-				/>
-			);
-
-			expect( screen.getByText( 'Partner terms apply.' ) ).toBeVisible();
-			expect( screen.queryByText( /By clicking "Continue,"/ ) ).not.toBeInTheDocument();
-		} );
-
-		// Only the caller can tell a write in flight from what it waits for afterwards, so it says
-		// when there is nothing to go back to yet.
-		it( 'holds the way back shut when the caller says to', async () => {
+		// Leaving wouldn't call back a write already on its way.
+		it( 'holds the way back shut while a change is being written', async () => {
 			const cancel = jest.fn();
-			render(
-				<SignupFormSocialFirst
-					{ ...defaultProps }
-					userEmail="typo@example.com"
-					emailUpdate={ { submit: jest.fn(), cancel, cancelDisabled: true } }
-				/>
-			);
+			renderUpdating( { emailUpdate: { submit: () => new Promise< void >( () => {} ), cancel } } );
 
+			await userEvent.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 			await userEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
 
 			expect( cancel ).not.toHaveBeenCalled();
 		} );
 
-		it( 'leaves the way back open while a change is in flight', async () => {
-			const cancel = jest.fn();
-			render(
-				<SignupFormSocialFirst
-					{ ...defaultProps }
-					userEmail="typo@example.com"
-					emailUpdate={ { submit: () => new Promise< void >( () => {} ), cancel } }
-				/>
-			);
-
-			await userEvent.click( screen.getByRole( 'button', { name: 'Continue' } ) );
-			await userEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
-
-			expect( cancel ).toHaveBeenCalled();
-		} );
-
+		// Otherwise a refusal leaves the field and the button with nothing to press.
 		it( 'gives the screen back when the change is refused', async () => {
-			render(
-				<SignupFormSocialFirst
-					{ ...defaultProps }
-					userEmail="typo@example.com"
-					emailUpdate={ { submit: () => Promise.reject( new Error( 'nope' ) ), cancel: jest.fn() } }
-				/>
-			);
+			renderUpdating( {
+				emailUpdate: { submit: () => Promise.reject( new Error( 'nope' ) ), cancel: jest.fn() },
+			} );
 
 			await userEvent.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 
 			expect( await screen.findByRole( 'button', { name: 'Continue' } ) ).toBeEnabled();
 		} );
-
-		it( 'offers a way back to whoever opened it', async () => {
-			const onCancelEmailUpdate = jest.fn();
-			render(
-				<SignupFormSocialFirst
-					{ ...defaultProps }
-					userEmail="typo@example.com"
-					emailUpdate={ { submit: jest.fn(), cancel: onCancelEmailUpdate } }
-				/>
-			);
-
-			await userEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
-
-			expect( onCancelEmailUpdate ).toHaveBeenCalled();
-		} );
 	} );
 
-	it( 'keeps an ordinary signup able to leave while its request is running', async () => {
-		render(
-			<SignupFormSocialFirst
-				{ ...defaultProps }
-				userEmail="new@example.com"
-				backButtonInFooter={ false }
-			/>
-		);
-
-		await userEvent.click( screen.getByRole( 'button', { name: 'Continue' } ) );
-
-		expect( screen.getByRole( 'button', { name: 'See all options' } ) ).toBeEnabled();
-	} );
-
-	// One expression picks between these three and the Cancel above, so an ordinary signup has to
-	// keep being offered whichever of them it was offered before.
+	// What this mode must not change: every other caller keeps the way back it had.
 	it.each( [
 		[ true, 'Back', 'See all options' ],
 		[ false, 'See all options', 'Back' ],
 	] )(
-		'keeps the way to the social screen for an ordinary signup, back button in footer: %s',
+		'leaves an ordinary signup its own way back, footer: %s',
 		( backButtonInFooter, shown, hidden ) => {
 			render(
 				<SignupFormSocialFirst

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -231,7 +231,6 @@ describe( 'SignupFormSocialFirst', () => {
 			expect( await screen.findByRole( 'button', { name: 'Updating…' } ) ).toBeVisible();
 		} );
 
-		// The screen has no other screen to be on, however it was reached.
 		it( 'shows the email field when it was given no address to start from', () => {
 			render(
 				<SignupFormSocialFirst
@@ -261,6 +260,22 @@ describe( 'SignupFormSocialFirst', () => {
 			expect( screenEl ).toContainElement( screen.getByText( 'That address is already in use.' ) );
 		} );
 
+		// Partner legal copy lives on the screen this mode doesn't render, so it has to be carried
+		// over rather than replaced by WordPress.com's.
+		it( "keeps a partner's own terms rather than the generic ones", () => {
+			render(
+				<SignupFormSocialFirst
+					{ ...defaultProps }
+					userEmail="typo@example.com"
+					customTosElement={ <span>Partner terms apply.</span> }
+					emailUpdate={ { submit: jest.fn(), cancel: jest.fn() } }
+				/>
+			);
+
+			expect( screen.getByText( 'Partner terms apply.' ) ).toBeVisible();
+			expect( screen.queryByText( /By clicking "Continue,"/ ) ).not.toBeInTheDocument();
+		} );
+
 		// Only the caller can tell a write in flight from what it waits for afterwards, so it says
 		// when there is nothing to go back to yet.
 		it( 'holds the way back shut when the caller says to', async () => {
@@ -278,7 +293,6 @@ describe( 'SignupFormSocialFirst', () => {
 			expect( cancel ).not.toHaveBeenCalled();
 		} );
 
-		// The way off the screen for a caller whose wait outlives its write.
 		it( 'leaves the way back open while a change is in flight', async () => {
 			const cancel = jest.fn();
 			render(
@@ -295,7 +309,6 @@ describe( 'SignupFormSocialFirst', () => {
 			expect( cancel ).toHaveBeenCalled();
 		} );
 
-		// Otherwise a refusal leaves the field and the button disabled with no way to try again.
 		it( 'gives the screen back when the change is refused', async () => {
 			render(
 				<SignupFormSocialFirst

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -223,8 +223,6 @@ describe( 'SignupFormSocialFirst', () => {
 			expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeVisible();
 		} );
 
-		// The compact layout puts the social form on the same page rather than a screen behind, so
-		// it is the one layout where email-only has to mean a different layout.
 		it( 'takes the standard layout rather than the compact one that shows social', () => {
 			renderUpdating( { isMobileCompactVariant: true } );
 
@@ -248,8 +246,6 @@ describe( 'SignupFormSocialFirst', () => {
 			expect( await screen.findByRole( 'button', { name: 'Updating…' } ) ).toBeVisible();
 		} );
 
-		// The form owns whether its own action is busy; only the caller knows whether a write is on
-		// its way, and leaving wouldn't call one back.
 		it( 'holds the way back shut when the caller says a change is on its way', async () => {
 			const cancel = jest.fn();
 			renderUpdating( { emailUpdate: { submit: jest.fn(), cancel, cancelDisabled: true } } );
@@ -269,7 +265,14 @@ describe( 'SignupFormSocialFirst', () => {
 			expect( cancel ).toHaveBeenCalled();
 		} );
 
-		// Both otherwise sit on the screen this mode never shows.
+		it( 'shows the email screen even when it was given no address to start from', () => {
+			renderUpdating( { userEmail: '' } );
+
+			expect(
+				screen.getByRole( 'textbox' ).closest( '.signup-form-social-first-screen' )
+			).toHaveClass( 'visible' );
+		} );
+
 		it( 'shows what the caller has to say, and a partner its own terms', () => {
 			renderUpdating( {
 				notice: <div>That address is already in use.</div>,
@@ -280,8 +283,13 @@ describe( 'SignupFormSocialFirst', () => {
 				screen.getByRole( 'textbox' ).closest( '.signup-form-social-first-screen' ) as HTMLElement
 			);
 			expect( emailScreen.getByText( 'That address is already in use.' ) ).toBeVisible();
-			expect( emailScreen.getByText( 'Partner terms apply.' ) ).toBeVisible();
 			expect( emailScreen.queryByText( /By clicking "Continue,"/ ) ).not.toBeInTheDocument();
+
+			// Partner copy points at the options below it, so it can't sit under them.
+			const terms = emailScreen.getByText( 'Partner terms apply.' );
+			expect(
+				terms.compareDocumentPosition( screen.getByRole( 'button', { name: 'Continue' } ) )
+			).toBe( Node.DOCUMENT_POSITION_FOLLOWING );
 		} );
 
 		// Otherwise a refusal leaves the field and the button with nothing to press.
@@ -296,7 +304,6 @@ describe( 'SignupFormSocialFirst', () => {
 		} );
 	} );
 
-	// What this mode must not change: every other caller keeps the way back it had.
 	it.each( [
 		[ true, 'Back', 'See all options' ],
 		[ false, 'See all options', 'Back' ],

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -216,13 +216,6 @@ describe( 'SignupFormSocialFirst', () => {
 			expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeVisible();
 		} );
 
-		it( "keeps the caller's own way back where the step container owns the footer", () => {
-			renderUpdating( { backButtonInFooter: true } );
-
-			expect( screen.queryByRole( 'button', { name: 'Back' } ) ).not.toBeInTheDocument();
-			expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeVisible();
-		} );
-
 		it( 'takes the standard layout rather than the compact one that shows social', () => {
 			renderUpdating( { isMobileCompactVariant: true } );
 

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import SignupFormSocialFirst, {
 	MobileCompactTosNotice,
@@ -248,15 +248,40 @@ describe( 'SignupFormSocialFirst', () => {
 			expect( await screen.findByRole( 'button', { name: 'Updating…' } ) ).toBeVisible();
 		} );
 
-		// Leaving wouldn't call back a write already on its way.
-		it( 'holds the way back shut while a change is being written', async () => {
+		// The form owns whether its own action is busy; only the caller knows whether a write is on
+		// its way, and leaving wouldn't call one back.
+		it( 'holds the way back shut when the caller says a change is on its way', async () => {
+			const cancel = jest.fn();
+			renderUpdating( { emailUpdate: { submit: jest.fn(), cancel, cancelDisabled: true } } );
+
+			await userEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+			expect( cancel ).not.toHaveBeenCalled();
+		} );
+
+		it( 'leaves the way back open otherwise', async () => {
 			const cancel = jest.fn();
 			renderUpdating( { emailUpdate: { submit: () => new Promise< void >( () => {} ), cancel } } );
 
 			await userEvent.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 			await userEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
 
-			expect( cancel ).not.toHaveBeenCalled();
+			expect( cancel ).toHaveBeenCalled();
+		} );
+
+		// Both otherwise sit on the screen this mode never shows.
+		it( 'shows what the caller has to say, and a partner its own terms', () => {
+			renderUpdating( {
+				notice: <div>That address is already in use.</div>,
+				customTosElement: <span>Partner terms apply.</span>,
+			} );
+
+			const emailScreen = within(
+				screen.getByRole( 'textbox' ).closest( '.signup-form-social-first-screen' ) as HTMLElement
+			);
+			expect( emailScreen.getByText( 'That address is already in use.' ) ).toBeVisible();
+			expect( emailScreen.getByText( 'Partner terms apply.' ) ).toBeVisible();
+			expect( emailScreen.queryByText( /By clicking "Continue,"/ ) ).not.toBeInTheDocument();
 		} );
 
 		// Otherwise a refusal leaves the field and the button with nothing to press.

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import SignupFormSocialFirst, {
 	MobileCompactTosNotice,
 } from 'calypso/blocks/signup-form/signup-form-social-first';
@@ -192,6 +193,81 @@ describe( 'SignupFormSocialFirst', () => {
 			expect( screen.queryByText( /Continue with GitHub/i ) ).not.toBeInTheDocument();
 		} );
 	} );
+
+	// Three routes lead back to signing up: the two ways to the social screen, whichever the step
+	// container's back button leaves showing, and the mobile-compact layout, which renders the
+	// social form outright.
+	describe( 'email-only mode', () => {
+		it.each( [
+			[ 'the back button in the footer', { backButtonInFooter: true } ],
+			[ 'the back button in the form', { backButtonInFooter: false } ],
+			[ 'the mobile-compact layout', { isMobileCompactVariant: true } ],
+		] )( 'offers no way to sign up again with %s', ( _label, layout ) => {
+			render(
+				<SignupFormSocialFirst
+					{ ...defaultProps }
+					{ ...layout }
+					userEmail="typo@example.com"
+					onUpdateEmail={ jest.fn() }
+				/>
+			);
+
+			expect( screen.queryByRole( 'button', { name: 'See all options' } ) ).not.toBeInTheDocument();
+			expect( screen.queryByRole( 'button', { name: 'Back' } ) ).not.toBeInTheDocument();
+			expect( screen.queryByRole( 'button', { name: /Continue with/ } ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'says it is updating, not signing up, while the request is in flight', async () => {
+			render(
+				<SignupFormSocialFirst
+					{ ...defaultProps }
+					userEmail="typo@example.com"
+					onUpdateEmail={ () => new Promise< void >( () => {} ) }
+				/>
+			);
+
+			await userEvent.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+			expect( await screen.findByRole( 'button', { name: 'Updating…' } ) ).toBeVisible();
+		} );
+
+		it( 'offers a way back to whoever opened it', async () => {
+			const onCancelEmailUpdate = jest.fn();
+			render(
+				<SignupFormSocialFirst
+					{ ...defaultProps }
+					userEmail="typo@example.com"
+					onUpdateEmail={ jest.fn() }
+					onCancelEmailUpdate={ onCancelEmailUpdate }
+				/>
+			);
+
+			await userEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+			expect( onCancelEmailUpdate ).toHaveBeenCalled();
+		} );
+	} );
+
+	// One expression picks between these three and the Cancel above, so an ordinary signup has to
+	// keep being offered whichever of them it was offered before.
+	it.each( [
+		[ true, 'Back', 'See all options' ],
+		[ false, 'See all options', 'Back' ],
+	] )(
+		'keeps the way to the social screen for an ordinary signup, back button in footer: %s',
+		( backButtonInFooter, shown, hidden ) => {
+			render(
+				<SignupFormSocialFirst
+					{ ...defaultProps }
+					userEmail="new@example.com"
+					backButtonInFooter={ backButtonInFooter }
+				/>
+			);
+
+			expect( screen.getByRole( 'button', { name: shown } ) ).toBeVisible();
+			expect( screen.queryByRole( 'button', { name: hidden } ) ).not.toBeInTheDocument();
+		}
+	);
 
 	describe( 'MobileCompactTosNotice', () => {
 		test( 'renders the "options above" copy', () => {

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -286,11 +286,13 @@ describe( 'SignupFormSocialFirst', () => {
 				customTosElement: <span>Partner terms apply.</span>,
 			} );
 
-			const emailScreen = within(
-				screen.getByRole( 'textbox' ).closest( '.signup-form-social-first-screen' ) as HTMLElement
-			);
+			const emailScreenEl = screen
+				.getByRole( 'textbox' )
+				.closest( '.signup-form-social-first-screen' ) as HTMLElement;
+			const emailScreen = within( emailScreenEl );
 			expect( emailScreen.getByText( 'That address is already in use.' ) ).toBeVisible();
-			expect( emailScreen.queryByText( /By clicking "Continue,"/ ) ).not.toBeInTheDocument();
+			// On text content: the generic terms are split across links, so no node holds the phrase.
+			expect( emailScreenEl ).not.toHaveTextContent( 'By clicking' );
 
 			// Partner copy points at the options below it, so it can't sit under them.
 			const terms = emailScreen.getByText( 'Partner terms apply.' );

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -208,7 +208,7 @@ describe( 'SignupFormSocialFirst', () => {
 					{ ...defaultProps }
 					{ ...layout }
 					userEmail="typo@example.com"
-					onUpdateEmail={ jest.fn() }
+					emailUpdate={ { submit: jest.fn(), cancel: jest.fn() } }
 				/>
 			);
 
@@ -222,7 +222,7 @@ describe( 'SignupFormSocialFirst', () => {
 				<SignupFormSocialFirst
 					{ ...defaultProps }
 					userEmail="typo@example.com"
-					onUpdateEmail={ () => new Promise< void >( () => {} ) }
+					emailUpdate={ { submit: () => new Promise< void >( () => {} ), cancel: jest.fn() } }
 				/>
 			);
 
@@ -231,14 +231,75 @@ describe( 'SignupFormSocialFirst', () => {
 			expect( await screen.findByRole( 'button', { name: 'Updating…' } ) ).toBeVisible();
 		} );
 
+		// The screen has no other screen to be on, however it was reached.
+		it( 'shows the email field when it was given no address to start from', () => {
+			render(
+				<SignupFormSocialFirst
+					{ ...defaultProps }
+					emailUpdate={ { submit: jest.fn(), cancel: jest.fn() } }
+				/>
+			);
+
+			expect(
+				screen.getByRole( 'textbox' ).closest( '.signup-form-social-first-screen' )
+			).toHaveClass( 'visible' );
+		} );
+
+		// Outside the screen it lands in a grid row of its own, beneath the field, the footer and
+		// the terms — which is where a failed update would explain itself.
+		it( 'puts what the caller has to say above the form it is about', () => {
+			render(
+				<SignupFormSocialFirst
+					{ ...defaultProps }
+					userEmail="typo@example.com"
+					notice={ <div>That address is already in use.</div> }
+					emailUpdate={ { submit: jest.fn(), cancel: jest.fn() } }
+				/>
+			);
+
+			const screenEl = screen.getByRole( 'textbox' ).closest( '.signup-form-social-first-screen' );
+			expect( screenEl ).toContainElement( screen.getByText( 'That address is already in use.' ) );
+		} );
+
+		// It leaves the screen, and a write already in flight would land anyway.
+		it( 'holds the way back shut while a change is being written', async () => {
+			const cancel = jest.fn();
+			render(
+				<SignupFormSocialFirst
+					{ ...defaultProps }
+					userEmail="typo@example.com"
+					emailUpdate={ { submit: () => new Promise< void >( () => {} ), cancel } }
+				/>
+			);
+
+			await userEvent.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+			await userEvent.click( await screen.findByRole( 'button', { name: 'Cancel' } ) );
+
+			expect( cancel ).not.toHaveBeenCalled();
+		} );
+
+		// Otherwise a refusal leaves the field and the button disabled with no way to try again.
+		it( 'gives the screen back when the change is refused', async () => {
+			render(
+				<SignupFormSocialFirst
+					{ ...defaultProps }
+					userEmail="typo@example.com"
+					emailUpdate={ { submit: () => Promise.reject( new Error( 'nope' ) ), cancel: jest.fn() } }
+				/>
+			);
+
+			await userEvent.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+			expect( await screen.findByRole( 'button', { name: 'Continue' } ) ).toBeEnabled();
+		} );
+
 		it( 'offers a way back to whoever opened it', async () => {
 			const onCancelEmailUpdate = jest.fn();
 			render(
 				<SignupFormSocialFirst
 					{ ...defaultProps }
 					userEmail="typo@example.com"
-					onUpdateEmail={ jest.fn() }
-					onCancelEmailUpdate={ onCancelEmailUpdate }
+					emailUpdate={ { submit: jest.fn(), cancel: onCancelEmailUpdate } }
 				/>
 			);
 


### PR DESCRIPTION
Part of DOTCOM-18086, and the first of two: this teaches the shared signup form a mode it doesn't have yet, and a follow-up uses it from the onboarding email verification gate.

## Proposed Changes

* `SignupFormSocialFirst` takes an optional `onUpdateEmail`, which replaces account creation with a change to the account the caller already has.
* On that screen nothing offers a second account: no social form, no route to one, and no back button to either. Submitting the address unchanged is how the caller gets its user back, so there is nothing else to leave by.
* The button says "Updating…" rather than "Creating Your Account…" while the change runs, and an address mistyped a second time no longer records a signup failure.
* `notice` and a partner's own terms render on that screen, since both otherwise sit only on the one this mode never shows.
* The social screen isn't rendered in this mode, and the compact layout, which has no screens at all, isn't used for it.

Nothing passes `onUpdateEmail`, so every existing flow renders exactly what it rendered before.

## Why are these changes being made?

The onboarding flow is gaining an email verification gate, which makes a mistyped address a dead end — the screen offers an inbox link and a resend, both aimed somewhere no mail will arrive. The way out is to send the user back to the account screen with the address prefilled, which the design asks for. What they submit there has to change the account rather than create another one: accounts are created *and* activated, so a second signup leaves the first holding the mistyped address permanently, and where a typo lands on a real person's address, that person is silently locked out of registering.

The account screen already has an email-only view — it is what a prefilled form opens on, and it is the field, Continue and the terms, with a link back to the social options. This mode renders that same screen from its own branch, beside the one the compact layout already has. Only the link back has to go, and nothing takes its place: an unchanged address submitted is already a complete instruction — the caller has its user and nothing to write, and can simply return them.

Its own branch rather than conditions threaded through the shared path, so every other caller renders what it rendered before, one line aside. Two things move onto the screen because this mode never leaves it: the notice a caller reports failures through, and partner legal copy. The signup screen isn't mounted at all — it stacks in the same grid cell, so it would go on setting the height, and the email-first variants mount a second `signup-email` input on it that takes the visible label and competes for the focus.

## Testing Instructions

Nothing in the product reaches this yet, so it is verified by the account screen being unchanged.

1. Run Calypso locally and open `/setup/onboarding`.
2. The account screen should look and behave exactly as on trunk: social buttons, the email field, and "See all options" or "Back" depending on the layout.
3. Repeat on a narrow viewport for the mobile-compact layout, and with a Woo referrer for the email-first one.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
