### PR TITLE
Dashboard: wrap guided-tour popups in an error boundary

### DIFF
--- a/client/dashboard/components/guided-tour/step/index.tsx
+++ b/client/dashboard/components/guided-tour/step/index.tsx
@@ -58,13 +58,10 @@ interface GuidedTourStepProps {
 
 /**
  * Renders a single step in a guided tour.
- *
- * An error inside a popup should never take down the surrounding page, so the
- * step is wrapped in a boundary that drops the popup and reports to Sentry.
  */
 export function GuidedTourStep( props: GuidedTourStepProps ) {
 	return (
-		<SilentErrorBoundary tags={ { feature: 'guided-tour' } }>
+		<SilentErrorBoundary sentryTags={ { feature: 'guided-tour' } }>
 			<GuidedTourStepContents { ...props } />
 		</SilentErrorBoundary>
 	);

--- a/client/dashboard/components/guided-tour/step/index.tsx
+++ b/client/dashboard/components/guided-tour/step/index.tsx
@@ -1,3 +1,4 @@
+import { captureException } from '@automattic/calypso-sentry';
 import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
@@ -7,11 +8,11 @@ import {
 } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
-import { useState, useContext, useEffect } from 'react';
+import { Component, useState, useContext, useEffect } from 'react';
 import { CardBody } from '../../card';
 import { SectionHeader } from '../../section-header';
 import { GuidedTourContext } from '../context';
-import type { ComponentProps, CSSProperties } from 'react';
+import type { ComponentProps, CSSProperties, ReactNode, ErrorInfo } from 'react';
 
 // This hook will return the async element matching the target selector.
 // After timeout has passed, it will return null.
@@ -46,24 +47,59 @@ const useAsyncElement = (
 	return asyncElement;
 };
 
-/**
- * Renders a single step in a guided tour.
- */
-export function GuidedTourStep( {
-	id,
-	target,
-	selector,
-	placement,
-	inline,
-	popoverStyle,
-}: {
+interface GuidedTourStepProps {
 	id: string;
 	target?: HTMLElement | null;
 	selector?: string;
 	placement?: ComponentProps< typeof Popover >[ 'placement' ];
 	inline?: boolean;
 	popoverStyle?: CSSProperties;
-} ) {
+}
+
+// An error inside a tour popup should never take down the surrounding page.
+// This boundary swallows the popup's render, keeping the page alive, while
+// still forwarding the error to Sentry so it stays visible.
+class GuidedTourStepErrorBoundary extends Component<
+	{ children: ReactNode },
+	{ hasError: boolean }
+> {
+	state = { hasError: false };
+
+	static getDerivedStateFromError() {
+		return { hasError: true };
+	}
+
+	componentDidCatch( error: Error, errorInfo: ErrorInfo ) {
+		captureException( error, {
+			tags: { calypso_section: 'dashboard', feature: 'guided-tour' },
+			extra: { componentStack: errorInfo.componentStack },
+		} );
+	}
+
+	render() {
+		return this.state.hasError ? null : this.props.children;
+	}
+}
+
+/**
+ * Renders a single step in a guided tour.
+ */
+export function GuidedTourStep( props: GuidedTourStepProps ) {
+	return (
+		<GuidedTourStepErrorBoundary>
+			<GuidedTourStepContents { ...props } />
+		</GuidedTourStepErrorBoundary>
+	);
+}
+
+function GuidedTourStepContents( {
+	id,
+	target,
+	selector,
+	placement,
+	inline,
+	popoverStyle,
+}: GuidedTourStepProps ) {
 	const {
 		guidedTours,
 		currentStep,

--- a/client/dashboard/components/guided-tour/step/index.tsx
+++ b/client/dashboard/components/guided-tour/step/index.tsx
@@ -1,4 +1,3 @@
-import { captureException } from '@automattic/calypso-sentry';
 import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
@@ -8,11 +7,12 @@ import {
 } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
-import { Component, useState, useContext, useEffect } from 'react';
+import { useState, useContext, useEffect } from 'react';
 import { CardBody } from '../../card';
 import { SectionHeader } from '../../section-header';
+import { SilentErrorBoundary } from '../../silent-error-boundary';
 import { GuidedTourContext } from '../context';
-import type { ComponentProps, CSSProperties, ReactNode, ErrorInfo } from 'react';
+import type { ComponentProps, CSSProperties } from 'react';
 
 // This hook will return the async element matching the target selector.
 // After timeout has passed, it will return null.
@@ -56,39 +56,17 @@ interface GuidedTourStepProps {
 	popoverStyle?: CSSProperties;
 }
 
-// An error inside a tour popup should never take down the surrounding page.
-// This boundary swallows the popup's render, keeping the page alive, while
-// still forwarding the error to Sentry so it stays visible.
-class GuidedTourStepErrorBoundary extends Component<
-	{ children: ReactNode },
-	{ hasError: boolean }
-> {
-	state = { hasError: false };
-
-	static getDerivedStateFromError() {
-		return { hasError: true };
-	}
-
-	componentDidCatch( error: Error, errorInfo: ErrorInfo ) {
-		captureException( error, {
-			tags: { calypso_section: 'dashboard', feature: 'guided-tour' },
-			extra: { componentStack: errorInfo.componentStack },
-		} );
-	}
-
-	render() {
-		return this.state.hasError ? null : this.props.children;
-	}
-}
-
 /**
  * Renders a single step in a guided tour.
+ *
+ * An error inside a popup should never take down the surrounding page, so the
+ * step is wrapped in a boundary that drops the popup and reports to Sentry.
  */
 export function GuidedTourStep( props: GuidedTourStepProps ) {
 	return (
-		<GuidedTourStepErrorBoundary>
+		<SilentErrorBoundary tags={ { feature: 'guided-tour' } }>
 			<GuidedTourStepContents { ...props } />
-		</GuidedTourStepErrorBoundary>
+		</SilentErrorBoundary>
 	);
 }
 

--- a/client/dashboard/components/silent-error-boundary/index.tsx
+++ b/client/dashboard/components/silent-error-boundary/index.tsx
@@ -1,0 +1,50 @@
+import { captureException } from '@automattic/calypso-sentry';
+import { Component } from 'react';
+import type { ReactNode, ErrorInfo } from 'react';
+
+interface SilentErrorBoundaryProps {
+	children: ReactNode;
+	/**
+	 * What to render once a child has thrown. Defaults to nothing, so the
+	 * subtree simply disappears.
+	 */
+	fallback?: ReactNode;
+	/**
+	 * Extra Sentry tags to attach to the reported error, e.g.
+	 * `{ feature: 'guided-tour' }`.
+	 */
+	tags?: Record< string, string >;
+}
+
+/**
+ * Contains a non-critical piece of UI so that an error thrown while it renders
+ * cannot take down the surrounding page: the subtree is replaced with
+ * `fallback` (nothing by default) while the error is still forwarded to Sentry.
+ *
+ * Only wrap UI that is safe to lose. Primary content should surface its error
+ * to the router's error page instead of being silently swallowed here.
+ */
+export class SilentErrorBoundary extends Component<
+	SilentErrorBoundaryProps,
+	{ hasError: boolean }
+> {
+	state = { hasError: false };
+
+	static getDerivedStateFromError() {
+		return { hasError: true };
+	}
+
+	componentDidCatch( error: Error, errorInfo: ErrorInfo ) {
+		captureException( error, {
+			tags: { calypso_section: 'dashboard', ...this.props.tags },
+			extra: { componentStack: errorInfo.componentStack },
+		} );
+	}
+
+	render() {
+		if ( this.state.hasError ) {
+			return this.props.fallback ?? null;
+		}
+		return this.props.children;
+	}
+}

--- a/client/dashboard/components/silent-error-boundary/index.tsx
+++ b/client/dashboard/components/silent-error-boundary/index.tsx
@@ -5,24 +5,20 @@ import type { ReactNode, ErrorInfo } from 'react';
 interface SilentErrorBoundaryProps {
 	children: ReactNode;
 	/**
-	 * What to render once a child has thrown. Defaults to nothing, so the
-	 * subtree simply disappears.
-	 */
-	fallback?: ReactNode;
-	/**
 	 * Extra Sentry tags to attach to the reported error, e.g.
 	 * `{ feature: 'guided-tour' }`.
 	 */
-	tags?: Record< string, string >;
+	sentryTags?: Record< string, string >;
 }
 
 /**
- * Contains a non-critical piece of UI so that an error thrown while it renders
- * cannot take down the surrounding page: the subtree is replaced with
- * `fallback` (nothing by default) while the error is still forwarded to Sentry.
+ * Wrap a non-critical piece of UI so that an error thrown while it renders
+ * cannot take down the surrounding page: the subtree renders nothing while the
+ * error is still forwarded to Sentry.
  *
- * Only wrap UI that is safe to lose. Primary content should surface its error
- * to the router's error page instead of being silently swallowed here.
+ * Only wrap UI that is safe to lose. Primary content should at least surface
+ * its error to the router's error page, unless it can be caught somewhere more
+ * appropriate.
  */
 export class SilentErrorBoundary extends Component<
 	SilentErrorBoundaryProps,
@@ -36,15 +32,12 @@ export class SilentErrorBoundary extends Component<
 
 	componentDidCatch( error: Error, errorInfo: ErrorInfo ) {
 		captureException( error, {
-			tags: { calypso_section: 'dashboard', ...this.props.tags },
+			tags: { calypso_section: 'dashboard', ...this.props.sentryTags },
 			extra: { componentStack: errorInfo.componentStack },
 		} );
 	}
 
 	render() {
-		if ( this.state.hasError ) {
-			return this.props.fallback ?? null;
-		}
-		return this.props.children;
+		return this.state.hasError ? null : this.props.children;
 	}
 }

--- a/client/dashboard/components/silent-error-boundary/index.tsx
+++ b/client/dashboard/components/silent-error-boundary/index.tsx
@@ -32,7 +32,7 @@ export class SilentErrorBoundary extends Component<
 
 	componentDidCatch( error: Error, errorInfo: ErrorInfo ) {
 		captureException( error, {
-			tags: { calypso_section: 'dashboard', ...this.props.sentryTags },
+			tags: { ...this.props.sentryTags, calypso_section: 'dashboard' },
 			extra: { componentStack: errorInfo.componentStack },
 		} );
 	}


### PR DESCRIPTION
Follow-up to #113380.

## Proposed Changes

* Add a shared `SilentErrorBoundary` dashboard component (`client/dashboard/components/silent-error-boundary`). It wraps a non-critical piece of UI: on a caught error it renders nothing and forwards the error to Sentry via `captureException`, tagged `calypso_section: dashboard` plus any caller-supplied `sentryTags`, with the React component stack in `extra`.
* Wrap the guided-tour popup (`GuidedTourStep`) in `SilentErrorBoundary` (tagged `feature: guided-tour`). `GuidedTourStep` is now a thin wrapper around the existing step body (`GuidedTourStepContents`); all call sites are unchanged.

## Why are these changes being made?

#113380 fixed one way a tour popup could throw (an invalid CSS selector built from a bad translation), but `useAsyncElement` runs on mount before the tour's active/completed guard, so any render-time error in a popup can take down the whole page for every visitor on that route. A boundary contains the blast radius to the popup while keeping the error visible in Sentry, so future regressions degrade gracefully instead of white-screening the page.

The dashboard had no reusable boundary of this shape (the router's global `defaultOnCatch` is the only one), yet the "wrap a non-critical widget, still report" pattern recurs elsewhere in the codebase (e.g. Reader's crowdsignal poll). Extracting `SilentErrorBoundary` gives the dashboard a single, intention-named place for it — the name signals it silently drops UI, so it should only wrap losable content, never primary content (which should at least surface to the router's error page).

Error boundaries catch render/lifecycle errors and synchronous throws inside effects — which covers the `document.querySelector` failure class from #113380. This is defense-in-depth layered on top of that `CSS.escape()` fix.

## Testing Instructions

* Temporarily make a tour step throw during render (e.g. pass an invalid `selector` such as `[aria-label=` to a `GuidedTourStep`).
* Open the page hosting the tour and confirm the page still renders — only the popup is missing — and no error page appears.
* Confirm the error is reported to Sentry with the `guided-tour` feature tag.
* Revert the temporary change and confirm the tour anchors and renders normally.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
