### PR TITLE
Analytics: preserve explicit blog IDs in super props

### DIFF
--- a/client/components/data/with-reader-related-posts/test/index.test.tsx
+++ b/client/components/data/with-reader-related-posts/test/index.test.tsx
@@ -66,9 +66,9 @@ describe( 'useRelatedPosts', () => {
 			wrapper: getWrapper(),
 		} );
 
-		await waitFor( () => expect( scope.isDone() ).toBe( true ) );
-		await waitFor( () => expect( result.current.posts ).toBeUndefined() );
-		expect( result.current.isError ).toBe( true );
+		await waitFor( () => expect( result.current.isError ).toBe( true ) );
+		expect( scope.isDone() ).toBe( true );
+		expect( result.current.posts ).toBeUndefined();
 	} );
 
 	it( 'returns an empty posts array when the request succeeds with no related posts', async () => {

--- a/client/lib/analytics/super-props.js
+++ b/client/lib/analytics/super-props.js
@@ -37,7 +37,7 @@ const getSuperProps = ( reduxStore ) => ( eventProperties ) => {
 	}
 
 	const explicitBlogId = getExplicitBlogId( eventProperties );
-	const path = eventProperties.path ?? getCurrentRoute( state );
+const path = eventProperties.path ?? getCurrentRoute( state ) ?? '';
 	const omitSelectedSite =
 		( ! eventProperties.force_site_id && shouldReportOmitBlogId( path ) ) ||
 		path.startsWith( '/reader' ); // Reader events need to track the blog that is being read, not the user's selected site

--- a/client/lib/analytics/super-props.js
+++ b/client/lib/analytics/super-props.js
@@ -12,6 +12,11 @@ function getSiteSlugOrIdFromURLSearchParams() {
 	return queryParams.get( 'siteSlug' ) || queryParams.get( 'siteId' );
 }
 
+function getExplicitBlogId( eventProperties ) {
+	const blogId = Number( eventProperties.blog_id );
+	return Number.isInteger( blogId ) && blogId > 0 ? blogId : null;
+}
+
 const getSuperProps = ( reduxStore ) => ( eventProperties ) => {
 	const state = reduxStore.getState();
 
@@ -31,27 +36,35 @@ const getSuperProps = ( reduxStore ) => ( eventProperties ) => {
 		} );
 	}
 
+	const explicitBlogId = getExplicitBlogId( eventProperties );
 	const path = eventProperties.path ?? getCurrentRoute( state );
 	const omitSelectedSite =
 		( ! eventProperties.force_site_id && shouldReportOmitBlogId( path ) ) ||
 		path.startsWith( '/reader' ); // Reader events need to track the blog that is being read, not the user's selected site
-	const selectedSite = omitSelectedSite
-		? null
-		: getSelectedSite( state ) || getSite( state, getSiteSlugOrIdFromURLSearchParams() );
+	let site = null;
+	if ( explicitBlogId ) {
+		site = getSite( state, explicitBlogId );
+	} else if ( ! omitSelectedSite ) {
+		site = getSelectedSite( state ) || getSite( state, getSiteSlugOrIdFromURLSearchParams() );
+	}
 
-	if ( selectedSite ) {
+	if ( explicitBlogId || site ) {
+		// Tracks expects a blog_id property to identify the blog which is
+		// why we use it here instead of calling the property site_id
+		superProps.blog_id = explicitBlogId ?? site.ID;
+	}
+
+	if ( site ) {
 		Object.assign( superProps, {
-			// Tracks expects a blog_id property to identify the blog which is
-			// why we use it here instead of calling the property site_id
-			blog_id: selectedSite.ID,
-
 			// Tracks expects a blog_lang property to identify the blog language which is
 			// why we use it here instead of calling the property site_language
-			blog_lang: selectedSite.lang,
+			blog_lang: site.lang,
 
-			site_id_label: selectedSite.jetpack ? 'jetpack' : 'wpcom',
-			site_plan_id: selectedSite.plan ? selectedSite.plan.product_id : null,
+			site_id_label: site.jetpack ? 'jetpack' : 'wpcom',
+			site_plan_id: site.plan ? site.plan.product_id : null,
 		} );
+	} else if ( explicitBlogId ) {
+		delete superProps.site_id_label;
 	}
 
 	return superProps;

--- a/client/lib/analytics/super-props.js
+++ b/client/lib/analytics/super-props.js
@@ -37,7 +37,7 @@ const getSuperProps = ( reduxStore ) => ( eventProperties ) => {
 	}
 
 	const explicitBlogId = getExplicitBlogId( eventProperties );
-const path = eventProperties.path ?? getCurrentRoute( state ) ?? '';
+	const path = eventProperties.path ?? getCurrentRoute( state ) ?? '';
 	const omitSelectedSite =
 		( ! eventProperties.force_site_id && shouldReportOmitBlogId( path ) ) ||
 		path.startsWith( '/reader' ); // Reader events need to track the blog that is being read, not the user's selected site

--- a/client/lib/analytics/test/super-props.js
+++ b/client/lib/analytics/test/super-props.js
@@ -107,6 +107,14 @@ describe( 'analytics super props', () => {
 		);
 	} );
 
+	test( 'keeps selected-site behavior when current route is unavailable', () => {
+		getCurrentRoute.mockReturnValue( null );
+
+		const superProps = getSuperProps( reduxStore )( {} );
+
+		expect( superProps.blog_id ).toBe( selectedSite.ID );
+	} );
+
 	test( 'ignores invalid explicit blog_id', () => {
 		const superProps = getSuperProps( reduxStore )( { blog_id: 0 } );
 

--- a/client/lib/analytics/test/super-props.js
+++ b/client/lib/analytics/test/super-props.js
@@ -1,0 +1,115 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { getConnectionSpeedData } from '@automattic/calypso-analytics';
+import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getSite } from 'calypso/state/sites/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import getSuperProps from '../super-props';
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	getConnectionSpeedData: jest.fn(),
+} ) );
+jest.mock( '@automattic/calypso-config', () => {
+	const config = jest.fn( ( key ) => key );
+	config.isEnabled = jest.fn( () => false );
+	return config;
+} );
+jest.mock( 'calypso/lib/analytics/utils', () => ( {
+	shouldReportOmitBlogId: jest.fn( ( path ) => path === '/me' ),
+} ) );
+jest.mock( 'calypso/state/current-user/selectors', () => ( {
+	getCurrentUserSiteCount: jest.fn(),
+} ) );
+jest.mock( 'calypso/state/selectors/get-current-route', () => jest.fn() );
+jest.mock( 'calypso/state/sites/selectors', () => ( {
+	getSite: jest.fn(),
+} ) );
+jest.mock( 'calypso/state/ui/selectors', () => ( {
+	getSelectedSite: jest.fn(),
+} ) );
+
+const state = {};
+const reduxStore = { getState: () => state };
+const selectedSite = {
+	ID: 111,
+	lang: 'en',
+	jetpack: false,
+	plan: { product_id: 1 },
+};
+const explicitSite = {
+	ID: 222,
+	lang: 'fr',
+	jetpack: true,
+	plan: { product_id: 2 },
+};
+
+describe( 'analytics super props', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		getConnectionSpeedData.mockReturnValue( {} );
+		getCurrentUserSiteCount.mockReturnValue( 2 );
+		getCurrentRoute.mockReturnValue( '/home/example.wordpress.com' );
+		getSelectedSite.mockReturnValue( selectedSite );
+		getSite.mockImplementation( ( _, siteId ) =>
+			siteId === explicitSite.ID ? explicitSite : null
+		);
+	} );
+
+	test( 'uses explicit blog_id instead of selected site', () => {
+		const superProps = getSuperProps( reduxStore )( { blog_id: explicitSite.ID } );
+
+		expect( superProps ).toEqual(
+			expect.objectContaining( {
+				blog_id: explicitSite.ID,
+				blog_lang: explicitSite.lang,
+				site_id_label: 'jetpack',
+				site_plan_id: explicitSite.plan.product_id,
+			} )
+		);
+		expect( getSelectedSite ).not.toHaveBeenCalled();
+	} );
+
+	test( 'preserves explicit blog_id when site is not in Redux', () => {
+		getSite.mockReturnValue( null );
+
+		const superProps = getSuperProps( reduxStore )( { blog_id: 333 } );
+
+		expect( superProps.blog_id ).toBe( 333 );
+		expect( superProps ).not.toHaveProperty( 'blog_lang' );
+		expect( superProps ).not.toHaveProperty( 'site_id_label' );
+		expect( superProps ).not.toHaveProperty( 'site_plan_id' );
+		expect( getSelectedSite ).not.toHaveBeenCalled();
+	} );
+
+	test( 'preserves explicit blog_id on routes that omit ambient site context', () => {
+		getCurrentRoute.mockReturnValue( '/me' );
+
+		const superProps = getSuperProps( reduxStore )( { blog_id: explicitSite.ID } );
+
+		expect( superProps.blog_id ).toBe( explicitSite.ID );
+		expect( superProps.blog_lang ).toBe( explicitSite.lang );
+		expect( getSelectedSite ).not.toHaveBeenCalled();
+	} );
+
+	test( 'keeps selected-site behavior when blog_id is not explicit', () => {
+		const superProps = getSuperProps( reduxStore )( {} );
+
+		expect( superProps ).toEqual(
+			expect.objectContaining( {
+				blog_id: selectedSite.ID,
+				blog_lang: selectedSite.lang,
+				site_id_label: 'wpcom',
+				site_plan_id: selectedSite.plan.product_id,
+			} )
+		);
+	} );
+
+	test( 'ignores invalid explicit blog_id', () => {
+		const superProps = getSuperProps( reduxStore )( { blog_id: 0 } );
+
+		expect( superProps.blog_id ).toBe( selectedSite.ID );
+	} );
+} );


### PR DESCRIPTION
Addresses DOTSUP-505
Part of DOTSUP-504

## Proposed Changes

* Preserve an explicit positive `blog_id` when Calypso builds analytics super properties.
* Derive `blog_lang`, `site_id_label`, and `site_plan_id` from the explicitly reported site instead of the currently selected site.
* Preserve an explicit ID without inventing site metadata when the site is not available in Redux.
* Add regression tests for conflicting sites, unknown sites, route-based omission, invalid IDs, and unchanged ambient selected-site behavior.

## Why are these changes being made?

Calypso merges super properties after event properties. When a caller explicitly reports the site an event concerns, the selected Calypso site can currently overwrite that `blog_id`.

Help Center work will begin reporting the support site's ID explicitly. This change makes that explicit value authoritative while leaving existing behavior unchanged for callers that do not provide a valid `blog_id`.

## Testing Instructions

* Run `yarn test-client client/lib/analytics/test --runInBand`.
* Run `yarn eslint client/lib/analytics/super-props.js client/lib/analytics/test/super-props.js`.
* Run `yarn typecheck-client`.
* Confirm the new tests cover:
  * explicit site differing from selected site
  * explicit site missing from Redux
  * explicit site on a route that omits ambient site context
  * no explicit site
  * invalid explicit site ID
