### PR TITLE
Dashboard: allow pinch-to-zoom by dropping maximum-scale on dashboard sections

### DIFF
--- a/client/components/head/index.jsx
+++ b/client/components/head/index.jsx
@@ -8,6 +8,7 @@ const Head = ( {
 	branchName,
 	faviconUrl,
 	shouldPrefetchRestProxy = true,
+	allowZoom = false,
 } ) => {
 	return (
 		<head>
@@ -15,7 +16,14 @@ const Head = ( {
 
 			<meta charSet="utf-8" />
 			<meta httpEquiv="X-UA-Compatible" content="IE=Edge" />
-			<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+			<meta
+				name="viewport"
+				content={
+					allowZoom
+						? 'width=device-width, initial-scale=1'
+						: 'width=device-width, initial-scale=1, maximum-scale=1'
+				}
+			/>
 			<meta name="format-detection" content="telephone=no" />
 			<meta name="mobile-web-app-capable" content="yes" />
 			<meta name="apple-mobile-web-app-capable" content="yes" />
@@ -53,6 +61,7 @@ Head.propTypes = {
 	branchName: PropTypes.string,
 	faviconUrl: PropTypes.string,
 	shouldPrefetchRestProxy: PropTypes.bool,
+	allowZoom: PropTypes.bool,
 };
 
 export default Head;

--- a/client/components/head/test/index.jsx
+++ b/client/components/head/test/index.jsx
@@ -35,4 +35,18 @@ describe( 'Head', () => {
 			document.querySelector( `link[rel="prefetch"][href="${ restProxyHref }"]` )
 		).toBeNull();
 	} );
+
+	test( 'should block zoom via maximum-scale by default', () => {
+		render( <Head /> );
+		expect( document.querySelector( 'meta[name="viewport"]' )?.getAttribute( 'content' ) ).toBe(
+			'width=device-width, initial-scale=1, maximum-scale=1'
+		);
+	} );
+
+	test( 'should allow zoom by dropping maximum-scale when allowZoom is set', () => {
+		render( <Head allowZoom /> );
+		expect( document.querySelector( 'meta[name="viewport"]' )?.getAttribute( 'content' ) ).toBe(
+			'width=device-width, initial-scale=1'
+		);
+	} );
 } );

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -24,6 +24,7 @@ import WooCommerceLogo from 'calypso/components/woocommerce-logo';
 import { InterimOmnibar } from 'calypso/dashboard/app/interim-omnibar/interim-omnibar';
 import { InitialOmnibar } from 'calypso/dashboard/app/omnibar/omnibar';
 import { getDashboardStepperLogo } from 'calypso/dashboard/app/stepper-logo';
+import { A4A_DASHBOARD_SECTION_DEFINITION } from 'calypso/dashboard/app-a4a/section';
 import { CIAB_DASHBOARD_SECTION_DEFINITION } from 'calypso/dashboard/app-ciab/section';
 import { DOTCOM_DASHBOARD_SECTION_DEFINITION } from 'calypso/dashboard/app-dotcom/section';
 import isDashboardEnv from 'calypso/dashboard/utils/is-dashboard-env';
@@ -113,6 +114,11 @@ class Document extends Component {
 				? `var localeFromRoute = ${ jsonStringifyForHtml( params.lang ?? '' ) };\n`
 				: '' );
 
+		const isDashboardSection =
+			sectionName === DOTCOM_DASHBOARD_SECTION_DEFINITION.name ||
+			sectionName === CIAB_DASHBOARD_SECTION_DEFINITION.name ||
+			sectionName === A4A_DASHBOARD_SECTION_DEFINITION.name;
+
 		const isDashboardOmnibarPage =
 			( isDashboardEnv() || env === 'development' ) &&
 			( sectionName === DOTCOM_DASHBOARD_SECTION_DEFINITION.name ||
@@ -153,6 +159,7 @@ class Document extends Component {
 					branchName={ branchName }
 					inlineScriptNonce={ inlineScriptNonce }
 					faviconUrl={ headFaviconUrl }
+					allowZoom={ isDashboardSection }
 					// Firefox can reuse the anonymous REST proxy prefetch after login; see https://github.com/Automattic/wp-calypso/pull/111842.
 					shouldPrefetchRestProxy={ ! app?.isFirefox }
 				>


### PR DESCRIPTION
Fixes DOTMSD-1473

## Proposed Changes

* Allow pinch-to-zoom on Dashboard (Multi-Site Dashboard) pages by dropping `maximum-scale=1` from the viewport meta tag for the dashboard sections (`dashboard-dotcom`, `dashboard-ciab`, `dashboard-a4a`).
* `Head` keeps `maximum-scale=1` by default; a new `allowZoom` prop opts a surface out. Every non-Dashboard surface is unchanged.

## Why are these changes being made?

`maximum-scale=1` blocks pinch-to-zoom, which is an accessibility problem for low-vision users.

It was re-added in Oct 2025 by "Disable zoom for login page" (#106160), but applied to the shared `Head` component, so it affected every Calypso page rather than just login. Scoping the removal to the Dashboard restores zoom where we control the surface (consistent wp-core components) while leaving login's intended behaviour intact.

History of `maximum-scale=1` in the viewport meta:

| Date | Commit | What it did |
|------|--------|-------------|
| 2015 | `53bde8c3f9c` | Initial commit of wp-calypso — present from day one (original Jade/Pug template) |
| 2018-01-31 | `e73971877a2` | Pug→JSX migration (#21424) — carried into `head/index.jsx` |
| 2019-04-29 | `468644b51e9` | "Remove the maximum scale limitation" — removed it |
| 2025-10-01 | `e2195a9e504` | "Disable zoom for login page" (#106160) — re-added it globally (the instance this PR scopes down) |

Mobile Safari note: iOS 10+ ignores `maximum-scale`/`user-scalable=no` to always permit pinch-zoom, so this only changes behaviour on Android (which honours it). iOS input focus-zoom is unaffected either way.

## Testing Instructions

* On Android (or Chrome DevTools device emulation), open a Dashboard page (e.g. `/sites`) and confirm pinch-to-zoom works.
* Open a non-Dashboard page (e.g. login) and confirm pinch-to-zoom is still blocked.
* `yarn test-client client/components/head/test/index.jsx` passes.

## Considerations

Scoped to all three dashboard variants (dotcom/ciab/a4a) since they share the same client. `allowZoom` is section-based rather than env-gated, so it applies wherever the dashboard renders.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
