### PR TITLE
Security: update React Router to 7.18.2 (merge 2026-08-10)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -197,7 +197,7 @@
 		"react-markdown": "^8.0.7",
 		"react-modal": "^3.16.3",
 		"react-redux": "^9.2.0",
-		"react-router-dom": "7.18.0",
+		"react-router-dom": "7.18.2",
 		"react-slider": "^2.0.6",
 		"react-transition-group": "^4.4.5",
 		"redux": "^5.0.1",
@@ -247,7 +247,7 @@
 		"html-loader": "^5.1.0",
 		"ignore-loader": "^0.1.2",
 		"pkg-dir": "^5.0.0",
-		"react-router": "7.18.0",
+		"react-router": "7.18.2",
 		"react-test-renderer": "^18.3.1",
 		"redux-mock-store": "^1.5.5",
 		"storybook": "^9.1.20"

--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -70,7 +70,7 @@
 		"deepmerge": "^4.3.1",
 		"history": "^5.3.0",
 		"i18n-calypso": "workspace:^",
-		"react-router-dom": "7.18.0",
+		"react-router-dom": "7.18.2",
 		"wpcom-proxy-request": "workspace:^"
 	},
 	"devDependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -82,7 +82,7 @@
 		"lodash": "^4.18.1",
 		"prop-types": "^15.8.1",
 		"react-modal": "^3.16.3",
-		"react-router-dom": "7.18.0",
+		"react-router-dom": "7.18.2",
 		"tslib": "^2.8.1",
 		"utility-types": "^3.10.0"
 	},

--- a/packages/design-picker/package.json
+++ b/packages/design-picker/package.json
@@ -51,7 +51,7 @@
 		"@wordpress/url": "^4.48.0",
 		"clsx": "^2.1.1",
 		"react-intersection-observer": "^9.4.3",
-		"react-router-dom": "7.18.0",
+		"react-router-dom": "7.18.2",
 		"tslib": "^2.8.1",
 		"utility-types": "^3.10.0"
 	},

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -66,7 +66,7 @@
 		"react-intersection-observer": "^9.4.3",
 		"react-markdown": "^9.0.1",
 		"react-redux": "^9.2.0",
-		"react-router-dom": "7.18.0",
+		"react-router-dom": "7.18.2",
 		"smooch": "^5.7.17",
 		"tslib": "^2.8.1",
 		"wpcom-proxy-request": "^7.0.5"

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -61,8 +61,8 @@
 		"clsx": "^2.1.1",
 		"debug": "^4.4.1",
 		"i18n-calypso": "workspace:^",
-		"react-router": "7.18.0",
-		"react-router-dom": "7.18.0",
+		"react-router": "7.18.2",
+		"react-router-dom": "7.18.2",
 		"tslib": "^2.8.1",
 		"wpcom-proxy-request": "workspace:^"
 	},

--- a/packages/zendesk-client/package.json
+++ b/packages/zendesk-client/package.json
@@ -52,7 +52,7 @@
 		"@wordpress/url": "^4.48.0",
 		"clsx": "^2.1.1",
 		"dompurify": "3.4.12",
-		"react-router-dom": "7.18.0",
+		"react-router-dom": "7.18.2",
 		"smooch": "^5.7.17",
 		"tslib": "^2.8.1",
 		"wpcom-proxy-request": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,7 +220,7 @@ __metadata:
     i18n-calypso: "workspace:^"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    react-router-dom: "npm:7.18.0"
+    react-router-dom: "npm:7.18.2"
     smooch: "npm:^5.7.17"
     typescript: "npm:^6.0.3"
     wpcom-proxy-request: "workspace:^"
@@ -893,7 +893,7 @@ __metadata:
     postcss: "npm:^8.5.15"
     prop-types: "npm:^15.8.1"
     react-modal: "npm:^3.16.3"
-    react-router-dom: "npm:7.18.0"
+    react-router-dom: "npm:7.18.2"
     storybook: "npm:^9.1.20"
     tslib: "npm:^2.8.1"
     typescript: "npm:^6.0.3"
@@ -1123,7 +1123,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     react-intersection-observer: "npm:^9.4.3"
-    react-router-dom: "npm:7.18.0"
+    react-router-dom: "npm:7.18.2"
     redux: "npm:^5.0.1"
     tslib: "npm:^2.8.1"
     typescript: "npm:^6.0.3"
@@ -1929,7 +1929,7 @@ __metadata:
     react-intersection-observer: "npm:^9.4.3"
     react-markdown: "npm:^9.0.1"
     react-redux: "npm:^9.2.0"
-    react-router-dom: "npm:7.18.0"
+    react-router-dom: "npm:7.18.2"
     smooch: "npm:^5.7.17"
     tslib: "npm:^2.8.1"
     typescript: "npm:^6.0.3"
@@ -2044,8 +2044,8 @@ __metadata:
     i18n-calypso: "workspace:^"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    react-router: "npm:7.18.0"
-    react-router-dom: "npm:7.18.0"
+    react-router: "npm:7.18.2"
+    react-router-dom: "npm:7.18.2"
     redux: "npm:^5.0.1"
     sass-loader: "npm:^16.0.5"
     storybook: "npm:^9.1.20"
@@ -2755,7 +2755,7 @@ __metadata:
     dompurify: "npm:3.4.12"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    react-router-dom: "npm:7.18.0"
+    react-router-dom: "npm:7.18.2"
     smooch: "npm:^5.7.17"
     tslib: "npm:^2.8.1"
     typescript: "npm:^6.0.3"
@@ -14727,8 +14727,8 @@ __metadata:
     react-markdown: "npm:^8.0.7"
     react-modal: "npm:^3.16.3"
     react-redux: "npm:^9.2.0"
-    react-router: "npm:7.18.0"
-    react-router-dom: "npm:7.18.0"
+    react-router: "npm:7.18.2"
+    react-router-dom: "npm:7.18.2"
     react-slider: "npm:^2.0.6"
     react-test-renderer: "npm:^18.3.1"
     react-transition-group: "npm:^4.4.5"
@@ -27965,21 +27965,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:7.18.0":
-  version: 7.18.0
-  resolution: "react-router-dom@npm:7.18.0"
+"react-router-dom@npm:7.18.2":
+  version: 7.18.2
+  resolution: "react-router-dom@npm:7.18.2"
   dependencies:
-    react-router: "npm:7.18.0"
+    react-router: "npm:7.18.2"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
-  checksum: 035303f4d14680bf5356ab20e40889fc7bac281f59399c34b8fd0ed884e2f8e9e1b17ce7e668cad5e8bc1b428fe32a33d97509947568a23f4271e0392501304c
+  checksum: 234926d664a5b5c355aeb8642f505784facbb63321231428f24e5ea7fb859876443082d63eef4b8167a01ea8d8dab231a666736343c3e4a86a05b2fcb88927b5
   languageName: node
   linkType: hard
 
-"react-router@npm:7.18.0":
-  version: 7.18.0
-  resolution: "react-router@npm:7.18.0"
+"react-router@npm:7.18.2":
+  version: 7.18.2
+  resolution: "react-router@npm:7.18.2"
   dependencies:
     cookie: "npm:^1.0.1"
     set-cookie-parser: "npm:^2.6.0"
@@ -27989,7 +27989,7 @@ __metadata:
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 7ab6c6dc7efdc14092486d63f55b04f9e3ef269fdec8c695a513f69e55d02a9beab8f637a13396952815d85accf16e7db2d65d9cbb68def13c349be82ceb5aee
+  checksum: 513b04adf020fcf95124557418e003d16b175765045332858d5817b045e49dfe33b529c4871c57b0cddf24fa5432589ffc45d1a9a5b398b069f02adb755fab15
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed Changes

* Update every direct `react-router` and `react-router-dom` dependency from 7.18.0 to 7.18.2.
* Regenerate `yarn.lock` so both packages resolve to one patched version.

## Why are these changes being made?

* Resolve Dependabot alerts #572, #573, and #574 for GHSA-qwww-vcr4-c8h2.
* Supersede #112940, which updates only `react-router` and leaves `react-router-dom` pulling a vulnerable 7.18.0 copy. That split package state caused router-context failures in unit tests.
* React Router 7.18.2 has passed the seven-day dependency age gate.

## Testing Instructions

* Run `yarn install --immutable`.
* Run `yarn why react-router -R` and `yarn why react-router-dom -R`; confirm both resolve only to 7.18.2.
* Run `yarn test-client client/landing/stepper/declarative-flow --runInBand`; confirm 104 suites and 712 tests pass.
* Run `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client`.
* Review the E2E and unit-test CI checks before merge.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents, interfaces, and assistive technologies (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have you tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
