### PR TITLE
Domain & plan flow: confirm the selected domain in the plans header

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -188,7 +188,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 
 	const getHeaderText = () => {
 		if ( isDomainAndPlanFlow( flowName ) ) {
-			return __( 'Choose the perfect plan' );
+			return __( 'Your domain name is ready' );
 		}
 
 		if ( isNewsletterFlow( flowName ) ) {
@@ -212,27 +212,16 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		}
 
 		if ( isDomainAndPlanFlow( flowName ) && domainCartItem?.meta ) {
-			return (
-				<>
-					<p>
-						{ translate(
-							'With your annual plan, you’ll get %(domainName)s {{strong}}free for the first year{{/strong}}.',
-							{
-								args: {
-									domainName: domainCartItem.meta,
-								},
-								components: {
-									strong: <strong />,
-								},
-							}
-						) }
-					</p>
-					<p>
-						{ translate(
-							'You’ll also unlock advanced features that make it easy to build and grow your site.'
-						) }
-					</p>
-				</>
+			return translate(
+				'Get {{strong}}%(domainName)s{{/strong}} free for the first year with any annual plan.',
+				{
+					args: {
+						domainName: domainCartItem.meta,
+					},
+					components: {
+						strong: <strong />,
+					},
+				}
 			);
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -187,8 +187,12 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	};
 
 	const getHeaderText = () => {
-		if ( isDomainAndPlanFlow( flowName ) ) {
+		if ( isDomainAndPlanFlow( flowName ) && domainCartItem?.meta ) {
 			return __( 'Your domain name is ready' );
+		}
+
+		if ( isDomainAndPlanFlow( flowName ) ) {
+			return __( 'Choose the perfect plan' );
 		}
 
 		if ( isNewsletterFlow( flowName ) ) {


### PR DESCRIPTION
Part of DOMENG-357

## Proposed Changes

* On the plans page of the **domain-and-plan** flow (reached via the "Get this domain" domain-upsell on a free site), rework the header copy so the selected domain reads as a clear confirmation:
  * Header: `Choose the perfect plan` → **`Your domain name is ready`**
  * Sub-header: now **`Get <domain> free for the first year with any annual plan.`** with the domain emphasized (bold), replacing the previous two-paragraph sub-header.

<img width="1640" height="1014" alt="Screenshot 2026-08-07 at 12 09 09" src="https://github.com/user-attachments/assets/57032cff-fc35-4760-a85e-769f1f90d069" />
<img width="1639" height="1013" alt="Screenshot 2026-08-07 at 12 09 57" src="https://github.com/user-attachments/assets/038b3563-8e84-402c-9c75-4adab158ce64" />


## Why are these changes being made?

* Per DOMENG-357, users adding a domain to a free site land on the plans page but easily overlook that a domain was selected — the domain was buried in the old sub-header text. This makes the chosen domain prominent and reads as a confirmation.
* The domain is deliberately kept out of the page title (domains can be very long and would overflow/clip the title), and instead emphasized inline in the sub-header — matching the design agreed in the ticket thread.

## Testing Instructions

* Go to the site overview page of a WordPress.com site that has no custom domain.
* Click "Get this domain" on the recommended domain (launches the `domain-and-plan` flow).
* On the plans page, verify the header reads "Your domain name is ready" and the sub-header reads "Get **<your-domain>** free for the first year with any annual plan." with the domain in bold.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)