### PR TITLE
Suppress dashboard email DNS warning for WordPress.com-managed domains

### DIFF
--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 import { connect, useSelector } from 'react-redux';
 import SiteIcon from 'calypso/blocks/site-icon';
 import AsyncLoad from 'calypso/components/async-load';
+import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import EmptyContent from 'calypso/components/empty-content';
 import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -330,6 +331,7 @@ const HomeContent = ( {
 
 	return (
 		<div className="customer-home__main">
+			{ siteId && <QuerySiteDomains siteId={ siteId } /> }
 			{ siteId && isJetpack && isPossibleJetpackConnectionProblem && (
 				<JetpackConnectionHealthBanner siteId={ siteId } />
 			) }

--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -254,7 +254,12 @@ const HomeContent = ( {
 			isFetchingDomainDiagnostics ||
 			! emailDnsDiagnostics ||
 			emailDnsDiagnostics.code === 'domain_not_mapped_to_atomic_site' ||
-			emailDnsDiagnostics.all_essential_email_dns_records_are_correct
+			emailDnsDiagnostics.all_essential_email_dns_records_are_correct ||
+			// When WordPress.com controls the domain's DNS and can restore the records
+			// automatically, don't alarm the user on the dashboard. The Diagnostics card
+			// in domain settings still surfaces the issue with a one-click fix.
+			( emailDnsDiagnostics.is_using_wpcom_name_servers &&
+				emailDnsDiagnostics.should_offer_automatic_fixes )
 		) {
 			return null;
 		}


### PR DESCRIPTION
Part of DOMENG-807

## Proposed Changes

* **Fetch the site's domains on My Home.** `customer-home` decides whether to show the email-DNS diagnostics warning based on the primary domain in Redux (`getDomainsBySiteId`), but it never fetched the domains itself. Since Domains/Upgrades now open the separate MSD app via a hard navigation, the classic SPA's Redux domains slice is never populated on My Home, so the diagnostics query stays disabled and the warning can't render. This adds `<QuerySiteDomains>` so the notice behaves deterministically.
* **Suppress the warning for WordPress.com-managed, auto-fixable domains.** When the domain uses WordPress.com name servers and the missing email DNS records can be restored automatically (`is_using_wpcom_name_servers && should_offer_automatic_fixes`), the alarming My Home notice is no longer shown. The Diagnostics card under Domain settings is unchanged and still surfaces the issue with the one-click "Fix DNS issues automatically" action.

## Why are these changes being made?

Right after buying a domain and a Commerce (eCommerce) plan through checkout, the site is Atomic and the domain uses our name servers, but the essential email DNS records (SPF/DKIM/DMARC) may not be populated yet. The dashboard would show an alarming "something is wrong" warning for a domain we control and can fix ourselves. This suppresses that dashboard alarm for the case where WordPress.com manages the domain and can auto-remediate, while keeping the actionable fix available in Domain settings.

Note: fully closing DOMENG-807 likely also wants a backend change to provision these records automatically at registration/checkout time. This is the Calypso-side improvement.

## Testing Instructions

### Background

The email-DNS warning on My Home is gated on the site's primary domain being in Redux, which trunk never populates on My Home (see the first change above). Because of that, the "before" state can't be reproduced on production/trunk. Use the companion **DON'T MERGE** PR #113394 (adds only `<QuerySiteDomains>`, no suppression) to see the warning, and this PR to confirm it's suppressed.

### Setup

1. Create an eCommerce/Commerce (Atomic) site, register a custom domain through checkout, and set it as the primary domain (it will be on WordPress.com name servers).
2. Pollute the email DNS: in the domain's DNS records, remove the SPF record and/or break the DMARC record.
3. Confirm `GET /wpcom/v2/domains/diagnostics/<domain>` returns `all_essential_email_dns_records_are_correct: false`, with `is_using_wpcom_name_servers: true` and `should_offer_automatic_fixes: true`.

### Current (broken) behaviour — warning present

1. Open the companion PR #113394 Calypso Live build and go to `/home/<domain>`.
2. The red email-DNS warning appears at the top of My Home.

<img width="1440" height="941" alt="Screenshot 2026-08-07 at 17 54 54" src="https://github.com/user-attachments/assets/cfa6c69f-5ff3-44f3-8bec-13b54e24e73c" />

### This PR — warning suppressed

1. Open this PR's Calypso Live build and go to `/home/<domain>`.
2. The warning is **not** shown (the domain is fetched, but the notice is suppressed because we control the DNS and can auto-fix it).
4. Negative check: on a domain using external name servers (`is_using_wpcom_name_servers: false`), the warning still shows — we only silence the case we can auto-fix.
5. The Diagnostics card under Domain settings is unchanged and still surfaces the issue with the one-click fix.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? (No new strings in this PR.)
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
