### PR TITLE
A4A: Stop a malformed active sites response from blanking the sites dashboard

### DIFF
--- a/client/a8c-for-agencies/data/sites/test/use-is-site-ready.test.ts
+++ b/client/a8c-for-agencies/data/sites/test/use-is-site-ready.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from '@testing-library/react';
+import useFetchActiveSites from '../use-fetch-active-sites';
+import useIsSiteReady from '../use-is-site-ready';
+
+jest.mock( '../use-fetch-active-sites' );
+
+const mockActiveSites = ( data: unknown ) => {
+	( useFetchActiveSites as jest.Mock ).mockReturnValue( { data } );
+};
+
+const activeSite = ( id: number ) => ( {
+	id,
+	url: `https://site-${ id }.wordpress.com`,
+	features: { wpcom_atomic: { state: 'active', blog_id: id } },
+} );
+
+describe( 'useIsSiteReady', () => {
+	it( 'reports the site once it is active', () => {
+		mockActiveSites( [ activeSite( 1 ), activeSite( 2 ) ] );
+
+		const { result } = renderHook( () => useIsSiteReady( { siteId: 2 } ) );
+
+		expect( result.current.isReady ).toBe( true );
+		expect( result.current.site?.id ).toBe( 2 );
+	} );
+
+	it( 'is not ready while the site is still provisioning', () => {
+		mockActiveSites( [ { id: 1, features: { wpcom_atomic: { state: 'provisioning' } } } ] );
+
+		const { result } = renderHook( () => useIsSiteReady( { siteId: 1 } ) );
+
+		expect( result.current.isReady ).toBe( false );
+		expect( result.current.site ).toBeNull();
+	} );
+
+	it( 'is not ready while the request is still loading', () => {
+		mockActiveSites( undefined );
+
+		const { result } = renderHook( () => useIsSiteReady( { siteId: 1 } ) );
+
+		expect( result.current.isReady ).toBe( false );
+	} );
+
+	it( 'ignores a response that is not a list instead of crashing the page', () => {
+		mockActiveSites( { message: 'Something went wrong' } );
+
+		const { result } = renderHook( () => useIsSiteReady( { siteId: 1 } ) );
+
+		expect( result.current.isReady ).toBe( false );
+		expect( result.current.site ).toBeNull();
+	} );
+
+	it( 'tolerates a matching site that arrives without feature details', () => {
+		mockActiveSites( [ { id: 1 }, { id: 2, features: {} } ] );
+
+		expect( renderHook( () => useIsSiteReady( { siteId: 1 } ) ).result.current.isReady ).toBe(
+			false
+		);
+		expect( renderHook( () => useIsSiteReady( { siteId: 2 } ) ).result.current.isReady ).toBe(
+			false
+		);
+	} );
+} );

--- a/client/a8c-for-agencies/data/sites/use-is-site-ready.ts
+++ b/client/a8c-for-agencies/data/sites/use-is-site-ready.ts
@@ -7,11 +7,11 @@ type Props = {
 
 type Site = {
 	id: number;
-	url: string;
-	features: {
-		wpcom_atomic: {
-			state: string;
-			blog_id: number;
+	url?: string;
+	features?: {
+		wpcom_atomic?: {
+			state?: string;
+			blog_id?: number;
 		};
 	};
 };
@@ -21,15 +21,14 @@ export default function useIsSiteReady( { siteId }: Props ) {
 	const { data } = useFetchActiveSites( { autoRefresh: ! site } );
 
 	useEffect( () => {
-		const match = data?.find(
-			( site: Site ) => site.id === siteId && site.features.wpcom_atomic?.state === 'active'
+		// This banner renders on every /sites load and polls once a second, so a
+		// response that isn't the expected list must not take the route down.
+		const sites: Site[] = Array.isArray( data ) ? data : [];
+		const match = sites.find(
+			( site: Site ) => site.id === siteId && site.features?.wpcom_atomic?.state === 'active'
 		);
 
-		if ( match ) {
-			setSite( match );
-		} else {
-			setSite( null );
-		}
+		setSite( match ?? null );
 	}, [ data, site, siteId ] );
 
 	return {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
@@ -32,7 +32,7 @@ function Banner( { siteId, migration, development, onDismiss }: BannerProps ) {
 	const wpOverviewUrl = `https://wordpress.com/overview/${ siteSlug }`;
 	const wpMigrationUrl = addQueryArgs(
 		{
-			siteId: site?.features.wpcom_atomic.blog_id,
+			siteId: site?.features?.wpcom_atomic?.blog_id,
 			siteSlug,
 		},
 		'https://wordpress.com/setup/site-migration'


### PR DESCRIPTION
Context: p1786110033608559/1786035789.807379-slack-C047ACYM8UQ

## Proposed Changes

* Treat a non-array response from the agency sites endpoint as an empty list in `useIsSiteReady`, instead of calling `.find()` on it directly.
* Guard the `features` / `wpcom_atomic` lookups in the same predicate, and in the provisioning banner where it reads `blog_id`.
* Mark the genuinely optional fields as optional on the local `Site` type, so the compiler catches the next unguarded dereference.
* Add unit tests for `useIsSiteReady` covering both crashes.

## Why are these changes being made?

The provisioning banner renders on every `/sites` load and polls the agency sites endpoint once a second while a site is being set up. `useIsSiteReady` called `.find()` straight on the untyped response:

```js
const match = data?.find(
    ( site ) => site.id === siteId && site.features.wpcom_atomic?.state === 'active'
);
```

`data` comes from a `wpcom.req.get` passthrough with no shape guard, so a response that is not an array throws `TypeError: data?.find is not a function` during render. There is no error boundary above the banner, so the whole `/sites` route goes to a white screen. This was hit in practice after creating a development site from Needs setup and landing back on `/sites`.

The same predicate then dereferenced `site.features` without a guard — a second latent crash on the same line for any site that arrives without feature details. `provisioning-site-notification.tsx` had the matching pattern (`site?.features.wpcom_atomic.blog_id`): optional on `site`, then two hard dereferences.

This PR does not explain *why* the endpoint returned a non-array; that still needs the response body. It makes the dashboard survive it either way, which is the behaviour we want regardless of the root cause.

Worth noting separately: none of the `config/a8c-for-agencies-*.json` files set the `catch-js-errors` feature flag, while `config/dashboard-production.json` does. That means crashes like this one are not being reported for A4A at all, which is why this surfaced only through manual testing. That is a separate change.

## Testing Instructions

Regression check on the normal path:

1. Go to Needs setup and create a site.
2. You land on `/sites` and the provisioning banner appears, then flips to "Your WordPress.com site is ready!" once the site is active.
3. Confirm the "Set up your site" button and the migration variant still link correctly.

Reproducing the crash (fails on trunk, passes here):

1. Stub the `/agency/<id>/sites` GET response to return an object rather than an array — for example `{ "message": "Something went wrong" }`.
2. With a site tracked in the `provisioningSites` localStorage key, load `/sites`.
3. On trunk the page is blank with `Uncaught TypeError: a?.find is not a function` in the console. With this change the banner simply stays in its pending state and the page renders.

The unit tests cover both cases directly; each one fails without the corresponding guard:

```
yarn test-client client/a8c-for-agencies/data/sites/test/use-is-site-ready.test.ts
```

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?