### PR TITLE
Gate WordPress Agent route outside production

### DIFF
--- a/client/me/index.js
+++ b/client/me/index.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import {
 	makeLayout,
@@ -34,14 +35,16 @@ export default function () {
 	page( '/me/find-friends', controller.profileRedirect, makeLayout, clientRender );
 
 	page( TELEGRAM_CONNECT_PATH, setupPreferences, telegramConnect, makeLayout, clientRender );
-	page(
-		WORDPRESS_AGENT_PATH,
-		setupPreferences,
-		controller.sidebar,
-		wordpressAgent,
-		makeLayout,
-		clientRender
-	);
+	if ( config.isEnabled( 'wordpress-agent' ) ) {
+		page(
+			WORDPRESS_AGENT_PATH,
+			setupPreferences,
+			controller.sidebar,
+			wordpressAgent,
+			makeLayout,
+			clientRender
+		);
+	}
 
 	page(
 		'/me/get-apps',

--- a/client/me/index.js
+++ b/client/me/index.js
@@ -35,7 +35,7 @@ export default function () {
 	page( '/me/find-friends', controller.profileRedirect, makeLayout, clientRender );
 
 	page( TELEGRAM_CONNECT_PATH, setupPreferences, telegramConnect, makeLayout, clientRender );
-	if ( config.isEnabled( 'wordpress-agent' ) ) {
+	if ( config.isEnabled( 'wordpress-agent-slack' ) ) {
 		page(
 			WORDPRESS_AGENT_PATH,
 			setupPreferences,

--- a/client/wordpress-agent/main.tsx
+++ b/client/wordpress-agent/main.tsx
@@ -145,10 +145,20 @@ export default function WordPressAgentPage( { pairToken, slackStatus }: WordPres
 
 	const title = translate( 'WordPress Agent' );
 	const pairingTitle = username
-		? translate( 'Connect this Slack account to your WordPress.com account %(username)s?', {
+		? translate( 'Connect your WordPress.com account %(username)s to this Slack workspace?', {
 				args: { username },
 		  } )
-		: translate( 'Connect this Slack account to your WordPress.com account?' );
+		: translate( 'Connect your WordPress.com account to this Slack workspace?' );
+	const installTitle = pairToken
+		? translate( 'Install WordPress Agent in another Slack workspace' )
+		: translate( 'Install WordPress Agent in Slack' );
+	const installDescription = pairToken
+		? translate(
+				'This is a separate step for adding WordPress Agent to a different Slack workspace.'
+		  )
+		: translate(
+				'Add WordPress Agent to a Slack workspace, then connect your WordPress.com account.'
+		  );
 	let connectionsContent: ReactNode;
 	if ( loading ) {
 		connectionsContent = (
@@ -232,7 +242,7 @@ export default function WordPressAgentPage( { pairToken, slackStatus }: WordPres
 							<h2>{ pairingTitle }</h2>
 							<p>
 								{ translate(
-									'WordPress Agent will use your WordPress.com account and sites when you message it in this Slack workspace.'
+									'WordPress Agent is already installed in this workspace. Connect your account to use your WordPress.com sites when you message it here.'
 								) }
 							</p>
 						</div>
@@ -250,10 +260,8 @@ export default function WordPressAgentPage( { pairToken, slackStatus }: WordPres
 
 			<div className="wordpress-agent-slack__heading">
 				<div>
-					<h2>{ translate( 'Slack' ) }</h2>
-					<p>
-						{ translate( 'Use WordPress Agent in direct messages in any connected workspace.' ) }
-					</p>
+					<h2>{ installTitle }</h2>
+					<p>{ installDescription }</p>
 				</div>
 				<Button
 					variant="primary"
@@ -261,7 +269,7 @@ export default function WordPressAgentPage( { pairToken, slackStatus }: WordPres
 					isBusy={ action === 'install' }
 					disabled={ !! action }
 				>
-					{ translate( 'Add to Slack' ) }
+					{ pairToken ? translate( 'Install in another workspace' ) : translate( 'Add to Slack' ) }
 				</Button>
 			</div>
 

--- a/config/development.json
+++ b/config/development.json
@@ -231,6 +231,7 @@
 		"two-factor/enhanced-security": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
+		"wordpress-agent": true,
 		"wordpress-ai-tools": true,
 		"wpcom-user-bootstrap": false
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -231,7 +231,7 @@
 		"two-factor/enhanced-security": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
-		"wordpress-agent": true,
+		"wordpress-agent-slack": true,
 		"wordpress-ai-tools": true,
 		"wpcom-user-bootstrap": false
 	}

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -147,6 +147,7 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"use-translation-chunks": true,
+		"wordpress-agent": true,
 		"wordpress-ai-tools": true,
 		"wpcom-user-bootstrap": true
 	},

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -147,7 +147,7 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"use-translation-chunks": true,
-		"wordpress-agent": true,
+		"wordpress-agent-slack": true,
 		"wordpress-ai-tools": true,
 		"wpcom-user-bootstrap": true
 	},

--- a/config/production.json
+++ b/config/production.json
@@ -181,6 +181,7 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"use-translation-chunks": true,
+		"wordpress-agent": false,
 		"wordpress-ai-tools": true,
 		"wpcom-user-bootstrap": true
 	},

--- a/config/production.json
+++ b/config/production.json
@@ -181,7 +181,7 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"use-translation-chunks": true,
-		"wordpress-agent": false,
+		"wordpress-agent-slack": false,
 		"wordpress-ai-tools": true,
 		"wpcom-user-bootstrap": true
 	},

--- a/config/stage.json
+++ b/config/stage.json
@@ -179,7 +179,7 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"use-translation-chunks": true,
-		"wordpress-agent": true,
+		"wordpress-agent-slack": true,
 		"wordpress-ai-tools": true,
 		"wpcom-user-bootstrap": true
 	},

--- a/config/stage.json
+++ b/config/stage.json
@@ -179,6 +179,7 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"use-translation-chunks": true,
+		"wordpress-agent": true,
 		"wordpress-ai-tools": true,
 		"wpcom-user-bootstrap": true
 	},

--- a/config/test.json
+++ b/config/test.json
@@ -123,6 +123,7 @@
 		"themes/showcase-modern": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
+		"wordpress-agent": true,
 		"wpcom-user-bootstrap": false
 	}
 }

--- a/config/test.json
+++ b/config/test.json
@@ -123,7 +123,7 @@
 		"themes/showcase-modern": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
-		"wordpress-agent": true,
+		"wordpress-agent-slack": true,
 		"wpcom-user-bootstrap": false
 	}
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -183,7 +183,7 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"use-translation-chunks": true,
-		"wordpress-agent": true,
+		"wordpress-agent-slack": true,
 		"wordpress-ai-tools": true,
 		"wpcom-user-bootstrap": true
 	},

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -183,6 +183,7 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"use-translation-chunks": true,
+		"wordpress-agent": true,
 		"wordpress-ai-tools": true,
 		"wpcom-user-bootstrap": true
 	},


### PR DESCRIPTION
## Proposed Changes

* Gate the WordPress Agent connection route behind a `wordpress-agent-slack` feature flag.
* Enable the route in development, test, wpcalypso, horizon, and staging while keeping it disabled in production.
* Clarify that the Slack link flow connects a WordPress.com account to an existing workspace, while the separate installation action adds WordPress Agent to another workspace.

## Why are these changes being made?

* The WordPress Agent Slack connection page is still being tested and should not be exposed in production.
* The existing copy made connecting an individual account and installing the app in a Slack workspace appear to be the same action.

## Testing Instructions

* Open `/me/get-apps/wordpress-agent` in a development, wpcalypso, horizon, or staging environment and confirm the route renders.
* Follow a Slack pairing link containing `pair_token` and confirm the first section explains that it connects the current WordPress.com account to the existing workspace.
* Confirm the second section says that it installs WordPress Agent in another Slack workspace.
* Use a production config and confirm the WordPress Agent route is not registered.
* Run `yarn eslint client/me/index.js client/wordpress-agent/main.tsx`.
* Run `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
