### PR TITLE
Onboarding: fix two #112534 rebase regressions (playground plans intent + raw diy-launchpad branch)

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -433,9 +433,6 @@ const onboarding: FlowV2< typeof initialize > = {
 									steps_total: checkoutStepperPosition.total,
 								} )
 							);
-						} else if ( diyLaunchpad ) {
-							// The diy-launchpad cohort skips the AI/manual chooser and lands straight in Site Setup.
-							window.location.replace( destination );
 						} else if ( blueprint ) {
 							// Blueprint archive flow never shows the setup-your-site-ai chooser;
 							// go straight to the AI site-spec destination.

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/test/get-plans-intent.test.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/test/get-plans-intent.test.ts
@@ -22,6 +22,13 @@ describe( 'getPlansIntent', () => {
 		it( 'does not force the paid-only intent for a plain onboarding flow', () => {
 			expect( getPlansIntent( ONBOARDING_FLOW ) ).toBeNull();
 		} );
+
+		it( 'prefers the playground intent when both playground and blueprint params are present', () => {
+			// The Playground flow enters via /setup/onboarding/playground/?blueprint=<id>,
+			// so its users reach the plans step carrying BOTH params. Playground must win.
+			window.history.replaceState( {}, '', '/?blueprint=123&playground=abc' );
+			expect( getPlansIntent( ONBOARDING_FLOW ) ).toBe( 'plans-playground' );
+		} );
 	} );
 
 	describe( 'plan-upgrade flow (dashboard "Change plan" downgrade entry point)', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-plans-intent.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-plans-intent.ts
@@ -38,15 +38,19 @@ export function getPlansIntent( flowName: string | null ): PlansIntent | null {
 		case AI_SITE_BUILDER_ONBOARDING_FLOW:
 			return 'plans-ai-assembler-paid-only';
 		case ONBOARDING_FLOW:
-			// The blueprint variation (/setup/onboarding/blueprint) offers paid plans
-			// only — Personal, Premium, Business, Commerce — to match the blueprint
-			// archive it builds from. Reuse the AI-site-builder intent purely for that
-			// plan-tier set (it carries no other AI-assembler behavior).
-			if ( search.has( 'blueprint' ) ) {
-				return 'plans-ai-assembler-paid-only';
-			}
+			// The playground check must come FIRST: the Playground flow enters via
+			// /setup/onboarding/playground/?blueprint=<numeric id>, so its users carry
+			// BOTH params at the plans step. Only the blueprint-archive flow
+			// (/setup/onboarding/blueprint) has `blueprint` without `playground`.
 			if ( search.has( 'playground' ) ) {
 				return playgroundPlansIntent( search.get( 'playground' )! );
+			}
+			// The blueprint-archive variation offers paid plans only — Personal,
+			// Premium, Business, Commerce — to match the blueprint archive it builds
+			// from. Reuse the AI-site-builder intent purely for that plan-tier set
+			// (it carries no other AI-assembler behavior).
+			if ( search.has( 'blueprint' ) ) {
+				return 'plans-ai-assembler-paid-only';
 			}
 			if ( search.get( 'ref' ) === WOO_HOSTING_SOLUTIONS_REF ) {
 				return 'plans-woo-hosting-solutions';


### PR DESCRIPTION
Two small regressions from the #112534 rebase, bundled into one PR to ship in a single deploy.

## Fix 1: Playground flow got the wrong plans page (`get-plans-intent.ts`)

#113190 added a `blueprint` query-param check to the `ONBOARDING_FLOW` case **ahead of** the existing `playground` check. But the Playground flow enters via `/setup/onboarding/playground/?blueprint=<numeric id>` and `customNavigate` merges params forward, so Playground users reach the plans step with **both** params — and were forced onto the paid-only blueprint plan set instead of `playgroundPlansIntent()`.

**Fix:** check `playground` first — both-params-present is definitionally the Playground flow (the blueprint-archive flow never sets `playground`). Blueprint-archive behavior unchanged. New regression test: `?blueprint=123&playground=abc` → `plans-playground` (fails on the old ordering).

## Fix 2: raw `diy-launchpad` branch resurrected (`onboarding.ts`)

Flagged by @ashfame in https://github.com/Automattic/wp-calypso/pull/112534#issuecomment-5240884321: the #112534 rebase reintroduced the `else if ( diyLaunchpad )` short-circuit in the processing success path, which #112953 had deliberately removed when launchpad personalization moved to resolved ExPlat variations. The raw check bypassed the AI/manual chooser on mere param presence, ignoring the resolved variation.

**Fix:** pure 3-line re-removal, restoring #112953's exact chain. The `diyLaunchpad` variable stays (it still feeds `resolveLaunchpadPersonalizationVariation()` + param propagation); the `blueprint` branch is unchanged.

## Testing
- `get-plans-intent.test.ts`: 7/7 passing (incl. the new both-params regression test); eslint clean on both files.
- A full-file audit of the #112534 merge (intended-delta vs landed-delta vs trunk-under, all 6 files) found no further divergences — these two are the complete set.

Supersedes #113427 (folded in here to deploy both fixes in one go).

🤖 Generated with [Claude Code](https://claude.com/claude-code)