### PR TITLE
Checkout: show specific Stripe failure message for redirect/async methods

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-purchase-order.tsx
+++ b/client/my-sites/checkout/src/hooks/use-purchase-order.tsx
@@ -42,6 +42,14 @@ export interface RawOrder {
 	user_id: number;
 	receipt_id: number | undefined;
 	processing_status: PurchaseOrderStatus;
+	/**
+	 * On a Stripe `payment-failure`, the backend returns a customer-facing
+	 * failure code and an already-translated message, matching what synchronous
+	 * card failures return. Both are absent on non-Stripe or non-failure orders.
+	 * See SHILL-1811.
+	 */
+	error_code?: string;
+	error_message?: string;
 }
 
 function transformPurchaseOrderStatusToOrderTransactionStatus(

--- a/client/my-sites/checkout/src/lib/blik-processor.ts
+++ b/client/my-sites/checkout/src/lib/blik-processor.ts
@@ -2,7 +2,7 @@ import { makeErrorResponse, makeSuccessResponse } from '@automattic/composite-ch
 import { formatCurrency } from '@automattic/number-formatters';
 import { createElement } from 'react';
 import { Root, createRoot } from 'react-dom/client';
-import { PurchaseOrderStatus, fetchPurchaseOrder } from '../hooks/use-purchase-order';
+import { RawOrder, fetchPurchaseOrder } from '../hooks/use-purchase-order';
 import { recordTransactionBeginAnalytics } from '../lib/analytics';
 import getDomainDetails from '../lib/get-domain-details';
 import getPostalCode from '../lib/get-postal-code';
@@ -125,14 +125,20 @@ export default async function blikProcessor(
 			} );
 
 			let orderStatus = 'processing';
+			let orderFailureMessage: string | undefined;
 			while ( isModalActive && [ 'processing', 'async-pending' ].includes( orderStatus ) ) {
-				orderStatus = await pollForOrderStatus( response.order_id, 2000, genericErrorMessage );
+				const order = await pollForOrderStatus( response.order_id, 2000, genericErrorMessage );
+				orderStatus = order.processing_status;
+				orderFailureMessage = order.error_message;
 			}
 			// `payment-confirmed` is treated as success: Stripe has accepted the payment
 			// but order finalization can still take a while. Hand off to the framework's
 			// pending page rather than keeping the user waiting in the modal.
 			if ( orderStatus !== 'success' && orderStatus !== 'payment-confirmed' ) {
-				throw new Error( explicitClosureMessage ?? genericFailureMessage );
+				// Prefer the specific, backend-translated Stripe failure message
+				// (e.g. "Your card has insufficient funds.") over the generic
+				// fallback, matching what synchronous card failures show. See SHILL-1811.
+				throw new Error( explicitClosureMessage ?? orderFailureMessage ?? genericFailureMessage );
 			}
 
 			safeDismissModal();
@@ -153,7 +159,7 @@ async function pollForOrderStatus(
 	orderId: number,
 	pollInterval: number,
 	genericErrorMessage: string
-): Promise< PurchaseOrderStatus > {
+): Promise< RawOrder > {
 	const orderData = await fetchPurchaseOrder( orderId );
 	if ( ! orderData ) {
 		// eslint-disable-next-line no-console
@@ -164,10 +170,10 @@ async function pollForOrderStatus(
 		orderData.processing_status === 'success' ||
 		orderData.processing_status === 'payment-confirmed'
 	) {
-		return orderData.processing_status;
+		return orderData;
 	}
 	await new Promise( ( resolve ) => setTimeout( resolve, pollInterval ) );
-	return orderData.processing_status;
+	return orderData;
 }
 
 function getRenderRoot( genericErrorMessage: string ) {

--- a/client/my-sites/checkout/src/lib/pix-automatico-processor.ts
+++ b/client/my-sites/checkout/src/lib/pix-automatico-processor.ts
@@ -3,7 +3,7 @@ import { isValidBrazilianTaxId } from '@automattic/wpcom-checkout';
 import { createElement } from 'react';
 import { flushSync } from 'react-dom';
 import { Root, createRoot } from 'react-dom/client';
-import { PurchaseOrderStatus, fetchPurchaseOrder } from '../hooks/use-purchase-order';
+import { RawOrder, fetchPurchaseOrder } from '../hooks/use-purchase-order';
 import { recordTransactionBeginAnalytics } from '../lib/analytics';
 import getDomainDetails from '../lib/get-domain-details';
 import getPostalCode from '../lib/get-postal-code';
@@ -162,11 +162,17 @@ export async function pixAutomaticoProcessor(
 			} );
 
 			let orderStatus = 'processing';
+			let orderFailureMessage: string | undefined;
 			while ( isModalActive && [ 'processing', 'async-pending' ].includes( orderStatus ) ) {
-				orderStatus = await pollForOrderStatus( response.order_id, 2000, genericErrorMessage );
+				const order = await pollForOrderStatus( response.order_id, 2000, genericErrorMessage );
+				orderStatus = order.processing_status;
+				orderFailureMessage = order.error_message;
 			}
 			if ( orderStatus !== 'success' ) {
-				throw new Error( explicitClosureMessage ?? genericFailureMessage );
+				// Prefer the specific, backend-translated Stripe failure message
+				// (e.g. "Your card has insufficient funds.") over the generic
+				// fallback, matching what synchronous card failures show. See SHILL-1811.
+				throw new Error( explicitClosureMessage ?? orderFailureMessage ?? genericFailureMessage );
 			}
 
 			safeDismissModal();
@@ -187,7 +193,7 @@ async function pollForOrderStatus(
 	orderId: number,
 	pollInterval: number,
 	genericErrorMessage: string
-): Promise< PurchaseOrderStatus > {
+): Promise< RawOrder > {
 	const orderData = await fetchPurchaseOrder( orderId );
 	if ( ! orderData ) {
 		// eslint-disable-next-line no-console
@@ -195,10 +201,10 @@ async function pollForOrderStatus(
 		throw new Error( genericErrorMessage );
 	}
 	if ( orderData.processing_status === 'success' ) {
-		return orderData.processing_status;
+		return orderData;
 	}
 	await new Promise( ( resolve ) => setTimeout( resolve, pollInterval ) );
-	return orderData.processing_status;
+	return orderData;
 }
 
 function createModalContainer(): HTMLElement {

--- a/client/my-sites/checkout/src/lib/pix-processor.ts
+++ b/client/my-sites/checkout/src/lib/pix-processor.ts
@@ -3,7 +3,7 @@ import { isValidBrazilianTaxId } from '@automattic/wpcom-checkout';
 import { createElement } from 'react';
 import { flushSync } from 'react-dom';
 import { Root, createRoot } from 'react-dom/client';
-import { PurchaseOrderStatus, fetchPurchaseOrder } from '../hooks/use-purchase-order';
+import { RawOrder, fetchPurchaseOrder } from '../hooks/use-purchase-order';
 import { recordTransactionBeginAnalytics } from '../lib/analytics';
 import getDomainDetails from '../lib/get-domain-details';
 import getPostalCode from '../lib/get-postal-code';
@@ -162,11 +162,17 @@ export async function pixProcessor(
 			} );
 
 			let orderStatus = 'processing';
+			let orderFailureMessage: string | undefined;
 			while ( isModalActive && [ 'processing', 'async-pending' ].includes( orderStatus ) ) {
-				orderStatus = await pollForOrderStatus( response.order_id, 2000, genericErrorMessage );
+				const order = await pollForOrderStatus( response.order_id, 2000, genericErrorMessage );
+				orderStatus = order.processing_status;
+				orderFailureMessage = order.error_message;
 			}
 			if ( orderStatus !== 'success' ) {
-				throw new Error( explicitClosureMessage ?? genericFailureMessage );
+				// Prefer the specific, backend-translated Stripe failure message
+				// (e.g. "Your card has insufficient funds.") over the generic
+				// fallback, matching what synchronous card failures show. See SHILL-1811.
+				throw new Error( explicitClosureMessage ?? orderFailureMessage ?? genericFailureMessage );
 			}
 
 			safeDismissModal();
@@ -187,7 +193,7 @@ async function pollForOrderStatus(
 	orderId: number,
 	pollInterval: number,
 	genericErrorMessage: string
-): Promise< PurchaseOrderStatus > {
+): Promise< RawOrder > {
 	const orderData = await fetchPurchaseOrder( orderId );
 	if ( ! orderData ) {
 		// eslint-disable-next-line no-console
@@ -195,10 +201,10 @@ async function pollForOrderStatus(
 		throw new Error( genericErrorMessage );
 	}
 	if ( orderData.processing_status === 'success' ) {
-		return orderData.processing_status;
+		return orderData;
 	}
 	await new Promise( ( resolve ) => setTimeout( resolve, pollInterval ) );
-	return orderData.processing_status;
+	return orderData;
 }
 
 function createModalContainer(): HTMLElement {

--- a/client/my-sites/checkout/src/lib/upi-processor.ts
+++ b/client/my-sites/checkout/src/lib/upi-processor.ts
@@ -2,7 +2,7 @@ import { makeErrorResponse, makeSuccessResponse } from '@automattic/composite-ch
 import { createElement } from 'react';
 import { flushSync } from 'react-dom';
 import { Root, createRoot } from 'react-dom/client';
-import { PurchaseOrderStatus, fetchPurchaseOrder } from '../hooks/use-purchase-order';
+import { RawOrder, fetchPurchaseOrder } from '../hooks/use-purchase-order';
 import { recordTransactionBeginAnalytics } from '../lib/analytics';
 import getDomainDetails from '../lib/get-domain-details';
 import getPostalCode from '../lib/get-postal-code';
@@ -166,14 +166,20 @@ export default async function upiProcessor(
 			} );
 
 			let orderStatus = 'processing';
+			let orderFailureMessage: string | undefined;
 			while ( isModalActive && [ 'processing', 'async-pending' ].includes( orderStatus ) ) {
-				orderStatus = await pollForOrderStatus( response.order_id, 2000, genericErrorMessage );
+				const order = await pollForOrderStatus( response.order_id, 2000, genericErrorMessage );
+				orderStatus = order.processing_status;
+				orderFailureMessage = order.error_message;
 			}
 			// `payment-confirmed` is treated as success: Stripe has accepted the payment
 			// but order finalization can still take a while. Hand off to the framework's
 			// pending page rather than keeping the user waiting in the modal.
 			if ( orderStatus !== 'success' && orderStatus !== 'payment-confirmed' ) {
-				throw new Error( explicitClosureMessage ?? genericFailureMessage );
+				// Prefer the specific, backend-translated Stripe failure message
+				// (e.g. "Your card has insufficient funds.") over the generic
+				// fallback, matching what synchronous card failures show. See SHILL-1811.
+				throw new Error( explicitClosureMessage ?? orderFailureMessage ?? genericFailureMessage );
 			}
 
 			safeDismissModal();
@@ -264,7 +270,7 @@ async function pollForOrderStatus(
 	orderId: number,
 	pollInterval: number,
 	genericErrorMessage: string
-): Promise< PurchaseOrderStatus > {
+): Promise< RawOrder > {
 	const orderData = await fetchPurchaseOrder( orderId );
 	if ( ! orderData ) {
 		// eslint-disable-next-line no-console
@@ -275,10 +281,10 @@ async function pollForOrderStatus(
 		orderData.processing_status === 'success' ||
 		orderData.processing_status === 'payment-confirmed'
 	) {
-		return orderData.processing_status;
+		return orderData;
 	}
 	await new Promise( ( resolve ) => setTimeout( resolve, pollInterval ) );
-	return orderData.processing_status;
+	return orderData;
 }
 
 function createModalContainer(): HTMLElement {

--- a/client/my-sites/checkout/src/lib/we-chat-processor.ts
+++ b/client/my-sites/checkout/src/lib/we-chat-processor.ts
@@ -7,7 +7,7 @@ import { createElement } from 'react';
 import { flushSync } from 'react-dom';
 import { Root, createRoot } from 'react-dom/client';
 import userAgent from 'calypso/lib/user-agent';
-import { PurchaseOrderStatus, fetchPurchaseOrder } from '../hooks/use-purchase-order';
+import { RawOrder, fetchPurchaseOrder } from '../hooks/use-purchase-order';
 import { recordTransactionBeginAnalytics } from '../lib/analytics';
 import getDomainDetails from '../lib/get-domain-details';
 import getPostalCode from '../lib/get-postal-code';
@@ -135,11 +135,17 @@ export default async function weChatProcessor(
 			);
 
 			let orderStatus = 'processing';
+			let orderFailureMessage: string | undefined;
 			while ( isModalActive && [ 'processing', 'async-pending' ].includes( orderStatus ) ) {
-				orderStatus = await pollForOrderStatus( response.order_id, 2000, genericErrorMessage );
+				const order = await pollForOrderStatus( response.order_id, 2000, genericErrorMessage );
+				orderStatus = order.processing_status;
+				orderFailureMessage = order.error_message;
 			}
 			if ( orderStatus !== 'success' ) {
-				throw new Error( explicitClosureMessage ?? genericFailureMessage );
+				// Prefer the specific, backend-translated Stripe failure message
+				// (e.g. "Your card has insufficient funds.") over the generic
+				// fallback, matching what synchronous card failures show. See SHILL-1811.
+				throw new Error( explicitClosureMessage ?? orderFailureMessage ?? genericFailureMessage );
 			}
 
 			const responseData: Partial< WPCOMTransactionEndpointResponseSuccess > = {
@@ -158,7 +164,7 @@ async function pollForOrderStatus(
 	orderId: number,
 	pollInterval: number,
 	genericErrorMessage: string
-): Promise< PurchaseOrderStatus > {
+): Promise< RawOrder > {
 	const orderData = await fetchPurchaseOrder( orderId );
 	if ( ! orderData ) {
 		// eslint-disable-next-line no-console
@@ -166,10 +172,10 @@ async function pollForOrderStatus(
 		throw new Error( genericErrorMessage );
 	}
 	if ( orderData.processing_status === 'success' ) {
-		return orderData.processing_status;
+		return orderData;
 	}
 	await new Promise( ( resolve ) => setTimeout( resolve, pollInterval ) );
-	return orderData.processing_status;
+	return orderData;
 }
 
 function createModalContainer(): HTMLElement {

--- a/client/my-sites/checkout/src/test/upi-processor.ts
+++ b/client/my-sites/checkout/src/test/upi-processor.ts
@@ -138,6 +138,49 @@ describe( 'upiProcessor', () => {
 		expect( transactionsEndpoint ).toHaveBeenCalledWith( basicExpectedStripeRequest );
 	} );
 
+	it( 'surfaces the specific Stripe failure message when the backend provides one', async () => {
+		// The processor renders the dialog into a div so that div must be
+		// present to avoid errors.
+		render( createElement( 'div', { className: 'upi-modal-target' } ) );
+
+		const orderId = 54321;
+		// The order-details endpoint now returns a customer-facing, already
+		// translated failure message for redirect/async Stripe methods, the same
+		// way synchronous card failures do. See SHILL-1811.
+		const mockOrderStatus = {
+			order_id: orderId,
+			user_id: 1234,
+			receipt_id: undefined,
+			processing_status: 'payment-failure',
+			error_code: 'insufficient_funds',
+			error_message: 'Your card has insufficient funds.',
+		};
+		mockOrderEndpoint( orderId, () => [ 200, mockOrderStatus ] );
+		mockTransactionsEndpoint( () => mockTransactionsRedirectResponse( orderId ) );
+		const expected = {
+			payload: 'Your card has insufficient funds.',
+			type: 'ERROR',
+		};
+
+		// We have to use `act()` because this changes the DOM async and
+		// otherwise we get a bunch of warnings.
+		await act( async () => {
+			await expect(
+				upiProcessor(
+					submitData,
+					{
+						...options,
+						contactDetails: {
+							countryCode,
+							postalCode,
+						},
+					},
+					translate
+				)
+			).resolves.toStrictEqual( expected );
+		} );
+	} );
+
 	it( 'returns an explicit error response if the transaction fails', async () => {
 		// The processor renders the dialog into a div so that div must be
 		// present to avoid errors.


### PR DESCRIPTION
Part of SHILL-1811 (front-end half).

## Proposed Changes

Redirect and asynchronous Stripe payment methods — UPI, BLIK, WeChat Pay, Pix and Pix Automático — open a modal and poll the order-details endpoint until the order resolves. Until now, any non-success outcome threw a single generic message: *"Payment failed. Please check your account and try again."* Synchronous card payments, by contrast, already surface the specific decline reason.

The order-details endpoint now returns a customer-facing, already-translated `error_code` / `error_message` on a Stripe `payment-failure`, matching what the synchronous card path returns. This PR threads that message through the front end:

- `RawOrder` (`client/my-sites/checkout/src/hooks/use-purchase-order.tsx`) gains the optional `error_code` / `error_message` fields.
- Each processor's local `pollForOrderStatus` now returns the whole `RawOrder` instead of just `processing_status`, so the polling loop can keep both the status and the failure message.
- On failure the thrown message is `explicitClosureMessage ?? orderFailureMessage ?? genericFailureMessage`, so:
  - an explicit cancellation / modal error still wins (the user closed the modal, the QR code expired, etc.);
  - otherwise the specific backend message is shown, e.g. *"Your card has insufficient funds."*;
  - the generic message remains the fallback when the backend sends no detail — non-Stripe orders and older responses are unaffected.

No new strings are introduced: the specific message is translated server-side, the same as for card declines.

Touched processors: `blik-processor.ts`, `pix-processor.ts`, `pix-automatico-processor.ts`, `upi-processor.ts`, `we-chat-processor.ts`.

## Why are these changes being made?

"Payment failed. Please check your account and try again." tells the buyer nothing actionable. When the real reason is an insufficient balance, a bank-side rejection, or an expired mandate, the buyer cannot tell whether to retry, top up, or pick another payment method — so they often just retry the same failing method or abandon checkout. Card payers already get the specific reason; this brings redirect/async methods (the dominant methods in India, Poland, Brazil and China) to parity now that the backend exposes the detail.

## Testing Instructions

Unit tests:

```
yarn test-client client/my-sites/checkout/src/test/upi-processor.ts
```

The new case, *"surfaces the specific Stripe failure message when the backend provides one"*, mocks an order-details response with `processing_status: 'payment-failure'` plus `error_code` / `error_message` and asserts the processor resolves with the specific message rather than the generic one.

Manual (requires a sandboxed wpcom with the SHILL-1811 backend change):

1. Sandbox your wpcom so the order-details endpoint returns `error_code` / `error_message` on a Stripe payment failure.
2. Go to checkout with a product and pick one of the affected methods — UPI is the easiest to drive (Pix / Pix Automático need a Brazilian tax ID, BLIK a Polish account, WeChat Pay a CN account).
3. In Stripe test mode, trigger a failing payment (e.g. a decline / insufficient-funds test credential) and leave the modal open until polling resolves.
4. The checkout error notice should show the specific reason, e.g. "Your card has insufficient funds.", instead of "Payment failed. Please check your account and try again."
5. Regression checks:
   - Close the modal yourself mid-poll → the cancellation message still wins over the backend message.
   - Fail a payment where the backend sends no `error_message` → the generic message still appears.
   - Complete a successful payment → unchanged; `payment-confirmed` on UPI/BLIK still hands off to the pending page.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? — no new strings; the message is translated server-side.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
