### PR TITLE
Domains: Only recommend setting a connected domain as primary once SSL is active

### DIFF
--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -1,7 +1,11 @@
 import { DomainSubtype, DomainStatus } from '@automattic/api-core';
-import { userPurchasesQuery, siteSetPrimaryDomainMutation } from '@automattic/api-queries';
+import {
+	userPurchasesQuery,
+	siteSetPrimaryDomainMutation,
+	sslDetailsQuery,
+} from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueries } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { useDispatch } from '@wordpress/data';
 import { sprintf, __ } from '@wordpress/i18n';
@@ -37,7 +41,15 @@ const SiteChangeAddressContent = lazy(
 
 const noop = () => {};
 
-export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) => {
+export const useActions = ( {
+	user,
+	sites,
+	domains,
+}: {
+	user: User;
+	sites?: Site[];
+	domains?: DomainSummary[];
+} ) => {
 	const router = useRouter();
 	const { recordTracksEvent } = useAnalytics();
 	const { createSuccessNotice } = useDispatch( noticesStore );
@@ -61,6 +73,47 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 			{} as Record< number, Site >
 		);
 	}, [ sites ] );
+	// A domain can only be made primary once its SSL certificate is provisioned.
+	// DomainSummary has no SSL field, so resolve it from the same query the SSL
+	// column uses, but only for domains that are otherwise eligible to avoid
+	// firing SSL requests for the whole list.
+	const primaryCandidateDomainNames = useMemo( () => {
+		return ( domains ?? [] )
+			.filter( ( item ) => {
+				const site = sitesByBlogId[ item.blog_id ];
+				const hasRedirect = site?.options?.is_redirect ?? false;
+				return (
+					!! site &&
+					item.subtype.id !== DomainSubtype.DEFAULT_ADDRESS &&
+					canSetAsPrimary( { domain: item, site, user } ) &&
+					! hasRedirect
+				);
+			} )
+			.map( ( item ) => item.domain );
+	}, [ domains, sitesByBlogId, user ] );
+
+	const sslQueries = useQueries( {
+		queries: primaryCandidateDomainNames.map( ( domainName ) => ( {
+			...sslDetailsQuery( domainName ),
+			staleTime: 60_000,
+		} ) ),
+	} );
+
+	// Serialize into a stable primitive so the memo below (and the actions memo)
+	// don't depend on the non-referentially-stable useQueries result.
+	const sslActiveKey = primaryCandidateDomainNames
+		.filter( ( _domainName, index ) => sslQueries[ index ]?.data?.certificate_provisioned )
+		.join( ',' );
+
+	const sslActiveByDomain = useMemo( () => {
+		const activeDomains = new Set( sslActiveKey ? sslActiveKey.split( ',' ) : [] );
+		const map: Record< string, boolean > = {};
+		primaryCandidateDomainNames.forEach( ( domainName ) => {
+			map[ domainName ] = activeDomains.has( domainName );
+		} );
+		return map;
+	}, [ primaryCandidateDomainNames, sslActiveKey ] );
+
 	const actions: Action< DomainSummary >[] = useMemo(
 		() => [
 			{
@@ -229,7 +282,15 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 				isEligible: ( item: DomainSummary ) => {
 					const site = sitesByBlogId[ item.blog_id ];
 					const hasRedirect = site?.options?.is_redirect ?? false;
-					return !! site && canSetAsPrimary( { domain: item, site, user } ) && ! hasRedirect;
+					const isSslActive =
+						item.subtype.id === DomainSubtype.DEFAULT_ADDRESS ||
+						( sslActiveByDomain[ item.domain ] ?? false );
+					return (
+						!! site &&
+						canSetAsPrimary( { domain: item, site, user } ) &&
+						! hasRedirect &&
+						isSslActive
+					);
 				},
 				disabled: isSettingPrimaryDomain,
 			},
@@ -386,6 +447,7 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 			isSettingPrimaryDomain,
 			createSuccessNotice,
 			sitesByBlogId,
+			sslActiveByDomain,
 			recordTracksEvent,
 		]
 	);

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -25,7 +25,7 @@ import {
 import { getCurrentDashboard } from '../../app/routing';
 import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import ComponentViewTracker from '../../components/component-view-tracker';
-import { isDomainRenewable, canSetAsPrimary } from '../../utils/domain';
+import { isDomainRenewable, canSetAsPrimaryIgnoringSsl } from '../../utils/domain';
 import { isTransferrableToWpcom } from '../../utils/domain-types';
 import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
 import { getRenewalUrlFromPurchase } from '../../utils/purchase';
@@ -82,12 +82,10 @@ export const useActions = ( {
 		return ( domains ?? [] )
 			.filter( ( item ) => {
 				const site = sitesByBlogId[ item.blog_id ];
-				const hasRedirect = site?.options?.is_redirect ?? false;
 				return (
 					!! site &&
 					item.subtype.id !== DomainSubtype.DEFAULT_ADDRESS &&
-					canSetAsPrimary( { domain: item, site, user } ) &&
-					! hasRedirect
+					canSetAsPrimaryIgnoringSsl( { domain: item, site, user } )
 				);
 			} )
 			.map( ( item ) => item.domain );
@@ -282,15 +280,11 @@ export const useActions = ( {
 				},
 				isEligible: ( item: DomainSummary ) => {
 					const site = sitesByBlogId[ item.blog_id ];
-					const hasRedirect = site?.options?.is_redirect ?? false;
 					const isSslActive =
 						item.subtype.id === DomainSubtype.DEFAULT_ADDRESS ||
 						( sslActiveByDomain[ item.domain ] ?? false );
 					return (
-						!! site &&
-						canSetAsPrimary( { domain: item, site, user } ) &&
-						! hasRedirect &&
-						isSslActive
+						!! site && canSetAsPrimaryIgnoringSsl( { domain: item, site, user } ) && isSslActive
 					);
 				},
 				disabled: isSettingPrimaryDomain,

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -1,7 +1,11 @@
 import { DomainSubtype, DomainStatus } from '@automattic/api-core';
-import { userPurchasesQuery, siteSetPrimaryDomainMutation } from '@automattic/api-queries';
+import {
+	userPurchasesQuery,
+	siteSetPrimaryDomainMutation,
+	sslDetailsQuery,
+} from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueries } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { useDispatch } from '@wordpress/data';
 import { sprintf, __ } from '@wordpress/i18n';
@@ -38,7 +42,15 @@ const SiteChangeAddressContent = lazy(
 
 const noop = () => {};
 
-export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) => {
+export const useActions = ( {
+	user,
+	sites,
+	domains,
+}: {
+	user: User;
+	sites?: Site[];
+	domains?: DomainSummary[];
+} ) => {
 	const router = useRouter();
 	const { recordTracksEvent } = useAnalytics();
 	const { createSuccessNotice } = useDispatch( noticesStore );
@@ -62,6 +74,47 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 			{} as Record< number, Site >
 		);
 	}, [ sites ] );
+	// A domain can only be made primary once its SSL certificate is provisioned.
+	// DomainSummary has no SSL field, so resolve it from the same query the SSL
+	// column uses, but only for domains that are otherwise eligible to avoid
+	// firing SSL requests for the whole list.
+	const primaryCandidateDomainNames = useMemo( () => {
+		return ( domains ?? [] )
+			.filter( ( item ) => {
+				const site = sitesByBlogId[ item.blog_id ];
+				const hasRedirect = site?.options?.is_redirect ?? false;
+				return (
+					!! site &&
+					item.subtype.id !== DomainSubtype.DEFAULT_ADDRESS &&
+					canSetAsPrimary( { domain: item, site, user } ) &&
+					! hasRedirect
+				);
+			} )
+			.map( ( item ) => item.domain );
+	}, [ domains, sitesByBlogId, user ] );
+
+	const sslQueries = useQueries( {
+		queries: primaryCandidateDomainNames.map( ( domainName ) => ( {
+			...sslDetailsQuery( domainName ),
+			staleTime: 60_000,
+		} ) ),
+	} );
+
+	// Serialize into a stable primitive so the memo below (and the actions memo)
+	// don't depend on the non-referentially-stable useQueries result.
+	const sslActiveKey = primaryCandidateDomainNames
+		.filter( ( _domainName, index ) => sslQueries[ index ]?.data?.certificate_provisioned )
+		.join( ',' );
+
+	const sslActiveByDomain = useMemo( () => {
+		const activeDomains = new Set( sslActiveKey ? sslActiveKey.split( ',' ) : [] );
+		const map: Record< string, boolean > = {};
+		primaryCandidateDomainNames.forEach( ( domainName ) => {
+			map[ domainName ] = activeDomains.has( domainName );
+		} );
+		return map;
+	}, [ primaryCandidateDomainNames, sslActiveKey ] );
+
 	const actions: Action< DomainSummary >[] = useMemo(
 		() => [
 			{
@@ -230,7 +283,15 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 				isEligible: ( item: DomainSummary ) => {
 					const site = sitesByBlogId[ item.blog_id ];
 					const hasRedirect = site?.options?.is_redirect ?? false;
-					return !! site && canSetAsPrimary( { domain: item, site, user } ) && ! hasRedirect;
+					const isSslActive =
+						item.subtype.id === DomainSubtype.DEFAULT_ADDRESS ||
+						( sslActiveByDomain[ item.domain ] ?? false );
+					return (
+						!! site &&
+						canSetAsPrimary( { domain: item, site, user } ) &&
+						! hasRedirect &&
+						isSslActive
+					);
 				},
 				disabled: isSettingPrimaryDomain,
 			},
@@ -387,6 +448,7 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 			isSettingPrimaryDomain,
 			createSuccessNotice,
 			sitesByBlogId,
+			sslActiveByDomain,
 			recordTracksEvent,
 		]
 	);

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -56,7 +56,10 @@ export default function DomainConnectionVerification( {
 	const hasCloudflareIpAddresses = domainMappingStatus.has_cloudflare_ip_addresses;
 
 	const connectedAndCanBeSetAsPrimary =
-		status === 'connected' && ! domainData.primary_domain && domainData.can_set_as_primary;
+		status === 'connected' &&
+		! domainData.primary_domain &&
+		domainData.can_set_as_primary &&
+		domainData.ssl_status === 'active';
 
 	return (
 		<Card

--- a/client/dashboard/domains/domain-connection-setup/test/domain-connection-verification.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-connection-verification.test.tsx
@@ -333,6 +333,7 @@ describe( 'DomainConnectionVerification', () => {
 					domainData={ createMockDomain( {
 						primary_domain: false,
 						can_set_as_primary: true,
+						ssl_status: 'active',
 					} ) }
 				/>
 			);
@@ -341,6 +342,24 @@ describe( 'DomainConnectionVerification', () => {
 
 			expect( screen.getByText( 'Set example.com as your primary site address' ) ).toBeVisible();
 		} );
+
+		test.each( [ 'pending', 'newly_registered', 'inactive' ] as const )(
+			'does not display "Recommended" section when SSL is not active (ssl_status: %s)',
+			( sslStatus ) => {
+				render(
+					<DomainConnectionVerification
+						{ ...defaultProps }
+						domainData={ createMockDomain( {
+							primary_domain: false,
+							can_set_as_primary: true,
+							ssl_status: sslStatus,
+						} ) }
+					/>
+				);
+
+				expect( screen.queryByText( 'Recommended' ) ).not.toBeInTheDocument();
+			}
+		);
 
 		test( 'does not display "Recommended" section when domain is not primary and cannot be set as primary', () => {
 			render(

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -45,7 +45,6 @@ function Domains() {
 	const { recordTracksEvent } = useAnalytics();
 	const fields = useFields( { showPrimaryDomainBadge: false } );
 	const { data: sites } = useSuspenseQuery( queries.sitesQuery() );
-	const actions = useActions( { user, sites } );
 	const searchParams = domainsIndexRoute.useSearch();
 
 	const { view, updateView, resetView } = usePersistentView( {
@@ -60,6 +59,8 @@ function Domains() {
 			return data.filter( ( domain ) => domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS );
 		},
 	} );
+
+	const actions = useActions( { user, sites, domains } );
 
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate(
 		domains ?? [],

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -55,7 +55,7 @@ function SiteDomains() {
 		site,
 	} );
 
-	const actions = useActions( { user, sites: [ site ] } );
+	const actions = useActions( { user, sites: [ site ], domains: siteDomains } );
 
 	const searchParams = siteDomainsRoute.useSearch();
 

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -58,7 +58,7 @@ function SiteDomains() {
 		site,
 	} );
 
-	const actions = useActions( { user, sites: [ site ] } );
+	const actions = useActions( { user, sites: [ site ], domains: siteDomains } );
 
 	const searchParams = siteDomainsRoute.useSearch();
 	const navigate = useNavigate();

--- a/client/dashboard/sites/domains/test/index.test.tsx
+++ b/client/dashboard/sites/domains/test/index.test.tsx
@@ -3,6 +3,7 @@
  */
 
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { render } from '../../../test-utils';
 import SiteDomains from '../index';
@@ -48,6 +49,15 @@ const domain = {
 	subscription_id: null,
 };
 
+const primaryCandidateDomain = {
+	...domain,
+	domain: 'candidate.com',
+	subtype: { id: 'domain_connection', label: 'Domain Connection' },
+	domain_status: { id: 'active', label: 'Active', type: 'success' },
+	primary_domain: false,
+	can_set_as_primary: true,
+};
+
 const ownerUser = {
 	ID: OWNER_USER_ID,
 	username: 'owner',
@@ -64,7 +74,13 @@ const nonOwnerUser = {
 	meta: { data: { flags: { active_flags: [] } } },
 } as unknown as User;
 
-function mockApis() {
+function mockApis( {
+	domains = [ domain ],
+	ssl,
+}: {
+	domains?: unknown[];
+	ssl?: { domain: string; certificate_provisioned: boolean };
+} = {} ) {
 	nock( 'https://public-api.wordpress.com' )
 		.get( `/rest/v1.1/sites/${ site.slug }` )
 		.query( true )
@@ -73,7 +89,7 @@ function mockApis() {
 	nock( 'https://public-api.wordpress.com' )
 		.get( '/rest/v1.2/all-domains' )
 		.query( true )
-		.reply( 200, { domains: [ domain ] } );
+		.reply( 200, { domains } );
 
 	nock( 'https://public-api.wordpress.com' )
 		.get( `/rest/v1.1/sites/${ SITE_ID }/domains/redirect` )
@@ -84,6 +100,20 @@ function mockApis() {
 		.get( '/rest/v1.1/me/preferences' )
 		.query( true )
 		.reply( 200, { calypso_preferences: {} } );
+
+	if ( ssl ) {
+		nock( 'https://public-api.wordpress.com' )
+			.get( `/wpcom/v2/domains/ssl/${ ssl.domain }` )
+			.query( true )
+			.reply( 200, {
+				data: {
+					certificate_provisioned: ssl.certificate_provisioned,
+					is_newly_registered: false,
+					is_expired: false,
+				},
+			} )
+			.persist();
+	}
 }
 
 describe( '<SiteDomains>', () => {
@@ -109,5 +139,41 @@ describe( '<SiteDomains>', () => {
 		await screen.findByRole( 'heading', { name: 'Domains' } );
 
 		expect( screen.getByRole( 'button', { name: 'Add domain name' } ) ).toBeVisible();
+	} );
+
+	test( 'hides "Make primary site address" action while SSL is still pending', async () => {
+		const user = userEvent.setup();
+		nock.cleanAll();
+		mockApis( {
+			domains: [ primaryCandidateDomain ],
+			ssl: { domain: primaryCandidateDomain.domain, certificate_provisioned: false },
+		} );
+
+		render( <SiteDomains />, { user: ownerUser } );
+
+		await screen.findByText( 'SSL pending' );
+
+		const actionsButtons = await screen.findAllByLabelText( 'Actions' );
+		await user.click( actionsButtons[ 0 ] );
+
+		expect( screen.queryByText( 'Make primary site address' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'shows "Make primary site address" action once SSL is active', async () => {
+		const user = userEvent.setup();
+		nock.cleanAll();
+		mockApis( {
+			domains: [ primaryCandidateDomain ],
+			ssl: { domain: primaryCandidateDomain.domain, certificate_provisioned: true },
+		} );
+
+		render( <SiteDomains />, { user: ownerUser } );
+
+		await screen.findByText( 'SSL active' );
+
+		const actionsButtons = await screen.findAllByLabelText( 'Actions' );
+		await user.click( actionsButtons[ 0 ] );
+
+		expect( screen.getByText( 'Make primary site address' ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/dashboard/sites/domains/test/index.test.tsx
+++ b/client/dashboard/sites/domains/test/index.test.tsx
@@ -3,6 +3,7 @@
  */
 
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { render } from '../../../test-utils';
 import SiteDomains from '../index';
@@ -74,6 +75,15 @@ const domain = {
 	tags: [],
 };
 
+const primaryCandidateDomain = {
+	...domain,
+	domain: 'candidate.com',
+	subtype: { id: 'domain_connection', label: 'Domain Connection' },
+	domain_status: { id: 'active', label: 'Active', type: 'success' },
+	primary_domain: false,
+	can_set_as_primary: true,
+};
+
 const ownerUser = {
 	ID: OWNER_USER_ID,
 	username: 'owner',
@@ -90,7 +100,13 @@ const nonOwnerUser = {
 	meta: { data: { flags: { active_flags: [] } } },
 } as unknown as User;
 
-function mockApis() {
+function mockApis( {
+	domains = [ domain, defaultAddressDomain ],
+	ssl,
+}: {
+	domains?: unknown[];
+	ssl?: { domain: string; certificate_provisioned: boolean };
+} = {} ) {
 	nock( 'https://public-api.wordpress.com' )
 		.get( `/rest/v1.1/sites/${ site.slug }` )
 		.query( true )
@@ -99,7 +115,7 @@ function mockApis() {
 	nock( 'https://public-api.wordpress.com' )
 		.get( '/rest/v1.2/all-domains' )
 		.query( true )
-		.reply( 200, { domains: [ domain, defaultAddressDomain ] } );
+		.reply( 200, { domains } );
 
 	nock( 'https://public-api.wordpress.com' )
 		.get( `/rest/v1.1/sites/${ SITE_ID }/domains/redirect` )
@@ -110,6 +126,20 @@ function mockApis() {
 		.get( '/rest/v1.1/me/preferences' )
 		.query( true )
 		.reply( 200, { calypso_preferences: {} } );
+
+	if ( ssl ) {
+		nock( 'https://public-api.wordpress.com' )
+			.get( `/wpcom/v2/domains/ssl/${ ssl.domain }` )
+			.query( true )
+			.reply( 200, {
+				data: {
+					certificate_provisioned: ssl.certificate_provisioned,
+					is_newly_registered: false,
+					is_expired: false,
+				},
+			} )
+			.persist();
+	}
 }
 
 describe( '<SiteDomains>', () => {
@@ -152,5 +182,41 @@ describe( '<SiteDomains>', () => {
 		await screen.findByRole( 'heading', { name: 'Domains' } );
 
 		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'hides "Make primary site address" action while SSL is still pending', async () => {
+		const user = userEvent.setup();
+		nock.cleanAll();
+		mockApis( {
+			domains: [ primaryCandidateDomain ],
+			ssl: { domain: primaryCandidateDomain.domain, certificate_provisioned: false },
+		} );
+
+		render( <SiteDomains />, { user: ownerUser } );
+
+		await screen.findByText( 'SSL pending' );
+
+		const actionsButtons = await screen.findAllByLabelText( 'Actions' );
+		await user.click( actionsButtons[ 0 ] );
+
+		expect( screen.queryByText( 'Make primary site address' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'shows "Make primary site address" action once SSL is active', async () => {
+		const user = userEvent.setup();
+		nock.cleanAll();
+		mockApis( {
+			domains: [ primaryCandidateDomain ],
+			ssl: { domain: primaryCandidateDomain.domain, certificate_provisioned: true },
+		} );
+
+		render( <SiteDomains />, { user: ownerUser } );
+
+		await screen.findByText( 'SSL active' );
+
+		const actionsButtons = await screen.findAllByLabelText( 'Actions' );
+		await user.click( actionsButtons[ 0 ] );
+
+		expect( screen.getByText( 'Make primary site address' ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/dashboard/sites/domains/test/index.test.tsx
+++ b/client/dashboard/sites/domains/test/index.test.tsx
@@ -217,6 +217,6 @@ describe( '<SiteDomains>', () => {
 		const actionsButtons = await screen.findAllByLabelText( 'Actions' );
 		await user.click( actionsButtons[ 0 ] );
 
-		expect( screen.getByText( 'Make primary site address' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Make primary site address' ) ).toBeVisible();
 	} );
 } );

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -151,6 +151,18 @@ export function canSetAsPrimary( {
 	);
 }
 
+export function canSetAsPrimaryIgnoringSsl( {
+	domain,
+	site,
+	user,
+}: {
+	domain: DomainSummary;
+	site: Site;
+	user: User;
+} ): boolean {
+	return canSetAsPrimary( { domain, site, user } ) && ! ( site.options?.is_redirect ?? false );
+}
+
 export function hasGSuiteWithUs( domain: Domain ) {
 	const status = domain.google_apps_subscription?.status;
 	return !! status && ! [ 'no_subscription', 'other_provider' ].includes( status );

--- a/client/dashboard/utils/test/domain.js
+++ b/client/dashboard/utils/test/domain.js
@@ -1,6 +1,7 @@
 import { DomainStatus, DomainSubtype, WhoisType } from '@automattic/api-core';
 import {
 	canEnableAutoRenew,
+	canSetAsPrimaryIgnoringSsl,
 	findRegistrantWhois,
 	findPrivacyServiceWhois,
 	isPendingPrimaryDomain,
@@ -71,6 +72,41 @@ describe( 'utils', () => {
 				isPendingPrimaryDomain( {
 					...baseDomain,
 					subtype: { id: DomainSubtype.DOMAIN_CONNECTION, label: 'Connection' },
+				} )
+			).toBe( false );
+		} );
+	} );
+
+	describe( 'canSetAsPrimaryIgnoringSsl', () => {
+		const baseDomain = {
+			subtype: { id: DomainSubtype.DOMAIN_CONNECTION, label: 'Connection' },
+			can_set_as_primary: true,
+			primary_domain: false,
+			domain_status: { id: DomainStatus.ACTIVE, label: 'Active', type: 'success' },
+		};
+		const site = { options: { is_redirect: false } };
+		const user = { meta: { data: { flags: { active_flags: [] } } } };
+
+		test( 'returns true for an eligible non-redirect domain', () => {
+			expect( canSetAsPrimaryIgnoringSsl( { domain: baseDomain, site, user } ) ).toBe( true );
+		} );
+
+		test( 'returns false when the site is a redirect', () => {
+			expect(
+				canSetAsPrimaryIgnoringSsl( {
+					domain: baseDomain,
+					site: { options: { is_redirect: true } },
+					user,
+				} )
+			).toBe( false );
+		} );
+
+		test( 'returns false when the domain cannot be set as primary', () => {
+			expect(
+				canSetAsPrimaryIgnoringSsl( {
+					domain: { ...baseDomain, can_set_as_primary: false },
+					site,
+					user,
 				} )
 			).toBe( false );
 		} );


### PR DESCRIPTION
Part of DOMENG-845

## Proposed Changes

* On the domain connection verification screen, gate the "Set as primary" recommendation on `ssl_status === 'active'`. While the SSL certificate is still provisioning (`pending` / `newly_registered` / `inactive`), the recommendation is no longer shown.
* Add tests covering the new gate (recommendation shown only when SSL is active; hidden for each non-active SSL status).

**Before:**
<img width="1374" height="563" alt="Screenshot 2026-09-10 at 13 55 54" src="https://github.com/user-attachments/assets/cdfeb49a-1109-48a1-bf5f-15cbb9cf3f02" />

**After:**
<img width="1367" height="548" alt="Screenshot 2026-09-10 at 13 56 03" src="https://github.com/user-attachments/assets/dfd18c95-ecda-46cf-9a31-5c6bc4e2f1e2" />

## Why are these changes being made?

The "Set as primary" recommendation on the connection verification screen is only a simple router link — it navigates the user back to the Domains page and nothing more. It does not perform the set-primary action itself.

For this particular case that is probably wrong: when the recommendation appears, the domain is not actually ready to be set as the primary domain, because its SSL certificate is still provisioning. The Domains page's own primary-domain selector treats such a domain as ineligible (it shows the "you must register or connect a new custom domain" notice). So the user follows a "recommended" action, lands back on the Domains page, and nothing changes — a dead end.

Gating the recommendation on SSL being active means it only appears once the domain can genuinely be made primary, removing the dead end reported in the issue.

Note (out of scope): even when SSL is active, the recommendation is still just a link to the Domains page rather than an action that sets the domain as primary. Making the button perform the set-primary mutation directly would be a separate follow-up.

## Testing Instructions

The "verified domain, SSL still provisioning" state is a transient window that is hard to catch naturally, so force it with the sandbox-only backend temp change:

1. Apply the backend patch from `wpcom#240637`.
2. In `wp-content/lib/domains/temp-domeng-845-repro.php`, set `const DOMAIN` at line 11 to your connected test domain. This forces that domain to report as verified/connected with its SSL certificate still provisioning.

Then, in Calypso:

* Open the domain's connection verification screen. With the temp change active (SSL pending), the "Recommended / Set as primary" block should not appear. Flip SSL back to active (revert the temp change) and reload → the block appears as before.
* On the Domains list (both the account-level Domains page and a site's Domains page), open the row's Actions menu. While SSL is pending, the "Make primary site address" action is hidden; once SSL is active it appears.

Automated tests:

* `yarn test-client client/dashboard/domains/domain-connection-setup/test/domain-connection-verification.test.tsx`
* `yarn test-client client/dashboard/sites/domains/test/index.test.tsx`
* `yarn test-client client/dashboard/utils/test/domain.js`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?