### PR TITLE
Playground: Prefer saved sites over retained Blueprint IDs

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -33,7 +33,10 @@ import { isPlanProductFree } from '../../../../../../packages/data-stores/src/pl
 import { useFlowLocale } from '../../../hooks/use-flow-locale';
 import { useQuery } from '../../../hooks/use-query';
 import { ONBOARD_STORE, SITE_STORE } from '../../../stores';
-import { getBlueprintArchiveSiteSpecUrl } from '../../../utils/blueprint-archive-import';
+import {
+	getBlueprintArchiveSiteSpecUrl,
+	getStandaloneBlueprintArchiveSlug,
+} from '../../../utils/blueprint-archive-import';
 import {
 	getBuildWowSiteIdentifier,
 	getBuildWowSiteSpecUrl,
@@ -100,6 +103,7 @@ const onboarding: FlowV2< typeof initialize > = {
 		const { setShouldShowNotification } = usePurchasePlanNotification();
 
 		const playgroundId = queryParams.get( 'playground' );
+		const blueprintArchiveSlug = getStandaloneBlueprintArchiveSlug( blueprint, playgroundId );
 
 		/**
 		 * Returns [destination, backDestination] for the post-checkout destination.
@@ -127,12 +131,12 @@ const onboarding: FlowV2< typeof initialize > = {
 				// setup-your-site-ai chooser. Land on the AI site-spec, which kicks off
 				// the background transfer-to-Atomic + blueprint-archive import and, on
 				// confirm, polls the import and redirects to the Atomic Site Editor.
-				if ( blueprint ) {
+				if ( blueprintArchiveSlug ) {
 					return [
 						getBlueprintArchiveSiteSpecUrl( {
 							siteSlug: providedDependencies.siteSlug as string,
 							siteId: providedDependencies.siteId as number,
-							blueprintSlug: blueprint,
+							blueprintSlug: blueprintArchiveSlug,
 							ref: refParameter,
 						} ),
 						null,
@@ -421,7 +425,7 @@ const onboarding: FlowV2< typeof initialize > = {
 								addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
 									// Blueprint archive flow goes straight from checkout to the AI
 									// site-spec (no post-checkout-onboarding hop, no chooser).
-									redirect_to: blueprint ? destination : redirectTo,
+									redirect_to: blueprintArchiveSlug ? destination : redirectTo,
 									signup: 1,
 									flow: ONBOARDING_FLOW,
 									checkoutBackUrl: pathToUrl( backDestination ?? '' ),
@@ -433,7 +437,7 @@ const onboarding: FlowV2< typeof initialize > = {
 									steps_total: checkoutStepperPosition.total,
 								} )
 							);
-						} else if ( blueprint ) {
+						} else if ( blueprintArchiveSlug ) {
 							// Blueprint archive flow never shows the setup-your-site-ai chooser;
 							// go straight to the AI site-spec destination.
 							window.location.replace( destination );

--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -8,6 +8,13 @@ export const BLUEPRINT_ARCHIVE_IMPORT_QUERY_VALUE = '1';
 // Reuse the flow that already hosts the AI site-spec step.
 const BLUEPRINT_ARCHIVE_SITE_SPEC_PATH = '/setup/ai-site-builder-spec/site-spec';
 
+export function getStandaloneBlueprintArchiveSlug(
+	blueprint: string | null,
+	playgroundId: string | null
+): string | null {
+	return playgroundId ? null : blueprint;
+}
+
 type ImportStatusResponse = {
 	importId?: string | null;
 	siteId?: number | null;

--- a/client/landing/stepper/utils/test/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/test/blueprint-archive-import.ts
@@ -1,0 +1,11 @@
+import { getStandaloneBlueprintArchiveSlug } from '../blueprint-archive-import';
+
+describe( 'getStandaloneBlueprintArchiveSlug', () => {
+	it( 'returns the Blueprint archive slug when there is no Playground ID', () => {
+		expect( getStandaloneBlueprintArchiveSlug( 'coaching-1', null ) ).toBe( 'coaching-1' );
+	} );
+
+	it( 'ignores the retained Blueprint value after a Playground ID exists', () => {
+		expect( getStandaloneBlueprintArchiveSlug( '945', 'playground-uuid' ) ).toBeNull();
+	} );
+} );


### PR DESCRIPTION
Supersedes the remaining onboarding-routing portion of #113320.

## Proposed Changes

* Treat a Blueprint value as a standalone archive only when the URL does not also contain a saved Playground ID.
* Use that derived archive slug for post-checkout destination selection and both paid and no-checkout redirects.
* Add focused regression coverage for standalone Blueprint archives and Playgrounds that retain their original Blueprint ID.

## Why are these changes being made?

The Playground onboarding flow retains the Blueprint Library ID used to initialize WordPress after it generates a persistent Playground ID. Archive routing treated any retained `blueprint` value as authoritative, so a saved Playground could be redirected to Site Spec instead of its Playground importer. #113425 restored Playground precedence on the plans page; this PR applies the same distinction to the later checkout and import destination.

## Testing Instructions

1. Run `yarn test-client client/landing/stepper/utils/test/blueprint-archive-import.ts --runInBand`.
2. Start `/setup/onboarding/playground?blueprint=945` and wait for the URL to gain a `playground` value.
3. Continue through site creation and verify the destination is the Playground importer rather than Site Spec.
4. Start a standalone Blueprint archive flow without a `playground` value and verify it still uses Site Spec.
5. Run `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g. browsers), interfaces (e.g. keyboard navigation), and assistive technologies (e.g. screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have you tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
