### PR TITLE
Billing history: Show the number of Studio Code AI credits purchased

### DIFF
--- a/client/dashboard/me/billing-history/test/utils.test.ts
+++ b/client/dashboard/me/billing-history/test/utils.test.ts
@@ -1,0 +1,42 @@
+import { renderTransactionQuantitySummary } from '../utils';
+import type { ReceiptItem } from '@automattic/api-core';
+
+const item = ( wpcom_product_slug: string, licensed_quantity: number ) =>
+	( {
+		wpcom_product_slug,
+		licensed_quantity,
+		new_quantity: 0,
+		type: 'new purchase',
+	} ) as ReceiptItem;
+
+describe( 'renderTransactionQuantitySummary', () => {
+	test( 'names Studio Code AI Credits in credits', () => {
+		expect( renderTransactionQuantitySummary( item( 'studio-code-ai-credits', 500 ) ) ).toEqual(
+			'Purchase of 500 credits'
+		);
+	} );
+
+	test( 'uses the singular form for a count of one', () => {
+		expect( renderTransactionQuantitySummary( item( 'studio-code-ai-credits', 1 ) ) ).toEqual(
+			'Purchase of 1 credit'
+		);
+	} );
+
+	test( 'separates thousands', () => {
+		expect( renderTransactionQuantitySummary( item( 'studio-code-ai-credits', 30000 ) ) ).toEqual(
+			'Purchase of 30,000 credits'
+		);
+	} );
+
+	test( 'leaves Akismet Pro unchanged', () => {
+		expect( renderTransactionQuantitySummary( item( 'ak_pro5h_yearly', 3 ) ) ).toEqual(
+			'Purchase of 3 500 API call licenses'
+		);
+	} );
+
+	test( 'leaves unmatched products on the generic summary', () => {
+		expect( renderTransactionQuantitySummary( item( 'jetpack_ai_yearly', 3 ) ) ).toEqual(
+			'Purchase of 3 items'
+		);
+	} );
+} );

--- a/client/dashboard/me/billing-history/utils.tsx
+++ b/client/dashboard/me/billing-history/utils.tsx
@@ -1,3 +1,4 @@
+import { PRODUCT_STUDIO_CODE_AI_CREDITS } from '@automattic/api-core';
 import { formatCurrency, formatNumber } from '@automattic/number-formatters';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { isAkismetPro500Plan } from '../../utils/akismet';
@@ -211,6 +212,14 @@ function renderAkismetTransactionQuantitySummary( licensedQuantity: number, isRe
 	);
 }
 
+function renderStudioCodeAiCreditsQuantitySummary( licensedQuantity: number ) {
+	return sprintf(
+		/* translators: %s: formatted number of Studio Code AI credits */
+		_n( 'Purchase of %s credit', 'Purchase of %s credits', licensedQuantity ),
+		formatNumber( licensedQuantity )
+	);
+}
+
 export function DomainTransactionVolumeSummary( { item }: { item: ReceiptItem } ) {
 	if ( ! item.volume ) {
 		return null;
@@ -289,6 +298,10 @@ export function renderTransactionQuantitySummary( {
 
 	if ( isAkismetPro500Plan( wpcom_product_slug ) ) {
 		return renderAkismetTransactionQuantitySummary( licensedQuantity, isRenewal );
+	}
+
+	if ( PRODUCT_STUDIO_CODE_AI_CREDITS === wpcom_product_slug ) {
+		return renderStudioCodeAiCreditsQuantitySummary( licensedQuantity );
 	}
 
 	if ( isRenewal ) {

--- a/client/me/purchases/billing-history/test/utils.ts
+++ b/client/me/purchases/billing-history/test/utils.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck - TODO: Fix TypeScript issues
 import deepFreeze from 'deep-freeze';
-import { groupDomainProducts } from '../utils';
+import { translate } from 'i18n-calypso';
+import { groupDomainProducts, renderTransactionQuantitySummary } from '../utils';
 
 const ident = ( x ) => x;
 
@@ -350,6 +351,45 @@ describe( 'utils', () => {
 			expect( result[ 1 ].amount_integer ).toEqual( 200 );
 			expect( result[ 2 ].amount ).toEqual( '$19' );
 			expect( result[ 2 ].amount_integer ).toEqual( 1900 );
+		} );
+	} );
+
+	describe( '#renderTransactionQuantitySummary()', () => {
+		const item = ( wpcom_product_slug, licensed_quantity ) => ( {
+			wpcom_product_slug,
+			licensed_quantity,
+			new_quantity: 0,
+			type: 'new purchase',
+		} );
+
+		test( 'should name Studio Code AI Credits in credits', () => {
+			expect(
+				renderTransactionQuantitySummary( item( 'studio-code-ai-credits', 500 ), translate )
+			).toEqual( 'Purchase of 500 credits' );
+		} );
+
+		test( 'should use the singular form for a count of one', () => {
+			expect(
+				renderTransactionQuantitySummary( item( 'studio-code-ai-credits', 1 ), translate )
+			).toEqual( 'Purchase of 1 credit' );
+		} );
+
+		test( 'should separate thousands', () => {
+			expect(
+				renderTransactionQuantitySummary( item( 'studio-code-ai-credits', 30000 ), translate )
+			).toEqual( 'Purchase of 30,000 credits' );
+		} );
+
+		test( 'should leave Akismet Pro unchanged', () => {
+			expect( renderTransactionQuantitySummary( item( 'ak_pro5h_yearly', 3 ), translate ) ).toEqual(
+				'Purchase of 3 500 API call licenses'
+			);
+		} );
+
+		test( 'should leave unmatched products on the generic summary', () => {
+			expect(
+				renderTransactionQuantitySummary( item( 'jetpack_ai_yearly', 3 ), translate )
+			).toEqual( 'Purchase of 3 items' );
 		} );
 	} );
 } );

--- a/client/me/purchases/billing-history/utils.tsx
+++ b/client/me/purchases/billing-history/utils.tsx
@@ -1,3 +1,4 @@
+import { PRODUCT_STUDIO_CODE_AI_CREDITS } from '@automattic/api-core';
 import {
 	getPlanTermLabel,
 	isDIFMProduct,
@@ -342,6 +343,17 @@ function renderAkismetTransactionQuantitySummary(
 	);
 }
 
+function renderStudioCodeAiCreditsQuantitySummary(
+	licensed_quantity: number,
+	translate: LocalizeProps[ 'translate' ]
+) {
+	return translate( 'Purchase of %(quantity)s credit', 'Purchase of %(quantity)s credits', {
+		args: { quantity: formatNumber( licensed_quantity ) },
+		count: licensed_quantity,
+		comment: '%(quantity)s is the number of Studio Code AI credits purchased',
+	} );
+}
+
 export function renderTransactionQuantitySummary(
 	{ licensed_quantity, new_quantity, type, wpcom_product_slug }: BillingTransactionItem,
 	translate: LocalizeProps[ 'translate' ]
@@ -384,6 +396,10 @@ export function renderTransactionQuantitySummary(
 
 	if ( isAkismetPro500( product ) ) {
 		return renderAkismetTransactionQuantitySummary( licensed_quantity, isRenewal, translate );
+	}
+
+	if ( PRODUCT_STUDIO_CODE_AI_CREDITS === wpcom_product_slug ) {
+		return renderStudioCodeAiCreditsQuantitySummary( licensed_quantity, translate );
 	}
 
 	if ( isRenewal ) {


### PR DESCRIPTION
Resolves SHILL-2359
Related to 234090-ghe-Automattic/wpcom - the receipt email half of this ticket.

**Merge #113538 first.** The base branch here is `add/shill-2360-studio-slug-constant`, which adds the `PRODUCT_STUDIO_CODE_AI_CREDITS` constant this PR imports. Rebases onto trunk cleanly once that lands.

## Proposed Changes

* `client/me/purchases/billing-history/utils.tsx` - branch in `renderTransactionQuantitySummary()` plus a `renderStudioCodeAiCreditsQuantitySummary()` helper, following `renderJetpackStatsQuantitySummary()`, which already pairs `formatNumber()` with a `%(quantity)s` placeholder.
* `client/dashboard/me/billing-history/utils.tsx` - the same, in that surface's own dispatcher, using `_n()` and `sprintf()` from `@wordpress/i18n`.
* Tests for both surfaces.

## Why are these changes being made?

**Before.** Both billing-history dispatchers branch per product - Jetpack Search, Jetpack Stats, Google Workspace and Titan, DIFM, the space add-on, Akismet Pro - and fall through to a generic "Purchase of %d items".

**Problem.** Studio Code AI Credits has no branch, so a 500-credit purchase reads "Purchase of 500 items". The P2 lists showing the credit count as a must-have.

**Fix.** One branch per dispatcher.

| Surface | Before | After |
|---|---|---|
| `/me/purchases` list and detail | Purchase of 500 items | Purchase of 500 credits |
| Dashboard billing history | Purchase of 500 items | Purchase of 500 credits |

Three things a reviewer will want to know.

**Two msgids for one English sentence.** Classic uses `i18n-calypso`'s `translate( sing, plural, { count, args } )`, the dashboard uses `@wordpress/i18n`'s `_n()` and `sprintf()`. Different libraries, so the string is authored twice.

**Identified by one shared slug constant.** `PRODUCT_STUDIO_CODE_AI_CREDITS` from `@automattic/api-core` is the single definition of this product's slug across the Studio Code AI Credits work, compared inline here. `packages/calypso-products` is frozen, which is why the constant lives in api-core.

**The plural signature is used even though the count is never 1** - minimum purchase is 100 credits in increments of 100. Polish and Russian pick their form from the numeral. Credits are a one-time, non-renewing purchase, so the branch sits above the `isRenewal` and `isUpgrade` frames and those never apply.

## Testing Instructions

**Environment:**
- Enable Store Sandbox mode
- `public-api.wordpress.com` sandboxed

Automated:

```
yarn test-client billing-history/test/utils
```

Covers the credit count on both surfaces, thousands separation, Akismet Pro unchanged, and a product with no branch still using the generic summary.

**Steps:**
1. Open `/me/purchases/billing` and `/me/billing/history`. Studio Code AI Credits rows read "Purchase of N credits" rather than "Purchase of N items".
2. Open the receipts below on both surfaces. Each receipt sits on one of two test accounts, so sign in as the one that owns it.
3. In the same lists, the Akismet Pro row still reads "Purchase of N 500 API call license(s)" - that is the regression check, visible in the same frame.

| Receipt | Expected | `/me/purchases/billing/<receiptId>` | `/me/billing/history/<receiptId>` |
|---|---|---|---|
| 20789366 | Purchase of 500 credits | [classic](/me/purchases/billing/20789366) | [dashboard](/me/billing/history/20789366) |
| 20789076 | Purchase of 500 credits | [classic](/me/purchases/billing/20789076) | [dashboard](/me/billing/history/20789076) |
| 20794293 | Purchase of 1,700 credits | [classic](/me/purchases/billing/20794293) | [dashboard](/me/billing/history/20794293) |
| 20789985 | Purchase of 30,000 credits | [classic](/me/purchases/billing/20789985) | [dashboard](/me/billing/history/20789985) |
| 20792858 | no quantity line - `licensed_quantity` is null | [classic](/me/purchases/billing/20792858) | [dashboard](/me/billing/history/20792858) |

20789366 and 20789076 are on one account, 20794293 and 20789985 on the other. 20794293 and 20789985 are the ones that show thousands separation.

Receipt items reach the client with `wpcom_product_slug` taken from the Store product's `product_slug`. Verified on the sandbox for the two fixtures:

```
receipt=20789366 wpcom_product_slug=studio-code-ai-credits licensed_quantity=500 type=new purchase
receipt=20789985 wpcom_product_slug=studio-code-ai-credits licensed_quantity=30000 type=new purchase
```

Before and after screenshots of both surfaces are attached. The dashboard pair also contains the Akismet Pro row unchanged, so it covers that regression.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
