### PR TITLE
Help Center: show one CSAT prompt per conversation

### DIFF
--- a/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
+++ b/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
@@ -118,8 +118,18 @@ function clusterMessagesBySender( messages: Message[] ) {
 
 	const groups = [ currentGroup ];
 
-	for ( const message of sortMessagesByTimestamp( messages ) ) {
+	const sortedMessages = sortMessagesByTimestamp( messages );
+	const lastCSATMessage = sortedMessages.filter( isCSATMessage ).at( -1 );
+
+	for ( const message of sortedMessages ) {
 		if ( EXCLUDED_MESSAGE_ROLES.includes( getPresentedRole( message ) as any ) ) {
+			continue;
+		}
+
+		// Zendesk can emit more than one CSAT prompt for the same conversation. They are all rendered
+		// with the same copy, so every extra one reads as a duplicate and lets the user submit
+		// conflicting ratings for a single ticket. Only the most recent prompt is kept.
+		if ( isCSATMessage( message ) && message !== lastCSATMessage ) {
 			continue;
 		}
 

--- a/packages/odie-client/src/components/message/test/get-message-unique-identifier.tsx
+++ b/packages/odie-client/src/components/message/test/get-message-unique-identifier.tsx
@@ -39,6 +39,32 @@ describe( 'getMessageUniqueIdentifier', () => {
 		expect( getMessageUniqueIdentifier( message ) ).toBe( 'internal-789' );
 	} );
 
+	it( 'returns message.id for Zendesk messages that carry no other identifier', () => {
+		const message: Message = {
+			content: 'test',
+			role: 'business',
+			type: 'message',
+			id: 'zendesk-message-id',
+			metadata: {},
+		};
+
+		expect( getMessageUniqueIdentifier( message ) ).toBe( 'zendesk-message-id' );
+	} );
+
+	it( 'prefers metadata.temporary_id over message.id so echoed messages match their local copy', () => {
+		const message: Message = {
+			content: 'test',
+			role: 'user',
+			type: 'message',
+			id: 'zendesk-message-id',
+			metadata: {
+				temporary_id: 'temp-123',
+			},
+		};
+
+		expect( getMessageUniqueIdentifier( message ) ).toBe( 'temp-123' );
+	} );
+
 	it( 'returns message.metadata.local_timestamp when no other identifier is present but local_timestamp is', () => {
 		const message: Message = {
 			content: 'test',

--- a/packages/odie-client/src/components/message/test/messages-cluster.tsx
+++ b/packages/odie-client/src/components/message/test/messages-cluster.tsx
@@ -3,7 +3,7 @@ import { MessagesClusterizer } from '../messages-cluster/messages-cluster';
 import type { Message } from '../../../types';
 
 jest.mock( '../../../utils', () => ( {
-	isCSATMessage: () => false,
+	isCSATMessage: ( message: Message ) => message?.metadata?.type === 'csat',
 } ) );
 
 jest.mock( '../../../utils/csat', () => ( {
@@ -46,6 +46,20 @@ const createBusinessMessage = ( {
 	metadata: agentId ? { '__zendesk_msg.agent.id': agentId } : {},
 } );
 
+const createCSATMessage = ( {
+	content,
+	received,
+}: {
+	content: string;
+	received: number;
+} ): Message => ( {
+	content,
+	received,
+	role: 'business',
+	type: 'message',
+	metadata: { type: 'csat' },
+} );
+
 describe( 'MessagesClusterizer', () => {
 	beforeEach( () => {
 		let nextId = 0;
@@ -80,5 +94,37 @@ describe( 'MessagesClusterizer', () => {
 
 		expect( screen.getByText( 'WordPress.com' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Jetpack' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders only the most recent CSAT prompt when Zendesk sends more than one', () => {
+		render(
+			<MessagesClusterizer
+				messages={ [
+					createCSATMessage( { content: 'First CSAT prompt', received: 1 } ),
+					createCSATMessage( { content: 'Second CSAT prompt', received: 2 } ),
+				] }
+			/>
+		);
+
+		expect( screen.queryByText( 'First CSAT prompt' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Second CSAT prompt' ) ).toBeInTheDocument();
+	} );
+
+	it( 'keeps non-CSAT messages sent after a CSAT prompt', () => {
+		render(
+			<MessagesClusterizer
+				messages={ [
+					createCSATMessage( { content: 'CSAT prompt', received: 1 } ),
+					createBusinessMessage( {
+						content: 'Follow-up message',
+						displayName: 'WordPress.com',
+						received: 2,
+					} ),
+				] }
+			/>
+		);
+
+		expect( screen.getByText( 'CSAT prompt' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Follow-up message' ) ).toBeInTheDocument();
 	} );
 } );

--- a/packages/odie-client/src/components/message/utils/get-message-unique-identifier.tsx
+++ b/packages/odie-client/src/components/message/utils/get-message-unique-identifier.tsx
@@ -5,6 +5,7 @@ export const getMessageUniqueIdentifier = ( message: Message, fallback?: string 
 		message.metadata?.temporary_id ??
 		message.message_id ??
 		message.internal_message_id ??
+		message.id ??
 		message.metadata?.local_timestamp ??
 		fallback
 	);

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -152,6 +152,10 @@ export type Message = {
 	content: ReactNode;
 	context?: Context;
 	displayName?: string;
+	/**
+	 * Set on messages originating from Zendesk, where it holds the Smooch message id.
+	 */
+	id?: string;
 	internal_message_id?: string;
 	message_id?: number;
 	meta?: Record< string, string >;

--- a/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
+++ b/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
@@ -93,22 +93,6 @@ function sortMessagesByTimestamp( messages: ZendeskMessage[] ) {
 	} );
 }
 
-/**
- * Zendesk can emit more than one CSAT prompt for the same conversation. They are all rendered with
- * the same copy, so every extra one reads as a duplicate and lets the user submit conflicting
- * ratings for a single ticket. Only the most recent prompt is kept.
- * @param messages - Messages sorted by timestamp.
- */
-function dropSupersededCSATMessages( messages: ZendeskMessage[] ) {
-	const lastCSATMessage = messages
-		.filter( ( message ) => message.metadata?.type === 'csat' )
-		.at( -1 );
-
-	return messages.filter(
-		( message ) => message.metadata?.type !== 'csat' || message === lastCSATMessage
-	);
-}
-
 function useSmooch( enabled = true, integrationKey?: string ) {
 	const queryClient = useQueryClient();
 	const { data: authData, isFetching: isAuthenticatingZendeskMessaging } =
@@ -408,9 +392,7 @@ export const useManagedZendeskChat = ( {
 	);
 
 	const agentticMessages = useMemo( () => {
-		const rawMessages = dropSupersededCSATMessages(
-			sortMessagesByTimestamp( conversation?.messages ?? [] )
-		);
+		const rawMessages = sortMessagesByTimestamp( conversation?.messages ?? [] );
 		const chatSessionId = conversation?.metadata?.chat_session_id;
 		const ratingMessage = rawMessages.find( ( msg ) => msg.metadata?.rated === true );
 		const hasRated = ratingMessage !== undefined;

--- a/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
+++ b/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
@@ -93,6 +93,22 @@ function sortMessagesByTimestamp( messages: ZendeskMessage[] ) {
 	} );
 }
 
+/**
+ * Zendesk can emit more than one CSAT prompt for the same conversation. They are all rendered with
+ * the same copy, so every extra one reads as a duplicate and lets the user submit conflicting
+ * ratings for a single ticket. Only the most recent prompt is kept.
+ * @param messages - Messages sorted by timestamp.
+ */
+function dropSupersededCSATMessages( messages: ZendeskMessage[] ) {
+	const lastCSATMessage = messages
+		.filter( ( message ) => message.metadata?.type === 'csat' )
+		.at( -1 );
+
+	return messages.filter(
+		( message ) => message.metadata?.type !== 'csat' || message === lastCSATMessage
+	);
+}
+
 function useSmooch( enabled = true, integrationKey?: string ) {
 	const queryClient = useQueryClient();
 	const { data: authData, isFetching: isAuthenticatingZendeskMessaging } =
@@ -392,7 +408,9 @@ export const useManagedZendeskChat = ( {
 	);
 
 	const agentticMessages = useMemo( () => {
-		const rawMessages = sortMessagesByTimestamp( conversation?.messages ?? [] );
+		const rawMessages = dropSupersededCSATMessages(
+			sortMessagesByTimestamp( conversation?.messages ?? [] )
+		);
 		const chatSessionId = conversation?.metadata?.chat_session_id;
 		const ratingMessage = rawMessages.find( ( msg ) => msg.metadata?.rated === true );
 		const hasRated = ratingMessage !== undefined;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SUTO-1454/duplicate-csat-message-appears-when-chat-closes

## Proposed Changes

**Only the most recent CSAT prompt is rendered when a chat closes, instead of one prompt per message Zendesk tags as `csat`.**

- Applied in the Odie message cluster, which is what the Help Center chat renders.
- `getMessageUniqueIdentifier` now falls back to the Zendesk message id. Zendesk-sent messages carry none of the identifiers it looked for (`temporary_id`, `message_id`, `internal_message_id`, `local_timestamp`), so it returned `undefined` for all of them — which silently disabled message deduplication and left React keys empty for every Zendesk message.

## Why are these changes being made?

When a support chat closes, the Help Center shows the rating prompt twice — the same “How would you rate your support experience?” copy with two sets of thumbs, one under the other. It reproduces on production today and was hit by several people during a support-flow test.

It is not just cosmetic. Both prompts are live, so a user can answer both, and answer them differently. That happened during testing: one good, one bad, both submitted against the same ticket, with Zendesk keeping whichever landed last. So a rating can end up recorded as the opposite of what the person meant.

The two prompts look identical because the chat overrides the text of any message Zendesk tags as `csat` with our own copy. Two different messages carrying that tag come out the other side indistinguishable. Rather than guess how many prompts Zendesk will send — which changes with the CSAT migration in [SUTO-1421](https://linear.app/a8c/issue/SUTO-1421/scope-changes-for-help-centertranscripts) — the chat now renders the latest one and ignores the rest.

## Testing Instructions

1. Run `yarn start` and open the Help Center on a Simple site.
2. Start a chat and escalate to a Happiness Engineer.
3. Have the resulting ticket solved so the CSAT prompt is sent to the conversation.
4. Confirm the rating prompt appears **once**, below a single “Chat with support team ended” divider.
5. Rate the chat and confirm the rating still submits, and that the prompt is replaced by the comment form as before.
6. Reopen the Help Center and confirm the chat history renders unchanged: attachments, Happiness Engineer names, and the automated messages before and after the prompt.
