### PR TITLE
MCP settings: rename Tracks tool_id to ability_name on tool_toggled events

### DIFF
--- a/client/dashboard/me/mcp/read/index.tsx
+++ b/client/dashboard/me/mcp/read/index.tsx
@@ -84,7 +84,7 @@ export default function McpRead() {
 			{
 				onSuccess: () => {
 					recordTracksEvent( 'calypso_dashboard_mcp_read_tool_toggled', {
-						tool_id: toolId,
+						ability_name: toolId,
 						enabled,
 						group: groupName ?? 'other',
 					} );

--- a/client/dashboard/me/mcp/write/index.tsx
+++ b/client/dashboard/me/mcp/write/index.tsx
@@ -84,7 +84,7 @@ export default function McpWrite() {
 			{
 				onSuccess: () => {
 					recordTracksEvent( 'calypso_dashboard_mcp_write_tool_toggled', {
-						tool_id: toolId,
+						ability_name: toolId,
 						enabled,
 						group: groupName ?? 'other',
 					} );

--- a/client/me/mcp/test/tools-subpage.jsx
+++ b/client/me/mcp/test/tools-subpage.jsx
@@ -1,0 +1,151 @@
+/**
+ * @jest-environment jsdom
+ */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import McpToolsSubpage from '../tools-subpage';
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/calypso-config', () => {
+	const config = jest.fn( () => null );
+	config.isEnabled = jest.fn( () => true );
+	return config;
+} );
+
+jest.mock( '@automattic/api-queries', () => ( {
+	sitesQuery: () => ( {
+		queryKey: [ 'sites' ],
+		queryFn: async () => ( { sites: [] } ),
+	} ),
+	userSettingsQuery: () => ( {
+		queryKey: [ 'me', 'settings' ],
+		queryFn: async () => ( {
+			mcp_abilities: {
+				account: {
+					'wpcom-mcp/posts-list': {
+						enabled: false,
+						readonly: true,
+						title: 'List posts',
+						description: 'List posts on your sites.',
+					},
+				},
+				groups: [],
+				group_intents: {},
+			},
+		} ),
+	} ),
+	userSettingsMutation: () => ( {
+		mutationFn: async () => ( {} ),
+	} ),
+} ) );
+
+jest.mock( 'calypso/lib/two-step-authorization', () => ( {
+	__esModule: true,
+	default: {
+		isReauthRequired: () => false,
+		on: jest.fn(),
+		off: jest.fn(),
+	},
+} ) );
+
+jest.mock( 'calypso/me/reauth-required', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+jest.mock( '../mcp-page-header', () => ( {
+	useMcpPageChrome: () => ( {
+		documentTitle: 'AI and MCP',
+		navigationHeaderProps: {},
+	} ),
+} ) );
+
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+jest.mock( 'calypso/components/data/document-head', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+jest.mock( 'calypso/components/navigation-header', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+async function toggleFirstTool( props ) {
+	const user = userEvent.setup();
+	renderWithProvider( <McpToolsSubpage { ...props } /> );
+
+	// Groups render collapsed; expand the "Other" bucket to reach the tool toggle.
+	await user.click( await screen.findByRole( 'button', { name: 'Show operations' } ) );
+	await user.click( await screen.findByRole( 'checkbox', { name: 'List posts' } ) );
+}
+
+function getToolToggledPayload( eventName ) {
+	const call = recordTracksEvent.mock.calls.find( ( [ name ] ) => name === eventName );
+	return call?.[ 1 ];
+}
+
+describe( 'client/me/mcp/tools-subpage Tracks payloads', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'fires calypso_dashboard_mcp_read_tool_toggled with ability_name and path', async () => {
+		await toggleFirstTool( {
+			path: '/me/mcp/read',
+			pageViewTitle: 'MCP Read Access',
+			headerTitle: 'Read',
+			filterTool: () => true,
+			toolCategory: 'read',
+		} );
+
+		await waitFor( () =>
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_dashboard_mcp_read_tool_toggled',
+				expect.objectContaining( {
+					path: '/me/mcp/read',
+					ability_name: 'wpcom-mcp/posts-list',
+					enabled: true,
+					group: 'other',
+				} )
+			)
+		);
+		expect( getToolToggledPayload( 'calypso_dashboard_mcp_read_tool_toggled' ) ).not.toHaveProperty(
+			'tool_id'
+		);
+	} );
+
+	it( 'fires calypso_dashboard_mcp_write_tool_toggled with ability_name and path', async () => {
+		await toggleFirstTool( {
+			path: '/me/mcp/write',
+			pageViewTitle: 'MCP Write Access',
+			headerTitle: 'Write',
+			filterTool: () => true,
+			toolCategory: 'write',
+		} );
+
+		await waitFor( () =>
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_dashboard_mcp_write_tool_toggled',
+				expect.objectContaining( {
+					path: '/me/mcp/write',
+					ability_name: 'wpcom-mcp/posts-list',
+					enabled: true,
+					group: 'other',
+				} )
+			)
+		);
+		expect(
+			getToolToggledPayload( 'calypso_dashboard_mcp_write_tool_toggled' )
+		).not.toHaveProperty( 'tool_id' );
+	} );
+} );

--- a/client/me/mcp/tools-subpage.jsx
+++ b/client/me/mcp/tools-subpage.jsx
@@ -133,7 +133,7 @@ export default function McpToolsSubpage( {
 				onSuccess: () => {
 					recordTracksEvent( tracksEvents.toolToggled, {
 						path,
-						tool_id: toolId,
+						ability_name: toolId,
 						enabled,
 						group: groupName ?? 'other',
 					} );


### PR DESCRIPTION
Part of AIINT-581. Follows #113350 (AIINT-578, merged), which added `path` to these events.

## Proposed Changes

* Rename the `tool_id` property to `ability_name` on `calypso_dashboard_mcp_read_tool_toggled` and `calypso_dashboard_mcp_write_tool_toggled`, on both surfaces that fire them:
  * Legacy `/me/mcp`: `client/me/mcp/tools-subpage.jsx` (shared read/write subpage).
  * MSD `/me/preferences/mcp`: `client/dashboard/me/mcp/read/index.tsx` and `client/dashboard/me/mcp/write/index.tsx`.
* Add `client/me/mcp/test/tools-subpage.jsx`: component tests pinning the `tool_toggled` payload shape for both categories — `ability_name` present, `tool_id` absent, `path` carried.

No other `calypso_dashboard_mcp_*` event carries `tool_id` (the group, enable-all, view, and site-exception events don't have one), and no `source` property exists on any of them, so this is the whole Calypso rename. Verified: `git grep -n "tool_id" client/me/mcp client/dashboard/me/mcp client/dashboard/sites/settings-ai-tools` returns zero hits.

## Why are these changes being made?

* The server-side `wpcom_mcp_*` events already call the same concept `ability_name`; the Calypso events called it `tool_id`. A Tracks query filtering on either name silently dropped the other family's data — the same failure class as the `enabled` encoding split fixed in AIINT-576.
* Both surfaces emit the same event names, so both change together or the data would split by surface rather than by date.
* This is a silent cutover for live events agreed with Data Science under AIINT-581: after deploy, the cutover date should be annotated for DS so historical queries can union `tool_id` (pre-deploy) with `ability_name` (post-deploy).

## Testing Instructions

* `yarn test-client client/me/mcp` — 26 tests pass, including the two new payload-shape tests.
* Manual smoke (optional, events are also asserted by the new tests): run `yarn start`, open `/me/mcp/read` with Tracks Vigilante or Event Monitor running, expand a group and toggle an ability. Verify `calypso_dashboard_mcp_read_tool_toggled` fires with `ability_name` (e.g. `wpcom-mcp/posts-list`), `path`, `enabled`, `group` — and no `tool_id`. Repeat on `/me/mcp/write` for `calypso_dashboard_mcp_write_tool_toggled`, and on `/me/preferences/mcp/read` for the MSD copy.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?