### PR TITLE
Add /me/logout route that clears site data, and route logout flows through it

### DIFF
--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -240,8 +240,12 @@ export async function logout( user: User ): Promise< void > {
 	//    ignoring the user's API-provided logout URL.
 	// 3. user.logout_URL: the WP.com logout URL from the /me API response.
 	// 4. Fallback: the static logout_url from config, or the dashboard root.
+	// OAuth dashboards with no static logout_url switch accounts through the
+	// OAuth flow, which manages its own redirect.
+	const isOAuthLogout = config.isEnabled( 'oauth' ) && ! configLogoutUrl;
+
 	let logoutUrl = '';
-	if ( config.isEnabled( 'oauth' ) && ! configLogoutUrl ) {
+	if ( isOAuthLogout ) {
 		const state = crypto.randomUUID();
 		sessionStorage.setItem( 'wpcom_oauth_state', state );
 
@@ -252,6 +256,17 @@ export async function logout( user: User ): Promise< void > {
 		logoutUrl = user.logout_URL;
 	} else {
 		logoutUrl = configLogoutUrl || window.location.origin;
+	}
+
+	// Point the logout URL's redirect at `/me/logout` so, after the WP.com session
+	// is invalidated, the browser lands there and clears its stored site data via
+	// the `Clear-Site-Data` header before reaching the login page. Ordering
+	// matters: the logout nonce is validated against the live session, so the
+	// clear must run on the way back, not before.
+	if ( ! isOAuthLogout ) {
+		const url = new URL( logoutUrl, window.location.origin );
+		url.searchParams.set( 'redirect_to', new URL( '/me/logout', window.location.origin ).href );
+		logoutUrl = url.href;
 	}
 
 	disablePersistQueryClient();

--- a/client/document/logout.jsx
+++ b/client/document/logout.jsx
@@ -1,0 +1,164 @@
+import { WordPressLogo } from '@automattic/components';
+
+function logoutFn( { redirectTo, counterpartOrigin, statsEnabled, supportSession } ) {
+	// Every failure here is silent, so report the outcome — otherwise a clear that
+	// stops working looks exactly like one that succeeded.
+	function bump( outcome ) {
+		if ( ! statsEnabled ) {
+			return;
+		}
+
+		const url =
+			window.location.protocol +
+			'//pixel.wp.com/g.gif?v=wpcom-no-pv&x_logout-clear-site-data=' +
+			outcome +
+			'&t=' +
+			Math.random();
+
+		try {
+			if ( window.fetch ) {
+				// `keepalive` so the request outlives the redirect below.
+				window.fetch( url, { mode: 'no-cors', keepalive: true } ).catch( function () {} );
+			} else {
+				new window.Image().src = url;
+			}
+		} catch ( e ) {}
+	}
+
+	let settled = false;
+	function done( outcome ) {
+		if ( settled ) {
+			return;
+		}
+		settled = true;
+		bump( outcome );
+		window.location.replace( redirectTo );
+	}
+
+	// Reported separately so a deliberate skip isn't counted as a failed clear.
+	if ( supportSession ) {
+		done( 'support-session' );
+		return;
+	}
+
+	const iframe = document.getElementById( 'logout-clear-frame' );
+
+	if ( ! iframe ) {
+		done( 'no-counterpart' );
+		return;
+	}
+
+	// Wait for the counterpart to report what it did, rather than for `load`,
+	// which fires even when the frame was blocked or served an error page.
+	window.addEventListener( 'message', function ( event ) {
+		if ( event.origin !== counterpartOrigin ) {
+			return;
+		}
+		if ( ! event.data || event.data.type !== 'wpcom-logout-clear' ) {
+			return;
+		}
+		done( event.data.cleared ? 'counterpart-cleared' : 'counterpart-not-cleared' );
+	} );
+
+	window.setTimeout( function () {
+		done( 'counterpart-timeout' );
+	}, 2000 );
+}
+
+function embedFn( { cleared, embedderOrigin } ) {
+	if ( window.parent !== window ) {
+		window.parent.postMessage( { type: 'wpcom-logout-clear', cleared: cleared }, embedderOrigin );
+	}
+}
+
+function Logout( {
+	redirectTo = '/log-in',
+	iframeSrc = null,
+	embed = false,
+	cleared = false,
+	embedderOrigin = null,
+	statsEnabled = false,
+	supportSession = false,
+} ) {
+	// Loaded inside the counterpart's iframe: carries the header, and reports back
+	// whether it was actually set.
+	if ( embed ) {
+		return (
+			<html lang="en">
+				<body>
+					{ /* eslint-disable react/no-danger */ }
+					{ embedderOrigin && (
+						<script
+							dangerouslySetInnerHTML={ {
+								__html: `
+								const embedFn = ${ embedFn.toString() };
+
+								embedFn( { cleared: ${ cleared ? 'true' : 'false' }, embedderOrigin: "${ encodeURI(
+									embedderOrigin
+								) }" } );
+								`,
+							} }
+						/>
+					) }
+					{ /* eslint-enable react/no-danger */ }
+				</body>
+			</html>
+		);
+	}
+
+	return (
+		<html lang="en">
+			<body>
+				{ /* eslint-disable react/no-danger */ }
+				{ /* Same boot placeholder as `document/index.jsx`, with the styles
+				     inlined because this page loads no stylesheet. */ }
+				<style
+					dangerouslySetInnerHTML={ {
+						__html: `
+							body { margin: 0; }
+							.wpcom-site__logo,
+							.wpcom-site__logo path {
+								fill: var(--color-neutral-10, #c3c4c7);
+								color: var(--color-neutral-10, #c3c4c7);
+							}
+							.wpcom-site__logo {
+								position: fixed;
+								top: 50%;
+								left: 50%;
+								transform: translate(-50%, -50%);
+							}
+						`,
+					} }
+				/>
+				<div id="wpcom" className="wpcom-site">
+					<WordPressLogo size={ 72 } className="wpcom-site__logo" />
+				</div>
+				{ iframeSrc && (
+					<iframe
+						id="logout-clear-frame"
+						title="Signing out"
+						src={ iframeSrc }
+						style={ { display: 'none' } }
+					/>
+				) }
+				<script
+					dangerouslySetInnerHTML={ {
+						__html: `
+						const logoutFn = ${ logoutFn.toString() };
+
+						logoutFn( {
+							redirectTo: "${ encodeURI( redirectTo ) }",
+							counterpartOrigin: ${ iframeSrc ? `"${ encodeURI( new URL( iframeSrc ).origin ) }"` : 'null' },
+							statsEnabled: ${ statsEnabled ? 'true' : 'false' },
+							supportSession: ${ supportSession ? 'true' : 'false' },
+						} );
+						`,
+					} }
+				/>
+				{ /* eslint-enable react/no-danger */ }
+			</body>
+		</html>
+	);
+}
+
+export default Logout;

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -28,13 +28,17 @@ import {
 	CIAB_DASHBOARD_SECTION_DEFINITION,
 	CIAB_DASHBOARD_SECTION_PATHS,
 } from 'calypso/dashboard/app-ciab/section';
-import { isAllowedDotcomDashboardHostname } from 'calypso/dashboard/app-dotcom/routing';
+import {
+	buildDotcomDashboardLink,
+	isAllowedDotcomDashboardHostname,
+} from 'calypso/dashboard/app-dotcom/routing';
 import {
 	DOTCOM_DASHBOARD_SECTION_DEFINITION,
 	DOTCOM_DASHBOARD_SECTION_PATHS,
 } from 'calypso/dashboard/app-dotcom/section';
 import { A4A_SIGNUP_PATHS } from 'calypso/dashboard/section';
 import isDashboardEnv from 'calypso/dashboard/utils/is-dashboard-env';
+import { wpcomLink } from 'calypso/dashboard/utils/link';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { STEPPER_SECTION_DEFINITION } from 'calypso/landing/stepper/section';
 import { SUBSCRIPTIONS_SECTION_DEFINITION } from 'calypso/landing/subscriptions/section';
@@ -1212,6 +1216,102 @@ function wpcomPages( app ) {
 	} );
 }
 
+/**
+ * Resolve the counterpart origin's `/me/logout` URL for the cross-origin clear.
+ *
+ * `Clear-Site-Data` only clears the origin that returns it, and Calypso and the
+ * Dashboard are separate origins. Returns `null` when there is no counterpart.
+ */
+function getCounterpartLogoutUrl( req ) {
+	if ( req.hostname.endsWith( '.calypso.live' ) ) {
+		return null;
+	}
+
+	if ( isAllowedDotcomDashboardHostname( req.hostname ) ) {
+		// `wpcomLink` resolves the classic origin from the `wpcom_url` config.
+		return wpcomLink( '/me/logout?embed=1' );
+	}
+
+	if ( [ 'wordpress.com', 'calypso.localhost' ].includes( req.hostname ) ) {
+		return buildDotcomDashboardLink( '/me/logout?embed=1' );
+	}
+
+	return null;
+}
+
+/**
+ * Resolve where `/me/logout` sends the user once data is cleared.
+ *
+ * Same-origin destinations are returned as a relative path. A few external hosts
+ * are allowed too, because logout flows legitimately end off-site — `wp-login.php`
+ * already accepts these, and dropping them would strand those flows on `/log-in`.
+ * Anything else falls back to `/log-in` rather than becoming an open redirect.
+ */
+const LOGOUT_REDIRECT_HOSTS = [ 'woocommerce.com', 'jetpack.com' ];
+
+function getLogoutRedirectTo( req ) {
+	const target = req.query.redirect_to;
+	if ( typeof target !== 'string' || ! target ) {
+		return '/log-in';
+	}
+
+	const host = req.get( 'host' );
+	try {
+		const resolved = new URL( target, `https://${ host }` );
+		const destination = resolved.pathname + resolved.search + resolved.hash;
+		// Reject protocol-relative (`//host`) destinations, which would otherwise
+		// read as a relative path.
+		if ( resolved.host === host && ! destination.startsWith( '//' ) ) {
+			return destination;
+		}
+
+		if ( resolved.protocol === 'https:' && LOGOUT_REDIRECT_HOSTS.includes( resolved.host ) ) {
+			return resolved.href;
+		}
+	} catch {
+		// Fall through to the default.
+	}
+
+	return '/log-in';
+}
+
+/**
+ * Whether this request should be answered with `Clear-Site-Data`.
+ *
+ * The browser honors the header even on a response it refuses to render, so
+ * framing controls can't gate it — any site could point an `<img>` at this route
+ * and wipe a visitor's data. Check the requester instead.
+ *
+ * Fails closed for the header only: the page still renders and redirects.
+ */
+function shouldClearSiteData( req, counterpartUrl ) {
+	// Matches `clearQueryClient` — the support user's token lives in this
+	// origin's sessionStorage.
+	if ( req.context?.isSupportSession ) {
+		return false;
+	}
+
+	const dest = req.get( 'sec-fetch-dest' );
+
+	if ( ! req.query.embed ) {
+		// Rules out `<img>` and `fetch()`. A cross-site navigation still qualifies,
+		// but that is a visible page load.
+		return dest === 'document' && req.get( 'sec-fetch-mode' ) === 'navigate';
+	}
+
+	// `Origin` is not sent on GET navigations, so the referrer identifies the
+	// embedder; the top-level response pins `Referrer-Policy` so it arrives.
+	if ( dest !== 'iframe' || ! counterpartUrl ) {
+		return false;
+	}
+
+	try {
+		return new URL( req.get( 'referer' ) ).origin === new URL( counterpartUrl ).origin;
+	} catch {
+		return false;
+	}
+}
+
 export default function pages() {
 	const app = express();
 
@@ -1223,6 +1323,46 @@ export default function pages() {
 	app.use( middlewareCache() );
 	app.use( setupLoggedInContext );
 	app.use( middlewareUnsupportedBrowser() );
+
+	// Clears this origin via `Clear-Site-Data`, then the counterpart origin
+	// through a hidden iframe, before redirecting to the login page. Session
+	// invalidation is the client logout flow's job. Registered before section
+	// routing so it responds on both hostnames.
+	app.get( '/me/logout', ( req, res ) => {
+		const counterpartUrl = getCounterpartLogoutUrl( req );
+		const cleared = shouldClearSiteData( req, counterpartUrl );
+
+		if ( cleared ) {
+			res.set( 'Clear-Site-Data', '"storage", "cache", "cookies"' );
+		}
+
+		if ( req.query.embed ) {
+			// Only the counterpart may frame this. `frame-ancestors` rather than
+			// `X-Frame-Options`, which can't express a cross-origin allowlist —
+			// and which this route avoids only by running before the section
+			// middleware that sets it.
+			const embedder = counterpartUrl ? new URL( counterpartUrl ).origin : null;
+			res.set( 'Content-Security-Policy', `frame-ancestors ${ embedder ?? "'none'" }` );
+			res.send( renderJsx( 'logout', { embed: true, cleared, embedderOrigin: embedder } ) );
+			return;
+		}
+
+		// Never framed. `Referrer-Policy` is pinned so the iframe below carries
+		// this origin as its referrer, which is what authorizes its clear.
+		res.set( {
+			'Content-Security-Policy': "frame-ancestors 'none'",
+			'Referrer-Policy': 'strict-origin',
+		} );
+		res.send(
+			renderJsx( 'logout', {
+				// No counterpart frame during a support session — neither origin is cleared.
+				iframeSrc: req.context?.isSupportSession ? null : counterpartUrl,
+				redirectTo: getLogoutRedirectTo( req ),
+				statsEnabled: !! config( 'mc_analytics_enabled' ),
+				supportSession: !! req.context?.isSupportSession,
+			} )
+		);
+	} );
 
 	if ( ! ( isJetpackCloud() || isA8CForAgencies() || isDashboardEnv() ) ) {
 		wpcomPages( app );

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -1376,6 +1376,188 @@ describe( 'main app', () => {
 		} );
 	} );
 
+	describe( 'Route /me/logout', () => {
+		const CLEAR_SITE_DATA = '"storage", "cache", "cookies"';
+
+		// The route reads request headers via `req.get`, and Express derives
+		// `req.hostname` from the Host header.
+		const logoutRequest = ( { url = '/me/logout', query = {}, headers = {}, cookies } = {} ) => {
+			const allHeaders = { host: 'wordpress.com', ...headers };
+			return {
+				url,
+				query,
+				headers: allHeaders,
+				...( cookies ? { cookies } : {} ),
+				get: jest.fn( ( name ) => allHeaders[ name.toLowerCase() ] ),
+			};
+		};
+
+		const navigation = ( extra = {} ) =>
+			logoutRequest( {
+				headers: { 'sec-fetch-dest': 'document', 'sec-fetch-mode': 'navigate' },
+				...extra,
+			} );
+
+		const clearHeaderCalls = ( response ) =>
+			response.setHeader.mock.calls.filter( ( [ name ] ) => name === 'Clear-Site-Data' );
+
+		beforeEach( () => {
+			app.withRenderJSX( 'content' );
+		} );
+
+		it( 'clears site data for a top-level navigation', async () => {
+			const { response } = await app.run( { request: navigation() } );
+
+			expect( response.setHeader ).toHaveBeenCalledWith( 'Clear-Site-Data', CLEAR_SITE_DATA );
+		} );
+
+		it( 'withholds the header for non-navigation requests', async () => {
+			// An <img> or fetch() pointed at this route: the browser honors
+			// Clear-Site-Data on any response it fetches, so this is the gate that
+			// stops an unrelated site wiping a visitor's data.
+			for ( const dest of [ 'image', 'empty', 'script' ] ) {
+				const { response } = await app.run( {
+					request: logoutRequest( { headers: { 'sec-fetch-dest': dest } } ),
+				} );
+
+				expect( clearHeaderCalls( response ) ).toHaveLength( 0 );
+			}
+		} );
+
+		it( 'clears site data for an embed framed by the counterpart origin', async () => {
+			const { response } = await app.run( {
+				request: logoutRequest( {
+					query: { embed: '1' },
+					headers: {
+						'sec-fetch-dest': 'iframe',
+						referer: 'https://my.wordpress.com/me/logout',
+					},
+				} ),
+			} );
+
+			expect( response.setHeader ).toHaveBeenCalledWith( 'Clear-Site-Data', CLEAR_SITE_DATA );
+		} );
+
+		it( 'withholds the header for an embed framed by anyone else', async () => {
+			const { response } = await app.run( {
+				request: logoutRequest( {
+					query: { embed: '1' },
+					headers: { 'sec-fetch-dest': 'iframe', referer: 'https://evil.example/' },
+				} ),
+			} );
+
+			expect( clearHeaderCalls( response ) ).toHaveLength( 0 );
+		} );
+
+		it( 'withholds the header when the embed has no referrer at all', async () => {
+			const { response } = await app.run( {
+				request: logoutRequest( {
+					query: { embed: '1' },
+					headers: { 'sec-fetch-dest': 'iframe' },
+				} ),
+			} );
+
+			expect( clearHeaderCalls( response ) ).toHaveLength( 0 );
+		} );
+
+		it( 'leaves support sessions alone', async () => {
+			// The support user's token lives in this origin's sessionStorage.
+			const { response } = await app.run( {
+				request: navigation( { cookies: { support_session_id: 'abc' } } ),
+			} );
+
+			expect( clearHeaderCalls( response ) ).toHaveLength( 0 );
+		} );
+
+		it( 'leaves support sessions alone on the embed variant too', async () => {
+			const { response } = await app.run( {
+				request: logoutRequest( {
+					query: { embed: '1' },
+					cookies: { support_session_id: 'abc' },
+					headers: {
+						'sec-fetch-dest': 'iframe',
+						referer: 'https://my.wordpress.com/me/logout',
+					},
+				} ),
+			} );
+
+			expect( clearHeaderCalls( response ) ).toHaveLength( 0 );
+		} );
+
+		it( 'forbids framing the top-level page', async () => {
+			const { response } = await app.run( { request: navigation() } );
+
+			expect( response.setHeader ).toHaveBeenCalledWith(
+				'Content-Security-Policy',
+				"frame-ancestors 'none'"
+			);
+		} );
+
+		it( 'pins the referrer policy so the embed request can be authorized', async () => {
+			const { response } = await app.run( { request: navigation() } );
+
+			expect( response.setHeader ).toHaveBeenCalledWith( 'Referrer-Policy', 'strict-origin' );
+		} );
+
+		it( 'does not set X-Frame-Options', async () => {
+			// The counterpart embeds this cross-origin, which SAMEORIGIN forbids. The
+			// route escapes that header only by being registered before the section
+			// middleware that sets it — moving it below would silently break the
+			// cross-origin clear.
+			const { response } = await app.run( {
+				request: logoutRequest( {
+					query: { embed: '1' },
+					headers: {
+						'sec-fetch-dest': 'iframe',
+						referer: 'https://my.wordpress.com/me/logout',
+					},
+				} ),
+			} );
+
+			expect( response.setHeader ).not.toHaveBeenCalledWith( 'X-Frame-Options', expect.anything() );
+		} );
+
+		it( 'honors a same-origin redirect_to', async () => {
+			await app.run( { request: navigation( { query: { redirect_to: '/me/account' } } ) } );
+
+			expect( app.getMocks().renderJsx ).toHaveBeenCalledWith(
+				'logout',
+				expect.objectContaining( { redirectTo: '/me/account' } )
+			);
+		} );
+
+		it.each( [
+			[ 'woocommerce.com', 'https://woocommerce.com/start/' ],
+			[ 'jetpack.com', 'https://jetpack.com/pricing/' ],
+		] )( 'honors an allowlisted %s redirect_to', async ( _label, redirect_to ) => {
+			// Logout flows legitimately end off-site; dropping these strands them.
+			await app.run( { request: navigation( { query: { redirect_to } } ) } );
+
+			expect( app.getMocks().renderJsx ).toHaveBeenCalledWith(
+				'logout',
+				expect.objectContaining( { redirectTo: redirect_to } )
+			);
+		} );
+
+		it.each( [
+			[ 'cross-origin', 'https://evil.example/steal' ],
+			[ 'protocol-relative', '//evil.example/steal' ],
+			[ 'javascript:', 'javascript:alert(1)' ], // eslint-disable-line no-script-url
+			// Near-misses on the allowlist: substring and subdomain tricks.
+			[ 'suffixed host', 'https://woocommerce.com.evil.example/start/' ],
+			[ 'subdomain of an allowed host', 'https://evil.woocommerce.com/start/' ],
+			[ 'allowed host over http', 'http://woocommerce.com/start/' ],
+			[ 'allowed host as userinfo', 'https://woocommerce.com@evil.example/' ],
+		] )( 'falls back to /log-in for a %s redirect_to', async ( _label, redirect_to ) => {
+			await app.run( { request: navigation( { query: { redirect_to } } ) } );
+
+			expect( app.getMocks().renderJsx ).toHaveBeenCalledWith(
+				'logout',
+				expect.objectContaining( { redirectTo: '/log-in' } )
+			);
+		} );
+	} );
+
 	describe( 'Route /browsehappy', () => {
 		beforeEach( () => {
 			app.withRenderJSX( 'content' );

--- a/client/state/current-user/actions.js
+++ b/client/state/current-user/actions.js
@@ -63,7 +63,18 @@ export function fetchCurrentUser( { retry = false } = {} ) {
 export function redirectToLogout( postLogoutRedirectUrl ) {
 	return async ( dispatch, getState ) => {
 		const userData = getCurrentUser( getState() );
-		const logoutUrl = getLogoutUrl( userData, postLogoutRedirectUrl );
+
+		// Route the post-logout redirect through `/me/logout` so the browser's stored
+		// site data (storage, cache, cookies) is cleared via the `Clear-Site-Data`
+		// response header once the WP.com session has been invalidated. Ordering
+		// matters: the logout nonce is validated against the live session, so the
+		// data clear must run on the way back, not before. The caller's requested
+		// destination is preserved via `/me/logout`'s own `redirect_to`.
+		const clearSiteDataUrl = new URL( '/me/logout', window.location.origin );
+		if ( postLogoutRedirectUrl ) {
+			clearSiteDataUrl.searchParams.set( 'redirect_to', postLogoutRedirectUrl );
+		}
+		const logoutUrl = getLogoutUrl( userData, clearSiteDataUrl.href );
 
 		// Clear any data stored locally within the user data module or localStorage
 		disablePersistence();


### PR DESCRIPTION
## Proposed Changes

- Add a server-side `/me/logout` route on both the classic Calypso and Dashboard hosts. It returns `Clear-Site-Data` for its own origin, clears the counterpart origin through a hidden iframe, then redirects to `/log-in`.
- Point both logout flows at it — the Dashboard `logout()` and the classic `redirectToLogout()`.
- Only emit the header for requests that could genuinely be the logout flow — the browser honors `Clear-Site-Data` even on responses it refuses to render, so framing controls can't gate it — and skip support sessions.
- Report the outcome of the cross-origin clear as a stat.

## How it works

```mermaid
sequenceDiagram
    autonumber
    participant B as Browser
    participant W as wordpress.com
    participant M as my.wordpress.com

    B->>W: Log out
    W-->>B: redirect to wp-login.php?redirect_to=…/me/logout
    Note over B,W: Session invalidated first — the logout<br/>nonce is checked against the live session
    B->>W: GET /me/logout
    W-->>B: Clear-Site-Data + page with hidden iframe
    B->>M: GET /me/logout?embed=1 (in iframe)
    M-->>B: Clear-Site-Data
    Note over B,M: iframe posts back whether it<br/>actually set the header
    B->>B: redirect to /log-in
```

Both origins end up cleared regardless of which one you started from — the flow is symmetric, so logging out from the Dashboard mirrors this with the hosts swapped. Logging out from wp-admin runs no Calypso code and is unaffected.

`Clear-Site-Data` covers `localStorage`, `sessionStorage`, cookies, Cache API, service workers, and IndexedDB — so this clears v1's persisted Redux state as well as the Dashboard's query cache.

## Testing Instructions

A bare `curl` gets no `Clear-Site-Data`, by design — the `Sec-Fetch-*` headers are what authorize it.

1. Start the dev server (`yarn start`).
2. Top-level page carries the header and embeds the counterpart iframe:
   ```
   curl -D - -H 'sec-fetch-dest: document' -H 'sec-fetch-mode: navigate' \
     http://calypso.localhost:3000/me/logout
   ```
   The same request against `http://my.localhost:3000/me/logout` is symmetric.
3. Embed variant carries the header only when framed by the counterpart:
   ```
   curl -D - -H 'sec-fetch-dest: iframe' -H 'referer: http://my.localhost:3000/' \
     'http://calypso.localhost:3000/me/logout?embed=1'
   ```
   Swap the referrer for anything else and the header should be absent.
4. `/me/logout?redirect_to=/me/account` redirects there, as does an allowlisted `https://woocommerce.com/start/`; other cross-origin, protocol-relative, and `javascript:` values fall back to `/log-in`.
5. Log out from the Dashboard and from the classic masterbar, and confirm storage is cleared for both origins. Worth doing once in Safari as well as Chrome.
6. `yarn test-server client/server/pages/test/index.js`

Full end-to-end through `wp-login.php` needs production or staging — in local dev, `user.logout_URL` targets production `wordpress.com`, which won't redirect back to `*.localhost`.

Browser behaviour was also checked against a harness serving these headers on two hostnames, since none of it is reachable from Jest: all six storage types cleared on the counterpart origin, the drive-by wipe blocked, and the three outcomes (`counterpart-cleared`, `counterpart-not-cleared`, `counterpart-timeout`) reported correctly.

## Considerations

- Overlaps the logout-time clear in #112557; the two shouldn't both ship. That PR's other layer — wiping the cache at boot on auth failure — does not overlap and covers session endings this never sees, such as wp-admin logout and expiry.
- A cross-site top-level navigation to this route still clears, so an unrelated site can force a logout. Gating on `Sec-Fetch-Site` was tried and rejected: measured in Chrome, the legitimate Jetpack Cloud path reports `cross-site` on the final hop identically to the attack, because the value reflects the most distant origin in the redirect chain. It would silently stop Jetpack Cloud and A8C for Agencies clearing. Left as-is — the attack is visible and recoverable.
- `woocommerce.com` and `jetpack.com` are allowlisted as post-logout destinations, so this route is deliberately an open redirect to those two hosts. Threading the caller's destination through `/me/logout` otherwise dropped it — the WCCOM signup path in `blocks/login` passes an absolute `woocommerce.com` URL and would have landed on `/log-in`. `wp-login.php` already accepts these destinations. Matched on exact host over https, so suffixed hosts, subdomains, and userinfo tricks still fall back.
- Support sessions are skipped entirely, matching `clearQueryClient`. The carve-out reaches the counterpart via the `support_session_id` cookie, worth confirming in production.
- The Dashboard OAuth account-switch flow manages its own redirect and is untouched.
- `redirectToLogout()` is shared with Jetpack Cloud and A8C for Agencies, which now also clear their own origin.
- The page shows the same loading placeholder as `document/index.jsx`, with the styles inlined because it loads no stylesheet. No text, so nothing to translate.
- Verified in Chrome. Safari partitions storage for cross-site iframes, which would stop the counterpart clear — the wpcom pair is same-site so it should be unaffected, but that is untested.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)




