### PR TITLE
Bump agenttic packages to 0.1.87

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"@automattic/accessible-focus": "workspace:^",
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-ui": "^0.1.84",
+		"@automattic/agenttic-ui": "^0.1.87",
 		"@automattic/api-core": "workspace:^",
 		"@automattic/api-queries": "workspace:^",
 		"@automattic/block-renderer": "workspace:^",

--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -41,8 +41,8 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.84",
-		"@automattic/agenttic-ui": "^0.1.84",
+		"@automattic/agenttic-client": "^0.1.87",
+		"@automattic/agenttic-ui": "^0.1.87",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/image-studio/package.json
+++ b/packages/image-studio/package.json
@@ -51,8 +51,8 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.84",
-		"@automattic/agenttic-ui": "^0.1.84",
+		"@automattic/agenttic-client": "^0.1.87",
+		"@automattic/agenttic-ui": "^0.1.87",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",

--- a/packages/jetpack-ai-sidebar/package.json
+++ b/packages/jetpack-ai-sidebar/package.json
@@ -44,7 +44,7 @@
 		"typecheck": "tsc --build --dry"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.84",
+		"@automattic/agenttic-client": "^0.1.87",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
 		"@automattic/components": "workspace:^",

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -41,7 +41,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.84",
+		"@automattic/agenttic-ui": "^0.1.87",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/zendesk-client/package.json
+++ b/packages/zendesk-client/package.json
@@ -36,7 +36,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.84",
+		"@automattic/agenttic-ui": "^0.1.87",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-config": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -182,8 +182,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/agents-manager@workspace:packages/agents-manager"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.84"
-    "@automattic/agenttic-ui": "npm:^0.1.84"
+    "@automattic/agenttic-client": "npm:^0.1.87"
+    "@automattic/agenttic-ui": "npm:^0.1.87"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
@@ -230,9 +230,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/agenttic-client@npm:^0.1.84":
-  version: 0.1.85
-  resolution: "@automattic/agenttic-client@npm:0.1.85"
+"@automattic/agenttic-client@npm:^0.1.87":
+  version: 0.1.87
+  resolution: "@automattic/agenttic-client@npm:0.1.87"
   dependencies:
     "@types/react": "npm:^18.0.0 || ^19.0.0"
     marked: "npm:^16.2.1"
@@ -245,13 +245,13 @@ __metadata:
   peerDependenciesMeta:
     "@wordpress/api-fetch":
       optional: true
-  checksum: e03b076d366a950306e52caccb2828e5a1585be7b409e2bebaf8b4867766bde7fcb227340538f05dd5f95963f641d924932a0e097aa50fcf1d050ad20787bfb1
+  checksum: 97b710151694fb4cbc339edf32d81cf025cd18290e1194b19c2e4038d47f57b6df8b75e74b2aba189ba2b71de2f643000acd32ec88930a25003e3ca09dc646f8
   languageName: node
   linkType: hard
 
-"@automattic/agenttic-ui@npm:^0.1.84":
-  version: 0.1.85
-  resolution: "@automattic/agenttic-ui@npm:0.1.85"
+"@automattic/agenttic-ui@npm:^0.1.87":
+  version: 0.1.87
+  resolution: "@automattic/agenttic-ui@npm:0.1.87"
   dependencies:
     "@automattic/charts": "npm:^1.10.0"
     "@radix-ui/react-popover": "npm:^1.1.15"
@@ -274,7 +274,7 @@ __metadata:
   dependenciesMeta:
     marked:
       optional: true
-  checksum: 857e4640d2fe0263d21b8dd8b46d6b81dc76992ae1ca03eda2d392fa61284997985366a91180e41039d714d0629d5abbc77dcd752536387a1640fd68232a6115
+  checksum: 647f89fe20cfe36614534b1a847fe1f472b23fedb90ff6c6091b130ad87bbda2a619415e04e9bcb2058b1628bd4b8640f5cff8dea757b8203a12febd7ee563e1
   languageName: node
   linkType: hard
 
@@ -1521,8 +1521,8 @@ __metadata:
   resolution: "@automattic/image-studio@workspace:packages/image-studio"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.84"
-    "@automattic/agenttic-ui": "npm:^0.1.84"
+    "@automattic/agenttic-client": "npm:^0.1.87"
+    "@automattic/agenttic-ui": "npm:^0.1.87"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/oauth-token": "workspace:^"
@@ -1610,7 +1610,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/jetpack-ai-sidebar@workspace:packages/jetpack-ai-sidebar"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.84"
+    "@automattic/agenttic-client": "npm:^0.1.87"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
@@ -1877,7 +1877,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/odie-client@workspace:packages/odie-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.84"
+    "@automattic/agenttic-ui": "npm:^0.1.87"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
@@ -2719,7 +2719,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/zendesk-client@workspace:packages/zendesk-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.84"
+    "@automattic/agenttic-ui": "npm:^0.1.87"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
@@ -14432,7 +14432,7 @@ __metadata:
   dependencies:
     "@automattic/accessible-focus": "workspace:^"
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-ui": "npm:^0.1.84"
+    "@automattic/agenttic-ui": "npm:^0.1.87"
     "@automattic/api-core": "workspace:^"
     "@automattic/api-queries": "workspace:^"
     "@automattic/block-renderer": "workspace:^"


### PR DESCRIPTION
Related to AI-1099, AI-1113 and WOOAI-878.

## Proposed Changes

Bumps `@automattic/agenttic-client` and `@automattic/agenttic-ui` from `^0.1.84` to `^0.1.87` across every consumer (`client`, `agents-manager`, `image-studio`, `jetpack-ai-sidebar`, `odie-client`, `zendesk-client`) and refreshes the lockfile. The lockfile previously resolved to 0.1.85, so this picks up 0.1.86 and 0.1.87.

What lands with the bump:

- **Fixes the wrong default floating chat position (AI-1099, AI-1113).** Agenttic UI no longer reads its internal `agenttic-chat-position` localStorage value, which silently took precedence over the `initialChatPosition` prop. The Agents Manager already owns the position (store default `right`, persisted to the backend as `agents_manager_floating_position`), so the panel now honors it instead of whatever a stale browser-local value said — the cause of the panel rendering bottom-left.
- **Unblocks tab-scoped chat sessions (WOOAI-878).** Adds the `onSessionIdChange` client config callback that #113405 needs to associate a conversation with its tab.
- Adds a one-shot `layoutCommand` prop (`{ id, side, resetSize? }`) for docking the floating panel programmatically. Not used here yet.
- Fixes a controlled-size feedback bug where a parent echoing `onResizeEnd` back through `size` repositioned the panel mid-animation.
- Drops per-event frame pacing when draining buffered SSE deltas.

Agenttic release: Automattic/agenttic#416.

## Compatibility

Agenttic 0.1.87 also changes its built-in default chat position from `left` to `right`. No effect here — the Agents Manager is the only consumer that mounts the floating panel, and it always passes `initialChatPosition` explicitly. Nothing in Calypso read the removed localStorage key or imported the renamed internal `chatStorage` module.

## Testing Instructions

1. `yarn install`
2. Open the floating assistant on a Simple site. It should dock bottom-right by default.
3. Drag it to the left edge, reload — it stays left (position now comes from the persisted store, not localStorage).
4. Set `localStorage.setItem( 'agenttic-chat-position', 'left' )`, reload, and confirm the panel still follows the store rather than the stale key.
5. Sanity-check a chat round trip: send a message, confirm streaming, image upload, and tool calls all still render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
