### PR TITLE
A4A: Make Earn tables consistent with DataViews defaults

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -93,12 +93,6 @@ $data-view-border-color: #f1f1f1;
 		max-width: 700px;
 	}
 
-	// DataViews hides table row actions until the row is hovered or focused.
-	// Opening a referral is the point of the row, so keep the action visible.
-	.dataviews-view-table tr .dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
-		opacity: 1;
-	}
-
 	// Scoped to the list column so the detail view's cards keep their own inset.
 	.referrals-layout__column .referrals-consolidated-views {
 		// The HStack is `width: 100%` and content-box, so the inline padding would

--- a/client/dashboard/agency/earn/woopayments/commissions-table.tsx
+++ b/client/dashboard/agency/earn/woopayments/commissions-table.tsx
@@ -47,8 +47,8 @@ export default function CommissionsTable( {
 		search: '',
 		filters: [],
 		sort: { field: '', direction: 'asc' },
+		titleField: 'site',
 		fields: [
-			'site',
 			'transactions',
 			'commissionsPaid',
 			'timeframeCommissions',


### PR DESCRIPTION
Resolves A4A-3166, A4A-3167

## Proposed Changes

* On the WooPayments commissions page, the Site column is now the table’s title column, so site names render in the same medium weight as the primary columns on the Referrals and Migration commissions tables.
* On the Referrals dashboard, the “View details” row action now appears when a row is hovered or focused, instead of being visible at all times. This removes a style override and returns the table to the default behavior. Clicking the row still opens the referral details, and the action always stays visible on touch devices.

## Why are these changes being made?

* The Earn pages had drifted apart: the WooPayments table was the only one whose first column rendered in the normal weight, and the Referrals table was the only one in the product that kept its row action permanently visible. Every other table with a single row action (Reports, deployments, activity logs, blocked sites) reveals it on hover.
* The Referrals change reverses A4A-3130, which forced the action to be always visible. Making tables consistent with each other and with the design system’s default won out over that one-off.

## Testing Instructions

* WooPayments column:
  * Open the Dashboard (A4A) live link > Manually change the URL to /earn/woopayments.
  * Verify the site names in the Site column render in the medium (semi-bold) weight, matching the Client column on /earn/referrals.

<img width="1044" height="572" alt="Screenshot 2026-08-07 at 1 35 11 PM" src="https://github.com/user-attachments/assets/90457094-2c84-4323-b9fa-c697495607d9" />


* Referrals row action:
  * Open the A4A live link > go to Referrals → Dashboard (agency account with at least one referral).
  * Verify the “View details” chevron is hidden until you hover a row or focus it with the keyboard, matching the Reports table.
  * Verify clicking the row still opens the referral details.

<img width="1044" height="531" alt="Screenshot 2026-08-07 at 2 12 03 PM" src="https://github.com/user-attachments/assets/ecd107d7-bbb1-46b1-8389-aff28e450007" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
