### PR TITLE
Nav 2026: make the new global navigation the default

### DIFF
--- a/client/layout/nav-2026-universal-header.tsx
+++ b/client/layout/nav-2026-universal-header.tsx
@@ -1,16 +1,8 @@
 import { UniversalNavbarHeader, type HeaderProps } from '@automattic/wpcom-template-parts';
-import clsx from 'clsx';
 import { useNav2026Props } from 'calypso/layout/use-nav-2026-props';
 
-export function Nav2026UniversalHeader( { className, variant, ...headerProps }: HeaderProps ) {
+export function Nav2026UniversalHeader( { variant, ...headerProps }: HeaderProps ) {
 	const nav2026Props = useNav2026Props( { variant } );
 
-	return (
-		<UniversalNavbarHeader
-			{ ...headerProps }
-			{ ...nav2026Props }
-			variant={ variant }
-			className={ clsx( className, nav2026Props.className ) }
-		/>
-	);
+	return <UniversalNavbarHeader { ...headerProps } { ...nav2026Props } variant={ variant } />;
 }

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -577,10 +577,6 @@ body.is-mobile-app-view {
 	padding-top: var( --masterbar-height );
 }
 
-.is-nav-2026-assignment-loading {
-	display: none;
-}
-
 // Source of truth for the fixed 2026 nav's geometry; everything that clears or sticks
 // to the nav derives from these vars.
 .layout:has( .x-nav--2026-redesign ) {

--- a/client/layout/test/use-nav-2026-props.test.tsx
+++ b/client/layout/test/use-nav-2026-props.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { useNav2026Props } from '../use-nav-2026-props';
+import type { ReactNode } from 'react';
+
+const state = { currentUser: { id: null, user: null } };
+const store = {
+	getState: () => state,
+	subscribe: () => () => {},
+	dispatch: () => {},
+} as never;
+const wrapper = ( { children }: { children: ReactNode } ) => (
+	<Provider store={ store }>{ children }</Provider>
+);
+
+describe( 'useNav2026Props', () => {
+	it( 'turns the 2026 nav on for the default header', () => {
+		const { result } = renderHook( () => useNav2026Props(), { wrapper } );
+
+		expect( result.current.nav2026 ).toBe( true );
+	} );
+
+	it( 'turns the 2026 nav on when no variant is passed', () => {
+		const { result } = renderHook( () => useNav2026Props( { variant: 'default' } ), { wrapper } );
+
+		expect( result.current.nav2026 ).toBe( true );
+	} );
+
+	it( 'leaves minimal headers on the old nav', () => {
+		const { result } = renderHook( () => useNav2026Props( { variant: 'minimal' } ), { wrapper } );
+
+		expect( result.current.nav2026 ).toBeUndefined();
+	} );
+
+	it( 'never returns a loading class', () => {
+		const { result } = renderHook( () => useNav2026Props(), { wrapper } );
+
+		expect( result.current ).not.toHaveProperty( 'className' );
+	} );
+} );

--- a/client/layout/use-nav-2026-props.ts
+++ b/client/layout/use-nav-2026-props.ts
@@ -1,5 +1,3 @@
-import config from '@automattic/calypso-config';
-import { useExperiment } from 'calypso/lib/explat';
 import { useSelector } from 'calypso/state';
 import {
 	getCurrentUser,
@@ -10,17 +8,13 @@ import type { HeaderProps } from '@automattic/wpcom-template-parts';
 
 type Nav2026Props =
 	| {
-			className?: string;
 			nav2026: true;
-			nav2026Variant: 1 | 2;
 			userAvatar?: string;
 			userName?: string;
 			userEmail?: string;
 	  }
 	| {
-			className?: string;
 			nav2026?: never;
-			nav2026Variant?: never;
 			userAvatar?: never;
 			userName?: never;
 			userEmail?: never;
@@ -30,74 +24,19 @@ type Nav2026Options = {
 	variant?: HeaderProps[ 'variant' ];
 };
 
-// ExPlat experiment driving the 2026 Global Nav A/B test. It's a single
-// `wpcom`-platform experiment (also serving the LOHP + Landpack PHP surfaces);
-// the wpcom assignments controller allowlists it so the /assignments/calypso
-// endpoint returns it here too, giving every surface consistent bucketing.
-// Keep in sync with the PHP constant WPCOM_Global_Nav_Helpers::NAV_2026_EXPERIMENT.
-const NAV_2026_EXPERIMENT = 'wpcom_global_navigation_202606';
-
-const VARIATION_TO_VARIANT: Partial< Record< string, 1 | 2 > > = {
-	showcase_products: 1,
-	showcase_products_and_ai: 2,
-};
-
 /**
- * Props to spread onto `UniversalNavbarHeader` to opt into the 2026 Global Nav.
- * Returns a temporary loading class while the assignment is pending, otherwise
- * returns `{}` when the nav stays on the old design.
- *
- * Resolution order:
- * 1. Minimal universal headers are not eligible for Nav 2026.
- * 2. `nav-redesign/2026` config flag — manual force-on for staff/dev. Variant
- *    follows the existing `nav-redesign/2026-variant-2` flag.
- * 3. The NAV_2026_EXPERIMENT assignment — `showcase_products`/`showcase_products_and_ai`
- *    map to variants 1/2; everything else (control, null) → old nav.
- *    Until the variant is resolved — from the server render through the client
- *    loading window — return a temporary className that hides the nav, then reveal
- *    it once resolved. Hiding from SSR (not just after hydration) is what prevents
- *    the old-nav→new-nav flash.
+ * Props to spread onto `UniversalNavbarHeader` to render the 2026 Global Nav.
+ * Every universal header gets it except the minimal variant, which keeps the
+ * old design.
  */
 export function useNav2026Props( options: Nav2026Options = {} ): Nav2026Props {
-	const isHeaderEligible = options.variant !== 'minimal';
-	const forcedOn = isHeaderEligible && config.isEnabled( 'nav-redesign/2026' );
 	const userAvatar = useSelector( ( state ) => getCurrentUser( state )?.avatar_URL );
 	const userName = useSelector( getCurrentUserDisplayName );
 	const userEmail = useSelector( getCurrentUserEmail );
 
-	// SSR is ineligible (no assignment server-side); the browser refetches on hydration.
-	const [ isLoadingExperiment, experimentAssignment ] = useExperiment( NAV_2026_EXPERIMENT, {
-		isEligible: isHeaderEligible && ! forcedOn && typeof window !== 'undefined',
-	} );
-
-	// Resolve the variant: the config flag forces it on for staff/dev, otherwise
-	// the experiment assignment decides. Anything else (control, null, unknown
-	// variation) leaves it undefined → old nav.
-	let variant: 1 | 2 | undefined;
-	if ( forcedOn ) {
-		variant = config.isEnabled( 'nav-redesign/2026-variant-2' ) ? 2 : 1;
-	} else if ( ! isLoadingExperiment && experimentAssignment?.variationName ) {
-		variant = VARIATION_TO_VARIANT[ experimentAssignment.variationName ];
-	}
-
-	// Hide the nav until the variant is resolved, then reveal it. The assignment is
-	// only available client-side, so we hide from the server render onwards (SSR:
-	// `window` is undefined; client: until the experiment finishes loading) and let
-	// the client reveal the resolved nav once known. Hiding from SSR — rather than
-	// only after hydration — is what actually prevents the old-nav→new-nav flash, and
-	// keeps the server and first client render in sync (no hydration mismatch).
-	//
-	// The nav markup and its links stay in the DOM; only `visibility` is toggled. A
-	// no-JS client (including crawlers) never runs the reveal, so it keeps the nav
-	// hidden — an accepted trade-off, pending SEO sign-off.
-	const isVariantResolved = forcedOn || ( typeof window !== 'undefined' && ! isLoadingExperiment );
-	if ( isHeaderEligible && ! forcedOn && ! isVariantResolved ) {
-		return { className: 'is-nav-2026-assignment-loading' };
-	}
-
-	if ( ! variant ) {
+	if ( options.variant === 'minimal' ) {
 		return {};
 	}
 
-	return { nav2026: true, nav2026Variant: variant, userAvatar, userName, userEmail };
+	return { nav2026: true, userAvatar, userName, userEmail };
 }

--- a/config/development.json
+++ b/config/development.json
@@ -154,8 +154,6 @@
 		"me/legacy-contact": true,
 		"migration-flow/introductory-offer": true,
 		"migration/ssh-migration": false,
-		"nav-redesign/2026": false,
-		"nav-redesign/2026-variant-2": false,
 		"notifications/redesign": true,
 		"oauth": false,
 		"oauth/unified-experience": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -91,8 +91,6 @@
 		"me/legacy-contact": false,
 		"migration-flow/introductory-offer": true,
 		"migration/ssh-migration": false,
-		"nav-redesign/2026": false,
-		"nav-redesign/2026-variant-2": false,
 		"oauth/unified-experience": false,
 		"onboarding/create-course": false,
 		"onboarding/email-verification": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -111,8 +111,6 @@
 		"me/legacy-contact": false,
 		"migration-flow/introductory-offer": true,
 		"migration/ssh-migration": false,
-		"nav-redesign/2026": false,
-		"nav-redesign/2026-variant-2": false,
 		"notifications/redesign": true,
 		"oauth/unified-experience": true,
 		"onboarding/create-course": false,

--- a/packages/wpcom-template-parts/src/types.ts
+++ b/packages/wpcom-template-parts/src/types.ts
@@ -10,10 +10,8 @@ export interface HeaderProps {
 	variant?: 'default' | 'minimal';
 	startUrl?: string;
 	loginUrl?: string;
-	/** Opt into the 2026 Global Nav redesign (logged-out surfaces). */
+	/** Opt into the 2026 Global Nav redesign. */
 	nav2026?: boolean;
-	/** Which 2026 taxonomy to render: 1 (Websites/Hosting/Domains/…) or 2 (Products/…). Defaults to 1. */
-	nav2026Variant?: 1 | 2;
 	/** Current user's avatar URL, used by the 2026 mobile menu footer when logged in. */
 	userAvatar?: string;
 	/** Current user's display name, used by the 2026 mobile menu footer when logged in. */

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -43,7 +43,6 @@ const UniversalNavbarHeader = ( {
 	startUrl,
 	loginUrl,
 	nav2026 = false,
-	nav2026Variant = 1,
 	userAvatar,
 	userName,
 	userEmail,
@@ -74,7 +73,7 @@ const UniversalNavbarHeader = ( {
 	const prevDropdownRef = useRef< string | null >( null );
 	// The <nav> element, so the legacy arm can bind DOM-listener telemetry.
 	const legacyNavRef = useRef< HTMLElement >( null );
-	useDropdownOffset( nav2026, nav2026Variant );
+	useDropdownOffset( nav2026 );
 	useFooterHeight( {
 		nav2026,
 		isMobileMenuOpen,
@@ -85,11 +84,8 @@ const UniversalNavbarHeader = ( {
 	const dropdownRef = useDropdownFlip( { nav2026, activeDropdown } );
 
 	const nav2026Menus = useMemo(
-		() =>
-			nav2026
-				? getNav2026Menus( { __, localizeUrl, locale, isLoggedIn, variant: nav2026Variant } )
-				: [],
-		[ nav2026, __, localizeUrl, locale, isLoggedIn, nav2026Variant ]
+		() => ( nav2026 ? getNav2026Menus( { __, localizeUrl, locale, isLoggedIn } ) : [] ),
+		[ nav2026, __, localizeUrl, locale, isLoggedIn ]
 	);
 	const activeCategory = nav2026Menus.find( ( menu ) => menu.name === currentDropdown );
 

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/desktop-dropdown.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/desktop-dropdown.tsx
@@ -1,7 +1,29 @@
 import clsx from 'clsx';
 import React from 'react';
 import { ClickableItem } from '../menu-items';
-import type { Nav2026Menu } from './types';
+import { Nav2026ItemContent } from './item-content';
+import type { Nav2026Group, Nav2026Menu } from './types';
+
+// Groups sharing a `columnGroup` key stack in one column; the rest get their own.
+function toColumns( groups: Nav2026Group[] ): Nav2026Group[][] {
+	const columns: Nav2026Group[][] = [];
+	const byKey = new Map< string, Nav2026Group[] >();
+
+	for ( const group of groups ) {
+		const existing = group.columnGroup ? byKey.get( group.columnGroup ) : undefined;
+		if ( existing ) {
+			existing.push( group );
+			continue;
+		}
+		const column = [ group ];
+		columns.push( column );
+		if ( group.columnGroup ) {
+			byKey.set( group.columnGroup, column );
+		}
+	}
+
+	return columns;
+}
 
 interface Nav2026DesktopDropdownProps {
 	dropdownRef: React.RefObject< HTMLDivElement | null >;
@@ -42,39 +64,39 @@ export function Nav2026DesktopDropdown( {
 						key={ menu.name }
 					>
 						<div className="x-dropdown-subcategories">
-							{ menu.groups.map( ( group ) => (
-								<div className="x-dropdown-column-group" key={ group.title }>
-									<h4
-										className="x-dropdown-subcategory-title"
-										role="presentation"
-										style={ { '--stagger-index': staggerIndex++ } as React.CSSProperties }
-									>
-										{ group.title }
-									</h4>
-									<ul>
-										{ group.items.map( ( item ) => (
-											<ClickableItem
-												key={ item.url }
-												index={ staggerIndex++ }
-												titleValue=""
-												content={
-													item.badge ? (
-														<>
-															{ item.label }
-															<span className="x-dropdown-badge-new">{ item.badge }</span>
-														</>
-													) : (
-														item.label
-													)
-												}
-												urlValue={ item.url }
-												type="dropdown"
-												trackingText={ item.label }
-												target={ item.target }
-												tabIndex={ activeDropdown === menu.name ? undefined : -1 }
-											/>
-										) ) }
-									</ul>
+							{ toColumns( menu.groups ).map( ( column ) => (
+								<div className="x-dropdown-column-group" key={ column[ 0 ].title }>
+									{ column.map( ( group ) => (
+										<div className="x-dropdown-subcategory" key={ group.title }>
+											<h4
+												className="x-dropdown-subcategory-title"
+												role="presentation"
+												style={ { '--stagger-index': staggerIndex++ } as React.CSSProperties }
+											>
+												{ group.title }
+											</h4>
+											<ul>
+												{ group.items.map( ( item ) => (
+													<ClickableItem
+														key={ item.url }
+														index={ staggerIndex++ }
+														titleValue=""
+														content={
+															<Nav2026ItemContent
+																item={ item }
+																badgeClassName="x-dropdown-badge-new"
+															/>
+														}
+														urlValue={ item.url }
+														type="dropdown"
+														trackingText={ item.label }
+														target={ item.target }
+														tabIndex={ activeDropdown === menu.name ? undefined : -1 }
+													/>
+												) ) }
+											</ul>
+										</div>
+									) ) }
 								</div>
 							) ) }
 						</div>

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/external-link-icon.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/external-link-icon.tsx
@@ -1,0 +1,18 @@
+// Marks links that leave WordPress.com. Rendered inside the link label, so the
+// leading nbsp keeps it from orphaning onto its own line in longer locales.
+export function Nav2026ExternalLinkIcon() {
+	return (
+		<span className="x-nav__external-link-icon">
+			&nbsp;
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 9 9"
+				className="x-icon x-icon--external"
+				role="presentation"
+				aria-hidden="true"
+			>
+				<path d="M5.5 0v1h1.795L2.38 5.915l.705.705L8 1.705V3.5h1V0H5.5zM8 8H1V1h3V0H1a1 1 0 00-1 1v7a1 1 0 001 1h7a1 1 0 001-1V5H8v3z" />
+			</svg>
+		</span>
+	);
+}

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/hooks.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/hooks.ts
@@ -55,7 +55,7 @@ export function useScrollState( nav2026: boolean ): boolean {
 }
 
 // Align the dropdown's first column under the first nav item.
-export function useDropdownOffset( nav2026: boolean, nav2026Variant: 1 | 2 ): void {
+export function useDropdownOffset( nav2026: boolean ): void {
 	useEffect( () => {
 		if ( ! nav2026 ) {
 			return;
@@ -96,7 +96,7 @@ export function useDropdownOffset( nav2026: boolean, nav2026Variant: 1 | 2 ): vo
 				window.cancelAnimationFrame( frame );
 			}
 		};
-	}, [ nav2026, nav2026Variant ] );
+	}, [ nav2026 ] );
 }
 
 interface UseFooterHeightArgs {

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/item-content.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/item-content.tsx
@@ -1,0 +1,20 @@
+import { Nav2026ExternalLinkIcon } from './external-link-icon';
+import type { Nav2026Item } from './types';
+
+// Link label plus its optional badge and external-link icon. Shared so desktop
+// and mobile render the same affordances.
+export function Nav2026ItemContent( {
+	item,
+	badgeClassName,
+}: {
+	item: Nav2026Item;
+	badgeClassName: string;
+} ) {
+	return (
+		<>
+			{ item.label }
+			{ item.badge && <span className={ badgeClassName }>{ item.badge }</span> }
+			{ item.isExternal && <Nav2026ExternalLinkIcon /> }
+		</>
+	);
+}

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/mobile-menu.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/mobile-menu.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import React from 'react';
 import { ClickableItem } from '../menu-items';
 import { Nav2026AppBanner } from './app-banner';
+import { Nav2026ItemContent } from './item-content';
 import type { Nav2026Menu } from './types';
 
 // Mystery-person Gravatar fallback for the mobile footer avatar.
@@ -198,16 +199,10 @@ export function Nav2026MobileMenu( {
 													<ClickableItem
 														titleValue=""
 														content={
-															item.badge ? (
-																<>
-																	{ item.label }
-																	<span className="x-menu-mobile-dropdown-badge-new">
-																		{ item.badge }
-																	</span>
-																</>
-															) : (
-																item.label
-															)
+															<Nav2026ItemContent
+																item={ item }
+																badgeClassName="x-menu-mobile-dropdown-badge-new"
+															/>
 														}
 														urlValue={ item.url }
 														type="menu"

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/mobile-menu.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/mobile-menu.tsx
@@ -178,6 +178,8 @@ export function Nav2026MobileMenu( {
 										<ul
 											className={ clsx( 'x-menu-mobile-dropdown-list', {
 												'is-visible': isActive,
+												// Only this list's subtitle sits flush; the rest keep their top padding.
+												'is-first-group': groupIndex === 0,
 											} ) }
 											data-dropdown-name={ menu.name }
 											key={ `${ menu.name }-${ group.title }` }

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/mobile-menu.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/mobile-menu.tsx
@@ -140,14 +140,14 @@ export function Nav2026MobileMenu( {
 									'is-hidden': !! activeCategory,
 								} ) }
 							>
-								{ nav2026Menus.map( ( menu, index ) => (
-									<li
-										className="x-menu-mobile-nav-item"
-										role="none"
-										key={ menu.name }
-										style={ { '--stagger-index': index } as React.CSSProperties }
-									>
-										{ menu.groups ? (
+								{ nav2026Menus.map( ( menu, index ) =>
+									menu.groups ? (
+										<li
+											className="x-menu-mobile-nav-item"
+											role="none"
+											key={ menu.name }
+											style={ { '--stagger-index': index } as React.CSSProperties }
+										>
 											<button
 												className="x-menu-mobile-nav-link x-link"
 												onClick={ () => setCurrentDropdown( menu.name ) }
@@ -156,18 +156,21 @@ export function Nav2026MobileMenu( {
 												{ menu.title }
 												<span className="x-menu-mobile-nav-chevron" aria-hidden="true" />
 											</button>
-										) : (
-											<ClickableItem
-												titleValue=""
-												content={ menu.title }
-												urlValue={ menu.href }
-												type="menu"
-												typeClassName="x-menu-mobile-nav-link x-link"
-												tabIndex={ mobileMenuTabIndex }
-											/>
-										) }
-									</li>
-								) ) }
+										</li>
+									) : (
+										<ClickableItem
+											key={ menu.name }
+											index={ index }
+											className="x-menu-mobile-nav-item"
+											titleValue=""
+											content={ menu.title }
+											urlValue={ menu.href }
+											type="menu"
+											typeClassName="x-menu-mobile-nav-link x-link"
+											tabIndex={ mobileMenuTabIndex }
+										/>
+									)
+								) }
 							</ul>
 							{ nav2026Menus
 								.filter( ( menu ) => menu.groups )
@@ -188,32 +191,24 @@ export function Nav2026MobileMenu( {
 												{ group.title }
 											</li>
 											{ group.items.map( ( item, itemIndex ) => (
-												<li
-													className="x-menu-mobile-dropdown-item"
-													role="none"
+												<ClickableItem
 													key={ item.url }
-													style={
-														{
-															'--stagger-index': groupIndex * 4 + itemIndex,
-														} as React.CSSProperties
+													index={ groupIndex * 4 + itemIndex }
+													className="x-menu-mobile-dropdown-item"
+													titleValue=""
+													content={
+														<Nav2026ItemContent
+															item={ item }
+															badgeClassName="x-menu-mobile-dropdown-badge-new"
+														/>
 													}
-												>
-													<ClickableItem
-														titleValue=""
-														content={
-															<Nav2026ItemContent
-																item={ item }
-																badgeClassName="x-menu-mobile-dropdown-badge-new"
-															/>
-														}
-														urlValue={ item.url }
-														type="menu"
-														typeClassName="x-menu-mobile-dropdown-link x-link"
-														trackingText={ item.label }
-														target={ item.target }
-														tabIndex={ isActive ? mobileMenuTabIndex : -1 }
-													/>
-												</li>
+													urlValue={ item.url }
+													type="menu"
+													typeClassName="x-menu-mobile-dropdown-link x-link"
+													trackingText={ item.label }
+													target={ item.target }
+													tabIndex={ isActive ? mobileMenuTabIndex : -1 }
+												/>
 											) ) }
 										</ul>
 									) );

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/taxonomy.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/taxonomy.ts
@@ -185,7 +185,7 @@ export function getNav2026Menus( {
 					items: [
 						{
 							label: __( 'Developer tools', __i18n_text_domain__ ),
-							url: 'https://developer.wordpress.com/docs/developer-tools/',
+							url: localizeUrl( '//developer.wordpress.com/docs/developer-tools/' ),
 						},
 						{
 							label: __( 'Developer blog', __i18n_text_domain__ ),
@@ -194,11 +194,11 @@ export function getNav2026Menus( {
 						},
 						{
 							label: __( 'Rest API', __i18n_text_domain__ ),
-							url: 'https://developer.wordpress.com/docs/api/',
+							url: localizeUrl( '//developer.wordpress.com/docs/api/' ),
 						},
 						{
 							label: __( 'Docs', __i18n_text_domain__ ),
-							url: 'https://developer.wordpress.com/docs/',
+							url: localizeUrl( '//developer.wordpress.com/docs/' ),
 						},
 						{
 							label: __( 'Studio', __i18n_text_domain__ ),

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/taxonomy.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/taxonomy.ts
@@ -174,7 +174,7 @@ export function getNav2026Menus( {
 							target: '_self',
 						},
 						{
-							label: __( 'Newspack', __i18n_text_domain__ ),
+							label: 'Newspack',
 							url: 'https://newspack.com/',
 							isExternal: true,
 						},

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/taxonomy.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/taxonomy.ts
@@ -26,7 +26,7 @@ export function getNav2026Menus( {
 }: GetNav2026MenusArgs ): Nav2026Menu[] {
 	const buildGroup: Nav2026Group = {
 		title: __( 'Build', __i18n_text_domain__ ),
-		columnGroup: 'build',
+		columnGroup: 'build-publish',
 		items: [
 			{
 				label: __( 'Website', __i18n_text_domain__ ),
@@ -47,7 +47,7 @@ export function getNav2026Menus( {
 	};
 	const publishGroup: Nav2026Group = {
 		title: __( 'Publish', __i18n_text_domain__ ),
-		columnGroup: 'publish',
+		columnGroup: 'build-publish',
 		items: [
 			{
 				label: __( 'Blog', __i18n_text_domain__ ),
@@ -91,28 +91,6 @@ export function getNav2026Menus( {
 					],
 				},
 				{
-					title: __( 'Affiliates', __i18n_text_domain__ ),
-					columnGroup: 'hosting',
-					items: [
-						{
-							label: __( 'Affiliate program', __i18n_text_domain__ ),
-							url: localizeUrl( '//wordpress.com/affiliates/' ),
-							target: '_self',
-						},
-					],
-				},
-				{
-					title: __( 'Enterprise', __i18n_text_domain__ ),
-					columnGroup: 'hosting',
-					items: [
-						{
-							label: __( 'Enterprise hosting', __i18n_text_domain__ ),
-							url: 'https://wpvip.com/',
-							isExternal: true,
-						},
-					],
-				},
-				{
 					title: __( 'Domains', __i18n_text_domain__ ),
 					columnGroup: 'domains',
 					items: [
@@ -136,6 +114,28 @@ export function getNav2026Menus( {
 							label: __( 'Professional email', __i18n_text_domain__ ),
 							url: localizeUrl( '//wordpress.com/professional-email/' ),
 							target: '_self',
+						},
+					],
+				},
+				{
+					title: __( 'Affiliates', __i18n_text_domain__ ),
+					columnGroup: 'affiliates-enterprise',
+					items: [
+						{
+							label: __( 'Affiliate program', __i18n_text_domain__ ),
+							url: localizeUrl( '//wordpress.com/affiliates/' ),
+							target: '_self',
+						},
+					],
+				},
+				{
+					title: __( 'Enterprise', __i18n_text_domain__ ),
+					columnGroup: 'affiliates-enterprise',
+					items: [
+						{
+							label: __( 'Enterprise hosting', __i18n_text_domain__ ),
+							url: 'https://wpvip.com/',
+							isExternal: true,
 						},
 					],
 				},

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/taxonomy.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/taxonomy.ts
@@ -1,4 +1,4 @@
-import type { Nav2026Group, Nav2026Item, Nav2026Menu } from './types';
+import type { Nav2026Group, Nav2026Menu } from './types';
 
 type LocalizeUrl = (
 	fullUrl: string,
@@ -14,20 +14,19 @@ interface GetNav2026MenusArgs {
 	localizeUrl: LocalizeUrl;
 	locale: string;
 	isLoggedIn: boolean;
-	variant: 1 | 2;
 }
 
-// 2026 nav taxonomies (Landpack `?nav_2026=1` / `=2`), picked by `variant`.
+// The 2026 nav taxonomy. Keep in sync with the WPCOM twin in
+// wp-content/a8c-plugins/wpcom-global-nav/nav-item-config.php.
 export function getNav2026Menus( {
 	__,
 	localizeUrl,
 	locale,
 	isLoggedIn,
-	variant,
 }: GetNav2026MenusArgs ): Nav2026Menu[] {
-	// Build/Publish groups are shared by both variants.
 	const buildGroup: Nav2026Group = {
 		title: __( 'Build', __i18n_text_domain__ ),
+		columnGroup: 'build',
 		items: [
 			{
 				label: __( 'Website', __i18n_text_domain__ ),
@@ -40,11 +39,6 @@ export function getNav2026Menus( {
 				target: '_self',
 			},
 			{
-				label: __( 'Gravatar (Link in bio)', __i18n_text_domain__ ),
-				url: 'https://gravatar.com/link-in-bio',
-				target: '_self',
-			},
-			{
 				label: __( 'AI website builder', __i18n_text_domain__ ),
 				url: localizeUrl( '//wordpress.com/ai-website-builder/?ref=topnav' ),
 				target: '_self',
@@ -53,6 +47,7 @@ export function getNav2026Menus( {
 	};
 	const publishGroup: Nav2026Group = {
 		title: __( 'Publish', __i18n_text_domain__ ),
+		columnGroup: 'publish',
 		items: [
 			{
 				label: __( 'Blog', __i18n_text_domain__ ),
@@ -66,212 +61,17 @@ export function getNav2026Menus( {
 			},
 		],
 	};
-	const featureItems: Nav2026Item[] = [
-		{
-			label: __( 'Themes', __i18n_text_domain__ ),
-			url: localizeUrl( '//wordpress.com/themes', locale, isLoggedIn, true ),
-		},
-		{
-			label: __( 'Plugins', __i18n_text_domain__ ),
-			url: localizeUrl( '//wordpress.com/plugins', locale, isLoggedIn, true ),
-		},
-		{
-			label: __( 'Patterns', __i18n_text_domain__ ),
-			url: localizeUrl( '//wordpress.com/patterns', locale, isLoggedIn, true ),
-		},
-		{
-			label: __( 'AI features', __i18n_text_domain__ ),
-			url: localizeUrl( '//wordpress.com/ai/' ),
-			target: '_self',
-		},
-	];
-	const resourcesMenu: Nav2026Menu = {
-		name: 'resources',
-		title: __( 'Resources', __i18n_text_domain__ ),
-		groups: [
-			{
-				title: __( 'Tools & Services', __i18n_text_domain__ ),
-				items: [
-					{
-						label: __( 'Business name generator', __i18n_text_domain__ ),
-						url: localizeUrl( '//wordpress.com/business-name-generator/' ),
-						target: '_self',
-					},
-					{
-						label: __( 'Logo generator', __i18n_text_domain__ ),
-						url: localizeUrl( '//wordpress.com/logo-maker/' ),
-						target: '_self',
-					},
-					{
-						label: __( 'Site profiler (WHOIS)', __i18n_text_domain__ ),
-						url: localizeUrl( '//wordpress.com/site-profiler' ),
-						target: '_self',
-					},
-					{
-						label: __( 'Speed test', __i18n_text_domain__ ),
-						url: localizeUrl( '//wordpress.com/speed-test/' ),
-						target: '_self',
-					},
-					{
-						label: __( 'Hire an expert', __i18n_text_domain__ ),
-						url: localizeUrl( '//wordpress.com/website-design-service/' ),
-						target: '_self',
-					},
-					{
-						label: __( 'AI website builder', __i18n_text_domain__ ),
-						url: localizeUrl( '//wordpress.com/ai-website-builder/?ref=topnav' ),
-						target: '_self',
-					},
-				],
-			},
-			{
-				title: __( 'For Developers', __i18n_text_domain__ ),
-				items: [
-					{
-						label: __( 'Developer tools', __i18n_text_domain__ ),
-						url: 'https://developer.wordpress.com/docs/developer-tools/',
-					},
-					{
-						label: __( 'Developer blog', __i18n_text_domain__ ),
-						url: localizeUrl( '//wordpress.com/blog/category/development/' ),
-						target: '_self',
-					},
-					{
-						label: __( 'Rest API', __i18n_text_domain__ ),
-						url: 'https://developer.wordpress.com/docs/api/',
-					},
-					{
-						label: __( 'Docs', __i18n_text_domain__ ),
-						url: 'https://developer.wordpress.com/docs/',
-					},
-					{
-						label: __( 'Studio', __i18n_text_domain__ ),
-						url: localizeUrl( '//developer.wordpress.com/studio/' ),
-						target: '_self',
-					},
-				],
-			},
-			{
-				title: __( 'Features', __i18n_text_domain__ ),
-				items: featureItems,
-			},
-			{
-				title: __( 'Discover', __i18n_text_domain__ ),
-				items: [
-					{
-						label: __( 'Latest news', __i18n_text_domain__ ),
-						url: localizeUrl( '//wordpress.com/blog/' ),
-						target: '_self',
-					},
-					{
-						label: __( 'Browse blogs', __i18n_text_domain__ ),
-						url: localizeUrl( '//wordpress.com/discover' ),
-						target: '_self',
-					},
-				],
-			},
-		],
-	};
-	const supportLink: Nav2026Menu = {
-		name: 'support',
-		title: __( 'Support', __i18n_text_domain__ ),
-		href: localizeUrl( '//wordpress.com/support/' ),
-	};
-	const pricingLink: Nav2026Menu = {
-		name: 'pricing',
-		title: __( 'Pricing', __i18n_text_domain__ ),
-		href: localizeUrl( '//wordpress.com/pricing/' ),
-	};
-
-	if ( variant === 2 ) {
-		return [
-			{
-				name: 'products',
-				title: __( 'Products', __i18n_text_domain__ ),
-				groups: [
-					buildGroup,
-					publishGroup,
-					{
-						title: __( 'Hosting', __i18n_text_domain__ ),
-						items: [
-							{
-								label: __( 'Managed hosting', __i18n_text_domain__ ),
-								url: localizeUrl( '//wordpress.com/hosting/' ),
-								target: '_self',
-							},
-							{
-								label: __( 'Agency hosting', __i18n_text_domain__ ),
-								url: localizeUrl( '//wordpress.com/for-agencies/' ),
-								target: '_self',
-							},
-							{
-								label: __( 'Enterprise hosting', __i18n_text_domain__ ),
-								url: 'https://wpvip.com/?utm_source=WordPresscom&utm_medium=automattic_referral&utm_campaign=top_nav',
-							},
-							{
-								label: __( 'Site migration', __i18n_text_domain__ ),
-								url: localizeUrl( '//wordpress.com/move/' ),
-								target: '_self',
-							},
-							{
-								label: __( 'Affiliate program', __i18n_text_domain__ ),
-								url: localizeUrl( '//wordpress.com/affiliates/' ),
-								target: '_self',
-							},
-						],
-					},
-					{
-						title: __( 'Domains', __i18n_text_domain__ ),
-						items: [
-							{
-								label: __( 'Find a domain', __i18n_text_domain__ ),
-								url: localizeUrl( '//wordpress.com/domains/' ),
-								target: '_self',
-							},
-							{
-								label: __( 'Transfer a domain', __i18n_text_domain__ ),
-								url: localizeUrl( '//wordpress.com/setup/domain-transfer' ),
-								target: '_self',
-							},
-							{
-								label: __( 'Site profiler (WHOIS)', __i18n_text_domain__ ),
-								url: localizeUrl( '//wordpress.com/site-profiler' ),
-								target: '_self',
-							},
-							{
-								label: __( 'Professional email', __i18n_text_domain__ ),
-								url: localizeUrl( '//wordpress.com/professional-email/' ),
-								target: '_self',
-							},
-						],
-					},
-				],
-			},
-			resourcesMenu,
-			supportLink,
-			pricingLink,
-		];
-	}
 
 	return [
 		{
-			name: 'websites',
-			title: __( 'Websites', __i18n_text_domain__ ),
+			name: 'products',
+			title: __( 'Products', __i18n_text_domain__ ),
 			groups: [
 				buildGroup,
 				publishGroup,
 				{
-					title: __( 'Features', __i18n_text_domain__ ),
-					items: featureItems,
-				},
-			],
-		},
-		{
-			name: 'hosting',
-			title: __( 'Hosting', __i18n_text_domain__ ),
-			groups: [
-				{
 					title: __( 'Hosting', __i18n_text_domain__ ),
+					columnGroup: 'hosting',
 					items: [
 						{
 							label: __( 'Managed hosting', __i18n_text_domain__ ),
@@ -284,10 +84,6 @@ export function getNav2026Menus( {
 							target: '_self',
 						},
 						{
-							label: __( 'Enterprise hosting', __i18n_text_domain__ ),
-							url: 'https://wpvip.com/?utm_source=WordPresscom&utm_medium=automattic_referral&utm_campaign=top_nav',
-						},
-						{
 							label: __( 'Site migration', __i18n_text_domain__ ),
 							url: localizeUrl( '//wordpress.com/move/' ),
 							target: '_self',
@@ -296,6 +92,7 @@ export function getNav2026Menus( {
 				},
 				{
 					title: __( 'Affiliates', __i18n_text_domain__ ),
+					columnGroup: 'hosting',
 					items: [
 						{
 							label: __( 'Affiliate program', __i18n_text_domain__ ),
@@ -304,14 +101,20 @@ export function getNav2026Menus( {
 						},
 					],
 				},
-			],
-		},
-		{
-			name: 'domains',
-			title: __( 'Domains', __i18n_text_domain__ ),
-			groups: [
+				{
+					title: __( 'Enterprise', __i18n_text_domain__ ),
+					columnGroup: 'hosting',
+					items: [
+						{
+							label: __( 'Enterprise hosting', __i18n_text_domain__ ),
+							url: 'https://wpvip.com/',
+							isExternal: true,
+						},
+					],
+				},
 				{
 					title: __( 'Domains', __i18n_text_domain__ ),
+					columnGroup: 'domains',
 					items: [
 						{
 							label: __( 'Find a domain', __i18n_text_domain__ ),
@@ -323,15 +126,11 @@ export function getNav2026Menus( {
 							url: localizeUrl( '//wordpress.com/setup/domain-transfer' ),
 							target: '_self',
 						},
-						{
-							label: __( 'Site profiler (WHOIS)', __i18n_text_domain__ ),
-							url: localizeUrl( '//wordpress.com/site-profiler' ),
-							target: '_self',
-						},
 					],
 				},
 				{
 					title: __( 'Email', __i18n_text_domain__ ),
+					columnGroup: 'domains',
 					items: [
 						{
 							label: __( 'Professional email', __i18n_text_domain__ ),
@@ -342,8 +141,126 @@ export function getNav2026Menus( {
 				},
 			],
 		},
-		resourcesMenu,
-		supportLink,
-		pricingLink,
+		{
+			name: 'resources',
+			title: __( 'Resources', __i18n_text_domain__ ),
+			groups: [
+				{
+					title: __( 'Tools & Services', __i18n_text_domain__ ),
+					items: [
+						{
+							label: __( 'Business name generator', __i18n_text_domain__ ),
+							url: localizeUrl( '//wordpress.com/business-name-generator/' ),
+							target: '_self',
+						},
+						{
+							label: __( 'Logo generator', __i18n_text_domain__ ),
+							url: localizeUrl( '//wordpress.com/logo-maker/' ),
+							target: '_self',
+						},
+						{
+							label: __( 'Speed test', __i18n_text_domain__ ),
+							url: localizeUrl( '//wordpress.com/speed-test/' ),
+							target: '_self',
+						},
+						{
+							label: __( 'Hire an expert', __i18n_text_domain__ ),
+							url: localizeUrl( '//wordpress.com/website-design-service/' ),
+							target: '_self',
+						},
+						{
+							label: __( 'Site profiler (WHOIS)', __i18n_text_domain__ ),
+							url: localizeUrl( '//wordpress.com/site-profiler' ),
+							target: '_self',
+						},
+						{
+							label: __( 'Newspack', __i18n_text_domain__ ),
+							url: 'https://newspack.com/',
+							isExternal: true,
+						},
+					],
+				},
+				{
+					title: __( 'For Developers', __i18n_text_domain__ ),
+					items: [
+						{
+							label: __( 'Developer tools', __i18n_text_domain__ ),
+							url: 'https://developer.wordpress.com/docs/developer-tools/',
+						},
+						{
+							label: __( 'Developer blog', __i18n_text_domain__ ),
+							url: localizeUrl( '//wordpress.com/blog/category/development/' ),
+							target: '_self',
+						},
+						{
+							label: __( 'Rest API', __i18n_text_domain__ ),
+							url: 'https://developer.wordpress.com/docs/api/',
+						},
+						{
+							label: __( 'Docs', __i18n_text_domain__ ),
+							url: 'https://developer.wordpress.com/docs/',
+						},
+						{
+							label: __( 'Studio', __i18n_text_domain__ ),
+							url: localizeUrl( '//developer.wordpress.com/studio/' ),
+							target: '_self',
+							isExternal: true,
+						},
+					],
+				},
+				{
+					title: __( 'Features', __i18n_text_domain__ ),
+					items: [
+						{
+							label: __( 'Themes', __i18n_text_domain__ ),
+							url: localizeUrl( '//wordpress.com/themes', locale, isLoggedIn, true ),
+						},
+						{
+							label: __( 'Plugins', __i18n_text_domain__ ),
+							url: localizeUrl( '//wordpress.com/plugins', locale, isLoggedIn, true ),
+						},
+						{
+							label: __( 'Patterns', __i18n_text_domain__ ),
+							url: localizeUrl( '//wordpress.com/patterns', locale, isLoggedIn, true ),
+						},
+						{
+							label: __( 'AI features', __i18n_text_domain__ ),
+							url: localizeUrl( '//wordpress.com/ai/' ),
+							target: '_self',
+						},
+						{
+							label: __( 'View all', __i18n_text_domain__ ),
+							url: localizeUrl( '//wordpress.com/features/' ),
+							target: '_self',
+						},
+					],
+				},
+				{
+					title: __( 'Discover', __i18n_text_domain__ ),
+					items: [
+						{
+							label: __( 'Latest news', __i18n_text_domain__ ),
+							url: localizeUrl( '//wordpress.com/blog/' ),
+							target: '_self',
+						},
+						{
+							label: __( 'Browse blogs', __i18n_text_domain__ ),
+							url: localizeUrl( '//wordpress.com/discover' ),
+							target: '_self',
+						},
+					],
+				},
+			],
+		},
+		{
+			name: 'support',
+			title: __( 'Support', __i18n_text_domain__ ),
+			href: localizeUrl( '//wordpress.com/support/' ),
+		},
+		{
+			name: 'pricing',
+			title: __( 'Pricing', __i18n_text_domain__ ),
+			href: localizeUrl( '//wordpress.com/pricing/' ),
+		},
 	];
 }

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/types.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/types.ts
@@ -4,11 +4,14 @@ export interface Nav2026Item {
 	url: string;
 	target?: string;
 	badge?: string;
+	isExternal?: boolean;
 }
 
 export interface Nav2026Group {
 	title: string;
 	items: Nav2026Item[];
+	// Groups sharing a key stack vertically in one desktop column; unset = own column.
+	columnGroup?: string;
 }
 
 export type Nav2026Menu =

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1833,6 +1833,12 @@ $x-menu-2026-admin-bar-mobile: 46px;
 			pointer-events: auto;
 			// Drill-in: fade the items in so they don't pop in over the fading-out nav list.
 			transition: opacity 0.27s var( --x-menu-2026-easing );
+
+			// Completes the 30px above a section title (8px here + 22px subtitle
+			// padding). On the list, not the items, so link pitch stays 36px.
+			&:not( .is-first-group ) {
+				margin-top: 8px;
+			}
 		}
 	}
 

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1419,6 +1419,8 @@ $x-menu-2026-admin-bar-mobile: 46px;
 	.x-dropdown-subcategories {
 		display: flex;
 		flex-wrap: wrap;
+		// Don't stretch short columns to the tallest column's height.
+		align-items: flex-start;
 		gap: $x-dropdown-2026-column-gap;
 		max-width: $x-nav-2026-content-max-width;
 		margin: 0;
@@ -1428,15 +1430,14 @@ $x-menu-2026-admin-bar-mobile: 46px;
 	.x-dropdown-column-group {
 		display: flex;
 		flex-direction: column;
-		gap: 32px;
+		gap: 12px;
+		min-width: 0;
 		max-width: $x-dropdown-2026-column-max-width;
 		margin: 0;
 	}
 
 	.x-dropdown-subcategory {
-		display: flex;
-		flex-direction: column;
-		gap: 12px;
+		min-width: 0;
 		margin: 0;
 
 		> ul {
@@ -1460,7 +1461,8 @@ $x-menu-2026-admin-bar-mobile: 46px;
 
 	.x-dropdown-subcategory-title {
 		margin: 0;
-		padding: 0;
+		// Separates the title from the first link below it.
+		padding-bottom: 12px;
 		font-size: $x-dropdown-2026-subtitle-font-size;
 		font-weight: 400;
 		line-height: 33px;

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1884,9 +1884,12 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		text-transform: uppercase;
 		color: $studio-gray-30;
 
-		&:first-child {
-			padding-top: 0;
-		}
+	}
+
+	// Each group is its own <ul>, so scope the flush-top exception to the
+	// category's first list — otherwise every subtitle is a :first-child.
+	.x-menu-mobile-dropdown-list.is-first-group .x-menu-mobile-dropdown-subtitle:first-child {
+		padding-top: 0;
 	}
 
 	.x-menu-mobile-dropdown-link.x-menu-mobile-dropdown-link {

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1428,8 +1428,15 @@ $x-menu-2026-admin-bar-mobile: 46px;
 	.x-dropdown-column-group {
 		display: flex;
 		flex-direction: column;
-		gap: 12px;
+		gap: 32px;
 		max-width: $x-dropdown-2026-column-max-width;
+		margin: 0;
+	}
+
+	.x-dropdown-subcategory {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
 		margin: 0;
 
 		> ul {
@@ -1508,6 +1515,19 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		vertical-align: 2px;
 	}
 
+}
+
+/* Leaves-WordPress.com marker; shared by the 2026 desktop dropdown and mobile menu. */
+.x-nav__external-link-icon {
+	white-space: nowrap;
+
+	.x-icon--external {
+		display: inline-block;
+		width: 9px;
+		height: 9px;
+		fill: currentColor;
+		vertical-align: baseline;
+	}
 }
 
 /* Mobile menu — full-screen white panel: header (logo ⇄ back + close), drill-down category list, footer (logged-out CTAs vs logged-in user). */


### PR DESCRIPTION
Part of [MARTECH-2779](https://linear.app/a8c/issue/MARTECH-2779/make-nav-2-the-default-in-calypso)

## Proposed Changes

* Everyone now sees the new global navigation. It appears immediately when the page loads instead of waiting on an A/B test result, so there's no longer a moment where the header is blank or briefly shows the old menu.
* Updated the menu contents: Enterprise hosting now has its own spot under Products and opens WP VIP, Newspack has been added under Resources, and the Features list ends with a "View all" link.
* Removed some links that were duplicated or no longer needed: the Gravatar link-in-bio entry, a second copy of the AI website builder, and the Site profiler entry under Domains (it stays under Resources).
* Links that take you off WordPress.com — Enterprise hosting, Newspack, and Studio — now show a small external-link icon on both desktop and mobile.
* The desktop menu columns and the spacing between menu sections now match WordPress.com exactly, and the mobile menu regains the breathing room above its section titles.

## Why are these changes being made?

* The A/B test on the redesigned navigation concluded in its favour, so it becomes the permanent navigation for everyone. Serving it directly also removes the brief flash of missing navigation that the test made unavoidable, since the old behaviour had to hide the header until the visitor's assignment arrived.

## Testing Instructions

* Load a page that uses the universal header, e.g. `/patterns`, logged out — the new navigation is there right away, with no flash of the old menu and no gap where the header should be.
* Open the Products menu: Build and Publish share the first column, Hosting stands alone, Domains and Email share a column, and Affiliates and Enterprise share the last one. Enterprise hosting opens wpvip.com.
* Open the Resources menu: Newspack ends Tools & Services and "View all" ends Features.
* Enterprise hosting, Newspack, and Studio show an external-link icon — and no other links do. Check on a narrow screen too.
* On a narrow screen, open the menu and drill into Products: each section title (Publish, Hosting, …) has clear space above it.
* Visit the subscription management page and confirm its slimmed-down header is unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
