### PR TITLE
Signup form: put the email-only screen's terms under its one action

### DIFF
--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -253,10 +253,13 @@ const SignupFormSocialFirst = ( {
 				<div className={ clsx( 'signup-form-social-first-screen', 'visible' ) }>
 					{ notice }
 					<div className="signup-form-social-first-email">
-						<PasswordlessSignupForm
-							{ ...passwordlessFormProps }
-							renderTerms={ renderEmailStepTermsOfService }
-						/>
+						{ /* Placed here rather than handed to the form, which puts terms wherever its
+						     footer isn't — a rule about a button, not about the copy. Partner copy
+						     points at the options below it; the generic names the button, so it
+						     belongs under it. */ }
+						{ customTosElement && renderEmailStepTermsOfService() }
+						<PasswordlessSignupForm { ...passwordlessFormProps } />
+						{ ! customTosElement && renderEmailStepTermsOfService() }
 					</div>
 				</div>
 			</div>

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -231,6 +231,24 @@ describe( 'SignupFormSocialFirst', () => {
 			expect( screen.getByRole( 'textbox' ) ).toBeVisible();
 		} );
 
+		// The generic terms name the button, so they read correctly under it — and moving them there
+		// must not take the partner's copy, which points at what follows it.
+		it( 'puts the generic terms under the action, and a partner its own above', () => {
+			renderUpdating();
+			const generic = screen.getByRole( 'button', { name: 'Continue' } );
+			expect( generic.compareDocumentPosition( screen.getByText( /agree to our/ ) ) ).toBe(
+				Node.DOCUMENT_POSITION_FOLLOWING
+			);
+
+			renderUpdating( { customTosElement: <span>Partner terms apply.</span> } );
+			const partner = screen.getAllByText( 'Partner terms apply.' )[ 0 ];
+			expect(
+				partner.compareDocumentPosition(
+					screen.getAllByRole( 'button', { name: 'Continue' } )[ 1 ]
+				)
+			).toBe( Node.DOCUMENT_POSITION_FOLLOWING );
+		} );
+
 		it( 'says it is updating, not signing up, while the request is in flight', async () => {
 			renderUpdating( {
 				onUpdateEmail: () => new Promise< void >( () => {} ),


### PR DESCRIPTION
## Proposed Changes

* The email-only signup screen places its own terms, so they sit under Continue rather than above it.

## Why are these changes being made?

`PasswordlessSignupForm` renders terms after its footer when it is given a secondary action, and before it otherwise. That is a rule about a button rather than about the copy, and the email-only screen — added for the onboarding email verification gate — has no secondary action, so its terms render above Continue. Everywhere else the same screen shows them below it, because "See all options" happens to be there.

Rather than tell the form where to put them, the screen places them. The generic copy names the button — "By clicking Continue, you agree to…" — so it reads correctly underneath it. A partner's own copy points at the options below it, so that stays above. The form is untouched, so no caller that doesn't ask for this mode can be affected, including the Gravatar signup form, which is the one other caller that supplies terms and relies on the current order.

Only reachable through the onboarding email verification gate, which is behind a feature flag that is off everywhere.

## Testing Instructions

1. Run Calypso locally and open `/setup/onboarding?flags=onboarding/email-verification`.
2. Create an account with any address, then press `edit` on the verification screen.
3. The account screen should read: field, Continue, then the terms.
4. Open `/setup/onboarding` normally. The account screen should be unchanged — social buttons, and terms in their usual place.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
