### PR TITLE
Stats: keep the pricing grid away from Simple sites

### DIFF
--- a/client/my-sites/stats/pricing-grid/gate.tsx
+++ b/client/my-sites/stats/pricing-grid/gate.tsx
@@ -18,9 +18,9 @@ const loadPricingGrid = () =>
 /**
  * Replaces the Stats dashboard with the pricing grid for newly connected sites
  * that haven't picked a plan yet. Everyone else falls straight through to the
- * dashboard: the connection-date check is synchronous against site options, so
- * established sites never wait on the purchase and notice lookups this gate
- * needs before it can decide.
+ * dashboard: the connection-date and site-type checks are synchronous against
+ * site options, so those sites never wait on the purchase and notice lookups
+ * this gate needs before it can decide.
  */
 function PricingGridGate( { children }: { children: ReactNode } ) {
 	const siteId = useSelector( getSelectedSiteId );
@@ -28,14 +28,14 @@ function PricingGridGate( { children }: { children: ReactNode } ) {
 	// catches up in the background and keeps the grid away on later visits.
 	const [ hasChosen, setHasChosen ] = useState( false );
 
-	const { isEligible, isNewConnection, isLoading } = useIsPricingGridEligible( siteId );
+	const { isEligible, isApplicable, isLoading } = useIsPricingGridEligible( siteId );
 	const { data: isVisible, isLoading: isLoadingVisibility } = useNoticeVisibilityQuery(
 		siteId,
 		'pricing_grid',
-		isNewConnection
+		isApplicable
 	);
 
-	if ( ! isNewConnection || hasChosen ) {
+	if ( ! isApplicable || hasChosen ) {
 		return <>{ children }</>;
 	}
 

--- a/client/my-sites/stats/pricing-grid/hooks/test/use-eligibility.test.ts
+++ b/client/my-sites/stats/pricing-grid/hooks/test/use-eligibility.test.ts
@@ -5,6 +5,7 @@
 import { renderHook } from '@testing-library/react';
 import { getPurchasesError } from 'calypso/state/purchases/selectors';
 import { getSiteOption } from 'calypso/state/sites/selectors';
+import getIsSimpleSite from 'calypso/state/sites/selectors/is-simple-site';
 import useStatsPurchases from '../../../hooks/use-stats-purchases';
 import useIsPricingGridEligible from '../use-eligibility';
 
@@ -13,6 +14,7 @@ jest.mock( 'calypso/state', () => ( {
 } ) );
 jest.mock( 'calypso/state/purchases/selectors' );
 jest.mock( 'calypso/state/sites/selectors' );
+jest.mock( 'calypso/state/sites/selectors/is-simple-site' );
 jest.mock( '../../../hooks/use-stats-purchases' );
 
 const SITE_ID = 123;
@@ -23,9 +25,11 @@ function mockSite( {
 	connectedAt = POST_LAUNCH_DATE as string | number | null,
 	hasAnyPlan = false,
 	isLoadingPurchases = false,
+	isSimpleSite = false,
 	purchasesError = null as object | null,
 } = {} ) {
 	( getSiteOption as jest.Mock ).mockReturnValue( connectedAt );
+	( getIsSimpleSite as unknown as jest.Mock ).mockReturnValue( isSimpleSite );
 	( getPurchasesError as unknown as jest.Mock ).mockReturnValue( purchasesError );
 	( useStatsPurchases as jest.Mock ).mockReturnValue( {
 		hasAnyPlan,
@@ -45,7 +49,7 @@ describe( 'useIsPricingGridEligible', () => {
 
 		expect( result.current ).toEqual( {
 			isEligible: true,
-			isNewConnection: true,
+			isApplicable: true,
 			isLoading: false,
 		} );
 	} );
@@ -56,7 +60,16 @@ describe( 'useIsPricingGridEligible', () => {
 		const { result } = renderHook( () => useIsPricingGridEligible( SITE_ID ) );
 
 		expect( result.current.isEligible ).toBe( false );
-		expect( result.current.isNewConnection ).toBe( false );
+		expect( result.current.isApplicable ).toBe( false );
+	} );
+
+	it( 'is not eligible for a WordPress.com Simple site', () => {
+		mockSite( { isSimpleSite: true } );
+
+		const { result } = renderHook( () => useIsPricingGridEligible( SITE_ID ) );
+
+		expect( result.current.isEligible ).toBe( false );
+		expect( result.current.isApplicable ).toBe( false );
 	} );
 
 	it( 'is not eligible when the site already holds a Stats plan', () => {
@@ -80,7 +93,7 @@ describe( 'useIsPricingGridEligible', () => {
 
 		const { result } = renderHook( () => useIsPricingGridEligible( SITE_ID ) );
 
-		expect( result.current.isNewConnection ).toBe( true );
+		expect( result.current.isApplicable ).toBe( true );
 	} );
 
 	it( 'is not eligible when the connection date is missing', () => {
@@ -92,7 +105,7 @@ describe( 'useIsPricingGridEligible', () => {
 		expect( result.current.isLoading ).toBe( false );
 	} );
 
-	it( 'only reports loading for newly connected sites', () => {
+	it( 'only reports loading for sites the grid applies to', () => {
 		mockSite( { isLoadingPurchases: true } );
 
 		const { result } = renderHook( () => useIsPricingGridEligible( SITE_ID ) );
@@ -104,5 +117,11 @@ describe( 'useIsPricingGridEligible', () => {
 		const { result: preLaunch } = renderHook( () => useIsPricingGridEligible( SITE_ID ) );
 
 		expect( preLaunch.current.isLoading ).toBe( false );
+
+		mockSite( { isSimpleSite: true, isLoadingPurchases: true } );
+
+		const { result: simple } = renderHook( () => useIsPricingGridEligible( SITE_ID ) );
+
+		expect( simple.current.isLoading ).toBe( false );
 	} );
 } );

--- a/client/my-sites/stats/pricing-grid/hooks/use-eligibility.ts
+++ b/client/my-sites/stats/pricing-grid/hooks/use-eligibility.ts
@@ -1,6 +1,7 @@
 import { useSelector } from 'calypso/state';
 import { getPurchasesError } from 'calypso/state/purchases/selectors';
 import { getSiteOption } from 'calypso/state/sites/selectors';
+import getIsSimpleSite from 'calypso/state/sites/selectors/is-simple-site';
 import useStatsPurchases from '../../hooks/use-stats-purchases';
 
 /**
@@ -10,12 +11,19 @@ import useStatsPurchases from '../../hooks/use-stats-purchases';
 const LAUNCH_DATE = Date.parse( '2026-08-07T00:00:00Z' );
 
 /**
- * Whether the pricing grid applies to this site: a newly connected site that hasn't
- * picked a Stats plan yet. Bundled plans (Complete, Growth, Business) count as having
- * one, which is why this defers to `useStatsPurchases` rather than scanning products.
+ * Whether the pricing grid applies to this site: a newly connected site, other than a
+ * WordPress.com Simple one, that hasn't picked a Stats plan yet. Bundled plans
+ * (Complete, Growth, Business) count as having one, which is why this defers to
+ * `useStatsPurchases` rather than scanning products.
  */
 export default function useIsPricingGridEligible( siteId: number | null ) {
 	const { hasAnyPlan, isLoading: isLoadingPurchases } = useStatsPurchases( siteId );
+
+	// Simple sites upgrade through WP.com plans, prompted inside the Stats dashboard
+	// itself, so the Jetpack Stats products this grid sells are not their upgrade path.
+	// Odyssey serves Simple Classic's wp-admin as well, so being an Odyssey route says
+	// nothing about the site type on its own.
+	const isSimpleSite = useSelector( ( state ) => !! getIsSimpleSite( state, siteId ) );
 
 	// A failed purchases fetch reads as "loaded, no plan" upstream (FETCH_FAILED marks
 	// the store loaded with an empty list), which would show the grid to a site that
@@ -41,10 +49,13 @@ export default function useIsPricingGridEligible( siteId: number | null ) {
 			: Date.parse( String( connectedAt ?? '' ) );
 	const isNewConnection = Number.isFinite( connectedAtMs ) && connectedAtMs >= LAUNCH_DATE;
 
+	// Both checks read site data the store already holds, so ruling a site out here costs
+	// nothing — only an applicable site goes on to wait for its purchases.
+	const isApplicable = isNewConnection && ! isSimpleSite;
+
 	return {
-		isEligible: isNewConnection && ! hasAnyPlan && ! purchasesError,
-		isNewConnection,
-		// The date check needs no fetch, so only newly connected sites ever wait.
-		isLoading: isNewConnection && isLoadingPurchases,
+		isEligible: isApplicable && ! hasAnyPlan && ! purchasesError,
+		isApplicable,
+		isLoading: isApplicable && isLoadingPurchases,
 	};
 }


### PR DESCRIPTION
Fixes STATS-436

## Proposed Changes

* Stop the Stats pricing grid ("Choose your Stats plan") from replacing the Stats dashboard on WordPress.com Simple sites.
* `useIsPricingGridEligible` now folds a `getIsSimpleSite` check into the synchronous prerequisite it already applies (the connection date), exposed as `isApplicable` in place of `isNewConnection`. Atomic and self-hosted Jetpack sites are unaffected.
* Extended the hook's unit tests to cover the Simple-site case, including that such sites never enter the gate's loading state.

## Why are these changes being made?

* The grid sells Jetpack Stats products. Simple sites don't buy those — their upgrade path is a WP.com plan, which the Stats dashboard already offers via its own "Unlock site growth analytics / Upgrade to Personal" CTA. A new free Simple site was landing on the grid the first time it opened Stats, choosing "Start for free", and then immediately being upsold again through the WP.com path.
* Odyssey Stats also serves Simple Classic's wp-admin, so mounting the gate on an Odyssey route says nothing about the site type on its own — the check has to be explicit.
* Putting the check alongside the connection-date test keeps it free: both read site data already in the store, so a Simple site falls straight through to the dashboard without the purchases fetch, the notice-visibility fetch, or the loading placeholder the gate would otherwise render.

## Testing Instructions

* On a WordPress.com **Simple** site created after 2026-08-07 with no plan, open `wp-admin` → Stats. Before this change the "Choose your Stats plan" grid appears; after it, the Stats dashboard loads directly (with the usual WP.com "Unlock site growth analytics" upsell below the chart).
* On a self-hosted **Jetpack** site connected after 2026-08-07 with no Stats plan, open Stats in wp-admin and confirm the pricing grid still appears, and that choosing either option still dismisses it for subsequent visits.
* On an **Atomic** site created after 2026-08-07, confirm behaviour is unchanged by this PR.
* Unit tests: `yarn test-client client/my-sites/stats/pricing-grid`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
