### PR TITLE
Checkout: only use one list of payment methods

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -505,20 +505,25 @@ export default function useCreatePaymentMethods( {
 		stripeLoadingError,
 	} );
 
+	// In Germany, PayPal is the preferred option, so we display it before
+	// credit cards. See https://wp.me/pxLjZ-9aA
+	const shouldPreferPayPal = currentTaxCountryCode?.toUpperCase() === 'DE';
+	const payPalMethods = [ paypalExpressMethod, paypalPPCPMethod ];
+	const cardAndPayPalMethods = shouldPreferPayPal
+		? [ ...payPalMethods, stripeMethod, freePaymentMethod ]
+		: [ stripeMethod, freePaymentMethod, ...payPalMethods ];
+
 	// The order of this array is the order that Payment Methods will be
 	// displayed in Checkout, although not all payment methods here will be
 	// listed; the list of allowed payment methods is returned by the shopping
 	// cart which will be used to filter this list in
 	// `filterAppropriatePaymentMethods()`.
-	let paymentMethods = [
+	return [
 		...existingCardMethods,
 		...existingPayPalPPCPMethods,
 		applePayMethod,
 		googlePayMethod,
-		stripeMethod,
-		freePaymentMethod,
-		paypalExpressMethod,
-		paypalPPCPMethod,
+		...cardAndPayPalMethods,
 		idealMethod,
 		blikMethod,
 		sofortMethod,
@@ -531,31 +536,4 @@ export default function useCreatePaymentMethods( {
 		bancontactMethod,
 		stripeUpiMethod,
 	].filter( isValueTruthy );
-
-	// In Germany, PayPal is the preferred option, so we display it before
-	// credit cards. See https://wp.me/pxLjZ-9aA
-	if ( currentTaxCountryCode?.toUpperCase() === 'DE' ) {
-		paymentMethods = [
-			...existingCardMethods,
-			...existingPayPalPPCPMethods,
-			applePayMethod,
-			googlePayMethod,
-			paypalExpressMethod,
-			paypalPPCPMethod,
-			stripeMethod,
-			freePaymentMethod,
-			idealMethod,
-			sofortMethod,
-			pixMethod,
-			pixAutomaticoMethod,
-			alipayMethod,
-			p24Method,
-			epsMethod,
-			wechatMethod,
-			bancontactMethod,
-			stripeUpiMethod,
-		].filter( isValueTruthy );
-	}
-
-	return paymentMethods;
 }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2383/

## Proposed changes

Germany shows PayPal ahead of credit cards in checkout. That was previously done by declaring a second, fully hard-coded copy of the payment method list; this replaces it with a single list where only the PayPal/credit-card block is reordered.

* Extract `payPalMethods` and build a `cardAndPayPalMethods` block whose order flips when the tax country is `DE`.
* Return one array from `useCreatePaymentMethods` instead of building a default list and then overwriting it for Germany.
* Include BLIK in Germany, which the duplicate list had been missing.

## Why are these changes being made?

The ordering of payment methods in checkout is decided by a single array in `useCreatePaymentMethods`, but the German ordering was implemented as a complete second copy of that array. Every change to the payment method list therefore had to be made twice, and there was nothing to enforce that. It had already drifted: BLIK was added to the default list but never to the German copy, so German customers silently lost a payment method that everyone else could see.

Since the only actual difference between the two lists is where the two PayPal entries sit relative to the credit card entries, the fix is to express exactly that difference and nothing else. Adding or reordering a payment method now happens in one place, and the German behaviour can't drift from it again. Restoring BLIK for Germany is a side effect of collapsing the lists — if it should be excluded there, that needs to be a deliberate, separate condition.

## Testing instructions

* Load checkout with a paid product on a sandboxed environment, using a contact/tax country that is *not* Germany.
* Confirm the payment method order is unchanged: saved cards, saved PayPal, Apple Pay, Google Pay, credit card, then PayPal, then the remaining local methods.
* Change the tax country to Germany (DE) in the contact step.
* Confirm PayPal now appears above the credit card option, and that everything else keeps its previous position.
* Confirm BLIK still appears where expected for a cart/country that allows it.

