### PR TITLE
MSD Billing: rename Monetize subscriptions, reorder, and crosslink

### DIFF
--- a/client/dashboard/me/billing-monetize-subscriptions/index.tsx
+++ b/client/dashboard/me/billing-monetize-subscriptions/index.tsx
@@ -4,13 +4,15 @@ import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { useResizeObserver } from '@wordpress/compose';
 import { DataViews, filterSortAndPaginate, type View } from '@wordpress/dataviews';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
-import { monetizeSubscriptionRoute } from '../../app/router/me';
+import { monetizeSubscriptionRoute, purchasesRoute } from '../../app/router/me';
 import { DataViewsCard } from '../../components/dataviews';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import RouterLinkButton from '../../components/router-link-button';
 import { adjustDataViewFieldsForWidth } from '../../utils/dataviews-width';
 import { useMonetizeFieldDefinitions } from './dataviews';
 import { getMonetizeSubscriptionsPageTitle } from './title';
@@ -97,7 +99,14 @@ function MonetizeSubscriptions() {
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ getMonetizeSubscriptionsPageTitle() }
-					description={ __( 'Manage your Monetize subscriptions.' ) }
+					description={ createInterpolateElement(
+						__(
+							'Manage memberships and donations from other WordPress.com sites. Your own plans and purchases are in <link>Active upgrades</link>.'
+						),
+						{
+							link: <RouterLinkButton variant="link" to={ purchasesRoute.to } />,
+						}
+					) }
 				/>
 			}
 		>

--- a/client/dashboard/me/billing-monetize-subscriptions/title.ts
+++ b/client/dashboard/me/billing-monetize-subscriptions/title.ts
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
 
 export function getMonetizeSubscriptionsPageTitle(): string {
-	return __( 'Monetize subscriptions' );
+	return __( 'Memberships & donations' );
 }

--- a/client/dashboard/me/billing-purchases/index.tsx
+++ b/client/dashboard/me/billing-purchases/index.tsx
@@ -7,13 +7,20 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import { useResizeObserver } from '@wordpress/compose';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useMemo, useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
+import { useAppContext } from '../../app/context';
 import { usePersistentView } from '../../app/hooks/use-persistent-view';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
-import { billingHistoryRoute, purchasesIndexRoute, purchasesRoute } from '../../app/router/me';
+import {
+	billingHistoryRoute,
+	monetizeSubscriptionsRoute,
+	purchasesIndexRoute,
+	purchasesRoute,
+} from '../../app/router/me';
 import { DataViews, DataViewsCard } from '../../components/dataviews';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -32,6 +39,10 @@ import {
 import { PurchaseRemovedNotice } from './purchase-removed-notice';
 
 export default function PurchasesList() {
+	const { supports } = useAppContext();
+	const supportsMonetizeSubscriptions = Boolean(
+		supports.me && supports.me.billing && supports.me.billing.monetizeSubscriptions
+	);
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
 	const currentSearchParams = purchasesRoute.useSearch();
 	const { removed, removedDomain, removedId } = purchasesIndexRoute.useSearch();
@@ -133,7 +144,18 @@ export default function PurchasesList() {
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ __( 'Active upgrades' ) }
-					description={ __( 'View and manage your active plans and purchases.' ) }
+					description={
+						supportsMonetizeSubscriptions
+							? createInterpolateElement(
+									__(
+										'View and manage your active plans and purchases. Purchases from other WordPress.com sites are in <link>Memberships & donations</link>.'
+									),
+									{
+										link: <RouterLinkButton variant="link" to={ monetizeSubscriptionsRoute.to } />,
+									}
+							  )
+							: __( 'View and manage your active plans and purchases.' )
+					}
 					actions={
 						activeSiteId !== undefined && (
 							<RouterLinkButton

--- a/client/dashboard/me/billing/index.tsx
+++ b/client/dashboard/me/billing/index.tsx
@@ -43,20 +43,20 @@ function Billing() {
 					decoration={ <Icon icon={ receipt } /> }
 					to={ purchasesRoute.to }
 				/>
+				{ supportsBilling.monetizeSubscriptions ? (
+					<RouterLinkSummaryButton
+						title={ getMonetizeSubscriptionsPageTitle() }
+						description={ __( 'Manage memberships and donations from other WordPress.com sites.' ) }
+						decoration={ <Icon icon={ currencyDollar } /> }
+						to={ monetizeSubscriptionsRoute.to }
+					/>
+				) : null }
 				<RouterLinkSummaryButton
 					title={ __( 'Billing history' ) }
 					description={ __( 'View email receipts for past purchases.' ) }
 					decoration={ <Icon icon={ backup } /> }
 					to={ billingHistoryRoute.to }
 				/>
-				{ supportsBilling.monetizeSubscriptions ? (
-					<RouterLinkSummaryButton
-						title={ getMonetizeSubscriptionsPageTitle() }
-						description={ __( 'Manage Monetize subscriptions.' ) }
-						decoration={ <Icon icon={ currencyDollar } /> }
-						to={ monetizeSubscriptionsRoute.to }
-					/>
-				) : null }
 				<RouterLinkSummaryButton
 					title={ __( 'Payment methods' ) }
 					description={ __( 'Manage credit cards saved to your account.' ) }


### PR DESCRIPTION
Part of SHILL-1852

## Proposed Changes

* Rename the "Monetize subscriptions" page to "Memberships & donations" (page title, breadcrumb, and billing menu item).
* Move the renamed item above "Billing history" in the Billing menu.
* Add crosslinks between the two purchase pages:
  * "Active upgrades" now mentions that purchases from other WordPress.com sites are in "Memberships & donations", with a link. Only shown when the dashboard variant supports the monetize page.
  * "Memberships & donations" now mentions that your own plans and purchases are in "Active upgrades", with a link.
* Reword both page/menu descriptions to drop the "Monetize" jargon.

## Why are these changes being made?

* "Monetize subscriptions" is unclear naming. Site owners may not know what "Monetize" means, and the customers who actually made these purchases definitely will not.
* The new name describes what the page contains (memberships and donations from other WordPress.com sites) and avoids the inaccurate "subscriptions" wording.
* Very few users have both types of purchases, but for those who do, the crosslinks make it easier to find the right page.

## Testing Instructions

1. Start the dashboard with `yarn start-dashboard`.
2. Go to `/me/billing`. Confirm the menu order is: Active upgrades, Memberships & donations, Billing history, Payment methods, Tax details.
3. Open "Memberships & donations". Confirm the title, breadcrumb, and description with a working link to "Active upgrades".
4. Open "Active upgrades". Confirm the description mentions "Memberships & donations" with a working link.
5. On a dashboard variant without monetize subscriptions support, confirm "Active upgrades" shows the original description without the link.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)