### PR TITLE
Omnibar: support wpcom-account node

### DIFF
--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -15,8 +15,10 @@ import { OmnibarHomeIcon } from './home';
 import { useHelpCenterPlugin } from './plugin-help-center';
 import { useNotificationsPlugin } from './plugin-notifications';
 import { useStatsSparklinePlugin } from './plugin-stats-sparkline';
+import { buildWpcomAccountNode } from './plugin-wpcom-account';
 import type { AppConfig } from '../context';
 import type { User } from '@automattic/api-core';
+import type { OmnibarNodeBuilders } from '@automattic/omnibar';
 
 const onClickResponsiveMenu = () => omnibarEvents.mobileMenu.emit();
 
@@ -24,8 +26,11 @@ const UNSUPPORTED_DOTCOM_NODE_IDS = new Set( [
 	'site-plan',
 	'site-plan-badge',
 	'site-status-badge',
-	'my-wpcom-account',
 ] );
+
+const DOTCOM_NODE_BUILDERS: OmnibarNodeBuilders = {
+	'my-wpcom-account': buildWpcomAccountNode,
+};
 
 function removeUnsupportedNodes( nodes: AdminBarNode[], supports: AppConfig[ 'supports' ] ) {
 	return nodes.filter( ( node ) => {
@@ -59,7 +64,10 @@ export default function OmnibarContainer( { user }: { user?: User } ) {
 
 	const baseOmnibarNodes = useMemo( () => {
 		const nodes = siteNodes ?? dashboardNodes ?? [];
-		const result = buildOmnibarNodesFromAdminBarNodes( removeUnsupportedNodes( nodes, supports ) );
+		const result = buildOmnibarNodesFromAdminBarNodes(
+			removeUnsupportedNodes( nodes, supports ),
+			DOTCOM_NODE_BUILDERS
+		);
 
 		if ( ! result.home ) {
 			result.home = { id: '' };

--- a/client/dashboard/app/omnibar/plugin-wpcom-account.scss
+++ b/client/dashboard/app/omnibar/plugin-wpcom-account.scss
@@ -1,0 +1,31 @@
+.omnibar__popover {
+	.omnibar__wpcom-account {
+		display: block;
+		box-sizing: border-box;
+		width: 100%;
+		height: 34px;
+		padding: 0 14px;
+		margin-block: 6px;
+		border-radius: 2px;
+		background-color: var( --studio-wordpress-blue-50, #3858e9 );
+		color: var( --omnibar-text-color );
+		line-height: 32px;
+		text-align: center;
+
+		svg {
+			position: relative;
+			top: -1px;
+			margin-inline: -2px -4px;
+			fill: currentColor;
+			vertical-align: middle;
+			transform: scale( 0.8 );
+		}
+	}
+
+	[role='menuitem']:hover,
+	[role='menuitem'][data-active-item] {
+		.omnibar__wpcom-account {
+			background-color: #4664eb;
+		}
+	}
+}

--- a/client/dashboard/app/omnibar/plugin-wpcom-account.tsx
+++ b/client/dashboard/app/omnibar/plugin-wpcom-account.tsx
@@ -1,0 +1,21 @@
+import { OmnibarHomeIcon } from './home';
+import type { AdminBarNode, OmnibarNode } from '@automattic/omnibar';
+
+import './plugin-wpcom-account.scss';
+
+export function buildWpcomAccountNode( adminBarNode: AdminBarNode ): Partial< OmnibarNode > {
+	const doc = new DOMParser().parseFromString( adminBarNode.title || '', 'text/html' );
+	const button = doc.querySelector( '.wpcom-button' ) ?? doc.body;
+	const content = Array.from( button.childNodes ).map( ( child, index ) =>
+		( child as Element ).classList?.contains( 'wpcom-logo' ) ? (
+			<OmnibarHomeIcon key={ index } />
+		) : (
+			child.textContent
+		)
+	);
+
+	return {
+		title: undefined,
+		render: () => <span className="omnibar__wpcom-account">{ content }</span>,
+	};
+}

--- a/packages/omnibar/src/components/_variables.scss
+++ b/packages/omnibar/src/components/_variables.scss
@@ -8,5 +8,5 @@ $omnibar-submenu-background: #0c0c0c;
 $omnibar-text-color: #fff;
 $omnibar-submenu-text-color: #bcbcbc;
 $omnibar-highlight-color: #7b90ff;
-
+$omnibar-secondary-group-background: rgba( 255, 255, 255, 0.15 );
 $omnibar-avatar-ring-color: #303030;

--- a/packages/omnibar/src/components/omnibar-menu.scss
+++ b/packages/omnibar/src/components/omnibar-menu.scss
@@ -1,0 +1,49 @@
+.omnibar__popover {
+	// All colors used by the Menu's internal Emotion styles read from these
+	// CSS custom properties (see node_modules/@wordpress/components/src/menu/styles.ts).
+	// Setting them here re-skins the entire popover without specificity wars.
+	--wp-components-color-background: var( --omnibar-submenu-background );
+	--wp-components-color-foreground: var( --omnibar-text-color );
+	--wp-components-color-accent: transparent; // hover/active item bg
+	--wp-components-color-accent-inverted: var(
+		--omnibar-submenu-highlight-color
+	); // hover/active item text
+	--wp-components-color-gray-100: transparent; // submenu-trigger-open bg
+	--wp-components-color-gray-700: var( --omnibar-text-color ); // prefix / suffix text
+
+	// Padding, border-radius, and the elevation portion of the popover's
+	// box-shadow are hardcoded (not tokens). Class is doubled to outrank
+	// Emotion's auto-generated selector at the popover level.
+	&.omnibar__popover {
+		border-radius: 0;
+		box-shadow: none;
+		padding-inline: 0;
+	}
+
+	[role='menuitem'],
+	[role='menuitemradio'],
+	[role='menuitemcheckbox'] {
+		border-radius: 0;
+		grid-template-columns: minmax( 0, max-content ) 1fr;
+		padding-inline: 10px;
+	}
+
+	.omnibar__menu-group.is-secondary {
+		grid-column: 1 / -1;
+		margin-block-start: 8px;
+		background-color: var( --omnibar-secondary-group-background );
+
+		&:first-child {
+			margin-block-start: -4px;
+		}
+
+		&:last-child {
+			margin-block-end: -4px;
+		}
+
+		@supports ( grid-template-columns: subgrid ) {
+			display: grid;
+			grid-template-columns: subgrid;
+		}
+	}
+}

--- a/packages/omnibar/src/components/omnibar-menu.tsx
+++ b/packages/omnibar/src/components/omnibar-menu.tsx
@@ -5,6 +5,8 @@ import { useRef, useState } from 'react';
 import { OmnibarNodeContent } from './omnibar-node';
 import type { OmnibarNode } from '../types';
 
+import './omnibar-menu.scss';
+
 const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 	'@wordpress/components'
@@ -54,7 +56,12 @@ function OmnibarMenuContent( { nodes }: { nodes: OmnibarNode[] } ) {
 				</Menu.Group>
 			) }
 			{ groups.map( ( group ) => (
-				<Menu.Group key={ group.id }>
+				<Menu.Group
+					key={ group.id }
+					className={
+						group.variant ? `omnibar__menu-group is-${ group.variant }` : 'omnibar__menu-group'
+					}
+				>
 					{ group.title && <Menu.GroupLabel>{ group.title }</Menu.GroupLabel> }
 					{ ( group.children || [] ).map( ( item ) => (
 						<OmnibarMenuItem key={ item.id } node={ item } />
@@ -89,7 +96,7 @@ export function OmnibarMenu( { node, className }: { node: OmnibarNode; className
 	}
 
 	const handleMouseLeave = ( event: React.MouseEvent ) => {
-		const movingTo = event.relatedTarget as Node | null;
+		const movingTo = event.relatedTarget instanceof Node ? event.relatedTarget : null;
 		if (
 			! triggerRef.current?.contains( movingTo ) &&
 			! popoverRef.current?.contains( movingTo )

--- a/packages/omnibar/src/components/omnibar-user.scss
+++ b/packages/omnibar/src/components/omnibar-user.scss
@@ -39,9 +39,13 @@
 		gap: 6px;
 	}
 
-	.omnibar__user-info {
-		opacity: 0.8;
+	.omnibar__user-username {
 		font-size: 11px;
+		color: var( --omnibar-submenu-text-color );
+	}
+
+	.omnibar__user-details > span {
+		line-height: 18px;
 	}
 }
 
@@ -55,10 +59,22 @@
 	}
 }
 
+.omnibar__popover:has( .omnibar__user ) {
+	min-width: 270px;
+}
+
 .omnibar__popover {
 	.omnibar__user-avatar {
 		width: 64px;
 		height: 64px;
 		border: 0;
+	}
+
+	[role='group']:has( .omnibar__user ) [role='menuitem'] {
+		padding-inline-start: 88px;
+	}
+
+	.omnibar__user .omnibar__user-avatar {
+		margin-inline-start: -72px;
 	}
 }

--- a/packages/omnibar/src/components/omnibar-user.tsx
+++ b/packages/omnibar/src/components/omnibar-user.tsx
@@ -32,14 +32,12 @@ export function OmnibarUserNode( { node }: { node: OmnibarNode } ) {
 							return {
 								...grandChild,
 								render: ( { title, icon, meta } ) => (
-									<Stack direction="row" gap="md" align="center" className="omnibar__user">
+									<Stack direction="row" gap="sm" align="center" className="omnibar__user">
 										{ icon && <span className="omnibar__user-avatar">{ icon }</span> }
-										<Stack direction="column" gap="sm">
-											<Stack direction="column" gap="xs">
-												<span>{ meta?.displayName }</span>
-												<span className="omnibar__user-info">@{ meta?.username }</span>
-											</Stack>
-											<span className="omnibar__user-info">{ title }</span>
+										<Stack direction="column" className="omnibar__user-details">
+											<span>{ meta?.displayName }</span>
+											<span className="omnibar__user-username">{ meta?.username }</span>
+											<span>{ title }</span>
 										</Stack>
 									</Stack>
 								),

--- a/packages/omnibar/src/components/omnibar.scss
+++ b/packages/omnibar/src/components/omnibar.scss
@@ -8,9 +8,11 @@ body:has( .omnibar ) {
 	--omnibar-menu-active-background: #{$omnibar-submenu-background};
 	--omnibar-submenu-background: #{$omnibar-submenu-background};
 	--omnibar-text-color: #{$omnibar-text-color};
+	--omnibar-submenu-text-color: #{$omnibar-submenu-text-color};
 	--omnibar-highlight-color: #{$omnibar-highlight-color};
 	--omnibar-submenu-highlight-color: #{$omnibar-highlight-color};
 	--omnibar-avatar-ring-color: #{$omnibar-avatar-ring-color};
+	--omnibar-secondary-group-background: #{$omnibar-secondary-group-background};
 
 	@media ( min-width: 782px ) {
 		--omnibar-height: #{$omnibar-height};
@@ -217,34 +219,4 @@ body:has( .omnibar ) {
 
 .omnibar .dashicons-menu-alt::before {
 	top: 0.5px;
-}
-
-.omnibar__popover {
-	// All colors used by the Menu's internal Emotion styles read from these
-	// CSS custom properties (see node_modules/@wordpress/components/src/menu/styles.ts).
-	// Setting them here re-skins the entire popover without specificity wars.
-	--wp-components-color-background: var( --omnibar-submenu-background );
-	--wp-components-color-foreground: var( --omnibar-text-color );
-	--wp-components-color-accent: transparent; // hover/active item bg
-	--wp-components-color-accent-inverted: var(
-		--omnibar-submenu-highlight-color
-	); // hover/active item text
-	--wp-components-color-gray-100: transparent; // submenu-trigger-open bg
-	--wp-components-color-gray-700: var( --omnibar-text-color ); // prefix / suffix text
-
-	// Padding, border-radius, and the elevation portion of the popover's
-	// box-shadow are hardcoded (not tokens). Class is doubled to outrank
-	// Emotion's auto-generated selector at the popover level.
-	&.omnibar__popover {
-		border-radius: 0;
-		box-shadow: none;
-	}
-
-	[role='menuitem'],
-	[role='menuitemradio'],
-	[role='menuitemcheckbox'] {
-		border-radius: 0;
-		grid-template-columns: minmax( 0, max-content ) 1fr;
-		padding-inline: 6px;
-	}
 }

--- a/packages/omnibar/src/style.scss
+++ b/packages/omnibar/src/style.scss
@@ -1,3 +1,4 @@
 @import './components/omnibar.scss';
+@import './components/omnibar-menu.scss';
 @import './components/omnibar-responsive-menu.scss';
 @import './components/omnibar-user.scss';

--- a/packages/omnibar/src/types/admin-bar.ts
+++ b/packages/omnibar/src/types/admin-bar.ts
@@ -6,5 +6,6 @@ export interface AdminBarNode {
 	group: boolean;
 	meta?: {
 		menu_title?: string;
+		class?: string;
 	};
 }

--- a/packages/omnibar/src/types/index.ts
+++ b/packages/omnibar/src/types/index.ts
@@ -1,2 +1,2 @@
 export type { AdminBarNode } from './admin-bar';
-export type { OmnibarNode, OmnibarNodes, OmnibarProps } from './omnibar';
+export type { OmnibarNode, OmnibarNodeBuilders, OmnibarNodes, OmnibarProps } from './omnibar';

--- a/packages/omnibar/src/types/omnibar.ts
+++ b/packages/omnibar/src/types/omnibar.ts
@@ -1,15 +1,23 @@
+import type { AdminBarNode } from './admin-bar';
+
 export interface OmnibarNode {
 	id: string;
 	title?: string;
 	label?: string;
 	icon?: React.ReactElement;
 	group?: boolean;
+	variant?: 'secondary';
 	href?: string;
 	onClick?: () => void;
 	meta?: SiteActionNodeMeta & UserInfoNodeMeta;
 	render?: ( node: OmnibarNode ) => React.ReactNode;
 	children?: OmnibarNode[];
 }
+
+export type OmnibarNodeBuilders = Record<
+	string,
+	( adminBarNode: AdminBarNode ) => Partial< OmnibarNode >
+>;
 
 export interface SiteActionNodeMeta {
 	subtitle?: string;

--- a/packages/omnibar/src/utils/admin-bar.tsx
+++ b/packages/omnibar/src/utils/admin-bar.tsx
@@ -1,7 +1,10 @@
 import { dispatch } from '@wordpress/data';
-import type { AdminBarNode, OmnibarNode, OmnibarNodes } from '../types';
+import type { AdminBarNode, OmnibarNode, OmnibarNodeBuilders, OmnibarNodes } from '../types';
 
-export function buildOmnibarNodesFromAdminBarNodes( adminBarNodes: AdminBarNode[] ): OmnibarNodes {
+export function buildOmnibarNodesFromAdminBarNodes(
+	adminBarNodes: AdminBarNode[],
+	builders?: OmnibarNodeBuilders
+): OmnibarNodes {
 	const omnibarNodes: OmnibarNodes = {};
 	const siteActionNodes: OmnibarNode[] = [];
 
@@ -13,6 +16,10 @@ export function buildOmnibarNodesFromAdminBarNodes( adminBarNodes: AdminBarNode[
 			href: node.href,
 			group: node.group,
 		};
+
+		if ( node.meta?.class?.split( ' ' ).includes( 'ab-sub-secondary' ) ) {
+			omnibarNode.variant = 'secondary';
+		}
 
 		switch ( node.id ) {
 			case 'wp-logo':
@@ -113,6 +120,11 @@ export function buildOmnibarNodesFromAdminBarNodes( adminBarNodes: AdminBarNode[
 				};
 				break;
 			}
+		}
+
+		const builder = builders?.[ node.id ];
+		if ( builder ) {
+			Object.assign( omnibarNode, builder( node ) );
 		}
 
 		nodeMap.set( node.id, omnibarNode );


### PR DESCRIPTION

## Proposed Changes

This PR implements the `wpcom-account` node which links to the WP.com account:

<img width="276" height="219" alt="image" src="https://github.com/user-attachments/assets/543c8a9d-e325-4458-a67d-480ed4792a48" />

Some details:

- Add `.ab-secondary` styling support to the omnibar package so that we can render the node in a different group with alternate background color.
- The "My WordPress.com Account" text and href come from the backend (admin-bar endpoint); we just inject the logo and stylings.
- To do the above, the dashboard parses the node via a new builder pattern in the omnibar package, which takes the raw backend response and build a node object.

## Testing Instructions

Test with `dashboard/omnibar-radical` flag turned on. Go to any dashboard screen, hover to the top-right, verify the new node is shown as screenshot above.
