### PR TITLE
Update mobile checkout experiment name to 1.1

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1219,7 +1219,7 @@ export default function CheckoutMainContent( {
 
 /**
  * Styles for the mobile sticky order summary experiment
- * (`calypso_mobile_checkout_sticky_summary_v1`).
+ * (`calypso_mobile_checkout_sticky_summary_v1_1`).
  *
  * Interpolated last in `StepContainerV2CheckoutFixer` so that for a user
  * enrolled in both this and the checkout UI redesign, these rules win the

--- a/client/my-sites/checkout/src/hooks/test/use-mobile-checkout-sticky-summary-experiment.ts
+++ b/client/my-sites/checkout/src/hooks/test/use-mobile-checkout-sticky-summary-experiment.ts
@@ -28,7 +28,7 @@ const mockUseIsStepContainerV2 = useInitialIsInStepContainerV2FlowContext as jes
 >;
 
 const treatmentAssignment = {
-	experimentName: 'calypso_mobile_checkout_sticky_summary_v1',
+	experimentName: 'calypso_mobile_checkout_sticky_summary_v1_1',
 	variationName: 'treatment',
 	retrievedTimestamp: 0,
 	ttl: 0,
@@ -48,9 +48,12 @@ describe( 'useMobileCheckoutStickySummaryExperiment', () => {
 	it( 'only requests experiment assignment on mobile inside a StepContainerV2 flow', () => {
 		renderHook( () => useMobileCheckoutStickySummaryExperiment() );
 
-		expect( mockUseExperiment ).toHaveBeenCalledWith( 'calypso_mobile_checkout_sticky_summary_v1', {
-			isEligible: true,
-		} );
+		expect( mockUseExperiment ).toHaveBeenCalledWith(
+			'calypso_mobile_checkout_sticky_summary_v1_1',
+			{
+				isEligible: true,
+			}
+		);
 	} );
 
 	it( 'opts out of experiment assignment on large viewports', () => {
@@ -58,9 +61,12 @@ describe( 'useMobileCheckoutStickySummaryExperiment', () => {
 
 		renderHook( () => useMobileCheckoutStickySummaryExperiment() );
 
-		expect( mockUseExperiment ).toHaveBeenCalledWith( 'calypso_mobile_checkout_sticky_summary_v1', {
-			isEligible: false,
-		} );
+		expect( mockUseExperiment ).toHaveBeenCalledWith(
+			'calypso_mobile_checkout_sticky_summary_v1_1',
+			{
+				isEligible: false,
+			}
+		);
 	} );
 
 	// The sticky summary only exists in the StepContainerV2 branch, and these
@@ -71,9 +77,12 @@ describe( 'useMobileCheckoutStickySummaryExperiment', () => {
 
 		renderHook( () => useMobileCheckoutStickySummaryExperiment() );
 
-		expect( mockUseExperiment ).toHaveBeenCalledWith( 'calypso_mobile_checkout_sticky_summary_v1', {
-			isEligible: false,
-		} );
+		expect( mockUseExperiment ).toHaveBeenCalledWith(
+			'calypso_mobile_checkout_sticky_summary_v1_1',
+			{
+				isEligible: false,
+			}
+		);
 	} );
 
 	it( 'returns isLoading false and isMobileCheckoutStickySummary false on large viewports', () => {
@@ -163,7 +172,7 @@ describe( 'useMobileCheckoutStickySummaryExperiment', () => {
 			rerender();
 
 			expect( mockUseExperiment ).toHaveBeenLastCalledWith(
-				'calypso_mobile_checkout_sticky_summary_v1',
+				'calypso_mobile_checkout_sticky_summary_v1_1',
 				{ isEligible: false }
 			);
 		} );

--- a/client/my-sites/checkout/src/hooks/use-mobile-checkout-sticky-summary-experiment.ts
+++ b/client/my-sites/checkout/src/hooks/use-mobile-checkout-sticky-summary-experiment.ts
@@ -3,7 +3,7 @@ import { useRef } from 'react';
 import { useInitialIsInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import { useExperiment } from 'calypso/lib/explat';
 
-const EXPERIMENT_NAME = 'calypso_mobile_checkout_sticky_summary_v1';
+const EXPERIMENT_NAME = 'calypso_mobile_checkout_sticky_summary_v1_1';
 const QUERY_PARAM = 'mobile_checkout_sticky_summary';
 
 export interface MobileCheckoutStickySummaryExperiment {


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

This bumps the experiment name to `calypso_mobile_checkout_sticky_summary_v1_1`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We are re-starting this experiment. See 22714-explat-experiment and p1785966929357819/1785314921.301189-slack-C09S7QUPAA0 and 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

None