### PR TITLE
A4A Marketplace: Fix product filter menu items shifting on hover

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/index.tsx
@@ -86,90 +86,92 @@ export default function ProductFilter( {
 	const hasSelections = hasSelectedFilter( selectedFilters );
 
 	return (
-		<div className="product-filter-container">
-			<div ref={ ref }>
-				<DropdownMenu
-					className="product-filter"
-					label={ translate( 'Filter' ) }
-					icon={ funnel }
-					variant="product-filter"
-					open={ openDropdown }
-					onToggle={ () => setOpenDropdown( ! openDropdown ) }
-				>
-					{ () => (
-						<MenuGroup className="product-filter__group">
-							<ProductFilterItem
-								label={ translate( 'Category' ) }
-								options={ categories }
-								selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_CATEGORIES ] }
-								onOptionClick={ ( option ) =>
-									updateFilter( PRODUCT_FILTER_KEY_CATEGORIES, option )
-								}
-							/>
-							<ProductFilterItem
-								label={ translate( 'Developed by' ) }
-								options={ vendors }
-								selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_VENDORS ] }
-								onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_VENDORS, option ) }
-							/>
-							<ProductFilterItem
-								label={ translate( 'Type' ) }
-								options={ types }
-								selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_TYPES ] }
-								onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_TYPES, option ) }
-							/>
-							<ProductFilterItem
-								label={ translate( 'Price' ) }
-								options={ prices }
-								selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_PRICES ] }
-								onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_PRICES, option ) }
-							/>
-						</MenuGroup>
-					) }
-				</DropdownMenu>
+		<>
+			<div className="product-filter-container">
+				<div ref={ ref }>
+					<DropdownMenu
+						className="product-filter"
+						label={ translate( 'Filter' ) }
+						icon={ funnel }
+						variant="product-filter"
+						open={ openDropdown }
+						onToggle={ () => setOpenDropdown( ! openDropdown ) }
+					>
+						{ () => (
+							<MenuGroup className="product-filter__group">
+								<ProductFilterItem
+									label={ translate( 'Category' ) }
+									options={ categories }
+									selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_CATEGORIES ] }
+									onOptionClick={ ( option ) =>
+										updateFilter( PRODUCT_FILTER_KEY_CATEGORIES, option )
+									}
+								/>
+								<ProductFilterItem
+									label={ translate( 'Developed by' ) }
+									options={ vendors }
+									selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_VENDORS ] }
+									onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_VENDORS, option ) }
+								/>
+								<ProductFilterItem
+									label={ translate( 'Type' ) }
+									options={ types }
+									selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_TYPES ] }
+									onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_TYPES, option ) }
+								/>
+								<ProductFilterItem
+									label={ translate( 'Price' ) }
+									options={ prices }
+									selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_PRICES ] }
+									onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_PRICES, option ) }
+								/>
+							</MenuGroup>
+						) }
+					</DropdownMenu>
+				</div>
+
+				{ hasSelectedFilterByType( selectedFilters[ PRODUCT_FILTER_KEY_CATEGORIES ] ) && (
+					<ProductFilterSelect
+						label={ translate( 'Category' ) }
+						options={ categories }
+						selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_CATEGORIES ] }
+						onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_CATEGORIES, option ) }
+					/>
+				) }
+
+				{ hasSelectedFilterByType( selectedFilters[ PRODUCT_FILTER_KEY_VENDORS ] ) && (
+					<ProductFilterSelect
+						label={ translate( 'Developed by' ) }
+						options={ vendors }
+						selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_VENDORS ] }
+						onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_VENDORS, option ) }
+					/>
+				) }
+
+				{ hasSelectedFilterByType( selectedFilters[ PRODUCT_FILTER_KEY_TYPES ] ) && (
+					<ProductFilterSelect
+						label={ translate( 'Type' ) }
+						options={ types }
+						selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_TYPES ] }
+						onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_TYPES, option ) }
+					/>
+				) }
+
+				{ hasSelectedFilterByType( selectedFilters[ PRODUCT_FILTER_KEY_PRICES ] ) && (
+					<ProductFilterSelect
+						label={ translate( 'Price' ) }
+						options={ prices }
+						selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_PRICES ] }
+						onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_PRICES, option ) }
+					/>
+				) }
 			</div>
-
-			{ hasSelectedFilterByType( selectedFilters[ PRODUCT_FILTER_KEY_CATEGORIES ] ) && (
-				<ProductFilterSelect
-					label={ translate( 'Category' ) }
-					options={ categories }
-					selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_CATEGORIES ] }
-					onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_CATEGORIES, option ) }
-				/>
-			) }
-
-			{ hasSelectedFilterByType( selectedFilters[ PRODUCT_FILTER_KEY_VENDORS ] ) && (
-				<ProductFilterSelect
-					label={ translate( 'Developed by' ) }
-					options={ vendors }
-					selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_VENDORS ] }
-					onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_VENDORS, option ) }
-				/>
-			) }
-
-			{ hasSelectedFilterByType( selectedFilters[ PRODUCT_FILTER_KEY_TYPES ] ) && (
-				<ProductFilterSelect
-					label={ translate( 'Type' ) }
-					options={ types }
-					selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_TYPES ] }
-					onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_TYPES, option ) }
-				/>
-			) }
-
-			{ hasSelectedFilterByType( selectedFilters[ PRODUCT_FILTER_KEY_PRICES ] ) && (
-				<ProductFilterSelect
-					label={ translate( 'Price' ) }
-					options={ prices }
-					selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_PRICES ] }
-					onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_PRICES, option ) }
-				/>
-			) }
 
 			{ hasSelections && (
 				<Button className="product-filter-button" plain onClick={ resetFilters }>
 					{ translate( 'Reset filter' ) }
 				</Button>
 			) }
-		</div>
+		</>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/product-filter-select.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/product-filter-select.tsx
@@ -51,6 +51,7 @@ export function ProductFilterSelect( { label, options, selectedOptions, onOption
 			</Button>
 
 			<PopoverMenu
+				className="product-filter-select__menu"
 				context={ buttonRef.current }
 				isVisible={ openDropdown }
 				onClose={ () => setOpenDropdown( false ) }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/style.scss
@@ -2,15 +2,23 @@
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
 
+.product-filter-container {
+	display: none;
+
+	@include break-large {
+		display: flex;
+		flex-direction: row;
+		gap: 8px;
+	}
+}
+
 .product-filter {
 	max-height: 33px;
 	max-width: 33px;
 }
 
-.product-filter-container {
-	display: flex;
-	flex-direction: row;
-	gap: 8px;
+.product-filter__group {
+	padding: 8px;
 }
 
 .product-filter-button {
@@ -49,6 +57,18 @@
 	}
 }
 
-.product-filter__group {
-	padding: 8px;
+.product-filter-select__menu .popover__menu-item.popover__menu-item.popover__menu-item {
+	&:focus,
+	&:focus-visible,
+	&:hover {
+		background: none;
+		color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+		svg {
+			fill: var(--color-accent-60);
+		}
+	}
+
+	&:focus-visible {
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/style.scss
@@ -13,40 +13,6 @@
 	gap: 8px;
 }
 
-.components-popover.is-product-filter {
-	border-radius: 4px;
-	border: 1px solid var(--color-neutral-5);
-	z-index: 10;
-}
-
-.product-filter__group {
-	padding: 8px;
-}
-
-.product-filter__group .components-menu-item__button.components-button {
-	border-radius: 4px;
-	padding: 8px 12px;
-
-	&:focus,
-	&:focus-visible,
-	&:focus-within,
-	&:hover:not(:disabled) {
-		border: none;
-		box-shadow: none;
-		// 37.0.0 moved the focus ring from box-shadow to outline; suppress it too.
-		outline: none;
-	}
-
-	&:hover:not(:disabled) {
-		background-color: var(--color-neutral-0);
-	}
-}
-
-.product-filter__group .components-menu-item__item {
-	display: flex;
-	gap: 8px;
-}
-
 .product-filter-button {
 	white-space: nowrap;
 	max-height: 36px;
@@ -81,4 +47,8 @@
 	@include break-huge {
 		display: block;
 	}
+}
+
+.product-filter__group {
+	padding: 8px;
 }


### PR DESCRIPTION
## Proposed Changes

* Remove the custom popover/menu-item overrides in the filter dropdown styles, so the design system's own focus/hover styles apply.
* Align the `ProductFilterSelect` popover menu items with the same hover/focus treatment via a new `product-filter-select__menu` class.
* Hide `product-filter-container` below the `large` breakpoint, and move the “Reset filter” button out of that container so it stays visible.

## Why are these changes being made?

* The overrides stripped `border`/`box-shadow`/`outline` from menu items, which made them shift on hover. The two filter menus (funnel dropdown and the per-filter selects) also hovered inconsistently.

## Testing Instructions

* Go to Marketplace → Products.
* Open the funnel dropdown and each filter select — hover and keyboard-focus the items. Nothing should shift, and both menus should look the same.
* Resize below the large breakpoint: filter controls are hidden, “Reset filter” remains.
* Check in dark mode too.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
