### PR TITLE
Checkout: name the missing billing fields for Ebanx

### DIFF
--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -285,33 +285,34 @@ function isCreditCardFormValid(
 			// VGS card fields validation is handled separately via useVgsFormValidation hook
 			// which checks the VGS form state directly
 			let isValid = true;
-			const requiredFields = [
-				'cardholderName',
-				'state',
-				'city',
-				'postal-code',
-				'address-1',
-				'street-number',
-				'phone-number',
-				'document',
-			];
+			// The required fields, in the order the form renders them, mapped to
+			// the labels it renders them under. Keep in sync with
+			// country-specific-payment-fields.tsx and credit-card-fields.tsx:
+			// the notice is only useful if it names the fields the way the form
+			// does.
+			const requiredFieldLabels: Record< string, string > = {
+				cardholderName: __( 'Cardholder name' ),
+				document: __( 'Taxpayer Identification Number' ),
+				'phone-number': __( 'Phone' ),
+				'address-1': __( 'Address' ),
+				'street-number': __( 'Street Number' ),
+				city: __( 'City' ),
+				state: __( 'State' ),
+				'postal-code': __( 'Postal Code' ),
+			};
+			const missingFieldLabels: string[] = [];
 
-			requiredFields.forEach( ( fieldName ) => {
+			Object.entries( requiredFieldLabels ).forEach( ( [ fieldName, label ] ) => {
 				const fieldValue = rawState[ fieldName ]?.value;
 				if ( ! fieldValue || fieldValue.trim() === '' ) {
 					isValid = false;
 					store.dispatch( actions.setFieldError( fieldName, __( 'This field is required' ) ) );
+					missingFieldLabels.push( label );
 				}
 			} );
 
 			if ( ! isValid ) {
-				// Unlike the stripe branch above, nothing here previously
-				// surfaced an error notice or scrolled the invalid fields
-				// into view, so the button appeared to do nothing.
-				// requiredFields holds raw keys like 'street-number' rather
-				// than labels, so this stays generic; naming them is
-				// follow-up work.
-				setFieldsError();
+				setFieldsError( missingFieldLabels );
 			}
 
 			debug( 'ebanx validation - cardholder name and contact details', {

--- a/client/my-sites/checkout/src/test/credit-card.tsx
+++ b/client/my-sites/checkout/src/test/credit-card.tsx
@@ -43,7 +43,7 @@ jest.mock( '@stripe/react-stripe-js', () => {
 	return { ...stripe, useElements: mockUseElements };
 } );
 
-function TestWrapper( { paymentProcessors = undefined } ) {
+function TestWrapper( { paymentProcessors = undefined, additionalMethodArgs = undefined } ) {
 	const [ store ] = useState( () => createTestReduxStore() );
 	const [ queryClient ] = useState( () => new QueryClient() );
 	const [ testRegistry ] = useState( () => createRegistry( {} ) );
@@ -52,16 +52,19 @@ function TestWrapper( { paymentProcessors = undefined } ) {
 		<RegistryProvider value={ testRegistry }>
 			<ReduxProvider store={ store }>
 				<QueryClientProvider client={ queryClient }>
-					<TestWrapperInner paymentProcessors={ paymentProcessors } />
+					<TestWrapperInner
+						paymentProcessors={ paymentProcessors }
+						additionalMethodArgs={ additionalMethodArgs }
+					/>
 				</QueryClientProvider>
 			</ReduxProvider>
 		</RegistryProvider>
 	);
 }
 
-function TestWrapperInner( { paymentProcessors = undefined } ) {
+function TestWrapperInner( { paymentProcessors = undefined, additionalMethodArgs = undefined } ) {
 	const creditCardStore = useCreateCreditCardStore();
-	const paymentMethod = useCreateCreditCardMethod( creditCardStore );
+	const paymentMethod = useCreateCreditCardMethod( creditCardStore, additionalMethodArgs );
 	return (
 		<>
 			<GlobalNotices />
@@ -87,7 +90,7 @@ const cardNumber = '4242424242424242';
 const cardExpiry = '05/99';
 const cardCvv = '123';
 const activePayButtonText = 'Complete Checkout';
-function useCreateCreditCardMethod( store: CardStoreType, additionalArgs = {} ) {
+function useCreateCreditCardMethod( store: CardStoreType, additionalArgs = undefined ) {
 	const [ method ] = useState( () =>
 		createCreditCardMethod( {
 			store,
@@ -209,6 +212,27 @@ describe( 'Credit card payment method', () => {
 
 		const element = await screen.findByText(
 			'Please fill out the required fields: Cardholder name'
+		);
+		expect( element ).not.toBeFalsy();
+		expect( processorFunction ).not.toHaveBeenCalled();
+	} );
+
+	it( 'names the missing billing fields when using Ebanx', async () => {
+		const user = userEvent.setup();
+		const processorFunction = jest.fn( () => Promise.resolve( makeSuccessResponse( {} ) ) );
+		render(
+			<TestWrapper
+				paymentProcessors={ { card: processorFunction } }
+				additionalMethodArgs={ { shouldUseEbanx: true } }
+			/>
+		);
+
+		await waitFor( () => expect( screen.getByText( activePayButtonText ) ).not.toBeDisabled() );
+		await user.click( await screen.findByText( activePayButtonText ) );
+
+		// Every billing field is empty, so all of them are named, in form order.
+		const element = await screen.findByText(
+			'Please fill out the required fields: Cardholder name, Taxpayer Identification Number, Phone, Address, Street Number, City, State, and Postal Code'
 		);
 		expect( element ).not.toBeFalsy();
 		expect( processorFunction ).not.toHaveBeenCalled();


### PR DESCRIPTION
Part of CHE-529. Stacked on #113396, review that one first.

### Changes proposed in this Pull Request

The Ebanx branch of `isCreditCardFormValid` showed the generic "something seems to be missing" notice, because its required fields were raw keys (`street-number`, `document`) rather than labels. This maps them to the labels the form already renders them under, so the notice names them:

> Please fill out the required fields: Cardholder name, Taxpayer Identification Number, Phone, Address, Street Number, City, State, and Postal Code

The msgids are the ones `country-specific-payment-fields.tsx` already uses, so no new strings to translate. The separate `requiredFields` array is gone, the map is now the single source for both which fields are required and what they are called, in the order the form renders them.

### Testing

Adds the first test that touches this branch. `isCreditCardFormValid` isn't exported, so it goes through the rendered form with `shouldUseEbanx`. Verified it fails when the change is reverted.

- `npx jest --config=test/client/jest.config.js client/my-sites/checkout/src/test/credit-card.tsx` → 7/7

### Unrelated thing I ran into

`credit-card-fields.tsx:200` renders the Ebanx cardholder label as `__( 'Cardholder name', 'calypso' )`. Nothing in the repo ever calls `setLocaleData` for a `calypso` domain (`calypso-i18n-provider` calls it with no domain, so only `default` is populated), so that string always falls back to English no matter the locale. Not touching it here, but it affects the shipped label.
