### PR TITLE
Dashboard: stabilize domain upsell card span to survive page translation

### DIFF
--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -112,10 +112,12 @@ const DomainUpsellCardContent = ( {
 			description={
 				<Text variant="muted">
 					{ createInterpolateElement( description, {
-						domain: suggestedDomain ? (
-							<span>{ suggestedDomain.domain_name }</span>
-						) : (
-							<TextBlur>{ search }</TextBlur>
+						// Keep this span's identity stable so that Google Translate doesn't crash the page.
+						// A known React issue: react/react#11538
+						domain: (
+							<span translate="no">
+								{ suggestedDomain ? suggestedDomain.domain_name : <TextBlur>{ search }</TextBlur> }
+							</span>
 						),
 						link: (
 							<UpsellCTAButton


### PR DESCRIPTION
Fixes DOTMSD-1515

## Proposed Changes

* Keep the `domain` interpolated element in `DomainUpsellCardContent` a single, stable `<span translate="no">` across the pending→resolved transition of `domainSuggestionsQuery`, swapping only its child (`<TextBlur>` → domain name) instead of swapping the wrapper element itself.

## Why are these changes being made?

Site overview (`/sites/<slug>`) crashes to the router error page ~1–2s after load, with no user interaction, when browser page-translation is active (Chrome Google Translate, Edge auto-translate). This is the top remaining contributor to Sentry CALYPSO-3G00.

Previously the card mounted with `<TextBlur>` while the slow suggestions query was pending. The translator reparents the sibling raw text nodes (Chrome wraps them in `<font>`, Edge stamps `_msttexthash`). When the query resolved, React swapped the whole `<TextBlur>` element for a new `<span>` — a commit-phase Placement whose stale `getHostSibling()` anchor was a now-detached text node, so `parent.insertBefore(...)` threw `NotFoundError` (react/react#11538).

Keeping the outer `<span>` identity stable makes the resolve an in-place child update: the inner `<TextBlur>` element is deleted and a text node is appended into the now-empty stable span (null anchor → `appendChild`, no `insertBefore`). Translators reparent text nodes, not elements, so the stable span survives. `translate="no"` is added as hardening — domain names shouldn't be translated anyway.

All three branches of `DomainUpsellCard` share `DomainUpsellCardContent`, so this covers all of them. The illustration SVG's `{ domain ?? search }` is the lone child of a `<text>` element (a text update, not a placement) and needs no change.

Precedent: #113376 (same crash class on the same page, merged).

## Testing Instructions

1. Find a test site has the `example.com is included free for one year with your paid plan.` upsell card
2. Go back to site overview
3. Clear `REACT_QUERY_OFFLINE_CACHE`
4. Reload page
5. Use Google Translate to translate the page to something else
6. Click your test site in the site list
7. As page loads ... crash

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
