### PR TITLE
Instant downgrades: allow refundable renewals, not just initial purchases

### DIFF
--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -789,12 +789,17 @@ export function hasAmountAvailableToRefund( purchase: Purchase ) {
 
 /**
  * Returns true if the plan is eligible for an instant, self-serve downgrade: the
- * plan is still within its initial refund window (not a renewal) and has neither
- * expired nor entered its post-expiry grace period.
+ * plan has a refundable receipt and has neither expired nor entered its
+ * post-expiry grace period.
  *
- * Note: this intentionally does NOT require a refundable amount. Instant
- * downgrades are also offered for plans that were paid with credits or are
- * otherwise free, where no money would be refunded.
+ * `is_refundable` covers any refundable receipt, so it holds both for an initial
+ * purchase and for a renewal that is still within its own refund window — both
+ * cases where an instant downgrade costs neither side money.
+ *
+ * Note: this intentionally does NOT require a refundable amount. A refundable
+ * receipt worth nothing generally means the purchase was free (or fully paid
+ * with credits), which is still a valid instant downgrade — it just issues no
+ * refund, and the confirmation modal drops its refund line accordingly.
  *
  * This is distinct from {@link isExpiredAndInGracePeriod}, which gates the
  * downgrade-to-checkout flow for plans whose expiry date has already passed.
@@ -803,7 +808,7 @@ export function isWithinRefundWindowDowngradeEligible( purchase: Purchase ): boo
 	return (
 		purchase.is_plan_type_downgradable &&
 		purchase.is_plan &&
-		purchase.is_within_initial_refund_window &&
+		purchase.is_refundable &&
 		! isExpiredOrRemoved( purchase )
 	);
 }

--- a/client/dashboard/utils/test/purchase.ts
+++ b/client/dashboard/utils/test/purchase.ts
@@ -17,6 +17,7 @@ import {
 	creditCardExpiresBeforeSubscription,
 	getRenewalUrlFromPurchase,
 	isPurchaseDowngradeEligible,
+	isWithinRefundWindowDowngradeEligible,
 } from '../purchase';
 import type { Purchase } from '@automattic/api-core';
 
@@ -489,9 +490,56 @@ describe( 'isPurchaseDowngradeEligible', () => {
 				makePurchase( {
 					is_plan: true,
 					is_plan_type_downgradable: true,
-					is_within_initial_refund_window: true,
+					is_refundable: true,
 				} )
 			)
 		).toBe( true );
+	} );
+} );
+
+describe( 'isWithinRefundWindowDowngradeEligible', () => {
+	const downgradablePlan = ( overrides: Partial< Purchase > = {} ) =>
+		makePurchase( { is_plan: true, is_plan_type_downgradable: true, ...overrides } );
+
+	test( 'is true for a refundable plan', () => {
+		expect(
+			isWithinRefundWindowDowngradeEligible( downgradablePlan( { is_refundable: true } ) )
+		).toBe( true );
+	} );
+
+	test( 'is true for a refundable renewal outside the initial refund window', () => {
+		expect(
+			isWithinRefundWindowDowngradeEligible(
+				downgradablePlan( { is_within_initial_refund_window: false, is_refundable: true } )
+			)
+		).toBe( true );
+	} );
+
+	test( 'is false once no receipt is refundable, even inside the initial refund window', () => {
+		expect(
+			isWithinRefundWindowDowngradeEligible(
+				downgradablePlan( { is_within_initial_refund_window: true, is_refundable: false } )
+			)
+		).toBe( false );
+	} );
+
+	test( 'is false for a plan in its post-expiry grace period even when refundable', () => {
+		expect(
+			isWithinRefundWindowDowngradeEligible(
+				downgradablePlan( {
+					is_refundable: true,
+					expiry_status: 'expired',
+					subscription_status: 'active',
+				} )
+			)
+		).toBe( false );
+	} );
+
+	test( 'is false for a non-plan product', () => {
+		expect(
+			isWithinRefundWindowDowngradeEligible(
+				makePurchase( { is_plan: false, is_plan_type_downgradable: true, is_refundable: true } )
+			)
+		).toBe( false );
 	} );
 } );

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -816,12 +816,17 @@ export function hasAmountAvailableToRefund( purchase: Purchase ): boolean {
 
 /**
  * Returns true if the plan is eligible for an instant, self-serve downgrade: the
- * plan is still within its initial refund window (not a renewal) and has neither
- * expired nor entered its post-expiry grace period.
+ * plan has a refundable receipt and has neither expired nor entered its
+ * post-expiry grace period.
  *
- * Note: this intentionally does NOT require a refundable amount. Instant
- * downgrades are also offered for plans that were paid with credits or are
- * otherwise free, where no money would be refunded.
+ * `isRefundable` covers any refundable receipt, so it holds both for an initial
+ * purchase and for a renewal that is still within its own refund window — both
+ * cases where an instant downgrade costs neither side money.
+ *
+ * Note: this intentionally does NOT require a refundable amount. A refundable
+ * receipt worth nothing generally means the purchase was free (or fully paid
+ * with credits), which is still a valid instant downgrade — it just issues no
+ * refund, and the confirmation modal drops its refund line accordingly.
  *
  * The caller is responsible for confirming the purchase is a plan (see `isPlan`
  * from `@automattic/calypso-products`). This is distinct from
@@ -829,7 +834,7 @@ export function hasAmountAvailableToRefund( purchase: Purchase ): boolean {
  * plans whose expiry date has already passed.
  */
 export function isWithinRefundWindowDowngradeEligible( purchase: Purchase ): boolean {
-	return purchase.isWithinInitialRefundWindow && ! isExpiredOrRemoved( purchase );
+	return purchase.isRefundable && ! isExpiredOrRemoved( purchase );
 }
 
 /**

--- a/client/me/purchases/lib/raw-purchase-helpers.ts
+++ b/client/me/purchases/lib/raw-purchase-helpers.ts
@@ -398,7 +398,7 @@ export function getDowngradePlanFromPurchase( purchase: Purchase ) {
 }
 
 export function isWithinRefundWindowDowngradeEligible( purchase: Purchase ): boolean {
-	return purchase.is_within_initial_refund_window && ! isExpiredOrRemoved( purchase );
+	return purchase.is_refundable && ! isExpiredOrRemoved( purchase );
 }
 
 export function getDisplayName( purchase: Purchase ): TranslateResult {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -297,10 +297,11 @@ const PlansFeaturesMain = ( {
 	);
 	const isPlanExpired = !! sitePlansData?.find( ( p ) => p.currentPlan )?.expired;
 
-	// Refund-window instant downgrade: when the current plan is still within its
-	// initial refund window, a downgrade is performed instantly via the cancel
-	// endpoint instead of routing the user to checkout. This applies regardless of
-	// whether any money would be refunded (e.g. plans paid with credits or free).
+	// Refund-window instant downgrade: when the current plan has a refundable
+	// receipt — its initial purchase or, after a renewal, the renewal's — a
+	// downgrade is performed instantly via the cancel endpoint instead of routing
+	// the user to checkout. This applies regardless of whether any money would be
+	// refunded (e.g. plans paid with credits or free).
 	const reduxDispatch = useReduxDispatch();
 	const queryClient = useQueryClient();
 	const cancelAndRefundMutation = useMutation( cancelAndRefundPurchaseMutation() );
@@ -321,7 +322,7 @@ const PlansFeaturesMain = ( {
 	const isWithinRefundWindow =
 		config.isEnabled( 'plans/expired-downgrade' ) &&
 		!! currentPurchase &&
-		currentPurchase.is_within_initial_refund_window &&
+		currentPurchase.is_refundable &&
 		! currentPurchase.is_past_expiry_date;
 	// The delayed-downgrade flow (schedule a downgrade at renewal for an active
 	// plan) is gated separately from the launched expired/refund downgrade flow.


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2376/self-serve-instant-downgrades-are-not-available-after-renewal

## Proposed Changes

With this PR, self-serve **instant** downgrades are now offered to anyone whose plan has a refundable receipt, rather than only to those still inside the refund window of their *original* purchase. The eligibility check switches from `is_within_initial_refund_window` to `is_refundable`.

## Why are these changes being made?

An instant downgrade issues a refund, so it is only safe to offer while a refund is actually permitted — otherwise either the customer or we lose money. The check used for that was `is_within_initial_refund_window`, which is true only for a subscription's original receipt. That is narrower than the real constraint: a plan renewed a few days ago is just as refundable as one purchased a few days ago, and the backend supports refunding a renewal. Customers who renewed and immediately realised they wanted a smaller plan were pushed into the delayed-downgrade path and had to wait until the end of their term, even though an instant downgrade would have cost neither side anything.

`is_refundable` expresses the actual constraint — the subscription has a refundable receipt — and so covers both the initial purchase and a renewal still inside its own refund window. It is not a strict superset of the old flag: a plan inside its initial refund window with no refundable receipt at all no longer qualifies for the instant path and falls through to the delayed downgrade instead. That is the correct outcome, since there is no receipt to refund against.

Deliberately, no refund-*amount* check is added. A refundable receipt worth nothing generally means the purchase was free or paid entirely with credits, which is still a valid instant downgrade — it simply issues no refund. The confirmation modal already handles this: it omits the "You will be refunded X" line and labels its confirm button "Downgrade" rather than "Downgrade and refund X".

## Testing Instructions

* Use a Simple site with a paid, downgradable WordPress.com plan (e.g. Explorer or higher).
* Renew the plan so that it is past its initial purchase refund window but inside the renewal's refund window, then visit the plans page for that site.
* Choose a lower-tier plan. Before this change the confirmation modal offered to schedule the downgrade for the end of the term; it should now offer an instant downgrade, with a confirm button reading "Downgrade and refund X".
* Confirm, and check that the plan changes immediately and the refund is issued against the renewal receipt.
* Regression check: a plan with no refundable receipt (well past any refund window) should still show the delayed "Schedule downgrade" flow, and an expired plan should still route to checkout.
