### PR TITLE
Checkout: Show the credit quantity for Studio Code AI Credits

### DIFF
--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -1,3 +1,4 @@
+import { PRODUCT_STUDIO_CODE_AI_CREDITS } from '@automattic/api-core';
 import {
 	isAddOn,
 	isPlan,
@@ -124,6 +125,21 @@ export function getLabel( product: ResponseCartProduct ): string {
 
 	if ( isAkismetPro500( product ) ) {
 		return getAkismetPro500ProductDisplayName( product.product_name, quantity );
+	}
+
+	if ( PRODUCT_STUDIO_CODE_AI_CREDITS === product.product_slug && quantity > 1 ) {
+		return translate(
+			'%(productName)s (%(quantity)s credit)',
+			'%(productName)s (%(quantity)s credits)',
+			{
+				count: quantity,
+				args: {
+					productName: product.product_name,
+					quantity: formatNumber( quantity, { decimals: 0 } ),
+				},
+				textOnly: true,
+			}
+		);
 	}
 
 	return product.product_name || '';

--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -127,7 +127,7 @@ export function getLabel( product: ResponseCartProduct ): string {
 		return getAkismetPro500ProductDisplayName( product.product_name, quantity );
 	}
 
-	if ( PRODUCT_STUDIO_CODE_AI_CREDITS === product.product_slug && quantity > 1 ) {
+	if ( PRODUCT_STUDIO_CODE_AI_CREDITS === product.product_slug ) {
 		return translate(
 			'%(productName)s (%(quantity)s credit)',
 			'%(productName)s (%(quantity)s credits)',

--- a/packages/wpcom-checkout/test/checkout-labels.ts
+++ b/packages/wpcom-checkout/test/checkout-labels.ts
@@ -9,26 +9,28 @@ const studioCredits = {
 
 describe( 'getLabel', () => {
 	describe( 'Studio Code AI Credits', () => {
-		it( 'includes the credit quantity at the minimum purchase', () => {
-			expect( getLabel( { ...studioCredits, quantity: 100 } ) ).toBe(
-				'Studio Code AI Credits (100 credits)'
-			);
-		} );
-
 		it( 'includes the credit quantity', () => {
 			expect( getLabel( { ...studioCredits, quantity: 500 } ) ).toBe(
 				'Studio Code AI Credits (500 credits)'
 			);
 		} );
 
-		it( 'separates thousands in the credit quantity', () => {
+		it( 'uses the singular form for one credit', () => {
+			expect( getLabel( { ...studioCredits, quantity: 1 } ) ).toBe(
+				'Studio Code AI Credits (1 credit)'
+			);
+		} );
+
+		it( 'uses a separator for thousands of credits', () => {
 			expect( getLabel( { ...studioCredits, quantity: 1000 } ) ).toBe(
 				'Studio Code AI Credits (1,000 credits)'
 			);
 		} );
 
-		it( 'returns the product name alone for a quantity of one', () => {
-			expect( getLabel( { ...studioCredits, quantity: 1 } ) ).toBe( 'Studio Code AI Credits' );
+		it( 'shows zero credits when the cart has no quantity', () => {
+			expect( getLabel( { ...studioCredits, quantity: null } ) ).toBe(
+				'Studio Code AI Credits (0 credits)'
+			);
 		} );
 	} );
 

--- a/packages/wpcom-checkout/test/checkout-labels.ts
+++ b/packages/wpcom-checkout/test/checkout-labels.ts
@@ -1,0 +1,66 @@
+import { getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+import { getLabel } from '../src';
+
+const studioCredits = {
+	...getEmptyResponseCartProduct(),
+	product_slug: 'studio-code-ai-credits',
+	product_name: 'Studio Code AI Credits',
+};
+
+describe( 'getLabel', () => {
+	describe( 'Studio Code AI Credits', () => {
+		it( 'includes the credit quantity at the minimum purchase', () => {
+			expect( getLabel( { ...studioCredits, quantity: 100 } ) ).toBe(
+				'Studio Code AI Credits (100 credits)'
+			);
+		} );
+
+		it( 'includes the credit quantity', () => {
+			expect( getLabel( { ...studioCredits, quantity: 500 } ) ).toBe(
+				'Studio Code AI Credits (500 credits)'
+			);
+		} );
+
+		it( 'separates thousands in the credit quantity', () => {
+			expect( getLabel( { ...studioCredits, quantity: 1000 } ) ).toBe(
+				'Studio Code AI Credits (1,000 credits)'
+			);
+		} );
+
+		it( 'returns the product name alone for a quantity of one', () => {
+			expect( getLabel( { ...studioCredits, quantity: 1 } ) ).toBe( 'Studio Code AI Credits' );
+		} );
+	} );
+
+	describe( 'other products', () => {
+		it( 'returns the product name for a plan', () => {
+			const plan = {
+				...getEmptyResponseCartProduct(),
+				product_slug: 'business-bundle',
+				product_name: 'WordPress.com Business',
+			};
+			expect( getLabel( plan ) ).toBe( 'WordPress.com Business' );
+		} );
+
+		it( 'keeps the Akismet Pro 500 request count', () => {
+			const akismetPro500 = {
+				...getEmptyResponseCartProduct(),
+				product_slug: 'ak_pro5h_yearly',
+				product_name: 'Akismet Pro',
+				quantity: 2,
+			};
+			expect( getLabel( akismetPro500 ) ).toBe( 'Akismet Pro (1000 requests/month)' );
+		} );
+
+		it( 'returns the domain name for a domain registration', () => {
+			const domain = {
+				...getEmptyResponseCartProduct(),
+				product_slug: 'domain_reg',
+				product_name: 'Domain Registration',
+				meta: 'example.com',
+				is_domain_registration: true,
+			};
+			expect( getLabel( domain ) ).toBe( 'example.com' );
+		} );
+	} );
+} );


### PR DESCRIPTION
Resolves SHILL-2354

## Proposed Changes

Render Product name with quantity for new Studio AI Credits product:
* Add a Studio Code AI Credits branch to `getLabel()` in `packages/wpcom-checkout/src/checkout-labels.ts`, so the line item and summary reads `Studio Code AI Credits (500 credits)`.
* Add `packages/wpcom-checkout/test/checkout-labels.ts`, test coverage for `getLabel()`.

## Why are these changes being made?

Studio Code AI Credits is sold in a quantity from the link, so checkout should make it clear how many credits they are buying.

`getLabel()` composes the quantity-aware product title at checkout. It has branches for Jetpack AI, Jetpack Stats and Akismet Pro 500. Studio Code AI Credits had none, so it fell through to `return product.product_name || ''`, the bare name with no quantity, on every surface.


| Scenario | Before | After |
|---|---|---|
| Studio Code AI Credits, quantity 100 | `Studio Code AI Credits` | `Studio Code AI Credits (100 credits)` |
| Studio Code AI Credits, quantity 1000 | `Studio Code AI Credits` | `Studio Code AI Credits (1,000 credits)` |
| Studio Code AI Credits, quantity 1 | `Studio Code AI Credits` | `Studio Code AI Credits (1 credit)` |
| Studio Code AI Credits, no quantity in the URL | `Studio Code AI Credits` | `Studio Code AI Credits (0 credits)` |
| Akismet Pro 500, any quantity | `Akismet Pro (N requests/month)` | unchanged |
| Any other product | bare product name | unchanged |

## Screenshots

<img width="2000" height="528" alt="studio-code-ai-credits-500-checkout-both-surfaces" src="https://github.com/user-attachments/assets/21c13875-984f-4b21-a768-080884df1ddf" />
<img width="2000" height="528" alt="studio-code-ai-credits-1000-checkout-both-surfaces" src="https://github.com/user-attachments/assets/84ea41d3-374a-4180-9e83-dda14bba1fba" />



## Testing Instructions

**Automated**

```
yarn test-packages packages/wpcom-checkout
```

Covers Studio at 1, 500 and 1000 credits, a cart with no quantity, and Akismet Pro 500, a plan and a domain unchanged.

A cart with no quantity comes back from the API as `quantity: null` and renders `(0 credits)` while still charging. That is the cart being wrong rather than the label, and it needs a backend fix so quantity is never null when money is charged. The test records the current output so it is not discovered by surprise later.

```
yarn typecheck-packages
```

Not `typecheck-client` - that resolves `@automattic/wpcom-checkout` to the prebuilt `dist/types`, so it never sees these edits.

**Manual Studio Code AI Credits, at quantity 500**
 - go to http://calypso.localhost:3016/checkout/wpcom/studio-code-ai-credits:-q-500 -> `Studio Code AI Credits (500 credits)`
 - http://calypso.localhost:3016/checkout/wpcom/studio-code-ai-credits:-q-1000 -> `Studio Code AI Credits (1,000 credits)`
The API returns `product_name` as  `Studio Code AI Credits` (quantity) from the url param is added.

**Manual regression**

1. Run `yarn start` on this branch and open `http://calypso.localhost:3000/checkout/akismet/ak_pro5h_yearly:-q-2`
2. Verify that the "Your order" line item reads `Akismet Pro (1000 requests/month)`
3. Verify that the summary sidebar on the right reads `Akismet Pro (1000 requests/month)`, the same text from the same function
4. Open `http://calypso.localhost:3000/checkout/akismet/ak_pro5h_bi_yearly:-q-1` and verify both surfaces read `Akismet Pro (500 requests/month)`



