### PR TITLE
Domains: stop sending free site addresses to a domain page that 404s

### DIFF
--- a/client/state/site-address-change/actions.js
+++ b/client/state/site-address-change/actions.js
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { translate } from 'i18n-calypso';
 import wpcom from 'calypso/lib/wp';
-import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
+import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import {
 	SITE_ADDRESS_AVAILABILITY_REQUEST,
 	SITE_ADDRESS_AVAILABILITY_SUCCESS,
@@ -173,11 +173,9 @@ export const requestSiteAddressChange =
 
 				// site slug, potentially freshly updated by the `requestSite` above
 				const siteSlug = getSiteSlug( getState(), siteId );
-				// new name of the `*.wordpress.com` domain that we just changed
-				const newDomain = newSlug + '.' + domain;
 
 				if ( ! skipRedirection ) {
-					page( domainManagementEdit( siteSlug, newDomain ) );
+					page.replace( domainManagementList( siteSlug ) );
 				}
 			}
 		} catch ( error ) {


### PR DESCRIPTION
## Proposed Changes

* After a site address change, land back on the site's domains list instead of the domain settings page for the new `*.wordpress.com` address.

## Why are these changes being made?

`requestSiteAddressChange` ended with `page( domainManagementEdit( siteSlug, newDomain ) )`, where `newDomain` is always a free `*.wordpress.com` address. Nothing renders that page: the classic settings page has no branch for free addresses, and for people on the new dashboard the URL redirects into `domains/$domainName`, whose loader fetches `/domain-details/:domain` and fails with `invalid_domain`.

The redirect only existed because the URL still held the old address — it dates from when the "Change site address" UI lived on that very page, removed in #41196. Every caller added since passes `skipRedirection` and navigates itself; the classic domains list is the last one that doesn't, so it now gets `domainManagementList( siteSlug )` — the same list, at the new slug.

## Testing Instructions

Needs a Simple site using a free `*.wordpress.com` address.

1. From the site's domains list in classic, use the row action **Change site address** and complete the change.
2. After: you stay on the domains list, now at `/domains/manage/<new-slug>`. Before: `/domains/manage/<new-sub>.wordpress.com/edit/...`, which renders an empty settings page — or errors on `invalid_domain` for a forced-opt-in account.
3. Confirm Back doesn't return to the pre-change URL (the navigation uses `page.replace`).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
