### PR TITLE
Fix Squarespace import E2E: use a reachable source site URL

### DIFF
--- a/test/e2e/specs/tools/import__sites-squarespace.spec.ts
+++ b/test/e2e/specs/tools/import__sites-squarespace.spec.ts
@@ -59,7 +59,7 @@ test.describe(
 			pageImportLetsFindYourSite,
 			sitePublic,
 		} ) => {
-			const squarespaceSiteURL = 'https://example.squarespace.com/';
+			const squarespaceSiteURL = 'https://www.squarespace.com/';
 
 			await test.step( 'When I visit the "Let\'s find your site" page as coming from the wp-admin Tools > Import page', async function () {
 				await pageImportLetsFindYourSite.visit( sitePublic.blog_details.site_slug );


### PR DESCRIPTION
## Proposed Changes

**Points the Squarespace import E2E test at a source site that still responds.**

- `import__sites-squarespace.spec.ts` used `https://example.squarespace.com/` as the site to import from. That host stopped answering, so the test could never get past the first step.
- Swapped it for `https://www.squarespace.com/`, which the URL analyzer still identifies as the `squarespace` platform.

## Why are these changes being made?

The "Two" scenario of the Squarespace import spec has been failing on the pre-release E2E run against `trunk`, and re-running does not help — TeamCity labels it flaky, but nothing about it is random.

The test types a Squarespace site address into the "Let's find your site" step and expects to be sent to the Squarespace importer. To decide where to send you, that step asks the backend to look at the address and work out what platform the site runs on. The address the test used no longer resolves to a live site, so the backend cannot fetch it and returns an error instead of a platform. Without a platform, the step has nothing to route on, stays where it is and shows an error — so the importer heading the test waits for never appears, and it times out.

The other two scenarios in the same file are unaffected: they open the importer directly and never go through address detection.

Note that this trades one live external dependency for another. Stubbing the analyzer response in the test would be more durable, but it is a larger change than what is needed to unblock the release run.

## Testing Instructions

1. Run `yarn start`.
2. Visit `/setup/site-migration/site-migration-identify?siteSlug=<your-site-slug>&hide_importer_link=true&isUploadInProgress=false`.
3. Enter `https://www.squarespace.com/` in the Site address field and click **Check my site**.
4. Confirm you land on the **Import content from Squarespace** page.
5. Upload `test/e2e/specs/tools/import-files/squarespace-export-example.xml` and confirm the import confirmation screen appears with the **Import** button enabled.
