### PR TITLE
Add support for the new native Zendesk CSAT

### DIFF
--- a/packages/help-center/src/components/help-center-support-chat-message.tsx
+++ b/packages/help-center/src/components/help-center-support-chat-message.tsx
@@ -1,6 +1,11 @@
 /* eslint-disable no-restricted-imports */
 import { Gravatar, TimeSince, WordPressLogo } from '@automattic/components';
 import { WapuuAvatar } from '@automattic/odie-client/src/assets';
+import {
+	getSurveyResponseRatingMetadataKey,
+	getZendeskSurveyResponseId,
+	isZendeskSurveyMessage,
+} from '@automattic/zendesk-client';
 import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
@@ -30,13 +35,38 @@ export const HelpCenterSupportChatMessage = ( {
 	const { currentUser } = useHelpCenterContext();
 	const recordTracksEvent = useHelpCenterTracksEvent();
 	const { received, role, text, altText } = message;
-	const messageText =
-		'metadata' in message && message.metadata?.type === 'csat'
-			? __(
-					'Please help us improve. How would you rate your support experience?',
-					__i18n_text_domain__
-			  )
-			: text;
+
+	// The rated outcome of a `zd:surveys` CSAT Survey Response, if this conversation has one and
+	// it's already been rated -- persisted on the conversation's own metadata by
+	// useSurveyResponseRating (in @automattic/odie-client), keyed by survey_response_id.
+	const conversationMessages: ( OdieMessage | ZendeskMessage )[] = conversation.messages;
+	const surveyMessage = conversationMessages.find(
+		( conversationMessage ): conversationMessage is ZendeskMessage =>
+			'source' in conversationMessage &&
+			isZendeskSurveyMessage( conversationMessage as ZendeskMessage )
+	);
+	const surveyResponseId = surveyMessage?.actions?.[ 0 ]?.uri
+		? getZendeskSurveyResponseId( surveyMessage.actions[ 0 ].uri )
+		: null;
+	const surveyRating = surveyResponseId
+		? ( conversation as ZendeskConversation ).metadata?.[
+				getSurveyResponseRatingMetadataKey( surveyResponseId )
+		  ]
+		: undefined;
+
+	let messageText: string | undefined;
+	if ( surveyRating === 'good' ) {
+		messageText = __( 'Good 👍', __i18n_text_domain__ );
+	} else if ( surveyRating === 'bad' ) {
+		messageText = __( 'Needs improvement 👎', __i18n_text_domain__ );
+	} else if ( 'metadata' in message && message.metadata?.type === 'csat' ) {
+		messageText = __(
+			'Please help us improve. How would you rate your support experience?',
+			__i18n_text_domain__
+		);
+	} else {
+		messageText = text;
+	}
 	const helpCenterContext = useHelpCenterContext();
 	const helpCenterContextSectionName = helpCenterContext.sectionName;
 	const { supportInteractions } = useGetHistoryChats();

--- a/packages/help-center/src/components/help-center-support-chat-message.tsx
+++ b/packages/help-center/src/components/help-center-support-chat-message.tsx
@@ -1,11 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import { Gravatar, TimeSince, WordPressLogo } from '@automattic/components';
 import { WapuuAvatar } from '@automattic/odie-client/src/assets';
-import {
-	getSurveyResponseRatingMetadataKey,
-	getZendeskSurveyResponseId,
-	isZendeskSurveyMessage,
-} from '@automattic/zendesk-client';
 import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
@@ -13,7 +8,7 @@ import { Link } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useGetHistoryChats } from '../hooks';
 import { useHelpCenterTracksEvent } from '../hooks/use-help-center-tracks-event';
-import { getChatLinkFromConversation } from './utils';
+import { getChatLinkFromConversation, getZendeskSurveyRating } from './utils';
 import type { OdieConversation, OdieMessage } from '@automattic/odie-client';
 import type { ZendeskConversation, ZendeskMessage } from '@automattic/zendesk-client';
 
@@ -35,24 +30,7 @@ export const HelpCenterSupportChatMessage = ( {
 	const { currentUser } = useHelpCenterContext();
 	const recordTracksEvent = useHelpCenterTracksEvent();
 	const { received, role, text, altText } = message;
-
-	// The rated outcome of a `zd:surveys` CSAT Survey Response, if this conversation has one and
-	// it's already been rated -- persisted on the conversation's own metadata by
-	// useSurveyResponseRating (in @automattic/odie-client), keyed by survey_response_id.
-	const conversationMessages: ( OdieMessage | ZendeskMessage )[] = conversation.messages;
-	const surveyMessage = conversationMessages.find(
-		( conversationMessage ): conversationMessage is ZendeskMessage =>
-			'source' in conversationMessage &&
-			isZendeskSurveyMessage( conversationMessage as ZendeskMessage )
-	);
-	const surveyResponseId = surveyMessage?.actions?.[ 0 ]?.uri
-		? getZendeskSurveyResponseId( surveyMessage.actions[ 0 ].uri )
-		: null;
-	const surveyRating = surveyResponseId
-		? ( conversation as ZendeskConversation ).metadata?.[
-				getSurveyResponseRatingMetadataKey( surveyResponseId )
-		  ]
-		: undefined;
+	const surveyRating = getZendeskSurveyRating( conversation );
 
 	let messageText: string | undefined;
 	if ( surveyRating === 'good' ) {

--- a/packages/help-center/src/components/utils.tsx
+++ b/packages/help-center/src/components/utils.tsx
@@ -1,5 +1,11 @@
 import { getConversationIdFromInteraction } from '@automattic/odie-client/src/utils';
-import { ZendeskConversation, ZendeskMessage } from '@automattic/zendesk-client';
+import {
+	getSurveyResponseRatingMetadataKey,
+	getZendeskSurveyResponseId,
+	isZendeskSurveyMessage,
+	ZendeskConversation,
+	ZendeskMessage,
+} from '@automattic/zendesk-client';
 import Smooch from 'smooch';
 import type { OdieConversation, OdieMessage, SupportInteraction } from '@automattic/odie-client';
 
@@ -97,6 +103,37 @@ export const getZendeskConversations = () => {
 		// Smooch is not completely initialized yet
 		return [];
 	}
+};
+
+/**
+ * Returns the rated outcome of a conversation's `zd:surveys` CSAT Survey Response, if it has one
+ * and it's already been rated -- persisted on the conversation's own metadata by
+ * useSurveyResponseRating (in @automattic/odie-client), keyed by survey_response_id.
+ */
+export const getZendeskSurveyRating = (
+	conversation: OdieConversation | ZendeskConversation
+): 'good' | 'bad' | undefined => {
+	if ( ! Array.isArray( conversation.messages ) ) {
+		return undefined;
+	}
+
+	const surveyMessage = ( conversation.messages as ( OdieMessage | ZendeskMessage )[] ).find(
+		( message ): message is ZendeskMessage =>
+			'source' in message && isZendeskSurveyMessage( message )
+	);
+	const surveyResponseId = surveyMessage?.actions?.[ 0 ]?.uri
+		? getZendeskSurveyResponseId( surveyMessage.actions[ 0 ].uri )
+		: null;
+
+	if ( ! surveyResponseId ) {
+		return undefined;
+	}
+
+	const rating = ( conversation as ZendeskConversation ).metadata?.[
+		getSurveyResponseRatingMetadataKey( surveyResponseId )
+	];
+
+	return rating === 'good' || rating === 'bad' ? rating : undefined;
 };
 
 export const getClientId = ( conversations: ZendeskConversation[] ): string =>

--- a/packages/odie-client/src/components/message/message-content.tsx
+++ b/packages/odie-client/src/components/message/message-content.tsx
@@ -1,11 +1,12 @@
 import { zendeskMessageConverter } from '@automattic/zendesk-client';
 import clsx from 'clsx';
 import { useOdieAssistantContext } from '../../context';
-import { hasSubmittedCSATRating, isCSATMessage } from '../../utils';
+import { hasSubmittedCSATRating, isCSATMessage, isZendeskSurveyMessage } from '../../utils';
 import { FeedbackForm } from './feedback-form';
 import { IntroductionMessage } from './introduction-message/introduction-message';
 import MarkdownOrChildren from './mardown-or-children';
 import { UserMessage } from './user-message';
+import { ZendeskSurveyRating } from './zendesk-survey-rating';
 import type { Message } from '../../types';
 import type { ZendeskMessage } from '@automattic/zendesk-client';
 
@@ -17,6 +18,7 @@ export const MessageContent = ( {
 	header?: React.ReactNode;
 } ) => {
 	const isFeedbackMessage = isCSATMessage( message );
+	const isSurveyMessage = isZendeskSurveyMessage( message );
 	const messageClasses = clsx(
 		'odie-chatbox-message',
 		'agenttic',
@@ -28,7 +30,7 @@ export const MessageContent = ( {
 			'is-sending': message.role === 'user' && ! message.received && message.metadata?.temporary_id,
 		},
 		{
-			'odie-chatbox-message-conversation-feedback': isFeedbackMessage,
+			'odie-chatbox-message-conversation-feedback': isFeedbackMessage || isSurveyMessage,
 		}
 	);
 	const { chat } = useOdieAssistantContext();
@@ -74,6 +76,9 @@ export const MessageContent = ( {
 			{ message.type === 'introduction' && <IntroductionMessage content={ message.content } /> }
 			{ displayCSAT && isFeedbackMessage && message.feedbackOptions && (
 				<FeedbackForm chatFeedbackOptions={ message?.feedbackOptions } />
+			) }
+			{ isSurveyMessage && message.feedbackOptions?.[ 0 ] && (
+				<ZendeskSurveyRating action={ message.feedbackOptions[ 0 ] } />
 			) }
 		</div>
 	);

--- a/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
+++ b/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
@@ -10,6 +10,7 @@ import {
 	isHappinessEngineerMessage,
 	isZendeskChatStartedMessage,
 	isZendeskIntroMessage,
+	isZendeskSurveyMessage,
 } from '../../../utils/csat';
 import ChatWithSupportLabel from '../../chat-with-support';
 import { getMessageUniqueIdentifier } from '../utils/get-message-unique-identifier';
@@ -25,7 +26,7 @@ const EXCLUDED_MESSAGE_ROLES = [ 'zendesk-intro' ] as const;
  * @returns The presented role of the message.
  */
 function getPresentedRole( message: Message ) {
-	if ( isCSATMessage( message ) ) {
+	if ( isCSATMessage( message ) || isZendeskSurveyMessage( message ) ) {
 		return 'csat';
 	} else if ( isAttachment( message ) ) {
 		return 'attachment';
@@ -158,7 +159,9 @@ export function MessagesClusterizer( { messages }: { messages: Message[] } ) {
 
 	return groups.map( ( group ) => {
 		const startingHumanSupport = group.messages.some( isZendeskChatStartedMessage );
-		const endingHumanSupport = group.messages.some( isCSATMessage );
+		const endingHumanSupport = group.messages.some(
+			( message ) => isCSATMessage( message ) || isZendeskSurveyMessage( message )
+		);
 
 		const messageHeader = () => {
 			// Real Happiness Engineer messages always show the "Happiness Engineer" override so that

--- a/packages/odie-client/src/components/message/test/get-message-unique-identifier.test.tsx
+++ b/packages/odie-client/src/components/message/test/get-message-unique-identifier.test.tsx
@@ -78,20 +78,6 @@ describe( 'getMessageUniqueIdentifier', () => {
 		expect( getMessageUniqueIdentifier( message ) ).toBe( 1234567890 );
 	} );
 
-	it( 'returns the raw Zendesk message id when no other identifier is present but id is', () => {
-		// zendeskMessageConverter spreads the original ZendeskMessage, so the runtime object
-		// carries an `id` even though it isn't declared on the `Message` type.
-		const message = {
-			content: 'test',
-			role: 'user',
-			type: 'message',
-			metadata: {},
-			id: 'zd-message-123',
-		} as unknown as Message;
-
-		expect( getMessageUniqueIdentifier( message ) ).toBe( 'zd-message-123' );
-	} );
-
 	it( 'returns the fallback string when no other identifier is present', () => {
 		const message: Message = {
 			content: 'test',

--- a/packages/odie-client/src/components/message/test/get-message-unique-identifier.test.tsx
+++ b/packages/odie-client/src/components/message/test/get-message-unique-identifier.test.tsx
@@ -78,6 +78,20 @@ describe( 'getMessageUniqueIdentifier', () => {
 		expect( getMessageUniqueIdentifier( message ) ).toBe( 1234567890 );
 	} );
 
+	it( 'returns the raw Zendesk message id when no other identifier is present but id is', () => {
+		// zendeskMessageConverter spreads the original ZendeskMessage, so the runtime object
+		// carries an `id` even though it isn't declared on the `Message` type.
+		const message = {
+			content: 'test',
+			role: 'user',
+			type: 'message',
+			metadata: {},
+			id: 'zd-message-123',
+		} as unknown as Message;
+
+		expect( getMessageUniqueIdentifier( message ) ).toBe( 'zd-message-123' );
+	} );
+
 	it( 'returns the fallback string when no other identifier is present', () => {
 		const message: Message = {
 			content: 'test',

--- a/packages/odie-client/src/components/message/test/messages-cluster.tsx
+++ b/packages/odie-client/src/components/message/test/messages-cluster.tsx
@@ -13,6 +13,7 @@ jest.mock( '../../../utils/csat', () => ( {
 		!! message?.metadata?.[ '__zendesk_msg.agent.id' ],
 	isZendeskChatStartedMessage: () => false,
 	isZendeskIntroMessage: () => false,
+	isZendeskSurveyMessage: () => false,
 } ) );
 
 // Tracks every mount of the mocked ChatMessage below, so tests can assert a re-render did (or

--- a/packages/odie-client/src/components/message/utils/get-message-unique-identifier.tsx
+++ b/packages/odie-client/src/components/message/utils/get-message-unique-identifier.tsx
@@ -1,12 +1,20 @@
 import { Message } from '../../../types';
 
 export const getMessageUniqueIdentifier = ( message: Message, fallback?: string ) => {
+	// Raw Zendesk-sourced messages (zendeskMessageConverter spreads the original ZendeskMessage)
+	// carry their own `id`, even though it isn't declared on the `Message` type. Falling through
+	// to `fallback` for these -- as opposed to an id-having message -- means an unstable,
+	// per-render-regenerated key (see clusterMessagesBySender's group.id), which remounts the
+	// message on every render instead of just the ones that actually change.
+	const zendeskMessageId = 'id' in message ? ( message as { id?: string } ).id : undefined;
+
 	return (
 		message.metadata?.temporary_id ??
 		message.message_id ??
 		message.internal_message_id ??
 		message.id ??
 		message.metadata?.local_timestamp ??
+		zendeskMessageId ??
 		fallback
 	);
 };

--- a/packages/odie-client/src/components/message/utils/get-message-unique-identifier.tsx
+++ b/packages/odie-client/src/components/message/utils/get-message-unique-identifier.tsx
@@ -1,20 +1,12 @@
 import { Message } from '../../../types';
 
 export const getMessageUniqueIdentifier = ( message: Message, fallback?: string ) => {
-	// Raw Zendesk-sourced messages (zendeskMessageConverter spreads the original ZendeskMessage)
-	// carry their own `id`, even though it isn't declared on the `Message` type. Falling through
-	// to `fallback` for these -- as opposed to an id-having message -- means an unstable,
-	// per-render-regenerated key (see clusterMessagesBySender's group.id), which remounts the
-	// message on every render instead of just the ones that actually change.
-	const zendeskMessageId = 'id' in message ? ( message as { id?: string } ).id : undefined;
-
 	return (
 		message.metadata?.temporary_id ??
 		message.message_id ??
 		message.internal_message_id ??
 		message.id ??
 		message.metadata?.local_timestamp ??
-		zendeskMessageId ??
 		fallback
 	);
 };

--- a/packages/odie-client/src/components/message/zendesk-survey-rating.tsx
+++ b/packages/odie-client/src/components/message/zendesk-survey-rating.tsx
@@ -1,0 +1,109 @@
+import {
+	CSATForm,
+	getBadRatingReasons,
+	isTestModeEnvironment,
+	useRateSurveyResponse,
+} from '@automattic/zendesk-client';
+import { useI18n } from '@wordpress/react-i18n';
+import { useMemo } from 'react';
+import { useOdieAssistantContext } from '../../context';
+import { useSurveyResponseRating } from '../../hooks';
+import type { MessageAction } from '../../types';
+
+function parseSurveyResponseUri(
+	uri: string
+): { id: string; accessToken: string; zendeskOrigin: string } | null {
+	try {
+		const url = new URL( uri );
+		const id = url.pathname.split( '/' ).filter( Boolean ).pop();
+		const accessToken = url.searchParams.get( 'access_token' );
+
+		if ( ! id || ! accessToken ) {
+			return null;
+		}
+
+		return { id, accessToken, zendeskOrigin: url.hostname };
+	} catch {
+		return null;
+	}
+}
+
+export const ZendeskSurveyRating = ( { action }: { action: MessageAction } ) => {
+	const parsed = useMemo(
+		() => ( action.uri ? parseSurveyResponseUri( action.uri ) : null ),
+		[ action.uri ]
+	);
+	const { mutateAsync: rateSurveyResponse } = useRateSurveyResponse();
+	const { chat } = useOdieAssistantContext();
+	const { __ } = useI18n();
+	const { rating, recoveredRating, isDismissed, persistRating, persistDismissed } =
+		useSurveyResponseRating( parsed?.id ?? '', chat.conversationId );
+
+	if ( ! parsed ) {
+		return null;
+	}
+
+	const onSendFeedback = async ( score: 'good' | 'bad' ): Promise< void > => {
+		persistRating( score );
+		await rateSurveyResponse( {
+			survey_response_id: parsed.id,
+			access_token: parsed.accessToken,
+			zendesk_origin: parsed.zendeskOrigin,
+			score,
+			test_mode: isTestModeEnvironment(),
+		} );
+	};
+
+	const onSendComment = async (
+		comment: string,
+		reasonId: string,
+		score: 'good' | 'bad'
+	): Promise< void > => {
+		// This survey's actual closed-ended "reason" question has its own Zendesk-generated
+		// option ids, which don't match our static reason codes -- fold the label into the
+		// free-text comment instead of guessing at a mismatched structured answer.
+		const reasonLabel = reasonId
+			? getBadRatingReasons().find( ( reason ) => reason.value === reasonId )?.label
+			: undefined;
+		const combinedComment = [ reasonLabel, comment ].filter( Boolean ).join( ' - ' );
+
+		await rateSurveyResponse( {
+			survey_response_id: parsed.id,
+			access_token: parsed.accessToken,
+			zendesk_origin: parsed.zendeskOrigin,
+			score,
+			comment: combinedComment || undefined,
+			test_mode: isTestModeEnvironment(),
+		} );
+	};
+
+	if ( isDismissed && rating ) {
+		return (
+			<div className="zendesk-csat-form">
+				<div className="zendesk-csat-form__rating-message">
+					<div>
+						{ rating === 'good'
+							? __( 'Good 👍', '__i18n_text_domain__' )
+							: __( 'Needs improvement 👎', '__i18n_text_domain__' ) }
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<CSATForm
+			// Keyed on recoveredRating (set only by the mount-time metadata fetch), not the live
+			// `rating` -- that would remount this the instant a thumb is clicked, before the
+			// request even starts, discarding the in-progress loading state. This key only
+			// changes when a genuine remount needs to recover an already-answered state.
+			key={ recoveredRating ?? 'unrated' }
+			ticketId={ null }
+			preDeterminedScore={ recoveredRating }
+			showRatingMessageWithPreDeterminedScore
+			onSendFeedback={ onSendFeedback }
+			onSendComment={ onSendComment }
+			onFormHidden={ persistDismissed }
+		/>
+	);
+};

--- a/packages/odie-client/src/components/message/zendesk-survey-rating.tsx
+++ b/packages/odie-client/src/components/message/zendesk-survey-rating.tsx
@@ -1,18 +1,16 @@
 import {
 	CSATForm,
-	getBadRatingReasons,
 	isTestModeEnvironment,
 	useRateSurveyResponse,
+	type SurveyReasonQuestion,
 } from '@automattic/zendesk-client';
 import { useI18n } from '@wordpress/react-i18n';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useOdieAssistantContext } from '../../context';
 import { useSurveyResponseRating } from '../../hooks';
 import type { MessageAction } from '../../types';
 
-function parseSurveyResponseUri(
-	uri: string
-): { id: string; accessToken: string; zendeskOrigin: string } | null {
+function parseSurveyResponseUri( uri: string ): { id: string; accessToken: string } | null {
 	try {
 		const url = new URL( uri );
 		const id = url.pathname.split( '/' ).filter( Boolean ).pop();
@@ -22,7 +20,7 @@ function parseSurveyResponseUri(
 			return null;
 		}
 
-		return { id, accessToken, zendeskOrigin: url.hostname };
+		return { id, accessToken };
 	} catch {
 		return null;
 	}
@@ -38,6 +36,10 @@ export const ZendeskSurveyRating = ( { action }: { action: MessageAction } ) => 
 	const { __ } = useI18n();
 	const { rating, recoveredRating, isDismissed, persistRating, persistDismissed } =
 		useSurveyResponseRating( parsed?.id ?? '', chat.conversationId );
+	// The survey's real closed-ended "reason" question, learned from the rating submission's
+	// response (see rate_survey_response() on the backend) -- there's no way to know it before
+	// that first round-trip, so the reason dropdown starts empty and fills in once it resolves.
+	const [ reasonQuestion, setReasonQuestion ] = useState< SurveyReasonQuestion >( null );
 
 	if ( ! parsed ) {
 		return null;
@@ -45,34 +47,29 @@ export const ZendeskSurveyRating = ( { action }: { action: MessageAction } ) => 
 
 	const onSendFeedback = async ( score: 'good' | 'bad' ): Promise< void > => {
 		persistRating( score );
-		await rateSurveyResponse( {
+		const result = await rateSurveyResponse( {
 			survey_response_id: parsed.id,
 			access_token: parsed.accessToken,
-			zendesk_origin: parsed.zendeskOrigin,
 			score,
 			test_mode: isTestModeEnvironment(),
 		} );
+
+		if ( result.reason_question ) {
+			setReasonQuestion( result.reason_question );
+		}
 	};
 
 	const onSendComment = async (
 		comment: string,
-		reasonId: string,
+		reasonOptionId: string,
 		score: 'good' | 'bad'
 	): Promise< void > => {
-		// This survey's actual closed-ended "reason" question has its own Zendesk-generated
-		// option ids, which don't match our static reason codes -- fold the label into the
-		// free-text comment instead of guessing at a mismatched structured answer.
-		const reasonLabel = reasonId
-			? getBadRatingReasons().find( ( reason ) => reason.value === reasonId )?.label
-			: undefined;
-		const combinedComment = [ reasonLabel, comment ].filter( Boolean ).join( ' - ' );
-
 		await rateSurveyResponse( {
 			survey_response_id: parsed.id,
 			access_token: parsed.accessToken,
-			zendesk_origin: parsed.zendeskOrigin,
 			score,
-			comment: combinedComment || undefined,
+			comment: comment || undefined,
+			reason_option_id: reasonOptionId || undefined,
 			test_mode: isTestModeEnvironment(),
 		} );
 	};
@@ -101,6 +98,14 @@ export const ZendeskSurveyRating = ( { action }: { action: MessageAction } ) => 
 			ticketId={ null }
 			preDeterminedScore={ recoveredRating }
 			showRatingMessageWithPreDeterminedScore
+			// Explicitly [] (not undefined) so CSATForm doesn't fall back to its static reason
+			// codes -- those belong to the ticket-based flow and don't exist on this survey.
+			reasonOptions={
+				reasonQuestion?.options.map( ( option ) => ( {
+					label: option.label,
+					value: option.id,
+				} ) ) ?? []
+			}
 			onSendFeedback={ onSendFeedback }
 			onSendComment={ onSendComment }
 			onFormHidden={ persistDismissed }

--- a/packages/odie-client/src/components/message/zendesk-survey-rating.tsx
+++ b/packages/odie-client/src/components/message/zendesk-survey-rating.tsx
@@ -1,5 +1,6 @@
 import {
 	CSATForm,
+	getZendeskSurveyResponseId,
 	isTestModeEnvironment,
 	useRateSurveyResponse,
 	type SurveyReasonQuestion,
@@ -12,9 +13,8 @@ import type { MessageAction } from '../../types';
 
 function parseSurveyResponseUri( uri: string ): { id: string; accessToken: string } | null {
 	try {
-		const url = new URL( uri );
-		const id = url.pathname.split( '/' ).filter( Boolean ).pop();
-		const accessToken = url.searchParams.get( 'access_token' );
+		const id = getZendeskSurveyResponseId( uri );
+		const accessToken = new URL( uri ).searchParams.get( 'access_token' );
 
 		if ( ! id || ! accessToken ) {
 			return null;

--- a/packages/odie-client/src/hooks/index.ts
+++ b/packages/odie-client/src/hooks/index.ts
@@ -6,3 +6,4 @@ export { useGetCombinedChat } from './use-get-combined-chat';
 export { useOdieUserTracking } from './use-odie-user-tracking';
 export { useSendZendeskMessage, useSendZendeskMessageOnce } from './use-send-zendesk-message';
 export { useUpdateDocumentTitle } from './use-update-document-title';
+export { useSurveyResponseRating } from './use-survey-response-rating';

--- a/packages/odie-client/src/hooks/use-survey-response-rating.ts
+++ b/packages/odie-client/src/hooks/use-survey-response-rating.ts
@@ -1,3 +1,4 @@
+import { getSurveyResponseRatingMetadataKey } from '@automattic/zendesk-client';
 import { useCallback, useEffect, useState } from 'react';
 import Smooch from 'smooch';
 
@@ -22,7 +23,7 @@ export const useSurveyResponseRating = (
 		undefined
 	);
 	const [ isDismissed, setIsDismissed ] = useState( false );
-	const ratingKey = `zd_survey_rating_${ surveyResponseId }`;
+	const ratingKey = getSurveyResponseRatingMetadataKey( surveyResponseId );
 	const dismissedKey = `zd_survey_dismissed_${ surveyResponseId }`;
 
 	useEffect( () => {

--- a/packages/odie-client/src/hooks/use-survey-response-rating.ts
+++ b/packages/odie-client/src/hooks/use-survey-response-rating.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useState } from 'react';
+import Smooch from 'smooch';
+
+/**
+ * Persists a CSAT Survey Response's rating (and whether the responder has finished submitting)
+ * on the Zendesk conversation's own metadata, keyed by survey_response_id. This is the source
+ * of truth -- local component state alone doesn't survive the message list re-rendering/
+ * remounting the message this lives in, which happens independently of anything the user does.
+ *
+ * `recoveredRating` is intentionally separate from `rating`: it's set only by the mount-time
+ * fetch from Smooch, never by `persistRating()`. Callers should use it (not `rating`) to key/
+ * initialize a component that needs to survive a remount -- using `rating` there would force an
+ * immediate remount the instant the responder clicks, before their request even starts,
+ * discarding any in-progress loading state.
+ */
+export const useSurveyResponseRating = (
+	surveyResponseId: string,
+	conversationId: string | null
+) => {
+	const [ rating, setRating ] = useState< 'good' | 'bad' | undefined >( undefined );
+	const [ recoveredRating, setRecoveredRating ] = useState< 'good' | 'bad' | undefined >(
+		undefined
+	);
+	const [ isDismissed, setIsDismissed ] = useState( false );
+	const ratingKey = `zd_survey_rating_${ surveyResponseId }`;
+	const dismissedKey = `zd_survey_dismissed_${ surveyResponseId }`;
+
+	useEffect( () => {
+		if ( ! conversationId ) {
+			return;
+		}
+
+		let isCancelled = false;
+
+		Smooch.getConversationById( conversationId ).then( ( conversation ) => {
+			if ( isCancelled ) {
+				return;
+			}
+
+			const storedRating = conversation?.metadata?.[ ratingKey ];
+
+			if ( storedRating === 'good' || storedRating === 'bad' ) {
+				setRating( storedRating );
+				setRecoveredRating( storedRating );
+			}
+
+			if ( conversation?.metadata?.[ dismissedKey ] ) {
+				setIsDismissed( true );
+			}
+		} );
+
+		return () => {
+			isCancelled = true;
+		};
+	}, [ conversationId, ratingKey, dismissedKey ] );
+
+	const persistRating = useCallback(
+		async ( score: 'good' | 'bad' ) => {
+			setRating( score );
+
+			if ( ! conversationId ) {
+				return;
+			}
+
+			const conversation = await Smooch.getConversationById( conversationId );
+
+			await Smooch.updateConversation( conversationId, {
+				metadata: {
+					...conversation?.metadata,
+					[ ratingKey ]: score,
+				},
+			} );
+		},
+		[ conversationId, ratingKey ]
+	);
+
+	const persistDismissed = useCallback( async () => {
+		setIsDismissed( true );
+
+		if ( ! conversationId ) {
+			return;
+		}
+
+		const conversation = await Smooch.getConversationById( conversationId );
+
+		await Smooch.updateConversation( conversationId, {
+			metadata: {
+				...conversation?.metadata,
+				[ dismissedKey ]: true,
+			},
+		} );
+	}, [ conversationId, dismissedKey ] );
+
+	return { rating, recoveredRating, isDismissed, persistRating, persistDismissed };
+};

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -212,6 +212,7 @@ export type MessageAction = {
 	metadata: ChatFeedbackActions;
 	label: string;
 	onClick: () => void;
+	uri?: string;
 };
 
 export type OdieMessage = {

--- a/packages/odie-client/src/utils/csat.ts
+++ b/packages/odie-client/src/utils/csat.ts
@@ -1,8 +1,12 @@
+import {
+	isCsatTriggerMessage,
+	isZendeskSurveyMessage as isZendeskSurveyMessageBase,
+} from '@automattic/zendesk-client';
 import type { Chat, Message } from '../types';
 import type { ZendeskMessage } from '@automattic/zendesk-client';
 
 export const isCSATMessage = ( message: Message ) =>
-	message?.feedbackOptions?.length && message?.metadata?.type === 'csat';
+	!! message?.feedbackOptions?.length && isCsatTriggerMessage( message );
 
 export const hasFeedbackForm = ( message: Message ) => message?.type === 'form';
 
@@ -11,6 +15,9 @@ export const isAttachment = ( message: Message ) =>
 
 export const isZendeskIntroMessage = ( message: Message | ZendeskMessage ) =>
 	'source' in message && message.source?.type === 'zd:answerBot';
+
+export const isZendeskSurveyMessage = ( message: Message | ZendeskMessage ) =>
+	'source' in message && isZendeskSurveyMessageBase( message );
 
 export const isZendeskChatStartedMessage = ( message: Message ) =>
 	message?.internal_message_id === 'zendesk-chat-started';

--- a/packages/odie-client/src/utils/index.ts
+++ b/packages/odie-client/src/utils/index.ts
@@ -8,7 +8,12 @@ export {
 	getConversationIdFromInteraction,
 	getOdieIdFromInteraction,
 } from './support-interaction-utils';
-export { isCSATMessage, hasCSATMessage, hasSubmittedCSATRating } from './csat';
+export {
+	isCSATMessage,
+	hasCSATMessage,
+	hasSubmittedCSATRating,
+	isZendeskSurveyMessage,
+} from './csat';
 export { isStaleOdieChat } from './chat-utils';
 import type { Chat, Message } from '../types';
 

--- a/packages/zendesk-client/src/components/csat-form.scss
+++ b/packages/zendesk-client/src/components/csat-form.scss
@@ -50,7 +50,7 @@
 	.zendesk-csat-form__feedback {
 		p {
 			padding-top: 12px;
-			padding-bottom: 20px;
+			padding-bottom: 20px !important;
 			background-color: unset !important;
 			line-height: 20px;
 		}

--- a/packages/zendesk-client/src/components/csat-form.tsx
+++ b/packages/zendesk-client/src/components/csat-form.tsx
@@ -33,6 +33,15 @@ export interface CSATFormProps {
 	 * preceding message) and would otherwise show it twice. Set this to show it anyway.
 	 */
 	showRatingMessageWithPreDeterminedScore?: boolean;
+	/**
+	 * Options for the "bad" score's reason dropdown. Defaults to the static WPCOM reason
+	 * taxonomy (used by the ticket_id-based flow). Pass this explicitly -- even as an empty
+	 * array while real options are still loading -- for a caller whose reasons come from
+	 * somewhere else (e.g. a CSAT Survey's own closed-ended question options); an empty array
+	 * intentionally does NOT fall back to the static list, since those codes wouldn't mean
+	 * anything to that caller's backend.
+	 */
+	reasonOptions?: { label: string; value: string }[];
 }
 
 export const CSATForm = ( {
@@ -43,6 +52,7 @@ export const CSATForm = ( {
 	onFormHidden,
 	className,
 	showRatingMessageWithPreDeterminedScore,
+	reasonOptions: reasonOptionsProp,
 }: CSATFormProps ) => {
 	const [ score, setScore ] = useState( preDeterminedScore );
 	const [ comment, setComment ] = useState( '' );
@@ -55,7 +65,7 @@ export const CSATForm = ( {
 	// block a fast double-click. The ref updates synchronously and is shared across both closures.
 	const isSubmittingScoreRef = useRef( false );
 	const feedbackRef = useRef< HTMLDivElement | null >( null );
-	const badRatingReasons = getBadRatingReasons();
+	const reasonOptions = reasonOptionsProp ?? getBadRatingReasons();
 
 	const { isPending: isSubmittingRateChat, mutateAsync: rateChat } = useRateChat();
 	const isSubmitting = isSubmittingRateChat || isSubmittingComment || isSubmittingScore;
@@ -176,7 +186,7 @@ export const CSATForm = ( {
 									className="zendesk-csat-form__reason"
 									label={ __( 'Reason' ) }
 									value={ reason }
-									options={ badRatingReasons }
+									options={ reasonOptions }
 									onChange={ ( value ) => setReason( value ) }
 									__next40pxDefaultSize
 								/>

--- a/packages/zendesk-client/src/components/csat-form.tsx
+++ b/packages/zendesk-client/src/components/csat-form.tsx
@@ -10,25 +10,55 @@ import './csat-form.scss';
 
 export interface CSATFormProps {
 	ticketId: number | null;
-	onSendFeedback: ( score: 'good' | 'bad' ) => void;
+	onSendFeedback: ( score: 'good' | 'bad' ) => void | Promise< void >;
+	/**
+	 * When provided, the comment step submits through this callback instead of the
+	 * ticket_id-based `/help/csat` endpoint. Used by callers rating something that isn't a
+	 * Zendesk ticket satisfaction rating (e.g. a CSAT Survey Response).
+	 */
+	onSendComment?: (
+		comment: string,
+		reasonId: string,
+		score: 'good' | 'bad'
+	) => void | Promise< void >;
+	/**
+	 * Called once the form collapses after the responder submits (either "Send" or "No thanks").
+	 */
+	onFormHidden?: () => void;
 	className?: string;
 	preDeterminedScore?: 'good' | 'bad';
+	/**
+	 * The "Good 👍"/"Needs improvement 👎" message is hidden by default when preDeterminedScore
+	 * is set, since some callers already show the score another way (e.g. a pressed button on a
+	 * preceding message) and would otherwise show it twice. Set this to show it anyway.
+	 */
+	showRatingMessageWithPreDeterminedScore?: boolean;
 }
 
 export const CSATForm = ( {
 	ticketId,
 	preDeterminedScore,
 	onSendFeedback,
+	onSendComment,
+	onFormHidden,
 	className,
+	showRatingMessageWithPreDeterminedScore,
 }: CSATFormProps ) => {
 	const [ score, setScore ] = useState( preDeterminedScore );
 	const [ comment, setComment ] = useState( '' );
 	const [ reason, setReason ] = useState( '' );
 	const [ isFormHidden, setIsFormHidden ] = useState( false );
+	const [ isSubmittingComment, setIsSubmittingComment ] = useState( false );
+	const [ isSubmittingScore, setIsSubmittingScore ] = useState( false );
+	// A ref alongside the state above: two clicks fired before the first re-render commits would
+	// both still see the pre-click `isSubmittingScore` value from state, so the state alone can't
+	// block a fast double-click. The ref updates synchronously and is shared across both closures.
+	const isSubmittingScoreRef = useRef( false );
 	const feedbackRef = useRef< HTMLDivElement | null >( null );
 	const badRatingReasons = getBadRatingReasons();
 
-	const { isPending: isSubmitting, mutateAsync: rateChat } = useRateChat();
+	const { isPending: isSubmittingRateChat, mutateAsync: rateChat } = useRateChat();
+	const isSubmitting = isSubmittingRateChat || isSubmittingComment || isSubmittingScore;
 
 	useEffect( () => {
 		if ( score && feedbackRef?.current ) {
@@ -37,20 +67,51 @@ export const CSATForm = ( {
 	}, [ score ] );
 
 	const postScore = useCallback(
-		( selectedScore: 'good' | 'bad' ) => {
+		async ( selectedScore: 'good' | 'bad' ) => {
+			if ( isSubmittingScoreRef.current ) {
+				return;
+			}
+
+			isSubmittingScoreRef.current = true;
+			setIsSubmittingScore( true );
 			setScore( selectedScore );
-			onSendFeedback( selectedScore );
+
+			try {
+				await onSendFeedback( selectedScore );
+			} finally {
+				isSubmittingScoreRef.current = false;
+				setIsSubmittingScore( false );
+			}
 		},
 		[ onSendFeedback ]
 	);
 
+	const hideForm = useCallback( () => {
+		setIsFormHidden( true );
+		onFormHidden?.();
+	}, [ onFormHidden ] );
+
 	const postCSAT = useCallback( async () => {
-		if ( ! ticketId || ! score ) {
+		if ( ! score ) {
 			return;
 		}
 
-		setIsFormHidden( true );
+		hideForm();
 		if ( ! comment && ! reason ) {
+			return;
+		}
+
+		if ( onSendComment ) {
+			setIsSubmittingComment( true );
+			try {
+				await onSendComment( comment, reason, score );
+			} finally {
+				setIsSubmittingComment( false );
+			}
+			return;
+		}
+
+		if ( ! ticketId ) {
 			return;
 		}
 
@@ -61,7 +122,7 @@ export const CSATForm = ( {
 			reason_id: reason,
 			test_mode: isTestModeEnvironment(),
 		} );
-	}, [ rateChat, ticketId, score, comment, reason ] );
+	}, [ rateChat, ticketId, score, comment, reason, onSendComment, hideForm ] );
 
 	return (
 		<div className={ clsx( 'zendesk-csat-form', className ) }>
@@ -71,33 +132,34 @@ export const CSATForm = ( {
 						<Button
 							onClick={ () => postScore( 'good' ) }
 							className="zendesk-csat-form__thumbs-button"
+							disabled={ isSubmittingScore }
 						>
 							<ThumbsUpIcon />
 						</Button>
 						<Button
 							onClick={ () => postScore( 'bad' ) }
 							className="zendesk-csat-form__thumbs-button"
+							disabled={ isSubmittingScore }
 						>
 							<ThumbsDownIcon />
 						</Button>
 					</div>
 				</div>
 			) }
+			{ isSubmitting && (
+				<div className="zendesk-csat-form__loading">
+					<Spinner />
+				</div>
+			) }
 			{ score && (
 				<>
-					{ ! preDeterminedScore && (
+					{ ( ! preDeterminedScore || showRatingMessageWithPreDeterminedScore ) && (
 						<div className="zendesk-csat-form__rating-message">
 							<div>
 								{ score === 'good'
 									? __( 'Good 👍', '__i18n_text_domain__' )
 									: __( 'Needs improvement 👎', '__i18n_text_domain__' ) }
 							</div>
-						</div>
-					) }
-
-					{ isSubmitting && (
-						<div className="zendesk-csat-form__loading">
-							<Spinner />
 						</div>
 					) }
 
@@ -132,7 +194,7 @@ export const CSATForm = ( {
 									{ __( 'Send', '__i18n_text_domain__' ) }
 								</Button>
 
-								<Button variant="tertiary" onClick={ () => setIsFormHidden( true ) }>
+								<Button variant="tertiary" onClick={ hideForm }>
 									{ __( 'No thanks', '__i18n_text_domain__' ) }
 								</Button>
 							</div>

--- a/packages/zendesk-client/src/index.ts
+++ b/packages/zendesk-client/src/index.ts
@@ -7,13 +7,19 @@ export {
 } from './use-authenticate-zendesk-messaging';
 export { useZendeskMessagingAvailability } from './use-zendesk-messaging-availability';
 export { useRateChat } from './use-rate-chat';
+export { useRateSurveyResponse } from './use-rate-survey-response';
 export { useUpdateZendeskUserFields } from './use-update-zendesk-user-fields';
 export { useAttachFileToConversation } from './use-attach-file';
 export { useGetUnreadConversations } from './use-get-unread-conversations';
 export { useGetZendeskConversation } from './use-get-zendesk-conversation';
 export { calculateUnread } from './use-get-unread-conversations';
 
-export { isTestModeEnvironment, getBadRatingReasons } from './util';
+export {
+	isTestModeEnvironment,
+	getBadRatingReasons,
+	isCsatTriggerMessage,
+	isZendeskSurveyMessage,
+} from './util';
 
 export {
 	ZENDESK_CUSTOM_FIELD_AI_CHAT_ID,

--- a/packages/zendesk-client/src/index.ts
+++ b/packages/zendesk-client/src/index.ts
@@ -8,6 +8,7 @@ export {
 export { useZendeskMessagingAvailability } from './use-zendesk-messaging-availability';
 export { useRateChat } from './use-rate-chat';
 export { useRateSurveyResponse } from './use-rate-survey-response';
+export type { SurveyReasonOption, SurveyReasonQuestion } from './use-rate-survey-response';
 export { useUpdateZendeskUserFields } from './use-update-zendesk-user-fields';
 export { useAttachFileToConversation } from './use-attach-file';
 export { useGetUnreadConversations } from './use-get-unread-conversations';

--- a/packages/zendesk-client/src/index.ts
+++ b/packages/zendesk-client/src/index.ts
@@ -20,6 +20,8 @@ export {
 	getBadRatingReasons,
 	isCsatTriggerMessage,
 	isZendeskSurveyMessage,
+	getZendeskSurveyResponseId,
+	getSurveyResponseRatingMetadataKey,
 } from './util';
 
 export {

--- a/packages/zendesk-client/src/types.ts
+++ b/packages/zendesk-client/src/types.ts
@@ -73,6 +73,7 @@ export type MessageAction = {
 	tooltip?: string;
 	icon?: React.ReactNode;
 	pressed?: boolean;
+	uri?: string;
 };
 
 export type ZendeskContentType =

--- a/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
+++ b/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
@@ -42,6 +42,7 @@ import { useConnectionStatusNotice } from './use-connection-status-notice';
 import {
 	convertZendeskMessageToAgentticFormat,
 	getSmoochContainer,
+	isCsatTriggerMessage,
 	isSupportedImageType,
 	isTestModeEnvironment,
 	MAX_ATTACHMENTS,
@@ -331,7 +332,7 @@ export const useManagedZendeskChat = ( {
 
 	const hasCSAT = useMemo( () => {
 		const messages = conversation?.messages ?? [];
-		return messages.some( ( msg ) => msg.metadata?.type === 'csat' );
+		return messages.some( isCsatTriggerMessage );
 	}, [ conversation?.messages ] );
 
 	const disconnectedListener = useCallback( () => {
@@ -462,7 +463,7 @@ export const useManagedZendeskChat = ( {
 
 		let ticketId: number | null = null;
 		const messages = rawMessages.map( ( message ): AgentticMessage => {
-			const isCSAT = message.metadata?.type === 'csat';
+			const isCSAT = isCsatTriggerMessage( message );
 
 			if ( isCSAT ) {
 				ticketId = message.actions?.[ 0 ]?.metadata?.ticket_id ?? null;

--- a/packages/zendesk-client/src/use-rate-survey-response.ts
+++ b/packages/zendesk-client/src/use-rate-survey-response.ts
@@ -1,0 +1,32 @@
+import { useMutation } from '@tanstack/react-query';
+import apiFetch, { APIFetchOptions } from '@wordpress/api-fetch';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+
+type SurveyResponseRatingPayload = {
+	survey_response_id: string;
+	access_token: string;
+	score: 'good' | 'bad';
+	comment?: string;
+	zendesk_origin: string;
+	test_mode?: boolean;
+};
+
+export const useRateSurveyResponse = () => {
+	return useMutation( {
+		mutationFn: ( payload: SurveyResponseRatingPayload ) => {
+			return canAccessWpcomApis()
+				? wpcomRequest( {
+						path: '/help/csat-survey-response',
+						apiNamespace: 'wpcom/v2',
+						method: 'POST',
+						body: payload,
+				  } )
+				: apiFetch( {
+						global: true,
+						path: '/help-center/csat-survey-response',
+						method: 'POST',
+						data: payload,
+				  } as APIFetchOptions );
+		},
+	} );
+};

--- a/packages/zendesk-client/src/use-rate-survey-response.ts
+++ b/packages/zendesk-client/src/use-rate-survey-response.ts
@@ -1,19 +1,39 @@
 import { useMutation } from '@tanstack/react-query';
-import apiFetch, { APIFetchOptions } from '@wordpress/api-fetch';
+import apiFetch from '@wordpress/api-fetch';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import type { APIFetchOptions } from './types';
 
 type SurveyResponseRatingPayload = {
 	survey_response_id: string;
 	access_token: string;
 	score: 'good' | 'bad';
 	comment?: string;
-	zendesk_origin: string;
+	reason_option_id?: string;
 	test_mode?: boolean;
+};
+
+export type SurveyReasonOption = {
+	id: string;
+	label: string;
+};
+
+/**
+ * The survey's real closed-ended "reason" question, if it has one -- present on every
+ * response regardless of whether a reason was submitted, so the caller can render the
+ * survey-configured options for a follow-up submission.
+ */
+export type SurveyReasonQuestion = {
+	question_id: string;
+	options: SurveyReasonOption[];
+} | null;
+
+type SurveyResponseRatingResult = {
+	reason_question?: SurveyReasonQuestion;
 };
 
 export const useRateSurveyResponse = () => {
 	return useMutation( {
-		mutationFn: ( payload: SurveyResponseRatingPayload ) => {
+		mutationFn: ( payload: SurveyResponseRatingPayload ): Promise< SurveyResponseRatingResult > => {
 			return canAccessWpcomApis()
 				? wpcomRequest( {
 						path: '/help/csat-survey-response',
@@ -21,7 +41,7 @@ export const useRateSurveyResponse = () => {
 						method: 'POST',
 						body: payload,
 				  } )
-				: apiFetch( {
+				: apiFetch< SurveyResponseRatingResult >( {
 						global: true,
 						path: '/help-center/csat-survey-response',
 						method: 'POST',

--- a/packages/zendesk-client/src/util.tsx
+++ b/packages/zendesk-client/src/util.tsx
@@ -140,6 +140,21 @@ export const getBadRatingReasons = () => {
 };
 
 /**
+ * A CSAT trigger message is a WPCOM-configured Zendesk message flagged with metadata.type
+ * 'csat', prompting the responder to rate their support experience via our own thumbs-up/down
+ * UI (as opposed to a `zd:surveys` message, which is Zendesk's native CSAT Survey feature).
+ */
+export const isCsatTriggerMessage = ( message: Pick< ZendeskMessage, 'metadata' > ) =>
+	message?.metadata?.type === 'csat';
+
+/**
+ * A CSAT Survey message is delivered via Zendesk's native Surveys feature, identified by its
+ * `source.type`. See https://developer.zendesk.com/api-reference/ticketing/ticket-management/csat_survey_responses/
+ */
+export const isZendeskSurveyMessage = ( message: Pick< ZendeskMessage, 'source' > ) =>
+	message?.source?.type === 'zd:surveys';
+
+/**
  * Converts a ZendeskMessage to the agenttic-ui Message interface format
  * Used for components that require the standardized Message interface
  * @param message - The Zendesk message to convert

--- a/packages/zendesk-client/src/util.tsx
+++ b/packages/zendesk-client/src/util.tsx
@@ -155,6 +155,26 @@ export const isZendeskSurveyMessage = ( message: Pick< ZendeskMessage, 'source' 
 	message?.source?.type === 'zd:surveys';
 
 /**
+ * Extracts a CSAT Survey Response's id from its action `uri` (the last path segment). Returns
+ * null if `uri` isn't a valid URL -- callers should treat that the same as "no survey response".
+ */
+export const getZendeskSurveyResponseId = ( uri: string ): string | null => {
+	try {
+		return new URL( uri ).pathname.split( '/' ).filter( Boolean ).pop() ?? null;
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * The conversation metadata key a CSAT Survey Response's rating is persisted under (see
+ * useSurveyResponseRating in @automattic/odie-client). Shared so any other reader of a
+ * conversation's metadata -- e.g. a chat history list -- derives the same key.
+ */
+export const getSurveyResponseRatingMetadataKey = ( surveyResponseId: string ) =>
+	`zd_survey_rating_${ surveyResponseId }`;
+
+/**
  * Converts a ZendeskMessage to the agenttic-ui Message interface format
  * Used for components that require the standardized Message interface
  * @param message - The Zendesk message to convert

--- a/packages/zendesk-client/src/zendesk-message-converter.tsx
+++ b/packages/zendesk-client/src/zendesk-message-converter.tsx
@@ -86,16 +86,12 @@ function getContentMessage( message: ZendeskMessage ): ReactNode {
 			messageContent = __( 'Message content not supported', __i18n_text_domain__ );
 	}
 
-	if ( isCsatTriggerMessage( message ) && message.actions?.length ) {
+	if (
+		message.actions?.length &&
+		( isCsatTriggerMessage( message ) || isZendeskSurveyMessage( message ) )
+	) {
 		messageContent = __(
 			'Please help us improve. How would you rate your support experience?',
-			__i18n_text_domain__
-		);
-	}
-
-	if ( isZendeskSurveyMessage( message ) && message.actions?.length ) {
-		messageContent = __(
-			'Please help us improve. How would you rate the support you received?',
 			__i18n_text_domain__
 		);
 	}

--- a/packages/zendesk-client/src/zendesk-message-converter.tsx
+++ b/packages/zendesk-client/src/zendesk-message-converter.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import DOMPurify from 'dompurify';
+import { isCsatTriggerMessage, isZendeskSurveyMessage } from './util';
 import type { MessageType, ZendeskMessage } from './types';
 import type { ReactNode } from 'react';
 
@@ -85,9 +86,16 @@ function getContentMessage( message: ZendeskMessage ): ReactNode {
 			messageContent = __( 'Message content not supported', __i18n_text_domain__ );
 	}
 
-	if ( message?.metadata?.type === 'csat' && message.actions?.length ) {
+	if ( isCsatTriggerMessage( message ) && message.actions?.length ) {
 		messageContent = __(
 			'Please help us improve. How would you rate your support experience?',
+			__i18n_text_domain__
+		);
+	}
+
+	if ( isZendeskSurveyMessage( message ) && message.actions?.length ) {
+		messageContent = __(
+			'Please help us improve. How would you rate the support you received?',
 			__i18n_text_domain__
 		);
 	}

--- a/packages/zendesk-client/test/csat-form.test.tsx
+++ b/packages/zendesk-client/test/csat-form.test.tsx
@@ -1,0 +1,262 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { CSATForm } from '../src/components/csat-form';
+
+// jsdom doesn't implement scrollIntoView; CSATForm calls it when the feedback step mounts.
+Element.prototype.scrollIntoView = jest.fn();
+
+jest.mock( '../src/util', () => ( {
+	getBadRatingReasons: () => [
+		{ label: 'No reason provided', value: '' },
+		{ label: 'Static reason', value: 'static-reason' },
+	],
+	isTestModeEnvironment: () => false,
+} ) );
+
+const mockMutateAsync = jest.fn();
+let mockIsPending = false;
+
+jest.mock( '../src/use-rate-chat', () => ( {
+	useRateChat: () => ( {
+		isPending: mockIsPending,
+		mutateAsync: mockMutateAsync,
+	} ),
+} ) );
+
+function getThumbsButtons() {
+	const buttons = document.querySelectorAll< HTMLButtonElement >(
+		'.zendesk-csat-form__thumbs-button'
+	);
+	return { thumbsUp: buttons[ 0 ], thumbsDown: buttons[ 1 ] };
+}
+
+describe( 'CSATForm', () => {
+	beforeEach( () => {
+		mockMutateAsync.mockReset().mockResolvedValue( undefined );
+		mockIsPending = false;
+	} );
+
+	it( 'shows the rating message after a thumb is clicked when no score is predetermined', async () => {
+		const onSendFeedback = jest.fn();
+		render( <CSATForm ticketId={ 1 } onSendFeedback={ onSendFeedback } /> );
+
+		const { thumbsUp } = getThumbsButtons();
+		await act( async () => {
+			fireEvent.click( thumbsUp );
+		} );
+
+		expect( onSendFeedback ).toHaveBeenCalledWith( 'good' );
+		expect( screen.getByText( 'Good 👍' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not show the rating message when preDeterminedScore is set', () => {
+		render( <CSATForm ticketId={ 1 } preDeterminedScore="good" onSendFeedback={ jest.fn() } /> );
+
+		expect( screen.queryByText( 'Good 👍' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the rating message when preDeterminedScore is set and showRatingMessageWithPreDeterminedScore is true', () => {
+		render(
+			<CSATForm
+				ticketId={ 1 }
+				preDeterminedScore="bad"
+				showRatingMessageWithPreDeterminedScore
+				onSendFeedback={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByText( 'Needs improvement 👎' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not render the thumbs buttons at all when preDeterminedScore is set', () => {
+		render( <CSATForm ticketId={ 1 } preDeterminedScore="good" onSendFeedback={ jest.fn() } /> );
+
+		expect( document.querySelectorAll( '.zendesk-csat-form__thumbs-button' ) ).toHaveLength( 0 );
+	} );
+
+	it( 'ignores a second click on the thumbs while the first submission is still in flight', async () => {
+		let resolveFeedback: () => void = () => undefined;
+		const onSendFeedback = jest.fn(
+			() =>
+				new Promise< void >( ( resolve ) => {
+					resolveFeedback = resolve;
+				} )
+		);
+		render( <CSATForm ticketId={ 1 } onSendFeedback={ onSendFeedback } /> );
+
+		const { thumbsUp } = getThumbsButtons();
+
+		// Both clicks fire before the isSubmittingScore state update commits -- this is exactly
+		// the race isSubmittingScoreRef exists to guard against.
+		await act( async () => {
+			fireEvent.click( thumbsUp );
+			fireEvent.click( thumbsUp );
+			resolveFeedback();
+		} );
+
+		expect( onSendFeedback ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'disables the thumbs buttons while the score submission is pending', async () => {
+		let resolveFeedback: () => void = () => undefined;
+		const onSendFeedback = jest.fn(
+			() =>
+				new Promise< void >( ( resolve ) => {
+					resolveFeedback = resolve;
+				} )
+		);
+		render( <CSATForm ticketId={ 1 } onSendFeedback={ onSendFeedback } /> );
+
+		const { thumbsUp, thumbsDown } = getThumbsButtons();
+
+		act( () => {
+			fireEvent.click( thumbsUp );
+		} );
+
+		expect( thumbsUp ).toBeDisabled();
+		expect( thumbsDown ).toBeDisabled();
+
+		await act( async () => {
+			resolveFeedback();
+		} );
+
+		expect( thumbsUp ).not.toBeDisabled();
+		expect( thumbsDown ).not.toBeDisabled();
+	} );
+
+	it( 'hides the form without submitting anything when Send is clicked with no comment or reason', async () => {
+		const onFormHidden = jest.fn();
+		render(
+			<CSATForm ticketId={ 1 } onSendFeedback={ jest.fn() } onFormHidden={ onFormHidden } />
+		);
+
+		const { thumbsUp } = getThumbsButtons();
+		await act( async () => {
+			fireEvent.click( thumbsUp );
+		} );
+
+		await act( async () => {
+			fireEvent.click( screen.getByText( 'Send' ) );
+		} );
+
+		expect( mockMutateAsync ).not.toHaveBeenCalled();
+		expect( onFormHidden ).toHaveBeenCalledTimes( 1 );
+		expect( screen.queryByText( 'Send' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'calls onFormHidden when No thanks is clicked', async () => {
+		const onFormHidden = jest.fn();
+		render(
+			<CSATForm ticketId={ 1 } onSendFeedback={ jest.fn() } onFormHidden={ onFormHidden } />
+		);
+
+		const { thumbsUp } = getThumbsButtons();
+		await act( async () => {
+			fireEvent.click( thumbsUp );
+		} );
+
+		await act( async () => {
+			fireEvent.click( screen.getByText( 'No thanks' ) );
+		} );
+
+		expect( onFormHidden ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'calls rateChat with the ticket_id when a comment is submitted without onSendComment', async () => {
+		render( <CSATForm ticketId={ 42 } onSendFeedback={ jest.fn() } /> );
+
+		const { thumbsUp } = getThumbsButtons();
+		await act( async () => {
+			fireEvent.click( thumbsUp );
+		} );
+
+		const textarea = document.querySelector( 'textarea' ) as HTMLTextAreaElement;
+		await act( async () => {
+			fireEvent.change( textarea, { target: { value: 'Great support!' } } );
+		} );
+
+		await act( async () => {
+			fireEvent.click( screen.getByText( 'Send' ) );
+		} );
+
+		expect( mockMutateAsync ).toHaveBeenCalledWith( {
+			ticket_id: 42,
+			score: 'good',
+			comment: 'Great support!',
+			reason_id: '',
+			test_mode: false,
+		} );
+	} );
+
+	it( 'calls onSendComment instead of rateChat when onSendComment is provided', async () => {
+		const onSendComment = jest.fn().mockResolvedValue( undefined );
+		render(
+			<CSATForm ticketId={ 1 } onSendFeedback={ jest.fn() } onSendComment={ onSendComment } />
+		);
+
+		const { thumbsDown } = getThumbsButtons();
+		await act( async () => {
+			fireEvent.click( thumbsDown );
+		} );
+
+		const select = screen.getByLabelText( 'Reason' );
+		await act( async () => {
+			fireEvent.change( select, { target: { value: 'static-reason' } } );
+		} );
+
+		await act( async () => {
+			fireEvent.click( screen.getByText( 'Send' ) );
+		} );
+
+		expect( onSendComment ).toHaveBeenCalledWith( '', 'static-reason', 'bad' );
+		expect( mockMutateAsync ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not call rateChat when ticketId is null and onSendComment is not provided, but still hides the form', async () => {
+		const onFormHidden = jest.fn();
+		render(
+			<CSATForm ticketId={ null } onSendFeedback={ jest.fn() } onFormHidden={ onFormHidden } />
+		);
+
+		const { thumbsDown } = getThumbsButtons();
+		await act( async () => {
+			fireEvent.click( thumbsDown );
+		} );
+
+		const select = screen.getByLabelText( 'Reason' );
+		await act( async () => {
+			fireEvent.change( select, { target: { value: 'static-reason' } } );
+		} );
+
+		await act( async () => {
+			fireEvent.click( screen.getByText( 'Send' ) );
+		} );
+
+		expect( mockMutateAsync ).not.toHaveBeenCalled();
+		expect( onFormHidden ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'falls back to the static reason options when reasonOptions is not provided', async () => {
+		render( <CSATForm ticketId={ 1 } onSendFeedback={ jest.fn() } /> );
+
+		const { thumbsDown } = getThumbsButtons();
+		await act( async () => {
+			fireEvent.click( thumbsDown );
+		} );
+
+		expect( screen.getByText( 'Static reason' ) ).toBeInTheDocument();
+	} );
+
+	it( 'uses the provided reasonOptions, including an empty array, instead of the static list', async () => {
+		render( <CSATForm ticketId={ 1 } onSendFeedback={ jest.fn() } reasonOptions={ [] } /> );
+
+		const { thumbsDown } = getThumbsButtons();
+		await act( async () => {
+			fireEvent.click( thumbsDown );
+		} );
+
+		expect( screen.queryByText( 'Static reason' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/packages/zendesk-client/test/use-managed-zendesk-chat.test.tsx
+++ b/packages/zendesk-client/test/use-managed-zendesk-chat.test.tsx
@@ -91,6 +91,8 @@ jest.mock( '../src/util', () => ( {
 		disabled: false,
 	} ) ),
 	getSmoochContainer: () => globalThis.document.createElement( 'div' ),
+	isCsatTriggerMessage: ( message: { metadata?: { type?: string } } ) =>
+		message?.metadata?.type === 'csat',
 	isSupportedImageType: ( type: string ) =>
 		[ 'image/jpeg', 'image/jpg', 'image/png', 'image/gif' ].includes( type ),
 	isTestModeEnvironment: () => false,


### PR DESCRIPTION
Fixes DOTCOM-18187

## Proposed Changes

* Support Zendesk's native CSAT Survey messaging source (`zd:surveys`) in the Zendesk live chat — previously only our own WPCOM-configured `metadata.type: 'csat'` trigger message was recognized, so a native survey message rendered as an unstyled, non-interactive text bubble.
* Add `isZendeskSurveyMessage` / `isCsatTriggerMessage` predicates in `@automattic/zendesk-client`, reused by `@automattic/odie-client` instead of duplicating the same checks (four inline copies consolidated to one each).
* Add a `ZendeskSurveyRating` component reusing the existing thumbs-up/down `CSATForm` UI, wired to a new `useRateSurveyResponse` hook that submits the rating via Zendesk's Guide GraphQL API (`POST /api/graphql`, `SurveyResponseSubmit` mutation) — the same call Zendesk's own hosted survey webview makes. The corresponding backend endpoint lives in a separate wpcom PR.
* Persist the submitted rating and dismissed/collapsed state on the Zendesk conversation's own metadata (`Smooch.updateConversation`) so the answered state survives the message list remounting the message component — local React state alone doesn't survive that.
* Fix an unstable `key` bug in the message list: both the per-message key fallback and the per-cluster `Fragment` key were built from `crypto.randomUUID()`, regenerated on every render (the clustering function isn't memoized). A changing key forces React to unmount/remount that subtree, so any unrelated re-render was tearing down and rebuilding the whole visible transcript — this is what caused the CSAT form to blink/reset mid-interaction. Both now derive a stable id from the message's own Zendesk-assigned `id` where available.
* `CSATForm` changes (backward-compatible, opt-in for new behavior):
  * Guards against double-submission from a fast double-click on the thumbs buttons, disables them while a request is in flight, and shows the existing loading spinner for that request too (previously only the comment-step submission tracked a loading state).
  * New optional `onSendComment` / `onFormHidden` / `showRatingMessageWithPreDeterminedScore` props, all opt-in — existing callers (`FeedbackForm`, `use-managed-zendesk-chat.tsx`) are unaffected.
  * Font/spacing fixes for the comment step so it visually matches the rest of the message bubble instead of falling back to `@wordpress/components`' default paragraph styling.

## Why are these changes being made?

Zendesk's Sunshine Conversations messaging can deliver CSAT prompts either through a WPCOM-configured trigger message (already supported) or through Zendesk's own native Surveys feature (`source.type: 'zd:surveys'`), and we're now seeing the latter. The documented public REST endpoint for submitting a Survey Response consistently rejects anonymous access-token submission in practice (confirmed against a live Zendesk sandbox instance across several auth variations), so this uses the same undocumented GraphQL mutation Zendesk's own hosted survey page calls — captured from a real browser session completing the same survey successfully.

## Testing Instructions

1. `yarn start`, open the Help Center / Zendesk live chat, and get a support conversation into a state where Zendesk delivers a `zd:surveys` CSAT prompt (requires a Zendesk sandbox/staging instance configured with the native Surveys feature).
2. Click thumbs up or down:
   * Only one rating request should fire even on a fast double-click; both buttons should disable and show a spinner while it's in flight.
   * The "Good 👍" / "Needs improvement 👎" message should appear above the comment box.
   * For "bad", a reason dropdown should also appear.
3. Add a comment (and, for "bad", a reason) and click Send — the message should collapse to just the rating message, matching the old CSAT-flow's look.
4. Reload the page / trigger a re-render of the message list (e.g. a new message arriving) — the answered state should persist instead of resetting to the unanswered thumbs UI.
5. Confirm the old CSAT flow (`metadata.type: 'csat'` trigger message) still behaves exactly as before — `yarn typecheck-packages` passes, and none of its call sites pass the new opt-in `CSATForm` props.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?