### PR TITLE
Zendesk config telemetry: report once per shared query resolution

### DIFF
--- a/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
@@ -19,7 +19,8 @@ type ReportingState = {
 /**
  * Keyed on the cached query rather than the client, so the state dies with the query it
  * describes. An evicted query comes back as a fresh instance whose update counters restart
- * at zero, and reusing the old state would read that as a repeat and stay silent.
+ * at zero, and reusing the old state would read that as a repeat and stay silent. A reset
+ * keeps the instance and rewinds the counters, which the resolution key handles instead.
  *
  * Module-scoped because every observer of one query has to share it; a ref would be
  * per-component, which is the duplication this guards against.
@@ -66,7 +67,10 @@ export function useCanConnectToZendeskMessaging( enabled = true ) {
 	} );
 
 	useEffect( () => {
-		const cachedQuery = queryClient.getQueryCache().find( { queryKey: QUERY_KEY } );
+		// `exact`, because the default is a prefix match: a query keyed
+		// `[ 'canConnectToZendesk', siteId ]` would match too, and which one comes back
+		// depends on cache iteration order.
+		const cachedQuery = queryClient.getQueryCache().find( { queryKey: QUERY_KEY, exact: true } );
 
 		if ( ! cachedQuery ) {
 			return;
@@ -88,11 +92,18 @@ export function useCanConnectToZendeskMessaging( enabled = true ) {
 			return;
 		}
 
-		// The update counters are per-query and monotonic. Timestamps are neither: two
-		// resolutions inside one millisecond collapse, and `errorUpdatedAt` is recomputed per
-		// observer whenever `select` throws.
-		const { dataUpdateCount, errorUpdateCount } = cachedQuery.state;
-		const resolutionKey = `${ query.status }:${ dataUpdateCount }:${ errorUpdateCount }`;
+		// All five come off the cache entry, not the observer snapshot, so they describe one
+		// resolution. The counters separate two resolutions landing in the same millisecond;
+		// the timestamps separate resolutions either side of a `resetQueries`, which rewinds
+		// the counters on the same Query object.
+		const { dataUpdateCount, errorUpdateCount, dataUpdatedAt, errorUpdatedAt } = cachedQuery.state;
+		const resolutionKey = [
+			query.status,
+			dataUpdateCount,
+			errorUpdateCount,
+			dataUpdatedAt,
+			errorUpdatedAt,
+		].join( ':' );
 
 		if ( reportingState.lastResolutionKey === resolutionKey ) {
 			return;
@@ -118,6 +129,10 @@ export function useCanConnectToZendeskMessaging( enabled = true ) {
 			failure_count: failureCount,
 			reporting_version: REPORTING_VERSION,
 		} );
+		// The two timestamps look redundant next to `fetchStatus`, which already cycles on
+		// every network refetch. They are what re-runs this for a resolution that leaves
+		// `fetchStatus` untouched: a manual `setQueryData`, or the refetch that follows a
+		// `resetQueries` and lands on the counters it started from.
 	}, [
 		query.data,
 		query.dataUpdatedAt,

--- a/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { hashKey, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from '@wordpress/element';
-import type { QueryClient } from '@tanstack/react-query';
+import type { Query } from '@tanstack/react-query';
 
 const QUERY_KEY = [ 'canConnectToZendesk' ];
 
@@ -17,24 +17,21 @@ type ReportingState = {
 };
 
 /**
- * Module-scoped because every observer of the same query has to share it. A ref would be
+ * Keyed on the cached query rather than the client, so the state dies with the query it
+ * describes. An evicted query comes back as a fresh instance whose update counters restart
+ * at zero, and reusing the old state would read that as a repeat and stay silent.
+ *
+ * Module-scoped because every observer of one query has to share it; a ref would be
  * per-component, which is the duplication this guards against.
  */
-const reportingStates = new WeakMap< QueryClient, Map< string, ReportingState > >();
+const reportingStates = new WeakMap< Query, ReportingState >();
 
-function getReportingState( queryClient: QueryClient, queryKeyHash: string ): ReportingState {
-	let byQueryKey = reportingStates.get( queryClient );
-
-	if ( ! byQueryKey ) {
-		byQueryKey = new Map();
-		reportingStates.set( queryClient, byQueryKey );
-	}
-
-	let state = byQueryKey.get( queryKeyHash );
+function getReportingState( cachedQuery: Query ): ReportingState {
+	let state = reportingStates.get( cachedQuery );
 
 	if ( ! state ) {
 		state = { peakFailureCount: 0 };
-		byQueryKey.set( queryKeyHash, state );
+		reportingStates.set( cachedQuery, state );
 	}
 
 	return state;
@@ -69,25 +66,33 @@ export function useCanConnectToZendeskMessaging( enabled = true ) {
 	} );
 
 	useEffect( () => {
-		const reportingState = getReportingState( queryClient, hashKey( QUERY_KEY ) );
+		const cachedQuery = queryClient.getQueryCache().find( { queryKey: QUERY_KEY } );
 
-		if ( query.status === 'pending' ) {
+		if ( ! cachedQuery ) {
+			return;
+		}
+
+		const reportingState = getReportingState( cachedQuery );
+
+		if ( query.fetchStatus !== 'idle' ) {
 			// A success resets `failureCount` to 0, so retries that ended in recovery are only
-			// visible while the query is still in flight.
+			// visible while the fetch is still running. A refetch over cached data keeps
+			// `status` at 'success' throughout, which is why this tracks `fetchStatus`.
 			reportingState.peakFailureCount = Math.max(
 				reportingState.peakFailureCount,
 				query.failureCount
 			);
+		}
+
+		if ( query.status === 'pending' ) {
 			return;
 		}
 
 		// The update counters are per-query and monotonic. Timestamps are neither: two
 		// resolutions inside one millisecond collapse, and `errorUpdatedAt` is recomputed per
 		// observer whenever `select` throws.
-		const queryState = queryClient.getQueryState( QUERY_KEY );
-		const resolutionKey = `${ query.status }:${ queryState?.dataUpdateCount ?? 0 }:${
-			queryState?.errorUpdateCount ?? 0
-		}`;
+		const { dataUpdateCount, errorUpdateCount } = cachedQuery.state;
+		const resolutionKey = `${ query.status }:${ dataUpdateCount }:${ errorUpdateCount }`;
 
 		if ( reportingState.lastResolutionKey === resolutionKey ) {
 			return;
@@ -119,6 +124,7 @@ export function useCanConnectToZendeskMessaging( enabled = true ) {
 		query.error?.message,
 		query.errorUpdatedAt,
 		query.failureCount,
+		query.fetchStatus,
 		query.status,
 		queryClient,
 	] );

--- a/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
@@ -1,6 +1,44 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useQuery } from '@tanstack/react-query';
+import { hashKey, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from '@wordpress/element';
+import type { QueryClient } from '@tanstack/react-query';
+
+const QUERY_KEY = [ 'canConnectToZendesk' ];
+
+/**
+ * Bump when the meaning of the events below changes, so Superset can tell old rows from new
+ * ones. Version 2 reports once per settled query instead of once per observer per state.
+ */
+const REPORTING_VERSION = 2;
+
+type ReportingState = {
+	lastResolutionKey?: string;
+	peakFailureCount: number;
+};
+
+/**
+ * Module-scoped because every observer of the same query has to share it. A ref would be
+ * per-component, which is the duplication this guards against.
+ */
+const reportingStates = new WeakMap< QueryClient, Map< string, ReportingState > >();
+
+function getReportingState( queryClient: QueryClient, queryKeyHash: string ): ReportingState {
+	let byQueryKey = reportingStates.get( queryClient );
+
+	if ( ! byQueryKey ) {
+		byQueryKey = new Map();
+		reportingStates.set( queryClient, byQueryKey );
+	}
+
+	let state = byQueryKey.get( queryKeyHash );
+
+	if ( ! state ) {
+		state = { peakFailureCount: 0 };
+		byQueryKey.set( queryKeyHash, state );
+	}
+
+	return state;
+}
 
 function fetchZendeskConfig() {
 	// Parse the JSON to throw errors for all non-success responses
@@ -11,8 +49,9 @@ function fetchZendeskConfig() {
  * This hook verifies connectivity to Zendesk's messaging service by making a config request and manages automatic retries with error tracking.
  */
 export function useCanConnectToZendeskMessaging( enabled = true ) {
+	const queryClient = useQueryClient();
 	const query = useQuery< boolean, Error >( {
-		queryKey: [ 'canConnectToZendesk' ],
+		queryKey: QUERY_KEY,
 		queryFn: fetchZendeskConfig,
 		staleTime: Infinity,
 		// Retry 3 times with a 1 second delay between each retry
@@ -30,20 +69,59 @@ export function useCanConnectToZendeskMessaging( enabled = true ) {
 	} );
 
 	useEffect( () => {
+		const reportingState = getReportingState( queryClient, hashKey( QUERY_KEY ) );
+
+		if ( query.status === 'pending' ) {
+			// A success resets `failureCount` to 0, so retries that ended in recovery are only
+			// visible while the query is still in flight.
+			reportingState.peakFailureCount = Math.max(
+				reportingState.peakFailureCount,
+				query.failureCount
+			);
+			return;
+		}
+
+		// The update counters are per-query and monotonic. Timestamps are neither: two
+		// resolutions inside one millisecond collapse, and `errorUpdatedAt` is recomputed per
+		// observer whenever `select` throws.
+		const queryState = queryClient.getQueryState( QUERY_KEY );
+		const resolutionKey = `${ query.status }:${ queryState?.dataUpdateCount ?? 0 }:${
+			queryState?.errorUpdateCount ?? 0
+		}`;
+
+		if ( reportingState.lastResolutionKey === resolutionKey ) {
+			return;
+		}
+
+		reportingState.lastResolutionKey = resolutionKey;
+
+		const failureCount = Math.max( reportingState.peakFailureCount, query.failureCount );
+		reportingState.peakFailureCount = 0;
+
 		// Leaving for backwards compatibility. This event is no longer needed. The one below is more general.
-		if ( ! query.data && query.status !== 'pending' ) {
+		if ( ! query.data ) {
 			recordTracksEvent( 'calypso_helpcenter_zendesk_config_error', {
 				status: query.status,
 				status_text: query.error?.message,
+				reporting_version: REPORTING_VERSION,
 			} );
 		}
 
 		recordTracksEvent( 'calypso_helpcenter_zendesk_config_request', {
 			status: query.status,
 			status_text: query.error?.message,
-			failure_count: query.failureCount,
+			failure_count: failureCount,
+			reporting_version: REPORTING_VERSION,
 		} );
-	}, [ query.data, query.error?.message, query.status, query.failureCount ] );
+	}, [
+		query.data,
+		query.dataUpdatedAt,
+		query.error?.message,
+		query.errorUpdatedAt,
+		query.failureCount,
+		query.status,
+		queryClient,
+	] );
 
 	return query;
 }

--- a/packages/zendesk-client/test/use-can-connect-to-zendesk-messaging.test.tsx
+++ b/packages/zendesk-client/test/use-can-connect-to-zendesk-messaging.test.tsx
@@ -1,0 +1,223 @@
+/**
+ * @jest-environment jsdom
+ */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { useCanConnectToZendeskMessaging } from '../src/use-can-connect-to-zendesk-messaging';
+import type { ReactNode } from 'react';
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	...jest.requireActual( '@automattic/calypso-analytics' ),
+	recordTracksEvent: jest.fn(),
+} ) );
+
+const REQUEST_EVENT = 'calypso_helpcenter_zendesk_config_request';
+const ERROR_EVENT = 'calypso_helpcenter_zendesk_config_error';
+const REPORTING_VERSION = 2;
+const fetchMock = jest.fn();
+const originalFetch = globalThis.fetch;
+
+function makeResponse( data: boolean ) {
+	return { json: () => Promise.resolve( data ) };
+}
+
+function makeQueryClient() {
+	return new QueryClient();
+}
+
+function makeWrapper( queryClient: QueryClient, strictMode = false ) {
+	return function Wrapper( { children }: { children: ReactNode } ) {
+		const content = strictMode ? <StrictMode>{ children }</StrictMode> : children;
+
+		return <QueryClientProvider client={ queryClient }>{ content }</QueryClientProvider>;
+	};
+}
+
+function getEventCalls( eventName: string ) {
+	return ( recordTracksEvent as jest.Mock ).mock.calls.filter( ( [ name ] ) => name === eventName );
+}
+
+describe( 'useCanConnectToZendeskMessaging', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		fetchMock.mockReset();
+		fetchMock.mockResolvedValue( makeResponse( true ) );
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+	} );
+
+	afterEach( () => {
+		globalThis.fetch = originalFetch;
+	} );
+
+	it( 'reports one event after a successful resolution', async () => {
+		const queryClient = makeQueryClient();
+		const { result } = renderHook( () => useCanConnectToZendeskMessaging(), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
+		expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 1 );
+		expect( getEventCalls( ERROR_EVENT ) ).toHaveLength( 0 );
+		expect( getEventCalls( REQUEST_EVENT )[ 0 ][ 1 ] ).toEqual( {
+			status: 'success',
+			status_text: undefined,
+			failure_count: 0,
+			reporting_version: REPORTING_VERSION,
+		} );
+	} );
+
+	it( 'reports once for multiple simultaneous consumers', async () => {
+		const queryClient = makeQueryClient();
+		const wrapper = makeWrapper( queryClient );
+		const first = renderHook( () => useCanConnectToZendeskMessaging(), { wrapper } );
+		const second = renderHook( () => useCanConnectToZendeskMessaging(), { wrapper } );
+
+		await waitFor( () => {
+			expect( first.result.current.isSuccess ).toBe( true );
+			expect( second.result.current.isSuccess ).toBe( true );
+		} );
+
+		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
+		expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 1 );
+	} );
+
+	it( 'does not report again when mounting against cached data', async () => {
+		const queryClient = makeQueryClient();
+		const wrapper = makeWrapper( queryClient );
+		const first = renderHook( () => useCanConnectToZendeskMessaging(), { wrapper } );
+
+		await waitFor( () => expect( first.result.current.isSuccess ).toBe( true ) );
+		first.unmount();
+
+		const second = renderHook( () => useCanConnectToZendeskMessaging(), { wrapper } );
+		await waitFor( () => expect( second.result.current.isSuccess ).toBe( true ) );
+
+		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
+		expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 1 );
+	} );
+
+	it( 'reports the error event when a successful response carries falsy data', async () => {
+		fetchMock.mockResolvedValue( makeResponse( false ) );
+		const queryClient = makeQueryClient();
+		const { result } = renderHook( () => useCanConnectToZendeskMessaging(), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 1 );
+		expect( getEventCalls( ERROR_EVENT ) ).toHaveLength( 1 );
+		expect( getEventCalls( ERROR_EVENT )[ 0 ][ 1 ] ).toEqual( {
+			status: 'success',
+			status_text: undefined,
+			reporting_version: REPORTING_VERSION,
+		} );
+	} );
+
+	it( 'reports once after retries reach a final error', async () => {
+		fetchMock.mockRejectedValue( new Error( 'Zendesk unavailable' ) );
+		const queryClient = makeQueryClient();
+		const { result } = renderHook( () => useCanConnectToZendeskMessaging(), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		await waitFor( () => expect( result.current.isError ).toBe( true ), { timeout: 5000 } );
+
+		expect( fetchMock ).toHaveBeenCalledTimes( 4 );
+		expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 1 );
+		expect( getEventCalls( ERROR_EVENT ) ).toHaveLength( 1 );
+		expect( getEventCalls( REQUEST_EVENT )[ 0 ][ 1 ] ).toEqual( {
+			status: 'error',
+			status_text: 'Zendesk unavailable',
+			failure_count: 4,
+			reporting_version: REPORTING_VERSION,
+		} );
+		expect( getEventCalls( ERROR_EVENT )[ 0 ][ 1 ] ).toEqual( {
+			status: 'error',
+			status_text: 'Zendesk unavailable',
+			reporting_version: REPORTING_VERSION,
+		} );
+	} );
+
+	it( 'keeps the retry count on a resolution that recovered', async () => {
+		fetchMock
+			.mockRejectedValueOnce( new Error( 'Zendesk unavailable' ) )
+			.mockRejectedValueOnce( new Error( 'Zendesk unavailable' ) )
+			.mockResolvedValue( makeResponse( true ) );
+		const queryClient = makeQueryClient();
+		const { result } = renderHook( () => useCanConnectToZendeskMessaging(), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ), { timeout: 5000 } );
+
+		expect( fetchMock ).toHaveBeenCalledTimes( 3 );
+		expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 1 );
+		expect( getEventCalls( REQUEST_EVENT )[ 0 ][ 1 ] ).toEqual( {
+			status: 'success',
+			status_text: undefined,
+			failure_count: 2,
+			reporting_version: REPORTING_VERSION,
+		} );
+	} );
+
+	it( 'does not report when disabled', () => {
+		const queryClient = makeQueryClient();
+		const { result } = renderHook( () => useCanConnectToZendeskMessaging( false ), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		expect( result.current.status ).toBe( 'pending' );
+		expect( fetchMock ).not.toHaveBeenCalled();
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'reports one new event after a genuine refetch', async () => {
+		const queryClient = makeQueryClient();
+		const { result } = renderHook( () => useCanConnectToZendeskMessaging(), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		await act( async () => {
+			await result.current.refetch();
+		} );
+
+		expect( fetchMock ).toHaveBeenCalledTimes( 2 );
+		await waitFor( () => expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 2 ) );
+	} );
+
+	it( 'reports independently for separate query clients', async () => {
+		const first = renderHook( () => useCanConnectToZendeskMessaging(), {
+			wrapper: makeWrapper( makeQueryClient() ),
+		} );
+		const second = renderHook( () => useCanConnectToZendeskMessaging(), {
+			wrapper: makeWrapper( makeQueryClient() ),
+		} );
+
+		await waitFor( () => {
+			expect( first.result.current.isSuccess ).toBe( true );
+			expect( second.result.current.isSuccess ).toBe( true );
+		} );
+
+		expect( fetchMock ).toHaveBeenCalledTimes( 2 );
+		expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 2 );
+	} );
+
+	it( 'reports once under StrictMode', async () => {
+		const queryClient = makeQueryClient();
+		const { result } = renderHook( () => useCanConnectToZendeskMessaging(), {
+			wrapper: makeWrapper( queryClient, true ),
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
+		expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 1 );
+	} );
+} );

--- a/packages/zendesk-client/test/use-can-connect-to-zendesk-messaging.test.tsx
+++ b/packages/zendesk-client/test/use-can-connect-to-zendesk-messaging.test.tsx
@@ -192,6 +192,48 @@ describe( 'useCanConnectToZendeskMessaging', () => {
 		await waitFor( () => expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 2 ) );
 	} );
 
+	it( 'keeps the retry count on a refetch that recovered', async () => {
+		const queryClient = makeQueryClient();
+		const { result } = renderHook( () => useCanConnectToZendeskMessaging(), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		fetchMock
+			.mockRejectedValueOnce( new Error( 'Zendesk unavailable' ) )
+			.mockRejectedValueOnce( new Error( 'Zendesk unavailable' ) )
+			.mockResolvedValue( makeResponse( true ) );
+
+		await act( async () => {
+			await result.current.refetch();
+		} );
+
+		await waitFor( () => expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 2 ) );
+		expect( getEventCalls( REQUEST_EVENT )[ 1 ][ 1 ] ).toEqual( {
+			status: 'success',
+			status_text: undefined,
+			failure_count: 2,
+			reporting_version: REPORTING_VERSION,
+		} );
+	} );
+
+	it( 'reports again after the query is evicted from the cache', async () => {
+		const queryClient = makeQueryClient();
+		const wrapper = makeWrapper( queryClient );
+		const first = renderHook( () => useCanConnectToZendeskMessaging(), { wrapper } );
+
+		await waitFor( () => expect( first.result.current.isSuccess ).toBe( true ) );
+		first.unmount();
+		queryClient.removeQueries( { queryKey: [ 'canConnectToZendesk' ] } );
+
+		const second = renderHook( () => useCanConnectToZendeskMessaging(), { wrapper } );
+		await waitFor( () => expect( second.result.current.isSuccess ).toBe( true ) );
+
+		expect( fetchMock ).toHaveBeenCalledTimes( 2 );
+		expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 2 );
+	} );
+
 	it( 'reports independently for separate query clients', async () => {
 		const first = renderHook( () => useCanConnectToZendeskMessaging(), {
 			wrapper: makeWrapper( makeQueryClient() ),

--- a/packages/zendesk-client/test/use-can-connect-to-zendesk-messaging.test.tsx
+++ b/packages/zendesk-client/test/use-can-connect-to-zendesk-messaging.test.tsx
@@ -234,6 +234,38 @@ describe( 'useCanConnectToZendeskMessaging', () => {
 		expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 2 );
 	} );
 
+	it( 'reports both of two identical consecutive errors', async () => {
+		fetchMock.mockRejectedValue( new Error( 'Zendesk unavailable' ) );
+		const queryClient = makeQueryClient();
+		const { result } = renderHook( () => useCanConnectToZendeskMessaging(), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		await waitFor( () => expect( result.current.isError ).toBe( true ), { timeout: 5000 } );
+
+		await act( async () => {
+			await result.current.refetch();
+		} );
+
+		await waitFor( () => expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 2 ) );
+		expect( getEventCalls( ERROR_EVENT ) ).toHaveLength( 2 );
+	}, 15000 );
+
+	it( 'reports again after the query is reset', async () => {
+		const queryClient = makeQueryClient();
+		const wrapper = makeWrapper( queryClient );
+		const { result } = renderHook( () => useCanConnectToZendeskMessaging(), { wrapper } );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		await act( async () => {
+			await queryClient.resetQueries( { queryKey: [ 'canConnectToZendesk' ], exact: true } );
+		} );
+
+		await waitFor( () => expect( fetchMock ).toHaveBeenCalledTimes( 2 ) );
+		await waitFor( () => expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 2 ) );
+	} );
+
 	it( 'reports independently for separate query clients', async () => {
 		const first = renderHook( () => useCanConnectToZendeskMessaging(), {
 			wrapper: makeWrapper( makeQueryClient() ),


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-509/zendesk-config-telemetry-report-once-per-shared-query-resolution

## Proposed Changes

**`calypso_helpcenter_zendesk_config_request` now fires once per settled config query instead of once per observer per state.**

- Only settled states report. Pending states, retries, cached mounts, co-mounted consumers and StrictMode double-mounts all stay silent; a genuine refetch still emits one event.
- Dedupe state is keyed on the cached query itself, so it is collected along with the query. An evicted query comes back as a fresh instance with its update counters back at zero, and reusing the old state would read that as a repeat and report nothing.
- Resolution identity comes from the query's monotonic `dataUpdateCount`/`errorUpdateCount` rather than timestamps — two resolutions inside one millisecond would otherwise collapse into one.
- `failure_count` survives a recovery. TanStack resets it on success, so the peak is tracked while a fetch is in flight and reported with the resolution. Tracking runs off `fetchStatus`, not `status`, because a refetch over cached data stays `success` for its whole run.
- Both events carry `reporting_version: 2`.
- `calypso_helpcenter_zendesk_config_error` keeps its existing condition and rides the same dedupe boundary, so its funnels keep working at one event per resolution.

The hook's return shape is unchanged, so no consumer changes.

## Why are these changes being made?

We ping Zendesk once per session to check whether chat is reachable, and the answer is cached forever. But twelve different parts of the UI ask for that answer, and each one logged an event every time it read it — including reads that never touched the network. One real check produced roughly 43 log events per user per day, 6.5M rows on 2026-08-05 alone.

The point of the event is to tell us how often Zendesk is actually reachable. Instead it measured how often React mounted a component, so a genuine Zendesk outage would barely move the number. See [DOTSUP-509](https://linear.app/a8c/issue/DOTSUP-509/zendesk-config-telemetry-report-once-per-shared-query-resolution).

Two consequences worth flagging for whoever owns the dashboards:

- Volume drops roughly 40x, and the event now means "settled" rather than "attempted", so a resolution rate can no longer be computed from this event alone. `reporting_version` is there to separate old rows from new ones.
- Alert thresholds tuned to the current volume will misfire on deploy and need retuning.

## Testing Instructions

**Calypso**

1. Run `yarn start` and open a site.
2. Open the browser console and watch Tracks events (`window._tkq`).
3. Open the Help Center. Confirm exactly one `calypso_helpcenter_zendesk_config_request` fires, with `status: 'success'`, `failure_count: 0` and `reporting_version: 2` — not one per mounted consumer.
4. Close and reopen the Help Center, and visit a page with a chat button or the purchase-cancellation flow. Confirm no further events while the answer stays cached.
5. Block zendesk config in devtools and reload. Confirm one `..._request` with `status: 'error'` and `failure_count: 4`, plus one `..._config_error` — not one per retry.

**Simple / Atomic / CIAB**

1. `cd apps/help-center && yarn dev --sync`.
2. Open the Help Center from wp-admin and confirm the same single event per resolution.
