### PR TITLE
Site Overview: Add accessible name to unlaunched site setup progress ring

### DIFF
--- a/client/dashboard/components/overview-card/index.tsx
+++ b/client/dashboard/components/overview-card/index.tsx
@@ -11,6 +11,7 @@ import {
 import { isRTL, __ } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
+import { useId } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { Card, CardBody } from '../../components/card';
 import { isOnboardingUrl, isRelativeUrl } from '../../utils/url';
@@ -29,7 +30,7 @@ export interface OverviewCardProps {
 		value: number;
 		max: number;
 		label: string;
-		ariaLabel?: string;
+		ariaValueText?: string;
 		variant?: ComponentProps< typeof CircularProgressBar >[ 'variant' ];
 	};
 	intent?: 'activate' | 'upsell' | 'success' | 'warning' | 'error';
@@ -75,6 +76,7 @@ export default function OverviewCard( {
 	onClick,
 }: OverviewCardProps ) {
 	const { recordTracksEvent } = useAnalytics();
+	const descriptionId = useId();
 
 	const renderHeading = () => {
 		if ( isLoading ) {
@@ -165,6 +167,7 @@ export default function OverviewCard( {
 							{ renderHeading() }
 						</Heading>
 						<Text
+							id={ descriptionId }
 							intent={ intent === 'warning' || intent === 'error' ? intent : undefined }
 							variant={ intent === 'warning' || intent === 'error' ? undefined : 'muted' }
 							lineHeight="16px"
@@ -177,7 +180,8 @@ export default function OverviewCard( {
 			</VStack>
 			{ progress && (
 				<CircularProgressBar
-					ariaLabel={ progress.ariaLabel }
+					ariaLabelledBy={ description ? descriptionId : undefined }
+					ariaValueText={ progress.ariaValueText }
 					currentStep={ progress.value }
 					numberOfSteps={ progress.max }
 					size={ 80 }

--- a/client/dashboard/components/overview-card/index.tsx
+++ b/client/dashboard/components/overview-card/index.tsx
@@ -176,6 +176,7 @@ export default function OverviewCard( {
 			</VStack>
 			{ progress && (
 				<CircularProgressBar
+					ariaLabel={ __( 'Steps to launch your site' ) }
 					currentStep={ progress.value }
 					numberOfSteps={ progress.max }
 					size={ 80 }

--- a/client/dashboard/components/overview-card/index.tsx
+++ b/client/dashboard/components/overview-card/index.tsx
@@ -29,6 +29,7 @@ export interface OverviewCardProps {
 		value: number;
 		max: number;
 		label: string;
+		ariaLabel?: string;
 		variant?: ComponentProps< typeof CircularProgressBar >[ 'variant' ];
 	};
 	intent?: 'activate' | 'upsell' | 'success' | 'warning' | 'error';
@@ -176,7 +177,7 @@ export default function OverviewCard( {
 			</VStack>
 			{ progress && (
 				<CircularProgressBar
-					ariaLabel={ __( 'Steps to launch your site' ) }
+					ariaLabel={ progress.ariaLabel }
 					currentStep={ progress.value }
 					numberOfSteps={ progress.max }
 					size={ 80 }

--- a/client/dashboard/sites/overview-visibility-card/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card/index.tsx
@@ -1,6 +1,6 @@
 import { siteLaunchpadQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { lockOutline, published } from '@wordpress/icons';
 import { LAUNCHPAD_PERSONALIZATION_EXPERIMENT, normalizeVariation } from 'calypso/lib/ai-launchpad';
 import { useExperiment } from 'calypso/lib/explat';
@@ -83,7 +83,12 @@ function VisibilityCardUnlaunched( { site }: { site: Site } ) {
 				value: completedTasks,
 				max: numberOfTasks,
 				label: `${ completedTasks }/${ numberOfTasks }`,
-				ariaLabel: __( 'Steps to launch your site' ),
+				ariaValueText: sprintf(
+					/* translators: %1$d: number of completed steps, %2$d: total number of steps. e.g. "2 of 5 steps complete" */
+					__( '%1$d of %2$d steps complete' ),
+					completedTasks,
+					numberOfTasks
+				),
 				...( isLaunchpadCompleted && { variant: 'success' as const } ),
 			} }
 		/>

--- a/client/dashboard/sites/overview-visibility-card/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card/index.tsx
@@ -83,6 +83,7 @@ function VisibilityCardUnlaunched( { site }: { site: Site } ) {
 				value: completedTasks,
 				max: numberOfTasks,
 				label: `${ completedTasks }/${ numberOfTasks }`,
+				ariaLabel: __( 'Steps to launch your site' ),
 				...( isLaunchpadCompleted && { variant: 'success' as const } ),
 			} }
 		/>

--- a/packages/components/src/circular-progress-bar/README.md
+++ b/packages/components/src/circular-progress-bar/README.md
@@ -22,3 +22,5 @@ function render() {
 - `numberOfSteps`: a number representing the total number of steps (required).
 - `size`: a number representing the base size of component in pixels (required).
 - `enableDesktopScaling`: a boolean that applys the 'desktop-scaling' class which scales the component size by 1.2x (optional)
+- `ariaLabelledBy`: the id of an element that labels the progress bar, wired to `aria-labelledby` (optional)
+- `ariaValueText`: a human-readable description of the current value (e.g. "2 of 5 steps complete"), wired to `aria-valuetext` (optional)

--- a/packages/components/src/circular-progress-bar/index.tsx
+++ b/packages/components/src/circular-progress-bar/index.tsx
@@ -13,6 +13,7 @@ const CircularProgressBar = ( {
 	showProgressText = true,
 	customText,
 	variant,
+	ariaLabel,
 }: {
 	currentStep: number | null;
 	numberOfSteps: number | null;
@@ -23,6 +24,7 @@ const CircularProgressBar = ( {
 	showProgressText?: boolean;
 	customText?: ReactNode;
 	variant?: 'success';
+	ariaLabel?: string;
 } ) => {
 	const SIZE = size;
 	const RADIUS = SIZE / 2 - strokeWidth / 2;
@@ -35,6 +37,10 @@ const CircularProgressBar = ( {
 	return (
 		<div
 			role="progressbar"
+			aria-valuemin={ 0 }
+			aria-valuemax={ numberOfSteps }
+			aria-valuenow={ currentStep }
+			aria-label={ ariaLabel }
 			className={ clsx( 'circular__progress-bar', {
 				'desktop-scaling': enableDesktopScaling,
 				'is-success': variant === 'success',

--- a/packages/components/src/circular-progress-bar/index.tsx
+++ b/packages/components/src/circular-progress-bar/index.tsx
@@ -13,7 +13,8 @@ const CircularProgressBar = ( {
 	showProgressText = true,
 	customText,
 	variant,
-	ariaLabel,
+	ariaLabelledBy,
+	ariaValueText,
 }: {
 	currentStep: number | null;
 	numberOfSteps: number | null;
@@ -24,7 +25,8 @@ const CircularProgressBar = ( {
 	showProgressText?: boolean;
 	customText?: ReactNode;
 	variant?: 'success';
-	ariaLabel?: string;
+	ariaLabelledBy?: string;
+	ariaValueText?: string;
 } ) => {
 	const SIZE = size;
 	const RADIUS = SIZE / 2 - strokeWidth / 2;
@@ -40,7 +42,8 @@ const CircularProgressBar = ( {
 			aria-valuemin={ 0 }
 			aria-valuemax={ numberOfSteps }
 			aria-valuenow={ currentStep }
-			aria-label={ ariaLabel }
+			aria-valuetext={ ariaValueText }
+			aria-labelledby={ ariaLabelledBy }
 			className={ clsx( 'circular__progress-bar', {
 				'desktop-scaling': enableDesktopScaling,
 				'is-success': variant === 'success',


### PR DESCRIPTION
Fixes DOTMSD-1475

## Proposed Changes

* Add an `ariaLabel` prop to the shared `CircularProgressBar` component and wire the `role="progressbar"` element with `aria-valuemin`/`aria-valuemax`/`aria-valuenow`/`aria-label`.
* Pass `ariaLabel="Steps to launch your site"` from the Site Overview `OverviewCard` unlaunched-site setup progress ring.

## Why are these changes being made?

The `1/4` visibility progress ring on Site Overview announced nothing to assistive tech — axe flagged `aria-progressbar-name`. The `role="progressbar"` element had no accessible name and no value semantics, so screen readers couldn't convey what it represented or how far along it was. This gives it a name and exposes its min/max/current values.

## Testing Instructions

* Open Site Overview for an unlaunched site.
* Inspect the setup progress ring (`.circular__progress-bar`) and confirm it now has `aria-label="Steps to launch your site"` plus `aria-valuemin`/`aria-valuemax`/`aria-valuenow`.
* Run axe (or a screen reader) and confirm the `aria-progressbar-name` violation is gone and the ring announces its label and progress.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
