### PR TITLE
Jetpack AI sidebar: reveal the field a picker just changed

### DIFF
--- a/packages/jetpack-ai-sidebar/src/components/excerpt-picker.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/excerpt-picker.test.tsx
@@ -11,7 +11,7 @@ import { SUGGESTION_ACTION_COMPLETE_EVENT } from '../utils/suggestion-events';
 import ExcerptPicker from './excerpt-picker';
 
 const mockEditPost = jest.fn();
-const mockRevealSidebarField = jest.fn();
+const mockRevealSidebarField = jest.fn().mockResolvedValue( true );
 let mockCurrentExcerpt: string | undefined;
 
 jest.mock( '../utils/reveal-sidebar-field', () => ( {

--- a/packages/jetpack-ai-sidebar/src/components/excerpt-picker.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/excerpt-picker.test.tsx
@@ -11,7 +11,12 @@ import { SUGGESTION_ACTION_COMPLETE_EVENT } from '../utils/suggestion-events';
 import ExcerptPicker from './excerpt-picker';
 
 const mockEditPost = jest.fn();
+const mockRevealSidebarField = jest.fn();
 let mockCurrentExcerpt: string | undefined;
+
+jest.mock( '../utils/reveal-sidebar-field', () => ( {
+	revealSidebarField: ( ...args: unknown[] ) => mockRevealSidebarField( ...args ),
+} ) );
 
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: ( store: string ) => {
@@ -35,6 +40,7 @@ jest.mock( '@wordpress/data', () => ( {
 describe( 'ExcerptPicker', () => {
 	beforeEach( () => {
 		mockEditPost.mockClear();
+		mockRevealSidebarField.mockClear();
 		mockCurrentExcerpt = undefined;
 	} );
 
@@ -84,6 +90,14 @@ describe( 'ExcerptPicker', () => {
 		} finally {
 			window.removeEventListener( SUGGESTION_ACTION_COMPLETE_EVENT, handleComplete );
 		}
+	} );
+
+	it( 'reveals the excerpt in the document sidebar once applied', () => {
+		render( <ExcerptPicker excerpts={ excerpts } /> );
+
+		fireEvent.click( screen.getByText( excerpts[ 0 ].excerpt ) );
+
+		expect( mockRevealSidebarField ).toHaveBeenCalledWith( 'excerpt' );
 	} );
 
 	it( 'renders no options without crashing when the excerpts prop is malformed', () => {

--- a/packages/jetpack-ai-sidebar/src/components/excerpt-picker.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/excerpt-picker.tsx
@@ -16,6 +16,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { revealSidebarField } from '../utils/reveal-sidebar-field';
 import { notifySuggestionActionComplete } from '../utils/suggestion-events';
 import BaseSuggestionPicker from './base-suggestion-picker';
 import type { OnResponseAction } from '../utils/response-action';
@@ -52,6 +53,7 @@ export default function ExcerptPicker( {
 	const handleApply = useCallback(
 		( excerpt: string ) => {
 			editPost( { excerpt } );
+			revealSidebarField( 'excerpt' );
 			notifySuggestionActionComplete();
 		},
 		[ editPost ]

--- a/packages/jetpack-ai-sidebar/src/components/seo-description-picker.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/seo-description-picker.test.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import SeoDescriptionPicker from './seo-description-picker';
 
 const mockEditPost = jest.fn();
-const mockRevealSidebarField = jest.fn();
+const mockRevealSidebarField = jest.fn().mockResolvedValue( true );
 let mockCurrentMeta: Record< string, string > | undefined;
 
 jest.mock( '../utils/reveal-sidebar-field', () => ( {

--- a/packages/jetpack-ai-sidebar/src/components/seo-description-picker.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/seo-description-picker.test.tsx
@@ -10,7 +10,12 @@ import React from 'react';
 import SeoDescriptionPicker from './seo-description-picker';
 
 const mockEditPost = jest.fn();
+const mockRevealSidebarField = jest.fn();
 let mockCurrentMeta: Record< string, string > | undefined;
+
+jest.mock( '../utils/reveal-sidebar-field', () => ( {
+	revealSidebarField: ( ...args: unknown[] ) => mockRevealSidebarField( ...args ),
+} ) );
 
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: ( store: string ) => {
@@ -34,6 +39,7 @@ jest.mock( '@wordpress/data', () => ( {
 describe( 'SeoDescriptionPicker', () => {
 	beforeEach( () => {
 		mockEditPost.mockClear();
+		mockRevealSidebarField.mockClear();
 		mockCurrentMeta = undefined;
 	} );
 
@@ -47,6 +53,14 @@ describe( 'SeoDescriptionPicker', () => {
 			explanation: 'b',
 		},
 	];
+
+	it( 'reveals the SEO panel once a description is applied', () => {
+		render( <SeoDescriptionPicker descriptions={ descriptions } /> );
+
+		fireEvent.click( screen.getByText( descriptions[ 0 ].description ) );
+
+		expect( mockRevealSidebarField ).toHaveBeenCalledWith( 'seo' );
+	} );
 
 	it( 'renders every suggested SEO description', () => {
 		render( <SeoDescriptionPicker descriptions={ descriptions } /> );

--- a/packages/jetpack-ai-sidebar/src/components/seo-description-picker.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/seo-description-picker.tsx
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { revealSidebarField } from '../utils/reveal-sidebar-field';
 import BaseSuggestionPicker from './base-suggestion-picker';
 import type { OnResponseAction } from '../utils/response-action';
 
@@ -59,6 +60,7 @@ export default function SeoDescriptionPicker( {
 	const handleApply = useCallback(
 		( description: string ) => {
 			editPost( { meta: { [ SEO_DESCRIPTION_META_KEY ]: description } } );
+			revealSidebarField( 'seo' );
 		},
 		[ editPost ]
 	);

--- a/packages/jetpack-ai-sidebar/src/components/seo-title-picker.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/seo-title-picker.test.tsx
@@ -10,7 +10,12 @@ import React from 'react';
 import SeoTitlePicker from './seo-title-picker';
 
 const mockEditPost = jest.fn();
+const mockRevealSidebarField = jest.fn();
 let mockCurrentMeta: Record< string, string > | undefined;
+
+jest.mock( '../utils/reveal-sidebar-field', () => ( {
+	revealSidebarField: ( ...args: unknown[] ) => mockRevealSidebarField( ...args ),
+} ) );
 
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: ( store: string ) => {
@@ -34,6 +39,7 @@ jest.mock( '@wordpress/data', () => ( {
 describe( 'SeoTitlePicker', () => {
 	beforeEach( () => {
 		mockEditPost.mockClear();
+		mockRevealSidebarField.mockClear();
 		mockCurrentMeta = undefined;
 	} );
 
@@ -41,6 +47,14 @@ describe( 'SeoTitlePicker', () => {
 		{ title: 'Best Vegetable Garden Guide for Beginners', explanation: 'a' },
 		{ title: 'Start a Vegetable Garden: Easy Beginner Steps', explanation: 'b' },
 	];
+
+	it( 'reveals the SEO panel once a title is applied', () => {
+		render( <SeoTitlePicker titles={ titles } /> );
+
+		fireEvent.click( screen.getByText( titles[ 0 ].title ) );
+
+		expect( mockRevealSidebarField ).toHaveBeenCalledWith( 'seo' );
+	} );
 
 	it( 'renders every suggested SEO title', () => {
 		render( <SeoTitlePicker titles={ titles } /> );

--- a/packages/jetpack-ai-sidebar/src/components/seo-title-picker.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/seo-title-picker.test.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import SeoTitlePicker from './seo-title-picker';
 
 const mockEditPost = jest.fn();
-const mockRevealSidebarField = jest.fn();
+const mockRevealSidebarField = jest.fn().mockResolvedValue( true );
 let mockCurrentMeta: Record< string, string > | undefined;
 
 jest.mock( '../utils/reveal-sidebar-field', () => ( {

--- a/packages/jetpack-ai-sidebar/src/components/seo-title-picker.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/seo-title-picker.tsx
@@ -18,6 +18,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { revealSidebarField } from '../utils/reveal-sidebar-field';
 import BaseSuggestionPicker from './base-suggestion-picker';
 import type { OnResponseAction } from '../utils/response-action';
 
@@ -60,6 +61,7 @@ export default function SeoTitlePicker( {
 	const handleApply = useCallback(
 		( title: string ) => {
 			editPost( { meta: { [ SEO_TITLE_META_KEY ]: title } } );
+			revealSidebarField( 'seo' );
 		},
 		[ editPost ]
 	);

--- a/packages/jetpack-ai-sidebar/src/utils/image-studio.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/image-studio.test.ts
@@ -17,7 +17,7 @@ jest.mock( '@wordpress/block-editor', () => ( {
 } ) );
 
 jest.mock( './reveal-sidebar-field', () => ( {
-	revealSidebarField: jest.fn(),
+	revealSidebarField: jest.fn().mockResolvedValue( true ),
 } ) );
 
 const mockDispatch = dispatch as unknown as jest.Mock;
@@ -180,21 +180,13 @@ describe( 'openImageStudioForFeaturedImage', () => {
 		expect( editPost ).not.toHaveBeenCalled();
 	} );
 
-	it( 'sets the featured image on close', () => {
+	it( 'sets the featured image on close and reveals where it landed', () => {
 		openImageStudioForFeaturedImage();
 		const onClose = openImageStudio.mock.calls[ 0 ][ 1 ];
 
 		onClose( { id: 99, url: 'https://example.com/new.jpg', alt: 'A cat' } );
 
 		expect( editPost ).toHaveBeenCalledWith( { featured_media: 99 } );
-	} );
-
-	it( 'reveals the featured image so the user can see where it landed', () => {
-		openImageStudioForFeaturedImage();
-		const onClose = openImageStudio.mock.calls[ 0 ][ 1 ];
-
-		onClose( { id: 99, url: 'https://example.com/new.jpg', alt: 'A cat' } );
-
 		expect( revealSidebarField ).toHaveBeenCalledWith( 'featuredImage' );
 	} );
 

--- a/packages/jetpack-ai-sidebar/src/utils/image-studio.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/image-studio.test.ts
@@ -6,6 +6,7 @@ import {
 	openImageStudioForBlock,
 	openImageStudioForFeaturedImage,
 } from './image-studio';
+import { revealSidebarField } from './reveal-sidebar-field';
 
 jest.mock( '@wordpress/data', () => ( {
 	dispatch: jest.fn(),
@@ -13,6 +14,10 @@ jest.mock( '@wordpress/data', () => ( {
 
 jest.mock( '@wordpress/block-editor', () => ( {
 	store: 'core/block-editor',
+} ) );
+
+jest.mock( './reveal-sidebar-field', () => ( {
+	revealSidebarField: jest.fn(),
 } ) );
 
 const mockDispatch = dispatch as unknown as jest.Mock;
@@ -184,6 +189,15 @@ describe( 'openImageStudioForFeaturedImage', () => {
 		expect( editPost ).toHaveBeenCalledWith( { featured_media: 99 } );
 	} );
 
+	it( 'reveals the featured image so the user can see where it landed', () => {
+		openImageStudioForFeaturedImage();
+		const onClose = openImageStudio.mock.calls[ 0 ][ 1 ];
+
+		onClose( { id: 99, url: 'https://example.com/new.jpg', alt: 'A cat' } );
+
+		expect( revealSidebarField ).toHaveBeenCalledWith( 'featuredImage' );
+	} );
+
 	it( 'clears the featured image when closed with a removed image', () => {
 		openImageStudioForFeaturedImage();
 		const onClose = openImageStudio.mock.calls[ 0 ][ 1 ];
@@ -191,6 +205,7 @@ describe( 'openImageStudioForFeaturedImage', () => {
 		onClose( null );
 
 		expect( editPost ).toHaveBeenCalledWith( { featured_media: 0 } );
+		expect( revealSidebarField ).not.toHaveBeenCalled();
 	} );
 
 	it( 'leaves the featured image untouched when closed without an image', () => {
@@ -200,5 +215,6 @@ describe( 'openImageStudioForFeaturedImage', () => {
 		onClose( undefined );
 
 		expect( editPost ).not.toHaveBeenCalled();
+		expect( revealSidebarField ).not.toHaveBeenCalled();
 	} );
 } );

--- a/packages/jetpack-ai-sidebar/src/utils/image-studio.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/image-studio.ts
@@ -13,6 +13,7 @@
 
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { dispatch } from '@wordpress/data';
+import { revealSidebarField } from './reveal-sidebar-field';
 
 const IMAGE_STUDIO_STORE = 'image-studio';
 
@@ -84,7 +85,8 @@ export function openImageStudioForBlock( block: any, mode: ImageStudioMode ): bo
 	const attachmentId = block.attributes?.id;
 
 	const handleClose = ( image: ImageStudioImage | null ) => {
-		// A null image means the user removed it.
+		// Image Studio passes null only after deleting the attachment from the
+		// media library, so the block cannot keep pointing at it.
 		if ( image === null ) {
 			dispatch( blockEditorStore ).updateBlockAttributes( clientId, {
 				url: undefined,
@@ -135,7 +137,9 @@ export function openImageStudioForFeaturedImage(): boolean {
 			return;
 		}
 
-		// A null image means the user removed it; clear the featured image.
+		// Image Studio passes null only after deleting the attachment from the
+		// media library, so the featured image has to go with it. Closing without
+		// saving, or a generation that fails, never reaches this callback.
 		if ( image === null ) {
 			editor.editPost( { featured_media: 0 } );
 			return;
@@ -143,6 +147,7 @@ export function openImageStudioForFeaturedImage(): boolean {
 
 		if ( image?.id ) {
 			editor.editPost( { featured_media: image.id } );
+			revealSidebarField( 'featuredImage' );
 		}
 	};
 

--- a/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.test.ts
@@ -265,6 +265,18 @@ describe( 'revealSidebarField', () => {
 		await expect( revealSidebarField( 'excerpt' ) ).resolves.toBe( false );
 	} );
 
+	it( 'keeps the block selection when opening the sidebar rejects', async () => {
+		// The sidebar never opens, so taking the selection costs the user their
+		// place and reveals nothing in return.
+		mockEnableComplementaryArea.mockRejectedValueOnce( new Error( 'no such area' ) );
+		renderField();
+
+		await revealSidebarField( 'excerpt' );
+
+		expect( mockClearActiveBlockFocus ).not.toHaveBeenCalled();
+		expect( mockClearSelectedBlock ).not.toHaveBeenCalled();
+	} );
+
 	it( 'leaves focus where the user put it', async () => {
 		renderField();
 		const chatInput = document.createElement( 'textarea' );

--- a/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.test.ts
@@ -56,17 +56,16 @@ function renderSidebar( innerHTML: string ) {
 
 /**
  * Renders the excerpt field inside the document sidebar, mirroring the editor's
- * layout of excerpt text beside the edit button. jsdom implements neither
- * scrollIntoView nor focus tracking, so both are stubbed to make the calls
- * observable.
+ * layout of excerpt text beside the edit button. The field is focusable so a
+ * stray focus call would move `document.activeElement`; jsdom does not
+ * implement scrollIntoView, so that one is stubbed to make the call observable.
  */
 function renderField() {
 	const sidebar = renderSidebar(
-		'<div class="excerpt-row"><p>New excerpt</p><div class="editor-post-excerpt__dropdown"></div></div>'
+		'<div class="excerpt-row"><p>New excerpt</p><div class="editor-post-excerpt__dropdown" tabindex="-1"></div></div>'
 	);
 	const field = sidebar.querySelector< HTMLElement >( '.editor-post-excerpt__dropdown' )!;
 	field.scrollIntoView = jest.fn();
-	field.focus = jest.fn();
 	return field;
 }
 
@@ -97,43 +96,62 @@ describe( 'revealSidebarField', () => {
 		expect( mockClearSelectedBlock ).not.toHaveBeenCalled();
 	} );
 
-	it( "reveals Jetpack's AI excerpt panel, which replaces the core excerpt", async () => {
-		const sidebar = renderSidebar( '<div class="jetpack-ai-post-excerpt"></div>' );
-		const field = sidebar.querySelector< HTMLElement >( '.jetpack-ai-post-excerpt' )!;
-		field.scrollIntoView = jest.fn();
+	it( "prefers Jetpack's excerpt panel over the core excerpt dropdown", async () => {
+		// Core's dropdown comes first in the DOM, so a pass here proves the
+		// variant order decided it rather than document order.
+		const sidebar = renderSidebar(
+			'<div class="editor-post-excerpt__dropdown"></div><div class="jetpack-ai-post-excerpt"></div>'
+		);
+		const core = sidebar.querySelector< HTMLElement >( '.editor-post-excerpt__dropdown' )!;
+		const jetpack = sidebar.querySelector< HTMLElement >( '.jetpack-ai-post-excerpt' )!;
+		core.scrollIntoView = jest.fn();
+		jetpack.scrollIntoView = jest.fn();
 
-		const revealed = await revealSidebarField( 'excerpt' );
+		await revealSidebarField( 'excerpt' );
 
-		expect( revealed ).toBe( true );
-		expect( field.scrollIntoView ).toHaveBeenCalled();
+		expect( jetpack.scrollIntoView ).toHaveBeenCalled();
+		expect( core.scrollIntoView ).not.toHaveBeenCalled();
+		// The matched variant's panel stays open; `post-excerpt` was opened only
+		// to look inside it, so it closes again.
+		expect( mockOpenPanels ).toEqual( [ 'jetpack-ai-content-lens/ai-content-lens-plugin' ] );
 	} );
 
-	it( 'restores the panel preference when the field never appears', async () => {
+	it( 'stops polling at the timeout and puts panel preferences back', async () => {
 		mockOpenPanels = [ 'post-status' ];
 		renderSidebar( '' );
 
-		const revealed = await revealSidebarField( 'seo', { timeout: 0 } );
-
-		expect( revealed ).toBe( false );
+		await expect( revealSidebarField( 'excerpt', { timeout: 50 } ) ).resolves.toBe( false );
 		expect( mockOpenPanels ).toEqual( [ 'post-status' ] );
 	} );
 
-	it( 'clears the block selection and opens the document sidebar', async () => {
-		renderSidebar( '<div class="editor-post-excerpt__dropdown"></div>' );
+	it( 'clears the block selection so the document settings own the sidebar slot', async () => {
+		renderField();
 
-		const revealed = await revealSidebarField( 'excerpt' );
+		await revealSidebarField( 'excerpt' );
 
-		expect( revealed ).toBe( true );
 		expect( mockClearSelectedBlock ).toHaveBeenCalled();
+	} );
+
+	// Contract with @wordpress/interface. No test can catch Gutenberg renaming these.
+	it( 'opens the document sidebar in the core scope', async () => {
+		renderField();
+
+		await revealSidebarField( 'excerpt' );
+
 		expect( mockEnableComplementaryArea ).toHaveBeenCalledWith( 'core', 'edit-post/document' );
 	} );
 
-	it( 'returns false when the field never renders', async () => {
-		renderSidebar( '' );
+	it( 'finds a field the editor renders a frame or two late', async () => {
+		const sidebar = renderSidebar( '' );
+		const field = document.createElement( 'div' );
+		field.className = 'editor-post-excerpt__dropdown';
+		field.scrollIntoView = jest.fn();
 
-		const revealed = await revealSidebarField( 'excerpt', { timeout: 0 } );
+		const revealing = revealSidebarField( 'excerpt', { timeout: 500 } );
+		requestAnimationFrame( () => requestAnimationFrame( () => sidebar.appendChild( field ) ) );
 
-		expect( revealed ).toBe( false );
+		await expect( revealing ).resolves.toBe( true );
+		expect( field.scrollIntoView ).toHaveBeenCalled();
 	} );
 
 	it( 'ignores a matching element outside the document sidebar', async () => {
@@ -142,14 +160,6 @@ describe( 'revealSidebarField', () => {
 		const revealed = await revealSidebarField( 'excerpt', { timeout: 0 } );
 
 		expect( revealed ).toBe( false );
-	} );
-
-	it( 'opens a collapsed panel for fields that declare one', async () => {
-		renderSidebar( '<div class="jetpack-seo-panel"></div>' );
-
-		await revealSidebarField( 'seo' );
-
-		expect( mockToggleEditorPanelOpened ).toHaveBeenCalledWith( 'jetpack-seo/jetpack-seo' );
 	} );
 
 	it( 'leaves an already open panel alone', async () => {
@@ -161,36 +171,39 @@ describe( 'revealSidebarField', () => {
 		expect( mockToggleEditorPanelOpened ).not.toHaveBeenCalled();
 	} );
 
-	it( 'leaves panel preferences untouched when the matched variant needs no panel', async () => {
-		mockOpenPanels = [ 'post-status' ];
-		renderField();
-
-		await revealSidebarField( 'excerpt' );
-
-		expect( mockOpenPanels ).toEqual( [ 'post-status' ] );
-	} );
-
 	it( 'scrolls the field into view', async () => {
 		const field = renderField();
 
 		await revealSidebarField( 'excerpt' );
 
-		expect( field.scrollIntoView ).toHaveBeenCalledWith(
-			expect.objectContaining( { block: 'center' } )
-		);
+		expect( field.scrollIntoView ).toHaveBeenCalledWith( { behavior: 'smooth', block: 'center' } );
 	} );
 
-	it( 'resolves false rather than rejecting when the editor stores are missing', async () => {
+	it( 'skips the smooth scroll when the user prefers reduced motion', async () => {
+		// The shared jest setup stubs matchMedia as always-false; override one call.
+		( window.matchMedia as jest.Mock ).mockReturnValueOnce( { matches: true } );
+		const field = renderField();
+
+		await revealSidebarField( 'excerpt' );
+
+		expect( field.scrollIntoView ).toHaveBeenCalledWith( { behavior: 'auto', block: 'center' } );
+	} );
+
+	it( 'returns false without touching the editor when the interface store is unavailable', async () => {
 		mockStoresRegistered = false;
 		renderField();
 
 		await expect( revealSidebarField( 'excerpt' ) ).resolves.toBe( false );
+		expect( mockClearSelectedBlock ).not.toHaveBeenCalled();
 	} );
 
-	it( 'reveals the featured image where the summary renders it as a row', async () => {
+	it.each( [
+		'fields-controls__featured-image-image',
+		'fields-controls__featured-image-placeholder',
+	] )( 'reveals the featured image summary row rendered as .%s', async ( className ) => {
 		mockOpenPanels = [ 'post-status' ];
-		const sidebar = renderSidebar( '<span class="fields-controls__featured-image-image"></span>' );
-		const field = sidebar.querySelector< HTMLElement >( '.fields-controls__featured-image-image' )!;
+		const sidebar = renderSidebar( `<span class="${ className }"></span>` );
+		const field = sidebar.querySelector< HTMLElement >( `.${ className }` )!;
 		field.scrollIntoView = jest.fn();
 
 		const revealed = await revealSidebarField( 'featuredImage' );
@@ -199,21 +212,6 @@ describe( 'revealSidebarField', () => {
 		expect( field.scrollIntoView ).toHaveBeenCalled();
 		// A row is not a panel, so the classic panel opened to look inside it closes again.
 		expect( mockOpenPanels ).toEqual( [ 'post-status' ] );
-	} );
-
-	it( 'reveals the summary row while the post still has no featured image', async () => {
-		const sidebar = renderSidebar(
-			'<span class="fields-controls__featured-image-placeholder"></span>'
-		);
-		const field = sidebar.querySelector< HTMLElement >(
-			'.fields-controls__featured-image-placeholder'
-		)!;
-		field.scrollIntoView = jest.fn();
-
-		const revealed = await revealSidebarField( 'featuredImage' );
-
-		expect( revealed ).toBe( true );
-		expect( field.scrollIntoView ).toHaveBeenCalled();
 	} );
 
 	it( 'opens the classic featured image panel and leaves it open', async () => {
@@ -233,7 +231,7 @@ describe( 'revealSidebarField', () => {
 	} );
 
 	it( 'leaves focus where the user put it', async () => {
-		const field = renderField();
+		renderField();
 		const chatInput = document.createElement( 'textarea' );
 		document.body.appendChild( chatInput );
 		chatInput.focus();
@@ -241,6 +239,5 @@ describe( 'revealSidebarField', () => {
 		await revealSidebarField( 'excerpt' );
 
 		expect( document.activeElement ).toBe( chatInput );
-		expect( field.focus ).not.toHaveBeenCalled();
 	} );
 } );

--- a/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.test.ts
@@ -16,6 +16,15 @@ const mockToggleEditorPanelOpened = jest.fn( ( panelName: string ) => {
 } );
 
 let mockStoresRegistered = true;
+// wp.data throws for a store that was never registered, which is what happens
+// to core/editor outside the post editor.
+let mockEditorStoreRegistered = true;
+
+function mockAssertEditorStore(): void {
+	if ( ! mockEditorStoreRegistered ) {
+		throw new Error( "Store 'core/editor' is not registered." );
+	}
+}
 
 jest.mock( '@wordpress/data', () => ( {
 	dispatch: jest.fn( ( store: string ) => {
@@ -29,12 +38,14 @@ jest.mock( '@wordpress/data', () => ( {
 			return { enableComplementaryArea: mockEnableComplementaryArea };
 		}
 		if ( store === 'core/editor' ) {
+			mockAssertEditorStore();
 			return { toggleEditorPanelOpened: mockToggleEditorPanelOpened };
 		}
 		return {};
 	} ),
 	select: jest.fn( ( store: string ) => {
 		if ( store === 'core/editor' ) {
+			mockAssertEditorStore();
 			return {
 				isEditorPanelOpened: ( panelName: string ) => mockOpenPanels.includes( panelName ),
 				isEditorPanelRemoved: ( panelName: string ) => mockRemovedPanels.includes( panelName ),
@@ -76,6 +87,17 @@ describe( 'revealSidebarField', () => {
 		mockOpenPanels = [];
 		mockRemovedPanels = [];
 		mockStoresRegistered = true;
+		mockEditorStoreRegistered = true;
+	} );
+
+	it( 'still reveals a rendered field when the editor store is not registered', async () => {
+		mockEditorStoreRegistered = false;
+		const field = renderField();
+
+		await expect( revealSidebarField( 'excerpt' ) ).resolves.toBe( true );
+		expect( field.scrollIntoView ).toHaveBeenCalled();
+		// Panel state is unreadable, so toggling one blind could close the field.
+		expect( mockToggleEditorPanelOpened ).not.toHaveBeenCalled();
 	} );
 
 	it( 'does not write preferences for panels the editor has removed', async () => {

--- a/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.test.ts
@@ -3,6 +3,7 @@
  */
 
 const mockClearSelectedBlock = jest.fn();
+const mockClearActiveBlockFocus = jest.fn();
 const mockEnableComplementaryArea = jest.fn();
 let mockOpenPanels: string[] = [];
 let mockRemovedPanels: string[] = [];
@@ -53,6 +54,10 @@ jest.mock( '@wordpress/data', () => ( {
 		}
 		return {};
 	} ),
+} ) );
+
+jest.mock( './block-actions', () => ( {
+	clearActiveBlockFocus: () => mockClearActiveBlockFocus(),
 } ) );
 
 import { revealSidebarField } from './reveal-sidebar-field';
@@ -152,6 +157,14 @@ describe( 'revealSidebarField', () => {
 		await revealSidebarField( 'excerpt' );
 
 		expect( mockClearSelectedBlock ).toHaveBeenCalled();
+	} );
+
+	it( 'drops the sidebar block focus so the editor does not stay dimmed', async () => {
+		renderField();
+
+		await revealSidebarField( 'excerpt' );
+
+		expect( mockClearActiveBlockFocus ).toHaveBeenCalled();
 	} );
 
 	// Contract with @wordpress/interface. No test can catch Gutenberg renaming these.

--- a/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.test.ts
@@ -1,0 +1,201 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const mockClearSelectedBlock = jest.fn();
+const mockEnableComplementaryArea = jest.fn();
+let mockOpenPanels: string[] = [];
+let mockRemovedPanels: string[] = [];
+
+// Mirrors core's toggle so tests can assert the preference the user is left
+// with, rather than how many times it was written.
+const mockToggleEditorPanelOpened = jest.fn( ( panelName: string ) => {
+	mockOpenPanels = mockOpenPanels.includes( panelName )
+		? mockOpenPanels.filter( ( name ) => name !== panelName )
+		: [ ...mockOpenPanels, panelName ];
+} );
+
+let mockStoresRegistered = true;
+
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: jest.fn( ( store: string ) => {
+		if ( ! mockStoresRegistered ) {
+			return {};
+		}
+		if ( store === 'core/block-editor' ) {
+			return { clearSelectedBlock: mockClearSelectedBlock };
+		}
+		if ( store === 'core/interface' ) {
+			return { enableComplementaryArea: mockEnableComplementaryArea };
+		}
+		if ( store === 'core/editor' ) {
+			return { toggleEditorPanelOpened: mockToggleEditorPanelOpened };
+		}
+		return {};
+	} ),
+	select: jest.fn( ( store: string ) => {
+		if ( store === 'core/editor' ) {
+			return {
+				isEditorPanelOpened: ( panelName: string ) => mockOpenPanels.includes( panelName ),
+				isEditorPanelRemoved: ( panelName: string ) => mockRemovedPanels.includes( panelName ),
+			};
+		}
+		return {};
+	} ),
+} ) );
+
+import { revealSidebarField } from './reveal-sidebar-field';
+
+function renderSidebar( innerHTML: string ) {
+	const sidebar = document.createElement( 'div' );
+	sidebar.id = 'edit-post:document';
+	sidebar.innerHTML = innerHTML;
+	document.body.appendChild( sidebar );
+	return sidebar;
+}
+
+/**
+ * Renders the excerpt field inside the document sidebar, mirroring the editor's
+ * layout of excerpt text beside the edit button. jsdom implements neither
+ * scrollIntoView nor focus tracking, so both are stubbed to make the calls
+ * observable.
+ */
+function renderField() {
+	const sidebar = renderSidebar(
+		'<div class="excerpt-row"><p>New excerpt</p><div class="editor-post-excerpt__dropdown"></div></div>'
+	);
+	const field = sidebar.querySelector< HTMLElement >( '.editor-post-excerpt__dropdown' )!;
+	field.scrollIntoView = jest.fn();
+	field.focus = jest.fn();
+	return field;
+}
+
+describe( 'revealSidebarField', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		document.body.innerHTML = '';
+		mockOpenPanels = [];
+		mockRemovedPanels = [];
+		mockStoresRegistered = true;
+	} );
+
+	it( 'does not write preferences for panels the editor has removed', async () => {
+		// Jetpack removes the core excerpt panel when it supplies its own.
+		mockRemovedPanels = [ 'post-excerpt' ];
+		renderField();
+
+		await revealSidebarField( 'excerpt' );
+
+		expect( mockToggleEditorPanelOpened ).not.toHaveBeenCalledWith( 'post-excerpt' );
+	} );
+
+	it( 'returns false for an unknown field without touching the editor', async () => {
+		const revealed = await revealSidebarField( 'not-a-field' );
+
+		expect( revealed ).toBe( false );
+		expect( mockEnableComplementaryArea ).not.toHaveBeenCalled();
+		expect( mockClearSelectedBlock ).not.toHaveBeenCalled();
+	} );
+
+	it( "reveals Jetpack's AI excerpt panel, which replaces the core excerpt", async () => {
+		const sidebar = renderSidebar( '<div class="jetpack-ai-post-excerpt"></div>' );
+		const field = sidebar.querySelector< HTMLElement >( '.jetpack-ai-post-excerpt' )!;
+		field.scrollIntoView = jest.fn();
+
+		const revealed = await revealSidebarField( 'excerpt' );
+
+		expect( revealed ).toBe( true );
+		expect( field.scrollIntoView ).toHaveBeenCalled();
+	} );
+
+	it( 'restores the panel preference when the field never appears', async () => {
+		mockOpenPanels = [ 'post-status' ];
+		renderSidebar( '' );
+
+		const revealed = await revealSidebarField( 'seo', { timeout: 0 } );
+
+		expect( revealed ).toBe( false );
+		expect( mockOpenPanels ).toEqual( [ 'post-status' ] );
+	} );
+
+	it( 'clears the block selection and opens the document sidebar', async () => {
+		renderSidebar( '<div class="editor-post-excerpt__dropdown"></div>' );
+
+		const revealed = await revealSidebarField( 'excerpt' );
+
+		expect( revealed ).toBe( true );
+		expect( mockClearSelectedBlock ).toHaveBeenCalled();
+		expect( mockEnableComplementaryArea ).toHaveBeenCalledWith( 'core', 'edit-post/document' );
+	} );
+
+	it( 'returns false when the field never renders', async () => {
+		renderSidebar( '' );
+
+		const revealed = await revealSidebarField( 'excerpt', { timeout: 0 } );
+
+		expect( revealed ).toBe( false );
+	} );
+
+	it( 'ignores a matching element outside the document sidebar', async () => {
+		document.body.innerHTML = '<div class="editor-post-excerpt__dropdown"></div>';
+
+		const revealed = await revealSidebarField( 'excerpt', { timeout: 0 } );
+
+		expect( revealed ).toBe( false );
+	} );
+
+	it( 'opens a collapsed panel for fields that declare one', async () => {
+		renderSidebar( '<div class="jetpack-seo-panel"></div>' );
+
+		await revealSidebarField( 'seo' );
+
+		expect( mockToggleEditorPanelOpened ).toHaveBeenCalledWith( 'jetpack-seo/jetpack-seo' );
+	} );
+
+	it( 'leaves an already open panel alone', async () => {
+		mockOpenPanels = [ 'jetpack-seo/jetpack-seo' ];
+		renderSidebar( '<div class="jetpack-seo-panel"></div>' );
+
+		await revealSidebarField( 'seo' );
+
+		expect( mockToggleEditorPanelOpened ).not.toHaveBeenCalled();
+	} );
+
+	it( 'leaves panel preferences untouched when the matched variant needs no panel', async () => {
+		mockOpenPanels = [ 'post-status' ];
+		renderField();
+
+		await revealSidebarField( 'excerpt' );
+
+		expect( mockOpenPanels ).toEqual( [ 'post-status' ] );
+	} );
+
+	it( 'scrolls the field into view', async () => {
+		const field = renderField();
+
+		await revealSidebarField( 'excerpt' );
+
+		expect( field.scrollIntoView ).toHaveBeenCalledWith(
+			expect.objectContaining( { block: 'center' } )
+		);
+	} );
+
+	it( 'resolves false rather than rejecting when the editor stores are missing', async () => {
+		mockStoresRegistered = false;
+		renderField();
+
+		await expect( revealSidebarField( 'excerpt' ) ).resolves.toBe( false );
+	} );
+
+	it( 'leaves focus where the user put it', async () => {
+		const field = renderField();
+		const chatInput = document.createElement( 'textarea' );
+		document.body.appendChild( chatInput );
+		chatInput.focus();
+
+		await revealSidebarField( 'excerpt' );
+
+		expect( document.activeElement ).toBe( chatInput );
+		expect( field.focus ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.test.ts
@@ -187,6 +187,51 @@ describe( 'revealSidebarField', () => {
 		await expect( revealSidebarField( 'excerpt' ) ).resolves.toBe( false );
 	} );
 
+	it( 'reveals the featured image where the summary renders it as a row', async () => {
+		mockOpenPanels = [ 'post-status' ];
+		const sidebar = renderSidebar( '<span class="fields-controls__featured-image-image"></span>' );
+		const field = sidebar.querySelector< HTMLElement >( '.fields-controls__featured-image-image' )!;
+		field.scrollIntoView = jest.fn();
+
+		const revealed = await revealSidebarField( 'featuredImage' );
+
+		expect( revealed ).toBe( true );
+		expect( field.scrollIntoView ).toHaveBeenCalled();
+		// A row is not a panel, so the classic panel opened to look inside it closes again.
+		expect( mockOpenPanels ).toEqual( [ 'post-status' ] );
+	} );
+
+	it( 'reveals the summary row while the post still has no featured image', async () => {
+		const sidebar = renderSidebar(
+			'<span class="fields-controls__featured-image-placeholder"></span>'
+		);
+		const field = sidebar.querySelector< HTMLElement >(
+			'.fields-controls__featured-image-placeholder'
+		)!;
+		field.scrollIntoView = jest.fn();
+
+		const revealed = await revealSidebarField( 'featuredImage' );
+
+		expect( revealed ).toBe( true );
+		expect( field.scrollIntoView ).toHaveBeenCalled();
+	} );
+
+	it( 'opens the classic featured image panel and leaves it open', async () => {
+		renderSidebar( '<div class="editor-post-featured-image"></div>' );
+
+		const revealed = await revealSidebarField( 'featuredImage' );
+
+		expect( revealed ).toBe( true );
+		expect( mockOpenPanels ).toEqual( [ 'featured-image' ] );
+	} );
+
+	it( 'resolves false when opening the sidebar rejects', async () => {
+		mockEnableComplementaryArea.mockRejectedValueOnce( new Error( 'no such area' ) );
+		renderField();
+
+		await expect( revealSidebarField( 'excerpt' ) ).resolves.toBe( false );
+	} );
+
 	it( 'leaves focus where the user put it', async () => {
 		const field = renderField();
 		const chatInput = document.createElement( 'textarea' );

--- a/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.ts
@@ -10,6 +10,7 @@
  */
 
 import { dispatch, select } from '@wordpress/data';
+import { clearActiveBlockFocus } from './block-actions';
 
 export interface SidebarTarget {
 	/** Panel preference name, for variants the editor renders as a collapsible panel. */
@@ -173,7 +174,12 @@ export async function revealSidebarField(
 		return false;
 	}
 
+	// A block the sidebar focused dims the rest of the editor, and
+	// clearSelectedBlock on its own leaves that dimming in place.
+	clearActiveBlockFocus();
+
 	// A selected block takes the sidebar slot over the document settings.
+	// clearActiveBlockFocus spares a selection the user made, so clear that too.
 	(
 		dispatch( 'core/block-editor' ) as unknown as { clearSelectedBlock?: () => void }
 	 )?.clearSelectedBlock?.();

--- a/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.ts
@@ -28,6 +28,15 @@ export const SIDEBAR_TARGETS: Record< string, SidebarTarget[] > = {
 		{ panelName: 'post-excerpt', selector: '.editor-post-excerpt' },
 	],
 	seo: [ { panelName: 'jetpack-seo/jetpack-seo', selector: '.jetpack-seo-panel' } ],
+	featuredImage: [
+		// The Summary row is a thumbnail once an image is set and a placeholder
+		// until then, and the editor may still be on either as the reveal runs.
+		{
+			selector:
+				'.fields-controls__featured-image-image, .fields-controls__featured-image-placeholder',
+		},
+		{ panelName: 'featured-image', selector: '.editor-post-featured-image' },
+	],
 };
 
 const DOCUMENT_SIDEBAR = 'edit-post/document';
@@ -152,7 +161,11 @@ export async function revealSidebarField(
 		dispatch( 'core/block-editor' ) as unknown as { clearSelectedBlock?: () => void }
 	 )?.clearSelectedBlock?.();
 
-	await editorInterface.enableComplementaryArea( 'core', DOCUMENT_SIDEBAR );
+	try {
+		await editorInterface.enableComplementaryArea( 'core', DOCUMENT_SIDEBAR );
+	} catch {
+		return false;
+	}
 
 	// A collapsed panel does not render its contents, so every candidate panel
 	// has to be open before any of them can be found.

--- a/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.ts
@@ -103,31 +103,48 @@ async function waitForField(
 	return found;
 }
 
+/** `core/editor` is absent outside the post editor, where `select` throws. */
 function editorSelectors() {
-	return select( 'core/editor' ) as unknown as {
-		isEditorPanelOpened?: ( panelName: string ) => boolean;
-		isEditorPanelRemoved?: ( panelName: string ) => boolean;
-	};
+	try {
+		return select( 'core/editor' ) as unknown as {
+			isEditorPanelOpened?: ( panelName: string ) => boolean;
+			isEditorPanelRemoved?: ( panelName: string ) => boolean;
+		};
+	} catch {
+		return undefined;
+	}
 }
 
 /**
  * Whether a panel needs opening. Panels the editor has removed are skipped, so
- * a variant this editor cannot render costs no preference writes.
+ * a variant this editor cannot render costs no preference writes. Panels whose
+ * state cannot be read are skipped too, because toggling one blind could close
+ * the very panel holding the field.
  * @param panelName - Panel preference name.
  * @returns Whether the panel should be opened.
  */
 function needsOpening( panelName: string ): boolean {
-	const { isEditorPanelOpened, isEditorPanelRemoved } = editorSelectors();
+	const selectors = editorSelectors();
 
-	return ! isEditorPanelRemoved?.( panelName ) && ! isEditorPanelOpened?.( panelName );
+	if ( ! selectors?.isEditorPanelOpened ) {
+		return false;
+	}
+
+	return (
+		! selectors.isEditorPanelRemoved?.( panelName ) && ! selectors.isEditorPanelOpened( panelName )
+	);
 }
 
 function togglePanel( panelName: string ): void {
-	const editorDispatch = dispatch( 'core/editor' ) as unknown as {
-		toggleEditorPanelOpened?: ( panelName: string ) => void;
-	};
+	try {
+		const editorDispatch = dispatch( 'core/editor' ) as unknown as {
+			toggleEditorPanelOpened?: ( panelName: string ) => void;
+		};
 
-	editorDispatch?.toggleEditorPanelOpened?.( panelName );
+		editorDispatch?.toggleEditorPanelOpened?.( panelName );
+	} catch {
+		// The panel stays as the user left it.
+	}
 }
 
 /**

--- a/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.ts
@@ -1,0 +1,183 @@
+/**
+ * Reveals a post field in the block editor's document sidebar after the AI
+ * changes it, so the user can see where the change landed.
+ *
+ * A field can be rendered more than one way — Jetpack replaces the core
+ * excerpt panel with its own when the AI Assistant block is available, and
+ * core itself renders the excerpt as a panel on older versions and as a
+ * Summary row on newer ones. Each field lists its variants in order of
+ * preference and the first one present wins.
+ */
+
+import { dispatch, select } from '@wordpress/data';
+
+export interface SidebarTarget {
+	/** Panel preference name, for variants the editor renders as a collapsible panel. */
+	panelName?: string;
+	/** Selector for the field, resolved within the document sidebar. */
+	selector: string;
+}
+
+export const SIDEBAR_TARGETS: Record< string, SidebarTarget[] > = {
+	excerpt: [
+		{
+			panelName: 'jetpack-ai-content-lens/ai-content-lens-plugin',
+			selector: '.jetpack-ai-post-excerpt',
+		},
+		{ selector: '.editor-post-excerpt__dropdown' },
+		{ panelName: 'post-excerpt', selector: '.editor-post-excerpt' },
+	],
+	seo: [ { panelName: 'jetpack-seo/jetpack-seo', selector: '.jetpack-seo-panel' } ],
+};
+
+const DOCUMENT_SIDEBAR = 'edit-post/document';
+const DOCUMENT_SIDEBAR_ID = 'edit-post:document';
+const DEFAULT_TIMEOUT_MS = 2000;
+
+export interface RevealOptions {
+	/** How long to wait for the field to render, in milliseconds. */
+	timeout?: number;
+}
+
+function prefersReducedMotion(): boolean {
+	return window.matchMedia?.( '(prefers-reduced-motion: reduce)' ).matches ?? false;
+}
+
+function nextFrame(): Promise< void > {
+	return new Promise( ( resolve ) => requestAnimationFrame( () => resolve() ) );
+}
+
+interface FoundField {
+	variant: SidebarTarget;
+	field: HTMLElement;
+}
+
+/**
+ * Looks for each variant once, in order of preference.
+ * @param variants - Variants to look for, most preferred first.
+ * @returns The first variant present, or null.
+ */
+function findField( variants: SidebarTarget[] ): FoundField | null {
+	const sidebar = document.getElementById( DOCUMENT_SIDEBAR_ID );
+
+	for ( const variant of variants ) {
+		const field = sidebar?.querySelector< HTMLElement >( variant.selector );
+
+		if ( field ) {
+			return { variant, field };
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Waits for whichever variant this editor renders. Variants are checked
+ * together rather than in turn, so an editor using the last variant is no
+ * slower than one using the first.
+ * @param variants - Variants to look for, most preferred first.
+ * @param timeout  - How long to wait, in milliseconds.
+ * @returns The first variant found, or null.
+ */
+async function waitForField(
+	variants: SidebarTarget[],
+	timeout: number
+): Promise< FoundField | null > {
+	const deadline = performance.now() + timeout;
+	let found = findField( variants );
+
+	while ( ! found && performance.now() < deadline ) {
+		await nextFrame();
+		found = findField( variants );
+	}
+
+	return found;
+}
+
+function editorSelectors() {
+	return select( 'core/editor' ) as unknown as {
+		isEditorPanelOpened?: ( panelName: string ) => boolean;
+		isEditorPanelRemoved?: ( panelName: string ) => boolean;
+	};
+}
+
+/**
+ * Whether a panel needs opening. Panels the editor has removed are skipped, so
+ * a variant this editor cannot render costs no preference writes.
+ * @param panelName - Panel preference name.
+ * @returns Whether the panel should be opened.
+ */
+function needsOpening( panelName: string ): boolean {
+	const { isEditorPanelOpened, isEditorPanelRemoved } = editorSelectors();
+
+	return ! isEditorPanelRemoved?.( panelName ) && ! isEditorPanelOpened?.( panelName );
+}
+
+function togglePanel( panelName: string ): void {
+	const editorDispatch = dispatch( 'core/editor' ) as unknown as {
+		toggleEditorPanelOpened?: ( panelName: string ) => void;
+	};
+
+	editorDispatch?.toggleEditorPanelOpened?.( panelName );
+}
+
+/**
+ * Reveals a field in the document sidebar.
+ * @param fieldId         - Key of the target to reveal.
+ * @param options         - Reveal options.
+ * @param options.timeout - How long to wait for the field to render, in milliseconds.
+ * @returns Whether the field was found and revealed.
+ */
+export async function revealSidebarField(
+	fieldId: string,
+	{ timeout = DEFAULT_TIMEOUT_MS }: RevealOptions = {}
+): Promise< boolean > {
+	const variants = SIDEBAR_TARGETS[ fieldId ];
+
+	if ( ! variants?.length ) {
+		return false;
+	}
+
+	const editorInterface = dispatch( 'core/interface' ) as unknown as {
+		enableComplementaryArea?: ( scope: string, area: string ) => Promise< void >;
+	};
+
+	// The sidebar is the whole point, so there is nothing to reveal without it.
+	if ( ! editorInterface?.enableComplementaryArea ) {
+		return false;
+	}
+
+	// A selected block takes the sidebar slot over the document settings.
+	(
+		dispatch( 'core/block-editor' ) as unknown as { clearSelectedBlock?: () => void }
+	 )?.clearSelectedBlock?.();
+
+	await editorInterface.enableComplementaryArea( 'core', DOCUMENT_SIDEBAR );
+
+	// A collapsed panel does not render its contents, so every candidate panel
+	// has to be open before any of them can be found.
+	const openedPanels = variants
+		.map( ( variant ) => variant.panelName )
+		.filter( ( panelName ): panelName is string => !! panelName && needsOpening( panelName ) );
+
+	openedPanels.forEach( togglePanel );
+
+	const found = await waitForField( variants, timeout );
+
+	// Panels belonging to variants this editor does not render were opened only
+	// to look inside them, so leave the user's preferences as they were.
+	openedPanels
+		.filter( ( panelName ) => panelName !== found?.variant.panelName )
+		.forEach( togglePanel );
+
+	if ( ! found ) {
+		return false;
+	}
+
+	// Focus stays where the user put it — usually the chat input.
+	found.field.scrollIntoView?.( {
+		behavior: prefersReducedMotion() ? 'auto' : 'smooth',
+		block: 'center',
+	} );
+	return true;
+}

--- a/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/reveal-sidebar-field.ts
@@ -174,7 +174,14 @@ export async function revealSidebarField(
 		return false;
 	}
 
-	// A block the sidebar focused dims the rest of the editor, and
+	try {
+		await editorInterface.enableComplementaryArea( 'core', DOCUMENT_SIDEBAR );
+	} catch {
+		return false;
+	}
+
+	// Clearing costs the user their place, so it waits until the sidebar opens.
+	// A block the sidebar focused also dims the rest of the editor, and
 	// clearSelectedBlock on its own leaves that dimming in place.
 	clearActiveBlockFocus();
 
@@ -183,12 +190,6 @@ export async function revealSidebarField(
 	(
 		dispatch( 'core/block-editor' ) as unknown as { clearSelectedBlock?: () => void }
 	 )?.clearSelectedBlock?.();
-
-	try {
-		await editorInterface.enableComplementaryArea( 'core', DOCUMENT_SIDEBAR );
-	} catch {
-		return false;
-	}
 
 	// A collapsed panel does not render its contents, so every candidate panel
 	// has to be open before any of them can be found.


### PR DESCRIPTION
Part of FORNO-449

## Proposed Changes

* After the Excerpt, SEO Title, or SEO Description picker applies an edit, open the document sidebar and scroll to the panel that changed.


https://github.com/user-attachments/assets/ebdcba74-d8ae-495e-8713-5a47f2905717



## Why are these changes being made?

* Users can't see where the AI's edit landed without manually finding the panel themselves.

## Testing Instructions

* Checkout `add/jetpack-ai-sidebar-reveal-fields` locally and `cd apps/agents-manager && yarn dev --sync`
* Sandbox widgets.wp.com
* With the post/document sidebar is closed, open the WordPress Agent and apply an edit via the Excerpt, SEO Title, or SEO Description picker.
* Confirm the document sidebar opens and scrolls to the matching panel.
* Generate a featured image from the the WordPress Agent suggestion
* Verify the sidebar opens to reveal the featured image section

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?