### PR TITLE
Purchases: Hide Cancel and Remove for purchases the customer cannot manage

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -63,6 +63,7 @@ import {
 	hasQueryableSite,
 	isAgencyPartnerType,
 	isRemoved,
+	isManageableByUser,
 	isJetpackHoldingSitePurchase,
 	isAkismetProduct,
 	isPartnerPurchase,
@@ -1534,6 +1535,20 @@ function CancelPurchaseInner() {
 						__( 'This subscription is managed by %s. Please contact them to make changes.' ),
 						purchase.partner_name ?? ''
 					),
+					{ type: 'snackbar' }
+				);
+				createdErrorNoticeForRedirect.current = true;
+			}
+			return false;
+		}
+
+		// Only support can cancel or remove these. The buttons are hidden on
+		// Purchase Settings, so this catches direct links, including the
+		// remove-and-refund one inside this flow.
+		if ( ! isManageableByUser( purchase ) ) {
+			if ( ! createdErrorNoticeForRedirect.current ) {
+				createErrorNotice(
+					__( 'Only our support team can change this subscription. Please contact support.' ),
 					{ type: 'snackbar' }
 				);
 				createdErrorNoticeForRedirect.current = true;

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -100,6 +100,7 @@ import {
 	isExpiredAndInGracePeriod,
 	isExpiredWithNoAutoRenewAttemptsLeft,
 	isRemoved,
+	isManageableByUser,
 	isExpiredOrRemoved,
 	mightStillAutoRenew,
 	isWithinRefundWindowDowngradeEligible,
@@ -349,6 +350,11 @@ export function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase }
 	// those flags, so the check has to be repeated here. Agency-provisioned
 	// purchases are bought through WordPress.com and stay cancellable.
 	if ( purchase.is_host_managed ) {
+		return null;
+	}
+
+	// Only support can cancel or remove some purchases.
+	if ( ! isManageableByUser( purchase ) ) {
 		return null;
 	}
 
@@ -724,6 +730,12 @@ function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 	// of management links; if they aren't available, skip the card entirely so
 	// we don't render an empty shell.
 	if ( ! isOwner && ! hasProductAction ) {
+		return null;
+	}
+
+	// Skip the card for a purchase only support can change: cancel and remove are
+	// hidden above, and prepaid credits have nothing to renew or upgrade.
+	if ( ! isManageableByUser( purchase ) && ! hasProductAction ) {
 		return null;
 	}
 

--- a/client/dashboard/me/billing-purchases/purchase-settings/test/cancel-or-remove-action-button.test.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/test/cancel-or-remove-action-button.test.tsx
@@ -111,6 +111,37 @@ describe( '<CancelOrRemoveActionButton />', () => {
 		expect( container ).toBeEmptyDOMElement();
 	} );
 
+	test( 'hides Remove when is_manageable_by_user is false and auto-renew is off', () => {
+		const { container } = render(
+			<CancelOrRemoveActionButton
+				purchase={ makePurchase( {
+					is_manageable_by_user: false,
+					is_auto_renew_enabled: false,
+				} ) }
+			/>
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'hides Cancel when is_manageable_by_user is false and auto-renew is on', () => {
+		const { container } = render(
+			<CancelOrRemoveActionButton purchase={ makePurchase( { is_manageable_by_user: false } ) } />
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'shows Cancel when is_manageable_by_user is true', () => {
+		render(
+			<CancelOrRemoveActionButton purchase={ makePurchase( { is_manageable_by_user: true } ) } />
+		);
+		expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeVisible();
+	} );
+
+	test( 'shows Cancel when the purchase has no is_manageable_by_user field', () => {
+		render( <CancelOrRemoveActionButton purchase={ makePurchase() } /> );
+		expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeVisible();
+	} );
+
 	test( 'renders nothing for a non-refundable domain transfer with auto-renew on', () => {
 		const { container } = render(
 			<CancelOrRemoveActionButton

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -96,6 +96,16 @@ export function isRemoved( purchase: Purchase ): boolean {
 }
 
 /**
+ * Returns true if the customer can refund, cancel or remove this purchase themselves.
+ *
+ * Defaults to true when the field is missing, so a server that predates it keeps
+ * today's behavior instead of locking every purchase.
+ */
+export function isManageableByUser( purchase: Purchase ): boolean {
+	return purchase.is_manageable_by_user !== false;
+}
+
+/**
  * Convenience check for "expired in any way" — either still active but past the
  * expiration date (grace period), or fully removed.
  */

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -48,6 +48,7 @@ import {
 	getMutationFlowType,
 	getPurchaseCancellationFlowType,
 	hasAmountAvailableToRefund,
+	isManageableByUser,
 	type CancelIntent,
 	type DisplayVariant,
 } from 'calypso/dashboard/utils/purchase';
@@ -298,6 +299,13 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		// cancel here. The CTA is hidden on the manage-purchase page; this also
 		// turns away anyone arriving from a stale link.
 		if ( purchase.is_host_managed ) {
+			return false;
+		}
+
+		// Only support can cancel or remove these. The buttons are hidden on the
+		// manage-purchase page, so this catches direct links, including the
+		// remove-and-refund one inside this flow.
+		if ( ! isManageableByUser( purchase ) ) {
 			return false;
 		}
 

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -95,6 +95,7 @@ import {
 	isAkismetHoldingSitePurchase,
 	isDotcomPlan,
 	isMarketplaceHoldingSitePurchase,
+	isManageableByUser,
 	isPartnerPurchase,
 } from 'calypso/dashboard/utils/purchase';
 import reinstallPlugins from 'calypso/data/marketplace/reinstall-plugins-api';
@@ -844,6 +845,13 @@ class ManagePurchase extends Component<
 			return null;
 		}
 
+		// Only support can cancel or remove some purchases. `is_removable` is false
+		// server-side for these, but visibility here is driven by auto-renew state
+		// instead, so the check has to be repeated.
+		if ( ! isManageableByUser( purchase ) ) {
+			return null;
+		}
+
 		const canRefund = hasAmountAvailableToRefund( purchase );
 		const autoRenewOn = !! purchase.is_auto_renew_enabled;
 		// A domain connection bundled with a plan renews with that plan, so Cancel
@@ -999,6 +1007,11 @@ class ManagePurchase extends Component<
 		// check has to be repeated. Agency-provisioned purchases are bought through
 		// WordPress.com and stay cancellable.
 		if ( purchase.is_host_managed ) {
+			return null;
+		}
+
+		// Only support can cancel or remove some purchases.
+		if ( ! isManageableByUser( purchase ) ) {
 			return null;
 		}
 

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -208,6 +208,63 @@ describe( 'Purchase Management Buttons', () => {
 		expect( screen.queryByText( /Cancel subscription/ ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'hides the Remove button when is_manageable_by_user is false and auto-renew is OFF', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/me/payment-methods?expired=include' )
+			.reply( 200 );
+
+		const store = createMockReduxStoreForPurchase( {
+			...purchase,
+			is_auto_renew_enabled: false,
+			is_manageable_by_user: false,
+		} );
+
+		render(
+			<QueryClientProvider client={ queryClient }>
+				<ReduxProvider store={ store }>
+					<ManagePurchase
+						purchaseId={ Number( purchase.ID ) }
+						isSiteLevel
+						siteSlug="onecooltestsite.com"
+					/>
+				</ReduxProvider>
+			</QueryClientProvider>
+		);
+
+		// Wait for component to fully render
+		expect( await findPaymentMethodNavItem() ).toBeInTheDocument();
+		expect( screen.queryByText( /Remove plan/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /will be removed immediately/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'hides the Cancel button when is_manageable_by_user is false and auto-renew is ON', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/me/payment-methods?expired=include' )
+			.reply( 200 );
+
+		const store = createMockReduxStoreForPurchase( {
+			...purchase,
+			is_auto_renew_enabled: true,
+			is_manageable_by_user: false,
+		} );
+
+		render(
+			<QueryClientProvider client={ queryClient }>
+				<ReduxProvider store={ store }>
+					<ManagePurchase
+						purchaseId={ Number( purchase.ID ) }
+						isSiteLevel
+						siteSlug="onecooltestsite.com"
+					/>
+				</ReduxProvider>
+			</QueryClientProvider>
+		);
+
+		// Wait for component to fully render
+		expect( await findPaymentMethodNavItem() ).toBeInTheDocument();
+		expect( screen.queryByText( /Cancel subscription/ ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'renders a Remove button for a domain connection bundled with a plan, even though auto-renew is ON', async () => {
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.2/me/payment-methods?expired=include' )

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -265,6 +265,14 @@ export interface Purchase {
 	is_removable: boolean;
 
 	/**
+	 * True if the customer can refund, cancel or remove this purchase themselves.
+	 *
+	 * Set per product, not per user. Support can still act on the purchase.
+	 * Optional in the response, so read it through `isManageableByUser()`.
+	 */
+	is_manageable_by_user?: boolean;
+
+	/**
 	 * True if this subscription has refundable receipts.
 	 *
 	 * If this is true, it means that it's possible the subscription could


### PR DESCRIPTION
Resolves SHILL-2361
Server-side half: 234110-ghe-Automattic/wpcom. That one adds the flag this reads, so merge it first or nothing here changes.

## Proposed Changes

* Add optional `is_manageable_by_user` to the `Purchase` type, read through a new `isManageableByUser()` helper.
* Hide Cancel and Remove on both purchase surfaces when it is false.
* Redirect off the cancel/remove confirmation screen on both surfaces, so a direct link cannot open it.
* Tests on both surfaces for the hidden buttons, plus the missing-field fallback.

## Why are these changes being made?

**Before.** Both surfaces decide Cancel and Remove from auto-renew and expiry state.

**Problem.** Studio Code AI Credits is prepaid and non-refundable, so auto-renew is off, both fall through, and Remove renders for a purchase the server will not refund or cancel.

**Fix.** Read `is_manageable_by_user` off the purchase payload. It is set per product, not per user.

Hiding the buttons is not enough on its own. The confirmation screen still opens by direct link, and its remove path deletes the purchase without a refund, so both surfaces reject it there too. `is_host_managed` already works this way.

The helper defaults to true when the field is missing, so a server without it keeps today's behavior.

Not wired to `purchase.is_removable`, which would break other products: that flag is false whenever a refund is still owed, so anything with auto-renew off inside its refund window would lose its Remove button.

| Surface | Before | After |
|---|---|---|
| Classic purchase page | Remove rendered | no Cancel, no Remove |
| Dashboard purchase settings | Remove rendered | no Cancel, no Remove, no empty card |
| Cancel screen by direct link | loaded, remove succeeded | redirects back |
| Any other product, auto-renew off | Remove rendered | unchanged |

## Screenshots

<img width="1505" height="388" alt="image" src="https://github.com/user-attachments/assets/f0562014-1028-4e9d-8bda-0303b80e1861" />

## Testing Instructions

**Environment:**
- Enable Store Sandbox mode
- `public-api.wordpress.com` sandboxed, running the server-side branch

Purchase Credits: http://calypso.localhost:3000/checkout/wpcom/studio-code-ai-credits:-q-500

**Steps:**
1. Open `/me/purchases/siteless.wp.com/{purchaseId}` on the classic host. No "Cancel subscription" row, no "Remove" card.
2. Open the same purchase on the Dashboard host. Only "Enable auto-renew" renders, with no empty card below it.
3. Open `/me/purchases/siteless.wp.com/{purchaseId}/cancel?intent=remove` on the classic host. It redirects back to the purchase page.
4. Do the same on the Dashboard host. It redirects back and shows a snackbar naming support.
5. Open any other purchase with auto-renew off, for example Jetpack Akismet Anti-spam. Its Remove card still renders on both surfaces.

Classic is served on `calypso.localhost`, the Dashboard on `my.localhost`. A Dashboard route loaded on the classic host hangs on the boot splash.

Point Calypso at a server without the branch to check the fallback: every purchase keeps the buttons it has today, because the field is absent rather than false.

**Automated:**

```
yarn test-client client/me/purchases client/dashboard/me/billing-purchases
```
