### PR TITLE
Dashboard: increase rollout percentage to 100

### DIFF
--- a/client/controller/test/controller.js
+++ b/client/controller/test/controller.js
@@ -26,9 +26,8 @@ jest.mock( 'calypso/lib/analytics/mc', () => ( { bumpStat: jest.fn() } ) );
 const mockStore = configureStore();
 
 describe( 'maybeRedirectToMultiSiteDashboard', () => {
-	// `config/test.json` enables `dashboard/enable-percentage-rollout`, so the
-	// user ID has to fall outside the cohort (`id % 100 >= 50`, below the
-	// new-user threshold) for enrollment to be driven by the preference alone.
+	// `config/test.json` enables `dashboard/enable-percentage-rollout`, which now
+	// enrols every user, so `forced-opt-out` is the only way to be unenrolled.
 	const targetPath = ( params ) => `/emails/choose-email-solution/${ params.domain }`;
 
 	const buildContext = ( optIn ) => ( {
@@ -51,8 +50,11 @@ describe( 'maybeRedirectToMultiSiteDashboard', () => {
 		dashboardLink.mockClear();
 	} );
 
-	it( 'does not redirect when the flag is disabled and the user is not force-enrolled', () => {
-		maybeRedirectToMultiSiteDashboard( targetPath, () => false )( buildContext(), next );
+	it( 'does not redirect when the flag is disabled and the user is not enrolled', () => {
+		maybeRedirectToMultiSiteDashboard( targetPath, () => false )(
+			buildContext( 'forced-opt-out' ),
+			next
+		);
 
 		expect( navigate ).not.toHaveBeenCalled();
 		expect( next ).toHaveBeenCalled();

--- a/client/dashboard/utils/hosting-dashboard-enrollment.ts
+++ b/client/dashboard/utils/hosting-dashboard-enrollment.ts
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { isSupportSession } from '@automattic/calypso-support-session';
 import type { HostingDashboardOptIn } from '@automattic/api-core';
 
-const ROLLOUT_PERCENTAGE = 50;
+const ROLLOUT_PERCENTAGE = 100;
 
 // When rollout begins, users registered after this ID (i.e. new users) are enrolled.
 const NEW_USER_ID_THRESHOLD = 282953237;

--- a/client/dashboard/utils/test/hosting-dashboard-enrollment.ts
+++ b/client/dashboard/utils/test/hosting-dashboard-enrollment.ts
@@ -13,11 +13,11 @@ jest.mock( '@automattic/calypso-config', () => {
 
 const mockedIsEnabled = jest.mocked( config.isEnabled );
 
-const IN_COHORT = 100; // % 100 === 0, in cohort
-// The out-of-cohort fixtures assume the current 50% rollout (last two digits
-// >= 50). At 100% no user is outside the cohort, so the cases using these no
-// longer apply.
-const OUT_OF_COHORT = 99; // % 100 === 99, not in cohort
+// At 100% every user is in the cohort, whatever their ID. These two sit either
+// side of the boundary the rollout used on its way up, so they double as a
+// check that no ID is left behind.
+const LOW_USER_ID = 100; // % 100 === 0
+const HIGH_USER_ID = 99; // % 100 === 99
 
 const preference = ( value: HostingDashboardOptIn[ 'value' ] ): HostingDashboardOptIn => ( {
 	value,
@@ -33,8 +33,11 @@ beforeEach( () => {
 } );
 
 describe( 'getHostingDashboardEnrollment', () => {
-	it( 'leaves cohort-range users unenrolled while the rollout flag is off', () => {
-		expect( getHostingDashboardEnrollment( undefined, IN_COHORT ) ).toEqual( {
+	it( 'leaves users unenrolled while the rollout flag is off', () => {
+		expect( getHostingDashboardEnrollment( undefined, LOW_USER_ID ) ).toEqual( {
+			enrolled: false,
+		} );
+		expect( getHostingDashboardEnrollment( undefined, HIGH_USER_ID ) ).toEqual( {
 			enrolled: false,
 		} );
 	} );
@@ -43,34 +46,40 @@ describe( 'getHostingDashboardEnrollment', () => {
 		beforeEach( () => enableFlags( 'dashboard/enable-percentage-rollout' ) );
 
 		it( 'the escape hatch (forced-opt-out) wins over cohort membership', () => {
-			expect( getHostingDashboardEnrollment( preference( 'forced-opt-out' ), IN_COHORT ) ).toEqual(
-				{ enrolled: false }
-			);
+			expect(
+				getHostingDashboardEnrollment( preference( 'forced-opt-out' ), LOW_USER_ID )
+			).toEqual( { enrolled: false } );
 		} );
 
-		it( 'keeps opted-in users enrolled even when outside the cohort', () => {
-			expect( getHostingDashboardEnrollment( preference( 'opt-in' ), OUT_OF_COHORT ) ).toEqual( {
+		it( 'enrolls every user, whatever their ID', () => {
+			expect( getHostingDashboardEnrollment( undefined, LOW_USER_ID ) ).toEqual( {
 				enrolled: true,
-				reason: 'opt-in',
+				reason: 'forced',
+			} );
+			expect( getHostingDashboardEnrollment( undefined, HIGH_USER_ID ) ).toEqual( {
+				enrolled: true,
+				reason: 'forced',
 			} );
 		} );
 
 		it( 'the cohort overrides an explicit opt-out', () => {
-			expect( getHostingDashboardEnrollment( preference( 'opt-out' ), IN_COHORT ) ).toEqual( {
+			expect( getHostingDashboardEnrollment( preference( 'opt-out' ), LOW_USER_ID ) ).toEqual( {
 				enrolled: true,
 				reason: 'forced',
 			} );
 		} );
 
-		it( 'enrolls cohort members who have no preference', () => {
-			expect( getHostingDashboardEnrollment( undefined, IN_COHORT ) ).toEqual( {
+		// At full rollout the cohort is checked first, so users who had opted in
+		// of their own accord now report as 'forced' rather than 'opt-in'.
+		it( 'reports opted-in users as forced', () => {
+			expect( getHostingDashboardEnrollment( preference( 'opt-in' ), HIGH_USER_ID ) ).toEqual( {
 				enrolled: true,
 				reason: 'forced',
 			} );
 		} );
 
-		it( 'leaves non-cohort users who never opted in unenrolled', () => {
-			expect( getHostingDashboardEnrollment( preference( 'opt-out' ), OUT_OF_COHORT ) ).toEqual( {
+		it( 'leaves users with no ID unenrolled', () => {
+			expect( getHostingDashboardEnrollment( preference( 'opt-out' ), undefined ) ).toEqual( {
 				enrolled: false,
 			} );
 		} );
@@ -78,55 +87,54 @@ describe( 'getHostingDashboardEnrollment', () => {
 } );
 
 describe( 'isOptInToggleVisible', () => {
-	it( 'shows the toggle to users who are not in the cohort', () => {
-		expect( isOptInToggleVisible( preference( 'opt-out' ), OUT_OF_COHORT ) ).toBe( true );
+	it( 'shows the toggle while the rollout flag is off', () => {
+		expect( isOptInToggleVisible( preference( 'opt-out' ), HIGH_USER_ID ) ).toBe( true );
 	} );
 
 	it( 'hides the toggle from escape-hatched users even while the rollout flag is off', () => {
-		expect( isOptInToggleVisible( preference( 'forced-opt-out' ), OUT_OF_COHORT ) ).toBe( false );
+		expect( isOptInToggleVisible( preference( 'forced-opt-out' ), HIGH_USER_ID ) ).toBe( false );
 	} );
 
 	describe( 'with the rollout flag on', () => {
 		beforeEach( () => enableFlags( 'dashboard/enable-percentage-rollout' ) );
 
-		it( 'hides the toggle from cohort members', () => {
-			expect( isOptInToggleVisible( preference( 'opt-in' ), IN_COHORT ) ).toBe( false );
-		} );
-
-		it( 'still shows the toggle to non-cohort users', () => {
-			expect( isOptInToggleVisible( preference( 'opt-out' ), OUT_OF_COHORT ) ).toBe( true );
+		it( 'hides the toggle from every user, whatever their ID', () => {
+			expect( isOptInToggleVisible( preference( 'opt-in' ), LOW_USER_ID ) ).toBe( false );
+			expect( isOptInToggleVisible( preference( 'opt-out' ), HIGH_USER_ID ) ).toBe( false );
 		} );
 	} );
 
 	describe( 'with force-opt-in-visibility on', () => {
 		it( 'overrides the cohort and the escape hatch', () => {
 			enableFlags( 'dashboard/force-opt-in-visibility', 'dashboard/enable-percentage-rollout' );
-			expect( isOptInToggleVisible( undefined, IN_COHORT ) ).toBe( true );
-			expect( isOptInToggleVisible( preference( 'forced-opt-out' ), OUT_OF_COHORT ) ).toBe( true );
+			expect( isOptInToggleVisible( undefined, LOW_USER_ID ) ).toBe( true );
+			expect( isOptInToggleVisible( preference( 'forced-opt-out' ), HIGH_USER_ID ) ).toBe( true );
 		} );
 	} );
 } );
 
 describe( 'isAdvancedNoticeVisible', () => {
 	it( 'shows nothing while the rollout-advance-notice flag is off', () => {
-		expect( isAdvancedNoticeVisible( undefined, IN_COHORT ) ).toBe( false );
-		expect( isAdvancedNoticeVisible( undefined, OUT_OF_COHORT ) ).toBe( false );
+		expect( isAdvancedNoticeVisible( undefined, LOW_USER_ID ) ).toBe( false );
+		expect( isAdvancedNoticeVisible( undefined, HIGH_USER_ID ) ).toBe( false );
 	} );
 
 	describe( 'with the rollout-advance-notice flag on', () => {
 		beforeEach( () => enableFlags( 'dashboard/rollout-advance-notice' ) );
 
 		it( 'shows the banner to every user, regardless of cohort', () => {
-			expect( isAdvancedNoticeVisible( undefined, IN_COHORT ) ).toBe( true );
-			expect( isAdvancedNoticeVisible( undefined, OUT_OF_COHORT ) ).toBe( true );
+			expect( isAdvancedNoticeVisible( undefined, LOW_USER_ID ) ).toBe( true );
+			expect( isAdvancedNoticeVisible( undefined, HIGH_USER_ID ) ).toBe( true );
 		} );
 
 		it( 'hides the banner from escape-hatched (forced-opt-in) users', () => {
-			expect( isAdvancedNoticeVisible( preference( 'forced-opt-in' ), IN_COHORT ) ).toBe( false );
+			expect( isAdvancedNoticeVisible( preference( 'forced-opt-in' ), LOW_USER_ID ) ).toBe( false );
 		} );
 
 		it( 'hides the banner from escape-hatched (forced-opt-out) users', () => {
-			expect( isAdvancedNoticeVisible( preference( 'forced-opt-out' ), IN_COHORT ) ).toBe( false );
+			expect( isAdvancedNoticeVisible( preference( 'forced-opt-out' ), LOW_USER_ID ) ).toBe(
+				false
+			);
 		} );
 	} );
 } );

--- a/client/test/root-section.ts
+++ b/client/test/root-section.ts
@@ -38,18 +38,8 @@ function initRouter( { state }: { state: any } ) {
 }
 
 describe( 'Logged In Landing Page', () => {
-	test( 'user with no sites goes to Sites Dashboard', async () => {
-		const state = { currentUser: { id: 55 }, sites: { items: {} }, ui: {} };
-		const { page } = initRouter( { state } );
-
-		page( '/' );
-
-		await waitFor( () => expect( page.current ).toBe( '/sites' ) );
-	} );
-
 	if ( isEnabled( 'dashboard/enable-percentage-rollout' ) ) {
 		test( 'rollout cohort user with no sites goes to Sites Dashboard', async () => {
-			// User ID 1 will be allocated to the new dashboard rollout
 			const state = { currentUser: { id: 1 }, sites: { items: {} }, ui: {} };
 			const { page } = initRouter( { state } );
 			const assign = mockLocationAssign();
@@ -121,42 +111,7 @@ describe( 'Logged In Landing Page', () => {
 		await waitFor( () => expect( page.current ).toBe( '/stats/day/test.jurassic.ninja' ) );
 	} );
 
-	test( 'user who opts in goes to sites page', async () => {
-		const state = {
-			currentUser: {
-				id: 55,
-				capabilities: { 1: { edit_posts: true } },
-				user: { primary_blog: 1, site_count: 2 },
-			},
-			preferences: {
-				localValues: {
-					'sites-landing-page': { useSitesAsLandingPage: true, updatedAt: 1111 },
-					'reader-landing-page': { useReaderAsLandingPage: false, updatedAt: 1111 },
-				},
-			},
-			ui: {},
-			sites: {
-				items: {
-					1: {
-						ID: 1,
-						URL: 'https://test.wordpress.com',
-					},
-					2: {
-						ID: 2,
-						URL: 'https://test.jurassic.ninja',
-						jetpack: true,
-					},
-				},
-			},
-		};
-		const { page } = initRouter( { state } );
-
-		page( '/' );
-
-		await waitFor( () => expect( page.current ).toBe( '/sites' ) );
-	} );
-
-	if ( isEnabled( 'add/dashboard-enable-percentage-rollout' ) ) {
+	if ( isEnabled( 'dashboard/enable-percentage-rollout' ) ) {
 		test( 'rollout cohort user who opts in goes to sites page', async () => {
 			const state = {
 				currentUser: {
@@ -185,8 +140,8 @@ describe( 'Logged In Landing Page', () => {
 					},
 				},
 			};
-			const assign = mockLocationAssign();
 			const { page } = initRouter( { state } );
+			const assign = mockLocationAssign();
 
 			page( '/' );
 

--- a/packages/calypso-e2e/src/lib/test-account.ts
+++ b/packages/calypso-e2e/src/lib/test-account.ts
@@ -13,6 +13,10 @@ import { SidebarComponent } from './components/sidebar-component';
 import { LoginPage } from './pages/login-page';
 import type { TestAccountCredentials } from '../secrets';
 
+// Feature flags forced on for every E2E session, in the `flags` cookie format that
+// @automattic/calypso-config reads: a leading `-` disables.
+const FLAG_OVERRIDES = [ '-dashboard/enable-percentage-rollout' ];
+
 /**
  * Represents the WPCOM test account.
  */
@@ -54,6 +58,7 @@ export class TestAccount {
 	): Promise< void > {
 		const browserContext = page.context();
 		await browserContext.clearCookies();
+		await TestAccount.applyFlagOverrides( browserContext );
 
 		if ( await this.hasFreshAuthCookies() ) {
 			this.log( 'Found fresh cookies, skipping log in' );
@@ -70,6 +75,27 @@ export class TestAccount {
 		if ( waitUntilStable ) {
 			await TestAccount.waitForAppShell( page );
 		}
+	}
+
+	/**
+	 * Opts every E2E session out of the hosting dashboard rollout.
+	 *
+	 * These specs target classic Calypso, so they should not be moved onto the
+	 * dashboard by a percentage rollout they have no control over. Overrides are
+	 * honored in development, on the staging environments and on calypso.live, and
+	 * ignored on production, so release runs against production are unaffected.
+	 *
+	 * @param {BrowserContext} browserContext Browser context to set the cookie on.
+	 */
+	private static async applyFlagOverrides( browserContext: BrowserContext ): Promise< void > {
+		await browserContext.addCookies( [
+			{
+				name: 'flags',
+				value: FLAG_OVERRIDES.join( ',' ),
+				domain: new URL( getCalypsoURL( '/' ) ).hostname,
+				path: '/',
+			},
+		] );
 	}
 
 	/**


### PR DESCRIPTION
Closes: DOTMSD-1442

## Proposed Changes

* Increase the hosting dashboard rollout percentage from 50% to 100%.
* Update the rollout unit tests, which assumed a user could fall outside the cohort.
* Opt E2E runs out of the rollout, so the classic Calypso specs stay on the UI they assert on.

The Me smoke test also needed updating. That has landed in #113474, and this branch is rebased on top of it.

## Why are these changes being made?

The staged rollout has reached the point where the remaining cohort can be moved over. Setting the percentage to 100 enrolls all users, rather than the half currently selected by user ID.

## Considerations

At 100% the shared E2E accounts are in the cohort too, so `TestAccount.authenticate` sets a `flags` cookie disabling `dashboard/enable-percentage-rollout` for the session. Overrides are ignored on production, so release runs still see real enrollment — acceptable, since the build reports 37 passed, 14 ignored and zero failed at 100%.

The red E2E check is a `failOnMetricChange` guard, not a test failure: the reference build ran the full suite (163 passed) while this branch correctly runs only `@calypso-pr` (37 passed). Pre-existing CI behaviour, unrelated to the rollout.

## Testing Instructions

* With the percentage rollout flag enabled, confirm the dashboard is the default experience regardless of user ID (previously only user IDs in the lower half of the modulo range were enrolled).
* Confirm the opt-in toggle is hidden for all enrolled users.
* Confirm support sessions and users with a forced opt-out are unaffected.
* Note: the welcome modal shares the same percentage, so it now becomes eligible for all pre-threshold users who have not previously opted in. Worth a sanity check that this is the intended cohort.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
