### PR TITLE
Add dev toolbar helper to override Blackbox test collect keys.

### DIFF
--- a/client/blocks/login/utils/blackbox-sdk.js
+++ b/client/blocks/login/utils/blackbox-sdk.js
@@ -3,6 +3,17 @@ import { loadScript } from '@automattic/load-script';
 
 let loadPromise = null;
 
+export function getBlackboxApiKey() {
+	if ( process.env.NODE_ENV === 'development' ) {
+		// Guarded require so the dev-only override module is dead-code
+		// eliminated from production bundles.
+		const { resolveBlackboxApiKey } = require( 'calypso/lib/blackbox-helper/api-key' );
+		return resolveBlackboxApiKey( config( 'blackbox_api_key' ) );
+	}
+
+	return config( 'blackbox_api_key' );
+}
+
 /**
  * Inject the Blackbox SDK script once.
  * Returns a Promise that always resolves (never rejects) so Blackbox can never block login.
@@ -16,7 +27,7 @@ export function loadBlackboxSdk() {
 		return Promise.resolve();
 	}
 
-	const apiKey = config( 'blackbox_api_key' );
+	const apiKey = getBlackboxApiKey();
 	if ( ! config.isEnabled( 'blackbox' ) || ! apiKey ) {
 		return Promise.resolve();
 	}

--- a/client/blocks/login/utils/test/use-blackbox.jsx
+++ b/client/blocks/login/utils/test/use-blackbox.jsx
@@ -8,6 +8,7 @@ import { loadBlackboxSdk } from '../blackbox-sdk';
 import { useBlackbox } from '../use-blackbox';
 
 jest.mock( '../blackbox-sdk', () => ( {
+	getBlackboxApiKey: jest.fn( () => 'test-api-key' ),
 	loadBlackboxSdk: jest.fn( () => Promise.resolve() ),
 } ) );
 

--- a/client/blocks/login/utils/use-blackbox.js
+++ b/client/blocks/login/utils/use-blackbox.js
@@ -1,6 +1,5 @@
-import config from '@automattic/calypso-config';
 import { useEffect, useState } from 'react';
-import { loadBlackboxSdk } from 'calypso/blocks/login/utils/blackbox-sdk';
+import { getBlackboxApiKey, loadBlackboxSdk } from 'calypso/blocks/login/utils/blackbox-sdk';
 
 // Give the SDK a short window to synchronously or near-synchronously start a challenge
 // after configure(), avoiding a brief enabled submit button while the widget initializes.
@@ -84,7 +83,7 @@ export function useBlackbox( { containerRef, enabled } ) {
 
 			try {
 				window.Blackbox.configure( {
-					apiKey: config( 'blackbox_api_key' ),
+					apiKey: getBlackboxApiKey(),
 					challengeContainer: containerRef.current,
 					// Fill the login form column so the challenge lines up with the
 					// input above and the full-width Continue button below.

--- a/client/components/environment-badge/index.jsx
+++ b/client/components/environment-badge/index.jsx
@@ -28,6 +28,10 @@ export function StoreSandboxHelper() {
 	return <div className="environment is-store-sandbox" />;
 }
 
+export function BlackboxHelper() {
+	return <div className="environment is-blackbox" />;
+}
+
 export function Branch( { branchName, commitChecksum } ) {
 	return branchName === 'trunk' ? null : (
 		<span className="environment branch-name" title={ 'Commit ' + commitChecksum }>

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -16,6 +16,7 @@ import EnvironmentBadge, {
 	ReactQueryDevtoolsHelper,
 	RtlCssDisabledHelper,
 	StoreSandboxHelper,
+	BlackboxHelper,
 } from 'calypso/components/environment-badge';
 import Head from 'calypso/components/head';
 import JetpackLogo from 'calypso/components/jetpack-logo';
@@ -71,6 +72,7 @@ class Document extends Component {
 			sectionGroup,
 			sectionName,
 			storeSandboxHelper,
+			blackboxHelper,
 			target,
 			user,
 			useTranslationChunks,
@@ -236,6 +238,7 @@ class Document extends Component {
 							{ featuresHelper && <FeaturesHelper /> }
 							{ authHelper && <AuthHelper /> }
 							{ storeSandboxHelper && <StoreSandboxHelper /> }
+							{ blackboxHelper && <BlackboxHelper /> }
 							{ isRtlCssDisabled && <RtlCssDisabledHelper /> }
 							{ branchName && (
 								<Branch branchName={ branchName } commitChecksum={ commitChecksum } />

--- a/client/document/test/loading-placeholder.test.tsx
+++ b/client/document/test/loading-placeholder.test.tsx
@@ -51,6 +51,7 @@ const baseProps: DocumentProps = {
 	sectionName: 'stepper',
 	path: '/',
 	storeSandboxHelper: false,
+	blackboxHelper: false,
 	target: 'evergreen',
 	user: null,
 	useTranslationChunks: false,

--- a/client/lib/blackbox-helper/api-key.js
+++ b/client/lib/blackbox-helper/api-key.js
@@ -1,0 +1,63 @@
+/**
+ * Dev-only override for the Blackbox public test collect keys.
+ * @see test/e2e/lib/blackbox-test-key.ts
+ * @see blackbox.api/docs/test-keys.md
+ */
+
+const BLACKBOX_DEV_API_KEY_OVERRIDE_STORAGE_KEY = 'blackbox-dev-api-key-override';
+
+const BLACKBOX_TEST_COLLECT_KEYS = {
+	allow: '1xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+	block: '2xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+	challenge: '3xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+};
+
+export const BLACKBOX_DEV_API_KEY_OVERRIDE_OPTIONS = [ 'default', 'allow', 'block', 'challenge' ];
+
+export function getBlackboxDevApiKeyOverride() {
+	if ( typeof window === 'undefined' || typeof window.sessionStorage === 'undefined' ) {
+		return 'default';
+	}
+
+	try {
+		const stored = window.sessionStorage.getItem( BLACKBOX_DEV_API_KEY_OVERRIDE_STORAGE_KEY );
+		if ( stored && BLACKBOX_DEV_API_KEY_OVERRIDE_OPTIONS.includes( stored ) ) {
+			return stored;
+		}
+	} catch {
+		// Private browsing can block sessionStorage.
+	}
+
+	return 'default';
+}
+
+export function setBlackboxDevApiKeyOverride( override ) {
+	if ( ! BLACKBOX_DEV_API_KEY_OVERRIDE_OPTIONS.includes( override ) ) {
+		return;
+	}
+
+	try {
+		if ( override === 'default' ) {
+			window.sessionStorage.removeItem( BLACKBOX_DEV_API_KEY_OVERRIDE_STORAGE_KEY );
+		} else {
+			window.sessionStorage.setItem( BLACKBOX_DEV_API_KEY_OVERRIDE_STORAGE_KEY, override );
+		}
+	} catch {
+		// Fall through — reload still applies when storage works on the next visit.
+	}
+
+	window.location.reload();
+}
+
+export function resolveBlackboxApiKey( configApiKey ) {
+	if ( process.env.NODE_ENV !== 'development' ) {
+		return configApiKey;
+	}
+
+	const override = getBlackboxDevApiKeyOverride();
+	if ( override === 'default' ) {
+		return configApiKey;
+	}
+
+	return BLACKBOX_TEST_COLLECT_KEYS[ override ] || configApiKey;
+}

--- a/client/lib/blackbox-helper/index.tsx
+++ b/client/lib/blackbox-helper/index.tsx
@@ -1,0 +1,46 @@
+import { createRoot } from 'react-dom/client';
+import {
+	BLACKBOX_DEV_API_KEY_OVERRIDE_OPTIONS,
+	getBlackboxDevApiKeyOverride,
+	setBlackboxDevApiKeyOverride,
+} from 'calypso/lib/blackbox-helper/api-key';
+
+import './style.scss';
+
+const OVERRIDE_LABELS: Record< string, string > = {
+	default: 'Default',
+	allow: 'Allow',
+	block: 'Block',
+	challenge: 'Challenge',
+};
+
+function BlackboxHelper() {
+	const override = getBlackboxDevApiKeyOverride();
+	const menuItemClasses = [
+		'blackbox-helper__menu-item',
+		override === 'default' ? 'is-default' : `is-${ override }`,
+	];
+
+	return (
+		<>
+			<div className={ menuItemClasses.join( ' ' ) }>Blackbox: { OVERRIDE_LABELS[ override ] }</div>
+			<div className="blackbox-helper__popover">
+				{ BLACKBOX_DEV_API_KEY_OVERRIDE_OPTIONS.map( ( option ) => (
+					<label key={ option } className="blackbox-helper__label">
+						<input
+							type="radio"
+							name="blackbox-api-key-override"
+							value={ option }
+							checked={ override === option }
+							onChange={ () => setBlackboxDevApiKeyOverride( option ) }
+						/>
+						{ OVERRIDE_LABELS[ option ] }
+					</label>
+				) ) }
+				<p className="blackbox-helper__help">Use authorized test accounts for verify to work.</p>
+			</div>
+		</>
+	);
+}
+
+export default ( element: HTMLElement ) => createRoot( element ).render( <BlackboxHelper /> );

--- a/client/lib/blackbox-helper/style.scss
+++ b/client/lib/blackbox-helper/style.scss
@@ -1,0 +1,47 @@
+.blackbox-helper__menu-item.is-allow {
+	color: var(--dashboard__foreground-color-success);
+}
+
+.blackbox-helper__menu-item.is-block {
+	color: var(--color-error);
+}
+
+.blackbox-helper__menu-item.is-challenge {
+	color: var(--color-warning);
+}
+
+.blackbox-helper__popover {
+	display: none;
+}
+
+.environment.is-blackbox:hover .blackbox-helper__popover {
+	display: block;
+	position: absolute;
+	bottom: 100%;
+	right: 0;
+	// padding: 8px 12px;
+	padding: 4px;
+	background: var(--color-surface);
+	box-shadow: 0 0 0 1px var(--color-border-subtle);
+	width: 250px;
+}
+
+.blackbox-helper__help {
+	margin: 8px 0 0;
+	font-size: 8px;
+	line-height: 1.4;
+	color: var(--color-text-subtle);
+	white-space: normal;
+}
+
+.blackbox-helper__label {
+	display: block;
+	margin-bottom: 4px;
+	line-height: 16px;
+
+	input[type="radio"] {
+		appearance: auto;
+		vertical-align: middle;
+		margin: 0 4px 0 0;
+	}
+}

--- a/client/lib/blackbox-helper/test/api-key.js
+++ b/client/lib/blackbox-helper/test/api-key.js
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+	getBlackboxDevApiKeyOverride,
+	resolveBlackboxApiKey,
+	setBlackboxDevApiKeyOverride,
+} from '../api-key';
+
+describe( 'blackbox-helper/api-key', () => {
+	const originalNodeEnv = process.env.NODE_ENV;
+	const reload = jest.fn();
+
+	beforeAll( () => {
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			value: { reload },
+		} );
+	} );
+
+	beforeEach( () => {
+		window.sessionStorage.clear();
+		reload.mockClear();
+	} );
+
+	afterAll( () => {
+		process.env.NODE_ENV = originalNodeEnv;
+	} );
+
+	test( 'resolveBlackboxApiKey returns config key outside development', () => {
+		process.env.NODE_ENV = 'production';
+		setBlackboxDevApiKeyOverride( 'challenge' );
+
+		expect( resolveBlackboxApiKey( 'prod-key' ) ).toBe( 'prod-key' );
+	} );
+
+	test( 'resolveBlackboxApiKey returns the selected test key in development', () => {
+		process.env.NODE_ENV = 'development';
+		setBlackboxDevApiKeyOverride( 'challenge' );
+
+		expect( resolveBlackboxApiKey( 'prod-key' ) ).toBe( '3xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' );
+	} );
+
+	test( 'resolveBlackboxApiKey falls back to config key when override is default', () => {
+		process.env.NODE_ENV = 'development';
+
+		expect( resolveBlackboxApiKey( 'prod-key' ) ).toBe( 'prod-key' );
+	} );
+
+	test( 'setBlackboxDevApiKeyOverride persists the override and reloads', () => {
+		setBlackboxDevApiKeyOverride( 'allow' );
+
+		expect( getBlackboxDevApiKeyOverride() ).toBe( 'allow' );
+		expect( reload ).toHaveBeenCalled();
+	} );
+
+	test( 'setBlackboxDevApiKeyOverride clears the override when set back to default', () => {
+		setBlackboxDevApiKeyOverride( 'block' );
+		setBlackboxDevApiKeyOverride( 'default' );
+
+		expect( getBlackboxDevApiKeyOverride() ).toBe( 'default' );
+	} );
+
+	test( 'setBlackboxDevApiKeyOverride ignores invalid values', () => {
+		setBlackboxDevApiKeyOverride( 'not-valid' );
+
+		expect( getBlackboxDevApiKeyOverride() ).toBe( 'default' );
+		expect( reload ).not.toHaveBeenCalled();
+	} );
+
+	test( 'getBlackboxDevApiKeyOverride ignores invalid stored values', () => {
+		window.sessionStorage.setItem( 'blackbox-dev-api-key-override', 'not-valid' );
+
+		expect( getBlackboxDevApiKeyOverride() ).toBe( 'default' );
+	} );
+} );

--- a/client/lib/load-dev-helpers/index.js
+++ b/client/lib/load-dev-helpers/index.js
@@ -77,4 +77,13 @@ export default function loadDevHelpers( reduxStore ) {
 			).then( ( helper ) => helper.default( el ) );
 		}
 	}
+
+	if ( config.isEnabled( 'dev/blackbox-helper' ) ) {
+		const el = document.querySelector( '.environment.is-blackbox' );
+		if ( el ) {
+			import(
+				/* webpackChunkName: "async-load-calypso-lib-blackbox-helper" */ 'calypso/lib/blackbox-helper'
+			).then( ( helper ) => helper.default( el ) );
+		}
+	}
 }

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -266,6 +266,7 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 	const authHelper = config.isEnabled( 'dev/auth-helper' );
 	const accountSettingsHelper = config.isEnabled( 'dev/account-settings-helper' );
 	const storeSandboxHelper = config.isEnabled( 'dev/store-sandbox-helper' );
+	const blackboxHelper = config.isEnabled( 'dev/blackbox-helper' );
 	// preferences helper requires a Redux store, which doesn't exist in Gutenboarding
 	const preferencesHelper =
 		config.isEnabled( 'dev/preferences-helper' ) && entrypoint !== 'entry-gutenboarding';
@@ -296,6 +297,7 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 		authHelper,
 		preferencesHelper,
 		storeSandboxHelper,
+		blackboxHelper,
 		featuresHelper,
 		store: reduxStore,
 		target: 'evergreen',

--- a/config/development.json
+++ b/config/development.json
@@ -82,6 +82,7 @@
 		"design-picker/use-assembler-styles": true,
 		"dev/account-settings-helper": true,
 		"dev/auth-helper": true,
+		"dev/blackbox-helper": true,
 		"dev/features-helper": true,
 		"dev/preferences-helper": true,
 		"dev/react-query-devtools": true,


### PR DESCRIPTION
Expose Default, Allow, Block, and Challenge in the environment badge so local development can switch `getBlackboxApiKey()` outcomes without editing config or restarting the dev server.

<img width="678" height="322" alt="CleanShot 2026-08-06 at 15 29 42@2x" src="https://github.com/user-attachments/assets/ddf3eafc-f6a2-4897-9474-9369be89a329" />

### Testing

Switch between each option and keep your dev tool open to see the `/collect` requests:

```
# profile -> expected /collect returned session_id
Default -> A valid random session
Allow -> bbtest_allow__________
Block -> bbtest_block__________
Challenge -> bbtest_challenge______
```