### PR TITLE
E2E: stop the Appearance specs depending on the classic landing page

### DIFF
--- a/test/e2e/specs/appearance/theme__details-preview.spec.ts
+++ b/test/e2e/specs/appearance/theme__details-preview.spec.ts
@@ -7,7 +7,6 @@ test.describe(
 		test( 'As a gutenberg simple site user, I can preview a different theme on my site', async ( {
 			page,
 			accountGutenbergSimple,
-			componentSidebar,
 			componentSiteSelect,
 			pageThemes,
 			pageThemeDetails,
@@ -23,7 +22,7 @@ test.describe(
 			} );
 
 			await test.step( 'When I navigate to Appearance > Themes', async function () {
-				await componentSidebar.navigate( 'Appearance', 'Themes' );
+				await pageThemes.visitShowcase( testAccountSiteDomain );
 			} );
 
 			await test.step( `And I choose the test site ${ testAccountSiteDomain } if the site selector is shown`, async function () {

--- a/test/e2e/specs/fse/fse__temp-smoke-test.spec.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.spec.ts
@@ -65,6 +65,16 @@ test.describe(
 			await test.step( 'Authenticate and setup the test', async () => {
 				const testAccount = new TestAccount( accountName );
 				await testAccount.authenticate( page );
+
+				// This spec asserts on classic Calypso navigation, so it has to start from
+				// a classic Calypso page. `/` no longer serves one: the hosting dashboard
+				// rollout lands every account in the dashboard instead. My Home is where
+				// these accounts used to land, so it is the closest equivalent.
+				await page.goto(
+					DataHelper.getCalypsoURL(
+						`/home/${ DataHelper.getAccountSiteURL( accountName, { protocol: false } ) }`
+					)
+				);
 			} );
 
 			await test.step( 'Navigate to Full Site Editor', async () => {


### PR DESCRIPTION
## Proposed Changes

* `theme__details-preview`: visit the theme showcase directly instead of clicking through the classic Calypso sidebar.
* `fse__temp-smoke-test`: keep the sidebar click, but start from My Home rather than the landing page.

## Why are these changes being made?

Both specs reached their screen through the classic Calypso sidebar, so both depended on the account landing in classic Calypso. As the hosting dashboard rollout reaches every account, that is no longer where accounts land.

They need different fixes, because the sidebar means something different in each:

* The theme spec is about previewing a theme. Navigation is incidental, so it goes straight to the showcase — the same treatment as the other specs in this series.
* The site editor smoke test asserts on navigation. Its file comment says the goal is "to catch major breaks with the integration --- i.e. Calypso navigation no longer working", and the sidebar call is marked "Explicitly doing sidebar navigation to ensure Calypso navigation is intact." Replacing that with a direct URL would delete the thing it tests. So it keeps the click and instead starts from a classic Calypso page.

My Home was chosen as that starting page because it is where these accounts landed before the rollout — classic Calypso's root redirect sends users with edit permissions to `/home/{site}` — so it is the closest equivalent to what the spec used to get for free.

## Considerations

* This is the last of the specs that reached their screen through the classic sidebar. Together with #113501, #113503 and #113504, that covers the `@calypso-pr` specs affected by the rollout.
* The site editor spec now hardcodes an assumption that My Home is a classic Calypso page. If My Home later moves to the dashboard, this spec needs revisiting — it will fail loudly at the sidebar step rather than silently passing.

## Testing Instructions

* Run `specs/appearance/theme__details-preview.spec.ts` and `specs/fse/fse__temp-smoke-test.spec.ts` and confirm both reach their screens and pass.
* For the site editor spec in particular, confirm the sidebar renders on My Home so the Appearance > Editor click still exercises Calypso navigation.

Verified locally: `tsc --noEmit` over `test/e2e`, Prettier and ESLint. The specs themselves have not been run — that needs a live instance and the secrets file.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
