### PR TITLE
MCP: add is_a11n and is_test audience properties to Calypso Tracks events

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -1231,7 +1231,11 @@ export const mcpRoute = createRoute( {
 	getParentRoute: () => preferencesRoute,
 	path: 'mcp',
 	loader: async () => {
-		await queryClient.ensureQueryData( userSettingsQuery() );
+		await Promise.all( [
+			queryClient.ensureQueryData( userSettingsQuery() ),
+			// The MCP Tracks audience props read Automattician status on first render (view events).
+			queryClient.ensureQueryData( isAutomatticianQuery() ),
+		] );
 	},
 } );
 

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -5,6 +5,7 @@ import { Icon, __experimentalVStack as VStack, ToggleControl } from '@wordpress/
 import { __, sprintf } from '@wordpress/i18n';
 import { seen, pencil, notAllowed, connection, globe } from '@wordpress/icons';
 import { getOverridesToMatch, groupIntentKey } from '../../../me/mcp/group-intents';
+import { useMcpTracksAudienceProps } from '../../../me/mcp/tracks';
 import {
 	getAccountMcpAbilities,
 	getDisabledSiteIds,
@@ -72,6 +73,7 @@ function getWriteBadge( tools: Array< [ string, McpAbility ] > ) {
 
 function McpComponent() {
 	const { recordTracksEvent } = useAnalytics();
+	const tracksAudienceProps = useMcpTracksAudienceProps();
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 
 	const mcpAbilities = getAccountMcpAbilities( userSettings || {} );
@@ -130,7 +132,10 @@ function McpComponent() {
 			} as any,
 			{
 				onSuccess: () => {
-					recordTracksEvent( 'calypso_dashboard_mcp_account_toggled', { enabled } );
+					recordTracksEvent( 'calypso_dashboard_mcp_account_toggled', {
+						...tracksAudienceProps,
+						enabled,
+					} );
 				},
 			}
 		);
@@ -153,7 +158,10 @@ function McpComponent() {
 				/>
 			}
 		>
-			<ComponentViewTracker eventName="calypso_dashboard_mcp_view" />
+			<ComponentViewTracker
+				eventName="calypso_dashboard_mcp_view"
+				properties={ tracksAudienceProps }
+			/>
 			<VStack spacing={ 4 }>
 				<Card>
 					<CardBody>

--- a/client/dashboard/me/mcp/mcp-sites/index.tsx
+++ b/client/dashboard/me/mcp/mcp-sites/index.tsx
@@ -3,6 +3,7 @@ import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
+import { useMcpTracksAudienceProps } from '../../../../me/mcp/tracks';
 import {
 	getAccountMcpAbilities,
 	getDisabledSiteIds,
@@ -28,6 +29,7 @@ import type { Site } from '@automattic/api-core';
 
 export default function McpMcpSites() {
 	const { recordTracksEvent } = useAnalytics();
+	const tracksAudienceProps = useMcpTracksAudienceProps();
 	const { queries } = useAppContext();
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 	const sitesQueryResult = useQuery(
@@ -87,7 +89,7 @@ export default function McpMcpSites() {
 			} as any,
 			{
 				onSuccess: () => {
-					recordTracksEvent( eventName, { site_id: siteId } );
+					recordTracksEvent( eventName, { ...tracksAudienceProps, site_id: siteId } );
 				},
 			}
 		);
@@ -102,7 +104,10 @@ export default function McpMcpSites() {
 			} as any,
 			{
 				onSuccess: () => {
-					recordTracksEvent( 'calypso_dashboard_mcp_site_removed', { site_id: siteId } );
+					recordTracksEvent( 'calypso_dashboard_mcp_site_removed', {
+						...tracksAudienceProps,
+						site_id: siteId,
+					} );
 				},
 			}
 		);
@@ -144,7 +149,10 @@ export default function McpMcpSites() {
 				/>
 			}
 		>
-			<ComponentViewTracker eventName="calypso_dashboard_mcp_mcp_sites_view" />
+			<ComponentViewTracker
+				eventName="calypso_dashboard_mcp_mcp_sites_view"
+				properties={ tracksAudienceProps }
+			/>
 			<VStack spacing={ 8 }>
 				<Card>
 					<CardBody>

--- a/client/dashboard/me/mcp/read/index.tsx
+++ b/client/dashboard/me/mcp/read/index.tsx
@@ -13,6 +13,7 @@ import { chevronDown, chevronUp } from '@wordpress/icons';
 import { Fragment, useRef, useState } from 'react';
 import { groupIntentKey, getOverridesToMatch } from '../../../../me/mcp/group-intents';
 import { groupToolsByGroup, groupToolsBySubCategory } from '../../../../me/mcp/groups';
+import { useMcpTracksAudienceProps } from '../../../../me/mcp/tracks';
 import { getGroupDescriptors, getAccountMcpAbilities } from '../../../../me/mcp/utils';
 import { useAnalytics } from '../../../app/analytics';
 import Breadcrumbs from '../../../app/breadcrumbs';
@@ -39,6 +40,7 @@ interface SubGroup {
 
 export default function McpRead() {
 	const { recordTracksEvent } = useAnalytics();
+	const tracksAudienceProps = useMcpTracksAudienceProps();
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 	const mcpAbilities = getAccountMcpAbilities( userSettings || {} );
 	const isDesktop = useViewportMatch( 'medium' );
@@ -54,6 +56,7 @@ export default function McpRead() {
 		}
 		setOpenGroups( new Set( openGroupsRef.current ) );
 		recordTracksEvent( 'calypso_dashboard_mcp_read_group_toggled', {
+			...tracksAudienceProps,
 			group: groupName ?? 'other',
 			is_open: willBeOpen,
 		} );
@@ -84,6 +87,7 @@ export default function McpRead() {
 			{
 				onSuccess: () => {
 					recordTracksEvent( 'calypso_dashboard_mcp_read_tool_toggled', {
+						...tracksAudienceProps,
 						ability_name: toolId,
 						enabled,
 						group: groupName ?? 'other',
@@ -113,6 +117,7 @@ export default function McpRead() {
 			{
 				onSuccess: () => {
 					recordTracksEvent( 'calypso_dashboard_mcp_read_enable_all_toggled', {
+						...tracksAudienceProps,
 						enabled,
 						scope: 'page',
 					} );
@@ -147,6 +152,7 @@ export default function McpRead() {
 			{
 				onSuccess: () => {
 					recordTracksEvent( 'calypso_dashboard_mcp_read_enable_all_toggled', {
+						...tracksAudienceProps,
 						enabled,
 						scope: 'group',
 						group: groupName ?? 'other',
@@ -167,7 +173,10 @@ export default function McpRead() {
 				/>
 			}
 		>
-			<ComponentViewTracker eventName="calypso_dashboard_mcp_read_view" />
+			<ComponentViewTracker
+				eventName="calypso_dashboard_mcp_read_view"
+				properties={ tracksAudienceProps }
+			/>
 			<VStack spacing={ 4 }>
 				<Card>
 					<CardBody>

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -13,6 +13,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { copy, check } from '@wordpress/icons';
 import { useState } from 'react';
+import { useMcpTracksAudienceProps } from '../../../../me/mcp/tracks';
 import { hasEnabledAccountTools } from '../../../../me/mcp/utils';
 import Breadcrumbs from '../../../app/breadcrumbs';
 import { Card, CardBody } from '../../../components/card';
@@ -26,6 +27,7 @@ import './style.scss';
 
 function McpSetupComponent() {
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
+	const tracksAudienceProps = useMcpTracksAudienceProps();
 
 	type McpClient =
 		| 'claude'
@@ -115,7 +117,10 @@ function McpSetupComponent() {
 					/>
 				}
 			>
-				<ComponentViewTracker eventName="calypso_dashboard_mcp_setup_view" />
+				<ComponentViewTracker
+					eventName="calypso_dashboard_mcp_setup_view"
+					properties={ tracksAudienceProps }
+				/>
 				<Card>
 					<CardBody>
 						<VStack spacing={ 4 }>
@@ -155,7 +160,10 @@ function McpSetupComponent() {
 				/>
 			}
 		>
-			<ComponentViewTracker eventName="calypso_dashboard_mcp_setup_view" />
+			<ComponentViewTracker
+				eventName="calypso_dashboard_mcp_setup_view"
+				properties={ tracksAudienceProps }
+			/>
 			<>
 				<Card>
 					<CardBody>

--- a/client/dashboard/me/mcp/write/index.tsx
+++ b/client/dashboard/me/mcp/write/index.tsx
@@ -13,6 +13,7 @@ import { chevronDown, chevronUp } from '@wordpress/icons';
 import { Fragment, useRef, useState } from 'react';
 import { groupIntentKey, getOverridesToMatch } from '../../../../me/mcp/group-intents';
 import { groupToolsByGroup, groupToolsBySubCategory } from '../../../../me/mcp/groups';
+import { useMcpTracksAudienceProps } from '../../../../me/mcp/tracks';
 import { getGroupDescriptors, getAccountMcpAbilities } from '../../../../me/mcp/utils';
 import { useAnalytics } from '../../../app/analytics';
 import Breadcrumbs from '../../../app/breadcrumbs';
@@ -39,6 +40,7 @@ interface SubGroup {
 
 export default function McpWrite() {
 	const { recordTracksEvent } = useAnalytics();
+	const tracksAudienceProps = useMcpTracksAudienceProps();
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 	const mcpAbilities = getAccountMcpAbilities( userSettings || {} );
 	const isDesktop = useViewportMatch( 'medium' );
@@ -54,6 +56,7 @@ export default function McpWrite() {
 		}
 		setOpenGroups( new Set( openGroupsRef.current ) );
 		recordTracksEvent( 'calypso_dashboard_mcp_write_group_toggled', {
+			...tracksAudienceProps,
 			group: groupName ?? 'other',
 			is_open: willBeOpen,
 		} );
@@ -84,6 +87,7 @@ export default function McpWrite() {
 			{
 				onSuccess: () => {
 					recordTracksEvent( 'calypso_dashboard_mcp_write_tool_toggled', {
+						...tracksAudienceProps,
 						ability_name: toolId,
 						enabled,
 						group: groupName ?? 'other',
@@ -113,6 +117,7 @@ export default function McpWrite() {
 			{
 				onSuccess: () => {
 					recordTracksEvent( 'calypso_dashboard_mcp_write_enable_all_toggled', {
+						...tracksAudienceProps,
 						enabled,
 						scope: 'page',
 					} );
@@ -147,6 +152,7 @@ export default function McpWrite() {
 			{
 				onSuccess: () => {
 					recordTracksEvent( 'calypso_dashboard_mcp_write_enable_all_toggled', {
+						...tracksAudienceProps,
 						enabled,
 						scope: 'group',
 						group: groupName ?? 'other',
@@ -167,7 +173,10 @@ export default function McpWrite() {
 				/>
 			}
 		>
-			<ComponentViewTracker eventName="calypso_dashboard_mcp_write_view" />
+			<ComponentViewTracker
+				eventName="calypso_dashboard_mcp_write_view"
+				properties={ tracksAudienceProps }
+			/>
 			<VStack spacing={ 4 }>
 				<Card>
 					<CardBody>

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -37,6 +37,7 @@ import {
 	termDescription,
 } from '@wordpress/icons';
 import { useState } from 'react';
+import { useMcpTracksAudienceProps } from '../../../me/mcp/tracks';
 import {
 	getAccountMcpAbilities,
 	getSiteContextToolIds,
@@ -319,6 +320,7 @@ function EmailAssistantCard( {
 
 export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 	const { recordTracksEvent } = useAnalytics();
+	const tracksAudienceProps = useMcpTracksAudienceProps();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: pluginStatus } = useSuspenseQuery( bigSkyPluginQuery( site.ID ) );
 
@@ -390,6 +392,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 			{
 				onSuccess: () => {
 					recordTracksEvent( 'calypso_dashboard_mcp_site_toggled', {
+						...tracksAudienceProps,
 						enabled,
 						site_id: site.ID,
 					} );

--- a/client/dashboard/sites/settings-ai-tools/test/index.test.tsx
+++ b/client/dashboard/sites/settings-ai-tools/test/index.test.tsx
@@ -4,6 +4,7 @@
 
 import {
 	bigSkyPluginQuery,
+	isAutomatticianQuery,
 	queryClient,
 	siteBySlugQuery,
 	sitePostByEmailSettingsQuery,
@@ -74,6 +75,7 @@ function seedQueries(
 				: [],
 		},
 	} as UserSettings );
+	queryClient.setQueryData( isAutomatticianQuery().queryKey, { number: 0, teams: [] } );
 	if ( seedPostByEmailSettings ) {
 		queryClient.setQueryData( sitePostByEmailSettingsQuery( activeSite ).queryKey, {
 			post_by_email_address: postByEmailAddress,

--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -26,6 +26,7 @@ import { filterVisibleTools, isReadTool, isWriteTool } from './categories';
 import { getOverridesToMatch, groupIntentKey } from './group-intents';
 import { getAccessSummaryBadge, getWriteAccessBadge } from './hub-helpers';
 import { useMcpPageChrome } from './mcp-page-header';
+import { useMcpTracksAudienceProps } from './tracks';
 import {
 	getAccountMcpAbilities,
 	getDisabledSiteIds,
@@ -40,6 +41,7 @@ function McpComponent( { path } ) {
 	const { documentTitle, navigationHeaderProps } = useMcpPageChrome();
 	const queryClient = useQueryClient();
 	const dispatch = useDispatch();
+	const tracksAudienceProps = useMcpTracksAudienceProps();
 	const {
 		data: userSettings,
 		isLoading: isLoadingUserSettings,
@@ -119,7 +121,11 @@ function McpComponent( { path } ) {
 			},
 			{
 				onSuccess: () => {
-					recordTracksEvent( 'calypso_dashboard_mcp_account_toggled', { path, enabled } );
+					recordTracksEvent( 'calypso_dashboard_mcp_account_toggled', {
+						...tracksAudienceProps,
+						path,
+						enabled,
+					} );
 				},
 			}
 		);

--- a/client/me/mcp/test/tools-subpage.jsx
+++ b/client/me/mcp/test/tools-subpage.jsx
@@ -12,12 +12,16 @@ jest.mock( '@automattic/calypso-analytics', () => ( {
 } ) );
 
 jest.mock( '@automattic/calypso-config', () => {
-	const config = jest.fn( () => null );
+	const config = jest.fn( ( key ) => ( key === 'env_id' ? 'production' : null ) );
 	config.isEnabled = jest.fn( () => true );
 	return config;
 } );
 
 jest.mock( '@automattic/api-queries', () => ( {
+	isAutomatticianQuery: () => ( {
+		queryKey: [ 'read', 'teams' ],
+		queryFn: async () => true,
+	} ),
 	sitesQuery: () => ( {
 		queryKey: [ 'sites' ],
 		queryFn: async () => ( { sites: [] } ),
@@ -116,6 +120,8 @@ describe( 'client/me/mcp/tools-subpage Tracks payloads', () => {
 					ability_name: 'wpcom-mcp/posts-list',
 					enabled: true,
 					group: 'other',
+					is_a11n: 'true',
+					is_test: 'false',
 				} )
 			)
 		);
@@ -141,6 +147,8 @@ describe( 'client/me/mcp/tools-subpage Tracks payloads', () => {
 					ability_name: 'wpcom-mcp/posts-list',
 					enabled: true,
 					group: 'other',
+					is_a11n: 'true',
+					is_test: 'false',
 				} )
 			)
 		);

--- a/client/me/mcp/test/tracks.jsx
+++ b/client/me/mcp/test/tracks.jsx
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useMcpTracksAudienceProps } from '../tracks';
+
+let mockEnvId = 'production';
+let mockIsAutomattician = true;
+
+jest.mock( '@automattic/calypso-config', () => {
+	const config = jest.fn( ( key ) => ( key === 'env_id' ? mockEnvId : null ) );
+	config.isEnabled = jest.fn( () => true );
+	return config;
+} );
+
+jest.mock( '@automattic/api-queries', () => ( {
+	isAutomatticianQuery: () => ( {
+		queryKey: [ 'read', 'teams' ],
+		queryFn: async () => mockIsAutomattician,
+	} ),
+} ) );
+
+function createWrapper() {
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { retry: false } },
+	} );
+	return ( { children } ) => (
+		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+	);
+}
+
+describe( 'useMcpTracksAudienceProps', () => {
+	beforeEach( () => {
+		mockEnvId = 'production';
+		mockIsAutomattician = true;
+	} );
+
+	it( 'string-encodes both properties for an Automattician in production', async () => {
+		const { result } = renderHook( () => useMcpTracksAudienceProps(), {
+			wrapper: createWrapper(),
+		} );
+
+		await waitFor( () => expect( result.current.is_a11n ).toBe( 'true' ) );
+		expect( result.current ).toEqual( { is_a11n: 'true', is_test: 'false' } );
+	} );
+
+	it( 'marks a non-Automattician as is_a11n false', async () => {
+		mockIsAutomattician = false;
+
+		const { result } = renderHook( () => useMcpTracksAudienceProps(), {
+			wrapper: createWrapper(),
+		} );
+
+		await waitFor( () => expect( result.current.is_a11n ).toBe( 'false' ) );
+		expect( result.current ).toEqual( { is_a11n: 'false', is_test: 'false' } );
+	} );
+
+	it( 'defaults is_a11n to false while the teams query is unresolved', () => {
+		const { result } = renderHook( () => useMcpTracksAudienceProps(), {
+			wrapper: createWrapper(),
+		} );
+
+		expect( result.current.is_a11n ).toBe( 'false' );
+	} );
+
+	it.each( [ 'development', 'wpcalypso', 'horizon', 'stage', 'dashboard-stage' ] )(
+		'marks the %s environment as test',
+		( envId ) => {
+			mockEnvId = envId;
+
+			const { result } = renderHook( () => useMcpTracksAudienceProps(), {
+				wrapper: createWrapper(),
+			} );
+
+			expect( result.current.is_test ).toBe( 'true' );
+		}
+	);
+
+	it.each( [ 'production', 'dashboard-production', 'jetpack-cloud-production' ] )(
+		'does not mark the %s environment as test',
+		( envId ) => {
+			mockEnvId = envId;
+
+			const { result } = renderHook( () => useMcpTracksAudienceProps(), {
+				wrapper: createWrapper(),
+			} );
+
+			expect( result.current.is_test ).toBe( 'false' );
+		}
+	);
+} );

--- a/client/me/mcp/tools-subpage.jsx
+++ b/client/me/mcp/tools-subpage.jsx
@@ -27,6 +27,7 @@ import { filterVisibleTools } from './categories';
 import { getOverridesToMatch, groupIntentKey } from './group-intents';
 import { groupToolsByGroup, groupToolsBySubCategory } from './groups';
 import { useMcpPageChrome } from './mcp-page-header';
+import { useMcpTracksAudienceProps } from './tracks';
 import { getAccountMcpAbilities, getGroupDescriptors } from './utils';
 
 import './style.scss';
@@ -75,6 +76,7 @@ export default function McpToolsSubpage( {
 	const [ reauthRequired, setReauthRequired ] = useState( false );
 	const openGroupsRef = useRef( new Set() );
 	const [ openGroups, setOpenGroups ] = useState( () => openGroupsRef.current );
+	const tracksAudienceProps = useMcpTracksAudienceProps();
 
 	const tracksEvents = TRACKS_EVENTS[ toolCategory ];
 
@@ -87,6 +89,7 @@ export default function McpToolsSubpage( {
 		}
 		setOpenGroups( new Set( openGroupsRef.current ) );
 		recordTracksEvent( tracksEvents.groupToggled, {
+			...tracksAudienceProps,
 			path,
 			group: groupName ?? 'other',
 			is_open: willBeOpen,
@@ -132,6 +135,7 @@ export default function McpToolsSubpage( {
 			{
 				onSuccess: () => {
 					recordTracksEvent( tracksEvents.toolToggled, {
+						...tracksAudienceProps,
 						path,
 						ability_name: toolId,
 						enabled,
@@ -163,7 +167,12 @@ export default function McpToolsSubpage( {
 			},
 			{
 				onSuccess: () => {
-					recordTracksEvent( tracksEvents.enableAllToggled, { path, enabled, scope: 'page' } );
+					recordTracksEvent( tracksEvents.enableAllToggled, {
+						...tracksAudienceProps,
+						path,
+						enabled,
+						scope: 'page',
+					} );
 				},
 			}
 		);
@@ -196,6 +205,7 @@ export default function McpToolsSubpage( {
 			{
 				onSuccess: () => {
 					recordTracksEvent( tracksEvents.enableAllToggled, {
+						...tracksAudienceProps,
 						path,
 						enabled,
 						scope: 'group',

--- a/client/me/mcp/tracks.js
+++ b/client/me/mcp/tracks.js
@@ -1,0 +1,29 @@
+import { isAutomatticianQuery } from '@automattic/api-queries';
+import config from '@automattic/calypso-config';
+import { useQuery } from '@tanstack/react-query';
+
+/**
+ * Audience properties for the calypso_dashboard_mcp_* Tracks events.
+ *
+ * Mirrors TracksPropsHelper::audience_props() in wpcom (AIINT-586) so the
+ * properties mean the same thing across the wpcom, Calypso, and Jetpack
+ * families:
+ *
+ * - is_a11n is identity, not access — the user is an Automattician (a8c team
+ * membership), regardless of the MCP allowlist.
+ * - is_test is environment only — a non-production build (development, stage,
+ * wpcalypso, horizon). The bundle cannot see the proxied/sandboxed request
+ * state the PHP helper reads, so proxied production traffic reads 'false'
+ * here; the two properties stay disjoint either way.
+ *
+ * Both are the strings 'true'/'false', per the AIINT-576 encoding cutover.
+ * @returns {{ is_a11n: 'true'|'false', is_test: 'true'|'false' }}
+ */
+export function useMcpTracksAudienceProps() {
+	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
+
+	return {
+		is_a11n: isAutomattician === true ? 'true' : 'false',
+		is_test: /(^|-)production$/.test( config( 'env_id' ) ) ? 'false' : 'true',
+	};
+}


### PR DESCRIPTION
Part of AIINT-586

## Proposed Changes

* Add a shared `useMcpTracksAudienceProps()` hook (`client/me/mcp/tracks.js`) returning the `is_a11n` / `is_test` audience properties as `'true'`/`'false'` strings, matching the definitions the wpcom half of this work settled on:
  * `is_a11n` is identity, not access — the user is an Automattician (a8c team membership via `isAutomatticianQuery()`), regardless of the MCP allowlist.
  * `is_test` is environment only — a non-production build (`env_id`), kept disjoint from `is_a11n` so sandbox traffic can be isolated from ordinary dogfooding.
* Spread the two properties into all 16 `calypso_dashboard_mcp_*` events across both clients: classic `client/me/mcp/` (account toggle, read/write tool pages) and the Dashboard (`client/dashboard/me/mcp/` index/read/write/mcp-sites/setup views and toggles, plus `calypso_dashboard_mcp_site_toggled` in `sites/settings-ai-tools`).
* Preload `isAutomatticianQuery()` in the dashboard `mcpRoute` loader so first-render view events carry the real `is_a11n` value instead of the loading default.

Deliberately not included, per the issue: `ai_session_id` is *not* added — no MCP session exists in scope for browser UI events. The 5 `jetpack_mcp_*` events and the tracks-events-registration registry updates live in their own repos.

## Why are these changes being made?

* The Tracks Standards for AI Product Events ask every event for `is_a11n`, `is_test`, and `ai_session_id`; the MCP events carried none of them. Without `is_a11n`/`is_test` there is no way to separate dogfooding and sandbox traffic from real usage — MCP is still Automattician-gated, so every row in the table today is internal, and once the gate lifts nothing in the historical data would mark it as such.
* One deliberate client-side divergence, documented in the hook: the browser bundle cannot see the proxied/sandboxed request state the PHP helper reads, so `is_test` here means "non-production build environment".

## Testing Instructions

* `yarn test-client client/me/mcp client/dashboard/sites/settings-ai-tools` — new unit tests cover the hook's encoding/environment mapping and the updated event payloads.
* Manual, classic surface: `yarn start`, go to `/me/mcp`, toggle "Enable MCP access" → `calypso_dashboard_mcp_account_toggled` fires with `is_a11n: 'true'` (on an a11n account) and `is_test: 'true'` (dev build).
* Manual, Dashboard surface: `yarn start-dashboard`, go to `/me/preferences/mcp` → `calypso_dashboard_mcp_view` fires with the same two properties; toggle tools on the Read/Write subpages and inspect the `*_tool_toggled` events.
* Inspect the `t.gif` request payload in the browser network tab, or check Tracks live view.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?