### PR TITLE
A4A: Create a site from the licenses page without leaving it

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/create-site-button/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/create-site-button/index.tsx
@@ -1,0 +1,46 @@
+import { Button } from '@automattic/components';
+import { Spinner } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+
+import './style.scss';
+
+type Props = {
+	isProvisioning: boolean;
+	isLoading: boolean;
+	onCreateSite: () => void;
+	className?: string;
+	primary?: boolean;
+	borderless?: boolean;
+};
+
+export default function CreateSiteButton( {
+	isProvisioning,
+	isLoading,
+	onCreateSite,
+	className,
+	primary,
+	borderless,
+}: Props ) {
+	const translate = useTranslate();
+
+	return (
+		<Button
+			className={ className }
+			compact
+			primary={ primary }
+			borderless={ borderless }
+			busy={ isLoading }
+			disabled={ isLoading || isProvisioning }
+			onClick={ onCreateSite }
+		>
+			{ isProvisioning ? (
+				<span className="licenses-create-site-button-provisioning">
+					<Spinner />
+					{ translate( 'Creating site…' ) }
+				</span>
+			) : (
+				translate( 'Create site' )
+			) }
+		</Button>
+	);
+}

--- a/client/a8c-for-agencies/sections/purchases/licenses/create-site-button/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/create-site-button/style.scss
@@ -1,0 +1,9 @@
+.licenses-create-site-button-provisioning {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+
+	.components-spinner {
+		margin: 0;
+	}
+}

--- a/client/a8c-for-agencies/sections/purchases/licenses/hooks/use-create-site-from-license.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/hooks/use-create-site-from-license.tsx
@@ -30,6 +30,11 @@ export default function useCreateSiteFromLicense( licenseKey: string ): CreateSi
 
 	const onCreateSite = useCallback( () => {
 		if ( ! pendingSiteId ) {
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_licenses_create_site_redirect_needs_setup', {
+					license_key: licenseKey,
+				} )
+			);
 			page( A4A_SITES_LINK_NEEDS_SETUP );
 			return;
 		}

--- a/client/a8c-for-agencies/sections/purchases/licenses/hooks/use-create-site-from-license.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/hooks/use-create-site-from-license.tsx
@@ -1,11 +1,15 @@
 import page from '@automattic/calypso-router';
 import { useCallback, useState } from 'react';
-import { A4A_SITES_LINK_NEEDS_SETUP } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_LICENSES_LINK,
+	A4A_SITES_LINK_NEEDS_SETUP,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { findPendingSiteIdByLicenseKey, hasProvisioningSite } from '../lib/pending-sites';
 import LicenseSiteConfigurationsModal from '../license-site-configurations-modal';
+import usePaymentMethodGate from './use-payment-method-gate';
 
 type CreateSiteFromLicense = {
 	onCreateSite: () => void;
@@ -18,17 +22,25 @@ type CreateSiteFromLicense = {
  * Lets an unassigned WordPress.com license be turned into a site without
  * leaving the licenses page, using the same configuration modal the Needs
  * setup page opens. Falls back to that page when the license has no pending
- * site to configure — the modal creates a development site when given no ID.
+ * site to configure.
  */
-export default function useCreateSiteFromLicense( licenseKey: string ): CreateSiteFromLicense {
+export default function useCreateSiteFromLicense(
+	licenseKey: string,
+	isClientLicense?: boolean
+): CreateSiteFromLicense {
 	const dispatch = useDispatch();
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
 	const { data: pendingSites, isLoading } = useFetchPendingSites();
+	const isBlockedByMissingPaymentMethod = usePaymentMethodGate( isClientLicense );
 
 	const pendingSiteId = findPendingSiteIdByLicenseKey( pendingSites, licenseKey );
 
 	const onCreateSite = useCallback( () => {
+		if ( isBlockedByMissingPaymentMethod( A4A_LICENSES_LINK ) ) {
+			return;
+		}
+
 		if ( ! pendingSiteId ) {
 			dispatch(
 				recordTracksEvent( 'calypso_a4a_licenses_create_site_redirect_needs_setup', {
@@ -45,7 +57,7 @@ export default function useCreateSiteFromLicense( licenseKey: string ): CreateSi
 			} )
 		);
 		setIsModalOpen( true );
-	}, [ dispatch, licenseKey, pendingSiteId ] );
+	}, [ dispatch, isBlockedByMissingPaymentMethod, licenseKey, pendingSiteId ] );
 
 	return {
 		onCreateSite,

--- a/client/a8c-for-agencies/sections/purchases/licenses/hooks/use-create-site-from-license.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/hooks/use-create-site-from-license.tsx
@@ -1,0 +1,57 @@
+import page from '@automattic/calypso-router';
+import { useCallback, useState } from 'react';
+import { A4A_SITES_LINK_NEEDS_SETUP } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { findPendingSiteIdByLicenseKey, hasProvisioningSite } from '../lib/pending-sites';
+import LicenseSiteConfigurationsModal from '../license-site-configurations-modal';
+
+type CreateSiteFromLicense = {
+	onCreateSite: () => void;
+	isProvisioning: boolean;
+	isLoading: boolean;
+	modal: JSX.Element | null;
+};
+
+/**
+ * Lets an unassigned WordPress.com license be turned into a site without
+ * leaving the licenses page, using the same configuration modal the Needs
+ * setup page opens. Falls back to that page when the license has no pending
+ * site to configure — the modal creates a development site when given no ID.
+ */
+export default function useCreateSiteFromLicense( licenseKey: string ): CreateSiteFromLicense {
+	const dispatch = useDispatch();
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+
+	const { data: pendingSites, isLoading } = useFetchPendingSites();
+
+	const pendingSiteId = findPendingSiteIdByLicenseKey( pendingSites, licenseKey );
+
+	const onCreateSite = useCallback( () => {
+		if ( ! pendingSiteId ) {
+			page( A4A_SITES_LINK_NEEDS_SETUP );
+			return;
+		}
+
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_licenses_create_site_modal_open', {
+				license_key: licenseKey,
+			} )
+		);
+		setIsModalOpen( true );
+	}, [ dispatch, licenseKey, pendingSiteId ] );
+
+	return {
+		onCreateSite,
+		isProvisioning: hasProvisioningSite( pendingSites ),
+		isLoading,
+		modal:
+			isModalOpen && pendingSiteId ? (
+				<LicenseSiteConfigurationsModal
+					siteId={ pendingSiteId }
+					closeModal={ () => setIsModalOpen( false ) }
+				/>
+			) : null,
+	};
+}

--- a/client/a8c-for-agencies/sections/purchases/licenses/hooks/use-payment-method-gate.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/hooks/use-payment-method-gate.tsx
@@ -1,0 +1,47 @@
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { addQueryArgs } from 'calypso/lib/url';
+import { useDispatch } from 'calypso/state';
+import { errorNotice } from 'calypso/state/notices/actions';
+import usePaymentMethod from '../../payment-methods/hooks/use-payment-method';
+
+/**
+ * Guards license actions that cost money. Returns a predicate that reports
+ * whether the action can't proceed, having told the agency why and where to
+ * come back to. Client licenses are billed to the client, so they skip it.
+ */
+export default function usePaymentMethodGate( isClientLicense?: boolean ) {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	const { paymentMethodRequired } = usePaymentMethod();
+
+	return useCallback(
+		( returnUrl: string ) => {
+			if ( ! paymentMethodRequired || isClientLicense ) {
+				return false;
+			}
+
+			const noticeLinkHref = addQueryArgs(
+				{
+					return: returnUrl,
+				},
+				'/purchases/payment-methods/add'
+			);
+			const errorMessage = translate(
+				'A primary payment method is required.{{br/}} ' +
+					'{{a}}Try adding a new payment method{{/a}} or contact support.',
+				{
+					components: {
+						a: <a href={ noticeLinkHref } />,
+						br: <br />,
+					},
+				}
+			);
+
+			dispatch( errorNotice( errorMessage ) );
+			return true;
+		},
+		[ dispatch, isClientLicense, paymentMethodRequired, translate ]
+	);
+}

--- a/client/a8c-for-agencies/sections/purchases/licenses/lib/pending-sites.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/lib/pending-sites.ts
@@ -1,7 +1,7 @@
 export type PendingSite = {
 	id: number;
-	features: {
-		wpcom_atomic: {
+	features?: {
+		wpcom_atomic?: {
 			license_key: string;
 			state: string;
 		};

--- a/client/a8c-for-agencies/sections/purchases/licenses/lib/pending-sites.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/lib/pending-sites.ts
@@ -1,0 +1,38 @@
+export type PendingSite = {
+	id: number;
+	features: {
+		wpcom_atomic: {
+			license_key: string;
+			state: string;
+		};
+	};
+};
+
+/**
+ * The pending site a license will become once the agency configures it. Only
+ * sites still in the `pending` state can be created; anything further along is
+ * already on its way to the sites dashboard.
+ */
+export function findPendingSiteIdByLicenseKey(
+	pendingSites: PendingSite[] | undefined,
+	licenseKey: string
+): number | null {
+	return (
+		pendingSites?.find(
+			( { features }: PendingSite ) =>
+				features?.wpcom_atomic?.license_key === licenseKey &&
+				features?.wpcom_atomic?.state === 'pending'
+		)?.id ?? null
+	);
+}
+
+/**
+ * Mirrors the Needs setup page: provisioning is treated as an account-wide
+ * state, so no other site can be created while one is being built.
+ */
+export function hasProvisioningSite( pendingSites: PendingSite[] | undefined ): boolean {
+	return !! pendingSites?.some(
+		( { features }: PendingSite ) =>
+			features?.wpcom_atomic?.state === 'provisioning' && !! features?.wpcom_atomic?.license_key
+	);
+}

--- a/client/a8c-for-agencies/sections/purchases/licenses/lib/test/pending-sites.test.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/lib/test/pending-sites.test.ts
@@ -1,0 +1,59 @@
+import { findPendingSiteIdByLicenseKey, hasProvisioningSite } from '../pending-sites';
+import type { PendingSite } from '../pending-sites';
+
+const pendingSite = ( id: number, license_key: string, state: string ): PendingSite => ( {
+	id,
+	features: { wpcom_atomic: { license_key, state } },
+} );
+
+describe( 'findPendingSiteIdByLicenseKey', () => {
+	it( 'returns the id of the pending site behind the license', () => {
+		const sites = [
+			pendingSite( 1, 'wpcom-hosting-business_aaa', 'pending' ),
+			pendingSite( 2, 'wpcom-hosting-business_bbb', 'pending' ),
+		];
+
+		expect( findPendingSiteIdByLicenseKey( sites, 'wpcom-hosting-business_bbb' ) ).toBe( 2 );
+	} );
+
+	it( 'ignores sites that are no longer pending', () => {
+		const sites = [ pendingSite( 1, 'wpcom-hosting-business_aaa', 'provisioning' ) ];
+
+		expect( findPendingSiteIdByLicenseKey( sites, 'wpcom-hosting-business_aaa' ) ).toBeNull();
+	} );
+
+	it( 'returns null when no site matches the license', () => {
+		const sites = [ pendingSite( 1, 'wpcom-hosting-business_aaa', 'pending' ) ];
+
+		expect( findPendingSiteIdByLicenseKey( sites, 'wpcom-hosting-business_zzz' ) ).toBeNull();
+	} );
+
+	it( 'returns null while pending sites are still loading', () => {
+		expect( findPendingSiteIdByLicenseKey( undefined, 'wpcom-hosting-business_aaa' ) ).toBeNull();
+	} );
+} );
+
+describe( 'hasProvisioningSite', () => {
+	it( 'reports provisioning across any site, not just the one being looked at', () => {
+		const sites = [
+			pendingSite( 1, 'wpcom-hosting-business_aaa', 'pending' ),
+			pendingSite( 2, 'wpcom-hosting-business_bbb', 'provisioning' ),
+		];
+
+		expect( hasProvisioningSite( sites ) ).toBe( true );
+	} );
+
+	it( 'is false when every site is still pending', () => {
+		expect(
+			hasProvisioningSite( [ pendingSite( 1, 'wpcom-hosting-business_aaa', 'pending' ) ] )
+		).toBe( false );
+	} );
+
+	it( 'ignores provisioning sites without a license key', () => {
+		expect( hasProvisioningSite( [ pendingSite( 1, '', 'provisioning' ) ] ) ).toBe( false );
+	} );
+
+	it( 'is false while pending sites are still loading', () => {
+		expect( hasProvisioningSite( undefined ) ).toBe( false );
+	} );
+} );

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -79,7 +79,7 @@ export default function LicenseDetailsActions( {
 		isProvisioning,
 		isLoading: isLoadingPendingSites,
 		modal: siteConfigurationsModal,
-	} = useCreateSiteFromLicense( licenseKey );
+	} = useCreateSiteFromLicense( licenseKey, isClientLicense );
 
 	const openRevokeDialog = useCallback( () => {
 		setRevokeDialog( true );

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -7,7 +7,6 @@ import {
 	A4A_MARKETPLACE_ASSIGN_LICENSE_LINK,
 	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
 	A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
-	A4A_SITES_LINK_NEEDS_SETUP,
 	EXTERNAL_PRESSABLE_AUTH_URL,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import {
@@ -23,6 +22,8 @@ import { hasAgencyCapability } from 'calypso/state/a8c-for-agencies/agency/selec
 import { A4AStore } from 'calypso/state/a8c-for-agencies/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
+import CreateSiteButton from '../create-site-button';
+import useCreateSiteFromLicense from '../hooks/use-create-site-from-license';
 import useLicenseDownloadUrlMutation from '../revoke-license-dialog/hooks/use-license-download-url-mutation';
 import type { LicenseSubscription } from 'calypso/state/partner-portal/types';
 
@@ -71,9 +72,14 @@ export default function LicenseDetailsActions( {
 	const debugUrl = siteUrl ? `https://jptools.wordpress.com/debug/?url=${ siteUrl }` : null;
 	const downloadUrl = useLicenseDownloadUrlMutation( licenseKey );
 
-	const redirectUrl = isWPCOMHostingLicense
-		? A4A_SITES_LINK_NEEDS_SETUP
-		: addQueryArgs( { key: licenseKey }, A4A_MARKETPLACE_ASSIGN_LICENSE_LINK );
+	const assignLicenseUrl = addQueryArgs( { key: licenseKey }, A4A_MARKETPLACE_ASSIGN_LICENSE_LINK );
+
+	const {
+		onCreateSite,
+		isProvisioning,
+		isLoading: isLoadingPendingSites,
+		modal: siteConfigurationsModal,
+	} = useCreateSiteFromLicense( licenseKey );
 
 	const openRevokeDialog = useCallback( () => {
 		setRevokeDialog( true );
@@ -182,11 +188,27 @@ export default function LicenseDetailsActions( {
 
 			{ ! isPressableAddonLicense &&
 				licenseState === LicenseState.Detached &&
-				licenseType === LicenseType.Partner && (
-					<Button compact primary className="license-details__assign-button" href={ redirectUrl }>
-						{ isWPCOMHostingLicense ? translate( 'Create site' ) : translate( 'Assign license' ) }
+				licenseType === LicenseType.Partner &&
+				( isWPCOMHostingLicense ? (
+					<CreateSiteButton
+						className="license-details__assign-button"
+						primary
+						isProvisioning={ isProvisioning }
+						isLoading={ isLoadingPendingSites }
+						onCreateSite={ onCreateSite }
+					/>
+				) : (
+					<Button
+						compact
+						primary
+						className="license-details__assign-button"
+						href={ assignLicenseUrl }
+					>
+						{ translate( 'Assign license' ) }
 					</Button>
-				) }
+				) ) }
+
+			{ siteConfigurationsModal }
 
 			{ revokeDialog && (
 				<CancelLicenseFeedbackModal

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -13,7 +13,6 @@ import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
 import A4APopoverTrigger from 'calypso/a8c-for-agencies/components/a4a-popover/trigger';
 import EmptyValueIndicator from 'calypso/a8c-for-agencies/components/empty-value-indicator';
 import {
-	A4A_SITES_LINK_NEEDS_SETUP,
 	A4A_FEEDBACK_LINK,
 	A4A_LICENSES_LINK,
 	EXTERNAL_PRESSABLE_AUTH_URL,
@@ -192,7 +191,7 @@ export default function LicensePreview( {
 	}, [ isBlockedByMissingPaymentMethod, licenseKey ] );
 
 	const createSite = useCallback( () => {
-		if ( isBlockedByMissingPaymentMethod( A4A_SITES_LINK_NEEDS_SETUP ) ) {
+		if ( isBlockedByMissingPaymentMethod( A4A_LICENSES_LINK ) ) {
 			return;
 		}
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -36,11 +36,11 @@ import { addQueryArgs } from 'calypso/lib/url';
 import { useDispatch, useSelector } from 'calypso/state';
 import { isAgencyOwner } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { infoNotice, errorNotice } from 'calypso/state/notices/actions';
+import { infoNotice } from 'calypso/state/notices/actions';
 import { getSite } from 'calypso/state/sites/selectors';
-import usePaymentMethod from '../../payment-methods/hooks/use-payment-method';
 import CreateSiteButton from '../create-site-button';
 import useCreateSiteFromLicense from '../hooks/use-create-site-from-license';
+import usePaymentMethodGate from '../hooks/use-payment-method-gate';
 import LicenseDetails from '../license-details';
 import BundleDetails from '../license-details/bundle-details';
 import LicensesOverviewContext from '../licenses-overview/context';
@@ -140,45 +140,15 @@ export default function LicensePreview( {
 		dispatch( recordTracksEvent( 'calypso_a4a_license_list_copy_license_click' ) );
 	}, [ dispatch, translate ] );
 
-	const { paymentMethodRequired } = usePaymentMethod();
+	const isBlockedByMissingPaymentMethod = usePaymentMethodGate( !! referral );
 	const {
 		onCreateSite,
 		isProvisioning,
 		isLoading: isLoadingPendingSites,
 		modal: siteConfigurationsModal,
-	} = useCreateSiteFromLicense( licenseKey );
+	} = useCreateSiteFromLicense( licenseKey, !! referral );
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const domain = siteUrl && ! isPressableLicense ? getUrlParts( siteUrl ).hostname || siteUrl : '';
-
-	// Returns true when the action can't proceed, having told the agency why.
-	const isBlockedByMissingPaymentMethod = useCallback(
-		( returnUrl: string ) => {
-			if ( ! paymentMethodRequired || referral ) {
-				return false;
-			}
-
-			const noticeLinkHref = addQueryArgs(
-				{
-					return: returnUrl,
-				},
-				'/purchases/payment-methods/add'
-			);
-			const errorMessage = translate(
-				'A primary payment method is required.{{br/}} ' +
-					'{{a}}Try adding a new payment method{{/a}} or contact support.',
-				{
-					components: {
-						a: <a href={ noticeLinkHref } />,
-						br: <br />,
-					},
-				}
-			);
-
-			dispatch( errorNotice( errorMessage ) );
-			return true;
-		},
-		[ dispatch, paymentMethodRequired, referral, translate ]
-	);
 
 	const assign = useCallback( () => {
 		const redirectUrl = addQueryArgs( { key: licenseKey }, '/marketplace/assign-license' );
@@ -189,14 +159,6 @@ export default function LicensePreview( {
 
 		page( redirectUrl );
 	}, [ isBlockedByMissingPaymentMethod, licenseKey ] );
-
-	const createSite = useCallback( () => {
-		if ( isBlockedByMissingPaymentMethod( A4A_LICENSES_LINK ) ) {
-			return;
-		}
-
-		onCreateSite();
-	}, [ isBlockedByMissingPaymentMethod, onCreateSite ] );
 
 	useEffect( () => {
 		if ( isHighlighted ) {
@@ -350,7 +312,7 @@ export default function LicensePreview( {
 												borderless
 												isProvisioning={ isProvisioning }
 												isLoading={ isLoadingPendingSites }
-												onCreateSite={ createSite }
+												onCreateSite={ onCreateSite }
 											/>
 										) : (
 											<Button

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -40,6 +40,8 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { infoNotice, errorNotice } from 'calypso/state/notices/actions';
 import { getSite } from 'calypso/state/sites/selectors';
 import usePaymentMethod from '../../payment-methods/hooks/use-payment-method';
+import CreateSiteButton from '../create-site-button';
+import useCreateSiteFromLicense from '../hooks/use-create-site-from-license';
 import LicenseDetails from '../license-details';
 import BundleDetails from '../license-details/bundle-details';
 import LicensesOverviewContext from '../licenses-overview/context';
@@ -140,17 +142,25 @@ export default function LicensePreview( {
 	}, [ dispatch, translate ] );
 
 	const { paymentMethodRequired } = usePaymentMethod();
+	const {
+		onCreateSite,
+		isProvisioning,
+		isLoading: isLoadingPendingSites,
+		modal: siteConfigurationsModal,
+	} = useCreateSiteFromLicense( licenseKey );
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const domain = siteUrl && ! isPressableLicense ? getUrlParts( siteUrl ).hostname || siteUrl : '';
 
-	const assign = useCallback( () => {
-		const redirectUrl = isWPCOMLicense
-			? A4A_SITES_LINK_NEEDS_SETUP
-			: addQueryArgs( { key: licenseKey }, '/marketplace/assign-license' );
-		if ( paymentMethodRequired && ! referral ) {
+	// Returns true when the action can't proceed, having told the agency why.
+	const isBlockedByMissingPaymentMethod = useCallback(
+		( returnUrl: string ) => {
+			if ( ! paymentMethodRequired || referral ) {
+				return false;
+			}
+
 			const noticeLinkHref = addQueryArgs(
 				{
-					return: redirectUrl,
+					return: returnUrl,
 				},
 				'/purchases/payment-methods/add'
 			);
@@ -166,11 +176,28 @@ export default function LicensePreview( {
 			);
 
 			dispatch( errorNotice( errorMessage ) );
+			return true;
+		},
+		[ dispatch, paymentMethodRequired, referral, translate ]
+	);
+
+	const assign = useCallback( () => {
+		const redirectUrl = addQueryArgs( { key: licenseKey }, '/marketplace/assign-license' );
+
+		if ( isBlockedByMissingPaymentMethod( redirectUrl ) ) {
 			return;
 		}
 
 		page( redirectUrl );
-	}, [ isWPCOMLicense, licenseKey, paymentMethodRequired, referral, translate, dispatch ] );
+	}, [ isBlockedByMissingPaymentMethod, licenseKey ] );
+
+	const createSite = useCallback( () => {
+		if ( isBlockedByMissingPaymentMethod( A4A_SITES_LINK_NEEDS_SETUP ) ) {
+			return;
+		}
+
+		onCreateSite();
+	}, [ isBlockedByMissingPaymentMethod, onCreateSite ] );
 
 	useEffect( () => {
 		if ( isHighlighted ) {
@@ -316,16 +343,26 @@ export default function LicensePreview( {
 							{ ! domain && licenseState === LicenseState.Detached && ! isPressableAddonLicense && (
 								<span className="license-preview__unassigned">
 									<Badge intent="warning">{ translate( 'Unassigned' ) }</Badge>
-									{ licenseType === LicenseType.Partner && ! isPressableAddonLicense && (
-										<Button
-											className="license-preview__assign-button"
-											borderless
-											compact
-											onClick={ assign }
-										>
-											{ isWPCOMLicense ? translate( 'Create site' ) : translate( 'Assign' ) }
-										</Button>
-									) }
+									{ licenseType === LicenseType.Partner &&
+										! isPressableAddonLicense &&
+										( isWPCOMLicense ? (
+											<CreateSiteButton
+												className="license-preview__assign-button"
+												borderless
+												isProvisioning={ isProvisioning }
+												isLoading={ isLoadingPendingSites }
+												onCreateSite={ createSite }
+											/>
+										) : (
+											<Button
+												className="license-preview__assign-button"
+												borderless
+												compact
+												onClick={ assign }
+											>
+												{ translate( 'Assign' ) }
+											</Button>
+										) ) }
 								</span>
 							) }
 							{ revokedAt && (
@@ -433,6 +470,7 @@ export default function LicensePreview( {
 						isDevSite={ isDevelopmentSite }
 					/>
 				) ) }
+			{ siteConfigurationsModal }
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-site-configurations-modal.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-site-configurations-modal.tsx
@@ -1,0 +1,28 @@
+import SiteConfigurationsModal from 'calypso/a8c-for-agencies/components/site-configurations-modal';
+import { useRandomSiteName } from 'calypso/a8c-for-agencies/components/site-configurations-modal/use-random-site-name';
+import useSiteCreatedCallback from 'calypso/a8c-for-agencies/hooks/use-site-created-callback';
+
+type Props = {
+	siteId: number;
+	closeModal: () => void;
+};
+
+/**
+ * Wraps the site configuration modal so `useRandomSiteName` — two uncached
+ * requests on mount — only runs once the modal opens, rather than once per
+ * license row on the licenses page.
+ */
+export default function LicenseSiteConfigurationsModal( { siteId, closeModal }: Props ) {
+	const { randomSiteName, isRandomSiteNameLoading, refetchRandomSiteName } = useRandomSiteName();
+	const onCreateSiteSuccess = useSiteCreatedCallback( refetchRandomSiteName );
+
+	return (
+		<SiteConfigurationsModal
+			closeModal={ closeModal }
+			randomSiteName={ randomSiteName }
+			isRandomSiteNameLoading={ isRandomSiteNameLoading }
+			siteId={ siteId }
+			onCreateSiteSuccess={ onCreateSiteSuccess }
+		/>
+	);
+}


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/A4A-3165/a4a-wpcom-flow-efficiency-improvements

## Proposed Changes

* Clicking **Create site** on an unassigned WordPress.com license now opens the site configuration modal right on the licenses page, instead of sending the agency to the “Needs setup” page.
* Finishing the setup takes them to the sites dashboard, exactly as it does today from “Needs setup.”
* While a site is being provisioned, the button shows a spinner and can’t be clicked, so it’s clear something is already in progress.

## Why are these changes being made?

* Creating a site from a license took an unnecessary detour: the button dropped agencies on another page where they had to find the same license again before they could do anything with it.
* Everything needed to create the site is already known at that point, so the extra hop adds steps without adding clarity.
* The provisioning state was already handled this way on the “Needs setup” page — this brings the licenses page in line with it.

## Testing Instructions

* Go to Purchases → Licenses with at least one unassigned WordPress.com license.
* Click **Create site** on the license row and confirm the site configuration modal opens in place, without navigating away.
<img width="896" height="229" alt="Screenshot 2026-08-07 at 12 52 41 AM" src="https://github.com/user-attachments/assets/815f87db-4861-4b8a-acc2-b074bbe8015d" />
<img width="782" height="647" alt="Screenshot 2026-08-07 at 12 52 45 AM" src="https://github.com/user-attachments/assets/c7822419-ba98-47d3-8136-b2230d2214ca" />

* Complete the modal and confirm you end up on the sites dashboard with the new site provisioning.
* Go back to the licenses page while that site is still provisioning and confirm the **Create site** buttons show “Creating site…” and are disabled.
* Confirm unassigned non-WordPress.com licenses still show **Assign** and behave as before.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
