### PR TITLE
Zendesk config telemetry: attach the support site when a consumer knows it

### DIFF
--- a/client/components/chat-button/index.tsx
+++ b/client/components/chat-button/index.tsx
@@ -49,7 +49,10 @@ const ChatButton: FC< Props > = ( {
 	);
 	const { setShowHelpCenter, setNavigateToRoute, setNewMessagingChat } =
 		useDataStoreDispatch( HELP_CENTER_STORE );
-	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging();
+	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging(
+		true,
+		siteId ?? undefined
+	);
 
 	function shouldShowChatButton(): boolean {
 		if ( isEligibleForChat && hasActiveChats && canConnectToZendesk ) {

--- a/packages/help-center/src/components/help-center-chat.tsx
+++ b/packages/help-center/src/components/help-center-chat.tsx
@@ -33,7 +33,8 @@ export function HelpCenterChat( {
 	} = useHelpCenterContext();
 	const featureConfig = useFeatureConfig();
 	const { data: canConnectToZendesk, isLoading } = useCanConnectToZendeskMessaging(
-		!! currentUser?.ID
+		!! currentUser?.ID,
+		site?.ID
 	);
 	const { search } = useLocation();
 	const { data } = useSupportStatus( ! featureConfig.chat.skipSupportStatus );

--- a/packages/help-center/src/components/help-center-chat.tsx
+++ b/packages/help-center/src/components/help-center-chat.tsx
@@ -32,10 +32,6 @@ export function HelpCenterChat( {
 		newInteractionsBotVersion,
 	} = useHelpCenterContext();
 	const featureConfig = useFeatureConfig();
-	const { data: canConnectToZendesk, isLoading } = useCanConnectToZendeskMessaging(
-		!! currentUser?.ID,
-		site?.ID
-	);
 	const { search } = useLocation();
 	const { data } = useSupportStatus( ! featureConfig.chat.skipSupportStatus );
 	const params = new URLSearchParams( search );
@@ -45,6 +41,10 @@ export function HelpCenterChat( {
 	const requestedSiteId = Number( siteId ) || Number( site?.ID );
 	const selectedSiteId =
 		Number.isInteger( requestedSiteId ) && requestedSiteId > 0 ? requestedSiteId : undefined;
+	const { data: canConnectToZendesk, isLoading } = useCanConnectToZendeskMessaging(
+		!! currentUser?.ID,
+		selectedSiteId ?? site?.ID
+	);
 	const recordTracksEvent = useHelpCenterTracksEvent( { explicitSiteId: selectedSiteId } );
 	const externalChatProvider = params.get( 'externalChatProvider' );
 	const externalChatId = params.get( 'externalChatId' );

--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -84,10 +84,13 @@ const playNotificationSound = () => {
 const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } ) => {
 	const { isEligibleForChat } = useChatStatus();
 	const queryClient = useQueryClient();
-	const { currentUser } = useHelpCenterContext();
+	const { currentUser, site } = useHelpCenterContext();
 	const recordTracksEvent = useHelpCenterTracksEvent();
 	const smoochRef = useRef< HTMLDivElement >( null );
-	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging( !! currentUser?.ID );
+	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging(
+		!! currentUser?.ID,
+		site?.ID
+	);
 	const {
 		isHelpCenterShown,
 		isChatLoaded,

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -36,9 +36,12 @@ const HelpCenter: React.FC< Container > = ( {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
 		return helpCenterSelect.isHelpCenterShown();
 	}, [] );
-	const { currentUser } = useHelpCenterContext();
+	const { currentUser, site } = useHelpCenterContext();
 	const { setCurrentUser } = useDispatch( HELP_CENTER_STORE );
-	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging( !! currentUser?.ID );
+	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging(
+		!! currentUser?.ID,
+		site?.ID
+	);
 	const { data: supportInteractionsOpen, isLoading: isLoadingOpenInteractions } =
 		useGetSupportInteractions( 'zendesk' );
 	const hasOpenZendeskConversations =

--- a/packages/help-center/src/components/notices.tsx
+++ b/packages/help-center/src/components/notices.tsx
@@ -11,8 +11,11 @@ import './notices.scss';
 import { HELP_CENTER_STORE } from '../stores';
 
 export const BlockedZendeskNotice: React.FC = () => {
-	const { currentUser, sectionName } = useHelpCenterContext();
-	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging( !! currentUser?.ID );
+	const { currentUser, sectionName, site } = useHelpCenterContext();
+	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging(
+		!! currentUser?.ID,
+		site?.ID
+	);
 	const { isEligibleForChat } = useChatStatus();
 	const featureConfig = useFeatureConfig();
 	const { setShowSupportDoc } = useDispatch( HELP_CENTER_STORE );

--- a/packages/help-center/src/hooks/use-get-support-interactions.ts
+++ b/packages/help-center/src/hooks/use-get-support-interactions.ts
@@ -14,11 +14,11 @@ export const useGetSupportInteractions = (
 	enabled = true
 ) => {
 	const isTestMode = isTestModeEnvironment();
-	const { currentUser } = useHelpCenterContext();
+	const { currentUser, site } = useHelpCenterContext();
 	// No auth cookie yet (e.g. right after in-stepper signup) means these authed requests
 	// would 401 and leave the panel stuck loading; skip them and render the logged-out home.
 	const isAuthed = !! currentUser?.ID && ! isCookieAuthMissing();
-	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging( isAuthed );
+	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging( isAuthed, site?.ID );
 
 	let shouldFetch = enabled && isAuthed;
 	// Only fetch Zendesk interactions if the user can connect to Zendesk.

--- a/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
@@ -1,4 +1,4 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { getValidBlogId, recordTracksEvent, withSiteContext } from '@automattic/calypso-analytics';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from '@wordpress/element';
 import type { Query } from '@tanstack/react-query';
@@ -8,12 +8,14 @@ const QUERY_KEY = [ 'canConnectToZendesk' ];
 /**
  * Bump when the meaning of the events below changes, so Superset can tell old rows from new
  * ones. Version 2 reports once per settled query instead of once per observer per state.
+ * Version 3 attaches the support site as `blog_id` when a consumer knows it.
  */
-const REPORTING_VERSION = 2;
+const REPORTING_VERSION = 3;
 
 type ReportingState = {
 	lastResolutionKey?: string;
 	peakFailureCount: number;
+	blogId?: number;
 };
 
 /**
@@ -45,8 +47,13 @@ function fetchZendeskConfig() {
 
 /**
  * This hook verifies connectivity to Zendesk's messaging service by making a config request and manages automatic retries with error tracking.
+ *
+ * `siteId` is the support site the caller knows, if any. The connectivity check is shared
+ * across all consumers, so the reported event attaches the last valid site any of them
+ * supplied; when none did, the properties stay site-less rather than asserting that no
+ * site exists.
  */
-export function useCanConnectToZendeskMessaging( enabled = true ) {
+export function useCanConnectToZendeskMessaging( enabled = true, siteId?: number | string ) {
 	const queryClient = useQueryClient();
 	const query = useQuery< boolean, Error >( {
 		queryKey: QUERY_KEY,
@@ -77,6 +84,11 @@ export function useCanConnectToZendeskMessaging( enabled = true ) {
 		}
 
 		const reportingState = getReportingState( cachedQuery );
+
+		const blogId = getValidBlogId( siteId );
+		if ( blogId ) {
+			reportingState.blogId = blogId;
+		}
 
 		if ( query.fetchStatus !== 'idle' ) {
 			// A success resets `failureCount` to 0, so retries that ended in recovery are only
@@ -123,12 +135,18 @@ export function useCanConnectToZendeskMessaging( enabled = true ) {
 			} );
 		}
 
-		recordTracksEvent( 'calypso_helpcenter_zendesk_config_request', {
+		const requestProperties = {
 			status: query.status,
 			status_text: query.error?.message,
 			failure_count: failureCount,
 			reporting_version: REPORTING_VERSION,
-		} );
+		};
+		recordTracksEvent(
+			'calypso_helpcenter_zendesk_config_request',
+			reportingState.blogId
+				? withSiteContext( requestProperties, 'chat_site', reportingState.blogId )
+				: requestProperties
+		);
 		// The two timestamps look redundant next to `fetchStatus`, which already cycles on
 		// every network refetch. They are what re-runs this for a resolution that leaves
 		// `fetchStatus` untouched: a manual `setQueryData`, or the refetch that follows a
@@ -142,6 +160,7 @@ export function useCanConnectToZendeskMessaging( enabled = true ) {
 		query.fetchStatus,
 		query.status,
 		queryClient,
+		siteId,
 	] );
 
 	return query;

--- a/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
@@ -8,7 +8,8 @@ const QUERY_KEY = [ 'canConnectToZendesk' ];
 /**
  * Bump when the meaning of the events below changes, so Superset can tell old rows from new
  * ones. Version 2 reports once per settled query instead of once per observer per state.
- * Version 3 attaches the support site as `blog_id` when a consumer knows it.
+ * Version 3 attaches the support site as `blog_id` when a consumer knows it; only the
+ * request event gained anything in v3, the error event merely shares the counter.
  */
 const REPORTING_VERSION = 3;
 
@@ -144,7 +145,7 @@ export function useCanConnectToZendeskMessaging( enabled = true, siteId?: number
 		recordTracksEvent(
 			'calypso_helpcenter_zendesk_config_request',
 			reportingState.blogId
-				? withSiteContext( requestProperties, 'chat_site', reportingState.blogId )
+				? withSiteContext( requestProperties, 'help_center_context', reportingState.blogId )
 				: requestProperties
 		);
 		// The two timestamps look redundant next to `fetchStatus`, which already cycles on

--- a/packages/zendesk-client/test/use-can-connect-to-zendesk-messaging.test.tsx
+++ b/packages/zendesk-client/test/use-can-connect-to-zendesk-messaging.test.tsx
@@ -84,7 +84,59 @@ describe( 'useCanConnectToZendeskMessaging', () => {
 			failure_count: 0,
 			reporting_version: REPORTING_VERSION,
 			blog_id: 123,
-			site_context_source: 'chat_site',
+			site_context_source: 'help_center_context',
+		} );
+	} );
+
+	it( 'coerces a string site id', async () => {
+		const queryClient = makeQueryClient();
+		const { result } = renderHook( () => useCanConnectToZendeskMessaging( true, '123' ), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( getEventCalls( REQUEST_EVENT )[ 0 ][ 1 ] ).toMatchObject( {
+			blog_id: 123,
+			site_context_source: 'help_center_context',
+		} );
+	} );
+
+	it( 'keeps the properties site-less for an invalid site id', async () => {
+		const queryClient = makeQueryClient();
+		const { result } = renderHook( () => useCanConnectToZendeskMessaging( true, 0 ), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( getEventCalls( REQUEST_EVENT )[ 0 ][ 1 ] ).toEqual( {
+			status: 'success',
+			status_text: undefined,
+			failure_count: 0,
+			reporting_version: REPORTING_VERSION,
+		} );
+	} );
+
+	it( 'does not attribute a site that arrives after the resolution was reported', async () => {
+		// Pins a known limitation: the query resolves once, so a site the consumer learns
+		// later cannot be attached retroactively for that page load.
+		const queryClient = makeQueryClient();
+		const wrapper = makeWrapper( queryClient );
+		const { result, rerender } = renderHook(
+			( { siteId }: { siteId?: number } = {} ) => useCanConnectToZendeskMessaging( true, siteId ),
+			{ wrapper, initialProps: {} }
+		);
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		rerender( { siteId: 789 } );
+
+		expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 1 );
+		expect( getEventCalls( REQUEST_EVENT )[ 0 ][ 1 ] ).toEqual( {
+			status: 'success',
+			status_text: undefined,
+			failure_count: 0,
+			reporting_version: REPORTING_VERSION,
 		} );
 	} );
 
@@ -104,7 +156,7 @@ describe( 'useCanConnectToZendeskMessaging', () => {
 		expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 1 );
 		expect( getEventCalls( REQUEST_EVENT )[ 0 ][ 1 ] ).toMatchObject( {
 			blog_id: 456,
-			site_context_source: 'chat_site',
+			site_context_source: 'help_center_context',
 		} );
 	} );
 

--- a/packages/zendesk-client/test/use-can-connect-to-zendesk-messaging.test.tsx
+++ b/packages/zendesk-client/test/use-can-connect-to-zendesk-messaging.test.tsx
@@ -15,7 +15,7 @@ jest.mock( '@automattic/calypso-analytics', () => ( {
 
 const REQUEST_EVENT = 'calypso_helpcenter_zendesk_config_request';
 const ERROR_EVENT = 'calypso_helpcenter_zendesk_config_error';
-const REPORTING_VERSION = 2;
+const REPORTING_VERSION = 3;
 const fetchMock = jest.fn();
 const originalFetch = globalThis.fetch;
 
@@ -67,6 +67,44 @@ describe( 'useCanConnectToZendeskMessaging', () => {
 			status_text: undefined,
 			failure_count: 0,
 			reporting_version: REPORTING_VERSION,
+		} );
+	} );
+
+	it( 'attaches the site a consumer supplied', async () => {
+		const queryClient = makeQueryClient();
+		const { result } = renderHook( () => useCanConnectToZendeskMessaging( true, 123 ), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( getEventCalls( REQUEST_EVENT )[ 0 ][ 1 ] ).toEqual( {
+			status: 'success',
+			status_text: undefined,
+			failure_count: 0,
+			reporting_version: REPORTING_VERSION,
+			blog_id: 123,
+			site_context_source: 'chat_site',
+		} );
+	} );
+
+	it( 'uses the site any observer supplied, not just the reporting one', async () => {
+		const queryClient = makeQueryClient();
+		const wrapper = makeWrapper( queryClient );
+		const siteAware = renderHook( () => useCanConnectToZendeskMessaging( true, 456 ), {
+			wrapper,
+		} );
+		const siteless = renderHook( () => useCanConnectToZendeskMessaging(), { wrapper } );
+
+		await waitFor( () => {
+			expect( siteAware.result.current.isSuccess ).toBe( true );
+			expect( siteless.result.current.isSuccess ).toBe( true );
+		} );
+
+		expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 1 );
+		expect( getEventCalls( REQUEST_EVENT )[ 0 ][ 1 ] ).toMatchObject( {
+			blog_id: 456,
+			site_context_source: 'chat_site',
 		} );
 	} );
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-517/zendesk-config-telemetry-attach-the-support-site-when-a-consumer-knows

## Proposed Changes

**`calypso_helpcenter_zendesk_config_request` now carries the support site whenever any consumer of the shared connectivity check knows it.**

- `useCanConnectToZendeskMessaging` takes an optional `siteId`; the last valid site any observer supplied is stored in the shared per-query reporting state (from DOTSUP-509) and attached via `withSiteContext` as `blog_id` + `site_context_source: 'help_center_context'` — the same label the rest of the panel's events use for this site, since that is where it comes from.
- The five Help Center package consumers pass `site?.ID` from `HelpCenterContext` (`help-center-chat` prefers the `?siteId=` route param it already treats as selected), and `ChatButton` forwards the `siteId` prop it already receives. The widgets hosts (wp-admin, Gutenberg, Customizer) receive their site synchronously, so the event is always attributed there — where it previously carried no site at all.
- One known limit: the event reports once per query resolution, so a site the consumer only learns *after* the connectivity check settles is not attached retroactively for that page load (pinned by a test). In practice the site is known at mount everywhere except a cold dashboard load racing `siteByIdQuery`, and those rows still get the ambient dashboard `blog_id` from super props.
- When no observer knows a site, the properties stay exactly as they were (ambient super props in Calypso, site-less elsewhere) rather than asserting `site_context_source: 'none'` — the shared check cannot distinguish “no site exists” from “no site-aware consumer mounted”, so coverage can only improve.
- `reporting_version` bumps to 3 so queries can split explicitly attributed rows from older ones.

## Why are these changes being made?

This event is the highest-volume of the four in [DOTSUP-504](https://linear.app/a8c/issue/DOTSUP-504), and the only one no sub-issue covered: every other Help Center/Zendesk event gained explicit site attribution, while this one still relied on whichever site Calypso happened to have selected — and carried nothing outside Calypso. The parent issue’s acceptance criterion is `blog_id` coverage at or above 95% on all four events on both host paths, which this event would have failed in the [DOTSUP-511](https://linear.app/a8c/issue/DOTSUP-511) validation.

## Testing Instructions

### Calypso

1. Run `yarn start` and set `localStorage.setItem( 'debug', 'calypso:analytics*' )` in the browser console.
2. Open the Help Center on a site-scoped route and watch for `calypso_helpcenter_zendesk_config_request`. Confirm it carries that site's `blog_id` with `site_context_source: 'help_center_context'` and `reporting_version: 3`.
3. Reload and open the Help Center from `/me`: the event should carry the site the panel mounts with (previously selected site, else your primary site), still labeled `'help_center_context'`.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing) and open the Help Center from wp-admin.
4. Confirm `calypso_helpcenter_zendesk_config_request` now carries the site's `blog_id` with `site_context_source: 'help_center_context'`, which it previously did not.
