### PR TITLE
Agents Manager: Use drawerRight icon for Switch to sidebar

### DIFF
--- a/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
@@ -53,6 +53,7 @@ jest.mock( '@wordpress/icons', () => ( {
 	cog: 'cog',
 	columns: 'columns',
 	comment: 'comment',
+	drawerRight: 'drawerRight',
 	heading: 'heading',
 } ) );
 jest.mock( '../../contexts', () => ( {

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -7,7 +7,7 @@ import {
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { backup, cog, columns, comment, heading } from '@wordpress/icons';
+import { backup, cog, columns, comment, drawerRight, heading } from '@wordpress/icons';
 import { Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { useAgentsManagerContext } from '../../contexts';
 import { useSetupCustomActions } from '../../hooks/custom-actions';
@@ -25,7 +25,7 @@ import AgentHistory from '../agent-history';
 import { type Options as ChatHeaderOptions } from '../chat-header';
 import EditorAiChatButton from '../editor-ai-chat-button';
 import EditorHelpCenterButton from '../editor-help-center-button';
-import { SwitchToFloating, SwitchToSidebar } from '../icons';
+import { SwitchToFloating } from '../icons';
 import OrchestratorChat from '../orchestrator-chat';
 import SupportGuide from '../support-guide';
 import SupportGuides from '../support-guides';
@@ -361,7 +361,7 @@ export default function AgentDock( {
 			! isReaderChat &&
 				! isDocked &&
 				canDock && {
-					icon: <SwitchToSidebar />,
+					icon: drawerRight,
 					title: __( 'Switch to sidebar', __i18n_text_domain__ ),
 					onClick: () => {
 						recordMoreOptionsClick( 'dock' );

--- a/packages/agents-manager/src/components/icons.tsx
+++ b/packages/agents-manager/src/components/icons.tsx
@@ -72,25 +72,3 @@ export const SwitchToFloating = ( { size = 24, color = 'currentColor', className
 		</SVG>
 	);
 };
-
-export const SwitchToSidebar = ( { size = 24, color = 'currentColor', className }: IconProps ) => {
-	return (
-		<SVG
-			className={ className }
-			width={ size }
-			height={ size }
-			viewBox="0 0 24 24"
-			fill="none"
-			xmlns="http://www.w3.org/2000/svg"
-			aria-hidden="true"
-			focusable="false"
-		>
-			<Path
-				fillRule="evenodd"
-				clipRule="evenodd"
-				d="M18 4H6C4.9 4 4 4.9 4 6V18C4 19.1 4.9 20 6 20H18C19.1 20 20 19.1 20 18V6C20 4.9 19.1 4 18 4ZM11.25 18.5H6C5.7 18.5 5.5 18.3 5.5 18V6C5.5 5.7 5.7 5.5 6 5.5H11.25V18.5ZM18.5 18C18.5 18.3 18.3 18.5 18 18.5H12.75V5.5H18C18.3 5.5 18.5 5.7 18.5 6V18Z"
-				fill={ color }
-			/>
-		</SVG>
-	);
-};


### PR DESCRIPTION
Fixes AI-1107

## Proposed Changes

* Replace the custom split-screen SVG used for the “Switch to sidebar” chat-header menu item with Gutenberg’s `drawerRight` icon from `@wordpress/icons`.
* Remove the now-unused `SwitchToSidebar` component from `packages/agents-manager/src/components/icons.tsx`.
* Add `drawerRight` to the `@wordpress/icons` mock in the `agent-dock` unit tests.

## Why are these changes being made?

* The “Switch to sidebar” option currently shows a split-screen icon, which reads as the split-screen feature rather than docking the chat to the sidebar. Gutenberg’s `drawerRight` icon communicates the docked-sidebar layout and keeps the menu consistent with the other `@wordpress/icons` glyphs used there.

## Testing Instructions

A minor icon fix; will do self-review, test, and then merge the PR.

| Before | After |
| - | - |
|  <img width="177" height="140" alt="截圖 2026-08-11 凌晨12 24 24" src="https://github.com/user-attachments/assets/61e7cf72-0804-4063-b06e-a8c18ac72b06" /> | <img width="178" height="141" alt="截圖 2026-08-11 凌晨12 23 47" src="https://github.com/user-attachments/assets/2a66f602-2ad1-4c39-a5e7-7522246657fb" /> |

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
