### PR TITLE
Jetpack AI sidebar: add Generate Featured Image suggestion

### DIFF
--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -481,16 +481,15 @@ describe( 'AgentChat', () => {
 		expect( screen.queryByRole( 'button', { name: 'Proofread' } ) ).toBeNull();
 	} );
 
-	it( 'shortens the featured image label alongside the design suggestions', () => {
-		const featuredImageSuggestion = {
-			id: 'generate-featured-image',
-			label: 'Generate Featured Image',
-			description: 'Create a new image with AI and set it as the featured image.',
-			prompt: '',
-		};
+	it( 'keeps the featured image suggestion out of the writing group', () => {
 		const suggestions = [
 			{ id: 'customize-colors', label: 'Customize colors', prompt: 'Customize colors' },
-			featuredImageSuggestion,
+			{
+				id: 'generate-featured-image',
+				label: 'Generate featured image',
+				description: 'Create a new image with AI and set it as the featured image.',
+				prompt: '',
+			},
 			{ id: 'optimize-title', label: 'Optimize Title', prompt: 'Optimize the title' },
 		];
 
@@ -502,23 +501,6 @@ describe( 'AgentChat', () => {
 
 		const button = screen.getByRole( 'button', { name: 'Generate featured image' } );
 		expect( button.closest( '.agents-manager-writing-suggestions' ) ).toBeNull();
-	} );
-
-	it( 'keeps the featured image label as provided in the flat view', () => {
-		const featuredImageSuggestion = {
-			id: 'generate-featured-image',
-			label: 'Generate Featured Image',
-			description: 'Create a new image with AI and set it as the featured image.',
-			prompt: '',
-		};
-
-		renderAgentChat( {
-			isOpen: true,
-			emptyViewSuggestions: [ featuredImageSuggestion ],
-			groupWritingSuggestions: false,
-		} );
-
-		expect( screen.getByRole( 'button', { name: 'Generate Featured Image' } ) ).toBeInTheDocument();
 	} );
 
 	it( 'keeps the flat empty view when there are no writing suggestions', () => {

--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -481,6 +481,46 @@ describe( 'AgentChat', () => {
 		expect( screen.queryByRole( 'button', { name: 'Proofread' } ) ).toBeNull();
 	} );
 
+	it( 'shortens the featured image label alongside the design suggestions', () => {
+		const featuredImageSuggestion = {
+			id: 'generate-featured-image',
+			label: 'Generate Featured Image',
+			description: 'Create a new image with AI and set it as the featured image.',
+			prompt: '',
+		};
+		const suggestions = [
+			{ id: 'customize-colors', label: 'Customize colors', prompt: 'Customize colors' },
+			featuredImageSuggestion,
+			{ id: 'optimize-title', label: 'Optimize Title', prompt: 'Optimize the title' },
+		];
+
+		renderAgentChat( {
+			isOpen: true,
+			emptyViewSuggestions: suggestions,
+			groupWritingSuggestions: true,
+		} );
+
+		const button = screen.getByRole( 'button', { name: 'Generate featured image' } );
+		expect( button.closest( '.agents-manager-writing-suggestions' ) ).toBeNull();
+	} );
+
+	it( 'keeps the featured image label as provided in the flat view', () => {
+		const featuredImageSuggestion = {
+			id: 'generate-featured-image',
+			label: 'Generate Featured Image',
+			description: 'Create a new image with AI and set it as the featured image.',
+			prompt: '',
+		};
+
+		renderAgentChat( {
+			isOpen: true,
+			emptyViewSuggestions: [ featuredImageSuggestion ],
+			groupWritingSuggestions: false,
+		} );
+
+		expect( screen.getByRole( 'button', { name: 'Generate Featured Image' } ) ).toBeInTheDocument();
+	} );
+
 	it( 'keeps the flat empty view when there are no writing suggestions', () => {
 		const suggestion = {
 			id: 'customize-colors',

--- a/packages/agents-manager/src/components/agent-chat/grouped-empty-view.tsx
+++ b/packages/agents-manager/src/components/agent-chat/grouped-empty-view.tsx
@@ -5,8 +5,8 @@ import { __, isRTL } from '@wordpress/i18n';
 import { Icon, chevronDown, chevronLeft, chevronRight } from '@wordpress/icons';
 import {
 	DESIGN_SUGGESTION_IDS,
-	formatTopLevelSuggestions,
 	formatWritingSuggestionLabels,
+	hideTopLevelDescriptions,
 	WHAT_ELSE_CAN_I_DO_SUGGESTION_ID,
 	WRITING_SUGGESTION_IDS,
 } from '../../hooks/use-empty-view-suggestions';
@@ -70,7 +70,7 @@ export default function GroupedEmptyView( {
 		);
 	}
 
-	const topLevelSuggestions = formatTopLevelSuggestions(
+	const topLevelSuggestions = hideTopLevelDescriptions(
 		displaySuggestions.filter(
 			( suggestion ) =>
 				! WRITING_SUGGESTION_IDS.has( suggestion.id ) &&

--- a/packages/agents-manager/src/components/agent-chat/grouped-empty-view.tsx
+++ b/packages/agents-manager/src/components/agent-chat/grouped-empty-view.tsx
@@ -5,6 +5,7 @@ import { __, isRTL } from '@wordpress/i18n';
 import { Icon, chevronDown, chevronLeft, chevronRight } from '@wordpress/icons';
 import {
 	DESIGN_SUGGESTION_IDS,
+	formatTopLevelSuggestions,
 	formatWritingSuggestionLabels,
 	WHAT_ELSE_CAN_I_DO_SUGGESTION_ID,
 	WRITING_SUGGESTION_IDS,
@@ -69,10 +70,12 @@ export default function GroupedEmptyView( {
 		);
 	}
 
-	const topLevelSuggestions = displaySuggestions.filter(
-		( suggestion ) =>
-			! WRITING_SUGGESTION_IDS.has( suggestion.id ) &&
-			suggestion.id !== WHAT_ELSE_CAN_I_DO_SUGGESTION_ID
+	const topLevelSuggestions = formatTopLevelSuggestions(
+		displaySuggestions.filter(
+			( suggestion ) =>
+				! WRITING_SUGGESTION_IDS.has( suggestion.id ) &&
+				suggestion.id !== WHAT_ELSE_CAN_I_DO_SUGGESTION_ID
+		)
 	);
 	const collapsedIcon = isRTL() ? chevronLeft : chevronRight;
 

--- a/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
@@ -25,7 +25,7 @@ jest.mock( '../../contexts', () => ( {
 } ) );
 
 import { renderHook, waitFor } from '@testing-library/react';
-import { useEmptyViewSuggestions } from '../use-empty-view-suggestions';
+import { formatTopLevelSuggestions, useEmptyViewSuggestions } from '../use-empty-view-suggestions';
 import type { LoadedProviders } from '../../utils/load-external-providers';
 
 const readerSuggestion = {
@@ -331,4 +331,35 @@ describe( 'useEmptyViewSuggestions', () => {
 			);
 		}
 	);
+} );
+
+describe( 'formatTopLevelSuggestions', () => {
+	const featuredImage = {
+		id: 'generate-featured-image',
+		label: 'Generate Featured Image',
+		description: 'Create a new image with AI and set it as the featured image.',
+		prompt: '',
+	};
+
+	it( 'shortens the label and drops the description', () => {
+		const [ formatted ] = formatTopLevelSuggestions( [ featuredImage ] );
+
+		expect( formatted.label ).toBe( 'Generate featured image' );
+		expect( formatted.description ).toBeUndefined();
+	} );
+
+	it( 'keeps the rest of the suggestion intact', () => {
+		const action = jest.fn();
+		const [ formatted ] = formatTopLevelSuggestions( [ { ...featuredImage, action } ] );
+
+		expect( formatted.id ).toBe( featuredImage.id );
+		expect( formatted.prompt ).toBe( '' );
+		expect( formatted.action ).toBe( action );
+	} );
+
+	it( 'leaves suggestions it does not know about alone', () => {
+		expect( formatTopLevelSuggestions( [ siteEditorSuggestion ] ) ).toEqual( [
+			siteEditorSuggestion,
+		] );
+	} );
 } );

--- a/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
@@ -25,7 +25,7 @@ jest.mock( '../../contexts', () => ( {
 } ) );
 
 import { renderHook, waitFor } from '@testing-library/react';
-import { formatTopLevelSuggestions, useEmptyViewSuggestions } from '../use-empty-view-suggestions';
+import { hideTopLevelDescriptions, useEmptyViewSuggestions } from '../use-empty-view-suggestions';
 import type { LoadedProviders } from '../../utils/load-external-providers';
 
 const readerSuggestion = {
@@ -333,32 +333,32 @@ describe( 'useEmptyViewSuggestions', () => {
 	);
 } );
 
-describe( 'formatTopLevelSuggestions', () => {
+describe( 'hideTopLevelDescriptions', () => {
 	const featuredImage = {
 		id: 'generate-featured-image',
-		label: 'Generate Featured Image',
+		label: 'Generate featured image',
 		description: 'Create a new image with AI and set it as the featured image.',
 		prompt: '',
 	};
 
-	it( 'shortens the label and drops the description', () => {
-		const [ formatted ] = formatTopLevelSuggestions( [ featuredImage ] );
+	it( 'drops the description', () => {
+		const [ formatted ] = hideTopLevelDescriptions( [ featuredImage ] );
 
-		expect( formatted.label ).toBe( 'Generate featured image' );
 		expect( formatted.description ).toBeUndefined();
 	} );
 
 	it( 'keeps the rest of the suggestion intact', () => {
 		const action = jest.fn();
-		const [ formatted ] = formatTopLevelSuggestions( [ { ...featuredImage, action } ] );
+		const [ formatted ] = hideTopLevelDescriptions( [ { ...featuredImage, action } ] );
 
 		expect( formatted.id ).toBe( featuredImage.id );
+		expect( formatted.label ).toBe( featuredImage.label );
 		expect( formatted.prompt ).toBe( '' );
 		expect( formatted.action ).toBe( action );
 	} );
 
 	it( 'leaves suggestions it does not know about alone', () => {
-		expect( formatTopLevelSuggestions( [ siteEditorSuggestion ] ) ).toEqual( [
+		expect( hideTopLevelDescriptions( [ siteEditorSuggestion ] ) ).toEqual( [
 			siteEditorSuggestion,
 		] );
 	} );

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -39,10 +39,9 @@ const WRITING_SUGGESTION_LABELS: Record< string, () => string > = {
 
 export const WRITING_SUGGESTION_IDS = new Set( Object.keys( WRITING_SUGGESTION_LABELS ) );
 
-// Provider suggestions that stay out of the writing group
-const TOP_LEVEL_SUGGESTION_LABELS: Record< string, () => string > = {
-	'generate-featured-image': () => __( 'Generate featured image', __i18n_text_domain__ ),
-};
+// Provider suggestions that stay out of the writing group sit beside the design
+// actions, which show no description.
+const HIDE_DESCRIPTION_IDS = new Set( [ 'generate-featured-image' ] );
 
 // Keep writing action labels consistent across flat and grouped editor views.
 export function getWritingSuggestionLabel( suggestion: Suggestion ): string {
@@ -64,11 +63,12 @@ export function formatWritingSuggestionLabels(
 	);
 }
 
-export function formatTopLevelSuggestions( suggestions: Suggestion[] ): Suggestion[] {
-	return suggestions.map( ( suggestion ) => {
-		const label = TOP_LEVEL_SUGGESTION_LABELS[ suggestion.id ]?.();
-		return label ? { ...suggestion, label, description: undefined } : suggestion;
-	} );
+export function hideTopLevelDescriptions( suggestions: Suggestion[] ): Suggestion[] {
+	return suggestions.map( ( suggestion ) =>
+		HIDE_DESCRIPTION_IDS.has( suggestion.id )
+			? { ...suggestion, description: undefined }
+			: suggestion
+	);
 }
 
 export const DEFAULT_EMPTY_VIEW_SUGGESTION_IDS = {

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -39,6 +39,11 @@ const WRITING_SUGGESTION_LABELS: Record< string, () => string > = {
 
 export const WRITING_SUGGESTION_IDS = new Set( Object.keys( WRITING_SUGGESTION_LABELS ) );
 
+// Provider suggestions that stay out of the writing group
+const TOP_LEVEL_SUGGESTION_LABELS: Record< string, () => string > = {
+	'generate-featured-image': () => __( 'Generate featured image', __i18n_text_domain__ ),
+};
+
 // Keep writing action labels consistent across flat and grouped editor views.
 export function getWritingSuggestionLabel( suggestion: Suggestion ): string {
 	return WRITING_SUGGESTION_LABELS[ suggestion.id ]?.() ?? suggestion.label;
@@ -57,6 +62,13 @@ export function formatWritingSuggestionLabels(
 			? { ...suggestion, label: getWritingSuggestionLabel( suggestion ) }
 			: suggestion
 	);
+}
+
+export function formatTopLevelSuggestions( suggestions: Suggestion[] ): Suggestion[] {
+	return suggestions.map( ( suggestion ) => {
+		const label = TOP_LEVEL_SUGGESTION_LABELS[ suggestion.id ]?.();
+		return label ? { ...suggestion, label, description: undefined } : suggestion;
+	} );
 }
 
 export const DEFAULT_EMPTY_VIEW_SUGGESTION_IDS = {

--- a/packages/image-studio/src/components/header/index.test.tsx
+++ b/packages/image-studio/src/components/header/index.test.tsx
@@ -78,6 +78,7 @@ jest.mock( '../../store', () => ( {
 		EditorSidebar: 'editor_sidebar',
 		JetpackExternalMediaBlock: 'jetpack_external_media_block',
 		JetpackExternalMediaFeaturedImage: 'jetpack_external_media_featured_image',
+		JetpackAIFeaturedImage: 'jetpack_ai_featured_image',
 		PostEditorFeatureClip: 'post_editor_feature_clip',
 	},
 } ) );
@@ -250,6 +251,25 @@ describe( 'Header', () => {
 					getIsAnnotationMode: () => false,
 					getDraftIds: () => [],
 					getEntryPoint: () => ImageStudioEntryPoint.EditorBlock,
+				} ) );
+				return result;
+			} );
+
+			render( <Header { ...defaultProps } mode={ ImageStudioMode.Edit } /> );
+
+			expect( screen.getByRole( 'button', { name: /Save and apply/i } ) ).toHaveTextContent(
+				'Save & Apply'
+			);
+		} );
+
+		it( 'renders save button with "Save & Apply" text for the JetpackAIFeaturedImage entry point', () => {
+			mockUseSelect.mockImplementation( ( selector: any ) => {
+				const result = selector( () => ( {
+					getImageStudioAiProcessing: () => false,
+					getHasUpdatedMetadata: () => false,
+					getIsAnnotationMode: () => false,
+					getDraftIds: () => [],
+					getEntryPoint: () => ImageStudioEntryPoint.JetpackAIFeaturedImage,
 				} ) );
 				return result;
 			} );

--- a/packages/image-studio/src/components/header/index.tsx
+++ b/packages/image-studio/src/components/header/index.tsx
@@ -125,6 +125,7 @@ export const Header = ( {
 			case ImageStudioEntryPoint.EditorSidebar:
 			case ImageStudioEntryPoint.JetpackExternalMediaBlock:
 			case ImageStudioEntryPoint.JetpackExternalMediaFeaturedImage:
+			case ImageStudioEntryPoint.JetpackAIFeaturedImage:
 				return __( 'Save & Apply', __i18n_text_domain__ );
 			case ImageStudioEntryPoint.MediaLibrary:
 			default:
@@ -141,6 +142,7 @@ export const Header = ( {
 			case ImageStudioEntryPoint.EditorSidebar:
 			case ImageStudioEntryPoint.JetpackExternalMediaBlock:
 			case ImageStudioEntryPoint.JetpackExternalMediaFeaturedImage:
+			case ImageStudioEntryPoint.JetpackAIFeaturedImage:
 				return __( 'Save and apply image', __i18n_text_domain__ );
 			case ImageStudioEntryPoint.MediaLibrary:
 			default:

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -2110,7 +2110,7 @@ describe( 'getEmptyViewSuggestions', () => {
 			( suggestion ) => suggestion.id === 'generate-featured-image'
 		);
 
-		expect( chip?.label ).toBe( 'Generate Featured Image' );
+		expect( chip?.label ).toBe( 'Generate featured image' );
 		expect( chip?.prompt ).toBe( '' );
 		expect( typeof chip?.action ).toBe( 'function' );
 	} );

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -51,6 +51,7 @@ const mockSelectBlock = jest.fn( ( clientId?: string | null ) => {
 const mockClearSelectedBlock = jest.fn( () => {
 	mockSelectedBlockClientId = null;
 } );
+const mockEditPost = jest.fn();
 const mockedRecordTracksEvent = recordTracksEvent as jest.MockedFunction<
 	typeof recordTracksEvent
 >;
@@ -147,6 +148,9 @@ jest.mock( '@wordpress/data', () => ( {
 		}
 		if ( store === 'image-studio' ) {
 			return mockImageStudioActions ?? {};
+		}
+		if ( store === 'core/editor' ) {
+			return { editPost: mockEditPost };
 		}
 		return {};
 	} ),

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -58,6 +58,7 @@ let mockSelectedBlock: any = null;
 let mockCurrentPostType: string | undefined = 'post';
 let mockBlocksByClientId: Record< string, any > = {};
 let mockEditorBlocks: any[] = [];
+let mockImageStudioActions: { openImageStudio: jest.Mock } | null = null;
 const SHOW_COMPONENT_TOOL_ID = 'jetpack_ai__show_component';
 const LEGACY_SHOW_COMPONENT_TOOL_ID = 'big_sky__show_component';
 const UPDATE_BLOCK_CONTENT_TOOL_ID = 'wpcom__update_block_content';
@@ -143,6 +144,9 @@ jest.mock( '@wordpress/data', () => ( {
 				selectBlock: mockSelectBlock,
 				clearSelectedBlock: mockClearSelectedBlock,
 			};
+		}
+		if ( store === 'image-studio' ) {
+			return mockImageStudioActions ?? {};
 		}
 		return {};
 	} ),
@@ -1819,6 +1823,7 @@ describe( 'getEmptyViewSuggestions', () => {
 	afterEach( () => {
 		delete ( globalThis as any ).agentsManagerData;
 		delete ( window as any ).wp;
+		mockImageStudioActions = null;
 	} );
 
 	it( 'hides post suggestions without a sidebar config', () => {
@@ -2091,6 +2096,55 @@ describe( 'getEmptyViewSuggestions', () => {
 		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
 
 		expect( ids ).not.toContain( 'generate-excerpt' );
+	} );
+
+	it( 'shows Generate Featured Image when Image Studio is available', () => {
+		installPostTypeMock( 'post' );
+		mockImageStudioActions = { openImageStudio: jest.fn() };
+
+		const chip = getEmptyViewSuggestions().find(
+			( suggestion ) => suggestion.id === 'generate-featured-image'
+		);
+
+		expect( chip?.label ).toBe( 'Generate Featured Image' );
+		expect( chip?.prompt ).toBe( '' );
+		expect( typeof chip?.action ).toBe( 'function' );
+	} );
+
+	it( 'hides Generate Featured Image when Image Studio is not available', () => {
+		installPostTypeMock( 'post' );
+		mockImageStudioActions = null;
+
+		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+
+		expect( ids ).not.toContain( 'generate-featured-image' );
+	} );
+
+	it( 'hides Generate Featured Image for unsupported post-level entities', () => {
+		installPostTypeMock( 'wp_template', 123 );
+		mockImageStudioActions = { openImageStudio: jest.fn() };
+
+		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+
+		expect( ids ).not.toContain( 'generate-featured-image' );
+	} );
+
+	it( "invoking the suggestion's action opens Image Studio and does not submit a prompt", () => {
+		installPostTypeMock( 'post' );
+		const openImageStudio = jest.fn();
+		mockImageStudioActions = { openImageStudio };
+
+		const chip = getEmptyViewSuggestions().find(
+			( suggestion ) => suggestion.id === 'generate-featured-image'
+		);
+		const shouldSubmitPrompt = chip?.action?.();
+
+		expect( openImageStudio ).toHaveBeenCalledWith(
+			undefined,
+			expect.any( Function ),
+			'jetpack_ai_featured_image'
+		);
+		expect( shouldSubmitPrompt ).toBe( false );
 	} );
 
 	it( 'shows the SEO Enhancer dropdown when the seoSuggestions feature is enabled', () => {

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -126,7 +126,7 @@ const GENERATE_FEATURED_IMAGE_SUGGESTION = {
 	id: 'generate-featured-image',
 	label: __( 'Generate Featured Image', __i18n_text_domain__ ),
 	description: __(
-		'Create a new image with Image Studio and set it as the featured image.',
+		'Create a new image with AI and set it as the featured image.',
 		__i18n_text_domain__
 	),
 	prompt: '',

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -124,7 +124,7 @@ const OPTIMIZE_TITLE_SUGGESTION = {
  */
 const GENERATE_FEATURED_IMAGE_SUGGESTION = {
 	id: 'generate-featured-image',
-	label: __( 'Generate Featured Image', __i18n_text_domain__ ),
+	label: __( 'Generate featured image', __i18n_text_domain__ ),
 	description: __(
 		'Create a new image with AI and set it as the featured image.',
 		__i18n_text_domain__
@@ -364,8 +364,8 @@ function getPostLevelSuggestions(
 	}
 
 	return [
-		...( isOptimizeTitleSuggestionEnabled() ? [ OPTIMIZE_TITLE_SUGGESTION ] : [] ),
 		...( isImageStudioAvailable() ? [ GENERATE_FEATURED_IMAGE_SUGGESTION ] : [] ),
+		...( isOptimizeTitleSuggestionEnabled() ? [ OPTIMIZE_TITLE_SUGGESTION ] : [] ),
 		...( isExcerptSuggestionAvailable( currentPostType, supportsExcerpt )
 			? [ GENERATE_EXCERPT_SUGGESTION ]
 			: [] ),

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -49,7 +49,11 @@ import {
 	BLOCK_ACTION_COMPLETE_EVENT,
 	SELECTED_BLOCK_CLEAR_EVENT,
 } from './utils/block-actions';
-import { isImageStudioAvailable, openImageStudioForBlock } from './utils/image-studio';
+import {
+	isImageStudioAvailable,
+	openImageStudioForBlock,
+	openImageStudioForFeaturedImage,
+} from './utils/image-studio';
 import {
 	isAiEditorialReviewEnabled,
 	isBlockTransformationsEnabled,
@@ -109,6 +113,24 @@ const OPTIMIZE_TITLE_SUGGESTION = {
 		__i18n_text_domain__
 	),
 	prompt: __( 'Optimize the title of this post', __i18n_text_domain__ ),
+};
+
+/**
+ * Post-level suggestion that opens Image Studio directly instead of routing
+ * through the agent — same "action instead of prompt" escape hatch the
+ * block-level generate-image/edit-image suggestions use. Always opens in
+ * generate mode: it creates a new image and overwrites whatever featured
+ * image is currently set, it does not pre-load the existing one for editing.
+ */
+const GENERATE_FEATURED_IMAGE_SUGGESTION = {
+	id: 'generate-featured-image',
+	label: __( 'Generate Featured Image', __i18n_text_domain__ ),
+	description: __(
+		'Create a new image with Image Studio and set it as the featured image.',
+		__i18n_text_domain__
+	),
+	prompt: '',
+	action: () => ! openImageStudioForFeaturedImage(),
 };
 
 /**
@@ -343,6 +365,7 @@ function getPostLevelSuggestions(
 
 	return [
 		...( isOptimizeTitleSuggestionEnabled() ? [ OPTIMIZE_TITLE_SUGGESTION ] : [] ),
+		...( isImageStudioAvailable() ? [ GENERATE_FEATURED_IMAGE_SUGGESTION ] : [] ),
 		...( isExcerptSuggestionAvailable( currentPostType, supportsExcerpt )
 			? [ GENERATE_EXCERPT_SUGGESTION ]
 			: [] ),
@@ -1012,6 +1035,7 @@ export function getEmptyViewSuggestions(): Array< {
 	description?: string;
 	prompt?: string;
 	options?: SuggestionOption[];
+	action?: () => boolean | Promise< boolean >;
 } > {
 	return getPostLevelSuggestions( getCurrentEditorPostType() );
 }

--- a/packages/jetpack-ai-sidebar/src/utils/image-studio.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/image-studio.test.ts
@@ -23,7 +23,9 @@ const editPost = jest.fn();
 
 // Routes the stores this module dispatches to. An Image Studio bundle that
 // is not loaded leaves the store registered but without openImageStudio.
-function stubStores( { imageStudioRegistered = true } = {} ) {
+// wp.data returns undefined for a store that was never registered, which is
+// what happens to core/editor outside the post editor.
+function stubStores( { imageStudioRegistered = true, editorRegistered = true } = {} ) {
 	mockDispatch.mockImplementation( ( storeRef: string ) => {
 		if ( storeRef === 'image-studio' ) {
 			return imageStudioRegistered ? { openImageStudio } : {};
@@ -32,7 +34,7 @@ function stubStores( { imageStudioRegistered = true } = {} ) {
 			return { updateBlockAttributes };
 		}
 		if ( storeRef === 'core/editor' ) {
-			return { editPost };
+			return editorRegistered ? { editPost } : undefined;
 		}
 		return undefined;
 	} );
@@ -152,6 +154,25 @@ describe( 'openImageStudioForFeaturedImage', () => {
 		stubStores( { imageStudioRegistered: false } );
 		expect( openImageStudioForFeaturedImage() ).toBe( false );
 		expect( openImageStudio ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not open when the editor store is not registered', () => {
+		stubStores( { editorRegistered: false } );
+		expect( openImageStudioForFeaturedImage() ).toBe( false );
+		expect( openImageStudio ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does nothing on close when the editor store has gone away', () => {
+		openImageStudioForFeaturedImage();
+		const onClose = openImageStudio.mock.calls[ 0 ][ 1 ];
+
+		stubStores( { editorRegistered: false } );
+
+		expect( () =>
+			onClose( { id: 99, url: 'https://example.com/new.jpg', alt: 'A cat' } )
+		).not.toThrow();
+		expect( () => onClose( null ) ).not.toThrow();
+		expect( editPost ).not.toHaveBeenCalled();
 	} );
 
 	it( 'sets the featured image on close', () => {

--- a/packages/jetpack-ai-sidebar/src/utils/image-studio.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/image-studio.test.ts
@@ -1,7 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { dispatch } from '@wordpress/data';
-import { isImageStudioAvailable, openImageStudioForBlock } from './image-studio';
+import {
+	isImageStudioAvailable,
+	openImageStudioForBlock,
+	openImageStudioForFeaturedImage,
+} from './image-studio';
 
 jest.mock( '@wordpress/data', () => ( {
 	dispatch: jest.fn(),
@@ -15,8 +19,9 @@ const mockDispatch = dispatch as unknown as jest.Mock;
 
 const openImageStudio = jest.fn();
 const updateBlockAttributes = jest.fn();
+const editPost = jest.fn();
 
-// Routes the two stores this module dispatches to. An Image Studio bundle that
+// Routes the stores this module dispatches to. An Image Studio bundle that
 // is not loaded leaves the store registered but without openImageStudio.
 function stubStores( { imageStudioRegistered = true } = {} ) {
 	mockDispatch.mockImplementation( ( storeRef: string ) => {
@@ -25,6 +30,9 @@ function stubStores( { imageStudioRegistered = true } = {} ) {
 		}
 		if ( storeRef === 'core/block-editor' ) {
 			return { updateBlockAttributes };
+		}
+		if ( storeRef === 'core/editor' ) {
+			return { editPost };
 		}
 		return undefined;
 	} );
@@ -122,5 +130,54 @@ describe( 'openImageStudioForBlock', () => {
 		onClose( undefined );
 
 		expect( updateBlockAttributes ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'openImageStudioForFeaturedImage', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		stubStores();
+	} );
+
+	it( 'opens in generate mode with the featured-image entry point', () => {
+		expect( openImageStudioForFeaturedImage() ).toBe( true );
+		expect( openImageStudio ).toHaveBeenCalledWith(
+			undefined,
+			expect.any( Function ),
+			'jetpack_ai_featured_image'
+		);
+	} );
+
+	it( 'does not open when the Image Studio bundle is not loaded', () => {
+		stubStores( { imageStudioRegistered: false } );
+		expect( openImageStudioForFeaturedImage() ).toBe( false );
+		expect( openImageStudio ).not.toHaveBeenCalled();
+	} );
+
+	it( 'sets the featured image on close', () => {
+		openImageStudioForFeaturedImage();
+		const onClose = openImageStudio.mock.calls[ 0 ][ 1 ];
+
+		onClose( { id: 99, url: 'https://example.com/new.jpg', alt: 'A cat' } );
+
+		expect( editPost ).toHaveBeenCalledWith( { featured_media: 99 } );
+	} );
+
+	it( 'clears the featured image when closed with a removed image', () => {
+		openImageStudioForFeaturedImage();
+		const onClose = openImageStudio.mock.calls[ 0 ][ 1 ];
+
+		onClose( null );
+
+		expect( editPost ).toHaveBeenCalledWith( { featured_media: 0 } );
+	} );
+
+	it( 'leaves the featured image untouched when closed without an image', () => {
+		openImageStudioForFeaturedImage();
+		const onClose = openImageStudio.mock.calls[ 0 ][ 1 ];
+
+		onClose( undefined );
+
+		expect( editPost ).not.toHaveBeenCalled();
 	} );
 } );

--- a/packages/jetpack-ai-sidebar/src/utils/image-studio.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/image-studio.ts
@@ -19,6 +19,9 @@ const IMAGE_STUDIO_STORE = 'image-studio';
 /** Mirrors ImageStudioEntryPoint.EditorSidebar, duplicated to avoid a package dependency. */
 const EDITOR_SIDEBAR_ENTRY_POINT = 'editor_sidebar';
 
+/** Mirrors ImageStudioEntryPoint.JetpackAIFeaturedImage, duplicated to avoid a package dependency. */
+const FEATURED_IMAGE_ENTRY_POINT = 'jetpack_ai_featured_image';
+
 export type ImageStudioMode = 'edit' | 'generate';
 
 /** The subset of the Image Studio image payload written back to the block. */
@@ -93,6 +96,39 @@ export function openImageStudioForBlock( block: any, mode: ImageStudioMode ): bo
 		EDITOR_SIDEBAR_ENTRY_POINT,
 		block.name
 	);
+
+	return true;
+}
+
+/**
+ * Opens Image Studio in generate mode, writing the result back as the
+ * post's featured image on close.
+ * @returns Whether Image Studio was opened.
+ */
+export function openImageStudioForFeaturedImage(): boolean {
+	const imageStudioActions = getImageStudioActions();
+
+	if ( ! imageStudioActions ) {
+		return false;
+	}
+
+	const handleClose = ( image: ImageStudioImage | null ) => {
+		const editor = dispatch( 'core/editor' ) as {
+			editPost: ( edits: Record< string, unknown > ) => void;
+		};
+
+		// A null image means the user removed it; clear the featured image.
+		if ( image === null ) {
+			editor.editPost( { featured_media: 0 } );
+			return;
+		}
+
+		if ( image?.id ) {
+			editor.editPost( { featured_media: image.id } );
+		}
+	};
+
+	imageStudioActions.openImageStudio( undefined, handleClose, FEATURED_IMAGE_ENTRY_POINT );
 
 	return true;
 }

--- a/packages/jetpack-ai-sidebar/src/utils/image-studio.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/image-studio.ts
@@ -40,12 +40,27 @@ interface ImageStudioActions {
 	) => void;
 }
 
+interface EditorActions {
+	editPost: ( edits: Record< string, unknown > ) => void;
+}
+
 function getImageStudioActions(): ImageStudioActions | undefined {
 	const actions = dispatch( IMAGE_STUDIO_STORE ) as Partial< ImageStudioActions > | undefined;
 
 	return typeof actions?.openImageStudio === 'function'
 		? ( actions as ImageStudioActions )
 		: undefined;
+}
+
+/** `core/editor` is absent outside the post editor, where `dispatch` returns undefined. */
+function getEditorActions(): EditorActions | undefined {
+	try {
+		const actions = dispatch( 'core/editor' ) as Partial< EditorActions > | undefined;
+
+		return typeof actions?.editPost === 'function' ? ( actions as EditorActions ) : undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 export function isImageStudioAvailable(): boolean {
@@ -108,14 +123,17 @@ export function openImageStudioForBlock( block: any, mode: ImageStudioMode ): bo
 export function openImageStudioForFeaturedImage(): boolean {
 	const imageStudioActions = getImageStudioActions();
 
-	if ( ! imageStudioActions ) {
+	// Without the editor store there is nowhere to write the result, so do not open at all.
+	if ( ! imageStudioActions || ! getEditorActions() ) {
 		return false;
 	}
 
 	const handleClose = ( image: ImageStudioImage | null ) => {
-		const editor = dispatch( 'core/editor' ) as {
-			editPost: ( edits: Record< string, unknown > ) => void;
-		};
+		const editor = getEditorActions();
+
+		if ( ! editor ) {
+			return;
+		}
 
 		// A null image means the user removed it; clear the featured image.
 		if ( image === null ) {


### PR DESCRIPTION
Part of FORNO-465

## Proposed Changes

* Add a "Generate Featured Image" post-level suggestion that opens Image Studio directly (no agent round trip) and sets the result as the post's featured image.
* Fix Image Studio's header Save button showing plain "Save" instead of "Save & Apply" for the `JetpackAIFeaturedImage` entry point.
* Would benefit from the changes in https://github.com/Automattic/wp-calypso/pull/113499 which will enable us to open the post sidebar and visually show the featured image applied on closing Image Studio.

## Why are these changes being made?

* Lets users generate a featured image from the AM chat sidebar without leaving the editor.

## Testing Instructions

* On a post/page with Image Studio enabled, open the AM chat sidebar with no block selected → click "Generate Featured Image" → generate/save an image → confirm it's set as the post's featured image.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?