### PR TITLE
e2e tests: merge the TeamCity Pre-Release E2E aggregator into its only job

### DIFF
--- a/.claude/skills/fix-e2e-tests/baseline-failures.sh
+++ b/.claude/skills/fix-e2e-tests/baseline-failures.sh
@@ -40,7 +40,7 @@ printf '%-50s %10s %10s %8s\n' '------------------------------------------------
 
 for ID in \
 	calypso_calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix \
-	calypso_calypso_WebApp_Calypso_E2E_Playwright_Pre_Release_Matrix
+	calypso_calypso_WebApp_Calypso_E2E_Pre_Release
 do
 	base="buildType:(id:${ID}),sinceDate:${SINCE},state:finished,branch:default:any,count:10000"
 	total=$(count "${base}")

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -24,10 +24,9 @@ object WebApp : Project({
 	buildType(Translate)
 	buildType(BuildDockerImage)
 	buildType(PlaywrightTestPRMatrix)
-	buildType(PlaywrightTestPreReleaseMatrix)
+	buildType(PreReleaseE2ETests)
 	buildType(PlaywrightTestDashboardPRMatrix)
 	buildType(PlaywrightTestA4APRMatrix)
-	buildType(PreReleaseE2ETests)
 	buildType(AuthenticationE2ETests)
 })
 
@@ -1026,12 +1025,12 @@ object PlaywrightTestPRMatrix : BuildType({
 
 })
 
-object PlaywrightTestPreReleaseMatrix : BuildType({
+object PreReleaseE2ETests : BuildType({
 	templates(CalypsoE2ETestsBuildTemplate)
-	id("calypso_WebApp_Calypso_E2E_Playwright_Pre_Release_Matrix")
-	uuid = "a1b2c3d4-e5f6-7890-1234-56789abcdef0"
-	name = "Pre-Release E2E Tests (Playwright Test)"
-	description = "Runs Calypso pre-release e2e tests using Playwright Test runner with build matrix"
+	id("calypso_WebApp_Calypso_E2E_Pre_Release")
+	uuid = "9c2f634f-6582-4245-bb77-fb97d9f16533"
+	name = "Pre-Release E2E Tests"
+	description = "Runs pre-release suites of E2E tests against trunk on staging, intended to be run after PR merge, but before deployment to production."
 
 	params {
 		text("TEST_GROUP", "@calypso-release")
@@ -1172,53 +1171,6 @@ object PlaywrightTestA4APRMatrix : BuildType({
 	dependencies {
 		snapshot(BuildDockerImage) {
 			onDependencyFailure = FailureAction.FAIL_TO_START
-		}
-	}
-})
-
-object PreReleaseE2ETests : BuildType({
-	id("calypso_WebApp_Calypso_E2E_Pre_Release")
-	uuid = "9c2f634f-6582-4245-bb77-fb97d9f16533"
-	name = "Pre-Release E2E Tests"
-	description = "Aggregator build that runs pre-release suites of E2E tests against trunk on staging, intended to be run after PR merge, but before deployment to production."
-
-	vcs {
-		root(Settings.WpCalypso)
-		branchFilter = allBranchesExceptMergeQueue()
-		cleanCheckout = true
-	}
-
-	dependencies {
-		snapshot(PlaywrightTestPreReleaseMatrix) {
-			onDependencyFailure = FailureAction.ADD_PROBLEM
-		}
-	}
-
-	features {
-		perfmon {
-		}
-		commitStatusPublisher {
-			vcsRootExtId = "${Settings.WpCalypso.id}"
-			publisher = github {
-				githubUrl = "https://api.github.com"
-				authType = personalToken {
-					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
-				}
-			}
-		}
-		notifications {
-			notifierSettings = slackNotifier {
-				connection = "PROJECT_EXT_11"
-				sendTo = "#e2eflowtesting-notif"
-				messageFormat = verboseMessageFormat {
-					addStatusText = true
-				}
-			}
-			branchFilter = "+:<default>"
-			buildFailedToStart = true
-			buildFailed = true
-			buildFinishedSuccessfully = false
-			buildProbablyHanging = true
 		}
 	}
 })


### PR DESCRIPTION
## Proposed Changes

* Fold the TeamCity build `Pre-Release E2E Tests (Playwright Test)` into the aggregator build `Pre-Release E2E Tests`. A single build now runs the tests.
* Keep the aggregator's build id (`calypso_WebApp_Calypso_E2E_Pre_Release`), uuid, and name. External triggers reference them.
* Drop the aggregator's own `vcs`, `perfmon`, and `commitStatusPublisher` blocks. `CalypsoE2ETestsBuildTemplate` already sets all three to the same values.
* Point `baseline-failures.sh` at the surviving build id.

## Why are these changes being made?

The Jest to Playwright migration left the aggregator with one dependency. An aggregator over a single job costs a build queue slot and a duplicate Slack notification, and tells us nothing the job itself does not.

## Testing Instructions

This is CI configuration, so it cannot run before merge. After merge, open the `Pre-Release E2E Tests` build in TeamCity and confirm:

* The build runs the Desktop and Mobile matrix jobs itself, instead of depending on another build.
* Its id is still `calypso_WebApp_Calypso_E2E_Pre_Release`.
