### PR TITLE
A4A: Revamp the AI and MCP main page to follow the WP.com layout

### DIFF
--- a/client/a8c-for-agencies/sections/ai-mcp/primary/overview/index.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/overview/index.tsx
@@ -5,6 +5,7 @@ import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar
 import LayoutBody from 'calypso/layout/hosting-dashboard/body';
 import LayoutHeader, {
 	LayoutHeaderTitle as Title,
+	LayoutHeaderSubtitle as Subtitle,
 	LayoutHeaderActions as Actions,
 } from 'calypso/layout/hosting-dashboard/header';
 import AiMcpOverviewContent from './overview-content';
@@ -17,6 +18,11 @@ export default function AiMcpOverview() {
 			<LayoutTop>
 				<LayoutHeader>
 					<Title>{ title }</Title>
+					<Subtitle>
+						{ __(
+							'Control how AI assistants interact with your Automattic for Agencies account and sites.'
+						) }
+					</Subtitle>
 					<Actions>
 						<MobileSidebarNavigation />
 					</Actions>

--- a/client/dashboard/agency/resources/mcp/index.tsx
+++ b/client/dashboard/agency/resources/mcp/index.tsx
@@ -12,7 +12,17 @@ export default function Mcp() {
 	const { settings, isLoading, isSaving, save } = useMcpSettings();
 
 	return (
-		<PageLayout header={ <PageHeader title={ __( 'MCP' ) } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={ __( 'AI and MCP' ) }
+					description={ __(
+						'Control how AI assistants interact with your Automattic for Agencies account and sites.'
+					) }
+				/>
+			}
+		>
 			<McpOverview
 				settings={ settings }
 				isLoading={ isLoading }

--- a/client/dashboard/agency/resources/mcp/overview-content.tsx
+++ b/client/dashboard/agency/resources/mcp/overview-content.tsx
@@ -93,40 +93,46 @@ export default function McpOverview( {
 					</VStack>
 				</CardBody>
 
-				<CardDivider style={ { borderColor: 'var(--color-border-subtle)' } } />
-				<SummaryButton
-					density="medium"
-					title={ __( 'Read' ) }
-					decoration={ <Icon icon={ seen } size={ 24 } /> }
-					badges={ [ getReadBadge( availableAbilities ) ] }
-					href={ toolsPath }
-					disabled={ ! mcpEnabled }
-					onClick={ handleNavClick( toolsPath, 'calypso_a4a_ai_mcp_available_tools_click' ) }
-				/>
-				<SummaryButton
-					density="medium"
-					title={ __( 'Write' ) }
-					decoration={ <Icon icon={ pencil } size={ 24 } /> }
-					badges={ [ { text: __( 'Coming soon' ) } ] }
-					disabled
-				/>
+				{ mcpEnabled && (
+					<>
+						<CardDivider style={ { borderColor: 'var(--color-border-subtle)' } } />
+						<SummaryButton
+							density="medium"
+							title={ __( 'Read' ) }
+							decoration={ <Icon icon={ seen } size={ 24 } /> }
+							badges={ [ getReadBadge( availableAbilities ) ] }
+							href={ toolsPath }
+							onClick={ handleNavClick( toolsPath, 'calypso_a4a_ai_mcp_available_tools_click' ) }
+						/>
+						<SummaryButton
+							density="medium"
+							title={ __( 'Write' ) }
+							decoration={ <Icon icon={ pencil } size={ 24 } /> }
+							badges={ [ { text: __( 'Coming soon' ) } ] }
+							disabled
+						/>
+					</>
+				) }
 			</Card>
 
-			<SummaryButton
-				title={ __( 'Connect external AI assistant' ) }
-				description={ __( 'Get instructions for connecting your external AI assistant.' ) }
-				decoration={ <Icon icon={ connection } size={ 24 } /> }
-				href={ connectPath }
-				disabled={ ! mcpEnabled }
-				onClick={ handleNavClick( connectPath, 'calypso_a4a_ai_mcp_connect_click' ) }
-			/>
+			{ mcpEnabled && (
+				<>
+					<SummaryButton
+						title={ __( 'Connect external AI assistant' ) }
+						description={ __( 'Get instructions for connecting your external AI assistant.' ) }
+						decoration={ <Icon icon={ connection } size={ 24 } /> }
+						href={ connectPath }
+						onClick={ handleNavClick( connectPath, 'calypso_a4a_ai_mcp_connect_click' ) }
+					/>
 
-			<SummaryButton
-				title={ __( 'Starter prompts' ) }
-				description={ __( 'Ready-made prompts to copy into your connected assistant.' ) }
-				decoration={ <Icon icon={ listView } size={ 24 } /> }
-				disabled
-			/>
+					<SummaryButton
+						title={ __( 'Starter prompts' ) }
+						description={ __( 'Ready-made prompts to copy into your connected assistant.' ) }
+						decoration={ <Icon icon={ listView } size={ 24 } /> }
+						disabled
+					/>
+				</>
+			) }
 		</VStack>
 	);
 }

--- a/client/dashboard/agency/resources/mcp/overview-content.tsx
+++ b/client/dashboard/agency/resources/mcp/overview-content.tsx
@@ -8,8 +8,6 @@ import type { RecordTracksEvent } from './types';
 import type { McpAvailableAbility, McpSettings, McpSettingsUpdate } from '@automattic/api-core';
 import type { MouseEvent } from 'react';
 
-import './style.scss';
-
 const MCP_TOOLS_PATH = '/resources/ai-mcp/tools';
 const MCP_CONNECT_PATH = '/resources/ai-mcp/connect';
 

--- a/client/dashboard/agency/resources/mcp/overview-content.tsx
+++ b/client/dashboard/agency/resources/mcp/overview-content.tsx
@@ -1,19 +1,11 @@
-import {
-	Icon,
-	ToggleControl,
-	__experimentalHStack as HStack,
-	__experimentalSpacer as Spacer,
-	__experimentalText as Text,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { Icon, ToggleControl, __experimentalVStack as VStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { check } from '@wordpress/icons';
-import clsx from 'clsx';
-import { Card, CardBody } from '../../../components/card';
+import { connection, listView, pencil, seen } from '@wordpress/icons';
+import { Card, CardBody, CardDivider } from '../../../components/card';
+import { SectionHeader } from '../../../components/section-header';
 import SummaryButton from '../../../components/summary-button';
-import McpStarterPrompts from './starter-prompts-content';
 import type { RecordTracksEvent } from './types';
-import type { McpSettings, McpSettingsUpdate } from '@automattic/api-core';
+import type { McpAvailableAbility, McpSettings, McpSettingsUpdate } from '@automattic/api-core';
 import type { MouseEvent } from 'react';
 
 import './style.scss';
@@ -21,15 +13,26 @@ import './style.scss';
 const MCP_TOOLS_PATH = '/resources/ai-mcp/tools';
 const MCP_CONNECT_PATH = '/resources/ai-mcp/connect';
 
-function StepNumber( { n, completed }: { n: number; completed?: boolean } ) {
-	return (
-		<span
-			className={ clsx( 'mcp-overview__step-number', { 'is-completed': completed } ) }
-			aria-hidden="true"
-		>
-			{ completed ? <Icon icon={ check } size={ 18 } /> : n }
-		</span>
-	);
+function getReadBadge( abilities: McpAvailableAbility[] ) {
+	if ( abilities.length === 0 ) {
+		return { text: __( 'No tools available' ) };
+	}
+
+	const enabledCount = abilities.filter( ( ability ) => ability.enabled ).length;
+
+	if ( enabledCount === abilities.length ) {
+		return { text: __( 'All enabled' ), intent: 'success' as const };
+	}
+
+	if ( enabledCount === 0 ) {
+		return { text: __( 'None enabled' ) };
+	}
+
+	return {
+		/* translators: %1$d is the number of enabled tools, %2$d is the total number of tools */
+		text: sprintf( __( '%1$d of %2$d enabled' ), enabledCount, abilities.length ),
+		intent: 'info' as const,
+	};
 }
 
 interface McpOverviewProps {
@@ -63,96 +66,69 @@ export default function McpOverview( {
 		};
 
 	const availableAbilities = settings?.available_abilities ?? [];
-	const enabledCount = availableAbilities.filter( ( ability ) => ability.enabled ).length;
-	const totalCount = availableAbilities.length;
-	const mainEnabled = !! settings?.enabled;
+	const mcpEnabled = !! settings?.enabled;
 
 	const onMainToggle = ( next: boolean ) => {
 		recordTracksEvent( 'calypso_a4a_ai_mcp_enable_toggled', { enabled: next } );
 		onSave( { enabled: next } );
 	};
 
-	const availableToolsBadge =
-		totalCount > 0
-			? {
-					/* translators: %(enabledCount)d enabled, %(totalCount)d total */
-					text: sprintf( __( '%(enabledCount)d of %(totalCount)d enabled' ), {
-						enabledCount,
-						totalCount,
-					} ) as string,
-					intent: ( enabledCount > 0 ? 'info' : undefined ) as 'info' | undefined,
-			  }
-			: { text: __( 'No tools available' ) as string };
-
 	return (
-		<>
-			<Spacer marginBottom={ 8 } style={ { maxWidth: '650px' } }>
-				<Text size={ 15 }>
-					{ __(
-						'Connect an AI agent to check site health, tier progress, payouts, and more across your agency, on demand. Set it up in three easy steps and put your agent to work.'
-					) }
-				</Text>
-			</Spacer>
+		<VStack spacing={ 4 }>
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<SectionHeader
+							level={ 3 }
+							title={ __( 'External AI agent access' ) }
+							description={ __(
+								'Allow external AI agents to access your Automattic for Agencies account and sites via MCP.'
+							) }
+						/>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							checked={ mcpEnabled }
+							disabled={ isLoading || isSaving }
+							label={ __( 'Enable MCP access' ) }
+							onChange={ onMainToggle }
+						/>
+					</VStack>
+				</CardBody>
 
-			<VStack spacing={ 4 }>
-				<Card>
-					<CardBody>
-						<HStack alignment="flex-start" justify="space-between" spacing={ 4 }>
-							<HStack
-								className="mcp-overview__step-heading"
-								alignment="flex-start"
-								justify="flex-start"
-								spacing={ 3 }
-							>
-								<StepNumber n={ 1 } completed={ mainEnabled } />
-								<VStack spacing={ 1 }>
-									<Text weight={ 600 } size={ 15 }>
-										{ __( 'Enable MCP access' ) }
-									</Text>
-									<Text variant="muted">
-										{ __(
-											'Allow external AI agents to access your Automattic for Agencies account via MCP.'
-										) }
-									</Text>
-								</VStack>
-							</HStack>
-							<ToggleControl
-								__nextHasNoMarginBottom
-								label=""
-								aria-label={ __( 'Enable MCP access' ) }
-								checked={ mainEnabled }
-								onChange={ onMainToggle }
-								disabled={ isLoading || isSaving }
-							/>
-						</HStack>
-					</CardBody>
-				</Card>
-
+				<CardDivider style={ { borderColor: 'var(--color-border-subtle)' } } />
 				<SummaryButton
-					title={ __( 'Select tools' ) }
-					description={ __( 'Choose what AI agents can do in your account.' ) }
-					decoration={ <StepNumber n={ 2 } /> }
-					badges={ [ availableToolsBadge ] }
+					density="medium"
+					title={ __( 'Read' ) }
+					decoration={ <Icon icon={ seen } size={ 24 } /> }
+					badges={ [ getReadBadge( availableAbilities ) ] }
 					href={ toolsPath }
-					disabled={ ! mainEnabled }
+					disabled={ ! mcpEnabled }
 					onClick={ handleNavClick( toolsPath, 'calypso_a4a_ai_mcp_available_tools_click' ) }
 				/>
-
 				<SummaryButton
-					title={ __( 'Connect your AI agent' ) }
-					description={ __(
-						'Required — add the MCP connection to your AI agent to finish setup.'
-					) }
-					decoration={ <StepNumber n={ 3 } /> }
-					href={ connectPath }
-					disabled={ ! mainEnabled }
-					onClick={ handleNavClick( connectPath, 'calypso_a4a_ai_mcp_connect_click' ) }
+					density="medium"
+					title={ __( 'Write' ) }
+					decoration={ <Icon icon={ pencil } size={ 24 } /> }
+					badges={ [ { text: __( 'Coming soon' ) } ] }
+					disabled
 				/>
-			</VStack>
+			</Card>
 
-			<Spacer marginTop={ 8 } marginBottom={ 0 }>
-				<McpStarterPrompts recordTracksEvent={ recordTracksEvent } disabled={ ! mainEnabled } />
-			</Spacer>
-		</>
+			<SummaryButton
+				title={ __( 'Connect external AI assistant' ) }
+				description={ __( 'Get instructions for connecting your external AI assistant.' ) }
+				decoration={ <Icon icon={ connection } size={ 24 } /> }
+				href={ connectPath }
+				disabled={ ! mcpEnabled }
+				onClick={ handleNavClick( connectPath, 'calypso_a4a_ai_mcp_connect_click' ) }
+			/>
+
+			<SummaryButton
+				title={ __( 'Starter prompts' ) }
+				description={ __( 'Ready-made prompts to copy into your connected assistant.' ) }
+				decoration={ <Icon icon={ listView } size={ 24 } /> }
+				disabled
+			/>
+		</VStack>
 	);
 }

--- a/client/dashboard/agency/resources/mcp/style.scss
+++ b/client/dashboard/agency/resources/mcp/style.scss
@@ -1,27 +1,3 @@
-.mcp-overview__step-number {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	flex-shrink: 0;
-	inline-size: 24px;
-	block-size: 24px;
-	border-radius: 50%;
-	box-shadow: inset 0 0 0 1px var( --color-border-subtle );
-	color: var( --color-text );
-	font-size: 13px;
-	font-weight: 600;
-	line-height: 1;
-}
-
-.mcp-overview__step-number.is-completed {
-	box-shadow: inset 0 0 0 1px var( --color-primary );
-	color: var( --color-primary );
-
-	svg {
-		fill: currentColor;
-	}
-}
-
 .mcp-connect-agent ol {
 	padding-inline-start: 20px;
 	margin: 0;

--- a/client/dashboard/agency/resources/mcp/test/overview-content.test.tsx
+++ b/client/dashboard/agency/resources/mcp/test/overview-content.test.tsx
@@ -84,7 +84,7 @@ describe( '<McpOverview>', () => {
 		).toHaveAttribute( 'href', '/resources/ai-mcp/connect' );
 	} );
 
-	test( 'disables Read and Connect until MCP access is enabled', () => {
+	test( 'hides the tool and connection rows until MCP access is enabled', () => {
 		render(
 			<McpOverview
 				settings={ settings( false, [ ability( 'get-site-health', true ) ] ) }
@@ -92,13 +92,11 @@ describe( '<McpOverview>', () => {
 			/>
 		);
 
-		expect( screen.getByRole( 'button', { name: /^Read\b/ } ) ).toHaveAttribute(
-			'aria-disabled',
-			'true'
-		);
-		expect(
-			screen.getByRole( 'button', { name: /^Connect external AI assistant/ } )
-		).toHaveAttribute( 'aria-disabled', 'true' );
+		expect( screen.getByRole( 'checkbox', { name: 'Enable MCP access' } ) ).toBeVisible();
+		expect( screen.queryByText( /^Read$/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /^Write$/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /^Connect external AI assistant$/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /^Starter prompts$/ ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'shows Write as coming soon', () => {

--- a/client/dashboard/agency/resources/mcp/test/overview-content.test.tsx
+++ b/client/dashboard/agency/resources/mcp/test/overview-content.test.tsx
@@ -6,36 +6,142 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '../../../../test-utils';
 import McpOverview from '../overview-content';
-import type { McpSettings } from '@automattic/api-core';
+import type { McpAvailableAbility, McpSettings } from '@automattic/api-core';
 
-const enabledSettings = { enabled: true, available_abilities: [] } as unknown as McpSettings;
-const disabledSettings = { enabled: false, available_abilities: [] } as unknown as McpSettings;
+function ability( name: string, enabled: boolean ): McpAvailableAbility {
+	return { name, title: name, description: '', category: 'sites', enabled };
+}
 
-describe( '<McpOverview> starter prompts section', () => {
-	test( 'shows expandable starter prompts when MCP access is enabled', async () => {
-		render( <McpOverview settings={ enabledSettings } onSave={ jest.fn() } /> );
+function settings( enabled: boolean, abilities: McpAvailableAbility[] = [] ): McpSettings {
+	return {
+		enabled,
+		available_categories: [ { slug: 'sites', label: 'Sites' } ],
+		available_abilities: abilities,
+	};
+}
 
-		expect( screen.getByText( 'Starter prompts' ) ).toBeVisible();
-		expect( screen.getByText( 'Program health snapshot' ) ).toBeVisible();
+describe( '<McpOverview>', () => {
+	test( 'toggling MCP access saves the new value', async () => {
+		const onSave = jest.fn();
+		render( <McpOverview settings={ settings( false ) } onSave={ onSave } /> );
 
-		await userEvent.click( screen.getByText( 'Program health snapshot' ) );
-		expect(
-			screen.getByText( /Give me a high-level health check of my Automattic for Agencies account/ )
-		).toBeVisible();
+		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Enable MCP access' } ) );
+
+		expect( onSave ).toHaveBeenCalledWith( { enabled: true } );
 	} );
 
-	test( 'disables the starter prompts until MCP access is enabled', async () => {
-		render( <McpOverview settings={ disabledSettings } onSave={ jest.fn() } /> );
+	test( 'shows how many read tools are enabled', () => {
+		render(
+			<McpOverview
+				settings={ settings( true, [
+					ability( 'get-site-health', true ),
+					ability( 'list-invoices', true ),
+					ability( 'get-billing-summary', false ),
+				] ) }
+				onSave={ jest.fn() }
+			/>
+		);
 
-		expect( screen.getByText( 'Starter prompts' ) ).toBeVisible();
-		expect( screen.getByText( 'Program health snapshot' ) ).toBeVisible();
-		expect( screen.getByRole( 'button', { name: 'Program health snapshot' } ) ).toBeDisabled();
+		expect( screen.getByText( '2 of 3 enabled' ) ).toBeVisible();
+	} );
 
-		await userEvent.click( screen.getByText( 'Program health snapshot' ) );
+	test( 'shows "All enabled" when every read tool is on', () => {
+		render(
+			<McpOverview
+				settings={ settings( true, [ ability( 'get-site-health', true ) ] ) }
+				onSave={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByText( 'All enabled' ) ).toBeVisible();
+	} );
+
+	test( 'shows "None enabled" when every read tool is off', () => {
+		render(
+			<McpOverview
+				settings={ settings( true, [ ability( 'get-site-health', false ) ] ) }
+				onSave={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByText( 'None enabled' ) ).toBeVisible();
+	} );
+
+	test( 'links Read and Connect to their screens once MCP access is enabled', () => {
+		render(
+			<McpOverview
+				settings={ settings( true, [ ability( 'get-site-health', true ) ] ) }
+				onSave={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByRole( 'link', { name: /^Read\b/ } ) ).toHaveAttribute(
+			'href',
+			'/resources/ai-mcp/tools'
+		);
 		expect(
-			screen.queryByText(
-				/Give me a high-level health check of my Automattic for Agencies account/
-			)
-		).not.toBeInTheDocument();
+			screen.getByRole( 'link', { name: /^Connect external AI assistant/ } )
+		).toHaveAttribute( 'href', '/resources/ai-mcp/connect' );
+	} );
+
+	test( 'disables Read and Connect until MCP access is enabled', () => {
+		render(
+			<McpOverview
+				settings={ settings( false, [ ability( 'get-site-health', true ) ] ) }
+				onSave={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByRole( 'button', { name: /^Read\b/ } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+		expect(
+			screen.getByRole( 'button', { name: /^Connect external AI assistant/ } )
+		).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	test( 'shows Write as coming soon', () => {
+		render(
+			<McpOverview
+				settings={ settings( true, [ ability( 'get-site-health', true ) ] ) }
+				onSave={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByText( 'Coming soon' ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: /^Write\b/ } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+	} );
+
+	test( 'shows Starter prompts as disabled for now', () => {
+		render(
+			<McpOverview
+				settings={ settings( true, [ ability( 'get-site-health', true ) ] ) }
+				onSave={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByRole( 'button', { name: /^Starter prompts/ } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+	} );
+
+	test( 'navigates via onNavigate instead of the href when provided', async () => {
+		const onNavigate = jest.fn();
+		render(
+			<McpOverview
+				settings={ settings( true, [ ability( 'get-site-health', true ) ] ) }
+				onSave={ jest.fn() }
+				onNavigate={ onNavigate }
+			/>
+		);
+
+		await userEvent.click( screen.getByRole( 'link', { name: /^Read\b/ } ) );
+
+		expect( onNavigate ).toHaveBeenCalledWith( '/resources/ai-mcp/tools' );
 	} );
 } );

--- a/client/dashboard/app/responsive-sidebar/agency.tsx
+++ b/client/dashboard/app/responsive-sidebar/agency.tsx
@@ -83,7 +83,7 @@ export default function AgencySidebar() {
 						<SidebarMenuItem to="/resources/learn">{ __( 'Learn' ) }</SidebarMenuItem>
 					) }
 					{ canAccessMcp && (
-						<SidebarMenuItem to="/resources/ai-mcp">{ __( 'MCP' ) }</SidebarMenuItem>
+						<SidebarMenuItem to="/resources/ai-mcp">{ __( 'AI and MCP' ) }</SidebarMenuItem>
 					) }
 				</SidebarExpandableMenuItem>
 			) }

--- a/client/dashboard/app/responsive-sidebar/test/agency.test.tsx
+++ b/client/dashboard/app/responsive-sidebar/test/agency.test.tsx
@@ -101,12 +101,12 @@ describe( '<AgencySidebar>', () => {
 	test( 'shows MCP when the agency is MCP-enabled and the user holds the learn capability', async () => {
 		await renderSidebar( [ 'a4a_read_learn' ] );
 
-		expect( screen.getByRole( 'link', { name: 'MCP' } ) ).toBeVisible();
+		expect( screen.getByRole( 'link', { name: 'AI and MCP' } ) ).toBeVisible();
 	} );
 
 	test( 'hides MCP when the agency is MCP-enabled but the user lacks the learn capability', async () => {
 		await renderSidebar( [ 'a4a_read_managed_sites' ] );
 
-		expect( screen.queryByRole( 'link', { name: 'MCP' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: 'AI and MCP' } ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -189,7 +189,7 @@ const ensureMcpSettings = async () => {
 
 export const mcpRoute = createRoute( {
 	staticData: { requiresAgencyCapability: 'a4a_read_learn' },
-	head: () => ( { meta: [ { title: __( 'MCP' ) } ] } ),
+	head: () => ( { meta: [ { title: __( 'AI and MCP' ) } ] } ),
 	getParentRoute: () => agencyRoute,
 	path: 'resources/ai-mcp',
 	beforeLoad: async ( { cause } ) => {


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-3168/mcp-revamp-the-main-a4a-connection-screen

## Proposed Changes

* Rebuild the A4A **AI and MCP** main page to follow the WordPress.com layout: an "External AI agent access" card with the MCP toggle, then **Read** and **Write** rows, followed by **Connect external AI assistant** and **Starter prompts**.
* **Write** is badged "Coming soon" — A4A abilities carry no read/write metadata yet, so every current ability counts toward the Read badge.
* **Starter prompts** is rendered disabled. It gets its own page in a follow-up PR.
* Rename the page and the dashboard sidebar entry to "AI and MCP" (the classic sidebar already used that label).

The overview component is shared by the new dashboard route and the classic A4A section, so both surfaces pick up the change.


<img width="1724" height="962" alt="Screenshot 2026-08-08 at 2 03 38 AM" src="https://github.com/user-attachments/assets/7be6056e-771f-45df-852a-759df6faef8d" />


## Why are these changes being made?

The A4A MCP page used a bespoke numbered three-step layout that had drifted from the WordPress.com AI and MCP screen. Aligning the two gives users one consistent mental model for MCP access and makes room for the Read/Write split as write tools land.

## Testing Instructions

1. Visit **Resources → AI and MCP** in both the new dashboard and the classic A4A section.
2. Confirm the page reads "AI and MCP" with the description line, and the sidebar entry matches.
3. Toggle **Enable MCP access** off — **Read** and **Connect external AI assistant** become disabled; toggle it back on and confirm they link to the tools and connect screens.
4. Confirm the **Read** badge reflects the enabled tool count (`All enabled` / `None enabled` / `N of M enabled`), and that **Write** and **Starter prompts** are disabled.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
