### PR TITLE
Domain Search: explain why a suggestion can't be added instead of failing silently

### DIFF
--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -41,16 +41,21 @@ const summarizeCartResponse = async ( response: Response ): Promise< CartRespons
 	try {
 		const body = await response.json();
 
-		if ( Array.isArray( body?.products ) ) {
-			diagnostic.products = body.products
+		// Cart requests are made with ?http_envelope=1, which nests the real payload
+		// under `body` and always returns HTTP 200 — so a rejected add still looks
+		// like a success at the transport level, and its reason only appears here.
+		const payload = body?.body ?? body;
+
+		if ( Array.isArray( payload?.products ) ) {
+			diagnostic.products = payload.products
 				.map( ( product: { product_slug?: string; meta?: string } ) =>
 					[ product.product_slug, product.meta ].filter( Boolean ).join( ':' )
 				)
 				.slice( 0, 5 );
 		}
 
-		if ( Array.isArray( body?.messages?.errors ) ) {
-			diagnostic.errors = body.messages.errors
+		if ( Array.isArray( payload?.messages?.errors ) ) {
+			diagnostic.errors = payload.messages.errors
 				.map( ( error: { code?: string; message?: string } ) =>
 					[ error.code, error.message ].filter( Boolean ).join( ': ' )
 				)

--- a/packages/domain-search/src/components/search-notice/index.tsx
+++ b/packages/domain-search/src/components/search-notice/index.tsx
@@ -76,6 +76,7 @@ export const SearchNotice = () => {
 		queries,
 		events,
 		currentSiteUrl,
+		blockedSuggestion,
 		config: { includeOwnedDomainInSuggestions },
 	} = useDomainSearch();
 	const { error: suggestionError } = useQuery( queries.domainSuggestions( query ) );
@@ -84,6 +85,18 @@ export const SearchNotice = () => {
 	);
 
 	const notice = useMemo( () => {
+		// A suggestion the user tried to add but the registry can't sell right now
+		// (e.g. the TLD is in maintenance). Takes precedence: it's the result of an
+		// explicit action, unlike the passive notice about the searched query.
+		if ( blockedSuggestion && blockedSuggestion.query === query ) {
+			return getAvailabilityNotice(
+				blockedSuggestion.availability.domain_name,
+				blockedSuggestion.availability,
+				events,
+				currentSiteUrl
+			);
+		}
+
 		if (
 			! availability ||
 			shouldHideAvailabilityNotice( availability, includeOwnedDomainInSuggestions )
@@ -99,7 +112,14 @@ export const SearchNotice = () => {
 		}
 
 		return getAvailabilityNotice( query, availability, events, currentSiteUrl );
-	}, [ query, availability, events, currentSiteUrl, includeOwnedDomainInSuggestions ] );
+	}, [
+		query,
+		availability,
+		events,
+		currentSiteUrl,
+		includeOwnedDomainInSuggestions,
+		blockedSuggestion,
+	] );
 
 	const errorMessage = suggestionError?.message ?? availabilityError?.message;
 

--- a/packages/domain-search/src/components/suggestion-cta/index.tsx
+++ b/packages/domain-search/src/components/suggestion-cta/index.tsx
@@ -4,6 +4,7 @@ import { envelope } from '@wordpress/icons';
 import { useState } from 'react';
 import { useIsCurrentMutation } from '../../hooks/use-is-current-mutation';
 import { useSuggestion } from '../../hooks/use-suggestion';
+import { UNAVAILABLE_FOR_PURCHASE_STATUSES } from '../../page/constants';
 import { useDomainSearch } from '../../page/context';
 import {
 	DomainSearchTrademarkClaimsModal,
@@ -17,7 +18,7 @@ export interface DomainSuggestionCTAProps {
 }
 
 export const DomainSuggestionCTA = ( { domainName }: DomainSuggestionCTAProps ) => {
-	const { cart, events, queries } = useDomainSearch();
+	const { cart, events, queries, query, setBlockedSuggestion } = useDomainSearch();
 	const suggestion = useSuggestion( domainName );
 
 	const queryClient = useQueryClient();
@@ -37,6 +38,8 @@ export const DomainSuggestionCTA = ( { domainName }: DomainSuggestionCTAProps ) 
 			mutationId,
 		},
 		mutationFn: async ( { acceptedTrademarkClaim }: { acceptedTrademarkClaim: boolean } ) => {
+			setBlockedSuggestion( null );
+
 			if ( acceptedTrademarkClaim ) {
 				events.onTrademarkClaimsNoticeAccepted( suggestion );
 				await cart.onAddItem( suggestion );
@@ -48,6 +51,11 @@ export const DomainSuggestionCTA = ( { domainName }: DomainSuggestionCTAProps ) 
 			);
 
 			events.onDomainAddAvailabilityPreCheck( availability, domainName, suggestion.vendor );
+
+			if ( UNAVAILABLE_FOR_PURCHASE_STATUSES.includes( availability.status ) ) {
+				setBlockedSuggestion( { query, availability } );
+				return;
+			}
 
 			if ( ! availability.trademark_claims_notice_info ) {
 				await cart.onAddItem( suggestion );

--- a/packages/domain-search/src/components/suggestion-cta/test/index.tsx
+++ b/packages/domain-search/src/components/suggestion-cta/test/index.tsx
@@ -11,6 +11,7 @@ import { mockGetAvailabilityQuery } from '../../../test-helpers/queries/availabi
 import { mockGetSuggestionsQuery } from '../../../test-helpers/queries/suggestions';
 import { TestDomainSearchWithSuggestions } from '../../../test-helpers/renderer';
 import { DomainSuggestionsList } from '../../../ui';
+import { SearchNotice } from '../../search-notice';
 
 describe( 'DomainSuggestionCTA', () => {
 	describe( 'Add to cart cta', () => {
@@ -621,6 +622,49 @@ describe( 'DomainSuggestionCTA', () => {
 				expect( successCta ).toHaveClass( 'is-busy' );
 			} );
 		} );
+	} );
+
+	it( 'explains why a suggestion cannot be added when its TLD is in maintenance', async () => {
+		const user = userEvent.setup();
+
+		mockGetSuggestionsQuery( {
+			params: { query: 'test-maintenance' },
+			suggestions: [ buildSuggestion( { domain_name: 'test-maintenance.blog' } ) ],
+		} );
+
+		mockGetAvailabilityQuery( {
+			params: { domainName: 'test-maintenance.blog' },
+			availability: buildAvailability( {
+				domain_name: 'test-maintenance.blog',
+				tld: 'blog',
+				status: DomainAvailabilityStatus.MAINTENANCE,
+			} ),
+		} );
+
+		const onAddDomainToCart = jest.fn();
+
+		render(
+			<TestDomainSearchWithSuggestions query="test-maintenance" events={ { onAddDomainToCart } }>
+				<SearchNotice />
+				<DomainSuggestionsList>
+					<DomainSuggestionCTA domainName="test-maintenance.blog" />
+				</DomainSuggestionsList>
+			</TestDomainSearchWithSuggestions>
+		);
+
+		await user.click( await screen.findByRole( 'button', { name: 'Add to cart' } ) );
+
+		const [ notice ] = await screen.findAllByText(
+			/are undergoing maintenance\. Please try a different extension/
+		);
+
+		expect( notice ).toBeVisible();
+
+		// The cart rejects these outright, so the add is never attempted.
+		expect( onAddDomainToCart ).not.toHaveBeenCalled();
+		expect( screen.getByRole( 'button', { name: 'Add to cart' } ) ).not.toHaveClass(
+			'is-destructive'
+		);
 	} );
 
 	it( 'allows contacting support if the premium domain is too expensive', async () => {

--- a/packages/domain-search/src/helpers/test/get-availability-notice.tsx
+++ b/packages/domain-search/src/helpers/test/get-availability-notice.tsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react';
+import { UNAVAILABLE_FOR_PURCHASE_STATUSES } from '../../page/constants';
+import { buildAvailability } from '../../test-helpers/factories/availability';
+import { getAvailabilityNotice } from '../get-availability-notice';
+import type { DomainSearchEvents } from '../../page/types';
+
+const events = {} as DomainSearchEvents;
+
+describe( 'getAvailabilityNotice', () => {
+	// The suggestion CTA refuses to add these to the cart, so each one has to
+	// explain itself — otherwise the click does nothing with no message.
+	it.each( UNAVAILABLE_FOR_PURCHASE_STATUSES )(
+		'returns a notice for %s, which blocks adding to the cart',
+		( status ) => {
+			const notice = getAvailabilityNotice(
+				'example.blog',
+				buildAvailability( { domain_name: 'example.blog', tld: 'blog', status } ),
+				events
+			);
+
+			expect( notice ).not.toBeNull();
+
+			const { container } = render( <>{ notice?.message }</> );
+
+			expect( container.textContent?.trim() ).not.toHaveLength( 0 );
+		}
+	);
+} );

--- a/packages/domain-search/src/page/constants.ts
+++ b/packages/domain-search/src/page/constants.ts
@@ -9,9 +9,12 @@ export const DEFAULT_FILTER: FilterState = {
 // The registry can't sell these right now, and the shopping cart rejects them
 // with a generic "invalid product" error that tells the user nothing. Block the
 // add and show the availability notice, which explains the actual reason.
+//
+// Every status here must produce a notice from getAvailabilityNotice — blocking
+// a status it returns null for would leave the button doing nothing at all.
+// get-availability-notice's test enforces that.
 export const UNAVAILABLE_FOR_PURCHASE_STATUSES: DomainAvailabilityStatus[] = [
 	DomainAvailabilityStatus.MAINTENANCE,
-	DomainAvailabilityStatus.TLD_NOT_SUPPORTED_TEMPORARILY,
 	DomainAvailabilityStatus.PURCHASES_DISABLED,
 ];
 

--- a/packages/domain-search/src/page/constants.ts
+++ b/packages/domain-search/src/page/constants.ts
@@ -1,8 +1,18 @@
+import { DomainAvailabilityStatus } from '@automattic/api-core';
 import type { FilterState } from '../components/search-bar/types';
 
 export const DEFAULT_FILTER: FilterState = {
 	exactSldMatchesOnly: false,
 	tlds: [],
 };
+
+// The registry can't sell these right now, and the shopping cart rejects them
+// with a generic "invalid product" error that tells the user nothing. Block the
+// add and show the availability notice, which explains the actual reason.
+export const UNAVAILABLE_FOR_PURCHASE_STATUSES: DomainAvailabilityStatus[] = [
+	DomainAvailabilityStatus.MAINTENANCE,
+	DomainAvailabilityStatus.TLD_NOT_SUPPORTED_TEMPORARILY,
+	DomainAvailabilityStatus.PURCHASES_DISABLED,
+];
 
 export const DOMAIN_BUNDLE_UNAVAILABLE_ERROR_CODE = 'domain_bundle_unavailable';

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -10,7 +10,7 @@ import {
 import { createContext, useCallback, useContext, useMemo, useState } from 'react';
 import { isBlogSubdomainQuery } from '../helpers';
 import { DEFAULT_FILTER } from './constants';
-import { type DomainSearchProps, type DomainSearchContextType } from './types';
+import type { BlockedSuggestion, DomainSearchProps, DomainSearchContextType } from './types';
 
 const noop = () => {};
 
@@ -66,6 +66,8 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 	openFullCart: () => {},
 	query: '',
 	setQuery: () => {},
+	blockedSuggestion: null,
+	setBlockedSuggestion: () => {},
 	config: {
 		vendor: 'variation2_front',
 		skippable: false,
@@ -116,6 +118,7 @@ export const useDomainSearchContextValue = ( {
 
 	const [ isFullCartOpen, setIsFullCartOpen ] = useState( false );
 	const [ filter, setFilter ] = useState( DEFAULT_FILTER );
+	const [ blockedSuggestion, setBlockedSuggestion ] = useState< BlockedSuggestion | null >( null );
 
 	const closeFullCart = useCallback( () => {
 		setIsFullCartOpen( false );
@@ -236,6 +239,8 @@ export const useDomainSearchContextValue = ( {
 					normalizedEvents.onQueryChange( normalizedQuery );
 				}
 			},
+			blockedSuggestion,
+			setBlockedSuggestion,
 			slots,
 			currentSiteUrl,
 			filter,
@@ -261,5 +266,6 @@ export const useDomainSearchContextValue = ( {
 		normalizedConfig,
 		filter,
 		setFilter,
+		blockedSuggestion,
 	] );
 };

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -165,6 +165,15 @@ export interface DomainSearchProps {
 	config?: Partial< DomainSearchConfig >;
 }
 
+/**
+ * A suggestion the user tried to add that the registry can't sell right now.
+ * Stamped with the query it was raised under so a new search drops it.
+ */
+export interface BlockedSuggestion {
+	query: string;
+	availability: DomainAvailability;
+}
+
 export interface DomainSearchContextType
 	extends Omit<
 		DomainSearchProps,
@@ -176,6 +185,8 @@ export interface DomainSearchContextType
 	openFullCart: () => void;
 	query: string;
 	setQuery: ( query: string ) => void;
+	blockedSuggestion: BlockedSuggestion | null;
+	setBlockedSuggestion: ( blockedSuggestion: BlockedSuggestion | null ) => void;
 	filter: FilterState;
 	setFilter: ( filter: FilterState ) => void;
 	resetFilter: () => void;


### PR DESCRIPTION
## Proposed Changes

* Block the add-to-cart when the availability pre-check reports the domain can't be sold right now (TLD in maintenance, or domain registration disabled), and show the availability notice explaining why.
* Unwrap the `http_envelope` in the E2E cart diagnostics so cart error messages actually appear in failure output.

## Why are these changes being made?

A pre-release E2E run failed on the launch-site flow, and the failure turned out to be a real user-facing bug.

The `.blog` registry was in a scheduled maintenance window. Suggestions still listed `.blog` domains at full price with a live "Add to cart" button, but the cart rejected every add with a generic "We encountered a problem while adding this product to your shopping cart." The button flipped to a red error state and stayed there, and a toast repeated the same generic text. Nothing told the user the TLD was temporarily unavailable, and nothing suggested trying a different extension — every signal the user got was a restatement of "something went wrong".

The information needed was already in hand. The add-to-cart path fetches domain availability before adding, and that response said `tld_in_maintenance` with an end time. It was only used to check for trademark claims and price limits, so the maintenance status was fetched and discarded. The copy for this case also already exists and is already translated — it was only reachable when the user typed the exact domain as their search query, not when they clicked a suggestion.

Suggestions deliberately don't pre-check availability (that would be one request per row), so the button can't be disabled up front. Acting on the status at click time is the first point where this is knowable.

The E2E change is unrelated to behaviour but comes from the same investigation: the diagnostics tried to log the cart's error messages, but cart requests use `http_envelope=1`, which nests the payload one level down. Every logged response showed `status: 200, ok: true` and no errors — the one field that would have identified this immediately. The cause had to be recovered from a Playwright trace instead.

## Testing Instructions

Reproducing the real thing needs a TLD in maintenance, so unit tests cover the behaviour: see the new case in the suggestion CTA tests.

To exercise it manually, stub the availability response for a domain to return status `tld_in_maintenance` with a `tld` and `maintenance_end_time`, then:

1. Search for a keyword (not a full domain) so the target appears as a suggestion.
2. Click "Add to cart" on it.
3. A notice appears above the results: "Domains ending with **.blog** are undergoing maintenance. Please try a different extension or check back in 6 hours."
4. No cart request is made, and the button returns to its normal state rather than the red error state.
5. Search again — the notice clears.

## Considerations

The notice appears as a banner above the results rather than as tooltip text on the button. A tooltip on a small icon button is easy to miss, and the existing translated copy is a rich string with markup that doesn't fit a tooltip. This does mean the message can land above the fold while the user's attention is on the button.

The blocked-status list is deliberately narrow: the statuses where the registry demonstrably can't complete a sale *and* where there is copy to explain it. Blocking a status the notice helper has no message for would leave the button doing nothing and saying nothing — worse than the generic cart error. A test asserts every blocked status produces a notice, so the two lists can't drift apart. Other statuses that fail at the cart can be added once they have copy.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)



