### PR TITLE
Onboarding: add build_dest=wow for Atomic blueprint builds

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -33,6 +33,7 @@ import { isPlanProductFree } from '../../../../../../packages/data-stores/src/pl
 import { useFlowLocale } from '../../../hooks/use-flow-locale';
 import { useQuery } from '../../../hooks/use-query';
 import { ONBOARD_STORE, SITE_STORE } from '../../../stores';
+import { getBlueprintArchiveSiteSpecUrl } from '../../../utils/blueprint-archive-import';
 import {
 	getBuildWowSiteIdentifier,
 	getBuildWowSiteSpecUrl,
@@ -99,6 +100,7 @@ const onboarding: FlowV2< typeof initialize > = {
 		const { setShouldShowNotification } = usePurchasePlanNotification();
 
 		const playgroundId = queryParams.get( 'playground' );
+		const buildDest = queryParams.get( 'build_dest' );
 
 		/**
 		 * Returns [destination, backDestination] for the post-checkout destination.
@@ -126,6 +128,24 @@ const onboarding: FlowV2< typeof initialize > = {
 					siteSlug: providedDependencies.siteSlug as string,
 					siteId: providedDependencies.siteId as number,
 				};
+
+				// build_dest=wow: skip the Playground-based importer and land on the AI
+				// site-spec, which kicks off the background transfer-to-Atomic +
+				// blueprint-archive import and, on confirm, polls the import and
+				// redirects to the Site Editor. The blueprint step already verified the
+				// archive exists (and stripped build_dest when it does not).
+				if ( blueprint && buildDest === 'wow' ) {
+					return [
+						getBlueprintArchiveSiteSpecUrl( {
+							siteSlug: providedDependencies.siteSlug as string,
+							siteId: providedDependencies.siteId as number,
+							blueprintSlug: blueprint,
+							ref: refParameter,
+						} ),
+						null,
+						null,
+					];
+				}
 
 				if ( blueprint ) {
 					params.blueprint = blueprint;
@@ -406,7 +426,9 @@ const onboarding: FlowV2< typeof initialize > = {
 							// replace the location to delete processing step from history.
 							window.location.replace(
 								addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
-									redirect_to: redirectTo,
+									// build_dest=wow goes straight from checkout to the AI site-spec
+									// (no post-checkout-onboarding hop, no chooser).
+									redirect_to: blueprint && buildDest === 'wow' ? destination : redirectTo,
 									signup: 1,
 									flow: ONBOARDING_FLOW,
 									checkoutBackUrl: pathToUrl( backDestination ?? '' ),
@@ -418,6 +440,10 @@ const onboarding: FlowV2< typeof initialize > = {
 									steps_total: checkoutStepperPosition.total,
 								} )
 							);
+						} else if ( blueprint && buildDest === 'wow' ) {
+							// build_dest=wow never shows the setup-your-site-ai chooser; go
+							// straight to the AI site-spec destination.
+							window.location.replace( destination );
 						} else if (
 							refParameter === WOO_HOSTING_SOLUTIONS_REF &&
 							isEnabled( 'onboarding/woo-hosting-post-purchase-setup-choice' )

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blueprint/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blueprint/index.tsx
@@ -1,7 +1,7 @@
 import { StepContainer } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
 import Loading from 'calypso/components/loading';
@@ -17,11 +17,19 @@ import type { Step as StepType } from '../../types';
 export const BlueprintStep: StepType = ( { navigation } ) => {
 	const { submit } = navigation;
 	const { __ } = useI18n();
-	const [ query ] = useSearchParams();
+	const [ query, setQuery ] = useSearchParams();
 	const { setBlueprint } = useDispatch( ONBOARD_STORE );
+	const hasSubmitted = useRef( false );
+
+	const blueprintParam = query.get( 'blueprint' ) ?? '';
+	const buildDestParam = query.get( 'build_dest' ) ?? '';
 
 	useEffect( () => {
 		const fetchBlueprint = async () => {
+			if ( hasSubmitted.current ) {
+				return;
+			}
+
 			// A numeric Blueprint library post ID or a post slug, both resolved on
 			// blueprintlibrary.wordpress.com by the import backends.
 			const id = getBlueprintArchiveIdentifier( query );
@@ -34,7 +42,7 @@ export const BlueprintStep: StepType = ( { navigation } ) => {
 			// Atomic site, so it needs that archive to exist on the library post.
 			// Verify up front; when missing, fall back to the legacy Simple-site
 			// import by stripping the param (tracked, so missing archives surface).
-			if ( query.get( 'build_dest' ) === 'wow' ) {
+			if ( 'wow' === buildDestParam ) {
 				const hasArchive = await checkBlueprintExists( id );
 
 				if ( ! hasArchive ) {
@@ -43,20 +51,28 @@ export const BlueprintStep: StepType = ( { navigation } ) => {
 					} );
 					logBlueprintArchiveEvent( 'wow_archive_missing', { blueprint: id } );
 
-					const url = new URL( window.location.href );
-					url.searchParams.delete( 'build_dest' );
-					window.history.replaceState( null, '', url.toString() );
+					// Strip through the router rather than window.history: navigation to
+					// a logged-out user's auth step builds its path from the router's
+					// search params, which a plain history.replaceState would leave
+					// holding build_dest=wow. Submitting is deferred to the re-run of
+					// this effect, once the sanitized query is what navigation will
+					// carry forward.
+					const sanitized = new URLSearchParams( query );
+					sanitized.delete( 'build_dest' );
+					setQuery( sanitized, { replace: true } );
+					return;
 				}
 			}
 
 			// Save the Blueprint library identifier to the store
+			hasSubmitted.current = true;
 			setBlueprint( id );
 			submit();
 		};
 
 		fetchBlueprint();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
+	}, [ blueprintParam, buildDestParam ] );
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blueprint/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blueprint/index.tsx
@@ -5,8 +5,12 @@ import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
 import Loading from 'calypso/components/loading';
-import { getBlueprintID } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint';
+import { getBlueprintArchiveIdentifier } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import {
+	checkBlueprintExists,
+	logBlueprintArchiveEvent,
+} from 'calypso/landing/stepper/utils/blueprint-archive-import';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step as StepType } from '../../types';
 
@@ -18,13 +22,36 @@ export const BlueprintStep: StepType = ( { navigation } ) => {
 
 	useEffect( () => {
 		const fetchBlueprint = async () => {
-			const id = getBlueprintID( query );
+			// A numeric Blueprint library post ID or a post slug, both resolved on
+			// blueprintlibrary.wordpress.com by the import backends.
+			const id = getBlueprintArchiveIdentifier( query );
 
-			if ( id ) {
-				// Save the Blueprint library ID to the store
-				setBlueprint( id );
-				submit();
+			if ( ! id ) {
+				return;
 			}
+
+			// build_dest=wow restores the blueprint's pre-built archive onto an
+			// Atomic site, so it needs that archive to exist on the library post.
+			// Verify up front; when missing, fall back to the legacy Simple-site
+			// import by stripping the param (tracked, so missing archives surface).
+			if ( query.get( 'build_dest' ) === 'wow' ) {
+				const hasArchive = await checkBlueprintExists( id );
+
+				if ( ! hasArchive ) {
+					recordTracksEvent( 'calypso_blueprint_build_dest_wow_archive_missing', {
+						blueprint: id,
+					} );
+					logBlueprintArchiveEvent( 'wow_archive_missing', { blueprint: id } );
+
+					const url = new URL( window.location.href );
+					url.searchParams.delete( 'build_dest' );
+					window.history.replaceState( null, '', url.toString() );
+				}
+			}
+
+			// Save the Blueprint library identifier to the store
+			setBlueprint( id );
+			submit();
 		};
 
 		fetchBlueprint();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blueprint/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blueprint/test/index.tsx
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+import { waitFor } from '@testing-library/react';
+import React from 'react';
+import { useLocation } from 'react-router';
+import {
+	checkBlueprintExists,
+	logBlueprintArchiveEvent,
+} from 'calypso/landing/stepper/utils/blueprint-archive-import';
+import BlueprintStep from '..';
+import { mockStepProps, renderStep } from '../../test/helpers';
+
+jest.mock( 'calypso/landing/stepper/utils/blueprint-archive-import', () => ( {
+	checkBlueprintExists: jest.fn(),
+	logBlueprintArchiveEvent: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+// The router's search params are what navigation carries into the logged-out
+// auth step, so the assertions below read them rather than window.location.
+let currentSearch = '';
+const LocationProbe = () => {
+	currentSearch = useLocation().search;
+	return null;
+};
+
+const render = ( initialEntry: string, submit: jest.Mock ) =>
+	renderStep(
+		<>
+			<BlueprintStep { ...mockStepProps( { navigation: { submit } } ) } />
+			<LocationProbe />
+		</>,
+		{ initialEntry }
+	);
+
+describe( 'BlueprintStep', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		currentSearch = '';
+	} );
+
+	it( 'keeps build_dest=wow when the blueprint has an archive', async () => {
+		( checkBlueprintExists as jest.Mock ).mockResolvedValue( true );
+		let searchAtSubmit = '';
+		const submit = jest.fn( () => {
+			searchAtSubmit = currentSearch;
+		} );
+
+		render( '/blueprint?blueprint=961&build_dest=wow', submit );
+
+		await waitFor( () => expect( submit ).toHaveBeenCalled() );
+		expect( checkBlueprintExists ).toHaveBeenCalledWith( '961' );
+		expect( searchAtSubmit ).toContain( 'build_dest=wow' );
+	} );
+
+	it( 'strips build_dest from the router before submitting when the archive is missing', async () => {
+		( checkBlueprintExists as jest.Mock ).mockResolvedValue( false );
+		let searchAtSubmit = '';
+		const submit = jest.fn( () => {
+			searchAtSubmit = currentSearch;
+		} );
+
+		render( '/blueprint?blueprint=961&build_dest=wow', submit );
+
+		await waitFor( () => expect( submit ).toHaveBeenCalled() );
+		// The fallback must be visible in the router's own params, otherwise the
+		// logged-out auth branch re-adds build_dest after sign-in.
+		expect( searchAtSubmit ).not.toContain( 'build_dest' );
+		expect( searchAtSubmit ).toContain( 'blueprint=961' );
+		expect( submit ).toHaveBeenCalledTimes( 1 );
+		expect( logBlueprintArchiveEvent ).toHaveBeenCalledWith( 'wow_archive_missing', {
+			blueprint: '961',
+		} );
+	} );
+
+	it( 'does not look up an archive without build_dest=wow', async () => {
+		const submit = jest.fn();
+
+		render( '/blueprint?blueprint=941', submit );
+
+		await waitFor( () => expect( submit ).toHaveBeenCalled() );
+		expect( checkBlueprintExists ).not.toHaveBeenCalled();
+	} );
+
+	it( 'accepts a blueprint slug', async () => {
+		( checkBlueprintExists as jest.Mock ).mockResolvedValue( true );
+		const submit = jest.fn();
+
+		render( '/blueprint?blueprint=coachava&build_dest=wow', submit );
+
+		await waitFor( () => expect( submit ).toHaveBeenCalled() );
+		expect( checkBlueprintExists ).toHaveBeenCalledWith( 'coachava' );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
@@ -147,12 +147,11 @@ export function getBlueprintID( query: URLSearchParams ): string | null {
 
 /**
  * The blueprint identifier for the onboarding blueprint flow
- * (`/setup/onboarding/blueprint/?blueprint=<id>`). Unlike getBlueprintID — which
- * is scoped to numeric Playground / blueprint-library ids — this also accepts a
- * dotcomblueprints post slug, the value blueprint-archive-import resolves against
- * the dotcomblueprints host. The archive's existence is validated server-side
- * (checkBlueprintExists), so we only shape-check here: a non-empty numeric id or
- * slug (lowercase alphanumerics + hyphens).
+ * (`/setup/onboarding/blueprint/?blueprint=<id-or-slug>`). Unlike getBlueprintID —
+ * which is scoped to numeric ids — this also accepts a blueprint-library post
+ * slug; both forms resolve against blueprintlibrary.wordpress.com server-side.
+ * We only shape-check here: a non-empty numeric id or slug (lowercase
+ * alphanumerics + hyphens).
  */
 export function getBlueprintArchiveIdentifier( query: URLSearchParams ): string | null {
 	const raw = query.get( 'blueprint' )?.trim() ?? '';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/test/get-plans-intent.test.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/test/get-plans-intent.test.ts
@@ -25,6 +25,21 @@ describe( 'getPlansIntent', () => {
 			window.history.replaceState( {}, '', '/?blueprint=123&playground=abc' );
 			expect( getPlansIntent( ONBOARDING_FLOW ) ).toBe( 'plans-playground' );
 		} );
+
+		it( 'hides the free plan when the blueprint targets Atomic via build_dest=wow', () => {
+			window.history.replaceState( {}, '', '/?blueprint=945&build_dest=wow' );
+			expect( getPlansIntent( ONBOARDING_FLOW ) ).toBe( 'plans-ai-assembler-paid-only' );
+		} );
+
+		it( 'keeps the default grid when build_dest is not wow', () => {
+			window.history.replaceState( {}, '', '/?blueprint=945&build_dest=simple' );
+			expect( getPlansIntent( ONBOARDING_FLOW ) ).toBeNull();
+		} );
+
+		it( 'keeps playground precedence when build_dest=wow is present alongside playground', () => {
+			window.history.replaceState( {}, '', '/?blueprint=123&playground=abc&build_dest=wow' );
+			expect( getPlansIntent( ONBOARDING_FLOW ) ).toBe( 'plans-playground' );
+		} );
 	} );
 
 	describe( 'plan-upgrade flow (dashboard "Change plan" downgrade entry point)', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-plans-intent.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-plans-intent.ts
@@ -41,6 +41,12 @@ export function getPlansIntent( flowName: string | null ): PlansIntent | null {
 			if ( search.has( 'playground' ) ) {
 				return playgroundPlansIntent( search.get( 'playground' )! );
 			}
+			// Blueprint imports targeting Atomic (build_dest=wow) need a plan that
+			// supports the transfer, so hide the free plan. Plain blueprint imports
+			// build on a Simple site and keep the default grid.
+			if ( search.has( 'blueprint' ) && search.get( 'build_dest' ) === 'wow' ) {
+				return 'plans-ai-assembler-paid-only';
+			}
 			if ( search.get( 'ref' ) === WOO_HOSTING_SOLUTIONS_REF ) {
 				return 'plans-woo-hosting-solutions';
 			}

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -184,10 +184,14 @@ function BlueprintCtaButton( {
 		return null;
 	}
 
-	// The onboarding blueprint step (getBlueprintID) accepts a numeric
-	// blueprint-library id via ?blueprint=<id>.
+	// The onboarding blueprint step accepts a blueprint-library post id or slug
+	// via ?blueprint=. build_dest=wow asks for the theme demo to be restored onto
+	// an Atomic site from the blueprint's archive, which keeps the plugins the
+	// Simple-site blueprint runner would drop; the step falls back to that runner
+	// when the blueprint has no archive.
 	const href = addQueryArgs( '/setup/onboarding/blueprint', {
 		blueprint: blueprintId,
+		build_dest: 'wow',
 		ref: `theme-${ themeId }`,
 	} );
 


### PR DESCRIPTION
Depends on wpcom ghe-wpcom-233643 (blueprint id-or-slug resolution on blueprintlibrary).

### Proposed Changes

Adds an opt-in `build_dest=wow` to the blueprint onboarding route, for blueprints that ship a pre-built Playground export archive and should be built on **Atomic** instead of Simple. The legacy `/setup/onboarding/blueprint?blueprint=<id>` behavior is unchanged when the param is absent.

* **Blueprint step** — accepts a numeric library ID **or** a slug (both resolve on blueprintlibrary). For `build_dest=wow` it verifies the archive exists via `GET /wpcom/v2/blueprint-archive/{id-or-slug}` *before* domains/checkout; when the archive is missing it records `calypso_blueprint_build_dest_wow_archive_missing` (Tracks + logstash) and strips the param, so the run degrades to the legacy Simple import rather than failing later.
* **Plans** — `blueprint` + `build_dest=wow` uses the paid-only intent, since the Atomic transfer requires a paid plan. Playground keeps precedence when both params are present; plain blueprint runs keep the default grid including Free.
* **Post-checkout** — `build_dest=wow` lands on the AI site-spec (`/setup/ai-site-builder-spec/site-spec?blueprint_archive_import=1&...`) instead of the Playground importer, with checkout's `redirect_to` pointed straight there and the `setup-your-site-ai` chooser skipped. The existing site-spec machinery then starts the transfer + archive import on mount, and on confirm polls both and redirects to the Site Editor.

### Why are these changes being made?

The blueprint route builds on a Simple site: `imports/library/new` applies the blueprint with the wpcom server-side runner, which supports only theme switch / WXR content / options / user meta — **no plugin installs**. That is fine for content-and-theme demos but silently drops plugin steps, so a plugin-dependent theme demo imports "successfully" as a broken site.

Blueprints that carry a Playground export archive can instead be restored onto Atomic through the existing `backup_import` pipeline (transfer + full-state restore), which is full fidelity. `build_dest=wow` is the opt-in switch for that, chosen per entry point rather than changing the default route.

### Testing Instructions

Requires a sandboxed API with wpcom #233643 applied. Blueprint **961** on blueprintlibrary (slug `coachava`) has an export archive.

1. **Wow path** — visit `/setup/onboarding/blueprint?blueprint=961&build_dest=wow`. The plans step should hide the free plan. Pick a paid plan and complete checkout; you should land directly on the **site-spec** (not `setup-your-site-ai`), with the archive import running in the background. Confirming the spec waits for the Atomic transfer + import and redirects to the Site Editor. (`bin/allow-sandbox-production-writes` must be enabled on the sandbox for the transfer/restore to actually run.)
2. **Slug form** — repeat with `?blueprint=coachava&build_dest=wow`; identical behavior.
3. **Missing archive** — use a blueprint without an export archive plus `build_dest=wow`. The param should be stripped, the free plan should reappear, and the legacy Simple import should run; check for the `calypso_blueprint_build_dest_wow_archive_missing` event.
4. **Legacy unchanged** — `/setup/onboarding/blueprint?blueprint=941` with no `build_dest`: default plans grid including Free, `importerPlayground` → `imports/library/new`, Simple site.
5. **Playground unchanged** — `/setup/onboarding/playground/?blueprint-url=...&playground=<uuid>` behaves as before.

Unit tests: `yarn test-client --testPathPattern 'unified-plans/test/get-plans-intent'` (9 passing, including three new cases for wow gating, non-wow `build_dest`, and playground precedence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
