### PR TITLE
Freshly Pressed Stream - Add badge with Freshly Pressed date

### DIFF
--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -9,6 +9,7 @@ import AutoDirection from 'calypso/components/auto-direction';
 import ReaderFollowButton from 'calypso/reader/follow-button';
 import { READER_DISCOVER } from 'calypso/reader/follow-sources';
 import FeaturedAsset from './featured-asset';
+import { FreshlyPressedBadge } from './freshly-pressed-badge';
 
 /**
  * Rather than create complex logic to create context or pass props
@@ -34,6 +35,7 @@ const CompactPost = ( props ) => {
 		postByline,
 		teams,
 		openSuggestedFollows,
+		freshlyPressedOn,
 	} = props;
 
 	const translate = useTranslate();
@@ -89,6 +91,7 @@ const CompactPost = ( props ) => {
 				<div className="reader-post-card__post-details">
 					<div className="reader-post-card__post-heading">
 						<div className="reader-post-card__post-title-meta">
+							{ freshlyPressedOn && <FreshlyPressedBadge displayedOn={ freshlyPressedOn } /> }
 							<AutoDirection>
 								<h2 className="reader-post-card__title">
 									<a className="reader-post-card__title-link" href={ post.URL }>
@@ -132,6 +135,7 @@ CompactPost.propTypes = {
 	post: PropTypes.object.isRequired,
 	postByline: PropTypes.object,
 	openSuggestedFollows: PropTypes.func,
+	freshlyPressedOn: PropTypes.string,
 };
 
 export default CompactPost;

--- a/client/blocks/reader-post-card/freshly-pressed-badge.tsx
+++ b/client/blocks/reader-post-card/freshly-pressed-badge.tsx
@@ -12,14 +12,14 @@ type FreshlyPressedPost = {
 export function getFreshlyPressedOn(
 	streamKey: string | undefined,
 	post: FreshlyPressedPost | null | undefined
-): string | null {
+): string | undefined {
 	if ( streamKey !== FRESHLY_PRESSED_STREAM_KEY ) {
-		return null;
+		return undefined;
 	}
 
 	const displayedOn = post?.editorial?.displayed_on;
 	if ( typeof displayedOn !== 'string' || displayedOn.trim() === '' ) {
-		return null;
+		return undefined;
 	}
 
 	return displayedOn;

--- a/client/blocks/reader-post-card/freshly-pressed-badge.tsx
+++ b/client/blocks/reader-post-card/freshly-pressed-badge.tsx
@@ -1,0 +1,46 @@
+import { useTranslate } from 'i18n-calypso';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+
+export const FRESHLY_PRESSED_STREAM_KEY = 'discover:freshly-pressed';
+
+type FreshlyPressedPost = {
+	editorial?: {
+		displayed_on?: string;
+	};
+};
+
+export function getFreshlyPressedOn(
+	streamKey: string | undefined,
+	post: FreshlyPressedPost | null | undefined
+): string | null {
+	if ( streamKey !== FRESHLY_PRESSED_STREAM_KEY ) {
+		return null;
+	}
+
+	const displayedOn = post?.editorial?.displayed_on;
+	if ( typeof displayedOn !== 'string' || displayedOn.trim() === '' ) {
+		return null;
+	}
+
+	return displayedOn;
+}
+
+export function FreshlyPressedBadge( { displayedOn }: { displayedOn: string } ) {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+	const date = moment( displayedOn, moment.ISO_8601, true );
+
+	if ( ! date.isValid() ) {
+		return null;
+	}
+
+	return (
+		<span className="reader-post-card__freshly-pressed-badge">
+			{ translate( 'Freshly Pressed on %(date)s', {
+				args: { date: date.format( 'll' ) },
+				comment:
+					'Badge on Discover Freshly Pressed cards. %(date)s is a localized calendar date such as Aug 11, 2026.',
+			} ) }
+		</span>
+	);
+}

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -20,6 +20,7 @@ import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import isReaderCardExpanded from 'calypso/state/selectors/is-reader-card-expanded';
 import PostByline from './byline';
 import ConversationPost from './conversation-post';
+import { getFreshlyPressedOn } from './freshly-pressed-badge';
 import GalleryPost from './gallery';
 import PostPhoto from './photo';
 import PostCardComments from './post-card-comments';
@@ -175,6 +176,7 @@ class ReaderPostCard extends Component {
 
 		const shouldShowPostCardComments = ! isConversations;
 		const showSuggestedFollows = isReaderSearchPage || isDiscoverPage;
+		const freshlyPressedOn = getFreshlyPressedOn( this.props.streamKey, post );
 
 		const classes = clsx( 'reader-post-card', {
 			'has-thumbnail': !! post.canonical_media,
@@ -239,6 +241,7 @@ class ReaderPostCard extends Component {
 					site={ site }
 					postKey={ postKey }
 					postByline={ postByline }
+					freshlyPressedOn={ freshlyPressedOn }
 					onClick={ this.handleCardClick }
 					openSuggestedFollows={ this.openSuggestedFollowsModal }
 				>

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -542,6 +542,10 @@
 	font-size: 12px;
 	line-height: 1.6;
 	overflow-wrap: anywhere;
+
+	@include ui-mixins.when-dark-theme {
+		background-color: var(--color-border-subtle);
+	}
 }
 
 .reader-post-card__byline .site-icon {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -529,6 +529,21 @@
 	align-self: center;
 }
 
+.reader-post-card__freshly-pressed-badge {
+	display: inline-flex;
+	align-items: center;
+	width: fit-content;
+	max-width: 100%;
+	margin-bottom: 6px;
+	border-radius: 4px;
+	padding: 0 9px 2px;
+	background-color: var(--color-neutral-0);
+	color: var(--color-neutral-70);
+	font-size: 12px;
+	line-height: 1.6;
+	overflow-wrap: anywhere;
+}
+
 .reader-post-card__byline .site-icon {
 	flex-shrink: 0;
 	margin: 0 12px 0 0;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -534,7 +534,7 @@
 	align-items: center;
 	width: fit-content;
 	max-width: 100%;
-	margin-bottom: 6px;
+	margin-block-end: 6px;
 	border-radius: 4px;
 	padding: 0 9px 2px;
 	background-color: var(--color-neutral-0);

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -536,7 +536,7 @@
 	max-width: 100%;
 	margin-block-end: 6px;
 	border-radius: 4px;
-	padding: 0 9px 2px;
+	padding: 1px 9px;
 	background-color: var(--color-neutral-0);
 	color: var(--color-neutral-70);
 	font-size: 12px;

--- a/client/blocks/reader-post-card/test/compact.test.jsx
+++ b/client/blocks/reader-post-card/test/compact.test.jsx
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import CompactPost from '../compact';
+
+jest.mock( '@automattic/viewport-react', () => ( {
+	useBreakpoint: () => false,
+} ) );
+jest.mock( 'calypso/blocks/reader-excerpt', () => () => null );
+jest.mock( 'calypso/blocks/reader-post-options-menu/reader-post-ellipsis-menu', () => () => null );
+jest.mock( 'calypso/reader/follow-button', () => () => null );
+jest.mock( '../featured-asset', () => () => null );
+jest.mock( '../freshly-pressed-badge', () => ( {
+	FreshlyPressedBadge: ( { displayedOn } ) => <div>Freshly Pressed on { displayedOn }</div>,
+} ) );
+
+const post = {
+	ID: 1,
+	site_ID: 1,
+	URL: 'https://example.com/post',
+	title: 'A featured post',
+};
+
+describe( 'CompactPost Freshly Pressed badge', () => {
+	it( 'renders the badge above the title when freshlyPressedOn is set', () => {
+		render(
+			<CompactPost
+				post={ post }
+				freshlyPressedOn="2026-08-11T12:00:00+00:00"
+				postByline={ <div>byline</div> }
+			/>
+		);
+
+		expect( screen.getByText( /Freshly Pressed on/i ) ).toBeVisible();
+		expect( screen.getByRole( 'heading', { name: 'A featured post' } ) ).toBeVisible();
+	} );
+
+	it( 'does not render the badge when freshlyPressedOn is missing', () => {
+		render( <CompactPost post={ post } postByline={ <div>byline</div> } /> );
+
+		expect( screen.queryByText( /Freshly Pressed on/i ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/blocks/reader-post-card/test/freshly-pressed-badge.test.tsx
+++ b/client/blocks/reader-post-card/test/freshly-pressed-badge.test.tsx
@@ -12,17 +12,17 @@ describe( 'getFreshlyPressedOn', () => {
 		expect( getFreshlyPressedOn( 'discover:freshly-pressed', post ) ).toBe( displayedOn );
 	} );
 
-	it( 'returns null on other streams even when editorial is present', () => {
-		expect( getFreshlyPressedOn( 'discover:recommended', post ) ).toBeNull();
-		expect( getFreshlyPressedOn( 'following', post ) ).toBeNull();
-		expect( getFreshlyPressedOn( undefined, post ) ).toBeNull();
+	it( 'returns undefined on other streams even when editorial is present', () => {
+		expect( getFreshlyPressedOn( 'discover:recommended', post ) ).toBeUndefined();
+		expect( getFreshlyPressedOn( 'following', post ) ).toBeUndefined();
+		expect( getFreshlyPressedOn( undefined, post ) ).toBeUndefined();
 	} );
 
-	it( 'returns null when displayed_on is missing or empty', () => {
-		expect( getFreshlyPressedOn( 'discover:freshly-pressed', {} ) ).toBeNull();
+	it( 'returns undefined when displayed_on is missing or empty', () => {
+		expect( getFreshlyPressedOn( 'discover:freshly-pressed', {} ) ).toBeUndefined();
 		expect(
 			getFreshlyPressedOn( 'discover:freshly-pressed', { editorial: { displayed_on: '' } } )
-		).toBeNull();
+		).toBeUndefined();
 	} );
 } );
 

--- a/client/blocks/reader-post-card/test/freshly-pressed-badge.test.tsx
+++ b/client/blocks/reader-post-card/test/freshly-pressed-badge.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { FreshlyPressedBadge, getFreshlyPressedOn } from '../freshly-pressed-badge';
+
+describe( 'getFreshlyPressedOn', () => {
+	const displayedOn = '2026-08-11T12:00:00+00:00';
+	const post = { editorial: { displayed_on: displayedOn } };
+
+	it( 'returns displayed_on on the Freshly Pressed Discover stream', () => {
+		expect( getFreshlyPressedOn( 'discover:freshly-pressed', post ) ).toBe( displayedOn );
+	} );
+
+	it( 'returns null on other streams even when editorial is present', () => {
+		expect( getFreshlyPressedOn( 'discover:recommended', post ) ).toBeNull();
+		expect( getFreshlyPressedOn( 'following', post ) ).toBeNull();
+		expect( getFreshlyPressedOn( undefined, post ) ).toBeNull();
+	} );
+
+	it( 'returns null when displayed_on is missing or empty', () => {
+		expect( getFreshlyPressedOn( 'discover:freshly-pressed', {} ) ).toBeNull();
+		expect(
+			getFreshlyPressedOn( 'discover:freshly-pressed', { editorial: { displayed_on: '' } } )
+		).toBeNull();
+	} );
+} );
+
+describe( 'FreshlyPressedBadge', () => {
+	it( 'renders an absolute Freshly Pressed date', () => {
+		render( <FreshlyPressedBadge displayedOn="2026-08-11T12:00:00+00:00" /> );
+
+		expect( screen.getByText( /Freshly Pressed on .+2026/i ) ).toBeVisible();
+	} );
+
+	it( 'renders nothing for an invalid date', () => {
+		const { container } = render( <FreshlyPressedBadge displayedOn="not-a-date" /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes # https://linear.app/a8c/issue/NL-825/clarify-freshly-pressed-feed-activity-in-the-design

## Proposed Changes

Add a badge at the top of cards in the FP stream to show the FP date of the post.

BEFORE
<img width="469" height="201" alt="Screenshot 2026-08-11 at 12 33 38 PM" src="https://github.com/user-attachments/assets/7f251c75-2851-4756-a882-d2d777611ad5" />


AFTER
<img width="468" height="201" alt="Screenshot 2026-08-11 at 12 33 07 PM" src="https://github.com/user-attachments/assets/d5e237b5-84ef-4ad8-9031-c2f1c4917bb0" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Posts show their publish date on cards as normal, but this adds confusion in FP. Users see dates that are not chronological, may be separated by a few days, top one may be a few days old -> gives a false impression that the stream is not updating with new content daily.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the discover section FP feed and verify the badge shows as expected, works well on all viewport widths, and in light and dark mode.
* Smoke test other reader streams verify they dont have the badge.
* go to the blog stream for one of those FP posts blogs, verify the badge isn't visible there either.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
