### PR TITLE
Help Center: deduplicate the site-aware Tracks call sites

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -10,13 +10,11 @@ import { useCurrentSupportInteraction } from '@automattic/odie-client/src/data/u
 import { getOdieIdFromInteraction } from '@automattic/odie-client/src/utils';
 import { Button, TextControl, Tip } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { getQueryArgs } from '@wordpress/url';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useDebounce } from 'use-debounce';
-import { preventWidows } from 'calypso/lib/formatting';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 /**
  * Internal Dependencies
@@ -28,9 +26,9 @@ import { useSiteAnalysis } from '../data/use-site-analysis';
 import { useSubmitTicketMutation } from '../data/use-submit-support-ticket';
 import { useUserSites } from '../data/use-user-sites';
 import { useHelpCenterTracksEvent } from '../hooks/use-help-center-tracks-event';
+import { useRedirectToArticle } from '../hooks/use-redirect-to-article';
 import { queryClient } from '../query-client';
 import { HELP_CENTER_STORE } from '../stores';
-import { SearchResult } from '../types';
 import { HelpCenterGPT } from './help-center-gpt';
 import HelpCenterSearchResults from './help-center-search-results';
 import { HelpCenterSitePicker } from './help-center-site-picker';
@@ -159,41 +157,10 @@ export const HelpCenterContactForm = () => {
 	const showingSearchResults = params.get( 'show-results' ) === 'true';
 	const simplifiedForm = params.get( 'simplified-form' ) === 'true';
 
-	const redirectToArticle = useCallback(
-		( event: React.MouseEvent< HTMLAnchorElement, MouseEvent >, result: SearchResult ) => {
-			event.preventDefault();
-
-			// if result.post_id isn't set then open in a new window
-			if ( ! result.post_id ) {
-				const tracksData = {
-					search_query: debouncedMessage,
-					force_site_id: true,
-					location: 'help-center',
-					result_url: result.link,
-					post_id: result.post_id,
-					// Article blog, not the site the user needs help with.
-					article_blog_id: result.blog_id,
-				};
-				recordTracksEvent( 'calypso_inlinehelp_article_no_postid_redirect', tracksData );
-				window.open( result.link, '_blank' );
-				return;
-			}
-
-			const params = new URLSearchParams( {
-				link: result.link,
-				postId: String( result.post_id ),
-				query: debouncedMessage || '',
-				title: preventWidows( decodeEntities( result.title ) ),
-			} );
-
-			if ( result.blog_id ) {
-				params.set( 'blogId', String( result.blog_id ) );
-			}
-
-			navigate( `/post/?${ params }` );
-		},
-		[ debouncedMessage, navigate, recordTracksEvent ]
-	);
+	const redirectToArticle = useRedirectToArticle( {
+		searchQuery: debouncedMessage || '',
+		explicitSiteId: supportSite?.ID,
+	} );
 
 	// this indicates the user was happy with the GPT response
 	function handleGPTClose() {

--- a/packages/help-center/src/hooks/test/use-redirect-to-article.tsx
+++ b/packages/help-center/src/hooks/test/use-redirect-to-article.tsx
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment jsdom
+ */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { HelpCenterRequiredContextProvider } from '../../contexts/HelpCenterContext';
+import { useRedirectToArticle } from '../use-redirect-to-article';
+import type { SearchResult } from '../../types';
+
+const mockNavigate = jest.fn();
+
+jest.mock( 'react-router-dom', () => ( {
+	...jest.requireActual( 'react-router-dom' ),
+	useNavigate: () => mockNavigate,
+} ) );
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	...jest.requireActual( '@automattic/calypso-analytics' ),
+	recordTracksEvent: jest.fn(),
+} ) );
+
+const site = { ID: 111, URL: 'https://example.com', name: 'Example' };
+
+function wrapper( { children }: { children: React.ReactNode } ) {
+	return (
+		<MemoryRouter>
+			<HelpCenterRequiredContextProvider
+				value={ {
+					site: site as never,
+					currentRoute: '/',
+					sectionName: 'help-center',
+				} }
+			>
+				{ children }
+			</HelpCenterRequiredContextProvider>
+		</MemoryRouter>
+	);
+}
+
+function clickEvent() {
+	return { preventDefault: jest.fn() } as unknown as React.MouseEvent<
+		HTMLAnchorElement,
+		MouseEvent
+	>;
+}
+
+const resultWithoutPostId = {
+	link: 'https://en.support.wordpress.com/domains/',
+	title: 'Domains',
+	blog_id: 9619154,
+} as SearchResult;
+
+describe( 'useRedirectToArticle', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		window.open = jest.fn();
+	} );
+
+	it( 'reports the article blog separately from the support site', () => {
+		const { result } = renderHook( () => useRedirectToArticle( { searchQuery: 'domains' } ), {
+			wrapper,
+		} );
+
+		result.current( clickEvent(), resultWithoutPostId );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_inlinehelp_article_no_postid_redirect',
+			expect.objectContaining( {
+				search_query: 'domains',
+				result_url: 'https://en.support.wordpress.com/domains/',
+				article_blog_id: 9619154,
+				blog_id: 111,
+				site_context_source: 'help_center_context',
+			} )
+		);
+		expect( window.open ).toHaveBeenCalledWith( resultWithoutPostId.link, '_blank' );
+	} );
+
+	it( 'prefers an explicitly selected support site', () => {
+		const { result } = renderHook(
+			() => useRedirectToArticle( { searchQuery: 'domains', explicitSiteId: 222 } ),
+			{ wrapper }
+		);
+
+		result.current( clickEvent(), resultWithoutPostId );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_inlinehelp_article_no_postid_redirect',
+			expect.objectContaining( { blog_id: 222, site_context_source: 'explicit' } )
+		);
+	} );
+
+	it( 'opens results that have a post id inside the Help Center without recording', () => {
+		const { result } = renderHook( () => useRedirectToArticle( { searchQuery: 'domains' } ), {
+			wrapper,
+		} );
+
+		result.current( clickEvent(), {
+			...resultWithoutPostId,
+			post_id: 185130,
+		} as SearchResult );
+
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+		expect( window.open ).not.toHaveBeenCalled();
+		expect( mockNavigate ).toHaveBeenCalledWith(
+			expect.stringContaining( 'postId=185130&query=domains' )
+		);
+		expect( mockNavigate ).toHaveBeenCalledWith( expect.stringContaining( 'blogId=9619154' ) );
+	} );
+} );

--- a/packages/help-center/src/hooks/use-help-center-search.ts
+++ b/packages/help-center/src/hooks/use-help-center-search.ts
@@ -1,12 +1,8 @@
-/* eslint-disable no-restricted-imports */
 import { useDispatch } from '@wordpress/data';
 import { useState, useCallback, useEffect } from '@wordpress/element';
-import { decodeEntities } from '@wordpress/html-entities';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { preventWidows } from 'calypso/lib/formatting';
 import { HELP_CENTER_STORE } from '../stores';
-import { SearchResult } from '../types';
-import { useHelpCenterTracksEvent } from './use-help-center-tracks-event';
+import { useRedirectToArticle } from './use-redirect-to-article';
 
 export const useHelpCenterSearch = ( onSearchChange?: ( query: string ) => void ) => {
 	const navigate = useNavigate();
@@ -15,7 +11,6 @@ export const useHelpCenterSearch = ( onSearchChange?: ( query: string ) => void 
 	const query = params.get( 'query' );
 	const [ searchQuery, setSearchQuery ] = useState( query || '' );
 	const { setSubject, setMessage } = useDispatch( HELP_CENTER_STORE );
-	const recordTracksEvent = useHelpCenterTracksEvent();
 
 	// when the user sets the search query, let's also populate the email subject and body
 	// for later in case they subject the same query via email
@@ -39,41 +34,7 @@ export const useHelpCenterSearch = ( onSearchChange?: ( query: string ) => void 
 		}
 	}, [ searchQuery, query, navigate ] );
 
-	const redirectToArticle = useCallback(
-		( event: React.MouseEvent< HTMLAnchorElement, MouseEvent >, result: SearchResult ) => {
-			event.preventDefault();
-
-			// if result.post_id isn't set then open in a new window
-			if ( ! result.post_id ) {
-				const tracksData = {
-					search_query: searchQuery,
-					force_site_id: true,
-					location: 'help-center',
-					result_url: result.link,
-					post_id: result.post_id,
-					// Article blog, not the site the user needs help with.
-					article_blog_id: result.blog_id,
-				};
-				recordTracksEvent( 'calypso_inlinehelp_article_no_postid_redirect', tracksData );
-				window.open( result.link, '_blank' );
-				return;
-			}
-
-			const params = new URLSearchParams( {
-				link: result.link,
-				postId: String( result.post_id ),
-				query: searchQuery,
-				title: preventWidows( decodeEntities( result.title ) ),
-			} );
-
-			if ( result.blog_id ) {
-				params.set( 'blogId', String( result.blog_id ) );
-			}
-
-			navigate( `/post/?${ params }` );
-		},
-		[ navigate, recordTracksEvent, searchQuery ]
-	);
+	const redirectToArticle = useRedirectToArticle( { searchQuery } );
 
 	return {
 		searchQuery,

--- a/packages/help-center/src/hooks/use-redirect-to-article.ts
+++ b/packages/help-center/src/hooks/use-redirect-to-article.ts
@@ -3,7 +3,7 @@ import { useCallback } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useNavigate } from 'react-router-dom';
 import { preventWidows } from 'calypso/lib/formatting';
-import { SearchResult } from '../types';
+import type { SearchResult } from '../types';
 import { useHelpCenterTracksEvent } from './use-help-center-tracks-event';
 
 type Options = {

--- a/packages/help-center/src/hooks/use-redirect-to-article.ts
+++ b/packages/help-center/src/hooks/use-redirect-to-article.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-imports */
 import { useCallback } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useNavigate } from 'react-router-dom';

--- a/packages/help-center/src/hooks/use-redirect-to-article.ts
+++ b/packages/help-center/src/hooks/use-redirect-to-article.ts
@@ -1,0 +1,58 @@
+/* eslint-disable no-restricted-imports */
+import { useCallback } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+import { useNavigate } from 'react-router-dom';
+import { preventWidows } from 'calypso/lib/formatting';
+import { SearchResult } from '../types';
+import { useHelpCenterTracksEvent } from './use-help-center-tracks-event';
+
+type Options = {
+	/** Query that produced the result, recorded on the event and carried into the article view. */
+	searchQuery: string;
+	/** Site the support flow is about, when the caller knows better than the Help Center context. */
+	explicitSiteId?: unknown;
+};
+
+/**
+ * Opens a search result: inside the Help Center when the result has a post id, in a new
+ * tab otherwise. Only the new-tab case records an event, because the in-app route records
+ * its own.
+ */
+export function useRedirectToArticle( { searchQuery, explicitSiteId }: Options ) {
+	const navigate = useNavigate();
+	const recordTracksEvent = useHelpCenterTracksEvent( { explicitSiteId } );
+
+	return useCallback(
+		( event: React.MouseEvent< HTMLAnchorElement, MouseEvent >, result: SearchResult ) => {
+			event.preventDefault();
+
+			if ( ! result.post_id ) {
+				recordTracksEvent( 'calypso_inlinehelp_article_no_postid_redirect', {
+					search_query: searchQuery,
+					force_site_id: true,
+					location: 'help-center',
+					result_url: result.link,
+					post_id: result.post_id,
+					// Article blog, not the site the user needs help with.
+					article_blog_id: result.blog_id,
+				} );
+				window.open( result.link, '_blank' );
+				return;
+			}
+
+			const params = new URLSearchParams( {
+				link: result.link,
+				postId: String( result.post_id ),
+				query: searchQuery,
+				title: preventWidows( decodeEntities( result.title ) ),
+			} );
+
+			if ( result.blog_id ) {
+				params.set( 'blogId', String( result.blog_id ) );
+			}
+
+			navigate( `/post/?${ params }` );
+		},
+		[ navigate, recordTracksEvent, searchQuery ]
+	);
+}

--- a/packages/help-center/src/hooks/use-redirect-to-article.ts
+++ b/packages/help-center/src/hooks/use-redirect-to-article.ts
@@ -1,9 +1,10 @@
+/* eslint-disable no-restricted-imports */
 import { useCallback } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useNavigate } from 'react-router-dom';
 import { preventWidows } from 'calypso/lib/formatting';
-import type { SearchResult } from '../types';
 import { useHelpCenterTracksEvent } from './use-help-center-tracks-event';
+import type { SearchResult } from '../types';
 
 type Options = {
 	/** Query that produced the result, recorded on the event and carried into the article view. */

--- a/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
+++ b/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
@@ -109,6 +109,28 @@ function getSmoochSiteId() {
 	return siteId;
 }
 
+type TracksProperties = Record< string, unknown >;
+
+/**
+ * Records against the site the singleton currently knows. Used from the Smooch delegate,
+ * which is installed outside React and so cannot read a hook.
+ */
+function recordWithSmoochSite( eventName: string, properties: TracksProperties = {} ) {
+	recordTracksEvent(
+		eventName,
+		withSiteContext( properties, [ [ 'chat_site', getSmoochSiteId() ] ] )
+	);
+}
+
+/** Records against the site this hook instance was given. */
+function useZendeskTracksEvent( siteId: number | string | undefined ) {
+	return useCallback(
+		( eventName: string, properties: TracksProperties = {} ) =>
+			recordTracksEvent( eventName, withSiteContext( properties, [ [ 'chat_site', siteId ] ] ) ),
+		[ siteId ]
+	);
+}
+
 function useSmoochSiteContext( siteId: number | string | undefined ) {
 	const entryRef = useRef< SmoochSiteEntry >( { siteId } );
 	entryRef.current.siteId = siteId;
@@ -149,10 +171,7 @@ function useSmooch( enabled = true, integrationKey?: string ) {
 				integrationId: isTestMode ? SMOOCH_INTEGRATION_ID_STAGING : integrationId,
 				delegate: {
 					async onInvalidAuth() {
-						recordTracksEvent(
-							'calypso_smooch_messenger_auth_error',
-							withSiteContext( {}, [ [ 'chat_site', getSmoochSiteId() ] ] )
-						);
+						recordWithSmoochSite( 'calypso_smooch_messenger_auth_error' );
 
 						await queryClient.invalidateQueries( {
 							queryKey: [ 'getMessagingAuth', 'zendesk', isTestMode, false ],
@@ -278,6 +297,7 @@ export const useManagedZendeskChat = ( {
 	const connectionStatusRef = useRef( connectionStatus );
 	connectionStatusRef.current = connectionStatus;
 	const hadDisconnectRef = useRef( false );
+	const recordZendeskTracksEvent = useZendeskTracksEvent( siteId );
 
 	const connectionNotice = useConnectionStatusNotice( connectionStatus, true );
 
@@ -320,19 +340,13 @@ export const useManagedZendeskChat = ( {
 	const disconnectedListener = useCallback( () => {
 		hadDisconnectRef.current = true;
 		setConnectionStatus( 'disconnected' );
-		recordTracksEvent(
-			'calypso_smooch_messenger_disconnected',
-			withSiteContext( {}, [ [ 'chat_site', siteId ] ] )
-		);
-	}, [ setConnectionStatus, siteId ] );
+		recordZendeskTracksEvent( 'calypso_smooch_messenger_disconnected' );
+	}, [ setConnectionStatus, recordZendeskTracksEvent ] );
 
 	const reconnectingListener = useCallback( () => {
 		setConnectionStatus( 'reconnecting' );
-		recordTracksEvent(
-			'calypso_smooch_messenger_reconnecting',
-			withSiteContext( {}, [ [ 'chat_site', siteId ] ] )
-		);
-	}, [ setConnectionStatus, siteId ] );
+		recordZendeskTracksEvent( 'calypso_smooch_messenger_reconnecting' );
+	}, [ setConnectionStatus, recordZendeskTracksEvent ] );
 
 	const typingStartListener = useCallback(
 		( { conversation }: ConversationData ) => {
@@ -352,12 +366,9 @@ export const useManagedZendeskChat = ( {
 		// We don't want a "connected" status on page load, it's only useful as a sign of a recovered connection.
 		if ( connectionStatus ) {
 			setConnectionStatus( 'connected' );
-			recordTracksEvent(
-				'calypso_smooch_messenger_connected',
-				withSiteContext( {}, [ [ 'chat_site', siteId ] ] )
-			);
+			recordZendeskTracksEvent( 'calypso_smooch_messenger_connected' );
 		}
-	}, [ setConnectionStatus, connectionStatus, siteId ] );
+	}, [ setConnectionStatus, connectionStatus, recordZendeskTracksEvent ] );
 
 	const navigate = useNavigate();
 
@@ -737,10 +748,7 @@ export const useManagedZendeskChat = ( {
 						// eslint-disable-next-line no-console
 						console.error( 'Error uploading Zendesk chat attachments', error );
 						try {
-							recordTracksEvent(
-								'zendesk_chat_file_upload_failed',
-								withSiteContext( {}, [ [ 'chat_site', siteId ] ] )
-							);
+							recordZendeskTracksEvent( 'zendesk_chat_file_upload_failed' );
 						} catch {
 							// Swallow analytics errors to avoid affecting user flow.
 						}
@@ -760,7 +768,7 @@ export const useManagedZendeskChat = ( {
 			clientId,
 			Smooch,
 			attachFileToConversation,
-			siteId,
+			recordZendeskTracksEvent,
 		]
 	);
 
@@ -792,17 +800,16 @@ export const useManagedZendeskChat = ( {
 			}
 
 			if ( queue.length > 0 ) {
-				recordTracksEvent(
-					'calypso_smooch_messenger_queue_flushed',
-					withSiteContext( { queued_messages: queue.length }, [ [ 'chat_site', siteId ] ] )
-				);
+				recordZendeskTracksEvent( 'calypso_smooch_messenger_queue_flushed', {
+					queued_messages: queue.length,
+				} );
 			}
 
 			return Smooch.getConversationById( conversationId ).then( setConversation );
 		};
 
 		flushAndResync();
-	}, [ connectionStatus, Smooch, conversation?.id, siteId ] );
+	}, [ connectionStatus, Smooch, conversation?.id, recordZendeskTracksEvent ] );
 
 	useEffect( () => {
 		return () => {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-513/help-center-deduplicate-the-site-aware-tracks-call-sites

## Proposed Changes

**Both places where a site-aware Tracks payload was written out by hand now go through one shared recorder.**

Help Center — `redirectToArticle` existed twice, near-verbatim:

- Adds `useRedirectToArticle`, parameterised by the search query and an optional explicit support site.
- Uses it from `use-help-center-search.ts` and `help-center-contact-form.tsx`.
- Keeps the Tracks call inside the hook, so the payload cannot drift between callers.

Zendesk chat — six call sites each repeated `withSiteContext( …, [ [ 'chat_site', siteId ] ] )`:

- Five run inside the hook body and now share `useZendeskTracksEvent( siteId )`.
- The sixth fires from Smooch's `onInvalidAuth` delegate, installed once on the singleton outside React where no hook is callable, so it goes through a module-level `recordWithSmoochSite()` against the same registration.

No behaviour change anywhere. The Help Center copies already produced an identical payload shape and identical article URLs, differing only in where the search query came from; the Zendesk call sites were byte-identical apart from the delegate's site lookup.

## Why are these changes being made?

Duplicated tracking code had already caused a defect. When DOTSUP-507 split the support article's blog out of `blog_id` into `article_blog_id`, two of the three call sites were updated and the contact form was missed — so the same event carried different properties depending on which path the user took to reach it.

That failure mode is quiet. The shared helper drops a `blog_id` it does not recognise rather than raising an error, so a missed call site silently loses the property instead of breaking. It was caught only because a reviewer went looking for a third copy.

The same shape had appeared in the Zendesk chat client: one rule about how a site becomes `blog_id`, written out six times. Collapsing both means the next change to either event happens in one place.

Worth noting for reviewers that these are per-package wrappers rather than one shared hook, and deliberately so. Each package learns its site from a different source — Help Center from React context, Odie from a provider prop, Zendesk from an option plus the Smooch singleton — and the dependency graph rules out a shared context. The logic that decides `blog_id` and stamps `site_context_source` is already centralised in `withSiteContext`; only the line saying where a given package's site comes from differs.

## Testing Instructions

### Calypso

1. Run `yarn start`.
2. Open the Help Center on a site and search for something with results, e.g. `change domain`.
3. Click a result that opens in the Help Center and confirm the article renders with `postId` and `blogId` in the URL.
4. Open the contact form (Get help → contact options) and repeat from its search results — same behaviour.
5. With Tracks recording, confirm `calypso_inlinehelp_article_no_postid_redirect` fires only for results with no post id, carrying `blog_id` for the support site and `article_blog_id` for the article's own blog.
6. Open a Zendesk chat, then use DevTools → Network → Offline and back Online. Confirm `calypso_smooch_messenger_disconnected` and `_connected` still carry `blog_id` with `site_context_source: chat_site`.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
4. Open the Help Center, search, and confirm results open the same way from both the search view and the contact form.

