### PR TITLE
Zendesk telemetry: retire calypso_helpcenter_zendesk_config_error

### DIFF
--- a/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
@@ -6,7 +6,7 @@ import type { Query } from '@tanstack/react-query';
 const QUERY_KEY = [ 'canConnectToZendesk' ];
 
 /**
- * Bump when the meaning of the events below changes, so Superset can tell old rows from new
+ * Bump when the meaning of the event below changes, so Superset can tell old rows from new
  * ones. Version 2 reports once per settled query instead of once per observer per state.
  * Version 3 attaches the support site as `blog_id` when a consumer knows it; only the
  * request event gained anything in v3, the error event merely shares the counter.
@@ -126,15 +126,6 @@ export function useCanConnectToZendeskMessaging( enabled = true, siteId?: number
 
 		const failureCount = Math.max( reportingState.peakFailureCount, query.failureCount );
 		reportingState.peakFailureCount = 0;
-
-		// Leaving for backwards compatibility. This event is no longer needed. The one below is more general.
-		if ( ! query.data ) {
-			recordTracksEvent( 'calypso_helpcenter_zendesk_config_error', {
-				status: query.status,
-				status_text: query.error?.message,
-				reporting_version: REPORTING_VERSION,
-			} );
-		}
 
 		const requestProperties = {
 			status: query.status,

--- a/packages/zendesk-client/test/use-can-connect-to-zendesk-messaging.test.tsx
+++ b/packages/zendesk-client/test/use-can-connect-to-zendesk-messaging.test.tsx
@@ -190,7 +190,7 @@ describe( 'useCanConnectToZendeskMessaging', () => {
 		expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 1 );
 	} );
 
-	it( 'reports the error event when a successful response carries falsy data', async () => {
+	it( 'does not report the retired error event when a successful response carries falsy data', async () => {
 		fetchMock.mockResolvedValue( makeResponse( false ) );
 		const queryClient = makeQueryClient();
 		const { result } = renderHook( () => useCanConnectToZendeskMessaging(), {
@@ -200,12 +200,7 @@ describe( 'useCanConnectToZendeskMessaging', () => {
 		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
 
 		expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 1 );
-		expect( getEventCalls( ERROR_EVENT ) ).toHaveLength( 1 );
-		expect( getEventCalls( ERROR_EVENT )[ 0 ][ 1 ] ).toEqual( {
-			status: 'success',
-			status_text: undefined,
-			reporting_version: REPORTING_VERSION,
-		} );
+		expect( getEventCalls( ERROR_EVENT ) ).toHaveLength( 0 );
 	} );
 
 	it( 'reports once after retries reach a final error', async () => {
@@ -219,16 +214,11 @@ describe( 'useCanConnectToZendeskMessaging', () => {
 
 		expect( fetchMock ).toHaveBeenCalledTimes( 4 );
 		expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 1 );
-		expect( getEventCalls( ERROR_EVENT ) ).toHaveLength( 1 );
+		expect( getEventCalls( ERROR_EVENT ) ).toHaveLength( 0 );
 		expect( getEventCalls( REQUEST_EVENT )[ 0 ][ 1 ] ).toEqual( {
 			status: 'error',
 			status_text: 'Zendesk unavailable',
 			failure_count: 4,
-			reporting_version: REPORTING_VERSION,
-		} );
-		expect( getEventCalls( ERROR_EVENT )[ 0 ][ 1 ] ).toEqual( {
-			status: 'error',
-			status_text: 'Zendesk unavailable',
 			reporting_version: REPORTING_VERSION,
 		} );
 	} );
@@ -338,7 +328,7 @@ describe( 'useCanConnectToZendeskMessaging', () => {
 		} );
 
 		await waitFor( () => expect( getEventCalls( REQUEST_EVENT ) ).toHaveLength( 2 ) );
-		expect( getEventCalls( ERROR_EVENT ) ).toHaveLength( 2 );
+		expect( getEventCalls( ERROR_EVENT ) ).toHaveLength( 0 );
 	}, 15000 );
 
 	it( 'reports again after the query is reset', async () => {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-518/decide-the-fate-of-calypso-helpcenter-zendesk-config-error-retire-it

> [!NOTE]
> The two funnels referencing this event were reviewed as part of DOTSUP-518 and judged stale — nobody is watching them, so the retirement path was chosen. Anything still needing the failure signal can read `calypso_helpcenter_zendesk_config_request` filtered on `status: 'error'`.

## Proposed Changes

**Removes `calypso_helpcenter_zendesk_config_error`, which has been marked as superseded in code while still firing in production.**

- The comment above it has said "no longer needed" since the more general `calypso_helpcenter_zendesk_config_request` gained `status` and `failure_count`, which carry the same information and more.
- Tests now pin that the retired event no longer fires on any failure path.

## Why are these changes being made?

[DOTSUP-504](https://linear.app/a8c/issue/DOTSUP-504) flagged this event as being in limbo: deprecated in code, live in production, referenced by two funnels, and unregistered — so it burns rows nobody is supposed to read and confuses anyone auditing the Help Center's telemetry. Retiring it (or deliberately keeping and registering it) is the last loose end of that issue's cleanup.

## Testing Instructions

1. Run `yarn start` and set `localStorage.setItem( 'debug', 'calypso:analytics*' )` in the browser console.
2. Block the zendesk config request (e.g. via DevTools request blocking) and open the Help Center.
3. Confirm `calypso_helpcenter_zendesk_config_request` fires with `status: 'error'`, and `calypso_helpcenter_zendesk_config_error` does not fire.
