### PR TITLE
Playground: Preserve saved-site routing precedence

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -33,7 +33,10 @@ import { isPlanProductFree } from '../../../../../../packages/data-stores/src/pl
 import { useFlowLocale } from '../../../hooks/use-flow-locale';
 import { useQuery } from '../../../hooks/use-query';
 import { ONBOARD_STORE, SITE_STORE } from '../../../stores';
-import { getBlueprintArchiveSiteSpecUrl } from '../../../utils/blueprint-archive-import';
+import {
+	getBlueprintArchiveSiteSpecUrl,
+	getStandaloneBlueprintArchiveSlug,
+} from '../../../utils/blueprint-archive-import';
 import {
 	getBuildWowSiteIdentifier,
 	getBuildWowSiteSpecUrl,
@@ -101,6 +104,11 @@ const onboarding: FlowV2< typeof initialize > = {
 
 		const playgroundId = queryParams.get( 'playground' );
 		const buildDest = queryParams.get( 'build_dest' );
+		const blueprintArchiveSlug = getStandaloneBlueprintArchiveSlug(
+			blueprint,
+			playgroundId,
+			buildDest
+		);
 
 		/**
 		 * Returns [destination, backDestination] for the post-checkout destination.
@@ -119,7 +127,7 @@ const onboarding: FlowV2< typeof initialize > = {
 				const isFree =
 					! planCartItem || isPlanProductFree( {} as unknown as State, planCartItem?.product_id );
 
-				if ( isFree && ! blueprint ) {
+				if ( isFree && playgroundId ) {
 					// Redirect free plan users to a home page
 					return [ `/home/${ providedDependencies.siteSlug }`, null, null ];
 				}
@@ -134,12 +142,12 @@ const onboarding: FlowV2< typeof initialize > = {
 				// blueprint-archive import and, on confirm, polls the import and
 				// redirects to the Site Editor. The blueprint step already verified the
 				// archive exists (and stripped build_dest when it does not).
-				if ( blueprint && buildDest === 'wow' ) {
+				if ( blueprintArchiveSlug ) {
 					return [
 						getBlueprintArchiveSiteSpecUrl( {
 							siteSlug: providedDependencies.siteSlug as string,
 							siteId: providedDependencies.siteId as number,
-							blueprintSlug: blueprint,
+							blueprintSlug: blueprintArchiveSlug,
 							ref: refParameter,
 						} ),
 						null,
@@ -147,10 +155,10 @@ const onboarding: FlowV2< typeof initialize > = {
 					];
 				}
 
-				if ( blueprint ) {
-					params.blueprint = blueprint;
-				} else if ( playgroundId ) {
+				if ( playgroundId ) {
 					params.playground = playgroundId;
+				} else if ( blueprint ) {
+					params.blueprint = blueprint;
 				}
 
 				return [
@@ -428,7 +436,7 @@ const onboarding: FlowV2< typeof initialize > = {
 								addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
 									// build_dest=wow goes straight from checkout to the AI site-spec
 									// (no post-checkout-onboarding hop, no chooser).
-									redirect_to: blueprint && buildDest === 'wow' ? destination : redirectTo,
+									redirect_to: blueprintArchiveSlug ? destination : redirectTo,
 									signup: 1,
 									flow: ONBOARDING_FLOW,
 									checkoutBackUrl: pathToUrl( backDestination ?? '' ),
@@ -440,7 +448,7 @@ const onboarding: FlowV2< typeof initialize > = {
 									steps_total: checkoutStepperPosition.total,
 								} )
 							);
-						} else if ( blueprint && buildDest === 'wow' ) {
+						} else if ( blueprintArchiveSlug ) {
 							// build_dest=wow never shows the setup-your-site-ai chooser; go
 							// straight to the AI site-spec destination.
 							window.location.replace( destination );

--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -8,6 +8,14 @@ export const BLUEPRINT_ARCHIVE_IMPORT_QUERY_VALUE = '1';
 // Reuse the flow that already hosts the AI site-spec step.
 const BLUEPRINT_ARCHIVE_SITE_SPEC_PATH = '/setup/ai-site-builder-spec/site-spec';
 
+export function getStandaloneBlueprintArchiveSlug(
+	blueprint: string | null,
+	playgroundId: string | null,
+	buildDest: string | null
+): string | null {
+	return ! playgroundId && buildDest === 'wow' ? blueprint : null;
+}
+
 type ImportStatusResponse = {
 	importId?: string | null;
 	siteId?: number | null;

--- a/client/landing/stepper/utils/test/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/test/blueprint-archive-import.ts
@@ -1,0 +1,16 @@
+import { getStandaloneBlueprintArchiveSlug } from '../blueprint-archive-import';
+
+describe( 'getStandaloneBlueprintArchiveSlug', () => {
+	it( 'returns the Blueprint archive slug for a standalone build_dest=wow flow', () => {
+		expect( getStandaloneBlueprintArchiveSlug( 'coaching-1', null, 'wow' ) ).toBe( 'coaching-1' );
+	} );
+
+	it( 'ignores Blueprint values without build_dest=wow', () => {
+		expect( getStandaloneBlueprintArchiveSlug( '945', null, null ) ).toBeNull();
+	} );
+
+	it( 'ignores retained Blueprint values after a Playground ID exists', () => {
+		expect( getStandaloneBlueprintArchiveSlug( '945', 'playground-uuid', null ) ).toBeNull();
+		expect( getStandaloneBlueprintArchiveSlug( '945', 'playground-uuid', 'wow' ) ).toBeNull();
+	} );
+} );


### PR DESCRIPTION
Supersedes #113320 and #113433.

## Proposed Changes

* Give a saved Playground ID precedence over a retained Blueprint value throughout onboarding destination selection.
* Use the Atomic Blueprint archive route only for standalone `blueprint` requests with `build_dest=wow`.
* Preserve the legacy Blueprint importer for requests without `build_dest=wow`.
* Add unit coverage for standalone Blueprint archives and retained Blueprint values in Playground URLs.

## Why are these changes being made?

* Plans already give `playground` precedence when both `playground` and `blueprint` are present, but onboarding could persist a Blueprint destination or route `blueprint&playground&build_dest=wow` into the Atomic Blueprint flow. Keeping one precedence rule ensures saved Playground sites return to the Playground importer after site creation and checkout.

## Testing Instructions

* Run `yarn test-client client/landing/stepper/utils/test/blueprint-archive-import.ts --runInBand`.
* Run `yarn eslint client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts client/landing/stepper/utils/blueprint-archive-import.ts client/landing/stepper/utils/test/blueprint-archive-import.ts`.
* Run `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client`.
* Verify `blueprint=945&playground=<id>` retains the Playground importer destination.
* Verify `blueprint=945&playground=<id>&build_dest=wow` still retains the Playground importer destination.
* Verify `blueprint=<archive-slug>&build_dest=wow` routes to the Atomic Blueprint site-spec flow.
* Verify `blueprint=945` continues to use the legacy Blueprint importer.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g. browsers), interfaces (e.g. keyboard navigation), and assistive technologies (e.g. screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
