### PR TITLE
E2E tests: Fix `As a WordPress.com user, I can require 2fa via SMS` E2E test

### DIFF
--- a/packages/calypso-e2e/src/lib/test-account.ts
+++ b/packages/calypso-e2e/src/lib/test-account.ts
@@ -155,7 +155,7 @@ export class TestAccount {
 		const message = await emailClient.getLastMatchingMessage( {
 			inboxId: SecretsManager.secrets.mailosaur.totpUserInboxId,
 			sentTo: this.credentials.smsNumber.number,
-			body: 'WordPress.com verification code',
+			body: 'WordPress,com verification code', // The `,` here is temporary and intentional, see 232569-ghe-Automattic/wpcom
 			receivedAfter: new Date( Date.now() - 10 * 1000 ), // Last 10 seconds
 		} );
 		return emailClient.get2FACodeFromMessage( message );


### PR DESCRIPTION
## Proposed Changes

Fix the `As a WordPress.com user, I can require 2fa via SMS` E2E test by replacing a `.` with `,`.

## Why are these changes being made?

232569-ghe-Automattic/wpcom temporarily changed the "WordPress.com" string in SMS messages to "WordPress,com" to test whether carriers were blocking our SMS messages because they contained a URL. That change inadvertently broke the `As a WordPress.com user, I can require 2fa via SMS` E2E test, which was reported by @lucatume.

## Testing Instructions

E2E tests should be passing.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
