### PR TITLE
A4A MSD: Add the Partner Directory expertise screen

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -77,6 +77,7 @@ const PartnerDirectoryDashboard = () => {
 			onPublishSuccess={ onPublishSuccess }
 			onPublishError={ onPublishError }
 			openSupportGuide={ showSupportGuide }
+			shouldUseRouterLink={ false }
 		/>
 	);
 };

--- a/client/dashboard/agency/partner-directory/dashboard-content.tsx
+++ b/client/dashboard/agency/partner-directory/dashboard-content.tsx
@@ -21,6 +21,7 @@ import {
 	isAgencyProfileComplete,
 	isApplicationCompleted,
 } from './lib';
+import LinkButton from './link-button';
 import StatusBadge from './status-badge';
 import type { DirectoryStatusBadge } from './lib';
 import type { Agency, AgencyPartnerDirectorySlug, AgencyProfile } from '@automattic/api-core';
@@ -54,6 +55,11 @@ interface Props {
 	onPublishSuccess?: ( agency: Agency ) => void;
 	onPublishError?: () => void;
 	openSupportGuide?: ( url: string ) => void;
+	/**
+	 * Set to false in apps without the dashboard's TanStack Router, so link
+	 * buttons render plain anchors for the host app's own router to pick up.
+	 */
+	shouldUseRouterLink?: boolean;
 }
 
 /*
@@ -71,6 +77,7 @@ export default function PartnerDirectoryDashboardContent( {
 	onPublishSuccess,
 	onPublishError,
 	openSupportGuide,
+	shouldUseRouterLink,
 }: Props ) {
 	const profile = agency.profile;
 	const application = profile?.partner_directory_application;
@@ -170,6 +177,7 @@ export default function PartnerDirectoryDashboardContent( {
 						showPopoverOnLoad={ showPopoverOnLoad }
 						expertiseUrl={ expertiseUrl }
 						recordTracksEvent={ recordTracksEvent }
+						shouldUseRouterLink={ shouldUseRouterLink }
 					/>
 					<Text>{ DIRECTORY_NAMES[ directory ] }</Text>
 				</HStack>
@@ -225,6 +233,7 @@ export default function PartnerDirectoryDashboardContent( {
 														showPopoverOnLoad={ false }
 														expertiseUrl={ expertiseUrl }
 														recordTracksEvent={ recordTracksEvent }
+														shouldUseRouterLink={ shouldUseRouterLink }
 													/>
 													{ badge.key === 'approved' && ! brandMeta.isAvailable && (
 														<Text>{ __( 'This Partner Directory is launching soon.' ) }</Text>
@@ -246,12 +255,22 @@ export default function PartnerDirectoryDashboardContent( {
 					) }
 					actions={
 						<>
-							<Button variant="secondary" href={ expertiseUrl } onClick={ onEditExpertiseClick }>
+							<LinkButton
+								variant="secondary"
+								href={ expertiseUrl }
+								onClick={ onEditExpertiseClick }
+								shouldUseRouterLink={ shouldUseRouterLink }
+							>
 								{ __( 'Edit expertise' ) }
-							</Button>
-							<Button variant="secondary" href={ profileUrl } onClick={ onEditProfileClick }>
+							</LinkButton>
+							<LinkButton
+								variant="secondary"
+								href={ profileUrl }
+								onClick={ onEditProfileClick }
+								shouldUseRouterLink={ shouldUseRouterLink }
+							>
 								{ __( 'Edit profile' ) }
-							</Button>
+							</LinkButton>
 						</>
 					}
 				/>
@@ -285,13 +304,14 @@ export default function PartnerDirectoryDashboardContent( {
 								  )
 						}
 						actions={
-							<Button
+							<LinkButton
 								variant={ applicationWasSubmitted ? 'secondary' : 'primary' }
 								href={ expertiseUrl }
 								onClick={ applicationWasSubmitted ? onEditExpertiseClick : onApplyNowClick }
+								shouldUseRouterLink={ shouldUseRouterLink }
 							>
 								{ applicationWasSubmitted ? __( 'Edit expertise' ) : __( 'Apply now' ) }
-							</Button>
+							</LinkButton>
 						}
 					/>
 				</ActionList>
@@ -303,7 +323,7 @@ export default function PartnerDirectoryDashboardContent( {
 							'When approved, add details to your agency’s public profile for clients to see.'
 						) }
 						actions={
-							<Button
+							<LinkButton
 								variant={
 									applicationWasSubmitted && hasDirectoryApproval && ! isProfileComplete
 										? 'primary'
@@ -312,9 +332,10 @@ export default function PartnerDirectoryDashboardContent( {
 								href={ profileUrl }
 								onClick={ onFinishProfileClick }
 								disabled={ ! applicationWasSubmitted || ! hasDirectoryApproval }
+								shouldUseRouterLink={ shouldUseRouterLink }
 							>
 								{ isProfileComplete ? __( 'Edit profile' ) : __( 'Finish profile' ) }
-							</Button>
+							</LinkButton>
 						}
 					/>
 				</ActionList>

--- a/client/dashboard/agency/partner-directory/expertise/expertise-content.tsx
+++ b/client/dashboard/agency/partner-directory/expertise/expertise-content.tsx
@@ -294,6 +294,9 @@ export default function PartnerDirectoryExpertiseContent( {
 					variant="tertiary"
 					disabled={ isSubmitting }
 					shouldUseRouterLink={ shouldUseRouterLink }
+					onClick={ () =>
+						recordTracksEvent( 'calypso_a4a_partner_directory_expertise_cancel_click' )
+					}
 				>
 					{ __( 'Cancel' ) }
 				</LinkButton>

--- a/client/dashboard/agency/partner-directory/expertise/expertise-content.tsx
+++ b/client/dashboard/agency/partner-directory/expertise/expertise-content.tsx
@@ -1,0 +1,303 @@
+import { agencyPartnerDirectoryApplicationMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import {
+	Button,
+	CheckboxControl,
+	TextControl,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { sprintf, __ } from '@wordpress/i18n';
+import { useRef } from 'react';
+import { withSnackbar } from '../../../app/snackbars/with-snackbar';
+import { ButtonStack } from '../../../components/button-stack';
+import { Card, CardBody } from '../../../components/card';
+import { SectionHeader } from '../../../components/section-header';
+import { Text } from '../../../components/text';
+import { DIRECTORY_NAMES } from '../lib';
+import LinkButton from '../link-button';
+import { getAvailableProducts, getAvailableServices, SELECTABLE_DIRECTORIES } from './options';
+import TokenSelector from './token-selector';
+import useExpertiseForm, { getExpertiseFormData } from './use-expertise-form';
+import useExpertiseFormValidation from './use-expertise-form-validation';
+import type { Agency, AgencyProfile } from '@automattic/api-core';
+
+import './style.scss';
+
+/**
+ * The minimal agency shape the expertise form needs. Kept structural so both
+ * the dashboard (`@automattic/api-core` agency) and the A4A client (Redux
+ * agency) can provide it.
+ */
+interface PartnerDirectoryExpertiseAgency {
+	id: number;
+	profile?: AgencyProfile | null;
+}
+
+interface Props {
+	agency: PartnerDirectoryExpertiseAgency;
+	recordTracksEvent: ( eventName: string, properties?: Record< string, unknown > ) => void;
+	/** Where the Cancel button and the not-submitted state lead back to. */
+	dashboardUrl: string;
+	onSubmitSuccess?: ( agency: Agency ) => void;
+	onSubmitError?: () => void;
+	shouldUseRouterLink?: boolean;
+}
+
+/*
+ * Shared by the dashboard snackbar and the classic app's notices so the two
+ * hosts can't drift apart.
+ */
+export const getApplicationSubmittedMessage = () => __( 'Application submitted.' );
+export const getApplicationSubmitFailedMessage = () => __( 'Failed to submit your application.' );
+
+export default function PartnerDirectoryExpertiseContent( {
+	agency,
+	recordTracksEvent,
+	dashboardUrl,
+	onSubmitSuccess,
+	onSubmitError,
+	shouldUseRouterLink,
+}: Props ) {
+	const initialFormData = getExpertiseFormData( agency.profile );
+	const hasApplication = initialFormData !== null;
+
+	const {
+		formData,
+		setFormData,
+		isDirectorySelected,
+		isDirectoryApproved,
+		setDirectorySelected,
+		getDirectoryClientSamples,
+		setDirectoryClientSamples,
+	} = useExpertiseForm( { initialFormData } );
+	const { validate, validationError, updateValidationError } = useExpertiseFormValidation();
+
+	const { mutate: submitApplication, isPending: isSubmitting } = useMutation(
+		withSnackbar( agencyPartnerDirectoryApplicationMutation( agency.id ), {
+			success: getApplicationSubmittedMessage(),
+			error: getApplicationSubmitFailedMessage(),
+		} )
+	);
+
+	const contentRef = useRef< HTMLDivElement >( null );
+
+	const availableServices = getAvailableServices();
+	const availableProducts = getAvailableProducts();
+
+	const submitForm = () => {
+		recordTracksEvent( 'calypso_a4a_partner_directory_expertise_submit_click', {
+			is_update: hasApplication,
+		} );
+
+		const error = validate( formData );
+		if ( error ) {
+			// The services and products fields sit above the fold; bring them
+			// back into view so their errors aren't missed.
+			if ( error.services || error.products ) {
+				contentRef.current?.scrollIntoView( { behavior: 'smooth' } );
+			}
+			return;
+		}
+
+		submitApplication(
+			{
+				services: formData.services,
+				products: formData.products,
+				directories: formData.directories.map( ( { directory, urls, note } ) => ( {
+					directory,
+					urls,
+					note,
+				} ) ),
+				feedback_url: formData.feedbackUrl,
+				is_published: formData.isPublished,
+			},
+			{
+				onSuccess: ( updatedAgency ) => onSubmitSuccess?.( updatedAgency ),
+				onError: () => onSubmitError?.(),
+			}
+		);
+	};
+
+	const pendingDirectories = formData.directories.filter( ( { status } ) => status !== 'approved' );
+
+	return (
+		<VStack ref={ contentRef } spacing={ 8 }>
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<SectionHeader level={ 3 } title={ __( 'Product and service' ) } />
+
+						<VStack spacing={ 2 }>
+							<TokenSelector
+								label={ __( 'What services do you offer?' ) }
+								options={ availableServices }
+								value={ formData.services }
+								maxItems={ 5 }
+								onChange={ ( services ) => {
+									setFormData( ( state ) => ( { ...state, services } ) );
+									updateValidationError( { services: undefined } );
+								} }
+							/>
+							{ validationError.services && (
+								<Text intent="error">{ validationError.services }</Text>
+							) }
+							<Text variant="muted">
+								{ __(
+									'We allow each agency to offer up to five services to help you focus on what you do best.'
+								) }
+							</Text>
+						</VStack>
+
+						<VStack spacing={ 2 }>
+							<TokenSelector
+								label={ __( 'What products do you work with?' ) }
+								options={ availableProducts }
+								value={ formData.products }
+								onChange={ ( products ) => {
+									setFormData( ( state ) => ( { ...state, products } ) );
+									updateValidationError( { products: undefined } );
+								} }
+							/>
+							{ validationError.products && (
+								<Text intent="error">{ validationError.products }</Text>
+							) }
+						</VStack>
+					</VStack>
+				</CardBody>
+			</Card>
+
+			<Card>
+				<CardBody>
+					<VStack spacing={ 6 }>
+						<SectionHeader level={ 3 } title={ __( 'Partner Directories' ) } />
+
+						<VStack spacing={ 3 }>
+							<VStack spacing={ 1 }>
+								<Text weight={ 500 }>{ __( 'Automattic Partner Directories' ) }</Text>
+								<Text variant="muted">
+									{ __( 'Select the Automattic directories you would like to appear on.' ) }
+								</Text>
+							</VStack>
+							<VStack spacing={ 2 }>
+								{ SELECTABLE_DIRECTORIES.map( ( directory ) => (
+									<CheckboxControl
+										key={ directory }
+										__nextHasNoMarginBottom
+										label={ DIRECTORY_NAMES[ directory ] }
+										checked={ isDirectorySelected( directory ) }
+										disabled={ isDirectoryApproved( directory ) }
+										onChange={ ( checked ) => {
+											setDirectorySelected( directory, checked );
+											updateValidationError( { directories: undefined, clientSites: undefined } );
+										} }
+									/>
+								) ) }
+							</VStack>
+							{ validationError.directories && (
+								<Text intent="error">{ validationError.directories }</Text>
+							) }
+						</VStack>
+
+						{ pendingDirectories.length > 0 && (
+							<VStack spacing={ 4 }>
+								<VStack spacing={ 1 }>
+									<Text weight={ 500 }>{ __( 'Client sites' ) }</Text>
+									<Text variant="muted">
+										{ __(
+											'For each directory you selected, provide URLs of 5 client sites you’ve worked on. This helps us gauge your expertise.'
+										) }
+									</Text>
+								</VStack>
+								<div className="partner-directory-expertise__client-sites">
+									{ pendingDirectories.map( ( { directory } ) => {
+										const samples = getDirectoryClientSamples( directory );
+
+										return (
+											<VStack spacing={ 2 } key={ directory }>
+												<Text weight={ 500 }>
+													{ sprintf(
+														/* translators: %s is the directory name, e.g. "WordPress.com" */
+														__( 'Relevant examples for %s' ),
+														DIRECTORY_NAMES[ directory ]
+													) }
+												</Text>
+												{ samples.map( ( sample, index ) => (
+													<TextControl
+														key={ `${ directory }-sample-${ index }` }
+														__next40pxDefaultSize
+														__nextHasNoMarginBottom
+														type="text"
+														placeholder={ __( 'Enter URL' ) }
+														aria-label={ sprintf(
+															/* translators: %1$d is a number from 1 to 5, %2$s is the directory name, e.g. "WordPress.com" */
+															__( 'Client site %1$d for %2$s' ),
+															index + 1,
+															DIRECTORY_NAMES[ directory ]
+														) }
+														value={ sample }
+														onChange={ ( value ) => {
+															setDirectoryClientSamples(
+																directory,
+																samples.map( ( url, i ) => ( i === index ? value : url ) )
+															);
+															updateValidationError( { clientSites: undefined } );
+														} }
+													/>
+												) ) }
+											</VStack>
+										);
+									} ) }
+								</div>
+								{ validationError.clientSites && (
+									<Text intent="error">{ validationError.clientSites }</Text>
+								) }
+							</VStack>
+						) }
+
+						<VStack spacing={ 2 }>
+							<TextControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								type="text"
+								label={ __( 'Share customer feedback' ) }
+								placeholder={ __( 'Enter URL' ) }
+								value={ formData.feedbackUrl }
+								onChange={ ( feedbackUrl ) => {
+									setFormData( ( state ) => ( { ...state, feedbackUrl } ) );
+									updateValidationError( { feedbackUrl: undefined } );
+								} }
+							/>
+							{ validationError.feedbackUrl && (
+								<Text intent="error">{ validationError.feedbackUrl }</Text>
+							) }
+							<Text variant="muted">
+								{ __(
+									'Share a link to your customer feedback from Google, Clutch, Facebook, etc., or testimonials featured on your website. If you don’t have online reviews, provide a link to client references or case studies.'
+								) }
+							</Text>
+						</VStack>
+					</VStack>
+				</CardBody>
+			</Card>
+
+			<ButtonStack justify="flex-start">
+				<Button
+					variant="primary"
+					onClick={ submitForm }
+					isBusy={ isSubmitting }
+					disabled={ isSubmitting }
+				>
+					{ hasApplication ? __( 'Update my expertise' ) : __( 'Submit my application' ) }
+				</Button>
+				<LinkButton
+					href={ dashboardUrl }
+					variant="tertiary"
+					disabled={ isSubmitting }
+					shouldUseRouterLink={ shouldUseRouterLink }
+				>
+					{ __( 'Cancel' ) }
+				</LinkButton>
+			</ButtonStack>
+		</VStack>
+	);
+}

--- a/client/dashboard/agency/partner-directory/expertise/expertise-content.tsx
+++ b/client/dashboard/agency/partner-directory/expertise/expertise-content.tsx
@@ -1,6 +1,7 @@
 import { agencyPartnerDirectoryApplicationMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import {
+	BaseControl,
 	Button,
 	CheckboxControl,
 	TextControl,
@@ -173,7 +174,9 @@ export default function PartnerDirectoryExpertiseContent( {
 
 						<VStack spacing={ 3 }>
 							<VStack spacing={ 1 }>
-								<Text weight={ 500 }>{ __( 'Automattic Partner Directories' ) }</Text>
+								<BaseControl.VisualLabel style={ { marginBottom: 0 } }>
+									{ __( 'Automattic Partner Directories' ) }
+								</BaseControl.VisualLabel>
 								<Text variant="muted">
 									{ __( 'Select the Automattic directories you would like to appear on.' ) }
 								</Text>
@@ -201,7 +204,9 @@ export default function PartnerDirectoryExpertiseContent( {
 						{ pendingDirectories.length > 0 && (
 							<VStack spacing={ 4 }>
 								<VStack spacing={ 1 }>
-									<Text weight={ 500 }>{ __( 'Client sites' ) }</Text>
+									<BaseControl.VisualLabel style={ { marginBottom: 0 } }>
+										{ __( 'Client sites' ) }
+									</BaseControl.VisualLabel>
 									<Text variant="muted">
 										{ __(
 											'For each directory you selected, provide URLs of 5 client sites you’ve worked on. This helps us gauge your expertise.'

--- a/client/dashboard/agency/partner-directory/expertise/index.tsx
+++ b/client/dashboard/agency/partner-directory/expertise/index.tsx
@@ -1,0 +1,39 @@
+import { activeAgencyQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
+import { useAnalytics } from '../../../app/analytics';
+import Breadcrumbs from '../../../app/breadcrumbs';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+import PartnerDirectoryExpertiseContent from './expertise-content';
+
+const DASHBOARD_URL = '/agency/partner-directory';
+
+export default function AgencyPartnerDirectoryExpertise() {
+	const { data: agency } = useQuery( activeAgencyQuery() );
+	const { recordTracksEvent } = useAnalytics();
+	const navigate = useNavigate();
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
+					title={ __( 'Share your expertise' ) }
+					description={ __( 'Pick your agency’s specialties and choose your directories.' ) }
+				/>
+			}
+		>
+			{ agency && (
+				<PartnerDirectoryExpertiseContent
+					agency={ agency }
+					recordTracksEvent={ recordTracksEvent }
+					dashboardUrl={ DASHBOARD_URL }
+					onSubmitSuccess={ () => navigate( { to: DASHBOARD_URL } ) }
+				/>
+			) }
+		</PageLayout>
+	);
+}

--- a/client/dashboard/agency/partner-directory/expertise/index.tsx
+++ b/client/dashboard/agency/partner-directory/expertise/index.tsx
@@ -6,9 +6,8 @@ import { useAnalytics } from '../../../app/analytics';
 import Breadcrumbs from '../../../app/breadcrumbs';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
+import { PARTNER_DIRECTORY_ROUTE } from '../paths';
 import PartnerDirectoryExpertiseContent from './expertise-content';
-
-const DASHBOARD_URL = '/agency/partner-directory';
 
 export default function AgencyPartnerDirectoryExpertise() {
 	const { data: agency } = useQuery( activeAgencyQuery() );
@@ -30,8 +29,8 @@ export default function AgencyPartnerDirectoryExpertise() {
 				<PartnerDirectoryExpertiseContent
 					agency={ agency }
 					recordTracksEvent={ recordTracksEvent }
-					dashboardUrl={ DASHBOARD_URL }
-					onSubmitSuccess={ () => navigate( { to: DASHBOARD_URL } ) }
+					dashboardUrl={ PARTNER_DIRECTORY_ROUTE }
+					onSubmitSuccess={ () => navigate( { to: PARTNER_DIRECTORY_ROUTE } ) }
 				/>
 			) }
 		</PageLayout>

--- a/client/dashboard/agency/partner-directory/expertise/style.scss
+++ b/client/dashboard/agency/partner-directory/expertise/style.scss
@@ -1,0 +1,12 @@
+@import "@wordpress/base-styles/breakpoints";
+
+.partner-directory-expertise__client-sites {
+	display: grid;
+	grid-template-columns: 1fr;
+	row-gap: 16px;
+
+	@media ( min-width: #{ $break-medium } ) {
+		grid-template-columns: 1fr 1fr;
+		column-gap: 32px;
+	}
+}

--- a/client/dashboard/agency/partner-directory/index.tsx
+++ b/client/dashboard/agency/partner-directory/index.tsx
@@ -8,13 +8,14 @@ import PageLayout from '../../components/page-layout';
 import { a4aLink } from '../../utils/link';
 import PartnerDirectoryDashboardContent from './dashboard-content';
 
+const EXPERTISE_URL = '/agency/partner-directory/expertise';
+
 /*
- * TODO: The expertise, profile, and lead matching screens are not migrated to
- * the dashboard yet, so these link to the classic A4A app — and lead matching
- * is not reachable from here at all until it migrates. Switch to dashboard
+ * TODO: The profile and lead matching screens are not migrated to the
+ * dashboard yet, so this links to the classic A4A app — and lead matching is
+ * not reachable from here at all until it migrates. Switch to dashboard
  * routes once those screens are migrated.
  */
-const EXPERTISE_URL = a4aLink( '/partner-directory/agency-expertise' );
 const PROFILE_URL = a4aLink( '/partner-directory/agency-details' );
 
 export default function AgencyPartnerDirectory() {

--- a/client/dashboard/agency/partner-directory/index.tsx
+++ b/client/dashboard/agency/partner-directory/index.tsx
@@ -7,8 +7,7 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { a4aLink } from '../../utils/link';
 import PartnerDirectoryDashboardContent from './dashboard-content';
-
-const EXPERTISE_URL = '/agency/partner-directory/expertise';
+import { PARTNER_DIRECTORY_EXPERTISE_ROUTE } from './paths';
 
 /*
  * TODO: The profile and lead matching screens are not migrated to the
@@ -34,7 +33,7 @@ export default function AgencyPartnerDirectory() {
 				<PartnerDirectoryDashboardContent
 					agency={ agency }
 					recordTracksEvent={ recordTracksEvent }
-					expertiseUrl={ EXPERTISE_URL }
+					expertiseUrl={ PARTNER_DIRECTORY_EXPERTISE_ROUTE }
 					profileUrl={ PROFILE_URL }
 					openSupportGuide={ openSupportGuide }
 				/>

--- a/client/dashboard/agency/partner-directory/not-approved-popover.tsx
+++ b/client/dashboard/agency/partner-directory/not-approved-popover.tsx
@@ -14,6 +14,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useEffect, useRef, useState } from 'react';
 import { CardBody } from '../../components/card';
+import LinkButton from './link-button';
 import type { UserPreferences } from '@automattic/api-core';
 import type { ReactNode } from 'react';
 
@@ -24,6 +25,7 @@ interface Props {
 	showOnLoad: boolean;
 	expertiseUrl: string;
 	recordTracksEvent: ( eventName: string, properties?: Record< string, unknown > ) => void;
+	shouldUseRouterLink?: boolean;
 }
 
 /**
@@ -36,6 +38,7 @@ export default function NotApprovedPopover( {
 	showOnLoad,
 	expertiseUrl,
 	recordTracksEvent,
+	shouldUseRouterLink,
 }: Props ) {
 	const [ anchor, setAnchor ] = useState< HTMLElement | null >( null );
 	const [ showPopover, setShowPopover ] = useState( false );
@@ -134,7 +137,7 @@ export default function NotApprovedPopover( {
 								) }
 							</Text>
 							<HStack spacing={ 3 } justify="flex-start">
-								<Button
+								<LinkButton
 									variant="primary"
 									size="compact"
 									href={ expertiseUrl }
@@ -143,9 +146,10 @@ export default function NotApprovedPopover( {
 											'calypso_a4a_partner_directory_dashboard_update_expertise_click'
 										)
 									}
+									shouldUseRouterLink={ shouldUseRouterLink }
 								>
 									{ __( 'Update my expertise' ) }
-								</Button>
+								</LinkButton>
 								{ ! popoverDismissed && (
 									<Button
 										variant="secondary"

--- a/client/dashboard/agency/partner-directory/paths.ts
+++ b/client/dashboard/agency/partner-directory/paths.ts
@@ -1,0 +1,8 @@
+/*
+ * Partner Directory route paths, shared by the router and the screens that
+ * link to them so the two can't drift apart.
+ */
+export const PARTNER_DIRECTORY_ROUTE = '/agency/partner-directory';
+
+export const PARTNER_DIRECTORY_EXPERTISE_SEGMENT = 'expertise';
+export const PARTNER_DIRECTORY_EXPERTISE_ROUTE = `${ PARTNER_DIRECTORY_ROUTE }/${ PARTNER_DIRECTORY_EXPERTISE_SEGMENT }`;

--- a/client/dashboard/agency/partner-directory/status-badge.tsx
+++ b/client/dashboard/agency/partner-directory/status-badge.tsx
@@ -7,6 +7,7 @@ interface Props {
 	showPopoverOnLoad: boolean;
 	expertiseUrl: string;
 	recordTracksEvent: ( eventName: string, properties?: Record< string, unknown > ) => void;
+	shouldUseRouterLink?: boolean;
 }
 
 /**
@@ -18,6 +19,7 @@ export default function StatusBadge( {
 	showPopoverOnLoad,
 	expertiseUrl,
 	recordTracksEvent,
+	shouldUseRouterLink,
 }: Props ) {
 	if ( badge.key !== 'rejected' ) {
 		return <Badge intent={ badge.intent }>{ badge.label }</Badge>;
@@ -28,6 +30,7 @@ export default function StatusBadge( {
 			showOnLoad={ showPopoverOnLoad }
 			expertiseUrl={ expertiseUrl }
 			recordTracksEvent={ recordTracksEvent }
+			shouldUseRouterLink={ shouldUseRouterLink }
 		>
 			<Badge intent={ badge.intent }>{ badge.label }</Badge>
 		</NotApprovedPopover>

--- a/client/dashboard/agency/partner-directory/test/expertise.test.tsx
+++ b/client/dashboard/agency/partner-directory/test/expertise.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import AgencyPartnerDirectoryExpertise from '../expertise';
+import PartnerDirectoryExpertiseContent from '../expertise/expertise-content';
+import type { AgencyPartnerDirectoryApplication, AgencyProfile } from '@automattic/api-core';
+
+const API = 'https://public-api.wordpress.com';
+
+function makeProfile(
+	application: AgencyPartnerDirectoryApplication | null = null
+): AgencyProfile {
+	return {
+		company_details: {
+			name: 'Test Agency',
+			email: 'test@example.com',
+			website: 'https://example.com',
+			bio_description: 'We build sites.',
+			logo_url: '',
+			landing_page_url: '',
+			country: 'US',
+		},
+		listing_details: {
+			is_available: true,
+			is_global: false,
+			industries: [ 'technology_and_it_services' ],
+			services: [ 'seo' ],
+			products: [ 'wordpress_com' ],
+			languages_spoken: [ 'en' ],
+		},
+		budget_details: {
+			budget_lower_range: '0',
+			budget_upper_range: '',
+			has_hourly_rate: false,
+			hourly_rate_value: '',
+		},
+		partner_directory_application: application,
+	};
+}
+
+function makeApplication(): AgencyPartnerDirectoryApplication {
+	return {
+		status: 'in-progress',
+		directories: [
+			{
+				status: 'approved',
+				directory: 'wordpress',
+				urls: [
+					'https://one.example.com',
+					'https://two.example.com',
+					'https://three.example.com',
+					'https://four.example.com',
+					'https://five.example.com',
+				],
+				note: '',
+				is_published: true,
+			},
+		],
+		feedback_url: 'https://example.com/reviews',
+		is_published: true,
+	};
+}
+
+function mockAgency( application: AgencyPartnerDirectoryApplication | null = null ) {
+	nock( API )
+		.get( '/wpcom/v2/agency' )
+		.query( true )
+		.reply( 200, [ { id: 123, name: 'Test Agency', profile: makeProfile( application ) } ] )
+		.persist();
+}
+
+beforeAll( () => {
+	// jsdom doesn't implement scrollIntoView, which the form calls when
+	// validation fails on the fields above the fold.
+	window.HTMLElement.prototype.scrollIntoView = jest.fn();
+} );
+
+beforeEach( () => {
+	nock.cleanAll();
+} );
+
+describe( '<AgencyPartnerDirectoryExpertise>', () => {
+	test( 'invites a new agency to submit an application', async () => {
+		mockAgency();
+
+		render( <AgencyPartnerDirectoryExpertise /> );
+
+		expect( await screen.findByRole( 'button', { name: 'Submit my application' } ) ).toBeVisible();
+		expect( screen.getByRole( 'checkbox', { name: 'WordPress.com' } ) ).not.toBeChecked();
+		expect( screen.getByRole( 'link', { name: 'Cancel' } ) ).toBeVisible();
+	} );
+
+	test( 'shows validation errors when submitting an empty form', async () => {
+		mockAgency();
+
+		render( <AgencyPartnerDirectoryExpertise /> );
+
+		await userEvent.click( await screen.findByRole( 'button', { name: 'Submit my application' } ) );
+
+		expect( screen.getByText( 'Services can’t be empty' ) ).toBeVisible();
+		expect( screen.getByText( 'Products can’t be empty' ) ).toBeVisible();
+		expect( screen.getByText( 'Directories can’t be empty' ) ).toBeVisible();
+		expect( screen.getByText( 'Feedback URL can’t be empty' ) ).toBeVisible();
+	} );
+
+	test( 'requires client site URLs for newly selected directories', async () => {
+		mockAgency( makeApplication() );
+
+		render( <AgencyPartnerDirectoryExpertise /> );
+
+		// Approved directories can't be unselected.
+		expect( await screen.findByRole( 'checkbox', { name: 'WordPress.com' } ) ).toBeDisabled();
+
+		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Pressable.com' } ) );
+		expect( screen.getByText( 'Relevant examples for Pressable.com' ) ).toBeVisible();
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Update my expertise' } ) );
+		expect( screen.getByText( 'Please provide valid URLs' ) ).toBeVisible();
+	} );
+
+	test( 'submits the application and reports the saved agency back', async () => {
+		const application = makeApplication();
+		const updatedAgency = { id: 123, name: 'Test Agency', profile: makeProfile( application ) };
+		const scope = nock( API )
+			.put( '/wpcom/v2/agency/123/profile/application' )
+			.reply( 200, updatedAgency );
+
+		const onSubmitSuccess = jest.fn();
+
+		render(
+			<PartnerDirectoryExpertiseContent
+				agency={ { id: 123, profile: makeProfile( application ) } }
+				recordTracksEvent={ jest.fn() }
+				dashboardUrl="/agency/partner-directory"
+				onSubmitSuccess={ onSubmitSuccess }
+			/>
+		);
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Update my expertise' } ) );
+
+		await waitFor( () => expect( onSubmitSuccess ).toHaveBeenCalled() );
+		expect( scope.isDone() ).toBe( true );
+	} );
+} );

--- a/client/dashboard/app-a4a/section.ts
+++ b/client/dashboard/app-a4a/section.ts
@@ -12,6 +12,7 @@ export const A4A_DASHBOARD_SECTION_PATHS = [
 	'/marketplace/exclusive-offers',
 	'/agency/tiers',
 	'/agency/partner-directory',
+	'/agency/partner-directory/expertise',
 	'/resources/learn',
 	'/resources/ai-mcp',
 	'/resources/ai-mcp/read',

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -25,6 +25,10 @@ import {
 import { isEnabled } from '@automattic/calypso-config';
 import { createRoute, createLazyRoute, notFound, Outlet } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
+import {
+	PARTNER_DIRECTORY_EXPERTISE_SEGMENT,
+	PARTNER_DIRECTORY_ROUTE,
+} from '../../agency/partner-directory/paths';
 import { getSiteTypeFeatureSupports } from '../../utils/site-type-feature-support';
 import { dashboardRedirect, redirectAsNotAllowed } from './redirect';
 import { rootRoute } from './root';
@@ -148,7 +152,7 @@ export const agencyPartnerDirectoryRoute = createRoute( {
 		],
 	} ),
 	getParentRoute: () => agencyRoute,
-	path: 'agency/partner-directory',
+	path: PARTNER_DIRECTORY_ROUTE,
 	beforeLoad: async ( { cause } ) => {
 		if ( cause === 'preload' ) {
 			return;
@@ -183,7 +187,7 @@ export const agencyPartnerDirectoryExpertiseRoute = createRoute( {
 		],
 	} ),
 	getParentRoute: () => agencyPartnerDirectoryRoute,
-	path: 'expertise',
+	path: PARTNER_DIRECTORY_EXPERTISE_SEGMENT,
 	loader: () => queryClient.ensureQueryData( activeAgencyQuery() ),
 } ).lazy( () =>
 	import( '../../agency/partner-directory/expertise' ).then( ( d ) =>

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -137,7 +137,7 @@ export const agencyTiersRoute = createRoute( {
 	)
 );
 
-// `/agency/partner-directory` – partner directory application dashboard
+// `/agency/partner-directory` – layout that gates on the partner directory program
 export const agencyPartnerDirectoryRoute = createRoute( {
 	staticData: { requiresAgencyCapability: 'a4a_read_partner_directory' },
 	head: () => ( {
@@ -159,10 +159,35 @@ export const agencyPartnerDirectoryRoute = createRoute( {
 			throw redirectAsNotAllowed( { to: '/overview' } );
 		}
 	},
+} );
+
+const agencyPartnerDirectoryIndexRoute = createRoute( {
+	getParentRoute: () => agencyPartnerDirectoryRoute,
+	path: '/',
 	loader: () => queryClient.ensureQueryData( activeAgencyQuery() ),
 } ).lazy( () =>
 	import( '../../agency/partner-directory' ).then( ( d ) =>
 		createLazyRoute( 'agency-partner-directory' )( {
+			component: d.default,
+		} )
+	)
+);
+
+// `/agency/partner-directory/expertise` – apply to or update the directory application
+export const agencyPartnerDirectoryExpertiseRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Share your expertise' ),
+			},
+		],
+	} ),
+	getParentRoute: () => agencyPartnerDirectoryRoute,
+	path: 'expertise',
+	loader: () => queryClient.ensureQueryData( activeAgencyQuery() ),
+} ).lazy( () =>
+	import( '../../agency/partner-directory/expertise' ).then( ( d ) =>
+		createLazyRoute( 'agency-partner-directory-expertise' )( {
 			component: d.default,
 		} )
 	)
@@ -864,7 +889,10 @@ export const createAgencyRoutes = () => [
 	agencyRoute.addChildren( [
 		agencyOverviewRoute,
 		agencyTiersRoute,
-		agencyPartnerDirectoryRoute,
+		agencyPartnerDirectoryRoute.addChildren( [
+			agencyPartnerDirectoryIndexRoute,
+			agencyPartnerDirectoryExpertiseRoute,
+		] ),
 		exclusiveOffersRoute,
 		learnRoute,
 		mcpRoute.addChildren( [


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/113550.

Part of A4A-3190.

## Proposed Changes

* Add the “Share your expertise” screen to the new agencies dashboard, at `/agency/partner-directory/expertise`. Agencies use it to apply to the Partner Directories or update a submitted application.
* The form asks for services (up to five), products, the directories to appear on, five client-site URLs per newly selected directory, and a customer feedback URL. Everything is validated on submit, with error messages under each field.
* Directories that are already approved stay selected and can’t be unselected; their client-site URLs are not asked for again.
* Submitting saves the application, shows a confirmation snackbar, and returns to the Partner Directory dashboard. Saving failures show an error snackbar.
* The Partner Directory dashboard’s “Apply now”, “Edit expertise”, and “Update my expertise” buttons now open this screen in place instead of sending the agency to the classic app.
* The classic app is unchanged — it keeps its own expertise screen until the follow-up PR switches it to this shared one.

## Why are these changes being made?

* The Partner Directory expertise screen is being ported to the new agencies dashboard so agencies can manage their whole directory application there, following the same approach as the Partner Directory dashboard port.

## Testing Instructions

* Open the branch preview with `env=dashboard-a4a`, load `/overview` to enter the agencies dashboard as an agency user, then go to Agency → Partner Directories.
* Click “Apply now” (or “Edit expertise” if an application exists) — the expertise screen opens at `/agency/partner-directory/expertise` without a full page load.

<img width="1920" height="964" alt="Screenshot 2026-08-14 at 2 24 17 PM" src="https://github.com/user-attachments/assets/0eed11b1-bc52-46a7-b28d-4c4d0650a7d0" />



* Submit the empty form: each required field shows an error message and the page scrolls back to the top fields.

<img width="708" height="322" alt="Screenshot 2026-08-14 at 9 29 03 AM" src="https://github.com/user-attachments/assets/52721119-6555-437a-be64-f2776f88225e" />

<img width="688" height="309" alt="Screenshot 2026-08-14 at 9 29 24 AM" src="https://github.com/user-attachments/assets/1e940624-173e-499b-ab64-2fc2d46acee9" />

<img width="716" height="507" alt="Screenshot 2026-08-14 at 9 29 32 AM" src="https://github.com/user-attachments/assets/712d1eeb-a9e8-4ec2-bdf2-7f7d00d02ef2" />


<img width="640" height="164" alt="Screenshot 2026-08-14 at 9 30 14 AM" src="https://github.com/user-attachments/assets/8453fb3e-ee2d-461a-9863-6bee98ad5e16" />


* Select a directory: five URL fields appear for it, laid out in two columns on wide screens. Invalid or duplicate URLs are rejected on submit.

<img width="716" height="772" alt="Screenshot 2026-08-14 at 9 32 24 AM" src="https://github.com/user-attachments/assets/d258b69f-9ee4-49ff-8e58-72cec7dff598" />

<img width="379" height="322" alt="Screenshot 2026-08-14 at 9 29 39 AM" src="https://github.com/user-attachments/assets/3686b7e5-948e-40fc-bb09-d8ebad34b8fa" />

<img width="376" height="317" alt="Screenshot 2026-08-14 at 9 30 04 AM" src="https://github.com/user-attachments/assets/6e3aade0-6078-4240-8a65-1d1ca7ff1471" />

* With an agency that has an approved directory: its checkbox is checked and disabled, and no URL fields are shown for it.

<img width="650" height="721" alt="Screenshot 2026-08-14 at 9 46 14 AM" src="https://github.com/user-attachments/assets/da5e2ffb-159c-495f-ba5d-e90d8cb98d44" />

* Submit a valid form: the request goes out as `PUT …/profile/application`, a “Application submitted.” snackbar appears, and you land back on the Partner Directory dashboard with the badges reflecting the saved state.

<img width="219" height="93" alt="Screenshot 2026-08-14 at 9 35 55 AM" src="https://github.com/user-attachments/assets/a5a247c4-ac4a-46cc-a665-1df6b225a580" />

* Cancel returns to the Partner Directory dashboard without saving.
* An agency that isn’t part of the Partner Directory program is redirected to the overview page when opening the URL directly.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
