### PR TITLE
STATS-345: Add a pre-connection pricing screen to Odyssey Stats

### DIFF
--- a/apps/odyssey-stats/.size-limit.js
+++ b/apps/odyssey-stats/.size-limit.js
@@ -15,4 +15,11 @@ module.exports = [
 		path: path.join( __dirname, 'dist/widget-loader.min.js' ),
 		limit: '10 KiB',
 	},
+	{
+		// The pre-connection pricing screen. It shares the dashboard's component tree but
+		// carries none of the reporting views, so it should stay well under that budget —
+		// a jump towards it means the screen has started pulling in dashboard code.
+		path: path.join( __dirname, 'dist/pricing.min.js' ),
+		limit: '230 KiB',
+	},
 ];

--- a/apps/odyssey-stats/src/app.scss
+++ b/apps/odyssey-stats/src/app.scss
@@ -4,11 +4,10 @@
 @import "./styles/typography";
 @import "@wordpress/base-styles/breakpoints";
 
-// Scoped to `.jp-stats-dashboard` (the class Jetpack's PHP puts on the Stats app's own mount
-// element) rather than `.wp-admin`, since WP core already puts a `wp-admin` class on the real
-// `<body>` — using it here would apply these rules to the whole wp-admin page, not just the Stats
-// app.
-.jp-stats-dashboard {
+// Scoped to the app's own mount elements (the classes Jetpack's PHP puts on them) rather than
+// `.wp-admin`, since WP core already puts a `wp-admin` class on the real `<body>` — using it here
+// would apply these rules to the whole wp-admin page, not just the Stats app.
+#{$stats-app-mounts} {
 	.card {
 		border: 0;
 		max-width: initial;
@@ -139,9 +138,9 @@
 	}
 }
 
-// Scoped with `:where()` so it adds zero specificity, rather than the class-level weight
-// `.jp-stats-dashboard` carries on its own.
-:where(.jp-stats-dashboard) .inner-notice-container .card.banner.is-jetpack {
+// Scoped with `:where()` so it adds zero specificity, rather than the class-level weight the
+// mount classes carry on their own.
+:where(#{$stats-app-mounts}) .inner-notice-container .card.banner.is-jetpack {
 	border-left: 3px solid var(--color-jetpack);
 }
 

--- a/apps/odyssey-stats/src/components/pricing-purchase.tsx
+++ b/apps/odyssey-stats/src/components/pricing-purchase.tsx
@@ -1,0 +1,57 @@
+import { PRODUCT_JETPACK_STATS_YEARLY } from '@automattic/calypso-products';
+import StatsMain from 'calypso/my-sites/stats/components/stats-main';
+import { PRICING_GRID_REFERRER } from 'calypso/my-sites/stats/pricing-grid/hooks/use-dismiss-pricing-grid';
+import { StatsSingleItemPagePurchaseFrame } from 'calypso/my-sites/stats/stats-purchase/stats-purchase-shared';
+import { StatsCommercialPurchase } from 'calypso/my-sites/stats/stats-purchase/stats-purchase-single-item';
+import { useSelector } from 'calypso/state';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
+import config from '../lib/config-api';
+
+/**
+ * The views-tier step of the pre-connection pricing screen.
+ *
+ * Renders the same commercial pitch, slider and copy as the site-scoped purchase page, so the
+ * two never drift. Only the two things a site without a connection cannot do are replaced: the
+ * checkout is siteless (`StatsCommercialPurchase` derives that from the connection status it
+ * already reads), and "I will do it later" starts the connection instead of returning to a
+ * dashboard that does not exist yet.
+ * @param props                   - Component props.
+ * @param props.onPostpone        - Runs when the visitor declines the paid plan.
+ * @param props.onBeforeCheckout  - Runs immediately before leaving for checkout.
+ */
+export default function PricingPurchase( {
+	onPostpone,
+	onBeforeCheckout,
+}: {
+	onPostpone: () => void;
+	onBeforeCheckout: () => void;
+} ) {
+	const product = useSelector( ( state ) =>
+		getProductBySlug( state, PRODUCT_JETPACK_STATS_YEARLY )
+	);
+
+	return (
+		<StatsMain fullWidthLayout>
+			{ /*
+			 * `stats-purchase-page` is the scope the purchase stylesheet defines its Jetpack
+			 * design tokens on, so the frame's own rules resolve only inside it. The real
+			 * purchase route applies the same pair of classes.
+			 */ }
+			<div className="stats stats-purchase-page">
+				<StatsSingleItemPagePurchaseFrame>
+					<StatsCommercialPurchase
+						siteId={ null }
+						siteSlug={ config( 'site_suffix' ) }
+						planValue={ 0 }
+						currencyCode={ product?.currency_code ?? 'USD' }
+						adminUrl={ config( 'admin_url' ) }
+						redirectUri="admin.php?page=stats"
+						from={ PRICING_GRID_REFERRER }
+						onPostpone={ onPostpone }
+						onBeforeCheckout={ onBeforeCheckout }
+					/>
+				</StatsSingleItemPagePurchaseFrame>
+			</div>
+		</StatsMain>
+	);
+}

--- a/apps/odyssey-stats/src/lib/init-pricing-config.ts
+++ b/apps/odyssey-stats/src/lib/init-pricing-config.ts
@@ -1,0 +1,2 @@
+import { initConfig } from './config-api';
+initConfig( 'jetpackStatsOdysseyPricingConfigData' );

--- a/apps/odyssey-stats/src/lib/load-wp-components-style.ts
+++ b/apps/odyssey-stats/src/lib/load-wp-components-style.ts
@@ -43,6 +43,20 @@ function isAtLeast( version: unknown, minimum: string ): boolean {
 }
 
 /**
+ * `config()` throws on an unknown key in development builds, and not every entry point ships
+ * every key — the pre-connection pricing screen has no blog ID or initial state to report. A
+ * missing key has to read as "no signal", not as a boot failure.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- config values are untyped.
+function readConfig( key: string ): any {
+	try {
+		return config( key );
+	} catch {
+		return undefined;
+	}
+}
+
+/**
  * Whether wp-admin already serves `@wordpress/components`' base CSS, making our own copy redundant.
  *
  * Two independent signals, either one sufficient:
@@ -59,12 +73,22 @@ function isAtLeast( version: unknown, minimum: string ): boolean {
  * renders unstyled.
  */
 export function isProvidedByWpAdmin(): boolean {
+	// Both signals are served at the top level of the config. The nested read stays as a
+	// fallback: the JS ships from a CDN and can run against a `stats-admin` old enough to
+	// place them only inside the dashboard's `intial_state`.
 	const siteOptions =
-		config( 'intial_state' )?.sites?.items?.[ config( 'blog_id' ) as number ]?.options ?? {};
+		readConfig( 'intial_state' )?.sites?.items?.[ readConfig( 'blog_id' ) as number ]?.options ??
+		{};
 
 	return (
-		isAtLeast( siteOptions.stats_admin_version, STATS_ADMIN_VERSION_WITH_WP_COMPONENTS_DEP ) ||
-		isAtLeast( siteOptions.software_version, WP_VERSION_WITH_GLOBAL_WP_COMPONENTS )
+		isAtLeast(
+			readConfig( 'stats_admin_version' ) ?? siteOptions.stats_admin_version,
+			STATS_ADMIN_VERSION_WITH_WP_COMPONENTS_DEP
+		) ||
+		isAtLeast(
+			readConfig( 'software_version' ) ?? siteOptions.software_version,
+			WP_VERSION_WITH_GLOBAL_WP_COMPONENTS
+		)
 	);
 }
 

--- a/apps/odyssey-stats/src/lib/test/load-wp-components-style.test.js
+++ b/apps/odyssey-stats/src/lib/test/load-wp-components-style.test.js
@@ -145,3 +145,46 @@ describe( 'isProvidedByWpAdmin — malformed or missing data fails safe toward l
 		expect( isProvidedByWpAdmin() ).toBe( false );
 	} );
 } );
+
+describe( 'isProvidedByWpAdmin — screens that ship no site data', () => {
+	afterEach( () => {
+		config.mockReset();
+	} );
+
+	/**
+	 * The pre-connection pricing screen has no blog id and no initial state, so both signals
+	 * arrive at the top level of the config instead of nested under the site's options.
+	 *
+	 * @param {Object} values Top-level config values.
+	 */
+	function mockTopLevel( values ) {
+		config.mockImplementation( ( key ) => {
+			if ( key in values ) {
+				return values[ key ];
+			}
+			// The real config throws on an unknown key in development builds.
+			throw new ReferenceError( `Could not find config value for key '${ key }'` );
+		} );
+	}
+
+	it( 'reads software_version from the top level', () => {
+		mockTopLevel( { software_version: '7.0.3' } );
+		expect( isProvidedByWpAdmin() ).toBe( true );
+	} );
+
+	it( 'reads stats_admin_version from the top level', () => {
+		mockTopLevel( { stats_admin_version: '0.32.0' } );
+		expect( isProvidedByWpAdmin() ).toBe( true );
+	} );
+
+	it( 'loads our copy when neither top-level signal holds', () => {
+		mockTopLevel( { software_version: '6.9', stats_admin_version: '0.31.11' } );
+		expect( isProvidedByWpAdmin() ).toBe( false );
+	} );
+
+	it( 'survives a payload with no blog id and no initial state', () => {
+		// Reading these keys used to throw and take the whole screen down with it.
+		mockTopLevel( {} );
+		expect( isProvidedByWpAdmin() ).toBe( false );
+	} );
+} );

--- a/apps/odyssey-stats/src/pricing.tsx
+++ b/apps/odyssey-stats/src/pricing.tsx
@@ -1,0 +1,154 @@
+/**
+ * Entry point for the Stats pricing screen a site sees before it is connected.
+ *
+ * Kept separate from `app.tsx` because there is no blog ID and no WordPress.com token
+ * yet, and the dashboard's store, routing and site-data boot all assume both. Prices come
+ * straight from the public API for the same reason: the wp-admin proxy the dashboard reads
+ * through needs a blog token this site does not have.
+ */
+
+// `init-pricing-config` has to be the first import, because there could be packages that
+// reference it in their side effects.
+// eslint-disable-next-line import/order
+import './lib/init-pricing-config';
+// The section stylesheets must be evaluated before the pricing grid's own, so that the
+// grid's container padding outranks the `.stats > *` centring rule. The dashboard gets
+// this ordering for free because it loads the grid as an async chunk.
+/* eslint-disable import/order */
+import 'calypso/assets/stylesheets/style.scss';
+import 'calypso/my-sites/stats/style.scss';
+import './app.scss';
+/* eslint-enable import/order */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { Provider as ReduxProvider } from 'react-redux';
+import { createStore, applyMiddleware, compose, Store, Middleware } from 'redux';
+import { thunk as thunkMiddleware } from 'redux-thunk';
+import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
+import PricingGrid from 'calypso/my-sites/stats/pricing-grid/pricing-grid';
+import { WithAddReducer } from 'calypso/state/add-reducer';
+import currentUser from 'calypso/state/current-user/reducer';
+import documentHead from 'calypso/state/document-head/reducer';
+import notices from 'calypso/state/notices/reducer';
+import { receiveProductsList } from 'calypso/state/products-list/actions';
+import productsList from 'calypso/state/products-list/reducer';
+import purchases from 'calypso/state/purchases/reducer';
+import sites from 'calypso/state/sites/reducer';
+import ui from 'calypso/state/ui/reducer';
+import { combineReducers, addReducerEnhancer } from 'calypso/state/utils';
+import Layout from './components/layout';
+import PricingPurchase from './components/pricing-purchase';
+import config from './lib/config-api';
+import loadWpComponentsStyle from './lib/load-wp-components-style';
+import setLocale from './lib/set-locale';
+
+const MOUNT_ID = 'jp-stats-pricing';
+const PRODUCTS_ENDPOINT = 'https://public-api.wordpress.com/rest/v1.1/products?type=jetpack';
+
+/**
+ * Tell the site the visitor has picked a plan, so the dashboard does not open with its own
+ * pricing grid and ask the same question once the site connects.
+ *
+ * Sent with `sendBeacon` because every caller navigates away in the same tick — a normal
+ * request would be cancelled in flight, losing the choice at the exact moment it is made.
+ * Recorded on the site rather than on WordPress.com: there is no blog ID to key it against
+ * until the connection exists.
+ */
+function recordPlanChoice() {
+	const url = `${ config( 'api_root' ) }jetpack/v4/stats-app/pricing-choice?_wpnonce=${ config(
+		'nonce'
+	) }`;
+
+	navigator.sendBeacon?.( url );
+}
+
+/**
+ * The visitor has not chosen yet, so the screen owns which of the two views is showing.
+ * A router would buy nothing here: neither view is linkable from outside wp-admin.
+ */
+function PricingApp() {
+	const [ view, setView ] = useState< 'grid' | 'purchase' >( 'grid' );
+
+	// "Start for free" and "I will do it later" both mean the same thing before a connection
+	// exists: take the free plan, which needs the site linked to WordPress.com first.
+	const goToConnection = () => {
+		recordPlanChoice();
+		window.location.href = config( 'connect_url' );
+	};
+
+	if ( view === 'purchase' ) {
+		return <PricingPurchase onPostpone={ goToConnection } onBeforeCheckout={ recordPlanChoice } />;
+	}
+
+	return (
+		<PricingGrid onSelectFree={ goToConnection } onSelectPaid={ () => setView( 'purchase' ) } />
+	);
+}
+
+/**
+ * Fill the products store from the public API.
+ *
+ * Unauthenticated on purpose: the product catalogue is public, and the site has no token
+ * to sign a request with. A failure is not fatal — the grid renders without the price and
+ * both calls to action still work.
+ */
+async function loadProducts( store: Store ) {
+	try {
+		const response = await globalThis.fetch( PRODUCTS_ENDPOINT );
+
+		if ( ! response.ok ) {
+			return;
+		}
+
+		store.dispatch( receiveProductsList( await response.json(), 'jetpack' ) );
+	} catch {
+		// Leaves the price block out; see above.
+	}
+}
+
+async function AppBoot() {
+	const root = document.getElementById( MOUNT_ID );
+
+	if ( ! root ) {
+		return;
+	}
+
+	// Awaited before anything renders so components are never painted unstyled on the WP
+	// versions that need it. Resolves immediately without a request on WP 7.0+.
+	await loadWpComponentsStyle();
+
+	const localeSlug = config( 'i18n_locale_slug' ) || config( 'i18n_default_locale_slug' ) || 'en';
+
+	const store = createStore(
+		combineReducers( {
+			currentUser,
+			documentHead,
+			notices,
+			productsList,
+			purchases,
+			sites,
+			ui,
+		} ),
+		compose( addReducerEnhancer, applyMiddleware( thunkMiddleware as Middleware ) )
+	) as Store & WithAddReducer;
+
+	await Promise.all( [ loadProducts( store ), setLocale( localeSlug, false ) ] );
+
+	createRoot( root ).render(
+		<CalypsoI18nProvider>
+			<QueryClientProvider client={ new QueryClient() }>
+				<ReduxProvider store={ store }>
+					<Layout
+						primary={ <PricingApp /> }
+						secondary={ null }
+						sectionName="stats"
+						sectionGroup="sites"
+					/>
+				</ReduxProvider>
+			</QueryClientProvider>
+		</CalypsoI18nProvider>
+	);
+}
+
+AppBoot();

--- a/apps/odyssey-stats/src/styles/mounts.scss
+++ b/apps/odyssey-stats/src/styles/mounts.scss
@@ -1,0 +1,9 @@
+// Every wp-admin element the full Stats app mounts on: the dashboard entry and the
+// pre-connection pricing entry. Both need the same wp-admin resets, and the stylesheets that
+// carry those resets are hand-scoped rather than machine-prefixed (see `ignoreFiles` in
+// webpack-css-scope.js), so they cannot pick a new mount up on their own.
+//
+// A new entry point has to be added here *and* to `prefix`/`entryPointRoots` in
+// webpack-css-scope.js. The dashboard widget is deliberately absent: it ships its own
+// stylesheets and shares none of these rules.
+$stats-app-mounts: ".jp-stats-dashboard, .jp-stats-pricing";

--- a/apps/odyssey-stats/src/styles/theme.scss
+++ b/apps/odyssey-stats/src/styles/theme.scss
@@ -1,6 +1,7 @@
 @import "variables";
+@import "mounts";
 
-.jp-stats-dashboard {
+#{$stats-app-mounts} {
 	@include odyssey-stats-base-vars;
 }
 

--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -1,3 +1,5 @@
+@import "mounts";
+
 // Override spinner styles
 .stats-module__placeholder {
 	.spinner {
@@ -52,10 +54,10 @@
 	}
 }
 
-// Overrides layout for WP Admin. Scoped to `.jp-stats-dashboard` (the class Jetpack's PHP puts on
-// the Stats app's mount element) rather than `.wp-admin`, since WP core puts `.wp-admin` on the
-// real `<body>` — using it here would apply these overrides to the whole wp-admin page.
-.jp-stats-dashboard {
+// Overrides layout for WP Admin. Scoped to the app's own mount elements (the classes Jetpack's
+// PHP puts on them) rather than `.wp-admin`, since WP core puts `.wp-admin` on the real `<body>`
+// — using it here would apply these overrides to the whole wp-admin page.
+#{$stats-app-mounts} {
 	// CSS variable overrides.
 	--sidebar-width-max: 160px;
 	--sidebar-width-min: 36px;

--- a/apps/odyssey-stats/webpack-css-scope.js
+++ b/apps/odyssey-stats/webpack-css-scope.js
@@ -7,7 +7,8 @@
  * real plugin instead of a hand-copied stand-in that can drift from what actually ships.
  */
 
-// .jp-stats-dashboard: normal content. .jp-stats-widget: the WP-Admin dashboard widget's mount.
+// .jp-stats-dashboard: normal content. .jp-stats-pricing: the pre-connection pricing screen's
+// mount. .jp-stats-widget: the WP-Admin dashboard widget's mount.
 // The rest are portal roots: .color-scheme/.ReactModalPortal (Popover/Dialog),
 // [data-base-ui-portal]/[data-wp-compat-overlay-slot] (@wordpress/ui), .components-modal__screen-overlay
 // (@wordpress/components Modal), .components-popover__fallback-container (@wordpress/components
@@ -15,7 +16,7 @@
 // .web-preview (the post-preview modal, RootChild-portaled into a classless document.body div —
 // the modal's own root rules are `exclude`d below for the same reason).
 const prefix =
-	':where(.jp-stats-dashboard, .color-scheme, .ReactModalPortal, [data-base-ui-portal], [data-wp-compat-overlay-slot], .components-modal__screen-overlay, .components-popover__fallback-container, .jp-stats-widget, .web-preview)';
+	':where(.jp-stats-dashboard, .jp-stats-pricing, .color-scheme, .ReactModalPortal, [data-base-ui-portal], [data-wp-compat-overlay-slot], .components-modal__screen-overlay, .components-popover__fallback-container, .jp-stats-widget, .web-preview)';
 
 // `prefix` roots that are always document.body-appended and never nested inside another root, so
 // self-nesting them under `prefix` is always dead — unlike the portal roots below, which routinely
@@ -23,6 +24,7 @@ const prefix =
 // without flagging legitimate portal-root nesting as a false positive.
 const entryPointRoots = [
 	'.jp-stats-dashboard',
+	'.jp-stats-pricing',
 	'.jp-stats-widget',
 	'.components-popover__fallback-container',
 	'.web-preview',
@@ -65,6 +67,9 @@ const exclude = [
 	// .jp-stats-dashboard styling itself or descendants (wp-admin.scss). Compound forms too, e.g.
 	// `.jp-stats-dashboard.theme-default .focus-content`.
 	/^\.jp-stats-dashboard(?![\w-])/,
+	// .jp-stats-pricing likewise: the same hand-scoped stylesheets target both mounts through
+	// `$stats-app-mounts` (src/styles/mounts.scss).
+	/^\.jp-stats-pricing(?![\w-])/,
 	// .jp-stats-widget styling itself (widget/index.scss). Compound forms too, e.g.
 	// `.jp-stats-widget.is-ready` or `.jp-stats-widget :hover`.
 	/^\.jp-stats-widget(?![\w-])/,

--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -55,6 +55,7 @@ module.exports = {
 	entry: {
 		build: path.join( __dirname, 'src', 'app' ),
 		'widget-loader': path.join( __dirname, 'src', 'widget-loader' ),
+		pricing: path.join( __dirname, 'src', 'pricing' ),
 	},
 	mode: isDevelopment ? 'development' : 'production',
 	devtool: sourceMap,

--- a/client/my-sites/stats/hooks/test/use-plan-usage-query.test.ts
+++ b/client/my-sites/stats/hooks/test/use-plan-usage-query.test.ts
@@ -1,4 +1,26 @@
-import { getUsageLimitStatus, PlanUsage } from '../use-plan-usage-query';
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createElement } from 'react';
+import wpcom from 'calypso/lib/wp';
+import usePlanUsageQuery, { getUsageLimitStatus, PlanUsage } from '../use-plan-usage-query';
+
+jest.mock( 'calypso/lib/wp', () => ( { req: { get: jest.fn() } } ) );
+
+const get = wpcom.req.get as jest.Mock;
+
+const renderUsageQuery = ( siteId: number | null ) => {
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { retry: false } },
+	} );
+
+	return renderHook( () => usePlanUsageQuery( siteId ), {
+		wrapper: ( { children } ) =>
+			createElement( QueryClientProvider, { client: queryClient }, children ),
+	} );
+};
 
 const buildUsage = ( viewsLimit: number, viewsCount: number ): PlanUsage =>
 	( {
@@ -47,5 +69,29 @@ describe( 'getUsageLimitStatus', () => {
 			isNearLimit: false,
 			isOverLimit: false,
 		} );
+	} );
+} );
+
+describe( 'usePlanUsageQuery', () => {
+	afterEach( () => get.mockReset() );
+
+	it( 'does not ask for usage on a site that has no id', () => {
+		// A site with no WordPress.com connection has no id and no recorded usage, so the
+		// request could only ever 404 — and it fires on the pre-connection pricing screen,
+		// where nothing can answer it.
+		renderUsageQuery( null );
+
+		expect( get ).not.toHaveBeenCalled();
+	} );
+
+	it( 'asks for usage once the site has an id', async () => {
+		get.mockResolvedValue( { views_limit: 10000 } );
+
+		renderUsageQuery( 1234 );
+
+		await waitFor( () => expect( get ).toHaveBeenCalled() );
+		expect( get ).toHaveBeenCalledWith(
+			expect.objectContaining( { path: '/sites/1234/jetpack-stats/usage' } )
+		);
 	} );
 } );

--- a/client/my-sites/stats/hooks/use-plan-usage-query.ts
+++ b/client/my-sites/stats/hooks/use-plan-usage-query.ts
@@ -70,5 +70,8 @@ export default function usePlanUsageQuery(
 		queryKey: [ 'stats', 'usage', 'query', siteId ],
 		queryFn: () => queryPlanUsage( siteId ),
 		select: selectPlanUsage,
+		// A site with no WordPress.com connection has no ID and no recorded usage, so the
+		// request could only ever 404. Callers already treat missing usage as "no tiers used".
+		enabled: !! siteId,
 	} );
 }

--- a/client/my-sites/stats/pricing-grid/gate.tsx
+++ b/client/my-sites/stats/pricing-grid/gate.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useState } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -14,6 +15,27 @@ const loadPricingGrid = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-my-sites-stats-pricing-grid" */ './pricing-grid'
 	);
+
+/**
+ * Whether the visitor already picked a plan on the pre-connection pricing screen, which asks
+ * the same question this grid does. Recorded on the site rather than on WordPress.com,
+ * because the choice is made before the site has a blog ID to key it against. A site
+ * connected by any other route never sets it, so it still gets the grid.
+ *
+ * Read defensively: the key ships with every Odyssey screen, but `config()` throws on an
+ * unknown key in development builds and this component lives in shared Calypso code.
+ *
+ * Exported for tests: it is the whole suppression rule, and getting it wrong in either
+ * direction is costly — too eager and a site never sees the grid, too shy and a visitor is
+ * asked to pick a plan twice.
+ */
+export function hasChosenBeforeConnecting(): boolean {
+	try {
+		return !! config( 'stats_pricing_choice_recorded' );
+	} catch {
+		return false;
+	}
+}
 
 /**
  * Replaces the Stats dashboard with the pricing grid for newly connected sites
@@ -35,7 +57,7 @@ function PricingGridGate( { children }: { children: ReactNode } ) {
 		isNewConnection
 	);
 
-	if ( ! isNewConnection || hasChosen ) {
+	if ( ! isNewConnection || hasChosen || hasChosenBeforeConnecting() ) {
 		return <>{ children }</>;
 	}
 

--- a/client/my-sites/stats/pricing-grid/pricing-grid.tsx
+++ b/client/my-sites/stats/pricing-grid/pricing-grid.tsx
@@ -36,6 +36,17 @@ interface Feature {
 interface PricingGridProps {
 	/** Called when the visitor picks a plan, so the host can reveal the dashboard. */
 	onDismiss?: () => void;
+	/**
+	 * Replace the free CTA's behaviour. A site with no WordPress.com connection has no
+	 * dashboard to reveal and no notice to dismiss, so the pre-connection screen sends the
+	 * visitor into the connection flow instead.
+	 */
+	onSelectFree?: () => void;
+	/**
+	 * Replace the paid CTA's behaviour. The default route is site-scoped, which a site with
+	 * no connection cannot form: it has no site slug yet.
+	 */
+	onSelectPaid?: () => void;
 }
 
 /**
@@ -45,7 +56,7 @@ interface PricingGridProps {
  * to the Search one. Gating lives in `gate.tsx`; by the time this renders the site
  * is known to be eligible and undismissed.
  */
-export default function PricingGrid( { onDismiss }: PricingGridProps ) {
+export default function PricingGrid( { onDismiss, onSelectFree, onSelectPaid }: PricingGridProps ) {
 	const translate = useTranslate();
 	// Same breakpoint the jetpack-components PricingTable uses via useViewportMatch.
 	const isLg = useViewportMatch( 'large' );
@@ -141,6 +152,12 @@ export default function PricingGrid( { onDismiss }: PricingGridProps ) {
 			blog_id: siteId,
 			cta: 'free',
 		} );
+
+		if ( onSelectFree ) {
+			onSelectFree();
+			return;
+		}
+
 		dismissPricingGrid();
 		onDismiss?.();
 	};
@@ -155,6 +172,12 @@ export default function PricingGrid( { onDismiss }: PricingGridProps ) {
 			blog_id: siteId,
 			cta: 'paid',
 		} );
+
+		if ( onSelectPaid ) {
+			onSelectPaid();
+			return;
+		}
+
 		page( `/stats/purchase/${ siteSlug }?from=${ PRICING_GRID_REFERRER }` );
 	};
 

--- a/client/my-sites/stats/pricing-grid/test/gate.test.ts
+++ b/client/my-sites/stats/pricing-grid/test/gate.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment jsdom
+ */
+import config from '@automattic/calypso-config';
+import { hasChosenBeforeConnecting } from '../gate';
+
+// The real default export is callable *and* carries `isEnabled`, which modules pulled in by
+// this file's import graph call at load time. A plain mock function breaks them.
+jest.mock( '@automattic/calypso-config', () => {
+	const isEnabled = jest.fn( () => false );
+	const configFn = Object.assign( jest.fn(), { isEnabled } );
+	return { __esModule: true, default: configFn, isEnabled };
+} );
+
+const mockConfig = config as unknown as jest.Mock;
+
+describe( 'hasChosenBeforeConnecting', () => {
+	afterEach( () => mockConfig.mockReset() );
+
+	it( 'suppresses the grid once a plan was picked before connecting', () => {
+		mockConfig.mockReturnValue( true );
+
+		expect( hasChosenBeforeConnecting() ).toBe( true );
+	} );
+
+	it( 'shows the grid to a site that was never offered the choice', () => {
+		mockConfig.mockReturnValue( false );
+
+		expect( hasChosenBeforeConnecting() ).toBe( false );
+	} );
+
+	it( 'shows the grid when the key is missing entirely', () => {
+		// A site connected by any other route runs against a payload without this key, and
+		// `config()` throws rather than returning undefined in development builds.
+		mockConfig.mockImplementation( () => {
+			throw new ReferenceError( 'Could not find config value' );
+		} );
+
+		expect( hasChosenBeforeConnecting() ).toBe( false );
+	} );
+
+	it( 'reads the key the site actually ships', () => {
+		mockConfig.mockReturnValue( false );
+
+		hasChosenBeforeConnecting();
+
+		expect( mockConfig ).toHaveBeenCalledWith( 'stats_pricing_choice_recorded' );
+	} );
+} );

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -60,6 +60,12 @@ const getStatsCheckoutURL = (
 			// We know the site and we're in Calypso
 			checkoutType = siteSlug; // go to normal checkout (with site and user context (logged-in))
 		}
+	} else if ( isFromWpAdmin ) {
+		// A site with no WordPress.com connection has no ID to scope checkout with, but it does
+		// know its own address. Buy first and let the return leg register the site, link the
+		// user and attach the licence in one pass.
+		isSitelessCheckout = true;
+		checkoutType = 'jetpack';
 	} else {
 		// We don't know the site and we're in Calypso
 		checkoutType = 'jetpack'; // go to siteless checkout

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -54,6 +54,17 @@ interface StatsCommercialPurchaseProps {
 	adminUrl: string;
 	redirectUri: string;
 	from: string;
+	/**
+	 * Replace what "I will do it later" does. The default returns to the site's own dashboard
+	 * and records the dismissal server-side, neither of which a site without a WordPress.com
+	 * connection can do.
+	 */
+	onPostpone?: () => void;
+	/**
+	 * Runs immediately before leaving for checkout. Lets a caller record the choice while the
+	 * page is still alive, since the redirect that follows cancels anything still in flight.
+	 */
+	onBeforeCheckout?: () => void;
 }
 
 interface StatsSingleItemPagePurchaseProps {
@@ -232,6 +243,8 @@ const StatsCommercialPurchase = ( {
 	from,
 	adminUrl,
 	redirectUri,
+	onPostpone,
+	onBeforeCheckout,
 }: StatsCommercialPurchaseProps ) => {
 	const translate = useTranslate();
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
@@ -288,6 +301,11 @@ const StatsCommercialPurchase = ( {
 			blog_id: siteId,
 			from,
 		} );
+
+		if ( onPostpone ) {
+			onPostpone();
+			return;
+		}
 
 		// Skipping is the visitor's plan decision — made on a page that shows the full
 		// paid pitch — so the pricing grid mustn't take over the dashboard afterwards,
@@ -365,8 +383,10 @@ const StatsCommercialPurchase = ( {
 					variant="primary"
 					primary={ isWPCOMSite ? true : undefined }
 					disabled={ ! haveTiers || needsConnectionForUpgrade }
-					onClick={ () =>
-						gotoCheckoutPage( {
+					onClick={ () => {
+						onBeforeCheckout?.();
+
+						return gotoCheckoutPage( {
 							from,
 							type: 'commercial',
 							siteSlug,
@@ -377,8 +397,8 @@ const StatsCommercialPurchase = ( {
 							quantity: purchaseTierQuantity,
 							isUpgrade: hasAnyStatsPlan, // All cross grades are not possible for the site-only flow.
 							isSiteFullyConnected: !! connectionStatus?.isSiteFullyConnected,
-						} )
-					}
+						} );
+					} }
 				>
 					{ continueButtonText }
 				</ButtonComponent>
@@ -766,4 +786,10 @@ function StatsCommercialFlowOptOutForm( {
 	);
 }
 
-export { StatsSingleItemPagePurchase, StatsSingleItemPersonalPurchasePage };
+export {
+	StatsSingleItemPagePurchase,
+	StatsSingleItemPersonalPurchasePage,
+	// Exported for the pre-connection pricing screen, which composes the same commercial pitch
+	// into its own frame rather than the site-scoped purchase page.
+	StatsCommercialPurchase,
+};

--- a/client/my-sites/stats/stats-purchase/test/stats-purchase-checkout-redirect.test.ts
+++ b/client/my-sites/stats/stats-purchase/test/stats-purchase-checkout-redirect.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment jsdom
+ */
+import config from '@automattic/calypso-config';
+import gotoCheckoutPage from '../stats-purchase-checkout-redirect';
+
+// `calypso-products` reads the named export at import time, so both shapes have to resolve to
+// the same mock or the module graph fails to load.
+jest.mock( '@automattic/calypso-config', () => {
+	const isEnabled = jest.fn();
+	return { __esModule: true, default: { isEnabled }, isEnabled };
+} );
+jest.mock( 'calypso/lib/analytics/tracks', () => ( { recordTracksEvent: jest.fn() } ) );
+jest.mock( '../../utils', () => ( { trackStatsAnalyticsEvent: jest.fn() } ) );
+
+const ADMIN_URL = 'https://example.com/wp-admin/';
+const SITE_SLUG = 'example.com';
+
+/** Ask for the URL rather than the redirect, which `redirect: false` returns directly. */
+const checkoutUrl = ( overrides = {} ) =>
+	new URL(
+		gotoCheckoutPage( {
+			from: 'jetpack-stats-pricing-grid',
+			type: 'commercial',
+			siteSlug: SITE_SLUG,
+			siteId: 1234,
+			adminUrl: ADMIN_URL,
+			redirect: false,
+			...overrides,
+		} ) as unknown as string
+	);
+
+/** Run inside wp-admin (Odyssey) rather than Calypso. */
+const inWpAdmin = ( enabled: boolean ) =>
+	( config.isEnabled as jest.Mock ).mockImplementation(
+		( feature: string ) => feature === 'is_running_in_jetpack_site' && enabled
+	);
+
+describe( 'gotoCheckoutPage — site with no connection', () => {
+	beforeEach( () => inWpAdmin( true ) );
+
+	it( 'checks out siteless when there is no site id yet', () => {
+		const url = checkoutUrl( { siteId: null } );
+
+		expect( url.pathname ).toBe( '/checkout/jetpack/jetpack_stats_yearly' );
+	} );
+
+	it( 'asks WordPress.com to connect the site after payment', () => {
+		const url = checkoutUrl( { siteId: null } );
+
+		// Without this the purchase completes against no site and the licence is never attached.
+		expect( url.searchParams.get( 'connect_after_checkout' ) ).toBe( 'true' );
+		expect( url.searchParams.get( 'from_site_slug' ) ).toBe( SITE_SLUG );
+		expect( url.searchParams.get( 'admin_url' ) ).toBe( ADMIN_URL );
+	} );
+
+	it( 'carries the chosen views tier', () => {
+		const url = checkoutUrl( { siteId: null, quantity: 50000 } );
+
+		expect( url.pathname ).toBe( '/checkout/jetpack/jetpack_stats_yearly:-q-50000' );
+	} );
+
+	it( 'does not scope checkout to a site it cannot name', () => {
+		const url = checkoutUrl( { siteId: null } );
+
+		expect( url.searchParams.get( 'site' ) ).toBeNull();
+	} );
+} );
+
+describe( 'gotoCheckoutPage — connected site', () => {
+	beforeEach( () => inWpAdmin( true ) );
+
+	it( 'scopes checkout to the site once it is fully connected', () => {
+		const url = checkoutUrl( { isSiteFullyConnected: true } );
+
+		expect( url.pathname ).toBe( '/checkout/1234/jetpack_stats_yearly' );
+		expect( url.searchParams.get( 'connect_after_checkout' ) ).toBeNull();
+	} );
+
+	it( 'falls back to siteless checkout while the user connection is missing', () => {
+		const url = checkoutUrl( { isSiteFullyConnected: false } );
+
+		expect( url.pathname ).toBe( '/checkout/jetpack/jetpack_stats_yearly' );
+		expect( url.searchParams.get( 'connect_after_checkout' ) ).toBe( 'true' );
+	} );
+} );
+
+describe( 'gotoCheckoutPage — Calypso', () => {
+	beforeEach( () => inWpAdmin( false ) );
+
+	it( 'leaves the siteless Calypso path alone', () => {
+		// Calypso has its own logged-in session, so the connect-after-checkout hand-off that
+		// wp-admin needs would be wrong here.
+		const url = checkoutUrl( { siteId: null } );
+
+		expect( url.pathname ).toBe( '/checkout/jetpack/jetpack_stats_yearly' );
+		expect( url.searchParams.get( 'connect_after_checkout' ) ).toBeNull();
+		expect( url.searchParams.get( 'admin_url' ) ).toBeNull();
+	} );
+
+	it( 'uses the site slug when the site is known', () => {
+		const url = checkoutUrl();
+
+		expect( url.pathname ).toBe( `/checkout/${ SITE_SLUG }/jetpack_stats_yearly` );
+	} );
+} );


### PR DESCRIPTION
Part of STATS-345

Companion PR, ships the plugin that renders this: Automattic/jetpack#51182 — merge this one first.

## Proposed Changes

* Adds a `pricing` webpack entry to `odyssey-stats`, alongside `build` and `widget-loader`. It renders the plan comparison and the views-tier slider on a site that has no WordPress.com connection yet.
* Reuses `PricingGrid` and `StatsCommercialPurchase` rather than copying them, via optional callbacks: the free path goes into the connection flow, the paid path checks out siteless, and "I will do it later" declines to the free plan. Without a callback every connected screen behaves exactly as before.
* `getStatsCheckoutURL` now sets the siteless checkout params when running in wp-admin with no site id. Previously that branch produced a `checkout/jetpack/` URL with no `connect_after_checkout`, so the purchase completed against no site.
* `.jp-stats-pricing` becomes a first-class CSS scope root, and the hand-scoped wp-admin resets move onto a shared `$stats-app-mounts` list so a fourth entry point costs one line instead of edits across three files.
* `usePlanUsageQuery` is now `enabled` only with a site id — without one the request could only 404 — and `isProvidedByWpAdmin` reads its two version signals from the top level of the config, since this screen ships no `blog_id` or `intial_state`.

## Why are these changes being made?

Installing the standalone Jetpack Stats plugin on an unconnected site used to dead-end: the Stats menu either did not appear or bounced to My Jetpack onboarding, so nobody saw what Stats costs before being asked to connect. We want the plan choice first, and the connection to follow from it.

The screen has to live here rather than in the Jetpack plugin so the pricing UI and copy exist in one place. A second copy in PHP would drift from this one the first time pricing changed.

## Testing Instructions

The plugin side is Automattic/jetpack#51182 — it registers the Stats menu before the site is connected and enqueues this bundle, so you need both to exercise the screen. That PR has the install steps (Jetpack Beta, pick its branch for Jetpack Stats). This PR should merge **first**: the plugin loads `pricing.min.js` from the CDN and renders an empty page without it.

**Sync the bundle to your sandbox**

`yarn dev` in `apps/odyssey-stats` builds and rsyncs the whole `dist` directory to the Odyssey path on your sandbox, so the new entry rides along with no extra configuration — there is no per-entry allowlist. Point the site at your sandbox as usual for Odyssey work (see the Odyssey Stats app README for the sandbox setup).

Two things worth knowing: the sync target is a single shared path, so only one sync can run at a time; and check your sandbox is not write-limited, which fails quietly and leaves the site loading the previous bundle.

**Then**

1. On a site with no Jetpack connection, install the standalone Stats plugin from the companion PR and go to **Stats**.
2. You should get the plan comparison with real prices. Prices come from the public products endpoint, unauthenticated, because there is no blog token to sign a request with.
3. **Get Paid Stats** → the views slider, then **Get Stats to grow my site** → a WordPress.com checkout URL under `/checkout/jetpack/` carrying `connect_after_checkout=true`, `from_site_slug`, and the chosen tier as `:-q-<views>`.
4. **Start for free** and **I will do it later** both go to the connection flow.
5. Regression check on a connected site: the dashboard, the traffic page's pricing grid, and `/stats/purchase/:site` should all behave exactly as on trunk.

Screenshots of both screens to follow.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
