### PR TITLE
Help Center: fix "Get help" button styling while resolving

### DIFF
--- a/packages/help-center/src/components/help-center-footer.scss
+++ b/packages/help-center/src/components/help-center-footer.scss
@@ -23,6 +23,16 @@
 		&:hover {
 			box-shadow: none;
 		}
+
+		// Keep the button recognisable while the destination is still resolving:
+		// the default disabled style greys the border out to near-invisibility.
+		&:disabled,
+		&[aria-disabled="true"],
+		&[aria-disabled="true"]:hover {
+			border-color: var(--wp-components-color-accent, var(--wp-admin-theme-color, $help-center-blue));
+			color: var(--wp-components-color-accent, var(--wp-admin-theme-color, $help-center-blue));
+			opacity: 0.6;
+		}
 	}
 }
 

--- a/packages/help-center/src/components/help-center-footer.tsx
+++ b/packages/help-center/src/components/help-center-footer.tsx
@@ -92,7 +92,6 @@ export const HelpCenterContactButton = () => {
 					variant="secondary"
 					className="button help-center-contact-page__button"
 					disabled={ isResolvingHumanRoute }
-					isBusy={ isResolvingHumanRoute }
 					accessibleWhenDisabled
 					__next40pxDefaultSize
 				>


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-18169/get-help-button-in-help-center-has-no-borderbackground-in-my-home

## Proposed Changes

**The Help Center footer's “Get help” button now keeps looking like a button while it waits for the support checks to finish.**

- Removed `isBusy`, which painted the WordPress components striped-gradient loader across the button.
- The disabled state now keeps the accent border and accent text, dimmed with `opacity: 0.6`, instead of inheriting the near-invisible `#dbdbdb` disabled border.
- The click guard is unchanged — the button still can't be activated before the human-support route resolves.

## Why are these changes being made?

When you open the Help Center, the footer button briefly waits on two background checks before it knows whether to send you to the AI assistant or straight to a Happiness Engineer. During that wait it was rendered in a “busy + disabled” state, and the styling for that state wiped out everything that made it read as a button: the blue outline turned an almost-invisible grey, the label went grey, and a diagonal grey barber-pole pattern was drawn over the whole thing.

The result looked less like a button and more like a broken placeholder or a stuck loading skeleton, so people didn't recognise it as the way to get help ([DOTCOM-18169](https://linear.app/a8c/issue/DOTCOM-18169)). The wait is short and the button's destination is the same in the overwhelming majority of cases, so a loud loading treatment was never worth the confusion it caused.

## Testing Instructions

### Calypso

1. Run `yarn start`.
2. Go to My Home and open the Help Center.
3. Watch the “Get help” button at the bottom of the panel as the panel opens. It should keep its blue border and blue label the whole time, appearing slightly dimmed for the brief moment before it becomes clickable.
4. Confirm there is no striped/diagonal grey pattern at any point.
5. Click “Get help” once it's active and confirm it still navigates to the AI chat (or the contact form, depending on your eligibility).

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
4. Open the Help Center and repeat steps 3–5 above.
