### PR TITLE
People: Open user editor by ID

### DIFF
--- a/client/dashboard/components/logs-activity-formatted-block/index.tsx
+++ b/client/dashboard/components/logs-activity-formatted-block/index.tsx
@@ -125,15 +125,16 @@ const Person: BlockRenderer = ( { content, children, onClick, meta } ) => {
 		return <strong>{ children }</strong>;
 	}
 
-	const { siteId, name, activity, intent, section } = content;
+	const { siteId, userId, name, activity, intent, section } = content;
 
 	if ( ! siteId || ! name ) {
 		return <strong>{ children }</strong>;
 	}
+	const userPath = userId ? `user/${ userId }` : name;
 
 	return (
 		<a
-			href={ wpcomLink( `/people/edit/${ siteId }/${ name }` ) }
+			href={ wpcomLink( `/people/edit/${ siteId }/${ userPath }` ) }
 			onClick={ onClick }
 			data-activity={ activity ?? meta.activity }
 			data-section={ section ?? meta.section ?? 'users' }

--- a/client/dashboard/components/logs-activity-formatted-block/test/index.test.tsx
+++ b/client/dashboard/components/logs-activity-formatted-block/test/index.test.tsx
@@ -245,13 +245,28 @@ describe( 'Person blocks', () => {
 		renderFormatted( {
 			type: 'person',
 			siteId: 'site_id',
+			userId: 123,
 			name: 'tony',
 			children: [ 'Tony Stark' ],
 		} );
 
 		const link = screen.getByRole( 'link' );
-		expect( link ).toHaveAttribute( 'href', 'https://wordpress.com/people/edit/site_id/tony' );
+		expect( link ).toHaveAttribute( 'href', 'https://wordpress.com/people/edit/site_id/user/123' );
 		expect( link.querySelector( 'strong' ) ).toHaveTextContent( 'Tony Stark' );
+	} );
+
+	test( 'keeps legacy name-based people editor links', () => {
+		renderFormatted( {
+			type: 'person',
+			siteId: 'site_id',
+			name: 'tony',
+			children: [ 'Tony Stark' ],
+		} );
+
+		expect( screen.getByRole( 'link' ) ).toHaveAttribute(
+			'href',
+			'https://wordpress.com/people/edit/site_id/tony'
+		);
 	} );
 
 	test.each( [

--- a/client/dashboard/components/logs-activity-formatted-block/types.ts
+++ b/client/dashboard/components/logs-activity-formatted-block/types.ts
@@ -14,6 +14,7 @@ export interface ActivityBlockNode {
 	isTrashed?: boolean;
 	commentId?: number | string;
 	name?: string;
+	userId?: number | string;
 	siteSlug?: string;
 	pluginSlug?: string;
 	themeUri?: string;

--- a/client/data/users/test/use-update-user-mutation.test.tsx
+++ b/client/data/users/test/use-update-user-mutation.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import wp from 'calypso/lib/wp';
+import useUpdateUserMutation from '../use-update-user-mutation';
+import { getCacheKey } from '../use-user-query';
+import type { PropsWithChildren } from 'react';
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: {
+		post: jest.fn(),
+	},
+} ) );
+
+describe( 'useUpdateUserMutation', () => {
+	test( 'updates ID and login query caches', async () => {
+		const queryClient = new QueryClient();
+		const wrapper = ( { children }: PropsWithChildren ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+		const user = { ID: 123, login: 'Bug Repro User' };
+		jest.mocked( wp.req.post ).mockResolvedValue( user );
+		const onSuccess = jest.fn();
+		const { result } = renderHook( () => useUpdateUserMutation( 456, { onSuccess } ), {
+			wrapper,
+		} );
+
+		act( () => result.current.updateUser( 123, { roles: [ 'editor' ] } ) );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		expect( queryClient.getQueryData( getCacheKey( 456, 123 ) ) ).toEqual( user );
+		expect( queryClient.getQueryData( getCacheKey( 456, 'Bug Repro User' ) ) ).toEqual( user );
+		expect( onSuccess.mock.calls[ 0 ][ 0 ] ).toEqual( user );
+		expect( onSuccess.mock.calls[ 0 ][ 1 ] ).toEqual( {
+			userId: 123,
+			variables: { roles: [ 'editor' ] },
+		} );
+	} );
+} );

--- a/client/data/users/test/use-user-query.test.tsx
+++ b/client/data/users/test/use-user-query.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import wpcom from 'calypso/lib/wp';
+import useUserQuery from '../use-user-query';
+import type { PropsWithChildren } from 'react';
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: {
+		get: jest.fn(),
+	},
+} ) );
+
+const mockGet = jest.mocked( wpcom.req.get );
+
+describe( 'useUserQuery', () => {
+	let queryClient: QueryClient;
+	let wrapper: React.FC< PropsWithChildren >;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockGet.mockResolvedValue( { ID: 123 } );
+		queryClient = new QueryClient( {
+			defaultOptions: { queries: { retry: false } },
+		} );
+		wrapper = ( { children } ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+	} );
+
+	test( 'fetches users by numeric ID', async () => {
+		const { result } = renderHook( () => useUserQuery( 456, 123 ), { wrapper } );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( mockGet ).toHaveBeenCalledWith( '/sites/456/users/123' );
+	} );
+
+	test( 'keeps string identifiers as login lookups', async () => {
+		const { result } = renderHook( () => useUserQuery( 456, '123' ), { wrapper } );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( mockGet ).toHaveBeenCalledWith( '/sites/456/users/login:123' );
+	} );
+} );

--- a/client/data/users/use-update-user-mutation.js
+++ b/client/data/users/use-update-user-mutation.js
@@ -9,9 +9,10 @@ function useUpdateUserMutation( siteId, queryOptions = {} ) {
 		mutationFn: ( { userId, variables } ) =>
 			wp.req.post( `/sites/${ siteId }/users/${ userId }`, variables ),
 		...queryOptions,
-		onSuccess( data, ...rest ) {
+		onSuccess( data, variables, ...rest ) {
+			queryClient.setQueryData( getCacheKey( siteId, Number( variables.userId ) ), data );
 			queryClient.setQueryData( getCacheKey( siteId, data.login ), data );
-			queryOptions.onSuccess?.( data, ...rest );
+			queryOptions.onSuccess?.( data, variables, ...rest );
 		},
 	} );
 

--- a/client/data/users/use-user-query.js
+++ b/client/data/users/use-user-query.js
@@ -11,11 +11,9 @@ export const getCacheKey = ( siteId, userIdentifier ) => [
 ];
 
 const useUserQuery = ( siteId, userIdentifier, queryOptions = {} ) => {
-	const userPath = getUserPath( userIdentifier );
-
 	return useQuery( {
-		queryKey: [ 'user', siteId, userPath ],
-		queryFn: () => wpcom.req.get( `/sites/${ siteId }/users/${ userPath }` ),
+		queryKey: getCacheKey( siteId, userIdentifier ),
+		queryFn: () => wpcom.req.get( `/sites/${ siteId }/users/${ getUserPath( userIdentifier ) }` ),
 		...queryOptions,
 	} );
 };

--- a/client/data/users/use-user-query.js
+++ b/client/data/users/use-user-query.js
@@ -1,12 +1,21 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
-export const getCacheKey = ( siteId, login ) => [ 'user', siteId, login ];
+const getUserPath = ( userIdentifier ) =>
+	typeof userIdentifier === 'number' ? userIdentifier : `login:${ userIdentifier }`;
 
-const useUserQuery = ( siteId, login, queryOptions = {} ) => {
+export const getCacheKey = ( siteId, userIdentifier ) => [
+	'user',
+	siteId,
+	getUserPath( userIdentifier ),
+];
+
+const useUserQuery = ( siteId, userIdentifier, queryOptions = {} ) => {
+	const userPath = getUserPath( userIdentifier );
+
 	return useQuery( {
-		queryKey: getCacheKey( siteId, login ),
-		queryFn: () => wpcom.req.get( `/sites/${ siteId }/users/login:${ login }` ),
+		queryKey: [ 'user', siteId, userPath ],
+		queryFn: () => wpcom.req.get( `/sites/${ siteId }/users/${ userPath }` ),
 		...queryOptions,
 	} );
 };

--- a/client/my-sites/people/controller.jsx
+++ b/client/my-sites/people/controller.jsx
@@ -20,7 +20,7 @@ export default {
 	redirectToTeam,
 
 	enforceSiteEnding( context, next ) {
-		const siteId = getSiteFragment( context.path );
+		const siteId = context.params.site || getSiteFragment( context.path );
 
 		if ( ! siteId ) {
 			redirectToTeam( context );
@@ -202,7 +202,10 @@ function renderSingleTeamMember( context, next ) {
 	context.primary = (
 		<>
 			<SingleTeamMemberTitle />
-			<EditTeamMember userLogin={ context.params.user_login } />
+			<EditTeamMember
+				userId={ context.params.user_id ? Number( context.params.user_id ) : undefined }
+				userLogin={ context.params.user_login }
+			/>
 		</>
 	);
 	next();

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -24,6 +24,7 @@ import './style.scss';
 
 export const EditTeamMemberForm = ( {
 	siteId,
+	userId,
 	userLogin,
 	isJetpack,
 	isMultisite,
@@ -47,7 +48,13 @@ export const EditTeamMemberForm = ( {
 	};
 
 	const { markChanged, markSaved } = useProtectForm();
-	const { data: user, error, isLoading } = useUserQuery( siteId, userLogin, { retry: false } );
+	const {
+		data: user,
+		error,
+		isLoading,
+	} = useUserQuery( siteId, userId ?? userLogin, {
+		retry: false,
+	} );
 
 	useEffect( () => {
 		! isLoading && error && page.redirect( `/people/team/${ siteSlug }` );

--- a/client/my-sites/people/index.js
+++ b/client/my-sites/people/index.js
@@ -115,6 +115,16 @@ export default function () {
 	);
 
 	page(
+		'/people/edit/:site/user/:user_id',
+		peopleController.enforceSiteEnding,
+		siteSelection,
+		navigation,
+		peopleController.person,
+		makeLayout,
+		clientRender
+	);
+
+	page(
 		'/people/edit/:site_id/:user_login',
 		peopleController.enforceSiteEnding,
 		siteSelection,

--- a/client/my-sites/people/people-list-item/index.tsx
+++ b/client/my-sites/people/people-list-item/index.tsx
@@ -189,7 +189,7 @@ const PeopleListItem: React.FC< PeopleListItemProps > = ( {
 				return `/people/viewers/${ site?.slug }/${ user?.ID }`;
 
 			default:
-				return canLinkToProfile() && `/people/edit/${ site?.slug }/${ user?.login }`;
+				return canLinkToProfile() && `/people/edit/${ site?.slug }/user/${ user?.ID }`;
 		}
 	};
 

--- a/client/my-sites/people/people-list-item/test/index.tsx
+++ b/client/my-sites/people/people-list-item/test/index.tsx
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import PeopleListItem from '../index';
+import type { Member, SiteDetails } from '@automattic/data-stores';
+import type { ComponentType } from 'react';
+
+jest.mock( '@automattic/data-stores', () => ( {
+	useSendInvites: () => ( {
+		isPending: false,
+		mutateAsync: jest.fn(),
+	} ),
+} ) );
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: ( Component: ComponentType ) => Component,
+	translate: ( text: string ) => text,
+	useTranslate: () => ( text: string ) => text,
+} ) );
+
+jest.mock( 'calypso/lib/site/utils', () => ( {
+	userCan: () => true,
+} ) );
+
+jest.mock( 'calypso/my-sites/people/people-profile', () => () => <span>User profile</span> );
+
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => jest.fn(),
+	useSelector: () => false,
+} ) );
+
+jest.mock( 'calypso/state/analytics/actions', () => ( {
+	composeAnalytics: jest.fn(),
+	recordGoogleEvent: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/analytics/actions/record', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/invites/actions', () => ( {
+	requestSiteInvites: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/notices/actions', () => ( {
+	createNotice: jest.fn(),
+	removeNotice: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/sites/selectors', () => ( {
+	isSimpleSite: jest.fn(),
+} ) );
+
+describe( 'PeopleListItem', () => {
+	test( 'links team members by user ID', () => {
+		const user = {
+			ID: 123,
+			login: 'Bug Repro User',
+			roles: [ 'author' ],
+		} as Member;
+		const site = {
+			ID: 456,
+			slug: 'example.wordpress.com',
+			capabilities: { promote_users: true },
+		} as SiteDetails;
+
+		render( <PeopleListItem site={ site } user={ user } /> );
+
+		expect( screen.getByRole( 'link' ) ).toHaveAttribute(
+			'href',
+			'/people/edit/example.wordpress.com/user/123'
+		);
+	} );
+} );


### PR DESCRIPTION
Fixes DOTCOM-17762

## Proposed Changes

* Add an ID-backed People edit route while retaining the existing login route for legacy links.
* Link People rows and Activity Log person entries using stable user IDs when available.
* Fetch ID-backed users from the numeric user endpoint and keep ID and login query caches synchronized after edits.
* Add regression coverage for generated links, query selection, legacy links, and mutation cache updates.

## Why are these changes being made?

Atomic users can have login names containing spaces. The login-based user endpoint returns `404 unknown_user` for these valid users, causing the edit page to redirect immediately back to the team list. The numeric user endpoint resolves the same users correctly.

## Testing Instructions

Automated checks completed:

* `yarn test-client client/data/users/test/use-user-query.test.tsx client/data/users/test/use-update-user-mutation.test.tsx client/my-sites/people/people-list-item/test/index.tsx client/dashboard/components/logs-activity-formatted-block/test/index.test.tsx`
* `yarn eslint [12 changed files]`
* `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client`
* `git diff --check`

Manual verification completed on a controlled Atomic site:

* Opened a user whose login contains spaces from the People team page.
* Confirmed the URL uses `/people/edit/{site}/user/{userId}` and the details page remains open instead of redirecting.
* Confirmed the expected user details render through the ID-backed route.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.org/api/hooks/using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
  - [ ] For UI changes, have you tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?