### PR TITLE
Omnibar: use orange background in support session

### DIFF
--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -4,6 +4,7 @@ import {
 	siteAdminBarQuery,
 	siteByIdQuery,
 } from '@automattic/api-queries';
+import { isSupportSession } from '@automattic/calypso-support-session';
 import { AdminBarNode, Omnibar, buildOmnibarNodesFromAdminBarNodes } from '@automattic/omnibar';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
@@ -97,7 +98,13 @@ export default function OmnibarContainer( { user }: { user?: User } ) {
 	if ( ! hydrated ) {
 		return <InitialOmnibar user={ user } />;
 	}
-	return <Omnibar nodes={ omnibarNodes } onClickResponsiveMenu={ onClickResponsiveMenu } />;
+	return (
+		<Omnibar
+			nodes={ omnibarNodes }
+			onClickResponsiveMenu={ onClickResponsiveMenu }
+			className={ isSupportSession() ? 'is-support-session' : undefined }
+		/>
+	);
 }
 
 export function InitialOmnibar( { user }: { user?: User } ) {

--- a/client/dashboard/app/omnibar/style.scss
+++ b/client/dashboard/app/omnibar/style.scss
@@ -4,3 +4,12 @@
 	inset-inline: 0;
 	z-index: 999;
 }
+
+body:has( .omnibar.is-support-session ) {
+	--omnibar-background: #b26200;
+	--omnibar-menu-active-background: #8a4d00;
+	--omnibar-submenu-background: #8a4d00;
+	--omnibar-highlight-color: #fff;
+	--omnibar-submenu-highlight-color: #ffbf86;
+	--omnibar-avatar-ring-color: #8a4d00;
+}

--- a/packages/omnibar/src/components/omnibar-user.scss
+++ b/packages/omnibar/src/components/omnibar-user.scss
@@ -1,5 +1,3 @@
-@import './variables';
-
 .omnibar,
 .omnibar__popover {
 	.omnibar__user {
@@ -11,7 +9,7 @@
 		box-sizing: border-box;
 		width: 30px;
 		height: 30px;
-		border: 1px solid $omnibar-avatar-ring-color;
+		border: 1px solid var( --omnibar-avatar-ring-color );
 		border-radius: 50%;
 		overflow: hidden;
 
@@ -33,7 +31,7 @@
 			display: block;
 			object-fit: cover;
 			border-radius: 50%;
-			background: $omnibar-avatar-ring-color;
+			background: var( --omnibar-avatar-ring-color );
 		}
 	}
 

--- a/packages/omnibar/src/components/omnibar.scss
+++ b/packages/omnibar/src/components/omnibar.scss
@@ -4,6 +4,13 @@
 body:has( .omnibar ) {
 	--omnibar-height: #{$omnibar-height-mobile};
 	--masterbar-height: var( --omnibar-height );
+	--omnibar-background: #{$omnibar-base-color};
+	--omnibar-menu-active-background: #{$omnibar-submenu-background};
+	--omnibar-submenu-background: #{$omnibar-submenu-background};
+	--omnibar-text-color: #{$omnibar-text-color};
+	--omnibar-highlight-color: #{$omnibar-highlight-color};
+	--omnibar-submenu-highlight-color: #{$omnibar-highlight-color};
+	--omnibar-avatar-ring-color: #{$omnibar-avatar-ring-color};
 
 	@media ( min-width: 782px ) {
 		--omnibar-height: #{$omnibar-height};
@@ -11,9 +18,6 @@ body:has( .omnibar ) {
 }
 
 .omnibar {
-	--omnibar-background: #{$omnibar-base-color};
-	--omnibar-menu-active-background: #{$omnibar-submenu-background};
-
 	background-color: var( --omnibar-background );
 	min-height: var( --omnibar-height );
 	height: var( --omnibar-height );
@@ -42,7 +46,7 @@ body:has( .omnibar ) {
 		height: var( --omnibar-height );
 		min-width: 52px;
 		padding: 0;
-		color: $omnibar-text-color;
+		color: var( --omnibar-text-color );
 		background-color: transparent;
 		font-family: inherit;
 		font-size: $omnibar-font-size;
@@ -58,7 +62,7 @@ body:has( .omnibar ) {
 		&:active,
 		&[aria-expanded='true'] {
 			background-color: var( --omnibar-menu-active-background );
-			color: $omnibar-text-color;
+			color: var( --omnibar-text-color );
 			box-shadow: none;
 			outline: none;
 		}
@@ -68,7 +72,7 @@ body:has( .omnibar ) {
 		}
 
 		&:focus-visible {
-			box-shadow: inset 0 0 0 2px $omnibar-highlight-color;
+			box-shadow: inset 0 0 0 2px var( --omnibar-highlight-color );
 			outline-offset: -2px;
 		}
 
@@ -219,12 +223,14 @@ body:has( .omnibar ) {
 	// All colors used by the Menu's internal Emotion styles read from these
 	// CSS custom properties (see node_modules/@wordpress/components/src/menu/styles.ts).
 	// Setting them here re-skins the entire popover without specificity wars.
-	--wp-components-color-background: #{$omnibar-submenu-background};
-	--wp-components-color-foreground: #{$omnibar-text-color};
+	--wp-components-color-background: var( --omnibar-submenu-background );
+	--wp-components-color-foreground: var( --omnibar-text-color );
 	--wp-components-color-accent: transparent; // hover/active item bg
-	--wp-components-color-accent-inverted: #{$omnibar-highlight-color}; // hover/active item text
+	--wp-components-color-accent-inverted: var(
+		--omnibar-submenu-highlight-color
+	); // hover/active item text
 	--wp-components-color-gray-100: transparent; // submenu-trigger-open bg
-	--wp-components-color-gray-700: #{$omnibar-text-color}; // prefix / suffix text
+	--wp-components-color-gray-700: var( --omnibar-text-color ); // prefix / suffix text
 
 	// Padding, border-radius, and the elevation portion of the popover's
 	// box-shadow are hardcoded (not tokens). Class is doubled to outrank

--- a/packages/omnibar/src/components/omnibar.tsx
+++ b/packages/omnibar/src/components/omnibar.tsx
@@ -7,9 +7,13 @@ import type { OmnibarProps } from '../types';
 
 import './omnibar.scss';
 
-export function Omnibar( { nodes, onClickResponsiveMenu }: OmnibarProps ) {
+export function Omnibar( { nodes, onClickResponsiveMenu, className }: OmnibarProps ) {
 	return (
-		<div className="omnibar" role="navigation" aria-label="Toolbar">
+		<div
+			className={ className ? `omnibar ${ className }` : 'omnibar' }
+			role="navigation"
+			aria-label="Toolbar"
+		>
 			{ onClickResponsiveMenu && (
 				<OmnibarResponsiveMenu onClickResponsiveMenu={ onClickResponsiveMenu } />
 			) }

--- a/packages/omnibar/src/types/omnibar.ts
+++ b/packages/omnibar/src/types/omnibar.ts
@@ -32,4 +32,5 @@ export interface OmnibarNodes {
 export interface OmnibarProps {
 	nodes: OmnibarNodes;
 	onClickResponsiveMenu?: () => void;
+	className?: string;
 }


### PR DESCRIPTION
## Proposed Changes

Recolor the omnibar with orange color in support session:

<img width="1792" height="64" alt="image" src="https://github.com/user-attachments/assets/1a0b9cc0-845f-441e-8f19-3d046a0df713" />

## Testing Instructions

Test with `dashboard/omnibar-radical` flag turned on.

1. Check out locally.
2. Run in browser console:

```
document.cookie = 'support_session_id=1; path=/';
location.reload();
```

3. Verify the omnibar turns orange as the above screenshot.
4. To reset, run this:

```
document.cookie = 'support_session_id=; path=/; max-age=0';
location.reload();
```