### PR TITLE
A4A: Restyle the MCP connection guide to follow the WP.com setup layout

### DIFF
--- a/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/connect-agent-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/connect-agent-content.tsx
@@ -1,3 +1,5 @@
+import { __experimentalText as Text, __experimentalVStack as VStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
 import McpConnectAgent from 'calypso/dashboard/agency/resources/mcp/connect-agent-content';
 import { useDispatch } from 'calypso/state';
@@ -13,5 +15,14 @@ export default function AiMcpConnectAgentContent() {
 		[ dispatch ]
 	);
 
-	return <McpConnectAgent recordTracksEvent={ recordTracks } />;
+	return (
+		<VStack spacing={ 6 }>
+			<Text size={ 15 }>
+				{ __(
+					'Get instructions for connecting your external AI assistant to your Automattic for Agencies account via MCP.'
+				) }
+			</Text>
+			<McpConnectAgent recordTracksEvent={ recordTracks } />
+		</VStack>
+	);
 }

--- a/client/dashboard/agency/resources/mcp/connect-agent-content.tsx
+++ b/client/dashboard/agency/resources/mcp/connect-agent-content.tsx
@@ -4,7 +4,6 @@ import {
 	TextareaControl,
 	ExternalLink,
 	__experimentalHStack as HStack,
-	__experimentalSpacer as Spacer,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -12,12 +11,27 @@ import { __, sprintf } from '@wordpress/i18n';
 import { check, copy } from '@wordpress/icons';
 import { useCallback, useMemo, useState } from 'react';
 import { Card, CardBody } from '../../../components/card';
-import { CollapsibleCard } from '../../../components/collapsible-card';
+import { SectionHeader } from '../../../components/section-header';
 import { AGENT_CONFIGS, DEFAULT_AGENT_ID } from './agent-configs';
 import type { AgentConfig } from './agent-configs';
 import type { RecordTracksEvent } from './types';
+import type { ReactNode } from 'react';
 
 import './style.scss';
+
+function SetupSteps( { steps }: { steps: ReactNode[] } ) {
+	return (
+		<ol className="mcp-connect-agent__steps">
+			{ steps.map( ( step, index ) => (
+				<li key={ index }>
+					<Text as="p" variant="muted">
+						{ step }
+					</Text>
+				</li>
+			) ) }
+		</ol>
+	);
+}
 
 function ConfigSnippet( {
 	snippet,
@@ -33,7 +47,7 @@ function ConfigSnippet( {
 	return (
 		<>
 			<HStack alignment="center" justify="space-between" spacing={ 2 }>
-				<Text variant="muted">
+				<Text as="p" variant="muted">
 					{ file
 						? sprintf(
 								/* translators: %(file)s is the config file name */
@@ -46,6 +60,7 @@ function ConfigSnippet( {
 					style={ { flexShrink: 0 } }
 					variant="tertiary"
 					icon={ copied ? check : copy }
+					iconSize={ 20 }
 					label={ copied ? __( 'Copied' ) : __( 'Copy configuration' ) }
 					showTooltip
 					onClick={ onCopy }
@@ -110,22 +125,23 @@ export default function McpConnectAgent( {
 	const hasSteps = !! selectedAgent.quickSetup && selectedAgent.quickSetup.length > 0;
 	const hasQuickSetup = hasSteps || !! selectedAgent.installAction;
 
-	return (
-		<>
-			<Spacer marginBottom={ 8 } style={ { maxWidth: '650px' } }>
-				<Text size={ 15 }>
-					{ __(
-						'Get instructions for connecting your external AI assistant to your Automattic for Agencies account via MCP.'
-					) }
-				</Text>
-			</Spacer>
+	// The documentation link belongs at the end of the last configuration card, so
+	// it stays reachable whichever setup paths this agent offers.
+	const docsLink = (
+		<ExternalLink href={ selectedAgent.docsUrl }>{ selectedAgent.docsLabel }</ExternalLink>
+	);
 
-			<VStack spacing={ 4 } className="mcp-connect-agent">
-				<Card>
-					<CardBody>
+	return (
+		<VStack spacing={ 4 } className="mcp-connect-agent">
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<SectionHeader level={ 3 } title={ __( 'Choose your AI assistant' ) } />
 						<SelectControl
+							__next40pxDefaultSize
 							__nextHasNoMarginBottom
-							label={ __( 'Choose your AI assistant' ) }
+							label={ __( 'AI assistant' ) }
+							help={ __( 'Pick your assistant to get the matching setup instructions.' ) }
 							value={ selectedAgent.id }
 							options={ AGENT_CONFIGS.map( ( agent ) => ( {
 								label: agent.label,
@@ -133,94 +149,76 @@ export default function McpConnectAgent( {
 							} ) ) }
 							onChange={ onAgentChange }
 						/>
+					</VStack>
+				</CardBody>
+			</Card>
+
+			{ hasQuickSetup && (
+				<Card>
+					<CardBody>
+						<VStack spacing={ 4 }>
+							<SectionHeader level={ 3 } title={ __( 'Quick setup' ) } />
+							{ selectedAgent.quickSetupDescription && (
+								<Text as="p" variant="muted">
+									{ selectedAgent.quickSetupDescription }
+								</Text>
+							) }
+							{ hasSteps && <SetupSteps steps={ selectedAgent.quickSetup as ReactNode[] } /> }
+							{ selectedAgent.installAction && (
+								<>
+									<Text as="p" variant="muted">
+										{ __(
+											'Or use the one-click install to add the Automattic for Agencies MCP app.'
+										) }
+									</Text>
+									<Button
+										style={ { width: 'fit-content' } }
+										variant="primary"
+										href={ selectedAgent.installAction.deepLink }
+										onClick={ onInstallActionClick }
+									>
+										{ selectedAgent.installAction.label }
+									</Button>
+								</>
+							) }
+						</VStack>
 					</CardBody>
 				</Card>
+			) }
 
-				{ hasQuickSetup && (
-					<Card>
-						<CardBody>
-							<VStack spacing={ 3 }>
-								<Text weight={ 600 } size={ 15 }>
-									{ __( 'Quick setup' ) }
-								</Text>
-								{ selectedAgent.quickSetupDescription && (
-									<Text variant="muted">{ selectedAgent.quickSetupDescription }</Text>
-								) }
-								{ hasSteps && (
-									<ol>
-										{ selectedAgent.quickSetup!.map( ( step, index ) => (
-											<li key={ index }>
-												<Text>{ step }</Text>
-											</li>
-										) ) }
-									</ol>
-								) }
-								{ selectedAgent.installAction && (
-									<>
-										<Text>
-											{ __(
-												'Or use the one-click install to add the Automattic for Agencies MCP app.'
-											) }
-										</Text>
-										<Button
-											style={ { width: 'fit-content' } }
-											variant="primary"
-											href={ selectedAgent.installAction.deepLink }
-											onClick={ onInstallActionClick }
-										>
-											{ selectedAgent.installAction.label }
-										</Button>
-									</>
-								) }
-							</VStack>
-						</CardBody>
-					</Card>
-				) }
+			{ selectedAgent.manualSetupSnippet && (
+				<Card>
+					<CardBody>
+						<VStack spacing={ 4 }>
+							<SectionHeader level={ 3 } title={ __( 'Manual setup' ) } />
+							<ConfigSnippet
+								snippet={ selectedAgent.manualSetupSnippet }
+								file={ selectedAgent.manualSetupFile }
+								copied={ copied }
+								onCopy={ () =>
+									copySnippet(
+										selectedAgent.manualSetupSnippet as string,
+										'calypso_a4a_ai_mcp_manual_config_copied',
+										setCopied
+									)
+								}
+							/>
+							{ ! selectedAgent.fallbackSetup && docsLink }
+						</VStack>
+					</CardBody>
+				</Card>
+			) }
 
-				{ selectedAgent.manualSetupSnippet && (
-					<Card>
-						<CardBody>
-							<VStack spacing={ 3 }>
-								<Text weight={ 600 } size={ 15 }>
-									{ __( 'Manual setup' ) }
-								</Text>
-								<ConfigSnippet
-									snippet={ selectedAgent.manualSetupSnippet }
-									file={ selectedAgent.manualSetupFile }
-									copied={ copied }
-									onCopy={ () =>
-										copySnippet(
-											selectedAgent.manualSetupSnippet as string,
-											'calypso_a4a_ai_mcp_manual_config_copied',
-											setCopied
-										)
-									}
-								/>
-							</VStack>
-						</CardBody>
-					</Card>
-				) }
-
-				{ selectedAgent.fallbackSetup && (
-					<CollapsibleCard
-						initialExpanded={ false }
-						toggleLabel={ __( 'Toggle fallback setup' ) }
-						header={
-							<Text weight={ 600 } size={ 15 }>
-								{ __( 'Older clients or troubleshooting' ) }
+			{ selectedAgent.fallbackSetup && (
+				<Card>
+					<CardBody>
+						<VStack spacing={ 4 }>
+							<SectionHeader level={ 3 } title={ __( 'Older clients or troubleshooting' ) } />
+							<Text as="p" variant="muted">
+								{ selectedAgent.fallbackSetup.description }
 							</Text>
-						}
-					>
-						<VStack spacing={ 3 }>
-							<Text variant="muted">{ selectedAgent.fallbackSetup.description }</Text>
 							{ selectedAgent.fallbackSetup.steps && (
-								<ol>
-									{ selectedAgent.fallbackSetup.steps.map( ( step, index ) => (
-										<li key={ index }>
-											<Text>{ step }</Text>
-										</li>
-									) ) }
-								</ol>
+								<SetupSteps steps={ selectedAgent.fallbackSetup.steps } />
 							) }
 							<ConfigSnippet
 								snippet={ selectedAgent.fallbackSetup.snippet }
@@ -234,12 +232,13 @@ export default function McpConnectAgent( {
 									)
 								}
 							/>
+							{ docsLink }
 						</VStack>
-					</CollapsibleCard>
-				) }
+					</CardBody>
+				</Card>
+			) }
 
-				<ExternalLink href={ selectedAgent.docsUrl } children={ selectedAgent.docsLabel } />
-			</VStack>
-		</>
+			{ ! selectedAgent.manualSetupSnippet && ! selectedAgent.fallbackSetup && docsLink }
+		</VStack>
 	);
 }

--- a/client/dashboard/agency/resources/mcp/connect-agent.tsx
+++ b/client/dashboard/agency/resources/mcp/connect-agent.tsx
@@ -10,10 +10,14 @@ export default function McpConnectAgentScreen() {
 
 	return (
 		<PageLayout
+			size="small"
 			header={
 				<PageHeader
-					title={ __( 'Connect external AI assistant' ) }
 					prefix={ <Breadcrumbs length={ 2 } /> }
+					title={ __( 'Connect external AI assistant' ) }
+					description={ __(
+						'Get instructions for connecting your external AI assistant to your Automattic for Agencies account via MCP.'
+					) }
 				/>
 			}
 		>

--- a/client/dashboard/agency/resources/mcp/style.scss
+++ b/client/dashboard/agency/resources/mcp/style.scss
@@ -1,10 +1,10 @@
-.mcp-connect-agent ol {
+.mcp-connect-agent__steps {
 	padding-inline-start: 20px;
 	margin: 0;
 }
 
-.mcp-connect-agent ol li,
-.mcp-connect-agent ol li > span {
+.mcp-connect-agent__steps li,
+.mcp-connect-agent__steps li > p {
 	color: var( --color-neutral-60 );
 	font-size: 13px;
 }

--- a/client/dashboard/agency/resources/mcp/test/connect-agent-content.test.tsx
+++ b/client/dashboard/agency/resources/mcp/test/connect-agent-content.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../../test-utils';
+import { AGENT_CONFIGS, DEFAULT_AGENT_ID } from '../agent-configs';
+import McpConnectAgent from '../connect-agent-content';
+
+let clipboardWriteText: jest.Mock;
+
+beforeEach( () => {
+	clipboardWriteText = jest.fn().mockResolvedValue( undefined );
+	Object.defineProperty( window.navigator, 'clipboard', {
+		value: { writeText: clipboardWriteText },
+		configurable: true,
+	} );
+} );
+
+const defaultAgent = AGENT_CONFIGS.find( ( agent ) => agent.id === DEFAULT_AGENT_ID )!;
+
+describe( '<McpConnectAgent>', () => {
+	test( 'offers every configured assistant and starts on the default', () => {
+		render( <McpConnectAgent /> );
+
+		const select = screen.getByRole( 'combobox', { name: 'AI assistant' } );
+		expect( select ).toHaveValue( DEFAULT_AGENT_ID );
+		for ( const agent of AGENT_CONFIGS ) {
+			expect( screen.getByRole( 'option', { name: agent.label } ) ).toBeInTheDocument();
+		}
+	} );
+
+	test( 'shows the quick setup steps for the selected assistant', () => {
+		render( <McpConnectAgent /> );
+
+		expect( screen.getByRole( 'heading', { name: 'Quick setup' } ) ).toBeVisible();
+		expect( screen.getByText( defaultAgent.quickSetupDescription as string ) ).toBeVisible();
+		// Every quick setup step is rendered as a list item.
+		expect( screen.getAllByRole( 'listitem' ).length ).toBeGreaterThanOrEqual(
+			defaultAgent.quickSetup!.length
+		);
+	} );
+
+	test( 'switching assistants swaps the instructions and records the choice', async () => {
+		const recordTracksEvent = jest.fn();
+		const other = AGENT_CONFIGS.find( ( agent ) => agent.id !== DEFAULT_AGENT_ID )!;
+		render( <McpConnectAgent recordTracksEvent={ recordTracksEvent } /> );
+
+		await userEvent.selectOptions(
+			screen.getByRole( 'combobox', { name: 'AI assistant' } ),
+			other.id
+		);
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_a4a_ai_mcp_connect_agent_selected', {
+			agent_id: other.id,
+		} );
+		expect( screen.getByRole( 'link', { name: new RegExp( other.docsLabel ) } ) ).toBeVisible();
+	} );
+
+	test( 'copies the fallback configuration and records a tracks event', async () => {
+		const recordTracksEvent = jest.fn();
+		render( <McpConnectAgent recordTracksEvent={ recordTracksEvent } /> );
+
+		expect(
+			screen.getByRole( 'heading', { name: 'Older clients or troubleshooting' } )
+		).toBeVisible();
+		await userEvent.click( screen.getByRole( 'button', { name: 'Copy configuration' } ) );
+
+		expect( clipboardWriteText ).toHaveBeenCalledWith( defaultAgent.fallbackSetup!.snippet );
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_a4a_ai_mcp_fallback_config_copied', {
+			agent_id: defaultAgent.id,
+		} );
+	} );
+
+	test( 'links to the documentation for the selected assistant', () => {
+		render( <McpConnectAgent /> );
+
+		expect(
+			screen.getByRole( 'link', { name: new RegExp( defaultAgent.docsLabel ) } )
+		).toHaveAttribute( 'href', defaultAgent.docsUrl );
+	} );
+} );


### PR DESCRIPTION
> Follow-up to #113401 — based on `revamp/a4a/mcp-screen`, not `trunk`. Merge that one first.

Closes https://linear.app/a8c/issue/A4A-3172/mcp-revamp-the-connection-guide-page

## Proposed Changes

* Restyle the MCP connection guide to follow the WordPress.com setup screen: description in the page header, cards titled with `SectionHeader`, and setup steps as muted list items.
* Add a help line to the assistant picker explaining what selecting one changes.
* Show **Older clients or troubleshooting** as a plain card instead of a collapsible one, so the Node bridge fallback no longer hides behind a toggle.

**The instructions themselves are unchanged.** `agent-configs.tsx` has a zero diff — every quick setup step, bridge step, config snippet, install deep link, and docs link is exactly as it was. This is presentation only.

<img width="1726" height="959" alt="Screenshot 2026-08-08 at 3 57 09 AM" src="https://github.com/user-attachments/assets/b4bb0177-93dd-4df6-b257-5e93bfc3cf8a" />


## Why are these changes being made?

The connection guide was the last MCP screen still on its own layout. Matching the WordPress.com setup screen makes the whole MCP section read as one product.

## Testing Instructions

1. Visit **Resources → AI and MCP → Connect external AI assistant** in both the new dashboard and the classic A4A section.
2. Step through every assistant in the picker and confirm its quick setup, manual setup, and fallback instructions read the same as before.
3. Copy a configuration and confirm the button confirms the copy and the clipboard holds the snippet.
4. Confirm the documentation link is present for every assistant.

## Notes for reviewers

The docs link now sits at the end of whichever card is last for the selected assistant — fallback, else manual setup, else on its own. Not every assistant offers both sections, so pinning it to one would drop it for some.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
