### PR TITLE
Omnibar: fix node visibility and css on mobile/responsive widths

### DIFF
--- a/client/dashboard/app/omnibar/plugin-ai-chat.scss
+++ b/client/dashboard/app/omnibar/plugin-ai-chat.scss
@@ -1,12 +1,11 @@
-// wp-admin sizes this glyph to 30px below 782px and 24px above it. The viewBox
-// matches wp-admin's markup too, so the star lands on the same pixels; only the
-// mobile value has to override the omnibar's shared 32px icon size.
 .omnibar .omnibar__menu svg.omnibar__ai-chat-icon {
 	width: 30px;
 	height: 30px;
 
 	@media ( min-width: 782px ) {
-		width: 24px;
-		height: 24px;
+		width: 22px;
+		height: 22px;
+		margin-inline-start: 2px;
+		margin-inline-end: 3px;
 	}
 }

--- a/client/dashboard/app/omnibar/plugin-reader.scss
+++ b/client/dashboard/app/omnibar/plugin-reader.scss
@@ -1,3 +1,9 @@
+.omnibar .omnibar__reader {
+	@media ( max-width: 360px ) {
+		display: none;
+	}
+}
+
 .omnibar .omnibar__menu svg.omnibar__reader-icon {
 	width: 36px;
 	height: auto;

--- a/client/dashboard/app/omnibar/plugin-reader.tsx
+++ b/client/dashboard/app/omnibar/plugin-reader.tsx
@@ -26,6 +26,7 @@ export function useReaderPlugin(): OmnibarNode {
 		id: 'reader',
 		title: __( 'Reader' ),
 		icon: <ReaderIcon />,
+		className: 'omnibar__reader',
 		href: wpcomLink( '/reader' ),
 		onClick: () => recordTracksEvent( 'calypso_masterbar_reader_clicked' ),
 	};

--- a/client/dashboard/app/omnibar/plugin-stats-sparkline.scss
+++ b/client/dashboard/app/omnibar/plugin-stats-sparkline.scss
@@ -2,6 +2,12 @@
 	vertical-align: middle;
 }
 
+.omnibar .omnibar__stats-sparkline {
+	@media ( max-width: 781px ) {
+		display: none;
+	}
+}
+
 .omnibar .omnibar__menu svg.wpcom-stats-sparkline {
 	width: auto;
 	height: auto;

--- a/client/dashboard/app/omnibar/plugin-stats-sparkline.tsx
+++ b/client/dashboard/app/omnibar/plugin-stats-sparkline.tsx
@@ -31,6 +31,7 @@ export function useStatsSparklinePlugin( {
 		id: 'stats',
 		href: `${ adminUrl }admin.php?page=stats`,
 		label,
+		className: 'omnibar__stats-sparkline',
 		render: () => (
 			<>
 				<StatsSparkline hourlyViews={ hourlyViews } />

--- a/packages/omnibar/src/components/omnibar-user.scss
+++ b/packages/omnibar/src/components/omnibar-user.scss
@@ -37,6 +37,7 @@
 
 	.omnibar__user-label {
 		gap: 6px;
+		white-space: nowrap;
 	}
 
 	.omnibar__user-username {

--- a/packages/omnibar/src/components/omnibar.scss
+++ b/packages/omnibar/src/components/omnibar.scss
@@ -24,6 +24,7 @@ body:has( .omnibar ) {
 	min-height: var( --omnibar-height );
 	height: var( --omnibar-height );
 	display: flex;
+	position: relative;
 	padding: 0;
 	margin: 0;
 	font-size: $omnibar-font-size;
@@ -33,6 +34,13 @@ body:has( .omnibar ) {
 		display: flex;
 		align-items: center;
 		margin-inline-start: auto;
+
+		@media ( max-width: 480px ) {
+			position: absolute;
+			top: 0;
+			inset-inline-end: 0;
+			background: var( --omnibar-background );
+		}
 
 		.omnibar__menu {
 			@media ( min-width: 782px ) {
@@ -96,6 +104,13 @@ body:has( .omnibar ) {
 		}
 	}
 
+	.omnibar__responsive-menu {
+		.dashicons-before::before {
+			padding-inline: 1px;
+		}
+	}
+
+
 	.omnibar__home {
 		@media ( min-width: 782px ) {
 			padding-inline-start: 8px;
@@ -122,11 +137,15 @@ body:has( .omnibar ) {
 		}
 	}
 
-	.omnibar__responsive-menu {
-		min-width: 53px;
+	.omnibar__updates {
+		@media ( max-width: 600px ) {
+			display: none;
+		}
+	}
 
-		.dashicons-before::before {
-			padding-inline-end: 3px;
+	.omnibar__new-content {
+		@media ( max-width: 480px ) {
+			display: none;
 		}
 	}
 
@@ -216,8 +235,4 @@ body:has( .omnibar ) {
 		font-size: 20px;
 		top: 1px;
 	}
-}
-
-.omnibar .dashicons-menu-alt::before {
-	top: 0.5px;
 }

--- a/packages/omnibar/src/utils/admin-bar.tsx
+++ b/packages/omnibar/src/utils/admin-bar.tsx
@@ -52,6 +52,7 @@ export function buildOmnibarNodesFromAdminBarNodes(
 			}
 			case 'new-content': {
 				omnibarNode.icon = <span className="dashicons-before dashicons-plus" />;
+				omnibarNode.className = 'omnibar__new-content';
 				siteActionNodes.push( omnibarNode );
 				break;
 			}
@@ -71,6 +72,7 @@ export function buildOmnibarNodesFromAdminBarNodes(
 				omnibarNode.title = undefined;
 				omnibarNode.label = doc.querySelector( '.screen-reader-text' )?.textContent?.trim();
 				omnibarNode.icon = <span className="dashicons-before dashicons-update" />;
+				omnibarNode.className = 'omnibar__updates';
 				omnibarNode.meta = {
 					subtitle: doc.querySelector( '.ab-label' )?.textContent?.trim(),
 				};


### PR DESCRIPTION
## Proposed Changes

For the new omnibar, hide certain nodes and fix overlapping nodes on mobile / responsive widths.

## Why are these changes being made?

Parity with wp-admin behavior.

## Testing Instructions

Test with the new `dashboard/omnibar-radical` flag turned on.

1. Go to `/sites`
2. Try reducing the screen width, observe the behavior, verify some nodes (like `+` or updates icon) get hidden as you resize, and finally the right nodes will cover the left nodes similar to wp-admin's behavior.