### PR TITLE
Analytics: take a single site and source in withSiteContext

### DIFF
--- a/apps/agents-manager/agents-manager-gutenberg-disconnected.js
+++ b/apps/agents-manager/agents-manager-gutenberg-disconnected.js
@@ -57,14 +57,10 @@ function AgentsManagerHelpButton() {
 					location: 'help-center',
 					section: 'gutenberg',
 				},
-				[
-					[
-						'agents_manager_data',
-						typeof agentsManagerData !== 'undefined' && agentsManagerData?.isWpcomPlatform === true
-							? agentsManagerData?.site?.ID
-							: undefined,
-					],
-				]
+				'agents_manager_data',
+				typeof agentsManagerData !== 'undefined' && agentsManagerData?.isWpcomPlatform === true
+					? agentsManagerData?.site?.ID
+					: undefined
 			)
 		);
 	};

--- a/apps/agents-manager/agents-manager-wp-admin-disconnected.js
+++ b/apps/agents-manager/agents-manager-wp-admin-disconnected.js
@@ -39,14 +39,10 @@ function initHelpCenterTracking() {
 					location: 'help-center',
 					section: 'wp-admin',
 				},
-				[
-					[
-						'agents_manager_data',
-						typeof agentsManagerData !== 'undefined' && agentsManagerData?.isWpcomPlatform === true
-							? agentsManagerData?.site?.ID
-							: undefined,
-					],
-				]
+				'agents_manager_data',
+				typeof agentsManagerData !== 'undefined' && agentsManagerData?.isWpcomPlatform === true
+					? agentsManagerData?.site?.ID
+					: undefined
 			)
 		);
 	} );

--- a/apps/help-center/tracks.js
+++ b/apps/help-center/tracks.js
@@ -1,18 +1,17 @@
 /* global helpCenterData */
-import { recordTracksEvent, withSiteContext } from '@automattic/calypso-analytics';
+import { NO_SITE_CONTEXT, recordTracksEvent, withSiteContext } from '@automattic/calypso-analytics';
 
 export function recordHostTracksEvent( eventName, properties = {} ) {
 	recordTracksEvent(
 		eventName,
-		withSiteContext( properties, [
-			[
-				'help_center_data',
-				typeof helpCenterData !== 'undefined' ? helpCenterData?.site?.ID : undefined,
-			],
-		] )
+		withSiteContext(
+			properties,
+			'help_center_data',
+			typeof helpCenterData !== 'undefined' ? helpCenterData?.site?.ID : undefined
+		)
 	);
 }
 
 export function recordDisconnectedHostTracksEvent( eventName, properties = {} ) {
-	recordTracksEvent( eventName, withSiteContext( properties, [] ) );
+	recordTracksEvent( eventName, withSiteContext( properties, NO_SITE_CONTEXT ) );
 }

--- a/client/blocks/eligibility-warnings/support-link.tsx
+++ b/client/blocks/eligibility-warnings/support-link.tsx
@@ -21,7 +21,7 @@ const SupportLink = ( {
 	onShowHelpAssistant?: () => void;
 } & LocalizeProps ) => {
 	const sectionName = useSelector( getSectionName );
-	const { siteCandidates } = useHelpCenterSite();
+	const { site, siteContextSource } = useHelpCenterSite();
 	const { show, isMinimized } = useDateStoreSelect( ( select ) => {
 		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
 		return {
@@ -47,7 +47,8 @@ const SupportLink = ( {
 						location: 'help-center',
 						section: sectionName,
 					},
-					siteCandidates
+					siteContextSource,
+					site?.ID
 				)
 			);
 		}
@@ -61,7 +62,8 @@ const SupportLink = ( {
 		show,
 		setShowHelpCenter,
 		sectionName,
-		siteCandidates,
+		siteContextSource,
+		site?.ID,
 		isMinimized,
 		setIsMinimized,
 	] );

--- a/client/blocks/inline-help/inline-help-search-card.tsx
+++ b/client/blocks/inline-help/inline-help-search-card.tsx
@@ -66,7 +66,8 @@ const InlineHelpSearchCard = ( {
 						location: location,
 						section: sectionName,
 					},
-					[ [ siteContextSource, blogId ] ]
+					siteContextSource,
+					blogId
 				)
 			);
 		}

--- a/client/dashboard/app/omnibar/plugin-help-center.tsx
+++ b/client/dashboard/app/omnibar/plugin-help-center.tsx
@@ -76,7 +76,8 @@ function handleMenuClick(
 					location: 'help-center',
 					section: 'dashboard',
 				},
-				[ [ 'omnibar', omnibarSiteId ] ]
+				'omnibar',
+				omnibarSiteId
 			)
 		);
 		closeAgentsManagerChat();
@@ -95,7 +96,8 @@ function handleMenuClick(
 				section: 'dashboard',
 				destination,
 			},
-			[ [ 'omnibar', omnibarSiteId ] ]
+			'omnibar',
+			omnibarSiteId
 		)
 	);
 }

--- a/client/layout/masterbar/masterbar-agents-manager/index.jsx
+++ b/client/layout/masterbar/masterbar-agents-manager/index.jsx
@@ -20,7 +20,7 @@ import './style.scss';
 const MasterbarAgentsManager = ( { tooltip } ) => {
 	const translate = useTranslate();
 	const sectionName = useSelector( getSectionName );
-	const { siteCandidates } = useHelpCenterSite();
+	const { site, siteContextSource } = useHelpCenterSite();
 
 	const agentsManagerVisible = useDateStoreSelect(
 		( select ) => select( AGENTS_MANAGER_STORE ).getAgentsManagerState().isOpen,
@@ -37,7 +37,8 @@ const MasterbarAgentsManager = ( { tooltip } ) => {
 					is_menu_panel_enabled: true,
 					is_assignment_loaded: true,
 				},
-				siteCandidates
+				siteContextSource,
+				site?.ID
 			)
 		);
 	};
@@ -65,7 +66,8 @@ const MasterbarAgentsManager = ( { tooltip } ) => {
 						location: 'help-center',
 						section: sectionName,
 					},
-					siteCandidates
+					siteContextSource,
+					site?.ID
 				)
 			);
 			return closeAgentsManagerChat();
@@ -83,7 +85,8 @@ const MasterbarAgentsManager = ( { tooltip } ) => {
 					section: sectionName,
 					destination,
 				},
-				siteCandidates
+				siteContextSource,
+				site?.ID
 			)
 		);
 	};

--- a/client/layout/masterbar/masterbar-help-center/index.jsx
+++ b/client/layout/masterbar/masterbar-help-center/index.jsx
@@ -25,7 +25,7 @@ const HELP_CENTER_STORE = HelpCenter.register();
 const MasterbarHelpCenter = ( { tooltip } ) => {
 	const translate = useTranslate();
 	const sectionName = useSelector( getSectionName );
-	const { siteCandidates } = useHelpCenterSite();
+	const { site, siteContextSource } = useHelpCenterSite();
 	const isNotificationsOpen = useSelector( ( state ) => getIsNotificationsOpen( state ) );
 	const prevIsNotificationsOpen = usePrevious( isNotificationsOpen );
 	const [ helpCenterPage, setHelpCenterPage ] = useState( null );
@@ -56,7 +56,8 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 					is_menu_panel_enabled: isMenuPanelExperimentEnabled,
 					is_assignment_loaded: ! isLoadingExperimentAssignment,
 				},
-				siteCandidates
+				siteContextSource,
+				site?.ID
 			)
 		);
 	};
@@ -71,7 +72,8 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 					location: 'help-center',
 					section: sectionName,
 				},
-				siteCandidates
+				siteContextSource,
+				site?.ID
 			)
 		);
 
@@ -100,7 +102,8 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 							location: 'help-center',
 							section: sectionName,
 						},
-						siteCandidates
+						siteContextSource,
+						site?.ID
 					)
 				);
 				setShowHelpCenter( false );
@@ -119,7 +122,8 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 						section: sectionName,
 						destination,
 					},
-					siteCandidates
+					siteContextSource,
+					site?.ID
 				)
 			);
 		}

--- a/client/layout/test/use-help-center-site.test.ts
+++ b/client/layout/test/use-help-center-site.test.ts
@@ -51,6 +51,7 @@ describe( 'useHelpCenterSite', () => {
 		const { result } = renderHookWithProvider( () => useHelpCenterSite() );
 
 		expect( result.current.site ).toBe( selectedSite );
+		expect( result.current.siteContextSource ).toBe( 'calypso_selected_site' );
 	} );
 
 	it( 'falls back to URL-param site before primary site', () => {
@@ -63,6 +64,7 @@ describe( 'useHelpCenterSite', () => {
 
 		expect( result.current.site ).toBe( urlParamSite );
 		expect( result.current.urlParamSite ).toBe( urlParamSite );
+		expect( result.current.siteContextSource ).toBe( 'calypso_url_param_site' );
 	} );
 
 	it( 'falls back to primary site', () => {
@@ -72,9 +74,10 @@ describe( 'useHelpCenterSite', () => {
 		const { result } = renderHookWithProvider( () => useHelpCenterSite() );
 
 		expect( result.current.site ).toBe( primarySite );
+		expect( result.current.siteContextSource ).toBe( 'calypso_primary_site' );
 	} );
 
-	it( 'reports the candidates in the same priority as the resolved site', () => {
+	it( 'names the source of the site it resolved', () => {
 		window.history.replaceState( {}, '', '/?siteId=2' );
 		mockGetSelectedSite.mockReturnValue( selectedSite );
 		mockGetSite.mockReturnValue( urlParamSite );
@@ -83,16 +86,14 @@ describe( 'useHelpCenterSite', () => {
 
 		const { result } = renderHookWithProvider( () => useHelpCenterSite() );
 
-		expect( result.current.siteCandidates ).toEqual( [
-			[ 'calypso_selected_site', 1 ],
-			[ 'calypso_url_param_site', 2 ],
-			[ 'calypso_primary_site', 3 ],
-		] );
+		expect( result.current.site ).toBe( selectedSite );
+		expect( result.current.siteContextSource ).toBe( 'calypso_selected_site' );
 	} );
 
-	it( 'returns no site when no candidate resolves', () => {
+	it( 'returns no site, and no source, when nothing resolves', () => {
 		const { result } = renderHookWithProvider( () => useHelpCenterSite() );
 
 		expect( result.current.site ).toBeNull();
+		expect( result.current.siteContextSource ).toBe( 'none' );
 	} );
 } );

--- a/client/layout/use-help-center-site.ts
+++ b/client/layout/use-help-center-site.ts
@@ -1,11 +1,10 @@
-import { useMemo } from 'react';
+import { NO_SITE_CONTEXT } from '@automattic/calypso-analytics';
 import { useSelector } from 'react-redux';
 import { getSiteSlugOrIdFromURLSearchParams } from 'calypso/lib/analytics/super-props';
 import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import getSite from 'calypso/state/sites/selectors/get-site';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import type { SiteCandidate } from '@automattic/calypso-analytics';
 
 export function useHelpCenterSite() {
 	const selectedSite = useSelector( getSelectedSite );
@@ -14,21 +13,22 @@ export function useHelpCenterSite() {
 	const primarySiteSlug = useSelector( getPrimarySiteSlug );
 	const primarySite = useSelector( ( state ) => getSiteBySlug( state, primarySiteSlug ) );
 
-	// The same order as `site`, kept as candidates so events can report which one they got.
-	const siteCandidates: SiteCandidate[] = useMemo(
-		() => [
-			[ 'calypso_selected_site', selectedSite?.ID ],
-			[ 'calypso_url_param_site', urlParamSite?.ID ],
-			[ 'calypso_primary_site', primarySite?.ID ],
-		],
-		[ selectedSite?.ID, urlParamSite?.ID, primarySite?.ID ]
-	);
+	const site = selectedSite || urlParamSite || primarySite;
+
+	let siteContextSource = NO_SITE_CONTEXT;
+	if ( selectedSite ) {
+		siteContextSource = 'calypso_selected_site';
+	} else if ( urlParamSite ) {
+		siteContextSource = 'calypso_url_param_site';
+	} else if ( primarySite ) {
+		siteContextSource = 'calypso_primary_site';
+	}
 
 	return {
 		selectedSite,
 		urlParamSite,
 		primarySite,
-		siteCandidates,
-		site: selectedSite || urlParamSite || primarySite,
+		site,
+		siteContextSource,
 	};
 }

--- a/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
+++ b/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
@@ -86,7 +86,8 @@ export default function useAdminBarIntegration( {
 						is_menu_panel_enabled: false,
 						is_assignment_loaded: true,
 					},
-					[ [ 'agents_manager_context', site?.ID ] ]
+					'agents_manager_context',
+					site?.ID
 				)
 			);
 
@@ -98,7 +99,8 @@ export default function useAdminBarIntegration( {
 						location: 'help-center',
 						section: sectionName || 'wp-admin',
 					},
-					[ [ 'agents_manager_context', site?.ID ] ]
+					'agents_manager_context',
+					site?.ID
 				)
 			);
 

--- a/packages/calypso-analytics/src/index.ts
+++ b/packages/calypso-analytics/src/index.ts
@@ -33,6 +33,5 @@ export {
 } from './train-tracks';
 export { getConnectionSpeedData } from './utils/connection-speed-data';
 export { getValidBlogId, withSiteContext, NO_SITE_CONTEXT } from './utils/site-context';
-export type { SiteCandidate } from './utils/site-context';
 
 export type { Railcar } from './train-tracks';

--- a/packages/calypso-analytics/src/utils/site-context.ts
+++ b/packages/calypso-analytics/src/utils/site-context.ts
@@ -10,9 +10,10 @@ export function getValidBlogId( value: unknown ): number | undefined {
 
 /**
  * Attaches `siteId` as `blog_id` and `source` as `site_context_source`. When `siteId` is
- * not a valid blog id, the event carries no `blog_id` and reports `site_context_source`
- * as `none` instead. A `blog_id` already in `properties` is dropped, not used: it is
- * whatever the caller put there, not necessarily the site the event is about.
+ * not a valid blog id, or `source` is `NO_SITE_CONTEXT`, the event carries no `blog_id`
+ * and reports `site_context_source` as `none` instead. A `blog_id` already in
+ * `properties` is dropped, not used: it is whatever the caller put there, not
+ * necessarily the site the event is about.
  *
  * `force_site_id` is dropped along with it when no site resolves. It only has an effect
  * when no explicit `blog_id` is present, and there it tells Calypso's super props to fall
@@ -24,7 +25,7 @@ export function withSiteContext(
 	siteId?: unknown
 ): TracksProperties {
 	const eventProperties = { ...properties };
-	const blogId = getValidBlogId( siteId );
+	const blogId = source === NO_SITE_CONTEXT ? undefined : getValidBlogId( siteId );
 
 	delete eventProperties.blog_id;
 	if ( blogId ) {

--- a/packages/calypso-analytics/src/utils/site-context.ts
+++ b/packages/calypso-analytics/src/utils/site-context.ts
@@ -1,7 +1,5 @@
 type TracksProperties = Record< string, unknown >;
 
-export type SiteCandidate = readonly [ source: string, siteId: unknown ];
-
 export const NO_SITE_CONTEXT = 'none';
 
 export function getValidBlogId( value: unknown ): number | undefined {
@@ -11,38 +9,31 @@ export function getValidBlogId( value: unknown ): number | undefined {
 }
 
 /**
- * Attaches the first valid site in `candidates` (highest priority first) as `blog_id`, and
- * its label as `site_context_source`. A `blog_id` already in `properties` is dropped, not
- * used: it is whatever the caller put there, not necessarily the site the event is about.
+ * Attaches `siteId` as `blog_id` and `source` as `site_context_source`. When `siteId` is
+ * not a valid blog id, the event carries no `blog_id` and reports `site_context_source`
+ * as `none` instead. A `blog_id` already in `properties` is dropped, not used: it is
+ * whatever the caller put there, not necessarily the site the event is about.
  *
- * `force_site_id` is dropped along with it when nothing resolves. It only has an effect
+ * `force_site_id` is dropped along with it when no site resolves. It only has an effect
  * when no explicit `blog_id` is present, and there it tells Calypso's super props to fall
  * back to the selected site — which would contradict a `site_context_source` of `none`.
  */
 export function withSiteContext(
 	properties: TracksProperties,
-	candidates: readonly SiteCandidate[]
+	source: string,
+	siteId?: unknown
 ): TracksProperties {
 	const eventProperties = { ...properties };
-	const resolved = candidates.reduce< { source: string; blogId: number } | undefined >(
-		( winner, [ source, siteId ] ) => {
-			if ( winner ) {
-				return winner;
-			}
-			const blogId = getValidBlogId( siteId );
-
-			return blogId ? { source, blogId } : undefined;
-		},
-		undefined
-	);
+	const blogId = getValidBlogId( siteId );
 
 	delete eventProperties.blog_id;
-	if ( resolved ) {
-		eventProperties.blog_id = resolved.blogId;
+	if ( blogId ) {
+		eventProperties.blog_id = blogId;
+		eventProperties.site_context_source = source;
 	} else {
 		delete eventProperties.force_site_id;
+		eventProperties.site_context_source = NO_SITE_CONTEXT;
 	}
-	eventProperties.site_context_source = resolved?.source ?? NO_SITE_CONTEXT;
 
 	return eventProperties;
 }

--- a/packages/calypso-analytics/test/site-context.ts
+++ b/packages/calypso-analytics/test/site-context.ts
@@ -47,6 +47,13 @@ describe( 'withSiteContext', () => {
 		} );
 	} );
 
+	test( 'ignores the site when the source is deliberately none', () => {
+		expect( withSiteContext( { source: 'chat' }, 'none', 123 ) ).toEqual( {
+			source: 'chat',
+			site_context_source: 'none',
+		} );
+	} );
+
 	test( 'never lets a caller-supplied blog_id stand in for the site', () => {
 		expect( withSiteContext( { source: 'chat', blog_id: 999 }, 'chat_site', 123 ) ).toEqual( {
 			source: 'chat',

--- a/packages/calypso-analytics/test/site-context.ts
+++ b/packages/calypso-analytics/test/site-context.ts
@@ -15,29 +15,16 @@ describe( 'getValidBlogId', () => {
 } );
 
 describe( 'withSiteContext', () => {
-	test( 'attaches the first usable candidate and names it', () => {
-		expect(
-			withSiteContext( { source: 'chat' }, [
-				[ 'explicit', undefined ],
-				[ 'help_center_context', 0 ],
-				[ 'primary_site', 123 ],
-			] )
-		).toEqual( { source: 'chat', blog_id: 123, site_context_source: 'primary_site' } );
-	} );
-
-	test( 'prefers the earlier candidate when several are usable', () => {
-		expect(
-			withSiteContext( {}, [
-				[ 'explicit', 123 ],
-				[ 'primary_site', 456 ],
-			] )
-		).toEqual( { blog_id: 123, site_context_source: 'explicit' } );
+	test( 'attaches the site and names its source', () => {
+		expect( withSiteContext( { source: 'chat' }, 'primary_site', 123 ) ).toEqual( {
+			source: 'chat',
+			blog_id: 123,
+			site_context_source: 'primary_site',
+		} );
 	} );
 
 	test( 'preserves other caller properties', () => {
-		expect(
-			withSiteContext( { source: 'chat', queued_messages: 2 }, [ [ 'chat_site', 123 ] ] )
-		).toEqual( {
+		expect( withSiteContext( { source: 'chat', queued_messages: 2 }, 'chat_site', 123 ) ).toEqual( {
 			source: 'chat',
 			queued_messages: 2,
 			blog_id: 123,
@@ -45,39 +32,45 @@ describe( 'withSiteContext', () => {
 		} );
 	} );
 
-	test( 'reports none, and omits blog_id, when no candidate is usable', () => {
-		expect(
-			withSiteContext( { source: 'chat' }, [
-				[ 'explicit', 0 ],
-				[ 'primary_site', Number.NaN ],
-			] )
-		).toEqual( { source: 'chat', site_context_source: 'none' } );
-		expect( withSiteContext( { source: 'chat' }, [] ) ).toEqual( {
+	test( 'reports none, and omits blog_id, when the site is not usable', () => {
+		expect( withSiteContext( { source: 'chat' }, 'explicit', 0 ) ).toEqual( {
+			source: 'chat',
+			site_context_source: 'none',
+		} );
+		expect( withSiteContext( { source: 'chat' }, 'primary_site', Number.NaN ) ).toEqual( {
+			source: 'chat',
+			site_context_source: 'none',
+		} );
+		expect( withSiteContext( { source: 'chat' }, 'chat_site' ) ).toEqual( {
 			source: 'chat',
 			site_context_source: 'none',
 		} );
 	} );
 
 	test( 'never lets a caller-supplied blog_id stand in for the site', () => {
-		expect( withSiteContext( { source: 'chat', blog_id: 999 }, [ [ 'chat_site', 123 ] ] ) ).toEqual(
-			{ source: 'chat', blog_id: 123, site_context_source: 'chat_site' }
-		);
-		expect( withSiteContext( { source: 'chat', blog_id: 999 }, [] ) ).toEqual( {
+		expect( withSiteContext( { source: 'chat', blog_id: 999 }, 'chat_site', 123 ) ).toEqual( {
+			source: 'chat',
+			blog_id: 123,
+			site_context_source: 'chat_site',
+		} );
+		expect( withSiteContext( { source: 'chat', blog_id: 999 }, 'chat_site' ) ).toEqual( {
 			source: 'chat',
 			site_context_source: 'none',
 		} );
 	} );
 
 	test( 'drops force_site_id when no site resolved, so super props cannot backfill one', () => {
-		expect( withSiteContext( { force_site_id: true, source: 'article' }, [] ) ).toEqual( {
-			source: 'article',
-			site_context_source: 'none',
-		} );
+		expect( withSiteContext( { force_site_id: true, source: 'article' }, 'support_site' ) ).toEqual(
+			{
+				source: 'article',
+				site_context_source: 'none',
+			}
+		);
 	} );
 
 	test( 'keeps force_site_id when a site resolved', () => {
 		expect(
-			withSiteContext( { force_site_id: true, source: 'article' }, [ [ 'chat_site', 123 ] ] )
+			withSiteContext( { force_site_id: true, source: 'article' }, 'chat_site', 123 )
 		).toEqual( {
 			force_site_id: true,
 			source: 'article',
@@ -88,7 +81,7 @@ describe( 'withSiteContext', () => {
 
 	test( 'does not mutate the caller properties', () => {
 		const properties = { source: 'chat', blog_id: 999 };
-		withSiteContext( properties, [ [ 'chat_site', 123 ] ] );
+		withSiteContext( properties, 'chat_site', 123 );
 		expect( properties ).toEqual( { source: 'chat', blog_id: 999 } );
 	} );
 } );

--- a/packages/help-center/src/hooks/test/use-help-center-tracks-event.ts
+++ b/packages/help-center/src/hooks/test/use-help-center-tracks-event.ts
@@ -7,6 +7,12 @@ describe( 'getHelpCenterTracksProperties', () => {
 		).toEqual( { source: 'odie', blog_id: 11, site_context_source: 'explicit' } );
 	} );
 
+	test( 'falls back to the Help Center context site when the explicit site is invalid', () => {
+		expect(
+			getHelpCenterTracksProperties( { source: 'odie' }, { explicitSiteId: 0, siteId: 22 } )
+		).toEqual( { source: 'odie', blog_id: 22, site_context_source: 'help_center_context' } );
+	} );
+
 	test( 'uses Help Center context site', () => {
 		expect( getHelpCenterTracksProperties( {}, { siteId: 22 } ) ).toEqual( {
 			blog_id: 22,

--- a/packages/help-center/src/hooks/use-help-center-tracks-event.ts
+++ b/packages/help-center/src/hooks/use-help-center-tracks-event.ts
@@ -1,4 +1,4 @@
-import { recordTracksEvent, withSiteContext } from '@automattic/calypso-analytics';
+import { getValidBlogId, recordTracksEvent, withSiteContext } from '@automattic/calypso-analytics';
 import { useCallback, useRef } from '@wordpress/element';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 
@@ -15,10 +15,9 @@ export function getHelpCenterTracksProperties(
 	properties: TracksProperties = {},
 	{ explicitSiteId, siteId }: SiteContext = {}
 ): TracksProperties {
-	return withSiteContext( properties, [
-		[ 'explicit', explicitSiteId ],
-		[ 'help_center_context', siteId ],
-	] );
+	return getValidBlogId( explicitSiteId )
+		? withSiteContext( properties, 'explicit', explicitSiteId )
+		: withSiteContext( properties, 'help_center_context', siteId );
 }
 
 export function recordHelpCenterTracksEvent(

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -138,7 +138,8 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 						chat_id: mainChatState?.odieId,
 						bot_name_slug: newInteractionsBotSlug,
 					},
-					[ [ 'selected_site', selectedSiteId ] ]
+					'selected_site',
+					selectedSiteId
 				)
 			);
 		},

--- a/packages/support-articles/src/components/help-center-article/index.tsx
+++ b/packages/support-articles/src/components/help-center-article/index.tsx
@@ -71,7 +71,8 @@ export const HelpCenterArticle = ( {
 					search_query: query,
 					article_source: post.source,
 				},
-				[ [ 'support_site', siteId ] ]
+				'support_site',
+				siteId
 			);
 
 			recordTracksEvent( 'calypso_helpcenter_article_viewed', tracksData );
@@ -95,7 +96,8 @@ export const HelpCenterArticle = ( {
 									article_blog_id: post?.site_ID,
 									section_id: entry?.target?.id,
 								},
-								[ [ 'support_site', siteId ] ]
+								'support_site',
+								siteId
 							);
 							recordTracksEvent( 'calypso_helpcenter_article_section_view', tracksData );
 							observer.unobserve( entry.target ); // Unobserve after first intersection

--- a/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
+++ b/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
@@ -116,17 +116,14 @@ type TracksProperties = Record< string, unknown >;
  * which is installed outside React and so cannot read a hook.
  */
 function recordWithSmoochSite( eventName: string, properties: TracksProperties = {} ) {
-	recordTracksEvent(
-		eventName,
-		withSiteContext( properties, [ [ 'chat_site', getSmoochSiteId() ] ] )
-	);
+	recordTracksEvent( eventName, withSiteContext( properties, 'chat_site', getSmoochSiteId() ) );
 }
 
 /** Records against the site this hook instance was given. */
 function useZendeskTracksEvent( siteId: number | string | undefined ) {
 	return useCallback(
 		( eventName: string, properties: TracksProperties = {} ) =>
-			recordTracksEvent( eventName, withSiteContext( properties, [ [ 'chat_site', siteId ] ] ) ),
+			recordTracksEvent( eventName, withSiteContext( properties, 'chat_site', siteId ) ),
 		[ siteId ]
 	);
 }


### PR DESCRIPTION
## Proposed Changes

**`withSiteContext` now takes a single site and its source as plain arguments instead of a list of `[ label, siteId ]` tuples.**

- `withSiteContext( properties, 'omnibar', siteId )` replaces `withSiteContext( properties, [ [ 'omnibar', siteId ] ] )`; an event with deliberately no site passes `withSiteContext( properties, NO_SITE_CONTEXT )`.
- The two real fallback chains resolve before the call, where their data lives: `useHelpCenterSite` returns the winning site together with its `siteContextSource`, and the Help Center wrapper picks `explicit` over `help_center_context` with a plain conditional.
- The `SiteCandidate` tuple type is gone. Event payloads are unchanged in every reachable case: an invalid or missing site still resolves to `site_context_source: 'none'` with no `blog_id`. The one theoretical difference is that `useHelpCenterSite` now picks its source by the same site-object fallback the UI uses rather than by first valid site ID — these can only disagree for a site object with an invalid `ID`, which Redux's ID-keyed site storage cannot produce.

## Why are these changes being made?

Almost every caller attaches exactly one site with one label, but the old signature made all of them build a nested array of tuples — `[ [ 'omnibar', siteId ] ]` — a shape that is hard to read and easy to get wrong. Only two call sites ever passed more than one candidate, and each of them already owns the data needed to pick a winner itself. Moving that choice to the caller leaves the shared helper with the one job every event needs: stamp the site and where it came from.

## Testing Instructions

Behavior is unchanged; this verifies the refactor did not alter event payloads.

### Calypso

1. Run `yarn start` and set `localStorage.setItem( 'debug', 'calypso:analytics*' )` in the browser console.
2. On a site-scoped route, click the Help icon in the masterbar, run a search, close the panel. Confirm `wpcom_help_center_icon_interaction`, `calypso_inlinehelp_show`, `calypso_inlinehelp_search` and `calypso_inlinehelp_close` carry `blog_id` with `site_context_source: 'calypso_selected_site'` (the search event from inside the panel reports `'help_center_context'`).
3. Repeat from `/me`: same events, `site_context_source: 'calypso_primary_site'`.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync` (and `cd apps/agents-manager && yarn dev --sync` for the Agents Manager entry points).
3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
4. Open the Help Center from wp-admin and the editor. Confirm the same events carry the site's `blog_id` with `site_context_source: 'help_center_data'` (or `'agents_manager_data'` from the Agents Manager entry points).
