### PR TITLE
Dashboard: remove the Themes item from the sidebar navigation

### DIFF
--- a/client/dashboard/app-a4a/index.tsx
+++ b/client/dashboard/app-a4a/index.tsx
@@ -35,7 +35,6 @@ boot( {
 		sites: false,
 		domains: false,
 		emails: false,
-		themes: false,
 		reader: false,
 		help: true,
 		notifications: false,

--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -30,7 +30,6 @@ boot( {
 		sites: true,
 		domains: true,
 		emails: true,
-		themes: false,
 		reader: false,
 		help: true,
 		notifications: false,

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -27,7 +27,6 @@ boot( {
 		sites: true,
 		domains: true,
 		emails: true,
-		themes: true,
 		reader: true,
 		help: true,
 		notifications: true,

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -60,7 +60,6 @@ export type AppConfig = {
 		plugins: boolean;
 		domains: boolean;
 		emails: boolean;
-		themes: boolean;
 		reader: boolean;
 		help: boolean;
 		notifications: boolean;
@@ -108,7 +107,6 @@ export const APP_CONTEXT_DEFAULT_CONFIG: AppConfig = {
 		plugins: false,
 		domains: false,
 		emails: false,
-		themes: false,
 		reader: false,
 		help: false,
 		notifications: false,

--- a/client/dashboard/app/responsive-sidebar/sidebar.tsx
+++ b/client/dashboard/app/responsive-sidebar/sidebar.tsx
@@ -1,5 +1,5 @@
 import { __, sprintf } from '@wordpress/i18n';
-import { brush, envelope, globe, layout, plugins } from '@wordpress/icons';
+import { envelope, globe, layout, plugins } from '@wordpress/icons';
 import { useRef } from 'react';
 import ReferralSidebar from '../../agency/earn/referrals/referral-sidebar';
 import AgencySiteSidebar from '../../agency/sites/site-sidebar';
@@ -97,11 +97,6 @@ function PrimaryMenuSidebar() {
 						{ __( 'Browse plugins' ) }
 					</SidebarMenuItem>
 				</SidebarExpandableMenuItem>
-			) }
-			{ supports.themes && (
-				<SidebarMenuItem icon={ brush } href={ wpcomLink( '/themes' ) }>
-					{ __( 'Themes' ) }
-				</SidebarMenuItem>
 			) }
 		</SidebarMenu>
 	);


### PR DESCRIPTION
Part of DOTMSD-1488

## Proposed Changes

* Remove the Themes item from the dashboard's primary sidebar navigation.
* Drop the `supports.themes` app config flag, which nothing reads once the item is gone.

## Why are these changes being made?

Themes was the only primary sidebar item that sent people out of the dashboard entirely — it was an external link to the classic Themes page, opening in a new tab, rather than a route within the dashboard. That made it an odd fit next to Sites, Domains, Emails, and Plugins, which all navigate in place.

Nothing else in the dashboard referenced Themes: there was no route, screen, command palette entry, or breadcrumb behind it, so removing the menu item removes the whole feature surface. The flag that gated it was only ever consulted for this one item, so it went too rather than being left as dead config.

Themes remains reachable at its existing location; only the dashboard sidebar shortcut is gone.

## Testing Instructions

* Open the dashboard and check the primary (root) sidebar: Sites, Domains, Emails, and Plugins are present, and Themes is gone.
* Expand Plugins and confirm its sub-items, including the external "Browse plugins" link, still work — that link shares the helper the removed item used.
* Confirm the Agency and Client dashboard variants are unchanged (they never showed Themes).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
