### PR TITLE
A4A: Send WordPress.com purchases to the Needs setup page after BD checkout

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
@@ -20,6 +20,7 @@ import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import CartMessageCleanup from './cart-message-cleanup';
 import ClientCheckoutError from './checkout-error';
 import ClientCheckoutPlaceholder from './checkout-placeholder';
+import getPurchasedWPCOMPlanSlug from './lib/get-purchased-wpcom-plan-slug';
 import getSuccessRedirectUrl from './lib/get-success-redirect-url';
 import type { ShoppingCartItem } from '../types';
 
@@ -254,7 +255,8 @@ function BillingDragonCheckoutContent( {
 				sitelessCheckoutType="a4a"
 				redirectTo={ getSuccessRedirectUrl(
 					window.location.origin,
-					shouldClearCartOnSuccess && ! isPlanCheckout
+					shouldClearCartOnSuccess && ! isPlanCheckout,
+					isPlanCheckout ? null : getPurchasedWPCOMPlanSlug( cartItems )
 				) }
 				customizedPreviousPath="/marketplace"
 				siteSlug={ siteSlug ?? '' }

--- a/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/lib/get-purchased-wpcom-plan-slug.ts
+++ b/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/lib/get-purchased-wpcom-plan-slug.ts
@@ -1,0 +1,11 @@
+import { isWPCOMHostingProduct } from '../../lib/hosting';
+import type { ShoppingCartItem } from '../../types';
+
+/**
+ * A cart holding a WordPress.com plan lands on the "Needs setup" page rather
+ * than the licenses list, so the agency can provision the site right away. The
+ * returned slug is what that page's confirmation banner reports to Tracks.
+ */
+export default function getPurchasedWPCOMPlanSlug( cartItems: ShoppingCartItem[] ): string | null {
+	return cartItems.find( ( { slug } ) => isWPCOMHostingProduct( slug ) )?.slug ?? null;
+}

--- a/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/lib/get-success-redirect-url.ts
+++ b/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/lib/get-success-redirect-url.ts
@@ -1,16 +1,31 @@
+import {
+	A4A_LICENSES_LINK,
+	A4A_SITES_LINK_NEEDS_SETUP,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+
 /**
  * The checkout pending page replaces `:receiptId` with the real receipt ID, but
  * only when the transaction succeeds — failed or cancelled payments are sent
- * back to checkout instead. This makes `receipt_id` on the licenses page a
+ * back to checkout instead. This makes `receipt_id` on the landing page a
  * reliable "successful purchase" signal used to clear the persisted mini-cart.
  */
 export const RECEIPT_ID_PLACEHOLDER = ':receiptId';
 
 export default function getSuccessRedirectUrl(
 	origin: string,
-	shouldClearCartOnSuccess: boolean
+	shouldClearCartOnSuccess: boolean,
+	wpcomPlanSlug?: string | null
 ): string {
-	const url = `${ origin }/purchases/licenses`;
+	const url = `${ origin }${ wpcomPlanSlug ? A4A_SITES_LINK_NEEDS_SETUP : A4A_LICENSES_LINK }`;
 
-	return shouldClearCartOnSuccess ? `${ url }?receipt_id=${ RECEIPT_ID_PLACEHOLDER }` : url;
+	const queryArgs = [
+		...( wpcomPlanSlug
+			? [ `wpcom_creator_purchased=${ encodeURIComponent( wpcomPlanSlug ) }` ]
+			: [] ),
+		// Built by hand rather than with `addQueryArgs`, which would percent-encode
+		// the colon the pending page looks for when interpolating the receipt ID.
+		...( shouldClearCartOnSuccess ? [ `receipt_id=${ RECEIPT_ID_PLACEHOLDER }` ] : [] ),
+	];
+
+	return queryArgs.length ? `${ url }?${ queryArgs.join( '&' ) }` : url;
 }

--- a/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/lib/test/get-purchased-wpcom-plan-slug.test.ts
+++ b/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/lib/test/get-purchased-wpcom-plan-slug.test.ts
@@ -1,0 +1,31 @@
+import getPurchasedWPCOMPlanSlug from '../get-purchased-wpcom-plan-slug';
+import type { ShoppingCartItem } from '../../../types';
+
+const cartItem = ( slug: string ) => ( { slug } ) as ShoppingCartItem;
+
+describe( 'getPurchasedWPCOMPlanSlug', () => {
+	it( 'returns the slug of the purchased WordPress.com plan', () => {
+		expect( getPurchasedWPCOMPlanSlug( [ cartItem( 'wpcom-hosting-business' ) ] ) ).toBe(
+			'wpcom-hosting-business'
+		);
+	} );
+
+	it( 'matches a WordPress.com plan alongside other products, as the legacy flow did', () => {
+		expect(
+			getPurchasedWPCOMPlanSlug( [
+				cartItem( 'jetpack-backup' ),
+				cartItem( 'wpcom-hosting-business' ),
+			] )
+		).toBe( 'wpcom-hosting-business' );
+	} );
+
+	it( 'returns null when no WordPress.com plan is in the cart', () => {
+		expect(
+			getPurchasedWPCOMPlanSlug( [ cartItem( 'jetpack-backup' ), cartItem( 'pressable-build' ) ] )
+		).toBeNull();
+	} );
+
+	it( 'returns null for an empty cart', () => {
+		expect( getPurchasedWPCOMPlanSlug( [] ) ).toBeNull();
+	} );
+} );

--- a/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/lib/test/get-success-redirect-url.test.ts
+++ b/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/lib/test/get-success-redirect-url.test.ts
@@ -20,4 +20,26 @@ describe( 'getSuccessRedirectUrl', () => {
 			`receipt_id=${ RECEIPT_ID_PLACEHOLDER }`
 		);
 	} );
+
+	it( 'sends WordPress.com purchases to the needs setup page with the purchased plan', () => {
+		expect(
+			getSuccessRedirectUrl( 'https://agencies.automattic.com', false, 'wpcom-hosting-business' )
+		).toBe(
+			'https://agencies.automattic.com/sites/need-setup?wpcom_creator_purchased=wpcom-hosting-business'
+		);
+	} );
+
+	it( 'keeps the receipt ID placeholder alongside the purchased plan', () => {
+		expect(
+			getSuccessRedirectUrl( 'https://agencies.automattic.com', true, 'wpcom-hosting-business' )
+		).toBe(
+			'https://agencies.automattic.com/sites/need-setup?wpcom_creator_purchased=wpcom-hosting-business&receipt_id=:receiptId'
+		);
+	} );
+
+	it( 'falls back to the licenses URL when no WordPress.com plan was purchased', () => {
+		expect( getSuccessRedirectUrl( 'https://agencies.automattic.com', false, null ) ).toBe(
+			'https://agencies.automattic.com/purchases/licenses'
+		);
+	} );
 } );

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -13,6 +13,7 @@ import useCreateWPCOMSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
 import useSiteCreatedCallback from 'calypso/a8c-for-agencies/hooks/use-site-created-callback';
 import useTrackProvisioningSites from 'calypso/a8c-for-agencies/hooks/use-track-provisioning-sites';
+import useClearCartOnCheckoutSuccess from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-clear-cart-on-checkout-success';
 import LayoutColumn from 'calypso/layout/hosting-dashboard/column';
 import LayoutHeader, {
 	LayoutHeaderTitle as Title,
@@ -46,6 +47,8 @@ export default function NeedSetup( { licenseKey }: Props ) {
 	const [ currentSiteConfigurationId, setCurrentSiteConfigurationId ] = useState< number | null >(
 		null
 	);
+
+	useClearCartOnCheckoutSuccess();
 
 	const closeModal = () => setCurrentSiteConfigurationId( null );
 


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/A4A-3165/a4a-wpcom-flow-efficiency-improvements

## Proposed Changes

* Bring the Billing Dragon checkout to parity with the legacy purchase flow for WordPress.com purchases.
* After buying a WordPress.com plan, agencies now land on the “Needs setup” page with the purchase confirmation banner, instead of the licenses list.
* The mini-cart now clears on the “Needs setup” page too, so it still empties after a successful purchase.

## Why are these changes being made?

* The legacy flow already sent WordPress.com purchases straight to “Needs setup,” where agencies get a confirmation that the purchase went through and can immediately create their site. That behaviour was never carried over when checkout moved to Billing Dragon.
* As a result, agencies buying a WordPress.com plan today are dropped on the licenses list with no confirmation and no obvious next step — they have to work out on their own that the site still needs to be created.
* This restores the original, more guided experience rather than introducing anything new.

## Testing Instructions

* Add a WordPress.com plan to the cart in the marketplace and complete checkout.
* Confirm you land on the “Needs setup” page and see the purchase confirmation banner.

<img width="2554" height="721" alt="Screenshot 2026-08-07 at 12 07 41 AM 2" src="https://github.com/user-attachments/assets/b2c68880-0e43-40eb-bfb5-11d22c123632" />

* Confirm the mini-cart is empty afterwards.
* Repeat with a cart containing only non-WordPress.com products (e.g. a Jetpack license) and confirm you still land on the licenses list as before.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
