### PR TITLE
Name no address on the verification gate until it is known which one

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -188,11 +188,18 @@ const UserStepComponent: StepType< { accepts: UserStepAccepts } > = function Use
 	const isAccountFromThisSession =
 		createdUserId !== null && String( createdUserId ) === String( userId );
 	const settings = userSettingsQuery();
-	const { data: userSettings, isSuccess: settingsRead } = useDataQuery( {
+	const {
+		data: userSettings,
+		isSuccess: settingsRead,
+		isError: settingsUnavailable,
+	} = useDataQuery( {
 		...settings,
 		queryKey: [ ...settings.queryKey, gateScopeForUser ],
 		enabled: gateStatus === 'gated' && ! isAccountFromThisSession,
 		meta: { persist: false },
+		// Kept trying, so a read that fails is a wait rather than a dead end. Focus does the same,
+		// but only for someone who leaves and comes back.
+		refetchInterval: ( query ) => ( query.state.status === 'error' ? 15000 : false ),
 	} );
 	const pendingEmail =
 		requestedEmail ??
@@ -322,6 +329,12 @@ const UserStepComponent: StepType< { accepts: UserStepAccepts } > = function Use
 	);
 
 	if ( gateStatus === 'gated' && ! isEditingEmail ) {
+		// Naming an address before knowing it names the one a correction was made to get away
+		// from. An account made here has none to find, so only someone returning waits.
+		if ( ! addressSettled && ! settingsUnavailable ) {
+			return <Step.Loading />;
+		}
+
 		return (
 			<EmailVerificationGate
 				onEditEmail={ beginEmailEdit }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -197,8 +197,9 @@ const UserStepComponent: StepType< { accepts: UserStepAccepts } > = function Use
 		queryKey: [ ...settings.queryKey, gateScopeForUser ],
 		enabled: gateStatus === 'gated' && ! isAccountFromThisSession,
 		meta: { persist: false },
-		// Kept trying, so a read that fails is a wait rather than a dead end. Focus does the same,
-		// but only for someone who leaves and comes back.
+		// Reaching the gate matters more than reaching it with an answer, so this gives up early
+		// and keeps trying from there. Focus retries too, but only for someone who leaves.
+		retry: 1,
 		refetchInterval: ( query ) => ( query.state.status === 'error' ? 15000 : false ),
 	} );
 	const pendingEmail =

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/email-verification-gate.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/email-verification-gate.tsx
@@ -287,6 +287,21 @@ describe( 'account step email verification gate', () => {
 		} );
 	} );
 
+	// Waiting on an answer that is not coming would be a worse dead end than the one it avoids.
+	it( 'shows the gate anyway when it cannot find out', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/settings' )
+			.times( 2 )
+			.reply( 500 );
+
+		renderUser( makeStore( false ) );
+
+		// Past the one retry it makes before giving up.
+		expect(
+			await screen.findByRole( 'heading', { name: GATE_HEADING }, { timeout: 5000 } )
+		).toBeVisible();
+	} );
+
 	// Naming the address before it is known names the one a correction was made to get away from.
 	it( 'names no address until it knows which one', async () => {
 		nock( 'https://public-api.wordpress.com' )

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/email-verification-gate.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/email-verification-gate.tsx
@@ -163,6 +163,12 @@ const renderUser = (
 	queryClient?: QueryClient
 ) => {
 	const submit = jest.fn();
+	// The gate asks where a correction is before naming an address. Declared last, so a test with
+	// something particular to say about the settings is matched on its own first.
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( '/rest/v1.1/me/settings' )
+		.reply( 200, { user_email: EMAIL } );
 	const { unmount } = renderWithProvider(
 		<MemoryRouter initialEntries={ [ url ] }>
 			<UserStep flow="onboarding" stepName="user" navigation={ { submit, goBack: jest.fn() } } />
@@ -281,18 +287,21 @@ describe( 'account step email verification gate', () => {
 		} );
 	} );
 
-	// A correction made in an earlier session is only in the settings, so until those answer the
-	// address on screen is the mistyped one, and resending would send there.
-	it( 'will not resend until it knows where a resend would go', async () => {
+	// Naming the address before it is known names the one a correction was made to get away from.
+	it( 'names no address until it knows which one', async () => {
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.1/me/settings' )
 			.delay( 50 )
-			.reply( 200, { user_email: EMAIL } );
+			.reply( 200, {
+				user_email: EMAIL,
+				user_email_change_pending: true,
+				new_user_email: CORRECTED_EMAIL,
+			} );
 
 		renderUser( makeStore( false ) );
 
-		expect( await screen.findByRole( 'button', { name: 'Resend' } ) ).toBeDisabled();
-		await waitFor( () => expect( screen.getByRole( 'button', { name: 'Resend' } ) ).toBeEnabled() );
+		expect( screen.queryByText( EMAIL, { exact: false } ) ).not.toBeInTheDocument();
+		expect( await screen.findByText( CORRECTED_EMAIL, { exact: false } ) ).toBeVisible();
 	} );
 
 	// Submitting the address the account already holds asks for no change, and is answered without


### PR DESCRIPTION
## Proposed Changes

* The verification gate waits for the answer before naming an address, rather than naming the account's and holding back what acts on it.
* A read that fails no longer strands the screen: it gives up early, shows the gate, and keeps trying in the background.

The feature flag remains off everywhere.

## Why are these changes being made?

The gate tells the user an email went to an address. A correction made in an earlier session lives only in the account settings, so until those answer, the address the gate would name is the one the correction was made to get away from.

That was handled by disabling the resend and hiding the inbox link, which left the wrong address on screen with two dead controls beside it and nothing explaining either. Waiting for the answer removes the cause rather than the symptoms.

Almost nobody waits: an account created in the same session cannot have a correction to find, so that path never asks. Only someone returning to the gate does, and a read that fails ends the wait rather than extending it.

## Testing Instructions

1. Run Calypso locally and open `/setup/onboarding?flags=onboarding/email-verification`.
2. Create an account. The gate should appear as immediately as it does today — this path asks nothing.
3. Press `edit`, correct the address, submit, then reload. The gate should name the corrected address, never the one it replaced.
4. Block `/me/settings` in devtools and reload. The gate should still appear rather than waiting indefinitely.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
