### PR TITLE
Nav 2026: Site profiler label and locale layout fixes

### DIFF
--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -49,7 +49,7 @@ const UniversalNavbarHeader = ( {
 }: HeaderProps ) => {
 	const locale = useLocale();
 	const localizeUrl = useLocalizeUrl();
-	const { __ } = useI18n();
+	const { __, hasTranslation } = useI18n();
 	const [ isMobileMenuOpen, setMobileMenuOpen ] = useState( false );
 	// Mobile drill-down: which category is expanded (null = top level).
 	const [ currentDropdown, setCurrentDropdown ] = useState< string | null >( null );
@@ -84,8 +84,9 @@ const UniversalNavbarHeader = ( {
 	const dropdownRef = useDropdownFlip( { nav2026, activeDropdown } );
 
 	const nav2026Menus = useMemo(
-		() => ( nav2026 ? getNav2026Menus( { __, localizeUrl, locale, isLoggedIn } ) : [] ),
-		[ nav2026, __, localizeUrl, locale, isLoggedIn ]
+		() =>
+			nav2026 ? getNav2026Menus( { __, localizeUrl, locale, isLoggedIn, hasTranslation } ) : [],
+		[ nav2026, __, localizeUrl, locale, isLoggedIn, hasTranslation ]
 	);
 	const activeCategory = nav2026Menus.find( ( menu ) => menu.name === currentDropdown );
 

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/taxonomy.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/taxonomy.ts
@@ -169,7 +169,7 @@ export function getNav2026Menus( {
 							target: '_self',
 						},
 						{
-							label: __( 'Site profiler (WHOIS)', __i18n_text_domain__ ),
+							label: __( 'Site profiler', __i18n_text_domain__ ),
 							url: localizeUrl( '//wordpress.com/site-profiler' ),
 							target: '_self',
 						},

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/taxonomy.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/taxonomy.ts
@@ -14,6 +14,7 @@ interface GetNav2026MenusArgs {
 	localizeUrl: LocalizeUrl;
 	locale: string;
 	isLoggedIn: boolean;
+	hasTranslation?: ( text: string ) => boolean;
 }
 
 // The 2026 nav taxonomy. Keep in sync with the WPCOM twin in
@@ -23,7 +24,13 @@ export function getNav2026Menus( {
 	localizeUrl,
 	locale,
 	isLoggedIn,
+	hasTranslation,
 }: GetNav2026MenusArgs ): Nav2026Menu[] {
+	// Fall back to the old translated label until "Site profiler" is translated.
+	const siteProfilerLabel =
+		locale.startsWith( 'en' ) || hasTranslation?.( 'Site profiler' )
+			? __( 'Site profiler', __i18n_text_domain__ )
+			: __( 'Site profiler (WHOIS)', __i18n_text_domain__ );
 	const buildGroup: Nav2026Group = {
 		title: __( 'Build', __i18n_text_domain__ ),
 		columnGroup: 'build-publish',
@@ -169,7 +176,7 @@ export function getNav2026Menus( {
 							target: '_self',
 						},
 						{
-							label: __( 'Site profiler', __i18n_text_domain__ ),
+							label: siteProfilerLabel,
 							url: localizeUrl( '//wordpress.com/site-profiler' ),
 							target: '_self',
 						},

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1418,10 +1418,10 @@ $x-menu-2026-admin-bar-mobile: 46px;
 
 	.x-dropdown-subcategories {
 		display: flex;
-		flex-wrap: wrap;
+		flex-wrap: nowrap; // Columns compress (labels wrap) in verbose locales; never spill to a second row.
 		// Don't stretch short columns to the tallest column's height.
 		align-items: flex-start;
-		gap: $x-dropdown-2026-column-gap;
+		gap: clamp(40px, 7vw, $x-dropdown-2026-column-gap);
 		max-width: $x-nav-2026-content-max-width;
 		margin: 0;
 		padding: 0;


### PR DESCRIPTION
Part of [MARTECH-2779](https://linear.app/a8c/issue/MARTECH-2779/make-nav-2-the-default-in-calypso)

## Proposed Changes

* Renames "Site profiler (WHOIS)" to "Site profiler", matching the design spec and WordPress.com.
* Keeps the navigation menu columns on one row in every language: long labels now wrap inside their column instead of pushing a whole column onto a second row far below the rest.

## Why are these changes being made?

* In languages with longer labels, the menus could grow almost twice as tall, with a large empty gap before the last column. Validated in de/fr/ar, including right-to-left layout.

## Testing Instructions

* Open `/de/patterns` in a ~1000px-wide window and open the Products menu — all columns sit on one row.
* Check an English page at normal width — unchanged.
* Check `/ar/patterns` — right-to-left layout mirrors correctly.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
