### PR TITLE
Checkout: show the state placeholder instead of preselecting the first state

### DIFF
--- a/client/my-sites/domains/components/form/state-select.jsx
+++ b/client/my-sites/domains/components/form/state-select.jsx
@@ -78,7 +78,9 @@ class StateSelect extends PureComponent {
 							aria-describedby={ validationId }
 							id={ `${ this.constructor.name }-${ fieldId }` }
 							name={ name }
-							value={ value }
+							// An undefined value leaves the select uncontrolled, which makes the
+							// browser preselect the first state instead of the disabled placeholder.
+							value={ value ?? '' }
 							disabled={ disabled }
 							onBlur={ onBlur }
 							onChange={ onChange }

--- a/client/my-sites/domains/components/form/test/state-select.jsx
+++ b/client/my-sites/domains/components/form/test/state-select.jsx
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import countryStatesReducer from 'calypso/state/country-states/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import StateSelect from '../state-select';
+
+const reducers = { countryStates: countryStatesReducer };
+
+const initialState = {
+	countryStates: {
+		items: {
+			in: [
+				{ code: 'AN', name: 'Andaman and Nicobar Islands' },
+				{ code: 'AP', name: 'Andhra Pradesh' },
+			],
+		},
+		isFetching: {},
+	},
+};
+
+describe( '<StateSelect />', () => {
+	const defaultProps = {
+		label: 'State',
+		name: 'state',
+		countryCode: 'IN',
+		onChange: jest.fn(),
+	};
+
+	test( 'shows the placeholder rather than the first state when there is no value', () => {
+		renderWithProvider( <StateSelect { ...defaultProps } value={ undefined } />, {
+			initialState,
+			reducers,
+		} );
+
+		expect( screen.getByRole( 'combobox', { name: 'State' } ) ).toHaveValue( '' );
+		expect( screen.getByRole( 'option', { name: 'Select State' } ).selected ).toBe( true );
+	} );
+
+	test( 'shows the placeholder rather than the first state when the value is empty', () => {
+		renderWithProvider( <StateSelect { ...defaultProps } value="" />, { initialState, reducers } );
+
+		expect( screen.getByRole( 'combobox', { name: 'State' } ) ).toHaveValue( '' );
+	} );
+
+	test( 'shows the selected state when there is a value', () => {
+		renderWithProvider( <StateSelect { ...defaultProps } value="AP" />, {
+			initialState,
+			reducers,
+		} );
+
+		expect( screen.getByRole( 'combobox', { name: 'State' } ) ).toHaveValue( 'AP' );
+	} );
+} );


### PR DESCRIPTION
Fixes [SHILL-2387](https://linear.app/a8c/issue/SHILL-2387/checkout-contact-form-state-dropdown-incorrectly-shows-first-option)

## Proposed Changes

* `StateSelect` now falls back to an empty string when it receives no `value`, so the `<select>` stays controlled and renders its "Select State" placeholder instead of the first state in the list.
* Added unit tests for `StateSelect` covering the absent, empty, and populated value cases.

## Why are these changes being made?

* `StateSelect` passed `value` straight through to the underlying `<select>`. Checkout's tax fields hold `state` as `undefined` until the shopper touches the field — `tax-fields.tsx` reads `state?.value`, and `updateOnChangePayload` sets `state: undefined` whenever the previously selected country didn't require a subdivision.
* With `value === undefined` React leaves the select uncontrolled. Both the HTML "ask for a reset" algorithm and React's own `updateOptions` fallback select *the first option that is not disabled*, which skips the `disabled` "Select State" placeholder and lands on the first real state — "Andaman and Nicobar Islands" for India.
* The form value is still empty at that point, so submitting the contact step fails validation with "We could not validate your contact information. Please review and update all the highlighted fields." Touching the field then gives `state` a defined `''`, which is why the dropdown visibly snaps back to "Select state" right after the error appears.
* Fixing this in `StateSelect` rather than at the call site also covers the other places that can pass an absent value: the PIX payment method, the Ebanx country-specific payment fields, and the US address fieldset.

## Testing Instructions

* Go to checkout and open the billing/contact step.
* Select "India" in the Country dropdown and enter a postal code such as `123456`.
* Confirm the State dropdown shows "Select State" rather than a preselected state.
* Pick a state and press "Continue to payment" — the step should advance.
* Repeat with another country that requires a subdivision (for example, United States or Canada, where the placeholder reads "Select Province").
* Unit tests: `yarn test-client client/my-sites/domains/components/form/test/state-select.jsx`

Note: one snapshot in `client/components/domains/contact-details-form-fields/test/index.js` fails locally on an emotion class-name diff. It fails identically on a clean trunk checkout and is unrelated to this change.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Follow-ups worth considering (not in this PR)

* `tax-fields.tsx` doesn't pass `name`, `isError`, or `errorMessage` to `StateSelect`, so the state field is never actually highlighted when validation fails — despite the error message telling the shopper to review the highlighted fields.
* The Dashboard has its own state field in `client/dashboard/components/domain-contact-details-form/region-address-fieldsets.tsx`, built on `SelectControl` with no empty option at all, so it shows the same preselect-the-first-state behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
