### PR TITLE
Agents Manager: Hide Site Editor suggestions while typing

### DIFF
--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -122,6 +122,7 @@ const mockAgentChat = jest.fn(
 				Click auto-submit suggestion
 			</button>
 			<button onClick={ () => onInputChange?.( 'Describe these images' ) }>Type message</button>
+			<button onClick={ () => onInputChange?.( '' ) }>Clear message</button>
 			<button onClick={ () => onSubmit( 'Describe these images' ) }>Submit message</button>
 			<button onClick={ () => onAbort?.() }>Stop</button>
 			{ error && <div data-testid="chat-error">{ error }</div> }
@@ -655,6 +656,43 @@ describe( 'OrchestratorChat', () => {
 		expect( screen.getByText( 'Customize colors' ) ).toBeTruthy();
 		expect( screen.getByText( 'Change page layout' ) ).toBeTruthy();
 		expect( screen.getByText( 'Dynamic action' ) ).toBeTruthy();
+	} );
+
+	it( 'hides all suggestions while the user types and restores them when cleared', () => {
+		const emptySuggestions: Suggestion[] = [
+			{ id: 'change-page-layout', label: 'Change page layout', prompt: 'Change page layout' },
+		];
+		const writingSuggestions: Suggestion[] = [
+			{ id: 'proofread-content', label: 'Proofread', prompt: 'Proofread this page' },
+		];
+
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( {
+				suggestions: writingSuggestions,
+			} )
+		);
+
+		render(
+			chat( {
+				emptyViewSuggestions: emptySuggestions,
+				useSuggestions: () => ( { suggestions: writingSuggestions } ),
+			} )
+		);
+
+		expect( screen.getByText( 'Change page layout' ) ).toBeTruthy();
+		expect( screen.getByText( 'Proofread' ) ).toBeTruthy();
+		jest.mocked( recordBigSkyTracksEvent ).mockClear();
+
+		fireEvent.click( screen.getByText( 'Type message' ) );
+
+		expect( screen.queryByText( 'Change page layout' ) ).toBeNull();
+		expect( screen.queryByText( 'Proofread' ) ).toBeNull();
+
+		fireEvent.click( screen.getByText( 'Clear message' ) );
+
+		expect( screen.getByText( 'Change page layout' ) ).toBeTruthy();
+		expect( screen.getByText( 'Proofread' ) ).toBeTruthy();
+		expect( recordBigSkyTracksEvent ).not.toHaveBeenCalled();
 	} );
 
 	it( 'replaces provider empty-view suggestions with contextual dynamic suggestions', () => {

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -949,18 +949,15 @@ export default function OrchestratorChat( {
 		( isProcessing || ( isThinking && ! isBuildingSite ) ) && ! shouldSuppressTransientThinking;
 
 	// Determine which suggestions to show following Big Sky's logic:
-	// - Empty chat: show provider empty-view chips plus dynamic chips.
-	// - Active chat/input: show dynamic suggestions only.
+	// - Empty input and chat: show provider empty-view chips plus dynamic chips.
+	// - Empty input and active chat: show dynamic suggestions only.
+	// - Non-empty input: hide empty-view suggestions while AgentUI hides active-chat suggestions.
 	let displayedEmptyViewSuggestions: Suggestion[] = [];
-	if ( ! suggestionsVisible ) {
-		// Minimized/collapsed: the chat renders no suggestions, so leave the list
+	if ( ! suggestionsVisible || inputValue.length > 0 ) {
+		// Hidden or actively composing: the chat renders no suggestions, so leave the list
 		// empty to avoid firing chat_suggestions_rendered for hidden chips.
 		displayedEmptyViewSuggestions = [];
-	} else if (
-		! isLoadingConversation &&
-		displayedMessages.length === 0 &&
-		inputValue.length === 0
-	) {
+	} else if ( ! isLoadingConversation && displayedMessages.length === 0 ) {
 		// Prefer the registered store, but fall back to the live `useSuggestions`
 		// output when the store is empty. Clicking a suggestion calls
 		// `clearSuggestions()`, which empties the store, and the re-registration


### PR DESCRIPTION
## Proposed Changes

* Hide page, design, and writing suggestion chips while the Site Editor chat composer contains text.
* Restore the merged suggestion set when the composer is cleared without recording a duplicate suggestion impression.
* Add regression coverage for typing and clearing the composer.

## Why are these changes being made?

* An empty Site Editor chat shows page and design suggestions alongside writing actions. Typing previously skipped that merged set and left only the writing actions visible, which made the suggestion area change unexpectedly. Hiding all suggestions while the user types keeps the composer stable and restores the full empty-state set when it is cleared.

## Testing Instructions

Automated checks completed:

* `yarn typecheck-packages`
* `yarn jest -c test/packages/jest.config.js --runInBand --no-watchman --testPathPattern=agents-manager` — 63 suites and 703 tests passed.
* `yarn eslint packages/agents-manager/src/components/orchestrator-chat/index.tsx packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx`
* `yarn prettier --check packages/agents-manager/src/components/orchestrator-chat/index.tsx packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx`
* `git diff --check`

Manual Site Editor checks:

1. Run `cd apps/agents-manager && yarn dev --sync`.
2. Open the Site Editor and start with an empty Agents Manager conversation.
3. With no block selected, confirm page and design suggestions appear alongside Writing assistance.
4. Type in the chat composer without submitting. Confirm all suggestions disappear.
5. Clear the composer. Confirm the original page and design suggestions and Writing assistance return.
6. Select a supported text block and repeat the typing and clearing steps. Confirm contextual suggestions hide while typing and return after clearing.
7. Repeat the checks in docked and floating layouts.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks/using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?