### PR TITLE
feat: add write-new-site flow (create a new site from write-editor)

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/write-new-site/README.md
+++ b/client/landing/stepper/declarative-flow/flows/write-new-site/README.md
@@ -21,7 +21,7 @@ built for the already-logged-in case.
 
 ## Source param
 
-The picker links here with a `source` token (e.g. `/setup/write-new-site?source=write-editor`).
+The picker links here with a `source` token (e.g. `/setup/write-new-site?source=write_editor`).
 Stepper preserves the query string across steps, so the flow forwards `source`
 into the final editor redirect (`…admin.php?page=write&source={source}`). The
 Write editor (`jetpack-mu-wpcom` `write.php`) reads `source` for its back-button

--- a/client/landing/stepper/declarative-flow/flows/write-new-site/README.md
+++ b/client/landing/stepper/declarative-flow/flows/write-new-site/README.md
@@ -1,0 +1,35 @@
+# write-new-site flow
+
+Lets a logged-in user create a brand-new WordPress.com site and land straight in
+the Write editor. Linked from the "Start a new site" path on the write-editor
+site picker (`/write-editor`), which is reachable only by authenticated users.
+
+This is the logged-in counterpart to the [`write-on`](../write-on/README.md)
+flow. `write-on` is a logged-out fake door tied to an anonymous draft and
+rejects authenticated users; `write-new-site` has no draft hand-off and is
+built for the already-logged-in case.
+
+## Flow
+
+1. Run the built-in signup step (auto-injected by `__experimentalUseBuiltinAuth`
+   together with `stepsWithRequiredLogin`). Write-editor visitors are already
+   authenticated, so this is a no-op for them.
+2. Create the new site (`STEPS.SITE_CREATION_STEP` + `STEPS.PROCESSING`). No
+   plan or domain step — a free site is created.
+3. Redirect the user to the Write editor of the new site:
+   `https://{newSlug}/wp-admin/admin.php?page=write`.
+
+## Testing instructions
+
+1. While logged in, visit `/setup/write-new-site`.
+2. Verify a new free site is created and you land at
+   `https://{newSlug}.wordpress.com/wp-admin/admin.php?page=write` with the
+   Write editor open on a fresh post.
+
+## Owned by
+
+@allilevine
+
+## Context
+
+- Linear: CM-859

--- a/client/landing/stepper/declarative-flow/flows/write-new-site/README.md
+++ b/client/landing/stepper/declarative-flow/flows/write-new-site/README.md
@@ -19,6 +19,18 @@ built for the already-logged-in case.
 3. Redirect the user to the Write editor of the new site:
    `https://{newSlug}/wp-admin/admin.php?page=write`.
 
+## Source param
+
+The picker links here with a `source` token (e.g. `/setup/write-new-site?source=write-editor`).
+Stepper preserves the query string across steps, so the flow forwards `source`
+into the final editor redirect (`…admin.php?page=write&source={source}`). The
+Write editor (`jetpack-mu-wpcom` `write.php`) reads `source` for its back-button
+destination and `wpcom_write_editor_open` Tracks event. `source` is also added
+to this flow's `calypso_write_new_site_flow_site_created` event.
+
+Signup attribution (`ref`) is captured automatically by Stepper's signup Tracks
+and does not need to be forwarded to the editor.
+
 ## Testing instructions
 
 1. While logged in, visit `/setup/write-new-site`.

--- a/client/landing/stepper/declarative-flow/flows/write-new-site/test/write-new-site.test.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-new-site/test/write-new-site.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment jsdom
+ */
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { ProcessingResult } from '../../../internals/steps-repository/processing-step/constants';
+import writeNewSite from '../write-new-site';
+
+jest.mock( '@automattic/onboarding', () => ( {
+	WRITE_NEW_SITE_FLOW: 'write-new-site',
+} ) );
+
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/landing/stepper/utils/steps-with-required-login', () => ( {
+	stepsWithRequiredLogin: ( steps: unknown ) => steps,
+} ) );
+
+jest.mock( '../../../internals/steps', () => ( {
+	STEPS: {
+		SITE_CREATION_STEP: { slug: 'create-site' },
+		PROCESSING: { slug: 'processing' },
+	},
+} ) );
+
+const submitFor = ( step: 'create-site' | 'processing', providedDependencies: object ) => {
+	const navigate = jest.fn();
+	const navigation = writeNewSite.useStepNavigation( step, navigate );
+	const result = navigation.submit?.( {
+		slug: step,
+		providedDependencies,
+	} as Parameters< NonNullable< typeof navigation.submit > >[ 0 ] );
+	return { navigate, result };
+};
+
+describe( 'write-new-site flow', () => {
+	const originalLocation = window.location;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		Object.defineProperty( window, 'location', {
+			value: { assign: jest.fn(), replace: jest.fn() },
+			writable: true,
+			configurable: true,
+		} );
+	} );
+
+	afterEach( () => {
+		Object.defineProperty( window, 'location', {
+			value: originalLocation,
+			writable: true,
+			configurable: true,
+		} );
+	} );
+
+	it( 'is registered as a signup flow with built-in auth', () => {
+		expect( writeNewSite.name ).toBe( 'write-new-site' );
+		expect( writeNewSite.isSignupFlow ).toBe( true );
+		expect( writeNewSite.__experimentalUseBuiltinAuth ).toBe( true );
+	} );
+
+	it( 'exposes the create-site and processing steps', () => {
+		expect( writeNewSite.initialize() ).toEqual( [
+			{ slug: 'create-site' },
+			{ slug: 'processing' },
+		] );
+	} );
+
+	it( 'navigates from create-site to processing', async () => {
+		const { navigate } = submitFor( 'create-site', {} );
+		expect( navigate ).toHaveBeenCalledWith( 'processing', undefined, true );
+	} );
+
+	it( 'redirects to the Write editor and records a tracks event on success', async () => {
+		const { result } = submitFor( 'processing', {
+			processingResult: ProcessingResult.SUCCESS,
+			siteId: 99,
+			siteSlug: 'example.wordpress.com',
+		} );
+		await result;
+
+		expect( window.location.assign ).toHaveBeenCalledWith(
+			'https://example.wordpress.com/wp-admin/admin.php?page=write'
+		);
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_write_new_site_flow_site_created', {
+			site_id: 99,
+		} );
+	} );
+
+	it( 'does nothing on processing failure', async () => {
+		const { result } = submitFor( 'processing', {
+			processingResult: ProcessingResult.FAILURE,
+		} );
+		await result;
+
+		expect( window.location.assign ).not.toHaveBeenCalled();
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does nothing when processing succeeds without a site slug', async () => {
+		const { result } = submitFor( 'processing', {
+			processingResult: ProcessingResult.SUCCESS,
+			siteId: 99,
+		} );
+		await result;
+
+		expect( window.location.assign ).not.toHaveBeenCalled();
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/flows/write-new-site/test/write-new-site.test.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-new-site/test/write-new-site.test.ts
@@ -97,7 +97,7 @@ describe( 'write-new-site flow', () => {
 	} );
 
 	it( 'forwards the source query param into the Write editor redirect and tracks event', async () => {
-		mockSearch = 'source=write-editor';
+		mockSearch = 'source=write_editor';
 
 		const { result } = submitFor( 'processing', {
 			processingResult: ProcessingResult.SUCCESS,
@@ -107,11 +107,11 @@ describe( 'write-new-site flow', () => {
 		await result;
 
 		expect( window.location.assign ).toHaveBeenCalledWith(
-			'https://example.wordpress.com/wp-admin/admin.php?page=write&source=write-editor'
+			'https://example.wordpress.com/wp-admin/admin.php?page=write&source=write_editor'
 		);
 		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_write_new_site_flow_site_created', {
 			site_id: 99,
-			source: 'write-editor',
+			source: 'write_editor',
 		} );
 	} );
 

--- a/client/landing/stepper/declarative-flow/flows/write-new-site/test/write-new-site.test.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-new-site/test/write-new-site.test.ts
@@ -5,12 +5,18 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ProcessingResult } from '../../../internals/steps-repository/processing-step/constants';
 import writeNewSite from '../write-new-site';
 
+let mockSearch = '';
+
 jest.mock( '@automattic/onboarding', () => ( {
 	WRITE_NEW_SITE_FLOW: 'write-new-site',
 } ) );
 
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {
 	recordTracksEvent: jest.fn(),
+} ) );
+
+jest.mock( '../../../../hooks/use-query', () => ( {
+	useQuery: () => new URLSearchParams( mockSearch ),
 } ) );
 
 jest.mock( 'calypso/landing/stepper/utils/steps-with-required-login', () => ( {
@@ -39,6 +45,7 @@ describe( 'write-new-site flow', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockSearch = '';
 		Object.defineProperty( window, 'location', {
 			value: { assign: jest.fn(), replace: jest.fn() },
 			writable: true,
@@ -85,6 +92,26 @@ describe( 'write-new-site flow', () => {
 		);
 		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_write_new_site_flow_site_created', {
 			site_id: 99,
+			source: null,
+		} );
+	} );
+
+	it( 'forwards the source query param into the Write editor redirect and tracks event', async () => {
+		mockSearch = 'source=write-editor';
+
+		const { result } = submitFor( 'processing', {
+			processingResult: ProcessingResult.SUCCESS,
+			siteId: 99,
+			siteSlug: 'example.wordpress.com',
+		} );
+		await result;
+
+		expect( window.location.assign ).toHaveBeenCalledWith(
+			'https://example.wordpress.com/wp-admin/admin.php?page=write&source=write-editor'
+		);
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_write_new_site_flow_site_created', {
+			site_id: 99,
+			source: 'write-editor',
 		} );
 	} );
 

--- a/client/landing/stepper/declarative-flow/flows/write-new-site/write-new-site.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-new-site/write-new-site.ts
@@ -1,5 +1,6 @@
 import { WRITE_NEW_SITE_FLOW } from '@automattic/onboarding';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useQuery } from '../../../hooks/use-query';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import { STEPS } from '../../internals/steps';
 import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
@@ -15,6 +16,11 @@ const writeNewSite: FlowV2< typeof initialize > = {
 	__experimentalUseBuiltinAuth: true,
 	initialize,
 	useStepNavigation( _currentStepSlug, navigate ) {
+		// The picker links here with a `source` (e.g. `?source=write-editor`). Stepper
+		// preserves the query string across steps, so it is still present here. Forward
+		// it into the Write editor, which reads `source` for its back button and Tracks.
+		const source = useQuery().get( 'source' );
+
 		const submit: SubmitHandler< typeof initialize > = async ( submittedStep ) => {
 			const { slug, providedDependencies } = submittedStep;
 			switch ( slug ) {
@@ -35,9 +41,16 @@ const writeNewSite: FlowV2< typeof initialize > = {
 
 					recordTracksEvent( 'calypso_write_new_site_flow_site_created', {
 						site_id: siteId,
+						source,
 					} );
 
-					window.location.assign( `https://${ siteSlug }/wp-admin/admin.php?page=write` );
+					const params = new URLSearchParams( { page: 'write' } );
+					if ( source ) {
+						params.set( 'source', source );
+					}
+					window.location.assign(
+						`https://${ siteSlug }/wp-admin/admin.php?${ params.toString() }`
+					);
 					return;
 				}
 

--- a/client/landing/stepper/declarative-flow/flows/write-new-site/write-new-site.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-new-site/write-new-site.ts
@@ -16,7 +16,7 @@ const writeNewSite: FlowV2< typeof initialize > = {
 	__experimentalUseBuiltinAuth: true,
 	initialize,
 	useStepNavigation( _currentStepSlug, navigate ) {
-		// The picker links here with a `source` (e.g. `?source=write-editor`). Stepper
+		// The picker links here with a `source` (e.g. `?source=write_editor`). Stepper
 		// preserves the query string across steps, so it is still present here. Forward
 		// it into the Write editor, which reads `source` for its back button and Tracks.
 		const source = useQuery().get( 'source' );

--- a/client/landing/stepper/declarative-flow/flows/write-new-site/write-new-site.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-new-site/write-new-site.ts
@@ -1,0 +1,53 @@
+import { WRITE_NEW_SITE_FLOW } from '@automattic/onboarding';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
+import { STEPS } from '../../internals/steps';
+import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
+import { type FlowV2, type SubmitHandler } from '../../internals/types';
+
+function initialize() {
+	return stepsWithRequiredLogin( [ STEPS.SITE_CREATION_STEP, STEPS.PROCESSING ] );
+}
+
+const writeNewSite: FlowV2< typeof initialize > = {
+	name: WRITE_NEW_SITE_FLOW,
+	isSignupFlow: true,
+	__experimentalUseBuiltinAuth: true,
+	initialize,
+	useStepNavigation( _currentStepSlug, navigate ) {
+		const submit: SubmitHandler< typeof initialize > = async ( submittedStep ) => {
+			const { slug, providedDependencies } = submittedStep;
+			switch ( slug ) {
+				case 'create-site':
+					return navigate( 'processing', undefined, true );
+
+				case 'processing': {
+					if ( providedDependencies.processingResult !== ProcessingResult.SUCCESS ) {
+						// Site creation failed. Stay on the flow so the processing
+						// step's error UI surfaces; nothing further we can do here.
+						return;
+					}
+
+					const { siteId, siteSlug } = providedDependencies;
+					if ( ! siteSlug ) {
+						return;
+					}
+
+					recordTracksEvent( 'calypso_write_new_site_flow_site_created', {
+						site_id: siteId,
+					} );
+
+					window.location.assign( `https://${ siteSlug }/wp-admin/admin.php?page=write` );
+					return;
+				}
+
+				default:
+					return;
+			}
+		};
+
+		return { submit };
+	},
+};
+
+export default writeNewSite;

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -23,6 +23,7 @@ import {
 	ART_PROMO_FLOW,
 	DIRECT_TO_CART_FLOW,
 	WRITE_ON_FLOW,
+	WRITE_NEW_SITE_FLOW,
 	EDUCATION_FLOW,
 } from '@automattic/onboarding';
 import type { Flow, FlowV2 } from '../declarative-flow/internals/types';
@@ -78,6 +79,9 @@ const availableFlows: Record< string, () => Promise< { default: FlowV2< any > } 
 
 	[ WRITE_ON_FLOW ]: () =>
 		import( /* webpackChunkName: "write-on-flow" */ './flows/write-on/write-on' ),
+
+	[ WRITE_NEW_SITE_FLOW ]: () =>
+		import( /* webpackChunkName: "write-new-site-flow" */ './flows/write-new-site/write-new-site' ),
 };
 
 /**

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -14,6 +14,7 @@ export const COPY_SITE_FLOW = 'copy-site';
 export const BUILD_FLOW = 'build';
 export const WRITE_FLOW = 'write';
 export const WRITE_ON_FLOW = 'write-on';
+export const WRITE_NEW_SITE_FLOW = 'write-new-site';
 export const START_WRITING_FLOW = 'start-writing';
 export const SITE_SETUP_FLOW = 'site-setup';
 export const WITH_THEME_FLOW = 'with-theme';


### PR DESCRIPTION
Part of CM-859

## Proposed Changes

* Add a new stepper flow `write-new-site` (`/setup/write-new-site`) that lets a **logged-in** user create a new WordPress.com site and land directly in the Write editor of that site.
* The flow reuses the existing `SITE_CREATION_STEP` + `PROCESSING` steps (a free site — no plan or domain step) and, on success, redirects to `https://{newSlug}/wp-admin/admin.php?page=write`.
* Forward a `source` query param through the flow into the editor redirect (`…admin.php?page=write&source={source}`). The Write editor (`jetpack-mu-wpcom` `write.php`) reads `source` for its back button and the `wpcom_write_editor_open` Tracks event, matching the existing Reader → write-editor convention.
* Register the flow and add its constant to `@automattic/onboarding`.

This is the wp-calypso half of CM-859. The "Start a new site" button on the write-editor site picker (served outside this repo) points at `/setup/write-new-site?source=write_editor`.

## Why are these changes being made?

CM-859 asks for a path to start a new site from the write-editor site picker, which currently only lets a user pick an existing site. The picker is reachable only by logged-in users, so it needs a logged-in-friendly destination.

The existing `write-on` flow already performs the "create a site → land in the Write editor" hand-off, but it is a deliberately logged-out fake door tied to an anonymous draft: on mount it redirects any authenticated user to `/setup/onboarding`, so it can't be reused here. `/start` and `/setup/onboarding` end at Launchpad rather than the editor, and reworking that shared, high-traffic flow for this narrow case is undesirable. A small dedicated flow keeps `write-on`'s anonymous acquisition funnel clean and keeps this behavior in experiment-owned code.

## Testing Instructions

1. While logged in, visit `/setup/write-new-site?source=write_editor`.
2. Verify a new free site is created and you land at `https://{newSlug}.wordpress.com/wp-admin/admin.php?page=write&source=write_editor` with the Write editor open on a fresh post.

Unit tests cover flow metadata, `create-site → processing` navigation, the success redirect, the `source` carry-through, the Tracks event, and the no-op cases (processing failure, missing site slug):

```
yarn test-client client/landing/stepper/declarative-flow/flows/write-new-site
```

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?

🤖 Generated with [Claude Code](https://claude.com/claude-code)