### PR TITLE
Require concrete summaries for block content updates

### DIFF
--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -2935,6 +2935,20 @@ describe( 'toolProvider', () => {
 			expect( typeof updateBlock?.callback ).toBe( 'function' );
 		} );
 
+		it( 'documents the completed-edit summary contract in the update-block-content schema', async () => {
+			const abilities = await toolProvider.getAbilities();
+			const updateBlock = abilities.find( ( a: any ) => a.name === 'wpcom/update-block-content' );
+			const summaryDescription = updateBlock?.input_schema?.properties?.summary?.description;
+
+			expect( updateBlock ).toBeDefined();
+			expect( summaryDescription ).toContain( 'concrete completed edit' );
+			expect( summaryDescription ).toContain( 'language of the current user message' );
+			expect( summaryDescription ).toContain( 'name the exact corrections' );
+			expect( summaryDescription ).toContain( 'Changed "stuffs" to "stuff".' );
+			expect( summaryDescription ).toContain( 'no changes were needed' );
+			expect( summaryDescription ).not.toContain( 'brief user-friendly description' );
+		} );
+
 		it( 'delegates non-Jetpack legacy show-component callbacks to Big Sky', async () => {
 			const args = {
 				type: 'color-picker',

--- a/packages/jetpack-ai-sidebar/src/utils/tool-provider.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tool-provider.ts
@@ -32,7 +32,8 @@ export const UPDATE_BLOCK_CONTENT_ABILITY: Tool = {
 			},
 			summary: {
 				type: 'string',
-				description: 'A brief user-friendly description of what was changed.',
+				description:
+					'A concise confirmation of the concrete completed edit, in the language of the current user message. For spelling or grammar changes, name the exact corrections when they fit in one sentence; if there are too many, state the count. For example: Changed "stuffs" to "stuff". Never merely restate the request, scope, or action category. If the text is unchanged, say that no changes were needed.',
 			},
 			currentText: {
 				type: 'string',


### PR DESCRIPTION
Part of the fix for vague Jetpack AI edit confirmations.

## Proposed Changes

* Replace the vague `wpcom/update-block-content` summary description with a concrete completed-edit contract.
* Ask the model to name exact spelling or grammar corrections when they fit in one sentence, use the request language, and report when no changes were needed.
* Add regression coverage for the schema contract.

## Why are these changes being made?

Gutenberg sessions without the Big Sky rewrite ability fall back to `wpcom/update-block-content`. The sidebar returns this tool's `summary` directly as the assistant message.

The old schema only asked for a “brief user-friendly description”, so a real correction from “stuffs” to “stuff” could still display the vague response “Corrected spelling and grammar in the selected paragraph.”

Paired WPCOM prompt and eval PR 233020

## Testing Instructions

* Run `yarn test-packages packages/jetpack-ai-sidebar --runInBand`.
* Run `yarn workspace @automattic/jetpack-ai-sidebar typecheck`.
* Run `yarn eslint packages/jetpack-ai-sidebar/src/utils/tool-provider.ts packages/jetpack-ai-sidebar/src/index.test.ts`.
* Run `yarn prettier --check packages/jetpack-ai-sidebar/src/utils/tool-provider.ts packages/jetpack-ai-sidebar/src/index.test.ts`.
* Build the Agents Manager sidebar bundle and confirm it contains `concrete completed edit` and no longer contains `A brief user-friendly description of what was changed.`
* In the Jetpack AI sidebar, select a block containing “This is great stuffs!”, ask “Check the grammar and spelling of this text”, and confirm the response names the exact “stuffs” to “stuff” correction.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://react-redux.org/api/hooks#usingmemoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the “[Status] String Freeze” label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the “[Status] Needs Privacy Updates” label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?