### PR TITLE
Domain Search: stop polling the a11y tree for the bundle CTA

### DIFF
--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -43,6 +43,14 @@ const memberLineHas =
 		element?.classList.contains( 'bundle-card__members' ) === true &&
 		( element.textContent ?? '' ).includes( domain );
 
+// `findByRole` with a name filter rebuilds the accessibility tree for the whole
+// results page on every poll, which costs more than the request chain it waits
+// for. Wait on the cheap text query, then assert the role once it is there.
+const findBundleCta = async () => {
+	await screen.findByText( 'Get bundle' );
+	return screen.getByRole( 'button', { name: 'Get bundle' } );
+};
+
 const findBundleMember = ( domain: string ) => screen.findByText( memberLineHas( domain ) );
 const getBundleMember = ( domain: string ) => screen.getByText( memberLineHas( domain ) );
 const queryBundleMember = ( domain: string ) => screen.queryByText( memberLineHas( domain ) );
@@ -1455,7 +1463,7 @@ describe( 'ResultsPage', () => {
 				</TestDomainSearch>
 			);
 
-			expect( await screen.findByRole( 'button', { name: 'Get bundle' } ) ).toBeInTheDocument();
+			expect( await findBundleCta() ).toBeInTheDocument();
 			// The companion (.net) is offered; the primary (.com) is not chipped.
 			expect( screen.getByText( '.net' ) ).toBeInTheDocument();
 			expect(
@@ -1517,7 +1525,7 @@ describe( 'ResultsPage', () => {
 
 			// The offer renders once, inside the featured-inline wrapper below the
 			// featured cards — never duplicated into the regular suggestions list.
-			expect( await screen.findByRole( 'button', { name: 'Get bundle' } ) ).toBeInTheDocument();
+			expect( await findBundleCta() ).toBeInTheDocument();
 			const featuredInlineWrapper = container.querySelector(
 				'.domain-search--results__featured-inline-bundles'
 			);


### PR DESCRIPTION
## Proposed Changes

* Route the two inline-bundle tests in `packages/domain-search/src/page/test/results.tsx` through a `findBundleCta` helper instead of awaiting `findByRole` directly.

## Why are these changes being made?

`renders an inline bundle row beneath a trigger domain that is in the cart` failed twice in its last 100 runs, on `trunk` and on `renovate/major-linters`, one of them in build 18919617:

https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Run_All_Unit_Tests/18919617

The `Nock: No match` line in that failure's DOM dump is a red herring; it's a stale `a11y-speak` announcement left by the previous test, which passes.

The test is just too close to the 1000ms default. Its CI duration runs 682ms median and 975ms at p90, and the two failures sat at 1359ms and 1395ms against a max passing run of 1379ms; the distribution is continuous straight through the threshold.

Most of that is the assertion, not the app. Measured on the same test, three runs each:

| awaited assertion | wait |
|---|---|
| `findByRole( 'button', { name: 'Get bundle' } )` | 197 / 200 / 211 ms |
| `findByText( 'Get bundle' )` | 94 / 91 / 95 ms |

Both wait for the same element, so roughly half the wait was `findByRole` rebuilding the accessibility tree for the whole results page on every poll.

After the change the test runs 72-86ms idle (was 150-179ms) and 131-146ms under ten concurrent jest processes (was 280ms). The featured sibling drops the same way, 287ms to 64-78ms. Both were the slowest tests in the file and no longer are.

## Testing Instructions

* `yarn jest --config test/packages/jest.config.js packages/domain-search`

The invariant worth checking: `findBundleCta` still asserts a `button` with the accessible name, it just doesn't poll on that query. If the wait were satisfied by something other than the real CTA the test would pass vacuously, so I checked the negative: setting `bundleSuggestion: null` on the `mockGetBundleForDomainQuery` call fails the test with `Unable to find an element with the text: Get bundle`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
