### PR TITLE
A4A: drop the redundant checked-checkbox color override

### DIFF
--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -255,12 +255,6 @@
 		margin: 0 8px 0 0;
 	}
 
-	.components-checkbox-control__input[type="checkbox"]:checked,
-	.components-checkbox-control__input[type="checkbox"]:indeterminate {
-		background: var(--color-primary-50);
-		border-color: var(--color-primary-50);
-	}
-
 	.components-checkbox-control__input[type="checkbox"]:focus {
 		box-shadow: none;
 		outline: none;


### PR DESCRIPTION
## Proposed Changes

* Drop the A4A `:checked` / `:indeterminate` checkbox color override so core's `CheckboxControl` styles apply as-is.

| Before | After |
|--------|--------|
| <img width="203" height="68" alt="Screenshot 2026-08-12 at 11 09 20 PM" src="https://github.com/user-attachments/assets/214e4e72-2dc7-4dad-a506-5a9254c81e6a" /> | <img width="492" height="155" alt="Screenshot 2026-08-12 at 11 21 40 PM" src="https://github.com/user-attachments/assets/97fae2d1-a3a9-4dbe-933a-c11292e09ec2" /> | 

## Why are these changes being made?

* The override set the checked background to `--color-primary-50`, which resolves to the same token core already uses via `--wp-components-color-accent` — so it changed nothing for enabled checkboxes.
* It did, however, beat core's `:disabled` colors, so a disabled checked checkbox rendered as an active blue box with a grey checkmark. Most visible on the Partner Directory expertise form, where already-approved directories are checked and disabled.

## Testing Instructions

* Go to Partner Directory → Agency expertise with at least one approved directory.
* The approved (disabled) directory checkbox now renders in core's disabled style — grey box, grey checkmark — instead of a blue box with a grey check.
* Confirm enabled checkboxes elsewhere in A4A are unchanged (still Automattic blue when checked).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
