### PR TITLE
Stats: Add blog_id to upsell impression and analytics events

### DIFF
--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -197,7 +197,7 @@ const StatsDateControl = ( {
 		let period = bestPeriodForDays( rangeInDays );
 
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-		recordTracksEvent( eventNames[ event_from ][ 'apply_button' ] );
+		recordTracksEvent( eventNames[ event_from ][ 'apply_button' ], { blog_id: siteId } );
 
 		const appliedShortcut = findShortcutForRange( shortcutList, {
 			chartStart: startDate,
@@ -241,7 +241,9 @@ const StatsDateControl = ( {
 				);
 			}
 		} else {
-			recordTracksEvent( eventNames[ event_from ][ shortcut.id as EventNameKey ] );
+			recordTracksEvent( eventNames[ event_from ][ shortcut.id as EventNameKey ], {
+				blog_id: siteId,
+			} );
 			if ( shortcut.id === 'all_time' ) {
 				closePopover();
 				setTimeout( () => page( generateAllTimeLink() ), 250 );
@@ -265,7 +267,7 @@ const StatsDateControl = ( {
 			onShortcutClick={ onShortcutClickHandler }
 			onDateControlClick={ () => {
 				const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-				recordTracksEvent( eventNames[ event_from ][ 'trigger_button' ] );
+				recordTracksEvent( eventNames[ event_from ][ 'trigger_button' ], { blog_id: siteId } );
 			} }
 			tooltip={ translate( 'Filter all data by date' ) }
 			overlay={ overlay }

--- a/client/my-sites/stats/components/empty-state-action/empty-state-action.tsx
+++ b/client/my-sites/stats/components/empty-state-action/empty-state-action.tsx
@@ -1,6 +1,8 @@
 import { Card, CardBody, Icon } from '@wordpress/components';
 import { chevronRight } from '@wordpress/icons';
 import { trackStatsAnalyticsEvent } from 'calypso/my-sites/stats/utils';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { JSX } from 'react';
 
 import './styles.scss';
@@ -21,8 +23,13 @@ const EmptyStateAction: React.FC< EmptyStateActionProps > = ( {
 	analyticsDetails,
 	onClick,
 } ) => {
+	const siteId = useSelector( getSelectedSiteId );
+
 	const handleClick = () => {
-		trackStatsAnalyticsEvent( 'empty_state_interaction', analyticsDetails );
+		trackStatsAnalyticsEvent( 'empty_state_interaction', {
+			...analyticsDetails,
+			blog_id: siteId,
+		} );
 
 		onClick();
 	};

--- a/client/my-sites/stats/features/modules/stats-devices/stats-module-devices.tsx
+++ b/client/my-sites/stats/features/modules/stats-devices/stats-module-devices.tsx
@@ -132,6 +132,7 @@ const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 		recordTracksEvent( `${ event_from }_devices_module_menu_clicked`, {
 			button: optionLabels[ filter ]?.analyticsId ?? filter,
+			blog_id: siteId,
 		} );
 
 		setSelectedOption( filter );

--- a/client/my-sites/stats/features/modules/stats-locations/locations-nav-tabs.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/locations-nav-tabs.tsx
@@ -9,7 +9,13 @@ import { StatsQueryType } from '../types';
 import { UrlGeoMode, OPTION_KEYS } from './types';
 import useOptionLabels from './use-option-labels';
 
-function LocationsNavTabs( { query }: { query: StatsQueryType & { geoMode?: UrlGeoMode } } ) {
+function LocationsNavTabs( {
+	query,
+	givenSiteId,
+}: {
+	query: StatsQueryType & { geoMode?: UrlGeoMode };
+	givenSiteId?: number;
+} ) {
 	const optionLabels = useOptionLabels();
 	const tabPanelTabs = useMemo( () => {
 		return Object.entries( optionLabels ).map( ( [ key, item ] ) => {
@@ -37,6 +43,7 @@ function LocationsNavTabs( { query }: { query: StatsQueryType & { geoMode?: UrlG
 				if ( tab?.path ) {
 					trackStatsAnalyticsEvent( 'stats_locations_module_menu_clicked', {
 						stat_type: tab.feature,
+						blog_id: givenSiteId,
 					} );
 					page( tab.path );
 				}

--- a/client/my-sites/stats/features/modules/stats-locations/locations-nav-tabs.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/locations-nav-tabs.tsx
@@ -14,7 +14,7 @@ function LocationsNavTabs( {
 	givenSiteId,
 }: {
 	query: StatsQueryType & { geoMode?: UrlGeoMode };
-	givenSiteId?: number;
+	givenSiteId: number;
 } ) {
 	const optionLabels = useOptionLabels();
 	const tabPanelTabs = useMemo( () => {

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -196,6 +196,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 		trackStatsAnalyticsEvent( 'stats_locations_module_country_filter_changed', {
 			stat_type: optionLabels[ selectedOption ].feature,
 			country: value,
+			blog_id: siteId,
 		} );
 
 		setCountryFilter( value );
@@ -205,6 +206,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 		const filter = selection.value;
 		trackStatsAnalyticsEvent( 'stats_locations_module_menu_clicked', {
 			stat_type: optionLabels[ filter ].feature,
+			blog_id: siteId,
 		} );
 
 		if ( summary ) {
@@ -217,6 +219,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 	const onShowMoreClick = () => {
 		trackStatsAnalyticsEvent( 'stats_locations_module_show_more_clicked', {
 			stat_type: optionLabels[ selectedOption ].feature,
+			blog_id: siteId,
 		} );
 	};
 

--- a/client/my-sites/stats/features/modules/stats-top-posts/nav-tabs.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/nav-tabs.tsx
@@ -48,6 +48,7 @@ function NavTabs( { query }: StatsModulePostsProps ) {
 				if ( tab?.path ) {
 					trackStatsAnalyticsEvent( 'stats_posts_module_menu_clicked', {
 						stat_type: tab.analyticsId,
+						blog_id: siteId,
 					} );
 
 					page( tab.path );

--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -77,6 +77,7 @@ const StatsTopPosts: React.FC< StatsModulePostsProps > = ( {
 	const onStatTypeChange = ( option: StatTypeOptionType ) => {
 		trackStatsAnalyticsEvent( 'stats_posts_module_menu_clicked', {
 			stat_type: option.analyticsId,
+			blog_id: siteId,
 		} );
 
 		setLocalStatType( option.value );

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm-dropdown.tsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm-dropdown.tsx
@@ -15,6 +15,7 @@ interface UTMDropdownProps {
 	onSelect: ( key: string ) => void;
 	selectOptions: Record< string, { selectLabel: string; isGrouped?: boolean } >;
 	selected: keyof typeof SELECTED_OPTION_KEYS;
+	siteId: number;
 }
 
 const BASE_CLASS_NAME = 'stats-utm-picker';
@@ -25,6 +26,7 @@ const UTMDropdown: React.FC< UTMDropdownProps > = ( {
 	onSelect,
 	selectOptions,
 	selected, // which option is indicated as selected
+	siteId,
 } ) => {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const infoReferenceElement = useRef( null );
@@ -35,7 +37,7 @@ const UTMDropdown: React.FC< UTMDropdownProps > = ( {
 
 		if ( ! popoverOpened ) {
 			// record an event for opening the date picker
-			recordTracksEvent( `${ event_from }_stats_utm_dropdown_opened` );
+			recordTracksEvent( `${ event_from }_stats_utm_dropdown_opened`, { blog_id: siteId } );
 		}
 
 		togglePopoverOpened( ! popoverOpened );
@@ -48,6 +50,7 @@ const UTMDropdown: React.FC< UTMDropdownProps > = ( {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 		recordTracksEvent( `${ event_from }_stats_utm_dropdown_option_selected`, {
 			option: key,
+			blog_id: siteId,
 		} );
 
 		togglePopoverOpened( false );

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
@@ -190,6 +190,7 @@ const StatsModuleUTM = ( {
 				onSelect={ setSelectedOption }
 				selectOptions={ optionLabels }
 				selected={ selectedOption }
+				siteId={ siteId }
 			/>
 		</div>
 	);

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -108,6 +108,7 @@ interface FeedbackPanelProps {
 	onDismissPanel: () => void;
 	onLeaveReview: () => void;
 	onSendFeedback: () => void;
+	siteId: number;
 }
 
 function FeedbackPanel( {
@@ -115,6 +116,7 @@ function FeedbackPanel( {
 	onDismissPanel,
 	onLeaveReview,
 	onSendFeedback,
+	siteId,
 }: FeedbackPanelProps ) {
 	const translate = useTranslate();
 	const [ animationClassName, setAnimationClassName ] = useState(
@@ -122,18 +124,18 @@ function FeedbackPanel( {
 	);
 
 	const handleDismissPanel = () => {
-		trackStatsAnalyticsEvent( TRACKS_EVENT_DISMISS_FLOATING_PANEL );
+		trackStatsAnalyticsEvent( TRACKS_EVENT_DISMISS_FLOATING_PANEL, { blog_id: siteId } );
 		setAnimationClassName( FEEDBACK_PANEL_ANIMATION_NAME_EXIT );
 		onDismissPanel();
 	};
 
 	const handleLeaveReviewFromPanel = () => {
-		trackStatsAnalyticsEvent( TRACKS_EVENT_LEAVE_REVIEW_FROM_PANEL );
+		trackStatsAnalyticsEvent( TRACKS_EVENT_LEAVE_REVIEW_FROM_PANEL, { blog_id: siteId } );
 		onLeaveReview();
 	};
 
 	const handleSendFeedbackFromPanel = () => {
-		trackStatsAnalyticsEvent( TRACKS_EVENT_SEND_FEEDBACK_FROM_PANEL );
+		trackStatsAnalyticsEvent( TRACKS_EVENT_SEND_FEEDBACK_FROM_PANEL, { blog_id: siteId } );
 		onSendFeedback();
 	};
 
@@ -167,30 +169,31 @@ function FeedbackPanel( {
 interface FeedbackCardProps {
 	onLeaveReview: () => void;
 	onSendFeedback: () => void;
+	siteId: number;
 }
 
-function FeedbackCard( { onLeaveReview, onSendFeedback }: FeedbackCardProps ) {
+function FeedbackCard( { onLeaveReview, onSendFeedback, siteId }: FeedbackCardProps ) {
 	const [ hasFiredViewEvent, setHasFiredViewEvent ] = useState( false );
 	const inlineFeedbackCardRef = useRef( null );
 	const isVisible = useOnScreen( inlineFeedbackCardRef );
 
 	useEffect( () => {
-		trackStatsAnalyticsEvent( TRACKS_EVENT_DID_PRESENT_FEEDBACK_CARD );
-	}, [] );
+		trackStatsAnalyticsEvent( TRACKS_EVENT_DID_PRESENT_FEEDBACK_CARD, { blog_id: siteId } );
+	}, [ siteId ] );
 
 	useEffect( () => {
 		if ( isVisible && ! hasFiredViewEvent ) {
-			trackStatsAnalyticsEvent( TRACKS_EVENT_DID_VIEW_FEEDBACK_CARD );
+			trackStatsAnalyticsEvent( TRACKS_EVENT_DID_VIEW_FEEDBACK_CARD, { blog_id: siteId } );
 			setHasFiredViewEvent( true );
 		}
-	}, [ isVisible, hasFiredViewEvent ] );
+	}, [ isVisible, hasFiredViewEvent, siteId ] );
 
 	const handleLeaveReviewFromCard = () => {
-		trackStatsAnalyticsEvent( TRACKS_EVENT_LEAVE_REVIEW_FROM_CARD );
+		trackStatsAnalyticsEvent( TRACKS_EVENT_LEAVE_REVIEW_FROM_CARD, { blog_id: siteId } );
 		onLeaveReview();
 	};
 	const handleSendFeedbackFromCard = () => {
-		trackStatsAnalyticsEvent( TRACKS_EVENT_SEND_FEEDBACK_FROM_CARD );
+		trackStatsAnalyticsEvent( TRACKS_EVENT_SEND_FEEDBACK_FROM_CARD, { blog_id: siteId } );
 		onSendFeedback();
 	};
 
@@ -214,10 +217,10 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 		if ( ! isPending && ! isError && shouldShowFeedbackPanel ) {
 			setTimeout( () => {
 				setIsFloatingPanelOpen( true );
-				trackStatsAnalyticsEvent( TRACKS_EVENT_VIEW_FLOATING_PANEL );
+				trackStatsAnalyticsEvent( TRACKS_EVENT_VIEW_FLOATING_PANEL, { blog_id: siteId } );
 			}, FEEDBACK_PANEL_PRESENTATION_DELAY );
 		}
-	}, [ isPending, isError, shouldShowFeedbackPanel ] );
+	}, [ isPending, isError, shouldShowFeedbackPanel, siteId ] );
 
 	const dismissPanelWithDelay = () => {
 		// Allows the animation to run first.
@@ -243,12 +246,17 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 
 	return (
 		<div className="stats-feedback-container">
-			<FeedbackCard onLeaveReview={ handleLeaveReview } onSendFeedback={ handleSendFeedback } />
+			<FeedbackCard
+				onLeaveReview={ handleLeaveReview }
+				onSendFeedback={ handleSendFeedback }
+				siteId={ siteId }
+			/>
 			<FeedbackPanel
 				isOpen={ isFloatingPanelOpen }
 				onDismissPanel={ handleDismissPanel }
 				onLeaveReview={ handleLeaveReview }
 				onSendFeedback={ handleSendFeedback }
+				siteId={ siteId }
 			/>
 		</div>
 	);

--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -58,10 +58,12 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 			onClose();
 
 			if ( isDirectClose ) {
-				trackStatsAnalyticsEvent( 'stats_feedback_action_directly_close_form_modal' );
+				trackStatsAnalyticsEvent( 'stats_feedback_action_directly_close_form_modal', {
+					blog_id: siteId,
+				} );
 			}
 		},
-		[ onClose ]
+		[ onClose, siteId ]
 	);
 
 	const onFormSubmit = useCallback( () => {
@@ -79,8 +81,9 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 
 		trackStatsAnalyticsEvent( 'stats_feedback_action_submit_form', {
 			feedback: content,
+			blog_id: siteId,
 		} );
-	}, [ content, submitFeedback ] );
+	}, [ content, submitFeedback, siteId ] );
 
 	useEffect( () => {
 		if ( isSubmissionSuccessful ) {

--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -93,9 +93,9 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 			return;
 		} else if ( dotPagerIndex >= viewEvents.length ) {
 			// Prevent out of bounds index when switching sites.
-			recordTracksEvent( viewEvents[ viewEvents.length - 1 ], { site_id: selectedSiteId } );
+			recordTracksEvent( viewEvents[ viewEvents.length - 1 ], { blog_id: selectedSiteId } );
 		} else {
-			recordTracksEvent( viewEvents[ dotPagerIndex ], { site_id: selectedSiteId } );
+			recordTracksEvent( viewEvents[ dotPagerIndex ], { blog_id: selectedSiteId } );
 		}
 	}, [ viewEvents, dotPagerIndex, selectedSiteId ] );
 

--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -93,9 +93,15 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 			return;
 		} else if ( dotPagerIndex >= viewEvents.length ) {
 			// Prevent out of bounds index when switching sites.
-			recordTracksEvent( viewEvents[ viewEvents.length - 1 ], { blog_id: selectedSiteId } );
+			recordTracksEvent( viewEvents[ viewEvents.length - 1 ], {
+				blog_id: selectedSiteId,
+				site_id: selectedSiteId,
+			} );
 		} else {
-			recordTracksEvent( viewEvents[ dotPagerIndex ], { blog_id: selectedSiteId } );
+			recordTracksEvent( viewEvents[ dotPagerIndex ], {
+				blog_id: selectedSiteId,
+				site_id: selectedSiteId,
+			} );
 		}
 	}, [ viewEvents, dotPagerIndex, selectedSiteId ] );
 

--- a/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
+++ b/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
@@ -4,8 +4,9 @@ import { Button } from '@automattic/components';
 import { Icon, chevronDown } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 import { useCallback } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { dismissBlock } from './actions';
 
 import './mini-carousel-block.scss';
@@ -21,21 +22,22 @@ const MiniCarouselBlock = ( {
 	dismissText,
 } ) => {
 	const dispatch = useDispatch();
+	const selectedSiteId = useSelector( getSelectedSiteId );
 
 	const onClick = useCallback( () => {
-		recordTracksEvent( clickEvent );
+		recordTracksEvent( clickEvent, { blog_id: selectedSiteId } );
 		if ( href.startsWith( '/' ) ) {
 			page( href );
 			return;
 		}
 
 		location.href = href;
-	}, [ clickEvent, href ] );
+	}, [ clickEvent, href, selectedSiteId ] );
 
 	const onDismiss = useCallback( () => {
-		recordTracksEvent( dismissEvent );
+		recordTracksEvent( dismissEvent, { blog_id: selectedSiteId } );
 		dispatch( dismissBlock( dismissEvent ) );
-	}, [ dismissEvent, dispatch ] );
+	}, [ dismissEvent, dispatch, selectedSiteId ] );
 
 	return (
 		<div className="mini-carousel-block">

--- a/client/my-sites/stats/pages/purchase/index.tsx
+++ b/client/my-sites/stats/pages/purchase/index.tsx
@@ -92,9 +92,9 @@ const StatsPurchasePage = ( {
 		}
 
 		if ( triggeredEvent ) {
-			recordTracksEvent( triggeredEvent );
+			recordTracksEvent( triggeredEvent, { blog_id: siteId } );
 		}
-	}, [ siteSlug, query, query?.from ] );
+	}, [ siteSlug, query, query?.from, siteId ] );
 
 	const commercialProduct = useSelector( ( state ) =>
 		getProductBySlug( state, PRODUCT_JETPACK_STATS_YEARLY )

--- a/client/my-sites/stats/pages/purchase/index.tsx
+++ b/client/my-sites/stats/pages/purchase/index.tsx
@@ -7,7 +7,7 @@ import page from '@automattic/calypso-router';
 import { ProductsList } from '@automattic/data-stores';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -70,6 +70,8 @@ const StatsPurchasePage = ( {
 		}
 	}, [ siteSlug, isVip ] );
 
+	const hasTrackedUpgradeSource = useRef( false );
+
 	useEffect( () => {
 		// Scroll to top on page load
 		window.scrollTo( 0, 0 );
@@ -91,7 +93,10 @@ const StatsPurchasePage = ( {
 				break;
 		}
 
-		if ( triggeredEvent ) {
+		// Wait for the selected site to resolve so the event carries a real
+		// blog_id, and fire at most once per page load.
+		if ( triggeredEvent && siteId && ! hasTrackedUpgradeSource.current ) {
+			hasTrackedUpgradeSource.current = true;
 			recordTracksEvent( triggeredEvent, { blog_id: siteId } );
 		}
 	}, [ siteSlug, query, query?.from, siteId ] );

--- a/client/my-sites/stats/promo-cards/index.jsx
+++ b/client/my-sites/stats/promo-cards/index.jsx
@@ -109,7 +109,7 @@ export default function PromoCards( { isOdysseyStats, slug, pageSlug } ) {
 			'-',
 			'_'
 		);
-		recordTracksEvent( tracksEventName );
+		recordTracksEvent( tracksEventName, { blog_id: selectedSiteId } );
 	};
 
 	const pagerDidSelectPage = ( index ) => setDotPagerIndex( index );

--- a/client/my-sites/stats/promo-cards/index.jsx
+++ b/client/my-sites/stats/promo-cards/index.jsx
@@ -64,9 +64,9 @@ export default function PromoCards( { isOdysseyStats, slug, pageSlug } ) {
 			return;
 		} else if ( dotPagerIndex >= viewEvents.length ) {
 			// Prevent out of bounds index when switching sites.
-			recordTracksEvent( viewEvents[ viewEvents.length - 1 ], { site_id: selectedSiteId } );
+			recordTracksEvent( viewEvents[ viewEvents.length - 1 ], { blog_id: selectedSiteId } );
 		} else {
-			recordTracksEvent( viewEvents[ dotPagerIndex ], { site_id: selectedSiteId } );
+			recordTracksEvent( viewEvents[ dotPagerIndex ], { blog_id: selectedSiteId } );
 		}
 	}, [ viewEvents, dotPagerIndex, selectedSiteId ] );
 

--- a/client/my-sites/stats/promo-cards/index.jsx
+++ b/client/my-sites/stats/promo-cards/index.jsx
@@ -64,9 +64,15 @@ export default function PromoCards( { isOdysseyStats, slug, pageSlug } ) {
 			return;
 		} else if ( dotPagerIndex >= viewEvents.length ) {
 			// Prevent out of bounds index when switching sites.
-			recordTracksEvent( viewEvents[ viewEvents.length - 1 ], { blog_id: selectedSiteId } );
+			recordTracksEvent( viewEvents[ viewEvents.length - 1 ], {
+				blog_id: selectedSiteId,
+				site_id: selectedSiteId,
+			} );
 		} else {
-			recordTracksEvent( viewEvents[ dotPagerIndex ], { blog_id: selectedSiteId } );
+			recordTracksEvent( viewEvents[ dotPagerIndex ], {
+				blog_id: selectedSiteId,
+				site_id: selectedSiteId,
+			} );
 		}
 	}, [ viewEvents, dotPagerIndex, selectedSiteId ] );
 

--- a/client/my-sites/stats/stats-card-upsell/index.tsx
+++ b/client/my-sites/stats/stats-card-upsell/index.tsx
@@ -39,8 +39,9 @@ const StatsCardUpsell: React.FC< Props > = ( { className, statType, siteId, butt
 	useEffect( () => {
 		trackStatsAnalyticsEvent( 'stats_card_upsell_view', {
 			stat_type: statType,
+			blog_id: siteId,
 		} );
-	}, [ statType ] );
+	}, [ statType, siteId ] );
 
 	return (
 		<UpsellComponent

--- a/client/my-sites/stats/stats-card-upsell/stats-card-update-jetpack-version.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-update-jetpack-version.tsx
@@ -27,6 +27,7 @@ const StatsCardUpdateJetpackVersion: React.FC< Props > = ( { className, siteId, 
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 		recordTracksEvent( `${ event_from }_${ tracksEvent }`, {
 			module: statType,
+			blog_id: siteId,
 		} );
 
 		// redirect to the Plugins page

--- a/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
@@ -35,10 +35,11 @@ const StatsCardUpsellJetpack: React.FC< Props > = ( { className, siteId, statTyp
 
 		// publish an event
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-		recordTracksEvent( `${ event_from }_${ tracksEvent }` );
+		recordTracksEvent( `${ event_from }_${ tracksEvent }`, { blog_id: siteId } );
 		// publish new unified upgrade event
 		trackStatsAnalyticsEvent( 'stats_upgrade_clicked', {
 			type: statType,
+			blog_id: siteId,
 		} );
 
 		// redirect to the Purchase page

--- a/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
@@ -40,7 +40,9 @@ const ChartHeader = ( {
 			return;
 		}
 
-		events.forEach( ( event ) => recordTracksEvent( event.name, event.params ) );
+		events.forEach( ( event ) =>
+			recordTracksEvent( event.name, { blog_id: siteId, ...event.params } )
+		);
 		dispatch( toggleUpsellModal( siteId, statType ) );
 	};
 

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -161,7 +161,9 @@ class StatModuleChartTabs extends Component {
 		}
 
 		// Record the chart type change event
-		this.props.recordTracksEvent( CHART_TYPE_EVENTS[ event_from ][ newType ] );
+		this.props.recordTracksEvent( CHART_TYPE_EVENTS[ event_from ][ newType ], {
+			blog_id: siteId,
+		} );
 	};
 
 	formatLineChartTimeTick = ( date ) => {

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
@@ -6,6 +6,8 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import React, { useEffect, useRef } from 'react';
 import useWPAdminTheme from 'calypso/my-sites/stats/hooks/use-wp-admin-theme';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { trackStatsAnalyticsEvent } from '../utils';
 import StatsUtmBuilderForm, { type UtmBuilderProps } from './stats-module-utm-builder-form';
 
@@ -18,6 +20,7 @@ interface Props {
 const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger, initialData } ) => {
 	const [ isOpen, setOpen ] = useState< boolean | null >( null );
 	const scrollY = useRef( { y: 0, mobile: false } );
+	const siteId = useSelector( getSelectedSiteId );
 
 	const openModal = () => {
 		const isMobile = document.body.scrollTop > 0;
@@ -46,8 +49,11 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger, initialData }
 	const translate = useTranslate();
 
 	const handleClick = () => {
-		trackStatsAnalyticsEvent( 'utm_builder_opened' );
-		trackStatsAnalyticsEvent( 'advanced_feature_interaction', { feature: 'utm_builder' } );
+		trackStatsAnalyticsEvent( 'utm_builder_opened', { blog_id: siteId } );
+		trackStatsAnalyticsEvent( 'advanced_feature_interaction', {
+			feature: 'utm_builder',
+			blog_id: siteId,
+		} );
 
 		openModal();
 	};

--- a/client/my-sites/stats/stats-module/all-time-nav.jsx
+++ b/client/my-sites/stats/stats-module/all-time-nav.jsx
@@ -94,7 +94,9 @@ export const StatsModuleSummaryLinks = ( props ) => {
 			return;
 		}
 
-		events.forEach( ( event ) => recordTracksEvent( event.name, event.params ) );
+		events.forEach( ( event ) =>
+			recordTracksEvent( event.name, { blog_id: siteId, ...event.params } )
+		);
 		dispatch( toggleUpsellModal( siteId, statType ) );
 	};
 

--- a/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
@@ -71,12 +71,16 @@ const CommercialSiteUpgradeNotice = ( {
 	useEffect( () => {
 		if ( ! noticeDismissed ) {
 			if ( isOdysseyStats ) {
-				recordTracksEvent( 'jetpack_odyssey_stats_commercial_site_upgrade_notice_viewed' );
+				recordTracksEvent( 'jetpack_odyssey_stats_commercial_site_upgrade_notice_viewed', {
+					blog_id: siteId,
+				} );
 			} else {
-				recordTracksEvent( 'calypso_stats_commercial_site_upgrade_notice_viewed' );
+				recordTracksEvent( 'calypso_stats_commercial_site_upgrade_notice_viewed', {
+					blog_id: siteId,
+				} );
 			}
 		}
-	}, [ noticeDismissed, isOdysseyStats ] );
+	}, [ noticeDismissed, isOdysseyStats, siteId ] );
 
 	if ( noticeDismissed ) {
 		return null;

--- a/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
@@ -42,9 +42,13 @@ const CommercialSiteUpgradeNotice = ( {
 
 	const dismissNotice = () => {
 		if ( isOdysseyStats ) {
-			recordTracksEvent( 'jetpack_odyssey_stats_commercial_site_upgrade_notice_dismissed' );
+			recordTracksEvent( 'jetpack_odyssey_stats_commercial_site_upgrade_notice_dismissed', {
+				blog_id: siteId,
+			} );
 		} else {
-			recordTracksEvent( 'calypso_stats_commercial_site_upgrade_notice_dismissed' );
+			recordTracksEvent( 'calypso_stats_commercial_site_upgrade_notice_dismissed', {
+				blog_id: siteId,
+			} );
 		}
 
 		setNoticeDismissed( true );
@@ -54,14 +58,18 @@ const CommercialSiteUpgradeNotice = ( {
 	const gotoJetpackStatsProduct = () => {
 		if ( isOdysseyStats ) {
 			recordTracksEvent(
-				'jetpack_odyssey_stats_commercial_site_upgrade_notice_support_button_clicked'
+				'jetpack_odyssey_stats_commercial_site_upgrade_notice_support_button_clicked',
+				{ blog_id: siteId }
 			);
 		} else {
-			recordTracksEvent( 'calypso_stats_commercial_site_upgrade_notice_support_button_clicked' );
+			recordTracksEvent( 'calypso_stats_commercial_site_upgrade_notice_support_button_clicked', {
+				blog_id: siteId,
+			} );
 		}
 
 		trackStatsAnalyticsEvent( 'stats_upgrade_clicked', {
 			type: 'notice-commercial',
+			blog_id: siteId,
 		} );
 
 		// Allow some time for the event to be recorded before redirecting.

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -50,7 +50,8 @@ const DoYouLoveJetpackStatsNotice = ( {
 		recordTracksEvent(
 			isOdysseyStats
 				? 'jetpack_odyssey_stats_do_you_love_jetpack_stats_notice_dismissed'
-				: 'calypso_stats_do_you_love_jetpack_stats_notice_dismissed'
+				: 'calypso_stats_do_you_love_jetpack_stats_notice_dismissed',
+			{ blog_id: siteId }
 		);
 
 		setNoticeDismissed( true );
@@ -58,7 +59,9 @@ const DoYouLoveJetpackStatsNotice = ( {
 	};
 
 	const openWPCOMPaidStatsUpsellModal = () => {
-		recordTracksEvent( 'calypso_stats_do_you_love_jetpack_stats_notice_upgrade_button_clicked' );
+		recordTracksEvent( 'calypso_stats_do_you_love_jetpack_stats_notice_upgrade_button_clicked', {
+			blog_id: siteId,
+		} );
 		dispatch( toggleUpsellModal( siteId, STATS_DO_YOU_LOVE_JETPACK_STATS_NOTICE ) );
 	};
 
@@ -66,11 +69,13 @@ const DoYouLoveJetpackStatsNotice = ( {
 		recordTracksEvent(
 			isOdysseyStats
 				? 'jetpack_odyssey_stats_do_you_love_jetpack_stats_notice_support_button_clicked'
-				: 'calypso_stats_do_you_love_jetpack_stats_notice_support_button_clicked'
+				: 'calypso_stats_do_you_love_jetpack_stats_notice_support_button_clicked',
+			{ blog_id: siteId }
 		);
 
 		trackStatsAnalyticsEvent( 'stats_upgrade_clicked', {
 			type: 'notice-love-stats',
+			blog_id: siteId,
 		} );
 
 		// Allow some time for the event to be recorded before redirecting.

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -89,10 +89,11 @@ const DoYouLoveJetpackStatsNotice = ( {
 			recordTracksEvent(
 				isOdysseyStats
 					? 'jetpack_odyssey_stats_do_you_love_jetpack_stats_notice_viewed'
-					: 'calypso_stats_do_you_love_jetpack_stats_notice_viewed'
+					: 'calypso_stats_do_you_love_jetpack_stats_notice_viewed',
+				{ blog_id: siteId }
 			);
 		}
-	}, [ noticeDismissed, isOdysseyStats ] );
+	}, [ noticeDismissed, isOdysseyStats, siteId ] );
 
 	if ( noticeDismissed ) {
 		return null;

--- a/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
@@ -19,14 +19,16 @@ const getStatsPurchaseURL = ( siteId: number | null ) => {
 const handleUpgradeClick = (
 	event: React.MouseEvent< HTMLAnchorElement, MouseEvent >,
 	upgradeUrl: string,
-	isOdysseyStats: boolean
+	isOdysseyStats: boolean,
+	siteId: number | null
 ) => {
 	event.preventDefault();
 
 	recordTracksEvent(
 		isOdysseyStats
 			? 'jetpack_odyssey_stats_purchase_success_banner_upgrade_clicked'
-			: 'calypso_stats_purchase_success_banner_upgrade_clicked'
+			: 'calypso_stats_purchase_success_banner_upgrade_clicked',
+		{ blog_id: siteId }
 	);
 
 	setTimeout( () => page( upgradeUrl ), 250 );
@@ -78,7 +80,7 @@ const FreePlanPurchaseSuccessJetpackStatsNotice = ( {
 							jetpackStatsProductLink: (
 								<a
 									onClick={ ( e ) =>
-										handleUpgradeClick( e, getStatsPurchaseURL( siteId ), isOdysseyStats )
+										handleUpgradeClick( e, getStatsPurchaseURL( siteId ), isOdysseyStats, siteId )
 									}
 									className="notice-banner__action-link notice-banner__action-link--inline"
 									href={ getStatsPurchaseURL( siteId ) }

--- a/client/my-sites/stats/stats-notices/free-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-site-upgrade-notice.tsx
@@ -47,7 +47,8 @@ const FreeSiteUpgradeNotice = ( { siteId, hasFreeStats, isOdysseyStats }: StatsN
 		recordTracksEvent(
 			isOdysseyStats
 				? 'jetpack_odyssey_stats_free_site_upgrade_notice_dismissed'
-				: 'calypso_stats_free_site_upgrade_notice_dismissed'
+				: 'calypso_stats_free_site_upgrade_notice_dismissed',
+			{ blog_id: siteId }
 		);
 
 		setNoticeDismissed( true );
@@ -56,7 +57,9 @@ const FreeSiteUpgradeNotice = ( { siteId, hasFreeStats, isOdysseyStats }: StatsN
 	};
 
 	const openWPCOMPaidStatsUpsellModal = () => {
-		recordTracksEvent( 'calypso_stats_free_site_upgrade_notice_upgrade_button_clicked' );
+		recordTracksEvent( 'calypso_stats_free_site_upgrade_notice_upgrade_button_clicked', {
+			blog_id: siteId,
+		} );
 		dispatch( toggleUpsellModal( siteId, STATS_FREE_SITE_UPGRADE_NOTICE ) );
 	};
 
@@ -64,11 +67,13 @@ const FreeSiteUpgradeNotice = ( { siteId, hasFreeStats, isOdysseyStats }: StatsN
 		recordTracksEvent(
 			isOdysseyStats
 				? 'jetpack_odyssey_stats_free_site_upgrade_notice_support_button_clicked'
-				: 'calypso_stats_free_site_upgrade_notice_support_button_clicked'
+				: 'calypso_stats_free_site_upgrade_notice_support_button_clicked',
+			{ blog_id: siteId }
 		);
 
 		trackStatsAnalyticsEvent( 'stats_upgrade_clicked', {
 			type: 'notice-free-site-upgrade',
+			blog_id: siteId,
 		} );
 
 		// Allow some time for the event to be recorded before redirecting.

--- a/client/my-sites/stats/stats-notices/free-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-site-upgrade-notice.tsx
@@ -87,10 +87,11 @@ const FreeSiteUpgradeNotice = ( { siteId, hasFreeStats, isOdysseyStats }: StatsN
 			recordTracksEvent(
 				isOdysseyStats
 					? 'jetpack_odyssey_stats_free_site_upgrade_notice_viewed'
-					: 'calypso_stats_free_site_upgrade_notice_viewed'
+					: 'calypso_stats_free_site_upgrade_notice_viewed',
+				{ blog_id: siteId }
 			);
 		}
-	}, [ noticeDismissed, isOdysseyStats ] );
+	}, [ noticeDismissed, isOdysseyStats, siteId ] );
 
 	if ( noticeDismissed ) {
 		return null;

--- a/client/my-sites/stats/stats-notices/gdpr-cookie-consent-notice.tsx
+++ b/client/my-sites/stats/stats-notices/gdpr-cookie-consent-notice.tsx
@@ -23,9 +23,10 @@ const GDPRCookieConsentNotice = ( { siteId, isOdysseyStats }: StatsNoticeProps )
 	);
 
 	const dismissNotice = () => {
-		isOdysseyStats
-			? recordTracksEvent( 'jetpack_odyssey_stats_gdpr_cookie_consent_notice_dismissed' )
-			: recordTracksEvent( 'calypso_stats_gdpr_cookie_consent_notice_dismissed' );
+		const event = isOdysseyStats
+			? 'jetpack_odyssey_stats_gdpr_cookie_consent_notice_dismissed'
+			: 'calypso_stats_gdpr_cookie_consent_notice_dismissed';
+		recordTracksEvent( event, { blog_id: siteId } );
 
 		setNoticeDismissed( true );
 		postponeNoticeAsync();

--- a/client/my-sites/stats/stats-notices/tier-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/tier-upgrade-notice.tsx
@@ -24,9 +24,10 @@ const TierUpgradeNotice = ( { siteId, isOdysseyStats, isOverLimit }: StatsNotice
 	);
 
 	const dismissNotice = () => {
-		isOdysseyStats
-			? recordTracksEvent( 'jetpack_odyssey_stats_tier_upgrade_notice_dismissed' )
-			: recordTracksEvent( 'calypso_stats_tier_upgrade_notice_dismissed' );
+		const event = isOdysseyStats
+			? 'jetpack_odyssey_stats_tier_upgrade_notice_dismissed'
+			: 'calypso_stats_tier_upgrade_notice_dismissed';
+		recordTracksEvent( event, { blog_id: siteId } );
 
 		setNoticeDismissed( true );
 		postponeNoticeAsync();

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -205,6 +205,7 @@ class StatsPeriodNavigation extends PureComponent {
 		recordTracksEvent( `${ event_from }_stats_date_range_navigation`, {
 			range_in_days: dateRange.daysInRange,
 			direction: previousOrNext ? 'previous' : 'next',
+			blog_id: this.props.siteId,
 		} );
 
 		const navigationStart = momentSiteZone( dateRange.chartStart );

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -307,7 +307,9 @@ class StatsPeriodNavigation extends PureComponent {
 			return;
 		}
 
-		events.forEach( ( event ) => recordTracksEvent( event.name, event.params ) );
+		events.forEach( ( event ) =>
+			recordTracksEvent( event.name, { blog_id: this.props.siteId, ...event.params } )
+		);
 		this.props.toggleUpsellModal( this.props.siteId, statType );
 	};
 

--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -4,6 +4,8 @@ import { useEffect } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { EXTENSION_THRESHOLD_IN_MILLION } from 'calypso/my-sites/stats/hooks/use-available-upgrade-tiers';
 import TierUpgradeSlider from 'calypso/my-sites/stats/stats-purchase/tier-upgrade-slider';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { StatsPlanTierUI } from '../types';
 
 import './styles.scss';
@@ -79,6 +81,7 @@ function StatsCommercialUpgradeSlider( {
 }: StatsCommercialUpgradeSliderProps ) {
 	const translate = useTranslate();
 	const uiStrings = useTranslatedStrings();
+	const siteId = useSelector( getSelectedSiteId );
 
 	// TODO: Guard against bad data.
 	// The code below assumes we have a valid tier listing with at least one item.
@@ -127,6 +130,7 @@ function StatsCommercialUpgradeSlider( {
 			recordTracksEvent( analyticsEventName, {
 				tier_views: quantity,
 				default_changed: index !== 0, // 0 is the default initialVlaue value for <TierUpgradeSlider />
+				blog_id: siteId,
 			} );
 		}
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -208,11 +208,14 @@ const gotoCheckoutPage = ( {
 	}
 
 	// Keeping the event for data continuity
-	recordTracksEvent( `calypso_stats_${ eventName }_purchase_button_clicked` );
+	recordTracksEvent( `calypso_stats_${ eventName }_purchase_button_clicked`, {
+		blog_id: siteId,
+	} );
 	// Add parameters to the event
 	trackStatsAnalyticsEvent( 'stats_purchase_button_clicked', {
 		type,
 		quantity,
+		blog_id: siteId,
 	} );
 
 	const redirectUrl = getRedirectUrl( { type, adminUrl, redirectUri, siteSlug } );

--- a/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
@@ -16,15 +16,20 @@ import './styles.scss';
 const getStatsPurchaseURL = ( siteId, productType = 'commercial' ) =>
 	`/stats/purchase/${ siteId }?productType=${ productType }`;
 
-const handleUpgradeClick = ( event, upgradeUrl, isOdysseyStats ) => {
+const handleUpgradeClick = ( event, upgradeUrl, isOdysseyStats, siteId ) => {
 	event.preventDefault();
 
 	isOdysseyStats
-		? recordTracksEvent( 'jetpack_odyssey_stats_purchase_summary_screen_upgrade_clicked' )
-		: recordTracksEvent( 'calypso_stats_purchase_summary_screen_upgrade_clicked' );
+		? recordTracksEvent( 'jetpack_odyssey_stats_purchase_summary_screen_upgrade_clicked', {
+				blog_id: siteId,
+		  } )
+		: recordTracksEvent( 'calypso_stats_purchase_summary_screen_upgrade_clicked', {
+				blog_id: siteId,
+		  } );
 
 	trackStatsAnalyticsEvent( 'stats_upgrade_clicked', {
 		type: 'summary-screen',
+		blog_id: siteId,
 	} );
 
 	setTimeout( () => page( upgradeUrl ), 250 );
@@ -94,7 +99,12 @@ const StatsPWYWOwnedNotice = ( { siteId, siteSlug } ) => {
 			<Button
 				variant="primary"
 				onClick={ ( e ) =>
-					handleUpgradeClick( e, getStatsPurchaseURL( siteId, 'commercial' ), isOdysseyStats )
+					handleUpgradeClick(
+						e,
+						getStatsPurchaseURL( siteId, 'commercial' ),
+						isOdysseyStats,
+						siteId
+					)
 				}
 			>
 				{ translate( 'Upgrade my Stats' ) }
@@ -136,7 +146,7 @@ const StatsFreeOwnedNotice = ( { siteId, siteSlug } ) => {
 			<Button
 				variant="primary"
 				onClick={ ( e ) =>
-					handleUpgradeClick( e, getStatsPurchaseURL( siteId, 'personal' ), isOdysseyStats )
+					handleUpgradeClick( e, getStatsPurchaseURL( siteId, 'personal' ), isOdysseyStats, siteId )
 				}
 			>
 				{ translate( 'Upgrade my Stats' ) }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -87,7 +87,9 @@ const PersonalPurchase = ( {
 
 	const handleCheckoutPostponed = () => {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-		recordTracksEvent( `${ event_from }_stats_purchase_flow_skip_button_clicked` );
+		recordTracksEvent( `${ event_from }_stats_purchase_flow_skip_button_clicked`, {
+			blog_id: siteId,
+		} );
 
 		// redirect to the Traffic page
 		setTimeout( () => {

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -281,7 +281,9 @@ const StatsCommercialPurchase = ( {
 
 	const handleCheckoutPostponed = () => {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-		recordTracksEvent( `${ event_from }_stats_purchase_commercial_skip_button_clicked` );
+		recordTracksEvent( `${ event_from }_stats_purchase_commercial_skip_button_clicked`, {
+			blog_id: siteId,
+		} );
 
 		setTimeout( () => {
 			page( `/stats/day/${ siteSlug }` );
@@ -408,7 +410,9 @@ const StatsPersonalPurchase = ( {
 		e.preventDefault();
 		const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-		recordTracksEvent( `${ event_from }_stats_plan_switched_from_personal_to_commercial` );
+		recordTracksEvent( `${ event_from }_stats_plan_switched_from_personal_to_commercial`, {
+			blog_id: siteId,
+		} );
 
 		page( `/stats/purchase/${ siteSlug }?productType=commercial&from=switch-from-personal` );
 	};
@@ -565,7 +569,9 @@ function StatsCommercialFlowOptOutForm( {
 
 	const handleSwitchToPersonalClick = () => {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-		recordTracksEvent( `${ event_from }_stats_purchase_commercial_switch_to_personal_clicked` );
+		recordTracksEvent( `${ event_from }_stats_purchase_commercial_switch_to_personal_clicked`, {
+			blog_id: siteId,
+		} );
 		setTimeout(
 			() =>
 				page( `/stats/purchase/${ siteSlug }?productType=personal&from=switch-from-commercial` ),
@@ -575,7 +581,9 @@ function StatsCommercialFlowOptOutForm( {
 
 	const handleRequestUpdateClick = () => {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-		recordTracksEvent( `${ event_from }_stats_purchase_commercial_update_classification_clicked` );
+		recordTracksEvent( `${ event_from }_stats_purchase_commercial_update_classification_clicked`, {
+			blog_id: siteId,
+		} );
 
 		// For Jetpack sites, open the Jetpack support form. Do not prefill.
 		if ( isJetpackSupport ) {

--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -3,6 +3,8 @@ import { useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import TierUpgradeSlider from 'calypso/my-sites/stats/stats-purchase/tier-upgrade-slider';
 import { StatsPWYWSliderSettings } from 'calypso/my-sites/stats/stats-purchase/types';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './styles.scss';
 
 function useTranslatedStrings( defaultAveragePayment: number, currencyCode: string ) {
@@ -93,6 +95,7 @@ function StatsPWYWUpgradeSlider( {
 	// TODO: Figure out how to get the actual average payment from the API in the future.
 	const defaultAveragePayment = defaultStartingValue * settings.sliderStepPrice;
 	const uiStrings = useTranslatedStrings( defaultAveragePayment, currencyCode );
+	const siteId = useSelector( getSelectedSiteId );
 
 	// New steps generation.
 	const tiers = generatePlanTiers( settings );
@@ -111,6 +114,7 @@ function StatsPWYWUpgradeSlider( {
 			recordTracksEvent( analyticsEventName, {
 				step: mappedIndex,
 				default_changed: mappedIndex !== mappedDefaultIndex,
+				blog_id: siteId,
 			} );
 		}
 		onSliderChange( mappedIndex );

--- a/client/my-sites/stats/stats-upsell-modal/index.tsx
+++ b/client/my-sites/stats/stats-upsell-modal/index.tsx
@@ -50,7 +50,7 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 		closeModal();
 		recordTracksEvent( `${ eventPrefix }_stats_upsell_modal_submit`, {
 			stat_type: statType,
-			blog_id: selectedSiteId,
+			blog_id: siteId,
 		} );
 		const checkoutProductUrl = new URL(
 			`https://wordpress.com/checkout/${ siteSlug }/${ planSlug }`
@@ -65,7 +65,7 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 				eventName={ `${ eventPrefix }_stats_upsell_modal_view` }
 				eventProperties={ {
 					stat_type: statType,
-					blog_id: selectedSiteId,
+					blog_id: siteId,
 				} }
 			/>
 			<Button

--- a/client/my-sites/stats/stats-upsell-modal/index.tsx
+++ b/client/my-sites/stats/stats-upsell-modal/index.tsx
@@ -50,6 +50,7 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 		closeModal();
 		recordTracksEvent( `${ eventPrefix }_stats_upsell_modal_submit`, {
 			stat_type: statType,
+			blog_id: selectedSiteId,
 		} );
 		const checkoutProductUrl = new URL(
 			`https://wordpress.com/checkout/${ siteSlug }/${ planSlug }`
@@ -64,6 +65,7 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 				eventName={ `${ eventPrefix }_stats_upsell_modal_view` }
 				eventProperties={ {
 					stat_type: statType,
+					blog_id: selectedSiteId,
 				} }
 			/>
 			<Button

--- a/client/my-sites/stats/stats-upsell/index.tsx
+++ b/client/my-sites/stats/stats-upsell/index.tsx
@@ -67,6 +67,7 @@ export default function StatsUpsell( {
 		event.preventDefault();
 		recordTracksEvent( `${ eventPrefix }_stats_upsell_submit`, {
 			stat_type: statType,
+			blog_id: selectedSiteId,
 		} );
 		if ( isOdysseyStats ) {
 			const checkoutProductUrl = new URL(
@@ -85,6 +86,7 @@ export default function StatsUpsell( {
 			if ( ! isExpanded ) {
 				recordTracksEvent( `${ eventPrefix }_stats_upsell_expand`, {
 					stat_type: statType,
+					blog_id: selectedSiteId,
 				} );
 			}
 			setIsExpanded( ! isExpanded );
@@ -113,6 +115,7 @@ export default function StatsUpsell( {
 
 		recordTracksEvent( `${ eventPrefix }_stats_upsell_learn_more`, {
 			stat_type: statType,
+			blog_id: selectedSiteId,
 		} );
 	};
 
@@ -122,6 +125,7 @@ export default function StatsUpsell( {
 				eventName={ `${ eventPrefix }_stats_upsell_view` }
 				eventProperties={ {
 					stat_type: statType,
+					blog_id: selectedSiteId,
 				} }
 			/>
 			<div className="stats-upsell__content">


### PR DESCRIPTION
Fixes STATS-421

Follow-up: STATS-423 (register the affected events in Tracks with owners and descriptions, and run the STATS-421 verification query — `blog_id_pct` ≥ 95 — after deploy).

## Why
Stats upsell impression events were not carrying the blog_id parameter, which prevented them from being tied to specific sites for impact measurement. Without blog_id, it's impossible to measure impression-to-purchase conversion and determine if upsells are reaching the right audience.

## Changes
Added blog_id parameter to all stats-related tracking events:
- Upsell impression events (stats_card_upsell_view)
- Notice viewed, dismissed, and CTA/support click events (commercial/free site upgrade, do you love stats, GDPR, tier upgrade, free plan purchase success)
- Upsell page and modal events (stats_upsell_*, stats_upsell_modal_*)
- Purchase flow events (checkout redirect, personal/commercial flows, purchase notices, upgrade sliders)
- Date control events (date picker opened, date range applied, shortcuts) — including gated clicks via the onGatedHandler implementations
- Date range navigation and chart type selection events
- Feedback panel, card, and modal events
- Locations, posts, devices, and UTM module events
- Promo card and mini-carousel view/click/dismiss events
- UTM builder and empty-state action events

Mini-carousel and promo-card view events keep the pre-existing `site_id` key alongside the new `blog_id` for data continuity. The purchase-page upgrade-source attribution event now waits for a resolved site ID and fires at most once.

Deliberately left alone: `calypso_jetpack_module_toggle` — its schema is shared with non-stats producers (site-settings) that also omit blog_id; changing only the stats emitters would fragment the event.

## Testing
- Verified all tracking calls now include blog_id parameter
- Confirmed code follows existing patterns in the stats module
- All formatting and linting issues resolved
