### PR TITLE
Omnibar: keep a panel button active while its panel is open and hovered

### DIFF
--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -148,6 +148,7 @@ export default function Notifications( {
 	return (
 		<Dropdown
 			popoverProps={ {
+				className: 'dashboard-notifications__popover',
 				placement: 'bottom-start',
 				offset: 8,
 				focusOnMount: true,

--- a/client/dashboard/app/omnibar/plugin-help-center.tsx
+++ b/client/dashboard/app/omnibar/plugin-help-center.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { useHelpCenter } from '../help-center';
+import { useElementIsHovered } from './use-element-is-hovered';
 import type { OmnibarNode } from '@automattic/omnibar';
 
 import './plugin-help-center.scss';
@@ -24,10 +25,14 @@ function HelpIcon() {
 
 export function useHelpCenterPlugin(): OmnibarNode {
 	const { isShown: isHelpCenterShown, setShowHelpCenter } = useHelpCenter();
+	const isHovered = useElementIsHovered( '.help-center__container' );
+	const isActive = isHelpCenterShown && isHovered;
+
 	return {
 		id: 'help-center',
 		label: __( 'Help' ),
 		icon: <HelpIcon />,
+		isActive,
 		onClick: () => setShowHelpCenter( ! isHelpCenterShown ),
 	};
 }

--- a/client/dashboard/app/omnibar/plugin-notifications.scss
+++ b/client/dashboard/app/omnibar/plugin-notifications.scss
@@ -23,6 +23,7 @@
 
 .omnibar .omnibar__menu:hover .omnibar__notifications-unread-dot,
 .omnibar .omnibar__menu:focus-visible .omnibar__notifications-unread-dot,
-.omnibar .omnibar__menu:active .omnibar__notifications-unread-dot {
+.omnibar .omnibar__menu:active .omnibar__notifications-unread-dot,
+.omnibar .omnibar__menu.is-active .omnibar__notifications-unread-dot {
 	stroke: var( --omnibar-menu-active-background );
 }

--- a/client/dashboard/app/omnibar/plugin-notifications.tsx
+++ b/client/dashboard/app/omnibar/plugin-notifications.tsx
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { useEffect, useRef, useState } from 'react';
 import { omnibarEvents, useOmnibarEvent } from './events';
+import { useElementIsHovered } from './use-element-is-hovered';
 import type { User } from '@automattic/api-core';
 import type { OmnibarNode } from '@automattic/omnibar';
 
@@ -21,10 +22,15 @@ export function useNotificationsPlugin( { user }: { user?: User } ): OmnibarNode
 	const [ hasUnseenNotifications, setHasUnseenNotifications ] = useState(
 		!! user?.has_unseen_notes
 	);
+	const [ isOpen, setIsOpen ] = useState( false );
 
 	useOmnibarEvent( 'notificationsUnseenCount', ( count ) =>
 		setHasUnseenNotifications( count > 0 )
 	);
+	useOmnibarEvent( 'notificationsOpen', setIsOpen );
+
+	const isHovered = useElementIsHovered( '.dashboard-notifications__popover' );
+	const isActive = isOpen && isHovered;
 
 	const bellRef = useRef< HTMLSpanElement >( null );
 
@@ -41,6 +47,7 @@ export function useNotificationsPlugin( { user }: { user?: User } ): OmnibarNode
 				<BellIcon hasUnread={ hasUnseenNotifications } />
 			</span>
 		),
+		isActive,
 		onClick: () => omnibarEvents.notifications.emit(),
 	};
 }

--- a/client/dashboard/app/omnibar/use-element-is-hovered.ts
+++ b/client/dashboard/app/omnibar/use-element-is-hovered.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Reports whether the pointer is currently over an element matching `selector`.
+ * The omnibar's panels render in portals the plugin can't hold a ref to, so this
+ * hit-tests by selector at the document level. Callers pair it with the panel's
+ * open state (e.g. `isOpen && isHovered`) to keep a button active while the
+ * pointer is over its open panel.
+ * @param selector CSS selector matching the element to watch.
+ */
+export function useElementIsHovered( selector: string ): boolean {
+	const [ isHovered, setIsHovered ] = useState( false );
+
+	useEffect( () => {
+		const handlePointerOver = ( event: PointerEvent ) => {
+			const target = event.target as Element | null;
+			setIsHovered( !! target?.closest( selector ) );
+		};
+
+		// Pointer leaving the document entirely never fires a follow-up
+		// pointerover, so clear the state explicitly.
+		const handlePointerOut = ( event: PointerEvent ) => {
+			if ( ! event.relatedTarget ) {
+				setIsHovered( false );
+			}
+		};
+
+		document.addEventListener( 'pointerover', handlePointerOver );
+		document.addEventListener( 'pointerout', handlePointerOut );
+		return () => {
+			document.removeEventListener( 'pointerover', handlePointerOver );
+			document.removeEventListener( 'pointerout', handlePointerOut );
+		};
+	}, [ selector ] );
+
+	return isHovered;
+}

--- a/packages/omnibar/src/components/omnibar-menu.tsx
+++ b/packages/omnibar/src/components/omnibar-menu.tsx
@@ -67,7 +67,9 @@ function OmnibarMenuContent( { nodes }: { nodes: OmnibarNode[] } ) {
 
 export function OmnibarMenu( { node, className }: { node: OmnibarNode; className?: string } ) {
 	const label = node.title || node.label || '';
-	const menuClassName = className ? `omnibar__menu ${ className }` : 'omnibar__menu';
+	const menuClassName = [ 'omnibar__menu', className, node.isActive && 'is-active' ]
+		.filter( Boolean )
+		.join( ' ' );
 	const [ isOpen, setIsOpen ] = useState( false );
 	const triggerRef = useRef< HTMLElement >( null );
 	const popoverRef = useRef< HTMLElement >( null );

--- a/packages/omnibar/src/components/omnibar.scss
+++ b/packages/omnibar/src/components/omnibar.scss
@@ -56,6 +56,7 @@ body:has( .omnibar ) {
 		&:hover,
 		&:focus-visible,
 		&:active,
+		&.is-active,
 		&[aria-expanded='true'] {
 			background-color: var( --omnibar-menu-active-background );
 			color: $omnibar-text-color;

--- a/packages/omnibar/src/types/omnibar.ts
+++ b/packages/omnibar/src/types/omnibar.ts
@@ -6,6 +6,8 @@ export interface OmnibarNode {
 	group?: boolean;
 	href?: string;
 	onClick?: () => void;
+	/** Highlights the button as active (e.g. while its related panel is open and hovered). */
+	isActive?: boolean;
 	meta?: SiteActionNodeMeta & UserInfoNodeMeta;
 	render?: ( node: OmnibarNode ) => React.ReactNode;
 	children?: OmnibarNode[];


### PR DESCRIPTION
## Proposed Changes

Keep the omnibar Notifications and Help buttons visually active while their related panel is open, extending the highlight across the gap between the button and its (portaled) panel.

- Add an optional `isActive` flag to `OmnibarNode`; when set, `OmnibarMenu` appends an `is-active` class that reuses the button's existing hover/active highlight styling.
- Add a small `useElementIsHovered( selector )` hook. It reports whether the pointer is currently over an element matching the selector, hit-testing at the document level (the panels render in portals the plugin can't hold a ref to). The button keeps its own native `:hover`, so combining the two gives: active whenever the pointer is over the button **or** the open panel, and inactive once it leaves both.
- Each plugin pairs the hook with its panel's open state: `isActive = isOpen && isHovered` (Notifications, driven by the existing `notificationsOpen` event) and `isActive = isHelpCenterShown && isHovered` (Help, driven by Help Center's `isShown`).
- Give the Notifications `Dropdown` popover a `dashboard-notifications__popover` class so it can be hit-tested (the Help Center panel already exposes `.help-center__container`). Extend the notifications unread-dot stroke rule so the dot border still matches the active background in this state.

Only affects the `dashboard/omnibar-radical` omnibar.

## Why are these changes being made?

When you open the Notifications or Help panel from the omnibar, the trigger button lost its highlight as soon as the pointer moved off it, so there was no persistent visual tie between an open panel and the button that owns it. This keeps that connection while the pointer stays within the button-or-panel region, and clears it when the pointer leaves both — matching common menu/popover behavior. A pure-CSS `:hover` can't do this because the panel renders in a separate portal, so a small JS hit-test bridges the gap.

## Testing Instructions

1. Enable the `dashboard/omnibar-radical` feature flag and run `yarn start`.
2. In the dashboard omnibar, click the **Notifications** bell to open the panel.
   - The bell button stays highlighted while the pointer is over the button or anywhere in the notifications panel.
   - Move the pointer off both the button and the panel: the highlight goes away (the panel stays open).
   - Move back over the panel: the button highlights again.
3. Repeat with the **Help** button and the Help Center panel.
4. Confirm the notifications unread dot's border still matches the button background while the button is in this active state.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
