### PR TITLE
Gravatar domains: search the name, not the advertised domain

### DIFF
--- a/client/signup/steps/domains/index.tsx
+++ b/client/signup/steps/domains/index.tsx
@@ -87,8 +87,19 @@ const DomainSearchUI = (
 	// eslint-disable-next-line no-nested-ternary
 	const currentSiteId = site?.ID ? site.ID : siteId ? parseInt( siteId, 10 ) : undefined;
 
+	// The Gravatar offer links here with the full domain it advertised (e.g. `example.link`).
+	// Searching for that verbatim returns a single exact match at its undiscounted price and
+	// hides the other TLDs the offer covers, so search on the name alone instead.
+	const initialQuery = useMemo( () => {
+		if ( isDomainForGravatarFlow( flowName ) ) {
+			return queryObject.new?.split( '.' )[ 0 ];
+		}
+
+		return queryObject.new;
+	}, [ flowName, queryObject.new ] );
+
 	const { query, setQuery, clearQuery } = useQueryHandler( {
-		initialQuery: queryObject.new,
+		initialQuery,
 		currentSiteUrl,
 	} );
 

--- a/client/signup/steps/domains/test/index.tsx
+++ b/client/signup/steps/domains/test/index.tsx
@@ -10,15 +10,17 @@ jest.mock( 'calypso/components/domains/wpcom-domain-search', () => ( {
 	WPCOMDomainSearch: jest.fn().mockReturnValue( null ),
 } ) );
 jest.mock( 'calypso/components/domains/wpcom-domain-search/use-query-handler', () => ( {
-	useQueryHandler: () => ( { query: '', setQuery: jest.fn(), clearQuery: jest.fn() } ),
+	useQueryHandler: jest.fn( () => ( { query: '', setQuery: jest.fn(), clearQuery: jest.fn() } ) ),
 } ) );
 
 import React from 'react';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
+import { useQueryHandler } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import DomainSearchStep from '../';
 
 const mockWPCOMDomainSearch = WPCOMDomainSearch as jest.Mock;
+const mockUseQueryHandler = useQueryHandler as jest.Mock;
 
 const domainItem = { meta: 'example.com', product_slug: 'domain_reg' };
 
@@ -135,5 +137,36 @@ describe( 'DomainSearchStep — domain-only checkout simplification', () => {
 			} )
 		);
 		expect( goToNextStep ).toHaveBeenCalledTimes( 1 );
+	} );
+} );
+
+describe( 'DomainSearchStep — Gravatar domain prefill', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockWPCOMDomainSearch.mockReturnValue( null );
+	} );
+
+	it( 'strips the TLD from the prefilled query so every included TLD stays visible', () => {
+		renderWithProvider(
+			<DomainSearchStep
+				{ ...baseProps }
+				flowName="domain-for-gravatar"
+				queryObject={ { new: 'example.link' } }
+			/>
+		);
+
+		expect( mockUseQueryHandler ).toHaveBeenCalledWith(
+			expect.objectContaining( { initialQuery: 'example' } )
+		);
+	} );
+
+	it( 'leaves the prefilled query untouched in other flows', () => {
+		renderWithProvider(
+			<DomainSearchStep { ...baseProps } queryObject={ { new: 'example.link' } } />
+		);
+
+		expect( mockUseQueryHandler ).toHaveBeenCalledWith(
+			expect.objectContaining( { initialQuery: 'example.link' } )
+		);
 	} );
 } );


### PR DESCRIPTION
## Proposed Changes

Strip the TLD from the prefilled domain query in the Gravatar flow, so the domain step searches on the name alone.

## Why are these changes being made?

The Gravatar "free domain" offer links into the domain step with the full domain it advertised:

```
/start/domain-for-gravatar/domain-only?new=example.link
```

`initialQuery` is seeded verbatim from `?new=`, so the step searches for `example.link` rather than `example`. Two consequences:

- Results collapse to a single **Exact match** card for `.link`.
- That card renders at its undiscounted price (€9/yr when I reproduced it), while the offer's other TLDs — `.art`, `.blog`, `.bio`, `.fyi`, `.guru`, `.life`, `.live`, `.online`, `.social` … — never render at all, so their €0 first-year pricing is never seen.

The domain *is* eligible for the offer. Clearing the `.link` suffix by hand and re-searching shows it free. It is only the prefilled exact-match path that misprices it. Net effect: on a page selling a free domain, the largest and most prominent card is the only one showing a price.

Scoped to `isDomainForGravatarFlow`, so every other flow keeps exact-match behaviour — searching `example.com` elsewhere still returns a priced exact match as before.

`split( '.' )[ 0 ]` matches the existing idiom in `use-query-handler.ts` for reducing a host to its first label.

## Testing Instructions

1. Visit `/start/domain-for-gravatar/domain-only?new=example.link`.
2. The search box should contain `example`, not `example.link`.
3. The full suggestion list renders, with the offer's TLDs showing €0 for the first year — including `.link`.
4. Sanity-check another flow, e.g. `/start/domain/domain-only?new=example.com`. Unchanged: still an exact-match card at its normal price.

Note: the offer is limited to one free domain per user, so an account that has already redeemed one will see prices rather than €0. That is the offer logic, not this change.

Unit tests cover both branches.

## Note for reviewers

This is a guard on the receiving end. The promo itself still builds a `?new=` value with the TLD attached, which is worth fixing at source too so the intent is explicit at both ends — this PR makes the domain step resilient either way. I was not able to locate that generator; it appears to live outside this repo.
