### PR TITLE
A4A MSD: Add the Partner Directory expertise building blocks

### DIFF
--- a/client/dashboard/agency/partner-directory/expertise/options.ts
+++ b/client/dashboard/agency/partner-directory/expertise/options.ts
@@ -1,0 +1,47 @@
+import { __ } from '@wordpress/i18n';
+import type { AgencyPartnerDirectorySlug } from '@automattic/api-core';
+
+/**
+ * The services an agency can offer, keyed by the slug the API stores.
+ */
+export const getAvailableServices = (): Record< string, string > => ( {
+	seo: __( 'Search Engine Optimization (SEO)' ),
+	email_marketing_social_media: __( 'Email Marketing & Social Media' ),
+	content_strategy_development: __( 'Content Strategy & Development' ),
+	paid_advertising: __( 'Paid Advertising' ),
+	website_online_store_development: __( 'Website or Online Store Development' ),
+	site_migration_platform_integration: __( 'Site Migration and Platform Integration' ),
+	site_maintenance_platform_integration: __( 'Site Maintenance & Plugin Management' ),
+	website_performance_optimization: __( 'Website Performance Optimization' ),
+	conversion_rate_checkout_optimization: __( 'Conversion Rate & Checkout Optimization' ),
+	ecommerce_consulting: __( 'eCommerce Consulting' ),
+	growth_consulting: __( 'Growth Consulting' ),
+	accessibility_consulting: __( 'Accessibility Consulting' ),
+	security_consulting: __( 'Security Consulting' ),
+	international_multilingual_consulting: __( 'International and Multilingual Consulting' ),
+	ai_powered_web_applications: __( 'AI-powered Web Applications' ),
+	headless_wordpress_and_woo: __( 'Headless WordPress & Woo' ),
+} );
+
+/**
+ * The Automattic products an agency can work with, keyed by the slug the API
+ * stores. Product names are brands, so they are not translated.
+ */
+export const getAvailableProducts = (): Record< string, string > => ( {
+	wordpress_com: 'WordPress.com',
+	woocommerce: 'WooCommerce',
+	jetpack: 'Jetpack',
+	wordpress_vip: 'WordPress VIP',
+	pressable: 'Pressable',
+} );
+
+/**
+ * The directories an agency can apply to. A subset of the known directories:
+ * VIP listings are managed by Automattic and can't be applied for.
+ */
+export const SELECTABLE_DIRECTORIES: AgencyPartnerDirectorySlug[] = [
+	'wordpress',
+	'woocommerce',
+	'jetpack',
+	'pressable',
+];

--- a/client/dashboard/agency/partner-directory/expertise/token-selector.tsx
+++ b/client/dashboard/agency/partner-directory/expertise/token-selector.tsx
@@ -9,7 +9,7 @@ interface TokenSelectorProps {
 	/** The selected option slugs. */
 	value: string[];
 	onChange: ( slugs: string[] ) => void;
-	/** Hides the suggestions once this many options are selected. */
+	/** Caps the selection at this many options and hides the suggestions once reached. */
 	maxItems?: number;
 }
 
@@ -42,12 +42,12 @@ export default function TokenSelector( {
 	);
 
 	const onLabelsChange = ( tokens: ( string | TokenItem )[] ) => {
-		onChange(
-			tokens.flatMap( ( token ) => {
-				const slug = slugsByLabel[ typeof token === 'string' ? token : token.value ];
-				return slug ? [ slug ] : [];
-			} )
-		);
+		const slugs = tokens.flatMap( ( token ) => {
+			const slug = slugsByLabel[ typeof token === 'string' ? token : token.value ];
+			return slug ? [ slug ] : [];
+		} );
+
+		onChange( maxItems === undefined ? slugs : slugs.slice( 0, maxItems ) );
 	};
 
 	const suggestions =
@@ -60,7 +60,9 @@ export default function TokenSelector( {
 			<FormTokenField
 				__experimentalAutoSelectFirstMatch
 				__experimentalExpandOnFocus
-				__experimentalValidateInput={ ( token ) => token in slugsByLabel }
+				__experimentalValidateInput={ ( token ) =>
+					token in slugsByLabel && ( maxItems === undefined || value.length < maxItems )
+				}
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 				help=""

--- a/client/dashboard/agency/partner-directory/expertise/token-selector.tsx
+++ b/client/dashboard/agency/partner-directory/expertise/token-selector.tsx
@@ -1,0 +1,74 @@
+import { FormTokenField } from '@wordpress/components';
+import { useEffect, useMemo, useRef } from 'react';
+import type { TokenItem } from '@wordpress/components/build-types/form-token-field/types';
+
+interface TokenSelectorProps {
+	label: string;
+	/** The selectable options: slug (stored value) → translated label (displayed). */
+	options: Record< string, string >;
+	/** The selected option slugs. */
+	value: string[];
+	onChange: ( slugs: string[] ) => void;
+	/** Hides the suggestions once this many options are selected. */
+	maxItems?: number;
+}
+
+/**
+ * A token field that displays option labels while storing their slugs.
+ * Only known options can be added.
+ */
+export default function TokenSelector( {
+	label,
+	options,
+	value,
+	onChange,
+	maxItems,
+}: TokenSelectorProps ) {
+	const containerRef = useRef< HTMLDivElement >( null );
+
+	// FormTokenField hardcodes autocomplete="off", which Chrome ignores.
+	useEffect( () => {
+		containerRef.current?.querySelector( 'input' )?.setAttribute( 'autocomplete', 'none' );
+	}, [] );
+
+	const slugsByLabel = useMemo(
+		() =>
+			Object.fromEntries( Object.entries( options ).map( ( [ slug, text ] ) => [ text, slug ] ) ),
+		[ options ]
+	);
+
+	const selectedLabels = value.flatMap( ( slug ) =>
+		options[ slug ] ? [ options[ slug ] ] : []
+	);
+
+	const onLabelsChange = ( tokens: ( string | TokenItem )[] ) => {
+		onChange(
+			tokens.flatMap( ( token ) => {
+				const slug = slugsByLabel[ typeof token === 'string' ? token : token.value ];
+				return slug ? [ slug ] : [];
+			} )
+		);
+	};
+
+	const suggestions =
+		maxItems !== undefined && value.length >= maxItems
+			? []
+			: Object.values( options ).sort( ( a, b ) => a.localeCompare( b ) );
+
+	return (
+		<div ref={ containerRef }>
+			<FormTokenField
+				__experimentalAutoSelectFirstMatch
+				__experimentalExpandOnFocus
+				__experimentalValidateInput={ ( token ) => token in slugsByLabel }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				help=""
+				label={ label }
+				onChange={ onLabelsChange }
+				suggestions={ suggestions }
+				value={ selectedLabels }
+			/>
+		</div>
+	);
+}

--- a/client/dashboard/agency/partner-directory/expertise/use-expertise-form-validation.ts
+++ b/client/dashboard/agency/partner-directory/expertise/use-expertise-form-validation.ts
@@ -1,0 +1,74 @@
+import { __ } from '@wordpress/i18n';
+import { useCallback, useState } from 'react';
+import { areUrlsUnique, isValidUrl } from '../lib';
+import type { ExpertiseFormData } from './use-expertise-form';
+
+export interface ExpertiseValidationState {
+	services?: string;
+	products?: string;
+	directories?: string;
+	clientSites?: string;
+	feedbackUrl?: string;
+}
+
+export default function useExpertiseFormValidation() {
+	const [ validationError, setValidationError ] = useState< ExpertiseValidationState >( {} );
+
+	const updateValidationError = useCallback(
+		( newState: ExpertiseValidationState ) =>
+			setValidationError( ( previous ) => ( { ...previous, ...newState } ) ),
+		[]
+	);
+
+	const validate = useCallback( ( payload: ExpertiseFormData ) => {
+		const newValidationError: ExpertiseValidationState = {};
+
+		if ( payload.services.length < 1 ) {
+			newValidationError.services = __( 'Services can’t be empty' );
+		}
+
+		if ( payload.products.length < 1 ) {
+			newValidationError.products = __( 'Products can’t be empty' );
+		}
+
+		if ( payload.directories.length < 1 ) {
+			newValidationError.directories = __( 'Directories can’t be empty' );
+		} else {
+			for ( const directory of payload.directories ) {
+				// Already-approved directories keep their reviewed URLs, so they
+				// aren't validated again.
+				if ( directory.status === 'approved' ) {
+					continue;
+				}
+
+				if ( directory.urls.length < 1 ) {
+					newValidationError.clientSites = __( 'Client sites can’t be empty' );
+					break;
+				}
+				if ( directory.urls.some( ( url ) => ! isValidUrl( url ) ) ) {
+					newValidationError.clientSites = __( 'Please provide valid URLs' );
+					break;
+				}
+				if ( ! areUrlsUnique( directory.urls ) ) {
+					newValidationError.clientSites = __( 'URLs should be unique' );
+					break;
+				}
+			}
+		}
+
+		if ( payload.feedbackUrl === '' ) {
+			newValidationError.feedbackUrl = __( 'Feedback URL can’t be empty' );
+		} else if ( ! isValidUrl( payload.feedbackUrl ) ) {
+			newValidationError.feedbackUrl = __( 'Please enter a valid URL' );
+		}
+
+		if ( Object.keys( newValidationError ).length > 0 ) {
+			setValidationError( newValidationError );
+			return newValidationError;
+		}
+
+		return null;
+	}, [] );
+
+	return { validate, validationError, updateValidationError };
+}

--- a/client/dashboard/agency/partner-directory/expertise/use-expertise-form-validation.ts
+++ b/client/dashboard/agency/partner-directory/expertise/use-expertise-form-validation.ts
@@ -1,6 +1,7 @@
-import { __ } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 import { useCallback, useState } from 'react';
 import { areUrlsUnique, isValidUrl } from '../lib';
+import { CLIENT_SITE_URLS_COUNT } from './use-expertise-form';
 import type { ExpertiseFormData } from './use-expertise-form';
 
 export interface ExpertiseValidationState {
@@ -41,8 +42,12 @@ export default function useExpertiseFormValidation() {
 					continue;
 				}
 
-				if ( directory.urls.length < 1 ) {
-					newValidationError.clientSites = __( 'Client sites can’t be empty' );
+				if ( directory.urls.length < CLIENT_SITE_URLS_COUNT ) {
+					newValidationError.clientSites = sprintf(
+						/* translators: %d is the number of client site URLs required per directory */
+						__( 'Please provide %d client site URLs for each directory' ),
+						CLIENT_SITE_URLS_COUNT
+					);
 					break;
 				}
 				if ( directory.urls.some( ( url ) => ! isValidUrl( url ) ) ) {

--- a/client/dashboard/agency/partner-directory/expertise/use-expertise-form.ts
+++ b/client/dashboard/agency/partner-directory/expertise/use-expertise-form.ts
@@ -5,6 +5,9 @@ import type {
 	AgencyProfile,
 } from '@automattic/api-core';
 
+/** The number of client site URLs required for each directory applied to. */
+export const CLIENT_SITE_URLS_COUNT = 5;
+
 export interface ExpertiseDirectoryEntry {
 	directory: AgencyPartnerDirectorySlug;
 	urls: string[];
@@ -39,7 +42,13 @@ export function getExpertiseFormData( profile?: AgencyProfile | null ): Expertis
 				status,
 				directory,
 				isPublished: is_published,
-				urls,
+				// Pad short URL lists so pending directories always render — and
+				// require — the full set of client site fields. Approved
+				// directories keep their reviewed URLs untouched.
+				urls:
+					status === 'approved' || urls.length >= CLIENT_SITE_URLS_COUNT
+						? urls
+						: [ ...urls, ...Array( CLIENT_SITE_URLS_COUNT - urls.length ).fill( '' ) ],
 				note,
 			} )
 		),
@@ -88,7 +97,7 @@ export default function useExpertiseForm( {
 								status: 'pending' as const,
 								directory: name,
 								isPublished: false,
-								urls: [ '', '', '', '', '' ],
+								urls: Array( CLIENT_SITE_URLS_COUNT ).fill( '' ),
 								note: '',
 							},
 						],

--- a/client/dashboard/agency/partner-directory/expertise/use-expertise-form.ts
+++ b/client/dashboard/agency/partner-directory/expertise/use-expertise-form.ts
@@ -1,0 +1,134 @@
+import { useCallback, useState } from 'react';
+import type {
+	AgencyPartnerDirectoryEntryStatus,
+	AgencyPartnerDirectorySlug,
+	AgencyProfile,
+} from '@automattic/api-core';
+
+export interface ExpertiseDirectoryEntry {
+	directory: AgencyPartnerDirectorySlug;
+	urls: string[];
+	note?: string;
+	status?: AgencyPartnerDirectoryEntryStatus;
+	isPublished?: boolean;
+}
+
+export interface ExpertiseFormData {
+	services: string[];
+	products: string[];
+	directories: ExpertiseDirectoryEntry[];
+	feedbackUrl: string;
+	isPublished?: boolean;
+}
+
+/**
+ * The agency's submitted application as expertise form data, or null when no
+ * application was submitted yet.
+ */
+export function getExpertiseFormData( profile?: AgencyProfile | null ): ExpertiseFormData | null {
+	const application = profile?.partner_directory_application;
+	if ( ! profile || ! application ) {
+		return null;
+	}
+
+	return {
+		services: profile.listing_details.services ?? [],
+		products: profile.listing_details.products ?? [],
+		directories: application.directories.map(
+			( { status, directory, is_published, urls, note } ) => ( {
+				status,
+				directory,
+				isPublished: is_published,
+				urls,
+				note,
+			} )
+		),
+		feedbackUrl: application.feedback_url,
+		isPublished: !! application.is_published,
+	};
+}
+
+export default function useExpertiseForm( {
+	initialFormData,
+}: {
+	initialFormData: ExpertiseFormData | null;
+} ) {
+	const [ formData, setFormData ] = useState< ExpertiseFormData >(
+		initialFormData ?? {
+			services: [],
+			products: [],
+			directories: [],
+			feedbackUrl: '',
+		}
+	);
+
+	const isDirectorySelected = useCallback(
+		( name: AgencyPartnerDirectorySlug ) =>
+			formData.directories.some( ( { directory } ) => directory === name ),
+		[ formData ]
+	);
+
+	const isDirectoryApproved = useCallback(
+		( name: AgencyPartnerDirectorySlug ) =>
+			formData.directories.some(
+				( { directory, status } ) => directory === name && status === 'approved'
+			),
+		[ formData ]
+	);
+
+	const setDirectorySelected = useCallback(
+		( name: AgencyPartnerDirectorySlug, selected: boolean ) => {
+			setFormData( ( state ) => {
+				if ( selected ) {
+					return {
+						...state,
+						directories: [
+							...state.directories,
+							{
+								status: 'pending' as const,
+								directory: name,
+								isPublished: false,
+								urls: [ '', '', '', '', '' ],
+								note: '',
+							},
+						],
+					};
+				}
+
+				return {
+					...state,
+					directories: state.directories.filter( ( { directory } ) => directory !== name ),
+				};
+			} );
+		},
+		[]
+	);
+
+	const getDirectoryClientSamples = useCallback(
+		( name: AgencyPartnerDirectorySlug ) =>
+			formData.directories.find( ( { directory } ) => directory === name )?.urls ?? [],
+		[ formData.directories ]
+	);
+
+	const setDirectoryClientSamples = useCallback(
+		( name: AgencyPartnerDirectorySlug, urls: string[] ) => {
+			setFormData( ( state ) => ( {
+				...state,
+				directories: state.directories.map( ( entry ) =>
+					entry.directory === name ? { ...entry, urls } : entry
+				),
+			} ) );
+		},
+		[]
+	);
+
+	return {
+		formData,
+		setFormData,
+		isDirectorySelected,
+		isDirectoryApproved,
+		setDirectorySelected,
+		getDirectoryClientSamples,
+		setDirectoryClientSamples,
+	};
+}

--- a/client/dashboard/agency/partner-directory/lib.ts
+++ b/client/dashboard/agency/partner-directory/lib.ts
@@ -42,11 +42,15 @@ export function getDirectoryStatusBadge(
 	}
 }
 
-function isValidUrl( url: string ): boolean {
+export function isValidUrl( url: string ): boolean {
 	return (
 		url.length > 3 &&
 		/^(https?:\/\/)?([a-z0-9-]+\.)+[a-z]{2,}(:[0-9]{1,5})?(\/[^\s]*)?$/i.test( url )
 	);
+}
+
+export function areUrlsUnique( urls: string[] ): boolean {
+	return new Set( urls ).size === urls.length;
 }
 
 /**

--- a/client/dashboard/agency/partner-directory/link-button.tsx
+++ b/client/dashboard/agency/partner-directory/link-button.tsx
@@ -1,0 +1,55 @@
+import { Button } from '@wordpress/components';
+import RouterLinkButton from '../../components/router-link-button';
+import type { ComponentProps, ReactNode } from 'react';
+
+interface LinkButtonProps {
+	href: string;
+	children: ReactNode;
+	variant?: ComponentProps< typeof Button >[ 'variant' ];
+	size?: ComponentProps< typeof Button >[ 'size' ];
+	disabled?: boolean;
+	onClick?: React.MouseEventHandler< HTMLAnchorElement >;
+	/**
+	 * Set to false in apps without the dashboard's TanStack Router, so the button
+	 * renders a plain anchor for the host app's own router to pick up.
+	 */
+	shouldUseRouterLink?: boolean;
+}
+
+/**
+ * A link-shaped button shared by the dashboard and the classic A4A app.
+ * Dashboard-internal paths render as router links; absolute URLs (screens not
+ * migrated to the dashboard yet) always render as plain anchors.
+ */
+export default function LinkButton( {
+	href,
+	children,
+	variant,
+	size,
+	disabled,
+	onClick,
+	shouldUseRouterLink = true,
+}: LinkButtonProps ) {
+	// Anchors can't be disabled, so a disabled link renders as a plain button.
+	if ( disabled ) {
+		return (
+			<Button variant={ variant } size={ size } disabled accessibleWhenDisabled>
+				{ children }
+			</Button>
+		);
+	}
+
+	if ( shouldUseRouterLink && href.startsWith( '/' ) ) {
+		return (
+			<RouterLinkButton to={ href } variant={ variant } size={ size } onClick={ onClick }>
+				{ children }
+			</RouterLinkButton>
+		);
+	}
+
+	return (
+		<Button href={ href } variant={ variant } size={ size } onClick={ onClick }>
+			{ children }
+		</Button>
+	);
+}


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/113460.

Part of A4A-3190.

## Proposed Changes

* Add the building blocks for the upcoming “Share your expertise” screen in the new agencies dashboard: the form state and validation logic, the selector used to pick services and products, the option lists, URL helpers, and a link button that navigates in place in the dashboard and as a plain link in the classic app.
* No user-facing changes — these pieces are unused until the follow-up PR adds the screen itself.

## Why are these changes being made?

* The Partner Directory expertise screen is being ported to the new agencies dashboard, following the same steps as the Partner Directory dashboard port. Landing the shared pieces first keeps each PR in the stack small and reviewable.

## Testing Instructions

* No user-facing changes. The pieces are exercised by the tests added with the screen in the follow-up PR.
* CI type checks and unit tests should pass.

<img width="1920" height="963" alt="Screenshot 2026-08-14 at 9 52 39 AM" src="https://github.com/user-attachments/assets/72af364b-48ba-4df0-8f1f-f93464a03521" />

<img width="339" height="282" alt="Screenshot 2026-08-27 at 11 42 53 AM" src="https://github.com/user-attachments/assets/1306e0b6-2595-4e45-aea6-5f4b1c2327b4" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
