### PR TITLE
Onboarding: re-remove the raw diy-launchpad processing branch

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -433,9 +433,6 @@ const onboarding: FlowV2< typeof initialize > = {
 									steps_total: checkoutStepperPosition.total,
 								} )
 							);
-						} else if ( diyLaunchpad ) {
-							// The diy-launchpad cohort skips the AI/manual chooser and lands straight in Site Setup.
-							window.location.replace( destination );
 						} else if ( blueprint ) {
 							// Blueprint archive flow never shows the setup-your-site-ai chooser;
 							// go straight to the AI site-spec destination.


### PR DESCRIPTION
## Why

Flagged by @ashfame in https://github.com/Automattic/wp-calypso/pull/112534#issuecomment-5240884321: #112534's rebase accidentally **reintroduced** the raw `else if ( diyLaunchpad )` short-circuit in the processing success path. That branch was deliberately removed in #112953 when launchpad personalization moved to resolved ExPlat variations — the raw param check bypasses the AI/manual chooser on the mere *presence* of `?diy-launchpad=`, ignoring the resolved variation (so `control`-assigned users skipped the chooser too).

Root cause: #112534 was authored against a pre-#112953 trunk; the rebase conflict resolution kept the stale branch alongside the new blueprint branch.

## What

Pure re-removal (3 deleted lines), restoring #112953's exact chain:
- The `else if ( blueprint )` branch (blueprint-archive flow) is unchanged.
- The `diyLaunchpad` variable stays — it still feeds `resolveLaunchpadPersonalizationVariation()` and `diy-launchpad` param propagation, which is the #112953-sanctioned path.

## Testing

- eslint clean; no other raw `diyLaunchpad` branching remains (verified — remaining usages are variation resolution + param passthrough).
- Behavior matches trunk-as-of-#112953 for the diy-launchpad cohort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)