### PR TITLE
Playground: start the blueprint import at most once per site

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-setup/index.tsx
@@ -27,6 +27,7 @@ export const PlaygroundSetupStep: Step< {
 	const { submit } = props.navigation;
 	const { __ } = useI18n();
 	const playgroundClientRef = useRef< PlaygroundClient | null >( null );
+	const blueprintImportStartedForSiteRef = useRef< number | null >( null );
 	const { siteId, siteSlug } = useSiteData();
 	const [ query ] = useSearchParams();
 	const { mutateAsync: importBlueprint } = useImportBlueprint();
@@ -35,6 +36,16 @@ export const PlaygroundSetupStep: Step< {
 		// If blueprint exists, import it and then submit
 		const blueprint = query.get( 'blueprint' );
 		if ( blueprint && submit && siteId ) {
+			// Start the import at most once per site. This effect's deps (`query`,
+			// `submit`) get new identities across renders, and dev hot-reloads re-run
+			// it — a second POST while the first import is still in flight is rejected
+			// with a 409 "Simultaneous imports are not permitted", which left the flow
+			// stuck because the losing call never reaches submit().
+			if ( blueprintImportStartedForSiteRef.current === siteId ) {
+				return;
+			}
+			blueprintImportStartedForSiteRef.current = siteId;
+
 			const runBlueprintImport = async () => {
 				try {
 					await importBlueprint( { blueprint, siteId } );


### PR DESCRIPTION
## Why

Loading `/setup/onboarding/blueprint?blueprint=<id>` (which hands off to the `importerPlayground` step) logs:

```
ImportExistsError: Simultaneous imports are not permitted.
    at runBlueprintImport (playground-setup/index.tsx:73)
```

The import effect has **no idempotency guard**:

```tsx
}, [ query, submit, siteSlug, siteId, importBlueprint ] );
```

`query` (from `useSearchParams`) and `submit` get new identities across renders, and dev hot-reloads re-run the effect (the reported stack came through `webpack-client.ts → processUpdate → dispatchSetState`). So `POST /sites/{id}/imports/library/new` can fire more than once for one site.

Server-side, `RESTAPI_Import_Manager::can_import()` only permits a start when there's no import record — or its status is in `{new, finished, failed, stopped, expired}` and no `{importer}_job_id` option lingers. A concurrent start is therefore rejected with a **409 `import_exists`**. Since only the *winning* call reaches `submit()`, the loser just `console.error`s and the flow can dead-end on the setup step.

## What

Guard the start with a `useRef` keyed on `siteId`, so the import fires at most once per site regardless of re-renders or hot-reloads. A genuine retry still works — a page load remounts the step and resets the ref.

## Testing

- Repro: load the blueprint onboarding entry in local dev; previously two identical `ImportExistsError`s appeared (one HMR-triggered), now a single import starts and the step advances.
- eslint clean. Note: this step has no existing test coverage, so no unit test is added here — happy to add one with the `useSiteData` / `useImportBlueprint` mocks if reviewers want it.

Fixes the "Simultaneous imports are not permitted" report (BLU-7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)