### PR TITLE
Site Spec: report Tracks events from the CIAB flow

### DIFF
--- a/client/lib/site-spec/utils.ts
+++ b/client/lib/site-spec/utils.ts
@@ -199,6 +199,9 @@ export function getCiabSiteSpecConfig(): SiteSpecConfig {
 	const ref = new URLSearchParams( window.location.search ).get( 'ref' );
 
 	return {
+		// Needed for `tracking`: without it the widget falls back to its own
+		// default of `enabled: false` and this flow reports no events at all.
+		...getDefaultSiteSpecConfig(),
 		buildSiteUrl: '/setup/ai-site-builder/?create_garden_site=1&trigger_backend_build=0&spec_id=',
 		backButton: {
 			enabled: ref === 'new-site-popover' || ref === 'start-store',


### PR DESCRIPTION
Fixes #

## Proposed Changes

* `getCiabSiteSpecConfig()` now spreads `getDefaultSiteSpecConfig()`, so the CIAB/store flow inherits the `tracking` config.

## Why are these changes being made?

`getCiabSiteSpecConfig()` builds its config from scratch rather than extending `getDefaultSiteSpecConfig()`, so it ships no `tracking` key. The Site Spec widget's own default is `enabled: false`, so every event from this flow has been dropped — no `onboarding_started`, no `chat_suggestion_click`, no `site_specs_created`.

Checking `wyeast.tracks.prod_events` for the six weeks to 2026-08-11 confirms it: no events carrying `sitespec_version` originate from this surface, while the Big Sky embed over the same window shows 36,397 `onboarding_started` and 26,210 `site_specs_created`. We have no idea how the store flow performs because it has never reported.

Every other Calypso config — `getEarlyProvisionSiteSpecConfig()`, `getBuildWowSiteSpecConfig()`, `getVegaSiteSpecConfig()` — already spreads the default. CIAB is the odd one out.

The spread also introduces `agentUrl`/`agentId`/`buildSiteUrl` keys, all `undefined` in every environment config (only `script_url` and `css_url` are set under `site_spec`). `buildSiteUrl` is overridden on the very next line, and the widget reads the other two through `??`/`||` fallbacks — `config?.agentId || 'site-spec'` — so resolved behaviour is identical to today. The three sibling configs above already depend on exactly this.

## Testing Instructions

1. Open the store flow at `/setup/ai-site-builder` with `?ref=start-store`.
2. Confirm Site Spec renders unchanged: same Woo branding, same five chips, same back button behaviour, same build-site redirect on spec confirmation.
3. With Tracks debugging enabled, confirm `jetpack_calypso_onboarding_started` now fires on load. Before this change, nothing fired.
4. Click a chip and submit a description; confirm `jetpack_calypso_chat_suggestion_click` and `jetpack_calypso_site_specs_created` fire.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

No new strings and no UI change, so the string-freeze, dark-mode, a11y and memoizing items do not apply. The privacy item is checked as considered rather than done: this turns on event reporting for a flow that was silent, using the same events and the same `jetpack_calypso` prefix already emitted by the other Site Spec flows. Worth a second opinion from someone who knows whether that needs the label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
