### PR TITLE
Fix CSAT rating state being lost after submitting a comment

### DIFF
--- a/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
+++ b/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
@@ -111,12 +111,16 @@ function clusterMessagesBySender( messages: Message[] ) {
 		role: MessageRole | 'csat' | 'attachment' | 'feedback' | 'zendesk-intro' | 'business-automated';
 		messages: Message[];
 	} = {
-		id: crypto.randomUUID(),
+		// A deterministic id, not crypto.randomUUID(): that was regenerated on every render (this
+		// function isn't memoized), so the Fragment keyed on it below force-remounted the entire
+		// cluster -- including any in-progress CSATForm state -- on every unrelated re-render.
+		id: String( getMessageUniqueIdentifier( messages[ 0 ], 'group-0' ) ),
 		role: getPresentedRole( messages[ 0 ] ),
 		messages: [],
 	};
 
 	const groups = [ currentGroup ];
+	let groupIndex = 1;
 
 	const sortedMessages = sortMessagesByTimestamp( messages );
 	const lastCSATMessage = sortedMessages.filter( isCSATMessage ).at( -1 );
@@ -135,11 +139,12 @@ function clusterMessagesBySender( messages: Message[] ) {
 
 		if ( shouldStartNewGroup( message, currentGroup ) ) {
 			currentGroup = {
-				id: crypto.randomUUID(),
+				id: String( getMessageUniqueIdentifier( message, `group-${ groupIndex }` ) ),
 				role: getPresentedRole( message ),
 				messages: [],
 			};
 			groups.push( currentGroup );
+			groupIndex++;
 		}
 
 		currentGroup.messages.push( message );

--- a/packages/odie-client/src/components/message/test/messages-cluster.tsx
+++ b/packages/odie-client/src/components/message/test/messages-cluster.tsx
@@ -15,14 +15,26 @@ jest.mock( '../../../utils/csat', () => ( {
 	isZendeskIntroMessage: () => false,
 } ) );
 
+// Tracks every mount of the mocked ChatMessage below, so tests can assert a re-render did (or
+// didn't) force React to remount a message -- which is exactly the failure mode of DOTCOM-18205:
+// an unstable message-cluster key wiped CSATForm's local rating state on every unrelated re-render.
+const mockMountSpy = jest.fn();
+
 jest.mock( '..', () => ( {
 	__esModule: true,
-	default: ( { message, header }: { message: Message; header?: React.ReactNode } ) => (
-		<div>
-			{ header }
-			<div>{ message.content }</div>
-		</div>
-	),
+	default: ( { message, header }: { message: Message; header?: React.ReactNode } ) => {
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		jest.requireActual( 'react' ).useEffect( () => {
+			mockMountSpy( message.content );
+		}, [] );
+
+		return (
+			<div>
+				{ header }
+				<div>{ message.content }</div>
+			</div>
+		);
+	},
 } ) );
 
 jest.mock( '../../chat-with-support', () => () => null );
@@ -72,6 +84,7 @@ describe( 'MessagesClusterizer', () => {
 
 	afterEach( () => {
 		jest.restoreAllMocks();
+		mockMountSpy.mockClear();
 	} );
 
 	it( 'splits automated business message groups when the display name changes', () => {
@@ -126,5 +139,44 @@ describe( 'MessagesClusterizer', () => {
 
 		expect( screen.getByText( 'CSAT prompt' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Follow-up message' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not remount a message when re-rendered with an equivalent (but new) messages array', () => {
+		// A fresh array reference each time, as happens when a parent re-renders in response to an
+		// unrelated Zendesk conversation event -- e.g. after submitting a CSAT comment. Regression
+		// test for DOTCOM-18205: an unstable crypto.randomUUID() group key was force-remounting the
+		// whole message cluster (and resetting CSATForm's local rating state) on every such re-render.
+		const buildMessages = (): Message[] => [
+			createCSATMessage( { content: 'CSAT prompt', received: 1 } ),
+		];
+
+		const { rerender } = render( <MessagesClusterizer messages={ buildMessages() } /> );
+		expect( mockMountSpy ).toHaveBeenCalledTimes( 1 );
+
+		rerender( <MessagesClusterizer messages={ buildMessages() } /> );
+
+		expect( mockMountSpy ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'remounts a message when a genuinely new message is appended', () => {
+		const first = [ createCSATMessage( { content: 'CSAT prompt', received: 1 } ) ];
+		const { rerender } = render( <MessagesClusterizer messages={ first } /> );
+		expect( mockMountSpy ).toHaveBeenCalledTimes( 1 );
+
+		rerender(
+			<MessagesClusterizer
+				messages={ [
+					...first,
+					createBusinessMessage( {
+						content: 'Follow-up message',
+						displayName: 'WordPress.com',
+						received: 2,
+					} ),
+				] }
+			/>
+		);
+
+		expect( mockMountSpy ).toHaveBeenCalledTimes( 2 );
+		expect( mockMountSpy ).toHaveBeenNthCalledWith( 2, 'Follow-up message' );
 	} );
 } );


### PR DESCRIPTION
Related to DOTCOM-18205

## Proposed changes

* Replace the two `crypto.randomUUID()` calls used to generate message-cluster group ids in `MessagesClusterizer` with a deterministic id derived from each group's first message, via the existing `getMessageUniqueIdentifier()` helper.

## Why are these changes being made?

* `clusterMessagesBySender()` isn't memoized, so it runs on every render — and with `crypto.randomUUID()`, that meant every group got a brand-new id on every render.
* The message cluster's `Fragment` is keyed on that group id. Submitting a CSAT comment (`postCSAT()` → `rateChat()`) triggers a Zendesk conversation update, which re-renders the message list. Since the key changed, React force-remounted the entire cluster, including `CSATForm` — resetting its local `useState(score)` and losing the rating the responder had just submitted.
* Deterministic ids keep the key stable across re-renders that don't actually add/remove/reorder messages, so only genuine structural changes cause a remount.

## Testing instructions

* `yarn typecheck-client` and `yarn typecheck-packages` pass.
* `yarn jest -c=test/packages/jest.config.js packages/odie-client` passes (62/62).
* Manually verified: open a support chat, let it reach the CSAT prompt, click a thumbs rating, type a comment, click Send — the rating pill now stays visible instead of disappearing.