### PR TITLE
A4A: Remove DataViews override on the Needs Setup sites page

### DIFF
--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/style.scss
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/style.scss
@@ -64,12 +64,6 @@
 	}
 }
 
-.sites-dashboard.is-without-filters {
-	.dataviews-view-table {
-		margin-block-start: 32px;
-	}
-}
-
 .has-product-referral {
 	.plan-field {
 		padding-inline: 8px;


### PR DESCRIPTION
## Proposed Changes

* Remove the custom spacing override applied to the table on the Needs Setup sites page, so it uses the default DataViews styling.

| Before | After |
|--------|--------|
| <img width="2310" height="315" alt="Screenshot 2026-08-07 at 7 03 13 PM" src="https://github.com/user-attachments/assets/e8bed204-fe3e-474b-96d6-77423f20e9dd" /> | <img width="2305" height="284" alt="Screenshot 2026-08-07 at 7 03 03 PM" src="https://github.com/user-attachments/assets/e8709602-e113-4393-af01-01fef7e2ec02" /> | 

## Why are these changes being made?

* The Needs Setup table was the only place carrying a bespoke tweak on top of DataViews. Dropping it keeps the page consistent with every other DataViews table in A4A and removes styling we'd otherwise have to maintain as the design system evolves.

## Testing Instructions

* Go to Sites → Needs Setup in Automattic for Agencies.
* Confirm the table renders correctly and its spacing matches other DataViews tables in the product (e.g. the main Sites list).
* Check it in both light and dark mode, and at mobile width.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
