### PR TITLE
Checkout: Move UPI above new credit cards when available

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -523,6 +523,7 @@ export default function useCreatePaymentMethods( {
 		...existingPayPalPPCPMethods,
 		applePayMethod,
 		googlePayMethod,
+		stripeUpiMethod,
 		...cardAndPayPalMethods,
 		idealMethod,
 		blikMethod,
@@ -534,6 +535,5 @@ export default function useCreatePaymentMethods( {
 		epsMethod,
 		wechatMethod,
 		bancontactMethod,
-		stripeUpiMethod,
 	].filter( isValueTruthy );
 }


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-2385/move-upi-higher-in-checkout-payment-method-list

## Proposed Changes

This PR moves the UPI payment method position in checkout's payment method list. Previously it was shown at the end of the list but since it is a very popular payment method in the countries where it is available, there's a desire to make it pre-selected. To that end, this PR puts it just below saved cards and Wallet methods, which I believe we would still prefer to encourage if our users have them available.


Before             |  After
:-------------------------:|:-------------------------:
<img width="664" height="553" alt="Screenshot 2026-08-10 at 11 19 42 AM" src="https://github.com/user-attachments/assets/814ca7c6-41b1-46f4-85cb-705af15283c0" /> | <img width="676" height="813" alt="Screenshot 2026-08-10 at 11 20 29 AM" src="https://github.com/user-attachments/assets/ea7dacca-f44b-42b5-adbe-b7f2537cd4b9" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

There was a request here to make UPI pre-selected: p1786140955544959-slack-C096PD42U

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Set your currency to INR in store admin
- Navigate to checkout with a product and set your address to India, with a valid postal code and state.
- Verify the UPI payment method appears in the list with the UPI logo.