### PR TITLE
Domains: don't fetch purchase ID 0 for domains without a subscription

### DIFF
--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -188,9 +188,10 @@ export const domainOverviewRoute = createRoute( {
 
 		queryClient.prefetchQuery( siteByIdQuery( domain.blog_id ) );
 		queryClient.prefetchQuery( mailboxesQuery( domain.blog_id ) );
-		await queryClient.ensureQueryData(
-			purchaseQuery( parseInt( domain.subscription_id ?? '0', 10 ) )
-		);
+
+		if ( domain.subscription_id ) {
+			await queryClient.ensureQueryData( purchaseQuery( parseInt( domain.subscription_id, 10 ) ) );
+		}
 	},
 } ).lazy( () =>
 	import( '../../domains/domain-overview' ).then( ( d ) =>

--- a/client/dashboard/domains/domain-connection-setup/transfer-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/transfer-setup.tsx
@@ -42,9 +42,10 @@ export default function DomainTransferSetup() {
 	const { data: domainConnectionSetupInfo } = useSuspenseQuery(
 		domainConnectionSetupInfoQuery( domainName, domain.blog_id )
 	);
-	const { data: purchase } = useQuery(
-		purchaseQuery( parseInt( domain.subscription_id ?? '0', 10 ) )
-	);
+	const { data: purchase } = useQuery( {
+		...purchaseQuery( parseInt( domain.subscription_id ?? '0', 10 ) ),
+		enabled: !! domain.subscription_id,
+	} );
 	const { data: site } = useQuery( siteByIdQuery( domain.blog_id ) );
 
 	const registrar = domainConnectionSetupInfo?.registrar || null;

--- a/client/dashboard/domains/domain-overview/actions.tsx
+++ b/client/dashboard/domains/domain-overview/actions.tsx
@@ -5,7 +5,7 @@ import {
 	removePurchaseMutation,
 	purchaseQuery,
 } from '@automattic/api-queries';
-import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
 	Button,
@@ -45,9 +45,10 @@ export default function Actions( { isDisabled }: { isDisabled?: boolean } ) {
 	const { user } = useAuth();
 	const { domainName } = domainRoute.useParams();
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
-	const { data: purchase } = useSuspenseQuery(
-		purchaseQuery( parseInt( domain.subscription_id ?? '0', 10 ) )
-	);
+	const { data: purchase } = useQuery( {
+		...purchaseQuery( parseInt( domain.subscription_id ?? '0', 10 ) ),
+		enabled: !! domain.subscription_id,
+	} );
 	const { mutate: disconnectDomain, isPending: isDisconnecting } = useMutation(
 		disconnectDomainMutation( domainName )
 	);
@@ -94,7 +95,7 @@ export default function Actions( { isDisabled }: { isDisabled?: boolean } ) {
 	);
 
 	const availableActions = {
-		renew: purchase.is_renewable && domain.current_user_is_owner,
+		renew: !! purchase?.is_renewable && domain.current_user_is_owner,
 		transfer: shouldShowTransferAction( domain ),
 		transferIn: shouldShowTransferInAction( domain ),
 		disconnect: shouldShowDisconnectAction( domain ),
@@ -111,7 +112,7 @@ export default function Actions( { isDisabled }: { isDisabled?: boolean } ) {
 		<VStack spacing={ 4 }>
 			<SectionHeader level={ 3 } title={ __( 'Actions' ) } />
 			<ActionList>
-				{ availableActions.renew && (
+				{ availableActions.renew && purchase && (
 					<ActionList.ActionItem
 						title={ __( 'Renew' ) }
 						description={ __( 'Renew domain registration.' ) }
@@ -191,7 +192,7 @@ export default function Actions( { isDisabled }: { isDisabled?: boolean } ) {
 						}
 					/>
 				) }
-				{ availableActions.remove && (
+				{ availableActions.remove && purchase && (
 					<ActionList.ActionItem
 						title={ getDeleteTitle( domain ) }
 						description={ getDeleteDescription( domain ) }
@@ -208,7 +209,7 @@ export default function Actions( { isDisabled }: { isDisabled?: boolean } ) {
 						}
 					/>
 				) }
-				{ availableActions.cancel && (
+				{ availableActions.cancel && purchase && (
 					<ActionList.ActionItem
 						title={ getDeleteTitle( domain ) }
 						description={ getDeleteDescription( domain ) }

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -34,9 +34,10 @@ export default function DomainOverview() {
 	const { domainName } = domainRoute.useParams();
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 
-	const { data: purchase } = useSuspenseQuery(
-		purchaseQuery( parseInt( domain.subscription_id ?? '0', 10 ) )
-	);
+	const { data: purchase } = useQuery( {
+		...purchaseQuery( parseInt( domain.subscription_id ?? '0', 10 ) ),
+		enabled: !! domain.subscription_id,
+	} );
 
 	const { data: site } = useQuery( siteByIdQuery( domain.blog_id ) );
 
@@ -98,7 +99,7 @@ export default function DomainOverview() {
 							</HStack>
 						}
 						actions={
-							purchase.can_explicit_renew &&
+							purchase?.can_explicit_renew &&
 							domain.current_user_is_owner && (
 								<Button
 									variant="primary"

--- a/client/dashboard/domains/domain-transfer/inbound-transfer/failed.tsx
+++ b/client/dashboard/domains/domain-transfer/inbound-transfer/failed.tsx
@@ -16,9 +16,10 @@ export const InboundTransferFailed = ( { domain }: { domain: Domain } ) => {
 	const { data: domainInboundTransferStatus } = useQuery(
 		domainInboundTransferStatusQuery( domain.domain )
 	);
-	const { data: purchase } = useQuery(
-		purchaseQuery( parseInt( domain.subscription_id ?? '0', 10 ) )
-	);
+	const { data: purchase } = useQuery( {
+		...purchaseQuery( parseInt( domain.subscription_id ?? '0', 10 ) ),
+		enabled: !! domain.subscription_id,
+	} );
 
 	return (
 		<InboundTransferStep


### PR DESCRIPTION
## Proposed Changes

* Skip fetching a domain's purchase when the domain has no subscription, instead of requesting purchase ID `0`.
* Treat the purchase as optional on the domain overview page, so the renew button and the renew/remove/cancel actions simply don't render when there is nothing to renew.

## Why are these changes being made?

Domains without a purchase — free `*.wordpress.com` addresses, staging subdomains, and some connected domains — have no subscription ID. The overview page was falling back to `0` to satisfy the query's number argument, but `0` isn't a sentinel the API understands: it's a request for a subscription that doesn't exist, and the API answers with a `subscription_missing` error.

That error surfaced two ways: a stream of `SubscriptionMissingError: Unable to find subscription` reports in Sentry, and a rejected route loader on the domain overview page for every affected domain.

The rest of the domains code already anticipated a missing purchase — the helpers that decide whether to show the remove and cancel actions take an optional purchase and return false without one. Only the call sites that needed a non-optional value used the `0` fallback.

## Considerations

The overview page used suspense queries, which can't be conditionally disabled — likely why the `0` fallback was reached for in the first place. Switching those two call sites to regular queries with an `enabled` guard makes the purchase legitimately optional. The route loader still prefetches it when a subscription exists, so there's no new loading state for domains that do have a purchase.

## Testing Instructions

* Open the overview page for a domain with a purchase (a registered domain) and confirm it's unchanged: the renew button appears in the header, and the renew, remove, and cancel actions appear as before.
* Open the overview page for a domain without a purchase — a staging subdomain, or the free address of a site with no custom domain. The page should load, with no renew button and no renew/remove/cancel actions.
* With the network tab open on that second page, confirm no request is made for purchase ID `0`, and that no `subscription_missing` error appears in the console.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
