### PR TITLE
Jetpack AI sidebar: keep post-level suggestions in the empty view

### DIFF
--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -2302,6 +2302,28 @@ describe( 'useSuggestions', () => {
 		}
 	);
 
+	it( 'keeps post-level suggestions in the empty view only', () => {
+		installAiEditorialReviewData( { optimizeTitleSuggestion: true } );
+		installPostTypeMock( 'post' );
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		const latestCall = onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ];
+		expect( latestCall?.[ 0 ] ).toEqual( [] );
+		expect( latestCall?.[ 1 ] ).toBe( false );
+
+		const emptyViewLabels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
+		expect( emptyViewLabels ).toContain( 'Optimize Title' );
+		expect( emptyViewLabels ).toContain( 'Editorial Review' );
+
+		// The rendered event fires once per page load (module-level guard), so
+		// only the first render with the chip available can assert it — which is
+		// this test: every earlier test either selects a block or uses an
+		// unsupported post type.
+		expect( getTracksCalls( 'jetpack_ai_editorial_review_suggestion_rendered' ) ).toHaveLength( 1 );
+	} );
+
 	it( 'keeps selected-block suggestions on template entities', () => {
 		installAiEditorialReviewData();
 		mockCurrentPostType = 'wp_template';
@@ -2370,7 +2392,7 @@ describe( 'useSuggestions', () => {
 		] );
 	} );
 
-	it( 'shows editor-level suggestions after the selected-block chip is cleared', () => {
+	it( 'returns no suggestions after the selected-block chip is cleared', () => {
 		installAiEditorialReviewData();
 		const block = { clientId: 'b-clear', name: 'core/paragraph' };
 		mockSelectedBlock = block;
@@ -2393,10 +2415,7 @@ describe( 'useSuggestions', () => {
 
 		latestSuggestions =
 			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
-		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
-			'Simple Review',
-			'Editorial Review',
-		] );
+		expect( latestSuggestions ).toEqual( [] );
 	} );
 
 	it( 'tracks rendered image block transformation suggestions', () => {
@@ -2436,13 +2455,14 @@ describe( 'useSuggestions', () => {
 		expect( latestSuggestions ).toEqual( [] );
 	} );
 
-	it( 'shows review suggestions at post level regardless of the block transformations feature', () => {
+	it( 'keeps review suggestions in the empty view regardless of the block transformations feature', () => {
 		( globalThis as any ).agentsManagerData = {
 			jetpackAiSidebar: {
 				enabled: true,
 				features: { aiEditorialReview: true },
 			},
 		};
+		installPostTypeMock( 'post' );
 		mockSelectedBlock = null;
 		const onSuggestions = jest.fn();
 
@@ -2450,7 +2470,8 @@ describe( 'useSuggestions', () => {
 
 		const latestSuggestions =
 			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
-		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
+		expect( latestSuggestions ).toEqual( [] );
+		expect( getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label ) ).toEqual( [
 			'Editorial Review',
 		] );
 	} );
@@ -2633,7 +2654,7 @@ describe( 'useSuggestions', () => {
 		] );
 	} );
 
-	it( 're-shows editor suggestions when a generated title is applied', () => {
+	it( 'keeps hook suggestions empty at post level after a generated title is applied', () => {
 		installAiEditorialReviewData( { optimizeTitleSuggestion: true } );
 		const onSuggestions = jest.fn();
 
@@ -2657,9 +2678,7 @@ describe( 'useSuggestions', () => {
 
 		latestSuggestions =
 			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
-		expect(
-			latestSuggestions.map( ( suggestion: { label: string } ) => suggestion.label )
-		).toEqual( [ 'Optimize Title', 'Simple Review', 'Editorial Review' ] );
+		expect( latestSuggestions ).toEqual( [] );
 	} );
 
 	it( 'keeps block suggestions hidden after a Proofread request finishes', () => {

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -1158,6 +1158,10 @@ export const capabilities = {
  * Returns contextual suggestions based on the selected block type.
  * Hides after a suggestion is clicked, then restores suggestions after a
  * suggestion action completes.
+ *
+ * Post-level suggestions (Optimize Title, reviews, SEO) are not returned
+ * here — they surface through `getEmptyViewSuggestions`, so they render only
+ * while the chat and its input are empty.
  * @returns {Object} Object containing a suggestions array.
  */
 export function useSuggestions(
@@ -1240,21 +1244,11 @@ export function useSuggestions(
 	const editorContext = useSelect( ( select ) => {
 		const blockEditor = select( 'core/block-editor' ) as { getSelectedBlock?: () => any };
 		const editor = select( 'core/editor' ) as {
-			getCurrentPostId?: () => EditorPostId | null | undefined;
 			getCurrentPostType?: () => string | undefined;
 		};
-		const core = select( 'core' ) as {
-			getPostType?: ( name: string ) => { supports?: Record< string, boolean > } | undefined;
-		};
-		const postType = editor?.getCurrentPostType?.();
 		return {
 			selectedBlock: blockEditor?.getSelectedBlock?.() ?? null,
-			postId: normalizeEditorPostId( editor?.getCurrentPostId?.() ),
-			postType,
-			supportsExcerpt:
-				postType && isExcerptSuggestionEnabled()
-					? postTypeRecordSupportsExcerpt( postType, core?.getPostType?.( postType ) )
-					: false,
+			postType: editor?.getCurrentPostType?.(),
 		};
 	}, [] );
 
@@ -1265,15 +1259,6 @@ export function useSuggestions(
 	}, [ editorContext.selectedBlock?.clientId ] );
 
 	const selectedBlock = editorContext.selectedBlock;
-	const postLevelSuggestions = useMemo(
-		() =>
-			getPostLevelSuggestions(
-				editorContext.postType,
-				editorContext.postId,
-				editorContext.supportsExcerpt
-			),
-		[ editorContext.postId, editorContext.postType, editorContext.supportsExcerpt ]
-	);
 	const blockTransformationsEnabled = isBlockTransformationsEnabled();
 	const applicable = useMemo(
 		() =>
@@ -1293,29 +1278,14 @@ export function useSuggestions(
 			} ) ),
 		[ applicable ]
 	);
-	// Editor-level reviews (Optimize Title, Generate Feedback, AI Editorial Review)
-	// show only with no block selected; a selected block shows block transforms.
+	// Only block transforms are returned dynamically; post-level chips come
+	// from getEmptyViewSuggestions and render only in the chat's empty view.
 	const visibleSuggestions = useMemo( () => {
-		if ( hidden ) {
+		if ( hidden || ! selectedBlock ) {
 			return [];
 		}
-		// Both branches narrow to this shared shape; the explicit annotation lets
-		// the generic applySuggestionLimit infer a single element type across them.
-		const activeSuggestions: Array< {
-			id: string;
-			label: string;
-			prompt: string;
-			options?: SuggestionOption[];
-			action?: () => boolean | Promise< boolean >;
-		} > = selectedBlock ? blockTransformationSuggestions : postLevelSuggestions;
-		return applySuggestionLimit( activeSuggestions, maxSuggestions );
-	}, [
-		blockTransformationSuggestions,
-		hidden,
-		maxSuggestions,
-		postLevelSuggestions,
-		selectedBlock,
-	] );
+		return applySuggestionLimit( blockTransformationSuggestions, maxSuggestions );
+	}, [ blockTransformationSuggestions, hidden, maxSuggestions, selectedBlock ] );
 	const visibleSuggestionIds = useMemo(
 		() => new Set( visibleSuggestions.map( ( suggestion ) => suggestion.id ) ),
 		[ visibleSuggestions ]
@@ -1327,9 +1297,11 @@ export function useSuggestions(
 	const visibleBlockTransformationSuggestionsKey = visibleBlockTransformationSuggestions
 		.map( ( suggestion ) => suggestion.id )
 		.join( '|' );
-	const isAiEditorialReviewSuggestionVisible = visibleSuggestionIds.has(
-		AI_EDITORIAL_REVIEW_SUGGESTION.id
-	);
+	// The AI Editorial Review chip renders through the empty view, which is a
+	// plain function with no render signal, so the availability that puts the
+	// chip there is tracked from this hook instead.
+	const isAiEditorialReviewSuggestionAvailable =
+		! selectedBlock && isAiEditorialReviewAvailable( editorContext.postType );
 
 	useEffect( () => {
 		if ( editorContext.selectedBlock ) {
@@ -1338,11 +1310,11 @@ export function useSuggestions(
 	}, [ editorContext.selectedBlock?.clientId, editorContext.selectedBlock ] );
 
 	useEffect( () => {
-		if ( ! suggestionsVisible || hidden || ! isAiEditorialReviewSuggestionVisible ) {
+		if ( ! suggestionsVisible || hidden || ! isAiEditorialReviewSuggestionAvailable ) {
 			return;
 		}
 		trackAiEditorialReviewSuggestionRenderedOnce();
-	}, [ hidden, isAiEditorialReviewSuggestionVisible, suggestionsVisible ] );
+	}, [ hidden, isAiEditorialReviewSuggestionAvailable, suggestionsVisible ] );
 
 	useEffect( () => {
 		if (


### PR DESCRIPTION
Related to #113494

## Proposed Changes

* Jetpack AI's post-level chips (Optimize Title, reviews, SEO) now come only from `getEmptyViewSuggestions`; `useSuggestions` returns block transformations alone.

## Why are these changes being made?

* The chat renders empty-view chips only while the conversation and input are empty, so the post-level chips now clear while typing and mid-conversation, matching Big Sky's. Previously they also rode the dynamic channel and never went away.

## Testing Instructions

1. Sandbox `widgets.wp.com`, then `cd apps/agents-manager && yarn dev --sync`.
2. In the page editor's AI sidebar: post-level chips show in the empty chat, and disappear while typing or once a conversation starts.
3. Select a paragraph block: block chips still show and persist while typing.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
