### PR TITLE
Onboarding: add post_plan_selection email verification variant

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -5,7 +5,6 @@ import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
-import { reloadProxy, requestAllBlogsAccess } from 'wpcom-proxy-request';
 import { clearSessionStorageQuery } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
 import { WOO_HOSTING_SOLUTIONS_REF } from 'calypso/landing/stepper/constants';
 import {
@@ -292,16 +291,6 @@ const onboarding: FlowV2< typeof initialize > = {
 				}
 				case 'email-verification': {
 					const next = queryParams.get( 'next' ) || 'create-site';
-
-					// Verifying the email invalidates the proxy session established at signup, and with
-					// it the all-blogs-access grant that authorizes site creation. Only the free path
-					// creates a site from here (the paid path already has one), so re-establish that
-					// access — the same setup the account step runs at signup — before proceeding.
-					if ( next === 'create-site' && ! isEnabled( 'oauth' ) ) {
-						reloadProxy();
-						await requestAllBlogsAccess();
-					}
-
 					return navigate( next as typeof currentStepSlug );
 				}
 				case 'create-site':

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -48,6 +48,7 @@ import { getOnboardingPostCheckoutDestination } from '../../helpers/get-onboardi
 import { withLocale } from '../../helpers/with-locale';
 import { usePurchasePlanNotification } from '../../internals/hooks/use-purchase-plan-notification';
 import { STEPS } from '../../internals/steps';
+import { isDeferredEmailVerification } from '../../internals/steps-repository/__user/use-email-verification-gate';
 import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
 import { type FlowV2, type ProvidedDependencies, type SubmitHandler } from '../../internals/types';
 import { getOnboardingStepperPosition } from './step-counter-config';
@@ -58,6 +59,7 @@ function initialize() {
 		STEPS.DOMAIN_SEARCH,
 		STEPS.USE_MY_DOMAIN,
 		STEPS.UNIFIED_PLANS,
+		STEPS.EMAIL_VERIFICATION,
 		STEPS.SITE_CREATION_STEP,
 		STEPS.PROCESSING,
 		STEPS.POST_CHECKOUT_ONBOARDING,
@@ -74,6 +76,9 @@ const onboarding: FlowV2< typeof initialize > = {
 	initialize,
 	useStepNavigation( currentStepSlug, navigate ) {
 		const flowName = this.name;
+		// Variant B: the account step doesn't gate; the verification step is met after the free plan
+		// selection or, for a paid order, on return from checkout.
+		const deferredEmailVerification = isDeferredEmailVerification( flowName );
 
 		const {
 			setDomain,
@@ -271,7 +276,22 @@ const onboarding: FlowV2< typeof initialize > = {
 					setProductCartItems( products.filter( ( product ) => product !== null ) );
 
 					setSignupCompleteFlowName( flowName );
+
+					// A fully free order never reaches checkout, so the deferred gate is met here,
+					// right after the plan is chosen, before the site is created.
+					if ( deferredEmailVerification && ! pickedPlan ) {
+						return navigate(
+							'email-verification?next=create-site' as typeof currentStepSlug,
+							undefined,
+							false
+						);
+					}
+
 					return navigate( 'create-site', undefined, false );
+				}
+				case 'email-verification': {
+					const next = queryParams.get( 'next' ) || 'create-site';
+					return navigate( next as typeof currentStepSlug );
 				}
 				case 'create-site':
 					return navigate( 'processing', undefined, true );
@@ -412,7 +432,7 @@ const onboarding: FlowV2< typeof initialize > = {
 							 * redirect the user back to Playground to start the import.
 							 */
 							const playgroundId = getQueryArg( window.location.href, 'playground' );
-							const redirectTo: string =
+							let redirectTo: string =
 								playgroundId &&
 								! isPlanProductFree( {} as unknown as State, planCartItem?.product_id )
 									? addQueryArgs( withLocale( '/setup/site-setup/importerPlayground', locale ), {
@@ -428,6 +448,21 @@ const onboarding: FlowV2< typeof initialize > = {
 												...( diyLaunchpad ? { 'diy-launchpad': diyLaunchpad } : {} ),
 											}
 									  );
+
+							// Variant B: a paid order meets the deferred gate on return from checkout,
+							// before post-checkout-onboarding. The Playground import path keeps its own
+							// return target.
+							if ( deferredEmailVerification && ! playgroundId ) {
+								redirectTo = addQueryArgs(
+									withLocale( '/setup/onboarding/email-verification', locale ),
+									{
+										next: 'post-checkout-onboarding',
+										siteSlug,
+										...( refParameter ? { ref: refParameter } : {} ),
+										...( diyLaunchpad ? { 'diy-launchpad': diyLaunchpad } : {} ),
+									}
+								);
+							}
 
 							const checkoutStepperPosition = getOnboardingStepperPosition( 'checkout' );
 

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -5,6 +5,7 @@ import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
+import { reloadProxy, requestAllBlogsAccess } from 'wpcom-proxy-request';
 import { clearSessionStorageQuery } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
 import { WOO_HOSTING_SOLUTIONS_REF } from 'calypso/landing/stepper/constants';
 import {
@@ -291,6 +292,16 @@ const onboarding: FlowV2< typeof initialize > = {
 				}
 				case 'email-verification': {
 					const next = queryParams.get( 'next' ) || 'create-site';
+
+					// Verifying the email invalidates the proxy session established at signup, and with
+					// it the all-blogs-access grant that authorizes site creation. Only the free path
+					// creates a site from here (the paid path already has one), so re-establish that
+					// access — the same setup the account step runs at signup — before proceeding.
+					if ( next === 'create-site' && ! isEnabled( 'oauth' ) ) {
+						reloadProxy();
+						await requestAllBlogsAccess();
+					}
+
 					return navigate( next as typeof currentStepSlug );
 				}
 				case 'create-site':

--- a/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding-deferred-email-verification.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding-deferred-email-verification.ts
@@ -2,10 +2,16 @@
  * @jest-environment jsdom
  */
 import { renderHook } from '@testing-library/react';
+import { reloadProxy, requestAllBlogsAccess } from 'wpcom-proxy-request';
 import onboarding from '../onboarding';
 
 let mockDeferredFlagOn = true;
 let mockQueryParams = new URLSearchParams( '' );
+
+jest.mock( 'wpcom-proxy-request', () => ( {
+	reloadProxy: jest.fn(),
+	requestAllBlogsAccess: jest.fn( () => Promise.resolve() ),
+} ) );
 
 jest.mock( '@automattic/calypso-config', () => {
 	const actual = jest.requireActual( '@automattic/calypso-config' );
@@ -135,8 +141,7 @@ describe( 'onboarding deferred email verification (Variant B)', () => {
 		expect( navigate ).toHaveBeenCalledWith( 'create-site', undefined, false );
 	} );
 
-	it( 'advances the verification step to the target named in the next query param', async () => {
-		mockQueryParams = new URLSearchParams( 'next=post-checkout-onboarding' );
+	const submitEmailVerification = async () => {
 		const navigate = jest.fn();
 		const { result } = renderHook( () =>
 			onboarding.useStepNavigation.call(
@@ -151,6 +156,35 @@ describe( 'onboarding deferred email verification (Variant B)', () => {
 			providedDependencies: {},
 		} as Parameters< NonNullable< typeof result.current.submit > >[ 0 ] );
 
+		return { navigate };
+	};
+
+	it( 'advances the verification step to the target named in the next query param', async () => {
+		mockQueryParams = new URLSearchParams( 'next=post-checkout-onboarding' );
+
+		const { navigate } = await submitEmailVerification();
+
 		expect( navigate ).toHaveBeenCalledWith( 'post-checkout-onboarding' );
+	} );
+
+	// Verification invalidates the signup proxy session; the free path re-grants site-creation
+	// access before create-site so `/sites/new` is authorized.
+	it( 're-establishes proxy site-creation access before creating the site on the free path', async () => {
+		mockQueryParams = new URLSearchParams( 'next=create-site' );
+
+		const { navigate } = await submitEmailVerification();
+
+		expect( requestAllBlogsAccess ).toHaveBeenCalledTimes( 1 );
+		expect( navigate ).toHaveBeenCalledWith( 'create-site' );
+	} );
+
+	// The paid path already has a site, so it must not run the site-creation re-grant.
+	it( 'does not re-request blog access on the paid path', async () => {
+		mockQueryParams = new URLSearchParams( 'next=post-checkout-onboarding' );
+
+		await submitEmailVerification();
+
+		expect( requestAllBlogsAccess ).not.toHaveBeenCalled();
+		expect( reloadProxy ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding-deferred-email-verification.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding-deferred-email-verification.ts
@@ -2,16 +2,10 @@
  * @jest-environment jsdom
  */
 import { renderHook } from '@testing-library/react';
-import { reloadProxy, requestAllBlogsAccess } from 'wpcom-proxy-request';
 import onboarding from '../onboarding';
 
 let mockDeferredFlagOn = true;
 let mockQueryParams = new URLSearchParams( '' );
-
-jest.mock( 'wpcom-proxy-request', () => ( {
-	reloadProxy: jest.fn(),
-	requestAllBlogsAccess: jest.fn( () => Promise.resolve() ),
-} ) );
 
 jest.mock( '@automattic/calypso-config', () => {
 	const actual = jest.requireActual( '@automattic/calypso-config' );
@@ -141,7 +135,8 @@ describe( 'onboarding deferred email verification (Variant B)', () => {
 		expect( navigate ).toHaveBeenCalledWith( 'create-site', undefined, false );
 	} );
 
-	const submitEmailVerification = async () => {
+	it( 'advances the verification step to the target named in the next query param', async () => {
+		mockQueryParams = new URLSearchParams( 'next=post-checkout-onboarding' );
 		const navigate = jest.fn();
 		const { result } = renderHook( () =>
 			onboarding.useStepNavigation.call(
@@ -156,35 +151,6 @@ describe( 'onboarding deferred email verification (Variant B)', () => {
 			providedDependencies: {},
 		} as Parameters< NonNullable< typeof result.current.submit > >[ 0 ] );
 
-		return { navigate };
-	};
-
-	it( 'advances the verification step to the target named in the next query param', async () => {
-		mockQueryParams = new URLSearchParams( 'next=post-checkout-onboarding' );
-
-		const { navigate } = await submitEmailVerification();
-
 		expect( navigate ).toHaveBeenCalledWith( 'post-checkout-onboarding' );
-	} );
-
-	// Verification invalidates the signup proxy session; the free path re-grants site-creation
-	// access before create-site so `/sites/new` is authorized.
-	it( 're-establishes proxy site-creation access before creating the site on the free path', async () => {
-		mockQueryParams = new URLSearchParams( 'next=create-site' );
-
-		const { navigate } = await submitEmailVerification();
-
-		expect( requestAllBlogsAccess ).toHaveBeenCalledTimes( 1 );
-		expect( navigate ).toHaveBeenCalledWith( 'create-site' );
-	} );
-
-	// The paid path already has a site, so it must not run the site-creation re-grant.
-	it( 'does not re-request blog access on the paid path', async () => {
-		mockQueryParams = new URLSearchParams( 'next=post-checkout-onboarding' );
-
-		await submitEmailVerification();
-
-		expect( requestAllBlogsAccess ).not.toHaveBeenCalled();
-		expect( reloadProxy ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding-deferred-email-verification.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding-deferred-email-verification.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { renderHook } from '@testing-library/react';
+import { ProcessingResult } from '../../../internals/steps-repository/processing-step/constants';
 import onboarding from '../onboarding';
 
 let mockDeferredFlagOn = true;
@@ -86,6 +87,63 @@ jest.mock( '@automattic/onboarding', () => ( {
 	clearStepPersistedState: jest.fn(),
 } ) );
 
+jest.mock( 'calypso/lib/ai-launchpad', () => ( {
+	resolveLaunchpadPersonalizationVariation: jest.fn( async () => 'control' ),
+	getLaunchpadPersonalizationDestination: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/url', () => ( { pathToUrl: ( path: string ) => path } ) );
+
+jest.mock( '../../../helpers/get-onboarding-post-checkout-destination', () => ( {
+	getOnboardingPostCheckoutDestination: jest.fn( () => [
+		'/home/example.wordpress.com',
+		null,
+		null,
+	] ),
+} ) );
+
+jest.mock( '../step-counter-config', () => ( {
+	getOnboardingStepperPosition: () => ( { current: 3, total: 3 } ),
+} ) );
+
+// Runs the `processing` case for a successful, paid order (goToCheckout) with a mocked
+// `window.location`, and returns the URL passed to `window.location.replace`.
+const submitPaidProcessing = async () => {
+	const replace = jest.fn();
+	const originalLocation = Object.getOwnPropertyDescriptor( window, 'location' );
+	Object.defineProperty( window, 'location', {
+		configurable: true,
+		value: { href: 'http://localhost/', search: '', replace },
+	} );
+
+	try {
+		const navigate = jest.fn();
+		const { result } = renderHook( () =>
+			onboarding.useStepNavigation.call(
+				onboarding,
+				'processing' as Parameters< typeof onboarding.useStepNavigation >[ 0 ],
+				navigate
+			)
+		);
+
+		await result.current.submit?.( {
+			slug: 'processing',
+			providedDependencies: {
+				processingResult: ProcessingResult.SUCCESS,
+				goToCheckout: true,
+				siteSlug: 'example.wordpress.com',
+				siteId: 123,
+			},
+		} as Parameters< NonNullable< typeof result.current.submit > >[ 0 ] );
+
+		return replace.mock.calls[ 0 ]?.[ 0 ] ? decodeURIComponent( replace.mock.calls[ 0 ][ 0 ] ) : '';
+	} finally {
+		if ( originalLocation ) {
+			Object.defineProperty( window, 'location', originalLocation );
+		}
+	}
+};
+
 const submitPlans = async ( providedDependencies: Record< string, unknown > ) => {
 	const navigate = jest.fn();
 	const { result } = renderHook( () =>
@@ -152,5 +210,24 @@ describe( 'onboarding deferred email verification (Variant B)', () => {
 		} as Parameters< NonNullable< typeof result.current.submit > >[ 0 ] );
 
 		expect( navigate ).toHaveBeenCalledWith( 'post-checkout-onboarding' );
+	} );
+
+	it( 'points a paid order back at the verification step on return from checkout', async () => {
+		const checkoutUrl = await submitPaidProcessing();
+
+		expect( checkoutUrl ).toContain( '/checkout/' );
+		// The checkout return (redirect_to) lands on the deferred gate, which then advances to
+		// post-checkout-onboarding once verified.
+		expect( checkoutUrl ).toContain( '/setup/onboarding/email-verification' );
+		expect( checkoutUrl ).toContain( 'next=post-checkout-onboarding' );
+	} );
+
+	it( 'sends a paid order straight to post-checkout-onboarding when the deferred flag is off', async () => {
+		mockDeferredFlagOn = false;
+
+		const checkoutUrl = await submitPaidProcessing();
+
+		expect( checkoutUrl ).toContain( '/setup/onboarding/post-checkout-onboarding' );
+		expect( checkoutUrl ).not.toContain( 'email-verification' );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding-deferred-email-verification.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding-deferred-email-verification.ts
@@ -1,0 +1,156 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import onboarding from '../onboarding';
+
+let mockDeferredFlagOn = true;
+let mockQueryParams = new URLSearchParams( '' );
+
+jest.mock( '@automattic/calypso-config', () => {
+	const actual = jest.requireActual( '@automattic/calypso-config' );
+	const configFn = ( key: string ) => actual( key );
+	Object.assign( configFn, actual, {
+		isEnabled: ( flag: string ) =>
+			flag === 'onboarding/email-verification-deferred'
+				? mockDeferredFlagOn
+				: actual.isEnabled( flag ),
+	} );
+	return configFn;
+} );
+
+jest.mock( 'calypso/components/domains/wpcom-domain-search/use-query-handler', () => ( {
+	clearSessionStorageQuery: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		resetOnboardStore: jest.fn(),
+		setDomain: jest.fn(),
+		setDomainCartItem: jest.fn(),
+		setDomainCartItems: jest.fn(),
+		setPlanCartItem: jest.fn(),
+		setProductCartItems: jest.fn(),
+		setSiteUrl: jest.fn(),
+		setSignupDomainOrigin: jest.fn(),
+		setHideFreePlan: jest.fn(),
+	} ),
+	useSelect: jest.fn( () => ( {} ) ),
+	resolveSelect: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/landing/stepper/hooks/use-query', () => ( {
+	useQuery: jest.fn( () => mockQueryParams ),
+} ) );
+
+jest.mock( 'calypso/landing/stepper/hooks/use-flow-locale', () => ( {
+	useFlowLocale: jest.fn( () => 'en' ),
+} ) );
+
+jest.mock( 'calypso/state', () => ( {
+	useSelector: jest.fn(),
+	useDispatch: () => jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/analytics/survicate', () => ( { addSurvicate: jest.fn() } ) );
+jest.mock( 'calypso/lib/analytics/signup', () => ( { SIGNUP_DOMAIN_ORIGIN: {} } ) );
+jest.mock( 'calypso/lib/explat', () => ( { loadExperimentAssignment: jest.fn() } ) );
+
+jest.mock( 'calypso/landing/stepper/stores', () => ( {
+	ONBOARD_STORE: 'ONBOARD_STORE',
+	SITE_STORE: 'SITE_STORE',
+} ) );
+
+jest.mock( '@automattic/data-stores', () => ( {} ) );
+
+jest.mock(
+	'calypso/landing/stepper/declarative-flow/internals/hooks/use-purchase-plan-notification',
+	() => ( {
+		usePurchasePlanNotification: jest.fn( () => ( { setShouldShowNotification: jest.fn() } ) ),
+	} )
+);
+
+jest.mock( 'calypso/signup/storageUtils', () => ( {
+	persistSignupDestination: jest.fn(),
+	setSignupCompleteFlowName: jest.fn(),
+	setSignupCompleteSlug: jest.fn(),
+	clearSignupCompleteSlug: jest.fn(),
+	clearSignupCompleteFlowName: jest.fn(),
+	clearSignupDestinationCookie: jest.fn(),
+	clearSignupCompleteSiteID: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/onboarding', () => ( {
+	ONBOARDING_FLOW: 'onboarding',
+	SITE_SETUP_FLOW: 'site-setup',
+	clearStepPersistedState: jest.fn(),
+} ) );
+
+const submitPlans = async ( providedDependencies: Record< string, unknown > ) => {
+	const navigate = jest.fn();
+	const { result } = renderHook( () =>
+		onboarding.useStepNavigation.call(
+			onboarding,
+			'plans' as Parameters< typeof onboarding.useStepNavigation >[ 0 ],
+			navigate
+		)
+	);
+
+	await result.current.submit?.( {
+		slug: 'plans',
+		providedDependencies,
+	} as Parameters< NonNullable< typeof result.current.submit > >[ 0 ] );
+
+	return { navigate };
+};
+
+describe( 'onboarding deferred email verification (Variant B)', () => {
+	beforeEach( () => {
+		mockDeferredFlagOn = true;
+		mockQueryParams = new URLSearchParams( '' );
+		jest.clearAllMocks();
+	} );
+
+	it( 'sends a fully free order to the verification step before the site is created', async () => {
+		const { navigate } = await submitPlans( { cartItems: [] } );
+
+		expect( navigate ).toHaveBeenCalledWith(
+			'email-verification?next=create-site',
+			undefined,
+			false
+		);
+	} );
+
+	it( 'sends a paid order straight to site creation', async () => {
+		const { navigate } = await submitPlans( { cartItems: [ { product_id: 1 } ] } );
+
+		expect( navigate ).toHaveBeenCalledWith( 'create-site', undefined, false );
+	} );
+
+	it( 'keeps the free order on site creation when the deferred flag is off', async () => {
+		mockDeferredFlagOn = false;
+
+		const { navigate } = await submitPlans( { cartItems: [] } );
+
+		expect( navigate ).toHaveBeenCalledWith( 'create-site', undefined, false );
+	} );
+
+	it( 'advances the verification step to the target named in the next query param', async () => {
+		mockQueryParams = new URLSearchParams( 'next=post-checkout-onboarding' );
+		const navigate = jest.fn();
+		const { result } = renderHook( () =>
+			onboarding.useStepNavigation.call(
+				onboarding,
+				'email-verification' as Parameters< typeof onboarding.useStepNavigation >[ 0 ],
+				navigate
+			)
+		);
+
+		await result.current.submit?.( {
+			slug: 'email-verification',
+			providedDependencies: {},
+		} as Parameters< NonNullable< typeof result.current.submit > >[ 0 ] );
+
+		expect( navigate ).toHaveBeenCalledWith( 'post-checkout-onboarding' );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/email-verification/index.tsx
@@ -29,8 +29,10 @@ interface Props {
 	// The address the activation email went to, which after a correction is the one just accepted
 	// rather than the one `/me` still reports.
 	email: string;
-	// Returns to the account step to correct the address this was sent to.
-	onEditEmail: () => void;
+	// Returns to the account step to correct the address this was sent to. Omitted where correcting
+	// the address isn't offered — the deferred gate, met after checkout, has no account form to
+	// return to.
+	onEditEmail?: () => void;
 	// Set while a correction is waiting to be confirmed, which changes what resending has to do.
 	pendingEmail?: string;
 	// Whether the address above is the one being waited on, or is standing in until the settings
@@ -94,30 +96,43 @@ const EmailVerificationGate = ( {
 			provider: inboxLink?.provider,
 		} );
 
-	const subText = createInterpolateElement(
-		sprintf(
-			// translators: %s is the email address the verification link was sent to.
-			__(
-				'We just sent an email to <email>%s</email> (<edit>edit</edit>). Click the link in the email to verify your account.'
-			),
-			email
-		),
-		{
-			email: <strong />,
-			edit: (
-				<WPButton
-					variant="link"
-					// A correction submitted now would queue behind the send, and a reload while it
-					// waited would leave the address written down with nothing able to carry it out.
-					disabled={ isSending }
-					onClick={ () => {
-						recordTracksEvent( 'calypso_signup_email_verification_edit_click', { flow } );
-						onEditEmail();
-					} }
-				/>
-			),
-		}
-	);
+	const subText = onEditEmail
+		? createInterpolateElement(
+				sprintf(
+					// translators: %s is the email address the verification link was sent to.
+					__(
+						'We just sent an email to <email>%s</email> (<edit>edit</edit>). Click the link in the email to verify your account.'
+					),
+					email
+				),
+				{
+					email: <strong />,
+					edit: (
+						<WPButton
+							variant="link"
+							// A correction submitted now would queue behind the send, and a reload while it
+							// waited would leave the address written down with nothing able to carry it out.
+							disabled={ isSending }
+							onClick={ () => {
+								recordTracksEvent( 'calypso_signup_email_verification_edit_click', { flow } );
+								onEditEmail();
+							} }
+						/>
+					),
+				}
+		  )
+		: createInterpolateElement(
+				sprintf(
+					// translators: %s is the email address the verification link was sent to.
+					__(
+						'We just sent an email to <email>%s</email>. Click the link in the email to verify your account.'
+					),
+					email
+				),
+				{
+					email: <strong />,
+				}
+		  );
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -41,7 +41,11 @@ import { useHandleSocialResponse } from './handle-social-response';
 import { SignupSlider } from './signup-slider';
 import useAccountCreationExperiment from './use-account-creation-experiment';
 import { useBackoffPoll } from './use-backoff-poll';
-import { ACTIVATION_EMAIL_SOURCE, useEmailVerificationGate } from './use-email-verification-gate';
+import {
+	ACTIVATION_EMAIL_SOURCE,
+	isEmailVerificationEnabled,
+	useEmailVerificationGate,
+} from './use-email-verification-gate';
 import { useSocialService } from './use-social-service';
 import { useUpdateEmail } from './use-update-email';
 import type { SignupAllowedService } from 'calypso/components/social-buttons/utils';
@@ -86,7 +90,11 @@ const UserStepComponent: StepType< { accepts: UserStepAccepts } > = function Use
 	const [ wpAccountCreateResponse, setWpAccountCreateResponse ] = useState< AccountCreateReturn >();
 	const [ createdUserId, setCreatedUserId ] = useState< number | string | null >( null );
 
-	const { isEnabled: gateEnabled, status: gateStatus } = useEmailVerificationGate( flow );
+	const { status: gateStatus } = useEmailVerificationGate( flow );
+	// Sending the activation email and aiming it back at onboarding is shared by both variants: the
+	// account step gates in Variant A, but in Variant B the same link is what the deferred gate,
+	// met after checkout, goes on to wait for.
+	const emailVerificationEnabled = isEmailVerificationEnabled( flow );
 	const gateScopeForUser = gateScope( flow, userId );
 	// Scoped, since `/me` resolving a different account is a case this step already handles and the
 	// gate is keyed on the same scope for it. Derived once: the address it was opened with is both
@@ -237,7 +245,7 @@ const UserStepComponent: StepType< { accepts: UserStepAccepts } > = function Use
 		}
 		setCreatedUserId( data.ID ?? null );
 		setSignupIsNewUser( data.ID );
-		if ( gateEnabled ) {
+		if ( emailVerificationEnabled ) {
 			// The activation email from account creation is the one the gate asks for, so the gate
 			// sends nothing on arrival — this only records the send the server just made.
 			recordTracksEvent( 'calypso_signup_email_verification_email_sent', {
@@ -308,7 +316,7 @@ const UserStepComponent: StepType< { accepts: UserStepAccepts } > = function Use
 				isMobileCompactVariant={ isMobileCompactLayout }
 				allowedSocialServices={ allowedSocialServices }
 				customTosElement={ signupTosElement }
-				activationEmailFrom={ gateEnabled ? ACTIVATION_EMAIL_SOURCE : undefined }
+				activationEmailFrom={ emailVerificationEnabled ? ACTIVATION_EMAIL_SOURCE : undefined }
 				onUpdateEmail={ isEditingEmail ? updateEmail : undefined }
 			/>
 			{ accountCreateResponse && 'bearer_token' in accountCreateResponse && (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/use-email-verification-gate.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/use-email-verification-gate.ts
@@ -4,7 +4,11 @@
 import config from '@automattic/calypso-config';
 import { renderHook } from '@testing-library/react';
 import { useSelector } from 'calypso/state';
-import { useEmailVerificationGate } from '../use-email-verification-gate';
+import {
+	isDeferredEmailVerification,
+	isEmailVerificationEnabled,
+	useEmailVerificationGate,
+} from '../use-email-verification-gate';
 
 jest.mock( '@automattic/calypso-config', () => {
 	const actual = jest.requireActual( '@automattic/calypso-config' );
@@ -85,5 +89,63 @@ describe( 'useEmailVerificationGate', () => {
 
 			expect( statusFor() ).toBe( 'verified' );
 		} );
+	} );
+
+	// The deferred flag (Variant B) must not open the account-step gate: it moves later in the flow.
+	it( 'does not gate the account step under the deferred flag alone', () => {
+		mockConfig.enabledFlags.clear();
+		mockConfig.enabledFlags.add( 'onboarding/email-verification-deferred' );
+		mockUser( { email_verified: false } );
+
+		expect( statusFor() ).toBe( 'clear' );
+	} );
+} );
+
+describe( 'isDeferredEmailVerification', () => {
+	afterEach( () => mockConfig.enabledFlags.clear() );
+
+	it( 'is true for onboarding with the deferred flag on', () => {
+		mockConfig.enabledFlags.add( 'onboarding/email-verification-deferred' );
+
+		expect( isDeferredEmailVerification( 'onboarding' ) ).toBe( true );
+	} );
+
+	it( 'is false for other flows', () => {
+		mockConfig.enabledFlags.add( 'onboarding/email-verification-deferred' );
+
+		expect( isDeferredEmailVerification( 'newsletter' ) ).toBe( false );
+	} );
+
+	it( 'is false when only the account-step flag is on', () => {
+		mockConfig.enabledFlags.add( 'onboarding/email-verification' );
+
+		expect( isDeferredEmailVerification( 'onboarding' ) ).toBe( false );
+	} );
+} );
+
+describe( 'isEmailVerificationEnabled', () => {
+	afterEach( () => mockConfig.enabledFlags.clear() );
+
+	// Either variant sends the activation email and points it back at onboarding.
+	it( 'is true under the account-step flag', () => {
+		mockConfig.enabledFlags.add( 'onboarding/email-verification' );
+
+		expect( isEmailVerificationEnabled( 'onboarding' ) ).toBe( true );
+	} );
+
+	it( 'is true under the deferred flag', () => {
+		mockConfig.enabledFlags.add( 'onboarding/email-verification-deferred' );
+
+		expect( isEmailVerificationEnabled( 'onboarding' ) ).toBe( true );
+	} );
+
+	it( 'is false with neither flag on', () => {
+		expect( isEmailVerificationEnabled( 'onboarding' ) ).toBe( false );
+	} );
+
+	it( 'is false for other flows', () => {
+		mockConfig.enabledFlags.add( 'onboarding/email-verification' );
+
+		expect( isEmailVerificationEnabled( 'newsletter' ) ).toBe( false );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-email-verification-gate.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-email-verification-gate.ts
@@ -7,6 +7,31 @@ import { getCurrentUser } from 'calypso/state/current-user/selectors';
 // back here. Matched as an exact string: changing it here alone sends them somewhere else.
 export const ACTIVATION_EMAIL_SOURCE = 'onboarding-with-email-verification';
 
+// Variant A: the gate holds the user on the account step, right after creation.
+const ACCOUNT_STEP_FLAG = 'onboarding/email-verification';
+// Variant B: the account step never gates; the gate is met later, after the free plan selection
+// or after checkout. Wired by the flow, not by this hook.
+const DEFERRED_FLAG = 'onboarding/email-verification-deferred';
+
+/**
+ * Whether either variant is live for this flow. Both send the same activation email on account
+ * creation and point its link back here, so the account step asks for that whichever gates.
+ */
+export function isEmailVerificationEnabled( flow: string ): boolean {
+	return (
+		flow === ONBOARDING_FLOW &&
+		( config.isEnabled( ACCOUNT_STEP_FLAG ) || config.isEnabled( DEFERRED_FLAG ) )
+	);
+}
+
+/**
+ * Whether the gate is deferred past the account step (Variant B). The flow reads this to move the
+ * gate to after the free plan selection or after checkout.
+ */
+export function isDeferredEmailVerification( flow: string ): boolean {
+	return flow === ONBOARDING_FLOW && config.isEnabled( DEFERRED_FLAG );
+}
+
 // `pending` is not a kind of `clear`: the user's ID survives a reload but the user object does
 // not, so there is a window where the account is logged in and nothing is known about it. Reading
 // those absent fields as an unverified email opens the gate onto a blank address.
@@ -37,7 +62,7 @@ interface EmailVerificationGate {
 export function useEmailVerificationGate( flow: string ): EmailVerificationGate {
 	const currentUser = useSelector( getCurrentUser );
 
-	const isEnabled = config.isEnabled( 'onboarding/email-verification' ) && flow === ONBOARDING_FLOW;
+	const isEnabled = config.isEnabled( ACCOUNT_STEP_FLAG ) && flow === ONBOARDING_FLOW;
 
 	// Verification is read before enablement, so turning the flag off mid-attempt can't be
 	// mistaken for the user having confirmed.

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/email-verification/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/email-verification/index.tsx
@@ -1,5 +1,5 @@
 import { Step } from '@automattic/onboarding';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { usePartnerBranding } from 'calypso/lib/partner-branding';
 import { useSelector } from 'calypso/state';
@@ -29,10 +29,15 @@ const EmailVerificationStep: StepType = function EmailVerificationStep( { flow, 
 	const { topBarLogo } = usePartnerBranding();
 	const scope = gateScope( flow, userId );
 
+	// `navigation` is a fresh object each render, so the effect re-runs on unrelated re-renders;
+	// this keeps the advance (and its event) to once per verified attempt.
+	const hasAdvanced = useRef( false );
+
 	useEffect( () => {
-		if ( ! isVerified ) {
+		if ( ! isVerified || hasAdvanced.current ) {
 			return;
 		}
+		hasAdvanced.current = true;
 		// Only the tab that opened the gate records the confirmation; a link opened in another tab of
 		// the same browser resolves this one by polling.
 		const claim = claimGateConfirmation( scope );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/email-verification/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/email-verification/index.tsx
@@ -1,0 +1,63 @@
+import { Step } from '@automattic/onboarding';
+import { useEffect } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { usePartnerBranding } from 'calypso/lib/partner-branding';
+import { useSelector } from 'calypso/state';
+import {
+	getCurrentUserEmail,
+	getCurrentUserId,
+	isCurrentUserEmailVerified,
+} from 'calypso/state/current-user/selectors';
+import EmailVerificationGate from '../__user/email-verification';
+import { claimGateConfirmation, gateScope } from '../__user/email-verification/storage';
+import type { Step as StepType } from '../../types';
+
+/**
+ * The deferred email verification gate (Variant B). Unlike the account-step gate, this runs as a
+ * step of its own so the flow can place it after the free plan selection or after checkout — the
+ * latter returns from an external page by URL, which the framework's account step can't answer.
+ *
+ * The gate component owns the polling and the resend; this step owns advancing the flow once `/me`
+ * reports the account verified. Correcting the address isn't offered here: by this point the
+ * account exists (and, on the paid path, has already been paid for), and there's no account form to
+ * return to.
+ */
+const EmailVerificationStep: StepType = function EmailVerificationStep( { flow, navigation } ) {
+	const userId = useSelector( getCurrentUserId );
+	const email = useSelector( getCurrentUserEmail );
+	const isVerified = useSelector( isCurrentUserEmailVerified );
+	const { topBarLogo } = usePartnerBranding();
+	const scope = gateScope( flow, userId );
+
+	useEffect( () => {
+		if ( ! isVerified ) {
+			return;
+		}
+		// Only the tab that opened the gate records the confirmation; a link opened in another tab of
+		// the same browser resolves this one by polling.
+		const claim = claimGateConfirmation( scope );
+		if ( claim ) {
+			recordTracksEvent( 'calypso_signup_email_verification_confirmed', {
+				flow,
+				seconds_on_step: claim.secondsOnStep,
+			} );
+		}
+		navigation.submit?.();
+	}, [ isVerified, scope, flow, navigation ] );
+
+	if ( isVerified ) {
+		return <Step.Loading />;
+	}
+
+	return (
+		<EmailVerificationGate
+			flow={ flow }
+			scope={ scope }
+			email={ email ?? '' }
+			addressSettled
+			logo={ topBarLogo }
+		/>
+	);
+};
+
+export default EmailVerificationStep;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/email-verification/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/email-verification/test/index.tsx
@@ -40,7 +40,6 @@ jest.mock( '../../__user/email-verification/storage', () => ( {
 
 const renderStep = ( submit = jest.fn() ) => {
 	render(
-		// @ts-expect-error -- only the props the step reads are provided.
 		<EmailVerificationStep
 			flow="onboarding"
 			navigation={ { submit } }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/email-verification/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/email-verification/test/index.tsx
@@ -79,4 +79,29 @@ describe( 'EmailVerificationStep', () => {
 		);
 		expect( screen.queryByTestId( 'gate' ) ).not.toBeInTheDocument();
 	} );
+
+	it( 'advances only once when the navigation object changes identity on re-render', () => {
+		mockState = { ...mockState, verified: true };
+		const submit = jest.fn();
+
+		// The flow hands the step a fresh `navigation` object every render, so a re-render must not
+		// re-trigger the advance or double-record the confirmation.
+		const { rerender } = render(
+			<EmailVerificationStep
+				flow="onboarding"
+				navigation={ { submit } }
+				stepName="email-verification"
+			/>
+		);
+		rerender(
+			<EmailVerificationStep
+				flow="onboarding"
+				navigation={ { submit } }
+				stepName="email-verification"
+			/>
+		);
+
+		expect( submit ).toHaveBeenCalledTimes( 1 );
+		expect( recordTracksEvent ).toHaveBeenCalledTimes( 1 );
+	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/email-verification/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/email-verification/test/index.tsx
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import EmailVerificationStep from '../index';
+
+let mockState = { userId: 7, email: 'person@example.com', verified: false };
+
+jest.mock( 'calypso/state', () => ( {
+	useSelector: ( selector: ( state: unknown ) => unknown ) => selector( mockState ),
+} ) );
+
+jest.mock( 'calypso/state/current-user/selectors', () => ( {
+	getCurrentUserId: ( state: { userId: number } ) => state.userId,
+	getCurrentUserEmail: ( state: { email: string } ) => state.email,
+	isCurrentUserEmailVerified: ( state: { verified: boolean } ) => state.verified,
+} ) );
+
+jest.mock( '@automattic/onboarding', () => ( {
+	Step: { Loading: () => <div data-testid="loading" /> },
+} ) );
+
+jest.mock( 'calypso/lib/partner-branding', () => ( {
+	usePartnerBranding: () => ( { topBarLogo: null } ),
+} ) );
+
+jest.mock( 'calypso/lib/analytics/tracks', () => ( { recordTracksEvent: jest.fn() } ) );
+
+const mockGateProps = jest.fn();
+jest.mock( '../../__user/email-verification', () => ( props: Record< string, unknown > ) => {
+	mockGateProps( props );
+	return <div data-testid="gate" />;
+} );
+
+jest.mock( '../../__user/email-verification/storage', () => ( {
+	gateScope: ( flow: string, userId: number ) => `${ flow }:${ userId }`,
+	claimGateConfirmation: jest.fn( () => ( { secondsOnStep: 12 } ) ),
+} ) );
+
+const renderStep = ( submit = jest.fn() ) => {
+	render(
+		// @ts-expect-error -- only the props the step reads are provided.
+		<EmailVerificationStep
+			flow="onboarding"
+			navigation={ { submit } }
+			stepName="email-verification"
+		/>
+	);
+	return submit;
+};
+
+describe( 'EmailVerificationStep', () => {
+	beforeEach( () => {
+		mockState = { userId: 7, email: 'person@example.com', verified: false };
+		jest.clearAllMocks();
+	} );
+
+	it( 'shows the gate, without an edit affordance, while the account is unverified', () => {
+		const submit = renderStep();
+
+		expect( screen.getByTestId( 'gate' ) ).toBeVisible();
+		expect( submit ).not.toHaveBeenCalled();
+
+		const props = mockGateProps.mock.calls[ 0 ][ 0 ];
+		expect( props.email ).toBe( 'person@example.com' );
+		expect( props.scope ).toBe( 'onboarding:7' );
+		expect( props.onEditEmail ).toBeUndefined();
+	} );
+
+	it( 'advances the flow and records the confirmation once verified', () => {
+		mockState = { ...mockState, verified: true };
+
+		const submit = renderStep();
+
+		expect( submit ).toHaveBeenCalledTimes( 1 );
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_signup_email_verification_confirmed',
+			expect.objectContaining( { flow: 'onboarding', seconds_on_step: 12 } )
+		);
+		expect( screen.queryByTestId( 'gate' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -54,6 +54,11 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/education-student-validation' ),
 	},
 
+	EMAIL_VERIFICATION: {
+		slug: 'email-verification',
+		asyncComponent: () => import( './steps-repository/email-verification' ),
+	},
+
 	ERROR: { slug: 'error', asyncComponent: () => import( './steps-repository/error-step' ) },
 
 	FLEX_SITE_CREATION: {

--- a/config/development.json
+++ b/config/development.json
@@ -161,6 +161,7 @@
 		"oauth/unified-experience": true,
 		"onboarding/create-course": false,
 		"onboarding/email-verification": false,
+		"onboarding/email-verification-deferred": false,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,
 		"onboarding/import-from-squarespace": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -96,6 +96,7 @@
 		"oauth/unified-experience": false,
 		"onboarding/create-course": false,
 		"onboarding/email-verification": false,
+		"onboarding/email-verification-deferred": false,
 		"onboarding/post-checkout-ai-step": true,
 		"onboarding/woo-hosting-post-purchase-setup-choice": true,
 		"p2/p2-plus": true,

--- a/config/production.json
+++ b/config/production.json
@@ -112,6 +112,7 @@
 		"oauth/unified-experience": false,
 		"onboarding/create-course": false,
 		"onboarding/email-verification": false,
+		"onboarding/email-verification-deferred": false,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,
 		"onboarding/import-from-squarespace": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -111,6 +111,7 @@
 		"oauth/unified-experience": true,
 		"onboarding/create-course": false,
 		"onboarding/email-verification": false,
+		"onboarding/email-verification-deferred": false,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,
 		"onboarding/import-from-squarespace": true,

--- a/config/test.json
+++ b/config/test.json
@@ -80,6 +80,7 @@
 		"oauth/unified-experience": false,
 		"onboarding/create-course": false,
 		"onboarding/email-verification": false,
+		"onboarding/email-verification-deferred": false,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,
 		"onboarding/import-from-squarespace": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -117,6 +117,7 @@
 		"oauth/unified-experience": true,
 		"onboarding/create-course": false,
 		"onboarding/email-verification": false,
+		"onboarding/email-verification-deferred": false,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,
 		"onboarding/import-from-squarespace": true,


### PR DESCRIPTION
Part of DOTCOM-18120

## Proposed Changes

Adds **Variant B** of the onboarding email-verification experiment, behind the
`onboarding/email-verification-deferred` config flag (off in all environments).

Variant A (existing) gates verification *inside* the account step. Variant B leaves
account creation ungated and moves the gate later, depending on whether the order
reaches checkout:

- **Fully free** (free domain + free plan): gate shown right after plan selection.
- **Paid**: gate shown on return from checkout, before post-checkout onboarding.

> The variant is currently only reachable via the feature flag. A follow-up PR will wire
up the real ExPlat experiment with better variant naming

## Testing Instructions

1. Check out this branch locally and set `onboarding/email-verification-deferred` to
   `true` in `config/development.json`.
2. Make sure you're logged out, then go to `/setup`.
3. Create a new account (you can use a `+something` suffix in the email address).
4. **Free path:** select a free domain and the free plan.
   - Confirm the next step is email verification.
   - Validate the email and confirm the flow continues.
5. **Paid path:** select a paid plan or domain.
   - The next step is checkout — pay with the Store sandbox.
   - Confirm the next step on return is email verification.

<img width="1673" height="957" alt="Screenshot 2026-08-13 at 17 41 57" src="https://github.com/user-attachments/assets/e2ae51f2-e1e2-4d8f-8ce4-4345f3fa4e6c" />

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
