### PR TITLE
Agents Manager: let providers rewrite the displayed transcript

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -36,6 +36,7 @@ import type {
 	GetChatComponent,
 	UseSuggestionsHook,
 	SiteBuildUtils,
+	TransformMessages,
 	UseCheckpointHook,
 	ProviderCapabilities,
 } from '../../utils/load-external-providers';
@@ -59,6 +60,7 @@ interface Props {
 	getChatComponent?: GetChatComponent;
 	/** Utilities for site building flow (e.g., progress tracking, site preview). */
 	siteBuildUtils?: SiteBuildUtils;
+	transformMessages?: TransformMessages;
 	/** Hook for saving and restoring editor state so that AI actions can be undone. */
 	useCheckpoint?: UseCheckpointHook;
 	/** Optional capability flags declared by one or more loaded providers. */
@@ -74,6 +76,7 @@ export default function AgentDock( {
 	getChatComponent,
 	useSuggestions,
 	siteBuildUtils,
+	transformMessages,
 	useCheckpoint,
 	capabilities,
 }: Props ) {
@@ -403,6 +406,7 @@ export default function AgentDock( {
 			useSuggestions={ useSuggestions }
 			getChatComponent={ getChatComponent }
 			siteBuildUtils={ siteBuildUtils }
+			transformMessages={ transformMessages }
 			useCheckpoint={ useCheckpoint }
 			capabilities={ capabilities }
 			isChatInputDisabled={ ! isChatEnabled }

--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -209,6 +209,7 @@ function AgentSetup( { agentId: hostAgentId }: { agentId?: string } ): JSX.Eleme
 			useSuggestions={ loadedProviders.useSuggestions }
 			getChatComponent={ loadedProviders.getChatComponent }
 			siteBuildUtils={ loadedProviders.siteBuildUtils }
+			transformMessages={ loadedProviders.transformMessages }
 			useCheckpoint={ loadedProviders.useCheckpoint }
 			capabilities={ loadedProviders.capabilities }
 		/>

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -51,6 +51,7 @@ import type {
 	GetChatComponent,
 	UseSuggestionsHook,
 	SiteBuildUtils,
+	TransformMessages,
 	UseCheckpointHook,
 	ProviderCapabilities,
 } from '../../utils/load-external-providers';
@@ -182,6 +183,8 @@ interface Props {
 	getChatComponent?: GetChatComponent;
 	/** Utilities for site building flow (e.g., progress tracking, site preview). */
 	siteBuildUtils?: SiteBuildUtils;
+	/** Rewrite the transcript before it is displayed. See `TransformMessages`. */
+	transformMessages?: TransformMessages;
 	/** Hook for saving and restoring editor state so that AI actions can be undone. */
 	useCheckpoint?: UseCheckpointHook;
 	/** Optional capability flags declared by one or more loaded providers. */
@@ -208,6 +211,7 @@ export default function OrchestratorChat( {
 	useSuggestions,
 	getChatComponent,
 	siteBuildUtils,
+	transformMessages,
 	useCheckpoint,
 	capabilities,
 	isChatInputDisabled,
@@ -829,6 +833,14 @@ export default function OrchestratorChat( {
 	const displayedMessages = useMemo< AgentsManagerUIMessage[] >( () => {
 		let currentMessages: AgentsManagerUIMessage[] = messages;
 
+		// Let the provider rewrite the transcript first, while the messages are
+		// still the raw ones. Applied on every render over the whole list, so a
+		// message restored from conversation history is presented the same way as
+		// one that was just sent.
+		if ( transformMessages ) {
+			currentMessages = transformMessages( currentMessages );
+		}
+
 		currentMessages = currentMessages.filter(
 			( message ) =>
 				! deletedMessageIds.has( message.id ) &&
@@ -945,6 +957,7 @@ export default function OrchestratorChat( {
 		retainedShowComponentMessages,
 		siteBuildUtils,
 		thinkingMessage,
+		transformMessages,
 	] );
 
 	// Notify parent when has-messages state changes.

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -20,6 +20,7 @@ import type {
 	UseCheckpointReturn,
 	UseSuggestionsHook,
 } from '../load-external-providers';
+import type { UIMessage } from '@automattic/agenttic-client';
 
 jest.mock( '@automattic/agenttic-client', () => ( { getAgentManager: jest.fn() } ), {
 	virtual: true,
@@ -682,6 +683,37 @@ describe( 'loadExternalProviders', () => {
 
 		expect( providers.getChatComponent?.( 'title-picker' ) ).toBe( TitlePicker );
 		expect( providers.getChatComponent?.( 'chat-suggestions' ) ).toBeNull();
+	} );
+
+	it( 'chains message transforms across providers', async () => {
+		// Chained, not first-write-wins: one provider hiding its own prompts must
+		// not stop another from presenting its messages.
+		setAgentsManagerData( {
+			agentProviders: [
+				{
+					transformMessages: ( messages: UIMessage[] ) =>
+						messages.map( ( message ) => ( { ...message, id: `${ message.id }-a` } ) ),
+				},
+				{
+					transformMessages: ( messages: UIMessage[] ) =>
+						messages.map( ( message ) => ( { ...message, id: `${ message.id }-b` } ) ),
+				},
+			],
+		} );
+
+		const providers = await loadExternalProviders();
+
+		expect( providers.transformMessages?.( [ { id: '1' } as UIMessage ] ) ).toEqual( [
+			{ id: '1-a-b' },
+		] );
+	} );
+
+	it( 'leaves the transcript alone when no provider transforms messages', async () => {
+		setAgentsManagerData( { agentProviders: [ {} ] } );
+
+		const providers = await loadExternalProviders();
+
+		expect( providers.transformMessages ).toBeUndefined();
 	} );
 
 	it( 'uses the first provider for onTaskUpdate', async () => {

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -108,6 +108,21 @@ type ChatComponentType =
 export type GetChatComponent = ( type: ChatComponentType ) => React.ComponentType< unknown > | null;
 
 /**
+ * Rewrite the visible transcript.
+ *
+ * Applied to the whole message list on every render — including messages
+ * rehydrated from conversation history — so a provider can present a message
+ * differently from what it sent. The motivating case is a host that submits a
+ * large machine-facing prompt (block ids, computed styles, tool instructions)
+ * and wants the user to see a short summary instead. Deriving the display from
+ * the content, rather than flagging it at send time, is what makes it survive a
+ * reload.
+ *
+ * Must be pure and cheap: it runs on every render of the transcript.
+ */
+export type TransformMessages = ( messages: UIMessage[] ) => UIMessage[];
+
+/**
  * Checkpoint return type - for saving and restoring editor state so that AI actions can be undone.
  */
 export type UseCheckpointReturn = {
@@ -182,6 +197,7 @@ export interface LoadedProviders {
 	useAbilitiesSetup?: AbilitiesSetupHook;
 	useSuggestions?: UseSuggestionsHook;
 	getChatComponent?: GetChatComponent;
+	transformMessages?: TransformMessages;
 	siteBuildUtils?: SiteBuildUtils;
 	useCheckpoint?: UseCheckpointHook;
 	/**
@@ -600,6 +616,7 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	const allMarkdownComponents: MarkdownComponents[] = [];
 	const allMarkdownExtensions: MarkdownExtensions[] = [];
 	const allGetChatComponents: GetChatComponent[] = [];
+	const allTransformMessages: TransformMessages[] = [];
 	const allAbilitiesSetups: AbilitiesSetupHook[] = [];
 	const allUseSuggestions: UseSuggestionsHook[] = [];
 	const allGetEmptyViewSuggestions: ( () => Suggestion[] )[] = [];
@@ -650,6 +667,9 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		}
 		if ( module.getChatComponent ) {
 			allGetChatComponents.push( module.getChatComponent );
+		}
+		if ( module.transformMessages ) {
+			allTransformMessages.push( module.transformMessages );
 		}
 		if ( module.useAbilitiesSetup ) {
 			allAbilitiesSetups.push( module.useAbilitiesSetup );
@@ -760,6 +780,18 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		};
 	}
 
+	// Merge transformMessages: compose in registration order, so each provider
+	// rewrites what the previous one produced. Unlike the singleton exports this
+	// is chained rather than first-write-wins — two providers can each present
+	// their own messages without one silently disabling the other.
+	let mergedTransformMessages: TransformMessages | undefined;
+	if ( allTransformMessages.length === 1 ) {
+		mergedTransformMessages = allTransformMessages[ 0 ];
+	} else if ( allTransformMessages.length > 1 ) {
+		mergedTransformMessages = ( messages: UIMessage[] ) =>
+			allTransformMessages.reduce( ( current, transform ) => transform( current ), messages );
+	}
+
 	// Merge getChatComponent: try each provider, return first non-null.
 	if ( allGetChatComponents.length === 1 ) {
 		mergedGetChatComponent = allGetChatComponents[ 0 ];
@@ -823,6 +855,7 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		onTaskUpdate: mergedOnTaskUpdate,
 		useSuggestions: mergedUseSuggestions,
 		getChatComponent: mergedGetChatComponent,
+		transformMessages: mergedTransformMessages,
 		siteBuildUtils: mergedSiteBuildUtils,
 		useCheckpoint: mergedUseCheckpoint,
 		// Match peer fields: undefined when no provider opted in.


### PR DESCRIPTION
## Proposed Changes

Adds an optional `transformMessages` export to the external-provider contract. It is applied to the whole message list at the top of the `displayedMessages` pipeline in `orchestrator-chat` — the same place `siteBuildUtils.groupSiteBuildMessages` already reshapes messages for display.

```ts
export type TransformMessages = ( messages: UIMessage[] ) => UIMessage[];
```

A provider that exports it gets to decide how its own messages appear, without agents-manager knowing anything about them.

### Why

Big Sky's easy mode lets you annotate blocks in the page and send the batch to the agent. What gets sent is agent-facing: block ids, computed styles, nearby text, and instructions for passing the annotations on to `wpcom__block_editing`. Rendering that verbatim in the transcript is noise — the user should see "2 annotations submitted".

### Why at display time rather than send time

The obvious alternative is a flag at submit ("send this, but don't show it"). That only covers the message being sent. On reload the message comes back from conversation history as ordinary text and renders in full, so the raw prompt reappears.

Deriving the display from the message content instead means history renders identically to a live send. This is the approach the Easy Site Editor already uses (`useAnnotationMessageTransform`), and porting easy mode to the site editor is what surfaced the gap.

### Merge semantics

Transforms are **chained** across providers in registration order, not first-write-wins like the singleton exports. Two providers can each present their own messages; one hiding its prompts must not silently disable another's.

## Testing Instructions

Unit: `yarn jest packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts` — covers chaining and the no-provider case.

End to end, against a local build of `apps/agents-manager` served in place of `widgets.wp.com` (Big Sky branch `migrate-ese-to-site-editor`, which registers the annotation transform):

1. Open the site editor with `&flags=easy-mode` in query string
2. Annotate a block and submit annotation submit.
3. The transcript shows "N annotations submitted", not the raw prompt.
4. Agent actions the annotation prompt
5. Reload. The message still shows the label, not the prompt.

No behaviour change for providers that do not export `transformMessages`.