### PR TITLE
A4A: Fix Pressable upgrade plan selection

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-normalized-slider-selection.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-normalized-slider-selection.ts
@@ -1,0 +1,11 @@
+export default function getNormalizedSliderSelection(
+	selectedIndex: number,
+	minimumIndex: number,
+	optionCount: number
+): number {
+	if ( selectedIndex < 0 || selectedIndex >= minimumIndex || minimumIndex >= optionCount ) {
+		return selectedIndex;
+	}
+
+	return minimumIndex;
+}

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/test/get-normalized-slider-selection.test.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/test/get-normalized-slider-selection.test.ts
@@ -1,0 +1,23 @@
+import getNormalizedSliderSelection from '../get-normalized-slider-selection';
+
+describe( 'getNormalizedSliderSelection', () => {
+	it( 'keeps a selected option that is above the minimum', () => {
+		expect( getNormalizedSliderSelection( 4, 3, 10 ) ).toBe( 4 );
+	} );
+
+	it( 'moves a selected option below the minimum to the first eligible option', () => {
+		expect( getNormalizedSliderSelection( 1, 3, 10 ) ).toBe( 3 );
+	} );
+
+	it( 'keeps a missing selection for the parent state to restore', () => {
+		expect( getNormalizedSliderSelection( -1, 3, 10 ) ).toBe( -1 );
+	} );
+
+	it( 'keeps a custom option above the minimum', () => {
+		expect( getNormalizedSliderSelection( 10, 3, 11 ) ).toBe( 10 );
+	} );
+
+	it( 'keeps the selected option when no eligible option exists', () => {
+		expect( getNormalizedSliderSelection( 2, 10, 10 ) ).toBe( 2 );
+	} );
+} );

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -17,6 +17,7 @@ import {
 	PLAN_CATEGORY_SIGNATURE_HIGH,
 	PLAN_CATEGORY_PREMIUM,
 } from '../constants';
+import getNormalizedSliderSelection from '../lib/get-normalized-slider-selection';
 import getPressablePlan, { PressablePlan } from '../lib/get-pressable-plan';
 import getSliderOptions from '../lib/get-slider-options';
 import { FilterType } from '../types';
@@ -130,28 +131,26 @@ export default function PlanSelectionFilter( {
 		[ dispatch, onSelectPlan, plans ]
 	);
 
-	const selectedOptionIndex = useMemo( () => {
-		let options = [];
+	const selectedOptions = useMemo( (): Option[] => {
 		switch ( selectedTab ) {
 			case PLAN_CATEGORY_STANDARD:
 			case PLAN_CATEGORY_SIGNATURE:
-				options = lowPlanOptions;
-				break;
+				return lowPlanOptions;
 			case PLAN_CATEGORY_ENTERPRISE:
 			case PLAN_CATEGORY_SIGNATURE_HIGH:
-				options = highPlanOptions;
-				break;
+				return highPlanOptions;
 			case PLAN_CATEGORY_PREMIUM:
-				options = premiumPlanOptions;
-				break;
+				return premiumPlanOptions;
 			default:
-				return 0;
+				return [];
 		}
+	}, [ selectedTab, lowPlanOptions, highPlanOptions, premiumPlanOptions ] );
 
-		return options.findIndex(
+	const selectedOptionIndex = useMemo( () => {
+		return selectedOptions.findIndex(
 			( { value } ) => value === ( selectedPlan ? selectedPlan.slug : null )
 		);
-	}, [ selectedTab, lowPlanOptions, highPlanOptions, premiumPlanOptions, selectedPlan ] );
+	}, [ selectedOptions, selectedPlan ] );
 
 	const onSelectFilterType = useCallback(
 		( value: FilterType ) => {
@@ -228,6 +227,22 @@ export default function PlanSelectionFilter( {
 		},
 		[ pressablePlan ]
 	);
+
+	useEffect( () => {
+		const normalizedIndex = getNormalizedSliderSelection(
+			selectedOptionIndex,
+			getSliderMinimum( selectedTab, selectedOptions ),
+			selectedOptions.length
+		);
+
+		if ( normalizedIndex === selectedOptionIndex ) {
+			return;
+		}
+
+		const normalizedSlug = selectedOptions[ normalizedIndex ]?.value;
+		const normalizedPlan = plans.find( ( plan ) => plan.slug === normalizedSlug ) ?? null;
+		onSelectPlan( normalizedPlan );
+	}, [ getSliderMinimum, onSelectPlan, plans, selectedOptionIndex, selectedOptions, selectedTab ] );
 
 	useEffect( () => {
 		// Ensure standard tab is not disabled if no existing plan


### PR DESCRIPTION
## Proposed Changes

* Synchronize the Pressable plan card with the slider's first eligible upgrade.
* Correct stale lower-plan selections when switching from referral mode to agency purchase mode.
* Add focused regression coverage for slider selection normalization.

<img width="1488" height="953" alt="image" src="https://github.com/user-attachments/assets/1833166e-f67f-4c70-ac8d-6fa32956ca6e" />

## Why are these changes being made?

* Referral mode allows selecting plans below an agency's active Pressable plan.
* That selection persists after referral mode is disabled, leaving the details card behind the slider's eligible upgrade position.

## Testing Instructions

* Open A4A Marketplace hosting and select Pressable.
* With an active Pressable plan, enable **Refer products** and select a lower plan.
* Disable **Refer products**.
* Verify that the slider and plan card both select the next eligible upgrade from the active plan.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have you tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

*— ClemenAgent (Powered by Codex)*
