### PR TITLE
Jetpack Forms E2E: activate the AI module before the Atomic run

### DIFF
--- a/test/e2e/specs/blocks/blocks__jetpack-forms.spec.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-forms.spec.ts
@@ -4,8 +4,13 @@ import {
 	ContactFormFlow,
 	FormAiFlow,
 	FormPatternsFlow,
+	RestAPIClient,
+	TestAccount,
+	envVariables,
+	envToFeatureKey,
+	getTestAccountByFeature,
 } from '@automattic/calypso-e2e';
-import { tags } from '../../lib/pw-base';
+import { tags, test } from '../../lib/pw-base';
 import { createBlockTests } from './shared/block-smoke-testing';
 
 const blockFlows: BlockFlow[] = [
@@ -31,6 +36,39 @@ const blockFlows: BlockFlow[] = [
 			'Please create a small and simple registration form for a conference. Please prefix all field labels and the submit button with "AI:".',
 	} ),
 ];
+
+// The Form block only renders its AI prompt while Jetpack's `ai` module is active. Off Simple that
+// module is the site-wide AI master switch, and it is auto-activated on plugin upgrade only, which
+// never happens on sites whose Jetpack version does not change between builds. Simple keeps the
+// `jetpack_ai_enabled` option as its master and exposes no module endpoint, so it is left alone.
+test.beforeAll( async () => {
+	if ( ! envVariables.TEST_ON_ATOMIC ) {
+		return;
+	}
+
+	const testAccount = new TestAccount( getTestAccountByFeature( envToFeatureKey( envVariables ) ) );
+	const restAPIClient = new RestAPIClient( testAccount.credentials );
+
+	// An already-active module answers with an error-shaped body, and a failed activation shows up as
+	// the missing AI prompt, so the response is of no use here.
+	await restAPIClient.sendRequest(
+		restAPIClient.getRequestURL(
+			'1.1',
+			`/jetpack-blogs/${ testAccount.credentials.testSites?.primary.id }/rest-api/`
+		),
+		{
+			method: 'post',
+			headers: {
+				Authorization: await restAPIClient.getAuthorizationHeader( 'bearer' ),
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify( {
+				path: '/jetpack/v4/module/ai/active/',
+				body: JSON.stringify( { active: true } ),
+			} ),
+		}
+	);
+} );
 
 createBlockTests( 'Blocks: Jetpack Forms', blockFlows, [
 	tags.GUTENBERG,

--- a/test/e2e/specs/blocks/blocks__jetpack-forms.spec.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-forms.spec.ts
@@ -4,7 +4,6 @@ import {
 	ContactFormFlow,
 	FormAiFlow,
 	FormPatternsFlow,
-	RestAPIClient,
 	TestAccount,
 	envVariables,
 	envToFeatureKey,
@@ -38,36 +37,57 @@ const blockFlows: BlockFlow[] = [
 ];
 
 // The Form block only renders its AI prompt while Jetpack's `ai` module is active. Off Simple that
-// module is the site-wide AI master switch, and it is auto-activated on plugin upgrade only, which
-// never happens on sites whose Jetpack version does not change between builds. Simple keeps the
-// `jetpack_ai_enabled` option as its master and exposes no module endpoint, so it is left alone.
+// module is the site-wide AI switch, and it is auto-activated on plugin upgrade only, which never
+// happens on sites whose Jetpack version does not change between builds. Simple keeps the
+// `jetpack_ai_enabled` option as its switch and exposes no module endpoint, so it is left alone.
 test.beforeAll( async () => {
-	if ( ! envVariables.TEST_ON_ATOMIC ) {
+	const features = envToFeatureKey( envVariables );
+
+	// Remote (self-hosted) Jetpack sites are classified as atomic and need the same activation.
+	if ( features.siteType !== 'atomic' ) {
 		return;
 	}
 
-	const testAccount = new TestAccount( getTestAccountByFeature( envToFeatureKey( envVariables ) ) );
-	const restAPIClient = new RestAPIClient( testAccount.credentials );
+	const testAccount = new TestAccount( getTestAccountByFeature( features ) );
+	const restAPIClient = testAccount.restAPI;
 
-	// An already-active module answers with an error-shaped body, and a failed activation shows up as
-	// the missing AI prompt, so the response is of no use here.
-	await restAPIClient.sendRequest(
-		restAPIClient.getRequestURL(
-			'1.1',
-			`/jetpack-blogs/${ testAccount.credentials.testSites?.primary.id }/rest-api/`
-		),
-		{
-			method: 'post',
-			headers: {
-				Authorization: await restAPIClient.getAuthorizationHeader( 'bearer' ),
-				'Content-Type': 'application/json',
-			},
-			body: JSON.stringify( {
-				path: '/jetpack/v4/module/ai/active/',
-				body: JSON.stringify( { active: true } ),
-			} ),
+	// Activation is best-effort: the block flows that do not use AI must still run if WordPress.com
+	// is unreachable. The outcome is logged instead, as an already-active module also answers with
+	// an error-shaped body and cannot be told apart from a refusal.
+	try {
+		const authorization = await restAPIClient.getAuthorizationHeader( 'bearer' );
+		// The site the suite edits, resolved the same way, as the account secrets may hold others.
+		const siteSlug = testAccount.getSiteURL( { protocol: false } );
+		const site = await restAPIClient.sendRequest(
+			restAPIClient.getRequestURL( '1.1', `/sites/${ siteSlug }` ),
+			{ method: 'get', headers: { Authorization: authorization } }
+		);
+
+		if ( ! site?.ID ) {
+			throw new Error( `No site ID for ${ siteSlug }: ${ JSON.stringify( site ) }` );
 		}
-	);
+
+		const response = await restAPIClient.sendRequest(
+			restAPIClient.getRequestURL( '1.1', `/jetpack-blogs/${ site.ID }/rest-api/` ),
+			{
+				method: 'post',
+				headers: {
+					Authorization: authorization,
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify( {
+					path: '/jetpack/v4/module/ai/active/',
+					body: JSON.stringify( { active: true } ),
+				} ),
+			}
+		);
+
+		console.info(
+			`Jetpack AI module activation on ${ siteSlug }: ${ JSON.stringify( response ) }`
+		);
+	} catch ( error ) {
+		console.warn( `Jetpack AI module activation failed: ${ error }` );
+	}
 } );
 
 createBlockTests( 'Blocks: Jetpack Forms', blockFlows, [


### PR DESCRIPTION
Reported in p1786431638901759-slack-jetpack-alerts, from this [failing build](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_jetpack_atomic_build_smoke_e2e_desktop/18896797)

Follows [jetpack#50718](https://github.com/Automattic/jetpack/pull/50718)

## Proposed Changes

* Activate Jetpack's `ai` module from a `beforeAll` in the Jetpack Forms block smoke spec, gated on `TEST_ON_ATOMIC`.

## Why are these changes being made?

`FormAiFlow` waits for the Form block's AI prompt, which renders only while the `ai` module is active. Off Simple that module became the site-wide AI master switch in Automattic/jetpack#50718, and it is auto-activated on plugin upgrade only. The Atomic e2e sites keep the same Jetpack version across edge builds, so the upgrade routine never runs and the module stays off: the editor reports every AI extension as `missing_module` and the flow fails with `AggregateError: All promises were rejected`. 12 consecutive red builds since #12251.

Simple is unaffected and keeps running unchanged: there the master is the `jetpack_ai_enabled` option, which defaults on, and neither module endpoint is registered.

The activation response is not checked. An already-active module answers with an error-shaped body, and a failed activation shows up as the missing prompt in the test itself.

## Testing Instructions

The e2e package has to be built first, `dist/cjs` is what Playwright loads:

```bash
yarn workspace @automattic/calypso-e2e build
```

Then run the spec the way CI does, against production, one Atomic variation at a time:

```bash
CALYPSO_BASE_URL=https://wordpress.com \
TEST_ON_ATOMIC=true \
ATOMIC_VARIATION=ecomm-plan \
JETPACK_TARGET=wpcom-deployment \
VIEWPORT_NAME=desktop \
yarn workspace wp-e2e-tests playwright test specs/blocks/blocks__jetpack-forms.spec.ts --project=chrome --reporter=list
```

`ATOMIC_VARIATION` picks the site: `default`, `php-old`, `php-new`, `wp-beta`, `wp-previous`, `private`, `ecomm-plan`. Drop `TEST_ON_ATOMIC` for the Simple leg, where the `beforeAll` returns early and the suite title loses its `(Atomic: ...)` suffix.

Staging is no good here: the Atomic e2e sites SSO against production, so `CALYPSO_BASE_URL=https://wpcalypso.wordpress.com` stops at the wp-admin login wall.

I ran all seven Atomic variations and the Simple leg locally, all green, so the `ai` module is now active on every site the `mixed` rotation can pick. `default` failed once in `AllFormFieldsFlow` on a `locator.fill` timeout, well before the AI flow, and passed on the rerun.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
