### PR TITLE
Signup and login: move the account switch below the buttons on both screens

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -85,6 +85,7 @@ class Login extends Component {
 		isUserAccountEmailUpdateRedirect: PropTypes.bool,
 		isFromAutomatticForAgenciesPlugin: PropTypes.bool,
 		isManualRenewalImmediateLoginAttempt: PropTypes.bool,
+		lostPasswordLink: PropTypes.node,
 		linkingSocialService: PropTypes.string,
 		oauth2Client: PropTypes.object,
 		rebootAfterLogin: PropTypes.func.isRequired,
@@ -408,6 +409,7 @@ class Login extends Component {
 			userEmail,
 			handleUsernameChange,
 			signupUrl,
+			lostPasswordLink,
 			isWCCOM,
 			isBlazePro,
 			translate,
@@ -530,6 +532,7 @@ class Login extends Component {
 				userEmail={ userEmail }
 				handleUsernameChange={ handleUsernameChange }
 				signupUrl={ signupUrl }
+				lostPasswordLink={ lostPasswordLink }
 				sendMagicLoginLink={ this.sendMagicLoginLink }
 				isFromAkismet={ this.props.isFromAkismet }
 				isFromPassport={ this.props.isFromPassport }

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -111,6 +111,7 @@ export class LoginForm extends Component {
 		isJetpack: PropTypes.bool,
 		isUserAccountEmailUpdateRedirect: PropTypes.bool,
 		loginButtonText: PropTypes.string,
+		lostPasswordLink: PropTypes.node,
 		isGravatarFixedAccountLogin: PropTypes.bool.isRequired,
 		isGravPoweredClient: PropTypes.bool,
 	};
@@ -701,6 +702,7 @@ export class LoginForm extends Component {
 			isGravatarFixedAccountLogin,
 			isSocialFirst,
 			isUserAccountEmailUpdateRedirect,
+			lostPasswordLink,
 		} = this.props;
 
 		const isLastUsedPassword =
@@ -886,9 +888,24 @@ export class LoginForm extends Component {
 						} ) }
 						aria-hidden={ isPasswordHidden }
 					>
-						<FormLabel htmlFor="password" hasCoreStylesNoCaps>
-							{ this.props.translate( 'Password' ) }
-						</FormLabel>
+						{ /*
+						 * The lost-password link shares the label row, so it reads as belonging to the
+						 * field it resets. Only while the field is shown: `is-hidden` keeps the block in
+						 * the DOM off-screen for password managers, and a link there would still take
+						 * focus. Desktop only, see login-form.scss; below 960px the footer has it.
+						 */ }
+						{ lostPasswordLink && ! isPasswordHidden ? (
+							<div className="login__form-password-label-row">
+								<FormLabel htmlFor="password" hasCoreStylesNoCaps>
+									{ this.props.translate( 'Password' ) }
+								</FormLabel>
+								{ lostPasswordLink }
+							</div>
+						) : (
+							<FormLabel htmlFor="password" hasCoreStylesNoCaps>
+								{ this.props.translate( 'Password' ) }
+							</FormLabel>
+						) }
 
 						<FormPasswordInput
 							autoCapitalize="off"

--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -32,6 +32,32 @@ $breakpoint-mobile: 782px; //Mobile size.
 	margin-bottom: 8px;
 }
 
+// Desktop puts the lost-password link on the password field's label row, beside the field it
+// resets, which also leaves the login top bar's right side empty, matching signup's. Below
+// 960px the footer keeps the link it has always had, so this one is hidden there rather than
+// shown twice. Same treatment as the footer's "Don't have an account?" line. Hardcoded
+// fallback rather than a `--wpds-*` token, for the reason given on the badge above.
+.login__form-password-label-row {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 16px;
+}
+
+// Anchored under `.login` because `.card a:not(.components-external-link)` strips the
+// underline from every link in the card at a specificity a lone class cannot beat.
+.login .login__form-password-label-row .login__form-lost-password {
+	display: none;
+	font-size: 0.875rem;
+	line-height: 20px;
+	color: var(--studio-gray-60, #50575e);
+	text-decoration: underline;
+
+	@include break-large {
+		display: inline;
+	}
+}
+
 form {
 	margin-left: auto;
 	margin-right: auto;

--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -35,8 +35,9 @@ $breakpoint-mobile: 782px; //Mobile size.
 // Desktop puts the lost-password link on the password field's label row, beside the field it
 // resets, which also leaves the login top bar's right side empty, matching signup's. Below
 // 960px the footer keeps the link it has always had, so this one is hidden there rather than
-// shown twice. Same treatment as the footer's "Don't have an account?" line. Hardcoded
-// fallback rather than a `--wpds-*` token, for the reason given on the badge above.
+// shown twice. Link blue and a step smaller than the label, so it reads as the field's
+// secondary action rather than a second label. Hardcoded fallback rather than a `--wpds-*`
+// token, for the reason given on the badge above.
 .login__form-password-label-row {
 	display: flex;
 	align-items: baseline;
@@ -48,10 +49,15 @@ $breakpoint-mobile: 782px; //Mobile size.
 // underline from every link in the card at a specificity a lone class cannot beat.
 .login .login__form-password-label-row .login__form-lost-password {
 	display: none;
-	font-size: 0.875rem;
-	line-height: 20px;
-	color: var(--studio-gray-60, #50575e);
+	font-size: 0.75rem;
+	line-height: 16px;
+	color: var(--color-link, #3858e9);
 	text-decoration: underline;
+
+	&:hover,
+	&:focus {
+		color: var(--color-link-dark, #1d35b4);
+	}
 
 	@include break-large {
 		display: inline;

--- a/client/blocks/login/test/login-form.jsx
+++ b/client/blocks/login/test/login-form.jsx
@@ -190,6 +190,42 @@ describe( 'LoginForm', () => {
 		expect( passwordContainer ).toHaveClass( 'is-hidden' );
 	} );
 
+	test( 'puts the lost-password link on the password label row once the field is shown', async () => {
+		const { container } = render(
+			<LoginForm isSocialFirst lostPasswordLink={ <a href="/">Lost your password?</a> } />,
+			{ initialState: { login: { authAccountType: 'regular' } } }
+		);
+
+		const row = container.getElementsByClassName( 'login__form-password-label-row' )[ 0 ];
+		expect( row ).toContainElement( screen.getByText( 'Password' ) );
+		expect( row ).toContainElement( screen.getByRole( 'link', { name: 'Lost your password?' } ) );
+	} );
+
+	test( 'does not render the lost-password link while the password field is hidden', async () => {
+		const { container } = render(
+			<LoginForm isSocialFirst lostPasswordLink={ <a href="/">Lost your password?</a> } />
+		);
+
+		expect( container.getElementsByClassName( 'login__form-password' )[ 0 ] ).toHaveClass(
+			'is-hidden'
+		);
+		expect( screen.queryByRole( 'link', { name: 'Lost your password?' } ) ).not.toBeInTheDocument();
+		expect( container.getElementsByClassName( 'login__form-password-label-row' ) ).toHaveLength(
+			0
+		);
+	} );
+
+	test( 'renders a plain password label when no lost-password link is passed', async () => {
+		const { container } = render( <LoginForm isSocialFirst />, {
+			initialState: { login: { authAccountType: 'regular' } },
+		} );
+
+		expect( screen.getByLabelText( /^password$/i ) ).toBeInTheDocument();
+		expect( container.getElementsByClassName( 'login__form-password-label-row' ) ).toHaveLength(
+			0
+		);
+	} );
+
 	test( 'shows "Continue" button text for passwordless accounts', async () => {
 		render( <LoginForm isSocialFirst />, {
 			initialState: {

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -52,6 +52,12 @@ interface SignupFormSocialFirst {
 	isEmailFirstVariant?: boolean;
 	isEmailAtBottom?: boolean;
 	isMobileCompactVariant?: boolean;
+	/**
+	 * Answers "I already have an account" below the buttons instead of in the top bar, where the
+	 * link sits among the page furniture and gets read as chrome. The email-first variants render
+	 * it regardless, having always carried their own.
+	 */
+	showLoginLink?: boolean;
 	allowedSocialServices?: SignupAllowedService[];
 	customTosElement?: JSX.Element;
 	activationEmailFrom?: string;
@@ -115,6 +121,7 @@ const SignupFormSocialFirst = ( {
 	isEmailFirstVariant,
 	isEmailAtBottom,
 	isMobileCompactVariant,
+	showLoginLink,
 	allowedSocialServices,
 	customTosElement,
 	activationEmailFrom,
@@ -345,7 +352,7 @@ const SignupFormSocialFirst = ( {
 						{ emailLoginBlock }
 					</>
 				) }
-				{ isEmailFirstVariant && loginLinkParagraph }
+				{ ( isEmailFirstVariant || showLoginLink ) && loginLinkParagraph }
 			</div>
 			<div className={ getVisibilityClassName( 'email' ) }>{ emailScreen }</div>
 		</div>

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -153,6 +153,7 @@ class SocialSignupForm extends Component {
 					<UsernameOrEmailButton
 						key="social-signup-button-email"
 						onClick={ () => setCurrentStep( 'email' ) }
+						showWordPressLogo={ false }
 					/>
 				),
 			},

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -110,6 +110,56 @@ describe( 'SignupFormSocialFirst', () => {
 		} );
 	} );
 
+	describe( 'email button icon', () => {
+		test( 'uses the mail icon, not the WordPress logo, so email reads as a peer of the social options', () => {
+			render( <SignupFormSocialFirst { ...defaultProps } /> );
+
+			const emailButton = screen.getByText( /Continue with email/i ).closest( 'button' );
+			expect( emailButton ).toBeInTheDocument();
+			expect( emailButton?.querySelector( '.social-icons__mail' ) ).toBeInTheDocument();
+			// The logo renders with the bare `social-icons` class, so count the icons to catch a
+			// regression that leaves both in the button.
+			expect( emailButton?.querySelectorAll( 'svg' ) ).toHaveLength( 1 );
+		} );
+	} );
+
+	describe( 'showLoginLink', () => {
+		const loginLinkSelector = '.signup-form-social-first__login-link';
+
+		test( 'renders the "Have an account? Log in" paragraph when set', () => {
+			const { container } = render( <SignupFormSocialFirst { ...defaultProps } showLoginLink /> );
+
+			const loginLink = container.querySelector( loginLinkSelector );
+			expect( loginLink ).toBeInTheDocument();
+			expect( within( loginLink as HTMLElement ).getByRole( 'link' ) ).toHaveAttribute(
+				'href',
+				'/log-in'
+			);
+		} );
+
+		test( 'omits the paragraph when unset', () => {
+			const { container } = render( <SignupFormSocialFirst { ...defaultProps } /> );
+
+			expect( container.querySelector( loginLinkSelector ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'email-first variants keep their own paragraph without it', () => {
+			const { container } = render(
+				<SignupFormSocialFirst { ...defaultProps } isEmailFirstVariant />
+			);
+
+			expect( container.querySelector( loginLinkSelector ) ).toBeInTheDocument();
+		} );
+
+		test( 'renders one paragraph, not two, when both conditions hold', () => {
+			const { container } = render(
+				<SignupFormSocialFirst { ...defaultProps } isEmailFirstVariant showLoginLink />
+			);
+
+			expect( container.querySelectorAll( loginLinkSelector ) ).toHaveLength( 1 );
+		} );
+	} );
+
 	describe( 'isMobileCompactVariant', () => {
 		test( 'renders the mobile-compact wrapper class', () => {
 			const { container } = render(

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -111,15 +111,26 @@ describe( 'SignupFormSocialFirst', () => {
 	} );
 
 	describe( 'email button icon', () => {
-		test( 'uses the mail icon, not the WordPress logo, so email reads as a peer of the social options', () => {
+		test( 'uses the envelope icon, not the WordPress logo, so email reads as a peer of the social options', () => {
 			render( <SignupFormSocialFirst { ...defaultProps } /> );
 
 			const emailButton = screen.getByText( /Continue with email/i ).closest( 'button' );
 			expect( emailButton ).toBeInTheDocument();
-			expect( emailButton?.querySelector( '.social-icons__mail' ) ).toBeInTheDocument();
+			expect( emailButton?.querySelector( '.social-icons__envelope' ) ).toBeInTheDocument();
 			// The logo renders with the bare `social-icons` class, so count the icons to catch a
 			// regression that leaves both in the button.
 			expect( emailButton?.querySelectorAll( 'svg' ) ).toHaveLength( 1 );
+		} );
+
+		test( 'carries the enabled-state class the disabled styling keys off', () => {
+			render( <SignupFormSocialFirst { ...defaultProps } /> );
+
+			const icon = screen
+				.getByText( /Continue with email/i )
+				.closest( 'button' )
+				?.querySelector( '.social-icons__envelope' );
+			expect( icon ).toHaveClass( 'social-icons', 'social-icons--enabled' );
+			expect( icon ).not.toHaveClass( 'social-icons--disabled' );
 		} );
 	} );
 

--- a/client/components/social-buttons/style.scss
+++ b/client/components/social-buttons/style.scss
@@ -19,6 +19,15 @@
 		fill: inherit;
 	}
 
+	// WPDS icons carry no fill of their own, so `inherit` above resolves to the
+	// initial black and they render heavier than the label beside them. Opt them
+	// onto `currentColor` so they track the label, including when the button
+	// disables. Scoped by class rather than applied to every `> svg`: the brand
+	// marks inherit deliberately, their fills being their own.
+	> svg.social-icons__envelope {
+		fill: currentColor;
+	}
+
 	> span {
 		font-feature-settings: "clig" off, "liga" off;
 		margin-inline: -20px auto;

--- a/client/components/social-buttons/style.scss
+++ b/client/components/social-buttons/style.scss
@@ -24,8 +24,16 @@
 	// onto `currentColor` so they track the label, including when the button
 	// disables. Scoped by class rather than applied to every `> svg`: the brand
 	// marks inherit deliberately, their fills being their own.
+	//
+	// The scale corrects for WPDS drawing its glyphs inset in a 24x24 canvas: the
+	// envelope inks only 18x14 of it, so at a 20px box it reads about a quarter
+	// smaller than the brand marks beside it. 1.3 brings the ink to roughly 19px
+	// wide, in line with Google and GitHub. Done as a transform rather than a
+	// bigger box because the label's negative margin is tuned to a 20px icon, so
+	// growing the box would push the text out of line with the buttons above.
 	> svg.social-icons__envelope {
 		fill: currentColor;
+		transform: scale(1.3);
 	}
 
 	> span {

--- a/client/components/social-buttons/username-or-email.tsx
+++ b/client/components/social-buttons/username-or-email.tsx
@@ -44,6 +44,9 @@ export const UsernameOrEmailButton = ( {
 					size={ 20 }
 				/>
 			) : (
+				// 20 to match the other icons' box. The glyph is scaled up in CSS rather than by
+				// raising this number, because the label's negative margin is tuned to a 20px box:
+				// a bigger box shifts the text out of line with the buttons above it.
 				<Icon
 					icon={ envelope }
 					size={ 20 }

--- a/client/components/social-buttons/username-or-email.tsx
+++ b/client/components/social-buttons/username-or-email.tsx
@@ -2,6 +2,7 @@ import { WordPressLogo } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
+import MailIcon from 'calypso/components/social-icons/mail';
 import { useSelector } from 'calypso/state';
 import { isFormDisabled } from 'calypso/state/login/selectors';
 
@@ -10,9 +11,19 @@ import './style.scss';
 
 type UsernameOrEmailButtonProps = {
 	onClick: () => void;
+	/**
+	 * Marks email out as the WordPress.com option, which is what the login page wants: its
+	 * other buttons are all third parties. Signup opts out, because there the logo reads as
+	 * branding on one button of three rather than as a provider, so email looks like the
+	 * house pick instead of a peer of Google and Apple.
+	 */
+	showWordPressLogo?: boolean;
 };
 
-export const UsernameOrEmailButton = ( { onClick }: UsernameOrEmailButtonProps ) => {
+export const UsernameOrEmailButton = ( {
+	onClick,
+	showWordPressLogo = true,
+}: UsernameOrEmailButtonProps ) => {
 	const { __ } = useI18n();
 	const isDisabled = useSelector( isFormDisabled );
 
@@ -24,13 +35,17 @@ export const UsernameOrEmailButton = ( { onClick }: UsernameOrEmailButtonProps )
 			variant="secondary"
 			__next40pxDefaultSize
 		>
-			<WordPressLogo
-				className={ clsx(
-					'social-icons',
-					isDisabled ? 'social-icons--disabled' : 'social-icons--enabled'
-				) }
-				size={ 20 }
-			/>
+			{ showWordPressLogo ? (
+				<WordPressLogo
+					className={ clsx(
+						'social-icons',
+						isDisabled ? 'social-icons--disabled' : 'social-icons--enabled'
+					) }
+					size={ 20 }
+				/>
+			) : (
+				<MailIcon width="20" height="20" isDisabled={ isDisabled } />
+			) }
 			<span className="social-buttons__service-name">{ __( 'Continue with email' ) }</span>
 		</Button>
 	);

--- a/client/components/social-buttons/username-or-email.tsx
+++ b/client/components/social-buttons/username-or-email.tsx
@@ -1,8 +1,8 @@
 import { WordPressLogo } from '@automattic/components';
 import { Button } from '@wordpress/components';
+import { Icon, envelope } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
-import MailIcon from 'calypso/components/social-icons/mail';
 import { useSelector } from 'calypso/state';
 import { isFormDisabled } from 'calypso/state/login/selectors';
 
@@ -44,7 +44,14 @@ export const UsernameOrEmailButton = ( {
 					size={ 20 }
 				/>
 			) : (
-				<MailIcon width="20" height="20" isDisabled={ isDisabled } />
+				<Icon
+					icon={ envelope }
+					size={ 20 }
+					className={ clsx( 'social-icons', 'social-icons__envelope', {
+						'social-icons--disabled': isDisabled,
+						'social-icons--enabled': ! isDisabled,
+					} ) }
+				/>
 			) }
 			<span className="social-buttons__service-name">{ __( 'Continue with email' ) }</span>
 		</Button>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -270,11 +270,14 @@ const UserStepComponent: StepType< { accepts: UserStepAccepts } > = function Use
 
 	// Existing users land here and sign up again rather than log in, and a top-bar "Log in" reads as
 	// page furniture at the moment they need it. Below the buttons it answers the question they are
-	// actually asking. Two layouts keep the top bar instead: the compact mobile one, which has no
-	// room for the line and whose top bar is the whole affordance, and the email-edit screen, which
-	// has no second account to offer at all. V1 is left alone as the retiring layout.
+	// actually asking.
+	//
+	// Desktop only. Below 960px signup and login both keep the top-right link they have today, and
+	// moving just one of them would introduce a third pattern rather than remove one. The email-edit
+	// screen is excluded as well, having no second account to offer, and V1 is left alone as the
+	// retiring layout.
 	const showsInFormLoginLink =
-		isStepContainerV2 && ! isMobileCompactLayout && ! isEditingEmail && ! hideLoginLink;
+		isStepContainerV2 && isLargeViewport && ! isEditingEmail && ! hideLoginLink;
 
 	const emailLabelText = isStepContainerV2 ? translate( 'Enter your email' ) : undefined;
 	// Partner branding always wins: isMobileCompactLayout is already false whenever

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -57,9 +57,10 @@ export type UserStepAccepts = {
 	headerText?: string;
 	subHeaderText?: string;
 	/**
-	 * Hides the top-level "Log in" link (V2 top bar / V1 footer). The email-first
-	 * account-step variant keeps its own in-form "Have an account? Log in" link.
-	 * Existing users can still sign in via the social / email buttons either way.
+	 * Drops the step's own "Log in" link, wherever that layout puts it: the V2 top bar, the V1
+	 * footer, or the line below the buttons. The email-first account-step variant keeps its
+	 * in-form link regardless. Existing users can still sign in via the social / email buttons
+	 * either way.
 	 */
 	hideLoginLink?: boolean;
 	allowedSocialServices?: SignupAllowedService[];
@@ -267,6 +268,14 @@ const UserStepComponent: StepType< { accepts: UserStepAccepts } > = function Use
 	const isMobileCompactLayout =
 		isStepContainerV2 && isMobileViewport && ! isWooReferrer && ! partnerConfig && ! isEditingEmail;
 
+	// Existing users land here and sign up again rather than log in, and a top-bar "Log in" reads as
+	// page furniture at the moment they need it. Below the buttons it answers the question they are
+	// actually asking. Two layouts keep the top bar instead: the compact mobile one, which has no
+	// room for the line and whose top bar is the whole affordance, and the email-edit screen, which
+	// has no second account to offer at all. V1 is left alone as the retiring layout.
+	const showsInFormLoginLink =
+		isStepContainerV2 && ! isMobileCompactLayout && ! isEditingEmail && ! hideLoginLink;
+
 	const emailLabelText = isStepContainerV2 ? translate( 'Enter your email' ) : undefined;
 	// Partner branding always wins: isMobileCompactLayout is already false whenever
 	// partnerConfig is set, so the ! partnerConfig check here is belt-and-suspenders
@@ -306,6 +315,7 @@ const UserStepComponent: StepType< { accepts: UserStepAccepts } > = function Use
 				isEmailFirstVariant={ isEmailFirstVariant }
 				isEmailAtBottom={ isEmailAtBottom }
 				isMobileCompactVariant={ isMobileCompactLayout }
+				showLoginLink={ showsInFormLoginLink }
 				allowedSocialServices={ allowedSocialServices }
 				customTosElement={ signupTosElement }
 				activationEmailFrom={ gateEnabled ? ACTIVATION_EMAIL_SOURCE : undefined }
@@ -381,7 +391,7 @@ const UserStepComponent: StepType< { accepts: UserStepAccepts } > = function Use
 				logo={ topBarLogo }
 				leftElement={ backButton }
 				rightElement={
-					hideLoginLink || isEmailFirstVariant || isEditingEmail ? null : (
+					hideLoginLink || isEmailFirstVariant || isEditingEmail || showsInFormLoginLink ? null : (
 						<Step.LinkButton href={ loginLink }>{ translate( 'Log in' ) }</Step.LinkButton>
 					)
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
@@ -10,6 +10,13 @@ $gray-50: #646970;
 $breakpoint-mobile: 660px;
 
 .step-route.user {
+	// The stepper default is 3rem, the login page's content wrapper uses 2rem, and a
+	// user moving between the two screens sees the form jump. Match login. Scoped to
+	// this step so the rest of the stepper keeps the default.
+	.step-container-v2__content-wrapper {
+		gap: 2rem;
+	}
+
 	.form-fieldset {
 		margin-bottom: 8px;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/index.tsx
@@ -23,12 +23,26 @@ import UserStep, { type UserStepAccepts } from '..';
 const mockUseViewportMatch = useViewportMatch as unknown as jest.Mock;
 const mockUsePartnerBranding = usePartnerBranding as unknown as jest.Mock;
 
-// Drives isMobileViewport = useViewportMatch( 'small', '<' ). Every other call
-// (e.g. useViewportMatch( 'large' )) resolves to false, i.e. not a wide viewport.
-const setViewport = ( { isMobile }: { isMobile: boolean } ) =>
-	mockUseViewportMatch.mockImplementation( ( breakpoint: string, operator?: string ) =>
-		breakpoint === 'small' && operator === '<' ? isMobile : false
-	);
+// Drives the two breakpoints the step reads: isMobileViewport = useViewportMatch( 'small', '<' )
+// at 660px, and isLargeViewport = useViewportMatch( 'large' ) at 960px. `isLarge` defaults to the
+// opposite of `isMobile` so the common cases stay one argument; pass both to reach the band in
+// between, where the layout is the standard one but the login link has not moved yet.
+const setViewport = ( {
+	isMobile,
+	isLarge = ! isMobile,
+}: {
+	isMobile: boolean;
+	isLarge?: boolean;
+} ) =>
+	mockUseViewportMatch.mockImplementation( ( breakpoint: string, operator?: string ) => {
+		if ( breakpoint === 'small' && operator === '<' ) {
+			return isMobile;
+		}
+		if ( breakpoint === 'large' ) {
+			return isLarge;
+		}
+		return false;
+	} );
 
 const noPartnerBranding = {
 	hasCustomBranding: false,
@@ -163,6 +177,17 @@ describe( 'User email signup step', () => {
 
 		it( 'leaves the compact mobile layout on its top-bar link', () => {
 			setViewport( { isMobile: true } );
+
+			const { container } = renderUserStep();
+
+			expect( container.querySelector( loginLinkSelector ) ).not.toBeInTheDocument();
+			expect( screen.getByRole( 'link', { name: 'Log in' } ) ).toBeVisible();
+		} );
+
+		it( 'leaves the band between the breakpoints on its top-bar link', () => {
+			// Wide enough for the standard layout, not wide enough to be a desktop. Login keeps
+			// its top-right link below 960px, so signup has to as well or the two diverge.
+			setViewport( { isMobile: false, isLarge: false } );
 
 			const { container } = renderUserStep();
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/index.tsx
@@ -146,4 +146,35 @@ describe( 'User email signup step', () => {
 			expect( screen.getByRole( 'heading', { name: 'Create your account' } ) ).toBeVisible();
 		} );
 	} );
+
+	describe( 'login link placement', () => {
+		const loginLinkSelector = '.signup-form-social-first__login-link';
+
+		it( 'answers "Have an account?" below the buttons rather than in the top bar', () => {
+			const { container } = renderUserStep();
+
+			expect( container.querySelector( loginLinkSelector ) ).toBeInTheDocument();
+			// One route to logging in, not two: the top bar no longer carries its own.
+			expect( screen.getAllByRole( 'link', { name: 'Log in' } ) ).toHaveLength( 1 );
+			expect(
+				screen.getByRole( 'link', { name: 'Log in' } ).closest( loginLinkSelector )
+			).toBeInTheDocument();
+		} );
+
+		it( 'leaves the compact mobile layout on its top-bar link', () => {
+			setViewport( { isMobile: true } );
+
+			const { container } = renderUserStep();
+
+			expect( container.querySelector( loginLinkSelector ) ).not.toBeInTheDocument();
+			expect( screen.getByRole( 'link', { name: 'Log in' } ) ).toBeVisible();
+		} );
+
+		it( 'drops the link entirely when hideLoginLink is set', () => {
+			const { container } = renderUserStep( '/onboarding/user', { hideLoginLink: true } );
+
+			expect( container.querySelector( loginLinkSelector ) ).not.toBeInTheDocument();
+			expect( screen.queryByRole( 'link', { name: 'Log in' } ) ).not.toBeInTheDocument();
+		} );
+	} );
 } );

--- a/client/login/wp-login/components/one-login-footer.scss
+++ b/client/login/wp-login/components/one-login-footer.scss
@@ -54,7 +54,11 @@
 	// two screens reads as one control in one place. Font family is left to inherit rather
 	// than copying signup's hardcoded "SF Pro Text": that resolves to the same face on
 	// Apple platforms, and to a better fallback everywhere else.
+	//
+	// Desktop only: below 960px the route to signup stays in the top bar, where both this
+	// screen and signup already put it, and this slot keeps the lost-password link.
 	.one-login__footer-signup {
+		display: none;
 		margin: 0;
 		font-size: 0.875rem;
 		line-height: 20px;
@@ -63,6 +67,18 @@
 		a {
 			color: inherit;
 			text-decoration: underline;
+		}
+
+		@media ( min-width: 960px ) {
+			display: block;
+		}
+	}
+
+	// The other half of that swap: the lost-password link is the footer's on mobile, and the
+	// top bar's on desktop.
+	.one-login__footer-mobile {
+		@media ( min-width: 960px ) {
+			display: none;
 		}
 	}
 }

--- a/client/login/wp-login/components/one-login-footer.scss
+++ b/client/login/wp-login/components/one-login-footer.scss
@@ -49,4 +49,20 @@
 			font-size: inherit;
 		}
 	}
+
+	// Mirrors the signup page's "Have an account? Log in" line, so the switch between the
+	// two screens reads as one control in one place. Font family is left to inherit rather
+	// than copying signup's hardcoded "SF Pro Text": that resolves to the same face on
+	// Apple platforms, and to a better fallback everywhere else.
+	.one-login__footer-signup {
+		margin: 0;
+		font-size: 0.875rem;
+		line-height: 20px;
+		color: var( --studio-gray-60, #50575e );
+
+		a {
+			color: inherit;
+			text-decoration: underline;
+		}
+	}
 }

--- a/client/login/wp-login/components/one-login-footer.tsx
+++ b/client/login/wp-login/components/one-login-footer.tsx
@@ -10,8 +10,8 @@ import './one-login-footer.scss';
 interface OneLoginFooterProps {
 	/**
 	 * When `isLoginView` is true, this is the "lost password" link. Below 960px it stays here,
-	 * where it has always been; desktop promotes it to the top bar and gives this slot to the
-	 * route to signup instead.
+	 * where it has always been; desktop moves it up beside the password field and gives this
+	 * slot to the route to signup instead.
 	 */
 	lostPasswordLink?: JSX.Element;
 	/**
@@ -71,10 +71,10 @@ const OneLoginFooter = ( {
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 
 	if ( isLoginView ) {
-		// Desktop takes the route to signup and leaves password recovery to the top bar; below
-		// 960px the two swap back to where they have always been. Both are rendered and one is
-		// hidden in CSS, matching the top bar, because this page is server-rendered and a
-		// viewport hook would jump on hydration.
+		// Desktop takes the route to signup and leaves password recovery to the password field's
+		// label row; below 960px the two swap back to where they have always been. Both are
+		// rendered and one is hidden in CSS, matching the top bar, because this page is
+		// server-rendered and a viewport hook would jump on hydration.
 		return (
 			<div className="one-login__footer">
 				<div className="one-login__footer-links-wrapper one-login__footer-mobile">

--- a/client/login/wp-login/components/one-login-footer.tsx
+++ b/client/login/wp-login/components/one-login-footer.tsx
@@ -1,19 +1,21 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useTranslate } from 'i18n-calypso';
 import { type JSX } from 'react';
 import { useSelector } from 'react-redux';
 import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import useSignupLink from '../hooks/use-signup-link';
 import './one-login-footer.scss';
 
 interface OneLoginFooterProps {
 	/**
-	 * When `isLoginView` is true, this is the "lost password" link.
-	 */
-	lostPasswordLink?: JSX.Element;
-	/**
 	 * When `isLoginView` is false, this is the "back to login" link.
 	 */
 	loginLink?: JSX.Element;
+	/**
+	 * Passed through to the signup link so an explicit `?signup_url` is honoured.
+	 */
+	signupUrl?: string;
 	/**
 	 * The content of the footer. If provided, it will be rendered instead of the default links.
 	 */
@@ -32,9 +34,29 @@ const recordBackToWpcomLinkClick = () => {
 	recordTracksEvent( 'calypso_login_back_to_wpcom_link_click' );
 };
 
+/**
+ * The route to signup, in the same place and the same words that signup uses for its route to
+ * login, so the switch between the two reads as one control rather than two unrelated links.
+ */
+const SignUpPrompt = ( { signupUrl }: { signupUrl?: string } ) => {
+	const translate = useTranslate();
+	const { href, onClick } = useSignupLink( { signupUrl, origin: 'login-footer' } );
+
+	return (
+		<p className="one-login__footer-signup">
+			{ translate( "Don't have an account? {{link}}Sign up{{/link}}", {
+				components: {
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					link: <a href={ href } onClick={ onClick } rel="external" />,
+				},
+			} ) }
+		</p>
+	);
+};
+
 const OneLoginFooter = ( {
-	lostPasswordLink,
 	loginLink,
+	signupUrl,
 	isLoginView,
 	supportLink,
 	children,
@@ -44,7 +66,7 @@ const OneLoginFooter = ( {
 	if ( isLoginView ) {
 		return (
 			<div className="one-login__footer">
-				<div className="one-login__footer-links-wrapper">{ lostPasswordLink }</div>
+				<SignUpPrompt signupUrl={ signupUrl } />
 				<div className="one-login__footer-links-wrapper">
 					{ oauth2Client && (
 						<LoggedOutFormBackLink

--- a/client/login/wp-login/components/one-login-footer.tsx
+++ b/client/login/wp-login/components/one-login-footer.tsx
@@ -9,6 +9,12 @@ import './one-login-footer.scss';
 
 interface OneLoginFooterProps {
 	/**
+	 * When `isLoginView` is true, this is the "lost password" link. Below 960px it stays here,
+	 * where it has always been; desktop promotes it to the top bar and gives this slot to the
+	 * route to signup instead.
+	 */
+	lostPasswordLink?: JSX.Element;
+	/**
 	 * When `isLoginView` is false, this is the "back to login" link.
 	 */
 	loginLink?: JSX.Element;
@@ -55,6 +61,7 @@ const SignUpPrompt = ( { signupUrl }: { signupUrl?: string } ) => {
 };
 
 const OneLoginFooter = ( {
+	lostPasswordLink,
 	loginLink,
 	signupUrl,
 	isLoginView,
@@ -64,8 +71,15 @@ const OneLoginFooter = ( {
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 
 	if ( isLoginView ) {
+		// Desktop takes the route to signup and leaves password recovery to the top bar; below
+		// 960px the two swap back to where they have always been. Both are rendered and one is
+		// hidden in CSS, matching the top bar, because this page is server-rendered and a
+		// viewport hook would jump on hydration.
 		return (
 			<div className="one-login__footer">
+				<div className="one-login__footer-links-wrapper one-login__footer-mobile">
+					{ lostPasswordLink }
+				</div>
 				<SignUpPrompt signupUrl={ signupUrl } />
 				<div className="one-login__footer-links-wrapper">
 					{ oauth2Client && (

--- a/client/login/wp-login/components/one-login-layout.scss
+++ b/client/login/wp-login/components/one-login-layout.scss
@@ -28,22 +28,14 @@
 	gap: rem( 16px );
 }
 
-// The main login view swaps its top-right link at the desktop breakpoint: password recovery
-// takes the slot and the route to signup moves to the footer, matching signup. Below 960px
-// nothing moves. Both are in the markup and one is hidden, rather than a viewport hook picking
-// one, because this page is server-rendered and a hook would jump on hydration.
+// The main login view drops its top-right link at the desktop breakpoint: the route to signup
+// moves to the footer, matching signup, and nothing takes the slot, also matching signup. Below
+// 960px nothing moves. Hidden in CSS rather than by a viewport hook, because this page is
+// server-rendered and a hook would jump on hydration.
 //
-// `display: contents` so the visible one still sits in the parent's flex gap, and
-// `display: none` so the hidden one leaves the accessibility tree rather than lingering
-// as a second, invisible route to the same place.
-.wp-login__top-right-desktop {
-	display: none;
-
-	@media ( min-width: 960px ) {
-		display: contents;
-	}
-}
-
+// `display: contents` so the link still sits in the parent's flex gap when shown, and
+// `display: none` so it leaves the accessibility tree when hidden, rather than lingering as a
+// second, invisible route to the same place.
 .wp-login__top-right-mobile {
 	display: contents;
 

--- a/client/login/wp-login/components/one-login-layout.scss
+++ b/client/login/wp-login/components/one-login-layout.scss
@@ -28,6 +28,30 @@
 	gap: rem( 16px );
 }
 
+// The main login view swaps its top-right link at the desktop breakpoint: password recovery
+// takes the slot and the route to signup moves to the footer, matching signup. Below 960px
+// nothing moves. Both are in the markup and one is hidden, rather than a viewport hook picking
+// one, because this page is server-rendered and a hook would jump on hydration.
+//
+// `display: contents` so the visible one still sits in the parent's flex gap, and
+// `display: none` so the hidden one leaves the accessibility tree rather than lingering
+// as a second, invisible route to the same place.
+.wp-login__top-right-desktop {
+	display: none;
+
+	@media ( min-width: 960px ) {
+		display: contents;
+	}
+}
+
+.wp-login__top-right-mobile {
+	display: contents;
+
+	@media ( min-width: 960px ) {
+		display: none;
+	}
+}
+
 .wp-login__one-login-layout-tos {
 	color: var( --studio-gray-50, #646970 );
 

--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -131,13 +131,28 @@ const OneLoginLayout = ( {
 	};
 
 	const topBar = (): JSX.Element => {
-		// On the main login view the route to signup moves down to the footer, matching where
-		// signup puts its route to login, and password recovery takes the slot it vacates.
-		// Everywhere else (2FA, magic login, the OAuth2 screen) the top bar is unchanged: those
-		// are mid-flow screens with no lost-password link to promote.
-		const rightElement = (
+		const signupOrLoginLink = isSectionSignup ? <LoginLink /> : <SignUpLink />;
+
+		// On the main login view, desktop moves the route to signup down to the footer, matching
+		// where signup puts its route to login, and password recovery takes the slot it vacates.
+		// Below 960px nothing moves: both screens keep the top-right link they have today.
+		//
+		// Both are rendered and chosen in CSS rather than by a viewport hook, because this page is
+		// server-rendered: a hook has no viewport on the server, so it would render the mobile
+		// arrangement and then visibly jump on hydration for every desktop visitor. The hidden one
+		// is `display: none`, so it stays out of the accessibility tree either way.
+		//
+		// Everywhere else (2FA, magic login, the OAuth2 screen) no lostPasswordLink is passed and
+		// this collapses to exactly what it rendered before.
+		const rightElement = lostPasswordLink ? (
 			<nav className="wp-login__one-login-layout-top-right">
-				{ lostPasswordLink ?? ( isSectionSignup ? <LoginLink /> : <SignUpLink /> ) }
+				<span className="wp-login__top-right-desktop">{ lostPasswordLink }</span>
+				<span className="wp-login__top-right-mobile">{ signupOrLoginLink }</span>
+				{ noThanksRedirectUrl && <NoThanksLink /> }
+			</nav>
+		) : (
+			<nav className="wp-login__one-login-layout-top-right">
+				{ signupOrLoginLink }
 				{ noThanksRedirectUrl && <NoThanksLink /> }
 			</nav>
 		);

--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -36,11 +36,12 @@ interface OneLoginLayoutProps {
 	loginUrl?: string;
 	isLostPasswordView?: boolean;
 	/**
-	 * Takes the top-right slot when provided, displacing the "Create an account" link, which the
-	 * main login view moves to its footer. Pass it only from views that actually offer password
-	 * recovery: mid-flow screens like 2FA have none and keep the signup link up there.
+	 * Keeps the "Create an account" link in the top bar below 960px only. The main login view
+	 * passes this: on desktop its footer carries the route to signup instead, matching signup,
+	 * and the top bar's right side is left empty, also matching signup. Mid-flow screens like
+	 * 2FA keep the link up there at every width.
 	 */
-	lostPasswordLink?: JSX.Element | null;
+	signupLinkMobileOnly?: boolean;
 	noThanksRedirectUrl?: string;
 	/**
 	 * Optional override for the content column width passed to `Step.CenteredColumnLayout`. Defaults to 6.
@@ -68,7 +69,7 @@ const OneLoginLayout = ( {
 	isSectionSignup,
 	loginUrl,
 	isLostPasswordView,
-	lostPasswordLink,
+	signupLinkMobileOnly,
 	noThanksRedirectUrl,
 	columnWidth,
 	showLogo = true,
@@ -134,25 +135,23 @@ const OneLoginLayout = ( {
 		const signupOrLoginLink = isSectionSignup ? <LoginLink /> : <SignUpLink />;
 
 		// On the main login view, desktop moves the route to signup down to the footer, matching
-		// where signup puts its route to login, and password recovery takes the slot it vacates.
+		// where signup puts its route to login, and leaves this slot empty, also matching signup.
 		// Below 960px nothing moves: both screens keep the top-right link they have today.
 		//
-		// Both are rendered and chosen in CSS rather than by a viewport hook, because this page is
-		// server-rendered: a hook has no viewport on the server, so it would render the mobile
-		// arrangement and then visibly jump on hydration for every desktop visitor. The hidden one
-		// is `display: none`, so it stays out of the accessibility tree either way.
+		// Hidden in CSS rather than by a viewport hook, because this page is server-rendered: a
+		// hook has no viewport on the server, so it would render the mobile arrangement and then
+		// visibly jump on hydration for every desktop visitor. `display: none`, so the hidden
+		// link stays out of the accessibility tree rather than lingering as a second route.
 		//
-		// Everywhere else (2FA, magic login, the OAuth2 screen) no lostPasswordLink is passed and
-		// this collapses to exactly what it rendered before.
-		const rightElement = lostPasswordLink ? (
+		// Everywhere else (2FA, magic login, the OAuth2 screen) the flag is not passed and this
+		// collapses to exactly what it rendered before.
+		const rightElement = (
 			<nav className="wp-login__one-login-layout-top-right">
-				<span className="wp-login__top-right-desktop">{ lostPasswordLink }</span>
-				<span className="wp-login__top-right-mobile">{ signupOrLoginLink }</span>
-				{ noThanksRedirectUrl && <NoThanksLink /> }
-			</nav>
-		) : (
-			<nav className="wp-login__one-login-layout-top-right">
-				{ signupOrLoginLink }
+				{ signupLinkMobileOnly ? (
+					<span className="wp-login__top-right-mobile">{ signupOrLoginLink }</span>
+				) : (
+					signupOrLoginLink
+				) }
 				{ noThanksRedirectUrl && <NoThanksLink /> }
 			</nav>
 		);

--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -1,18 +1,13 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useLocale } from '@automattic/i18n-utils';
 import { Step } from '@automattic/onboarding';
 import clsx from 'clsx';
 import { useTranslate, type TranslateResult } from 'i18n-calypso';
 import { type JSX } from 'react';
-import { getSignupUrl, pathWithLeadingSlash } from 'calypso/lib/login';
 import { usePartnerBranding } from 'calypso/lib/partner-branding';
 import { useLoginContext } from 'calypso/login/login-context';
-import { useDispatch, useSelector } from 'calypso/state';
-import { redirectToLogout } from 'calypso/state/current-user/actions';
-import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
-import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
-import { getCurrentQueryArguments } from 'calypso/state/selectors/get-current-query-arguments';
+import { useSelector } from 'calypso/state';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
+import useSignupLink from '../hooks/use-signup-link';
 import HeadingLogo from './heading-logo';
 import './one-login-layout.scss';
 
@@ -40,6 +35,12 @@ interface OneLoginLayoutProps {
 	isSectionSignup?: boolean;
 	loginUrl?: string;
 	isLostPasswordView?: boolean;
+	/**
+	 * Takes the top-right slot when provided, displacing the "Create an account" link, which the
+	 * main login view moves to its footer. Pass it only from views that actually offer password
+	 * recovery: mid-flow screens like 2FA have none and keep the signup link up there.
+	 */
+	lostPasswordLink?: JSX.Element | null;
 	noThanksRedirectUrl?: string;
 	/**
 	 * Optional override for the content column width passed to `Step.CenteredColumnLayout`. Defaults to 6.
@@ -67,46 +68,31 @@ const OneLoginLayout = ( {
 	isSectionSignup,
 	loginUrl,
 	isLostPasswordView,
+	lostPasswordLink,
 	noThanksRedirectUrl,
 	columnWidth,
 	showLogo = true,
 	subHeadingProminent = false,
 }: OneLoginLayoutProps ) => {
 	const translate = useTranslate();
-	const urlLocale = useLocale();
-	const isLoggedIn = useSelector( isUserLoggedIn );
-	const userLocale = useSelector( getCurrentUserLocale );
-	// For logged-in users, use their user locale setting. For logged-out users, use URL locale.
-	const locale = isLoggedIn && userLocale ? userLocale : urlLocale;
 	const currentRoute = useSelector( getCurrentRoute );
-	const currentQuery = useSelector( getCurrentQueryArguments );
-	const oauth2Client = useSelector( getCurrentOAuth2Client );
-	const dispatch = useDispatch();
 	const { headingText, subHeadingText, subHeadingTextSecondary } = useLoginContext();
 	const validatedHeadingText = ensureHeadingProvided( headingText );
 	const { topBarLogo } = usePartnerBranding();
+	const signupLink = useSignupLink( { signupUrl: signupUrlProp, origin: 'login-layout' } );
 
 	const SignUpLink = () => {
-		// use '?signup_url' if explicitly passed as URL query param
-		const signupUrl: string = signupUrlProp
-			? window.location.origin + pathWithLeadingSlash( signupUrlProp )
-			: getSignupUrl( currentQuery, currentRoute, oauth2Client, locale );
-
-		const handleClick = ( event: React.MouseEvent< HTMLElement > ) => {
-			recordTracksEvent( 'calypso_login_sign_up_link_click', { origin: 'login-layout' } );
-
-			if ( isLoggedIn ) {
-				event.preventDefault();
-				dispatch( redirectToLogout( signupUrl ) );
-			}
-		};
-
 		if ( isLostPasswordView ) {
 			return null;
 		}
 
 		return (
-			<Step.LinkButton href={ signupUrl } key="sign-up-link" onClick={ handleClick } rel="external">
+			<Step.LinkButton
+				href={ signupLink.href }
+				key="sign-up-link"
+				onClick={ signupLink.onClick }
+				rel="external"
+			>
 				{ translate( 'Create an account' ) }
 			</Step.LinkButton>
 		);
@@ -145,9 +131,13 @@ const OneLoginLayout = ( {
 	};
 
 	const topBar = (): JSX.Element => {
+		// On the main login view the route to signup moves down to the footer, matching where
+		// signup puts its route to login, and password recovery takes the slot it vacates.
+		// Everywhere else (2FA, magic login, the OAuth2 screen) the top bar is unchanged: those
+		// are mid-flow screens with no lost-password link to promote.
 		const rightElement = (
 			<nav className="wp-login__one-login-layout-top-right">
-				{ isSectionSignup ? <LoginLink /> : <SignUpLink /> }
+				{ lostPasswordLink ?? ( isSectionSignup ? <LoginLink /> : <SignUpLink /> ) }
 				{ noThanksRedirectUrl && <NoThanksLink /> }
 			</nav>
 		);

--- a/client/login/wp-login/hooks/use-signup-link.ts
+++ b/client/login/wp-login/hooks/use-signup-link.ts
@@ -1,0 +1,55 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useLocale } from '@automattic/i18n-utils';
+import { getSignupUrl, pathWithLeadingSlash } from 'calypso/lib/login';
+import { useDispatch, useSelector } from 'calypso/state';
+import { redirectToLogout } from 'calypso/state/current-user/actions';
+import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import { getCurrentQueryArguments } from 'calypso/state/selectors/get-current-query-arguments';
+import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
+
+interface UseSignupLinkParams {
+	/**
+	 * `signupUrl` should merge with `getSignupLinkComponent` logic in `/client/blocks/login/index.js`,
+	 * so we have a single source for this logic.
+	 */
+	signupUrl?: string;
+	/**
+	 * Distinguishes the top-bar link from the footer line in Tracks.
+	 */
+	origin: string;
+}
+
+/**
+ * The signup destination and its click handling, shared by the top bar's "Create an account"
+ * and the login footer's "Don't have an account? Sign up". Both routes to signup have to agree
+ * on the URL and on logging a signed-in user out first, so they resolve it in one place rather
+ * than each rebuilding it.
+ */
+export default function useSignupLink( { signupUrl, origin }: UseSignupLinkParams ) {
+	const urlLocale = useLocale();
+	const isLoggedIn = useSelector( isUserLoggedIn );
+	const userLocale = useSelector( getCurrentUserLocale );
+	// For logged-in users, use their user locale setting. For logged-out users, use URL locale.
+	const locale = isLoggedIn && userLocale ? userLocale : urlLocale;
+	const currentRoute = useSelector( getCurrentRoute );
+	const currentQuery = useSelector( getCurrentQueryArguments );
+	const oauth2Client = useSelector( getCurrentOAuth2Client );
+	const dispatch = useDispatch();
+
+	// use '?signup_url' if explicitly passed as URL query param
+	const href: string = signupUrl
+		? window.location.origin + pathWithLeadingSlash( signupUrl )
+		: getSignupUrl( currentQuery, currentRoute, oauth2Client, locale );
+
+	const onClick = ( event: React.MouseEvent< HTMLElement > ) => {
+		recordTracksEvent( 'calypso_login_sign_up_link_click', { origin } );
+
+		if ( isLoggedIn ) {
+			event.preventDefault();
+			dispatch( redirectToLogout( href ) );
+		}
+	};
+
+	return { href, onClick };
+}

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -167,33 +167,47 @@ export class Login extends Component {
 		return <LocaleSuggestions locale={ locale } path={ path } />;
 	}
 
+	handleLostPasswordClick = ( event ) => {
+		event.preventDefault();
+		this.props.recordTracksEvent( 'calypso_login_reset_password_link_click' );
+		page(
+			login( {
+				redirectTo: this.props.redirectTo,
+				locale: this.props.locale,
+				action:
+					this.props.isWooJPC || this.props.isJetpack ? 'jetpack/lostpassword' : 'lostpassword',
+				oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,
+				from: this.props.currentQuery?.from,
+			} )
+		);
+	};
+
+	/**
+	 * The footer's copy, which is where this link lives below 960px.
+	 */
 	getLostPasswordLink() {
 		if ( this.props.twoFactorAuthType ) {
 			return null;
 		}
 
-		// Rendered into the top bar, so it takes the same treatment as the link it replaces
-		// there rather than the footer's, which is a different colour and weight.
 		return (
-			<Step.LinkButton
-				href="/"
-				onClick={ ( event ) => {
-					event.preventDefault();
-					this.props.recordTracksEvent( 'calypso_login_reset_password_link_click' );
-					page(
-						login( {
-							redirectTo: this.props.redirectTo,
-							locale: this.props.locale,
-							action:
-								this.props.isWooJPC || this.props.isJetpack
-									? 'jetpack/lostpassword'
-									: 'lostpassword',
-							oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,
-							from: this.props.currentQuery?.from,
-						} )
-					);
-				} }
-			>
+			<a className="one-login__footer-link" href="/" onClick={ this.handleLostPasswordClick }>
+				{ this.props.translate( 'Lost your password?' ) }
+			</a>
+		);
+	}
+
+	/**
+	 * The same link for the desktop top bar, where it takes that slot's treatment rather than the
+	 * footer's lighter one. Only one of the two is ever visible: see one-login-layout.scss.
+	 */
+	getLostPasswordTopBarLink() {
+		if ( this.props.twoFactorAuthType ) {
+			return null;
+		}
+
+		return (
+			<Step.LinkButton href="/" onClick={ this.handleLostPasswordClick }>
 				{ this.props.translate( 'Lost your password?' ) }
 			</Step.LinkButton>
 		);
@@ -284,6 +298,7 @@ export class Login extends Component {
 						<OneLoginFooter
 							isLoginView={ isLoginView }
 							signupUrl={ signupUrl }
+							lostPasswordLink={ this.getLostPasswordLink() }
 							loginLink={ this.getLoginLink() }
 							supportLink={ this.getSupportLink() }
 						/>
@@ -381,10 +396,10 @@ export class Login extends Component {
 						connectorPlugins={ this.props.connectorPlugins }
 						signupUrl={ this.props.signupUrl }
 						isLostPasswordView={ isLostPasswordView }
-						// Only the main login view swaps its top-right link: it is the one that pairs
-						// with signup, and the one whose footer now carries the route to signup.
-						// getLostPasswordLink() is already null under 2FA, so those keep the top bar.
-						lostPasswordLink={ isLoginView ? this.getLostPasswordLink() : undefined }
+						// Only the main login view swaps its top-right link, and only on desktop: it is
+						// the one that pairs with signup, and the one whose footer carries the route
+						// to signup there. Already null under 2FA, so those keep the top bar too.
+						lostPasswordLink={ isLoginView ? this.getLostPasswordTopBarLink() : undefined }
 						noThanksRedirectUrl={ this.getNoThanksRedirectUrl() }
 						subHeadingProminent={ this.props.isFromJetpackConnector && ! isLostPasswordView }
 					>

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -1,7 +1,6 @@
 import page from '@automattic/calypso-router';
 import { Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { Step } from '@automattic/onboarding';
 import { ExternalLink } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
@@ -72,6 +71,7 @@ export class Login extends Component {
 		twoFactorAuthType: PropTypes.string,
 		action: PropTypes.string,
 		isGravPoweredClient: PropTypes.bool,
+		isWoo: PropTypes.bool,
 	};
 
 	static defaultProps = { isJetpack: false, isLoginView: true };
@@ -198,18 +198,18 @@ export class Login extends Component {
 	}
 
 	/**
-	 * The same link for the desktop top bar, where it takes that slot's treatment rather than the
-	 * footer's lighter one. Only one of the two is ever visible: see one-login-layout.scss.
+	 * The same link for desktop, where it sits on the password field's label row, beside the
+	 * field it resets. Only one of the two is ever visible: see login-form.scss.
 	 */
-	getLostPasswordTopBarLink() {
+	getLostPasswordFormLink() {
 		if ( this.props.twoFactorAuthType ) {
 			return null;
 		}
 
 		return (
-			<Step.LinkButton href="/" onClick={ this.handleLostPasswordClick }>
+			<a className="login__form-lost-password" href="/" onClick={ this.handleLostPasswordClick }>
 				{ this.props.translate( 'Lost your password?' ) }
-			</Step.LinkButton>
+			</a>
 		);
 	}
 
@@ -291,6 +291,15 @@ export class Login extends Component {
 				socialServiceResponse={ socialServiceResponse }
 				domain={ domain }
 				fromSite={ fromSite }
+				// Desktop only, and only on the main login view: the one that pairs with signup.
+				// Gravatar-powered clients carry their own link in their footer, and Woo renders
+				// its own "Forgot password?" inside the form, so neither gets a second one. Already
+				// null under 2FA, and never reaches the form while the password is hidden.
+				lostPasswordLink={
+					isLoginView && ! isGravPoweredClient && ! this.props.isWoo
+						? this.getLostPasswordFormLink()
+						: undefined
+				}
 				footer={
 					isGravPoweredLoginPage ? (
 						<GravPoweredLoginBlockFooter />
@@ -396,10 +405,10 @@ export class Login extends Component {
 						connectorPlugins={ this.props.connectorPlugins }
 						signupUrl={ this.props.signupUrl }
 						isLostPasswordView={ isLostPasswordView }
-						// Only the main login view swaps its top-right link, and only on desktop: it is
+						// Only the main login view empties its top-right slot, and only on desktop: it is
 						// the one that pairs with signup, and the one whose footer carries the route
-						// to signup there. Already null under 2FA, so those keep the top bar too.
-						lostPasswordLink={ isLoginView ? this.getLostPasswordTopBarLink() : undefined }
+						// to signup there. 2FA and the other mid-flow views keep the top bar.
+						signupLinkMobileOnly={ isLoginView }
 						noThanksRedirectUrl={ this.getNoThanksRedirectUrl() }
 						subHeadingProminent={ this.props.isFromJetpackConnector && ! isLostPasswordView }
 					>

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -1,6 +1,7 @@
 import page from '@automattic/calypso-router';
 import { Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { Step } from '@automattic/onboarding';
 import { ExternalLink } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
@@ -171,9 +172,10 @@ export class Login extends Component {
 			return null;
 		}
 
+		// Rendered into the top bar, so it takes the same treatment as the link it replaces
+		// there rather than the footer's, which is a different colour and weight.
 		return (
-			<a
-				className="one-login__footer-link"
+			<Step.LinkButton
 				href="/"
 				onClick={ ( event ) => {
 					event.preventDefault();
@@ -193,7 +195,7 @@ export class Login extends Component {
 				} }
 			>
 				{ this.props.translate( 'Lost your password?' ) }
-			</a>
+			</Step.LinkButton>
 		);
 	}
 
@@ -281,7 +283,7 @@ export class Login extends Component {
 					) : (
 						<OneLoginFooter
 							isLoginView={ isLoginView }
-							lostPasswordLink={ this.getLostPasswordLink() }
+							signupUrl={ signupUrl }
 							loginLink={ this.getLoginLink() }
 							supportLink={ this.getSupportLink() }
 						/>
@@ -325,6 +327,7 @@ export class Login extends Component {
 			isGenericOauth,
 			isGravPoweredClient,
 			isJetpack,
+			isLoginView,
 			action,
 			partnerConfig,
 		} = this.props;
@@ -378,6 +381,10 @@ export class Login extends Component {
 						connectorPlugins={ this.props.connectorPlugins }
 						signupUrl={ this.props.signupUrl }
 						isLostPasswordView={ isLostPasswordView }
+						// Only the main login view swaps its top-right link: it is the one that pairs
+						// with signup, and the one whose footer now carries the route to signup.
+						// getLostPasswordLink() is already null under 2FA, so those keep the top bar.
+						lostPasswordLink={ isLoginView ? this.getLostPasswordLink() : undefined }
 						noThanksRedirectUrl={ this.getNoThanksRedirectUrl() }
 						subHeadingProminent={ this.props.isFromJetpackConnector && ! isLostPasswordView }
 					>

--- a/packages/calypso-e2e/src/lib/pages/login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/login-page.ts
@@ -161,10 +161,14 @@ export class LoginPage {
 	}
 
 	/**
-	 * Clicks the "Create an account" link.
+	 * Clicks the link through to signup.
+	 *
+	 * The main login view carries this below the buttons as "Don't have an account? Sign up".
+	 * The mid-flow views (2FA, magic login, QR, and the OAuth2 authorize screen) keep
+	 * "Create an account" in the top bar, so match either. Only one is ever on screen.
 	 */
 	async clickCreateNewAccount(): Promise< Locator > {
-		const locator = this.page.getByRole( 'link', { name: 'Create an account' } );
+		const locator = this.page.getByRole( 'link', { name: /^(Create an account|Sign up)$/ } );
 		await locator.waitFor();
 		await locator.click();
 


### PR DESCRIPTION
## Why

Existing users land on the signup page and create duplicate or unexpected accounts because the "Log in" sits in the top bar, where it is difficult to correlate with the main form.

So the proposal is to move the switch between signing up and logging in in the same place on both screens, below the buttons.

**The rationale is consistency on that action: users learn that this is the way to switch from one mode to the other.**


## What

**Signup**
- "Log in" moves out of the top bar to a line below the buttons: "Have an account? Log in"
- The email button gets an envelope icon instead of the WordPress logo, so the four options read as parallel choices rather than one branded one

**Login**
- "Don't have an account? Sign up" added below the buttons, matching signup's line
- "Lost your password?" moves onto the password field's label row, right-aligned against the "Password" label, so it reads as belonging to the field it resets. It appears once the password step is shown. The top-right slot "Create an account" vacates stays empty, matching signup's desktop top bar

The video below predates that last point: it shows "Lost your password?" in the top-right slot. The current arrangement is the label row.

Only the main login view changes. 2FA, magic login, QR login and the OAuth2 authorize screen keep "Create an account" in the top bar: they are mid-flow screens with no lost-password link to promote.


## Before and after

| Screen | Before | After |
| --- | --- | --- |
| **Signup** | <img width="2876" height="1714" alt="Screenshot 2026-08-31 at 15 19 06" src="https://github.com/user-attachments/assets/7f8e2ddc-288e-43f1-bc49-76160f9b1676" /> | <img width="2876" height="1714" alt="Screenshot 2026-08-31 at 15 20 23" src="https://github.com/user-attachments/assets/1df293cb-3cfd-48c6-bfec-15bc166f8ecd" /> |
| **Login**, email step | <img width="2876" height="1714" alt="Screenshot 2026-08-31 at 15 18 39" src="https://github.com/user-attachments/assets/218dafe4-fe83-40d4-ad3d-1add65e58f86" /> | <img width="2876" height="1714" alt="Screenshot 2026-08-31 at 15 19 37" src="https://github.com/user-attachments/assets/06fde8a6-07f8-4119-9a84-f187df11ec7c" /> |
| **Login**, password step | - | <img width="2876" height="1714" alt="Screenshot 2026-08-31 at 15 20 02" src="https://github.com/user-attachments/assets/098e23d0-f36f-404a-9026-3bd6f13d33c8" /> |

## Desktop only

**Below 960px this is a no-op on both screens.** They keep the top-right link they have today, which already matches each other, so moving only one of them would introduce a third pattern rather than remove one.

Resize below 960px to check: signup keeps "Log in" in the top bar with no line in the form, and login keeps "Create an account" top-right with "Lost your password?" in the footer. Verified at 500px and 800px against 1280px.


## Not doing

> The subtext under the h1 is rendered by OneLoginLayout, which is shared by the main login view, magic login, QR login, the OAuth2 authorize screen, and the old /start signup step. Restyling it to match signup (16px→14px, SF Pro Text, darker grey) hits all of them.






