### PR TITLE
A4A: Fix user profile menu alignment on mobile

### DIFF
--- a/client/a8c-for-agencies/components/sidebar/header/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/header/style.scss
@@ -1,5 +1,3 @@
-@import "calypso/assets/stylesheets/shared/mixins/breakpoints";
-
 @import "@wordpress/base-styles/variables";
 @import "@wordpress/base-styles/mixins";
 
@@ -56,13 +54,6 @@ html.accessible-focus .a4a-sidebar__profile-dropdown-button:focus {
 	position: absolute;
 	// 4px below the bottom of the icon
 	inset-block-start: calc(100% + 4px);
-
-	// Float the dropdown to the left on small screens,
-	// and to the right on larger screens
-	inset-inline-end: 0;
-	@include breakpoint-deprecated( ">660px" ) {
-		inset-inline-end: initial;
-	}
 
 	// The menu should render "on top" of the profile picture & site switcher
 	z-index: 20;


### PR DESCRIPTION
## Proposed Changes

* Align the sidebar user profile menu with the avatar button that opens it on mobile.

| Before | After |
|--------|--------|
| <img width="404" height="703" alt="Screenshot 2026-08-07 at 8 28 34 PM" src="https://github.com/user-attachments/assets/8d852ce4-d8eb-4a38-9bfb-c10ffbee96dc" /> | <img width="396" height="693" alt="Screenshot 2026-08-07 at 8 27 22 PM" src="https://github.com/user-attachments/assets/06a2dae5-fd07-4eed-b5ec-4514dbbf724f" /> | 

## Why are these changes being made?

* On mobile, opening the user menu from the sidebar pushed it flush against the right edge of the screen, while the avatar that opens it sits on the left. The menu looked detached from its button. Wide screens were already correct and are unchanged.

## Testing Instructions

* Open Automattic for Agencies and resize the browser to a narrow width (under 660px), or use a mobile device.
* Open the sidebar and click the profile avatar.
* The menu should open directly below the avatar, aligned to it.
* Widen the browser again and confirm the menu still looks the same as before.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
