### PR TITLE
Launch site step: stop retrying forever and show the error

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -124,23 +124,42 @@ function getSignupDestination( { siteSlug, redirect_to, localeSlug, flowName } )
 	return redirectTo;
 }
 
-function getLaunchDestination( dependencies ) {
+function getLaunchReturnTarget( dependencies ) {
 	// If a back_to parameter is provided, use it as the destination
 	if ( dependencies.back_to ) {
-		return addQueryArgs( { celebrateLaunch: 'true' }, dependencies.back_to );
+		return { url: dependencies.back_to, celebrateArgs: { celebrateLaunch: 'true' } };
 	}
 
 	const ref = dependencies.refParameter?.trim() ?? '';
 	const isWpAdminPath = ref === 'wp-admin' || ref.startsWith( 'wp-admin/' );
 
 	if ( isWpAdminPath ) {
-		return addQueryArgs(
-			{ 'celebrate-launch': 'true' },
-			`https://${ dependencies.siteSlug }/${ ref }`
-		);
+		return {
+			url: `https://${ dependencies.siteSlug }/${ ref }`,
+			celebrateArgs: { 'celebrate-launch': 'true' },
+		};
 	}
 
-	return addQueryArgs( { celebrateLaunch: 'true' }, `/home/${ dependencies.siteSlug }` );
+	return {
+		url: `/home/${ dependencies.siteSlug }`,
+		celebrateArgs: { celebrateLaunch: 'true' },
+	};
+}
+
+/**
+ * Where the user came from before entering the launch flow, without the arguments that celebrate a
+ * successful launch. Use this when the launch did not happen.
+ * @param {Object} dependencies the signup dependency store
+ * @returns {string} the URL to send the user back to
+ */
+export function getLaunchReturnUrl( dependencies ) {
+	return getLaunchReturnTarget( dependencies ).url;
+}
+
+function getLaunchDestination( dependencies ) {
+	const { url, celebrateArgs } = getLaunchReturnTarget( dependencies );
+
+	return addQueryArgs( celebrateArgs, url );
 }
 
 function getDomainSignupFlowDestination( { designType, siteSlug, flowName } ) {

--- a/client/signup/steps/launch-site/index.jsx
+++ b/client/signup/steps/launch-site/index.jsx
@@ -1,17 +1,83 @@
+import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import StepWrapper from 'calypso/signup/step-wrapper';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
+
+import './style.scss';
+
+function getErrorMessage( step ) {
+	const errors = step?.errors;
+
+	if ( Array.isArray( errors ) ) {
+		return errors[ 0 ]?.message;
+	}
+
+	return errors?.message;
+}
 
 class LaunchSiteComponent extends Component {
 	componentDidMount() {
+		// The processing screen unmounts and remounts this step whenever the step status changes,
+		// so launching on every mount turns a failed request into an endless request loop.
+		const status = this.props.step?.status;
+
+		if ( ! status || status === 'in-progress' ) {
+			this.launchSite();
+		}
+	}
+
+	launchSite = () => {
 		const { flowName, stepName } = this.props;
+
 		this.props.submitSignupStep( { stepName } );
 		this.props.goToNextStep( flowName );
+	};
+
+	renderErrorContent() {
+		const { signupDependencies, translate } = this.props;
+		const siteSlug = signupDependencies?.siteSlug;
+
+		return (
+			<div className="launch-site__actions">
+				<Button primary onClick={ this.launchSite }>
+					{ translate( 'Try again' ) }
+				</Button>
+				<Button href={ siteSlug ? `/home/${ siteSlug }` : '/home' }>
+					{ translate( 'Back to dashboard' ) }
+				</Button>
+			</div>
+		);
 	}
 
 	render() {
-		return null;
+		const { flowName, positionInFlow, step, stepName, translate } = this.props;
+
+		if ( step?.status !== 'invalid' ) {
+			return null;
+		}
+
+		const headerText = translate( 'We couldn’t launch your site' );
+		const message =
+			getErrorMessage( step ) ||
+			translate( 'Something went wrong and we couldn’t launch your site. Please try again.' );
+
+		return (
+			<StepWrapper
+				className="launch-site"
+				flowName={ flowName }
+				stepName={ stepName }
+				positionInFlow={ positionInFlow }
+				headerText={ headerText }
+				fallbackHeaderText={ headerText }
+				subHeaderText={ message }
+				fallbackSubHeaderText={ message }
+				hideSkip
+				stepContent={ this.renderErrorContent() }
+			/>
+		);
 	}
 }
 
-export default connect( null, { submitSignupStep } )( LaunchSiteComponent );
+export default connect( null, { submitSignupStep } )( localize( LaunchSiteComponent ) );

--- a/client/signup/steps/launch-site/index.jsx
+++ b/client/signup/steps/launch-site/index.jsx
@@ -2,6 +2,7 @@ import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { getLaunchReturnUrl } from 'calypso/signup/config/flows';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 
@@ -24,28 +25,20 @@ class LaunchSiteComponent extends Component {
 		const status = this.props.step?.status;
 
 		if ( ! status || status === 'in-progress' ) {
-			this.launchSite();
+			const { flowName, stepName } = this.props;
+
+			this.props.submitSignupStep( { stepName } );
+			this.props.goToNextStep( flowName );
 		}
 	}
 
-	launchSite = () => {
-		const { flowName, stepName } = this.props;
-
-		this.props.submitSignupStep( { stepName } );
-		this.props.goToNextStep( flowName );
-	};
-
 	renderErrorContent() {
 		const { signupDependencies, translate } = this.props;
-		const siteSlug = signupDependencies?.siteSlug;
 
 		return (
 			<div className="launch-site__actions">
-				<Button primary onClick={ this.launchSite }>
-					{ translate( 'Try again' ) }
-				</Button>
-				<Button href={ siteSlug ? `/home/${ siteSlug }` : '/home' }>
-					{ translate( 'Back to dashboard' ) }
+				<Button primary href={ getLaunchReturnUrl( signupDependencies ?? {} ) }>
+					{ translate( 'Go back' ) }
 				</Button>
 			</div>
 		);
@@ -61,7 +54,7 @@ class LaunchSiteComponent extends Component {
 		const headerText = translate( 'We couldn’t launch your site' );
 		const message =
 			getErrorMessage( step ) ||
-			translate( 'Something went wrong and we couldn’t launch your site. Please try again.' );
+			translate( 'Something went wrong and we couldn’t launch your site.' );
 
 		return (
 			<StepWrapper
@@ -73,6 +66,7 @@ class LaunchSiteComponent extends Component {
 				fallbackHeaderText={ headerText }
 				subHeaderText={ message }
 				fallbackSubHeaderText={ message }
+				hideBack
 				hideSkip
 				stepContent={ this.renderErrorContent() }
 			/>

--- a/client/signup/steps/launch-site/style.scss
+++ b/client/signup/steps/launch-site/style.scss
@@ -1,0 +1,6 @@
+.launch-site__actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 12px;
+	justify-content: center;
+}

--- a/client/signup/steps/launch-site/test/index.jsx
+++ b/client/signup/steps/launch-site/test/index.jsx
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import LaunchSiteComponent from '../index';
@@ -55,10 +54,37 @@ describe( 'LaunchSiteComponent', () => {
 		expect(
 			screen.getByText( 'You can not launch your site without a paid eCommerce plan.' )
 		).toBeVisible();
-		expect( screen.getByRole( 'button', { name: 'Try again' } ) ).toBeVisible();
-		expect( screen.getByRole( 'link', { name: 'Back to dashboard' } ) ).toHaveAttribute(
+		expect( screen.queryByRole( 'button', { name: 'Try again' } ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: 'Go back' } ) ).toHaveAttribute(
 			'href',
 			'/home/example.wordpress.com'
+		);
+	} );
+
+	it( 'sends the user back to where the launch flow was started from', () => {
+		renderStep( {
+			signupDependencies: {
+				siteSlug: 'example.wordpress.com',
+				back_to: '/sites/example.wordpress.com/settings',
+			},
+			step: { stepName: 'launch', status: 'invalid', errors: { message: 'Nope.' } },
+		} );
+
+		expect( screen.getByRole( 'link', { name: 'Go back' } ) ).toHaveAttribute(
+			'href',
+			'/sites/example.wordpress.com/settings'
+		);
+	} );
+
+	it( 'sends the user back to wp-admin when the flow was started from there', () => {
+		renderStep( {
+			signupDependencies: { siteSlug: 'example.wordpress.com', refParameter: 'wp-admin' },
+			step: { stepName: 'launch', status: 'invalid', errors: { message: 'Nope.' } },
+		} );
+
+		expect( screen.getByRole( 'link', { name: 'Go back' } ) ).toHaveAttribute(
+			'href',
+			'https://example.wordpress.com/wp-admin'
 		);
 	} );
 
@@ -78,23 +104,8 @@ describe( 'LaunchSiteComponent', () => {
 		renderStep( { step: { stepName: 'launch', status: 'invalid', errors: {} } } );
 
 		expect(
-			screen.getByText( 'Something went wrong and we couldn’t launch your site. Please try again.' )
+			screen.getByText( 'Something went wrong and we couldn’t launch your site.' )
 		).toBeVisible();
-	} );
-
-	it( 'submits exactly one new attempt per "Try again" click', async () => {
-		const user = userEvent.setup();
-		const goToNextStep = jest.fn();
-		renderStep( {
-			goToNextStep,
-			step: { stepName: 'launch', status: 'invalid', errors: { message: 'Nope.' } },
-		} );
-
-		await user.click( screen.getByRole( 'button', { name: 'Try again' } ) );
-
-		expect( submitSignupStep ).toHaveBeenCalledTimes( 1 );
-		expect( submitSignupStep ).toHaveBeenCalledWith( { stepName: 'launch' } );
-		expect( goToNextStep ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it.each( [ 'pending', 'processing', 'completed' ] )(

--- a/client/signup/steps/launch-site/test/index.jsx
+++ b/client/signup/steps/launch-site/test/index.jsx
@@ -1,0 +1,114 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { submitSignupStep } from 'calypso/state/signup/progress/actions';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import LaunchSiteComponent from '../index';
+
+jest.mock( 'calypso/state/signup/progress/actions', () => ( {
+	submitSignupStep: jest.fn( () => ( { type: 'TEST_SUBMIT_SIGNUP_STEP' } ) ),
+} ) );
+
+const defaultProps = {
+	flowName: 'launch-site',
+	stepName: 'launch',
+	positionInFlow: 2,
+	signupDependencies: { siteSlug: 'example.wordpress.com' },
+};
+
+function renderStep( props = {} ) {
+	return renderWithProvider(
+		<LaunchSiteComponent { ...defaultProps } goToNextStep={ jest.fn() } { ...props } />
+	);
+}
+
+describe( 'LaunchSiteComponent', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'launches the site once and renders nothing when the step has not run yet', () => {
+		const goToNextStep = jest.fn();
+		const { container } = renderStep( { goToNextStep } );
+
+		expect( submitSignupStep ).toHaveBeenCalledTimes( 1 );
+		expect( submitSignupStep ).toHaveBeenCalledWith( { stepName: 'launch' } );
+		expect( goToNextStep ).toHaveBeenCalledTimes( 1 );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'does not launch again when the step already failed, and shows the error', () => {
+		const goToNextStep = jest.fn();
+		renderStep( {
+			goToNextStep,
+			step: {
+				stepName: 'launch',
+				status: 'invalid',
+				errors: { message: 'You can not launch your site without a paid eCommerce plan.' },
+			},
+		} );
+
+		expect( submitSignupStep ).not.toHaveBeenCalled();
+		expect( goToNextStep ).not.toHaveBeenCalled();
+		expect(
+			screen.getByText( 'You can not launch your site without a paid eCommerce plan.' )
+		).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Try again' } ) ).toBeVisible();
+		expect( screen.getByRole( 'link', { name: 'Back to dashboard' } ) ).toHaveAttribute(
+			'href',
+			'/home/example.wordpress.com'
+		);
+	} );
+
+	it( 'reads the error message from an array of errors', () => {
+		renderStep( {
+			step: {
+				stepName: 'launch',
+				status: 'invalid',
+				errors: [ { message: 'This site is flagged as spam.' } ],
+			},
+		} );
+
+		expect( screen.getByText( 'This site is flagged as spam.' ) ).toBeVisible();
+	} );
+
+	it( 'falls back to a generic message when the error has none', () => {
+		renderStep( { step: { stepName: 'launch', status: 'invalid', errors: {} } } );
+
+		expect(
+			screen.getByText( 'Something went wrong and we couldn’t launch your site. Please try again.' )
+		).toBeVisible();
+	} );
+
+	it( 'submits exactly one new attempt per "Try again" click', async () => {
+		const user = userEvent.setup();
+		const goToNextStep = jest.fn();
+		renderStep( {
+			goToNextStep,
+			step: { stepName: 'launch', status: 'invalid', errors: { message: 'Nope.' } },
+		} );
+
+		await user.click( screen.getByRole( 'button', { name: 'Try again' } ) );
+
+		expect( submitSignupStep ).toHaveBeenCalledTimes( 1 );
+		expect( submitSignupStep ).toHaveBeenCalledWith( { stepName: 'launch' } );
+		expect( goToNextStep ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it.each( [ 'pending', 'processing', 'completed' ] )(
+		'does not resubmit when the step status is %s',
+		( status ) => {
+			const goToNextStep = jest.fn();
+			const { container } = renderStep( {
+				goToNextStep,
+				step: { stepName: 'launch', status },
+			} );
+
+			expect( submitSignupStep ).not.toHaveBeenCalled();
+			expect( goToNextStep ).not.toHaveBeenCalled();
+			expect( container ).toBeEmptyDOMElement();
+		}
+	);
+} );


### PR DESCRIPTION
Part of DOTOBRD-582

## Proposed Changes

* The `launch` step of the `launch-site` flow submitted itself on every mount, and the processing screen remounts the step every time its status changes. A launch request that keeps failing therefore looped at about three requests per second with a blank screen — one user produced 368,038 cycles in a day.
* The step now submits only when it has not run yet. On failure it renders the error message returned by the API, a "Try again" button for one more attempt, and a link back to the dashboard.

### Screenshots

| Before | After |
| --- | --- |
| <img width="498" height="237" alt="Screenshot 2026-08-11 at 16 35 48" src="https://github.com/user-attachments/assets/8c356d20-b78a-49f1-ac06-12d8875a2bb5" /> | <img width="624" height="236" alt="Screenshot 2026-08-11 at 17 00 38" src="https://github.com/user-attachments/assets/d6ab3d53-da3e-41f0-9e20-db06acf9fa64" /> | 

### Recordings

- Trying to launch site without this PR. This is the behavior described in DOTOBRD-582 (infinite loop when launching site)

https://github.com/user-attachments/assets/cccf90de-b750-4217-98ca-bfed29b71c4d

- Trying to launch site with this PR applied. Now the error message that comes from the server is shown and allows the user to take action

https://github.com/user-attachments/assets/dc546df0-cdb5-4c5b-9d91-971ff25cef05

## Why are these changes being made?

Users whose launch request fails (trial plan, spam-flagged blog, a `siteSlug` the logged-in account cannot manage) got no error and no way out, only a hidden request loop. The server-side causes are tracked separately; this makes the client fail visibly and recoverably.

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Make `POST /sites/{siteSlug}/launch` fail for a test site (the easiest way is by hacking `WPCOM_JSON_API_Launch_Site_Endpoint` to return a `WP_Error`)
- Visit `/start/launch-site?siteSlug=<your-site>` and complete the domain and plan steps.
- The launch step should show the error message with "Go back" instead of rendering nothing. The Network tab should show a single launch request, not a stream of them.
- Click "Go back" and ensure you're taken back to where you started the launch site flow

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)