### PR TITLE
Stats: follow the store rename through the licensing surfaces

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/index.tsx
@@ -136,7 +136,7 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 					translate( 'VaultPress Backup w/ 1TB storage' ),
 					translate( 'Scan w/ WAF' ),
 					translate( 'Akismet Anti-spam w/ 60k API calls/mo' ),
-					translate( 'Stats w/ 100k views/mo (Commercial use)' ),
+					translate( 'Stats w/ 100k views/mo' ),
 					translate( 'VideoPress w/ 1TB storage' ),
 					translate( 'Boost w/ Auto CSS Generation' ),
 					translate( 'Social Advanced w/ unlimited shares' ),

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/index.tsx
@@ -136,7 +136,7 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 					translate( 'VaultPress Backup w/ 1TB storage' ),
 					translate( 'Scan w/ WAF' ),
 					translate( 'Akismet Anti-spam w/ 60k API calls/mo' ),
-					translate( 'Stats w/ 100k views/mo' ),
+					translate( 'Stats (Paid) w/ 100k views/mo' ),
 					translate( 'VideoPress w/ 1TB storage' ),
 					translate( 'Boost w/ Auto CSS Generation' ),
 					translate( 'Social Advanced w/ unlimited shares' ),

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/stats/UpsellStatsCard.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/stats/UpsellStatsCard.tsx
@@ -32,7 +32,7 @@ const UpsellStatsCard = ( { site }: Props ) => {
 		[ translate ]
 	);
 	const footerText = translate(
-		'Commercial sites require a paid plan, which you can purchase at a discount within {{a}}the marketplace{{/a}}.',
+		'A paid plan is required, which you can purchase at a discount within {{a}}the marketplace{{/a}}.',
 		{
 			components: {
 				a: <a href="/marketplace/products?search_query=stats" />,

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/stats/UpsellStatsCard.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/stats/UpsellStatsCard.tsx
@@ -32,7 +32,7 @@ const UpsellStatsCard = ( { site }: Props ) => {
 		[ translate ]
 	);
 	const footerText = translate(
-		'A paid plan is required, which you can purchase at a discount within {{a}}the marketplace{{/a}}.',
+		'A paid plan is required to unlock premium features. You can purchase one at a discount within {{a}}the marketplace{{/a}}.',
 		{
 			components: {
 				a: <a href="/marketplace/products?search_query=stats" />,

--- a/client/jetpack-cloud/sections/partner-portal/lib/get-product-title.ts
+++ b/client/jetpack-cloud/sections/partner-portal/lib/get-product-title.ts
@@ -9,7 +9,7 @@ export default function getProductTitle( product: string, removeVariant: boolean
 		return 'AI';
 	}
 
-	if ( 'Jetpack Stats (Commercial license)' === product ) {
+	if ( product.startsWith( 'Jetpack Stats' ) ) {
 		return 'Stats';
 	}
 

--- a/client/jetpack-cloud/sections/partner-portal/lib/get-product-title.ts
+++ b/client/jetpack-cloud/sections/partner-portal/lib/get-product-title.ts
@@ -9,7 +9,8 @@ export default function getProductTitle( product: string, removeVariant: boolean
 		return 'AI';
 	}
 
-	if ( product.startsWith( 'Jetpack Stats' ) ) {
+	// The store catalog renamed this product; both names are served until the rename ships (STATS-426).
+	if ( 'Jetpack Stats (Paid)' === product || 'Jetpack Stats (Commercial license)' === product ) {
 		return 'Stats';
 	}
 

--- a/client/jetpack-cloud/sections/partner-portal/lib/get-product-title.ts
+++ b/client/jetpack-cloud/sections/partner-portal/lib/get-product-title.ts
@@ -9,8 +9,7 @@ export default function getProductTitle( product: string, removeVariant: boolean
 		return 'AI';
 	}
 
-	// The store catalog renamed this product; both names are served until the rename ships (STATS-426).
-	if ( 'Jetpack Stats (Paid)' === product || 'Jetpack Stats (Commercial license)' === product ) {
+	if ( 'Jetpack Stats (Paid)' === product ) {
 		return 'Stats';
 	}
 

--- a/client/jetpack-cloud/sections/partner-portal/lib/test/get-product-title.ts
+++ b/client/jetpack-cloud/sections/partner-portal/lib/test/get-product-title.ts
@@ -5,15 +5,12 @@ describe( 'getProductTitle', () => {
 		expect( getProductTitle( 'Jetpack AI' ) ).toBe( 'AI' );
 	} );
 
-	it.each( [
-		'Jetpack Stats',
-		'Jetpack Stats (Commercial license)',
-		'Jetpack Stats (Paid)',
-		'Jetpack Stats (Name your price)',
-		'Jetpack Stats (Free)',
-	] )( 'returns "Stats" if the product name is "%s"', ( product ) => {
-		expect( getProductTitle( product ) ).toBe( 'Stats' );
-	} );
+	it.each( [ 'Jetpack Stats (Paid)', 'Jetpack Stats (Commercial license)' ] )(
+		'returns "Stats" if the product name is "%s"',
+		( product ) => {
+			expect( getProductTitle( product ) ).toBe( 'Stats' );
+		}
+	);
 
 	it.each( [
 		[ 'Jetpack Whatchamacallit', 'Whatchamacallit' ],

--- a/client/jetpack-cloud/sections/partner-portal/lib/test/get-product-title.ts
+++ b/client/jetpack-cloud/sections/partner-portal/lib/test/get-product-title.ts
@@ -5,8 +5,14 @@ describe( 'getProductTitle', () => {
 		expect( getProductTitle( 'Jetpack AI' ) ).toBe( 'AI' );
 	} );
 
-	it( 'returns "Stats" if the product name is "Jetpack Stats (Commercial license)"', () => {
-		expect( getProductTitle( 'Jetpack Stats (Commercial license)' ) ).toBe( 'Stats' );
+	it.each( [
+		'Jetpack Stats',
+		'Jetpack Stats (Commercial license)',
+		'Jetpack Stats (Paid)',
+		'Jetpack Stats (Name your price)',
+		'Jetpack Stats (Free)',
+	] )( 'returns "Stats" if the product name is "%s"', ( product ) => {
+		expect( getProductTitle( product ) ).toBe( 'Stats' );
 	} );
 
 	it.each( [

--- a/client/jetpack-cloud/sections/partner-portal/lib/test/get-product-title.ts
+++ b/client/jetpack-cloud/sections/partner-portal/lib/test/get-product-title.ts
@@ -5,12 +5,9 @@ describe( 'getProductTitle', () => {
 		expect( getProductTitle( 'Jetpack AI' ) ).toBe( 'AI' );
 	} );
 
-	it.each( [ 'Jetpack Stats (Paid)', 'Jetpack Stats (Commercial license)' ] )(
-		'returns "Stats" if the product name is "%s"',
-		( product ) => {
-			expect( getProductTitle( product ) ).toBe( 'Stats' );
-		}
-	);
+	it( 'returns "Stats" if the product name is "Jetpack Stats (Paid)"', () => {
+		expect( getProductTitle( 'Jetpack Stats (Paid)' ) ).toBe( 'Stats' );
+	} );
 
 	it.each( [
 		[ 'Jetpack Whatchamacallit', 'Whatchamacallit' ],


### PR DESCRIPTION
Part of STATS-429. Follow-up to STATS-426 / #113450.

## Proposed Changes

* `getProductTitle()` in the partner portal now matches the renamed `Jetpack Stats (Paid)` instead of the retired `Jetpack Stats (Commercial license)`.
* Updated the accompanying unit test.
* The A4A Premier Agency Hosting bullet now reads `Stats (Paid) w/ 100k views/mo` instead of `Stats w/ 100k views/mo (Commercial use)`.
* The A4A Stats upsell footer now reads `A paid plan is required to unlock premium features. You can purchase one at a discount within the marketplace.` instead of opening with `Commercial sites require…`.

## Why are these changes being made?

STATS-429 tracked the two Jetpack Stats naming references deliberately left out of the STATS-426 rename, pending a decision. Both are now settled:

**Licensing catalog.** The open question was whether the partner licensing catalog is a second product list needing its own rename. It is not. Both A4A-facing endpoints read `Store_Product::product_name` straight off `store-product-list.php`:

* `/jetpack-licensing/partner/product-families` → `class-jetpack-start-product-helpers.php:305` → `class-provisionable-item.php`
* `/agency/products` (behind `a4a-bd-term-pricing` + `a4a-bd-checkout`) → `class-product-family-resource.php:108`; its `products-config.php` carries slugs and product IDs only, no names

So the store rename — wpcom 233461, merged as `6ef7d08576d` — flows into Jetpack Manage and A4A on its own, with no licensing-side file to edit. Both endpoints now serve `Jetpack Stats (Paid)`.

That made the Calypso side a live bug rather than dead code. The special case only recognised the retired name, so the renamed one fell through to the generic regex, which strips `Jetpack ` and the parentheses and yields **`Stats Paid`** in the licence lightbox and licence-assignment flows.

Only the paid tier needs handling: Free and PWYW exist in `Family_Collection` but are not provisionable items and have no entry in `products-config.php`, so they never appear in either endpoint's product list.

**A4A hosting bullet.** `(Commercial use)` is dropped per the decision on the issue — for agencies everything is commercial use — and the bullet now carries the renamed product name, matching its siblings in the same list (`VaultPress Backup w/ 1TB storage`, `Social Advanced w/ unlimited shares`).

**A4A Stats upsell footer.** Same reasoning applied to the one other A4A string that led with "Commercial": qualifying the paid-plan requirement to *commercial* sites tells an agency nothing, since every site they manage qualifies. The sentence now leads with the requirement and what it buys, and keeps the discounted marketplace link.

**Sweep.** `get-product-title.ts` was the only place in the repo keying logic off a Jetpack Stats product-name string; every other Stats display name was already aligned by #113450, and partner-portal product icons key off slugs, not names. No A4A-visible product name contains "Commercial" any more: the only remaining `ommercial` hits in the store catalog are Akismet `description` fields, which neither endpoint emits, and `Akismet Personal (Free non-commercial license)`, which is not a provisionable item and absent from `products-config.php`.

That leaves no "commercial" wording anywhere in A4A. What remains elsewhere is entitlement copy rather than product naming, which belongs to the STATS-364 sweep: `client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx`, the non-commercial licence copy in `client/my-sites/stats/stats-purchase/`, and the `Commercial use` feature bullets in `packages/calypso-products/src/translations.tsx` (:1506, :1991).

## Testing Instructions

* `yarn test-client client/jetpack-cloud/sections/partner-portal/lib` — 13 suites, 97 tests pass.
* `yarn typecheck-client` — clean.
* In Jetpack Manage or A8C for Agencies, open **Marketplace → Products** and the Jetpack Stats licence lightbox, then run an assignment flow. The product reads `Stats`, not `Stats Paid`.
* A8C for Agencies → **Marketplace → Hosting → Premier Agency Hosting**: the Jetpack Complete list reads `Stats (Paid) w/ 100k views/mo`.
* A8C for Agencies → **Sites → any site without Stats → Stats tab**: the upsell card footer reads `A paid plan is required to unlock premium features. You can purchase one at a discount within the marketplace.`, with "the marketplace" still linking to `/marketplace/products?search_query=stats`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
