### PR TITLE
Dashboard: harden guided-tour selectors against bad translations

### DIFF
--- a/client/dashboard/sites/dataviews/sites-dataviews.tsx
+++ b/client/dashboard/sites/dataviews/sites-dataviews.tsx
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
 import { DataViews, DataViewsCard } from '../../components/dataviews';
@@ -89,7 +89,9 @@ export function SitesDataViews( {
 			>
 				<GuidedTourStep
 					id="hosting-dashboard-tours-sites-switch-layouts"
-					selector={ `.dataviews__view-actions button[aria-label="${ __( 'Layout' ) }"]` }
+					selector={ `.dataviews__view-actions button[aria-label=${ CSS.escape(
+						__( 'Layout' )
+					) }]` }
 					placement="bottom"
 					inline
 					// The footer in DataViews uses a z-index of 2, so we need to apply the same value to ensure our element does not appear behind it.
@@ -97,7 +99,9 @@ export function SitesDataViews( {
 				/>
 				<GuidedTourStep
 					id="hosting-dashboard-tours-sites-appearance-options"
-					selector={ `.dataviews__view-actions button[aria-label="${ __( 'View options' ) }"]` }
+					selector={ `.dataviews__view-actions button[aria-label=${ CSS.escape(
+						_x( 'View options', 'View is used as a noun' )
+					) }]` }
 					placement="bottom"
 					inline
 					popoverStyle={ { zIndex: 2 } }


### PR DESCRIPTION
Fixes Sentry CALYPSO-3G1D (`SyntaxError` in `getAsyncElement`).
Fixes DOTMSD-1494

## Proposed Changes

* Escape the interpolated `aria-label` value in the sites guided-tour selectors with `CSS.escape()`, so a malformed translation can no longer produce an invalid CSS selector.
* Match the View options step to the button's real translation call — `_x( 'View options', 'View is used as a noun' )` instead of the context-less `__( 'View options' )` — so the step resolves in non-English locales.

## Why are these changes being made?

The guided-tour step builds a `document.querySelector` string by interpolating a translated label straight into `[aria-label="…"]`:

```
`.dataviews__view-actions button[aria-label="${ __( 'Layout' ) }"]`
```

`__()` returns whatever GlotPress ships for the locale. The `zh-sg` bundle has a garbage translation for the source string `Layout` — a multi-line book blurb ("This book contains carefully selected tests and exercises…"). Its embedded newlines terminate the CSS string, making the whole selector invalid, so `querySelector` throws `SyntaxError`. `useAsyncElement()` runs on mount before the tour's active/completed guard, so every `zh-sg` visitor to `/sites` hit it (6 users / 8 events in Sentry).

`CSS.escape()` renders any translated value — newlines, quotes, anything — into a valid unquoted attribute-selector token, so no locale's data can break the selector again. No `try/catch` is added: a genuinely malformed selector should still surface to Sentry.

The `_x` context fix is a latent-bug cleanup: the DOM button uses a contextual translation, so the old context-less lookup silently failed to match in localized UIs.

Note: the bad `zh-sg` "Layout" translation should also be corrected at the source in GlotPress; this PR only makes the consumer resilient to it.

## Testing Instructions

* Change your language to zh-sg, that is, 中文
* Open `/sites`, and confirm no `SyntaxError` in the console.
* Clear the tour setting from your preferences to make sure the tour popups up
* In English, confirm the Sites guided tour still anchors to the Layout and View options buttons.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
