### PR TITLE
Jetpack Manage: Link plugin updates to a site-scoped, filtered plugin manager

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/test/use-row-metadata.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/test/use-row-metadata.ts
@@ -259,7 +259,7 @@ describe( 'useRowMetadata', () => {
 		const expected = {
 			eventName: 'calypso_jetpack_agency_dashboard_update_plugins_click_small_screen',
 			isExternalLink: false,
-			link: `/plugins/updates/${ FAKE_SITE.url }`,
+			link: `/plugins/manage/${ FAKE_SITE.url }?updates=1`,
 			isSupported: true,
 			row: rows.plugin,
 			siteDown: false,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { AllowedTypes } from '../../types';
 
@@ -67,11 +68,11 @@ const getLinks = (
 		case 'plugin': {
 			link = `${ siteUrlWithScheme }/wp-admin/plugins.php`;
 			isExternalLink = true;
-			if ( ! isAtomicSite ) {
-				link =
-					status === 'warning'
-						? `/plugins/updates/${ siteUrlWithMultiSiteSupport }`
-						: `/plugins/manage/${ siteUrlWithMultiSiteSupport }`;
+			if ( ! isAtomicSite && ! isA8CForAgencies() ) {
+				link = `/plugins/manage/${ siteUrlWithMultiSiteSupport }`;
+				if ( status === 'warning' ) {
+					link += '?updates=1';
+				}
 				isExternalLink = false;
 			}
 			break;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/test/get-links.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/test/get-links.ts
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
+import getLinks from '../get-links';
+
+jest.mock( 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies' );
+
+const SITE_URL = 'example.com';
+const SITE_URL_WITH_SCHEME = 'https://example.com';
+
+const getPluginLink = ( status: string, isAtomicSite = false ) =>
+	getLinks( 'plugin', status, SITE_URL, SITE_URL_WITH_SCHEME, isAtomicSite );
+
+describe( 'getLinks', () => {
+	beforeEach( () => {
+		jest.mocked( isA8CForAgencies ).mockReturnValue( false );
+	} );
+
+	describe( 'plugin', () => {
+		it( 'links a site with pending updates to the site-scoped plugin manager, pre-filtered', () => {
+			expect( getPluginLink( 'warning' ) ).toEqual( {
+				link: '/plugins/manage/example.com?updates=1',
+				isExternalLink: false,
+			} );
+		} );
+
+		it( 'links a site without pending updates to the site-scoped plugin manager, unfiltered', () => {
+			expect( getPluginLink( 'success' ) ).toEqual( {
+				link: '/plugins/manage/example.com',
+				isExternalLink: false,
+			} );
+		} );
+
+		it( 'preserves the multisite path when building the site slug', () => {
+			const { link } = getLinks(
+				'plugin',
+				'warning',
+				'example.com/subsite',
+				'https://example.com/subsite',
+				false
+			);
+
+			expect( link ).toEqual( '/plugins/manage/example.com::subsite?updates=1' );
+		} );
+
+		it( 'links Atomic sites out to wp-admin', () => {
+			expect( getPluginLink( 'warning', true ) ).toEqual( {
+				link: 'https://example.com/wp-admin/plugins.php',
+				isExternalLink: true,
+			} );
+		} );
+
+		it.each( [ 'warning', 'success' ] )( 'links out to wp-admin in A4A (%s)', ( status ) => {
+			jest.mocked( isA8CForAgencies ).mockReturnValue( true );
+
+			expect( getPluginLink( status ) ).toEqual( {
+				link: 'https://example.com/wp-admin/plugins.php',
+				isExternalLink: true,
+			} );
+		} );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
@@ -190,7 +190,7 @@ describe( '<SiteTable>', () => {
 
 		const pluginEle = getByTestId( `row-${ blogId }-plugin` );
 		expect( pluginEle.getAttribute( 'href' ) ).toEqual(
-			`/plugins/updates/${ urlToSlug( siteUrl ) }`
+			`/plugins/manage/${ urlToSlug( siteUrl ) }?updates=1`
 		);
 		expect( getByText( `${ pluginUpdates.length } Available` ) ).toBeInTheDocument();
 	} );

--- a/client/my-sites/plugins/controller.jsx
+++ b/client/my-sites/plugins/controller.jsx
@@ -106,7 +106,13 @@ export function plugins( context, next ) {
 }
 
 export function renderPluginsDashboard( context, next ) {
-	context.primary = <PluginsDashboard pluginSlug={ context.params.slug } />;
+	context.primary = (
+		<PluginsDashboard
+			pluginSlug={ context.params.slug }
+			siteSlug={ context.params.site }
+			filterUpdates={ context.query.updates === '1' }
+		/>
+	);
 	next();
 }
 

--- a/client/my-sites/plugins/plugins-dashboard/index.tsx
+++ b/client/my-sites/plugins/plugins-dashboard/index.tsx
@@ -3,6 +3,7 @@ import { hasMarketplaceProduct } from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import A4APluginsJetpackBanner from 'calypso/a8c-for-agencies/sections/plugins/plugins-jetpack-banner';
 import QueryDotorgPlugins from 'calypso/components/data/query-dotorg-plugins';
 import QueryJetpackSitesFeatures from 'calypso/components/data/query-jetpack-sites-features';
@@ -44,7 +45,7 @@ import { getAllPlugins as getAllWporgPlugins } from 'calypso/state/plugins/wporg
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import getSelectedOrAllSitesWithJetpackPlugin from 'calypso/state/selectors/get-selected-or-all-sites-with-jetpack-plugin';
 import getSites from 'calypso/state/selectors/get-sites';
-import { isRequestingSites } from 'calypso/state/sites/selectors';
+import { getSiteId, isRequestingSites } from 'calypso/state/sites/selectors';
 import { PluginActionName, PluginActions, Site } from '../hooks/types';
 import { withShowPluginActionDialog } from '../hooks/use-show-plugin-action-dialog';
 import PluginAvailableOnSitesList from '../plugin-management-v2/plugin-details-v2/plugin-available-on-sites-list';
@@ -63,6 +64,8 @@ type ActionCallbacks = Record< PluginActionName, PluginActionCallback >;
 
 interface PluginsDashboardProps {
 	pluginSlug: string;
+	siteSlug?: string;
+	filterUpdates?: boolean;
 	doSearch: ( query: string ) => void; // prop coming from UrlSearch
 	search: string | undefined;
 	showPluginActionDialog: (
@@ -84,6 +87,8 @@ interface PluginsDashboardProps {
 
 const PluginsDashboard = ( {
 	pluginSlug,
+	siteSlug,
+	filterUpdates,
 	doSearch,
 	search: searchTerm,
 	showPluginActionDialog,
@@ -91,8 +96,15 @@ const PluginsDashboard = ( {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const isJetpackCloudOrA8CForAgencies = isJetpackCloud() || isA8CForAgencies();
-	const allSites = useSelector( ( state ) =>
+	const sites = useSelector( ( state ) =>
 		isA8CForAgencies() ? getSelectedOrAllSitesWithJetpackPlugin( state ) : getSites( state )
+	);
+	const selectedSiteId = useSelector( ( state ) =>
+		siteSlug ? getSiteId( state, siteSlug ) : null
+	);
+	const allSites = useMemo(
+		() => ( siteSlug ? sites.filter( ( site ) => site?.ID === selectedSiteId ) : sites ),
+		[ sites, siteSlug, selectedSiteId ]
 	);
 	const siteIds = siteObjectsToSiteIds( allSites ) ?? [];
 	const wporgPlugins = useSelector( ( state ) => getAllWporgPlugins( state ) );
@@ -348,6 +360,7 @@ const PluginsDashboard = ( {
 					pluginSlug={ pluginSlug }
 					currentPlugins={ currentPlugins }
 					initialSearch={ searchTerm }
+					initialFilterUpdates={ filterUpdates }
 					isLoading={ isLoading }
 					onSearch={ doSearch }
 					bulkActionDialog={ bulkActionDialog }

--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -19,17 +19,26 @@ import { PLUGINS_STATUS } from 'calypso/state/plugins/installed/status/constants
 import { Plugin } from 'calypso/state/plugins/installed/types';
 import { useActions } from './use-actions';
 import { useFields } from './use-fields';
-import type { SupportedLayouts } from '@wordpress/dataviews';
+import type { Filter, SupportedLayouts } from '@wordpress/dataviews';
 import './style.scss';
 
 interface Props {
 	pluginSlug: string | null;
 	currentPlugins: Array< Plugin >;
 	initialSearch?: string;
+	initialFilterUpdates?: boolean;
 	isLoading: boolean;
 	onSearch?: ( search: string ) => void;
 	bulkActionDialog: ( action: string, plugins: Array< Plugin > ) => void;
 }
+
+const UPDATES_FILTERS: Filter[] = [
+	{
+		field: 'status',
+		operator: 'isAny',
+		value: [ PLUGINS_STATUS.UPDATE ],
+	},
+];
 
 const openPluginSitesPane = ( plugin: Plugin ) => {
 	recordTracksEvent( 'calypso_plugins_list_open_plugin_sites_pane', {
@@ -42,6 +51,7 @@ export default function PluginsListDataViews( {
 	pluginSlug,
 	currentPlugins,
 	initialSearch,
+	initialFilterUpdates,
 	isLoading,
 	onSearch,
 	bulkActionDialog,
@@ -69,6 +79,7 @@ export default function PluginsListDataViews( {
 			...initialDataViewsState,
 			perPage: 15,
 			search: initialSearch,
+			filters: initialFilterUpdates ? UPDATES_FILTERS : [],
 			fields: [ 'sites', 'update' ],
 			type: shouldUseListView ? DATAVIEWS_LIST : DATAVIEWS_TABLE,
 			titleField: 'plugins',
@@ -93,7 +104,7 @@ export default function PluginsListDataViews( {
 		};
 	} );
 
-	const [ isFilteringUpdates, setIsFilteringUpdates ] = useState( false );
+	const [ isFilteringUpdates, setIsFilteringUpdates ] = useState( !! initialFilterUpdates );
 
 	useEffect( () => {
 		// Sets the correct fields when route changes or viewport changes
@@ -130,13 +141,7 @@ export default function PluginsListDataViews( {
 						} else {
 							setDataViewsState( {
 								...dataViewsState,
-								filters: [
-									{
-										field: 'status',
-										operator: 'isAny',
-										value: [ PLUGINS_STATUS.UPDATE ],
-									},
-								],
+								filters: UPDATES_FILTERS,
 								page: 1,
 							} );
 						}

--- a/client/my-sites/plugins/plugins-list/test/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/test/plugins-list-dataviews.tsx
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { PLUGINS_STATUS } from 'calypso/state/plugins/installed/status/constants';
+import PluginsListDataViews from '../plugins-list-dataviews';
+import type { View } from '@wordpress/dataviews';
+import type { Plugin } from 'calypso/state/plugins/installed/types';
+
+const mockLastView = jest.fn();
+
+jest.mock( 'calypso/components/dataviews', () => ( {
+	DataViews: ( { view, header }: { view: View; header: React.ReactNode } ) => {
+		mockLastView( view );
+		return <div data-testid="dataviews">{ header }</div>;
+	},
+} ) );
+
+jest.mock( 'calypso/components/data/query-dotorg-plugins', () => () => null );
+
+const plugin = (
+	slug: string,
+	status: ( typeof PLUGINS_STATUS )[ keyof typeof PLUGINS_STATUS ][]
+) => ( { slug, id: `${ slug }/${ slug }`, name: slug, sites: {}, status } ) as unknown as Plugin;
+
+const CURRENT_PLUGINS = [
+	plugin( 'jetpack', [ PLUGINS_STATUS.ACTIVE, PLUGINS_STATUS.UPDATE ] ),
+	plugin( 'akismet', [ PLUGINS_STATUS.ACTIVE ] ),
+];
+
+const renderList = ( props: Partial< React.ComponentProps< typeof PluginsListDataViews > > = {} ) =>
+	render(
+		<Provider store={ configureStore()( {} ) }>
+			<PluginsListDataViews
+				pluginSlug={ null }
+				currentPlugins={ CURRENT_PLUGINS }
+				isLoading={ false }
+				bulkActionDialog={ jest.fn() }
+				{ ...props }
+			/>
+		</Provider>
+	);
+
+const updatesFilter = () =>
+	mockLastView.mock.calls
+		.at( -1 )?.[ 0 ]
+		.filters?.find( ( f: { field: string } ) => f.field === 'status' );
+
+describe( '<PluginsListDataViews>', () => {
+	beforeAll( () => {
+		window.matchMedia = jest.fn().mockImplementation( ( query ) => ( {
+			matches: true,
+			media: query,
+			onchange: null,
+			addListener: jest.fn(),
+			removeListener: jest.fn(),
+			addEventListener: jest.fn(),
+			removeEventListener: jest.fn(),
+		} ) );
+	} );
+
+	beforeEach( () => mockLastView.mockClear() );
+
+	it( 'applies the update filter when arriving with initialFilterUpdates', () => {
+		renderList( { initialFilterUpdates: true } );
+
+		expect( updatesFilter() ).toEqual( {
+			field: 'status',
+			operator: 'isAny',
+			value: [ PLUGINS_STATUS.UPDATE ],
+		} );
+	} );
+
+	it( 'shows the update toggle as already pressed', () => {
+		renderList( { initialFilterUpdates: true } );
+
+		expect( screen.getByRole( 'button', { name: /Update available/ } ) ).toHaveAttribute(
+			'aria-pressed',
+			'true'
+		);
+	} );
+
+	it( 'applies no filter without initialFilterUpdates', () => {
+		renderList();
+
+		expect( mockLastView.mock.calls.at( -1 )?.[ 0 ].filters ).toEqual( [] );
+		expect( screen.getByRole( 'button', { name: /Update available/ } ) ).toHaveAttribute(
+			'aria-pressed',
+			'false'
+		);
+	} );
+} );

--- a/client/my-sites/plugins/test/controller-dashboard.js
+++ b/client/my-sites/plugins/test/controller-dashboard.js
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderPluginsDashboard } from '../controller';
+
+jest.mock( '../plugins-dashboard', () => 'PluginsDashboard' );
+
+const renderWith = ( { params = {}, query = {} } = {} ) => {
+	const context = { params, query };
+	const next = jest.fn();
+
+	renderPluginsDashboard( context, next );
+
+	expect( next ).toHaveBeenCalledTimes( 1 );
+	return context.primary.props;
+};
+
+describe( 'renderPluginsDashboard', () => {
+	test( 'scopes the dashboard to the route site and pre-filters when ?updates=1', () => {
+		expect( renderWith( { params: { site: 'example.com' }, query: { updates: '1' } } ) ).toEqual(
+			expect.objectContaining( { siteSlug: 'example.com', filterUpdates: true } )
+		);
+	} );
+
+	test( 'does not filter without the query param', () => {
+		expect( renderWith( { params: { site: 'example.com' } } ) ).toEqual(
+			expect.objectContaining( { siteSlug: 'example.com', filterUpdates: false } )
+		);
+	} );
+
+	test( 'does not filter for any other value of the query param', () => {
+		expect( renderWith( { query: { updates: 'yes' } } ) ).toEqual(
+			expect.objectContaining( { filterUpdates: false } )
+		);
+	} );
+
+	test( 'leaves the dashboard unscoped when the route has no site param', () => {
+		expect( renderWith( { params: { slug: 'jetpack' } } ) ).toEqual(
+			expect.objectContaining( { pluginSlug: 'jetpack', siteSlug: undefined } )
+		);
+	} );
+} );


### PR DESCRIPTION
Fixes MANAGE-3

## Proposed Changes

* Link the Sites dashboard's Plugins column to `/plugins/manage/<site-slug>` in Jetpack Manage, adding `?updates=1` when the site has pending updates, and to the site's `wp-admin/plugins.php` in Automattic for Agencies.
* Scope the plugin manager to the site in the route, so `/plugins/manage/<site-slug>` lists only that site's plugins.
* Apply the existing "Update available" filter on arrival when `?updates=1` is present.
* Add unit tests for the link, the route-to-props wiring, and the seeded filter.

## Why are these changes being made?

The Plugins column of the Sites dashboard shows a warning like "3 Available" for any site with pending plugin updates. `getLinks` in `client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts` built that cell's link as follows: Atomic sites got an external link to `wp-admin/plugins.php`, and non-Atomic (self-hosted, Jetpack-connected) sites got `/plugins/updates/<slug>` when updates were pending and `/plugins/manage/<slug>` otherwise.

`/plugins/updates/<slug>` only exists as a route in Calypso's `plugins` section, which registers `/plugins/:pluginFilter(active|inactive|updates)/:site_id?`. That section is not enabled in Jetpack Manage or in A4A — both set `enable_all_sections: false` and neither lists a `plugins` key in its config, so `sections-filter.js` drops it and its page.js handlers are never registered. Jetpack Manage registers its own routes instead (`/plugins`, `/plugins/manage/sites`, `/plugins/manage/sites/:slug`, `/plugins/manage/:site`, `/plugins/:plugin`), none of which match a two-segment path like `/plugins/updates/example.com`.

The result is a dead link. The cell renders a same-origin `<a href>`, so page.js intercepts the click and pushes the new URL, then finds no matching route. Its `unhandled()` fallback compares `window.location` against the context's canonical path, sees they already match because the push happened first, and returns without doing anything. The address bar changes to `/plugins/updates/<slug>`, no route handler runs, `context.primary` is never set, and the previous view stays on screen.

A4A is worse: it registers no per-site plugins route at all. Its `/plugins/manage/sites/:slug` takes a *plugin* slug, which `renderPluginsDashboard` passes through as `pluginSlug`, so both branches of the non-Atomic link are dead there.

Sending Jetpack Manage to `/plugins/manage/<slug>` fixes the dead link but not the expectation the cell sets up. That route is registered, but `renderPluginsDashboard` only forwards `context.params.slug`; `params.site` is read solely by `pluginManagementContext` to decide whether to draw a sidebar. `PluginsDashboard` then selects every site via `getSites` and lists every plugin across all of them, unfiltered. Clicking "3 Available" on one site would land on a list of every plugin on every site, with those three somewhere inside it.

This change carries the site and the update intent through to the list. The site comes from the route, which already has it. The filter comes from a query param, which the dashboard reads and uses to seed the DataViews `status` filter that the page's own "Update available (N)" header toggle already applies — so the filter is visible as a pressed button and clears in one click.

Two notes on scope:

* A4A keeps linking out to `wp-admin/plugins.php` rather than following Jetpack Manage, because it has no route to follow it to. That matches what its own site preview pane already does for plugins ("we are currently working to make this section function from the Automattic for Agencies dashboard; in the meantime, you'll be taken to WP-Admin").
* Site scoping is a prop rather than the usual `siteSelection` middleware. `siteSelection` sets the global `selectedSiteId`, which is sticky and would then leak into the multi-site views at `/plugins/manage/sites`, requiring a second change to clear it there. `siteSlug` is only ever set on Jetpack Manage's `/plugins/manage/:site`, so Calypso and A4A keep today's behavior by construction.

## Testing Instructions

Prerequisites: a local Calypso dev instance, and an agency account with at least one self-hosted (non-Atomic) Jetpack site that has one or more plugin updates available.

**Jetpack Manage**

1. Run `yarn start`.
2. Visit `http://jetpack.cloud.localhost:3000/dashboard`.
3. Find a self-hosted site whose Plugins column shows a warning like "3 Available", and click that cell.
4. Verify the URL is `/plugins/manage/<site-slug>?updates=1` and the plugin manager renders. Before this change the URL changed to `/plugins/updates/<site-slug>` and the page never updated.
5. Verify the list contains only plugins that have an update available, and that every row's Sites column reads `1`.
6. Verify the "Update available (N)" button above the list is already pressed.
7. Click that button. Verify the filter clears and all of that site's plugins appear, still only that site's.
8. Find a self-hosted site with no pending plugin updates and click its Plugins cell. Verify the URL is `/plugins/manage/<site-slug>` with no query param, the list is unfiltered, and it still shows only that site.
9. Visit `/plugins/manage/sites`. Verify every site's plugins are listed again.
10. Click the Plugins cell for an Atomic site. Verify it still opens `https://<site>/wp-admin/plugins.php` in a new tab.

**Automattic for Agencies**

11. Run `yarn start-a8c-for-agencies`.
12. Visit the Sites dashboard and click the Plugins cell for a self-hosted site with pending updates.
13. Verify it opens `https://<site>/wp-admin/plugins.php` in a new tab, matching the "Manage Plugins in wp-admin" link in the site preview pane's Plugins tab. Before this change the URL changed to `/plugins/updates/<site-slug>` and the page never updated.
14. Visit `/plugins/manage/sites` and verify it still lists every site's plugins.

**Unit tests**

```
yarn test-client client/my-sites/plugins client/jetpack-cloud/sections/agency-dashboard/sites-overview
```

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
