### PR TITLE
Site generation: consume the server-interpreted build milestone (BIGR-809)

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/build-progress-poller.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/build-progress-poller.ts
@@ -4,18 +4,19 @@ const BUILD_TERMINAL_STATUSES = new Set( [ 'done', 'fail' ] );
 
 export type BuildProgressResponse = {
 	current?: string | null;
+	milestone?: string | null;
 	history?: Array< {
 		status?: string;
 	} >;
 };
 
-// Coarse UI milestones for the persisted pipeline step ids. This map chases
-// backend pipeline internals across a repo boundary, so it will lag when steps
-// are inserted or renamed upstream — an unmapped id degrades to the previous
-// milestone, never to breakage. The server owns two sibling maps over the same
-// step stream (Builder_Progress_Reader::MILESTONE_LABELS and the Big Sky
-// editor's toolId labels); the durable fix is the endpoint serving interpreted
-// milestones so the client stops tracking pipeline internals.
+// FALLBACK map of coarse UI milestones for the persisted pipeline step ids,
+// used only against servers that don't send the interpreted `milestone` field
+// yet. The endpoint now serves that field (Builder_Progress_Reader::
+// PIPELINE_MILESTONES, BIGR-809) from the repo the pipeline is vendored into,
+// so a step inserted or renamed upstream lands with its milestone in the same
+// deploy. Delete this map once the field has been in production long enough
+// that no older server can answer the poll.
 const MILESTONE_TOOLS: Record< string, string[] > = {
 	preparing: [ 'scaffold-theme', 'scaffold-plugin', 'refine-prompt', 'site-spec' ],
 	designing: [
@@ -66,6 +67,16 @@ export function getStepIndexForProgress(
 	response: BuildProgressResponse,
 	stepIds: string[]
 ): number | null {
+	// The server-interpreted milestone is authoritative when recognized: it is
+	// computed from the same full history by the map that lives next to the
+	// pipeline. The local scan below only serves servers not sending it yet.
+	if ( typeof response.milestone === 'string' ) {
+		const serverIndex = stepIds.indexOf( response.milestone );
+		if ( serverIndex !== -1 ) {
+			return serverIndex;
+		}
+	}
+
 	// The backend refreshes a repeated step's timestamp (heartbeat), so history
 	// order does not track milestone order — a long-running tool can resurface
 	// after later steps. Take the furthest recognized milestone across the whole

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/build-progress-poller.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/build-progress-poller.ts
@@ -47,6 +47,38 @@ describe( 'getStepIndexForProgress', () => {
 		expect( getStepIndexForProgress( { current: 'fail' }, stepIds ) ).toBeNull();
 		expect( getStepIndexForProgress( {}, stepIds ) ).toBeNull();
 	} );
+
+	it( 'prefers the server-interpreted milestone over the local map', () => {
+		// The server computes the milestone from the same full history with the
+		// map that lives next to the pipeline, so it wins even when the local
+		// map would say otherwise (e.g. a step this client build has never
+		// heard of).
+		expect(
+			getStepIndexForProgress(
+				{
+					current: 'a-step-this-client-does-not-know',
+					milestone: 'polishing',
+					history: [ { status: 'theme-json' } ],
+				},
+				stepIds
+			)
+		).toBe( 4 );
+	} );
+
+	it( 'falls back to the local map when the milestone is absent or unrecognized', () => {
+		// Older servers don't send the field; a newer server could one day send
+		// a milestone id this client build predates. Both degrade to the local
+		// scan instead of breaking.
+		expect( getStepIndexForProgress( { milestone: null, current: 'header-hero' }, stepIds ) ).toBe(
+			2
+		);
+		expect(
+			getStepIndexForProgress(
+				{ milestone: 'a-milestone-from-the-future', current: 'header-hero' },
+				stepIds
+			)
+		).toBe( 2 );
+	} );
 } );
 
 describe( 'pollForBuildProgress', () => {


### PR DESCRIPTION
Client side of BIGR-809 (server side: Automattic/wpcom#233747 — the build-progress endpoint now serves an interpreted `milestone` field).

## Proposed Changes

- `getStepIndexForProgress` prefers the server-interpreted `milestone` when it matches a known step id. The server computes it from the same full history with a map that lives next to the vendored pipeline, so a step renamed or added upstream lands with its milestone in the same wpcom deploy instead of waiting for a Calypso release.
- The local `MILESTONE_TOOLS` map stays as a fallback for servers that don't send the field yet (and for a hypothetical milestone id this client build predates — both degrade to the local scan). It gets deleted once the field has been in production long enough.

## Why are these changes being made?

The map's own comment says it: it "chases backend pipeline internals across a repo boundary, so it will lag when steps are inserted or renamed upstream." Three sibling maps interpret the same step stream today; interpretation belongs next to the pipeline.

## Testing Instructions

- `yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/` — 37 tests green; new cases cover milestone preferred over the local map, and fallback when the field is absent or unrecognized.
- Manual: start an AI site build (build-wow flow), watch the site-generation step advance through its milestones with the Network tab open on `build-progress` — the response now carries `milestone`, and the checklist follows it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtGHzKGKcZZkLLxz8WUomU
