### PR TITLE
A4A: Add the adaptive growth section to the Overview

### DIFF
--- a/client/a8c-for-agencies/sections/overview/dashboard-overview-body/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/dashboard-overview-body/index.tsx
@@ -7,6 +7,7 @@ import {
 	A4A_MARKETPLACE_PRODUCTS_LINK,
 	A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
 	A4A_REFERRALS_DASHBOARD,
+	A4A_SITES_LINK,
 	A4A_WOOPAYMENTS_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useScheduleCall from 'calypso/a8c-for-agencies/hooks/use-schedule-call';
@@ -52,6 +53,7 @@ export default function DashboardOverviewBody() {
 			hasPartnerDirectoryListing={ hasPartnerDirectoryListing }
 			links={ {
 				tiers: A4A_AGENCY_TIER_LINK,
+				sites: A4A_SITES_LINK,
 				referrals: A4A_REFERRALS_DASHBOARD,
 				woopayments: A4A_WOOPAYMENTS_LINK,
 				marketplace: A4A_MARKETPLACE_PRODUCTS_LINK,

--- a/client/a8c-for-agencies/sections/overview/dashboard-overview-body/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/dashboard-overview-body/index.tsx
@@ -4,6 +4,8 @@ import { CONTACT_URL_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/components/a
 import { ONBOARDING_TOUR_HASH } from 'calypso/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour';
 import {
 	A4A_AGENCY_TIER_LINK,
+	A4A_MARKETPLACE_PRODUCTS_LINK,
+	A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
 	A4A_REFERRALS_DASHBOARD,
 	A4A_WOOPAYMENTS_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
@@ -18,6 +20,10 @@ export default function DashboardOverviewBody() {
 	const dispatch = useDispatch();
 	const agency = useSelector( getActiveAgency );
 	const approvalStatus = agency?.approval_status;
+	const hasPartnerDirectoryListing =
+		!! agency?.profile?.partner_directory_application?.directories.some(
+			( { status } ) => status === 'approved'
+		);
 
 	const { scheduleCall, isLoading: isSchedulingCall } = useScheduleCall();
 
@@ -43,10 +49,13 @@ export default function DashboardOverviewBody() {
 			influencedRevenue={ agency.influenced_revenue ?? 0 }
 			approvalStatus={ approvalStatus }
 			capabilities={ agency.user?.capabilities }
+			hasPartnerDirectoryListing={ hasPartnerDirectoryListing }
 			links={ {
 				tiers: A4A_AGENCY_TIER_LINK,
 				referrals: A4A_REFERRALS_DASHBOARD,
 				woopayments: A4A_WOOPAYMENTS_LINK,
+				marketplace: A4A_MARKETPLACE_PRODUCTS_LINK,
+				partnerDirectory: A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
 				contactSupport: CONTACT_URL_HASH_FRAGMENT,
 				helpful: [
 					{

--- a/client/dashboard/agency/overview/growth-card.tsx
+++ b/client/dashboard/agency/overview/growth-card.tsx
@@ -25,11 +25,21 @@ import OverviewLinkButton from './overview-link-button';
 import useWooPaymentsStoreCount from './use-woopayments-store-count';
 import type { AgencyOverviewLinks } from './overview-content';
 import type { AgencyTierType, RecordTracksEvent } from '../tiers/types';
+import type { AgencyCapability } from '@automattic/api-core';
 
 type GrowthCardLinks = Pick<
 	AgencyOverviewLinks,
 	'tiers' | 'sites' | 'referrals' | 'woopayments' | 'marketplace' | 'partnerDirectory'
 >;
+
+// The marketplace destination differs per host (products on the classic app,
+// exclusive offers on the dashboard), so either capability unlocks those rows.
+// TODO: drop 'a4a_read_exclusive_offers' once the MSD dashboard has a real
+// marketplace screen and its overview links there instead of exclusive offers.
+const MARKETPLACE_CAPABILITIES: AgencyCapability[] = [
+	'a4a_read_marketplace',
+	'a4a_read_exclusive_offers',
+];
 
 interface GrowthItem {
 	id: string;
@@ -39,6 +49,8 @@ interface GrowthItem {
 	actionLabel: string;
 	href: string;
 	isExternal?: boolean;
+	/** Capabilities that can act on the row (any of them); rows without one are visible to everyone. */
+	requiredCapability?: AgencyCapability | AgencyCapability[];
 }
 
 interface GrowthContent {
@@ -53,6 +65,8 @@ interface GrowthCardProps {
 	isPending?: boolean;
 	/** Disables the WooPayments store lookup for users without earnings access. */
 	canAccessEarnings?: boolean;
+	/** The current user's agency capabilities; rows the user can't act on are hidden. */
+	capabilities?: string[];
 	/** Swaps Premier’s “get listed” move for moving more sites once the agency has an approved listing. */
 	hasPartnerDirectoryListing?: boolean;
 	tierId?: AgencyTierType;
@@ -86,6 +100,7 @@ function getGrowRevenueItem(
 		),
 		actionLabel: __( 'Review' ),
 		href: links.tiers,
+		requiredCapability: 'a4a_read_agency_tier',
 	};
 }
 
@@ -109,6 +124,7 @@ function getPendingContent( links: GrowthCardLinks ): GrowthContent {
 				description: __( 'Browse 60+ products you’ll be able to resell' ),
 				actionLabel: __( 'Explore' ),
 				href: links.marketplace,
+				requiredCapability: MARKETPLACE_CAPABILITIES,
 			},
 		],
 	};
@@ -128,18 +144,20 @@ function getEmergingContent( links: GrowthCardLinks ): GrowthContent {
 			{
 				id: 'refer-hosting',
 				icon: globe,
-				title: __( 'Refer a client' ),
-				description: __( 'Their spend counts toward IAR · you earn 20% recurring' ),
+				title: __( 'Refer sites' ),
+				description: __( 'Client spend counts toward IAR · you earn 20% recurring' ),
 				actionLabel: __( 'Refer' ),
 				href: links.referrals,
+				requiredCapability: 'a4a_read_referrals',
 			},
 			{
-				id: 'recommend-plan',
+				id: 'refer-products',
 				icon: currencyDollar,
-				title: __( 'Recommend a plan' ),
+				title: __( 'Refer products' ),
 				description: __( 'Counts toward IAR · 50% recurring on renewals' ),
-				actionLabel: __( 'Recommend' ),
+				actionLabel: __( 'Refer' ),
 				href: links.marketplace,
+				requiredCapability: MARKETPLACE_CAPABILITIES,
 			},
 			{
 				id: 'browse-marketplace',
@@ -148,6 +166,7 @@ function getEmergingContent( links: GrowthCardLinks ): GrowthContent {
 				description: __( '60+ products at up to 80% off — purchases count toward IAR' ),
 				actionLabel: __( 'Browse' ),
 				href: links.marketplace,
+				requiredCapability: MARKETPLACE_CAPABILITIES,
 			},
 		],
 	};
@@ -170,25 +189,28 @@ function getAgencyContent( links: GrowthCardLinks ): GrowthContent {
 				id: 'refer-hosting',
 				icon: globe,
 				title: __( 'Refer more sites' ),
-				description: __( 'Their spend counts toward IAR · you earn 20% recurring' ),
+				description: __( 'Client spend counts toward IAR · you earn 20% recurring' ),
 				actionLabel: __( 'Refer' ),
 				href: links.referrals,
+				requiredCapability: 'a4a_read_referrals',
 			},
 			{
 				id: 'set-up-woopayments',
 				icon: currencyDollar,
-				title: __( 'Set up WooPayments' ),
+				title: __( 'Set up WooPayments for clients' ),
 				description: __( '$1 of IAR for every $100 in sales · earn 0.05% TPV' ),
 				actionLabel: __( 'Set up' ),
 				href: links.woopayments,
+				requiredCapability: 'a4a_read_referrals',
 			},
 			{
-				id: 'recommend-plan',
+				id: 'refer-products',
 				icon: store,
-				title: __( 'Recommend plans' ),
+				title: __( 'Refer products' ),
 				description: __( 'Counts toward IAR · 50% recurring on renewals' ),
-				actionLabel: __( 'Recommend' ),
+				actionLabel: __( 'Refer' ),
 				href: links.marketplace,
+				requiredCapability: MARKETPLACE_CAPABILITIES,
 			},
 		],
 	};
@@ -211,10 +233,11 @@ function getProContent(
 		wooPaymentsItem = {
 			id: 'set-up-woopayments',
 			icon: payment,
-			title: __( 'Set up WooPayments' ),
+			title: __( 'Set up WooPayments for clients' ),
 			description: __( '$1 of IAR for every $100 in sales · earn 0.05% TPV' ),
 			actionLabel: __( 'Set up' ),
 			href: links.woopayments,
+			requiredCapability: 'a4a_read_referrals',
 		};
 	}
 
@@ -265,6 +288,7 @@ function getPremierContent(
 						description: __( '20% recurring on every renewal · grows IAR' ),
 						actionLabel: __( 'Review sites' ),
 						href: links.sites,
+						requiredCapability: 'a4a_read_managed_sites',
 				  }
 				: {
 						id: 'partner-directory',
@@ -275,6 +299,7 @@ function getPremierContent(
 						),
 						actionLabel: __( 'Set up listing' ),
 						href: links.partnerDirectory,
+						requiredCapability: 'a4a_read_partner_directory',
 				  },
 			{
 				id: 'set-up-woopayments',
@@ -283,6 +308,7 @@ function getPremierContent(
 				description: __( '$1 IAR per $100 in sales' ),
 				actionLabel: __( 'Set up' ),
 				href: links.woopayments,
+				requiredCapability: 'a4a_read_referrals',
 			},
 			{
 				id: 'marketing-development-funds',
@@ -351,6 +377,7 @@ export default function GrowthCard( {
 	agencyId,
 	isPending,
 	canAccessEarnings = true,
+	capabilities,
 	hasPartnerDirectoryListing,
 	tierId,
 	influencedRevenue,
@@ -382,12 +409,28 @@ export default function GrowthCard( {
 		hasPartnerDirectoryListing
 	);
 
+	// Rows the user can't act on would only bounce off the route guards.
+	const canActOn = ( item: GrowthItem ) => {
+		if ( ! item.requiredCapability || ! capabilities ) {
+			return true;
+		}
+		const required = Array.isArray( item.requiredCapability )
+			? item.requiredCapability
+			: [ item.requiredCapability ];
+		return required.some( ( capability ) => capabilities.includes( capability ) );
+	};
+	const items = content.items.filter( canActOn );
+
+	if ( ! items.length ) {
+		return null;
+	}
+
 	return (
 		<Card>
 			<CardHeader>
 				<SectionHeader level={ 3 } title={ content.title } description={ content.description } />
 			</CardHeader>
-			{ content.items.map( ( item, index ) => {
+			{ items.map( ( item, index ) => {
 				const handleClick = () =>
 					recordTracksEvent?.( 'calypso_a4a_overview_growth_action_click', {
 						action_id: item.id,

--- a/client/dashboard/agency/overview/growth-card.tsx
+++ b/client/dashboard/agency/overview/growth-card.tsx
@@ -261,7 +261,7 @@ function getPremierContent(
 				? {
 						id: 'move-client-sites',
 						icon: globe,
-						title: __( 'Move more client sites to Automattic hosting' ),
+						title: __( 'Move sites to Automattic hosting' ),
 						description: __( '20% recurring on every renewal · grows IAR' ),
 						actionLabel: __( 'Review sites' ),
 						href: links.sites,

--- a/client/dashboard/agency/overview/growth-card.tsx
+++ b/client/dashboard/agency/overview/growth-card.tsx
@@ -128,7 +128,7 @@ function getEmergingContent( links: GrowthCardLinks ): GrowthContent {
 			{
 				id: 'refer-hosting',
 				icon: globe,
-				title: __( 'Refer a client to WordPress.com or Pressable hosting' ),
+				title: __( 'Refer a client' ),
 				description: __( 'Their spend counts toward IAR · you earn 20% recurring' ),
 				actionLabel: __( 'Refer' ),
 				href: links.referrals,
@@ -136,7 +136,7 @@ function getEmergingContent( links: GrowthCardLinks ): GrowthContent {
 			{
 				id: 'recommend-plan',
 				icon: currencyDollar,
-				title: __( 'Recommend a Jetpack or WooCommerce plan' ),
+				title: __( 'Recommend a plan' ),
 				description: __( 'Counts toward IAR · 50% recurring on renewals' ),
 				actionLabel: __( 'Recommend' ),
 				href: links.marketplace,
@@ -169,7 +169,7 @@ function getAgencyContent( links: GrowthCardLinks ): GrowthContent {
 			{
 				id: 'refer-hosting',
 				icon: globe,
-				title: __( 'Refer more sites to WordPress.com or Pressable hosting' ),
+				title: __( 'Refer more sites' ),
 				description: __( 'Their spend counts toward IAR · you earn 20% recurring' ),
 				actionLabel: __( 'Refer' ),
 				href: links.referrals,
@@ -177,7 +177,7 @@ function getAgencyContent( links: GrowthCardLinks ): GrowthContent {
 			{
 				id: 'set-up-woopayments',
 				icon: currencyDollar,
-				title: __( 'Set up WooPayments for client stores' ),
+				title: __( 'Set up WooPayments' ),
 				description: __( '$1 of IAR for every $100 in sales · earn 0.05% TPV' ),
 				actionLabel: __( 'Set up' ),
 				href: links.woopayments,
@@ -185,7 +185,7 @@ function getAgencyContent( links: GrowthCardLinks ): GrowthContent {
 			{
 				id: 'recommend-plan',
 				icon: store,
-				title: __( 'Recommend Jetpack & WooCommerce plans' ),
+				title: __( 'Recommend plans' ),
 				description: __( 'Counts toward IAR · 50% recurring on renewals' ),
 				actionLabel: __( 'Recommend' ),
 				href: links.marketplace,
@@ -211,7 +211,7 @@ function getProContent(
 		wooPaymentsItem = {
 			id: 'set-up-woopayments',
 			icon: payment,
-			title: __( 'Set up WooPayments on your client stores' ),
+			title: __( 'Set up WooPayments' ),
 			description: __( '$1 of IAR for every $100 in sales · earn 0.05% TPV' ),
 			actionLabel: __( 'Set up' ),
 			href: links.woopayments,

--- a/client/dashboard/agency/overview/growth-card.tsx
+++ b/client/dashboard/agency/overview/growth-card.tsx
@@ -2,16 +2,7 @@ import { formatCurrency } from '@automattic/number-formatters';
 import { Button, Icon } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
-import {
-	chartBar,
-	currencyDollar,
-	globe,
-	help,
-	payment,
-	people,
-	store,
-	trendingUp,
-} from '@wordpress/icons';
+import { currencyDollar, globe, help, payment, store } from '@wordpress/icons';
 import { Fragment } from 'react';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody, CardDivider, CardHeader } from '../../components/card';
@@ -22,7 +13,6 @@ import getCurrentAgencyTier from '../tiers/get-current-agency-tier';
 import { PARTNER_PROGRAM_GUIDE_URL, PROGRAM_INCENTIVES_URL } from './constants';
 import NewTabLabel from './new-tab-label';
 import OverviewLinkButton from './overview-link-button';
-import useWooPaymentsStoreCount from './use-woopayments-store-count';
 import type { AgencyOverviewLinks } from './overview-content';
 import type { AgencyTierType, RecordTracksEvent } from '../tiers/types';
 import type { AgencyCapability } from '@automattic/api-core';
@@ -60,48 +50,16 @@ interface GrowthContent {
 }
 
 interface GrowthCardProps {
-	agencyId: number;
 	/** Shows the “While you wait” variant for accounts still under review. */
 	isPending?: boolean;
-	/** Disables the WooPayments store lookup for users without earnings access. */
-	canAccessEarnings?: boolean;
 	/** The current user's agency capabilities; rows the user can't act on are hidden. */
 	capabilities?: string[];
 	/** Swaps Premier’s “get listed” move for moving more sites once the agency has an approved listing. */
 	hasPartnerDirectoryListing?: boolean;
 	tierId?: AgencyTierType;
-	influencedRevenue: number;
 	links: GrowthCardLinks;
 	shouldUseRouterLink?: boolean;
 	recordTracksEvent?: RecordTracksEvent;
-}
-
-/**
- * Replaces the “set up WooPayments” move once the agency already has
- * WooPayments stores — the next best move then is growing IAR itself.
- */
-function getGrowRevenueItem(
-	target: number,
-	influencedRevenue: number,
-	links: GrowthCardLinks
-): GrowthItem {
-	return {
-		id: 'grow-influenced-revenue',
-		icon: trendingUp,
-		title: sprintf(
-			/* translators: %s is the influenced revenue target, e.g. $250,000 */
-			__( 'Grow influenced revenue to %s' ),
-			formatCurrency( target, 'USD', { stripZeros: true } )
-		),
-		description: sprintf(
-			/* translators: %s is the remaining influenced revenue to reach the target, e.g. $171,600 */
-			__( '%s to go — move client sites to Automattic hosting & set up WooPayments' ),
-			formatCurrency( Math.max( target - influencedRevenue, 0 ), 'USD', { stripZeros: true } )
-		),
-		actionLabel: __( 'Review' ),
-		href: links.tiers,
-		requiredCapability: 'a4a_read_agency_tier',
-	};
 }
 
 function getPendingContent( links: GrowthCardLinks ): GrowthContent {
@@ -130,45 +88,52 @@ function getPendingContent( links: GrowthCardLinks ): GrowthContent {
 	};
 }
 
+/** The three IAR-growing paths shared by the “grow toward the next tier” states. */
+function getGrowTowardItems( links: GrowthCardLinks ): GrowthItem[] {
+	return [
+		{
+			id: 'refer-products-hosting',
+			icon: globe,
+			title: __( 'Refer products & hosting' ),
+			description: __( 'Earn up to 50% recurring commission on client purchases.' ),
+			actionLabel: __( 'Refer' ),
+			href: links.referrals,
+			requiredCapability: 'a4a_read_referrals',
+		},
+		{
+			id: 'purchase-products-hosting',
+			icon: store,
+			title: __( 'Directly purchase products & hosting' ),
+			description: __( 'Get exclusive wholesale agency discounts on products & hosting.' ),
+			actionLabel: __( 'Browse' ),
+			href: links.marketplace,
+			requiredCapability: MARKETPLACE_CAPABILITIES,
+		},
+		{
+			id: 'set-up-woopayments',
+			icon: currencyDollar,
+			title: __( 'Set up WooPayments' ),
+			description: __(
+				'Earn commission of up to 5 basis points on payment volume across your client sites.'
+			),
+			actionLabel: __( 'Set up' ),
+			href: links.woopayments,
+			requiredCapability: 'a4a_read_referrals',
+		},
+	];
+}
+
 function getEmergingContent( links: GrowthCardLinks ): GrowthContent {
 	return {
 		title: __( 'Grow toward Agency Partner' ),
 		description: sprintf(
 			/* translators: %s is the influenced revenue target, e.g. $1,200 */
 			__(
-				'Reach %s to become an Agency Partner — unlocks directory listings and a partner badge.'
+				'Reach %s IAR to become an Agency Partner and unlock directory listings and a partner badge. All three paths below count toward your IAR.'
 			),
 			formatCurrency( TARGET_INFLUENCED_REVENUE[ 'agency-partner' ], 'USD', { stripZeros: true } )
 		),
-		items: [
-			{
-				id: 'refer-hosting',
-				icon: globe,
-				title: __( 'Refer sites' ),
-				description: __( 'Client spend counts toward IAR · you earn 20% recurring' ),
-				actionLabel: __( 'Refer' ),
-				href: links.referrals,
-				requiredCapability: 'a4a_read_referrals',
-			},
-			{
-				id: 'refer-products',
-				icon: currencyDollar,
-				title: __( 'Refer products' ),
-				description: __( 'Counts toward IAR · 50% recurring on renewals' ),
-				actionLabel: __( 'Refer' ),
-				href: links.marketplace,
-				requiredCapability: MARKETPLACE_CAPABILITIES,
-			},
-			{
-				id: 'browse-marketplace',
-				icon: store,
-				title: __( 'Buy & resell from the Marketplace' ),
-				description: __( '60+ products at up to 80% off — purchases count toward IAR' ),
-				actionLabel: __( 'Browse' ),
-				href: links.marketplace,
-				requiredCapability: MARKETPLACE_CAPABILITIES,
-			},
-		],
+		items: getGrowTowardItems( links ),
 	};
 }
 
@@ -178,95 +143,29 @@ function getAgencyContent( links: GrowthCardLinks ): GrowthContent {
 		description: sprintf(
 			/* translators: %s is the influenced revenue target, e.g. $5,000 */
 			__(
-				'Reach %s to become a Pro Partner — unlocks free agency hosting, a dedicated Partner Manager, and priority support.'
+				'Reach %s IAR to become a Pro Partner and unlock free agency hosting, a dedicated Partner Manager, and priority support. All three paths below count toward your IAR.'
 			),
 			formatCurrency( TARGET_INFLUENCED_REVENUE[ 'pro-agency-partner' ], 'USD', {
 				stripZeros: true,
 			} )
 		),
-		items: [
-			{
-				id: 'refer-hosting',
-				icon: globe,
-				title: __( 'Refer more sites' ),
-				description: __( 'Client spend counts toward IAR · you earn 20% recurring' ),
-				actionLabel: __( 'Refer' ),
-				href: links.referrals,
-				requiredCapability: 'a4a_read_referrals',
-			},
-			{
-				id: 'set-up-woopayments',
-				icon: currencyDollar,
-				title: __( 'Set up WooPayments for clients' ),
-				description: __( '$1 of IAR for every $100 in sales · earn 0.05% TPV' ),
-				actionLabel: __( 'Set up' ),
-				href: links.woopayments,
-				requiredCapability: 'a4a_read_referrals',
-			},
-			{
-				id: 'refer-products',
-				icon: store,
-				title: __( 'Refer products' ),
-				description: __( 'Counts toward IAR · 50% recurring on renewals' ),
-				actionLabel: __( 'Refer' ),
-				href: links.marketplace,
-				requiredCapability: MARKETPLACE_CAPABILITIES,
-			},
-		],
+		items: getGrowTowardItems( links ),
 	};
 }
 
-function getProContent(
-	links: GrowthCardLinks,
-	influencedRevenue: number,
-	hasWooPaymentsStores?: boolean
-): GrowthContent {
-	// While the store count loads, hold the row rather than flashing the wrong one.
-	let wooPaymentsItem: GrowthItem | null = null;
-	if ( hasWooPaymentsStores === true ) {
-		wooPaymentsItem = getGrowRevenueItem(
-			TARGET_INFLUENCED_REVENUE[ 'premier-partner' ],
-			influencedRevenue,
-			links
-		);
-	} else if ( hasWooPaymentsStores === false ) {
-		wooPaymentsItem = {
-			id: 'set-up-woopayments',
-			icon: payment,
-			title: __( 'Set up WooPayments for clients' ),
-			description: __( '$1 of IAR for every $100 in sales · earn 0.05% TPV' ),
-			actionLabel: __( 'Set up' ),
-			href: links.woopayments,
-			requiredCapability: 'a4a_read_referrals',
-		};
-	}
-
+function getProContent( links: GrowthCardLinks ): GrowthContent {
 	return {
 		title: __( 'Grow toward Premier Partner' ),
-		description: __(
-			'The Premier Partner tier unlocks Marketing Development Funds and a Parse.ly trial. It takes more than revenue.'
+		description: sprintf(
+			/* translators: %s is the influenced revenue target, e.g. $250,000 */
+			__(
+				'Reach %s IAR to become a Premier Partner and unlock Marketing Development Funds and a Parse.ly trial. All three paths below count toward your IAR.'
+			),
+			formatCurrency( TARGET_INFLUENCED_REVENUE[ 'premier-partner' ], 'USD', {
+				stripZeros: true,
+			} )
 		),
-		items: [
-			...( wooPaymentsItem ? [ wooPaymentsItem ] : [] ),
-			{
-				id: 'enterprise-projects',
-				icon: chartBar,
-				title: __( 'Deliver 3 enterprise-scale projects' ),
-				description: __( 'Or onboard 3 shared anchor customers' ),
-				actionLabel: __( 'Learn more' ),
-				href: PROGRAM_INCENTIVES_URL,
-				isExternal: true,
-			},
-			{
-				id: 'certify-developers',
-				icon: people,
-				title: __( 'Certify 30% of your developers' ),
-				description: __( 'Across Automattic certifications' ),
-				actionLabel: __( 'Start' ),
-				href: PROGRAM_INCENTIVES_URL,
-				isExternal: true,
-			},
-		],
+		items: getGrowTowardItems( links ),
 	};
 }
 
@@ -327,8 +226,6 @@ function getContent(
 	isPending: boolean,
 	tierLevel: number,
 	links: GrowthCardLinks,
-	influencedRevenue: number,
-	hasWooPaymentsStores?: boolean,
 	hasPartnerDirectoryListing?: boolean
 ): GrowthContent {
 	if ( isPending ) {
@@ -338,7 +235,7 @@ function getContent(
 		return getPremierContent( links, hasPartnerDirectoryListing );
 	}
 	if ( tierLevel >= 2 ) {
-		return getProContent( links, influencedRevenue, hasWooPaymentsStores );
+		return getProContent( links );
 	}
 	if ( tierLevel >= 1 ) {
 		return getAgencyContent( links );
@@ -374,13 +271,10 @@ function GrowthItemIcon( { icon }: { icon: JSX.Element } ) {
  * Premier (top tier) shifts to getting the most out of its benefits.
  */
 export default function GrowthCard( {
-	agencyId,
 	isPending,
-	canAccessEarnings = true,
 	capabilities,
 	hasPartnerDirectoryListing,
 	tierId,
-	influencedRevenue,
 	links,
 	shouldUseRouterLink,
 	recordTracksEvent,
@@ -388,26 +282,7 @@ export default function GrowthCard( {
 	const isSmallViewport = useViewportMatch( 'medium', '<' );
 	const tier = getCurrentAgencyTier( tierId );
 	const tierLevel = tier?.level ?? 0;
-	// Only the Pro/VIP content swaps a row on the store count, so don't fire the
-	// lookup for other tiers.
-	const needsStoreCount = ! isPending && canAccessEarnings && tierLevel >= 2 && tierLevel < 4;
-	const { storeCount, isLoading: isLoadingStoreCount } = useWooPaymentsStoreCount(
-		agencyId,
-		needsStoreCount
-	);
-	// undefined = still loading; getProContent holds the row until it resolves.
-	let hasWooPaymentsStores: boolean | undefined = false;
-	if ( needsStoreCount ) {
-		hasWooPaymentsStores = isLoadingStoreCount ? undefined : storeCount > 0;
-	}
-	const content = getContent(
-		!! isPending,
-		tierLevel,
-		links,
-		influencedRevenue,
-		hasWooPaymentsStores,
-		hasPartnerDirectoryListing
-	);
+	const content = getContent( !! isPending, tierLevel, links, hasPartnerDirectoryListing );
 
 	// Rows the user can't act on would only bounce off the route guards.
 	const canActOn = ( item: GrowthItem ) => {

--- a/client/dashboard/agency/overview/growth-card.tsx
+++ b/client/dashboard/agency/overview/growth-card.tsx
@@ -1,0 +1,427 @@
+import { formatCurrency } from '@automattic/number-formatters';
+import { Button, Icon } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	chartBar,
+	currencyDollar,
+	globe,
+	help,
+	payment,
+	people,
+	store,
+	trendingUp,
+} from '@wordpress/icons';
+import { Fragment } from 'react';
+import { ButtonStack } from '../../components/button-stack';
+import { Card, CardBody, CardDivider, CardHeader } from '../../components/card';
+import { IconListItem } from '../../components/icon-list/icon-list-item';
+import { SectionHeader } from '../../components/section-header';
+import { TARGET_INFLUENCED_REVENUE } from '../tiers/constants';
+import getCurrentAgencyTier from '../tiers/get-current-agency-tier';
+import { PARTNER_PROGRAM_GUIDE_URL, PROGRAM_INCENTIVES_URL } from './constants';
+import NewTabLabel from './new-tab-label';
+import OverviewLinkButton from './overview-link-button';
+import useWooPaymentsStoreCount from './use-woopayments-store-count';
+import type { AgencyOverviewLinks } from './overview-content';
+import type { AgencyTierType, RecordTracksEvent } from '../tiers/types';
+
+type GrowthCardLinks = Pick<
+	AgencyOverviewLinks,
+	'tiers' | 'referrals' | 'woopayments' | 'marketplace' | 'partnerDirectory'
+>;
+
+interface GrowthItem {
+	id: string;
+	icon: JSX.Element;
+	title: string;
+	description: string;
+	actionLabel: string;
+	href: string;
+	isExternal?: boolean;
+}
+
+interface GrowthContent {
+	title: string;
+	description?: string;
+	items: GrowthItem[];
+}
+
+interface GrowthCardProps {
+	agencyId: number;
+	/** Shows the “While you wait” variant for accounts still under review. */
+	isPending?: boolean;
+	/** Disables the WooPayments store lookup for users without earnings access. */
+	canAccessEarnings?: boolean;
+	/** Hides Premier’s “get listed” move once the agency has an approved listing. */
+	hasPartnerDirectoryListing?: boolean;
+	tierId?: AgencyTierType;
+	influencedRevenue: number;
+	links: GrowthCardLinks;
+	shouldUseRouterLink?: boolean;
+	recordTracksEvent?: RecordTracksEvent;
+}
+
+/**
+ * Replaces the “set up WooPayments” move once the agency already has
+ * WooPayments stores — the next best move then is growing IAR itself.
+ */
+function getGrowRevenueItem(
+	target: number,
+	influencedRevenue: number,
+	links: GrowthCardLinks
+): GrowthItem {
+	return {
+		id: 'grow-influenced-revenue',
+		icon: trendingUp,
+		title: sprintf(
+			/* translators: %s is the influenced revenue target, e.g. $250,000 */
+			__( 'Grow influenced revenue to %s' ),
+			formatCurrency( target, 'USD', { stripZeros: true } )
+		),
+		description: sprintf(
+			/* translators: %s is the remaining influenced revenue to reach the target, e.g. $171,600 */
+			__( '%s to go — move client sites to Automattic hosting & set up WooPayments' ),
+			formatCurrency( Math.max( target - influencedRevenue, 0 ), 'USD', { stripZeros: true } )
+		),
+		actionLabel: __( 'Review' ),
+		href: links.tiers,
+	};
+}
+
+function getPendingContent( links: GrowthCardLinks ): GrowthContent {
+	return {
+		title: __( 'While you wait' ),
+		items: [
+			{
+				id: 'program-guide',
+				icon: help,
+				title: __( 'Read the partner program guide' ),
+				description: __( 'Learn how tiers, IAR and benefits work' ),
+				actionLabel: __( 'Read' ),
+				href: PARTNER_PROGRAM_GUIDE_URL,
+				isExternal: true,
+			},
+			{
+				id: 'explore-marketplace',
+				icon: store,
+				title: __( 'Explore the Marketplace' ),
+				description: __( 'Browse 60+ products you’ll be able to resell' ),
+				actionLabel: __( 'Explore' ),
+				href: links.marketplace,
+			},
+		],
+	};
+}
+
+function getEmergingContent( links: GrowthCardLinks ): GrowthContent {
+	return {
+		title: __( 'Grow toward Agency Partner' ),
+		description: sprintf(
+			/* translators: %s is the influenced revenue target, e.g. $1,200 */
+			__(
+				'Reach %s to become an Agency Partner — unlocks directory listings and a partner badge.'
+			),
+			formatCurrency( TARGET_INFLUENCED_REVENUE[ 'agency-partner' ], 'USD', { stripZeros: true } )
+		),
+		items: [
+			{
+				id: 'refer-hosting',
+				icon: globe,
+				title: __( 'Refer a client to WordPress.com or Pressable hosting' ),
+				description: __( 'Their spend counts toward IAR · you earn 20% recurring' ),
+				actionLabel: __( 'Refer' ),
+				href: links.referrals,
+			},
+			{
+				id: 'recommend-plan',
+				icon: currencyDollar,
+				title: __( 'Recommend a Jetpack or WooCommerce plan' ),
+				description: __( 'Counts toward IAR · 50% recurring on renewals' ),
+				actionLabel: __( 'Recommend' ),
+				href: links.marketplace,
+			},
+			{
+				id: 'browse-marketplace',
+				icon: store,
+				title: __( 'Buy & resell from the Marketplace' ),
+				description: __( '60+ products at up to 80% off — purchases count toward IAR' ),
+				actionLabel: __( 'Browse' ),
+				href: links.marketplace,
+			},
+		],
+	};
+}
+
+function getAgencyContent( links: GrowthCardLinks, growRevenueItem?: GrowthItem ): GrowthContent {
+	return {
+		title: __( 'Grow toward Pro Partner' ),
+		description: sprintf(
+			/* translators: %s is the influenced revenue target, e.g. $5,000 */
+			__(
+				'Reach %s to become a Pro Partner — unlocks free agency hosting, a dedicated Partner Manager, and priority support.'
+			),
+			formatCurrency( TARGET_INFLUENCED_REVENUE[ 'pro-agency-partner' ], 'USD', {
+				stripZeros: true,
+			} )
+		),
+		items: [
+			{
+				id: 'refer-hosting',
+				icon: globe,
+				title: __( 'Refer more sites to WordPress.com or Pressable hosting' ),
+				description: __( 'Their spend counts toward IAR · you earn 20% recurring' ),
+				actionLabel: __( 'Refer' ),
+				href: links.referrals,
+			},
+			growRevenueItem ?? {
+				id: 'set-up-woopayments',
+				icon: currencyDollar,
+				title: __( 'Set up WooPayments for client stores' ),
+				description: __( '$1 of IAR for every $100 in sales · earn 0.05% TPV' ),
+				actionLabel: __( 'Set up' ),
+				href: links.woopayments,
+			},
+			{
+				id: 'recommend-plan',
+				icon: store,
+				title: __( 'Recommend Jetpack & WooCommerce plans' ),
+				description: __( 'Counts toward IAR · 50% recurring on renewals' ),
+				actionLabel: __( 'Recommend' ),
+				href: links.marketplace,
+			},
+		],
+	};
+}
+
+function getProContent( links: GrowthCardLinks, growRevenueItem?: GrowthItem ): GrowthContent {
+	return {
+		title: __( 'Grow toward Premier' ),
+		description: __(
+			'Premier unlocks Marketing Development Funds and a Parse.ly trial. It takes more than revenue.'
+		),
+		items: [
+			growRevenueItem ?? {
+				id: 'set-up-woopayments',
+				icon: payment,
+				title: __( 'Set up WooPayments on your client stores' ),
+				description: __( '$1 of IAR for every $100 in sales · earn 0.05% TPV' ),
+				actionLabel: __( 'Set up' ),
+				href: links.woopayments,
+			},
+			{
+				id: 'enterprise-projects',
+				icon: chartBar,
+				title: __( 'Deliver 3 enterprise-scale projects' ),
+				description: __( 'Or onboard 3 shared anchor customers' ),
+				actionLabel: __( 'Learn more' ),
+				href: PROGRAM_INCENTIVES_URL,
+				isExternal: true,
+			},
+			{
+				id: 'certify-developers',
+				icon: people,
+				title: __( 'Certify 30% of your developers' ),
+				description: __( 'Across Automattic certifications' ),
+				actionLabel: __( 'Start' ),
+				href: PROGRAM_INCENTIVES_URL,
+				isExternal: true,
+			},
+		],
+	};
+}
+
+function getPremierContent(
+	links: GrowthCardLinks,
+	hasPartnerDirectoryListing?: boolean
+): GrowthContent {
+	return {
+		title: __( 'Get the most from Premier' ),
+		description: __( 'You’re Premier — make sure you’re getting leads and using every benefit.' ),
+		items: [
+			...( hasPartnerDirectoryListing
+				? []
+				: [
+						{
+							id: 'partner-directory',
+							icon: globe,
+							title: __( 'Get listed in the Partner Directory' ),
+							description: __(
+								'Receive vetted leads across WordPress.com, Woo, Jetpack & Pressable'
+							),
+							actionLabel: __( 'Set up listing' ),
+							href: links.partnerDirectory,
+						},
+				  ] ),
+			{
+				id: 'set-up-woopayments',
+				icon: payment,
+				title: __( 'Set up WooPayments on more stores' ),
+				description: __( '$1 IAR per $100 in sales' ),
+				actionLabel: __( 'Set up' ),
+				href: links.woopayments,
+			},
+			{
+				id: 'marketing-development-funds',
+				icon: currencyDollar,
+				title: __( 'Use your Marketing Development Funds' ),
+				description: __( 'Premier benefit — co-fund campaigns' ),
+				actionLabel: __( 'Learn more' ),
+				href: PROGRAM_INCENTIVES_URL,
+				isExternal: true,
+			},
+		],
+	};
+}
+
+function getContent(
+	isPending: boolean,
+	tierLevel: number,
+	links: GrowthCardLinks,
+	hasWooPaymentsStores: boolean,
+	influencedRevenue: number,
+	hasPartnerDirectoryListing?: boolean
+): GrowthContent {
+	if ( isPending ) {
+		return getPendingContent( links );
+	}
+	if ( tierLevel >= 4 ) {
+		return getPremierContent( links, hasPartnerDirectoryListing );
+	}
+	if ( tierLevel >= 2 ) {
+		return getProContent(
+			links,
+			hasWooPaymentsStores
+				? getGrowRevenueItem(
+						TARGET_INFLUENCED_REVENUE[ 'premier-partner' ],
+						influencedRevenue,
+						links
+				  )
+				: undefined
+		);
+	}
+	if ( tierLevel >= 1 ) {
+		return getAgencyContent(
+			links,
+			hasWooPaymentsStores
+				? getGrowRevenueItem(
+						TARGET_INFLUENCED_REVENUE[ 'pro-agency-partner' ],
+						influencedRevenue,
+						links
+				  )
+				: undefined
+		);
+	}
+	return getEmergingContent( links );
+}
+
+/**
+ * The “grow toward the next tier” module of the Overview screen. Its goal and
+ * actions adapt to the agency’s account state: pending accounts get a “while
+ * you wait” list, each tier points at the moves that unlock the next one, and
+ * Premier (top tier) shifts to getting the most out of its benefits.
+ */
+function GrowthItemIcon( { icon }: { icon: JSX.Element } ) {
+	return (
+		<div
+			aria-hidden="true"
+			style={ {
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				flexShrink: 0,
+				width: '48px',
+				height: '48px',
+				borderRadius: '4px',
+				background: 'var(--color-gray-100)',
+				color: 'var(--color-gray-700)',
+			} }
+		>
+			<Icon icon={ icon } size={ 28 } />
+		</div>
+	);
+}
+
+export default function GrowthCard( {
+	agencyId,
+	isPending,
+	canAccessEarnings = true,
+	hasPartnerDirectoryListing,
+	tierId,
+	influencedRevenue,
+	links,
+	shouldUseRouterLink,
+	recordTracksEvent,
+}: GrowthCardProps ) {
+	const isSmallViewport = useViewportMatch( 'medium', '<' );
+	const tier = getCurrentAgencyTier( tierId );
+	const { storeCount } = useWooPaymentsStoreCount( agencyId, ! isPending && canAccessEarnings );
+	const content = getContent(
+		!! isPending,
+		tier?.level ?? 0,
+		links,
+		storeCount > 0,
+		influencedRevenue,
+		hasPartnerDirectoryListing
+	);
+
+	return (
+		<Card>
+			<CardHeader>
+				<SectionHeader level={ 3 } title={ content.title } description={ content.description } />
+			</CardHeader>
+			{ content.items.map( ( item, index ) => {
+				const handleClick = () =>
+					recordTracksEvent?.( 'calypso_a4a_overview_growth_action_click', {
+						action_id: item.id,
+						agency_tier: tier?.id,
+					} );
+
+				return (
+					<Fragment key={ item.id }>
+						{ index > 0 && <CardDivider style={ { borderColor: 'var(--color-gray-100)' } } /> }
+						<CardBody>
+							<IconListItem
+								title={ item.title }
+								description={ item.description }
+								decoration={ ! isSmallViewport && <GrowthItemIcon icon={ item.icon } /> }
+								layout={ isSmallViewport ? 'stacked' : 'inline' }
+								suffix={
+									<ButtonStack
+										justify={ isSmallViewport ? 'flex-start' : 'flex-end' }
+										expanded={ isSmallViewport }
+										style={ { flexShrink: 0 } }
+										as="span"
+									>
+										{ item.isExternal ? (
+											<Button
+												size="compact"
+												variant="secondary"
+												href={ item.href }
+												target="_blank"
+												rel="noreferrer"
+												onClick={ handleClick }
+											>
+												<NewTabLabel>{ item.actionLabel }</NewTabLabel>
+											</Button>
+										) : (
+											<OverviewLinkButton
+												size="compact"
+												variant="secondary"
+												href={ item.href }
+												shouldUseRouterLink={ shouldUseRouterLink }
+												onClick={ handleClick }
+											>
+												{ item.actionLabel }
+											</OverviewLinkButton>
+										) }
+									</ButtonStack>
+								}
+							/>
+						</CardBody>
+					</Fragment>
+				);
+			} ) }
+		</Card>
+	);
+}

--- a/client/dashboard/agency/overview/growth-card.tsx
+++ b/client/dashboard/agency/overview/growth-card.tsx
@@ -28,7 +28,7 @@ import type { AgencyTierType, RecordTracksEvent } from '../tiers/types';
 
 type GrowthCardLinks = Pick<
 	AgencyOverviewLinks,
-	'tiers' | 'referrals' | 'woopayments' | 'marketplace' | 'partnerDirectory'
+	'tiers' | 'sites' | 'referrals' | 'woopayments' | 'marketplace' | 'partnerDirectory'
 >;
 
 interface GrowthItem {
@@ -239,20 +239,25 @@ function getPremierContent(
 		title: __( 'Get the most from Premier' ),
 		description: __( 'You’re Premier — make sure you’re getting leads and using every benefit.' ),
 		items: [
-			...( hasPartnerDirectoryListing
-				? []
-				: [
-						{
-							id: 'partner-directory',
-							icon: globe,
-							title: __( 'Get listed in the Partner Directory' ),
-							description: __(
-								'Receive vetted leads across WordPress.com, Woo, Jetpack & Pressable'
-							),
-							actionLabel: __( 'Set up listing' ),
-							href: links.partnerDirectory,
-						},
-				  ] ),
+			hasPartnerDirectoryListing
+				? {
+						id: 'move-client-sites',
+						icon: globe,
+						title: __( 'Move more client sites to Automattic hosting' ),
+						description: __( '20% recurring on every renewal · grows IAR' ),
+						actionLabel: __( 'Review sites' ),
+						href: links.sites,
+				  }
+				: {
+						id: 'partner-directory',
+						icon: globe,
+						title: __( 'Get listed in the Partner Directory' ),
+						description: __(
+							'Receive vetted leads across WordPress.com, Woo, Jetpack & Pressable'
+						),
+						actionLabel: __( 'Set up listing' ),
+						href: links.partnerDirectory,
+				  },
 			{
 				id: 'set-up-woopayments',
 				icon: payment,

--- a/client/dashboard/agency/overview/growth-card.tsx
+++ b/client/dashboard/agency/overview/growth-card.tsx
@@ -153,7 +153,7 @@ function getEmergingContent( links: GrowthCardLinks ): GrowthContent {
 	};
 }
 
-function getAgencyContent( links: GrowthCardLinks, growRevenueItem?: GrowthItem ): GrowthContent {
+function getAgencyContent( links: GrowthCardLinks ): GrowthContent {
 	return {
 		title: __( 'Grow toward Pro Partner' ),
 		description: sprintf(
@@ -174,7 +174,7 @@ function getAgencyContent( links: GrowthCardLinks, growRevenueItem?: GrowthItem 
 				actionLabel: __( 'Refer' ),
 				href: links.referrals,
 			},
-			growRevenueItem ?? {
+			{
 				id: 'set-up-woopayments',
 				icon: currencyDollar,
 				title: __( 'Set up WooPayments for client stores' ),
@@ -301,16 +301,7 @@ function getContent(
 		);
 	}
 	if ( tierLevel >= 1 ) {
-		return getAgencyContent(
-			links,
-			hasWooPaymentsStores
-				? getGrowRevenueItem(
-						TARGET_INFLUENCED_REVENUE[ 'pro-agency-partner' ],
-						influencedRevenue,
-						links
-				  )
-				: undefined
-		);
+		return getAgencyContent( links );
 	}
 	return getEmergingContent( links );
 }

--- a/client/dashboard/agency/overview/growth-card.tsx
+++ b/client/dashboard/agency/overview/growth-card.tsx
@@ -53,7 +53,7 @@ interface GrowthCardProps {
 	isPending?: boolean;
 	/** Disables the WooPayments store lookup for users without earnings access. */
 	canAccessEarnings?: boolean;
-	/** Hides Premier’s “get listed” move once the agency has an approved listing. */
+	/** Swaps Premier’s “get listed” move for moving more sites once the agency has an approved listing. */
 	hasPartnerDirectoryListing?: boolean;
 	tierId?: AgencyTierType;
 	influencedRevenue: number;
@@ -389,7 +389,8 @@ export default function GrowthCard( {
 				const handleClick = () =>
 					recordTracksEvent?.( 'calypso_a4a_overview_growth_action_click', {
 						action_id: item.id,
-						agency_tier: tier?.id,
+						// Pending accounts have no tier yet, so don't report the default one.
+						agency_tier: isPending ? undefined : tier?.id,
 					} );
 
 				return (

--- a/client/dashboard/agency/overview/growth-card.tsx
+++ b/client/dashboard/agency/overview/growth-card.tsx
@@ -194,21 +194,37 @@ function getAgencyContent( links: GrowthCardLinks ): GrowthContent {
 	};
 }
 
-function getProContent( links: GrowthCardLinks, growRevenueItem?: GrowthItem ): GrowthContent {
+function getProContent(
+	links: GrowthCardLinks,
+	influencedRevenue: number,
+	hasWooPaymentsStores?: boolean
+): GrowthContent {
+	// While the store count loads, hold the row rather than flashing the wrong one.
+	let wooPaymentsItem: GrowthItem | null = null;
+	if ( hasWooPaymentsStores === true ) {
+		wooPaymentsItem = getGrowRevenueItem(
+			TARGET_INFLUENCED_REVENUE[ 'premier-partner' ],
+			influencedRevenue,
+			links
+		);
+	} else if ( hasWooPaymentsStores === false ) {
+		wooPaymentsItem = {
+			id: 'set-up-woopayments',
+			icon: payment,
+			title: __( 'Set up WooPayments on your client stores' ),
+			description: __( '$1 of IAR for every $100 in sales · earn 0.05% TPV' ),
+			actionLabel: __( 'Set up' ),
+			href: links.woopayments,
+		};
+	}
+
 	return {
 		title: __( 'Grow toward Premier' ),
 		description: __(
 			'Premier unlocks Marketing Development Funds and a Parse.ly trial. It takes more than revenue.'
 		),
 		items: [
-			growRevenueItem ?? {
-				id: 'set-up-woopayments',
-				icon: payment,
-				title: __( 'Set up WooPayments on your client stores' ),
-				description: __( '$1 of IAR for every $100 in sales · earn 0.05% TPV' ),
-				actionLabel: __( 'Set up' ),
-				href: links.woopayments,
-			},
+			...( wooPaymentsItem ? [ wooPaymentsItem ] : [] ),
 			{
 				id: 'enterprise-projects',
 				icon: chartBar,
@@ -283,8 +299,8 @@ function getContent(
 	isPending: boolean,
 	tierLevel: number,
 	links: GrowthCardLinks,
-	hasWooPaymentsStores: boolean,
 	influencedRevenue: number,
+	hasWooPaymentsStores?: boolean,
 	hasPartnerDirectoryListing?: boolean
 ): GrowthContent {
 	if ( isPending ) {
@@ -294,16 +310,7 @@ function getContent(
 		return getPremierContent( links, hasPartnerDirectoryListing );
 	}
 	if ( tierLevel >= 2 ) {
-		return getProContent(
-			links,
-			hasWooPaymentsStores
-				? getGrowRevenueItem(
-						TARGET_INFLUENCED_REVENUE[ 'premier-partner' ],
-						influencedRevenue,
-						links
-				  )
-				: undefined
-		);
+		return getProContent( links, influencedRevenue, hasWooPaymentsStores );
 	}
 	if ( tierLevel >= 1 ) {
 		return getAgencyContent( links );
@@ -311,12 +318,6 @@ function getContent(
 	return getEmergingContent( links );
 }
 
-/**
- * The “grow toward the next tier” module of the Overview screen. Its goal and
- * actions adapt to the agency’s account state: pending accounts get a “while
- * you wait” list, each tier points at the moves that unlock the next one, and
- * Premier (top tier) shifts to getting the most out of its benefits.
- */
 function GrowthItemIcon( { icon }: { icon: JSX.Element } ) {
 	return (
 		<div
@@ -338,6 +339,12 @@ function GrowthItemIcon( { icon }: { icon: JSX.Element } ) {
 	);
 }
 
+/**
+ * The “grow toward the next tier” module of the Overview screen. Its goal and
+ * actions adapt to the agency’s account state: pending accounts get a “while
+ * you wait” list, each tier points at the moves that unlock the next one, and
+ * Premier (top tier) shifts to getting the most out of its benefits.
+ */
 export default function GrowthCard( {
 	agencyId,
 	isPending,
@@ -351,13 +358,25 @@ export default function GrowthCard( {
 }: GrowthCardProps ) {
 	const isSmallViewport = useViewportMatch( 'medium', '<' );
 	const tier = getCurrentAgencyTier( tierId );
-	const { storeCount } = useWooPaymentsStoreCount( agencyId, ! isPending && canAccessEarnings );
+	const tierLevel = tier?.level ?? 0;
+	// Only the Pro/VIP content swaps a row on the store count, so don't fire the
+	// lookup for other tiers.
+	const needsStoreCount = ! isPending && canAccessEarnings && tierLevel >= 2 && tierLevel < 4;
+	const { storeCount, isLoading: isLoadingStoreCount } = useWooPaymentsStoreCount(
+		agencyId,
+		needsStoreCount
+	);
+	// undefined = still loading; getProContent holds the row until it resolves.
+	let hasWooPaymentsStores: boolean | undefined = false;
+	if ( needsStoreCount ) {
+		hasWooPaymentsStores = isLoadingStoreCount ? undefined : storeCount > 0;
+	}
 	const content = getContent(
 		!! isPending,
-		tier?.level ?? 0,
+		tierLevel,
 		links,
-		storeCount > 0,
 		influencedRevenue,
+		hasWooPaymentsStores,
 		hasPartnerDirectoryListing
 	);
 

--- a/client/dashboard/agency/overview/growth-card.tsx
+++ b/client/dashboard/agency/overview/growth-card.tsx
@@ -219,9 +219,9 @@ function getProContent(
 	}
 
 	return {
-		title: __( 'Grow toward Premier' ),
+		title: __( 'Grow toward Premier Partner' ),
 		description: __(
-			'Premier unlocks Marketing Development Funds and a Parse.ly trial. It takes more than revenue.'
+			'The Premier Partner tier unlocks Marketing Development Funds and a Parse.ly trial. It takes more than revenue.'
 		),
 		items: [
 			...( wooPaymentsItem ? [ wooPaymentsItem ] : [] ),
@@ -253,7 +253,9 @@ function getPremierContent(
 ): GrowthContent {
 	return {
 		title: __( 'Get the most from Premier' ),
-		description: __( 'You’re Premier — make sure you’re getting leads and using every benefit.' ),
+		description: __(
+			'You’re a Premier Partner — make sure you’re getting leads and using every benefit.'
+		),
 		items: [
 			hasPartnerDirectoryListing
 				? {

--- a/client/dashboard/agency/overview/index.tsx
+++ b/client/dashboard/agency/overview/index.tsx
@@ -60,6 +60,7 @@ export default function AgencyOverview() {
 				hasPartnerDirectoryListing={ hasPartnerDirectoryListing }
 				links={ {
 					tiers: '/agency/tiers',
+					sites: '/sites',
 					referrals: '/earn/referrals',
 					woopayments: '/earn/woopayments',
 					marketplace: '/marketplace/exclusive-offers',

--- a/client/dashboard/agency/overview/index.tsx
+++ b/client/dashboard/agency/overview/index.tsx
@@ -15,12 +15,20 @@ import AgencyOverviewHeader from './overview-header';
 // '#contact-support' placeholder in agency/tiers/constants.ts — wire both up together.
 const CONTACT_SUPPORT_URL = '#contact-support';
 
+// TODO: the MSD dashboard has no partner-directory screen yet — point the growth
+// card there once it exists.
+const PARTNER_DIRECTORY_URL = '#partner-directory';
+
 export default function AgencyOverview() {
 	const { data: agency } = useQuery( activeAgencyQuery() );
 	const { recordTracksEvent } = useAnalytics();
 	const locale = useLocale();
 	const agencyId = agency?.id ?? 0;
 	const approvalStatus = agency?.approval_status;
+	const hasPartnerDirectoryListing =
+		!! agency?.profile?.partner_directory_application?.directories.some(
+			( { status } ) => status === 'approved'
+		);
 	const { scheduleCall, isLoading: isSchedulingCall } = useScheduleCall( agency?.id );
 
 	if ( ! agency ) {
@@ -49,10 +57,13 @@ export default function AgencyOverview() {
 				influencedRevenue={ agency.influenced_revenue ?? 0 }
 				approvalStatus={ approvalStatus }
 				capabilities={ agency.user?.capabilities }
+				hasPartnerDirectoryListing={ hasPartnerDirectoryListing }
 				links={ {
 					tiers: '/agency/tiers',
 					referrals: '/earn/referrals',
 					woopayments: '/earn/woopayments',
+					marketplace: '/marketplace/exclusive-offers',
+					partnerDirectory: PARTNER_DIRECTORY_URL,
 					contactSupport: CONTACT_SUPPORT_URL,
 					helpful: [
 						{

--- a/client/dashboard/agency/overview/overview-content.tsx
+++ b/client/dashboard/agency/overview/overview-content.tsx
@@ -3,6 +3,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { PendingTierCard, RejectedTierCard } from './application-status-cards';
 import EventCard from './event-card';
+import GrowthCard from './growth-card';
 import HelpfulLinksCard from './helpful-links-card';
 import ReferralEarningsCard from './referral-earnings-card';
 import TierOverviewCard from './tier-overview-card';
@@ -19,6 +20,8 @@ export interface AgencyOverviewLinks {
 	tiers: string;
 	referrals: string;
 	woopayments: string;
+	marketplace: string;
+	partnerDirectory: string;
 	contactSupport: string;
 	helpful: HelpfulLink[];
 }
@@ -31,6 +34,8 @@ export interface AgencyOverviewContentProps {
 	approvalStatus?: AgencyApprovalStatus | '';
 	/** The current user's agency capabilities; the earning cards lock without referrals access. */
 	capabilities?: string[];
+	/** Whether the agency already has an approved Partner Directory listing. */
+	hasPartnerDirectoryListing?: boolean;
 	links: AgencyOverviewLinks;
 	shouldUseRouterLink?: boolean;
 	onScheduleCall?: () => void;
@@ -50,6 +55,7 @@ export default function AgencyOverviewContent( {
 	influencedRevenue,
 	approvalStatus,
 	capabilities,
+	hasPartnerDirectoryListing,
 	links,
 	shouldUseRouterLink,
 	onScheduleCall,
@@ -84,6 +90,19 @@ export default function AgencyOverviewContent( {
 						shouldUseRouterLink={ shouldUseRouterLink }
 						onScheduleCall={ onScheduleCall }
 						isSchedulingCall={ isSchedulingCall }
+						recordTracksEvent={ recordTracksEvent }
+					/>
+				) }
+				{ ! isRejected && (
+					<GrowthCard
+						agencyId={ agencyId }
+						isPending={ isPending }
+						canAccessEarnings={ canAccessEarnings }
+						hasPartnerDirectoryListing={ hasPartnerDirectoryListing }
+						tierId={ tierId }
+						influencedRevenue={ influencedRevenue }
+						links={ links }
+						shouldUseRouterLink={ shouldUseRouterLink }
 						recordTracksEvent={ recordTracksEvent }
 					/>
 				) }

--- a/client/dashboard/agency/overview/overview-content.tsx
+++ b/client/dashboard/agency/overview/overview-content.tsx
@@ -96,13 +96,10 @@ export default function AgencyOverviewContent( {
 				) }
 				{ ! isRejected && (
 					<GrowthCard
-						agencyId={ agencyId }
 						isPending={ isPending }
-						canAccessEarnings={ canAccessEarnings }
 						capabilities={ capabilities }
 						hasPartnerDirectoryListing={ hasPartnerDirectoryListing }
 						tierId={ tierId }
-						influencedRevenue={ influencedRevenue }
 						links={ links }
 						shouldUseRouterLink={ shouldUseRouterLink }
 						recordTracksEvent={ recordTracksEvent }

--- a/client/dashboard/agency/overview/overview-content.tsx
+++ b/client/dashboard/agency/overview/overview-content.tsx
@@ -18,6 +18,7 @@ const REFERRALS_CAPABILITY = 'a4a_read_referrals';
 
 export interface AgencyOverviewLinks {
 	tiers: string;
+	sites: string;
 	referrals: string;
 	woopayments: string;
 	marketplace: string;

--- a/client/dashboard/agency/overview/overview-content.tsx
+++ b/client/dashboard/agency/overview/overview-content.tsx
@@ -99,6 +99,7 @@ export default function AgencyOverviewContent( {
 						agencyId={ agencyId }
 						isPending={ isPending }
 						canAccessEarnings={ canAccessEarnings }
+						capabilities={ capabilities }
 						hasPartnerDirectoryListing={ hasPartnerDirectoryListing }
 						tierId={ tierId }
 						influencedRevenue={ influencedRevenue }

--- a/client/dashboard/agency/tiers/influenced-revenue.tsx
+++ b/client/dashboard/agency/tiers/influenced-revenue.tsx
@@ -51,25 +51,27 @@ function InfluencedRevenueStrapline( {
 					onClose={ () => setShowPopover( false ) }
 				>
 					<VStack spacing={ 3 } style={ { width: '280px', padding: '8px' } }>
-						<Text>
+						<Text size={ 13 } lineHeight="20px">
 							{ __(
 								'Influenced revenue is revenue connected to your agency’s direct influence through referrals, client purchases, and managed sites using Automattic products.'
 							) }
 						</Text>
-						<Text>
+						<Text size={ 13 } lineHeight="20px">
 							{ __(
 								'Earn commissions by referring Automattic products to your clients, receive revenue share from WooPayments transactions, and unlock savings through volume discounts on bulk purchases.'
 							) }
 						</Text>
-						<InlineSupportLink
-							supportLink={ LEARN_MORE_URL }
-							forceOpenInHelpCenter
-							onClick={ () =>
-								recordTracksEvent( 'calypso_a4a_agency_tier_influenced_revenue_learn_more_click' )
-							}
-						>
-							{ __( 'Learn more' ) }
-						</InlineSupportLink>
+						<Text size={ 13 } lineHeight="20px">
+							<InlineSupportLink
+								supportLink={ LEARN_MORE_URL }
+								forceOpenInHelpCenter
+								onClick={ () =>
+									recordTracksEvent( 'calypso_a4a_agency_tier_influenced_revenue_learn_more_click' )
+								}
+							>
+								{ __( 'Learn more' ) }
+							</InlineSupportLink>
+						</Text>
 					</VStack>
 				</Popover>
 			) }

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -30,6 +30,7 @@
 		"a4a-bd-checkout": false,
 		"a4a-bd-term-pricing": true,
 		"a4a-migrations-request-verification": true,
+		"a4a-overview-revamp": true,
 		"a4a-partner-directory": false,
 		"a4a-pressable-referrals": true,
 		"a4a-signup-v2": true,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -32,6 +32,7 @@
 		"a4a-bd-checkout": false,
 		"a4a-bd-term-pricing": true,
 		"a4a-migrations-request-verification": true,
+		"a4a-overview-revamp": true,
 		"a4a-partner-directory": false,
 		"a4a-pressable-referrals": true,
 		"a4a-signup-v2": true,

--- a/packages/api-core/src/agency/types.ts
+++ b/packages/api-core/src/agency/types.ts
@@ -130,6 +130,13 @@ export interface Agency {
 	user?: {
 		capabilities: string[];
 	};
+	profile?: {
+		partner_directory_application?: null | {
+			directories: {
+				status: 'pending' | 'approved' | 'rejected' | 'closed';
+			}[];
+		};
+	};
 	third_party?: null | {
 		pressable?: null | {
 			usage?: null | {

--- a/packages/api-core/src/agency/types.ts
+++ b/packages/api-core/src/agency/types.ts
@@ -130,13 +130,6 @@ export interface Agency {
 	user?: {
 		capabilities: string[];
 	};
-	profile?: {
-		partner_directory_application?: null | {
-			directories: {
-				status: 'pending' | 'approved' | 'rejected' | 'closed';
-			}[];
-		};
-	};
 	third_party?: null | {
 		pressable?: null | {
 			usage?: null | {


### PR DESCRIPTION
Part of A4A-3164.

## Proposed Changes

* Add a new growth section to the revamped Overview, right below the tier card. Its goal and actions adapt to where the agency is in its journey:
  * **Account under review** — a “While you wait” list: read the partner program guide and explore the Marketplace.
  * **Account activated / Agency Partner / Pro & VIP Pro** — “Grow toward {next tier}” with a per-tier goal line (“Reach {$X} IAR to become a {tier} and unlock {benefits}. All three paths below count toward your IAR.”) and the same three paths: “Refer products & hosting” (Refer), “Directly purchase products & hosting” (Browse), and “Set up WooPayments” (Set up).
  * **Premier Partner** — “Get the most from Premier”: get listed in the Partner Directory, set up WooPayments on more stores, and use Marketing Development Funds.
* When a Premier agency already has an approved Partner Directory listing, the “get listed” step becomes “Move sites to Automattic hosting” with a Review sites link.
* The section is hidden for rejected accounts.
* Rows the user has no capability to act on are hidden (and the card hides entirely when nothing is actionable), matching how the rest of the page respects agency member roles.
* The influenced revenue tooltip pins its text size, so the classic app renders it at the same 13px as the new dashboard instead of inheriting a larger root font through the popover portal.
* The `a4a-overview-revamp` flag is now enabled on stage and horizon for testing; production stays off.
* Each action fires a Tracks event (`calypso_a4a_overview_growth_action_click`) with the action and current tier.
* The section renders on both the new dashboard and the classic agencies dashboard (behind the `a4a-overview-revamp` flag, development only).

## Why are these changes being made?

* The Overview should point every agency at its most relevant next step instead of showing everyone the same static page. This section reads the agency’s tier and account state so the page always suggests the next best move.

## Testing Instructions

Using this PR’s Calypso Live link with the `a8c-for-agencies` environment, sign in as an agency and open the Overview with `?flags=a4a-overview-revamp`. The section appears below the tier card in the left column.

Scenarios, by account state:

* **Pending account** — the section shows “While you wait” with two rows: “Read the partner program guide” (Read, opens in a new tab) and “Explore the Marketplace” (Explore → Marketplace).

<img width="549" height="233" alt="Screenshot 2026-08-07 at 11 55 48 AM" src="https://github.com/user-attachments/assets/c6b776fe-64a1-4313-ad68-d95f4479b4a5" />


* **Rejected account** — the section does not render at all.
* **Account activated (no tier progress)** — “Grow toward Agency Partner” with the $1,200 goal line and the three shared rows: “Refer products & hosting” (Refer → Referrals), “Directly purchase products & hosting” (Browse → Marketplace), “Set up WooPayments” (Set up → WooPayments).

<img width="704" height="386" alt="Screenshot 2026-08-14 at 11 29 44 AM" src="https://github.com/user-attachments/assets/5cb8d5bb-9f5e-462e-80d8-ebbe3fd14e0c" />


* **Agency Partner** — “Grow toward Pro Partner” with the $5,000 goal line and the same three rows.

<img width="704" height="386" alt="Screenshot 2026-08-14 at 11 29 59 AM" src="https://github.com/user-attachments/assets/de6c3e4e-fc05-41ce-9612-e425b1ea4204" />


* **Pro Partner (or VIP Pro)** — “Grow toward Premier Partner” with the $250,000 goal line and the same three rows.


<img width="704" height="386" alt="Screenshot 2026-08-14 at 11 30 08 AM" src="https://github.com/user-attachments/assets/149bdbc7-a3e9-4676-b102-66e61f9911c9" />

* **Premier Partner, no approved Partner Directory listing** — “Get the most from Premier” with three rows: “Get listed in the Partner Directory” (Set up listing → Partner Directory), “Set up WooPayments on more stores” (Set up → WooPayments), “Use your Marketing Development Funds” (Learn more, new tab).

<img width="549" height="286" alt="Screenshot 2026-08-07 at 12 10 27 PM" src="https://github.com/user-attachments/assets/0f244b70-668b-4136-869c-eb258ea56faa" />


* **Premier Partner, with an approved listing** — the first row becomes “Move sites to Automattic hosting” (“20% recurring on every renewal · grows IAR”, Review sites → Sites) and the Partner Directory row is not shown.


<img width="518" height="365" alt="Screenshot 2026-08-13 at 2 03 04 PM" src="https://github.com/user-attachments/assets/de7ce580-210f-4ffd-a8df-a4e7858a0507" />


Other checks:

* **Small screens** — the icon squares hide, and each action button moves below its text, full width.

<img width="374" height="494" alt="Screenshot 2026-08-07 at 12 22 26 PM" src="https://github.com/user-attachments/assets/7d0f5aef-1ade-4512-b747-39d685b6a89a" />

* **Team member with limited capabilities** — rows the member can’t act on are hidden instead of bouncing off the route guards (referrals/WooPayments rows need referrals access, marketplace rows need marketplace access, and the Review/Review sites/Set up listing rows need their sections). If nothing is actionable, the whole card hides.

<img width="688" height="272" alt="Screenshot 2026-08-13 at 3 06 29 PM" src="https://github.com/user-attachments/assets/153f4f1b-7742-4cc1-a85f-d31411cb7458" />


* **New dashboard** — the same section renders below the tier card on the MSD Overview (development).
* **Tooltip** — the “Influenced revenue” info popover renders its text at 13px in both apps.
* **Tracks** — clicking any action fires `calypso_a4a_overview_growth_action_click` with `action_id` and `agency_tier`.

### Where each button goes

**Pending — “While you wait”**

| Row | Button | New dashboard | Classic dashboard |
|---|---|---|---|
| Read the partner program guide | Read | agencieshelp.automattic.com/knowledge-base/agency-tiering-benefits (new tab) | same |
| Explore the Marketplace | Explore | `/marketplace/exclusive-offers` | `/marketplace/products` |

**All “Grow toward” tiers (Account activated, Agency Partner, Pro / VIP Pro)**

| Row | Button | New dashboard | Classic dashboard |
|---|---|---|---|
| Refer products & hosting | Refer | `/earn/referrals` | `/referrals/dashboard` |
| Directly purchase products & hosting | Browse | `/marketplace/exclusive-offers` | `/marketplace/products` |
| Set up WooPayments | Set up | `/earn/woopayments` | `/woopayments` |

**Premier — “Get the most from Premier”**

| Row | Button | New dashboard | Classic dashboard |
|---|---|---|---|
| Get listed in the Partner Directory *(not listed)* | Set up listing | `#partner-directory` (placeholder until the screen exists) | `/partner-directory/dashboard` |
| Move sites to Automattic hosting *(listed)* | Review sites | `/sites` | `/sites` |
| Set up WooPayments on more stores | Set up | `/earn/woopayments` | `/woopayments` |
| Use your Marketing Development Funds | Learn more | automattic.com/for-agencies/program-incentives/ (new tab) | same |

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)







