### PR TITLE
api-core: Add Studio Code AI Credits product slug constant

### DIFF
--- a/packages/api-core/src/constants.ts
+++ b/packages/api-core/src/constants.ts
@@ -244,6 +244,8 @@ export const WPCOM_DIFM_LITE = 'wp_difm_lite';
 
 export const PRODUCT_1GB_SPACE = 'wordpress_com_1gb_space_addon_yearly';
 
+export const PRODUCT_STUDIO_CODE_AI_CREDITS = 'studio-code-ai-credits';
+
 export const OFFSITE_REDIRECT = 'offsite_redirect';
 
 export const AkismetUpgradesProductMap: Record< string, string > = {


### PR DESCRIPTION
Part of SHILL-2360

Related to SHILL-2354 and SHILL-2355

## Proposed Changes

* Add the `studio-code-ai-credits` product slug as a constant in `packages/api-core/src/constants.ts`.

## Why are these changes being made?

That file keeps single product slugs as plain exports - `WPCOM_DIFM_LITE`, `PRODUCT_1GB_SPACE`, `OFFSITE_REDIRECT`. Studio Code AI Credits is new and isn't one of them.

Nothing imports it yet.

## Testing Instructions

**Steps:**
1. Run `yarn typecheck-packages` - exits 0 with no output
2. Run `yarn eslint packages/api-core/src/constants.ts` - reports no errors
3. Run `git grep -n PRODUCT_STUDIO_CODE_AI_CREDITS -- ':!*/dist/*'` - only the declaration, which shows nothing existing can change
