### PR TITLE
Jetpack Manage: Fix plugin status links and filter updates by site

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/test/site-card.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/test/site-card.tsx
@@ -82,7 +82,7 @@ describe( '<SiteCard>', () => {
 			},
 			monitor: { error: false, type: 'monitor', status: 'inactive', value: '' },
 			scan: { threats: 3, type: 'scan', status: 'failed', value: '3 Threats' },
-			plugin: { updates: 3, type: 'plugin', status: 'warning', value: '3 Available' },
+			plugin: { updates: 3, type: 'plugin', status: 'warning', value: '3 Updates' },
 		};
 		const initialState = {
 			partnerPortal: {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/test/use-formatted-sites.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/test/use-formatted-sites.ts
@@ -143,8 +143,23 @@ describe( 'useFormattedSites', () => {
 			status: 'warning',
 			type: 'plugin',
 			updates: 1,
-			value: '1 Available',
+			value: '1 Update',
 		} );
+	} );
+
+	it( 'should pluralize plugin updates for the given sites', () => {
+		const {
+			result: { current: formattedSites },
+		} = renderHook( () =>
+			useFormattedSites( [
+				{
+					...FAKE_SITE,
+					awaiting_plugin_updates: [ 'plugin1', 'plugin2' ],
+				},
+			] )
+		);
+
+		expect( formattedSites[ 0 ].plugin.value ).toEqual( '2 Updates' );
 	} );
 
 	it( 'should return correct "stats" data for the given sites', () => {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
@@ -174,11 +174,17 @@ const useFormatPluginData = () => {
 					updates: 0,
 				};
 			}
+			const updateCount = pluginUpdates.length;
 			return {
-				value: `${ pluginUpdates?.length } ${ translate( 'Available' ) }`,
-				status: pluginUpdates?.length > 0 ? 'warning' : 'success',
+				value: translate( '%(updates)d Update', '%(updates)d Updates', {
+					count: updateCount,
+					args: {
+						updates: updateCount,
+					},
+				} ) as string,
+				status: updateCount > 0 ? 'warning' : 'success',
 				type: 'plugin',
-				updates: pluginUpdates?.length,
+				updates: updateCount,
 			};
 		},
 		[ translate ]

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/test/use-row-metadata.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/test/use-row-metadata.ts
@@ -98,7 +98,7 @@ const rows: SiteData = {
 	plugin: {
 		updates: pluginUpdates.length,
 		type: 'plugin',
-		value: `${ pluginUpdates.length } Available`,
+		value: `${ pluginUpdates.length } Updates`,
 		status: 'warning',
 	},
 	stats: {
@@ -259,7 +259,7 @@ describe( 'useRowMetadata', () => {
 		const expected = {
 			eventName: 'calypso_jetpack_agency_dashboard_update_plugins_click_small_screen',
 			isExternalLink: false,
-			link: `/plugins/updates/${ FAKE_SITE.url }`,
+			link: `/plugins/manage/${ FAKE_SITE.url }?updates=1`,
 			isSupported: true,
 			row: rows.plugin,
 			siteDown: false,
@@ -267,6 +267,28 @@ describe( 'useRowMetadata', () => {
 			tooltipId: `${ FAKE_SITE.blog_id }-plugin`,
 		};
 		expect( metadata ).toEqual( expected );
+	} );
+
+	it( 'should return the plugin management link for Atomic sites', () => {
+		jest.spyOn( useIsMultisiteSupported, 'default' ).mockReturnValue( true );
+		const {
+			result: { current: metadata },
+		} = renderHook( () =>
+			useRowMetadata(
+				{
+					...rows,
+					site: {
+						...rows.site,
+						value: { ...FAKE_SITE, is_atomic: true },
+					},
+				},
+				'plugin',
+				false
+			)
+		);
+
+		expect( metadata.link ).toEqual( `/plugins/manage/${ FAKE_SITE.url }?updates=1` );
+		expect( metadata.isExternalLink ).toBe( false );
 	} );
 
 	it( 'should return the expected Stats metadata', () => {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { AllowedTypes } from '../../types';
 
@@ -65,15 +66,17 @@ const getLinks = (
 			break;
 		}
 		case 'plugin': {
-			link = `${ siteUrlWithScheme }/wp-admin/plugins.php`;
-			isExternalLink = true;
-			if ( ! isAtomicSite ) {
-				link =
-					status === 'warning'
-						? `/plugins/updates/${ siteUrlWithMultiSiteSupport }`
-						: `/plugins/manage/${ siteUrlWithMultiSiteSupport }`;
-				isExternalLink = false;
+			// A4A has no per-site plugin management yet, so agencies go to wp-admin — the same
+			// destination as the Plugins tab of the site preview pane.
+			if ( isA8CForAgencies() ) {
+				link = `${ siteUrlWithScheme }/wp-admin/plugins.php`;
+				isExternalLink = true;
+				break;
 			}
+
+			link = `/plugins/manage/${ siteUrlWithMultiSiteSupport }${
+				status === 'warning' ? '?updates=1' : ''
+			}`;
 			break;
 		}
 	}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/test/get-links.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/test/get-links.ts
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment node
+ */
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
+import getLinks from '../get-links';
+
+jest.mock( 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies' );
+
+const mockedIsA8CForAgencies = isA8CForAgencies as jest.MockedFunction< typeof isA8CForAgencies >;
+
+const SITE_URL = 'test.wordpress.com';
+const SITE_URL_WITH_SCHEME = 'https://test.wordpress.com';
+
+const getPluginLink = ( status: string, isAtomicSite = false ) =>
+	getLinks( 'plugin', status, SITE_URL, SITE_URL_WITH_SCHEME, isAtomicSite );
+
+describe( 'getLinks', () => {
+	describe( 'plugin, in A4A', () => {
+		beforeEach( () => {
+			mockedIsA8CForAgencies.mockReturnValue( true );
+		} );
+
+		it( 'links to wp-admin when updates are available', () => {
+			expect( getPluginLink( 'warning' ) ).toEqual( {
+				link: `${ SITE_URL_WITH_SCHEME }/wp-admin/plugins.php`,
+				isExternalLink: true,
+			} );
+		} );
+
+		it( 'links to wp-admin when plugins are up to date', () => {
+			expect( getPluginLink( 'success' ) ).toEqual( {
+				link: `${ SITE_URL_WITH_SCHEME }/wp-admin/plugins.php`,
+				isExternalLink: true,
+			} );
+		} );
+
+		it( 'links to wp-admin for Atomic sites', () => {
+			expect( getPluginLink( 'warning', true ) ).toEqual( {
+				link: `${ SITE_URL_WITH_SCHEME }/wp-admin/plugins.php`,
+				isExternalLink: true,
+			} );
+		} );
+	} );
+
+	describe( 'plugin, in Jetpack Manage', () => {
+		beforeEach( () => {
+			mockedIsA8CForAgencies.mockReturnValue( false );
+		} );
+
+		it( 'links to the plugin dashboard filtered by updates when updates are available', () => {
+			expect( getPluginLink( 'warning' ) ).toEqual( {
+				link: `/plugins/manage/${ SITE_URL }?updates=1`,
+				isExternalLink: false,
+			} );
+		} );
+
+		it( 'links to the unfiltered plugin dashboard when plugins are up to date', () => {
+			expect( getPluginLink( 'success' ) ).toEqual( {
+				link: `/plugins/manage/${ SITE_URL }`,
+				isExternalLink: false,
+			} );
+		} );
+
+		it( 'links Atomic sites to the plugin dashboard too', () => {
+			expect( getPluginLink( 'warning', true ) ).toEqual( {
+				link: `/plugins/manage/${ SITE_URL }?updates=1`,
+				isExternalLink: false,
+			} );
+		} );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/test/site-table-row.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/test/site-table-row.tsx
@@ -106,7 +106,7 @@ describe( '<SiteTableRow>', () => {
 		plugin: {
 			updates: pluginUpdates.length,
 			type: 'plugin',
-			value: `${ pluginUpdates.length } ${ translate( 'Available' ) }`,
+			value: `${ pluginUpdates.length } Updates`,
 			status: 'warning',
 		},
 	};

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
@@ -110,7 +110,7 @@ describe( '<SiteTable>', () => {
 			plugin: {
 				updates: pluginUpdates.length,
 				type: 'plugin',
-				value: `${ pluginUpdates.length } ${ translate( 'Available' ) }`,
+				value: `${ pluginUpdates.length } Updates`,
 				status: 'warning',
 			},
 		},
@@ -190,8 +190,8 @@ describe( '<SiteTable>', () => {
 
 		const pluginEle = getByTestId( `row-${ blogId }-plugin` );
 		expect( pluginEle.getAttribute( 'href' ) ).toEqual(
-			`/plugins/updates/${ urlToSlug( siteUrl ) }`
+			`/plugins/manage/${ urlToSlug( siteUrl ) }?updates=1`
 		);
-		expect( getByText( `${ pluginUpdates.length } Available` ) ).toBeInTheDocument();
+		expect( getByText( `${ pluginUpdates.length } Updates` ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -500,6 +500,17 @@
 	color: var(--color-warning-50);
 }
 
+// Mirrors the A4A rule in sections/sites/sites-dashboard/style.scss. The hover underline sits on
+// the value so it picks up the status color; on the anchor it would resolve to the link blue.
+.sites-overview__row-status > a {
+	text-decoration: none;
+
+	&:hover > *,
+	&:focus-visible > * {
+		text-decoration: underline;
+	}
+}
+
 .sites-overview__failed {
 	@extend .sites-overview__column-content;
 	color: var(--studio-red-50);

--- a/client/jetpack-cloud/sections/plugin-management/controller.tsx
+++ b/client/jetpack-cloud/sections/plugin-management/controller.tsx
@@ -1,6 +1,8 @@
 import page, { type Callback, type Context } from '@automattic/calypso-router';
 import JetpackManageSidebar from 'calypso/jetpack-cloud/sections/sidebar-navigation/jetpack-manage';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import Header from '../agency-dashboard/header';
 import PluginsOverview from './plugins-overview';
 
@@ -24,6 +26,11 @@ export const pluginManagementContext: Callback = ( context, next ) => {
 	context.header = <Header />;
 	// Set secondary context only on multi-site view
 	if ( ! site ) {
+		// `/plugins/manage/:site` selects a site and nothing downstream clears it, so the
+		// multi-site views would otherwise stay scoped to whichever site was visited last.
+		if ( getSelectedSiteId( context.store.getState() ) ) {
+			context.store.dispatch( setSelectedSiteId( null ) );
+		}
 		setSidebar( context );
 	}
 	next();

--- a/client/jetpack-cloud/sections/plugin-management/index.ts
+++ b/client/jetpack-cloud/sections/plugin-management/index.ts
@@ -30,6 +30,7 @@ export default function (): void {
 	page(
 		'/plugins/manage/:site',
 		scrollTopIfNoHash,
+		siteSelection,
 		navigation,
 		pluginManagementContext,
 		renderPluginsDashboard,

--- a/client/jetpack-cloud/sections/plugin-management/test/controller.tsx
+++ b/client/jetpack-cloud/sections/plugin-management/test/controller.tsx
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { pluginManagementContext } from '../controller';
+
+jest.mock( 'calypso/state/partner-portal/partner/selectors' );
+jest.mock( 'calypso/state/ui/actions' );
+jest.mock( 'calypso/state/ui/selectors' );
+
+const mockedIsAgencyUser = isAgencyUser as jest.MockedFunction< typeof isAgencyUser >;
+const mockedSetSelectedSiteId = setSelectedSiteId as jest.MockedFunction<
+	typeof setSelectedSiteId
+>;
+const mockedGetSelectedSiteId = getSelectedSiteId as jest.MockedFunction<
+	typeof getSelectedSiteId
+>;
+
+const createContext = ( params: { site?: string } ) => ( {
+	params,
+	path: '/plugins/manage/sites',
+	secondary: undefined as unknown,
+	store: {
+		getState: () => ( {} ),
+		dispatch: jest.fn(),
+	},
+} );
+
+describe( 'pluginManagementContext', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockedIsAgencyUser.mockReturnValue( true );
+	} );
+
+	test( 'clears the selected site on the multi-site view', () => {
+		mockedGetSelectedSiteId.mockReturnValue( 123 );
+		const context = createContext( {} );
+		const next = jest.fn();
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial page.js context
+		pluginManagementContext( context as any, next );
+
+		expect( mockedSetSelectedSiteId ).toHaveBeenCalledWith( null );
+		expect( context.store.dispatch ).toHaveBeenCalledTimes( 1 );
+		expect( context.secondary ).toBeTruthy();
+		expect( next ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'keeps the selected site on the per-site view', () => {
+		mockedGetSelectedSiteId.mockReturnValue( 123 );
+		const context = createContext( { site: 'example.com' } );
+		const next = jest.fn();
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial page.js context
+		pluginManagementContext( context as any, next );
+
+		expect( mockedSetSelectedSiteId ).not.toHaveBeenCalled();
+		expect( context.store.dispatch ).not.toHaveBeenCalled();
+		expect( context.secondary ).toBeUndefined();
+		expect( next ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/client/my-sites/plugins/controller.jsx
+++ b/client/my-sites/plugins/controller.jsx
@@ -106,7 +106,12 @@ export function plugins( context, next ) {
 }
 
 export function renderPluginsDashboard( context, next ) {
-	context.primary = <PluginsDashboard pluginSlug={ context.params.slug } />;
+	context.primary = (
+		<PluginsDashboard
+			pluginSlug={ context.params.slug }
+			showOnlyUpdates={ context.query?.updates === '1' }
+		/>
+	);
 	next();
 }
 

--- a/client/my-sites/plugins/plugins-dashboard/index.tsx
+++ b/client/my-sites/plugins/plugins-dashboard/index.tsx
@@ -42,8 +42,8 @@ import {
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 import { getAllPlugins as getAllWporgPlugins } from 'calypso/state/plugins/wporg/selectors';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import getSelectedOrAllSites from 'calypso/state/selectors/get-selected-or-all-sites';
 import getSelectedOrAllSitesWithJetpackPlugin from 'calypso/state/selectors/get-selected-or-all-sites-with-jetpack-plugin';
-import getSites from 'calypso/state/selectors/get-sites';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
 import { PluginActionName, PluginActions, Site } from '../hooks/types';
 import { withShowPluginActionDialog } from '../hooks/use-show-plugin-action-dialog';
@@ -63,6 +63,7 @@ type ActionCallbacks = Record< PluginActionName, PluginActionCallback >;
 
 interface PluginsDashboardProps {
 	pluginSlug: string;
+	showOnlyUpdates?: boolean;
 	doSearch: ( query: string ) => void; // prop coming from UrlSearch
 	search: string | undefined;
 	showPluginActionDialog: (
@@ -84,6 +85,7 @@ interface PluginsDashboardProps {
 
 const PluginsDashboard = ( {
 	pluginSlug,
+	showOnlyUpdates = false,
 	doSearch,
 	search: searchTerm,
 	showPluginActionDialog,
@@ -92,7 +94,9 @@ const PluginsDashboard = ( {
 	const translate = useTranslate();
 	const isJetpackCloudOrA8CForAgencies = isJetpackCloud() || isA8CForAgencies();
 	const allSites = useSelector( ( state ) =>
-		isA8CForAgencies() ? getSelectedOrAllSitesWithJetpackPlugin( state ) : getSites( state )
+		isA8CForAgencies()
+			? getSelectedOrAllSitesWithJetpackPlugin( state )
+			: getSelectedOrAllSites( state )
 	);
 	const siteIds = siteObjectsToSiteIds( allSites ) ?? [];
 	const wporgPlugins = useSelector( ( state ) => getAllWporgPlugins( state ) );
@@ -125,14 +129,15 @@ const PluginsDashboard = ( {
 	const sitesWithPlugin = useSelector( ( state ) =>
 		getSiteObjectsWithPlugin( state, siteIds, pluginSlug )
 	);
-	allSites.sort( orderByAtomic );
-	const sitesToShow = allSites.filter(
-		( item ): item is SiteDetails =>
-			item !== null &&
-			item !== undefined &&
-			! item?.options?.is_domain_only &&
-			! item?.options?.is_wpforteams_site
-	);
+	const sitesToShow = allSites
+		.filter(
+			( item ): item is SiteDetails =>
+				item !== null &&
+				item !== undefined &&
+				! item?.options?.is_domain_only &&
+				! item?.options?.is_wpforteams_site
+		)
+		.sort( orderByAtomic );
 
 	const sitesWithoutPluginAvailable = sitesToShow.filter(
 		( site ) =>
@@ -345,9 +350,13 @@ const PluginsDashboard = ( {
 				</LayoutTop>
 
 				<PluginsListDataViews
+					// The dashboard survives page.js navigations, so reset the view when the route
+					// switches between the "updates only" and the unfiltered plugin list.
+					key={ showOnlyUpdates ? 'updates' : 'all' }
 					pluginSlug={ pluginSlug }
 					currentPlugins={ currentPlugins }
 					initialSearch={ searchTerm }
+					showOnlyUpdates={ showOnlyUpdates }
 					isLoading={ isLoading }
 					onSearch={ doSearch }
 					bulkActionDialog={ bulkActionDialog }

--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -26,10 +26,19 @@ interface Props {
 	pluginSlug: string | null;
 	currentPlugins: Array< Plugin >;
 	initialSearch?: string;
+	showOnlyUpdates?: boolean;
 	isLoading: boolean;
 	onSearch?: ( search: string ) => void;
 	bulkActionDialog: ( action: string, plugins: Array< Plugin > ) => void;
 }
+
+const getUpdateFilters = (): NonNullable< DataViewsState[ 'filters' ] > => [
+	{
+		field: 'status',
+		operator: 'isAny',
+		value: [ PLUGINS_STATUS.UPDATE ],
+	},
+];
 
 const openPluginSitesPane = ( plugin: Plugin ) => {
 	recordTracksEvent( 'calypso_plugins_list_open_plugin_sites_pane', {
@@ -42,6 +51,7 @@ export default function PluginsListDataViews( {
 	pluginSlug,
 	currentPlugins,
 	initialSearch,
+	showOnlyUpdates = false,
 	isLoading,
 	onSearch,
 	bulkActionDialog,
@@ -67,6 +77,7 @@ export default function PluginsListDataViews( {
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( () => {
 		return {
 			...initialDataViewsState,
+			filters: showOnlyUpdates ? getUpdateFilters() : [],
 			perPage: 15,
 			search: initialSearch,
 			fields: [ 'sites', 'update' ],
@@ -130,13 +141,7 @@ export default function PluginsListDataViews( {
 						} else {
 							setDataViewsState( {
 								...dataViewsState,
-								filters: [
-									{
-										field: 'status',
-										operator: 'isAny',
-										value: [ PLUGINS_STATUS.UPDATE ],
-									},
-								],
+								filters: getUpdateFilters(),
 								page: 1,
 							} );
 						}

--- a/client/my-sites/plugins/plugins-list/test/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/test/plugins-list-dataviews.tsx
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { PLUGINS_STATUS } from 'calypso/state/plugins/installed/status/constants';
+import PluginsListDataViews from '../plugins-list-dataviews';
+
+jest.mock( '@automattic/viewport', () => ( {
+	isDesktop: () => true,
+	subscribeIsDesktop: () => () => {},
+} ) );
+
+jest.mock( 'calypso/components/data/query-dotorg-plugins', () => () => null );
+
+jest.mock( 'calypso/components/dataviews', () => ( {
+	DataViews: ( { view }: { view: { filters: unknown[] } } ) => (
+		<div data-testid="filters">{ JSON.stringify( view.filters ) }</div>
+	),
+} ) );
+
+jest.mock( 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies', () => () => false );
+
+jest.mock( '../use-actions', () => ( {
+	useActions: () => [],
+} ) );
+
+jest.mock( '../use-fields', () => ( {
+	useFields: () => [
+		{
+			id: 'status',
+			getValue: ( { item }: { item: { status: number[] } } ) => item.status,
+			filterBy: {
+				operators: [ 'isAny' ],
+			},
+		},
+	],
+} ) );
+
+const renderList = ( showOnlyUpdates: boolean ) => {
+	const store = configureStore()( {} );
+
+	render(
+		<Provider store={ store }>
+			<PluginsListDataViews
+				pluginSlug={ null }
+				currentPlugins={ [] }
+				isLoading={ false }
+				bulkActionDialog={ jest.fn() }
+				showOnlyUpdates={ showOnlyUpdates }
+			/>
+		</Provider>
+	);
+
+	return JSON.parse( screen.getByTestId( 'filters' ).textContent || '[]' );
+};
+
+describe( 'PluginsListDataViews', () => {
+	test( 'starts with the update-available filter active when requested by the route', () => {
+		expect( renderList( true ) ).toEqual( [
+			{
+				field: 'status',
+				operator: 'isAny',
+				value: [ PLUGINS_STATUS.UPDATE ],
+			},
+		] );
+	} );
+
+	test( 'starts unfiltered otherwise', () => {
+		expect( renderList( false ) ).toEqual( [] );
+	} );
+} );

--- a/client/my-sites/plugins/test/controller-dashboard.js
+++ b/client/my-sites/plugins/test/controller-dashboard.js
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderPluginsDashboard } from '../controller';
+
+describe( 'renderPluginsDashboard', () => {
+	test( 'enables the update filter when the route asks for it', () => {
+		const context = { params: {}, query: { updates: '1' } };
+		const next = jest.fn();
+
+		renderPluginsDashboard( context, next );
+
+		expect( context.primary.props.showOnlyUpdates ).toBe( true );
+		expect( next ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'leaves the update filter off by default', () => {
+		const context = { params: {}, query: {} };
+		const next = jest.fn();
+
+		renderPluginsDashboard( context, next );
+
+		expect( context.primary.props.showOnlyUpdates ).toBe( false );
+		expect( next ).toHaveBeenCalledTimes( 1 );
+	} );
+} );


### PR DESCRIPTION
Fixes MANAGE-3

## Proposed Changes

* Point the Plugins cell in the sites table at a route that exists, per app: `/plugins/manage/:site` in Jetpack Manage, wp-admin in A4A.
* Carry `?updates=1` when the site has updates pending, and honour it in the plugin dashboard.
* Scope `/plugins/manage/:site` to the site in the URL, and clear that selection when returning to the multi-site views.
* Say "3 Updates" instead of "3 Available", and stop the cell's link underline rendering in link blue under status-coloured text.

## Why are these changes being made?

The sites table in Jetpack Manage has a Plugins column showing how many plugin updates each site has pending. The cell is a link, and `getLinks()` decides where each status cell points.

**The link went nowhere.** For a site with updates pending, `getLinks()` returned `/plugins/updates/:site`. Jetpack Cloud used to register that path as part of a `:filter(manage|active|inactive|updates)` route, but the route was dropped when the plugins screen moved to DataViews in #97697. Nothing has served `/plugins/updates/:site` since, so clicking the cell rendered a blank page. This restores a working destination by pointing at `/plugins/manage/:site`, which does route, and re-adds the `siteSelection` middleware that #97697 also dropped from it.

**The destination was not scoped or filtered.** `/plugins/manage/:site` renders `PluginsDashboard`, which listed every site's plugins regardless of the `:site` in the URL, and listed them unfiltered. So even once the link worked, a user who clicked "3 Updates" on one site landed in a full multi-site plugin list and had to hunt for the site they had just clicked. The controller now reads `?updates=1` to pre-apply the update filter, and the site list comes from the existing `getSelectedOrAllSites` selector.

That selector only behaves correctly if the selected site is cleared when returning to the multi-site view. wpcom does this with the `noSite` middleware and A4A with `resetSite`; Jetpack Cloud's pre-DataViews screen did it itself, and that was lost in #97697 too. Adding it back to `pluginManagementContext` is what makes the selector safe here, and it independently fixes `/plugins/manage/sites` staying scoped to whichever site you visited last.

**`getLinks()` is not Jetpack-Cloud-only.** Despite living under `client/jetpack-cloud/`, it is reached from A4A as well: `/sites` renders the same Plugins column through `SiteStatusContent`. The two apps have different plugin-management capabilities. Jetpack Manage has a full plugin section with a per-site route; A4A shipped plugin management as an MVP and registers only `/plugins`, `/plugins/:slug`, `/plugins/manage/sites` and `/plugins/manage/sites/:slug`. Sending every plugin cell to `/plugins/manage/:site` would give A4A a URL matching none of its routes, and it has no catch-all.

A4A already has a stated position on where plugin management should go while the dashboard version is unbuilt. Its own site preview pane links the Plugins tab to wp-admin, with the caption:

> Note: We are currently working to make this section function from the Automattic for Agencies dashboard. In the meantime, you'll be taken to WP-Admin.

So A4A's plugin cell now opens wp-admin. This also fixes A4A's non-Atomic sites, which were pointed at the same dead `/plugins/updates/:site` as Jetpack Manage.

**Copy and styling.** "3 Available" does not say what is available; it now reads "3 Updates", pluralized. Separately, base Calypso styles anchors with a link colour but no `text-decoration`, so the cell rendered a blue underline beneath orange status text. A4A hit this and fixed it in its own stylesheet, with a comment explaining the scoping choice:

> Scoped here rather than on the shared status column, which Jetpack Cloud also renders. The hover underline sits on the value so it picks up the status color; on the anchor it would resolve to the link blue instead.

This adds the matching rule to the Jetpack Cloud stylesheet. The Threats link has the identical bug and is fixed by the same rule. Note this removes the resting underline, matching A4A, rather than recolouring it.

## Testing Instructions

Prerequisites: an agency account with at least one site that has plugin updates available, and at least one site that does not. Check out `fix/manage-3-plugin-status-links`.

### 1. Jetpack Manage: the link works and lands scoped and filtered

```
yarn start-jetpack-cloud
```

1. Open `http://jetpack.cloud.localhost:3000/dashboard`.
2. Find a site whose Plugins cell shows pending updates. Verify it reads e.g. "3 Updates", not "3 Available".
3. Verify the cell text and its underline are both orange, with no blue underline.
4. Click the cell.
5. Verify you land on `/plugins/manage/<site>?updates=1`, the list contains only that site's plugins, and the "Update available (N)" button is already active with no unfiltered flash first.

On `trunk`, step 4 renders a blank page.

### 2. Jetpack Manage: sites with no pending updates

1. Back on `/dashboard`, click the Plugins cell of a site showing no updates available.
2. Verify you land on `/plugins/manage/<site>` with that site's full plugin list and the update filter off.

### 3. Jetpack Manage: the multi-site views are not left scoped

1. From step 1, while on `/plugins/manage/<site>?updates=1`, click the site count next to any plugin.
2. Verify you land on `/plugins/manage/sites/<plugin>` and it shows **all** your sites, not only the one you came from, with the update filter off.
3. Open `/plugins/manage/sites` from the sidebar. Verify it lists all sites.

On `trunk`, steps 2 and 3 stay scoped to the site from step 1.

### 4. Filters set by hand survive a search

1. Go to `/plugins/manage/sites`.
2. Open the DataViews filter chrome and apply any status filter.
3. Search for a plugin name in the same view.
4. Verify your filter is still applied.

### 5. A4A: the cell opens wp-admin

```
yarn start-a8c-for-agencies
```

1. Open `http://agencies.localhost:3000/sites`.
2. Click the Plugins cell of a site with pending updates.
3. Verify it opens `https://<site>/wp-admin/plugins.php` in a new tab.
4. Repeat on a site with no pending updates. Verify it also opens wp-admin.

On `trunk`, step 2 renders a blank page for non-Atomic sites.

### 6. wpcom is unaffected

```
yarn start
```

1. Open `http://calypso.localhost:3000/plugins/manage/sites`.
2. Verify the plugin list renders as it does on `trunk`.

### Automated

```
yarn test-client client/jetpack-cloud/sections/agency-dashboard client/jetpack-cloud/sections/plugin-management client/my-sites/plugins
yarn typecheck-client
```

76 suites / 457 tests pass. `typecheck-client` reports two pre-existing errors in `client/my-sites/plugins/plugins-dashboard/index.tsx` (implicit `any` at lines 144 and 306); both are present on `trunk` and are untouched here.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
