### PR TITLE
Domains landing: hide WordPress logo in header for DSAPI resellers

### DIFF
--- a/client/landing/domains/header/index.jsx
+++ b/client/landing/domains/header/index.jsx
@@ -22,12 +22,16 @@ class DomainsLandingHeader extends Component {
 			</svg>
 		);
 
-		switch ( this.props.reseller ) {
+		const reseller = this.props.reseller === undefined ? 'wordpress' : this.props.reseller;
+
+		switch ( reseller ) {
 			case 'tumblr_live':
 			case 'tumblr_ote':
 				return tumblrLogo;
-			default:
+			case 'wordpress':
 				return <WordPressLogo className="header__logo" size={ 52 } />;
+			default:
+				return null;
 		}
 	};
 


### PR DESCRIPTION
Resolves DOTCOM-16468

## Proposed Changes

* Off-label the domain landing pages (registrant contact verification and transfer confirmation) for DSAPI resellers by hiding the WordPress logo in the header when a `reseller` query parameter is present.
* The header keeps its existing behavior otherwise: the WordPress logo is shown when no reseller is set, and the Tumblr logo is shown for the `tumblr_live` / `tumblr_ote` resellers. Any other reseller value now renders no logo instead of falling back to the WordPress logo.

## Why are these changes being made?

* Domain landing pages (contact verification and transfer confirmation) are also used by DSAPI resellers. Showing the WordPress logo on these pages is confusing for their customers, so these pages should be white-labeled for resellers.

## Testing Instructions

1. Run Calypso locally with `yarn start`.
2. Visit `/domain-services/registrant-verification` and verify that the WordPress logo is visible in the header.

<img width="1540" height="922" alt="Screenshot 2026-08-13 at 09 19 16" src="https://github.com/user-attachments/assets/cb5a1f32-d2a3-4b92-9eb0-de935a7ee369" />

3. Visit `/domain-services/registrant-verification?reseller=test-reseller` and verify that the WordPress logo is not displayed.

<img width="1574" height="832" alt="Screenshot 2026-08-13 at 09 18 58" src="https://github.com/user-attachments/assets/d4b0e03f-d413-42e3-8995-d1900c1a0dc5" />

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)