### PR TITLE
Dashboard: show rollout advance notice to all users

### DIFF
--- a/client/dashboard/utils/hosting-dashboard-enrollment.ts
+++ b/client/dashboard/utils/hosting-dashboard-enrollment.ts
@@ -102,9 +102,9 @@ export function isOptInToggleVisible(
 }
 
 /**
- * Whether the advanced notice should be visible for this user. Hidden for
- * escape-hatched users (forced opt-in or opt-out), whose enrollment changes
- * only via support tooling.
+ * Whether the advanced notice should be visible for this user. Shown to every
+ * user once the flag is on, except escape-hatched users (forced opt-in or
+ * opt-out), whose enrollment changes only via support tooling.
  */
 export function isAdvancedNoticeVisible(
 	preference: HostingDashboardOptIn | undefined,
@@ -114,9 +114,5 @@ export function isAdvancedNoticeVisible(
 		return false;
 	}
 
-	return (
-		config.isEnabled( 'dashboard/rollout-advance-notice' ) &&
-		!! userId &&
-		userId % 100 < ROLLOUT_PERCENTAGE
-	);
+	return config.isEnabled( 'dashboard/rollout-advance-notice' ) && !! userId;
 }

--- a/client/dashboard/utils/test/hosting-dashboard-enrollment.ts
+++ b/client/dashboard/utils/test/hosting-dashboard-enrollment.ts
@@ -116,12 +116,9 @@ describe( 'isAdvancedNoticeVisible', () => {
 	describe( 'with the rollout-advance-notice flag on', () => {
 		beforeEach( () => enableFlags( 'dashboard/rollout-advance-notice' ) );
 
-		it( 'shows the banner to users who can still opt in', () => {
+		it( 'shows the banner to every user, regardless of cohort', () => {
 			expect( isAdvancedNoticeVisible( undefined, IN_COHORT ) ).toBe( true );
-		} );
-
-		it( 'hides the banner from non-cohort users', () => {
-			expect( isAdvancedNoticeVisible( undefined, OUT_OF_COHORT ) ).toBe( false );
+			expect( isAdvancedNoticeVisible( undefined, OUT_OF_COHORT ) ).toBe( true );
 		} );
 
 		it( 'hides the banner from escape-hatched (forced-opt-in) users', () => {


### PR DESCRIPTION
Related: https://github.com/Automattic/wp-calypso/pull/112350

## Proposed Changes

* Remove the 50% cohort check that gated the hosting dashboard rollout advance-notice banner.
* The banner now shows to every logged-in user while the `dashboard/rollout-advance-notice` flag is on.
* Users on the support escape hatch (forced opt-in or forced opt-out) still never see it.

## Why are these changes being made?

* The advance notice warns users that their default experience is moving to the new hosting dashboard. It was originally scoped to the same 50% cohort as the rollout itself, so only half of users were being warned.
* We want everyone to get the heads-up ahead of the wider rollout, so the notice should no longer depend on cohort membership. The flag remains the single switch for turning it on and off.

## Testing Instructions

* Enable the `dashboard/rollout-advance-notice` flag.
* Log in as a user whose ID is outside the old 50% cohort (last two digits >= 50) and visit the sites list / plugins pages — the advance-notice banner should now appear.
* Confirm the banner is still hidden for users with a forced opt-in or forced opt-out preference.
* `yarn test-client client/dashboard/utils/test/hosting-dashboard-enrollment.ts`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)