### PR TITLE
Write On: thread `source` through the anon flow

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/write-on/test/write-on.test.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-on/test/write-on.test.ts
@@ -9,6 +9,8 @@ import writeOn, { ANON_DRAFT_STORAGE_KEY, MAX_DRAFT_SIZE } from '../write-on';
 
 const mockIsEnabled = jest.fn( ( flag: string ) => flag === 'calypso/write-on-flow' );
 
+let mockSearch = '';
+
 jest.mock( '@automattic/calypso-config', () => {
 	const fn = Object.assign( ( key: string ) => key, {
 		isEnabled: ( flag: string ) => mockIsEnabled( flag ),
@@ -38,7 +40,7 @@ jest.mock( 'calypso/landing/stepper/stores', () => ( {
 } ) );
 
 jest.mock( '../../../../hooks/use-query', () => ( {
-	useQuery: () => new URLSearchParams(),
+	useQuery: () => new URLSearchParams( mockSearch ),
 } ) );
 
 jest.mock( 'calypso/landing/stepper/utils/steps-with-required-login', () => ( {
@@ -66,6 +68,7 @@ describe( 'write-on flow', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockSearch = '';
 		mockIsEnabled.mockImplementation( ( flag: string ) => flag === 'calypso/write-on-flow' );
 		window.localStorage.clear();
 		Object.defineProperty( window, 'location', {
@@ -138,6 +141,25 @@ describe( 'write-on flow', () => {
 		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_write_on_draft_transfer_succeeded', {
 			site_id: 99,
 		} );
+	} );
+
+	it( 'forwards the source query param into the Write editor redirect', async () => {
+		mockSearch = 'source=post_new';
+		window.localStorage.setItem(
+			ANON_DRAFT_STORAGE_KEY,
+			JSON.stringify( { title: 'My title', content: '<p>Body</p>', ts: 1 } )
+		);
+		wpcomPostMock.mockResolvedValue( { ID: 42 } );
+
+		await submitFor( 'processing', {
+			processingResult: ProcessingResult.SUCCESS,
+			siteId: 99,
+			siteSlug: 'example.wordpress.com',
+		} );
+
+		expect( window.location.assign ).toHaveBeenCalledWith(
+			'https://example.wordpress.com/wp-admin/admin.php?page=write&post=42&source=post_new'
+		);
 	} );
 
 	it( 'preserves the localStorage draft, logs to logstash, and lands on the site home when the POST fails', async () => {

--- a/client/landing/stepper/declarative-flow/flows/write-on/test/write-on.test.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-on/test/write-on.test.ts
@@ -37,6 +37,10 @@ jest.mock( 'calypso/landing/stepper/stores', () => ( {
 	ONBOARD_STORE: 'ONBOARD_STORE',
 } ) );
 
+jest.mock( '../../../../hooks/use-query', () => ( {
+	useQuery: () => new URLSearchParams(),
+} ) );
+
 jest.mock( 'calypso/landing/stepper/utils/steps-with-required-login', () => ( {
 	stepsWithRequiredLogin: ( steps: unknown ) => steps,
 } ) );

--- a/client/landing/stepper/declarative-flow/flows/write-on/test/write-on.test.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-on/test/write-on.test.ts
@@ -162,6 +162,25 @@ describe( 'write-on flow', () => {
 		);
 	} );
 
+	it( 'sanitizes the source query param to match the anon funnel before forwarding', async () => {
+		mockSearch = 'source=Post_New%21';
+		window.localStorage.setItem(
+			ANON_DRAFT_STORAGE_KEY,
+			JSON.stringify( { title: 'My title', content: '<p>Body</p>', ts: 1 } )
+		);
+		wpcomPostMock.mockResolvedValue( { ID: 42 } );
+
+		await submitFor( 'processing', {
+			processingResult: ProcessingResult.SUCCESS,
+			siteId: 99,
+			siteSlug: 'example.wordpress.com',
+		} );
+
+		expect( window.location.assign ).toHaveBeenCalledWith(
+			'https://example.wordpress.com/wp-admin/admin.php?page=write&post=42&source=post_new'
+		);
+	} );
+
 	it( 'preserves the localStorage draft, logs to logstash, and lands on the site home when the POST fails', async () => {
 		window.localStorage.setItem(
 			ANON_DRAFT_STORAGE_KEY,

--- a/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
@@ -59,6 +59,14 @@ function clearAnonDraft() {
 	}
 }
 
+// Normalize the funnel `source` to [a-z0-9_-], lowercased first — kept identical
+// to the anon funnel's reader (wpcom's write-editor-anon.php / jetpack's view.js,
+// both mirroring PHP sanitize_key) so the whole journey reports one consistent
+// value. Empty string when absent, so callers can omit the prop entirely.
+function sanitizeSource( raw: string | null ): string {
+	return ( raw || '' ).toLowerCase().replace( /[^a-z0-9_-]/g, '' );
+}
+
 function initialize() {
 	// The flag is a kill switch for the flow. When it is off, redirect to the
 	// standard onboarding flow so there is nothing to land users on.
@@ -83,7 +91,7 @@ const writeOn: FlowV2< typeof initialize > = {
 		// The anon entry point links here with a `source` (e.g. `?source=post_new`).
 		// Stepper preserves the query string across steps, so it is still present at
 		// entry — carry it into the funnel's Tracks events for attribution.
-		const source = useQuery().get( 'source' );
+		const source = sanitizeSource( useQuery().get( 'source' ) );
 
 		// Entry checks must fire at most once per mount. Re-running them on a
 		// later isLoggedIn flip (e.g. mid-signup) would redirect the user out of
@@ -116,7 +124,7 @@ const writeOn: FlowV2< typeof initialize > = {
 
 			recordTracksEvent( 'calypso_write_on_flow_entered', {
 				draft_size: draft.title.length + draft.content.length,
-				source,
+				...( source ? { source } : {} ),
 			} );
 
 			if ( draft.title ) {
@@ -127,7 +135,7 @@ const writeOn: FlowV2< typeof initialize > = {
 	useStepNavigation( currentStepSlug, navigate ) {
 		// Same `source` the entry point carried in — forward it into the Write
 		// editor so its back button and Tracks stay attributed to the funnel.
-		const source = useQuery().get( 'source' );
+		const source = sanitizeSource( useQuery().get( 'source' ) );
 
 		const submit: SubmitHandler< typeof initialize > = async ( submittedStep ) => {
 			const { slug, providedDependencies } = submittedStep;

--- a/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
+++ b/client/landing/stepper/declarative-flow/flows/write-on/write-on.ts
@@ -8,6 +8,7 @@ import { logToLogstash } from 'calypso/lib/logstash';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { useQuery } from '../../../hooks/use-query';
 import { ONBOARD_STORE } from '../../../stores';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import { STEPS } from '../../internals/steps';
@@ -79,6 +80,11 @@ const writeOn: FlowV2< typeof initialize > = {
 		const isLoggedIn = useSelector( isUserLoggedIn );
 		const hasRunEntryChecks = useRef( false );
 
+		// The anon entry point links here with a `source` (e.g. `?source=post_new`).
+		// Stepper preserves the query string across steps, so it is still present at
+		// entry — carry it into the funnel's Tracks events for attribution.
+		const source = useQuery().get( 'source' );
+
 		// Entry checks must fire at most once per mount. Re-running them on a
 		// later isLoggedIn flip (e.g. mid-signup) would redirect the user out of
 		// the flow during the auth round-trip.
@@ -110,14 +116,19 @@ const writeOn: FlowV2< typeof initialize > = {
 
 			recordTracksEvent( 'calypso_write_on_flow_entered', {
 				draft_size: draft.title.length + draft.content.length,
+				source,
 			} );
 
 			if ( draft.title ) {
 				setSiteTitle( draft.title );
 			}
-		}, [ currentStepSlug, isLoggedIn, setSiteTitle ] );
+		}, [ currentStepSlug, isLoggedIn, setSiteTitle, source ] );
 	},
 	useStepNavigation( currentStepSlug, navigate ) {
+		// Same `source` the entry point carried in — forward it into the Write
+		// editor so its back button and Tracks stay attributed to the funnel.
+		const source = useQuery().get( 'source' );
+
 		const submit: SubmitHandler< typeof initialize > = async ( submittedStep ) => {
 			const { slug, providedDependencies } = submittedStep;
 			switch ( slug ) {
@@ -153,8 +164,12 @@ const writeOn: FlowV2< typeof initialize > = {
 							site_id: siteId,
 						} );
 
+						const params = new URLSearchParams( { page: 'write', post: String( post.ID ) } );
+						if ( source ) {
+							params.set( 'source', source );
+						}
 						window.location.assign(
-							`https://${ siteSlug }/wp-admin/admin.php?page=write&post=${ post.ID }`
+							`https://${ siteSlug }/wp-admin/admin.php?${ params.toString() }`
 						);
 					} catch ( error ) {
 						// Surfacing the failure to the user is handled upstream by


### PR DESCRIPTION
<!-- Part of READ-641. This is the third and final PR that completes source attribution through the anon Write editor funnel; the anon-side Tracks events and signup handoff landed in the wpcom and jetpack PRs. -->

Part of READ-641

## Proposed Changes

* `client/landing/stepper/declarative-flow/flows/write-on/write-on.ts`: read the incoming `source` query param (e.g. `?source=post_new`) via `useQuery()`, normalized to `[a-z0-9_-]` (lowercased) — kept identical to the anon funnel's `source` reader (wpcom `write-editor-anon.php` / jetpack `view.js`) so the whole journey reports one consistent value.
* Add `source` to the `calypso_write_on_flow_entered` Tracks event fired on authed entry into the flow, omitting the prop entirely when absent (no `source: null` noise), matching the anon funnel events.
* Forward `source` into the final Write editor redirect (`admin.php?page=write&post=<id>&source=<source>`) so the editor's back button and Tracks stay attributed.
* Add unit tests asserting `source` is forwarded into the Write editor redirect and that a non-normalized value is sanitized before forwarding, plus a `use-query` mock so the suite stays green.

## Why are these changes being made?

The anon (logged-out) Write editor funnel now threads a `source` query param through its Tracks events and the signup handoff. That handoff lands users on `/setup/write-on`, but this flow did not read `source` — so attribution died at the last hop into the authed funnel. This mirrors what `write-new-site` already does for its own handoff, completing the chain from anon entry (`source=post_new`) through signup.

## Testing Instructions

* Existing unit tests: `yarn test-client client/landing/stepper/declarative-flow/flows/write-on/test/write-on.test.ts` — all 12 pass.
* Manual: with the `calypso/write-on-flow` flag on and an anon draft in `localStorage`, visit `/setup/write-on?source=post_new` while logged out. Confirm `calypso_write_on_flow_entered` carries `source: "post_new"`, and after signup + site creation the redirect URL includes `&source=post_new`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
