### PR TITLE
A4A: Keep slider line below marker

### DIFF
--- a/client/a8c-for-agencies/components/slider/style.scss
+++ b/client/a8c-for-agencies/components/slider/style.scss
@@ -17,8 +17,20 @@
 
 .a4a-slider__input {
 	position: relative;
+	isolation: isolate;
 	flex-grow: 1;
 	margin-block-start: -16px;
+
+	&::before {
+		content: "";
+		position: absolute;
+		inset-block-start: 22px;
+		inset-inline: 0;
+		min-height: 6px;
+		background: var(--color-primary-5);
+		border-radius: 4px;
+		pointer-events: none;
+	}
 
 	@include break-medium {
 		margin-block-start: 0;
@@ -28,6 +40,8 @@
 .a4a-slider__input [type="range"] {
 	-webkit-appearance: none;
 	appearance: none;
+	position: relative;
+	z-index: 3;
 	background: transparent;
 	height: 50px;
 	width: 100%;
@@ -43,7 +57,7 @@
 	}
 
 	@mixin slider-track-style {
-		background: var(--color-primary-5);
+		background: transparent;
 		height: 6px;
 		border-radius: 4px;
 	}
@@ -80,6 +94,7 @@
 
 .a4a-slider__marker-container {
 	position: relative;
+	z-index: 4;
 	margin-block-start: -24px;
 	display: flex;
 	align-items: flex-start;


### PR DESCRIPTION
Resolves A4A-3115

## Proposed Changes

- Make the A4A Marketplace slider track layering consistent across browsers.
- Keep the selected and disabled track segments below the circular slider thumb.
- Preserve the current slider layout and interactions.

<img width="1092" height="305" alt="image" src="https://github.com/user-attachments/assets/5dcd288c-20b5-4c91-bcbd-fa8db878cbca" />


## Why are these changes being made?

Firefox can paint the selected track segment above the current-plan marker because it stacks native range controls differently from Chromium. A deterministic layer order keeps the marker visible in every supported browser.

## Testing Instructions

- Open A4A Marketplace → Hosting → Pressable.
- Select larger plans with the WordPress installs slider in Firefox and Chrome.
- Verify the colored line stays below the circular marker.
- Verify keyboard changes and marker clicks still work.
- Check the WordPress.com plan slider and a Pressable plan with an existing-plan minimum.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the “[Status] String Freeze” label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have you tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the “[Status] Needs Privacy Updates” label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

*— ClemenAgent (Powered by Codex)*
