### PR TITLE
Dashboard: Fix sidebar navigator crash when matches is empty

### DIFF
--- a/client/dashboard/components/sidebar-navigator/index.tsx
+++ b/client/dashboard/components/sidebar-navigator/index.tsx
@@ -18,7 +18,10 @@ import './style.scss';
  * Example: given routeId `/sites/$siteSlug` and screen paths `['/', '/sites/$siteSlug', '/me']`,
  * it tries `/sites` (no match), then `/` (match) → returns `/`.
  */
-function findParentPath( routeId: string, screenPaths: string[] ): string | undefined {
+function findParentPath( routeId: string | undefined, screenPaths: string[] ): string | undefined {
+	if ( ! routeId ) {
+		return undefined;
+	}
 	const parts = routeId.split( '/' );
 	while ( parts.length > 1 ) {
 		parts.pop();
@@ -76,9 +79,7 @@ function UnforwardedSidebarNavigator(
 
 	const previousPath = usePrevious( activePath );
 	const isBack =
-		previousPath !== undefined &&
-		activePath !== previousPath &&
-		activePath === findParentPath( previousPath, screenPaths );
+		activePath !== previousPath && activePath === findParentPath( previousPath, screenPaths );
 
 	const contextValue = useMemo( () => ( { activePath, isBack } ), [ activePath, isBack ] );
 


### PR DESCRIPTION
## Proposed Changes

* Fix a production crash in the Dashboard sidebar navigator: `findParentPath` now guards against an undefined `routeId` instead of calling `.split()` on it.
* Simplify the `isBack` check to rely on that guard (drops the now-redundant `previousPath !== undefined` clause).

Resolves Sentry issue `CALYPSO-3G1V` (`TypeError: Cannot read properties of undefined (reading 'split')`, `dashboard-production`, ongoing since 2026-07-21).

## Why are these changes being made?

`matches` is filtered to drop `notFound`/`error` matches so an unresolved route falls back to the primary menu. When every match is filtered out, `matches` is empty, so `matches[ matches.length - 1 ]?.routeId` is `undefined`. The old `findParentPath( routeId: string )` then ran `undefined.split( '/' )` and threw before the `?? screenPaths[ 0 ]` fallback could apply.

The router is not registered with TanStack, so `routeId` is typed `any` — the type system never flagged that it could be `undefined`. This is a runtime fix on that untyped surface.

## Testing Instructions

* Navigate the Dashboard to a URL whose route fully fails to resolve (all matches `notFound`/`error`).
* Confirm the sidebar falls back to the primary menu and no `Cannot read properties of undefined (reading 'split')` error appears in the console.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
