### PR TITLE
A4A Pressable: update promo banners for the Q3 2026 hosting offer

### DIFF
--- a/client/a8c-for-agencies/components/a4a-pressable-offer/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-pressable-offer/index.tsx
@@ -11,11 +11,8 @@ import SimpleList from '../simple-list';
 
 import './style.scss';
 
-const PRESSABLE_Q2_2026_DEADLINE = new Date( '2026-06-30T23:59:59.999Z' );
-const CONTACT_SALES_MAILTO =
-	'mailto:partnerships@automattic.com?subject=Pressable%20Summer%202026%20Promo';
-const FULL_TERMS_URL =
-	'https://pressable.com/legal/summer-2026-migration-bonus-terms-and-conditions/';
+const PRESSABLE_Q3_2026_DEADLINE = new Date( '2026-09-30T23:59:59.999Z' );
+const FULL_TERMS_URL = 'https://pressable.com/legal/hosting-promotion-terms/';
 
 const PressableOffer = () => {
 	const translate = useTranslate();
@@ -30,32 +27,22 @@ const PressableOffer = () => {
 	const shouldShowOffer =
 		agency?.billing_system === 'billingdragon' &&
 		pressableOwnership !== 'agency' &&
-		new Date() <= PRESSABLE_Q2_2026_DEADLINE;
+		new Date() <= PRESSABLE_Q3_2026_DEADLINE;
 
 	const onToggleView = useCallback( () => {
 		dispatch(
-			recordTracksEvent( 'calypso_a4a_pressable_promo_offer_q2_2026_toggle_view', {
+			recordTracksEvent( 'calypso_a4a_pressable_promo_offer_q3_2026_toggle_view', {
 				event_type: isExpanded ? 'collapse' : 'expand',
 			} )
 		);
 		setIsExpanded( ( isExpanded ) => ! isExpanded );
 	}, [ dispatch, isExpanded ] );
 
-	const onContactSalesClick = useCallback(
-		( e: React.MouseEvent< HTMLAnchorElement | HTMLButtonElement > ) => {
-			e.stopPropagation();
-			dispatch(
-				recordTracksEvent( 'calypso_a4a_pressable_promo_offer_q2_2026_contact_sales_click' )
-			);
-		},
-		[ dispatch ]
-	);
-
 	const onSeeFullTermsClick = useCallback(
 		( e: React.MouseEvent< HTMLAnchorElement | HTMLButtonElement > ) => {
 			e.stopPropagation();
 			dispatch(
-				recordTracksEvent( 'calypso_a4a_pressable_promo_offer_q2_2026_see_full_terms_click' )
+				recordTracksEvent( 'calypso_a4a_pressable_promo_offer_q3_2026_see_full_terms_click' )
 			);
 		},
 		[ dispatch ]
@@ -80,7 +67,16 @@ const PressableOffer = () => {
 		>
 			<div className="a4a-pressable-offer__main">
 				<h3 className="a4a-pressable-offer__title">
-					<span>{ translate( 'Earn up to 35% cash back on Pressable. Offer ends June 30!' ) }</span>
+					<span>
+						{ translate(
+							'{{b}}Limited time offer:{{/b}} Get up to 6 months of free Pressable hosting on new plans!',
+							{
+								components: {
+									b: <b />,
+								},
+							}
+						) }
+					</span>
 
 					<Button className="a4a-pressable-offer__view-toggle-mobile">
 						<Icon icon={ chevronDown } size={ 24 } />
@@ -89,57 +85,39 @@ const PressableOffer = () => {
 
 				{ isExpanded && (
 					<div className="a4a-pressable-offer__body">
-						<p className="a4a-pressable-offer__intro">
-							{ translate(
-								'Migrate your clients to Pressable and earn up to $50,000 back. Plans starting at 15% back for 12 months, up to 35% for 36 months. {{em}}All deals must be registered through the Automattic for Agencies team to qualify.{{/em}}',
-								{
-									components: {
-										em: <em />,
-									},
-								}
-							) }
-						</p>
-
 						<SimpleList
 							items={ [
 								translate(
-									'{{b}}Payout:{{/b}} 15% back (12-month plan), 25% back (24-month plan), 35% back (36-month plan)',
+									'{{b}}6 Months Free on Annual Plans:{{/b}} Purchase a 12-month plan and receive a 50% discount on the upfront cost.',
 									{
 										components: {
 											b: <b />,
 										},
 									}
 								),
-								translate( '{{b}}Max payout:{{/b}} $50,000 per agency', {
-									components: {
-										b: <b />,
-									},
-								} ),
-								translate( '{{b}}Payout date:{{/b}} July 15, 2027', {
-									components: {
-										b: <b />,
-									},
-								} ),
 								translate(
-									'{{b}}Not eligible:{{/b}} Migrations from WordPress VIP or WordPress.com to Pressable',
+									'{{b}}3 Months Free on Monthly Plans:{{/b}} Choose a monthly billing cycle and receive savings equal to 3 free months (applied as a discount evenly across the first 12 invoices).',
 									{
 										components: {
 											b: <b />,
 										},
 									}
+								),
+								translate(
+									'{{b}}Automattic for Agencies Exclusive:{{/b}} As a partner, you can unlock these savings on Pressable’s full Signature Plan suite in addition to Premium plans.',
+									{
+										components: {
+											b: <b />,
+										},
+									}
+								),
+								translate(
+									'You will continue to earn your standard revenue share and reseller incentives on these accounts.'
 								),
 							] }
 						/>
 
 						<div className="a4a-pressable-offer__body-actions">
-							<Button
-								variant="primary"
-								href={ CONTACT_SALES_MAILTO }
-								onClick={ onContactSalesClick }
-							>
-								{ translate( 'Contact sales to claim this offer' ) }
-							</Button>
-
 							<Button
 								variant="secondary"
 								href={ FULL_TERMS_URL }
@@ -151,7 +129,7 @@ const PressableOffer = () => {
 							</Button>
 
 							<span className="a4a-pressable-offer__body-actions-footnote">
-								{ translate( '*Offer valid May 21 – June 30, 2026' ) }
+								{ translate( '*Offer valid August 11 – September 30, 2026' ) }
 							</span>
 						</div>
 					</div>

--- a/client/a8c-for-agencies/components/a4a-pressable-offer/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-pressable-offer/index.tsx
@@ -88,7 +88,7 @@ const PressableOffer = () => {
 						<SimpleList
 							items={ [
 								translate(
-									'{{b}}6 Months Free on Annual Plans:{{/b}} Purchase a 12-month plan and receive a 50% discount on the upfront cost.',
+									'{{b}}6 months free on annual plans:{{/b}} Purchase a 12-month plan and receive a 50% discount on the upfront cost.',
 									{
 										components: {
 											b: <b />,
@@ -96,7 +96,7 @@ const PressableOffer = () => {
 									}
 								),
 								translate(
-									'{{b}}3 Months Free on Monthly Plans:{{/b}} Choose a monthly billing cycle and receive savings equal to 3 free months (applied as a discount evenly across the first 12 invoices).',
+									'{{b}}3 months free on monthly plans:{{/b}} Choose a monthly billing cycle and receive savings equal to 3 free months (applied as a discount evenly across the first 12 invoices).',
 									{
 										components: {
 											b: <b />,
@@ -104,7 +104,7 @@ const PressableOffer = () => {
 									}
 								),
 								translate(
-									'{{b}}Automattic for Agencies Exclusive:{{/b}} As a partner, you can unlock these savings on Pressable’s full Signature Plan suite in addition to Premium plans.',
+									'{{b}}Automattic for Agencies exclusive:{{/b}} As a partner, you can unlock these savings on Pressable’s full Signature Plan suite in addition to Premium plans.',
 									{
 										components: {
 											b: <b />,

--- a/client/a8c-for-agencies/components/a4a-pressable-offer/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-pressable-offer/index.tsx
@@ -12,7 +12,7 @@ import SimpleList from '../simple-list';
 import './style.scss';
 
 const PRESSABLE_Q3_2026_DEADLINE = new Date( '2026-09-30T23:59:59.999Z' );
-const FULL_TERMS_URL = 'https://pressable.com/legal/hosting-promotion-terms/';
+const FULL_TERMS_URL = 'https://pressable.com/legal/late-summer-promotion-terms-and-conditions/';
 
 const PressableOffer = () => {
 	const translate = useTranslate();

--- a/client/a8c-for-agencies/components/a4a-pressable-offer/style.scss
+++ b/client/a8c-for-agencies/components/a4a-pressable-offer/style.scss
@@ -57,22 +57,12 @@
 
 	.simple-list {
 		max-width: 850px;
+		margin-block-start: 24px;
 		margin-inline-start: 16px;
 
 		li {
 			@include body-medium;
 		}
-	}
-}
-
-.a4a-pressable-offer__intro {
-	@include body-medium;
-	max-width: 850px;
-	margin-block-start: 24px;
-	margin-block-end: 0;
-
-	em {
-		font-style: italic;
 	}
 }
 

--- a/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
@@ -2,6 +2,7 @@ import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { useMemo } from 'react';
+import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { UpcomingEventProps } from 'calypso/a8c-for-agencies/components/upcoming-event/types';
 import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
 import PressableLogo from 'calypso/assets/images/a8c-for-agencies/events/pressable-logo.svg';
@@ -114,38 +115,35 @@ export const useUpcomingEvents = () => {
 			...( shouldShowPressablePromoOffer
 				? [
 						{
-							id: 'a4a-pressable-promo-offer-2026-q2',
+							id: 'a4a-pressable-promo-offer-2026-q3',
 							date: {
-								from: moment( '2026-05-21' ),
-								to: moment( '2026-06-30' ),
+								from: moment( '2026-08-11' ),
+								to: moment( '2026-09-30' ),
 							},
-							title: translate( 'Earn up to 35% cash back on Pressable. Offer ends June 30!' ),
+							title: translate(
+								'Limited time offer: Get up to 6 months of free Pressable hosting on new plans!'
+							),
 							subtitle: translate( 'Automattic for Agencies & Pressable' ),
 							descriptions: [
 								translate(
-									'Migrate your clients to Pressable and earn up to $50,000 back. Plans starting at 15% back for 12 months, up to 35% for 36 months. {{em}}All deals must be registered through the Automattic for Agencies team to qualify.{{/em}}',
-									{
-										components: {
-											em: <em />,
-										},
-									}
+									'Enjoy up to 6 months free on Pressable Signature and Premium Plans with Automattic for Agencies. Choose annual billing for 6 months free or monthly billing for 3 months free, while still earning revenue share and reseller incentives.'
 								),
 							],
 							ctas: [
 								{
 									variant: 'primary',
-									label: translate( 'Contact sales to claim this offer' ),
-									url: 'mailto:partnerships@automattic.com?subject=Pressable%20Summer%202026%20Promo',
+									label: translate( 'View promo details' ),
+									url: A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
 									trackEventName:
-										'calypso_a4a_overview_events_a4a_pressable_promo_offer_q2_2026_contact_sales_click',
+										'calypso_a4a_overview_events_a4a_pressable_promo_offer_q3_2026_view_promo_details_click',
 								},
 								{
 									variant: 'secondary',
 									label: translate( 'See full terms' ),
-									url: 'https://pressable.com/legal/summer-2026-migration-bonus-terms-and-conditions/',
+									url: 'https://pressable.com/legal/hosting-promotion-terms/',
 									isExternal: true,
 									trackEventName:
-										'calypso_a4a_overview_events_a4a_pressable_promo_offer_q2_2026_see_full_terms_click',
+										'calypso_a4a_overview_events_a4a_pressable_promo_offer_q3_2026_see_full_terms_click',
 								},
 							],
 							logoUrl: PressableLogo,

--- a/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
@@ -140,7 +140,7 @@ export const useUpcomingEvents = () => {
 								{
 									variant: 'secondary',
 									label: translate( 'See full terms' ),
-									url: 'https://pressable.com/legal/hosting-promotion-terms/',
+									url: 'https://pressable.com/legal/late-summer-promotion-terms-and-conditions/',
 									isExternal: true,
 									trackEventName:
 										'calypso_a4a_overview_events_a4a_pressable_promo_offer_q3_2026_see_full_terms_click',


### PR DESCRIPTION
Related to A4A-3145

⚠️ Don't merge before August 11, 2026.

<img width="1516" height="431" alt="Screenshot 2026-08-07 at 12 18 46" src="https://github.com/user-attachments/assets/2e750d45-3424-4ea5-9a77-47758fca8f06" />

<img width="1010" height="235" alt="Screenshot 2026-08-07 at 12 19 16" src="https://github.com/user-attachments/assets/f3fc6e04-cdbe-49d5-8b46-6bf408b8c6a5" />

<img width="424" height="356" alt="Screenshot 2026-08-07 at 12 18 55" src="https://github.com/user-attachments/assets/5668e4e8-e1c7-4647-bb5b-922fd343d445" />

## Proposed Changes

- Update the `PressableOffer` marketplace hero banner with the Q3 2026 offer: new headline, the four free-hosting bullets, a single **See full terms** CTA, and the `*Offer valid August 11 – September 30, 2026` footnote.
- Update the Overview event card with the matching date range, headline, body copy, and a **View promo details** CTA linking to the Pressable marketplace page.
- Point both banners at `pressable.com/legal/hosting-promotion-terms/`, the same terms page the Pressable plan cards already link to. _* This is a placeholder link_
- Bump the banner's auto-hide deadline to 2026-09-30 and rename the Tracks events to a `q3_2026` suffix so the new promo reports separately from the previous one.
- Drop the now-unused `.a4a-pressable-offer__intro` rule and restore the list's top margin.

The visibility gate is unchanged: BillingDragon agencies that do not own, and have never owned, a Pressable plan through A4A.

## Why are these changes being made?

A offer — up to 6 months of free Pressable hosting for new customers — runs August 11 through September 30, 2026, and needs banners on both the Overview page and the Pressable marketplace.

The banner is not date-gated on the start date so it can be verified on the live link ahead of the August 11 merge.

⚠️ The terms link was listed as TBD in the issue. It currently points at the existing Pressable hosting promotion terms page — worth confirming with the Pressable team before this goes live.

## Testing Instructions

0. Sandbox `public-api.wordpress.com` and use `define( 'USE_STORE_SANDBOX', true );` to see the discounted pricing.
1. Open the live link as a BillingDragon agency with no Pressable plan.
2. On the Overview page, confirm the Pressable event card shows the August 11—September 30, 2026 date range, the new headline and body copy, and that **View promo details** goes to the Pressable marketplace page and **See full terms** opens the terms page in a new tab.
3. Navigate to Marketplace > Hosting > Premier Agency Hosting and confirm the banner renders the new headline and the four bullets.
4. Confirm the banner collapses and expands on click, Enter, and Space, and that **See full terms** opens in a new tab without toggling the banner.
5. Confirm the banner does not render for an agency that owns a Pressable plan through A4A.
6. Verify no console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_01HhdjYGGhE3MHy5jxWfUAQ4
