### PR TITLE
Jetpack AI Sidebar: Handle unsupported structural requests

### DIFF
--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -3052,8 +3052,14 @@ describe( 'toolProvider', () => {
 		it( 'includes update-block-content and show-component abilities', async () => {
 			const abilities = await toolProvider.getAbilities();
 			const names = abilities.map( ( a: any ) => a.name );
+			const updateBlock = abilities.find(
+				( ability: any ) => ability.name === 'wpcom/update-block-content'
+			);
 
 			expect( names ).toContain( 'wpcom/update-block-content' );
+			expect( updateBlock?.description ).toContain(
+				'Do not use this tool to add, move, remove, or reorder blocks, sections, or template parts.'
+			);
 			expect( names ).toContain( SHOW_COMPONENT_ABILITY_NAME );
 			expect( names ).toContain( LEGACY_SHOW_COMPONENT_ABILITY_NAME );
 			expect( names ).not.toContain( SHOW_COMPONENT_TOOL_ID );
@@ -4662,7 +4668,7 @@ describe( 'applyReviewEdit', () => {
 		}
 	);
 
-	it( 'fails safely when the block has no editable string-like attribute', async () => {
+	it( 'returns a visible limitation without continuing for an unsupported edit target', async () => {
 		const { blockUpdates } = installWpDataMockWithBlockEditor( {
 			'550e8400-e29b-41d4-a716-446655440000': {
 				name: 'core/query',
@@ -4675,7 +4681,13 @@ describe( 'applyReviewEdit', () => {
 		jest.advanceTimersByTime( 1000 );
 		const result = await promise;
 
-		expect( result ).toMatchObject( { success: false } );
+		expect( result ).toEqual( {
+			success: false,
+			error: 'unsupported edit target: core/query',
+			agentMessage:
+				'I can edit text inside supported blocks, but I can’t add, move, remove, or reorder blocks.',
+			returnToAgent: false,
+		} );
 		expect( blockUpdates ).toEqual( [] );
 	} );
 

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -8,6 +8,7 @@
 
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { dispatch, select } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 import { countOccurrences } from './blocks';
 
 /**
@@ -39,6 +40,13 @@ let activeBlockFocusClientId: string | null = null;
 let activeBlockFocusLayout: HTMLElement | null = null;
 const FOCUS_MODE_CLASS = 'is-focus-mode';
 const ROOT_BLOCK_LIST_SELECTOR = '.block-editor-block-list__layout.is-root-container';
+
+function getUnsupportedEditTargetMessage(): string {
+	return __(
+		'I can edit text inside supported blocks, but I can’t add, move, remove, or reorder blocks.',
+		__i18n_text_domain__
+	);
+}
 
 export const BLOCK_ACTION_COMPLETE_EVENT = 'jetpack-ai-sidebar-block-action-complete';
 export const SELECTED_BLOCK_CLEAR_EVENT = 'agents-manager-selected-block-cleared';
@@ -713,6 +721,7 @@ export function handleUpdateBlockContent( input: any ): any {
 		return {
 			success: false,
 			error: `unsupported edit target: ${ snapshot.name }`,
+			agentMessage: getUnsupportedEditTargetMessage(),
 			returnToAgent: false,
 		};
 	}
@@ -755,12 +764,17 @@ export function handleUpdateBlockContent( input: any ): any {
 	return new Promise< any >( ( resolve ) => {
 		setTimeout( () => {
 			let latestSnapshot = getBlockSnapshot( targetClientId, snapshotAttribute, currentText );
-			const resolveFailure = ( error: string ) => {
+			const resolveFailure = ( error: string, agentMessage?: string ) => {
 				if ( blockEl ) {
 					removeProcessingEffect( blockEl );
 				}
 				notifyBlockActionComplete();
-				resolve( { success: false, error, returnToAgent: false } );
+				resolve( {
+					success: false,
+					error,
+					...( agentMessage ? { agentMessage } : {} ),
+					returnToAgent: false,
+				} );
 			};
 
 			// Re-check immediately before mutation because the shimmer intentionally delays writes.
@@ -792,7 +806,10 @@ export function handleUpdateBlockContent( input: any ): any {
 				return;
 			}
 			if ( ! latestSnapshot.attributeName ) {
-				resolveFailure( `unsupported edit target: ${ latestSnapshot.name }` );
+				resolveFailure(
+					`unsupported edit target: ${ latestSnapshot.name }`,
+					getUnsupportedEditTargetMessage()
+				);
 				return;
 			}
 

--- a/packages/jetpack-ai-sidebar/src/utils/tool-provider.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tool-provider.ts
@@ -18,7 +18,7 @@ export const UPDATE_BLOCK_CONTENT_ABILITY: Tool = {
 	name: UPDATE_BLOCK_CONTENT_TOOL_ID,
 	...( { label: 'Update block content', category: 'jetpack-ai' } as any ), // eslint-disable-line @typescript-eslint/no-explicit-any
 	description:
-		'Update the text content of a specific block in the editor. Use this after translating, changing tone, checking grammar, or any other text transformation. The block will be updated directly in the editor.',
+		'Update text within an existing supported text block in the editor. Use this after translating, changing tone, checking grammar, or another text transformation. Do not use this tool to add, move, remove, or reorder blocks, sections, or template parts. The block text will be updated directly in the editor.',
 	input_schema: {
 		type: 'object',
 		properties: {


### PR DESCRIPTION
## Proposed Changes

* Restrict `wpcom/update-block-content` to supported text transformations in its tool description.
* Return a visible limitation when a structural or otherwise unsupported block reaches the text-editing fallback.
* Keep `returnToAgent: false` so the fallback does not start another Agent turn or consume another request.
* Add focused tests for the tool description and failure result.

## Why are these changes being made?

Jetpack-only sites do not have the structural block-editing ability. For requests such as moving or removing a section, the Agent could still select the text-only tool. Unsupported targets then returned only a client error while stopping the loop, leaving the sidebar with no visible reply.

This keeps writing assistance separate from structural site editing and makes the fallback understandable when routing still goes wrong.

The matching server-side routing change is in a separate WPCOM PR.

## Testing Instructions

1. Open the editor with the Jetpack AI sidebar enabled and Big Sky disabled.
2. Select a structural block such as a template part.
3. Ask the sidebar to remove or move it.
4. Confirm the sidebar explains that it can edit text but cannot change the block layout.
5. Confirm the editor content is unchanged and the Agent does not retry the tool.

Automated checks:

* `yarn test-packages packages/jetpack-ai-sidebar/src/index.test.ts --runInBand` — 191 tests passed.
* `yarn workspace @automattic/jetpack-ai-sidebar build`
* Targeted ESLint on the three changed files.
* Prettier check on the three changed files.
* Production Agents Manager bundle build.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?