### PR TITLE
MCP settings: add path to /me/mcp Tracks toggle events and hardcode event names

### DIFF
--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -119,7 +119,7 @@ function McpComponent( { path } ) {
 			},
 			{
 				onSuccess: () => {
-					recordTracksEvent( 'calypso_dashboard_mcp_account_toggled', { enabled } );
+					recordTracksEvent( 'calypso_dashboard_mcp_account_toggled', { path, enabled } );
 				},
 			}
 		);

--- a/client/me/mcp/tools-subpage.jsx
+++ b/client/me/mcp/tools-subpage.jsx
@@ -31,6 +31,21 @@ import { getAccountMcpAbilities, getGroupDescriptors } from './utils';
 
 import './style.scss';
 
+// Hardcoded full event names (no runtime assembly) so each one stays
+// greppable, per the Tracks naming conventions.
+const TRACKS_EVENTS = {
+	read: {
+		groupToggled: 'calypso_dashboard_mcp_read_group_toggled',
+		toolToggled: 'calypso_dashboard_mcp_read_tool_toggled',
+		enableAllToggled: 'calypso_dashboard_mcp_read_enable_all_toggled',
+	},
+	write: {
+		groupToggled: 'calypso_dashboard_mcp_write_group_toggled',
+		toolToggled: 'calypso_dashboard_mcp_write_tool_toggled',
+		enableAllToggled: 'calypso_dashboard_mcp_write_enable_all_toggled',
+	},
+};
+
 /**
  * @param {Object} props
  * @param {string} props.path
@@ -61,8 +76,7 @@ export default function McpToolsSubpage( {
 	const openGroupsRef = useRef( new Set() );
 	const [ openGroups, setOpenGroups ] = useState( () => openGroupsRef.current );
 
-	const eventPrefix =
-		toolCategory === 'write' ? 'calypso_dashboard_mcp_write' : 'calypso_dashboard_mcp_read';
+	const tracksEvents = TRACKS_EVENTS[ toolCategory ];
 
 	const toggleGroupOpen = ( groupKey, groupName ) => {
 		const willBeOpen = ! openGroupsRef.current.has( groupKey );
@@ -72,7 +86,8 @@ export default function McpToolsSubpage( {
 			openGroupsRef.current.delete( groupKey );
 		}
 		setOpenGroups( new Set( openGroupsRef.current ) );
-		recordTracksEvent( `${ eventPrefix }_group_toggled`, {
+		recordTracksEvent( tracksEvents.groupToggled, {
+			path,
 			group: groupName ?? 'other',
 			is_open: willBeOpen,
 		} );
@@ -116,7 +131,8 @@ export default function McpToolsSubpage( {
 			},
 			{
 				onSuccess: () => {
-					recordTracksEvent( `${ eventPrefix }_tool_toggled`, {
+					recordTracksEvent( tracksEvents.toolToggled, {
+						path,
 						tool_id: toolId,
 						enabled,
 						group: groupName ?? 'other',
@@ -147,7 +163,7 @@ export default function McpToolsSubpage( {
 			},
 			{
 				onSuccess: () => {
-					recordTracksEvent( `${ eventPrefix }_enable_all_toggled`, { enabled, scope: 'page' } );
+					recordTracksEvent( tracksEvents.enableAllToggled, { path, enabled, scope: 'page' } );
 				},
 			}
 		);
@@ -179,7 +195,8 @@ export default function McpToolsSubpage( {
 			},
 			{
 				onSuccess: () => {
-					recordTracksEvent( `${ eventPrefix }_enable_all_toggled`, {
+					recordTracksEvent( tracksEvents.enableAllToggled, {
+						path,
 						enabled,
 						scope: 'group',
 						group: groupName ?? 'other',


### PR DESCRIPTION
Fixes [AIINT-578](https://linear.app/a8c/issue/AIINT-578/mcp-settings-toggle-events-from-memcp-carry-no-path-and-six-of-their).

## Proposed Changes

* Add the `path` property to all seven `calypso_dashboard_mcp_*_toggled` events fired from the classic `/me/mcp` pages, using the same value the co-located `PageViewTracker` already receives (`/me/mcp`, `/me/mcp/read`, `/me/mcp/write`). The MSD equivalent (`/me/preferences/mcp`) injects `path` via its analytics client; the classic pages call `recordTracksEvent` directly, so it is passed explicitly at each call site.
* Replace the runtime-assembled event names in `client/me/mcp/tools-subpage.jsx` (``${eventPrefix}_group_toggled` etc.) with a `TRACKS_EVENTS` lookup keyed on `toolCategory` that holds all six full event names as hardcoded, greppable literals, per the Tracks naming conventions.

## Why are these changes being made?

* `/me/mcp` and `/me/preferences/mcp` fire the same seven toggle event names, but only the MSD page attaches `path`, so fires from the two surfaces are indistinguishable in Tracks (~27% of toggle fires carry no `path` as of 2026-08-03).
* Six of the event names were built from template literals at runtime, so they cannot be found by searching the codebase for the event name.

## Testing Instructions

* Check out this branch and run `yarn start`.
* Open `/me/mcp/read` with the Tracks Vigilante extension or Event Monitor running (or `localStorage.setItem('debug', 'calypso:analytics*')` and watch the console).
* Toggle a single ability, a group enable-all, the page-level enable-all, and expand/collapse a group. Verify `calypso_dashboard_mcp_read_tool_toggled`, `calypso_dashboard_mcp_read_enable_all_toggled`, and `calypso_dashboard_mcp_read_group_toggled` each fire with `path: /me/mcp/read` alongside the existing `tool_id`/`enabled`/`group`/`scope`/`is_open` properties.
* Repeat on `/me/mcp/write` and verify the `calypso_dashboard_mcp_write_*` equivalents carry `path: /me/mcp/write`.
* On `/me/mcp`, toggle "Enable MCP access" and verify `calypso_dashboard_mcp_account_toggled` fires with `path: /me/mcp`.
* Verify the six event names now appear as string literals in `client/me/mcp/tools-subpage.jsx`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?