### PR TITLE
Omnibar: implement support session language switcher

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -72,6 +72,7 @@ module.exports = {
 							'!@automattic/agents-manager',
 							'!@automattic/i18n-utils',
 							'!@automattic/languages',
+							'!@automattic/language-picker',
 							'!@automattic/load-script',
 							'!@automattic/number-formatters',
 							'!@automattic/search',

--- a/client/dashboard/app/i18n.tsx
+++ b/client/dashboard/app/i18n.tsx
@@ -1,9 +1,7 @@
 import { defaultI18n, type I18n, type LocaleData } from '@wordpress/i18n';
 import { I18nProvider as WPI18nProvider } from '@wordpress/react-i18n';
 import { useEffect, useState, type PropsWithChildren } from 'react';
-import { useAuth } from './auth';
-import { useSessionLocale } from './locale/session-locale';
-import { getUserLanguage } from './shared-locale-loader';
+import { useLocaleSlug } from './locale';
 
 async function fetchLocaleData(
 	language: string,
@@ -140,14 +138,6 @@ async function switchWebpackCSS( isRTL: boolean ) {
 			}
 		}
 	}
-}
-
-// Determine the locale to use. A session locale (set by the omnibar language
-// switcher) takes precedence over the logged-in user's saved locale.
-function useLocaleSlug() {
-	const { user } = useAuth();
-	const sessionLocale = useSessionLocale();
-	return sessionLocale ?? getUserLanguage( user );
 }
 
 export function I18nProvider( { children }: PropsWithChildren ) {

--- a/client/dashboard/app/locale/index.ts
+++ b/client/dashboard/app/locale/index.ts
@@ -1,10 +1,19 @@
 import { useAuth } from '../auth';
+import { getUserLanguage } from '../shared-locale-loader';
 import { useSessionLocale } from './session-locale';
 
 type ComputedAttributes = {
 	localeSlug?: string;
 	localeVariant?: string;
 };
+
+// Determine the locale to use. A session locale (set by the omnibar language
+// switcher) takes precedence over the logged-in user's saved locale.
+export function useLocaleSlug() {
+	const { user } = useAuth();
+	const sessionLocale = useSessionLocale();
+	return sessionLocale ?? getUserLanguage( user );
+}
 
 export function useLocale() {
 	const { user } = useAuth();

--- a/client/dashboard/app/locale/session-locale.ts
+++ b/client/dashboard/app/locale/session-locale.ts
@@ -1,12 +1,44 @@
 import { useSyncExternalStore } from 'react';
 
+const STORAGE_KEY = 'wpcom-dashboard-session-locale';
+
 /**
  * Session-local locale set by the omnibar language switcher. Changes the
  * dashboard's language for the current session without touching the account
  * setting. A module singleton so the omnibar and app (separate React trees,
- * one JS realm) share it; not persisted.
+ * one JS realm) share it.
  */
-let sessionLocale: string | null = null;
+function readStoredLocale(): string | null {
+	if ( typeof window === 'undefined' ) {
+		return null;
+	}
+
+	try {
+		const stored = window.sessionStorage.getItem( STORAGE_KEY );
+		window.sessionStorage.removeItem( STORAGE_KEY ); // Consumed by the reload that set it
+		return stored;
+	} catch {
+		return null;
+	}
+}
+
+function writeStoredLocale( locale: string | null ): void {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+
+	try {
+		if ( locale === null ) {
+			window.sessionStorage.removeItem( STORAGE_KEY );
+		} else {
+			window.sessionStorage.setItem( STORAGE_KEY, locale );
+		}
+	} catch {
+		// Ignore.
+	}
+}
+
+let sessionLocale: string | null = readStoredLocale();
 const listeners = new Set< () => void >();
 
 export function getSessionLocale(): string | null {
@@ -18,6 +50,7 @@ export function setSessionLocale( locale: string | null ): void {
 		return;
 	}
 	sessionLocale = locale;
+	writeStoredLocale( locale );
 	listeners.forEach( ( listener ) => listener() );
 }
 

--- a/client/dashboard/app/omnibar/events.ts
+++ b/client/dashboard/app/omnibar/events.ts
@@ -26,6 +26,7 @@ export const omnibarEvents = {
 	notificationsOpen: createOmnibarEvent< boolean >(),
 	siteSwitcher: createOmnibarEvent(),
 	siteSwitcherAnchor: createOmnibarEvent< HTMLElement | null >(),
+	languageSwitcher: createOmnibarEvent(),
 	linkClick: createOmnibarEvent< { href: string; event: MouseEvent } >(),
 };
 

--- a/client/dashboard/app/omnibar/omnibar-language-switcher-modal.scss
+++ b/client/dashboard/app/omnibar/omnibar-language-switcher-modal.scss
@@ -1,0 +1,30 @@
+@import '@wordpress/base-styles/breakpoints';
+
+.omnibar-language-switcher-modal {
+	@media ( min-width: $break-small ) {
+		height: 80%;
+		max-height: 600px;
+	}
+
+	.components-modal__content {
+		display: flex;
+	}
+
+	.components-modal__content > div {
+		width: 100%;
+	}
+}
+
+.omnibar-language-switcher-content {
+	height: 100%;
+}
+
+.omnibar-language-switcher-body {
+	overflow-y: auto;
+	padding: 2px;
+	margin: -2px;
+}
+
+.omnibar-language-switcher-footer {
+	margin-block-start: auto;
+}

--- a/client/dashboard/app/omnibar/omnibar-language-switcher-modal.tsx
+++ b/client/dashboard/app/omnibar/omnibar-language-switcher-modal.tsx
@@ -1,0 +1,69 @@
+import LanguagePicker, { createLanguageGroups } from '@automattic/language-picker';
+import languages from '@automattic/languages';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+	Modal,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useMemo, useState } from 'react';
+import { useLocaleSlug } from '../locale';
+import { setSessionLocale } from '../locale/session-locale';
+import type { Language } from '@automattic/languages';
+
+import './omnibar-language-switcher-modal.scss';
+
+export default function OmnibarLanguageSwitcherModal( { onClose }: { onClose: () => void } ) {
+	const currentLocale = useLocaleSlug();
+
+	const [ selectedLanguage, setSelectedLanguage ] = useState< Language | undefined >( () =>
+		languages.find( ( { langSlug } ) => langSlug === currentLocale )
+	);
+
+	const languageGroups = useMemo( () => createLanguageGroups( __ ), [] );
+
+	const apply = ( locale: string ) => {
+		setSessionLocale( locale );
+		window.location.reload();
+	};
+
+	return (
+		<Modal
+			title={ __( 'Select a language' ) }
+			className="omnibar-language-switcher-modal"
+			size="large"
+			onRequestClose={ onClose }
+		>
+			<VStack spacing={ 4 } className="omnibar-language-switcher-content">
+				<div className="omnibar-language-switcher-body">
+					<LanguagePicker
+						headingTitle
+						languages={ languages }
+						languageGroups={ languageGroups }
+						selectedLanguage={ selectedLanguage }
+						onSelectLanguage={ setSelectedLanguage }
+					/>
+				</div>
+				<HStack
+					justify="flex-end"
+					spacing={ 2 }
+					expanded={ false }
+					className="omnibar-language-switcher-footer"
+				>
+					<Button variant="tertiary" onClick={ onClose }>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button
+						variant="primary"
+						accessibleWhenDisabled
+						disabled={ ! selectedLanguage || selectedLanguage.langSlug === currentLocale }
+						onClick={ () => selectedLanguage && apply( selectedLanguage.langSlug ) }
+					>
+						{ __( 'Apply' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</Modal>
+	);
+}

--- a/client/dashboard/app/omnibar/omnibar-language-switcher.tsx
+++ b/client/dashboard/app/omnibar/omnibar-language-switcher.tsx
@@ -1,0 +1,25 @@
+import { Suspense, lazy, useState } from 'react';
+import { useOmnibarEvent } from './events';
+
+const OmnibarLanguageSwitcherModal = lazy(
+	() =>
+		import(
+			/* webpackChunkName: "async-omnibar-language-switcher" */ './omnibar-language-switcher-modal'
+		)
+);
+
+export default function OmnibarLanguageSwitcher() {
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	useOmnibarEvent( 'languageSwitcher', () => setIsOpen( true ) );
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<Suspense fallback={ null }>
+			<OmnibarLanguageSwitcherModal onClose={ () => setIsOpen( false ) } />
+		</Suspense>
+	);
+}

--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -15,6 +15,7 @@ import { omnibarEvents } from './events';
 import { OmnibarHomeIcon } from './home';
 import { useAiChatPlugin } from './plugin-ai-chat';
 import { useHelpCenterPlugin } from './plugin-help-center';
+import { useLanguageSwitcherPlugin } from './plugin-language-switcher';
 import { useNotificationsPlugin } from './plugin-notifications';
 import { useReaderPlugin } from './plugin-reader';
 import { buildSiteBadgeNode } from './plugin-site-badges';
@@ -111,6 +112,7 @@ export default function OmnibarContainer( { user }: { user?: User } ) {
 	const helpCenterPluginNode = useHelpCenterPlugin();
 	const aiChatPluginNode = useAiChatPlugin();
 	const notificationsPluginNode = useNotificationsPlugin( { user } );
+	const languageSwitcherNode = useLanguageSwitcherPlugin( { user } );
 	const statsSparklineNode = useStatsSparklinePlugin( { siteId, site } );
 	const siteActions = statsSparklineNode
 		? [ ...( baseOmnibarNodes.siteActions ?? [] ), statsSparklineNode ]
@@ -120,6 +122,7 @@ export default function OmnibarContainer( { user }: { user?: User } ) {
 		...baseOmnibarNodes,
 		siteActions,
 		plugins: [
+			...( languageSwitcherNode ? [ languageSwitcherNode ] : [] ),
 			...( supports.reader ? [ readerPluginNode ] : [] ),
 			...( supports.help ? [ helpCenterPluginNode ] : [] ),
 			...( supports.help && aiChatPluginNode ? [ aiChatPluginNode ] : [] ),

--- a/client/dashboard/app/omnibar/plugin-language-switcher.tsx
+++ b/client/dashboard/app/omnibar/plugin-language-switcher.tsx
@@ -1,0 +1,25 @@
+import { isSupportSession } from '@automattic/calypso-support-session';
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { globe } from '@wordpress/icons';
+import { useSessionLocale } from '../locale/session-locale';
+import { getUserLanguage } from '../shared-locale-loader';
+import { omnibarEvents } from './events';
+import type { User } from '@automattic/api-core';
+import type { OmnibarNode } from '@automattic/omnibar';
+
+export function useLanguageSwitcherPlugin( { user }: { user?: User } ): OmnibarNode | undefined {
+	const sessionLocale = useSessionLocale();
+
+	if ( ! isSupportSession() ) {
+		return undefined;
+	}
+
+	return {
+		id: 'language-switcher',
+		title: sessionLocale ?? getUserLanguage( user ),
+		label: __( 'Change language' ),
+		icon: <Icon icon={ globe } />,
+		onClick: () => omnibarEvents.languageSwitcher.emit(),
+	};
+}

--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -27,6 +27,7 @@ import MutationErrorTracker from '../mutation-error-tracker';
 import { NavigationBlockerRegistry } from '../navigation-blocker';
 import Notifications from '../notifications';
 import { useOmnibarEvent } from '../omnibar/events';
+import OmnibarLanguageSwitcher from '../omnibar/omnibar-language-switcher';
 import OmnibarSiteSwitcher from '../omnibar/omnibar-site-switcher';
 import { useSyncOmnibarSite } from '../omnibar/site';
 import ResponsiveSidebar from '../responsive-sidebar';
@@ -211,6 +212,7 @@ function Root() {
 			{ supports.help && <OmnibarHelpCenter /> }
 			{ supports.help && <OmnibarAgentsManager /> }
 			<OmnibarSiteSwitcher />
+			<OmnibarLanguageSwitcher />
 			<Snackbars />
 			<CheckoutSuccessFlashMessage />
 			{ isResurrectedWelcomeModalEnabled && (

--- a/packages/omnibar/src/components/omnibar-node.tsx
+++ b/packages/omnibar/src/components/omnibar-node.tsx
@@ -13,7 +13,7 @@ export function OmnibarNodeContent( { node }: { node: OmnibarNode } ) {
 				className="omnibar__node-content"
 				style={ { minWidth: 0 } }
 			>
-				<span style={ { flexShrink: 0 } }>{ node.icon }</span>
+				<span style={ { display: 'flex', flexShrink: 0 } }>{ node.icon }</span>
 				<span
 					className="omnibar__label"
 					style={ {


### PR DESCRIPTION


## Proposed Changes

This PR implements the language switcher in the omnibar when in support session:

<img width="1792" height="64" alt="image" src="https://github.com/user-attachments/assets/2f77e249-33c6-4fb8-9def-3aaa60ac2ed6" />

Note that here, I propose to move the node to the right. This is because in the new design, the left side is for site-related nodes, while for global/account related nodes we use the right side.

BTW, in this PR, we reload the page to apply the selected locale. This fixes a broken behavior in interim omnibar (https://github.com/Automattic/wp-calypso/pull/112367) where only parts of the dashboard are retranslated. This is because the dashboard imports `__()` directly from `@wordpress/i18n` in many places, which does not react without rerender. So in the interim omnibar, switching language in support session does not reliably update the strings across screens (I tried it).

This PR proposes to simply reload the page, by storing (and deleting) the requested locale to the session storage. The alternative is to use something like `useI18n` to translate strings, but it will touch so many places. Also, with reload, RTL languages work automatically (the CSS is swapped).


## Testing Instructions

Test with `dashboard/omnibar-radical` flag turned on.

1. Check out locally.
2. Run in browser console:

```
document.cookie = 'support_session_id=1; path=/';
location.reload();
```

3. Verify the language switcher behavior.
4. To reset, run this:

```
document.cookie = 'support_session_id=; path=/; max-age=0';
location.reload();
```