### PR TITLE
Domain Search: fix darker suggestion row dividers after components v37 bump

### DIFF
--- a/packages/domain-search/src/ui/domain-suggestions-list/style.scss
+++ b/packages/domain-search/src/ui/domain-suggestions-list/style.scss
@@ -1,3 +1,4 @@
-.domain-suggestions-list__divider {
+hr.domain-suggestions-list__divider {
 	background: none;
+	border-color: var( --color-border-secondary );
 }


### PR DESCRIPTION
## Proposed Changes

* Fix the domain suggestions list row dividers rendering in a darker gray (~`rgb(128,128,128)`) instead of the intended subtle `rgba(0,0,0,0.1)` line.

**Before:**
<img width="1193" height="994" alt="Screenshot 2026-08-07 at 17 34 41" src="https://github.com/user-attachments/assets/324c04bd-9b4e-4f47-a7a0-686cbb655105" />

**After:**
<img width="1156" height="1053" alt="Screenshot 2026-08-07 at 17 58 29" src="https://github.com/user-attachments/assets/0d0591fa-f024-43a0-a334-837ae59e608a" />

## Why are these changes being made?

The `@wordpress/components` 35 → 37 bump (#112947) switched the base `Divider` component to color its line via the **logical** `border-block-end: 1px solid currentColor`. A logical longhand outranks `Card`'s **physical** `border-color: colorDivider` override in the cascade, so the `CardDivider` used for the row separators fell back to `currentColor` (~`rgb(128,128,128)`) — a much darker line than before.

The pre-existing local override (`.domain-suggestions-list__divider { background: none }`) never touched the border color, so it had no effect on this.

This re-asserts the intended divider color using a matching logical longhand (`border-block-end-color`) at winning specificity (`hr.` element + class), restoring the pre-bump `rgba(0,0,0,0.1)` appearance. This value is WordPress's own `CONFIG.colorDivider` constant and is already used raw elsewhere in this package.

## Testing Instructions

* Go to the domains search page and search for a term that returns suggestions (e.g. `ecommercetesting77`).
* Verify the horizontal separator lines between the non-featured suggestion rows are a light/subtle gray, not a dark medium gray.
* Before this fix the separators were a dark medium gray; after, they are the subtle light gray line.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
