### PR TITLE
Signup: hide the free-domain promo when the domain is not free

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -338,30 +338,25 @@ const DomainSearchStep: StepType< {
 		return true;
 	}, [ flow, isCiab, site, sourceSlug ] );
 
+	// The slots have to be left out entirely rather than render nothing: the results
+	// page keys its mobile sticky banner off `BeforeResults` being present, and that
+	// banner carries its own "free domain with a paid plan" copy.
 	const slots = useMemo( () => {
+		if ( hideFreeDomainPromo || ! isFirstDomainFreeForFirstYear ) {
+			return {};
+		}
+
 		return {
-			BeforeResults: () => {
-				if ( hideFreeDomainPromo || ! isFirstDomainFreeForFirstYear ) {
-					return null;
-				}
-
-				return (
-					<FreeDomainForAYearPromo
-						isCiab={ isCiab }
-						title={ freeDomainPromoTitle }
-						subtitle={ freeDomainPromoSubtitle }
-					/>
-				);
-			},
-			BeforeFullCartItems: () => {
-				if ( hideFreeDomainPromo || ! isFirstDomainFreeForFirstYear ) {
-					return null;
-				}
-
-				// The textOnly variant has a single-paragraph layout (no title/subtitle pair),
-				// so the promo title/subtitle props don't apply here.
-				return <FreeDomainForAYearPromo textOnly isCiab={ isCiab } />;
-			},
+			BeforeResults: () => (
+				<FreeDomainForAYearPromo
+					isCiab={ isCiab }
+					title={ freeDomainPromoTitle }
+					subtitle={ freeDomainPromoSubtitle }
+				/>
+			),
+			// The textOnly variant has a single-paragraph layout (no title/subtitle pair),
+			// so the promo title/subtitle props don't apply here.
+			BeforeFullCartItems: () => <FreeDomainForAYearPromo textOnly isCiab={ isCiab } />,
 		};
 	}, [
 		isFirstDomainFreeForFirstYear,

--- a/client/signup/steps/domains/index.tsx
+++ b/client/signup/steps/domains/index.tsx
@@ -1,11 +1,6 @@
 import { FreeDomainSuggestion, useMyDomainInputMode } from '@automattic/api-core';
 import page from '@automattic/calypso-router';
-import {
-	isDomainForGravatarFlow,
-	isEcommerceFlow,
-	isFreeFlow,
-	isWithThemeFlow,
-} from '@automattic/onboarding';
+import { isDomainForGravatarFlow, isEcommerceFlow, isWithThemeFlow } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
@@ -304,34 +299,29 @@ const DomainSearchUI = (
 		};
 	}, [ flowName, isDomainOnlyFlow, isOnboardingWithEmailFlow, allowedTldParam ] );
 
+	// For /start flows, we want to show the free domain for a year discount for all flows
+	// except if we're in a site context, in the free or monthly plan flows or in the domain-only flow
+	const isFirstDomainFreeForFirstYear = ! (
+		siteSlug ||
+		siteId ||
+		isMonthlyOrFreeFlow( flowName ) ||
+		isDomainOnlyFlow ||
+		isDomainForGravatarFlow( flowName )
+	);
+
+	// The slots have to be left out entirely rather than render nothing: the results
+	// page keys its mobile sticky banner off `BeforeResults` being present, and that
+	// banner carries its own "free domain with a paid plan" copy.
 	const slots = useMemo( () => {
+		if ( isOnboardingWithEmailFlow || ! isFirstDomainFreeForFirstYear ) {
+			return {};
+		}
+
 		return {
-			BeforeResults: () => {
-				if (
-					isDomainOnlyFlow ||
-					isDomainForGravatarFlow( flowName ) ||
-					isFreeFlow( flowName ) ||
-					isOnboardingWithEmailFlow
-				) {
-					return null;
-				}
-
-				return <FreeDomainForAYearPromo />;
-			},
-			BeforeFullCartItems: () => {
-				if (
-					isDomainOnlyFlow ||
-					isDomainForGravatarFlow( flowName ) ||
-					isFreeFlow( flowName ) ||
-					isOnboardingWithEmailFlow
-				) {
-					return null;
-				}
-
-				return <FreeDomainForAYearPromo textOnly />;
-			},
+			BeforeResults: () => <FreeDomainForAYearPromo />,
+			BeforeFullCartItems: () => <FreeDomainForAYearPromo textOnly />,
 		};
-	}, [ flowName, isOnboardingWithEmailFlow, isDomainOnlyFlow ] );
+	}, [ isOnboardingWithEmailFlow, isFirstDomainFreeForFirstYear ] );
 
 	const flowAllowsMultipleDomainsInCart = isDomainOnlyFlow;
 
@@ -419,21 +409,6 @@ const DomainSearchUI = (
 			</Button>
 		);
 	};
-
-	// For /start flows, we want to show the free domain for a year discount for all flows
-	// except if we're in a site context, in the free or monthly plan flows or in the domain-only flow
-	const isFirstDomainFreeForFirstYear = useMemo( () => {
-		if (
-			siteSlug ||
-			siteId ||
-			isMonthlyOrFreeFlow( flowName ) ||
-			isDomainOnlyFlow ||
-			isDomainForGravatarFlow( flowName )
-		) {
-			return false;
-		}
-		return true;
-	}, [ flowName, siteSlug, siteId, isDomainOnlyFlow ] );
 
 	return (
 		<StepWrapper

--- a/client/signup/steps/domains/test/index.tsx
+++ b/client/signup/steps/domains/test/index.tsx
@@ -34,10 +34,14 @@ const baseProps = {
 	previousStepName: null,
 };
 
-function renderStep( props = baseProps, options = {} ) {
+function renderStepProps( props = baseProps, options = {} ) {
 	mockWPCOMDomainSearch.mockClear();
 	renderWithProvider( <DomainSearchStep { ...props } />, options );
-	return mockWPCOMDomainSearch.mock.calls[ 0 ][ 0 ].events;
+	return mockWPCOMDomainSearch.mock.calls[ 0 ][ 0 ];
+}
+
+function renderStep( props = baseProps, options = {} ) {
+	return renderStepProps( props, options ).events;
 }
 
 const LOGGED_IN_STATE = { currentUser: { id: 12345 } };
@@ -135,5 +139,33 @@ describe( 'DomainSearchStep — domain-only checkout simplification', () => {
 			} )
 		);
 		expect( goToNextStep ).toHaveBeenCalledTimes( 1 );
+	} );
+} );
+
+describe( 'DomainSearchStep — free domain for a year promo', () => {
+	const onboardingProps = { ...baseProps, flowName: 'onboarding', stepName: 'domains' };
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockWPCOMDomainSearch.mockReturnValue( null );
+	} );
+
+	it( 'promotes the free first year when signing up for a new site', () => {
+		const { slots } = renderStepProps( onboardingProps, { initialState: LOGGED_IN_STATE } );
+
+		expect( slots.BeforeResults ).toBeDefined();
+		expect( slots.BeforeFullCartItems ).toBeDefined();
+	} );
+
+	// Asserting on the keys rather than what they render, because that is what the
+	// results page reads to decide whether to show the mobile sticky banner.
+	it( 'hides the promo when adding a domain to an existing site', () => {
+		const { slots } = renderStepProps(
+			{ ...onboardingProps, queryObject: { siteSlug: 'example.wordpress.com' } },
+			{ initialState: LOGGED_IN_STATE }
+		);
+
+		expect( slots.BeforeResults ).toBeUndefined();
+		expect( slots.BeforeFullCartItems ).toBeUndefined();
 	} );
 } );


### PR DESCRIPTION
Adding a domain to an existing site shows "Claim your first domain, free!" and "your first year's domain registration is on us", and then charges for the domain at checkout. Found it launching a site with credits.

The domain step gated the promo on flow name alone, so the site context never got a look. `isFirstDomainFreeForFirstYear` in the same file already encodes the real condition, it was just declared below the memo that needed it and only handed to the search component as a prop. Hoisted it up and gated the slots on it.

The gate omits the slots instead of rendering nothing from them, which matters more than it looks:

```js
const showCompactBanner = !! slots?.BeforeResults;
```

`results.tsx` keys the mobile sticky banner off `BeforeResults` being present, not off what it returns, and that banner has its own hardcoded "Claim your free domain name with a paid plan" copy. Returning null fixes desktop and leaves the promo up on phones. Every other consumer of `slots` reads presence the same way. The /setup step had the same shape so it gets the same change.

One deliberate widening: the old guard used `isFreeFlow`, `isFirstDomainFreeForFirstYear` uses `isMonthlyOrFreeFlow`, so the promo now also goes away in the monthly flows. Those don't get a free domain either.

The two conditions stay separate from the /setup one on purpose, they are not the same computation: /start reads `queryObject.siteSlug`/`siteId`, /setup reads the selected site and calls `siteHasPaidPlan`, plus isCiab and the hundred-year flows. A shared hook would need about eight parameters.

To verify: revert `client/signup/steps/domains/index.tsx` and the second new test fails.
