### PR TITLE
Atomic transfer: revive the dead latest-transfer poll

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/transfer-pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/transfer-pending/index.tsx
@@ -84,13 +84,13 @@ const TransferPending: React.FunctionComponent< Props > = ( props ) => {
 	// Redirect based on transfer status
 	const didRedirect = React.useRef( false );
 	React.useEffect( () => {
-		const retryOnError = () => {
+		const redirectWithNotice = ( message: string ) => {
 			if ( didRedirect.current ) {
 				return;
 			}
 
 			dispatch(
-				errorNotice( __( "Sorry, we couldn't process your transfer. Please try again later." ), {
+				errorNotice( message, {
 					id: 'atomic-transfer-error',
 					isPersistent: true,
 					displayOnNextPage: true,
@@ -111,9 +111,21 @@ const TransferPending: React.FunctionComponent< Props > = ( props ) => {
 			}
 
 			// If the processing status indicates that there was something wrong.
-			if ( transferStates.ERROR === transfer.status ) {
+			if ( [ transferStates.ERROR, transferStates.REVERTED ].includes( transfer.status ) ) {
 				// Redirect users back to the stats page so they can try again.
-				retryOnError();
+				redirectWithNotice(
+					__( "Sorry, we couldn't process your transfer. Please try again later." )
+				);
+
+				return;
+			}
+
+			if ( transferStates.CLIENT_TIMEOUT === transfer.status ) {
+				redirectWithNotice(
+					__(
+						'Your transfer is taking longer than expected. It may still finish — reload the page to check.'
+					)
+				);
 
 				return;
 			}

--- a/client/my-sites/checkout/checkout-thank-you/transfer-pending/test/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/transfer-pending/test/index.tsx
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from '@testing-library/react';
+import { transferStates } from 'calypso/state/atomic-transfer/constants';
+import TransferPending from '..';
+
+const mockDispatch = jest.fn();
+const mockPage = jest.fn();
+let mockTransfer: { status?: string } = {};
+
+jest.mock( '@automattic/calypso-router', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockPage( ...args ),
+} ) );
+
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => mockDispatch,
+	useSelector: ( selector: ( state: object ) => unknown ) => selector( {} ),
+} ) );
+
+jest.mock( 'calypso/state/selectors/get-atomic-transfer', () => ( {
+	__esModule: true,
+	default: () => mockTransfer,
+} ) );
+
+jest.mock( 'calypso/state/sites/selectors', () => ( {
+	getSiteSlug: () => 'example.wordpress.com',
+} ) );
+
+jest.mock( '@wordpress/react-i18n', () => ( {
+	useI18n: () => ( { __: ( text: string ) => text } ),
+} ) );
+
+jest.mock( 'calypso/components/loading', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+jest.mock( 'calypso/lib/analytics/wait-heartbeat', () => ( {
+	useWaitHeartbeat: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/interval', () => ( {
+	useInterval: jest.fn(),
+} ) );
+
+describe( 'TransferPending', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockTransfer = {};
+	} );
+
+	test.each( [ transferStates.ERROR, transferStates.REVERTED ] )(
+		'redirects status %s to stats with a failure notice',
+		( status ) => {
+			mockTransfer = { status };
+
+			render( <TransferPending siteId={ 123 } orderId={ 456 } /> );
+
+			expect( mockDispatch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					notice: expect.objectContaining( {
+						text: "Sorry, we couldn't process your transfer. Please try again later.",
+					} ),
+				} )
+			);
+			expect( mockPage ).toHaveBeenCalledWith( '/stats/example.wordpress.com' );
+		}
+	);
+
+	test( 'redirects timed out transfers to stats with a timeout notice', () => {
+		mockTransfer = { status: transferStates.CLIENT_TIMEOUT };
+
+		render( <TransferPending siteId={ 123 } orderId={ 456 } /> );
+
+		expect( mockDispatch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				notice: expect.objectContaining( {
+					text: 'Your transfer is taking longer than expected. It may still finish — reload the page to check.',
+				} ),
+			} )
+		);
+		expect( mockPage ).toHaveBeenCalledWith( '/stats/example.wordpress.com' );
+	} );
+
+	test( 'redirects completed transfers to thank you', () => {
+		mockTransfer = { status: transferStates.COMPLETED };
+
+		render( <TransferPending siteId={ 123 } orderId={ 456 } /> );
+
+		expect( mockPage ).toHaveBeenCalledWith( '/checkout/thank-you/example.wordpress.com/456' );
+		expect( mockDispatch ).not.toHaveBeenCalledWith(
+			expect.objectContaining( { notice: expect.anything() } )
+		);
+	} );
+
+	test( 'keeps waiting for an in-progress transfer', () => {
+		mockTransfer = { status: transferStates.ACTIVE };
+
+		render( <TransferPending siteId={ 123 } orderId={ 456 } /> );
+
+		expect( mockPage ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/state/atomic-transfer/README.md
+++ b/client/state/atomic-transfer/README.md
@@ -20,11 +20,12 @@ The status of an automated transfer represents where in the transfer process a g
 The highest-level values of the status are _has never attempted to transfer_, _is transferring_, and _has transferred_.
 However, inside of _is transferring_ there are many sub-states that are more granular in the process tracking.
 
-|   status    | meaning                                                        |
-| :---------: | -------------------------------------------------------------- |
-|  `PENDING`  | A Transfer record was created but the transfer has not started |
-|  `ACTIVE`   | A transfer is in progress                                      |
-| `COMPLETED` | The transfer has completed and the Atomic site is ready        |
-|   `ERROR`   | The transfer failed                                            |
-| `REVERTED`  | The transfer was reverted                                      |
-|  _falsey_   | No information about any transfers exists in Calypso           |
+|      status      | meaning                                                                                |
+| :--------------: | -------------------------------------------------------------------------------------- |
+|    `PENDING`     | A Transfer record was created but the transfer has not started                         |
+|     `ACTIVE`     | A transfer is in progress                                                              |
+|   `COMPLETED`    | The transfer has completed and the Atomic site is ready                                |
+|     `ERROR`      | The transfer failed                                                                    |
+|    `REVERTED`    | The transfer was reverted                                                              |
+| `CLIENT_TIMEOUT` | The client stopped waiting after five minutes; transfer may still finish on the server |
+|     _falsey_     | No information about any transfers exists in Calypso                                   |

--- a/client/state/atomic-transfer/constants.js
+++ b/client/state/atomic-transfer/constants.js
@@ -4,5 +4,6 @@ export const transferStates = {
 	COMPLETED: 'completed',
 	ERROR: 'error',
 	REVERTED: 'reverted',
+	CLIENT_TIMEOUT: 'client_timeout',
 	PROVISIONED: 'provisioned',
 };

--- a/client/state/data-layer/wpcom/sites/transfers/latest.js
+++ b/client/state/data-layer/wpcom/sites/transfers/latest.js
@@ -6,7 +6,115 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { requestSite } from 'calypso/state/sites/actions';
 
-export const requestTransfer = ( action ) =>
+export const TRANSFER_POLL_DEADLINE_MS = 5 * 60 * 1000;
+
+const POLL_INTERVAL_MS = 10000;
+const MISSING_RECORD_ATTEMPTS = 6;
+
+const settledStates = [ transferStates.COMPLETED, transferStates.ERROR, transferStates.REVERTED ];
+
+const pollDeadlines = new Map();
+
+const clearTimers = ( entry ) => {
+	if ( entry?.timerId ) {
+		clearTimeout( entry.timerId );
+	}
+
+	if ( entry?.deadlineTimerId ) {
+		clearTimeout( entry.deadlineTimerId );
+	}
+};
+
+const clearPollDeadline = ( siteId ) => {
+	clearTimers( pollDeadlines.get( siteId ) );
+	pollDeadlines.delete( siteId );
+};
+
+export const clearPollDeadlines = () => {
+	for ( const siteId of [ ...pollDeadlines.keys() ] ) {
+		clearPollDeadline( siteId );
+	}
+};
+
+const getPollDeadline = ( siteId ) => {
+	const stored = pollDeadlines.get( siteId );
+
+	// Keep timeout state sticky for one extra deadline so duplicate fetches cannot restart the wait.
+	// Clear it after that window to bound memory while allowing a later, intentional fetch to start fresh.
+	if ( stored && Date.now() - stored.deadline > TRANSFER_POLL_DEADLINE_MS ) {
+		clearPollDeadline( siteId );
+		return undefined;
+	}
+
+	return stored;
+};
+
+const scheduleTransferPoll = ( siteId, dispatch ) => {
+	const stored = pollDeadlines.get( siteId );
+	if ( stored?.timerId ) {
+		clearTimeout( stored.timerId );
+	}
+
+	const timerId = setTimeout( () => dispatch( fetchAtomicTransfer( siteId ) ), POLL_INTERVAL_MS );
+	pollDeadlines.set( siteId, { ...stored, timerId } );
+};
+
+const setTransferTimeout = ( siteId, dispatch, transfer = {} ) => {
+	const stored = pollDeadlines.get( siteId );
+	clearTimers( stored );
+	pollDeadlines.set( siteId, {
+		...stored,
+		deadline: stored?.deadline ?? Date.now(),
+		hasTimedOut: true,
+		timerId: undefined,
+		deadlineTimerId: undefined,
+	} );
+
+	dispatch(
+		setAtomicTransfer( siteId, {
+			...transfer,
+			status: transferStates.CLIENT_TIMEOUT,
+		} )
+	);
+};
+
+// The deadline is otherwise only checked when a response arrives. A request that never settles —
+// a stalled connection, a tab the browser froze — produces no response at all, so without an
+// absolute timer the wait would outlive its deadline in exactly the case it exists to catch.
+const armDeadlineTimer = ( siteId, dispatch ) => {
+	const stored = getPollDeadline( siteId );
+
+	if ( stored?.hasTimedOut || stored?.deadlineTimerId ) {
+		return;
+	}
+
+	const deadline = stored?.deadline ?? Date.now() + TRANSFER_POLL_DEADLINE_MS;
+	const deadlineTimerId = setTimeout(
+		() => setTransferTimeout( siteId, dispatch ),
+		Math.max( 0, deadline - Date.now() )
+	);
+
+	pollDeadlines.set( siteId, { ...stored, deadline, deadlineTimerId } );
+};
+
+export const armTransferDeadline = ( siteId ) => ( dispatch ) =>
+	armDeadlineTimer( siteId, dispatch );
+
+const pollOrTimeout = ( siteId, dispatch ) => {
+	const stored = getPollDeadline( siteId );
+	const deadline = stored?.deadline ?? Date.now() + TRANSFER_POLL_DEADLINE_MS;
+
+	if ( stored?.hasTimedOut || Date.now() >= deadline ) {
+		setTransferTimeout( siteId, dispatch );
+		return;
+	}
+
+	pollDeadlines.set( siteId, { ...stored, deadline } );
+	scheduleTransferPoll( siteId, dispatch );
+};
+
+export const requestTransfer = ( action ) => [
+	// Keep default exponential backoff for transient failures; onTransferError handles terminal cases.
 	http(
 		{
 			method: 'GET',
@@ -14,16 +122,52 @@ export const requestTransfer = ( action ) =>
 			apiVersion: '1.2',
 		},
 		action
-	);
+	),
+	armTransferDeadline( action.siteId ),
+];
 
 export const receiveTransfer =
 	( { siteId }, transfer ) =>
 	( dispatch ) => {
+		if ( ! transfer?.status ) {
+			pollOrTimeout( siteId, dispatch );
+			return;
+		}
+
+		const stored = getPollDeadline( siteId );
+		const transferId = transfer.atomic_transfer_id;
+		const recorded =
+			stored && ( stored.transferId === transferId || stored.transferId === undefined )
+				? stored
+				: undefined;
+		const status = transfer.status;
+		const isSettled = settledStates.includes( status );
+
+		if ( recorded?.hasTimedOut && ! isSettled ) {
+			setTransferTimeout( siteId, dispatch, transfer );
+			return;
+		}
+
 		dispatch( setAtomicTransfer( siteId, transfer ) );
 
-		const status = transfer.status;
-		if ( status !== transferStates.ERROR && status !== transferStates.COMPLETED ) {
-			setTimeout( () => dispatch( fetchAtomicTransfer( siteId ) ), 10000 );
+		if ( isSettled ) {
+			clearPollDeadline( siteId );
+		} else {
+			if ( ! recorded ) {
+				// A different transfer is under way: drop the previous wait's deadline, timers and
+				// timeout flag instead of inheriting them.
+				clearPollDeadline( siteId );
+			}
+
+			const deadline = recorded?.deadline ?? Date.now() + TRANSFER_POLL_DEADLINE_MS;
+
+			if ( Date.now() < deadline ) {
+				pollDeadlines.set( siteId, { ...pollDeadlines.get( siteId ), transferId, deadline } );
+				scheduleTransferPoll( siteId, dispatch );
+			} else {
+				pollDeadlines.set( siteId, { ...pollDeadlines.get( siteId ), transferId, deadline } );
+				setTransferTimeout( siteId, dispatch, transfer );
+			}
 		}
 
 		if ( status === transferStates.COMPLETED ) {
@@ -32,12 +176,42 @@ export const receiveTransfer =
 		}
 	};
 
+export const onTransferError =
+	( { siteId }, error ) =>
+	( dispatch ) => {
+		const statusCode = error?.status ?? error?.statusCode;
+		const isMissingRecord =
+			error?.error === 'no_transfer_record' || error?.code === 'no_transfer_record';
+
+		if ( ( statusCode >= 400 && statusCode < 500 ) || isMissingRecord ) {
+			if ( isMissingRecord ) {
+				const stored = getPollDeadline( siteId );
+				const missingRecordAttempts = ( stored?.missingRecordAttempts ?? 0 ) + 1;
+
+				// The record is written moments after the purchase, so a few short retries recover the
+				// common race; beyond that the client cannot tell the difference from a transfer that
+				// was never started, and waiting on it is what traps the user.
+				if ( missingRecordAttempts < MISSING_RECORD_ATTEMPTS ) {
+					const deadline = stored?.deadline ?? Date.now() + TRANSFER_POLL_DEADLINE_MS;
+					pollDeadlines.set( siteId, { ...stored, deadline, missingRecordAttempts } );
+					scheduleTransferPoll( siteId, dispatch );
+					return;
+				}
+			}
+
+			setTransferTimeout( siteId, dispatch );
+			return;
+		}
+
+		pollOrTimeout( siteId, dispatch );
+	};
+
 registerHandlers( 'state/data-layer/wpcom/sites/atomic/transfer/index.js', {
 	[ ATOMIC_TRANSFER_REQUEST ]: [
 		dispatchRequest( {
 			fetch: requestTransfer,
 			onSuccess: receiveTransfer,
-			onError: () => {},
+			onError: onTransferError,
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/sites/transfers/latest.js
+++ b/client/state/data-layer/wpcom/sites/transfers/latest.js
@@ -4,6 +4,7 @@ import { transferStates } from 'calypso/state/atomic-transfer/constants';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
+import getAtomicTransfer from 'calypso/state/selectors/get-atomic-transfer';
 import { requestSite } from 'calypso/state/sites/actions';
 
 export const TRANSFER_POLL_DEADLINE_MS = 5 * 60 * 1000;
@@ -13,108 +14,55 @@ const MISSING_RECORD_ATTEMPTS = 6;
 
 const settledStates = [ transferStates.COMPLETED, transferStates.ERROR, transferStates.REVERTED ];
 
-const pollDeadlines = new Map();
+// Timers only. The verdict of a wait lives in the store, as CLIENT_TIMEOUT on the site's transfer.
+const waits = new Map();
 
-const clearTimers = ( entry ) => {
-	if ( entry?.timerId ) {
-		clearTimeout( entry.timerId );
-	}
+const stopWait = ( siteId ) => {
+	const wait = waits.get( siteId );
 
-	if ( entry?.deadlineTimerId ) {
-		clearTimeout( entry.deadlineTimerId );
-	}
+	clearTimeout( wait?.pollTimerId );
+	clearTimeout( wait?.deadlineTimerId );
+	waits.delete( siteId );
 };
 
-const clearPollDeadline = ( siteId ) => {
-	clearTimers( pollDeadlines.get( siteId ) );
-	pollDeadlines.delete( siteId );
-};
-
-export const clearPollDeadlines = () => {
-	for ( const siteId of [ ...pollDeadlines.keys() ] ) {
-		clearPollDeadline( siteId );
+export const clearTransferWaits = () => {
+	for ( const siteId of [ ...waits.keys() ] ) {
+		stopWait( siteId );
 	}
 };
 
-const getPollDeadline = ( siteId ) => {
-	const stored = pollDeadlines.get( siteId );
+const schedulePoll = ( siteId, dispatch ) => {
+	const wait = waits.get( siteId );
 
-	// Keep timeout state sticky for one extra deadline so duplicate fetches cannot restart the wait.
-	// Clear it after that window to bound memory while allowing a later, intentional fetch to start fresh.
-	if ( stored && Date.now() - stored.deadline > TRANSFER_POLL_DEADLINE_MS ) {
-		clearPollDeadline( siteId );
-		return undefined;
-	}
-
-	return stored;
-};
-
-const scheduleTransferPoll = ( siteId, dispatch ) => {
-	const stored = pollDeadlines.get( siteId );
-	if ( stored?.timerId ) {
-		clearTimeout( stored.timerId );
-	}
-
-	const timerId = setTimeout( () => dispatch( fetchAtomicTransfer( siteId ) ), POLL_INTERVAL_MS );
-	pollDeadlines.set( siteId, { ...stored, timerId } );
-};
-
-const setTransferTimeout = ( siteId, dispatch, transfer = {} ) => {
-	const stored = pollDeadlines.get( siteId );
-	clearTimers( stored );
-	pollDeadlines.set( siteId, {
-		...stored,
-		deadline: stored?.deadline ?? Date.now(),
-		hasTimedOut: true,
-		timerId: undefined,
-		deadlineTimerId: undefined,
+	clearTimeout( wait?.pollTimerId );
+	waits.set( siteId, {
+		...wait,
+		pollTimerId: setTimeout( () => dispatch( fetchAtomicTransfer( siteId ) ), POLL_INTERVAL_MS ),
 	} );
+};
 
-	dispatch(
-		setAtomicTransfer( siteId, {
-			...transfer,
-			status: transferStates.CLIENT_TIMEOUT,
-		} )
+const giveUp = ( siteId, dispatch, transfer = {} ) => {
+	stopWait( siteId );
+	dispatch( setAtomicTransfer( siteId, { ...transfer, status: transferStates.CLIENT_TIMEOUT } ) );
+};
+
+// Two consumers poll the same site, and a response can arrive after we stopped waiting, so every
+// entry point asks the store first: a wait that already ended in a timeout must not revive the
+// progress bar. A response carrying a different transfer means a new wait, which may proceed.
+const gaveUp = ( getState, siteId, transferId ) => {
+	const stored = getAtomicTransfer( getState(), siteId );
+
+	return (
+		stored.status === transferStates.CLIENT_TIMEOUT &&
+		( transferId === undefined || stored.atomic_transfer_id === transferId )
 	);
 };
 
-// The deadline is otherwise only checked when a response arrives. A request that never settles —
-// a stalled connection, a tab the browser froze — produces no response at all, so without an
-// absolute timer the wait would outlive its deadline in exactly the case it exists to catch.
-const armDeadlineTimer = ( siteId, dispatch ) => {
-	const stored = getPollDeadline( siteId );
-
-	if ( stored?.hasTimedOut || stored?.deadlineTimerId ) {
-		return;
-	}
-
-	const deadline = stored?.deadline ?? Date.now() + TRANSFER_POLL_DEADLINE_MS;
-	const deadlineTimerId = setTimeout(
-		() => setTransferTimeout( siteId, dispatch ),
-		Math.max( 0, deadline - Date.now() )
-	);
-
-	pollDeadlines.set( siteId, { ...stored, deadline, deadlineTimerId } );
-};
-
-export const armTransferDeadline = ( siteId ) => ( dispatch ) =>
-	armDeadlineTimer( siteId, dispatch );
-
-const pollOrTimeout = ( siteId, dispatch ) => {
-	const stored = getPollDeadline( siteId );
-	const deadline = stored?.deadline ?? Date.now() + TRANSFER_POLL_DEADLINE_MS;
-
-	if ( stored?.hasTimedOut || Date.now() >= deadline ) {
-		setTransferTimeout( siteId, dispatch );
-		return;
-	}
-
-	pollDeadlines.set( siteId, { ...stored, deadline } );
-	scheduleTransferPoll( siteId, dispatch );
-};
+const keepWaiting = ( siteId, dispatch, getState ) =>
+	gaveUp( getState, siteId ) ? giveUp( siteId, dispatch ) : schedulePoll( siteId, dispatch );
 
 export const requestTransfer = ( action ) => [
-	// Keep default exponential backoff for transient failures; onTransferError handles terminal cases.
+	// Keep the default exponential backoff for transient failures; onTransferError handles the rest.
 	http(
 		{
 			method: 'GET',
@@ -123,51 +71,45 @@ export const requestTransfer = ( action ) => [
 		},
 		action
 	),
-	armTransferDeadline( action.siteId ),
+	// Responses are the only other thing that ends a wait, so a request that never answers — a
+	// stalled connection, a frozen tab — would wait forever without this. One timer per wait: a
+	// second request joins the deadline already running instead of opening a new one.
+	( dispatch, getState ) => {
+		if ( waits.get( action.siteId )?.deadlineTimerId || gaveUp( getState, action.siteId ) ) {
+			return;
+		}
+
+		waits.set( action.siteId, {
+			...waits.get( action.siteId ),
+			deadlineTimerId: setTimeout(
+				() => giveUp( action.siteId, dispatch ),
+				TRANSFER_POLL_DEADLINE_MS
+			),
+		} );
+	},
 ];
 
 export const receiveTransfer =
 	( { siteId }, transfer ) =>
-	( dispatch ) => {
-		if ( ! transfer?.status ) {
-			pollOrTimeout( siteId, dispatch );
+	( dispatch, getState ) => {
+		const status = transfer?.status;
+
+		if ( ! status ) {
+			keepWaiting( siteId, dispatch, getState );
 			return;
 		}
 
-		const stored = getPollDeadline( siteId );
-		const transferId = transfer.atomic_transfer_id;
-		const recorded =
-			stored && ( stored.transferId === transferId || stored.transferId === undefined )
-				? stored
-				: undefined;
-		const status = transfer.status;
-		const isSettled = settledStates.includes( status );
-
-		if ( recorded?.hasTimedOut && ! isSettled ) {
-			setTransferTimeout( siteId, dispatch, transfer );
+		if ( gaveUp( getState, siteId, transfer.atomic_transfer_id ) ) {
+			giveUp( siteId, dispatch, transfer );
 			return;
 		}
 
 		dispatch( setAtomicTransfer( siteId, transfer ) );
 
-		if ( isSettled ) {
-			clearPollDeadline( siteId );
+		if ( settledStates.includes( status ) ) {
+			stopWait( siteId );
 		} else {
-			if ( ! recorded ) {
-				// A different transfer is under way: drop the previous wait's deadline, timers and
-				// timeout flag instead of inheriting them.
-				clearPollDeadline( siteId );
-			}
-
-			const deadline = recorded?.deadline ?? Date.now() + TRANSFER_POLL_DEADLINE_MS;
-
-			if ( Date.now() < deadline ) {
-				pollDeadlines.set( siteId, { ...pollDeadlines.get( siteId ), transferId, deadline } );
-				scheduleTransferPoll( siteId, dispatch );
-			} else {
-				pollDeadlines.set( siteId, { ...pollDeadlines.get( siteId ), transferId, deadline } );
-				setTransferTimeout( siteId, dispatch, transfer );
-			}
+			schedulePoll( siteId, dispatch );
 		}
 
 		if ( status === transferStates.COMPLETED ) {
@@ -178,32 +120,32 @@ export const receiveTransfer =
 
 export const onTransferError =
 	( { siteId }, error ) =>
-	( dispatch ) => {
+	( dispatch, getState ) => {
 		const statusCode = error?.status ?? error?.statusCode;
 		const isMissingRecord =
 			error?.error === 'no_transfer_record' || error?.code === 'no_transfer_record';
 
 		if ( ( statusCode >= 400 && statusCode < 500 ) || isMissingRecord ) {
-			if ( isMissingRecord ) {
-				const stored = getPollDeadline( siteId );
-				const missingRecordAttempts = ( stored?.missingRecordAttempts ?? 0 ) + 1;
+			const attempts = ( waits.get( siteId )?.missingRecordAttempts ?? 0 ) + 1;
 
-				// The record is written moments after the purchase, so a few short retries recover the
-				// common race; beyond that the client cannot tell the difference from a transfer that
-				// was never started, and waiting on it is what traps the user.
-				if ( missingRecordAttempts < MISSING_RECORD_ATTEMPTS ) {
-					const deadline = stored?.deadline ?? Date.now() + TRANSFER_POLL_DEADLINE_MS;
-					pollDeadlines.set( siteId, { ...stored, deadline, missingRecordAttempts } );
-					scheduleTransferPoll( siteId, dispatch );
-					return;
-				}
+			// The record is written moments after the purchase, so a few short retries recover the
+			// common race; beyond that the client cannot tell the difference from a transfer that was
+			// never started, and waiting on it is what traps the user.
+			if ( isMissingRecord && attempts < MISSING_RECORD_ATTEMPTS ) {
+				waits.set( siteId, { ...waits.get( siteId ), missingRecordAttempts: attempts } );
+				schedulePoll( siteId, dispatch );
+				return;
 			}
 
-			setTransferTimeout( siteId, dispatch );
+			// The remaining 4xx cases (a failed capability check, a blog we cannot validate) say the
+			// client cannot read the status, not that the transfer failed — it runs server-side either
+			// way. Hence the timeout status, whose copy says the transfer may still finish, rather than
+			// an error claiming it did not.
+			giveUp( siteId, dispatch );
 			return;
 		}
 
-		pollOrTimeout( siteId, dispatch );
+		keepWaiting( siteId, dispatch, getState );
 	};
 
 registerHandlers( 'state/data-layer/wpcom/sites/atomic/transfer/index.js', {

--- a/client/state/data-layer/wpcom/sites/transfers/test/latest.js
+++ b/client/state/data-layer/wpcom/sites/transfers/test/latest.js
@@ -3,7 +3,7 @@ import { transferStates } from 'calypso/state/atomic-transfer/constants';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { requestSite } from 'calypso/state/sites/actions';
 import {
-	clearPollDeadlines,
+	clearTransferWaits,
 	onTransferError,
 	receiveTransfer,
 	requestTransfer,
@@ -18,8 +18,7 @@ jest.mock( 'calypso/state/sites/actions', () => ( {
 } ) );
 
 const siteId = 1916284;
-const start = 1000000;
-let setTimeoutSpy;
+const POLL_INTERVAL_MS = 10000;
 
 const transfer = ( status, atomicTransferId = 1 ) => ( {
 	atomic_transfer_id: atomicTransferId,
@@ -28,17 +27,49 @@ const transfer = ( status, atomicTransferId = 1 ) => ( {
 	created_at: '2026-08-11T18:00:00Z',
 } );
 
+const timedOut = ( transferData = {} ) =>
+	setAtomicTransfer( siteId, { ...transferData, status: transferStates.CLIENT_TIMEOUT } );
+
+// The handlers read the transfer back out of the store, so the fake one applies what they dispatch
+// the same way the reducer does.
+const createStore = () => {
+	const state = { atomicTransfer: {} };
+	const getState = () => state;
+	const dispatch = jest.fn( ( action ) => {
+		if ( action?.type === setAtomicTransfer( siteId, {} ).type ) {
+			state.atomicTransfer[ action.siteId ] = {
+				...state.atomicTransfer[ action.siteId ],
+				...action.transfer,
+			};
+		}
+
+		return action;
+	} );
+
+	return { dispatch, getState };
+};
+
+// Every response follows a request, so tests arm the deadline the way production arms it.
+const startWait = ( { dispatch, getState } ) =>
+	requestTransfer( { siteId } )[ 1 ]( dispatch, getState );
+
+const receive = ( store, transferData ) =>
+	receiveTransfer( { siteId }, transferData )( store.dispatch, store.getState );
+
+const fail = ( store, error ) =>
+	onTransferError( { siteId }, error )( store.dispatch, store.getState );
+
+beforeEach( () => {
+	jest.useFakeTimers();
+	jest.clearAllMocks();
+	clearTransferWaits();
+} );
+
+afterEach( () => {
+	jest.useRealTimers();
+} );
+
 describe( 'requestTransfer', () => {
-	beforeEach( () => {
-		jest.useFakeTimers();
-		jest.setSystemTime( start );
-		clearPollDeadlines();
-	} );
-
-	afterEach( () => {
-		jest.useRealTimers();
-	} );
-
 	test( 'should dispatch an http request', () => {
 		const [ request ] = requestTransfer( { siteId } );
 
@@ -55,72 +86,64 @@ describe( 'requestTransfer', () => {
 	} );
 
 	test( 'should time out a request that never responds', () => {
-		const dispatch = jest.fn();
-		const [ , armDeadline ] = requestTransfer( { siteId } );
+		const store = createStore();
 
-		armDeadline( dispatch );
+		startWait( store );
 		jest.advanceTimersByTime( TRANSFER_POLL_DEADLINE_MS );
 
-		expect( dispatch ).toHaveBeenCalledWith(
-			setAtomicTransfer( siteId, { status: transferStates.CLIENT_TIMEOUT } )
-		);
+		expect( store.dispatch ).toHaveBeenCalledWith( timedOut() );
 	} );
 
-	test( 'should anchor the deadline to the wait already in progress', () => {
-		const dispatch = jest.fn();
+	test( 'should not extend the deadline of a wait already in progress', () => {
+		const store = createStore();
 
-		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE ) )( dispatch );
-		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS - 1000 );
-		requestTransfer( { siteId } )[ 1 ]( dispatch );
-		dispatch.mockClear();
-		jest.advanceTimersByTime( 1000 );
+		startWait( store );
+		jest.advanceTimersByTime( TRANSFER_POLL_DEADLINE_MS / 2 );
+		startWait( store );
+		jest.advanceTimersByTime( TRANSFER_POLL_DEADLINE_MS / 2 );
 
-		expect( dispatch ).toHaveBeenCalledWith(
-			setAtomicTransfer( siteId, { status: transferStates.CLIENT_TIMEOUT } )
-		);
+		expect( store.dispatch ).toHaveBeenCalledWith( timedOut() );
+	} );
+
+	test( 'should not start a new deadline once the wait has timed out', () => {
+		const store = createStore();
+
+		startWait( store );
+		jest.advanceTimersByTime( TRANSFER_POLL_DEADLINE_MS );
+		store.dispatch.mockClear();
+		startWait( store );
+		jest.advanceTimersByTime( TRANSFER_POLL_DEADLINE_MS );
+
+		expect( store.dispatch ).not.toHaveBeenCalled();
 	} );
 } );
 
 describe( 'receiveTransfer', () => {
-	beforeEach( () => {
-		jest.useFakeTimers();
-		setTimeoutSpy = jest.spyOn( global, 'setTimeout' );
-		jest.setSystemTime( start );
-		jest.clearAllMocks();
-		clearPollDeadlines();
-	} );
-
-	afterEach( () => {
-		jest.useRealTimers();
-		jest.restoreAllMocks();
-	} );
-
 	test( 'should dispatch the transfer and poll while it is in progress', () => {
-		const dispatch = jest.fn();
+		const store = createStore();
 		const response = transfer( transferStates.ACTIVE );
 
-		receiveTransfer( { siteId }, response )( dispatch );
+		receive( store, response );
 
-		expect( dispatch ).toHaveBeenCalledWith( setAtomicTransfer( siteId, response ) );
-		expect( setTimeoutSpy ).toHaveBeenLastCalledWith( expect.any( Function ), 10000 );
-		jest.runOnlyPendingTimers();
-		expect( dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
+		expect( store.dispatch ).toHaveBeenCalledWith( setAtomicTransfer( siteId, response ) );
+		jest.advanceTimersByTime( POLL_INTERVAL_MS );
+		expect( store.dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
 	} );
 
 	test.each( [ 'reverting', 'unknown' ] )( 'should poll unknown status %s', ( status ) => {
-		const dispatch = jest.fn();
+		const store = createStore();
 
-		receiveTransfer( { siteId }, transfer( status ) )( dispatch );
-		jest.runOnlyPendingTimers();
+		receive( store, transfer( status ) );
+		jest.advanceTimersByTime( POLL_INTERVAL_MS );
 
-		expect( dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
+		expect( store.dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
 	} );
 
 	test( 'should keep one poll timer per site', () => {
-		const dispatch = jest.fn();
+		const store = createStore();
 
-		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE ) )( dispatch );
-		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE ) )( dispatch );
+		receive( store, transfer( transferStates.ACTIVE ) );
+		receive( store, transfer( transferStates.ACTIVE ) );
 
 		expect( jest.getTimerCount() ).toBe( 1 );
 	} );
@@ -128,304 +151,155 @@ describe( 'receiveTransfer', () => {
 	test.each( [ transferStates.COMPLETED, transferStates.ERROR, transferStates.REVERTED ] )(
 		'should stop polling on settled status %s',
 		( status ) => {
-			const dispatch = jest.fn();
+			const store = createStore();
 
-			receiveTransfer( { siteId }, transfer( status ) )( dispatch );
-			jest.runOnlyPendingTimers();
+			receive( store, transfer( status ) );
+			jest.advanceTimersByTime( POLL_INTERVAL_MS );
 
-			expect( dispatch ).not.toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
+			expect( store.dispatch ).not.toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
 		}
 	);
 
 	test( 'should refresh the site after completion', () => {
-		const dispatch = jest.fn();
+		const store = createStore();
 
-		receiveTransfer( { siteId }, transfer( transferStates.COMPLETED ) )( dispatch );
+		receive( store, transfer( transferStates.COMPLETED ) );
 
 		expect( requestSite ).toHaveBeenCalledWith( siteId );
-		expect( dispatch ).toHaveBeenLastCalledWith( requestSite( siteId ) );
+		expect( store.dispatch ).toHaveBeenLastCalledWith( requestSite( siteId ) );
 	} );
 
 	test( 'should keep polling until the deadline arrives', () => {
-		const dispatch = jest.fn();
-
-		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE ) )( dispatch );
-		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS - 1 );
-		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE ) )( dispatch );
-
-		expect( dispatch ).not.toHaveBeenCalledWith(
-			setAtomicTransfer( siteId, transfer( transferStates.CLIENT_TIMEOUT ) )
-		);
-		jest.runOnlyPendingTimers();
-		expect( dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
-	} );
-
-	test( 'should set client timeout when the deadline expires', () => {
-		const dispatch = jest.fn();
+		const store = createStore();
 		const response = transfer( transferStates.ACTIVE );
 
-		receiveTransfer( { siteId }, response )( dispatch );
-		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS );
-		receiveTransfer( { siteId }, response )( dispatch );
+		startWait( store );
+		jest.advanceTimersByTime( TRANSFER_POLL_DEADLINE_MS / 2 );
+		receive( store, response );
 
-		expect( dispatch ).toHaveBeenLastCalledWith(
-			setAtomicTransfer( siteId, { ...response, status: transferStates.CLIENT_TIMEOUT } )
-		);
+		expect( store.dispatch ).not.toHaveBeenCalledWith( timedOut( response ) );
+		jest.advanceTimersByTime( POLL_INTERVAL_MS );
+		expect( store.dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
 	} );
 
-	test( 'should keep timeout status sticky', () => {
-		const dispatch = jest.fn();
+	test( 'should stop polling once the deadline expires', () => {
+		const store = createStore();
+
+		startWait( store );
+		receive( store, transfer( transferStates.ACTIVE ) );
+		jest.advanceTimersByTime( TRANSFER_POLL_DEADLINE_MS );
+		store.dispatch.mockClear();
+		jest.advanceTimersByTime( TRANSFER_POLL_DEADLINE_MS );
+
+		expect( store.dispatch ).not.toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
+	} );
+
+	test( 'should keep reporting the timeout to late responses, with their data', () => {
+		const store = createStore();
 		const response = transfer( transferStates.ACTIVE );
 
-		receiveTransfer( { siteId }, response )( dispatch );
-		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS );
-		receiveTransfer( { siteId }, response )( dispatch );
-		dispatch.mockClear();
-		receiveTransfer( { siteId }, response )( dispatch );
+		startWait( store );
+		receive( store, response );
+		jest.advanceTimersByTime( TRANSFER_POLL_DEADLINE_MS );
+		store.dispatch.mockClear();
+		receive( store, response );
 
-		expect( dispatch ).toHaveBeenCalledTimes( 1 );
-		expect( dispatch ).toHaveBeenCalledWith(
-			setAtomicTransfer( siteId, { ...response, status: transferStates.CLIENT_TIMEOUT } )
-		);
+		expect( store.dispatch ).toHaveBeenCalledTimes( 1 );
+		expect( store.dispatch ).toHaveBeenCalledWith( timedOut( response ) );
 	} );
 
-	test.each( [ transferStates.COMPLETED, transferStates.ERROR, transferStates.REVERTED ] )(
-		'should prefer settled status %s over expired deadline',
-		( status ) => {
-			const dispatch = jest.fn();
+	test( 'should give a new transfer a fresh wait after the previous one timed out', () => {
+		const store = createStore();
+		const newTransfer = transfer( transferStates.ACTIVE, 2 );
 
-			receiveTransfer( { siteId }, transfer( transferStates.ACTIVE ) )( dispatch );
-			jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS + 1 );
-			receiveTransfer( { siteId }, transfer( status ) )( dispatch );
+		startWait( store );
+		receive( store, transfer( transferStates.ACTIVE, 1 ) );
+		jest.advanceTimersByTime( TRANSFER_POLL_DEADLINE_MS );
+		store.dispatch.mockClear();
 
-			expect( dispatch ).not.toHaveBeenCalledWith(
-				setAtomicTransfer( siteId, {
-					...transfer( status ),
-					status: transferStates.CLIENT_TIMEOUT,
-				} )
-			);
-		}
-	);
+		receive( store, newTransfer );
+		receive( store, newTransfer );
 
-	test( 'should not reopen the deadline for the same transfer', () => {
-		const dispatch = jest.fn();
-
-		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE ) )( dispatch );
-		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS + 1 );
-		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE ) )( dispatch );
-
-		expect( dispatch ).toHaveBeenLastCalledWith(
-			setAtomicTransfer( siteId, {
-				...transfer( transferStates.ACTIVE ),
-				status: transferStates.CLIENT_TIMEOUT,
-			} )
-		);
-	} );
-
-	test( 'should give a new transfer a fresh deadline', () => {
-		const dispatch = jest.fn();
-
-		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE, 1 ) )( dispatch );
-		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS + 1 );
-		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE, 2 ) )( dispatch );
-
-		expect( dispatch ).not.toHaveBeenCalledWith(
-			setAtomicTransfer( siteId, {
-				...transfer( transferStates.ACTIVE, 2 ),
-				status: transferStates.CLIENT_TIMEOUT,
-			} )
-		);
-		jest.runOnlyPendingTimers();
-		expect( dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
-	} );
-
-	test( 'should give a new transfer a fresh deadline after the previous one timed out', () => {
-		const dispatch = jest.fn();
-
-		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE, 1 ) )( dispatch );
-		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS );
-		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE, 1 ) )( dispatch );
-
-		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE, 2 ) )( dispatch );
-		dispatch.mockClear();
-		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE, 2 ) )( dispatch );
-
-		expect( dispatch ).not.toHaveBeenCalledWith(
-			setAtomicTransfer( siteId, {
-				...transfer( transferStates.ACTIVE, 2 ),
-				status: transferStates.CLIENT_TIMEOUT,
-			} )
-		);
-	} );
-
-	test( 'should not let a poll from an ended wait time out a new wait', () => {
-		const dispatch = jest.fn();
-
-		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE ) )( dispatch );
-		receiveTransfer( { siteId }, transfer( transferStates.COMPLETED ) )( dispatch );
-		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS + 1 );
-		jest.runOnlyPendingTimers();
-		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE ) )( dispatch );
-
-		expect( dispatch ).not.toHaveBeenLastCalledWith(
-			setAtomicTransfer( siteId, {
-				...transfer( transferStates.ACTIVE ),
-				status: transferStates.CLIENT_TIMEOUT,
-			} )
-		);
-	} );
-
-	test( 'should preserve transfer data when timing out', () => {
-		const dispatch = jest.fn();
-		const response = transfer( transferStates.ACTIVE );
-
-		receiveTransfer( { siteId }, response )( dispatch );
-		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS );
-		receiveTransfer( { siteId }, response )( dispatch );
-
-		expect( dispatch ).toHaveBeenLastCalledWith(
-			setAtomicTransfer( siteId, {
-				...response,
-				status: transferStates.CLIENT_TIMEOUT,
-			} )
-		);
+		expect( store.dispatch ).not.toHaveBeenCalledWith( timedOut( newTransfer ) );
+		expect( store.dispatch ).toHaveBeenCalledWith( setAtomicTransfer( siteId, newTransfer ) );
+		jest.advanceTimersByTime( POLL_INTERVAL_MS );
+		expect( store.dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
 	} );
 
 	test( 'should recover from an empty response by polling', () => {
-		const dispatch = jest.fn();
+		const store = createStore();
 
-		receiveTransfer( { siteId }, undefined )( dispatch );
-		jest.runOnlyPendingTimers();
+		receive( store, undefined );
+		jest.advanceTimersByTime( POLL_INTERVAL_MS );
 
-		expect( dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
+		expect( store.dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
+	} );
+
+	test( 'should report the timeout for an empty response after the deadline', () => {
+		const store = createStore();
+
+		startWait( store );
+		jest.advanceTimersByTime( TRANSFER_POLL_DEADLINE_MS );
+		store.dispatch.mockClear();
+		receive( store, undefined );
+
+		expect( store.dispatch ).toHaveBeenCalledWith( timedOut() );
 	} );
 } );
 
 describe( 'onTransferError', () => {
-	beforeEach( () => {
-		jest.useFakeTimers();
-		jest.setSystemTime( start );
-		clearPollDeadlines();
-	} );
-
-	afterEach( () => {
-		jest.useRealTimers();
-	} );
-
 	test.each( [ { status: 404 }, { statusCode: 403 } ] )(
-		'should dispatch a terminal status on client error %p',
+		'should end the wait on client error %p',
 		( error ) => {
-			const dispatch = jest.fn();
+			const store = createStore();
 
-			onTransferError( { siteId }, error )( dispatch );
-			jest.runOnlyPendingTimers();
+			startWait( store );
+			fail( store, error );
+			jest.advanceTimersByTime( POLL_INTERVAL_MS );
 
-			expect( dispatch ).toHaveBeenCalledWith(
-				setAtomicTransfer( siteId, { status: transferStates.CLIENT_TIMEOUT } )
-			);
+			expect( store.dispatch ).toHaveBeenCalledWith( timedOut() );
+			expect( store.dispatch ).not.toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
 		}
 	);
 
-	test( 'should retry missing transfer records before timing out', () => {
-		const dispatch = jest.fn();
+	test( 'should retry missing transfer records before ending the wait', () => {
+		const store = createStore();
+		const missingRecord = { status: 400, error: 'no_transfer_record' };
+
+		startWait( store );
 
 		for ( let attempt = 1; attempt < 6; attempt++ ) {
-			onTransferError( { siteId }, { status: 400, error: 'no_transfer_record' } )( dispatch );
-			jest.runOnlyPendingTimers();
+			fail( store, missingRecord );
+			jest.advanceTimersByTime( POLL_INTERVAL_MS );
 		}
 
-		expect( dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
-		onTransferError( { siteId }, { status: 400, error: 'no_transfer_record' } )( dispatch );
+		expect( store.dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
+		store.dispatch.mockClear();
+		fail( store, missingRecord );
 
-		expect( dispatch ).toHaveBeenLastCalledWith(
-			setAtomicTransfer( siteId, { status: transferStates.CLIENT_TIMEOUT } )
-		);
+		expect( store.dispatch ).toHaveBeenCalledWith( timedOut() );
 	} );
 
 	test( 'should poll again after a server error', () => {
-		const dispatch = jest.fn();
+		const store = createStore();
 
-		onTransferError( { siteId }, { status: 500 } )( dispatch );
-		jest.runOnlyPendingTimers();
+		startWait( store );
+		fail( store, { status: 500 } );
+		jest.advanceTimersByTime( POLL_INTERVAL_MS );
 
-		expect( dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
+		expect( store.dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
 	} );
 
-	test( 'should time out after server errors exceed the deadline', () => {
-		const dispatch = jest.fn();
+	test( 'should stop retrying server errors once the wait has timed out', () => {
+		const store = createStore();
 
-		onTransferError( { siteId }, { status: 500 } )( dispatch );
-		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS );
-		onTransferError( { siteId }, { status: 500 } )( dispatch );
+		startWait( store );
+		jest.advanceTimersByTime( TRANSFER_POLL_DEADLINE_MS );
+		store.dispatch.mockClear();
+		fail( store, { status: 500 } );
+		jest.advanceTimersByTime( POLL_INTERVAL_MS );
 
-		expect( dispatch ).toHaveBeenLastCalledWith(
-			setAtomicTransfer( siteId, { status: transferStates.CLIENT_TIMEOUT } )
-		);
-	} );
-
-	test( 'should keep timeout status sticky after server errors', () => {
-		const dispatch = jest.fn();
-
-		onTransferError( { siteId }, { status: 500 } )( dispatch );
-		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS );
-		onTransferError( { siteId }, { status: 500 } )( dispatch );
-		dispatch.mockClear();
-		onTransferError( { siteId }, { status: 500 } )( dispatch );
-
-		expect( dispatch ).toHaveBeenCalledTimes( 1 );
-		expect( dispatch ).toHaveBeenCalledWith(
-			setAtomicTransfer( siteId, { status: transferStates.CLIENT_TIMEOUT } )
-		);
-	} );
-
-	test( 'should adopt an error-created deadline when a response succeeds', () => {
-		const dispatch = jest.fn();
-		const response = transfer( transferStates.ACTIVE );
-
-		onTransferError( { siteId }, { status: 500 } )( dispatch );
-		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS - 1 );
-		dispatch.mockClear();
-		receiveTransfer( { siteId }, response )( dispatch );
-
-		expect( dispatch ).not.toHaveBeenCalledWith(
-			setAtomicTransfer( siteId, { ...response, status: transferStates.CLIENT_TIMEOUT } )
-		);
-		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS );
-		receiveTransfer( { siteId }, response )( dispatch );
-		expect( dispatch ).toHaveBeenLastCalledWith(
-			setAtomicTransfer( siteId, { ...response, status: transferStates.CLIENT_TIMEOUT } )
-		);
-	} );
-
-	test( 'should honor timeout created before a response succeeds', () => {
-		const dispatch = jest.fn();
-		const response = transfer( transferStates.ACTIVE );
-
-		onTransferError( { siteId }, { status: 500 } )( dispatch );
-		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS );
-		onTransferError( { siteId }, { status: 500 } )( dispatch );
-		dispatch.mockClear();
-		receiveTransfer( { siteId }, response )( dispatch );
-
-		expect( dispatch ).toHaveBeenCalledWith(
-			setAtomicTransfer( siteId, { ...response, status: transferStates.CLIENT_TIMEOUT } )
-		);
-	} );
-
-	test( 'should start a fresh wait after a stale timeout entry', () => {
-		const dispatch = jest.fn();
-
-		onTransferError( { siteId }, { status: 500 } )( dispatch );
-		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS );
-		onTransferError( { siteId }, { status: 500 } )( dispatch );
-		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS * 2 + 1 );
-		dispatch.mockClear();
-		onTransferError( { siteId }, { status: 500 } )( dispatch );
-		jest.runOnlyPendingTimers();
-
-		expect( dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
-		expect( dispatch ).not.toHaveBeenCalledWith(
-			setAtomicTransfer( siteId, { status: transferStates.CLIENT_TIMEOUT } )
-		);
+		expect( store.dispatch ).toHaveBeenCalledWith( timedOut() );
+		expect( store.dispatch ).not.toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
 	} );
 } );

--- a/client/state/data-layer/wpcom/sites/transfers/test/latest.js
+++ b/client/state/data-layer/wpcom/sites/transfers/test/latest.js
@@ -1,0 +1,431 @@
+import { fetchAtomicTransfer, setAtomicTransfer } from 'calypso/state/atomic-transfer/actions';
+import { transferStates } from 'calypso/state/atomic-transfer/constants';
+import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+import { requestSite } from 'calypso/state/sites/actions';
+import {
+	clearPollDeadlines,
+	onTransferError,
+	receiveTransfer,
+	requestTransfer,
+	TRANSFER_POLL_DEADLINE_MS,
+} from '../latest';
+
+jest.mock( 'calypso/state/sites/actions', () => ( {
+	requestSite: jest.fn( ( requestedSiteId ) => ( {
+		type: 'TEST_REQUEST_SITE',
+		siteId: requestedSiteId,
+	} ) ),
+} ) );
+
+const siteId = 1916284;
+const start = 1000000;
+let setTimeoutSpy;
+
+const transfer = ( status, atomicTransferId = 1 ) => ( {
+	atomic_transfer_id: atomicTransferId,
+	blog_id: siteId,
+	status,
+	created_at: '2026-08-11T18:00:00Z',
+} );
+
+describe( 'requestTransfer', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+		jest.setSystemTime( start );
+		clearPollDeadlines();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	test( 'should dispatch an http request', () => {
+		const [ request ] = requestTransfer( { siteId } );
+
+		expect( request ).toEqual(
+			http(
+				{
+					method: 'GET',
+					path: `/sites/${ siteId }/transfers/latest`,
+					apiVersion: '1.2',
+				},
+				{ siteId }
+			)
+		);
+	} );
+
+	test( 'should time out a request that never responds', () => {
+		const dispatch = jest.fn();
+		const [ , armDeadline ] = requestTransfer( { siteId } );
+
+		armDeadline( dispatch );
+		jest.advanceTimersByTime( TRANSFER_POLL_DEADLINE_MS );
+
+		expect( dispatch ).toHaveBeenCalledWith(
+			setAtomicTransfer( siteId, { status: transferStates.CLIENT_TIMEOUT } )
+		);
+	} );
+
+	test( 'should anchor the deadline to the wait already in progress', () => {
+		const dispatch = jest.fn();
+
+		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE ) )( dispatch );
+		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS - 1000 );
+		requestTransfer( { siteId } )[ 1 ]( dispatch );
+		dispatch.mockClear();
+		jest.advanceTimersByTime( 1000 );
+
+		expect( dispatch ).toHaveBeenCalledWith(
+			setAtomicTransfer( siteId, { status: transferStates.CLIENT_TIMEOUT } )
+		);
+	} );
+} );
+
+describe( 'receiveTransfer', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+		setTimeoutSpy = jest.spyOn( global, 'setTimeout' );
+		jest.setSystemTime( start );
+		jest.clearAllMocks();
+		clearPollDeadlines();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+		jest.restoreAllMocks();
+	} );
+
+	test( 'should dispatch the transfer and poll while it is in progress', () => {
+		const dispatch = jest.fn();
+		const response = transfer( transferStates.ACTIVE );
+
+		receiveTransfer( { siteId }, response )( dispatch );
+
+		expect( dispatch ).toHaveBeenCalledWith( setAtomicTransfer( siteId, response ) );
+		expect( setTimeoutSpy ).toHaveBeenLastCalledWith( expect.any( Function ), 10000 );
+		jest.runOnlyPendingTimers();
+		expect( dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
+	} );
+
+	test.each( [ 'reverting', 'unknown' ] )( 'should poll unknown status %s', ( status ) => {
+		const dispatch = jest.fn();
+
+		receiveTransfer( { siteId }, transfer( status ) )( dispatch );
+		jest.runOnlyPendingTimers();
+
+		expect( dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
+	} );
+
+	test( 'should keep one poll timer per site', () => {
+		const dispatch = jest.fn();
+
+		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE ) )( dispatch );
+		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE ) )( dispatch );
+
+		expect( jest.getTimerCount() ).toBe( 1 );
+	} );
+
+	test.each( [ transferStates.COMPLETED, transferStates.ERROR, transferStates.REVERTED ] )(
+		'should stop polling on settled status %s',
+		( status ) => {
+			const dispatch = jest.fn();
+
+			receiveTransfer( { siteId }, transfer( status ) )( dispatch );
+			jest.runOnlyPendingTimers();
+
+			expect( dispatch ).not.toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
+		}
+	);
+
+	test( 'should refresh the site after completion', () => {
+		const dispatch = jest.fn();
+
+		receiveTransfer( { siteId }, transfer( transferStates.COMPLETED ) )( dispatch );
+
+		expect( requestSite ).toHaveBeenCalledWith( siteId );
+		expect( dispatch ).toHaveBeenLastCalledWith( requestSite( siteId ) );
+	} );
+
+	test( 'should keep polling until the deadline arrives', () => {
+		const dispatch = jest.fn();
+
+		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE ) )( dispatch );
+		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS - 1 );
+		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE ) )( dispatch );
+
+		expect( dispatch ).not.toHaveBeenCalledWith(
+			setAtomicTransfer( siteId, transfer( transferStates.CLIENT_TIMEOUT ) )
+		);
+		jest.runOnlyPendingTimers();
+		expect( dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
+	} );
+
+	test( 'should set client timeout when the deadline expires', () => {
+		const dispatch = jest.fn();
+		const response = transfer( transferStates.ACTIVE );
+
+		receiveTransfer( { siteId }, response )( dispatch );
+		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS );
+		receiveTransfer( { siteId }, response )( dispatch );
+
+		expect( dispatch ).toHaveBeenLastCalledWith(
+			setAtomicTransfer( siteId, { ...response, status: transferStates.CLIENT_TIMEOUT } )
+		);
+	} );
+
+	test( 'should keep timeout status sticky', () => {
+		const dispatch = jest.fn();
+		const response = transfer( transferStates.ACTIVE );
+
+		receiveTransfer( { siteId }, response )( dispatch );
+		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS );
+		receiveTransfer( { siteId }, response )( dispatch );
+		dispatch.mockClear();
+		receiveTransfer( { siteId }, response )( dispatch );
+
+		expect( dispatch ).toHaveBeenCalledTimes( 1 );
+		expect( dispatch ).toHaveBeenCalledWith(
+			setAtomicTransfer( siteId, { ...response, status: transferStates.CLIENT_TIMEOUT } )
+		);
+	} );
+
+	test.each( [ transferStates.COMPLETED, transferStates.ERROR, transferStates.REVERTED ] )(
+		'should prefer settled status %s over expired deadline',
+		( status ) => {
+			const dispatch = jest.fn();
+
+			receiveTransfer( { siteId }, transfer( transferStates.ACTIVE ) )( dispatch );
+			jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS + 1 );
+			receiveTransfer( { siteId }, transfer( status ) )( dispatch );
+
+			expect( dispatch ).not.toHaveBeenCalledWith(
+				setAtomicTransfer( siteId, {
+					...transfer( status ),
+					status: transferStates.CLIENT_TIMEOUT,
+				} )
+			);
+		}
+	);
+
+	test( 'should not reopen the deadline for the same transfer', () => {
+		const dispatch = jest.fn();
+
+		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE ) )( dispatch );
+		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS + 1 );
+		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE ) )( dispatch );
+
+		expect( dispatch ).toHaveBeenLastCalledWith(
+			setAtomicTransfer( siteId, {
+				...transfer( transferStates.ACTIVE ),
+				status: transferStates.CLIENT_TIMEOUT,
+			} )
+		);
+	} );
+
+	test( 'should give a new transfer a fresh deadline', () => {
+		const dispatch = jest.fn();
+
+		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE, 1 ) )( dispatch );
+		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS + 1 );
+		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE, 2 ) )( dispatch );
+
+		expect( dispatch ).not.toHaveBeenCalledWith(
+			setAtomicTransfer( siteId, {
+				...transfer( transferStates.ACTIVE, 2 ),
+				status: transferStates.CLIENT_TIMEOUT,
+			} )
+		);
+		jest.runOnlyPendingTimers();
+		expect( dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
+	} );
+
+	test( 'should give a new transfer a fresh deadline after the previous one timed out', () => {
+		const dispatch = jest.fn();
+
+		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE, 1 ) )( dispatch );
+		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS );
+		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE, 1 ) )( dispatch );
+
+		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE, 2 ) )( dispatch );
+		dispatch.mockClear();
+		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE, 2 ) )( dispatch );
+
+		expect( dispatch ).not.toHaveBeenCalledWith(
+			setAtomicTransfer( siteId, {
+				...transfer( transferStates.ACTIVE, 2 ),
+				status: transferStates.CLIENT_TIMEOUT,
+			} )
+		);
+	} );
+
+	test( 'should not let a poll from an ended wait time out a new wait', () => {
+		const dispatch = jest.fn();
+
+		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE ) )( dispatch );
+		receiveTransfer( { siteId }, transfer( transferStates.COMPLETED ) )( dispatch );
+		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS + 1 );
+		jest.runOnlyPendingTimers();
+		receiveTransfer( { siteId }, transfer( transferStates.ACTIVE ) )( dispatch );
+
+		expect( dispatch ).not.toHaveBeenLastCalledWith(
+			setAtomicTransfer( siteId, {
+				...transfer( transferStates.ACTIVE ),
+				status: transferStates.CLIENT_TIMEOUT,
+			} )
+		);
+	} );
+
+	test( 'should preserve transfer data when timing out', () => {
+		const dispatch = jest.fn();
+		const response = transfer( transferStates.ACTIVE );
+
+		receiveTransfer( { siteId }, response )( dispatch );
+		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS );
+		receiveTransfer( { siteId }, response )( dispatch );
+
+		expect( dispatch ).toHaveBeenLastCalledWith(
+			setAtomicTransfer( siteId, {
+				...response,
+				status: transferStates.CLIENT_TIMEOUT,
+			} )
+		);
+	} );
+
+	test( 'should recover from an empty response by polling', () => {
+		const dispatch = jest.fn();
+
+		receiveTransfer( { siteId }, undefined )( dispatch );
+		jest.runOnlyPendingTimers();
+
+		expect( dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
+	} );
+} );
+
+describe( 'onTransferError', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+		jest.setSystemTime( start );
+		clearPollDeadlines();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	test.each( [ { status: 404 }, { statusCode: 403 } ] )(
+		'should dispatch a terminal status on client error %p',
+		( error ) => {
+			const dispatch = jest.fn();
+
+			onTransferError( { siteId }, error )( dispatch );
+			jest.runOnlyPendingTimers();
+
+			expect( dispatch ).toHaveBeenCalledWith(
+				setAtomicTransfer( siteId, { status: transferStates.CLIENT_TIMEOUT } )
+			);
+		}
+	);
+
+	test( 'should retry missing transfer records before timing out', () => {
+		const dispatch = jest.fn();
+
+		for ( let attempt = 1; attempt < 6; attempt++ ) {
+			onTransferError( { siteId }, { status: 400, error: 'no_transfer_record' } )( dispatch );
+			jest.runOnlyPendingTimers();
+		}
+
+		expect( dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
+		onTransferError( { siteId }, { status: 400, error: 'no_transfer_record' } )( dispatch );
+
+		expect( dispatch ).toHaveBeenLastCalledWith(
+			setAtomicTransfer( siteId, { status: transferStates.CLIENT_TIMEOUT } )
+		);
+	} );
+
+	test( 'should poll again after a server error', () => {
+		const dispatch = jest.fn();
+
+		onTransferError( { siteId }, { status: 500 } )( dispatch );
+		jest.runOnlyPendingTimers();
+
+		expect( dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
+	} );
+
+	test( 'should time out after server errors exceed the deadline', () => {
+		const dispatch = jest.fn();
+
+		onTransferError( { siteId }, { status: 500 } )( dispatch );
+		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS );
+		onTransferError( { siteId }, { status: 500 } )( dispatch );
+
+		expect( dispatch ).toHaveBeenLastCalledWith(
+			setAtomicTransfer( siteId, { status: transferStates.CLIENT_TIMEOUT } )
+		);
+	} );
+
+	test( 'should keep timeout status sticky after server errors', () => {
+		const dispatch = jest.fn();
+
+		onTransferError( { siteId }, { status: 500 } )( dispatch );
+		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS );
+		onTransferError( { siteId }, { status: 500 } )( dispatch );
+		dispatch.mockClear();
+		onTransferError( { siteId }, { status: 500 } )( dispatch );
+
+		expect( dispatch ).toHaveBeenCalledTimes( 1 );
+		expect( dispatch ).toHaveBeenCalledWith(
+			setAtomicTransfer( siteId, { status: transferStates.CLIENT_TIMEOUT } )
+		);
+	} );
+
+	test( 'should adopt an error-created deadline when a response succeeds', () => {
+		const dispatch = jest.fn();
+		const response = transfer( transferStates.ACTIVE );
+
+		onTransferError( { siteId }, { status: 500 } )( dispatch );
+		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS - 1 );
+		dispatch.mockClear();
+		receiveTransfer( { siteId }, response )( dispatch );
+
+		expect( dispatch ).not.toHaveBeenCalledWith(
+			setAtomicTransfer( siteId, { ...response, status: transferStates.CLIENT_TIMEOUT } )
+		);
+		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS );
+		receiveTransfer( { siteId }, response )( dispatch );
+		expect( dispatch ).toHaveBeenLastCalledWith(
+			setAtomicTransfer( siteId, { ...response, status: transferStates.CLIENT_TIMEOUT } )
+		);
+	} );
+
+	test( 'should honor timeout created before a response succeeds', () => {
+		const dispatch = jest.fn();
+		const response = transfer( transferStates.ACTIVE );
+
+		onTransferError( { siteId }, { status: 500 } )( dispatch );
+		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS );
+		onTransferError( { siteId }, { status: 500 } )( dispatch );
+		dispatch.mockClear();
+		receiveTransfer( { siteId }, response )( dispatch );
+
+		expect( dispatch ).toHaveBeenCalledWith(
+			setAtomicTransfer( siteId, { ...response, status: transferStates.CLIENT_TIMEOUT } )
+		);
+	} );
+
+	test( 'should start a fresh wait after a stale timeout entry', () => {
+		const dispatch = jest.fn();
+
+		onTransferError( { siteId }, { status: 500 } )( dispatch );
+		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS );
+		onTransferError( { siteId }, { status: 500 } )( dispatch );
+		jest.setSystemTime( start + TRANSFER_POLL_DEADLINE_MS * 2 + 1 );
+		dispatch.mockClear();
+		onTransferError( { siteId }, { status: 500 } )( dispatch );
+		jest.runOnlyPendingTimers();
+
+		expect( dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
+		expect( dispatch ).not.toHaveBeenCalledWith(
+			setAtomicTransfer( siteId, { status: transferStates.CLIENT_TIMEOUT } )
+		);
+	} );
+} );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-17961/bring-the-dead-transfer-poll-back-to-life

## Proposed Changes

**The `/transfers/latest` status poll now survives errors, gives up on a deadline, and tells the user instead of freezing.**

- `onError` no longer swallows failures: server errors keep the poll alive, a missing transfer record is retried briefly and then treated as terminal.
- A per-site five-minute deadline ends the wait with a client-only `CLIENT_TIMEOUT` status — the same shape the automated-transfer poller got in [DOTCOM-17962](https://linear.app/a8c/issue/DOTCOM-17962).
- The deadline is armed when the request is issued, so a request that never responds still times out.
- A new transfer for the same site starts a fresh wait instead of inheriting the previous one's timeout flag.
- `REVERTED` settles the wait; previously it kept polling a transfer that had already ended.
- `TransferPending` splits the two outcomes: a failed transfer keeps the “we couldn’t process your transfer” notice, a client timeout says the transfer may still finish.

## Why are these changes being made?

When someone buys an eCommerce plan, their site moves to Atomic hosting and checkout shows a progress screen until the move finishes. That screen learned about the move from a poll that asked the server every ten seconds — and the code that scheduled the next question lived inside the success path, with failures thrown away silently. One dropped request and the questioning stopped: no error, no retry, no way out. The customer sat on a progress bar that would never move again, having just paid.

The poll now keeps asking through transient failures, stops after five minutes rather than never, and says something honest when it stops. Because the transfer itself almost always succeeds on the server, a client-side timeout is phrased as “this is taking longer than expected, it may still finish” instead of an outright failure — telling a paying customer their transfer failed invites a duplicate purchase or a support ticket for something that is still running.

Part of milestone 1 of the Atomic Transfer Flow Optimization project: no customer is ever trapped on a waiting screen.

## Testing Instructions

1. Run `yarn start` and log in with a Simple site on a plan that transfers to Atomic.
2. Buy an eCommerce plan (or reach `/checkout/thank-you/:site/:receiptId` for one) so the transfer progress screen renders.
3. Open DevTools → Network and block `*/transfers/latest*` while the progress screen is visible. Confirm the screen keeps polling through the failures instead of freezing, and after five minutes redirects to Stats with the “taking longer than expected” notice.
4. Unblock the requests and repeat without interference: the transfer completes and you land on the thank-you page as before.
5. To check the failure copy, force a transfer that ends in `error` or `reverted` — the notice should still read “Sorry, we couldn’t process your transfer.”
