### PR TITLE
Stepper: hold the last processing message instead of replaying the list

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/test/use-loading-message-index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/test/use-loading-message-index.tsx
@@ -68,6 +68,21 @@ describe( 'useLoadingMessageIndex', () => {
 		expect( result.current ).toBe( 1 );
 	} );
 
+	test( 'keeps moving when a message that is not the last one has an unusable duration', () => {
+		const badDurations: LoadingMessage[] = [
+			{ title: 'First', duration: Infinity },
+			{ title: 'Second', duration: 0 },
+			{ title: 'Third', duration: Infinity },
+		];
+		const { result } = renderHook( () => useLoadingMessageIndex( badDurations ) );
+
+		act( () => void jest.advanceTimersByTime( 5000 ) );
+		expect( result.current ).toBe( 1 );
+
+		act( () => void jest.advanceTimersByTime( 5000 ) );
+		expect( result.current ).toBe( 2 );
+	} );
+
 	test( 'never returns a negative index for an empty list', () => {
 		const { result } = renderHook( () => useLoadingMessageIndex( [] ) );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/test/use-loading-message-index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/test/use-loading-message-index.tsx
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useLoadingMessageIndex } from '../use-loading-message-index';
+import type { LoadingMessage } from '../types';
+
+jest.useFakeTimers();
+
+const THREE_MESSAGES: LoadingMessage[] = [
+	{ title: 'First', duration: 1000 },
+	{ title: 'Second', duration: 1000 },
+	{ title: 'Third', duration: Infinity },
+];
+
+describe( 'useLoadingMessageIndex', () => {
+	test( 'advances through the list', () => {
+		const { result } = renderHook( () => useLoadingMessageIndex( THREE_MESSAGES ) );
+
+		expect( result.current ).toBe( 0 );
+
+		act( () => void jest.advanceTimersByTime( 1000 ) );
+		expect( result.current ).toBe( 1 );
+
+		act( () => void jest.advanceTimersByTime( 1000 ) );
+		expect( result.current ).toBe( 2 );
+	} );
+
+	test( 'holds on the last message instead of wrapping', () => {
+		const { result } = renderHook( () => useLoadingMessageIndex( THREE_MESSAGES ) );
+
+		act( () => void jest.advanceTimersByTime( 60000 ) );
+
+		expect( result.current ).toBe( 2 );
+	} );
+
+	test( 'stops scheduling once the terminal message is reached', () => {
+		const setIntervalSpy = jest.spyOn( window, 'setInterval' );
+		renderHook( () => useLoadingMessageIndex( THREE_MESSAGES ) );
+
+		act( () => void jest.advanceTimersByTime( 60000 ) );
+		const callsAtHold = setIntervalSpy.mock.calls.length;
+
+		act( () => void jest.advanceTimersByTime( 60000 ) );
+
+		expect( setIntervalSpy.mock.calls.length ).toBe( callsAtHold );
+		setIntervalSpy.mockRestore();
+	} );
+
+	test( 'restarts from the first message when the list changes length', () => {
+		const shortList: LoadingMessage[] = [
+			{ title: 'Only', duration: 1000 },
+			{ title: 'Last', duration: Infinity },
+		];
+		const { result, rerender } = renderHook(
+			( { messages }: { messages: LoadingMessage[] } ) => useLoadingMessageIndex( messages ),
+			{ initialProps: { messages: THREE_MESSAGES } }
+		);
+
+		act( () => void jest.advanceTimersByTime( 2000 ) );
+		expect( result.current ).toBe( 2 );
+
+		rerender( { messages: shortList } );
+		expect( result.current ).toBe( 0 );
+
+		act( () => void jest.advanceTimersByTime( 1000 ) );
+		expect( result.current ).toBe( 1 );
+	} );
+
+	test( 'never returns a negative index for an empty list', () => {
+		const { result } = renderHook( () => useLoadingMessageIndex( [] ) );
+
+		expect( result.current ).toBe( 0 );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/types.ts
@@ -4,8 +4,9 @@ export interface LoadingMessage {
 	title: string;
 	subtitle?: string | React.ReactNode;
 	/**
-	 * How long to show this message, in milliseconds. `Infinity` holds it
-	 * indefinitely and is only valid on the final entry of a list.
+	 * How long to show this message, in milliseconds. The last entry of a list always holds
+	 * until the wait ends, whatever its duration; `Infinity` there records that intent.
+	 * Anywhere else a non-positive or non-finite duration falls back to a default.
 	 */
 	duration: number;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/types.ts
@@ -3,5 +3,9 @@ import React from 'react';
 export interface LoadingMessage {
 	title: string;
 	subtitle?: string | React.ReactNode;
+	/**
+	 * How long to show this message, in milliseconds. `Infinity` holds it
+	 * indefinitely and is only valid on the final entry of a list.
+	 */
 	duration: number;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-loading-message-index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-loading-message-index.ts
@@ -2,6 +2,16 @@ import { useEffect, useState } from 'react';
 import { useInterval } from 'calypso/lib/interval';
 import type { LoadingMessage } from './types';
 
+// Used when a message that is not the last one carries a duration the interval cannot honour.
+// These lists are copy, edited by people who do not own this hook, and a delay of `Infinity`,
+// `0` or `NaN` mid-list would otherwise hold that message for the whole wait.
+const FALLBACK_DURATION_MS = 5000;
+
+const durationOf = ( message?: LoadingMessage ): number => {
+	const duration = message?.duration ?? 0;
+	return Number.isFinite( duration ) && duration > 0 ? duration : FALLBACK_DURATION_MS;
+};
+
 /**
  * Walk forward through a list of loading messages and hold on the last one.
  *
@@ -20,7 +30,9 @@ export function useLoadingMessageIndex( loadingMessages: LoadingMessage[] ): num
 
 	useInterval(
 		() => setCurrentMessageIndex( ( index ) => Math.min( index + 1, lastMessageIndex ) ),
-		currentMessageIndex < lastMessageIndex ? loadingMessages[ currentMessageIndex ]?.duration : null
+		currentMessageIndex < lastMessageIndex
+			? durationOf( loadingMessages[ currentMessageIndex ] )
+			: null
 	);
 
 	return Math.max( 0, Math.min( currentMessageIndex, lastMessageIndex ) );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-loading-message-index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-loading-message-index.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { useInterval } from 'calypso/lib/interval';
+import type { LoadingMessage } from './types';
+
+/**
+ * Walk forward through a list of loading messages and hold on the last one.
+ *
+ * The list can change identity mid-wait (it depends on an intent that resolves
+ * asynchronously), so the index resets whenever the list length changes.
+ * @param loadingMessages The messages to walk through.
+ * @returns The index of the message to display.
+ */
+export function useLoadingMessageIndex( loadingMessages: LoadingMessage[] ): number {
+	const [ currentMessageIndex, setCurrentMessageIndex ] = useState( 0 );
+	const lastMessageIndex = loadingMessages.length - 1;
+
+	useEffect( () => {
+		setCurrentMessageIndex( 0 );
+	}, [ loadingMessages.length ] );
+
+	useInterval(
+		() => setCurrentMessageIndex( ( index ) => Math.min( index + 1, lastMessageIndex ) ),
+		currentMessageIndex < lastMessageIndex ? loadingMessages[ currentMessageIndex ]?.duration : null
+	);
+
+	return Math.max( 0, Math.min( currentMessageIndex, lastMessageIndex ) );
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.tsx
@@ -37,11 +37,11 @@ export function useProcessingLoadingMessages( flow?: string | null ): LoadingMes
 
 	if ( flow && isTransferringHostedSiteCreationFlow( flow ) ) {
 		return [
-			{ title: __( 'Preparing your new server' ), duration: 15000 },
-			{ title: __( 'Installing WordPress' ), duration: 10000 },
-			{ title: __( 'Copying your site' ), duration: 20000 },
-			{ title: __( 'Securing your connection' ), duration: 15000 },
-			{ title: __( 'Distributing your site worldwide' ), duration: 20000 },
+			{ title: __( 'Preparing your new server' ), duration: 14000 },
+			{ title: __( 'Installing WordPress' ), duration: 6000 },
+			{ title: __( 'Copying your site' ), duration: 9000 },
+			{ title: __( 'Securing your connection' ), duration: 5000 },
+			{ title: __( 'Distributing your site worldwide' ), duration: 6000 },
 			{ title: __( 'Finishing up — this can take a few minutes' ), duration: Infinity },
 		];
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.tsx
@@ -37,12 +37,12 @@ export function useProcessingLoadingMessages( flow?: string | null ): LoadingMes
 
 	if ( flow && isTransferringHostedSiteCreationFlow( flow ) ) {
 		return [
-			{ title: __( 'Laying the foundations' ), duration: 5000 },
-			{ title: __( 'Warming up CPUs' ), duration: 3000 },
-			{ title: __( 'Installing WordPress' ), duration: 3000 },
-			{ title: __( 'Securing your data' ), duration: 5000 },
-			{ title: __( 'Distributing your site worldwide' ), duration: 5000 },
-			{ title: __( 'Closing the loop' ), duration: Infinity },
+			{ title: __( 'Preparing your new server' ), duration: 15000 },
+			{ title: __( 'Installing WordPress' ), duration: 10000 },
+			{ title: __( 'Copying your site' ), duration: 20000 },
+			{ title: __( 'Securing your connection' ), duration: 15000 },
+			{ title: __( 'Distributing your site worldwide' ), duration: 20000 },
+			{ title: __( 'Finishing up — this can take a few minutes' ), duration: Infinity },
 		];
 	}
 
@@ -52,6 +52,7 @@ export function useProcessingLoadingMessages( flow?: string | null ): LoadingMes
 			{ title: __( 'Securing your data' ), duration: 4500 },
 			{ title: __( 'Enabling encryption' ), duration: 5000 },
 			{ title: __( 'Applying a shiny top coat' ), duration: 4000 },
+			{ title: __( 'Finishing up — this can take a few minutes' ), duration: Infinity },
 		];
 	}
 
@@ -62,6 +63,7 @@ export function useProcessingLoadingMessages( flow?: string | null ): LoadingMes
 				{ title: __( 'Enabling encryption' ), duration: 3000 },
 				{ title: __( 'Applying a shiny top coat' ), duration: 4000 },
 				{ title: __( 'Closing the loop' ), duration: 4000 },
+				{ title: __( 'Finishing up — this can take a few minutes' ), duration: Infinity },
 			];
 			break;
 		case SiteIntent.Sell:
@@ -71,6 +73,7 @@ export function useProcessingLoadingMessages( flow?: string | null ): LoadingMes
 				{ title: __( 'Enabling encryption' ), duration: 3000 },
 				{ title: __( 'Applying a shiny top coat' ), duration: 4000 },
 				{ title: __( 'Closing the loop' ), duration: 5000 },
+				{ title: __( 'Finishing up — this can take a few minutes' ), duration: Infinity },
 			];
 			break;
 		default:
@@ -85,6 +88,7 @@ export function useProcessingLoadingMessages( flow?: string | null ): LoadingMes
 				{ title: __( 'Optimizing your content' ), duration: 6000 },
 				{ title: __( 'Applying a shiny top coat' ), duration: 4000 },
 				{ title: __( 'Closing the loop' ), duration: 5000 },
+				{ title: __( 'Finishing up — this can take a few minutes' ), duration: Infinity },
 			];
 			break;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -20,11 +20,11 @@ import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordSignupProcessingScreen } from 'calypso/lib/analytics/signup';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useWaitHeartbeat } from 'calypso/lib/analytics/wait-heartbeat';
-import { useInterval } from 'calypso/lib/interval';
 import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 import useCaptureFlowException from '../../../../hooks/use-capture-flow-exception';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import { ProcessingResult } from './constants';
+import { useLoadingMessageIndex } from './hooks/use-loading-message-index';
 import { useProcessingLoadingMessages } from './hooks/use-processing-loading-messages';
 import HundredYearPlanFlowProcessingScreen from './hundred-year-plan-flow-processing-screen';
 import TailoredFlowPreCheckoutScreen from './tailored-flow-precheckout-screen';
@@ -67,12 +67,12 @@ const ProcessingStep: StepType< {
 	const { __ } = useI18n();
 	const loadingMessages = useProcessingLoadingMessages( flow );
 
-	const [ currentMessageIndex, setCurrentMessageIndex ] = useState( 0 );
 	const [ hasActionSuccessfullyRun, setHasActionSuccessfullyRun ] = useState( false );
 	const [ hasEmptyActionRun, setHasEmptyActionRun ] = useState( false );
 	const [ destinationState, setDestinationState ] = useState<
 		{ siteCreated?: boolean } | undefined
 	>( {} );
+	const safeMessageIndex = useLoadingMessageIndex( loadingMessages );
 
 	/**
 	 * There is a long-term bug here that the `submit` function will be called multiple times if we
@@ -97,13 +97,6 @@ const ProcessingStep: StepType< {
 	const isSubmittedRef = useRef( false );
 
 	const recordSignupComplete = useRecordSignupComplete( flow );
-
-	useInterval(
-		() => {
-			setCurrentMessageIndex( ( s ) => ( s + 1 ) % loadingMessages.length );
-		},
-		loadingMessages[ currentMessageIndex ]?.duration
-	);
 
 	const action = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getPendingAction(),
@@ -138,7 +131,7 @@ const ProcessingStep: StepType< {
 	} );
 
 	const getCurrentMessage = () => {
-		return props.title || progressTitle || loadingMessages[ currentMessageIndex ]?.title;
+		return props.title || progressTitle || loadingMessages[ safeMessageIndex ]?.title;
 	};
 
 	const captureFlowException = useCaptureFlowException( props.flow, 'ProcessingStep' );
@@ -234,7 +227,7 @@ const ProcessingStep: StepType< {
 	}, [ hasActionSuccessfullyRun, recordSignupComplete, flow ] );
 
 	const getSubtitle = () => {
-		return props.subtitle || loadingMessages[ currentMessageIndex ]?.subtitle;
+		return props.subtitle || loadingMessages[ safeMessageIndex ]?.subtitle;
 	};
 
 	const flowName = props.flow || '';

--- a/client/lib/interval/test/use-interval.tsx
+++ b/client/lib/interval/test/use-interval.tsx
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from '@testing-library/react';
+import { useInterval } from '../use-interval';
+import type { TimeoutMS } from 'calypso/types';
+
+jest.useFakeTimers();
+
+type TestComponentProps = {
+	delay: TimeoutMS | null | false;
+	callback: () => void;
+};
+
+function TestComponent( { delay, callback }: TestComponentProps ) {
+	useInterval( callback, delay );
+	return null;
+}
+
+describe( 'useInterval', () => {
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	test( 'runs callback at finite delay', () => {
+		const callback = jest.fn();
+
+		render( <TestComponent callback={ callback } delay={ 1000 } /> );
+		jest.advanceTimersByTime( 1000 );
+
+		expect( callback ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'does not run callback when delay is null', () => {
+		const callback = jest.fn();
+
+		render( <TestComponent callback={ callback } delay={ null } /> );
+		jest.advanceTimersByTime( 1000 );
+
+		expect( callback ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does not run callback when delay is false', () => {
+		const callback = jest.fn();
+
+		render( <TestComponent callback={ callback } delay={ false } /> );
+		jest.advanceTimersByTime( 1000 );
+
+		expect( callback ).not.toHaveBeenCalled();
+	} );
+
+	test.each( [ Infinity, NaN ] )( 'does not schedule a non-finite delay: %s', ( delay ) => {
+		const callback = jest.fn();
+		const setIntervalSpy = jest.spyOn( window, 'setInterval' );
+
+		render( <TestComponent callback={ callback } delay={ delay } /> );
+		jest.advanceTimersByTime( 1000 );
+
+		expect( setIntervalSpy ).not.toHaveBeenCalled();
+		expect( callback ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does not schedule a non-positive delay', () => {
+		const callback = jest.fn();
+		const setIntervalSpy = jest.spyOn( window, 'setInterval' );
+
+		render( <TestComponent callback={ callback } delay={ 0 } /> );
+		jest.advanceTimersByTime( 1000 );
+
+		expect( setIntervalSpy ).not.toHaveBeenCalled();
+		expect( callback ).not.toHaveBeenCalled();
+	} );
+
+	test( 'clears the running interval when the delay becomes Infinity', () => {
+		const callback = jest.fn();
+		const { rerender } = render( <TestComponent callback={ callback } delay={ 1000 } /> );
+
+		jest.advanceTimersByTime( 1000 );
+		rerender( <TestComponent callback={ callback } delay={ Infinity } /> );
+		jest.advanceTimersByTime( 5000 );
+
+		expect( callback ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'starts an interval when the delay changes from Infinity to finite', () => {
+		const callback = jest.fn();
+		const { rerender } = render( <TestComponent callback={ callback } delay={ Infinity } /> );
+
+		jest.advanceTimersByTime( 5000 );
+		expect( callback ).not.toHaveBeenCalled();
+
+		rerender( <TestComponent callback={ callback } delay={ 1000 } /> );
+		jest.advanceTimersByTime( 1000 );
+
+		expect( callback ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'clears interval when delay changes to null', () => {
+		const callback = jest.fn();
+		const { rerender } = render( <TestComponent callback={ callback } delay={ 1000 } /> );
+
+		jest.advanceTimersByTime( 1000 );
+		rerender( <TestComponent callback={ callback } delay={ null } /> );
+		jest.advanceTimersByTime( 1000 );
+
+		expect( callback ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/client/lib/interval/use-interval.ts
+++ b/client/lib/interval/use-interval.ts
@@ -12,7 +12,8 @@ import type { TimeoutMS } from 'calypso/types';
 /**
  * Invoke a function on an interval.
  * @param callback Function to invoke
- * @param delay    Interval timout in MS. `null` or `false` to stop the interval.
+ * @param delay    Interval timeout in MS. `null`, `false`, or a value that is not a positive
+ *                 finite number to stop the interval.
  */
 export function useInterval( callback: () => void, delay: TimeoutMS | null | false ) {
 	const savedCallback = useRef( callback );
@@ -24,7 +25,7 @@ export function useInterval( callback: () => void, delay: TimeoutMS | null | fal
 
 	// Set up the interval.
 	useEffect( () => {
-		if ( delay === null || delay === false ) {
+		if ( delay === null || delay === false || ! Number.isFinite( delay ) || delay <= 0 ) {
 			return;
 		}
 		const tick = () => void savedCallback.current();

--- a/packages/help-center/src/hooks/use-typer.ts
+++ b/packages/help-center/src/hooks/use-typer.ts
@@ -57,7 +57,7 @@ export default function useTyper(
 
 	const populatedOptions: Options = { ...DEFAULT_OPTIONS, ...options };
 	const delayBetweenCharacters = populatedOptions.randomDelayBetweenCharacters
-		? Math.random() * populatedOptions.delayBetweenCharacters
+		? Math.max( 1, Math.random() * populatedOptions.delayBetweenCharacters )
 		: populatedOptions.delayBetweenCharacters;
 
 	const delayInCharacters = populatedOptions.randomDelayBetweenCharacters


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-18111/stepper-wait-screens-replay-the-same-loading-messages-forever-the-stay

## Proposed Changes

**Onboarding wait screens now walk through their loading messages once and hold on the last one, instead of replaying the whole list forever.**

- `useInterval` stops for any delay that is not a positive finite number. `Infinity` used to fall through to `setInterval`, which the HTML spec coerces to `0` — so the message meant to stay put ticked every few milliseconds.
- The message index walks forward and stops at the end rather than wrapping. It now lives in a small `useLoadingMessageIndex` hook, which also resets when the list changes length: the list depends on an intent that resolves asynchronously, and a shorter list arriving mid-wait would otherwise strand the screen on its final message.
- Every message list gets a terminal message to hold on, so no flow ends up frozen on a mid-flow string like “Applying a shiny top coat”.
- The Atomic transfer list is rewritten to describe the stages a transfer actually goes through, over roughly the time it actually takes. Copy is adjustable pending the wider pass in [DOTCOM-17968](https://linear.app/a8c/issue/DOTCOM-17968).

## Why are these changes being made?

When someone moves a site to Atomic hosting, they sit on a waiting screen that cycles through short status messages while the work happens in the background. The last message is supposed to be the reassuring one — “this is taking a while, stay here” — and it is supposed to stay on screen until the transfer finishes.

It didn’t. Because of a timer bug it flashed past instantly and the screen started the list again from the top, so people watched the same handful of messages loop over and over. On a wait that can run past a minute, that reads as a stuck page rather than a working one — the exact opposite of what the reassuring message is for.

The screen now tells a story that moves forward once and then settles, which is both honest about what is happening and readable as progress.

## Testing Instructions

1. Run `yarn start`.
2. Start a transfer to hosted-site onboarding — `/setup/transferring-hosted-site` for an eligible site is the most direct route. This flow shows no progress bar, so the messages are the only sign of life.
3. Watch the whole wait. The messages should step forward once through the list and then stop on “Finishing up — this can take a few minutes”, staying there until the transfer completes. They must never restart from the first message.
4. Run a `copy-site` flow and confirm it likewise ends on a holding message rather than freezing on a mid-flow one.
5. Run an ordinary site-creation flow (and, if convenient, a store or DIFM one) to confirm the messages still advance normally and the step still completes and redirects as before.
