### PR TITLE
A4A: Add a Themes management page (API test harness — do not deploy)

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import {
+	brush,
 	category,
 	currencyDollar,
 	home,
@@ -36,6 +37,7 @@ import {
 	A4A_MIGRATIONS_LINK,
 	A4A_SETTINGS_LINK,
 	A4A_PLUGINS_LINK,
+	A4A_THEMES_LINK,
 	A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
 	A4A_REFERRALS_DASHBOARD,
 	A4A_TEAM_LINK,
@@ -148,6 +150,19 @@ const useMainMenuItems = ( path: string ) => {
 							title: translate( 'Plugins' ),
 							trackEventProps: {
 								menu_item: 'Automattic for Agencies / Plugins',
+							},
+						},
+				  ]
+				: [] ),
+			...( isSectionNameEnabled( 'a8c-for-agencies-themes' )
+				? [
+						{
+							icon: brush,
+							path: '/',
+							link: A4A_THEMES_LINK,
+							title: translate( 'Themes' ),
+							trackEventProps: {
+								menu_item: 'Automattic for Agencies / Themes',
 							},
 						},
 				  ]

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -13,6 +13,7 @@ export const A4A_SITES_LINK_WALKTHROUGH_TOUR = `${ A4A_SITES_LINK }?tour=sites-w
 export const A4A_SITES_LINK_ADD_NEW_SITE_TOUR = '/sites?tour=add-new-site';
 export const A4A_SITES_CONNECT_URL_LINK = '/sites/connect-url';
 export const A4A_PLUGINS_LINK = '/plugins';
+export const A4A_THEMES_LINK = '/themes';
 export const A4A_MARKETPLACE_LINK = '/marketplace';
 export const A4A_MARKETPLACE_PRODUCTS_LINK = `${ A4A_MARKETPLACE_LINK }/products`;
 export const A4A_MARKETPLACE_HOSTING_LINK = `${ A4A_MARKETPLACE_LINK }/hosting`;

--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -23,6 +23,7 @@ import {
 	A4A_SITES_LINK_ADD_NEW_SITE_TOUR,
 	A4A_SITES_CONNECT_URL_LINK,
 	A4A_PLUGINS_LINK,
+	A4A_THEMES_LINK,
 	A4A_MARKETPLACE_LINK,
 	A4A_MARKETPLACE_PRODUCTS_LINK,
 	A4A_MARKETPLACE_HOSTING_LINK,
@@ -117,6 +118,7 @@ const MEMBER_ACCESSIBLE_PATHS: Record< string, string[] > = {
 	[ A4A_TEAM_INVITE_LINK ]: [ 'a4a_edit_user_invites' ],
 	[ A4A_AGENCY_TIER_LINK ]: [ 'a4a_read_agency_tier' ],
 	[ A4A_PLUGINS_LINK ]: [ 'a4a_read_managed_sites' ],
+	[ A4A_THEMES_LINK ]: [ 'a4a_read_managed_sites' ],
 	// TODO: Add the correct capability for WooPayments
 	[ A4A_WOOPAYMENTS_LINK ]: [ 'a4a_read_referrals' ],
 	[ A4A_WOOPAYMENTS_DASHBOARD_LINK ]: [ 'a4a_read_referrals' ],
@@ -142,6 +144,7 @@ const MEMBER_ACCESSIBLE_DYNAMIC_PATHS: Record< string, string[] > = {
 	marketplace: [ 'a4a_read_marketplace' ],
 	licenses: [ 'a4a_jetpack_licensing' ],
 	plugins: [ 'a4a_read_managed_sites' ],
+	themes: [ 'a4a_read_managed_sites' ],
 	referrals: [ 'a4a_read_referrals' ],
 	'agent-studio': [ 'a4a_read_learn' ],
 };
@@ -152,6 +155,7 @@ const DYNAMIC_PATH_PATTERNS: Record< string, RegExp > = {
 	licenses: /^\/purchases\/licenses(\/.*)?$/,
 	team: /^\/team(\/.*)?$/,
 	plugins: /^\/plugins(\/.*)?$/,
+	themes: /^\/themes(\/.*)?$/,
 	referrals: /^\/referrals(\/.*)?$/,
 	'agent-studio': /^\/resources-and-tools\/agent-studio\/(projects|agents|outputs)\/[^/]+(\/.*)?$/,
 };

--- a/client/a8c-for-agencies/sections/themes/controller.tsx
+++ b/client/a8c-for-agencies/sections/themes/controller.tsx
@@ -1,0 +1,29 @@
+import { type Callback, type Context } from '@automattic/calypso-router';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import MainSidebar from '../../components/sidebar-menu/main';
+import ThemesDashboard from './primary/themes-dashboard';
+
+// Reset selected site id for multi-site view since it is never reset
+// and the themes aggregation behaves differently when there
+// is a selected site which is incorrect for multi-site view
+const resetSite = ( context: Context ) => {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	if ( siteId ) {
+		context.store.dispatch( setSelectedSiteId( null ) );
+	}
+};
+
+export const themesContext: Callback = ( context, next ) => {
+	resetSite( context );
+	context.secondary = <MainSidebar path={ context.path } />;
+	context.primary = (
+		<>
+			<PageViewTracker title="Themes" path={ context.path } />
+			<ThemesDashboard />
+		</>
+	);
+	next();
+};

--- a/client/a8c-for-agencies/sections/themes/hooks/use-fetch-all-sites-themes.ts
+++ b/client/a8c-for-agencies/sections/themes/hooks/use-fetch-all-sites-themes.ts
@@ -1,0 +1,81 @@
+import { useQueries } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import wpcom from 'calypso/lib/wp';
+import { THEME_STATUS } from '../types';
+import type {
+	AggregatedTheme,
+	SiteThemesApiResponse,
+	ThemeSiteInstance,
+	ThemesDashboardSite,
+} from '../types';
+
+export default function useFetchAllSitesThemes( sites: ThemesDashboardSite[] ) {
+	const { siteThemes, isLoading } = useQueries( {
+		queries: sites.map( ( site ) => ( {
+			queryKey: [ 'a4a-site-themes', site.ID ],
+			queryFn: (): Promise< SiteThemesApiResponse > =>
+				wpcom.req.get( `/sites/${ site.ID }/themes`, { apiVersion: '1' } ),
+			staleTime: 1000 * 60 * 5,
+			refetchOnWindowFocus: false,
+			retry: 1,
+		} ) ),
+		combine: ( results ) => ( {
+			siteThemes: results.map( ( result ) => result.data ),
+			isLoading: results.some( ( result ) => result.isLoading ),
+		} ),
+	} );
+
+	const themes = useMemo( () => {
+		const byThemeId = new Map< string, AggregatedTheme >();
+
+		siteThemes.forEach( ( response, index ) => {
+			const site = sites[ index ];
+			if ( ! site || ! response?.themes ) {
+				return;
+			}
+
+			response.themes.forEach( ( theme ) => {
+				let aggregated = byThemeId.get( theme.id );
+				if ( ! aggregated ) {
+					aggregated = {
+						id: theme.id,
+						name: theme.name,
+						author: theme.author,
+						screenshot: theme.screenshot,
+						status: [],
+						sites: [],
+						pendingUpdates: [],
+					};
+					byThemeId.set( theme.id, aggregated );
+				} else if ( ! aggregated.screenshot && theme.screenshot ) {
+					aggregated.screenshot = theme.screenshot;
+				}
+
+				const instance: ThemeSiteInstance = {
+					siteId: site.ID,
+					siteTitle: site.title || site.URL,
+					siteUrl: site.URL,
+					version: theme.version,
+					active: theme.active,
+					newVersion: theme.update?.new_version ?? null,
+				};
+
+				aggregated.sites.push( instance );
+				if ( instance.newVersion ) {
+					aggregated.pendingUpdates.push( instance );
+				}
+			} );
+		} );
+
+		byThemeId.forEach( ( theme ) => {
+			theme.status = [
+				theme.sites.some( ( site ) => site.active ) ? THEME_STATUS.ACTIVE : THEME_STATUS.INACTIVE,
+				...( theme.pendingUpdates.length ? [ THEME_STATUS.UPDATE ] : [] ),
+			];
+		} );
+
+		return Array.from( byThemeId.values() ).sort( ( a, b ) => a.name.localeCompare( b.name ) );
+	}, [ siteThemes, sites ] );
+
+	return { themes, isLoading };
+}

--- a/client/a8c-for-agencies/sections/themes/hooks/use-set-site-themes-autoupdate.ts
+++ b/client/a8c-for-agencies/sections/themes/hooks/use-set-site-themes-autoupdate.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+export default function useSetSiteThemesAutoupdate() {
+	const queryClient = useQueryClient();
+
+	return useMutation( {
+		mutationFn: ( {
+			siteId,
+			themes,
+			autoupdate,
+		}: {
+			siteId: number;
+			themes: string[];
+			autoupdate: boolean;
+		} ) =>
+			wpcom.req.post( `/sites/${ siteId }/themes`, {
+				autoupdate,
+				themes,
+			} ),
+		onSettled: ( _data, _error, { siteId } ) => {
+			queryClient.invalidateQueries( { queryKey: [ 'a4a-site-themes', siteId ] } );
+		},
+	} );
+}

--- a/client/a8c-for-agencies/sections/themes/hooks/use-update-site-themes.ts
+++ b/client/a8c-for-agencies/sections/themes/hooks/use-update-site-themes.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+export default function useUpdateSiteThemes() {
+	const queryClient = useQueryClient();
+
+	return useMutation( {
+		mutationFn: ( { siteId, themes }: { siteId: number; themes: string[] } ) =>
+			wpcom.req.post( `/sites/${ siteId }/themes`, {
+				action: 'update',
+				themes,
+			} ),
+		onSettled: ( _data, _error, { siteId } ) => {
+			queryClient.invalidateQueries( { queryKey: [ 'a4a-site-themes', siteId ] } );
+		},
+	} );
+}

--- a/client/a8c-for-agencies/sections/themes/index.tsx
+++ b/client/a8c-for-agencies/sections/themes/index.tsx
@@ -1,0 +1,10 @@
+import page from '@automattic/calypso-router';
+import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { themesContext } from './controller';
+
+import './style.scss';
+
+export default function () {
+	page( '/themes', requireAccessContext, themesContext, makeLayout, clientRender );
+}

--- a/client/a8c-for-agencies/sections/themes/primary/themes-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/themes/primary/themes-dashboard/index.tsx
@@ -1,0 +1,383 @@
+import { sprintf, _n, __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+import { useCallback, useMemo, useState } from 'react';
+import {
+	DATAVIEWS_LIST,
+	DATAVIEWS_TABLE,
+	initialDataViewsState,
+} from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import QuerySites from 'calypso/components/data/query-sites';
+import SidebarNavigation from 'calypso/components/sidebar-navigation';
+import Layout from 'calypso/layout/hosting-dashboard';
+import LayoutColumn from 'calypso/layout/hosting-dashboard/column';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+	LayoutHeaderSubtitle as Subtitle,
+} from 'calypso/layout/hosting-dashboard/header';
+import LayoutTop from 'calypso/layout/hosting-dashboard/top';
+import acceptDialog from 'calypso/lib/accept';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import getSelectedOrAllSitesWithJetpackPlugin from 'calypso/state/selectors/get-selected-or-all-sites-with-jetpack-plugin';
+import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
+import useFetchAllSitesThemes from '../../hooks/use-fetch-all-sites-themes';
+import useSetSiteThemesAutoupdate from '../../hooks/use-set-site-themes-autoupdate';
+import useUpdateSiteThemes from '../../hooks/use-update-site-themes';
+import ThemeSitesPane from './theme-sites-pane';
+import ThemesList from './themes-list';
+import type { AggregatedTheme, ThemeSiteInstance } from '../../types';
+
+import 'calypso/my-sites/plugins/plugins-dashboard/style.scss';
+import 'calypso/sites/components/dotcom-style.scss';
+import './style.scss';
+
+type UpdatePair = { themeId: string; siteId: number };
+
+const pairKey = ( themeId: string, siteId: number ) => `${ themeId }|${ siteId }`;
+
+export default function ThemesDashboard() {
+	const dispatch = useDispatch();
+
+	const sites = useSelector( getSelectedOrAllSitesWithJetpackPlugin );
+	const sitesLoaded = useSelector( hasLoadedSites );
+
+	const { themes, isLoading } = useFetchAllSitesThemes( sites );
+	const { mutateAsync: updateSiteThemes } = useUpdateSiteThemes();
+	const { mutateAsync: setSiteThemesAutoupdate } = useSetSiteThemesAutoupdate();
+
+	const [ updatingKeys, setUpdatingKeys ] = useState< Set< string > >( new Set() );
+
+	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
+		...initialDataViewsState,
+		perPage: 15,
+		fields: [ 'sites', 'update' ],
+		titleField: 'name',
+		mediaField: 'icon',
+		layout: {
+			styles: {
+				name: {
+					width: '60%',
+					minWidth: '300px',
+				},
+				sites: {
+					width: '70px',
+				},
+				update: {
+					minWidth: '200px',
+				},
+				actions: {
+					width: '50px',
+				},
+			},
+		},
+	} );
+
+	// Re-resolve the selected item so the pane reflects refetched data after updates.
+	const selectedTheme = useMemo(
+		() =>
+			dataViewsState.selectedItem &&
+			themes.find( ( theme ) => theme.id === dataViewsState.selectedItem?.id ),
+		[ dataViewsState.selectedItem, themes ]
+	);
+
+	const openThemeSitesPane = useCallback(
+		( theme: AggregatedTheme ) => {
+			setDataViewsState( ( prevState ) => ( {
+				...prevState,
+				selectedItem: theme,
+				type: DATAVIEWS_LIST,
+			} ) );
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_themes_list_theme_sitecount_click', {
+					theme_slug: theme.id,
+					site_count: theme.sites.length,
+				} )
+			);
+		},
+		[ dispatch ]
+	);
+
+	const closeThemeSitesPane = useCallback( () => {
+		setDataViewsState( ( prevState ) => ( {
+			...prevState,
+			selectedItem: null,
+			type: DATAVIEWS_TABLE,
+		} ) );
+	}, [] );
+
+	const isThemeUpdating = useCallback(
+		( themeId: string ) =>
+			Array.from( updatingKeys ).some( ( key ) => key.startsWith( `${ themeId }|` ) ),
+		[ updatingKeys ]
+	);
+
+	const isSiteUpdating = useCallback(
+		( themeId: string, siteId: number ) => updatingKeys.has( pairKey( themeId, siteId ) ),
+		[ updatingKeys ]
+	);
+
+	const performUpdates = useCallback(
+		async ( pairs: UpdatePair[] ) => {
+			if ( ! pairs.length ) {
+				return;
+			}
+
+			setUpdatingKeys( ( previous ) => {
+				const next = new Set( previous );
+				pairs.forEach( ( pair ) => next.add( pairKey( pair.themeId, pair.siteId ) ) );
+				return next;
+			} );
+
+			const themesBySite = new Map< number, string[] >();
+			pairs.forEach( ( pair ) => {
+				themesBySite.set( pair.siteId, [
+					...( themesBySite.get( pair.siteId ) ?? [] ),
+					pair.themeId,
+				] );
+			} );
+
+			const results = await Promise.allSettled(
+				Array.from( themesBySite.entries() ).map( ( [ siteId, themeSlugs ] ) =>
+					updateSiteThemes( { siteId, themes: themeSlugs } ).finally( () => {
+						setUpdatingKeys( ( previous ) => {
+							const next = new Set( previous );
+							themeSlugs.forEach( ( slug ) => next.delete( pairKey( slug, siteId ) ) );
+							return next;
+						} );
+					} )
+				)
+			);
+
+			const failures = results.filter( ( result ) => result.status === 'rejected' ).length;
+			if ( failures ) {
+				dispatch(
+					errorNotice(
+						sprintf(
+							/* translators: %d is the number of sites where theme updates failed */
+							_n(
+								'Theme updates failed on %d site.',
+								'Theme updates failed on %d sites.',
+								failures
+							),
+							failures
+						)
+					)
+				);
+			} else {
+				dispatch( successNotice( __( 'Themes updated.' ), { duration: 5000 } ) );
+			}
+		},
+		[ dispatch, updateSiteThemes ]
+	);
+
+	const confirmUpdateThemes = useCallback(
+		( items: AggregatedTheme[] ) => {
+			const eligible = items.filter( ( item ) => item.pendingUpdates.length > 0 );
+			if ( ! eligible.length ) {
+				return;
+			}
+
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_themes_update_click', { theme_count: eligible.length } )
+			);
+
+			const pairs: UpdatePair[] = eligible.flatMap( ( item ) =>
+				item.pendingUpdates.map( ( site ) => ( { themeId: item.id, siteId: site.siteId } ) )
+			);
+			const siteCount = new Set( pairs.map( ( pair ) => pair.siteId ) ).size;
+
+			const message =
+				eligible.length === 1
+					? sprintf(
+							/* translators: %1$s is a theme name, %2$d is a number of sites */
+							_n(
+								'You are about to update %1$s on %2$d site.',
+								'You are about to update %1$s on %2$d sites.',
+								siteCount
+							),
+							eligible[ 0 ].name,
+							siteCount
+					  )
+					: sprintf(
+							/* translators: %1$d is a number of themes, %2$d is a number of sites */
+							_n(
+								'You are about to update %1$d themes on %2$d site.',
+								'You are about to update %1$d themes on %2$d sites.',
+								siteCount
+							),
+							eligible.length,
+							siteCount
+					  );
+
+			acceptDialog(
+				<p>{ message }</p>,
+				( accepted: boolean ) => {
+					if ( accepted ) {
+						performUpdates( pairs );
+					}
+				},
+				__( 'Update' ),
+				__( 'Cancel' ),
+				{
+					useModal: true,
+					additionalClassNames: 'themes-dashboard__confirmation-modal',
+					modalOptions: {
+						title: __( 'Update themes' ),
+					},
+				}
+			);
+		},
+		[ dispatch, performUpdates ]
+	);
+
+	const updateSingleSite = useCallback(
+		( theme: AggregatedTheme, site: ThemeSiteInstance ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_themes_sites_pane_update_click', {
+					theme_slug: theme.id,
+					site_id: site.siteId,
+				} )
+			);
+			performUpdates( [ { themeId: theme.id, siteId: site.siteId } ] );
+		},
+		[ dispatch, performUpdates ]
+	);
+
+	const confirmSetAutoupdates = useCallback(
+		( items: AggregatedTheme[], autoupdate: boolean ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_themes_autoupdate_toggle_click', {
+					theme_count: items.length,
+					enabled: autoupdate,
+				} )
+			);
+
+			const themesBySite = new Map< number, string[] >();
+			items.forEach( ( item ) =>
+				item.sites.forEach( ( site ) => {
+					themesBySite.set( site.siteId, [
+						...( themesBySite.get( site.siteId ) ?? [] ),
+						item.id,
+					] );
+				} )
+			);
+
+			const message = autoupdate
+				? sprintf(
+						/* translators: %1$d is a number of themes, %2$d is a number of sites */
+						_n(
+							'This will enable auto-updates for %1$d theme on %2$d site.',
+							'This will enable auto-updates for %1$d theme across %2$d sites.',
+							themesBySite.size
+						),
+						items.length,
+						themesBySite.size
+				  )
+				: sprintf(
+						/* translators: %1$d is a number of themes, %2$d is a number of sites */
+						_n(
+							'This will disable auto-updates for %1$d theme on %2$d site.',
+							'This will disable auto-updates for %1$d theme across %2$d sites.',
+							themesBySite.size
+						),
+						items.length,
+						themesBySite.size
+				  );
+
+			acceptDialog(
+				<p>{ message }</p>,
+				async ( accepted: boolean ) => {
+					if ( ! accepted ) {
+						return;
+					}
+					const results = await Promise.allSettled(
+						Array.from( themesBySite.entries() ).map( ( [ siteId, themeSlugs ] ) =>
+							setSiteThemesAutoupdate( { siteId, themes: themeSlugs, autoupdate } )
+						)
+					);
+					const failures = results.filter( ( result ) => result.status === 'rejected' ).length;
+					if ( failures ) {
+						dispatch( errorNotice( __( 'Some auto-update settings could not be changed.' ) ) );
+					} else {
+						dispatch(
+							successNotice(
+								autoupdate ? __( 'Auto-updates enabled.' ) : __( 'Auto-updates disabled.' ),
+								{ duration: 5000 }
+							)
+						);
+					}
+				},
+				autoupdate ? __( 'Enable' ) : __( 'Disable' ),
+				__( 'Cancel' ),
+				{
+					useModal: true,
+					additionalClassNames: 'themes-dashboard__confirmation-modal',
+					modalOptions: {
+						title: autoupdate ? __( 'Enable auto-updates' ) : __( 'Disable auto-updates' ),
+					},
+				}
+			);
+		},
+		[ dispatch, setSiteThemesAutoupdate ]
+	);
+
+	const showLoading = ! sitesLoaded || ( sites.length > 0 && isLoading );
+
+	const updatedDataViewsState = useMemo(
+		() => ( { ...dataViewsState, selectedItem: selectedTheme } ),
+		[ dataViewsState, selectedTheme ]
+	);
+
+	const dashboardTitle = selectedTheme
+		? sprintf(
+				/* translators: %s is a theme name */
+				__( 'Manage %s in all sites' ),
+				selectedTheme.name
+		  )
+		: __( 'Manage themes' );
+
+	return (
+		<Layout
+			className={ clsx(
+				'sites-dashboard',
+				'sites-dashboard__layout',
+				! selectedTheme && 'preview-hidden'
+			) }
+			wide
+			title={ dashboardTitle }
+			sidebarNavigation={ <SidebarNavigation sectionTitle={ __( 'Manage themes' ) } /> }
+		>
+			<QuerySites allSites />
+			<LayoutColumn className="sites-overview" wide>
+				<LayoutTop withNavigation={ false }>
+					<LayoutHeader>
+						<Title>{ __( 'Manage themes' ) }</Title>
+						{ ! selectedTheme && (
+							<Subtitle>{ __( 'Manage all your themes in one place' ) }</Subtitle>
+						) }
+					</LayoutHeader>
+				</LayoutTop>
+				<ThemesList
+					themes={ themes }
+					isLoading={ showLoading }
+					dataViewsState={ updatedDataViewsState }
+					setDataViewsState={ setDataViewsState }
+					onUpdateThemes={ confirmUpdateThemes }
+					onSetAutoupdates={ confirmSetAutoupdates }
+					openThemeSitesPane={ openThemeSitesPane }
+					isThemeUpdating={ isThemeUpdating }
+				/>
+			</LayoutColumn>
+			{ selectedTheme && (
+				<ThemeSitesPane
+					theme={ selectedTheme }
+					onClose={ closeThemeSitesPane }
+					onUpdateSite={ updateSingleSite }
+					isSiteUpdating={ isSiteUpdating }
+				/>
+			) }
+		</Layout>
+	);
+}

--- a/client/a8c-for-agencies/sections/themes/primary/themes-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/themes/primary/themes-dashboard/style.scss
@@ -1,0 +1,69 @@
+.themes-list__screenshot {
+	display: block;
+	object-fit: cover;
+	border-radius: 4px;
+}
+
+.themes-list__screenshot-fallback {
+	color: var( --color-neutral-20 );
+}
+
+.themes-list__name-container {
+	text-overflow: ellipsis;
+	overflow: hidden;
+}
+
+.themes-list__sites-button {
+	margin-inline-start: -12px;
+	font-size: inherit;
+	color: inherit;
+	cursor: pointer;
+}
+
+.themes-dashboard__updating {
+	color: var( --color-text-subtle );
+	font-style: italic;
+}
+
+.themes-dashboard__sites-pane-screenshot {
+	border-radius: 2px;
+	object-fit: cover;
+}
+
+.themes-sites-table {
+	inline-size: 100%;
+	border-collapse: collapse;
+
+	th {
+		text-align: start;
+		color: var( --color-text-subtle );
+		font-weight: 500;
+		padding-block: 8px;
+		border-block-end: 1px solid var( --color-border-subtle );
+	}
+
+	td {
+		padding-block: 12px;
+		border-block-end: 1px solid var( --color-border-subtle );
+		vertical-align: middle;
+	}
+}
+
+.themes-sites-table__site-title {
+	font-weight: 500;
+}
+
+.themes-sites-table__site-url {
+	color: var( --color-text-subtle );
+	font-size: 0.75rem;
+}
+
+.themes-sites-table__active-badge {
+	display: inline-block;
+	padding-block: 2px;
+	padding-inline: 8px;
+	border-radius: 16px;
+	background: var( --color-success-5 );
+	color: var( --color-success-80 );
+	font-size: 0.75rem;
+}

--- a/client/a8c-for-agencies/sections/themes/primary/themes-dashboard/theme-sites-pane.tsx
+++ b/client/a8c-for-agencies/sections/themes/primary/themes-dashboard/theme-sites-pane.tsx
@@ -1,0 +1,105 @@
+import { Gridicon } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { sprintf, __ } from '@wordpress/i18n';
+import LayoutBody from 'calypso/layout/hosting-dashboard/body';
+import LayoutColumn from 'calypso/layout/hosting-dashboard/column';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+	LayoutHeaderActions as Actions,
+} from 'calypso/layout/hosting-dashboard/header';
+import LayoutTop from 'calypso/layout/hosting-dashboard/top';
+import type { AggregatedTheme, ThemeSiteInstance } from '../../types';
+
+const getDisplayUrl = ( url: string ) => url.replace( /^https?:\/\//, '' );
+
+export default function ThemeSitesPane( {
+	theme,
+	onClose,
+	onUpdateSite,
+	isSiteUpdating,
+}: {
+	theme: AggregatedTheme;
+	onClose: () => void;
+	onUpdateSite: ( theme: AggregatedTheme, site: ThemeSiteInstance ) => void;
+	isSiteUpdating: ( themeId: string, siteId: number ) => boolean;
+} ) {
+	return (
+		<LayoutColumn className="plugin-manage-sites-pane" wide>
+			<LayoutTop withNavigation={ false }>
+				<LayoutHeader>
+					<Title>
+						{ theme.screenshot && (
+							<img
+								className="themes-dashboard__sites-pane-screenshot"
+								width={ 24 }
+								height={ 24 }
+								src={ theme.screenshot }
+								alt={ theme.name }
+							/>
+						) }
+						{ theme.name }
+					</Title>
+					<Actions>
+						<Button variant="tertiary" onClick={ onClose } aria-label={ __( 'Close' ) }>
+							<Gridicon icon="cross" size={ 24 } />
+						</Button>
+					</Actions>
+				</LayoutHeader>
+			</LayoutTop>
+			<LayoutBody>
+				<table className="themes-sites-table">
+					<thead>
+						<tr>
+							<th>{ __( 'Site' ) }</th>
+							<th>{ __( 'Version' ) }</th>
+							<th>{ __( 'Status' ) }</th>
+							<th>{ __( 'Update available' ) }</th>
+						</tr>
+					</thead>
+					<tbody>
+						{ theme.sites.map( ( site ) => (
+							<tr key={ site.siteId }>
+								<td>
+									<div className="themes-sites-table__site-title">{ site.siteTitle }</div>
+									<a
+										className="themes-sites-table__site-url"
+										href={ site.siteUrl }
+										target="_blank"
+										rel="noreferrer"
+									>
+										{ getDisplayUrl( site.siteUrl ) }
+									</a>
+								</td>
+								<td>{ site.version }</td>
+								<td>
+									{ site.active ? (
+										<span className="themes-sites-table__active-badge">{ __( 'Active' ) }</span>
+									) : (
+										__( 'Inactive' )
+									) }
+								</td>
+								<td>
+									{ isSiteUpdating( theme.id, site.siteId ) && (
+										<span className="themes-dashboard__updating">{ __( 'Updating…' ) }</span>
+									) }
+									{ ! isSiteUpdating( theme.id, site.siteId ) &&
+										( site.newVersion ? (
+											<Button variant="secondary" onClick={ () => onUpdateSite( theme, site ) }>
+												{ sprintf(
+													/* translators: %s is the new theme version */
+													__( 'Update to version %s' ),
+													site.newVersion
+												) }
+											</Button>
+										) : (
+											__( 'No' )
+										) ) }
+								</td>
+							</tr>
+						) ) }
+					</tbody>
+				</table>
+			</LayoutBody>
+		</LayoutColumn>
+	);
+}

--- a/client/a8c-for-agencies/sections/themes/primary/themes-dashboard/themes-list.tsx
+++ b/client/a8c-for-agencies/sections/themes/primary/themes-dashboard/themes-list.tsx
@@ -1,0 +1,287 @@
+import { Gridicon } from '@automattic/components';
+import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
+import { Button } from '@wordpress/components';
+import { filterSortAndPaginate, Operator } from '@wordpress/dataviews';
+import { sprintf, _n, __ } from '@wordpress/i18n';
+import { useEffect, useMemo, useState } from 'react';
+import {
+	DATAVIEWS_LIST,
+	DATAVIEWS_TABLE,
+} from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import { DataViews } from 'calypso/components/dataviews';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { THEME_STATUS } from '../../types';
+import type { AggregatedTheme } from '../../types';
+import type { SupportedLayouts } from '@wordpress/dataviews';
+
+import './style.scss';
+
+export default function ThemesList( {
+	themes,
+	isLoading,
+	dataViewsState,
+	setDataViewsState,
+	onUpdateThemes,
+	onSetAutoupdates,
+	openThemeSitesPane,
+	isThemeUpdating,
+}: {
+	themes: AggregatedTheme[];
+	isLoading: boolean;
+	dataViewsState: DataViewsState;
+	setDataViewsState: React.Dispatch< React.SetStateAction< DataViewsState > >;
+	onUpdateThemes: ( items: AggregatedTheme[] ) => void;
+	onSetAutoupdates: ( items: AggregatedTheme[], autoupdate: boolean ) => void;
+	openThemeSitesPane: ( theme: AggregatedTheme ) => void;
+	isThemeUpdating: ( themeId: string ) => boolean;
+} ) {
+	const dispatch = useDispatch();
+	const isPaneOpen = !! dataViewsState.selectedItem;
+	const isDesktopView = isDesktop();
+	const shouldUseListView = isPaneOpen || ! isDesktopView;
+
+	// Match the plugins list: restrict layouts to the one in use, which also
+	// removes the layout switcher option.
+	const defaultLayouts: SupportedLayouts = shouldUseListView ? { list: {} } : { table: {} };
+
+	const themeUpdateCount = themes.filter( ( theme ) => theme.pendingUpdates.length > 0 ).length;
+
+	const [ isFilteringUpdates, setIsFilteringUpdates ] = useState( false );
+
+	useEffect( () => {
+		setDataViewsState( ( prevState ) => ( {
+			...prevState,
+			type: shouldUseListView ? DATAVIEWS_LIST : DATAVIEWS_TABLE,
+		} ) );
+
+		const unsubscribe = subscribeIsDesktop( ( matches ) => {
+			setDataViewsState( ( prevState ) => ( {
+				...prevState,
+				type: isPaneOpen || ! matches ? DATAVIEWS_LIST : DATAVIEWS_TABLE,
+			} ) );
+		} );
+
+		return () => unsubscribe();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ isPaneOpen ] );
+
+	useEffect( () => {
+		if (
+			dataViewsState.filters?.length === 1 &&
+			dataViewsState.filters[ 0 ].field === 'status' &&
+			dataViewsState.filters[ 0 ].value?.includes( THEME_STATUS.UPDATE )
+		) {
+			setIsFilteringUpdates( true );
+		} else {
+			setIsFilteringUpdates( false );
+		}
+	}, [ dataViewsState.filters ] );
+
+	const fields = useMemo(
+		() => [
+			{
+				id: 'status',
+				label: __( 'Status' ),
+				getValue: ( { item }: { item: AggregatedTheme } ) => item.status,
+				render: () => null,
+				elements: [
+					{ value: THEME_STATUS.ACTIVE, label: __( 'Active' ) },
+					{ value: THEME_STATUS.INACTIVE, label: __( 'Inactive' ) },
+					{ value: THEME_STATUS.UPDATE, label: __( 'Update available' ) },
+				],
+				filterBy: {
+					operators: [ 'isAny' as Operator ],
+					isPrimary: false,
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'icon',
+				label: __( 'Screenshot' ),
+				render: ( { item }: { item: AggregatedTheme } ) => {
+					const size = shouldUseListView ? 52 : 35;
+					return item.screenshot ? (
+						<img
+							className="themes-list__screenshot"
+							style={ { width: size, height: size } }
+							src={ item.screenshot }
+							alt={ item.name }
+						/>
+					) : (
+						<Gridicon className="themes-list__screenshot-fallback" icon="themes" size={ 36 } />
+					);
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'name',
+				label: __( 'Installed themes' ),
+				getValue: ( { item }: { item: AggregatedTheme } ) => item.name,
+				enableGlobalSearch: true,
+				render: ( { item }: { item: AggregatedTheme } ) => (
+					<>
+						<div className="themes-list__name-container">{ item.name }</div>
+						{ isThemeUpdating( item.id ) && (
+							<div className="themes-dashboard__updating">{ __( 'Updating…' ) }</div>
+						) }
+					</>
+				),
+				enableSorting: true,
+			},
+			{
+				id: 'sites',
+				label: __( 'Sites' ),
+				enableHiding: false,
+				getValue: ( { item }: { item: AggregatedTheme } ) => item.sites.length,
+				render: ( { item }: { item: AggregatedTheme } ) => {
+					const numberOfSites = item.sites.length;
+					return (
+						<Button
+							className="themes-list__sites-button"
+							onClick={ () => openThemeSitesPane( item ) }
+						>
+							{ shouldUseListView
+								? sprintf(
+										/* translators: %d is the number of sites the theme is installed on */
+										_n( '%d site', '%d sites', numberOfSites ),
+										numberOfSites
+								  )
+								: numberOfSites }
+						</Button>
+					);
+				},
+				enableSorting: true,
+			},
+			{
+				id: 'update',
+				label: __( 'Update available' ),
+				getValue: ( { item }: { item: AggregatedTheme } ) =>
+					item.pendingUpdates.length ? 'a' : 'b',
+				enableHiding: false,
+				enableSorting: true,
+				render: ( { item }: { item: AggregatedTheme } ) => {
+					if ( shouldUseListView ) {
+						return null;
+					}
+
+					if ( isThemeUpdating( item.id ) ) {
+						return <span className="themes-dashboard__updating">{ __( 'Updating…' ) }</span>;
+					}
+
+					if ( ! item.pendingUpdates.length ) {
+						return __( 'No' );
+					}
+
+					return (
+						<Button variant="secondary" onClick={ () => onUpdateThemes( [ item ] ) }>
+							{ sprintf(
+								/* translators: %s is the new theme version */
+								__( 'Update to version %s' ),
+								item.pendingUpdates[ 0 ].newVersion
+							) }
+						</Button>
+					);
+				},
+			},
+		],
+		[ shouldUseListView, isThemeUpdating, onUpdateThemes, openThemeSitesPane ]
+	);
+
+	const actions = useMemo(
+		() => [
+			{
+				id: 'update',
+				label: __( 'Update to latest version' ),
+				supportsBulk: true,
+				isEligible: ( item: AggregatedTheme ) => item.pendingUpdates.length > 0,
+				callback: ( items: AggregatedTheme[] ) => onUpdateThemes( items ),
+			},
+			{
+				id: 'enable-autoupdates',
+				label: __( 'Enable auto-updates' ),
+				supportsBulk: true,
+				callback: ( items: AggregatedTheme[] ) => onSetAutoupdates( items, true ),
+			},
+			{
+				id: 'disable-autoupdates',
+				label: __( 'Disable auto-updates' ),
+				supportsBulk: true,
+				callback: ( items: AggregatedTheme[] ) => onSetAutoupdates( items, false ),
+			},
+		],
+		[ onUpdateThemes, onSetAutoupdates ]
+	);
+
+	const header = (
+		<>
+			{ themeUpdateCount > 0 && (
+				<Button
+					isPressed={ isFilteringUpdates }
+					onClick={ () => {
+						if ( isFilteringUpdates ) {
+							setDataViewsState( ( prevState ) => ( {
+								...prevState,
+								filters: [],
+								page: 1,
+							} ) );
+						} else {
+							setDataViewsState( ( prevState ) => ( {
+								...prevState,
+								filters: [
+									{
+										field: 'status',
+										operator: 'isAny',
+										value: [ THEME_STATUS.UPDATE ],
+									},
+								],
+								page: 1,
+							} ) );
+						}
+						setIsFilteringUpdates( ! isFilteringUpdates );
+						dispatch( recordTracksEvent( 'calypso_a4a_themes_list_pending_update_filter_click' ) );
+					} }
+				>
+					{ sprintf(
+						/* translators: %d is the number of themes with updates available */
+						__( 'Update available (%d)' ),
+						themeUpdateCount
+					) }
+				</Button>
+			) }
+		</>
+	);
+
+	const { data, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( themes, dataViewsState, fields );
+	}, [ themes, dataViewsState, fields ] );
+
+	return (
+		<DataViews
+			data={ data }
+			view={ dataViewsState }
+			onChangeView={ setDataViewsState }
+			onChangeSelection={ ( selection: string[] ) => {
+				if ( dataViewsState.type === DATAVIEWS_LIST ) {
+					const theme = themes.find( ( item ) => item.id === selection[ 0 ] );
+					if ( theme ) {
+						openThemeSitesPane( theme );
+					}
+				}
+			} }
+			onClickItem={ ( item: AggregatedTheme ) => openThemeSitesPane( item ) }
+			getItemId={ ( item: AggregatedTheme ) => item.id }
+			fields={ fields }
+			search
+			searchLabel={ __( 'Search' ) }
+			actions={ isPaneOpen ? [] : actions }
+			isLoading={ isLoading }
+			paginationInfo={ paginationInfo }
+			defaultLayouts={ defaultLayouts }
+			header={ header }
+		/>
+	);
+}

--- a/client/a8c-for-agencies/sections/themes/style.scss
+++ b/client/a8c-for-agencies/sections/themes/style.scss
@@ -1,0 +1,35 @@
+@import "@wordpress/base-styles/mixins";
+
+.is-section-a8c-for-agencies-themes {
+	.wpcom-site {
+		.main.hosting-dashboard-layout.sites-dashboard.sites-dashboard__layout:not(.preview-hidden) {
+			.hosting-dashboard-layout-column__container.hosting-dashboard-layout-column__container.hosting-dashboard-layout-column__container {
+				height: calc(100vh - 40px - var(--masterbar-height));
+
+				.hosting-dashboard-layout__top-wrapper {
+					display: block;
+				}
+			}
+		}
+	}
+
+	.plugin-manage-sites-pane {
+		.hosting-dashboard-layout-column__container {
+			.hosting-dashboard-layout__top-wrapper {
+				display: flex;
+			}
+
+			.hosting-dashboard-layout__viewport {
+				box-sizing: border-box;
+
+				> div {
+					width: 100%;
+				}
+			}
+		}
+	}
+
+	.themes-dashboard__confirmation-modal .components-modal__content p {
+		@include body-medium;
+	}
+}

--- a/client/a8c-for-agencies/sections/themes/types.ts
+++ b/client/a8c-for-agencies/sections/themes/types.ts
@@ -1,0 +1,46 @@
+export interface SiteTheme {
+	id: string;
+	name: string;
+	version: string;
+	active: boolean;
+	autoupdate: boolean;
+	update: { new_version: string } | null;
+	author?: string;
+	screenshot?: string;
+}
+
+export interface SiteThemesApiResponse {
+	found: number;
+	themes: SiteTheme[];
+}
+
+export interface ThemeSiteInstance {
+	siteId: number;
+	siteTitle: string;
+	siteUrl: string;
+	version: string;
+	active: boolean;
+	newVersion: string | null;
+}
+
+export const THEME_STATUS = {
+	ACTIVE: 'active',
+	INACTIVE: 'inactive',
+	UPDATE: 'update',
+} as const;
+
+export interface AggregatedTheme {
+	id: string;
+	name: string;
+	author?: string;
+	screenshot?: string;
+	status: string[];
+	sites: ThemeSiteInstance[];
+	pendingUpdates: ThemeSiteInstance[];
+}
+
+export interface ThemesDashboardSite {
+	ID: number;
+	title: string;
+	URL: string;
+}

--- a/client/sections.js
+++ b/client/sections.js
@@ -879,6 +879,12 @@ const sections = [
 		group: 'a8c-for-agencies',
 	},
 	{
+		name: 'a8c-for-agencies-themes',
+		paths: [ '/themes' ],
+		module: 'calypso/a8c-for-agencies/sections/themes',
+		group: 'a8c-for-agencies',
+	},
+	{
 		name: 'a8c-for-agencies-marketplace',
 		paths: [
 			'/marketplace',

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -64,6 +64,7 @@
 		"a8c-for-agencies-overview": true,
 		"a8c-for-agencies-reports": true,
 		"a8c-for-agencies-plugins": true,
+		"a8c-for-agencies-themes": true,
 		"a8c-for-agencies-sites": true,
 		"a8c-for-agencies-marketplace": true,
 		"a8c-for-agencies-purchases": true,


### PR DESCRIPTION
## Proposed Changes

This is a test interface for exercising the new theme-update API path (Jetpack + WPCOM PRs) - it is not intended to ship in its current form. The section is enabled only in config/a8c-for-agencies-development.json; the stage, horizon, and production section allowlists are deliberately untouched, so this is invisible outside local dev even if merged. Keep as draft.

Adds a "Themes" entry to the A4A sidebar (below Plugins) and a Manage themes page mirroring the Manage plugins page: aggregated theme list across all of the agency's Jetpack sites with screenshots, status filters (Active / Inactive / Update available), search, an "Update available (N)" quick filter, a per-theme sites slide-out pane, per-row and bulk "Update to version X" actions with confirmation dialogs, and bulk auto-update enable/disable. Updates post `{ action: 'update', themes: [...] }` to `POST /sites/%s/themes` per site - the route hardened by the companion Jetpack PR.

<img width="1997" height="1522" alt="Screenshot 2026-08-11 at 10 18 02 AM" src="https://github.com/user-attachments/assets/1ccb10fb-3cc6-4d22-aff4-b7e5e5206299" />

Known shortcuts (why this shouldn't ship as-is)

- Client-side fan-out: theme inventories come from one `GET /sites/%s/themes` request per site (react-query, 5-minute cache). Fine for a test fleet; the real implementation waits on the `awaiting_theme_updates` Elasticsearch field on the wpcom side.
- Style coupling: for pixel parity the page imports `my-sites/plugins/plugins-dashboard/style.scss` and `sites/components/dotcom-style.scss` and reuses plugins class names (including plugin-manage-sites-pane). Extracting shared styles is part of the planned themes/plugins consolidation.
- No tests; permission gating reuses `a4a_read_managed_sites` like Plugins.

## Testing Instructions

Prereqs: an agency account with a few Jetpack-connected sites; at least one site with a pending theme update (easiest: lower a theme's Version: in its style.css, then visit wp-admin → Updates). For the full loop, one site should run the companion Jetpack branch - but the bulk update route already exists in production, so basic testing works against prod API too.

1. Start the A4A dev server and log in at agencies.localhost:3000. "Themes" appears in the sidebar directly below "Plugins".
2. Open it. The page mirrors Manage plugins: same header (title + subtitle), toolbar, column set (theme with screenshot / sites / update available), and row treatment.
3. Search for a theme name; toggle the filter → "Update available"; click the "Update available (N)" chip. All narrow the list correctly.
4. Click a sites count. A slide-out pane opens listing each site with version, Active badge, and a per-site update button.
5. Click a row's "Update to version X". A confirmation modal summarizes the themes/sites affected; confirming shows "Updating…", then a success notice, and the row flips to "No" after refetch. Verify on the site that the theme actually updated.
6. Select multiple themes → "Update to latest version" bulk action. Same confirm-and-update flow across sites.
7. Bulk "Enable auto-updates" on a theme, then on a site running the Jetpack branch run wp option get auto_update_themes. The slug appears (and wp-admin → Appearance shows auto-updates enabled); "Disable auto-updates" removes it.
8. Sanity: the Plugins page, sites dashboard, and theme activation elsewhere are unchanged.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
