### PR TITLE
Agents Manager: bind cached JWTs to user and site

### DIFF
--- a/packages/agents-manager/src/auth/__tests__/calypso-auth-provider.test.ts
+++ b/packages/agents-manager/src/auth/__tests__/calypso-auth-provider.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/order -- jest.mock calls must precede imports */
+jest.mock(
+	'@automattic/oauth-token',
+	() => ( {
+		getToken: jest.fn( () => false ),
+	} ),
+	{ virtual: true }
+);
+
+jest.mock(
+	'@wordpress/api-fetch',
+	() => ( {
+		__esModule: true,
+		default: jest.fn(),
+	} ),
+	{ virtual: true }
+);
+
+jest.mock(
+	'wpcom-proxy-request',
+	() => ( {
+		__esModule: true,
+		default: jest.fn(),
+		canAccessWpcomApis: jest.fn( () => false ),
+	} ),
+	{ virtual: true }
+);
+
+import * as oauthToken from '@automattic/oauth-token';
+import apiFetch from '@wordpress/api-fetch';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import { createCalypsoAuthProvider } from '../calypso-auth-provider';
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+const mockCanAccessWpcomApis = canAccessWpcomApis as jest.Mock;
+const mockGetOAuthToken = oauthToken.getToken as jest.Mock;
+const mockWpcomRequest = wpcomRequest as jest.Mock;
+
+describe( 'createCalypsoAuthProvider JWT cache', () => {
+	beforeEach( () => {
+		mockApiFetch.mockReset();
+		mockCanAccessWpcomApis.mockReset().mockReturnValue( false );
+		mockGetOAuthToken.mockReset().mockReturnValue( false );
+		mockWpcomRequest.mockReset();
+		localStorage.clear();
+		sessionStorage.clear();
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'reuses a token for the same user and site without writing it to browser storage', async () => {
+		mockApiFetch.mockResolvedValue( { token: 'cached-token', blog_id: '4101' } );
+		const auth = createCalypsoAuthProvider( 4101, { userId: 5101 } );
+
+		await expect( auth() ).resolves.toMatchObject( { Authorization: 'cached-token' } );
+		await expect( auth() ).resolves.toMatchObject( { Authorization: 'cached-token' } );
+
+		expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( sessionStorage ).toHaveLength( 0 );
+	} );
+
+	it( 'uses user B auth after a same-page account switch', async () => {
+		mockApiFetch
+			.mockResolvedValueOnce( { token: 'user-a-token', blog_id: '4102' } )
+			.mockResolvedValueOnce( { token: 'user-b-token', blog_id: '4102' } );
+
+		const userAAuth = createCalypsoAuthProvider( 4102, { userId: 5102 } );
+		const userBAuth = createCalypsoAuthProvider( 4102, { userId: 5103 } );
+
+		await expect( userAAuth() ).resolves.toMatchObject( { Authorization: 'user-a-token' } );
+		await expect( userBAuth() ).resolves.toMatchObject( { Authorization: 'user-b-token' } );
+		expect( mockApiFetch ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'does not reuse one site auth token for another site', async () => {
+		mockApiFetch
+			.mockResolvedValueOnce( { token: 'site-4103-token', blog_id: '4103' } )
+			.mockResolvedValueOnce( { token: 'site-4104-token', blog_id: '4104' } );
+
+		const siteAAuth = createCalypsoAuthProvider( 4103, { userId: 5104 } );
+		const siteBAuth = createCalypsoAuthProvider( 4104, { userId: 5104 } );
+
+		await expect( siteAAuth() ).resolves.toMatchObject( {
+			Authorization: 'site-4103-token',
+		} );
+		await expect( siteBAuth() ).resolves.toMatchObject( {
+			Authorization: 'site-4104-token',
+		} );
+		expect( mockApiFetch ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'refetches an expired token', async () => {
+		const now = 1_000_000;
+		const nowSpy = jest.spyOn( Date, 'now' ).mockReturnValue( now );
+		mockApiFetch
+			.mockResolvedValueOnce( { token: 'first-token', blog_id: '4105' } )
+			.mockResolvedValueOnce( { token: 'fresh-token', blog_id: '4105' } );
+		const auth = createCalypsoAuthProvider( 4105, { userId: 5105 } );
+
+		await expect( auth() ).resolves.toMatchObject( { Authorization: 'first-token' } );
+		nowSpy.mockReturnValue( now + 30 * 60 * 1000 + 1 );
+		await expect( auth() ).resolves.toMatchObject( { Authorization: 'fresh-token' } );
+		expect( mockApiFetch ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'applies the same user boundary to wpcomRequest JWTs', async () => {
+		mockCanAccessWpcomApis.mockReturnValue( true );
+		mockWpcomRequest
+			.mockResolvedValueOnce( { token: 'user-a-token', blog_id: 4106 } )
+			.mockResolvedValueOnce( { token: 'user-b-token', blog_id: 4106 } );
+
+		const userAAuth = createCalypsoAuthProvider( 4106, { userId: 5106 } );
+		const userBAuth = createCalypsoAuthProvider( 4106, { userId: 5107 } );
+
+		await expect( userAAuth() ).resolves.toMatchObject( {
+			Authorization: 'Bearer user-a-token',
+		} );
+		await expect( userAAuth() ).resolves.toMatchObject( {
+			Authorization: 'Bearer user-a-token',
+		} );
+		await expect( userBAuth() ).resolves.toMatchObject( {
+			Authorization: 'Bearer user-b-token',
+		} );
+		expect( mockWpcomRequest ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'ignores a JWT left in sessionStorage by the old cache', async () => {
+		sessionStorage.setItem(
+			'jetpack-ai-jwt-token',
+			JSON.stringify( { token: 'legacy-token', expire: Date.now() + 60_000 } )
+		);
+		mockApiFetch.mockResolvedValue( { token: 'fresh-token', blog_id: '4107' } );
+
+		const auth = createCalypsoAuthProvider( 4107, { userId: 5108 } );
+
+		await expect( auth() ).resolves.toMatchObject( { Authorization: 'fresh-token' } );
+		expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'caches within the page when the caller has no user identity', async () => {
+		mockApiFetch.mockResolvedValue( { token: 'reader-token', blog_id: '4108' } );
+		const auth = createCalypsoAuthProvider( 4108 );
+
+		await expect( auth() ).resolves.toMatchObject( { Authorization: 'reader-token' } );
+		await expect( auth() ).resolves.toMatchObject( { Authorization: 'reader-token' } );
+		expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/packages/agents-manager/src/auth/calypso-auth-provider.ts
+++ b/packages/agents-manager/src/auth/calypso-auth-provider.ts
@@ -18,16 +18,17 @@ interface CalypsoAuthError {
 
 interface CalypsoAuthProviderOptions {
 	logWpcomJwtFailure?: boolean;
+	userId?: string | number;
 }
 
-const JWT_TOKEN_ID = 'jetpack-ai-jwt-token';
 const JWT_TOKEN_EXPIRATION_TIME = 30 * 60 * 1000; // 30 minutes
 
 interface TokenData {
 	token: string;
-	blogId: string;
 	expire: number;
 }
+
+const jwtCache = new Map< string, TokenData >();
 
 declare global {
 	interface Window {
@@ -44,76 +45,63 @@ declare global {
 }
 
 /**
- * Get cached JWT token data from sessionStorage
- * @param key - Storage key
+ * Get a cached JWT token from this page load.
+ * @param key - Cache key
  * @returns TokenData or null
  */
 function getCachedJwtToken( key: string ): TokenData | null {
-	try {
-		const cached = sessionStorage.getItem( key );
-		if ( cached ) {
-			const tokenData = JSON.parse( cached ) as TokenData;
-			if ( tokenData?.token && tokenData?.expire && tokenData.expire > Date.now() ) {
-				return tokenData;
-			}
-		}
-	} catch {
-		// Invalid cached token
+	const cached = jwtCache.get( key );
+	if ( cached?.token && cached.expire > Date.now() ) {
+		return cached;
 	}
+
+	jwtCache.delete( key );
 	return null;
 }
 
-/**
- * Set cached JWT token data in sessionStorage
- * @param key - Storage key
- * @param tokenData - Token data to cache
- */
-function setCachedJwtToken( key: string, tokenData: TokenData ): void {
-	try {
-		sessionStorage.setItem( key, JSON.stringify( tokenData ) );
-	} catch {
-		// Continue without caching
-	}
+function getJwtCacheKey(
+	source: 'api' | 'wpcom',
+	userId?: string | number,
+	blogId?: string | number
+): string {
+	return `${ source }:${ userId ?? 'no-user' }:${ blogId ?? 'no-site' }`;
 }
 
 /**
  * Request a JWT token from the WordPress REST API (for wp-admin contexts)
  * Based on big-sky-plugin's requestJetpackToken implementation
  * @param siteId - Optional site ID to use for simple sites (if not available in window)
- * @param useCachedToken - Whether to use cached token
+ * @param userId - Current user ID used to bind cached tokens
  */
 async function requestJWTToken(
 	siteId?: string | number,
-	useCachedToken = true
+	userId?: string | number
 ): Promise< TokenData | null > {
-	// Check for cached token
-	if ( useCachedToken ) {
-		const cached = getCachedJwtToken( JWT_TOKEN_ID );
-		if ( cached ) {
-			return cached;
-		}
+	const effectiveSiteId = siteId || window.Jetpack_Editor_Initial_State?.wpcomBlogId;
+	const cacheKey = getJwtCacheKey( 'api', userId, effectiveSiteId );
+
+	const cached = getCachedJwtToken( cacheKey );
+	if ( cached ) {
+		return cached;
 	}
 
 	const apiNonce = window.JP_CONNECTION_INITIAL_STATE?.apiNonce;
-	// Use provided siteId or fallback to window
-	const effectiveSiteId = siteId || window.Jetpack_Editor_Initial_State?.wpcomBlogId;
 
-	let data: { token: string; blog_id: string } = {
+	let data: { token: string } = {
 		token: '',
-		blog_id: '',
 	};
 
 	try {
 		if ( canAccessWpcomApis() ) {
 			// WordPress.com simple site — use /ai/jwt (supports user-only and site-scoped tokens)
-			data = await apiFetch< { token: string; blog_id: string } >( {
+			data = await apiFetch< { token: string } >( {
 				path: '/wpcom/v2/ai/jwt',
 				method: 'POST',
 				data: effectiveSiteId ? { blog_id: Number( effectiveSiteId ) } : {},
 			} );
 		} else {
 			// Jetpack-connected site
-			data = await apiFetch< { token: string; blog_id: string } >( {
+			data = await apiFetch< { token: string } >( {
 				path: '/jetpack/v4/jetpack-ai-jwt?_cacheBuster=' + Date.now(),
 				credentials: 'same-origin',
 				headers: {
@@ -132,12 +120,10 @@ async function requestJWTToken(
 
 	const newTokenData: TokenData = {
 		token: data.token,
-		blogId: data.blog_id || '',
 		expire: Date.now() + JWT_TOKEN_EXPIRATION_TIME,
 	};
 
-	// Cache the token
-	setCachedJwtToken( JWT_TOKEN_ID, newTokenData );
+	jwtCache.set( cacheKey, newTokenData );
 
 	return newTokenData;
 }
@@ -146,22 +132,20 @@ async function requestJWTToken(
  * Request a JWT token using wpcomRequest (for Calypso contexts).
  * Uses the /wpcom/v2/ai/jwt endpoint which supports both site-scoped
  * and user-only tokens.
- *
  * @param siteId - Optional site ID. When provided, the JWT includes site context.
- * @param useCachedToken - Whether to use cached token (default: true)
+ * @param userId - Current user ID used to bind cached tokens
+ * @param logFailure - Whether to log failed token requests
  */
 async function requestJWTTokenViaWpcom(
 	siteId?: string | number,
-	useCachedToken = true,
+	userId?: string | number,
 	logFailure = true
 ): Promise< string | null > {
-	const cacheKey = siteId ? `${ JWT_TOKEN_ID }-wpcom-${ siteId }` : `${ JWT_TOKEN_ID }-wpcom`;
+	const cacheKey = getJwtCacheKey( 'wpcom', userId, siteId );
 
-	if ( useCachedToken ) {
-		const cached = getCachedJwtToken( cacheKey );
-		if ( cached ) {
-			return cached.token;
-		}
+	const cached = getCachedJwtToken( cacheKey );
+	if ( cached ) {
+		return cached.token;
 	}
 
 	try {
@@ -170,14 +154,13 @@ async function requestJWTTokenViaWpcom(
 			apiNamespace: 'wpcom/v2',
 			method: 'POST',
 			body: siteId ? { blog_id: Number( siteId ) } : {},
-		} ) ) as { token?: string; blog_id?: number; success?: boolean };
+		} ) ) as { token?: string };
 
 		const token = data?.token;
 
 		if ( token ) {
-			setCachedJwtToken( cacheKey, {
+			jwtCache.set( cacheKey, {
 				token,
-				blogId: String( data?.blog_id || siteId || '' ),
 				expire: Date.now() + JWT_TOKEN_EXPIRATION_TIME,
 			} );
 		}
@@ -247,7 +230,7 @@ export const createCalypsoAuthProvider = (
 			// Fallback to JWT via /ai/jwt (works with or without siteId)
 			const jwtToken = await requestJWTTokenViaWpcom(
 				siteId,
-				true,
+				options.userId,
 				options.logWpcomJwtFailure ?? true
 			);
 			if ( jwtToken ) {
@@ -257,7 +240,7 @@ export const createCalypsoAuthProvider = (
 		} else {
 			// Not in Calypso: Use JWT token from apiFetch (wp-admin context)
 			try {
-				const tokenData = await requestJWTToken( siteId );
+				const tokenData = await requestJWTToken( siteId, options.userId );
 				if ( tokenData?.token ) {
 					// Use token directly without "Bearer" prefix (as per big-sky-plugin)
 					headers.Authorization = tokenData.token;

--- a/packages/agents-manager/src/utils/__tests__/create-agent-config.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/create-agent-config.test.ts
@@ -146,6 +146,20 @@ describe( 'createAgentConfig', () => {
 		expect( context ).toEqual( expect.objectContaining( { selectedSiteId: 247750866 } ) );
 	} );
 
+	it( 'binds the auth provider to the current user and site', async () => {
+		await createAgentConfig( {
+			sessionId: 'session-1',
+			sessionSiteKey: '987',
+			sessionUserId: 123,
+			siteId: 987,
+		} );
+
+		expect( mockCreateCalypsoAuthProvider ).toHaveBeenCalledWith( 987, {
+			logWpcomJwtFailure: true,
+			userId: 123,
+		} );
+	} );
+
 	it( 'adds site editor constructor arguments from the host environment', async () => {
 		const config = await createAgentConfig( {
 			sessionId: 'session-1',

--- a/packages/agents-manager/src/utils/create-agent-config.ts
+++ b/packages/agents-manager/src/utils/create-agent-config.ts
@@ -269,6 +269,7 @@ export async function createAgentConfig(
 			saveSessionId( newSessionId, agentId, sessionSiteKey, sessionUserId ),
 		authProvider: createCalypsoAuthProvider( siteId, {
 			logWpcomJwtFailure: ! isReaderChatAgent( agentId ),
+			...( sessionUserId !== undefined && { userId: sessionUserId } ),
 		} ),
 		enableStreaming: true,
 	};


### PR DESCRIPTION
🤖 Codex (GPT-5)

Fixes WOOAI-944

## Why are these changes being made?

Agents Manager cached 30-minute JWTs in `sessionStorage` under keys that did not identify the current user. If account A logged out and account B logged in in the same tab, B could reuse A's cached JWT until it expired.

This is a frontend cache-selection bug. The backend still signs and validates the token's user and site; the fix belongs in the auth provider that decides which token to reuse.

Session IDs are a separate concern and are already scoped by user, site, and agent in #113405. This PR only changes JWT caching.

## Proposed Changes

* Replace the browser-persistent JWT cache with a module-level, expiring `Map` keyed by token source, user ID, and site ID.
* Pass the user already captured as `sessionUserId` to the auth provider instead of introducing a second identity field.
* Apply the same cache boundary to both JWT request paths: `apiFetch` for wp-admin/Jetpack contexts and `wpcomRequest` for the WordPress.com fallback.
* Stop reading, writing, migrating, or clearing JWTs in `sessionStorage`. A normal logout reload removes the in-memory cache; the keyed identity also protects a user or site change within the same document.
* Preserve within-page caching for callers that do not supply a user ID, including Reader Chat. Those callers still lose the cache on page reload.
* Keep the 30-minute expiry check and add behavior-level regressions for reuse, user and site isolation, expiry, both request paths, legacy stored tokens, and callers without user identity.

This deliberately does not change headless initialization or agent-session storage, and it does not clear Image Studio's similarly named cache entries. The tradeoff is one JWT request per page load instead of one per tab in surfaces that use JWT authentication.

## Testing Instructions

### Calypso smoke test

1. From a clean checkout, run `yarn install` and then `yarn start` from the repository root.
2. Open Agents Manager for a test site.
3. Load an existing conversation and submit a message.
4. Confirm history and authenticated requests continue to work. Calypso normally uses OAuth, so this is primarily a regression smoke test for the shared auth provider.

### Simple/Atomic/CIAB JWT flow

1. Configure the standard `widgets.wp.com` sandbox described in `packages/agents-manager/AGENTS.md`.
2. Run `cd apps/agents-manager && yarn dev --sync`.
3. In one tab, sign in as account A on a JWT-authenticated test site, open Agents Manager, and load history or submit a message.
4. In the Network panel, confirm the JWT endpoint is requested (`/jetpack/v4/jetpack-ai-jwt` or `/wpcom/v2/ai/jwt`).
5. Log out, sign in as account B in the same tab, and reopen Agents Manager.
6. Confirm a fresh JWT request is made for B and A's conversations are not shown.
7. In a clean tab that has not opened Image Studio, confirm Agents Manager does not create a `jetpack-ai-jwt-token*` entry in `sessionStorage`.

## Proofs

* The auth-provider regressions verify that account B does not receive account A's token, sites do not share tokens, expired tokens are refetched, and both JWT request paths use the same identity boundary.
* The regressions also verify that Agents Manager does not write JWTs to browser storage, ignores a legacy JWT already present in `sessionStorage`, and still caches once per page when a caller has no user ID.
* `yarn jest -c test/packages/jest.config.js --testPathPattern=agents-manager --runInBand` — 68 suites and 800 tests passed.
* `yarn workspace @automattic/agents-manager build` — passed.
* Targeted ESLint and Prettier checks passed for all four changed files.
* PR CI passed at `3cd92400faa`: unit tests, code style, Calypso/Dashboard/A4A E2E, Docker image, and translation checks.
* The final two-account sandbox flow has not been rerun after the in-memory-cache reimplementation; the steps above are provided for reviewer verification.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have you tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
