### PR TITLE
Image Studio: Send annotation state to the backend

### DIFF
--- a/packages/image-studio/src/utils/client-context.test.ts
+++ b/packages/image-studio/src/utils/client-context.test.ts
@@ -35,12 +35,13 @@ jest.mock( '../stores/video-studio', () => ( {
 import { getClientContext } from './client-context';
 
 interface ImageStoreSelectors {
-	getImageStudioAttachmentId?: () => number | null;
+	getImageStudioAttachmentId?: () => number | null | undefined;
 	getIsImageStudioOpen?: () => boolean;
 	getSelectedStyle?: () => string | null;
 	getSelectedAspectRatio?: () => string | null;
 	getEntryPoint?: () => string | null;
 	getBlockType?: () => string | null;
+	getAnnotatedAttachmentIds?: () => number[];
 }
 
 interface VideoStoreSelectors {
@@ -100,6 +101,7 @@ describe( 'getClientContext', () => {
 				getSelectedAspectRatio: () => '16:9',
 				getEntryPoint: () => 'media_library',
 				getBlockType: () => null,
+				getAnnotatedAttachmentIds: () => [],
 			},
 			videoStudio: {
 				getSelectedStyle: () => null,
@@ -112,6 +114,7 @@ describe( 'getClientContext', () => {
 		expect( ctx.imageStudio ).toMatchObject( {
 			isOpen: true,
 			id: 42,
+			isAnnotated: false,
 			style: 'cinematic',
 			aspect_ratio: '16:9',
 			entryPoint: 'media_library',
@@ -129,6 +132,7 @@ describe( 'getClientContext', () => {
 				getSelectedAspectRatio: () => '9:16',
 				getEntryPoint: () => 'post_editor_feature_clip',
 				getBlockType: () => null,
+				getAnnotatedAttachmentIds: () => [ 42 ],
 			},
 			videoStudio: {
 				getSelectedStyle: () => 'cinematic',
@@ -149,7 +153,56 @@ describe( 'getClientContext', () => {
 		expect( ctx.videoStudio ).not.toHaveProperty( 'aspect_ratio' );
 		// Tone has been collapsed into style; the videoStudio payload no longer carries it.
 		expect( ctx.videoStudio ).not.toHaveProperty( 'tone' );
+		expect( ctx.videoStudio ).not.toHaveProperty( 'isAnnotated' );
 	} );
+
+	it( 'emits true when the current image attachment is annotated', () => {
+		setupSelect( {
+			imageStudio: {
+				getImageStudioAttachmentId: () => 42,
+				getIsImageStudioOpen: () => true,
+				getEntryPoint: () => 'media_library',
+				getAnnotatedAttachmentIds: () => [ 42 ],
+			},
+		} );
+
+		const ctx = getClientContext();
+
+		expect( ctx.imageStudio?.isAnnotated ).toBe( true );
+	} );
+
+	it( 'emits false when a different image attachment is annotated', () => {
+		setupSelect( {
+			imageStudio: {
+				getImageStudioAttachmentId: () => 42,
+				getIsImageStudioOpen: () => true,
+				getEntryPoint: () => 'media_library',
+				getAnnotatedAttachmentIds: () => [ 41, 43 ],
+			},
+		} );
+
+		const ctx = getClientContext();
+
+		expect( ctx.imageStudio?.isAnnotated ).toBe( false );
+	} );
+
+	it.each( [ undefined, null ] )(
+		'emits false when the image attachment ID is %s',
+		( attachmentId ) => {
+			setupSelect( {
+				imageStudio: {
+					getImageStudioAttachmentId: () => attachmentId,
+					getIsImageStudioOpen: () => true,
+					getEntryPoint: () => 'media_library',
+					getAnnotatedAttachmentIds: () => [ 42 ],
+				},
+			} );
+
+			const ctx = getClientContext();
+
+			expect( ctx.imageStudio?.isAnnotated ).toBe( false );
+		}
+	);
 
 	it( 'includes the current post title in the videoStudio payload when available', () => {
 		setupSelect( {

--- a/packages/image-studio/src/utils/client-context.ts
+++ b/packages/image-studio/src/utils/client-context.ts
@@ -24,6 +24,7 @@ export interface ImageStudioMetadata {
 export interface ImageStudioData {
 	isOpen: boolean;
 	id: number | null;
+	isAnnotated: boolean;
 	style?: string;
 	aspect_ratio?: string;
 	metadata: ImageStudioMetadata;
@@ -299,9 +300,12 @@ function detectImageEntity(): DetectedEntity | null {
 			return { videoStudio, isOpen, isVideo: true };
 		}
 
+		const annotatedAttachmentIds = storeSelect.getAnnotatedAttachmentIds?.() || [];
 		const imageStudio: ImageStudioData = {
 			isOpen,
 			id: attachmentId,
+			isAnnotated:
+				typeof attachmentId === 'number' && annotatedAttachmentIds.includes( attachmentId ),
 			entryPoint, // 'editor_block' | 'media_library' | etc.
 			blockType, // 'core/image' | etc.
 			metadata,


### PR DESCRIPTION
## Proposed Changes

* Add `imageStudio.isAnnotated` to the Image Studio client context.
* Derive the flag from the current numeric attachment ID and the annotation store.
* Keep the field out of the Video Studio payload.
* Cover annotated, unannotated, missing-ID, and video cases.

## Why are these changes being made?

Image Studio knows whether the current attachment contains user-drawn annotations, but text orchestration cannot inspect the image pixels. Publishing this boolean gives the backend a deterministic signal when an annotated edit is misclassified as a new generation.

This is the producer half of a coordinated client/server rollout. Older servers safely ignore the additional context field.

## Testing Instructions

1. Run `yarn test-packages packages/image-studio`.
2. Run `yarn eslint packages/image-studio/src/utils/client-context.ts packages/image-studio/src/utils/client-context.test.ts`.
3. Run `yarn typecheck-packages`.
4. Run `yarn workspace @automattic/image-studio build`.
5. Run `yarn workspace @automattic/agents-manager-app build`.
6. Sync the Image Studio bundle and companion backend change to a sandbox.
7. Annotate an existing image and submit an edit such as “make it taller.” Confirm the existing image is edited and the blue marks are removed.
8. Generate a different image while an unannotated attachment remains selected. Confirm it stays a generation.

Results:

* 38 Image Studio suites and 1,024 tests passed.
* Changed-file ESLint and the full package typecheck passed.
* Image Studio and Agents Manager production builds passed.
* Annotated edits produced the expected output on the sandbox.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks/useSelector) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
