### PR TITLE
Help Center Tracks: attach the support site to host entry points

### DIFF
--- a/apps/agents-manager/agents-manager-gutenberg-disconnected.js
+++ b/apps/agents-manager/agents-manager-gutenberg-disconnected.js
@@ -12,7 +12,7 @@
 
 /* global agentsManagerData */
 
-import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { recordTracksEvent, withSiteContext } from '@automattic/calypso-analytics';
 import { Button, Fill } from '@wordpress/components';
 import { useMediaQuery } from '@wordpress/compose';
 import { createElement } from '@wordpress/element';
@@ -50,11 +50,23 @@ function AgentsManagerHelpButton() {
 			: 'https://wordpress.com/help';
 
 	const handleClick = () => {
-		recordTracksEvent( 'calypso_inlinehelp_show', {
-			force_site_id: true,
-			location: 'help-center',
-			section: 'gutenberg',
-		} );
+		recordTracksEvent(
+			'calypso_inlinehelp_show',
+			withSiteContext(
+				{
+					location: 'help-center',
+					section: 'gutenberg',
+				},
+				[
+					[
+						'agents_manager_data',
+						typeof agentsManagerData !== 'undefined' && agentsManagerData?.isWpcomPlatform === true
+							? agentsManagerData?.site?.ID
+							: undefined,
+					],
+				]
+			)
+		);
 	};
 
 	const button = createElement( Button, {

--- a/apps/agents-manager/agents-manager-gutenberg-disconnected.js
+++ b/apps/agents-manager/agents-manager-gutenberg-disconnected.js
@@ -57,14 +57,10 @@ function AgentsManagerHelpButton() {
 					location: 'help-center',
 					section: 'gutenberg',
 				},
-				[
-					[
-						'agents_manager_data',
-						typeof agentsManagerData !== 'undefined' && agentsManagerData?.isWpcomPlatform === true
-							? agentsManagerData?.site?.ID
-							: undefined,
-					],
-				]
+				'agents_manager_data',
+				typeof agentsManagerData !== 'undefined' && agentsManagerData?.isWpcomPlatform === true
+					? agentsManagerData?.site?.ID
+					: undefined
 			)
 		);
 	};

--- a/apps/agents-manager/agents-manager-wp-admin-disconnected.js
+++ b/apps/agents-manager/agents-manager-wp-admin-disconnected.js
@@ -39,14 +39,10 @@ function initHelpCenterTracking() {
 					location: 'help-center',
 					section: 'wp-admin',
 				},
-				[
-					[
-						'agents_manager_data',
-						typeof agentsManagerData !== 'undefined' && agentsManagerData?.isWpcomPlatform === true
-							? agentsManagerData?.site?.ID
-							: undefined,
-					],
-				]
+				'agents_manager_data',
+				typeof agentsManagerData !== 'undefined' && agentsManagerData?.isWpcomPlatform === true
+					? agentsManagerData?.site?.ID
+					: undefined
 			)
 		);
 	} );

--- a/apps/agents-manager/agents-manager-wp-admin-disconnected.js
+++ b/apps/agents-manager/agents-manager-wp-admin-disconnected.js
@@ -10,8 +10,9 @@
  * The help icon is already provided by the PHP admin bar Item component
  * as a direct link to the help page. This file just adds tracking for clicks.
  */
+/* global agentsManagerData */
 import './config';
-import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { recordTracksEvent, withSiteContext } from '@automattic/calypso-analytics';
 
 // Import WordPress admin bar integration styles
 import '@automattic/agents-manager/src/hooks/use-admin-bar-integration/style.scss';
@@ -31,11 +32,23 @@ function initHelpCenterTracking() {
 
 	// Track help center icon click
 	button.addEventListener( 'click', () => {
-		recordTracksEvent( 'calypso_inlinehelp_show', {
-			force_site_id: true,
-			location: 'help-center',
-			section: 'wp-admin',
-		} );
+		recordTracksEvent(
+			'calypso_inlinehelp_show',
+			withSiteContext(
+				{
+					location: 'help-center',
+					section: 'wp-admin',
+				},
+				[
+					[
+						'agents_manager_data',
+						typeof agentsManagerData !== 'undefined' && agentsManagerData?.isWpcomPlatform === true
+							? agentsManagerData?.site?.ID
+							: undefined,
+					],
+				]
+			)
+		);
 	} );
 
 	// Prevent multiple initializations

--- a/apps/help-center/__tests__/tracks.test.js
+++ b/apps/help-center/__tests__/tracks.test.js
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const mockRecordTracksEvent = jest.fn();
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	...jest.requireActual( '@automattic/calypso-analytics' ),
+	recordTracksEvent: mockRecordTracksEvent,
+} ) );
+
+const { recordDisconnectedHostTracksEvent, recordHostTracksEvent } = require( '../tracks' );
+
+describe( 'recordHostTracksEvent', () => {
+	beforeEach( () => {
+		mockRecordTracksEvent.mockClear();
+		delete globalThis.helpCenterData;
+	} );
+
+	it( 'adds site attribution from Help Center inline data', () => {
+		globalThis.helpCenterData = { site: { ID: 123 } };
+
+		recordHostTracksEvent( 'calypso_inlinehelp_show', { location: 'help-center' } );
+
+		expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_inlinehelp_show', {
+			location: 'help-center',
+			blog_id: 123,
+			site_context_source: 'help_center_data',
+		} );
+	} );
+
+	it( 'does not infer a site when Help Center data is unavailable', () => {
+		recordHostTracksEvent( 'calypso_inlinehelp_show', {
+			force_site_id: true,
+			location: 'help-center',
+		} );
+
+		expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_inlinehelp_show', {
+			location: 'help-center',
+			site_context_source: 'none',
+		} );
+	} );
+
+	it( 'does not trust site data for disconnected host events', () => {
+		globalThis.helpCenterData = { site: { ID: 123 } };
+
+		recordDisconnectedHostTracksEvent( 'calypso_inlinehelp_show', {
+			jetpack_disconnected_site: true,
+		} );
+
+		expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_inlinehelp_show', {
+			jetpack_disconnected_site: true,
+			site_context_source: 'none',
+		} );
+	} );
+} );

--- a/apps/help-center/help-center-customizer.jsx
+++ b/apps/help-center/help-center-customizer.jsx
@@ -1,11 +1,11 @@
 /* global helpCenterData */
 import './config';
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import HelpCenter from '@automattic/help-center';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import { useDispatch as useDataStoreDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useCallback } from '@wordpress/element';
 import { createRoot } from 'react-dom/client';
+import { recordHostTracksEvent } from './tracks';
 
 import './help-center.scss';
 
@@ -45,7 +45,7 @@ function CustomizerHelpCenterContent() {
 	);
 
 	const trackIconInteraction = useCallback( () => {
-		recordTracksEvent( 'wpcom_help_center_icon_interaction', {
+		recordHostTracksEvent( 'wpcom_help_center_icon_interaction', {
 			is_help_center_visible: isShown ?? false,
 			section: helpCenterData.sectionName || 'wp-customizer',
 			is_menu_panel_enabled: false,
@@ -54,8 +54,7 @@ function CustomizerHelpCenterContent() {
 
 	const handleToggleHelpCenter = useCallback( () => {
 		trackIconInteraction();
-		recordTracksEvent( `calypso_inlinehelp_${ isShown ? 'close' : 'show' }`, {
-			force_site_id: true,
+		recordHostTracksEvent( `calypso_inlinehelp_${ isShown ? 'close' : 'show' }`, {
 			location: 'help-center',
 			section: helpCenterData.sectionName || 'wp-customizer',
 		} );

--- a/apps/help-center/help-center-gutenberg.jsx
+++ b/apps/help-center/help-center-gutenberg.jsx
@@ -15,6 +15,7 @@ import { useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { useCanvasMode } from './hooks/use-canvas-mode';
 import { useMenuPanelExperiment } from './hooks/use-menu-panel-experiment';
+import { recordHostTracksEvent } from './tracks';
 import { getEditorType } from './utils';
 import './help-center.scss';
 
@@ -42,7 +43,7 @@ function HelpCenterContent() {
 	);
 
 	const trackIconInteraction = useCallback( () => {
-		recordTracksEvent( 'wpcom_help_center_icon_interaction', {
+		recordHostTracksEvent( 'wpcom_help_center_icon_interaction', {
 			is_help_center_visible: isShown ?? false,
 			section: helpCenterData.sectionName || 'wp-admin',
 			is_menu_panel_enabled: isMenuPanelExperimentEnabled ?? false,
@@ -52,8 +53,7 @@ function HelpCenterContent() {
 
 	const handleToggleHelpCenter = useCallback( () => {
 		trackIconInteraction();
-		recordTracksEvent( `calypso_inlinehelp_${ isShown ? 'close' : 'show' }`, {
-			force_site_id: true,
+		recordHostTracksEvent( `calypso_inlinehelp_${ isShown ? 'close' : 'show' }`, {
 			location: 'help-center',
 			section: helpCenterData.sectionName || 'gutenberg-editor',
 			editor_type: getEditorType(),
@@ -79,8 +79,7 @@ function HelpCenterContent() {
 					setNavigateToRoute( destination );
 					setHelpCenterPage( destination );
 				} else {
-					recordTracksEvent( `calypso_inlinehelp_close`, {
-						force_site_id: true,
+					recordHostTracksEvent( `calypso_inlinehelp_close`, {
 						location: 'help-center',
 						section: helpCenterData.sectionName || 'wp-admin',
 					} );
@@ -92,8 +91,7 @@ function HelpCenterContent() {
 				setHelpCenterPage( destination );
 				setShowHelpCenter( true );
 
-				recordTracksEvent( `calypso_inlinehelp_show`, {
-					force_site_id: true,
+				recordHostTracksEvent( `calypso_inlinehelp_show`, {
 					location: 'help-center',
 					section: helpCenterData.sectionName || 'wp-admin',
 					destination,

--- a/apps/help-center/help-center-wp-admin-disconnected.js
+++ b/apps/help-center/help-center-wp-admin-disconnected.js
@@ -1,6 +1,6 @@
 import './config';
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import './help-center.scss';
+import { recordDisconnectedHostTracksEvent } from './tracks';
 
 function initHelpCenterTracking() {
 	// Check for agents-manager-masterbar first, then fall back to help-center
@@ -10,8 +10,7 @@ function initHelpCenterTracking() {
 
 	if ( button && ! button.dataset.trackingInitialized ) {
 		button.addEventListener( 'click', () => {
-			recordTracksEvent( 'calypso_inlinehelp_show', {
-				force_site_id: true,
+			recordDisconnectedHostTracksEvent( 'calypso_inlinehelp_show', {
 				location: 'help-center',
 				section: 'wp-admin-disconnected',
 				jetpack_disconnected_site: true,

--- a/apps/help-center/help-center-wp-admin.jsx
+++ b/apps/help-center/help-center-wp-admin.jsx
@@ -7,6 +7,7 @@ import { useDispatch as useDataStoreDispatch, useSelect } from '@wordpress/data'
 import { useEffect, useCallback, useState } from '@wordpress/element';
 import { createRoot } from 'react-dom/client';
 import { useMenuPanelExperiment } from './hooks/use-menu-panel-experiment';
+import { recordHostTracksEvent } from './tracks';
 
 import './help-center.scss';
 
@@ -85,7 +86,7 @@ function AdminHelpCenterContent() {
 	);
 
 	const trackIconInteraction = useCallback( () => {
-		recordTracksEvent( 'wpcom_help_center_icon_interaction', {
+		recordHostTracksEvent( 'wpcom_help_center_icon_interaction', {
 			is_help_center_visible: isShown ?? false,
 			section: helpCenterData.sectionName || 'wp-admin',
 			is_menu_panel_enabled: isMenuPanelExperimentEnabled ?? false,
@@ -119,8 +120,7 @@ function AdminHelpCenterContent() {
 
 	const handleToggleHelpCenter = () => {
 		trackIconInteraction();
-		recordTracksEvent( `calypso_inlinehelp_${ isShown ? 'close' : 'show' }`, {
-			force_site_id: true,
+		recordHostTracksEvent( `calypso_inlinehelp_${ isShown ? 'close' : 'show' }`, {
 			location: 'help-center',
 			section: helpCenterData.sectionName || 'wp-admin',
 		} );
@@ -146,8 +146,7 @@ function AdminHelpCenterContent() {
 					setNavigateToRoute( destination );
 					setHelpCenterPage( destination );
 				} else {
-					recordTracksEvent( `calypso_inlinehelp_close`, {
-						force_site_id: true,
+					recordHostTracksEvent( `calypso_inlinehelp_close`, {
 						location: 'help-center',
 						section: helpCenterData.sectionName || 'wp-admin',
 					} );
@@ -159,8 +158,7 @@ function AdminHelpCenterContent() {
 				setHelpCenterPage( destination );
 				setShowHelpCenter( true );
 
-				recordTracksEvent( `calypso_inlinehelp_show`, {
-					force_site_id: true,
+				recordHostTracksEvent( `calypso_inlinehelp_show`, {
 					location: 'help-center',
 					section: helpCenterData.sectionName || 'wp-admin',
 					destination,

--- a/apps/help-center/jest.config.js
+++ b/apps/help-center/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	preset: '../../test/packages/jest-preset.js',
+	testEnvironment: 'jsdom',
+	testMatch: [ '<rootDir>/**/__tests__/*.[jt]s?(x)', '!**/.eslintrc.*' ],
+	moduleFileExtensions: [ 'js', 'jsx', 'ts', 'tsx', 'json' ],
+};

--- a/apps/help-center/tracks.js
+++ b/apps/help-center/tracks.js
@@ -1,0 +1,18 @@
+/* global helpCenterData */
+import { recordTracksEvent, withSiteContext } from '@automattic/calypso-analytics';
+
+export function recordHostTracksEvent( eventName, properties = {} ) {
+	recordTracksEvent(
+		eventName,
+		withSiteContext( properties, [
+			[
+				'help_center_data',
+				typeof helpCenterData !== 'undefined' ? helpCenterData?.site?.ID : undefined,
+			],
+		] )
+	);
+}
+
+export function recordDisconnectedHostTracksEvent( eventName, properties = {} ) {
+	recordTracksEvent( eventName, withSiteContext( properties, [] ) );
+}

--- a/apps/help-center/tracks.js
+++ b/apps/help-center/tracks.js
@@ -1,18 +1,17 @@
 /* global helpCenterData */
-import { recordTracksEvent, withSiteContext } from '@automattic/calypso-analytics';
+import { NO_SITE_CONTEXT, recordTracksEvent, withSiteContext } from '@automattic/calypso-analytics';
 
 export function recordHostTracksEvent( eventName, properties = {} ) {
 	recordTracksEvent(
 		eventName,
-		withSiteContext( properties, [
-			[
-				'help_center_data',
-				typeof helpCenterData !== 'undefined' ? helpCenterData?.site?.ID : undefined,
-			],
-		] )
+		withSiteContext(
+			properties,
+			'help_center_data',
+			typeof helpCenterData !== 'undefined' ? helpCenterData?.site?.ID : undefined
+		)
 	);
 }
 
 export function recordDisconnectedHostTracksEvent( eventName, properties = {} ) {
-	recordTracksEvent( eventName, withSiteContext( properties, [] ) );
+	recordTracksEvent( eventName, withSiteContext( properties, NO_SITE_CONTEXT ) );
 }

--- a/client/blocks/eligibility-warnings/support-link.tsx
+++ b/client/blocks/eligibility-warnings/support-link.tsx
@@ -1,4 +1,4 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { recordTracksEvent, withSiteContext } from '@automattic/calypso-analytics';
 import { HelpCenter } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
 import {
@@ -8,6 +8,7 @@ import {
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
+import { useHelpCenterSite } from 'calypso/layout/use-help-center-site';
 import { getSectionName } from 'calypso/state/ui/selectors';
 import type { HelpCenterSelect } from '@automattic/data-stores';
 
@@ -20,6 +21,7 @@ const SupportLink = ( {
 	onShowHelpAssistant?: () => void;
 } & LocalizeProps ) => {
 	const sectionName = useSelector( getSectionName );
+	const { selectedSite, urlParamSite, primarySite } = useHelpCenterSite();
 	const { show, isMinimized } = useDateStoreSelect( ( select ) => {
 		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
 		return {
@@ -38,11 +40,20 @@ const SupportLink = ( {
 		if ( ! show ) {
 			setShowHelpCenter( true );
 
-			recordTracksEvent( 'calypso_inlinehelp_show', {
-				force_site_id: true,
-				location: 'help-center',
-				section: sectionName,
-			} );
+			recordTracksEvent(
+				'calypso_inlinehelp_show',
+				withSiteContext(
+					{
+						location: 'help-center',
+						section: sectionName,
+					},
+					[
+						[ 'calypso_selected_site', selectedSite?.ID ],
+						[ 'calypso_url_param_site', urlParamSite?.ID ],
+						[ 'calypso_primary_site', primarySite?.ID ],
+					]
+				)
+			);
 		}
 
 		if ( isMinimized ) {
@@ -54,6 +65,9 @@ const SupportLink = ( {
 		show,
 		setShowHelpCenter,
 		sectionName,
+		selectedSite?.ID,
+		urlParamSite?.ID,
+		primarySite?.ID,
 		isMinimized,
 		setIsMinimized,
 	] );

--- a/client/blocks/eligibility-warnings/support-link.tsx
+++ b/client/blocks/eligibility-warnings/support-link.tsx
@@ -21,7 +21,7 @@ const SupportLink = ( {
 	onShowHelpAssistant?: () => void;
 } & LocalizeProps ) => {
 	const sectionName = useSelector( getSectionName );
-	const { siteCandidates } = useHelpCenterSite();
+	const { site, siteContextSource } = useHelpCenterSite();
 	const { show, isMinimized } = useDateStoreSelect( ( select ) => {
 		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
 		return {
@@ -47,7 +47,8 @@ const SupportLink = ( {
 						location: 'help-center',
 						section: sectionName,
 					},
-					siteCandidates
+					siteContextSource,
+					site?.ID
 				)
 			);
 		}
@@ -61,7 +62,8 @@ const SupportLink = ( {
 		show,
 		setShowHelpCenter,
 		sectionName,
-		siteCandidates,
+		siteContextSource,
+		site?.ID,
 		isMinimized,
 		setIsMinimized,
 	] );

--- a/client/blocks/eligibility-warnings/support-link.tsx
+++ b/client/blocks/eligibility-warnings/support-link.tsx
@@ -21,7 +21,7 @@ const SupportLink = ( {
 	onShowHelpAssistant?: () => void;
 } & LocalizeProps ) => {
 	const sectionName = useSelector( getSectionName );
-	const { selectedSite, urlParamSite, primarySite } = useHelpCenterSite();
+	const { siteCandidates } = useHelpCenterSite();
 	const { show, isMinimized } = useDateStoreSelect( ( select ) => {
 		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
 		return {
@@ -47,11 +47,7 @@ const SupportLink = ( {
 						location: 'help-center',
 						section: sectionName,
 					},
-					[
-						[ 'calypso_selected_site', selectedSite?.ID ],
-						[ 'calypso_url_param_site', urlParamSite?.ID ],
-						[ 'calypso_primary_site', primarySite?.ID ],
-					]
+					siteCandidates
 				)
 			);
 		}
@@ -65,9 +61,7 @@ const SupportLink = ( {
 		show,
 		setShowHelpCenter,
 		sectionName,
-		selectedSite?.ID,
-		urlParamSite?.ID,
-		primarySite?.ID,
+		siteCandidates,
 		isMinimized,
 		setIsMinimized,
 	] );

--- a/client/blocks/inline-help/inline-help-search-card.tsx
+++ b/client/blocks/inline-help/inline-help-search-card.tsx
@@ -66,7 +66,8 @@ const InlineHelpSearchCard = ( {
 						location: location,
 						section: sectionName,
 					},
-					[ [ siteContextSource, blogId ] ]
+					siteContextSource,
+					blogId
 				)
 			);
 		}

--- a/client/blocks/inline-help/inline-help-search-card.tsx
+++ b/client/blocks/inline-help/inline-help-search-card.tsx
@@ -18,8 +18,10 @@ type Props = {
 	onSearch?: ( query: string ) => void;
 	sectionName: string;
 	useSearchControl: boolean;
+	// An absent blogId means the caller has no site — the event reports
+	// site_context_source 'none' and super props will not infer one.
 	blogId?: number | string;
-	siteContextSource?: string;
+	siteContextSource: string;
 };
 
 const AUTO_FOCUS_LOCATION = [ 'help-center', 'inline-help-popover' ];
@@ -33,7 +35,7 @@ const InlineHelpSearchCard = ( {
 	sectionName,
 	useSearchControl,
 	blogId,
-	siteContextSource = 'explicit',
+	siteContextSource,
 }: Props ) => {
 	const cardRef = useRef< { searchInput: HTMLInputElement } >( undefined );
 	const translate = useTranslate();

--- a/client/blocks/inline-help/inline-help-search-card.tsx
+++ b/client/blocks/inline-help/inline-help-search-card.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-imports */
-import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { recordTracksEvent, withSiteContext } from '@automattic/calypso-analytics';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useEffect } from 'react';
@@ -18,6 +18,8 @@ type Props = {
 	onSearch?: ( query: string ) => void;
 	sectionName: string;
 	useSearchControl: boolean;
+	blogId?: number | string;
+	siteContextSource?: string;
 };
 
 const AUTO_FOCUS_LOCATION = [ 'help-center', 'inline-help-popover' ];
@@ -30,6 +32,8 @@ const InlineHelpSearchCard = ( {
 	onSearch,
 	sectionName,
 	useSearchControl,
+	blogId,
+	siteContextSource = 'explicit',
 }: Props ) => {
 	const cardRef = useRef< { searchInput: HTMLInputElement } >( undefined );
 	const translate = useTranslate();
@@ -48,22 +52,23 @@ const InlineHelpSearchCard = ( {
 
 	const searchHelperHandler = ( query: string ) => {
 		const inputQuery = query.trim();
+		const shouldTrack = location === 'help-center' ? inputQuery.length > 2 : inputQuery.length > 0;
 
-		if ( location === 'help-center' ) {
-			if ( inputQuery?.length > 2 ) {
-				recordTracksEvent( 'calypso_inlinehelp_search', {
-					search_query: query,
-					location: location,
-					section: sectionName,
-				} );
+		if ( shouldTrack ) {
+			if ( location !== 'help-center' ) {
+				debug( 'search query received: ', query );
 			}
-		} else if ( inputQuery?.length ) {
-			debug( 'search query received: ', query );
-			recordTracksEvent( 'calypso_inlinehelp_search', {
-				search_query: query,
-				location: location,
-				section: sectionName,
-			} );
+			recordTracksEvent(
+				'calypso_inlinehelp_search',
+				withSiteContext(
+					{
+						search_query: query,
+						location: location,
+						section: sectionName,
+					},
+					[ [ siteContextSource, blogId ] ]
+				)
+			);
 		}
 
 		// Set the query search

--- a/client/blocks/inline-help/test/inline-help-search-card.test.tsx
+++ b/client/blocks/inline-help/test/inline-help-search-card.test.tsx
@@ -34,6 +34,7 @@ const renderCard = ( blogId?: number ) =>
 			sectionName="help-center"
 			useSearchControl={ false }
 			blogId={ blogId }
+			siteContextSource="explicit"
 		/>
 	);
 

--- a/client/blocks/inline-help/test/inline-help-search-card.test.tsx
+++ b/client/blocks/inline-help/test/inline-help-search-card.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import InlineHelpSearchCard from '../inline-help-search-card';
+
+const mockRecordTracksEvent = recordTracksEvent as jest.Mock;
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	...jest.requireActual( '@automattic/calypso-analytics' ),
+	recordTracksEvent: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/components/search-card', () => ( {
+	__esModule: true,
+	default: ( { onSearch }: { onSearch: ( query: string ) => void } ) => (
+		<input
+			aria-label="search"
+			onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
+				onSearch( event.target.value )
+			}
+		/>
+	),
+} ) );
+
+const renderCard = ( blogId?: number ) =>
+	render(
+		<InlineHelpSearchCard
+			searchQuery=""
+			location="help-center"
+			sectionName="help-center"
+			useSearchControl={ false }
+			blogId={ blogId }
+		/>
+	);
+
+describe( 'InlineHelpSearchCard', () => {
+	beforeEach( () => {
+		mockRecordTracksEvent.mockClear();
+	} );
+
+	it( 'tracks explicit site attribution', () => {
+		renderCard( 123 );
+
+		fireEvent.change( screen.getByRole( 'textbox', { name: 'search' } ), {
+			target: { value: 'domains' },
+		} );
+
+		expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_inlinehelp_search',
+			expect.objectContaining( {
+				blog_id: 123,
+				site_context_source: 'explicit',
+			} )
+		);
+	} );
+
+	it( 'does not infer site attribution when site is absent', () => {
+		renderCard();
+
+		fireEvent.change( screen.getByRole( 'textbox', { name: 'search' } ), {
+			target: { value: 'domains' },
+		} );
+
+		expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_inlinehelp_search',
+			expect.objectContaining( { site_context_source: 'none' } )
+		);
+		expect( mockRecordTracksEvent.mock.calls[ 0 ][ 1 ] ).not.toHaveProperty( 'blog_id' );
+	} );
+} );

--- a/client/dashboard/app/analytics/super-props.ts
+++ b/client/dashboard/app/analytics/super-props.ts
@@ -1,43 +1,71 @@
-import { siteBySlugQuery, sitesQueryKey } from '@automattic/api-queries';
+import { siteByIdQuery, siteBySlugQuery, sitesQueryKey } from '@automattic/api-queries';
+// eslint-disable-next-line no-restricted-imports -- Explicit event site attribution must precede dashboard super props.
+import { getValidBlogId, NO_SITE_CONTEXT } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import type { User, Site } from '@automattic/api-core';
 import type { QueryClient } from '@tanstack/react-query';
 import type { AnyRouter, RouterState } from '@tanstack/react-router';
 
-export const getSuperProps = ( user: User, router: AnyRouter, queryClient: QueryClient ) => () => {
-	const superProps = {
-		environment: process.env.NODE_ENV,
-		environment_id: config( 'env_id' ),
-		site_count: user.site_count,
-		site_id_label: 'wpcom',
-		client: config( 'client_slug' ),
+export const getSuperProps =
+	( user: User, router: AnyRouter, queryClient: QueryClient ) =>
+	( eventProperties: Record< string, unknown > = {} ): Record< string, unknown > => {
+		const superProps = {
+			environment: process.env.NODE_ENV,
+			environment_id: config( 'env_id' ),
+			site_count: user.site_count,
+			site_id_label: 'wpcom',
+			client: config( 'client_slug' ),
+		};
+
+		if ( typeof window !== 'undefined' ) {
+			Object.assign( superProps, {
+				vph: window.innerHeight,
+				vpw: window.innerWidth,
+			} );
+		}
+
+		const explicitBlogId = getValidBlogId( eventProperties.blog_id );
+		if ( explicitBlogId ) {
+			const explicitSite = getSiteFromCache( queryClient, explicitBlogId );
+
+			if ( ! explicitSite ) {
+				const explicitSuperProps = Object.fromEntries(
+					Object.entries( superProps ).filter( ( [ key ] ) => key !== 'site_id_label' )
+				);
+				return { ...explicitSuperProps, blog_id: explicitBlogId };
+			}
+
+			return {
+				...superProps,
+				blog_id: explicitBlogId,
+				blog_lang: explicitSite.lang,
+				site_id_label: explicitSite.jetpack ? 'jetpack' : 'wpcom',
+				site_plan_id: explicitSite.plan?.product_id ?? null,
+			};
+		}
+
+		if ( eventProperties.site_context_source === NO_SITE_CONTEXT ) {
+			return superProps;
+		}
+
+		const siteSlug = router.state.matches.at( -1 )?.params?.siteSlug;
+		if ( ! siteSlug ) {
+			return superProps;
+		}
+
+		const site = getSiteFromCache( queryClient, siteSlug );
+		if ( ! site ) {
+			return superProps;
+		}
+
+		return {
+			...superProps,
+			blog_id: site.ID,
+			blog_lang: site.lang,
+			site_id_label: site.jetpack ? 'jetpack' : 'wpcom',
+			site_plan_id: site.plan?.product_id ?? null,
+		};
 	};
-
-	if ( typeof window !== 'undefined' ) {
-		Object.assign( superProps, {
-			vph: window.innerHeight,
-			vpw: window.innerWidth,
-		} );
-	}
-
-	const siteSlug = router.state.matches.at( -1 )?.params?.siteSlug;
-	if ( ! siteSlug ) {
-		return superProps;
-	}
-
-	const site = getSiteFromCache( queryClient, siteSlug );
-	if ( ! site ) {
-		return superProps;
-	}
-
-	return {
-		...superProps,
-		blog_id: site.ID,
-		blog_lang: site.lang,
-		site_id_label: site.jetpack ? 'jetpack' : 'wpcom',
-		site_plan_id: site.plan?.product_id ?? null,
-	};
-};
 
 /**
  * Normalize the path by removing leading double slashes and trailing slashes.
@@ -53,28 +81,48 @@ export function getNormalizedPath( matches: RouterState[ 'matches' ], basePath =
 /**
  * Attempts to retrieve the site information from the tanstack cache.
  *
- * It looks for the site slug in both the "site" and "sites" caches. Perhaps it's
+ * It looks for the site identifier in both the "site" and "sites" caches. Perhaps it's
  * overkill to search in both places. But this whole thing is a heuristic - we're
  * hoping to attach site info if it happens to be available. So I think checking
  * both caches represents a "best effort" attempt.
  */
-export function getSiteFromCache( queryClient: QueryClient, siteSlug: string ): Site | undefined {
-	const site = queryClient.getQueryData< Site >( siteBySlugQuery( siteSlug ).queryKey );
+export function getSiteFromCache(
+	queryClient: QueryClient,
+	siteSlugOrId: string | number
+): Site | undefined {
+	const site =
+		typeof siteSlugOrId === 'string'
+			? queryClient.getQueryData< Site >( siteBySlugQuery( siteSlugOrId ).queryKey )
+			: queryClient.getQueryData< Site >( siteByIdQuery( siteSlugOrId ).queryKey );
 	if ( site ) {
 		return site;
+	}
+
+	const sitesBySlugQueries = queryClient.getQueriesData< Site >( {
+		queryKey: [ 'site-by-slug' ],
+	} );
+	const siteById = sitesBySlugQueries
+		.map( ( [ , data ] ) => data )
+		.find( ( cachedSite ) => cachedSite?.ID === Number( siteSlugOrId ) );
+	if ( siteById ) {
+		return siteById;
 	}
 
 	const sitesQueries = queryClient.getQueriesData< Site[] | { sites: Site[] } >( {
 		queryKey: sitesQueryKey,
 	} );
+	const cachedSites = sitesQueries
+		.map( ( [ , data ] ) => {
+			const sites = Array.isArray( data ) ? data : data?.sites;
+			return sites || [];
+		} )
+		.flat();
 	const sitesBySlug = new Map(
-		sitesQueries
-			.map( ( [ , data ] ) => {
-				const sites = Array.isArray( data ) ? data : data?.sites;
-				return ( sites || [] ).map( ( site ) => [ site.slug, site ] as const );
-			} )
-			.flat() as [ string, Site ][]
+		cachedSites.map( ( cachedSite ) => [ cachedSite.slug, cachedSite ] as [ string, Site ] )
 	);
 
-	return sitesBySlug.get( siteSlug );
+	return (
+		( typeof siteSlugOrId === 'string' ? sitesBySlug.get( siteSlugOrId ) : undefined ) ??
+		cachedSites.find( ( cachedSite ) => cachedSite?.ID === Number( siteSlugOrId ) )
+	);
 }

--- a/client/dashboard/app/analytics/test/super-props.test.ts
+++ b/client/dashboard/app/analytics/test/super-props.test.ts
@@ -1,0 +1,99 @@
+import { siteByIdQuery, siteBySlugQuery } from '@automattic/api-queries';
+import { QueryClient } from '@tanstack/react-query';
+import { getSuperProps } from '../super-props';
+import type { Site, User } from '@automattic/api-core';
+import type { AnyRouter } from '@tanstack/react-router';
+
+const user = { site_count: 2 } as User;
+
+function createRouter( siteSlug?: string ) {
+	return {
+		state: {
+			matches: siteSlug ? [ { params: { siteSlug } } ] : [],
+		},
+	} as unknown as AnyRouter;
+}
+
+describe( 'getSuperProps', () => {
+	test( 'preserves explicit blog_id when route site differs', () => {
+		const queryClient = new QueryClient();
+		queryClient.setQueryData( siteBySlugQuery( 'route-site' ).queryKey, {
+			ID: 11,
+			lang: 'en',
+		} as unknown as Site );
+
+		const superProps = getSuperProps(
+			user,
+			createRouter( 'route-site' ),
+			queryClient
+		)( { blog_id: 22 } );
+
+		expect( superProps.blog_id ).toBe( 22 );
+	} );
+
+	test( 'uses cached explicit site metadata when available', () => {
+		const queryClient = new QueryClient();
+		queryClient.setQueryData( siteByIdQuery( 22 ).queryKey, {
+			ID: 22,
+			lang: 'it',
+			jetpack: true,
+			plan: { product_id: 'business' },
+		} as unknown as Site );
+
+		const superProps = getSuperProps(
+			user,
+			createRouter( 'route-site' ),
+			queryClient
+		)( { blog_id: 22 } );
+
+		expect( superProps ).toEqual(
+			expect.objectContaining( {
+				blog_id: 22,
+				blog_lang: 'it',
+				site_id_label: 'jetpack',
+				site_plan_id: 'business',
+			} )
+		);
+	} );
+
+	test( 'uses explicit site metadata cached by slug', () => {
+		const queryClient = new QueryClient();
+		queryClient.setQueryData( siteBySlugQuery( 'explicit-site' ).queryKey, {
+			ID: 22,
+			lang: 'it',
+			jetpack: true,
+			plan: { product_id: 'business' },
+		} as unknown as Site );
+
+		const superProps = getSuperProps(
+			user,
+			createRouter( 'route-site' ),
+			queryClient
+		)( { blog_id: 22 } );
+
+		expect( superProps ).toEqual(
+			expect.objectContaining( {
+				blog_id: 22,
+				blog_lang: 'it',
+				site_id_label: 'jetpack',
+				site_plan_id: 'business',
+			} )
+		);
+	} );
+
+	test( 'does not infer route site when site context is explicitly absent', () => {
+		const queryClient = new QueryClient();
+		queryClient.setQueryData( siteBySlugQuery( 'route-site' ).queryKey, {
+			ID: 11,
+			lang: 'en',
+		} as unknown as Site );
+
+		const superProps = getSuperProps(
+			user,
+			createRouter( 'route-site' ),
+			queryClient
+		)( { force_site_id: true, site_context_source: 'none' } );
+
+		expect( superProps ).not.toHaveProperty( 'blog_id' );
+	} );
+} );

--- a/client/dashboard/app/interim-omnibar/omnibar-help-center.tsx
+++ b/client/dashboard/app/interim-omnibar/omnibar-help-center.tsx
@@ -1,9 +1,36 @@
+import { omnibarSiteIdQuery, siteByIdQuery } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
+import { useQuery } from '@tanstack/react-query';
 import { Suspense, lazy, useCallback, useState } from 'react';
 import { useAuth } from '../auth';
 import { useHelpCenter } from '../help-center';
+import type HelpCenterApp from '../help-center/help-center-app';
+import type { Site } from '@automattic/api-core';
 
 const AsyncHelpCenterApp = lazy( () => import( '../help-center/help-center-app' ) );
+
+type HelpCenterSite = NonNullable< React.ComponentProps< typeof HelpCenterApp >[ 'site' ] >;
+
+// The dashboard has no `launchpad_screen` option, so the launchpad features it
+// gates simply stay off.
+function toHelpCenterSite( site: Site ): HelpCenterSite {
+	return {
+		ID: site.ID,
+		name: site.name,
+		URL: site.URL,
+		domain: site.slug,
+		plan: { product_slug: site.plan?.product_slug ?? '' },
+		is_wpcom_atomic: site.is_wpcom_atomic,
+		jetpack: site.jetpack,
+		logo: { id: 0, sizes: [], url: site.icon?.img ?? '' },
+		site_owner: site.site_owner,
+		options: {
+			launchpad_screen: '',
+			site_intent: site.options?.site_intent ?? '',
+			admin_url: site.options?.admin_url ?? '',
+		},
+	};
+}
 
 /**
  * The `help-center` query param is acted on by `useActionHooks` inside the
@@ -28,6 +55,11 @@ export default function OmnibarHelpCenter() {
 	const { user } = useAuth();
 	const { isShown, setShowHelpCenter } = useHelpCenter();
 	const [ shouldMount, setShouldMount ] = useState( hasHelpCenterQueryParam );
+	const { data: omnibarSiteId } = useQuery( omnibarSiteIdQuery() );
+	const { data: site } = useQuery( {
+		...siteByIdQuery( omnibarSiteId ?? 0 ),
+		enabled: !! omnibarSiteId,
+	} );
 
 	const handleClose = useCallback( () => {
 		setShowHelpCenter( false, undefined, true );
@@ -52,6 +84,7 @@ export default function OmnibarHelpCenter() {
 				locale={ user.language }
 				onboardingUrl={ config( 'wpcom_signup_url' ) }
 				sectionName="dashboard"
+				site={ site ? toHelpCenterSite( site ) : null }
 			/>
 		</Suspense>
 	);

--- a/client/dashboard/app/interim-omnibar/test/omnibar-help-center.test.tsx
+++ b/client/dashboard/app/interim-omnibar/test/omnibar-help-center.test.tsx
@@ -2,13 +2,20 @@
  * @jest-environment jsdom
  */
 
+import { omnibarSiteIdQuery, siteByIdQuery } from '@automattic/api-queries';
+import { QueryClient } from '@tanstack/react-query';
 import { screen } from '@testing-library/react';
 import { render } from '../../../test-utils';
 import OmnibarHelpCenter from '../omnibar-help-center';
+import type { Site } from '@automattic/api-core';
 
 jest.mock( '@automattic/help-center', () => ( {
 	__esModule: true,
-	default: () => <div role="region" aria-label="Help Center" />,
+	default: ( { site }: { site?: { ID: number } | null } ) => (
+		<div role="region" aria-label="Help Center">
+			{ site ? `site:${ site.ID }` : 'site:none' }
+		</div>
+	),
 } ) );
 
 describe( '<OmnibarHelpCenter />', () => {
@@ -40,6 +47,29 @@ describe( '<OmnibarHelpCenter />', () => {
 
 			unmount();
 		}
+	} );
+
+	test( 'hands the omnibar site to the Help Center', async () => {
+		window.history.replaceState( {}, '', '/sites?help-center=home' );
+		const queryClient = new QueryClient( {
+			defaultOptions: { queries: { retry: false } },
+		} );
+		queryClient.setQueryData( omnibarSiteIdQuery().queryKey, 456 );
+		queryClient.setQueryData( siteByIdQuery( 456 ).queryKey, {
+			ID: 456,
+			name: 'Test Site',
+			URL: 'https://test.example',
+			slug: 'test.example',
+			is_wpcom_atomic: false,
+			jetpack: false,
+			site_owner: 1,
+		} as Site );
+
+		render( <OmnibarHelpCenter />, { queryClient } );
+
+		expect( await screen.findByRole( 'region', { name: 'Help Center' } ) ).toHaveTextContent(
+			'site:456'
+		);
 	} );
 
 	test( 'ignores unrelated query params', () => {

--- a/client/dashboard/app/omnibar/plugin-help-center.tsx
+++ b/client/dashboard/app/omnibar/plugin-help-center.tsx
@@ -76,7 +76,8 @@ function handleMenuClick(
 					location: 'help-center',
 					section: 'dashboard',
 				},
-				[ [ 'omnibar', omnibarSiteId ] ]
+				'omnibar',
+				omnibarSiteId
 			)
 		);
 		closeAgentsManagerChat();
@@ -95,7 +96,8 @@ function handleMenuClick(
 				section: 'dashboard',
 				destination,
 			},
-			[ [ 'omnibar', omnibarSiteId ] ]
+			'omnibar',
+			omnibarSiteId
 		)
 	);
 }

--- a/client/dashboard/app/omnibar/plugin-help-center.tsx
+++ b/client/dashboard/app/omnibar/plugin-help-center.tsx
@@ -5,7 +5,11 @@ import {
 	openAgentsManagerChat,
 	useShouldUseUnifiedAgent,
 } from '@automattic/agents-manager';
+import { omnibarSiteIdQuery } from '@automattic/api-queries';
+// eslint-disable-next-line no-restricted-imports -- Help Center host events need explicit site attribution.
+import { withSiteContext } from '@automattic/calypso-analytics';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { Icon, backup, comment, page, rss, video } from '@wordpress/icons';
 import { useAnalytics } from '../analytics';
@@ -46,6 +50,7 @@ function menuIcon( icon: JSX.Element ) {
 function handleMenuClick(
 	recordTracksEvent: RecordTracksEvent,
 	destination: string,
+	omnibarSiteId: number | null | undefined,
 	isExternal = false
 ) {
 	// Re-clicking the current route closes the chat; external links never do.
@@ -64,11 +69,16 @@ function handleMenuClick(
 	}
 
 	if ( isClosing ) {
-		recordTracksEvent( 'calypso_inlinehelp_close', {
-			force_site_id: true,
-			location: 'help-center',
-			section: 'dashboard',
-		} );
+		recordTracksEvent(
+			'calypso_inlinehelp_close',
+			withSiteContext(
+				{
+					location: 'help-center',
+					section: 'dashboard',
+				},
+				[ [ 'omnibar', omnibarSiteId ] ]
+			)
+		);
 		closeAgentsManagerChat();
 		return;
 	}
@@ -77,15 +87,23 @@ function handleMenuClick(
 	// other items open the chat at their own route.
 	openAgentsManagerChat( destination === '/chat' ? undefined : destination );
 
-	recordTracksEvent( 'calypso_inlinehelp_show', {
-		force_site_id: true,
-		location: 'help-center',
-		section: 'dashboard',
-		destination,
-	} );
+	recordTracksEvent(
+		'calypso_inlinehelp_show',
+		withSiteContext(
+			{
+				location: 'help-center',
+				section: 'dashboard',
+				destination,
+			},
+			[ [ 'omnibar', omnibarSiteId ] ]
+		)
+	);
 }
 
-function getAgentsManagerMenuNodes( recordTracksEvent: RecordTracksEvent ): OmnibarNode[] {
+function getAgentsManagerMenuNodes(
+	recordTracksEvent: RecordTracksEvent,
+	omnibarSiteId: number | null | undefined
+): OmnibarNode[] {
 	return [
 		{
 			id: 'help-chat',
@@ -95,13 +113,13 @@ function getAgentsManagerMenuNodes( recordTracksEvent: RecordTracksEvent ): Omni
 					id: 'chat-support',
 					title: __( 'Chat support' ),
 					icon: menuIcon( comment ),
-					onClick: () => handleMenuClick( recordTracksEvent, '/chat' ),
+					onClick: () => handleMenuClick( recordTracksEvent, '/chat', omnibarSiteId ),
 				},
 				{
 					id: 'chat-history',
 					title: __( 'Chat history' ),
 					icon: menuIcon( backup ),
-					onClick: () => handleMenuClick( recordTracksEvent, '/history' ),
+					onClick: () => handleMenuClick( recordTracksEvent, '/history', omnibarSiteId ),
 				},
 			],
 		},
@@ -114,7 +132,7 @@ function getAgentsManagerMenuNodes( recordTracksEvent: RecordTracksEvent ): Omni
 					id: 'support-guides',
 					title: __( 'Support guides' ),
 					icon: menuIcon( page ),
-					onClick: () => handleMenuClick( recordTracksEvent, '/support-guides' ),
+					onClick: () => handleMenuClick( recordTracksEvent, '/support-guides', omnibarSiteId ),
 				},
 				{
 					id: 'courses',
@@ -124,6 +142,7 @@ function getAgentsManagerMenuNodes( recordTracksEvent: RecordTracksEvent ): Omni
 						handleMenuClick(
 							recordTracksEvent,
 							localizeUrl( 'https://wordpress.com/support/courses/' ),
+							omnibarSiteId,
 							true
 						),
 				},
@@ -135,6 +154,7 @@ function getAgentsManagerMenuNodes( recordTracksEvent: RecordTracksEvent ): Omni
 						handleMenuClick(
 							recordTracksEvent,
 							localizeUrl( 'https://wordpress.com/blog/category/product-features/' ),
+							omnibarSiteId,
 							true
 						),
 				},
@@ -147,13 +167,14 @@ export function useHelpCenterPlugin(): OmnibarNode {
 	const shouldUseUnifiedAgent = useShouldUseUnifiedAgent();
 	const { isShown: isHelpCenterShown, setShowHelpCenter } = useHelpCenter();
 	const { recordTracksEvent } = useAnalytics();
+	const { data: omnibarSiteId } = useQuery( omnibarSiteIdQuery() );
 
 	if ( shouldUseUnifiedAgent ) {
 		return {
 			id: 'help-center',
 			label: __( 'Help' ),
 			icon: <HelpIcon />,
-			children: getAgentsManagerMenuNodes( recordTracksEvent ),
+			children: getAgentsManagerMenuNodes( recordTracksEvent, omnibarSiteId ),
 		};
 	}
 

--- a/client/dashboard/app/omnibar/plugin-help-center.tsx
+++ b/client/dashboard/app/omnibar/plugin-help-center.tsx
@@ -14,10 +14,7 @@ import { __ } from '@wordpress/i18n';
 import { Icon, backup, comment, page, rss, video } from '@wordpress/icons';
 import { useAnalytics } from '../analytics';
 import { useHelpCenter } from '../help-center';
-import { useRouteSiteId } from './site';
 import type { AnalyticsClient } from '../analytics';
-// eslint-disable-next-line no-restricted-imports -- Help Center host events need explicit site attribution.
-import type { SiteCandidate } from '@automattic/calypso-analytics';
 import type { OmnibarNode } from '@automattic/omnibar';
 
 import './plugin-help-center.scss';
@@ -53,7 +50,7 @@ function menuIcon( icon: JSX.Element ) {
 function handleMenuClick(
 	recordTracksEvent: RecordTracksEvent,
 	destination: string,
-	siteCandidates: readonly SiteCandidate[],
+	omnibarSiteId: number | null | undefined,
 	isExternal = false
 ) {
 	// Re-clicking the current route closes the chat; external links never do.
@@ -79,7 +76,7 @@ function handleMenuClick(
 					location: 'help-center',
 					section: 'dashboard',
 				},
-				siteCandidates
+				[ [ 'omnibar', omnibarSiteId ] ]
 			)
 		);
 		closeAgentsManagerChat();
@@ -98,14 +95,14 @@ function handleMenuClick(
 				section: 'dashboard',
 				destination,
 			},
-			siteCandidates
+			[ [ 'omnibar', omnibarSiteId ] ]
 		)
 	);
 }
 
 function getAgentsManagerMenuNodes(
 	recordTracksEvent: RecordTracksEvent,
-	siteCandidates: readonly SiteCandidate[]
+	omnibarSiteId: number | null | undefined
 ): OmnibarNode[] {
 	return [
 		{
@@ -116,13 +113,13 @@ function getAgentsManagerMenuNodes(
 					id: 'chat-support',
 					title: __( 'Chat support' ),
 					icon: menuIcon( comment ),
-					onClick: () => handleMenuClick( recordTracksEvent, '/chat', siteCandidates ),
+					onClick: () => handleMenuClick( recordTracksEvent, '/chat', omnibarSiteId ),
 				},
 				{
 					id: 'chat-history',
 					title: __( 'Chat history' ),
 					icon: menuIcon( backup ),
-					onClick: () => handleMenuClick( recordTracksEvent, '/history', siteCandidates ),
+					onClick: () => handleMenuClick( recordTracksEvent, '/history', omnibarSiteId ),
 				},
 			],
 		},
@@ -135,7 +132,7 @@ function getAgentsManagerMenuNodes(
 					id: 'support-guides',
 					title: __( 'Support guides' ),
 					icon: menuIcon( page ),
-					onClick: () => handleMenuClick( recordTracksEvent, '/support-guides', siteCandidates ),
+					onClick: () => handleMenuClick( recordTracksEvent, '/support-guides', omnibarSiteId ),
 				},
 				{
 					id: 'courses',
@@ -145,7 +142,7 @@ function getAgentsManagerMenuNodes(
 						handleMenuClick(
 							recordTracksEvent,
 							localizeUrl( 'https://wordpress.com/support/courses/' ),
-							siteCandidates,
+							omnibarSiteId,
 							true
 						),
 				},
@@ -157,7 +154,7 @@ function getAgentsManagerMenuNodes(
 						handleMenuClick(
 							recordTracksEvent,
 							localizeUrl( 'https://wordpress.com/blog/category/product-features/' ),
-							siteCandidates,
+							omnibarSiteId,
 							true
 						),
 				},
@@ -171,20 +168,13 @@ export function useHelpCenterPlugin(): OmnibarNode {
 	const { isShown: isHelpCenterShown, setShowHelpCenter } = useHelpCenter();
 	const { recordTracksEvent } = useAnalytics();
 	const { data: omnibarSiteId } = useQuery( omnibarSiteIdQuery() );
-	// The omnibar site is published asynchronously, so the route is the only
-	// site available while it resolves.
-	const routeSiteId = useRouteSiteId();
-	const siteCandidates: SiteCandidate[] = [
-		[ 'omnibar', omnibarSiteId ],
-		[ 'dashboard_route', routeSiteId ],
-	];
 
 	if ( shouldUseUnifiedAgent ) {
 		return {
 			id: 'help-center',
 			label: __( 'Help' ),
 			icon: <HelpIcon />,
-			children: getAgentsManagerMenuNodes( recordTracksEvent, siteCandidates ),
+			children: getAgentsManagerMenuNodes( recordTracksEvent, omnibarSiteId ),
 		};
 	}
 

--- a/client/dashboard/app/omnibar/plugin-help-center.tsx
+++ b/client/dashboard/app/omnibar/plugin-help-center.tsx
@@ -14,7 +14,10 @@ import { __ } from '@wordpress/i18n';
 import { Icon, backup, comment, page, rss, video } from '@wordpress/icons';
 import { useAnalytics } from '../analytics';
 import { useHelpCenter } from '../help-center';
+import { useRouteSiteId } from './site';
 import type { AnalyticsClient } from '../analytics';
+// eslint-disable-next-line no-restricted-imports -- Help Center host events need explicit site attribution.
+import type { SiteCandidate } from '@automattic/calypso-analytics';
 import type { OmnibarNode } from '@automattic/omnibar';
 
 import './plugin-help-center.scss';
@@ -50,7 +53,7 @@ function menuIcon( icon: JSX.Element ) {
 function handleMenuClick(
 	recordTracksEvent: RecordTracksEvent,
 	destination: string,
-	omnibarSiteId: number | null | undefined,
+	siteCandidates: readonly SiteCandidate[],
 	isExternal = false
 ) {
 	// Re-clicking the current route closes the chat; external links never do.
@@ -76,7 +79,7 @@ function handleMenuClick(
 					location: 'help-center',
 					section: 'dashboard',
 				},
-				[ [ 'omnibar', omnibarSiteId ] ]
+				siteCandidates
 			)
 		);
 		closeAgentsManagerChat();
@@ -95,14 +98,14 @@ function handleMenuClick(
 				section: 'dashboard',
 				destination,
 			},
-			[ [ 'omnibar', omnibarSiteId ] ]
+			siteCandidates
 		)
 	);
 }
 
 function getAgentsManagerMenuNodes(
 	recordTracksEvent: RecordTracksEvent,
-	omnibarSiteId: number | null | undefined
+	siteCandidates: readonly SiteCandidate[]
 ): OmnibarNode[] {
 	return [
 		{
@@ -113,13 +116,13 @@ function getAgentsManagerMenuNodes(
 					id: 'chat-support',
 					title: __( 'Chat support' ),
 					icon: menuIcon( comment ),
-					onClick: () => handleMenuClick( recordTracksEvent, '/chat', omnibarSiteId ),
+					onClick: () => handleMenuClick( recordTracksEvent, '/chat', siteCandidates ),
 				},
 				{
 					id: 'chat-history',
 					title: __( 'Chat history' ),
 					icon: menuIcon( backup ),
-					onClick: () => handleMenuClick( recordTracksEvent, '/history', omnibarSiteId ),
+					onClick: () => handleMenuClick( recordTracksEvent, '/history', siteCandidates ),
 				},
 			],
 		},
@@ -132,7 +135,7 @@ function getAgentsManagerMenuNodes(
 					id: 'support-guides',
 					title: __( 'Support guides' ),
 					icon: menuIcon( page ),
-					onClick: () => handleMenuClick( recordTracksEvent, '/support-guides', omnibarSiteId ),
+					onClick: () => handleMenuClick( recordTracksEvent, '/support-guides', siteCandidates ),
 				},
 				{
 					id: 'courses',
@@ -142,7 +145,7 @@ function getAgentsManagerMenuNodes(
 						handleMenuClick(
 							recordTracksEvent,
 							localizeUrl( 'https://wordpress.com/support/courses/' ),
-							omnibarSiteId,
+							siteCandidates,
 							true
 						),
 				},
@@ -154,7 +157,7 @@ function getAgentsManagerMenuNodes(
 						handleMenuClick(
 							recordTracksEvent,
 							localizeUrl( 'https://wordpress.com/blog/category/product-features/' ),
-							omnibarSiteId,
+							siteCandidates,
 							true
 						),
 				},
@@ -168,13 +171,20 @@ export function useHelpCenterPlugin(): OmnibarNode {
 	const { isShown: isHelpCenterShown, setShowHelpCenter } = useHelpCenter();
 	const { recordTracksEvent } = useAnalytics();
 	const { data: omnibarSiteId } = useQuery( omnibarSiteIdQuery() );
+	// The omnibar site is published asynchronously, so the route is the only
+	// site available while it resolves.
+	const routeSiteId = useRouteSiteId();
+	const siteCandidates: SiteCandidate[] = [
+		[ 'omnibar', omnibarSiteId ],
+		[ 'dashboard_route', routeSiteId ],
+	];
 
 	if ( shouldUseUnifiedAgent ) {
 		return {
 			id: 'help-center',
 			label: __( 'Help' ),
 			icon: <HelpIcon />,
-			children: getAgentsManagerMenuNodes( recordTracksEvent, omnibarSiteId ),
+			children: getAgentsManagerMenuNodes( recordTracksEvent, siteCandidates ),
 		};
 	}
 

--- a/client/dashboard/app/omnibar/site.ts
+++ b/client/dashboard/app/omnibar/site.ts
@@ -8,7 +8,7 @@ import {
 } from '@automattic/api-queries';
 import calypsoConfig from '@automattic/calypso-config';
 import { useMutation } from '@tanstack/react-query';
-import { useRouter } from '@tanstack/react-router';
+import { useRouter, useRouterState } from '@tanstack/react-router';
 import { removeQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
 import { logToLogstash } from 'calypso/lib/logstash';
@@ -30,6 +30,18 @@ async function ensureSite( siteId: number | undefined ) {
 	} catch {
 		return undefined;
 	}
+}
+
+/**
+ * The site the current route resolved. `useSyncOmnibarSite` publishes
+ * asynchronously, so this is the only site available on the first render.
+ */
+export function useRouteSiteId() {
+	return useRouterState( {
+		select: ( state ) =>
+			state.matches.findLast( ( match ) => !! ( match.loaderData as { site?: Site } )?.site )
+				?.loaderData?.site?.ID,
+	} );
 }
 
 /**

--- a/client/dashboard/app/omnibar/site.ts
+++ b/client/dashboard/app/omnibar/site.ts
@@ -8,7 +8,7 @@ import {
 } from '@automattic/api-queries';
 import calypsoConfig from '@automattic/calypso-config';
 import { useMutation } from '@tanstack/react-query';
-import { useRouter, useRouterState } from '@tanstack/react-router';
+import { useRouter } from '@tanstack/react-router';
 import { removeQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
 import { logToLogstash } from 'calypso/lib/logstash';
@@ -30,18 +30,6 @@ async function ensureSite( siteId: number | undefined ) {
 	} catch {
 		return undefined;
 	}
-}
-
-/**
- * The site the current route resolved. `useSyncOmnibarSite` publishes
- * asynchronously, so this is the only site available on the first render.
- */
-export function useRouteSiteId() {
-	return useRouterState( {
-		select: ( state ) =>
-			state.matches.findLast( ( match ) => !! ( match.loaderData as { site?: Site } )?.site )
-				?.loaderData?.site?.ID,
-	} );
 }
 
 /**
@@ -73,6 +61,15 @@ export function useSyncOmnibarSite() {
 				( router.state.location.search as Record< string, string | undefined > ).origin_site_id
 			);
 			const originSiteId = originSiteIdParam > 0 ? originSiteIdParam : undefined;
+
+			// The route already knows its site, and everything below is async: publish it
+			// now so consumers reading this as shared state — the omnibar itself, and the
+			// site attribution on the events it records — don't spend the resolution
+			// window on the previously visited site, or on no site at all.
+			if ( routeSite && isMemberOfSite( routeSite ) ) {
+				queryClient.cancelQueries( { queryKey: omnibarSiteIdQuery().queryKey } );
+				queryClient.setQueryData( omnibarSiteIdQuery().queryKey, () => routeSite.ID );
+			}
 
 			let recentSiteIds: number[];
 			try {

--- a/client/dashboard/app/omnibar/test/site.test.tsx
+++ b/client/dashboard/app/omnibar/test/site.test.tsx
@@ -2,16 +2,49 @@
  * @jest-environment jsdom
  */
 import { omnibarSiteIdQuery, queryClient, rawUserPreferencesQuery } from '@automattic/api-queries';
-import { act, waitFor } from '@testing-library/react';
+import {
+	Outlet,
+	RouterProvider,
+	createRootRoute,
+	createRoute,
+	createRouter,
+} from '@tanstack/react-router';
+import { act, render as testingLibraryRender, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { render } from '../../../test-utils';
 import { AUTH_QUERY_KEY } from '../../auth';
 import { useSyncOmnibarSite } from '../site';
-import type { User, UserPreferences } from '@automattic/api-core';
+import type { Site, User, UserPreferences } from '@automattic/api-core';
 
 function OmnibarProbe() {
 	useSyncOmnibarSite();
 	return null;
+}
+
+// The shared `render()` has no route loader, so a site-bearing route needs its own router.
+function renderRouterWithSiteRoute( site: Site ) {
+	function RootComponent() {
+		useSyncOmnibarSite();
+		return <Outlet />;
+	}
+
+	const rootRoute = createRootRoute( { component: RootComponent } );
+	const indexRoute = createRoute( {
+		getParentRoute: () => rootRoute,
+		path: '/',
+		component: () => <div>home</div>,
+	} );
+	const siteRoute = createRoute( {
+		getParentRoute: () => rootRoute,
+		path: '/sites/$slug',
+		loader: () => ( { site } ),
+		component: () => <div>site</div>,
+	} );
+	const router = createRouter( { routeTree: rootRoute.addChildren( [ indexRoute, siteRoute ] ) } );
+
+	testingLibraryRender( <RouterProvider router={ router } /> );
+
+	return router;
 }
 
 // Flush pending microtasks/effects so a hypothetical re-triggered write would fire.
@@ -76,6 +109,39 @@ describe( 'useSyncOmnibarSite', () => {
 
 		// The omnibar still resolves to the primary blog and publishes it as shared state.
 		expect( queryClient.getQueryData( omnibarSiteIdQuery().queryKey ) ).toBe( 123 );
+	} );
+
+	test( 'publishes the route site before the asynchronous candidates resolve', async () => {
+		queryClient.setQueryData( AUTH_QUERY_KEY, { ID: 1, primary_blog: 123 } as User );
+		// The site the omnibar was showing before this navigation.
+		queryClient.setQueryData( omnibarSiteIdQuery().queryKey, 111 );
+
+		// Reading preferences fails, so the resolution that awaits them bails out and
+		// anything published here can only have come from the route.
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( '/rest/v1.1/me/preferences' )
+			.reply( 403, { error: 'unauthorized' } );
+
+		const router = renderRouterWithSiteRoute( { ID: 456, capabilities: {} } as Site );
+		await waitFor( () => expect( document.body.textContent ).toContain( 'home' ) );
+
+		router.navigate( { to: '/sites/$slug', params: { slug: 'foo' } } );
+		await waitFor( () => expect( document.body.textContent ).toContain( 'site' ) );
+
+		// Events recorded in this window — a Help click right after landing — must
+		// attribute the site being visited, not the one left behind.
+		await waitFor( () =>
+			expect( queryClient.getQueryData( omnibarSiteIdQuery().queryKey ) ).toBe( 456 )
+		);
+		await waitFor( () =>
+			expect( queryClient.getQueryState( rawUserPreferencesQuery().queryKey )?.status ).toBe(
+				'error'
+			)
+		);
+		await flush();
+
+		expect( queryClient.getQueryData( omnibarSiteIdQuery().queryKey ) ).toBe( 456 );
 	} );
 
 	test( 'does not attempt a write when reading preferences fails', async () => {

--- a/client/layout/agents-manager-loader.tsx
+++ b/client/layout/agents-manager-loader.tsx
@@ -2,9 +2,8 @@ import { useShouldUseUnifiedAgent } from '@automattic/agents-manager';
 import { useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
-import { getSiteBySlug } from 'calypso/state/sites/selectors';
-import { getSelectedSite, isSiteSection } from 'calypso/state/ui/selectors';
+import { isSiteSection } from 'calypso/state/ui/selectors';
+import { useHelpCenterSite } from './use-help-center-site';
 
 const importAgentsManager = () =>
 	import(
@@ -20,10 +19,8 @@ export default function AgentsManagerLoader( {
 } ) {
 	const shouldUseUnifiedAgent = useShouldUseUnifiedAgent();
 	const user = useSelector( getCurrentUser );
-	const selectedSite = useSelector( getSelectedSite );
 	const isSiteSpecific = useSelector( isSiteSection );
-	const primarySiteSlug = useSelector( getPrimarySiteSlug );
-	const primarySite = useSelector( ( state ) => getSiteBySlug( state, primarySiteSlug ) );
+	const { selectedSite, site } = useHelpCenterSite();
 
 	if ( ! shouldUseUnifiedAgent || ! loadAgentsManager ) {
 		return null;
@@ -35,7 +32,7 @@ export default function AgentsManagerLoader( {
 			placeholder={ null }
 			currentUser={ user }
 			sectionName={ sectionName }
-			site={ selectedSite || primarySite }
+			site={ site }
 			currentSiteId={ isSiteSpecific ? selectedSite?.ID : undefined }
 		/>
 	);

--- a/client/layout/help-center-loader.tsx
+++ b/client/layout/help-center-loader.tsx
@@ -10,10 +10,8 @@ import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { onboardingUrl } from 'calypso/lib/paths';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
 import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-user-purchases';
-import { getSiteBySlug } from 'calypso/state/sites/selectors';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { useHelpCenterSite } from './use-help-center-site';
 
 const importHelpCenter = () =>
 	import( /* webpackChunkName: "async-load-automattic-help-center" */ '@automattic/help-center' );
@@ -37,9 +35,7 @@ export default function HelpCenterLoader( { sectionName, loadHelpCenter, current
 	const hasPurchases = useSelector( hasCancelableUserPurchases );
 	const user = useSelector( getCurrentUser );
 	const agency = useSelector( getActiveAgency );
-	const selectedSite = useSelector( getSelectedSite );
-	const primarySiteSlug = useSelector( getPrimarySiteSlug );
-	const primarySite = useSelector( ( state ) => getSiteBySlug( state, primarySiteSlug ) );
+	const { site } = useHelpCenterSite();
 
 	if ( ! loadHelpCenter ) {
 		return null;
@@ -66,7 +62,7 @@ export default function HelpCenterLoader( { sectionName, loadHelpCenter, current
 			currentRoute={ currentRoute }
 			locale={ locale }
 			sectionName={ sectionName }
-			site={ selectedSite || primarySite }
+			site={ site }
 			currentUser={ user }
 			hasPurchases={ hasPurchases }
 			// hide Calypso's version of the help-center on Desktop, because the Editor has its own help-center

--- a/client/layout/masterbar/masterbar-agents-manager/index.jsx
+++ b/client/layout/masterbar/masterbar-agents-manager/index.jsx
@@ -20,7 +20,7 @@ import './style.scss';
 const MasterbarAgentsManager = ( { tooltip } ) => {
 	const translate = useTranslate();
 	const sectionName = useSelector( getSectionName );
-	const { siteCandidates } = useHelpCenterSite();
+	const { site, siteContextSource } = useHelpCenterSite();
 
 	const agentsManagerVisible = useDateStoreSelect(
 		( select ) => select( AGENTS_MANAGER_STORE ).getAgentsManagerState().isOpen,
@@ -37,7 +37,8 @@ const MasterbarAgentsManager = ( { tooltip } ) => {
 					is_menu_panel_enabled: true,
 					is_assignment_loaded: true,
 				},
-				siteCandidates
+				siteContextSource,
+				site?.ID
 			)
 		);
 	};
@@ -65,7 +66,8 @@ const MasterbarAgentsManager = ( { tooltip } ) => {
 						location: 'help-center',
 						section: sectionName,
 					},
-					siteCandidates
+					siteContextSource,
+					site?.ID
 				)
 			);
 			return closeAgentsManagerChat();
@@ -83,7 +85,8 @@ const MasterbarAgentsManager = ( { tooltip } ) => {
 					section: sectionName,
 					destination,
 				},
-				siteCandidates
+				siteContextSource,
+				site?.ID
 			)
 		);
 	};

--- a/client/layout/masterbar/masterbar-agents-manager/index.jsx
+++ b/client/layout/masterbar/masterbar-agents-manager/index.jsx
@@ -20,7 +20,7 @@ import './style.scss';
 const MasterbarAgentsManager = ( { tooltip } ) => {
 	const translate = useTranslate();
 	const sectionName = useSelector( getSectionName );
-	const { selectedSite, urlParamSite, primarySite } = useHelpCenterSite();
+	const { siteCandidates } = useHelpCenterSite();
 
 	const agentsManagerVisible = useDateStoreSelect(
 		( select ) => select( AGENTS_MANAGER_STORE ).getAgentsManagerState().isOpen,
@@ -37,11 +37,7 @@ const MasterbarAgentsManager = ( { tooltip } ) => {
 					is_menu_panel_enabled: true,
 					is_assignment_loaded: true,
 				},
-				[
-					[ 'calypso_selected_site', selectedSite?.ID ],
-					[ 'calypso_url_param_site', urlParamSite?.ID ],
-					[ 'calypso_primary_site', primarySite?.ID ],
-				]
+				siteCandidates
 			)
 		);
 	};
@@ -69,11 +65,7 @@ const MasterbarAgentsManager = ( { tooltip } ) => {
 						location: 'help-center',
 						section: sectionName,
 					},
-					[
-						[ 'calypso_selected_site', selectedSite?.ID ],
-						[ 'calypso_url_param_site', urlParamSite?.ID ],
-						[ 'calypso_primary_site', primarySite?.ID ],
-					]
+					siteCandidates
 				)
 			);
 			return closeAgentsManagerChat();
@@ -91,11 +83,7 @@ const MasterbarAgentsManager = ( { tooltip } ) => {
 					section: sectionName,
 					destination,
 				},
-				[
-					[ 'calypso_selected_site', selectedSite?.ID ],
-					[ 'calypso_url_param_site', urlParamSite?.ID ],
-					[ 'calypso_primary_site', primarySite?.ID ],
-				]
+				siteCandidates
 			)
 		);
 	};

--- a/client/layout/masterbar/masterbar-agents-manager/index.jsx
+++ b/client/layout/masterbar/masterbar-agents-manager/index.jsx
@@ -5,12 +5,13 @@ import {
 	isAgentsManagerChatVisible,
 	openAgentsManagerChat,
 } from '@automattic/agents-manager';
-import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { recordTracksEvent, withSiteContext } from '@automattic/calypso-analytics';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useSelect as useDateStoreSelect } from '@wordpress/data';
 import { Icon, comment, backup, page, video, rss } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import { useHelpCenterSite } from 'calypso/layout/use-help-center-site';
 import { getSectionName } from 'calypso/state/ui/selectors';
 import Item from '../item';
 import HelpIcon from './help-icon';
@@ -19,6 +20,7 @@ import './style.scss';
 const MasterbarAgentsManager = ( { tooltip } ) => {
 	const translate = useTranslate();
 	const sectionName = useSelector( getSectionName );
+	const { selectedSite, urlParamSite, primarySite } = useHelpCenterSite();
 
 	const agentsManagerVisible = useDateStoreSelect(
 		( select ) => select( AGENTS_MANAGER_STORE ).getAgentsManagerState().isOpen,
@@ -26,12 +28,22 @@ const MasterbarAgentsManager = ( { tooltip } ) => {
 	);
 
 	const trackIconInteraction = () => {
-		recordTracksEvent( 'wpcom_help_center_icon_interaction', {
-			is_help_center_visible: agentsManagerVisible,
-			section: sectionName,
-			is_menu_panel_enabled: true,
-			is_assignment_loaded: true,
-		} );
+		recordTracksEvent(
+			'wpcom_help_center_icon_interaction',
+			withSiteContext(
+				{
+					is_help_center_visible: agentsManagerVisible,
+					section: sectionName,
+					is_menu_panel_enabled: true,
+					is_assignment_loaded: true,
+				},
+				[
+					[ 'calypso_selected_site', selectedSite?.ID ],
+					[ 'calypso_url_param_site', urlParamSite?.ID ],
+					[ 'calypso_primary_site', primarySite?.ID ],
+				]
+			)
+		);
 	};
 
 	const handleMenuClick = ( destination, isExternal = false ) => {
@@ -50,11 +62,20 @@ const MasterbarAgentsManager = ( { tooltip } ) => {
 		}
 
 		if ( isClosing ) {
-			recordTracksEvent( 'calypso_inlinehelp_close', {
-				force_site_id: true,
-				location: 'help-center',
-				section: sectionName,
-			} );
+			recordTracksEvent(
+				'calypso_inlinehelp_close',
+				withSiteContext(
+					{
+						location: 'help-center',
+						section: sectionName,
+					},
+					[
+						[ 'calypso_selected_site', selectedSite?.ID ],
+						[ 'calypso_url_param_site', urlParamSite?.ID ],
+						[ 'calypso_primary_site', primarySite?.ID ],
+					]
+				)
+			);
 			return closeAgentsManagerChat();
 		}
 
@@ -62,12 +83,21 @@ const MasterbarAgentsManager = ( { tooltip } ) => {
 		// button; other items open the chat at their own route.
 		openAgentsManagerChat( destination === '/chat' ? undefined : destination );
 
-		recordTracksEvent( 'calypso_inlinehelp_show', {
-			force_site_id: true,
-			location: 'help-center',
-			section: sectionName,
-			destination,
-		} );
+		recordTracksEvent(
+			'calypso_inlinehelp_show',
+			withSiteContext(
+				{
+					location: 'help-center',
+					section: sectionName,
+					destination,
+				},
+				[
+					[ 'calypso_selected_site', selectedSite?.ID ],
+					[ 'calypso_url_param_site', urlParamSite?.ID ],
+					[ 'calypso_primary_site', primarySite?.ID ],
+				]
+			)
+		);
 	};
 
 	// Menu items for the panel

--- a/client/layout/masterbar/masterbar-help-center/index.jsx
+++ b/client/layout/masterbar/masterbar-help-center/index.jsx
@@ -1,4 +1,4 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { recordTracksEvent, withSiteContext } from '@automattic/calypso-analytics';
 import { HelpCenter } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { usePrevious } from '@wordpress/compose';
@@ -12,6 +12,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import { useHelpCenterSite } from 'calypso/layout/use-help-center-site';
 import { useExperiment } from 'calypso/lib/explat';
 import getIsNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import { getSectionName } from 'calypso/state/ui/selectors';
@@ -24,6 +25,7 @@ const HELP_CENTER_STORE = HelpCenter.register();
 const MasterbarHelpCenter = ( { tooltip } ) => {
 	const translate = useTranslate();
 	const sectionName = useSelector( getSectionName );
+	const { selectedSite, urlParamSite, primarySite } = useHelpCenterSite();
 	const isNotificationsOpen = useSelector( ( state ) => getIsNotificationsOpen( state ) );
 	const prevIsNotificationsOpen = usePrevious( isNotificationsOpen );
 	const [ helpCenterPage, setHelpCenterPage ] = useState( null );
@@ -45,22 +47,41 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 		! isLoadingExperimentAssignment && experimentAssignment?.variationName === 'menu_popover';
 
 	const trackIconInteraction = () => {
-		recordTracksEvent( `wpcom_help_center_icon_interaction`, {
-			is_help_center_visible: helpCenterVisible,
-			section: sectionName,
-			is_menu_panel_enabled: isMenuPanelExperimentEnabled,
-			is_assignment_loaded: ! isLoadingExperimentAssignment,
-		} );
+		recordTracksEvent(
+			`wpcom_help_center_icon_interaction`,
+			withSiteContext(
+				{
+					is_help_center_visible: helpCenterVisible,
+					section: sectionName,
+					is_menu_panel_enabled: isMenuPanelExperimentEnabled,
+					is_assignment_loaded: ! isLoadingExperimentAssignment,
+				},
+				[
+					[ 'calypso_selected_site', selectedSite?.ID ],
+					[ 'calypso_url_param_site', urlParamSite?.ID ],
+					[ 'calypso_primary_site', primarySite?.ID ],
+				]
+			)
+		);
 	};
 
 	const handleToggleHelpCenter = () => {
 		trackIconInteraction();
 
-		recordTracksEvent( `calypso_inlinehelp_${ helpCenterVisible ? 'close' : 'show' }`, {
-			force_site_id: true,
-			location: 'help-center',
-			section: sectionName,
-		} );
+		recordTracksEvent(
+			`calypso_inlinehelp_${ helpCenterVisible ? 'close' : 'show' }`,
+			withSiteContext(
+				{
+					location: 'help-center',
+					section: sectionName,
+				},
+				[
+					[ 'calypso_selected_site', selectedSite?.ID ],
+					[ 'calypso_url_param_site', urlParamSite?.ID ],
+					[ 'calypso_primary_site', primarySite?.ID ],
+				]
+			)
+		);
 
 		setShowHelpCenter( ! helpCenterVisible );
 	};
@@ -80,11 +101,20 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 				setNavigateToRoute( destination );
 				setHelpCenterPage( destination );
 			} else {
-				recordTracksEvent( `calypso_inlinehelp_close`, {
-					force_site_id: true,
-					location: 'help-center',
-					section: sectionName,
-				} );
+				recordTracksEvent(
+					`calypso_inlinehelp_close`,
+					withSiteContext(
+						{
+							location: 'help-center',
+							section: sectionName,
+						},
+						[
+							[ 'calypso_selected_site', selectedSite?.ID ],
+							[ 'calypso_url_param_site', urlParamSite?.ID ],
+							[ 'calypso_primary_site', primarySite?.ID ],
+						]
+					)
+				);
 				setShowHelpCenter( false );
 				setHelpCenterPage( null );
 			}
@@ -93,12 +123,21 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 			setHelpCenterPage( destination );
 			setShowHelpCenter( true );
 
-			recordTracksEvent( `calypso_inlinehelp_show`, {
-				force_site_id: true,
-				location: 'help-center',
-				section: sectionName,
-				destination,
-			} );
+			recordTracksEvent(
+				`calypso_inlinehelp_show`,
+				withSiteContext(
+					{
+						location: 'help-center',
+						section: sectionName,
+						destination,
+					},
+					[
+						[ 'calypso_selected_site', selectedSite?.ID ],
+						[ 'calypso_url_param_site', urlParamSite?.ID ],
+						[ 'calypso_primary_site', primarySite?.ID ],
+					]
+				)
+			);
 		}
 	};
 

--- a/client/layout/masterbar/masterbar-help-center/index.jsx
+++ b/client/layout/masterbar/masterbar-help-center/index.jsx
@@ -25,7 +25,7 @@ const HELP_CENTER_STORE = HelpCenter.register();
 const MasterbarHelpCenter = ( { tooltip } ) => {
 	const translate = useTranslate();
 	const sectionName = useSelector( getSectionName );
-	const { selectedSite, urlParamSite, primarySite } = useHelpCenterSite();
+	const { siteCandidates } = useHelpCenterSite();
 	const isNotificationsOpen = useSelector( ( state ) => getIsNotificationsOpen( state ) );
 	const prevIsNotificationsOpen = usePrevious( isNotificationsOpen );
 	const [ helpCenterPage, setHelpCenterPage ] = useState( null );
@@ -56,11 +56,7 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 					is_menu_panel_enabled: isMenuPanelExperimentEnabled,
 					is_assignment_loaded: ! isLoadingExperimentAssignment,
 				},
-				[
-					[ 'calypso_selected_site', selectedSite?.ID ],
-					[ 'calypso_url_param_site', urlParamSite?.ID ],
-					[ 'calypso_primary_site', primarySite?.ID ],
-				]
+				siteCandidates
 			)
 		);
 	};
@@ -75,11 +71,7 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 					location: 'help-center',
 					section: sectionName,
 				},
-				[
-					[ 'calypso_selected_site', selectedSite?.ID ],
-					[ 'calypso_url_param_site', urlParamSite?.ID ],
-					[ 'calypso_primary_site', primarySite?.ID ],
-				]
+				siteCandidates
 			)
 		);
 
@@ -108,11 +100,7 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 							location: 'help-center',
 							section: sectionName,
 						},
-						[
-							[ 'calypso_selected_site', selectedSite?.ID ],
-							[ 'calypso_url_param_site', urlParamSite?.ID ],
-							[ 'calypso_primary_site', primarySite?.ID ],
-						]
+						siteCandidates
 					)
 				);
 				setShowHelpCenter( false );
@@ -131,11 +119,7 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 						section: sectionName,
 						destination,
 					},
-					[
-						[ 'calypso_selected_site', selectedSite?.ID ],
-						[ 'calypso_url_param_site', urlParamSite?.ID ],
-						[ 'calypso_primary_site', primarySite?.ID ],
-					]
+					siteCandidates
 				)
 			);
 		}

--- a/client/layout/masterbar/masterbar-help-center/index.jsx
+++ b/client/layout/masterbar/masterbar-help-center/index.jsx
@@ -25,7 +25,7 @@ const HELP_CENTER_STORE = HelpCenter.register();
 const MasterbarHelpCenter = ( { tooltip } ) => {
 	const translate = useTranslate();
 	const sectionName = useSelector( getSectionName );
-	const { siteCandidates } = useHelpCenterSite();
+	const { site, siteContextSource } = useHelpCenterSite();
 	const isNotificationsOpen = useSelector( ( state ) => getIsNotificationsOpen( state ) );
 	const prevIsNotificationsOpen = usePrevious( isNotificationsOpen );
 	const [ helpCenterPage, setHelpCenterPage ] = useState( null );
@@ -56,7 +56,8 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 					is_menu_panel_enabled: isMenuPanelExperimentEnabled,
 					is_assignment_loaded: ! isLoadingExperimentAssignment,
 				},
-				siteCandidates
+				siteContextSource,
+				site?.ID
 			)
 		);
 	};
@@ -71,7 +72,8 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 					location: 'help-center',
 					section: sectionName,
 				},
-				siteCandidates
+				siteContextSource,
+				site?.ID
 			)
 		);
 
@@ -100,7 +102,8 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 							location: 'help-center',
 							section: sectionName,
 						},
-						siteCandidates
+						siteContextSource,
+						site?.ID
 					)
 				);
 				setShowHelpCenter( false );
@@ -119,7 +122,8 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 						section: sectionName,
 						destination,
 					},
-					siteCandidates
+					siteContextSource,
+					site?.ID
 				)
 			);
 		}

--- a/client/layout/test/use-help-center-site.test.ts
+++ b/client/layout/test/use-help-center-site.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
+import { getSiteBySlug } from 'calypso/state/sites/selectors';
+import getSite from 'calypso/state/sites/selectors/get-site';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
+import { useHelpCenterSite } from '../use-help-center-site';
+
+jest.mock( 'calypso/state/ui/selectors', () => ( {
+	getSelectedSite: jest.fn(),
+} ) );
+jest.mock( 'calypso/state/selectors/get-primary-site-slug', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+jest.mock( 'calypso/state/sites/selectors', () => ( {
+	getSiteBySlug: jest.fn(),
+} ) );
+jest.mock( 'calypso/state/sites/selectors/get-site', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+const mockGetSelectedSite = getSelectedSite as unknown as jest.Mock;
+const mockGetPrimarySiteSlug = getPrimarySiteSlug as unknown as jest.Mock;
+const mockGetSiteBySlug = getSiteBySlug as unknown as jest.Mock;
+const mockGetSite = getSite as unknown as jest.Mock;
+
+const selectedSite = { ID: 1 };
+const urlParamSite = { ID: 2 };
+const primarySite = { ID: 3 };
+
+describe( 'useHelpCenterSite', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		window.history.replaceState( {}, '', '/' );
+		mockGetSelectedSite.mockReturnValue( null );
+		mockGetPrimarySiteSlug.mockReturnValue( null );
+		mockGetSiteBySlug.mockReturnValue( null );
+		mockGetSite.mockReturnValue( null );
+	} );
+
+	it( 'prefers selected site', () => {
+		mockGetSelectedSite.mockReturnValue( selectedSite );
+		mockGetPrimarySiteSlug.mockReturnValue( 'primary-site' );
+		mockGetSiteBySlug.mockReturnValue( primarySite );
+
+		const { result } = renderHookWithProvider( () => useHelpCenterSite() );
+
+		expect( result.current.site ).toBe( selectedSite );
+	} );
+
+	it( 'falls back to URL-param site before primary site', () => {
+		window.history.replaceState( {}, '', '/?siteId=2' );
+		mockGetSite.mockReturnValue( urlParamSite );
+		mockGetPrimarySiteSlug.mockReturnValue( 'primary-site' );
+		mockGetSiteBySlug.mockReturnValue( primarySite );
+
+		const { result } = renderHookWithProvider( () => useHelpCenterSite() );
+
+		expect( result.current.site ).toBe( urlParamSite );
+		expect( result.current.urlParamSite ).toBe( urlParamSite );
+	} );
+
+	it( 'falls back to primary site', () => {
+		mockGetPrimarySiteSlug.mockReturnValue( 'primary-site' );
+		mockGetSiteBySlug.mockReturnValue( primarySite );
+
+		const { result } = renderHookWithProvider( () => useHelpCenterSite() );
+
+		expect( result.current.site ).toBe( primarySite );
+	} );
+
+	it( 'returns no site when no candidate resolves', () => {
+		const { result } = renderHookWithProvider( () => useHelpCenterSite() );
+
+		expect( result.current.site ).toBeNull();
+	} );
+} );

--- a/client/layout/test/use-help-center-site.test.ts
+++ b/client/layout/test/use-help-center-site.test.ts
@@ -51,6 +51,7 @@ describe( 'useHelpCenterSite', () => {
 		const { result } = renderHookWithProvider( () => useHelpCenterSite() );
 
 		expect( result.current.site ).toBe( selectedSite );
+		expect( result.current.siteContextSource ).toBe( 'calypso_selected_site' );
 	} );
 
 	it( 'falls back to URL-param site before primary site', () => {
@@ -63,6 +64,7 @@ describe( 'useHelpCenterSite', () => {
 
 		expect( result.current.site ).toBe( urlParamSite );
 		expect( result.current.urlParamSite ).toBe( urlParamSite );
+		expect( result.current.siteContextSource ).toBe( 'calypso_url_param_site' );
 	} );
 
 	it( 'falls back to primary site', () => {
@@ -72,9 +74,10 @@ describe( 'useHelpCenterSite', () => {
 		const { result } = renderHookWithProvider( () => useHelpCenterSite() );
 
 		expect( result.current.site ).toBe( primarySite );
+		expect( result.current.siteContextSource ).toBe( 'calypso_primary_site' );
 	} );
 
-	it( 'reports the candidates in the same priority as the resolved site', () => {
+	it( 'names the source of the site it resolved', () => {
 		window.history.replaceState( {}, '', '/?siteId=2' );
 		mockGetSelectedSite.mockReturnValue( selectedSite );
 		mockGetSite.mockReturnValue( urlParamSite );
@@ -83,16 +86,14 @@ describe( 'useHelpCenterSite', () => {
 
 		const { result } = renderHookWithProvider( () => useHelpCenterSite() );
 
-		expect( result.current.siteCandidates ).toEqual( [
-			[ 'calypso_selected_site', 1 ],
-			[ 'calypso_url_param_site', 2 ],
-			[ 'calypso_primary_site', 3 ],
-		] );
+		expect( result.current.site ).toBe( selectedSite );
+		expect( result.current.siteContextSource ).toBe( 'calypso_selected_site' );
 	} );
 
-	it( 'returns no site when no candidate resolves', () => {
+	it( 'returns no site, and no source, when nothing resolves', () => {
 		const { result } = renderHookWithProvider( () => useHelpCenterSite() );
 
 		expect( result.current.site ).toBeNull();
+		expect( result.current.siteContextSource ).toBe( 'none' );
 	} );
 } );

--- a/client/layout/test/use-help-center-site.test.ts
+++ b/client/layout/test/use-help-center-site.test.ts
@@ -74,6 +74,22 @@ describe( 'useHelpCenterSite', () => {
 		expect( result.current.site ).toBe( primarySite );
 	} );
 
+	it( 'reports the candidates in the same priority as the resolved site', () => {
+		window.history.replaceState( {}, '', '/?siteId=2' );
+		mockGetSelectedSite.mockReturnValue( selectedSite );
+		mockGetSite.mockReturnValue( urlParamSite );
+		mockGetPrimarySiteSlug.mockReturnValue( 'primary-site' );
+		mockGetSiteBySlug.mockReturnValue( primarySite );
+
+		const { result } = renderHookWithProvider( () => useHelpCenterSite() );
+
+		expect( result.current.siteCandidates ).toEqual( [
+			[ 'calypso_selected_site', 1 ],
+			[ 'calypso_url_param_site', 2 ],
+			[ 'calypso_primary_site', 3 ],
+		] );
+	} );
+
 	it( 'returns no site when no candidate resolves', () => {
 		const { result } = renderHookWithProvider( () => useHelpCenterSite() );
 

--- a/client/layout/test/use-help-center-site.test.ts
+++ b/client/layout/test/use-help-center-site.test.ts
@@ -54,6 +54,21 @@ describe( 'useHelpCenterSite', () => {
 		expect( result.current.siteContextSource ).toBe( 'calypso_selected_site' );
 	} );
 
+	it( 'keeps a previously selected site on general-admin routes, before the primary site', () => {
+		// Redux's selectedSiteId is sticky: /me, /read and /help don't clear it,
+		// so a session that visited a site attributes that site there — matching
+		// the site the Help Center panel actually mounts with.
+		window.history.replaceState( {}, '', '/me' );
+		mockGetSelectedSite.mockReturnValue( selectedSite );
+		mockGetPrimarySiteSlug.mockReturnValue( 'primary-site' );
+		mockGetSiteBySlug.mockReturnValue( primarySite );
+
+		const { result } = renderHookWithProvider( () => useHelpCenterSite() );
+
+		expect( result.current.site ).toBe( selectedSite );
+		expect( result.current.siteContextSource ).toBe( 'calypso_selected_site' );
+	} );
+
 	it( 'falls back to URL-param site before primary site', () => {
 		window.history.replaceState( {}, '', '/?siteId=2' );
 		mockGetSite.mockReturnValue( urlParamSite );

--- a/client/layout/use-help-center-site.ts
+++ b/client/layout/use-help-center-site.ts
@@ -1,0 +1,21 @@
+import { useSelector } from 'react-redux';
+import { getSiteSlugOrIdFromURLSearchParams } from 'calypso/lib/analytics/super-props';
+import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
+import { getSiteBySlug } from 'calypso/state/sites/selectors';
+import getSite from 'calypso/state/sites/selectors/get-site';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+export function useHelpCenterSite() {
+	const selectedSite = useSelector( getSelectedSite );
+	const urlParamSiteId = getSiteSlugOrIdFromURLSearchParams();
+	const urlParamSite = useSelector( ( state ) => getSite( state, urlParamSiteId ) );
+	const primarySiteSlug = useSelector( getPrimarySiteSlug );
+	const primarySite = useSelector( ( state ) => getSiteBySlug( state, primarySiteSlug ) );
+
+	return {
+		selectedSite,
+		urlParamSite,
+		primarySite,
+		site: selectedSite || urlParamSite || primarySite,
+	};
+}

--- a/client/layout/use-help-center-site.ts
+++ b/client/layout/use-help-center-site.ts
@@ -1,11 +1,10 @@
-import { useMemo } from 'react';
+import { NO_SITE_CONTEXT } from '@automattic/calypso-analytics';
 import { useSelector } from 'react-redux';
 import { getSiteSlugOrIdFromURLSearchParams } from 'calypso/lib/analytics/super-props';
 import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import getSite from 'calypso/state/sites/selectors/get-site';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import type { SiteCandidate } from '@automattic/calypso-analytics';
 
 export function useHelpCenterSite() {
 	const selectedSite = useSelector( getSelectedSite );
@@ -14,21 +13,22 @@ export function useHelpCenterSite() {
 	const primarySiteSlug = useSelector( getPrimarySiteSlug );
 	const primarySite = useSelector( ( state ) => getSiteBySlug( state, primarySiteSlug ) );
 
-	// The same order as `site`, kept as candidates so events can report which one they got.
-	const siteCandidates: SiteCandidate[] = useMemo(
-		() => [
-			[ 'calypso_selected_site', selectedSite?.ID ],
-			[ 'calypso_url_param_site', urlParamSite?.ID ],
-			[ 'calypso_primary_site', primarySite?.ID ],
-		],
-		[ selectedSite?.ID, urlParamSite?.ID, primarySite?.ID ]
-	);
+	const site = selectedSite || urlParamSite || primarySite;
+
+	let siteContextSource = NO_SITE_CONTEXT;
+	if ( selectedSite ) {
+		siteContextSource = 'calypso_selected_site';
+	} else if ( urlParamSite ) {
+		siteContextSource = 'calypso_url_param_site';
+	} else if ( primarySite ) {
+		siteContextSource = 'calypso_primary_site';
+	}
 
 	return {
 		selectedSite,
 		urlParamSite,
 		primarySite,
-		siteCandidates,
-		site: selectedSite || urlParamSite || primarySite,
+		site,
+		siteContextSource,
 	};
 }

--- a/client/layout/use-help-center-site.ts
+++ b/client/layout/use-help-center-site.ts
@@ -1,9 +1,11 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { getSiteSlugOrIdFromURLSearchParams } from 'calypso/lib/analytics/super-props';
 import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import getSite from 'calypso/state/sites/selectors/get-site';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import type { SiteCandidate } from '@automattic/calypso-analytics';
 
 export function useHelpCenterSite() {
 	const selectedSite = useSelector( getSelectedSite );
@@ -12,10 +14,21 @@ export function useHelpCenterSite() {
 	const primarySiteSlug = useSelector( getPrimarySiteSlug );
 	const primarySite = useSelector( ( state ) => getSiteBySlug( state, primarySiteSlug ) );
 
+	// The same order as `site`, kept as candidates so events can report which one they got.
+	const siteCandidates: SiteCandidate[] = useMemo(
+		() => [
+			[ 'calypso_selected_site', selectedSite?.ID ],
+			[ 'calypso_url_param_site', urlParamSite?.ID ],
+			[ 'calypso_primary_site', primarySite?.ID ],
+		],
+		[ selectedSite?.ID, urlParamSite?.ID, primarySite?.ID ]
+	);
+
 	return {
 		selectedSite,
 		urlParamSite,
 		primarySite,
+		siteCandidates,
 		site: selectedSite || urlParamSite || primarySite,
 	};
 }

--- a/client/lib/analytics/super-props.js
+++ b/client/lib/analytics/super-props.js
@@ -1,4 +1,4 @@
-import { getConnectionSpeedData } from '@automattic/calypso-analytics';
+import { getConnectionSpeedData, NO_SITE_CONTEXT } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { shouldReportOmitBlogId } from 'calypso/lib/analytics/utils';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
@@ -6,7 +6,7 @@ import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
-function getSiteSlugOrIdFromURLSearchParams() {
+export function getSiteSlugOrIdFromURLSearchParams() {
 	const { search = '' } = typeof window !== 'undefined' ? window.location : {};
 	const queryParams = new URLSearchParams( search );
 	return queryParams.get( 'siteSlug' ) || queryParams.get( 'siteId' );
@@ -37,6 +37,10 @@ const getSuperProps = ( reduxStore ) => ( eventProperties ) => {
 	}
 
 	const explicitBlogId = getExplicitBlogId( eventProperties );
+	if ( ! explicitBlogId && eventProperties.site_context_source === NO_SITE_CONTEXT ) {
+		return superProps;
+	}
+
 	const path = eventProperties.path ?? getCurrentRoute( state ) ?? '';
 	const omitSelectedSite =
 		( ! eventProperties.force_site_id && shouldReportOmitBlogId( path ) ) ||

--- a/client/lib/analytics/test/super-props.js
+++ b/client/lib/analytics/test/super-props.js
@@ -11,6 +11,7 @@ import getSuperProps from '../super-props';
 
 jest.mock( '@automattic/calypso-analytics', () => ( {
 	getConnectionSpeedData: jest.fn(),
+	NO_SITE_CONTEXT: 'none',
 } ) );
 jest.mock( '@automattic/calypso-config', () => {
 	const config = jest.fn( ( key ) => key );
@@ -119,5 +120,14 @@ describe( 'analytics super props', () => {
 		const superProps = getSuperProps( reduxStore )( { blog_id: 0 } );
 
 		expect( superProps.blog_id ).toBe( selectedSite.ID );
+	} );
+
+	test( 'does not infer selected site when site context is explicitly absent', () => {
+		const superProps = getSuperProps( reduxStore )( {
+			force_site_id: true,
+			site_context_source: 'none',
+		} );
+
+		expect( superProps ).not.toHaveProperty( 'blog_id' );
 	} );
 } );

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -4,13 +4,14 @@ import { useStillNeedHelpURL } from '@automattic/help-center/src/hooks';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useDebounce } from 'use-debounce';
 import { RESULT_ARTICLE } from 'calypso/blocks/inline-help/constants';
 import HelpSearchCard from 'calypso/blocks/inline-help/inline-help-search-card';
 import HelpSearchResults from 'calypso/blocks/inline-help/inline-help-search-results';
 import CardHeading from 'calypso/components/card-heading';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
@@ -25,6 +26,7 @@ const getResultLink = ( result ) => amendYouTubeLink( result.link );
 export default function HelpSearch() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const siteId = useSelector( getSelectedSiteId );
 	const [ searchQuery, setSearchQuery ] = useState( '' );
 	const [ debouncedQuery ] = useDebounce( searchQuery, 500 );
 
@@ -69,6 +71,8 @@ export default function HelpSearch() {
 								searchQuery={ debouncedQuery }
 								onSearch={ setSearchQuery }
 								location={ HELP_COMPONENT_LOCATION }
+								blogId={ siteId }
+								siteContextSource="calypso_selected_site"
 								placeholder={ translate( 'Search support articles' ) }
 							/>
 							<HelpSearchResults

--- a/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
+++ b/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
@@ -86,7 +86,8 @@ export default function useAdminBarIntegration( {
 						is_menu_panel_enabled: false,
 						is_assignment_loaded: true,
 					},
-					[ [ 'agents_manager_context', site?.ID ] ]
+					'agents_manager_context',
+					site?.ID
 				)
 			);
 
@@ -98,7 +99,8 @@ export default function useAdminBarIntegration( {
 						location: 'help-center',
 						section: sectionName || 'wp-admin',
 					},
-					[ [ 'agents_manager_context', site?.ID ] ]
+					'agents_manager_context',
+					site?.ID
 				)
 			);
 

--- a/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
+++ b/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
@@ -1,4 +1,4 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { recordTracksEvent, withSiteContext } from '@automattic/calypso-analytics';
 import { useSelect } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -45,7 +45,7 @@ export default function useAdminBarIntegration( {
 }: UseAdminBarIntegrationOptions ): boolean {
 	const navigate = useNavigate();
 	const { pathname } = useLocation();
-	const { resumeActiveChat, sectionName } = useAgentsManagerContext();
+	const { resumeActiveChat, sectionName, site } = useAgentsManagerContext();
 	const { isOpen, isMinimized } = useSelect(
 		( select ) => ( select( AGENTS_MANAGER_STORE ) as AgentsManagerSelect ).getAgentsManagerState(),
 		[]
@@ -77,19 +77,30 @@ export default function useAdminBarIntegration( {
 
 		const handleMenuPanelClick = () => {
 			// Track icon interaction
-			recordTracksEvent( 'wpcom_help_center_icon_interaction', {
-				is_help_center_visible: isOpen,
-				section: sectionName || 'wp-admin',
-				is_menu_panel_enabled: false,
-				is_assignment_loaded: true,
-			} );
+			recordTracksEvent(
+				'wpcom_help_center_icon_interaction',
+				withSiteContext(
+					{
+						is_help_center_visible: isOpen,
+						section: sectionName || 'wp-admin',
+						is_menu_panel_enabled: false,
+						is_assignment_loaded: true,
+					},
+					[ [ 'agents_manager_context', site?.ID ] ]
+				)
+			);
 
 			// Track the toggle action
-			recordTracksEvent( `calypso_inlinehelp_${ isOpen ? 'close' : 'show' }`, {
-				force_site_id: true,
-				location: 'help-center',
-				section: sectionName || 'wp-admin',
-			} );
+			recordTracksEvent(
+				`calypso_inlinehelp_${ isOpen ? 'close' : 'show' }`,
+				withSiteContext(
+					{
+						location: 'help-center',
+						section: sectionName || 'wp-admin',
+					},
+					[ [ 'agents_manager_context', site?.ID ] ]
+				)
+			);
 
 			// Toggle submenu visibility by toggling the open-click class
 			button?.classList.toggle( OPEN_CLICK_CLASS );
@@ -98,7 +109,7 @@ export default function useAdminBarIntegration( {
 		if ( button ) {
 			button.onclick = handleMenuPanelClick;
 		}
-	}, [ isOpen, sectionName ] );
+	}, [ isOpen, sectionName, site?.ID ] );
 
 	// Close submenu when clicking outside
 	useEffect( () => {

--- a/packages/calypso-analytics/src/index.ts
+++ b/packages/calypso-analytics/src/index.ts
@@ -33,6 +33,5 @@ export {
 } from './train-tracks';
 export { getConnectionSpeedData } from './utils/connection-speed-data';
 export { getValidBlogId, withSiteContext, NO_SITE_CONTEXT } from './utils/site-context';
-export type { SiteCandidate } from './utils/site-context';
 
 export type { Railcar } from './train-tracks';

--- a/packages/calypso-analytics/src/utils/site-context.ts
+++ b/packages/calypso-analytics/src/utils/site-context.ts
@@ -1,7 +1,5 @@
 type TracksProperties = Record< string, unknown >;
 
-export type SiteCandidate = readonly [ source: string, siteId: unknown ];
-
 export const NO_SITE_CONTEXT = 'none';
 
 export function getValidBlogId( value: unknown ): number | undefined {
@@ -11,38 +9,32 @@ export function getValidBlogId( value: unknown ): number | undefined {
 }
 
 /**
- * Attaches the first valid site in `candidates` (highest priority first) as `blog_id`, and
- * its label as `site_context_source`. A `blog_id` already in `properties` is dropped, not
- * used: it is whatever the caller put there, not necessarily the site the event is about.
+ * Attaches `siteId` as `blog_id` and `source` as `site_context_source`. When `siteId` is
+ * not a valid blog id, or `source` is `NO_SITE_CONTEXT`, the event carries no `blog_id`
+ * and reports `site_context_source` as `none` instead. A `blog_id` already in
+ * `properties` is dropped, not used: it is whatever the caller put there, not
+ * necessarily the site the event is about.
  *
- * `force_site_id` is dropped along with it when nothing resolves. It only has an effect
+ * `force_site_id` is dropped along with it when no site resolves. It only has an effect
  * when no explicit `blog_id` is present, and there it tells Calypso's super props to fall
  * back to the selected site — which would contradict a `site_context_source` of `none`.
  */
 export function withSiteContext(
 	properties: TracksProperties,
-	candidates: readonly SiteCandidate[]
+	source: string,
+	siteId?: unknown
 ): TracksProperties {
 	const eventProperties = { ...properties };
-	const resolved = candidates.reduce< { source: string; blogId: number } | undefined >(
-		( winner, [ source, siteId ] ) => {
-			if ( winner ) {
-				return winner;
-			}
-			const blogId = getValidBlogId( siteId );
-
-			return blogId ? { source, blogId } : undefined;
-		},
-		undefined
-	);
+	const blogId = source === NO_SITE_CONTEXT ? undefined : getValidBlogId( siteId );
 
 	delete eventProperties.blog_id;
-	if ( resolved ) {
-		eventProperties.blog_id = resolved.blogId;
+	if ( blogId ) {
+		eventProperties.blog_id = blogId;
+		eventProperties.site_context_source = source;
 	} else {
 		delete eventProperties.force_site_id;
+		eventProperties.site_context_source = NO_SITE_CONTEXT;
 	}
-	eventProperties.site_context_source = resolved?.source ?? NO_SITE_CONTEXT;
 
 	return eventProperties;
 }

--- a/packages/calypso-analytics/test/site-context.ts
+++ b/packages/calypso-analytics/test/site-context.ts
@@ -15,29 +15,16 @@ describe( 'getValidBlogId', () => {
 } );
 
 describe( 'withSiteContext', () => {
-	test( 'attaches the first usable candidate and names it', () => {
-		expect(
-			withSiteContext( { source: 'chat' }, [
-				[ 'explicit', undefined ],
-				[ 'help_center_context', 0 ],
-				[ 'primary_site', 123 ],
-			] )
-		).toEqual( { source: 'chat', blog_id: 123, site_context_source: 'primary_site' } );
-	} );
-
-	test( 'prefers the earlier candidate when several are usable', () => {
-		expect(
-			withSiteContext( {}, [
-				[ 'explicit', 123 ],
-				[ 'primary_site', 456 ],
-			] )
-		).toEqual( { blog_id: 123, site_context_source: 'explicit' } );
+	test( 'attaches the site and names its source', () => {
+		expect( withSiteContext( { source: 'chat' }, 'primary_site', 123 ) ).toEqual( {
+			source: 'chat',
+			blog_id: 123,
+			site_context_source: 'primary_site',
+		} );
 	} );
 
 	test( 'preserves other caller properties', () => {
-		expect(
-			withSiteContext( { source: 'chat', queued_messages: 2 }, [ [ 'chat_site', 123 ] ] )
-		).toEqual( {
+		expect( withSiteContext( { source: 'chat', queued_messages: 2 }, 'chat_site', 123 ) ).toEqual( {
 			source: 'chat',
 			queued_messages: 2,
 			blog_id: 123,
@@ -45,39 +32,52 @@ describe( 'withSiteContext', () => {
 		} );
 	} );
 
-	test( 'reports none, and omits blog_id, when no candidate is usable', () => {
-		expect(
-			withSiteContext( { source: 'chat' }, [
-				[ 'explicit', 0 ],
-				[ 'primary_site', Number.NaN ],
-			] )
-		).toEqual( { source: 'chat', site_context_source: 'none' } );
-		expect( withSiteContext( { source: 'chat' }, [] ) ).toEqual( {
+	test( 'reports none, and omits blog_id, when the site is not usable', () => {
+		expect( withSiteContext( { source: 'chat' }, 'explicit', 0 ) ).toEqual( {
+			source: 'chat',
+			site_context_source: 'none',
+		} );
+		expect( withSiteContext( { source: 'chat' }, 'primary_site', Number.NaN ) ).toEqual( {
+			source: 'chat',
+			site_context_source: 'none',
+		} );
+		expect( withSiteContext( { source: 'chat' }, 'chat_site' ) ).toEqual( {
+			source: 'chat',
+			site_context_source: 'none',
+		} );
+	} );
+
+	test( 'ignores the site when the source is deliberately none', () => {
+		expect( withSiteContext( { source: 'chat' }, 'none', 123 ) ).toEqual( {
 			source: 'chat',
 			site_context_source: 'none',
 		} );
 	} );
 
 	test( 'never lets a caller-supplied blog_id stand in for the site', () => {
-		expect( withSiteContext( { source: 'chat', blog_id: 999 }, [ [ 'chat_site', 123 ] ] ) ).toEqual(
-			{ source: 'chat', blog_id: 123, site_context_source: 'chat_site' }
-		);
-		expect( withSiteContext( { source: 'chat', blog_id: 999 }, [] ) ).toEqual( {
+		expect( withSiteContext( { source: 'chat', blog_id: 999 }, 'chat_site', 123 ) ).toEqual( {
+			source: 'chat',
+			blog_id: 123,
+			site_context_source: 'chat_site',
+		} );
+		expect( withSiteContext( { source: 'chat', blog_id: 999 }, 'chat_site' ) ).toEqual( {
 			source: 'chat',
 			site_context_source: 'none',
 		} );
 	} );
 
 	test( 'drops force_site_id when no site resolved, so super props cannot backfill one', () => {
-		expect( withSiteContext( { force_site_id: true, source: 'article' }, [] ) ).toEqual( {
-			source: 'article',
-			site_context_source: 'none',
-		} );
+		expect( withSiteContext( { force_site_id: true, source: 'article' }, 'support_site' ) ).toEqual(
+			{
+				source: 'article',
+				site_context_source: 'none',
+			}
+		);
 	} );
 
 	test( 'keeps force_site_id when a site resolved', () => {
 		expect(
-			withSiteContext( { force_site_id: true, source: 'article' }, [ [ 'chat_site', 123 ] ] )
+			withSiteContext( { force_site_id: true, source: 'article' }, 'chat_site', 123 )
 		).toEqual( {
 			force_site_id: true,
 			source: 'article',
@@ -88,7 +88,7 @@ describe( 'withSiteContext', () => {
 
 	test( 'does not mutate the caller properties', () => {
 		const properties = { source: 'chat', blog_id: 999 };
-		withSiteContext( properties, [ [ 'chat_site', 123 ] ] );
+		withSiteContext( properties, 'chat_site', 123 );
 		expect( properties ).toEqual( { source: 'chat', blog_id: 999 } );
 	} );
 } );

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -76,6 +76,8 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 				onSearch={ setSearchQueryAndEmailSubject }
 				location="help-center"
 				isVisible
+				blogId={ site?.ID }
+				siteContextSource="help_center_context"
 				placeholder={ __( 'Search guides…', __i18n_text_domain__ ) }
 				sectionName={ sectionName }
 				useSearchControl

--- a/packages/help-center/src/components/help-center-support-guides.tsx
+++ b/packages/help-center/src/components/help-center-support-guides.tsx
@@ -16,7 +16,7 @@ export const HelpCenterSupportGuides = ( {
 	onSearchChange,
 	currentRoute,
 }: HelpCenterSupportGuidesProps ) => {
-	const { sectionName } = useHelpCenterContext();
+	const { sectionName, site } = useHelpCenterContext();
 	const { searchQuery, setSearchQueryAndEmailSubject, redirectToArticle } =
 		useHelpCenterSearch( onSearchChange );
 
@@ -27,6 +27,8 @@ export const HelpCenterSupportGuides = ( {
 				onSearch={ setSearchQueryAndEmailSubject }
 				location="help-center"
 				isVisible
+				blogId={ site?.ID }
+				siteContextSource="help_center_context"
 				placeholder={ __( 'Search guides…', __i18n_text_domain__ ) }
 				sectionName={ sectionName }
 				useSearchControl

--- a/packages/help-center/src/hooks/test/use-help-center-tracks-event.ts
+++ b/packages/help-center/src/hooks/test/use-help-center-tracks-event.ts
@@ -7,6 +7,12 @@ describe( 'getHelpCenterTracksProperties', () => {
 		).toEqual( { source: 'odie', blog_id: 11, site_context_source: 'explicit' } );
 	} );
 
+	test( 'falls back to the Help Center context site when the explicit site is invalid', () => {
+		expect(
+			getHelpCenterTracksProperties( { source: 'odie' }, { explicitSiteId: 0, siteId: 22 } )
+		).toEqual( { source: 'odie', blog_id: 22, site_context_source: 'help_center_context' } );
+	} );
+
 	test( 'uses Help Center context site', () => {
 		expect( getHelpCenterTracksProperties( {}, { siteId: 22 } ) ).toEqual( {
 			blog_id: 22,

--- a/packages/help-center/src/hooks/use-help-center-tracks-event.ts
+++ b/packages/help-center/src/hooks/use-help-center-tracks-event.ts
@@ -1,4 +1,4 @@
-import { recordTracksEvent, withSiteContext } from '@automattic/calypso-analytics';
+import { getValidBlogId, recordTracksEvent, withSiteContext } from '@automattic/calypso-analytics';
 import { useCallback, useRef } from '@wordpress/element';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 
@@ -15,10 +15,9 @@ export function getHelpCenterTracksProperties(
 	properties: TracksProperties = {},
 	{ explicitSiteId, siteId }: SiteContext = {}
 ): TracksProperties {
-	return withSiteContext( properties, [
-		[ 'explicit', explicitSiteId ],
-		[ 'help_center_context', siteId ],
-	] );
+	return getValidBlogId( explicitSiteId )
+		? withSiteContext( properties, 'explicit', explicitSiteId )
+		: withSiteContext( properties, 'help_center_context', siteId );
 }
 
 export function recordHelpCenterTracksEvent(

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -138,7 +138,8 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 						chat_id: mainChatState?.odieId,
 						bot_name_slug: newInteractionsBotSlug,
 					},
-					[ [ 'selected_site', selectedSiteId ] ]
+					'selected_site',
+					selectedSiteId
 				)
 			);
 		},

--- a/packages/support-articles/src/components/help-center-article/index.tsx
+++ b/packages/support-articles/src/components/help-center-article/index.tsx
@@ -71,7 +71,8 @@ export const HelpCenterArticle = ( {
 					search_query: query,
 					article_source: post.source,
 				},
-				[ [ 'support_site', siteId ] ]
+				'support_site',
+				siteId
 			);
 
 			recordTracksEvent( 'calypso_helpcenter_article_viewed', tracksData );
@@ -95,7 +96,8 @@ export const HelpCenterArticle = ( {
 									article_blog_id: post?.site_ID,
 									section_id: entry?.target?.id,
 								},
-								[ [ 'support_site', siteId ] ]
+								'support_site',
+								siteId
 							);
 							recordTracksEvent( 'calypso_helpcenter_article_section_view', tracksData );
 							observer.unobserve( entry.target ); // Unobserve after first intersection

--- a/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
+++ b/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
@@ -116,17 +116,14 @@ type TracksProperties = Record< string, unknown >;
  * which is installed outside React and so cannot read a hook.
  */
 function recordWithSmoochSite( eventName: string, properties: TracksProperties = {} ) {
-	recordTracksEvent(
-		eventName,
-		withSiteContext( properties, [ [ 'chat_site', getSmoochSiteId() ] ] )
-	);
+	recordTracksEvent( eventName, withSiteContext( properties, 'chat_site', getSmoochSiteId() ) );
 }
 
 /** Records against the site this hook instance was given. */
 function useZendeskTracksEvent( siteId: number | string | undefined ) {
 	return useCallback(
 		( eventName: string, properties: TracksProperties = {} ) =>
-			recordTracksEvent( eventName, withSiteContext( properties, [ [ 'chat_site', siteId ] ] ) ),
+			recordTracksEvent( eventName, withSiteContext( properties, 'chat_site', siteId ) ),
 		[ siteId ]
 	);
 }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-506/help-center-tracks-add-explicit-site-attribution-to-host-integrations

## Proposed Changes

**Every host that opens the Help Center now passes the site the support request is about, instead of leaving attribution to whatever site Calypso happened to have selected.**

- wp-admin, Gutenberg and the Customizer attribute from `helpCenterData.site`; the Calypso masterbars and loaders reuse the site handed to the Help Center; the Agents Manager entry points use their own context.
- `InlineHelpSearchCard` takes an optional `blogId` so each caller supplies the site it knows.
- When there genuinely is no support site, the event resolves to `site_context_source: 'none'` and both super-props implementations leave `blog_id` off rather than substituting the route-derived site.
- Affected events: `wpcom_help_center_icon_interaction`, `calypso_inlinehelp_show`, `calypso_inlinehelp_close`, `calypso_inlinehelp_search`.
- The Multi-site Dashboard hands the omnibar-resolved site to the legacy Help Center panel, the same way the unified agent already receives it, so panel events attribute the site the user is looking at instead of resolving to `'none'`.
- `withSiteContext` now takes a single site and its source as plain arguments — `withSiteContext( properties, 'omnibar', siteId )` — instead of a list of `[ label, siteId ]` tuples (#113529). The two real fallback chains resolve before the call, where their data lives.

`site_context_source` names where the site came from, so its value is per-host by design: the Calypso masterbars report `calypso_selected_site` / `calypso_url_param_site` / `calypso_primary_site`, the standalone hosts report their own, and the Help Center panel reports `help_center_context` — the site it was mounted with, which in Calypso is the one those same masterbar candidates resolved. The `blog_id` agrees across all of them; only the label differs.

**Note for analytics consumers:** on general-admin routes (`/me`, `/read`, `/help`), `wpcom_help_center_icon_interaction` previously carried no `blog_id` at all. It now carries the site the Help Center panel actually mounts with: the site previously selected in the session (Calypso keeps the selection when you leave a site's pages), tagged `'calypso_selected_site'` — or, in a session that never visited a site, the user's primary site, tagged `'calypso_primary_site'`. Queries that treat “has `blog_id`” as the site-specific signal should filter on `site_context_source` instead.

## Why are these changes being made?

Help Center telemetry could not be broken down by site. The events fired fine, but the site id attached to them was ambient: it came from whichever site you had selected in Calypso, which is not necessarily the site you were asking for help about — and outside Calypso, in wp-admin or Gutenberg or the Customizer, nothing attached a site at all. Site coverage on these events sat anywhere between 15% and 81%, so no support metric could be split by plan, by host, or by site.

This is the host-integration half of [DOTSUP-504](https://linear.app/a8c/issue/DOTSUP-504). The events fired from inside the Help Center context were fixed in [DOTSUP-507](https://linear.app/a8c/issue/DOTSUP-507); the ones here fire from the icon, the panel open/close, and the search box, which live outside that context provider and so could not use the shared hook.

## Testing Instructions

1. Run `yarn start`, then open Calypso on a site-scoped route such as `/home/<site>`.
2. Click the Help icon in the masterbar, run a search, then close the panel.
3. In the browser console, watch the Tracks payloads (`localStorage.setItem( 'debug', 'calypso:analytics*' )` before step 2). Confirm `wpcom_help_center_icon_interaction`, `calypso_inlinehelp_show`, `calypso_inlinehelp_search` and `calypso_inlinehelp_close` all carry `blog_id` for that site. The events fired by the host carry `site_context_source: 'calypso_selected_site'`; the search event fired from inside the panel carries the same site as `'help_center_context'`, because the panel reads its own mounted site rather than Calypso's resolution.
4. Navigate from that site to `/me` and repeat. The events keep that site's `blog_id` with `site_context_source: 'calypso_selected_site'` — Calypso's selection is sticky across general-admin routes, and it is the site the panel still mounts with. In a fresh session that never visited a site, `/me` attributes your primary site as `'calypso_primary_site'` instead.
5. On a route carrying `?siteId=<other-site>` with no selected site, confirm the events attribute that site, not the primary one — and that escalating to support chat routes to that same site, since the panel now mounts with it.
6. Open wp-admin on an Atomic site, click the Help icon and repeat the search/close flow. Confirm the events carry that site's `blog_id`, which they previously did not.
7. Repeat step 6 inside the block editor and the Customizer.
8. Open the Agents Manager from the masterbar and confirm its entry-point events carry the site from its own context.
9. Run `yarn start-dashboard`, open a site in the Multi-site Dashboard, open the Help Center from the omnibar and run a search. Confirm the panel's events carry that site's `blog_id` with `site_context_source: 'help_center_context'`.

