### PR TITLE
Agents Manager: Load the editor abilities and heavy chat components lazily

### DIFF
--- a/apps/agents-manager/AGENTS.md
+++ b/apps/agents-manager/AGENTS.md
@@ -2,7 +2,7 @@
 
 Build and deployment layer for the Agents Manager. Most code lives in `packages/agents-manager/` — see its `AGENTS.md` for architecture and conventions.
 
-This app bundles the package into 7 webpack entry points deployed to `widgets.wp.com/agents-manager/`. Jetpack enqueues these on Simple, Atomic, and CIAB sites.
+This app bundles the package into 9 webpack entry points deployed to `widgets.wp.com/agents-manager/`. They are separate compilations sharing one `dist/`, so each entry's chunk filenames and chunk-loading global must stay entry-unique. Jetpack enqueues these on Simple, Atomic, and CIAB sites.
 
 ## Build & Sync
 

--- a/apps/agents-manager/webpack.config.js
+++ b/apps/agents-manager/webpack.config.js
@@ -32,7 +32,15 @@ function getIndividualConfig( options = {} ) {
 	const { name, env, argv, injectPolyfill = true } = options;
 
 	const outputPath = path.join( __dirname, 'dist' );
-	const webpackConfig = getBaseWebpackConfig( env, argv );
+	// Every entry emits into the shared `dist/`, so chunk files (JS and the
+	// CSS the base config derives from this name) must be entry-unique —
+	// same-named files from another entry's build would overwrite these. The
+	// content hash busts CDN caches: chunk URLs carry no `?ver` query, unlike
+	// the entries enqueued via `asset.json`.
+	const webpackConfig = getBaseWebpackConfig( env, {
+		...argv,
+		'output-chunk-filename': `${ name }.[name].[contenthash:8].min.js`,
+	} );
 
 	return {
 		...webpackConfig,
@@ -42,6 +50,10 @@ function getIndividualConfig( options = {} ) {
 			...webpackConfig.output,
 			path: outputPath,
 			filename: '[name].min.js',
+			// Entries loaded on the same page (e.g. wp-admin + image-studio)
+			// must not share a chunk-loading runtime global.
+			chunkLoadingGlobal: `webpackChunk_${ name.replace( /-/g, '_' ) }`,
+			uniqueName: name,
 			library: 'agentsManager',
 		},
 		module: {
@@ -145,7 +157,12 @@ function getIndividualConfig( options = {} ) {
 function getReaderConfig( options = {} ) {
 	const { env, argv } = options;
 	const outputPath = path.join( __dirname, 'dist' );
-	const webpackConfig = getBaseWebpackConfig( env, argv );
+	// Chunk files must be entry-unique and content-hashed in the shared
+	// `dist/` — see `getIndividualConfig`.
+	const webpackConfig = getBaseWebpackConfig( env, {
+		...argv,
+		'output-chunk-filename': 'reader-chat.[name].[contenthash:8].min.js',
+	} );
 
 	return {
 		...webpackConfig,

--- a/packages/agents-manager/AGENTS.md
+++ b/packages/agents-manager/AGENTS.md
@@ -27,14 +27,22 @@ cd apps/agents-manager && yarn dev --sync
 - **i18n**: Use `@wordpress/i18n` with the `__i18n_text_domain__` text domain placeholder — passed unquoted as it is a global constant, not a string literal. The webpack `DefinePlugin` replaces it with `'default'` at build time.
 - **Curly quotes**: Preserve `""` `''` exactly as they appear. Do not convert to unicode escapes or ASCII equivalents.
 
+## Performance
+
+One source ships to every surface, so weight one surface needs is weight they all carry — `reader-chat` most of all, since it bundles its dependencies instead of externalizing them.
+
+- **Load heavy, surface-specific code on demand.** Components go through `lazyComponent()` (`utils/lazy-component.ts`); other modules take a gated dynamic `import()`, as `abilities/index.ts` does. One static import of `@wordpress/block-editor`, `blocks`, `core-data`, or `media-utils` anywhere in the shared chat path pulls that tree into every entry.
+- **Measure before and after** — `webpack-bundle-analyzer`, or the per-entry sizes from `yarn build` in `apps/agents-manager`. Import chains are easy to misjudge by reading.
+
 ## Ability Scoping
 
-AM ability registration (`registerAmAbilities()`) is surface-agnostic by design — it runs wherever the chat mounts, and that is safe because registration grants nothing:
+AM ability registration (`registerAmAbilities()`) is called wherever the chat mounts, but the ability code is editor-only and lazy: `abilities/index.ts` is a thin facade, and the editor abilities in `abilities/editor-abilities.ts` load as an async chunk only on editor pages (`isEditorPage()`). Non-editor chats (Reader, wp-admin list screens, Calypso) never fetch it. Safety never depended on that gate — registration grants nothing:
 
 - **The backend route settings are the scope authority** (`wpcom` repo, `lib/ai/agents/route-settings/wp-orchestrator/`): deny-by-default, per-URL allowlists rebuild each agent's tool set from scratch. Client-side registration and provider advertisement never make an ability callable.
 - **Execution ownership comes from provider order, not the registry** — tool calls resolve through the provider chain first-write-wins by ability name, and `amToolProvider` is placed before the external providers. Registering an ability in the `@wordpress/abilities` registry alone does not route execution to it.
-- **Migrating an ability = a folder under `src/abilities/` + an `AM_ABILITIES` entry** — `amToolProvider` then executes it ahead of the provider's copy. If it renders a chat component, also add its type to `AM_COMPONENTS` in the converter.
-- **Test both implementations with `?am_abilities=0`** — the switch flips execution, registration, and rendering to the provider copies in one move.
+- **Migrating an ability = a folder under `src/abilities/` + an `EDITOR_ABILITIES` entry in `abilities/editor-abilities.ts`** — `amToolProvider` then executes it ahead of the provider's copy. If it renders a chat component, also add its type to `AM_COMPONENTS` in the converter, wrapped with the `lazyComponent()` helper (`utils/lazy-component.ts`).
+- **Keep the ability code lazy** — heavy editor abilities and their dependencies land in `abilities/editor-abilities.ts` (never as static imports of the facade or shared chat code), and chat components load through the converter's `AM_COMPONENTS` map via `lazyComponent()`. A light all-surface ability (e.g. `wp-admin-navigate` when it migrates) lands in the facade's `ALL_SURFACE_ABILITIES` list instead — the chunk exists to keep the editor stack out of every bundle, not to gate every ability. In jsdom tests, open the gate by adding the `site-editor-php` body class before exercising the facade (see the loader suite).
+- **Test both implementations with `?am_abilities=0`** — the switch flips execution, registration, and rendering to the provider copies in one move, and skips loading the abilities chunk entirely.
 - **Never rename an ability while migrating it** — the name is the key the route settings match on; renaming silently drops it from every surface.
 - **Guard mutating callbacks in place**: when migrating a callback that changes editor state (e.g. `apply-block-edits`, `set-styles`), start it with an `isEditorPage()` early-return that returns an error result. Callbacks that don't mutate editor state (e.g. `show-component`, which only records a checkpoint) need no guard.
 - **Checkpoint domains land with their abilities** — `utils/checkpoints.ts` snapshots and restores only the migrated domains (global styles today); a migrating ability that writes checkpoints brings its domain's snapshot/restore along, with scoped keys. Until every writer migrates, provider-held checkpoints stay restorable through the `provider-checkpoints` bridge, which shrinks away per ability.
@@ -45,6 +53,7 @@ AM ability registration (`registerAmAbilities()`) is surface-agnostic by design 
 ## Pitfalls
 
 - **Two deployment targets**: Every change must work in both Calypso (SPA) and Simple/Atomic/CIAB (via `widgets.wp.com` bundles). They use different bootstrap paths.
+- **Async chunks resolve from the entry script's URL** (webpack `publicPath: "auto"`): the abilities chunk and any new lazy seam must be verified on both targets plus the inlined `reader-chat` bundle — a chunk that 404s fails silently as a missing feature, not an error page. All entries share `dist/`, so chunk filenames and the chunk-loading global are entry-unique (`output-chunk-filename` + `chunkLoadingGlobal` per config) — a same-named chunk from another entry's build would overwrite it.
 - **asset.json sync gap**: Adding/removing `@wordpress/*` dependencies changes `.asset.json` files, which Jetpack fetches from production — not your sandbox. Dependency changes require a deploy to take effect on Atomic.
 - **Unregistered script handles**: `@wordpress/*` packages WordPress doesn't register as scripts (e.g. `@wordpress/abilities`, `@wordpress/ui`) must stay force-bundled in `apps/agents-manager/webpack.config.js` — an externalized unregistered dependency makes `WP_Scripts` silently drop the whole bundle.
 - **Disconnected variants**: Several entry points have `-disconnected` versions showing minimal UI. Changes to shared code can silently break these.

--- a/packages/agents-manager/src/abilities/__tests__/index.test.ts
+++ b/packages/agents-manager/src/abilities/__tests__/index.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 jest.mock( '@wordpress/abilities', () => ( {
 	getAbility: jest.fn(),
 	registerAbility: jest.fn(),
@@ -15,15 +18,17 @@ jest.mock( '../show-component', () => ( {
 	showComponentAbility: { name: 'big-sky/show-component', callback: mockShowComponentCallback },
 } ) );
 
-// `registerAmAbilities` runs once per module instance, so each test loads a
-// fresh module (and the matching mock instances) to start clean.
+import { executeAbilityFromList } from '../execute-ability';
+
+// Registration runs once per module instance, so each test loads fresh
+// modules (and the matching mock instances) to start clean.
 async function load() {
 	jest.resetModules();
 	const abilities = jest.requireMock( '@wordpress/abilities' );
-	const { registerAmAbilities, amToolProvider } = await import( '..' );
-	return { registerAmAbilities, amToolProvider, ...abilities } as {
-		registerAmAbilities: () => Promise< void >;
-		amToolProvider: ( typeof import('..') )[ 'amToolProvider' ];
+	const facade = await import( '..' );
+	const editorAbilities = await import( '../editor-abilities' );
+	return { ...facade, editorAbilities, ...abilities } as typeof facade & {
+		editorAbilities: typeof editorAbilities;
 		getAbility: jest.Mock;
 		registerAbility: jest.Mock;
 		registerAbilityCategory: jest.Mock;
@@ -31,51 +36,253 @@ async function load() {
 	};
 }
 
-beforeEach( () => jest.clearAllMocks() );
+// The facade gates on `isEditorPage()`, which reads the admin body classes.
+function setEditorPage( isEditor: boolean ) {
+	document.body.classList.toggle( 'site-editor-php', isEditor );
+}
 
-describe( 'amToolProvider', () => {
-	it( 'executes an owned ability by its normalized name', async () => {
+beforeEach( () => {
+	jest.clearAllMocks();
+	document.body.className = '';
+	window.history.replaceState( {}, '', '/' );
+} );
+
+describe( 'abilities facade', () => {
+	it( 'stays inert off the editor', async () => {
+		const error = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+		const { registerAmAbilities, amToolProvider, getAmCheckpointContext, registerAbility } =
+			await load();
+
+		await registerAmAbilities();
+
+		expect( registerAbility ).not.toHaveBeenCalled();
+		await expect( amToolProvider.getAbilities() ).resolves.toEqual( [] );
+		expect( getAmCheckpointContext() ).toEqual( [] );
+		await expect( amToolProvider.executeAbility( 'big_sky__show_component', {} ) ).rejects.toThrow(
+			'Agents Manager does not own the ability: big_sky__show_component'
+		);
+		expect( error ).toHaveBeenCalled();
+	} );
+
+	it( 'registers the abilities when the chat mounts', async () => {
+		setEditorPage( true );
+		const { registerAmAbilities, registerAbility } = await load();
+
+		await registerAmAbilities();
+
+		// Registration runs fire-and-forget with the load — let it settle.
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+		expect( registerAbility ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it.each( [
+		[ 'the site editor', [ 'site-editor-php' ] ],
+		[ 'the post editor', [ 'post-new-php', 'post-type-post' ] ],
+	] as const )( 'loads on %s', async ( _label, bodyClasses ) => {
+		document.body.classList.add( ...bodyClasses );
+		const { amToolProvider } = await load();
+
+		await expect( amToolProvider.getAbilities() ).resolves.toHaveLength( 2 );
+	} );
+
+	it( 'stays closed on a custom-post-type editor screen', async () => {
+		document.body.classList.add( 'post-php', 'post-type-product' );
+		const { amToolProvider } = await load();
+
+		await expect( amToolProvider.getAbilities() ).resolves.toEqual( [] );
+	} );
+
+	it( 'registers on the first load even when the provider triggers it', async () => {
+		setEditorPage( true );
+		const { amToolProvider, registerAbility } = await load();
+
+		await amToolProvider.getAbilities();
+
+		// Registration runs fire-and-forget with the load — let it settle.
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+		expect( registerAbility ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'loads on the first execution, with no prior call', async () => {
+		setEditorPage( true );
 		mockShowComponentCallback.mockResolvedValueOnce( { result: { success: true } } );
 		const { amToolProvider } = await load();
 
 		await expect( amToolProvider.executeAbility( 'big_sky__show_component', {} ) ).resolves.toEqual(
 			{ result: { success: true } }
 		);
-		expect( mockShowComponentCallback ).toHaveBeenCalledWith( {} );
 	} );
 
-	it( 'logs and rethrows when an owned ability fails', async () => {
-		const error = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
-		mockShowComponentCallback.mockRejectedValueOnce( new Error( 'Callback exploded.' ) );
-		const { amToolProvider } = await load();
+	it( 'skips loading with `?am_abilities=0`', async () => {
+		setEditorPage( true );
+		window.history.replaceState( {}, '', '/?am_abilities=0' );
+		const { registerAmAbilities, amToolProvider, registerAbility } = await load();
 
-		await expect( amToolProvider.executeAbility( 'big_sky__show_component', {} ) ).rejects.toThrow(
-			'Callback exploded.'
-		);
+		await registerAmAbilities();
+
+		expect( registerAbility ).not.toHaveBeenCalled();
+		await expect( amToolProvider.getAbilities() ).resolves.toEqual( [] );
+	} );
+
+	it( 'stops advertising checkpoints when `?am_abilities=0` is set after a load', async () => {
+		setEditorPage( true );
+		jest.resetModules();
+		jest.doMock( '../editor-abilities', () => ( {
+			getEditorAbilities: () => [],
+			registerEditorAbilities: jest.fn().mockResolvedValue( undefined ),
+			getAvailableCheckpoints: () => [ { checkpointId: 'cp-1' } ],
+		} ) );
+
+		try {
+			const { amToolProvider, getAmCheckpointContext } = await import( '..' );
+			await amToolProvider.getAbilities();
+
+			expect( getAmCheckpointContext() ).toHaveLength( 1 );
+
+			window.history.replaceState( {}, '', '/?am_abilities=0' );
+
+			expect( getAmCheckpointContext() ).toEqual( [] );
+		} finally {
+			jest.dontMock( '../editor-abilities' );
+		}
+	} );
+
+	it( 'retries the load after a failed chunk fetch', async () => {
+		const error = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+		setEditorPage( true );
+		jest.resetModules();
+		let attempt = 0;
+		jest.doMock( '../editor-abilities', () => {
+			attempt++;
+			if ( attempt === 1 ) {
+				throw new Error( 'Chunk failed.' );
+			}
+			return {
+				getEditorAbilities: () => [ { name: 'big-sky/show-component' } ],
+				registerEditorAbilities: jest.fn().mockResolvedValue( undefined ),
+				getAvailableCheckpoints: () => [],
+			};
+		} );
+
+		try {
+			const { amToolProvider } = await import( '..' );
+
+			await expect( amToolProvider.getAbilities() ).resolves.toEqual( [] );
+			await expect( amToolProvider.getAbilities() ).resolves.toHaveLength( 1 );
+			expect( error ).toHaveBeenCalled();
+		} finally {
+			jest.dontMock( '../editor-abilities' );
+		}
+	} );
+
+	it( 'never loads the editor abilities just to read the checkpoint context', async () => {
+		setEditorPage( true );
+		const { getAmCheckpointContext, registerAbility } = await load();
+
+		expect( getAmCheckpointContext() ).toEqual( [] );
+		// A load would resolve and register in a later task — let it settle.
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+		expect( registerAbility ).not.toHaveBeenCalled();
+	} );
+
+	it( 'logs registration failures instead of throwing', async () => {
+		const error = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+		setEditorPage( true );
+		jest.resetModules();
+		jest.doMock( '../editor-abilities', () => ( {
+			getEditorAbilities: () => [],
+			registerEditorAbilities: jest.fn().mockRejectedValue( new Error( 'Registration exploded.' ) ),
+			getAvailableCheckpoints: () => [],
+		} ) );
+
+		try {
+			const { registerAmAbilities } = await import( '..' );
+
+			await expect( registerAmAbilities() ).resolves.toBeUndefined();
+			// Registration runs fire-and-forget with the load — flush it.
+			await Promise.resolve();
+			expect( error ).toHaveBeenCalledWith(
+				'[AgentsManager] Failed to register the editor abilities:',
+				expect.any( Error )
+			);
+		} finally {
+			jest.dontMock( '../editor-abilities' );
+		}
+	} );
+
+	it( 'degrades to no abilities when the chunk fails to load', async () => {
+		const error = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+		setEditorPage( true );
+		jest.resetModules();
+		jest.doMock( '../editor-abilities', () => {
+			throw new Error( 'Chunk failed.' );
+		} );
+
+		try {
+			const { registerAmAbilities, amToolProvider } = await import( '..' );
+
+			await expect( registerAmAbilities() ).resolves.toBeUndefined();
+			await expect( amToolProvider.getAbilities() ).resolves.toEqual( [] );
+			expect( error ).toHaveBeenCalledWith(
+				'[AgentsManager] Failed to load the editor abilities:',
+				expect.any( Error )
+			);
+		} finally {
+			jest.dontMock( '../editor-abilities' );
+		}
+	} );
+} );
+
+describe( 'executeAbilityFromList', () => {
+	const stubAbility = ( callback: jest.Mock ) => ( {
+		name: 'big-sky/show-component',
+		label: 'Show component',
+		description: 'Stub ability',
+		category: 'big-sky',
+		callback,
+	} );
+
+	it( 'executes an ability by its normalized name', async () => {
+		const callback = jest.fn().mockResolvedValue( { result: { success: true } } );
+
+		await expect(
+			executeAbilityFromList( [ stubAbility( callback ) ], 'big_sky__show_component', {} )
+		).resolves.toEqual( { result: { success: true } } );
+		expect( callback ).toHaveBeenCalledWith( {} );
+	} );
+
+	it( 'logs and rethrows when an ability fails', async () => {
+		const error = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+		const callback = jest.fn().mockRejectedValue( new Error( 'Callback exploded.' ) );
+
+		await expect(
+			executeAbilityFromList( [ stubAbility( callback ) ], 'big_sky__show_component', {} )
+		).rejects.toThrow( 'Callback exploded.' );
 		expect( error ).toHaveBeenCalledWith(
 			'[AgentsManager] Ability "big_sky__show_component" failed:',
 			expect.any( Error )
 		);
 	} );
 
-	it( 'logs and rethrows for an ability it does not own', async () => {
+	it( 'logs and rethrows for an unknown ability', async () => {
 		const error = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
-		const { amToolProvider } = await load();
 
-		await expect( amToolProvider.executeAbility( 'big-sky/unknown', {} ) ).rejects.toThrow(
+		await expect( executeAbilityFromList( [], 'big-sky/unknown', {} ) ).rejects.toThrow(
 			'Agents Manager does not own the ability: big-sky/unknown'
 		);
 		expect( error ).toHaveBeenCalled();
 	} );
 } );
 
-describe( 'registerAmAbilities', () => {
+describe( 'registerEditorAbilities', () => {
 	it( 'registers the category, then the abilities, exactly once', async () => {
-		const { registerAmAbilities, registerAbility, registerAbilityCategory, unregisterAbility } =
+		const { editorAbilities, registerAbility, registerAbilityCategory, unregisterAbility } =
 			await load();
 
-		await registerAmAbilities();
-		await registerAmAbilities();
+		await editorAbilities.registerEditorAbilities();
+		await editorAbilities.registerEditorAbilities();
 
 		expect( registerAbilityCategory ).toHaveBeenCalledTimes( 1 );
 		expect( registerAbilityCategory ).toHaveBeenCalledWith( 'big-sky', expect.any( Object ) );
@@ -94,13 +301,13 @@ describe( 'registerAmAbilities', () => {
 	} );
 
 	it( 'replaces a provider copy when the name is already registered', async () => {
-		const { registerAmAbilities, getAbility, registerAbility, unregisterAbility } = await load();
+		const { editorAbilities, getAbility, registerAbility, unregisterAbility } = await load();
 		registerAbility.mockRejectedValueOnce(
 			new Error( 'Ability "big-sky/restore-checkpoint" is already registered' )
 		);
 		getAbility.mockReturnValue( { name: 'big-sky/restore-checkpoint' } );
 
-		await registerAmAbilities();
+		await editorAbilities.registerEditorAbilities();
 
 		expect( unregisterAbility ).toHaveBeenCalledWith( 'big-sky/restore-checkpoint' );
 		expect( registerAbility ).toHaveBeenCalledTimes( 3 );
@@ -108,11 +315,11 @@ describe( 'registerAmAbilities', () => {
 
 	it( 'does not unregister when the failure is not a collision', async () => {
 		const warn = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
-		const { registerAmAbilities, getAbility, registerAbility, unregisterAbility } = await load();
+		const { editorAbilities, getAbility, registerAbility, unregisterAbility } = await load();
 		registerAbility.mockRejectedValueOnce( new Error( 'Invalid ability definition' ) );
 		getAbility.mockReturnValue( undefined );
 
-		await registerAmAbilities();
+		await editorAbilities.registerEditorAbilities();
 
 		expect( unregisterAbility ).not.toHaveBeenCalled();
 		expect( registerAbility ).toHaveBeenCalledTimes( 2 );

--- a/packages/agents-manager/src/abilities/ability-name.ts
+++ b/packages/agents-manager/src/abilities/ability-name.ts
@@ -1,0 +1,14 @@
+import type { Ability } from './types';
+
+// The agent routes tool calls with `/` → `__` and `-` → `_`.
+const normalizeAbilityName = ( name: string ) => name.replace( /\//g, '__' ).replace( /-/g, '_' );
+
+/**
+ * Finds an ability by its raw or agent-normalized name — the one matching
+ * rule for both execution and ownership checks.
+ */
+export function findAbilityByName( abilities: Ability[], name: string ): Ability | undefined {
+	return abilities.find(
+		( ability ) => ability.name === name || normalizeAbilityName( ability.name ) === name
+	);
+}

--- a/packages/agents-manager/src/abilities/editor-abilities.ts
+++ b/packages/agents-manager/src/abilities/editor-abilities.ts
@@ -1,0 +1,86 @@
+/**
+ * The editor ability implementations. This module carries the editor stack
+ * (checkpoint engine, style application), so it must only be reached through
+ * the lazy facade in `./index.ts` — never import it statically from shared
+ * chat code.
+ */
+
+import {
+	getAbility,
+	registerAbility,
+	registerAbilityCategory,
+	unregisterAbility,
+} from '@wordpress/abilities';
+import { BIG_SKY_ABILITY_CATEGORY } from './constants';
+import { restoreCheckpointAbility } from './restore-checkpoint';
+import { showComponentAbility } from './show-component';
+import type { Ability } from './types';
+
+// Editor abilities. Migrating an editor ability from Big Sky = add its folder
+// under `abilities/` and list it here.
+const EDITOR_ABILITIES: Ability[] = [ restoreCheckpointAbility, showComponentAbility ];
+
+export const getEditorAbilities = () => EDITOR_ABILITIES;
+
+// Registration is one-time per page load.
+let hasRegistered = false;
+
+/**
+ * Registers the editor abilities in the `@wordpress/abilities` registry.
+ *
+ * Registration keeps the abilities discoverable in the registry — execution
+ * ownership lives in `amToolProvider`. The registry rejects duplicate
+ * names, and providers may register their own copies first; a collision is
+ * resolved by replacing the provider's copy. Providers delete their copies as
+ * cleanup once a migration lands.
+ */
+export async function registerEditorAbilities(): Promise< void > {
+	if ( hasRegistered ) {
+		return;
+	}
+
+	hasRegistered = true;
+
+	// Register the category before the abilities that reference it.
+	try {
+		await registerAbilityCategory( BIG_SKY_ABILITY_CATEGORY, {
+			label: 'Big Sky',
+			description: 'Big Sky abilities',
+		} );
+	} catch {
+		// Category may already be registered.
+	}
+
+	for ( const ability of EDITOR_ABILITIES ) {
+		try {
+			await registerAbility( ability );
+		} catch ( error ) {
+			// TODO (ability-migration): Collapse this replace branch once Big Sky
+			// deletes its ability copies — with nothing left to collide, plain
+			// register plus the warning suffices.
+
+			// Only retry when another copy actually holds the name — without
+			// one, the failure is not a collision and re-registering would
+			// fail the same way.
+			if ( ! getAbility( ability.name ) ) {
+				// eslint-disable-next-line no-console
+				console.warn( `[AgentsManager] Failed to register ability: ${ ability.name }`, error );
+				continue;
+			}
+
+			try {
+				await unregisterAbility( ability.name );
+				await registerAbility( ability );
+			} catch ( replaceError ) {
+				// eslint-disable-next-line no-console
+				console.warn(
+					`[AgentsManager] Failed to register ability: ${ ability.name }`,
+					replaceError
+				);
+			}
+		}
+	}
+}
+
+// Re-exported for the facade's sync checkpoint view (`getAmCheckpointContext`).
+export { getAvailableCheckpoints } from '../utils/checkpoints';

--- a/packages/agents-manager/src/abilities/execute-ability.ts
+++ b/packages/agents-manager/src/abilities/execute-ability.ts
@@ -1,0 +1,25 @@
+import { findAbilityByName } from './ability-name';
+import type { Ability } from './types';
+
+/**
+ * Finds an ability by its raw or normalized name and runs its callback.
+ * Failures — including unknown names — log and rethrow so the chat surfaces
+ * the error.
+ */
+export async function executeAbilityFromList(
+	abilities: Ability[],
+	name: string,
+	args: unknown
+): Promise< unknown > {
+	try {
+		const ability = findAbilityByName( abilities, name );
+		if ( ! ability?.callback ) {
+			throw new Error( `Agents Manager does not own the ability: ${ name }` );
+		}
+		return await ability.callback( args );
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.error( `[AgentsManager] Ability "${ name }" failed:`, error );
+		throw error;
+	}
+}

--- a/packages/agents-manager/src/abilities/index.ts
+++ b/packages/agents-manager/src/abilities/index.ts
@@ -1,106 +1,124 @@
-import {
-	getAbility,
-	registerAbility,
-	registerAbilityCategory,
-	unregisterAbility,
-} from '@wordpress/abilities';
+/**
+ * Lazy facade over the ability implementations.
+ *
+ * The editor abilities carry the editor stack (checkpoint engine, style
+ * application), so they load as an async chunk and only on editor pages.
+ * Chats everywhere else (Reader, wp-admin list screens, Calypso) never fetch
+ * the chunk, keeping their bundles small. The `?am_abilities=0` testing
+ * switch skips the load too, flipping the whole flow back to the provider
+ * copies.
+ */
+
 import isAmAbilitiesDisabled from '../utils/is-am-abilities-disabled';
-import { BIG_SKY_ABILITY_CATEGORY } from './constants';
-import { restoreCheckpointAbility } from './restore-checkpoint';
-import { showComponentAbility } from './show-component';
+import { isEditorPage } from '../utils/is-editor-page';
+import { executeAbilityFromList } from './execute-ability';
 import type { ToolProvider } from '../extension-types';
 import type { Ability } from './types';
+import type { CheckpointContextItem } from '../utils/checkpoints';
 
-// AM-owned abilities. Migrating an ability from Big Sky = add its folder
-// under `abilities/` and list it here.
-const AM_ABILITIES: Ability[] = [ restoreCheckpointAbility, showComponentAbility ];
+type EditorAbilitiesModule = typeof import('./editor-abilities');
 
-// The agent routes tool calls with `/` → `__` and `-` → `_`.
-export const normalizeAbilityName = ( name: string ) =>
-	name.replace( /\//g, '__' ).replace( /-/g, '_' );
+let editorAbilitiesPromise: Promise< EditorAbilitiesModule > | null = null;
+let loadedEditorAbilities: EditorAbilitiesModule | null = null;
 
-// The `?am_abilities=0` switch empties this, flipping execution back to the
-// provider copies for testing.
-const getOwnedAbilities = () => ( isAmAbilitiesDisabled() ? [] : AM_ABILITIES );
+// TODO (ability-migration): Drop the `?am_abilities=0` checks in this file —
+// the load gate below, the owned-ability list, and the checkpoint context —
+// with the switch itself. See `utils/is-am-abilities-disabled.ts`.
+function loadEditorAbilities(): Promise< EditorAbilitiesModule > | null {
+	if ( ! editorAbilitiesPromise && isEditorPage() && ! isAmAbilitiesDisabled() ) {
+		editorAbilitiesPromise = import(
+			/* webpackChunkName: "am-editor-abilities" */ './editor-abilities'
+		).then(
+			( module ) => {
+				loadedEditorAbilities = module;
+
+				// Register on the first successful load, whichever call
+				// triggered it — the mount effect may have failed transiently.
+				module.registerEditorAbilities().catch( ( error ) => {
+					// eslint-disable-next-line no-console
+					console.error( '[AgentsManager] Failed to register the editor abilities:', error );
+				} );
+
+				return module;
+			},
+			( error ) => {
+				// A transient chunk failure must not disable the abilities for
+				// the rest of the session — the next call retries.
+				editorAbilitiesPromise = null;
+
+				// eslint-disable-next-line no-console
+				console.error( '[AgentsManager] Failed to load the editor abilities:', error );
+				throw error;
+			}
+		);
+	}
+	return editorAbilitiesPromise;
+}
+
+// All-surface abilities stay in the main bundle and run on every surface —
+// none yet; `wp-admin-navigate` lands here when it migrates (AI-1082). Only
+// the editor stack earns the lazy chunk.
+const ALL_SURFACE_ABILITIES: Ability[] = [];
+
+// A failed chunk load (already logged and set up to retry above) degrades to
+// "AM owns nothing" — tool calls then fall through to the provider copies.
+async function getOwnedAbilities(): Promise< Ability[] > {
+	if ( isAmAbilitiesDisabled() ) {
+		return [];
+	}
+
+	let editorAbilities: Ability[] = [];
+	try {
+		const module = loadEditorAbilities();
+		editorAbilities = module ? ( await module ).getEditorAbilities() : [];
+	} catch {
+		// Fall through with the chunk-less list.
+	}
+
+	return [ ...ALL_SURFACE_ABILITIES, ...editorAbilities ];
+}
 
 /**
  * Serves AM-owned abilities to the agent's tool pipeline. Tool calls resolve
  * through the provider chain first-write-wins by ability name, and this
  * provider is placed before the external ones — so each migrated ability
  * executes through AM even if a provider still ships its copy.
+ *
+ * Off the editor only the all-surface abilities are owned; everything else
+ * falls through to the provider copies and the editor chunk stays unloaded.
  */
 export const amToolProvider: ToolProvider = {
-	getAbilities: async () => getOwnedAbilities(),
-	executeAbility: async ( name: string, args: unknown ) => {
-		try {
-			const ability = getOwnedAbilities().find(
-				( candidate ) => candidate.name === name || normalizeAbilityName( candidate.name ) === name
-			);
-			if ( ! ability?.callback ) {
-				throw new Error( `Agents Manager does not own the ability: ${ name }` );
-			}
-			return await ( ability.callback as ( input: unknown ) => Promise< unknown > )( args );
-		} catch ( error ) {
-			// eslint-disable-next-line no-console
-			console.error( `[AgentsManager] Ability "${ name }" failed:`, error );
-			throw error;
-		}
-	},
+	getAbilities: getOwnedAbilities,
+	executeAbility: async ( name: string, args: unknown ) =>
+		executeAbilityFromList( await getOwnedAbilities(), name, args ),
 };
 
-// Registration is one-time per page load.
-let hasRegistered = false;
-
 /**
- * Registers AM-owned abilities in the `@wordpress/abilities` registry.
- *
- * Registration keeps the abilities discoverable in the registry — execution
- * ownership lives in `amToolProvider` above. The registry rejects duplicate
- * names, and providers may register their own copies first; a collision is
- * resolved by replacing the provider's copy. Providers delete their copies as
- * cleanup once a migration lands.
+ * Loads the editor abilities when the surface qualifies — registration
+ * happens with the load. A no-op everywhere else; all-surface abilities need
+ * no registration, since execution ownership comes from the provider chain,
+ * not the registry.
  */
 export async function registerAmAbilities(): Promise< void > {
-	if ( hasRegistered ) {
-		return;
-	}
-	hasRegistered = true;
-
-	// Register the category before the abilities that reference it.
 	try {
-		await registerAbilityCategory( BIG_SKY_ABILITY_CATEGORY, {
-			label: 'Big Sky',
-			description: 'Big Sky abilities',
-		} );
+		await loadEditorAbilities();
 	} catch {
-		// Category may already be registered.
+		// Already logged; the next facade call retries the load.
+	}
+}
+
+/**
+ * AM's checkpoints for the merged `availableCheckpoints` context — a sync
+ * view because the `ContextProvider` contract is sync. Empty until the
+ * editor abilities finish loading: with no ability executions there are no
+ * checkpoints, so reading is never a reason to load them. Empty again under
+ * `?am_abilities=0`, so the agent is never offered ids that AM no longer
+ * restores.
+ */
+export function getAmCheckpointContext(): CheckpointContextItem[] {
+	if ( isAmAbilitiesDisabled() || ! loadedEditorAbilities ) {
+		return [];
 	}
 
-	for ( const ability of AM_ABILITIES ) {
-		try {
-			await registerAbility( ability );
-		} catch ( error ) {
-			// TODO (ability-migration): Collapse this replace branch once Big Sky deletes its
-			// ability copies — with nothing left to collide, plain register
-			// plus the warning suffices.
-			// Only retry when another copy actually holds the name — without
-			// one, the failure is not a collision and re-registering would
-			// fail the same way.
-			if ( ! getAbility( ability.name ) ) {
-				// eslint-disable-next-line no-console
-				console.warn( `[AgentsManager] Failed to register ability: ${ ability.name }`, error );
-				continue;
-			}
-			try {
-				await unregisterAbility( ability.name );
-				await registerAbility( ability );
-			} catch ( replaceError ) {
-				// eslint-disable-next-line no-console
-				console.warn(
-					`[AgentsManager] Failed to register ability: ${ ability.name }`,
-					replaceError
-				);
-			}
-		}
-	}
+	return loadedEditorAbilities.getAvailableCheckpoints();
 }

--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -3,7 +3,7 @@
  */
 /* eslint-disable import/order -- jest.mock calls must precede imports */
 
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { Suggestion } from '@automattic/agenttic-ui';
 import type { ComponentProps, ReactNode, Ref } from 'react';
@@ -195,9 +195,10 @@ jest.mock( '../feedback-input', () => ( {
 jest.mock( '../icons', () => ( {
 	AI: () => null,
 } ) );
+const mockSelectedBlock = jest.fn( () => null );
 jest.mock( '../selected-block', () => ( {
 	__esModule: true,
-	default: () => null,
+	default: mockSelectedBlock,
 } ) );
 jest.mock( '../../utils/is-plugin-compass-agent', () => ( {
 	isPluginCompassHost: () => false,
@@ -239,6 +240,19 @@ describe( 'AgentChat', () => {
 		jest.clearAllMocks();
 		mockHasAiChatEntry.mockReturnValue( false );
 		document.body.className = '';
+	} );
+
+	it( 'renders the selected-block chip only on editor pages', async () => {
+		document.body.classList.add( 'post-php', 'post-type-post' );
+		renderAgentChat();
+		await waitFor( () => expect( mockSelectedBlock ).toHaveBeenCalled() );
+
+		mockSelectedBlock.mockClear();
+		document.body.className = '';
+		renderAgentChat();
+		// The lazy chunk resolves in a microtask — flush before asserting absence.
+		await act( () => Promise.resolve() );
+		expect( mockSelectedBlock ).not.toHaveBeenCalled();
 	} );
 
 	const imageUpload = ( isUploadingImages: boolean ) =>

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -19,13 +19,13 @@ import { AGENTS_MANAGER_STORE } from '../../stores';
 import { getAgentsManagerInlineData } from '../../utils/get-agents-manager-inline-data';
 import { isEditorPage } from '../../utils/is-editor-page';
 import { isReaderChatHost } from '../../utils/is-reader-chat-agent';
+import lazyComponent from '../../utils/lazy-component';
 import { recordBigSkyTracksEvent } from '../../utils/tracks';
 import ChatHeader, { type Options as ChatHeaderOptions } from '../chat-header';
 import ChatMessageSkeleton from '../chat-message-skeleton';
 import ContextCards from '../context-cards';
 import CustomALink from '../custom-a-link';
 import FeedbackInput from '../feedback-input';
-import SelectedBlock from '../selected-block';
 import getSuggestionClickPayload from './get-suggestion-click-payload';
 import GroupedEmptyView from './grouped-empty-view';
 import type { UseImageUploadResult } from '../../hooks/use-image-upload';
@@ -109,6 +109,12 @@ interface Props {
 	/** Called when a context card's dismiss button is clicked. */
 	onContextCardDismiss?: ( card: ExternalContextCard ) => void;
 }
+
+// Carries the block-editor stack, so it loads on demand — and only on editor
+// pages, keeping the chunk out of every other chat.
+const SelectedBlock = lazyComponent(
+	() => import( /* webpackChunkName: "am-selected-block" */ '../selected-block' )
+);
 
 const DEFAULT_ACCEPTED_IMAGE_TYPES = [
 	'image/jpeg',
@@ -363,7 +369,7 @@ export default function AgentChat( {
 								dropZoneRef={ conversationViewRef as RefObject< HTMLElement > }
 							/>
 						) }
-						<SelectedBlock />
+						{ isEditorPage() && <SelectedBlock /> }
 						{ /* `readOnly` (not `disabled`) so the stop button stays active while a batch uploads. */ }
 						<AgentUI.Input
 							imageUploaderRef={

--- a/packages/agents-manager/src/hooks/__tests__/use-abilities-registration.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-abilities-registration.test.ts
@@ -7,29 +7,11 @@ import useAbilitiesRegistration from '../use-abilities-registration';
 
 jest.mock( '../../abilities', () => ( { registerAmAbilities: jest.fn() } ) );
 
+// Whether anything actually loads or registers (editor-only lazy loading, the
+// `?am_abilities=0` switch) is decided inside `registerAmAbilities()` and
+// covered by the abilities facade tests.
 describe( 'useAbilitiesRegistration', () => {
-	beforeEach( () => {
-		jest.clearAllMocks();
-		window.history.replaceState( {}, '', '/' );
-	} );
-
 	it( 'registers AM abilities on mount', () => {
-		renderHook( () => useAbilitiesRegistration() );
-
-		expect( registerAmAbilities ).toHaveBeenCalledTimes( 1 );
-	} );
-
-	it( 'skips registration with `?am_abilities=0`', () => {
-		window.history.replaceState( {}, '', '/?am_abilities=0' );
-
-		renderHook( () => useAbilitiesRegistration() );
-
-		expect( registerAmAbilities ).not.toHaveBeenCalled();
-	} );
-
-	it.each( [ '1', 'off', '' ] )( 'still registers with `?am_abilities=%s`', ( value ) => {
-		window.history.replaceState( {}, '', `/?am_abilities=${ value }` );
-
 		renderHook( () => useAbilitiesRegistration() );
 
 		expect( registerAmAbilities ).toHaveBeenCalledTimes( 1 );

--- a/packages/agents-manager/src/hooks/use-abilities-registration.ts
+++ b/packages/agents-manager/src/hooks/use-abilities-registration.ts
@@ -1,17 +1,14 @@
 import { useEffect } from '@wordpress/element';
 import { registerAmAbilities } from '../abilities';
-import isAmAbilitiesDisabled from '../utils/is-am-abilities-disabled';
 
 /**
- * Registers AM-owned abilities once the chat has mounted — ownership and
- * collision semantics live in `registerAmAbilities()`, and the
- * `?am_abilities=0` testing switch in `isAmAbilitiesDisabled()`.
+ * Registers AM-owned abilities once the chat has mounted. Whether anything
+ * loads or registers is decided inside `registerAmAbilities()` — the ability
+ * code is editor-only and lazy, and the `?am_abilities=0` testing switch
+ * skips it entirely.
  */
 export default function useAbilitiesRegistration(): void {
 	useEffect( () => {
-		if ( isAmAbilitiesDisabled() ) {
-			return;
-		}
 		registerAmAbilities();
 	}, [] );
 }

--- a/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
@@ -14,10 +14,21 @@ jest.mock(
 jest.mock( '../../components/escalation-button', () => ( {
 	EscalationButton: mockEscalationButton,
 } ) );
-jest.mock( '../../components/button-picker', () => ( { __esModule: true, default: jest.fn() } ) );
-jest.mock( '../../components/color-picker', () => ( { __esModule: true, default: jest.fn() } ) );
-jest.mock( '../../components/font-picker', () => ( { __esModule: true, default: jest.fn() } ) );
+jest.mock( '../../components/button-picker', () => ( {
+	__esModule: true,
+	default: jest.fn( () => null ),
+} ) );
+jest.mock( '../../components/color-picker', () => ( {
+	__esModule: true,
+	default: jest.fn( () => null ),
+} ) );
+jest.mock( '../../components/font-picker', () => ( {
+	__esModule: true,
+	default: jest.fn( () => null ),
+} ) );
 
+import { render, waitFor } from '@testing-library/react';
+import { createElement } from '@wordpress/element';
 import ButtonPicker from '../../components/button-picker';
 import ColorPicker from '../../components/color-picker';
 import FontPicker from '../../components/font-picker';
@@ -651,11 +662,13 @@ describe( 'convertToolMessagesToComponents', () => {
 	);
 
 	describe( 'AM-owned components', () => {
+		// The AM components are lazy wrappers, so the assertion renders the
+		// resolved component and waits for the picker chunk to arrive.
 		it.each( [
 			[ 'button-picker', ButtonPicker ],
 			[ 'color-picker', ColorPicker ],
 			[ 'font-picker', FontPicker ],
-		] )( 'resolves %s to its AM component', ( type, expected ) => {
+		] )( 'resolves %s to its AM component', async ( type, picker ) => {
 			const message = createToolMessage( SHOW_COMPONENT_TOOL_ID, {
 				type,
 				props: { variations: [] },
@@ -666,10 +679,14 @@ describe( 'convertToolMessagesToComponents', () => {
 				messages: [ message ],
 			} );
 
-			expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
-				type: 'component',
-				component: expected,
-			} );
+			const content = result[ 0 ].content[ 0 ] as {
+				type: string;
+				component: React.ComponentType;
+			};
+			expect( content.type ).toBe( 'component' );
+
+			render( createElement( content.component ) );
+			await waitFor( () => expect( picker ).toHaveBeenCalled() );
 		} );
 
 		it( 'passes props without `contentType`', () => {

--- a/packages/agents-manager/src/utils/__tests__/lazy-component.test.tsx
+++ b/packages/agents-manager/src/utils/__tests__/lazy-component.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import lazyComponent from '../lazy-component';
+
+// The failure paths wait on the helper's real retry delay, so they need more
+// than Testing Library's default timeout.
+const RETRY_TIMEOUT = { timeout: 3000 };
+
+describe( 'lazyComponent', () => {
+	it( 'renders the loaded component', async () => {
+		const Lazy = lazyComponent( () =>
+			Promise.resolve( { default: () => <div>Loaded content</div> } )
+		);
+
+		render( <Lazy /> );
+
+		expect( await screen.findByText( 'Loaded content' ) ).toBeVisible();
+	} );
+
+	it( 'retries once, so a transient chunk failure still renders', async () => {
+		let attempt = 0;
+		const Lazy = lazyComponent( () => {
+			attempt++;
+			return attempt === 1
+				? Promise.reject( new Error( 'Chunk failed.' ) )
+				: Promise.resolve( { default: () => <div>Loaded after retry</div> } );
+		} );
+
+		render( <Lazy /> );
+
+		expect(
+			await screen.findByText( 'Loaded after retry', undefined, RETRY_TIMEOUT )
+		).toBeVisible();
+	} );
+
+	it( 'renders nothing and logs when the chunk fails to load', async () => {
+		const error = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+		const Lazy = lazyComponent( () => Promise.reject( new Error( 'Chunk failed.' ) ) );
+
+		const { container } = render( <Lazy /> );
+
+		await waitFor(
+			() =>
+				expect( error ).toHaveBeenCalledWith(
+					'[AgentsManager] Failed to load a chat component:',
+					expect.any( Error )
+				),
+			RETRY_TIMEOUT
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { amToolProvider } from '../../abilities';
 import { restoreCheckpointAbility } from '../../abilities/restore-checkpoint';
 import { showComponentAbility } from '../../abilities/show-component';
 import { getAvailableCheckpoints } from '../checkpoints';
@@ -33,6 +34,14 @@ jest.mock( '../checkpoints', () => ( {
 	restoreCheckpoint: jest.fn(),
 	setCheckpoint: jest.fn(),
 } ) );
+
+// The abilities facade only loads the editor abilities on editor pages —
+// open the gate and resolve the load, so the merged provider and the sync
+// checkpoint context see AM's abilities.
+beforeAll( async () => {
+	document.body.classList.add( 'site-editor-php' );
+	await amToolProvider.getAbilities();
+} );
 
 function setAgentsManagerData( data: Record< string, unknown > ) {
 	( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData = data;

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -1,9 +1,7 @@
 import { __ } from '@wordpress/i18n';
-import ButtonPicker from '../components/button-picker';
-import ColorPicker from '../components/color-picker';
 import { EscalationButton } from '../components/escalation-button';
-import FontPicker from '../components/font-picker';
 import isAmAbilitiesDisabled from './is-am-abilities-disabled';
+import lazyComponent from './lazy-component';
 import { isShowComponentTool } from './show-component-tools';
 import { getDisplayMessageFromToolData, isDisplayableToolMessageTool } from './tool-message-utils';
 import type { GetChatComponent } from './load-external-providers';
@@ -19,10 +17,20 @@ export interface AgentsManagerUIMessage extends UIMessage {
 
 // AM-owned components by `ShowComponentType`. These take precedence over
 // provider components — AM is the single source of truth for each migrated type.
+//
+// The pickers carry the block-editor preview stack, so they load on demand:
+// a picker row fetches its chunk when it first renders, and other chats never
+// download it.
 const AM_COMPONENTS: Record< ShowComponentType, React.ComponentType > = {
-	'button-picker': ButtonPicker as React.ComponentType,
-	'color-picker': ColorPicker as React.ComponentType,
-	'font-picker': FontPicker as React.ComponentType,
+	'button-picker': lazyComponent(
+		() => import( /* webpackChunkName: "am-button-picker" */ '../components/button-picker' )
+	),
+	'color-picker': lazyComponent(
+		() => import( /* webpackChunkName: "am-color-picker" */ '../components/color-picker' )
+	),
+	'font-picker': lazyComponent(
+		() => import( /* webpackChunkName: "am-font-picker" */ '../components/font-picker' )
+	),
 };
 
 function getAmComponent( type: string ): React.ComponentType | null {

--- a/packages/agents-manager/src/utils/is-am-abilities-disabled.ts
+++ b/packages/agents-manager/src/utils/is-am-abilities-disabled.ts
@@ -2,9 +2,9 @@
 // deletes its ability copies — with no provider fallback left, disabling AM
 // would only break the tools.
 /**
- * `?am_abilities=0` flips both execution and rendering of migrated abilities
- * to the provider copies, so testers can compare the implementations
- * end-to-end.
+ * `?am_abilities=0` flips the migrated abilities back to the provider copies
+ * — execution, registration, and rendering, with the abilities chunk never
+ * loaded — so testers can compare the implementations end-to-end.
  */
 export default function isAmAbilitiesDisabled(): boolean {
 	return new URLSearchParams( window.location.search ).get( 'am_abilities' ) === '0';

--- a/packages/agents-manager/src/utils/lazy-component.ts
+++ b/packages/agents-manager/src/utils/lazy-component.ts
@@ -1,0 +1,50 @@
+import { Component, createElement, lazy, Suspense } from '@wordpress/element';
+
+const RETRY_DELAY_MS = 500;
+
+// Catching a render error needs a class — there is no hook equivalent.
+class LazyBoundary extends Component< { children: React.ReactNode }, { failed: boolean } > {
+	state = { failed: false };
+
+	static getDerivedStateFromError() {
+		return { failed: true };
+	}
+
+	componentDidCatch( error: Error ) {
+		// eslint-disable-next-line no-console
+		console.error( '[AgentsManager] Failed to load a chat component:', error );
+	}
+
+	render() {
+		return this.state.failed ? null : this.props.children;
+	}
+}
+
+/**
+ * Wraps a dynamically imported component so it loads on first render — the
+ * standard way to keep heavy, rarely-shown components out of the initial
+ * bundles. Renders nothing while the chunk loads, and nothing if the chunk
+ * fails twice or the component throws: `Suspense` handles neither, so without
+ * the boundary a failed picker would take the whole chat down with it.
+ */
+export default function lazyComponent(
+	load: () => Promise< { default: React.ComponentType } >
+): React.ComponentType {
+	// `lazy()` caches a rejected import, so one failed fetch would keep this
+	// component missing for the rest of the page. Retry inside the loader,
+	// after a pause — an immediate retry hits the same CDN edge that just
+	// 404'd a freshly deployed chunk.
+	const Inner = lazy( () =>
+		load().catch( () =>
+			new Promise( ( resolve ) => setTimeout( resolve, RETRY_DELAY_MS ) ).then( load )
+		)
+	);
+
+	return function LazyComponent( props: Record< string, unknown > ) {
+		return createElement(
+			LazyBoundary,
+			null,
+			createElement( Suspense, { fallback: null }, createElement( Inner, props ) )
+		);
+	};
+}

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -12,8 +12,8 @@
  */
 
 import { getAgentManager, UIMessage } from '@automattic/agenttic-client';
-import { amToolProvider, normalizeAbilityName } from '../abilities';
-import { getAvailableCheckpoints } from './checkpoints';
+import { amToolProvider, getAmCheckpointContext } from '../abilities';
+import { findAbilityByName } from '../abilities/ability-name';
 import { getAgentsManagerInlineData } from './get-agents-manager-inline-data';
 import { isReaderChatAgent } from './is-reader-chat-agent';
 import {
@@ -346,7 +346,7 @@ function withAmCheckpoints(
 	return {
 		getClientContext: () => {
 			const context = contextProvider.getClientContext();
-			const amCheckpoints = getAvailableCheckpoints();
+			const amCheckpoints = getAmCheckpointContext();
 			if ( ! amCheckpoints.length ) {
 				return context;
 			}
@@ -688,10 +688,7 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 				// earliest provider that currently exposes the ability handles it.
 				const results = await collectAbilityResults();
 				for ( let i = 0; i < allToolProviders.length; i++ ) {
-					const owns = results[ i ].some(
-						( ability ) => ability.name === name || normalizeAbilityName( ability.name ) === name
-					);
-					if ( owns ) {
+					if ( findAbilityByName( results[ i ], name ) ) {
 						const result = await allToolProviders[ i ].executeAbility( name, args );
 
 						// TODO (ability-migration): Delete with the provider-checkpoints


### PR DESCRIPTION
Part of AI-1110.

## Proposed Changes

* Make `packages/agents-manager/src/abilities/index.ts` a thin facade that loads the ability implementations (now `abilities/editor-abilities.ts`) as an async chunk, only on editor pages and only when the `?am_abilities=0` testing switch is off.
* Load the three style pickers and the selected-block chip on first render through a shared `lazyComponent()` helper. It retries a failed chunk once after a short pause, and carries its own `Suspense` plus an error boundary — so a chunk that stays unreachable renders nothing instead of taking the chat down with it.
* Render the selected-block chip only on editor pages, so its chunk stays out of every other chat.
* Give each webpack entry unique chunk filenames (entry-prefixed, content-hashed, JS and CSS alike) and its own chunk-loading global. All nine entries compile separately into one `dist/`, so without this one entry's chunks overwrite another's, and two entries on the same page (wp-admin + Image Studio) share a runtime global.
* A chunk that fails to load is logged and retried on the next call; until it loads, Agents Manager owns no abilities, so tool calls fall through to the provider copies.

## Why are these changes being made?

The migrated abilities are editor tools, but every chat bundle shipped them statically — including surfaces that can never use them. The Reader chat is the worst case: it disables externalization, so `@wordpress/block-editor`, `@wordpress/blocks` and `@wordpress/core-data` were all inlined for a chat that has no editor at all.

This also sets the pattern for the rest of the Big Sky ability migration: each new ability lands inside the existing chunk instead of growing every bundle.

## Testing Instructions

**Bundle sizes** (production build, `yarn build` in `apps/agents-manager`):

| Entry | Before | After | Reduction |
| --- | --- | --- | --- |
| `reader-chat` | 5857 KB | 2846 KB | −3011 KB (−51%) |
| `agents-manager-wp-admin` | 1744 KB | 1587 KB | −157 KB (−9%) |
| `agents-manager-gutenberg` | 1743 KB | 1586 KB | −157 KB (−9%) |
| `agents-manager-ciab` | 1743 KB | 1585 KB | −158 KB (−9%) |
| `agents-manager-wooai` | 1743 KB | 1586 KB | −157 KB (−9%) |

Both sides measured from a clean `yarn build` on the same trunk commit. The editor entries externalize `@wordpress/block-editor`, so their chunks carry less weight than the Reader's, which inlines everything. `image-studio` is unchanged at 926 KB.

**Calypso** (`yarn start`): open the chat from the masterbar on a non-editor screen and confirm no `am-` chunk is requested and no console errors.

**Sandbox** (`cd apps/agents-manager && yarn dev --sync`, sandbox `widgets.wp.com`):

1. Post or site editor — the chat loads `<entry>.am-editor-abilities.<hash>.min.js` (Network tab, filter `am-`). Ask for colors, pick one: the picker chunk loads, the style applies, and "undo that" restores it.

https://github.com/user-attachments/assets/09a5dfcd-bf93-4c39-8390-9fb7b0dcb9ff

2. Select a block in the editor — the selected-block chip appears above the input and its chunk loads.

<img width="344" height="166" alt="截圖 2026-08-12 凌晨2 05 23" src="https://github.com/user-attachments/assets/52fc9e3e-f535-44e9-a3f5-30f0c3246cee" />

3. A wp-admin list screen (e.g. Posts) and the Reader — the chat opens and works, and no `am-` chunk is requested.

<img width="2558" height="1288" alt="截圖 2026-08-12 凌晨3 31 21" src="https://github.com/user-attachments/assets/c41afed1-f24f-496e-b7e9-a0a71186366f" />

4. Append `?am_abilities=0` in the editor — no `am-editor-abilities` chunk loads, and the pickers come from Big Sky as before.

<img width="2560" height="1371" alt="截圖 2026-08-12 凌晨3 44 12" src="https://github.com/user-attachments/assets/f65e6409-dceb-4423-afcb-40c00ce1de9a" />

5. Image Studio on the same page as the wp-admin chat — both open normally (they no longer share a chunk-loading global).

<img width="1715" height="1288" alt="截圖 2026-08-12 凌晨3 41 28" src="https://github.com/user-attachments/assets/8aee487b-7c82-4d89-978b-87962a00dfd4" />

<img width="1716" height="1288" alt="截圖 2026-08-12 凌晨3 37 58" src="https://github.com/user-attachments/assets/5d539592-dcf7-45eb-af63-4c07b423b977" />

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?



