### PR TITLE
Emails: redirect the no-domain email home to the MSD

### DIFF
--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -131,25 +131,30 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 	// first render can run on stale data. Waiting for the refetch to settle
 	// avoids sending someone who already bought email off to a purchase page,
 	// which a cross-origin navigation would make unrecoverable.
-	const redirectDomainName =
+	const canRedirectToDashboard =
 		isEnabled( 'emails/titan-tiers' ) &&
 		! selectedDomainName &&
 		! isSiteDomainLoading &&
-		! isSiteDomainFetching &&
-		domainsWithEmail.length < 1 &&
-		domainsWithNoEmail.length === 1
-			? domainsWithNoEmail[ 0 ].name
-			: undefined;
+		! isSiteDomainFetching;
+
+	let dashboardRedirectPath: string | undefined;
+	if ( canRedirectToDashboard ) {
+		if ( nonWpcomDomains.length < 1 ) {
+			// No custom domain to buy email for, so land on the emails index,
+			// which prompts for a domain first.
+			dashboardRedirectPath = '/emails';
+		} else if ( domainsWithEmail.length < 1 && domainsWithNoEmail.length === 1 ) {
+			dashboardRedirectPath = `/emails/choose-email-solution/${ encodeURIComponent(
+				domainsWithNoEmail[ 0 ].name
+			) }`;
+		}
+	}
 
 	useEffect( () => {
-		if ( redirectDomainName ) {
-			navigate(
-				dashboardLink(
-					`/emails/choose-email-solution/${ encodeURIComponent( redirectDomainName ) }`
-				)
-			);
+		if ( dashboardRedirectPath ) {
+			navigate( dashboardLink( dashboardRedirectPath ) );
 		}
-	}, [ redirectDomainName ] );
+	}, [ dashboardRedirectPath ] );
 
 	if ( isSiteDomainLoading || ! hasSitesLoaded || ! selectedSite || ! domains ) {
 		return (


### PR DESCRIPTION
Follow-up to #113314

## Proposed Changes

Redirect the email home to the MSD when the site has no custom domain and `emails/titan-tiers` is on. `EmailHome` now computes a redirect path rather than a domain name, so both no-domain and single-domain cases are covered:

* no custom domain -> `/emails`
* one custom domain with no email -> `/emails/choose-email-solution/<domain>` (unchanged from #113314)

## Why are these changes being made?

#113314 redirected the single-domain-with-no-email branch of `EmailHome`, but a site with no custom domain returns earlier, from the `nonWpcomDomains.length < 1` branch that renders `EmailNoDomain` ("Get your own domain for a custom email address"). That branch never reaches the redirect, so the flag had no effect there and users stayed on the deprecated classic page.

The no-domain case targets `/emails` rather than the plans page because there is no domain to build a `choose-email-solution` URL from. The MSD emails index renders `EmptyDomainsState` when the user has no domains, which is the dashboard equivalent of `EmailNoDomain`.

## Testing Instructions

Flag overrides are not read on production (see `packages/calypso-config/src/index.ts`), so use wpcalypso or a local dev instance.

With a site that has **no custom domain** (only its `*.wordpress.com` address):

1. `/email/<site-slug>?flags=-dashboard/enable-percentage-rollout,emails/titan-tiers` -> redirects to `/emails`.
2. Same URL with `-emails/titan-tiers` -> the classic "Get your own domain for a custom email address" page renders.

Regression check, with a site that has **one custom domain and no email**:

3. Repeat both, confirming case 1 still lands on `/emails/choose-email-solution/<domain>`.

`-dashboard/enable-percentage-rollout` is needed because `isForcedOptIn` is an independent redirect trigger: since #112778 that flag is on in every environment, so any user with `id % 100 < 50` or `id > 282953237` is force-enrolled and redirected regardless of `emails/titan-tiers`.

## Note for reviewers

`EmailNoDomain` is also reachable from `/mailboxes/:site`, which falls through to `EmailHome` when no mailbox is configured (`client/my-sites/email/mailboxes/index.tsx`). That route has no redirect middleware of its own, so this change makes "My Mailboxes" redirect too. Flagging it explicitly rather than silently including it - happy to gate on `source` if that is not wanted.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
