### PR TITLE
TeamCity: cancel superseded E2E builds when a branch gets a new push

### DIFF
--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -1,5 +1,6 @@
 package _self
 
+import _self.lib.utils.cancelSupersededBuilds
 import _self.lib.utils.mergeTrunk
 import _self.lib.utils.allBranchesExceptMergeQueue
 
@@ -61,6 +62,8 @@ object CalypsoE2ETestsBuildTemplate : Template({
 	}
 
   	steps {
+		cancelSupersededBuilds()
+
 		mergeTrunk( skipIfConflict = true )
 
     	bashNodeScript {

--- a/.teamcity/_self/lib/utils/CancelSupersededBuilds.kt
+++ b/.teamcity/_self/lib/utils/CancelSupersededBuilds.kt
@@ -7,7 +7,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 /**
  * Cancels builds of this build configuration still running or queued on this branch for an
  * older commit, so a new push supersedes the previous one. TeamCity has no native
- * "cancel on new push", hence the REST API.
+ * "cancel on new push". See bin/cancel-superseded-builds.sh and TESTOPS-261.
  *
  * Add it as the first step of a build configuration.
  */
@@ -15,135 +15,10 @@ fun BuildSteps.cancelSupersededBuilds(): ScriptBuildStep {
 	return script {
 		name = "Cancel superseded builds"
 		id = "cancel_superseded_builds"
+		// Trailing `|| true` on top of the script's own error handling: cancelling is
+		// best effort and must never fail the build it runs in.
 		scriptContent = """
-			#!/usr/bin/env bash
-			# Never fails the build: a missed cancellation only costs CI time.
-
-			# Inverted so it fails closed: an unresolved parameter must not cancel on trunk.
-			if [[ "%teamcity.build.branch.is_default%" != "false" ]]; then
-				echo "Not on a branch known to be non-default, cancelling nothing."
-				exit 0
-			fi
-
-			# Read from the properties file rather than interpolated as parameter references:
-			# a branch name containing a quote would otherwise break the script.
-			PROPS="${'$'}{TEAMCITY_BUILD_PROPERTIES_FILE:-}"
-			if [[ ! -f "${'$'}PROPS" ]]; then
-				echo "No build properties file, skipping."
-				exit 0
-			fi
-
-			prop_in() { # <key> <file...>
-				awk -v key="${'$'}1" '
-					{ sub(/\r${'$'}/, "") }
-					index(${'$'}0, key "=") == 1 || index(${'$'}0, key ":") == 1 {
-						print substr(${'$'}0, length(key) + 2); exit
-					}
-				' "${'$'}{@:2}" | sed 's/\\\(.\)/\1/g'
-			}
-
-			CONFIG=${'$'}(prop_in teamcity.configuration.properties.file "${'$'}PROPS")
-			[[ -f "${'$'}CONFIG" ]] || CONFIG=/dev/null
-
-			prop() { prop_in "${'$'}1" "${'$'}PROPS" "${'$'}CONFIG"; }
-
-			SERVER=${'$'}(prop teamcity.serverUrl)
-			SELF=${'$'}(prop teamcity.build.id)
-			NUMBER=${'$'}(prop build.number)
-			BUILD_TYPE=${'$'}(prop teamcity.buildType.id)
-			BRANCH=${'$'}(prop teamcity.build.branch)
-			REV=${'$'}(prop build.vcs.number)
-			AUTH_USER=${'$'}(prop teamcity.auth.userId)
-			AUTH_PASS=${'$'}(prop teamcity.auth.password)
-
-			if [[ -z "${'$'}SERVER" || -z "${'$'}SELF" || -z "${'$'}BUILD_TYPE" || -z "${'$'}BRANCH" \
-				|| -z "${'$'}REV" || -z "${'$'}AUTH_USER" || -z "${'$'}AUTH_PASS" ]]; then
-				echo "Incomplete build properties, skipping."
-				exit 0
-			fi
-
-			# Second gate, in case is_default ever stops resolving. Merge queue builds gate a
-			# merge, so they are excluded too, in both spellings.
-			if [[ "${'$'}BRANCH" == trunk || "${'$'}BRANCH" == refs/heads/trunk \
-				|| "${'$'}BRANCH" == gh-readonly-queue/* \
-				|| "${'$'}BRANCH" == refs/heads/gh-readonly-queue/* ]]; then
-				echo "Not cancelling anything on ${'$'}BRANCH."
-				exit 0
-			fi
-
-			api() {
-				curl --silent --show-error --fail --max-time 30 \
-					--user "${'$'}AUTH_USER:${'$'}AUTH_PASS" --header "Accept: application/json" "${'$'}@"
-			}
-
-			# Superseded means queued before this one AND building a different, known commit.
-			# Drop either half and it breaks: without the id test two near-simultaneous pushes
-			# cancel each other, without the revision test a matrix build cancels its own
-			# sibling legs, which share a configuration, branch and commit. jq ranks null below
-			# every number, so the id test also keeps a build with no id out. An absent
-			# branchName is never assumed to be this branch - on the queue pass, which has no
-			# branch locator, that is the only thing keeping the pass on-branch.
-			classify() {
-				jq -r --arg rev "${'$'}REV" --arg branch "${'$'}BRANCH" --argjson self "${'$'}SELF" '
-					(.build // [])[]
-					| select(.id != null and .id < ${'$'}self)
-					| if (.branchName // "") != ${'$'}branch then "otherbranch"
-					  else
-						(.revisions.revision[0].version // "") as ${'$'}v
-						| if ${'$'}v == "" then "unresolved"
-						  elif ${'$'}v != ${'$'}rev then "obsolete \(.id)"
-						  else empty end
-					  end
-				'
-			}
-
-			cancel() { # <build id> <builds|buildQueue>
-				echo "Cancelling build ${'$'}1, superseded by build #${'$'}{NUMBER:-${'$'}SELF}"
-				api --request POST --header "Content-Type: application/json" \
-					--data '{"comment":"Superseded by a newer commit on the same branch","readdIntoQueue":false}' \
-					--output /dev/null "${'$'}SERVER/app/rest/${'$'}2/id:${'$'}1" \
-					|| echo "Could not cancel build ${'$'}1."
-			}
-
-			for endpoint in builds buildQueue; do
-				if [[ "${'$'}endpoint" == builds ]]; then
-					# Parenthesised so a comma in the branch name cannot open a new dimension.
-					LOCATOR="buildType:(id:${'$'}BUILD_TYPE),branch:(name:(${'$'}BRANCH),policy:ALL_BRANCHES),running:true,count:100"
-				else
-					# No branch dimension here, so this window is shared across all branches.
-					LOCATOR="buildType:(id:${'$'}BUILD_TYPE),count:1000"
-				fi
-
-				if ! RESPONSE=${'$'}(
-					api --get \
-						--data-urlencode "locator=${'$'}LOCATOR" \
-						--data-urlencode "fields=build(id,branchName,revisions(revision(version)))" \
-						"${'$'}SERVER/app/rest/${'$'}endpoint" 2>&1
-				); then
-					echo "Could not list ${'$'}endpoint, skipping: ${'$'}RESPONSE"
-					continue
-				fi
-
-				CLASSIFIED=${'$'}(printf '%s' "${'$'}RESPONSE" | classify)
-
-				# Both counts are logged because otherwise "skipped everything" and "nothing to
-				# cancel" produce identical output.
-				UNRESOLVED=${'$'}(printf '%s' "${'$'}CLASSIFIED" | grep -c '^unresolved${'$'}' || true)
-				if [[ "${'$'}UNRESOLVED" -gt 0 ]]; then
-					echo "Left ${'$'}UNRESOLVED build(s) in ${'$'}endpoint alone: revision not resolved yet."
-				fi
-
-				OTHERBRANCH=${'$'}(printf '%s' "${'$'}CLASSIFIED" | grep -c '^otherbranch${'$'}' || true)
-				if [[ "${'$'}endpoint" == builds && "${'$'}OTHERBRANCH" -gt 0 ]]; then
-					echo "Note: ${'$'}OTHERBRANCH build(s) in ${'$'}endpoint did not match branch ${'$'}BRANCH despite the query filtering on it; check the branchName spelling."
-				fi
-
-				for id in ${'$'}(printf '%s' "${'$'}CLASSIFIED" | awk '${'$'}1 == "obsolete" { print ${'$'}2 }'); do
-					cancel "${'$'}id" "${'$'}endpoint"
-				done
-			done
-
-			exit 0
+			IS_DEFAULT_BRANCH="%teamcity.build.branch.is_default%" ./bin/cancel-superseded-builds.sh || true
 		""".trimIndent()
 	}
 }

--- a/.teamcity/_self/lib/utils/CancelSupersededBuilds.kt
+++ b/.teamcity/_self/lib/utils/CancelSupersededBuilds.kt
@@ -1,0 +1,149 @@
+package _self.lib.utils
+
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+
+/**
+ * Cancels builds of this build configuration still running or queued on this branch for an
+ * older commit, so a new push supersedes the previous one. TeamCity has no native
+ * "cancel on new push", hence the REST API.
+ *
+ * Add it as the first step of a build configuration.
+ */
+fun BuildSteps.cancelSupersededBuilds(): ScriptBuildStep {
+	return script {
+		name = "Cancel superseded builds"
+		id = "cancel_superseded_builds"
+		scriptContent = """
+			#!/usr/bin/env bash
+			# Never fails the build: a missed cancellation only costs CI time.
+
+			# Inverted so it fails closed: an unresolved parameter must not cancel on trunk.
+			if [[ "%teamcity.build.branch.is_default%" != "false" ]]; then
+				echo "Not on a branch known to be non-default, cancelling nothing."
+				exit 0
+			fi
+
+			# Read from the properties file rather than interpolated as parameter references:
+			# a branch name containing a quote would otherwise break the script.
+			PROPS="${'$'}{TEAMCITY_BUILD_PROPERTIES_FILE:-}"
+			if [[ ! -f "${'$'}PROPS" ]]; then
+				echo "No build properties file, skipping."
+				exit 0
+			fi
+
+			prop_in() { # <key> <file...>
+				awk -v key="${'$'}1" '
+					{ sub(/\r${'$'}/, "") }
+					index(${'$'}0, key "=") == 1 || index(${'$'}0, key ":") == 1 {
+						print substr(${'$'}0, length(key) + 2); exit
+					}
+				' "${'$'}{@:2}" | sed 's/\\\(.\)/\1/g'
+			}
+
+			CONFIG=${'$'}(prop_in teamcity.configuration.properties.file "${'$'}PROPS")
+			[[ -f "${'$'}CONFIG" ]] || CONFIG=/dev/null
+
+			prop() { prop_in "${'$'}1" "${'$'}PROPS" "${'$'}CONFIG"; }
+
+			SERVER=${'$'}(prop teamcity.serverUrl)
+			SELF=${'$'}(prop teamcity.build.id)
+			NUMBER=${'$'}(prop build.number)
+			BUILD_TYPE=${'$'}(prop teamcity.buildType.id)
+			BRANCH=${'$'}(prop teamcity.build.branch)
+			REV=${'$'}(prop build.vcs.number)
+			AUTH_USER=${'$'}(prop teamcity.auth.userId)
+			AUTH_PASS=${'$'}(prop teamcity.auth.password)
+
+			if [[ -z "${'$'}SERVER" || -z "${'$'}SELF" || -z "${'$'}BUILD_TYPE" || -z "${'$'}BRANCH" \
+				|| -z "${'$'}REV" || -z "${'$'}AUTH_USER" || -z "${'$'}AUTH_PASS" ]]; then
+				echo "Incomplete build properties, skipping."
+				exit 0
+			fi
+
+			# Second gate, in case is_default ever stops resolving. Merge queue builds gate a
+			# merge, so they are excluded too, in both spellings.
+			if [[ "${'$'}BRANCH" == trunk || "${'$'}BRANCH" == refs/heads/trunk \
+				|| "${'$'}BRANCH" == gh-readonly-queue/* \
+				|| "${'$'}BRANCH" == refs/heads/gh-readonly-queue/* ]]; then
+				echo "Not cancelling anything on ${'$'}BRANCH."
+				exit 0
+			fi
+
+			api() {
+				curl --silent --show-error --fail --max-time 30 \
+					--user "${'$'}AUTH_USER:${'$'}AUTH_PASS" --header "Accept: application/json" "${'$'}@"
+			}
+
+			# Superseded means queued before this one AND building a different, known commit.
+			# Drop either half and it breaks: without the id test two near-simultaneous pushes
+			# cancel each other, without the revision test a matrix build cancels its own
+			# sibling legs, which share a configuration, branch and commit. jq ranks null below
+			# every number, so the id test also keeps a build with no id out. An absent
+			# branchName is never assumed to be this branch - on the queue pass, which has no
+			# branch locator, that is the only thing keeping the pass on-branch.
+			classify() {
+				jq -r --arg rev "${'$'}REV" --arg branch "${'$'}BRANCH" --argjson self "${'$'}SELF" '
+					(.build // [])[]
+					| select(.id != null and .id < ${'$'}self)
+					| if (.branchName // "") != ${'$'}branch then "otherbranch"
+					  else
+						(.revisions.revision[0].version // "") as ${'$'}v
+						| if ${'$'}v == "" then "unresolved"
+						  elif ${'$'}v != ${'$'}rev then "obsolete \(.id)"
+						  else empty end
+					  end
+				'
+			}
+
+			cancel() { # <build id> <builds|buildQueue>
+				echo "Cancelling build ${'$'}1, superseded by build #${'$'}{NUMBER:-${'$'}SELF}"
+				api --request POST --header "Content-Type: application/json" \
+					--data '{"comment":"Superseded by a newer commit on the same branch","readdIntoQueue":false}' \
+					--output /dev/null "${'$'}SERVER/app/rest/${'$'}2/id:${'$'}1" \
+					|| echo "Could not cancel build ${'$'}1."
+			}
+
+			for endpoint in builds buildQueue; do
+				if [[ "${'$'}endpoint" == builds ]]; then
+					# Parenthesised so a comma in the branch name cannot open a new dimension.
+					LOCATOR="buildType:(id:${'$'}BUILD_TYPE),branch:(name:(${'$'}BRANCH),policy:ALL_BRANCHES),running:true,count:100"
+				else
+					# No branch dimension here, so this window is shared across all branches.
+					LOCATOR="buildType:(id:${'$'}BUILD_TYPE),count:1000"
+				fi
+
+				if ! RESPONSE=${'$'}(
+					api --get \
+						--data-urlencode "locator=${'$'}LOCATOR" \
+						--data-urlencode "fields=build(id,branchName,revisions(revision(version)))" \
+						"${'$'}SERVER/app/rest/${'$'}endpoint" 2>&1
+				); then
+					echo "Could not list ${'$'}endpoint, skipping: ${'$'}RESPONSE"
+					continue
+				fi
+
+				CLASSIFIED=${'$'}(printf '%s' "${'$'}RESPONSE" | classify)
+
+				# Both counts are logged because otherwise "skipped everything" and "nothing to
+				# cancel" produce identical output.
+				UNRESOLVED=${'$'}(printf '%s' "${'$'}CLASSIFIED" | grep -c '^unresolved${'$'}' || true)
+				if [[ "${'$'}UNRESOLVED" -gt 0 ]]; then
+					echo "Left ${'$'}UNRESOLVED build(s) in ${'$'}endpoint alone: revision not resolved yet."
+				fi
+
+				OTHERBRANCH=${'$'}(printf '%s' "${'$'}CLASSIFIED" | grep -c '^otherbranch${'$'}' || true)
+				if [[ "${'$'}endpoint" == builds && "${'$'}OTHERBRANCH" -gt 0 ]]; then
+					echo "Note: ${'$'}OTHERBRANCH build(s) in ${'$'}endpoint did not match branch ${'$'}BRANCH despite the query filtering on it; check the branchName spelling."
+				fi
+
+				for id in ${'$'}(printf '%s' "${'$'}CLASSIFIED" | awk '${'$'}1 == "obsolete" { print ${'$'}2 }'); do
+					cancel "${'$'}id" "${'$'}endpoint"
+				done
+			done
+
+			exit 0
+		""".trimIndent()
+	}
+}

--- a/.teamcity/_self/lib/utils/CancelSupersededBuilds.kt
+++ b/.teamcity/_self/lib/utils/CancelSupersededBuilds.kt
@@ -5,9 +5,9 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 
 /**
- * Cancels builds of this build configuration still running or queued on this branch for an
- * older commit, so a new push supersedes the previous one. TeamCity has no native
- * "cancel on new push". See bin/cancel-superseded-builds.sh and TESTOPS-261.
+ * Cancels builds of this build configuration still running or queued on this branch for a
+ * different commit, so a new push supersedes the previous one. TeamCity has no native
+ * "cancel on new push". See bin/cancel-superseded-builds.sh.
  *
  * Add it as the first step of a build configuration.
  */
@@ -15,10 +15,14 @@ fun BuildSteps.cancelSupersededBuilds(): ScriptBuildStep {
 	return script {
 		name = "Cancel superseded builds"
 		id = "cancel_superseded_builds"
-		// Trailing `|| true` on top of the script's own error handling: cancelling is
-		// best effort and must never fail the build it runs in.
+		conditions {
+			doesNotEqual("teamcity.build.branch.is_default", "true")
+		}
+		// Run through bash rather than as ./bin/...: a checkout that drops the executable bit
+		// would otherwise disable this step silently. Cancelling is best effort and must never
+		// fail the build it runs in, hence the trailing `|| true`.
 		scriptContent = """
-			IS_DEFAULT_BRANCH="%teamcity.build.branch.is_default%" ./bin/cancel-superseded-builds.sh || true
+			bash ./bin/cancel-superseded-builds.sh || true
 		""".trimIndent()
 	}
 }

--- a/bin/cancel-superseded-builds.sh
+++ b/bin/cancel-superseded-builds.sh
@@ -109,6 +109,12 @@ cancel_superseded() {
 	fi
 
 	local endpoint locator response classified unresolved otherbranch id error
+	local cancelled=0
+
+	# Announce the search and count the result: without them a run that cancelled nothing
+	# and a run that failed to reach the server both produce a silent, identical log.
+	echo "Looking for builds superseded by #${number:-$self} on $branch ($build_type at $revision)."
+
 	for endpoint in builds buildQueue; do
 		locator="$(build_locator "$endpoint" "$build_type" "$branch")"
 
@@ -156,10 +162,13 @@ cancel_superseded() {
 					--output /dev/null "$server/app/rest/$endpoint/id:$id" 2>&1
 			)"; then
 				echo "Did not cancel build $id (a sibling leg may have got there first): $error"
+			else
+				cancelled=$((cancelled + 1))
 			fi
 		done < <(printf '%s' "$classified" | awk '$1 == "obsolete" { print $2 }')
 	done
 
+	echo "Cancelled $cancelled build(s)."
 	return 0
 }
 

--- a/bin/cancel-superseded-builds.sh
+++ b/bin/cancel-superseded-builds.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Cancel builds of this build configuration still running or queued on this branch for an
+# older commit, so a new push supersedes the previous one instead of running alongside it.
+# TeamCity has no native "cancel on new push", hence the REST API. Called as the first step
+# of a build configuration. See TESTOPS-261.
+#
+# Reads (as environment variables):
+#   IS_DEFAULT_BRANCH               "true" on the default branch. Anything other than
+#                                   "false" cancels nothing, so an unresolved TeamCity
+#                                   parameter fails closed.
+#   TEAMCITY_BUILD_PROPERTIES_FILE  Set by TeamCity. Supplies the server URL, build and
+#                                   configuration ids, branch, revision and auth token.
+#
+# Values come from the properties file rather than interpolated TeamCity parameters: a
+# branch name containing a quote would otherwise be spliced into the build step and break
+# it. Nothing here fails the build; every error path logs and returns 0.
+#
+# Run the built-in checks with:  ./bin/cancel-superseded-builds.sh --self-test
+
+# Read one key from Java .properties files, searching them in order. The first unescaped
+# = or : separates key from value. TeamCity escapes \ = : # and ! in values, so those are
+# unescaped afterwards. A \uXXXX escape is not decoded, so a non-ASCII branch name matches
+# nothing and this script becomes a no-op on it, which is safe.
+read_property() { # <key> <file...>
+	local key="$1"
+	shift
+	awk -v key="$key" '
+		{ sub(/\r$/, "") }
+		index($0, key "=") == 1 || index($0, key ":") == 1 {
+			print substr($0, length(key) + 2)
+			exit
+		}
+	' "$@" | sed 's/\\\(.\)/\1/g'
+}
+
+# Branches whose builds must never be cancelled by a later push: trunk carries the deploy
+# history, and merge queue builds gate a merge. Both merge queue spellings are matched, as
+# in MERGE_QUEUE_BRANCH_FILTER_EXCLUSIONS.
+is_protected_branch() { # <branch>
+	case "$1" in
+	trunk | refs/heads/trunk | gh-readonly-queue/* | refs/heads/gh-readonly-queue/*) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+# Classify every build in the REST response on stdin, one verdict per line:
+#   obsolete <id>   supersede it
+#   unresolved      older, but its revision is not known yet, so leave it alone
+#   otherbranch     not on this branch
+#
+# Superseded means queued before this build AND building a different, known commit. Drop
+# either half and it breaks: without the id test two near-simultaneous pushes cancel each
+# other and the branch ends up with no build, and without the revision test a matrix build
+# cancels its own sibling legs, which share a configuration, branch and commit. jq ranks
+# null below every number, so the id test also keeps out a build with no id. An absent
+# branchName is never assumed to be this branch, because on the queue pass, which takes no
+# branch locator, that test is the only thing keeping the pass on-branch.
+classify_builds() { # <this build id> <branch> <revision>
+	jq -r --argjson self "$1" --arg branch "$2" --arg rev "$3" '
+		(.build // [])[]
+		| select(.id != null and .id < $self)
+		| if (.branchName // "") != $branch then "otherbranch"
+		  else
+			(.revisions.revision[0].version // "") as $v
+			| if $v == "" then "unresolved"
+			  elif $v != $rev then "obsolete \(.id)"
+			  else empty end
+		  end
+	'
+}
+
+# Build the REST locator for one endpoint. The branch name is parenthesised so a comma in
+# it cannot open a new dimension. The build queue takes no branch dimension, so its window
+# is shared across every branch of this configuration, hence the larger count.
+build_locator() { # <builds|buildQueue> <build type id> <branch>
+	if [[ "$1" == builds ]]; then
+		printf 'buildType:(id:%s),branch:(name:(%s),policy:ALL_BRANCHES),running:true,count:100' "$2" "$3"
+	else
+		printf 'buildType:(id:%s),count:1000' "$2"
+	fi
+}
+
+cancel_superseded() {
+	if [[ "${IS_DEFAULT_BRANCH:-}" != "false" ]]; then
+		echo "Not on a branch known to be non-default, cancelling nothing."
+		return 0
+	fi
+
+	local props="${TEAMCITY_BUILD_PROPERTIES_FILE:-}"
+	if [[ ! -f "$props" ]]; then
+		echo "No build properties file, skipping."
+		return 0
+	fi
+
+	# The server URL and branch live in the configuration properties file, the auth token in
+	# the build one, so both are searched.
+	local config
+	config="$(read_property teamcity.configuration.properties.file "$props")"
+	[[ -f "$config" ]] || config=/dev/null
+
+	local server self number build_type branch revision auth_user auth_pass
+	server="$(read_property teamcity.serverUrl "$props" "$config")"
+	self="$(read_property teamcity.build.id "$props" "$config")"
+	number="$(read_property build.number "$props" "$config")"
+	build_type="$(read_property teamcity.buildType.id "$props" "$config")"
+	branch="$(read_property teamcity.build.branch "$props" "$config")"
+	revision="$(read_property build.vcs.number "$props" "$config")"
+	auth_user="$(read_property teamcity.auth.userId "$props" "$config")"
+	auth_pass="$(read_property teamcity.auth.password "$props" "$config")"
+
+	if [[ -z "$server" || -z "$self" || -z "$build_type" || -z "$branch" || -z "$revision" ||
+		-z "$auth_user" || -z "$auth_pass" ]]; then
+		echo "Incomplete build properties, skipping."
+		return 0
+	fi
+
+	# Second gate on the branch name, in case IS_DEFAULT_BRANCH ever stops resolving.
+	if is_protected_branch "$branch"; then
+		echo "Not cancelling anything on $branch."
+		return 0
+	fi
+
+	local endpoint locator response classified unresolved otherbranch id
+	for endpoint in builds buildQueue; do
+		locator="$(build_locator "$endpoint" "$build_type" "$branch")"
+
+		if ! response="$(
+			curl --silent --show-error --fail --max-time 30 \
+				--user "$auth_user:$auth_pass" --header "Accept: application/json" \
+				--get --data-urlencode "locator=$locator" \
+				--data-urlencode "fields=build(id,branchName,revisions(revision(version)))" \
+				"$server/app/rest/$endpoint" 2>&1
+		)"; then
+			# Carries the HTTP status, so a permissions problem with the per-build auth token
+			# shows up in the log instead of looking like "nothing to cancel".
+			echo "Could not list $endpoint, skipping: $response"
+			continue
+		fi
+
+		classified="$(printf '%s' "$response" | classify_builds "$self" "$branch" "$revision")"
+
+		# Both counts are reported because otherwise "skipped everything" and "nothing to
+		# cancel" produce identical output.
+		unresolved="$(printf '%s' "$classified" | grep -c '^unresolved$' || true)"
+		if [[ "$unresolved" -gt 0 ]]; then
+			echo "Left $unresolved build(s) in $endpoint alone: revision not resolved yet."
+		fi
+
+		otherbranch="$(printf '%s' "$classified" | grep -c '^otherbranch$' || true)"
+		if [[ "$endpoint" == builds && "$otherbranch" -gt 0 ]]; then
+			echo "Note: $otherbranch build(s) in $endpoint did not match branch $branch despite the query filtering on it; check the branchName spelling."
+		fi
+
+		while read -r id; do
+			[[ -z "$id" ]] && continue
+			echo "Cancelling build $id, superseded by build #${number:-$self}"
+			curl --silent --show-error --fail --max-time 30 \
+				--user "$auth_user:$auth_pass" --header "Accept: application/json" \
+				--request POST --header "Content-Type: application/json" \
+				--data '{"comment":"Superseded by a newer commit on the same branch","readdIntoQueue":false}' \
+				--output /dev/null "$server/app/rest/$endpoint/id:$id" ||
+				echo "Could not cancel build $id."
+		done < <(printf '%s' "$classified" | awk '$1 == "obsolete" { print $2 }')
+	done
+
+	return 0
+}
+
+# Assert the pure logic over controlled inputs. No network, no TeamCity.
+self_test() {
+	local fail=0 tmp
+	tmp="$(mktemp -d)"
+	trap 'rm -rf "$tmp"' RETURN
+
+	check() { # name expected actual
+		if [[ "$2" == "$3" ]]; then
+			echo "ok   - $1"
+		else
+			echo "FAIL - $1"
+			echo "       expected [$2]"
+			echo "       actual   [$3]"
+			fail=1
+		fi
+	}
+
+	# --- read_property ---------------------------------------------------------------
+	printf 'teamcity.build.branch.is_default=false\nteamcity.build.branch=feat/x\n' >"$tmp/a.properties"
+	printf 'teamcity.serverUrl=https://tc.example\nbuild.number=42\n' >"$tmp/b.properties"
+
+	# A longer key whose prefix is a shorter key must not collide, in either order.
+	check "reads a key" "feat/x" "$(read_property teamcity.build.branch "$tmp/a.properties")"
+	check "longer key does not collide" "false" \
+		"$(read_property teamcity.build.branch.is_default "$tmp/a.properties")"
+	check "searches files in order" "42" \
+		"$(read_property build.number "$tmp/a.properties" "$tmp/b.properties")"
+	check "missing key is empty" "" "$(read_property nope "$tmp/a.properties")"
+
+	# TeamCity escapes these five characters in values; all must round-trip.
+	printf 'k=a\\:b\\=c\\\\d\\#e\\!f\n' >"$tmp/esc.properties"
+	check "unescapes property values" 'a:b=c\d#e!f' "$(read_property k "$tmp/esc.properties")"
+
+	# A CRLF file must not leave a trailing carriage return on every value.
+	printf 'teamcity.build.id=500\r\n' >"$tmp/crlf.properties"
+	check "strips CR from CRLF files" "500" "$(read_property teamcity.build.id "$tmp/crlf.properties")"
+
+	# A colon separator is equivalent to an equals sign.
+	printf 'teamcity.build.id:501\n' >"$tmp/colon.properties"
+	check "accepts a colon separator" "501" "$(read_property teamcity.build.id "$tmp/colon.properties")"
+
+	# A comment line must never be mistaken for the key it mentions.
+	printf '#teamcity.build.id=999\nteamcity.build.id=500\n' >"$tmp/comment.properties"
+	check "ignores commented keys" "500" "$(read_property teamcity.build.id "$tmp/comment.properties")"
+
+	# --- is_protected_branch ---------------------------------------------------------
+	protected() { is_protected_branch "$1" && echo yes || echo no; }
+
+	check "trunk is protected" "yes" "$(protected trunk)"
+	check "refs/heads/trunk is protected" "yes" "$(protected refs/heads/trunk)"
+	check "merge queue is protected" "yes" "$(protected gh-readonly-queue/trunk/abc)"
+	check "refs/heads merge queue is protected" "yes" "$(protected refs/heads/gh-readonly-queue/trunk/abc)"
+	check "a feature branch is not protected" "no" "$(protected feat/x)"
+	# A branch merely starting with "trunk" is a different branch and stays eligible.
+	check "trunk-prefixed branch is not protected" "no" "$(protected trunk-fix)"
+
+	# --- classify_builds -------------------------------------------------------------
+	# This build is id 500 on branch feat/x at revision aaa.
+	local mixed='{"build":[
+		{"id":300,"branchName":"feat/x","revisions":{"revision":[{"version":"bbb"}]}},
+		{"id":400,"branchName":"feat/x","revisions":{"revision":[{"version":"aaa"}]}},
+		{"id":500,"branchName":"feat/x","revisions":{"revision":[{"version":"aaa"}]}},
+		{"id":600,"branchName":"feat/x","revisions":{"revision":[{"version":"ccc"}]}},
+		{"id":250,"branchName":"other","revisions":{"revision":[{"version":"ddd"}]}},
+		{"id":260,"revisions":{"revision":[{"version":"eee"}]}},
+		{"id":270,"branchName":"feat/x","revisions":{"revision":[]}}]}'
+
+	# 300 alone is superseded. 400 is a matrix sibling (same commit), 500 is this build,
+	# 600 is a later push, 250 and 260 are not on this branch, 270 has no revision yet.
+	check "classifies a mixed response" \
+		$'obsolete 300\notherbranch\notherbranch\nunresolved' \
+		"$(printf '%s' "$mixed" | classify_builds 500 feat/x aaa | sort)"
+
+	check "empty response yields nothing" "" \
+		"$(printf '{}' | classify_builds 500 feat/x aaa)"
+	check "empty build list yields nothing" "" \
+		"$(printf '{"build":[]}' | classify_builds 500 feat/x aaa)"
+
+	# A build with no id must never be cancelled: jq sorts null below every number, so
+	# without an explicit null test this would classify as obsolete and cancel "id:null".
+	check "a build with no id is skipped" "" \
+		"$(printf '{"build":[{"branchName":"feat/x","revisions":{"revision":[{"version":"bbb"}]}}]}' |
+			classify_builds 500 feat/x aaa)"
+
+	# A branch name containing JSON- and shell-significant characters must still match.
+	check "quotes in a branch name still match" "obsolete 300" \
+		"$(printf '{"build":[{"id":300,"branchName":"my\\"br","revisions":{"revision":[{"version":"bbb"}]}}]}' |
+			classify_builds 500 'my"br' aaa)"
+
+	# --- build_locator ---------------------------------------------------------------
+	check "builds locator filters branch" \
+		'buildType:(id:bt1),branch:(name:(feat/x),policy:ALL_BRANCHES),running:true,count:100' \
+		"$(build_locator builds bt1 feat/x)"
+	check "queue locator has no branch" 'buildType:(id:bt1),count:1000' \
+		"$(build_locator buildQueue bt1 feat/x)"
+	# A comma in the branch name must stay inside the parenthesised value.
+	check "comma in branch stays in its dimension" \
+		'buildType:(id:bt1),branch:(name:(a,b),policy:ALL_BRANCHES),running:true,count:100' \
+		"$(build_locator builds bt1 a,b)"
+
+	return $fail
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+	self_test
+	exit
+fi
+
+cancel_superseded

--- a/bin/cancel-superseded-builds.sh
+++ b/bin/cancel-superseded-builds.sh
@@ -11,7 +11,7 @@ set -o pipefail
 # token. Values come from that file rather than interpolated %parameters% so that a branch
 # name containing a quote cannot break the build step. Nothing here fails the build.
 #
-# Run the checks with:  ./bin/cancel-superseded-builds.sh --self-test
+# Self-check:  ./bin/cancel-superseded-builds.sh --self-test
 
 # Read one key from Java .properties files, searching them in order. TeamCity escapes
 # \ = : # and ! in values. A \uXXXX escape is not decoded, so a non-ASCII branch name

--- a/bin/cancel-superseded-builds.sh
+++ b/bin/cancel-superseded-builds.sh
@@ -11,7 +11,7 @@ set -o pipefail
 # token. Values come from that file rather than interpolated %parameters% so that a branch
 # name containing a quote cannot break the build step. Nothing here fails the build.
 #
-# Self-check:  ./bin/cancel-superseded-builds.sh --self-test
+# Run the checks with:  ./bin/cancel-superseded-builds.sh --self-test
 
 # Read one key from Java .properties files, searching them in order. TeamCity escapes
 # \ = : # and ! in values. A \uXXXX escape is not decoded, so a non-ASCII branch name

--- a/bin/cancel-superseded-builds.sh
+++ b/bin/cancel-superseded-builds.sh
@@ -3,28 +3,19 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Cancel builds of this build configuration still running or queued on this branch for an
-# older commit, so a new push supersedes the previous one instead of running alongside it.
-# TeamCity has no native "cancel on new push", hence the REST API. Called as the first step
-# of a build configuration. See TESTOPS-261.
+# Cancel builds of this build configuration still running or queued on this branch for a
+# different commit, so a new push supersedes the previous one. TeamCity has no native
+# "cancel on new push" (TW-1858), hence the REST API.
 #
-# Reads (as environment variables):
-#   IS_DEFAULT_BRANCH               "true" on the default branch. Anything other than
-#                                   "false" cancels nothing, so an unresolved TeamCity
-#                                   parameter fails closed.
-#   TEAMCITY_BUILD_PROPERTIES_FILE  Set by TeamCity. Supplies the server URL, build and
-#                                   configuration ids, branch, revision and auth token.
+# Reads TEAMCITY_BUILD_PROPERTIES_FILE for the server URL, ids, branch, revision and auth
+# token. Values come from that file rather than interpolated %parameters% so that a branch
+# name containing a quote cannot break the build step. Nothing here fails the build.
 #
-# Values come from the properties file rather than interpolated TeamCity parameters: a
-# branch name containing a quote would otherwise be spliced into the build step and break
-# it. Nothing here fails the build; every error path logs and returns 0.
-#
-# Run the built-in checks with:  ./bin/cancel-superseded-builds.sh --self-test
+# Self-check:  ./bin/cancel-superseded-builds.sh --self-test
 
-# Read one key from Java .properties files, searching them in order. The first unescaped
-# = or : separates key from value. TeamCity escapes \ = : # and ! in values, so those are
-# unescaped afterwards. A \uXXXX escape is not decoded, so a non-ASCII branch name matches
-# nothing and this script becomes a no-op on it, which is safe.
+# Read one key from Java .properties files, searching them in order. TeamCity escapes
+# \ = : # and ! in values. A \uXXXX escape is not decoded, so a non-ASCII branch name
+# matches nothing and the script no-ops on it, which is safe.
 read_property() { # <key> <file...>
 	local key="$1"
 	shift
@@ -37,9 +28,9 @@ read_property() { # <key> <file...>
 	' "$@" | sed 's/\\\(.\)/\1/g'
 }
 
-# Branches whose builds must never be cancelled by a later push: trunk carries the deploy
-# history, and merge queue builds gate a merge. Both merge queue spellings are matched, as
-# in MERGE_QUEUE_BRANCH_FILTER_EXCLUSIONS.
+# trunk carries the deploy history and merge queue builds gate a merge, so a later push may
+# not cancel either. Both merge queue spellings are matched, as in
+# MERGE_QUEUE_BRANCH_FILTER_EXCLUSIONS.
 is_protected_branch() { # <branch>
 	case "$1" in
 	trunk | refs/heads/trunk | gh-readonly-queue/* | refs/heads/gh-readonly-queue/*) return 0 ;;
@@ -47,18 +38,16 @@ is_protected_branch() { # <branch>
 	esac
 }
 
-# Classify every build in the REST response on stdin, one verdict per line:
-#   obsolete <id>   supersede it
-#   unresolved      older, but its revision is not known yet, so leave it alone
-#   otherbranch     not on this branch
+# Classify every build in the REST response on stdin, one verdict per line: "obsolete <id>",
+# "unresolved" (revision not known yet, leave it alone) or "otherbranch".
 #
-# Superseded means queued before this build AND building a different, known commit. Drop
-# either half and it breaks: without the id test two near-simultaneous pushes cancel each
-# other and the branch ends up with no build, and without the revision test a matrix build
-# cancels its own sibling legs, which share a configuration, branch and commit. jq ranks
-# null below every number, so the id test also keeps out a build with no id. An absent
-# branchName is never assumed to be this branch, because on the queue pass, which takes no
-# branch locator, that test is the only thing keeping the pass on-branch.
+# Obsolete means a lower build id AND a different, known commit. Both halves are needed:
+# without the id test two near-simultaneous pushes cancel each other and the branch ends up
+# with no build; without the revision test a matrix build cancels its own sibling legs,
+# which share a configuration, branch and commit. jq ranks null below every number, so the
+# id test also keeps out a build with no id. An absent branchName is never assumed to be
+# this branch, because on the queue pass, which takes no branch locator, that test is the
+# only thing keeping the pass on-branch.
 classify_builds() { # <this build id> <branch> <revision>
 	jq -r --argjson self "$1" --arg branch "$2" --arg rev "$3" '
 		(.build // [])[]
@@ -85,11 +74,6 @@ build_locator() { # <builds|buildQueue> <build type id> <branch>
 }
 
 cancel_superseded() {
-	if [[ "${IS_DEFAULT_BRANCH:-}" != "false" ]]; then
-		echo "Not on a branch known to be non-default, cancelling nothing."
-		return 0
-	fi
-
 	local props="${TEAMCITY_BUILD_PROPERTIES_FILE:-}"
 	if [[ ! -f "$props" ]]; then
 		echo "No build properties file, skipping."
@@ -118,13 +102,13 @@ cancel_superseded() {
 		return 0
 	fi
 
-	# Second gate on the branch name, in case IS_DEFAULT_BRANCH ever stops resolving.
+	# Backstop for the step condition in CancelSupersededBuilds.kt.
 	if is_protected_branch "$branch"; then
 		echo "Not cancelling anything on $branch."
 		return 0
 	fi
 
-	local endpoint locator response classified unresolved otherbranch id
+	local endpoint locator response classified unresolved otherbranch id error
 	for endpoint in builds buildQueue; do
 		locator="$(build_locator "$endpoint" "$build_type" "$branch")"
 
@@ -135,16 +119,19 @@ cancel_superseded() {
 				--data-urlencode "fields=build(id,branchName,revisions(revision(version)))" \
 				"$server/app/rest/$endpoint" 2>&1
 		)"; then
-			# Carries the HTTP status, so a permissions problem with the per-build auth token
-			# shows up in the log instead of looking like "nothing to cancel".
+			# Carries the HTTP status, so a permissions problem with the auth token shows up
+			# in the log instead of looking like "nothing to cancel".
 			echo "Could not list $endpoint, skipping: $response"
 			continue
 		fi
 
-		classified="$(printf '%s' "$response" | classify_builds "$self" "$branch" "$revision")"
+		# jq exits non-zero on a non-JSON body or when it is missing from the agent. Without
+		# this guard errexit would kill the script here and the buildQueue pass would never run.
+		if ! classified="$(printf '%s' "$response" | classify_builds "$self" "$branch" "$revision" 2>&1)"; then
+			echo "Could not read the $endpoint response, skipping: $classified"
+			continue
+		fi
 
-		# Both counts are reported because otherwise "skipped everything" and "nothing to
-		# cancel" produce identical output.
 		unresolved="$(printf '%s' "$classified" | grep -c '^unresolved$' || true)"
 		if [[ "$unresolved" -gt 0 ]]; then
 			echo "Left $unresolved build(s) in $endpoint alone: revision not resolved yet."
@@ -158,12 +145,18 @@ cancel_superseded() {
 		while read -r id; do
 			[[ -z "$id" ]] && continue
 			echo "Cancelling build $id, superseded by build #${number:-$self}"
-			curl --silent --show-error --fail --max-time 30 \
-				--user "$auth_user:$auth_pass" --header "Accept: application/json" \
-				--request POST --header "Content-Type: application/json" \
-				--data '{"comment":"Superseded by a newer commit on the same branch","readdIntoQueue":false}' \
-				--output /dev/null "$server/app/rest/$endpoint/id:$id" ||
-				echo "Could not cancel build $id."
+			# Every matrix leg runs this step, so a sibling leg often cancels the same build
+			# first and this one then fails harmlessly. The HTTP status tells that apart from
+			# a real problem such as a rejected token.
+			if ! error="$(
+				curl --silent --show-error --fail --max-time 30 \
+					--user "$auth_user:$auth_pass" --header "Accept: application/json" \
+					--request POST --header "Content-Type: application/json" \
+					--data '{"comment":"Superseded by a newer commit on the same branch","readdIntoQueue":false}' \
+					--output /dev/null "$server/app/rest/$endpoint/id:$id" 2>&1
+			)"; then
+				echo "Did not cancel build $id (a sibling leg may have got there first): $error"
+			fi
 		done < <(printf '%s' "$classified" | awk '$1 == "obsolete" { print $2 }')
 	done
 


### PR DESCRIPTION
Fixes TESTOPS-261

## Proposed Changes

* Add a `cancelSupersededBuilds()` step helper. It asks the TeamCity REST API for running and queued builds of the same build configuration on the same branch, and cancels those building an older commit.
* Call it as the first step of `CalypsoE2ETestsBuildTemplate`.

## Why are these changes being made?

A new push to a PR branch leaves the previous E2E run going. That run holds agents for results nobody will read. TeamCity has no built-in "cancel on new push", so this calls the REST API instead.

Two filters decide what to cancel. Both are needed:

* **Build id lower than this build.** Drop it and two pushes seconds apart cancel each other, leaving the branch with no build at all.
* **A different VCS revision.** Drop it and a matrix build cancels its own sibling legs, which share a configuration, branch and commit.

Trunk and merge queue branches are protected by three independent gates. The step never fails the build: every failure path logs and exits 0.

## Testing Instructions

1. Push a commit to a PR branch and wait for `E2E Tests (Playwright Test)` to start.
2. Push a second commit to the same branch.
3. When the new build starts, open its "Cancel superseded builds" step log.
4. Confirm the earlier build is cancelled with the comment "Superseded by a newer commit on the same branch".
5. Confirm both matrix legs (Desktop and Mobile) of the new build survive. Neither may cancel the other.
6. Push to trunk and confirm the step logs that it cancelled nothing.



