### PR TITLE
Subscribers: show pending-only subscriber lists

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -331,7 +331,10 @@ export default function SubscriberDataViews( {
 
 	const EmptyComponent = isSimple || isAtomic ? SubscriberLaunchpad : JetpackEmptyListView;
 	const shouldShowLaunchpad =
-		! isLoading && ! searchTerm && ( ! grandTotal || ( grandTotal === 1 && isOwnerSubscribed ) );
+		! isLoading &&
+		! searchTerm &&
+		filters.includes( SubscribersFilterBy.All ) &&
+		( ! denominator || ( denominator === 1 && isOwnerSubscribed ) );
 
 	/**
 	 * Read page from URL when component mounts or URL changes.

--- a/client/my-sites/subscribers/components/subscriber-data-views/test/subscriber-data-views.test.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/test/subscriber-data-views.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import SubscriberDataViews from '../subscriber-data-views';
+import type { ReactNode } from 'react';
+
+jest.mock( '@automattic/components', () => ( { Gravatar: () => null } ) );
+
+jest.mock( '@automattic/data-stores', () => ( {
+	HelpCenter: { register: () => 'help-center' },
+} ) );
+
+jest.mock( '@automattic/i18n-utils', () => ( {
+	useLocalizeUrl: () => ( url: string ) => url,
+} ) );
+
+jest.mock( '@automattic/viewport-react', () => ( {
+	useBreakpoint: () => false,
+} ) );
+
+jest.mock( '@wordpress/admin-ui', () => ( {
+	Page: ( { children }: { children: ReactNode } ) => <>{ children }</>,
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Button: () => null,
+	Icon: () => null,
+	Spinner: () => null,
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( { setShowSupportDoc: jest.fn() } ),
+} ) );
+
+jest.mock( '@wordpress/dataviews', () => ( {
+	DataViews: ( { data }: { data: Array< { email_address: string } > } ) => (
+		<>
+			{ data.map( ( subscriber ) => (
+				<div key={ subscriber.email_address }>{ subscriber.email_address }</div>
+			) ) }
+		</>
+	),
+} ) );
+
+jest.mock( 'calypso/components/jetpack-title', () => () => null );
+jest.mock( 'calypso/data/newsletter-categories', () => ( {
+	useSubscribedNewsletterCategories: () => ( { data: undefined, isLoading: false } ),
+} ) );
+jest.mock( 'calypso/state', () => ( {
+	useSelector: ( selector: ( state: object ) => unknown ) => selector( {} ),
+} ) );
+jest.mock( 'calypso/state/current-user/selectors', () => ( {
+	getCurrentUserLocale: () => 'en-US',
+} ) );
+jest.mock( 'calypso/state/memberships/product-list/selectors', () => ( {
+	getProductsForSiteId: () => [],
+} ) );
+jest.mock( 'calypso/state/selectors/is-site-automated-transfer', () => () => false );
+jest.mock( 'calypso/state/selectors/is-site-wpcom', () => () => true );
+jest.mock( 'calypso/state/selectors/is-site-wpcom-staging', () => () => false );
+jest.mock( 'calypso/state/sites/selectors', () => ( {
+	getSiteSlug: () => 'example.wordpress.com',
+	isSimpleSite: () => false,
+} ) );
+
+jest.mock( '../../../hooks', () => ( {
+	useAddSubscribersCallback: () => jest.fn(),
+	useMigrateSubscribersCallback: () => jest.fn(),
+	useSubscriptionPlans: () => [],
+	useUnsubscribeModal: () => ( {
+		currentSubscribers: [],
+		onSetUnsubscribers: jest.fn(),
+		onConfirmModal: jest.fn(),
+		resetSubscribers: jest.fn(),
+	} ),
+} ) );
+
+jest.mock( '../../../queries', () => ( {
+	useSubscriberCountQuery: () => ( { data: { total_subscribers: 0 } } ),
+	useSubscriberDetailsQuery: () => ( { data: undefined, isLoading: false } ),
+	useSubscribersQuery: () => ( {
+		data: {
+			per_page: 10,
+			page: 1,
+			pages: 1,
+			total: 1,
+			total_unfiltered: 1,
+			is_owner_subscribed: false,
+			subscribers: [
+				{
+					user_id: 0,
+					email_subscription_id: 123,
+					subscription_status: 'Not confirmed',
+					email_address: 'pending@example.com',
+					display_name: 'pending@example.com',
+					avatar: '',
+					email_date_subscribed: '2026-08-07T00:00:00',
+				},
+			],
+		},
+		isLoading: false,
+	} ),
+} ) );
+
+jest.mock( '../../../tracks', () => ( {
+	useRecordSubscriberClicked: () => jest.fn(),
+	useRecordSubscriberFilter: () => jest.fn(),
+	useRecordSubscriberSearch: () => jest.fn(),
+	useRecordSubscriberSort: () => jest.fn(),
+} ) );
+
+jest.mock( '../../add-subscribers-modal', () => ( { AddSubscribersModal: () => null } ) );
+jest.mock( '../../jetpack-empty-list-view', () => ( {
+	JetpackEmptyListView: () => <div>Jetpack empty list</div>,
+} ) );
+jest.mock( '../../migrate-subscribers-modal', () => ( { MigrateSubscribersModal: () => null } ) );
+jest.mock( '../../subscriber-details', () => ( { SubscriberDetails: () => null } ) );
+jest.mock( '../../subscriber-details/skeleton', () => ( {
+	SubscriberDetailsSkeleton: () => null,
+} ) );
+jest.mock( '../../subscriber-launchpad', () => ( {
+	SubscriberLaunchpad: () => <div>Subscriber launchpad</div>,
+} ) );
+jest.mock( '../../subscribers-header-popover', () => ( { SubscribersHeaderPopover: () => null } ) );
+jest.mock( '../../unsubscribe-modal', () => ( { UnsubscribeModal: () => null } ) );
+
+describe( 'SubscriberDataViews', () => {
+	it( 'renders pending subscribers when aggregate count is zero', () => {
+		render(
+			<SubscriberDataViews
+				siteId={ 1 }
+				isUnverified={ false }
+				onCompSubscription={ jest.fn() }
+				onRemoveComp={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByText( 'pending@example.com' ) ).toBeVisible();
+		expect( screen.getByText( '1 total subscriber' ) ).toBeVisible();
+		expect( screen.queryByText( 'Jetpack empty list' ) ).not.toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
Part of NL-587

## Proposed Changes

* Use the list endpoint's unfiltered total when deciding whether to show the subscriber launchpad.
* Only show the launchpad in the default `All` view, preserving empty filtered results.
* Add a regression test for a Jetpack site whose aggregate count is zero while the list returns a pending subscriber.

## Why are these changes being made?

* `/subscribers/counts` excludes pending-only email records. After the NL-586 backend fix returns those records in the default list, the aggregate can still be zero and incorrectly replace the populated list with `JetpackEmptyListView`.
* This PR depends on the wpcom backend change for NL-586.

## Testing Instructions

* Run `yarn test-client client/my-sites/subscribers/components/subscriber-data-views/test/subscriber-data-views.test.tsx`.
* Run `yarn eslint client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx client/my-sites/subscribers/components/subscriber-data-views/test/subscriber-data-views.test.tsx`.
* Run `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client`.
* After NL-586 backend changes are available, open a controlled Jetpack site with only an unconfirmed subscriber and confirm the subscriber row appears instead of the empty list.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks/using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?