### PR TITLE
A4A MSD: Add the Partner Directory data layer and building blocks

### DIFF
--- a/client/dashboard/agency/partner-directory/get-brand-meta.tsx
+++ b/client/dashboard/agency/partner-directory/get-brand-meta.tsx
@@ -1,0 +1,67 @@
+import { JetpackLogo } from '@automattic/components/src/logos/jetpack-logo';
+import { WooCommerceWooLogo } from '@automattic/components/src/logos/woocommerce-woo-logo';
+import { WordPressLogo } from '@automattic/components/src/logos/wordpress-logo';
+import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
+import type { AgencyPartnerDirectorySlug } from '@automattic/api-core';
+import type { ReactNode } from 'react';
+
+export type BrandMeta = {
+	icon: ReactNode;
+	url: string;
+	profileUrl: string;
+	isAvailable: boolean;
+};
+
+/**
+ * Returns the public directory URLs and icon for a partner directory brand.
+ */
+export function getBrandMeta(
+	directory: AgencyPartnerDirectorySlug,
+	agency?: { id: number; name: string } | null
+): BrandMeta {
+	const agencySlug =
+		agency?.name
+			.toLowerCase()
+			.replace( /[^a-z0-9\s]/g, '' )
+			.replace( /\s+/g, '-' )
+			.replace( /^-+|-+$/g, '' ) ?? '-';
+	const agencyId = agency?.id ?? '';
+
+	switch ( directory ) {
+		case 'wordpress':
+			return {
+				icon: <WordPressLogo size={ 24 } />,
+				url: 'https://wordpress.com/development-services/',
+				profileUrl: `https://wordpress.com/development-services/${ agencySlug }/${ agencyId }`,
+				isAvailable: true,
+			};
+		case 'woocommerce':
+			return {
+				icon: <WooCommerceWooLogo width={ 36 } height={ 24 } />,
+				url: 'https://woocommerce.com/development-services/',
+				profileUrl: `https://woocommerce.com/development-services/${ agencySlug }/${ agencyId }`,
+				isAvailable: true,
+			};
+		case 'pressable':
+			return {
+				icon: <img src={ pressableIcon } alt="" width={ 24 } />,
+				url: 'https://pressable.com/development-services/',
+				profileUrl: `https://pressable.com/development-services/${ agencySlug }/${ agencyId }`,
+				isAvailable: true,
+			};
+		case 'jetpack':
+			return {
+				icon: <JetpackLogo size={ 24 } />,
+				url: 'https://jetpack.com/development-services/',
+				profileUrl: `https://jetpack.com/development-services/${ agencySlug }/${ agencyId }`,
+				isAvailable: true,
+			};
+		default:
+			return {
+				icon: undefined,
+				url: '',
+				profileUrl: '',
+				isAvailable: false,
+			};
+	}
+}

--- a/client/dashboard/agency/partner-directory/get-brand-meta.tsx
+++ b/client/dashboard/agency/partner-directory/get-brand-meta.tsx
@@ -12,6 +12,15 @@ export type BrandMeta = {
 	isAvailable: boolean;
 };
 
+const DIRECTORY_BRANDS: Partial<
+	Record< AgencyPartnerDirectorySlug, { host: string; icon: ReactNode } >
+> = {
+	wordpress: { host: 'wordpress.com', icon: <WordPressLogo size={ 24 } /> },
+	woocommerce: { host: 'woocommerce.com', icon: <WooCommerceWooLogo width={ 36 } height={ 24 } /> },
+	pressable: { host: 'pressable.com', icon: <img src={ pressableIcon } alt="" width={ 24 } /> },
+	jetpack: { host: 'jetpack.com', icon: <JetpackLogo size={ 24 } /> },
+};
+
 /**
  * Returns the public directory URLs and icon for a partner directory brand.
  */
@@ -19,49 +28,28 @@ export function getBrandMeta(
 	directory: AgencyPartnerDirectorySlug,
 	agency?: { id: number; name: string } | null
 ): BrandMeta {
+	const brand = DIRECTORY_BRANDS[ directory ];
+	if ( ! brand ) {
+		return {
+			icon: undefined,
+			url: '',
+			profileUrl: '',
+			isAvailable: false,
+		};
+	}
+
 	const agencySlug =
 		agency?.name
 			.toLowerCase()
 			.replace( /[^a-z0-9\s]/g, '' )
 			.replace( /\s+/g, '-' )
-			.replace( /^-+|-+$/g, '' ) ?? '-';
-	const agencyId = agency?.id ?? '';
+			.replace( /^-+|-+$/g, '' ) || '-';
+	const url = `https://${ brand.host }/development-services/`;
 
-	switch ( directory ) {
-		case 'wordpress':
-			return {
-				icon: <WordPressLogo size={ 24 } />,
-				url: 'https://wordpress.com/development-services/',
-				profileUrl: `https://wordpress.com/development-services/${ agencySlug }/${ agencyId }`,
-				isAvailable: true,
-			};
-		case 'woocommerce':
-			return {
-				icon: <WooCommerceWooLogo width={ 36 } height={ 24 } />,
-				url: 'https://woocommerce.com/development-services/',
-				profileUrl: `https://woocommerce.com/development-services/${ agencySlug }/${ agencyId }`,
-				isAvailable: true,
-			};
-		case 'pressable':
-			return {
-				icon: <img src={ pressableIcon } alt="" width={ 24 } />,
-				url: 'https://pressable.com/development-services/',
-				profileUrl: `https://pressable.com/development-services/${ agencySlug }/${ agencyId }`,
-				isAvailable: true,
-			};
-		case 'jetpack':
-			return {
-				icon: <JetpackLogo size={ 24 } />,
-				url: 'https://jetpack.com/development-services/',
-				profileUrl: `https://jetpack.com/development-services/${ agencySlug }/${ agencyId }`,
-				isAvailable: true,
-			};
-		default:
-			return {
-				icon: undefined,
-				url: '',
-				profileUrl: '',
-				isAvailable: false,
-			};
-	}
+	return {
+		icon: brand.icon,
+		url,
+		profileUrl: `${ url }${ agencySlug }/${ agency?.id ?? '' }`,
+		isAvailable: true,
+	};
 }

--- a/client/dashboard/agency/partner-directory/get-brand-meta.tsx
+++ b/client/dashboard/agency/partner-directory/get-brand-meta.tsx
@@ -1,6 +1,7 @@
 import { JetpackLogo } from '@automattic/components/src/logos/jetpack-logo';
 import { WooCommerceWooLogo } from '@automattic/components/src/logos/woocommerce-woo-logo';
 import { WordPressLogo } from '@automattic/components/src/logos/wordpress-logo';
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
 import type { AgencyPartnerDirectorySlug } from '@automattic/api-core';
 import type { ReactNode } from 'react';
@@ -15,7 +16,12 @@ export type BrandMeta = {
 const DIRECTORY_BRANDS: Partial<
 	Record< AgencyPartnerDirectorySlug, { host: string; icon: ReactNode } >
 > = {
-	wordpress: { host: 'wordpress.com', icon: <WordPressLogo size={ 24 } /> },
+	wordpress: {
+		host: 'wordpress.com',
+		// An explicit className drops the component's default `wordpress-logo`
+		// class, whose bottom margin would inflate the icon box.
+		icon: <WordPressLogo size={ 24 } className="partner-directory-wordpress-logo" />,
+	},
 	woocommerce: { host: 'woocommerce.com', icon: <WooCommerceWooLogo width={ 36 } height={ 24 } /> },
 	pressable: { host: 'pressable.com', icon: <img src={ pressableIcon } alt="" width={ 24 } /> },
 	jetpack: { host: 'jetpack.com', icon: <JetpackLogo size={ 24 } /> },
@@ -47,7 +53,13 @@ export function getBrandMeta(
 	const url = `https://${ brand.host }/development-services/`;
 
 	return {
-		icon: brand.icon,
+		// The fixed-width box keeps rows aligned: the Woo wordmark is wider
+		// than the square logos, and the decoration slot sizes to content.
+		icon: (
+			<HStack as="span" expanded={ false } justify="center" style={ { width: '36px' } }>
+				{ brand.icon }
+			</HStack>
+		),
 		url,
 		profileUrl: `${ url }${ agencySlug }/${ agency?.id ?? '' }`,
 		isAvailable: true,

--- a/client/dashboard/agency/partner-directory/lib.ts
+++ b/client/dashboard/agency/partner-directory/lib.ts
@@ -1,0 +1,93 @@
+import { __ } from '@wordpress/i18n';
+import type {
+	AgencyPartnerDirectoryApplication,
+	AgencyPartnerDirectorySlug,
+	AgencyProfile,
+} from '@automattic/api-core';
+import type { Badge } from '@automattic/ui';
+import type { ComponentProps } from 'react';
+
+export type StatusBadgeIntent = ComponentProps< typeof Badge >[ 'intent' ];
+
+export interface DirectoryStatusBadge {
+	key: 'pending' | 'approved' | 'rejected' | 'closed' | 'unknown';
+	label: string;
+	intent: StatusBadgeIntent;
+}
+
+export const DIRECTORY_NAMES: Record< AgencyPartnerDirectorySlug, string > = {
+	wordpress: 'WordPress.com',
+	woocommerce: 'WooCommerce.com',
+	jetpack: 'Jetpack.com',
+	pressable: 'Pressable.com',
+	vip: 'WordPress VIP',
+};
+
+export function getDirectoryStatusBadge( status?: string ): DirectoryStatusBadge {
+	switch ( status ) {
+		case 'pending':
+			return { key: 'pending', label: __( 'Pending' ), intent: 'warning' };
+		case 'approved':
+			return { key: 'approved', label: __( 'Approved' ), intent: 'success' };
+		case 'rejected':
+			return { key: 'rejected', label: __( 'Not approved' ), intent: 'error' };
+		case 'closed':
+			return { key: 'closed', label: __( 'Closed' ), intent: 'default' };
+		default:
+			return { key: 'unknown', label: '-', intent: 'default' };
+	}
+}
+
+function isValidUrl( url: string ): boolean {
+	return (
+		url.length > 3 &&
+		/^(https?:\/\/)?([a-z0-9-]+\.)+[a-z]{2,}(:[0-9]{1,5})?(\/[^\s]*)?$/i.test( url )
+	);
+}
+
+function isValidEmail( email: string ): boolean {
+	return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test( email );
+}
+
+/**
+ * Whether the agency's public profile has all the details required to be
+ * listed in a partner directory. Mirrors the validation of the agency
+ * details form.
+ */
+export function isAgencyProfileComplete( profile?: AgencyProfile | null ): boolean {
+	if ( ! profile ) {
+		return false;
+	}
+
+	const { company_details: company, listing_details: listing } = profile;
+
+	return (
+		company.name.length > 0 &&
+		isValidEmail( company.email ) &&
+		isValidUrl( company.website ) &&
+		company.bio_description.length > 0 &&
+		// The landing page URL is optional.
+		( company.landing_page_url.length === 0 || isValidUrl( company.landing_page_url ) ) &&
+		( company.country?.length ?? 0 ) > 0 &&
+		listing.industries.length > 0 &&
+		listing.services.length > 0 &&
+		listing.products.length > 0 &&
+		( listing.languages_spoken?.length ?? 0 ) > 0
+	);
+}
+
+/**
+ * Whether the application flow is fully completed: the profile is published
+ * and at least one directory listing is approved and published.
+ */
+export function isApplicationCompleted(
+	application?: AgencyPartnerDirectoryApplication | null
+): boolean {
+	return (
+		( application?.is_published &&
+			application.directories.some(
+				( directory ) => directory.status === 'approved' && directory.is_published
+			) ) ??
+		false
+	);
+}

--- a/client/dashboard/agency/partner-directory/lib.ts
+++ b/client/dashboard/agency/partner-directory/lib.ts
@@ -1,6 +1,8 @@
 import { __ } from '@wordpress/i18n';
+import emailValidator from 'email-validator';
 import type {
 	AgencyPartnerDirectoryApplication,
+	AgencyPartnerDirectoryEntryStatus,
 	AgencyPartnerDirectorySlug,
 	AgencyProfile,
 } from '@automattic/api-core';
@@ -23,7 +25,9 @@ export const DIRECTORY_NAMES: Record< AgencyPartnerDirectorySlug, string > = {
 	vip: 'WordPress VIP',
 };
 
-export function getDirectoryStatusBadge( status?: string ): DirectoryStatusBadge {
+export function getDirectoryStatusBadge(
+	status?: AgencyPartnerDirectoryEntryStatus
+): DirectoryStatusBadge {
 	switch ( status ) {
 		case 'pending':
 			return { key: 'pending', label: __( 'Pending' ), intent: 'warning' };
@@ -45,10 +49,6 @@ function isValidUrl( url: string ): boolean {
 	);
 }
 
-function isValidEmail( email: string ): boolean {
-	return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test( email );
-}
-
 /**
  * Whether the agency's public profile has all the details required to be
  * listed in a partner directory. Mirrors the validation of the agency
@@ -63,7 +63,7 @@ export function isAgencyProfileComplete( profile?: AgencyProfile | null ): boole
 
 	return (
 		company.name.length > 0 &&
-		isValidEmail( company.email ) &&
+		emailValidator.validate( company.email ) &&
 		isValidUrl( company.website ) &&
 		company.bio_description.length > 0 &&
 		// The landing page URL is optional.
@@ -85,7 +85,7 @@ export function isApplicationCompleted(
 ): boolean {
 	return (
 		( application?.is_published &&
-			application.directories.some(
+			application.directories?.some(
 				( directory ) => directory.status === 'approved' && directory.is_published
 			) ) ??
 		false

--- a/client/dashboard/agency/partner-directory/not-approved-popover.tsx
+++ b/client/dashboard/agency/partner-directory/not-approved-popover.tsx
@@ -1,5 +1,9 @@
-import { userPreferenceMutation, userPreferenceQuery } from '@automattic/api-queries';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import {
+	rawUserPreferencesQuery,
+	userPreferenceMutation,
+	userPreferenceQuery,
+} from '@automattic/api-queries';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
 	Button,
 	Popover,
@@ -10,6 +14,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useEffect, useRef, useState } from 'react';
 import { CardBody } from '../../components/card';
+import type { UserPreferences } from '@automattic/api-core';
 import type { ReactNode } from 'react';
 
 const PREFERENCE_NAME = 'a4a-partner-directory-dashboard-not-approved-popover';
@@ -34,13 +39,12 @@ export default function NotApprovedPopover( {
 }: Props ) {
 	const [ anchor, setAnchor ] = useState< HTMLElement | null >( null );
 	const [ showPopover, setShowPopover ] = useState( false );
-	// Covers the gap until the preference cache reflects the mutation.
-	const [ dismissedLocally, setDismissedLocally ] = useState( false );
 
+	const queryClient = useQueryClient();
 	const { data: preferenceDismissed } = useQuery( userPreferenceQuery( PREFERENCE_NAME ) );
 	const { mutate: savePreference } = useMutation( userPreferenceMutation( PREFERENCE_NAME ) );
 
-	const popoverDismissed = dismissedLocally || !! preferenceDismissed;
+	const popoverDismissed = !! preferenceDismissed;
 
 	useEffect( () => {
 		if ( showOnLoad && preferenceDismissed === false ) {
@@ -50,7 +54,15 @@ export default function NotApprovedPopover( {
 
 	const dismissPopover = ( eventName: string ) => {
 		setShowPopover( false );
-		setDismissedLocally( true );
+		// Write through the host app's query client: the mutation's own cache
+		// update targets the MSD singleton, which the classic app doesn't read.
+		queryClient.setQueryData< UserPreferences >(
+			rawUserPreferencesQuery().queryKey,
+			( previous ) => ( {
+				...previous,
+				[ PREFERENCE_NAME ]: true,
+			} )
+		);
 		savePreference( true );
 		recordTracksEvent( eventName );
 	};
@@ -79,6 +91,7 @@ export default function NotApprovedPopover( {
 		<VStack
 			as="span"
 			ref={ setAnchor }
+			tabIndex={ 0 }
 			onMouseEnter={ openOnHover }
 			onMouseLeave={ closeOnHoverOut }
 			onFocus={ () => handleShowPopover( true ) }

--- a/client/dashboard/agency/partner-directory/not-approved-popover.tsx
+++ b/client/dashboard/agency/partner-directory/not-approved-popover.tsx
@@ -17,7 +17,7 @@ import { CardBody } from '../../components/card';
 import type { UserPreferences } from '@automattic/api-core';
 import type { ReactNode } from 'react';
 
-const PREFERENCE_NAME = 'a4a-partner-directory-dashboard-not-approved-popover';
+const PREFERENCE_NAME = 'a4a-dashboard-pd-not-approved-popover';
 
 interface Props {
 	children: ReactNode;
@@ -99,7 +99,15 @@ export default function NotApprovedPopover( {
 			tabIndex={ 0 }
 			onMouseEnter={ openOnHover }
 			onMouseLeave={ closeOnHoverOut }
-			onFocus={ () => handleShowPopover( true ) }
+			onFocus={ openOnHover }
+			onBlur={ closeOnHoverOut }
+			onKeyDown={ ( event: React.KeyboardEvent ) => {
+				// Escape always closes, even the on-load popover; the dismissal
+				// isn't persisted, so the nudge returns on the next visit.
+				if ( event.key === 'Escape' ) {
+					setShowPopover( false );
+				}
+			} }
 		>
 			{ children }
 			{ showPopover && (
@@ -110,11 +118,14 @@ export default function NotApprovedPopover( {
 					shift
 					focusOnMount={ false }
 					onFocusOutside={ () => handleShowPopover( false ) }
+					onClose={ () => setShowPopover( false ) }
 				>
 					<CardBody
 						style={ { width: 'min(80vw, 350px)' } }
 						onMouseEnter={ openOnHover }
 						onMouseLeave={ closeOnHoverOut }
+						onFocus={ openOnHover }
+						onBlur={ closeOnHoverOut }
 					>
 						<VStack spacing={ 4 }>
 							<Text as="p">
@@ -128,7 +139,9 @@ export default function NotApprovedPopover( {
 									size="compact"
 									href={ expertiseUrl }
 									onClick={ () =>
-										dismissPopover( 'calypso_partner_directory_dashboard_update_expertise_click' )
+										dismissPopover(
+											'calypso_a4a_partner_directory_dashboard_update_expertise_click'
+										)
 									}
 								>
 									{ __( 'Update my expertise' ) }
@@ -138,7 +151,7 @@ export default function NotApprovedPopover( {
 										variant="secondary"
 										size="compact"
 										onClick={ () =>
-											dismissPopover( 'calypso_partner_directory_dashboard_do_it_later_click' )
+											dismissPopover( 'calypso_a4a_partner_directory_dashboard_do_it_later_click' )
 										}
 									>
 										{ __( 'I’ll do it later' ) }

--- a/client/dashboard/agency/partner-directory/not-approved-popover.tsx
+++ b/client/dashboard/agency/partner-directory/not-approved-popover.tsx
@@ -1,0 +1,136 @@
+import { userPreferenceMutation, userPreferenceQuery } from '@automattic/api-queries';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import {
+	Button,
+	Popover,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useEffect, useRef, useState } from 'react';
+import { CardBody } from '../../components/card';
+import type { ReactNode } from 'react';
+
+const PREFERENCE_NAME = 'a4a-partner-directory-dashboard-not-approved-popover';
+
+interface Props {
+	children: ReactNode;
+	showOnLoad: boolean;
+	expertiseUrl: string;
+	recordTracksEvent: ( eventName: string, properties?: Record< string, unknown > ) => void;
+}
+
+/**
+ * Anchors a popover to its children nudging the agency to update its
+ * expertise after a rejected application. Shown once on load until
+ * dismissed, and on hover afterwards.
+ */
+export default function NotApprovedPopover( {
+	children,
+	showOnLoad,
+	expertiseUrl,
+	recordTracksEvent,
+}: Props ) {
+	const [ anchor, setAnchor ] = useState< HTMLElement | null >( null );
+	const [ showPopover, setShowPopover ] = useState( false );
+	// Covers the gap until the preference cache reflects the mutation.
+	const [ dismissedLocally, setDismissedLocally ] = useState( false );
+
+	const { data: preferenceDismissed } = useQuery( userPreferenceQuery( PREFERENCE_NAME ) );
+	const { mutate: savePreference } = useMutation( userPreferenceMutation( PREFERENCE_NAME ) );
+
+	const popoverDismissed = dismissedLocally || !! preferenceDismissed;
+
+	useEffect( () => {
+		if ( showOnLoad && preferenceDismissed === false ) {
+			setShowPopover( true );
+		}
+	}, [ showOnLoad, preferenceDismissed ] );
+
+	const dismissPopover = ( eventName: string ) => {
+		setShowPopover( false );
+		setDismissedLocally( true );
+		savePreference( true );
+		recordTracksEvent( eventName );
+	};
+
+	const handleShowPopover = ( show: boolean ) => {
+		// While the on-load popover is up, only its own actions can close it.
+		if ( ! showOnLoad || popoverDismissed ) {
+			setShowPopover( show );
+		}
+	};
+
+	// The popover renders in a portal outside the anchor, so closing waits a
+	// beat to let the cursor travel from the badge into the popover.
+	const closeTimer = useRef< number | undefined >( undefined );
+	const openOnHover = () => {
+		window.clearTimeout( closeTimer.current );
+		handleShowPopover( true );
+	};
+	const closeOnHoverOut = () => {
+		window.clearTimeout( closeTimer.current );
+		closeTimer.current = window.setTimeout( () => handleShowPopover( false ), 150 );
+	};
+	useEffect( () => () => window.clearTimeout( closeTimer.current ), [] );
+
+	return (
+		<VStack
+			as="span"
+			ref={ setAnchor }
+			onMouseEnter={ openOnHover }
+			onMouseLeave={ closeOnHoverOut }
+			onFocus={ () => handleShowPopover( true ) }
+		>
+			{ children }
+			{ showPopover && (
+				<Popover
+					anchor={ anchor }
+					placement="bottom-start"
+					offset={ 12 }
+					shift
+					focusOnMount={ false }
+					onFocusOutside={ () => handleShowPopover( false ) }
+				>
+					<CardBody
+						style={ { width: 'min(80vw, 350px)' } }
+						onMouseEnter={ openOnHover }
+						onMouseLeave={ closeOnHoverOut }
+					>
+						<VStack spacing={ 4 }>
+							<Text as="p">
+								{ __(
+									'Your agency wasn’t approved. Please check your email for feedback from our review team.'
+								) }
+							</Text>
+							<HStack spacing={ 3 } justify="flex-start">
+								<Button
+									variant="primary"
+									size="compact"
+									href={ expertiseUrl }
+									onClick={ () =>
+										dismissPopover( 'calypso_partner_directory_dashboard_update_expertise_click' )
+									}
+								>
+									{ __( 'Update my expertise' ) }
+								</Button>
+								{ ! popoverDismissed && (
+									<Button
+										variant="secondary"
+										size="compact"
+										onClick={ () =>
+											dismissPopover( 'calypso_partner_directory_dashboard_do_it_later_click' )
+										}
+									>
+										{ __( 'I’ll do it later' ) }
+									</Button>
+								) }
+							</HStack>
+						</VStack>
+					</CardBody>
+				</Popover>
+			) }
+		</VStack>
+	);
+}

--- a/client/dashboard/agency/partner-directory/not-approved-popover.tsx
+++ b/client/dashboard/agency/partner-directory/not-approved-popover.tsx
@@ -41,7 +41,12 @@ export default function NotApprovedPopover( {
 	const [ showPopover, setShowPopover ] = useState( false );
 
 	const queryClient = useQueryClient();
-	const { data: preferenceDismissed } = useQuery( userPreferenceQuery( PREFERENCE_NAME ) );
+	const { data: preferenceDismissed } = useQuery( {
+		...userPreferenceQuery( PREFERENCE_NAME ),
+		// The dismissal only ever changes through this popover, so avoid
+		// refetching the preferences on every visit to the screen.
+		staleTime: 5 * 60 * 1000,
+	} );
 	const { mutate: savePreference } = useMutation( userPreferenceMutation( PREFERENCE_NAME ) );
 
 	const popoverDismissed = !! preferenceDismissed;

--- a/client/dashboard/agency/partner-directory/status-badge.tsx
+++ b/client/dashboard/agency/partner-directory/status-badge.tsx
@@ -1,0 +1,35 @@
+import { Badge } from '@automattic/ui';
+import NotApprovedPopover from './not-approved-popover';
+import type { DirectoryStatusBadge } from './lib';
+
+interface Props {
+	badge: DirectoryStatusBadge;
+	showPopoverOnLoad: boolean;
+	expertiseUrl: string;
+	recordTracksEvent: ( eventName: string, properties?: Record< string, unknown > ) => void;
+}
+
+/**
+ * A directory application status badge. When the application was rejected, it
+ * carries the "not approved" popover.
+ */
+export default function StatusBadge( {
+	badge,
+	showPopoverOnLoad,
+	expertiseUrl,
+	recordTracksEvent,
+}: Props ) {
+	if ( badge.key !== 'rejected' ) {
+		return <Badge intent={ badge.intent }>{ badge.label }</Badge>;
+	}
+
+	return (
+		<NotApprovedPopover
+			showOnLoad={ showPopoverOnLoad }
+			expertiseUrl={ expertiseUrl }
+			recordTracksEvent={ recordTracksEvent }
+		>
+			<Badge intent={ badge.intent }>{ badge.label }</Badge>
+		</NotApprovedPopover>
+	);
+}

--- a/packages/api-core/src/agency/index.ts
+++ b/packages/api-core/src/agency/index.ts
@@ -1,2 +1,3 @@
 export * from './fetchers';
+export * from './mutators';
 export * from './types';

--- a/packages/api-core/src/agency/mutators.ts
+++ b/packages/api-core/src/agency/mutators.ts
@@ -1,0 +1,19 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { Agency, AgencyPartnerDirectoryApplicationUpdate } from './types';
+
+/**
+ * Updates the agency's partner directory application and returns the updated agency.
+ */
+export async function updateAgencyPartnerDirectoryApplication(
+	agencyId: number,
+	update: AgencyPartnerDirectoryApplicationUpdate
+): Promise< Agency > {
+	return wpcom.req.put(
+		{
+			path: `/agency/${ agencyId }/profile/application`,
+			apiNamespace: 'wpcom/v2',
+			method: 'PUT',
+		},
+		update
+	);
+}

--- a/packages/api-core/src/agency/types.ts
+++ b/packages/api-core/src/agency/types.ts
@@ -40,6 +40,72 @@ export type AgencyCapability =
 	| 'a4a_remove_payment_methods'
 	| 'a4a_remove_managed_sites';
 
+export type AgencyPartnerDirectorySlug =
+	| 'wordpress'
+	| 'jetpack'
+	| 'woocommerce'
+	| 'pressable'
+	| 'vip';
+
+export type AgencyPartnerDirectoryEntryStatus = 'pending' | 'approved' | 'rejected' | 'closed';
+
+export interface AgencyPartnerDirectoryEntry {
+	status?: AgencyPartnerDirectoryEntryStatus;
+	directory: AgencyPartnerDirectorySlug;
+	urls: string[];
+	note: string;
+	is_published?: boolean;
+}
+
+export interface AgencyPartnerDirectoryApplication {
+	status?: 'pending' | 'in-progress' | 'completed';
+	directories: AgencyPartnerDirectoryEntry[];
+	feedback_url: string;
+	is_published?: boolean;
+}
+
+export interface AgencyProfile {
+	company_details: {
+		name: string;
+		email: string;
+		website: string;
+		bio_description: string;
+		logo_url: string;
+		landing_page_url: string;
+		country: string;
+	};
+	listing_details: {
+		is_available: boolean;
+		is_global: boolean;
+		industries: string[];
+		services: string[];
+		products: string[];
+		languages_spoken: string[];
+	};
+	budget_details: {
+		budget_lower_range: string;
+		budget_upper_range: string;
+		has_hourly_rate: boolean;
+		hourly_rate_value: string;
+	};
+	partner_directory_application: AgencyPartnerDirectoryApplication | null;
+}
+
+/**
+ * Body of PUT /wpcom/v2/agency/$agencyId/profile/application.
+ */
+export interface AgencyPartnerDirectoryApplicationUpdate {
+	services: string[];
+	products: string[];
+	directories: {
+		directory: AgencyPartnerDirectorySlug;
+		urls: string[];
+		note?: string;
+	}[];
+	feedback_url: string;
+	is_published?: boolean;
+}
+
 /**
  * A single agency, as returned by GET /wpcom/v2/agency. Only the fields
  * consumed by the dashboard are modeled here.
@@ -54,6 +120,11 @@ export interface Agency {
 	};
 	influenced_revenue?: number;
 	approval_status?: AgencyApprovalStatus | '';
+	profile?: AgencyProfile;
+	partner_directory?: {
+		allowed: boolean;
+		directories: AgencyPartnerDirectorySlug[];
+	};
 	created_at: string;
 	billing_system?: 'billingdragon' | 'legacy';
 	user?: {

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -47,4 +47,6 @@ export interface UserPreferences {
 	'reader-profile-sites-visibility'?: 'public' | 'hidden';
 	'reader-profile-hidden-sites'?: number[];
 	two_step_security_key_reregister_required?: boolean;
+	// Kept from the A4A client so earlier dismissals carry over.
+	'a4a-partner-directory-dashboard-not-approved-popover'?: boolean;
 }

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -47,6 +47,5 @@ export interface UserPreferences {
 	'reader-profile-sites-visibility'?: 'public' | 'hidden';
 	'reader-profile-hidden-sites'?: number[];
 	two_step_security_key_reregister_required?: boolean;
-	// Kept from the A4A client so earlier dismissals carry over.
-	'a4a-partner-directory-dashboard-not-approved-popover'?: boolean;
+	'a4a-dashboard-pd-not-approved-popover'?: boolean;
 }

--- a/packages/api-queries/src/agency.ts
+++ b/packages/api-queries/src/agency.ts
@@ -121,7 +121,11 @@ export const agencyPartnerDirectoryApplicationMutation = ( agencyId: number ) =>
 		mutationFn: ( update: AgencyPartnerDirectoryApplicationUpdate ) =>
 			updateAgencyPartnerDirectoryApplication( agencyId, update ),
 		onSuccess: ( agency: Agency ) => {
-			queryClient.setQueryData( activeAgencyQuery().queryKey, agency );
+			// Merge rather than replace: the PUT response may omit fields the
+			// GET provides (e.g. `user.capabilities`), which gate routes and menus.
+			queryClient.setQueryData( activeAgencyQuery().queryKey, ( previous ) =>
+				previous ? { ...previous, ...agency } : agency
+			);
 		},
 	} );
 

--- a/packages/api-queries/src/agency.ts
+++ b/packages/api-queries/src/agency.ts
@@ -4,12 +4,18 @@ import {
 	fetchAgencyScheduleCallLink,
 	fetchAgencyMcpSettings,
 	updateAgencyMcpSettings,
+	updateAgencyPartnerDirectoryApplication,
 	fetchTipaltiIFrameUrl,
 	fetchTipaltiPayee,
 } from '@automattic/api-core';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
-import type { Agency, McpSettings, McpSettingsUpdate } from '@automattic/api-core';
+import type {
+	Agency,
+	AgencyPartnerDirectoryApplicationUpdate,
+	McpSettings,
+	McpSettingsUpdate,
+} from '@automattic/api-core';
 
 // Mirror the server's response shape so the optimistic snapshot matches what
 // onSuccess later writes.
@@ -107,6 +113,16 @@ export const tipaltiPayeeQuery = ( agencyId: number ) =>
 		queryKey: [ 'agency', agencyId, 'tipalti-payee' ] as const,
 		queryFn: () => fetchTipaltiPayee( agencyId ),
 		enabled: !! agencyId,
+	} );
+
+export const agencyPartnerDirectoryApplicationMutation = ( agencyId: number ) =>
+	mutationOptions( {
+		meta: { statId: 'agcy-pd-application-update' },
+		mutationFn: ( update: AgencyPartnerDirectoryApplicationUpdate ) =>
+			updateAgencyPartnerDirectoryApplication( agencyId, update ),
+		onSuccess: ( agency: Agency ) => {
+			queryClient.setQueryData( activeAgencyQuery().queryKey, agency );
+		},
 	} );
 
 export const mcpSettingsQuery = ( agencyId: number ) =>

--- a/packages/api-queries/src/agency.ts
+++ b/packages/api-queries/src/agency.ts
@@ -118,8 +118,15 @@ export const tipaltiPayeeQuery = ( agencyId: number ) =>
 export const agencyPartnerDirectoryApplicationMutation = ( agencyId: number ) =>
 	mutationOptions( {
 		meta: { statId: 'agcy-pd-application-update' },
-		mutationFn: ( update: AgencyPartnerDirectoryApplicationUpdate ) =>
-			updateAgencyPartnerDirectoryApplication( agencyId, update ),
+		mutationFn: async ( update: AgencyPartnerDirectoryApplicationUpdate ) => {
+			const agency = await updateAgencyPartnerDirectoryApplication( agencyId, update );
+			// A 2xx without the saved application means the write didn't take;
+			// surface it as an error instead of reporting success.
+			if ( ! agency?.profile?.partner_directory_application?.status ) {
+				throw new Error( 'The response did not include the saved application.' );
+			}
+			return agency;
+		},
 		onSuccess: ( agency: Agency ) => {
 			// Merge rather than replace: the PUT response may omit fields the
 			// GET provides (e.g. `user.capabilities`), which gate routes and menus.

--- a/packages/api-queries/src/me-preferences.ts
+++ b/packages/api-queries/src/me-preferences.ts
@@ -26,7 +26,7 @@ const defaultValues: Required< UserPreferences > = {
 	'reader-profile-sites-visibility': 'public',
 	'reader-profile-hidden-sites': [],
 	two_step_security_key_reregister_required: false,
-	'a4a-partner-directory-dashboard-not-approved-popover': false,
+	'a4a-dashboard-pd-not-approved-popover': false,
 };
 
 const staticPreferenceStatIds: Record< string, string > = {
@@ -46,7 +46,7 @@ const staticPreferenceStatIds: Record< string, string > = {
 	'reader-profile-sites-visibility': 'sitevis',
 	'reader-profile-hidden-sites': 'hidsit',
 	two_step_security_key_reregister_required: '2fakey',
-	'a4a-partner-directory-dashboard-not-approved-popover': 'a4apd',
+	'a4a-dashboard-pd-not-approved-popover': 'a4apd',
 };
 
 const dynamicPreferenceStatPrefixes: Record< string, string > = {

--- a/packages/api-queries/src/me-preferences.ts
+++ b/packages/api-queries/src/me-preferences.ts
@@ -26,6 +26,7 @@ const defaultValues: Required< UserPreferences > = {
 	'reader-profile-sites-visibility': 'public',
 	'reader-profile-hidden-sites': [],
 	two_step_security_key_reregister_required: false,
+	'a4a-partner-directory-dashboard-not-approved-popover': false,
 };
 
 const staticPreferenceStatIds: Record< string, string > = {
@@ -45,6 +46,7 @@ const staticPreferenceStatIds: Record< string, string > = {
 	'reader-profile-sites-visibility': 'sitevis',
 	'reader-profile-hidden-sites': 'hidsit',
 	two_step_security_key_reregister_required: '2fakey',
+	'a4a-partner-directory-dashboard-not-approved-popover': 'a4apd',
 };
 
 const dynamicPreferenceStatPrefixes: Record< string, string > = {


### PR DESCRIPTION
Part of A4A-2859.

## Proposed Changes

* Add the data layer and building blocks for the Partner Directory dashboard coming to the new agencies dashboard (screen and wiring follow in the next PR):
  * The agency’s partner directory application (directories, statuses, published state) is now modeled on the agency data, with a mutation to save the application.
  * A user preference that remembers when the “not approved” popover was dismissed.
  * The directory status badge, with the “not approved” popover that nudges the agency to update its expertise after a rejection: it can open once on load (dismissible, remembered), and on hover afterwards — it stays open while the cursor is over it and never stacks.
  * Directory brand metadata (logos, directory and profile links) and the status-to-badge mapping helpers.

## Why are these changes being made?

* The Partner Directory dashboard is being ported to the new agencies dashboard. Splitting the data layer and building blocks from the screen keeps both halves reviewable; the follow-up PR adds the screen, navigation, and tests that exercise everything here.

## Testing Instructions

* This PR adds no user-facing surface on its own — the screen lands in the follow-up PR, and its tests exercise these pieces.
* Code review: check the application typing against the `/wpcom/v2/agency/{id}/profile/application` payload, and that the application mutation issues a `PUT` (the endpoint doesn’t register `POST`).

<img width="1920" height="803" alt="Screenshot 2026-08-12 at 11 43 16 AM" src="https://github.com/user-attachments/assets/24a722a8-4c55-4133-a273-6f1453763fe5" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
