### PR TITLE
A4A MSD: Add the Partner Directory dashboard

### DIFF
--- a/client/dashboard/agency/partner-directory/dashboard-content.tsx
+++ b/client/dashboard/agency/partner-directory/dashboard-content.tsx
@@ -10,6 +10,7 @@ import {
 import { sprintf, _n, __ } from '@wordpress/i18n';
 import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import ActionList from '../../components/action-list';
+import { Card, CardBody } from '../../components/card';
 import IconList from '../../components/icon-list';
 import { SectionHeader } from '../../components/section-header';
 import { getBrandMeta } from './get-brand-meta';
@@ -188,48 +189,52 @@ export default function PartnerDirectoryDashboardContent( {
 						approvedCount
 					) }
 				/>
-				<IconList>
-					{ directoryStatuses.map( ( { directory, badge } ) => {
-						const brandMeta = getBrandMeta( directory, agency );
+				<Card>
+					<CardBody>
+						<VStack spacing={ 6 }>
+							{ directoryStatuses.map( ( { directory, badge } ) => {
+								const brandMeta = getBrandMeta( directory, agency );
 
-						return (
-							<IconList.Item
-								key={ directory }
-								decoration={ brandMeta.icon }
-								title={ DIRECTORY_NAMES[ directory ] }
-								description={
-									badge.key === 'approved' && brandMeta.isAvailable ? (
-										<VStack spacing={ 1 } alignment="flex-start" as="span">
-											<ExternalLink href={ brandMeta.url }>
-												{ sprintf(
-													/* translators: %s is the brand name, e.g. WordPress.com */
-													__( '%s Partner Directory' ),
-													DIRECTORY_NAMES[ directory ]
-												) }
-											</ExternalLink>
-											<ExternalLink href={ brandMeta.profileUrl }>
-												{ __( 'Your agency’s profile' ) }
-											</ExternalLink>
-										</VStack>
-									) : (
-										<VStack spacing={ 1 } alignment="flex-start" as="span">
-											{ /* No auto-open here: it would cover the congratulations screen. */ }
-											<StatusBadge
-												badge={ badge }
-												showPopoverOnLoad={ false }
-												expertiseUrl={ expertiseUrl }
-												recordTracksEvent={ recordTracksEvent }
-											/>
-											{ badge.key === 'approved' && ! brandMeta.isAvailable && (
-												<Text>{ __( 'This Partner Directory is launching soon.' ) }</Text>
-											) }
-										</VStack>
-									)
-								}
-							/>
-						);
-					} ) }
-				</IconList>
+								return (
+									<IconList.Item
+										key={ directory }
+										decoration={ brandMeta.icon }
+										title={ DIRECTORY_NAMES[ directory ] }
+										description={
+											badge.key === 'approved' && brandMeta.isAvailable ? (
+												<VStack spacing={ 1 } alignment="flex-start" as="span">
+													<ExternalLink href={ brandMeta.url }>
+														{ sprintf(
+															/* translators: %s is the brand name, e.g. WordPress.com */
+															__( '%s Partner Directory' ),
+															DIRECTORY_NAMES[ directory ]
+														) }
+													</ExternalLink>
+													<ExternalLink href={ brandMeta.profileUrl }>
+														{ __( 'Your agency’s profile' ) }
+													</ExternalLink>
+												</VStack>
+											) : (
+												<VStack spacing={ 1 } alignment="flex-start" as="span">
+													{ /* No auto-open here: it would cover the congratulations screen. */ }
+													<StatusBadge
+														badge={ badge }
+														showPopoverOnLoad={ false }
+														expertiseUrl={ expertiseUrl }
+														recordTracksEvent={ recordTracksEvent }
+													/>
+													{ badge.key === 'approved' && ! brandMeta.isAvailable && (
+														<Text>{ __( 'This Partner Directory is launching soon.' ) }</Text>
+													) }
+												</VStack>
+											)
+										}
+									/>
+								);
+							} ) }
+						</VStack>
+					</CardBody>
+				</Card>
 				<SectionHeader
 					level={ 3 }
 					title={ __( 'Edit your agency’s information' ) }

--- a/client/dashboard/agency/partner-directory/dashboard-content.tsx
+++ b/client/dashboard/agency/partner-directory/dashboard-content.tsx
@@ -10,6 +10,7 @@ import {
 import { sprintf, _n, __ } from '@wordpress/i18n';
 import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import ActionList from '../../components/action-list';
+import IconList from '../../components/icon-list';
 import { SectionHeader } from '../../components/section-header';
 import { getBrandMeta } from './get-brand-meta';
 import {
@@ -32,7 +33,7 @@ const KB_PROFILE_CONTENT_URL =
  * dashboard (`@automattic/api-core` agency) and the A4A client (Redux agency)
  * can provide it.
  */
-export interface PartnerDirectoryDashboardAgency {
+interface PartnerDirectoryDashboardAgency {
 	id: number;
 	name: string;
 	profile?: AgencyProfile | null;
@@ -44,7 +45,7 @@ interface DirectoryStatus {
 }
 
 interface Props {
-	agency?: PartnerDirectoryDashboardAgency | null;
+	agency: PartnerDirectoryDashboardAgency;
 	recordTracksEvent: ( eventName: string, properties?: Record< string, unknown > ) => void;
 	expertiseUrl: string;
 	profileUrl: string;
@@ -69,11 +70,11 @@ export default function PartnerDirectoryDashboardContent( {
 	onPublishError,
 	openSupportGuide,
 }: Props ) {
-	const profile = agency?.profile;
+	const profile = agency.profile;
 	const application = profile?.partner_directory_application;
 
 	const { mutate: publishProfile, isPending: isPublishingProfile } = useMutation(
-		withSnackbar( agencyPartnerDirectoryApplicationMutation( agency?.id ?? 0 ), {
+		withSnackbar( agencyPartnerDirectoryApplicationMutation( agency.id ), {
 			success: getProfilePublishedMessage(),
 			error: getProfilePublishFailedMessage(),
 		} )
@@ -96,19 +97,19 @@ export default function PartnerDirectoryDashboardContent( {
 		directories.filter( ( { status } ) => status === 'rejected' ).length === 1;
 
 	const onApplyNowClick = () => {
-		recordTracksEvent( 'calypso_partner_directory_dashboard_apply_now_click' );
+		recordTracksEvent( 'calypso_a4a_partner_directory_dashboard_apply_now_click' );
 	};
 
 	const onFinishProfileClick = () => {
-		recordTracksEvent( 'calypso_partner_directory_dashboard_finish_profile_click' );
+		recordTracksEvent( 'calypso_a4a_partner_directory_dashboard_finish_profile_click' );
 	};
 
 	const onEditExpertiseClick = () => {
-		recordTracksEvent( 'calypso_partner_directory_dashboard_edit_expertise_click' );
+		recordTracksEvent( 'calypso_a4a_partner_directory_dashboard_edit_expertise_click' );
 	};
 
 	const onEditProfileClick = () => {
-		recordTracksEvent( 'calypso_partner_directory_dashboard_edit_profile_click' );
+		recordTracksEvent( 'calypso_a4a_partner_directory_dashboard_edit_profile_click' );
 	};
 
 	const onPublishProfileClick = () => {
@@ -116,7 +117,7 @@ export default function PartnerDirectoryDashboardContent( {
 			return;
 		}
 
-		recordTracksEvent( 'calypso_partner_directory_dashboard_publish_profile_click' );
+		recordTracksEvent( 'calypso_a4a_partner_directory_dashboard_publish_profile_click' );
 
 		publishProfile(
 			{
@@ -187,12 +188,12 @@ export default function PartnerDirectoryDashboardContent( {
 						approvedCount
 					) }
 				/>
-				<ActionList>
+				<IconList>
 					{ directoryStatuses.map( ( { directory, badge } ) => {
 						const brandMeta = getBrandMeta( directory, agency );
 
 						return (
-							<ActionList.ActionItem
+							<IconList.Item
 								key={ directory }
 								decoration={ brandMeta.icon }
 								title={ DIRECTORY_NAMES[ directory ] }
@@ -225,11 +226,10 @@ export default function PartnerDirectoryDashboardContent( {
 										</VStack>
 									)
 								}
-								actions={ null }
 							/>
 						);
 					} ) }
-				</ActionList>
+				</IconList>
 				<SectionHeader
 					level={ 3 }
 					title={ __( 'Edit your agency’s information' ) }

--- a/client/dashboard/agency/partner-directory/dashboard-content.tsx
+++ b/client/dashboard/agency/partner-directory/dashboard-content.tsx
@@ -52,6 +52,12 @@ interface Props {
 	openSupportGuide?: ( url: string ) => void;
 }
 
+/**
+ * Shared by the dashboard snackbar and the classic app's success notice so
+ * the two hosts can't drift apart.
+ */
+export const getProfileSavedMessage = () => __( 'Your profile has been saved!' );
+
 export default function PartnerDirectoryDashboardContent( {
 	agency,
 	recordTracksEvent,
@@ -65,7 +71,7 @@ export default function PartnerDirectoryDashboardContent( {
 
 	const { mutate: publishProfile, isPending: isPublishingProfile } = useMutation(
 		withSnackbar( agencyPartnerDirectoryApplicationMutation( agency?.id ?? 0 ), {
-			success: __( 'Your profile has been saved!' ),
+			success: getProfileSavedMessage(),
 			error: __( 'Failed to publish your profile.' ),
 		} )
 	);
@@ -74,16 +80,17 @@ export default function PartnerDirectoryDashboardContent( {
 	const isProfileComplete = isAgencyProfileComplete( profile );
 	const isCompleted = isApplicationCompleted( application );
 
-	const directoryStatuses: DirectoryStatus[] =
-		application?.directories.map( ( { directory, status } ) => ( {
-			directory,
-			badge: getDirectoryStatusBadge( status ),
-		} ) ) ?? [];
+	const directories = application?.directories ?? [];
 
-	const hasDirectoryApproval = directoryStatuses.some( ( { badge } ) => badge.key === 'approved' );
+	const directoryStatuses: DirectoryStatus[] = directories.map( ( { directory, status } ) => ( {
+		directory,
+		badge: getDirectoryStatusBadge( status ),
+	} ) );
+
+	const hasDirectoryApproval = directories.some( ( { status } ) => status === 'approved' );
 	// The "not approved" popover only auto-opens for a single, unambiguous rejection.
 	const showPopoverOnLoad =
-		directoryStatuses.filter( ( { badge } ) => badge.key === 'rejected' ).length === 1;
+		directories.filter( ( { status } ) => status === 'rejected' ).length === 1;
 
 	const onApplyNowClick = () => {
 		recordTracksEvent( 'calypso_partner_directory_dashboard_apply_now_click' );
@@ -112,7 +119,7 @@ export default function PartnerDirectoryDashboardContent( {
 			{
 				services: profile.listing_details.services ?? [],
 				products: profile.listing_details.products ?? [],
-				directories: application.directories.map( ( { directory, urls, note } ) => ( {
+				directories: directories.map( ( { directory, urls, note } ) => ( {
 					directory,
 					urls,
 					note,
@@ -201,16 +208,15 @@ export default function PartnerDirectoryDashboardContent( {
 										</VStack>
 									) : (
 										<VStack spacing={ 1 } alignment="flex-start" as="span">
+											{ /* No auto-open here: it would cover the congratulations screen. */ }
 											<StatusBadge
 												badge={ badge }
-												showPopoverOnLoad={ showPopoverOnLoad }
+												showPopoverOnLoad={ false }
 												expertiseUrl={ expertiseUrl }
 												recordTracksEvent={ recordTracksEvent }
 											/>
 											{ badge.key === 'approved' && ! brandMeta.isAvailable && (
-												<Text variant="muted">
-													{ __( 'This Partner Directory is launching soon.' ) }
-												</Text>
+												<Text>{ __( 'This Partner Directory is launching soon.' ) }</Text>
 											) }
 										</VStack>
 									)
@@ -266,7 +272,7 @@ export default function PartnerDirectoryDashboardContent( {
 							<Button
 								variant={ applicationWasSubmitted ? 'secondary' : 'primary' }
 								href={ expertiseUrl }
-								onClick={ onApplyNowClick }
+								onClick={ applicationWasSubmitted ? onEditExpertiseClick : onApplyNowClick }
 							>
 								{ applicationWasSubmitted ? __( 'Edit expertise' ) : __( 'Apply now' ) }
 							</Button>
@@ -300,14 +306,12 @@ export default function PartnerDirectoryDashboardContent( {
 						title={ __( 'New clients will find you' ) }
 						description={
 							<VStack spacing={ 1 } as="span">
-								<Text variant="muted">
+								<Text>
 									{ __(
 										'Your agency will appear in the Partner Directories you select and get approved for, including WordPress.com, Woo.com, Pressable.com, and Jetpack.com.'
 									) }
 								</Text>
-								<Text variant="muted">
-									{ __( 'These Partner Directories are launching soon.' ) }
-								</Text>
+								<Text>{ __( 'These Partner Directories are launching soon.' ) }</Text>
 							</VStack>
 						}
 						actions={

--- a/client/dashboard/agency/partner-directory/dashboard-content.tsx
+++ b/client/dashboard/agency/partner-directory/dashboard-content.tsx
@@ -49,14 +49,16 @@ interface Props {
 	expertiseUrl: string;
 	profileUrl: string;
 	onPublishSuccess?: ( agency: Agency ) => void;
+	onPublishError?: () => void;
 	openSupportGuide?: ( url: string ) => void;
 }
 
-/**
- * Shared by the dashboard snackbar and the classic app's success notice so
- * the two hosts can't drift apart.
+/*
+ * Shared by the dashboard snackbar and the classic app's notices so the two
+ * hosts can't drift apart.
  */
-export const getProfileSavedMessage = () => __( 'Your profile has been saved!' );
+export const getProfilePublishedMessage = () => __( 'Profile published.' );
+export const getProfilePublishFailedMessage = () => __( 'Failed to publish your profile.' );
 
 export default function PartnerDirectoryDashboardContent( {
 	agency,
@@ -64,6 +66,7 @@ export default function PartnerDirectoryDashboardContent( {
 	expertiseUrl,
 	profileUrl,
 	onPublishSuccess,
+	onPublishError,
 	openSupportGuide,
 }: Props ) {
 	const profile = agency?.profile;
@@ -71,8 +74,8 @@ export default function PartnerDirectoryDashboardContent( {
 
 	const { mutate: publishProfile, isPending: isPublishingProfile } = useMutation(
 		withSnackbar( agencyPartnerDirectoryApplicationMutation( agency?.id ?? 0 ), {
-			success: getProfileSavedMessage(),
-			error: __( 'Failed to publish your profile.' ),
+			success: getProfilePublishedMessage(),
+			error: getProfilePublishFailedMessage(),
 		} )
 	);
 
@@ -129,6 +132,7 @@ export default function PartnerDirectoryDashboardContent( {
 			},
 			{
 				onSuccess: ( updatedAgency ) => onPublishSuccess?.( updatedAgency ),
+				onError: () => onPublishError?.(),
 			}
 		);
 	};

--- a/client/dashboard/agency/partner-directory/dashboard-content.tsx
+++ b/client/dashboard/agency/partner-directory/dashboard-content.tsx
@@ -66,6 +66,7 @@ export default function PartnerDirectoryDashboardContent( {
 	const { mutate: publishProfile, isPending: isPublishingProfile } = useMutation(
 		withSnackbar( agencyPartnerDirectoryApplicationMutation( agency?.id ?? 0 ), {
 			success: __( 'Your profile has been saved!' ),
+			error: __( 'Failed to publish your profile.' ),
 		} )
 	);
 

--- a/client/dashboard/agency/partner-directory/dashboard-content.tsx
+++ b/client/dashboard/agency/partner-directory/dashboard-content.tsx
@@ -1,0 +1,333 @@
+import { agencyPartnerDirectoryApplicationMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import {
+	Button,
+	ExternalLink,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { sprintf, _n, __ } from '@wordpress/i18n';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
+import ActionList from '../../components/action-list';
+import { SectionHeader } from '../../components/section-header';
+import { getBrandMeta } from './get-brand-meta';
+import {
+	DIRECTORY_NAMES,
+	getDirectoryStatusBadge,
+	isAgencyProfileComplete,
+	isApplicationCompleted,
+} from './lib';
+import StatusBadge from './status-badge';
+import type { DirectoryStatusBadge } from './lib';
+import type { Agency, AgencyPartnerDirectorySlug, AgencyProfile } from '@automattic/api-core';
+
+const KB_APPROVAL_PROCESS_URL =
+	'https://agencieshelp.automattic.com/knowledge-base/agency-directory-listings';
+const KB_PROFILE_CONTENT_URL =
+	'https://agencieshelp.automattic.com/knowledge-base/agency-directory-listings/#profile-content';
+
+/**
+ * The minimal agency shape the dashboard needs. Kept structural so both the
+ * dashboard (`@automattic/api-core` agency) and the A4A client (Redux agency)
+ * can provide it.
+ */
+export interface PartnerDirectoryDashboardAgency {
+	id: number;
+	name: string;
+	profile?: AgencyProfile | null;
+}
+
+interface DirectoryStatus {
+	directory: AgencyPartnerDirectorySlug;
+	badge: DirectoryStatusBadge;
+}
+
+interface Props {
+	agency?: PartnerDirectoryDashboardAgency | null;
+	recordTracksEvent: ( eventName: string, properties?: Record< string, unknown > ) => void;
+	expertiseUrl: string;
+	profileUrl: string;
+	onPublishSuccess?: ( agency: Agency ) => void;
+	openSupportGuide?: ( url: string ) => void;
+}
+
+export default function PartnerDirectoryDashboardContent( {
+	agency,
+	recordTracksEvent,
+	expertiseUrl,
+	profileUrl,
+	onPublishSuccess,
+	openSupportGuide,
+}: Props ) {
+	const profile = agency?.profile;
+	const application = profile?.partner_directory_application;
+
+	const { mutate: publishProfile, isPending: isPublishingProfile } = useMutation(
+		withSnackbar( agencyPartnerDirectoryApplicationMutation( agency?.id ?? 0 ), {
+			success: __( 'Your profile has been saved!' ),
+		} )
+	);
+
+	const applicationWasSubmitted = application ? application.status !== 'completed' : false;
+	const isProfileComplete = isAgencyProfileComplete( profile );
+	const isCompleted = isApplicationCompleted( application );
+
+	const directoryStatuses: DirectoryStatus[] =
+		application?.directories.map( ( { directory, status } ) => ( {
+			directory,
+			badge: getDirectoryStatusBadge( status ),
+		} ) ) ?? [];
+
+	const hasDirectoryApproval = directoryStatuses.some( ( { badge } ) => badge.key === 'approved' );
+	// The "not approved" popover only auto-opens for a single, unambiguous rejection.
+	const showPopoverOnLoad =
+		directoryStatuses.filter( ( { badge } ) => badge.key === 'rejected' ).length === 1;
+
+	const onApplyNowClick = () => {
+		recordTracksEvent( 'calypso_partner_directory_dashboard_apply_now_click' );
+	};
+
+	const onFinishProfileClick = () => {
+		recordTracksEvent( 'calypso_partner_directory_dashboard_finish_profile_click' );
+	};
+
+	const onEditExpertiseClick = () => {
+		recordTracksEvent( 'calypso_partner_directory_dashboard_edit_expertise_click' );
+	};
+
+	const onEditProfileClick = () => {
+		recordTracksEvent( 'calypso_partner_directory_dashboard_edit_profile_click' );
+	};
+
+	const onPublishProfileClick = () => {
+		if ( ! profile || ! application ) {
+			return;
+		}
+
+		recordTracksEvent( 'calypso_partner_directory_dashboard_publish_profile_click' );
+
+		publishProfile(
+			{
+				services: profile.listing_details.services ?? [],
+				products: profile.listing_details.products ?? [],
+				directories: application.directories.map( ( { directory, urls, note } ) => ( {
+					directory,
+					urls,
+					note,
+				} ) ),
+				feedback_url: application.feedback_url,
+				is_published: true,
+			},
+			{
+				onSuccess: ( updatedAgency ) => onPublishSuccess?.( updatedAgency ),
+			}
+		);
+	};
+
+	const supportGuideLink = ( url: string, label: string ) =>
+		openSupportGuide ? (
+			<Button variant="link" onClick={ () => openSupportGuide( url ) }>
+				{ label }
+			</Button>
+		) : (
+			<ExternalLink href={ url }>{ label }</ExternalLink>
+		);
+
+	const learnMoreSection = (
+		<VStack spacing={ 3 } alignment="flex-start">
+			<SectionHeader level={ 3 } title={ __( 'Learn more about the program' ) } />
+			{ supportGuideLink( KB_APPROVAL_PROCESS_URL, __( 'How does the approval process work?' ) ) }
+			{ supportGuideLink( KB_PROFILE_CONTENT_URL, __( 'What can I put on my public profile?' ) ) }
+		</VStack>
+	);
+
+	const directoryStatusBadges = (
+		// The extra block-start padding separates the badges from the item title,
+		// which sits closer to plain-text descriptions than to badge chips.
+		<VStack spacing={ 2 } as="span" style={ { paddingBlockStart: '4px' } }>
+			{ directoryStatuses.map( ( { directory, badge } ) => (
+				<HStack key={ directory } spacing={ 2 } justify="flex-start" as="span">
+					<StatusBadge
+						badge={ badge }
+						showPopoverOnLoad={ showPopoverOnLoad }
+						expertiseUrl={ expertiseUrl }
+						recordTracksEvent={ recordTracksEvent }
+					/>
+					<Text>{ DIRECTORY_NAMES[ directory ] }</Text>
+				</HStack>
+			) ) }
+		</VStack>
+	);
+
+	// The application is completed: at least one directory was approved and published.
+	if ( isCompleted ) {
+		const approvedCount = directoryStatuses.filter(
+			( { badge } ) => badge.key === 'approved'
+		).length;
+
+		return (
+			<VStack spacing={ 8 }>
+				<SectionHeader
+					title={ _n(
+						'Congratulations! Your agency is now listed in our Partner Directory.',
+						'Congratulations! Your agency is now listed in our Partner Directories.',
+						approvedCount
+					) }
+				/>
+				<ActionList>
+					{ directoryStatuses.map( ( { directory, badge } ) => {
+						const brandMeta = getBrandMeta( directory, agency );
+
+						return (
+							<ActionList.ActionItem
+								key={ directory }
+								decoration={ brandMeta.icon }
+								title={ DIRECTORY_NAMES[ directory ] }
+								description={
+									badge.key === 'approved' && brandMeta.isAvailable ? (
+										<VStack spacing={ 1 } alignment="flex-start" as="span">
+											<ExternalLink href={ brandMeta.url }>
+												{ sprintf(
+													/* translators: %s is the brand name, e.g. WordPress.com */
+													__( '%s Partner Directory' ),
+													DIRECTORY_NAMES[ directory ]
+												) }
+											</ExternalLink>
+											<ExternalLink href={ brandMeta.profileUrl }>
+												{ __( 'Your agency’s profile' ) }
+											</ExternalLink>
+										</VStack>
+									) : (
+										<VStack spacing={ 1 } alignment="flex-start" as="span">
+											<StatusBadge
+												badge={ badge }
+												showPopoverOnLoad={ showPopoverOnLoad }
+												expertiseUrl={ expertiseUrl }
+												recordTracksEvent={ recordTracksEvent }
+											/>
+											{ badge.key === 'approved' && ! brandMeta.isAvailable && (
+												<Text variant="muted">
+													{ __( 'This Partner Directory is launching soon.' ) }
+												</Text>
+											) }
+										</VStack>
+									)
+								}
+								actions={ null }
+							/>
+						);
+					} ) }
+				</ActionList>
+				<SectionHeader
+					level={ 3 }
+					title={ __( 'Edit your agency’s information' ) }
+					description={ __(
+						'Expand to more Automattic directories by adding products or updating your agency’s profile.'
+					) }
+					actions={
+						<>
+							<Button variant="secondary" href={ expertiseUrl } onClick={ onEditExpertiseClick }>
+								{ __( 'Edit expertise' ) }
+							</Button>
+							<Button variant="secondary" href={ profileUrl } onClick={ onEditProfileClick }>
+								{ __( 'Edit profile' ) }
+							</Button>
+						</>
+					}
+				/>
+				{ learnMoreSection }
+			</VStack>
+		);
+	}
+
+	return (
+		<VStack spacing={ 8 }>
+			<SectionHeader
+				title={ __( 'Boost your agency’s visibility across Automattic listings.' ) }
+				description={ __(
+					'List your agency in our Partner Directories. Showcase your skills, attract clients, and grow your business.'
+				) }
+			/>
+			<VStack spacing={ 4 }>
+				<SectionHeader level={ 3 } title={ __( 'How do I start?' ) } />
+				<ActionList>
+					<ActionList.ActionItem
+						title={ __( 'Share your expertise' ) }
+						description={
+							applicationWasSubmitted && directoryStatuses.length > 0
+								? directoryStatusBadges
+								: __(
+										'Pick your agency’s specialties and choose your directories. We’ll review your application.'
+								  )
+						}
+						actions={
+							<Button
+								variant={ applicationWasSubmitted ? 'secondary' : 'primary' }
+								href={ expertiseUrl }
+								onClick={ onApplyNowClick }
+							>
+								{ applicationWasSubmitted ? __( 'Edit expertise' ) : __( 'Apply now' ) }
+							</Button>
+						}
+					/>
+				</ActionList>
+				<ActionList>
+					<ActionList.ActionItem
+						title={ __( 'Finish adding details to your public profile' ) }
+						description={ __(
+							'When approved, add details to your agency’s public profile for clients to see.'
+						) }
+						actions={
+							<Button
+								variant={
+									applicationWasSubmitted && hasDirectoryApproval && ! isProfileComplete
+										? 'primary'
+										: 'secondary'
+								}
+								href={ profileUrl }
+								onClick={ onFinishProfileClick }
+								disabled={ ! applicationWasSubmitted || ! hasDirectoryApproval }
+							>
+								{ isProfileComplete ? __( 'Edit profile' ) : __( 'Finish profile' ) }
+							</Button>
+						}
+					/>
+				</ActionList>
+				<ActionList>
+					<ActionList.ActionItem
+						title={ __( 'New clients will find you' ) }
+						description={
+							<VStack spacing={ 1 } as="span">
+								<Text variant="muted">
+									{ __(
+										'Your agency will appear in the Partner Directories you select and get approved for, including WordPress.com, Woo.com, Pressable.com, and Jetpack.com.'
+									) }
+								</Text>
+								<Text variant="muted">
+									{ __( 'These Partner Directories are launching soon.' ) }
+								</Text>
+							</VStack>
+						}
+						actions={
+							<Button
+								variant={ applicationWasSubmitted ? 'primary' : 'secondary' }
+								onClick={ onPublishProfileClick }
+								disabled={
+									! applicationWasSubmitted ||
+									! hasDirectoryApproval ||
+									! isProfileComplete ||
+									isPublishingProfile
+								}
+								isBusy={ isPublishingProfile }
+							>
+								{ __( 'Done' ) }
+							</Button>
+						}
+					/>
+				</ActionList>
+			</VStack>
+			{ learnMoreSection }
+		</VStack>
+	);
+}

--- a/client/dashboard/agency/partner-directory/index.tsx
+++ b/client/dashboard/agency/partner-directory/index.tsx
@@ -9,9 +9,10 @@ import { a4aLink } from '../../utils/link';
 import PartnerDirectoryDashboardContent from './dashboard-content';
 
 /*
- * TODO: The expertise and profile forms are not migrated to the dashboard yet,
- * so these link to the classic A4A app. Switch to dashboard routes once those
- * screens are migrated.
+ * TODO: The expertise, profile, and lead matching screens are not migrated to
+ * the dashboard yet, so these link to the classic A4A app — and lead matching
+ * is not reachable from here at all until it migrates. Switch to dashboard
+ * routes once those screens are migrated.
  */
 const EXPERTISE_URL = a4aLink( '/partner-directory/agency-expertise' );
 const PROFILE_URL = a4aLink( '/partner-directory/agency-details' );
@@ -27,7 +28,7 @@ export default function AgencyPartnerDirectory() {
 	};
 
 	return (
-		<PageLayout size="small" header={ <PageHeader title={ __( 'Partner Directory' ) } /> }>
+		<PageLayout size="small" header={ <PageHeader title={ __( 'Partner Directories' ) } /> }>
 			{ agency && (
 				<PartnerDirectoryDashboardContent
 					agency={ agency }

--- a/client/dashboard/agency/partner-directory/index.tsx
+++ b/client/dashboard/agency/partner-directory/index.tsx
@@ -2,6 +2,7 @@ import { activeAgencyQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
+import { useHelpCenter } from '../../app/help-center';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import PartnerDirectoryDashboardContent from './dashboard-content';
@@ -17,6 +18,12 @@ const PROFILE_URL = '/partner-directory/agency-details';
 export default function AgencyPartnerDirectory() {
 	const { data: agency } = useQuery( activeAgencyQuery() );
 	const { recordTracksEvent } = useAnalytics();
+	const { setShowHelpCenter, setNavigateToRoute } = useHelpCenter();
+
+	const openSupportGuide = ( link: string ) => {
+		setShowHelpCenter( true );
+		setNavigateToRoute( '/post?link=' + encodeURIComponent( link ) );
+	};
 
 	return (
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Partner Directory' ) } /> }>
@@ -26,6 +33,7 @@ export default function AgencyPartnerDirectory() {
 					recordTracksEvent={ recordTracksEvent }
 					expertiseUrl={ EXPERTISE_URL }
 					profileUrl={ PROFILE_URL }
+					openSupportGuide={ openSupportGuide }
 				/>
 			) }
 		</PageLayout>

--- a/client/dashboard/agency/partner-directory/index.tsx
+++ b/client/dashboard/agency/partner-directory/index.tsx
@@ -5,15 +5,16 @@ import { useAnalytics } from '../../app/analytics';
 import { useHelpCenter } from '../../app/help-center';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { a4aLink } from '../../utils/link';
 import PartnerDirectoryDashboardContent from './dashboard-content';
 
 /*
  * TODO: The expertise and profile forms are not migrated to the dashboard yet,
- * so these point at the A4A app routes, which don't resolve here. Update them
- * once those screens are migrated.
+ * so these link to the classic A4A app. Switch to dashboard routes once those
+ * screens are migrated.
  */
-const EXPERTISE_URL = '/partner-directory/agency-expertise';
-const PROFILE_URL = '/partner-directory/agency-details';
+const EXPERTISE_URL = a4aLink( '/partner-directory/agency-expertise' );
+const PROFILE_URL = a4aLink( '/partner-directory/agency-details' );
 
 export default function AgencyPartnerDirectory() {
 	const { data: agency } = useQuery( activeAgencyQuery() );

--- a/client/dashboard/agency/partner-directory/index.tsx
+++ b/client/dashboard/agency/partner-directory/index.tsx
@@ -1,0 +1,33 @@
+import { activeAgencyQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+import { useAnalytics } from '../../app/analytics';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import PartnerDirectoryDashboardContent from './dashboard-content';
+
+/*
+ * TODO: The expertise and profile forms are not migrated to the dashboard yet,
+ * so these point at the A4A app routes, which don't resolve here. Update them
+ * once those screens are migrated.
+ */
+const EXPERTISE_URL = '/partner-directory/agency-expertise';
+const PROFILE_URL = '/partner-directory/agency-details';
+
+export default function AgencyPartnerDirectory() {
+	const { data: agency } = useQuery( activeAgencyQuery() );
+	const { recordTracksEvent } = useAnalytics();
+
+	return (
+		<PageLayout size="small" header={ <PageHeader title={ __( 'Partner Directory' ) } /> }>
+			{ agency && (
+				<PartnerDirectoryDashboardContent
+					agency={ agency }
+					recordTracksEvent={ recordTracksEvent }
+					expertiseUrl={ EXPERTISE_URL }
+					profileUrl={ PROFILE_URL }
+				/>
+			) }
+		</PageLayout>
+	);
+}

--- a/client/dashboard/agency/partner-directory/test/index.test.tsx
+++ b/client/dashboard/agency/partner-directory/test/index.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import AgencyPartnerDirectory from '../index';
+import type { AgencyPartnerDirectoryApplication, AgencyProfile } from '@automattic/api-core';
+
+const API = 'https://public-api.wordpress.com';
+
+function makeProfile(
+	application: AgencyPartnerDirectoryApplication | null = null
+): AgencyProfile {
+	return {
+		company_details: {
+			name: 'Test Agency',
+			email: 'test@example.com',
+			website: 'https://example.com',
+			bio_description: 'We build sites.',
+			logo_url: '',
+			landing_page_url: '',
+			country: 'US',
+		},
+		listing_details: {
+			is_available: true,
+			is_global: false,
+			industries: [ 'technology_and_it_services' ],
+			services: [ 'seo' ],
+			products: [ 'wordpress_com' ],
+			languages_spoken: [ 'en' ],
+		},
+		budget_details: {
+			budget_lower_range: '0',
+			budget_upper_range: '',
+			has_hourly_rate: false,
+			hourly_rate_value: '',
+		},
+		partner_directory_application: application,
+	};
+}
+
+function mockAgency( application: AgencyPartnerDirectoryApplication | null = null ) {
+	nock( API )
+		.get( '/wpcom/v2/agency' )
+		.query( true )
+		.reply( 200, [ { id: 123, name: 'Test Agency', profile: makeProfile( application ) } ] )
+		.persist();
+}
+
+function mockPreferences( preferences: Record< string, unknown > = {} ) {
+	nock( API )
+		.get( '/rest/v1.1/me/preferences' )
+		.query( true )
+		.reply( 200, { calypso_preferences: preferences } )
+		.persist();
+}
+
+describe( '<AgencyPartnerDirectory>', () => {
+	test( 'invites the agency to apply when no application was submitted', async () => {
+		mockAgency( null );
+
+		render( <AgencyPartnerDirectory /> );
+
+		expect(
+			await screen.findByRole( 'heading', {
+				name: 'Boost your agency’s visibility across Automattic listings.',
+			} )
+		).toBeVisible();
+		expect( screen.getByRole( 'link', { name: 'Apply now' } ) ).toBeVisible();
+	} );
+
+	test( 'shows the per-directory status once the application was submitted', async () => {
+		mockAgency( {
+			status: 'pending',
+			directories: [ { directory: 'wordpress', status: 'pending', urls: [], note: '' } ],
+			feedback_url: '',
+			is_published: false,
+		} );
+
+		render( <AgencyPartnerDirectory /> );
+
+		expect( await screen.findByRole( 'link', { name: 'Edit expertise' } ) ).toBeVisible();
+		expect( screen.getByText( 'Pending' ) ).toBeVisible();
+		expect( screen.getByText( 'WordPress.com' ) ).toBeVisible();
+	} );
+
+	test( 'opens the update-expertise popover when a directory was rejected', async () => {
+		mockAgency( {
+			status: 'pending',
+			directories: [ { directory: 'wordpress', status: 'rejected', urls: [], note: '' } ],
+			feedback_url: '',
+			is_published: false,
+		} );
+		mockPreferences();
+
+		render( <AgencyPartnerDirectory /> );
+
+		expect( await screen.findByText( 'Not approved' ) ).toBeVisible();
+		await waitFor( () =>
+			expect(
+				screen.getByText(
+					'Your agency wasn’t approved. Please check your email for feedback from our review team.'
+				)
+			).toBeVisible()
+		);
+		expect( screen.getByRole( 'link', { name: 'Update my expertise' } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'I’ll do it later' } ) ).toBeVisible();
+	} );
+
+	test( 'keeps the popover closed when it was dismissed before', async () => {
+		mockAgency( {
+			status: 'pending',
+			directories: [ { directory: 'wordpress', status: 'rejected', urls: [], note: '' } ],
+			feedback_url: '',
+			is_published: false,
+		} );
+		mockPreferences( { 'a4a-partner-directory-dashboard-not-approved-popover': true } );
+
+		render( <AgencyPartnerDirectory /> );
+
+		expect( await screen.findByText( 'Not approved' ) ).toBeVisible();
+		expect( screen.queryByRole( 'link', { name: 'Update my expertise' } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'congratulates the agency when a directory listing is approved and published', async () => {
+		mockAgency( {
+			status: 'completed',
+			directories: [
+				{ directory: 'wordpress', status: 'approved', urls: [], note: '', is_published: true },
+			],
+			feedback_url: '',
+			is_published: true,
+		} );
+
+		render( <AgencyPartnerDirectory /> );
+
+		expect(
+			await screen.findByRole( 'heading', {
+				name: 'Congratulations! Your agency is now listed in our Partner Directory.',
+			} )
+		).toBeVisible();
+		expect( screen.getByRole( 'link', { name: /Your agency’s profile/ } ) ).toBeVisible();
+		expect( screen.getByRole( 'link', { name: 'Edit profile' } ) ).toBeVisible();
+	} );
+} );

--- a/client/dashboard/agency/partner-directory/test/index.test.tsx
+++ b/client/dashboard/agency/partner-directory/test/index.test.tsx
@@ -115,7 +115,7 @@ describe( '<AgencyPartnerDirectory>', () => {
 			feedback_url: '',
 			is_published: false,
 		} );
-		mockPreferences( { 'a4a-partner-directory-dashboard-not-approved-popover': true } );
+		mockPreferences( { 'a4a-dashboard-pd-not-approved-popover': true } );
 
 		render( <AgencyPartnerDirectory /> );
 

--- a/client/dashboard/app-a4a/index.tsx
+++ b/client/dashboard/app-a4a/index.tsx
@@ -24,6 +24,7 @@ boot( {
 		agency: {
 			overview: true,
 			tiers: true,
+			partnerDirectory: true,
 			exclusiveOffers: true,
 			learn: true,
 			mcp: true,

--- a/client/dashboard/app-a4a/section.ts
+++ b/client/dashboard/app-a4a/section.ts
@@ -11,6 +11,7 @@ export const A4A_DASHBOARD_SECTION_PATHS = [
 	'/overview',
 	'/marketplace/exclusive-offers',
 	'/agency/tiers',
+	'/agency/partner-directory',
 	'/resources/learn',
 	'/resources/ai-mcp',
 	'/resources/ai-mcp/tools',

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -17,6 +17,7 @@ import type { PostHogOverrides } from '@automattic/posthog';
 export type AgencySupports = {
 	overview: boolean;
 	tiers: boolean;
+	partnerDirectory: boolean;
 	exclusiveOffers: boolean;
 	learn: boolean;
 	mcp: boolean;

--- a/client/dashboard/app/responsive-sidebar/agency.tsx
+++ b/client/dashboard/app/responsive-sidebar/agency.tsx
@@ -77,7 +77,7 @@ export default function AgencySidebar() {
 					) }
 					{ canAccessPartnerDirectory && (
 						<SidebarMenuItem to="/agency/partner-directory">
-							{ __( 'Partner Directory' ) }
+							{ __( 'Partner Directories' ) }
 						</SidebarMenuItem>
 					) }
 				</SidebarExpandableMenuItem>

--- a/client/dashboard/app/responsive-sidebar/agency.tsx
+++ b/client/dashboard/app/responsive-sidebar/agency.tsx
@@ -5,6 +5,7 @@ import { home, globe, layout, pages, tag, currencyDollar, people } from '@wordpr
 import { SidebarExpandableMenuItem, SidebarMenuItem } from '../../components/sidebar';
 import { useAppContext } from '../context';
 import {
+	agencyPartnerDirectoryRoute,
 	agencySitesRoute,
 	agencyTeamRoute,
 	agencyTiersRoute,
@@ -33,6 +34,10 @@ export default function AgencySidebar() {
 	const capabilities = activeAgency?.user?.capabilities ?? [];
 	const canAccess = ( route: AnyRoute ) => isRouteAllowedByCapabilities( route, capabilities );
 
+	const canAccessTiers = !! supports.agency.tiers && canAccess( agencyTiersRoute );
+	const canAccessPartnerDirectory =
+		!! ( supports.agency.partnerDirectory && activeAgency?.partner_directory?.allowed ) &&
+		canAccess( agencyPartnerDirectoryRoute );
 	const canAccessLearn = !! supports.agency.learn && canAccess( learnRoute );
 	const canAccessMcp =
 		!! ( supports.agency.mcp && activeAgency?.mcp?.allowed ) && canAccess( mcpRoute );
@@ -61,9 +66,20 @@ export default function AgencySidebar() {
 					{ __( 'Team' ) }
 				</SidebarMenuItem>
 			) }
-			{ supports.agency.tiers && canAccess( agencyTiersRoute ) && (
-				<SidebarExpandableMenuItem label={ __( 'Agency' ) } icon={ globe } to="/agency/tiers">
-					<SidebarMenuItem to="/agency/tiers">{ __( 'Tiers' ) }</SidebarMenuItem>
+			{ ( canAccessTiers || canAccessPartnerDirectory ) && (
+				<SidebarExpandableMenuItem
+					label={ __( 'Agency' ) }
+					icon={ globe }
+					to={ canAccessTiers ? '/agency/tiers' : '/agency/partner-directory' }
+				>
+					{ canAccessTiers && (
+						<SidebarMenuItem to="/agency/tiers">{ __( 'Tiers' ) }</SidebarMenuItem>
+					) }
+					{ canAccessPartnerDirectory && (
+						<SidebarMenuItem to="/agency/partner-directory">
+							{ __( 'Partner Directory' ) }
+						</SidebarMenuItem>
+					) }
 				</SidebarExpandableMenuItem>
 			) }
 			{ supports.agency.exclusiveOffers && canAccess( exclusiveOffersRoute ) && (

--- a/client/dashboard/app/responsive-sidebar/test/agency.test.tsx
+++ b/client/dashboard/app/responsive-sidebar/test/agency.test.tsx
@@ -12,6 +12,7 @@ import type { AgencySupports } from '../../context';
 const agencySupports: AgencySupports = {
 	overview: true,
 	tiers: true,
+	partnerDirectory: true,
 	exclusiveOffers: true,
 	learn: true,
 	mcp: true,
@@ -31,7 +32,14 @@ function mockAgency( capabilities: string[] ) {
 	nock( 'https://public-api.wordpress.com' )
 		.persist()
 		.get( '/wpcom/v2/agency' )
-		.reply( 200, [ { id: 1, mcp: { allowed: true }, user: { capabilities } } ] );
+		.reply( 200, [
+			{
+				id: 1,
+				mcp: { allowed: true },
+				partner_directory: { allowed: true, directories: [] },
+				user: { capabilities },
+			},
+		] );
 }
 
 async function renderSidebar( capabilities: string[] ) {
@@ -93,6 +101,24 @@ describe( '<AgencySidebar>', () => {
 		expect( screen.getByRole( 'link', { name: 'Payout settings' } ) ).toBeVisible();
 		expect( screen.queryByRole( 'link', { name: 'Referrals' } ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'link', { name: 'WooPayments' } ) ).not.toBeInTheDocument();
+	} );
+
+	// Partner Directory is gated by both an agency flag
+	// (`partner_directory.allowed`) and a capability. `mockAgency` always
+	// reports the flag on, so these cases isolate the capability gate.
+	test( 'shows Partner Directory when the user holds the partner directory capability', async () => {
+		await renderSidebar( [ 'a4a_read_partner_directory' ] );
+
+		expect( screen.getByRole( 'button', { name: 'Agency' } ) ).toBeVisible();
+		expect( screen.getByRole( 'link', { name: 'Partner Directory' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'link', { name: 'Tiers' } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'hides Partner Directory when the user lacks the partner directory capability', async () => {
+		await renderSidebar( [ 'a4a_read_agency_tier' ] );
+
+		expect( screen.getByRole( 'link', { name: 'Tiers' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'link', { name: 'Partner Directory' } ) ).not.toBeInTheDocument();
 	} );
 
 	// MCP is the one item gated by both a tier flag (`mcp.allowed`) and a

--- a/client/dashboard/app/responsive-sidebar/test/agency.test.tsx
+++ b/client/dashboard/app/responsive-sidebar/test/agency.test.tsx
@@ -110,7 +110,7 @@ describe( '<AgencySidebar>', () => {
 		await renderSidebar( [ 'a4a_read_partner_directory' ] );
 
 		expect( screen.getByRole( 'button', { name: 'Agency' } ) ).toBeVisible();
-		expect( screen.getByRole( 'link', { name: 'Partner Directory' } ) ).toBeVisible();
+		expect( screen.getByRole( 'link', { name: 'Partner Directories' } ) ).toBeVisible();
 		expect( screen.queryByRole( 'link', { name: 'Tiers' } ) ).not.toBeInTheDocument();
 	} );
 
@@ -118,7 +118,7 @@ describe( '<AgencySidebar>', () => {
 		await renderSidebar( [ 'a4a_read_agency_tier' ] );
 
 		expect( screen.getByRole( 'link', { name: 'Tiers' } ) ).toBeVisible();
-		expect( screen.queryByRole( 'link', { name: 'Partner Directory' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: 'Partner Directories' } ) ).not.toBeInTheDocument();
 	} );
 
 	// MCP is the one item gated by both a tier flag (`mcp.allowed`) and a

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -143,7 +143,7 @@ export const agencyPartnerDirectoryRoute = createRoute( {
 	head: () => ( {
 		meta: [
 			{
-				title: __( 'Partner Directory' ),
+				title: __( 'Partner Directories' ),
 			},
 		],
 	} ),

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -137,6 +137,27 @@ export const agencyTiersRoute = createRoute( {
 	)
 );
 
+// `/agency/partner-directory` – partner directory application dashboard
+export const agencyPartnerDirectoryRoute = createRoute( {
+	staticData: { requiresAgencyCapability: 'a4a_read_partner_directory' },
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Partner Directory' ),
+			},
+		],
+	} ),
+	getParentRoute: () => agencyRoute,
+	path: 'agency/partner-directory',
+	loader: () => queryClient.ensureQueryData( activeAgencyQuery() ),
+} ).lazy( () =>
+	import( '../../agency/partner-directory' ).then( ( d ) =>
+		createLazyRoute( 'agency-partner-directory' )( {
+			component: d.default,
+		} )
+	)
+);
+
 // `/marketplace/exclusive-offers` – partner offers (Refer / Resell)
 export const exclusiveOffersRoute = createRoute( {
 	staticData: { requiresAgencyCapability: 'a4a_read_exclusive_offers' },
@@ -822,6 +843,7 @@ export const createAgencyRoutes = () => [
 	agencyRoute.addChildren( [
 		agencyOverviewRoute,
 		agencyTiersRoute,
+		agencyPartnerDirectoryRoute,
 		exclusiveOffersRoute,
 		learnRoute,
 		mcpRoute.addChildren( [

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -149,6 +149,16 @@ export const agencyPartnerDirectoryRoute = createRoute( {
 	} ),
 	getParentRoute: () => agencyRoute,
 	path: 'agency/partner-directory',
+	beforeLoad: async ( { cause } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
+		const agency = await queryClient.ensureQueryData( activeAgencyQuery() );
+		if ( ! agency?.partner_directory?.allowed ) {
+			throw redirectAsNotAllowed( { to: '/overview' } );
+		}
+	},
 	loader: () => queryClient.ensureQueryData( activeAgencyQuery() ),
 } ).lazy( () =>
 	import( '../../agency/partner-directory' ).then( ( d ) =>


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/113461, which adds the data layer and building blocks (status badges, the “not approved” popover, brand metadata).

Part of A4A-2859.

## Proposed Changes

* Add the Partner Directory application dashboard to the new agencies dashboard, at `/agency/partner-directory`, with a sidebar entry under Agency.
* Agencies that aren’t part of the Partner Directory program are redirected to the overview page when opening the URL directly.
* The screen adapts to the application state:
  * **Not applied yet** — a “How do I start?” guide with three steps: share your expertise (apply), finish your public profile, and get found by new clients, plus approval-process and profile-content guides that open in the Help Center.
  * **Applied** — the expertise step shows a status badge per directory (Pending, Approved, Not approved, Closed).
  * **Rejected** — the “Not approved” badge carries a popover nudging the agency to update its expertise. It opens once on load for a single unambiguous rejection (dismissible, remembered via a user preference), and on hover afterwards.
  * **Approved & published** — a congratulations view listing each directory with links to the live directory and the agency’s public profile.
* Publishing the profile saves the application with a confirmation snackbar, or an error message if saving fails.

## Why are these changes being made?

* The Partner Directory dashboard is being ported to the new agencies dashboard so agencies can manage their directory presence there. The classic dashboard switches to this same screen in the follow-up PR, so both stay in sync.

## Testing Instructions

* Run `yarn start-dashboard` and open the A4A dashboard as an agency user.
* Open Agency → Partner Directories (`/agency/partner-directory`).
* An agency that isn’t part of the Partner Directory program has no sidebar entry and is redirected to the overview page when opening the URL directly.
* Walk the states:
  * An agency with no application sees the three-step “How do I start?” guide; only “Apply now” is enabled.
  * An agency with a submitted application sees per-directory status badges under “Share your expertise”.
  * With exactly one rejected directory, the “not approved” popover opens on load; its buttons dismiss it permanently (reload to confirm). With several rejections, nothing opens on load.
  * Hover a “Not approved” badge: the popover opens, stays open while the cursor is over it (buttons clickable), and closes when the cursor leaves. Popovers do not stack.
  * With an approved directory and a complete profile, “Done” publishes and shows the success snackbar; the request goes out as `PUT …/profile/application`.
  * An approved & published agency sees the congratulations view with directory and profile links.

<img width="1352" height="704" alt="Screenshot 2026-08-11 at 2 58 36 PM" src="https://github.com/user-attachments/assets/27dd2f85-ead1-4f3c-8747-853497ed66c6" />

<img width="1352" height="760" alt="Screenshot 2026-08-11 at 2 59 02 PM" src="https://github.com/user-attachments/assets/83f495b5-513f-425d-9489-c9be61f07ce1" />

<img width="1920" height="803" alt="Screenshot 2026-08-12 at 11 43 16 AM" src="https://github.com/user-attachments/assets/24a722a8-4c55-4133-a273-6f1453763fe5" />

<img width="1920" height="856" alt="Screenshot 2026-08-12 at 12 23 45 PM" src="https://github.com/user-attachments/assets/c69fb2b4-cb51-4b4e-aa5c-5effa1176a40" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)


