### PR TITLE
Plugins: resolve real wp.org icons instead of generated patterns

### DIFF
--- a/client/dashboard/plugins/manage/index.tsx
+++ b/client/dashboard/plugins/manage/index.tsx
@@ -1,8 +1,9 @@
-import { MarketplaceSearchResult } from '@automattic/api-core';
+import { isGeneratedPluginIcon, MarketplaceSearchResult } from '@automattic/api-core';
 import {
 	marketplacePluginsQuery,
 	marketplaceSearchQuery,
 	pluginsQuery,
+	useWpOrgPluginIcons,
 } from '@automattic/api-queries';
 import { useQueries, useQuery } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
@@ -92,18 +93,17 @@ export default function PluginsList() {
 		} ),
 	} );
 
-	const iconBySlug = useMemo( () => {
-		// Only recalculate once all queries have data
-		if ( ! allSearchQueriesLoaded ) {
-			return new Map< string, PluginListRow[ 'icon' ] >();
-		}
+	const marketplaceSearchBySlug = useMemo(
+		() =>
+			marketplaceSearchData.reduce( ( acc, { fields } ) => {
+				acc.set( fields.slug, fields );
+				return acc;
+			}, new Map< string, MarketplaceSearchResult[ 'fields' ] >() ),
+		[ marketplaceSearchData ]
+	);
 
+	const indexIconBySlug = useMemo( () => {
 		const marketplacePluginsBySlug = new Map( Object.entries( marketplacePlugins?.results || {} ) );
-
-		const marketplaceSearchBySlug = marketplaceSearchData.reduce( ( acc, { fields } ) => {
-			acc.set( fields.slug, fields );
-			return acc;
-		}, new Map< string, MarketplaceSearchResult[ 'fields' ] >() );
 
 		return plugins.reduce( ( acc, { slug } ) => {
 			let icon;
@@ -117,7 +117,28 @@ export default function PluginsList() {
 
 			return acc;
 		}, new Map< string, PluginListRow[ 'icon' ] >() );
-	}, [ plugins, marketplacePlugins, marketplaceSearchData, allSearchQueriesLoaded ] );
+	}, [ plugins, marketplacePlugins, marketplaceSearchBySlug ] );
+
+	// The search index only has a generated pattern for wp.org plugins (SEARCH-333).
+	// Waiting for every batch keeps this to one request rather than one per instalment.
+	const wpOrgIcons = useWpOrgPluginIcons(
+		allSearchQueriesLoaded
+			? [ ...indexIconBySlug ]
+					.filter( ( [ , icon ] ) => isGeneratedPluginIcon( icon ) )
+					.map( ( [ slug ] ) => slug )
+			: []
+	);
+
+	const iconBySlug = useMemo( () => {
+		// Only recalculate once all queries have data
+		if ( ! allSearchQueriesLoaded ) {
+			return new Map< string, PluginListRow[ 'icon' ] >();
+		}
+
+		return new Map(
+			[ ...indexIconBySlug ].map( ( [ slug, icon ] ) => [ slug, wpOrgIcons[ slug ] || icon ] )
+		);
+	}, [ indexIconBySlug, allSearchQueriesLoaded, wpOrgIcons ] );
 
 	const pluginsWithIcon = useMemo( () => {
 		return plugins.map( ( plugin ) => {

--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -1,3 +1,4 @@
+import { buildDefaultIconUrl } from '@automattic/api-core';
 import languages, { LanguageSlug } from '@automattic/languages';
 import {
 	UseQueryResult,
@@ -29,10 +30,6 @@ const getIconUrl = ( pluginSlug: string, icon: string ): string => {
 
 	return buildDefaultIconUrl( pluginSlug );
 };
-
-function buildDefaultIconUrl( pluginSlug: string ) {
-	return `https://s.w.org/plugins/geopattern-icon/${ pluginSlug }.svg`;
-}
 
 const mapIndexResultsToPluginData = ( results: ESHits ): Plugin[] => {
 	if ( ! results ) {

--- a/client/my-sites/plugins/use-plugins/index.ts
+++ b/client/my-sites/plugins/use-plugins/index.ts
@@ -1,3 +1,5 @@
+import { isGeneratedPluginIcon } from '@automattic/api-core';
+import { useWpOrgPluginIcons } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { Plugin } from 'calypso/data/marketplace/types';
@@ -108,12 +110,23 @@ const usePlugins = ( {
 			break;
 	}
 
+	// The search index only has a generated pattern for wp.org plugins (SEARCH-333).
+	const wpOrgIcons = useWpOrgPluginIcons(
+		plugins
+			.filter( ( plugin: Plugin ) => isGeneratedPluginIcon( plugin.icon ) )
+			.map( ( plugin: Plugin ) => plugin.slug )
+	);
+
+	plugins = plugins.map( ( plugin: Plugin ) =>
+		wpOrgIcons[ plugin.slug ] ? { ...plugin, icon: wpOrgIcons[ plugin.slug ] } : plugin
+	);
+
 	function fetchNextPageAndStop() {
 		if ( ! infinite || ! hasNextPage ) {
 			return;
 		}
 
-		fetchNextPage && fetchNextPage();
+		fetchNextPage?.();
 	}
 
 	return {

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -787,6 +787,7 @@ function setUpCSP( req, res, next ) {
 			'https://wordpress.com',
 			'*.doubleclick.net', // Google DoubleClick tracking pixels (ad.doubleclick.net, *.fls.doubleclick.net, etc.)
 			'https://api.wordpress.org', // WordPress.org API (plugin/theme info)
+			'https://wordpress.org', // WordPress.org plugin directory REST API (plugin icons)
 			'https://pixel.wp.com', // WordPress.com stats pixel
 			'https://*.google.com',
 			'www.google-analytics.com',

--- a/packages/api-core/src/marketplace-search/__tests__/icons.test.ts
+++ b/packages/api-core/src/marketplace-search/__tests__/icons.test.ts
@@ -1,0 +1,24 @@
+import { buildDefaultIconUrl, isGeneratedPluginIcon } from '..';
+
+describe( 'buildDefaultIconUrl', () => {
+	it( 'builds the pattern URL wp.org generates for a slug', () => {
+		expect( buildDefaultIconUrl( 'jetpack' ) ).toBe(
+			'https://s.w.org/plugins/geopattern-icon/jetpack.svg'
+		);
+	} );
+} );
+
+describe( 'isGeneratedPluginIcon', () => {
+	it( 'recognises a generated pattern', () => {
+		expect( isGeneratedPluginIcon( buildDefaultIconUrl( 'jetpack' ) ) ).toBe( true );
+	} );
+
+	it( 'leaves real asset URLs alone', () => {
+		expect( isGeneratedPluginIcon( 'https://ps.w.org/jetpack/assets/icon.svg' ) ).toBe( false );
+	} );
+
+	it( 'handles a missing icon', () => {
+		expect( isGeneratedPluginIcon() ).toBe( false );
+		expect( isGeneratedPluginIcon( '' ) ).toBe( false );
+	} );
+} );

--- a/packages/api-core/src/marketplace-search/icons.ts
+++ b/packages/api-core/src/marketplace-search/icons.ts
@@ -1,0 +1,20 @@
+const GENERATED_ICON_URL_PREFIX = 'https://s.w.org/plugins/geopattern-icon/';
+
+/**
+ * Builds the pattern URL wp.org generates for a plugin with no icon of its own.
+ * @param pluginSlug the plugin slug
+ * @returns the generated pattern URL
+ */
+export const buildDefaultIconUrl = ( pluginSlug: string ): string =>
+	`${ GENERATED_ICON_URL_PREFIX }${ pluginSlug }.svg`;
+
+/**
+ * Whether an icon URL is a generated pattern rather than a real asset.
+ *
+ * A pattern is not always wrong — it is also what wp.org serves for a plugin
+ * that has no icon. See SEARCH-333.
+ * @param icon a plugin icon URL
+ * @returns true when the URL is a generated pattern
+ */
+export const isGeneratedPluginIcon = ( icon?: string ): boolean =>
+	!! icon?.startsWith( GENERATED_ICON_URL_PREFIX );

--- a/packages/api-core/src/marketplace-search/index.ts
+++ b/packages/api-core/src/marketplace-search/index.ts
@@ -1,2 +1,3 @@
 export * from './fetchers';
+export * from './icons';
 export * from './types';

--- a/packages/api-core/src/plugins/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/plugins/__tests__/fetchers.test.ts
@@ -1,0 +1,129 @@
+import { fetchWpOrgPluginIcons, WPORG_ICONS_BATCH_SIZE } from '..';
+
+const icons = ( {
+	svg = false,
+	icon = false,
+	icon_2x = false,
+	generated = false,
+}: Partial< {
+	svg: string | false;
+	icon: string | false;
+	icon_2x: string | false;
+	generated: boolean;
+} > ) => ( { svg, icon, icon_2x, generated } );
+
+const mockResponse = ( body: unknown, ok = true, status = ok ? 200 : 500 ) => {
+	const fetchMock = jest.fn().mockResolvedValue( {
+		ok,
+		status,
+		json: async () => body,
+	} );
+	global.fetch = fetchMock as unknown as typeof global.fetch;
+	return fetchMock;
+};
+
+describe( 'fetchWpOrgPluginIcons', () => {
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'maps each slug to its icon URL', async () => {
+		mockResponse( [
+			{ slug: 'jetpack', icons: icons( { svg: 'https://ps.w.org/jetpack/assets/icon.svg' } ) },
+			{
+				slug: 'akismet',
+				icons: icons( {
+					icon: 'https://ps.w.org/akismet/assets/icon-128x128.png',
+					icon_2x: 'https://ps.w.org/akismet/assets/icon-256x256.png',
+				} ),
+			},
+		] );
+
+		await expect( fetchWpOrgPluginIcons( [ 'jetpack', 'akismet' ] ) ).resolves.toEqual( {
+			jetpack: 'https://ps.w.org/jetpack/assets/icon.svg',
+			akismet: 'https://ps.w.org/akismet/assets/icon-128x128.png',
+		} );
+	} );
+
+	it( 'asks wp.org for every slug in a single request', async () => {
+		const fetchMock = mockResponse( [] );
+
+		await fetchWpOrgPluginIcons( [ 'jetpack', 'akismet' ] );
+
+		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
+		const url = new URL( fetchMock.mock.calls[ 0 ][ 0 ] as string );
+		expect( url.origin + url.pathname ).toBe(
+			'https://wordpress.org/plugins/wp-json/wp/v2/plugin'
+		);
+		expect( url.searchParams.getAll( 'slug[]' ) ).toEqual( [ 'jetpack', 'akismet' ] );
+		expect( url.searchParams.get( '_fields' ) ).toBe( 'slug,icons' );
+	} );
+
+	it( 'omits plugins wp.org only has a generated pattern for', async () => {
+		mockResponse( [
+			{
+				slug: 'classic-widgets',
+				icons: icons( {
+					icon: 'https://s.w.org/plugins/geopattern-icon/classic-widgets.svg',
+					generated: true,
+				} ),
+			},
+		] );
+
+		await expect( fetchWpOrgPluginIcons( [ 'classic-widgets' ] ) ).resolves.toEqual( {} );
+	} );
+
+	it( 'omits slugs wp.org does not recognise', async () => {
+		mockResponse( [] );
+
+		await expect( fetchWpOrgPluginIcons( [ 'a-premium-plugin' ] ) ).resolves.toEqual( {} );
+	} );
+
+	// Resolving empty here would be cached as "these plugins have no icon" and
+	// never retried, turning one bad response into a permanent placeholder.
+	it( 'rejects when wp.org fails', async () => {
+		mockResponse( null, false );
+
+		await expect( fetchWpOrgPluginIcons( [ 'jetpack' ] ) ).rejects.toThrow( /responded/ );
+	} );
+
+	// Without a numeric `status` the shared retry predicate cannot tell a 429
+	// from a network blip, and retries it three more times for every slug.
+	it( 'carries the HTTP status so a client error is not retried', async () => {
+		mockResponse( null, false, 429 );
+
+		await expect( fetchWpOrgPluginIcons( [ 'jetpack' ] ) ).rejects.toMatchObject( {
+			status: 429,
+			statusCode: 429,
+		} );
+	} );
+
+	it( 'does not resolve a slug that collides with an Object prototype key', async () => {
+		mockResponse( [] );
+
+		const icons = await fetchWpOrgPluginIcons( [ 'constructor' ] );
+
+		expect( icons.constructor ).toBeUndefined();
+	} );
+
+	it( 'rejects when a 200 carries something other than the collection', async () => {
+		mockResponse( { code: 'rest_forbidden' } );
+
+		await expect( fetchWpOrgPluginIcons( [ 'jetpack' ] ) ).rejects.toThrow( /unexpected body/ );
+	} );
+
+	it( 'rejects rather than silently truncating past the batch size', async () => {
+		const fetchMock = mockResponse( [] );
+		const slugs = Array.from( { length: WPORG_ICONS_BATCH_SIZE + 1 }, ( _, i ) => `plugin-${ i }` );
+
+		await expect( fetchWpOrgPluginIcons( slugs ) ).rejects.toThrow( /at most/ );
+		expect( fetchMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'makes no request when there are no slugs', async () => {
+		const fetchMock = mockResponse( [] );
+
+		await expect( fetchWpOrgPluginIcons( [] ) ).resolves.toEqual( {} );
+		expect( fetchMock ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/api-core/src/plugins/fetchers.ts
+++ b/packages/api-core/src/plugins/fetchers.ts
@@ -44,3 +44,80 @@ export function fetchWpOrgPlugin( pluginSlug: string, locale: string ): Promise<
 
 	return getRequest( WPORG_PLUGINS_ENDPOINT, query );
 }
+
+const WPORG_PLUGIN_DIRECTORY_ENDPOINT = 'https://wordpress.org/plugins/wp-json/wp/v2/plugin';
+
+export const WPORG_ICONS_BATCH_SIZE = 100;
+
+interface WpOrgDirectoryIcons {
+	svg: string | false;
+	icon: string | false;
+	icon_2x: string | false;
+	// True when the plugin has no icon and wp.org is serving its generated pattern.
+	generated: boolean;
+}
+
+/**
+ * Fetches real icon URLs for several wp.org plugins at once.
+ *
+ * Works around SEARCH-333, where the search index serves a generated pattern for
+ * every wp.org plugin; delete once the index serves real URLs again. Rejects
+ * rather than resolving empty, so a failure is retried instead of being cached
+ * as "these plugins have no icon". Unrecognised slugs are dropped.
+ * @param slugs plugin slugs, at most `WPORG_ICONS_BATCH_SIZE` of them
+ * @returns icon URL by slug, omitting plugins with no icon of their own
+ */
+export async function fetchWpOrgPluginIcons(
+	slugs: string[]
+): Promise< Record< string, string > > {
+	if ( ! slugs.length ) {
+		return {};
+	}
+
+	// Beyond this, `per_page` truncates silently.
+	if ( slugs.length > WPORG_ICONS_BATCH_SIZE ) {
+		throw new Error(
+			`fetchWpOrgPluginIcons accepts at most ${ WPORG_ICONS_BATCH_SIZE } slugs, got ${ slugs.length }`
+		);
+	}
+
+	const query = stringifyQs(
+		{ slug: slugs, per_page: WPORG_ICONS_BATCH_SIZE, _fields: 'slug,icons' },
+		{ arrayFormat: 'brackets' }
+	);
+
+	const response = await fetch( `${ WPORG_PLUGIN_DIRECTORY_ENDPOINT }?${ query }`, {
+		method: 'GET',
+		headers: { Accept: 'application/json' },
+	} );
+
+	if ( ! response.ok ) {
+		// `status` is what the shared retry predicate reads to stop retrying a 4xx.
+		throw Object.assign( new Error( `wp.org plugin directory responded ${ response.status }` ), {
+			status: response.status,
+			statusCode: response.status,
+		} );
+	}
+
+	const plugins: { slug: string; icons?: WpOrgDirectoryIcons }[] = await response.json();
+
+	if ( ! Array.isArray( plugins ) ) {
+		throw new Error( 'wp.org plugin directory returned an unexpected body' );
+	}
+
+	return plugins.reduce< Record< string, string > >( ( icons, { slug, icons: pluginIcons } ) => {
+		if ( ! pluginIcons || pluginIcons.generated ) {
+			return icons;
+		}
+
+		// `icon` is 128px, plenty at the sizes these render, and lighter than `icon_2x`.
+		const url = pluginIcons.svg || pluginIcons.icon || pluginIcons.icon_2x;
+
+		if ( url ) {
+			icons[ slug ] = url;
+		}
+
+		return icons;
+		// Null-prototype: a slug like `constructor` must not hit `Object.prototype`.
+	}, Object.create( null ) );
+}

--- a/packages/api-queries/src/__tests__/plugin-icons.test.ts
+++ b/packages/api-queries/src/__tests__/plugin-icons.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fetchWpOrgPluginIcons } from '@automattic/api-core';
+import { wpOrgPluginIconQuery } from '../plugin';
+
+jest.mock( '@automattic/api-core', () => ( {
+	...jest.requireActual( '@automattic/api-core' ),
+	fetchWpOrgPluginIcons: jest.fn(),
+} ) );
+
+const mockedFetch = fetchWpOrgPluginIcons as jest.MockedFunction< typeof fetchWpOrgPluginIcons >;
+
+const run = ( slug: string ) =>
+	( wpOrgPluginIconQuery( slug ).queryFn as () => Promise< string | null > )();
+
+describe( 'wpOrgPluginIconQuery', () => {
+	beforeEach( () => {
+		mockedFetch.mockReset();
+	} );
+
+	it( 'coalesces slugs queued in the same tick into one request', async () => {
+		mockedFetch.mockResolvedValue( {
+			jetpack: 'https://ps.w.org/jetpack/assets/icon.svg',
+			akismet: 'https://ps.w.org/akismet/assets/icon-128x128.png',
+		} );
+
+		const [ jetpack, akismet ] = await Promise.all( [ run( 'jetpack' ), run( 'akismet' ) ] );
+
+		expect( mockedFetch ).toHaveBeenCalledTimes( 1 );
+		expect( mockedFetch ).toHaveBeenCalledWith( [ 'jetpack', 'akismet' ] );
+		expect( jetpack ).toBe( 'https://ps.w.org/jetpack/assets/icon.svg' );
+		expect( akismet ).toBe( 'https://ps.w.org/akismet/assets/icon-128x128.png' );
+	} );
+
+	// React Query rejects `undefined` as query data, and a plugin with no icon
+	// still has to settle rather than retry forever.
+	it( 'resolves null for a plugin wp.org has no icon for', async () => {
+		mockedFetch.mockResolvedValue( {} );
+
+		await expect( run( 'classic-widgets' ) ).resolves.toBeNull();
+	} );
+
+	it( 'rejects every slug in a batch when the request fails', async () => {
+		mockedFetch.mockRejectedValue( new Error( 'wp.org plugin directory responded 503' ) );
+
+		const results = await Promise.allSettled( [ run( 'jetpack' ), run( 'akismet' ) ] );
+
+		expect( mockedFetch ).toHaveBeenCalledTimes( 1 );
+		expect( results.map( ( result ) => result.status ) ).toEqual( [ 'rejected', 'rejected' ] );
+	} );
+
+	it( 'starts a fresh batch for slugs queued in a later tick', async () => {
+		mockedFetch.mockResolvedValue( {} );
+
+		await run( 'jetpack' );
+		await run( 'akismet' );
+
+		expect( mockedFetch ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'keys the cache per slug so a growing list only adds entries', () => {
+		expect( wpOrgPluginIconQuery( 'jetpack' ).queryKey ).toEqual( [
+			'wp-org-plugin-icon',
+			'jetpack',
+		] );
+	} );
+
+	// Persisting one entry per plugin ever scrolled past would grow unbounded.
+	it( 'opts out of the persisted query cache', () => {
+		expect( wpOrgPluginIconQuery( 'jetpack' ).meta ).toEqual( { persist: false } );
+	} );
+} );

--- a/packages/api-queries/src/plugin.ts
+++ b/packages/api-queries/src/plugin.ts
@@ -1,10 +1,12 @@
 import {
 	fetchWpOrgPlugin,
+	fetchWpOrgPluginIcons,
 	fetchMarketplacePlugin,
 	fetchMarketplacePlugins,
 	installPlugin,
+	WPORG_ICONS_BATCH_SIZE,
 } from '@automattic/api-core';
-import { mutationOptions, queryOptions } from '@tanstack/react-query';
+import { mutationOptions, queryOptions, useQueries } from '@tanstack/react-query';
 import { invalidatePlugins, invalidateSitePlugins } from './site-plugins';
 
 export const marketplacePluginQuery = ( slug: string ) =>
@@ -23,6 +25,87 @@ export const wpOrgPluginQuery = ( slug: string, locale: string ) =>
 	queryOptions( {
 		queryKey: [ 'wp-org-plugin', slug, locale ],
 		queryFn: () => fetchWpOrgPlugin( slug, locale ),
+	} );
+
+type IconWaiter = {
+	resolve: ( icon: string | null ) => void;
+	reject: ( error: unknown ) => void;
+};
+
+const pendingIconSlugs = new Map< string, IconWaiter[] >();
+let iconFlushScheduled = false;
+
+const flushIconRequests = () => {
+	iconFlushScheduled = false;
+
+	const waiting = [ ...pendingIconSlugs ];
+	pendingIconSlugs.clear();
+
+	for ( let index = 0; index < waiting.length; index += WPORG_ICONS_BATCH_SIZE ) {
+		const batch = waiting.slice( index, index + WPORG_ICONS_BATCH_SIZE );
+
+		fetchWpOrgPluginIcons( batch.map( ( [ slug ] ) => slug ) ).then(
+			( icons ) =>
+				batch.forEach( ( [ slug, waiters ] ) =>
+					waiters.forEach( ( waiter ) => waiter.resolve( icons[ slug ] ?? null ) )
+				),
+			( error ) =>
+				batch.forEach( ( [ , waiters ] ) =>
+					waiters.forEach( ( waiter ) => waiter.reject( error ) )
+				)
+		);
+	}
+};
+
+/**
+ * Queues one slug, resolving it from a request shared with everything else
+ * queued in the same tick.
+ *
+ * Callers that learn their slugs in instalments get one request per instalment,
+ * and should wait for the full set. The queue is module state, which holds only
+ * because nothing prefetches these queries server-side.
+ * @param slug the plugin slug to resolve
+ * @returns the icon URL, or null when wp.org has no icon for it
+ */
+const loadWpOrgPluginIcon = ( slug: string ) =>
+	new Promise< string | null >( ( resolve, reject ) => {
+		pendingIconSlugs.set( slug, [
+			...( pendingIconSlugs.get( slug ) ?? [] ),
+			{ resolve, reject },
+		] );
+
+		if ( ! iconFlushScheduled ) {
+			iconFlushScheduled = true;
+			setTimeout( flushIconRequests );
+		}
+	} );
+
+export const wpOrgPluginIconQuery = ( slug: string ) =>
+	queryOptions( {
+		queryKey: [ 'wp-org-plugin-icon', slug ],
+		queryFn: () => loadWpOrgPluginIcon( slug ),
+		staleTime: Infinity,
+		// Not persisted: one request per page load beats an entry per plugin ever seen.
+		meta: { persist: false },
+	} );
+
+/**
+ * Resolves real wp.org icon URLs for a list of plugin slugs.
+ *
+ * Keyed per slug so a growing list adds keys rather than replacing them.
+ * @param slugs plugin slugs to resolve
+ * @returns icon URL by slug, omitting plugins wp.org has no icon for
+ */
+export const useWpOrgPluginIcons = ( slugs: string[] ): Record< string, string > =>
+	useQueries( {
+		queries: slugs.map( ( slug ) => wpOrgPluginIconQuery( slug ) ),
+		combine: ( results ) =>
+			results.reduce< Record< string, string > >( ( icons, { data }, index ) => {
+				if ( data ) {
+					icons[ slugs[ index ] ] = data;
+				}
+				return icons;
+			}, Object.create( null ) ),
 	} );
 
 export const installPluginMutation = () =>


### PR DESCRIPTION
> [!IMPORTANT]
> Temporary workaround for SEARCH-333, where the search index serves a placeholder icon for every wp.org plugin — delete this once that's fixed.

## Proposed Changes

* Add `fetchWpOrgPluginIcons` to `@automattic/api-core`: one request to the wp.org plugin directory resolves up to 100 slugs to real icon URLs.
* Add `wpOrgPluginIconQuery` / `useWpOrgPluginIcons` to `@automattic/api-queries`. The cache is keyed per slug; requests are coalesced, so every slug queued in the same tick resolves from a single call.
* Use it where each client assembles its plugin list — `usePlugins` in classic Calypso, `PluginsList` in the Multi-site Dashboard.
* Allow `https://wordpress.org` in the CSP `connect-src` list.

Both `PluginIcon` components are untouched: the wrong value came from the data layer, so that is where it is corrected.

## Why are these changes being made?

The marketplace search index stores the generated geopattern placeholder as `plugin.icons` for **every** wp.org-sourced plugin (`blog_id` 108986944), even when wp.org holds a real icon. Sampling 50 rows across five queries: 50/50 patterned. Woo Marketplace rows (`blog_id` 113771570) store real URLs and are untouched here.

The same root cause empties `plugin.banners` — 50/50 return `""` — so this is not only the plugin tiles. The real fix is upstream and repairs both fields for every consumer of the index at once; SEARCH-333 has the diagnosis and the one check that identifies the cause. No other field in the mapping carries the real icon, so the URL has to come from wp.org itself.

`wordpress.org/plugins/wp-json/wp/v2/plugin` takes repeated `slug[]` parameters and `_fields=slug,icons`. A page of results costs one request — 20 slugs is 4.2 KB — and it returns `icons.generated`, which says authoritatively whether a plugin has an icon at all. Nothing is guessed, and nothing is retried for the ~20% that genuinely have none.

## Screenshots

### Before / after

| Before | After |
| --- | --- |
| <img width="2880" height="1800" alt="my wordpress com_plugins_manage(Desktop (Cris))" src="https://github.com/user-attachments/assets/0fad058e-a3d5-4285-910c-66e28ab2fed5" /> | <img width="2880" height="1800" alt="my localhost_3000_plugins_manage(Desktop (Cris))" src="https://github.com/user-attachments/assets/19f9a0d8-2020-4154-8b7a-1b6b0a4420ef" /> |
| <img width="2880" height="1800" alt="wordpress com_plugins_browse_business(Desktop (Cris)) (1)" src="https://github.com/user-attachments/assets/ad09dc56-4059-4df9-b65f-0072af8ad355" /> | <img width="2880" height="1800" alt="calypso localhost_3000_plugins_browse_business(Desktop (Cris)) (1)" src="https://github.com/user-attachments/assets/d1a0e9f0-1bdd-4a54-94d8-4d78f3b92847" /> |


### Still showing the generated pattern
These are plugins wp.org itself reports `generated: true` for — it has no icon for them either, so the pattern is the correct result and no request is wasted discovering that. Roughly 20% of the catalogue.

## Two decisions worth flagging

**Per-slug cache keys, not one key per page.** Keying on the page's slug array is simpler and wrong: ES pages 20 at a time, so the array grows 20 → 40 → 60 and every page is a new key. Icons on screen blink back to placeholders on each scroll, and the Dashboard fans out a request per partially-resolved search batch. Keying per slug makes paging additive; the batch loader keeps that from costing a request per plugin.

**A failed lookup rejects rather than resolving empty.** An empty result is indistinguishable from "none of these has an icon", and with `staleTime: Infinity` one transient 503 would cache the placeholder permanently. The error carries `status` so the retry predicate stops on a 4xx instead of retrying for every slug in the batch.

### Alternatives considered

Guessing `ps.w.org` asset filenames and cascading through them on `<img onError>` was built first and discarded. Measured against 1,480 slugs with live requests: four candidates reach 73% of plugins at 1.43 failed requests each, and 82 have an icon under a name no reasonable list covers — nearly all `.gif`, including Yoast SEO, Sensei, WP Job Manager and Forminator. It also needs hydration-safe retry handling, because `/plugins` is server-rendered.

Also rejected: one `plugin_information` call per slug (works, ~1 KB each, but 20 requests where one will do); a batched wp.org *search* per query (only 20% slug overlap); and `query_plugins` with a slug list (silently ignores `request[slug]` in every form).

## Testing Instructions

`yarn start`, then compare against production. Measured in the browser on a local build:

| Page | Tiles | Loaded | Broken | Real | Pattern |
| --- | --- | --- | --- | --- | --- |
| `/plugins/browse/business` | 40 | 40 | **0** | 36 | 4 |
| `/plugins/browse/business` (scrolled) | 220 | 220 | **0** | 190 | 30 |
| `/plugins?s=elementor` | 20 | 20 | **0** | — | — |
| `/plugins/manage` (Dashboard) | 21 | 21 | **0** | 20 | 1 |

* **`.gif` icons resolve.** `?s=elementor` renders three plugins serving `icon-128x128.gif`. Any approach that guesses filenames misses these.
* **One request per page of results.** Filter the network panel to `wp-json`: the Dashboard issues exactly one request carrying 20 `slug[]` values.
* **No flicker while scrolling.** Driving 8 infinite-scroll pages with a 250 ms watcher recorded 0 reverts, 220/220 still loaded at the end.
* **"by Woo" tiles are unchanged** — they already had real icons and are never looked up.

Payload is effectively unchanged: the geopatterns being replaced average 7.6 KB and the real icons 8.1 KB.

## Known trade-off

`PluginIcon` has no `onError` fallback, so a `ps.w.org` asset that 404s renders a broken-image glyph where a geopattern used to be. Adding one back reintroduces the per-image retry machinery this PR removes; the URLs come from wp.org's own record and carry a `?rev=` pin; and 281 tiles across four pages produced zero broken images.

## Follow-ups, not in this PR

* `fetchWpOrgPlugin` passes its field list as a positive filter, which the wp.org API treats as *additive* — **113 KB** for `woocommerce`, 130 KB for `jetpack`. Negating the unused fields brings it under 1 KB. The Dashboard plugin detail page pays this today.
* `usePlugin` prefers the marketplace-search icon over `wpOrgPluginQuery`, so the detail header shows the geopattern over a wp.org icon it already knows how to fetch. Guarding that branch with `isGeneratedPluginIcon` fixes it.
* `client/dashboard/plugins/manage/components/plugin-sites.tsx` renders its own `<img>` rather than `PluginIcon`.
* The Dashboard's `allSearchQueriesLoaded` gate blanks every icon when any one marketplace-search batch fails. Pre-existing, unchanged here.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [x] Have you checked for TypeScript, ESLint or other errors?
- [x] Have you tested the feature in various signed in/out scenarios?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you considered if this change should be behind a feature flag?

