### PR TITLE
Site Spec: pass the blueprint identifier into the widget config

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -25,9 +25,9 @@ import {
 import { logToLogstash } from 'calypso/lib/logstash';
 import { useSiteSpec } from 'calypso/lib/site-spec';
 import {
+	getBlueprintSiteSpecConfig,
 	getBuildWowSiteSpecConfig,
 	getCiabSiteSpecConfig,
-	getDefaultSiteSpecConfig,
 	getEarlyProvisionSiteSpecConfig,
 	type SiteSpecConfig,
 } from 'calypso/lib/site-spec/utils';
@@ -459,7 +459,9 @@ const SiteSpec: StepType = function SiteSpec() {
 	} else if ( shouldImportBlueprint ) {
 		siteSpecStep = (
 			<SiteSpecContainer
-				siteSpecConfig={ getDefaultSiteSpecConfig() }
+				siteSpecConfig={ getBlueprintSiteSpecConfig( {
+					blueprintId: blueprintArchiveSlug,
+				} ) }
 				onSpecConfirm={ handleBlueprintArchiveSpecConfirm }
 			/>
 		);

--- a/client/lib/site-spec/utils.ts
+++ b/client/lib/site-spec/utils.ts
@@ -34,6 +34,9 @@ export interface SiteSpecConfig {
 	agentId?: string;
 	buildSiteUrl?: string;
 	authProvider?: () => Promise< Record< string, string > >;
+	// Blueprint identifier when building from a blueprint. Forwarded by the widget
+	// to the agent (metadata.blueprint_id) so it can run a blueprint-aware interview.
+	blueprintId?: string;
 	theme?: {
 		// Branding
 		brandIcon?: ReactElement | string | null; // ReactElement or image URL; null hides
@@ -188,6 +191,25 @@ export function getDefaultSiteSpecConfig(): SiteSpecConfig {
 				client: 'calypso',
 			} ),
 		},
+	};
+}
+
+/**
+ * SiteSpec configuration for a site being built from a blueprint. Extends the
+ * default config with the blueprint identifier so the widget forwards it to the
+ * agent (as metadata.blueprint_id), which then runs a blueprint-aware interview.
+ * @param {Object} params            Params.
+ * @param {string} params.blueprintId Blueprint identifier (numeric library id or slug).
+ * @returns {SiteSpecConfig} Configuration object for the blueprint flow.
+ */
+export function getBlueprintSiteSpecConfig( {
+	blueprintId,
+}: {
+	blueprintId?: string;
+} ): SiteSpecConfig {
+	return {
+		...getDefaultSiteSpecConfig(),
+		...( blueprintId ? { blueprintId } : {} ),
 	};
 }
 


### PR DESCRIPTION
Follows [#113475](https://github.com/Automattic/wp-calypso/pull/113475) (merged). Pairs with the wpcom blueprint-aware site-spec agent.

### Proposed Changes

* `client/lib/site-spec/utils.ts` — add `blueprintId` to `SiteSpecConfig` and a `getBlueprintSiteSpecConfig()` helper that spreads the default config plus the identifier.
* `site-spec` step — the blueprint branch now builds its config with `getBlueprintSiteSpecConfig( { blueprintId: blueprintArchiveSlug } )` instead of the plain default.

That is the whole change: one extra field reaching the widget. Nothing else about the step's behavior moves.

### Why are these changes being made?

When a site is built from a blueprint, the site-spec interview should already know what the blueprint provides — its site type, theme, plugins and pages — so it can skip generic questions and ask the ones specific to that vertical. The wpcom agent reads a per-blueprint descriptor for exactly this, keyed by the blueprint identifier, but it only gets that identifier if the client sends it: the widget forwards `config.blueprintId` as `metadata.blueprint_id`, which the agent resolves as `client.blueprint_id`.

Calypso knows the identifier (it is already in the step's query params) but was not passing it, so the agent ran a generic interview on blueprint builds. The identifier also drives the widget's auto-start, so the agent asks the first question instead of waiting on the user.

### Testing Instructions

Requires a widget bundle that forwards `blueprint_id` gh3-site-spec-305, unreleased — point `config/_shared.json` `site_spec` at a dev bundle locally) and the wpcom agent branch on a sandbox.

1. Run Calypso locally against a sandbox and open the site-spec step for a blueprint build:
   `/setup/ai-site-builder-spec/site-spec?blueprint_archive_import=1&blueprint_slug=coachava&siteSlug=<site>`
2. The agent should open the conversation itself and ask a blueprint-specific question (for `coachava`, coaching-specific: coach/brand name, niche, clients) rather than a generic "what is your website for?".
3. Confirm the config reaches the widget: `window.configData.site_spec` shows the bundle in use, and the agent request carries `metadata.blueprint_id`.
4. Without `blueprint_slug`, the step should behave exactly as before (default config, no auto-start).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
