### PR TITLE
A4A: Add a dedicated Starter prompts page

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -65,6 +65,7 @@ export const A4A_DEV_TOOLS_LINK = `${ A4A_RESOURCES_LINK }/dev-tools`;
 export const A4A_AI_MCP_LINK = `${ A4A_RESOURCES_LINK }/ai-mcp`;
 export const A4A_AI_MCP_AVAILABLE_TOOLS_LINK = `${ A4A_AI_MCP_LINK }/tools`;
 export const A4A_AI_MCP_CONNECT_LINK = `${ A4A_AI_MCP_LINK }/connect`;
+export const A4A_AI_MCP_STARTER_PROMPTS_LINK = `${ A4A_AI_MCP_LINK }/prompts`;
 export const A4A_BENCHMARKS_LINK = `${ A4A_RESOURCES_LINK }/benchmarks`;
 
 // Client

--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -61,6 +61,7 @@ import {
 	A4A_AI_MCP_LINK,
 	A4A_AI_MCP_AVAILABLE_TOOLS_LINK,
 	A4A_AI_MCP_CONNECT_LINK,
+	A4A_AI_MCP_STARTER_PROMPTS_LINK,
 	A4A_BENCHMARKS_LINK,
 	A4A_EXCLUSIVE_OFFERS_LINK,
 	A4A_AMPLIFY_LINK,
@@ -133,6 +134,7 @@ const MEMBER_ACCESSIBLE_PATHS: Record< string, string[] > = {
 	[ A4A_AI_MCP_LINK ]: [ 'a4a_read_learn' ],
 	[ A4A_AI_MCP_AVAILABLE_TOOLS_LINK ]: [ 'a4a_read_learn' ],
 	[ A4A_AI_MCP_CONNECT_LINK ]: [ 'a4a_read_learn' ],
+	[ A4A_AI_MCP_STARTER_PROMPTS_LINK ]: [ 'a4a_read_learn' ],
 	[ A4A_BENCHMARKS_LINK ]: [ 'a4a_read_learn' ],
 };
 

--- a/client/a8c-for-agencies/sections/ai-mcp/controller.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/controller.tsx
@@ -4,6 +4,7 @@ import LearnSidebar from 'calypso/a8c-for-agencies/components/sidebar-menu/learn
 import AiMcpAvailableTools from './primary/available-tools';
 import AiMcpConnectAgent from './primary/connect-agent';
 import AiMcpOverview from './primary/overview';
+import AiMcpStarterPrompts from './primary/starter-prompts';
 
 export const aiMcpOverviewContext: Callback = ( context, next ) => {
 	context.primary = (
@@ -24,6 +25,20 @@ export const aiMcpAvailableToolsContext: Callback = ( context, next ) => {
 				path={ context.path }
 			/>
 			<AiMcpAvailableTools />
+		</>
+	);
+	context.secondary = <LearnSidebar path={ context.path } />;
+	next();
+};
+
+export const aiMcpStarterPromptsContext: Callback = ( context, next ) => {
+	context.primary = (
+		<>
+			<PageViewTracker
+				title="Resources and tools > AI and MCP > Starter prompts"
+				path={ context.path }
+			/>
+			<AiMcpStarterPrompts />
 		</>
 	);
 	context.secondary = <LearnSidebar path={ context.path } />;

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/overview/overview-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/overview/overview-content.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import {
 	A4A_AI_MCP_AVAILABLE_TOOLS_LINK,
 	A4A_AI_MCP_CONNECT_LINK,
+	A4A_AI_MCP_STARTER_PROMPTS_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useFetchMcpSettings from 'calypso/a8c-for-agencies/data/mcp-ai/use-fetch-mcp-settings';
 import useSaveMcpSettings from 'calypso/a8c-for-agencies/data/mcp-ai/use-save-mcp-settings';
@@ -36,6 +37,7 @@ export default function AiMcpOverviewContent() {
 			recordTracksEvent={ recordTracks }
 			toolsPath={ A4A_AI_MCP_AVAILABLE_TOOLS_LINK }
 			connectPath={ A4A_AI_MCP_CONNECT_LINK }
+			promptsPath={ A4A_AI_MCP_STARTER_PROMPTS_LINK }
 		/>
 	);
 }

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/starter-prompts/index.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/starter-prompts/index.tsx
@@ -1,0 +1,42 @@
+import { __ } from '@wordpress/i18n';
+import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { A4A_AI_MCP_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import LayoutBody from 'calypso/layout/hosting-dashboard/body';
+import LayoutHeader, {
+	LayoutHeaderActions as Actions,
+	LayoutHeaderBreadcrumb as Breadcrumb,
+} from 'calypso/layout/hosting-dashboard/header';
+import AiMcpStarterPromptsContent from './starter-prompts-content';
+
+export default function AiMcpStarterPrompts() {
+	const title = __( 'Starter prompts' );
+
+	return (
+		<Layout title={ title } wide>
+			<LayoutTop>
+				<LayoutHeader>
+					<Breadcrumb
+						hideOnMobile
+						items={ [
+							{
+								label: __( 'AI and MCP' ),
+								href: A4A_AI_MCP_LINK,
+							},
+							{
+								label: title,
+							},
+						] }
+					/>
+					<Actions useColumnAlignment>
+						<MobileSidebarNavigation />
+					</Actions>
+				</LayoutHeader>
+			</LayoutTop>
+			<LayoutBody>
+				<AiMcpStarterPromptsContent />
+			</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/starter-prompts/starter-prompts-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/starter-prompts/starter-prompts-content.tsx
@@ -1,0 +1,28 @@
+import { __experimentalText as Text, __experimentalVStack as VStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useCallback } from 'react';
+import McpStarterPrompts from 'calypso/dashboard/agency/resources/mcp/starter-prompts-content';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+export default function AiMcpStarterPromptsContent() {
+	const dispatch = useDispatch();
+
+	const recordTracks = useCallback(
+		( eventName: string, properties?: Record< string, unknown > ) => {
+			dispatch( recordTracksEvent( eventName, properties ) );
+		},
+		[ dispatch ]
+	);
+
+	return (
+		<VStack spacing={ 6 }>
+			<Text size={ 15 }>
+				{ __(
+					'Copy a prompt into your connected assistant to get going. Edit freely — these are starting points, not scripts.'
+				) }
+			</Text>
+			<McpStarterPrompts recordTracksEvent={ recordTracks } />
+		</VStack>
+	);
+}

--- a/client/a8c-for-agencies/sections/learn/index.ts
+++ b/client/a8c-for-agencies/sections/learn/index.ts
@@ -3,6 +3,7 @@ import page from '@automattic/calypso-router';
 import {
 	A4A_AI_MCP_AVAILABLE_TOOLS_LINK,
 	A4A_AI_MCP_CONNECT_LINK,
+	A4A_AI_MCP_STARTER_PROMPTS_LINK,
 	A4A_AI_MCP_LINK,
 	A4A_AGENT_STUDIO_LINK,
 	A4A_BENCHMARKS_LINK,
@@ -22,6 +23,7 @@ import {
 } from '../agent-studio/controller';
 import {
 	aiMcpAvailableToolsContext,
+	aiMcpStarterPromptsContext,
 	aiMcpConnectContext,
 	aiMcpOverviewContext,
 } from '../ai-mcp/controller';
@@ -80,6 +82,14 @@ export default function () {
 		requireAccessContext,
 		requireMcpBetaAccessContext,
 		aiMcpAvailableToolsContext,
+		makeLayout,
+		clientRender
+	);
+	page(
+		A4A_AI_MCP_STARTER_PROMPTS_LINK,
+		requireAccessContext,
+		requireMcpBetaAccessContext,
+		aiMcpStarterPromptsContext,
 		makeLayout,
 		clientRender
 	);

--- a/client/dashboard/agency/resources/mcp/overview-content.tsx
+++ b/client/dashboard/agency/resources/mcp/overview-content.tsx
@@ -10,6 +10,7 @@ import type { MouseEvent } from 'react';
 
 const MCP_TOOLS_PATH = '/resources/ai-mcp/tools';
 const MCP_CONNECT_PATH = '/resources/ai-mcp/connect';
+const MCP_PROMPTS_PATH = '/resources/ai-mcp/prompts';
 
 function getReadBadge( abilities: McpAvailableAbility[] ) {
 	if ( abilities.length === 0 ) {
@@ -41,6 +42,7 @@ interface McpOverviewProps {
 	recordTracksEvent?: RecordTracksEvent;
 	toolsPath?: string;
 	connectPath?: string;
+	promptsPath?: string;
 	onNavigate?: ( path: string ) => void;
 }
 
@@ -52,6 +54,7 @@ export default function McpOverview( {
 	recordTracksEvent = () => {},
 	toolsPath = MCP_TOOLS_PATH,
 	connectPath = MCP_CONNECT_PATH,
+	promptsPath = MCP_PROMPTS_PATH,
 	onNavigate,
 }: McpOverviewProps ) {
 	const handleNavClick =
@@ -129,7 +132,8 @@ export default function McpOverview( {
 						title={ __( 'Starter prompts' ) }
 						description={ __( 'Ready-made prompts to copy into your connected assistant.' ) }
 						decoration={ <Icon icon={ listView } size={ 24 } /> }
-						disabled
+						href={ promptsPath }
+						onClick={ handleNavClick( promptsPath, 'calypso_a4a_ai_mcp_starter_prompts_click' ) }
 					/>
 				</>
 			) }

--- a/client/dashboard/agency/resources/mcp/starter-prompts-content.tsx
+++ b/client/dashboard/agency/resources/mcp/starter-prompts-content.tsx
@@ -6,9 +6,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { check, copy } from '@wordpress/icons';
-import clsx from 'clsx';
-import { Fragment, useCallback, useState } from 'react';
-import { Card, CardBody, CardDivider } from '../../../components/card';
+import { useCallback, useState } from 'react';
 import { CollapsibleCard } from '../../../components/collapsible-card';
 import type { RecordTracksEvent } from './types';
 
@@ -25,9 +23,7 @@ export const STARTER_PROMPTS: StarterPrompt[] = [
 	{
 		id: 'program-health-snapshot',
 		title: __( 'Program health snapshot' ),
-		description: __(
-			'Get a high-level read on your account, covering your tier and what it takes to level up, earnings and eligibility across all streams, and billing status, with the top action items surfaced first.'
-		),
+		description: __( 'Your tier, earnings, and billing, with what to act on first.' ),
 		prompt: __(
 			'Give me a high-level health check of my Automattic for Agencies account. Cover three areas: (1) **Agency & tier** — my current tier, influenced revenue, and the gap to the next tier plus what’s required to get there; (2) **Earnings & eligibility** — lifetime earnings across referrals, WooPayments, and migrations, upcoming payouts, and flag any unresolved or unattributed referrals I could be leaving on the table; (3) **Billing** — current and previous month charges, payment method, and any upcoming renewals at risk of lapsing. Summarize with the most important action items up top.'
 		),
@@ -35,9 +31,7 @@ export const STARTER_PROMPTS: StarterPrompt[] = [
 	{
 		id: 'portfolio-health-summary',
 		title: __( 'Portfolio health summary' ),
-		description: __(
-			'Scan every site you manage and get a grouped list of issues, including active threats, disconnected sites, vulnerable plugins, monitors down, and pending updates, so you know what to fix first.'
-		),
+		description: __( 'Every managed site, grouped by what needs fixing.' ),
 		prompt: __(
 			'Scan all the sites I manage in Automattic for Agencies and give me a succinct list of issues across the portfolio. Group by issue type — active threats, disconnected sites, vulnerable plugins, monitors down, and pending plugin updates — and list the affected sites under each. Start with a one-line count of healthy vs. unhealthy sites, and tell me which issues to fix first.'
 		),
@@ -45,9 +39,7 @@ export const STARTER_PROMPTS: StarterPrompt[] = [
 	{
 		id: 'recurring-weekly-report',
 		title: __( 'Recurring weekly report' ),
-		description: __(
-			'Schedule an automatic weekly rundown of your entire account, including priorities, earnings, tier progress, site health, and billing, delivered where you want it every Monday morning.'
-		),
+		description: __( 'A full account rundown, delivered every Monday morning.' ),
 		prompt: __(
 			'Every Monday at 9:00 AM, generate a full weekly report on my Automattic for Agencies account and deliver it to me. Include an executive summary with top priorities, then sections for: earnings & eligibility (lifetime paid, upcoming payouts, unresolved referrals, migration incentive status), agency tier and progress, portfolio health (healthy vs. unhealthy site counts with issues grouped by type), and renewals & billing. Lead with anything urgent — active security threats or anything at risk of lapsing. Keep it skimmable with clear sections. Ask me where I’d like it delivered — Slack, email, or a saved document — before scheduling.'
 		),
@@ -56,11 +48,9 @@ export const STARTER_PROMPTS: StarterPrompt[] = [
 
 function StarterPromptItem( {
 	prompt,
-	disabled,
 	onCopy,
 }: {
 	prompt: StarterPrompt;
-	disabled?: boolean;
 	onCopy: ( prompt: StarterPrompt ) => void;
 } ) {
 	const [ copied, setCopied ] = useState( false );
@@ -73,35 +63,32 @@ function StarterPromptItem( {
 			setTimeout( () => setCopied( false ), 2000 );
 		} catch {
 			// If the clipboard write fails, stay silent — the user can select the
-			// prompt manually from the text below.
+			// prompt manually from the text above.
 		}
 	}, [ prompt, onCopy ] );
 
 	return (
 		<CollapsibleCard
-			isBorderless
-			disabled={ disabled }
+			className="mcp-starter-prompt-card"
 			toggleLabel={ prompt.title }
 			header={
-				<Text weight={ 600 } size={ 15 }>
-					{ prompt.title }
-				</Text>
+				<VStack spacing={ 1 }>
+					<Text weight={ 600 } size={ 15 }>
+						{ prompt.title }
+					</Text>
+					<Text variant="muted">{ prompt.description }</Text>
+				</VStack>
 			}
 		>
-			<VStack spacing={ 3 }>
-				<Text variant="muted">{ prompt.description }</Text>
+			<VStack spacing={ 4 }>
 				<div className="mcp-starter-prompt">
-					<HStack justify="flex-end" className="mcp-starter-prompt__toolbar">
-						<Button
-							variant="tertiary"
-							icon={ copied ? check : copy }
-							label={ copied ? __( 'Copied' ) : __( 'Copy prompt' ) }
-							showTooltip
-							onClick={ handleCopy }
-						/>
-					</HStack>
 					<Text className="mcp-starter-prompt__text">{ prompt.prompt }</Text>
 				</div>
+				<HStack justify="flex-start" expanded={ false }>
+					<Button variant="secondary" icon={ copied ? check : copy } onClick={ handleCopy }>
+						{ copied ? __( 'Copied' ) : __( 'Copy prompt' ) }
+					</Button>
+				</HStack>
 			</VStack>
 		</CollapsibleCard>
 	);
@@ -109,10 +96,8 @@ function StarterPromptItem( {
 
 export default function McpStarterPrompts( {
 	recordTracksEvent = () => {},
-	disabled = false,
 }: {
 	recordTracksEvent?: RecordTracksEvent;
-	disabled?: boolean;
 } ) {
 	const onCopy = useCallback(
 		( prompt: StarterPrompt ) => {
@@ -122,28 +107,10 @@ export default function McpStarterPrompts( {
 	);
 
 	return (
-		<Card>
-			<CardBody>
-				<VStack
-					spacing={ 2 }
-					className={ clsx( 'mcp-starter-prompts__intro', { 'is-disabled': disabled } ) }
-				>
-					<Text weight={ 600 } size={ 15 }>
-						{ __( 'Starter prompts' ) }
-					</Text>
-					<Text variant="muted">
-						{ __(
-							'The sky’s the limit with AI agents. To help you get the most out of our MCP, we’ve created a set of starter prompts you can hand straight to the AI agent of your choice once connected. Feel free to modify them as you see fit for the best experience, tailored to your agency.'
-						) }
-					</Text>
-				</VStack>
-			</CardBody>
+		<VStack spacing={ 4 }>
 			{ STARTER_PROMPTS.map( ( prompt ) => (
-				<Fragment key={ prompt.id }>
-					<CardDivider style={ { borderColor: 'var(--color-border-subtle)' } } />
-					<StarterPromptItem prompt={ prompt } disabled={ disabled } onCopy={ onCopy } />
-				</Fragment>
+				<StarterPromptItem key={ prompt.id } prompt={ prompt } onCopy={ onCopy } />
 			) ) }
-		</Card>
+		</VStack>
 	);
 }

--- a/client/dashboard/agency/resources/mcp/starter-prompts.tsx
+++ b/client/dashboard/agency/resources/mcp/starter-prompts.tsx
@@ -1,0 +1,27 @@
+import { __ } from '@wordpress/i18n';
+import { useAnalytics } from '../../../app/analytics';
+import Breadcrumbs from '../../../app/breadcrumbs';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+import McpStarterPrompts from './starter-prompts-content';
+
+export default function McpStarterPromptsScreen() {
+	const { recordTracksEvent } = useAnalytics();
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
+					title={ __( 'Starter prompts' ) }
+					description={ __(
+						'Copy a prompt into your connected assistant to get going. Edit freely — these are starting points, not scripts.'
+					) }
+				/>
+			}
+		>
+			<McpStarterPrompts recordTracksEvent={ recordTracksEvent } />
+		</PageLayout>
+	);
+}

--- a/client/dashboard/agency/resources/mcp/style.scss
+++ b/client/dashboard/agency/resources/mcp/style.scss
@@ -24,8 +24,8 @@
 	max-height: 400px;
 }
 
-.mcp-starter-prompts__intro.is-disabled {
-	opacity: 0.5;
+.mcp-starter-prompt-card .collapsible-card__content {
+	margin-block-start: 16px;
 }
 
 .mcp-starter-prompt {
@@ -33,10 +33,6 @@
 	border: 1px solid var( --color-border-subtle );
 	border-radius: 4px;
 	background: var( --color-neutral-0 );
-}
-
-.mcp-starter-prompt__toolbar {
-	margin-block-end: 4px;
 }
 
 .mcp-starter-prompt__text {

--- a/client/dashboard/agency/resources/mcp/test/overview-content.test.tsx
+++ b/client/dashboard/agency/resources/mcp/test/overview-content.test.tsx
@@ -114,10 +114,24 @@ describe( '<McpOverview>', () => {
 		);
 	} );
 
-	test( 'shows Starter prompts as disabled for now', () => {
+	test( 'links Starter prompts to its screen once MCP access is enabled', () => {
 		render(
 			<McpOverview
 				settings={ settings( true, [ ability( 'get-site-health', true ) ] ) }
+				onSave={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByRole( 'link', { name: /^Starter prompts/ } ) ).toHaveAttribute(
+			'href',
+			'/resources/ai-mcp/prompts'
+		);
+	} );
+
+	test( 'disables Starter prompts until MCP access is enabled', () => {
+		render(
+			<McpOverview
+				settings={ settings( false, [ ability( 'get-site-health', true ) ] ) }
 				onSave={ jest.fn() }
 			/>
 		);

--- a/client/dashboard/agency/resources/mcp/test/overview-content.test.tsx
+++ b/client/dashboard/agency/resources/mcp/test/overview-content.test.tsx
@@ -128,20 +128,6 @@ describe( '<McpOverview>', () => {
 		);
 	} );
 
-	test( 'disables Starter prompts until MCP access is enabled', () => {
-		render(
-			<McpOverview
-				settings={ settings( false, [ ability( 'get-site-health', true ) ] ) }
-				onSave={ jest.fn() }
-			/>
-		);
-
-		expect( screen.getByRole( 'button', { name: /^Starter prompts/ } ) ).toHaveAttribute(
-			'aria-disabled',
-			'true'
-		);
-	} );
-
 	test( 'navigates via onNavigate instead of the href when provided', async () => {
 		const onNavigate = jest.fn();
 		render(

--- a/client/dashboard/agency/resources/mcp/test/starter-prompts-content.test.tsx
+++ b/client/dashboard/agency/resources/mcp/test/starter-prompts-content.test.tsx
@@ -22,24 +22,33 @@ beforeEach( () => {
 } );
 
 describe( '<McpStarterPrompts>', () => {
-	test( 'shows a collapsed FAQ item per prompt with the prompt text hidden', () => {
+	test( 'shows a collapsed card per prompt with the prompt text hidden', () => {
 		render( <McpStarterPrompts /> );
 
-		expect( screen.getByText( 'Starter prompts' ) ).toBeVisible();
-		expect( screen.getByText( 'Program health snapshot' ) ).toBeVisible();
-		expect( screen.getByText( 'Portfolio health summary' ) ).toBeVisible();
-		expect( screen.getByText( 'Recurring weekly report' ) ).toBeVisible();
+		for ( const prompt of STARTER_PROMPTS ) {
+			expect( screen.getByText( prompt.title ) ).toBeVisible();
+			expect( screen.getByText( prompt.description ) ).toBeVisible();
+		}
 
-		// The prompt text stays out of the way until the item is expanded.
+		// The prompt text stays out of the way until the card is expanded.
 		expect( screen.queryByText( STARTER_PROMPTS[ 0 ].prompt ) ).not.toBeInTheDocument();
 	} );
 
-	test( 'expands an item to reveal its prompt', async () => {
+	test( 'expands a card to reveal its prompt', async () => {
 		render( <McpStarterPrompts /> );
 
-		await userEvent.click( screen.getByText( 'Program health snapshot' ) );
+		await userEvent.click( screen.getByText( STARTER_PROMPTS[ 0 ].title ) );
 
 		expect( screen.getByText( STARTER_PROMPTS[ 0 ].prompt ) ).toBeVisible();
+	} );
+
+	test( 'expands each card independently', async () => {
+		render( <McpStarterPrompts /> );
+
+		await userEvent.click( screen.getByText( STARTER_PROMPTS[ 1 ].title ) );
+
+		expect( screen.getByText( STARTER_PROMPTS[ 1 ].prompt ) ).toBeVisible();
+		expect( screen.queryByText( STARTER_PROMPTS[ 0 ].prompt ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'copies the raw prompt text and records a tracks event', async () => {
@@ -48,7 +57,7 @@ describe( '<McpStarterPrompts>', () => {
 
 		const firstPrompt = STARTER_PROMPTS[ 0 ];
 		await userEvent.click( screen.getByText( firstPrompt.title ) );
-		await userEvent.click( screen.getByRole( 'button', { name: /copy prompt/i } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: 'Copy prompt' } ) );
 
 		expect( clipboardWriteText ).toHaveBeenCalledWith( firstPrompt.prompt );
 		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_a4a_ai_mcp_starter_prompt_copied', {
@@ -56,11 +65,12 @@ describe( '<McpStarterPrompts>', () => {
 		} );
 	} );
 
-	test( 'items cannot be expanded when disabled', async () => {
-		render( <McpStarterPrompts disabled /> );
+	test( 'confirms the copy on the button itself', async () => {
+		render( <McpStarterPrompts /> );
 
-		await userEvent.click( screen.getByText( 'Program health snapshot' ) );
+		await userEvent.click( screen.getByText( STARTER_PROMPTS[ 0 ].title ) );
+		await userEvent.click( screen.getByRole( 'button', { name: 'Copy prompt' } ) );
 
-		expect( screen.queryByText( STARTER_PROMPTS[ 0 ].prompt ) ).not.toBeInTheDocument();
+		expect( await screen.findByRole( 'button', { name: 'Copied' } ) ).toBeVisible();
 	} );
 } );

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -225,6 +225,16 @@ const mcpAvailableToolsRoute = createRoute( {
 	)
 );
 
+const mcpStarterPromptsRoute = createRoute( {
+	head: () => ( { meta: [ { title: __( 'Starter prompts' ) } ] } ),
+	getParentRoute: () => mcpRoute,
+	path: 'prompts',
+} ).lazy( () =>
+	import( '../../agency/resources/mcp/starter-prompts' ).then( ( d ) =>
+		createLazyRoute( 'resources-mcp-prompts' )( { component: d.default } )
+	)
+);
+
 const mcpConnectRoute = createRoute( {
 	head: () => ( { meta: [ { title: __( 'Connect external AI assistant' ) } ] } ),
 	getParentRoute: () => mcpRoute,
@@ -814,7 +824,12 @@ export const createAgencyRoutes = () => [
 		agencyTiersRoute,
 		exclusiveOffersRoute,
 		learnRoute,
-		mcpRoute.addChildren( [ mcpOverviewRoute, mcpAvailableToolsRoute, mcpConnectRoute ] ),
+		mcpRoute.addChildren( [
+			mcpOverviewRoute,
+			mcpAvailableToolsRoute,
+			mcpStarterPromptsRoute,
+			mcpConnectRoute,
+		] ),
 		agencySitesRoute,
 		agencyTeamRoute,
 		earnOverviewRoute,


### PR DESCRIPTION
> Follow-up to #113401 — based on `revamp/a4a/mcp-screen`, not `trunk`. Merge that one first.

Fixes https://linear.app/a8c/issue/A4A-3171/mcp-add-dedicated-starter-prompt-page

## Proposed Changes

* Give starter prompts a dedicated page at `/ai-mcp/prompts` instead of embedding them at the bottom of the MCP overview.
* Enable the **Starter prompts** row on the overview, which #113401 left disabled.
* Show each prompt as its own collapsible card with a short summary, revealing the full prompt and a **Copy prompt** button on expand.

Registered on both surfaces — a `prompts` route in the dashboard, and a route, page, and controller context in the classic section.

<img width="1725" height="960" alt="Screenshot 2026-08-08 at 3 31 15 AM" src="https://github.com/user-attachments/assets/1658d77d-a87f-4feb-9c35-49ffd7d0e257" />


## Why are these changes being made?

The overview was carrying three long prompts inline, which buried the settings above them. Moving the prompts to their own page keeps the overview to a scannable set of links and gives the prompts room to breathe.

## Testing Instructions

1. Visit **Resources → AI and MCP** in both the new dashboard and the classic A4A section.
2. Click **Starter prompts** — it should navigate to the new page, not reload or bounce to the agency overview.
3. Expand a prompt, hit **Copy prompt**, and confirm the button briefly reads "Copied" and the clipboard holds the raw prompt.
4. Turn **Enable MCP access** off and confirm the Starter prompts row is disabled, like Read and Connect.

## Notes for reviewers

New classic paths must also be added to the path-to-capability map in `client/a8c-for-agencies/lib/permission.ts`. Without an entry, `isPathAllowed()` fails and `handleMultiUserSupport` does `window.location.href = A4A_OVERVIEW_LINK` — a full page load to the agency overview, which reads as a routing bug rather than a permissions one.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
