### PR TITLE
Dashboard: add outgoing email block notice to site overview

### DIFF
--- a/client/dashboard/sites/overview/email-block-notice.tsx
+++ b/client/dashboard/sites/overview/email-block-notice.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useEffect, useRef } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { useHelpCenter } from '../../app/help-center';
 import Notice from '../../components/notice';
@@ -16,6 +17,19 @@ export function getEmailBlock( site: Site ): AtomicEmailBlock | null {
 export function EmailBlockNotice( { site }: { site: Site } ) {
 	const { recordTracksEvent } = useAnalytics();
 	const { setOpenOdieWithContext } = useHelpCenter();
+	const hasRecordedImpression = useRef( false );
+
+	// The arbiter only renders the winning candidate, so this counts notices
+	// actually shown, not sites eligible to show one.
+	useEffect( () => {
+		if ( hasRecordedImpression.current ) {
+			return;
+		}
+		hasRecordedImpression.current = true;
+		recordTracksEvent( 'calypso_dashboard_email_block_notice_impression', {
+			site_id: site.ID,
+		} );
+	}, [ recordTracksEvent, site.ID ] );
 
 	const handleContactClick = () => {
 		recordTracksEvent( 'calypso_dashboard_email_block_notice_contact_click', {

--- a/client/dashboard/sites/overview/email-block-notice.tsx
+++ b/client/dashboard/sites/overview/email-block-notice.tsx
@@ -1,0 +1,47 @@
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useAnalytics } from '../../app/analytics';
+import { useHelpCenter } from '../../app/help-center';
+import Notice from '../../components/notice';
+import type { AtomicEmailBlock, Site } from '@automattic/api-core';
+
+/**
+ * The site's outgoing email block, or `null` when the site can send. Read at
+ * the call site so the notice never decides its own visibility.
+ */
+export function getEmailBlock( site: Site ): AtomicEmailBlock | null {
+	return site.atomic_email_block?.status === 'blocked' ? site.atomic_email_block : null;
+}
+
+export function EmailBlockNotice( { site }: { site: Site } ) {
+	const { recordTracksEvent } = useAnalytics();
+	const { setOpenOdieWithContext } = useHelpCenter();
+
+	const handleContactClick = () => {
+		recordTracksEvent( 'calypso_dashboard_email_block_notice_contact_click', {
+			site_id: site.ID,
+		} );
+		setOpenOdieWithContext( {
+			initialMessage: __( 'Outgoing email from my site is blocked.' ),
+			section: 'site-overview',
+			siteUrl: site.URL,
+			siteId: site.ID,
+		} );
+	};
+
+	return (
+		<Notice
+			variant="error"
+			title={ __( 'Your site can’t send email' ) }
+			actions={
+				<Button variant="primary" onClick={ handleContactClick }>
+					{ __( 'Contact us' ) }
+				</Button>
+			}
+		>
+			{ __(
+				'Outgoing email from this site is blocked, so contact form messages, order confirmations, and password resets aren’t reaching their recipients. Contact us to get sending restored.'
+			) }
+		</Notice>
+	);
+}

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -39,6 +39,7 @@ import VisibilityCard from '../overview-visibility-card';
 import VisibilityCardCiab from '../overview-visibility-card-ciab';
 import { InaccessibleJetpackNotice } from '../site/notices';
 import StagingSiteSyncDropdown from '../staging-site-sync-dropdown';
+import { EmailBlockNotice, getEmailBlock } from './email-block-notice';
 import { StorageWarningBanner, useShouldShowStorageWarningBanner } from './storage-warning-banner';
 import type { Site } from '@automattic/api-core';
 import './style.scss';
@@ -260,6 +261,7 @@ function SiteOverview( {
 						<InaccessibleJetpackNotice error={ site.__inaccessible_jetpack_error } />
 					) }
 					{ isStorageWarningVisible && <StorageWarningBanner site={ site } /> }
+					{ !! getEmailBlock( site ) && <EmailBlockNotice site={ site } /> }
 				</SitesNoticeArbiter>
 			}
 		>

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -260,8 +260,8 @@ function SiteOverview( {
 					{ site.__inaccessible_jetpack_error && (
 						<InaccessibleJetpackNotice error={ site.__inaccessible_jetpack_error } />
 					) }
-					{ isStorageWarningVisible && <StorageWarningBanner site={ site } /> }
 					{ !! getEmailBlock( site ) && <EmailBlockNotice site={ site } /> }
+					{ isStorageWarningVisible && <StorageWarningBanner site={ site } /> }
 				</SitesNoticeArbiter>
 			}
 		>

--- a/client/dashboard/sites/overview/test/email-block-notice.tsx
+++ b/client/dashboard/sites/overview/test/email-block-notice.tsx
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import { render } from '../../../test-utils';
+import { EmailBlockNotice, getEmailBlock } from '../email-block-notice';
+import type { Site } from '@automattic/api-core';
+
+function createSite( atomic_email_block: Site[ 'atomic_email_block' ] ) {
+	// Only the fields the notice actually reads.
+	return { ID: 123, URL: 'https://example.wordpress.com', atomic_email_block } as unknown as Site;
+}
+
+describe( 'getEmailBlock', () => {
+	test( 'returns null when the field is absent or null', () => {
+		expect( getEmailBlock( createSite( undefined ) ) ).toBeNull();
+		expect( getEmailBlock( createSite( null ) ) ).toBeNull();
+	} );
+
+	test( 'returns the block when the site is blocked', () => {
+		const block = {
+			status: 'blocked' as const,
+			reason: 'Too many bounces, sender blocked',
+			expires_on: '2026-09-01 00:00:00',
+		};
+		expect( getEmailBlock( createSite( block ) ) ).toEqual( block );
+	} );
+} );
+
+test( 'renders a non-dismissible error notice with a contact action', () => {
+	render(
+		<EmailBlockNotice
+			site={ createSite( {
+				status: 'blocked',
+				reason: 'Too many bounces, sender blocked',
+				expires_on: '2026-09-01 00:00:00',
+			} ) }
+		/>
+	);
+
+	expect( screen.getByText( 'Your site can’t send email' ) ).toBeVisible();
+	expect( screen.getByRole( 'button', { name: 'Contact us' } ) ).toBeVisible();
+	expect( screen.queryByRole( 'button', { name: 'Dismiss' } ) ).not.toBeInTheDocument();
+} );

--- a/client/dashboard/sites/overview/test/email-block-notice.tsx
+++ b/client/dashboard/sites/overview/test/email-block-notice.tsx
@@ -27,16 +27,24 @@ describe( 'getEmailBlock', () => {
 	} );
 } );
 
-test( 'renders a non-dismissible error notice with a contact action', () => {
-	render(
-		<EmailBlockNotice
-			site={ createSite( {
-				status: 'blocked',
-				reason: 'Too many bounces, sender blocked',
-				expires_on: '2026-09-01 00:00:00',
-			} ) }
-		/>
+const blockedSite = createSite( {
+	status: 'blocked',
+	reason: 'Too many bounces, sender blocked',
+	expires_on: '2026-09-01 00:00:00',
+} );
+
+test( 'records one impression when the notice is shown', () => {
+	const { recordTracksEvent } = render( <EmailBlockNotice site={ blockedSite } /> );
+
+	expect( recordTracksEvent ).toHaveBeenCalledTimes( 1 );
+	expect( recordTracksEvent ).toHaveBeenCalledWith(
+		'calypso_dashboard_email_block_notice_impression',
+		{ site_id: 123 }
 	);
+} );
+
+test( 'renders a non-dismissible error notice with a contact action', () => {
+	render( <EmailBlockNotice site={ blockedSite } /> );
 
 	expect( screen.getByText( 'Your site can’t send email' ) ).toBeVisible();
 	expect( screen.getByRole( 'button', { name: 'Contact us' } ) ).toBeVisible();

--- a/packages/api-core/src/site/fetchers.ts
+++ b/packages/api-core/src/site/fetchers.ts
@@ -42,6 +42,7 @@ export const SITE_FIELDS = [
 	'garden_partner',
 	'garden_is_provisioned',
 	'big_sky_enabled',
+	'atomic_email_block',
 ];
 
 export const JOINED_SITE_FIELDS = SITE_FIELDS.join( ',' );

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -60,6 +60,18 @@ export interface SiteOptions {
 	import_engine?: string | null;
 }
 
+/**
+ * Outgoing email block on a WordPress.com on Atomic site, as reported by the
+ * site endpoint. `null`/absent means the site can send. `status` is always
+ * `blocked` today; the field exists so an at-risk state can be added later
+ * without changing the shape.
+ */
+export interface AtomicEmailBlock {
+	status: 'blocked';
+	reason: string;
+	expires_on: string;
+}
+
 export interface Site {
 	ID: number;
 	slug: string;
@@ -107,6 +119,7 @@ export interface Site {
 	garden_is_provisioned: boolean | null;
 	/** Present when requested via SITE_FIELDS; indicates Big Sky / AI builder availability. */
 	big_sky_enabled?: boolean;
+	atomic_email_block?: AtomicEmailBlock | null;
 
 	// Injected local properties
 	__inaccessible_jetpack_error?: Error;


### PR DESCRIPTION
Part of DOTDEV-294

<img width="1226" height="452" alt="Captura de Tela 2026-08-10 às 17 00 53" src="https://github.com/user-attachments/assets/d40557c7-da38-40b1-9a90-117164f9fdc2" />

## Proposed Changes

* Show a red, non-dismissible notice on a site's overview when that site is blocked from sending outgoing email. Its action opens the Help Center, since restoring sending needs support.

Inert until the backend ships the `atomic_email_block` field (`Automattic/wpcom` 232553 and 232840, `Automattic/jetpack#51038`).

## Why are these changes being made?

When WP Cloud blocks a WoA site from sending mail, contact form messages, WooCommerce order emails, and password resets stop being delivered. Around 2,900 WoW sites are blocked at any moment, and owners usually find out from a customer.

A notification email does exist, but it goes to one recipient (the blog owner), at most once per 30 days, and can be dropped silently. There is no second signal anywhere in the product today.

Overview rather than the Emails section: the block is site-scoped, while Emails manages mailboxes on domains, which keep working normally while a site is blocked.

DOTDEV-294 also asks for a warning *before* the block. Not included here; that signal is still being worked out with the mail team.

## Testing Instructions

The field is not live yet, so stub it: in `packages/api-core/src/site/fetchers.ts`, have `fetchSite` merge `atomic_email_block: { status: 'blocked', reason: 'Too many bounces, sender blocked', expires_on: '2026-09-01 00:00:00' }` into the response before returning.

1. `yarn start-dashboard`, then visit `/sites/<your-site>`. A red "Your site can't send email" notice should appear.
2. "Contact us" opens the Help Center with the site context prefilled.
3. There is no dismiss button, and the notice survives a reload.
4. Remove the stub: the notice goes, and any other overview notice takes the slot again. Revert the change.

## Notes for review

* Non-dismissible per the MSD critical-notice guideline, so on a blocked site it holds the overview's only notice slot indefinitely. Dismissible-with-return is a small follow-up if that trade is wrong.
* It sits above the storage banner, so it outranks a storage *error* too. Both are non-dismissible errors, so whichever loses the slot is suppressed for as long as it lasts; happy to swap if out-of-storage should win that tie.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

