### PR TITLE
Sites: Normalize pasted domain searches

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -74,7 +74,7 @@ const getFetchPaginatedSitesOptions = (
 		// Exclude staging sites from the standalone dashboard list; the classic
 		// Calypso backport keeps them (the API includes them by default).
 		...( ! isDashboardBackport() && { include_staging: false } ),
-		search: view.search?.replace( /^https?:\/\//i, '' ),
+		search: view.search?.replace( /^https?:\/\//i, '' ).replace( /\/$/, '' ),
 		sort_field: view.sort?.field,
 		sort_direction: view.sort?.direction,
 		page: view.page,

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -74,7 +74,7 @@ const getFetchPaginatedSitesOptions = (
 		// Exclude staging sites from the standalone dashboard list; the classic
 		// Calypso backport keeps them (the API includes them by default).
 		...( ! isDashboardBackport() && { include_staging: false } ),
-		search: view.search,
+		search: view.search?.replace( /^https?:\/\//i, '' ),
 		sort_field: view.sort?.field,
 		sort_direction: view.sort?.direction,
 		page: view.page,

--- a/client/dashboard/sites/test/index.test.tsx
+++ b/client/dashboard/sites/test/index.test.tsx
@@ -4,6 +4,7 @@
 
 import { startSiteCollisionListener } from '@automattic/api-queries';
 import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { render } from '../../test-utils';
 import Sites from '../index';
@@ -39,8 +40,26 @@ function mockSitesEndpoint( sites: Site[] ) {
 		.reply( 200, { sites, total: sites.length } );
 }
 
+function mockSitesSearchEndpoint( sites: Site[] ) {
+	const searches: string[] = [];
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( '/rest/v1.3/me/sites' )
+		.query( ( query ) => {
+			if ( typeof query.search !== 'string' ) {
+				return false;
+			}
+			searches.push( query.search );
+			return true;
+		} )
+		.reply( 200, { sites, total: sites.length } );
+	return searches;
+}
+
 describe( '<Sites>', () => {
 	beforeEach( () => {
+		window.history.replaceState( {}, '', '/' );
+
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.2/read/teams' )
 			.query( true )
@@ -178,5 +197,29 @@ describe( '<Sites>', () => {
 		expect( row2[ 0 ] ).toHaveTextContent( 'my-second-site.wordpress.com' );
 		expect( row2[ 1 ] ).toHaveTextContent( 'Coming soon' );
 		expect( row2[ 2 ] ).toHaveTextContent( 'Free' );
+	} );
+
+	test.each( [
+		'my-first-site.wordpress.com',
+		'https://my-first-site.wordpress.com',
+		'http://my-first-site.wordpress.com',
+	] )( 'normalizes the site search query for %s', async ( search ) => {
+		const user = userEvent.setup();
+		mockSitesEndpoint( mockSites );
+		const searches = mockSitesSearchEndpoint( [ mockSites[ 0 ] ] );
+
+		render( <Sites />, {
+			user: {
+				site_count: 13,
+			} as User,
+		} );
+
+		await screen.findByRole( 'table' );
+		const searchInput = screen.getByRole( 'searchbox' );
+		await user.type( searchInput, search );
+
+		await waitFor( () => expect( searches ).toContain( 'my-first-site.wordpress.com' ) );
+		expect( searchInput ).toHaveValue( search );
+		expect( screen.getByText( 'My First Site' ) ).toBeVisible();
 	} );
 } );

--- a/client/dashboard/sites/test/index.test.tsx
+++ b/client/dashboard/sites/test/index.test.tsx
@@ -201,8 +201,11 @@ describe( '<Sites>', () => {
 
 	test.each( [
 		'my-first-site.wordpress.com',
+		'my-first-site.wordpress.com/',
 		'https://my-first-site.wordpress.com',
+		'https://my-first-site.wordpress.com/',
 		'http://my-first-site.wordpress.com',
+		'http://my-first-site.wordpress.com/',
 	] )( 'normalizes the site search query for %s', async ( search ) => {
 		const user = userEvent.setup();
 		mockSitesEndpoint( mockSites );


### PR DESCRIPTION
Fixes DOTMSD-1363

## Proposed Changes

* Strip an optional `http://` or `https://` prefix and one trailing slash from the site search sent to the API.
* Keep the search value shown in the input unchanged.
* Cover bare, HTTP-prefixed, and HTTPS-prefixed domain searches, with and without a trailing slash, in an integration test.

## Why are these changes being made?

The sites API expects a bare domain. Protocol-prefixed searches can return no results, and URLs copied from a browser address bar normally include a trailing slash that also prevents a match. Normalizing only the outbound API query makes these common pasted forms behave consistently without rewriting what the user typed.

## Testing Instructions

Author verification passed on Calypso Live `build-192092`: all six bare/HTTP/HTTPS forms, with and without a trailing slash, returned the same controlled site while preserving the entered value.

1. Open `/sites` with an account containing a controlled test site.
2. Search for that site using its bare domain, with and without a trailing slash, and confirm it appears.
3. Repeat with `https://` before the domain, with and without a trailing slash, and confirm the same site appears.
4. Repeat with `http://` before the domain, with and without a trailing slash, and confirm the same site appears.
5. Confirm each entered value remains unchanged in the search input.
6. Run `yarn test-client client/dashboard/sites/test/index.test.tsx --runInBand`.
7. Run `yarn test-client --findRelatedTests client/dashboard/sites/index.tsx client/dashboard/sites/test/index.test.tsx --runInBand`.
8. Run `yarn typecheck-client`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?