### PR TITLE
Dashboard: Sync PHP logs severity filter to the URL query params

### DIFF
--- a/client/dashboard/app/hooks/test/use-persistent-view.test.tsx
+++ b/client/dashboard/app/hooks/test/use-persistent-view.test.tsx
@@ -315,6 +315,167 @@ describe( 'usePersistentView', () => {
 		} );
 	} );
 
+	describe( 'syncFiltersToQueryParams', () => {
+		it( 'should parse comma-separated query param values into a multi-value filter', async () => {
+			mockGetCalypsoPreferences( {} );
+
+			const { Wrapper } = createTestWrapper();
+
+			const queryParams = { severity: 'Warning,Fatal error' };
+			const { result } = renderHook(
+				() =>
+					usePersistentView( {
+						slug,
+						defaultView,
+						queryParams,
+						queryParamFilterFields: [ 'severity' ],
+						syncFiltersToQueryParams: true,
+					} ),
+				{ wrapper: Wrapper }
+			);
+
+			await waitFor( () => {
+				expect( result.current.view.filters ).toEqual( [
+					{ field: 'severity', operator: 'isAny', value: [ 'Warning', 'Fatal error' ] },
+				] );
+			} );
+		} );
+
+		it( 'should ignore persisted filters for synced fields', async () => {
+			const persistedView = {
+				type: 'table',
+				sort: { field: 'name', direction: 'asc' },
+				filters: [
+					{ field: 'severity', operator: 'isAny', value: [ 'User' ] },
+					{ field: 'status', operator: 'isAny', value: [ 'active' ] },
+				],
+			};
+			mockGetCalypsoPreferences( {
+				'hosting-dashboard-dataviews-view-sites': persistedView,
+			} );
+
+			const { Wrapper } = createTestWrapper();
+
+			const { result } = renderHook(
+				() =>
+					usePersistentView( {
+						slug,
+						defaultView,
+						queryParams: {},
+						queryParamFilterFields: [ 'severity' ],
+						syncFiltersToQueryParams: true,
+					} ),
+				{ wrapper: Wrapper }
+			);
+
+			await waitFor( () => {
+				expect( result.current.view.filters ).toEqual( [
+					{ field: 'status', operator: 'isAny', value: [ 'active' ] },
+				] );
+			} );
+		} );
+
+		it( 'should sync filter changes to the URL query params without persisting them', async () => {
+			mockGetCalypsoPreferences( {} );
+
+			const viewToPersist: View = {
+				type: 'grid',
+				layout: { previewSize: 120 },
+				sort: { field: 'name', direction: 'asc' },
+			};
+			const expectedUpdatePreferences = mockUpdateCalypsoPreferences( {
+				'hosting-dashboard-dataviews-view-sites': viewToPersist,
+			} );
+
+			const { Wrapper, getRouter } = createTestWrapper();
+
+			const queryParams = { severity: 'User' };
+			const { result } = renderHook(
+				() =>
+					usePersistentView( {
+						slug,
+						defaultView,
+						queryParams,
+						queryParamFilterFields: [ 'severity' ],
+						syncFiltersToQueryParams: true,
+					} ),
+				{ wrapper: Wrapper }
+			);
+
+			await waitFor( () => {
+				expect( result.current.updateView ).toBeTruthy();
+			} );
+
+			act( () => {
+				result.current.updateView( {
+					...viewToPersist,
+					page: 1,
+					search: '',
+					filters: [
+						{ field: 'severity', operator: 'isAny', value: [ 'Warning', 'Fatal error' ] },
+					],
+				} );
+			} );
+
+			await waitFor( () => {
+				const router = getRouter();
+				expect( router?.state.location.search ).toEqual( {
+					severity: 'Warning,Fatal error',
+				} );
+			} );
+
+			expect( result.current.view.filters ).toEqual( [
+				{ field: 'severity', operator: 'isAny', value: [ 'Warning', 'Fatal error' ] },
+			] );
+
+			await waitFor( () => {
+				expect( expectedUpdatePreferences.isDone() ).toBe( true );
+			} );
+		} );
+
+		it( 'should remove the query param when the filter is cleared', async () => {
+			mockGetCalypsoPreferences( {} );
+			mockUpdateCalypsoPreferences();
+
+			const { Wrapper, getRouter } = createTestWrapper();
+
+			const queryParams = { 'current-param': 'current-value', severity: 'Warning' };
+			const { result } = renderHook(
+				() =>
+					usePersistentView( {
+						slug,
+						defaultView,
+						queryParams,
+						queryParamFilterFields: [ 'severity' ],
+						syncFiltersToQueryParams: true,
+					} ),
+				{ wrapper: Wrapper }
+			);
+
+			await waitFor( () => {
+				expect( result.current.updateView ).toBeTruthy();
+			} );
+
+			act( () => {
+				result.current.updateView( {
+					...defaultView,
+					page: 1,
+					search: '',
+					filters: [],
+				} );
+			} );
+
+			await waitFor( () => {
+				const router = getRouter();
+				expect( router?.state.location.search ).toEqual( {
+					'current-param': 'current-value',
+				} );
+			} );
+
+			expect( result.current.view.filters ).toEqual( [] );
+		} );
+	} );
+
 	describe( 'resetView', () => {
 		it( 'should clear the persisted view', async () => {
 			const persistedView = {

--- a/client/dashboard/app/hooks/test/use-persistent-view.test.tsx
+++ b/client/dashboard/app/hooks/test/use-persistent-view.test.tsx
@@ -433,6 +433,91 @@ describe( 'usePersistentView', () => {
 			} );
 		} );
 
+		it( 'should keep a newly added filter with no value yet in the view', async () => {
+			mockGetCalypsoPreferences( {} );
+			mockUpdateCalypsoPreferences();
+
+			const { Wrapper, getRouter } = createTestWrapper();
+
+			const queryParams = {};
+			const { result } = renderHook(
+				() =>
+					usePersistentView( {
+						slug,
+						defaultView,
+						queryParams,
+						queryParamFilterFields: [ 'severity' ],
+						syncFiltersToQueryParams: true,
+					} ),
+				{ wrapper: Wrapper }
+			);
+
+			await waitFor( () => {
+				expect( result.current.updateView ).toBeTruthy();
+			} );
+
+			const searchBefore = getRouter()?.state.location.search;
+
+			act( () => {
+				result.current.updateView( {
+					...defaultView,
+					page: 1,
+					search: '',
+					filters: [ { field: 'severity', operator: 'isAny', value: undefined } ],
+				} );
+			} );
+
+			await waitFor( () => {
+				expect( result.current.view.filters ).toEqual( [
+					{ field: 'severity', operator: 'isAny', value: undefined },
+				] );
+			} );
+
+			expect( getRouter()?.state.location.search ).toEqual( searchBefore );
+		} );
+
+		it( 'should keep the filter but drop the query param when its values are cleared', async () => {
+			mockGetCalypsoPreferences( {} );
+			mockUpdateCalypsoPreferences();
+
+			const { Wrapper, getRouter } = createTestWrapper();
+
+			const queryParams = { severity: 'Warning' };
+			const { result } = renderHook(
+				() =>
+					usePersistentView( {
+						slug,
+						defaultView,
+						queryParams,
+						queryParamFilterFields: [ 'severity' ],
+						syncFiltersToQueryParams: true,
+					} ),
+				{ wrapper: Wrapper }
+			);
+
+			await waitFor( () => {
+				expect( result.current.updateView ).toBeTruthy();
+			} );
+
+			act( () => {
+				result.current.updateView( {
+					...defaultView,
+					page: 1,
+					search: '',
+					filters: [ { field: 'severity', operator: 'isAny', value: undefined } ],
+				} );
+			} );
+
+			await waitFor( () => {
+				const router = getRouter();
+				expect( router?.state.location.search ).toEqual( {} );
+			} );
+
+			expect( result.current.view.filters ).toEqual( [
+				{ field: 'severity', operator: 'isAny', value: undefined },
+			] );
+		} );
+
 		it( 'should remove the query param when the filter is cleared', async () => {
 			mockGetCalypsoPreferences( {} );
 			mockUpdateCalypsoPreferences();

--- a/client/dashboard/app/hooks/test/use-persistent-view.test.tsx
+++ b/client/dashboard/app/hooks/test/use-persistent-view.test.tsx
@@ -359,6 +359,23 @@ describe( 'usePersistentView', () => {
 			} );
 		} );
 
+		it( 'should not apply a boolean filter for a field with allowed values', async () => {
+			mockGetCalypsoPreferences( {} );
+
+			const { result } = renderHookWithRouterSearch(
+				{
+					queryParamFilterFields: [
+						{ field: 'severity', values: [ 'User', 'Warning', 'Deprecated', 'Fatal error' ] },
+					],
+				},
+				'/?severity=true'
+			);
+
+			await waitFor( () => {
+				expect( result.current.view.filters ).toEqual( [] );
+			} );
+		} );
+
 		it( 'should parse comma-separated query param values into a multi-value filter', async () => {
 			mockGetCalypsoPreferences( {} );
 

--- a/client/dashboard/app/hooks/test/use-persistent-view.test.tsx
+++ b/client/dashboard/app/hooks/test/use-persistent-view.test.tsx
@@ -3,11 +3,19 @@
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { createRouter, RouterProvider, createRootRoute, createRoute } from '@tanstack/react-router';
+import {
+	createRouter,
+	createMemoryHistory,
+	RouterProvider,
+	createRootRoute,
+	createRoute,
+	useSearch,
+} from '@tanstack/react-router';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { Suspense } from 'react';
 import { usePersistentView } from '../use-persistent-view';
+import type { UseViewOptions } from '../use-persistent-view';
 import type { View } from '@wordpress/dataviews';
 
 const defaultView: View = {
@@ -17,7 +25,7 @@ const defaultView: View = {
 };
 const slug = 'sites';
 
-function createTestWrapper() {
+function createTestWrapper( initialPath = '/' ) {
 	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
 	let router: ReturnType< typeof createRouter > | undefined;
 
@@ -31,6 +39,7 @@ function createTestWrapper() {
 
 		router = createRouter( {
 			routeTree: rootRoute.addChildren( [ indexRoute ] ),
+			history: createMemoryHistory( { initialEntries: [ initialPath ] } ),
 		} );
 
 		return (
@@ -41,6 +50,21 @@ function createTestWrapper() {
 	};
 
 	return { Wrapper, getRouter: () => router };
+}
+
+// Renders the hook with `queryParams` fed live from the router, the way
+// production callers pass `useSearch()` output — so the hook sees params
+// change after its own navigations.
+function renderHookWithRouterSearch( options: Partial< UseViewOptions >, initialPath = '/' ) {
+	const { Wrapper, getRouter } = createTestWrapper( initialPath );
+	const utils = renderHook(
+		() => {
+			const search = useSearch( { strict: false } );
+			return usePersistentView( { slug, defaultView, queryParams: search, ...options } );
+		},
+		{ wrapper: Wrapper }
+	);
+	return { ...utils, getRouter };
 }
 
 function mockGetCalypsoPreferences( preferences: any ) {
@@ -319,20 +343,13 @@ describe( 'usePersistentView', () => {
 		it( 'should canonicalize param values case-insensitively when allowed values are provided', async () => {
 			mockGetCalypsoPreferences( {} );
 
-			const { Wrapper } = createTestWrapper();
-
-			const queryParams = { severity: 'warning,FATAL+ERROR,bogus' };
-			const { result } = renderHook(
-				() =>
-					usePersistentView( {
-						slug,
-						defaultView,
-						queryParams,
-						queryParamFilterFields: [
-							{ field: 'severity', values: [ 'User', 'Warning', 'Deprecated', 'Fatal error' ] },
-						],
-					} ),
-				{ wrapper: Wrapper }
+			const { result } = renderHookWithRouterSearch(
+				{
+					queryParamFilterFields: [
+						{ field: 'severity', values: [ 'User', 'Warning', 'Deprecated', 'Fatal error' ] },
+					],
+				},
+				'/?severity=warning,FATAL+ERROR,bogus'
 			);
 
 			await waitFor( () => {
@@ -345,18 +362,9 @@ describe( 'usePersistentView', () => {
 		it( 'should parse comma-separated query param values into a multi-value filter', async () => {
 			mockGetCalypsoPreferences( {} );
 
-			const { Wrapper } = createTestWrapper();
-
-			const queryParams = { severity: 'Warning,Fatal error' };
-			const { result } = renderHook(
-				() =>
-					usePersistentView( {
-						slug,
-						defaultView,
-						queryParams,
-						queryParamFilterFields: [ 'severity' ],
-					} ),
-				{ wrapper: Wrapper }
+			const { result } = renderHookWithRouterSearch(
+				{ queryParamFilterFields: [ 'severity' ] },
+				'/?severity=Warning,Fatal%20error'
 			);
 
 			await waitFor( () => {
@@ -379,18 +387,9 @@ describe( 'usePersistentView', () => {
 				'hosting-dashboard-dataviews-view-sites': persistedView,
 			} );
 
-			const { Wrapper } = createTestWrapper();
-
-			const { result } = renderHook(
-				() =>
-					usePersistentView( {
-						slug,
-						defaultView,
-						queryParams: {},
-						queryParamFilterFields: [ 'severity' ],
-					} ),
-				{ wrapper: Wrapper }
-			);
+			const { result } = renderHookWithRouterSearch( {
+				queryParamFilterFields: [ 'severity' ],
+			} );
 
 			await waitFor( () => {
 				expect( result.current.view.filters ).toEqual( [
@@ -411,18 +410,9 @@ describe( 'usePersistentView', () => {
 				'hosting-dashboard-dataviews-view-sites': viewToPersist,
 			} );
 
-			const { Wrapper, getRouter } = createTestWrapper();
-
-			const queryParams = { severity: 'User' };
-			const { result } = renderHook(
-				() =>
-					usePersistentView( {
-						slug,
-						defaultView,
-						queryParams,
-						queryParamFilterFields: [ 'severity' ],
-					} ),
-				{ wrapper: Wrapper }
+			const { result, getRouter } = renderHookWithRouterSearch(
+				{ queryParamFilterFields: [ 'severity' ] },
+				'/?severity=User'
 			);
 
 			await waitFor( () => {
@@ -447,9 +437,11 @@ describe( 'usePersistentView', () => {
 				} );
 			} );
 
-			expect( result.current.view.filters ).toEqual( [
-				{ field: 'severity', operator: 'isAny', value: [ 'Warning', 'Fatal error' ] },
-			] );
+			await waitFor( () => {
+				expect( result.current.view.filters ).toEqual( [
+					{ field: 'severity', operator: 'isAny', value: [ 'Warning', 'Fatal error' ] },
+				] );
+			} );
 
 			await waitFor( () => {
 				expect( expectedUpdatePreferences.isDone() ).toBe( true );
@@ -460,19 +452,9 @@ describe( 'usePersistentView', () => {
 			mockGetCalypsoPreferences( {} );
 			mockUpdateCalypsoPreferences();
 
-			const { Wrapper, getRouter } = createTestWrapper();
-
-			const queryParams = {};
-			const { result } = renderHook(
-				() =>
-					usePersistentView( {
-						slug,
-						defaultView,
-						queryParams,
-						queryParamFilterFields: [ 'severity' ],
-					} ),
-				{ wrapper: Wrapper }
-			);
+			const { result, getRouter } = renderHookWithRouterSearch( {
+				queryParamFilterFields: [ 'severity' ],
+			} );
 
 			await waitFor( () => {
 				expect( result.current.updateView ).toBeTruthy();
@@ -502,18 +484,9 @@ describe( 'usePersistentView', () => {
 			mockGetCalypsoPreferences( {} );
 			mockUpdateCalypsoPreferences();
 
-			const { Wrapper, getRouter } = createTestWrapper();
-
-			const queryParams = { severity: 'Warning' };
-			const { result } = renderHook(
-				() =>
-					usePersistentView( {
-						slug,
-						defaultView,
-						queryParams,
-						queryParamFilterFields: [ 'severity' ],
-					} ),
-				{ wrapper: Wrapper }
+			const { result, getRouter } = renderHookWithRouterSearch(
+				{ queryParamFilterFields: [ 'severity' ] },
+				'/?severity=Warning'
 			);
 
 			await waitFor( () => {
@@ -534,27 +507,20 @@ describe( 'usePersistentView', () => {
 				expect( router?.state.location.search ).toEqual( {} );
 			} );
 
-			expect( result.current.view.filters ).toEqual( [
-				{ field: 'severity', operator: 'isAny', value: undefined },
-			] );
+			await waitFor( () => {
+				expect( result.current.view.filters ).toEqual( [
+					{ field: 'severity', operator: 'isAny', value: undefined },
+				] );
+			} );
 		} );
 
 		it( 'should remove the query param when the filter is cleared', async () => {
 			mockGetCalypsoPreferences( {} );
 			mockUpdateCalypsoPreferences();
 
-			const { Wrapper, getRouter } = createTestWrapper();
-
-			const queryParams = { 'current-param': 'current-value', severity: 'Warning' };
-			const { result } = renderHook(
-				() =>
-					usePersistentView( {
-						slug,
-						defaultView,
-						queryParams,
-						queryParamFilterFields: [ 'severity' ],
-					} ),
-				{ wrapper: Wrapper }
+			const { result, getRouter } = renderHookWithRouterSearch(
+				{ queryParamFilterFields: [ 'severity' ] },
+				'/?current-param=current-value&severity=Warning'
 			);
 
 			await waitFor( () => {
@@ -577,7 +543,9 @@ describe( 'usePersistentView', () => {
 				} );
 			} );
 
-			expect( result.current.view.filters ).toEqual( [] );
+			await waitFor( () => {
+				expect( result.current.view.filters ).toEqual( [] );
+			} );
 		} );
 	} );
 

--- a/client/dashboard/app/hooks/test/use-persistent-view.test.tsx
+++ b/client/dashboard/app/hooks/test/use-persistent-view.test.tsx
@@ -315,7 +315,33 @@ describe( 'usePersistentView', () => {
 		} );
 	} );
 
-	describe( 'syncFiltersToQueryParams', () => {
+	describe( 'query param filter sync', () => {
+		it( 'should canonicalize param values case-insensitively when allowed values are provided', async () => {
+			mockGetCalypsoPreferences( {} );
+
+			const { Wrapper } = createTestWrapper();
+
+			const queryParams = { severity: 'warning,FATAL+ERROR,bogus' };
+			const { result } = renderHook(
+				() =>
+					usePersistentView( {
+						slug,
+						defaultView,
+						queryParams,
+						queryParamFilterFields: [
+							{ field: 'severity', values: [ 'User', 'Warning', 'Deprecated', 'Fatal error' ] },
+						],
+					} ),
+				{ wrapper: Wrapper }
+			);
+
+			await waitFor( () => {
+				expect( result.current.view.filters ).toEqual( [
+					{ field: 'severity', operator: 'isAny', value: [ 'Warning', 'Fatal error' ] },
+				] );
+			} );
+		} );
+
 		it( 'should parse comma-separated query param values into a multi-value filter', async () => {
 			mockGetCalypsoPreferences( {} );
 
@@ -329,7 +355,6 @@ describe( 'usePersistentView', () => {
 						defaultView,
 						queryParams,
 						queryParamFilterFields: [ 'severity' ],
-						syncFiltersToQueryParams: true,
 					} ),
 				{ wrapper: Wrapper }
 			);
@@ -363,7 +388,6 @@ describe( 'usePersistentView', () => {
 						defaultView,
 						queryParams: {},
 						queryParamFilterFields: [ 'severity' ],
-						syncFiltersToQueryParams: true,
 					} ),
 				{ wrapper: Wrapper }
 			);
@@ -397,7 +421,6 @@ describe( 'usePersistentView', () => {
 						defaultView,
 						queryParams,
 						queryParamFilterFields: [ 'severity' ],
-						syncFiltersToQueryParams: true,
 					} ),
 				{ wrapper: Wrapper }
 			);
@@ -447,7 +470,6 @@ describe( 'usePersistentView', () => {
 						defaultView,
 						queryParams,
 						queryParamFilterFields: [ 'severity' ],
-						syncFiltersToQueryParams: true,
 					} ),
 				{ wrapper: Wrapper }
 			);
@@ -490,7 +512,6 @@ describe( 'usePersistentView', () => {
 						defaultView,
 						queryParams,
 						queryParamFilterFields: [ 'severity' ],
-						syncFiltersToQueryParams: true,
 					} ),
 				{ wrapper: Wrapper }
 			);
@@ -532,7 +553,6 @@ describe( 'usePersistentView', () => {
 						defaultView,
 						queryParams,
 						queryParamFilterFields: [ 'severity' ],
-						syncFiltersToQueryParams: true,
 					} ),
 				{ wrapper: Wrapper }
 			);

--- a/client/dashboard/app/hooks/use-persistent-view.ts
+++ b/client/dashboard/app/hooks/use-persistent-view.ts
@@ -108,15 +108,17 @@ export function useBasePersistentView( {
 			.map( ( field ) => getTransientFilter( field, queryParams[ field ] ) )
 	);
 
+	const transientFilterParamsKey = JSON.stringify(
+		transientFilterFields.map( ( field ) => [ field, queryParams?.[ field ] ] )
+	);
+
 	useEffect( () => {
 		setTransientFilters(
 			transientFilterFields.map( ( field ) => getTransientFilter( field, queryParams[ field ] ) )
 		);
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [
-		JSON.stringify( transientFilterFields.map( ( field ) => [ field, queryParams[ field ] ] ) ),
-	] );
+	}, [ transientFilterParamsKey ] );
 
 	useEffect( () => {
 		if ( ! matches || matches.length === 0 ) {
@@ -174,95 +176,34 @@ export function useBasePersistentView( {
 
 	const updateView = useCallback(
 		( newView: View ) => {
-			let transientFieldsToStrip: string[];
+			const changes = syncFiltersToQueryParams
+				? computeSyncedFiltersChanges( {
+						newView,
+						queryParams,
+						queryParamFilterFields,
+						transientProperties,
+				  } )
+				: computeTransientFiltersChanges( {
+						newView,
+						queryParams,
+						transientFilterFields,
+						transientProperties,
+				  } );
 
-			if ( syncFiltersToQueryParams ) {
-				transientFieldsToStrip = queryParamFilterFields;
-
-				if ( queryParams ) {
-					const newQueryParams = { ...queryParams };
-					const newTransientFilters: Filter[] = [];
-					let filtersChanged = false;
-
-					queryParamFilterFields.forEach( ( field ) => {
-						const filter = newView.filters?.find( ( f ) => f.field === field );
-						const serialized = filter ? serializeTransientFilterValue( filter ) : undefined;
-						const current =
-							queryParams[ field ] === undefined ? undefined : String( queryParams[ field ] );
-
-						if ( serialized === undefined ) {
-							delete newQueryParams[ field ];
-						} else {
-							newQueryParams[ field ] = serialized;
-							newTransientFilters.push( filter as Filter );
-						}
-
-						if ( serialized !== current ) {
-							filtersChanged = true;
-						}
-					} );
-
-					const newTransientProperties = {
-						page: newView.page,
-						search: newView.search,
-					};
-					const propertiesChanged = ! fastDeepEqual( newTransientProperties, transientProperties );
-
-					if ( filtersChanged || propertiesChanged ) {
-						if ( filtersChanged ) {
-							setTransientFilters( newTransientFilters );
-						}
-						navigate( {
-							search: mergeQueryParamsWithTransientProperties(
-								newQueryParams,
-								newTransientProperties
-							),
-							replace: filtersChanged ? true : undefined,
-							resetScroll: false,
-						} );
-					}
-				}
-			} else {
-				const newTransientFilterFields = transientFilterFields.filter(
-					( field ) =>
-						newView.filters?.some(
-							( filter ) =>
-								filter.field === field &&
-								fastDeepEqual(
-									filter.value,
-									getTransientFilter( field, queryParams[ field ] ).value
-								)
-						)
-				);
-				transientFieldsToStrip = newTransientFilterFields;
-
-				if ( queryParams ) {
-					const newTransientProperties = {
-						page: newView.page,
-						search: newView.search,
-					};
-
-					if ( ! fastDeepEqual( newTransientFilterFields, transientFilterFields ) ) {
-						setTransientFilters( [] );
-						navigate( {
-							search: clearQueryParamsFromTransientFilters( queryParams, transientFilterFields ),
-							replace: true,
-						} );
-					} else if ( ! fastDeepEqual( newTransientProperties, transientProperties ) ) {
-						navigate( {
-							search: mergeQueryParamsWithTransientProperties(
-								queryParams,
-								newTransientProperties
-							),
-							resetScroll: false,
-						} );
-					}
-				}
+			if ( changes.transientFilters ) {
+				setTransientFilters( changes.transientFilters );
+			}
+			if ( changes.navigateSearch ) {
+				navigate( {
+					search: changes.navigateSearch,
+					replace: changes.replace,
+					resetScroll: changes.resetScroll,
+				} );
 			}
 
 			let viewToPersist = newView;
 			viewToPersist = removeTransientPropertiesFromView( viewToPersist );
-			viewToPersist = removeTransientFiltersFromView( viewToPersist, transientFieldsToStrip );
+			viewToPersist = removeTransientFiltersFromView( viewToPersist, changes.fieldsToStrip );
 			viewToPersist = removeEmptyFiltersFromView( viewToPersist );
 
 			// Persist view if different from baseView.
@@ -306,6 +247,130 @@ export function useBasePersistentView( {
 	}, [ persistView, navigate, queryParams, syncFiltersToQueryParams, queryParamFilterFields ] );
 
 	return { view, updateView, resetView: isViewModified ? resetView : undefined };
+}
+
+/**
+ * The transient-state effects an `updateView` call should perform, computed as
+ * data so the deciding stays pure and the doing stays mechanical:
+ * - `fieldsToStrip`: filter fields to exclude from the persisted view.
+ * - `transientFilters`: new transient filter state; `undefined` means leave it untouched.
+ * - `navigateSearch`: query params to navigate to; `undefined` means don't navigate.
+ */
+type UpdateViewChanges = {
+	fieldsToStrip: string[];
+	transientFilters?: Filter[];
+	navigateSearch?: any;
+	replace?: boolean;
+	resetScroll?: boolean;
+};
+
+// Synced mode: the URL is the source of truth for `queryParamFilterFields`
+// filters — filter changes are written back to the query params and never
+// persisted to the preference.
+function computeSyncedFiltersChanges( {
+	newView,
+	queryParams,
+	queryParamFilterFields,
+	transientProperties,
+}: {
+	newView: View;
+	queryParams: any;
+	queryParamFilterFields: string[];
+	transientProperties: { page: number; search: string };
+} ): UpdateViewChanges {
+	if ( ! queryParams ) {
+		return { fieldsToStrip: queryParamFilterFields };
+	}
+
+	const newQueryParams = { ...queryParams };
+	const newTransientFilters: Filter[] = [];
+	let filtersChanged = false;
+
+	queryParamFilterFields.forEach( ( field ) => {
+		const filter = newView.filters?.find( ( f ) => f.field === field );
+		const serialized = filter ? serializeTransientFilterValue( filter ) : undefined;
+		const current = queryParams[ field ] === undefined ? undefined : String( queryParams[ field ] );
+
+		if ( filter === undefined || serialized === undefined ) {
+			delete newQueryParams[ field ];
+		} else {
+			newQueryParams[ field ] = serialized;
+			newTransientFilters.push( filter );
+		}
+
+		if ( serialized !== current ) {
+			filtersChanged = true;
+		}
+	} );
+
+	const newTransientProperties = { page: newView.page, search: newView.search };
+	const propertiesChanged = ! fastDeepEqual( newTransientProperties, transientProperties );
+
+	if ( ! filtersChanged && ! propertiesChanged ) {
+		return { fieldsToStrip: queryParamFilterFields };
+	}
+
+	const changes: UpdateViewChanges = {
+		fieldsToStrip: queryParamFilterFields,
+		navigateSearch: mergeQueryParamsWithTransientProperties(
+			newQueryParams,
+			newTransientProperties
+		),
+		resetScroll: false,
+	};
+	if ( filtersChanged ) {
+		changes.transientFilters = newTransientFilters;
+		changes.replace = true;
+	}
+	return changes;
+}
+
+// Default mode: query param filters are inbound-only. Once the user changes one
+// in the UI, the param is cleared and the persisted preference takes over.
+function computeTransientFiltersChanges( {
+	newView,
+	queryParams,
+	transientFilterFields,
+	transientProperties,
+}: {
+	newView: View;
+	queryParams: any;
+	transientFilterFields: string[];
+	transientProperties: { page: number; search: string };
+} ): UpdateViewChanges {
+	const keptTransientFilterFields = transientFilterFields.filter(
+		( field ) =>
+			newView.filters?.some(
+				( filter ) =>
+					filter.field === field &&
+					fastDeepEqual( filter.value, getTransientFilter( field, queryParams[ field ] ).value )
+			)
+	);
+
+	const changes: UpdateViewChanges = { fieldsToStrip: keptTransientFilterFields };
+
+	if ( ! queryParams ) {
+		return changes;
+	}
+
+	const newTransientProperties = { page: newView.page, search: newView.search };
+
+	if ( ! fastDeepEqual( keptTransientFilterFields, transientFilterFields ) ) {
+		changes.transientFilters = [];
+		changes.navigateSearch = clearQueryParamsFromTransientFilters(
+			queryParams,
+			transientFilterFields
+		);
+		changes.replace = true;
+	} else if ( ! fastDeepEqual( newTransientProperties, transientProperties ) ) {
+		changes.navigateSearch = mergeQueryParamsWithTransientProperties(
+			queryParams,
+			newTransientProperties
+		);
+		changes.resetScroll = false;
+	}
+
+	return changes;
 }
 
 function getTransientFilter( field: string, rawValue: unknown ): Filter {

--- a/client/dashboard/app/hooks/use-persistent-view.ts
+++ b/client/dashboard/app/hooks/use-persistent-view.ts
@@ -106,37 +106,25 @@ export function useBasePersistentView( {
 	const filterFieldNames = queryParams ? filterFieldConfigs.map( ( { field } ) => field ) : [];
 	const filterFieldNamesKey = JSON.stringify( filterFieldNames );
 
-	const transientFilterFields = filterFieldNames.filter(
+	const paramFilterFields = filterFieldNames.filter(
 		( field ) => queryParams[ field ] !== undefined
 	);
 
-	const getFilterFromQueryParam = ( field: string ) => {
+	// Filters derived from the URL query params — the source of truth for
+	// synced fields. Derived, not state: it cannot drift from the URL.
+	const urlFilters = paramFilterFields.flatMap( ( field ) => {
 		const config = filterFieldConfigs.find( ( c ) => c.field === field );
-		return getTransientFilter( field, queryParams[ field ], config?.values );
-	};
+		return getTransientFilter( field, queryParams[ field ], config?.values ) ?? [];
+	} );
 
-	const [ transientFilters, setTransientFilters ] = useState< Filter[] >( () =>
-		transientFilterFields.flatMap( ( field ) => getFilterFromQueryParam( field ) ?? [] )
+	// Filters the URL cannot express: chips added via the "Add filter" UI that
+	// have no value selected yet. Held separately so an in-progress chip isn't
+	// dismissed mid-edit; it graduates to a query param once it gains a value.
+	const [ draftFilters, setDraftFilters ] = useState< Filter[] >( [] );
+
+	const urlFilterParamsKey = JSON.stringify(
+		paramFilterFields.map( ( field ) => [ field, queryParams?.[ field ] ] )
 	);
-
-	const transientFilterParamsKey = JSON.stringify(
-		transientFilterFields.map( ( field ) => [ field, queryParams?.[ field ] ] )
-	);
-
-	useEffect( () => {
-		// Rebuild from the query params, but keep filters with no value yet:
-		// they have no param to rebuild from and are still being edited.
-		setTransientFilters( ( currentFilters ) => [
-			...transientFilterFields.flatMap( ( field ) => getFilterFromQueryParam( field ) ?? [] ),
-			...currentFilters.filter(
-				( filter ) =>
-					! transientFilterFields.includes( filter.field ) &&
-					serializeTransientFilterValue( filter ) === undefined
-			),
-		] );
-
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ transientFilterParamsKey ] );
 
 	useEffect( () => {
 		if ( ! matches || matches.length === 0 ) {
@@ -144,7 +132,7 @@ export function useBasePersistentView( {
 		}
 
 		let transientQueryParams: Record< string, unknown > = {};
-		transientFilters.forEach( ( { field } ) => {
+		urlFilters.forEach( ( { field } ) => {
 			transientQueryParams[ field ] = queryParams[ field ];
 		} );
 		transientQueryParams = mergeQueryParamsWithTransientProperties(
@@ -155,20 +143,27 @@ export function useBasePersistentView( {
 			matches[ matches.length - 1 ].pathname.replace( /\/$/, '' ),
 			transientQueryParams
 		);
-	}, [ matches, transientProperties, transientFilters, queryParams ] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ matches, transientProperties, urlFilterParamsKey, queryParams ] );
 
 	// The URL is the source of truth for the synced fields, so persisted filters
 	// for them (e.g. from a preference saved before syncing existed) are ignored.
+	// A draft yields to the URL if its field gains a param (e.g. via history
+	// navigation).
 	const view: View = useMemo( () => {
+		const activeDraftFilters = draftFilters.filter(
+			( filter ) => ! paramFilterFields.includes( filter.field )
+		);
 		const mergedView = {
 			...baseView,
 			...transientProperties,
-			...( ( transientFilters.length > 0 || filterFieldNames.length > 0 ) && {
+			...( filterFieldNames.length > 0 && {
 				filters: [
 					...( baseView.filters || [] ).filter(
 						( filter ) => ! filterFieldNames.includes( filter.field )
 					),
-					...transientFilters,
+					...urlFilters,
+					...activeDraftFilters,
 				],
 			} ),
 		};
@@ -179,7 +174,14 @@ export function useBasePersistentView( {
 
 		return mergedView;
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ baseView, transientProperties, transientFilters, filterFieldNamesKey, sanitizeFields ] );
+	}, [
+		baseView,
+		transientProperties,
+		draftFilters,
+		urlFilterParamsKey,
+		filterFieldNamesKey,
+		sanitizeFields,
+	] );
 
 	const updateView = useCallback(
 		( newView: View ) => {
@@ -187,12 +189,12 @@ export function useBasePersistentView( {
 				newView,
 				queryParams,
 				filterFieldNames,
-				transientFilters,
+				draftFilters,
 				transientProperties,
 			} );
 
-			if ( changes.transientFilters ) {
-				setTransientFilters( changes.transientFilters );
+			if ( changes.draftFilters ) {
+				setDraftFilters( changes.draftFilters );
 			}
 			if ( changes.navigateSearch ) {
 				navigate( {
@@ -220,7 +222,7 @@ export function useBasePersistentView( {
 		[
 			queryParams,
 			transientProperties,
-			transientFilters,
+			draftFilters,
 			filterFieldNamesKey,
 			navigate,
 			baseView,
@@ -233,7 +235,7 @@ export function useBasePersistentView( {
 
 	const resetView = useCallback( () => {
 		persistView( undefined );
-		setTransientFilters( [] );
+		setDraftFilters( [] );
 		navigate( {
 			search: mergeQueryParamsWithTransientProperties(
 				clearQueryParamsFromTransientFilters( queryParams, filterFieldNames ),
@@ -251,12 +253,12 @@ export function useBasePersistentView( {
  * The transient-state effects an `updateView` call should perform, computed as
  * data so the deciding stays pure and the doing stays mechanical:
  * - `fieldsToStrip`: filter fields to exclude from the persisted view.
- * - `transientFilters`: new transient filter state; `undefined` means leave it untouched.
+ * - `draftFilters`: new draft filter state; `undefined` means leave it untouched.
  * - `navigateSearch`: query params to navigate to; `undefined` means don't navigate.
  */
 type UpdateViewChanges = {
 	fieldsToStrip: string[];
-	transientFilters?: Filter[];
+	draftFilters?: Filter[];
 	navigateSearch?: any;
 	replace?: boolean;
 	resetScroll?: boolean;
@@ -266,26 +268,24 @@ function computeUpdateViewChanges( {
 	newView,
 	queryParams,
 	filterFieldNames,
-	transientFilters,
+	draftFilters,
 	transientProperties,
 }: {
 	newView: View;
 	queryParams: any;
 	filterFieldNames: string[];
-	transientFilters: Filter[];
+	draftFilters: Filter[];
 	transientProperties: { page: number; search: string };
 } ): UpdateViewChanges {
 	if ( ! queryParams ) {
 		return { fieldsToStrip: [] };
 	}
 
-	// All synced-field filters stay in the transient state, including ones with
-	// no value yet (a filter just added via the "Add filter" UI): they can't be
-	// expressed in the URL, but dropping them would dismiss the filter mid-edit.
-	const newTransientFilters =
-		newView.filters?.filter( ( filter ) => filterFieldNames.includes( filter.field ) ) ?? [];
-
 	const newQueryParams = { ...queryParams };
+	// Synced-field filters that can't be expressed in the URL — no value yet
+	// (e.g. just added via the "Add filter" UI) — become drafts instead, so
+	// they aren't dismissed mid-edit.
+	const newDraftFilters: Filter[] = [];
 	let filtersChanged = false;
 
 	filterFieldNames.forEach( ( field ) => {
@@ -295,6 +295,9 @@ function computeUpdateViewChanges( {
 
 		if ( serialized === undefined ) {
 			delete newQueryParams[ field ];
+			if ( filter ) {
+				newDraftFilters.push( filter );
+			}
 		} else {
 			newQueryParams[ field ] = serialized;
 		}
@@ -306,8 +309,8 @@ function computeUpdateViewChanges( {
 
 	const changes: UpdateViewChanges = { fieldsToStrip: filterFieldNames };
 
-	if ( ! fastDeepEqual( newTransientFilters, transientFilters ) ) {
-		changes.transientFilters = newTransientFilters;
+	if ( ! fastDeepEqual( newDraftFilters, draftFilters ) ) {
+		changes.draftFilters = newDraftFilters;
 	}
 
 	const newTransientProperties = { page: newView.page, search: newView.search };

--- a/client/dashboard/app/hooks/use-persistent-view.ts
+++ b/client/dashboard/app/hooks/use-persistent-view.ts
@@ -32,6 +32,15 @@ export interface UseViewOptions {
 	queryParamFilterFields?: string[];
 
 	/**
+	 * When true, the URL query params are the source of truth for the
+	 * `queryParamFilterFields` filters: changing them in the UI updates the URL,
+	 * and they are never persisted to the user preference. Fields synced this way
+	 * should restrict `filterBy.operators` to `isAny`, as that is the only
+	 * operator (besides boolean `is`) a query param can express.
+	 */
+	syncFiltersToQueryParams?: boolean;
+
+	/**
 	 * Sanitize the field by removing any invalid or malformed entries and migrating deprecated fields.
 	 */
 	sanitizeFields?: ( fields: View[ 'fields' ] ) => View[ 'fields' ];
@@ -58,6 +67,7 @@ export function useBasePersistentView( {
 	defaultView,
 	queryParams,
 	queryParamFilterFields = [],
+	syncFiltersToQueryParams = false,
 	matches,
 	sanitizeFields,
 	navigate,
@@ -104,7 +114,9 @@ export function useBasePersistentView( {
 		);
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ JSON.stringify( transientFilterFields ) ] );
+	}, [
+		JSON.stringify( transientFilterFields.map( ( field ) => [ field, queryParams[ field ] ] ) ),
+	] );
 
 	useEffect( () => {
 		if ( ! matches || matches.length === 0 ) {
@@ -125,15 +137,21 @@ export function useBasePersistentView( {
 		);
 	}, [ matches, transientProperties, transientFilters, queryParams ] );
 
+	// For synced fields the URL is the source of truth, so persisted filters for
+	// them (e.g. from a preference saved before syncing was enabled) are ignored.
+	const excludedFilterFields = syncFiltersToQueryParams
+		? queryParamFilterFields
+		: transientFilterFields;
+
 	// Merge transient properties and filters from query params into the view.
 	const view: View = useMemo( () => {
 		const mergedView = {
 			...baseView,
 			...transientProperties,
-			...( transientFilters.length > 0 && {
+			...( ( transientFilters.length > 0 || syncFiltersToQueryParams ) && {
 				filters: [
 					...( baseView.filters || [] ).filter(
-						( filter ) => ! transientFilterFields.includes( filter.field )
+						( filter ) => ! excludedFilterFields.includes( filter.field )
 					),
 					...transientFilters,
 				],
@@ -145,42 +163,106 @@ export function useBasePersistentView( {
 		}
 
 		return mergedView;
-	}, [ baseView, transientProperties, transientFilterFields, transientFilters, sanitizeFields ] );
+	}, [
+		baseView,
+		transientProperties,
+		excludedFilterFields,
+		transientFilters,
+		syncFiltersToQueryParams,
+		sanitizeFields,
+	] );
 
 	const updateView = useCallback(
 		( newView: View ) => {
-			const newTransientFilterFields = transientFilterFields.filter(
-				( field ) =>
-					newView.filters?.some(
-						( filter ) =>
-							filter.field === field &&
-							fastDeepEqual( filter.value, getTransientFilter( field, queryParams[ field ] ).value )
-					)
-			);
+			let transientFieldsToStrip: string[];
 
-			if ( queryParams ) {
-				const newTransientProperties = {
-					page: newView.page,
-					search: newView.search,
-				};
+			if ( syncFiltersToQueryParams ) {
+				transientFieldsToStrip = queryParamFilterFields;
 
-				if ( ! fastDeepEqual( newTransientFilterFields, transientFilterFields ) ) {
-					setTransientFilters( [] );
-					navigate( {
-						search: clearQueryParamsFromTransientFilters( queryParams, transientFilterFields ),
-						replace: true,
+				if ( queryParams ) {
+					const newQueryParams = { ...queryParams };
+					const newTransientFilters: Filter[] = [];
+					let filtersChanged = false;
+
+					queryParamFilterFields.forEach( ( field ) => {
+						const filter = newView.filters?.find( ( f ) => f.field === field );
+						const serialized = filter ? serializeTransientFilterValue( filter ) : undefined;
+						const current =
+							queryParams[ field ] === undefined ? undefined : String( queryParams[ field ] );
+
+						if ( serialized === undefined ) {
+							delete newQueryParams[ field ];
+						} else {
+							newQueryParams[ field ] = serialized;
+							newTransientFilters.push( filter as Filter );
+						}
+
+						if ( serialized !== current ) {
+							filtersChanged = true;
+						}
 					} );
-				} else if ( ! fastDeepEqual( newTransientProperties, transientProperties ) ) {
-					navigate( {
-						search: mergeQueryParamsWithTransientProperties( queryParams, newTransientProperties ),
-						resetScroll: false,
-					} );
+
+					const newTransientProperties = {
+						page: newView.page,
+						search: newView.search,
+					};
+					const propertiesChanged = ! fastDeepEqual( newTransientProperties, transientProperties );
+
+					if ( filtersChanged || propertiesChanged ) {
+						if ( filtersChanged ) {
+							setTransientFilters( newTransientFilters );
+						}
+						navigate( {
+							search: mergeQueryParamsWithTransientProperties(
+								newQueryParams,
+								newTransientProperties
+							),
+							replace: filtersChanged ? true : undefined,
+							resetScroll: false,
+						} );
+					}
+				}
+			} else {
+				const newTransientFilterFields = transientFilterFields.filter(
+					( field ) =>
+						newView.filters?.some(
+							( filter ) =>
+								filter.field === field &&
+								fastDeepEqual(
+									filter.value,
+									getTransientFilter( field, queryParams[ field ] ).value
+								)
+						)
+				);
+				transientFieldsToStrip = newTransientFilterFields;
+
+				if ( queryParams ) {
+					const newTransientProperties = {
+						page: newView.page,
+						search: newView.search,
+					};
+
+					if ( ! fastDeepEqual( newTransientFilterFields, transientFilterFields ) ) {
+						setTransientFilters( [] );
+						navigate( {
+							search: clearQueryParamsFromTransientFilters( queryParams, transientFilterFields ),
+							replace: true,
+						} );
+					} else if ( ! fastDeepEqual( newTransientProperties, transientProperties ) ) {
+						navigate( {
+							search: mergeQueryParamsWithTransientProperties(
+								queryParams,
+								newTransientProperties
+							),
+							resetScroll: false,
+						} );
+					}
 				}
 			}
 
 			let viewToPersist = newView;
 			viewToPersist = removeTransientPropertiesFromView( viewToPersist );
-			viewToPersist = removeTransientFiltersFromView( viewToPersist, newTransientFilterFields );
+			viewToPersist = removeTransientFiltersFromView( viewToPersist, transientFieldsToStrip );
 			viewToPersist = removeEmptyFiltersFromView( viewToPersist );
 
 			// Persist view if different from baseView.
@@ -196,6 +278,8 @@ export function useBasePersistentView( {
 			queryParams,
 			transientProperties,
 			transientFilterFields,
+			queryParamFilterFields,
+			syncFiltersToQueryParams,
 			navigate,
 			baseView,
 			defaultView,
@@ -207,11 +291,19 @@ export function useBasePersistentView( {
 
 	const resetView = useCallback( () => {
 		persistView( undefined );
+		if ( syncFiltersToQueryParams ) {
+			setTransientFilters( [] );
+		}
 		navigate( {
-			search: mergeQueryParamsWithTransientProperties( queryParams, { page: 1, search: '' } ),
+			search: mergeQueryParamsWithTransientProperties(
+				syncFiltersToQueryParams
+					? clearQueryParamsFromTransientFilters( queryParams, queryParamFilterFields )
+					: queryParams,
+				{ page: 1, search: '' }
+			),
 			replace: true,
 		} );
-	}, [ persistView, navigate, queryParams ] );
+	}, [ persistView, navigate, queryParams, syncFiltersToQueryParams, queryParamFilterFields ] );
 
 	return { view, updateView, resetView: isViewModified ? resetView : undefined };
 }
@@ -221,7 +313,17 @@ function getTransientFilter( field: string, rawValue: unknown ): Filter {
 	if ( stringValue === 'true' || stringValue === 'false' ) {
 		return { field, operator: 'is', value: stringValue === 'true' } as Filter;
 	}
-	return { field, operator: 'isAny', value: [ stringValue ] } as Filter;
+	return { field, operator: 'isAny', value: stringValue.split( ',' ) } as Filter;
+}
+
+function serializeTransientFilterValue( filter: Filter ): string | undefined {
+	if ( typeof filter.value === 'boolean' ) {
+		return String( filter.value );
+	}
+	if ( Array.isArray( filter.value ) && filter.value.length > 0 ) {
+		return filter.value.map( String ).join( ',' );
+	}
+	return undefined;
 }
 
 function removeTransientPropertiesFromView( view: View ): View {

--- a/client/dashboard/app/hooks/use-persistent-view.ts
+++ b/client/dashboard/app/hooks/use-persistent-view.ts
@@ -7,6 +7,13 @@ import { setTransientQueryParamsAtPathname } from '../transient-query-params';
 import type { AnyRouteMatch } from '@tanstack/react-router';
 import type { Filter, View } from '@wordpress/dataviews';
 
+/**
+ * A field whose filter is kept in sync with the URL query params. Provide
+ * `values` to restrict the accepted param values; they are canonicalized
+ * case-insensitively, so hand-typed URLs keep working.
+ */
+export type QueryParamFilterField = string | { field: string; values?: readonly string[] };
+
 export interface UseViewOptions {
 	/**
 	 * Unique slug to identify the view.
@@ -26,19 +33,14 @@ export interface UseViewOptions {
 	queryParams?: any;
 
 	/**
-	 * Fields that should become transient filters when present in the URL query params.
-	 * The returned view's `filters` will be merged with the transient filters.
+	 * Fields whose filters are kept in sync with the URL query params: params
+	 * become filters in the returned view, changing the filters in the UI
+	 * updates the URL, and they are never persisted to the user preference.
+	 * Requires `queryParams`. Fields synced this way should restrict
+	 * `filterBy.operators` to `isAny`, as that is the only operator (besides
+	 * boolean `is`) a query param can express.
 	 */
-	queryParamFilterFields?: string[];
-
-	/**
-	 * When true, the URL query params are the source of truth for the
-	 * `queryParamFilterFields` filters: changing them in the UI updates the URL,
-	 * and they are never persisted to the user preference. Fields synced this way
-	 * should restrict `filterBy.operators` to `isAny`, as that is the only
-	 * operator (besides boolean `is`) a query param can express.
-	 */
-	syncFiltersToQueryParams?: boolean;
+	queryParamFilterFields?: QueryParamFilterField[];
 
 	/**
 	 * Sanitize the field by removing any invalid or malformed entries and migrating deprecated fields.
@@ -48,8 +50,9 @@ export interface UseViewOptions {
 
 /**
  * Hook for managing DataViews view state.
- * Transient properties (`page` and `search`) are synced to the URL query params,
- * while the rest of the properties is persisted to Calypso preferences.
+ * Transient properties (`page` and `search`) and `queryParamFilterFields`
+ * filters are synced to the URL query params, while the rest of the properties
+ * is persisted to Calypso preferences.
  */
 export function usePersistentView( options: UseViewOptions ) {
 	const navigate = useNavigate();
@@ -67,7 +70,6 @@ export function useBasePersistentView( {
 	defaultView,
 	queryParams,
 	queryParamFilterFields = [],
-	syncFiltersToQueryParams = false,
 	matches,
 	sanitizeFields,
 	navigate,
@@ -98,14 +100,23 @@ export function useBasePersistentView( {
 
 	const transientProperties = useMemo( () => ( { page, search } ), [ page, search ] );
 
-	const transientFilterFields = queryParamFilterFields.filter(
-		( field ) => queryParams && queryParams[ field ] !== undefined
+	const filterFieldConfigs = queryParamFilterFields.map( ( config ) =>
+		typeof config === 'string' ? { field: config, values: undefined } : config
+	);
+	const filterFieldNames = queryParams ? filterFieldConfigs.map( ( { field } ) => field ) : [];
+	const filterFieldNamesKey = JSON.stringify( filterFieldNames );
+
+	const transientFilterFields = filterFieldNames.filter(
+		( field ) => queryParams[ field ] !== undefined
 	);
 
+	const getFilterFromQueryParam = ( field: string ) => {
+		const config = filterFieldConfigs.find( ( c ) => c.field === field );
+		return getTransientFilter( field, queryParams[ field ], config?.values );
+	};
+
 	const [ transientFilters, setTransientFilters ] = useState< Filter[] >( () =>
-		queryParamFilterFields
-			.filter( ( field ) => queryParams && queryParams[ field ] !== undefined )
-			.map( ( field ) => getTransientFilter( field, queryParams[ field ] ) )
+		transientFilterFields.flatMap( ( field ) => getFilterFromQueryParam( field ) ?? [] )
 	);
 
 	const transientFilterParamsKey = JSON.stringify(
@@ -116,9 +127,7 @@ export function useBasePersistentView( {
 		// Rebuild from the query params, but keep filters with no value yet:
 		// they have no param to rebuild from and are still being edited.
 		setTransientFilters( ( currentFilters ) => [
-			...transientFilterFields.map( ( field ) =>
-				getTransientFilter( field, queryParams[ field ] )
-			),
+			...transientFilterFields.flatMap( ( field ) => getFilterFromQueryParam( field ) ?? [] ),
 			...currentFilters.filter(
 				( filter ) =>
 					! transientFilterFields.includes( filter.field ) &&
@@ -148,21 +157,16 @@ export function useBasePersistentView( {
 		);
 	}, [ matches, transientProperties, transientFilters, queryParams ] );
 
-	// For synced fields the URL is the source of truth, so persisted filters for
-	// them (e.g. from a preference saved before syncing was enabled) are ignored.
-	const excludedFilterFields = syncFiltersToQueryParams
-		? queryParamFilterFields
-		: transientFilterFields;
-
-	// Merge transient properties and filters from query params into the view.
+	// The URL is the source of truth for the synced fields, so persisted filters
+	// for them (e.g. from a preference saved before syncing existed) are ignored.
 	const view: View = useMemo( () => {
 		const mergedView = {
 			...baseView,
 			...transientProperties,
-			...( ( transientFilters.length > 0 || syncFiltersToQueryParams ) && {
+			...( ( transientFilters.length > 0 || filterFieldNames.length > 0 ) && {
 				filters: [
 					...( baseView.filters || [] ).filter(
-						( filter ) => ! excludedFilterFields.includes( filter.field )
+						( filter ) => ! filterFieldNames.includes( filter.field )
 					),
 					...transientFilters,
 				],
@@ -174,31 +178,18 @@ export function useBasePersistentView( {
 		}
 
 		return mergedView;
-	}, [
-		baseView,
-		transientProperties,
-		excludedFilterFields,
-		transientFilters,
-		syncFiltersToQueryParams,
-		sanitizeFields,
-	] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ baseView, transientProperties, transientFilters, filterFieldNamesKey, sanitizeFields ] );
 
 	const updateView = useCallback(
 		( newView: View ) => {
-			const changes = syncFiltersToQueryParams
-				? computeSyncedFiltersChanges( {
-						newView,
-						queryParams,
-						queryParamFilterFields,
-						transientFilters,
-						transientProperties,
-				  } )
-				: computeTransientFiltersChanges( {
-						newView,
-						queryParams,
-						transientFilterFields,
-						transientProperties,
-				  } );
+			const changes = computeUpdateViewChanges( {
+				newView,
+				queryParams,
+				filterFieldNames,
+				transientFilters,
+				transientProperties,
+			} );
 
 			if ( changes.transientFilters ) {
 				setTransientFilters( changes.transientFilters );
@@ -225,13 +216,12 @@ export function useBasePersistentView( {
 				}
 			}
 		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[
 			queryParams,
 			transientProperties,
-			transientFilterFields,
 			transientFilters,
-			queryParamFilterFields,
-			syncFiltersToQueryParams,
+			filterFieldNamesKey,
 			navigate,
 			baseView,
 			defaultView,
@@ -243,19 +233,16 @@ export function useBasePersistentView( {
 
 	const resetView = useCallback( () => {
 		persistView( undefined );
-		if ( syncFiltersToQueryParams ) {
-			setTransientFilters( [] );
-		}
+		setTransientFilters( [] );
 		navigate( {
 			search: mergeQueryParamsWithTransientProperties(
-				syncFiltersToQueryParams
-					? clearQueryParamsFromTransientFilters( queryParams, queryParamFilterFields )
-					: queryParams,
+				clearQueryParamsFromTransientFilters( queryParams, filterFieldNames ),
 				{ page: 1, search: '' }
 			),
 			replace: true,
 		} );
-	}, [ persistView, navigate, queryParams, syncFiltersToQueryParams, queryParamFilterFields ] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ persistView, navigate, queryParams, filterFieldNamesKey ] );
 
 	return { view, updateView, resetView: isViewModified ? resetView : undefined };
 }
@@ -275,36 +262,33 @@ type UpdateViewChanges = {
 	resetScroll?: boolean;
 };
 
-// Synced mode: the URL is the source of truth for `queryParamFilterFields`
-// filters — filter changes are written back to the query params and never
-// persisted to the preference.
-function computeSyncedFiltersChanges( {
+function computeUpdateViewChanges( {
 	newView,
 	queryParams,
-	queryParamFilterFields,
+	filterFieldNames,
 	transientFilters,
 	transientProperties,
 }: {
 	newView: View;
 	queryParams: any;
-	queryParamFilterFields: string[];
+	filterFieldNames: string[];
 	transientFilters: Filter[];
 	transientProperties: { page: number; search: string };
 } ): UpdateViewChanges {
 	if ( ! queryParams ) {
-		return { fieldsToStrip: queryParamFilterFields };
+		return { fieldsToStrip: [] };
 	}
 
 	// All synced-field filters stay in the transient state, including ones with
 	// no value yet (a filter just added via the "Add filter" UI): they can't be
 	// expressed in the URL, but dropping them would dismiss the filter mid-edit.
 	const newTransientFilters =
-		newView.filters?.filter( ( filter ) => queryParamFilterFields.includes( filter.field ) ) ?? [];
+		newView.filters?.filter( ( filter ) => filterFieldNames.includes( filter.field ) ) ?? [];
 
 	const newQueryParams = { ...queryParams };
 	let filtersChanged = false;
 
-	queryParamFilterFields.forEach( ( field ) => {
+	filterFieldNames.forEach( ( field ) => {
 		const filter = newView.filters?.find( ( f ) => f.field === field );
 		const serialized = filter ? serializeTransientFilterValue( filter ) : undefined;
 		const current = queryParams[ field ] === undefined ? undefined : String( queryParams[ field ] );
@@ -320,7 +304,7 @@ function computeSyncedFiltersChanges( {
 		}
 	} );
 
-	const changes: UpdateViewChanges = { fieldsToStrip: queryParamFilterFields };
+	const changes: UpdateViewChanges = { fieldsToStrip: filterFieldNames };
 
 	if ( ! fastDeepEqual( newTransientFilters, transientFilters ) ) {
 		changes.transientFilters = newTransientFilters;
@@ -341,60 +325,34 @@ function computeSyncedFiltersChanges( {
 	return changes;
 }
 
-// Default mode: query param filters are inbound-only. Once the user changes one
-// in the UI, the param is cleared and the persisted preference takes over.
-function computeTransientFiltersChanges( {
-	newView,
-	queryParams,
-	transientFilterFields,
-	transientProperties,
-}: {
-	newView: View;
-	queryParams: any;
-	transientFilterFields: string[];
-	transientProperties: { page: number; search: string };
-} ): UpdateViewChanges {
-	const keptTransientFilterFields = transientFilterFields.filter(
-		( field ) =>
-			newView.filters?.some(
-				( filter ) =>
-					filter.field === field &&
-					fastDeepEqual( filter.value, getTransientFilter( field, queryParams[ field ] ).value )
-			)
-	);
-
-	const changes: UpdateViewChanges = { fieldsToStrip: keptTransientFilterFields };
-
-	if ( ! queryParams ) {
-		return changes;
-	}
-
-	const newTransientProperties = { page: newView.page, search: newView.search };
-
-	if ( ! fastDeepEqual( keptTransientFilterFields, transientFilterFields ) ) {
-		changes.transientFilters = [];
-		changes.navigateSearch = clearQueryParamsFromTransientFilters(
-			queryParams,
-			transientFilterFields
-		);
-		changes.replace = true;
-	} else if ( ! fastDeepEqual( newTransientProperties, transientProperties ) ) {
-		changes.navigateSearch = mergeQueryParamsWithTransientProperties(
-			queryParams,
-			newTransientProperties
-		);
-		changes.resetScroll = false;
-	}
-
-	return changes;
-}
-
-function getTransientFilter( field: string, rawValue: unknown ): Filter {
+function getTransientFilter(
+	field: string,
+	rawValue: unknown,
+	allowedValues?: readonly string[]
+): Filter | undefined {
 	const stringValue = String( rawValue );
 	if ( stringValue === 'true' || stringValue === 'false' ) {
 		return { field, operator: 'is', value: stringValue === 'true' } as Filter;
 	}
-	return { field, operator: 'isAny', value: stringValue.split( ',' ) } as Filter;
+
+	let values = stringValue.split( ',' );
+	if ( allowedValues ) {
+		// '+' is tolerated as an encoded space: the router's search parser uses
+		// decodeURIComponent, which leaves it as-is.
+		values = Array.from(
+			new Set(
+				values.flatMap( ( value ) => {
+					const normalized = value.replace( /\+/g, ' ' ).trim().toLowerCase();
+					const canonical = allowedValues.find( ( v ) => v.toLowerCase() === normalized );
+					return canonical === undefined ? [] : [ canonical ];
+				} )
+			)
+		);
+		if ( values.length === 0 ) {
+			return undefined;
+		}
+	}
+	return { field, operator: 'isAny', value: values } as Filter;
 }
 
 function serializeTransientFilterValue( filter: Filter ): string | undefined {

--- a/client/dashboard/app/hooks/use-persistent-view.ts
+++ b/client/dashboard/app/hooks/use-persistent-view.ts
@@ -334,7 +334,10 @@ function getTransientFilter(
 	allowedValues?: readonly string[]
 ): Filter | undefined {
 	const stringValue = String( rawValue );
-	if ( stringValue === 'true' || stringValue === 'false' ) {
+	// The boolean shorthand applies only to fields without an allowlist —
+	// otherwise 'true'/'false' would bypass validation with a filter shape
+	// the field doesn't support.
+	if ( ! allowedValues && ( stringValue === 'true' || stringValue === 'false' ) ) {
 		return { field, operator: 'is', value: stringValue === 'true' } as Filter;
 	}
 

--- a/client/dashboard/app/hooks/use-persistent-view.ts
+++ b/client/dashboard/app/hooks/use-persistent-view.ts
@@ -113,9 +113,18 @@ export function useBasePersistentView( {
 	);
 
 	useEffect( () => {
-		setTransientFilters(
-			transientFilterFields.map( ( field ) => getTransientFilter( field, queryParams[ field ] ) )
-		);
+		// Rebuild from the query params, but keep filters with no value yet:
+		// they have no param to rebuild from and are still being edited.
+		setTransientFilters( ( currentFilters ) => [
+			...transientFilterFields.map( ( field ) =>
+				getTransientFilter( field, queryParams[ field ] )
+			),
+			...currentFilters.filter(
+				( filter ) =>
+					! transientFilterFields.includes( filter.field ) &&
+					serializeTransientFilterValue( filter ) === undefined
+			),
+		] );
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ transientFilterParamsKey ] );
@@ -181,6 +190,7 @@ export function useBasePersistentView( {
 						newView,
 						queryParams,
 						queryParamFilterFields,
+						transientFilters,
 						transientProperties,
 				  } )
 				: computeTransientFiltersChanges( {
@@ -219,6 +229,7 @@ export function useBasePersistentView( {
 			queryParams,
 			transientProperties,
 			transientFilterFields,
+			transientFilters,
 			queryParamFilterFields,
 			syncFiltersToQueryParams,
 			navigate,
@@ -271,19 +282,26 @@ function computeSyncedFiltersChanges( {
 	newView,
 	queryParams,
 	queryParamFilterFields,
+	transientFilters,
 	transientProperties,
 }: {
 	newView: View;
 	queryParams: any;
 	queryParamFilterFields: string[];
+	transientFilters: Filter[];
 	transientProperties: { page: number; search: string };
 } ): UpdateViewChanges {
 	if ( ! queryParams ) {
 		return { fieldsToStrip: queryParamFilterFields };
 	}
 
+	// All synced-field filters stay in the transient state, including ones with
+	// no value yet (a filter just added via the "Add filter" UI): they can't be
+	// expressed in the URL, but dropping them would dismiss the filter mid-edit.
+	const newTransientFilters =
+		newView.filters?.filter( ( filter ) => queryParamFilterFields.includes( filter.field ) ) ?? [];
+
 	const newQueryParams = { ...queryParams };
-	const newTransientFilters: Filter[] = [];
 	let filtersChanged = false;
 
 	queryParamFilterFields.forEach( ( field ) => {
@@ -291,11 +309,10 @@ function computeSyncedFiltersChanges( {
 		const serialized = filter ? serializeTransientFilterValue( filter ) : undefined;
 		const current = queryParams[ field ] === undefined ? undefined : String( queryParams[ field ] );
 
-		if ( filter === undefined || serialized === undefined ) {
+		if ( serialized === undefined ) {
 			delete newQueryParams[ field ];
 		} else {
 			newQueryParams[ field ] = serialized;
-			newTransientFilters.push( filter );
 		}
 
 		if ( serialized !== current ) {
@@ -303,25 +320,24 @@ function computeSyncedFiltersChanges( {
 		}
 	} );
 
+	const changes: UpdateViewChanges = { fieldsToStrip: queryParamFilterFields };
+
+	if ( ! fastDeepEqual( newTransientFilters, transientFilters ) ) {
+		changes.transientFilters = newTransientFilters;
+	}
+
 	const newTransientProperties = { page: newView.page, search: newView.search };
 	const propertiesChanged = ! fastDeepEqual( newTransientProperties, transientProperties );
 
-	if ( ! filtersChanged && ! propertiesChanged ) {
-		return { fieldsToStrip: queryParamFilterFields };
-	}
-
-	const changes: UpdateViewChanges = {
-		fieldsToStrip: queryParamFilterFields,
-		navigateSearch: mergeQueryParamsWithTransientProperties(
+	if ( filtersChanged || propertiesChanged ) {
+		changes.navigateSearch = mergeQueryParamsWithTransientProperties(
 			newQueryParams,
 			newTransientProperties
-		),
-		resetScroll: false,
-	};
-	if ( filtersChanged ) {
-		changes.transientFilters = newTransientFilters;
-		changes.replace = true;
+		);
+		changes.replace = filtersChanged ? true : undefined;
+		changes.resetScroll = false;
 	}
+
 	return changes;
 }
 

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -55,7 +55,6 @@ import {
 	canTransferSite,
 	canViewHundredYearPlanSettings,
 } from '../../sites/features';
-import { VALUES_SEVERITY } from '../../sites/logs/dataviews/constants';
 import { reauthRequiredLink } from '../../utils/link';
 import {
 	getActivityLogHiddenGroups,
@@ -324,20 +323,6 @@ export const siteLogsPhpRoute = createRoute( {
 	getParentRoute: () => siteLogsRoute,
 	path: 'php',
 	loader: loadSiteLogsRoute,
-	validateSearch: ( search ): { severity?: string } => {
-		// Accepts a comma-separated list, canonicalized case-insensitively.
-		// Tolerates '+'-encoded spaces, which decodeURIComponent (used by the
-		// router's search parser) leaves as-is.
-		const values = String( search.severity ?? '' )
-			.replace( /\+/g, ' ' )
-			.split( ',' )
-			.map( ( value ) =>
-				VALUES_SEVERITY.find( ( v ) => v.toLowerCase() === value.trim().toLowerCase() )
-			)
-			.filter( ( value ): value is ( typeof VALUES_SEVERITY )[ number ] => value !== undefined );
-		const severity = Array.from( new Set( values ) ).join( ',' );
-		return { severity: severity || undefined };
-	},
 } ).lazy( () =>
 	import( '../../sites/logs' ).then( ( d ) =>
 		createLazyRoute( 'site-logs-php' )( {

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -324,9 +324,16 @@ export const siteLogsPhpRoute = createRoute( {
 	getParentRoute: () => siteLogsRoute,
 	path: 'php',
 	loader: loadSiteLogsRoute,
-	validateSearch: ( search ): { severity?: ( typeof VALUES_SEVERITY )[ number ] } => ( {
-		severity: VALUES_SEVERITY.find( ( v ) => v === search.severity ),
-	} ),
+	validateSearch: ( search ): { severity?: string } => {
+		// Accepts a comma-separated list; tolerates '+'-encoded spaces, which
+		// decodeURIComponent (used by the router's search parser) leaves as-is.
+		const severity = String( search.severity ?? '' )
+			.replace( /\+/g, ' ' )
+			.split( ',' )
+			.filter( ( value ) => VALUES_SEVERITY.some( ( v ) => v === value ) )
+			.join( ',' );
+		return { severity: severity || undefined };
+	},
 } ).lazy( () =>
 	import( '../../sites/logs' ).then( ( d ) =>
 		createLazyRoute( 'site-logs-php' )( {

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -325,13 +325,17 @@ export const siteLogsPhpRoute = createRoute( {
 	path: 'php',
 	loader: loadSiteLogsRoute,
 	validateSearch: ( search ): { severity?: string } => {
-		// Accepts a comma-separated list; tolerates '+'-encoded spaces, which
-		// decodeURIComponent (used by the router's search parser) leaves as-is.
-		const severity = String( search.severity ?? '' )
+		// Accepts a comma-separated list, canonicalized case-insensitively.
+		// Tolerates '+'-encoded spaces, which decodeURIComponent (used by the
+		// router's search parser) leaves as-is.
+		const values = String( search.severity ?? '' )
 			.replace( /\+/g, ' ' )
 			.split( ',' )
-			.filter( ( value ) => VALUES_SEVERITY.some( ( v ) => v === value ) )
-			.join( ',' );
+			.map( ( value ) =>
+				VALUES_SEVERITY.find( ( v ) => v.toLowerCase() === value.trim().toLowerCase() )
+			)
+			.filter( ( value ): value is ( typeof VALUES_SEVERITY )[ number ] => value !== undefined );
+		const severity = Array.from( new Set( values ) ).join( ',' );
 		return { severity: severity || undefined };
 	},
 } ).lazy( () =>

--- a/client/dashboard/emails/test/index.test.tsx
+++ b/client/dashboard/emails/test/index.test.tsx
@@ -9,13 +9,14 @@ import { render } from '../../test-utils';
 import Emails from '../index';
 import type { DomainSummary, EmailAccount } from '@automattic/api-core';
 
+let mockEmailsSearch: Record< string, unknown > = {};
 jest.mock( '../../app/router/emails', () => {
 	const actual = jest.requireActual( '../../app/router/emails' );
 	return {
 		...actual,
 		emailsRoute: {
 			...actual.emailsRoute,
-			useSearch: () => ( {} ),
+			useSearch: () => mockEmailsSearch,
 		},
 	};
 } );
@@ -72,6 +73,44 @@ function mockApi( { domains, accounts }: { domains: DomainSummary[]; accounts: E
 }
 
 describe( '<Emails>', () => {
+	afterEach( () => {
+		mockEmailsSearch = {};
+	} );
+
+	test( 'applies the domain filter from the URL query params', async () => {
+		const OTHER_DOMAIN = 'other.example.com';
+		const otherDomain = {
+			...nonOwnedDomain,
+			domain: OTHER_DOMAIN,
+			blog_id: 2,
+			site_slug: OTHER_DOMAIN,
+		} as DomainSummary;
+		const otherAccount = {
+			...forwardingAccount,
+			domains: [ { domain: OTHER_DOMAIN, is_primary: true } ],
+			emails: [
+				{
+					mailbox: 'zzz',
+					domain: OTHER_DOMAIN,
+					target: 'someone-else@example.com',
+					email_type: 'email_forward',
+					role: 'standard',
+					warnings: [],
+				},
+			],
+		} as unknown as EmailAccount;
+
+		mockEmailsSearch = { domainName: DOMAIN };
+		mockApi( {
+			domains: [ nonOwnedDomain, otherDomain ],
+			accounts: [ forwardingAccount, otherAccount ],
+		} );
+		render( <Emails /> );
+
+		expect( await screen.findByText( `yea@${ DOMAIN }` ) ).toBeVisible();
+		expect( screen.queryByText( `zzz@${ OTHER_DOMAIN }` ) ).not.toBeInTheDocument();
+	} );
+
 	// DOTMSD-1477
 	test( 'lists forwards on a domain the user administers but does not own', async () => {
 		mockApi( { domains: [ nonOwnedDomain ], accounts: [ forwardingAccount ] } );

--- a/client/dashboard/me/billing-history/test/index.test.tsx
+++ b/client/dashboard/me/billing-history/test/index.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { screen, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { render } from '../../../test-utils';
@@ -105,6 +105,45 @@ function mockEndpoints( { siteList = sites }: { siteList?: Site[] } = {} ) {
 }
 
 describe( '<BillingHistory>', () => {
+	afterEach( () => {
+		window.history.replaceState( null, '', '/' );
+	} );
+
+	test( 'applies the site filter from the URL query params', async () => {
+		window.history.replaceState( null, '', '/?site=1' );
+		mockEndpoints();
+		render( <BillingHistory />, { user: testUser } );
+
+		const table = await screen.findByRole( 'table' );
+		await within( table ).findByText( 'Site A Personal Plan' );
+		expect( within( table ).queryByText( 'Site B Business Plan' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'writes the site filter to the URL query params', async () => {
+		mockEndpoints();
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.post( '/rest/v1.1/me/preferences' )
+			.reply( 200 );
+		const user = userEvent.setup();
+		const { router } = render( <BillingHistory />, { user: testUser } );
+
+		await screen.findByRole( 'table' );
+		await user.click( screen.getByRole( 'button', { name: 'Add filter' } ) );
+		await user.click( screen.getByRole( 'menuitem', { name: 'Site' } ) );
+		await user.click( await screen.findByRole( 'option', { name: /Site A/ } ) );
+
+		await waitFor( () => {
+			expect( router.state.location.search ).toEqual( { site: '1' } );
+		} );
+
+		const table = screen.getByRole( 'table' );
+		await waitFor( () => {
+			expect( within( table ).queryByText( 'Site B Business Plan' ) ).not.toBeInTheDocument();
+		} );
+		expect( within( table ).getByText( 'Site A Personal Plan' ) ).toBeVisible();
+	} );
+
 	test( 'shows receipts for every site', async () => {
 		mockEndpoints();
 		render( <BillingHistory />, { user: testUser } );

--- a/client/dashboard/sites/logs/dataviews/index.tsx
+++ b/client/dashboard/sites/logs/dataviews/index.tsx
@@ -76,6 +76,7 @@ function SiteLogsDataViews( {
 		defaultView: logType === LogType.PHP ? DEFAULT_PHP_LOGS_VIEW : DEFAULT_SERVER_LOGS_VIEW,
 		queryParams: search,
 		queryParamFilterFields: logType === LogType.PHP ? [ 'severity' ] : [],
+		syncFiltersToQueryParams: true,
 	} );
 
 	// Where DataViews' infinite scroll has advanced the window to. Deliberately

--- a/client/dashboard/sites/logs/dataviews/index.tsx
+++ b/client/dashboard/sites/logs/dataviews/index.tsx
@@ -24,6 +24,7 @@ import {
 	type ServerLogWithId,
 } from '../utils';
 import { useActions } from './actions';
+import { VALUES_SEVERITY } from './constants';
 import { useFields } from './fields';
 import {
 	DEFAULT_PER_PAGE,
@@ -63,9 +64,6 @@ function SiteLogsDataViews( {
 	const queryClient = useQueryClient();
 	const { recordTracksEvent } = useAnalytics();
 	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
-	// The validated route search (not the raw location search), so values
-	// canonicalized by `validateSearch` (e.g. severity casing) are what the
-	// filters and the URL sync consume.
 	const search = useSearch( { strict: false } );
 	const rafIdRef = useRef< number | null >( null );
 	const dataviewsRef = useRef< HTMLDivElement | null >( null );
@@ -77,8 +75,8 @@ function SiteLogsDataViews( {
 		slug: `site-logs-${ logType }`,
 		defaultView: logType === LogType.PHP ? DEFAULT_PHP_LOGS_VIEW : DEFAULT_SERVER_LOGS_VIEW,
 		queryParams: search,
-		queryParamFilterFields: logType === LogType.PHP ? [ 'severity' ] : [],
-		syncFiltersToQueryParams: true,
+		queryParamFilterFields:
+			logType === LogType.PHP ? [ { field: 'severity', values: VALUES_SEVERITY } ] : [],
 	} );
 
 	// Where DataViews' infinite scroll has advanced the window to. Deliberately

--- a/client/dashboard/sites/logs/dataviews/index.tsx
+++ b/client/dashboard/sites/logs/dataviews/index.tsx
@@ -1,7 +1,7 @@
 import { LogType, PHPLog, ServerLog, SiteLogsParams } from '@automattic/api-core';
 import { siteLogsInfiniteQuery } from '@automattic/api-queries';
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
-import { useRouter } from '@tanstack/react-router';
+import { useSearch } from '@tanstack/react-router';
 import { ToggleControl, Button, Spinner } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { View, Filter, Field } from '@wordpress/dataviews';
@@ -60,11 +60,13 @@ function SiteLogsDataViews( {
 	onAutoRefreshRequest,
 	site,
 }: SiteLogsDataViewsProps & { logType: typeof LogType.PHP | typeof LogType.SERVER } ) {
-	const router = useRouter();
 	const queryClient = useQueryClient();
 	const { recordTracksEvent } = useAnalytics();
 	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
-	const search = router.state.location.search;
+	// The validated route search (not the raw location search), so values
+	// canonicalized by `validateSearch` (e.g. severity casing) are what the
+	// filters and the URL sync consume.
+	const search = useSearch( { strict: false } );
 	const rafIdRef = useRef< number | null >( null );
 	const dataviewsRef = useRef< HTMLDivElement | null >( null );
 	const {

--- a/client/dashboard/sites/test/index.test.tsx
+++ b/client/dashboard/sites/test/index.test.tsx
@@ -53,6 +53,42 @@ describe( '<Sites>', () => {
 			.reply( 200, { calypso_preferences: {} } );
 	} );
 
+	afterEach( () => {
+		window.history.replaceState( null, '', '/' );
+	} );
+
+	test( 'applies the deleted-sites filter from the URL query params', async () => {
+		window.history.replaceState( null, '', '/?is_deleted=true' );
+
+		const deletedSitesRequest = nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.3/me/sites' )
+			.query( ( q ) => q.site_visibility === 'deleted' )
+			.reply( 200, {
+				sites: [
+					{
+						...mockSites[ 0 ],
+						ID: 99,
+						name: 'My Deleted Site',
+						slug: 'my-deleted-site.wordpress.com',
+						URL: 'https://my-deleted-site.wordpress.com',
+						is_deleted: true,
+					} as Site,
+				],
+				total: 1,
+			} );
+		mockSitesEndpoint( mockSites );
+
+		render( <Sites />, {
+			user: {
+				site_count: mockSites.length,
+			} as User,
+		} );
+
+		expect( await screen.findByText( 'My Deleted Site' ) ).toBeVisible();
+		expect( deletedSitesRequest.isDone() ).toBe( true );
+		expect( screen.queryByText( 'My First Site' ) ).not.toBeInTheDocument();
+	} );
+
 	test( 'renders Add new site button', async () => {
 		mockSitesEndpoint( mockSites );
 		render( <Sites />, {


### PR DESCRIPTION
## Proposed Changes

* DataViews filters declared via `usePersistentView`'s `queryParamFilterFields` now stay in sync with the URL: params apply the filter on load, and changing the filter in the UI updates the URL, so the current filtered view is always shareable by copying the address bar. This applies to all screens using the option: PHP logs `severity`, sites `is_deleted`, emails `domainName`, deployments `repository`, and billing purchases/history `site`.
* Synced fields are no longer stored in the persisted view preference — the URL is their single source of truth. The rest of the view (sort, columns, density…) persists as before.
* Params accept comma-separated lists (e.g. `?severity=Warning,Fatal error`). Fields can declare allowed values (`{ field: 'severity', values: VALUES_SEVERITY }`) and the hook canonicalizes params case-insensitively (`?severity=warning` works) and tolerates `+`-encoded spaces, which the router's search parser doesn't decode.
* Validation lives in the hook next to the field declaration, not in the router: the severity `validateSearch` was removed from the central route config, so new screens get synced, validated filters without touching the router.

## Why are these changes being made?

* Deep links like `?severity=Fatal error` already worked, but the URL never reflected filter changes made in the UI — changing the filter actually *removed* the param. Sharing a filtered view required hand-crafting the URL.
* Keeping a filter in both the URL and the persisted preference would create two competing sources of truth (stale bookmarks resurrecting old filters over newer preferences), so for synced fields the preference intentionally drops the filter and the URL wins.
* One behavior for every screen instead of an opt-in flag: an earlier revision gated this behind `syncFiltersToQueryParams`, but two permanent filter-semantics modes doubled the hook's complexity for no product reason. Single code path, applied everywhere.
* Filter changes use `history.replace`, so they don't pollute browser history.

## Testing Instructions

* Go to `/sites/<site>/logs/php` on a site with PHP logs.
* Change the severity filter — the URL should update to `?severity=…`, comma-separated when multiple values are selected. Clearing the filter removes the param. Adding a filter chip and picking values works without the chip disappearing.
* Reload the page — the filter from the URL should be applied. `?severity=warning`, `?severity=Fatal+error`, and `?severity=Fatal%20error` all work; invalid values are ignored.
* Verify the `from`/`to` date range params survive filter changes.
* Verify the severity filter is *not* restored from a previous session without the param in the URL (it is no longer part of the saved view preference), while sort/density/columns still are.
* Spot-check another synced screen (e.g. sites list "deleted" filter or billing purchases filtered by site): toggling the filter should write/remove its query param, and the param should apply the filter on load.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?