### PR TITLE
Onboarding: build the blueprint's Atomic site before checkout (build_dest=wow)

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -102,6 +102,13 @@ const onboarding: FlowV2< typeof initialize > = {
 		const playgroundId = queryParams.get( 'playground' );
 		const buildDest = queryParams.get( 'build_dest' );
 
+		// `blueprint` is not in the onboard store's persist list, so it is lost on any full page
+		// load — returning from checkout, most notably. The URL carries it (navigate merges query
+		// params forward), so fall back to that; otherwise the post-checkout branches below stop
+		// recognising a blueprint build and route to the generic setup chooser instead of the
+		// site spec.
+		const blueprintSlug = blueprint || queryParams.get( 'blueprint' );
+
 		/**
 		 * Returns [destination, backDestination] for the post-checkout destination.
 		 */
@@ -114,12 +121,12 @@ const onboarding: FlowV2< typeof initialize > = {
 				return [ `/home/${ providedDependencies.siteSlug }`, null, null ];
 			}
 
-			if ( playgroundId || blueprint ) {
+			if ( playgroundId || blueprintSlug ) {
 				// Check if the user selected the free plan
 				const isFree =
 					! planCartItem || isPlanProductFree( {} as unknown as State, planCartItem?.product_id );
 
-				if ( isFree && ! blueprint ) {
+				if ( isFree && ! blueprintSlug ) {
 					// Redirect free plan users to a home page
 					return [ `/home/${ providedDependencies.siteSlug }`, null, null ];
 				}
@@ -134,12 +141,12 @@ const onboarding: FlowV2< typeof initialize > = {
 				// blueprint-archive import and, on confirm, polls the import and
 				// redirects to the Site Editor. The blueprint step already verified the
 				// archive exists (and stripped build_dest when it does not).
-				if ( blueprint && buildDest === 'wow' ) {
+				if ( blueprintSlug && buildDest === 'wow' ) {
 					return [
 						getBlueprintArchiveSiteSpecUrl( {
 							siteSlug: providedDependencies.siteSlug as string,
 							siteId: providedDependencies.siteId as number,
-							blueprintSlug: blueprint,
+							blueprintSlug,
 							ref: refParameter,
 						} ),
 						null,
@@ -147,8 +154,8 @@ const onboarding: FlowV2< typeof initialize > = {
 					];
 				}
 
-				if ( blueprint ) {
-					params.blueprint = blueprint;
+				if ( blueprintSlug ) {
+					params.blueprint = blueprintSlug;
 				} else if ( playgroundId ) {
 					params.playground = playgroundId;
 				}
@@ -216,6 +223,21 @@ const onboarding: FlowV2< typeof initialize > = {
 					setDomainCartItem( providedDependencies.domainItem as MinimalRequestCartProduct );
 					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
 					setSignupDomainOrigin( providedDependencies.signupDomainOrigin as string );
+
+					// build_dest=wow builds the blueprint on Atomic, which takes minutes. Create
+					// the site as soon as the domain is known so the backend can start that build
+					// while the customer is still picking a plan, instead of after checkout. The
+					// site is created plan-less; `plans` follows and the cart is filled on the way
+					// back through `create-site`.
+					if ( blueprintSlug && buildDest === 'wow' ) {
+						// planCartItem is persisted in the onboard store, so a plan chosen in an
+						// earlier run is still here even though this customer has not picked one
+						// yet. Left in place it makes the site look plan-ready: the cart is filled
+						// with the stale plan and the flow jumps straight to checkout, skipping
+						// plan selection entirely.
+						setPlanCartItem( null );
+						return navigate( 'create-site' );
+					}
 
 					return navigate( 'plans' );
 				case 'use-my-domain': {
@@ -396,6 +418,34 @@ const onboarding: FlowV2< typeof initialize > = {
 						setSignupCompleteFlowName( flowName );
 						setSignupCompleteSlug( providedDependencies.siteSlug );
 
+						// The blueprint path created the site straight after the domain step, so
+						// there is no plan yet. Send the customer on to pick one, carrying the new
+						// site forward — `create-site` recognises it and fills the cart rather than
+						// creating a second site. Without this the branches below would treat an
+						// unpaid site as finished and skip both plans and checkout.
+						// Gate on the round-trip marker rather than on planCartItem: that value is
+						// persisted, so it cannot distinguish "no plan chosen yet" from "a plan is
+						// left over from a previous run". early_created_site is only present on the
+						// way back from plan selection, which also stops this from looping.
+						// Key on siteSlug, not siteId: createSiteAction's re-entry branch (stale
+						// signup cookies from an earlier checkout) returns a slug with no id, and
+						// requiring the id there silently drops the customer past plan selection.
+						if (
+							blueprintSlug &&
+							buildDest === 'wow' &&
+							! queryParams.get( 'early_created_site_slug' ) &&
+							providedDependencies.siteSlug
+						) {
+							return navigate(
+								addQueryArgs( 'plans', {
+									early_created_site_slug: providedDependencies.siteSlug as string,
+									...( providedDependencies.siteId
+										? { early_created_site: providedDependencies.siteId as number }
+										: {} ),
+								} ) as typeof currentStepSlug
+							);
+						}
+
 						if ( providedDependencies.goToCheckout ) {
 							const siteSlug = providedDependencies.siteSlug as string;
 
@@ -428,7 +478,7 @@ const onboarding: FlowV2< typeof initialize > = {
 								addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
 									// build_dest=wow goes straight from checkout to the AI site-spec
 									// (no post-checkout-onboarding hop, no chooser).
-									redirect_to: blueprint && buildDest === 'wow' ? destination : redirectTo,
+									redirect_to: blueprintSlug && buildDest === 'wow' ? destination : redirectTo,
 									signup: 1,
 									flow: ONBOARDING_FLOW,
 									checkoutBackUrl: pathToUrl( backDestination ?? '' ),
@@ -440,7 +490,7 @@ const onboarding: FlowV2< typeof initialize > = {
 									steps_total: checkoutStepperPosition.total,
 								} )
 							);
-						} else if ( blueprint && buildDest === 'wow' ) {
+						} else if ( blueprintSlug && buildDest === 'wow' ) {
 							// build_dest=wow never shows the setup-your-site-ai chooser; go
 							// straight to the AI site-spec destination.
 							window.location.replace( destination );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -120,6 +120,7 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 		partnerBundle,
 		gardenName,
 		gardenPartnerName,
+		blueprint,
 	} = useSelect(
 		( select: ( arg: string ) => OnboardSelect ) => ( {
 			domainItem: select( ONBOARD_STORE ).getSelectedDomain(),
@@ -133,6 +134,7 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			partnerBundle: select( ONBOARD_STORE ).getPartnerBundle(),
 			gardenName: select( ONBOARD_STORE ).getGardenName(),
 			gardenPartnerName: select( ONBOARD_STORE ).getGardenPartnerName(),
+			blueprint: select( ONBOARD_STORE ).getBlueprint(),
 		} ),
 		[]
 	);
@@ -217,6 +219,31 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			};
 		}
 
+		// The blueprint Atomic path creates the site right after the domain step so the
+		// build can run during plan selection. Coming back through here with a plan chosen,
+		// the site already exists — reuse it and just fill the cart. Skipping the cart here
+		// would send the customer to an empty checkout.
+		const blueprintEarlySiteId = parseInt( urlQueryParams.get( 'early_created_site' ) ?? '', 10 );
+		const blueprintEarlySiteSlug = urlQueryParams.get( 'early_created_site_slug' ) ?? '';
+		if ( blueprint && urlQueryParams.get( 'build_dest' ) === 'wow' && blueprintEarlySiteSlug ) {
+			const blueprintCartItems = [
+				...( planCartItem ? [ planCartItem ] : [] ),
+				...( productCartItems ?? [] ),
+				...mergedDomainCartItems,
+			];
+
+			if ( blueprintCartItems.length > 0 ) {
+				await addProductsToCart( blueprintEarlySiteSlug, flow, blueprintCartItems );
+			}
+
+			return {
+				...( isNaN( blueprintEarlySiteId ) ? {} : { siteId: blueprintEarlySiteId } ),
+				siteSlug: blueprintEarlySiteSlug,
+				goToCheckout: shouldGoToCheckout,
+				siteCreated: true,
+			};
+		}
+
 		// Flow A: The site was early-created during the AI chat session.
 		// Flow B: If early_created_site is absent, the regular createSiteWithCart path below handles creation.
 		const earlyCreatedSite = urlQueryParams.get( 'early_created_site' );
@@ -292,7 +319,12 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			urlQueryParams.get( 'spec_id' ),
 			isPlaygroundPublish ? 'playground-publish' : undefined,
 			undefined, // provisionTarget
-			launchpadPersonalizationVariation === 'ai_launchpad'
+			launchpadPersonalizationVariation === 'ai_launchpad',
+			// Only build_dest=wow targets Atomic. The legacy blueprint flow imports onto a
+			// Simple site post-checkout, so passing the slug there would provision an Atomic
+			// site it never asked for. The blueprint step has already confirmed the archive
+			// exists and stripped build_dest when it does not.
+			urlQueryParams.get( 'build_dest' ) === 'wow' ? blueprint : null
 		);
 
 		if ( ! site ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -9,8 +9,11 @@ import DocumentHead from 'calypso/components/data/document-head';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import {
 	getBlueprintArchiveSiteIdentifier,
+	fetchBlueprintImportStatus,
 	getSiteAdminUrl,
 	getSiteEditorUrl,
+	IMPORT_FAILURE_STATUSES,
+	IMPORT_SUCCESS,
 	logBlueprintArchiveEvent,
 	startBlueprintArchiveImport,
 	waitForAtomicTransferComplete,
@@ -148,6 +151,36 @@ const SiteSpec: StepType = function SiteSpec() {
 	const messageCountRef = useRef( 0 );
 	const isSubmittingRef = useRef( false );
 	const blueprintImportStartedRef = useRef( false );
+	// Set once anything observes the pre-checkout build finished — the start request's response,
+	// or the background watcher below. Spec confirm then redirects immediately instead of
+	// entering the poll loop. Mirrored to sessionStorage so a mid-spec reload keeps the signal.
+	const blueprintImportCompleteRef = useRef( false );
+	// Prefetched on readiness so confirm can redirect without any request at all.
+	const blueprintAdminUrlRef = useRef< string | null >( null );
+	const blueprintReadySessionKey = blueprintArchiveSiteIdentifier
+		? `blueprint-import-ready-${ blueprintArchiveSiteIdentifier }`
+		: null;
+
+	const markBlueprintImportComplete = useCallback( () => {
+		blueprintImportCompleteRef.current = true;
+		if ( blueprintReadySessionKey ) {
+			try {
+				sessionStorage.setItem( blueprintReadySessionKey, '1' );
+			} catch {
+				// Storage unavailable: the ref still covers this page view.
+			}
+		}
+		// Prefetch the redirect target so confirm is a pure navigation.
+		if ( ! blueprintAdminUrlRef.current && blueprintArchiveSiteIdentifier ) {
+			getSiteAdminUrl( blueprintArchiveSiteIdentifier )
+				.then( ( adminUrl ) => {
+					blueprintAdminUrlRef.current = adminUrl;
+				} )
+				.catch( () => {
+					// Confirm falls back to fetching it.
+				} );
+		}
+	}, [ blueprintReadySessionKey, blueprintArchiveSiteIdentifier ] );
 
 	const handleCiabMessage = useCallback( () => {
 		messageCountRef.current += 1;
@@ -373,13 +406,19 @@ const SiteSpec: StepType = function SiteSpec() {
 		isSubmittingRef.current = true;
 
 		try {
-			logBlueprintArchiveEvent( 'spec_confirm_poll_start', {
-				site_identifier: blueprintArchiveSiteIdentifier,
-			} );
+			// When the build is already known to be finished — from the start response, the
+			// background watcher, or a previous page view via sessionStorage — go straight to
+			// the redirect. The polls are the fallback for a build still in flight.
+			if ( ! blueprintImportCompleteRef.current ) {
+				logBlueprintArchiveEvent( 'spec_confirm_poll_start', {
+					site_identifier: blueprintArchiveSiteIdentifier,
+				} );
 
-			await waitForAtomicTransferComplete( blueprintArchiveSiteIdentifier );
-			await waitForBlueprintImportComplete( blueprintArchiveSiteIdentifier );
-			const adminUrl = await getSiteAdminUrl( blueprintArchiveSiteIdentifier );
+				await waitForAtomicTransferComplete( blueprintArchiveSiteIdentifier );
+				await waitForBlueprintImportComplete( blueprintArchiveSiteIdentifier );
+			}
+			const adminUrl =
+				blueprintAdminUrlRef.current ?? ( await getSiteAdminUrl( blueprintArchiveSiteIdentifier ) );
 			const siteEditorUrl = getSiteEditorUrl( adminUrl );
 
 			logBlueprintArchiveEvent( 'redirect_site_editor', {
@@ -415,10 +454,25 @@ const SiteSpec: StepType = function SiteSpec() {
 			site_identifier: blueprintArchiveSiteIdentifier,
 		} );
 
+		// A mid-spec reload loses component state; the readiness flag survives in sessionStorage.
+		if ( blueprintReadySessionKey ) {
+			try {
+				if ( '1' === sessionStorage.getItem( blueprintReadySessionKey ) ) {
+					markBlueprintImportComplete();
+				}
+			} catch {
+				// Storage unavailable: rely on the start response and the watcher.
+			}
+		}
+
 		startBlueprintArchiveImport( blueprintArchiveSiteIdentifier, blueprintArchiveSlug )
-			.then( () => {
+			.then( ( status ) => {
+				if ( status?.importStatus === IMPORT_SUCCESS ) {
+					markBlueprintImportComplete();
+				}
 				logBlueprintArchiveEvent( 'start_success', {
 					site_identifier: blueprintArchiveSiteIdentifier,
+					already_complete: blueprintImportCompleteRef.current,
 				} );
 			} )
 			.catch( ( error ) => {
@@ -427,7 +481,53 @@ const SiteSpec: StepType = function SiteSpec() {
 					error: error instanceof Error ? error.message : String( error ),
 				} );
 			} );
-	}, [ shouldImportBlueprint, blueprintArchiveSlug, blueprintArchiveSiteIdentifier ] );
+	}, [
+		shouldImportBlueprint,
+		blueprintArchiveSlug,
+		blueprintArchiveSiteIdentifier,
+		blueprintReadySessionKey,
+		markBlueprintImportComplete,
+	] );
+
+	// Watch the build in the background while the user reviews the spec, so readiness is known
+	// the moment it happens rather than discovered by polling after confirm. Only records the
+	// flag — the redirect itself always waits for the user to confirm. A terminal failure stops
+	// the watcher and leaves error handling to the confirm path, which surfaces it properly.
+	useEffect( () => {
+		if ( ! shouldImportBlueprint || ! blueprintArchiveSiteIdentifier ) {
+			return;
+		}
+
+		let cancelled = false;
+
+		const interval = setInterval( async () => {
+			if ( cancelled || blueprintImportCompleteRef.current ) {
+				clearInterval( interval );
+				return;
+			}
+
+			const status = await fetchBlueprintImportStatus( blueprintArchiveSiteIdentifier );
+
+			if ( cancelled ) {
+				return;
+			}
+
+			if ( IMPORT_SUCCESS === status ) {
+				markBlueprintImportComplete();
+				logBlueprintArchiveEvent( 'background_ready', {
+					site_identifier: blueprintArchiveSiteIdentifier,
+				} );
+				clearInterval( interval );
+			} else if ( status && IMPORT_FAILURE_STATUSES.includes( status ) ) {
+				clearInterval( interval );
+			}
+		}, 5000 );
+
+		return () => {
+			cancelled = true;
+			clearInterval( interval );
+		};
+	}, [ shouldImportBlueprint, blueprintArchiveSiteIdentifier, markBlueprintImportComplete ] );
 
 	if ( buildWowRequested && isLoadingAutomattician ) {
 		return <DocumentHead title={ translate( 'Build Your Site with AI' ) } />;

--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -29,8 +29,27 @@ type AtomicTransferResponse = {
 const wait = ( ms: number ) => new Promise< void >( ( resolve ) => setTimeout( resolve, ms ) );
 
 // Terminal states returned by GET /sites/{id}/imports (see Import_V1_1_Helpers::translate_status).
-const IMPORT_SUCCESS = 'importSuccess';
-const IMPORT_FAILURE_STATUSES = [ 'importFailure', 'importExpired', 'importStopped' ];
+export const IMPORT_SUCCESS = 'importSuccess';
+export const IMPORT_FAILURE_STATUSES = [ 'importFailure', 'importExpired', 'importStopped' ];
+
+/**
+ * One-shot import status check. Returns the current importStatus, or null on any
+ * request error — background watchers poll this without wanting throws.
+ */
+export async function fetchBlueprintImportStatus(
+	siteIdentifier: string
+): Promise< string | null > {
+	try {
+		const status = ( await wpcom.req.get( {
+			path: `/sites/${ siteIdentifier }/imports`,
+			apiVersion: '1.1',
+		} ) ) as ImportStatusResponse;
+
+		return status?.importStatus ?? null;
+	} catch {
+		return null;
+	}
+}
 
 // Terminal Atomic transfer states (see calypso/state/automated-transfer/constants).
 const ATOMIC_TRANSFER_COMPLETE_STATES: TransferStates[] = [
@@ -132,9 +151,14 @@ export async function waitForBlueprintImportComplete(
 ): Promise< void > {
 	const maxFinishTime = Date.now() + totalTimeoutSeconds * 1000;
 	let lastStatus: string | null | undefined;
+	let firstAttempt = true;
 
 	while ( Date.now() < maxFinishTime ) {
-		await wait( pollIntervalMs );
+		// Check first, wait between attempts — see waitForAtomicTransferComplete.
+		if ( ! firstAttempt ) {
+			await wait( pollIntervalMs );
+		}
+		firstAttempt = false;
 
 		try {
 			const status = ( await wpcom.req.get( {
@@ -182,9 +206,15 @@ export async function waitForAtomicTransferComplete(
 ): Promise< void > {
 	const maxFinishTime = Date.now() + totalTimeoutSeconds * 1000;
 	let lastStatus: TransferStates | undefined;
+	let firstAttempt = true;
 
 	while ( Date.now() < maxFinishTime ) {
-		await wait( pollIntervalMs );
+		// Check first, wait between attempts: the transfer routinely finished while the user
+		// reviewed the spec, and a leading wait turns "already done" into a guaranteed delay.
+		if ( ! firstAttempt ) {
+			await wait( pollIntervalMs );
+		}
+		firstAttempt = false;
 
 		try {
 			const transfer = ( await wpcom.req.get( {

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -159,7 +159,8 @@ export const createSite = async (
 	specId?: string | null,
 	ref?: string,
 	provisionTarget?: string | null,
-	aiLaunchpadEnabled?: boolean
+	aiLaunchpadEnabled?: boolean,
+	blueprintSlug?: string | null
 ) => {
 	const siteUrl = storedSiteUrl || domainItem?.domain_name;
 
@@ -209,6 +210,14 @@ export const createSite = async (
 				} ),
 			...( specId && {
 				spec_id: specId,
+			} ),
+			// Starts the blueprint build as soon as the site exists. For blueprints that
+			// need plugins the backend provisions a suspended Atomic site and builds it
+			// while the customer picks a plan and checks out, handing the blog over once
+			// the purchase lands. Plugin-free blueprints are ignored here and still take
+			// the ordinary post-checkout import path.
+			...( blueprintSlug && {
+				blueprint_slug: blueprintSlug,
 			} ),
 			options: {
 				...newSiteParams.options,


### PR DESCRIPTION
## What / why

Companion to the wpcom pre-checkout blueprint experiment (Automattic/wpcom#234203). Today the `build_dest=wow` theme-CTA funnel starts its multi-minute Atomic transfer + blueprint restore **after** checkout. With the backend able to build before payment, this PR makes the funnel start that build as early as possible and land the customer in the Site Editor the instant they confirm their spec.

All behaviour is gated on `blueprint && build_dest === 'wow'` — every other flow is untouched.

## Changes

**Trigger** — `createSite()` passes `blueprint_slug` to `/sites/new` (mirroring `spec_id`), which starts the transfer + restore server-side at creation.

**Earlier site creation** — for this path, `domains` navigates to `create-site` before `plans`, so the build runs while the customer picks a plan and pays:

```
domains → create-site → processing (creates) → plans → create-site (reuses) → checkout
```

The return pass reuses the created site and fills the cart. Two traps handled: the persisted `planCartItem` is cleared on entry (a stale plan from a previous run otherwise skips plan selection straight to checkout), and the round-trip is keyed on `siteSlug` rather than `siteId` because the stale-signup-cookie re-entry branch (`isManageSiteFlow`) returns a slug without an id.

**Instant redirect on spec confirm** — readiness is tracked while the user reviews the spec, via three signals: the import-start response (the backend now answers with the finished record for a repeat request), a background 5s status poll, and a `sessionStorage` flag that survives mid-spec reloads. When ready: confirm skips both poll loops and navigates to a prefetched Site Editor URL — zero requests between click and redirect. When not: the existing polls run as fallback, now check-first instead of sleeping 5s before the first check.

Logstash events (`start_success.already_complete`, `background_ready`, `spec_confirm_poll_start`) give the build-vs-checkout race distribution for free.

## Testing

Exercised end-to-end on a wpcom sandbox with the companion PR: CTA → domain → plans → checkout → spec → Site Editor on a finished coachava site. `tsc` and eslint clean on all touched files.

## Known trade-offs / open items

- `siteIntent` is derived from the chosen plan; creating the site before plan selection means blueprint sites get an empty intent rather than `Sell` even if the customer later picks Commerce. Probably right for blueprint-defined sites, but it is a behaviour difference.
- The `isManageSiteFlow` re-entry branch still reuses the previous session's site by design (browser-back-from-checkout protection); for this flow that could point a build at the wrong site. Left untouched pending a decision.
- The backend feature flag (`wpcom_woa_transfer_before_checkout_enabled`) has no production hook yet, so this path is inert in production until the companion PR's gating is decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
