### PR TITLE
E2E: reach the People page by URL in the invite specs

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -1,4 +1,5 @@
 import { Page, Locator } from 'playwright';
+import { getCalypsoURL } from '../../data-helper';
 import { clickNavTab } from '../../element-helper';
 
 export type PeoplePageTabs = 'Users' | 'Followers' | 'Email Followers' | 'Invites';
@@ -39,6 +40,15 @@ export class PeoplePage {
 	 */
 	getPage(): Page {
 		return this.page;
+	}
+
+	/**
+	 * Visits the Users > All Users page for a site.
+	 *
+	 * @param {string} siteSlug Site slug, without protocol.
+	 */
+	async visit( siteSlug: string ): Promise< void > {
+		await this.page.goto( getCalypsoURL( `people/team/${ siteSlug }` ) );
 	}
 
 	/**
@@ -205,7 +215,7 @@ export class PeoplePage {
 	 * the user in the team members list and clicking their profile link.
 	 *
 	 * Callers must navigate to the Users > All Users page before calling
-	 * this method (e.g. via componentSidebar.navigate).
+	 * this method (e.g. via `visit`).
 	 *
 	 * @param username Username of the team member.
 	 */

--- a/test/e2e/specs/users/invite__new-user.spec.ts
+++ b/test/e2e/specs/users/invite__new-user.spec.ts
@@ -36,19 +36,20 @@ test.describe(
 
 		test( 'As a WordPress.com user, I can invite a new user to my site, they can accept the invite and sign up, then I can remove them', async ( {
 			page,
-			componentSidebar,
 			clientEmail,
 			pageIncognito,
 			pagePeople,
 			pageAddPeople,
 			accountPreRelease,
 		} ) => {
+			const siteSlug = accountPreRelease.getSiteURL( { protocol: false } );
+
 			await test.step( 'Given I am logged in as a site owner', async function () {
 				await accountPreRelease.authenticate( page );
 			} );
 
 			await test.step( 'When I navigate to Users > All Users', async function () {
-				await componentSidebar.navigate( 'Users', 'All Users' );
+				await pagePeople.visit( siteSlug );
 			} );
 
 			await test.step( `And I invite a new user with role ${ role }`, async function () {
@@ -61,7 +62,7 @@ test.describe(
 			} );
 
 			await test.step( 'When I navigate to Users > All Users', async function () {
-				await componentSidebar.navigate( 'Users', 'All Users' );
+				await pagePeople.visit( siteSlug );
 				await pagePeople.clickViewAllIfAvailable();
 			} );
 
@@ -121,7 +122,7 @@ test.describe(
 			} );
 
 			await test.step( 'When I navigate back to Users > All Users', async function () {
-				await componentSidebar.navigate( 'Users', 'All Users' );
+				await pagePeople.visit( siteSlug );
 			} );
 
 			await test.step( 'Then I can see the invited user part of the team', async function () {

--- a/test/e2e/specs/users/invite__revoke.spec.ts
+++ b/test/e2e/specs/users/invite__revoke.spec.ts
@@ -84,12 +84,13 @@ test.describe.fixme(
 
 		test( 'As a site owner, I can revoke a pending invite so that the invitation link becomes invalid', async ( {
 			page,
-			componentSidebar,
 			clientEmail,
 			pageIncognito,
 			pagePeople,
 			accountDefaultUser,
 		} ) => {
+			const siteSlug = accountDefaultUser.getSiteURL( { protocol: false } );
+
 			await test.step( 'Given I create an invite via REST API', async function () {
 				const restAPIClient = new RestAPIClient( credentials );
 
@@ -121,7 +122,7 @@ test.describe.fixme(
 			} );
 
 			await test.step( 'When I navigate to Users > All Users', async function () {
-				await componentSidebar.navigate( 'Users', 'All Users' );
+				await pagePeople.visit( siteSlug );
 			} );
 
 			await test.step( 'Then I can see the invite is pending', async function () {


### PR DESCRIPTION
## Proposed Changes

* Navigate to Users > All Users by URL in the two invite specs, instead of clicking through the classic Calypso sidebar.
* Add `PeoplePage.visit`, the only page object involved that lacked one.

## Why are these changes being made?

Both specs reached the People page by clicking Users > All Users in the classic Calypso sidebar, so they depended on the account landing in classic Calypso. As the hosting dashboard rollout reaches every account, that is no longer where accounts land.

The sidebar is incidental to what these specs cover — they are about inviting, accepting and revoking — so they can go straight to the People page. The screen itself is unchanged and still served by classic Calypso at `/people/team/{site}`, which is the route `PeoplePage` already documents.

## Considerations

* `invite__revoke` is currently `test.describe.fixme` (muted since 2026-02-02 over an invites endpoint throttle, TESTOPS-232). It is updated here for consistency so it is not left behind on the old navigation, but it will not run until that mute is lifted.

## Testing Instructions

* Run `specs/users/invite__new-user.spec.ts` and confirm it reaches the People page and passes.

Verified locally: `yarn workspace @automattic/calypso-e2e build`, `tsc --noEmit` over `test/e2e`, Prettier and ESLint. The specs themselves have not been run — that needs a live instance and the secrets file.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
