### PR TITLE
Zendesk: attach support site to lifecycle events

### DIFF
--- a/packages/agents-manager/src/components/__tests__/zendesk-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/zendesk-chat.test.tsx
@@ -6,6 +6,10 @@ import { render } from '@testing-library/react';
 
 const mockUseManagedZendeskChat = jest.fn();
 let mockZendeskTicketProductFieldValue: string | undefined = 'woocommerce_core_product';
+let mockSite: { ID: number | string; URL: string } | null = {
+	ID: 123,
+	URL: 'https://example.com',
+};
 
 jest.mock( '@automattic/zendesk-client', () => ( {
 	useManagedZendeskChat: ( props: unknown ) => mockUseManagedZendeskChat( props ),
@@ -16,7 +20,7 @@ jest.mock( '@automattic/zendesk-client', () => ( {
 
 jest.mock( '../../contexts', () => ( {
 	useAgentsManagerContext: () => ( {
-		site: { ID: 123, URL: 'https://example.com' },
+		site: mockSite,
 		zendeskConversationTags: [ 'woo_support_flow_ai_plugin' ],
 		zendeskSmoochIntegrationKey: 'woo',
 		zendeskTicketProductFieldValue: mockZendeskTicketProductFieldValue,
@@ -39,6 +43,7 @@ describe( 'ZendeskChat', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockZendeskTicketProductFieldValue = 'woocommerce_core_product';
+		mockSite = { ID: 123, URL: 'https://example.com' };
 		mockUseManagedZendeskChat.mockReturnValue( {
 			agentticMessages: [],
 			onSubmit: jest.fn(),
@@ -93,6 +98,43 @@ describe( 'ZendeskChat', () => {
 			expect.objectContaining( {
 				conversationTicketFields: {},
 			} )
+		);
+	} );
+
+	it( 'passes the support site ID to managed Zendesk chat', () => {
+		render(
+			<ZendeskChat
+				chatHeaderOptions={ [] }
+				isDocked={ false }
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+			/>
+		);
+
+		expect( mockUseManagedZendeskChat ).toHaveBeenCalledWith(
+			expect.objectContaining( { blogId: 123 } )
+		);
+	} );
+
+	it.each( [
+		[ 'numeric string', '456', 456 ],
+		[ 'invalid value', 'invalid', undefined ],
+	] )( 'normalizes a support site ID provided as %s', ( _, siteId, expectedBlogId ) => {
+		mockSite = { ID: siteId, URL: 'https://example.com' };
+
+		render(
+			<ZendeskChat
+				chatHeaderOptions={ [] }
+				isDocked={ false }
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+			/>
+		);
+
+		expect( mockUseManagedZendeskChat ).toHaveBeenCalledWith(
+			expect.objectContaining( { blogId: expectedBlogId } )
 		);
 	} );
 } );

--- a/packages/agents-manager/src/components/zendesk-chat/index.tsx
+++ b/packages/agents-manager/src/components/zendesk-chat/index.tsx
@@ -61,6 +61,7 @@ export default function ZendeskChat( {
 		zendeskSmoochIntegrationKey,
 		zendeskTicketProductFieldValue,
 	} = useAgentsManagerContext();
+	const blogId = Number( site?.ID );
 	const siteUrl = getSiteUrl( site );
 	const conversationTicketFields = useMemo(
 		() =>
@@ -84,6 +85,7 @@ export default function ZendeskChat( {
 		notice,
 		hasInteractionEnded,
 	} = useManagedZendeskChat( {
+		blogId: Number.isInteger( blogId ) && blogId > 0 ? blogId : undefined,
 		conversationTags: zendeskConversationTags,
 		conversationTicketFields,
 		smoochIntegrationKey: zendeskSmoochIntegrationKey,

--- a/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
+++ b/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
@@ -204,6 +204,7 @@ function sendMessage(
 }
 
 type ManagedZendeskChatOptions = {
+	blogId?: number;
 	conversationTags?: string[];
 	conversationTicketFields?: ZendeskTicketFields;
 	/** Index into `SMOOCH_INTEGRATION_ID_CUSTOM` selecting a dedicated Smooch integration (e.g. `woo`). */
@@ -221,6 +222,7 @@ type ManagedZendeskChatOptions = {
  * - sendMessage: A function to send a message to the conversation.
  */
 export const useManagedZendeskChat = ( {
+	blogId,
 	conversationTags = EMPTY_ARRAY,
 	conversationTicketFields = EMPTY_TICKET_FIELDS,
 	smoochIntegrationKey,
@@ -240,6 +242,8 @@ export const useManagedZendeskChat = ( {
 	const [ pendingImages, setPendingImages ] = useState< ZendeskImagePreview[] >( [] );
 	const refetchTimeoutRef = useRef< ReturnType< typeof setTimeout > | null >( null );
 	const messageQueueRef = useRef< QueuedMessage[] >( [] );
+	const blogIdRef = useRef( blogId );
+	blogIdRef.current = blogId;
 	const connectionStatusRef = useRef( connectionStatus );
 	connectionStatusRef.current = connectionStatus;
 	const hadDisconnectRef = useRef( false );
@@ -282,11 +286,16 @@ export const useManagedZendeskChat = ( {
 
 	const disconnectedListener = useCallback( () => {
 		hadDisconnectRef.current = true;
+		connectionStatusRef.current = 'disconnected';
 		setConnectionStatus( 'disconnected' );
-		recordTracksEvent( 'calypso_smooch_messenger_disconnected' );
+		recordTracksEvent(
+			'calypso_smooch_messenger_disconnected',
+			blogIdRef.current ? { blog_id: blogIdRef.current } : undefined
+		);
 	}, [ setConnectionStatus ] );
 
 	const reconnectingListener = useCallback( () => {
+		connectionStatusRef.current = 'reconnecting';
 		setConnectionStatus( 'reconnecting' );
 		recordTracksEvent( 'calypso_smooch_messenger_reconnecting' );
 	}, [ setConnectionStatus ] );
@@ -307,11 +316,15 @@ export const useManagedZendeskChat = ( {
 	const connectedListener = useCallback( () => {
 		// We only want to revert the connection status to connected if it was disconnected before.
 		// We don't want a "connected" status on page load, it's only useful as a sign of a recovered connection.
-		if ( connectionStatus ) {
+		if ( connectionStatusRef.current ) {
+			connectionStatusRef.current = 'connected';
 			setConnectionStatus( 'connected' );
-			recordTracksEvent( 'calypso_smooch_messenger_connected' );
+			recordTracksEvent(
+				'calypso_smooch_messenger_connected',
+				blogIdRef.current ? { blog_id: blogIdRef.current } : undefined
+			);
 		}
-	}, [ setConnectionStatus, connectionStatus ] );
+	}, [ setConnectionStatus ] );
 
 	const navigate = useNavigate();
 

--- a/packages/zendesk-client/test/use-managed-zendesk-chat.test.tsx
+++ b/packages/zendesk-client/test/use-managed-zendesk-chat.test.tsx
@@ -1,8 +1,9 @@
 /**
  * @jest-environment jsdom
  */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Smooch from 'smooch';
 import { useManagedZendeskChat } from '../src/use-managed-zendesk-chat';
@@ -98,12 +99,25 @@ const smooch = Smooch as unknown as {
 	createConversation: jest.Mock;
 	getConversationById: jest.Mock;
 	loadConversation: jest.Mock;
+	on: jest.Mock;
+	off: jest.Mock;
 };
+
+const mockRecordTracksEvent = recordTracksEvent as jest.Mock;
+
+function getSmoochListener( eventName: string ) {
+	const listener = smooch.on.mock.calls.find(
+		( [ registeredEvent ] ) => registeredEvent === eventName
+	)?.[ 1 ];
+	expect( listener ).toBeDefined();
+	return listener as () => void;
+}
 
 function renderUseManagedZendeskChat( {
 	conversationId,
 	conversationTags = [],
 	conversationTicketFields,
+	blogId,
 	startedFromAiChatId,
 	startedFromChatSessionId,
 	startedFromMessageId,
@@ -114,6 +128,7 @@ function renderUseManagedZendeskChat( {
 		string | number,
 		string | number | boolean | null | undefined
 	>;
+	blogId?: number;
 	startedFromAiChatId?: number;
 	startedFromChatSessionId?: string;
 	startedFromMessageId?: string;
@@ -136,8 +151,14 @@ function renderUseManagedZendeskChat( {
 	};
 
 	return renderHook(
-		() => useManagedZendeskChat( { conversationTags, conversationTicketFields } ),
+		( { currentBlogId }: { currentBlogId?: number } ) =>
+			useManagedZendeskChat( {
+				conversationTags,
+				conversationTicketFields,
+				blogId: currentBlogId,
+			} ),
 		{
+			initialProps: { currentBlogId: blogId },
 			wrapper: ( { children } ) => (
 				<QueryClientProvider client={ queryClient }>
 					<MemoryRouter initialEntries={ [ initialEntry ] }>{ children }</MemoryRouter>
@@ -236,5 +257,66 @@ describe( 'useManagedZendeskChat', () => {
 		);
 
 		expect( smooch.createConversation ).not.toHaveBeenCalled();
+	} );
+
+	it( 'adds the support site ID to connection lifecycle events', async () => {
+		const { result } = renderUseManagedZendeskChat( {
+			conversationId: 'conversation-1',
+			blogId: 123,
+		} );
+
+		await waitFor( () => expect( result.current.conversation?.id ).toBe( 'conversation-1' ) );
+		const disconnectedListener = getSmoochListener( 'disconnected' );
+		const connectedListener = getSmoochListener( 'connected' );
+
+		await act( async () => {
+			disconnectedListener();
+			connectedListener();
+			await Promise.resolve();
+		} );
+		expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_smooch_messenger_disconnected', {
+			blog_id: 123,
+		} );
+		expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_smooch_messenger_connected', {
+			blog_id: 123,
+		} );
+	} );
+
+	it( 'records lifecycle events without site properties when no support site is provided', async () => {
+		const { result } = renderUseManagedZendeskChat( { conversationId: 'conversation-1' } );
+
+		await waitFor( () => expect( result.current.conversation?.id ).toBe( 'conversation-1' ) );
+		const disconnectedListener = getSmoochListener( 'disconnected' );
+
+		act( () => disconnectedListener() );
+		expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_smooch_messenger_disconnected',
+			undefined
+		);
+	} );
+
+	it( 'uses the current support site without re-registering listeners', async () => {
+		const { result, rerender } = renderUseManagedZendeskChat( {
+			conversationId: 'conversation-1',
+			blogId: 123,
+		} );
+
+		await waitFor( () => expect( result.current.conversation?.id ).toBe( 'conversation-1' ) );
+		const disconnectedListener = getSmoochListener( 'disconnected' );
+		const connectedListener = getSmoochListener( 'connected' );
+		const registrationCount = smooch.on.mock.calls.length;
+		const removalCount = smooch.off.mock.calls.length;
+
+		rerender( { currentBlogId: 456 } );
+
+		expect( getSmoochListener( 'disconnected' ) ).toBe( disconnectedListener );
+		expect( getSmoochListener( 'connected' ) ).toBe( connectedListener );
+		expect( smooch.on ).toHaveBeenCalledTimes( registrationCount );
+		expect( smooch.off ).toHaveBeenCalledTimes( removalCount );
+
+		act( () => disconnectedListener() );
+		expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_smooch_messenger_disconnected', {
+			blog_id: 456,
+		} );
 	} );
 } );


### PR DESCRIPTION
Fixes DOTSUP-508

## Proposed Changes

* Pass the support site ID from Agents Manager into `useManagedZendeskChat`.
* Attach `blog_id` to managed Smooch connected and disconnected events.
* Keep lifecycle listener registrations stable while using current site and connection state.
* Cover numeric, string, invalid, absent, and changing site IDs.

## Why are these changes being made?

* Managed Zendesk chat records lifecycle events outside Help Center context.
* Without an explicit `blog_id`, those events cannot be reliably attributed to the site involved in the support request.
* Stable listener callbacks avoid stale site IDs and duplicate registrations when context changes.

## Testing Instructions

* Run `yarn test-packages packages/zendesk-client packages/agents-manager --runInBand`.
* Run `yarn typecheck-packages`.
* Run `yarn eslint packages/zendesk-client/src/use-managed-zendesk-chat.tsx packages/zendesk-client/test/use-managed-zendesk-chat.test.tsx packages/agents-manager/src/components/zendesk-chat/index.tsx packages/agents-manager/src/components/__tests__/zendesk-chat.test.tsx`.
* Calypso: run `yarn start`, open Agents Manager Zendesk chat for a selected site, trigger disconnect and reconnect, and confirm both lifecycle events contain the selected site as `blog_id`.
* Simple, Atomic, or CIAB: run `cd apps/agents-manager && yarn dev --sync`, sandbox `widgets.wp.com`, then repeat the lifecycle event check on a controlled site.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have you tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use? (p4TIVU-aUh-p2)