### PR TITLE
Dashboard: reword Migrate card and surface Plan card first on overview

### DIFF
--- a/client/dashboard/app-ciab/translations.ts
+++ b/client/dashboard/app-ciab/translations.ts
@@ -10,7 +10,10 @@ const ciabGetTranslations = ( translation: string, text: string ) => {
 		translations = {
 			'Add new site': __( 'Add new store', ciabDomain ),
 			'Anyone can view your site.': __( 'Anyone can view your store.', ciabDomain ),
-			'Bring your site to WordPress.com.': __( 'Bring your store to WordPress.com.', ciabDomain ),
+			'Move a site from another host to WordPress.com.': __(
+				'Move a store from another host to WordPress.com.',
+				ciabDomain
+			),
 			'Choose between a visual grid view and a more compact table view of your sites.': __(
 				'Choose between a visual grid view and a more compact table view of your stores.',
 				ciabDomain
@@ -23,7 +26,7 @@ const ciabGetTranslations = ( translation: string, text: string ) => {
 			'Edit site ↗': __( 'Edit store ↗', ciabDomain ),
 			'Import site ↗': __( 'Import store ↗', ciabDomain ),
 			'Leave site': __( 'Leave store', ciabDomain ),
-			'Migrate site': __( 'Migrate store', ciabDomain ),
+			'Migrate another site': __( 'Migrate another store', ciabDomain ),
 			Site: __( 'Store', ciabDomain ),
 			Sites: __( 'Stores', ciabDomain ),
 			Public: __( 'Live', ciabDomain ),

--- a/client/dashboard/sites/overview-migrate-site-card/index.tsx
+++ b/client/dashboard/sites/overview-migrate-site-card/index.tsx
@@ -10,8 +10,8 @@ export default function MigrateSiteCard( { site }: { site: Site } ) {
 		<OverviewCard
 			icon={ shuffle }
 			title={ __( 'Migrate' ) }
-			heading={ __( 'Migrate site' ) }
-			description={ __( 'Bring your site to WordPress.com.' ) }
+			heading={ __( 'Migrate another site' ) }
+			description={ __( 'Move a site from another host to WordPress.com.' ) }
 			link={ addQueryArgs( wpcomLink( '/setup/site-migration' ), {
 				siteSlug: site.slug,
 			} ) }

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -91,6 +91,7 @@ function SiteOverviewPrimaryCards( { site, spacing }: { site: Site; spacing: num
 
 	return (
 		<>
+			<PlanCard site={ site } />
 			{ ( () => {
 				const showVisibilityCard = ! site.is_wpcom_flex;
 				return (
@@ -115,7 +116,6 @@ function SiteOverviewPrimaryCards( { site, spacing }: { site: Site; spacing: num
 				} )() }
 				<ScanCard site={ site } />
 			</Grid>
-			<PlanCard site={ site } />
 		</>
 	);
 }


### PR DESCRIPTION
Part of DOTMSD-1287. Fixes DSGCOM-694.

## Proposed Changes

* **Reword the Migrate card** on the site overview. The current copy ("Migrate site" / "Bring your site to WordPress.com.") reads as if it applies to the site being viewed, which confuses users who are already on WordPress.com. New copy makes it explicit the card is about bringing *another* site: heading "Migrate another site", description "Move a site from another host to WordPress.com."
<img width="1720" height="560" alt="image" src="https://github.com/user-attachments/assets/11f4d7b4-8228-4d80-8851-3ac813a38249" />

* **Move the Plan card to the first position** in the overview primary cards (leftmost on desktop, first in the stack on mobile/tablet). Previously it was the last card, so on small viewports it rendered below the fold and users could not see their plan, storage, or bandwidth without scrolling. The change is DOM order, not a CSS-only reorder, so visual order and focus/reading order stay consistent.

## Why are these changes being made?

* Overview card analytics (Feb–Jul 2026, see DOTMSD-1287) show the Migrate card has a high click-through rate on Simple sites but only a 3% purchase conversion, against 39% on Atomic — users click it expecting something about their current site. The wording is the problem, not the placement.
* The same analysis shows the Plan card drives the most purchases of any overview card on every site type, yet it was the least visible card on mobile (DSGCOM-694).

## Testing Instructions

1. Open the hosting dashboard site overview for a site on a free plan.
2. Verify the Plan card is the first card (left on desktop, top on mobile) and the Visibility/Backup and Migrate/Scan columns follow it.
3. Verify the Migrate card reads "Migrate another site" / "Move a site from another host to WordPress.com."
4. Resize to a narrow viewport and confirm the Plan card (with storage and bandwidth) is visible at the top without scrolling.
5. Check an Atomic site and a self-hosted Jetpack site: card order starts with the Plan/Subscriptions card; no Migrate card regression (it only shows for free-plan wpcom sites).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
