### PR TITLE
Earn: wait for paid subscribers before showing empty state

### DIFF
--- a/client/my-sites/earn/paid-subscriptions/index.tsx
+++ b/client/my-sites/earn/paid-subscriptions/index.tsx
@@ -9,6 +9,7 @@ import { shallowEqual } from 'react-redux';
 import QueryMembershipsEarnings from 'calypso/components/data/query-memberships-earnings';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import EmptyContent from 'calypso/components/empty-content';
 import Gravatar from 'calypso/components/gravatar';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -24,7 +25,9 @@ import { requestSubscribers } from 'calypso/state/memberships/subscribers/action
 import {
 	getTotalSubscribersForSiteId,
 	getOwnershipsForSiteId,
+	hasLoadedSubscribersForSiteId,
 } from 'calypso/state/memberships/subscribers/selectors';
+import getRequest from 'calypso/state/selectors/get-request';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import {
 	PLAN_YEARLY_FREQUENCY,
@@ -54,6 +57,12 @@ const PaidSubscriptionsSection = ( { query }: PaidSubscriptionsSectionProps ) =>
 	const totalSubscribers = useSelector( ( state ) =>
 		getTotalSubscribersForSiteId( state, site?.ID )
 	);
+	const hasLoadedSubscribers = useSelector( ( state ) =>
+		hasLoadedSubscribersForSiteId( state, site?.ID )
+	);
+	const subscribersRequestStatus = useSelector(
+		( state ) => getRequest( state, requestSubscribers( site?.ID, 0 ) ).status
+	);
 
 	const fetchNextSubscriberPage = useCallback(
 		( force: boolean ) => {
@@ -76,6 +85,27 @@ const PaidSubscriptionsSection = ( { query }: PaidSubscriptionsSectionProps ) =>
 	);
 
 	function renderSubscriberList() {
+		if ( subscribersRequestStatus === 'failure' && ! hasLoadedSubscribers ) {
+			return (
+				<div role="alert">
+					<EmptyContent
+						title={ translate( 'Sorry, something went wrong.' ) }
+						line={ translate( 'We couldn’t load your paid subscribers. Please try again.' ) }
+						action={ translate( 'Try again' ) }
+						actionCallback={ () => fetchNextSubscriberPage( true ) }
+					/>
+				</div>
+			);
+		}
+
+		if ( ! hasLoadedSubscribers ) {
+			return (
+				<div role="status" aria-label={ translate( 'Loading paid subscribers' ) }>
+					<LoadingEllipsis />
+				</div>
+			);
+		}
+
 		return (
 			<div>
 				{ Object.values( paid_subscriptions ).length === 0 && (

--- a/client/my-sites/earn/paid-subscriptions/test/index.test.tsx
+++ b/client/my-sites/earn/paid-subscriptions/test/index.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import deterministicStringify from 'fast-json-stable-stringify';
+import PaidSubscriptionsSection from '..';
+
+const mockDispatch = jest.fn();
+let mockState: Record< string, unknown >;
+
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => mockDispatch,
+	useSelector: ( selector: ( currentState: Record< string, unknown > ) => unknown ) =>
+		selector( mockState ),
+} ) );
+
+jest.mock( 'i18n-calypso', () => ( {
+	...jest.requireActual( 'i18n-calypso' ),
+	useTranslate: () => ( text: string ) => text,
+} ) );
+
+jest.mock( 'calypso/components/localized-moment', () => ( {
+	useLocalizedMoment: () => () => ( { format: () => '' } ),
+} ) );
+
+jest.mock( 'calypso/components/data/query-memberships-earnings', () => () => null );
+jest.mock( 'calypso/components/data/query-memberships-settings', () => () => null );
+jest.mock( 'calypso/lib/jetpack/is-jetpack-cloud', () => () => false );
+
+const site = { ID: 1, slug: 'example.wordpress.com' };
+
+function createState( subscribers?: object, requestStatus?: string ) {
+	const requestKey = deterministicStringify( {
+		offset: 0,
+		siteId: site.ID,
+		type: 'MEMBERSHIPS_SUBSCRIBERS_LIST',
+	} );
+
+	return {
+		ui: { selectedSiteId: site.ID },
+		sites: { items: { [ site.ID ]: site } },
+		memberships: { subscribers: { list: subscribers ? { [ site.ID ]: subscribers } : {} } },
+		dataRequests: requestStatus ? { [ requestKey ]: { status: requestStatus } } : {},
+	};
+}
+
+describe( 'PaidSubscriptionsSection', () => {
+	beforeEach( () => {
+		mockDispatch.mockClear();
+	} );
+
+	test( 'shows a loader before the first subscriber response', () => {
+		mockState = createState();
+
+		render( <PaidSubscriptionsSection /> );
+
+		expect( screen.getByRole( 'status', { name: 'Loading paid subscribers' } ) ).toBeVisible();
+		expect(
+			screen.queryByText( /You don't have any paid subscribers yet/ )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'shows the empty state after an empty subscriber response', () => {
+		mockState = createState( { total: 0, ownerships: {} }, 'success' );
+
+		render( <PaidSubscriptionsSection /> );
+
+		expect( screen.getByText( /You don't have any paid subscribers yet/ ) ).toBeVisible();
+	} );
+
+	test( 'shows a retryable error after the first request fails', async () => {
+		const user = userEvent.setup();
+		mockState = createState( undefined, 'failure' );
+
+		render( <PaidSubscriptionsSection /> );
+
+		expect( screen.getByRole( 'alert' ) ).toHaveTextContent(
+			'We couldn’t load your paid subscribers. Please try again.'
+		);
+
+		mockDispatch.mockClear();
+		await user.click( screen.getByRole( 'button', { name: 'Try again' } ) );
+
+		expect( mockDispatch ).toHaveBeenCalledWith( {
+			meta: { dataLayer: { trackRequest: true } },
+			offset: 0,
+			siteId: site.ID,
+			type: 'MEMBERSHIPS_SUBSCRIBERS_LIST',
+		} );
+	} );
+} );

--- a/client/state/data-layer/wpcom/sites/memberships/index.js
+++ b/client/state/data-layer/wpcom/sites/memberships/index.js
@@ -11,6 +11,7 @@ import {
 	MEMBERSHIPS_COUPONS_RECEIVE,
 } from 'calypso/state/action-types';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+import { bypassDataLayer } from 'calypso/state/data-layer/utils';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 
@@ -127,6 +128,8 @@ export const handleMembershipGetEarnings = dispatchRequest( {
 	onError: noop,
 } );
 
+export const handleMembershipSubscribersError = ( action ) => bypassDataLayer( action );
+
 export const handleMembershipGetSubscribers = dispatchRequest( {
 	fetch: ( action ) =>
 		http(
@@ -142,7 +145,7 @@ export const handleMembershipGetSubscribers = dispatchRequest( {
 		siteId,
 		subscribers,
 	} ),
-	onError: noop,
+	onError: handleMembershipSubscribersError,
 } );
 
 export const handleMembershipGetSettings = dispatchRequest( {

--- a/client/state/data-layer/wpcom/sites/memberships/test/index.js
+++ b/client/state/data-layer/wpcom/sites/memberships/test/index.js
@@ -1,0 +1,18 @@
+import { bypassDataLayer } from 'calypso/state/data-layer/utils';
+import { requestSubscribers } from 'calypso/state/memberships/subscribers/actions';
+import { handleMembershipSubscribersError } from '..';
+
+test( 'subscriber request errors remain dispatchable for request tracking', () => {
+	const request = requestSubscribers( 1, 0 );
+	const failure = {
+		...request,
+		meta: {
+			dataLayer: {
+				...request.meta.dataLayer,
+				error: { message: 'Unable to load subscribers' },
+			},
+		},
+	};
+
+	expect( handleMembershipSubscribersError( failure ) ).toEqual( bypassDataLayer( failure ) );
+} );

--- a/client/state/memberships/subscribers/actions.js
+++ b/client/state/memberships/subscribers/actions.js
@@ -14,6 +14,11 @@ export const requestSubscribers = ( siteId, offset ) => ( {
 	siteId,
 	type: MEMBERSHIPS_SUBSCRIBERS_LIST,
 	offset,
+	meta: {
+		dataLayer: {
+			trackRequest: true,
+		},
+	},
 } );
 
 export const requestSubscriptionStop = ( siteId, subscriber, noticeText ) => {

--- a/client/state/memberships/subscribers/selectors.js
+++ b/client/state/memberships/subscribers/selectors.js
@@ -9,3 +9,7 @@ export function getTotalSubscribersForSiteId( state, siteId ) {
 export function getOwnershipsForSiteId( state, siteId ) {
 	return state?.memberships?.subscribers?.list?.[ siteId ]?.ownerships ?? emptyObject;
 }
+
+export function hasLoadedSubscribersForSiteId( state, siteId ) {
+	return Boolean( state?.memberships?.subscribers?.list?.[ siteId ] );
+}

--- a/client/state/memberships/subscribers/test/actions.js
+++ b/client/state/memberships/subscribers/test/actions.js
@@ -1,0 +1,11 @@
+import { MEMBERSHIPS_SUBSCRIBERS_LIST } from 'calypso/state/action-types';
+import { requestSubscribers } from '../actions';
+
+test( 'requestSubscribers() tracks the request status', () => {
+	expect( requestSubscribers( 1, 0 ) ).toEqual( {
+		meta: { dataLayer: { trackRequest: true } },
+		offset: 0,
+		siteId: 1,
+		type: MEMBERSHIPS_SUBSCRIBERS_LIST,
+	} );
+} );

--- a/client/state/memberships/subscribers/test/selectors.js
+++ b/client/state/memberships/subscribers/test/selectors.js
@@ -1,0 +1,23 @@
+import { hasLoadedSubscribersForSiteId } from '../selectors';
+
+describe( 'hasLoadedSubscribersForSiteId()', () => {
+	test( 'returns false before subscribers are received for the site', () => {
+		const state = {
+			memberships: {
+				subscribers: { list: { 2: { total: 0, ownerships: {} } } },
+			},
+		};
+
+		expect( hasLoadedSubscribersForSiteId( state, 1 ) ).toBe( false );
+	} );
+
+	test( 'returns true after an empty subscriber list is received for the site', () => {
+		const state = {
+			memberships: {
+				subscribers: { list: { 1: { total: 0, ownerships: {} } } },
+			},
+		};
+
+		expect( hasLoadedSubscribersForSiteId( state, 1 ) ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
Fixes NL-750

## Proposed Changes

* Track paid-subscriber list requests so the UI can distinguish pending, failed, and completed requests.
* Show an accessible loading indicator until the first subscriber response arrives.
* Show a retryable error when the initial request fails, while preserving previously loaded data during later requests.

## Why are these changes being made?

* The paid-subscriber selectors return empty defaults before data loads. The page treated those defaults as a completed empty response, so sites with paid subscribers briefly saw the empty state during every initial load.

## Testing Instructions

1. Open **Earn > Paid Subscribers** for a site with paid subscribers.
2. Reload the page and confirm a loading indicator appears while the first request is pending. The empty state should not flash before the subscriber list.
3. Open the page for a site without paid subscribers and confirm the empty state appears after the request completes.
4. Make the initial subscriber request fail and confirm the page shows an error with a **Try again** button.
5. Restore the request, choose **Try again**, and confirm the subscriber list or completed empty state appears.

Automated checks:

* `yarn test-client client/my-sites/earn/paid-subscriptions/test client/state/memberships/subscribers/test client/state/data-layer/wpcom/sites/memberships/test` (4 suites, 7 tests)
* `yarn eslint` on all eight changed files
* `yarn prettier --check` on all eight changed files
* `yarn workspace @automattic/omnibar build`
* `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client`
* `git diff --check`
* Independent review with no findings
* All required CI checks passed. The ICFY job passed on retry after its first dependency install hit an Electron download socket reset.

Manual verification on Calypso Live `build-193045` using a controlled owned site at 3440 x 1080:

* Hard-refreshed with Slow 3G throttling and confirmed the loading state appears before the response, without flashing the empty state.
* Confirmed an empty subscriber response settles to the expected empty state.
* Blocked the subscriber request, refreshed, and confirmed the initial failure state.
* Removed the block, retried, and confirmed the request recovers to the expected empty state.
* The populated subscriber-list state was not manually exercised.

Translation context:

* `Loading paid subscribers` is the loading indicator's `aria-label`, so it is announced by assistive technology rather than displayed visually.
* `We couldn’t load your paid subscribers. Please try again.` appears in the initial-load error state with the **Try again** action.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?