### PR TITLE
Fix site-scoped JWT reuse in Agents Manager

### DIFF
--- a/packages/agents-manager/src/auth/__tests__/calypso-auth-provider.test.ts
+++ b/packages/agents-manager/src/auth/__tests__/calypso-auth-provider.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/order -- jest.mock calls must precede imports */
+jest.mock( '@automattic/oauth-token', () => ( {
+	getToken: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( 'wpcom-proxy-request', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+	canAccessWpcomApis: jest.fn( () => false ),
+} ) );
+
+import apiFetch from '@wordpress/api-fetch';
+import { createCalypsoAuthProvider } from '../calypso-auth-provider';
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+describe( 'createCalypsoAuthProvider', () => {
+	beforeEach( () => {
+		sessionStorage.clear();
+		mockApiFetch.mockReset();
+	} );
+
+	it( 'does not reuse a cached site-scoped JWT for a different site', async () => {
+		mockApiFetch
+			.mockResolvedValueOnce( { token: 'site-123-token', blog_id: '123' } )
+			.mockResolvedValueOnce( { token: 'site-456-token', blog_id: '456' } );
+
+		const firstHeaders = await createCalypsoAuthProvider( 123 )();
+		const secondHeaders = await createCalypsoAuthProvider( 456 )();
+
+		expect( firstHeaders.Authorization ).toBe( 'site-123-token' );
+		expect( secondHeaders.Authorization ).toBe( 'site-456-token' );
+		expect( mockApiFetch ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'reuses a cached site-scoped JWT for the same site', async () => {
+		mockApiFetch.mockResolvedValueOnce( { token: 'site-123-token', blog_id: 123 } );
+
+		const firstHeaders = await createCalypsoAuthProvider( 123 )();
+		const secondHeaders = await createCalypsoAuthProvider( '123' )();
+
+		expect( firstHeaders.Authorization ).toBe( 'site-123-token' );
+		expect( secondHeaders.Authorization ).toBe( 'site-123-token' );
+		expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'reuses a legacy cached JWT with a numeric blog ID for the same site', async () => {
+		sessionStorage.setItem(
+			'jetpack-ai-jwt-token',
+			JSON.stringify( {
+				token: 'legacy-site-123-token',
+				blogId: 123,
+				expire: Date.now() + 60_000,
+			} )
+		);
+
+		const headers = await createCalypsoAuthProvider( '123' )();
+
+		expect( headers.Authorization ).toBe( 'legacy-site-123-token' );
+		expect( mockApiFetch ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/agents-manager/src/auth/calypso-auth-provider.ts
+++ b/packages/agents-manager/src/auth/calypso-auth-provider.ts
@@ -86,19 +86,23 @@ async function requestJWTToken(
 	siteId?: string | number,
 	useCachedToken = true
 ): Promise< TokenData | null > {
+	// Use provided siteId or fallback to window
+	const effectiveSiteId = siteId || window.Jetpack_Editor_Initial_State?.wpcomBlogId;
+
 	// Check for cached token
 	if ( useCachedToken ) {
 		const cached = getCachedJwtToken( JWT_TOKEN_ID );
-		if ( cached ) {
+		if (
+			cached &&
+			( ! effectiveSiteId || String( effectiveSiteId ) === String( cached.blogId ) )
+		) {
 			return cached;
 		}
 	}
 
 	const apiNonce = window.JP_CONNECTION_INITIAL_STATE?.apiNonce;
-	// Use provided siteId or fallback to window
-	const effectiveSiteId = siteId || window.Jetpack_Editor_Initial_State?.wpcomBlogId;
 
-	let data: { token: string; blog_id: string } = {
+	let data: { token: string; blog_id: string | number } = {
 		token: '',
 		blog_id: '',
 	};
@@ -106,14 +110,14 @@ async function requestJWTToken(
 	try {
 		if ( canAccessWpcomApis() ) {
 			// WordPress.com simple site — use /ai/jwt (supports user-only and site-scoped tokens)
-			data = await apiFetch< { token: string; blog_id: string } >( {
+			data = await apiFetch< { token: string; blog_id: string | number } >( {
 				path: '/wpcom/v2/ai/jwt',
 				method: 'POST',
 				data: effectiveSiteId ? { blog_id: Number( effectiveSiteId ) } : {},
 			} );
 		} else {
 			// Jetpack-connected site
-			data = await apiFetch< { token: string; blog_id: string } >( {
+			data = await apiFetch< { token: string; blog_id: string | number } >( {
 				path: '/jetpack/v4/jetpack-ai-jwt?_cacheBuster=' + Date.now(),
 				credentials: 'same-origin',
 				headers: {
@@ -132,7 +136,7 @@ async function requestJWTToken(
 
 	const newTokenData: TokenData = {
 		token: data.token,
-		blogId: data.blog_id || '',
+		blogId: data.blog_id ? String( data.blog_id ) : '',
 		expire: Date.now() + JWT_TOKEN_EXPIRATION_TIME,
 	};
 


### PR DESCRIPTION
## Proposed Changes

* Check the cached wp-admin JWT against the effective site ID before reusing it.
* Normalize returned and legacy cached blog IDs so numeric and string site IDs compare consistently.
* Add regression tests for different-site, same-site, and legacy numeric cache entries.

## Why are these changes being made?

Agents Manager stores wp-admin JWTs under one session key. When the effective site changed, the provider could reuse a valid token scoped to the previous site. The unified Agent endpoint now validates its authenticated site context, so the client must fetch a token for the requested site instead of sending a stale site-scoped token.

## Testing Instructions

* Run `yarn test-packages packages/agents-manager/src/auth/__tests__/calypso-auth-provider.test.ts --runInBand`.
  * Expected: 3 tests pass.
* Run `yarn prettier --check packages/agents-manager/src/auth/calypso-auth-provider.ts packages/agents-manager/src/auth/__tests__/calypso-auth-provider.test.ts`.
  * Expected: both files pass.
* Run `ESLINT_USE_FLAT_CONFIG=false yarn eslint packages/agents-manager/src/auth/calypso-auth-provider.ts packages/agents-manager/src/auth/__tests__/calypso-auth-provider.test.ts`.
  * Expected: 0 errors. The existing JSDoc warning in `calypso-auth-provider.ts` remains.
* Run `yarn tsc --noEmit --project packages/agents-manager/tsconfig.json`.
  * The package still reports the existing unrelated `stores.ts` and `stores.test.ts` errors; this change adds no new type errors.
* In one browser session, request an Agent token for site A, then request one for site B.
  * Expected: site B causes a new JWT request instead of reusing site A's token.
* Request another token for site B.
  * Expected: the matching cached token is reused.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?