### PR TITLE
Checkout: Add the shared checkout package and its import boundary

### DIFF
--- a/packages/checkout/.eslintrc.js
+++ b/packages/checkout/.eslintrc.js
@@ -1,0 +1,47 @@
+// The package must stay host-agnostic: host behavior enters through the host
+// context the embedding app supplies, server data through `@automattic/api-queries`.
+const LEGACY_APP = [ 'calypso/*', 'client/*' ];
+const REDUX = [
+	'redux',
+	'redux/*',
+	'react-redux',
+	'react-redux/*',
+	'redux-thunk',
+	'redux-thunk/*',
+];
+
+// `no-restricted-imports` and `no-restricted-modules` only see static `import`
+// and `require`, so `import()` needs its own selector.
+const DYNAMIC_IMPORT_ROOTS = [ 'calypso', 'client', 'redux', 'react-redux', 'redux-thunk' ];
+const dynamicImportSelector = `ImportExpression > Literal[value=/^(${ DYNAMIC_IMPORT_ROOTS.join(
+	'|'
+) })(\\/|$)/]`;
+
+module.exports = {
+	rules: {
+		'no-restricted-imports': [
+			'error',
+			{
+				patterns: [
+					{
+						group: LEGACY_APP,
+						message: 'Legacy app imports are not allowed in @automattic/checkout.',
+					},
+					{
+						group: REDUX,
+						message: 'Redux is not allowed in @automattic/checkout.',
+					},
+				],
+			},
+		],
+		'no-restricted-modules': [ 'error', { patterns: [ ...LEGACY_APP, ...REDUX ] } ],
+		'no-restricted-syntax': [
+			'error',
+			{
+				selector: dynamicImportSelector,
+				message:
+					'Legacy app and Redux imports are not allowed in @automattic/checkout, dynamic ones included.',
+			},
+		],
+	},
+};

--- a/packages/checkout/CHANGELOG.md
+++ b/packages/checkout/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version of `@automattic/checkout`.

--- a/packages/checkout/README.md
+++ b/packages/checkout/README.md
@@ -1,0 +1,17 @@
+# Checkout
+
+The host-agnostic WordPress.com checkout: the UI and logic that render identically inside any
+checkout host — a Calypso modal, a Dashboard modal, or the legacy full-page `/checkout` route.
+
+The package is being filled in incrementally; it starts as a skeleton plus the import boundary
+described below.
+
+## Import boundary
+
+Nothing in this package may import from the legacy Calypso app (`calypso/*`, `client/*`) or from
+Redux (`redux`, `react-redux`, `redux-thunk`). Host-specific behavior enters through a typed host
+context supplied by the embedding app, and server data is read through `@automattic/api-queries`.
+
+The boundary is enforced by `.eslintrc.js` — `no-restricted-imports`, `no-restricted-modules`, and
+a `no-restricted-syntax` selector for `import()` — so a forbidden import fails `yarn lint:js` in
+CI. `src/__tests__/import-boundary.ts` asserts the rules still bite.

--- a/packages/checkout/jest.config.js
+++ b/packages/checkout/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	preset: '../../test/packages/jest-preset.js',
+	testEnvironment: 'jsdom',
+	testMatch: [ '<rootDir>/**/__tests__/**/*.[jt]s?(x)', '!**/.eslintrc.*' ],
+};

--- a/packages/checkout/package.json
+++ b/packages/checkout/package.json
@@ -1,0 +1,54 @@
+{
+	"name": "@automattic/checkout",
+	"version": "1.0.0",
+	"description": "Host-agnostic WordPress.com checkout, embeddable in any host surface.",
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic Inc.",
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"types": "dist/types/index.d.ts",
+	"calypso:src": "src/index.ts",
+	"exports": {
+		".": {
+			"calypso:src": "./src/index.ts",
+			"types": "./dist/types/index.d.ts",
+			"import": "./dist/esm/index.js",
+			"require": "./dist/cjs/index.js"
+		}
+	},
+	"sideEffects": false,
+	"keywords": [
+		"checkout",
+		"payments",
+		"automattic",
+		"wordpress"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/checkout"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"bugs": "https://github.com/Automattic/wp-calypso/issues",
+	"files": [
+		"dist",
+		"src"
+	],
+	"scripts": {
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
+		"prepack": "yarn run clean && yarn run build",
+		"watch": "tsc --build ./tsconfig.json --watch"
+	},
+	"dependencies": {
+		"tslib": "^2.8.1"
+	},
+	"devDependencies": {
+		"@automattic/calypso-typescript-config": "workspace:^",
+		"eslint": "^9.0.0",
+		"typescript": "^6.0.3"
+	}
+}

--- a/packages/checkout/src/__tests__/import-boundary.ts
+++ b/packages/checkout/src/__tests__/import-boundary.ts
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment node
+ */
+import path from 'path';
+import { LegacyESLint } from 'eslint/use-at-your-own-risk';
+import packageJson from '../../package.json';
+
+const repoRoot = path.resolve( __dirname, '../../../..' );
+const filePath = path.join( repoRoot, 'packages/checkout/src/boundary-fixture.ts' );
+
+const BOUNDARY_RULES = [ 'no-restricted-imports', 'no-restricted-modules', 'no-restricted-syntax' ];
+
+const eslint = new LegacyESLint( { cwd: repoRoot } );
+
+async function lint( source: string ) {
+	const [ result ] = await eslint.lintText( source, { filePath } );
+	return result.messages;
+}
+
+async function boundaryErrors( source: string ) {
+	return ( await lint( source ) ).filter( ( { ruleId } ) =>
+		BOUNDARY_RULES.includes( ruleId ?? '' )
+	);
+}
+
+describe( 'import boundary', () => {
+	it.each( [
+		[ 'calypso/state', "import { getSelectedSite } from 'calypso/state/ui/selectors';" ],
+		[ 'calypso/lib', "import wpcom from 'calypso/lib/wp';" ],
+		[ 'client', "import { thing } from 'client/my-sites/checkout/src/thing';" ],
+		[ 'redux', "import { createStore } from 'redux';" ],
+		[ 'react-redux', "import { useSelector } from 'react-redux';" ],
+		[ 'redux-thunk', "import thunk from 'redux-thunk';" ],
+		[ 'a redux submodule', "import { createStore } from 'redux/es/redux';" ],
+		[ 'redux through require', "const { createStore } = require( 'redux/es/redux' );" ],
+		[ 'redux through import()', "const { createStore } = await import( 'redux' );" ],
+		[ 'a redux submodule through import()', "const store = await import( 'redux/es/redux' );" ],
+		[ 'calypso through import()', "const wpcom = await import( 'calypso/lib/wp' );" ],
+	] )( 'rejects importing %s', async ( _name, source ) => {
+		expect( await boundaryErrors( source ) ).not.toHaveLength( 0 );
+	} );
+
+	it.each( [
+		[ '@automattic/api-queries', "import { queryClient } from '@automattic/api-queries';" ],
+		[ '@tanstack/react-query', "import { useQuery } from '@tanstack/react-query';" ],
+		[ 'react', "import { useState } from 'react';" ],
+		[ 'a lazy chunk of its own', "const step = await import( './contact-step' );" ],
+	] )( 'allows importing %s', async ( _name, source ) => {
+		expect( await boundaryErrors( source ) ).toHaveLength( 0 );
+	} );
+
+	// The lint rules only see source text, so a forbidden module could still
+	// arrive as a declared dependency.
+	it( 'declares no dependency on the legacy app or Redux', () => {
+		const dependencies = Object.keys( {
+			...packageJson.dependencies,
+			...( packageJson as { peerDependencies?: Record< string, string > } ).peerDependencies,
+		} );
+
+		expect(
+			dependencies.filter( ( name ) => /^(redux|react-redux|redux-thunk)$/.test( name ) )
+		).toEqual( [] );
+	} );
+} );

--- a/packages/checkout/src/index.ts
+++ b/packages/checkout/src/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Public entry point of the host-agnostic checkout.
+ */
+
+export {};

--- a/packages/checkout/tsconfig-cjs.json
+++ b/packages/checkout/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"outDir": "dist/cjs"
+	}
+}

--- a/packages/checkout/tsconfig.json
+++ b/packages/checkout/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "@automattic/calypso-typescript-config/ts-package.json",
+	"compilerOptions": {
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+		"rootDir": "src"
+	},
+	"include": [ "src" ],
+	"exclude": [ "**/__tests__/*", "**/__mocks__/*" ]
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -20,6 +20,7 @@
 		{ "path": "./calypso-paypal" },
 		{ "path": "./calypso-stripe" },
 		{ "path": "./calypso-url" },
+		{ "path": "./checkout" },
 		{ "path": "./posthog" },
 		{ "path": "./components" },
 		{ "path": "./composite-checkout" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -858,6 +858,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@automattic/checkout@workspace:packages/checkout":
+  version: 0.0.0-use.local
+  resolution: "@automattic/checkout@workspace:packages/checkout"
+  dependencies:
+    "@automattic/calypso-typescript-config": "workspace:^"
+    eslint: "npm:^9.0.0"
+    tslib: "npm:^2.8.1"
+    typescript: "npm:^6.0.3"
+  languageName: unknown
+  linkType: soft
+
 "@automattic/color-studio@npm:^4.1.0":
   version: 4.1.0
   resolution: "@automattic/color-studio@npm:4.1.0"


### PR DESCRIPTION
## Proposed Changes

* Adds `packages/checkout` (`@automattic/checkout`): a workspace package that builds, is referenced from `packages/tsconfig.json`, and resolves from other workspaces. It is deliberately empty — `src/index.ts` exports nothing yet and nothing imports it, so there is no runtime change anywhere.
* Adds the package's import boundary in `packages/checkout/.eslintrc.js`: the legacy app (`calypso/*`, `client/*`) and Redux (`redux`, `react-redux`, `redux-thunk`, and their submodules) are rejected through static `import`, `require`, and `import()`. A forbidden import fails `yarn lint:js`, so CI goes red.
* Adds `src/__tests__/import-boundary.ts`, which lints fixture sources through the repo's real ESLint config and asserts each of those forms is reported, that the allowed dependencies (`@automattic/api-queries`, `@tanstack/react-query`, `react`) and the package's own lazy chunks are not, and that no forbidden module is declared as a dependency — the lint rules only read source text, so a dependency could otherwise slip past them.

## Why are these changes being made?

Checkout currently exists only as a composition inside `client/my-sites/checkout`, wired to Redux, page.js navigation, and a long tail of `calypso/*` imports. That works fine for the legacy app, which is the only surface that can render it: the Dashboard client is self-contained and does not reuse Calypso client code, so today it can only hand a user off to the full-page `/checkout` route and lose their place in the app.

The plan is to make one host-agnostic checkout that both surfaces embed. That means the composition eventually has to live somewhere neither host owns. The risk in a migration of that size is not the first move, it is the fiftieth: a single `calypso/state` import added months later quietly re-couples the package to the legacy app, and nobody notices until the Dashboard tries to bundle it.

So this PR lands the destination and the guard rail before any checkout code moves. The boundary is machine-enforced rather than documented, which is the whole point — convention alone cannot hold a boundary across a migration this long. Everything else (the host context seam, the shared data queries, the chrome-less checkout content, the move itself) arrives in later PRs and can be reviewed against a boundary that already exists.

## Testing Instructions

There is no user-facing behavior to exercise; the checks are that the package builds and that the guard actually bites.

1. Install and build the package:

    ```
    yarn
    yarn workspace @automattic/checkout run build
    ```

    `packages/checkout/dist/{cjs,esm,types}` should be produced.

2. Type-check and run the package tests:

    ```
    yarn typecheck-packages
    yarn test-packages packages/checkout
    ```

    All 16 boundary tests should pass.

3. Prove the guard by hand. Create a file with forbidden imports:

    ```
    cat > packages/checkout/src/boundary-proof.ts <<'EOF'
    import { createStore } from 'redux';
    import { getSelectedSiteId } from 'calypso/state/ui/selectors';

    export async function load() {
    	return import( 'react-redux' );
    }
    EOF
    yarn eslint packages/checkout/src/boundary-proof.ts
    ```

    ESLint should report three boundary errors — two `no-restricted-imports`, one `no-restricted-syntax` for the dynamic import — alongside two unused-variable errors from the fixture itself. Then remove the file:

    ```
    rm packages/checkout/src/boundary-proof.ts
    ```

4. Confirm nothing else moved: `git grep -l "@automattic/checkout" -- client apps packages ':!packages/checkout'` should return nothing, and the legacy checkout route should behave exactly as it does on trunk.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
