### PR TITLE
[DON'T MERGE] Query site domains on My Home (repro env for #113382)

### DIFF
--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 import { connect, useSelector } from 'react-redux';
 import SiteIcon from 'calypso/blocks/site-icon';
 import AsyncLoad from 'calypso/components/async-load';
+import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import EmptyContent from 'calypso/components/empty-content';
 import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -325,6 +326,7 @@ const HomeContent = ( {
 
 	return (
 		<div className="customer-home__main">
+			{ siteId && <QuerySiteDomains siteId={ siteId } /> }
 			{ siteId && isJetpack && isPossibleJetpackConnectionProblem && (
 				<JetpackConnectionHealthBanner siteId={ siteId } />
 			) }


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — testing environment only

This PR exists solely to provide a build where the My Home email-DNS warning can be reproduced, so reviewers of the real fix (#113382) can see the "before" state. It intentionally contains **only** the `QuerySiteDomains` change and **not** the suppression logic.

## Context

On My Home (`/home/<site>`), the email-DNS diagnostics warning is gated on the current site's primary domain being present in Redux (`getDomainsBySiteId`). `customer-home` never fetched the site's domains itself, and since Domains/Upgrades now open the separate MSD app via a hard navigation, the classic SPA's Redux domains slice is never populated on My Home. As a result the diagnostics query stays disabled and the warning can never render there — which is why it can't be reproduced on production/trunk.

## Proposed Changes

* Mount `<QuerySiteDomains>` in `customer-home` so My Home fetches its own domains. This alone (without any suppression) makes the warning render, creating a reproducible environment.

## Why are these changes being made?

To let reviewers observe the confusing warning that the real fix (#113382) removes. See DOMENG-807.

## Testing Instructions

1. Create an eCommerce/Commerce (Atomic) site, register a custom domain through checkout, and set it as the primary domain.
2. Pollute the email DNS: in the domain's DNS records, remove the SPF record and/or break the DMARC record.
3. Confirm `GET /wpcom/v2/domains/diagnostics/<domain>` returns `all_essential_email_dns_records_are_correct: false`.
4. Open this PR's Calypso Live build and go to `/home/<domain>`.
5. The red email-DNS warning appears at the top of My Home. (On trunk it does not, because the domains are never fetched.)

## Pre-merge Checklist

- [ ] DO NOT MERGE
