### PR TITLE
Report failed email confirmations, and say why when the reason is known

### DIFF
--- a/client/components/email-verification/index.js
+++ b/client/components/email-verification/index.js
@@ -1,90 +1,92 @@
-import { removeQueryArgs } from '@wordpress/url';
+import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 import i18n from 'i18n-calypso';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import { sendVerificationSignal } from 'calypso/lib/user/verification-checker';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
-import { successNotice } from 'calypso/state/notices/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
 /**
  * Page middleware
  */
 
-// Parse email verification params from query
 function parseVerificationParams( query ) {
 	const verified = query.verified;
 	const newEmailResult = query.new_email_result;
 
+	const isEmailChangeComplete = newEmailResult === '1';
+	const isEmailVerificationComplete = verified === '1';
+	const emailChangeFailed = newEmailResult === '0';
+	const emailVerificationFailed = verified === '0';
+
 	return {
-		isEmailChangeComplete: newEmailResult === '1',
-		isEmailVerificationComplete: verified === '1',
-		emailChangeFailed: newEmailResult === '0',
-		emailVerificationFailed: verified === '0',
-		hasAnyParam: !! ( newEmailResult || verified ),
+		isEmailChangeComplete,
+		isEmailVerificationComplete,
+		emailChangeFailed,
+		emailVerificationFailed,
+		hasValidResult:
+			isEmailChangeComplete ||
+			isEmailVerificationComplete ||
+			emailChangeFailed ||
+			emailVerificationFailed,
 		verified,
 		newEmailResult,
+		newEmailError: query.new_email_error,
 	};
 }
 
 export default function emailVerification( context, next ) {
 	const params = parseVerificationParams( context.query );
 
-	if ( ! params.hasAnyParam ) {
+	if ( ! params.hasValidResult ) {
 		next();
 		return;
 	}
 
-	// Redirect users to v2 if they opted in to the Multi-site Dashboard
-	if ( shouldRedirectToV2( context, next, params ) ) {
+	if ( redirectToOptedInDashboard( context, params ) ) {
 		return;
 	}
 
-	// Fallback to v1 logic
-	handleV1Logic( context, next, params );
+	handleV1Logic( context, params );
 
+	// Once: a second hand-off runs the rest of the chain again, past a redirect meant to end it.
 	next();
 }
 
-// Helper function to build redirect URL
-function buildDashboardRedirectUrl( verified, newEmailResult ) {
+function buildDashboardRedirectUrl( { verified, newEmailResult, newEmailError } ) {
 	bumpStat( 'dashboard-redirect', 'email-verification' );
-	let redirectUrl = dashboardLink( '/me/profile' );
+	// Not /me/profile: it redirects here without carrying the query arguments.
+	const redirectUrl = dashboardLink( '/me/account' );
 	if ( verified ) {
-		redirectUrl += `?verified=${ verified }`;
-	} else if ( newEmailResult ) {
-		redirectUrl += `?new_email_result=${ newEmailResult }`;
+		return addQueryArgs( redirectUrl, { verified } );
+	}
+	if ( newEmailResult ) {
+		return addQueryArgs( redirectUrl, {
+			new_email_result: newEmailResult,
+			new_email_error: newEmailError,
+		} );
 	}
 	return redirectUrl;
 }
 
 /**
- * v2
- * Redirect to v2 for success and error cases.
+ * Sends the result to the dashboard the user has opted in to, if they have. Returns true when it
+ * has done so, and the result is no longer this dashboard's to show.
  *
- * Examples:
- * /me/account?verified=1 → /v2/me/profile?verified=1
- * /me/account?new_email_result=1 → /v2/me/profile?new_email_result=1
+ * /me/account?verified=1 → <the dashboard they are on>/me/account?verified=1
  */
-function shouldRedirectToV2( context, next, params ) {
-	const hasValidParams =
-		params.isEmailChangeComplete ||
-		params.isEmailVerificationComplete ||
-		params.emailChangeFailed ||
-		params.emailVerificationFailed;
-
-	if ( ! hasValidParams || ! [ '/me/account', '/settings/account' ].includes( context.pathname ) ) {
+function redirectToOptedInDashboard( context, params ) {
+	if ( ! [ '/me/account', '/settings/account' ].includes( context.pathname ) ) {
 		return false;
 	}
 
-	// Check user preferences to see if they opted in to the Hosting Dashboard
 	let state = context.store.getState();
 
 	const arePreferencesLoaded = ( storeState ) =>
 		! storeState.preferences.fetching && storeState.preferences.remoteValues !== null;
 
 	if ( ! arePreferencesLoaded( state ) ) {
-		// Wait for preferences to load
 		const unsubscribe = context.store.subscribe( () => {
 			state = context.store.getState();
 
@@ -92,48 +94,64 @@ function shouldRedirectToV2( context, next, params ) {
 				unsubscribe();
 
 				if ( hasDashboardOptIn( state ) ) {
-					window.location.href = buildDashboardRedirectUrl(
-						params.verified,
-						params.newEmailResult
-					);
+					window.location.href = buildDashboardRedirectUrl( params );
 				}
 			}
 		} );
 
 		setTimeout( () => unsubscribe(), 10000 ); // 10 seconds
 
-		next();
-		return;
+		return false;
 	}
 
 	if ( hasDashboardOptIn( state ) ) {
-		window.location.href = buildDashboardRedirectUrl( params.verified, params.newEmailResult );
+		window.location.href = buildDashboardRedirectUrl( params );
 		return true;
 	}
 
 	return false;
 }
 
-/**
- * v1
- * Show notification for success cases only
- */
-function handleV1Logic( context, next, params ) {
+// The notice state seems to be cleared on page load, so it is dispatched a moment afterwards.
+const announce = ( context, notice ) => {
+	setTimeout( () => context.store.dispatch( notice ), 500 );
+};
+
+const invalidLinkMessage = () =>
+	i18n.translate(
+		'The email verification link is invalid or has expired. Please request a new one.'
+	);
+
+// Unknown or absent reads as it did before, so the server can start sending a reason later.
+function emailChangeFailureMessage( newEmailError ) {
+	if ( newEmailError === 'email_in_use' ) {
+		return i18n.translate(
+			'That email address is already used by another WordPress.com account. Try a different address.'
+		);
+	}
+	return invalidLinkMessage();
+}
+
+function handleV1Logic( context, params ) {
+	// This path forwards these on rather than consuming them; announcing here too says it twice.
+	if ( params.newEmailResult && context.pathname === '/settings/account' ) {
+		return;
+	}
+
 	if ( params.isEmailVerificationComplete ) {
 		context.page.replace( removeQueryArgs( context.canonicalPath, 'verified' ) );
-		sendVerificationSignal();
-		setTimeout( () => {
-			const message = i18n.translate( 'Email confirmed!' );
-			const notice = successNotice( message, { duration: 10000 } );
-			context.store.dispatch( notice );
-		}, 500 ); // A delay is needed here, because the notice state seems to be cleared upon page load
+		try {
+			sendVerificationSignal();
+		} catch {}
+		announce( context, successNotice( i18n.translate( 'Email confirmed!' ), { duration: 10000 } ) );
 	} else if ( params.isEmailChangeComplete ) {
 		context.page.replace( removeQueryArgs( context.canonicalPath, 'new_email_result' ) );
-		setTimeout( () => {
-			const message = i18n.translate(
-				'Email address updated. Make sure you update your contact information for any registered domains.'
-			);
-			const notice = successNotice( message, {
+		const message = i18n.translate(
+			'Email address updated. Make sure you update your contact information for any registered domains.'
+		);
+		announce(
+			context,
+			successNotice( message, {
 				duration: 10000,
 				button: i18n.translate( 'Update' ),
 				href: '/domains/manage?site=all&action=edit-contact-email',
@@ -145,10 +163,18 @@ function handleV1Logic( context, next, params ) {
 						} )
 					);
 				},
-			} );
-			context.store.dispatch( notice );
-		}, 500 ); // A delay is needed here, because the notice state seems to be cleared upon page load
+			} )
+		);
+	} else if ( params.emailVerificationFailed ) {
+		context.page.replace( removeQueryArgs( context.canonicalPath, 'verified' ) );
+		announce( context, errorNotice( invalidLinkMessage(), { duration: 10000 } ) );
+	} else if ( params.emailChangeFailed ) {
+		context.page.replace(
+			removeQueryArgs( context.canonicalPath, 'new_email_result', 'new_email_error' )
+		);
+		announce(
+			context,
+			errorNotice( emailChangeFailureMessage( params.newEmailError ), { duration: 10000 } )
+		);
 	}
-
-	next();
 }

--- a/client/components/email-verification/test/index.jsx
+++ b/client/components/email-verification/test/index.jsx
@@ -1,0 +1,161 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { sendVerificationSignal } from 'calypso/lib/user/verification-checker';
+import emailVerification from '..';
+
+jest.mock( 'calypso/lib/user/verification-checker', () => ( {
+	sendVerificationSignal: jest.fn(),
+} ) );
+
+// Opting out keeps the result on this dashboard, which is where the notices below are shown.
+const OPTED_OUT = {
+	fetching: false,
+	remoteValues: { 'hosting-dashboard-opt-in': { value: 'forced-opt-out' } },
+};
+// A cold load, before the preference that decides which dashboard has been read.
+const UNRESOLVED = { fetching: false, remoteValues: null };
+
+const contextFor = ( pathname, query, preferences = OPTED_OUT ) => ( {
+	pathname,
+	canonicalPath: pathname,
+	query,
+	page: { replace: jest.fn() },
+	store: {
+		getState: () => ( { preferences } ),
+		dispatch: jest.fn(),
+		subscribe: jest.fn( () => jest.fn() ),
+	},
+} );
+
+const noticesFrom = ( context ) =>
+	context.store.dispatch.mock.calls.filter( ( [ action ] ) => action?.type === 'NOTICE_CREATE' );
+
+describe( 'emailVerification', () => {
+	beforeEach( () => jest.useFakeTimers() );
+	afterEach( () => jest.useRealTimers() );
+
+	// Announcing on both this route and the one it forwards to leaves two identical notices.
+	it( 'leaves an email change result to the route it is forwarded to', () => {
+		const context = contextFor( '/settings/account', { new_email_result: '0' } );
+		const next = jest.fn();
+
+		emailVerification( context, next );
+		jest.runAllTimers();
+
+		expect( noticesFrom( context ) ).toHaveLength( 0 );
+		expect( context.page.replace ).not.toHaveBeenCalled();
+		// A second hand-off carries the chain past the redirect that forwards this result.
+		expect( next ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'hands the route on once when the dashboard preference has not been read', () => {
+		const context = contextFor( '/me/account', { new_email_result: '0' }, UNRESOLVED );
+		const next = jest.fn();
+
+		emailVerification( context, next );
+
+		expect( next ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	// Only the forwarding route is held back; anywhere else has to speak, or nothing does.
+	it( 'still reports an email change result anywhere else it lands', () => {
+		const context = contextFor( '/home', { new_email_result: '0' } );
+
+		emailVerification( context, jest.fn() );
+		jest.runAllTimers();
+
+		expect( noticesFrom( context ) ).toHaveLength( 1 );
+	} );
+
+	it( 'reports a failed email change once it reaches that route', () => {
+		const context = contextFor( '/me/account', { new_email_result: '0' } );
+
+		emailVerification( context, jest.fn() );
+		// Notices dispatched during the page load are cleared by it, so this one waits.
+		expect( noticesFrom( context ) ).toHaveLength( 0 );
+
+		jest.runAllTimers();
+
+		const [ [ action ] ] = noticesFrom( context );
+		expect( action.notice.status ).toBe( 'is-error' );
+		expect( action.notice.text ).toMatch( /invalid or has expired/ );
+		expect( context.page.replace ).toHaveBeenCalledWith( '/me/account' );
+	} );
+
+	it( 'names a taken address rather than blaming the link', () => {
+		const context = contextFor( '/me/account', {
+			new_email_result: '0',
+			new_email_error: 'email_in_use',
+		} );
+
+		emailVerification( context, jest.fn() );
+		jest.runAllTimers();
+
+		const [ [ action ] ] = noticesFrom( context );
+		expect( action.notice.text ).toMatch( /already used by another WordPress\.com account/ );
+	} );
+
+	// The reason is optional, so an unrecognised one has to read as before rather than as nothing.
+	it( 'falls back to the generic message for a reason it does not know', () => {
+		const context = contextFor( '/me/account', {
+			new_email_result: '0',
+			new_email_error: 'something_new',
+		} );
+
+		emailVerification( context, jest.fn() );
+		jest.runAllTimers();
+
+		const [ [ action ] ] = noticesFrom( context );
+		expect( action.notice.text ).toMatch( /invalid or has expired/ );
+	} );
+
+	it( 'confirms an email change that worked', () => {
+		const context = contextFor( '/me/account', { new_email_result: '1' } );
+
+		emailVerification( context, jest.fn() );
+		jest.runAllTimers();
+
+		const [ [ action ] ] = noticesFrom( context );
+		expect( action.notice.status ).toBe( 'is-success' );
+		expect( action.notice.text ).toMatch( /Email address updated/ );
+		expect( context.page.replace ).toHaveBeenCalledWith( '/me/account' );
+	} );
+
+	// A failed verification link is otherwise silent, the same dead end as a failed change.
+	it( 'reports a verification link that did not work', () => {
+		const context = contextFor( '/me/account', { verified: '0' } );
+
+		emailVerification( context, jest.fn() );
+		jest.runAllTimers();
+
+		const [ [ action ] ] = noticesFrom( context );
+		expect( action.notice.status ).toBe( 'is-error' );
+		expect( action.notice.text ).toMatch( /invalid or has expired/ );
+		expect( context.page.replace ).toHaveBeenCalledWith( '/me/account' );
+	} );
+
+	// Storage throws when it is disabled or full, and this only tells other tabs.
+	it( 'still confirms a verified email when other tabs cannot be told', () => {
+		sendVerificationSignal.mockImplementationOnce( () => {
+			throw new Error( 'storage disabled' );
+		} );
+		const context = contextFor( '/me/account', { verified: '1' } );
+
+		expect( () => emailVerification( context, jest.fn() ) ).not.toThrow();
+		jest.runAllTimers();
+
+		expect( noticesFrom( context ) ).toHaveLength( 1 );
+	} );
+
+	// Verification arrives on its own argument, which that path does not forward.
+	it( 'still reports a verified email on the route it lands on', () => {
+		const context = contextFor( '/settings/account', { verified: '1' } );
+
+		emailVerification( context, jest.fn() );
+		jest.runAllTimers();
+
+		expect( noticesFrom( context ) ).toHaveLength( 1 );
+	} );
+} );

--- a/client/dashboard/me/profile-personal-details/update-email/email-verification-banner.tsx
+++ b/client/dashboard/me/profile-personal-details/update-email/email-verification-banner.tsx
@@ -31,6 +31,7 @@ function getEmailVerificationParams() {
 			isEmailVerificationComplete: false,
 			emailChangeFailed: false,
 			emailVerificationFailed: false,
+			emailChangeError: null,
 		};
 	}
 	const params = new URLSearchParams( window.location.search );
@@ -42,6 +43,7 @@ function getEmailVerificationParams() {
 		isEmailVerificationComplete: verified === '1',
 		emailChangeFailed: newEmailResult === '0',
 		emailVerificationFailed: verified === '0',
+		emailChangeError: params.get( 'new_email_error' ),
 	};
 }
 
@@ -49,9 +51,21 @@ function getEmailVerificationParams() {
 function cleanUpEmailVerificationParams() {
 	const params = new URLSearchParams( window.location.search );
 	params.delete( 'new_email_result' );
+	params.delete( 'new_email_error' );
 	params.delete( 'verified' );
 	const newUrl = window.location.pathname + ( params.toString() ? '?' + params.toString() : '' );
 	window.history.replaceState( {}, '', newUrl );
+}
+
+// An unrecognised or absent reason falls back to the generic message, so the server can start
+// sending one without waiting on this.
+function emailChangeFailureMessage( emailChangeError: string | null ) {
+	if ( emailChangeError === 'email_in_use' ) {
+		return __(
+			'That email address is already used by another WordPress.com account. Try a different address.'
+		);
+	}
+	return __( 'The email verification link is invalid or has expired. Please request a new one.' );
 }
 
 interface EmailVerificationBannerProps {
@@ -71,6 +85,7 @@ export default function EmailVerificationBanner( {
 		isEmailVerificationComplete,
 		emailChangeFailed,
 		emailVerificationFailed,
+		emailChangeError,
 	} = getEmailVerificationParams();
 
 	const [ showSuccessNotice, setShowSuccessNotice ] = useState( () => {
@@ -110,10 +125,7 @@ export default function EmailVerificationBanner( {
 	useEffect( () => {
 		// Handle error cases
 		if ( emailChangeFailed || emailVerificationFailed ) {
-			createErrorNotice(
-				__( 'The email verification link is invalid or has expired. Please request a new one.' ),
-				{ type: 'snackbar' }
-			);
+			createErrorNotice( emailChangeFailureMessage( emailChangeError ), { type: 'snackbar' } );
 		}
 
 		// Clean up URL params if any verification params were present
@@ -131,6 +143,7 @@ export default function EmailVerificationBanner( {
 		isEmailVerificationComplete,
 		emailChangeFailed,
 		emailVerificationFailed,
+		emailChangeError,
 	] );
 
 	// One mutation per endpoint: TanStack hands a request in flight whatever options the latest

--- a/client/dashboard/me/profile-personal-details/update-email/test/email-verification-banner.test.tsx
+++ b/client/dashboard/me/profile-personal-details/update-email/test/email-verification-banner.test.tsx
@@ -26,6 +26,15 @@ const pendingSettings = {
 	new_user_email: 'pending@example.com',
 } as unknown as UserSettings;
 
+const originalLocation = window.location;
+
+const setSearch = ( search: string ) => {
+	Object.defineProperty( window, 'location', {
+		value: { ...originalLocation, search, pathname: '/test' },
+		writable: true,
+	} );
+};
+
 const notificationSnackBar = () => {
 	// Snackbar requires a custom matcher because its aria-live is not supported by the testing library
 	return document.getElementById( 'a11y-speak-polite' );
@@ -40,6 +49,7 @@ describe( '<EmailVerificationBanner>', () => {
 	} );
 
 	afterEach( () => {
+		Object.defineProperty( window, 'location', { value: originalLocation, writable: true } );
 		// Snackbars are their own notice type, so the default clear leaves them behind for the
 		// next case to find.
 		dispatch( noticesStore ).removeAllNotices( 'snackbar' );
@@ -318,38 +328,57 @@ describe( '<EmailVerificationBanner>', () => {
 	} );
 
 	test( 'shows success banner after email change verification', async () => {
-		const originalLocation = window.location;
-		Object.defineProperty( window, 'location', {
-			value: { ...originalLocation, search: '?new_email_result=1', pathname: '/test' },
-			writable: true,
-		} );
+		setSearch( '?new_email_result=1' );
 
 		render( <EmailVerificationBanner userSettings={ settings } isEmailVerified /> );
 
 		expect( await screen.findByText( 'Email address updated' ) ).toBeVisible();
 		expect( screen.getByText( 'Update domain contacts' ) ).toBeVisible();
+	} );
 
-		Object.defineProperty( window, 'location', {
-			value: originalLocation,
-			writable: true,
-		} );
+	// The reason is optional so this can ship before the server sends one; without the fallback a
+	// failure would announce nothing at all.
+	test( 'reports a failed email change generically when no reason is given', async () => {
+		setSearch( '?new_email_result=0' );
+
+		render(
+			<>
+				<EmailVerificationBanner userSettings={ settings } isEmailVerified />
+				<Snackbars />
+			</>
+		);
+
+		await waitFor( () =>
+			expect( notificationSnackBar() ).toHaveTextContent( 'invalid or has expired' )
+		);
+	} );
+
+	// Blaming the link would send the user back to Resend, which re-sends to the address that is
+	// already taken.
+	test( 'says the address is taken rather than blaming the link', async () => {
+		setSearch( '?new_email_result=0&new_email_error=email_in_use' );
+
+		render(
+			<>
+				<EmailVerificationBanner userSettings={ settings } isEmailVerified />
+				<Snackbars />
+			</>
+		);
+
+		await waitFor( () =>
+			expect( notificationSnackBar() ).toHaveTextContent(
+				'already used by another WordPress.com account'
+			)
+		);
+		expect( notificationSnackBar() ).not.toHaveTextContent( 'invalid or has expired' );
 	} );
 
 	test( 'shows success banner after initial email verification', async () => {
-		const originalLocation = window.location;
-		Object.defineProperty( window, 'location', {
-			value: { ...originalLocation, search: '?verified=1', pathname: '/test' },
-			writable: true,
-		} );
+		setSearch( '?verified=1' );
 
 		render( <EmailVerificationBanner userSettings={ settings } isEmailVerified /> );
 
 		expect( await screen.findByText( 'Email verified' ) ).toBeVisible();
 		expect( screen.queryByText( 'Update domain contacts' ) ).not.toBeInTheDocument();
-
-		Object.defineProperty( window, 'location', {
-			value: originalLocation,
-			writable: true,
-		} );
 	} );
 } );

--- a/client/my-sites/site-settings/controller.jsx
+++ b/client/my-sites/site-settings/controller.jsx
@@ -62,7 +62,10 @@ export function legacyRedirects( context, next ) {
 
 	if ( section === 'account' && context.query.new_email_result ) {
 		return page.redirect(
-			addQueryArgs( '/me/account', { new_email_result: context.query.new_email_result } )
+			addQueryArgs( '/me/account', {
+				new_email_result: context.query.new_email_result,
+				new_email_error: context.query.new_email_error,
+			} )
 		);
 	}
 


### PR DESCRIPTION
## Proposed Changes

* A failed confirmation now reports itself on the older account dashboard, which read the result but acted only on the success cases — leaving the failure silent and its query argument on the URL.
* Where the failure is that another account has since taken the address, both dashboards say so rather than blaming the link.
* A failed verification link is reported the same way, and the result now survives a browser that refuses storage.

The reason for a failure is optional, and anything unrecognised or absent reads exactly as it does today.

## Why are these changes being made?

Confirming an email change can fail, and until recently one of those failures lied: if another account claimed the address while the link sat unread, the confirmation reported success and the address never moved. A server-side change now reports that honestly, so failures are reached more often and for two quite different reasons.

Neither dashboard handled that well. The older one showed nothing at all, which matters because a large share of accounts are still on it. The newer one blamed the link, which for a taken address is wrong twice over — the link was fine, and it points the user at Resend, which re-sends to an address that is already gone.

The same silence turned out to cover failed verification links, which is the commoner of the two since every signup gets one. Because an unknown or missing reason falls back to the existing message, this can ship before the server starts sending one.

## Testing Instructions

Visit the return URLs directly — no need to reproduce the race. Check both dashboards: `/settings/account` redirects to `/me/account`, and the two have separate paths through this.

1. `/settings/account/?new_email_result=0` — an error notice about an invalid or expired link, and the query argument stripped. The old dashboard previously showed nothing.
2. `/settings/account/?new_email_result=0&new_email_error=email_in_use` — a notice saying the address is already used by another account, and to try a different one.
3. `/settings/account/?verified=0` — an error notice, where previously there was none.
4. `/settings/account/?new_email_result=1` and `?verified=1` — the success paths, unchanged. Worth confirming they still work.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
