### PR TITLE
Checkout: Add the WordPress.com siteless checkout route

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -88,6 +88,10 @@ export function checkoutUnifiedSiteless( context, next ) {
 	sitelessCheckout( context, next, { sitelessCheckoutType: 'unified' } );
 }
 
+export function checkoutWpcomSiteless( context, next ) {
+	sitelessCheckout( context, next, { sitelessCheckoutType: 'wpcom' } );
+}
+
 export function checkoutRenewalBySubscriptionId( context, next ) {
 	const { subscriptionId } = context.params;
 	const state = context.store.getState();

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -371,6 +371,14 @@ export default function getThankYouPageUrl( {
 		return addQueryArgs( { checkout_type: 'unified' }, '/' );
 	}
 
+	// WordPress.com siteless checkout
+	if ( sitelessCheckoutType === 'wpcom' ) {
+		debug( 'redirecting to siteless WordPress.com thank you' );
+		return receiptIdOrPlaceholder
+			? `/checkout/thank-you/no-site/${ receiptIdOrPlaceholder }`
+			: '/checkout/thank-you/no-site';
+	}
+
 	// If there is no purchase, then send the user to a generic page (not
 	// post-purchase related).
 	if ( noPurchaseMade ) {

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -1489,6 +1489,42 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/me/purchases/siteless.akismet.com/123abc' );
 	} );
 
+	it( 'redirects to the no-site thank you when the wpcom siteless arg is set', () => {
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			receiptId: 12342424241,
+			sitelessCheckoutType: 'wpcom',
+		} );
+		expect( url ).toBe( '/checkout/thank-you/no-site/12342424241' );
+	} );
+
+	it( 'redirects to the no-site thank you with a receipt placeholder when the wpcom siteless arg is set and no receipt is known', () => {
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			sitelessCheckoutType: 'wpcom',
+		} );
+		expect( url ).toBe( '/checkout/thank-you/no-site/:receiptId' );
+	} );
+
+	it( 'redirects to the bare no-site thank you when the wpcom siteless receipt id is not an integer', () => {
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			receiptId: 'pending',
+			sitelessCheckoutType: 'wpcom',
+		} );
+		expect( url ).toBe( '/checkout/thank-you/no-site' );
+	} );
+
+	it( 'ignores a disallowed external redirectTo and still uses the wpcom siteless thank you', () => {
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			receiptId: 12342424241,
+			redirectTo: 'https://not-an-allowed-host.example.com/somewhere',
+			sitelessCheckoutType: 'wpcom',
+		} );
+		expect( url ).toBe( '/checkout/thank-you/no-site/12342424241' );
+	} );
+
 	it( 'redirects to the jetpack checkout thank you with `no_product` when jetpack checkout arg is set and the cart is empty', () => {
 		const url = getThankYouPageUrl( {
 			...defaultArgs,

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -16,6 +16,7 @@ import {
 	checkoutJetpackSiteless,
 	checkoutMarketplaceSiteless,
 	checkoutUnifiedSiteless,
+	checkoutWpcomSiteless,
 	checkoutA4ASiteless,
 	checkoutRenewalBySubscriptionId,
 	checkoutThankYou,
@@ -216,6 +217,17 @@ export default function () {
 		setLocaleMiddleware(),
 		noSite,
 		checkoutUnifiedSiteless,
+		makeLayout,
+		clientRender
+	);
+
+	// WordPress.com siteless checkout is logged-in only, so it keeps redirectLoggedOut.
+	page(
+		'/checkout/wpcom/:productSlug',
+		setLocaleMiddleware(),
+		redirectLoggedOut,
+		noSite,
+		checkoutWpcomSiteless,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -216,8 +216,9 @@ export default function CheckoutMain( {
 			return marketplaceSiteSlug;
 		}
 
-		// Onboarding unified siteless checkout should return undefined to avoid using siteSlug which becomes "no-user"
-		if ( sitelessCheckoutType === 'unified' ) {
+		// Unified and WordPress.com siteless checkout have no site, so siteSlug would
+		// otherwise fall back to "no-user".
+		if ( sitelessCheckoutType === 'unified' || sitelessCheckoutType === 'wpcom' ) {
 			return undefined;
 		}
 

--- a/client/my-sites/checkout/src/hooks/use-checkout-flow-track-key.ts
+++ b/client/my-sites/checkout/src/hooks/use-checkout-flow-track-key.ts
@@ -42,6 +42,10 @@ export default function useCheckoutFlowTrackKey( {
 			return 'a4a_siteless_checkout';
 		}
 
+		if ( sitelessCheckoutType === 'wpcom' ) {
+			return 'wpcom_siteless_checkout';
+		}
+
 		if ( isLoggedOutCart ) {
 			return 'wpcom_registrationless';
 		}

--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -154,6 +154,7 @@ export default function usePrepareProductsForCart( {
 			sitelessCheckoutType === 'marketplace' ||
 			sitelessCheckoutType === 'a4a' ||
 			sitelessCheckoutType === 'unified' ||
+			sitelessCheckoutType === 'wpcom' ||
 			isGiftPurchase
 	);
 	useStripProductsFromUrl( siteSlug, doNotStripProducts );
@@ -236,7 +237,8 @@ function chooseAddHandler( {
 	if (
 		sitelessCheckoutType === 'jetpack' ||
 		sitelessCheckoutType === 'akismet' ||
-		sitelessCheckoutType === 'unified'
+		sitelessCheckoutType === 'unified' ||
+		sitelessCheckoutType === 'wpcom'
 	) {
 		return 'addProductFromSlug';
 	}
@@ -756,6 +758,7 @@ function createItemToAddToCart( {
 			sitelessCheckoutType,
 			isDomainOnlySitelessCheckout: sitelessCheckoutType === 'domainonly',
 			isUnifiedSitelessCheckout: sitelessCheckoutType === 'unified',
+			isWpcomSitelessCheckout: sitelessCheckoutType === 'wpcom',
 			isAkismetSitelessCheckout: sitelessCheckoutType === 'akismet',
 			isJetpackCheckout: sitelessCheckoutType === 'jetpack',
 			jetpackSiteSlug,

--- a/client/my-sites/checkout/src/test/use-checkout-flow-track-key.ts
+++ b/client/my-sites/checkout/src/test/use-checkout-flow-track-key.ts
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import useCheckoutFlowTrackKey from '../hooks/use-checkout-flow-track-key';
+import type { SitelessCheckoutType } from '@automattic/wpcom-checkout';
+
+function renderTrackKey( sitelessCheckoutType: SitelessCheckoutType ) {
+	return renderHook( () =>
+		useCheckoutFlowTrackKey( {
+			hasJetpackSiteSlug: false,
+			sitelessCheckoutType,
+			isJetpackNotAtomic: false,
+		} )
+	).result.current;
+}
+
+describe( 'useCheckoutFlowTrackKey', () => {
+	// Sharing 'wpcom_checkout' would make the siteless funnel impossible to split in Tracks.
+	it( 'gives WordPress.com siteless checkout its own flow key', () => {
+		expect( renderTrackKey( 'wpcom' ) ).toBe( 'wpcom_siteless_checkout' );
+	} );
+} );

--- a/client/my-sites/checkout/src/test/use-prepare-products-for-cart.tsx
+++ b/client/my-sites/checkout/src/test/use-prepare-products-for-cart.tsx
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import usePrepareProductsForCart from '../hooks/use-prepare-products-for-cart';
+import type { SitelessCheckoutType } from '@automattic/wpcom-checkout';
+
+jest.mock( 'calypso/my-sites/checkout/use-cart-key' );
+
+function renderPrepareProducts( {
+	productAliasFromUrl,
+	sitelessCheckoutType,
+}: {
+	productAliasFromUrl: string;
+	sitelessCheckoutType: SitelessCheckoutType;
+} ) {
+	return renderHook( () =>
+		usePrepareProductsForCart( {
+			productAliasFromUrl,
+			purchaseId: undefined,
+			usesJetpackProducts: false,
+			isPrivate: false,
+			siteSlug: undefined,
+			sitelessCheckoutType,
+			// The siteless route controller always sets this, so the 'wpcom' branch
+			// has to beat the localStorage path.
+			isNoSiteCart: true,
+		} )
+	);
+}
+
+describe( 'usePrepareProductsForCart for WordPress.com siteless checkout', () => {
+	it( 'builds the cart from the URL slug rather than from localStorage', () => {
+		const { result } = renderPrepareProducts( {
+			productAliasFromUrl: 'personal-bundle',
+			sitelessCheckoutType: 'wpcom',
+		} );
+
+		expect( result.current.isLoading ).toBe( false );
+		expect( result.current.error ).toBeNull();
+		expect( result.current.productsForCart ).toHaveLength( 1 );
+		expect( result.current.productsForCart[ 0 ].product_slug ).toBe( 'personal-bundle' );
+	} );
+
+	it( 'marks the product as a WordPress.com siteless checkout', () => {
+		const { result } = renderPrepareProducts( {
+			productAliasFromUrl: 'personal-bundle',
+			sitelessCheckoutType: 'wpcom',
+		} );
+
+		expect( result.current.productsForCart[ 0 ].extra.isWpcomSitelessCheckout ).toBe( true );
+	} );
+
+	it( 'only the wpcom type sets isWpcomSitelessCheckout', () => {
+		const { result } = renderPrepareProducts( {
+			productAliasFromUrl: 'ak_pro5h_yearly',
+			sitelessCheckoutType: 'akismet',
+		} );
+
+		expect( result.current.productsForCart[ 0 ].extra.isWpcomSitelessCheckout ).toBeFalsy();
+		expect( result.current.productsForCart[ 0 ].extra.isAkismetSitelessCheckout ).toBe( true );
+	} );
+
+	it( 'reads the quantity from a :-q- suffix on the URL slug', () => {
+		const { result } = renderPrepareProducts( {
+			productAliasFromUrl: 'personal-bundle:-q-500',
+			sitelessCheckoutType: 'wpcom',
+		} );
+
+		expect( result.current.productsForCart[ 0 ].product_slug ).toBe( 'personal-bundle' );
+		expect( result.current.productsForCart[ 0 ].quantity ).toBe( 500 );
+	} );
+
+	// Without 'wpcom' in `doNotStripProducts`, `useStripProductsFromUrl` rewrites the
+	// URL and the product is lost on reload.
+	it( 'leaves the product in the URL', () => {
+		const replaceState = jest.spyOn( window.history, 'replaceState' );
+		window.history.replaceState( null, '', '/checkout/wpcom/personal-bundle' );
+		replaceState.mockClear();
+
+		renderPrepareProducts( {
+			productAliasFromUrl: 'personal-bundle',
+			sitelessCheckoutType: 'wpcom',
+		} );
+
+		expect( replaceState ).not.toHaveBeenCalled();
+		replaceState.mockRestore();
+	} );
+} );

--- a/client/my-sites/checkout/test/controller.js
+++ b/client/my-sites/checkout/test/controller.js
@@ -10,7 +10,7 @@ import {
 import * as page from '@automattic/calypso-router';
 import configureStore from 'redux-mock-store';
 import { COMPARE_PLANS_QUERY_PARAM } from '../../plans/jetpack-plans/plan-upgrade/constants';
-import { redirectJetpackLegacyPlans } from '../controller';
+import { checkoutWpcomSiteless, redirectJetpackLegacyPlans } from '../controller';
 import * as utils from '../utils';
 
 jest.mock( '@automattic/calypso-router' );
@@ -65,5 +65,24 @@ describe( 'redirectJetpackLegacyPlans', () => {
 
 		expect( spy ).toHaveBeenCalledWith( redirectUrl );
 		expect( next ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'checkoutWpcomSiteless', () => {
+	it( 'renders checkout with the wpcom siteless type', () => {
+		const next = jest.fn();
+		const context = {
+			params: { productSlug: 'ak_pro5h_yearly' },
+			query: {},
+			store: mockStore( { currentUser: { id: 7 } } ),
+		};
+
+		checkoutWpcomSiteless( context, next );
+
+		const wrapper = context.primary.props.children[ 1 ];
+		expect( wrapper.props.sitelessCheckoutType ).toBe( 'wpcom' );
+		expect( wrapper.props.productAliasFromUrl ).toBe( 'ak_pro5h_yearly' );
+		expect( wrapper.props.isNoSiteCart ).toBe( true );
+		expect( next ).toHaveBeenCalled();
 	} );
 } );

--- a/client/my-sites/checkout/test/index.ts
+++ b/client/my-sites/checkout/test/index.ts
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+import page from '@automattic/calypso-router';
+import { makeLayout, redirectLoggedOut, render as clientRender } from 'calypso/controller';
+import { noSite } from 'calypso/my-sites/controller';
+import { checkoutWpcomSiteless } from '../controller';
+import registerCheckoutRoutes from '../index';
+
+const mockLocaleMiddleware = jest.fn();
+
+jest.mock( '@automattic/calypso-router', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/controller', () => ( {
+	makeLayout: jest.fn(),
+	redirectLoggedOut: jest.fn(),
+	redirectMyJetpack: jest.fn(),
+	render: jest.fn(),
+	setLocaleMiddleware: () => mockLocaleMiddleware,
+} ) );
+
+jest.mock( 'calypso/lib/siftscience' );
+jest.mock( 'calypso/my-sites/controller' );
+jest.mock( 'calypso/my-sites/email/paths' );
+jest.mock( '../controller' );
+
+describe( 'checkout routes', () => {
+	beforeEach( () => {
+		jest.mocked( page ).mockClear();
+	} );
+
+	const registrationIndexOf = ( path: string ) =>
+		( page as unknown as jest.Mock ).mock.calls.findIndex( ( [ route ] ) => route === path );
+
+	it( 'guards the WordPress.com siteless route with redirectLoggedOut', () => {
+		registerCheckoutRoutes();
+
+		expect( page ).toHaveBeenCalledWith(
+			'/checkout/wpcom/:productSlug',
+			mockLocaleMiddleware,
+			redirectLoggedOut,
+			noSite,
+			checkoutWpcomSiteless,
+			makeLayout,
+			clientRender
+		);
+	} );
+
+	// page.js matches in registration order, so /checkout/:product/:domainOrProduct
+	// would swallow this route.
+	it( 'registers the WordPress.com siteless route ahead of the generic product route', () => {
+		registerCheckoutRoutes();
+
+		const wpcomIndex = registrationIndexOf( '/checkout/wpcom/:productSlug' );
+		const genericIndex = registrationIndexOf( '/checkout/:product/:domainOrProduct' );
+
+		expect( wpcomIndex ).toBeGreaterThanOrEqual( 0 );
+		expect( genericIndex ).toBeGreaterThanOrEqual( 0 );
+		expect( wpcomIndex ).toBeLessThan( genericIndex );
+	} );
+} );

--- a/client/my-sites/checkout/use-cart-key.ts
+++ b/client/my-sites/checkout/use-cart-key.ts
@@ -27,6 +27,8 @@ export default function useCartKey(): ReturnType< typeof getCartKey > {
 		! selectedSite &&
 		( currentUrlPath.includes( '/marketplace/checkout' ) ||
 			currentUrlPath.includes( '/client/checkout' ) );
+	// `/checkout/wpcom` is deliberately absent: it is logged-in only and needs the
+	// 'no-site' key, and listing it here would force 'no-user'.
 	const isNoSiteCart =
 		isJetpackCheckout ||
 		isAkismetSitelessCheckout ||

--- a/client/my-sites/controller.jsx
+++ b/client/my-sites/controller.jsx
@@ -529,6 +529,7 @@ export function noSite( context, next ) {
 	);
 
 	const isUnifiedCheckoutFlow = context.pathname.includes( '/checkout/unified' );
+	const isWpcomCheckoutFlow = context.pathname.includes( '/checkout/wpcom' );
 	const isDomainsManage = context.pathname === '/domains/manage/';
 	const isGiftCheckoutFlow = context.pathname.includes( '/gift/' );
 	const isRenewal = context.pathname.includes( '/renew/' );
@@ -539,6 +540,7 @@ export function noSite( context, next ) {
 		! isAkismetCheckoutFlow &&
 		! isMarketplaceSitelessCheckoutFlow &&
 		! isUnifiedCheckoutFlow &&
+		! isWpcomCheckoutFlow &&
 		! isGiftCheckoutFlow &&
 		! isDomainsManage &&
 		! is100YearCheckoutFlow &&

--- a/client/my-sites/test/controller.js
+++ b/client/my-sites/test/controller.js
@@ -14,6 +14,7 @@ import {
 	recordNoVisibleSitesPageView,
 	redirectToPrimary,
 	siteSelection,
+	noSite,
 } from '../controller';
 
 jest.mock( 'calypso/state/sites/actions', () => ( {
@@ -486,5 +487,27 @@ describe( 'siteSelection — site fetch failure fallback', () => {
 
 		expect( redirect ).toHaveBeenCalledWith( `/stats/day?${ querystring }` );
 		expect( next ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'noSite', () => {
+	// Only a user with sites reaches siteSelection, so that is the state worth testing.
+	const stateWithSites = {
+		currentUser: { id: 7, user: { site_count: 2, visible_site_count: 2 }, capabilities: {} },
+		sites: { items: {} },
+		ui: { selectedSiteId: null },
+	};
+
+	// The dotted slug makes `getSiteFragment` see a site, so without the
+	// `isWpcomCheckoutFlow` exception this would fall through to the site selector.
+	it( 'lets the WordPress.com siteless checkout route through without a site', () => {
+		const pathname = '/checkout/wpcom/a.product';
+		const next = jest.fn();
+		const store = mockStore( stateWithSites );
+
+		noSite( { store, path: pathname, pathname, params: {}, query: {}, section: {} }, next );
+
+		expect( next ).toHaveBeenCalled();
+		expect( store.getActions() ).toContainEqual( expect.objectContaining( { siteId: null } ) );
 	} );
 } );

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -993,6 +993,7 @@ export type SitelessCheckoutType =
 	| 'marketplace'
 	| 'a4a'
 	| 'unified'
+	| 'wpcom'
 	| undefined;
 
 /**
@@ -1022,6 +1023,11 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	 * Marks a product as having been added by the siteless `/checkout/unified` route.
 	 */
 	isUnifiedSitelessCheckout?: boolean;
+
+	/**
+	 * Marks a product as having been added by the siteless `/checkout/wpcom` route.
+	 */
+	isWpcomSitelessCheckout?: boolean;
 
 	isAkismetSitelessCheckout?: boolean;
 	isJetpackCheckout?: boolean;


### PR DESCRIPTION
Resolves SHILL-2348
Related to 233127-ghe-Automattic/wpcom


## Proposed Changes

* `packages/shopping-cart/src/types.ts` - add `'wpcom'` to `SitelessCheckoutType` and add `isWpcomSitelessCheckout` to `RequestCartProductExtra`. 
* `index.js` / `controller.jsx` - add the `/checkout/wpcom/:productSlug` route and `checkoutWpcomSiteless()`. Registered next to `/checkout/unified/:productSlug`, with `redirectLoggedOut` and `noSite`.
* `use-prepare-products-for-cart.ts` - three changes. Add `'wpcom'` to `doNotStripProducts`, to the `addProductFromSlug` branch of `chooseAddHandler()`, and set `isWpcomSitelessCheckout` on the item `extra`. The `chooseAddHandler()` one is required: `sitelessCheckout()` always passes `isNoSiteCart`, so without it the route reads an empty saved cart and ignores the product in the URL.
* `my-sites/controller.jsx` - add an `isWpcomCheckoutFlow` exception to `noSite()`, matching Jetpack, Akismet, Marketplace and Unified. It only matters for a product slug containing a dot or one that is all digits, because `getSiteFragment()` reads those as a site and sends the buyer to the site selector.
* `checkout-main.tsx` - return `undefined` from `updatedSiteSlug` for `'wpcom'`, sharing the `'unified'` branch. Otherwise `useGetThankYouUrl()` and `usePrepareProductsForCart()` get `'no-user'`, which `CheckoutMainWrapper` sets for a no-site cart.
* `get-thank-you-page-url/index.ts` - send `'wpcom'` to `/checkout/thank-you/no-site`. Append the receipt ID when there is one, and use the bare URL when there is not. `getReceiptIdOrPlaceholder()` returns `undefined` for a non-integer receipt ID, without it the URL would end in `/undefined`.
* `use-checkout-flow-track-key.ts` - return `'wpcom_siteless_checkout'` for `'wpcom'`. Without it the flow reports `wpcom_checkout`, the same value ordinary site checkout uses, so the funnel cannot be split in Tracks.
* `use-cart-key.ts` - add a comment on the `isNoSiteCart` chain recording that `/checkout/wpcom` is left out on purpose. No code change.
* Jest specs for `usePrepareProductsForCart`, `useCheckoutFlowTrackKey`, the route registration and its ordering, `checkoutWpcomSiteless`, the `noSite()` exception, and the thank-you URL.


## Why are these changes being made?

**Before.** Checkout can already sell things that have no site. Each family that does it - Jetpack, Akismet, Marketplace, A4A - has its own route and controller on the client, plus its own `Checkout_Type` on the backend. `/checkout/akismet/:productSlug` is the closest to what this needs: no site selector, `no-site` cart key, product read from the URL.

**Problem.** Studio Code AI Credits belongs to the buyer, not a single site. There is no WordPress.com-branded siteless route to sell it through, and none of the existing ones fit - they carry other products' branding, and `unified` creates a real site. Without a route of its own, the cart reaches the server with `blog_id = 0` and no siteless flag, and gets rejected.

**Fix.** A WordPress.com-branded route similar to the Akismet model. The backend ties the purchase to a hidden per-user holding site. The client sets the flag, keeps the site slug out of the URLs, and sends the buyer to the no-site thank-you page. `getProductPartsFromAlias()` already parses the `:-q-<N>` suffix, so `/checkout/wpcom/<slug>:-q-500` works through the existing path.


## Testing Instructions

### Automated:

```
yarn test-client client/my-sites/checkout/src/test/use-prepare-products-for-cart.tsx client/my-sites/checkout/test/index.ts client/my-sites/checkout/test/controller.js client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts client/my-sites/checkout/src/test/use-checkout-flow-track-key.ts client/my-sites/test/controller.js
```



### Manual

**Environment:**
- Store Sandbox mode enabled
- `public-api.wordpress.com` sandboxed
- 233127-ghe-Automattic/wpcom applied, with product `4100` in the `wpcom_siteless_checkout_allowed_products` filter. 

Product `4100` is Studio Code AI Credits, slug `studio-code-ai-credits`. It bills per 100 credits rounded up, at $1 per 100, so `:-q-500` costs $5.

**Steps:**
1. Log in, then go to`/checkout/wpcom/studio-code-ai-credits:-q-500`.
2. Check that the total is $5. That is 500 credits billed as 5 units of 100, not 500 units., with no site selector and no site name on the page.
3. In the network panel, check that the cart request uses cart key `no-site`, and that the cart item `extra` has`isWpcomSitelessCheckout: true`.
4. Reload that URL. Check that the product and quantity survive and the URL is not rewritten to `/checkout/no-site`.
5.  Complete the purchase. Check that you land on `/checkout/thank-you/no-site/<receiptId>` and not the Calypso root.
6. Go to `/me/purchases`. Check the purchase is listed, opens Manage Purchase, and carries no "site disconnected" treatment. On the new dashboard, check the equivalent screen.
7. Buy again. Check the second purchase reuses the same holding site rather than creating a second one.
8. Open `/checkout/wpcom/studio-code-ai-credits` in a private window. Check that you are sent to log in.
9. Go to `/checkout/wpcom/business-bundle`, which is not on the allow-list. Check that checkout does not complete and no receipt is created.
10. Check that the page-view Tracks event carries `checkout_flow: wpcom_siteless_checkout`.


