### PR TITLE
Stats: fix CSV export filenames for selected date ranges

### DIFF
--- a/client/my-sites/stats/stats-download-csv/get-stats-csv-filename.js
+++ b/client/my-sites/stats/stats-download-csv/get-stats-csv-filename.js
@@ -5,15 +5,20 @@ import moment from 'moment';
  *
  * When a custom date range query is present (`start_date` + `date`), those dates
  * and the query period are used. Otherwise the legacy period object bounds are used.
- *
  * @param {Object} options
  * @param {string} options.siteSlug Site slug used as the filename prefix.
  * @param {string} options.path Stats module path segment (e.g. "posts").
  * @param {Object} options.period Period object with `period`, `startOf`, and `endOf`.
  * @param {Object} [options.query] Stats query; custom ranges include `start_date` and `date`.
+ * @param {boolean} [options.includeDates] Pass false for exports that are not date-scoped
+ * (e.g. the all-time Emails summary) to omit the period and date segments.
  * @returns {string} Filename ending in `.csv`.
  */
-export function getStatsCsvFileName( { siteSlug, path, period, query } ) {
+export function getStatsCsvFileName( { siteSlug, path, period, query, includeDates = true } ) {
+	if ( ! includeDates ) {
+		return [ siteSlug, path ].join( '-' ) + '.csv';
+	}
+
 	const hasCustomDateRange = Boolean( query?.start_date && query?.date );
 	const periodLabel = hasCustomDateRange && query.period ? query.period : period.period;
 

--- a/client/my-sites/stats/stats-download-csv/get-stats-csv-filename.js
+++ b/client/my-sites/stats/stats-download-csv/get-stats-csv-filename.js
@@ -21,13 +21,16 @@ export function getStatsCsvFileName( { siteSlug, path, period, query, includeDat
 		return [ siteSlug, path ].join( '-' ) + '.csv';
 	}
 
-	const hasCustomDateRange = Boolean( query?.start_date && query?.date );
+	const dateLocale = period.startOf.locale();
+	const customStart = query?.start_date ? moment( query.start_date, 'YYYY-MM-DD', true ) : null;
+	const customEnd = query?.date ? moment( query.date, 'YYYY-MM-DD', true ) : null;
+	const hasCustomDateRange = Boolean( customStart?.isValid() && customEnd?.isValid() );
 
 	const startDate = hasCustomDateRange
-		? moment( query.start_date, 'YYYY-MM-DD' ).format( 'L' )
+		? customStart.locale( dateLocale ).format( 'L' )
 		: period.startOf.format( 'L' );
 	const endDate = hasCustomDateRange
-		? moment( query.date, 'YYYY-MM-DD' ).format( 'L' )
+		? customEnd.locale( dateLocale ).format( 'L' )
 		: period.endOf.format( 'L' );
 
 	if ( hasCustomDateRange ) {

--- a/client/my-sites/stats/stats-download-csv/get-stats-csv-filename.js
+++ b/client/my-sites/stats/stats-download-csv/get-stats-csv-filename.js
@@ -4,7 +4,9 @@ import moment from 'moment';
  * Builds the CSV export filename so it matches the data selection.
  *
  * When a custom date range query is present (`start_date` + `date`), those dates
- * and the query period are used. Otherwise the legacy period object bounds are used.
+ * are used and the period segment is omitted (query.period is forced to `day` for
+ * API reasons and is not meaningful in the filename). Otherwise the legacy period
+ * object label and bounds are used.
  * @param {Object} options
  * @param {string} options.siteSlug Site slug used as the filename prefix.
  * @param {string} options.path Stats module path segment (e.g. "posts").
@@ -20,7 +22,6 @@ export function getStatsCsvFileName( { siteSlug, path, period, query, includeDat
 	}
 
 	const hasCustomDateRange = Boolean( query?.start_date && query?.date );
-	const periodLabel = hasCustomDateRange && query.period ? query.period : period.period;
 
 	const startDate = hasCustomDateRange
 		? moment( query.start_date, 'YYYY-MM-DD' ).format( 'L' )
@@ -29,5 +30,9 @@ export function getStatsCsvFileName( { siteSlug, path, period, query, includeDat
 		? moment( query.date, 'YYYY-MM-DD' ).format( 'L' )
 		: period.endOf.format( 'L' );
 
-	return [ siteSlug, path, periodLabel, startDate, endDate ].join( '-' ) + '.csv';
+	if ( hasCustomDateRange ) {
+		return [ siteSlug, path, startDate, endDate ].join( '-' ) + '.csv';
+	}
+
+	return [ siteSlug, path, period.period, startDate, endDate ].join( '-' ) + '.csv';
 }

--- a/client/my-sites/stats/stats-download-csv/get-stats-csv-filename.js
+++ b/client/my-sites/stats/stats-download-csv/get-stats-csv-filename.js
@@ -1,0 +1,28 @@
+import moment from 'moment';
+
+/**
+ * Builds the CSV export filename so it matches the data selection.
+ *
+ * When a custom date range query is present (`start_date` + `date`), those dates
+ * and the query period are used. Otherwise the legacy period object bounds are used.
+ *
+ * @param {Object} options
+ * @param {string} options.siteSlug Site slug used as the filename prefix.
+ * @param {string} options.path Stats module path segment (e.g. "posts").
+ * @param {Object} options.period Period object with `period`, `startOf`, and `endOf`.
+ * @param {Object} [options.query] Stats query; custom ranges include `start_date` and `date`.
+ * @returns {string} Filename ending in `.csv`.
+ */
+export function getStatsCsvFileName( { siteSlug, path, period, query } ) {
+	const hasCustomDateRange = Boolean( query?.start_date && query?.date );
+	const periodLabel = hasCustomDateRange && query.period ? query.period : period.period;
+
+	const startDate = hasCustomDateRange
+		? moment( query.start_date, 'YYYY-MM-DD' ).format( 'L' )
+		: period.startOf.format( 'L' );
+	const endDate = hasCustomDateRange
+		? moment( query.date, 'YYYY-MM-DD' ).format( 'L' )
+		: period.endOf.format( 'L' );
+
+	return [ siteSlug, path, periodLabel, startDate, endDate ].join( '-' ) + '.csv';
+}

--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -16,6 +16,7 @@ import {
 	isRequestingSiteStatsForQuery,
 } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getStatsCsvFileName } from './get-stats-csv-filename';
 
 import './style.scss';
 
@@ -53,16 +54,9 @@ class StatsDownloadCsv extends Component {
 
 	downloadCsv = ( event ) => {
 		event.preventDefault();
-		const { siteSlug, path, period, data, headers } = this.props;
+		const { siteSlug, path, period, query, data, headers } = this.props;
 
-		const fileName =
-			[
-				siteSlug,
-				path,
-				period.period,
-				period.startOf.format( 'L' ),
-				period.endOf.format( 'L' ),
-			].join( '-' ) + '.csv';
+		const fileName = getStatsCsvFileName( { siteSlug, path, period, query } );
 
 		this.props.recordGoogleEvent( 'Stats', 'CSV Download ' + titlecase( path ) );
 

--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -33,6 +33,7 @@ class StatsDownloadCsv extends Component {
 		hideIfNoData: PropTypes.bool,
 		headers: PropTypes.array,
 		rowModifierFn: PropTypes.func,
+		includeDates: PropTypes.bool,
 	};
 
 	processExportData = ( data ) => {
@@ -54,9 +55,9 @@ class StatsDownloadCsv extends Component {
 
 	downloadCsv = ( event ) => {
 		event.preventDefault();
-		const { siteSlug, path, period, query, data, headers } = this.props;
+		const { siteSlug, path, period, query, data, headers, includeDates } = this.props;
 
-		const fileName = getStatsCsvFileName( { siteSlug, path, period, query } );
+		const fileName = getStatsCsvFileName( { siteSlug, path, period, query, includeDates } );
 
 		this.props.recordGoogleEvent( 'Stats', 'CSV Download ' + titlecase( path ) );
 

--- a/client/my-sites/stats/stats-download-csv/test/get-stats-csv-filename.js
+++ b/client/my-sites/stats/stats-download-csv/test/get-stats-csv-filename.js
@@ -1,0 +1,79 @@
+import moment from 'moment';
+import { getStatsCsvFileName } from '../get-stats-csv-filename';
+
+describe( 'getStatsCsvFileName', () => {
+	const siteSlug = 'mercantile.wordpress.org';
+	const path = 'posts';
+
+	beforeAll( () => {
+		moment.locale( 'en' );
+	} );
+
+	it( 'uses the selected custom date range for multi-month exports (STATS-420)', () => {
+		// Period object still reflects a single month unit around the start date,
+		// which previously produced filenames like posts-month-01/01/2026-01/31/2026.
+		const period = {
+			period: 'month',
+			startOf: moment( '2026-01-01' ),
+			endOf: moment( '2026-01-31' ),
+		};
+		const query = {
+			period: 'day',
+			start_date: '2026-01-01',
+			date: '2026-08-06',
+			summarize: 1,
+		};
+
+		expect( getStatsCsvFileName( { siteSlug, path, period, query } ) ).toBe(
+			'mercantile.wordpress.org-posts-day-01/01/2026-08/06/2026.csv'
+		);
+	} );
+
+	it( 'uses the selected custom date range for a single-month export (STATS-420)', () => {
+		// A day-period unit around the start date previously produced
+		// posts-day-01/01/2026-01/01/2026 for a Jan 1–31 selection.
+		const period = {
+			period: 'day',
+			startOf: moment( '2026-01-01' ),
+			endOf: moment( '2026-01-01' ),
+		};
+		const query = {
+			period: 'day',
+			start_date: '2026-01-01',
+			date: '2026-01-31',
+			summarize: 1,
+		};
+
+		expect( getStatsCsvFileName( { siteSlug, path, period, query } ) ).toBe(
+			'mercantile.wordpress.org-posts-day-01/01/2026-01/31/2026.csv'
+		);
+	} );
+
+	it( 'falls back to period bounds when no custom date range is present', () => {
+		const period = {
+			period: 'month',
+			startOf: moment( '2026-01-01' ),
+			endOf: moment( '2026-01-31' ),
+		};
+		const query = {
+			period: 'month',
+			date: '2026-01-31',
+		};
+
+		expect( getStatsCsvFileName( { siteSlug, path, period, query } ) ).toBe(
+			'mercantile.wordpress.org-posts-month-01/01/2026-01/31/2026.csv'
+		);
+	} );
+
+	it( 'falls back to period bounds when query is omitted', () => {
+		const period = {
+			period: 'week',
+			startOf: moment( '2026-01-05' ),
+			endOf: moment( '2026-01-11' ),
+		};
+
+		expect( getStatsCsvFileName( { siteSlug, path, period } ) ).toBe(
+			'mercantile.wordpress.org-posts-week-01/05/2026-01/11/2026.csv'
+		);
+	} );
+} );

--- a/client/my-sites/stats/stats-download-csv/test/get-stats-csv-filename.js
+++ b/client/my-sites/stats/stats-download-csv/test/get-stats-csv-filename.js
@@ -65,6 +65,19 @@ describe( 'getStatsCsvFileName', () => {
 		);
 	} );
 
+	it( 'omits the period and date segments when includeDates is false', () => {
+		const period = {
+			period: 'day',
+			startOf: moment( '2026-08-06' ),
+			endOf: moment( '2026-08-06' ),
+		};
+		const query = { quantity: 30 };
+
+		expect(
+			getStatsCsvFileName( { siteSlug, path: 'emails', period, query, includeDates: false } )
+		).toBe( 'mercantile.wordpress.org-emails.csv' );
+	} );
+
 	it( 'falls back to period bounds when query is omitted', () => {
 		const period = {
 			period: 'week',

--- a/client/my-sites/stats/stats-download-csv/test/get-stats-csv-filename.js
+++ b/client/my-sites/stats/stats-download-csv/test/get-stats-csv-filename.js
@@ -12,6 +12,7 @@ describe( 'getStatsCsvFileName', () => {
 	it( 'uses the selected custom date range for multi-month exports (STATS-420)', () => {
 		// Period object still reflects a single month unit around the start date,
 		// which previously produced filenames like posts-month-01/01/2026-01/31/2026.
+		// query.period is forced to 'day' for custom ranges and is omitted from the filename.
 		const period = {
 			period: 'month',
 			startOf: moment( '2026-01-01' ),
@@ -25,7 +26,7 @@ describe( 'getStatsCsvFileName', () => {
 		};
 
 		expect( getStatsCsvFileName( { siteSlug, path, period, query } ) ).toBe(
-			'mercantile.wordpress.org-posts-day-01/01/2026-08/06/2026.csv'
+			'mercantile.wordpress.org-posts-01/01/2026-08/06/2026.csv'
 		);
 	} );
 
@@ -45,7 +46,7 @@ describe( 'getStatsCsvFileName', () => {
 		};
 
 		expect( getStatsCsvFileName( { siteSlug, path, period, query } ) ).toBe(
-			'mercantile.wordpress.org-posts-day-01/01/2026-01/31/2026.csv'
+			'mercantile.wordpress.org-posts-01/01/2026-01/31/2026.csv'
 		);
 	} );
 

--- a/client/my-sites/stats/stats-download-csv/test/get-stats-csv-filename.js
+++ b/client/my-sites/stats/stats-download-csv/test/get-stats-csv-filename.js
@@ -4,9 +4,15 @@ import { getStatsCsvFileName } from '../get-stats-csv-filename';
 describe( 'getStatsCsvFileName', () => {
 	const siteSlug = 'mercantile.wordpress.org';
 	const path = 'posts';
+	let previousLocale;
 
 	beforeAll( () => {
+		previousLocale = moment.locale();
 		moment.locale( 'en' );
+	} );
+
+	afterAll( () => {
+		moment.locale( previousLocale );
 	} );
 
 	it( 'uses the selected custom date range for multi-month exports (STATS-420)', () => {
@@ -59,6 +65,24 @@ describe( 'getStatsCsvFileName', () => {
 		const query = {
 			period: 'month',
 			date: '2026-01-31',
+		};
+
+		expect( getStatsCsvFileName( { siteSlug, path, period, query } ) ).toBe(
+			'mercantile.wordpress.org-posts-month-01/01/2026-01/31/2026.csv'
+		);
+	} );
+
+	it( 'falls back to period bounds when custom range dates are invalid', () => {
+		const period = {
+			period: 'month',
+			startOf: moment( '2026-01-01' ),
+			endOf: moment( '2026-01-31' ),
+		};
+		const query = {
+			period: 'day',
+			start_date: 'not-a-date',
+			date: '2026-08-06',
+			summarize: 1,
 		};
 
 		expect( getStatsCsvFileName( { siteSlug, path, period, query } ) ).toBe(

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -79,6 +79,7 @@ const StatsEmailSummaryInner = ( { period, query, context, breadcrumbTrail } ) =
 			path="emails"
 			query={ query }
 			period={ period }
+			includeDates={ false }
 			headers={ [ 'title', 'opens_rate', 'unique_clicks', 'link' ] }
 			rowModifierFn={ ( row, data ) => {
 				if ( ! Array.isArray( row ) || row.length === 0 ) {


### PR DESCRIPTION
Fixes STATS-420

## Proposed Changes

* Prefer the custom date-range query (`start_date` / `date`) when building Stats CSV download filenames, so the filename matches the selected range instead of a single period unit around the start date.
* Omit the period segment for custom ranges (query.period is forced to `day` for the API and is not meaningful in the filename), e.g. `…-posts-01/01/2026-08/06/2026.csv` instead of `…-posts-day-01/01/2026-08/06/2026.csv`.
* Extract `getStatsCsvFileName` and add regression coverage for the STATS-420 cases (multi-month and single-month custom ranges).
* Drop the period and date segments from the Emails summary export filename via a new `includeDates` option, so it downloads as `<site-slug>-emails.csv`.

## Why are these changes being made?

Exported report filenames did not reflect the selected date range. For a Jan 1–Aug 6 selection the file looked like a January-only month export, and for Jan 1–31 the filename used a day period with identical start/end dates. The CSV contents were correct; only the filename was wrong.

Custom date ranges also always forced `query.period` to `day`, which left a misleading `day-` prefix in every custom-range export even after the dates were fixed.

The Emails summary report has no date picker and its export is not date-scoped — it always returns the latest 30 emails — so a date range in that filename was misleading and is now omitted.

## Testing Instructions

1. Open Jetpack Stats → Posts (or another summary module with CSV download).
2. Select a custom range spanning multiple months (e.g. Jan 1–Aug 6, 2026) and download CSV.
3. Confirm the filename includes the full selected range **without** a period segment (e.g. `…-posts-01/01/2026-08/06/2026.csv`), not `…-posts-day-…` or a single month.
4. Select a single-month custom range (e.g. Jan 1–31) and download CSV.
5. Confirm the filename uses that full range without a period segment, not `…-day-01/01/2026-01/01/2026.csv`.
6. Select a standard period without a custom range (e.g. month view) and confirm the filename still uses that period’s label and start/end (e.g. `…-month-…`).
7. Open Stats → Emails (`/stats/day/emails/<site>`) and download CSV. Confirm the filename is `<site-slug>-emails.csv` with no period or dates.
8. Optional: `yarn test-client client/my-sites/stats/stats-download-csv/test/get-stats-csv-filename.js`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?


Made with [Cursor](https://cursor.com)
