### PR TITLE
Omnibar: port launch site node

### DIFF
--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -16,6 +16,7 @@ import { OmnibarHomeIcon } from './home';
 import { useAiChatPlugin } from './plugin-ai-chat';
 import { useHelpCenterPlugin } from './plugin-help-center';
 import { useLanguageSwitcherPlugin } from './plugin-language-switcher';
+import { useLaunchSitePlugin } from './plugin-launch-site';
 import { useNotificationsPlugin } from './plugin-notifications';
 import { useReaderPlugin } from './plugin-reader';
 import { buildSiteBadgeNode } from './plugin-site-badges';
@@ -114,9 +115,12 @@ export default function OmnibarContainer( { user }: { user?: User } ) {
 	const notificationsPluginNode = useNotificationsPlugin( { user } );
 	const languageSwitcherNode = useLanguageSwitcherPlugin( { user } );
 	const statsSparklineNode = useStatsSparklinePlugin( { siteId, site } );
-	const siteActions = statsSparklineNode
-		? [ ...( baseOmnibarNodes.siteActions ?? [] ), statsSparklineNode ]
-		: baseOmnibarNodes.siteActions;
+	const launchSiteNode = useLaunchSitePlugin( { site } );
+	const siteActions = [
+		...( baseOmnibarNodes.siteActions ?? [] ),
+		statsSparklineNode,
+		launchSiteNode,
+	].filter( ( node ) => node !== undefined );
 
 	const omnibarNodes = {
 		...baseOmnibarNodes,

--- a/client/dashboard/app/omnibar/plugin-launch-site.scss
+++ b/client/dashboard/app/omnibar/plugin-launch-site.scss
@@ -1,0 +1,28 @@
+// Keep the button in blueberry whatever the bar's palette is, as wp-admin does.
+.omnibar .omnibar__menu.omnibar__launch-site {
+	background-color: var( --studio-wordpress-blue-50, #3858e9 );
+
+	&:hover:not( [aria-disabled='true'] ),
+	&:focus-visible:not( [aria-disabled='true'] ),
+	&:active:not( [aria-disabled='true'] ) {
+		background-color: #4664eb;
+	}
+
+	&[aria-disabled='true'] {
+		cursor: default;
+	}
+
+	svg {
+		width: 28px;
+		height: 28px;
+
+		@media ( min-width: 782px ) {
+			width: 15px;
+			height: 15px;
+		}
+	}
+
+	@media ( max-width: 480px ) {
+		display: none;
+	}
+}

--- a/client/dashboard/app/omnibar/plugin-launch-site.tsx
+++ b/client/dashboard/app/omnibar/plugin-launch-site.tsx
@@ -1,0 +1,64 @@
+import { __ } from '@wordpress/i18n';
+import { useSiteLaunch } from '../../sites/site-launch-button/use-site-launch';
+import { dashboardLinkWithBackport } from '../../utils/link';
+import { useAnalytics } from '../analytics';
+import { useAppContext } from '../context';
+import type { Site } from '@automattic/api-core';
+import type { OmnibarNode } from '@automattic/omnibar';
+
+import './plugin-launch-site.scss';
+
+function LaunchRocketIcon() {
+	return (
+		<svg viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg">
+			<path
+				fillRule="evenodd"
+				clipRule="evenodd"
+				d="M10.6242 9.74354L7.62419 12.1261V13.2995C7.62419 13.4418 7.77653 13.5322 7.90147 13.4641L10.5265 12.0322C10.5867 11.9994 10.6242 11.9363 10.6242 11.8676V9.74354ZM6.49919 12.0875L3.91203 9.50037H2.7001C1.70383 9.50037 1.07079 8.43399 1.54786 7.55937L2.97968 4.93437C3.20967 4.51272 3.65161 4.25036 4.13191 4.25036H7.17569C9.1325 2.16798 11.3176 0.754637 14.1427 0.531305C14.9004 0.471402 15.5282 1.09911 15.4682 1.85687C15.2449 4.68199 13.8316 6.86706 11.7492 8.82386V11.8676C11.7492 12.3479 11.4868 12.7899 11.0652 13.0199L8.44018 14.4517C7.56557 14.9288 6.49919 14.2957 6.49919 13.2995V12.0875ZM6.25602 5.37536H4.13191C4.0633 5.37536 4.00017 5.41284 3.96731 5.47308L2.53549 8.09808C2.46734 8.22303 2.55777 8.37536 2.7001 8.37536H3.87344L6.25602 5.37536Z"
+			/>
+			<path d="M0.498047 13.3962C0.498047 12.2341 1.44011 11.2921 2.60221 11.2921C3.76431 11.2921 4.70638 12.2341 4.70638 13.3962C4.70638 14.5583 3.76431 15.5004 2.60221 15.5004H1.06055C0.749887 15.5004 0.498047 15.2486 0.498047 14.9379V13.3962Z" />
+		</svg>
+	);
+}
+
+const NO_SITE = { ID: 0, slug: '', name: '' } as Site;
+
+export function useLaunchSitePlugin( { site }: { site?: Site } ): OmnibarNode | undefined {
+	const { queries } = useAppContext();
+	const { recordTracksEvent } = useAnalytics();
+
+	const isLaunchable =
+		!! site &&
+		site.launch_status === 'unlaunched' &&
+		!! site.capabilities?.manage_options &&
+		! site.is_a4a_dev_site;
+	const launchSite = site ?? NO_SITE;
+	const siteOverviewUrl = `/sites/${ launchSite.slug }`;
+
+	const { isLoading, isExperimentLoading, isDisabled, isBusy, href, onClick } = useSiteLaunch(
+		launchSite,
+		{
+			tracksContext: 'omnibar',
+			backTo: siteOverviewUrl,
+			postLaunchUrl: dashboardLinkWithBackport( siteOverviewUrl ),
+			domainsOptions: { ...queries.domainsQuery(), enabled: isLaunchable },
+			recordTracksEvent,
+		}
+	);
+
+	if ( ! isLaunchable ) {
+		return undefined;
+	}
+
+	const disabled = isLoading || isExperimentLoading || isDisabled || isBusy;
+
+	return {
+		id: 'launch-site',
+		title: __( 'Launch site' ),
+		icon: <LaunchRocketIcon />,
+		className: 'omnibar__launch-site',
+		disabled,
+		href,
+		onClick,
+	};
+}

--- a/client/dashboard/app/omnibar/plugin-site-badges.tsx
+++ b/client/dashboard/app/omnibar/plugin-site-badges.tsx
@@ -17,7 +17,7 @@ export function buildSiteBadgeNode( adminBarNode: AdminBarNode ): Partial< Omnib
 	return {
 		title: undefined,
 		href,
-		interactive: !! href,
+		disabled: ! href,
 		render: () => (
 			<span className="omnibar__site-badge">
 				<span className="omnibar__site-badge-label">{ label }</span>

--- a/packages/omnibar/src/components/omnibar-menu.tsx
+++ b/packages/omnibar/src/components/omnibar-menu.tsx
@@ -27,7 +27,7 @@ function OmnibarMenuItem( { node }: { node: OmnibarNode } ) {
 		);
 	}
 
-	if ( node.interactive === false ) {
+	if ( node.disabled ) {
 		return (
 			<div className="omnibar__menu-static-item">
 				<OmnibarNodeContent node={ node } />
@@ -82,19 +82,23 @@ function OmnibarMenuContent( { nodes }: { nodes: OmnibarNode[] } ) {
 
 export function OmnibarMenu( { node, className }: { node: OmnibarNode; className?: string } ) {
 	const label = node.title || node.label || '';
-	const menuClassName = className ? `omnibar__menu ${ className }` : 'omnibar__menu';
+	const menuClassName = [ 'omnibar__menu', className, node.className ]
+		.filter( Boolean )
+		.join( ' ' );
 	const [ isOpen, setIsOpen ] = useState( false );
 	const triggerRef = useRef< HTMLElement >( null );
 	const popoverRef = useRef< HTMLElement >( null );
 	const closedByPointerRef = useRef( false );
 
 	if ( ! node.children ) {
+		const isLink = !! node.href && ! node.disabled;
 		return (
 			<Button
 				variant="unstyled"
 				className={ menuClassName }
-				render={ node.href ? <a href={ node.href } /> : undefined }
-				nativeButton={ ! node.href }
+				render={ isLink ? <a href={ node.href } /> : undefined }
+				nativeButton={ ! isLink }
+				disabled={ node.disabled }
 				onClick={ node.onClick }
 				aria-label={ label }
 			>

--- a/packages/omnibar/src/types/omnibar.ts
+++ b/packages/omnibar/src/types/omnibar.ts
@@ -9,7 +9,8 @@ export interface OmnibarNode {
 	variant?: 'secondary';
 	href?: string;
 	onClick?: ( event: React.MouseEvent ) => void;
-	interactive?: boolean;
+	disabled?: boolean;
+	className?: string;
 	meta?: SiteActionNodeMeta & UserInfoNodeMeta;
 	render?: ( node: OmnibarNode ) => React.ReactNode;
 	children?: OmnibarNode[];


### PR DESCRIPTION
## Proposed Changes

Port the launch site node from the interim omnibar to the new one:

<img width="2068" height="64" alt="image" src="https://github.com/user-attachments/assets/2534f6ab-6bd5-4fd5-823d-0a8ae57e3611" />


## Why are these changes being made?

We want to maintain omnibar parity between Calypso and wp-admin.

## Testing Instructions

Test with the `dashboard/omnibar-radical` flag turned out.

1. Go to `/sites/:site` of an unlaunched site; verify you can see the launch button and you can complete the launch flow.
1. Go to `/sites/:site` of a launched site; verify you cannot see the launch button.
