### PR TITLE
Jetpack Manage: Fix A4A plugin links and simplify update filtering

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { AllowedTypes } from '../../types';
 
@@ -65,6 +66,14 @@ const getLinks = (
 			break;
 		}
 		case 'plugin': {
+			// A4A has no per-site plugin management yet, so agencies go to wp-admin — the same
+			// destination as the Plugins tab of the site preview pane.
+			if ( isA8CForAgencies() ) {
+				link = `${ siteUrlWithScheme }/wp-admin/plugins.php`;
+				isExternalLink = true;
+				break;
+			}
+
 			link = `/plugins/manage/${ siteUrlWithMultiSiteSupport }${
 				status === 'warning' ? '?updates=1' : ''
 			}`;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/test/get-links.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/test/get-links.ts
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment node
+ */
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
+import getLinks from '../get-links';
+
+jest.mock( 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies' );
+
+const mockedIsA8CForAgencies = isA8CForAgencies as jest.MockedFunction< typeof isA8CForAgencies >;
+
+const SITE_URL = 'test.wordpress.com';
+const SITE_URL_WITH_SCHEME = 'https://test.wordpress.com';
+
+const getPluginLink = ( status: string, isAtomicSite = false ) =>
+	getLinks( 'plugin', status, SITE_URL, SITE_URL_WITH_SCHEME, isAtomicSite );
+
+describe( 'getLinks', () => {
+	describe( 'plugin, in A4A', () => {
+		beforeEach( () => {
+			mockedIsA8CForAgencies.mockReturnValue( true );
+		} );
+
+		it( 'links to wp-admin when updates are available', () => {
+			expect( getPluginLink( 'warning' ) ).toEqual( {
+				link: `${ SITE_URL_WITH_SCHEME }/wp-admin/plugins.php`,
+				isExternalLink: true,
+			} );
+		} );
+
+		it( 'links to wp-admin when plugins are up to date', () => {
+			expect( getPluginLink( 'success' ) ).toEqual( {
+				link: `${ SITE_URL_WITH_SCHEME }/wp-admin/plugins.php`,
+				isExternalLink: true,
+			} );
+		} );
+
+		it( 'links to wp-admin for Atomic sites', () => {
+			expect( getPluginLink( 'warning', true ) ).toEqual( {
+				link: `${ SITE_URL_WITH_SCHEME }/wp-admin/plugins.php`,
+				isExternalLink: true,
+			} );
+		} );
+	} );
+
+	describe( 'plugin, in Jetpack Manage', () => {
+		beforeEach( () => {
+			mockedIsA8CForAgencies.mockReturnValue( false );
+		} );
+
+		it( 'links to the plugin dashboard filtered by updates when updates are available', () => {
+			expect( getPluginLink( 'warning' ) ).toEqual( {
+				link: `/plugins/manage/${ SITE_URL }?updates=1`,
+				isExternalLink: false,
+			} );
+		} );
+
+		it( 'links to the unfiltered plugin dashboard when plugins are up to date', () => {
+			expect( getPluginLink( 'success' ) ).toEqual( {
+				link: `/plugins/manage/${ SITE_URL }`,
+				isExternalLink: false,
+			} );
+		} );
+
+		it( 'links Atomic sites to the plugin dashboard too', () => {
+			expect( getPluginLink( 'warning', true ) ).toEqual( {
+				link: `/plugins/manage/${ SITE_URL }?updates=1`,
+				isExternalLink: false,
+			} );
+		} );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-status-column.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-status-column.tsx
@@ -163,7 +163,6 @@ export default function SiteStatusColumn( { type, rows, metadata, disabled }: Pr
 	if ( link ) {
 		wrappedContent = (
 			<a
-				className={ status === 'warning' ? 'sites-overview__warning-link' : undefined }
 				data-testid={ `row-${ tooltipId }` }
 				target={ isExternalLink ? '_blank' : undefined }
 				rel={ isExternalLink ? 'noreferrer' : undefined }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/test/site-table-row.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/test/site-table-row.tsx
@@ -106,7 +106,7 @@ describe( '<SiteTableRow>', () => {
 		plugin: {
 			updates: pluginUpdates.length,
 			type: 'plugin',
-			value: `${ pluginUpdates.length } ${ translate( 'Updates' ) }`,
+			value: `${ pluginUpdates.length } Updates`,
 			status: 'warning',
 		},
 	};

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
@@ -110,7 +110,7 @@ describe( '<SiteTable>', () => {
 			plugin: {
 				updates: pluginUpdates.length,
 				type: 'plugin',
-				value: `${ pluginUpdates.length } ${ translate( 'Updates' ) }`,
+				value: `${ pluginUpdates.length } Updates`,
 				status: 'warning',
 			},
 		},
@@ -192,7 +192,6 @@ describe( '<SiteTable>', () => {
 		expect( pluginEle.getAttribute( 'href' ) ).toEqual(
 			`/plugins/manage/${ urlToSlug( siteUrl ) }?updates=1`
 		);
-		expect( pluginEle ).toHaveClass( 'sites-overview__warning-link' );
 		expect( getByText( `${ pluginUpdates.length } Updates` ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -500,13 +500,15 @@
 	color: var(--color-warning-50);
 }
 
-.sites-overview__warning-link,
-.sites-overview__warning-link:visited,
-.sites-overview__warning-link:hover,
-.sites-overview__warning-link:focus,
-.sites-overview__warning-link:active {
-	color: var(--color-warning-50);
-	text-decoration-color: currentColor;
+// Mirrors the A4A rule in sections/sites/sites-dashboard/style.scss. The hover underline sits on
+// the value so it picks up the status color; on the anchor it would resolve to the link blue.
+.sites-overview__row-status > a {
+	text-decoration: none;
+
+	&:hover > *,
+	&:focus-visible > * {
+		text-decoration: underline;
+	}
 }
 
 .sites-overview__failed {

--- a/client/jetpack-cloud/sections/plugin-management/controller.tsx
+++ b/client/jetpack-cloud/sections/plugin-management/controller.tsx
@@ -1,6 +1,8 @@
 import page, { type Callback, type Context } from '@automattic/calypso-router';
 import JetpackManageSidebar from 'calypso/jetpack-cloud/sections/sidebar-navigation/jetpack-manage';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import Header from '../agency-dashboard/header';
 import PluginsOverview from './plugins-overview';
 
@@ -24,6 +26,11 @@ export const pluginManagementContext: Callback = ( context, next ) => {
 	context.header = <Header />;
 	// Set secondary context only on multi-site view
 	if ( ! site ) {
+		// `/plugins/manage/:site` selects a site and nothing downstream clears it, so the
+		// multi-site views would otherwise stay scoped to whichever site was visited last.
+		if ( getSelectedSiteId( context.store.getState() ) ) {
+			context.store.dispatch( setSelectedSiteId( null ) );
+		}
 		setSidebar( context );
 	}
 	next();

--- a/client/jetpack-cloud/sections/plugin-management/test/controller.tsx
+++ b/client/jetpack-cloud/sections/plugin-management/test/controller.tsx
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { pluginManagementContext } from '../controller';
+
+jest.mock( 'calypso/state/partner-portal/partner/selectors' );
+jest.mock( 'calypso/state/ui/actions' );
+jest.mock( 'calypso/state/ui/selectors' );
+
+const mockedIsAgencyUser = isAgencyUser as jest.MockedFunction< typeof isAgencyUser >;
+const mockedSetSelectedSiteId = setSelectedSiteId as jest.MockedFunction<
+	typeof setSelectedSiteId
+>;
+const mockedGetSelectedSiteId = getSelectedSiteId as jest.MockedFunction<
+	typeof getSelectedSiteId
+>;
+
+const createContext = ( params: { site?: string } ) => ( {
+	params,
+	path: '/plugins/manage/sites',
+	secondary: undefined as unknown,
+	store: {
+		getState: () => ( {} ),
+		dispatch: jest.fn(),
+	},
+} );
+
+describe( 'pluginManagementContext', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockedIsAgencyUser.mockReturnValue( true );
+	} );
+
+	test( 'clears the selected site on the multi-site view', () => {
+		mockedGetSelectedSiteId.mockReturnValue( 123 );
+		const context = createContext( {} );
+		const next = jest.fn();
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial page.js context
+		pluginManagementContext( context as any, next );
+
+		expect( mockedSetSelectedSiteId ).toHaveBeenCalledWith( null );
+		expect( context.store.dispatch ).toHaveBeenCalledTimes( 1 );
+		expect( context.secondary ).toBeTruthy();
+		expect( next ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'keeps the selected site on the per-site view', () => {
+		mockedGetSelectedSiteId.mockReturnValue( 123 );
+		const context = createContext( { site: 'example.com' } );
+		const next = jest.fn();
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial page.js context
+		pluginManagementContext( context as any, next );
+
+		expect( mockedSetSelectedSiteId ).not.toHaveBeenCalled();
+		expect( context.store.dispatch ).not.toHaveBeenCalled();
+		expect( context.secondary ).toBeUndefined();
+		expect( next ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/client/my-sites/plugins/controller.jsx
+++ b/client/my-sites/plugins/controller.jsx
@@ -109,7 +109,6 @@ export function renderPluginsDashboard( context, next ) {
 	context.primary = (
 		<PluginsDashboard
 			pluginSlug={ context.params.slug }
-			siteSlug={ context.params.site }
 			showOnlyUpdates={ context.query?.updates === '1' }
 		/>
 	);

--- a/client/my-sites/plugins/plugins-dashboard/index.tsx
+++ b/client/my-sites/plugins/plugins-dashboard/index.tsx
@@ -42,10 +42,9 @@ import {
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 import { getAllPlugins as getAllWporgPlugins } from 'calypso/state/plugins/wporg/selectors';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import getSelectedOrAllSites from 'calypso/state/selectors/get-selected-or-all-sites';
 import getSelectedOrAllSitesWithJetpackPlugin from 'calypso/state/selectors/get-selected-or-all-sites-with-jetpack-plugin';
-import getSites from 'calypso/state/selectors/get-sites';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { PluginActionName, PluginActions, Site } from '../hooks/types';
 import { withShowPluginActionDialog } from '../hooks/use-show-plugin-action-dialog';
 import PluginAvailableOnSitesList from '../plugin-management-v2/plugin-details-v2/plugin-available-on-sites-list';
@@ -64,7 +63,6 @@ type ActionCallbacks = Record< PluginActionName, PluginActionCallback >;
 
 interface PluginsDashboardProps {
 	pluginSlug: string;
-	siteSlug?: string;
 	showOnlyUpdates?: boolean;
 	doSearch: ( query: string ) => void; // prop coming from UrlSearch
 	search: string | undefined;
@@ -87,7 +85,6 @@ interface PluginsDashboardProps {
 
 const PluginsDashboard = ( {
 	pluginSlug,
-	siteSlug,
 	showOnlyUpdates = false,
 	doSearch,
 	search: searchTerm,
@@ -96,14 +93,11 @@ const PluginsDashboard = ( {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const isJetpackCloudOrA8CForAgencies = isJetpackCloud() || isA8CForAgencies();
-	const availableSites = useSelector( ( state ) =>
-		isA8CForAgencies() ? getSelectedOrAllSitesWithJetpackPlugin( state ) : getSites( state )
+	const allSites = useSelector( ( state ) =>
+		isA8CForAgencies()
+			? getSelectedOrAllSitesWithJetpackPlugin( state )
+			: getSelectedOrAllSites( state )
 	);
-	const selectedSite = useSelector( getSelectedSite );
-	let allSites = availableSites;
-	if ( siteSlug ) {
-		allSites = selectedSite ? [ selectedSite ] : [];
-	}
 	const siteIds = siteObjectsToSiteIds( allSites ) ?? [];
 	const wporgPlugins = useSelector( ( state ) => getAllWporgPlugins( state ) );
 	const isLoading = useSelector(
@@ -135,14 +129,15 @@ const PluginsDashboard = ( {
 	const sitesWithPlugin = useSelector( ( state ) =>
 		getSiteObjectsWithPlugin( state, siteIds, pluginSlug )
 	);
-	allSites.sort( orderByAtomic );
-	const sitesToShow = allSites.filter(
-		( item ): item is SiteDetails =>
-			item !== null &&
-			item !== undefined &&
-			! item?.options?.is_domain_only &&
-			! item?.options?.is_wpforteams_site
-	);
+	const sitesToShow = allSites
+		.filter(
+			( item ): item is SiteDetails =>
+				item !== null &&
+				item !== undefined &&
+				! item?.options?.is_domain_only &&
+				! item?.options?.is_wpforteams_site
+		)
+		.sort( orderByAtomic );
 
 	const sitesWithoutPluginAvailable = sitesToShow.filter(
 		( site ) =>
@@ -355,6 +350,9 @@ const PluginsDashboard = ( {
 				</LayoutTop>
 
 				<PluginsListDataViews
+					// The dashboard survives page.js navigations, so reset the view when the route
+					// switches between the "updates only" and the unfiltered plugin list.
+					key={ showOnlyUpdates ? 'updates' : 'all' }
 					pluginSlug={ pluginSlug }
 					currentPlugins={ currentPlugins }
 					initialSearch={ searchTerm }

--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -104,15 +104,7 @@ export default function PluginsListDataViews( {
 		};
 	} );
 
-	const [ isFilteringUpdates, setIsFilteringUpdates ] = useState( showOnlyUpdates );
-
-	useEffect( () => {
-		setDataViewsState( ( currentState ) => ( {
-			...currentState,
-			filters: showOnlyUpdates ? getUpdateFilters() : [],
-			page: 1,
-		} ) );
-	}, [ showOnlyUpdates ] );
+	const [ isFilteringUpdates, setIsFilteringUpdates ] = useState( false );
 
 	useEffect( () => {
 		// Sets the correct fields when route changes or viewport changes

--- a/client/my-sites/plugins/plugins-list/test/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/test/plugins-list-dataviews.tsx
@@ -7,7 +7,6 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { PLUGINS_STATUS } from 'calypso/state/plugins/installed/status/constants';
 import PluginsListDataViews from '../plugins-list-dataviews';
-import type { ComponentProps, ComponentType } from 'react';
 
 jest.mock( '@automattic/viewport', () => ( {
 	isDesktop: () => true,
@@ -40,34 +39,36 @@ jest.mock( '../use-fields', () => ( {
 	],
 } ) );
 
-type TestProps = ComponentProps< typeof PluginsListDataViews > & {
-	showOnlyUpdates: boolean;
-};
+const renderList = ( showOnlyUpdates: boolean ) => {
+	const store = configureStore()( {} );
 
-const TestablePluginsListDataViews = PluginsListDataViews as ComponentType< TestProps >;
+	render(
+		<Provider store={ store }>
+			<PluginsListDataViews
+				pluginSlug={ null }
+				currentPlugins={ [] }
+				isLoading={ false }
+				bulkActionDialog={ jest.fn() }
+				showOnlyUpdates={ showOnlyUpdates }
+			/>
+		</Provider>
+	);
+
+	return JSON.parse( screen.getByTestId( 'filters' ).textContent || '[]' );
+};
 
 describe( 'PluginsListDataViews', () => {
 	test( 'starts with the update-available filter active when requested by the route', () => {
-		const store = configureStore()( {} );
-
-		render(
-			<Provider store={ store }>
-				<TestablePluginsListDataViews
-					pluginSlug={ null }
-					currentPlugins={ [] }
-					isLoading={ false }
-					bulkActionDialog={ jest.fn() }
-					showOnlyUpdates
-				/>
-			</Provider>
-		);
-
-		expect( JSON.parse( screen.getByTestId( 'filters' ).textContent || '[]' ) ).toEqual( [
+		expect( renderList( true ) ).toEqual( [
 			{
 				field: 'status',
 				operator: 'isAny',
 				value: [ PLUGINS_STATUS.UPDATE ],
 			},
 		] );
+	} );
+
+	test( 'starts unfiltered otherwise', () => {
+		expect( renderList( false ) ).toEqual( [] );
 	} );
 } );

--- a/client/my-sites/plugins/test/controller-dashboard.js
+++ b/client/my-sites/plugins/test/controller-dashboard.js
@@ -5,21 +5,23 @@
 import { renderPluginsDashboard } from '../controller';
 
 describe( 'renderPluginsDashboard', () => {
-	test( 'passes the site and update filter from the route to the dashboard', () => {
-		const context = {
-			params: {
-				site: 'example.com',
-			},
-			query: {
-				updates: '1',
-			},
-		};
+	test( 'enables the update filter when the route asks for it', () => {
+		const context = { params: {}, query: { updates: '1' } };
 		const next = jest.fn();
 
 		renderPluginsDashboard( context, next );
 
-		expect( context.primary.props.siteSlug ).toBe( 'example.com' );
 		expect( context.primary.props.showOnlyUpdates ).toBe( true );
+		expect( next ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'leaves the update filter off by default', () => {
+		const context = { params: {}, query: {} };
+		const next = jest.fn();
+
+		renderPluginsDashboard( context, next );
+
+		expect( context.primary.props.showOnlyUpdates ).toBe( false );
 		expect( next ).toHaveBeenCalledTimes( 1 );
 	} );
 } );


### PR DESCRIPTION
Part of MANAGE-3. Stacked on #112533 — please review and merge that one first.

## Proposed Changes

* Send A4A plugin cells to wp-admin instead of a route A4A does not register.
* Replace the hand-rolled per-site narrowing with `getSelectedOrAllSites`, and restore the selected-site reset that makes it correct.
* Replace the `showOnlyUpdates` effect with a `key`.
* Move the status-link styling out of the shared component and into the Jetpack Cloud stylesheet.

## Why are these changes being made?

**The A4A regression.** The sites table in both Jetpack Manage and A4A renders its Backup, Scan, Monitor and Plugins cells through the same `SiteStatusContent` component, which asks `getLinks()` where each cell should point. `getLinks()` lives under `client/jetpack-cloud/`, but it is not Jetpack-Cloud-only: A4A reaches it from `client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx`.

#112533 changed the `plugin` case to return `/plugins/manage/:site` unconditionally. Jetpack Cloud registers that route, but A4A does not — its plugin section only registers `/plugins`, `/plugins/:slug`, `/plugins/manage/sites` and `/plugins/manage/sites/:slug`, because plugin management there shipped as an MVP without a per-site view. A4A has no catch-all either, so clicking the Plugins cell on `/sites` now navigates to a URL that matches nothing and renders nothing.

Worth noting: A4A's non-Atomic sites were already broken before #112533, since the previous link (`/plugins/updates/:site`) also stopped routing anywhere when the plugins screen moved to DataViews in #97697. What #112533 changed is that it removed the `isAtomicSite` branch that was still sending Atomic sites to wp-admin, which is what made the breakage visible. So this fixes both cases rather than just restoring the old behaviour.

A4A already has a stated position on where plugin management should go while the dashboard version is unbuilt. Its own site preview pane links the Plugins tab to wp-admin, with the caption:

> Note: We are currently working to make this section function from the Automattic for Agencies dashboard. In the meantime, you'll be taken to WP-Admin.

This change makes the Plugins cell agree with that. Jetpack Manage keeps `/plugins/manage/:site?updates=1`, Atomic sites included.

**The simplifications.** Three parts of #112533 do more work than the result needs.

*Per-site scoping.* #112533 threads a `siteSlug` prop from the route controller into `PluginsDashboard`, then uses it to narrow the site list to the selected site. `getSelectedOrAllSites` is exactly that logic and already exists; the A4A branch of the same selector call was already getting it transitively through `getSelectedOrAllSitesWithJetpackPlugin`. Only the `getSites` branch was missing it.

The reason that swap was not already possible is a separate gap. `/plugins/manage/:site` selects a site, and in Jetpack Cloud nothing clears it afterwards, so the multi-site views would stay scoped to whichever site you visited last. wpcom handles this with the `noSite` middleware and A4A with `resetSite`; Jetpack Cloud's pre-DataViews screen did it itself, and that was dropped in #97697. This adds it back to `pluginManagementContext`, which also fixes the stale-scoping bug on its own. It mirrors A4A's four-line reset rather than importing `noSite`, which runs checkout-path predicates and can trigger a redirect.

*The update filter.* #112533 pre-applies the filter in the `useState` initialiser and then re-applies it from a `useEffect`. The effect is not redundant — `PluginsDashboard` survives page.js navigations, and clicking a plugin's site count navigates from `?updates=1` to the unfiltered list, so something does have to reset the filter on a route change. But the effect fires a second state write on mount, and it overwrites the whole `filters` array, so it also discards any filter the user set through the DataViews chrome. A `key` handles the route change without either problem.

*Status link styling.* #112533 adds a `sites-overview__warning-link` class to `SiteStatusColumn` to stop the underline rendering in link blue under orange text. A4A hit the same bug and fixed it in its own stylesheet, with a comment explaining the scoping choice:

> Scoped here rather than on the shared status column, which Jetpack Cloud also renders. The hover underline sits on the value so it picks up the status color; on the anchor it would resolve to the link blue instead.

Since `sites-overview/style.scss` is never loaded in A4A, the class was inert markup there. This adds the matching rule to the Jetpack Cloud stylesheet instead. The Threats link has the identical bug and gets fixed by the same rule. One behaviour difference to flag: this removes the resting underline, matching A4A, rather than recolouring it.

## Testing Instructions

Prerequisites: an agency account with at least one site that has plugin updates available. Check out `fix/manage-3-a4a-plugin-link`.

### 1. The A4A fix

```
yarn start-a8c-for-agencies
```

1. Open `http://agencies.localhost:3000/sites`.
2. Find a site whose Plugins cell shows a number of available updates (orange text).
3. Click the cell.
4. Verify it opens `https://<site>/wp-admin/plugins.php` in a new tab. On `trunk` + #112533 this navigates to a blank page instead.
5. Repeat on a site whose Plugins cell shows no updates available. Verify it also opens wp-admin.

### 2. Jetpack Manage is unchanged

```
yarn start-jetpack-cloud
```

1. Open `http://jetpack.cloud.localhost:3000/dashboard`.
2. Click a Plugins cell showing available updates.
3. Verify you land on `/plugins/manage/<site>?updates=1`, the list contains only that site's plugins, and the "Update available (N)" button is already active with no unfiltered flash first.
4. Click a Plugins cell on a site with no updates. Verify you land on `/plugins/manage/<site>` with the full plugin list and the filter off.

### 3. The selected-site reset

1. From step 2, while still on `/plugins/manage/<site>?updates=1`, click the site count next to any plugin.
2. Verify you land on `/plugins/manage/sites/<plugin>`, the list shows **all** your sites rather than only the one you came from, and the update filter is off.
3. Navigate to `/plugins/manage/sites` from the sidebar. Verify it lists all sites.

On `trunk` + #112533, steps 2 and 3 stay scoped to the site visited in step 2.

### 4. Filters set by hand are not discarded

1. Go to `/plugins/manage/sites`.
2. Open the DataViews filter chrome and apply any status filter.
3. Search for something in the same view.
4. Verify your filter is still applied after the search.

### 5. wpcom is unaffected

```
yarn start
```

1. Open `http://calypso.localhost:3000/plugins/manage/sites`.
2. Verify the plugin list renders as it does on `trunk`.

### Automated

```
yarn test-client client/jetpack-cloud/sections/agency-dashboard client/jetpack-cloud/sections/plugin-management client/my-sites/plugins
yarn typecheck-client
```

76 suites / 457 tests pass. `typecheck-client` reports two pre-existing errors in `client/my-sites/plugins/plugins-dashboard/index.tsx` (implicit `any` at lines 144 and 306); both are present on `trunk` and are untouched here.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
