### PR TITLE
Omnibar: stats + notification fixes

### DIFF
--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -134,7 +134,7 @@ export default function OmnibarContainer( { user }: { user?: User } ) {
 	const aiChatPluginNode = useAiChatPlugin();
 	const notificationsPluginNode = useNotificationsPlugin( { user } );
 	const languageSwitcherNode = useLanguageSwitcherPlugin( { user } );
-	const statsSparklineNode = useStatsSparklinePlugin( { siteId, site } );
+	const statsSparklineNode = useStatsSparklinePlugin( { site } );
 	const launchSiteNode = useLaunchSitePlugin( { site } );
 	const siteActions = [
 		...( baseOmnibarNodes.siteActions ?? [] ),

--- a/client/dashboard/app/omnibar/plugin-notifications.tsx
+++ b/client/dashboard/app/omnibar/plugin-notifications.tsx
@@ -27,6 +27,12 @@ export function useNotificationsPlugin( { user }: { user?: User } ): OmnibarNode
 		setHasUnseenNotifications( count > 0 )
 	);
 
+	useOmnibarEvent( 'notificationsOpen', ( isOpen ) => {
+		if ( isOpen ) {
+			setHasUnseenNotifications( false );
+		}
+	} );
+
 	const bellRef = useRef< HTMLSpanElement >( null );
 
 	// Re-runs every commit so the anchor stays correct if the bell button is replaced.

--- a/client/dashboard/app/omnibar/plugin-stats-sparkline.tsx
+++ b/client/dashboard/app/omnibar/plugin-stats-sparkline.tsx
@@ -7,21 +7,16 @@ import type { OmnibarNode } from '@automattic/omnibar';
 
 import './plugin-stats-sparkline.scss';
 
-export function useStatsSparklinePlugin( {
-	siteId,
-	site,
-}: {
-	siteId?: number | null;
-	site?: Site;
-} ): OmnibarNode | undefined {
+export function useStatsSparklinePlugin( { site }: { site?: Site } ): OmnibarNode | undefined {
+	const adminUrl = site?.options?.admin_url;
+	const canViewStats = !! site?.capabilities?.view_stats;
+
 	const { data: hourlyViews } = useQuery( {
-		...siteHourlyViewsQuery( siteId ?? 0 ),
-		enabled: !! siteId,
+		...siteHourlyViewsQuery( site?.ID ?? 0 ),
+		enabled: canViewStats,
 	} );
 
-	const adminUrl = site?.options?.admin_url;
-
-	if ( ! adminUrl || ! hourlyViews || hourlyViews.length === 0 ) {
+	if ( ! adminUrl || ! canViewStats || ! hourlyViews || hourlyViews.length === 0 ) {
 		return undefined;
 	}
 

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -26,6 +26,7 @@ interface SitePlan {
 export interface SiteCapabilities {
 	manage_options: boolean;
 	update_plugins: boolean;
+	view_stats: boolean;
 }
 
 export interface SiteOptions {


### PR DESCRIPTION
## Proposed Changes

Fixes the following things in the new omnibar:

- Gate the stats node behind `site?.capabilities?.view_stats`.
- Dismiss the dot icon from the notification bell icon when the panel is opened.

## Why are these changes being made?

Parity with the original masterbar.

## Testing Instructions

With the `dashboard/omnibar-radical` flag, verify the above behavior.
