### PR TITLE
Help Center: attach the support site to article view events

### DIFF
--- a/packages/agents-manager/src/components/support-guide/index.tsx
+++ b/packages/agents-manager/src/components/support-guide/index.tsx
@@ -99,6 +99,7 @@ export default function SupportGuide( {
 							currentSiteDomain={ site?.domain }
 							isEligibleForChat={ isEligibleForChat }
 							forceEmailSupport={ false }
+							siteId={ site?.ID }
 						/>
 					</div>
 					{ ! isFromChat && (

--- a/packages/calypso-analytics/src/utils/site-context.ts
+++ b/packages/calypso-analytics/src/utils/site-context.ts
@@ -14,6 +14,10 @@ export function getValidBlogId( value: unknown ): number | undefined {
  * Attaches the first valid site in `candidates` (highest priority first) as `blog_id`, and
  * its label as `site_context_source`. A `blog_id` already in `properties` is dropped, not
  * used: it is whatever the caller put there, not necessarily the site the event is about.
+ *
+ * `force_site_id` is dropped along with it when nothing resolves. It only has an effect
+ * when no explicit `blog_id` is present, and there it tells Calypso's super props to fall
+ * back to the selected site — which would contradict a `site_context_source` of `none`.
  */
 export function withSiteContext(
 	properties: TracksProperties,
@@ -35,6 +39,8 @@ export function withSiteContext(
 	delete eventProperties.blog_id;
 	if ( resolved ) {
 		eventProperties.blog_id = resolved.blogId;
+	} else {
+		delete eventProperties.force_site_id;
 	}
 	eventProperties.site_context_source = resolved?.source ?? NO_SITE_CONTEXT;
 

--- a/packages/calypso-analytics/test/site-context.ts
+++ b/packages/calypso-analytics/test/site-context.ts
@@ -68,6 +68,24 @@ describe( 'withSiteContext', () => {
 		} );
 	} );
 
+	test( 'drops force_site_id when no site resolved, so super props cannot backfill one', () => {
+		expect( withSiteContext( { force_site_id: true, source: 'article' }, [] ) ).toEqual( {
+			source: 'article',
+			site_context_source: 'none',
+		} );
+	} );
+
+	test( 'keeps force_site_id when a site resolved', () => {
+		expect(
+			withSiteContext( { force_site_id: true, source: 'article' }, [ [ 'chat_site', 123 ] ] )
+		).toEqual( {
+			force_site_id: true,
+			source: 'article',
+			blog_id: 123,
+			site_context_source: 'chat_site',
+		} );
+	} );
+
 	test( 'does not mutate the caller properties', () => {
 		const properties = { source: 'chat', blog_id: 999 };
 		withSiteContext( properties, [ [ 'chat_site', 123 ] ] );

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -186,6 +186,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 									currentSiteDomain={ currentSiteDomain }
 									isEligibleForChat={ isUserEligibleForPaidSupport }
 									forceEmailSupport={ !! forceEmailSupport || ! featureConfig.chat.enabled }
+									siteId={ site?.ID }
 								/>
 							}
 						/>

--- a/packages/support-articles/jest.config.js
+++ b/packages/support-articles/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	preset: '../../test/packages/jest-preset.js',
+	testEnvironment: 'jsdom',
+};

--- a/packages/support-articles/package.json
+++ b/packages/support-articles/package.json
@@ -37,6 +37,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
+		"@automattic/calypso-analytics": "workspace:^",
 		"wpcom-proxy-request": "workspace:^"
 	},
 	"private": true

--- a/packages/support-articles/src/components/help-center-article/index.tsx
+++ b/packages/support-articles/src/components/help-center-article/index.tsx
@@ -1,4 +1,4 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { recordTracksEvent, withSiteContext } from '@automattic/calypso-analytics';
 import { useEffect, createInterpolateElement, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useSearchParams } from 'react-router-dom';
@@ -17,11 +17,14 @@ export const HelpCenterArticle = ( {
 	currentSiteDomain,
 	isEligibleForChat,
 	forceEmailSupport,
+	siteId,
 }: {
 	sectionName: string;
 	currentSiteDomain?: string;
 	isEligibleForChat: boolean;
 	forceEmailSupport: boolean;
+	/** Site the support session is about, attached as `blog_id` on Tracks events. */
+	siteId?: number | string;
 } ) => {
 	const [ searchParams ] = useSearchParams();
 	const postUrl = searchParams.get( 'link' ) || '';
@@ -56,20 +59,24 @@ export const HelpCenterArticle = ( {
 
 	useEffect( () => {
 		if ( post ) {
-			const tracksData = {
-				force_site_id: true,
-				location: 'help-center',
-				section: sectionName,
-				result_url: post.URL,
-				post_id: post.ID,
-				blog_id: post.site_ID,
-				search_query: query,
-				article_source: post.source,
-			};
+			const tracksData = withSiteContext(
+				{
+					force_site_id: true,
+					location: 'help-center',
+					section: sectionName,
+					result_url: post.URL,
+					post_id: post.ID,
+					// Article blog, not the site the user needs help with.
+					article_blog_id: post.site_ID,
+					search_query: query,
+					article_source: post.source,
+				},
+				[ [ 'support_site', siteId ] ]
+			);
 
 			recordTracksEvent( 'calypso_helpcenter_article_viewed', tracksData );
 		}
-	}, [ post, query, sectionName ] );
+	}, [ post, query, sectionName, siteId ] );
 
 	// Trigger event for each section scrolled into view
 	useEffect( () => {
@@ -78,14 +85,18 @@ export const HelpCenterArticle = ( {
 				( entries ) => {
 					entries.forEach( ( entry ) => {
 						if ( entry.isIntersecting ) {
-							const tracksData = {
-								force_site_id: true,
-								location: 'help-center',
-								post_url: post?.URL,
-								post_id: post?.ID,
-								blog_id: post?.site_ID,
-								section_id: entry?.target?.id,
-							};
+							const tracksData = withSiteContext(
+								{
+									force_site_id: true,
+									location: 'help-center',
+									post_url: post?.URL,
+									post_id: post?.ID,
+									// Article blog, not the site the user needs help with.
+									article_blog_id: post?.site_ID,
+									section_id: entry?.target?.id,
+								},
+								[ [ 'support_site', siteId ] ]
+							);
 							recordTracksEvent( 'calypso_helpcenter_article_section_view', tracksData );
 							observer.unobserve( entry.target ); // Unobserve after first intersection
 						}
@@ -101,7 +112,7 @@ export const HelpCenterArticle = ( {
 				observer.disconnect();
 			};
 		}
-	}, [ elementRef, post?.ID, post?.URL, post?.site_ID ] );
+	}, [ elementRef, post?.ID, post?.URL, post?.site_ID, siteId ] );
 
 	return (
 		<div className="help-center-article" ref={ elementRef }>

--- a/packages/support-articles/src/components/test/help-center-article.tsx
+++ b/packages/support-articles/src/components/test/help-center-article.tsx
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment jsdom
+ */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { HelpCenterArticle } from '../help-center-article';
+
+const post = {
+	ID: 185130,
+	URL: 'https://en.support.wordpress.com/domains/',
+	site_ID: 9619154,
+	content: '<p>Article</p>',
+	source: '/support',
+};
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	...jest.requireActual( '@automattic/calypso-analytics' ),
+	recordTracksEvent: jest.fn(),
+} ) );
+
+jest.mock( 'react-router-dom', () => ( {
+	useSearchParams: () => [ new URLSearchParams( { link: post.URL, query: 'domains' } ) ],
+} ) );
+
+jest.mock( '../../hooks/use-post-by-url', () => ( {
+	usePostByUrl: () => ( { data: post, isLoading: false, error: null } ),
+} ) );
+
+jest.mock( '../../hooks/use-help-center-article-tab-component', () => ( {
+	useHelpCenterArticleTabComponent: () => undefined,
+} ) );
+
+jest.mock( '../../hooks/use-help-center-article-scroll', () => ( {
+	useHelpCenterArticleScroll: () => undefined,
+} ) );
+
+jest.mock( '../help-center-article/help-center-article-content', () => ( {
+	__esModule: true,
+	default: () => <div>content</div>,
+} ) );
+
+jest.mock( '../back-to-top-button', () => ( {
+	BackToTopButton: () => null,
+} ) );
+
+beforeAll( () => {
+	// jsdom has no IntersectionObserver; the section-view effect constructs one on mount.
+	window.IntersectionObserver = class {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	} as unknown as typeof IntersectionObserver;
+} );
+
+function renderArticle( siteId?: number | string ) {
+	return render(
+		<HelpCenterArticle
+			sectionName="help-center"
+			isEligibleForChat={ false }
+			forceEmailSupport={ false }
+			siteId={ siteId }
+		/>
+	);
+}
+
+describe( 'HelpCenterArticle analytics', () => {
+	beforeEach( () => jest.clearAllMocks() );
+
+	it( 'reports the support site as blog_id and the docs blog separately', () => {
+		renderArticle( 217279297 );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_helpcenter_article_viewed',
+			expect.objectContaining( {
+				blog_id: 217279297,
+				article_blog_id: 9619154,
+				post_id: 185130,
+				site_context_source: 'support_site',
+			} )
+		);
+	} );
+
+	it( 'reports no site rather than falling back to the article blog', () => {
+		renderArticle( undefined );
+
+		const [ , properties ] = ( recordTracksEvent as jest.Mock ).mock.calls.find(
+			( [ name ] ) => name === 'calypso_helpcenter_article_viewed'
+		);
+
+		expect( properties ).toEqual(
+			expect.objectContaining( {
+				article_blog_id: 9619154,
+				site_context_source: 'none',
+			} )
+		);
+		expect( properties ).not.toHaveProperty( 'blog_id' );
+	} );
+} );

--- a/packages/support-articles/tsconfig.json
+++ b/packages/support-articles/tsconfig.json
@@ -7,5 +7,6 @@
 		"types": []
 	},
 	"include": [ "src" ],
+	"exclude": [ "**/test/*" ],
 	"references": [ { "path": "../zendesk-client" }, { "path": "../odie-client" } ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2343,6 +2343,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/support-articles@workspace:packages/support-articles"
   dependencies:
+    "@automattic/calypso-analytics": "workspace:^"
     wpcom-proxy-request: "workspace:^"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-515/support-article-view-events-report-the-docs-blog-as-blog-id-not-the

## Proposed Changes

**Article view events now report the site the support session is about, instead of the blog that hosts the article.**

- `calypso_helpcenter_article_viewed` and `calypso_helpcenter_article_section_view` resolve `blog_id` through `withSiteContext`, so they also gain `site_context_source`.
- The article's own blog moves to `article_blog_id`, matching what DOTSUP-507 did for the click-side events.
- `HelpCenterArticle` takes an optional `siteId`; both existing callers already had a site in scope and now pass it.
- Adds the `@automattic/calypso-analytics` dependency the package was already importing without declaring.
- Adds a jest project for `packages/support-articles`, which had none, plus the `**/test/*` tsconfig exclusion `help-center` already uses so tests stay out of `dist`.

## Why are these changes being made?

Reading a support article told us which article was read, but not who was reading it. Because `blog_id` held the article's own blog, every view of a given article looked identical no matter whose site the reader was there about — so support content engagement could not be broken down by plan, host, or site, which is the whole point of the parent issue.

The two values are genuinely different things and both are worth keeping, so they now live in separate properties rather than competing for one.

This was found by driving a local Calypso instance and reading the events as they fired: opening the Help Center on a site and reading an article reported the docs blog, while the click that opened that same article correctly reported the user's site after DOTSUP-507.

One caveat worth a reviewer's attention: both payloads set `force_site_id: true`, which keeps the explicit value from being replaced by the Calypso selected site. That flag looks deliberate, which is why this needs the event owner's agreement rather than being treated as a straightforward correction.

## Testing Instructions

### Calypso

1. Run `yarn start`.
2. Open the Help Center on a site whose blog id you know, search for something, and open a result.
3. With Tracks recording, confirm `calypso_helpcenter_article_viewed` carries `blog_id` for your site, `article_blog_id` for the support docs blog, and `site_context_source: support_site`.
4. Scroll the article so a section heading enters view and confirm `calypso_helpcenter_article_section_view` reports the same way.
5. Open the Help Center from a route with no site, such as the Reader, and confirm the events report `site_context_source: none` with no `blog_id` rather than falling back to the docs blog.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
4. Open the Help Center, read a support article, and confirm the same properties.

