### PR TITLE
Dashboard: add Tracks events for the rest of payment methods

### DIFF
--- a/client/dashboard/me/billing-payment-methods/index.tsx
+++ b/client/dashboard/me/billing-payment-methods/index.tsx
@@ -39,7 +39,7 @@ import { PaymentMethodEditDialog } from './payment-method-edit-dialog';
 import type { StoredPaymentMethod } from '@automattic/api-core';
 import type { View, Fields, SortDirection, Action } from '@wordpress/dataviews';
 
-const getDeleteEventProperties = ( paymentMethod: StoredPaymentMethod ) => ( {
+const getPaymentMethodEventProperties = ( paymentMethod: StoredPaymentMethod ) => ( {
 	payment_partner: paymentMethod.payment_partner,
 	is_backup: paymentMethod.is_backup,
 	is_expired: paymentMethod.is_expired,
@@ -112,10 +112,49 @@ export default function PaymentMethods() {
 	);
 	const { mutate: setPaymentMethodTaxInfo } = useMutation( userPaymentMethodSetTaxInfoQuery() );
 	const { recordTracksEvent } = useAnalytics();
+	const recordActionClick = (
+		paymentMethod: StoredPaymentMethod,
+		action: string,
+		source: 'actions-menu' | 'toggle' = 'actions-menu'
+	) => {
+		recordTracksEvent( 'calypso_dashboard_payment_method_action_click', {
+			...getPaymentMethodEventProperties( paymentMethod ),
+			action,
+			source,
+		} );
+	};
+	const changePaymentMethodBackup = (
+		paymentMethod: StoredPaymentMethod,
+		isBackup: boolean,
+		source: 'actions-menu' | 'toggle'
+	) => {
+		recordActionClick( paymentMethod, isBackup ? 'enable-backup' : 'disable-backup', source );
+		// Unlike the click event above, these describe the state being saved, not
+		// the state the payment method was in when the user acted.
+		const eventProperties = {
+			...getPaymentMethodEventProperties( paymentMethod ),
+			is_backup: isBackup,
+		};
+		setPaymentMethodBackup(
+			{ ...paymentMethod, is_backup: isBackup },
+			{
+				onSuccess: () => {
+					recordTracksEvent( 'calypso_dashboard_payment_method_set_backup', eventProperties );
+				},
+				onError: ( error ) => {
+					recordTracksEvent( 'calypso_dashboard_payment_method_set_backup_failure', {
+						...eventProperties,
+						error_message: error.message,
+					} );
+				},
+			}
+		);
+	};
 	const paymentMethodFields = getFields( {
 		isUpdatingPaymentMethods,
 		isSettingPaymentMethodBackup,
-		setPaymentMethodBackup,
+		onChangeBackup: ( paymentMethod: StoredPaymentMethod, isBackup: boolean ) =>
+			changePaymentMethodBackup( paymentMethod, isBackup, 'toggle' ),
 	} );
 	const { data: filteredPaymentMethods, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( paymentMethods, currentView, paymentMethodFields );
@@ -132,10 +171,7 @@ export default function PaymentMethods() {
 			},
 			callback: ( items ) => {
 				const item = items[ 0 ];
-				setPaymentMethodBackup( {
-					...item,
-					is_backup: true,
-				} );
+				changePaymentMethodBackup( item, true, 'actions-menu' );
 			},
 		},
 		{
@@ -149,10 +185,7 @@ export default function PaymentMethods() {
 			},
 			callback: ( items ) => {
 				const item = items[ 0 ];
-				setPaymentMethodBackup( {
-					...item,
-					is_backup: false,
-				} );
+				changePaymentMethodBackup( item, false, 'actions-menu' );
 			},
 		},
 		{
@@ -160,6 +193,7 @@ export default function PaymentMethods() {
 			label: __( 'Edit billing information' ),
 			callback: ( items ) => {
 				const item = items[ 0 ];
+				recordActionClick( item, 'edit-billing-address' );
 				setEditDialogPaymentMethod( item );
 			},
 		},
@@ -171,10 +205,7 @@ export default function PaymentMethods() {
 			},
 			callback: ( items ) => {
 				const item = items[ 0 ];
-				recordTracksEvent(
-					'calypso_dashboard_payment_method_delete_click',
-					getDeleteEventProperties( item )
-				);
+				recordActionClick( item, 'remove' );
 				setRemoveDialogPaymentMethod( item );
 			},
 		},
@@ -193,6 +224,7 @@ export default function PaymentMethods() {
 							__next40pxDefaultSize
 							variant="primary"
 							onClick={ () => {
+								recordTracksEvent( 'calypso_dashboard_payment_method_add_click' );
 								navigate( { to: addPaymentMethodRoute.to } );
 							} }
 						>
@@ -221,13 +253,34 @@ export default function PaymentMethods() {
 					<PaymentMethodEditDialog
 						paymentMethod={ editAddressDialogPaymentMethod }
 						isVisible={ Boolean( editAddressDialogPaymentMethod ) }
-						onCancel={ () => setEditDialogPaymentMethod( undefined ) }
+						onCancel={ () => {
+							recordTracksEvent(
+								'calypso_dashboard_payment_method_edit_billing_address_cancel_click',
+								getPaymentMethodEventProperties( editAddressDialogPaymentMethod )
+							);
+							setEditDialogPaymentMethod( undefined );
+						} }
 						onConfirm={ ( data ) => {
+							const eventProperties = getPaymentMethodEventProperties(
+								editAddressDialogPaymentMethod
+							);
+							recordTracksEvent(
+								'calypso_dashboard_payment_method_edit_billing_address_save_click',
+								eventProperties
+							);
 							setPaymentMethodTaxInfo( data, {
 								onSuccess: () => {
+									recordTracksEvent(
+										'calypso_dashboard_payment_method_edit_billing_address',
+										eventProperties
+									);
 									createSuccessNotice( __( 'Billing address updated.' ), { type: 'snackbar' } );
 								},
 								onError: ( error ) => {
+									recordTracksEvent(
+										'calypso_dashboard_payment_method_edit_billing_address_failure',
+										{ ...eventProperties, error_message: error.message }
+									);
 									createErrorNotice( error?.message || __( 'Failed to update billing address.' ), {
 										type: 'snackbar',
 									} );
@@ -242,7 +295,7 @@ export default function PaymentMethods() {
 						isVisible={ Boolean( removeDialogPaymentMethod ) }
 						paymentMethod={ removeDialogPaymentMethod }
 						onConfirm={ () => {
-							const eventProperties = getDeleteEventProperties( removeDialogPaymentMethod );
+							const eventProperties = getPaymentMethodEventProperties( removeDialogPaymentMethod );
 							recordTracksEvent(
 								'calypso_dashboard_payment_method_delete_confirm_click',
 								eventProperties
@@ -264,7 +317,13 @@ export default function PaymentMethods() {
 							} );
 							setRemoveDialogPaymentMethod( undefined );
 						} }
-						onCancel={ () => setRemoveDialogPaymentMethod( undefined ) }
+						onCancel={ () => {
+							recordTracksEvent(
+								'calypso_dashboard_payment_method_delete_cancel_click',
+								getPaymentMethodEventProperties( removeDialogPaymentMethod )
+							);
+							setRemoveDialogPaymentMethod( undefined );
+						} }
 					/>
 				) }
 			</div>
@@ -275,13 +334,11 @@ export default function PaymentMethods() {
 function getFields( {
 	isUpdatingPaymentMethods,
 	isSettingPaymentMethodBackup,
-	setPaymentMethodBackup,
+	onChangeBackup,
 }: {
 	isUpdatingPaymentMethods: boolean;
 	isSettingPaymentMethodBackup: boolean;
-	setPaymentMethodBackup: (
-		paymentMethod: Pick< StoredPaymentMethod, 'stored_details_id' | 'is_backup' >
-	) => void;
+	onChangeBackup: ( paymentMethod: StoredPaymentMethod, isBackup: boolean ) => void;
 } ): Fields< StoredPaymentMethod > {
 	return [
 		{
@@ -383,10 +440,7 @@ function getFields( {
 							! isCreditCard( item ) || isSettingPaymentMethodBackup || isUpdatingPaymentMethods
 						}
 						onChange={ () => {
-							setPaymentMethodBackup( {
-								...item,
-								is_backup: ! item.is_backup,
-							} );
+							onChangeBackup( item, ! item.is_backup );
 						} }
 					/>
 				);

--- a/client/dashboard/me/billing-payment-methods/index.tsx
+++ b/client/dashboard/me/billing-payment-methods/index.tsx
@@ -39,6 +39,11 @@ import { PaymentMethodEditDialog } from './payment-method-edit-dialog';
 import type { StoredPaymentMethod } from '@automattic/api-core';
 import type { View, Fields, SortDirection, Action } from '@wordpress/dataviews';
 
+interface ChangeBackupArgs {
+	paymentMethod: StoredPaymentMethod;
+	isBackup: boolean;
+}
+
 const getPaymentMethodEventProperties = ( paymentMethod: StoredPaymentMethod ) => ( {
 	payment_partner: paymentMethod.payment_partner,
 	is_backup: paymentMethod.is_backup,
@@ -123,11 +128,15 @@ export default function PaymentMethods() {
 			source,
 		} );
 	};
-	const changePaymentMethodBackup = (
-		paymentMethod: StoredPaymentMethod,
-		isBackup: boolean,
-		source: 'actions-menu' | 'toggle'
-	) => {
+	const changePaymentMethodBackup = ( {
+		paymentMethod,
+		isBackup,
+		source,
+	}: {
+		paymentMethod: StoredPaymentMethod;
+		isBackup: boolean;
+		source: 'actions-menu' | 'toggle';
+	} ) => {
 		recordActionClick( paymentMethod, isBackup ? 'enable-backup' : 'disable-backup', source );
 		// Unlike the click event above, these describe the state being saved, not
 		// the state the payment method was in when the user acted.
@@ -153,8 +162,8 @@ export default function PaymentMethods() {
 	const paymentMethodFields = getFields( {
 		isUpdatingPaymentMethods,
 		isSettingPaymentMethodBackup,
-		onChangeBackup: ( paymentMethod: StoredPaymentMethod, isBackup: boolean ) =>
-			changePaymentMethodBackup( paymentMethod, isBackup, 'toggle' ),
+		onChangeBackup: ( { paymentMethod, isBackup }: ChangeBackupArgs ) =>
+			changePaymentMethodBackup( { paymentMethod, isBackup, source: 'toggle' } ),
 	} );
 	const { data: filteredPaymentMethods, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( paymentMethods, currentView, paymentMethodFields );
@@ -171,7 +180,11 @@ export default function PaymentMethods() {
 			},
 			callback: ( items ) => {
 				const item = items[ 0 ];
-				changePaymentMethodBackup( item, true, 'actions-menu' );
+				changePaymentMethodBackup( {
+					paymentMethod: item,
+					isBackup: true,
+					source: 'actions-menu',
+				} );
 			},
 		},
 		{
@@ -185,7 +198,11 @@ export default function PaymentMethods() {
 			},
 			callback: ( items ) => {
 				const item = items[ 0 ];
-				changePaymentMethodBackup( item, false, 'actions-menu' );
+				changePaymentMethodBackup( {
+					paymentMethod: item,
+					isBackup: false,
+					source: 'actions-menu',
+				} );
 			},
 		},
 		{
@@ -338,7 +355,7 @@ function getFields( {
 }: {
 	isUpdatingPaymentMethods: boolean;
 	isSettingPaymentMethodBackup: boolean;
-	onChangeBackup: ( paymentMethod: StoredPaymentMethod, isBackup: boolean ) => void;
+	onChangeBackup: ( args: ChangeBackupArgs ) => void;
 } ): Fields< StoredPaymentMethod > {
 	return [
 		{
@@ -440,7 +457,7 @@ function getFields( {
 							! isCreditCard( item ) || isSettingPaymentMethodBackup || isUpdatingPaymentMethods
 						}
 						onChange={ () => {
-							onChangeBackup( item, ! item.is_backup );
+							onChangeBackup( { paymentMethod: item, isBackup: ! item.is_backup } );
 						} }
 					/>
 				);

--- a/client/dashboard/me/billing-purchases/payment-method-selector/index.tsx
+++ b/client/dashboard/me/billing-purchases/payment-method-selector/index.tsx
@@ -40,7 +40,7 @@ import type { PaymentMethod, PaymentProcessorProp } from '@automattic/composite-
  * different user intents that happen to share this component, so they get
  * distinct events rather than one event with a flag.
  */
-function getEventNames( isPurchaseAssignment: boolean ) {
+function getEventNames( { isPurchaseAssignment }: { isPurchaseAssignment: boolean } ) {
 	return isPurchaseAssignment
 		? {
 				success: 'calypso_dashboard_purchase_payment_method_change',
@@ -90,7 +90,7 @@ export function PaymentMethodSelector( {
 	const currentlyAssignedPaymentMethodId = getPaymentMethodIdFromPayment( purchase );
 	const { stripe, stripeConfiguration } = useStripe();
 	const { recordTracksEvent } = useAnalytics();
-	const eventNames = getEventNames( Boolean( purchase ) );
+	const eventNames = getEventNames( { isPurchaseAssignment: Boolean( purchase ) } );
 	const submittedPaymentProcessorId = useRef( '' );
 
 	const { mutateAsync: assignPaymentMethod } = useMutation( assignPaymentMethodMutation() );

--- a/client/dashboard/me/billing-purchases/payment-method-selector/index.tsx
+++ b/client/dashboard/me/billing-purchases/payment-method-selector/index.tsx
@@ -19,7 +19,7 @@ import { useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import clsx from 'clsx';
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import { useAnalytics } from '../../../app/analytics';
 import { Card, CardBody } from '../../../components/card';
 import { Notice } from '../../../components/notice';
@@ -33,7 +33,7 @@ import {
 import getPaymentMethodIdFromPayment from './get-payment-method-id-from-payment';
 import TosText from './tos-text';
 import type { Purchase } from '@automattic/api-core';
-import type { PaymentMethod, PaymentProcessorProp } from '@automattic/composite-checkout';
+import type { PaymentMethod } from '@automattic/composite-checkout';
 
 /**
  * Adding a payment method and reassigning one to an existing subscription are
@@ -50,26 +50,6 @@ function getEventNames( { isPurchaseAssignment }: { isPurchaseAssignment: boolea
 				success: 'calypso_dashboard_payment_method_add',
 				failure: 'calypso_dashboard_payment_method_add_failure',
 		  };
-}
-
-/**
- * The submit button belongs to composite-checkout, which does not report which
- * payment method was submitted to the provider's completion callbacks. Record it
- * as each processor runs so the outcome events can name it.
- */
-function withProcessorTracking(
-	processors: PaymentProcessorProp,
-	submittedPaymentProcessorId: { current: string }
-): PaymentProcessorProp {
-	return Object.fromEntries(
-		Object.entries( processors ).map( ( [ processorId, processor ] ) => [
-			processorId,
-			( data: unknown ) => {
-				submittedPaymentProcessorId.current = processorId;
-				return processor( data );
-			},
-		] )
-	);
 }
 
 /**
@@ -91,7 +71,6 @@ export function PaymentMethodSelector( {
 	const { stripe, stripeConfiguration } = useStripe();
 	const { recordTracksEvent } = useAnalytics();
 	const eventNames = getEventNames( { isPurchaseAssignment: Boolean( purchase ) } );
-	const submittedPaymentProcessorId = useRef( '' );
 
 	const { mutateAsync: assignPaymentMethod } = useMutation( assignPaymentMethodMutation() );
 	const { mutateAsync: createPayPalAgreement } = useMutation( createPayPalAgreementMutation() );
@@ -114,12 +93,14 @@ export function PaymentMethodSelector( {
 		( {
 			transactionError,
 			paymentMethodId,
+			paymentProcessorId,
 		}: {
 			transactionError: string | null;
 			paymentMethodId: string | null | undefined;
+			paymentProcessorId: string | undefined;
 		} ) => {
 			recordTracksEvent( eventNames.failure, {
-				payment_processor: submittedPaymentProcessorId.current,
+				payment_processor: paymentProcessorId,
 				payment_method_id: paymentMethodId,
 				error_message: transactionError,
 			} );
@@ -145,9 +126,10 @@ export function PaymentMethodSelector( {
 
 	return (
 		<CheckoutProvider
-			onPaymentComplete={ () => {
+			onPaymentComplete={ ( { paymentMethodId, paymentProcessorId } ) => {
 				recordTracksEvent( eventNames.success, {
-					payment_processor: submittedPaymentProcessorId.current,
+					payment_processor: paymentProcessorId,
+					payment_method_id: paymentMethodId,
 				} );
 				onPaymentSelectComplete( {
 					successCallback,
@@ -158,31 +140,28 @@ export function PaymentMethodSelector( {
 			onPaymentRedirect={ showRedirectMessage }
 			onPaymentError={ handleChangeError }
 			paymentMethods={ paymentMethods }
-			paymentProcessors={ withProcessorTracking(
-				{
-					'existing-card': ( data: unknown ) =>
-						assignExistingCardProcessor( purchase, data, assignPaymentMethod ),
-					'existing-card-ebanx': ( data: unknown ) =>
-						assignExistingCardProcessor( purchase, data, assignPaymentMethod ),
-					'existing-paypal-ppcp': ( data: unknown ) =>
-						assignExistingPayPalPPCPProcessor( purchase, data, assignPaymentMethod ),
-					card: ( data: unknown ) =>
-						assignNewCardProcessor(
-							{
-								purchase,
-								stripe,
-								stripeConfiguration,
-								createStripeSetupIntent,
-								saveCreditCard,
-								updateCreditCard,
-							},
-							data
-						),
-					'paypal-express': ( data: unknown ) =>
-						assignPayPalProcessor( purchase, data, createPayPalAgreement ),
-				},
-				submittedPaymentProcessorId
-			) }
+			paymentProcessors={ {
+				'existing-card': ( data: unknown ) =>
+					assignExistingCardProcessor( purchase, data, assignPaymentMethod ),
+				'existing-card-ebanx': ( data: unknown ) =>
+					assignExistingCardProcessor( purchase, data, assignPaymentMethod ),
+				'existing-paypal-ppcp': ( data: unknown ) =>
+					assignExistingPayPalPPCPProcessor( purchase, data, assignPaymentMethod ),
+				card: ( data: unknown ) =>
+					assignNewCardProcessor(
+						{
+							purchase,
+							stripe,
+							stripeConfiguration,
+							createStripeSetupIntent,
+							saveCreditCard,
+							updateCreditCard,
+						},
+						data
+					),
+				'paypal-express': ( data: unknown ) =>
+					assignPayPalProcessor( purchase, data, createPayPalAgreement ),
+			} }
 			initiallySelectedPaymentMethodId={ getInitiallySelectedPaymentMethodId(
 				currentlyAssignedPaymentMethodId,
 				paymentMethods

--- a/client/dashboard/me/billing-purchases/payment-method-selector/index.tsx
+++ b/client/dashboard/me/billing-purchases/payment-method-selector/index.tsx
@@ -19,7 +19,8 @@ import { useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import clsx from 'clsx';
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
+import { useAnalytics } from '../../../app/analytics';
 import { Card, CardBody } from '../../../components/card';
 import { Notice } from '../../../components/notice';
 import { creditCardHasAlreadyExpired, isAkismetProduct } from '../../../utils/purchase';
@@ -32,7 +33,44 @@ import {
 import getPaymentMethodIdFromPayment from './get-payment-method-id-from-payment';
 import TosText from './tos-text';
 import type { Purchase } from '@automattic/api-core';
-import type { PaymentMethod } from '@automattic/composite-checkout';
+import type { PaymentMethod, PaymentProcessorProp } from '@automattic/composite-checkout';
+
+/**
+ * Adding a payment method and reassigning one to an existing subscription are
+ * different user intents that happen to share this component, so they get
+ * distinct events rather than one event with a flag.
+ */
+function getEventNames( isPurchaseAssignment: boolean ) {
+	return isPurchaseAssignment
+		? {
+				success: 'calypso_dashboard_purchase_payment_method_change',
+				failure: 'calypso_dashboard_purchase_payment_method_change_failure',
+		  }
+		: {
+				success: 'calypso_dashboard_payment_method_add',
+				failure: 'calypso_dashboard_payment_method_add_failure',
+		  };
+}
+
+/**
+ * The submit button belongs to composite-checkout, which does not report which
+ * payment method was submitted to the provider's completion callbacks. Record it
+ * as each processor runs so the outcome events can name it.
+ */
+function withProcessorTracking(
+	processors: PaymentProcessorProp,
+	submittedPaymentProcessorId: { current: string }
+): PaymentProcessorProp {
+	return Object.fromEntries(
+		Object.entries( processors ).map( ( [ processorId, processor ] ) => [
+			processorId,
+			( data: unknown ) => {
+				submittedPaymentProcessorId.current = processorId;
+				return processor( data );
+			},
+		] )
+	);
+}
 
 /**
  * A component to handle assigning payment methods to existing subscriptions.
@@ -51,6 +89,9 @@ export function PaymentMethodSelector( {
 	const { createSuccessNotice, createErrorNotice, createInfoNotice } = useDispatch( noticesStore );
 	const currentlyAssignedPaymentMethodId = getPaymentMethodIdFromPayment( purchase );
 	const { stripe, stripeConfiguration } = useStripe();
+	const { recordTracksEvent } = useAnalytics();
+	const eventNames = getEventNames( Boolean( purchase ) );
+	const submittedPaymentProcessorId = useRef( '' );
 
 	const { mutateAsync: assignPaymentMethod } = useMutation( assignPaymentMethodMutation() );
 	const { mutateAsync: createPayPalAgreement } = useMutation( createPayPalAgreementMutation() );
@@ -70,14 +111,25 @@ export function PaymentMethodSelector( {
 	}, [ createInfoNotice ] );
 
 	const handleChangeError = useCallback(
-		( { transactionError }: { transactionError: string | null } ) => {
+		( {
+			transactionError,
+			paymentMethodId,
+		}: {
+			transactionError: string | null;
+			paymentMethodId: string | null | undefined;
+		} ) => {
+			recordTracksEvent( eventNames.failure, {
+				payment_processor: submittedPaymentProcessorId.current,
+				payment_method_id: paymentMethodId,
+				error_message: transactionError,
+			} );
 			createErrorNotice(
 				transactionError ||
 					__( 'There was a problem assigning that payment method. Please try again.' ),
 				{ type: 'snackbar' }
 			);
 		},
-		[ createErrorNotice ]
+		[ createErrorNotice, recordTracksEvent, eventNames.failure ]
 	);
 
 	const showSuccessMessage = useCallback(
@@ -94,6 +146,9 @@ export function PaymentMethodSelector( {
 	return (
 		<CheckoutProvider
 			onPaymentComplete={ () => {
+				recordTracksEvent( eventNames.success, {
+					payment_processor: submittedPaymentProcessorId.current,
+				} );
 				onPaymentSelectComplete( {
 					successCallback,
 					showSuccessMessage,
@@ -103,28 +158,31 @@ export function PaymentMethodSelector( {
 			onPaymentRedirect={ showRedirectMessage }
 			onPaymentError={ handleChangeError }
 			paymentMethods={ paymentMethods }
-			paymentProcessors={ {
-				'existing-card': ( data: unknown ) =>
-					assignExistingCardProcessor( purchase, data, assignPaymentMethod ),
-				'existing-card-ebanx': ( data: unknown ) =>
-					assignExistingCardProcessor( purchase, data, assignPaymentMethod ),
-				'existing-paypal-ppcp': ( data: unknown ) =>
-					assignExistingPayPalPPCPProcessor( purchase, data, assignPaymentMethod ),
-				card: ( data: unknown ) =>
-					assignNewCardProcessor(
-						{
-							purchase,
-							stripe,
-							stripeConfiguration,
-							createStripeSetupIntent,
-							saveCreditCard,
-							updateCreditCard,
-						},
-						data
-					),
-				'paypal-express': ( data: unknown ) =>
-					assignPayPalProcessor( purchase, data, createPayPalAgreement ),
-			} }
+			paymentProcessors={ withProcessorTracking(
+				{
+					'existing-card': ( data: unknown ) =>
+						assignExistingCardProcessor( purchase, data, assignPaymentMethod ),
+					'existing-card-ebanx': ( data: unknown ) =>
+						assignExistingCardProcessor( purchase, data, assignPaymentMethod ),
+					'existing-paypal-ppcp': ( data: unknown ) =>
+						assignExistingPayPalPPCPProcessor( purchase, data, assignPaymentMethod ),
+					card: ( data: unknown ) =>
+						assignNewCardProcessor(
+							{
+								purchase,
+								stripe,
+								stripeConfiguration,
+								createStripeSetupIntent,
+								saveCreditCard,
+								updateCreditCard,
+							},
+							data
+						),
+					'paypal-express': ( data: unknown ) =>
+						assignPayPalProcessor( purchase, data, createPayPalAgreement ),
+				},
+				submittedPaymentProcessorId
+			) }
 			initiallySelectedPaymentMethodId={ getInitiallySelectedPaymentMethodId(
 				currentlyAssignedPaymentMethodId,
 				paymentMethods

--- a/client/dashboard/me/billing-purchases/payment-methods/credit-card-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/payment-methods/credit-card-payment-method.tsx
@@ -11,6 +11,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { Fragment, useState } from 'react';
+import { useAnalytics } from '../../../app/analytics';
 import InlineSupportLink from '../../../components/inline-support-link';
 import { TaxLocationForm, defaultTaxLocation } from '../../../components/tax-location-form';
 import { PaymentMethodImage } from '../payment-method-image';
@@ -203,6 +204,7 @@ function CreditCardSubmitButton( {
 } ) {
 	const { formStatus } = useFormStatus();
 	const { createErrorNotice } = useDispatch( noticesStore );
+	const { recordTracksEvent } = useAnalytics();
 
 	const handleButtonPress = () => {
 		if ( ! onClick ) {
@@ -212,6 +214,8 @@ function CreditCardSubmitButton( {
 		}
 		const formData = getFormData();
 		const cardElement = getCardElement();
+
+		recordTracksEvent( 'calypso_dashboard_payment_method_save_card_click' );
 
 		if ( ! formData.taxLocation.country_code ) {
 			createErrorNotice( __( 'Please select a country.' ), { type: 'snackbar' } );

--- a/packages/composite-checkout/src/components/form-and-transaction-event-handler.ts
+++ b/packages/composite-checkout/src/components/form-and-transaction-event-handler.ts
@@ -2,7 +2,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
 import { useEffect, useRef, useCallback } from 'react';
 import { useTransactionStatus } from '../lib/transaction-status';
-import { usePaymentMethodId } from '../public-api';
+import { usePaymentMethod, usePaymentMethodId } from '../public-api';
 import { TransactionStatus } from '../types';
 import type {
 	PaymentEventCallback,
@@ -57,6 +57,7 @@ export function useTransactionStatusHandler( {
 
 	const { __ } = useI18n();
 	const [ paymentMethodId ] = usePaymentMethodId();
+	const paymentProcessorId = usePaymentMethod()?.paymentProcessorId;
 	const {
 		previousTransactionStatus,
 		transactionLastResponse,
@@ -75,6 +76,7 @@ export function useTransactionStatusHandler( {
 		transactionError,
 		transactionStatus,
 		paymentMethodId,
+		paymentProcessorId,
 		transactionLastResponse,
 	} );
 
@@ -112,6 +114,7 @@ function useCallStatusChangeCallbacks( {
 	transactionError,
 	transactionStatus,
 	paymentMethodId,
+	paymentProcessorId,
 	transactionLastResponse,
 }: {
 	onPaymentComplete?: PaymentEventCallback;
@@ -120,6 +123,7 @@ function useCallStatusChangeCallbacks( {
 	transactionError: string | null;
 	transactionStatus: TransactionStatus;
 	paymentMethodId: string | null | undefined;
+	paymentProcessorId: string | undefined;
 	transactionLastResponse: PaymentProcessorResponseData;
 } ): void {
 	// Store the callbacks as refs so we do not call them more than once if they
@@ -140,16 +144,30 @@ function useCallStatusChangeCallbacks( {
 		}
 		if ( paymentCompleteRef.current && transactionStatus === TransactionStatus.COMPLETE ) {
 			debug( "transactionStatus status changed to complete so I'm calling onPaymentComplete" );
-			paymentCompleteRef.current( { transactionLastResponse } );
+			paymentCompleteRef.current( {
+				transactionLastResponse,
+				paymentMethodId,
+				paymentProcessorId,
+			} );
 		}
 		if ( paymentRedirectRef.current && transactionStatus === TransactionStatus.REDIRECTING ) {
 			debug( "transaction status changed to redirecting so I'm calling onPaymentRedirect" );
-			paymentRedirectRef.current( { transactionLastResponse } );
+			paymentRedirectRef.current( {
+				transactionLastResponse,
+				paymentMethodId,
+				paymentProcessorId,
+			} );
 		}
 		if ( paymentErrorRef.current && transactionStatus === TransactionStatus.ERROR ) {
 			debug( "transaction status changed to error so I'm calling onPaymentError" );
-			paymentErrorRef.current( { paymentMethodId, transactionError } );
+			paymentErrorRef.current( { paymentMethodId, paymentProcessorId, transactionError } );
 		}
 		prevTransactionStatus.current = transactionStatus;
-	}, [ transactionStatus, paymentMethodId, transactionLastResponse, transactionError ] );
+	}, [
+		transactionStatus,
+		paymentMethodId,
+		paymentProcessorId,
+		transactionLastResponse,
+		transactionError,
+	] );
 }

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -137,6 +137,7 @@ export type PaymentMethodChangedCallback = ( method: string ) => void;
 export type PaymentEventCallback = ( args: PaymentEventCallbackArguments ) => void;
 export type PaymentErrorCallback = ( args: {
 	paymentMethodId: string | null | undefined;
+	paymentProcessorId: string | undefined;
 	transactionError: string | null;
 } ) => void;
 export type CheckoutPageErrorCallback = (
@@ -153,6 +154,8 @@ export type StepChangedEventArguments = {
 
 export type PaymentEventCallbackArguments = {
 	transactionLastResponse: PaymentProcessorResponseData;
+	paymentMethodId: string | null | undefined;
+	paymentProcessorId: string | undefined;
 };
 
 export type PaymentProcessorResponseData = unknown;

--- a/packages/composite-checkout/test/checkout-provider.tsx
+++ b/packages/composite-checkout/test/checkout-provider.tsx
@@ -155,6 +155,20 @@ describe( 'CheckoutProvider', () => {
 		expect( onPaymentComplete ).toHaveBeenCalled();
 	} );
 
+	it( 'passes the active payment method and processor to onPaymentComplete', async () => {
+		const user = userEvent.setup();
+		const onPaymentComplete = jest.fn();
+		render( <MyCheckout onPaymentComplete={ onPaymentComplete } /> );
+		user.click( screen.getByText( 'Complete' ) );
+		expect( await screen.findByText( 'Form Complete' ) ).toBeInTheDocument();
+		expect( onPaymentComplete ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				paymentMethodId: mockMethod.id,
+				paymentProcessorId: mockMethod.paymentProcessorId,
+			} )
+		);
+	} );
+
 	it( 'does not call onPaymentComplete twice when transaction status is complete even if callback changes', async () => {
 		const user = userEvent.setup();
 		const onPaymentComplete = jest.fn();
@@ -260,6 +274,20 @@ describe( 'CheckoutProvider', () => {
 		expect( onPaymentError ).toHaveBeenCalled();
 	} );
 
+	it( 'passes the active payment method and processor to onPaymentError', async () => {
+		const onPaymentError = jest.fn();
+		const user = userEvent.setup();
+		render( <MyCheckout onPaymentError={ onPaymentError } /> );
+		user.click( screen.getByText( 'Cause Error' ) );
+		expect( await screen.findByText( 'Showing Error' ) ).toBeInTheDocument();
+		expect( onPaymentError ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				paymentMethodId: mockMethod.id,
+				paymentProcessorId: mockMethod.paymentProcessorId,
+			} )
+		);
+	} );
+
 	it( 'renders form as submitting when isValidating changed from true to false and transaction is submitting', async () => {
 		const onPaymentError = jest.fn();
 		const user = userEvent.setup();
@@ -286,7 +314,7 @@ describe( 'CheckoutProvider', () => {
 function createMockMethod(): PaymentMethod {
 	return {
 		id: 'mock',
-		paymentProcessorId: 'mock',
+		paymentProcessorId: 'mock-processor',
 		label: <span data-testid="mock-label">Mock Label</span>,
 		activeContent: <MockPaymentForm />,
 		submitButton: <button>Pay Please</button>,


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2401/dashboard-payment-methods-add-tracks-events-for-the-remaining

## Proposed Changes

Adds Tracks events to the rest of the Dashboard payment methods screen and the add/change payment method flows, which until now recorded only deletion. Row actions get one uniform event modeled on the sites dashboard's `calypso_dashboard_sites_action_click`, and each mutation gets success/failure counterparts matching the existing delete events.

Dashboard payment methods screen:

* Add `calypso_dashboard_payment_method_action_click` for every row action (`enable-backup`, `disable-backup`, `edit-billing-address`, `remove`), carrying `action` and `source`.
* Route the "Use as backup" column toggle through the same handler, so backup changes are counted whether they come from the toggle or the actions menu — `source` tells them apart.
* Drop `calypso_dashboard_payment_method_delete_click` in favor of the uniform action event, so the `remove` click isn't recorded twice.
* Add `calypso_dashboard_payment_method_set_backup` / `..._set_backup_failure` on the set-backup mutation.
* Add `calypso_dashboard_payment_method_delete_cancel_click` when the removal dialog is dismissed.
* Add `..._edit_billing_address_save_click` and `..._edit_billing_address_cancel_click`, plus `..._edit_billing_address` / `..._edit_billing_address_failure` on the tax info mutation.
* Add `calypso_dashboard_payment_method_add_click` on the "Add payment method" CTA.

Add and change payment method flows:

* Add `calypso_dashboard_payment_method_save_card_click` on the credit card "Save card" button.
* Add `calypso_dashboard_payment_method_add` / `..._add_failure` when a payment method is added, and `calypso_dashboard_purchase_payment_method_change` / `..._change_failure` when one is assigned to an existing subscription. Both carry `payment_processor` and `payment_method_id`.

composite-checkout:

* Pass `paymentMethodId` and `paymentProcessorId` to `onPaymentComplete` and `onPaymentRedirect`, and add `paymentProcessorId` to `onPaymentError`, which already received the method id. Additive to the callback argument objects, so existing consumers are unaffected.

Every payment methods screen event carries `payment_partner`, `is_backup` and `is_expired`. `path` and `environment_id` are added automatically by the Dashboard analytics client and super props, so neither is passed explicitly.

Two details worth knowing when querying these:

* On the set-backup events, `is_backup` is the value being saved. On `action_click` it is the state the payment method was in when the user acted.
* Both dialogs' `onCancel` also fires on Escape and outside-click, so the two `..._cancel_click` events count dismissals, not only button presses.

## Why are these changes being made?

SHILL-2398 instrumented deletion and nothing else, so we can currently see people removing payment methods but not what else they do on the screen: how often the actions menu is used and for what, how many people who start adding a card finish, or how often the billing address dialog is abandoned. Each of those is a funnel we can't measure, and as users move off the Classic purchases pages the uninstrumented half of the surface grows.

For the row actions, reusing `calypso_dashboard_sites_action_click` outright was tempting since the shape is exactly right, but that event is scoped to the sites DataViews and folding payment-method actions into it would make its `action` values ambiguous and skew every query already built on it. A parallel event with an identical contract keeps the two surfaces separable while staying queryable the same way.

The "Save card" event sits on the button's press handler rather than on the payment processor. The processor only runs after the button's own validation passes, so a processor-level hook would silently miss every click that bails out on the missing-country check — exactly the drop-off worth seeing. The credit card submit button is shared between the add and change flows, but the automatic `path` property already separates them, so it needs no flow argument.

Adding a payment method and reassigning one to an existing subscription share `PaymentMethodSelector` but are different user intents, so they get distinct event names instead of one event with a boolean property. Collapsing them would mean every future query had to remember to filter on that flag to get a correct "methods added" number.

The composite-checkout change exists because the completion events need to name the payment method that was used, and the provider wasn't reporting it. `useTransactionStatusHandler` already had the id in scope and handed it to `onPaymentError`, but gave `onPaymentComplete` and `onPaymentRedirect` only the transaction response — an arbitrary asymmetry. The alternative was for each consumer to wrap its own payment processors to record what was submitted, which is a workaround for a gap the provider is better placed to close, and one every future consumer would have to reinvent.

## Testing Instructions

* Open the browser devtools network tab and filter for `pixel.wp.com` (or use the Tracks debug tooling) so events are visible as they fire.
* Go to `/me/billing/payment-methods`. Click "Add payment method" and confirm `calypso_dashboard_payment_method_add_click`.
* On the add form, press "Save card" without choosing a country. Confirm `calypso_dashboard_payment_method_save_card_click` still fires alongside the "Please select a country" snackbar.
* Complete the form with a test card and confirm `calypso_dashboard_payment_method_add` fires on success, with `payment_processor: card`.
* Back on the list, open a row's actions menu and try each item. Confirm one `calypso_dashboard_payment_method_action_click` per item with the matching `action` and `source: actions-menu`.
* Flip the "Use as backup" toggle in the table and confirm the same event with `source: toggle`, followed by `calypso_dashboard_payment_method_set_backup` with `is_backup` set to the new value.
* Open "Edit billing information", press Cancel, then reopen and press Save. Confirm the cancel and save events, and `..._edit_billing_address` after the save succeeds.
* Open "Remove payment method", press Cancel, then reopen and confirm. Confirm the cancel, confirm, and delete events.
* From a purchase's payment method screen, assign a different method and confirm `calypso_dashboard_purchase_payment_method_change` rather than the `..._add` event.
* Because composite-checkout is shared, smoke-test a regular checkout purchase and confirm it still completes and redirects to the thank-you page as usual.
