### PR TITLE
Purchases: stop showing removed subscriptions as expired

### DIFF
--- a/client/dashboard/components/purchase-expiry-status/index.tsx
+++ b/client/dashboard/components/purchase-expiry-status/index.tsx
@@ -20,6 +20,7 @@ import {
 	isExpiring,
 	isExpiredOrRemoved,
 	isIncludedWithPlan,
+	isRemoved,
 	isOneTimePurchase,
 	isAkismetFreeProduct,
 	creditCardHasAlreadyExpired,
@@ -461,6 +462,14 @@ export function PurchaseExpiryStatus( {
 		return sprintf( __( 'Session used on %s' ), [
 			formatDate( new Date( purchase.expiry_date ), locale, { dateStyle: 'long' } ),
 		] );
+	}
+
+	// A removed subscription is settled: it cannot be renewed, and its expiry date
+	// records when it was cancelled rather than when it lapsed — so the expired
+	// copy below would announce that it "expired today" on the day support
+	// cancelled it, and offer a renewal link that leads nowhere.
+	if ( isRemoved( purchase ) ) {
+		return <span>{ __( 'No longer active' ) }</span>;
 	}
 
 	if ( isExpiredOrRemoved( purchase ) ) {

--- a/client/dashboard/components/purchase-expiry-status/test/index.test.tsx
+++ b/client/dashboard/components/purchase-expiry-status/test/index.test.tsx
@@ -94,6 +94,22 @@ describe( '<PurchaseExpiryStatus>', () => {
 		expect( renewLink() ).toBeVisible();
 	} );
 
+	test( 'says a removed purchase is over rather than dating it to the day it was cancelled', () => {
+		render(
+			<PurchaseExpiryStatus
+				purchase={ createPurchase( {
+					expiry_status: 'expired',
+					subscription_status: 'inactive',
+					expiry_date: NOW,
+				} ) }
+			/>
+		);
+
+		expect( screen.getByText( /no longer active/i ) ).toBeVisible();
+		expect( screen.queryByText( /expired today/i ) ).toBeNull();
+		expect( renewLink() ).toBeNull();
+	} );
+
 	describe( 'a monthly subscription', () => {
 		const monthly = { bill_period_days: SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD };
 

--- a/client/dashboard/me/billing-purchases/index.tsx
+++ b/client/dashboard/me/billing-purchases/index.tsx
@@ -19,6 +19,7 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
 import { adjustDataViewFieldsForWidth } from '../../utils/dataviews-width';
+import { isRemoved } from '../../utils/purchase';
 import { useIsSplitCancelRemoveEnabled } from './cancel-purchase/use-is-split-cancel-remove-enabled';
 import {
 	WIDE_FIELDS,
@@ -107,8 +108,14 @@ export default function PurchasesList() {
 		visibleFields: view.fields,
 	} );
 
+	// A removed subscription is not an upgrade the viewer still holds, and nothing
+	// on this page can act on one — whether they cancelled it or support did.
+	// Filtered here rather than in the query, because other readers of it (e.g.
+	// account deletion) do need to see removed subscriptions.
 	const allSubscriptions = useMemo( () => {
-		return isLoading ? [] : [ ...purchases, ...transferredPurchases ];
+		return isLoading
+			? []
+			: [ ...purchases, ...transferredPurchases ].filter( ( purchase ) => ! isRemoved( purchase ) );
 	}, [ isLoading, purchases, transferredPurchases ] );
 
 	const { data: filteredSubscriptions, paginationInfo } = useMemo( () => {

--- a/client/dashboard/me/billing-purchases/index.tsx
+++ b/client/dashboard/me/billing-purchases/index.tsx
@@ -107,10 +107,8 @@ export default function PurchasesList() {
 		siteFilter: currentSearchParams.site,
 		visibleFields: view.fields,
 	} );
-
-	// A removed subscription is not an upgrade the viewer still holds, and nothing
-	// on this page can act on one — whether they cancelled it or support did.
 	// Filtered here rather than in the query, because other readers of it (e.g.
+	// account deletion) do need to see removed subscriptions.
 	// account deletion) do need to see removed subscriptions.
 	const allSubscriptions = useMemo( () => {
 		return isLoading

--- a/client/dashboard/me/billing-purchases/test/index.test.tsx
+++ b/client/dashboard/me/billing-purchases/test/index.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+	allSitesQuery,
+	rawUserPreferencesQuery,
+	userPaymentMethodsQuery,
+	userPurchasesQuery,
+	userTransferredPurchasesQuery,
+} from '@automattic/api-queries';
+import { QueryClient } from '@tanstack/react-query';
+import { screen, waitFor } from '@testing-library/react';
+import { render } from '../../../test-utils';
+import PurchasesList from '../index';
+import type { Purchase } from '@automattic/api-core';
+
+jest.mock( '../../../app/router/me', () => {
+	const actual = jest.requireActual( '../../../app/router/me' );
+	return {
+		...actual,
+		purchasesRoute: { ...actual.purchasesRoute, useSearch: () => ( {} ) },
+		purchasesIndexRoute: { ...actual.purchasesIndexRoute, useSearch: () => ( {} ) },
+	};
+} );
+
+const createPurchase = ( overrides: Partial< Purchase > ): Purchase =>
+	( {
+		ID: 1,
+		blog_id: 100,
+		blogname: 'Example',
+		site_slug: 'example.wordpress.com',
+		domain: 'example.wordpress.com',
+		user_id: 1,
+		product_name: 'Jetpack Social',
+		product_slug: 'jetpack_social_basic_yearly',
+		product_type: 'jetpack',
+		expiry_status: 'auto-renewing',
+		subscription_status: 'active',
+		expiry_date: '2027-01-01T00:00:00+00:00',
+		...overrides,
+	} ) as Purchase;
+
+// The page reads several queries beyond the purchase list; seeding them all
+// keeps the render offline, and `staleTime` stops them refetching.
+function renderPurchasesList( purchases: Purchase[] ) {
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+	} );
+
+	queryClient.setQueryData( userPurchasesQuery().queryKey, purchases );
+	queryClient.setQueryData( userTransferredPurchasesQuery().queryKey, [] );
+	queryClient.setQueryData( allSitesQuery().queryKey, [] );
+	queryClient.setQueryData( userPaymentMethodsQuery( {} ).queryKey, [] );
+	// The view is persisted as a user preference, read through a suspense query.
+	queryClient.setQueryData( rawUserPreferencesQuery().queryKey, {} );
+
+	return render( <PurchasesList />, { queryClient } );
+}
+
+describe( '<PurchasesList>', () => {
+	test( 'leaves a removed subscription out of the active upgrades', async () => {
+		renderPurchasesList( [
+			createPurchase( { ID: 1, product_name: 'Jetpack Growth' } ),
+			createPurchase( {
+				ID: 2,
+				product_name: 'Jetpack Social',
+				// Cancelled by support: removed on the spot, with the expiry date
+				// backdated to the cancellation rather than to a lapse.
+				expiry_status: 'expired',
+				subscription_status: 'inactive',
+				expiry_date: new Date().toISOString(),
+			} ),
+		] );
+
+		await waitFor( () => expect( screen.getByText( 'Jetpack Growth' ) ).toBeVisible() );
+		expect( screen.queryByText( 'Jetpack Social' ) ).toBeNull();
+	} );
+
+	test( 'still lists a purchase that has lapsed but can be renewed', async () => {
+		renderPurchasesList( [
+			createPurchase( {
+				ID: 1,
+				product_name: 'Jetpack Growth',
+				expiry_status: 'expired',
+				subscription_status: 'active',
+				expiry_date: '2026-01-01T00:00:00+00:00',
+			} ),
+		] );
+
+		await waitFor( () => expect( screen.getByText( 'Jetpack Growth' ) ).toBeVisible() );
+	} );
+} );


### PR DESCRIPTION
Fixes [SHILL-2317](https://linear.app/a8c/issue/SHILL-2317/wordpresscom-purchases-page-shows-unhelpful-expired-today-notice-for)

## Proposed Changes

* Leave removed subscriptions (`subscription_status: 'inactive'`) out of the Active upgrades list in `client/dashboard/me/billing-purchases/index.tsx`. Filtered at the call site rather than in `userPurchasesQuery()`, because other readers of that query — account deletion, for one — do need to see removed subscriptions.
* Give `PurchaseExpiryStatus` a branch of its own for removed subscriptions, so any surface that still renders one reads "No longer active" instead of falling through to the expired copy. Placed after the concierge-session branch, so "Session used on <date>" is unaffected.
* Tests for both.

## Why are these changes being made?

A Jetpack Social plan cancelled by support kept showing up on the reporter's purchases page labelled **"Expired today"**, with a renewal link — on a subscription that neither the original purchaser nor the current owner could do anything about.

Two separate defects produce that:

1. **The list has no status filter.** `allSubscriptions` concatenated the user's purchases and their transferred purchases with nothing filtered out, so an inactive subscription rendered as a row. Several other dashboard call sites already guard against this — `sites/storage/storage-utils.ts` and `sites/jetpack-site-disconnect/index.tsx` both filter `! isRemoved( purchase )` — which is what confirms the endpoint returns them.
2. **The copy has no removed branch.** `PurchaseExpiryStatus` funnelled both grace-period-expired and removed subscriptions through `isExpiredOrRemoved` into `getExpiredCopy()`. Cancelling backdates `expiry_date` to the cancellation, so `getExpiredCopy()` computes zero days elapsed and returns "Expired today" — accurate about the date, wrong about what happened — and `UrgentExpiryStatus` then offers a renewal link that leads nowhere.

Worth recording, since triage on the issue pointed here: **this is not a caching bug.** `staleTime` is 0 with `refetchOnMount` and `refetchOnWindowFocus` in `packages/api-queries/src/query-client.ts`, so the list refetches on every mount. What can look like a stuck cache is `persistQueryClient` rehydrating from localStorage before the refetch resolves — a stale flash on load, not a stale read.

There is no field distinguishing "cancelled by support" from "lapsed and then removed"; `subscription_status` is the only signal the endpoint gives, and both cases mean the same thing to the reader — nothing left to act on. Hence the neutral "No longer active" rather than "Cancelled".

## Testing Instructions

Unit tests:

```
yarn test-client client/dashboard/me/billing-purchases client/dashboard/components/purchase-expiry-status
```

The list test was verified to fail without the filter (removing it turns "leaves a removed subscription out of the active upgrades" red).

Manually, on a user with a subscription cancelled from Store Admin:

1. Visit `/me/billing/purchases`. **Before:** the cancelled subscription is listed, with "Expired today" and a renewal link. **After:** it is not listed at all.
2. Confirm an *expired but still renewable* purchase (past its expiry date, `subscription_status` still `active`) is unaffected — it should still be listed, still say "Expired N days ago", and still offer renewal.
3. Confirm the site overview plan card reads "No longer active" for a removed plan rather than "Expired today".

Not verified in a running environment — the checks below reflect that.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors? — `yarn typecheck-client` reports no errors in any file touched here (trunk has pre-existing failures elsewhere), but the change has not been exercised in a browser.
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? — one new string, "No longer active"; the label still needs adding.
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Follow-up

Classic Calypso has the identical copy bug — `client/me/purchases/purchase-item/index.tsx` routes `isExpiredOrRemoved` through `getExpiredCopy()` the same way, and `purchases-list-in-dataviews` does not filter either. Left out of this PR because classic uses a different `Purchase` type (camelCase, different `expiry_status` values), so it is a port rather than a copy. Happy to do it here or separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
