### PR TITLE
Playground: Keep the remote client proxy out of React props

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-iframe/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-iframe/index.tsx
@@ -16,11 +16,11 @@ import './style.scss';
 
 export function PlaygroundIframe( {
 	className,
-	playgroundClient,
+	hasPlaygroundClient,
 	setPlaygroundClient,
 }: {
 	className?: string;
-	playgroundClient: PlaygroundClient | null;
+	hasPlaygroundClient: boolean;
 	setPlaygroundClient: ( client: PlaygroundClient ) => void;
 } ) {
 	const siteId = useSelector( getSelectedSiteId ) ?? 0;
@@ -44,7 +44,7 @@ export function PlaygroundIframe( {
 			return;
 		}
 
-		if ( playgroundClient ) {
+		if ( hasPlaygroundClient ) {
 			return;
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-setup/index.tsx
@@ -126,7 +126,7 @@ export const PlaygroundSetupStep: Step< {
 				{ ! hasBlueprint && (
 					<PlaygroundIframe
 						className="playground__onboarding-iframe"
-						playgroundClient={ playgroundClientRef.current }
+						hasPlaygroundClient={ Boolean( playgroundClientRef.current ) }
 						setPlaygroundClient={ startImport }
 					/>
 				) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/index.tsx
@@ -91,7 +91,7 @@ export const PlaygroundStep: StepType = ( { navigation, flow } ) => {
 			>
 				<PlaygroundIframe
 					className="playground__onboarding-iframe"
-					playgroundClient={ playgroundClientRef.current }
+					hasPlaygroundClient={ Boolean( playgroundClientRef.current ) }
 					setPlaygroundClient={ setPlaygroundClient }
 				/>
 			</Step.PlaygroundLayout>


### PR DESCRIPTION
Related to #113199

## Proposed Changes

* Pass a boolean readiness flag to `PlaygroundIframe` instead of passing the remote Playground client through React props.
* Keep the Comlink client proxy in the existing ref for callers that need to invoke it.

## Why are these changes being made?

* On a fresh Playground URL, initialization adds the generated Playground ID to the query string and rerenders the parent. React 19 development diagnostics inspect the changed function-valued prop, including coercion-related properties. Because the value is a remote Comlink proxy, that inspection becomes an invalid RPC lookup for `Symbol.toPrimitive`, throws in both React and the Playground worker, and leaves the browser URL on the next step while the Playground UI remains mounted.
* The boolean carries the only information `PlaygroundIframe` needs and prevents framework diagnostics from traversing the remote proxy.

## Testing Instructions

* Run `yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/playground/test`.
* Run `yarn typecheck-client`.
* Start Calypso locally and open `/setup/onboarding/playground` without a `playground` query parameter.
* Wait for the launch action to become available, select it, and confirm the flow advances to the account step, the launch action disappears, and no uncaught React or Playground worker exceptions are logged.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?