### PR TITLE
Onboarding: restore the legacy blueprint route

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -33,7 +33,6 @@ import { isPlanProductFree } from '../../../../../../packages/data-stores/src/pl
 import { useFlowLocale } from '../../../hooks/use-flow-locale';
 import { useQuery } from '../../../hooks/use-query';
 import { ONBOARD_STORE, SITE_STORE } from '../../../stores';
-import { getBlueprintArchiveSiteSpecUrl } from '../../../utils/blueprint-archive-import';
 import {
 	getBuildWowSiteIdentifier,
 	getBuildWowSiteSpecUrl,
@@ -123,28 +122,16 @@ const onboarding: FlowV2< typeof initialize > = {
 					return [ `/home/${ providedDependencies.siteSlug }`, null, null ];
 				}
 
-				// Blueprint archive flow: skip the Playground-based importer and the
-				// setup-your-site-ai chooser. Land on the AI site-spec, which kicks off
-				// the background transfer-to-Atomic + blueprint-archive import and, on
-				// confirm, polls the import and redirects to the Atomic Site Editor.
-				if ( blueprint ) {
-					return [
-						getBlueprintArchiveSiteSpecUrl( {
-							siteSlug: providedDependencies.siteSlug as string,
-							siteId: providedDependencies.siteId as number,
-							blueprintSlug: blueprint,
-							ref: refParameter,
-						} ),
-						null,
-						null,
-					];
-				}
-
 				const params: Record< string, string | number > = {
 					siteSlug: providedDependencies.siteSlug as string,
 					siteId: providedDependencies.siteId as number,
-					playground: playgroundId as string,
 				};
+
+				if ( blueprint ) {
+					params.blueprint = blueprint;
+				} else if ( playgroundId ) {
+					params.playground = playgroundId;
+				}
 
 				return [
 					addQueryArgs( withLocale( '/setup/site-setup/importerPlayground', locale ), params ),
@@ -419,9 +406,7 @@ const onboarding: FlowV2< typeof initialize > = {
 							// replace the location to delete processing step from history.
 							window.location.replace(
 								addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
-									// Blueprint archive flow goes straight from checkout to the AI
-									// site-spec (no post-checkout-onboarding hop, no chooser).
-									redirect_to: blueprint ? destination : redirectTo,
+									redirect_to: redirectTo,
 									signup: 1,
 									flow: ONBOARDING_FLOW,
 									checkoutBackUrl: pathToUrl( backDestination ?? '' ),
@@ -433,10 +418,6 @@ const onboarding: FlowV2< typeof initialize > = {
 									steps_total: checkoutStepperPosition.total,
 								} )
 							);
-						} else if ( blueprint ) {
-							// Blueprint archive flow never shows the setup-your-site-ai chooser;
-							// go straight to the AI site-spec destination.
-							window.location.replace( destination );
 						} else if (
 							refParameter === WOO_HOSTING_SOLUTIONS_REF &&
 							isEnabled( 'onboarding/woo-hosting-post-purchase-setup-choice' )

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blueprint/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blueprint/index.tsx
@@ -5,37 +5,26 @@ import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
 import Loading from 'calypso/components/loading';
-import { getBlueprintArchiveIdentifier } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint';
+import { getBlueprintID } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
-import { checkBlueprintExists } from 'calypso/landing/stepper/utils/blueprint-archive-import';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step as StepType } from '../../types';
 
 export const BlueprintStep: StepType = ( { navigation } ) => {
-	const { submit, goToStep } = navigation;
+	const { submit } = navigation;
 	const { __ } = useI18n();
 	const [ query ] = useSearchParams();
 	const { setBlueprint } = useDispatch( ONBOARD_STORE );
 
 	useEffect( () => {
 		const fetchBlueprint = async () => {
-			const id = getBlueprintArchiveIdentifier( query );
+			const id = getBlueprintID( query );
 
-			if ( ! id ) {
-				return;
+			if ( id ) {
+				// Save the Blueprint library ID to the store
+				setBlueprint( id );
+				submit();
 			}
-
-			// Fail fast if the blueprint doesn't resolve to a usable archive, before
-			// the user reaches checkout.
-			const exists = await checkBlueprintExists( id );
-			if ( ! exists ) {
-				goToStep?.( 'error' );
-				return;
-			}
-
-			// Save the blueprint identifier (dotcomblueprints slug or numeric id) to the store.
-			setBlueprint( id );
-			submit();
 		};
 
 		fetchBlueprint();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/test/get-plans-intent.test.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/test/get-plans-intent.test.ts
@@ -13,19 +13,15 @@ describe( 'getPlansIntent', () => {
 		expect( getPlansIntent( 'ai-site-builder-onboarding' ) ).toBe( 'plans-ai-assembler-paid-only' );
 	} );
 
-	describe( 'onboarding flow blueprint variation', () => {
-		it( 'maps to the four paid plans intent when a blueprint param is present', () => {
-			window.history.replaceState( {}, '', '/?blueprint=coachava' );
-			expect( getPlansIntent( ONBOARDING_FLOW ) ).toBe( 'plans-ai-assembler-paid-only' );
-		} );
-
-		it( 'does not force the paid-only intent for a plain onboarding flow', () => {
+	describe( 'onboarding flow blueprint param (legacy behavior)', () => {
+		it( 'does not special-case the blueprint param — legacy default plans grid', () => {
+			window.history.replaceState( {}, '', '/?blueprint=945' );
 			expect( getPlansIntent( ONBOARDING_FLOW ) ).toBeNull();
 		} );
 
-		it( 'prefers the playground intent when both playground and blueprint params are present', () => {
+		it( 'uses the playground intent when the playground param is present alongside blueprint', () => {
 			// The Playground flow enters via /setup/onboarding/playground/?blueprint=<id>,
-			// so its users reach the plans step carrying BOTH params. Playground must win.
+			// so its users reach the plans step carrying BOTH params.
 			window.history.replaceState( {}, '', '/?blueprint=123&playground=abc' );
 			expect( getPlansIntent( ONBOARDING_FLOW ) ).toBe( 'plans-playground' );
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-plans-intent.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-plans-intent.ts
@@ -38,19 +38,8 @@ export function getPlansIntent( flowName: string | null ): PlansIntent | null {
 		case AI_SITE_BUILDER_ONBOARDING_FLOW:
 			return 'plans-ai-assembler-paid-only';
 		case ONBOARDING_FLOW:
-			// The playground check must come FIRST: the Playground flow enters via
-			// /setup/onboarding/playground/?blueprint=<numeric id>, so its users carry
-			// BOTH params at the plans step. Only the blueprint-archive flow
-			// (/setup/onboarding/blueprint) has `blueprint` without `playground`.
 			if ( search.has( 'playground' ) ) {
 				return playgroundPlansIntent( search.get( 'playground' )! );
-			}
-			// The blueprint-archive variation offers paid plans only — Personal,
-			// Premium, Business, Commerce — to match the blueprint archive it builds
-			// from. Reuse the AI-site-builder intent purely for that plan-tier set
-			// (it carries no other AI-assembler behavior).
-			if ( search.has( 'blueprint' ) ) {
-				return 'plans-ai-assembler-paid-only';
 			}
 			if ( search.get( 'ref' ) === WOO_HOSTING_SOLUTIONS_REF ) {
 				return 'plans-woo-hosting-solutions';


### PR DESCRIPTION
## Why

`/setup/onboarding/blueprint?blueprint=945` (numeric blueprintlibrary id) predates the blueprint-archive flow. #112534 routed every `blueprint` value into the archive flow, whose slug-only existence check 404s numeric ids → error step, breaking legacy links.

The dotcomblueprints archive work is being migrated over to blueprintlibrary, so rather than maintaining a numeric/slug split, this restores the **entire** `blueprint` route to its pre-#112534 legacy behavior and deliberately leaves the dotcomblueprints (slug) route unrouted until the migration lands.

## What

- **blueprint step**: restored wholesale to the pre-#112534 version — legacy `getBlueprintID` (numeric-only), no archive existence check. Slug entries no-op (deliberate).
- **onboarding.ts**: `blueprint` values route to the Playground importer destination again (`params.blueprint` restored byte-for-byte); normal checkout `redirect_to`; archive branch removed from the processing chain.
- **get-plans-intent.ts**: blueprint special-case removed — default plans grid, exactly as before #113190.
- Tests updated: `?blueprint=945` → `null` intent; playground+blueprint co-presence → `plans-playground`.

The archive-flow *machinery* (site-spec kickoff, `blueprint-archive-import.ts` utils, wpcom endpoints) is left in place but unrouted, ready for the blueprintlibrary migration to re-wire.

## Testing

- `get-plans-intent.test.ts` 6/6 + `site-spec/index.test.tsx` 3/3; eslint clean.
- `/setup/onboarding/blueprint?blueprint=945` → domains → plans (full grid) → checkout → `importerPlayground` — the legacy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)