### PR TITLE
Dashboard: default the domain forwarding type based on context

### DIFF
--- a/client/dashboard/domains/domain-forwarding/add.tsx
+++ b/client/dashboard/domains/domain-forwarding/add.tsx
@@ -1,4 +1,8 @@
-import { domainQuery, domainForwardingSaveMutation } from '@automattic/api-queries';
+import {
+	domainQuery,
+	domainForwardingQuery,
+	domainForwardingSaveMutation,
+} from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
@@ -24,7 +28,10 @@ export default function AddDomainForwarding() {
 		} )
 	);
 	const { data: domainData } = useSuspenseQuery( domainQuery( domainName ) );
+	const { data: forwardingData } = useSuspenseQuery( domainForwardingQuery( domainName ) );
 	const forceSubdomainsOnly = domainData?.primary_domain && ! domainData?.is_domain_only_site;
+	// Only one root domain forward can exist at a time.
+	const hasRootForwarding = forwardingData.some( ( forwarding ) => ! forwarding.subdomain );
 
 	const handleSubmit = ( formData: FormData ) => {
 		const submitData: DomainForwardingSaveData = formDataToSubmitData( formData );
@@ -56,6 +63,7 @@ export default function AddDomainForwarding() {
 				isSubmitting={ saveMutation.isPending }
 				submitButtonText={ __( 'Add' ) }
 				forceSubdomain={ forceSubdomainsOnly }
+				defaultSourceType={ hasRootForwarding ? '' : 'root' }
 			/>
 		</PageLayout>
 	);

--- a/client/dashboard/domains/domain-forwarding/form.tsx
+++ b/client/dashboard/domains/domain-forwarding/form.tsx
@@ -117,12 +117,12 @@ export default function DomainForwardingForm( {
 				Edit: 'select',
 				elements: [
 					{
-						label: __( 'Subdomain' ),
-						value: '',
-					},
-					{
 						label: __( 'Domain' ),
 						value: 'root',
+					},
+					{
+						label: __( 'Subdomain' ),
+						value: '',
 					},
 				],
 				isVisible: () => {

--- a/client/dashboard/domains/domain-forwarding/form.tsx
+++ b/client/dashboard/domains/domain-forwarding/form.tsx
@@ -32,6 +32,7 @@ interface DomainForwardingFormProps {
 	isSubmitting: boolean;
 	submitButtonText: string;
 	forceSubdomain: boolean;
+	defaultSourceType?: FormData[ 'sourceType' ];
 }
 
 export default function DomainForwardingForm( {
@@ -41,11 +42,12 @@ export default function DomainForwardingForm( {
 	isSubmitting,
 	submitButtonText,
 	forceSubdomain,
+	defaultSourceType = '',
 }: DomainForwardingFormProps ) {
 	const [ formData, setFormData ] = useState< FormData >( () => {
 		if ( ! initialData ) {
 			return {
-				sourceType: '',
+				sourceType: forceSubdomain ? '' : defaultSourceType,
 				subdomain: '',
 				targetUrl: '',
 				isPermanent: false,

--- a/client/dashboard/domains/domain-forwarding/test/add.test.tsx
+++ b/client/dashboard/domains/domain-forwarding/test/add.test.tsx
@@ -11,6 +11,7 @@ const domainName = 'example.com';
 
 interface TestFormProps {
 	forceSubdomain?: boolean;
+	defaultSourceType?: FormData[ 'sourceType' ];
 	initialData?: any;
 	onSubmit?: ( data: FormData ) => void;
 	isSubmitting?: boolean;
@@ -63,6 +64,47 @@ test( 'shows both root domain and subdomain options when forceSubdomain is false
 
 	// Should show the source type selector when forceSubdomain is false
 	expect( screen.getByText( /Type/ ) ).toBeInTheDocument();
+} );
+
+test( 'selects the root domain as source when defaultSourceType is root', async () => {
+	const user = userEvent.setup();
+	const mockOnSubmit = jest.fn();
+
+	renderForm( { defaultSourceType: 'root', onSubmit: mockOnSubmit } );
+
+	await waitFor( () => {
+		expect( screen.getByText( /Target URL/ ) ).toBeInTheDocument();
+	} );
+
+	// The source URL field shows the root domain and is not editable
+	const sourceInput = screen.getByRole( 'textbox', { name: /source url/i } );
+	expect( sourceInput ).toBeDisabled();
+	expect( sourceInput ).toHaveValue( domainName );
+
+	const targetUrlInput = screen.getByRole( 'textbox', { name: /target url/i } );
+	await user.type( targetUrlInput, 'https://newsite.com' );
+
+	const submitButton = screen.getByRole( 'button', { name: 'Add' } );
+	await user.click( submitButton );
+
+	expect( mockOnSubmit ).toHaveBeenCalledWith( {
+		sourceType: 'root',
+		subdomain: '',
+		targetUrl: 'https://newsite.com',
+		isPermanent: false,
+		forwardPaths: false,
+	} );
+} );
+
+test( 'ignores defaultSourceType and keeps subdomain mode when forceSubdomain is true', async () => {
+	renderForm( { defaultSourceType: 'root', forceSubdomain: true } );
+
+	await waitFor( () => {
+		expect( screen.getByText( /Target URL/ ) ).toBeInTheDocument();
+	} );
+
+	expect( screen.queryByText( /Type/ ) ).not.toBeInTheDocument();
+	expect( screen.getByRole( 'textbox', { name: /source url/i } ) ).toBeEnabled();
 } );
 
 test( 'calls onSubmit with correct data when form is submitted', async () => {


### PR DESCRIPTION
## Proposed Changes

* Default the "Type" dropdown in the add domain forwarding form to **Domain** instead of **Subdomain**.
* Fall back to **Subdomain** when a root forward already exists (only one is allowed) or when the domain only supports subdomain forwards.
* List the Domain option first in the dropdown, matching the new default and the classic Calypso order.

## Why are these changes being made?

* Forwarding the whole domain is the common case, but the form silently defaulted to Subdomain. A user who filled in a target URL without touching the dropdown got a confusing server error (`The DNS record for the subdomain could not be updated.`) instead of the forward they wanted. This came out of a support interaction where exactly that happened.
* The classic Calypso forwarding card already picked the type from context: [Domain first](https://github.com/Automattic/wp-calypso/blob/9acfa561fe66/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx#L58), [Subdomain for primary domains](https://github.com/Automattic/wp-calypso/blob/9acfa561fe66/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx#L144-L147), and [Subdomain once a root forward exists](https://github.com/Automattic/wp-calypso/blob/9acfa561fe66/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx#L441-L443). This restores that behavior in the new dashboard.

## Testing Instructions

* In the dashboard, go to a domain without any forwards → Forwarding → Add. The type should default to **Domain** with the source field showing the root domain.
* Add a root domain forward, then add another forward: the type should now default to **Subdomain**.
* For a domain that is a site's primary address (non-domain-only), the type selector should stay hidden and subdomain-only, as before.
* `yarn test-client client/dashboard/domains/domain-forwarding`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HUT3661fe1NzfvwwDw9Bb

