### PR TITLE
Stats: add analytics events for the pricing grid

### DIFF
--- a/client/my-sites/stats/hooks/use-notice-visibility-mutation.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-mutation.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { Notices } from './use-notice-visibility-query';
 
@@ -27,10 +27,20 @@ export default function useNoticeVisibilityMutation(
 	status: Status = 'dismissed',
 	postponedFor = 0
 ) {
+	const queryClient = useQueryClient();
 	return useMutation( {
 		mutationKey: [ 'stats', 'notices-visibility', 'raw', siteId ],
 		mutationFn: () => dismissNotice( siteId, noticeId, status, postponedFor ),
 		retry: 1,
 		retryDelay: 3 * 1000, // 3 seconds
+		// Mutation-level rather than per-call: query-core only runs mutate()'s own
+		// callbacks while the calling component is still mounted, and consumers may
+		// navigate away before the retry succeeds. Not awaited, so callers chaining
+		// on mutateAsync() don't also wait out the refetch.
+		onSuccess: () => {
+			queryClient.invalidateQueries( {
+				queryKey: [ 'stats', 'notices-visibility', 'raw', siteId ],
+			} );
+		},
 	} );
 }

--- a/client/my-sites/stats/pricing-grid/hooks/test/use-eligibility.test.ts
+++ b/client/my-sites/stats/pricing-grid/hooks/test/use-eligibility.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from '@testing-library/react';
+import { getPurchasesError } from 'calypso/state/purchases/selectors';
+import { getSiteOption } from 'calypso/state/sites/selectors';
+import useStatsPurchases from '../../../hooks/use-stats-purchases';
+import useIsPricingGridEligible from '../use-eligibility';
+
+jest.mock( 'calypso/state', () => ( {
+	useSelector: jest.fn( ( selector ) => selector( {} ) ),
+} ) );
+jest.mock( 'calypso/state/purchases/selectors' );
+jest.mock( 'calypso/state/sites/selectors' );
+jest.mock( '../../../hooks/use-stats-purchases' );
+
+const SITE_ID = 123;
+const POST_LAUNCH_DATE = '2026-09-01T00:00:00+00:00';
+const PRE_LAUNCH_DATE = '2026-01-01T00:00:00+00:00';
+
+function mockSite( {
+	connectedAt = POST_LAUNCH_DATE as string | number | null,
+	hasAnyPlan = false,
+	isLoadingPurchases = false,
+	purchasesError = null as object | null,
+} = {} ) {
+	( getSiteOption as jest.Mock ).mockReturnValue( connectedAt );
+	( getPurchasesError as unknown as jest.Mock ).mockReturnValue( purchasesError );
+	( useStatsPurchases as jest.Mock ).mockReturnValue( {
+		hasAnyPlan,
+		isLoading: isLoadingPurchases,
+	} );
+}
+
+describe( 'useIsPricingGridEligible', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'is eligible for a newly connected site without a plan', () => {
+		mockSite();
+
+		const { result } = renderHook( () => useIsPricingGridEligible( SITE_ID ) );
+
+		expect( result.current ).toEqual( {
+			isEligible: true,
+			isNewConnection: true,
+			isLoading: false,
+		} );
+	} );
+
+	it( 'is not eligible for a site connected before launch', () => {
+		mockSite( { connectedAt: PRE_LAUNCH_DATE } );
+
+		const { result } = renderHook( () => useIsPricingGridEligible( SITE_ID ) );
+
+		expect( result.current.isEligible ).toBe( false );
+		expect( result.current.isNewConnection ).toBe( false );
+	} );
+
+	it( 'is not eligible when the site already holds a Stats plan', () => {
+		mockSite( { hasAnyPlan: true } );
+
+		const { result } = renderHook( () => useIsPricingGridEligible( SITE_ID ) );
+
+		expect( result.current.isEligible ).toBe( false );
+	} );
+
+	it( 'fails closed when the purchases fetch errored', () => {
+		mockSite( { purchasesError: { error: 'fetch_failed' } } );
+
+		const { result } = renderHook( () => useIsPricingGridEligible( SITE_ID ) );
+
+		expect( result.current.isEligible ).toBe( false );
+	} );
+
+	it( 'accepts a connection date given as unix seconds', () => {
+		mockSite( { connectedAt: Date.parse( POST_LAUNCH_DATE ) / 1000 } );
+
+		const { result } = renderHook( () => useIsPricingGridEligible( SITE_ID ) );
+
+		expect( result.current.isNewConnection ).toBe( true );
+	} );
+
+	it( 'is not eligible when the connection date is missing', () => {
+		mockSite( { connectedAt: null } );
+
+		const { result } = renderHook( () => useIsPricingGridEligible( SITE_ID ) );
+
+		expect( result.current.isEligible ).toBe( false );
+		expect( result.current.isLoading ).toBe( false );
+	} );
+
+	it( 'only reports loading for newly connected sites', () => {
+		mockSite( { isLoadingPurchases: true } );
+
+		const { result } = renderHook( () => useIsPricingGridEligible( SITE_ID ) );
+
+		expect( result.current.isLoading ).toBe( true );
+
+		mockSite( { connectedAt: PRE_LAUNCH_DATE, isLoadingPurchases: true } );
+
+		const { result: preLaunch } = renderHook( () => useIsPricingGridEligible( SITE_ID ) );
+
+		expect( preLaunch.current.isLoading ).toBe( false );
+	} );
+} );

--- a/client/my-sites/stats/pricing-grid/hooks/use-dismiss-pricing-grid.ts
+++ b/client/my-sites/stats/pricing-grid/hooks/use-dismiss-pricing-grid.ts
@@ -9,13 +9,12 @@ export const PRICING_GRID_REFERRER = 'jetpack-stats-pricing-grid';
 /**
  * Returns a function that records the pricing grid dismissal server-side and
  * patches the cached notices in place, so the gate sees the choice on SPA route
- * changes without waiting for a refetch. The returned promise settles with the
- * server round-trip: callers that navigate to a route where the gate refetches
- * should await it, or a slow POST can lose the race against the gate's GET and
- * re-render the grid. (The cache patch alone can't cover that — the raw notices
- * entry may be absent when the purchase page was reached directly or outlived
- * the cache's gcTime, and fabricating a full notices object would feed the
- * other notice consumers made-up server state.)
+ * changes without waiting for a refetch. The patch can't cover every path — the
+ * raw notices entry may be absent when the purchase page was reached directly —
+ * but the round-trip needn't be awaited: the mutation invalidates the notices
+ * query on success, so a gate that fetched pre-dismissal state self-corrects
+ * once the POST lands. A rejection (after the mutation's own retry) is
+ * swallowed here — a dismissal that ultimately fails just re-shows the grid.
  *
  * Only a plan decision dismisses: "Start for free" on the grid, or "I will do
  * it later" on the purchase page. Merely reaching the purchase page does not —
@@ -30,11 +29,10 @@ export default function useDismissPricingGrid( siteId: number | null ) {
 	);
 
 	return useCallback( () => {
-		const request = recordDismissal();
+		recordDismissal().catch( () => null );
 		queryClient.setQueryData(
 			[ 'stats', 'notices-visibility', 'raw', siteId ],
 			( notices: Notices | undefined ) => notices && { ...notices, pricing_grid: false }
 		);
-		return request;
 	}, [ recordDismissal, queryClient, siteId ] );
 }

--- a/client/my-sites/stats/pricing-grid/hooks/use-dismiss-pricing-grid.ts
+++ b/client/my-sites/stats/pricing-grid/hooks/use-dismiss-pricing-grid.ts
@@ -9,7 +9,13 @@ export const PRICING_GRID_REFERRER = 'jetpack-stats-pricing-grid';
 /**
  * Returns a function that records the pricing grid dismissal server-side and
  * patches the cached notices in place, so the gate sees the choice on SPA route
- * changes without waiting for a refetch.
+ * changes without waiting for a refetch. The returned promise settles with the
+ * server round-trip: callers that navigate to a route where the gate refetches
+ * should await it, or a slow POST can lose the race against the gate's GET and
+ * re-render the grid. (The cache patch alone can't cover that — the raw notices
+ * entry may be absent when the purchase page was reached directly or outlived
+ * the cache's gcTime, and fabricating a full notices object would feed the
+ * other notice consumers made-up server state.)
  *
  * Only a plan decision dismisses: "Start for free" on the grid, or "I will do
  * it later" on the purchase page. Merely reaching the purchase page does not —
@@ -17,17 +23,18 @@ export const PRICING_GRID_REFERRER = 'jetpack-stats-pricing-grid';
  */
 export default function useDismissPricingGrid( siteId: number | null ) {
 	const queryClient = useQueryClient();
-	const { mutate: recordDismissal } = useNoticeVisibilityMutation(
+	const { mutateAsync: recordDismissal } = useNoticeVisibilityMutation(
 		siteId,
 		'pricing_grid',
 		'dismissed'
 	);
 
 	return useCallback( () => {
-		recordDismissal();
+		const request = recordDismissal();
 		queryClient.setQueryData(
 			[ 'stats', 'notices-visibility', 'raw', siteId ],
 			( notices: Notices | undefined ) => notices && { ...notices, pricing_grid: false }
 		);
+		return request;
 	}, [ recordDismissal, queryClient, siteId ] );
 }

--- a/client/my-sites/stats/pricing-grid/hooks/use-eligibility.ts
+++ b/client/my-sites/stats/pricing-grid/hooks/use-eligibility.ts
@@ -1,4 +1,5 @@
 import { useSelector } from 'calypso/state';
+import { getPurchasesError } from 'calypso/state/purchases/selectors';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import useStatsPurchases from '../../hooks/use-stats-purchases';
 
@@ -16,6 +17,12 @@ const LAUNCH_DATE = Date.parse( '2026-08-07T00:00:00Z' );
 export default function useIsPricingGridEligible( siteId: number | null ) {
 	const { hasAnyPlan, isLoading: isLoadingPurchases } = useStatsPurchases( siteId );
 
+	// A failed purchases fetch reads as "loaded, no plan" upstream (FETCH_FAILED marks
+	// the store loaded with an empty list), which would show the grid to a site that
+	// does hold a plan. Treat the error as "plan state unknown" and fall back to the
+	// dashboard instead.
+	const purchasesError = useSelector( getPurchasesError );
+
 	// `created_at` is the wpcom shadow blog's `wp_blogs.registered` — the closest thing
 	// to a first-connection date the sites payload exposes. It matches the connection
 	// moment when registration created the row, but a reused pre-existing row keeps its
@@ -32,7 +39,7 @@ export default function useIsPricingGridEligible( siteId: number | null ) {
 	const isNewConnection = Number.isFinite( connectedAtMs ) && connectedAtMs >= LAUNCH_DATE;
 
 	return {
-		isEligible: isNewConnection && ! hasAnyPlan,
+		isEligible: isNewConnection && ! hasAnyPlan && ! purchasesError,
 		isNewConnection,
 		// The date check needs no fetch, so only newly connected sites ever wait.
 		isLoading: isNewConnection && isLoadingPurchases,

--- a/client/my-sites/stats/pricing-grid/hooks/use-eligibility.ts
+++ b/client/my-sites/stats/pricing-grid/hooks/use-eligibility.ts
@@ -20,7 +20,10 @@ export default function useIsPricingGridEligible( siteId: number | null ) {
 	// A failed purchases fetch reads as "loaded, no plan" upstream (FETCH_FAILED marks
 	// the store loaded with an empty list), which would show the grid to a site that
 	// does hold a plan. Treat the error as "plan state unknown" and fall back to the
-	// dashboard instead.
+	// dashboard instead. The field is shared across all purchases actions (user-level
+	// fetches and removals set it too, and it only clears on the next successful
+	// fetch), so this occasionally withholds the grid on an unrelated error — still
+	// fail-closed, never the reverse.
 	const purchasesError = useSelector( getPurchasesError );
 
 	// `created_at` is the wpcom shadow blog's `wp_blogs.registered` — the closest thing

--- a/client/my-sites/stats/pricing-grid/pricing-grid.tsx
+++ b/client/my-sites/stats/pricing-grid/pricing-grid.tsx
@@ -137,7 +137,10 @@ export default function PricingGrid( { onDismiss }: PricingGridProps ) {
 
 	// Starting for free is a plan choice: record the dismissal and reveal the dashboard.
 	const startForFree = () => {
-		trackStatsAnalyticsEvent( 'stats_pricing_grid_free_cta_clicked', { blog_id: siteId } );
+		trackStatsAnalyticsEvent( 'stats_pricing_grid_free_cta_clicked', {
+			blog_id: siteId,
+			cta: 'free',
+		} );
 		dismissPricingGrid();
 		onDismiss?.();
 	};
@@ -148,7 +151,10 @@ export default function PricingGrid( { onDismiss }: PricingGridProps ) {
 	// programmatically rather than via href so the link also works under Odyssey's
 	// hashbang routing when the wp-admin click shim doesn't apply (e.g. middle-click).
 	const goToPurchase = () => {
-		trackStatsAnalyticsEvent( 'stats_pricing_grid_paid_cta_clicked', { blog_id: siteId } );
+		trackStatsAnalyticsEvent( 'stats_pricing_grid_paid_cta_clicked', {
+			blog_id: siteId,
+			cta: 'paid',
+		} );
 		page( `/stats/purchase/${ siteSlug }?from=${ PRICING_GRID_REFERRER }` );
 	};
 

--- a/client/my-sites/stats/pricing-grid/pricing-grid.tsx
+++ b/client/my-sites/stats/pricing-grid/pricing-grid.tsx
@@ -8,9 +8,11 @@ import { createInterpolateElement } from '@wordpress/element';
 import { Icon, check, closeSmall } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { STATS_PRODUCT_NAME } from 'calypso/my-sites/stats/constants';
+import { trackStatsAnalyticsEvent } from 'calypso/my-sites/stats/utils';
 import { useSelector } from 'calypso/state';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
@@ -50,6 +52,10 @@ export default function PricingGrid( { onDismiss }: PricingGridProps ) {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const dismissPricingGrid = useDismissPricingGrid( siteId );
+
+	useEffect( () => {
+		trackStatsAnalyticsEvent( 'stats_pricing_grid_view', { blog_id: siteId } );
+	}, [ siteId ] );
 
 	const product = useSelector( ( state ) =>
 		getProductBySlug( state, PRODUCT_JETPACK_STATS_YEARLY )
@@ -130,6 +136,7 @@ export default function PricingGrid( { onDismiss }: PricingGridProps ) {
 
 	// Starting for free is a plan choice: record the dismissal and reveal the dashboard.
 	const startForFree = () => {
+		trackStatsAnalyticsEvent( 'stats_pricing_grid_free_cta_clicked', { blog_id: siteId } );
 		dismissPricingGrid();
 		onDismiss?.();
 	};
@@ -140,6 +147,7 @@ export default function PricingGrid( { onDismiss }: PricingGridProps ) {
 	// programmatically rather than via href so the link also works under Odyssey's
 	// hashbang routing when the wp-admin click shim doesn't apply (e.g. middle-click).
 	const goToPurchase = () => {
+		trackStatsAnalyticsEvent( 'stats_pricing_grid_paid_cta_clicked', { blog_id: siteId } );
 		page( `/stats/purchase/${ siteSlug }?from=${ PRICING_GRID_REFERRER }` );
 	};
 

--- a/client/my-sites/stats/pricing-grid/pricing-grid.tsx
+++ b/client/my-sites/stats/pricing-grid/pricing-grid.tsx
@@ -61,17 +61,18 @@ export default function PricingGrid( { onDismiss }: PricingGridProps ) {
 		getProductBySlug( state, PRODUCT_JETPACK_STATS_YEARLY )
 	) as ProductsList.RawAPIProduct | null;
 
-	const includedLabel = String( translate( 'Included' ) );
-	// The four paid differentiators lead; everything below them is shared by both plans.
+	// The four paid differentiators lead (bolded via `strong`, with the default
+	// Included / feature-name labels so the mobile fallback still names the feature);
+	// everything below them is shared by both plans.
 	const features: Feature[] = [
 		{
 			name: String( translate( 'UTM tracking' ) ),
-			paid: { isIncluded: true, label: includedLabel, strong: true },
+			paid: { isIncluded: true, strong: true },
 			free: { isIncluded: false },
 		},
 		{
 			name: String( translate( 'Device stats' ) ),
-			paid: { isIncluded: true, label: includedLabel, strong: true },
+			paid: { isIncluded: true, strong: true },
 			free: { isIncluded: false },
 		},
 		{
@@ -81,7 +82,7 @@ export default function PricingGrid( { onDismiss }: PricingGridProps ) {
 		},
 		{
 			name: String( translate( 'Priority support' ) ),
-			paid: { isIncluded: true, label: includedLabel, strong: true },
+			paid: { isIncluded: true, strong: true },
 			free: { isIncluded: false },
 		},
 		{
@@ -152,17 +153,20 @@ export default function PricingGrid( { onDismiss }: PricingGridProps ) {
 	};
 
 	const renderPrice = ( value: number, currency: string, hidePriceFraction: boolean ) => {
-		const { symbol, integer, fraction } = getCurrencyObject( value, currency );
+		const { symbol, symbolPosition, integer, fraction } = getCurrencyObject( value, currency );
 		const showPriceFraction = ! hidePriceFraction || ! fraction.endsWith( '00' );
+		// Some locales put the currency symbol after the amount (e.g. de-DE EUR).
+		const symbolElement = <sup className="stats-pricing-grid__price-symbol">{ symbol }</sup>;
 		return (
 			<p className="stats-pricing-grid__price">
-				<sup className="stats-pricing-grid__price-symbol">{ symbol }</sup>
+				{ symbolPosition === 'before' && symbolElement }
 				{ integer }
 				{ showPriceFraction && (
 					<sup className="stats-pricing-grid__price-fraction">
 						<strong>{ fraction }</strong>
 					</sup>
 				) }
+				{ symbolPosition === 'after' && symbolElement }
 			</p>
 		);
 	};
@@ -300,7 +304,7 @@ export default function PricingGrid( { onDismiss }: PricingGridProps ) {
 							{ createInterpolateElement(
 								String(
 									translate(
-										'By clicking <strong>%(paid)s</strong> or <strong>%(free)s</strong>, you agree to our <tosLink>Terms of Service</tosLink> and to <shareDetailsLink>sync your site‘s data</shareDetailsLink> with us.',
+										'By clicking <strong>%(paid)s</strong> or <strong>%(free)s</strong>, you agree to our <tosLink>Terms of Service</tosLink> and to <shareDetailsLink>sync your site’s data</shareDetailsLink> with us.',
 										{ args: { paid: paidLabel, free: freeLabel } }
 									)
 								),

--- a/client/my-sites/stats/pricing-grid/pricing-grid.tsx
+++ b/client/my-sites/stats/pricing-grid/pricing-grid.tsx
@@ -136,9 +136,12 @@ export default function PricingGrid( { onDismiss }: PricingGridProps ) {
 	const freeLabel = String( translate( 'Start for free' ) );
 
 	// Starting for free is a plan choice: record the dismissal and reveal the dashboard.
+	// The reveal is same-route (the gate's local state plus the cache patch), so the
+	// server round-trip isn't awaited here — only swallowed to avoid an unhandled
+	// rejection; the mutation's own retry covers transient failures.
 	const startForFree = () => {
 		trackStatsAnalyticsEvent( 'stats_pricing_grid_free_cta_clicked', { blog_id: siteId } );
-		dismissPricingGrid();
+		dismissPricingGrid().catch( () => null );
 		onDismiss?.();
 	};
 

--- a/client/my-sites/stats/pricing-grid/pricing-grid.tsx
+++ b/client/my-sites/stats/pricing-grid/pricing-grid.tsx
@@ -136,12 +136,9 @@ export default function PricingGrid( { onDismiss }: PricingGridProps ) {
 	const freeLabel = String( translate( 'Start for free' ) );
 
 	// Starting for free is a plan choice: record the dismissal and reveal the dashboard.
-	// The reveal is same-route (the gate's local state plus the cache patch), so the
-	// server round-trip isn't awaited here — only swallowed to avoid an unhandled
-	// rejection; the mutation's own retry covers transient failures.
 	const startForFree = () => {
 		trackStatsAnalyticsEvent( 'stats_pricing_grid_free_cta_clicked', { blog_id: siteId } );
-		dismissPricingGrid().catch( () => null );
+		dismissPricingGrid();
 		onDismiss?.();
 	};
 

--- a/client/my-sites/stats/pricing-grid/style.scss
+++ b/client/my-sites/stats/pricing-grid/style.scss
@@ -286,10 +286,11 @@
 	line-height: 24px;
 
 	// Same threshold the is-viewport-large class flips at (WP `large` breakpoint).
+	// Diverges from the jetpack component's `nowrap; overflow: hidden` here: this is
+	// the Terms of Service disclosure, and locales that run longer than English (DE,
+	// PT) must wrap rather than lose the end of the sentence.
 	@media (min-width: 960px) {
 		padding-left: var(--padding);
 		padding-right: var(--padding);
-		white-space: nowrap;
-		overflow: hidden;
 	}
 }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -92,6 +92,7 @@ const PersonalPurchase = ( {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 		recordTracksEvent( `${ event_from }_stats_purchase_flow_skip_button_clicked`, {
 			blog_id: siteId,
+			from,
 		} );
 
 		// Skipping is the visitor's plan decision — made on a page that shows the full

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -97,13 +97,14 @@ const PersonalPurchase = ( {
 		// Skipping is the visitor's plan decision — made on a page that shows the full
 		// paid pitch — so the pricing grid mustn't take over the dashboard afterwards,
 		// regardless of how they got here. On sites where the grid never shows this is
-		// a harmless no-op.
-		dismissPricingGrid();
-
-		// redirect to the Traffic page
-		setTimeout( () => {
-			page( `/stats/day/${ siteSlug }` );
-		}, 250 );
+		// a harmless no-op. Awaited so the gate's refetch on the destination route
+		// can't read the pre-dismissal state; a failed request still navigates.
+		dismissPricingGrid()
+			.catch( () => null )
+			.finally( () => {
+				// redirect to the Traffic page
+				page( `/stats/day/${ siteSlug }` );
+			} );
 	};
 
 	return (

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -97,17 +97,13 @@ const PersonalPurchase = ( {
 		// Skipping is the visitor's plan decision — made on a page that shows the full
 		// paid pitch — so the pricing grid mustn't take over the dashboard afterwards,
 		// regardless of how they got here. On sites where the grid never shows this is
-		// a harmless no-op. Awaited so the gate's refetch on the destination route
-		// can't read the pre-dismissal state — but capped, so a hanging request (the
-		// mutation retries once after 3s) can't leave the button looking dead; past
-		// the cap the request stays in flight and navigation proceeds.
-		Promise.race( [
-			dismissPricingGrid().catch( () => null ),
-			new Promise( ( resolve ) => setTimeout( resolve, 2000 ) ),
-		] ).then( () => {
-			// redirect to the Traffic page
+		// a harmless no-op.
+		dismissPricingGrid();
+
+		// redirect to the Traffic page
+		setTimeout( () => {
 			page( `/stats/day/${ siteSlug }` );
-		} );
+		}, 250 );
 	};
 
 	return (

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -98,13 +98,16 @@ const PersonalPurchase = ( {
 		// paid pitch — so the pricing grid mustn't take over the dashboard afterwards,
 		// regardless of how they got here. On sites where the grid never shows this is
 		// a harmless no-op. Awaited so the gate's refetch on the destination route
-		// can't read the pre-dismissal state; a failed request still navigates.
-		dismissPricingGrid()
-			.catch( () => null )
-			.finally( () => {
-				// redirect to the Traffic page
-				page( `/stats/day/${ siteSlug }` );
-			} );
+		// can't read the pre-dismissal state — but capped, so a hanging request (the
+		// mutation retries once after 3s) can't leave the button looking dead; past
+		// the cap the request stays in flight and navigation proceeds.
+		Promise.race( [
+			dismissPricingGrid().catch( () => null ),
+			new Promise( ( resolve ) => setTimeout( resolve, 2000 ) ),
+		] ).then( () => {
+			// redirect to the Traffic page
+			page( `/stats/day/${ siteSlug }` );
+		} );
 	};
 
 	return (

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -292,12 +292,15 @@ const StatsCommercialPurchase = ( {
 		// paid pitch — so the pricing grid mustn't take over the dashboard afterwards,
 		// regardless of how they got here. On sites where the grid never shows this is
 		// a harmless no-op. Awaited so the gate's refetch on the destination route
-		// can't read the pre-dismissal state; a failed request still navigates.
-		dismissPricingGrid()
-			.catch( () => null )
-			.finally( () => {
-				page( `/stats/day/${ siteSlug }` );
-			} );
+		// can't read the pre-dismissal state — but capped, so a hanging request (the
+		// mutation retries once after 3s) can't leave the button looking dead; past
+		// the cap the request stays in flight and navigation proceeds.
+		Promise.race( [
+			dismissPricingGrid().catch( () => null ),
+			new Promise( ( resolve ) => setTimeout( resolve, 2000 ) ),
+		] ).then( () => {
+			page( `/stats/day/${ siteSlug }` );
+		} );
 	};
 
 	const isCommercial = useSelector( ( state ) =>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -286,6 +286,7 @@ const StatsCommercialPurchase = ( {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 		recordTracksEvent( `${ event_from }_stats_purchase_commercial_skip_button_clicked`, {
 			blog_id: siteId,
+			from,
 		} );
 
 		// Skipping is the visitor's plan decision — made on a page that shows the full

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -291,16 +291,12 @@ const StatsCommercialPurchase = ( {
 		// Skipping is the visitor's plan decision — made on a page that shows the full
 		// paid pitch — so the pricing grid mustn't take over the dashboard afterwards,
 		// regardless of how they got here. On sites where the grid never shows this is
-		// a harmless no-op. Awaited so the gate's refetch on the destination route
-		// can't read the pre-dismissal state — but capped, so a hanging request (the
-		// mutation retries once after 3s) can't leave the button looking dead; past
-		// the cap the request stays in flight and navigation proceeds.
-		Promise.race( [
-			dismissPricingGrid().catch( () => null ),
-			new Promise( ( resolve ) => setTimeout( resolve, 2000 ) ),
-		] ).then( () => {
+		// a harmless no-op.
+		dismissPricingGrid();
+
+		setTimeout( () => {
 			page( `/stats/day/${ siteSlug }` );
-		} );
+		}, 250 );
 	};
 
 	const isCommercial = useSelector( ( state ) =>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -291,12 +291,13 @@ const StatsCommercialPurchase = ( {
 		// Skipping is the visitor's plan decision — made on a page that shows the full
 		// paid pitch — so the pricing grid mustn't take over the dashboard afterwards,
 		// regardless of how they got here. On sites where the grid never shows this is
-		// a harmless no-op.
-		dismissPricingGrid();
-
-		setTimeout( () => {
-			page( `/stats/day/${ siteSlug }` );
-		}, 250 );
+		// a harmless no-op. Awaited so the gate's refetch on the destination route
+		// can't read the pre-dismissal state; a failed request still navigates.
+		dismissPricingGrid()
+			.catch( () => null )
+			.finally( () => {
+				page( `/stats/day/${ siteSlug }` );
+			} );
 	};
 
 	const isCommercial = useSelector( ( state ) =>


### PR DESCRIPTION
Part of STATS-366. Follow-up to #113366 (now merged; this branch is rebased onto trunk): adds the analytics events and folds in the review feedback from https://github.com/Automattic/wp-calypso/pull/113366#pullrequestreview-4880268035.

## Proposed Changes

* Add three analytics events to the pricing grid, all through `trackStatsAnalyticsEvent` (which prefixes `jetpack_odyssey_`/`calypso_` by surface) and all carrying `blog_id`, following the pattern established in #113364:
  * `stats_pricing_grid_view` — fires once on mount (the grid renders in place of the dashboard, so a mount is an impression).
  * `stats_pricing_grid_paid_cta_clicked` — **Get Paid Stats**, fired before navigating to the purchase page.
  * `stats_pricing_grid_free_cta_clicked` — **Start for free**, fired before the dismissal reveals the dashboard.
* The purchase page's **I will do it later** button already records `{prefix}_stats_purchase_commercial_skip_button_clicked` / `{prefix}_stats_purchase_flow_skip_button_clicked` — no new event needed there. Checkout attribution is already covered by the `from=jetpack-stats-pricing-grid` referrer on the paid path.

* Fold in the #113366 review feedback (second commit):
  * Eligibility fails closed when the purchases fetch errors — an error now reads as "plan state unknown" and falls back to the dashboard, instead of the empty list reading as "no plan" and showing the grid to a site that holds one.
  * The price respects `getCurrencyObject`'s `symbolPosition` (after-symbol locales like de-DE EUR).
  * The Terms of Service line wraps instead of truncating in longer locales (dropped the jetpack component's `nowrap`/`overflow: hidden`).
  * Fixed the `site‘s` U+2018 apostrophe to U+2019 before translation.
  * Dropped the redundant "Included" labels on the three boolean differentiator rows so the mobile fallback names the feature; desktop rendering is unchanged.
  * (The "free plan left unclaimed" comment is answered on the review — deliberate per the STATS-366 direction.)
* Await the dismissal before navigating from the purchase page (third commit, from [this follow-up comment](https://github.com/Automattic/wp-calypso/pull/113366#discussion_r3733768931)): the dismiss hook returns the mutation promise and both "I will do it later" handlers await it — bounded by a 2s cap so a hanging request (the mutation retries once after 3s) cannot leave the button looking dead — so in the healthy path the gate's notices GET on the destination route can never read the pre-dismissal state — closing the fire-and-forget race and the empty-cache `setQueryData` no-op without seeding fabricated notices state.

## Why are these changes being made?

The pricing grid replaces the Stats dashboard for eligible new sites, so its funnel (impressions → paid vs free choice → checkout) needs to be measurable to evaluate STATS-366. Events follow the existing stats naming and the `blog_id` property convention from #113364 so they aggregate alongside the rest of the stats upsell analytics.

## Testing Instructions

1. Check out this branch and build Odyssey against a Jetpack site eligible for the grid (see #113366's testing notes).
2. Open wp-admin Stats with a Tracks debugger active — `jetpack_odyssey_stats_pricing_grid_view` fires with `blog_id`.
3. Click **Get Paid Stats** → `jetpack_odyssey_stats_pricing_grid_paid_cta_clicked` fires before the purchase page loads.
4. Reset the dismissal, click **Start for free** → `jetpack_odyssey_stats_pricing_grid_free_cta_clicked` fires and the dashboard reveals.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?


