### PR TITLE
Dashboard: wrap DomainExpiryField text returns in <span> to survive page translation

### DIFF
--- a/client/dashboard/domains/dataviews/field-expiry.tsx
+++ b/client/dashboard/domains/dataviews/field-expiry.tsx
@@ -29,6 +29,8 @@ export const DomainExpiryField = ( {
 	}
 
 	if ( domain.expiry === null ) {
+		// Wrapping span are a work around to an issue where Google Translate crashes the page.
+		// A known React issue: react/react#11538
 		if ( domain.subtype.id === DomainSubtype.DEFAULT_ADDRESS ) {
 			return <span>{ __( 'Free forever' ) }</span>;
 		}

--- a/client/dashboard/domains/dataviews/field-expiry.tsx
+++ b/client/dashboard/domains/dataviews/field-expiry.tsx
@@ -30,9 +30,9 @@ export const DomainExpiryField = ( {
 
 	if ( domain.expiry === null ) {
 		if ( domain.subtype.id === DomainSubtype.DEFAULT_ADDRESS ) {
-			return __( 'Free forever' );
+			return <span>{ __( 'Free forever' ) }</span>;
 		}
-		return '-';
+		return <span>-</span>;
 	}
 
 	const renewLabel = domain.auto_renewing


### PR DESCRIPTION
## Proposed Changes

* Wrap the two bare string returns in `DomainExpiryField` (`Free forever` and `-`) in `<span>` elements, so React commits an element boundary rather than a raw text node in these branches.

This is a **more selective alternative to #113375**, which installs a global `Node.prototype.insertBefore`/`removeChild` guard at Dashboard boot. We shall compare the two approaches in code review.

Fixes DOTMSD-1401

## Why are these changes being made?

Production Sentry issue `CALYPSO-3G00` (`dashboard-production`) reports a steadily climbing volume of:

> NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.

thrown from React's commit phase. This is the well-known class of crash where something outside React — overwhelmingly browser page-translation (Google Translate) and extensions like Grammarly — rewrites the text nodes React manages (e.g. wrapping them in `<font>`), so React's cached sibling reference is no longer a child when it commits and the browser throws. Because it throws during **commit**, it escapes TanStack Router's error handling and tears down the whole React tree. See facebook/react#11538.

When a component returns a bare string, React renders it as a raw text node with no wrapping element. Those are exactly the nodes translation tools reparent. Wrapping them in a `<span>` gives React a stable element boundary that survives the text-node rewrite.

Unlike the global guard in #113375, this only touches the fields we know surface the crash, and keeps browser translation fully working. The trade-off: it addresses these specific returns rather than the whole class of crash.

## Testing Instructions

* `yarn typecheck-client` passes.
* Manual:
  * load the site overview page on a site which shows the domain dataview
  * in Chrome
  * choose "Translate to …" on the page, that enables Google Translate
  * Navigate/interact. Best way I could reproduce was to go back to site list then back to the site overview
  * Before this change the page can show an error; after, it stays up.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

