### PR TITLE
Omnibar: various UI fixes 2

### DIFF
--- a/client/dashboard/app/omnibar/plugin-launch-site.scss
+++ b/client/dashboard/app/omnibar/plugin-launch-site.scss
@@ -5,7 +5,12 @@
 	&:hover:not( [aria-disabled='true'] ),
 	&:focus-visible:not( [aria-disabled='true'] ),
 	&:active:not( [aria-disabled='true'] ) {
-		background-color: #4664eb;
+		background-color: var( --wp-admin-theme-color-darker-10, #2145e6 );
+		color: var( --omnibar-text-color );
+
+		svg {
+			color: var( --omnibar-text-color );
+		}
 	}
 
 	&[aria-disabled='true'] {

--- a/client/dashboard/app/omnibar/style.scss
+++ b/client/dashboard/app/omnibar/style.scss
@@ -9,6 +9,7 @@ body:has( .omnibar.is-support-session ) {
 	--omnibar-background: #b26200;
 	--omnibar-menu-active-background: #8a4d00;
 	--omnibar-submenu-background: #8a4d00;
+	--omnibar-submenu-text-color: #fff;
 	--omnibar-highlight-color: #fff;
 	--omnibar-submenu-highlight-color: #ffbf86;
 	--omnibar-avatar-ring-color: #8a4d00;


### PR DESCRIPTION
## Proposed Changes

Fixes the following color issues in the new omnibar:

- hover color for the Launch site button
- submenu item color for support session.

## Testing Instructions

Test with the `dashboard/omnibar-radical` flag on.

1. Go to site overview of any unlaunched site, hover on the `Launch site` node, verify the background color looks good.
2. Simulate support session (see https://github.com/Automattic/wp-calypso/pull/113349), hover on any menu, verify submenu items color look good.

