### PR TITLE
E2E: reach Stats and plugin search by URL

### DIFF
--- a/test/e2e/specs/plugins/plugins__search.spec.ts
+++ b/test/e2e/specs/plugins/plugins__search.spec.ts
@@ -1,10 +1,4 @@
-import {
-	DataHelper,
-	PluginsPage,
-	SidebarComponent,
-	TestAccount,
-	envVariables,
-} from '@automattic/calypso-e2e';
+import { DataHelper, PluginsPage, TestAccount, envVariables } from '@automattic/calypso-e2e';
 import { skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 
 test.describe(
@@ -32,12 +26,11 @@ test.describe(
 			} );
 
 			await test.step( 'Navigate to the plugins page', async () => {
-				const sidebarComponent = new SidebarComponent( page );
-				await sidebarComponent.navigate( 'Plugins' );
+				pluginsPage = new PluginsPage( page );
+				await pluginsPage.visit( siteUrl );
 			} );
 
 			await test.step( 'Search for "woocommerce"', async () => {
-				pluginsPage = new PluginsPage( page );
 				await pluginsPage.search( 'woocommerce' );
 				await pluginsPage.validateExpectedSearchResultFound( 'WooCommerce' );
 			} );

--- a/test/e2e/specs/stats/stats.spec.ts
+++ b/test/e2e/specs/stats/stats.spec.ts
@@ -1,7 +1,6 @@
 import {
 	DataHelper,
 	StatsPage,
-	SidebarComponent,
 	TestAccount,
 	getTestAccountByFeature,
 	envToFeatureKey,
@@ -37,13 +36,7 @@ test.describe(
 			await test.step( 'Navigate to Stats', async () => {
 				statsPage = new StatsPage( page );
 
-				if ( envVariables.ATOMIC_VARIATION === 'ecomm-plan' ) {
-					return await statsPage.visit(
-						DataHelper.getAccountSiteURL( accountName, { protocol: false } )
-					);
-				}
-				const sidebarComponent = new SidebarComponent( page );
-				await sidebarComponent.navigate( 'Stats' );
+				await statsPage.visit( DataHelper.getAccountSiteURL( accountName, { protocol: false } ) );
 			} );
 
 			// Traffic


### PR DESCRIPTION
## Proposed Changes

* Navigate to Stats and to the plugin search page by URL instead of clicking through the classic Calypso sidebar.

## Why are these changes being made?

Both specs reached their screen by clicking the classic Calypso sidebar, so they depended on the account landing in classic Calypso. As the hosting dashboard rollout reaches every account, that is no longer where accounts land.

The sidebar is incidental to what either spec covers — neither asserts anything about navigation — and both page objects already expose a `visit` method, so they can go straight to the screen under test. The Stats spec already did exactly this on the `ecomm-plan` variation; that branch now covers every variation, which also removes a conditional.

Specs that deliberately exercise classic navigation are left alone and handled separately.

## Testing Instructions

* Run `specs/stats/stats.spec.ts` and `specs/plugins/plugins__search.spec.ts` and confirm they reach their screens and pass.

Verified locally: `tsc --noEmit` over `test/e2e`, Prettier and ESLint. The specs themselves have not been run — that needs a live instance and the secrets file.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
