### PR TITLE
E2E: wait for either app shell after logging in

### DIFF
--- a/packages/calypso-e2e/src/lib/test-account.ts
+++ b/packages/calypso-e2e/src/lib/test-account.ts
@@ -83,8 +83,11 @@ export class TestAccount {
 	 *
 	 * `Promise.any` resolves on the first shell to appear and rejects only if both
 	 * fail, so a broken login still surfaces as a failure. Neither branch is gated
-	 * on the `load` event here: the dashboard branch settles as soon as its main
-	 * landmark is in the DOM, and the classic branch waits for `load` itself.
+	 * on the `load` event here: the dashboard branch settles as soon as its sidebar
+	 * is in the DOM, and the classic branch waits for `load` itself.
+	 *
+	 * The dashboard branch waits for `attached` rather than `visible` because the
+	 * sidebar is rendered off-canvas below the `medium` breakpoint.
 	 *
 	 * @param {Page} page Page object.
 	 */
@@ -92,7 +95,9 @@ export class TestAccount {
 		try {
 			await Promise.any( [
 				new SidebarComponent( page ).waitForSidebarInitialization(),
-				page.getByRole( 'main' ).waitFor( { timeout: 20 * 1000 } ),
+				page
+					.locator( '.dashboard-sidebar-navigator' )
+					.waitFor( { state: 'attached', timeout: 20 * 1000 } ),
 			] );
 		} catch {
 			throw new Error(

--- a/packages/calypso-e2e/src/lib/test-account.ts
+++ b/packages/calypso-e2e/src/lib/test-account.ts
@@ -82,13 +82,13 @@ export class TestAccount {
 	 * `SidebarComponent.navigate`.
 	 *
 	 * `Promise.any` resolves on the first shell to appear and rejects only if both
-	 * fail, so a broken login still surfaces as a failure.
+	 * fail, so a broken login still surfaces as a failure. Neither branch is gated
+	 * on the `load` event here: the dashboard branch settles as soon as its main
+	 * landmark is in the DOM, and the classic branch waits for `load` itself.
 	 *
 	 * @param {Page} page Page object.
 	 */
 	private static async waitForAppShell( page: Page ): Promise< void > {
-		await page.waitForLoadState( 'load', { timeout: 20 * 1000 } );
-
 		try {
 			await Promise.any( [
 				new SidebarComponent( page ).waitForSidebarInitialization(),

--- a/packages/calypso-e2e/src/lib/test-account.ts
+++ b/packages/calypso-e2e/src/lib/test-account.ts
@@ -73,21 +73,11 @@ export class TestAccount {
 	}
 
 	/**
-	 * Waits for whichever app shell the landing page rendered.
+	 * Waits for whichever app shell `/` rendered: rollout enrollment decides whether
+	 * an account lands in classic Calypso or the hosting dashboard.
 	 *
-	 * `/` serves classic Calypso or the hosting dashboard depending on the account's
-	 * rollout enrollment, so waiting on the classic sidebar alone strands every spec
-	 * whose account lands in the dashboard. Specs navigate to their own target after
-	 * this, and those driving the classic sidebar re-wait for it in
-	 * `SidebarComponent.navigate`.
-	 *
-	 * `Promise.any` resolves on the first shell to appear and rejects only if both
-	 * fail, so a broken login still surfaces as a failure. Neither branch is gated
-	 * on the `load` event here: the dashboard branch settles as soon as its sidebar
-	 * is in the DOM, and the classic branch waits for `load` itself.
-	 *
-	 * The dashboard branch waits for `attached` rather than `visible` because the
-	 * sidebar is rendered off-canvas below the `medium` breakpoint.
+	 * Waits for `attached` rather than `visible` because the dashboard sidebar is
+	 * rendered off-canvas below the `medium` breakpoint.
 	 *
 	 * @param {Page} page Page object.
 	 */

--- a/packages/calypso-e2e/src/lib/test-account.ts
+++ b/packages/calypso-e2e/src/lib/test-account.ts
@@ -68,8 +68,36 @@ export class TestAccount {
 			await page.waitForURL( url, { timeout: 20 * 1000 } );
 		}
 		if ( waitUntilStable ) {
-			const sidebarComponent = new SidebarComponent( page );
-			await sidebarComponent.waitForSidebarInitialization();
+			await TestAccount.waitForAppShell( page );
+		}
+	}
+
+	/**
+	 * Waits for whichever app shell the landing page rendered.
+	 *
+	 * `/` serves classic Calypso or the hosting dashboard depending on the account's
+	 * rollout enrollment, so waiting on the classic sidebar alone strands every spec
+	 * whose account lands in the dashboard. Specs navigate to their own target after
+	 * this, and those driving the classic sidebar re-wait for it in
+	 * `SidebarComponent.navigate`.
+	 *
+	 * `Promise.any` resolves on the first shell to appear and rejects only if both
+	 * fail, so a broken login still surfaces as a failure.
+	 *
+	 * @param {Page} page Page object.
+	 */
+	private static async waitForAppShell( page: Page ): Promise< void > {
+		await page.waitForLoadState( 'load', { timeout: 20 * 1000 } );
+
+		try {
+			await Promise.any( [
+				new SidebarComponent( page ).waitForSidebarInitialization(),
+				page.getByRole( 'main' ).waitFor( { timeout: 20 * 1000 } ),
+			] );
+		} catch {
+			throw new Error(
+				'Timed out waiting for an app shell: neither the classic Calypso sidebar nor the hosting dashboard rendered after logging in.'
+			);
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes

* Wait for whichever app shell the landing page rendered after logging in, instead of assuming classic Calypso.

`TestAccount.authenticate` ended by waiting for the classic Calypso sidebar. That encodes an assumption that `/` always serves classic Calypso. As the hosting dashboard rollout reaches every account, `/` serves the dashboard instead, the wait times out after 20s, and the spec fails before its first step. This affects every spec that authenticates with the default `waitUntilStable`, whatever it goes on to test.

`Promise.any` is used deliberately: it resolves on the first shell to appear and rejects only if both fail, so a genuinely broken login still surfaces as a failure. `Promise.race` would resolve on the first promise to *settle* — including a rejection — and would leak an unhandled rejection from the losing branch.

## Why are these changes being made?

The specs are not testing screens that went away. Classic Calypso still serves People, Stats, the plugin marketplace and Reader, and the dashboard links into several of them. The specs simply never get past the front door once their account lands in the dashboard.

Fixing the landing wait addresses that at the source. The alternative considered was overriding the rollout feature flag for the whole e2e run, which would pin CI to a configuration no real user has, and would need a separate mechanism for release runs against production (flag overrides are ignored there).

## Considerations

* Classic Calypso renders `main` before its sidebar finishes initialising, so for classic landings this wait can resolve marginally earlier than it used to. Specs that drive the classic sidebar re-wait for it in `SidebarComponent.navigate`, so the guarantee is preserved where it is actually needed — but this is the place to look if anything turns flaky.
* This does not fix the specs that reach their screen by clicking through the classic sidebar; those navigate from whichever shell they land in. They are handled in follow-ups.

## Testing Instructions

* Run the `@calypso-pr` suite against an environment where the rollout enrolls the test accounts, and confirm specs get past authentication.
* Confirm specs still pass where the accounts land in classic Calypso.

Verified locally: `yarn workspace @automattic/calypso-e2e build`, `yarn typecheck-packages`, `tsc --noEmit` over `test/e2e`, and lint all pass. The suite itself has not been run — that needs a live instance and the secrets file.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
