### PR TITLE
Omnibar: ensure i18n works

### DIFF
--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -126,16 +126,20 @@ export default function OmnibarContainer( { user }: { user?: User } ) {
 		launchSiteNode,
 	].filter( ( node ) => node !== undefined );
 
+	const plugins = baseOmnibarNodes.user
+		? [
+				...( languageSwitcherNode ? [ languageSwitcherNode ] : [] ),
+				...( supports.reader ? [ readerPluginNode ] : [] ),
+				...( supports.help ? [ helpCenterPluginNode ] : [] ),
+				...( supports.help && aiChatPluginNode ? [ aiChatPluginNode ] : [] ),
+				...( supports.notifications ? [ notificationsPluginNode ] : [] ),
+		  ]
+		: [];
+
 	const omnibarNodes = {
 		...baseOmnibarNodes,
 		siteActions,
-		plugins: [
-			...( languageSwitcherNode ? [ languageSwitcherNode ] : [] ),
-			...( supports.reader ? [ readerPluginNode ] : [] ),
-			...( supports.help ? [ helpCenterPluginNode ] : [] ),
-			...( supports.help && aiChatPluginNode ? [ aiChatPluginNode ] : [] ),
-			...( supports.notifications ? [ notificationsPluginNode ] : [] ),
-		],
+		plugins,
 	};
 
 	if ( ! hydrated ) {

--- a/packages/api-core/src/dashboard-admin-bar/fetchers.ts
+++ b/packages/api-core/src/dashboard-admin-bar/fetchers.ts
@@ -2,8 +2,11 @@ import { AdminBarResponse } from '../admin-bar/types';
 import { wpcom } from '../wpcom-fetcher';
 
 export async function fetchDashboardAdminBar(): Promise< AdminBarResponse > {
-	return wpcom.req.get( {
-		path: '/dashboard/admin-bar',
-		apiNamespace: 'wpcom/v2',
-	} );
+	return wpcom.req.get(
+		{
+			path: '/dashboard/admin-bar',
+			apiNamespace: 'wpcom/v2',
+		},
+		{ _locale: 'user' }
+	);
 }

--- a/packages/api-core/src/site-admin-bar/fetchers.ts
+++ b/packages/api-core/src/site-admin-bar/fetchers.ts
@@ -2,8 +2,11 @@ import { AdminBarResponse } from '../admin-bar/types';
 import { wpcom } from '../wpcom-fetcher';
 
 export async function fetchSiteAdminBar( siteId: number ): Promise< AdminBarResponse > {
-	return wpcom.req.get( {
-		path: `/sites/${ siteId }/admin-bar`,
-		apiNamespace: 'wpcom/v2',
-	} );
+	return wpcom.req.get(
+		{
+			path: `/sites/${ siteId }/admin-bar`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{ _locale: 'user' }
+	);
 }

--- a/packages/omnibar/package.json
+++ b/packages/omnibar/package.json
@@ -37,6 +37,7 @@
 	"dependencies": {
 		"@wordpress/components": "^37.0.0",
 		"@wordpress/compose": "^8.2.0",
+		"@wordpress/i18n": "^6.21.0",
 		"@wordpress/icons": "^13.3.0",
 		"@wordpress/private-apis": "^1.51.0",
 		"@wordpress/ui": "^0.18.0"

--- a/packages/omnibar/src/components/omnibar-responsive-menu.tsx
+++ b/packages/omnibar/src/components/omnibar-responsive-menu.tsx
@@ -1,3 +1,4 @@
+import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/ui';
 
 import './omnibar-responsive-menu.scss';
@@ -11,7 +12,7 @@ export function OmnibarResponsiveMenu( {
 		<Button
 			variant="unstyled"
 			className="omnibar__menu omnibar__responsive-menu"
-			aria-label="Menu"
+			aria-label={ __( 'Menu' ) }
 			onClick={ onClickResponsiveMenu }
 		>
 			<span className="dashicons-before dashicons-menu-alt" />

--- a/packages/omnibar/src/components/omnibar.tsx
+++ b/packages/omnibar/src/components/omnibar.tsx
@@ -1,3 +1,4 @@
+import { __ } from '@wordpress/i18n';
 import { OmnibarHomeNode } from './omnibar-home';
 import { OmnibarPluginsNode } from './omnibar-plugins';
 import { OmnibarResponsiveMenu } from './omnibar-responsive-menu';
@@ -12,7 +13,7 @@ export function Omnibar( { nodes, onClickResponsiveMenu, className }: OmnibarPro
 		<div
 			className={ className ? `omnibar ${ className }` : 'omnibar' }
 			role="navigation"
-			aria-label="Toolbar"
+			aria-label={ __( 'Toolbar' ) }
 		>
 			{ onClickResponsiveMenu && (
 				<OmnibarResponsiveMenu onClickResponsiveMenu={ onClickResponsiveMenu } />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2000,6 +2000,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@wordpress/components": "npm:^37.0.0"
     "@wordpress/compose": "npm:^8.2.0"
+    "@wordpress/i18n": "npm:^6.21.0"
     "@wordpress/icons": "npm:^13.3.0"
     "@wordpress/private-apis": "npm:^1.51.0"
     "@wordpress/ui": "npm:^0.18.0"


### PR DESCRIPTION
## Proposed Changes

This PR fixes various i18n issues in the new omnibar:

- Ensure the site-less admin bar endpoint returns the nodes with the user's current locale.
- Ensure the tooltip is translated.

## Testing Instructions

Test with the `dashboard/omnibar-radical` flag turned on.

1. Ensure your account is using non-English
2. Go to /sites
3. Hard refresh
4. Verify you don't see a flash of `Howdy, ` text at the top-right.
