### PR TITLE
Omnibar: ensure relative and absolute paths land in correct URLs

### DIFF
--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -8,6 +8,7 @@ import { isSupportSession } from '@automattic/calypso-support-session';
 import { AdminBarNode, Omnibar, buildOmnibarNodesFromAdminBarNodes } from '@automattic/omnibar';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
+import { wpcomLink } from '../../utils/link';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { useAppContext } from '../context';
 import { omnibarEvents } from './events';
@@ -36,6 +37,27 @@ function removeUnsupportedNodes( nodes: AdminBarNode[], supports: AppConfig[ 'su
 	return nodes.filter( ( node ) => node.id !== 'command-palette' || supports.commandPalette );
 }
 
+function createHrefResolver( adminUrl?: string ) {
+	return ( href: string ) => {
+		let url;
+		try {
+			url = new URL( href, adminUrl );
+		} catch {
+			return href;
+		}
+
+		const path = url.pathname + url.search + url.hash;
+
+		if ( url.host === 'my.wordpress.com' ) {
+			return path;
+		}
+		if ( url.host === 'wordpress.com' ) {
+			return wpcomLink( path );
+		}
+		return url.href;
+	};
+}
+
 export default function OmnibarContainer( { user }: { user?: User } ) {
 	const { supports } = useAppContext();
 	const [ hydrated, setHydrated ] = useState( false );
@@ -59,7 +81,8 @@ export default function OmnibarContainer( { user }: { user?: User } ) {
 		const nodes = siteNodes ?? dashboardNodes ?? [];
 		const result = buildOmnibarNodesFromAdminBarNodes(
 			removeUnsupportedNodes( nodes, supports ),
-			DOTCOM_NODE_BUILDERS
+			DOTCOM_NODE_BUILDERS,
+			createHrefResolver( siteNodes ? site?.options?.admin_url : undefined )
 		);
 
 		if ( ! result.home ) {

--- a/client/dashboard/app/omnibar/plugin-notifications.tsx
+++ b/client/dashboard/app/omnibar/plugin-notifications.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { useEffect, useRef, useState } from 'react';
+import { wpcomLink } from '../../utils/link';
 import { omnibarEvents, useOmnibarEvent } from './events';
 import type { User } from '@automattic/api-core';
 import type { OmnibarNode } from '@automattic/omnibar';
@@ -30,7 +31,7 @@ export function useNotificationsPlugin( { user }: { user?: User } ): OmnibarNode
 
 	// Re-runs every commit so the anchor stays correct if the bell button is replaced.
 	useEffect( () => {
-		omnibarEvents.notificationsAnchor.emit( bellRef.current?.closest( 'button' ) ?? null );
+		omnibarEvents.notificationsAnchor.emit( bellRef.current?.closest( 'a' ) ?? null );
 	} );
 
 	return {
@@ -41,6 +42,10 @@ export function useNotificationsPlugin( { user }: { user?: User } ): OmnibarNode
 				<BellIcon hasUnread={ hasUnseenNotifications } />
 			</span>
 		),
-		onClick: () => omnibarEvents.notifications.emit(),
+		href: wpcomLink( '/notifications' ),
+		onClick: ( event ) => {
+			event.preventDefault();
+			omnibarEvents.notifications.emit();
+		},
 	};
 }

--- a/packages/omnibar/src/components/omnibar-menu.tsx
+++ b/packages/omnibar/src/components/omnibar-menu.tsx
@@ -121,15 +121,30 @@ export function OmnibarMenu( { node, className }: { node: OmnibarNode; className
 		setIsOpen( open );
 	};
 
+	const handleTouchEnd = ( event: React.TouchEvent ) => {
+		if ( ! node.href ) {
+			return;
+		}
+		event.preventDefault();
+		setIsOpen( ( open ) => ! open );
+	};
+
 	return (
 		<Menu open={ isOpen } onOpenChange={ handleOpenChange }>
 			<Menu.TriggerButton
 				ref={ triggerRef }
 				onMouseEnter={ () => setIsOpen( true ) }
 				onMouseLeave={ handleMouseLeave }
+				onTouchEnd={ handleTouchEnd }
 				aria-expanded={ isOpen }
 				render={
-					<Button variant="unstyled" className={ menuClassName } aria-label={ label }>
+					<Button
+						variant="unstyled"
+						className={ menuClassName }
+						aria-label={ label }
+						render={ node.href ? <a href={ node.href } /> : undefined }
+						nativeButton={ ! node.href }
+					>
 						<OmnibarNodeContent node={ node } />
 					</Button>
 				}

--- a/packages/omnibar/src/types/index.ts
+++ b/packages/omnibar/src/types/index.ts
@@ -1,2 +1,8 @@
 export type { AdminBarNode } from './admin-bar';
-export type { OmnibarNode, OmnibarNodeBuilders, OmnibarNodes, OmnibarProps } from './omnibar';
+export type {
+	OmnibarHrefResolver,
+	OmnibarNode,
+	OmnibarNodeBuilders,
+	OmnibarNodes,
+	OmnibarProps,
+} from './omnibar';

--- a/packages/omnibar/src/types/omnibar.ts
+++ b/packages/omnibar/src/types/omnibar.ts
@@ -8,7 +8,7 @@ export interface OmnibarNode {
 	group?: boolean;
 	variant?: 'secondary';
 	href?: string;
-	onClick?: () => void;
+	onClick?: ( event: React.MouseEvent ) => void;
 	interactive?: boolean;
 	meta?: SiteActionNodeMeta & UserInfoNodeMeta;
 	render?: ( node: OmnibarNode ) => React.ReactNode;
@@ -19,6 +19,8 @@ export type OmnibarNodeBuilders = Record<
 	string,
 	( adminBarNode: AdminBarNode ) => Partial< OmnibarNode >
 >;
+
+export type OmnibarHrefResolver = ( href: string ) => string;
 
 export interface SiteActionNodeMeta {
 	subtitle?: string;

--- a/packages/omnibar/src/utils/admin-bar.tsx
+++ b/packages/omnibar/src/utils/admin-bar.tsx
@@ -1,9 +1,16 @@
 import { dispatch } from '@wordpress/data';
-import type { AdminBarNode, OmnibarNode, OmnibarNodeBuilders, OmnibarNodes } from '../types';
+import type {
+	AdminBarNode,
+	OmnibarHrefResolver,
+	OmnibarNode,
+	OmnibarNodeBuilders,
+	OmnibarNodes,
+} from '../types';
 
 export function buildOmnibarNodesFromAdminBarNodes(
 	adminBarNodes: AdminBarNode[],
-	builders?: OmnibarNodeBuilders
+	builders?: OmnibarNodeBuilders,
+	resolveHref?: OmnibarHrefResolver
 ): OmnibarNodes {
 	const omnibarNodes: OmnibarNodes = {};
 	const siteActionNodes: OmnibarNode[] = [];
@@ -13,7 +20,7 @@ export function buildOmnibarNodesFromAdminBarNodes(
 		const omnibarNode: OmnibarNode = {
 			id: node.id,
 			title: node.meta?.menu_title || node.title || '',
-			href: node.href,
+			href: node.href && resolveHref ? resolveHref( node.href ) : node.href,
 			group: node.group,
 		};
 


### PR DESCRIPTION

## Proposed Changes

- Fix admin bar hrefs pointing at the wrong origin. `buildOmnibarNodesFromAdminBarNodes()` now accepts an OmnibarHrefResolver; createHrefResolver() in omnibar.tsx resolves relative hrefs against site.options.admin_url, rewrites `my.wordpress.com` to a bare path, and routes `wordpress.com` through wpcomLink().
- Render dropdown triggers (wp-logo, site-name, my-account, new-content) as anchors to retain their links.
- Give the notifications bell the `wpcomLink( '/notifications' )` fallback.

## Testing Instructions

Test with `dashboard/omnibar-radiccal` flag turned on.

1. Verify the site menu, when clicked, lands you to the site frontend.
2. Verify the `+ New` menu, when clicked, lands you to the post editor.
3. Verify the notification bell has the `wordpress.com/notifications` href (you can do Open in new tab on it).
