### PR TITLE
Omnibar: implement wpcom logout

### DIFF
--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -10,6 +10,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
 import { wpcomLink } from '../../utils/link';
 import { getSiteDisplayName } from '../../utils/site-name';
+import { AUTH_QUERY_KEY, initializeCurrentUser } from '../auth';
 import { useAppContext } from '../context';
 import { omnibarEvents } from './events';
 import { OmnibarHomeIcon } from './home';
@@ -17,6 +18,7 @@ import { useAiChatPlugin } from './plugin-ai-chat';
 import { useHelpCenterPlugin } from './plugin-help-center';
 import { useLanguageSwitcherPlugin } from './plugin-language-switcher';
 import { useLaunchSitePlugin } from './plugin-launch-site';
+import { createLogoutNodeBuilder } from './plugin-logout';
 import { useNotificationsPlugin } from './plugin-notifications';
 import { useReaderPlugin } from './plugin-reader';
 import { buildSiteBadgeNode } from './plugin-site-badges';
@@ -27,12 +29,6 @@ import type { User } from '@automattic/api-core';
 import type { OmnibarNodeBuilders } from '@automattic/omnibar';
 
 const onClickResponsiveMenu = () => omnibarEvents.mobileMenu.emit();
-
-const DOTCOM_NODE_BUILDERS: OmnibarNodeBuilders = {
-	'my-wpcom-account': buildWpcomAccountNode,
-	'site-plan-badge': buildSiteBadgeNode,
-	'site-status-badge': buildSiteBadgeNode,
-};
 
 function removeUnsupportedNodes( nodes: AdminBarNode[], supports: AppConfig[ 'supports' ] ) {
 	// The palette is only mounted where the app supports it, so elsewhere the
@@ -80,11 +76,31 @@ export default function OmnibarContainer( { user }: { user?: User } ) {
 		enabled: hydrated && !! siteId,
 	} );
 
+	const { data: authUser } = useQuery( {
+		queryKey: AUTH_QUERY_KEY,
+		queryFn: initializeCurrentUser,
+		initialData: user,
+		enabled: hydrated,
+		staleTime: 30 * 60 * 1000,
+		retry: false,
+		meta: { persist: false },
+	} );
+
+	const nodeBuilders = useMemo< OmnibarNodeBuilders >(
+		() => ( {
+			'my-wpcom-account': buildWpcomAccountNode,
+			'site-plan-badge': buildSiteBadgeNode,
+			'site-status-badge': buildSiteBadgeNode,
+			...( authUser ? { logout: createLogoutNodeBuilder( authUser ) } : {} ),
+		} ),
+		[ authUser ]
+	);
+
 	const baseOmnibarNodes = useMemo( () => {
 		const nodes = siteNodes ?? dashboardNodes ?? [];
 		const result = buildOmnibarNodesFromAdminBarNodes(
 			removeUnsupportedNodes( nodes, supports ),
-			DOTCOM_NODE_BUILDERS,
+			nodeBuilders,
 			createHrefResolver( siteNodes ? site?.options?.admin_url : undefined )
 		);
 
@@ -111,7 +127,7 @@ export default function OmnibarContainer( { user }: { user?: User } ) {
 		}
 
 		return result;
-	}, [ dashboardNodes, siteNodes, site, supports ] );
+	}, [ dashboardNodes, siteNodes, site, supports, nodeBuilders ] );
 
 	const readerPluginNode = useReaderPlugin();
 	const helpCenterPluginNode = useHelpCenterPlugin();

--- a/client/dashboard/app/omnibar/plugin-logout.ts
+++ b/client/dashboard/app/omnibar/plugin-logout.ts
@@ -1,0 +1,12 @@
+import { logout } from '../auth';
+import type { User } from '@automattic/api-core';
+import type { OmnibarNode } from '@automattic/omnibar';
+
+export function createLogoutNodeBuilder( user: User ) {
+	return (): Partial< OmnibarNode > => ( {
+		href: undefined,
+		onClick: () => {
+			logout( user );
+		},
+	} );
+}


### PR DESCRIPTION
## Proposed Changes

In the new omnibar, patch the `Log Out` node with the existing logic to also log out of MSD.

## Testing Instructions

Test with the `dashboard/omnibar-radical` flag turned on.

1. Go to /sites
2. Hover to your avatar node, click Log Out.
3. Verify you are logged out of MSD as well.
