### PR TITLE
Atomic transfer: give the status poller a deadline

### DIFF
--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -135,7 +135,11 @@ function BlockingHoldNotice( {
 }
 
 function TransferFailureNotice( { transferStatus, productName }: TransferFailureNoticeProps ) {
-	if ( transferStatus !== transferStates.FAILURE && transferStatus !== transferStates.ERROR ) {
+	if (
+		transferStatus !== transferStates.FAILURE &&
+		transferStatus !== transferStates.ERROR &&
+		transferStatus !== transferStates.CLIENT_TIMEOUT
+	) {
 		return null;
 	}
 

--- a/client/hosting/server-settings/hosting-activate-status.tsx
+++ b/client/hosting/server-settings/hosting-activate-status.tsx
@@ -36,6 +36,7 @@ const endStates: TransferStates[] = [
 	transferStates.FAILURE,
 	transferStates.ERROR,
 	transferStates.REVERTED,
+	transferStates.CLIENT_TIMEOUT,
 	transferStates.NULL,
 ];
 
@@ -82,7 +83,10 @@ const HostingActivateStatus = ( {
 		}
 	};
 
-	if ( transferStatus === transferStates.ERROR ) {
+	if (
+		transferStatus === transferStates.ERROR ||
+		transferStatus === transferStates.CLIENT_TIMEOUT
+	) {
 		return <HostingErrorStatus context={ context } />;
 	}
 

--- a/client/hosting/server-settings/main.tsx
+++ b/client/hosting/server-settings/main.tsx
@@ -251,6 +251,7 @@ const ServerSettings = ( { fetchUpdatedData }: ServerSettingsProps ) => {
 			transferState !== transferStates.ERROR &&
 			transferState !== transferStates.COMPLETED &&
 			transferState !== transferStates.COMPLETE &&
+			transferState !== transferStates.CLIENT_TIMEOUT &&
 			transferState !== transferStates.REVERTED
 	);
 

--- a/client/hosting/server-settings/test/hosting-activate-status.jsx
+++ b/client/hosting/server-settings/test/hosting-activate-status.jsx
@@ -101,6 +101,26 @@ describe( 'index', () => {
 		).toBeInTheDocument();
 	} );
 
+	test( 'Should show error status when the wait times out on the client', async () => {
+		const mockStore = configureStore();
+		mockInitialState.automatedTransfer[ 1 ].status = transferStates.CLIENT_TIMEOUT;
+		const store = mockStore( mockInitialState );
+
+		render(
+			<Provider store={ store }>
+				<HostingActivateStatus context="hosting" />
+			</Provider>
+		);
+
+		expect(
+			screen.queryByText( 'Please wait while we activate the hosting features.' )
+		).not.toBeInTheDocument();
+
+		expect(
+			screen.queryByText( 'There was an error activating hosting features.' )
+		).toBeInTheDocument();
+	} );
+
 	test( 'Should show error status and the transfer fails', async () => {
 		const mockStore = configureStore();
 		mockInitialState.automatedTransfer[ 1 ].status = transferStates.ERROR;

--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -115,6 +115,22 @@ export default function HeaderStagingSiteButton( {
 		}
 	}, [ __, dispatch, queryClient, siteId, isStagingSiteReady, stagingSite ] );
 
+	useEffect( () => {
+		if ( transferStatus !== transferStates.CLIENT_TIMEOUT ) {
+			return;
+		}
+
+		dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.UNSET ) );
+		dispatch(
+			errorNotice(
+				__( 'Adding the staging site is taking longer than expected. Please try again.' ),
+				{
+					id: stagingSiteAddFailureNoticeId,
+				}
+			)
+		);
+	}, [ __, dispatch, siteId, transferStatus ] );
+
 	const removeAllNotices = useCallback( () => {
 		dispatch( removeNotice( 'staging-site-add-success' ) );
 		dispatch( removeNotice( stagingSiteAddFailureNoticeId ) );
@@ -139,7 +155,7 @@ export default function HeaderStagingSiteButton( {
 				);
 				dispatch(
 					errorNotice(
-						// translators: "reason" is why adding the staging site failed.
+						// translators: %(reason)s is why adding the staging site failed.
 						sprintf( __( 'Failed to add staging site: %(reason)s' ), { reason: error.message } ),
 						{
 							id: stagingSiteAddFailureNoticeId,
@@ -195,6 +211,8 @@ export default function HeaderStagingSiteButton( {
 		);
 	} else if ( transferStatus === transferStates.RELOCATING_REVERT ) {
 		disabledReason = __( 'We are deleting your staging site.' );
+	} else if ( transferStatus === transferStates.CLIENT_TIMEOUT ) {
+		disabledReason = __( 'Adding the staging site is taking longer than expected.' );
 	}
 
 	return (

--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -115,21 +115,26 @@ export default function HeaderStagingSiteButton( {
 		}
 	}, [ __, dispatch, queryClient, siteId, isStagingSiteReady, stagingSite ] );
 
+	const hasTransferTimedOut = transferStatus === transferStates.CLIENT_TIMEOUT;
+
+	// The staging site itself already exists by this point, so the status is left alone: clearing
+	// it would hide the entry point entirely, and the transfer may still finish on the server.
 	useEffect( () => {
-		if ( transferStatus !== transferStates.CLIENT_TIMEOUT ) {
+		if ( ! hasTransferTimedOut ) {
 			return;
 		}
 
-		dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.UNSET ) );
 		dispatch(
 			errorNotice(
-				__( 'Adding the staging site is taking longer than expected. Please try again.' ),
+				__(
+					'Adding the staging site is taking longer than expected. It may still finish — reload the page to check.'
+				),
 				{
 					id: stagingSiteAddFailureNoticeId,
 				}
 			)
 		);
-	}, [ __, dispatch, siteId, transferStatus ] );
+	}, [ __, dispatch, hasTransferTimedOut ] );
 
 	const removeAllNotices = useCallback( () => {
 		dispatch( removeNotice( 'staging-site-add-success' ) );
@@ -192,7 +197,8 @@ export default function HeaderStagingSiteButton( {
 
 	const hasCompletedLoading = ! isLoadingQuotaValidation;
 	const isAddingStagingSite =
-		isLoadingAddStagingSite || ( isCreatingStagingSite && ! isCreatedStagingSite );
+		isLoadingAddStagingSite ||
+		( isCreatingStagingSite && ! isCreatedStagingSite && ! hasTransferTimedOut );
 
 	let disabledReason: string | undefined;
 	if ( ! hasCompletedLoading ) {
@@ -211,7 +217,7 @@ export default function HeaderStagingSiteButton( {
 		);
 	} else if ( transferStatus === transferStates.RELOCATING_REVERT ) {
 		disabledReason = __( 'We are deleting your staging site.' );
-	} else if ( transferStatus === transferStates.CLIENT_TIMEOUT ) {
+	} else if ( hasTransferTimedOut ) {
 		disabledReason = __( 'Adding the staging site is taking longer than expected.' );
 	}
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
+import Notice from 'calypso/components/notice';
 import ThankYouV2 from 'calypso/components/thank-you-v2';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
@@ -105,6 +106,7 @@ const MarketplaceThankYou = ( {
 		( ! hasThemes || isLoadedThemes );
 
 	const transferStatus = useSelector( ( state ) => getAutomatedTransferStatus( state, siteId ) );
+	const isTransferTimedOut = transferStatus === transferStates.CLIENT_TIMEOUT;
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
 	const isJetpackSelfHosted = isJetpack && ! isAtomic;
@@ -128,6 +130,11 @@ const MarketplaceThankYou = ( {
 	} );
 	// Set progressbar (currentStep) depending on transfer/plugin status.
 	useEffect( () => {
+		if ( isTransferTimedOut ) {
+			setShowProgressBar( false );
+			return;
+		}
+
 		// We don't want to show the progress bar again when it is hidden.
 		if ( ! showProgressBar ) {
 			return;
@@ -143,6 +150,7 @@ const MarketplaceThankYou = ( {
 	}, [
 		setShowProgressBar,
 		showProgressBar,
+		isTransferTimedOut,
 		isPageReady,
 		pluginSlugs.length,
 		themeSlugs.length,
@@ -177,7 +185,7 @@ const MarketplaceThankYou = ( {
 				` }
 			/>
 			<MarketplaceGoBackSection pluginSlugs={ pluginSlugs } themeSlugs={ themeSlugs } />
-			{ showProgressBar && (
+			{ showProgressBar && ! isTransferTimedOut && (
 				// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 				<div className="marketplace-plugin-install__root">
 					<MarketplaceProgressBar
@@ -187,7 +195,16 @@ const MarketplaceThankYou = ( {
 					/>
 				</div>
 			) }
-			{ ! showProgressBar && (
+			{ isTransferTimedOut && (
+				<Main className="marketplace-thank-you__container">
+					<Notice
+						status="is-error"
+						showDismiss={ false }
+						text={ translate( 'Setting up your site is taking longer than expected.' ) }
+					/>
+				</Main>
+			) }
+			{ ! showProgressBar && ! isTransferTimedOut && (
 				<Main className="marketplace-thank-you__container">
 					<ThankYouV2
 						title={ title }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-atomic-transfer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-atomic-transfer.tsx
@@ -54,7 +54,11 @@ export function useAtomicTransfer(
 			return;
 		}
 
-		if ( ! isFetchingTransferStatus && transferStatus !== transferStates.COMPLETE ) {
+		if (
+			! isFetchingTransferStatus &&
+			transferStatus !== transferStates.COMPLETE &&
+			transferStatus !== transferStates.CLIENT_TIMEOUT
+		) {
 			waitFor( 2 ).then( () => dispatch( fetchAutomatedTransferStatus( siteId ) ) );
 		}
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -139,7 +139,11 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 	}, [ areAllWporgPluginsFetched, areWporgPluginsFetched, pluginSlugs, dispatch, wporgPlugins ] );
 
 	useEffect( () => {
-		if ( ! isFetchingTransferStatus && transferStatus !== transferStates.COMPLETE ) {
+		if (
+			! isFetchingTransferStatus &&
+			transferStatus !== transferStates.COMPLETE &&
+			transferStatus !== transferStates.CLIENT_TIMEOUT
+		) {
 			dispatch( fetchAutomatedTransferStatus( siteId as number ) );
 		}
 	}, [ dispatch, isFetchingTransferStatus, siteId, transferStatus ] );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
@@ -20,11 +20,15 @@ const reducers = {
 // The deadline hook has its own suite; here we only assert how this hook arms it.
 type DeadlineArgs = { siteId: number; productSlug: string; enabled: boolean };
 
-const mockUseInstallDeadline = jest.fn( ( args: DeadlineArgs ) => ( {
-	hasTimedOut: false,
-	hasTransferFailed: false,
-	receivedEnabled: args.enabled,
-} ) );
+const deadlineVerdict =
+	( verdict: { hasTimedOut: boolean; hasTransferFailed: boolean } ) => ( args: DeadlineArgs ) => ( {
+		...verdict,
+		receivedEnabled: args.enabled,
+	} );
+
+const noDeadlineVerdict = deadlineVerdict( { hasTimedOut: false, hasTransferFailed: false } );
+
+const mockUseInstallDeadline = jest.fn( noDeadlineVerdict );
 
 jest.mock( '../use-install-deadline', () => ( {
 	...jest.requireActual( '../use-install-deadline' ),
@@ -168,6 +172,10 @@ describe( 'useProductInstall', () => {
 	} );
 
 	describe( 'error', () => {
+		afterEach( () => {
+			mockUseInstallDeadline.mockImplementation( noDeadlineVerdict );
+		} );
+
 		it( 'has no error before any grace period elapses', () => {
 			const { result } = renderProductInstall( { pluginSlug: 'give' } );
 			expect( result.current.error ).toBeNull();
@@ -199,6 +207,26 @@ describe( 'useProductInstall', () => {
 				expect( result.current.error ).toEqual( { type: 'rejected-upload', reason } );
 			}
 		);
+
+		it( 'reports the dedicated timeout error when the wait runs out', () => {
+			mockUseInstallDeadline.mockImplementation(
+				deadlineVerdict( { hasTimedOut: true, hasTransferFailed: false } )
+			);
+
+			const { result } = renderProductInstall( {}, uploadAwaitingActivation( 'direct' ) );
+
+			expect( result.current.error ).toEqual( { type: 'timeout' } );
+		} );
+
+		it( 'reports the transfer failure ahead of a timeout', () => {
+			mockUseInstallDeadline.mockImplementation(
+				deadlineVerdict( { hasTimedOut: true, hasTransferFailed: true } )
+			);
+
+			const { result } = renderProductInstall( {}, uploadAwaitingActivation( 'direct' ) );
+
+			expect( result.current.error ).toEqual( { type: 'transfer-failed' } );
+		} );
 
 		// The upload page sends the customer here as soon as the upload starts. Counting that time
 		// against a deadline calibrated for server-side transfers would fail a large file on a slow

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -309,7 +309,9 @@ export function useProductInstall( {
 		if (
 			pluginUploadError ||
 			pluginInstallStatus?.error ||
-			( atomicFlow && automatedTransferStatus === transferStates.FAILURE )
+			( atomicFlow &&
+				( automatedTransferStatus === transferStates.FAILURE ||
+					automatedTransferStatus === transferStates.CLIENT_TIMEOUT ) )
 		) {
 			return { type: 'generic' };
 		}

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -309,9 +309,7 @@ export function useProductInstall( {
 		if (
 			pluginUploadError ||
 			pluginInstallStatus?.error ||
-			( atomicFlow &&
-				( automatedTransferStatus === transferStates.FAILURE ||
-					automatedTransferStatus === transferStates.CLIENT_TIMEOUT ) )
+			( atomicFlow && automatedTransferStatus === transferStates.FAILURE )
 		) {
 			return { type: 'generic' };
 		}
@@ -324,6 +322,11 @@ export function useProductInstall( {
 	// also wait out the install or transfer the upload triggers, which is the very wait to bound.
 	const isUploadStillSending = isPluginUploadFlow && pluginUploadProgress < 100;
 
+	// The Redux status poller bounds the same wait from the other side, so honour its verdict
+	// alongside this screen's own deadline rather than treating it as an unexplained failure.
+	const hasTransferTimedOut =
+		atomicFlow && automatedTransferStatus === transferStates.CLIENT_TIMEOUT;
+
 	const { hasTimedOut, hasTransferFailed, diagnostics } = useInstallDeadline( {
 		siteId,
 		enabled: !! siteId && ! preflightError && ! isUploadStillSending,
@@ -335,7 +338,7 @@ export function useProductInstall( {
 	if ( ! error && hasTransferFailed ) {
 		error = { type: 'transfer-failed' };
 	}
-	if ( ! error && hasTimedOut ) {
+	if ( ! error && ( hasTimedOut || hasTransferTimedOut ) ) {
 		error = { type: 'timeout' };
 	}
 
@@ -349,7 +352,7 @@ export function useProductInstall( {
 		let outcome = null;
 		if ( hasTransferFailed ) {
 			outcome = 'transfer_failed';
-		} else if ( hasTimedOut ) {
+		} else if ( hasTimedOut || hasTransferTimedOut ) {
 			outcome = 'timeout';
 		}
 		if ( ! outcome || reportedOutcomeRef.current === outcome ) {
@@ -370,6 +373,7 @@ export function useProductInstall( {
 		} );
 	}, [
 		hasTimedOut,
+		hasTransferTimedOut,
 		hasTransferFailed,
 		themeSlug,
 		installStrategy,

--- a/client/my-sites/themes/atomic-transfer-dialog.tsx
+++ b/client/my-sites/themes/atomic-transfer-dialog.tsx
@@ -146,6 +146,19 @@ class AtomicTransferDialog extends Component< AtomicTransferDialogProps > {
 	componentDidUpdate( prevProps: Readonly< AtomicTransferDialogProps > ): void {
 		const { siteId, siteSlug, uploadError, isJetpack, transferStatus } = this.props;
 
+		if (
+			transferStatus === transferStates.CLIENT_TIMEOUT &&
+			prevProps.transferStatus !== transferStates.CLIENT_TIMEOUT
+		) {
+			this.stopSitePolling();
+			this.setState( {
+				requestActiveThemeCount: 0,
+				errorMessage: translate(
+					'The site transfer is taking longer than expected. Please try again.'
+				),
+			} );
+		}
+
 		// After transfer completes, wait for the site to be recognized as Jetpack.
 		// requestActiveThemeCount > 0 ensures we only act if we initiated a transfer in this session.
 		if (

--- a/client/state/automated-transfer/actions.js
+++ b/client/state/automated-transfer/actions.js
@@ -31,13 +31,11 @@ export const initiateAutomatedTransferWithPluginZip = ( siteId, pluginZip ) => (
 /**
  * Query the automated transfer status of a given site.
  * @param {number} siteId The id of the site to query.
- * @param {number} [pollDeadline] Optional wall-clock deadline for the current poll chain.
  * @returns {Object} An action object
  */
-export const fetchAutomatedTransferStatus = ( siteId, pollDeadline ) => ( {
+export const fetchAutomatedTransferStatus = ( siteId ) => ( {
 	type: AUTOMATED_TRANSFER_STATUS_REQUEST,
 	siteId,
-	pollDeadline,
 } );
 
 /**

--- a/client/state/automated-transfer/actions.js
+++ b/client/state/automated-transfer/actions.js
@@ -31,11 +31,13 @@ export const initiateAutomatedTransferWithPluginZip = ( siteId, pluginZip ) => (
 /**
  * Query the automated transfer status of a given site.
  * @param {number} siteId The id of the site to query.
+ * @param {number} [pollDeadline] Optional wall-clock deadline for the current poll chain.
  * @returns {Object} An action object
  */
-export const fetchAutomatedTransferStatus = ( siteId ) => ( {
+export const fetchAutomatedTransferStatus = ( siteId, pollDeadline ) => ( {
 	type: AUTOMATED_TRANSFER_STATUS_REQUEST,
 	siteId,
+	pollDeadline,
 } );
 
 /**

--- a/client/state/automated-transfer/constants.ts
+++ b/client/state/automated-transfer/constants.ts
@@ -27,6 +27,10 @@ export const transferStates = {
 	 * This is when the request to fetch the transfer status failed with an unknown error
 	 */
 	REQUEST_FAILURE: 'request_failure',
+	/**
+	 * Client-only: the status poller hit its deadline while the transfer was still in progress.
+	 */
+	CLIENT_TIMEOUT: 'client_timeout',
 } as const;
 
 export const transferInProgress = [

--- a/client/state/automated-transfer/reducer.js
+++ b/client/state/automated-transfer/reducer.js
@@ -20,27 +20,34 @@ import { transferStates } from './constants';
 import eligibility from './eligibility/reducer';
 import { automatedTransfer as schema } from './schema';
 
-export const status = withPersistence( ( state = null, action ) => {
-	switch ( action.type ) {
-		case ELIGIBILITY_UPDATE:
-			return state || transferStates.INQUIRING;
-		case INITIATE:
-			return transferStates.START;
-		case INITIATE_FAILURE:
-			return transferStates.FAILURE;
-		case SET_STATUS:
-			return action.status;
-		case TRANSFER_UPDATE:
-			return 'complete' === action.status ? transferStates.COMPLETE : state;
-		case REQUEST_STATUS_FAILURE:
-			// TODO : [MARKETPLACE] rely on a tangible status from the backend instead of this message
-			return action.error === 'An invalid transfer ID was passed.'
-				? transferStates.NONE
-				: transferStates.REQUEST_FAILURE;
-	}
+export const status = withPersistence(
+	( state = null, action ) => {
+		switch ( action.type ) {
+			case ELIGIBILITY_UPDATE:
+				return state || transferStates.INQUIRING;
+			case INITIATE:
+				return transferStates.START;
+			case INITIATE_FAILURE:
+				return transferStates.FAILURE;
+			case SET_STATUS:
+				return action.status;
+			case TRANSFER_UPDATE:
+				return 'complete' === action.status ? transferStates.COMPLETE : state;
+			case REQUEST_STATUS_FAILURE:
+				// TODO : [MARKETPLACE] rely on a tangible status from the backend instead of this message
+				return action.error === 'An invalid transfer ID was passed.'
+					? transferStates.NONE
+					: transferStates.REQUEST_FAILURE;
+		}
 
-	return state;
-} );
+		return state;
+	},
+	{
+		// CLIENT_TIMEOUT is client-only. Persisting it would render a stale error on screens that
+		// stop polling once they see it, leaving nothing able to clear it.
+		serialize: ( state ) => ( state === transferStates.CLIENT_TIMEOUT ? null : state ),
+	}
+);
 
 export const fetchingStatus = ( state = false, action ) => {
 	switch ( action.type ) {

--- a/client/state/automated-transfer/selectors/is-automated-transfer-active.js
+++ b/client/state/automated-transfer/selectors/is-automated-transfer-active.js
@@ -19,6 +19,7 @@ export const isActive = ( status ) =>
 				transferStates.REVERTED,
 				transferStates.CONFLICTS,
 				transferStates.INQUIRING,
+				transferStates.CLIENT_TIMEOUT,
 		  ].includes( status )
 		: false;
 /**

--- a/client/state/automated-transfer/selectors/is-automated-transfer-failed.js
+++ b/client/state/automated-transfer/selectors/is-automated-transfer-failed.js
@@ -9,7 +9,11 @@ import 'calypso/state/automated-transfer/init';
  * @returns {?boolean} is transfer currently failed? null if unknown
  */
 export const isFailed = ( status ) =>
-	status ? status === transferStates.CONFLICTS || status === transferStates.FAILURE : null;
+	status
+		? status === transferStates.CONFLICTS ||
+		  status === transferStates.FAILURE ||
+		  status === transferStates.CLIENT_TIMEOUT
+		: null;
 
 /**
  * Indicates whether or not an automated transfer is failed for a given site

--- a/client/state/automated-transfer/test/is-automated-transfer-active.js
+++ b/client/state/automated-transfer/test/is-automated-transfer-active.js
@@ -17,6 +17,7 @@ describe( 'Automated Transfer', () => {
 			expect( isActive( transferStates.CONFLICTS ) ).toBe( false );
 			expect( isActive( transferStates.FAILURE ) ).toBe( false );
 			expect( isActive( transferStates.INQUIRING ) ).toBe( false );
+			expect( isActive( transferStates.CLIENT_TIMEOUT ) ).toBe( false );
 		} );
 	} );
 } );

--- a/client/state/automated-transfer/test/is-automated-transfer-failed.js
+++ b/client/state/automated-transfer/test/is-automated-transfer-failed.js
@@ -11,6 +11,7 @@ describe( 'Automated Transfer', () => {
 		test( 'should return `true` for failed transfer states', () => {
 			expect( isFailed( transferStates.CONFLICTS ) ).toBe( true );
 			expect( isFailed( transferStates.FAILURE ) ).toBe( true );
+			expect( isFailed( transferStates.CLIENT_TIMEOUT ) ).toBe( true );
 		} );
 
 		test( 'should return `false` for non-failed transfer states', () => {

--- a/client/state/automated-transfer/test/reducer.js
+++ b/client/state/automated-transfer/test/reducer.js
@@ -2,6 +2,7 @@ import {
 	AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE as ELIGIBILITY_UPDATE,
 	AUTOMATED_TRANSFER_STATUS_REQUEST as REQUEST_STATUS,
 	AUTOMATED_TRANSFER_STATUS_REQUEST_FAILURE as REQUEST_STATUS_FAILURE,
+	AUTOMATED_TRANSFER_STATUS_SET as SET_STATUS,
 } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
 import { transferStates } from '../constants';
@@ -42,7 +43,7 @@ describe( 'state', () => {
 				const SITE_ID = 12345;
 				const AT_STATE = {
 					[ SITE_ID ]: {
-						status: 'backfilling',
+						status: transferStates.BACKFILLING,
 						eligibility: {
 							eligibilityHolds: [],
 							eligibilityWarnings: [],
@@ -58,10 +59,36 @@ describe( 'state', () => {
 				expect( serialized[ SITE_ID ] ).not.toHaveProperty( 'fetchingStatus' );
 
 				const deserialized = deserialize( reducer, AT_STATE );
-				expect( deserialized[ SITE_ID ] ).toHaveProperty( 'status' );
+				expect( deserialized[ SITE_ID ] ).toHaveProperty( 'status', transferStates.BACKFILLING );
 				expect( deserialized[ SITE_ID ] ).toHaveProperty( 'eligibility' );
 				// The non-persisted property has default value, persisted value is ignored
 				expect( deserialized[ SITE_ID ] ).toHaveProperty( 'fetchingStatus', false );
+			} );
+
+			test( 'should not persist the client timeout status', () => {
+				const SITE_ID = 12345;
+				const AT_STATE = {
+					[ SITE_ID ]: {
+						status: transferStates.CLIENT_TIMEOUT,
+						eligibility: {
+							eligibilityHolds: [],
+							eligibilityWarnings: [],
+							lastUpdate: 1000000000,
+						},
+					},
+				};
+
+				const serialized = serialize( reducer, AT_STATE ).root();
+				expect( serialized[ SITE_ID ] ).toHaveProperty( 'status', null );
+			} );
+
+			test( 'should set client timeout status', () => {
+				expect(
+					status( null, {
+						type: SET_STATUS,
+						status: transferStates.CLIENT_TIMEOUT,
+					} )
+				).toBe( transferStates.CLIENT_TIMEOUT );
 			} );
 		} );
 	} );

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
@@ -12,6 +12,27 @@ import { requestSite } from 'calypso/state/sites/actions';
 
 export const TRANSFER_STATUS_POLL_DEADLINE_MS = 5 * 60 * 1000;
 
+const POLL_INTERVAL_MS = 3000;
+
+// Statuses the backend will not move away from on its own. Polling past one of these would
+// keep asking about a transfer that has already ended, and letting the deadline fire on one
+// would overwrite a real outcome with a generic timeout.
+const settledStates = [
+	transferStates.COMPLETE,
+	transferStates.COMPLETED,
+	transferStates.ERROR,
+	transferStates.FAILURE,
+	transferStates.CONFLICTS,
+	transferStates.REVERTED,
+];
+
+// The deadline belongs to the wait, not to a single request. Consumers re-dispatch a
+// deadline-less fetch every time the status changes, so without an anchor per site each
+// response would open a fresh window and the deadline would never arrive.
+const pollDeadlines = new Map();
+
+export const clearPollDeadlines = () => pollDeadlines.clear();
+
 export const requestStatus = ( action ) =>
 	http(
 		{
@@ -28,16 +49,25 @@ export const receiveStatus =
 		const pluginId = uploaded_plugin_slug;
 
 		dispatch( setAutomatedTransferStatus( siteId, status, pluginId ) );
-		if ( status !== transferStates.ERROR && status !== transferStates.COMPLETE ) {
-			const deadline = pollDeadline ?? Date.now() + TRANSFER_STATUS_POLL_DEADLINE_MS;
+
+		if ( settledStates.includes( status ) ) {
+			pollDeadlines.delete( siteId );
+		} else {
+			const deadline =
+				pollDeadline ??
+				pollDeadlines.get( siteId ) ??
+				Date.now() + TRANSFER_STATUS_POLL_DEADLINE_MS;
+
 			if ( Date.now() < deadline ) {
-				setTimeout( dispatch, 3000, fetchAutomatedTransferStatus( siteId, deadline ) );
+				pollDeadlines.set( siteId, deadline );
+				setTimeout( dispatch, POLL_INTERVAL_MS, fetchAutomatedTransferStatus( siteId, deadline ) );
 			} else {
+				pollDeadlines.delete( siteId );
 				dispatch( setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, pluginId ) );
 			}
 		}
 
-		if ( status === transferStates.COMPLETE ) {
+		if ( status === transferStates.COMPLETE || status === transferStates.COMPLETED ) {
 			// Update the now-atomic site to ensure plugin page displays correctly.
 			dispatch( requestSite( siteId ) );
 		}

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
@@ -10,6 +10,8 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { requestSite } from 'calypso/state/sites/actions';
 
+export const TRANSFER_STATUS_POLL_DEADLINE_MS = 5 * 60 * 1000;
+
 export const requestStatus = ( action ) =>
 	http(
 		{
@@ -21,13 +23,18 @@ export const requestStatus = ( action ) =>
 	);
 
 export const receiveStatus =
-	( { siteId }, { status, uploaded_plugin_slug } ) =>
+	( { siteId, pollDeadline }, { status, uploaded_plugin_slug } ) =>
 	( dispatch ) => {
 		const pluginId = uploaded_plugin_slug;
 
 		dispatch( setAutomatedTransferStatus( siteId, status, pluginId ) );
 		if ( status !== transferStates.ERROR && status !== transferStates.COMPLETE ) {
-			setTimeout( dispatch, 3000, fetchAutomatedTransferStatus( siteId ) );
+			const deadline = pollDeadline ?? Date.now() + TRANSFER_STATUS_POLL_DEADLINE_MS;
+			if ( Date.now() < deadline ) {
+				setTimeout( dispatch, 3000, fetchAutomatedTransferStatus( siteId, deadline ) );
+			} else {
+				dispatch( setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, pluginId ) );
+			}
 		}
 
 		if ( status === transferStates.COMPLETE ) {

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
@@ -45,22 +45,33 @@ export const requestStatus = ( action ) =>
 	);
 
 export const receiveStatus =
-	( { siteId }, { status, uploaded_plugin_slug } ) =>
+	( { siteId }, { status, uploaded_plugin_slug, transfer_id: transferId } ) =>
 	( dispatch ) => {
 		const pluginId = uploaded_plugin_slug;
+		const isSettled = settledStates.includes( status );
+		const stored = pollDeadlines.get( siteId );
+		const recorded = stored?.transferId === transferId ? stored : undefined;
+
+		// Once a wait has run out of time it stays that way until the transfer actually ends.
+		// Otherwise the next status fetch — and several screens keep fetching — would replace
+		// the error with a spinner and start the five minutes over, indefinitely.
+		if ( recorded?.hasTimedOut && ! isSettled ) {
+			dispatch( setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, pluginId ) );
+			return;
+		}
 
 		dispatch( setAutomatedTransferStatus( siteId, status, pluginId ) );
 
-		if ( settledStates.includes( status ) ) {
+		if ( isSettled ) {
 			pollDeadlines.delete( siteId );
 		} else {
-			const deadline = pollDeadlines.get( siteId ) ?? Date.now() + TRANSFER_STATUS_POLL_DEADLINE_MS;
+			const deadline = recorded?.deadline ?? Date.now() + TRANSFER_STATUS_POLL_DEADLINE_MS;
 
 			if ( Date.now() < deadline ) {
-				pollDeadlines.set( siteId, deadline );
+				pollDeadlines.set( siteId, { transferId, deadline } );
 				setTimeout( dispatch, POLL_INTERVAL_MS, fetchAutomatedTransferStatus( siteId ) );
 			} else {
-				pollDeadlines.delete( siteId );
+				pollDeadlines.set( siteId, { transferId, deadline, hasTimedOut: true } );
 				dispatch( setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, pluginId ) );
 			}
 		}

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
@@ -26,9 +26,10 @@ const settledStates = [
 	transferStates.REVERTED,
 ];
 
-// The deadline belongs to the wait, not to a single request. Consumers re-dispatch a
-// deadline-less fetch every time the status changes, so without an anchor per site each
-// response would open a fresh window and the deadline would never arrive.
+// The deadline belongs to the wait, not to a single request: consumers re-dispatch a fetch
+// every time the status changes, and each of those would otherwise open a fresh window. It
+// is held here rather than carried on the action so a poll scheduled by a wait that has
+// since ended cannot apply its expired deadline to whatever is running now.
 const pollDeadlines = new Map();
 
 export const clearPollDeadlines = () => pollDeadlines.clear();
@@ -44,7 +45,7 @@ export const requestStatus = ( action ) =>
 	);
 
 export const receiveStatus =
-	( { siteId, pollDeadline }, { status, uploaded_plugin_slug } ) =>
+	( { siteId }, { status, uploaded_plugin_slug } ) =>
 	( dispatch ) => {
 		const pluginId = uploaded_plugin_slug;
 
@@ -53,14 +54,11 @@ export const receiveStatus =
 		if ( settledStates.includes( status ) ) {
 			pollDeadlines.delete( siteId );
 		} else {
-			const deadline =
-				pollDeadline ??
-				pollDeadlines.get( siteId ) ??
-				Date.now() + TRANSFER_STATUS_POLL_DEADLINE_MS;
+			const deadline = pollDeadlines.get( siteId ) ?? Date.now() + TRANSFER_STATUS_POLL_DEADLINE_MS;
 
 			if ( Date.now() < deadline ) {
 				pollDeadlines.set( siteId, deadline );
-				setTimeout( dispatch, POLL_INTERVAL_MS, fetchAutomatedTransferStatus( siteId, deadline ) );
+				setTimeout( dispatch, POLL_INTERVAL_MS, fetchAutomatedTransferStatus( siteId ) );
 			} else {
 				pollDeadlines.delete( siteId );
 				dispatch( setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, pluginId ) );

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
@@ -3,8 +3,9 @@ import {
 	fetchAutomatedTransferStatus,
 	setAutomatedTransferStatus,
 } from 'calypso/state/automated-transfer/actions';
+import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
-import { requestStatus, receiveStatus } from '../';
+import { requestStatus, receiveStatus, TRANSFER_STATUS_POLL_DEADLINE_MS } from '../';
 
 const siteId = 1916284;
 
@@ -18,6 +19,12 @@ const COMPLETE_RESPONSE = {
 const IN_PROGRESS_RESPONSE = {
 	blog_id: 1916284,
 	status: 'uploading',
+	uploaded_plugin_slug: 'hello-dolly',
+};
+
+const ERROR_RESPONSE = {
+	blog_id: 1916284,
+	status: 'error',
 	uploaded_plugin_slug: 'hello-dolly',
 };
 
@@ -39,6 +46,9 @@ describe( 'requestStatus', () => {
 describe( 'receiveStatus', () => {
 	beforeEach( () => {
 		jest.useFakeTimers();
+	} );
+	afterEach( () => {
+		jest.useRealTimers();
 	} );
 
 	test( 'should dispatch set status action', () => {
@@ -62,12 +72,66 @@ describe( 'receiveStatus', () => {
 	} );
 
 	test( 'should request status again if not complete', () => {
-		jest.useFakeTimers();
 		const dispatch = jest.fn();
 		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
 		jest.runAllTimers();
 
 		expect( dispatch ).toHaveBeenCalledTimes( 2 );
-		expect( dispatch ).toHaveBeenCalledWith( fetchAutomatedTransferStatus( siteId ) );
+		expect( dispatch ).toHaveBeenCalledWith(
+			fetchAutomatedTransferStatus( siteId, expect.any( Number ) )
+		);
 	} );
+
+	test( 'should start a deadline for a new poll chain', () => {
+		const now = 1000000;
+		jest.setSystemTime( now );
+		const dispatch = jest.fn();
+
+		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
+		jest.runAllTimers();
+
+		expect( dispatch ).toHaveBeenCalledWith(
+			fetchAutomatedTransferStatus( siteId, now + TRANSFER_STATUS_POLL_DEADLINE_MS )
+		);
+	} );
+
+	test( 'should carry the deadline through a poll chain', () => {
+		const pollDeadline = 2000000;
+		jest.setSystemTime( 1000000 );
+		const dispatch = jest.fn();
+
+		receiveStatus( { siteId, pollDeadline }, IN_PROGRESS_RESPONSE )( dispatch );
+		jest.runAllTimers();
+
+		expect( dispatch ).toHaveBeenCalledWith( fetchAutomatedTransferStatus( siteId, pollDeadline ) );
+	} );
+
+	test( 'should set client timeout when the deadline expires', () => {
+		const pollDeadline = 1000000;
+		jest.setSystemTime( pollDeadline );
+		const dispatch = jest.fn();
+
+		receiveStatus( { siteId, pollDeadline }, IN_PROGRESS_RESPONSE )( dispatch );
+
+		expect( dispatch ).toHaveBeenLastCalledWith(
+			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, 'hello-dolly' )
+		);
+		expect( dispatch ).not.toHaveBeenCalledWith(
+			fetchAutomatedTransferStatus( siteId, pollDeadline )
+		);
+	} );
+
+	test.each( [ COMPLETE_RESPONSE, ERROR_RESPONSE ] )(
+		'should prefer terminal status over an expired deadline',
+		( response ) => {
+			jest.setSystemTime( 1000000 );
+			const dispatch = jest.fn();
+
+			receiveStatus( { siteId, pollDeadline: 999999 }, response )( dispatch );
+
+			expect( dispatch ).not.toHaveBeenCalledWith(
+				setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, 'hello-dolly' )
+			);
+		}
+	);
 } );

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
@@ -25,12 +25,14 @@ const IN_PROGRESS_RESPONSE = {
 	blog_id: 1916284,
 	status: 'uploading',
 	uploaded_plugin_slug: 'hello-dolly',
+	transfer_id: 1,
 };
 
 const settledResponse = ( status ) => ( {
 	blog_id: 1916284,
 	status,
 	uploaded_plugin_slug: 'hello-dolly',
+	transfer_id: 1,
 } );
 
 describe( 'requestStatus', () => {
@@ -114,6 +116,63 @@ describe( 'receiveStatus', () => {
 		expect( dispatch ).toHaveBeenLastCalledWith(
 			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, 'hello-dolly' )
 		);
+	} );
+
+	test( 'should stay timed out rather than reopening the window', () => {
+		const start = 1000000;
+		jest.setSystemTime( start );
+		const dispatch = jest.fn();
+
+		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
+		jest.runAllTimers();
+		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS );
+		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
+
+		// Screens keep fetching after the error appears; none of those may revive the wait.
+		dispatch.mockClear();
+		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
+		jest.runAllTimers();
+
+		expect( dispatch ).toHaveBeenCalledTimes( 1 );
+		expect( dispatch ).toHaveBeenCalledWith(
+			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, 'hello-dolly' )
+		);
+	} );
+
+	test( 'should let the transfer finishing clear a timed-out wait', () => {
+		const start = 1000000;
+		jest.setSystemTime( start );
+		const dispatch = jest.fn();
+
+		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
+		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS );
+		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
+
+		dispatch.mockClear();
+		receiveStatus( { siteId }, COMPLETE_RESPONSE )( dispatch );
+
+		expect( dispatch ).toHaveBeenCalledWith(
+			setAutomatedTransferStatus( siteId, transferStates.COMPLETE, 'hello-dolly' )
+		);
+	} );
+
+	test( 'should not apply a deadline left behind by a previous transfer', () => {
+		const start = 1000000;
+		jest.setSystemTime( start );
+		const dispatch = jest.fn();
+
+		// A wait whose polling died at the HTTP layer leaves its deadline behind.
+		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
+
+		// Much later, a genuinely new transfer starts. It must get its own five minutes.
+		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS + 1 );
+		receiveStatus( { siteId }, { ...IN_PROGRESS_RESPONSE, transfer_id: 2 } )( dispatch );
+		jest.runAllTimers();
+
+		expect( dispatch ).not.toHaveBeenCalledWith(
+			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, 'hello-dolly' )
+		);
+		expect( dispatch ).toHaveBeenCalledWith( fetchAutomatedTransferStatus( siteId ) );
 	} );
 
 	test( 'should not let a poll scheduled by an ended wait time out the next one', () => {

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
@@ -83,47 +83,55 @@ describe( 'receiveStatus', () => {
 		jest.runAllTimers();
 
 		expect( dispatch ).toHaveBeenCalledTimes( 2 );
-		expect( dispatch ).toHaveBeenCalledWith(
-			fetchAutomatedTransferStatus( siteId, expect.any( Number ) )
-		);
+		expect( dispatch ).toHaveBeenCalledWith( fetchAutomatedTransferStatus( siteId ) );
 	} );
 
-	test( 'should start a deadline for a new poll chain', () => {
-		const now = 1000000;
-		jest.setSystemTime( now );
+	test( 'should keep polling until the deadline arrives', () => {
+		const start = 1000000;
+		jest.setSystemTime( start );
 		const dispatch = jest.fn();
 
 		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
+		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS - 1 );
+		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
 		jest.runAllTimers();
 
-		expect( dispatch ).toHaveBeenCalledWith(
-			fetchAutomatedTransferStatus( siteId, now + TRANSFER_STATUS_POLL_DEADLINE_MS )
+		expect( dispatch ).toHaveBeenCalledWith( fetchAutomatedTransferStatus( siteId ) );
+		expect( dispatch ).not.toHaveBeenCalledWith(
+			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, 'hello-dolly' )
 		);
 	} );
 
-	test( 'should carry the deadline through a poll chain', () => {
-		const pollDeadline = 2000000;
-		jest.setSystemTime( 1000000 );
-		const dispatch = jest.fn();
-
-		receiveStatus( { siteId, pollDeadline }, IN_PROGRESS_RESPONSE )( dispatch );
-		jest.runAllTimers();
-
-		expect( dispatch ).toHaveBeenCalledWith( fetchAutomatedTransferStatus( siteId, pollDeadline ) );
-	} );
-
 	test( 'should set client timeout when the deadline expires', () => {
-		const pollDeadline = 1000000;
-		jest.setSystemTime( pollDeadline );
+		const start = 1000000;
+		jest.setSystemTime( start );
 		const dispatch = jest.fn();
 
-		receiveStatus( { siteId, pollDeadline }, IN_PROGRESS_RESPONSE )( dispatch );
+		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
+		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS );
+		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
 
 		expect( dispatch ).toHaveBeenLastCalledWith(
 			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, 'hello-dolly' )
 		);
+	} );
+
+	test( 'should not let a poll scheduled by an ended wait time out the next one', () => {
+		const start = 1000000;
+		jest.setSystemTime( start );
+		const dispatch = jest.fn();
+
+		// A wait runs long, then ends.
+		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
+		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS - 1 );
+		receiveStatus( { siteId }, COMPLETE_RESPONSE )( dispatch );
+
+		// A poll it had already scheduled lands afterwards, during a new wait.
+		jest.runAllTimers();
+		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
+
 		expect( dispatch ).not.toHaveBeenCalledWith(
-			fetchAutomatedTransferStatus( siteId, pollDeadline )
+			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, 'hello-dolly' )
 		);
 	} );
 
@@ -135,10 +143,13 @@ describe( 'receiveStatus', () => {
 		transferStates.CONFLICTS,
 		transferStates.REVERTED,
 	] )( 'should prefer the settled status %s over an expired deadline', ( status ) => {
-		jest.setSystemTime( 1000000 );
+		const start = 1000000;
+		jest.setSystemTime( start );
 		const dispatch = jest.fn();
 
-		receiveStatus( { siteId, pollDeadline: 999999 }, settledResponse( status ) )( dispatch );
+		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
+		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS + 1 );
+		receiveStatus( { siteId }, settledResponse( status ) )( dispatch );
 
 		expect( dispatch ).not.toHaveBeenCalledWith(
 			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, 'hello-dolly' )
@@ -157,18 +168,16 @@ describe( 'receiveStatus', () => {
 		receiveStatus( { siteId }, settledResponse( status ) )( dispatch );
 		jest.runAllTimers();
 
-		expect( dispatch ).not.toHaveBeenCalledWith(
-			fetchAutomatedTransferStatus( siteId, expect.any( Number ) )
-		);
+		expect( dispatch ).not.toHaveBeenCalledWith( fetchAutomatedTransferStatus( siteId ) );
 	} );
 
-	test( 'should apply the deadline to requests that carry none', () => {
+	test( 'should bound a wait across requests that each look like a fresh start', () => {
 		const start = 1000000;
 		jest.setSystemTime( start );
 		const dispatch = jest.fn();
 
-		// Consumers re-dispatch without a deadline whenever the status changes. That must not
-		// open a fresh window, or the wait is never bounded.
+		// Consumers re-dispatch on every status change. Each of those must join the wait already
+		// in progress rather than opening a fresh window, or the wait is never bounded.
 		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
 		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS + 1 );
 		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
@@ -5,7 +5,12 @@ import {
 } from 'calypso/state/automated-transfer/actions';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
-import { requestStatus, receiveStatus, TRANSFER_STATUS_POLL_DEADLINE_MS } from '../';
+import {
+	requestStatus,
+	receiveStatus,
+	clearPollDeadlines,
+	TRANSFER_STATUS_POLL_DEADLINE_MS,
+} from '../';
 
 const siteId = 1916284;
 
@@ -22,11 +27,11 @@ const IN_PROGRESS_RESPONSE = {
 	uploaded_plugin_slug: 'hello-dolly',
 };
 
-const ERROR_RESPONSE = {
+const settledResponse = ( status ) => ( {
 	blog_id: 1916284,
-	status: 'error',
+	status,
 	uploaded_plugin_slug: 'hello-dolly',
-};
+} );
 
 describe( 'requestStatus', () => {
 	test( 'should dispatch an http request', () => {
@@ -46,6 +51,7 @@ describe( 'requestStatus', () => {
 describe( 'receiveStatus', () => {
 	beforeEach( () => {
 		jest.useFakeTimers();
+		clearPollDeadlines();
 	} );
 	afterEach( () => {
 		jest.useRealTimers();
@@ -121,17 +127,71 @@ describe( 'receiveStatus', () => {
 		);
 	} );
 
-	test.each( [ COMPLETE_RESPONSE, ERROR_RESPONSE ] )(
-		'should prefer terminal status over an expired deadline',
-		( response ) => {
-			jest.setSystemTime( 1000000 );
-			const dispatch = jest.fn();
+	test.each( [
+		transferStates.COMPLETE,
+		transferStates.COMPLETED,
+		transferStates.ERROR,
+		transferStates.FAILURE,
+		transferStates.CONFLICTS,
+		transferStates.REVERTED,
+	] )( 'should prefer the settled status %s over an expired deadline', ( status ) => {
+		jest.setSystemTime( 1000000 );
+		const dispatch = jest.fn();
 
-			receiveStatus( { siteId, pollDeadline: 999999 }, response )( dispatch );
+		receiveStatus( { siteId, pollDeadline: 999999 }, settledResponse( status ) )( dispatch );
 
-			expect( dispatch ).not.toHaveBeenCalledWith(
-				setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, 'hello-dolly' )
-			);
-		}
-	);
+		expect( dispatch ).not.toHaveBeenCalledWith(
+			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, 'hello-dolly' )
+		);
+	} );
+
+	test.each( [
+		transferStates.COMPLETED,
+		transferStates.FAILURE,
+		transferStates.CONFLICTS,
+		transferStates.REVERTED,
+	] )( 'should stop polling on the settled status %s', ( status ) => {
+		jest.setSystemTime( 1000000 );
+		const dispatch = jest.fn();
+
+		receiveStatus( { siteId }, settledResponse( status ) )( dispatch );
+		jest.runAllTimers();
+
+		expect( dispatch ).not.toHaveBeenCalledWith(
+			fetchAutomatedTransferStatus( siteId, expect.any( Number ) )
+		);
+	} );
+
+	test( 'should apply the deadline to requests that carry none', () => {
+		const start = 1000000;
+		jest.setSystemTime( start );
+		const dispatch = jest.fn();
+
+		// Consumers re-dispatch without a deadline whenever the status changes. That must not
+		// open a fresh window, or the wait is never bounded.
+		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
+		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS + 1 );
+		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
+
+		expect( dispatch ).toHaveBeenLastCalledWith(
+			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, 'hello-dolly' )
+		);
+	} );
+
+	test( 'should give a later wait a fresh deadline once one has settled', () => {
+		const start = 1000000;
+		jest.setSystemTime( start );
+		const dispatch = jest.fn();
+
+		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
+		receiveStatus( { siteId }, COMPLETE_RESPONSE )( dispatch );
+
+		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS + 1 );
+		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
+		jest.runAllTimers();
+
+		expect( dispatch ).not.toHaveBeenCalledWith(
+			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, 'hello-dolly' )
+		);
+	} );
 } );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-17962/give-the-transfer-status-poller-a-deadline

## Proposed Changes

**The Atomic transfer status poller now gives up after five minutes and reports a real timeout, instead of polling every three seconds forever.**

- A wall-clock deadline is threaded through the poll chain, so it belongs to the whole wait rather than to each individual request.
- When the deadline expires with the transfer still in progress, the poller sets a new client-only `CLIENT_TIMEOUT` status.
- Every screen that reads the transfer status now handles it: the marketplace thank-you page, the plugin install screen, hosting activation, the staging-site button, and the theme transfer dialog all stop waiting and show their error path.
- `CLIENT_TIMEOUT` is deliberately excluded from persistence. The screens that surface it stop polling once they see it, so a stale value restored from browser storage would render an error with nothing left to clear it.

The five-minute figure matches the deadline already used by the marketplace install screen and the Stepper transfer wait. It is currently duplicated across three places; [DOTCOM-18167](https://linear.app/a8c/issue/DOTCOM-18167) will decide whether five minutes is the right number before that gets consolidated.

## Why are these changes being made?

When someone turns a WordPress.com site into an Atomic site — buying a plugin, activating hosting features, uploading a theme — they land on a waiting screen while the transfer runs. That screen asks the server "are we done yet?" every three seconds, and until now it would keep asking indefinitely.

If the transfer stalled and never reported a final state, nothing ever told the person that something had gone wrong. The progress indicator just kept spinning, with no error, no explanation, and no way out other than closing the tab — including for customers who had just paid for the thing they were waiting on.

This gives the wait an end. After five minutes without a result, the person gets an error they can act on instead of a spinner that never stops. Part of [DOTCOM-17962](https://linear.app/a8c/issue/DOTCOM-17962), in the "make the flow work" milestone.

## Testing Instructions

The timeout is hard to hit naturally, so the quickest check is to shorten it: set `TRANSFER_STATUS_POLL_DEADLINE_MS` in `client/state/data-layer/wpcom/sites/automated-transfer/status/index.js` to a few seconds while testing.

1. Run `yarn start` and log in with a Simple site that is eligible for a transfer.
2. Start a transfer from one of the affected screens — the easiest is activating hosting features from the site's settings, or installing a marketplace plugin.
3. While the waiting screen is up, confirm it now stops after the shortened deadline and shows an error message rather than continuing to spin.
4. Reload the page. The error must be **gone** — you should get a fresh wait or the normal screen, not the previous timeout restored from storage.
5. Repeat on the marketplace thank-you page, the theme upload dialog, and the staging-site button in the site header to confirm each surfaces its own error path once.
6. Restore the constant, then run a real transfer end to end and confirm a normal, successful transfer still completes and redirects as before.
