### PR TITLE
Upgrade @wordpress/dataviews to 17.3.0

### DIFF
--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -36,7 +36,7 @@
 		"@wordpress/components": "^37.0.0",
 		"@wordpress/compose": "^8.2.0",
 		"@wordpress/data": "^10.48.0",
-		"@wordpress/dataviews": "^17.2.0",
+		"@wordpress/dataviews": "^17.3.0",
 		"@wordpress/element": "^8.0.0",
 		"@wordpress/i18n": "^6.21.0",
 		"@wordpress/icons": "^13.3.0",

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -169,18 +169,17 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 		? { ...paginationInfo, totalItems: paginationInfo.totalItems + NOTES_PER_PAGE }
 		: paginationInfo;
 
-	const loadMoreRef = useRef< HTMLDivElement >( null );
-
 	const infiniteScrollHandler = useCallback( () => {
 		if ( ! isLoading ) {
 			client?.loadMore();
 		}
 	}, [ client, isLoading ] );
 
-	// Fetch pages until the window is filled (a network page can be smaller), so
-	// there are enough notes to render before any of this is on screen.
+	// Fetch pages until the window is filled (a network page can be smaller), so a
+	// short list still overflows the panel and gets a scrollbar to drive more.
 	// Depend on `cachedNoteIds` by reference, not length: a same-length refresh must
-	// still re-run this to retry a `loadMore` the client's in-flight lock had blocked.
+	// still re-run this to retry a `loadMore` the client's in-flight lock had
+	// blocked — else a switch back to a short cached tab strands it with no scrollbar.
 	useEffect( () => {
 		if ( startPosition + NOTES_PER_PAGE > visibleNotes.length && ! isLoading && hasMoreNotes ) {
 			infiniteScrollHandler();
@@ -194,26 +193,8 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 		infiniteScrollHandler,
 	] );
 
-	// From then on, load more whenever the foot of the list is on screen — which
-	// covers both scrolling to the bottom and a list too short to scroll at all.
-	// An already-intersecting sentinel only reports again on a fresh observer, so
-	// re-observe as the notes change.
-	useEffect( () => {
-		const sentinel = loadMoreRef.current;
-		if ( ! sentinel ) {
-			return;
-		}
-		const observer = new IntersectionObserver( ( [ entry ] ) => {
-			if ( entry.isIntersecting ) {
-				infiniteScrollHandler();
-			}
-		} );
-		observer.observe( sentinel );
-		return () => observer.disconnect();
-	}, [ visibleNotes.length, cachedNoteIds, hasMoreNotes, infiniteScrollHandler ] );
-
-	// DataViews advances `startPosition` as the user scrolls, moving the rendered
-	// window over the notes the effect above has loaded.
+	// DataViews drives infinite scroll by advancing `startPosition`; the effect
+	// above reacts to that and loads more as the window nears the loaded notes.
 	const handleChangeView = useCallback( ( nextView: View ) => setView( nextView ), [] );
 
 	const noteListRef = useRef< HTMLObjectElement >( null );
@@ -291,7 +272,6 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 					// a fetch is in flight — otherwise it reads as a list stuck loading
 					// whenever the foot sits above the fold.
 					<VStack
-						ref={ loadMoreRef }
 						alignment="center"
 						style={ {
 							flexShrink: 0,

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -169,17 +169,18 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 		? { ...paginationInfo, totalItems: paginationInfo.totalItems + NOTES_PER_PAGE }
 		: paginationInfo;
 
+	const loadMoreRef = useRef< HTMLDivElement >( null );
+
 	const infiniteScrollHandler = useCallback( () => {
 		if ( ! isLoading ) {
 			client?.loadMore();
 		}
 	}, [ client, isLoading ] );
 
-	// Fetch pages until the window is filled (a network page can be smaller), so a
-	// short list still overflows the panel and gets a scrollbar to drive more.
+	// Fetch pages until the window is filled (a network page can be smaller), so
+	// there are enough notes to render before any of this is on screen.
 	// Depend on `cachedNoteIds` by reference, not length: a same-length refresh must
-	// still re-run this to retry a `loadMore` the client's in-flight lock had
-	// blocked — else a switch back to a short cached tab strands it with no scrollbar.
+	// still re-run this to retry a `loadMore` the client's in-flight lock had blocked.
 	useEffect( () => {
 		if ( startPosition + NOTES_PER_PAGE > visibleNotes.length && ! isLoading && hasMoreNotes ) {
 			infiniteScrollHandler();
@@ -193,8 +194,26 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 		infiniteScrollHandler,
 	] );
 
-	// DataViews drives infinite scroll by advancing `startPosition`; the effect
-	// above reacts to that and loads more as the window nears the loaded notes.
+	// From then on, load more whenever the foot of the list is on screen — which
+	// covers both scrolling to the bottom and a list too short to scroll at all.
+	// An already-intersecting sentinel only reports again on a fresh observer, so
+	// re-observe as the notes change.
+	useEffect( () => {
+		const sentinel = loadMoreRef.current;
+		if ( ! sentinel ) {
+			return;
+		}
+		const observer = new IntersectionObserver( ( [ entry ] ) => {
+			if ( entry.isIntersecting ) {
+				infiniteScrollHandler();
+			}
+		} );
+		observer.observe( sentinel );
+		return () => observer.disconnect();
+	}, [ visibleNotes.length, cachedNoteIds, hasMoreNotes, infiniteScrollHandler ] );
+
+	// DataViews advances `startPosition` as the user scrolls, moving the rendered
+	// window over the notes the effect above has loaded.
 	const handleChangeView = useCallback( ( nextView: View ) => setView( nextView ), [] );
 
 	const noteListRef = useRef< HTMLObjectElement >( null );
@@ -272,6 +291,7 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 					// a fetch is in flight — otherwise it reads as a list stuck loading
 					// whenever the foot sits above the fold.
 					<VStack
+						ref={ loadMoreRef }
 						alignment="center"
 						style={ {
 							flexShrink: 0,

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -210,11 +210,9 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 
 	// `groupBy` forces DataViews' list layout off its infinite-scroll path, which
 	// is the only path that renders its built-in load-more spinner — so we render
-	// our own at the foot of the list. Key it on "more to load" rather than the
-	// in-flight fetch so its space is already reserved when the bottom scrolls
-	// into view, and the list doesn't shift once `loadMore` dispatches. An empty
-	// list uses the `empty` slot above instead.
-	const showLoadMore = hasMoreNotes && data.length > 0;
+	// our own at the foot of the list, while a fetch is in flight. An empty list
+	// uses the `empty` slot above instead.
+	const showLoadMore = hasMoreNotes && data.length > 0 && tab.isLoading;
 
 	// Full-panel spinner until this tab's first load settles; after that DataViews
 	// is mounted and in-flight loading shows in the `empty` slot or the foot.
@@ -268,18 +266,7 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 				{ showLoadMore && (
 					// DataViews suppresses its own load-more spinner when notes are
 					// grouped, so this stands in for it, pinned below the list rows.
-					// Kept mounted so its height stays reserved, but only visible while
-					// a fetch is in flight — otherwise it reads as a list stuck loading
-					// whenever the foot sits above the fold.
-					<VStack
-						alignment="center"
-						style={ {
-							flexShrink: 0,
-							padding: '12px 0',
-							visibility: tab.isLoading ? 'visible' : 'hidden',
-						} }
-						aria-hidden={ ! tab.isLoading }
-					>
+					<VStack alignment="center" style={ { flexShrink: 0, padding: '12px 0' } }>
 						<Spinner />
 					</VStack>
 				) }

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -211,9 +211,9 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 	// `groupBy` forces DataViews' list layout off its infinite-scroll path, which
 	// is the only path that renders its built-in load-more spinner — so we render
 	// our own at the foot of the list. Key it on "more to load" rather than the
-	// in-flight fetch so it's already present when the bottom scrolls into view,
-	// not a beat later once `loadMore` dispatches. An empty list uses the `empty`
-	// slot above instead.
+	// in-flight fetch so its space is already reserved when the bottom scrolls
+	// into view, and the list doesn't shift once `loadMore` dispatches. An empty
+	// list uses the `empty` slot above instead.
 	const showLoadMore = hasMoreNotes && data.length > 0;
 
 	// Full-panel spinner until this tab's first load settles; after that DataViews
@@ -268,7 +268,18 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 				{ showLoadMore && (
 					// DataViews suppresses its own load-more spinner when notes are
 					// grouped, so this stands in for it, pinned below the list rows.
-					<VStack alignment="center" style={ { flexShrink: 0, padding: '12px 0' } }>
+					// Kept mounted so its height stays reserved, but only visible while
+					// a fetch is in flight — otherwise it reads as a list stuck loading
+					// whenever the foot sits above the fold.
+					<VStack
+						alignment="center"
+						style={ {
+							flexShrink: 0,
+							padding: '12px 0',
+							visibility: tab.isLoading ? 'visible' : 'hidden',
+						} }
+						aria-hidden={ ! tab.isLoading }
+					>
 						<Spinner />
 					</VStack>
 				) }

--- a/package.json
+++ b/package.json
@@ -401,7 +401,7 @@
 		"@wordpress/customize-widgets": "5.48.0",
 		"@wordpress/data-controls": "4.48.0",
 		"@wordpress/data": "^10.48.0",
-		"@wordpress/dataviews": "^17.2.0",
+		"@wordpress/dataviews": "^17.3.0",
 		"@wordpress/date": "5.48.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "^6.24.0",
 		"@wordpress/deprecated": "4.48.0",

--- a/packages/api-core/package.json
+++ b/packages/api-core/package.json
@@ -41,7 +41,7 @@
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/languages": "workspace:^",
 		"@automattic/shopping-cart": "workspace:^",
-		"@wordpress/dataviews": "^17.2.0",
+		"@wordpress/dataviews": "^17.3.0",
 		"@wordpress/html-entities": "^4.48.0",
 		"@wordpress/i18n": "^6.21.0",
 		"@wordpress/url": "^4.48.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -284,7 +284,7 @@ __metadata:
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/languages": "workspace:^"
     "@automattic/shopping-cart": "workspace:^"
-    "@wordpress/dataviews": "npm:^17.2.0"
+    "@wordpress/dataviews": "npm:^17.3.0"
     "@wordpress/html-entities": "npm:^4.48.0"
     "@wordpress/i18n": "npm:^6.21.0"
     "@wordpress/url": "npm:^4.48.0"
@@ -1811,7 +1811,7 @@ __metadata:
     "@wordpress/components": "npm:^37.0.0"
     "@wordpress/compose": "npm:^8.2.0"
     "@wordpress/data": "npm:^10.48.0"
-    "@wordpress/dataviews": "npm:^17.2.0"
+    "@wordpress/dataviews": "npm:^17.3.0"
     "@wordpress/element": "npm:^8.0.0"
     "@wordpress/i18n": "npm:^6.21.0"
     "@wordpress/icons": "npm:^13.3.0"
@@ -11543,30 +11543,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/dataviews@npm:^17.2.0":
-  version: 17.2.0
-  resolution: "@wordpress/dataviews@npm:17.2.0"
+"@wordpress/dataviews@npm:^17.3.0":
+  version: 17.3.0
+  resolution: "@wordpress/dataviews@npm:17.3.0"
   dependencies:
     "@ariakit/react": "npm:^0.4.32"
-    "@wordpress/a11y": "npm:^4.51.0"
-    "@wordpress/base-styles": "npm:^11.0.0"
-    "@wordpress/components": "npm:^37.0.0"
-    "@wordpress/compose": "npm:^8.4.0"
-    "@wordpress/data": "npm:^10.51.0"
-    "@wordpress/date": "npm:^5.51.0"
-    "@wordpress/deprecated": "npm:^4.51.0"
-    "@wordpress/element": "npm:^8.3.0"
-    "@wordpress/i18n": "npm:^6.24.0"
-    "@wordpress/icons": "npm:^15.2.0"
-    "@wordpress/keycodes": "npm:^4.51.0"
-    "@wordpress/primitives": "npm:^4.51.0"
-    "@wordpress/private-apis": "npm:^1.51.0"
-    "@wordpress/rich-text": "npm:^7.51.0"
-    "@wordpress/ui": "npm:^0.18.0"
-    "@wordpress/warning": "npm:^3.51.0"
+    "@wordpress/a11y": "npm:^4.52.0"
+    "@wordpress/base-styles": "npm:^12.0.0"
+    "@wordpress/components": "npm:^38.0.0"
+    "@wordpress/compose": "npm:^8.5.0"
+    "@wordpress/data": "npm:^10.52.0"
+    "@wordpress/date": "npm:^5.52.0"
+    "@wordpress/deprecated": "npm:^4.52.0"
+    "@wordpress/element": "npm:^8.4.0"
+    "@wordpress/i18n": "npm:^6.25.0"
+    "@wordpress/icons": "npm:^15.3.0"
+    "@wordpress/keycodes": "npm:^4.52.0"
+    "@wordpress/primitives": "npm:^4.52.0"
+    "@wordpress/private-apis": "npm:^1.52.0"
+    "@wordpress/rich-text": "npm:^7.52.0"
+    "@wordpress/ui": "npm:^0.19.0"
+    "@wordpress/warning": "npm:^3.52.0"
     clsx: "npm:^2.1.1"
     colord: "npm:^2.9.3"
-    date-fns: "npm:^4.1.0"
+    date-fns: "npm:^4.4.0"
     deepmerge: "npm:^4.3.1"
     fast-deep-equal: "npm:^3.1.3"
     remove-accents: "npm:^0.5.0"
@@ -11577,7 +11577,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 4f848884c5aaab170296df63f3bd44c1a7e919bba6c02a80b7ebac0482147311b593272e8a2706bd2aea704e03c005f97ca4b5c524c717cc1635ad7422295a18
+  checksum: 6bee02df11f3c7a5625329271685008efb865441cd590c3bc4d5cc7f07822ed5eb242c3d9bf8b5620ef2612d4653f0db69b81d05a6abfce160b5d59e254616df
   languageName: node
   linkType: hard
 
@@ -16586,6 +16586,13 @@ __metadata:
   version: 4.1.0
   resolution: "date-fns@npm:4.1.0"
   checksum: b79ff32830e6b7faa009590af6ae0fb8c3fd9ffad46d930548fbb5acf473773b4712ae887e156ba91a7b3dc30591ce0f517d69fd83bd9c38650fdc03b4e0bac8
+  languageName: node
+  linkType: hard
+
+"date-fns@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "date-fns@npm:4.4.0"
+  checksum: 988f0a13db183f5dfc85c36bbb6847a9c135a9225888bbea4005876ec15539a8613c21a07370a4e7ea543918d5a1cafb423c528b42cdbbde5fdfddb178126b21
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16582,14 +16582,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:4.1.0, date-fns@npm:^4.1.0":
+"date-fns@npm:4.1.0":
   version: 4.1.0
   resolution: "date-fns@npm:4.1.0"
   checksum: b79ff32830e6b7faa009590af6ae0fb8c3fd9ffad46d930548fbb5acf473773b4712ae887e156ba91a7b3dc30591ce0f517d69fd83bd9c38650fdc03b4e0bac8
   languageName: node
   linkType: hard
 
-"date-fns@npm:^4.4.0":
+"date-fns@npm:^4.1.0, date-fns@npm:^4.4.0":
   version: 4.4.0
   resolution: "date-fns@npm:4.4.0"
   checksum: 988f0a13db183f5dfc85c36bbb6847a9c135a9225888bbea4005876ec15539a8613c21a07370a4e7ea543918d5a1cafb423c528b42cdbbde5fdfddb178126b21


### PR DESCRIPTION
## Proposed Changes

* Bump `@wordpress/dataviews` from 17.2.0 to 17.3.0. The bumped entry in the root `package.json` is a `resolutions` override, so every workspace moves together — including `client/`, whose declared `^16.0.0` range has been overridden to the 17.x line all along. The lockfile carries a single resolution.
* Dedupe `date-fns` onto 4.4.0, which 17.3.0 pulls in. Four workspaces (`packages/ui`, `packages/date-range-picker`, `packages/domains-table`, `client`) declared `^4.1.0` and were resolving 4.1.0; CI's duplicate-package check requires the dedupe.
* One follow-on fix to the Notifications list, described below.

Notably in 17.3.0:

* Shift+Click range selection in the table and grid layouts (and in the picker layouts).
* DataForms no longer hijacks focus when the card and details layouts reveal validation errors, preserving the natural tab sequence.
* Fixes for the list layout ignoring density/loading settings when grouping is on, an unintended gap between grouped list items, popover hover text contrast on WordPress 7.0, and the search field resizing as its reset button appears.

### Notifications: load-more spinner

17.3.0 drops the gap between items in a grouped list layout, so the same notes occupy less vertical space. The Notifications footer spinner is keyed on "more notes to fetch" rather than on an in-flight request, so it renders continuously while any notes remain unloaded — it used to sit below the fold, and the shorter list brought it into view, where it read as a list stuck loading.

It now stays mounted so its height is still reserved (no shift when a fetch starts), but is only visible while a fetch is in flight.

## Why are these changes being made?

* Routine dependency maintenance: keeping our DataViews usage current with upstream so we pick up accessibility and layout fixes and don't accumulate a large version gap to cross later.

## Testing Instructions

* Open Notifications with an inbox longer than one screen. The footer spinner should appear only while notes are being fetched, not persistently. Scroll to the bottom and confirm more notes load.
* Repeat on a tab with only a few notes (for example Unread), and confirm the list still fills and scrolls as before.
* Smoke-test other DataViews-backed surfaces (for example the Dashboard sites list) and confirm rendering, sorting, filtering, pagination, and selection behave as before.
* Reviewer note: on table/grid views that declare `supportsBulk` actions, 17.3.0 intercepts Cmd/Ctrl+Click and Shift+Click for selection and prevents the default, so modifier-clicking a row no longer opens its link. This is intended upstream and is not overridden here, but it is worth a look on the domains, plugins, and subscribers lists. The Dashboard sites list is unaffected — it declares no bulk actions.
* Confirm no new console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

