### PR TITLE
Domains: stop hovering the Transfer button from spamming notices

### DIFF
--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -130,7 +130,6 @@ export const domainRoute = createRoute( {
 	loader: async ( { params: { domainName }, location } ) => {
 		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
 		const isNameServersSubRoute = location.pathname.includes( '/name-servers' );
-		const isTransferSubRoute = location.pathname.includes( '/transfer' );
 		const isContactInfoSubRoute = location.pathname.includes( '/contact-info' );
 		const isDnsSubRoute = location.pathname.includes( '/dns' );
 		const isContactVerificationSubRoute = location.pathname.includes( '/contact-verification' );
@@ -142,21 +141,6 @@ export const domainRoute = createRoute( {
 		// throw error and handle it with the global error boundary
 		if ( isNameServersSubRoute ) {
 			checkDomainNameServersPermissions( domain );
-		}
-
-		if ( isTransferSubRoute ) {
-			try {
-				checkDomainTransferPermissions( domain );
-			} catch ( error ) {
-				dispatch( noticesStore ).createWarningNotice(
-					__( 'You do not have permission to transfer this domain.' ),
-					{ type: 'snackbar' }
-				);
-				throw dashboardRedirect( {
-					to: '/domains/$domainName',
-					params: { domainName },
-				} );
-			}
 		}
 
 		if ( isContactInfoSubRoute ) {
@@ -580,6 +564,28 @@ export const domainTransferRoute = createRoute( {
 	} ),
 	getParentRoute: () => domainRoute,
 	path: 'transfer',
+	beforeLoad: async ( { params: { domainName }, cause } ) => {
+		// Preloads run whenever a link to this route is hovered, so they must
+		// stay free of side effects like notices and redirects.
+		if ( cause === 'preload' ) {
+			return;
+		}
+
+		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
+
+		try {
+			checkDomainTransferPermissions( domain );
+		} catch {
+			dispatch( noticesStore ).createWarningNotice(
+				__( 'You do not have permission to transfer this domain.' ),
+				{ type: 'snackbar' }
+			);
+			throw dashboardRedirect( {
+				to: '/domains/$domainName',
+				params: { domainName },
+			} );
+		}
+	},
 } );
 
 export const domainTransferIndexRoute = createRoute( {

--- a/client/dashboard/app/router/test/domains.test.ts
+++ b/client/dashboard/app/router/test/domains.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { DomainSubtype, type Domain } from '@automattic/api-core';
+import { domainQuery, queryClient } from '@automattic/api-queries';
+import { createRouter } from '@tanstack/react-router';
+import { select, dispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import { APP_CONTEXT_DEFAULT_CONFIG } from '../../context';
+import { createDomainsRoutes } from '../domains';
+import { rootRoute } from '../root';
+
+const DOMAIN_NAME = 'example.com';
+
+const nonTransferableDomain = {
+	domain: DOMAIN_NAME,
+	blog_id: 1,
+	site_slug: 'example.wordpress.com',
+	current_user_is_owner: true,
+	can_transfer_to_any_user: false,
+	can_transfer_to_other_site: false,
+	subtype: { id: DomainSubtype.DOMAIN_REGISTRATION, label: 'Domain Registration' },
+} as Domain;
+
+function createTestRouter() {
+	return createRouter( {
+		routeTree: rootRoute.addChildren( createDomainsRoutes() ),
+		context: { config: APP_CONTEXT_DEFAULT_CONFIG },
+	} );
+}
+
+function getSnackbarNotices() {
+	return select( noticesStore ).getNotices();
+}
+
+describe( 'domain routes', () => {
+	beforeEach( () => {
+		queryClient.setQueryData( domainQuery( DOMAIN_NAME ).queryKey, nonTransferableDomain );
+		getSnackbarNotices().forEach( ( { id } ) => dispatch( noticesStore ).removeNotice( id ) );
+	} );
+
+	afterEach( () => {
+		queryClient.clear();
+	} );
+
+	describe( 'transfer route permission guard', () => {
+		it( 'does not create a notice when the route is only preloaded', async () => {
+			const router = createTestRouter();
+
+			await router.preloadRoute( {
+				to: '/domains/$domainName/transfer',
+				params: { domainName: DOMAIN_NAME },
+			} );
+
+			expect( getSnackbarNotices() ).toHaveLength( 0 );
+		} );
+
+		it( 'redirects to the domain overview with a notice when the route is visited', async () => {
+			const router = createTestRouter();
+
+			await router.load();
+			await router.navigate( {
+				to: '/domains/$domainName/transfer',
+				params: { domainName: DOMAIN_NAME },
+			} );
+			await router.invalidate();
+
+			expect( router.state.location.pathname ).toBe( `/domains/${ DOMAIN_NAME }` );
+			expect( getSnackbarNotices() ).toEqual( [
+				expect.objectContaining( {
+					content: 'You do not have permission to transfer this domain.',
+				} ),
+			] );
+		} );
+	} );
+} );

--- a/client/dashboard/domains/domain-overview/actions.utils.ts
+++ b/client/dashboard/domains/domain-overview/actions.utils.ts
@@ -1,5 +1,6 @@
 import { Domain, DomainSubtype, DomainTransferStatus, Purchase } from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
+import { canTransferDomain } from '../../utils/domain-permissions';
 import { isExpiredOrRemoved, isIncludedWithPlan } from '../../utils/purchase';
 
 export const transferableTypes: DomainSubtype[] = [
@@ -44,24 +45,13 @@ export const canAutoRenewBeTurnedOff = ( purchase: Purchase ) => {
 };
 
 export const shouldShowTransferAction = ( domain: Domain ) => {
-	if (
-		! domain.current_user_is_owner ||
-		domain.is_redeemable ||
-		domain.pending_registration ||
-		domain.pending_registration_at_registry ||
-		domain.move_to_new_site_pending ||
-		domain.aftermarket_auction ||
-		! transferableTypes.includes( domain.subtype.id )
-	) {
+	if ( domain.move_to_new_site_pending || ! transferableTypes.includes( domain.subtype.id ) ) {
 		return false;
 	}
 
-	// If the domain cannot be transferred to any user or another site, we shouldn't show the transfer action
-	if ( ! domain.can_transfer_to_any_user && ! domain.can_transfer_to_other_site ) {
-		return false;
-	}
-
-	return true;
+	// Anything the transfer route itself rejects must not be offered here, or
+	// the button only leads to a redirect back to this page.
+	return canTransferDomain( domain );
 };
 
 export const shouldShowDisconnectAction = ( domain: Domain ) => {

--- a/client/dashboard/domains/domain-overview/test/actions.utils.test.ts
+++ b/client/dashboard/domains/domain-overview/test/actions.utils.test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { DomainSubtype, type Domain } from '@automattic/api-core';
 import { shouldShowTransferAction } from '../actions.utils';
 
@@ -43,5 +47,21 @@ describe( 'shouldShowTransferAction', () => {
 		} );
 
 		expect( shouldShowTransferAction( domain ) ).toBe( true );
+	} );
+
+	it( 'returns false for a 100-year domain', () => {
+		const domain = createDomain( { is_hundred_year_domain: true } );
+
+		expect( shouldShowTransferAction( domain ) ).toBe( false );
+	} );
+
+	it( 'returns false in a support session', () => {
+		window.isSupportSession = true;
+
+		try {
+			expect( shouldShowTransferAction( createDomain() ) ).toBe( false );
+		} finally {
+			delete window.isSupportSession;
+		}
 	} );
 } );

--- a/client/dashboard/utils/domain-permissions.ts
+++ b/client/dashboard/utils/domain-permissions.ts
@@ -242,6 +242,19 @@ export function checkDomainTransferPermissions( domain: Domain ): void {
 	}
 }
 
+/**
+ * Non-throwing counterpart of `checkDomainTransferPermissions`, for deciding
+ * whether to render a link to the transfer route.
+ */
+export function canTransferDomain( domain: Domain ): boolean {
+	try {
+		checkDomainTransferPermissions( domain );
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 export function checkDomainNameServersPermissions( domain: Domain ): void {
 	checkDomainPermissions( domain, PermissionCheck.NAME_SERVERS );
 }


### PR DESCRIPTION
## Proposed Changes

* Move the domain transfer permission check from the domain route's loader to the transfer route itself, and skip it on preloads.
* Hide the Transfer action on the domain overview whenever the transfer route would reject the user.

## Why are these changes being made?

Hovering the Transfer button on the domain overview produced a stream of "You do not have permission to transfer this domain." notices when the user lacked one of the transfer permissions.

The check lived in the domain route's loader and switched on `location.pathname`. The dashboard router runs with `defaultPreload: 'intent'` and `defaultPreloadStaleTime: 0`, so hovering a link to `/domains/<name>/transfer` runs that loader — and the loader created a notice as a side effect, one per run. It also redirected: because the domain route's match is already active, TanStack does not treat its loader as a preload and turns the redirect thrown there into a real navigation, which re-renders the page under the cursor and lets the hover fire again.

Moving the guard to `domainTransferRoute` puts it on a route that is not already active, so preloads are correctly flagged and can be skipped. Nothing about the guard's coverage changes: the old pathname check matched exactly the routes that now sit under this parent.

The second change addresses why the button was there at all. `shouldShowTransferAction()` was a hand-copied subset of the route's permission rules and had drifted — it was missing the support-session and 100-year-domain checks, so the UI offered a button the route refuses. It now delegates to the same rules, which means the Transfer action no longer renders in a support session or for a 100-year domain.

Note that `remove-domain-dialog.tsx`, `domain-removal-warning-step.tsx`, `featured-card-site.tsx` and `purchase-settings/index.tsx` still link into `/transfer` gated only on `can_transfer_to_any_user || can_transfer_to_other_site`. They no longer spam notices on hover, but clicking them can still bounce back with the warning. Aligning them can be a follow-up.

## Testing Instructions

Use a domain the current user cannot transfer — a 100-year domain, a domain in a support session, or one where `can_transfer_to_any_user` and `can_transfer_to_other_site` are both false.

1. Go to `/domains/<domain>`.
2. The Actions section no longer offers Transfer.
3. Visit `/domains/<domain>/transfer` directly. You are redirected to the domain overview and see a single "You do not have permission to transfer this domain." snackbar.
4. On a domain you *can* transfer, confirm the Transfer button is still there, hovering it is quiet, and clicking it opens the transfer page.

Before this change, hovering the Transfer button in step 2 filled the bottom of the page with notices.

`yarn test-client client/dashboard` (189 suites, 1531 tests) and `yarn typecheck-client` pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSfvY7F8fN7LDJdMEhWtSB
