### PR TITLE
FORNO-445 Track Jetpack AI sidebar response interactions

### DIFF
--- a/packages/agents-manager/src/components/__tests__/chat-response-tracking.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/chat-response-tracking.test.tsx
@@ -74,6 +74,54 @@ describe( 'ChatResponseRenderedTracker', () => {
 			tool_id: 'jetpack_ai__show_component',
 		} );
 	} );
+
+	it( 'records supported response properties', () => {
+		render(
+			<ChatResponseRenderedTracker
+				componentType="ai-editorial-review"
+				toolId="jetpack_ai__show_component"
+				responseTrackingProperties={ {
+					suggested_edit_count: 2,
+					conflict_count: 1,
+					implication_count: 0,
+					guideline_violation_count: 3,
+					review_context: 'notes_and_guidelines',
+				} }
+			/>
+		);
+
+		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_response_rendered', {
+			component_type: 'ai-editorial-review',
+			tool_id: 'jetpack_ai__show_component',
+			suggested_edit_count: 2,
+			conflict_count: 1,
+			implication_count: 0,
+			guideline_violation_count: 3,
+			review_context: 'notes_and_guidelines',
+		} );
+	} );
+
+	it( 'omits unsupported and invalid response properties', () => {
+		render(
+			<ChatResponseRenderedTracker
+				componentType="ai-editorial-review"
+				toolId="jetpack_ai__show_component"
+				responseTrackingProperties={ {
+					suggested_edit_count: -1,
+					conflict_count: 1.5,
+					implication_count: 2,
+					review_context: 'unknown-context',
+					private_text: 'do not record',
+				} }
+			/>
+		);
+
+		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_response_rendered', {
+			component_type: 'ai-editorial-review',
+			tool_id: 'jetpack_ai__show_component',
+			implication_count: 2,
+		} );
+	} );
 } );
 
 describe( 'createChatResponseActionCallback', () => {

--- a/packages/agents-manager/src/components/__tests__/chat-response-tracking.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/chat-response-tracking.test.tsx
@@ -1,0 +1,121 @@
+import { render } from '@testing-library/react';
+import * as tracks from '../../utils/tracks';
+import ChatResponseRenderedTracker, {
+	createChatResponseActionCallback,
+} from '../chat-response-tracking';
+
+let mockRecordBigSkyTracksEvent: jest.SpiedFunction< typeof tracks.recordBigSkyTracksEvent >;
+
+beforeEach( () => {
+	mockRecordBigSkyTracksEvent = jest
+		.spyOn( tracks, 'recordBigSkyTracksEvent' )
+		.mockImplementation( () => undefined );
+} );
+
+afterEach( () => {
+	mockRecordBigSkyTracksEvent.mockRestore();
+} );
+
+afterAll( () => {
+	// This suite imports the real Tracks module before spying on it. Clear that
+	// module instance so later suites can install their own module-level mocks.
+	jest.resetModules();
+} );
+
+describe( 'ChatResponseRenderedTracker', () => {
+	it( 'records the known response identifiers once', () => {
+		const { rerender } = render(
+			<ChatResponseRenderedTracker
+				componentType="title-picker"
+				toolId="jetpack_ai__show_component"
+				toolCallId="tool-call-1"
+			/>
+		);
+
+		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_response_rendered', {
+			component_type: 'title-picker',
+			tool_id: 'jetpack_ai__show_component',
+			tool_call_id: 'tool-call-1',
+		} );
+
+		rerender(
+			<ChatResponseRenderedTracker
+				componentType="title-picker"
+				toolId="jetpack_ai__show_component"
+				toolCallId="tool-call-1"
+			/>
+		);
+
+		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledTimes( 1 );
+
+		rerender(
+			<ChatResponseRenderedTracker
+				componentType="title-picker"
+				toolId="jetpack_ai__show_component"
+				toolCallId="tool-call-2"
+			/>
+		);
+
+		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledTimes( 2 );
+		expect( mockRecordBigSkyTracksEvent ).toHaveBeenLastCalledWith( 'chat_response_rendered', {
+			component_type: 'title-picker',
+			tool_id: 'jetpack_ai__show_component',
+			tool_call_id: 'tool-call-2',
+		} );
+	} );
+
+	it( 'omits an unavailable tool call id', () => {
+		render(
+			<ChatResponseRenderedTracker componentType="proofread" toolId="jetpack_ai__show_component" />
+		);
+
+		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_response_rendered', {
+			component_type: 'proofread',
+			tool_id: 'jetpack_ai__show_component',
+		} );
+	} );
+} );
+
+describe( 'createChatResponseActionCallback', () => {
+	it( 'records the action with response identifiers and aggregate item count', () => {
+		const onResponseAction = createChatResponseActionCallback( {
+			componentType: 'proofread',
+			toolId: 'jetpack_ai__show_component',
+			toolCallId: 'tool-call-1',
+		} );
+
+		onResponseAction( {
+			action: 'bulk_accept',
+			target: 'edit',
+			outcome: 'partial_failed',
+			itemCount: 3,
+		} );
+
+		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_response_action', {
+			component_type: 'proofread',
+			tool_id: 'jetpack_ai__show_component',
+			tool_call_id: 'tool-call-1',
+			action: 'bulk_accept',
+			target: 'edit',
+			outcome: 'partial_failed',
+			item_count: 3,
+		} );
+	} );
+
+	it( 'omits unavailable optional properties', () => {
+		const onResponseAction = createChatResponseActionCallback( {
+			componentType: 'title-picker',
+			toolId: 'jetpack_ai__show_component',
+		} );
+
+		onResponseAction( { action: 'accept', target: 'option', outcome: 'success' } );
+
+		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_response_action', {
+			component_type: 'title-picker',
+			tool_id: 'jetpack_ai__show_component',
+			action: 'accept',
+			target: 'option',
+			outcome: 'success',
+		} );
+	} );
+} );

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -750,6 +750,29 @@ describe( 'OrchestratorChat', () => {
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 2 );
 	} );
 
+	it( 'does not re-track lingering contextual suggestions when a block is deselected', () => {
+		mockSelectedBlockType = 'core/paragraph';
+		const blockSuggestions: Suggestion[] = [
+			{ id: 'change-tone', label: 'Change tone', prompt: 'Change the tone' },
+			{ id: 'check-grammar', label: 'Check grammar', prompt: 'Check the grammar' },
+		];
+		const useSuggestions = jest.fn( () => ( {
+			suggestions: blockSuggestions,
+			replaceEmptyViewSuggestions: true,
+		} ) );
+		mockUseAgentChat.mockReturnValue( agentChatReturn( { suggestions: blockSuggestions } ) );
+
+		const { rerender } = render( chat( { useSuggestions } ) );
+
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 1 );
+		mockSelectedBlockType = undefined;
+		rerender( chat( { useSuggestions } ) );
+		mockSelectedBlockType = 'core/paragraph';
+		rerender( chat( { useSuggestions } ) );
+
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	it( 'falls back to the static empty-view suggestions when the provider has none', () => {
 		const staticDefaults: Suggestion[] = [
 			{ id: 'getting-started', label: 'Getting started with WordPress', prompt: 'getting-started' },

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -554,7 +554,7 @@ describe( 'OrchestratorChat', () => {
 
 		render( chat( { useSuggestions: useSuggestions } ) );
 
-		expect( useSuggestions ).toHaveBeenCalledWith( 3, { suggestionsVisible: true } );
+		expect( useSuggestions ).toHaveBeenCalledWith( 3 );
 	} );
 
 	it( 'does not limit external provider suggestions while docked', () => {
@@ -562,7 +562,7 @@ describe( 'OrchestratorChat', () => {
 
 		render( chat( { isDocked: true, useSuggestions: useSuggestions } ) );
 
-		expect( useSuggestions ).toHaveBeenCalledWith( undefined, { suggestionsVisible: true } );
+		expect( useSuggestions ).toHaveBeenCalledWith( undefined );
 	} );
 
 	it( 'uses the current Gutenberg block type when the selected block changes', () => {

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -663,6 +663,7 @@ describe( 'OrchestratorChat', () => {
 	} );
 
 	it( 'replaces provider empty-view suggestions with contextual dynamic suggestions', () => {
+		mockSelectedBlockType = 'core/paragraph';
 		const emptySuggestions: Suggestion[] = [
 			{ id: 'simple-review', label: 'Simple Review', prompt: 'Review this page' },
 			{ id: 'proofread', label: 'Proofread', prompt: 'Proofread this page' },
@@ -712,6 +713,41 @@ describe( 'OrchestratorChat', () => {
 		expect( screen.queryByText( 'Proofread' ) ).toBeNull();
 		expect( screen.getByText( 'Change tone' ) ).toBeTruthy();
 		expect( screen.getByText( 'Check grammar' ) ).toBeTruthy();
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_suggestions_rendered', {
+			suggestions: '|change-tone|check-grammar|',
+			block_type: 'core/paragraph',
+		} );
+	} );
+
+	it( 'tracks the same contextual suggestions again when the selected block type changes', () => {
+		mockSelectedBlockType = 'core/paragraph';
+		const blockSuggestions: Suggestion[] = [
+			{ id: 'change-tone', label: 'Change tone', prompt: 'Change the tone' },
+			{ id: 'check-grammar', label: 'Check grammar', prompt: 'Check the grammar' },
+		];
+		const useSuggestions = jest.fn( () => ( {
+			suggestions: blockSuggestions,
+			replaceEmptyViewSuggestions: true,
+		} ) );
+		mockUseAgentChat.mockReturnValue( agentChatReturn( { suggestions: blockSuggestions } ) );
+
+		const { rerender } = render( chat( { useSuggestions } ) );
+
+		expect( recordBigSkyTracksEvent ).toHaveBeenLastCalledWith( 'chat_suggestions_rendered', {
+			suggestions: '|change-tone|check-grammar|',
+			block_type: 'core/paragraph',
+		} );
+		rerender( chat( { useSuggestions } ) );
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 1 );
+
+		mockSelectedBlockType = 'core/heading';
+		rerender( chat( { useSuggestions } ) );
+
+		expect( recordBigSkyTracksEvent ).toHaveBeenLastCalledWith( 'chat_suggestions_rendered', {
+			suggestions: '|change-tone|check-grammar|',
+			block_type: 'core/heading',
+		} );
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 2 );
 	} );
 
 	it( 'falls back to the static empty-view suggestions when the provider has none', () => {
@@ -725,7 +761,8 @@ describe( 'OrchestratorChat', () => {
 		expect( screen.getByText( 'Getting started with WordPress' ) ).toBeTruthy();
 	} );
 
-	it( 'tracks chat_suggestions_rendered for the empty-view suggestions', () => {
+	it( 'does not add block context to non-contextual empty-view suggestions', () => {
+		mockSelectedBlockType = 'core/paragraph';
 		const staticDefaults: Suggestion[] = [
 			{ id: 'getting-started', label: 'Getting started with WordPress', prompt: 'getting-started' },
 		];
@@ -734,6 +771,24 @@ describe( 'OrchestratorChat', () => {
 
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_suggestions_rendered', {
 			suggestions: '|getting-started|',
+		} );
+	} );
+
+	it( 'tracks suggestions without block context when the block editor store is unavailable', () => {
+		mockBlockEditorStoreThrows = true;
+		const blockSuggestions: Suggestion[] = [
+			{ id: 'check-grammar', label: 'Check grammar', prompt: 'Check the grammar' },
+		];
+		const useSuggestions = jest.fn( () => ( {
+			suggestions: blockSuggestions,
+			replaceEmptyViewSuggestions: true,
+		} ) );
+		mockUseAgentChat.mockReturnValue( agentChatReturn( { suggestions: blockSuggestions } ) );
+
+		render( chat( { useSuggestions } ) );
+
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_suggestions_rendered', {
+			suggestions: '|check-grammar|',
 		} );
 	} );
 

--- a/packages/agents-manager/src/components/chat-response-tracking.tsx
+++ b/packages/agents-manager/src/components/chat-response-tracking.tsx
@@ -5,6 +5,47 @@ interface ChatResponseRenderedTrackerProps {
 	componentType: string;
 	toolId: string;
 	toolCallId?: string;
+	responseTrackingProperties?: unknown;
+}
+
+const RESPONSE_COUNT_PROPERTIES = [
+	'suggested_edit_count',
+	'conflict_count',
+	'implication_count',
+	'guideline_violation_count',
+] as const;
+
+const REVIEW_CONTEXTS = new Set( [
+	'notes_and_guidelines',
+	'notes_only',
+	'guidelines_only',
+	'content_only',
+	'insufficient_input',
+] );
+
+/** Keeps only supported response properties with valid values. */
+function getResponseTrackingProperties( value: unknown ): Record< string, string | number > {
+	if ( typeof value !== 'object' || value === null ) {
+		return {};
+	}
+
+	const properties = value as Record< string, unknown >;
+	const safeProperties = RESPONSE_COUNT_PROPERTIES.reduce< Record< string, string | number > >(
+		( result, property ) => {
+			const count = properties[ property ];
+			if ( typeof count === 'number' && Number.isSafeInteger( count ) && count >= 0 ) {
+				result[ property ] = count;
+			}
+			return result;
+		},
+		{}
+	);
+	const reviewContext = properties.review_context;
+	if ( typeof reviewContext === 'string' && REVIEW_CONTEXTS.has( reviewContext ) ) {
+		safeProperties.review_context = reviewContext;
+	}
+
+	return safeProperties;
 }
 
 export interface ChatResponseAction {
@@ -47,6 +88,7 @@ export default function ChatResponseRenderedTracker( {
 	componentType,
 	toolId,
 	toolCallId,
+	responseTrackingProperties,
 }: ChatResponseRenderedTrackerProps ) {
 	const responseKey = JSON.stringify( [ toolId, toolCallId ?? null, componentType ] );
 	const lastTrackedResponseRef = useRef< string | null >( null );
@@ -60,8 +102,9 @@ export default function ChatResponseRenderedTracker( {
 			component_type: componentType,
 			tool_id: toolId,
 			...( toolCallId ? { tool_call_id: toolCallId } : {} ),
+			...getResponseTrackingProperties( responseTrackingProperties ),
 		} );
-	}, [ componentType, responseKey, toolCallId, toolId ] );
+	}, [ componentType, responseKey, responseTrackingProperties, toolCallId, toolId ] );
 
 	return null;
 }

--- a/packages/agents-manager/src/components/chat-response-tracking.tsx
+++ b/packages/agents-manager/src/components/chat-response-tracking.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef } from '@wordpress/element';
+import { recordBigSkyTracksEvent } from '../utils/tracks';
+
+interface ChatResponseRenderedTrackerProps {
+	componentType: string;
+	toolId: string;
+	toolCallId?: string;
+}
+
+export interface ChatResponseAction {
+	action: 'accept' | 'bulk_accept' | 'dismiss' | 'undo';
+	// Providers own their target vocabulary and should narrow it in their package.
+	target: string;
+	outcome: 'success' | 'failed' | 'partial_failed';
+	itemCount?: number;
+}
+
+interface ChatResponseIdentifiers {
+	componentType: string;
+	toolId: string;
+	toolCallId?: string;
+}
+
+/** Creates a host callback that records component-local response actions. */
+export function createChatResponseActionCallback( {
+	componentType,
+	toolId,
+	toolCallId,
+}: ChatResponseIdentifiers ) {
+	return ( { action, target, outcome, itemCount }: ChatResponseAction ) => {
+		recordBigSkyTracksEvent( 'chat_response_action', {
+			component_type: componentType,
+			tool_id: toolId,
+			...( toolCallId ? { tool_call_id: toolCallId } : {} ),
+			action,
+			target,
+			outcome,
+			...( itemCount !== undefined ? { item_count: itemCount } : {} ),
+		} );
+	};
+}
+
+/**
+ * Records a live component response after it reaches the rendered message tree.
+ */
+export default function ChatResponseRenderedTracker( {
+	componentType,
+	toolId,
+	toolCallId,
+}: ChatResponseRenderedTrackerProps ) {
+	const responseKey = JSON.stringify( [ toolId, toolCallId ?? null, componentType ] );
+	const lastTrackedResponseRef = useRef< string | null >( null );
+
+	useEffect( () => {
+		if ( lastTrackedResponseRef.current === responseKey ) {
+			return;
+		}
+		lastTrackedResponseRef.current = responseKey;
+		recordBigSkyTracksEvent( 'chat_response_rendered', {
+			component_type: componentType,
+			tool_id: toolId,
+			...( toolCallId ? { tool_call_id: toolCallId } : {} ),
+		} );
+	}, [ componentType, responseKey, toolCallId, toolId ] );
+
+	return null;
+}

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -995,24 +995,37 @@ export default function OrchestratorChat( {
 
 	// Track when a set of suggestions is rendered — the dynamic block-context
 	// suggestions or, on an empty chat, the empty-view starter chips. Mirrors
-	// Big Sky, which tracked the empty view too. Dedupe on the rendered ids so
-	// re-renders with the same set don't re-fire; a set that empties and returns
-	// to the same content isn't re-tracked.
+	// Big Sky, which tracked the empty view too. Dedupe on the rendered ids and
+	// block context so the same actions appearing for a different block type are
+	// tracked as a distinct exposure.
 	const displayedSuggestionIds = displayedEmptyViewSuggestions.map( ( s ) => s.id ).join( '|' );
-	const lastTrackedSuggestionsRef = useRef< string | null >( null );
+	const renderedSuggestionsBlockType =
+		selectedBlockType &&
+		displayedEmptyViewSuggestions.length > 0 &&
+		displayedEmptyViewSuggestions.every( ( suggestion ) =>
+			contextualSuggestionIds.has( suggestion.id )
+		)
+			? selectedBlockType
+			: undefined;
+	const renderedSuggestionsKey = JSON.stringify( [
+		displayedSuggestionIds,
+		renderedSuggestionsBlockType ?? null,
+	] );
+	const lastTrackedSuggestionsKeyRef = useRef< string | null >( null );
 	useEffect( () => {
 		if ( displayedEmptyViewSuggestions.length === 0 ) {
 			return;
 		}
-		if ( lastTrackedSuggestionsRef.current !== displayedSuggestionIds ) {
+		if ( lastTrackedSuggestionsKeyRef.current !== renderedSuggestionsKey ) {
 			recordBigSkyTracksEvent( 'chat_suggestions_rendered', {
 				suggestions: formatSuggestionIds( displayedEmptyViewSuggestions ),
+				...( renderedSuggestionsBlockType ? { block_type: renderedSuggestionsBlockType } : {} ),
 			} );
-			lastTrackedSuggestionsRef.current = displayedSuggestionIds;
+			lastTrackedSuggestionsKeyRef.current = renderedSuggestionsKey;
 		}
-		// `displayedEmptyViewSuggestions` identity is unstable; key on its ids.
+		// `displayedEmptyViewSuggestions` identity is unstable; key on its ids and block context.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ displayedSuggestionIds ] );
+	}, [ renderedSuggestionsKey ] );
 
 	return (
 		<AgentChat

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -1007,25 +1007,35 @@ export default function OrchestratorChat( {
 		)
 			? selectedBlockType
 			: undefined;
-	const renderedSuggestionsKey = JSON.stringify( [
-		displayedSuggestionIds,
-		renderedSuggestionsBlockType ?? null,
-	] );
-	const lastTrackedSuggestionsKeyRef = useRef< string | null >( null );
+	const lastTrackedSuggestionsRef = useRef< {
+		ids: string;
+		blockType?: string;
+	} | null >( null );
 	useEffect( () => {
 		if ( displayedEmptyViewSuggestions.length === 0 ) {
 			return;
 		}
-		if ( lastTrackedSuggestionsKeyRef.current !== renderedSuggestionsKey ) {
-			recordBigSkyTracksEvent( 'chat_suggestions_rendered', {
-				suggestions: formatSuggestionIds( displayedEmptyViewSuggestions ),
-				...( renderedSuggestionsBlockType ? { block_type: renderedSuggestionsBlockType } : {} ),
-			} );
-			lastTrackedSuggestionsKeyRef.current = renderedSuggestionsKey;
+		const previous = lastTrackedSuggestionsRef.current;
+		if (
+			previous?.ids === displayedSuggestionIds &&
+			( previous.blockType === renderedSuggestionsBlockType ||
+				// The suggestion store can retain contextual chips for one render after
+				// block deselection. Do not reclassify that exposure as post-level.
+				( previous.blockType && ! renderedSuggestionsBlockType ) )
+		) {
+			return;
 		}
+		recordBigSkyTracksEvent( 'chat_suggestions_rendered', {
+			suggestions: formatSuggestionIds( displayedEmptyViewSuggestions ),
+			...( renderedSuggestionsBlockType ? { block_type: renderedSuggestionsBlockType } : {} ),
+		} );
+		lastTrackedSuggestionsRef.current = {
+			ids: displayedSuggestionIds,
+			blockType: renderedSuggestionsBlockType,
+		};
 		// `displayedEmptyViewSuggestions` identity is unstable; key on its ids and block context.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ renderedSuggestionsKey ] );
+	}, [ displayedSuggestionIds, renderedSuggestionsBlockType ] );
 
 	return (
 		<AgentChat

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -410,9 +410,7 @@ export default function OrchestratorChat( {
 
 	// Use dynamic suggestions from the external provider (e.g., Big Sky block-based suggestions)
 	const maxDynamicSuggestions = isDocked ? undefined : 3;
-	const dynamicSuggestions = useSuggestions?.( maxDynamicSuggestions, {
-		suggestionsVisible,
-	} );
+	const dynamicSuggestions = useSuggestions?.( maxDynamicSuggestions );
 	const dynamicSuggestionsList = dynamicSuggestions?.suggestions ?? [];
 	const replaceEmptyViewSuggestions = dynamicSuggestions?.replaceEmptyViewSuggestions === true;
 	const dynamicSuggestionsKey = JSON.stringify(

--- a/packages/agents-manager/src/global.d.ts
+++ b/packages/agents-manager/src/global.d.ts
@@ -28,6 +28,8 @@ declare const agentsManagerData:
 			helpCenterUrl?: string;
 			/** Dev/internal context (localhost, jurassic, proxied a11ns, internal Atomic). Drives `is_test`. */
 			isDevMode?: boolean;
+			/** Whether the current request is attributed to an Automattician for tracking. */
+			isA11n?: boolean;
 			/** Whether the site is WordPress.com-hosted (Simple/WoA). */
 			isWpcomPlatform?: boolean;
 			/** The site's canonical identity; injected on wp-admin only. */

--- a/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
@@ -177,6 +177,7 @@ describe( 'convertToolMessagesToComponents', () => {
 						data: {
 							type: 'my-component',
 							props: { name: 'test' },
+							responseTrackingProperties: { suggested_edit_count: 2 },
 							summary: 'Choose one of these options.',
 							isCurrent: true,
 						},
@@ -213,6 +214,7 @@ describe( 'convertToolMessagesToComponents', () => {
 				componentType: 'my-component',
 				toolId: SHOW_COMPONENT_TOOL_ID,
 				toolCallId: 'tool-call-1',
+				responseTrackingProperties: { suggested_edit_count: 2 },
 			},
 		} );
 	} );

--- a/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
@@ -2,6 +2,12 @@ function mockEscalationButton() {
 	return null;
 }
 
+const mockResponseAction = jest.fn();
+
+function mockCreateChatResponseActionCallback() {
+	return mockResponseAction;
+}
+
 jest.mock(
 	'@automattic/agenttic-client',
 	() => ( {
@@ -26,10 +32,16 @@ jest.mock( '../../components/font-picker', () => ( {
 	__esModule: true,
 	default: jest.fn( () => null ),
 } ) );
+jest.mock( '../../components/chat-response-tracking', () => ( {
+	__esModule: true,
+	default: jest.fn( () => null ),
+	createChatResponseActionCallback: mockCreateChatResponseActionCallback,
+} ) );
 
 import { render, waitFor } from '@testing-library/react';
 import { createElement } from '@wordpress/element';
 import ButtonPicker from '../../components/button-picker';
+import ChatResponseRenderedTracker from '../../components/chat-response-tracking';
 import ColorPicker from '../../components/color-picker';
 import FontPicker from '../../components/font-picker';
 import convertToolMessagesToComponents from '../convert-tool-messages-to-components';
@@ -155,11 +167,22 @@ describe( 'convertToolMessagesToComponents', () => {
 	} );
 
 	it( 'renders tool messages as components', () => {
-		const message = createToolMessage( SHOW_COMPONENT_TOOL_ID, {
-			type: 'my-component',
-			props: { name: 'test' },
-			summary: 'Choose one of these options.',
-			isCurrent: true,
+		const message = createMessage( {
+			content: [
+				{
+					type: 'text',
+					text: JSON.stringify( {
+						tool_id: SHOW_COMPONENT_TOOL_ID,
+						tool_call_id: 'tool-call-1',
+						data: {
+							type: 'my-component',
+							props: { name: 'test' },
+							summary: 'Choose one of these options.',
+							isCurrent: true,
+						},
+					} ),
+				},
+			],
 		} );
 		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
 
@@ -180,6 +203,16 @@ describe( 'convertToolMessagesToComponents', () => {
 				name: 'test',
 				summary: 'Choose one of these options.',
 				contentType: 'my-component',
+				onResponseAction: mockResponseAction,
+			},
+		} );
+		expect( result[ 0 ].content[ 2 ] ).toMatchObject( {
+			type: 'component',
+			component: ChatResponseRenderedTracker,
+			componentProps: {
+				componentType: 'my-component',
+				toolId: SHOW_COMPONENT_TOOL_ID,
+				toolCallId: 'tool-call-1',
 			},
 		} );
 	} );
@@ -236,9 +269,12 @@ describe( 'convertToolMessagesToComponents', () => {
 			getChatComponent,
 		} );
 
-		expect( result[ 0 ].content ).toHaveLength( 1 );
+		expect( result[ 0 ].content ).toHaveLength( 2 );
 		expect( result[ 0 ].content[ 0 ] ).toMatchObject( { type: 'component' } );
 		expect( result[ 0 ].content[ 0 ].componentProps.summary ).toBeUndefined();
+		expect( result[ 0 ].content[ 1 ] ).toMatchObject( {
+			component: ChatResponseRenderedTracker,
+		} );
 	} );
 
 	it( 'does not suppress the thinking indicator for component messages with follow-up tasks', () => {
@@ -273,6 +309,7 @@ describe( 'convertToolMessagesToComponents', () => {
 		expect( result[ 0 ].content[ 0 ] ).toMatchObject( { component: MockComponent } );
 		// History rows carry no `isCurrent`, so the message renders inert.
 		expect( result[ 0 ].disabled ).toBe( true );
+		expect( result[ 0 ].content ).toHaveLength( 1 );
 	} );
 
 	it( 'renders the notice for prototype-member component types', () => {
@@ -853,12 +890,54 @@ describe( 'convertToolMessagesToComponents', () => {
 			expect( result[ 0 ].content[ 0 ] ).toMatchObject( { component: MockComponent } );
 			const componentProps = (
 				result[ 0 ].content[ 0 ] as {
-					componentProps?: { isMessageStale?: boolean };
+					componentProps?: {
+						isMessageStale?: boolean;
+						onResponseAction?: typeof mockResponseAction;
+					};
 				}
 			 ).componentProps;
 			expect( componentProps?.isMessageStale === true ).toBe( disabled );
+			expect( componentProps?.onResponseAction ).toBe( disabled ? undefined : mockResponseAction );
+			expect(
+				result[ 0 ].content.some(
+					( content ) =>
+						content.type === 'component' && content.component === ChatResponseRenderedTracker
+				)
+			).toBe( ! disabled );
 		}
 	);
+
+	it( 'replaces a provider-supplied action callback with the host callback', () => {
+		const message = createToolMessage( SHOW_COMPONENT_TOOL_ID, {
+			type: 'my-component',
+			props: { onResponseAction: 'untrusted-value' },
+			isCurrent: true,
+		} );
+		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
+
+		const result = convertToolMessagesToComponents( {
+			messages: [ message ],
+			getChatComponent,
+		} );
+
+		expect( result[ 0 ].content[ 0 ].componentProps.onResponseAction ).toBe( mockResponseAction );
+	} );
+
+	it( 'removes a provider-supplied action callback from stale responses', () => {
+		const message = createToolMessage( SHOW_COMPONENT_TOOL_ID, {
+			type: 'my-component',
+			props: { onResponseAction: 'untrusted-value' },
+			isCurrent: false,
+		} );
+		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
+
+		const result = convertToolMessagesToComponents( {
+			messages: [ message ],
+			getChatComponent,
+		} );
+
+		expect( result[ 0 ].content[ 0 ].componentProps.onResponseAction ).toBeUndefined();
+	} );
 
 	describe( 'AM-owned components', () => {
 		// The AM components are lazy wrappers, so the assertion renders the

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -860,16 +860,15 @@ describe( 'mergeUseSuggestionsHooks', () => {
 		} );
 	} );
 
-	it( 'forwards suggestion visibility options to provider hooks', () => {
+	it( 'forwards the suggestion limit to provider hooks', () => {
 		const firstHook = jest.fn( () => ( { suggestions: [] } ) ) as UseSuggestionsHook;
 		const secondHook = jest.fn( () => ( { suggestions: [] } ) ) as UseSuggestionsHook;
 		const merged = mergeUseSuggestionsHooks( [ firstHook, secondHook ] );
-		const options = { suggestionsVisible: false };
 
-		merged?.( undefined, options );
+		merged?.( 3 );
 
-		expect( firstHook ).toHaveBeenCalledWith( undefined, options );
-		expect( secondHook ).toHaveBeenCalledWith( undefined, options );
+		expect( firstHook ).toHaveBeenCalledWith( 3 );
+		expect( secondHook ).toHaveBeenCalledWith( 3 );
 	} );
 
 	it( 'uses only contextual suggestions when any provider replaces the empty view', () => {

--- a/packages/agents-manager/src/utils/__tests__/tracks.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/tracks.test.ts
@@ -107,6 +107,28 @@ describe( 'tracks wrappers', () => {
 			recordBigSkyTracksEvent( 'chat_input_send_message' );
 			expect( mockRecordTracksEvent ).toHaveBeenCalledTimes( 1 );
 		} );
+
+		it( 'adds the canonical server-provided blog ID', () => {
+			( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {
+				isDevMode: false,
+				site: { ID: 12345 },
+			};
+
+			recordBigSkyTracksEvent( 'chat_input_send_message' );
+
+			expect( lastEventProps().blog_id ).toBe( 12345 );
+		} );
+
+		it( 'omits blog_id when the server payload has no valid site ID', () => {
+			( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {
+				isDevMode: false,
+				site: { ID: 0 },
+			};
+
+			recordBigSkyTracksEvent( 'chat_input_send_message' );
+
+			expect( lastEventProps() ).not.toHaveProperty( 'blog_id' );
+		} );
 	} );
 
 	describe( 'recordAgentsManagerTracksEvent', () => {

--- a/packages/agents-manager/src/utils/__tests__/tracks.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/tracks.test.ts
@@ -123,8 +123,7 @@ describe( 'tracks wrappers', () => {
 				surface: 'editor',
 				is_test: true,
 			} );
-			// `is_a11n` is an unresolved seam — present but undefined for now.
-			expect( props ).toHaveProperty( 'is_a11n', undefined );
+			expect( props ).not.toHaveProperty( 'is_a11n' );
 		} );
 
 		it( 'uses the reader-chat surface token off the editor', () => {
@@ -138,6 +137,54 @@ describe( 'tracks wrappers', () => {
 			recordAgentsManagerTracksEvent( 'chat_minimize' );
 			expect( mockRecordTracksEvent ).toHaveBeenCalledTimes( 1 );
 		} );
+	} );
+
+	describe( 'is_a11n', () => {
+		const recorders = [
+			[ 'Big Sky', recordBigSkyTracksEvent ],
+			[ 'Agents Manager', recordAgentsManagerTracksEvent ],
+		] as const;
+
+		it.each( recorders )(
+			'%s recorder injects true when the server identifies Automattician traffic',
+			( _name, recordEvent ) => {
+				( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {
+					isDevMode: true,
+					isA11n: true,
+				};
+
+				recordEvent( 'x' );
+
+				expect( lastEventProps().is_a11n ).toBe( true );
+			}
+		);
+
+		it.each( recorders )(
+			'%s recorder injects false when the server identifies non-Automattician traffic',
+			( _name, recordEvent ) => {
+				( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {
+					isDevMode: false,
+					isA11n: false,
+				};
+
+				recordEvent( 'x' );
+
+				expect( lastEventProps().is_a11n ).toBe( false );
+			}
+		);
+
+		it.each( recorders )(
+			'%s recorder omits the property when the server payload has no identity signal',
+			( _name, recordEvent ) => {
+				( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {
+					isDevMode: false,
+				};
+
+				recordEvent( 'x' );
+
+				expect( lastEventProps() ).not.toHaveProperty( 'is_a11n' );
+			}
+		);
 	} );
 
 	describe( 'is_test (getIsTest)', () => {

--- a/packages/agents-manager/src/utils/__tests__/tracks.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/tracks.test.ts
@@ -154,6 +154,28 @@ describe( 'tracks wrappers', () => {
 			expect( lastEventProps().surface ).toBe( 'reader-chat' );
 		} );
 
+		it( 'adds the canonical server-provided blog ID when available', () => {
+			( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {
+				isDevMode: false,
+				site: { ID: 12345 },
+			};
+
+			recordAgentsManagerTracksEvent( 'chat_minimize' );
+
+			expect( lastEventProps().blog_id ).toBe( 12345 );
+		} );
+
+		it( 'omits blog_id when the server payload has no valid site ID', () => {
+			( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {
+				isDevMode: false,
+				site: { ID: 0 },
+			};
+
+			recordAgentsManagerTracksEvent( 'chat_minimize' );
+
+			expect( lastEventProps() ).not.toHaveProperty( 'blog_id' );
+		} );
+
 		it( 'fires even when the resolved agent id is a reader-chat agent', () => {
 			setResolvedAgentId( 'reader-chat' );
 			recordAgentsManagerTracksEvent( 'chat_minimize' );

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -280,7 +280,15 @@ export default function convertToolMessagesToComponents( {
 		// Handle `show-component` tool message
 		if ( isShowComponentTool( textData.tool_id ) ) {
 			const toolData = textData.data ?? {};
-			const { type: contentType, props, followUpTasks, isCurrent, postId, summary } = toolData;
+			const {
+				type: contentType,
+				props,
+				followUpTasks,
+				isCurrent,
+				postId,
+				summary,
+				responseTrackingProperties,
+			} = toolData;
 			const toolCallId =
 				typeof textData.tool_call_id === 'string' && textData.tool_call_id
 					? textData.tool_call_id
@@ -375,6 +383,7 @@ export default function convertToolMessagesToComponents( {
 										componentType: contentType,
 										toolId: textData.tool_id,
 										...( toolCallId ? { toolCallId } : {} ),
+										...( responseTrackingProperties ? { responseTrackingProperties } : {} ),
 									},
 								},
 						  ]

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -1,4 +1,7 @@
 import { __ } from '@wordpress/i18n';
+import ChatResponseRenderedTracker, {
+	createChatResponseActionCallback,
+} from '../components/chat-response-tracking';
 import { EscalationButton } from '../components/escalation-button';
 import isAmAbilitiesDisabled from './is-am-abilities-disabled';
 import lazyComponent from './lazy-component';
@@ -278,6 +281,10 @@ export default function convertToolMessagesToComponents( {
 		if ( isShowComponentTool( textData.tool_id ) ) {
 			const toolData = textData.data ?? {};
 			const { type: contentType, props, followUpTasks, isCurrent, postId, summary } = toolData;
+			const toolCallId =
+				typeof textData.tool_call_id === 'string' && textData.tool_call_id
+					? textData.tool_call_id
+					: undefined;
 			// The testing switch flips rendering to the provider components too,
 			// so the comparison covers the whole flow.
 			const amComponent = isAmAbilitiesDisabled() ? null : getAmComponent( contentType );
@@ -323,6 +330,19 @@ export default function convertToolMessagesToComponents( {
 			const isPageChanged =
 				!! postId && !! currentPostId && String( postId ) !== String( currentPostId );
 			const isStale = hasUserReplied || ! isCurrent || isPageChanged;
+			const shouldTrackResponse = ! isStale;
+			let responseActionProps = {};
+			if ( ! amComponent ) {
+				responseActionProps = {
+					onResponseAction: shouldTrackResponse
+						? createChatResponseActionCallback( {
+								componentType: contentType,
+								toolId: textData.tool_id,
+								...( toolCallId ? { toolCallId } : {} ),
+						  } )
+						: undefined,
+				};
+			}
 
 			const componentMessage: AgentsManagerUIMessage = {
 				...message,
@@ -342,9 +362,23 @@ export default function convertToolMessagesToComponents( {
 							...props,
 							...( summaryText && { summary: summaryText } ),
 							...ownerProps,
+							...responseActionProps,
 							...( isStale && { isMessageStale: true } ),
 						},
 					},
+					...( shouldTrackResponse
+						? [
+								{
+									type: 'component' as const,
+									component: ChatResponseRenderedTracker as React.ComponentType,
+									componentProps: {
+										componentType: contentType,
+										toolId: textData.tool_id,
+										...( toolCallId ? { toolCallId } : {} ),
+									},
+								},
+						  ]
+						: [] ),
 				],
 				disabled: isStale,
 				suppressThinking: followUpTasks !== true,

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -72,10 +72,7 @@ export type AbilitiesSetupHook = ( actions: {
  * Suggestions hook type - for providing dynamic suggestions based on context
  * (e.g., selected block in editor). Returns an array of suggestions.
  */
-export type UseSuggestionsHook = (
-	maxSuggestions?: number,
-	options?: { suggestionsVisible?: boolean }
-) => {
+export type UseSuggestionsHook = ( maxSuggestions?: number ) => {
 	suggestions: Suggestion[];
 	/** Whether contextual suggestions replace, rather than extend, the empty-view suggestions. */
 	replaceEmptyViewSuggestions?: boolean;
@@ -211,10 +208,10 @@ export function mergeUseSuggestionsHooks(
 		return hooks[ 0 ];
 	}
 
-	return ( maxSuggestions?: number, options?: { suggestionsVisible?: boolean } ) => {
+	return ( maxSuggestions?: number ) => {
 		const combined: Suggestion[] = [];
 		const seenIds = new Set< string >();
-		const results = hooks.map( ( hook ) => hook( maxSuggestions, options ) );
+		const results = hooks.map( ( hook ) => hook( maxSuggestions ) );
 		const replaceEmptyViewSuggestions = results.some(
 			( result ) => result?.replaceEmptyViewSuggestions === true
 		);

--- a/packages/agents-manager/src/utils/tracks.ts
+++ b/packages/agents-manager/src/utils/tracks.ts
@@ -37,6 +37,14 @@ function getIsA11n(): boolean | undefined {
 	return typeof isA11n === 'boolean' ? isA11n : undefined;
 }
 
+/** Reads the canonical server-provided blog ID when available. */
+function getBlogId(): number | undefined {
+	const blogId = getAgentsManagerInlineData()?.site?.ID;
+	return typeof blogId === 'number' && Number.isInteger( blogId ) && blogId > 0
+		? blogId
+		: undefined;
+}
+
 type BigSkyTracksData = {
 	bigSkyVersion: string;
 	sessionType: string;
@@ -99,9 +107,11 @@ export function recordBigSkyTracksEvent( eventName: string, props: TracksProps =
 
 	const bigSky = getBigSkyTracksData();
 	const isA11n = getIsA11n();
+	const blogId = getBlogId();
 	const baseProps: TracksProps = {
 		is_test: getIsTest(),
 		...( isA11n !== undefined ? { is_a11n: isA11n } : {} ),
+		...( blogId !== undefined ? { blog_id: blogId } : {} ),
 		sessionid: getSessionId(),
 		session_type: bigSky.sessionType,
 		// AM has no onboarding flow, so the phase is always the editor.

--- a/packages/agents-manager/src/utils/tracks.ts
+++ b/packages/agents-manager/src/utils/tracks.ts
@@ -129,6 +129,7 @@ export function recordBigSkyTracksEvent( eventName: string, props: TracksProps =
  */
 export function recordAgentsManagerTracksEvent( eventName: string, props: TracksProps = {} ): void {
 	const isA11n = getIsA11n();
+	const blogId = getBlogId();
 	const baseProps: TracksProps = {
 		ai_session_id: getSessionId(),
 		agent_name: DOLLY_AGENT_ID,
@@ -136,6 +137,7 @@ export function recordAgentsManagerTracksEvent( eventName: string, props: Tracks
 		path: typeof window !== 'undefined' ? window.location.pathname : '',
 		is_test: getIsTest(),
 		...( isA11n !== undefined ? { is_a11n: isA11n } : {} ),
+		...( blogId !== undefined ? { blog_id: blogId } : {} ),
 	};
 
 	recordTracksEvent( `${ AM_UNIFIED_EVENT_PREFIX }${ eventName }`, { ...baseProps, ...props } );

--- a/packages/agents-manager/src/utils/tracks.ts
+++ b/packages/agents-manager/src/utils/tracks.ts
@@ -11,6 +11,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { select } from '@wordpress/data';
 import { DOLLY_AGENT_ID } from '../constants';
 import { getSessionId } from './agent-session';
+import { getAgentsManagerInlineData } from './get-agents-manager-inline-data';
 import { isReaderChatAgent, isReaderChatHost } from './is-reader-chat-agent';
 import { getResolvedAgentId } from './resolved-agent-id';
 
@@ -30,9 +31,10 @@ type CoreSelectStore =
 const BIG_SKY_EVENT_PREFIX = 'jetpack_big_sky_';
 const AM_UNIFIED_EVENT_PREFIX = 'calypso_agents_manager_';
 
-// FIXME: Agents Manager has no per-user a11n signal today
+/** Reads the optional server-provided Automattician tracking signal. */
 function getIsA11n(): boolean | undefined {
-	return undefined;
+	const isA11n = getAgentsManagerInlineData()?.isA11n;
+	return typeof isA11n === 'boolean' ? isA11n : undefined;
 }
 
 type BigSkyTracksData = {
@@ -96,8 +98,10 @@ export function recordBigSkyTracksEvent( eventName: string, props: TracksProps =
 	}
 
 	const bigSky = getBigSkyTracksData();
+	const isA11n = getIsA11n();
 	const baseProps: TracksProps = {
 		is_test: getIsTest(),
+		...( isA11n !== undefined ? { is_a11n: isA11n } : {} ),
 		sessionid: getSessionId(),
 		session_type: bigSky.sessionType,
 		// AM has no onboarding flow, so the phase is always the editor.
@@ -114,13 +118,14 @@ export function recordBigSkyTracksEvent( eventName: string, props: TracksProps =
  * Records an Agents Manager event using the shared unified property names.
  */
 export function recordAgentsManagerTracksEvent( eventName: string, props: TracksProps = {} ): void {
+	const isA11n = getIsA11n();
 	const baseProps: TracksProps = {
 		ai_session_id: getSessionId(),
 		agent_name: DOLLY_AGENT_ID,
 		surface: isReaderChatHost() ? 'reader-chat' : 'editor',
 		path: typeof window !== 'undefined' ? window.location.pathname : '',
 		is_test: getIsTest(),
-		is_a11n: getIsA11n(),
+		...( isA11n !== undefined ? { is_a11n: isA11n } : {} ),
 	};
 
 	recordTracksEvent( `${ AM_UNIFIED_EVENT_PREFIX }${ eventName }`, { ...baseProps, ...props } );

--- a/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.test.tsx
@@ -319,60 +319,6 @@ describe( 'AiEditorialReview — smoke render', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'tracks the rendered result with aggregate counts', async () => {
-		render(
-			<AiEditorialReview
-				{ ...basePayload( {
-					review_context: 'notes_and_guidelines',
-					conflicts: [
-						{
-							subject: 'Procedural framing',
-							positions: [],
-							guideline_anchor: null,
-							recommended_resolution: '',
-						},
-					],
-					implications: [
-						{ change: 'Tone shift', implies: 'Update related FAQ.', affected_blocks: [ 1 ] },
-					],
-					suggested_edits: [
-						{
-							block_index: 1,
-							current_text: 'voted last Tuesday',
-							suggested_text: 'voted on Tuesday',
-							rationale: 'Concise.',
-							supported_by_reviewers: [],
-						},
-					],
-					guideline_violations: [
-						{
-							category: 'copy',
-							block_name: null,
-							guideline_quote: 'Avoid passive voice.',
-							block_index: 1,
-							violating_text: 'was voted upon',
-							issue: 'Passive voice detected.',
-						},
-					],
-				} ) }
-			/>
-		);
-
-		await waitFor( () => {
-			expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
-				'jetpack_ai_editorial_review_result_rendered',
-				{
-					outcome: 'success',
-					conflict_count: 1,
-					implication_count: 1,
-					suggested_edit_count: 1,
-					guideline_violation_count: 1,
-					review_context: 'notes_and_guidelines',
-				}
-			);
-		} );
-	} );
-
 	it( 'marks a review for another post as stale and non-actionable', () => {
 		// Review was generated for post 2 (postId prop); editor is currently on post 1 (mockCurrentPostId).
 		render(
@@ -791,8 +737,9 @@ describe( 'AiEditorialReview — suggested-edit accept flow', () => {
 
 	it( 'applies the edit and collapses the card on Accept', async () => {
 		mockApplyReviewEdit.mockResolvedValueOnce( { success: true } );
+		const onResponseAction = jest.fn();
 
-		render( <AiEditorialReview { ...editsPayload } /> );
+		render( <AiEditorialReview { ...editsPayload } onResponseAction={ onResponseAction } /> );
 
 		// Pre-accept: full card visible with rationale.
 		expect( screen.getByText( 'Concise.' ) ).toBeInTheDocument();
@@ -813,18 +760,14 @@ describe( 'AiEditorialReview — suggested-edit accept flow', () => {
 		await waitFor( () => {
 			expect( screen.getByText( 'Applied' ) ).toBeInTheDocument();
 		} );
-		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
-			'jetpack_ai_editorial_review_item_action',
-			{
-				action: 'accept',
-				target: 'edit',
-				outcome: 'success',
-			}
-		);
-
 		// Collapsed: rationale gone, Undo present.
 		expect( screen.queryByText( 'Concise.' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'Undo' ) ).toBeInTheDocument();
+		expect( onResponseAction ).toHaveBeenCalledWith( {
+			action: 'accept',
+			target: 'edit',
+			outcome: 'success',
+		} );
 	} );
 
 	it( 'falls to Go to section, not a stuck Applying, if the review goes stale mid-apply', async () => {
@@ -892,7 +835,11 @@ describe( 'AiEditorialReview — suggested-edit accept flow', () => {
 	} );
 
 	it( 'restores the full card from the collapsed row on Undo', async () => {
-		mockApplyReviewEdit.mockResolvedValueOnce( { success: true } );
+		mockApplyReviewEdit.mockResolvedValueOnce( {
+			success: true,
+			contentBefore: 'The council voted last Tuesday on the procedural matter.',
+			contentAfter: 'The council voted on Tuesday on the procedural matter.',
+		} );
 
 		render( <AiEditorialReview { ...editsPayload } /> );
 
@@ -945,8 +892,9 @@ describe( 'AiEditorialReview — suggested-edit accept flow', () => {
 			contentAfter: 'The council voted on Tuesday on the procedural matter.',
 		} );
 		mockUndoBlockEdit.mockReturnValueOnce( false ).mockReturnValueOnce( true );
+		const onResponseAction = jest.fn();
 
-		render( <AiEditorialReview { ...editsPayload } /> );
+		render( <AiEditorialReview { ...editsPayload } onResponseAction={ onResponseAction } /> );
 
 		await act( async () => {
 			fireEvent.click( screen.getByRole( 'button', { name: 'Apply change' } ) );
@@ -962,18 +910,29 @@ describe( 'AiEditorialReview — suggested-edit accept flow', () => {
 		expect( screen.getByText( 'Applied' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Concise.' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'Undo' ) ).toBeInTheDocument();
+		expect( onResponseAction ).toHaveBeenLastCalledWith( {
+			action: 'undo',
+			target: 'edit',
+			outcome: 'failed',
+		} );
 
 		fireEvent.click( screen.getByText( 'Undo' ) );
 
 		expect( mockUndoBlockEdit ).toHaveBeenCalledTimes( 2 );
 		expect( screen.getByText( 'Concise.' ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Apply change' } ) ).toBeInTheDocument();
+		expect( onResponseAction ).toHaveBeenLastCalledWith( {
+			action: 'undo',
+			target: 'edit',
+			outcome: 'success',
+		} );
 	} );
 
 	it( 'marks the row failed (and not collapsed) when applyReviewEdit rejects', async () => {
 		mockApplyReviewEdit.mockResolvedValueOnce( { success: false } );
+		const onResponseAction = jest.fn();
 
-		render( <AiEditorialReview { ...editsPayload } /> );
+		render( <AiEditorialReview { ...editsPayload } onResponseAction={ onResponseAction } /> );
 
 		await act( async () => {
 			fireEvent.click( screen.getByRole( 'button', { name: 'Apply change' } ) );
@@ -988,6 +947,11 @@ describe( 'AiEditorialReview — suggested-edit accept flow', () => {
 			screen.getByText( 'Could not apply automatically. The original text may have changed.' )
 		).toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: 'Undo' } ) ).not.toBeInTheDocument();
+		expect( onResponseAction ).toHaveBeenCalledWith( {
+			action: 'accept',
+			target: 'edit',
+			outcome: 'failed',
+		} );
 	} );
 
 	it( 'offers Go to section instead of Apply when the block has no editable text target', () => {
@@ -1246,7 +1210,8 @@ describe( 'AiEditorialReview — guideline violations', () => {
 	} );
 
 	it( 'collapses to a Dismissed row on Dismiss and restores the card on Undo', () => {
-		render( <AiEditorialReview { ...violationsPayload } /> );
+		const onResponseAction = jest.fn();
+		render( <AiEditorialReview { ...violationsPayload } onResponseAction={ onResponseAction } /> );
 
 		fireEvent.click( screen.getByRole( 'button', { name: 'Dismiss' } ) );
 
@@ -1255,12 +1220,22 @@ describe( 'AiEditorialReview — guideline violations', () => {
 		expect( screen.getByText( 'Dismissed' ) ).toBeInTheDocument();
 		expect( mockApplyReviewEdit ).not.toHaveBeenCalled();
 		expect( mockUndoBlockEdit ).not.toHaveBeenCalled();
+		expect( onResponseAction ).toHaveBeenLastCalledWith( {
+			action: 'dismiss',
+			target: 'guideline_violation',
+			outcome: 'success',
+		} );
 
 		fireEvent.click( screen.getByRole( 'button', { name: 'Undo' } ) );
 
 		// Back to the active advisory card.
 		expect( screen.getByText( 'Passive voice detected.' ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Go to section' } ) ).toBeInTheDocument();
+		expect( onResponseAction ).toHaveBeenLastCalledWith( {
+			action: 'undo',
+			target: 'guideline_violation',
+			outcome: 'success',
+		} );
 	} );
 
 	it( 'disables Go to section when the referenced block is gone and omits the excerpt row', () => {
@@ -1448,7 +1423,11 @@ describe( 'AiEditorialReview — conflict resolutions', () => {
 	} );
 
 	it( 'resolves in place on apply — keeps the header, shows Applied + Undo, and Undo restores the options', async () => {
-		mockApplyReviewEdit.mockResolvedValueOnce( { success: true } );
+		mockApplyReviewEdit.mockResolvedValueOnce( {
+			success: true,
+			contentBefore: 'The council voted last Tuesday on the procedural matter.',
+			contentAfter: 'The council voted on Tuesday on the procedural matter.',
+		} );
 
 		render( <AiEditorialReview { ...conflictPayload } /> );
 
@@ -1675,6 +1654,7 @@ describe( 'AiEditorialReview — conflict resolutions', () => {
 describe( 'AiEditorialReview — bulk Apply all', () => {
 	it( 'applies only supported pending edits sequentially', async () => {
 		mockApplyReviewEdit.mockResolvedValue( { success: true } );
+		const onResponseAction = jest.fn();
 		mockBlocks = [
 			...blocks,
 			{ clientId: 'b3', name: 'core/list', attributes: { content: 'List content' } },
@@ -1736,6 +1716,7 @@ describe( 'AiEditorialReview — bulk Apply all', () => {
 						},
 					],
 				} ) }
+				onResponseAction={ onResponseAction }
 			/>
 		);
 
@@ -1770,6 +1751,13 @@ describe( 'AiEditorialReview — bulk Apply all', () => {
 		// Footer disappears once everything is accepted (totalPendingCount === 0).
 		await waitFor( () => {
 			expect( screen.queryByText( /Apply all/ ) ).not.toBeInTheDocument();
+		} );
+		expect( onResponseAction ).toHaveBeenCalledTimes( 1 );
+		expect( onResponseAction ).toHaveBeenCalledWith( {
+			action: 'bulk_accept',
+			target: 'mixed',
+			outcome: 'success',
+			itemCount: 2,
 		} );
 	} );
 

--- a/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.tsx
@@ -31,13 +31,13 @@ import {
 	type BlockEditorStore,
 	type EditorStore,
 } from '../utils/blocks';
-import { getBulkResponseActionOutcome } from '../utils/response-action';
+import { getBulkResponseActionOutcome, type OnResponseAction } from '../utils/response-action';
 import { useCopyToClipboard } from '../utils/use-copy-to-clipboard';
+import useLatestResponseAction from '../utils/use-latest-response-action';
 import BlockRef, { getBlockTypeName, type BlockSnapshot } from './block-ref';
 import ReviewCard, { ReviewCardActions, type ReviewCardRow } from './review-card';
 import ReviewerChip, { type ReviewerMetadata } from './reviewer-chip';
 import SplitScreenGuide from './split-screen-guide';
-import type { OnResponseAction, ResponseAction } from '../utils/response-action';
 
 /**
  * Types mirroring the wpcom `AI_Editorial_Review_Ability` structured output.
@@ -457,10 +457,7 @@ export default function AiEditorialReview( {
 		[ getClientId, isPostStale ]
 	);
 	const focusCurrentPostBlock = isPostStale ? undefined : focusBlock;
-	const fireResponseAction = useCallback(
-		( action: ResponseAction ) => onResponseAction?.( action ),
-		[ onResponseAction ]
-	);
+	const fireResponseAction = useLatestResponseAction( onResponseAction, isLatestPostContextStale );
 
 	const handleRootMouseDown = useCallback( ( event: { target: EventTarget | null } ) => {
 		clearActiveBlockFocusUnlessBlockReferenceClick( event.target );

--- a/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.tsx
@@ -97,12 +97,6 @@ interface GuidelineViolation {
 }
 
 type EditorPostId = number | string;
-type ReviewContext =
-	| 'notes_and_guidelines'
-	| 'notes_only'
-	| 'guidelines_only'
-	| 'content_only'
-	| 'insufficient_input';
 
 interface AiEditorialReviewProps {
 	summary: string;
@@ -115,7 +109,6 @@ interface AiEditorialReviewProps {
 	implications?: Implication[] | null;
 	suggested_edits?: SuggestedEdit[] | null;
 	guideline_violations?: GuidelineViolation[] | null;
-	review_context?: ReviewContext;
 	/** Source post the review was generated for. Used to detect navigation to a different post. */
 	postId?: EditorPostId;
 	/** Whether the containing chat message is no longer interactive. */

--- a/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.tsx
@@ -31,16 +31,13 @@ import {
 	type BlockEditorStore,
 	type EditorStore,
 } from '../utils/blocks';
-import {
-	trackAiEditorialReviewItemAction,
-	trackAiEditorialReviewResultRendered,
-	type ReviewContext,
-} from '../utils/tracking';
+import { getBulkResponseActionOutcome } from '../utils/response-action';
 import { useCopyToClipboard } from '../utils/use-copy-to-clipboard';
 import BlockRef, { getBlockTypeName, type BlockSnapshot } from './block-ref';
 import ReviewCard, { ReviewCardActions, type ReviewCardRow } from './review-card';
 import ReviewerChip, { type ReviewerMetadata } from './reviewer-chip';
 import SplitScreenGuide from './split-screen-guide';
+import type { OnResponseAction, ResponseAction } from '../utils/response-action';
 
 /**
  * Types mirroring the wpcom `AI_Editorial_Review_Ability` structured output.
@@ -100,6 +97,12 @@ interface GuidelineViolation {
 }
 
 type EditorPostId = number | string;
+type ReviewContext =
+	| 'notes_and_guidelines'
+	| 'notes_only'
+	| 'guidelines_only'
+	| 'content_only'
+	| 'insufficient_input';
 
 interface AiEditorialReviewProps {
 	summary: string;
@@ -117,6 +120,8 @@ interface AiEditorialReviewProps {
 	postId?: EditorPostId;
 	/** Whether the containing chat message is no longer interactive. */
 	isMessageStale?: boolean;
+	/** Reports completed user actions to the host that rendered this response. */
+	onResponseAction?: OnResponseAction;
 	/**
 	 * Server-built map keyed by reviewer display name. Optional — older
 	 * reviews or the empty-state payload may omit it; consumers degrade
@@ -281,23 +286,6 @@ function isManualSuggestedEdit( edit: SuggestedEdit ): boolean {
 	return edit.requires_manual === true;
 }
 
-function deriveResultOutcome(
-	isCacheHit: boolean,
-	reviewContext: ReviewContext | undefined,
-	hasNoFindings: boolean
-): 'success' | 'cache_hit' | 'no_findings' | 'insufficient_input' {
-	if ( isCacheHit ) {
-		return 'cache_hit';
-	}
-	if ( reviewContext === 'insufficient_input' ) {
-		return 'insufficient_input';
-	}
-	if ( hasNoFindings ) {
-		return 'no_findings';
-	}
-	return 'success';
-}
-
 function getConflictApplyUnavailableReason(
 	reasons: Array< string | undefined >
 ): string | undefined {
@@ -311,20 +299,16 @@ function getConflictApplyUnavailableReason(
 	return __( 'Some resolutions need manual edit.', __i18n_text_domain__ );
 }
 
-/**
- * Main component.
- * @param {AiEditorialReviewProps} props - Structured review output.
- * @returns {import('react').ReactElement} The rendered component.
- */
+/** Renders an editorial review and applies supported review actions. */
 export default function AiEditorialReview( {
 	summary,
 	conflicts: conflictsProp,
 	implications: implicationsProp,
 	suggested_edits: suggestedEditsProp,
 	guideline_violations: guidelineViolationsProp,
-	review_context,
 	postId,
 	isMessageStale = false,
+	onResponseAction,
 	reviewers_metadata,
 	cached_at,
 }: AiEditorialReviewProps ) {
@@ -473,17 +457,9 @@ export default function AiEditorialReview( {
 		[ getClientId, isPostStale ]
 	);
 	const focusCurrentPostBlock = isPostStale ? undefined : focusBlock;
-
-	const fireItemAction = useCallback(
-		( options: {
-			action: 'accept' | 'undo' | 'dismiss' | 'bulk_accept';
-			target: 'edit' | 'conflict' | 'mixed';
-			outcome: 'success' | 'failed' | 'partial_failed';
-			itemCount?: number;
-		} ) => {
-			trackAiEditorialReviewItemAction( options );
-		},
-		[]
+	const fireResponseAction = useCallback(
+		( action: ResponseAction ) => onResponseAction?.( action ),
+		[ onResponseAction ]
 	);
 
 	const handleRootMouseDown = useCallback( ( event: { target: EventTarget | null } ) => {
@@ -575,7 +551,7 @@ export default function AiEditorialReview( {
 			}
 			if ( edit.block_index === null ) {
 				setEditStatus( editIndex, 'failed' );
-				fireItemAction( {
+				fireResponseAction( {
 					action: 'accept',
 					target: 'edit',
 					outcome: 'failed',
@@ -602,14 +578,14 @@ export default function AiEditorialReview( {
 					editableAttribute: result.editableAttribute,
 				};
 			}
-			fireItemAction( {
+			setEditStatus( editIndex, result.success ? 'accepted' : 'failed' );
+			fireResponseAction( {
 				action: 'accept',
 				target: 'edit',
 				outcome: result.success ? 'success' : 'failed',
 			} );
-			setEditStatus( editIndex, result.success ? 'accepted' : 'failed' );
 		},
-		[ applyTextToBlock, fireItemAction, isPostStale, setEditStatus ]
+		[ applyTextToBlock, fireResponseAction, isPostStale, setEditStatus ]
 	);
 	const handleUndoEdit = useCallback(
 		( editIndex: number ) => {
@@ -617,6 +593,10 @@ export default function AiEditorialReview( {
 				return;
 			}
 			const snap = editSnapshots.current[ editIndex ];
+			if ( editStatuses[ editIndex ] === 'accepted' && ! snap ) {
+				fireResponseAction( { action: 'undo', target: 'edit', outcome: 'failed' } );
+				return;
+			}
 			if ( snap ) {
 				if (
 					! undoBlockEdit(
@@ -626,37 +606,25 @@ export default function AiEditorialReview( {
 						snap.editableAttribute
 					)
 				) {
-					fireItemAction( {
-						action: 'undo',
-						target: 'edit',
-						outcome: 'failed',
-					} );
+					fireResponseAction( { action: 'undo', target: 'edit', outcome: 'failed' } );
 					return;
 				}
 				delete editSnapshots.current[ editIndex ];
 			}
-			fireItemAction( {
-				action: 'undo',
-				target: 'edit',
-				outcome: 'success',
-			} );
 			setEditStatus( editIndex, 'pending' );
+			fireResponseAction( { action: 'undo', target: 'edit', outcome: 'success' } );
 		},
-		[ fireItemAction, isPostStale, setEditStatus ]
+		[ editStatuses, fireResponseAction, isPostStale, setEditStatus ]
 	);
 	const handleDismissEdit = useCallback(
 		( editIndex: number ) => {
 			if ( isPostStale ) {
 				return;
 			}
-			fireItemAction( {
-				action: 'dismiss',
-				target: 'edit',
-				outcome: 'success',
-			} );
 			setEditStatus( editIndex, 'dismissed' );
+			fireResponseAction( { action: 'dismiss', target: 'edit', outcome: 'success' } );
 		},
-		[ fireItemAction, isPostStale, setEditStatus ]
+		[ fireResponseAction, isPostStale, setEditStatus ]
 	);
 
 	const handleDismissViolation = useCallback(
@@ -665,12 +633,28 @@ export default function AiEditorialReview( {
 				return;
 			}
 			setViolationStatuses( ( prev ) => ( { ...prev, [ index ]: 'dismissed' } ) );
+			fireResponseAction( {
+				action: 'dismiss',
+				target: 'guideline_violation',
+				outcome: 'success',
+			} );
 		},
-		[ isPostStale ]
+		[ fireResponseAction, isPostStale ]
 	);
-	const handleUndoViolation = useCallback( ( index: number ) => {
-		setViolationStatuses( ( prev ) => ( { ...prev, [ index ]: 'pending' } ) );
-	}, [] );
+	const handleUndoViolation = useCallback(
+		( index: number ) => {
+			if ( isPostStale ) {
+				return;
+			}
+			setViolationStatuses( ( prev ) => ( { ...prev, [ index ]: 'pending' } ) );
+			fireResponseAction( {
+				action: 'undo',
+				target: 'guideline_violation',
+				outcome: 'success',
+			} );
+		},
+		[ fireResponseAction, isPostStale ]
+	);
 
 	// ---------- Conflict handlers ----------
 	const handleAcceptCandidate = useCallback(
@@ -686,7 +670,7 @@ export default function AiEditorialReview( {
 				)
 			) {
 				setConflictStatus( conflictIndex, 'failed' );
-				fireItemAction( {
+				fireResponseAction( {
 					action: 'accept',
 					target: 'conflict',
 					outcome: 'failed',
@@ -713,14 +697,20 @@ export default function AiEditorialReview( {
 					editableAttribute: result.editableAttribute,
 				};
 			}
-			fireItemAction( {
+			setConflictStatus( conflictIndex, result.success ? 'accepted' : 'failed' );
+			fireResponseAction( {
 				action: 'accept',
 				target: 'conflict',
 				outcome: result.success ? 'success' : 'failed',
 			} );
-			setConflictStatus( conflictIndex, result.success ? 'accepted' : 'failed' );
 		},
-		[ applyTextToBlock, fireItemAction, getBlockEditDisabledReason, isPostStale, setConflictStatus ]
+		[
+			applyTextToBlock,
+			fireResponseAction,
+			getBlockEditDisabledReason,
+			isPostStale,
+			setConflictStatus,
+		]
 	);
 	const handleUndoConflict = useCallback(
 		( conflictIndex: number ) => {
@@ -728,6 +718,10 @@ export default function AiEditorialReview( {
 				return;
 			}
 			const snap = conflictSnapshots.current[ conflictIndex ];
+			if ( conflictStatuses[ conflictIndex ] === 'accepted' && ! snap ) {
+				fireResponseAction( { action: 'undo', target: 'conflict', outcome: 'failed' } );
+				return;
+			}
 			if ( snap ) {
 				if (
 					! undoBlockEdit(
@@ -737,37 +731,25 @@ export default function AiEditorialReview( {
 						snap.editableAttribute
 					)
 				) {
-					fireItemAction( {
-						action: 'undo',
-						target: 'conflict',
-						outcome: 'failed',
-					} );
+					fireResponseAction( { action: 'undo', target: 'conflict', outcome: 'failed' } );
 					return;
 				}
 				delete conflictSnapshots.current[ conflictIndex ];
 			}
-			fireItemAction( {
-				action: 'undo',
-				target: 'conflict',
-				outcome: 'success',
-			} );
 			setConflictStatus( conflictIndex, 'pending' );
+			fireResponseAction( { action: 'undo', target: 'conflict', outcome: 'success' } );
 		},
-		[ fireItemAction, isPostStale, setConflictStatus ]
+		[ conflictStatuses, fireResponseAction, isPostStale, setConflictStatus ]
 	);
 	const handleDismissConflict = useCallback(
 		( conflictIndex: number ) => {
 			if ( isPostStale ) {
 				return;
 			}
-			fireItemAction( {
-				action: 'dismiss',
-				target: 'conflict',
-				outcome: 'success',
-			} );
 			setConflictStatus( conflictIndex, 'dismissed' );
+			fireResponseAction( { action: 'dismiss', target: 'conflict', outcome: 'success' } );
 		},
-		[ fireItemAction, isPostStale, setConflictStatus ]
+		[ fireResponseAction, isPostStale, setConflictStatus ]
 	);
 
 	// ---------- Bulk apply ----------
@@ -824,12 +806,6 @@ export default function AiEditorialReview( {
 		}
 		let successCount = 0;
 		let failureCount = 0;
-		const getBulkOutcome = () => {
-			if ( failureCount === 0 ) {
-				return 'success';
-			}
-			return successCount === 0 ? 'failed' : 'partial_failed';
-		};
 		setBulkRunning( true );
 		try {
 			// Sequential so users see the shimmer on each block as it applies;
@@ -871,10 +847,10 @@ export default function AiEditorialReview( {
 						editableAttribute: result.editableAttribute,
 					};
 				}
-				if ( ! result.success ) {
-					failureCount++;
-				} else {
+				if ( result.success ) {
 					successCount++;
+				} else {
+					failureCount++;
 				}
 				setConflictStatus( i, result.success ? 'accepted' : 'failed' );
 			}
@@ -920,20 +896,20 @@ export default function AiEditorialReview( {
 						editableAttribute: result.editableAttribute,
 					};
 				}
-				if ( ! result.success ) {
-					failureCount++;
-				} else {
+				if ( result.success ) {
 					successCount++;
+				} else {
+					failureCount++;
 				}
 				setEditStatus( i, result.success ? 'accepted' : 'failed' );
 			}
 			if ( isLatestPostContextStale() ) {
 				return;
 			}
-			fireItemAction( {
+			fireResponseAction( {
 				action: 'bulk_accept',
 				target: bulkTarget,
-				outcome: getBulkOutcome(),
+				outcome: getBulkResponseActionOutcome( successCount, failureCount ),
 				itemCount: successCount + failureCount,
 			} );
 		} finally {
@@ -950,7 +926,7 @@ export default function AiEditorialReview( {
 		editStatuses,
 		applyTextToBlock,
 		findApplicableAiCandidate,
-		fireItemAction,
+		fireResponseAction,
 		getBlockEditDisabledReason,
 		isLatestPostContextStale,
 		isPostStale,
@@ -983,37 +959,6 @@ export default function AiEditorialReview( {
 		( name: string ): ReviewerMetadata | null => reviewers_metadata?.[ name ] ?? null,
 		[ reviewers_metadata ]
 	);
-
-	// Latch on the first effect run so re-renders do not duplicate `_result_rendered`.
-	const hasTrackedResultRef = useRef( false );
-	useEffect( () => {
-		if ( isPostStale || hasTrackedResultRef.current ) {
-			return;
-		}
-		hasTrackedResultRef.current = true;
-		const isCacheHit = cached_at !== undefined;
-		const noReviewerSignal =
-			conflicts.length === 0 &&
-			implications.length === 0 &&
-			suggested_edits.length === 0 &&
-			renderedGuidelineViolations.length === 0;
-		trackAiEditorialReviewResultRendered( {
-			outcome: deriveResultOutcome( isCacheHit, review_context, noReviewerSignal ),
-			conflictCount: conflicts.length,
-			implicationCount: implications.length,
-			suggestedEditCount: suggested_edits.length,
-			guidelineViolationCount: renderedGuidelineViolations.length,
-			reviewContext: review_context,
-		} );
-	}, [
-		cached_at,
-		conflicts,
-		implications,
-		isPostStale,
-		renderedGuidelineViolations,
-		review_context,
-		suggested_edits,
-	] );
 
 	return (
 		<div

--- a/packages/jetpack-ai-sidebar/src/components/base-suggestion-picker.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/base-suggestion-picker.test.tsx
@@ -21,9 +21,54 @@ describe( 'BaseSuggestionPicker', () => {
 
 	it( 'calls onApply with the clicked value', () => {
 		const onApply = jest.fn();
-		render( <BaseSuggestionPicker intro="Pick one:" options={ options } onApply={ onApply } /> );
+		const onResponseAction = jest.fn();
+		render(
+			<BaseSuggestionPicker
+				intro="Pick one:"
+				options={ options }
+				onApply={ onApply }
+				onResponseAction={ onResponseAction }
+			/>
+		);
 		fireEvent.click( screen.getByText( 'Second option' ) );
 		expect( onApply ).toHaveBeenCalledWith( 'Second option' );
+		expect( onResponseAction ).toHaveBeenCalledWith( {
+			action: 'accept',
+			target: 'option',
+			outcome: 'success',
+		} );
+	} );
+
+	it( 'reports a failed apply without marking the option as applied', () => {
+		const onApply = jest.fn( () => {
+			throw new Error( 'Could not apply suggestion' );
+		} );
+		const onComplete = jest.fn();
+		const onResponseAction = jest.fn();
+		render(
+			<BaseSuggestionPicker
+				intro="Pick one:"
+				options={ options }
+				onApply={ onApply }
+				onComplete={ onComplete }
+				onResponseAction={ onResponseAction }
+			/>
+		);
+
+		const preventUnhandledError = ( event: ErrorEvent ) => event.preventDefault();
+		window.addEventListener( 'error', preventUnhandledError );
+		fireEvent.click( screen.getByText( 'Second option' ) );
+		window.removeEventListener( 'error', preventUnhandledError );
+		expect( screen.getByText( 'Second option' ).closest( 'button' ) ).toHaveAttribute(
+			'aria-pressed',
+			'false'
+		);
+		expect( onComplete ).not.toHaveBeenCalled();
+		expect( onResponseAction ).toHaveBeenCalledWith( {
+			action: 'accept',
+			target: 'option',
+			outcome: 'failed',
+		} );
 	} );
 
 	it( 'highlights only the applied option', () => {
@@ -36,6 +81,7 @@ describe( 'BaseSuggestionPicker', () => {
 	} );
 
 	it( 'marks the option matching currentValue as applied without a click', () => {
+		const onResponseAction = jest.fn();
 		render(
 			<BaseSuggestionPicker
 				intro="Pick one:"
@@ -43,11 +89,13 @@ describe( 'BaseSuggestionPicker', () => {
 				onApply={ jest.fn() }
 				appliedMessage="Applied."
 				currentValue="Second option"
+				onResponseAction={ onResponseAction }
 			/>
 		);
 		const second = screen.getByText( 'Second option' ).closest( 'button' ) as HTMLButtonElement;
 		expect( second ).toHaveAttribute( 'aria-pressed', 'true' );
 		expect( screen.getByText( 'Applied.' ) ).toBeInTheDocument();
+		expect( onResponseAction ).not.toHaveBeenCalled();
 	} );
 
 	it( 'ignores a currentValue that matches no option', () => {

--- a/packages/jetpack-ai-sidebar/src/components/base-suggestion-picker.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/base-suggestion-picker.tsx
@@ -16,6 +16,7 @@
  * External dependencies
  */
 import { useState, useCallback } from '@wordpress/element';
+import type { OnResponseAction } from '../utils/response-action';
 
 /**
  * Props for the BaseSuggestionPicker component.
@@ -24,6 +25,7 @@ interface BaseSuggestionPickerProps {
 	intro: string;
 	options: string[];
 	onApply: ( value: string ) => void;
+	onComplete?: () => void;
 	/** Optional confirmation shown inline once a value has been applied. */
 	appliedMessage?: string;
 	/**
@@ -32,28 +34,43 @@ interface BaseSuggestionPickerProps {
 	 * shows which suggestion was chosen.
 	 */
 	currentValue?: string;
+	onResponseAction?: OnResponseAction;
 }
 
-/**
- * BaseSuggestionPicker component for the chat sidebar.
- * @param {BaseSuggestionPickerProps} props - Component props.
- * @returns {import('react').ReactElement} The rendered component.
- */
+/** Renders a shared list of suggestions and applies the selected option. */
 export default function BaseSuggestionPicker( {
 	intro,
 	options,
 	onApply,
+	onComplete,
 	appliedMessage,
 	currentValue,
+	onResponseAction,
 }: BaseSuggestionPickerProps ) {
 	const [ appliedValue, setAppliedValue ] = useState< string | null >( null );
 
 	const handleApply = useCallback(
 		( value: string ) => {
-			onApply( value );
-			setAppliedValue( value );
+			// These editor callbacks return no result, so only a synchronous throw signals failure.
+			try {
+				onApply( value );
+				setAppliedValue( value );
+			} catch ( error ) {
+				onResponseAction?.( {
+					action: 'accept',
+					target: 'option',
+					outcome: 'failed',
+				} );
+				throw error;
+			}
+			onResponseAction?.( {
+				action: 'accept',
+				target: 'option',
+				outcome: 'success',
+			} );
+			onComplete?.();
 		},
-		[ onApply ]
+		[ onApply, onComplete, onResponseAction ]
 	);
 
 	const derivedAppliedValue =

--- a/packages/jetpack-ai-sidebar/src/components/excerpt-picker.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/excerpt-picker.tsx
@@ -18,6 +18,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { notifySuggestionActionComplete } from '../utils/suggestion-events';
 import BaseSuggestionPicker from './base-suggestion-picker';
+import type { OnResponseAction } from '../utils/response-action';
 
 /**
  * Props for the ExcerptPicker component.
@@ -30,14 +31,15 @@ interface ExcerptOption {
 interface ExcerptPickerProps {
 	excerpts: ExcerptOption[];
 	onComplete?: () => void;
+	onResponseAction?: OnResponseAction;
 }
 
-/**
- * ExcerptPicker component for the chat sidebar.
- * @param {ExcerptPickerProps} props - Component props.
- * @returns {import('react').ReactElement} The rendered component.
- */
-export default function ExcerptPicker( { excerpts, onComplete }: ExcerptPickerProps ) {
+/** Renders excerpt suggestions and applies the selected excerpt to the post. */
+export default function ExcerptPicker( {
+	excerpts,
+	onComplete,
+	onResponseAction,
+}: ExcerptPickerProps ) {
 	const { editPost } = useDispatch( 'core/editor' );
 	const currentExcerpt = useSelect( ( select ) => {
 		return (
@@ -51,9 +53,8 @@ export default function ExcerptPicker( { excerpts, onComplete }: ExcerptPickerPr
 		( excerpt: string ) => {
 			editPost( { excerpt } );
 			notifySuggestionActionComplete();
-			onComplete?.();
 		},
-		[ editPost, onComplete ]
+		[ editPost ]
 	);
 
 	// The props arrive from an orchestrator tool payload, so guard the shape
@@ -72,8 +73,10 @@ export default function ExcerptPicker( { excerpts, onComplete }: ExcerptPickerPr
 			) }
 			options={ options }
 			onApply={ handleApply }
+			onComplete={ onComplete }
 			appliedMessage={ __( 'Excerpt updated.', 'jetpack' ) }
 			currentValue={ typeof currentExcerpt === 'string' ? currentExcerpt : undefined }
+			onResponseAction={ onResponseAction }
 		/>
 	);
 }

--- a/packages/jetpack-ai-sidebar/src/components/feedback-list.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/feedback-list.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import FeedbackList, { type FeedbackListItem } from './feedback-list';
+
+const mockApplyReviewEdit = jest.fn();
+const mockUndoBlockEdit = jest.fn();
+let mockCurrentPostId = 1;
+const mockBlocks = [
+	{ clientId: 'block-1', name: 'core/paragraph', attributes: { content: 'First source' } },
+	{ clientId: 'block-2', name: 'core/paragraph', attributes: { content: 'Second source' } },
+];
+
+jest.mock( '../utils/block-actions', () => ( {
+	applyReviewEdit: ( ...args: any[] ) => mockApplyReviewEdit( ...args ),
+	clearActiveBlockFocus: jest.fn(),
+	clearActiveBlockFocusUnlessBlockReferenceClick: jest.fn(),
+	countCurrentTextOccurrences: () => 1,
+	getEditableBlockContent: ( block: any ) => block.attributes.content,
+	hasEditableBlockTarget: () => true,
+	toggleBlockReferenceFocus: jest.fn(),
+	undoBlockEdit: ( ...args: any[] ) => mockUndoBlockEdit( ...args ),
+} ) );
+
+jest.mock( '../utils/blocks', () => ( {
+	flattenBlocks: ( blocks: any[] ) => blocks,
+	getEditorContentBlocks: ( blockEditor: { getBlocks: () => any[] } ) => blockEditor.getBlocks(),
+} ) );
+
+jest.mock( '../utils/use-copy-to-clipboard', () => ( {
+	useCopyToClipboard: () => ( {
+		clipboardSupported: false,
+		copiedKey: null,
+		copy: jest.fn(),
+	} ),
+} ) );
+
+jest.mock( './split-screen-guide', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+jest.mock( './review-card', () => {
+	const ReactModule = jest.requireActual< typeof import('react') >( 'react' );
+	return {
+		__esModule: true,
+		default: ( { status, onApply, onDismiss, onUndo }: any ) =>
+			ReactModule.createElement(
+				'div',
+				null,
+				status === 'accepted' || status === 'dismissed'
+					? ReactModule.createElement( 'button', { type: 'button', onClick: onUndo }, 'Undo' )
+					: ReactModule.createElement(
+							ReactModule.Fragment,
+							null,
+							ReactModule.createElement(
+								'button',
+								{ type: 'button', onClick: onApply },
+								status === 'failed' ? 'Retry' : 'Apply change'
+							),
+							ReactModule.createElement(
+								'button',
+								{ type: 'button', onClick: onDismiss },
+								'Dismiss'
+							)
+					  )
+			),
+	};
+} );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: ( mapSelect: any ) =>
+		mapSelect( ( store: string ) => {
+			if ( store === 'core/block-editor' ) {
+				return { getBlocks: () => mockBlocks };
+			}
+			if ( store === 'core/editor' ) {
+				return { getCurrentPostId: () => mockCurrentPostId };
+			}
+			return {};
+		} ),
+} ) );
+
+jest.mock( '@wordpress/components', () => {
+	const ReactModule = jest.requireActual< typeof import('react') >( 'react' );
+	return {
+		Panel: ( { children }: any ) => ReactModule.createElement( 'div', null, children ),
+		PanelBody: ( { children }: any ) => ReactModule.createElement( 'section', null, children ),
+	};
+} );
+
+const items: FeedbackListItem[] = [
+	{
+		title: 'First edit',
+		feedback: 'First feedback',
+		action: 'Rewrite',
+		block_index: 0,
+		current_text: 'First source',
+		suggested_text: 'First replacement',
+	},
+	{
+		title: 'Second edit',
+		feedback: 'Second feedback',
+		action: 'Rewrite',
+		block_index: 1,
+		current_text: 'Second source',
+		suggested_text: 'Second replacement',
+	},
+];
+
+function renderFeedbackList( onResponseAction: jest.Mock, listItems = items ) {
+	return render(
+		<FeedbackList
+			componentType="proofread"
+			summary="Review complete."
+			items={ listItems }
+			postId={ 1 }
+			sectionFallbackTitle="Suggested edits"
+			staleWarning="Review is stale."
+			failureMessage="Could not apply."
+			enableBulkApply
+			onResponseAction={ onResponseAction }
+		/>
+	);
+}
+
+beforeEach( () => {
+	mockApplyReviewEdit.mockReset();
+	mockUndoBlockEdit.mockReset();
+	mockUndoBlockEdit.mockReturnValue( true );
+	mockCurrentPostId = 1;
+	( window as any ).wp = {
+		data: {
+			select: () => ( { getCurrentPostId: () => mockCurrentPostId } ),
+		},
+	};
+} );
+
+afterEach( () => {
+	delete ( window as any ).wp;
+} );
+
+it( 'reports an individual apply and its inline undo from existing operation results', async () => {
+	const onResponseAction = jest.fn();
+	mockApplyReviewEdit.mockResolvedValueOnce( {
+		success: true,
+		clientId: 'block-1',
+		contentBefore: 'First source',
+		contentAfter: 'First replacement',
+	} );
+	renderFeedbackList( onResponseAction, [ items[ 0 ] ] );
+
+	await act( async () => {
+		fireEvent.click( screen.getByRole( 'button', { name: 'Apply change' } ) );
+	} );
+
+	await waitFor( () =>
+		expect( onResponseAction ).toHaveBeenLastCalledWith( {
+			action: 'accept',
+			target: 'edit',
+			outcome: 'success',
+		} )
+	);
+
+	fireEvent.click( screen.getByRole( 'button', { name: 'Undo' } ) );
+
+	expect( mockUndoBlockEdit ).toHaveBeenCalledWith(
+		'block-1',
+		'First source',
+		'First replacement',
+		undefined
+	);
+	expect( onResponseAction ).toHaveBeenLastCalledWith( {
+		action: 'undo',
+		target: 'edit',
+		outcome: 'success',
+	} );
+} );
+
+it( 'reports one aggregate action for a partial bulk apply', async () => {
+	const onResponseAction = jest.fn();
+	mockApplyReviewEdit
+		.mockResolvedValueOnce( {
+			success: true,
+			clientId: 'block-1',
+			contentBefore: 'First source',
+			contentAfter: 'First replacement',
+		} )
+		.mockResolvedValueOnce( { success: false } );
+	renderFeedbackList( onResponseAction );
+
+	await act( async () => {
+		fireEvent.click( screen.getByRole( 'button', { name: 'Apply all (2)' } ) );
+	} );
+
+	await waitFor( () => expect( onResponseAction ).toHaveBeenCalledTimes( 1 ) );
+	expect( onResponseAction ).toHaveBeenCalledWith( {
+		action: 'bulk_accept',
+		target: 'edit',
+		outcome: 'partial_failed',
+		itemCount: 2,
+	} );
+} );

--- a/packages/jetpack-ai-sidebar/src/components/feedback-list.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/feedback-list.test.tsx
@@ -114,8 +114,12 @@ const items: FeedbackListItem[] = [
 	},
 ];
 
-function renderFeedbackList( onResponseAction: jest.Mock, listItems = items ) {
-	return render(
+function feedbackList(
+	onResponseAction: jest.Mock | undefined,
+	listItems = items,
+	props: Partial< React.ComponentProps< typeof FeedbackList > > = {}
+) {
+	return (
 		<FeedbackList
 			componentType="proofread"
 			summary="Review complete."
@@ -126,8 +130,13 @@ function renderFeedbackList( onResponseAction: jest.Mock, listItems = items ) {
 			failureMessage="Could not apply."
 			enableBulkApply
 			onResponseAction={ onResponseAction }
+			{ ...props }
 		/>
 	);
+}
+
+function renderFeedbackList( onResponseAction: jest.Mock, listItems = items ) {
+	return render( feedbackList( onResponseAction, listItems ) );
 }
 
 beforeEach( () => {
@@ -206,4 +215,110 @@ it( 'reports one aggregate action for a partial bulk apply', async () => {
 		outcome: 'partial_failed',
 		itemCount: 2,
 	} );
+} );
+
+it( 'does not report an in-flight action after the host revokes tracking', async () => {
+	const onResponseAction = jest.fn();
+	let resolveApply: ( value: {
+		success: boolean;
+		clientId: string;
+		contentBefore: string;
+		contentAfter: string;
+	} ) => void = () => {};
+	mockApplyReviewEdit.mockImplementationOnce(
+		() =>
+			new Promise( ( resolve ) => {
+				resolveApply = resolve;
+			} )
+	);
+	const { rerender } = renderFeedbackList( onResponseAction, [ items[ 0 ] ] );
+
+	fireEvent.click( screen.getByRole( 'button', { name: 'Apply change' } ) );
+	rerender( feedbackList( undefined, [ items[ 0 ] ], { isMessageStale: true } ) );
+
+	await act( async () => {
+		resolveApply( {
+			success: true,
+			clientId: 'block-1',
+			contentBefore: 'First source',
+			contentAfter: 'First replacement',
+		} );
+	} );
+
+	expect( onResponseAction ).not.toHaveBeenCalled();
+} );
+
+it( 'does not report an in-flight action after the response unmounts', async () => {
+	const onResponseAction = jest.fn();
+	let resolveApply: ( value: {
+		success: boolean;
+		clientId: string;
+		contentBefore: string;
+		contentAfter: string;
+	} ) => void = () => {};
+	mockApplyReviewEdit.mockImplementationOnce(
+		() =>
+			new Promise( ( resolve ) => {
+				resolveApply = resolve;
+			} )
+	);
+	const { unmount } = renderFeedbackList( onResponseAction, [ items[ 0 ] ] );
+
+	fireEvent.click( screen.getByRole( 'button', { name: 'Apply change' } ) );
+	unmount();
+	await act( async () => {
+		resolveApply( {
+			success: true,
+			clientId: 'block-1',
+			contentBefore: 'First source',
+			contentAfter: 'First replacement',
+		} );
+	} );
+
+	expect( onResponseAction ).not.toHaveBeenCalled();
+} );
+
+it( 'stops bulk reporting when the post changes during an apply', async () => {
+	const onResponseAction = jest.fn();
+	let resolveFirstApply: ( value: { success: boolean } ) => void = () => {};
+	mockApplyReviewEdit.mockImplementationOnce(
+		() =>
+			new Promise( ( resolve ) => {
+				resolveFirstApply = resolve;
+			} )
+	);
+	const { rerender } = renderFeedbackList( onResponseAction );
+
+	fireEvent.click( screen.getByRole( 'button', { name: 'Apply all (2)' } ) );
+	await waitFor( () => expect( mockApplyReviewEdit ).toHaveBeenCalledTimes( 1 ) );
+
+	mockCurrentPostId = 2;
+	rerender( feedbackList( onResponseAction ) );
+	await act( async () => resolveFirstApply( { success: true } ) );
+
+	expect( mockApplyReviewEdit ).toHaveBeenCalledTimes( 1 );
+	expect( onResponseAction ).not.toHaveBeenCalled();
+} );
+
+it( 'does not report a failed undo when the post is stale', async () => {
+	const onResponseAction = jest.fn();
+	mockApplyReviewEdit.mockResolvedValueOnce( {
+		success: true,
+		clientId: 'block-1',
+		contentBefore: 'First source',
+		contentAfter: 'First replacement',
+	} );
+	const { rerender } = renderFeedbackList( onResponseAction, [ items[ 0 ] ] );
+
+	await act( async () => {
+		fireEvent.click( screen.getByRole( 'button', { name: 'Apply change' } ) );
+	} );
+	onResponseAction.mockClear();
+	mockCurrentPostId = 2;
+	rerender( feedbackList( onResponseAction, [ items[ 0 ] ] ) );
+
+	fireEvent.click( screen.getByRole( 'button', { name: 'Undo' } ) );
+
+	expect( mockUndoBlockEdit ).not.toHaveBeenCalled();
+	expect( onResponseAction ).not.toHaveBeenCalled();
 } );

--- a/packages/jetpack-ai-sidebar/src/components/feedback-list.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/feedback-list.tsx
@@ -42,10 +42,12 @@ import {
 	type BlockEditorStore,
 	type EditorStore,
 } from '../utils/blocks';
+import { getBulkResponseActionOutcome } from '../utils/response-action';
 import { useCopyToClipboard } from '../utils/use-copy-to-clipboard';
 import { type BlockSnapshot } from './block-ref';
 import ReviewCard, { type ReviewCardRow } from './review-card';
 import SplitScreenGuide from './split-screen-guide';
+import type { OnResponseAction } from '../utils/response-action';
 
 export interface FeedbackListItem {
 	title: string;
@@ -90,6 +92,8 @@ export interface FeedbackListProps {
 	postId?: EditorPostId;
 	/** Whether the containing chat message is no longer interactive. */
 	isMessageStale?: boolean;
+	/** Reports completed user actions to the host that rendered this response. */
+	onResponseAction?: OnResponseAction;
 	/** Title used when the flow provides flat items rather than sections. */
 	sectionFallbackTitle: string;
 	/** Warning shown when the reviewed post no longer matches the editor. */
@@ -202,11 +206,7 @@ function getApplyUnavailableReason(
 	return undefined;
 }
 
-/**
- * Render a flat, item-based feedback list.
- * @param {FeedbackListProps} props Component props.
- * @returns React element.
- */
+/** Renders actionable feedback items and their bulk-apply control. */
 export default function FeedbackList( {
 	componentType,
 	summary,
@@ -214,6 +214,7 @@ export default function FeedbackList( {
 	sections,
 	postId,
 	isMessageStale = false,
+	onResponseAction,
 	sectionFallbackTitle,
 	staleWarning,
 	failureMessage,
@@ -278,19 +279,23 @@ export default function FeedbackList( {
 	}, [] );
 
 	const applyItem = useCallback(
-		async ( item: FeedbackListItem, sectionIndex: number, itemIndex: number ) => {
+		async (
+			item: FeedbackListItem,
+			sectionIndex: number,
+			itemIndex: number
+		): Promise< boolean > => {
 			const key = getItemKey( sectionIndex, itemIndex );
 			const block = item.block_index === null ? null : flatBlocks[ item.block_index ];
 			if ( isLatestPostContextStale() || getApplyUnavailableReason( item, block ) ) {
 				setItemStatus( key, 'failed' );
-				return;
+				return false;
 			}
 
 			setItemStatus( key, 'applying' );
 			const clientId = block?.clientId;
 			if ( ! clientId || ! item.suggested_text ) {
 				setItemStatus( key, 'failed' );
-				return;
+				return false;
 			}
 
 			let result: Awaited< ReturnType< typeof applyReviewEdit > >;
@@ -305,7 +310,7 @@ export default function FeedbackList( {
 				);
 			} catch {
 				setItemStatus( key, 'failed' );
-				return;
+				return false;
 			}
 
 			if (
@@ -321,10 +326,11 @@ export default function FeedbackList( {
 					editableAttribute: result.editableAttribute,
 				};
 				setItemStatus( key, 'accepted' );
-				return;
+				return true;
 			}
 
 			setItemStatus( key, 'failed' );
+			return false;
 		},
 		[ flatBlocks, isLatestPostContextStale, setItemStatus ]
 	);
@@ -356,21 +362,38 @@ export default function FeedbackList( {
 		if ( bulkRunning || isLatestPostContextStale() ) {
 			return;
 		}
+		let successCount = 0;
+		let failureCount = 0;
 		setBulkRunning( true );
 		for ( const target of applyAllTargets ) {
 			// Apply sequentially so each edit validates against the live block.
 			// eslint-disable-next-line no-await-in-loop
-			await applyItem( target.item, target.sectionIndex, target.itemIndex );
+			const succeeded = await applyItem( target.item, target.sectionIndex, target.itemIndex );
+			if ( succeeded ) {
+				successCount++;
+			} else {
+				failureCount++;
+			}
 		}
 		setBulkRunning( false );
-	}, [ applyAllTargets, applyItem, bulkRunning, isLatestPostContextStale ] );
+		onResponseAction?.( {
+			action: 'bulk_accept',
+			target: 'edit',
+			outcome: getBulkResponseActionOutcome( successCount, failureCount ),
+			itemCount: successCount + failureCount,
+		} );
+	}, [ applyAllTargets, applyItem, bulkRunning, isLatestPostContextStale, onResponseAction ] );
 
 	const undoItem = useCallback(
-		( key: string ) => {
+		( key: string, status: ItemStatus ) => {
 			if ( isLatestPostContextStale() ) {
-				return;
+				return false;
 			}
 			const snapshot = editSnapshots.current[ key ];
+			if ( status === 'accepted' && ! snapshot ) {
+				setItemStatus( key, 'failed' );
+				return false;
+			}
 			if ( snapshot ) {
 				const didUndo = undoBlockEdit(
 					snapshot.clientId,
@@ -380,20 +403,23 @@ export default function FeedbackList( {
 				);
 				if ( ! didUndo ) {
 					setItemStatus( key, 'failed' );
-					return;
+					return false;
 				}
 				delete editSnapshots.current[ key ];
 			}
 			setItemStatus( key, 'pending' );
+			return true;
 		},
 		[ isLatestPostContextStale, setItemStatus ]
 	);
 
 	const dismissItem = useCallback(
 		( key: string ) => {
-			if ( ! isPostStale ) {
-				setItemStatus( key, 'dismissed' );
+			if ( isPostStale ) {
+				return false;
 			}
+			setItemStatus( key, 'dismissed' );
+			return true;
 		},
 		[ isPostStale, setItemStatus ]
 	);
@@ -527,7 +553,15 @@ export default function FeedbackList( {
 										copied={ copiedKey === key }
 										disabled={ isPostStale || bulkRunning }
 										failureMessage={ failureMessage }
-										onApply={ () => applyItem( item, sectionIndex, itemIndex ) }
+										onApply={ () => {
+											void applyItem( item, sectionIndex, itemIndex ).then( ( succeeded ) => {
+												onResponseAction?.( {
+													action: 'accept',
+													target: 'edit',
+													outcome: succeeded ? 'success' : 'failed',
+												} );
+											} );
+										} }
 										onGoToSection={ () => {
 											if ( item.block_index !== null && item.block_index !== undefined ) {
 												focusBlock( item.block_index );
@@ -538,8 +572,23 @@ export default function FeedbackList( {
 												copyItem( key, suggestionText );
 											}
 										} }
-										onDismiss={ () => dismissItem( key ) }
-										onUndo={ () => undoItem( key ) }
+										onDismiss={ () => {
+											if ( dismissItem( key ) ) {
+												onResponseAction?.( {
+													action: 'dismiss',
+													target: 'edit',
+													outcome: 'success',
+												} );
+											}
+										} }
+										onUndo={ () => {
+											const succeeded = undoItem( key, status );
+											onResponseAction?.( {
+												action: 'undo',
+												target: 'edit',
+												outcome: succeeded ? 'success' : 'failed',
+											} );
+										} }
 										onFocusBlock={ focusCurrentPostBlock }
 									/>
 								);

--- a/packages/jetpack-ai-sidebar/src/components/feedback-list.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/feedback-list.tsx
@@ -42,12 +42,12 @@ import {
 	type BlockEditorStore,
 	type EditorStore,
 } from '../utils/blocks';
-import { getBulkResponseActionOutcome } from '../utils/response-action';
+import { getBulkResponseActionOutcome, type OnResponseAction } from '../utils/response-action';
 import { useCopyToClipboard } from '../utils/use-copy-to-clipboard';
+import useLatestResponseAction from '../utils/use-latest-response-action';
 import { type BlockSnapshot } from './block-ref';
 import ReviewCard, { type ReviewCardRow } from './review-card';
 import SplitScreenGuide from './split-screen-guide';
-import type { OnResponseAction } from '../utils/response-action';
 
 export interface FeedbackListItem {
 	title: string;
@@ -255,6 +255,7 @@ export default function FeedbackList( {
 	const setItemStatus = useCallback( ( key: string, status: ItemStatus ) => {
 		setItemStatuses( ( prev ) => ( { ...prev, [ key ]: status } ) );
 	}, [] );
+	const fireResponseAction = useLatestResponseAction( onResponseAction, isLatestPostContextStale );
 
 	const focusBlock = useCallback(
 		( index: number ) => {
@@ -286,7 +287,11 @@ export default function FeedbackList( {
 		): Promise< boolean > => {
 			const key = getItemKey( sectionIndex, itemIndex );
 			const block = item.block_index === null ? null : flatBlocks[ item.block_index ];
-			if ( isLatestPostContextStale() || getApplyUnavailableReason( item, block ) ) {
+			const previousStatus = itemStatuses[ key ] ?? 'pending';
+			if ( isLatestPostContextStale() ) {
+				return false;
+			}
+			if ( getApplyUnavailableReason( item, block ) ) {
 				setItemStatus( key, 'failed' );
 				return false;
 			}
@@ -309,7 +314,16 @@ export default function FeedbackList( {
 					item.editable_attribute
 				);
 			} catch {
+				if ( isLatestPostContextStale() ) {
+					setItemStatus( key, previousStatus );
+					return false;
+				}
 				setItemStatus( key, 'failed' );
+				return false;
+			}
+
+			if ( isLatestPostContextStale() ) {
+				setItemStatus( key, previousStatus );
 				return false;
 			}
 
@@ -332,7 +346,7 @@ export default function FeedbackList( {
 			setItemStatus( key, 'failed' );
 			return false;
 		},
-		[ flatBlocks, isLatestPostContextStale, setItemStatus ]
+		[ flatBlocks, isLatestPostContextStale, itemStatuses, setItemStatus ]
 	);
 
 	// Pending, one-click-applicable items, used for the "Apply all" action.
@@ -362,27 +376,36 @@ export default function FeedbackList( {
 		if ( bulkRunning || isLatestPostContextStale() ) {
 			return;
 		}
-		let successCount = 0;
-		let failureCount = 0;
 		setBulkRunning( true );
-		for ( const target of applyAllTargets ) {
-			// Apply sequentially so each edit validates against the live block.
-			// eslint-disable-next-line no-await-in-loop
-			const succeeded = await applyItem( target.item, target.sectionIndex, target.itemIndex );
-			if ( succeeded ) {
-				successCount++;
-			} else {
-				failureCount++;
+		try {
+			let successCount = 0;
+			let failureCount = 0;
+			for ( const target of applyAllTargets ) {
+				if ( isLatestPostContextStale() ) {
+					return;
+				}
+				// Apply sequentially so each edit validates against the live block.
+				// eslint-disable-next-line no-await-in-loop
+				const succeeded = await applyItem( target.item, target.sectionIndex, target.itemIndex );
+				if ( isLatestPostContextStale() ) {
+					return;
+				}
+				if ( succeeded ) {
+					successCount++;
+				} else {
+					failureCount++;
+				}
 			}
+			fireResponseAction( {
+				action: 'bulk_accept',
+				target: 'edit',
+				outcome: getBulkResponseActionOutcome( successCount, failureCount ),
+				itemCount: successCount + failureCount,
+			} );
+		} finally {
+			setBulkRunning( false );
 		}
-		setBulkRunning( false );
-		onResponseAction?.( {
-			action: 'bulk_accept',
-			target: 'edit',
-			outcome: getBulkResponseActionOutcome( successCount, failureCount ),
-			itemCount: successCount + failureCount,
-		} );
-	}, [ applyAllTargets, applyItem, bulkRunning, isLatestPostContextStale, onResponseAction ] );
+	}, [ applyAllTargets, applyItem, bulkRunning, fireResponseAction, isLatestPostContextStale ] );
 
 	const undoItem = useCallback(
 		( key: string, status: ItemStatus ) => {
@@ -555,7 +578,10 @@ export default function FeedbackList( {
 										failureMessage={ failureMessage }
 										onApply={ () => {
 											void applyItem( item, sectionIndex, itemIndex ).then( ( succeeded ) => {
-												onResponseAction?.( {
+												if ( isLatestPostContextStale() ) {
+													return;
+												}
+												fireResponseAction( {
 													action: 'accept',
 													target: 'edit',
 													outcome: succeeded ? 'success' : 'failed',
@@ -574,7 +600,7 @@ export default function FeedbackList( {
 										} }
 										onDismiss={ () => {
 											if ( dismissItem( key ) ) {
-												onResponseAction?.( {
+												fireResponseAction( {
 													action: 'dismiss',
 													target: 'edit',
 													outcome: 'success',
@@ -583,7 +609,10 @@ export default function FeedbackList( {
 										} }
 										onUndo={ () => {
 											const succeeded = undoItem( key, status );
-											onResponseAction?.( {
+											if ( isLatestPostContextStale() ) {
+												return;
+											}
+											fireResponseAction( {
 												action: 'undo',
 												target: 'edit',
 												outcome: succeeded ? 'success' : 'failed',

--- a/packages/jetpack-ai-sidebar/src/components/image-alt-text-picker.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/image-alt-text-picker.test.tsx
@@ -55,7 +55,8 @@ describe( 'ImageAltTextPicker', () => {
 	} );
 
 	it( 'applies alt text to every image in one click and confirms', () => {
-		render( <ImageAltTextPicker images={ images } /> );
+		const onResponseAction = jest.fn();
+		render( <ImageAltTextPicker images={ images } onResponseAction={ onResponseAction } /> );
 		fireEvent.click( screen.getByRole( 'button', { name: 'Apply to all 2 images' } ) );
 
 		expect( mockUpdateBlockAttributes ).toHaveBeenCalledTimes( 2 );
@@ -71,6 +72,12 @@ describe( 'ImageAltTextPicker', () => {
 		// The button is replaced by the confirmation, and the images stay visible.
 		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'A cat on a sofa' ) ).toBeInTheDocument();
+		expect( onResponseAction ).toHaveBeenCalledWith( {
+			action: 'bulk_accept',
+			target: 'image',
+			outcome: 'success',
+			itemCount: 2,
+		} );
 	} );
 
 	it( 'calls onComplete after applying', () => {
@@ -78,6 +85,36 @@ describe( 'ImageAltTextPicker', () => {
 		render( <ImageAltTextPicker images={ images } onComplete={ onComplete } /> );
 		fireEvent.click( screen.getByRole( 'button', { name: 'Apply to all 2 images' } ) );
 		expect( onComplete ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'reports a partial failure when a later image update throws', () => {
+		const onComplete = jest.fn();
+		const onResponseAction = jest.fn();
+		mockUpdateBlockAttributes
+			.mockImplementationOnce( () => undefined )
+			.mockImplementationOnce( () => {
+				throw new Error( 'Could not update image' );
+			} );
+		render(
+			<ImageAltTextPicker
+				images={ images }
+				onComplete={ onComplete }
+				onResponseAction={ onResponseAction }
+			/>
+		);
+
+		const preventUnhandledError = ( event: ErrorEvent ) => event.preventDefault();
+		window.addEventListener( 'error', preventUnhandledError );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Apply to all 2 images' } ) );
+		window.removeEventListener( 'error', preventUnhandledError );
+		expect( screen.getByRole( 'button', { name: 'Apply to all 2 images' } ) ).toBeInTheDocument();
+		expect( onComplete ).not.toHaveBeenCalled();
+		expect( onResponseAction ).toHaveBeenCalledWith( {
+			action: 'bulk_accept',
+			target: 'image',
+			outcome: 'partial_failed',
+			itemCount: 2,
+		} );
 	} );
 
 	it( 'uses singular copy for a single image', () => {

--- a/packages/jetpack-ai-sidebar/src/components/image-alt-text-picker.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/image-alt-text-picker.tsx
@@ -16,6 +16,8 @@
 import { useDispatch } from '@wordpress/data';
 import { useState, useCallback } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { getBulkResponseActionOutcome } from '../utils/response-action';
+import type { OnResponseAction } from '../utils/response-action';
 
 /**
  * One generated alt-text suggestion: the target block, its image URL (for the
@@ -31,28 +33,44 @@ interface AltTextSuggestion {
 interface ImageAltTextPickerProps {
 	images: AltTextSuggestion[];
 	onComplete?: () => void;
+	onResponseAction?: OnResponseAction;
 }
 
-/**
- * ImageAltTextPicker component for the chat sidebar.
- *
- * Renders each image next to its suggested alt text, then applies every
- * suggestion in one action via a single common Apply button and shows a
- * confirmation.
- * @param {ImageAltTextPickerProps} props - Component props.
- * @returns {import('react').ReactElement|null} The rendered component.
- */
-export default function ImageAltTextPicker( { images, onComplete }: ImageAltTextPickerProps ) {
+/** Renders image alt-text suggestions and applies them in one action. */
+export default function ImageAltTextPicker( {
+	images,
+	onComplete,
+	onResponseAction,
+}: ImageAltTextPickerProps ) {
 	const [ applied, setApplied ] = useState( false );
 	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
 
 	const handleApplyAll = useCallback( () => {
-		images.forEach( ( image ) => {
-			updateBlockAttributes( image.clientId, { alt: image.alt } );
+		let completedCount = 0;
+		// Updates stop on the first throw; earlier completions produce `partial_failed`.
+		try {
+			images.forEach( ( image ) => {
+				updateBlockAttributes( image.clientId, { alt: image.alt } );
+				completedCount++;
+			} );
+			setApplied( true );
+		} catch ( error ) {
+			onResponseAction?.( {
+				action: 'bulk_accept',
+				target: 'image',
+				outcome: getBulkResponseActionOutcome( completedCount, 1 ),
+				itemCount: completedCount + 1,
+			} );
+			throw error;
+		}
+		onResponseAction?.( {
+			action: 'bulk_accept',
+			target: 'image',
+			outcome: 'success',
+			itemCount: completedCount,
 		} );
-		setApplied( true );
 		onComplete?.();
-	}, [ images, updateBlockAttributes, onComplete ] );
+	}, [ images, updateBlockAttributes, onComplete, onResponseAction ] );
 
 	if ( ! images?.length ) {
 		return null;

--- a/packages/jetpack-ai-sidebar/src/components/post-feedback.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/post-feedback.tsx
@@ -19,6 +19,7 @@ import FeedbackList, {
 	type FeedbackListItem,
 	type FeedbackListSection,
 } from './feedback-list';
+import type { OnResponseAction } from '../utils/response-action';
 
 export interface PostFeedbackProps {
 	summary: string;
@@ -26,19 +27,17 @@ export interface PostFeedbackProps {
 	sections?: FeedbackListSection[];
 	postId?: EditorPostId;
 	isMessageStale?: boolean;
+	onResponseAction?: OnResponseAction;
 }
 
-/**
- * Render the post feedback component.
- * @param {PostFeedbackProps} props Component props.
- * @returns React element.
- */
+/** Configures the shared feedback list for generated post feedback. */
 export default function PostFeedback( {
 	summary,
 	items,
 	sections,
 	postId,
 	isMessageStale,
+	onResponseAction,
 }: PostFeedbackProps ) {
 	return (
 		<FeedbackList
@@ -48,6 +47,7 @@ export default function PostFeedback( {
 			sections={ sections }
 			postId={ postId }
 			isMessageStale={ isMessageStale }
+			onResponseAction={ onResponseAction }
 			sectionFallbackTitle={ __( 'Suggested edits', __i18n_text_domain__ ) }
 			staleWarning={ __(
 				'Feedback context changed. Generate feedback again for this post.',

--- a/packages/jetpack-ai-sidebar/src/components/proofread.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/proofread.tsx
@@ -17,6 +17,7 @@ import FeedbackList, {
 	type FeedbackListItem,
 	type FeedbackListSection,
 } from './feedback-list';
+import type { OnResponseAction } from '../utils/response-action';
 
 export interface ProofreadProps {
 	summary: string;
@@ -24,19 +25,17 @@ export interface ProofreadProps {
 	sections?: FeedbackListSection[];
 	postId?: EditorPostId;
 	isMessageStale?: boolean;
+	onResponseAction?: OnResponseAction;
 }
 
-/**
- * Render the proofreader component.
- * @param {ProofreadProps} props Component props.
- * @returns React element.
- */
+/** Configures the shared feedback list for proofreader results. */
 export default function Proofread( {
 	summary,
 	items,
 	sections,
 	postId,
 	isMessageStale,
+	onResponseAction,
 }: ProofreadProps ) {
 	return (
 		<FeedbackList
@@ -46,6 +45,7 @@ export default function Proofread( {
 			sections={ sections }
 			postId={ postId }
 			isMessageStale={ isMessageStale }
+			onResponseAction={ onResponseAction }
 			sectionFallbackTitle={ __( 'Suggested edits', __i18n_text_domain__ ) }
 			staleWarning={ __(
 				'Review context changed. Run the spelling and grammar check again for this post.',

--- a/packages/jetpack-ai-sidebar/src/components/seo-description-picker.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/seo-description-picker.tsx
@@ -18,6 +18,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import BaseSuggestionPicker from './base-suggestion-picker';
+import type { OnResponseAction } from '../utils/response-action';
 
 /**
  * Jetpack SEO post meta key for the custom HTML <meta> description.
@@ -36,16 +37,14 @@ interface SeoDescriptionOption {
 interface SeoDescriptionPickerProps {
 	descriptions: SeoDescriptionOption[];
 	onComplete?: () => void;
+	onResponseAction?: OnResponseAction;
 }
 
-/**
- * SeoDescriptionPicker component for the chat sidebar.
- * @param {SeoDescriptionPickerProps} props - Component props.
- * @returns {import('react').ReactElement} The rendered component.
- */
+/** Renders SEO description suggestions and applies the selection to post meta. */
 export default function SeoDescriptionPicker( {
 	descriptions,
 	onComplete,
+	onResponseAction,
 }: SeoDescriptionPickerProps ) {
 	const { editPost } = useDispatch( 'core/editor' );
 	const currentDescription = useSelect( ( select ) => {
@@ -60,9 +59,8 @@ export default function SeoDescriptionPicker( {
 	const handleApply = useCallback(
 		( description: string ) => {
 			editPost( { meta: { [ SEO_DESCRIPTION_META_KEY ]: description } } );
-			onComplete?.();
 		},
-		[ editPost, onComplete ]
+		[ editPost ]
 	);
 
 	return (
@@ -70,8 +68,10 @@ export default function SeoDescriptionPicker( {
 			intro={ __( 'Choose an SEO description for your post:', 'jetpack' ) }
 			options={ descriptions.map( ( option ) => option.description ) }
 			onApply={ handleApply }
+			onComplete={ onComplete }
 			appliedMessage={ __( 'SEO description updated.', 'jetpack' ) }
 			currentValue={ typeof currentDescription === 'string' ? currentDescription : undefined }
+			onResponseAction={ onResponseAction }
 		/>
 	);
 }

--- a/packages/jetpack-ai-sidebar/src/components/seo-title-picker.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/seo-title-picker.tsx
@@ -19,6 +19,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import BaseSuggestionPicker from './base-suggestion-picker';
+import type { OnResponseAction } from '../utils/response-action';
 
 /**
  * Jetpack SEO post meta key for the custom HTML <title> override.
@@ -37,14 +38,15 @@ interface SeoTitleOption {
 interface SeoTitlePickerProps {
 	titles: SeoTitleOption[];
 	onComplete?: () => void;
+	onResponseAction?: OnResponseAction;
 }
 
-/**
- * SeoTitlePicker component for the chat sidebar.
- * @param {SeoTitlePickerProps} props - Component props.
- * @returns {import('react').ReactElement} The rendered component.
- */
-export default function SeoTitlePicker( { titles, onComplete }: SeoTitlePickerProps ) {
+/** Renders SEO title suggestions and applies the selected title to post meta. */
+export default function SeoTitlePicker( {
+	titles,
+	onComplete,
+	onResponseAction,
+}: SeoTitlePickerProps ) {
 	const { editPost } = useDispatch( 'core/editor' );
 	const currentSeoTitle = useSelect( ( select ) => {
 		const meta = (
@@ -58,9 +60,8 @@ export default function SeoTitlePicker( { titles, onComplete }: SeoTitlePickerPr
 	const handleApply = useCallback(
 		( title: string ) => {
 			editPost( { meta: { [ SEO_TITLE_META_KEY ]: title } } );
-			onComplete?.();
 		},
-		[ editPost, onComplete ]
+		[ editPost ]
 	);
 
 	return (
@@ -68,8 +69,10 @@ export default function SeoTitlePicker( { titles, onComplete }: SeoTitlePickerPr
 			intro={ __( 'Choose an SEO title for your post:', 'jetpack' ) }
 			options={ titles.map( ( option ) => option.title ) }
 			onApply={ handleApply }
+			onComplete={ onComplete }
 			appliedMessage={ __( 'SEO title updated.', 'jetpack' ) }
 			currentValue={ typeof currentSeoTitle === 'string' ? currentSeoTitle : undefined }
+			onResponseAction={ onResponseAction }
 		/>
 	);
 }

--- a/packages/jetpack-ai-sidebar/src/components/title-picker.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/title-picker.tsx
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { notifySuggestionActionComplete } from '../utils/suggestion-events';
 import BaseSuggestionPicker from './base-suggestion-picker';
+import type { OnResponseAction } from '../utils/response-action';
 
 /**
  * Props for the TitlePicker component.
@@ -29,14 +30,11 @@ interface TitleOption {
 interface TitlePickerProps {
 	titles: TitleOption[];
 	onComplete?: () => void;
+	onResponseAction?: OnResponseAction;
 }
 
-/**
- * TitlePicker component for the chat sidebar.
- * @param {TitlePickerProps} props - Component props.
- * @returns {import('react').ReactElement} The rendered component.
- */
-export default function TitlePicker( { titles, onComplete }: TitlePickerProps ) {
+/** Renders title suggestions and applies the selected title to the post. */
+export default function TitlePicker( { titles, onComplete, onResponseAction }: TitlePickerProps ) {
 	const { editPost } = useDispatch( 'core/editor' );
 	const currentTitle = useSelect(
 		( select ) =>
@@ -52,9 +50,8 @@ export default function TitlePicker( { titles, onComplete }: TitlePickerProps ) 
 		( title: string ) => {
 			editPost( { title } );
 			notifySuggestionActionComplete();
-			onComplete?.();
 		},
-		[ editPost, onComplete ]
+		[ editPost ]
 	);
 
 	return (
@@ -62,8 +59,10 @@ export default function TitlePicker( { titles, onComplete }: TitlePickerProps ) 
 			intro={ __( 'Choose a title for your post:', __i18n_text_domain__ ) }
 			options={ titles.map( ( option ) => option.title ) }
 			onApply={ handleApply }
+			onComplete={ onComplete }
 			appliedMessage={ __( 'Title updated.', __i18n_text_domain__ ) }
 			currentValue={ typeof currentTitle === 'string' ? currentTitle : undefined }
+			onResponseAction={ onResponseAction }
 		/>
 	);
 }

--- a/packages/jetpack-ai-sidebar/src/global.d.ts
+++ b/packages/jetpack-ai-sidebar/src/global.d.ts
@@ -25,6 +25,8 @@ declare const __i18n_text_domain__: string;
 declare const agentsManagerData:
 	| {
 			isDevMode?: boolean;
+			/** Whether the current request is attributed to an Automattician for tracking. */
+			isA11n?: boolean;
 			jetpackAiSidebar?: {
 				enabled: boolean;
 				features?: {

--- a/packages/jetpack-ai-sidebar/src/global.d.ts
+++ b/packages/jetpack-ai-sidebar/src/global.d.ts
@@ -27,6 +27,8 @@ declare const agentsManagerData:
 			isDevMode?: boolean;
 			/** Whether the current request is attributed to an Automattician for tracking. */
 			isA11n?: boolean;
+			/** The site's canonical identity; injected on wp-admin. */
+			site?: { ID?: number; domain?: string };
 			jetpackAiSidebar?: {
 				enabled: boolean;
 				features?: {

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -327,15 +327,11 @@ function installAiEditorialReviewData( features: Record< string, boolean > = {} 
 function SuggestionsProbe( {
 	onSuggestions,
 	maxSuggestions,
-	suggestionsVisible = true,
 }: {
 	onSuggestions: ( suggestions: any[], replaceEmptyViewSuggestions?: boolean ) => void;
 	maxSuggestions?: number;
-	suggestionsVisible?: boolean;
 } ) {
-	const { suggestions, replaceEmptyViewSuggestions } = useSuggestions( maxSuggestions, {
-		suggestionsVisible,
-	} );
+	const { suggestions, replaceEmptyViewSuggestions } = useSuggestions( maxSuggestions );
 	React.useEffect( () => {
 		onSuggestions( suggestions, replaceEmptyViewSuggestions );
 	}, [ onSuggestions, replaceEmptyViewSuggestions, suggestions ] );
@@ -2181,25 +2177,6 @@ describe( 'useSuggestions', () => {
 		delete ( window as any ).wp;
 	} );
 
-	it( 'does not track rendered suggestions when the suggestions are not visible', () => {
-		installAiEditorialReviewData();
-		mockSelectedBlock = { clientId: 'b-hidden', name: 'core/paragraph' };
-		const onSuggestions = jest.fn();
-
-		render( React.createElement( SuggestionsProbe, { onSuggestions, suggestionsVisible: false } ) );
-
-		const latestSuggestions =
-			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
-		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
-			'Translate content',
-			'Change tone',
-			'Check grammar',
-			'Simplify text',
-		] );
-		expect( getTracksCalls( 'jetpack_ai_editorial_review_suggestion_rendered' ) ).toEqual( [] );
-		expect( getTracksCalls( 'jetpack_ai_block_transformation_suggestion_rendered' ) ).toEqual( [] );
-	} );
-
 	it( 'shows only block-specific suggestions when a block is selected', () => {
 		installAiEditorialReviewData();
 		mockSelectedBlock = { clientId: 'b1', name: 'core/paragraph' };
@@ -2216,44 +2193,6 @@ describe( 'useSuggestions', () => {
 			'Simplify text',
 		] );
 		expect( getTracksCalls( 'jetpack_ai_editorial_review_suggestion_rendered' ) ).toEqual( [] );
-		expect( getTracksCalls( 'jetpack_ai_block_transformation_suggestion_rendered' ) ).toEqual( [
-			[
-				'jetpack_ai_block_transformation_suggestion_rendered',
-				{
-					suggestion_id: 'translate',
-					suggestion_type: 'text',
-					block_type: 'core/paragraph',
-					surface: 'jetpack_ai_sidebar',
-				},
-			],
-			[
-				'jetpack_ai_block_transformation_suggestion_rendered',
-				{
-					suggestion_id: 'change-tone',
-					suggestion_type: 'text',
-					block_type: 'core/paragraph',
-					surface: 'jetpack_ai_sidebar',
-				},
-			],
-			[
-				'jetpack_ai_block_transformation_suggestion_rendered',
-				{
-					suggestion_id: 'check-grammar',
-					suggestion_type: 'text',
-					block_type: 'core/paragraph',
-					surface: 'jetpack_ai_sidebar',
-				},
-			],
-			[
-				'jetpack_ai_block_transformation_suggestion_rendered',
-				{
-					suggestion_id: 'simplify-text',
-					suggestion_type: 'text',
-					block_type: 'core/paragraph',
-					surface: 'jetpack_ai_sidebar',
-				},
-			],
-		] );
 	} );
 
 	it( 'replaces editor-level empty-view suggestions when a block is selected', () => {
@@ -2360,35 +2299,6 @@ describe( 'useSuggestions', () => {
 			'Change tone',
 			'Check grammar',
 		] );
-		expect( getTracksCalls( 'jetpack_ai_block_transformation_suggestion_rendered' ) ).toEqual( [
-			[
-				'jetpack_ai_block_transformation_suggestion_rendered',
-				{
-					suggestion_id: 'translate',
-					suggestion_type: 'text',
-					block_type: 'core/heading',
-					surface: 'jetpack_ai_sidebar',
-				},
-			],
-			[
-				'jetpack_ai_block_transformation_suggestion_rendered',
-				{
-					suggestion_id: 'change-tone',
-					suggestion_type: 'text',
-					block_type: 'core/heading',
-					surface: 'jetpack_ai_sidebar',
-				},
-			],
-			[
-				'jetpack_ai_block_transformation_suggestion_rendered',
-				{
-					suggestion_id: 'check-grammar',
-					suggestion_type: 'text',
-					block_type: 'core/heading',
-					surface: 'jetpack_ai_sidebar',
-				},
-			],
-		] );
 	} );
 
 	it( 'returns no suggestions after the selected-block chip is cleared', () => {
@@ -2430,17 +2340,6 @@ describe( 'useSuggestions', () => {
 			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
 		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
 			'Generate alt text',
-		] );
-		expect( getTracksCalls( 'jetpack_ai_block_transformation_suggestion_rendered' ) ).toEqual( [
-			[
-				'jetpack_ai_block_transformation_suggestion_rendered',
-				{
-					suggestion_id: 'generate-alt-text',
-					suggestion_type: 'image',
-					block_type: 'core/image',
-					surface: 'jetpack_ai_sidebar',
-				},
-			],
 		] );
 	} );
 
@@ -2543,7 +2442,6 @@ describe( 'useSuggestions', () => {
 
 		expect( mockSetIsSplitScreen ).not.toHaveBeenCalled();
 		expect( getTracksCalls( 'jetpack_ai_editorial_review_suggestion_click' ) ).toEqual( [] );
-		expect( getTracksCalls( 'jetpack_ai_block_transformation_suggestion_click' ) ).toEqual( [] );
 	} );
 
 	it( 'exposes tone and language dropdown options on the block suggestions', () => {

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -3117,6 +3117,41 @@ describe( 'toolProvider', () => {
 			expect( parsed.data.calypsoCheckpointId ).toBe( 'call_test_123' );
 			expect( parsed.data.isCurrent ).toBe( true );
 			expect( parsed.data.hideZoomAction ).toBe( true );
+			expect( parsed.data.responseTrackingProperties ).toBeUndefined();
+		} );
+
+		it.each( [
+			[ 'proofread', { items: [ {}, {} ] }, { suggested_edit_count: 2 } ],
+			[ 'post-feedback', { items: [ {} ] }, { suggested_edit_count: 1 } ],
+			[
+				'ai-editorial-review',
+				{
+					suggested_edits: [ {}, {} ],
+					conflicts: [ {} ],
+					implications: [],
+					guideline_violations: [
+						{ guideline_quote: 'Use sentence case.' },
+						{ guideline_quote: '' },
+						{ guideline_quote: 'Prefer active voice.' },
+					],
+					review_context: 'notes_and_guidelines',
+				},
+				{
+					suggested_edit_count: 2,
+					conflict_count: 1,
+					implication_count: 0,
+					guideline_violation_count: 2,
+					review_context: 'notes_and_guidelines',
+				},
+			],
+		] )( 'adds privacy-safe response metadata for %s', async ( type, props, expected ) => {
+			const { result } = ( await toolProvider.executeAbility( SHOW_COMPONENT_TOOL_ID, {
+				type,
+				props,
+			} ) ) as any;
+
+			const parsed = JSON.parse( result.agentMessage );
+			expect( parsed.data.responseTrackingProperties ).toEqual( expected );
 		} );
 
 		it( 'echoes the tool call id at the envelope top level', async () => {

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -2319,11 +2319,8 @@ describe( 'useSuggestions', () => {
 		expect( emptyViewLabels ).toContain( 'Optimize Title' );
 		expect( emptyViewLabels ).toContain( 'Editorial Review' );
 
-		// The rendered event fires once per page load (module-level guard), so
-		// only the first render with the chip available can assert it — which is
-		// this test: every earlier test either selects a block or uses an
-		// unsupported post type.
-		expect( getTracksCalls( 'jetpack_ai_editorial_review_suggestion_rendered' ) ).toHaveLength( 1 );
+		// Chip exposure is tracked by Agents Manager's jetpack_big_sky_chat_suggestions_rendered.
+		expect( getTracksCalls( 'jetpack_ai_editorial_review_suggestion_rendered' ) ).toEqual( [] );
 	} );
 
 	it( 'keeps selected-block suggestions on template entities', () => {
@@ -2418,6 +2415,8 @@ describe( 'useSuggestions', () => {
 		latestSuggestions =
 			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
 		expect( latestSuggestions ).toEqual( [] );
+		// Chip exposure is tracked by Agents Manager's jetpack_big_sky_chat_suggestions_rendered.
+		expect( getTracksCalls( 'jetpack_ai_editorial_review_suggestion_rendered' ) ).toEqual( [] );
 	} );
 
 	it( 'tracks rendered image block transformation suggestions', () => {

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -65,6 +65,7 @@ import {
 	UPDATE_BLOCK_CONTENT_ABILITY,
 	isUpdateBlockContentTool,
 } from './utils/tool-provider';
+import { getResponseRenderedTrackingProperties } from './utils/tracking';
 import type { SuggestionOption } from '@automattic/agenttic-client';
 import type { ComponentType } from 'react';
 
@@ -463,6 +464,10 @@ function handleShowComponent( input: any ): any {
 		isCurrent: true,
 		hideZoomAction: true,
 	};
+	const responseTrackingProperties = getResponseRenderedTrackingProperties( type, componentProps );
+	if ( responseTrackingProperties ) {
+		data.responseTrackingProperties = responseTrackingProperties;
+	}
 	if ( type === 'ai-editorial-review' || type === 'post-feedback' || type === 'proofread' ) {
 		const reviewedPostId =
 			normalizeEditorPostId( componentProps.postId ) ?? getCurrentEditorPostId();

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -67,7 +67,6 @@ import {
 } from './utils/tool-provider';
 import {
 	type BlockTransformationSuggestionType,
-	trackAiEditorialReviewSuggestionRendered,
 	trackBlockTransformationSuggestionRendered,
 } from './utils/tracking';
 import type { SuggestionOption } from '@automattic/agenttic-client';
@@ -93,10 +92,6 @@ type BlockEditSnapshot = {
 };
 
 const blockEditSnapshots = new Map< string, BlockEditSnapshot >();
-
-/** Whether `_suggestion_rendered` has fired this page life (once-per-session). */
-let suggestionRenderedFiredOnce = false;
-
 /** Block transformation suggestions whose rendered event has fired this page life. */
 const blockTransformationSuggestionRenderedKeys = new Set< string >();
 
@@ -315,14 +310,6 @@ function isProofreadAvailable(
 	return (
 		isProofreadEnabled() && isEditorLevelSuggestionPostType( currentPostType ) && !! currentPostId
 	);
-}
-
-function trackAiEditorialReviewSuggestionRenderedOnce(): void {
-	if ( suggestionRenderedFiredOnce ) {
-		return;
-	}
-	suggestionRenderedFiredOnce = true;
-	trackAiEditorialReviewSuggestionRendered();
 }
 
 function getAiEditorialReviewSuggestions( currentPostType?: string ) {
@@ -1394,24 +1381,12 @@ export function useSuggestions(
 	const visibleBlockTransformationSuggestionsKey = visibleBlockTransformationSuggestions
 		.map( ( suggestion ) => suggestion.id )
 		.join( '|' );
-	// The AI Editorial Review chip renders through the empty view, which is a
-	// plain function with no render signal, so the availability that puts the
-	// chip there is tracked from this hook instead.
-	const isAiEditorialReviewSuggestionAvailable =
-		! selectedBlock && isAiEditorialReviewAvailable( editorContext.postType );
 
 	useEffect( () => {
 		if ( editorContext.selectedBlock ) {
 			rememberSelectedBlock( editorContext.selectedBlock );
 		}
 	}, [ editorContext.selectedBlock?.clientId, editorContext.selectedBlock ] );
-
-	useEffect( () => {
-		if ( ! suggestionsVisible || hidden || ! isAiEditorialReviewSuggestionAvailable ) {
-			return;
-		}
-		trackAiEditorialReviewSuggestionRenderedOnce();
-	}, [ hidden, isAiEditorialReviewSuggestionAvailable, suggestionsVisible ] );
 
 	useEffect( () => {
 		if (

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -65,10 +65,6 @@ import {
 	UPDATE_BLOCK_CONTENT_ABILITY,
 	isUpdateBlockContentTool,
 } from './utils/tool-provider';
-import {
-	type BlockTransformationSuggestionType,
-	trackBlockTransformationSuggestionRendered,
-} from './utils/tracking';
 import type { SuggestionOption } from '@automattic/agenttic-client';
 import type { ComponentType } from 'react';
 
@@ -92,9 +88,6 @@ type BlockEditSnapshot = {
 };
 
 const blockEditSnapshots = new Map< string, BlockEditSnapshot >();
-/** Block transformation suggestions whose rendered event has fired this page life. */
-const blockTransformationSuggestionRenderedKeys = new Set< string >();
-
 /** Default suggestion shown when no block is selected. */
 const OPTIMIZE_TITLE_SUGGESTION = {
 	id: 'optimize-title',
@@ -1015,7 +1008,6 @@ type BlockSuggestion = {
 	id: string;
 	label: string;
 	prompt: string;
-	type: BlockTransformationSuggestionType;
 	condition: ( block: any ) => boolean;
 	options?: SuggestionOption[];
 	// Runs on click instead of sending the prompt. AgentUI submits the prompt
@@ -1148,7 +1140,6 @@ const BLOCK_SUGGESTIONS: BlockSuggestion[] = [
 		label: __( 'Translate content', __i18n_text_domain__ ),
 		// Empty prompt — the picked option's `value` is the full prompt sent.
 		prompt: '',
-		type: 'text',
 		condition: ( block: any ) => TEXT_BLOCK_TYPES.includes( block?.name ),
 		options: TRANSLATE_LANGUAGE_OPTIONS,
 	},
@@ -1156,7 +1147,6 @@ const BLOCK_SUGGESTIONS: BlockSuggestion[] = [
 		id: 'change-tone',
 		label: __( 'Change tone', __i18n_text_domain__ ),
 		prompt: '',
-		type: 'text',
 		condition: ( block: any ) => TEXT_BLOCK_TYPES.includes( block?.name ),
 		options: CHANGE_TONE_OPTIONS,
 	},
@@ -1164,21 +1154,18 @@ const BLOCK_SUGGESTIONS: BlockSuggestion[] = [
 		id: 'check-grammar',
 		label: __( 'Check grammar', __i18n_text_domain__ ),
 		prompt: __( 'Check the grammar and spelling of this text', __i18n_text_domain__ ),
-		type: 'text',
 		condition: ( block: any ) => TEXT_BLOCK_TYPES.includes( block?.name ),
 	},
 	{
 		id: 'simplify-text',
 		label: __( 'Simplify text', __i18n_text_domain__ ),
 		prompt: __( 'Simplify this text to make it easier to read', __i18n_text_domain__ ),
-		type: 'text',
 		condition: ( block: any ) => TEXT_BLOCK_TYPES.includes( block?.name ),
 	},
 	{
 		id: 'generate-alt-text',
 		label: __( 'Generate alt text', __i18n_text_domain__ ),
 		prompt: __( 'Generate descriptive alt text for this image', __i18n_text_domain__ ),
-		type: 'image',
 		condition: ( block: any ) => IMAGE_BLOCK_TYPES.includes( block?.name ),
 	},
 	{
@@ -1186,7 +1173,6 @@ const BLOCK_SUGGESTIONS: BlockSuggestion[] = [
 		label: __( 'Generate image', __i18n_text_domain__ ),
 		// Empty prompt — opening Image Studio replaces sending anything to the agent.
 		prompt: '',
-		type: 'image',
 		condition: ( block: any ) => block?.name === 'core/image' && isImageStudioAvailable(),
 		action: () => ! openImageStudioForBlock( getSelectedOrRememberedBlock(), 'generate' ),
 	},
@@ -1194,34 +1180,11 @@ const BLOCK_SUGGESTIONS: BlockSuggestion[] = [
 		id: 'edit-image',
 		label: __( 'Edit image', __i18n_text_domain__ ),
 		prompt: '',
-		type: 'image',
 		condition: ( block: any ) =>
 			block?.name === 'core/image' && !! block?.attributes?.id && isImageStudioAvailable(),
 		action: () => ! openImageStudioForBlock( getSelectedOrRememberedBlock(), 'edit' ),
 	},
 ];
-
-function trackRenderedBlockTransformationSuggestions(
-	suggestions: BlockSuggestion[],
-	block: any
-): void {
-	if ( typeof block?.name !== 'string' ) {
-		return;
-	}
-
-	suggestions.forEach( ( suggestion ) => {
-		const renderedKey = `${ suggestion.id }:${ block.name }`;
-		if ( blockTransformationSuggestionRenderedKeys.has( renderedKey ) ) {
-			return;
-		}
-		blockTransformationSuggestionRenderedKeys.add( renderedKey );
-		trackBlockTransformationSuggestionRendered( {
-			suggestionId: suggestion.id,
-			suggestionType: suggestion.type,
-			blockType: block.name,
-		} );
-	} );
-}
 
 // ---------- capabilities ----------
 
@@ -1248,10 +1211,7 @@ export const capabilities = {
  * while the chat and its input are empty.
  * @returns {Object} Object containing a suggestions array.
  */
-export function useSuggestions(
-	maxSuggestions?: number,
-	{ suggestionsVisible = true }: { suggestionsVisible?: boolean } = {}
-): {
+export function useSuggestions( maxSuggestions?: number ): {
 	suggestions: Array< {
 		id: string;
 		label: string;
@@ -1370,48 +1330,11 @@ export function useSuggestions(
 		}
 		return applySuggestionLimit( blockTransformationSuggestions, maxSuggestions );
 	}, [ blockTransformationSuggestions, hidden, maxSuggestions, selectedBlock ] );
-	const visibleSuggestionIds = useMemo(
-		() => new Set( visibleSuggestions.map( ( suggestion ) => suggestion.id ) ),
-		[ visibleSuggestions ]
-	);
-	const visibleBlockTransformationSuggestions = useMemo(
-		() => applicable.filter( ( suggestion ) => visibleSuggestionIds.has( suggestion.id ) ),
-		[ applicable, visibleSuggestionIds ]
-	);
-	const visibleBlockTransformationSuggestionsKey = visibleBlockTransformationSuggestions
-		.map( ( suggestion ) => suggestion.id )
-		.join( '|' );
-
 	useEffect( () => {
 		if ( editorContext.selectedBlock ) {
 			rememberSelectedBlock( editorContext.selectedBlock );
 		}
 	}, [ editorContext.selectedBlock?.clientId, editorContext.selectedBlock ] );
-
-	useEffect( () => {
-		if (
-			! suggestionsVisible ||
-			hidden ||
-			! selectedBlock ||
-			! blockTransformationsEnabled ||
-			visibleBlockTransformationSuggestions.length === 0
-		) {
-			return;
-		}
-		trackRenderedBlockTransformationSuggestions(
-			visibleBlockTransformationSuggestions,
-			selectedBlock
-		);
-	}, [
-		blockTransformationsEnabled,
-		hidden,
-		selectedBlock,
-		selectedBlock?.name,
-		suggestionsVisible,
-		visibleBlockTransformationSuggestions,
-		visibleBlockTransformationSuggestions.length,
-		visibleBlockTransformationSuggestionsKey,
-	] );
 
 	return {
 		suggestions: visibleSuggestions,

--- a/packages/jetpack-ai-sidebar/src/utils/response-action.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/response-action.ts
@@ -1,0 +1,29 @@
+export interface ResponseAction {
+	action: 'accept' | 'bulk_accept' | 'dismiss' | 'undo';
+	target: ResponseActionTarget;
+	outcome: ResponseActionOutcome;
+	itemCount?: number;
+}
+
+export type ResponseActionOutcome = 'success' | 'failed' | 'partial_failed';
+
+export type ResponseActionTarget =
+	| 'conflict'
+	| 'edit'
+	| 'guideline_violation'
+	| 'image'
+	| 'mixed'
+	| 'option';
+
+export type OnResponseAction = ( action: ResponseAction ) => void;
+
+/** Maps all-success, all-failed, and mixed bulk results to one outcome. */
+export function getBulkResponseActionOutcome(
+	successCount: number,
+	failureCount: number
+): ResponseActionOutcome {
+	if ( failureCount === 0 ) {
+		return 'success';
+	}
+	return successCount === 0 ? 'failed' : 'partial_failed';
+}

--- a/packages/jetpack-ai-sidebar/src/utils/tracking.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tracking.test.ts
@@ -56,6 +56,7 @@ describe( 'Jetpack AI sidebar tracking', () => {
 		( globalThis as Record< string, unknown > ).agentsManagerData = {
 			isDevMode: false,
 			isA11n: false,
+			site: { ID: 12345 },
 		};
 		window.bigSkyInitialState = {
 			isFreeTrial: '',
@@ -79,6 +80,7 @@ describe( 'Jetpack AI sidebar tracking', () => {
 		trackSplitScreenGuideClick( { componentType: 'post-feedback' } );
 
 		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith( 'jetpack_ai_split_screen_guide_click', {
+			blog_id: 12345,
 			component_type: 'post-feedback',
 			guide_variant: 'inline_action_card',
 			is_test: false,
@@ -99,6 +101,7 @@ describe( 'Jetpack AI sidebar tracking', () => {
 		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
 			'jetpack_ai_split_screen_guide_rendered',
 			{
+				blog_id: 12345,
 				component_type: 'ai-editorial-review',
 				guide_variant: 'inline_action_card',
 				is_test: false,
@@ -134,6 +137,18 @@ describe( 'Jetpack AI sidebar tracking', () => {
 		trackSplitScreenGuideClick( { componentType: 'proofread' } );
 
 		expect( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ] ).not.toHaveProperty( 'is_a11n' );
+	} );
+
+	it( 'omits blog_id when the server payload has no valid site ID', () => {
+		( globalThis as Record< string, unknown > ).agentsManagerData = {
+			isDevMode: false,
+			isA11n: false,
+			site: { ID: 0 },
+		};
+
+		trackSplitScreenGuideClick( { componentType: 'proofread' } );
+
+		expect( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ] ).not.toHaveProperty( 'blog_id' );
 	} );
 
 	it( 'uses Agents Manager test and Big Sky free-trial and screen context', () => {

--- a/packages/jetpack-ai-sidebar/src/utils/tracking.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tracking.test.ts
@@ -11,7 +11,11 @@ jest.mock( '@wordpress/data', () => ( {
 
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { select } from '@wordpress/data';
-import { trackSplitScreenGuideClick, trackSplitScreenGuideRendered } from './tracking';
+import {
+	getResponseRenderedTrackingProperties,
+	trackSplitScreenGuideClick,
+	trackSplitScreenGuideRendered,
+} from './tracking';
 
 const mockedRecordTracksEvent = recordTracksEvent as jest.MockedFunction<
 	typeof recordTracksEvent
@@ -93,6 +97,53 @@ describe( 'Jetpack AI sidebar tracking', () => {
 		expectPrivacySafePayload( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ], {
 			allowPostType: true,
 		} );
+	} );
+
+	it.each( [ 'proofread', 'post-feedback' ] )(
+		'counts suggested edits in %s responses',
+		( componentType ) => {
+			expect(
+				getResponseRenderedTrackingProperties( componentType, {
+					items: [ { title: 'First' }, null, { title: 'Second' } ],
+				} )
+			).toEqual( { suggested_edit_count: 2 } );
+		}
+	);
+
+	it( 'counts each AI Editorial Review finding type', () => {
+		expect(
+			getResponseRenderedTrackingProperties( 'ai-editorial-review', {
+				suggested_edits: [ {}, {} ],
+				conflicts: [ {} ],
+				implications: [ {}, null ],
+				guideline_violations: [
+					{ guideline_quote: 'Use sentence case.' },
+					{ guideline_quote: '' },
+					{ guideline_quote: 'Prefer active voice.' },
+				],
+				review_context: 'notes_and_guidelines',
+			} )
+		).toEqual( {
+			suggested_edit_count: 2,
+			conflict_count: 1,
+			implication_count: 1,
+			guideline_violation_count: 2,
+			review_context: 'notes_and_guidelines',
+		} );
+	} );
+
+	it( 'omits an unknown AI Editorial Review context', () => {
+		expect(
+			getResponseRenderedTrackingProperties( 'ai-editorial-review', {
+				review_context: 'unknown-context',
+			} )
+		).not.toHaveProperty( 'review_context' );
+	} );
+
+	it( 'omits response metadata for components without review findings', () => {
+		expect(
+			getResponseRenderedTrackingProperties( 'title-picker', { titles: [ { title: 'Title' } ] } )
+		).toBeUndefined();
 	} );
 
 	it( 'tracks a split-screen guide impression with stable component metadata', () => {

--- a/packages/jetpack-ai-sidebar/src/utils/tracking.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tracking.test.ts
@@ -11,11 +11,7 @@ jest.mock( '@wordpress/data', () => ( {
 
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { select } from '@wordpress/data';
-import {
-	trackBlockTransformationSuggestionRendered,
-	trackSplitScreenGuideClick,
-	trackSplitScreenGuideRendered,
-} from './tracking';
+import { trackSplitScreenGuideClick, trackSplitScreenGuideRendered } from './tracking';
 
 const mockedRecordTracksEvent = recordTracksEvent as jest.MockedFunction<
 	typeof recordTracksEvent
@@ -79,27 +75,6 @@ describe( 'Jetpack AI sidebar tracking', () => {
 		delete ( window as WindowWithAgentsManagerActions ).__agentsManagerActions;
 	} );
 
-	it( 'tracks block transformation suggestion exposure with stable metadata', () => {
-		trackBlockTransformationSuggestionRendered( {
-			suggestionId: 'check-grammar',
-			suggestionType: 'text',
-			blockType: 'core/paragraph',
-		} );
-
-		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
-			'jetpack_ai_block_transformation_suggestion_rendered',
-			{
-				suggestion_id: 'check-grammar',
-				suggestion_type: 'text',
-				block_type: 'core/paragraph',
-				surface: 'jetpack_ai_sidebar',
-				sessionid: 'test-session-id',
-				is_a11n: false,
-			}
-		);
-		expectPrivacySafePayload( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ] );
-	} );
-
 	it( 'tracks split-screen guide clicks with stable component metadata', () => {
 		trackSplitScreenGuideClick( { componentType: 'post-feedback' } );
 
@@ -145,14 +120,10 @@ describe( 'Jetpack AI sidebar tracking', () => {
 			isA11n: true,
 		};
 
-		trackBlockTransformationSuggestionRendered( {
-			suggestionId: 'check-grammar',
-			suggestionType: 'text',
-			blockType: 'core/paragraph',
-		} );
+		trackSplitScreenGuideClick( { componentType: 'proofread' } );
 
 		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
-			'jetpack_ai_block_transformation_suggestion_rendered',
+			'jetpack_ai_split_screen_guide_click',
 			expect.objectContaining( { is_a11n: true } )
 		);
 	} );
@@ -160,11 +131,7 @@ describe( 'Jetpack AI sidebar tracking', () => {
 	it( 'omits is_a11n when the server payload predates the signal', () => {
 		( globalThis as Record< string, unknown > ).agentsManagerData = { isDevMode: false };
 
-		trackBlockTransformationSuggestionRendered( {
-			suggestionId: 'check-grammar',
-			suggestionType: 'text',
-			blockType: 'core/paragraph',
-		} );
+		trackSplitScreenGuideClick( { componentType: 'proofread' } );
 
 		expect( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ] ).not.toHaveProperty( 'is_a11n' );
 	} );

--- a/packages/jetpack-ai-sidebar/src/utils/tracking.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tracking.test.ts
@@ -57,7 +57,10 @@ type WindowWithAgentsManagerActions = Window & {
 describe( 'Jetpack AI sidebar tracking', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		( globalThis as Record< string, unknown > ).agentsManagerData = { isDevMode: false };
+		( globalThis as Record< string, unknown > ).agentsManagerData = {
+			isDevMode: false,
+			isA11n: false,
+		};
 		window.bigSkyInitialState = {
 			isFreeTrial: '',
 			currentScreen: { screen: 'post' },
@@ -91,6 +94,7 @@ describe( 'Jetpack AI sidebar tracking', () => {
 				block_type: 'core/paragraph',
 				surface: 'jetpack_ai_sidebar',
 				sessionid: 'test-session-id',
+				is_a11n: false,
 			}
 		);
 		expectPrivacySafePayload( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ] );
@@ -103,6 +107,7 @@ describe( 'Jetpack AI sidebar tracking', () => {
 			component_type: 'post-feedback',
 			guide_variant: 'inline_action_card',
 			is_test: false,
+			is_a11n: false,
 			post_type: 'post',
 			screen: 'post',
 			sessionid: 'test-session-id',
@@ -122,6 +127,7 @@ describe( 'Jetpack AI sidebar tracking', () => {
 				component_type: 'ai-editorial-review',
 				guide_variant: 'inline_action_card',
 				is_test: false,
+				is_a11n: false,
 				post_type: 'post',
 				screen: 'post',
 				sessionid: 'test-session-id',
@@ -131,6 +137,36 @@ describe( 'Jetpack AI sidebar tracking', () => {
 		expectPrivacySafePayload( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ], {
 			allowPostType: true,
 		} );
+	} );
+
+	it( 'uses the server-provided Automattician tracking value', () => {
+		( globalThis as Record< string, unknown > ).agentsManagerData = {
+			isDevMode: false,
+			isA11n: true,
+		};
+
+		trackBlockTransformationSuggestionRendered( {
+			suggestionId: 'check-grammar',
+			suggestionType: 'text',
+			blockType: 'core/paragraph',
+		} );
+
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_ai_block_transformation_suggestion_rendered',
+			expect.objectContaining( { is_a11n: true } )
+		);
+	} );
+
+	it( 'omits is_a11n when the server payload predates the signal', () => {
+		( globalThis as Record< string, unknown > ).agentsManagerData = { isDevMode: false };
+
+		trackBlockTransformationSuggestionRendered( {
+			suggestionId: 'check-grammar',
+			suggestionType: 'text',
+			blockType: 'core/paragraph',
+		} );
+
+		expect( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ] ).not.toHaveProperty( 'is_a11n' );
 	} );
 
 	it( 'uses Agents Manager test and Big Sky free-trial and screen context', () => {

--- a/packages/jetpack-ai-sidebar/src/utils/tracking.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tracking.test.ts
@@ -12,9 +12,6 @@ jest.mock( '@wordpress/data', () => ( {
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { select } from '@wordpress/data';
 import {
-	trackAiEditorialReviewItemAction,
-	trackAiEditorialReviewResultRendered,
-	trackAiEditorialReviewSuggestionRendered,
 	trackBlockTransformationSuggestionRendered,
 	trackSplitScreenGuideClick,
 	trackSplitScreenGuideRendered,
@@ -77,64 +74,6 @@ describe( 'Jetpack AI sidebar tracking', () => {
 		delete ( globalThis as Record< string, unknown > ).agentsManagerData;
 		delete window.bigSkyInitialState;
 		delete ( window as WindowWithAgentsManagerActions ).__agentsManagerActions;
-	} );
-
-	it( 'tracks suggestion exposure with only session context', () => {
-		trackAiEditorialReviewSuggestionRendered();
-
-		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
-			'jetpack_ai_editorial_review_suggestion_rendered',
-			{
-				sessionid: 'test-session-id',
-			}
-		);
-		expectPrivacySafePayload( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ] );
-	} );
-
-	it( 'tracks rendered results as aggregate usefulness counts', () => {
-		trackAiEditorialReviewResultRendered( {
-			outcome: 'success',
-			conflictCount: 2,
-			implicationCount: 3,
-			suggestedEditCount: 8,
-			guidelineViolationCount: 0,
-			reviewContext: 'notes_and_guidelines',
-		} );
-
-		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
-			'jetpack_ai_editorial_review_result_rendered',
-			{
-				outcome: 'success',
-				conflict_count: 2,
-				implication_count: 3,
-				suggested_edit_count: 8,
-				guideline_violation_count: 0,
-				review_context: 'notes_and_guidelines',
-				sessionid: 'test-session-id',
-			}
-		);
-		expectPrivacySafePayload( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ] );
-	} );
-
-	it( 'tracks item actions after completion without row identifiers', () => {
-		trackAiEditorialReviewItemAction( {
-			action: 'bulk_accept',
-			target: 'mixed',
-			outcome: 'partial_failed',
-			itemCount: 4,
-		} );
-
-		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
-			'jetpack_ai_editorial_review_item_action',
-			{
-				action: 'bulk_accept',
-				target: 'mixed',
-				outcome: 'partial_failed',
-				item_count: 4,
-				sessionid: 'test-session-id',
-			}
-		);
-		expectPrivacySafePayload( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ] );
 	} );
 
 	it( 'tracks block transformation suggestion exposure with stable metadata', () => {

--- a/packages/jetpack-ai-sidebar/src/utils/tracking.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tracking.ts
@@ -67,13 +67,23 @@ function getIsA11n(): boolean | undefined {
 	return typeof isA11n === 'boolean' ? isA11n : undefined;
 }
 
+/** Reads the canonical server-provided blog ID when available. */
+function getBlogId(): number | undefined {
+	const blogId = typeof agentsManagerData !== 'undefined' ? agentsManagerData?.site?.ID : undefined;
+	return typeof blogId === 'number' && Number.isInteger( blogId ) && blogId > 0
+		? blogId
+		: undefined;
+}
+
 function recordTracksEvent( eventName: string, properties: TrackProperties = {} ): void {
 	const sessionId = getSessionId();
 	const isA11n = getIsA11n();
+	const blogId = getBlogId();
 	recordTracksEventBase( `${ TRACKS_PREFIX }_${ eventName }`, {
 		...properties,
 		...( sessionId ? { sessionid: sessionId } : {} ),
 		...( isA11n !== undefined ? { is_a11n: isA11n } : {} ),
+		...( blogId !== undefined ? { blog_id: blogId } : {} ),
 	} );
 }
 

--- a/packages/jetpack-ai-sidebar/src/utils/tracking.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tracking.ts
@@ -69,29 +69,6 @@ function recordTracksEvent( eventName: string, properties: TrackProperties = {} 
 	} );
 }
 
-export type ReviewContext =
-	| 'notes_and_guidelines'
-	| 'notes_only'
-	| 'guidelines_only'
-	| 'content_only'
-	| 'insufficient_input';
-
-interface TrackAiEditorialReviewResultRenderedOptions {
-	outcome: 'success' | 'cache_hit' | 'no_findings' | 'insufficient_input';
-	conflictCount: number;
-	implicationCount: number;
-	suggestedEditCount: number;
-	guidelineViolationCount: number;
-	reviewContext?: ReviewContext;
-}
-
-interface TrackAiEditorialReviewItemActionOptions {
-	action: 'accept' | 'undo' | 'dismiss' | 'bulk_accept';
-	target: 'edit' | 'conflict' | 'mixed';
-	outcome: 'success' | 'failed' | 'partial_failed';
-	itemCount?: number;
-}
-
 export type BlockTransformationSuggestionType = 'text' | 'image';
 
 interface TrackBlockTransformationSuggestionOptions {
@@ -117,13 +94,6 @@ function getSplitScreenGuideProperties( {
 		session_type: bigSky.sessionType,
 		screen: bigSky.screen,
 	};
-}
-
-/**
- * Tracks the AI Editorial Review empty-view suggestion appearing.
- */
-export function trackAiEditorialReviewSuggestionRendered(): void {
-	recordTracksEvent( 'ai_editorial_review_suggestion_rendered' );
 }
 
 /**
@@ -162,60 +132,4 @@ export function trackSplitScreenGuideRendered( options: TrackSplitScreenGuideOpt
  */
 export function trackSplitScreenGuideClick( options: TrackSplitScreenGuideOptions ): void {
 	recordTracksEvent( 'ai_split_screen_guide_click', getSplitScreenGuideProperties( options ) );
-}
-
-/**
- * Tracks the review card mounting and becoming visible to the user.
- * @param options                          - Tracking options
- * @param options.outcome                  - High-level outcome: success, cache_hit, no_findings, or insufficient_input
- * @param options.conflictCount            - Number of conflict items in the payload
- * @param options.implicationCount         - Number of implication items in the payload
- * @param options.suggestedEditCount       - Total number of suggested edits
- * @param options.guidelineViolationCount  - Number of guideline violations in the payload
- * @param options.reviewContext            - Server-selected context used for this review
- */
-export function trackAiEditorialReviewResultRendered( {
-	outcome,
-	conflictCount,
-	implicationCount,
-	suggestedEditCount,
-	guidelineViolationCount,
-	reviewContext,
-}: TrackAiEditorialReviewResultRenderedOptions ): void {
-	const properties: TrackProperties = {
-		outcome,
-		conflict_count: conflictCount,
-		implication_count: implicationCount,
-		suggested_edit_count: suggestedEditCount,
-		guideline_violation_count: guidelineViolationCount,
-	};
-	if ( reviewContext !== undefined ) {
-		properties.review_context = reviewContext;
-	}
-	recordTracksEvent( 'ai_editorial_review_result_rendered', properties );
-}
-
-/**
- * Tracks a user action on an AI Editorial Review row.
- * @param options                - Tracking options
- * @param options.action         - Action verb
- * @param options.target         - Suggested edit, conflict, or mixed bulk action
- * @param options.outcome        - Whether the action completed successfully
- * @param options.itemCount      - (optional) Number of items attempted
- */
-export function trackAiEditorialReviewItemAction( {
-	action,
-	target,
-	outcome,
-	itemCount,
-}: TrackAiEditorialReviewItemActionOptions ): void {
-	const properties: TrackProperties = {
-		action,
-		target,
-		outcome,
-	};
-	if ( itemCount !== undefined ) {
-		properties.item_count = itemCount;
-	}
-	recordTracksEvent( 'ai_editorial_review_item_action', properties );
 }

--- a/packages/jetpack-ai-sidebar/src/utils/tracking.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tracking.ts
@@ -77,14 +77,6 @@ function recordTracksEvent( eventName: string, properties: TrackProperties = {} 
 	} );
 }
 
-export type BlockTransformationSuggestionType = 'text' | 'image';
-
-interface TrackBlockTransformationSuggestionOptions {
-	suggestionId: string;
-	suggestionType: BlockTransformationSuggestionType;
-	blockType: string;
-}
-
 interface TrackSplitScreenGuideOptions {
 	componentType: string;
 }
@@ -102,26 +94,6 @@ function getSplitScreenGuideProperties( {
 		session_type: bigSky.sessionType,
 		screen: bigSky.screen,
 	};
-}
-
-/**
- * Tracks a block transformation suggestion appearing for a selected block.
- * @param options                - Tracking options
- * @param options.suggestionId   - Stable suggestion identifier.
- * @param options.suggestionType - Transformation category.
- * @param options.blockType      - Core block type the suggestion applies to.
- */
-export function trackBlockTransformationSuggestionRendered( {
-	suggestionId,
-	suggestionType,
-	blockType,
-}: TrackBlockTransformationSuggestionOptions ): void {
-	recordTracksEvent( 'ai_block_transformation_suggestion_rendered', {
-		suggestion_id: suggestionId,
-		suggestion_type: suggestionType,
-		block_type: blockType,
-		surface: 'jetpack_ai_sidebar',
-	} );
 }
 
 /**

--- a/packages/jetpack-ai-sidebar/src/utils/tracking.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tracking.ts
@@ -61,11 +61,19 @@ function getIsTest(): boolean {
 	return typeof agentsManagerData !== 'undefined' && !! agentsManagerData?.isDevMode;
 }
 
+/** Reads the optional server-provided Automattician tracking signal. */
+function getIsA11n(): boolean | undefined {
+	const isA11n = typeof agentsManagerData !== 'undefined' ? agentsManagerData?.isA11n : undefined;
+	return typeof isA11n === 'boolean' ? isA11n : undefined;
+}
+
 function recordTracksEvent( eventName: string, properties: TrackProperties = {} ): void {
 	const sessionId = getSessionId();
+	const isA11n = getIsA11n();
 	recordTracksEventBase( `${ TRACKS_PREFIX }_${ eventName }`, {
 		...properties,
 		...( sessionId ? { sessionid: sessionId } : {} ),
+		...( isA11n !== undefined ? { is_a11n: isA11n } : {} ),
 	} );
 }
 

--- a/packages/jetpack-ai-sidebar/src/utils/tracking.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tracking.ts
@@ -9,6 +9,29 @@ const TRACKS_PREFIX = 'jetpack';
 
 type TrackProperties = Record< string, string | number | boolean >;
 
+type ReviewContext =
+	| 'notes_and_guidelines'
+	| 'notes_only'
+	| 'guidelines_only'
+	| 'content_only'
+	| 'insufficient_input';
+
+type ResponseRenderedTrackingProperties = {
+	suggested_edit_count: number;
+	conflict_count?: number;
+	implication_count?: number;
+	guideline_violation_count?: number;
+	review_context?: ReviewContext;
+};
+
+const REVIEW_CONTEXTS: ReadonlySet< string > = new Set< ReviewContext >( [
+	'notes_and_guidelines',
+	'notes_only',
+	'guidelines_only',
+	'content_only',
+	'insufficient_input',
+] );
+
 type WindowWithAgentsManagerActions = Window & {
 	__agentsManagerActions?: {
 		getSessionId?: () => unknown;
@@ -73,6 +96,56 @@ function getBlogId(): number | undefined {
 	return typeof blogId === 'number' && Number.isInteger( blogId ) && blogId > 0
 		? blogId
 		: undefined;
+}
+
+/** Counts the non-null entries that a review response can render. */
+function countResponseItems( value: unknown ): number {
+	return Array.isArray( value ) ? value.filter( ( item ) => item != null ).length : 0;
+}
+
+/** Counts guideline findings that have the quote required by the rendered card. */
+function countRenderableGuidelineViolations( value: unknown ): number {
+	if ( ! Array.isArray( value ) ) {
+		return 0;
+	}
+
+	return value.filter( ( item ) => {
+		if ( typeof item !== 'object' || item === null ) {
+			return false;
+		}
+		const quote = ( item as Record< string, unknown > ).guideline_quote;
+		return typeof quote === 'string' && quote.trim() !== '';
+	} ).length;
+}
+
+/** Accepts only the review-context vocabulary supplied by the AER server response. */
+function getReviewContext( value: unknown ): ReviewContext | undefined {
+	return typeof value === 'string' && REVIEW_CONTEXTS.has( value )
+		? ( value as ReviewContext )
+		: undefined;
+}
+
+/** Builds privacy-safe tracking metadata from Jetpack AI's known review payloads. */
+export function getResponseRenderedTrackingProperties(
+	componentType: string,
+	props: Record< string, unknown >
+): ResponseRenderedTrackingProperties | undefined {
+	if ( componentType === 'proofread' || componentType === 'post-feedback' ) {
+		return { suggested_edit_count: countResponseItems( props.items ) };
+	}
+
+	if ( componentType === 'ai-editorial-review' ) {
+		const reviewContext = getReviewContext( props.review_context );
+		return {
+			suggested_edit_count: countResponseItems( props.suggested_edits ),
+			conflict_count: countResponseItems( props.conflicts ),
+			implication_count: countResponseItems( props.implications ),
+			guideline_violation_count: countRenderableGuidelineViolations( props.guideline_violations ),
+			...( reviewContext ? { review_context: reviewContext } : {} ),
+		};
+	}
+
+	return undefined;
 }
 
 function recordTracksEvent( eventName: string, properties: TrackProperties = {} ): void {

--- a/packages/jetpack-ai-sidebar/src/utils/use-latest-response-action.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/use-latest-response-action.ts
@@ -1,0 +1,28 @@
+import { useCallback, useEffect, useRef } from '@wordpress/element';
+import type { OnResponseAction } from './response-action';
+
+/** Uses live host and post context, revoking dispatch when the response becomes stale or unmounts. */
+export default function useLatestResponseAction(
+	onResponseAction?: OnResponseAction,
+	isResponseStale?: () => boolean
+): OnResponseAction {
+	const onResponseActionRef = useRef( onResponseAction );
+	const isResponseStaleRef = useRef( isResponseStale );
+	onResponseActionRef.current = onResponseAction;
+	isResponseStaleRef.current = isResponseStale;
+	useEffect( () => {
+		onResponseActionRef.current = onResponseAction;
+		isResponseStaleRef.current = isResponseStale;
+		return () => {
+			onResponseActionRef.current = undefined;
+			isResponseStaleRef.current = undefined;
+		};
+	}, [ isResponseStale, onResponseAction ] );
+
+	return useCallback< OnResponseAction >( ( action ) => {
+		if ( isResponseStaleRef.current?.() ) {
+			return;
+		}
+		onResponseActionRef.current?.( action );
+	}, [] );
+}


### PR DESCRIPTION
Part of FORNO-445

Companion server signal: [Automattic/jetpack#51217](https://github.com/Automattic/jetpack/pull/51217)

## Proposed Changes

This PR makes tracking more consistent across the Jetpack AI sidebar while retaining the existing `jetpack_big_sky_*` event family. It consolidates duplicate suggestion and AI Editorial Review events, adds shared structured-response events, and supplies consistent site and Automattician context through the common recorders.

| Event or event group | Change in this PR |
| --- | --- |
| `jetpack_big_sky_chat_suggestions_rendered` | Remains the shared suggestion-exposure event. Contextual block suggestions now include `block_type`, and deduplication includes the block type so the same suggestions shown for a different block are a new exposure. |
| `jetpack_big_sky_chat_suggestion_click` | Remains the shared selection event. Contextual suggestions include `block_type`; dropdown selections include `option_id` when it can be matched to the configured option. |
| `jetpack_big_sky_chat_response_rendered` | New shared event for a current structured `show-component` response reaching the rendered message tree. It records `component_type`, `tool_id`, and optional `tool_call_id`. Review responses also include the available result counts and review context described below. |
| `jetpack_big_sky_chat_response_action` | New shared event for supported response interactions. It records `action`, `target`, `outcome`, optional `item_count`, and the response identifiers. Stale responses and actions that become stale while awaiting an edit do not emit the event. |
| Existing `jetpack_big_sky_*` events | Receive `blog_id` and the optional server-provided `is_a11n`, in addition to their existing Big Sky properties. |
| Existing `calypso_agents_manager_*` events | Receive `blog_id` and the optional server-provided `is_a11n` through their shared recorder. |
| `jetpack_ai_split_screen_guide_rendered` and `jetpack_ai_split_screen_guide_click` | Remain in place and receive `blog_id` and optional `is_a11n` through the Jetpack AI sidebar recorder. Their existing `is_test` and editor-context properties are retained. |

### Structured response coverage

The shared response events cover:

- Optimize Title
- Generate Excerpt
- SEO title and description
- Image alt text
- Proofreader
- Generate Feedback / Simple Review
- AI Editorial Review

`chat_response_rendered` identifies the displayed response with `component_type`, `tool_id`, and `tool_call_id` when available. Proofreader, Generate Feedback, and AI Editorial Review also record `suggested_edit_count`. AI Editorial Review additionally records `conflict_count`, `implication_count`, `guideline_violation_count`, and the server-provided `review_context` when valid.

The old AI Editorial Review render-time `outcome` classification is not copied to the shared event. Result composition remains available through the counts and `review_context`; response-action outcomes are recorded separately as `success`, `failed`, or `partial_failed`.

`chat_response_action` covers `accept`, `dismiss`, `undo`, and `bulk_accept`, depending on the component. The event records what was acted on through `target`, and bulk actions include `item_count`.

Block transformations update the selected block directly and do not render a structured response component. This PR therefore keeps their exposure and selection under the shared suggestion events but does not add a response-rendered event for the resulting mutation.

A structured response displayed again after the chat remounts records another render. Its stable `tool_call_id`, when available, identifies repeated displays of the same response.

### Common event context

Shared Big Sky events continue to carry `is_test`, `sessionid`, `session_type`, `phase`, `big_sky_version`, `screen`, `post_type`, and `is_home_page`. This PR adds `blog_id` and the optional server-provided `is_a11n` value.

Older server versions omit `is_a11n` rather than treating a missing signal as `false`. The Jetpack AI provider no longer receives the obsolete `suggestionsVisible` option: visibility and the remaining shared suggestion-rendered event are now handled centrally by `OrchestratorChat`.

### Removed duplicate events

The following events are retired:

- `jetpack_ai_editorial_review_suggestion_rendered`
- `jetpack_ai_editorial_review_result_rendered`
- `jetpack_ai_editorial_review_item_action`
- `jetpack_ai_block_transformation_suggestion_rendered`

Suggestion exposure remains covered by `jetpack_big_sky_chat_suggestions_rendered`. AI Editorial Review response display and interactions move to the shared response events. Block-transformation suggestion IDs and `block_type` remain available on the shared suggestion events.

## Why are these changes being made?

- Suggestion exposure and selection already use shared Big Sky events, but structured responses did not consistently record whether the result reached the user or how the user acted on it.
- Shared response events provide consistent component, tool-call, action, target, outcome, and review-result context across sidebar tools.
- Removing parallel AI Editorial Review and block-transformation events avoids recording the same behaviour under multiple event families.
- Adding `block_type` to contextual suggestion renders preserves the useful block context previously carried by the duplicate block-transformation event.
- Adding `blog_id` and the server-provided Automattician signal supplies analysis context without inferring identity in the client.

## Testing Instructions

1. Install the Jetpack build from [Automattic/jetpack#51217](https://github.com/Automattic/jetpack/pull/51217) using Jetpack Beta Tester.
2. Sync `update/streamline-jetpack-ai-tracks` to your sandbox and sandbox `widgets.wp.com`.
3. Open the post editor and use **Optimize Title**, **Generate Excerpt**, **Proofreader**, **Generate Feedback / Simple Review**, and **AI Editorial Review** from the Jetpack AI sidebar.
4. Try the available picker and review actions, including accept, dismiss, undo, and bulk accept.
5. Select paragraph and heading blocks and use suggestions such as **Check Grammar**, **Change Tone**, and **Translate**.
6. Inspect the browser developer console and confirm:
   - `jetpack_big_sky_chat_suggestions_rendered` records displayed suggestion IDs.
   - Contextual block-suggestion renders include `block_type`.
   - Showing the same suggestions for a different block type records a new render.
   - `jetpack_big_sky_chat_suggestion_click` records the selected suggestion and includes `block_type` for block suggestions.
   - Dropdown selections include `option_id`.
   - Structured responses emit `jetpack_big_sky_chat_response_rendered`.
   - Proofreader, Generate Feedback, and AI Editorial Review response-rendered events include `suggested_edit_count`.
   - AI Editorial Review response-rendered events also include its category counts and valid `review_context`.
   - Supported response interactions emit `jetpack_big_sky_chat_response_action` with the expected `action`, `target`, and `outcome`.
   - Bulk actions include `item_count` and report `success`, `failed`, or `partial_failed`.
   - Shared Big Sky events include `is_test` and `blog_id`.
   - With the companion Jetpack build, affected events include a boolean `is_a11n`.
   - The retired AI Editorial Review and block-transformation events do not fire.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g. browsers), interfaces (e.g. keyboard navigation), and assistive technologies (e.g. screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the &#34;[Status] String Freeze&#34; label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the &#34;[Status] Needs Privacy Updates&#34; label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
