### PR TITLE
Reader: Fix posts duplication, clearing of feed and multiple identical requests on Search page

### DIFF
--- a/client/reader/data/stream/hooks/use-infinite-stream/index.ts
+++ b/client/reader/data/stream/hooks/use-infinite-stream/index.ts
@@ -183,16 +183,16 @@ export const useInfiniteStream = ( {
 		const pages = query.data?.pages ?? [];
 		const collected: StreamItem[] = [];
 		// Stream endpoints can return the same post in more than one page, so we need to deduplicate them here.
-		const uniqueItem = new Set< string >();
+		const uniqueItems = new Set< string >();
 		for ( const page of pages ) {
 			const { streamItems } = normalizeStreamPage( page as ReadStreamResponse, streamType );
 			for ( const item of streamItems ) {
 				const id = keyToString( item );
 				if ( id !== null ) {
-					if ( uniqueItem.has( id ) ) {
+					if ( uniqueItems.has( id ) ) {
 						continue;
 					}
-					uniqueItem.add( id );
+					uniqueItems.add( id );
 				}
 				collected.push( item );
 			}

--- a/client/reader/data/stream/hooks/use-infinite-stream/index.ts
+++ b/client/reader/data/stream/hooks/use-infinite-stream/index.ts
@@ -217,6 +217,16 @@ export const useInfiniteStream = ( {
 		queryClient.invalidateQueries( { queryKey, refetchType: 'none' } );
 	}, [ queryClient, queryKey ] );
 
+	// `cancelRefetch` defaults to true, which aborts an in-flight page request and
+	// starts another. `<InfiniteList>` gates on `fetchingNextPage`, a React prop
+	// that only flips after a commit, so its rAF-driven scroll check can call this
+	// again before the guard catches up — firing several identical requests for the
+	// same page. `false` makes a repeat call join the in-flight promise instead.
+	const { fetchNextPage: fetchNextStreamPage } = query;
+	const fetchNextPage = useCallback( () => {
+		fetchNextStreamPage( { cancelRefetch: false } );
+	}, [ fetchNextStreamPage ] );
+
 	return {
 		items,
 		posts,
@@ -228,7 +238,7 @@ export const useInfiniteStream = ( {
 		hasNextPage: !! query.hasNextPage,
 		lastPage: ! query.hasNextPage && ! query.isFetchingNextPage && query.isFetched,
 		error: query.error,
-		fetchNextPage: query.fetchNextPage,
+		fetchNextPage,
 		refetch: query.refetch,
 		invalidate,
 	};

--- a/client/reader/data/stream/hooks/use-infinite-stream/index.ts
+++ b/client/reader/data/stream/hooks/use-infinite-stream/index.ts
@@ -12,6 +12,7 @@ import {
 } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { syncConversationFollowStatus, syncPostCache } from 'calypso/reader/data/post/cache';
+import { keyToString } from 'calypso/reader/post-key';
 import { useDispatch } from 'calypso/state';
 import { buildStreamQueryParams } from '../../build-query-params';
 import { extractPageHandle, normalizeStreamPage } from '../../normalization';
@@ -181,9 +182,18 @@ export const useInfiniteStream = ( {
 	const items: StreamItem[] = useMemo( () => {
 		const pages = query.data?.pages ?? [];
 		const collected: StreamItem[] = [];
+		// Stream endpoints can return the same post in more than one page, so we need to deduplicate them here.
+		const uniqueItem = new Set< string >();
 		for ( const page of pages ) {
 			const { streamItems } = normalizeStreamPage( page as ReadStreamResponse, streamType );
 			for ( const item of streamItems ) {
+				const id = keyToString( item );
+				if ( id !== null ) {
+					if ( uniqueItem.has( id ) ) {
+						continue;
+					}
+					uniqueItem.add( id );
+				}
 				collected.push( item );
 			}
 		}

--- a/client/reader/data/stream/hooks/use-infinite-stream/test/index.test.tsx
+++ b/client/reader/data/stream/hooks/use-infinite-stream/test/index.test.tsx
@@ -423,3 +423,41 @@ describe( 'useInfiniteStream — local removals', () => {
 		expect( result.current.pages[ 0 ].posts ).toHaveLength( 1 );
 	} );
 } );
+
+describe( 'useInfiniteStream — de-duplication', () => {
+	it( 'renders a post once when consecutive pages overlap', async () => {
+		nock( BASE )
+			.get( LIKES_PATH )
+			.query( ( q: Record< string, string | string[] | undefined > ) => ! ( 'before' in q ) )
+			.reply( 200, {
+				posts: [ apiPost( 1 ), apiPost( 2 ) ],
+				date_range: { after: '2026-04-01', before: null },
+			} );
+
+		// Offset-paginated recommendation and search streams re-rank between
+		// requests, so successive windows can return the same post twice.
+		nock( BASE )
+			.get( LIKES_PATH )
+			.query( ( q: Record< string, string | string[] | undefined > ) => q.before === '2026-04-01' )
+			.reply( 200, {
+				posts: [ apiPost( 2 ), apiPost( 3 ) ],
+				date_range: { after: null, before: null },
+			} );
+
+		const queryClient = makeQueryClient();
+		const { Wrapper } = makeWrapper( queryClient );
+		const { result } = renderHook( () => useInfiniteStream( { streamKey: 'likes' } ), {
+			wrapper: Wrapper,
+		} );
+
+		await waitFor( () => expect( result.current.items ).toHaveLength( 2 ) );
+
+		act( () => {
+			result.current.fetchNextPage();
+		} );
+
+		await waitFor( () => expect( result.current.lastPage ).toBe( true ) );
+		expect( result.current.items ).toHaveLength( 3 );
+		expect( result.current.items ).toMatchObject( [ postKey( 1 ), postKey( 2 ), postKey( 3 ) ] );
+	} );
+} );

--- a/client/reader/stream/error.tsx
+++ b/client/reader/stream/error.tsx
@@ -1,9 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
 import EmptyContent from 'calypso/components/empty-content';
-import { useDispatch } from 'calypso/state';
-import { errorNotice } from 'calypso/state/notices/actions';
 
 /**
  * Props for the StreamError component.
@@ -13,31 +10,10 @@ import { errorNotice } from 'calypso/state/notices/actions';
 interface StreamErrorProps {
 	onTryAgain?: () => void;
 	streamKey: string;
-	error: {
-		message: string;
-	};
 }
 
-export const StreamError = ( { onTryAgain, streamKey, error }: StreamErrorProps ) => {
+export const StreamError = ( { onTryAgain, streamKey }: StreamErrorProps ) => {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
-
-	useEffect( () => {
-		if ( ! error.message ) {
-			return;
-		}
-
-		dispatch(
-			errorNotice( translate( 'Stream error: %s', { args: error.message } ), { duration: 3000 } )
-		);
-	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
-
-	useEffect( () => {
-		recordTracksEvent( 'calypso_reader_stream_error', {
-			stream_key: streamKey,
-			path: window.location.pathname,
-		} );
-	}, [ streamKey ] );
 
 	const handleTryAgain = () => {
 		recordTracksEvent( 'calypso_reader_stream_error_try_again', {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -832,13 +832,7 @@ class ReaderStream extends Component {
 		// `items`, and replacing them with an empty state throws away what the
 		// user was reading.
 		if ( this.props.error && ! items.length ) {
-			body = (
-				<StreamError
-					onTryAgain={ this.tryAgain }
-					streamKey={ streamKey }
-					context={ this.state.selectedTab }
-				/>
-			);
+			body = <StreamError onTryAgain={ this.tryAgain } streamKey={ streamKey } />;
 		}
 
 		return (

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -1,8 +1,9 @@
 import './style.scss';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isDefaultLocale } from '@automattic/i18n-utils';
 import { times } from '@automattic/js-utils';
 import clsx from 'clsx';
-import { localize } from 'i18n-calypso';
+import { localize, useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { createRef, Component, Fragment } from 'react';
 import * as React from 'react';
@@ -35,6 +36,7 @@ import UpdateNotice from 'calypso/reader/update-notice';
 import { showSelectedPost, getStreamType } from 'calypso/reader/utils';
 import XPostHelper from 'calypso/reader/xpost-helper';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { getBlockedSites } from 'calypso/state/reader/site-blocks/selectors';
 import { viewStream } from 'calypso/state/reader-ui/actions';
 import { resetCardExpansions } from 'calypso/state/reader-ui/card-expansions/actions';
@@ -93,6 +95,31 @@ const useStreamRenderAnalytics = ( pages, streamKey ) => {
 			}
 		}
 	}, [ pages, streamKey, streamType, dispatch ] );
+};
+
+/**
+ * Report stream errors to Tracks and show a notice to the user.
+ */
+const useStreamErrorReporting = ( error, streamKey ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	React.useEffect( () => {
+		if ( ! error ) {
+			return;
+		}
+
+		recordTracksEvent( 'calypso_reader_stream_error', {
+			stream_key: streamKey,
+			path: window.location.pathname,
+		} );
+
+		if ( error.message ) {
+			dispatch(
+				errorNotice( translate( 'Stream error: %s', { args: error.message } ), { duration: 3000 } )
+			);
+		}
+	}, [ error, streamKey, dispatch, translate ] );
 };
 
 class ReaderStream extends Component {
@@ -718,7 +745,8 @@ class ReaderStream extends Component {
 						key={ this.props.streamKey }
 						ref={ this.setListContext }
 						items={ items }
-						lastPage={ lastPage }
+						// Avoid re-requests if the last page was already reached or if there was an error.
+						lastPage={ lastPage || !! this.props.error }
 						fetchingNextPage={ isRequesting }
 						guessedItemHeight={ GUESSED_POST_HEIGHT }
 						fetchNextPage={ this.fetchNextPage }
@@ -799,12 +827,15 @@ class ReaderStream extends Component {
 
 		const TopLevel = this.props.isMain ? ReaderMain : 'div';
 
-		if ( this.props.error ) {
+		// Only take over the panel when there is nothing to preserve. A failed
+		// `fetchNextPage` still leaves every successfully loaded page in
+		// `items`, and replacing them with an empty state throws away what the
+		// user was reading.
+		if ( this.props.error && ! items.length ) {
 			body = (
 				<StreamError
 					onTryAgain={ this.tryAgain }
 					streamKey={ streamKey }
-					error={ this.props.error }
 					context={ this.state.selectedTab }
 				/>
 			);
@@ -864,6 +895,7 @@ const withStreamPosts = ( WrappedComponent ) =>
 
 		useStreamRenderAnalytics( streamPostsQuery.pages, props.streamKey );
 		useStreamRenderAnalytics( recsStreamPostsQuery.pages, props.recsStreamKey );
+		useStreamErrorReporting( streamPostsQuery.error, props.streamKey );
 
 		const items = React.useMemo( () => {
 			const withRecommendations =

--- a/client/reader/stream/test/index.test.tsx
+++ b/client/reader/stream/test/index.test.tsx
@@ -3,17 +3,18 @@
  */
 import {
 	getSiteSubscriptionsQueryKey,
+	getStreamInfiniteQueryKey,
 	type SiteSubscriptionsInfiniteData,
 } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { Provider } from 'react-redux';
 import { applyMiddleware, createStore } from 'redux';
 import { thunk as thunkMiddleware } from 'redux-thunk';
 import { createPostCacheMiddleware } from 'calypso/reader/data/post/middleware';
-import { ANALYTICS_EVENT_RECORD } from 'calypso/state/action-types';
+import { ANALYTICS_EVENT_RECORD, NOTICE_CREATE } from 'calypso/state/action-types';
 import Stream from '../index';
 import type { SiteSubscriptionItem } from '@automattic/api-core';
 import type { ReactNode } from 'react';
@@ -558,5 +559,55 @@ describe( 'Stream — keyboard navigation', () => {
 		await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
 
 		expect( unlikeScope.isDone() ).toBe( false );
+	} );
+} );
+
+describe( 'Stream — failure after posts have loaded', () => {
+	const streamQueryKey = getStreamInfiniteQueryKey( {
+		streamKey: 'likes',
+		feedId: null,
+		localeSlug: null,
+		startDate: null,
+	} );
+
+	function mockLikesFailure() {
+		return nock( BASE )
+			.get( LIKES_PATH )
+			.query( ( q: Record< string, string | string[] | undefined > ) => q.number === '4' )
+			.reply( 500, { error: 'kaboom', message: 'Stream unavailable' } );
+	}
+
+	async function renderThenFail() {
+		mockLikesEndpoint( [ apiPost( 10 ), apiPost( 20 ) ] );
+		const utils = renderStream();
+		await waitFor( () => expect( screen.getByTestId( 'post-10' ) ).toBeVisible() );
+
+		mockLikesFailure();
+		await act( async () => {
+			await utils.queryClient.refetchQueries( { queryKey: streamQueryKey } );
+		} );
+		// `refetchQueries` resolves before the observer notification reaches the
+		// component, so assertions have to wait for the error to actually land.
+		await waitFor( () =>
+			expect( utils.queryClient.getQueryState( streamQueryKey )?.status ).toBe( 'error' )
+		);
+		return utils;
+	}
+
+	it( 'keeps the loaded posts on screen instead of swapping in the error state', async () => {
+		const { actions } = await renderThenFail();
+
+		// The notice is the observable signal that the container processed the error; without it the list could be intact simply because nothing failed.
+		await waitFor( () =>
+			expect(
+				actions.find( ( action ) => ( action as { type?: string } ).type === NOTICE_CREATE )
+			).toMatchObject( {
+				notice: { status: 'is-error', text: 'Stream error: Stream unavailable' },
+			} )
+		);
+
+		expect( screen.getByTestId( 'infinite-list' ) ).toBeVisible();
+		expect( screen.getByTestId( 'post-10' ) ).toBeVisible();
+		expect( screen.getByTestId( 'post-20' ) ).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: https://linear.app/a8c/issue/READ-663

## Proposed Changes

- Add de-duplication logic in `useInfiniteStream` hook. From backend duplicated posts are expected so on frontend we should handle it.
- Improve error handling in `ReaderStream` component. It just shows error in a Notice instead of clearing the whole loaded stream.
- Fix multiple identical API requests on Search page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Bug fixes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to /reader. Open search page.
- Open Network panel
- Scroll the stream and verify no post is duplicated.
- Verify that each `/recommendations/sites` request is called with different offset params (other than polling).
- Verify that when Search page is reached at the end of the page (after 100 posts or page 14) then it shows proper error as a Notice without affecting the loaded posts on stream.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
