### PR TITLE
Checkout: Link to AI Credits Guidelines when Studio Code AI Credits are in the cart

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/tos-text.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/tos-text.tsx
@@ -1,64 +1,99 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { getStudioCodeAiCreditsGuidelinesUrl } from 'calypso/my-sites/checkout/src/components/studio-code-ai-credits-guidelines';
 
 interface TosTextProps {
 	isAkismetPurchase: boolean;
 	is100YearPlanPurchase: boolean;
 	is100YearDomainPurchase: boolean;
+	hasStudioCodeAiCredits?: boolean;
 }
 
 export default function TosText( {
 	isAkismetPurchase,
 	is100YearPlanPurchase,
 	is100YearDomainPurchase,
+	hasStudioCodeAiCredits = false,
 }: TosTextProps ) {
 	const translate = useTranslate();
 
 	if ( is100YearPlanPurchase || is100YearDomainPurchase ) {
+		const components = {
+			tosLink: (
+				<a
+					href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+					target="_blank"
+					rel="noopener noreferrer"
+				/>
+			),
+		};
+
 		return (
 			<>
-				{ translate( 'You agree to our {{tosLink}}Terms of Service{{/tosLink}}.', {
-					components: {
-						tosLink: (
-							<a
-								href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-								target="_blank"
-								rel="noopener noreferrer"
-							/>
-						),
-					},
-				} ) }
+				{ hasStudioCodeAiCredits
+					? translate(
+							'You agree to our {{tosLink}}Terms of Service{{/tosLink}} and {{guidelines}}AI Credits Guidelines{{/guidelines}}.',
+							{
+								components: {
+									...components,
+									guidelines: (
+										<a
+											href={ getStudioCodeAiCreditsGuidelinesUrl() }
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+								},
+							}
+					  )
+					: translate( 'You agree to our {{tosLink}}Terms of Service{{/tosLink}}.', {
+							components,
+					  } ) }
 			</>
 		);
 	}
 
+	const components = {
+		tosLink: (
+			<a
+				href={
+					isAkismetPurchase
+						? localizeUrl( 'https://akismet.com/tos/' )
+						: localizeUrl( 'https://wordpress.com/tos/' )
+				}
+				target="_blank"
+				rel="noopener noreferrer"
+			/>
+		),
+		autoRenewalSupportPage: <InlineSupportLink supportContext="autorenewal" showIcon={ false } />,
+		faqCancellingSupportPage: (
+			<InlineSupportLink supportContext="cancel_purchase" showIcon={ false } />
+		),
+	};
+
 	return (
 		<>
-			{ translate(
-				'You agree to our {{tosLink}}Terms of Service{{/tosLink}} and authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time. You understand {{autoRenewalSupportPage}}how your subscription works{{/autoRenewalSupportPage}} and {{faqCancellingSupportPage}}how to cancel{{/faqCancellingSupportPage}}.',
-				{
-					components: {
-						tosLink: (
-							<a
-								href={
-									isAkismetPurchase
-										? localizeUrl( 'https://akismet.com/tos/' )
-										: localizeUrl( 'https://wordpress.com/tos/' )
-								}
-								target="_blank"
-								rel="noopener noreferrer"
-							/>
-						),
-						autoRenewalSupportPage: (
-							<InlineSupportLink supportContext="autorenewal" showIcon={ false } />
-						),
-						faqCancellingSupportPage: (
-							<InlineSupportLink supportContext="cancel_purchase" showIcon={ false } />
-						),
-					},
-				}
-			) }
+			{ hasStudioCodeAiCredits
+				? translate(
+						'You agree to our {{tosLink}}Terms of Service{{/tosLink}} and {{guidelines}}AI Credits Guidelines{{/guidelines}} and authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time. You understand {{autoRenewalSupportPage}}how your subscription works{{/autoRenewalSupportPage}} and {{faqCancellingSupportPage}}how to cancel{{/faqCancellingSupportPage}}.',
+						{
+							components: {
+								...components,
+								guidelines: (
+									<a
+										href={ getStudioCodeAiCreditsGuidelinesUrl() }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						}
+				  )
+				: translate(
+						'You agree to our {{tosLink}}Terms of Service{{/tosLink}} and authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time. You understand {{autoRenewalSupportPage}}how your subscription works{{/autoRenewalSupportPage}} and {{faqCancellingSupportPage}}how to cancel{{/faqCancellingSupportPage}}.',
+						{ components }
+				  ) }
 		</>
 	);
 }

--- a/client/my-sites/checkout/src/components/checkout-pay-button-footer.tsx
+++ b/client/my-sites/checkout/src/components/checkout-pay-button-footer.tsx
@@ -1,3 +1,4 @@
+import { PRODUCT_STUDIO_CODE_AI_CREDITS } from '@automattic/api-core';
 import { localizeUrl } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { Icon } from '@wordpress/components';
@@ -8,6 +9,10 @@ import { CheckoutSummaryRefundWindows } from './checkout-summary-refund-windows'
 import CheckoutTermsModal from './checkout-terms-modal';
 import { getRefundWindowSummary } from './refund-policies';
 import type { ResponseCart } from '@automattic/shopping-cart';
+
+// TODO: SHILL-2355 - swap in the real URL once Legal publishes the AI Credits Guidelines doc.
+// Wrap it in localizeUrl() like the tos and pp links below if the doc has localized versions.
+const AI_CREDITS_GUIDELINES_URL = '#ai-credits-guidelines-pending';
 
 const Wrapper = styled.div`
 	display: flex;
@@ -74,6 +79,41 @@ export default function CheckoutPayButtonFooter( { cart }: { cart: ResponseCart 
 	const translate = useTranslate();
 	const [ isTermsModalOpen, setIsTermsModalOpen ] = useState( false );
 	const hasRefundWindow = getRefundWindowSummary( cart ) !== null;
+	const hasStudioCodeAiCredits = cart.products.some(
+		( product ) => PRODUCT_STUDIO_CODE_AI_CREDITS === product.product_slug
+	);
+
+	// Only the tags a string uses get looked up, so both sentences share one map.
+	const components = {
+		tos: (
+			<a
+				href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+				target="_blank"
+				rel="noopener noreferrer"
+			/>
+		),
+		guidelines: <a href={ AI_CREDITS_GUIDELINES_URL } target="_blank" rel="noopener noreferrer" />,
+		pp: (
+			<a
+				href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+				target="_blank"
+				rel="noopener noreferrer"
+			/>
+		),
+		readmore: <button type="button" onClick={ () => setIsTermsModalOpen( true ) } />,
+	};
+
+	// Studio carts get their own sentence instead of editing the shared one - that would change its
+	// msgid and drop every checkout in every locale to English until GlotPress catches up.
+	const legalNotice = hasStudioCodeAiCredits
+		? translate(
+				'By checking out, you agree to our {{tos}}Terms of Service{{/tos}} and {{guidelines}}AI Credits Guidelines{{/guidelines}}, and have read our {{pp}}Privacy Policy{{/pp}}. {{readmore}}View billing and renewal details{{/readmore}}',
+				{ components }
+		  )
+		: translate(
+				'By purchasing, you accept the {{tos}}Terms of Service{{/tos}} and {{pp}}Privacy Policy{{/pp}}. {{readmore}}View billing and renewal details{{/readmore}}',
+				{ components }
+		  );
 
 	return (
 		<Wrapper className="checkout-pay-button-footer">
@@ -90,30 +130,7 @@ export default function CheckoutPayButtonFooter( { cart }: { cart: ResponseCart 
 
 			<Divider />
 
-			<LegalNotice>
-				{ translate(
-					'By purchasing, you accept the {{tos}}Terms of Service{{/tos}} and {{pp}}Privacy Policy{{/pp}}. {{readmore}}View billing and renewal details{{/readmore}}',
-					{
-						components: {
-							tos: (
-								<a
-									href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-							pp: (
-								<a
-									href={ localizeUrl( 'https://automattic.com/privacy/' ) }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-							readmore: <button type="button" onClick={ () => setIsTermsModalOpen( true ) } />,
-						},
-					}
-				) }
-			</LegalNotice>
+			<LegalNotice>{ legalNotice }</LegalNotice>
 
 			<CheckoutTermsModal
 				cart={ cart }

--- a/client/my-sites/checkout/src/components/checkout-pay-button-footer.tsx
+++ b/client/my-sites/checkout/src/components/checkout-pay-button-footer.tsx
@@ -1,4 +1,3 @@
-import { PRODUCT_STUDIO_CODE_AI_CREDITS } from '@automattic/api-core';
 import { localizeUrl } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { Icon } from '@wordpress/components';
@@ -8,11 +7,11 @@ import { useState } from 'react';
 import { CheckoutSummaryRefundWindows } from './checkout-summary-refund-windows';
 import CheckoutTermsModal from './checkout-terms-modal';
 import { getRefundWindowSummary } from './refund-policies';
+import {
+	getStudioCodeAiCreditsGuidelinesUrl,
+	hasStudioCodeAiCredits,
+} from './studio-code-ai-credits-guidelines';
 import type { ResponseCart } from '@automattic/shopping-cart';
-
-// TODO: SHILL-2355 - swap in the real URL once Legal publishes the AI Credits Guidelines doc.
-// Wrap it in localizeUrl() like the tos and pp links below if the doc has localized versions.
-const AI_CREDITS_GUIDELINES_URL = '#ai-credits-guidelines-pending';
 
 const Wrapper = styled.div`
 	display: flex;
@@ -79,11 +78,7 @@ export default function CheckoutPayButtonFooter( { cart }: { cart: ResponseCart 
 	const translate = useTranslate();
 	const [ isTermsModalOpen, setIsTermsModalOpen ] = useState( false );
 	const hasRefundWindow = getRefundWindowSummary( cart ) !== null;
-	const hasStudioCodeAiCredits = cart.products.some(
-		( product ) => PRODUCT_STUDIO_CODE_AI_CREDITS === product.product_slug
-	);
 
-	// Only the tags a string uses get looked up, so both sentences share one map.
 	const components = {
 		tos: (
 			<a
@@ -92,7 +87,6 @@ export default function CheckoutPayButtonFooter( { cart }: { cart: ResponseCart 
 				rel="noopener noreferrer"
 			/>
 		),
-		guidelines: <a href={ AI_CREDITS_GUIDELINES_URL } target="_blank" rel="noopener noreferrer" />,
 		pp: (
 			<a
 				href={ localizeUrl( 'https://automattic.com/privacy/' ) }
@@ -102,18 +96,6 @@ export default function CheckoutPayButtonFooter( { cart }: { cart: ResponseCart 
 		),
 		readmore: <button type="button" onClick={ () => setIsTermsModalOpen( true ) } />,
 	};
-
-	// Studio carts get their own sentence instead of editing the shared one - that would change its
-	// msgid and drop every checkout in every locale to English until GlotPress catches up.
-	const legalNotice = hasStudioCodeAiCredits
-		? translate(
-				'By checking out, you agree to our {{tos}}Terms of Service{{/tos}} and {{guidelines}}AI Credits Guidelines{{/guidelines}}, and have read our {{pp}}Privacy Policy{{/pp}}. {{readmore}}View billing and renewal details{{/readmore}}',
-				{ components }
-		  )
-		: translate(
-				'By purchasing, you accept the {{tos}}Terms of Service{{/tos}} and {{pp}}Privacy Policy{{/pp}}. {{readmore}}View billing and renewal details{{/readmore}}',
-				{ components }
-		  );
 
 	return (
 		<Wrapper className="checkout-pay-button-footer">
@@ -130,7 +112,28 @@ export default function CheckoutPayButtonFooter( { cart }: { cart: ResponseCart 
 
 			<Divider />
 
-			<LegalNotice>{ legalNotice }</LegalNotice>
+			<LegalNotice>
+				{ hasStudioCodeAiCredits( cart )
+					? translate(
+							'By checking out, you agree to our {{tos}}Terms of Service{{/tos}} and {{guidelines}}AI Credits Guidelines{{/guidelines}}, and have read our {{pp}}Privacy Policy{{/pp}}. {{readmore}}View billing and renewal details{{/readmore}}',
+							{
+								components: {
+									...components,
+									guidelines: (
+										<a
+											href={ getStudioCodeAiCreditsGuidelinesUrl() }
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+								},
+							}
+					  )
+					: translate(
+							'By purchasing, you accept the {{tos}}Terms of Service{{/tos}} and {{pp}}Privacy Policy{{/pp}}. {{readmore}}View billing and renewal details{{/readmore}}',
+							{ components }
+					  ) }
+			</LegalNotice>
 
 			<CheckoutTermsModal
 				cart={ cart }

--- a/client/my-sites/checkout/src/components/checkout-terms.tsx
+++ b/client/my-sites/checkout/src/components/checkout-terms.tsx
@@ -29,6 +29,7 @@ import JetpackSocialAdvancedPricingDisclaimer, {
 	showJetpackSocialAdvancedPricingDisclaimer,
 } from './jetpack-social-advanced-pricing-disclaimer';
 import RefundPolicies from './refund-policies';
+import { hasStudioCodeAiCredits } from './studio-code-ai-credits-guidelines';
 import { PlanTerms100Year, DomainTerms100Year } from './terms-100-year';
 import { TermsOfService } from './terms-of-service';
 import ThirdPartyPluginsTermsOfService from './third-party-plugins-terms-of-service';
@@ -101,6 +102,7 @@ export default function CheckoutTerms( {
 			</div>
 
 			<TermsOfService
+				hasStudioCodeAiCredits={ hasStudioCodeAiCredits( cart ) }
 				hasRenewableSubscription={ hasRenewableSubscription( cart ) || hasDomainTransfer }
 				isGiftPurchase={ Boolean( isGiftPurchase ) }
 				is100YearPlanPurchase={ has100YearPlan( cart ) }

--- a/client/my-sites/checkout/src/components/studio-code-ai-credits-guidelines.ts
+++ b/client/my-sites/checkout/src/components/studio-code-ai-credits-guidelines.ts
@@ -1,0 +1,18 @@
+import { PRODUCT_STUDIO_CODE_AI_CREDITS } from '@automattic/api-core';
+import { localizeUrl } from '@automattic/i18n-utils';
+import type { ResponseCart } from '@automattic/shopping-cart';
+
+/**
+ * TODO: SHILL-2355 - return the real URL once Legal publishes the AI Credits Guidelines doc.
+ * Until then the anchor hangs off the Terms of Service page, so following the link lands
+ * somewhere sensible instead of nowhere.
+ */
+export function getStudioCodeAiCreditsGuidelinesUrl() {
+	return `${ localizeUrl( 'https://wordpress.com/tos/' ) }#ai-credits-guidelines-pending`;
+}
+
+export function hasStudioCodeAiCredits( cart: ResponseCart ) {
+	return cart.products.some(
+		( product ) => PRODUCT_STUDIO_CODE_AI_CREDITS === product.product_slug
+	);
+}

--- a/client/my-sites/checkout/src/components/studio-code-ai-credits-guidelines.ts
+++ b/client/my-sites/checkout/src/components/studio-code-ai-credits-guidelines.ts
@@ -1,14 +1,12 @@
 import { PRODUCT_STUDIO_CODE_AI_CREDITS } from '@automattic/api-core';
-import { localizeUrl } from '@automattic/i18n-utils';
 import type { ResponseCart } from '@automattic/shopping-cart';
 
-/**
- * TODO: SHILL-2355 - return the real URL once Legal publishes the AI Credits Guidelines doc.
- * Until then the anchor hangs off the Terms of Service page, so following the link lands
- * somewhere sensible instead of nowhere.
- */
+// The guidelines doc is published in English only, so this skips localizeUrl().
+const AI_CREDITS_GUIDELINES_URL =
+	'https://developer.wordpress.com/docs/developer-tools/studio/studio-code/ai-credits-guidelines/';
+
 export function getStudioCodeAiCreditsGuidelinesUrl() {
-	return `${ localizeUrl( 'https://wordpress.com/tos/' ) }#ai-credits-guidelines-pending`;
+	return AI_CREDITS_GUIDELINES_URL;
 }
 
 export function hasStudioCodeAiCredits( cart: ResponseCart ) {

--- a/client/my-sites/checkout/src/components/terms-of-service.tsx
+++ b/client/my-sites/checkout/src/components/terms-of-service.tsx
@@ -25,6 +25,18 @@ export const TermsOfService = ( {
 	};
 
 	const renderTerms = () => {
+		// Show the extended ToS notice for renewable subscriptions, except gifts
+		if ( ! isGiftPurchase && hasRenewableSubscription ) {
+			return (
+				<TosText
+					isAkismetPurchase={ isAkismetCheckout() }
+					is100YearPlanPurchase={ is100YearPlanPurchase }
+					is100YearDomainPurchase={ is100YearDomainPurchase }
+					hasStudioCodeAiCredits={ hasStudioCodeAiCredits }
+				/>
+			);
+		}
+
 		const components = {
 			link: (
 				<a
@@ -39,37 +51,25 @@ export const TermsOfService = ( {
 			),
 		};
 
-		let message = hasStudioCodeAiCredits
-			? translate(
-					'You agree to our {{link}}Terms of Service{{/link}} and {{guidelines}}AI Credits Guidelines{{/guidelines}}.',
-					{
-						components: {
-							...components,
-							guidelines: (
-								<a
-									href={ getStudioCodeAiCreditsGuidelinesUrl() }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-						},
-					}
-			  )
-			: translate( 'You agree to our {{link}}Terms of Service{{/link}}.', { components } );
-
-		// Don't show the extended ToS notice for one-time purchases or gifts
-		if ( ! isGiftPurchase && hasRenewableSubscription ) {
-			message = (
-				<TosText
-					isAkismetPurchase={ isAkismetCheckout() }
-					is100YearPlanPurchase={ is100YearPlanPurchase }
-					is100YearDomainPurchase={ is100YearDomainPurchase }
-					hasStudioCodeAiCredits={ hasStudioCodeAiCredits }
-				/>
-			);
+		if ( ! hasStudioCodeAiCredits ) {
+			return translate( 'You agree to our {{link}}Terms of Service{{/link}}.', { components } );
 		}
 
-		return message;
+		return translate(
+			'You agree to our {{link}}Terms of Service{{/link}} and {{guidelines}}AI Credits Guidelines{{/guidelines}}.',
+			{
+				components: {
+					...components,
+					guidelines: (
+						<a
+							href={ getStudioCodeAiCreditsGuidelinesUrl() }
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+				},
+			}
+		);
 	};
 
 	return (

--- a/client/my-sites/checkout/src/components/terms-of-service.tsx
+++ b/client/my-sites/checkout/src/components/terms-of-service.tsx
@@ -4,13 +4,16 @@ import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import TosText from 'calypso/me/purchases/manage-purchase/payment-method-selector/tos-text';
 import CheckoutTermsItem from 'calypso/my-sites/checkout/src/components/checkout-terms-item';
+import { getStudioCodeAiCreditsGuidelinesUrl } from './studio-code-ai-credits-guidelines';
 
 export const TermsOfService = ( {
+	hasStudioCodeAiCredits,
 	hasRenewableSubscription,
 	isGiftPurchase,
 	is100YearPlanPurchase,
 	is100YearDomainPurchase,
 }: {
+	hasStudioCodeAiCredits: boolean;
 	hasRenewableSubscription: boolean;
 	isGiftPurchase: boolean;
 	is100YearPlanPurchase: boolean;
@@ -22,21 +25,37 @@ export const TermsOfService = ( {
 	};
 
 	const renderTerms = () => {
-		let message = translate( 'You agree to our {{link}}Terms of Service{{/link}}.', {
-			components: {
-				link: (
-					<a
-						href={
-							isAkismetCheckout()
-								? localizeUrl( 'https://akismet.com/tos/' )
-								: localizeUrl( 'https://wordpress.com/tos/' )
-						}
-						target="_blank"
-						rel="noopener noreferrer"
-					/>
-				),
-			},
-		} );
+		const components = {
+			link: (
+				<a
+					href={
+						isAkismetCheckout()
+							? localizeUrl( 'https://akismet.com/tos/' )
+							: localizeUrl( 'https://wordpress.com/tos/' )
+					}
+					target="_blank"
+					rel="noopener noreferrer"
+				/>
+			),
+		};
+
+		let message = hasStudioCodeAiCredits
+			? translate(
+					'You agree to our {{link}}Terms of Service{{/link}} and {{guidelines}}AI Credits Guidelines{{/guidelines}}.',
+					{
+						components: {
+							...components,
+							guidelines: (
+								<a
+									href={ getStudioCodeAiCreditsGuidelinesUrl() }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
+					}
+			  )
+			: translate( 'You agree to our {{link}}Terms of Service{{/link}}.', { components } );
 
 		// Don't show the extended ToS notice for one-time purchases or gifts
 		if ( ! isGiftPurchase && hasRenewableSubscription ) {
@@ -45,6 +64,7 @@ export const TermsOfService = ( {
 					isAkismetPurchase={ isAkismetCheckout() }
 					is100YearPlanPurchase={ is100YearPlanPurchase }
 					is100YearDomainPurchase={ is100YearDomainPurchase }
+					hasStudioCodeAiCredits={ hasStudioCodeAiCredits }
 				/>
 			);
 		}

--- a/client/my-sites/checkout/src/components/test/checkout-pay-button-footer.test.tsx
+++ b/client/my-sites/checkout/src/components/test/checkout-pay-button-footer.test.tsx
@@ -60,10 +60,9 @@ describe( 'CheckoutPayButtonFooter', () => {
 	it( 'links the AI Credits Guidelines for a cart containing Studio Code AI Credits', () => {
 		renderFooter( cartWith( PLAN_PREMIUM, PRODUCT_STUDIO_CODE_AI_CREDITS ) );
 
-		// TODO: SHILL-2355 - update alongside getStudioCodeAiCreditsGuidelinesUrl().
 		expect( screen.getByRole( 'link', { name: 'AI Credits Guidelines' } ) ).toHaveAttribute(
 			'href',
-			'https://wordpress.com/tos/#ai-credits-guidelines-pending'
+			'https://developer.wordpress.com/docs/developer-tools/studio/studio-code/ai-credits-guidelines/'
 		);
 		// The standard notice is unaffected by the extra line.
 		expect(

--- a/client/my-sites/checkout/src/components/test/checkout-pay-button-footer.test.tsx
+++ b/client/my-sites/checkout/src/components/test/checkout-pay-button-footer.test.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import { PRODUCT_STUDIO_CODE_AI_CREDITS } from '@automattic/api-core';
 import { PLAN_PREMIUM } from '@automattic/calypso-products';
 import { checkoutTheme } from '@automattic/composite-checkout';
 import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
@@ -10,12 +11,34 @@ import { render, screen } from '@testing-library/react';
 import CheckoutPayButtonFooter from '../checkout-pay-button-footer';
 import type { ResponseCart } from '@automattic/shopping-cart';
 
+const STUDIO_SENTENCE =
+	'By checking out, you agree to our Terms of Service and AI Credits Guidelines, and have read our Privacy Policy. View billing and renewal details';
+const SHARED_SENTENCE =
+	'By purchasing, you accept the Terms of Service and Privacy Policy. View billing and renewal details';
+
 function renderFooter( cart: ResponseCart ) {
 	return render(
 		<ThemeProvider theme={ checkoutTheme }>
 			<CheckoutPayButtonFooter cart={ cart } />
 		</ThemeProvider>
 	);
+}
+
+function cartWith( ...productSlugs: string[] ): ResponseCart {
+	const cart = getEmptyResponseCart();
+	cart.products.push(
+		...productSlugs.map( ( product_slug ) => ( {
+			...getEmptyResponseCartProduct(),
+			item_subtotal_integer: 5,
+			product_slug,
+		} ) )
+	);
+	return cart;
+}
+
+function legalNoticeText(): string {
+	// Both sentences render across several elements, so find one link they share.
+	return screen.getByRole( 'link', { name: 'Privacy Policy' } ).closest( 'p' )?.textContent ?? '';
 }
 
 describe( 'CheckoutPayButtonFooter', () => {
@@ -42,5 +65,42 @@ describe( 'CheckoutPayButtonFooter', () => {
 		const wrapper = container.querySelector( '.checkout-pay-button-footer' );
 		// 3 direct children: SSL trust line, divider, legal notice (modal is closed).
 		expect( wrapper?.childElementCount ).toBe( 3 );
+	} );
+
+	it( 'links the AI Credits Guidelines for a Studio Code AI Credits cart', () => {
+		renderFooter( cartWith( PRODUCT_STUDIO_CODE_AI_CREDITS ) );
+
+		expect( legalNoticeText() ).toBe( STUDIO_SENTENCE );
+		// TODO: SHILL-2355 - update alongside AI_CREDITS_GUIDELINES_URL when Legal publishes the doc.
+		expect( screen.getByRole( 'link', { name: 'AI Credits Guidelines' } ) ).toHaveAttribute(
+			'href',
+			'#ai-credits-guidelines-pending'
+		);
+	} );
+
+	it( 'renders the standard legal sentence for a plan cart', () => {
+		renderFooter( cartWith( PLAN_PREMIUM ) );
+
+		expect( legalNoticeText() ).toBe( SHARED_SENTENCE );
+		expect(
+			screen.queryByRole( 'link', { name: 'AI Credits Guidelines' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'keeps the Terms of Service and Privacy Policy links on a mixed cart', () => {
+		renderFooter( cartWith( PLAN_PREMIUM, PRODUCT_STUDIO_CODE_AI_CREDITS ) );
+
+		expect( legalNoticeText() ).toBe( STUDIO_SENTENCE );
+		expect( screen.getByRole( 'link', { name: 'Terms of Service' } ) ).toHaveAttribute(
+			'href',
+			'https://wordpress.com/tos/'
+		);
+		expect( screen.getByRole( 'link', { name: 'Privacy Policy' } ) ).toHaveAttribute(
+			'href',
+			'https://automattic.com/privacy/'
+		);
+		expect(
+			screen.getByRole( 'button', { name: 'View billing and renewal details' } )
+		).toBeVisible();
 	} );
 } );

--- a/client/my-sites/checkout/src/components/test/checkout-pay-button-footer.test.tsx
+++ b/client/my-sites/checkout/src/components/test/checkout-pay-button-footer.test.tsx
@@ -11,11 +11,6 @@ import { render, screen } from '@testing-library/react';
 import CheckoutPayButtonFooter from '../checkout-pay-button-footer';
 import type { ResponseCart } from '@automattic/shopping-cart';
 
-const STUDIO_SENTENCE =
-	'By checking out, you agree to our Terms of Service and AI Credits Guidelines, and have read our Privacy Policy. View billing and renewal details';
-const SHARED_SENTENCE =
-	'By purchasing, you accept the Terms of Service and Privacy Policy. View billing and renewal details';
-
 function renderFooter( cart: ResponseCart ) {
 	return render(
 		<ThemeProvider theme={ checkoutTheme }>
@@ -34,11 +29,6 @@ function cartWith( ...productSlugs: string[] ): ResponseCart {
 		} ) )
 	);
 	return cart;
-}
-
-function legalNoticeText(): string {
-	// Both sentences render across several elements, so find one link they share.
-	return screen.getByRole( 'link', { name: 'Privacy Policy' } ).closest( 'p' )?.textContent ?? '';
 }
 
 describe( 'CheckoutPayButtonFooter', () => {
@@ -67,40 +57,25 @@ describe( 'CheckoutPayButtonFooter', () => {
 		expect( wrapper?.childElementCount ).toBe( 3 );
 	} );
 
-	it( 'links the AI Credits Guidelines for a Studio Code AI Credits cart', () => {
-		renderFooter( cartWith( PRODUCT_STUDIO_CODE_AI_CREDITS ) );
-
-		expect( legalNoticeText() ).toBe( STUDIO_SENTENCE );
-		// TODO: SHILL-2355 - update alongside AI_CREDITS_GUIDELINES_URL when Legal publishes the doc.
-		expect( screen.getByRole( 'link', { name: 'AI Credits Guidelines' } ) ).toHaveAttribute(
-			'href',
-			'#ai-credits-guidelines-pending'
-		);
-	} );
-
-	it( 'renders the standard legal sentence for a plan cart', () => {
-		renderFooter( cartWith( PLAN_PREMIUM ) );
-
-		expect( legalNoticeText() ).toBe( SHARED_SENTENCE );
-		expect(
-			screen.queryByRole( 'link', { name: 'AI Credits Guidelines' } )
-		).not.toBeInTheDocument();
-	} );
-
-	it( 'keeps the Terms of Service and Privacy Policy links on a mixed cart', () => {
+	it( 'links the AI Credits Guidelines for a cart containing Studio Code AI Credits', () => {
 		renderFooter( cartWith( PLAN_PREMIUM, PRODUCT_STUDIO_CODE_AI_CREDITS ) );
 
-		expect( legalNoticeText() ).toBe( STUDIO_SENTENCE );
-		expect( screen.getByRole( 'link', { name: 'Terms of Service' } ) ).toHaveAttribute(
+		// TODO: SHILL-2355 - update alongside getStudioCodeAiCreditsGuidelinesUrl().
+		expect( screen.getByRole( 'link', { name: 'AI Credits Guidelines' } ) ).toHaveAttribute(
 			'href',
-			'https://wordpress.com/tos/'
+			'https://wordpress.com/tos/#ai-credits-guidelines-pending'
 		);
-		expect( screen.getByRole( 'link', { name: 'Privacy Policy' } ) ).toHaveAttribute(
-			'href',
-			'https://automattic.com/privacy/'
-		);
+		// The standard notice is unaffected by the extra line.
 		expect(
 			screen.getByRole( 'button', { name: 'View billing and renewal details' } )
 		).toBeVisible();
+	} );
+
+	it( 'omits the AI Credits Guidelines for any other cart', () => {
+		renderFooter( cartWith( PLAN_PREMIUM ) );
+
+		expect(
+			screen.queryByRole( 'link', { name: 'AI Credits Guidelines' } )
+		).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/SHILL-2355/checkout-add-legal-disclosures-or-disclaimers-only-if-needed

(code by both @tx2pnw and @DavidRothstein -- current writeup below by @DavidRothstein)

## Proposed Changes

We need to add an extra link to the terms-of-service language in checkout when Studio Code AI Credits are in the cart: https://developer.wordpress.com/docs/developer-tools/studio/studio-code/ai-credits-guidelines/

This involves changing a few things in a few places, because, for example, the **main** terms-of-service language on wide screens is actually completely different than the language on narrow screens (the language on narrow screens is the same as what you get after you click on "View billing and renewal details" on wide screens).

The principle that is applied in this pull request is that wherever we link to the Terms of Service in checkout, if Studio Code AI Credits is in the cart we should link to the AI Credits Guidelines also (while making only minor changes to the text beyond that).  And if Studio Code AI Credits is not in the cart, we shouldn't change the current terms-of-service language at all.

### With Studio Code AI Credits in the cart

| | Before | After |
| :---: | :---: | :---: |
| Desktop | <img width="406" height="512" alt="desktop-BEFORE" src="https://github.com/user-attachments/assets/c2aaa18e-bc9f-45c7-9dad-1159aede8a55" /> | <img width="408" height="528" alt="desktop-AFTER" src="https://github.com/user-attachments/assets/0da8d7df-a7c0-4560-b6ff-c2c183576a11" /> |
| Mobile | <img width="460" height="194" alt="mobile-BEFORE" src="https://github.com/user-attachments/assets/8062bbad-6ae6-488e-ba7a-7a066168ccd6" /> | <img width="460" height="194" alt="mobile-AFTER" src="https://github.com/user-attachments/assets/0fe296e1-2bb7-4898-bbc4-112ae1c25d87" /> |

### With Studio Code AI Credits and a renewable subscription in the cart

This is an edge case (and might even be impossible soon) but for completeness I'm showing it too.

Note that the weird line wrapping on mobile after this pull request is effectively a preexisting issue (caused by havig no-wrap behavior on both of the inline support links, "how your subscription works" and "how to cancel", at the end of the sentence).  It just so happened that adding the extra text to this sentence forced it to a length that triggered that awkward rendering.

| | Before | After |
| :---: | :---: | :---: |
| Desktop | <img width="402" height="612" alt="desktop-combined-BEFORE" src="https://github.com/user-attachments/assets/5b1e13b4-5d26-431d-8342-2fd13200a771" /> | <img width="399" height="625" alt="desktop-combined-AFTER" src="https://github.com/user-attachments/assets/4c719aa5-1f90-4790-b364-62bfb3779339" /> |
| Mobile | <img width="455" height="388" alt="mobile-combined-BEFORE" src="https://github.com/user-attachments/assets/173b4cdf-cb35-4b9d-9b00-de12570d7a7d" /> | <img width="457" height="406" alt="mobile-combined-AFTER" src="https://github.com/user-attachments/assets/00d28dcd-ddc0-46bf-8caf-4c4714e75aab" /> |

## Testing Instructions

I mainly tested this at `/checkout/wpcom/studio-code-ai-credits:-q-10000` (at both mobile and desktop screen widths) to see the new text for Studio Code AI Credits.

I also tested a regular WordPress.com checkout with a plan in the cart, to make sure this pull request didn't change that at all.

I tested the edge case (Studio Code AI Credits in the cart along with a renewable subscription) using a link like `/checkout/[site]/business-bundle,studio-code-ai-credits:-q-10000`.